### PR TITLE
feat(shelf): topic related-work shelf with wiki snapshots and personal import (IA redesign P5a)

### DIFF
--- a/src/backend/alembic/versions/0775b55c26e4_topic_papers_shelf.py
+++ b/src/backend/alembic/versions/0775b55c26e4_topic_papers_shelf.py
@@ -1,0 +1,53 @@
+"""课题「相关研究」书架（P5a）
+
+新建 topic_papers：课题对内容池论文的引用 + 入架 wiki 快照 + 备注。
+过渡期课题 = project，topic_id 外键 projects；source_library_id 可空
+（个人补充入库为空；删库 SET NULL，书架行靠快照兜底）。
+
+Revision ID: 0775b55c26e4
+Revises: fe8a86942dc7
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0775b55c26e4"
+down_revision: str | None = "fe8a86942dc7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topic_papers",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("topic_id", sa.Uuid(), nullable=False),
+        sa.Column("paper_id", sa.Uuid(), nullable=False),
+        sa.Column("source_library_id", sa.Uuid(), nullable=True),
+        sa.Column("wiki_snapshot", sa.Text(), nullable=True),
+        sa.Column("snapshot_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("added_by", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["topic_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["paper_id"], ["papers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["source_library_id"], ["direction_libraries.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["added_by"], ["users.id"], ondelete="SET NULL"),
+        sa.UniqueConstraint("topic_id", "paper_id", name="uq_topic_papers_topic_paper"),
+    )
+    op.create_index("ix_topic_papers_topic_id", "topic_papers", ["topic_id"])
+    op.create_index("ix_topic_papers_paper_id", "topic_papers", ["paper_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_topic_papers_paper_id", table_name="topic_papers")
+    op.drop_index("ix_topic_papers_topic_id", table_name="topic_papers")
+    op.drop_table("topic_papers")

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -27,6 +27,7 @@ from app.api import (
     projects,
     publications,
     search,
+    shelf,
     skills,
     ssh_credentials,
     users_profile,
@@ -57,6 +58,7 @@ api_router.include_router(ingest.router)
 api_router.include_router(wiki.router)
 api_router.include_router(ideas.router)
 api_router.include_router(search.router)
+api_router.include_router(shelf.router)
 api_router.include_router(skills.router)
 api_router.include_router(market.router)
 api_router.include_router(mcp_meta.router)

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -1,0 +1,157 @@
+"""课题「相关研究」书架路由（P5a）：/projects/{pid}/shelf。
+
+成员鉴权与现有 projects 一致（非成员一律 404）。业务规则在
+services/topic_shelf.py：入架落 wiki 快照 + 同步 upsert 个人库；
+移出只删书架行；个人补充入库不建方向库成员行。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.user import User
+from app.schemas.shelf import (
+    ShelfAddRequest,
+    ShelfIdsRead,
+    ShelfImportRequest,
+    ShelfItemRead,
+    ShelfNoteUpdate,
+    ShelfPage,
+)
+from app.services import paper_import as paper_import_service
+from app.services import projects as projects_service
+from app.services import topic_shelf as shelf_service
+
+router = APIRouter(tags=["shelf"])
+
+
+async def _require_member(session: AsyncSession, project_id: uuid.UUID, user: User) -> None:
+    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+
+
+@router.get("/projects/{project_id}/shelf", response_model=ShelfPage)
+async def list_shelf(
+    project_id: uuid.UUID,
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfPage:
+    await _require_member(session, project_id, user)
+    items, total = await shelf_service.list_shelf(
+        session, project_id=project_id, page=page, size=size
+    )
+    return ShelfPage(
+        items=[ShelfItemRead.model_validate(i) for i in items],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/projects/{project_id}/shelf/ids", response_model=ShelfIdsRead)
+async def list_shelf_ids(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfIdsRead:
+    await _require_member(session, project_id, user)
+    ids = await shelf_service.shelf_paper_ids(session, project_id=project_id)
+    return ShelfIdsRead(paper_ids=ids)
+
+
+@router.post(
+    "/projects/{project_id}/shelf",
+    response_model=ShelfItemRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_to_shelf(
+    project_id: uuid.UUID,
+    body: ShelfAddRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    """入架（重复入架幂等更新 note）；同步收藏进个人库。"""
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.add_to_shelf(
+            session,
+            project_id=project_id,
+            paper_id=body.paper_id,
+            user_id=user.id,
+            note=body.note,
+        )
+    except shelf_service.PaperNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND") from None
+    return ShelfItemRead.model_validate(item)
+
+
+@router.post(
+    "/projects/{project_id}/shelf/import",
+    response_model=ShelfItemRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_to_shelf(
+    project_id: uuid.UUID,
+    body: ShelfImportRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    """个人补充入库：查池命中直接入架；未命中抓取解析入池（不进任何方向库）再入架。"""
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.import_to_shelf(
+            session,
+            project_id=project_id,
+            user_id=user.id,
+            arxiv_id=body.arxiv_id,
+            doi=body.doi,
+            title=body.title,
+        )
+    except paper_import_service.ParseFailedError as e:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
+        ) from e
+    return ShelfItemRead.model_validate(item)
+
+
+@router.patch("/projects/{project_id}/shelf/{paper_id}", response_model=ShelfItemRead)
+async def update_shelf_note(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    body: ShelfNoteUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.update_note(
+            session, project_id=project_id, paper_id=paper_id, note=body.note
+        )
+    except shelf_service.ShelfItemNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    return ShelfItemRead.model_validate(item)
+
+
+@router.delete(
+    "/projects/{project_id}/shelf/{paper_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def remove_from_shelf(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """移出书架：只删书架行，个人库条目不动。"""
+    await _require_member(session, project_id, user)
+    try:
+        await shelf_service.remove_from_shelf(
+            session, project_id=project_id, paper_id=paper_id
+        )
+    except shelf_service.ShelfItemNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -33,6 +33,7 @@ from app.models.review import ReviewMessage, ReviewSession
 from app.models.skill import ProjectSkill, Skill, SkillListing, SkillRating, SkillVersion
 from app.models.ssh_credential import SSHCredential
 from app.models.system_setting import SystemSetting
+from app.models.topic_shelf import TopicPaper
 from app.models.user import User
 from app.models.voyage import VoyageRun, VoyageStep
 
@@ -76,6 +77,7 @@ __all__ = [
     "SkillVersion",
     "SystemSetting",
     "TimestampMixin",
+    "TopicPaper",
     "User",
     "UserAuthorProfile",
     "UserLibraryEntry",

--- a/src/backend/app/models/topic_shelf.py
+++ b/src/backend/app/models/topic_shelf.py
@@ -1,0 +1,50 @@
+"""课题「相关研究」书架（P5a）。
+
+书架三层策略（docs-dev/workspace-ia-redesign.md §3.4）：论文本体纯引用（paper_id
+指向全局内容池，永不复制）；库级 wiki 会漂移/消失 → 入架时落快照兜底，展示时
+库版实时优先；个人备注挂在书架行的 note 上。
+
+过渡期（P5a）课题 = project，topic_id 直接外键 projects；P5 引入独立 Topic 实体后
+随外键平移。入架必入个人库（user_library_entries），由 services/topic_shelf.py 保证。
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.paper import Paper
+
+
+class TopicPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """课题-论文书架行：引用内容池论文 + 入架时的 wiki 快照 + 课题语境备注。"""
+
+    __tablename__ = "topic_papers"
+    __table_args__ = (
+        UniqueConstraint("topic_id", "paper_id", name="uq_topic_papers_topic_paper"),
+    )
+
+    # 过渡期课题 = project（P5 拆出 Topic 实体后平移）
+    topic_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # 来源方向库（溯源用；个人补充入库为空；删库置空、书架行保留靠快照兜底）
+    source_library_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="SET NULL")
+    )
+    # 入架时可得的库版 wiki 快照（markdown）；展示优先级：库版实时 > 快照
+    wiki_snapshot: Mapped[str | None] = mapped_column(Text)
+    snapshot_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 课题语境的「为什么相关」备注
+    note: Mapped[str | None] = mapped_column(Text)
+    added_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+
+    paper: Mapped[Paper] = relationship()

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -1,0 +1,69 @@
+"""课题「相关研究」书架 schema（P5a）。"""
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class ShelfItemRead(BaseModel):
+    """书架条目：论文元数据 + 备注 + 解析后的 wiki（库版实时 > 快照）。"""
+
+    paper_id: uuid.UUID
+    title: str
+    authors: list[dict[str, Any]] = []
+    year: int | None
+    venue: str | None
+    arxiv_id: str | None
+    doi: str | None
+    url: str | None
+    tldr: str | None
+    note: str | None
+    # live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读
+    wiki_source: Literal["live", "snapshot", "none"]
+    wiki_content: str | None
+    snapshot_at: datetime | None
+    source_library_id: uuid.UUID | None
+    added_at: datetime
+
+    @field_validator("authors", mode="before")
+    @classmethod
+    def _default_authors(cls, v: Any) -> Any:
+        return v or []
+
+
+class ShelfPage(BaseModel):
+    items: list[ShelfItemRead]
+    total: int
+    page: int
+    size: int
+
+
+class ShelfIdsRead(BaseModel):
+    """书架全部 paper_id（前端「已入架」勾选态用）。"""
+
+    paper_ids: list[uuid.UUID]
+
+
+class ShelfAddRequest(BaseModel):
+    paper_id: uuid.UUID
+    note: str | None = Field(default=None, max_length=10_000)
+
+
+class ShelfNoteUpdate(BaseModel):
+    note: str | None = Field(default=None, max_length=10_000)
+
+
+class ShelfImportRequest(BaseModel):
+    """个人补充入库：arxiv_id / doi / title 至少给一个。"""
+
+    arxiv_id: str | None = None
+    doi: str | None = None
+    title: str | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one(self) -> "ShelfImportRequest":
+        if not (self.arxiv_id or self.doi or (self.title and self.title.strip())):
+            raise ValueError("arxiv_id / doi / title 至少给一个")
+        return self

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -134,6 +134,90 @@ async def _fields_from_doi(doi: str) -> dict[str, Any]:
     }
 
 
+async def resolve_fields(
+    *,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    bibtex: str | None = None,
+) -> dict[str, Any]:
+    """按来源解析论文字段（arxiv > doi > bibtex）；失败抛 ParseFailedError。"""
+    if arxiv_id:
+        return await _fields_from_arxiv(arxiv_id)
+    if doi:
+        return await _fields_from_doi(doi)
+    return parse_bibtex_entry(bibtex or "")
+
+
+async def create_pool_paper(
+    session: AsyncSession,
+    *,
+    fields: dict[str, Any],
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> Paper:
+    """按解析字段建内容池 Paper（source=manual，**不建任何成员行**；flush 不 commit）。
+
+    调用方负责先查池去重（find_pool_paper）与收尾 commit。有 arxiv_id 的尽力而为
+    补下 PDF + 抽全文；全文到手且无机构时 LLM 补机构（计费按传入的 user/project 归因）。
+    """
+    external_ids: dict[str, str] = {}
+    if fields.get("arxiv_id"):
+        external_ids["arxiv"] = fields["arxiv_id"]
+    if fields.get("doi"):
+        external_ids["doi"] = fields["doi"]
+    paper = Paper(
+        source="manual",
+        dedup_key=pool_dedup_key(
+            arxiv_id=fields.get("arxiv_id"),
+            doi=fields.get("doi"),
+            title=fields["title"],
+            year=fields.get("year"),
+            authors=fields.get("authors"),
+        ),
+        arxiv_id=fields.get("arxiv_id"),
+        doi=fields.get("doi"),
+        external_ids=external_ids or None,
+        title=fields["title"],
+        authors=fields.get("authors"),
+        affiliations=fields.get("affiliations"),
+        abstract=fields.get("abstract"),
+        year=fields.get("year"),
+        venue=fields.get("venue"),
+        url=fields.get("url"),
+        published_at=fields.get("published_at"),
+    )
+    session.add(paper)
+    await session.flush()
+
+    if paper.arxiv_id:
+        # 尽力而为补下 PDF + 抽全文；失败只记日志，不阻塞创建
+        from app.services.literature.pdf_extract import extract_full_text, save_pdf
+
+        try:
+            content = await get_arxiv_client().download_pdf(paper.arxiv_id)
+            pdf_path = save_pdf(str(paper.id), content)
+            paper.pdf_path = str(pdf_path)
+            txt_path = await extract_full_text(str(paper.id), pdf_path)
+            paper.full_text_path = str(txt_path)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning("auto PDF fetch failed for paper %s", paper.id, exc_info=True)
+
+    # 发表机构：全文到手后 LLM 从标题页解析（DOI 路径已有 OpenAlex 机构时不覆盖）；
+    # 失败不影响创建
+    if not paper.affiliations and paper.full_text_path:
+        from app.core.llm.router import get_llm_router
+        from app.services.affiliations import extract_affiliations_llm
+
+        affs = await extract_affiliations_llm(
+            paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+        )
+        if affs:
+            paper.affiliations = affs
+    return paper
+
+
 async def add_manual_paper(
     session: AsyncSession,
     *,
@@ -149,12 +233,7 @@ async def add_manual_paper(
     - 解析失败 → ParseFailedError（路由映射 422）
     - 新论文有 arxiv_id 的自动尝试补下 PDF，失败只记日志不阻塞
     """
-    if arxiv_id:
-        fields = await _fields_from_arxiv(arxiv_id)
-    elif doi:
-        fields = await _fields_from_doi(doi)
-    else:
-        fields = parse_bibtex_entry(bibtex or "")
+    fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
 
     library = await get_library_for_project(session, project_id)
     dedup_key = pool_dedup_key(
@@ -178,55 +257,8 @@ async def add_manual_paper(
         await session.refresh(pooled)
         return pooled
 
-    external_ids: dict[str, str] = {}
-    if fields.get("arxiv_id"):
-        external_ids["arxiv"] = fields["arxiv_id"]
-    if fields.get("doi"):
-        external_ids["doi"] = fields["doi"]
-    paper = Paper(
-        source="manual",
-        dedup_key=dedup_key,
-        arxiv_id=fields.get("arxiv_id"),
-        doi=fields.get("doi"),
-        external_ids=external_ids or None,
-        title=fields["title"],
-        authors=fields.get("authors"),
-        affiliations=fields.get("affiliations"),
-        abstract=fields.get("abstract"),
-        year=fields.get("year"),
-        venue=fields.get("venue"),
-        url=fields.get("url"),
-        published_at=fields.get("published_at"),
-    )
-    session.add(paper)
-    await session.flush()
+    paper = await create_pool_paper(session, fields=fields, project_id=project_id)
     await ensure_membership(session, library_id=library.id, paper_id=paper.id, status="included")
-
-    if paper.arxiv_id:
-        # 尽力而为补下 PDF + 抽全文；失败只记日志，不阻塞创建
-        from app.services.literature.pdf_extract import extract_full_text, save_pdf
-
-        try:
-            content = await get_arxiv_client().download_pdf(paper.arxiv_id)
-            pdf_path = save_pdf(str(paper.id), content)
-            paper.pdf_path = str(pdf_path)
-            txt_path = await extract_full_text(str(paper.id), pdf_path)
-            paper.full_text_path = str(txt_path)
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001
-            logger.warning("auto PDF fetch failed for paper %s", paper.id, exc_info=True)
-
-    # 发表机构：全文到手后 LLM 从标题页解析（DOI 路径已有 OpenAlex 机构时不覆盖）；
-    # 失败不影响创建
-    if not paper.affiliations and paper.full_text_path:
-        from app.core.llm.router import get_llm_router
-        from app.services.affiliations import extract_affiliations_llm
-
-        affs = await extract_affiliations_llm(paper, llm=get_llm_router(), project_id=project_id)
-        if affs:
-            paper.affiliations = affs
-
     await session.commit()
     await session.refresh(paper)
     return paper

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -1,0 +1,278 @@
+"""课题「相关研究」书架业务逻辑（P5a，不 import fastapi）。
+
+三条铁律（docs-dev/workspace-ia-redesign.md §3.4/§3.6）：
+- 论文本体纯引用（paper_id 指向全局内容池）；
+- 库版 wiki 引用为主、入架落快照兜底：展示优先级 库版实时 > 快照；
+- 入架必入个人库（user_library_entries，saved=true，共享同一次快照写入）；
+  移出书架不动个人库。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.models.topic_shelf import TopicPaper
+from app.services import paper_import, user_library
+from app.services.dedup import dedup_key_for
+from app.services.libraries import find_pool_paper
+from app.services.literature.arxiv import normalize_arxiv_id
+
+
+class PaperNotFoundError(Exception):
+    """paper_id 在内容池中不存在。"""
+
+
+class ShelfItemNotFoundError(Exception):
+    """课题书架上没有这篇论文。"""
+
+
+class _SnapshotPaper:
+    """给个人库快照用的论文视图：本体字段透传 Paper + 书架解析出的 wiki。"""
+
+    __slots__ = ("_paper", "wiki_content")
+
+    def __init__(self, paper: Paper, wiki_content: str | None) -> None:
+        self._paper = paper
+        self.wiki_content = wiki_content
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_paper"), name)
+
+
+async def _wiki_rows_for(
+    session: AsyncSession, paper_ids: list[uuid.UUID]
+) -> list[Any]:
+    """论文在各方向库的成员行概览：(paper_id, library_id, project_id, wiki_content)。"""
+    if not paper_ids:
+        return []
+    stmt = (
+        select(
+            LibraryPaper.paper_id,
+            LibraryPaper.library_id,
+            DirectionLibrary.project_id,
+            LibraryPaper.wiki_content,
+        )
+        .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
+        .where(LibraryPaper.paper_id.in_(paper_ids))
+    )
+    return list((await session.execute(stmt)).all())
+
+
+def _pick_live_wiki(rows: list[Any], project_id: uuid.UUID) -> str | None:
+    """从成员行里挑当前可得的库版 wiki：本课题隐式库优先，其次任一有 wiki 的库。"""
+    own = next((r for r in rows if r.project_id == project_id and r.wiki_content), None)
+    if own is not None:
+        return own.wiki_content
+    other = next((r for r in rows if r.wiki_content), None)
+    return other.wiki_content if other is not None else None
+
+
+def _item_dict(row: TopicPaper, paper: Paper, live_wiki: str | None) -> dict[str, Any]:
+    """书架条目出参：wiki 展示优先级 库版实时 > 快照；source 标注来源状态。"""
+    if live_wiki is not None:
+        wiki_source, wiki_content = "live", live_wiki
+    elif row.wiki_snapshot:
+        wiki_source, wiki_content = "snapshot", row.wiki_snapshot
+    else:
+        wiki_source, wiki_content = "none", None
+    return {
+        "paper_id": paper.id,
+        "title": paper.title,
+        "authors": paper.authors or [],
+        "year": paper.year,
+        "venue": paper.venue,
+        "arxiv_id": paper.arxiv_id,
+        "doi": paper.doi,
+        "url": paper.url,
+        "tldr": paper.tldr,
+        "note": row.note,
+        "wiki_source": wiki_source,
+        "wiki_content": wiki_content,
+        "snapshot_at": row.snapshot_at,
+        "source_library_id": row.source_library_id,
+        "added_at": row.created_at,
+    }
+
+
+async def _get_row(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
+) -> TopicPaper | None:
+    stmt = select(TopicPaper).where(
+        TopicPaper.topic_id == project_id, TopicPaper.paper_id == paper_id
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _item_of(
+    session: AsyncSession, row: TopicPaper, paper: Paper, project_id: uuid.UUID
+) -> dict[str, Any]:
+    wiki_rows = await _wiki_rows_for(session, [paper.id])
+    return _item_dict(row, paper, _pick_live_wiki(wiki_rows, project_id))
+
+
+async def list_shelf(
+    session: AsyncSession, *, project_id: uuid.UUID, page: int = 1, size: int = 20
+) -> tuple[list[dict[str, Any]], int]:
+    """分页列书架（最新入架在前），每条带解析后的 wiki 内容与来源状态。"""
+    base = (
+        select(TopicPaper, Paper)
+        .join(Paper, Paper.id == TopicPaper.paper_id)
+        .where(TopicPaper.topic_id == project_id)
+    )
+    total = (await session.execute(base.with_only_columns(func.count()))).scalar_one()
+    rows = (
+        await session.execute(
+            base.order_by(TopicPaper.created_at.desc())
+            .offset((page - 1) * size)
+            .limit(size)
+        )
+    ).all()
+    wiki_rows = await _wiki_rows_for(session, [paper.id for _, paper in rows])
+    by_paper: dict[uuid.UUID, list[Any]] = {}
+    for r in wiki_rows:
+        by_paper.setdefault(r.paper_id, []).append(r)
+    items = [
+        _item_dict(row, paper, _pick_live_wiki(by_paper.get(paper.id, []), project_id))
+        for row, paper in rows
+    ]
+    return items, int(total)
+
+
+async def shelf_paper_ids(session: AsyncSession, *, project_id: uuid.UUID) -> list[uuid.UUID]:
+    """书架全部 paper_id（前端标记「已入架」勾选态用）。"""
+    stmt = (
+        select(TopicPaper.paper_id)
+        .where(TopicPaper.topic_id == project_id)
+        .order_by(TopicPaper.created_at.desc())
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def add_to_shelf(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """入架：落 wiki 快照 + 同步 upsert 个人库（saved，共享同一次快照）。
+
+    重复入架幂等：只更新 note（快照保持首次入架时的版本）。
+    """
+    paper = await session.get(Paper, paper_id)
+    if paper is None:
+        raise PaperNotFoundError(str(paper_id))
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is not None:
+        if note is not None:
+            row.note = note
+        await session.commit()
+        return await _item_of(session, row, paper, project_id)
+
+    wiki_rows = await _wiki_rows_for(session, [paper_id])
+    live_wiki = _pick_live_wiki(wiki_rows, project_id)
+    # 来源库溯源：本课题隐式库优先，其次提供快照 wiki 的库，再其次任一库；都没有 = 个人补充
+    own = next((r for r in wiki_rows if r.project_id == project_id), None)
+    with_wiki = next((r for r in wiki_rows if r.wiki_content), None)
+    source = own or with_wiki or (wiki_rows[0] if wiki_rows else None)
+    row = TopicPaper(
+        topic_id=project_id,
+        paper_id=paper_id,
+        source_library_id=source.library_id if source is not None else None,
+        wiki_snapshot=live_wiki,
+        snapshot_at=utcnow() if live_wiki is not None else None,
+        note=note,
+        added_by=user_id,
+    )
+    session.add(row)
+    await session.flush()
+    # 入架必入个人库（书架是个人库的课题投影）；save_paper 内部 commit 一并落书架行
+    await user_library.save_paper(
+        session, user_id=user_id, paper=_SnapshotPaper(paper, live_wiki)
+    )
+    return await _item_of(session, row, paper, project_id)
+
+
+async def update_note(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID, note: str | None
+) -> dict[str, Any]:
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    row.note = note
+    await session.commit()
+    paper = await session.get(Paper, paper_id)
+    assert paper is not None  # 书架行外键保证
+    return await _item_of(session, row, paper, project_id)
+
+
+async def remove_from_shelf(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
+) -> None:
+    """移出书架：只删书架行；个人库条目与内容池行都不动。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    await session.delete(row)
+    await session.commit()
+
+
+async def import_to_shelf(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """个人补充入库：先按 dedup 查全局池，命中直接入架；未命中抓取解析入池后入架。
+
+    个人补充**不建任何 library_papers 成员行**（「在池但不在任何库」是合法状态，
+    §3.5）；解析计费按现有归因规则记调用用户。仅有标题且池中查不到时无法抓取
+    （paper_import.ParseFailedError → 路由映射 422）。
+    """
+    normalized_arxiv = normalize_arxiv_id(arxiv_id) if arxiv_id else None
+    clean_doi = doi.strip().removeprefix("https://doi.org/") if doi else None
+    paper = await find_pool_paper(
+        session,
+        arxiv_id=normalized_arxiv,
+        doi=clean_doi,
+        dedup_key=dedup_key_for(arxiv_id=normalized_arxiv, doi=clean_doi, title=title),
+    )
+    if paper is None and title and title.strip():
+        # 标题兜底：池键掺年份/首作者，纯标题哈希未必命中 → 退回大小写不敏感精确匹配
+        stmt = select(Paper).where(func.lower(Paper.title) == title.strip().lower()).limit(1)
+        paper = (await session.execute(stmt)).scalars().first()
+    if paper is None:
+        if not (normalized_arxiv or clean_doi):
+            raise paper_import.ParseFailedError(
+                "按标题没有找到这篇论文，请提供 arXiv 编号或 DOI"
+            )
+        fields = await paper_import.resolve_fields(arxiv_id=arxiv_id, doi=doi)
+        # 解析出的规范 id 再查一次池（输入可能是版本号/别名）
+        paper = await find_pool_paper(
+            session,
+            arxiv_id=fields.get("arxiv_id"),
+            doi=fields.get("doi"),
+            dedup_key=dedup_key_for(
+                arxiv_id=fields.get("arxiv_id"),
+                doi=fields.get("doi"),
+                title=fields.get("title"),
+                year=fields.get("year"),
+                authors=fields.get("authors"),
+            ),
+        )
+        if paper is None:
+            paper = await paper_import.create_pool_paper(
+                session, fields=fields, user_id=user_id, project_id=project_id
+            )
+    return await add_to_shelf(
+        session, project_id=project_id, paper_id=paper.id, user_id=user_id
+    )

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "fe8a86942dc7"  # 论文内容池收尾（P4 迁移 B，本分支最新）
-PREV_REVISION = "f7c2abfe8aeb"  # 方向文献库 + 论文内容池（P4 迁移 A）
+HEAD_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a，本分支最新）
+PREV_REVISION = "fe8a86942dc7"  # 论文内容池收尾（P4 迁移 B）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -57,6 +57,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "feedback_images",
                     "user_library_entries",
                     "user_publications",
+                    "topic_papers",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -208,13 +209,27 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "library_papers",
     } <= columns["_tables"]
     assert "dedup_key" in columns["papers"]
+    # 本分支新增：课题「相关研究」书架表（P5a）
+    assert "topic_papers" in columns["_tables"]
+    assert {
+        "topic_id",
+        "paper_id",
+        "source_library_id",
+        "wiki_snapshot",
+        "snapshot_at",
+        "note",
+        "added_by",
+    } <= columns["topic_papers"]
 
-    # 最新 revision 可往返（downgrade 还原 papers/concepts/paper_chunks 的旧列结构）
+    # 最新 revision 可往返（downgrade 只删 topic_papers，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert {"project_id", "status", "relevance_score", "wiki_content"} <= columns["papers"]
-    assert "dedup_key" in columns["papers"]  # 迁移 A 的列仍在
+    assert "topic_papers" not in columns["_tables"]
+    # P4 收尾后的内容池结构不受影响：判断列仍只在 library_papers 上
+    assert "project_id" not in columns["papers"]
+    assert "wiki_content" not in columns["papers"]
+    assert "dedup_key" in columns["papers"]
     assert "library_papers" in columns["_tables"]
     assert "preset_directions" in columns["registration_codes"]
     assert "wiki_content" in columns["user_library_entries"]

--- a/src/backend/tests/test_topic_shelf.py
+++ b/src/backend/tests/test_topic_shelf.py
@@ -1,0 +1,338 @@
+"""课题「相关研究」书架（P5a）：入架快照 / 幂等 / 移除不动个人库 / 个人补充入库。"""
+
+import uuid
+
+import fakeredis.aioredis
+import httpx
+import pytest_asyncio
+import respx
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.topic_shelf import TopicPaper
+from app.services.literature import reset_clients, set_clients
+from app.services.literature.arxiv import ArxivClient
+from app.services.literature.openalex import OpenAlexClient
+from tests.conftest import add_paper, membership_of, register_and_login
+
+ARXIV_FEED_ONE = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2407.12345v1</id>
+    <title>Personal Supplement Paper</title>
+    <summary>A paper added personally, outside any direction library.</summary>
+    <published>2026-07-01T00:00:00Z</published>
+    <author><name>Carol Wu</name></author>
+    <category term="cs.CL"/>
+  </entry>
+</feed>
+"""
+
+
+@pytest_asyncio.fixture
+async def lit_clients():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    set_clients(
+        arxiv=ArxivClient(redis=redis, min_interval=0),
+        openalex=OpenAlexClient(redis=redis, mailto="test@example.org"),
+    )
+    yield
+    reset_clients()
+    await redis.aclose()
+
+
+async def _setup(client, *, name="shelf-proj", email="alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_paper(project_id, **fields):
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=project_id, **fields)
+        await session.commit()
+        return str(paper.id)
+
+
+async def test_add_to_shelf_snapshots_wiki_and_saves_to_personal_library(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(
+        project_id,
+        title="Shelved Paper",
+        arxiv_id="2401.00001",
+        status="compiled",
+        wiki_content="# 库版解读",
+    )
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf",
+        json={"paper_id": paper_id, "note": "跟我的课题相关"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["paper_id"] == paper_id
+    assert body["note"] == "跟我的课题相关"
+    assert body["wiki_source"] == "live"
+    assert body["wiki_content"] == "# 库版解读"
+    assert body["snapshot_at"] is not None
+    assert body["source_library_id"] is not None
+
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        assert row.wiki_snapshot == "# 库版解读"
+        assert str(row.topic_id) == project_id
+        # 入架必入个人库：saved 且共享同一次快照
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        assert entry.saved is True
+        assert entry.wiki_content == "# 库版解读"
+
+
+async def test_add_is_idempotent_and_updates_note(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(project_id, title="Idempotent Paper", status="scored")
+
+    for note in ("first", "second"):
+        resp = await client.post(
+            f"/api/projects/{project_id}/shelf",
+            json={"paper_id": paper_id, "note": note},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.status_code == 200
+    page = resp.json()
+    assert page["total"] == 1
+    assert page["items"][0]["note"] == "second"
+    assert page["items"][0]["wiki_source"] == "none"
+
+    # ids 端点：勾选态用
+    resp = await client.get(f"/api/projects/{project_id}/shelf/ids", headers=headers)
+    assert resp.json()["paper_ids"] == [paper_id]
+
+
+async def test_snapshot_fallback_after_library_removal(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(
+        project_id, title="Vanishing Paper", status="compiled", wiki_content="# 快照兜底"
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+
+    # 模拟论文被从方向库剔除：删成员行（内容池行保留）
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        await session.delete(membership)
+        await session.commit()
+
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "snapshot"
+    assert item["wiki_content"] == "# 快照兜底"
+    assert item["snapshot_at"] is not None
+
+
+async def test_note_patch_and_remove_keeps_personal_library(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(project_id, title="Removable Paper", status="scored")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf",
+        json={"paper_id": paper_id, "note": "初始备注"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+
+    resp = await client.patch(
+        f"/api/projects/{project_id}/shelf/{paper_id}", json={"note": "改后备注"}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["note"] == "改后备注"
+
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers)
+    assert resp.status_code == 204
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["total"] == 0
+
+    # 移出书架不动个人库
+    async with get_sessionmaker()() as session:
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        assert entry.saved is True
+
+    # 再删 → 404
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_import_pool_hit_shelves_without_library_membership(client):
+    """池命中：他方向已有的论文直接入架，不给本课题隐式库建成员行。"""
+    project_id, headers = await _setup(client)
+    resp = await client.post("/api/projects", json={"name": "other-proj"}, headers=headers)
+    other_project_id = resp.json()["id"]
+    paper_id = await _seed_paper(
+        other_project_id,
+        title="Pooled Paper",
+        arxiv_id="2402.00002",
+        status="compiled",
+        wiki_content="# 他库解读",
+    )
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import",
+        json={"arxiv_id": "2402.00002"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["paper_id"] == paper_id
+    # 本课题库没有该论文 → 快照取自他库的 wiki
+    assert body["wiki_source"] == "live"
+    assert body["wiki_content"] == "# 他库解读"
+
+    async with get_sessionmaker()() as session:
+        assert await membership_of(session, project_id=project_id, paper_id=paper_id) is None
+        # 内容池仍只有一行
+        papers = (
+            (await session.execute(select(Paper).where(Paper.arxiv_id == "2402.00002")))
+            .scalars()
+            .all()
+        )
+        assert len(papers) == 1
+
+
+@respx.mock
+async def test_import_miss_fetches_and_creates_pool_only_paper(client, lit_clients):
+    """池未命中：抓 arxiv 解析入池（不建任何 library_papers 行）后入架 + 入个人库。"""
+    project_id, headers = await _setup(client)
+    respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        return_value=httpx.Response(200, text=ARXIV_FEED_ONE)
+    )
+    respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(return_value=httpx.Response(404))
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import",
+        json={"arxiv_id": "2407.12345v1"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == "Personal Supplement Paper"
+    assert body["wiki_source"] == "none"
+    assert body["source_library_id"] is None  # 个人补充：不挂任何来源库
+    paper_id = body["paper_id"]
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(paper_id))
+        assert paper is not None and paper.source == "manual"
+        # 「在池但不在任何库」是合法状态
+        memberships = (
+            (
+                await session.execute(
+                    select(LibraryPaper).where(LibraryPaper.paper_id == uuid.UUID(paper_id))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert memberships == []
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        assert entry.saved is True
+
+    # 再次 import 同一编号 → 池命中，幂等回到同一书架行
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import",
+        json={"arxiv_id": "2407.12345"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["paper_id"] == paper_id
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["total"] == 1
+
+
+async def test_import_title_only_pool_hit_and_miss(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(project_id, title="Titled Pool Paper", status="scored")
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import",
+        json={"title": "titled pool paper"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["paper_id"] == paper_id
+
+    # 只有标题且池中没有 → 无法抓取，422
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import",
+        json={"title": "No Such Paper Anywhere"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"].startswith("PARSE_FAILED")
+
+    # 三选一都不给 → 422（pydantic 校验）
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/import", json={}, headers=headers
+    )
+    assert resp.status_code == 422
+
+
+async def test_shelf_requires_project_membership(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_paper(project_id, title="Members Only", status="scored")
+    outsider = await register_and_login(client, email="shelf-outsider@example.com")
+    outsider_headers = {"Authorization": f"Bearer {outsider}"}
+
+    for method, url, kwargs in (
+        ("get", f"/api/projects/{project_id}/shelf", {}),
+        ("get", f"/api/projects/{project_id}/shelf/ids", {}),
+        ("post", f"/api/projects/{project_id}/shelf", {"json": {"paper_id": paper_id}}),
+        (
+            "post",
+            f"/api/projects/{project_id}/shelf/import",
+            {"json": {"arxiv_id": "2401.99999"}},
+        ),
+        ("patch", f"/api/projects/{project_id}/shelf/{paper_id}", {"json": {"note": "x"}}),
+        ("delete", f"/api/projects/{project_id}/shelf/{paper_id}", {}),
+    ):
+        resp = await getattr(client, method)(url, headers=outsider_headers, **kwargs)
+        assert resp.status_code == 404, (method, url, resp.text)
+
+    # 池中不存在的 paper_id 入架 → 404 PAPER_NOT_FOUND
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf",
+        json={"paper_id": str(uuid.uuid4())},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "PAPER_NOT_FOUND"

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -34,6 +34,7 @@ const NAV_LAB: NavEntry[] = [
 
 const NAV_MAIN: NavEntry[] = [
   { icon: 'dashboard', zh: '工作台', en: 'Workbench' },
+  { sub: 'research', icon: 'pin', zh: '相关研究', en: 'Related Work' },
 ];
 
 const NAV_PIPE: NavEntry[] = [
@@ -70,6 +71,7 @@ function crumbFor(pathname: string): [string, string] {
   if (p.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
   const table: Record<string, [string, string]> = {
     '/wiki': [tr('实验室', 'Lab'), tr('文献追踪', 'Research Wiki')],
+    '/research': [tr('课题研究', 'Topic'), tr('相关研究', 'Related Work')],
     '/forge': ['Stage 01', tr('想法生成', 'Idea Forge')],
     '/review': ['Stage 02', tr('想法评审', 'Idea Review')],
     '/experiment': ['Stage 03', tr('实验搭建', 'Experiment Lab')],

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -108,6 +108,7 @@ export const router = createBrowserRouter([
             children: [
               { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
               { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
+              { path: 'research', element: page(() => import('../features/research/ResearchPage'), 'ResearchPage') },
               { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
               { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
               { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
@@ -125,6 +126,7 @@ export const router = createBrowserRouter([
           // 旧路径重定向：跳到当前课题下的同名子页面
           { index: true, element: <LegacyTopicRedirect /> },
           { path: 'wiki', element: <LegacyTopicRedirect sub="wiki" /> },
+          { path: 'research', element: <LegacyTopicRedirect sub="research" /> },
           { path: 'forge', element: <LegacyTopicRedirect sub="forge" /> },
           { path: 'review', element: <LegacyTopicRedirect sub="review" /> },
           { path: 'experiment', element: <LegacyTopicRedirect sub="experiment" /> },

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -147,6 +147,37 @@ export function ReadingPage() {
       toast(`${tr('操作失败：', 'Action failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
+  // —— 课题「相关研究」书架：入架状态 + 加入/移出（P5a） ——
+  const projectId = paper?.project_id;
+  const shelfIdsQuery = useQuery({
+    queryKey: ['shelf-ids', projectId],
+    queryFn: () => api.listShelfIds(projectId!),
+    enabled: !!projectId,
+    retry: false,
+  });
+  const shelved = !!paperId && (shelfIdsQuery.data?.paper_ids ?? []).includes(paperId);
+  const shelfMutation = useMutation({
+    mutationFn: () =>
+      shelved
+        ? api.removeFromShelf(projectId!, paperId!)
+        : api.addToShelf(projectId!, { paper_id: paperId! }).then(() => undefined),
+    onSuccess: () => {
+      toast(
+        shelved
+          ? tr('已移出相关研究（个人库收藏保留）', 'Removed from related work (kept in my library)')
+          : tr('已加入相关研究', 'Added to related work'),
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['shelf-ids', projectId] });
+      void queryClient.invalidateQueries({ queryKey: ['shelf', projectId] });
+      // 入架同步收藏进个人库
+      void queryClient.invalidateQueries({ queryKey: ['library-state', id] });
+      void queryClient.invalidateQueries({ queryKey: ['library'] });
+    },
+    onError: (e) =>
+      toast(`${tr('操作失败：', 'Action failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
   const invalidateHighlights = useCallback(
     () => void queryClient.invalidateQueries({ queryKey: ['paper-highlights', id] }),
     [queryClient, id],
@@ -240,6 +271,15 @@ export function ReadingPage() {
             {paper.arxiv_id ?? paper.venue ?? tr('论文阅读', 'Paper reading')}
           </div>
         </div>
+        <button
+          className="icon-btn"
+          title={shelved ? tr('已在相关研究 · 点击移出', 'In related work · click to remove') : tr('加入相关研究', 'Add to related work')}
+          disabled={shelfMutation.isPending || shelfIdsQuery.isLoading}
+          onClick={() => shelfMutation.mutate()}
+          style={{ color: shelved ? 'var(--accent)' : 'var(--text-3)' }}
+        >
+          <Icon name="pin" size={17} />
+        </button>
         <button
           className="icon-btn"
           title={libSaved ? tr('从文献库移除', 'Remove from my library') : tr('加入文献库', 'Add to my library')}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -1,0 +1,532 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { PageHead } from '../../components/ui/PageHead';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { toast } from '../../components/ui/Toast';
+import { api, type ShelfImportInput, type ShelfItemRead } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { topicPath, useProject } from '../../app/project';
+import { SearchInput, useDebounced } from '../wiki/shared';
+
+/* ============================================================
+   /t/:topicId/research — 课题「相关研究」书架：
+   从方向文献库挑论文入架（引用为主、入架落 wiki 快照兜底），
+   或用 arXiv 编号 / DOI 个人补充入库；每篇可写「为什么相关」备注。
+   入架同时自动收藏进「我的文献库」；移出书架不动个人库。
+   ============================================================ */
+
+const PAGE_SIZE = 50;
+
+function errText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** 快照日期 → 「7 月 22 日」 / "Jul 22"。 */
+function fmtSnapshotDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return tr(
+    `${d.getMonth() + 1} 月 ${d.getDate()} 日`,
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  );
+}
+
+/** 手动添加输入解析：DOI（10.xxx / doi.org 链接）之外一律按 arXiv 编号处理。 */
+function parseImportInput(raw: string): ShelfImportInput | null {
+  let v = raw.trim();
+  if (!v) return null;
+  if (v.includes('doi.org/')) v = v.slice(v.indexOf('doi.org/') + 'doi.org/'.length);
+  if (/^10\.\d{4,}/.test(v)) return { doi: v };
+  if (v.includes('arxiv.org/')) {
+    const seg = v.split('/').filter(Boolean);
+    v = (seg[seg.length - 1] ?? '').replace(/\.pdf$/, '');
+  }
+  return v ? { arxiv_id: v } : null;
+}
+
+/* ---------------- wiki 来源徽标 ---------------- */
+
+function WikiBadge({ item }: { item: ShelfItemRead }) {
+  if (item.wiki_source === 'live') {
+    return (
+      <span
+        className="mono"
+        style={{
+          fontSize: 10,
+          color: 'var(--ok-tx)',
+          background: 'var(--ok-bg)',
+          padding: '1px 7px',
+          borderRadius: 999,
+          flexShrink: 0,
+        }}
+      >
+        {tr('解读可用', 'Wiki available')}
+      </span>
+    );
+  }
+  if (item.wiki_source === 'snapshot') {
+    return (
+      <span
+        className="mono"
+        title={tr(
+          '这篇论文的库版解读已不可用（被移除或重编译），下面显示的是入架时的快照。',
+          'The library wiki is no longer available; showing the snapshot taken when it was shelved.',
+        )}
+        style={{
+          fontSize: 10,
+          color: 'var(--warn-tx)',
+          background: 'var(--warn-bg)',
+          padding: '1px 7px',
+          borderRadius: 999,
+          flexShrink: 0,
+        }}
+      >
+        {tr(
+          `库中版本不可用 · ${fmtSnapshotDate(item.snapshot_at)}快照`,
+          `Library copy unavailable · snapshot ${fmtSnapshotDate(item.snapshot_at)}`,
+        )}
+      </span>
+    );
+  }
+  return null;
+}
+
+/* ---------------- 书架卡片（备注内联编辑） ---------------- */
+
+function ShelfCard({
+  item,
+  busy,
+  onOpen,
+  onSaveNote,
+  onRemove,
+}: {
+  item: ShelfItemRead;
+  busy: boolean;
+  onOpen: () => void;
+  onSaveNote: (note: string | null) => void;
+  onRemove: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(item.note ?? '');
+  const authors = item.authors.map((a) => a.name).join(', ');
+
+  const save = () => {
+    const next = draft.trim() || null;
+    setEditing(false);
+    if (next !== (item.note ?? null)) onSaveNote(next);
+  };
+
+  return (
+    <div className="card" style={{ padding: '14px 16px' }}>
+      <div className="row gap8" style={{ marginBottom: 5 }}>
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+          {item.arxiv_id ?? item.venue ?? '—'}
+        </span>
+        {item.year !== null && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{item.year}</span>
+        )}
+        <WikiBadge item={item} />
+        <span style={{ marginLeft: 'auto' }} />
+        <button
+          className="icon-btn"
+          title={tr('移出相关研究（个人库收藏保留）', 'Remove from related work (kept in my library)')}
+          disabled={busy}
+          onClick={onRemove}
+        >
+          <Icon name="trash" size={14} />
+        </button>
+      </div>
+
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onOpen();
+          }
+        }}
+        title={tr('打开阅读页', 'Open the reading page')}
+        style={{ fontSize: 13.5, fontWeight: 620, lineHeight: 1.35, cursor: 'pointer', color: 'var(--text)' }}
+      >
+        {item.title}
+      </div>
+      {(authors || item.venue) && (
+        <div
+          title={authors}
+          style={{
+            fontSize: 11.5,
+            color: 'var(--text-3)',
+            marginTop: 3,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {authors}
+          {authors && item.venue && item.arxiv_id ? ` · ${item.venue}` : ''}
+        </div>
+      )}
+
+      {/* —— 备注：点击进入编辑，失焦/⌘Enter 保存 —— */}
+      {editing ? (
+        <textarea
+          className="input"
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={save}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) save();
+            if (e.key === 'Escape') {
+              setDraft(item.note ?? '');
+              setEditing(false);
+            }
+          }}
+          placeholder={tr('这篇为什么和课题相关？', 'Why is this paper relevant?')}
+          style={{ marginTop: 8, width: '100%', minHeight: 54, fontSize: 12, lineHeight: 1.5, resize: 'vertical' }}
+        />
+      ) : (
+        <button
+          onClick={() => {
+            setDraft(item.note ?? '');
+            setEditing(true);
+          }}
+          title={tr('编辑备注', 'Edit note')}
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 6,
+            width: '100%',
+            marginTop: 8,
+            padding: '6px 8px',
+            border: 'none',
+            borderRadius: 8,
+            background: item.note ? 'var(--surface-2)' : 'transparent',
+            cursor: 'text',
+            textAlign: 'left',
+            fontSize: 12,
+            lineHeight: 1.5,
+            fontFamily: 'var(--sans)',
+            color: item.note ? 'var(--text-2)' : 'var(--text-4)',
+          }}
+        >
+          <Icon name="pen" size={12} style={{ marginTop: 2, flexShrink: 0, color: 'var(--text-4)' }} />
+          <span style={{ whiteSpace: 'pre-wrap' }}>
+            {item.note ?? tr('添加备注：这篇为什么相关…', 'Add a note: why is this relevant…')}
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ---------------- 页面 ---------------- */
+
+export function ResearchPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { currentProjectId } = useProject();
+  const pid = currentProjectId ?? '';
+
+  const [page, setPage] = useState(1);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [qInput, setQInput] = useState('');
+  const q = useDebounced(qInput.trim());
+  const [importInput, setImportInput] = useState('');
+  const importRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => setPage(1), [pid]);
+
+  const shelfQuery = useQuery({
+    queryKey: ['shelf', pid, page],
+    queryFn: () => api.listShelf(pid, { page, size: PAGE_SIZE }),
+    enabled: !!pid,
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+  const idsQuery = useQuery({
+    queryKey: ['shelf-ids', pid],
+    queryFn: () => api.listShelfIds(pid),
+    enabled: !!pid,
+    retry: false,
+  });
+  const shelvedIds = new Set(idsQuery.data?.paper_ids ?? []);
+
+  const searchQuery = useQuery({
+    queryKey: ['shelf-search', pid, q],
+    queryFn: () => api.searchProject(pid, { q, limit: 8 }),
+    enabled: !!pid && searchOpen && q.length > 0,
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['shelf', pid] });
+    void queryClient.invalidateQueries({ queryKey: ['shelf-ids', pid] });
+    // 入架同步收藏进个人库
+    void queryClient.invalidateQueries({ queryKey: ['library'] });
+    void queryClient.invalidateQueries({ queryKey: ['library-state'] });
+  };
+
+  const addMutation = useMutation({
+    mutationFn: (paperId: string) => api.addToShelf(pid, { paper_id: paperId }),
+    onSuccess: () => {
+      toast(tr('已加入相关研究', 'Added to related work'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('入架失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
+  });
+
+  const importMutation = useMutation({
+    mutationFn: (input: ShelfImportInput) => api.importToShelf(pid, input),
+    onSuccess: () => {
+      toast(tr('已添加到相关研究', 'Added to related work'), 'ok');
+      setImportInput('');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('添加失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
+  });
+
+  const noteMutation = useMutation({
+    mutationFn: ({ paperId, note }: { paperId: string; note: string | null }) =>
+      api.updateShelfNote(pid, paperId, note),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['shelf', pid] }),
+    onError: (e) => toast(`${tr('备注保存失败：', 'Failed to save note: ')}${errText(e)}`, 'error'),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (paperId: string) => api.removeFromShelf(pid, paperId),
+    onSuccess: () => {
+      toast(tr('已移出相关研究（个人库收藏保留）', 'Removed (still saved in my library)'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
+  });
+
+  const submitImport = () => {
+    const input = parseImportInput(importInput);
+    if (!input) {
+      toast(tr('先输入 arXiv 编号或 DOI', 'Enter an arXiv ID or DOI first'), 'info');
+      return;
+    }
+    importMutation.mutate(input);
+  };
+
+  const data = shelfQuery.data;
+  const items = data?.items ?? [];
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / data.size)) : 1;
+  const busy = addMutation.isPending || removeMutation.isPending || noteMutation.isPending;
+
+  return (
+    <div style={{ padding: '26px 30px', maxWidth: 860 }}>
+      <PageHead
+        eyebrow={tr('课题研究', 'Topic')}
+        title={tr('相关研究', 'Related Work')}
+        sub={tr(
+          '这个课题直接依赖的论文书架：从文献库挑选，或手动补充库外论文。',
+          'Papers this topic builds on: pick from the library, or add ones outside it.',
+        )}
+        right={
+          <>
+            <button
+              className={'btn sm ' + (searchOpen ? 'btn-primary' : 'btn-soft')}
+              onClick={() => {
+                setSearchOpen((o) => !o);
+                setImportOpen(false);
+              }}
+            >
+              <Icon name="search" size={13} />
+              {tr('从文献库添加', 'Add from library')}
+            </button>
+            <button
+              className={'btn sm ' + (importOpen ? 'btn-primary' : 'btn-soft')}
+              onClick={() => {
+                setImportOpen((o) => !o);
+                setSearchOpen(false);
+              }}
+            >
+              <Icon name="plus" size={13} />
+              {tr('手动添加', 'Add manually')}
+            </button>
+          </>
+        }
+      />
+
+      {/* —— 从文献库添加：按当前课题库检索，一键入架 —— */}
+      {searchOpen && (
+        <div className="card" style={{ padding: 14, marginBottom: 16 }}>
+          <div className="row gap10">
+            <SearchInput
+              value={qInput}
+              onChange={setQInput}
+              placeholder={tr('搜文献库：标题 / 摘要 / 解读…', 'Search the library: title / abstract / wiki…')}
+            />
+            <button className="btn btn-ghost sm" onClick={() => navigate(topicPath(pid, 'wiki'))}>
+              {tr('去文献追踪', 'Open Research Wiki')}
+            </button>
+          </div>
+          {q.length > 0 && (
+            <div className="col" style={{ marginTop: 10 }}>
+              {searchQuery.isLoading ? (
+                <div className="empty" style={{ padding: 14 }}>{tr('搜索中…', 'Searching…')}</div>
+              ) : (searchQuery.data?.papers ?? []).length === 0 ? (
+                <div className="empty" style={{ padding: 14 }}>
+                  {tr('文献库里没搜到，试试「手动添加」', 'Nothing found in the library — try “Add manually”')}
+                </div>
+              ) : (
+                (searchQuery.data?.papers ?? []).map((p) => {
+                  const added = shelvedIds.has(p.id);
+                  return (
+                    <div
+                      key={p.id}
+                      className="row gap10"
+                      style={{ padding: '8px 4px', borderBottom: '0.5px solid var(--border)' }}
+                    >
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 12.5, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
+                        <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginTop: 2 }}>
+                          {p.arxiv_id ?? p.venue ?? '—'}
+                          {p.year !== null ? ` · ${p.year}` : ''}
+                        </div>
+                      </div>
+                      {added ? (
+                        <span className="row gap6" style={{ fontSize: 11.5, color: 'var(--ok-tx)', flexShrink: 0 }}>
+                          <Icon name="check" size={13} />
+                          {tr('已入架', 'Added')}
+                        </span>
+                      ) : (
+                        <button
+                          className="btn btn-soft sm"
+                          disabled={addMutation.isPending}
+                          onClick={() => addMutation.mutate(p.id)}
+                        >
+                          <Icon name="plus" size={12} />
+                          {tr('入架', 'Add')}
+                        </button>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* —— 手动添加：arXiv 编号 / DOI —— */}
+      {importOpen && (
+        <div className="card" style={{ padding: 14, marginBottom: 16 }}>
+          <div className="row gap10">
+            <input
+              ref={importRef}
+              className="input"
+              autoFocus
+              style={{ height: 32, fontSize: 12.5, flex: 1, minWidth: 0 }}
+              value={importInput}
+              onChange={(e) => setImportInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitImport();
+              }}
+              placeholder={tr('arXiv 编号（如 2401.12345）或 DOI（如 10.1234/abc）', 'arXiv ID (e.g. 2401.12345) or DOI (e.g. 10.1234/abc)')}
+            />
+            <button className="btn btn-primary sm" disabled={importMutation.isPending} onClick={submitImport}>
+              {importMutation.isPending ? tr('解析中…', 'Resolving…') : tr('添加', 'Add')}
+            </button>
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 8, lineHeight: 1.5 }}>
+            {tr(
+              '文献库里没有的论文也能加：平台会自动抓取元数据和 PDF，只进这个课题的相关研究和你的个人文献库，不影响公共文献库。',
+              'Papers outside the library work too: metadata and PDF are fetched automatically. They go to this topic and your personal library only — the shared library is untouched.',
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* —— 书架列表 —— */}
+      {shelfQuery.isLoading ? (
+        <div className="col gap12">
+          <div className="skel" style={{ height: 110 }} />
+          <div className="skel" style={{ height: 110 }} />
+        </div>
+      ) : shelfQuery.isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('加载不出书架', 'Cannot load the shelf')}
+          desc={tr('后端暂时不可用，稍后再试。', 'The backend is unavailable — try again later.')}
+          action={
+            <button className="btn btn-soft sm" onClick={() => void shelfQuery.refetch()}>
+              {tr('重试', 'Retry')}
+            </button>
+          }
+        />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon="pin"
+          title={tr('书架还空着', 'The shelf is empty')}
+          desc={tr(
+            '去文献追踪逛逛，把相关论文加进来；或直接输入 arXiv 编号添加。',
+            'Browse the Research Wiki and shelve relevant papers, or add one by arXiv ID.',
+          )}
+          action={
+            <div className="row gap10">
+              <button className="btn btn-primary sm" onClick={() => navigate(topicPath(pid, 'wiki'))}>
+                <Icon name="book" size={13} />
+                {tr('去文献追踪', 'Open Research Wiki')}
+              </button>
+              <button
+                className="btn btn-soft sm"
+                onClick={() => {
+                  setImportOpen(true);
+                  setSearchOpen(false);
+                  setTimeout(() => importRef.current?.focus(), 0);
+                }}
+              >
+                <Icon name="plus" size={13} />
+                {tr('手动添加', 'Add manually')}
+              </button>
+            </div>
+          }
+        />
+      ) : (
+        <div className="col gap12">
+          <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+            {tr(`共 ${data?.total ?? items.length} 篇`, `${data?.total ?? items.length} papers`)}
+          </div>
+          {items.map((item) => (
+            <ShelfCard
+              key={item.paper_id}
+              item={item}
+              busy={busy}
+              onOpen={() => navigate(`/papers/${item.paper_id}/read`)}
+              onSaveNote={(note) => noteMutation.mutate({ paperId: item.paper_id, note })}
+              onRemove={() => removeMutation.mutate(item.paper_id)}
+            />
+          ))}
+          {totalPages > 1 && (
+            <div className="row gap10" style={{ justifyContent: 'center', padding: '6px 0' }}>
+              <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+                {tr('上一页', 'Prev')}
+              </button>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)' }}>
+                {page} / {totalPages}
+              </span>
+              <button
+                className="btn btn-ghost sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                {tr('下一页', 'Next')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -808,6 +808,42 @@ export interface SearchResult {
 }
 
 // ============================================================
+// P5a · 课题「相关研究」书架 — /projects/{pid}/shelf
+// ============================================================
+
+/** 书架条目 wiki 来源：live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读。 */
+export type ShelfWikiSource = 'live' | 'snapshot' | 'none';
+
+export interface ShelfItemRead {
+  paper_id: string;
+  title: string;
+  authors: PaperAuthor[];
+  year: number | null;
+  venue: string | null;
+  arxiv_id: string | null;
+  doi: string | null;
+  url: string | null;
+  tldr: string | null;
+  /** 课题语境的「为什么相关」备注 */
+  note: string | null;
+  wiki_source: ShelfWikiSource;
+  /** 解析后的 wiki：库版实时 > 快照；none 时为 null */
+  wiki_content: string | null;
+  /** 入架落快照的时间；没快照为 null */
+  snapshot_at: string | null;
+  /** 来源方向库（个人补充为 null） */
+  source_library_id: string | null;
+  added_at: string;
+}
+
+/** 个人补充入库：arXiv 编号 / DOI / 标题至少给一个。 */
+export interface ShelfImportInput {
+  arxiv_id?: string;
+  doi?: string;
+  title?: string;
+}
+
+// ============================================================
 // 文献知识底座：全文分段索引 + 文献库对话（docs/api-lit.md §8）
 // ============================================================
 
@@ -2559,6 +2595,34 @@ export const api = {
     if (opts.mode) params.set('mode', opts.mode);
     if (opts.limit) params.set('limit', String(opts.limit));
     return request<SearchResult>(`/projects/${projectId}/search?${params.toString()}`);
+  },
+
+  // —— P5a · 课题「相关研究」书架 ——
+  listShelf(projectId: string, opts: { page?: number; size?: number } = {}): Promise<PageOf<ShelfItemRead>> {
+    const params = new URLSearchParams();
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    const qs = params.toString();
+    return request<PageOf<ShelfItemRead>>(`/projects/${projectId}/shelf${qs ? `?${qs}` : ''}`);
+  },
+  /** 书架全部 paper_id（「已入架」勾选态用）。 */
+  listShelfIds(projectId: string): Promise<{ paper_ids: string[] }> {
+    return request<{ paper_ids: string[] }>(`/projects/${projectId}/shelf/ids`);
+  },
+  /** 入架（重复入架幂等更新备注）；后端同步收藏进个人库。 */
+  addToShelf(projectId: string, input: { paper_id: string; note?: string }): Promise<ShelfItemRead> {
+    return requestJson<ShelfItemRead>(`/projects/${projectId}/shelf`, 'POST', input);
+  },
+  /** 个人补充入库：查池命中直接入架，未命中抓取解析；422 → PARSE_FAILED。 */
+  importToShelf(projectId: string, input: ShelfImportInput): Promise<ShelfItemRead> {
+    return requestJson<ShelfItemRead>(`/projects/${projectId}/shelf/import`, 'POST', input);
+  },
+  updateShelfNote(projectId: string, paperId: string, note: string | null): Promise<ShelfItemRead> {
+    return requestJson<ShelfItemRead>(`/projects/${projectId}/shelf/${paperId}`, 'PATCH', { note });
+  },
+  /** 移出书架：只删书架行，个人库收藏不动。 */
+  removeFromShelf(projectId: string, paperId: string): Promise<void> {
+    return request<void>(`/projects/${projectId}/shelf/${paperId}`, { method: 'DELETE' });
   },
 
   // —— M2 · Ingest ——


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P5a, full-stack, builds on the P4 content pool.

## What changed

**Backend — `topic_papers` shelf**
- New table: topic (project) × pool paper membership with a `wiki_snapshot` fallback, soft `source_library_id` (SET NULL), per-topic note, UNIQUE(topic, paper). Migration `0775b55c26e4`.
- Shelf API under `/projects/{pid}/shelf`: list (wiki resolved live-first with snapshot fallback and a `wiki_source` badge), add (snapshots current wiki and upserts the personal library in the same write — the shelf is a projection of the personal library), note patch, remove (personal library untouched).
- Personal import (`POST .../shelf/import`): dedup-first against the global pool (pool hit skips parsing entirely); a miss fetches and parses into the pool **without creating any library membership** — personally added papers stay personal.

**Frontend — Related Research page**
- New `/t/:topicId/research` page in the topic zone: shelf cards with inline note editing and snapshot badges, in-page library search with one-click add, manual add by arXiv id / DOI (link-pasting tolerated), empty-state guidance.
- Reading page gains a pin action to add/remove the current paper from the shelf.

## Tests

- 8 new shelf tests (snapshot + personal-library coupling, idempotent re-add, snapshot fallback after library removal, import pool-hit/miss, auth).
- Full suite: 491 passed + 16 pre-existing errors, consistent with the main baseline; sqlite migration round-trip and fresh postgres `upgrade head` verified.
- Frontend `tsc --noEmit` + `npm run build` pass.

## Known follow-ups (P5b/P5c)

Manual snapshot refresh, PDF upload import, on-demand personal wiki compilation, notes/highlights re-scoping to user+paper, and promoting implicit libraries to shared direction libraries.