### PR TITLE
feat(frontend): workspace IA redesign — P1 sidebar zones, P2 topic URLs, P3 wizard & workbench

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -134,45 +134,17 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
   };
 
   return (
-    <div ref={wrapRef} style={{ position: 'relative', padding: collapsed ? '0 8px 6px' : '0 12px 6px' }}>
-      {/* 触发器：侧栏区头（图标 + 当前课题名 + 折叠箭头）；折叠态只留图标 */}
+    <div ref={wrapRef} style={{ position: 'relative' }}>
+      {/* 触发器：课题容器头部（图标 + 当前课题名 + 折叠箭头）；折叠态只留图标 */}
       <button
         onClick={() => setOpen((o) => !o)}
+        className={'topic-switch' + (open ? ' open' : '')}
         title={currentProject ? `${tr('切换课题', 'Switch topic')} · ${currentProject.name}` : tr('切换课题', 'Switch topic')}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: collapsed ? 'center' : 'flex-start',
-          gap: collapsed ? 0 : 8,
-          width: '100%',
-          height: 34,
-          padding: collapsed ? 0 : '0 8px 0 9px',
-          borderRadius: 9,
-          border: `0.5px solid ${open ? 'var(--accent)' : 'var(--border-2)'}`,
-          background: open ? 'var(--accent-soft)' : 'var(--surface)',
-          cursor: 'pointer',
-          fontFamily: 'var(--sans)',
-          transition: 'border-color .12s, background .12s',
-        }}
       >
-        <Icon name="layers" size={14} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+        <Icon name="layers" size={15} style={{ color: 'var(--accent)', flexShrink: 0 }} />
         {!collapsed && (
           <>
-            <span
-              style={{
-                flex: 1,
-                fontSize: 12.5,
-                fontWeight: 620,
-                textAlign: 'left',
-                color: currentProject ? 'var(--text)' : 'var(--text-3)',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              {triggerLabel}
-            </span>
+            <span className={'topic-switch-label' + (currentProject ? '' : ' placeholder')}>{triggerLabel}</span>
             <Icon
               name="chevDown"
               size={12}
@@ -189,8 +161,8 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
           style={{
             position: 'absolute',
             ...(collapsed
-              ? { top: 0, left: 'calc(100% + 6px)' }
-              : { top: 'calc(100% + 4px)', left: 12 }),
+              ? { top: 0, left: 'calc(100% + 18px)' }
+              : { top: 'calc(100% + 8px)', left: 0 }),
             zIndex: 40,
             width: 280,
             padding: 6,
@@ -463,29 +435,37 @@ export function AppShell() {
           {/* 收起后只留左侧图形标：直接不渲染字标，杜绝溢出（不靠 CSS 隐藏） */}
           {!navCollapsed && <PolarisWordmark height={30} />}
         </div>
-        {/* —— 课题区区头：课题切换器（只统辖下方课题作用域的导航） —— */}
-        <TopicSwitcher collapsed={navCollapsed} />
-        <div className="sb-scroll scroll">
-          {/* —— 课题区：工作台 + 流水线 + 任务 + 课题设置 —— */}
-          {NAV_MAIN.map((n) => (
-            <NavItem key={n.to} n={n} />
-          ))}
-          {NAV_PIPE.filter((n) => {
-            const key = FEATURE_BY_PATH[n.to];
-            return key == null || me?.features?.[key] !== false;
-          }).map((n) => (
-            <NavItem key={n.to} n={n} />
-          ))}
-          <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
-          {currentProjectId && (
-            <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
-          )}
+        {/* —— 课题区：eyebrow + 圆角视觉容器。切换器是容器头部，
+            容器内是课题作用域导航（工作台 + 流水线 + 任务 + 课题设置） —— */}
+        <div className="sb-topic-wrap">
+          <div className="sb-section sb-topic-eyebrow">{tr('课题', 'Topic')}</div>
+          <div className="topic-zone">
+            <TopicSwitcher collapsed={navCollapsed} />
+            <div className="topic-zone-hr" />
+            {NAV_MAIN.map((n) => (
+              <NavItem key={n.to} n={n} />
+            ))}
+            {NAV_PIPE.filter((n) => {
+              const key = FEATURE_BY_PATH[n.to];
+              return key == null || me?.features?.[key] !== false;
+            }).map((n) => (
+              <NavItem key={n.to} n={n} />
+            ))}
+            <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
+            {currentProjectId && (
+              <>
+                <div className="topic-zone-hr inset" />
+                <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
+              </>
+            )}
+          </div>
+        </div>
 
-          {/* —— 个人区：跨课题的个人页面 —— */}
+        {/* —— 个人区：跨课题的个人页面（设置入口在底部头像菜单里，不重复占位） —— */}
+        <div className="sb-scroll scroll">
           <div className="sb-section">{tr('个人', 'Personal')}</div>
           <NavItem n={{ to: '/library', icon: 'bookmark', zh: '我的文献库', en: 'My Library' }} />
           <NavItem n={{ to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' }} />
-          <NavItem n={{ to: '/settings', icon: 'settings', zh: '设置', en: 'Settings' }} />
         </div>
         <div className="sb-foot">
           <UserMenu me={me} collapsed={navCollapsed} />

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -7,7 +7,7 @@ import { Drawer } from '../components/ui/Drawer';
 import { GateCard, gateTitle } from '../components/ui/GateCard';
 import { ToastHost, toast } from '../components/ui/Toast';
 import { useAuth } from './auth';
-import { useProject } from './project';
+import { topicPath, useProject } from './project';
 import { SearchPalette } from './SearchPalette';
 import { UserMenu } from './UserMenu';
 import { FeedbackWidget } from '../features/feedback/FeedbackWidget';
@@ -17,7 +17,10 @@ import { LangToggle } from '../components/ui/LangToggle';
 import { connectNotifications } from '../lib/ws';
 
 interface NavEntry {
-  to: string;
+  /** 非课题作用域页面的绝对路径（与 sub 二选一）。 */
+  to?: string;
+  /** 课题作用域子路径（渲染时经 topicPath 拼 /t/<id> 前缀）；to 与 sub 都缺省 = 工作台。 */
+  sub?: string;
   no?: string;
   icon: IconName;
   zh: string;
@@ -26,42 +29,45 @@ interface NavEntry {
 
 // 实验室级导航：跨课题的公共资产（文献追踪未来升级为实验室级文献库，导航先归位）
 const NAV_LAB: NavEntry[] = [
-  { to: '/wiki', icon: 'book', zh: '文献追踪', en: 'Research Wiki' },
+  { sub: 'wiki', icon: 'book', zh: '文献追踪', en: 'Research Wiki' },
 ];
 
 const NAV_MAIN: NavEntry[] = [
-  { to: '/', icon: 'dashboard', zh: '工作台', en: 'Workbench' },
+  { icon: 'dashboard', zh: '工作台', en: 'Workbench' },
 ];
 
 const NAV_PIPE: NavEntry[] = [
-  { to: '/forge', no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge' },
-  { to: '/review', no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review' },
-  { to: '/experiment', no: '03', icon: 'flask', zh: '实验搭建', en: 'Experiment Lab' },
-  { to: '/writer', no: '04', icon: 'pen', zh: '论文撰写', en: 'Paper Writer' },
-  { to: '/paper-review', no: '05', icon: 'shield', zh: '论文评审', en: 'Paper Review' },
+  { sub: 'forge', no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge' },
+  { sub: 'review', no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review' },
+  { sub: 'experiment', no: '03', icon: 'flask', zh: '实验搭建', en: 'Experiment Lab' },
+  { sub: 'writer', no: '04', icon: 'pen', zh: '论文撰写', en: 'Paper Writer' },
+  { sub: 'paper-review', no: '05', icon: 'shield', zh: '论文评审', en: 'Paper Review' },
 ];
 
-// 阶段路径 → 功能权限键（管理员在设置里可禁用；被禁用的阶段从导航隐藏）
-const FEATURE_BY_PATH: Record<string, string> = {
-  '/forge': 'forge',
-  '/review': 'review',
-  '/experiment': 'experiment',
-  '/writer': 'writer',
-  '/paper-review': 'paper_review',
+// 阶段子路径 → 功能权限键（管理员在设置里可禁用；被禁用的阶段从导航隐藏）
+const FEATURE_BY_SUB: Record<string, string> = {
+  forge: 'forge',
+  review: 'review',
+  experiment: 'experiment',
+  writer: 'writer',
+  'paper-review': 'paper_review',
 };
 
 function crumbFor(pathname: string): [string, string] {
-  if (pathname === '/') return ['Polaris', tr('工作台', 'Workbench')];
-  if (pathname === '/start') return ['Polaris', tr('选择课题', 'Pick a topic')];
-  if (pathname === '/projects/new') return [tr('课题', 'Topics'), tr('新建课题', 'New topic')];
-  if (pathname.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];
-  if (pathname === '/voyages') return ['Polaris', tr('任务', 'Tasks')];
-  if (pathname.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
-  if (pathname.startsWith('/papers/')) return [tr('文献追踪', 'Research Wiki'), tr('论文阅读', 'Paper reading')];
-  if (pathname.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
-  if (pathname.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];
-  if (pathname.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
-  if (pathname.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
+  // 课题作用域路径统一去掉 /t/<topicId> 前缀后按旧表匹配
+  const scoped = /^\/t\/[^/]+(\/.*)?$/.exec(pathname);
+  const p = scoped ? (scoped[1] ?? '/') : pathname;
+  if (p === '/') return ['Polaris', tr('工作台', 'Workbench')];
+  if (p === '/start') return ['Polaris', tr('选择课题', 'Pick a topic')];
+  if (p === '/projects/new') return [tr('课题', 'Topics'), tr('新建课题', 'New topic')];
+  if (p.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];
+  if (p === '/voyages') return ['Polaris', tr('任务', 'Tasks')];
+  if (p.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
+  if (p.startsWith('/papers/')) return [tr('文献追踪', 'Research Wiki'), tr('论文阅读', 'Paper reading')];
+  if (p.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
+  if (p.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];
+  if (p.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
+  if (p.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
   const table: Record<string, [string, string]> = {
     '/wiki': [tr('实验室', 'Lab'), tr('文献追踪', 'Research Wiki')],
     '/forge': ['Stage 01', tr('想法生成', 'Idea Forge')],
@@ -73,7 +79,7 @@ function crumbFor(pathname: string): [string, string] {
     '/skills': ['Polaris', tr('技能', 'Skills')],
     '/settings': ['Polaris', tr('设置', 'Settings')],
   };
-  return table[pathname] ?? ['Polaris', '—'];
+  return table[p] ?? ['Polaris', '—'];
 }
 
 /** AppShell 通过 Outlet context 暴露给子页面的能力。 */
@@ -201,9 +207,16 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
                   onClick={() => {
                     setCurrentProjectId(p.id);
                     setOpen(false);
-                    // 正在看某个方向的详情页时，切换方向同步跳到新方向的详情（URL 驱动的页面）
-                    if (/^\/projects\/(?!new)/.test(location.pathname)) {
+                    const scoped = /^\/t\/[^/]+(?:\/(.*))?$/.exec(location.pathname);
+                    if (scoped) {
+                      // 课题作用域页面：切课题保持当前子页面（如 /t/a/forge → /t/b/forge）
+                      navigate(topicPath(p.id, scoped[1] || undefined));
+                    } else if (/^\/projects\/(?!new)/.test(location.pathname)) {
+                      // 课题设置页：跳到新课题的设置
                       navigate(`/projects/${p.id}`);
+                    } else {
+                      // 实体详情页或非课题域页面：回到新课题的工作台
+                      navigate(topicPath(p.id));
                     }
                   }}
                 >
@@ -269,10 +282,15 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
 }
 
 function NavItem({ n }: { n: NavEntry }) {
+  const { currentProjectId } = useProject();
+  // 课题作用域条目带 /t/<id> 前缀；无当前课题时退回旧路径，由重定向兜底
+  const to = n.to ?? topicPath(currentProjectId, n.sub);
+  // 工作台（课题根路径）只在精确匹配时高亮，避免盖住全部子页面
+  const end = n.to == null && n.sub == null;
   return (
     <NavLink
-      to={n.to}
-      end={n.to === '/'}
+      to={to}
+      end={end}
       className={({ isActive }) => 'nav-item' + (isActive ? ' active' : '')}
       title={tr(n.zh, n.en)}
     >
@@ -447,21 +465,21 @@ export function AppShell() {
         <div className="sb-nav-static">
           <div className="sb-section">{tr('实验室', 'Lab')}</div>
           {NAV_LAB.map((n) => (
-            <NavItem key={n.to} n={n} />
+            <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
 
           <div className="sb-section">{tr('课题研究', 'Topic')}</div>
           <TopicSwitcher collapsed={navCollapsed} />
           {NAV_MAIN.map((n) => (
-            <NavItem key={n.to} n={n} />
+            <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
           {NAV_PIPE.filter((n) => {
-            const key = FEATURE_BY_PATH[n.to];
+            const key = n.sub != null ? FEATURE_BY_SUB[n.sub] : undefined;
             return key == null || me?.features?.[key] !== false;
           }).map((n) => (
-            <NavItem key={n.to} n={n} />
+            <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
-          <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
+          <NavItem n={{ sub: 'voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
           {currentProjectId && (
             <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
           )}

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -24,12 +24,16 @@ interface NavEntry {
   en: string;
 }
 
+// 实验室级导航：跨课题的公共资产（文献追踪未来升级为实验室级文献库，导航先归位）
+const NAV_LAB: NavEntry[] = [
+  { to: '/wiki', icon: 'book', zh: '文献追踪', en: 'Research Wiki' },
+];
+
 const NAV_MAIN: NavEntry[] = [
   { to: '/', icon: 'dashboard', zh: '工作台', en: 'Workbench' },
 ];
 
 const NAV_PIPE: NavEntry[] = [
-  { to: '/wiki', no: '00', icon: 'book', zh: '文献追踪', en: 'Research Wiki' },
   { to: '/forge', no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge' },
   { to: '/review', no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review' },
   { to: '/experiment', no: '03', icon: 'flask', zh: '实验搭建', en: 'Experiment Lab' },
@@ -59,7 +63,7 @@ function crumbFor(pathname: string): [string, string] {
   if (pathname.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
   if (pathname.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
   const table: Record<string, [string, string]> = {
-    '/wiki': ['Stage 00', tr('文献追踪', 'Research Wiki')],
+    '/wiki': [tr('实验室', 'Lab'), tr('文献追踪', 'Research Wiki')],
     '/forge': ['Stage 01', tr('想法生成', 'Idea Forge')],
     '/review': ['Stage 02', tr('想法评审', 'Idea Review')],
     '/experiment': ['Stage 03', tr('实验搭建', 'Experiment Lab')],
@@ -87,7 +91,7 @@ export function useShell(): ShellContext {
 }
 
 /* ============================================================
-   侧边栏课题切换器（课题区区头）：触发器 + 卡片式下拉菜单。
+   侧边栏课题切换器（课题研究组内的特殊条目）：触发器 + 卡片式下拉菜单。
    菜单含课题列表（当前项打勾 + 蓝点）、新建课题、课题设置入口。
    折叠态只留图标按钮，菜单向右侧弹出（侧栏 z-index 已抬高，不会被主列裁剪）。
    ============================================================ */
@@ -135,7 +139,7 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
 
   return (
     <div ref={wrapRef} style={{ position: 'relative' }}>
-      {/* 触发器：课题容器头部（图标 + 当前课题名 + 折叠箭头）；折叠态只留图标 */}
+      {/* 触发器：与普通导航条目同高的描边条目（图标 + 当前课题名 + 折叠箭头）；折叠态只留图标 */}
       <button
         onClick={() => setOpen((o) => !o)}
         className={'topic-switch' + (open ? ' open' : '')}
@@ -435,30 +439,29 @@ export function AppShell() {
           {/* 收起后只留左侧图形标：直接不渲染字标，杜绝溢出（不靠 CSS 隐藏） */}
           {!navCollapsed && <PolarisWordmark height={30} />}
         </div>
-        {/* —— 课题区：eyebrow + 圆角视觉容器。切换器是容器头部，
-            容器内是课题作用域导航（工作台 + 流水线 + 任务 + 课题设置） —— */}
-        <div className="sb-topic-wrap">
-          <div className="sb-section sb-topic-eyebrow">{tr('课题', 'Topic')}</div>
-          <div className="topic-zone">
-            <TopicSwitcher collapsed={navCollapsed} />
-            <div className="topic-zone-hr" />
-            {NAV_MAIN.map((n) => (
-              <NavItem key={n.to} n={n} />
-            ))}
-            {NAV_PIPE.filter((n) => {
-              const key = FEATURE_BY_PATH[n.to];
-              return key == null || me?.features?.[key] !== false;
-            }).map((n) => (
-              <NavItem key={n.to} n={n} />
-            ))}
-            <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
-            {currentProjectId && (
-              <>
-                <div className="topic-zone-hr inset" />
-                <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
-              </>
-            )}
-          </div>
+        {/* —— 实验室 + 课题研究两组（平面分组，只靠 eyebrow + 间距区分，不加分隔线）。
+            放在滚动区之外：课题切换器的下拉菜单要能向右溢出到主列上 —— */}
+        <div className="sb-nav-static">
+          <div className="sb-section">{tr('实验室', 'Lab')}</div>
+          {NAV_LAB.map((n) => (
+            <NavItem key={n.to} n={n} />
+          ))}
+
+          <div className="sb-section">{tr('课题研究', 'Topic')}</div>
+          <TopicSwitcher collapsed={navCollapsed} />
+          {NAV_MAIN.map((n) => (
+            <NavItem key={n.to} n={n} />
+          ))}
+          {NAV_PIPE.filter((n) => {
+            const key = FEATURE_BY_PATH[n.to];
+            return key == null || me?.features?.[key] !== false;
+          }).map((n) => (
+            <NavItem key={n.to} n={n} />
+          ))}
+          <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
+          {currentProjectId && (
+            <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
+          )}
         </div>
 
         {/* —— 个人区：跨课题的个人页面（设置入口在底部头像菜单里，不重复占位） —— */}

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -145,7 +145,10 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
         className={'topic-switch' + (open ? ' open' : '')}
         title={currentProject ? `${tr('切换课题', 'Switch topic')} · ${currentProject.name}` : tr('切换课题', 'Switch topic')}
       >
-        <Icon name="layers" size={15} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+        {/* 图标放进 24px 轨道框（nav-ic）：中心与普通条目图标同在 33px 轨道，展开/折叠不位移 */}
+        <span className="nav-ic">
+          <Icon name="layers" size={18} style={{ color: 'var(--accent)' }} />
+        </span>
         {!collapsed && (
           <>
             <span className={'topic-switch-label' + (currentProject ? '' : ' placeholder')}>{triggerLabel}</span>

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -25,7 +25,7 @@ interface NavEntry {
 }
 
 const NAV_MAIN: NavEntry[] = [
-  { to: '/', icon: 'dashboard', zh: '总览', en: 'Dashboard' },
+  { to: '/', icon: 'dashboard', zh: '工作台', en: 'Workbench' },
 ];
 
 const NAV_PIPE: NavEntry[] = [
@@ -47,14 +47,15 @@ const FEATURE_BY_PATH: Record<string, string> = {
 };
 
 function crumbFor(pathname: string): [string, string] {
-  if (pathname === '/') return ['Polaris', tr('总览', 'Dashboard')];
-  if (pathname === '/projects/new') return [tr('研究方向', 'Directions'), tr('新建方向', 'New direction')];
-  if (pathname.startsWith('/projects/')) return [tr('研究方向', 'Directions'), tr('方向详情', 'Direction detail')];
+  if (pathname === '/') return ['Polaris', tr('工作台', 'Workbench')];
+  if (pathname === '/start') return ['Polaris', tr('选择课题', 'Pick a topic')];
+  if (pathname === '/projects/new') return [tr('课题', 'Topics'), tr('新建课题', 'New topic')];
+  if (pathname.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];
   if (pathname === '/voyages') return ['Polaris', tr('任务', 'Tasks')];
   if (pathname.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
   if (pathname.startsWith('/papers/')) return [tr('文献追踪', 'Research Wiki'), tr('论文阅读', 'Paper reading')];
   if (pathname.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
-  if (pathname.startsWith('/join/')) return [tr('研究方向', 'Directions'), tr('接受邀请', 'Accept invite')];
+  if (pathname.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];
   if (pathname.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
   if (pathname.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
   const table: Record<string, [string, string]> = {
@@ -65,7 +66,6 @@ function crumbFor(pathname: string): [string, string] {
     '/writer': ['Stage 04', tr('论文撰写', 'Paper Writer')],
     '/paper-review': ['Stage 05', tr('论文评审', 'Paper Review')],
     '/library': ['Polaris', tr('我的文献库', 'My Library')],
-    '/mcp-tools': ['Polaris', 'MCP'],
     '/skills': ['Polaris', tr('技能', 'Skills')],
     '/settings': ['Polaris', tr('设置', 'Settings')],
   };
@@ -87,10 +87,11 @@ export function useShell(): ShellContext {
 }
 
 /* ============================================================
-   顶栏研究方向切换器：胶囊触发器 + 卡片式下拉菜单。
-   菜单含方向列表（当前项打勾 + 蓝点）、新建方向、方向详情入口。
+   侧边栏课题切换器（课题区区头）：触发器 + 卡片式下拉菜单。
+   菜单含课题列表（当前项打勾 + 蓝点）、新建课题、课题设置入口。
+   折叠态只留图标按钮，菜单向右侧弹出（侧栏 z-index 已抬高，不会被主列裁剪）。
    ============================================================ */
-function DirectionSwitcher() {
+function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
   const { projects, isLoading, currentProjectId, currentProject, setCurrentProjectId } = useProject();
@@ -114,7 +115,7 @@ function DirectionSwitcher() {
     };
   }, [open]);
 
-  const triggerLabel = currentProject?.name ?? (isLoading ? tr('加载中…', 'Loading…') : tr('选择研究方向', 'Pick a direction'));
+  const triggerLabel = currentProject?.name ?? (isLoading ? tr('加载中…', 'Loading…') : tr('选择课题', 'Pick a topic'));
 
   const itemStyle: React.CSSProperties = {
     display: 'flex',
@@ -133,19 +134,20 @@ function DirectionSwitcher() {
   };
 
   return (
-    <div ref={wrapRef} style={{ position: 'relative', marginLeft: 18 }}>
-      {/* 触发器：胶囊（图标 + 当前方向名 + 折叠箭头） */}
+    <div ref={wrapRef} style={{ position: 'relative', padding: collapsed ? '0 8px 6px' : '0 12px 6px' }}>
+      {/* 触发器：侧栏区头（图标 + 当前课题名 + 折叠箭头）；折叠态只留图标 */}
       <button
         onClick={() => setOpen((o) => !o)}
-        title={tr('切换研究方向', 'Switch research direction')}
+        title={currentProject ? `${tr('切换课题', 'Switch topic')} · ${currentProject.name}` : tr('切换课题', 'Switch topic')}
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 7,
-          height: 32,
-          maxWidth: 280,
-          padding: '0 10px 0 11px',
-          borderRadius: 16,
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          gap: collapsed ? 0 : 8,
+          width: '100%',
+          height: 34,
+          padding: collapsed ? 0 : '0 8px 0 9px',
+          borderRadius: 9,
           border: `0.5px solid ${open ? 'var(--accent)' : 'var(--border-2)'}`,
           background: open ? 'var(--accent-soft)' : 'var(--surface)',
           cursor: 'pointer',
@@ -153,49 +155,56 @@ function DirectionSwitcher() {
           transition: 'border-color .12s, background .12s',
         }}
       >
-        <Icon name="layers" size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />
-        <span
-          style={{
-            fontSize: 12.5,
-            fontWeight: 620,
-            color: currentProject ? 'var(--text)' : 'var(--text-3)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            minWidth: 0,
-          }}
-        >
-          {triggerLabel}
-        </span>
-        <Icon
-          name="chevDown"
-          size={12}
-          style={{ color: 'var(--text-3)', flexShrink: 0, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
-        />
+        <Icon name="layers" size={14} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+        {!collapsed && (
+          <>
+            <span
+              style={{
+                flex: 1,
+                fontSize: 12.5,
+                fontWeight: 620,
+                textAlign: 'left',
+                color: currentProject ? 'var(--text)' : 'var(--text-3)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              {triggerLabel}
+            </span>
+            <Icon
+              name="chevDown"
+              size={12}
+              style={{ color: 'var(--text-3)', flexShrink: 0, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+            />
+          </>
+        )}
       </button>
 
-      {/* 下拉菜单 */}
+      {/* 下拉菜单：展开态在触发器正下方；折叠态向右侧弹出盖在主列上 */}
       {open && (
         <div
           className="card"
           style={{
             position: 'absolute',
-            top: 'calc(100% + 6px)',
-            left: 0,
+            ...(collapsed
+              ? { top: 0, left: 'calc(100% + 6px)' }
+              : { top: 'calc(100% + 4px)', left: 12 }),
             zIndex: 40,
-            width: 300,
+            width: 280,
             padding: 6,
             boxShadow: 'var(--shadow-pop)',
             animation: 'fadeUp 0.12s ease',
           }}
         >
           <div className="mono" style={{ fontSize: 10, color: 'var(--text-4)', padding: '4px 12px 6px', letterSpacing: '0.06em' }}>
-            {tr('研究方向', 'DIRECTIONS')}
+            {tr('课题', 'TOPICS')}
           </div>
           <div className="scroll" style={{ maxHeight: 320, overflowY: 'auto' }}>
             {projects.length === 0 && (
               <div style={{ padding: '10px 12px', fontSize: 12, color: 'var(--text-4)' }}>
-                {isLoading ? tr('加载中…', 'Loading…') : tr('还没有研究方向，先新建一个', 'No directions yet — create one first')}
+                {isLoading ? tr('加载中…', 'Loading…') : tr('还没有课题，先创建一个', 'No topics yet — create one first')}
               </div>
             )}
             {projects.map((p) => {
@@ -258,7 +267,7 @@ function DirectionSwitcher() {
             }}
           >
             <Icon name="plus" size={13} style={{ color: 'var(--text-3)' }} />
-            {tr('新建方向', 'New direction')}
+            {tr('新建课题', 'New topic')}
           </button>
           {currentProjectId && (
             <button
@@ -271,7 +280,7 @@ function DirectionSwitcher() {
               }}
             >
               <Icon name="settings" size={13} style={{ color: 'var(--text-3)' }} />
-              {tr('当前方向详情与设置', 'Current direction detail & settings')}
+              {tr('课题设置', 'Topic settings')}
             </button>
           )}
         </div>
@@ -299,6 +308,7 @@ function NavItem({ n }: { n: NavEntry }) {
 export function AppShell() {
   const location = useLocation();
   const queryClient = useQueryClient();
+  const { currentProjectId } = useProject();
 
   // —— 审批抽屉 ——
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -453,22 +463,29 @@ export function AppShell() {
           {/* 收起后只留左侧图形标：直接不渲染字标，杜绝溢出（不靠 CSS 隐藏） */}
           {!navCollapsed && <PolarisWordmark height={30} />}
         </div>
+        {/* —— 课题区区头：课题切换器（只统辖下方课题作用域的导航） —— */}
+        <TopicSwitcher collapsed={navCollapsed} />
         <div className="sb-scroll scroll">
+          {/* —— 课题区：工作台 + 流水线 + 任务 + 课题设置 —— */}
           {NAV_MAIN.map((n) => (
             <NavItem key={n.to} n={n} />
           ))}
-          <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
-          <NavItem n={{ to: '/mcp-tools', icon: 'server', zh: 'MCP', en: 'MCP' }} />
-          <NavItem n={{ to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' }} />
-          <NavItem n={{ to: '/library', icon: 'bookmark', zh: '我的文献库', en: 'My Library' }} />
-
-          <div className="sb-section">{tr('研究流水线', 'Pipeline')}</div>
           {NAV_PIPE.filter((n) => {
             const key = FEATURE_BY_PATH[n.to];
             return key == null || me?.features?.[key] !== false;
           }).map((n) => (
             <NavItem key={n.to} n={n} />
           ))}
+          <NavItem n={{ to: '/voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
+          {currentProjectId && (
+            <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
+          )}
+
+          {/* —— 个人区：跨课题的个人页面 —— */}
+          <div className="sb-section">{tr('个人', 'Personal')}</div>
+          <NavItem n={{ to: '/library', icon: 'bookmark', zh: '我的文献库', en: 'My Library' }} />
+          <NavItem n={{ to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' }} />
+          <NavItem n={{ to: '/settings', icon: 'settings', zh: '设置', en: 'Settings' }} />
         </div>
         <div className="sb-foot">
           <UserMenu me={me} collapsed={navCollapsed} />
@@ -491,8 +508,6 @@ export function AppShell() {
             <span className="sep">›</span>
             <b>{c2}</b>
           </div>
-          {/* —— 研究方向选择器 —— */}
-          <DirectionSwitcher />
           <div className="spacer" />
           <div className="searchbox" role="button" tabIndex={0} onClick={() => setSearchOpen(true)}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSearchOpen(true); }}>

--- a/src/frontend/src/app/SearchPalette.tsx
+++ b/src/frontend/src/app/SearchPalette.tsx
@@ -5,12 +5,15 @@ import { Icon, type IconName } from '../components/ui/Icon';
 import { PaperStatusPill, StatusPill } from '../components/ui/StatusPill';
 import { api, type GlobalSearchHit, type GlobalSearchHitType } from '../lib/api';
 import { tr } from '../lib/i18n';
-import { useProject } from './project';
+import { topicPath, useProject } from './project';
 
-/** 各实体类型的展示顺序 / 文案 / 图标 / 跳转目标。 */
-const TYPE_META: Record<GlobalSearchHitType, { zh: string; en: string; icon: IconName; to: (h: GlobalSearchHit) => string }> = {
+/** 各实体类型的展示顺序 / 文案 / 图标 / 跳转目标（pid = 当前课题，课题域列表页需要拼前缀）。 */
+const TYPE_META: Record<
+  GlobalSearchHitType,
+  { zh: string; en: string; icon: IconName; to: (h: GlobalSearchHit, pid: string | null) => string }
+> = {
   paper: { zh: '论文', en: 'Papers', icon: 'book', to: (h) => `/papers/${h.id}/read` },
-  concept: { zh: '概念', en: 'Concepts', icon: 'sparkle', to: (h) => `/wiki?concept=${encodeURIComponent(h.title)}` },
+  concept: { zh: '概念', en: 'Concepts', icon: 'sparkle', to: (h, pid) => topicPath(pid, `wiki?concept=${encodeURIComponent(h.title)}`) },
   idea: { zh: '想法', en: 'Ideas', icon: 'bulb', to: (h) => `/ideas/${h.id}` },
   experiment: { zh: '实验', en: 'Experiments', icon: 'flask', to: (h) => `/experiment/${h.id}` },
   voyage: { zh: 'AI 任务', en: 'Tasks', icon: 'compass', to: (h) => `/voyages/${h.id}` },
@@ -66,7 +69,7 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
 
   function go(hit: GlobalSearchHit) {
     onClose();
-    navigate(TYPE_META[hit.type].to(hit));
+    navigate(TYPE_META[hit.type].to(hit, currentProjectId));
   }
 
   function onKeyDown(e: React.KeyboardEvent) {

--- a/src/frontend/src/app/SearchPalette.tsx
+++ b/src/frontend/src/app/SearchPalette.tsx
@@ -89,13 +89,13 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
   const showing = debounced.length > 0;
   let body: React.ReactNode;
   if (!currentProjectId) {
-    body = <div className="empty" style={{ padding: 24 }}>{tr('请先在顶栏选择一个研究方向', 'Pick a research direction in the top bar first')}</div>;
+    body = <div className="empty" style={{ padding: 24 }}>{tr('请先在侧边栏选择一个课题', 'Pick a topic in the sidebar first')}</div>;
   } else if (!showing) {
     body = (
       <div className="empty" style={{ padding: 24 }}>
         {tr(
-          '输入关键词，搜索当前方向下的论文、概念、想法、实验、AI 任务与论文稿',
-          'Type keywords to search papers, concepts, ideas, experiments, AI tasks and drafts in this direction',
+          '输入关键词，搜索当前课题下的论文、概念、想法、实验、AI 任务与论文稿',
+          'Type keywords to search papers, concepts, ideas, experiments, AI tasks and drafts in this topic',
         )}
       </div>
     );
@@ -244,7 +244,7 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
         >
           <span>↑↓ {tr('选择', 'select')}</span>
           <span>↵ {tr('打开', 'open')}</span>
-          <span style={{ marginLeft: 'auto' }}>{tr('仅搜索当前研究方向', 'Searches current direction only')}</span>
+          <span style={{ marginLeft: 'auto' }}>{tr('仅搜索当前课题', 'Searches current topic only')}</span>
         </div>
       </div>
     </div>

--- a/src/frontend/src/app/project.tsx
+++ b/src/frontend/src/app/project.tsx
@@ -10,6 +10,16 @@ import { api, type ProjectRead } from '../lib/api';
 
 const CURRENT_KEY = 'polaris.project';
 
+/**
+ * 生成课题作用域路径：`/t/<topicId>` 或 `/t/<topicId>/<sub>`（sub 可带查询串）。
+ * 全站拼课题域链接统一走这里；topicId 为空时退回旧路径（如 `/wiki`），
+ * 由路由层的旧路径重定向兜底跳到当前课题。
+ */
+export function topicPath(topicId: string | null | undefined, sub?: string): string {
+  if (!topicId) return sub ? `/${sub}` : '/';
+  return sub ? `/t/${topicId}/${sub}` : `/t/${topicId}`;
+}
+
 export interface ProjectContextValue {
   /** 本人是成员的项目列表（后端不可用时为 []）。 */
   projects: ProjectRead[];

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -1,8 +1,8 @@
-import { Suspense, lazy, type ComponentType, type ReactNode } from 'react';
-import { Navigate, Outlet, createBrowserRouter, useOutletContext } from 'react-router-dom';
+import { Suspense, lazy, useEffect, type ComponentType, type ReactNode } from 'react';
+import { Navigate, Outlet, createBrowserRouter, useLocation, useOutletContext, useParams } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { RequireAuth } from './auth';
-import { ProjectProvider, useProject } from './project';
+import { ProjectProvider, topicPath, useProject } from './project';
 
 // 路由级代码分割：每个页面独立 chunk，首屏只加载壳层与当前页
 function page<K extends string>(
@@ -45,6 +45,46 @@ function RequireTopic() {
   return <Outlet context={ctx} />;
 }
 
+/**
+ * /t/:topicId 布局路由：URL 是课题作用域的事实源。
+ * - URL 中的课题在列表里 → 同步给 ProjectProvider（含写 localStorage），子页面照常用
+ *   useProject().currentProjectId 拉数据；
+ * - 列表加载完但 URL 课题不存在 → 重定向 /start；
+ * - 列表加载中 / context 尚未同步 → 渲染骨架（不闪现上一个课题的数据）；
+ * - 列表加载失败（后端不可用）→ 信任 URL 放行，页面自身降级。
+ */
+function TopicScope() {
+  const { topicId = '' } = useParams();
+  const { projects, isLoading, isError, currentProjectId, setCurrentProjectId } = useProject();
+  const ctx = useOutletContext();
+  const known = projects.some((p) => p.id === topicId);
+
+  useEffect(() => {
+    if (topicId && (known || isError) && topicId !== currentProjectId) setCurrentProjectId(topicId);
+  }, [topicId, known, isError, currentProjectId, setCurrentProjectId]);
+
+  if (isLoading) return <PageFallback />;
+  if (!known && !isError) return <Navigate to="/start" replace />;
+  if (topicId !== currentProjectId) return <PageFallback />;
+  return <Outlet context={ctx} />;
+}
+
+/**
+ * 旧课题域路径（/、/wiki、/forge…）重定向：收藏夹 / 刷新兼容。
+ * localStorage 记住的课题（仍在列表中）优先，否则列表第一个；都没有 → /start。
+ * 列表加载失败时信任 localStorage 里的 id（页面自身降级）。
+ */
+function LegacyTopicRedirect({ sub }: { sub?: string }) {
+  const { projects, isLoading, isError, currentProjectId } = useProject();
+  const location = useLocation();
+  if (isLoading) return <PageFallback />;
+  const remembered = currentProjectId && projects.some((p) => p.id === currentProjectId) ? currentProjectId : null;
+  const id = remembered ?? projects[0]?.id ?? (isError ? currentProjectId : null);
+  if (!id) return <Navigate to="/start" replace />;
+  // 保留查询串与锚点（如 /wiki?paper=xxx）
+  return <Navigate to={topicPath(id, sub) + location.search + location.hash} replace />;
+}
+
 export const router = createBrowserRouter([
   { path: '/login', element: page(() => import('../features/auth/LoginPage'), 'LoginPage') },
   {
@@ -61,19 +101,36 @@ export const router = createBrowserRouter([
       {
         element: <RequireTopic />,
         children: [
-          { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
-          { path: 'voyages', element: page(() => import('../features/voyages/VoyagesPage'), 'VoyagesPage') },
+          // 课题域列表页：/t/:topicId 前缀，URL 即作用域
+          {
+            path: 't/:topicId',
+            element: <TopicScope />,
+            children: [
+              { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
+              { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
+              { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
+              { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
+              { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
+              { path: 'writer', element: page(() => import('../features/writer/WriterPage'), 'WriterPage') },
+              { path: 'paper-review', element: page(() => import('../features/paper-review/PaperReviewPage'), 'PaperReviewPage') },
+              { path: 'voyages', element: page(() => import('../features/voyages/VoyagesPage'), 'VoyagesPage') },
+            ],
+          },
+          // 实体详情页：按实体 id 拉数据，保持顶层路径（分享/收藏链接稳定）
           { path: 'voyages/:id', element: page(() => import('../features/voyages/VoyageDetailPage'), 'VoyageDetailPage') },
-          { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
           { path: 'papers/:id/read', element: page(() => import('../features/reading/ReadingPage'), 'ReadingPage') },
-          { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
           { path: 'ideas/:id', element: page(() => import('../features/forge/IdeaDetailPage'), 'IdeaDetailPage') },
-          { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
-          { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
           { path: 'experiment/:id', element: page(() => import('../features/experiment/ExperimentDetailPage'), 'ExperimentDetailPage') },
-          { path: 'writer', element: page(() => import('../features/writer/WriterPage'), 'WriterPage') },
           { path: 'writer/:id', element: page(() => import('../features/writer/WriterEditorPage'), 'WriterEditorPage') },
-          { path: 'paper-review', element: page(() => import('../features/paper-review/PaperReviewPage'), 'PaperReviewPage') },
+          // 旧路径重定向：跳到当前课题下的同名子页面
+          { index: true, element: <LegacyTopicRedirect /> },
+          { path: 'wiki', element: <LegacyTopicRedirect sub="wiki" /> },
+          { path: 'forge', element: <LegacyTopicRedirect sub="forge" /> },
+          { path: 'review', element: <LegacyTopicRedirect sub="review" /> },
+          { path: 'experiment', element: <LegacyTopicRedirect sub="experiment" /> },
+          { path: 'writer', element: <LegacyTopicRedirect sub="writer" /> },
+          { path: 'paper-review', element: <LegacyTopicRedirect sub="paper-review" /> },
+          { path: 'voyages', element: <LegacyTopicRedirect sub="voyages" /> },
         ],
       },
       // —— 非课题作用域 ——

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -1,8 +1,8 @@
 import { Suspense, lazy, type ComponentType, type ReactNode } from 'react';
-import { createBrowserRouter } from 'react-router-dom';
+import { Navigate, Outlet, createBrowserRouter, useOutletContext } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { RequireAuth } from './auth';
-import { ProjectProvider } from './project';
+import { ProjectProvider, useProject } from './project';
 
 // 路由级代码分割：每个页面独立 chunk，首屏只加载壳层与当前页
 function page<K extends string>(
@@ -31,6 +31,20 @@ function PageFallback() {
   );
 }
 
+/**
+ * 课题作用域路由守卫：确认没有任何课题时统一重定向到 /start，
+ * 替代各页面重复的「还没有课题」空态。加载中渲染骨架（不闪跳）；
+ * 加载失败（后端不可用）放行，由页面自身优雅降级。
+ * 透传 AppShell 的 Outlet context，子页面 useShell() 不受影响。
+ */
+function RequireTopic() {
+  const { projects, isLoading, isError } = useProject();
+  const ctx = useOutletContext();
+  if (isLoading) return <PageFallback />;
+  if (!isError && projects.length === 0) return <Navigate to="/start" replace />;
+  return <Outlet context={ctx} />;
+}
+
 export const router = createBrowserRouter([
   { path: '/login', element: page(() => import('../features/auth/LoginPage'), 'LoginPage') },
   {
@@ -43,24 +57,33 @@ export const router = createBrowserRouter([
       </RequireAuth>
     ),
     children: [
-      { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
+      // —— 课题作用域路由：没有任何课题时统一重定向到 /start ——
+      {
+        element: <RequireTopic />,
+        children: [
+          { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
+          { path: 'voyages', element: page(() => import('../features/voyages/VoyagesPage'), 'VoyagesPage') },
+          { path: 'voyages/:id', element: page(() => import('../features/voyages/VoyageDetailPage'), 'VoyageDetailPage') },
+          { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
+          { path: 'papers/:id/read', element: page(() => import('../features/reading/ReadingPage'), 'ReadingPage') },
+          { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
+          { path: 'ideas/:id', element: page(() => import('../features/forge/IdeaDetailPage'), 'IdeaDetailPage') },
+          { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
+          { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
+          { path: 'experiment/:id', element: page(() => import('../features/experiment/ExperimentDetailPage'), 'ExperimentDetailPage') },
+          { path: 'writer', element: page(() => import('../features/writer/WriterPage'), 'WriterPage') },
+          { path: 'writer/:id', element: page(() => import('../features/writer/WriterEditorPage'), 'WriterEditorPage') },
+          { path: 'paper-review', element: page(() => import('../features/paper-review/PaperReviewPage'), 'PaperReviewPage') },
+        ],
+      },
+      // —— 非课题作用域 ——
+      { path: 'start', element: page(() => import('../features/start/StartPage'), 'StartPage') },
       { path: 'projects/new', element: page(() => import('../features/projects/ProjectWizardPage'), 'ProjectWizardPage') },
       { path: 'projects/:id', element: page(() => import('../features/projects/ProjectDetailPage'), 'ProjectDetailPage') },
       { path: 'join/:token', element: page(() => import('../features/projects/JoinPage'), 'JoinPage') },
-      { path: 'voyages', element: page(() => import('../features/voyages/VoyagesPage'), 'VoyagesPage') },
-      { path: 'voyages/:id', element: page(() => import('../features/voyages/VoyageDetailPage'), 'VoyageDetailPage') },
       { path: 'library', element: page(() => import('../features/library/LibraryPage'), 'LibraryPage') },
-      { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
-      { path: 'papers/:id/read', element: page(() => import('../features/reading/ReadingPage'), 'ReadingPage') },
-      { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
-      { path: 'ideas/:id', element: page(() => import('../features/forge/IdeaDetailPage'), 'IdeaDetailPage') },
-      { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
-      { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
-      { path: 'experiment/:id', element: page(() => import('../features/experiment/ExperimentDetailPage'), 'ExperimentDetailPage') },
-      { path: 'writer', element: page(() => import('../features/writer/WriterPage'), 'WriterPage') },
-      { path: 'writer/:id', element: page(() => import('../features/writer/WriterEditorPage'), 'WriterEditorPage') },
-      { path: 'paper-review', element: page(() => import('../features/paper-review/PaperReviewPage'), 'PaperReviewPage') },
-      { path: 'mcp-tools', element: page(() => import('../features/mcp/McpToolsPage'), 'McpToolsPage') },
+      // MCP 说明已并入设置页签，旧链接重定向
+      { path: 'mcp-tools', element: <Navigate to="/settings?tab=mcp" replace /> },
       { path: 'skills', element: page(() => import('../features/skills/SkillsPage'), 'SkillsPage') },
       { path: 'settings', element: page(() => import('../features/settings/SettingsPage'), 'SettingsPage') },
     ],

--- a/src/frontend/src/components/ui/PipelineFlow.tsx
+++ b/src/frontend/src/components/ui/PipelineFlow.tsx
@@ -13,6 +13,8 @@ export interface PipelineStage {
   count: number | null;
   /** 当前有任务运行中的阶段 */
   running?: boolean;
+  /** 流水线当前卡住的阶段（第一个还没有产出的阶段），高亮提示下一步 */
+  stuck?: boolean;
 }
 
 export interface PipelineFlowProps {
@@ -49,7 +51,7 @@ export function PipelineFlow({ stages, directionLabel, onNavigate }: PipelineFlo
                 borderRadius: 12,
                 padding: '16px 12px 14px',
                 textAlign: 'center',
-                border: '0.5px solid var(--border)',
+                border: s.stuck ? '1px solid var(--accent)' : '0.5px solid var(--border)',
                 background: s.running ? 'var(--accent-soft)' : 'var(--surface-2)',
                 position: 'relative',
                 cursor: 'pointer',
@@ -92,6 +94,11 @@ export function PipelineFlow({ stages, directionLabel, onNavigate }: PipelineFlo
                   style={{ marginTop: 6, fontSize: 9.5, color: 'var(--accent-text)', fontWeight: 600 }}
                 >
                   ● {tr('运行中', 'Running')}
+                </div>
+              )}
+              {s.stuck && !s.running && (
+                <div style={{ marginTop: 6, fontSize: 9.5, color: 'var(--accent-text)', fontWeight: 650 }}>
+                  ▸ {tr('下一步从这里继续', 'Next step starts here')}
                 </div>
               )}
             </div>

--- a/src/frontend/src/components/ui/PipelineFlow.tsx
+++ b/src/frontend/src/components/ui/PipelineFlow.tsx
@@ -35,7 +35,7 @@ export function PipelineFlow({ stages, directionLabel, onNavigate }: PipelineFlo
         </div>
         <span className="pill">
           <span className="dot" style={{ background: 'var(--ok)' }} />
-          {tr('当前方向', 'Current direction')} · {directionLabel}
+          {tr('当前课题', 'Current topic')} · {directionLabel}
         </span>
       </div>
       <div className="row" style={{ alignItems: 'stretch', gap: 0 }}>

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -262,41 +262,6 @@ function GatePreview({ gates, gatesError, openGates }: {
   );
 }
 
-/** 无研究方向时的引导空状态。 */
-function OnboardingEmpty() {
-  const navigate = useNavigate();
-  return (
-    <div className="card card-pad" style={{ textAlign: 'center', padding: '72px 40px' }}>
-      <div
-        style={{
-          width: 52,
-          height: 52,
-          borderRadius: 14,
-          margin: '0 auto 18px',
-          background: 'var(--accent-soft)',
-          color: 'var(--accent)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Icon name="sparkle" size={24} />
-      </div>
-      <div style={{ fontSize: 17, fontWeight: 680, marginBottom: 8 }}>{tr('从一个研究方向开始', 'Start with a research direction')}</div>
-      <div style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 460, margin: '0 auto 22px', lineHeight: 1.6 }}>
-        {tr(
-          'Polaris 的一切都围绕研究方向展开：文献追踪、想法生成、实验与论文。通过一次结构化访谈，把你的兴趣固化为可执行的方向定义。',
-          'Everything in Polaris revolves around a research direction: literature tracking, idea generation, experiments and papers. A structured interview turns your interests into an actionable direction definition.',
-        )}
-      </div>
-      <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-        <Icon name="plus" size={14} />
-        {tr('新建研究方向', 'New research direction')}
-      </button>
-    </div>
-  );
-}
-
 /** GET /projects/{pid}/stats → 4 张指标卡（后端不可用时显示 —）。 */
 function buildStatCards(stats: StatsRead | undefined, pendingGatesCount: number): StatCardProps[] {
   return [
@@ -335,7 +300,7 @@ function buildStatCards(stats: StatsRead | undefined, pendingGatesCount: number)
 export function DashboardPage() {
   const navigate = useNavigate();
   const { pendingGates, gatesError, openGates } = useShell();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { currentProject, currentProjectId } = useProject();
 
   const statsQuery = useQuery({
     queryKey: ['stats', currentProjectId],
@@ -345,19 +310,6 @@ export function DashboardPage() {
     refetchInterval: 60_000,
   });
 
-  // 无项目：引导创建方向
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Polaris · Autonomous Research"
-          title={tr('总览', 'Dashboard')}
-        />
-        <OnboardingEmpty />
-      </div>
-    );
-  }
-
   const statCards = buildStatCards(statsQuery.data, pendingGates.length);
   const stages = buildPipelineStages(statsQuery.data);
 
@@ -365,7 +317,7 @@ export function DashboardPage() {
     <div className="page fadeup">
       <PageHead
         eyebrow="Polaris · Autonomous Research"
-        title={tr('总览', 'Dashboard')}
+        title={tr('工作台', 'Workbench')}
         right={
           <>
             <button className="btn btn-ghost" onClick={() => navigate('/voyages')}>

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -9,21 +9,21 @@ import { ScoreRing } from '../../components/ui/ScoreRing';
 import { Delta } from '../../components/ui/Delta';
 import { gateTitle, gateDesc, gateKindLabel } from '../../components/ui/GateCard';
 import { useShell } from '../../app/AppShell';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { api, type ActivityRead, type GateRead, type StatsRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { compositeOf } from '../forge/ideaShared';
 
-/** 端到端流水线各阶段的真实计数（stats 未就绪时显示 —）。 */
-function buildPipelineStages(stats: StatsRead | undefined): PipelineStage[] {
+/** 端到端流水线各阶段的真实计数（stats 未就绪时显示 —）；path 带当前课题前缀。 */
+function buildPipelineStages(stats: StatsRead | undefined, pid: string | null): PipelineStage[] {
   return [
-    { key: 'wiki', path: '/wiki', no: '00', icon: 'book', zh: '文献追踪', en: 'Research Wiki', count: stats?.papers_total ?? null },
-    { key: 'forge', path: '/forge', no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge', count: stats?.ideas_candidate ?? null },
-    { key: 'review', path: '/review', no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review', count: stats?.ideas_under_review ?? null },
+    { key: 'wiki', path: topicPath(pid, 'wiki'), no: '00', icon: 'book', zh: '文献追踪', en: 'Research Wiki', count: stats?.papers_total ?? null },
+    { key: 'forge', path: topicPath(pid, 'forge'), no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge', count: stats?.ideas_candidate ?? null },
+    { key: 'review', path: topicPath(pid, 'review'), no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review', count: stats?.ideas_under_review ?? null },
     {
       key: 'experiment',
-      path: '/experiment',
+      path: topicPath(pid, 'experiment'),
       no: '03',
       icon: 'flask',
       zh: '实验搭建',
@@ -31,8 +31,8 @@ function buildPipelineStages(stats: StatsRead | undefined): PipelineStage[] {
       count: stats?.experiments_active ?? null,
       running: (stats?.experiments_running ?? 0) > 0,
     },
-    { key: 'writer', path: '/writer', no: '04', icon: 'pen', zh: '论文撰写', en: 'Paper Writer', count: stats?.manuscripts_total ?? null },
-    { key: 'paper-review', path: '/paper-review', no: '05', icon: 'shield', zh: '论文评审', en: 'Paper Review', count: stats?.manuscripts_under_review ?? null },
+    { key: 'writer', path: topicPath(pid, 'writer'), no: '04', icon: 'pen', zh: '论文撰写', en: 'Paper Writer', count: stats?.manuscripts_total ?? null },
+    { key: 'paper-review', path: topicPath(pid, 'paper-review'), no: '05', icon: 'shield', zh: '论文评审', en: 'Paper Review', count: stats?.manuscripts_under_review ?? null },
   ];
 }
 
@@ -64,7 +64,7 @@ function FeaturedIdeaCard({ pid }: { pid: string | null }) {
               : tr('候选池还是空的，先运行一次想法生成。', 'The candidate pool is empty — run idea generation first.')}
         </div>
         {!leaderboardQuery.isLoading && (
-          <button className="btn btn-ghost sm" style={{ marginTop: 14 }} onClick={() => navigate('/forge')}>
+          <button className="btn btn-ghost sm" style={{ marginTop: 14 }} onClick={() => navigate(topicPath(pid, 'forge'))}>
             <Icon name="bulb" size={13} />
             {tr('前往想法生成', 'Go to Idea Forge')}
           </button>
@@ -311,7 +311,7 @@ export function DashboardPage() {
   });
 
   const statCards = buildStatCards(statsQuery.data, pendingGates.length);
-  const stages = buildPipelineStages(statsQuery.data);
+  const stages = buildPipelineStages(statsQuery.data, currentProjectId);
 
   return (
     <div className="page fadeup">
@@ -320,11 +320,11 @@ export function DashboardPage() {
         title={tr('工作台', 'Workbench')}
         right={
           <>
-            <button className="btn btn-ghost" onClick={() => navigate('/voyages')}>
+            <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'voyages'))}>
               <Icon name="compass" size={15} />
               {tr('任务', 'Tasks')}
             </button>
-            <button className="btn btn-primary" onClick={() => navigate('/voyages')}>
+            <button className="btn btn-primary" onClick={() => navigate(topicPath(currentProjectId, 'voyages'))}>
               <Icon name="play" size={14} />
               {tr('运行今日循环', "Run today's loop")}
             </button>

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -15,9 +15,10 @@ import { api, type ActivityRead, type GateRead, type StatsRead } from '../../lib
 import { tr } from '../../lib/i18n';
 import { compositeOf } from '../forge/ideaShared';
 
-/** 端到端流水线各阶段的真实计数（stats 未就绪时显示 —）；path 带当前课题前缀。 */
-function buildPipelineStages(stats: StatsRead | undefined, pid: string | null): PipelineStage[] {
-  return [
+/** 端到端流水线各阶段的真实计数（stats 未就绪时显示 —）；path 带当前课题前缀；
+    stuckKey = 当前卡住（还没有产出）的阶段，进度漏斗高亮它。 */
+function buildPipelineStages(stats: StatsRead | undefined, pid: string | null, stuckKey: string | null): PipelineStage[] {
+  const stages: PipelineStage[] = [
     { key: 'wiki', path: topicPath(pid, 'wiki'), no: '00', icon: 'book', zh: '文献追踪', en: 'Research Wiki', count: stats?.papers_total ?? null },
     { key: 'forge', path: topicPath(pid, 'forge'), no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge', count: stats?.ideas_candidate ?? null },
     { key: 'review', path: topicPath(pid, 'review'), no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review', count: stats?.ideas_under_review ?? null },
@@ -34,6 +35,144 @@ function buildPipelineStages(stats: StatsRead | undefined, pid: string | null): 
     { key: 'writer', path: topicPath(pid, 'writer'), no: '04', icon: 'pen', zh: '论文撰写', en: 'Paper Writer', count: stats?.manuscripts_total ?? null },
     { key: 'paper-review', path: topicPath(pid, 'paper-review'), no: '05', icon: 'shield', zh: '论文评审', en: 'Paper Review', count: stats?.manuscripts_under_review ?? null },
   ];
+  return stages.map((s) => (s.key === stuckKey ? { ...s, stuck: true } : s));
+}
+
+// ============================================================
+// 「下一步」checklist：纯前端按产出计数推导（不加后端端点）。
+// 各阶段完成度做级联兜底：晚期产物存在即视为前置步骤已完成
+// （如实验只能由晋级想法而来），避免 stats 只统计部分状态时误判。
+// ============================================================
+
+interface NextStep {
+  key: string;
+  done: boolean;
+  /** 一句话说明（zh/en 在渲染处 tr） */
+  zh: string;
+  en: string;
+  /** 跳转按钮文案 */
+  actionZh: string;
+  actionEn: string;
+  path: string;
+}
+
+interface PipelineProgress {
+  hasPapers: boolean;
+  hasIdeas: boolean;
+  hasExperiments: boolean;
+  hasManuscripts: boolean;
+}
+
+function buildNextSteps(progress: PipelineProgress, pid: string | null, hasKeywords: boolean): NextStep[] {
+  const { hasPapers, hasIdeas, hasExperiments, hasManuscripts } = progress;
+  return [
+    {
+      key: 'papers',
+      done: hasPapers,
+      zh: '配置文献追踪并启动初始建库，建立课题知识库',
+      en: 'Set up literature tracking and run the initial library build',
+      actionZh: hasKeywords ? '去启动初始建库' : '先去课题设置里配置关键词',
+      actionEn: hasKeywords ? 'Run the initial build' : 'Configure terms in topic settings first',
+      path: hasKeywords ? topicPath(pid, 'wiki?tab=ingest') : `/projects/${pid ?? ''}`,
+    },
+    {
+      key: 'ideas',
+      done: hasIdeas,
+      zh: '基于知识库生成第一批研究想法',
+      en: 'Generate your first batch of research ideas from the library',
+      actionZh: '去生成想法',
+      actionEn: 'Generate ideas',
+      path: topicPath(pid, 'forge'),
+    },
+    {
+      key: 'experiments',
+      done: hasExperiments,
+      zh: '评审想法，把优胜者晋级为实验',
+      en: 'Review ideas and promote the winners to experiments',
+      actionZh: '去评审想法',
+      actionEn: 'Review ideas',
+      path: topicPath(pid, 'review'),
+    },
+    {
+      key: 'manuscripts',
+      done: hasManuscripts,
+      zh: '根据实验结果开始撰写论文',
+      en: 'Start writing the paper from your experiment results',
+      actionZh: '去写论文',
+      actionEn: 'Start writing',
+      path: topicPath(pid, 'writer'),
+    },
+  ];
+}
+
+/** 新课题引导卡：全部完成时整卡隐藏（由调用方判断）。 */
+function NextStepsCard({ steps, onNavigate }: { steps: NextStep[]; onNavigate: (path: string) => void }) {
+  const currentKey = steps.find((s) => !s.done)?.key ?? null;
+  const doneCount = steps.filter((s) => s.done).length;
+  return (
+    <div className="card card-pad" style={{ marginBottom: 24, borderColor: 'var(--accent-soft-2)' }}>
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 14 }}>
+        <span className="section-h">
+          <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('下一步', 'Next steps')}
+        </span>
+        <span className="pill" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+          {doneCount}/{steps.length} {tr('已完成', 'done')}
+        </span>
+      </div>
+      <div className="col gap8">
+        {steps.map((s) => {
+          const isCurrent = s.key === currentKey;
+          return (
+            <div
+              key={s.key}
+              className="row gap10"
+              style={{
+                padding: '9px 12px',
+                borderRadius: 10,
+                background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                alignItems: 'center',
+              }}
+            >
+              <span
+                style={{
+                  width: 20,
+                  height: 20,
+                  borderRadius: '50%',
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: s.done ? 'var(--ok-bg)' : isCurrent ? 'var(--accent)' : 'var(--surface-2)',
+                  color: s.done ? 'var(--ok-tx)' : isCurrent ? '#fff' : 'var(--text-4)',
+                  border: s.done || isCurrent ? 'none' : '1px solid var(--border-strong)',
+                }}
+              >
+                {s.done ? <Icon name="check" size={12} /> : isCurrent ? <Icon name="arrow" size={11} /> : null}
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  fontSize: 13,
+                  lineHeight: 1.5,
+                  color: s.done ? 'var(--text-3)' : isCurrent ? 'var(--text)' : 'var(--text-3)',
+                  fontWeight: isCurrent ? 650 : 450,
+                }}
+              >
+                {tr(s.zh, s.en)}
+              </span>
+              {isCurrent && (
+                <button className="btn btn-primary sm" style={{ flexShrink: 0 }} onClick={() => onNavigate(s.path)}>
+                  {tr(s.actionZh, s.actionEn)}
+                  <Icon name="arrow" size={12} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 /** 当前重点想法：取 leaderboard 第一名（真实数据）；无则空状态引导。 */
@@ -310,8 +449,58 @@ export function DashboardPage() {
     refetchInterval: 60_000,
   });
 
-  const statCards = buildStatCards(statsQuery.data, pendingGates.length);
-  const stages = buildPipelineStages(statsQuery.data, currentProjectId);
+  // stats 只统计部分状态（想法只算 candidate/under_review、实验只算未终态），
+  // checklist 需要「有没有任何产出」——用既有列表接口补齐口径（缓存与各阶段页共享）
+  const ideasQuery = useQuery({
+    queryKey: ['ideas', currentProjectId, 'all'],
+    queryFn: () => api.listIdeas(currentProjectId!),
+    enabled: !!currentProjectId,
+    retry: false,
+  });
+  const experimentsQuery = useQuery({
+    queryKey: ['experiments', currentProjectId],
+    queryFn: () => api.listExperiments(currentProjectId!),
+    enabled: !!currentProjectId,
+    retry: false,
+  });
+
+  const stats = statsQuery.data;
+  // 级联兜底：晚期产物存在 ⇒ 前置阶段必然完成（实验只能由晋级想法而来）
+  const hasManuscripts = (stats?.manuscripts_total ?? 0) > 0;
+  const hasExperiments =
+    (experimentsQuery.data?.length ?? 0) > 0 || (stats?.experiments_active ?? 0) > 0 || hasManuscripts;
+  const hasIdeas =
+    (ideasQuery.data?.length ?? 0) > 0 ||
+    (stats ? stats.ideas_candidate + stats.ideas_under_review > 0 : false) ||
+    hasExperiments;
+  const hasPapers = (stats?.papers_total ?? 0) > 0;
+  const progress: PipelineProgress = { hasPapers, hasIdeas, hasExperiments, hasManuscripts };
+
+  // stats/列表还没就绪时不渲染 checklist、不高亮漏斗（避免误判闪烁）
+  const checklistReady = !!stats && !ideasQuery.isLoading && !experimentsQuery.isLoading;
+
+  // 流水线漏斗高亮：第一个还没有产出的阶段（全流程有产出但暂无稿件送审时提示论文评审）
+  const stuckKey = !checklistReady || !stats
+    ? null
+    : !hasPapers
+      ? 'wiki'
+      : !hasIdeas
+        ? 'forge'
+        : !hasExperiments
+          ? 'review'
+          : !hasManuscripts
+            ? 'writer'
+            : stats.manuscripts_under_review === 0
+              ? 'paper-review'
+              : null;
+
+  const includeTerms = currentProject?.definition?.keywords?.include ?? [];
+  const nextSteps = buildNextSteps(progress, currentProjectId, includeTerms.length > 0);
+  // 全流程都有产出 → 整卡隐藏
+  const showChecklist = checklistReady && nextSteps.some((s) => !s.done);
+
+  const statCards = buildStatCards(stats, pendingGates.length);
+  const stages = buildPipelineStages(stats, currentProjectId, stuckKey);
 
   return (
     <div className="page fadeup">
@@ -331,6 +520,8 @@ export function DashboardPage() {
           </>
         }
       />
+
+      {showChecklist && <NextStepsCard steps={nextSteps} onNavigate={navigate} />}
 
       <PipelineFlow
         stages={stages}

--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -8,6 +8,7 @@ import { Timeline, TimelineItem } from '../../components/ui/Timeline';
 import { toast } from '../../components/ui/Toast';
 import { Markdown } from '../../lib/markdown';
 import { useShell } from '../../app/AppShell';
+import { topicPath, useProject } from '../../app/project';
 import { fmtDuration, fmtTime } from '../../lib/format';
 import {
   api,
@@ -693,6 +694,7 @@ export function ExperimentDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { openGates } = useShell();
+  const { currentProjectId } = useProject();
   const [tab, setTab] = useState<TabKey>('plan');
   const defaultedRef = useRef(false);
 
@@ -746,7 +748,7 @@ export function ExperimentDetailPage() {
           </div>
           <div className="row gap8" style={{ justifyContent: 'center' }}>
             <button className="btn btn-soft" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
-            <button className="btn btn-ghost" onClick={() => navigate('/experiment')}>{tr('返回列表', 'Back to list')}</button>
+            <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'experiment'))}>{tr('返回列表', 'Back to list')}</button>
           </div>
         </div>
       </div>
@@ -761,7 +763,7 @@ export function ExperimentDetailPage() {
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 4 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="h-eyebrow row gap8">
-            <span className="row gap6" style={{ cursor: 'pointer' }} onClick={() => navigate('/experiment')}>
+            <span className="row gap6" style={{ cursor: 'pointer' }} onClick={() => navigate(topicPath(exp.project_id, 'experiment'))}>
               ← Experiment Lab
             </span>
             <span className="mono" style={{ textTransform: 'none', color: 'var(--text-4)' }}>{exp.id.slice(0, 8)}</span>

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { Segmented } from '../../components/ui/Segmented';
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { fmtDuration, fmtRelative, fmtTime } from '../../lib/format';
 import { api, ApiError, EXPERIMENT_TERMINAL, type ExperimentRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
@@ -439,7 +439,7 @@ export function ExperimentPage() {
               desc={tr('先在想法评审页晋级一个想法，再回到这里发起实验。', 'Promote an idea in Idea Review first, then come back to start an experiment.')}
               action={
                 <div className="row gap8">
-                  <button className="btn btn-ghost" onClick={() => navigate('/review')}>
+                  <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'review'))}>
                     <Icon name="scale" size={14} />
                     {tr('前往想法评审', 'Go to Idea Review')}
                   </button>

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -182,7 +182,7 @@ export function ExperimentPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const newIdeaId = searchParams.get('new');
@@ -331,31 +331,6 @@ export function ExperimentPage() {
   });
   const confirmBusy = deleteOne.isPending || batchDelete.isPending || emptyTrash.isPending;
 
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 03 · Experiment Lab"
-          title={tr('实验搭建', 'Experiment Lab')}
-          sub={tr('从计划、审批、建环境到运行与报告。', 'From plan, approval and environment setup to runs and report.')}
-        />
-        <div className="card">
-          <EmptyState
-            icon="flask"
-            title={tr('还没有研究方向', 'No research direction yet')}
-            desc={tr('先创建研究方向、生成并晋级想法，再发起实验。', 'Create a direction, generate and promote an idea, then start an experiment.')}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="page fadeup" style={{ maxWidth: 1180 }}>
       <PageHead
@@ -363,10 +338,10 @@ export function ExperimentPage() {
         title={tr('实验搭建', 'Experiment Lab')}
         sub={
           currentProject
-            ? tr(`当前方向：${currentProject.name}`, `Current direction: ${currentProject.name}`)
+            ? tr(`当前课题：${currentProject.name}`, `Current topic: ${currentProject.name}`)
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a research direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <button className="btn btn-primary" disabled={!pid} onClick={() => setModalOpen(true)}>
@@ -431,7 +406,7 @@ export function ExperimentPage() {
       {!pid ? (
         <div className="card">
           <div className="empty" style={{ padding: 60 }}>
-            {projectsLoading ? tr('加载研究方向…', 'Loading directions…') : tr('请先选择研究方向', 'Pick a research direction first')}
+            {projectsLoading ? tr('加载课题…', 'Loading topics…') : tr('请先选择课题', 'Pick a topic first')}
           </div>
         </div>
       ) : isLoading ? (

--- a/src/frontend/src/features/experiment/NewExperimentModal.tsx
+++ b/src/frontend/src/features/experiment/NewExperimentModal.tsx
@@ -144,7 +144,7 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
         label={tr('想法', 'Idea')}
         en="promoted idea"
         hint={noIdeas ? undefined : tr('仅列出已晋级的想法。', 'Only promoted ideas are listed.')}
-        error={noIdeas ? tr('当前方向还没有已晋级的想法，先在想法评审页晋级一个。', 'No promoted ideas in this direction yet — promote one in Idea Review first.') : null}
+        error={noIdeas ? tr('当前课题还没有已晋级的想法，先在想法评审页晋级一个。', 'No promoted ideas in this topic yet — promote one in Idea Review first.') : null}
       >
         <SelectMenu
           value={ideaId}

--- a/src/frontend/src/features/experiment/NewExperimentModal.tsx
+++ b/src/frontend/src/features/experiment/NewExperimentModal.tsx
@@ -8,6 +8,7 @@ import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
 import { api } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { topicPath } from '../../app/project';
 
 /* ============================================================
    新建实验 Modal：选 promoted idea + SSH 凭据 + 预算 →
@@ -156,7 +157,7 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
       </FormField>
       {noIdeas && (
         <div style={{ marginTop: -6, marginBottom: 14 }}>
-          <button className="btn btn-soft sm" onClick={() => { onClose(); navigate('/review'); }}>
+          <button className="btn btn-soft sm" onClick={() => { onClose(); navigate(topicPath(pid, 'review')); }}>
             <Icon name="scale" size={13} />
             {tr('前往想法评审', 'Go to Idea Review')}
           </button>

--- a/src/frontend/src/features/forge/DeepDiveDrawer.tsx
+++ b/src/frontend/src/features/forge/DeepDiveDrawer.tsx
@@ -170,7 +170,7 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
       )}
 
       {seedType === 'concept' && (
-        <FormField label={tr('选择概念', 'Pick a concept')} en="concept" hint={tr('从当前方向的概念库中选一个作为探索起点。', 'Pick one from this direction’s concept library as the starting point.')}>
+        <FormField label={tr('选择概念', 'Pick a concept')} en="concept" hint={tr('从当前课题的概念库中选一个作为探索起点。', 'Pick one from this topic’s concept library as the starting point.')}>
           <div className="col gap8">
             <input
               className="input"

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -390,7 +390,7 @@ export function ForgePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { openGates } = useShell();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -559,32 +559,6 @@ export function ForgePage() {
     setDeepOpen(true);
   }
 
-  // —— 无项目：引导创建 ——
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 01 · Idea Forge"
-          title={tr('想法生成', 'Idea Forge')}
-          sub={tr('从知识库分析研究空白，生成候选想法。', 'Analyze research gaps in the knowledge base and generate candidate ideas.')}
-        />
-        <div className="card">
-          <EmptyState
-            icon="bulb"
-            title={tr('还没有研究方向', 'No research direction yet')}
-            desc={tr('想法生成需要一个研究方向和它的知识库：先创建方向并运行文献初始建库。', 'Idea Forge needs a direction and its knowledge base: create one and run the initial literature build first.')}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   const counts = state?.idea_counts;
 
   return (
@@ -594,10 +568,10 @@ export function ForgePage() {
         title={tr('想法生成', 'Idea Forge')}
         sub={
           currentProject
-            ? tr(`当前方向：${currentProject.name}`, `Current direction: ${currentProject.name}`)
+            ? tr(`当前课题：${currentProject.name}`, `Current topic: ${currentProject.name}`)
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a research direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <div className="row gap8">
@@ -829,7 +803,7 @@ export function ForgePage() {
 
       {!pid ? (
         <div className="card">
-          <EmptyState compact icon="bulb" title={tr('请先选择研究方向', 'Pick a research direction first')} />
+          <EmptyState compact icon="bulb" title={tr('请先选择课题', 'Pick a topic first')} />
         </div>
       ) : listQuery.isLoading ? (
         <div className="card">

--- a/src/frontend/src/features/forge/IdeaDetailPage.tsx
+++ b/src/frontend/src/features/forge/IdeaDetailPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useShell } from '../../app/AppShell';
+import { topicPath, useProject } from '../../app/project';
 import { DiscussionPanel } from '../review/DiscussionPanel';
 import { DiscussionBubble } from '../review/messages';
 import { compositeOf, DepthBadge, ResearchTypeBadge, RubricBar, SCORE_DIMS } from './ideaShared';
@@ -190,7 +191,7 @@ function EvidenceCard({ idea }: { idea: IdeaDetail }) {
             <div
               key={i}
               className={`row gap8${clickable ? ' hoverable' : ''}`}
-              onClick={clickable ? () => navigate(`/wiki?paper=${ev.paper_id}`) : undefined}
+              onClick={clickable ? () => navigate(topicPath(idea.project_id, `wiki?paper=${ev.paper_id}`)) : undefined}
               style={{
                 border: '0.5px solid var(--border)',
                 borderRadius: 9,
@@ -416,6 +417,7 @@ export function IdeaDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { openGates } = useShell();
+  const { currentProjectId } = useProject();
 
   const ideaQuery = useQuery({
     queryKey: ['idea', id],
@@ -468,15 +470,15 @@ export function IdeaDetailPage() {
         role="link"
         tabIndex={0}
         title={tr('打开库内论文', 'Open the paper in the library')}
-        onClick={() => navigate(`/wiki?paper=${paperId}`)}
+        onClick={() => navigate(topicPath(idea?.project_id, `wiki?paper=${paperId}`))}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') navigate(`/wiki?paper=${paperId}`);
+          if (e.key === 'Enter') navigate(topicPath(idea?.project_id, `wiki?paper=${paperId}`));
         }}
       >
         {paperTitles.get(paperId) ?? tr(`论文 ${paperId.slice(0, 8)}`, `Paper ${paperId.slice(0, 8)}`)}
       </span>
     ),
-    [paperTitles, navigate],
+    [paperTitles, navigate, idea?.project_id],
   );
 
   if (ideaQuery.isLoading) {
@@ -495,7 +497,7 @@ export function IdeaDetailPage() {
             title={tr('无法加载 idea', 'Could not load the idea')}
             desc={tr('后端不可用、接口未就绪，或该 idea 不存在。', 'Backend unavailable, API not ready, or the idea does not exist.')}
             action={
-              <button className="btn btn-ghost" onClick={() => navigate('/forge')}>
+              <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'forge'))}>
                 <Icon name="arrow" size={14} style={{ transform: 'rotate(180deg)' }} />
                 {tr('返回候选池', 'Back to candidates')}
               </button>
@@ -511,7 +513,7 @@ export function IdeaDetailPage() {
   return (
     <div className="page fadeup">
       {/* 头部 */}
-      <button className="btn btn-soft sm" onClick={() => navigate('/forge')} style={{ marginBottom: 16 }}>
+      <button className="btn btn-soft sm" onClick={() => navigate(topicPath(idea.project_id, 'forge'))} style={{ marginBottom: 16 }}>
         <Icon name="arrow" size={13} style={{ transform: 'rotate(180deg)' }} />
         {tr('返回候选池', 'Back to candidates')}
       </button>
@@ -592,7 +594,7 @@ export function IdeaDetailPage() {
                   <div
                     key={p.id}
                     className="row gap8 hoverable"
-                    onClick={() => navigate(`/wiki?paper=${p.id}`)}
+                    onClick={() => navigate(topicPath(idea.project_id, `wiki?paper=${p.id}`))}
                     style={{
                       border: '0.5px solid var(--border)',
                       borderRadius: 9,
@@ -646,7 +648,7 @@ export function IdeaDetailPage() {
           {/* 辩论记录入口 */}
           <button
             className="btn btn-ghost"
-            onClick={() => navigate(`/review?tab=matches&idea=${idea.id}`)}
+            onClick={() => navigate(topicPath(idea.project_id, `review?tab=matches&idea=${idea.id}`))}
             style={{ justifyContent: 'center' }}
           >
             <Icon name="scale" size={14} />

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -7,6 +7,7 @@ import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery'
 import { Markdown } from '../../lib/markdown';
 import { api, type LibraryEntry, type PaperAuthor, type Publication } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { topicPath } from '../../app/project';
 
 /* ============================================================
    我的文献库 · 右栏详情（三个 tab 共用）：
@@ -127,10 +128,10 @@ export function LibraryDetailPane({
     [],
   );
 
-  // [[概念]] 双链 → 方向的 wiki（对齐阅读页的处理）
+  // [[概念]] 双链 → 论文所属课题的 wiki（对齐阅读页的处理）
   const onWikiLink = useCallback(
-    (name: string) => navigate(`/wiki?concept=${encodeURIComponent(name)}`),
-    [navigate],
+    (name: string) => navigate(topicPath(paper?.project_id, `wiki?concept=${encodeURIComponent(name)}`)),
+    [navigate, paper?.project_id],
   );
 
   if (paperId !== null && paperQuery.isLoading) {

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -171,7 +171,7 @@ export function LibraryDetailPane({
         )}
         {!alive && (
           <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
-            {tr('源方向已删除，仅保留快照', 'Source direction deleted — snapshot only')}
+            {tr('源课题已删除，仅保留快照', 'Source topic deleted — snapshot only')}
           </span>
         )}
       </div>

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -96,7 +96,7 @@ function EntryRow({
           )}
           {entry.last_paper_id === null && (
             <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
-              {tr('源方向已删除', 'Source direction deleted')}
+              {tr('源课题已删除', 'Source topic deleted')}
             </span>
           )}
           {entry.visit_count > 0 && (

--- a/src/frontend/src/features/mcp/McpToolsPage.tsx
+++ b/src/frontend/src/features/mcp/McpToolsPage.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState, type CSSProperties } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
@@ -102,7 +101,8 @@ function ToolCard({ t }: { t: McpToolInfo }) {
   );
 }
 
-export function McpToolsPage() {
+/** MCP 接入说明主体（无页头），由设置页的「MCP 接入」页签复用。 */
+export function McpToolsContent() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['mcp-tools'],
     queryFn: () => api.listMcpTools(),
@@ -134,15 +134,13 @@ export function McpToolsPage() {
   );
 
   return (
-    <div className="page fadeup">
-      <PageHead
-        eyebrow="Polaris"
-        title={tr('MCP 工具', 'MCP Tools')}
-        sub={tr(
-          '把平台的只读检索能力（文献 / 概念 / 知识 / 项目状态）暴露为 MCP 工具，供 Claude Desktop、Cursor 等外部客户端调用。',
-          'Expose the platform’s read-only retrieval (papers / concepts / knowledge / project state) as MCP tools for external clients like Claude Desktop and Cursor.',
+    <div>
+      <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.55, marginBottom: 14, maxWidth: 720 }}>
+        {tr(
+          '把平台的只读检索能力（文献 / 概念 / 知识 / 课题状态）暴露为 MCP 工具，供 Claude Desktop、Cursor 等外部客户端调用。',
+          'Expose the platform’s read-only retrieval (papers / concepts / knowledge / topic state) as MCP tools for external clients like Claude Desktop and Cursor.',
         )}
-      />
+      </div>
 
       {/* 接入信息 */}
       <div
@@ -188,8 +186,8 @@ export function McpToolsPage() {
         </div>
         <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.55 }}>
           {tr(
-            '调用工具时需在参数里带 project_id（目标项目 uuid），服务端会校验你是否为该项目成员。本地桌面客户端也可用 stdio：python -m app.mcp（详见 docs/api-mcp.md）。',
-            'Each tool call takes a project_id (target project uuid); the server verifies your membership. Local desktop clients can also use stdio: python -m app.mcp (see docs/api-mcp.md).',
+            '调用工具时需在参数里带 project_id（目标课题 uuid），服务端会校验你是否为该课题成员。本地桌面客户端也可用 stdio：python -m app.mcp（详见 docs/api-mcp.md）。',
+            'Each tool call takes a project_id (target topic uuid); the server verifies your membership. Local desktop clients can also use stdio: python -m app.mcp (see docs/api-mcp.md).',
           )}
         </div>
       </div>

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -7,7 +7,7 @@ import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { Markdown } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
@@ -1142,7 +1142,7 @@ export function PaperReviewPage() {
               'Peer review only works on successfully compiled manuscripts. Compile on the Paper Writer page first, then come back.',
             )}
             action={
-              <button className="btn btn-ghost" onClick={() => navigate('/writer')}>
+              <button className="btn btn-ghost" onClick={() => navigate(topicPath(pid, 'writer'))}>
                 <Icon name="pen" size={14} />
                 {tr('去写论文', 'Go write the paper')}
               </button>

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -862,7 +862,7 @@ function ReviewDiscussion({ sessionId }: { sessionId: string }) {
 export function PaperReviewPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const [msId, setMsId] = useState<string | null>(null);
@@ -1001,37 +1001,6 @@ export function PaperReviewPage() {
 
   /* ---------------- 渲染 ---------------- */
 
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 05 · Paper Review"
-          title={tr('论文评审', 'Paper Review')}
-          sub={tr(
-            '先核验引用、逐条查错，再由三位 AI 评审员打分，汇总出接收/拒稿建议。',
-            'Citations and facts are checked first, then three AI reviewers score the paper, aggregated into an accept/reject recommendation.',
-          )}
-        />
-        <div className="card">
-          <EmptyState
-            icon="shield"
-            title={tr('还没有研究方向', 'No research direction yet')}
-            desc={tr(
-              '先创建研究方向，写出论文稿件并编译成功后，才能发起同行评审。',
-              'Create a research direction, write a manuscript, and compile it successfully before starting peer review.',
-            )}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New research direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   const noManuscripts = !manuscriptsQuery.isLoading && !manuscriptsQuery.isError && reviewable.length === 0;
 
   return (
@@ -1041,10 +1010,10 @@ export function PaperReviewPage() {
         title={tr('论文评审', 'Paper Review')}
         sub={
           currentProject
-            ? `${tr('当前方向', 'Current direction')}：${currentProject.name}`
+            ? `${tr('当前课题', 'Current topic')}：${currentProject.name}`
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a research direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <button
@@ -1160,7 +1129,7 @@ export function PaperReviewPage() {
       {!pid ? (
         <div className="card">
           <div className="empty" style={{ padding: 60 }}>
-            {projectsLoading ? tr('加载研究方向…', 'Loading directions…') : tr('请先选择研究方向', 'Pick a research direction first')}
+            {projectsLoading ? tr('加载课题…', 'Loading topics…') : tr('请先选择课题', 'Pick a topic first')}
           </div>
         </div>
       ) : noManuscripts ? (

--- a/src/frontend/src/features/projects/JoinPage.tsx
+++ b/src/frontend/src/features/projects/JoinPage.tsx
@@ -24,7 +24,7 @@ export function JoinPage() {
   const acceptMutation = useMutation({
     mutationFn: () => api.acceptInvite(token),
     onSuccess: (project) => {
-      toast(`${tr('已加入研究方向：', 'Joined research direction: ')}${project.name}`, 'ok');
+      toast(`${tr('已加入课题：', 'Joined topic: ')}${project.name}`, 'ok');
       void queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(project.id);
       navigate(`/projects/${project.id}`);
@@ -57,9 +57,9 @@ export function JoinPage() {
           </>
         ) : info.already_member ? (
           <>
-            <div style={{ fontSize: 16, fontWeight: 680, marginBottom: 8 }}>{tr('你已是该方向成员', 'You are already a member')}</div>
+            <div style={{ fontSize: 16, fontWeight: 680, marginBottom: 8 }}>{tr('你已是该课题成员', 'You are already a member')}</div>
             <div style={{ fontSize: 13, color: 'var(--text-2)', marginBottom: 20 }}>{info.project_name}</div>
-            <button className="btn btn-primary" onClick={() => navigate(`/projects/${info.project_id}`)}>{tr('进入方向', 'Open direction')}</button>
+            <button className="btn btn-primary" onClick={() => navigate(`/projects/${info.project_id}`)}>{tr('进入课题', 'Open topic')}</button>
           </>
         ) : !info.valid ? (
           <>
@@ -69,7 +69,7 @@ export function JoinPage() {
           </>
         ) : (
           <>
-            <div style={{ fontSize: 16, fontWeight: 680, marginBottom: 8 }}>{tr('邀请你加入研究方向', 'You are invited to join a research direction')}</div>
+            <div style={{ fontSize: 16, fontWeight: 680, marginBottom: 8 }}>{tr('邀请你加入课题', 'You are invited to join a topic')}</div>
             <div style={{ fontSize: 14, color: 'var(--text)', marginBottom: 4 }}>{info.project_name}</div>
             {info.inviter_name && (
               <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 20 }}>{tr('邀请人：', 'Invited by: ')}{info.inviter_name}</div>
@@ -79,7 +79,7 @@ export function JoinPage() {
               disabled={acceptMutation.isPending}
               onClick={() => acceptMutation.mutate()}
             >
-              {acceptMutation.isPending ? tr('加入中…', 'Joining…') : tr('加入该方向', 'Join this direction')}
+              {acceptMutation.isPending ? tr('加入中…', 'Joining…') : tr('加入该课题', 'Join this topic')}
             </button>
           </>
         )}

--- a/src/frontend/src/features/projects/JoinPage.tsx
+++ b/src/frontend/src/features/projects/JoinPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { api } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 
@@ -27,7 +27,7 @@ export function JoinPage() {
       toast(`${tr('已加入课题：', 'Joined topic: ')}${project.name}`, 'ok');
       void queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(project.id);
-      navigate(`/projects/${project.id}`);
+      navigate(topicPath(project.id));
     },
     onError: (e) => {
       const msg = e instanceof Error ? e.message : String(e);
@@ -59,7 +59,7 @@ export function JoinPage() {
           <>
             <div style={{ fontSize: 16, fontWeight: 680, marginBottom: 8 }}>{tr('你已是该课题成员', 'You are already a member')}</div>
             <div style={{ fontSize: 13, color: 'var(--text-2)', marginBottom: 20 }}>{info.project_name}</div>
-            <button className="btn btn-primary" onClick={() => navigate(`/projects/${info.project_id}`)}>{tr('进入课题', 'Open topic')}</button>
+            <button className="btn btn-primary" onClick={() => navigate(topicPath(info.project_id))}>{tr('进入课题', 'Open topic')}</button>
           </>
         ) : !info.valid ? (
           <>

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -144,7 +144,7 @@ export function ProjectDetailPage() {
   const deleteMutation = useMutation({
     mutationFn: () => api.deleteProject(id),
     onSuccess: () => {
-      toast(tr('研究方向已删除', 'Research direction deleted'), 'ok');
+      toast(tr('课题已删除', 'Topic deleted'), 'ok');
       setDeleteOpen(false);
       if (currentProjectId === id) setCurrentProjectId(null);
       void queryClient.invalidateQueries({ queryKey: ['projects'] });
@@ -152,7 +152,7 @@ export function ProjectDetailPage() {
     },
     onError: (err) => {
       const forbidden = err instanceof ApiError && err.status === 403;
-      toast(forbidden ? tr('只有方向创建者或管理员可以删除', 'Only the direction owner or an admin can delete it') : `${tr('删除失败：', 'Delete failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error');
+      toast(forbidden ? tr('只有课题创建者或管理员可以删除', 'Only the topic owner or an admin can delete it') : `${tr('删除失败：', 'Delete failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error');
     },
   });
 
@@ -229,7 +229,7 @@ export function ProjectDetailPage() {
       <div className="page fadeup">
         <div className="card card-pad" style={{ textAlign: 'center', padding: 60 }}>
           <div style={{ fontSize: 15, fontWeight: 650, marginBottom: 8 }}>
-            {notFound ? tr('方向不存在', 'Direction not found') : tr('无法加载方向详情', 'Failed to load direction detail')}
+            {notFound ? tr('课题不存在', 'Topic not found') : tr('无法加载课题设置', 'Failed to load topic settings')}
           </div>
           <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 18 }}>
             {error instanceof Error ? error.message : tr('后端不可用，请稍后重试', 'Backend unavailable — try again later')}
@@ -257,7 +257,7 @@ export function ProjectDetailPage() {
       {/* 页头 */}
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 24 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="h-eyebrow">Polaris · Direction</div>
+          <div className="h-eyebrow">{tr('课题设置', 'Topic Settings')}</div>
           {editingName ? (
             <div className="row gap8" style={{ marginTop: 8 }}>
               <input className="input" style={{ fontSize: 17, fontWeight: 650, width: 380 }} value={nameDraft}
@@ -296,7 +296,7 @@ export function ProjectDetailPage() {
             onClick={() => setDeleteOpen(true)}
           >
             <Icon name="x" size={13} />
-            {tr('删除方向', 'Delete direction')}
+            {tr('删除课题', 'Delete topic')}
           </button>
         </div>
       </div>
@@ -305,7 +305,7 @@ export function ProjectDetailPage() {
       <Modal
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}
-        title={tr('删除研究方向', 'Delete research direction')}
+        title={tr('删除课题', 'Delete topic')}
         sub={project.name}
         width={440}
         footer={
@@ -325,13 +325,13 @@ export function ProjectDetailPage() {
         }
       >
         <div style={{ fontSize: 13, lineHeight: 1.7, color: 'var(--text-2)' }}>
-          {tr('删除后，该方向下的', 'Deleting this direction also removes its ')}<b>{tr('论文库、概念库、笔记、AI 任务记录、想法与实验', 'paper library, concepts, notes, AI task history, ideas and experiments')}</b>{tr('都会一并删除，且', ' — and this ')}<b>{tr('无法恢复', 'cannot be undone')}</b>{tr('。确定要删除 “', '. Delete “')}{project.name}{tr('” 吗？', '”?')}
+          {tr('删除后，该课题下的', 'Deleting this topic also removes its ')}<b>{tr('论文库、概念库、笔记、AI 任务记录、想法与实验', 'paper library, concepts, notes, AI task history, ideas and experiments')}</b>{tr('都会一并删除，且', ' — and this ')}<b>{tr('无法恢复', 'cannot be undone')}</b>{tr('。确定要删除 “', '. Delete “')}{project.name}{tr('” 吗？', '”?')}
         </div>
       </Modal>
 
       <div className="col gap16">
         {/* 一句话定义 */}
-        <SectionCard icon="sparkle" zh="方向定义" en="Statement">
+        <SectionCard icon="sparkle" zh="课题定义" en="Statement">
           <EditableText value={def.statement ?? ''} placeholder={tr('尚未填写一句话定义', 'No one-line statement yet')}
             onSave={(v) => patchDef({ statement: v })} saving={saving} />
         </SectionCard>
@@ -503,7 +503,7 @@ export function ProjectDetailPage() {
           <div style={{ marginTop: 18, borderTop: '0.5px solid var(--border)', paddingTop: 14 }}>
             <div className="row" style={{ marginBottom: 10 }}>
               <span style={{ fontSize: 12.5, fontWeight: 650 }}>{tr('邀请链接', 'Invite links')}</span>
-              <span style={{ fontSize: 11.5, color: 'var(--text-3)', marginLeft: 8 }}>{tr('已注册用户打开链接即可加入本方向', 'Any registered user can join via the link')}</span>
+              <span style={{ fontSize: 11.5, color: 'var(--text-3)', marginLeft: 8 }}>{tr('已注册用户打开链接即可加入本课题', 'Any registered user can join via the link')}</span>
               <button
                 className="btn btn-soft sm"
                 style={{ marginLeft: 'auto' }}

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -7,7 +7,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { Modal } from '../../components/ui/Modal';
 import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { api, ApiError, type ProjectDefinition, type ProjectRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
@@ -286,7 +286,7 @@ export function ProjectDetailPage() {
           </div>
         </div>
         <div className="row gap8">
-          <button className="btn btn-ghost" onClick={() => navigate('/voyages')}>
+          <button className="btn btn-ghost" onClick={() => navigate(topicPath(id, 'voyages'))}>
             <Icon name="compass" size={14} />
             {tr('查看任务', 'View tasks')}
           </button>

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -204,8 +204,8 @@ export function ProjectWizardPage() {
   }
 
   function validateBasics(): string | null {
-    if (!name.trim()) return tr('请填写方向名称', 'Please enter a direction name');
-    if (!statement.trim()) return tr('请用一句话定义这个研究方向', 'Please define this research direction in one sentence');
+    if (!name.trim()) return tr('请填写课题名称', 'Please enter a topic name');
+    if (!statement.trim()) return tr('请用一句话定义这个课题', 'Please define this topic in one sentence');
     if (includeTerms.length === 0) return tr('至少添加 1 个 include 关键词（标题/摘要命中才进入相关性判定）', 'Add at least 1 include term (papers must match it in title/abstract to be scored)');
     return null;
   }
@@ -345,7 +345,7 @@ export function ProjectWizardPage() {
       const created = await api.createProject({ name: name.trim(), definition: buildDefinition() });
       await queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(created.id);
-      toast(tr('研究方向已创建', 'Research direction created'), 'ok');
+      toast(tr('课题已创建', 'Topic created'), 'ok');
       navigate(`/projects/${created.id}`);
     } catch (e) {
       toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
@@ -359,8 +359,8 @@ export function ProjectWizardPage() {
   return (
     <div className="page fadeup" style={{ maxWidth: 860 }}>
       <PageHead
-        eyebrow="Polaris · Directions"
-        title={tr('新建研究方向', 'New research direction')}
+        eyebrow="Polaris · Topics"
+        title={tr('新建课题', 'New topic')}
         sub={tr('填三项必填信息即可创建；高级设置可交给 AI 草拟后再微调。', 'Fill in three required fields to create; let AI draft the advanced settings, then tweak.')}
       />
 
@@ -382,11 +382,11 @@ export function ProjectWizardPage() {
       {tab === 0 && (
         <>
           <div className="card card-pad">
-            <FormField label={tr('方向名称', 'Name')} hint={tr('将显示在侧栏与项目列表中', 'Shown in the sidebar and project list')}>
+            <FormField label={tr('课题名称', 'Name')} hint={tr('将显示在侧栏与课题列表中', 'Shown in the sidebar and topic list')}>
               <input className="input" value={name} onChange={(e) => setName(e.target.value)}
                 placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
             </FormField>
-            <FormField label={tr('一句话定义', 'Statement')} hint={tr('用一句话说清这个方向研究什么、为什么重要', 'One sentence on what this direction studies and why it matters')}>
+            <FormField label={tr('一句话定义', 'Statement')} hint={tr('用一句话说清这个课题研究什么、为什么重要', 'One sentence on what this topic studies and why it matters')}>
               <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
                 placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
             </FormField>
@@ -416,7 +416,7 @@ export function ProjectWizardPage() {
       {tab === 1 && (
         <>
           <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '0 2px 12px', lineHeight: 1.6 }}>
-            {tr('以下内容全部可选，可直接创建方向。', 'Everything below is optional — you can create the direction right away.')}
+            {tr('以下内容全部可选，可直接创建课题。', 'Everything below is optional — you can create the topic right away.')}
             {aiFilled.size > 0 && tr(' AI 已预填部分分区，请确认或微调。', ' AI pre-filled some sections; review or tweak them.')}
           </div>
           <div className="col gap10">
@@ -426,7 +426,7 @@ export function ProjectWizardPage() {
                 badge={aiFilled.has(s.key) ? tr('AI 草稿', 'AI draft') : undefined}>
                 {s.key === 'goals' && (
                   <>
-                    <FormField label={tr('研究目标', 'Goals')} hint={tr('这个方向希望达成什么', 'What this direction aims to achieve')}>
+                    <FormField label={tr('研究目标', 'Goals')} hint={tr('这个课题希望达成什么', 'What this topic aims to achieve')}>
                       <ListEditor items={goals} onChange={setGoals} placeholder={tr('输入一个目标后回车', 'Type a goal, then press Enter')} />
                     </FormField>
                     <div className="row gap16" style={{ alignItems: 'flex-start' }}>
@@ -481,7 +481,7 @@ export function ProjectWizardPage() {
                 {s.key === 'anchors' && (
                   <>
                     <div className="field-hint" style={{ marginBottom: 10 }}>
-                      {tr('体现方向研究品味的代表作（可留空）', 'Representative papers that capture the taste of this direction (optional)')}
+                      {tr('体现课题研究品味的代表作（可留空）', 'Representative papers that capture the taste of this topic (optional)')}
                     </div>
                     <div className="col gap12">
                       {anchors.map((a, i) => (
@@ -503,7 +503,7 @@ export function ProjectWizardPage() {
                               value={a.url ?? ''}
                               onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, url: e.target.value } : x)))} />
                           </div>
-                          <input className="input" style={{ width: '100%' }} placeholder={tr('为什么它是这个方向的锚点', 'Why this paper anchors the direction')}
+                          <input className="input" style={{ width: '100%' }} placeholder={tr('为什么它是这个课题的锚点', 'Why this paper anchors the topic')}
                             value={a.reason ?? ''}
                             onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, reason: e.target.value } : x)))} />
                         </div>
@@ -575,7 +575,7 @@ export function ProjectWizardPage() {
         </button>
         <button className="btn btn-primary" onClick={() => void create()} disabled={busy}>
           <Icon name="check" size={14} />
-          {submitting ? tr('创建中…', 'Creating…') : tr('创建方向', 'Create direction')}
+          {submitting ? tr('创建中…', 'Creating…') : tr('创建课题', 'Create topic')}
         </button>
       </div>
     </div>

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -7,24 +7,22 @@ import { FormField } from '../../components/ui/FormField';
 import { Segmented } from '../../components/ui/Segmented';
 import { AccordionSection } from '../../components/ui/Accordion';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { api, type AnchorPaper, type ProjectDefinition, type RubricDimension } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 
 /* ============================================================
-   /projects/new — 创建页，两个可自由切换的标签页。
-   基本信息（唯一必填）：名称 + 一句话定义 + include 关键词；
-   高级设置（全部可选）：折叠分区编辑 definition 其余字段。
-   底部操作栏两页共用：「AI 帮我设置」按基本信息草拟高级设置
-   （只填空白分区，不覆盖已填内容，可反复点）+「创建方向」。
+   /projects/new — 创建页，单页为主。
+   必填只有两项：课题名称 + 一句话定义（30 秒建课题）；
+   其下一个默认折叠的「文献追踪配置」区块收纳 include 关键词、
+   arXiv 分类与全部高级分区（目标/问题/rubric/锚点/同义词/节奏），
+   可稍后在课题设置里补。
+   「AI 帮我设置」按名称与一句话草拟文献追踪配置
+   （只填空白分区，不覆盖已填内容，可反复点）。
+   创建成功后跳课题工作台。
    ============================================================ */
 
-const TABS = [
-  { zh: '基本信息', en: 'Basics' },
-  { zh: '高级设置', en: 'Advanced · optional' },
-] as const;
-
-/** 常用 arXiv 分类快捷多选（第 1 步）。 */
+/** 常用 arXiv 分类快捷多选。 */
 const QUICK_CATEGORIES = ['cs.CL', 'cs.AI', 'cs.LG', 'cs.CV', 'cs.MA', 'stat.ML'];
 
 const CADENCES = [
@@ -170,18 +168,18 @@ export function ProjectWizardPage() {
   const queryClient = useQueryClient();
   const { setCurrentProjectId } = useProject();
 
-  const [tab, setTab] = useState<0 | 1>(0);
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [drafting, setDrafting] = useState(false);
 
-  // —— 第 1 步（必填） ——
+  // —— 必填：名称 + 一句话 ——
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
+
+  // —— 文献追踪配置（全部可选，默认折叠） ——
+  const [trackOpen, setTrackOpen] = useState(false);
   const [includeTerms, setIncludeTerms] = useState<string[]>([]);
   const [categories, setCategories] = useState<string[]>(['cs.CL', 'cs.AI']);
-
-  // —— 第 2 步（全部可选） ——
   const [goals, setGoals] = useState<string[]>([]);
   const [inScope, setInScope] = useState<string[]>([]);
   const [outScope, setOutScope] = useState<string[]>([]);
@@ -206,7 +204,6 @@ export function ProjectWizardPage() {
   function validateBasics(): string | null {
     if (!name.trim()) return tr('请填写课题名称', 'Please enter a topic name');
     if (!statement.trim()) return tr('请用一句话定义这个课题', 'Please define this topic in one sentence');
-    if (includeTerms.length === 0) return tr('至少添加 1 个 include 关键词（标题/摘要命中才进入相关性判定）', 'Add at least 1 include term (papers must match it in title/abstract to be scored)');
     return null;
   }
 
@@ -297,15 +294,12 @@ export function ProjectWizardPage() {
     return filled;
   }
 
-  /** 「AI 帮我设置」：按基本信息草拟 definition → 填入高级设置空白分区并切过去。
+  /** 「AI 帮我设置」：按名称与一句话草拟 definition → 填入文献追踪配置的空白分区并展开。
       不覆盖已填内容，可反复点（每次只补当前仍为空的分区）。 */
   async function aiDraft() {
     const err = validateBasics();
     setFormError(err);
-    if (err) {
-      setTab(0); // 基本信息没填全：切回去看错误提示
-      return;
-    }
+    if (err) return;
     setDrafting(true);
     try {
       const res = await api.draftDefinition({
@@ -317,26 +311,25 @@ export function ProjectWizardPage() {
       if (res.source === 'fallback') {
         toast(tr('AI 未配置，已用默认模板', 'AI not configured — used the default template'), 'info');
       } else if (filled.size === 0) {
-        toast(tr('高级设置各分区都已有内容，没有需要 AI 补的空白', 'All advanced sections already have content — nothing for AI to fill'), 'info');
+        toast(tr('文献追踪配置各分区都已有内容，没有需要 AI 补的空白', 'All tracking sections already have content — nothing for AI to fill'), 'info');
       } else {
         toast(tr('AI 草稿已生成，可在下方微调', 'AI draft ready — tweak it below'), 'ok');
       }
-      setTab(1);
+      setTrackOpen(true);
     } catch (e) {
       // 端点未就绪/调用失败：优雅降级，仍可手动填写或直接创建
-      toast(tr(`AI 设置失败：${e instanceof Error ? e.message : String(e)}，可手动填写高级设置`, `AI setup failed: ${e instanceof Error ? e.message : String(e)} — you can fill the advanced settings manually`), 'error');
-      setTab(1);
+      toast(tr(`AI 设置失败：${e instanceof Error ? e.message : String(e)}，可手动填写文献追踪配置`, `AI setup failed: ${e instanceof Error ? e.message : String(e)} — you can fill the tracking settings manually`), 'error');
+      setTrackOpen(true);
     } finally {
       setDrafting(false);
     }
   }
 
-  /** 创建方向（第 1 步「直接创建」与第 2 步「创建方向」共用）。 */
+  /** 创建课题：成功后直接进课题工作台。 */
   async function create() {
     const err = validateBasics();
     if (err) {
       setFormError(err);
-      setTab(0);
       return;
     }
     setFormError(null);
@@ -346,7 +339,7 @@ export function ProjectWizardPage() {
       await queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(created.id);
       toast(tr('课题已创建', 'Topic created'), 'ok');
-      navigate(`/projects/${created.id}`);
+      navigate(topicPath(created.id));
     } catch (e) {
       toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
     } finally {
@@ -361,65 +354,56 @@ export function ProjectWizardPage() {
       <PageHead
         eyebrow="Polaris · Topics"
         title={tr('新建课题', 'New topic')}
-        sub={tr('填三项必填信息即可创建；高级设置可交给 AI 草拟后再微调。', 'Fill in three required fields to create; let AI draft the advanced settings, then tweak.')}
+        sub={tr('只需名称和一句话即可创建；文献追踪配置可选，也可稍后在课题设置里补。', 'Just a name and one sentence to create — literature tracking settings are optional and can be added later in topic settings.')}
       />
 
-      {/* 标签页切换：两页随时可来回切，填写内容都保留 */}
-      <div className="wiz-steps">
-        {TABS.map((s, i) => (
-          <div
-            key={s.en}
-            className={'wiz-step' + (i === tab ? ' on' : '')}
-            onClick={() => setTab(i as 0 | 1)}
-            style={{ cursor: 'pointer' }}
-          >
-            <span className="wiz-no mono">{i + 1}</span>
-            <span className="wiz-label">{tr(s.zh, s.en)}</span>
-          </div>
-        ))}
+      {/* —— 必填：名称 + 一句话 —— */}
+      <div className="card card-pad" style={{ marginBottom: 12 }}>
+        <FormField label={tr('课题名称', 'Name')} hint={tr('将显示在侧栏与课题列表中', 'Shown in the sidebar and topic list')}>
+          <input className="input" value={name} onChange={(e) => setName(e.target.value)}
+            placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
+        </FormField>
+        <FormField label={tr('一句话定义', 'Statement')} hint={tr('用一句话说清这个课题研究什么、为什么重要', 'One sentence on what this topic studies and why it matters')}>
+          <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
+            placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
+        </FormField>
+        {formError && <div className="field-error" style={{ marginTop: 4 }}>{formError}</div>}
       </div>
 
-      {tab === 0 && (
-        <>
-          <div className="card card-pad">
-            <FormField label={tr('课题名称', 'Name')} hint={tr('将显示在侧栏与课题列表中', 'Shown in the sidebar and topic list')}>
-              <input className="input" value={name} onChange={(e) => setName(e.target.value)}
-                placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
-            </FormField>
-            <FormField label={tr('一句话定义', 'Statement')} hint={tr('用一句话说清这个课题研究什么、为什么重要', 'One sentence on what this topic studies and why it matters')}>
-              <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
-                placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
-            </FormField>
-            <FormField label={tr('Include 关键词', 'Include terms')} hint={tr('标题/摘要命中这些词才进入相关性判定；回车添加，点击移除（至少 1 个）', 'Papers must match these in title/abstract to be scored; Enter to add, click to remove (at least 1)')}>
-              <ChipsInput items={includeTerms} onChange={setIncludeTerms} placeholder={tr('如 agent、tool use，回车添加', 'e.g. agent, tool use — Enter to add')} />
-            </FormField>
-            <FormField label={tr('arXiv 分类', 'arXiv categories')} hint={tr('常用分类快捷多选；更多分类可在创建后编辑', 'Quick-pick common categories; edit more after creating')}>
-              <div className="row gap6 wrap">
-                {QUICK_CATEGORIES.map((c) => (
-                  <button key={c} type="button" className={'chip mono' + (categories.includes(c) ? ' on' : '')}
-                    onClick={() => toggleCategory(c)}>
-                    {c}
-                  </button>
-                ))}
-                {categories.filter((c) => !QUICK_CATEGORIES.includes(c)).map((c) => (
-                  <button key={c} type="button" className="chip mono on" onClick={() => toggleCategory(c)} title={tr('点击移除', 'Click to remove')}>
-                    {c} ×
-                  </button>
-                ))}
-              </div>
-            </FormField>
-            {formError && <div className="field-error" style={{ marginTop: 4 }}>{formError}</div>}
+      {/* —— 文献追踪配置（可选，默认折叠） —— */}
+      <AccordionSection
+        title="文献追踪配置（可选，可稍后在课题设置里补）"
+        en="Literature tracking · optional, editable later in topic settings"
+        open={trackOpen}
+        onToggle={() => setTrackOpen((v) => !v)}
+        badge={aiFilled.size > 0 ? tr('AI 草稿', 'AI draft') : undefined}
+      >
+        <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '8px 0 14px', lineHeight: 1.6 }}>
+          {tr(
+            '以下内容全部可选，不填也能创建课题；启动文献追踪前需要至少 1 个 include 关键词。',
+            'Everything below is optional — you can create the topic without it; starting literature tracking requires at least 1 include term.',
+          )}
+          {aiFilled.size > 0 && tr(' AI 已预填部分分区，请确认或微调。', ' AI pre-filled some sections; review or tweak them.')}
+        </div>
+        <FormField label={tr('Include 关键词', 'Include terms')} hint={tr('标题/摘要命中这些词才进入相关性判定；回车添加，点击移除', 'Papers must match these in title/abstract to be scored; Enter to add, click to remove')}>
+          <ChipsInput items={includeTerms} onChange={setIncludeTerms} placeholder={tr('如 agent、tool use，回车添加', 'e.g. agent, tool use — Enter to add')} />
+        </FormField>
+        <FormField label={tr('arXiv 分类', 'arXiv categories')} hint={tr('常用分类快捷多选；更多分类可在创建后编辑', 'Quick-pick common categories; edit more after creating')}>
+          <div className="row gap6 wrap">
+            {QUICK_CATEGORIES.map((c) => (
+              <button key={c} type="button" className={'chip mono' + (categories.includes(c) ? ' on' : '')}
+                onClick={() => toggleCategory(c)}>
+                {c}
+              </button>
+            ))}
+            {categories.filter((c) => !QUICK_CATEGORIES.includes(c)).map((c) => (
+              <button key={c} type="button" className="chip mono on" onClick={() => toggleCategory(c)} title={tr('点击移除', 'Click to remove')}>
+                {c} ×
+              </button>
+            ))}
           </div>
-        </>
-      )}
-
-      {tab === 1 && (
-        <>
-          <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '0 2px 12px', lineHeight: 1.6 }}>
-            {tr('以下内容全部可选，可直接创建课题。', 'Everything below is optional — you can create the topic right away.')}
-            {aiFilled.size > 0 && tr(' AI 已预填部分分区，请确认或微调。', ' AI pre-filled some sections; review or tweak them.')}
-          </div>
-          <div className="col gap10">
+        </FormField>
+        <div className="col gap10" style={{ marginTop: 4 }}>
             {SECTIONS.map((s) => (
               <AccordionSection key={s.key} title={tr(s.zh, s.en)} open={open[s.key]}
                 onToggle={() => toggleSection(s.key)}
@@ -558,15 +542,13 @@ export function ProjectWizardPage() {
                 )}
               </AccordionSection>
             ))}
-          </div>
+        </div>
+      </AccordionSection>
 
-        </>
-      )}
-
-      {/* 底部操作栏：两个标签页共用 */}
+      {/* 底部操作栏 */}
       <div className="row gap10" style={{ marginTop: 18 }}>
         <span style={{ fontSize: 12, color: 'var(--text-3)' }}>
-          {tr('AI 按基本信息草拟高级设置，只补空白分区，不覆盖你已填的内容', 'AI drafts the advanced settings from the basics — it only fills blank sections and never overwrites your input')}
+          {tr('AI 按名称与一句话草拟文献追踪配置，只补空白分区，不覆盖你已填的内容', 'AI drafts the tracking settings from the name and statement — it only fills blank sections and never overwrites your input')}
         </span>
         <div style={{ flex: 1 }} />
         <button className="btn btn-soft" onClick={() => void aiDraft()} disabled={busy}>

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -11,6 +11,7 @@ import { fmtTime } from '../../lib/format';
 import { clickable } from '../../lib/a11y';
 import type { PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { topicPath } from '../../app/project';
 
 /* ============================================================
    阅读工作台 · 论文信息面板（PaperDetailPane 的精简版）：
@@ -80,7 +81,7 @@ export function InfoPanel({
               <span
                 className="author-link"
                 title={tr(`回文献库只看 ${a.name} 的论文`, `Back to the library, showing only ${a.name}'s papers`)}
-                {...clickable(() => navigate(`/wiki?author=${encodeURIComponent(a.name)}`))}
+                {...clickable(() => navigate(topicPath(paper.project_id, `wiki?author=${encodeURIComponent(a.name)}`)))}
               >
                 {a.name}
               </span>
@@ -97,7 +98,7 @@ export function InfoPanel({
               className="chip"
               style={{ fontSize: 10.5, height: 20 }}
               title={tr(`回文献库只看 ${name} 的论文`, `Back to the library, showing only papers from ${name}`)}
-              {...clickable(() => navigate(`/wiki?affiliation=${encodeURIComponent(name)}`))}
+              {...clickable(() => navigate(topicPath(paper.project_id, `wiki?affiliation=${encodeURIComponent(name)}`)))}
             >
               {name}
             </span>

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -14,6 +14,7 @@ import {
   type ReadingStatus,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { topicPath } from '../../app/project';
 import { NotesPanel } from './NotesPanel';
 import { HighlightsPanel } from './HighlightsPanel';
 import { PdfReader, type JumpTarget } from './PdfReader';
@@ -174,8 +175,8 @@ export function ReadingPage() {
   });
 
   const onWikiLink = useCallback(
-    (name: string) => navigate(`/wiki?concept=${encodeURIComponent(name)}`),
-    [navigate],
+    (name: string) => navigate(topicPath(paper?.project_id, `wiki?concept=${encodeURIComponent(name)}`)),
+    [navigate, paper?.project_id],
   );
 
   const onHighlightClick = useCallback((hlId: string) => {
@@ -217,7 +218,7 @@ export function ReadingPage() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', padding: '14px 18px 16px' }}>
       {/* —— 顶栏 —— */}
       <div className="row gap12" style={{ flexShrink: 0, marginBottom: 12 }}>
-        <button className="btn btn-ghost sm" onClick={() => navigate(`/wiki?paper=${paper.id}`)}>
+        <button className="btn btn-ghost sm" onClick={() => navigate(topicPath(paper.project_id, `wiki?paper=${paper.id}`))}>
           <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
           {tr('回文献库', 'Back to library')}
         </button>

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -197,7 +197,7 @@ export function ReadingPage() {
         <EmptyState
           icon="x"
           title={tr('打不开这篇论文', 'Cannot open this paper')}
-          desc={tr('论文不存在、你不在这个研究方向里，或后端暂时不可用。', 'It does not exist, you are not in this research direction, or the backend is unavailable.')}
+          desc={tr('论文不存在、你不在这个课题里，或后端暂时不可用。', 'It does not exist, you are not in this topic, or the backend is unavailable.')}
           action={
             <button className="btn btn-ghost" onClick={() => navigate('/wiki')}>
               <Icon name="book" size={14} />

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -10,7 +10,7 @@ import { KnobRange } from '../../components/ui/KnobRange';
 import { FormField } from '../../components/ui/FormField';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import {
@@ -231,7 +231,7 @@ function LeaderboardTab({
         title={tr('排行榜为空', 'Leaderboard is empty')}
         desc={tr('先在想法生成页生成候选想法，再运行一次评审。', 'Generate candidate ideas on the Idea Forge page first, then run a review.')}
         action={
-          <button className="btn btn-ghost" onClick={() => navigate('/forge')}>
+          <button className="btn btn-ghost" onClick={() => navigate(topicPath(pid, 'forge'))}>
             <Icon name="bulb" size={14} />
             {tr('前往想法生成', 'Go to Idea Forge')}
           </button>
@@ -342,7 +342,7 @@ function LeaderboardTab({
                 <button
                   className="btn btn-soft sm"
                   title={tr('从该想法发起实验', 'Start an experiment from this idea')}
-                  onClick={() => navigate(`/experiment?new=${r.id}`)}
+                  onClick={() => navigate(topicPath(pid, `experiment?new=${r.id}`))}
                 >
                   <Icon name="flask" size={12} />
                   {tr('发起实验', 'Start experiment')}

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -541,7 +541,7 @@ function MatchesTab({
 export function ReviewPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const tab: ReviewTab = searchParams.get('tab') === 'matches' ? 'matches' : 'leaderboard';
@@ -589,31 +589,6 @@ export function ReviewPage() {
     !members ||
     members.some((m) => m.role === 'owner' && ((me?.id && m.user_id === me.id) || (me?.email && m.email === me.email)));
 
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 02 · Idea Review"
-          title={tr('想法评审', 'Idea Review')}
-          sub={tr('AI 评审员对候选想法辩论排序，晋级需人工审批。', 'AI reviewers debate and rank candidate ideas; promotion needs human approval.')}
-        />
-        <div className="card">
-          <EmptyState
-            icon="scale"
-            title={tr('还没有研究方向', 'No research direction yet')}
-            desc={tr('先创建研究方向、生成候选想法，再运行评审。', 'Create a research direction and generate candidate ideas first, then run a review.')}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New research direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="page fadeup" style={{ maxWidth: 1280 }}>
       <PageHead
@@ -621,10 +596,10 @@ export function ReviewPage() {
         title={tr('想法评审', 'Idea Review')}
         sub={
           currentProject
-            ? `${tr('当前方向', 'Current direction')}：${currentProject.name}`
+            ? `${tr('当前课题', 'Current topic')}：${currentProject.name}`
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a research direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <button className="btn btn-primary" disabled={!pid || !!runningVoyage} onClick={() => setModalOpen(true)}>
@@ -679,7 +654,7 @@ export function ReviewPage() {
       <div className="card" style={{ overflow: 'hidden', minHeight: 320 }}>
         {!pid ? (
           <div className="empty" style={{ padding: 60 }}>
-            {projectsLoading ? tr('加载研究方向…', 'Loading directions…') : tr('请先选择研究方向', 'Pick a research direction first')}
+            {projectsLoading ? tr('加载课题…', 'Loading topics…') : tr('请先选择课题', 'Pick a topic first')}
           </div>
         ) : tab === 'leaderboard' ? (
           <LeaderboardTab

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Avatar } from '../../components/ui/Avatar';
 import { Icon } from '../../components/ui/Icon';
@@ -12,6 +13,7 @@ import { DropdownList, SelectMenu, useClickOutside } from '../../components/ui/S
 import { fmtTime } from '../../lib/format';
 import { SysinfoPanel } from '../../components/ui/SysinfoPanel';
 import { FeedbackTab } from '../feedback/FeedbackTab';
+import { McpToolsContent } from '../mcp/McpToolsPage';
 import { AcademicIdentitySection } from './AcademicIdentitySection';
 import { tr } from '../../lib/i18n';
 import { setTaskLogHistory, useTaskLogHistory } from '../../lib/prefs';
@@ -957,7 +959,7 @@ const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   default: { zh: '默认', en: 'Default' },
   navigator: { zh: '任务规划', en: 'Task planning' },
   sextant: { zh: '自动校验', en: 'Auto verification' },
-  interview: { zh: '方向访谈', en: 'Direction interview' },
+  interview: { zh: '课题访谈', en: 'Topic interview' },
   relevance: { zh: '相关度打分', en: 'Relevance scoring' },
   librarian: { zh: '文献抓取', en: 'Paper fetching' },
   reading: { zh: '精读编译', en: 'Deep reading' },
@@ -2135,7 +2137,7 @@ function MyUsageTab() {
 
 // ---------------- 页面 ----------------
 
-type Tab = 'personal' | 'ssh' | 'mymodels' | 'myusage' | 'llm' | 'usage' | 'users' | 'codes' | 'feedback';
+type Tab = 'personal' | 'ssh' | 'mymodels' | 'myusage' | 'mcp' | 'llm' | 'usage' | 'users' | 'codes' | 'feedback';
 
 
 // ---------------- 用户管理（admin） ----------------
@@ -2515,8 +2517,8 @@ function BatchAssignModal({ userIds, onClose, onDone }: { userIds: string[]; onC
       open
       onClose={onClose}
       width={480}
-      title={tr('批量分配研究方向', 'Assign directions in bulk')}
-      sub={tr(`已选 ${userIds.length} 个用户，将以成员身份加入所选方向`, `${userIds.length} users selected; they will join the chosen directions as members`)}
+      title={tr('批量分配课题', 'Assign topics in bulk')}
+      sub={tr(`已选 ${userIds.length} 个用户，将以成员身份加入所选课题`, `${userIds.length} users selected; they will join the chosen topics as members`)}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -2527,9 +2529,9 @@ function BatchAssignModal({ userIds, onClose, onDone }: { userIds: string[]; onC
       }
     >
       {!projects ? (
-        <div className="empty">{tr('加载方向列表…', 'Loading directions…')}</div>
+        <div className="empty">{tr('加载课题列表…', 'Loading topics…')}</div>
       ) : projects.length === 0 ? (
-        <div className="empty">{tr('还没有研究方向', 'No research directions yet')}</div>
+        <div className="empty">{tr('还没有课题', 'No topics yet')}</div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {projects.map((p) => {
@@ -2606,7 +2608,7 @@ function UsersTab() {
             </button>
           )}
           <button className="btn btn-soft" disabled={checked.size === 0} onClick={() => setAssignOpen(true)}>
-            {tr('批量分配方向', 'Assign directions')}{checked.size > 0 ? `（${checked.size}）` : ''}
+            {tr('批量分配课题', 'Assign topics')}{checked.size > 0 ? `（${checked.size}）` : ''}
           </button>
           <button className="btn btn-primary row gap6" onClick={() => setCreateOpen(true)}>
             <Icon name="plus" size={14} />
@@ -2816,8 +2818,8 @@ function CreateCodeModal({ onClose }: { onClose: () => void }) {
         />
       </FormField>
       <FormField
-        label={tr('预设研究方向', 'Preset research directions')}
-        hint={tr('可选，每行一个（最多 10 个）。用此码注册的同学会自动获得这些方向的项目', 'Optional, one per line (max 10). New users registering with this code automatically get a project for each direction')}
+        label={tr('预设课题', 'Preset topics')}
+        hint={tr('可选，每行一个（最多 10 个）。用此码注册的同学会自动获得这些课题', 'Optional, one per line (max 10). New users registering with this code automatically get a topic for each line')}
       >
         <textarea
           className="input"
@@ -2878,7 +2880,7 @@ function CodesTab() {
               <tr>
                 <th>{tr('注册码', 'Code')}</th>
                 <th>{tr('备注', 'Note')}</th>
-                <th>{tr('预设方向', 'Directions')}</th>
+                <th>{tr('预设课题', 'Topics')}</th>
                 <th>{tr('使用', 'Uses')}</th>
                 <th>{tr('有效期', 'Expiry')}</th>
                 <th>{tr('状态', 'Status')}</th>
@@ -2946,18 +2948,25 @@ function CodesTab() {
   );
 }
 
-const PERSONAL_TABS: Tab[] = ['personal', 'ssh', 'mymodels', 'myusage'];
+const PERSONAL_TABS: Tab[] = ['personal', 'ssh', 'mymodels', 'myusage', 'mcp'];
+const ALL_TABS: Tab[] = [...PERSONAL_TABS, 'llm', 'usage', 'users', 'codes', 'feedback'];
 
 export function SettingsPage() {
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
   const admin = isAdmin(me);
-  const [tab, setTab] = useState<Tab>('personal');
+  // 支持 /settings?tab=mcp 这类深链（如旧 /mcp-tools 路由的重定向）
+  const [searchParams] = useSearchParams();
+  const [tab, setTab] = useState<Tab>(() => {
+    const t = searchParams.get('tab');
+    return t !== null && ALL_TABS.includes(t as Tab) ? (t as Tab) : 'personal';
+  });
 
   const personalItems: { v: Tab; label: string }[] = [
     { v: 'personal', label: tr('个人信息', 'Profile') },
     { v: 'ssh', label: tr('SSH 凭据', 'SSH credentials') },
     { v: 'mymodels', label: tr('我的模型', 'My LLM') },
     { v: 'myusage', label: tr('用量', 'Usage') },
+    { v: 'mcp', label: tr('MCP 接入', 'MCP access') },
   ];
   const adminItems: { v: Tab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
@@ -2999,6 +3008,7 @@ export function SettingsPage() {
       {effectiveTab === 'ssh' && <SshTab />}
       {effectiveTab === 'mymodels' && <MyLlmTab />}
       {effectiveTab === 'myusage' && <MyUsageTab />}
+      {effectiveTab === 'mcp' && <McpToolsContent />}
       {effectiveTab === 'llm' && admin && <LlmTab />}
       {effectiveTab === 'usage' && admin && <UsageTab />}
       {effectiveTab === 'users' && admin && <UsersTab />}

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -176,7 +176,7 @@ function SkillDetailModal({
     mutationFn: (target: string) =>
       api.enableProjectSkill(currentProjectId!, { skill_id: skillId, target }),
     onSuccess: (row) => {
-      toast(`${tr('已启用到当前方向', 'Enabled for current direction')}：${skillTargetLabel(row.target)}`, 'ok');
+      toast(`${tr('已启用到当前课题', 'Enabled for current topic')}：${skillTargetLabel(row.target)}`, 'ok');
       invalidate();
     },
     onError: (e) =>
@@ -279,7 +279,7 @@ function SkillDetailModal({
                 if (t) enableMutation.mutate(t);
               }}
             >
-              {tr('启用到当前方向', 'Enable for current direction')}
+              {tr('启用到当前课题', 'Enable for current topic')}
             </button>
           </span>
         )}
@@ -816,7 +816,7 @@ function EnabledPanel({ projectId }: { projectId: string }) {
   const removeMutation = useMutation({
     mutationFn: (id: string) => api.removeProjectSkill(id),
     onSuccess: () => {
-      toast(tr('已从当前方向移除', 'Removed from current direction'), 'ok');
+      toast(tr('已从当前课题移除', 'Removed from current topic'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['project-skills', projectId] });
     },
     onError: (e) => toast(`${tr('移除失败', 'Remove failed')}：${errMsg(e)}`, 'error'),
@@ -834,12 +834,12 @@ function EnabledPanel({ projectId }: { projectId: string }) {
 
   return (
     <div className="card" style={{ padding: '14px 16px' }}>
-      <div style={{ fontSize: 13, fontWeight: 660, marginBottom: 4 }}>{tr('当前方向已启用', 'Enabled for current direction')}</div>
+      <div style={{ fontSize: 13, fontWeight: 660, marginBottom: 4 }}>{tr('当前课题已启用', 'Enabled for current topic')}</div>
       <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 12 }}>
         {tr('新发起的 AI 任务会按下面的技能执行；进行中的任务不受影响', 'New AI tasks will use these skills; running tasks are unaffected')}
       </div>
       {isLoading ? null : grouped.length === 0 ? (
-        <EmptyState compact icon="sparkle" title={tr('还没有启用技能', 'No skills enabled yet')} desc={tr('从左侧技能列表点启用到当前方向', 'Enable one from the skill list on the left')} />
+        <EmptyState compact icon="sparkle" title={tr('还没有启用技能', 'No skills enabled yet')} desc={tr('从左侧技能列表点启用到当前课题', 'Enable one from the skill list on the left')} />
       ) : (
         grouped.map(([target, list]) => (
           <div key={target} style={{ marginBottom: 12 }}>
@@ -872,7 +872,7 @@ function EnabledPanel({ projectId }: { projectId: string }) {
                   <button
                     className="icon-btn"
                     style={{ width: 24, height: 24 }}
-                    title={tr('从当前方向移除', 'Remove from current direction')}
+                    title={tr('从当前课题移除', 'Remove from current topic')}
                     onClick={() => removeMutation.mutate(r.id)}
                   >
                     <Icon name="x" size={12} />
@@ -1030,7 +1030,7 @@ export function SkillsPage() {
           <EnabledPanel projectId={currentProjectId} />
         ) : (
           <div className="card" style={{ padding: '14px 16px' }}>
-            <EmptyState compact icon="compass" title={tr('未选择研究方向', 'No direction selected')} desc={tr('选择研究方向后可把技能启用到该方向', 'Pick a research direction to enable skills for it')} />
+            <EmptyState compact icon="compass" title={tr('未选择课题', 'No topic selected')} desc={tr('选择课题后可把技能启用到该课题', 'Pick a topic to enable skills for it')} />
           </div>
         )}
       </div>

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -1,0 +1,124 @@
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '../../components/ui/Icon';
+import { useProject } from '../../app/project';
+import { fmtTime } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   /start — 选择或创建课题。
+   没有任何课题时，课题作用域路由（RequireTopic）统一重定向到这里；
+   已有课题的用户手动访问也能在此快速切换。
+   ============================================================ */
+
+export function StartPage() {
+  const navigate = useNavigate();
+  const { projects, isLoading, currentProjectId, setCurrentProjectId } = useProject();
+
+  return (
+    <div className="page fadeup" style={{ maxWidth: 640, margin: '0 auto', paddingTop: 48 }}>
+      <div style={{ textAlign: 'center', marginBottom: 28 }}>
+        <div
+          style={{
+            width: 52,
+            height: 52,
+            borderRadius: 14,
+            margin: '0 auto 18px',
+            background: 'var(--accent-soft)',
+            color: 'var(--accent)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Icon name="layers" size={24} />
+        </div>
+        <h1 style={{ fontSize: 20, fontWeight: 700, margin: '0 0 8px' }}>
+          {tr('选择或创建课题', 'Pick or create a topic')}
+        </h1>
+        <div style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 460, margin: '0 auto', lineHeight: 1.6 }}>
+          {tr(
+            '课题是你的个人研究空间：文献追踪、想法、实验和论文都在课题里进行。',
+            'A topic is your personal research space — literature tracking, ideas, experiments and papers all live inside one.',
+          )}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="col gap10">
+          <div className="skel" style={{ width: '100%', height: 56 }} />
+          <div className="skel" style={{ width: '100%', height: 56 }} />
+        </div>
+      ) : projects.length > 0 ? (
+        <div className="col gap10" style={{ marginBottom: 20 }}>
+          {projects.map((p) => (
+            <button
+              key={p.id}
+              className="card hoverable"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                width: '100%',
+                padding: '14px 18px',
+                cursor: 'pointer',
+                textAlign: 'left',
+                fontFamily: 'var(--sans)',
+              }}
+              onClick={() => {
+                setCurrentProjectId(p.id);
+                navigate('/');
+              }}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  flexShrink: 0,
+                  background: p.id === currentProjectId ? 'var(--accent)' : 'var(--border-strong)',
+                }}
+              />
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span
+                  style={{
+                    display: 'block',
+                    fontSize: 14,
+                    fontWeight: 640,
+                    color: 'var(--text)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {p.name}
+                </span>
+                {p.created_at && (
+                  <span className="mono" style={{ display: 'block', fontSize: 10.5, color: 'var(--text-4)', marginTop: 3 }}>
+                    {tr('创建于', 'Created')} {fmtTime(p.created_at)}
+                  </span>
+                )}
+              </span>
+              <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="card" style={{ padding: '28px 24px', textAlign: 'center', marginBottom: 20 }}>
+          <div style={{ fontSize: 13, color: 'var(--text-3)', lineHeight: 1.6 }}>
+            {tr('你还没有课题。创建第一个课题，从文献追踪开始你的研究。', 'You have no topics yet. Create your first one and start with literature tracking.')}
+          </div>
+        </div>
+      )}
+
+      <div style={{ textAlign: 'center' }}>
+        <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
+          <Icon name="plus" size={14} />
+          {tr('新建课题', 'New topic')}
+        </button>
+        <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 18, lineHeight: 1.6 }}>
+          {tr('拿到同事的邀请链接？直接打开即可加入。', 'Got an invite link from a teammate? Just open it to join.')}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -37,8 +37,8 @@ export function StartPage() {
         </h1>
         <div style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 460, margin: '0 auto', lineHeight: 1.6 }}>
           {tr(
-            '课题是你的个人研究空间：文献追踪、想法、实验和论文都在课题里进行。',
-            'A topic is your personal research space — literature tracking, ideas, experiments and papers all live inside one.',
+            '课题是你的个人研究空间：文献追踪、想法、实验和论文都在课题里进行。创建只需名称和一句话描述。',
+            'A topic is your personal research space — literature tracking, ideas, experiments and papers all live inside one. Creating one takes just a name and one sentence.',
           )}
         </div>
       </div>
@@ -105,7 +105,7 @@ export function StartPage() {
       ) : (
         <div className="card" style={{ padding: '28px 24px', textAlign: 'center', marginBottom: 20 }}>
           <div style={{ fontSize: 13, color: 'var(--text-3)', lineHeight: 1.6 }}>
-            {tr('你还没有课题。创建第一个课题，从文献追踪开始你的研究。', 'You have no topics yet. Create your first one and start with literature tracking.')}
+            {tr('你还没有课题。只需名称和一句话描述，30 秒创建第一个课题。', 'You have no topics yet. With just a name and one sentence, your first topic is 30 seconds away.')}
           </div>
         </div>
       )}

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Icon } from '../../components/ui/Icon';
-import { useProject } from '../../app/project';
+import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 
@@ -66,7 +66,7 @@ export function StartPage() {
               }}
               onClick={() => {
                 setCurrentProjectId(p.id);
-                navigate('/');
+                navigate(topicPath(p.id));
               }}
             >
               <span

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -6,6 +6,7 @@ import { StatusPill } from '../../components/ui/StatusPill';
 import { Timeline, TimelineItem } from '../../components/ui/Timeline';
 import { toast } from '../../components/ui/Toast';
 import { useShell } from '../../app/AppShell';
+import { topicPath, useProject } from '../../app/project';
 import { subscribeSse } from '../../lib/sse';
 import { fmtDuration, fmtTime, fmtTokens } from '../../lib/format';
 import { tr } from '../../lib/i18n';
@@ -375,6 +376,7 @@ const PAPER_LIST_PREVIEW = 5;
 
 function StepPaperList({ papers, total }: { papers: PaperBrief[]; total?: number }) {
   const navigate = useNavigate();
+  const { currentProjectId } = useProject();
   const [open, setOpen] = useState(false);
   if (papers.length === 0) return null;
   const shown = open ? papers : papers.slice(0, PAPER_LIST_PREVIEW);
@@ -400,7 +402,7 @@ function StepPaperList({ papers, total }: { papers: PaperBrief[]; total?: number
               minWidth: 0,
             }}
             title={p.title}
-            onClick={() => navigate(`/wiki?paper=${p.id}`)}
+            onClick={() => navigate(topicPath(currentProjectId, `wiki?paper=${p.id}`))}
           >
             {p.title}
           </span>
@@ -1441,6 +1443,7 @@ export function VoyageDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { openGates } = useShell();
+  const { currentProjectId } = useProject();
   const [live, setLive] = useState(false);
   const [showObsolete, setShowObsolete] = useState(false);
 
@@ -1634,7 +1637,7 @@ export function VoyageDetailPage() {
           </div>
           <div className="row gap8" style={{ justifyContent: 'center' }}>
             <button className="btn btn-soft" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
-            <button className="btn btn-ghost" onClick={() => navigate('/voyages')}>{tr('返回列表', 'Back to list')}</button>
+            <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'voyages'))}>{tr('返回列表', 'Back to list')}</button>
           </div>
         </div>
       </div>
@@ -1656,7 +1659,7 @@ export function VoyageDetailPage() {
             <span
               className="row gap6"
               style={{ cursor: 'pointer' }}
-              onClick={() => navigate('/voyages')}
+              onClick={() => navigate(topicPath(voyage.project_id, 'voyages'))}
             >
               ← Voyages
             </span>

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -318,7 +318,7 @@ function wikiStepFriendly(action: string, obs: Record<string, unknown>): WikiSte
       return {
         text:
           tr(
-            `AI 按研究方向给 ${num(obs.processed)} 篇候选论文打了相关性分：${passed} 篇通过，${num(obs.excluded)} 篇相关性不足自动删除`,
+            `AI 按课题给 ${num(obs.processed)} 篇候选论文打了相关性分：${passed} 篇通过，${num(obs.excluded)} 篇相关性不足自动删除`,
             `AI scored ${num(obs.processed)} candidate papers against the research direction: ${passed} passed, ${num(obs.excluded)} removed as not relevant enough`,
           ) +
           (failedCount ? tr(`，${failedCount} 篇打分失败`, `; ${failedCount} failed to score`) : ''),

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -145,7 +145,7 @@ function SkeletonRows() {
 export function VoyagesPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { projects, currentProjectId, isLoading: projectsLoading } = useProject();
+  const { projects, currentProjectId } = useProject();
 
   const [filter, setFilter] = useState<Filter>('all');
   const [kindFilter, setKindFilter] = useState<string>('all');
@@ -180,8 +180,6 @@ export function VoyagesPage() {
     onError: (err) => toast(`${tr('创建失败：', 'Create failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
   });
 
-  const noProjects = !projectsLoading && projects.length === 0;
-
   return (
     <div className="page fadeup">
       <PageHead
@@ -189,29 +187,14 @@ export function VoyagesPage() {
         title={tr('任务', 'Tasks')}
         sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
         right={
-          <button className="btn btn-primary" disabled={noProjects} onClick={() => setCreateOpen(true)}>
+          <button className="btn btn-primary" disabled={projects.length === 0} onClick={() => setCreateOpen(true)}>
             <Icon name="play" size={14} />
             {tr('新建演示任务', 'New demo task')}
           </button>
         }
       />
 
-      {noProjects ? (
-        <div className="card">
-          <EmptyState
-            icon="compass"
-            title={tr('还没有研究方向', 'No research directions yet')}
-            desc={tr('任务隶属于研究方向。先创建一个方向，再启动演示任务。', 'Tasks belong to a research direction. Create one first, then start a demo task.')}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New research direction')}
-              </button>
-            }
-          />
-        </div>
-      ) : (
-        <>
+      <>
           <div className="row gap10" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
             <Segmented options={FILTERS.map((f) => ({ v: f.v, label: tr(f.zh, f.en) }))} value={filter} onChange={setFilter} />
             <select
@@ -229,8 +212,8 @@ export function VoyagesPage() {
             <div style={{ flex: 1 }} />
             <Segmented
               options={[
-                { v: 'current' as const, label: tr('当前方向', 'Current direction') },
-                { v: 'all' as const, label: tr('全部方向', 'All directions') },
+                { v: 'current' as const, label: tr('当前课题', 'Current topic') },
+                { v: 'all' as const, label: tr('全部课题', 'All topics') },
               ]}
               value={scope}
               onChange={setScope}
@@ -316,8 +299,7 @@ export function VoyagesPage() {
               })}
             </div>
           )}
-        </>
-      )}
+      </>
 
       {/* 新建演示航程 */}
       <Modal
@@ -343,7 +325,7 @@ export function VoyagesPage() {
           </>
         }
       >
-        <FormField label={tr('所属方向', 'Direction')}>
+        <FormField label={tr('所属课题', 'Topic')}>
           <SelectMenu
             value={effectiveProjectId}
             options={projects.map((p) => ({ value: p.id, label: p.name }))}

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -114,7 +114,7 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
     onError: (e) => {
       if (e instanceof ApiError && e.status === 409) {
         toast(
-          tr('该项目已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this direction — wait for it to finish.'),
+          tr('该课题已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this topic — wait for it to finish.'),
           'error',
         );
         void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -7,6 +7,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { FormField } from '../../components/ui/FormField';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
+import { useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { api, ApiError, type IngestKnobs, type IngestMode, type IngestState } from '../../lib/api';
 import { tr } from '../../lib/i18n';
@@ -88,6 +89,11 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
+  // 无 include 关键词时 arXiv 检索会退化成无差别抓取（空转烧钱），前端禁止启动
+  const { projects } = useProject();
+  const project = projects.find((p) => p.id === pid);
+  const noKeywords = !!project && (project.definition?.keywords?.include ?? []).length === 0;
+
   // —— 成本旋钮（bootstrap） ——
   const [monthsBack, setMonthsBack] = useState(6);
   const [maxPapers, setMaxPapers] = useState(50);
@@ -124,7 +130,7 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
     },
   });
 
-  const busy = running || ingestMutation.isPending;
+  const busy = running || ingestMutation.isPending || noKeywords;
 
   function runBootstrap() {
     ingestMutation.mutate({
@@ -417,6 +423,33 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
             disabledText={tr('无上限', 'No cap')}
           />
 
+          {noKeywords && (
+            <div
+              style={{
+                margin: '0 0 12px',
+                padding: '10px 12px',
+                borderRadius: 8,
+                background: 'var(--warn-bg)',
+                color: 'var(--warn-tx)',
+                fontSize: 12,
+                fontWeight: 600,
+                lineHeight: 1.55,
+              }}
+            >
+              {tr(
+                '这个课题还没有配置 include 关键词，无法启动文献追踪——先在课题设置里配置关键词。',
+                'This topic has no include terms yet, so literature tracking cannot start — add them in topic settings first.',
+              )}
+              <button
+                className="btn btn-soft sm"
+                style={{ marginTop: 8, display: 'flex' }}
+                onClick={() => navigate(`/projects/${pid}`)}
+              >
+                <Icon name="sliders" size={13} />
+                {tr('去课题设置配置关键词', 'Configure terms in topic settings')}
+              </button>
+            </div>
+          )}
           <div className="row gap10" style={{ marginTop: 6 }}>
             <button className="btn btn-primary" disabled={busy} onClick={runBootstrap}>
               {ingestMutation.isPending ? (

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -151,7 +151,7 @@ function AddPaperModal({
       open={open}
       onClose={onClose}
       title={tr('添加文献', 'Add paper')}
-      sub={tr('手动把一篇论文加进当前研究方向的论文库', 'Manually add a paper to this direction’s library')}
+      sub={tr('手动把一篇论文加进当前课题的论文库', 'Manually add a paper to this topic’s library')}
       width={520}
       footer={
         <>

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
-import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { useProject } from '../../app/project';
 import { api } from '../../lib/api';
@@ -31,7 +30,7 @@ type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes';
 
 export function WikiPage() {
   const navigate = useNavigate();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const [tab, setTab] = useState<WikiTab>('papers');
@@ -127,38 +126,6 @@ export function WikiPage() {
     setPendingConceptName(name);
   }, []);
 
-  // —— 无项目：引导创建 ——
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 00 · Research Wiki"
-          title={tr('文献调研', 'Research Wiki')}
-          sub={tr(
-            '每日自动抓取、打分、精读编译前沿文献，知识库复利增长。',
-            'Fetch, score, and compile new papers daily — the library compounds over time.',
-          )}
-        />
-        <div className="card">
-          <EmptyState
-            icon="book"
-            title={tr('还没有研究方向', 'No research directions yet')}
-            desc={tr(
-              'Research Wiki 按研究方向组织：先通过结构化访谈创建一个方向，再运行初始建库回填文献。',
-              'The Research Wiki is organized by direction: create one via the structured interview, then run the initial library build.',
-            )}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   // 论文库计数口径 = 库内（相关性达标）；旧后端无 library 字段时退回 total
   const total = ingestQuery.data?.paper_counts?.library ?? ingestQuery.data?.paper_counts?.total;
 
@@ -172,8 +139,8 @@ export function WikiPage() {
           currentProject
             ? undefined
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <>
@@ -183,7 +150,7 @@ export function WikiPage() {
                 onClick={() => navigate(`/projects/${currentProject.id}`)}
               >
                 <Icon name="compass" size={14} />
-                {tr('方向详情', 'Direction detail')}
+                {tr('课题设置', 'Topic settings')}
               </button>
             )}
             <button className="btn btn-ghost" disabled={!pid} onClick={() => setPresentOpen(true)}>
@@ -233,8 +200,8 @@ export function WikiPage() {
         {!pid ? (
           <div className="empty" style={{ margin: 'auto' }}>
             {projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('请先选择研究方向', 'Pick a direction first')}
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('请先选择课题', 'Pick a topic first')}
           </div>
         ) : tab === 'papers' ? (
           <PapersTab

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -50,27 +50,31 @@ export function WikiPage() {
   }, [pid]);
 
   // 深链 /wiki?paper=<id>（idea 详情 / 阅读页返回）、/wiki?concept=<名称>
-  // （阅读页双链跳转，按名称解析）与 /wiki?author= / ?affiliation=
-  // （阅读页作者/机构点击 → 论文库按其过滤）：处理后清掉参数
+  // （阅读页双链跳转，按名称解析）、/wiki?author= / ?affiliation=
+  // （阅读页作者/机构点击 → 论文库按其过滤）与 /wiki?tab=<tab>
+  // （工作台「下一步」直达建库面板）：处理后清掉参数
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
     const p = searchParams.get('paper');
     const c = searchParams.get('concept');
     const author = searchParams.get('author');
     const affiliation = searchParams.get('affiliation');
-    if (!p && !c && !author && !affiliation) return;
+    const tabParam = searchParams.get('tab');
+    if (!p && !c && !author && !affiliation && !tabParam) return;
     if (p) {
       setPaperId(p);
       setTab('papers');
     } else if (c) {
       setPendingConceptName(c);
-    } else {
+    } else if (author || affiliation) {
       setAdvSeed((old) => ({
         author: author ?? undefined,
         affiliation: affiliation ?? undefined,
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
+    } else if (tabParam && ['papers', 'concepts', 'graph', 'chat', 'ingest', 'notes'].includes(tabParam)) {
+      setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
   }, [searchParams, setSearchParams]);

--- a/src/frontend/src/features/writer/CollaboratorsModal.tsx
+++ b/src/frontend/src/features/writer/CollaboratorsModal.tsx
@@ -74,7 +74,7 @@ export function CollaboratorsModal({ open, onClose, manuscriptId }: Collaborator
       toast(tr('已添加协作者', 'Collaborator added'), 'ok');
     },
     onError: (e) => {
-      if (isForbidden(e)) toast(tr('需要研究方向 owner 或管理员权限', 'Requires research-direction owner or admin permission'), 'error');
+      if (isForbidden(e)) toast(tr('需要课题 owner 或管理员权限', 'Requires topic owner or admin permission'), 'error');
       else toast(`${tr('添加失败：', 'Add failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
     },
   });
@@ -86,7 +86,7 @@ export function CollaboratorsModal({ open, onClose, manuscriptId }: Collaborator
       toast(tr('已移除协作者', 'Collaborator removed'), 'ok');
     },
     onError: (e) => {
-      if (isForbidden(e)) toast(tr('需要研究方向 owner 或管理员权限', 'Requires research-direction owner or admin permission'), 'error');
+      if (isForbidden(e)) toast(tr('需要课题 owner 或管理员权限', 'Requires topic owner or admin permission'), 'error');
       else if (e instanceof ApiError && e.status === 409) toast(tr('不能移除 owner', 'Cannot remove the owner'), 'error');
       else toast(`${tr('移除失败：', 'Remove failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
     },
@@ -98,7 +98,7 @@ export function CollaboratorsModal({ open, onClose, manuscriptId }: Collaborator
       setShareUrl(`${window.location.origin}${link.join_path}`);
     },
     onError: (e) => {
-      if (isForbidden(e)) toast(tr('需要研究方向 owner 或管理员权限', 'Requires research-direction owner or admin permission'), 'error');
+      if (isForbidden(e)) toast(tr('需要课题 owner 或管理员权限', 'Requires topic owner or admin permission'), 'error');
       else toast(`${tr('生成链接失败：', 'Create link failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
     },
   });

--- a/src/frontend/src/features/writer/TemplateUploadModal.tsx
+++ b/src/frontend/src/features/writer/TemplateUploadModal.tsx
@@ -186,8 +186,8 @@ export function TemplateUploadModal({ open, onClose, pid, onUploaded }: Template
       </label>
       <div className="field-hint" style={{ marginTop: 4 }}>
         {global
-          ? tr('全平台模板对所有研究方向可见，仅平台管理员可创建。', 'Platform-wide templates are visible to every project; only platform admins can create them.')
-          : tr('默认仅当前研究方向可用。', 'By default only the current project can use it.')}
+          ? tr('全平台模板对所有课题可见，仅平台管理员可创建。', 'Platform-wide templates are visible to every topic; only platform admins can create them.')
+          : tr('默认仅当前课题可用。', 'By default only the current topic can use it.')}
       </div>
     </Modal>
   );

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../lib/api';
 import { fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
+import { topicPath, useProject } from '../../app/project';
 import type { ProviderStatus } from '../../lib/yjs-provider';
 import { EditorPane, BinaryPreview, type PeerInfo } from './EditorPane';
 import { FileTree } from './FileTree';
@@ -241,6 +242,7 @@ export function WriterEditorPage() {
   const { id = '' } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { currentProjectId } = useProject();
 
   const detailQuery = useQuery({
     queryKey: ['manuscript', id],
@@ -655,7 +657,7 @@ export function WriterEditorPage() {
           title={tr('打不开这篇论文草稿', 'Cannot open this manuscript')}
           desc={tr('草稿不存在、你不在这个课题里，或后端暂时不可用。', 'It does not exist, you are not in this topic, or the backend is unavailable.')}
           action={
-            <button className="btn btn-ghost" onClick={() => navigate('/writer')}>
+            <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'writer'))}>
               <Icon name="pen" size={14} />
               {tr('回论文列表', 'Back to manuscripts')}
             </button>
@@ -690,7 +692,7 @@ export function WriterEditorPage() {
           flexShrink: 0,
         }}
       >
-        <button className="btn btn-ghost sm" onClick={() => navigate('/writer')}>
+        <button className="btn btn-ghost sm" onClick={() => navigate(topicPath(ms.project_id, 'writer'))}>
           <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
           {tr('论文列表', 'Manuscripts')}
         </button>

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -653,7 +653,7 @@ export function WriterEditorPage() {
         <EmptyState
           icon="x"
           title={tr('打不开这篇论文草稿', 'Cannot open this manuscript')}
-          desc={tr('草稿不存在、你不在这个研究方向里，或后端暂时不可用。', 'It does not exist, you are not in this research direction, or the backend is unavailable.')}
+          desc={tr('草稿不存在、你不在这个课题里，或后端暂时不可用。', 'It does not exist, you are not in this topic, or the backend is unavailable.')}
           action={
             <button className="btn btn-ghost" onClick={() => navigate('/writer')}>
               <Icon name="pen" size={14} />

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -236,7 +236,7 @@ function ManuscriptCard({
 export function WriterPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { projects, isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
   const [modalOpen, setModalOpen] = useState(false);
   const [view, setView] = useState<ViewMode>('active');
@@ -392,31 +392,6 @@ export function WriterPage() {
 
   const confirmBusy = deleteOne.isPending || batchDelete.isPending || emptyTrash.isPending;
 
-  if (!projectsLoading && projects.length === 0) {
-    return (
-      <div className="page fadeup">
-        <PageHead
-          eyebrow="Stage 04 · Paper Writer"
-          title={tr('论文撰写', 'Paper Writer')}
-          sub={tr('从模板起稿、AI 起草到编译预览与投稿审批。', 'From template and AI drafting to compile preview and submission approval.')}
-        />
-        <div className="card">
-          <EmptyState
-            icon="pen"
-            title={tr('还没有研究方向', 'No research directions yet')}
-            desc={tr('先创建研究方向，完成实验后再开始写论文。', 'Create a research direction and finish experiments before writing a paper.')}
-            action={
-              <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-                <Icon name="plus" size={14} />
-                {tr('新建研究方向', 'New direction')}
-              </button>
-            }
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="page fadeup" style={{ maxWidth: 1180 }}>
       <PageHead
@@ -424,10 +399,10 @@ export function WriterPage() {
         title={tr('论文撰写', 'Paper Writer')}
         sub={
           currentProject
-            ? `${tr('当前方向：', 'Current direction: ')}${currentProject.name}`
+            ? `${tr('当前课题：', 'Current topic: ')}${currentProject.name}`
             : projectsLoading
-              ? tr('加载研究方向…', 'Loading directions…')
-              : tr('选择一个研究方向', 'Pick a research direction')
+              ? tr('加载课题…', 'Loading topics…')
+              : tr('选择一个课题', 'Pick a topic')
         }
         right={
           <button className="btn btn-primary" disabled={!pid} onClick={() => setModalOpen(true)}>
@@ -492,7 +467,7 @@ export function WriterPage() {
       {!pid ? (
         <div className="card">
           <div className="empty" style={{ padding: 60 }}>
-            {projectsLoading ? tr('加载研究方向…', 'Loading directions…') : tr('请先选择研究方向', 'Pick a research direction first')}
+            {projectsLoading ? tr('加载课题…', 'Loading topics…') : tr('请先选择课题', 'Pick a topic first')}
           </div>
         </div>
       ) : activeQ.isLoading ? (

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -71,13 +71,19 @@ input {
 .nav-collapsed .sidebar { width: 66px; }
 /* 收起态：图形标居中（字标由 React 直接不渲染，尺寸与展开态一致，不缩放） */
 .nav-collapsed .sb-brand { justify-content: center; margin: 18px 0 12px; }
-.nav-collapsed .sb-scroll { padding: 4px 8px 14px; }
+.nav-collapsed .sb-scroll { padding: 0 8px 14px; }
 /* 收起态：保留小标题占位高度（文字隐藏、盒模型与展开态相同），
    否则流水线一组图标会整体上移、与展开态对不上 */
 .nav-collapsed .sb-section { padding-left: 0; padding-right: 0; overflow: hidden; white-space: nowrap; color: transparent; }
 /* 收起态：整行居中，仅留图标（行高与展开态相同，图标尺寸不变） */
-.nav-collapsed .nav-item { justify-content: center; gap: 0; padding: 8px 0; }
+.nav-collapsed .nav-item { justify-content: center; gap: 0; padding: 9px 0; }
 .nav-collapsed .nav-item .nav-label { display: none; }
+/* 收起态：课题容器优雅降级——icon-only、保留容器底色与边框，切换器按钮在容器顶部 */
+.nav-collapsed .sb-topic-wrap { margin: 6px 8px 4px; }
+.nav-collapsed .topic-zone { padding: 4px; }
+.nav-collapsed .topic-zone-hr { margin: 4px -4px 5px; }
+.nav-collapsed .topic-zone-hr.inset { margin: 4px 2px 5px; }
+.nav-collapsed .topic-switch { justify-content: center; gap: 0; padding: 0; }
 .nav-toggle { margin-right: 2px; }
 /* 图形标中心对齐图标列中线（12+24/2+... = 33px），与收起态一致 */
 /* 左边距使图形标(41px)中心落在 12.5+41/2 = 33px（= 收起态居中于 66px 侧栏的中心，
@@ -86,26 +92,61 @@ input {
 .sb-brand h1 { font-size: 14px; font-weight: 650; margin: 0; letter-spacing: -0.01em; }
 .sb-brand p { font-size: 11px; color: var(--text-3); margin: 1px 0 0; font-family: var(--mono); }
 
-.sb-scroll { flex: 1; overflow-y: auto; padding: 4px 12px 14px; }
+.sb-scroll { flex: 1; overflow-y: auto; padding: 0 12px 14px; }
 .sb-section {
   font-size: 11px; font-weight: 600; color: var(--text-4);
-  letter-spacing: 0.04em; text-transform: uppercase; padding: 14px 10px 6px;
+  letter-spacing: 0.04em; text-transform: uppercase; padding: 16px 10px 6px;
 }
+
+/* —— 课题区：eyebrow + 圆角视觉容器（切换器为容器头部，导航在容器内略有内缩） ——
+   容器与侧栏均不裁剪 overflow：切换器下拉菜单要能向右溢出到主列上（侧栏 z-index 已抬高）。 */
+.sb-topic-wrap { margin: 6px 12px 4px; flex-shrink: 0; }
+.sb-section.sb-topic-eyebrow { padding: 4px 10px 6px; }
+.topic-zone {
+  background: var(--surface);
+  border: 1px solid var(--border-2);
+  border-radius: var(--radius);
+  padding: 6px;
+  box-shadow: var(--shadow-card);
+}
+.topic-zone .nav-item:last-child { margin-bottom: 0; }
+/* 容器内 hairline：切换器头部下方全出血；「课题设置」上方内缩一档 */
+.topic-zone-hr { height: 1px; background: var(--border); margin: 5px -6px 6px; }
+.topic-zone-hr.inset { margin: 5px 6px 6px; }
+
+/* —— 课题切换器（容器头部）：全宽、hover 浅底、打开态浅蓝底 —— */
+.topic-switch {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; height: 38px; padding: 0 9px;
+  border: none; border-radius: 8px;
+  background: transparent; cursor: pointer;
+  font-family: var(--sans);
+  transition: background 0.12s;
+}
+.topic-switch:hover { background: var(--nav-hover); }
+.topic-switch.open { background: var(--accent-soft); }
+.topic-switch-label {
+  flex: 1; min-width: 0; text-align: left;
+  font-size: 12.5px; font-weight: 620; color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.topic-switch-label.placeholder { color: var(--text-3); }
 
 .nav-item {
   display: flex; align-items: center; gap: 11px;
-  padding: 8px 9px; border-radius: 9px; cursor: pointer;
+  padding: 9px 9px; border-radius: 9px; cursor: pointer;
   font-size: 13.5px; color: var(--text-2); font-weight: 500;
-  position: relative; user-select: none; margin-bottom: 1px;
+  position: relative; user-select: none; margin-bottom: 4px;
   text-decoration: none;
   transition: background 0.12s, color 0.12s;
 }
-.nav-item:hover { background: rgba(10, 30, 66, 0.04); color: var(--text); }
-.nav-item.active { background: var(--surface); color: var(--text); font-weight: 600; box-shadow: var(--shadow-card); }
+.nav-item:hover { background: var(--nav-hover); color: var(--text); }
+/* 选中态：浙大蓝浅底 + 蓝色图标文字（弃用白色胶囊，明度对白色容器与灰蓝侧栏底都成立） */
+.nav-item.active { background: var(--accent-soft); color: var(--accent-text); font-weight: 600; }
 .nav-item.active .nav-ic { color: var(--accent); }
-/* 24px 图标框、图标居中：展开态 icon 中心 = 12(scroll)+9(item)+12 = 33px；
-   收起态 icon 居中于 50px 轨道 = 8+13+12 = 33px，两态完全对齐 */
-.nav-ic { width: 24px; height: 19px; flex-shrink: 0; color: var(--text-3); display: flex; align-items: center; justify-content: center; }
+/* 24px 图标框、图标居中：个人区展开态 icon 中心 = 12(scroll)+9(item)+12 = 33px；
+   收起态 icon 居中于图标轨道 = 33px；课题容器内因内缩整体右移 6px，属有意为之 */
+.nav-ic { width: 24px; height: 20px; flex-shrink: 0; color: var(--text-3); display: flex; align-items: center; justify-content: center; }
 
 .sb-foot { padding: 8px 10px; border-top: 0.5px solid var(--border-2); }
 

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -72,17 +72,13 @@ input {
 /* 收起态：图形标居中（字标由 React 直接不渲染，尺寸与展开态一致，不缩放） */
 .nav-collapsed .sb-brand { justify-content: center; margin: 18px 0 12px; }
 .nav-collapsed .sb-scroll { padding: 0 8px 14px; }
-/* 收起态：保留小标题占位高度（文字隐藏、盒模型与展开态相同），
-   否则流水线一组图标会整体上移、与展开态对不上 */
-.nav-collapsed .sb-section { padding-left: 0; padding-right: 0; overflow: hidden; white-space: nowrap; color: transparent; }
+/* 收起态：eyebrow 文字隐藏，分组间只留 16px 干净间距（不加分隔线） */
+.nav-collapsed .sb-section { height: 16px; padding: 0; overflow: hidden; white-space: nowrap; color: transparent; }
 /* 收起态：整行居中，仅留图标（行高与展开态相同，图标尺寸不变） */
 .nav-collapsed .nav-item { justify-content: center; gap: 0; padding: 9px 0; }
 .nav-collapsed .nav-item .nav-label { display: none; }
-/* 收起态：课题容器优雅降级——icon-only、保留容器底色与边框，切换器按钮在容器顶部 */
-.nav-collapsed .sb-topic-wrap { margin: 6px 8px 4px; }
-.nav-collapsed .topic-zone { padding: 4px; }
-.nav-collapsed .topic-zone-hr { margin: 4px -4px 5px; }
-.nav-collapsed .topic-zone-hr.inset { margin: 4px 2px 5px; }
+/* 收起态：非滚动导航区收窄；切换器 icon-only、保留描边 */
+.nav-collapsed .sb-nav-static { padding: 0 8px; }
 .nav-collapsed .topic-switch { justify-content: center; gap: 0; padding: 0; }
 .nav-toggle { margin-right: 2px; }
 /* 图形标中心对齐图标列中线（12+24/2+... = 33px），与收起态一致 */
@@ -93,38 +89,34 @@ input {
 .sb-brand p { font-size: 11px; color: var(--text-3); margin: 1px 0 0; font-family: var(--mono); }
 
 .sb-scroll { flex: 1; overflow-y: auto; padding: 0 12px 14px; }
+/* 分组 eyebrow：三组（实验室/课题研究/个人）样式完全一致；
+   上 padding 20 + 上一条目 margin 4 ≈ 24px 分组间距，只靠间距区分、不加分隔线 */
 .sb-section {
   font-size: 11px; font-weight: 600; color: var(--text-4);
-  letter-spacing: 0.04em; text-transform: uppercase; padding: 16px 10px 6px;
+  letter-spacing: 0.04em; text-transform: uppercase; padding: 20px 10px 6px;
 }
 
-/* —— 课题区：eyebrow + 圆角视觉容器（切换器为容器头部，导航在容器内略有内缩） ——
-   容器与侧栏均不裁剪 overflow：切换器下拉菜单要能向右溢出到主列上（侧栏 z-index 已抬高）。 */
-.sb-topic-wrap { margin: 6px 12px 4px; flex-shrink: 0; }
-.sb-section.sb-topic-eyebrow { padding: 4px 10px 6px; }
-.topic-zone {
-  background: var(--surface);
-  border: 1px solid var(--border-2);
-  border-radius: var(--radius);
-  padding: 6px;
-  box-shadow: var(--shadow-card);
-}
-.topic-zone .nav-item:last-child { margin-bottom: 0; }
-/* 容器内 hairline：切换器头部下方全出血；「课题设置」上方内缩一档 */
-.topic-zone-hr { height: 1px; background: var(--border); margin: 5px -6px 6px; }
-.topic-zone-hr.inset { margin: 5px 6px 6px; }
+/* —— 非滚动导航区（实验室 + 课题研究两组）——
+   放在 sb-scroll 之外：课题切换器的下拉菜单要能向右溢出到主列上，
+   不能被滚动容器的 overflow 裁剪（侧栏本身 z-index 已抬高、不裁剪）。 */
+.sb-nav-static { padding: 0 12px; flex-shrink: 0; }
+/* 第一组（实验室）标签与 logo 间距 ≈ 24px（brand margin 12 + 这里 12） */
+.sb-nav-static > .sb-section:first-child { padding-top: 12px; }
 
-/* —— 课题切换器（容器头部）：全宽、hover 浅底、打开态浅蓝底 —— */
+/* —— 课题切换器：课题研究组内的一个「特殊条目」——
+   与普通条目同高（38px），常驻 1px 描边表达「可点切换」，打开态浅蓝底；
+   与下方「工作台」之间留 8px。 —— */
 .topic-switch {
   display: flex; align-items: center; gap: 8px;
   width: 100%; height: 38px; padding: 0 9px;
-  border: none; border-radius: 8px;
+  border: 1px solid var(--border-2); border-radius: 9px;
   background: transparent; cursor: pointer;
   font-family: var(--sans);
-  transition: background 0.12s;
+  margin-bottom: 8px;
+  transition: background 0.12s, border-color 0.12s;
 }
-.topic-switch:hover { background: var(--nav-hover); }
-.topic-switch.open { background: var(--accent-soft); }
+.topic-switch:hover { background: var(--nav-hover); border-color: var(--border-strong); }
+.topic-switch.open { background: var(--accent-soft); border-color: var(--accent-soft-2); }
 .topic-switch-label {
   flex: 1; min-width: 0; text-align: left;
   font-size: 12.5px; font-weight: 620; color: var(--text);
@@ -141,11 +133,11 @@ input {
   transition: background 0.12s, color 0.12s;
 }
 .nav-item:hover { background: var(--nav-hover); color: var(--text); }
-/* 选中态：浙大蓝浅底 + 蓝色图标文字（弃用白色胶囊，明度对白色容器与灰蓝侧栏底都成立） */
+/* 选中态：浙大蓝浅底 + 蓝色图标文字（弃用白色胶囊） */
 .nav-item.active { background: var(--accent-soft); color: var(--accent-text); font-weight: 600; }
 .nav-item.active .nav-ic { color: var(--accent); }
-/* 24px 图标框、图标居中：个人区展开态 icon 中心 = 12(scroll)+9(item)+12 = 33px；
-   收起态 icon 居中于图标轨道 = 33px；课题容器内因内缩整体右移 6px，属有意为之 */
+/* 24px 图标框、图标居中：展开态 icon 中心 = 12(区 padding)+9(item)+12 = 33px；
+   收起态 icon 居中于图标轨道 = 33px，两态对齐 */
 .nav-ic { width: 24px; height: 20px; flex-shrink: 0; color: var(--text-3); display: flex; align-items: center; justify-content: center; }
 
 .sb-foot { padding: 8px 10px; border-top: 0.5px solid var(--border-2); }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -72,8 +72,16 @@ input {
 /* 收起态：图形标居中（字标由 React 直接不渲染，尺寸与展开态一致，不缩放） */
 .nav-collapsed .sb-brand { justify-content: center; margin: 18px 0 12px; }
 .nav-collapsed .sb-scroll { padding: 0 8px 14px; }
-/* 收起态：eyebrow 文字隐藏，分组间只留 16px 干净间距（不加分隔线） */
-.nav-collapsed .sb-section { height: 16px; padding: 0; overflow: hidden; white-space: nowrap; color: transparent; }
+/* 收起态：eyebrow 文字隐藏（只作用于侧栏，别误伤审批抽屉里的同类标签），
+   组间 16px 间距 + 极短居中细线表达分组（中心对齐图标轨道中线 33px） */
+.nav-collapsed .sidebar .sb-section { position: relative; height: 16px; padding: 0; overflow: hidden; white-space: nowrap; color: transparent; }
+.nav-collapsed .sidebar .sb-section::after {
+  content: ''; position: absolute; left: 50%; top: 50%;
+  width: 24px; height: 1px; transform: translate(-50%, -50%);
+  background: var(--border);
+}
+/* 第一组（实验室）上方贴着 logo，不画线 */
+.nav-collapsed .sb-nav-static > .sb-section:first-child::after { content: none; }
 /* 收起态：整行居中，仅留图标（行高与展开态相同，图标尺寸不变） */
 .nav-collapsed .nav-item { justify-content: center; gap: 0; padding: 9px 0; }
 .nav-collapsed .nav-item .nav-label { display: none; }
@@ -105,10 +113,12 @@ input {
 
 /* —— 课题切换器：课题研究组内的一个「特殊条目」——
    与普通条目同高（38px），常驻 1px 描边表达「可点切换」，打开态浅蓝底；
-   与下方「工作台」之间留 8px。 —— */
+   与下方「工作台」之间留 8px。
+   图标走统一轨道：内 padding 8 + 描边 1 = nav-item 的 9，nav-ic 中心同为 33px；
+   gap 11 与 nav-item 一致，标签起点也对齐（56px）。 —— */
 .topic-switch {
-  display: flex; align-items: center; gap: 8px;
-  width: 100%; height: 38px; padding: 0 9px;
+  display: flex; align-items: center; gap: 11px;
+  width: 100%; height: 38px; padding: 0 8px;
   border: 1px solid var(--border-2); border-radius: 9px;
   background: transparent; cursor: pointer;
   font-family: var(--sans);
@@ -140,7 +150,8 @@ input {
    收起态 icon 居中于图标轨道 = 33px，两态对齐 */
 .nav-ic { width: 24px; height: 20px; flex-shrink: 0; color: var(--text-3); display: flex; align-items: center; justify-content: center; }
 
-.sb-foot { padding: 8px 10px; border-top: 0.5px solid var(--border-2); }
+/* 头像中心对齐图标轨道：7.5(这里) + 0.5(trigger 边框) + 8(trigger padding) + 17(头像半径) = 33px */
+.sb-foot { padding: 8px 7.5px; border-top: 0.5px solid var(--border-2); }
 
 /* —— 用户菜单（点头像弹出 设置 / 邀请 / 退出） —— */
 .user-menu-root { position: relative; }
@@ -154,8 +165,8 @@ input {
 .user-info { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .user-name { font-size: 13.5px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .user-role { font-size: 12px; color: var(--text-3); }
-/* 收起态：仅头像，居中；隐藏名字/角色/箭头 */
-.nav-collapsed .sb-foot { padding: 8px 0; }
+/* 收起态：仅头像，居中（8px 侧距与导航区一致 → 头像中心同在 33px 轨道）；隐藏名字/角色/箭头 */
+.nav-collapsed .sb-foot { padding: 8px; }
 .nav-collapsed .user-trigger { justify-content: center; gap: 0; padding: 8px 0; }
 .nav-collapsed .user-info { display: none; }
 

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -72,9 +72,11 @@ input {
 /* 收起态：图形标居中（字标由 React 直接不渲染，尺寸与展开态一致，不缩放） */
 .nav-collapsed .sb-brand { justify-content: center; margin: 18px 0 12px; }
 .nav-collapsed .sb-scroll { padding: 0 8px 14px; }
-/* 收起态：eyebrow 文字隐藏（只作用于侧栏，别误伤审批抽屉里的同类标签），
-   组间 16px 间距 + 极短居中细线表达分组（中心对齐图标轨道中线 33px） */
-.nav-collapsed .sidebar .sb-section { position: relative; height: 16px; padding: 0; overflow: hidden; white-space: nowrap; color: transparent; }
+/* 收起态：eyebrow 盒子与展开态逐像素等高——不改 padding/行高/高度，只把文字弄透明
+   （nowrap + overflow hidden 防止窄栏下换行改变高度），下方所有条目纵向零位移。
+   只作用于侧栏，别误伤审批抽屉里复用 .sb-section 的标签。
+   分割线画在同一盒子内居中，水平中心 = 33px 图标轨道中线。 */
+.nav-collapsed .sidebar .sb-section { position: relative; overflow: hidden; white-space: nowrap; color: transparent; }
 .nav-collapsed .sidebar .sb-section::after {
   content: ''; position: absolute; left: 50%; top: 50%;
   width: 24px; height: 1px; transform: translate(-50%, -50%);
@@ -98,9 +100,11 @@ input {
 
 .sb-scroll { flex: 1; overflow-y: auto; padding: 0 12px 14px; }
 /* 分组 eyebrow：三组（实验室/课题研究/个人）样式完全一致；
-   上 padding 20 + 上一条目 margin 4 ≈ 24px 分组间距，只靠间距区分、不加分隔线 */
+   上 padding 20 + 上一条目 margin 4 ≈ 24px 分组间距，展开态只靠间距区分、不加分隔线。
+   line-height 定死 14px → 盒子总高 = 20+14+6 = 40px（first-child 特例 12+14+6 = 32px），
+   收起态沿用同一盒模型（只隐藏文字），保证收放时下方条目纵向不跳。 */
 .sb-section {
-  font-size: 11px; font-weight: 600; color: var(--text-4);
+  font-size: 11px; font-weight: 600; color: var(--text-4); line-height: 14px;
   letter-spacing: 0.04em; text-transform: uppercase; padding: 20px 10px 6px;
 }
 

--- a/src/frontend/src/styles/tokens.css
+++ b/src/frontend/src/styles/tokens.css
@@ -12,6 +12,8 @@
   --surface:       #ffffff;   /* cards */
   --surface-2:     #f2f5f9;   /* inset / hover */
   --surface-3:     #e8edf4;   /* deeper inset / code blocks */
+  /* 导航 hover 浅底：半透明墨蓝，在白色容器与灰蓝侧栏底上都成立 */
+  --nav-hover:     rgba(10, 30, 66, 0.05);
 
   /* — Lines — */
   --border:        #e2e7ee;


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P1, frontend only.

## What changed

**Sidebar reorganized into two scope zones**
- Topic zone, headed by the topic switcher (moved from the topbar into the sidebar): Workbench (former Dashboard), pipeline stages 00–05, Tasks, Topic Settings. Collapsed sidebar shows an icon-only switcher.
- Personal zone: My Library, Skills, Settings. The MCP nav item is gone (see below).
- Topbar now only carries breadcrumb, ⌘K search, language toggle, feedback, and the approval bell.

**`/start` page + route guard**
- New `/start` page: pick an existing topic or create one; hints that invite links can be opened directly.
- `RequireTopic` wrapper route redirects topic-scoped routes (`/`, `/wiki`, `/forge`, `/review`, `/experiment`, `/writer`, `/paper-review`, `/voyages` and their detail children) to `/start` when the user has no topics. No flash during loading; backend-unavailable errors do not redirect.
- Removed the nine duplicated "no research direction yet" empty states across Dashboard/Wiki/Forge/Review/Experiment/Writer/PaperReview/Voyages.

**MCP folded into Settings**
- `McpToolsPage` body extracted as `McpToolsContent`, rendered as a new deep-linkable "MCP" tab in Settings (`?tab=mcp`); `/mcp-tools` redirects there.

**Terminology sweep**
- User-facing wording renamed from "research direction" to "topic" (研究方向 → 课题), Dashboard → Workbench, across the shell, switcher, wizard, detail pages, and admin settings. Code identifiers (`project`, `currentProjectId`, …) are intentionally unchanged until the P5 backend migration.

## Verification

- `tsc --noEmit` and `npm run build` pass.
- Behavior to smoke-test in review: fresh account → lands on `/start`; topic switcher in the sidebar (expanded + collapsed); `/mcp-tools` redirect; language toggle on all new copy.