### PR TITLE
feat(library): global paper content pool + direction library membership layer (IA redesign P4)

### DIFF
--- a/src/backend/alembic/versions/f7c2abfe8aeb_direction_libraries_and_paper_pool.py
+++ b/src/backend/alembic/versions/f7c2abfe8aeb_direction_libraries_and_paper_pool.py
@@ -1,0 +1,355 @@
+"""方向文献库 + 论文内容池（P4 迁移 A）
+
+新建 direction_libraries / direction_library_curators / library_papers 三张表；
+papers 加全局去重键 dedup_key；为每个现有 project 生成 1:1 隐式方向库并把论文
+归属 + 判断字段复制为成员行；回填 dedup_key 并按「chunks 最多 / 字段最全」
+消解同键冲突后加唯一索引。project_id 冗余列在迁移 B（P4 收尾）删除，此处先放开
+NOT NULL 以便新代码不再写入。
+
+Revision ID: f7c2abfe8aeb
+Revises: 94e6bc81c510
+Create Date: 2026-07-22
+"""
+
+import hashlib
+import re
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f7c2abfe8aeb"
+down_revision: str | None = "94e6bc81c510"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+# ---- 与 app/services/dedup.py 同口径（迁移内自带副本，避免依赖应用代码演化）----
+
+
+def _normalize_title(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
+
+
+def _normalize_author(name: str) -> str:
+    return re.sub(r"[^a-z一-鿿0-9]+", " ", name.lower()).strip()
+
+
+def _pool_dedup_key(
+    arxiv_id: str | None,
+    doi: str | None,
+    title: str,
+    year: int | None,
+    authors: list[Any] | None,
+) -> str:
+    if arxiv_id:
+        return f"arxiv:{arxiv_id.lower()}"
+    if doi:
+        return f"doi:{doi.lower()}"
+    parts = [_normalize_title(title)]
+    if year is not None:
+        parts.append(str(year))
+    first = authors[0] if authors else None
+    name = first.get("name") if isinstance(first, dict) else first
+    if isinstance(name, str) and name.strip():
+        parts.append(_normalize_author(name))
+    return f"title:{hashlib.sha1('|'.join(parts).encode()).hexdigest()}"
+
+
+def _table(name: str, *cols: sa.Column) -> sa.TableClause:
+    return sa.table(name, *cols)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ---- 1. 新表 ----
+    op.create_table(
+        "direction_libraries",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("statement", sa.Text(), nullable=True),
+        sa.Column("rubric", _JSON, nullable=True),
+        sa.Column("anchors", _JSON, nullable=True),
+        sa.Column("ingest_state", _JSON, nullable=True),
+        sa.Column("cadence", sa.String(32), nullable=True),
+        sa.Column("monthly_budget", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("project_id"),
+    )
+    op.create_table(
+        "direction_library_curators",
+        sa.Column(
+            "library_id",
+            sa.Uuid(),
+            sa.ForeignKey("direction_libraries.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "library_papers",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "library_id",
+            sa.Uuid(),
+            sa.ForeignKey("direction_libraries.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "paper_id", sa.Uuid(), sa.ForeignKey("papers.id", ondelete="CASCADE"), nullable=False
+        ),
+        sa.Column("relevance_score", sa.Float(), nullable=True),
+        sa.Column("tldr_note", sa.Text(), nullable=True),
+        sa.Column("wiki_content", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column("trash_reason", sa.String(16), nullable=True),
+        sa.Column("scored_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("compiled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("compiled_model", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("library_id", "paper_id", name="uq_library_papers_library_paper"),
+    )
+    op.create_index("ix_library_papers_library_id", "library_papers", ["library_id"])
+    op.create_index("ix_library_papers_paper_id", "library_papers", ["paper_id"])
+    op.create_index("ix_library_papers_library_status", "library_papers", ["library_id", "status"])
+
+    # ---- 2. papers.dedup_key + 放开 project_id 冗余列的 NOT NULL（迁移 B 删列）----
+    op.add_column("papers", sa.Column("dedup_key", sa.String(512), nullable=True))
+    with op.batch_alter_table("papers") as batch:
+        batch.alter_column("project_id", existing_type=sa.Uuid(), nullable=True)
+    with op.batch_alter_table("paper_chunks") as batch:
+        batch.alter_column("project_id", existing_type=sa.Uuid(), nullable=True)
+
+    # ---- 3. 数据迁移：隐式库 + 成员行 + dedup_key 回填 + 同键冲突消解 ----
+    now = datetime.now(UTC)
+    projects_t = _table(
+        "projects",
+        sa.column("id", sa.Uuid()),
+        sa.column("name", sa.String()),
+        sa.column("definition", _JSON),
+        sa.column("ingest_state", _JSON),
+        sa.column("owner_id", sa.Uuid()),
+    )
+    libs_t = _table(
+        "direction_libraries",
+        sa.column("id", sa.Uuid()),
+        sa.column("name", sa.String()),
+        sa.column("statement", sa.Text()),
+        sa.column("rubric", _JSON),
+        sa.column("anchors", _JSON),
+        sa.column("ingest_state", _JSON),
+        sa.column("cadence", sa.String()),
+        sa.column("created_by", sa.Uuid()),
+        sa.column("project_id", sa.Uuid()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    papers_t = _table(
+        "papers",
+        sa.column("id", sa.Uuid()),
+        sa.column("project_id", sa.Uuid()),
+        sa.column("arxiv_id", sa.String()),
+        sa.column("doi", sa.String()),
+        sa.column("title", sa.Text()),
+        sa.column("year", sa.Integer()),
+        sa.column("authors", _JSON),
+        sa.column("abstract", sa.Text()),
+        sa.column("pdf_path", sa.String()),
+        sa.column("full_text_path", sa.String()),
+        sa.column("relevance_score", sa.Float()),
+        sa.column("wiki_content", sa.Text()),
+        sa.column("status", sa.String()),
+        sa.column("trash_reason", sa.String()),
+        sa.column("scored_at", sa.DateTime(timezone=True)),
+        sa.column("compiled_at", sa.DateTime(timezone=True)),
+        sa.column("compiled_model", sa.String()),
+        sa.column("dedup_key", sa.String()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    members_t = _table(
+        "library_papers",
+        sa.column("id", sa.Uuid()),
+        sa.column("library_id", sa.Uuid()),
+        sa.column("paper_id", sa.Uuid()),
+        sa.column("relevance_score", sa.Float()),
+        sa.column("wiki_content", sa.Text()),
+        sa.column("status", sa.String()),
+        sa.column("trash_reason", sa.String()),
+        sa.column("scored_at", sa.DateTime(timezone=True)),
+        sa.column("compiled_at", sa.DateTime(timezone=True)),
+        sa.column("compiled_model", sa.String()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    lib_by_project: dict[Any, uuid.UUID] = {}
+    for row in bind.execute(sa.select(projects_t)).mappings():
+        definition = row["definition"] if isinstance(row["definition"], dict) else {}
+        lib_id = uuid.uuid4()
+        lib_by_project[row["id"]] = lib_id
+        bind.execute(
+            libs_t.insert().values(
+                id=lib_id,
+                name=row["name"],
+                statement=definition.get("statement"),
+                rubric=definition.get("rubric"),
+                anchors=definition.get("anchor_papers"),
+                ingest_state=row["ingest_state"],
+                cadence=definition.get("cadence"),
+                created_by=row["owner_id"],
+                project_id=row["id"],
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    paper_rows = list(bind.execute(sa.select(papers_t)).mappings())
+    for row in paper_rows:
+        if row["project_id"] in lib_by_project:
+            bind.execute(
+                members_t.insert().values(
+                    id=uuid.uuid4(),
+                    library_id=lib_by_project[row["project_id"]],
+                    paper_id=row["id"],
+                    relevance_score=row["relevance_score"],
+                    wiki_content=row["wiki_content"],
+                    status=row["status"] or "candidate",
+                    trash_reason=row["trash_reason"],
+                    scored_at=row["scored_at"],
+                    compiled_at=row["compiled_at"],
+                    compiled_model=row["compiled_model"],
+                    created_at=row["created_at"] or now,
+                    updated_at=row["updated_at"] or now,
+                )
+            )
+        key = _pool_dedup_key(
+            row["arxiv_id"], row["doi"], row["title"], row["year"], row["authors"]
+        )
+        bind.execute(
+            papers_t.update().where(papers_t.c.id == row["id"]).values(dedup_key=key)
+        )
+
+    _resolve_dedup_conflicts(bind, paper_rows)
+
+    op.create_index("ix_papers_dedup_key", "papers", ["dedup_key"], unique=True)
+
+
+def _resolve_dedup_conflicts(bind: sa.engine.Connection, paper_rows: list[Any]) -> None:
+    """同 dedup_key 多行：保留 chunks 最多 / 字段最全的一行，子表 repoint 后删除其余。"""
+    chunk_counts: dict[Any, int] = {
+        pid: int(n)
+        for pid, n in bind.execute(
+            sa.text("SELECT paper_id, COUNT(*) FROM paper_chunks GROUP BY paper_id")
+        )
+    }
+    groups: dict[str, list[Any]] = {}
+    for row in paper_rows:
+        key = _pool_dedup_key(
+            row["arxiv_id"], row["doi"], row["title"], row["year"], row["authors"]
+        )
+        groups.setdefault(key, []).append(row)
+
+    for rows in groups.values():
+        if len(rows) < 2:
+            continue
+
+        def completeness(row: Any) -> tuple:
+            return (
+                chunk_counts.get(row["id"], 0),
+                sum(
+                    1
+                    for f in ("full_text_path", "pdf_path", "wiki_content", "abstract", "doi")
+                    if row[f]
+                ),
+                # 平手时保留最早入库的一行（id 兜底保证确定性）
+                -(row["created_at"].timestamp() if row["created_at"] else 0),
+                str(row["id"]),
+            )
+
+        rows = sorted(rows, key=completeness, reverse=True)
+        survivor = rows[0]["id"]
+        for loser_row in rows[1:]:
+            _repoint_paper_refs(bind, loser=loser_row["id"], survivor=survivor)
+
+
+def _repoint_paper_refs(bind: sa.engine.Connection, *, loser: Any, survivor: Any) -> None:
+    params = {"loser": loser, "survivor": survivor}
+    # 成员行 / 概念关联 / 标签关联 / 个人状态：survivor 侧已存在同键行时删掉 loser 行
+    for sql_exists, sql_update, sql_delete in (
+        (
+            "SELECT library_id FROM library_papers WHERE paper_id = :survivor",
+            "UPDATE library_papers SET paper_id = :survivor "
+            "WHERE paper_id = :loser AND library_id NOT IN ({sub})",
+            "DELETE FROM library_papers WHERE paper_id = :loser",
+        ),
+        (
+            "SELECT concept_id FROM paper_concepts WHERE paper_id = :survivor",
+            "UPDATE paper_concepts SET paper_id = :survivor "
+            "WHERE paper_id = :loser AND concept_id NOT IN ({sub})",
+            "DELETE FROM paper_concepts WHERE paper_id = :loser",
+        ),
+        (
+            "SELECT tag_id FROM paper_tag_links WHERE paper_id = :survivor",
+            "UPDATE paper_tag_links SET paper_id = :survivor "
+            "WHERE paper_id = :loser AND tag_id NOT IN ({sub})",
+            "DELETE FROM paper_tag_links WHERE paper_id = :loser",
+        ),
+        (
+            "SELECT user_id FROM paper_user_meta WHERE paper_id = :survivor",
+            "UPDATE paper_user_meta SET paper_id = :survivor "
+            "WHERE paper_id = :loser AND user_id NOT IN ({sub})",
+            "DELETE FROM paper_user_meta WHERE paper_id = :loser",
+        ),
+    ):
+        bind.execute(sa.text(sql_update.format(sub=sql_exists)), params)
+        bind.execute(sa.text(sql_delete), params)
+    # 无唯一约束的子表 / 软引用：整体 repoint
+    for sql in (
+        "UPDATE paper_notes SET paper_id = :survivor WHERE paper_id = :loser",
+        "UPDATE paper_highlights SET paper_id = :survivor WHERE paper_id = :loser",
+        "UPDATE user_library_entries SET last_paper_id = :survivor WHERE last_paper_id = :loser",
+        "UPDATE user_publications SET paper_id = :survivor WHERE paper_id = :loser",
+    ):
+        bind.execute(sa.text(sql), params)
+    # loser 的 chunks 不并入（survivor 已是 chunks 最多的一行），随论文删除
+    bind.execute(sa.text("DELETE FROM paper_chunks WHERE paper_id = :loser"), params)
+    bind.execute(sa.text("DELETE FROM papers WHERE id = :loser"), params)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_papers_dedup_key", table_name="papers")
+    with op.batch_alter_table("paper_chunks") as batch:
+        batch.alter_column("project_id", existing_type=sa.Uuid(), nullable=False)
+    with op.batch_alter_table("papers") as batch:
+        batch.alter_column("project_id", existing_type=sa.Uuid(), nullable=False)
+    op.drop_column("papers", "dedup_key")
+    op.drop_index("ix_library_papers_library_status", table_name="library_papers")
+    op.drop_index("ix_library_papers_paper_id", table_name="library_papers")
+    op.drop_index("ix_library_papers_library_id", table_name="library_papers")
+    op.drop_table("library_papers")
+    op.drop_table("direction_library_curators")
+    op.drop_table("direction_libraries")

--- a/src/backend/alembic/versions/fe8a86942dc7_paper_pool_contract.py
+++ b/src/backend/alembic/versions/fe8a86942dc7_paper_pool_contract.py
@@ -1,0 +1,115 @@
+"""论文内容池收尾（P4 迁移 B）
+
+判断字段已全部迁到 library_papers（迁移 A + 代码切换）：删除 papers 上的
+project_id 与判断列、paper_chunks 冗余 project_id；concepts 完成
+project_id → library_id（按隐式库映射搬迁，唯一约束随迁）。
+
+Revision ID: fe8a86942dc7
+Revises: f7c2abfe8aeb
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "fe8a86942dc7"
+down_revision: str | None = "f7c2abfe8aeb"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ---- concepts: project_id → library_id ----
+    op.add_column("concepts", sa.Column("library_id", sa.Uuid(), nullable=True))
+    bind.execute(
+        sa.text(
+            "UPDATE concepts SET library_id = ("
+            "SELECT dl.id FROM direction_libraries dl WHERE dl.project_id = concepts.project_id"
+            ")"
+        )
+    )
+    # 无对应隐式库的孤儿概念（理论上不存在）直接清掉，保证 NOT NULL 收紧
+    bind.execute(sa.text("DELETE FROM concepts WHERE library_id IS NULL"))
+    op.drop_index("ix_concepts_project_id", table_name="concepts")
+    with op.batch_alter_table("concepts") as batch:
+        batch.drop_constraint("uq_concepts_project_slug", type_="unique")
+        batch.alter_column("library_id", existing_type=sa.Uuid(), nullable=False)
+        batch.create_foreign_key(
+            "fk_concepts_library_id",
+            "direction_libraries",
+            ["library_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch.create_unique_constraint("uq_concepts_library_slug", ["library_id", "slug"])
+        batch.drop_column("project_id")
+    op.create_index("ix_concepts_library_id", "concepts", ["library_id"])
+
+    # ---- paper_chunks: 删冗余 project_id ----
+    op.drop_index("ix_paper_chunks_project_id", table_name="paper_chunks")
+    with op.batch_alter_table("paper_chunks") as batch:
+        batch.drop_column("project_id")
+
+    # ---- papers: 删 project_id 与已迁走的判断列 ----
+    op.drop_index("ix_papers_project_id", table_name="papers")
+    with op.batch_alter_table("papers") as batch:
+        batch.drop_column("project_id")
+        batch.drop_column("relevance_score")
+        batch.drop_column("wiki_content")
+        batch.drop_column("status")
+        batch.drop_column("trash_reason")
+        batch.drop_column("scored_at")
+        batch.drop_column("compiled_at")
+        batch.drop_column("compiled_model")
+
+
+def downgrade() -> None:
+    # papers 判断列还原（数据不回搬——P4 后成员表才是权威，此处仅结构回滚）
+    with op.batch_alter_table("papers") as batch:
+        batch.add_column(sa.Column("compiled_model", sa.String(255), nullable=True))
+        batch.add_column(sa.Column("compiled_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("scored_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("trash_reason", sa.String(16), nullable=True))
+        batch.add_column(
+            sa.Column("status", sa.String(32), nullable=False, server_default="candidate")
+        )
+        batch.add_column(sa.Column("wiki_content", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("relevance_score", sa.Float(), nullable=True))
+        batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_papers_project_id", "projects", ["project_id"], ["id"], ondelete="CASCADE"
+        )
+    op.create_index("ix_papers_project_id", "papers", ["project_id"])
+
+    with op.batch_alter_table("paper_chunks") as batch:
+        batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_paper_chunks_project_id", "projects", ["project_id"], ["id"], ondelete="CASCADE"
+        )
+    op.create_index("ix_paper_chunks_project_id", "paper_chunks", ["project_id"])
+
+    op.drop_index("ix_concepts_library_id", table_name="concepts")
+    with op.batch_alter_table("concepts") as batch:
+        batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_concepts_project_id", "projects", ["project_id"], ["id"], ondelete="CASCADE"
+        )
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE concepts SET project_id = ("
+            "SELECT dl.project_id FROM direction_libraries dl WHERE dl.id = concepts.library_id"
+            ")"
+        )
+    )
+    with op.batch_alter_table("concepts") as batch:
+        batch.drop_constraint("uq_concepts_library_slug", type_="unique")
+        batch.drop_constraint("fk_concepts_library_id", type_="foreignkey")
+        batch.create_unique_constraint("uq_concepts_project_slug", ["project_id", "slug"])
+        batch.drop_column("library_id")
+    op.create_index("ix_concepts_project_id", "concepts", ["project_id"])

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -42,12 +42,14 @@ from app.models.activity import Activity
 from app.models.base import utcnow
 from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment, ExperimentRun
 from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import VoyageRun
 from app.services import experiments as experiments_service
 from app.services import ssh_exec
 from app.services.figure_annotate import prepare_image_for_llm
+from app.services.libraries import get_library_for_project
 
 RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0）
 MAX_SETUP_FIXES = 2  # 依赖安装失败回 LLM 修 requirements/run.sh 的次数上限
@@ -871,25 +873,26 @@ async def experiment_plan(ctx: ActionContext, params: dict[str, Any]) -> dict[st
             raise ValueError("实验关联的 idea 不存在")
 
         if not isinstance(experiment.plan, dict):  # 断点幂等
-            papers = (
-                (
-                    await session.execute(
-                        select(Paper)
-                        .where(
-                            Paper.project_id == experiment.project_id,
-                            Paper.status.in_(("compiled", "included")),
-                            Paper.wiki_content.is_not(None),
-                        )
-                        .order_by(Paper.relevance_score.desc().nulls_last(), Paper.created_at)
-                        .limit(_WIKI_CONTEXT_PAPERS)
+            library = await get_library_for_project(session, experiment.project_id)
+            rows = (
+                await session.execute(
+                    select(Paper.title, LibraryPaper.wiki_content)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                    .where(
+                        LibraryPaper.library_id == library.id,
+                        LibraryPaper.status.in_(("compiled", "included")),
+                        LibraryPaper.wiki_content.is_not(None),
                     )
+                    .order_by(
+                        LibraryPaper.relevance_score.desc().nulls_last(),
+                        LibraryPaper.created_at,
+                    )
+                    .limit(_WIKI_CONTEXT_PAPERS)
                 )
-                .scalars()
-                .all()
-            )
+            ).all()
             wiki_context = (
                 "\n\n".join(
-                    f"### {p.title}\n{(p.wiki_content or '')[:_WIKI_EXCERPT_CHARS]}" for p in papers
+                    f"### {title}\n{(wiki or '')[:_WIKI_EXCERPT_CHARS]}" for title, wiki in rows
                 )
                 or "（知识库为空）"
             )

--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -31,10 +31,12 @@ from app.core.llm.base import Message
 from app.models.activity import Activity
 from app.models.base import utcnow
 from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, paper_concepts
 from app.models.project import Project
 from app.models.review import ReviewMessage, ReviewSession
 from app.schemas.idea import FORGE_SIGNALS
+from app.services.libraries import get_library_for_project
 from app.services.review import (
     DEFAULT_PERSONAS,
     elo_update,
@@ -187,27 +189,29 @@ async def forge_read_context(ctx: ActionContext, params: dict[str, Any]) -> dict
     knobs = _forge_knobs(ctx)
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
-        papers = (
-            (
-                await session.execute(
-                    select(Paper)
-                    .where(
-                        Paper.project_id == project.id,
-                        Paper.status.in_(("compiled", "included")),
-                        Paper.wiki_content.is_not(None),
-                    )
-                    .order_by(Paper.relevance_score.desc().nulls_last(), Paper.created_at)
-                    .limit(int(knobs["max_context_papers"]))
+        library = await get_library_for_project(session, project.id)
+        rows = (
+            await session.execute(
+                select(Paper, LibraryPaper.wiki_content)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id == library.id,
+                    LibraryPaper.status.in_(("compiled", "included")),
+                    LibraryPaper.wiki_content.is_not(None),
                 )
+                .order_by(
+                    LibraryPaper.relevance_score.desc().nulls_last(), LibraryPaper.created_at
+                )
+                .limit(int(knobs["max_context_papers"]))
             )
-            .scalars()
-            .all()
-        )
+        ).all()
+        papers = [p for p, _ in rows]
+        wiki_of = {p.id: wiki for p, wiki in rows}
         concept_names = (
             (
                 await session.execute(
                     select(Concept.name)
-                    .where(Concept.project_id == project.id)
+                    .where(Concept.library_id == library.id)
                     .order_by(Concept.name)
                     .limit(100)
                 )
@@ -218,7 +222,7 @@ async def forge_read_context(ctx: ActionContext, params: dict[str, Any]) -> dict
 
     parts = []
     for paper in papers:
-        excerpt = (paper.wiki_content or "")[:_WIKI_EXCERPT_CHARS]
+        excerpt = (wiki_of.get(paper.id) or "")[:_WIKI_EXCERPT_CHARS]
         parts.append(f"### {paper.title}\nTL;DR：{paper.tldr or '（无）'}\n{excerpt}")
     context_text = "\n\n".join(parts)[:_CONTEXT_CHARS] or "（知识库为空）"
 
@@ -270,11 +274,12 @@ async def _concept_paper_map(
     session: AsyncSession, project_id: uuid.UUID
 ) -> dict[uuid.UUID, tuple[str, str, set[uuid.UUID]]]:
     """概念 → (name, category, 关联论文集合)。"""
+    library = await get_library_for_project(session, project_id)
     rows = (
         await session.execute(
             select(Concept.id, Concept.name, Concept.category, paper_concepts.c.paper_id)
             .join(paper_concepts, paper_concepts.c.concept_id == Concept.id)
-            .where(Concept.project_id == project_id)
+            .where(Concept.library_id == library.id)
         )
     ).all()
     result: dict[uuid.UUID, tuple[str, str, set[uuid.UUID]]] = {}
@@ -320,12 +325,18 @@ def _concept_holes(
 async def _trend_concepts(session: AsyncSession, project_id: uuid.UUID) -> list[dict[str, Any]]:
     """近 90 天入库论文中的高频概念（纯代码，无 LLM）。"""
     cutoff = utcnow() - timedelta(days=_TREND_WINDOW_DAYS)
+    library = await get_library_for_project(session, project_id)
     rows = (
         await session.execute(
             select(Concept.name, Paper.id)
             .join(paper_concepts, paper_concepts.c.concept_id == Concept.id)
             .join(Paper, Paper.id == paper_concepts.c.paper_id)
-            .where(Concept.project_id == project_id, Paper.created_at >= cutoff)
+            .join(
+                LibraryPaper,
+                (LibraryPaper.paper_id == Paper.id)
+                & (LibraryPaper.library_id == library.id),
+            )
+            .where(Concept.library_id == library.id, LibraryPaper.created_at >= cutoff)
         )
     ).all()
     counts: dict[str, int] = {}
@@ -367,16 +378,21 @@ async def forge_collect_signals(ctx: ActionContext, params: dict[str, Any]) -> d
             signals["trends"] = await _trend_concepts(session, ctx.run.project_id)
         excerpt_blocks: list[str] = []
         if "limitations" in enabled:
+            library = await get_library_for_project(session, ctx.run.project_id)
             papers = (
                 (
                     await session.execute(
                         select(Paper)
+                        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
                         .where(
-                            Paper.project_id == ctx.run.project_id,
+                            LibraryPaper.library_id == library.id,
                             Paper.full_text_path.is_not(None),
-                            Paper.status.in_(("compiled", "included")),
+                            LibraryPaper.status.in_(("compiled", "included")),
                         )
-                        .order_by(Paper.relevance_score.desc().nulls_last(), Paper.created_at)
+                        .order_by(
+                            LibraryPaper.relevance_score.desc().nulls_last(),
+                            LibraryPaper.created_at,
+                        )
                         .limit(_LIMIT_PAPERS)
                     )
                 )

--- a/src/backend/app/agents/voyage/actions_present.py
+++ b/src/backend/app/agents/voyage/actions_present.py
@@ -21,8 +21,10 @@ from app.agents.voyage.actions import ActionContext, register
 from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.services.figure_annotate import important_figures_with_bytes
+from app.services.libraries import get_library_for_project
 from app.services.presentation import (
     DeckSpec,
     build_deck,
@@ -124,19 +126,19 @@ async def _complete_json(
     raise ValueError(f"LLM 连续输出非法 JSON：{last_error}")
 
 
-async def _load_papers(ctx: ActionContext) -> list[Paper]:
+async def _load_papers(ctx: ActionContext) -> list[tuple[Paper, str | None]]:
+    """按 params.paper_ids 加载库内论文，返回 (Paper, 本方向库版 wiki) 对（保持传入顺序）。"""
     ids = [uuid.UUID(str(i)) for i in _params(ctx).get("paper_ids") or []]
     async with get_sessionmaker()() as session:
-        papers = (
-            (
-                await session.execute(
-                    select(Paper).where(Paper.id.in_(ids), Paper.project_id == ctx.run.project_id)
-                )
+        library = await get_library_for_project(session, ctx.run.project_id)
+        rows = (
+            await session.execute(
+                select(Paper, LibraryPaper.wiki_content)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(Paper.id.in_(ids), LibraryPaper.library_id == library.id)
             )
-            .scalars()
-            .all()
-        )
-    by_id = {p.id: p for p in papers}
+        ).all()
+    by_id = {p.id: (p, wiki) for p, wiki in rows}
     ordered = [by_id[i] for i in ids if i in by_id]
     if not ordered:
         raise ValueError("presentation: no papers found for given paper_ids")
@@ -167,11 +169,12 @@ def _figure_catalog(papers: list[Paper]) -> tuple[list[dict[str, Any]], dict[int
 
 @register("present.collect")
 async def present_collect(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
-    papers = await _load_papers(ctx)
+    pairs = await _load_papers(ctx)
+    papers = [p for p, _ in pairs]
     mode = str(_params(ctx).get("mode") or ("single" if len(papers) == 1 else "survey"))
     cap = _SINGLE_BODY_CHARS if mode == "single" else _SURVEY_BODY_CHARS
     materials = []
-    for p in papers:
+    for p, wiki in pairs:
         authors = "、".join(a.get("name", "") for a in (p.authors or []) if isinstance(a, dict))
         materials.append(
             {
@@ -179,7 +182,7 @@ async def present_collect(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                 "authors": authors[:120],
                 "venue": f"{p.venue or ''} {p.year or ''}".strip(),
                 "tldr": p.tldr or "",
-                "body": (p.wiki_content or p.abstract or "")[:cap],
+                "body": (wiki or p.abstract or "")[:cap],
             }
         )
     catalog, _ = _figure_catalog(papers)
@@ -266,7 +269,7 @@ async def present_build(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     deck = ctx.checkpoint.get("present_deck")
     if not deck:
         raise ValueError("present.build requires present_deck in checkpoint")
-    papers = await _load_papers(ctx)
+    papers = [p for p, _ in await _load_papers(ctx)]
     _, blobs = _figure_catalog(papers)
 
     # ①文本规范迭代：确定性校验 → LLM 修

--- a/src/backend/app/agents/voyage/actions_proposal.py
+++ b/src/backend/app/agents/voyage/actions_proposal.py
@@ -39,8 +39,10 @@ from app.core.llm.base import Message
 from app.models.activity import Activity
 from app.models.gate import Gate
 from app.models.idea import RESEARCH_TYPES, Idea
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.review import ReviewMessage, ReviewSession
+from app.services.libraries import get_library_for_project
 from app.services.literature.openalex import OpenAlexClient
 from app.services.literature.semantic_scholar import SemanticScholarClient
 from app.services.review import serialize_message
@@ -353,8 +355,11 @@ def validate_goal(raw: Any, *, library_ids: set[str], library_size: int) -> dict
 
 async def _library_index(ctx: ActionContext) -> tuple[set[str], int]:
     async with get_sessionmaker()() as session:
+        library = await get_library_for_project(session, ctx.run.project_id)
         rows = (
-            await session.execute(select(Paper.id).where(Paper.project_id == ctx.run.project_id))
+            await session.execute(
+                select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library.id)
+            )
         ).all()
     ids = {str(pid) for (pid,) in rows}
     return ids, len(ids)
@@ -504,14 +509,26 @@ async def _own_gate_comment(ctx: ActionContext) -> str:
 # ---- 阶段 2：方案深耕 ----
 
 
-async def _grounding_papers(ctx: ActionContext) -> list[Paper]:
+async def _grounding_papers(ctx: ActionContext) -> list[tuple[Paper, str | None]]:
+    """goal.grounding 引用的库内论文，返回 (Paper, 本方向库版 wiki) 对。"""
     goal = _goal(ctx)
     ids = [uuid.UUID(g["paper_id"]) for g in goal.get("grounding") or []]
     if not ids:
         return []
     async with get_sessionmaker()() as session:
-        papers = (await session.execute(select(Paper).where(Paper.id.in_(ids)))).scalars().all()
-    by_id = {p.id: p for p in papers}
+        library = await get_library_for_project(session, ctx.run.project_id)
+        rows = (
+            await session.execute(
+                select(Paper, LibraryPaper.wiki_content)
+                .join(
+                    LibraryPaper,
+                    (LibraryPaper.paper_id == Paper.id)
+                    & (LibraryPaper.library_id == library.id),
+                )
+                .where(Paper.id.in_(ids))
+            )
+        ).all()
+    by_id = {p.id: (p, wiki) for p, wiki in rows}
     return [by_id[i] for i in ids if i in by_id]
 
 
@@ -526,8 +543,8 @@ async def _grounding_context(ctx: ActionContext) -> str:
     papers = await _grounding_papers(ctx)
     why_by_id = {g["paper_id"]: g["why"] for g in goal.get("grounding") or []}
     parts = []
-    for paper in papers:
-        excerpt = (paper.wiki_content or paper.abstract or "")[:_GROUNDING_EXCERPT_CHARS]
+    for paper, wiki in papers:
+        excerpt = (wiki or paper.abstract or "")[:_GROUNDING_EXCERPT_CHARS]
         parts.append(
             f"[[paper:{paper.id}]] {paper.title}\n"
             f"与目标的关系：{why_by_id.get(str(paper.id), '')}\n{excerpt}"
@@ -737,11 +754,14 @@ async def proposal_experiments(ctx: ActionContext, params: dict[str, Any]) -> di
 async def _internal_similar(ctx: ActionContext, query_text: str) -> list[dict[str, Any]]:
     """库内相似论文：embedding 余弦 top-k；embedding 不可用降级关键词检索。"""
     async with get_sessionmaker()() as session:
+        library = await get_library_for_project(session, ctx.run.project_id)
         papers = (
             (
                 await session.execute(
-                    select(Paper).where(
-                        Paper.project_id == ctx.run.project_id, Paper.embedding.is_not(None)
+                    select(Paper)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                    .where(
+                        LibraryPaper.library_id == library.id, Paper.embedding.is_not(None)
                     )
                 )
             )
@@ -968,7 +988,7 @@ def _compose_content(
 async def _build_evidence(ctx: ActionContext) -> list[dict[str, Any]]:
     goal = _goal(ctx)
     papers = await _grounding_papers(ctx)
-    titles = {str(p.id): p.title for p in papers}
+    titles = {str(p.id): p.title for p, _ in papers}
     why_by_id = {g["paper_id"]: g["why"] for g in goal.get("grounding") or []}
     evidence: list[dict[str, Any]] = [
         {

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -26,12 +26,15 @@ from app.agents.voyage.actions import ActionContext, register
 from app.core.db import get_sessionmaker
 from app.models.activity import Activity
 from app.models.base import utcnow
-from app.models.paper import Paper
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper, PaperChunk
 from app.models.project import Project
 from app.services.affiliations import extract_affiliations_llm
 from app.services.chunks import embed_pending_chunks, index_paper_fulltext
 from app.services.concepts import link_all_paper_concepts
+from app.services.dedup import pool_dedup_key
 from app.services.figure_annotate import annotate_figures, figures_annotated
+from app.services.libraries import ensure_membership, find_pool_paper, get_library_for_project
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
@@ -159,18 +162,54 @@ def _parse_iso(value: str | None) -> datetime | None:
 
 
 async def _existing_keys(
-    session: AsyncSession, project_id: uuid.UUID
+    session: AsyncSession, library_id: uuid.UUID
 ) -> tuple[set[str], set[str], set[str]]:
-    """项目内去重键：arxiv_id / doi / 标题小写。"""
+    """库内去重键：arxiv_id / doi / 标题小写（本库已有成员的论文不再重复入库）。"""
     rows = (
         await session.execute(
-            select(Paper.arxiv_id, Paper.doi, Paper.title).where(Paper.project_id == project_id)
+            select(Paper.arxiv_id, Paper.doi, Paper.title)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id == library_id)
         )
     ).all()
     arxiv_ids = {a for a, _, _ in rows if a}
     dois = {d.lower() for _, d, _ in rows if d}
     titles = {t.strip().lower() for _, _, t in rows if t}
     return arxiv_ids, dois, titles
+
+
+async def _pool_paper_or_new(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    make_paper: Any,
+    arxiv_id: str | None,
+    doi: str | None,
+    title: str,
+    year: int | None,
+    authors: list[Any] | None,
+) -> Paper | None:
+    """写路径统一入口：先按 dedup 键查全局内容池，命中只建成员行（pool hit，
+    跳过重复解析），未命中用 ``make_paper()`` 建新内容池行 + 成员行。
+
+    返回本次新加入库的 Paper；本库已有成员行时返回 None（跳过）。
+    """
+    key = pool_dedup_key(arxiv_id=arxiv_id, doi=doi, title=title, year=year, authors=authors)
+    pooled = await find_pool_paper(session, arxiv_id=arxiv_id, doi=doi, dedup_key=key)
+    if pooled is not None:
+        _, created = await ensure_membership(
+            session, library_id=library_id, paper_id=pooled.id, status="candidate"
+        )
+        if not created:
+            return None
+        logger.info("paper pool hit: %s (%s)", pooled.id, title[:60])
+        return pooled
+    paper = make_paper()
+    paper.dedup_key = key
+    session.add(paper)
+    await session.flush()
+    await ensure_membership(session, library_id=library_id, paper_id=paper.id, status="candidate")
+    return paper
 
 
 # ---- 1. 检索候选（arXiv） ----
@@ -224,13 +263,15 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             categories=categories, keywords=include, since=since, until=now, limit=limit
         )
 
-        arxiv_ids, dois, titles = await _existing_keys(session, project.id)
+        library = await get_library_for_project(session, project.id)
+        arxiv_ids, dois, titles = await _existing_keys(session, library.id)
         new_papers: list[Paper] = []
 
-        def _try_insert(entry: dict[str, Any], source: str) -> bool:
-            """按 arxiv_id/doi/title 三方去重后入库；命中已存量返回 False。
+        async def _try_insert(entry: dict[str, Any], source: str) -> bool:
+            """三方键（arxiv_id/doi/title）+ 全局内容池去重后入库；已在本库返回 False。
 
-            边插边更新去重键集合——RSS↔API↔存量共用同一套集合，互不重插。
+            边插边更新去重键集合——RSS↔API↔存量共用同一套集合，互不重插；
+            池中已有的论文只建成员行（跳过重复解析）。
             """
             aid = entry.get("arxiv_id")
             title = (entry.get("title") or "").strip()
@@ -239,33 +280,47 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 return False
             if (aid and aid in arxiv_ids) or (doi and doi in dois) or title.lower() in titles:
                 return False
-            paper = Paper(
-                project_id=project.id,
-                source=source,
+
+            def make_paper() -> Paper:
+                return Paper(
+                    source=source,
+                    arxiv_id=aid,
+                    doi=entry.get("doi"),
+                    external_ids=(
+                        {"arxiv": aid} | ({"doi": entry["doi"]} if entry.get("doi") else {})
+                    ),
+                    title=title,
+                    authors=entry.get("authors"),
+                    abstract=entry.get("abstract"),
+                    year=entry.get("year"),
+                    venue=entry.get("primary_category"),
+                    url=entry.get("url"),
+                    published_at=_parse_iso(entry.get("published")),
+                )
+
+            paper = await _pool_paper_or_new(
+                session,
+                library_id=library.id,
+                make_paper=make_paper,
                 arxiv_id=aid,
-                doi=entry.get("doi"),
-                external_ids=({"arxiv": aid} | ({"doi": entry["doi"]} if entry.get("doi") else {})),
+                doi=doi,
                 title=title,
-                authors=entry.get("authors"),
-                abstract=entry.get("abstract"),
                 year=entry.get("year"),
-                venue=entry.get("primary_category"),
-                url=entry.get("url"),
-                published_at=_parse_iso(entry.get("published")),
-                status="candidate",
+                authors=entry.get("authors"),
             )
-            session.add(paper)
-            new_papers.append(paper)
             if aid:
                 arxiv_ids.add(aid)
             if doi:
                 dois.add(doi)
             titles.add(title.lower())
+            if paper is None:
+                return False
+            new_papers.append(paper)
             return True
 
         # 补漏层：关键词检索的日期窗口（索引有 3-5 天滞后，故靠 RSS 补新鲜）
         for entry in entries:
-            _try_insert(entry, "arxiv")
+            await _try_insert(entry, "arxiv")
 
         # 新鲜源：分类 RSS /new 当天公告（即时无滞后），仅增量模式补最新论文
         rss_found = 0
@@ -282,7 +337,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
                     if not _keyword_match(entry, includes_norm):
                         continue
                     rss_matched += 1
-                    if _try_insert(entry, "arxiv"):
+                    if await _try_insert(entry, "arxiv"):
                         rss_inserted += 1
 
         await session.flush()  # 拿到新论文 id，供 observation 清单
@@ -330,13 +385,15 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
             for a in (definition.get("anchor_papers") or [])
             if isinstance(a, dict) and a.get("arxiv_id")
         ]
+        library = await get_library_for_project(session, project.id)
         candidate_ids = (
             (
                 await session.execute(
                     select(Paper.arxiv_id)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
                     .where(
-                        Paper.project_id == project.id,
-                        Paper.status == "candidate",
+                        LibraryPaper.library_id == library.id,
+                        LibraryPaper.status == "candidate",
                         Paper.arxiv_id.is_not(None),
                     )
                     .order_by(Paper.published_at.desc().nulls_last())
@@ -347,7 +404,7 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
             .all()
         )
         frontier: list[str] = list(dict.fromkeys(anchors + list(candidate_ids)))
-        arxiv_ids, dois, titles = await _existing_keys(session, project.id)
+        arxiv_ids, dois, titles = await _existing_keys(session, library.id)
         processed_seeds = 0
 
         for _level in range(depth):
@@ -375,43 +432,61 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
                         continue
                     if (aid and aid in arxiv_ids) or (doi and doi in dois):
                         continue
-                    paper = Paper(
-                        project_id=project.id,
-                        source="semantic_scholar",
+                    authors = [
+                        {"name": a.get("name")}
+                        for a in (item.get("authors") or [])
+                        if a.get("name")
+                    ] or None
+
+                    def make_paper(
+                        item: dict[str, Any] = item,
+                        ext: dict[str, Any] = ext,
+                        aid: str | None = aid,
+                        title: str = title,
+                        authors: list[Any] | None = authors,
+                    ) -> Paper:
+                        return Paper(
+                            source="semantic_scholar",
+                            arxiv_id=aid,
+                            doi=ext.get("DOI"),
+                            external_ids={
+                                k: v
+                                for k, v in (
+                                    ("s2", item.get("paperId")),
+                                    ("arxiv", aid),
+                                    ("doi", ext.get("DOI")),
+                                )
+                                if v
+                            },
+                            title=title,
+                            authors=authors,
+                            abstract=item.get("abstract"),
+                            year=item.get("year"),
+                            venue=item.get("venue") or None,
+                            url=item.get("url"),
+                            published_at=_parse_iso(item.get("publicationDate")),
+                        )
+
+                    paper = await _pool_paper_or_new(
+                        session,
+                        library_id=library.id,
+                        make_paper=make_paper,
                         arxiv_id=aid,
-                        doi=ext.get("DOI"),
-                        external_ids={
-                            k: v
-                            for k, v in (
-                                ("s2", item.get("paperId")),
-                                ("arxiv", aid),
-                                ("doi", ext.get("DOI")),
-                            )
-                            if v
-                        },
+                        doi=doi,
                         title=title,
-                        authors=[
-                            {"name": a.get("name")}
-                            for a in (item.get("authors") or [])
-                            if a.get("name")
-                        ]
-                        or None,
-                        abstract=item.get("abstract"),
                         year=item.get("year"),
-                        venue=item.get("venue") or None,
-                        url=item.get("url"),
-                        published_at=_parse_iso(item.get("publicationDate")),
-                        status="candidate",
+                        authors=authors,
                     )
-                    session.add(paper)
-                    new_papers.append(paper)
-                    inserted += 1
                     titles.add(title.lower())
                     if aid:
                         arxiv_ids.add(aid)
                         next_frontier.append(aid)
                     if doi:
                         dois.add(doi)
+                    if paper is None:
+                        continue
+                    new_papers.append(paper)
+                    inserted += 1
             frontier = next_frontier[:10]
             if not frontier:
                 break
@@ -438,56 +513,67 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
 
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
+        library = await get_library_for_project(session, project.id)
         # 稀疏 definition 容忍：rubric / questions 缺失时 prompt 只用 statement
         context_text = build_relevance_context(project)
 
-        # 幂等断点：只取仍是 candidate 的论文 id（已打分的不重复调 LLM）。外层只查 id，
-        # 每篇打分在各自独立 session 内重新加载论文，避免多任务共享一个 AsyncSession。
-        paper_ids = list(
-            (
-                await session.execute(
-                    select(Paper.id)
-                    .where(Paper.project_id == project.id, Paper.status == "candidate")
-                    .order_by(Paper.published_at.desc().nulls_last(), Paper.created_at)
-                    # 最大化模式打分不截断（全部 candidate 逐篇打分，哨兵防失控）
-                    .limit(_UNLIMITED_SENTINEL if _unlimited(knobs) else _MAX_CANDIDATES_CAP)
+        # 幂等断点：只取仍是 candidate 的成员行（已打分的不重复调 LLM）。外层只查 id，
+        # 每篇打分在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
+        rows = (
+            await session.execute(
+                select(LibraryPaper.id, LibraryPaper.paper_id)
+                .join(Paper, Paper.id == LibraryPaper.paper_id)
+                .where(
+                    LibraryPaper.library_id == library.id,
+                    LibraryPaper.status == "candidate",
                 )
-            ).scalars()
-        )
+                .order_by(Paper.published_at.desc().nulls_last(), LibraryPaper.created_at)
+                # 最大化模式打分不截断（全部 candidate 逐篇打分，哨兵防失控）
+                .limit(_UNLIMITED_SENTINEL if _unlimited(knobs) else _MAX_CANDIDATES_CAP)
+            )
+        ).all()
+        membership_ids = [mid for mid, _ in rows]
+        paper_ids = [pid for _, pid in rows]
 
     guidance = ctx.skill_guidance("wiki.score_relevance")
-    total = len(paper_ids)
+    total = len(membership_ids)
     progress = {"n": 0}
+    project_id = ctx.run.project_id
 
-    async def score_one(paper_id: uuid.UUID) -> dict[str, Any] | None:
+    async def score_one(membership_id: uuid.UUID) -> dict[str, Any] | None:
         """单篇打分：独立 session 重新加载 → 共享打分服务写字段 → 状态转移 → 自行 commit。"""
         async with get_sessionmaker()() as session:
-            paper = await session.get(Paper, paper_id)
-            if paper is None or paper.status != "candidate":
+            membership = await session.get(LibraryPaper, membership_id)
+            if membership is None or membership.status != "candidate":
                 return None  # 竞态/已处理：幂等跳过（正常流不会命中）
+            paper = await session.get(Paper, membership.paper_id)
+            if paper is None:
+                return None
             progress["n"] += 1
             await ctx.log(f"相关性打分 {progress['n']}/{total}：{paper.title[:60]}")
             scored = await score_paper_relevance(
                 paper,
+                membership,
                 context_text=context_text,
                 llm=ctx.llm,
                 extra_guidance=guidance,
                 user_id=ctx.run.created_by,
+                project_id=project_id,
                 voyage_id=ctx.run.id,
             )
             score = scored.score
-            paper.status = "scored" if score >= threshold else "excluded"
-            paper.trash_reason = None if paper.status == "scored" else "irrelevant"
+            membership.status = "scored" if score >= threshold else "excluded"
+            membership.trash_reason = None if membership.status == "scored" else "irrelevant"
             # 逐篇 commit：worker 中途被杀后按 status 断点续跑，不重复打分
             await session.commit()
             return {
                 "id": str(paper.id),
                 "title": paper.title,
                 "score": score,
-                "passed": paper.status == "scored",
+                "passed": membership.status == "scored",
             }
 
-    results = await _gather_bounded(_LLM_CONCURRENCY, [score_one(pid) for pid in paper_ids])
+    results = await _gather_bounded(_LLM_CONCURRENCY, [score_one(mid) for mid in membership_ids])
     _reraise_if_cancelled(results)  # worker 被杀须上抛，不当作单篇失败
 
     # gather 后统一汇总（顺序按查询顺序，稳定；不在并发任务里改 ctx.checkpoint）
@@ -541,18 +627,20 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     failed: list[dict[str, str]] = []
 
     async with get_sessionmaker()() as session:
-        papers = (
-            (
-                await session.execute(
-                    select(Paper)
-                    .where(Paper.project_id == ctx.run.project_id, Paper.status == "scored")
-                    .order_by(Paper.relevance_score.desc().nulls_last())
-                    .limit(top_n)
+        library = await get_library_for_project(session, ctx.run.project_id)
+        pairs = (
+            await session.execute(
+                select(Paper, LibraryPaper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id == library.id, LibraryPaper.status == "scored"
                 )
+                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+                .limit(top_n)
             )
-            .scalars()
-            .all()
-        )
+        ).all()
+        papers = [p for p, _ in pairs]
+        membership_of = {p.id: m for p, m in pairs}
         # 发表日期回填：雪球/DOI 来源的论文只有年份，arXiv 能查到精确日期（时间线/趋势视图用）
         need_dates = [p for p in papers if p.published_at is None and p.arxiv_id]
         if need_dates:
@@ -590,7 +678,11 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             # 失败兜底，返回 None 不写入）；失败不影响主流程
             if not paper.affiliations and paper.full_text_path:
                 affs = await extract_affiliations_llm(
-                    paper, llm=ctx.llm, user_id=ctx.run.created_by, voyage_id=ctx.run.id
+                    paper,
+                    llm=ctx.llm,
+                    user_id=ctx.run.created_by,
+                    project_id=ctx.run.project_id,
+                    voyage_id=ctx.run.id,
                 )
                 if affs:
                     paper.affiliations = affs
@@ -612,10 +704,21 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     raise
                 except Exception:  # noqa: BLE001 — 机构补充尽力而为
                     logger.warning("affiliation enrich failed for %s", paper.id, exc_info=True)
-            # 全文分段索引（文献问答/idea 生成的知识底座）；失败不影响主流程
+            # 全文分段索引（文献问答/idea 生成的知识底座）；失败不影响主流程。
+            # 内容池命中的论文可能已有分段（其他方向建的），有则直接复用不重建
             if paper.full_text_path:
                 try:
-                    await index_paper_fulltext(session, paper)
+                    has_chunks = bool(
+                        (
+                            await session.execute(
+                                select(PaperChunk.id)
+                                .where(PaperChunk.paper_id == paper.id)
+                                .limit(1)
+                            )
+                        ).first()
+                    )
+                    if not has_chunks:
+                        await index_paper_fulltext(session, paper)
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:  # noqa: BLE001
@@ -634,7 +737,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     failed.append(
                         {"id": str(paper.id), "error": f"figures: {type(e).__name__}: {e}"}
                     )
-            paper.status = "fetched"  # 无全文也进入编译（Librarian 退化用摘要）
+            membership_of[paper.id].status = "fetched"  # 无全文也进入编译（退化用摘要）
             await session.commit()
             fetched += 1
 
@@ -660,30 +763,37 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
 
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
+        library = await get_library_for_project(session, project.id)
         statement = _definition(project).get("statement") or project.name
         # 幂等断点：已 compiled 的不再进入（status=fetched 才编译）。外层只查 id，每篇
-        # 编译在各自独立 session 内重新加载论文，避免多任务共享一个 AsyncSession。
-        paper_ids = list(
-            (
-                await session.execute(
-                    select(Paper.id)
-                    .where(Paper.project_id == project.id, Paper.status == "fetched")
-                    .order_by(Paper.relevance_score.desc().nulls_last())
-                    .limit(top_n)
+        # 编译在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
+        rows = (
+            await session.execute(
+                select(LibraryPaper.id, LibraryPaper.paper_id)
+                .where(
+                    LibraryPaper.library_id == library.id, LibraryPaper.status == "fetched"
                 )
-            ).scalars()
-        )
+                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+                .limit(top_n)
+            )
+        ).all()
+        membership_ids = [mid for mid, _ in rows]
+        paper_ids = [pid for _, pid in rows]
 
     guidance = ctx.skill_guidance("wiki.compile")
-    total = len(paper_ids)
+    total = len(membership_ids)
     progress = {"n": 0}
+    project_id = ctx.run.project_id
 
-    async def compile_one(paper_id: uuid.UUID) -> dict[str, Any] | None:
+    async def compile_one(membership_id: uuid.UUID) -> dict[str, Any] | None:
         """单篇编译：独立 session 重新加载 → 挑图注释 → 图文编译 → 自行 commit。"""
         async with get_sessionmaker()() as session:
-            paper = await session.get(Paper, paper_id)
-            if paper is None or paper.status != "fetched":
+            membership = await session.get(LibraryPaper, membership_id)
+            if membership is None or membership.status != "fetched":
                 return None  # 竞态/已处理：幂等跳过（正常流不会命中）
+            paper = await session.get(Paper, membership.paper_id)
+            if paper is None:
+                return None
             progress["n"] += 1
             await ctx.log(f"📖 精读编译 {progress['n']}/{total}：{paper.title}")
             # ① 编译前筛选注释论文图（stage=librarian 多模态）：图文编译要用重要图；
@@ -696,6 +806,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                         paper.figures,
                         llm=ctx.llm,
                         user_id=ctx.run.created_by,
+                        project_id=project_id,
                         voyage_id=ctx.run.id,
                     )
                     await session.commit()
@@ -709,13 +820,14 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                 statement=statement,
                 llm=ctx.llm,
                 user_id=ctx.run.created_by,
+                project_id=project_id,
                 voyage_id=ctx.run.id,
                 extra_guidance=guidance,
             )
-            paper.wiki_content = compiled.content
-            paper.compiled_at = utcnow()
-            paper.compiled_model = compiled.model or None
-            paper.status = "compiled"
+            membership.wiki_content = compiled.content
+            membership.compiled_at = utcnow()
+            membership.compiled_model = compiled.model or None
+            membership.status = "compiled"
             await session.commit()
             await ctx.log(
                 f"✓ 完成 {progress['n']}/{total}：{paper.title[:50]}（{len(compiled.content)} 字）",
@@ -723,7 +835,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
             )
             return {"id": str(paper.id), "title": paper.title}
 
-    results = await _gather_bounded(_LLM_CONCURRENCY, [compile_one(pid) for pid in paper_ids])
+    results = await _gather_bounded(_LLM_CONCURRENCY, [compile_one(mid) for mid in membership_ids])
     _reraise_if_cancelled(results)  # worker 被杀须上抛，不当作单篇失败
 
     # gather 后统一汇总（顺序按查询顺序=相关度降序，稳定）
@@ -757,12 +869,14 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
 async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
+        library = await get_library_for_project(session, project.id)
         # 全库上链逻辑与手动补建端点共用（services/concepts.py）
         stats, papers = await link_all_paper_concepts(
             session,
-            project_id=project.id,
+            library_id=library.id,
             llm=ctx.llm,
             user_id=ctx.run.created_by,
+            project_id=project.id,
             voyage_id=ctx.run.id,
         )
         created = int(stats["concepts_created"])
@@ -800,9 +914,10 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         )
         chunks_embedded, chunk_embed_error = await embed_pending_chunks(
             session,
-            project_id=project.id,
+            library_id=library.id,
             llm=ctx.llm,
             user_id=ctx.run.created_by,
+            project_id=project.id,
             voyage_id=ctx.run.id,
             **embed_kwargs,
         )

--- a/src/backend/app/api/concepts.py
+++ b/src/backend/app/api/concepts.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
+from app.models.library_direction import DirectionLibrary
 from app.models.paper import Concept
 from app.models.project import ProjectMember
 from app.models.user import User
@@ -21,14 +22,15 @@ from app.schemas.paper import (
 )
 from app.services import concepts as concepts_service
 from app.services import projects as projects_service
+from app.services.libraries import get_library_for_project
 
 router = APIRouter(tags=["concepts"])
 
 
-def _concept_read(concept: Concept, paper_count: int) -> ConceptRead:
+def _concept_read(concept: Concept, paper_count: int, project_id: uuid.UUID) -> ConceptRead:
     return ConceptRead(
         id=concept.id,
-        project_id=concept.project_id,
+        project_id=project_id,
         name=concept.name,
         category=concept.category,
         definition=concept.definition,
@@ -47,10 +49,11 @@ async def list_concepts(
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    library = await get_library_for_project(session, project_id)
     rows = await concepts_service.list_concepts(
-        session, project_id=project_id, category=category, q=q
+        session, library_id=library.id, category=category, q=q
     )
-    return [_concept_read(concept, count) for concept, count in rows]
+    return [_concept_read(concept, count, project_id) for concept, count in rows]
 
 
 @router.post("/projects/{project_id}/concepts/relink", response_model=ConceptRelinkResult)
@@ -67,8 +70,14 @@ async def relink_concepts(
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    library = await get_library_for_project(session, project_id)
     stats, _papers = await concepts_service.link_all_paper_concepts(
-        session, project_id=project_id, llm=get_llm_router(), user_id=user.id, backfill=True
+        session,
+        library_id=library.id,
+        llm=get_llm_router(),
+        user_id=user.id,
+        project_id=project_id,
+        backfill=True,
     )
     return ConceptRelinkResult(**stats)
 
@@ -80,16 +89,18 @@ async def get_concept(
     user: User = Depends(current_active_user),
 ) -> ConceptDetail:
     stmt = (
-        select(Concept)
-        .join(ProjectMember, ProjectMember.project_id == Concept.project_id)
+        select(Concept, DirectionLibrary.project_id)
+        .join(DirectionLibrary, DirectionLibrary.id == Concept.library_id)
+        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
         .where(Concept.id == concept_id, ProjectMember.user_id == user.id)
     )
-    concept = (await session.execute(stmt)).scalar_one_or_none()
-    if concept is None:
+    row = (await session.execute(stmt)).first()
+    if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONCEPT_NOT_FOUND")
+    concept, project_id = row
     papers = await concepts_service.papers_of_concept(session, concept.id)
     related = await concepts_service.related_concepts(session, concept)
-    base = _concept_read(concept, len(papers))
+    base = _concept_read(concept, len(papers), project_id)
     return ConceptDetail(
         **base.model_dump(),
         wiki_content=concept.wiki_content,

--- a/src/backend/app/api/highlights.py
+++ b/src/backend/app/api/highlights.py
@@ -80,7 +80,9 @@ async def create_paper_highlight(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    hl = await hl_service.create_highlight(session, paper=paper, author=user, data=data)
+    hl = await hl_service.create_highlight(
+        session, paper_id=paper.id, project_id=paper.project_id, author=user, data=data
+    )
     return _hl_read(hl, author_name_of(user.display_name, user.email))
 
 

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -68,7 +68,13 @@ async def create_paper_note(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    note = await notes_service.create_note(session, paper=paper, author=user, content=data.content)
+    note = await notes_service.create_note(
+        session,
+        paper_id=paper.id,
+        project_id=paper.project_id,
+        author=user,
+        content=data.content,
+    )
     return _note_read(note, notes_service.author_name_of(user.display_name, user.email))
 
 

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -18,7 +18,6 @@ from app.api.auth import current_active_user, require_llm_chat, require_llm_task
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
-from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.paper import (
     PaperBatchIds,
@@ -36,6 +35,7 @@ from app.schemas.paper import (
     TagRead,
 )
 from app.services import figure_annotate as figure_service
+from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
@@ -53,7 +53,7 @@ _HEARTBEAT_SECONDS = 15.0
 
 async def _reads_with_extras(
     session: AsyncSession,
-    papers: Sequence[Paper],
+    papers: Sequence[papers_service.PaperView],
     user_id: uuid.UUID,
     *,
     detail: bool = False,
@@ -66,7 +66,9 @@ async def _reads_with_extras(
     return [model.model_validate(p).model_copy(update=extras[p.id]) for p in papers]
 
 
-async def _paper_detail(session: AsyncSession, paper: Paper, user_id: uuid.UUID) -> PaperDetail:
+async def _paper_detail(
+    session: AsyncSession, paper: papers_service.PaperView, user_id: uuid.UUID
+) -> PaperDetail:
     (detail,) = await _reads_with_extras(session, [paper], user_id, detail=True)
     return detail  # type: ignore[return-value]
 
@@ -80,7 +82,7 @@ async def _get_member_project(session: AsyncSession, project_id: uuid.UUID, user
 
 async def _get_member_paper(
     session: AsyncSession, paper_id: uuid.UUID, user: User, *, with_concepts: bool = False
-) -> Paper:
+) -> papers_service.PaperView:
     paper = await papers_service.get_paper_for_user(
         session, paper_id=paper_id, user_id=user.id, with_concepts=with_concepts
     )
@@ -168,13 +170,19 @@ async def add_paper_manually(
         ) from e
     # 打分失败会 rollback 并使本 session 的 ORM 对象过期，先留住要用的 id
     paper_id, user_id = paper.id, user.id
+    library = await libraries_service.get_library_for_project(session, project_id)
+    membership = await libraries_service.get_membership(
+        session, library_id=library.id, paper_id=paper_id
+    )
     # 顺带相关性打分（best-effort）：失败只记日志，不影响 201；不改 status（人工纳入）
-    await relevance_service.score_added_paper_best_effort(session, paper, project, user_id=user_id)
+    await relevance_service.score_added_paper_best_effort(
+        session, paper, membership, project, user_id=user_id
+    )
     # 重新加载（带 concepts eager load），避免序列化时触发 async lazy load
-    paper = await papers_service.get_paper_for_user(
+    view = await papers_service.get_paper_for_user(
         session, paper_id=paper_id, user_id=user_id, with_concepts=True
     )
-    return await _paper_detail(session, paper, user_id)
+    return await _paper_detail(session, view, user_id)
 
 
 @router.get("/papers/{paper_id}", response_model=PaperDetail)
@@ -281,14 +289,16 @@ async def fetch_paper_pdf(
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
     """按需补下 PDF + 抽全文；已有 PDF 时幂等直接返回。"""
-    paper = await _get_member_paper(session, paper_id, user, with_concepts=True)
+    view = await _get_member_paper(session, paper_id, user, with_concepts=True)
     try:
-        paper = await papers_service.fetch_pdf(session, paper, user_id=user.id)
+        await papers_service.fetch_pdf(
+            session, view.paper, user_id=user.id, project_id=view.project_id
+        )
     except papers_service.PdfSourceUnsupportedError as e:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="PDF_SOURCE_UNSUPPORTED") from e
     except papers_service.PdfFetchFailedError as e:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="PDF_FETCH_FAILED") from e
-    return await _paper_detail(session, paper, user.id)
+    return await _paper_detail(session, view, user.id)
 
 
 # ---- 论文图片（docs/api-lit.md §6.5） ----
@@ -329,12 +339,15 @@ async def extract_paper_figures(
     user: User = Depends(current_active_user),
 ) -> PaperFiguresResponse:
     """提取嵌入图 + LLM 筛选注释；已有 figures 且非 force 时幂等直返。"""
-    paper = await _get_member_paper(session, paper_id, user)
+    view = await _get_member_paper(session, paper_id, user)
+    paper = view.paper
     if paper.figures is not None and not force:
         return PaperFiguresResponse(figures=[PaperFigure(**f) for f in paper.figures])
     if not paper.pdf_path or not Path(paper.pdf_path).exists():
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PDF_NOT_AVAILABLE")
-    figures = await figure_service.extract_and_annotate(session, paper, user_id=user.id)
+    figures = await figure_service.extract_and_annotate(
+        session, paper, user_id=user.id, project_id=view.project_id
+    )
     return PaperFiguresResponse(figures=[PaperFigure(**f) for f in figures])
 
 

--- a/src/backend/app/api/presentations.py
+++ b/src/backend/app/api/presentations.py
@@ -49,8 +49,14 @@ async def create_presentation(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     if data.mode == "single" and len(data.paper_ids) != 1:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="SINGLE_NEEDS_ONE_PAPER")
-    stmt = select(Paper.id, Paper.title).where(
-        Paper.id.in_(data.paper_ids), Paper.project_id == project_id
+    from app.models.library_direction import LibraryPaper
+    from app.services.libraries import get_library_for_project
+
+    library = await get_library_for_project(session, project_id)
+    stmt = (
+        select(Paper.id, Paper.title)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(Paper.id.in_(data.paper_ids), LibraryPaper.library_id == library.id)
     )
     rows = {pid: title for pid, title in (await session.execute(stmt)).all()}
     missing = [str(i) for i in data.paper_ids if i not in rows]

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -19,6 +19,7 @@ from app.api.auth import current_active_user, require_llm_chat
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperChunk
 from app.models.project import Project
 from app.models.user import User
@@ -39,6 +40,7 @@ from app.services import library_chat as library_chat_service
 from app.services import papers as papers_service
 from app.services import projects as projects_service
 from app.services import stats as stats_service
+from app.services.libraries import get_library_for_project
 from app.services.wiki_export import build_obsidian_zip
 
 logger = logging.getLogger(__name__)
@@ -104,7 +106,7 @@ async def search(
         concepts.append(
             ScoredConcept(
                 id=concept.id,
-                project_id=concept.project_id,
+                project_id=project_id,
                 name=concept.name,
                 category=concept.category,
                 definition=concept.definition,
@@ -262,13 +264,16 @@ async def rebuild_fulltext_index(
     幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
     """
     await _member_project(session, project_id, user)
-    chunked_ids = select(PaperChunk.paper_id).where(PaperChunk.project_id == project_id)
+    library = await get_library_for_project(session, project_id)
+    chunked_ids = select(PaperChunk.paper_id)
     try:
         papers = (
             (
                 await session.execute(
-                    select(Paper).where(
-                        Paper.project_id == project_id,
+                    select(Paper)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                    .where(
+                        LibraryPaper.library_id == library.id,
                         Paper.full_text_path.is_not(None),
                         Paper.id.not_in(chunked_ids),
                     )
@@ -291,11 +296,20 @@ async def rebuild_fulltext_index(
             chunk_count += n
     await session.commit()
     embedded, embed_error = await chunks_service.embed_pending_chunks(
-        session, project_id=project_id, llm=get_llm_router(), user_id=user.id
+        session,
+        library_id=library.id,
+        llm=get_llm_router(),
+        user_id=user.id,
+        project_id=project_id,
     )
     total_chunks = int(
         (
-            await session.execute(select(func.count()).where(PaperChunk.project_id == project_id))
+            await session.execute(
+                select(func.count())
+                .select_from(PaperChunk)
+                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+                .where(LibraryPaper.library_id == library.id)
+            )
         ).scalar_one()
     )
     return {

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.library import UserLibraryEntry
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.llm_config import LLMCallLog, LLMProviderConfig, LLMUsage, ModelRoute
 from app.models.manuscript import (
     Manuscript,
@@ -38,6 +39,8 @@ from app.models.voyage import VoyageRun, VoyageStep
 __all__ = [
     "Activity",
     "Concept",
+    "DirectionLibrary",
+    "DirectionLibraryCurator",
     "Experiment",
     "ExperimentRun",
     "Feedback",
@@ -45,6 +48,7 @@ __all__ = [
     "Gate",
     "Idea",
     "LLMCallLog",
+    "LibraryPaper",
     "LLMProviderConfig",
     "LLMUsage",
     "Manuscript",

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -1,0 +1,84 @@
+"""方向文献库：实验室层的文献策展单元（P4）。
+
+`papers` 是全局内容池（按 dedup_key 全平台唯一，只存论文本体：元数据/全文/图/embedding）；
+方向对论文的「归属 + 判断」（相关性分、状态流转、库版 wiki 解读）全部落在成员表
+`library_papers` 上——同一篇论文可以同时属于多个方向库，各自打分编译互不干扰，
+删库只删成员行，内容池行永不删除。
+
+过渡期（P4~P5）：每个 project（研究方向）对应一个 1:1 隐式库（project_id 回指），
+API 仍以 project_id 为入口，service 层经 services/libraries.py 解析到库。
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.paper import Paper
+
+
+class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "direction_libraries"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    statement: Mapped[str | None] = mapped_column(Text)  # 方向陈述（一段话）
+    rubric: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 相关性评分标准
+    anchors: Mapped[list[Any] | None] = mapped_column(JSONVariant)  # 锚点论文/关键词
+    # 文献 ingest 状态：{"watermark": iso, "last_run": {"voyage_id", "finished_at"}}
+    ingest_state: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    cadence: Mapped[str | None] = mapped_column(String(32))  # 同步节奏：daily | weekly | ...
+    monthly_budget: Mapped[int | None]  # 每月 ingest 预算（P6 治理用）
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+    # 过渡期隐式库 1:1 回指 project（P5 拆分课题/库后共享库此列为 NULL）
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), unique=True
+    )
+
+
+class DirectionLibraryCurator(TimestampMixin, Base):
+    """库策展人（P6 治理入口；P4 仅建表）。"""
+
+    __tablename__ = "direction_library_curators"
+
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), primary_key=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+
+
+class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """库-论文成员行：某方向库视角下对一篇内容池论文的归属与判断。"""
+
+    __tablename__ = "library_papers"
+    __table_args__ = (
+        UniqueConstraint("library_id", "paper_id", name="uq_library_papers_library_paper"),
+        Index("ix_library_papers_library_status", "library_id", "status"),
+    )
+
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    relevance_score: Mapped[float | None]  # LLM 对照方向 rubric 的打分
+    tldr_note: Mapped[str | None] = mapped_column(Text)  # 库视角一句话概括（可选）
+    wiki_content: Mapped[str | None] = mapped_column(Text)  # 库版图文解读 markdown
+    # 状态流转同 PAPER_STATUSES：candidate → scored|excluded → fetched → compiled；included 人工纳入
+    status: Mapped[str] = mapped_column(String(32), default="candidate", nullable=False)
+    # 进垃圾桶的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
+    trash_reason: Mapped[str | None] = mapped_column(String(16))
+    scored_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    compiled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 编译 wiki_content 实际用到的模型名（取自 LLM 返回结果）
+    compiled_model: Mapped[str | None] = mapped_column(String(255))
+
+    paper: Mapped[Paper] = relationship()

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -1,4 +1,8 @@
-"""论文（文献综述对象）、概念（wiki 词条）、笔记 / 标签 / 个人阅读状态与其关联表。"""
+"""论文内容池（全局）、概念（wiki 词条）、笔记 / 标签 / 个人阅读状态与其关联表。
+
+P4 起 ``papers`` 是全平台共享的内容池（按 dedup_key 唯一，只存论文本体）；
+方向对论文的归属与判断字段（相关性分 / 状态 / 库版 wiki）在
+``library_papers``（models/library_direction.py）。"""
 
 import uuid
 from datetime import datetime
@@ -26,8 +30,8 @@ EMBEDDING_DIM = 1024  # BGE-M3（lab LiteLLM /v1/embeddings）
 # postgres 用 pgvector（语义检索），sqlite 等回退 JSON 存 list（仅存不查）
 EmbeddingVariant = JSON().with_variant(Vector(EMBEDDING_DIM), "postgresql")
 
-# 论文状态流转：candidate →(打分) scored | excluded →(下载全文) fetched
-#              →(Librarian 编译) compiled；included/excluded 亦可人工覆盖
+# 论文在方向库内的状态流转（LibraryPaper.status）：candidate →(打分) scored | excluded
+# →(下载全文) fetched →(Librarian 编译) compiled；included/excluded 亦可人工覆盖
 PAPER_STATUSES = ("candidate", "scored", "excluded", "fetched", "compiled", "included")
 
 paper_concepts = Table(
@@ -41,9 +45,6 @@ paper_concepts = Table(
 class Paper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "papers"
 
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
-    )
     # 全局去重键：arxiv:<id> | doi:<小写doi> | title:<标题+年份+首作者sha1>（services/dedup.py）
     dedup_key: Mapped[str | None] = mapped_column(String(512), unique=True, index=True)
     source: Mapped[str | None] = mapped_column(String(32))  # arxiv | semantic_scholar | manual
@@ -60,28 +61,15 @@ class Paper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     pdf_path: Mapped[str | None] = mapped_column(String(1024))
     full_text_path: Mapped[str | None] = mapped_column(String(1024))
-    relevance_score: Mapped[float | None]
     tldr: Mapped[str | None] = mapped_column(Text)
-    wiki_content: Mapped[str | None] = mapped_column(Text)  # markdown，双链 [[概念名]]
     # 提取的论文图列表：[{index, page, width, height, caption: str|null, important: bool}]，
     # 图片文件落 <data_dir>/papers/<paper_id>/figures/fig_<index>.png（路径不出 API）
     figures: Mapped[list[Any] | None] = mapped_column(JSONVariant)
     embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
-    status: Mapped[str] = mapped_column(String(32), default="candidate", nullable=False)
-    # 进垃圾桶的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
-    trash_reason: Mapped[str | None] = mapped_column(String(16))
-    scored_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    compiled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    # 编译 wiki_content 实际用到的模型名（取自 LLM 返回结果）；存量数据为 null
-    compiled_model: Mapped[str | None] = mapped_column(String(255))
 
     concepts: Mapped[list["Concept"]] = relationship(
         secondary=paper_concepts, back_populates="papers"
     )
-
-    @property
-    def has_wiki(self) -> bool:
-        return bool(self.wiki_content)
 
     @property
     def pdf_available(self) -> bool:
@@ -100,9 +88,6 @@ class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     paper_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     seq: Mapped[int] = mapped_column(nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
@@ -203,10 +188,10 @@ class PaperUserMeta(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
 class Concept(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "concepts"
-    __table_args__ = (UniqueConstraint("project_id", "slug", name="uq_concepts_project_slug"),)
+    __table_args__ = (UniqueConstraint("library_id", "slug", name="uq_concepts_library_slug"),)
 
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), index=True, nullable=False
     )
     name: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
     slug: Mapped[str] = mapped_column(String(255), index=True, nullable=False)

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -44,6 +44,8 @@ class Paper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     project_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
+    # 全局去重键：arxiv:<id> | doi:<小写doi> | title:<标题+年份+首作者sha1>（services/dedup.py）
+    dedup_key: Mapped[str | None] = mapped_column(String(512), unique=True, index=True)
     source: Mapped[str | None] = mapped_column(String(32))  # arxiv | semantic_scholar | manual
     arxiv_id: Mapped[str | None] = mapped_column(String(64), index=True)
     doi: Mapped[str | None] = mapped_column(String(255), index=True)

--- a/src/backend/app/services/affiliations.py
+++ b/src/backend/app/services/affiliations.py
@@ -68,6 +68,7 @@ async def extract_affiliations_llm(
     *,
     llm: LLMRouter,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> list[str] | None:
     """LLM 从论文全文标题页解析机构名列表。
@@ -86,7 +87,7 @@ async def extract_affiliations_llm(
             ],
             max_tokens=_MAX_TOKENS,
             user_id=user_id,
-            project_id=paper.project_id,
+            project_id=project_id,
             voyage_id=voyage_id,
         )
         return _parse_affiliations(result.content)

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -16,6 +16,7 @@ from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperChunk
 
 CHUNK_TARGET_CHARS = 1200
@@ -65,14 +66,7 @@ async def replace_chunks(session: AsyncSession, paper: Paper, full_text: str) ->
     await session.execute(delete(PaperChunk).where(PaperChunk.paper_id == paper.id))
     chunks = split_text(sanitize_text(full_text))
     for seq, chunk_text in enumerate(chunks):
-        session.add(
-            PaperChunk(
-                paper_id=paper.id,
-                project_id=paper.project_id,
-                seq=seq,
-                text=chunk_text,
-            )
-        )
+        session.add(PaperChunk(paper_id=paper.id, seq=seq, text=chunk_text))
     return len(chunks)
 
 
@@ -87,18 +81,25 @@ async def index_paper_fulltext(session: AsyncSession, paper: Paper) -> int:
 async def embed_pending_chunks(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     llm: LLMRouter,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
     limit: int = 2000,
 ) -> tuple[int, str | None]:
-    """批量补齐缺失的分段向量，返回 (成功条数, 错误说明|None)。"""
+    """批量补齐库内论文缺失的分段向量，返回 (成功条数, 错误说明|None)。
+
+    project_id 仅用于 LLM 用量记账归属。
+    """
     pending = (
         (
             await session.execute(
                 select(PaperChunk)
-                .where(PaperChunk.project_id == project_id, PaperChunk.embedding.is_(None))
+                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+                .where(
+                    LibraryPaper.library_id == library_id, PaperChunk.embedding.is_(None)
+                )
                 .order_by(PaperChunk.created_at, PaperChunk.seq)
                 .limit(limit)
             )
@@ -137,7 +138,7 @@ def chunk_vector_search_supported(session: AsyncSession) -> bool:
 async def semantic_search_chunks(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     query_vector: list[float],
     limit: int,
     paper_ids: list[uuid.UUID] | None = None,
@@ -147,19 +148,20 @@ async def semantic_search_chunks(
     传 paper_ids 时把检索限制在这些论文内（伴读引用指定文献用）。
     """
     qv = json.dumps(query_vector)
-    params: dict[str, object] = {"qv": qv, "pid": str(project_id), "k": limit}
+    params: dict[str, object] = {"qv": qv, "lib": str(library_id), "k": limit}
     paper_filter = ""
     if paper_ids:
-        paper_filter = "AND paper_id = ANY(CAST(:pids AS uuid[])) "
+        paper_filter = "AND c.paper_id = ANY(CAST(:pids AS uuid[])) "
         params["pids"] = [str(p) for p in paper_ids]
     rows = (
         await session.execute(
             sa_text(
-                "SELECT id, 1 - (embedding <=> CAST(:qv AS vector)) AS score "
-                "FROM paper_chunks "
-                "WHERE project_id = :pid AND embedding IS NOT NULL "
+                "SELECT c.id, 1 - (c.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM paper_chunks c "
+                "JOIN library_papers lp ON lp.paper_id = c.paper_id AND lp.library_id = :lib "
+                "WHERE c.embedding IS NOT NULL "
                 f"{paper_filter}"
-                "ORDER BY embedding <=> CAST(:qv AS vector) "
+                "ORDER BY c.embedding <=> CAST(:qv AS vector) "
                 "LIMIT :k"
             ),
             params,
@@ -180,7 +182,7 @@ async def semantic_search_chunks(
 async def keyword_search_chunks(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     q: str,
     limit: int,
     paper_ids: list[uuid.UUID] | None = None,
@@ -196,7 +198,11 @@ async def keyword_search_chunks(
     for term in terms:
         clause = PaperChunk.text.ilike(f"%{term}%")
         cond = clause if cond is None else cond | clause
-    stmt = select(PaperChunk).where(PaperChunk.project_id == project_id, cond)
+    stmt = (
+        select(PaperChunk)
+        .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+        .where(LibraryPaper.library_id == library_id, cond)
+    )
     if paper_ids:
         stmt = stmt.where(PaperChunk.paper_id.in_(paper_ids))
     candidates = (await session.execute(stmt.limit(limit * 5))).scalars().all()

--- a/src/backend/app/services/citations.py
+++ b/src/backend/app/services/citations.py
@@ -9,10 +9,11 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
+from app.services.libraries import get_library_for_project, member_paper_stmt
 from app.services.papers import apply_paper_filters
 
 # 缺省导出的论文状态（未显式指定 status 时）
@@ -199,8 +200,9 @@ async def papers_for_export(
 
     paper_ids 指定时按 id 精确导出（多选导出），忽略状态缺省过滤。
     """
+    library = await get_library_for_project(session, project_id)
     stmt = apply_paper_filters(
-        select(Paper),
+        member_paper_stmt(library.id),
         project_id=project_id,
         status=status,
         tag=tag,
@@ -210,6 +212,6 @@ async def papers_for_export(
     if paper_ids:
         stmt = stmt.where(Paper.id.in_(paper_ids))
     elif not status:
-        stmt = stmt.where(Paper.status.in_(DEFAULT_EXPORT_STATUSES))
-    stmt = stmt.order_by(Paper.year.asc().nulls_last(), Paper.created_at.asc())
-    return (await session.execute(stmt)).scalars().all()
+        stmt = stmt.where(LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES))
+    stmt = stmt.order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
+    return [paper for paper, _ in (await session.execute(stmt)).all()]

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, paper_concepts
 
 logger = logging.getLogger(__name__)
@@ -86,16 +87,16 @@ def normalize_category(raw: Any) -> str:
 async def list_concepts(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     category: str | None = None,
     q: str | None = None,
 ) -> list[tuple[Concept, int]]:
-    """项目概念列表（附 paper_count）。"""
+    """方向库概念列表（附 paper_count）。"""
     paper_count = func.count(paper_concepts.c.paper_id).label("paper_count")
     stmt = (
         select(Concept, paper_count)
         .outerjoin(paper_concepts, paper_concepts.c.concept_id == Concept.id)
-        .where(Concept.project_id == project_id)
+        .where(Concept.library_id == library_id)
         .group_by(Concept.id)
         .order_by(paper_count.desc(), Concept.name)
     )
@@ -203,19 +204,19 @@ async def _fetch_definitions_batch(
 
 async def delete_orphan_concepts(
     session: AsyncSession,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     *,
     candidate_ids: set[uuid.UUID] | None = None,
 ) -> int:
-    """删除项目内零引用概念（paper_concepts 计数，含回收站论文的引用），返回删除数。
+    """删除库内零引用概念（paper_concepts 计数，含回收站论文的引用），返回删除数。
 
     ``candidate_ids`` 给出时只在这些概念里找孤儿（单篇同步后的定向检查）；
-    不给时全项目扫描。不 commit，由调用方提交。
+    不给时全库扫描。不 commit，由调用方提交。
     """
     if candidate_ids is not None and not candidate_ids:
         return 0
     stmt = delete(Concept).where(
-        Concept.project_id == project_id,
+        Concept.library_id == library_id,
         ~exists().where(paper_concepts.c.concept_id == Concept.id),
     )
     if candidate_ids is not None:
@@ -225,14 +226,25 @@ async def delete_orphan_concepts(
 
 
 async def _remove_stale_paper_links(
-    session: AsyncSession, paper_id: uuid.UUID, keep_concept_ids: set[uuid.UUID]
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    keep_concept_ids: set[uuid.UUID],
+    *,
+    library_id: uuid.UUID,
 ) -> set[uuid.UUID]:
-    """删除该论文上不在 ``keep_concept_ids`` 里的 paper_concepts 关联，返回被解除的概念 id。"""
+    """删除该论文上不在 ``keep_concept_ids`` 里的**本库**概念关联，返回被解除的概念 id。
+
+    只动 library_id 库的概念——同一篇内容池论文可能同时挂着其他方向库的概念链。
+    """
     stale = {
         cid
         for (cid,) in (
             await session.execute(
-                select(paper_concepts.c.concept_id).where(paper_concepts.c.paper_id == paper_id)
+                select(paper_concepts.c.concept_id)
+                .join(Concept, Concept.id == paper_concepts.c.concept_id)
+                .where(
+                    paper_concepts.c.paper_id == paper_id, Concept.library_id == library_id
+                )
             )
         ).all()
         if cid not in keep_concept_ids
@@ -250,9 +262,10 @@ async def _remove_stale_paper_links(
 async def link_all_paper_concepts(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    library_id: uuid.UUID,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
     backfill: bool = False,
 ) -> tuple[dict[str, Any], list[Paper]]:
@@ -271,25 +284,26 @@ async def link_all_paper_concepts(
     ``_AUTO_BACKFILL_CAP`` 个最老的占位重新要定义，让偶发失败随每日同步自愈,
     又不至于在占位堆积时每天重刷几百个。
     返回 (统计 dict, 涉及的论文列表)；本函数自行 commit。
+    project_id 仅用于 LLM 用量记账归属。
     """
-    papers = (
-        (
-            await session.execute(
-                select(Paper).where(
-                    Paper.project_id == project_id,
-                    Paper.status.in_(("compiled", "included")),
-                    Paper.wiki_content.is_not(None),
-                )
+    rows = (
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(
+                LibraryPaper.library_id == library_id,
+                LibraryPaper.status.in_(("compiled", "included")),
+                LibraryPaper.wiki_content.is_not(None),
             )
         )
-        .scalars()
-        .all()
-    )
-    links_by_paper = {p.id: extract_wikilinks(p.wiki_content or "") for p in papers}
+    ).all()
+    papers = [paper for paper, _ in rows]
+    wiki_by_paper = {paper.id: membership.wiki_content for paper, membership in rows}
+    links_by_paper = {pid: extract_wikilinks(wiki or "") for pid, wiki in wiki_by_paper.items()}
     all_names = sorted({name for names in links_by_paper.values() for name in names})
 
     existing = (
-        (await session.execute(select(Concept).where(Concept.project_id == project_id)))
+        (await session.execute(select(Concept).where(Concept.library_id == library_id)))
         .scalars()
         .all()
     )
@@ -319,7 +333,7 @@ async def link_all_paper_concepts(
         slugs.add(slug)
         meta = definitions.get(name) or {}
         concept = Concept(
-            project_id=project_id,
+            library_id=library_id,
             name=name,
             slug=slug,
             definition=str(meta.get("definition") or placeholder_definition(name)),
@@ -339,13 +353,17 @@ async def link_all_paper_concepts(
             backfilled += 1
     await session.flush()
 
+    # 只看本库概念的既有关联（同一篇论文可能挂着其他库的概念链，不参与也不误删）
     existing_pairs = (
         {
             (pid, cid)
             for pid, cid in (
                 await session.execute(
-                    select(paper_concepts.c.paper_id, paper_concepts.c.concept_id).where(
-                        paper_concepts.c.paper_id.in_(list(links_by_paper))
+                    select(paper_concepts.c.paper_id, paper_concepts.c.concept_id)
+                    .join(Concept, Concept.id == paper_concepts.c.concept_id)
+                    .where(
+                        paper_concepts.c.paper_id.in_(list(links_by_paper)),
+                        Concept.library_id == library_id,
                     )
                 )
             ).all()
@@ -371,7 +389,7 @@ async def link_all_paper_concepts(
     for pid, cid in existing_pairs:
         pairs_by_paper.setdefault(pid, set()).add(cid)
     for paper in papers:
-        if not paper.wiki_content:
+        if not wiki_by_paper.get(paper.id):
             continue
         target_ids = {
             by_name[name].id for name in links_by_paper.get(paper.id, []) if name in by_name
@@ -385,8 +403,8 @@ async def link_all_paper_concepts(
                 )
             )
             links_removed += len(stale)
-    # 同步收尾②：删除项目内零引用概念（含回收站论文的引用都算数，只删真孤儿）
-    concepts_removed = await delete_orphan_concepts(session, project_id)
+    # 同步收尾②：删除库内零引用概念（含回收站论文的引用都算数，只删真孤儿）
+    concepts_removed = await delete_orphan_concepts(session, library_id)
     await session.commit()
 
     stats = {
@@ -404,22 +422,26 @@ async def link_all_paper_concepts(
 async def link_paper_concepts(
     session: AsyncSession,
     paper: Paper,
+    membership: LibraryPaper,
     *,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
 ) -> tuple[int, int]:
     """单篇概念上链（手动编译/重编译后调用，docs/api-lit.md §6.6）——同步语义：
 
-    从 wiki_content 抽 [[双链]] → 缺失概念建词条（LLM 定义，失败占位）→ 建关联；
-    再删除该论文上新正文已不引用的陈旧关联，被解除关联且全库（含回收站论文）
+    从成员行 wiki_content 抽 [[双链]] → 缺失概念建词条（LLM 定义，失败占位）→ 建关联；
+    再删除该论文上新正文已不引用的**本库**陈旧关联，被解除关联且全库（含回收站论文）
     再无引用的概念一并删除。正文为空/None 时直接返回，不做任何删除（防误删）。
     返回 (新建概念数, 新建关联数)。调用方无需再 commit（本函数自行提交）。
+    project_id 仅用于 LLM 用量记账归属。
     """
-    if not paper.wiki_content:
+    if not membership.wiki_content:
         return 0, 0
-    names = extract_wikilinks(paper.wiki_content)
+    library_id = membership.library_id
+    names = extract_wikilinks(membership.wiki_content)
     existing = (
-        (await session.execute(select(Concept).where(Concept.project_id == paper.project_id)))
+        (await session.execute(select(Concept).where(Concept.library_id == library_id)))
         .scalars()
         .all()
     )
@@ -430,7 +452,7 @@ async def link_paper_concepts(
     definitions: dict[str, dict[str, str]] = {}
     if new_names and llm is not None:
         definitions = await fetch_concept_definitions(
-            llm, new_names, user_id=user_id, project_id=paper.project_id
+            llm, new_names, user_id=user_id, project_id=project_id
         )
 
     created = 0
@@ -441,7 +463,7 @@ async def link_paper_concepts(
         slugs.add(slug)
         meta = definitions.get(name) or {}
         concept = Concept(
-            project_id=paper.project_id,
+            library_id=library_id,
             name=name,
             slug=slug,
             definition=str(meta.get("definition") or placeholder_definition(name)),
@@ -456,7 +478,11 @@ async def link_paper_concepts(
         cid
         for (cid,) in (
             await session.execute(
-                select(paper_concepts.c.concept_id).where(paper_concepts.c.paper_id == paper.id)
+                select(paper_concepts.c.concept_id)
+                .join(Concept, Concept.id == paper_concepts.c.concept_id)
+                .where(
+                    paper_concepts.c.paper_id == paper.id, Concept.library_id == library_id
+                )
             )
         ).all()
     }
@@ -471,9 +497,11 @@ async def link_paper_concepts(
         existing_pairs.add(concept.id)
         linked += 1
 
-    # 同步收尾：删除新正文已不引用的陈旧关联；被解除关联且全库再无引用的概念删词条
+    # 同步收尾：删除新正文已不引用的本库陈旧关联；被解除关联且再无引用的概念删词条
     target_ids = {by_name[name].id for name in names if name in by_name}
-    stale = await _remove_stale_paper_links(session, paper.id, target_ids)
-    await delete_orphan_concepts(session, paper.project_id, candidate_ids=stale)
+    stale = await _remove_stale_paper_links(
+        session, paper.id, target_ids, library_id=library_id
+    )
+    await delete_orphan_concepts(session, library_id, candidate_ids=stale)
     await session.commit()
     return created, linked

--- a/src/backend/app/services/dedup.py
+++ b/src/backend/app/services/dedup.py
@@ -1,0 +1,79 @@
+"""跨库去重键（全平台共享工具）。
+
+层级：arxiv → doi → 规范化标题 sha1（优先序可由调用方覆盖——发表记录历史键是 doi 优先，
+必须保持前缀顺序不变，否则已存 dedup_key 全部失配）。
+
+标题层级只在没有 arxiv/doi 时启用；内容池（papers.dedup_key）在标题哈希里
+额外掺入年份 + 规范化首作者（RFC §4.3：降低「不同论文标题撞车」的误合并概率），
+个人库 / 发表记录沿用纯标题哈希（兼容既有数据）。
+"""
+
+import hashlib
+import re
+from typing import Any
+
+DEFAULT_PRIORITY: tuple[str, ...] = ("arxiv", "doi", "title")
+
+
+def normalize_title(title: str) -> str:
+    """规范化标题（个人库现行算法，全平台基准）：小写 + 非字母数字折叠为空格。"""
+    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
+
+
+def _normalize_author(name: str) -> str:
+    return re.sub(r"[^a-z一-鿿0-9]+", " ", name.lower()).strip()
+
+
+def _first_author_name(authors: list[Any] | None) -> str | None:
+    """从 authors JSON（[{"name": ...}] 或 [str]）里取首作者名。"""
+    if not authors:
+        return None
+    first = authors[0]
+    name = first.get("name") if isinstance(first, dict) else first
+    return name if isinstance(name, str) and name.strip() else None
+
+
+def dedup_key_for(
+    *,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    title: str | None = None,
+    year: int | None = None,
+    authors: list[Any] | None = None,
+    priority: tuple[str, ...] = DEFAULT_PRIORITY,
+) -> str | None:
+    """按优先序生成去重键：``arxiv:<id>`` | ``doi:<小写doi>`` | ``title:<sha1>``。
+
+    - 标题层级要求 title 非空；传入 year/authors 时把「年份 + 首作者」掺进哈希
+      （内容池用，防误合并），不传则退化为纯标题哈希（个人库/发表记录兼容口径）。
+    - 三层全空时返回 None（调用方自行兜底）。
+    """
+    for tier in priority:
+        if tier == "arxiv" and arxiv_id:
+            return f"arxiv:{arxiv_id.lower()}"
+        if tier == "doi" and doi:
+            return f"doi:{doi.lower()}"
+        if tier == "title" and title and title.strip():
+            parts = [normalize_title(title)]
+            if year is not None:
+                parts.append(str(year))
+            first_author = _first_author_name(authors)
+            if first_author:
+                parts.append(_normalize_author(first_author))
+            digest = hashlib.sha1("|".join(parts).encode()).hexdigest()
+            return f"title:{digest}"
+    return None
+
+
+def pool_dedup_key(
+    *,
+    arxiv_id: str | None,
+    doi: str | None,
+    title: str,
+    year: int | None = None,
+    authors: list[Any] | None = None,
+) -> str:
+    """内容池（papers.dedup_key）口径：arxiv → doi → 标题+年份+首作者哈希。"""
+    key = dedup_key_for(arxiv_id=arxiv_id, doi=doi, title=title, year=year, authors=authors)
+    assert key is not None  # title 非空保证有键
+    return key

--- a/src/backend/app/services/figure_annotate.py
+++ b/src/backend/app/services/figure_annotate.py
@@ -215,6 +215,7 @@ async def annotate_figures(
     *,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> list[dict[str, Any]]:
     """挑重要图并配中文图注，合并结果写 Paper.figures 并返回（调用方负责 commit）。"""
@@ -244,7 +245,7 @@ async def annotate_figures(
                     messages,
                     images=images,
                     user_id=user_id,
-                    project_id=paper.project_id,
+                    project_id=project_id,
                     voyage_id=voyage_id,
                 )
                 merged = _merge(candidates, _extract_json_array(result.content))
@@ -269,12 +270,13 @@ async def extract_and_annotate(
     paper: Paper,
     *,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
 ) -> list[dict[str, Any]]:
     """PyMuPDF 提取候选图 → LLM 筛选注释 → 写 Paper.figures 并落库。
 
     调用方需先保证 paper.pdf_path 存在（无 PDF 由路由映射 404）。
     """
     candidates = await extract_figures(str(paper.id), Path(paper.pdf_path))
-    figures = await annotate_figures(paper, candidates, user_id=user_id)
+    figures = await annotate_figures(paper, candidates, user_id=user_id, project_id=project_id)
     await session.commit()
     return figures

--- a/src/backend/app/services/graph.py
+++ b/src/backend/app/services/graph.py
@@ -12,8 +12,10 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, paper_concepts
 from app.services.concepts import wiki_slug
+from app.services.libraries import get_library_for_project
 
 # 图上展示的论文状态（candidate 未过筛选，噪声大，不进图）
 GRAPH_PAPER_STATUSES = ("scored", "fetched", "compiled", "included")
@@ -43,27 +45,34 @@ async def project_graph(
     max_authors: int = MAX_AUTHORS,
 ) -> dict[str, Any]:
     """构建项目知识图谱，返回 GraphResponse 形状的 dict。"""
+    library = await get_library_for_project(session, project_id)
     paper_total = int(
         (
             await session.execute(
                 select(func.count()).where(
-                    Paper.project_id == project_id, Paper.status.in_(GRAPH_PAPER_STATUSES)
+                    LibraryPaper.library_id == library.id,
+                    LibraryPaper.status.in_(GRAPH_PAPER_STATUSES),
                 )
             )
         ).scalar_one()
     )
-    papers = (
-        (
-            await session.execute(
-                select(Paper)
-                .where(Paper.project_id == project_id, Paper.status.in_(GRAPH_PAPER_STATUSES))
-                .order_by(Paper.relevance_score.desc().nulls_last(), Paper.created_at.desc())
-                .limit(max_papers)
+    rows = (
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(
+                LibraryPaper.library_id == library.id,
+                LibraryPaper.status.in_(GRAPH_PAPER_STATUSES),
             )
+            .order_by(
+                LibraryPaper.relevance_score.desc().nulls_last(),
+                LibraryPaper.created_at.desc(),
+            )
+            .limit(max_papers)
         )
-        .scalars()
-        .all()
-    )
+    ).all()
+    papers = [p for p, _ in rows]
+    membership_of = {p.id: m for p, m in rows}
     paper_ids = [p.id for p in papers]
 
     nodes: list[dict[str, Any]] = [
@@ -71,10 +80,10 @@ async def project_graph(
             "id": str(p.id),
             "type": "paper",
             "label": p.title,
-            "status": p.status,
+            "status": membership_of[p.id].status,
             "year": p.year,
             "published": p.published_at.date().isoformat() if p.published_at else None,
-            "relevance": p.relevance_score,
+            "relevance": membership_of[p.id].relevance_score,
         }
         for p in papers
     ]

--- a/src/backend/app/services/highlights.py
+++ b/src/backend/app/services/highlights.py
@@ -12,7 +12,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.paper import Paper, PaperHighlight
+from app.models.paper import PaperHighlight
 from app.models.project import ProjectMember
 from app.models.user import User
 from app.schemas.highlight import HighlightCreate
@@ -20,11 +20,16 @@ from app.services.notes import author_name_of
 
 
 async def create_highlight(
-    session: AsyncSession, *, paper: Paper, author: User, data: HighlightCreate
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    project_id: uuid.UUID,
+    author: User,
+    data: HighlightCreate,
 ) -> PaperHighlight:
     hl = PaperHighlight(
-        paper_id=paper.id,
-        project_id=paper.project_id,
+        paper_id=paper_id,
+        project_id=project_id,
         author_id=author.id,
         page=data.page,
         rects=[r.model_dump() for r in data.rects],

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -16,6 +16,7 @@ from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.idea import DeepIdeaRequest, ForgeKnobs
 from app.schemas.review import TournamentRequest
+from app.services.libraries import get_library_for_project, get_membership
 
 # 同项目 idea 类 voyage 互斥（docs/api-m3.md §1 + docs/api-idea2.md §2）
 IDEA_VOYAGE_KINDS = ("idea_forge", "idea_review", "idea_proposal")
@@ -174,12 +175,18 @@ async def _validate_seed(
         raise InvalidSeedError(value) from e
     if seed_type == "paper":
         paper = await session.get(Paper, target_id)
-        if paper is None or paper.project_id != project_id:
+        if paper is None:
+            raise InvalidSeedError(value)
+        library = await get_library_for_project(session, project_id)
+        if await get_membership(session, library_id=library.id, paper_id=paper.id) is None:
             raise InvalidSeedError(value)
         return f"论文《{paper.title[:60]}》"
     if seed_type == "concept":
         concept = await session.get(Concept, target_id)
-        if concept is None or concept.project_id != project_id:
+        if concept is None:
+            raise InvalidSeedError(value)
+        library = await get_library_for_project(session, project_id)
+        if concept.library_id != library.id:
             raise InvalidSeedError(value)
         return f"概念「{concept.name}」"
     if seed_type == "idea":

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -9,10 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.navigator import WIKI_KINDS
 from app.models.activity import Activity
-from app.models.paper import PAPER_STATUSES, Paper
+from app.models.library_direction import LibraryPaper
+from app.models.paper import PAPER_STATUSES
 from app.models.project import Project
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
+from app.services.libraries import get_library_for_project
 
 # 预算从 knobs 派生：每篇编译预留的 token 额度（打分+编译+概念定义+验证）
 _TOKENS_PER_PAPER = 20_000
@@ -87,11 +89,12 @@ async def create_ingest_voyage(
 
 
 async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str, int]:
+    library = await get_library_for_project(session, project_id)
     rows = (
         await session.execute(
-            select(Paper.status, func.count())
-            .where(Paper.project_id == project_id)
-            .group_by(Paper.status)
+            select(LibraryPaper.status, func.count())
+            .where(LibraryPaper.library_id == library.id)
+            .group_by(LibraryPaper.status)
         )
     ).all()
     counts = {status: 0 for status in PAPER_STATUSES}

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -1,0 +1,129 @@
+"""方向文献库解析与成员行工具（P4 过渡期：project 1:1 隐式库，不 import fastapi）。
+
+API 形状不变（仍收 project_id），service 层经这里解析到 DirectionLibrary 后
+用 LibraryPaper 承接论文归属与判断字段；新 project 建库时同步建隐式库
+（services/projects.py），这里的 get-or-create 只兜底历史/直插数据。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.models.project import Project, ProjectMember
+
+
+def implicit_library_for(project: Project) -> DirectionLibrary:
+    """按 project 组一个隐式库对象（继承 definition 的 statement/rubric/anchors/cadence）。"""
+    definition = project.definition if isinstance(project.definition, dict) else {}
+    return DirectionLibrary(
+        name=project.name,
+        statement=definition.get("statement"),
+        rubric=definition.get("rubric"),
+        anchors=definition.get("anchor_papers"),
+        ingest_state=project.ingest_state,
+        cadence=definition.get("cadence"),
+        created_by=project.owner_id,
+        project_id=project.id,
+    )
+
+
+async def get_library_for_project(
+    session: AsyncSession, project_id: uuid.UUID
+) -> DirectionLibrary:
+    """取 project 的隐式方向库；缺失时就地补建（flush 不 commit，随调用方事务落库）。"""
+    stmt = select(DirectionLibrary).where(DirectionLibrary.project_id == project_id)
+    library = (await session.execute(stmt)).scalar_one_or_none()
+    if library is not None:
+        return library
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise ValueError(f"project not found: {project_id}")
+    library = implicit_library_for(project)
+    session.add(library)
+    await session.flush()
+    return library
+
+
+async def get_library_id_for_project(session: AsyncSession, project_id: uuid.UUID) -> uuid.UUID:
+    return (await get_library_for_project(session, project_id)).id
+
+
+async def get_membership(
+    session: AsyncSession, *, library_id: uuid.UUID, paper_id: uuid.UUID
+) -> LibraryPaper | None:
+    stmt = select(LibraryPaper).where(
+        LibraryPaper.library_id == library_id, LibraryPaper.paper_id == paper_id
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def ensure_membership(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    status: str = "candidate",
+    **fields: Any,
+) -> tuple[LibraryPaper, bool]:
+    """成员行 get-or-create（flush 不 commit），返回 (行, 是否新建)。"""
+    membership = await get_membership(session, library_id=library_id, paper_id=paper_id)
+    if membership is not None:
+        return membership, False
+    membership = LibraryPaper(library_id=library_id, paper_id=paper_id, status=status, **fields)
+    session.add(membership)
+    await session.flush()
+    return membership, True
+
+
+async def membership_for_project(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
+) -> LibraryPaper | None:
+    """按 project 解析隐式库后取成员行（工具层「论文是否在本方向库内」的统一检查）。"""
+    library = await get_library_for_project(session, project_id)
+    return await get_membership(session, library_id=library.id, paper_id=paper_id)
+
+
+async def find_pool_paper(
+    session: AsyncSession,
+    *,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    dedup_key: str | None = None,
+) -> Paper | None:
+    """按 arxiv → doi → dedup_key 优先级查全局内容池（写路径「先查池」的统一入口）。"""
+    if arxiv_id:
+        stmt = select(Paper).where(Paper.arxiv_id == arxiv_id).limit(1)
+        if (paper := (await session.execute(stmt)).scalars().first()) is not None:
+            return paper
+    if doi:
+        stmt = select(Paper).where(func.lower(Paper.doi) == doi.lower()).limit(1)
+        if (paper := (await session.execute(stmt)).scalars().first()) is not None:
+            return paper
+    if dedup_key:
+        stmt = select(Paper).where(Paper.dedup_key == dedup_key).limit(1)
+        return (await session.execute(stmt)).scalars().first()
+    return None
+
+
+def member_paper_stmt(library_id: uuid.UUID) -> Select:
+    """库内论文基础查询：SELECT (Paper, LibraryPaper) 按成员表过滤。"""
+    return (
+        select(Paper, LibraryPaper)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(LibraryPaper.library_id == library_id)
+    )
+
+
+def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
+    """用户可见论文（其任一所属方向的库里有成员行）：SELECT (Paper, LibraryPaper, project_id)。"""
+    return (
+        select(Paper, LibraryPaper, DirectionLibrary.project_id)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
+        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
+        .where(ProjectMember.user_id == user_id)
+    )

--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -16,9 +16,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, PaperChunk, paper_concepts
 from app.models.project import Project
 from app.services import chunks as chunks_service
+from app.services.libraries import get_library_for_project
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +64,7 @@ class ChatSource:
 async def _retrieve_chunks(
     session: AsyncSession,
     *,
+    library_id: uuid.UUID,
     project_id: uuid.UUID,
     question: str,
     llm: LLMRouter,
@@ -79,7 +82,7 @@ async def _retrieve_chunks(
             vectors = await llm.embed([question], user_id=user_id, project_id=project_id)
             rows = await chunks_service.semantic_search_chunks(
                 session,
-                project_id=project_id,
+                library_id=library_id,
                 query_vector=vectors[0],
                 limit=MAX_CHUNKS,
                 paper_ids=paper_ids,
@@ -93,7 +96,7 @@ async def _retrieve_chunks(
             await session.rollback()  # postgres 报错后事务已中止，先回滚
     try:
         return await chunks_service.keyword_search_chunks(
-            session, project_id=project_id, q=question, limit=MAX_CHUNKS, paper_ids=paper_ids
+            session, library_id=library_id, q=question, limit=MAX_CHUNKS, paper_ids=paper_ids
         )
     except Exception:  # noqa: BLE001
         logger.warning("chunk keyword search failed; falling back to summaries", exc_info=True)
@@ -145,17 +148,29 @@ async def build_library_messages(
     project_id = project.id
     definition = project.definition if isinstance(project.definition, dict) else {}
     statement = definition.get("statement") or project.name
+    library_id = (await get_library_for_project(session, project_id)).id
 
     rows = await _retrieve_chunks(
-        session, project_id=project_id, question=question, llm=llm, user_id=user_id
+        session,
+        library_id=library_id,
+        project_id=project_id,
+        question=question,
+        llm=llm,
+        user_id=user_id,
     )
     papers: dict[uuid.UUID, Paper] = {}
+    memberships: dict[uuid.UUID, LibraryPaper] = {}
     if rows:
         paper_ids = list({c.paper_id for c, _ in rows})
         found = (
-            (await session.execute(select(Paper).where(Paper.id.in_(paper_ids)))).scalars().all()
-        )
-        papers = {p.id: p for p in found}
+            await session.execute(
+                select(Paper, LibraryPaper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(LibraryPaper.library_id == library_id, Paper.id.in_(paper_ids))
+            )
+        ).all()
+        papers = {p.id: p for p, _ in found}
+        memberships = {p.id: m for p, m in found}
 
     # (paper, 送入上下文的正文) 顺序清单：优先检索片段，否则高分论文摘要兜底
     entries: list[tuple[Paper, str]] = []
@@ -165,21 +180,19 @@ async def build_library_messages(
             entries.append((paper, snippet))
     else:
         fallback = (
-            (
-                await session.execute(
-                    select(Paper)
-                    .where(
-                        Paper.project_id == project_id,
-                        Paper.status.in_(("scored", "fetched", "compiled", "included")),
-                    )
-                    .order_by(Paper.relevance_score.desc().nulls_last())
-                    .limit(FALLBACK_PAPERS)
+            await session.execute(
+                select(Paper, LibraryPaper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(("scored", "fetched", "compiled", "included")),
                 )
+                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+                .limit(FALLBACK_PAPERS)
             )
-            .scalars()
-            .all()
-        )
-        entries = [(p, p.tldr or (p.abstract or "")[:400] or "（无摘要）") for p in fallback]
+        ).all()
+        entries = [(p, p.tldr or (p.abstract or "")[:400] or "（无摘要）") for p, _ in fallback]
+        memberships |= {p.id: m for p, m in fallback}
 
     # 涉及论文的概念清单（回答里的 [[双链]] 只允许用这些名字，保证前端可点可跳）
     concepts_by_paper: dict[uuid.UUID, list[str]] = {}
@@ -203,14 +216,15 @@ async def build_library_messages(
         blocks.append(
             f"[{i}] {paper.title}（{paper.year or '年份未知'}）{concept_line}{fig_line}\n{body}"
         )
+        membership = memberships.get(paper.id)
         sources.append(
             ChatSource(
                 index=i,
                 paper_id=str(paper.id),
                 title=paper.title,
                 year=paper.year,
-                status=paper.status,
-                relevance=paper.relevance_score,
+                status=membership.status if membership else None,
+                relevance=membership.relevance_score if membership else None,
                 concepts=names,
             )
         )
@@ -244,16 +258,16 @@ async def build_reference_context(
     """
     if not paper_ids:
         return "", []
+    library_id = (await get_library_for_project(session, project_id)).id
     found = (
-        (
-            await session.execute(
-                select(Paper).where(Paper.id.in_(paper_ids), Paper.project_id == project_id)
-            )
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id == library_id, Paper.id.in_(paper_ids))
         )
-        .scalars()
-        .all()
-    )
-    papers = {p.id: p for p in found}
+    ).all()
+    papers = {p.id: p for p, _ in found}
+    memberships = {p.id: m for p, m in found}
     # 保留用户的选择顺序，并滤掉不属于本项目的
     ordered = [papers[pid] for pid in paper_ids if pid in papers]
     if not ordered:
@@ -261,6 +275,7 @@ async def build_reference_context(
 
     rows = await _retrieve_chunks(
         session,
+        library_id=library_id,
         project_id=project_id,
         question=question,
         llm=llm,
@@ -280,14 +295,15 @@ async def build_reference_context(
         else:
             body = paper.tldr or (paper.abstract or "")[:400] or "（无摘要）"
         blocks.append(f"[{i}] {paper.title}（{paper.year or '年份未知'}）\n{body}")
+        membership = memberships.get(paper.id)
         sources.append(
             ChatSource(
                 index=i,
                 paper_id=str(paper.id),
                 title=paper.title,
                 year=paper.year,
-                status=paper.status,
-                relevance=paper.relevance_score,
+                status=membership.status if membership else None,
+                relevance=membership.relevance_score if membership else None,
             )
         )
     return "\n\n".join(blocks), sources

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -26,12 +26,14 @@ from app.models.activity import Activity
 from app.models.experiment import Experiment
 from app.models.gate import Gate
 from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript, ManuscriptFile
 from app.models.paper import Paper
 from app.models.project import Project, ProjectMember
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.manuscript import ManuscriptCreate
 from app.services.citations import DEFAULT_EXPORT_STATUSES, assign_citation_keys
+from app.services.libraries import get_library_for_project
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "assets" / "templates"
 TEMPLATE_KEYS = ("neurips2026", "iclr2026", "acl")
@@ -238,10 +240,15 @@ async def _citations_pack(session: AsyncSession, *, project_id: uuid.UUID) -> li
     条目含契约字段 {bibkey, title, year}，附加内部字段 paper_id / source
     供编译时按固定 key 生成 references.bib（避免库变动导致 key 漂移）。
     """
+    library = await get_library_for_project(session, project_id)
     stmt = (
         select(Paper)
-        .where(Paper.project_id == project_id, Paper.status.in_(DEFAULT_EXPORT_STATUSES))
-        .order_by(Paper.year.asc().nulls_last(), Paper.created_at.asc())
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(
+            LibraryPaper.library_id == library.id,
+            LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES),
+        )
+        .order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
     )
     papers = (await session.execute(stmt)).scalars().all()
     keys = assign_citation_keys(papers)

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -22,10 +22,10 @@ def author_name_of(display_name: str | None, email: str) -> str:
 
 
 async def create_note(
-    session: AsyncSession, *, paper: Paper, author: User, content: str
+    session: AsyncSession, *, paper_id: uuid.UUID, project_id: uuid.UUID, author: User, content: str
 ) -> PaperNote:
     note = PaperNote(
-        paper_id=paper.id, project_id=paper.project_id, author_id=author.id, content=content
+        paper_id=paper_id, project_id=project_id, author_id=author.id, content=content
     )
     session.add(note)
     await session.commit()

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -7,10 +7,16 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.paper import Paper
+from app.services.dedup import pool_dedup_key
+from app.services.libraries import (
+    ensure_membership,
+    find_pool_paper,
+    get_library_for_project,
+    get_membership,
+)
 from app.services.literature import get_arxiv_client, get_openalex_client
 from app.services.literature.arxiv import normalize_arxiv_id
 
@@ -25,7 +31,7 @@ class ParseFailedError(Exception):
 
 
 class DuplicatePaperError(Exception):
-    """项目内已有同 arxiv_id / doi 的论文。"""
+    """本方向库内已有同一篇论文（内容池命中且成员行已存在）。"""
 
     def __init__(self, paper_id: uuid.UUID) -> None:
         super().__init__(str(paper_id))
@@ -128,20 +134,6 @@ async def _fields_from_doi(doi: str) -> dict[str, Any]:
     }
 
 
-async def _find_duplicate(
-    session: AsyncSession, *, project_id: uuid.UUID, arxiv_id: str | None, doi: str | None
-) -> uuid.UUID | None:
-    conditions = []
-    if arxiv_id:
-        conditions.append(Paper.arxiv_id == arxiv_id)
-    if doi:
-        conditions.append(func.lower(Paper.doi) == doi.lower())
-    if not conditions:
-        return None
-    stmt = select(Paper.id).where(Paper.project_id == project_id, or_(*conditions)).limit(1)
-    return (await session.execute(stmt)).scalar_one_or_none()
-
-
 async def add_manual_paper(
     session: AsyncSession,
     *,
@@ -150,11 +142,12 @@ async def add_manual_paper(
     doi: str | None = None,
     bibtex: str | None = None,
 ) -> Paper:
-    """手动添加一篇文献（source=manual, status=included）。
+    """手动添加一篇文献（source=manual，成员行 status=included）。
 
-    - 项目内按 arxiv_id / doi 去重 → DuplicatePaperError（路由映射 409）
+    - 先查全局内容池（arxiv/doi/dedup_key）：池中已有则只建成员行（pool hit，
+      跳过解析下载）；本库已有成员行 → DuplicatePaperError（路由映射 409）
     - 解析失败 → ParseFailedError（路由映射 422）
-    - 有 arxiv_id 的自动尝试补下 PDF，失败只记日志不阻塞
+    - 新论文有 arxiv_id 的自动尝试补下 PDF，失败只记日志不阻塞
     """
     if arxiv_id:
         fields = await _fields_from_arxiv(arxiv_id)
@@ -163,11 +156,27 @@ async def add_manual_paper(
     else:
         fields = parse_bibtex_entry(bibtex or "")
 
-    dup_id = await _find_duplicate(
-        session, project_id=project_id, arxiv_id=fields.get("arxiv_id"), doi=fields.get("doi")
+    library = await get_library_for_project(session, project_id)
+    dedup_key = pool_dedup_key(
+        arxiv_id=fields.get("arxiv_id"),
+        doi=fields.get("doi"),
+        title=fields["title"],
+        year=fields.get("year"),
+        authors=fields.get("authors"),
     )
-    if dup_id is not None:
-        raise DuplicatePaperError(dup_id)
+    pooled = await find_pool_paper(
+        session, arxiv_id=fields.get("arxiv_id"), doi=fields.get("doi"), dedup_key=dedup_key
+    )
+    if pooled is not None:
+        if await get_membership(session, library_id=library.id, paper_id=pooled.id) is not None:
+            raise DuplicatePaperError(pooled.id)
+        logger.info("paper pool hit for manual import: %s", pooled.id)
+        await ensure_membership(
+            session, library_id=library.id, paper_id=pooled.id, status="included"
+        )
+        await session.commit()
+        await session.refresh(pooled)
+        return pooled
 
     external_ids: dict[str, str] = {}
     if fields.get("arxiv_id"):
@@ -175,9 +184,8 @@ async def add_manual_paper(
     if fields.get("doi"):
         external_ids["doi"] = fields["doi"]
     paper = Paper(
-        project_id=project_id,
         source="manual",
-        status="included",
+        dedup_key=dedup_key,
         arxiv_id=fields.get("arxiv_id"),
         doi=fields.get("doi"),
         external_ids=external_ids or None,
@@ -192,6 +200,7 @@ async def add_manual_paper(
     )
     session.add(paper)
     await session.flush()
+    await ensure_membership(session, library_id=library.id, paper_id=paper.id, status="included")
 
     if paper.arxiv_id:
         # 尽力而为补下 PDF + 抽全文；失败只记日志，不阻塞创建
@@ -214,7 +223,7 @@ async def add_manual_paper(
         from app.core.llm.router import get_llm_router
         from app.services.affiliations import extract_affiliations_llm
 
-        affs = await extract_affiliations_llm(paper, llm=get_llm_router())
+        affs = await extract_affiliations_llm(paper, llm=get_llm_router(), project_id=project_id)
         if affs:
             paper.affiliations = affs
 

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -1,4 +1,9 @@
-"""论文库与检索业务逻辑（不 import fastapi）。"""
+"""论文库与检索业务逻辑（不 import fastapi）。
+
+P4 起 ``papers`` 是全局内容池：方向维度的归属/判断（status、相关性分、库版 wiki）
+在 ``library_papers`` 成员行上。API 形状不变（仍收 project_id），这里解析到隐式库后
+以 (Paper, LibraryPaper) 联查，并用 :class:`PaperView` 还原旧单表字段口径给 schema。
+"""
 
 import asyncio
 import json
@@ -16,8 +21,21 @@ from sqlalchemy.orm import selectinload
 
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
-from app.models.paper import Concept, Paper, PaperNote, PaperTag, PaperUserMeta, paper_tag_links
-from app.models.project import ProjectMember
+from app.models.library_direction import LibraryPaper
+from app.models.paper import (
+    Concept,
+    Paper,
+    PaperHighlight,
+    PaperNote,
+    PaperTag,
+    PaperUserMeta,
+    paper_tag_links,
+)
+from app.services.libraries import (
+    get_library_for_project,
+    member_paper_stmt,
+    user_visible_paper_stmt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +66,66 @@ class PdfFetchFailedError(Exception):
     """PDF 下载失败（上游不可达 / 非 200 等）。"""
 
 
-def _member_paper_filter(stmt: Select, user_id: uuid.UUID) -> Select:
-    return stmt.join(ProjectMember, ProjectMember.project_id == Paper.project_id).where(
-        ProjectMember.user_id == user_id
-    )
+class PaperView:
+    """内容池论文 + 库成员行的合并视角（字段口径与旧单表 Paper 一致）。
+
+    本体字段（id/title/authors/pdf_path/…）透传 Paper；判断字段
+    （status/relevance_score/wiki_content/…）取成员行；``project_id`` 为本次
+    访问解析出的方向（过渡期 = 成员行所属隐式库回指的 project）。
+    ``created_at`` 口径 = 加入本方向库的时间（成员行 created_at）。
+    """
+
+    __slots__ = ("paper", "membership", "project_id")
+
+    def __init__(
+        self, paper: Paper, membership: LibraryPaper, project_id: uuid.UUID | None
+    ) -> None:
+        self.paper = paper
+        self.membership = membership
+        self.project_id = project_id
+
+    def __getattr__(self, name: str) -> Any:  # 本体字段透传
+        return getattr(object.__getattribute__(self, "paper"), name)
+
+    @property
+    def id(self) -> uuid.UUID:
+        return self.paper.id
+
+    @property
+    def relevance_score(self) -> float | None:
+        return self.membership.relevance_score
+
+    @property
+    def status(self) -> str:
+        return self.membership.status
+
+    @property
+    def trash_reason(self) -> str | None:
+        return self.membership.trash_reason
+
+    @property
+    def scored_at(self) -> datetime | None:
+        return self.membership.scored_at
+
+    @property
+    def compiled_at(self) -> datetime | None:
+        return self.membership.compiled_at
+
+    @property
+    def compiled_model(self) -> str | None:
+        return self.membership.compiled_model
+
+    @property
+    def wiki_content(self) -> str | None:
+        return self.membership.wiki_content
+
+    @property
+    def has_wiki(self) -> bool:
+        return bool(self.membership.wiki_content)
+
+    @property
+    def created_at(self) -> datetime:
+        return self.membership.created_at
 
 
 def apply_paper_filters(
@@ -71,17 +145,15 @@ def apply_paper_filters(
     created_from: datetime | None = None,
     created_to: datetime | None = None,
 ) -> Select:
-    """论文列表 / 引用导出共用的过滤条件（starred / reading_status 为 user_id 的个人视角）。
+    """论文列表 / 引用导出共用的过滤条件（作用于已 join 成员表的语句）。
 
-    status 支持组别名（docs/api-lit.md §8.5）：
-    - ``library``：库内文献 = 相关性达标及之后的状态（scored/fetched/compiled/included）
-    - ``pending_compile``：待编译 = 已达标但还没有解读（scored/fetched）
+    调用方须以 :func:`app.services.libraries.member_paper_stmt` 为基础语句
+    （本函数只加 WHERE，不负责 join）。status 支持组别名（docs/api-lit.md §8.5）。
     """
-    stmt = stmt.where(Paper.project_id == project_id)
     if status in PAPER_STATUS_GROUPS:
-        stmt = stmt.where(Paper.status.in_(PAPER_STATUS_GROUPS[status]))
+        stmt = stmt.where(LibraryPaper.status.in_(PAPER_STATUS_GROUPS[status]))
     elif status:
-        stmt = stmt.where(Paper.status == status)
+        stmt = stmt.where(LibraryPaper.status == status)
     if q:
         pattern = f"%{q}%"
         stmt = stmt.where(or_(Paper.title.ilike(pattern), Paper.abstract.ilike(pattern)))
@@ -105,9 +177,9 @@ def apply_paper_filters(
             )
         )
     if created_from:
-        stmt = stmt.where(Paper.created_at >= created_from)
+        stmt = stmt.where(LibraryPaper.created_at >= created_from)
     if created_to:
-        stmt = stmt.where(Paper.created_at <= created_to)
+        stmt = stmt.where(LibraryPaper.created_at <= created_to)
     if tag:
         stmt = stmt.where(
             Paper.id.in_(
@@ -152,9 +224,10 @@ async def list_papers(
     published_to: datetime | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
-) -> tuple[Sequence[Paper], int]:
+) -> tuple[Sequence[PaperView], int]:
+    library = await get_library_for_project(session, project_id)
     stmt = apply_paper_filters(
-        select(Paper),
+        member_paper_stmt(library.id),
         project_id=project_id,
         status=status,
         q=q,
@@ -169,30 +242,46 @@ async def list_papers(
         created_from=created_from,
         created_to=created_to,
     )
-    total = (await session.execute(select(func.count()).select_from(stmt.subquery()))).scalar_one()
+    total = (await session.execute(stmt.with_only_columns(func.count()))).scalar_one()
     if sort == "-published_at":
-        stmt = stmt.order_by(Paper.published_at.desc().nulls_last(), Paper.created_at.desc())
+        stmt = stmt.order_by(Paper.published_at.desc().nulls_last(), LibraryPaper.created_at.desc())
     else:  # relevance（默认）
-        stmt = stmt.order_by(Paper.relevance_score.desc().nulls_last(), Paper.created_at.desc())
+        stmt = stmt.order_by(
+            LibraryPaper.relevance_score.desc().nulls_last(), LibraryPaper.created_at.desc()
+        )
     stmt = stmt.offset((page - 1) * size).limit(size)
-    return (await session.execute(stmt)).scalars().all(), int(total)
+    rows = (await session.execute(stmt)).all()
+    return [PaperView(paper, membership, project_id) for paper, membership in rows], int(total)
 
 
 async def get_paper_for_user(
     session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool = False
-) -> Paper | None:
-    """取论文；非项目成员视为不存在。"""
-    stmt = _member_paper_filter(select(Paper), user_id).where(Paper.id == paper_id)
+) -> PaperView | None:
+    """取论文（含成员行视角）；用户任一所属方向的库里都没有时视为不存在。
+
+    论文同时在多个可见方向库时取一个确定性视角：优先有 wiki 解读的成员行，
+    其次最早加入的（跨方向复用的论文以先入库方向的解读为主视角）。
+    """
+    stmt = (
+        user_visible_paper_stmt(user_id)
+        .where(Paper.id == paper_id)
+        .order_by(LibraryPaper.wiki_content.is_(None), LibraryPaper.created_at)
+        .limit(1)
+    )
     if with_concepts:
         stmt = stmt.options(selectinload(Paper.concepts))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    row = (await session.execute(stmt)).first()
+    if row is None:
+        return None
+    paper, membership, project_id = row
+    return PaperView(paper, membership, project_id)
 
 
-async def set_paper_status(session: AsyncSession, paper: Paper, status: str) -> Paper:
-    paper.status = status
+async def set_paper_status(session: AsyncSession, view: PaperView, status: str) -> PaperView:
+    view.membership.status = status
     await session.commit()
-    await session.refresh(paper)
-    return paper
+    await session.refresh(view.membership)
+    return view
 
 
 # ---- 标签 / 个人状态 / 笔记数聚合（docs/api-lit.md §5） ----
@@ -235,14 +324,16 @@ async def paper_extras_map(
     return extras
 
 
-async def set_paper_tags(session: AsyncSession, paper: Paper, names: list[str]) -> list[str]:
+async def set_paper_tags(session: AsyncSession, view: PaperView, names: list[str]) -> list[str]:
     """整组覆盖论文标签：新名字自动建 tag，空数组=清空。返回排序后的标签名。"""
+    project_id = view.project_id
+    paper_id = view.paper.id
     cleaned = list(dict.fromkeys(n.strip() for n in names if n and n.strip()))
     existing = (
         (
             await session.execute(
                 select(PaperTag).where(
-                    PaperTag.project_id == paper.project_id, PaperTag.name.in_(cleaned or [""])
+                    PaperTag.project_id == project_id, PaperTag.name.in_(cleaned or [""])
                 )
             )
         )
@@ -252,18 +343,18 @@ async def set_paper_tags(session: AsyncSession, paper: Paper, names: list[str]) 
     by_name = {t.name: t for t in existing}
     for name in cleaned:
         if name not in by_name:
-            tag = PaperTag(project_id=paper.project_id, name=name)
+            tag = PaperTag(project_id=project_id, name=name)
             session.add(tag)
             by_name[name] = tag
     await session.flush()
-    await session.execute(delete(paper_tag_links).where(paper_tag_links.c.paper_id == paper.id))
+    await session.execute(delete(paper_tag_links).where(paper_tag_links.c.paper_id == paper_id))
     if cleaned:
         await session.execute(
             insert(paper_tag_links).values(
-                [{"paper_id": paper.id, "tag_id": by_name[n].id} for n in cleaned]
+                [{"paper_id": paper_id, "tag_id": by_name[n].id} for n in cleaned]
             )
         )
-    await prune_orphan_tags(session, project_id=paper.project_id)
+    await prune_orphan_tags(session, project_id=project_id)
     await session.commit()
     return sorted(cleaned)
 
@@ -298,7 +389,7 @@ async def list_project_tags(
 async def upsert_paper_user_meta(
     session: AsyncSession,
     *,
-    paper: Paper,
+    paper: Any,
     user_id: uuid.UUID,
     starred: bool | None = None,
     reading_status: str | None = None,
@@ -323,39 +414,52 @@ async def upsert_paper_user_meta(
     return meta
 
 
-# ---- 删除论文（docs/api-lit.md §8.6） ----
+# ---- 从方向库移除论文（docs/api-lit.md §8.6） ----
+#
+# P4 全局内容池语义：删除 = 删本方向的成员行与项目侧挂件（笔记/划线/标签关联）；
+# 内容池 Paper 行与磁盘文件（PDF/全文/图）永不删除（可能被其他方向复用）。
 
 
-def _remove_paper_files(paper: Paper) -> None:
-    """尽力清理论文落盘文件（PDF / 全文 / 图片目录）；失败只记日志。"""
-    import shutil
-
-    from app.services.literature.pdf_extract import figures_dir
-
-    for raw in (paper.pdf_path, paper.full_text_path):
-        if not raw:
-            continue
-        try:
-            Path(raw).unlink(missing_ok=True)
-        except OSError:
-            logger.warning("failed to remove paper file %s", raw, exc_info=True)
-    try:
-        fig_dir = figures_dir(str(paper.id)).parent  # <data_dir>/papers/<paper_id>/
-        if fig_dir.exists():
-            shutil.rmtree(fig_dir, ignore_errors=True)
-    except OSError:
-        logger.warning("failed to remove figures dir for %s", paper.id, exc_info=True)
-
-
-async def delete_paper(session: AsyncSession, paper: Paper) -> None:
-    """删除一篇论文：清理落盘文件 + 删行（分段/笔记/标签/概念关联 FK 级联）。
-
-    收尾清理项目内零引用标签（失去最后一篇论文的标签不残留）。
-    """
-    project_id = paper.project_id
-    _remove_paper_files(paper)
-    await session.delete(paper)
+async def _delete_membership_rows(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    memberships: Sequence[LibraryPaper],
+) -> None:
+    """硬删成员行 + 本项目挂在这些论文上的笔记/划线/标签关联（不 commit）。"""
+    paper_ids = [m.paper_id for m in memberships]
+    if not paper_ids:
+        return
+    await session.execute(
+        delete(PaperNote).where(
+            PaperNote.paper_id.in_(paper_ids), PaperNote.project_id == project_id
+        )
+    )
+    await session.execute(
+        delete(PaperHighlight).where(
+            PaperHighlight.paper_id.in_(paper_ids), PaperHighlight.project_id == project_id
+        )
+    )
+    project_tag_ids = select(PaperTag.id).where(PaperTag.project_id == project_id)
+    await session.execute(
+        delete(paper_tag_links).where(
+            paper_tag_links.c.paper_id.in_(paper_ids),
+            paper_tag_links.c.tag_id.in_(project_tag_ids),
+        )
+    )
+    for membership in memberships:
+        await session.delete(membership)
     await session.flush()
+
+
+async def delete_paper(session: AsyncSession, view: PaperView) -> None:
+    """从当前方向库彻底移除一篇论文（垃圾桶里的「彻底删除」）。
+
+    删成员行与本项目的笔记/划线/标签关联；收尾清理项目内零引用标签。
+    内容池行与落盘文件保留（其他方向可复用）。
+    """
+    project_id = view.project_id
+    await _delete_membership_rows(session, project_id=project_id, memberships=[view.membership])
     await prune_orphan_tags(session, project_id=project_id)
     await session.commit()
 
@@ -367,80 +471,83 @@ async def delete_papers(
     paper_ids: list[uuid.UUID],
     hard: bool = False,
 ) -> int:
-    """批量删除项目内论文（非本项目的 id 忽略），返回处理数。
+    """批量删除项目库内论文（非本库的 id 忽略），返回处理数。
 
-    默认软删（移入垃圾桶 = status excluded，可召回）；hard=True 彻底删除（清文件+删行）。
+    默认软删（移入垃圾桶 = 成员行 status excluded，可召回）；hard=True 删成员行。
     """
-    papers = (
+    library = await get_library_for_project(session, project_id)
+    memberships = (
         (
             await session.execute(
-                select(Paper).where(Paper.project_id == project_id, Paper.id.in_(paper_ids))
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == library.id, LibraryPaper.paper_id.in_(paper_ids)
+                )
             )
         )
         .scalars()
         .all()
     )
-    for paper in papers:
-        if hard:
-            _remove_paper_files(paper)
-            await session.delete(paper)
-        else:
-            paper.status = "excluded"
-            paper.trash_reason = "manual"
-    if hard and papers:
-        # 硬删后收尾：paper_tag_links 已随外键级联删除，清掉失去全部引用的标签
-        await session.flush()
+    if hard:
+        await _delete_membership_rows(session, project_id=project_id, memberships=memberships)
         await prune_orphan_tags(session, project_id=project_id)
+    else:
+        for membership in memberships:
+            membership.status = "excluded"
+            membership.trash_reason = "manual"
     await session.commit()
-    return len(papers)
+    return len(memberships)
 
 
-def restore_status_of(paper: Paper) -> str:
+def restore_status_of(membership: LibraryPaper) -> str:
     """垃圾桶召回后的状态：已编译回 compiled；打过分回 scored；否则按人工精选处理。"""
-    if paper.wiki_content:
+    if membership.wiki_content:
         return "compiled"
-    if paper.relevance_score is not None:
+    if membership.relevance_score is not None:
         return "scored"
     return "included"
 
 
-async def restore_paper(session: AsyncSession, paper: Paper) -> Paper:
+async def restore_paper(session: AsyncSession, view: PaperView) -> PaperView:
     """从垃圾桶召回（docs/api-lit.md §8.6）。"""
-    paper.status = restore_status_of(paper)
-    paper.trash_reason = None
+    view.membership.status = restore_status_of(view.membership)
+    view.membership.trash_reason = None
     await session.commit()
-    await session.refresh(paper)
-    return paper
+    await session.refresh(view.membership)
+    return view
 
 
 async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
-    """清空垃圾桶：彻底删除项目内全部 excluded 论文（清文件 + 删行），返回删除数。"""
-    papers = (
+    """清空垃圾桶：彻底移除库内全部 excluded 成员行，返回删除数。"""
+    library = await get_library_for_project(session, project_id)
+    memberships = (
         (
             await session.execute(
-                select(Paper).where(Paper.project_id == project_id, Paper.status == "excluded")
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == library.id, LibraryPaper.status == "excluded"
+                )
             )
         )
         .scalars()
         .all()
     )
-    for paper in papers:
-        _remove_paper_files(paper)
-        await session.delete(paper)
-    if papers:
-        await session.flush()
+    if memberships:
+        await _delete_membership_rows(session, project_id=project_id, memberships=memberships)
         await prune_orphan_tags(session, project_id=project_id)
     await session.commit()
-    return len(papers)
+    return len(memberships)
 
 
 # ---- PDF 按需补下（docs/api-lit.md §1） ----
 
 
 async def fetch_pdf(
-    session: AsyncSession, paper: Paper, *, user_id: uuid.UUID | None = None
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
 ) -> Paper:
-    """按需补下 PDF + 抽全文；已有 PDF 文件时幂等直接返回。
+    """按需补下 PDF + 抽全文；已有 PDF 文件时幂等直接返回（只动内容池本体字段）。
 
     - 无 arxiv_id → PdfSourceUnsupportedError（路由映射 400）
     - 下载失败 → PdfFetchFailedError（路由映射 502）
@@ -479,7 +586,9 @@ async def fetch_pdf(
         from app.core.llm.router import get_llm_router
         from app.services.affiliations import extract_affiliations_llm
 
-        affs = await extract_affiliations_llm(paper, llm=get_llm_router(), user_id=user_id)
+        affs = await extract_affiliations_llm(
+            paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+        )
         if affs:
             paper.affiliations = affs
     await session.commit()
@@ -490,7 +599,7 @@ async def fetch_pdf(
 # ---- AI 伴读上下文（docs/api-lit.md §3） ----
 
 
-def build_chat_context(paper: Paper) -> str:
+def build_chat_context(paper: PaperView) -> str:
     """伴读上下文：优先 full_text（超长头尾各留一半），否则 wiki_content，否则 abstract。"""
     if paper.full_text_path and Path(paper.full_text_path).exists():
         text_ = Path(paper.full_text_path).read_text(encoding="utf-8", errors="ignore")
@@ -525,7 +634,7 @@ CHAT_REFERENCES_SUFFIX = """
 
 
 def build_chat_messages(
-    paper: Paper,
+    paper: PaperView,
     *,
     question: str,
     history: Sequence[tuple[str, str]] = (),
@@ -548,11 +657,12 @@ def build_chat_messages(
 
 async def keyword_search_papers(
     session: AsyncSession, *, project_id: uuid.UUID, q: str, limit: int
-) -> list[tuple[Paper, float]]:
-    """关键词检索：title/abstract/wiki_content/笔记内容 ilike，按命中位置给启发式分。
+) -> list[tuple[PaperView, float]]:
+    """关键词检索：title/abstract/库版 wiki/笔记内容 ilike，按命中位置给启发式分。
 
     只检索库内文献（相关性达标）：已删除（excluded）/未筛选（candidate）不出现。
     """
+    library = await get_library_for_project(session, project_id)
     pattern = f"%{q}%"
     note_hit = Paper.id.in_(
         select(PaperNote.paper_id).where(
@@ -560,20 +670,19 @@ async def keyword_search_papers(
         )
     )
     stmt = (
-        select(Paper)
+        member_paper_stmt(library.id)
         .where(
-            Paper.status.in_(PAPER_STATUS_GROUPS["library"]),
-            Paper.project_id == project_id,
+            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
             or_(
                 Paper.title.ilike(pattern),
                 Paper.abstract.ilike(pattern),
-                Paper.wiki_content.ilike(pattern),
+                LibraryPaper.wiki_content.ilike(pattern),
                 note_hit,
             ),
         )
         .limit(limit * 3)
     )
-    papers = (await session.execute(stmt)).scalars().all()
+    rows = (await session.execute(stmt)).all()
     needle = q.lower()
 
     def score_of(p: Paper) -> float:
@@ -583,16 +692,20 @@ async def keyword_search_papers(
             return 0.7
         return 0.5  # wiki_content / 笔记命中
 
-    ranked = sorted(((p, score_of(p)) for p in papers), key=lambda x: -x[1])
+    ranked = sorted(
+        ((PaperView(paper, membership, project_id), score_of(paper)) for paper, membership in rows),
+        key=lambda x: -x[1],
+    )
     return ranked[:limit]
 
 
 async def keyword_search_concepts(
     session: AsyncSession, *, project_id: uuid.UUID, q: str, limit: int
 ) -> list[tuple[Concept, float]]:
+    library = await get_library_for_project(session, project_id)
     stmt = (
         select(Concept)
-        .where(Concept.project_id == project_id, Concept.name.ilike(f"%{q}%"))
+        .where(Concept.library_id == library.id, Concept.name.ilike(f"%{q}%"))
         .order_by(Concept.name)
         .limit(limit)
     )
@@ -605,32 +718,36 @@ def semantic_search_supported(session: AsyncSession) -> bool:
 
 async def semantic_search_papers(
     session: AsyncSession, *, project_id: uuid.UUID, query_vector: list[float], limit: int
-) -> list[tuple[Paper, float]]:
+) -> list[tuple[PaperView, float]]:
     """pgvector 余弦检索（仅 postgres；调用方需先判 semantic_search_supported）。"""
+    library = await get_library_for_project(session, project_id)
     qv = json.dumps(query_vector)
     rows = (
         await session.execute(
             text(
-                "SELECT id, 1 - (embedding <=> CAST(:qv AS vector)) AS score "
-                "FROM papers "
-                "WHERE project_id = :pid AND embedding IS NOT NULL "
-                "ORDER BY embedding <=> CAST(:qv AS vector) "
+                "SELECT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM papers p "
+                "JOIN library_papers lp ON lp.paper_id = p.id AND lp.library_id = :lib "
+                "WHERE p.embedding IS NOT NULL "
+                "ORDER BY p.embedding <=> CAST(:qv AS vector) "
                 "LIMIT :k"
             ),
-            {"qv": qv, "pid": str(project_id), "k": limit},
+            {"qv": qv, "lib": str(library.id), "k": limit},
         )
     ).all()
     if not rows:
         return []
     scores = {row.id: float(row.score) for row in rows}
-    papers = (
-        (await session.execute(select(Paper).where(Paper.id.in_(list(scores))))).scalars().all()
-    )
-    by_id = {p.id: p for p in papers}
-    return [(by_id[pid], scores[pid]) for pid, _ in ((r.id, r.score) for r in rows) if pid in by_id]
+    pairs = (
+        await session.execute(
+            member_paper_stmt(library.id).where(Paper.id.in_(list(scores)))
+        )
+    ).all()
+    by_id = {p.id: PaperView(p, m, project_id) for p, m in pairs}
+    return [(by_id[pid], scores[pid]) for pid in (r.id for r in rows) if pid in by_id]
 
 
-def rerank_document_of(paper: Paper) -> str:
+def rerank_document_of(paper: Any) -> str:
     """重排送审文本：title + abstract，截断 RERANK_DOC_CHARS 字。"""
     text_ = paper.title or ""
     if paper.abstract:
@@ -642,11 +759,11 @@ async def rerank_paper_rows(
     llm_router: LLMRouter,
     *,
     query: str,
-    rows: list[tuple[Paper, float]],
+    rows: list[tuple[PaperView, float]],
     limit: int,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
-) -> tuple[list[tuple[Paper, float]], bool]:
+) -> tuple[list[tuple[PaperView, float]], bool]:
     """对向量召回结果做 rerank，返回 (top limit 结果, 是否重排成功)。
 
     rerank 未配置（NotImplementedError）或调用异常时降级：按原向量分取前 limit。

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -60,6 +60,10 @@ async def create_project(
     session.add(project)
     await session.flush()
     session.add(ProjectMember(project_id=project.id, user_id=owner_id, role="owner"))
+    # P4 过渡期：每个方向 1:1 一个隐式文献库（论文归属经 library_papers 引用内容池）
+    from app.services.libraries import implicit_library_for
+
+    session.add(implicit_library_for(project))
     await session.commit()
     await session.refresh(project)
     return project

--- a/src/backend/app/services/publications.py
+++ b/src/backend/app/services/publications.py
@@ -5,7 +5,6 @@
 所有库内候选都要经用户确认（pending → confirmed | rejected）。
 """
 
-import hashlib
 import logging
 import re
 import uuid
@@ -18,6 +17,7 @@ from app.models.base import utcnow
 from app.models.paper import Paper
 from app.models.project import ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
+from app.services.dedup import dedup_key_for as shared_dedup_key_for
 from app.services.paper_import import (
     ParseFailedError,
     _fields_from_arxiv,
@@ -28,21 +28,17 @@ from app.services.paper_import import (
 logger = logging.getLogger(__name__)
 
 
-def _normalize_title(title: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
-
-
 def _normalize_name(name: str) -> str:
     return re.sub(r"[^a-z一-鿿0-9]+", " ", name.lower()).strip()
 
 
 def dedup_key_for(*, doi: str | None, arxiv_id: str | None, title: str) -> str:
-    """去重键：doi → arxiv → 规范化标题 sha1（优先级递减）。"""
-    if doi:
-        return f"doi:{doi.lower()}"
-    if arxiv_id:
-        return f"arxiv:{arxiv_id.lower()}"
-    return f"title:{hashlib.sha1(_normalize_title(title).encode()).hexdigest()}"
+    """去重键：doi → arxiv → 规范化标题 sha1（历史键 doi 优先，顺序不可改）。"""
+    key = shared_dedup_key_for(
+        doi=doi, arxiv_id=arxiv_id, title=title, priority=("doi", "arxiv", "title")
+    )
+    assert key is not None  # title 非空
+    return key
 
 
 # ---- 作者身份绑定 ----

--- a/src/backend/app/services/publications.py
+++ b/src/backend/app/services/publications.py
@@ -14,6 +14,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import utcnow
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper
 from app.models.project import ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
@@ -141,8 +142,11 @@ async def match_from_library(session: AsyncSession, *, user_id: uuid.UUID) -> in
         return 0
     stmt = (
         select(Paper)
-        .join(ProjectMember, ProjectMember.project_id == Paper.project_id)
-        .where(ProjectMember.user_id == user_id, Paper.status != "excluded")
+        .distinct()
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
+        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
+        .where(ProjectMember.user_id == user_id, LibraryPaper.status != "excluded")
     )
     papers = (await session.execute(stmt)).scalars().all()
     seen = await _existing_dedup_keys(session, user_id)

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -1,8 +1,8 @@
 """单篇文献相关性打分（LLM stage=relevance）。
 
 voyage 的 wiki.score_relevance 动作与手动添加端点共用：按项目 definition 组
-context（稀疏容忍）→ 调 LLM → 解析 → 写 relevance_score/tldr/scored_at。
-本模块不改 Paper.status、不 commit——状态转移与落库时机由调用方决定。
+context（稀疏容忍）→ 调 LLM → 解析 → 写成员行 relevance_score/scored_at 与论文 tldr。
+本模块不改成员行 status、不 commit——状态转移与落库时机由调用方决定。
 """
 
 import json
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter, get_llm_router
 from app.models.base import utcnow
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.project import Project
 
@@ -59,16 +60,18 @@ def build_relevance_context(project: Project) -> str:
 
 async def score_paper_relevance(
     paper: Paper,
+    membership: LibraryPaper,
     *,
     context_text: str,
     llm: LLMRouter | None = None,
     extra_guidance: str = "",
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> RelevanceResult:
-    """对一篇论文打相关性分并写 relevance_score/tldr/scored_at 字段。
+    """对一篇论文打相关性分：写成员行 relevance_score/scored_at 与论文 tldr。
 
-    不改 status、不 commit（由调用方决定状态转移与落库时机）。
+    不改成员行 status、不 commit（由调用方决定状态转移与落库时机）。
     extra_guidance：追加到 system prompt 的补充指引（voyage 技能注入点用）。
     """
     llm = llm or get_llm_router()
@@ -80,34 +83,37 @@ async def score_paper_relevance(
             Message(role="user", content=user_prompt),
         ],
         user_id=user_id,
-        project_id=paper.project_id,
+        project_id=project_id,
         voyage_id=voyage_id,
     )
     data = _extract_json(result.content)
     score = min(1.0, max(0.0, float(data["score"])))
-    paper.relevance_score = score
+    membership.relevance_score = score
     paper.tldr = str(data.get("tldr") or "") or paper.tldr
-    paper.scored_at = utcnow()
+    membership.scored_at = utcnow()
     return RelevanceResult(score=score, reason=str(data.get("reason") or ""), tldr=paper.tldr or "")
 
 
 async def score_added_paper_best_effort(
     session: AsyncSession,
     paper: Paper,
+    membership: LibraryPaper,
     project: Project,
     *,
     user_id: uuid.UUID | None = None,
 ) -> None:
     """手动添加后的顺带打分（best-effort）：成功则 commit 分数，失败只记 warning。
 
-    不改 status（手动添加 = 人工纳入，分低也保持 included）；LLM 失败/超时时
+    不改成员行 status（手动添加 = 人工纳入，分低也保持 included）；LLM 失败/超时时
     回滚未落库的字段改动，论文本身照常保留。
     """
     try:
         await score_paper_relevance(
             paper,
+            membership,
             context_text=build_relevance_context(project),
             user_id=user_id,
+            project_id=project.id,
         )
         await session.commit()
     except Exception:  # noqa: BLE001 — 顺带增值，失败不影响添加本身

--- a/src/backend/app/services/search.py
+++ b/src/backend/app/services/search.py
@@ -11,10 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.experiment import Experiment
 from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript
 from app.models.paper import Concept, Paper
 from app.models.voyage import VoyageRun
 from app.schemas.search import GlobalSearchHit
+from app.services.libraries import get_library_for_project
 
 _SNIPPET_CHARS = 120
 
@@ -35,36 +37,34 @@ async def global_search(
 ) -> list[GlobalSearchHit]:
     pattern = f"%{q}%"
     hits: list[GlobalSearchHit] = []
+    library = await get_library_for_project(session, project_id)
 
-    papers = (
-        (
-            await session.execute(
-                select(Paper)
-                .where(
-                    Paper.project_id == project_id,
-                    Paper.status != "excluded",  # 回收站不出现在搜索里
-                    or_(
-                        Paper.title.ilike(pattern),
-                        Paper.abstract.ilike(pattern),
-                        Paper.tldr.ilike(pattern),
-                    ),
-                )
-                .order_by(Paper.updated_at.desc())
-                .limit(limit_per_type)
+    paper_rows = (
+        await session.execute(
+            select(Paper, LibraryPaper.status)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(
+                LibraryPaper.library_id == library.id,
+                LibraryPaper.status != "excluded",  # 回收站不出现在搜索里
+                or_(
+                    Paper.title.ilike(pattern),
+                    Paper.abstract.ilike(pattern),
+                    Paper.tldr.ilike(pattern),
+                ),
             )
+            .order_by(Paper.updated_at.desc())
+            .limit(limit_per_type)
         )
-        .scalars()
-        .all()
-    )
+    ).all()
     hits += [
         GlobalSearchHit(
             type="paper",
             id=p.id,
             title=p.title,
             snippet=_snippet(p.tldr or p.abstract),
-            status=p.status,
+            status=status,
         )
-        for p in papers
+        for p, status in paper_rows
     ]
 
     concepts = (
@@ -72,7 +72,7 @@ async def global_search(
             await session.execute(
                 select(Concept)
                 .where(
-                    Concept.project_id == project_id,
+                    Concept.library_id == library.id,
                     or_(Concept.name.ilike(pattern), Concept.definition.ilike(pattern)),
                 )
                 .order_by(Concept.updated_at.desc())

--- a/src/backend/app/services/stats.py
+++ b/src/backend/app/services/stats.py
@@ -11,8 +11,9 @@ from app.models.activity import Activity
 from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment
 from app.models.gate import Gate
 from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript
-from app.models.paper import Paper
+from app.services.libraries import get_library_for_project
 from app.services.papers import PAPER_STATUS_GROUPS
 
 
@@ -24,14 +25,18 @@ async def project_stats(session: AsyncSession, project_id: uuid.UUID) -> dict[st
     today_start = datetime.combine(datetime.now(UTC).date(), time.min, tzinfo=UTC)
     # 「知识库论文」与文献页口径一致：只算库内（相关性达标及之后），
     # 不含回收站（excluded）与尚未打分的中间状态（candidate）
-    in_library = Paper.status.in_(PAPER_STATUS_GROUPS["library"])
+    library = await get_library_for_project(session, project_id)
+    in_library = LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"])
     papers_total = await _count(
-        session, select(func.count()).where(Paper.project_id == project_id, in_library)
+        session,
+        select(func.count()).where(LibraryPaper.library_id == library.id, in_library),
     )
     papers_today = await _count(
         session,
         select(func.count()).where(
-            Paper.project_id == project_id, in_library, Paper.created_at >= today_start
+            LibraryPaper.library_id == library.id,
+            in_library,
+            LibraryPaper.created_at >= today_start,
         ),
     )
     ideas_candidate = await _count(

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -1,7 +1,5 @@
 """个人文献库：浏览记录 upsert、收藏、列表检索（用户级，方向无关）。"""
 
-import hashlib
-import re
 import uuid
 from typing import cast
 
@@ -13,23 +11,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.base import utcnow
 from app.models.library import UserLibraryEntry
 from app.models.paper import Paper
+from app.services.dedup import dedup_key_for
 
 LIBRARY_SORTS = ("recent", "title", "visits")
 LIBRARY_TABS = ("saved", "history")
 
 
-def _normalize_title(title: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
-
-
 def dedup_key_for_paper(paper: Paper) -> str:
-    """跨方向去重键：arxiv → doi → 规范化标题 sha1（优先级递减）。"""
-    if paper.arxiv_id:
-        return f"arxiv:{paper.arxiv_id.lower()}"
-    if paper.doi:
-        return f"doi:{paper.doi.lower()}"
-    digest = hashlib.sha1(_normalize_title(paper.title).encode()).hexdigest()
-    return f"title:{digest}"
+    """跨方向去重键：arxiv → doi → 规范化标题 sha1（优先级递减，纯标题口径兼容存量键）。"""
+    key = dedup_key_for(arxiv_id=paper.arxiv_id, doi=paper.doi, title=paper.title)
+    assert key is not None  # Paper.title 非空
+    return key
 
 
 def _snapshot_fields(paper: Paper) -> dict:

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -27,6 +27,7 @@ from app.services.figure_annotate import (
     important_figures_with_bytes,
 )
 from app.services.literature.pdf_extract import extract_figures
+from app.services.papers import PaperView
 
 FULLTEXT_PROMPT_CHARS = 24000
 
@@ -134,6 +135,7 @@ async def compile_paper(
     statement: str,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
     extra_guidance: str = "",
 ) -> CompiledWiki:
@@ -165,7 +167,7 @@ async def compile_paper(
             ],
             images=images or None,
             user_id=user_id,
-            project_id=paper.project_id,
+            project_id=project_id,
             voyage_id=voyage_id,
         )
         if not result.content.strip():
@@ -180,18 +182,21 @@ async def compile_paper(
 
 async def recompile_paper(
     session: AsyncSession,
-    paper: Paper,
+    view: PaperView,
     *,
     user_id: uuid.UUID | None = None,
-) -> Paper:
-    """重跑筛选注释 + 图文编译，覆盖 wiki_content 并落库（docs/api-lit.md §6.6）。
+) -> PaperView:
+    """重跑筛选注释 + 图文编译，覆盖成员行 wiki_content 并落库（docs/api-lit.md §6.6）。
 
     无 PDF 时跳过图片、仅重写文字；status：scored/fetched 升为 compiled，其余不动。
     """
     llm = get_llm_router()
-    project = await session.get(Project, paper.project_id)
+    paper = view.paper
+    membership = view.membership
+    project = await session.get(Project, view.project_id) if view.project_id else None
     definition = project.definition if project and isinstance(project.definition, dict) else {}
     statement = definition.get("statement") or (project.name if project else paper.title)
+    project_id = view.project_id
 
     if paper.pdf_path and Path(paper.pdf_path).exists():
         # 从未提取过，或上一轮一张重要图都没选出来（多为旧提取逻辑漏掉矢量图）→ 重提候选
@@ -201,16 +206,22 @@ async def recompile_paper(
                 c | {"caption": None, "kind": None, "important": False} for c in candidates
             ]
         if paper.figures:
-            await annotate_figures(paper, paper.figures, llm=llm, user_id=user_id)
+            await annotate_figures(
+                paper, paper.figures, llm=llm, user_id=user_id, project_id=project_id
+            )
         await session.commit()
 
-    compiled = await compile_paper(paper, statement=statement, llm=llm, user_id=user_id)
-    paper.wiki_content = compiled.content
-    paper.compiled_at = utcnow()
-    paper.compiled_model = compiled.model or None
-    if paper.status in ("scored", "fetched"):
-        paper.status = "compiled"
+    compiled = await compile_paper(
+        paper, statement=statement, llm=llm, user_id=user_id, project_id=project_id
+    )
+    membership.wiki_content = compiled.content
+    membership.compiled_at = utcnow()
+    membership.compiled_model = compiled.model or None
+    if membership.status in ("scored", "fetched"):
+        membership.status = "compiled"
     await session.commit()
     # 单篇概念上链：新介绍里的 [[双链]] 建词条并关联（否则点击提示"概念尚未入库"）
-    await link_paper_concepts(session, paper, llm=llm, user_id=user_id)
-    return paper
+    await link_paper_concepts(
+        session, paper, membership, llm=llm, user_id=user_id, project_id=project_id
+    )
+    return view

--- a/src/backend/app/services/wiki_export.py
+++ b/src/backend/app/services/wiki_export.py
@@ -21,10 +21,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, PaperNote
 from app.models.project import Project
 from app.models.user import User
 from app.services.concepts import wiki_slug
+from app.services.libraries import get_library_for_project
 from app.services.literature.pdf_extract import figure_path
 from app.services.notes import author_name_of
 from app.services.wiki_compile import FIGURE_MARKER_RE
@@ -99,26 +101,26 @@ def _inline_paper_figures(
 
 
 async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
-    papers = (
-        (
-            await session.execute(
-                select(Paper)
-                .where(
-                    Paper.project_id == project.id,
-                    Paper.status.in_(("compiled", "included")),
-                )
-                .options(selectinload(Paper.concepts))
-                .order_by(Paper.relevance_score.desc().nulls_last())
+    library = await get_library_for_project(session, project.id)
+    paper_rows = (
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(
+                LibraryPaper.library_id == library.id,
+                LibraryPaper.status.in_(("compiled", "included")),
             )
+            .options(selectinload(Paper.concepts))
+            .order_by(LibraryPaper.relevance_score.desc().nulls_last())
         )
-        .scalars()
-        .all()
-    )
+    ).all()
+    papers = [p for p, _ in paper_rows]
+    membership_of = {p.id: m for p, m in paper_rows}
     concepts = (
         (
             await session.execute(
                 select(Concept)
-                .where(Concept.project_id == project.id)
+                .where(Concept.library_id == library.id)
                 .options(selectinload(Concept.papers))
                 .order_by(Concept.name)
             )
@@ -156,17 +158,18 @@ async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
 
         # papers/<slug>.md
         for slug, paper in paper_entries:
+            membership = membership_of[paper.id]
             fm = _frontmatter(
                 {
                     "title": paper.title,
                     "arxiv_id": paper.arxiv_id,
                     "year": paper.year,
-                    "relevance": paper.relevance_score,
-                    "status": paper.status,
+                    "relevance": membership.relevance_score,
+                    "status": membership.status,
                     "concepts": [c.name for c in paper.concepts],
                 }
             )
-            body = paper.wiki_content or (paper.abstract or "（尚未编译 wiki 页）")
+            body = membership.wiki_content or (paper.abstract or "（尚未编译 wiki 页）")
             if paper.figures:
                 body, extra_figure_lines = _inline_paper_figures(zf, paper, slug, body)
                 if extra_figure_lines:

--- a/src/backend/app/tools/external.py
+++ b/src/backend/app/tools/external.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper
+from app.services.libraries import membership_for_project
 from app.services.literature import get_openalex_client, get_s2_client
 from app.tools.context import ToolContext
 from app.tools.registry import tool
@@ -86,7 +87,9 @@ async def _resolve_ref(ctx: ToolContext, args: dict[str, Any]) -> str:
         raise ValueError(f"paper_id 不是合法 uuid：{raw}") from e
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, pid)
-        if paper is None or paper.project_id != ctx.project_id:
+        if paper is None or (
+            await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+        ) is None:
             raise ValueError(f"库内不存在该论文：{raw}")
         if paper.arxiv_id:
             return f"arXiv:{paper.arxiv_id}"

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -22,6 +22,7 @@ from app.services import citations as citations_service
 from app.services import concepts as concepts_service
 from app.services import highlights as highlights_service
 from app.services import notes as notes_service
+from app.services.libraries import membership_for_project
 from app.services.literature.pdf_extract import figure_path
 from app.tools.context import ToolContext
 from app.tools.literature import search_papers as _search_papers
@@ -41,7 +42,12 @@ async def _project_paper(
         raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
     opts = [selectinload(Paper.concepts)] if with_concepts else None
     paper = await session.get(Paper, pid, options=opts)
-    if paper is None or paper.project_id != ctx.project_id:
+    membership = (
+        await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+        if paper is not None
+        else None
+    )
+    if paper is None or membership is None:
         raise ValueError(f"库内不存在该论文：{raw_id}")
     return paper
 
@@ -218,7 +224,9 @@ async def find_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
     async with get_sessionmaker()() as session:
         for pid in paper_ids:
             paper = await session.get(Paper, pid)
-            if paper is None or paper.project_id != ctx.project_id:
+            if paper is None or (
+                await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+            ) is None:
                 continue
             for fig in paper.figures or []:
                 if not fig.get("important"):

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -13,6 +13,7 @@ from app.models.paper import Paper, PaperChunk
 from app.services import chunks as chunks_service
 from app.services import graph as graph_service
 from app.services import search as search_service
+from app.services.libraries import get_library_for_project, membership_for_project
 from app.tools.context import ToolContext
 from app.tools.registry import tool
 
@@ -40,6 +41,7 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     k = min(_MAX_K, max(1, int(args.get("k") or 6)))
 
     async with get_sessionmaker()() as session:
+        library = await get_library_for_project(session, ctx.project_id)
         rows: list[tuple[PaperChunk, float]] = []
         used_mode = "keyword"
         if chunks_service.chunk_vector_search_supported(session):
@@ -51,14 +53,14 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                     voyage_id=ctx.voyage_id,
                 )
                 rows = await chunks_service.semantic_search_chunks(
-                    session, project_id=ctx.project_id, query_vector=vectors[0], limit=k
+                    session, library_id=library.id, query_vector=vectors[0], limit=k
                 )
                 used_mode = "semantic"
             except NotImplementedError:
                 rows = []
         if not rows:
             rows = await chunks_service.keyword_search_chunks(
-                session, project_id=ctx.project_id, q=query, limit=k
+                session, library_id=library.id, q=query, limit=k
             )
             used_mode = used_mode if rows and used_mode == "semantic" else "keyword"
 
@@ -104,11 +106,16 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         stmt = (
             select(Paper)
-            .where(Paper.id == paper_id, Paper.project_id == ctx.project_id)
+            .where(Paper.id == paper_id)
             .options(selectinload(Paper.concepts))
         )
         paper = (await session.execute(stmt)).scalar_one_or_none()
-        if paper is None:
+        membership = (
+            await membership_for_project(session, project_id=ctx.project_id, paper_id=paper_id)
+            if paper is not None
+            else None
+        )
+        if paper is None or membership is None:
             raise ValueError(f"库内不存在该论文：{args.get('paper_id')}")
         authors = [a.get("name") for a in (paper.authors or []) if isinstance(a, dict)]
         return {
@@ -120,11 +127,11 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
             "arxiv_id": paper.arxiv_id,
             "doi": paper.doi,
             "url": paper.url,
-            "status": paper.status,
+            "status": membership.status,
             "tldr": paper.tldr,
             "abstract": (paper.abstract or "")[:2000] or None,
             "concepts": [c.name for c in paper.concepts],
-            "has_wiki": bool(paper.wiki_content),
+            "has_wiki": bool(membership.wiki_content),
             "has_fulltext": bool(paper.full_text_path),
         }
 

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -16,7 +16,9 @@ from app.core.db import get_sessionmaker
 from app.models.paper import Concept, Paper
 from app.services import concepts as concepts_service
 from app.services import papers as papers_service
+from app.services.libraries import get_library_for_project, membership_for_project
 from app.services.paper_review import relevant_excerpt
+from app.services.papers import PaperView
 from app.tools.context import ToolContext
 from app.tools.registry import tool
 
@@ -36,7 +38,7 @@ _CONCEPT_CATEGORIES = [
 ]
 
 
-def _paper_brief(paper: Paper, score: float | None = None) -> dict[str, Any]:
+def _paper_brief(paper: PaperView, score: float | None = None) -> dict[str, Any]:
     brief: dict[str, Any] = {
         "paper_id": str(paper.id),
         "title": paper.title,
@@ -50,15 +52,20 @@ def _paper_brief(paper: Paper, score: float | None = None) -> dict[str, Any]:
     return brief
 
 
-async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> Paper:
+async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> PaperView:
     try:
         paper_id = uuid.UUID(str(raw_id))
     except ValueError as e:
         raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
     paper = await session.get(Paper, paper_id)
-    if paper is None or paper.project_id != ctx.project_id:
+    membership = (
+        await membership_for_project(session, project_id=ctx.project_id, paper_id=paper_id)
+        if paper is not None
+        else None
+    )
+    if paper is None or membership is None:
         raise ValueError(f"库内不存在该论文：{raw_id}")
-    return paper
+    return PaperView(paper, membership, ctx.project_id)
 
 
 @tool(
@@ -210,12 +217,13 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     if not name:
         raise ValueError("get_concept 需要非空 name")
     async with get_sessionmaker()() as session:
-        stmt = select(Concept).where(Concept.project_id == ctx.project_id, Concept.name.ilike(name))
+        library = await get_library_for_project(session, ctx.project_id)
+        stmt = select(Concept).where(Concept.library_id == library.id, Concept.name.ilike(name))
         concept = (await session.execute(stmt)).scalars().first()
         if concept is None:  # 精确不中再模糊
             stmt = (
                 select(Concept)
-                .where(Concept.project_id == ctx.project_id, Concept.name.ilike(f"%{name}%"))
+                .where(Concept.library_id == library.id, Concept.name.ilike(f"%{name}%"))
                 .order_by(Concept.name)
             )
             concept = (await session.execute(stmt)).scalars().first()
@@ -249,8 +257,9 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 async def list_concepts(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     category = str(args.get("category") or "").strip() or None
     async with get_sessionmaker()() as session:
+        library = await get_library_for_project(session, ctx.project_id)
         rows = await concepts_service.list_concepts(
-            session, project_id=ctx.project_id, category=category
+            session, library_id=library.id, category=category
         )
     return {
         "concepts": [

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -101,6 +101,112 @@ async def fake_redis(app):
 
 INVITE_CODE = "test-invite"
 
+# ---- P4 内容池造数据助手 ----
+
+# 判断字段落 library_papers 成员行（其余入 Paper 内容池行）
+_MEMBERSHIP_FIELDS = (
+    "relevance_score",
+    "wiki_content",
+    "status",
+    "trash_reason",
+    "scored_at",
+    "compiled_at",
+    "compiled_model",
+)
+
+
+async def add_paper(session, *, project_id, **fields):
+    """测试造数据统一入口：建内容池 Paper + 隐式库成员行，返回 Paper。
+
+    兼容旧单表口径：status/relevance_score/wiki_content 等判断字段自动落成员行。
+    """
+    import uuid as _uuid
+
+    from app.models.library_direction import LibraryPaper
+    from app.models.paper import Paper
+    from app.services.libraries import get_library_for_project
+
+    member_kwargs = {k: fields.pop(k) for k in list(fields) if k in _MEMBERSHIP_FIELDS}
+    member_kwargs.setdefault("status", "candidate")
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    paper = Paper(**fields)
+    session.add(paper)
+    await session.flush()
+    session.add(LibraryPaper(library_id=library.id, paper_id=paper.id, **member_kwargs))
+    await session.flush()
+    return paper
+
+
+async def membership_of(session, *, project_id, paper_id):
+    """取论文在某方向隐式库的成员行（断言判断字段用）。"""
+    import uuid as _uuid
+
+    from app.services.libraries import get_library_for_project, get_membership
+
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    return await get_membership(
+        session,
+        library_id=library.id,
+        paper_id=paper_id if isinstance(paper_id, _uuid.UUID) else _uuid.UUID(str(paper_id)),
+    )
+
+
+async def project_paper_rows(session, *, project_id):
+    """某方向隐式库的 (Paper, LibraryPaper) 全量列表（测试断言判断字段用）。"""
+    import uuid as _uuid
+
+    from sqlalchemy import select
+
+    from app.models.library_direction import LibraryPaper
+    from app.models.paper import Paper
+    from app.services.libraries import get_library_for_project
+
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    rows = (
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id == library.id)
+        )
+    ).all()
+    return [(paper, membership) for paper, membership in rows]
+
+
+async def project_concepts(session, *, project_id):
+    """某方向隐式库的概念列表。"""
+    import uuid as _uuid
+
+    from sqlalchemy import select
+
+    from app.models.paper import Concept
+    from app.services.libraries import get_library_for_project
+
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    return list(
+        (
+            await session.execute(select(Concept).where(Concept.library_id == library.id))
+        ).scalars()
+    )
+
+
+async def add_concept(session, *, project_id, **fields):
+    """建方向库概念（旧 Concept(project_id=...) 口径的替代）。"""
+    import uuid as _uuid
+
+    from app.models.paper import Concept
+    from app.services.libraries import get_library_for_project
+
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    concept = Concept(library_id=library.id, **fields)
+    session.add(concept)
+    await session.flush()
+    return concept
+
 
 def _username_from_email(email: str) -> str:
     """从 email 派生一个合法用户名（小写字母/数字/下划线 3-32 位）。"""

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -29,7 +29,7 @@ from app.services.literature import (
     reset_clients,
     set_clients,
 )
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, membership_of, register_and_login
 
 FULL_TEXT = (
     "Great Paper Title\n"
@@ -72,7 +72,7 @@ def _paper(tmp_path, full_text: str | None) -> Paper:
         f = tmp_path / "full.txt"
         f.write_text(full_text, encoding="utf-8")
         txt_path = str(f)
-    return Paper(project_id=uuid.uuid4(), title="Affil Paper", full_text_path=txt_path)
+    return Paper(title="Affil Paper", full_text_path=txt_path)
 
 
 # ---- 服务函数单测（无 DB） ----
@@ -86,7 +86,7 @@ async def test_extract_affiliations_parses_array(tmp_path):
     call = llm.calls[0]
     assert call["stage"] == "librarian"
     assert call["max_tokens"] == _MAX_TOKENS
-    assert call["project_id"] == paper.project_id
+    assert call["project_id"] is None  # stub 未传记账归属
 
 
 async def test_extract_affiliations_truncates_head(tmp_path):
@@ -116,9 +116,7 @@ async def test_extract_affiliations_llm_error_returns_none(tmp_path):
 async def test_extract_affiliations_no_fulltext_returns_none(tmp_path):
     llm = _StubLLM('["Zhejiang University"]')
     assert await extract_affiliations_llm(_paper(tmp_path, None), llm=llm) is None
-    missing = Paper(
-        project_id=uuid.uuid4(), title="T", full_text_path=str(tmp_path / "nope.txt")
-    )
+    missing = Paper(title="T", full_text_path=str(tmp_path / "nope.txt"))
     assert await extract_affiliations_llm(missing, llm=llm) is None
     assert llm.calls == []
 
@@ -153,7 +151,7 @@ async def _setup_scored_paper(
         f.write_text(full_text, encoding="utf-8")
         txt_path = str(f)
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=project_id,
             source="snowball",
             status="scored",
@@ -195,7 +193,11 @@ async def test_fetch_extract_prefers_llm_over_openalex(client, lit_clients, tmp_
     assert not openalex_route.called  # 有全文 → 走 LLM，OpenAlex 不被调
     paper = await _load_paper(paper_id)
     assert paper.affiliations == ["Zhejiang University", "Google DeepMind"]  # fake LLM 数组
-    assert paper.status == "fetched"
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(
+            session, project_id=run.project_id, paper_id=paper_id
+        )
+        assert membership.status == "fetched"
 
 
 async def test_fetch_extract_llm_failure_falls_back_to_openalex(
@@ -261,7 +263,7 @@ async def test_fetch_pdf_backfills_affiliations(client, lit_clients):
     resp = await client.post("/api/projects", json={"name": "affil-proj"}, headers=headers)
     project_id = uuid.UUID(resp.json()["id"])
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=project_id,
             source="manual",
             status="included",

--- a/src/backend/tests/test_citations_export.py
+++ b/src/backend/tests/test_citations_export.py
@@ -4,9 +4,8 @@ import json
 import uuid
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
 from app.services.citations import split_author_name
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def _setup(client):
@@ -16,7 +15,9 @@ async def _setup(client):
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
         pid = uuid.UUID(project_id)
-        p1 = Paper(  # venue 含 Proceedings → inproceedings；与 p2 的 key 冲突（后缀 a）
+        # venue 含 Proceedings → inproceedings；与 p2 的 key 冲突（后缀 a）
+        p1 = await add_paper(
+            session,
             project_id=pid,
             title="The Great Agent Benchmark",
             authors=[{"name": "Alice Smith"}, {"name": "Bob Jones"}],
@@ -26,7 +27,7 @@ async def _setup(client):
             url="https://example.org/one",
             status="included",
         )
-        p2 = Paper(  # 有 venue（期刊）→ article + journal 字段
+        p2 = await add_paper(session,   # 有 venue（期刊）→ article + journal 字段
             project_id=pid,
             title="Great Expectations of LLMs",
             authors=[{"name": "Smith, Alice"}],
@@ -34,7 +35,7 @@ async def _setup(client):
             venue="Nature",
             status="compiled",
         )
-        p3 = Paper(  # 无 venue → misc；arxiv 论文带 eprint；中文名整个作 family
+        p3 = await add_paper(session,   # 无 venue → misc；arxiv 论文带 eprint；中文名整个作 family
             project_id=pid,
             title="Quantum Annealing Survey",
             authors=[{"name": "张三"}],
@@ -42,7 +43,13 @@ async def _setup(client):
             arxiv_id="2501.00042",
             status="included",
         )
-        p4 = Paper(project_id=pid, title="Excluded Paper", year=2020, status="excluded")
+        p4 = await add_paper(
+            session,
+            project_id=pid,
+            title="Excluded Paper",
+            year=2020,
+            status="excluded",
+        )
         session.add_all([p1, p2, p3, p4])
         await session.commit()
         p1_id = str(p1.id)

--- a/src/backend/tests/test_concepts_relink.py
+++ b/src/backend/tests/test_concepts_relink.py
@@ -5,10 +5,10 @@ import uuid
 from sqlalchemy import insert, select
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Concept, Paper, paper_concepts
+from app.models.paper import Paper, paper_concepts
 from app.services.concepts import link_paper_concepts, placeholder_definition
 
-from .conftest import register_and_login
+from .conftest import add_concept, add_paper, membership_of, project_concepts, register_and_login
 
 
 async def _setup(client):
@@ -22,20 +22,20 @@ async def _setup(client):
     async with get_sessionmaker()() as session:
         session.add_all(
             [
-                Paper(
+                await add_paper(session,
                     project_id=pid,
                     title="Paper A",
                     status="compiled",
                     wiki_content="本文提出 [[自我博弈]]，结合 [[强化学习]] 训练。",
                 ),
-                Paper(
+                await add_paper(session,
                     project_id=pid,
                     title="Paper B",
                     status="included",
                     wiki_content="基于 [[强化学习]] 与 [[课程学习]] 的方法。",
                 ),
                 # 未编译 / 无 wiki 内容的不参与
-                Paper(project_id=pid, title="Paper C", status="candidate"),
+                await add_paper(session, project_id=pid, title="Paper C", status="candidate"),
             ]
         )
         await session.commit()
@@ -76,14 +76,14 @@ async def test_relink_backfills_placeholder_definitions(client):
     async with get_sessionmaker()() as session:
         session.add_all(
             [
-                Concept(
+                await add_concept(session,
                     project_id=pid,
                     name="自我博弈",
                     slug="old-x",
                     definition=placeholder_definition("自我博弈"),
                     category="other",
                 ),
-                Concept(
+                await add_concept(session,
                     project_id=pid,
                     name="课程学习",
                     slug="old-y",
@@ -99,17 +99,11 @@ async def test_relink_backfills_placeholder_definitions(client):
     assert resp.json()["concepts_backfilled"] == 2
 
     async with get_sessionmaker()() as session:
-        rows = (
-            (
-                await session.execute(
-                    select(Concept).where(
-                        Concept.project_id == pid, Concept.name.in_(["自我博弈", "课程学习"])
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        )
+        rows = [
+            c
+            for c in await project_concepts(session, project_id=pid)
+            if c.name in ("自我博弈", "课程学习")
+        ]
         assert len(rows) == 2
         for concept in rows:
             assert not concept.definition.endswith("（定义待补充）")
@@ -119,11 +113,10 @@ async def test_relink_backfills_placeholder_definitions(client):
 async def _set_wiki_content(project_id: str, title: str, content) -> uuid.UUID:
     async with get_sessionmaker()() as session:
         paper = (
-            await session.execute(
-                select(Paper).where(Paper.project_id == uuid.UUID(project_id), Paper.title == title)
-            )
+            await session.execute(select(Paper).where(Paper.title == title))
         ).scalar_one()
-        paper.wiki_content = content
+        membership = await membership_of(session, project_id=project_id, paper_id=paper.id)
+        membership.wiki_content = content
         await session.commit()
         return paper.id
 
@@ -157,9 +150,21 @@ async def test_relink_keeps_concepts_referenced_by_trash_papers(client):
     project_id, headers = await _setup(client)
     pid = uuid.UUID(project_id)
     async with get_sessionmaker()() as session:
-        trashed = Paper(project_id=pid, title="Trashed", status="excluded")
-        kept = Concept(project_id=pid, name="回收站概念", slug="trash-c", definition="d")
-        orphan = Concept(project_id=pid, name="孤儿概念", slug="orphan-c", definition="d")
+        trashed = await add_paper(session, project_id=pid, title="Trashed", status="excluded")
+        kept = await add_concept(
+            session,
+            project_id=pid,
+            name="回收站概念",
+            slug="trash-c",
+            definition="d",
+        )
+        orphan = await add_concept(
+            session,
+            project_id=pid,
+            name="孤儿概念",
+            slug="orphan-c",
+            definition="d",
+        )
         session.add_all([trashed, kept, orphan])
         await session.flush()
         await session.execute(
@@ -172,11 +177,7 @@ async def test_relink_keeps_concepts_referenced_by_trash_papers(client):
     assert resp.json()["concepts_removed"] == 1  # 只删孤儿概念
 
     async with get_sessionmaker()() as session:
-        names = (
-            (await session.execute(select(Concept.name).where(Concept.project_id == pid)))
-            .scalars()
-            .all()
-        )
+        names = [c.name for c in await project_concepts(session, project_id=pid)]
     assert "回收站概念" in names and "孤儿概念" not in names
 
 
@@ -190,7 +191,8 @@ async def test_link_paper_concepts_syncs_after_recompile(client):
     )
     async with get_sessionmaker()() as session:
         paper = (await session.execute(select(Paper).where(Paper.id == paper_id))).scalar_one()
-        created, linked = await link_paper_concepts(session, paper)
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        created, linked = await link_paper_concepts(session, paper, membership)
     assert created == 1 and linked == 1  # 新概念（llm=None → 占位定义）
 
     counts = await _concept_counts(client, project_id, headers)
@@ -206,7 +208,8 @@ async def test_link_paper_concepts_empty_content_keeps_links(client):
     paper_id = await _set_wiki_content(project_id, "Paper A", None)
     async with get_sessionmaker()() as session:
         paper = (await session.execute(select(Paper).where(Paper.id == paper_id))).scalar_one()
-        assert await link_paper_concepts(session, paper) == (0, 0)
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        assert await link_paper_concepts(session, paper, membership) == (0, 0)
 
     counts = await _concept_counts(client, project_id, headers)
     assert counts == {"自我博弈": 1, "强化学习": 2, "课程学习": 1}
@@ -233,7 +236,7 @@ async def test_auto_sweep_backfills_placeholders_capped(client):
     # 无引用的占位会被 #65 的孤儿清理直接删除，不走回填。
     async with get_sessionmaker()() as session:
         session.add(
-            Concept(
+            await add_concept(session,
                 project_id=pid,
                 name="强化学习",
                 slug="ph-rl",
@@ -244,16 +247,19 @@ async def test_auto_sweep_backfills_placeholders_capped(client):
         await session.commit()
 
     async with get_sessionmaker()() as session:
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, pid)
         stats, _ = await link_all_paper_concepts(
-            session, project_id=pid, llm=LLMRouter(), backfill=False
+            session, library_id=library.id, llm=LLMRouter(), backfill=False
         )
     assert stats["concepts_backfilled"] == 1
 
     async with get_sessionmaker()() as session:
-        row = (
-            await session.execute(
-                select(Concept).where(Concept.project_id == pid, Concept.name == "强化学习")
-            )
-        ).scalar_one()
+        row = next(
+            c
+            for c in await project_concepts(session, project_id=pid)
+            if c.name == "强化学习"
+        )
         assert not row.definition.endswith("（定义待补充）")
         assert row.category == "method"  # fake provider 返回 method

--- a/src/backend/tests/test_highlights.py
+++ b/src/backend/tests/test_highlights.py
@@ -5,9 +5,8 @@ import uuid
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
 from app.models.user import User
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 RECT = {"x0": 0.1, "y0": 0.1, "x1": 0.5, "y1": 0.12}
 
@@ -28,7 +27,7 @@ async def _setup(client):
     assert resp.status_code == 204, resp.text
 
     async with get_sessionmaker()() as session:
-        p1 = Paper(
+        p1 = await add_paper(session,
             project_id=uuid.UUID(project_id), title="Attention Is All You Need", status="fetched"
         )
         session.add(p1)

--- a/src/backend/tests/test_idea_forge.py
+++ b/src/backend/tests/test_idea_forge.py
@@ -16,8 +16,7 @@ from app.core.llm.fake import EMBEDDING_DIM, FakeProvider
 from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.idea import Idea
-from app.models.paper import Paper
-from tests.conftest import RecordingBus, register_and_login
+from tests.conftest import RecordingBus, add_concept, add_paper, register_and_login
 
 DEFINITION = {"statement": "自动化科研 agent 的方法研究"}
 
@@ -43,7 +42,7 @@ async def _seed_compiled_papers(project_id: str, n: int = 3) -> list[str]:
     async with get_sessionmaker()() as session:
         ids = []
         for i in range(n):
-            paper = Paper(
+            paper = await add_paper(session,
                 project_id=uuid.UUID(project_id),
                 source="manual",
                 title=f"Compiled paper {i}",
@@ -333,7 +332,6 @@ async def test_collect_signals_concept_holes_and_trends(client, queue_stub):
     """确定性信号：method×problem 零共现概念对 + 近 90 天概念趋势（纯代码，无 LLM）。"""
     from app.agents.voyage.actions import ActionContext
     from app.agents.voyage.actions_ideas import forge_collect_signals
-    from app.models.paper import Concept
     from app.models.voyage import VoyageRun
 
     project_id, headers = await _setup_project(client)
@@ -341,9 +339,27 @@ async def test_collect_signals_concept_holes_and_trends(client, queue_stub):
 
     async with get_sessionmaker()() as session:
         pid = uuid.UUID(project_id)
-        method_a = Concept(project_id=pid, name="方法A", slug="m-a", category="method")
-        method_b = Concept(project_id=pid, name="方法B", slug="m-b", category="method")
-        problem_x = Concept(project_id=pid, name="问题X", slug="p-x", category="problem")
+        method_a = await add_concept(
+            session,
+            project_id=pid,
+            name="方法A",
+            slug="m-a",
+            category="method",
+        )
+        method_b = await add_concept(
+            session,
+            project_id=pid,
+            name="方法B",
+            slug="m-b",
+            category="method",
+        )
+        problem_x = await add_concept(
+            session,
+            project_id=pid,
+            name="问题X",
+            slug="p-x",
+            category="problem",
+        )
         session.add_all([method_a, method_b, problem_x])
         await session.flush()
         # 方法A 与 问题X 共现（paper0）；方法B 只出现在 paper1/2 → 方法B×问题X 零共现

--- a/src/backend/tests/test_idea_proposal.py
+++ b/src/backend/tests/test_idea_proposal.py
@@ -16,9 +16,8 @@ from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.gate import Gate
 from app.models.idea import Idea
-from app.models.paper import Paper
 from app.models.review import ReviewMessage, ReviewSession
-from tests.conftest import RecordingBus, register_and_login
+from tests.conftest import RecordingBus, add_paper, register_and_login
 
 STATEMENT = "自动化科研 agent 的方法研究"
 
@@ -47,7 +46,7 @@ async def _seed_searchable_papers(project_id: str, statement: str, n: int = 3) -
     async with get_sessionmaker()() as session:
         ids = []
         for i in range(n):
-            paper = Paper(
+            paper = await add_paper(session,
                 project_id=uuid.UUID(project_id),
                 source="manual",
                 title=f"Deep paper {i}",

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -4,7 +4,7 @@ import uuid
 
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def _make_project(client, headers, name="lib-proj"):
@@ -14,7 +14,7 @@ async def _make_project(client, headers, name="lib-proj"):
 
 async def _make_paper(project_id: str, **kwargs) -> str:
     async with get_sessionmaker()() as session:
-        paper = Paper(project_id=uuid.UUID(project_id), **kwargs)
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), **kwargs)
         session.add(paper)
         await session.commit()
         return str(paper.id)

--- a/src/backend/tests/test_library_chat.py
+++ b/src/backend/tests/test_library_chat.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from sqlalchemy import func, select
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper, PaperChunk
+from app.models.paper import PaperChunk
 from app.services.chunks import CHUNK_MAX_CHARS, split_text
-from tests.conftest import register_and_login
+from tests.conftest import add_concept, add_paper, register_and_login
 
 
 def _parse_sse(text: str) -> list[tuple[str, dict]]:
@@ -67,7 +67,7 @@ async def _setup(client, tmp_path_factory=None):
         for i, (title, body) in enumerate(seeds):
             txt = txt_dir / f"p{i}.txt"
             txt.write_text(body, encoding="utf-8")
-            p = Paper(
+            p = await add_paper(session,
                 project_id=project_id,
                 title=title,
                 abstract=f"{title} abstract",
@@ -102,7 +102,7 @@ async def test_rebuild_index_and_chunk_rows(client):
 
     async with get_sessionmaker()() as session:
         count = (
-            await session.execute(select(func.count()).where(PaperChunk.project_id == project_id))
+            await session.execute(select(func.count()).select_from(PaperChunk))
         ).scalar_one()
         assert count == body["total_chunks"]
 
@@ -188,11 +188,11 @@ async def test_library_chat_sources_include_concepts(client):
 
     from sqlalchemy import insert
 
-    from app.models.paper import Concept, paper_concepts
+    from app.models.paper import paper_concepts
     from app.services.concepts import wiki_slug
 
     async with get_sessionmaker()() as session:
-        c = Concept(
+        c = await add_concept(session,
             project_id=project_id, name="思维树", slug=wiki_slug("思维树"), category="method"
         )
         session.add(c)

--- a/src/backend/tests/test_manuscripts.py
+++ b/src/backend/tests/test_manuscripts.py
@@ -12,8 +12,7 @@ from app.core.db import get_sessionmaker
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.idea import Idea
 from app.models.manuscript import Manuscript
-from app.models.paper import Paper
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -91,7 +90,7 @@ async def _seed_experiment(project_id: str, idea_id: str, tmp_path=None) -> str:
 
 async def _seed_paper(project_id: str, title: str, year: int = 2024, status="compiled") -> str:
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             title=title,
             authors=[{"name": "Ada Smith"}],

--- a/src/backend/tests/test_mcp_server.py
+++ b/src/backend/tests/test_mcp_server.py
@@ -4,7 +4,7 @@ import json
 import uuid
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
+from tests.conftest import add_paper
 
 from .conftest import register_and_login
 
@@ -17,7 +17,7 @@ async def _setup(client, email="mcp@example.com"):
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
         session.add(
-            Paper(
+            await add_paper(session,
                 project_id=uuid.UUID(project_id),
                 source="manual",
                 title="MCP retrieval paper",

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "94e6bc81c510"  # registration_codes.preset_directions（本分支最新）
-PREV_REVISION = "8b3b904e7588"  # user_library_entries.wiki_content 快照
+HEAD_REVISION = "f7c2abfe8aeb"  # 方向文献库 + 论文内容池（P4 迁移 A，本分支最新）
+PREV_REVISION = "94e6bc81c510"  # registration_codes.preset_directions
 
 
 def _make_config(db_path: Path) -> Config:
@@ -195,14 +195,24 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "llm_self_managed" in columns["users"]
     # 个人库 wiki 快照列（上一版）
     assert "wiki_content" in columns["user_library_entries"]
-    # 本分支新增：注册码预设研究方向列
+    # 注册码预设研究方向列（上一版）
     assert "preset_directions" in columns["registration_codes"]
+    # 本分支新增：方向文献库三表 + papers.dedup_key（P4 迁移 A）
+    assert {
+        "direction_libraries",
+        "direction_library_curators",
+        "library_papers",
+    } <= columns["_tables"]
+    assert "dedup_key" in columns["papers"]
 
-    # 最新 revision 可往返（downgrade 移除 registration_codes.preset_directions 列）
+    # 最新 revision 可往返（downgrade 移除方向文献库三表与 papers.dedup_key）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "preset_directions" not in columns["registration_codes"]
+    assert "direction_libraries" not in columns["_tables"]
+    assert "library_papers" not in columns["_tables"]
+    assert "dedup_key" not in columns["papers"]
+    assert "preset_directions" in columns["registration_codes"]
     assert "wiki_content" in columns["user_library_entries"]
     assert "paper_id" in columns["user_publications"]
     assert "owner_id" in columns["llm_providers"]

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "f7c2abfe8aeb"  # 方向文献库 + 论文内容池（P4 迁移 A，本分支最新）
-PREV_REVISION = "94e6bc81c510"  # registration_codes.preset_directions
+HEAD_REVISION = "fe8a86942dc7"  # 论文内容池收尾（P4 迁移 B，本分支最新）
+PREV_REVISION = "f7c2abfe8aeb"  # 方向文献库 + 论文内容池（P4 迁移 A）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -125,8 +125,12 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "attempts",
         "provenance",
     } <= columns["voyage_steps"]
-    # 垃圾桶原因标签
-    assert "trash_reason" in columns["papers"]
+    # 垃圾桶原因等判断字段已迁 library_papers（P4 迁移 B 删列）
+    assert "trash_reason" not in columns["papers"]
+    assert "status" not in columns["papers"]
+    assert "relevance_score" not in columns["papers"]
+    assert "wiki_content" not in columns["papers"]
+    assert "project_id" not in columns["papers"]
     # PDF 划线标注表（上一版 paper_highlights）
     assert "paper_highlights" in columns["_tables"]
     assert {
@@ -197,7 +201,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "wiki_content" in columns["user_library_entries"]
     # 注册码预设研究方向列（上一版）
     assert "preset_directions" in columns["registration_codes"]
-    # 本分支新增：方向文献库三表 + papers.dedup_key（P4 迁移 A）
+    # 本分支新增：方向文献库三表 + papers.dedup_key（P4 迁移 A）+ 收尾（迁移 B）
     assert {
         "direction_libraries",
         "direction_library_curators",
@@ -205,13 +209,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["_tables"]
     assert "dedup_key" in columns["papers"]
 
-    # 最新 revision 可往返（downgrade 移除方向文献库三表与 papers.dedup_key）
+    # 最新 revision 可往返（downgrade 还原 papers/concepts/paper_chunks 的旧列结构）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "direction_libraries" not in columns["_tables"]
-    assert "library_papers" not in columns["_tables"]
-    assert "dedup_key" not in columns["papers"]
+    assert {"project_id", "status", "relevance_score", "wiki_content"} <= columns["papers"]
+    assert "dedup_key" in columns["papers"]  # 迁移 A 的列仍在
+    assert "library_papers" in columns["_tables"]
     assert "preset_directions" in columns["registration_codes"]
     assert "wiki_content" in columns["user_library_entries"]
     assert "paper_id" in columns["user_publications"]

--- a/src/backend/tests/test_notes.py
+++ b/src/backend/tests/test_notes.py
@@ -7,10 +7,9 @@ import zipfile
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
 from app.models.user import User
 from app.services.notes import author_name_of
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def _setup(client):
@@ -29,14 +28,19 @@ async def _setup(client):
     assert resp.status_code == 204, resp.text
 
     async with get_sessionmaker()() as session:
-        p1 = Paper(
+        p1 = await add_paper(session,
             project_id=uuid.UUID(project_id),
             title="Agent Planning with RL",
             abstract="Planning for agents.",
             status="compiled",
             wiki_content="## TL;DR\n\n一句话（fake）。\n",
         )
-        p2 = Paper(project_id=uuid.UUID(project_id), title="Second Paper", status="included")
+        p2 = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Second Paper",
+            status="included",
+        )
         session.add_all([p1, p2])
         await session.commit()
         ids = {"p1": str(p1.id), "p2": str(p2.id)}

--- a/src/backend/tests/test_paper_figure_tools.py
+++ b/src/backend/tests/test_paper_figure_tools.py
@@ -9,9 +9,9 @@ from PIL import Image
 import app.tools as tools
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
-from app.models.paper import Concept, Paper
 from app.services.literature.pdf_extract import figure_path
 from app.tools import ToolContext, ToolResult
+from tests.conftest import add_concept, add_paper
 
 from .conftest import register_and_login
 
@@ -61,7 +61,7 @@ async def _seed_paper_with_figures(project_id: str) -> str:
         },
     ]
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="manual",
             title="Retrieval Augmented Generation",
@@ -131,11 +131,17 @@ async def test_related_papers_shared_concept(client):
     project_id, _ = await _project(client, email="fig3@example.com")
     async with get_sessionmaker()() as session:
         pid = uuid.UUID(project_id)
-        concept = Concept(project_id=pid, name="RAG", slug="rag", definition="检索增强")
-        p1 = Paper(
+        concept = await add_concept(
+            session,
+            project_id=pid,
+            name="RAG",
+            slug="rag",
+            definition="检索增强",
+        )
+        p1 = await add_paper(session,
             project_id=pid, source="manual", title="Paper A", status="compiled", concepts=[concept]
         )
-        p2 = Paper(
+        p2 = await add_paper(session,
             project_id=pid, source="manual", title="Paper B", status="compiled", concepts=[concept]
         )
         session.add_all([p1, p2])

--- a/src/backend/tests/test_paper_figures.py
+++ b/src/backend/tests/test_paper_figures.py
@@ -18,7 +18,7 @@ from app.models.llm_config import LLMUsage
 from app.models.paper import Paper
 from app.services.figure_annotate import annotate_figures
 from app.services.literature.pdf_extract import extract_figures, figure_path, save_pdf
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 def _image_bytes(width: int, height: int, value: int = 90) -> bytes:
@@ -151,7 +151,7 @@ async def _setup_paper(client, *, email: str = "alice@example.com"):
     resp = await client.post("/api/projects", json={"name": "fig-proj"}, headers=headers)
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="manual",
             title="Figured Paper",
@@ -238,13 +238,7 @@ async def test_figures_api_extract_annotate_idempotent_force(client):
 
 
 def _paper_stub() -> Paper:
-    return Paper(
-        id=uuid.uuid4(),
-        project_id=uuid.uuid4(),
-        title="Stub Paper",
-        abstract="stub",
-        status="fetched",
-    )
+    return Paper(id=uuid.uuid4(), title="Stub Paper", abstract="stub")
 
 
 def _candidate(index: int, *, page: int = 1, width: int = 400, height: int = 300) -> dict:

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -12,7 +12,7 @@ from app.models.paper import Paper
 from app.services.literature import reset_clients, set_clients
 from app.services.literature.arxiv import ArxivClient
 from app.services.literature.openalex import OpenAlexClient
-from tests.conftest import register_and_login
+from tests.conftest import membership_of, register_and_login
 
 ARXIV_FEED_ONE = """<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
@@ -85,7 +85,8 @@ async def test_add_by_arxiv_id_and_dedupe_409(client, lit_clients):
 
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, uuid.UUID(paper_id))
-        assert paper.source == "manual" and paper.status == "included"
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        assert paper.source == "manual" and membership.status == "included"
 
     # 项目内按 arxiv_id 去重 → 409 带已有 paper_id
     resp = await client.post(
@@ -184,10 +185,11 @@ async def test_add_scores_relevance_best_effort(client):
 
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, uuid.UUID(body["id"]))
-        assert paper.relevance_score == body["relevance_score"]
+        membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
+        assert membership.relevance_score == body["relevance_score"]
         assert paper.tldr == body["tldr"]
-        assert paper.scored_at is not None
-        assert paper.status == "included"  # 人工纳入，打分不改状态
+        assert membership.scored_at is not None
+        assert membership.status == "included"  # 人工纳入，打分不改状态
 
 
 async def test_add_low_score_keeps_included(client):
@@ -209,8 +211,8 @@ async def test_add_low_score_keeps_included(client):
     assert body["status"] == "included"
 
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, uuid.UUID(body["id"]))
-        assert paper.status == "included" and paper.trash_reason is None
+        membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
+        assert membership.status == "included" and membership.trash_reason is None
 
 
 async def test_add_llm_failure_still_201(client, monkeypatch):
@@ -231,9 +233,9 @@ async def test_add_llm_failure_still_201(client, monkeypatch):
     assert body["status"] == "included"
 
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, uuid.UUID(body["id"]))
-        assert paper.relevance_score is None and paper.scored_at is None
-        assert paper.status == "included"
+        membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
+        assert membership.relevance_score is None and membership.scored_at is None
+        assert membership.status == "included"
 
 
 async def test_add_mutual_exclusion_422(client):

--- a/src/backend/tests/test_paper_reading.py
+++ b/src/backend/tests/test_paper_reading.py
@@ -15,7 +15,7 @@ from app.models.paper import Paper
 from app.services.literature import reset_clients, set_clients
 from app.services.literature.arxiv import ArxivClient
 from app.services.literature.pdf_extract import save_pdf
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 def _pdf_bytes(text: str = "hello polaris") -> bytes:
@@ -45,7 +45,7 @@ async def _setup(client, *, arxiv_id: str | None = "2406.00001", email: str = "a
     resp = await client.post("/api/projects", json={"name": "read-proj"}, headers=headers)
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="arxiv" if arxiv_id else "manual",
             arxiv_id=arxiv_id,
@@ -194,7 +194,7 @@ async def test_chat_with_referenced_papers(client):
     foreign_pid = resp.json()["id"]
 
     async with get_sessionmaker()() as session:
-        referenced = Paper(
+        referenced = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="manual",
             title="Fara-1.5 Learning Environments",
@@ -202,7 +202,7 @@ async def test_chat_with_referenced_papers(client):
             tldr="Fara-1.5 一句话总结：可扩展的 CUA 学习环境。",
             status="included",
         )
-        foreign = Paper(
+        foreign = await add_paper(session,
             project_id=uuid.UUID(foreign_pid),
             source="manual",
             title="Foreign Paper",

--- a/src/backend/tests/test_paper_tags_meta.py
+++ b/src/backend/tests/test_paper_tags_meta.py
@@ -3,8 +3,7 @@
 import uuid
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def _setup(client):
@@ -13,8 +12,18 @@ async def _setup(client):
     resp = await client.post("/api/projects", json={"name": "tags-proj"}, headers=headers)
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        p1 = Paper(project_id=uuid.UUID(project_id), title="Paper One", status="included")
-        p2 = Paper(project_id=uuid.UUID(project_id), title="Paper Two", status="compiled")
+        p1 = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Paper One",
+            status="included",
+        )
+        p2 = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Paper Two",
+            status="compiled",
+        )
         session.add_all([p1, p2])
         await session.commit()
         ids = {"p1": str(p1.id), "p2": str(p2.id)}

--- a/src/backend/tests/test_presentation.py
+++ b/src/backend/tests/test_presentation.py
@@ -6,7 +6,7 @@ import uuid
 from pptx import Presentation as PptxFile
 
 from app.services.presentation import DeckSpec, build_deck, validate_deck_spec
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 DECK = {
     "title": "测试分享",
@@ -139,10 +139,9 @@ async def test_create_presentation_voyage(client, queue_stub):
     assert resp.status_code == 404
 
     from app.core.db import get_sessionmaker
-    from app.models.paper import Paper
 
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             title="Self-Rewarding Language Models",
             abstract="LLM as its own reward model.",

--- a/src/backend/tests/test_projects.py
+++ b/src/backend/tests/test_projects.py
@@ -1,4 +1,4 @@
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def test_projects_require_auth(client):
@@ -54,7 +54,11 @@ async def test_delete_project(client):
     from app.models.paper import Paper
 
     async with get_sessionmaker()() as session:
-        session.add(Paper(project_id=_uuid.UUID(project_id), title="orphan check"))
+        session.add(await add_paper(
+            session,
+            project_id=_uuid.UUID(project_id),
+            title="orphan check"),
+        )
         await session.commit()
 
     resp = await client.delete(f"/api/projects/{project_id}", headers=headers)
@@ -63,12 +67,23 @@ async def test_delete_project(client):
     resp = await client.get(f"/api/projects/{project_id}", headers=headers)
     assert resp.status_code == 404
     async with get_sessionmaker()() as session:
-        count = (
+        from app.models.library_direction import DirectionLibrary, LibraryPaper
+
+        # 隐式库与成员行随方向级联删除；内容池 Paper 行保留（全局复用，P4 语义）
+        libs = (
             await session.execute(
-                select(func.count()).where(Paper.project_id == _uuid.UUID(project_id))
+                select(func.count()).where(
+                    DirectionLibrary.project_id == _uuid.UUID(project_id)
+                )
             )
         ).scalar_one()
-        assert count == 0
+        assert libs == 0
+        memberships = (
+            await session.execute(select(func.count()).select_from(LibraryPaper))
+        ).scalar_one()
+        assert memberships == 0
+        pool = (await session.execute(select(func.count()).select_from(Paper))).scalar_one()
+        assert pool == 1
 
 
 async def test_delete_project_requires_owner(client):

--- a/src/backend/tests/test_publications.py
+++ b/src/backend/tests/test_publications.py
@@ -3,9 +3,8 @@
 import uuid
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
 from app.services import publications as publications_service
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 
 async def _login(client, email="alice@example.com"):
@@ -20,7 +19,7 @@ async def _make_project(client, headers, name="pub-proj"):
 
 async def _make_paper(project_id: str, **kwargs) -> str:
     async with get_sessionmaker()() as session:
-        paper = Paper(project_id=uuid.UUID(project_id), **kwargs)
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), **kwargs)
         session.add(paper)
         await session.commit()
         return str(paper.id)

--- a/src/backend/tests/test_rerank.py
+++ b/src/backend/tests/test_rerank.py
@@ -18,7 +18,7 @@ from app.core.security import encrypt_secret
 from app.models.llm_config import LLMProviderConfig, LLMUsage, ModelRoute
 from app.models.paper import Paper
 from app.services import papers as papers_service
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, register_and_login
 
 # ---- provider 层 ----
 
@@ -145,13 +145,13 @@ async def _setup_semantic_project(client, monkeypatch):
     project_id = uuid.UUID(resp.json()["id"])
 
     async with get_sessionmaker()() as session:
-        pa = Paper(
+        pa = await add_paper(session,
             project_id=project_id,
             title="Cooking pasta at home",
             abstract="A recipe study about food.",
             status="compiled",
         )
-        pb = Paper(
+        pb = await add_paper(session,
             project_id=project_id,
             title="Agent planning",
             abstract=None,
@@ -164,11 +164,16 @@ async def _setup_semantic_project(client, monkeypatch):
     monkeypatch.setattr(papers_service, "semantic_search_supported", lambda session: True)
 
     async def fake_vector_search(session, *, project_id, query_vector, limit):
+        from tests.conftest import membership_of
+
         papers = (
             (await session.execute(select(Paper).where(Paper.id.in_(ordered_ids)))).scalars().all()
         )
-        by_id = {p.id: p for p in papers}
-        return [(by_id[ordered_ids[0]], 0.9), (by_id[ordered_ids[1]], 0.8)][:limit]
+        views = {}
+        for p in papers:
+            membership = await membership_of(session, project_id=project_id, paper_id=p.id)
+            views[p.id] = papers_service.PaperView(p, membership, project_id)
+        return [(views[ordered_ids[0]], 0.9), (views[ordered_ids[1]], 0.8)][:limit]
 
     monkeypatch.setattr(papers_service, "semantic_search_papers", fake_vector_search)
     return str(project_id), headers

--- a/src/backend/tests/test_search.py
+++ b/src/backend/tests/test_search.py
@@ -6,8 +6,8 @@ from app.core.db import get_sessionmaker
 from app.models.experiment import Experiment
 from app.models.idea import Idea
 from app.models.manuscript import Manuscript
-from app.models.paper import Concept, Paper
 from app.models.voyage import VoyageRun
+from tests.conftest import add_concept, add_paper
 
 from .conftest import register_and_login
 
@@ -24,14 +24,19 @@ async def _setup(client):
         idea = Idea(project_id=pid, title="Graph retrieval idea", summary="用图检索增强 RAG")
         session.add_all(
             [
-                Paper(
+                await add_paper(session,
                     project_id=pid,
                     title="Graph Retrieval for LLMs",
                     tldr="graph-based retrieval",
                     status="included",
                 ),
-                Paper(project_id=pid, title="Excluded graph paper", status="excluded"),
-                Concept(
+                await add_paper(
+                    session,
+                    project_id=pid,
+                    title="Excluded graph paper",
+                    status="excluded",
+                ),
+                await add_concept(session,
                     project_id=pid, name="Graph RAG", slug="graph-rag", definition="图增强检索"
                 ),
                 idea,

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -8,8 +8,8 @@ import app.tools as tools
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.idea import Idea
-from app.models.paper import Concept, Paper
 from app.tools import ToolContext
+from tests.conftest import add_concept, add_paper
 
 from .conftest import register_and_login
 
@@ -80,14 +80,14 @@ async def test_run_tool_unknown_and_bad_args():
 async def test_library_tools_end_to_end(client):
     project_id = await _project(client)
     async with get_sessionmaker()() as session:
-        concept = Concept(
+        concept = await add_concept(session,
             project_id=project_id,
             name="Retrieval",
             slug="retrieval",
             definition="按需取信息",
             category="method",
         )
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=project_id,
             source="manual",
             title="Retrieval Augmented Agents",
@@ -141,7 +141,13 @@ async def test_cross_project_isolation(client):
     proj_a = await _project(client, email="a@example.com")
     proj_b = await _project(client, email="b@example.com")
     async with get_sessionmaker()() as session:
-        paper = Paper(project_id=proj_b, source="manual", title="B secret", status="compiled")
+        paper = await add_paper(
+            session,
+            project_id=proj_b,
+            source="manual",
+            title="B secret",
+            status="compiled",
+        )
         session.add(paper)
         await session.commit()
         b_paper_id = str(paper.id)

--- a/src/backend/tests/test_wiki_api.py
+++ b/src/backend/tests/test_wiki_api.py
@@ -9,8 +9,8 @@ from sqlalchemy import insert
 
 from app.core.db import get_sessionmaker
 from app.models.activity import Activity
-from app.models.paper import Concept, Paper, paper_concepts
-from tests.conftest import register_and_login
+from app.models.paper import Paper, paper_concepts
+from tests.conftest import add_concept, add_paper, register_and_login
 
 
 async def _setup(client):
@@ -20,7 +20,7 @@ async def _setup(client):
     project_id = uuid.UUID(resp.json()["id"])
 
     async with get_sessionmaker()() as session:
-        p1 = Paper(
+        p1 = await add_paper(session,
             project_id=project_id,
             source="arxiv",
             arxiv_id="2406.10001",
@@ -36,7 +36,7 @@ async def _setup(client):
             wiki_content="## TL;DR\n\n使用 [[Agent]] 与 [[规划]] 的方法。\n",
             status="compiled",
         )
-        p2 = Paper(
+        p2 = await add_paper(session,
             project_id=project_id,
             source="arxiv",
             arxiv_id="2406.10002",
@@ -48,14 +48,14 @@ async def _setup(client):
             relevance_score=0.3,
             status="excluded",
         )
-        c1 = Concept(
+        c1 = await add_concept(session,
             project_id=project_id,
             name="Agent",
             slug="agent",
             definition="能自主感知-决策-行动的智能体。",
             category="method",
         )
-        c2 = Concept(
+        c2 = await add_concept(session,
             project_id=project_id,
             name="规划",
             slug="规划",
@@ -269,15 +269,34 @@ async def test_papers_status_group_filters(client):
     project_id, headers, ids = await _setup(client)
 
     from app.core.db import get_sessionmaker
-    from app.models.paper import Paper
 
     async with get_sessionmaker()() as session:
         session.add_all(
             [
-                Paper(project_id=uuid.UUID(project_id), title="scored one", status="scored"),
-                Paper(project_id=uuid.UUID(project_id), title="fetched one", status="fetched"),
-                Paper(project_id=uuid.UUID(project_id), title="included one", status="included"),
-                Paper(project_id=uuid.UUID(project_id), title="cand one", status="candidate"),
+                await add_paper(
+                    session,
+                    project_id=uuid.UUID(project_id),
+                    title="scored one",
+                    status="scored",
+                ),
+                await add_paper(
+                    session,
+                    project_id=uuid.UUID(project_id),
+                    title="fetched one",
+                    status="fetched",
+                ),
+                await add_paper(
+                    session,
+                    project_id=uuid.UUID(project_id),
+                    title="included one",
+                    status="included",
+                ),
+                await add_paper(
+                    session,
+                    project_id=uuid.UUID(project_id),
+                    title="cand one",
+                    status="candidate",
+                ),
             ]
         )
         await session.commit()
@@ -300,14 +319,16 @@ async def test_papers_status_group_filters(client):
 
 
 async def test_delete_paper_and_batch(client, tmp_path):
-    """删除论文（docs/api-lit.md §8.6）：单删 + 批量删 + 文件清理 + 成员校验。"""
+    """删除论文（docs/api-lit.md §8.6）：单删 + 批量删 + 成员校验。
+
+    P4 全局内容池语义：删除只摘掉本方向的成员行，内容池行与落盘文件保留
+    （其他方向可复用）。"""
     project_id, headers, ids = await _setup(client)
 
     from app.core.db import get_sessionmaker
-    from app.models.paper import Paper
     from app.services.literature.pdf_extract import figure_path
 
-    # 给 p1 落一个假 PDF 和图片文件，删除时应一并清理
+    # 给 p1 落一个假 PDF 和图片文件：P4 起删除不清理内容池文件
     pdf = tmp_path / "p1.pdf"
     pdf.write_bytes(b"%PDF-fake")
     fig = figure_path(ids["p1"], 0)
@@ -326,7 +347,10 @@ async def test_delete_paper_and_batch(client, tmp_path):
 
     resp = await client.delete(f"/api/papers/{ids['p1']}", headers=headers)
     assert resp.status_code == 204
-    assert not pdf.exists() and not fig.exists()
+    # 内容池行与文件保留；本方向视角下论文不复存在
+    assert pdf.exists() and fig.exists()
+    async with get_sessionmaker()() as session:
+        assert await session.get(Paper, uuid.UUID(ids["p1"])) is not None
     resp = await client.get(f"/api/papers/{ids['p1']}", headers=headers)
     assert resp.status_code == 404
 
@@ -435,12 +459,11 @@ async def test_papers_advanced_filters(client):
     from datetime import UTC, datetime
 
     from app.core.db import get_sessionmaker
-    from app.models.paper import Paper
 
     project_id, headers, ids = await _setup(client)
     async with get_sessionmaker()() as session:
         session.add(
-            Paper(
+            await add_paper(session,
                 project_id=uuid.UUID(project_id),
                 title="Affiliation Paper",
                 authors=[{"name": "Carol Zhang"}],

--- a/src/backend/tests/test_wiki_figures_compile.py
+++ b/src/backend/tests/test_wiki_figures_compile.py
@@ -18,7 +18,7 @@ from app.services.literature.pdf_extract import (
     save_pdf,
 )
 from app.services.wiki_compile import compile_paper, strip_invalid_figure_markers
-from tests.conftest import register_and_login
+from tests.conftest import add_paper, membership_of, register_and_login
 
 
 def _transparent_png_bytes(width: int = 400, height: int = 300) -> bytes:
@@ -103,10 +103,8 @@ def test_flatten_png_white_handles_la_and_palette_transparency():
 def _paper_stub(**kwargs) -> Paper:
     return Paper(
         id=uuid.uuid4(),
-        project_id=uuid.uuid4(),
         title="Interleaved Paper",
         abstract="A paper about agents.",
-        status="fetched",
         **kwargs,
     )
 
@@ -182,7 +180,7 @@ async def _setup_paper(client, *, status: str = "scored"):
     resp = await client.post("/api/projects", json={"name": "recompile-proj"}, headers=headers)
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="manual",
             title="Recompiled Paper",
@@ -222,9 +220,9 @@ async def test_recompile_with_pdf_full_flow(client):
         }
     ]
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, uuid.UUID(paper_id))
-        assert paper.compiled_at is not None
-        assert paper.compiled_model == "fake-default"  # 编译所用模型落库
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        assert membership.compiled_at is not None
+        assert membership.compiled_model == "fake-default"  # 编译所用模型落库
         # LLMUsage 记账归属 project（annotate + 编译 + 概念定义各 1 次 librarian 调用）
         rows = (
             (await session.execute(select(LLMUsage).where(LLMUsage.stage == "librarian")))
@@ -270,7 +268,7 @@ async def test_obsidian_export_rewrites_figure_markers(client):
     resp = await client.post("/api/projects", json={"name": "export-proj"}, headers=headers)
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        paper = Paper(
+        paper = await add_paper(session,
             project_id=uuid.UUID(project_id),
             source="arxiv",
             arxiv_id="2406.20001",
@@ -365,7 +363,7 @@ async def test_annotate_figures_records_kind(app):
     from app.models.paper import Paper
     from app.services.figure_annotate import annotate_figures
 
-    paper = Paper(id=_uuid.uuid4(), project_id=_uuid.uuid4(), title="Kind Paper", status="fetched")
+    paper = Paper(id=_uuid.uuid4(), title="Kind Paper")
     candidates = [
         {"index": 0, "page": 1, "width": 400, "height": 300},
         {"index": 1, "page": 2, "width": 300, "height": 200},

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -20,7 +20,7 @@ from app.core.llm.fake import FakeProvider
 from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.llm_config import LLMUsage
-from app.models.paper import EMBEDDING_DIM, Concept, Paper, paper_concepts
+from app.models.paper import EMBEDDING_DIM, paper_concepts
 from app.models.project import Project
 from app.services import ingest as ingest_service
 from app.services.literature import (
@@ -31,7 +31,12 @@ from app.services.literature import (
     set_clients,
 )
 from app.services.literature.pdf_extract import figure_path
-from tests.conftest import RecordingBus, register_and_login
+from tests.conftest import (
+    RecordingBus,
+    project_concepts,
+    project_paper_rows,
+    register_and_login,
+)
 
 DEFINITION = {
     "statement": "自动化科研 agent 的方法研究",
@@ -295,25 +300,21 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert detail["steps"][1]["observation"]["inserted"] == 1  # 雪球 1 篇
 
     async with get_sessionmaker()() as session:
-        papers = (
-            (await session.execute(select(Paper).where(Paper.project_id == uuid.UUID(project_id))))
-            .scalars()
-            .all()
-        )
-        assert len(papers) == 4  # 3 arXiv 候选 + 1 雪球
+        rows = await project_paper_rows(session, project_id=project_id)
+        assert len(rows) == 4  # 3 arXiv 候选 + 1 雪球
         by_status = {}
-        for p in papers:
-            by_status.setdefault(p.status, []).append(p)
+        for p, m in rows:
+            by_status.setdefault(m.status, []).append((p, m))
         assert len(by_status.get("excluded", [])) == 1  # "irrelevant" 论文被排除
-        assert by_status["excluded"][0].arxiv_id == "2406.00003"
-        compiled = by_status.get("compiled", [])
-        assert len(compiled) == 3
-        for p in compiled:
-            assert p.relevance_score is not None and p.relevance_score >= 0.6
-            assert p.scored_at is not None and p.compiled_at is not None
-            assert p.compiled_model == "fake-default"  # 编译所用模型落库（voyage 路径）
+        assert by_status["excluded"][0][0].arxiv_id == "2406.00003"
+        compiled_rows = by_status.get("compiled", [])
+        assert len(compiled_rows) == 3
+        for p, m in compiled_rows:
+            assert m.relevance_score is not None and m.relevance_score >= 0.6
+            assert m.scored_at is not None and m.compiled_at is not None
+            assert m.compiled_model == "fake-default"  # 编译所用模型落库（voyage 路径）
             assert p.tldr
-            assert "[[Agent]]" in p.wiki_content  # 双链
+            assert "[[Agent]]" in m.wiki_content  # 双链
             assert p.full_text_path and p.pdf_path  # PDF 已抽全文
             assert p.embedding is not None and len(p.embedding) == EMBEDDING_DIM
             # 管线顺带提取论文图（小图被滤），compile 后由 fake VLM 注释
@@ -330,15 +331,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
             ]
             assert figure_path(str(p.id), 0).exists()
 
-        concepts = (
-            (
-                await session.execute(
-                    select(Concept).where(Concept.project_id == uuid.UUID(project_id))
-                )
-            )
-            .scalars()
-            .all()
-        )
+        concepts = await project_concepts(session, project_id=project_id)
         names = {c.name for c in concepts}
         assert names == {"Agent", "强化学习"}
         for c in concepts:
@@ -402,14 +395,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     since_dt = datetime.fromisoformat(detail2["steps"][0]["observation"]["window_since"])
     assert watermark_dt - since_dt == timedelta(days=14)
     async with get_sessionmaker()() as session:
-        total = int(
-            (
-                await session.execute(
-                    select(func.count()).where(Paper.project_id == uuid.UUID(project_id))
-                )
-            ).scalar_one()
-        )
-        assert total == 4
+        assert len(await project_paper_rows(session, project_id=project_id)) == 4
 
 
 class _CrashOnNthRelevance(FakeProvider):
@@ -450,15 +436,9 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
 
     assert await _relevance_call_count() == 3  # 崩溃前 3 篇成功打分（并发，非串行的 1）
     async with get_sessionmaker()() as session:
-        scored = (
-            await session.execute(
-                select(func.count()).where(
-                    Paper.project_id == uuid.UUID(project_id),
-                    Paper.status.in_(("scored", "excluded")),
-                )
-            )
-        ).scalar_one()
-        assert int(scored) == 3  # 逐篇 commit：崩溃前的进度已落库
+        rows = await project_paper_rows(session, project_id=project_id)
+        scored = sum(1 for _, m in rows if m.status in ("scored", "excluded"))
+        assert scored == 3  # 逐篇 commit：崩溃前的进度已落库
 
     # resume：从断点续跑到 done，总打分调用数 == 论文数（无重复）
     engine2, _ = _make_engine()
@@ -468,16 +448,13 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
     assert await _relevance_call_count() == 4  # 4 篇论文各打分一次
 
     async with get_sessionmaker()() as session:
-        statuses = (
-            (
-                await session.execute(
-                    select(Paper.status).where(Paper.project_id == uuid.UUID(project_id))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert sorted(statuses) == ["compiled", "compiled", "compiled", "excluded"]
+        rows = await project_paper_rows(session, project_id=project_id)
+        assert sorted(m.status for _, m in rows) == [
+            "compiled",
+            "compiled",
+            "compiled",
+            "excluded",
+        ]
 
 
 class _BreakOneRelevance(FakeProvider):
@@ -525,16 +502,8 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
 
     async with get_sessionmaker()() as session:
         by_status: dict[str, int] = {}
-        for status in (
-            (
-                await session.execute(
-                    select(Paper.status).where(Paper.project_id == uuid.UUID(project_id))
-                )
-            )
-            .scalars()
-            .all()
-        ):
-            by_status[status] = by_status.get(status, 0) + 1
+        for _, m in await project_paper_rows(session, project_id=project_id):
+            by_status[m.status] = by_status.get(m.status, 0) + 1
         # 失败打分的那篇仍是 candidate（下次续跑会重试），其余照常推进
         assert by_status.get("candidate", 0) == 1
         assert by_status.get("excluded", 0) == 1  # irrelevant 篮子编织论文
@@ -571,17 +540,9 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
     assert detail["steps"][0]["observation"]["inserted"] == 3  # 默认分类兜底后仍能检索
 
     async with get_sessionmaker()() as session:
-        statuses = (
-            (
-                await session.execute(
-                    select(Paper.status).where(Paper.project_id == uuid.UUID(project_id))
-                )
-            )
-            .scalars()
-            .all()
-        )
+        rows = await project_paper_rows(session, project_id=project_id)
         # 无锚点论文 → 雪球 0 篇；3 候选：2 编译 + 1 排除（无 rubric 时打分只用 statement）
-        assert sorted(statuses) == ["compiled", "compiled", "excluded"]
+        assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
 
 
 def test_rss_loose_keyword_filter():
@@ -634,16 +595,8 @@ async def test_incremental_rss_fresh_layer(client, queue_stub, wiki_mocks):
     assert "cs.LG" in obs["rss_categories"]
 
     async with get_sessionmaker()() as session:
-        by_aid = {
-            aid: status
-            for aid, status in (
-                await session.execute(
-                    select(Paper.arxiv_id, Paper.status).where(
-                        Paper.project_id == uuid.UUID(project_id)
-                    )
-                )
-            ).all()
-        }
+        rows = await project_paper_rows(session, project_id=project_id)
+        by_aid = {p.arxiv_id: m.status for p, m in rows}
         # 版本号已归一化（无 v1/v2 后缀），新鲜论文入库
         assert "2607.30001" in by_aid
         assert "2607.30002" in by_aid
@@ -652,16 +605,7 @@ async def test_incremental_rss_fresh_layer(client, queue_stub, wiki_mocks):
         assert "2607.30004" not in by_aid
         assert "2607.30005" not in by_aid
         # 与存量重复的 arxiv_id 未产生第二条记录
-        dup_count = int(
-            (
-                await session.execute(
-                    select(func.count()).where(
-                        Paper.project_id == uuid.UUID(project_id),
-                        Paper.arxiv_id == "2406.00001",
-                    )
-                )
-            ).scalar_one()
-        )
+        dup_count = sum(1 for p, _ in rows if p.arxiv_id == "2406.00001")
         assert dup_count == 1
 
 
@@ -806,15 +750,8 @@ async def test_unlimited_bootstrap_uncapped(client, queue_stub, wiki_mocks_big):
     assert compile_obs["processed"] == total and compile_obs["succeeded"] == total
 
     async with get_sessionmaker()() as session:
-        compiled = int(
-            (
-                await session.execute(
-                    select(func.count()).where(
-                        Paper.project_id == uuid.UUID(project_id), Paper.status == "compiled"
-                    )
-                )
-            ).scalar_one()
-        )
+        rows = await project_paper_rows(session, project_id=project_id)
+        compiled = sum(1 for _, m in rows if m.status == "compiled")
         assert compiled == total  # 全部编译落库，无一截断
 
 


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P4, backend only. Design: local `docs-dev/rfc-paper-content-pool.md`.

## What changed

**Papers become a global content pool.** `papers` loses `project_id`; identity is enforced by a new `dedup_key` UNIQUE (arxiv → doi → normalized-title hash with year + first-author gating). Full text, chunks, embeddings, and figures are parsed once and reused platform-wide; ingest and manual import now check the pool first and log `paper pool hit` when they skip re-parsing.

**New membership layer.** `direction_libraries` (with a transitional 1:1 implicit library per existing project, inheriting rubric/ingest state), `direction_library_curators`, and `library_papers` carrying the judgment-side fields moved off `papers`: relevance score, wiki content, pipeline status, trash reason, scoring/compile timestamps. `concepts` moves from project scope to library scope.

**All read/write paths switched** (64 files): paper listing/filtering, semantic + keyword search (raw SQL now joins `library_papers`), wiki compile/concept linking, MCP tools (external protocol unchanged), five voyage actions, writing/citation checks, graph/stats/export/reading-chat/publications. Deletion semantics: removing a paper or a project deletes membership rows only; pool rows and files are permanent.

**API shapes are unchanged** — services resolve `project_id` to the implicit library internally; the frontend needs no changes in this phase.

## Migrations

- `f7c2abfe8aeb`: new tables, `dedup_key` backfill with duplicate resolution, data carry-over into implicit libraries
- `fe8a86942dc7`: contract — drop `papers.project_id` + moved columns, `paper_chunks.project_id`, re-scope `concepts`

Verified three ways: sqlite full-chain round-trip, fresh postgres `upgrade head`, and postgres upgrade from the pre-P4 schema with seeded cross-project duplicates (pool ends with one row, both libraries keep their own status/score/wiki, notes/user-meta repointed without loss).

## Tests

`pytest`: 485 passed + 16 errors — identical to the main baseline (the 16 are a pre-existing `_run_tectonic` fixture patch issue in manuscript/paper-review tests, untouched here). `ruff` clean on all touched files.

## Suggested pre-merge check

Point the dev stack at this branch, run `alembic upgrade head`, and smoke wiki browsing/search/idea generation/writing/MCP on :5173.