### PR TITLE
feat(library): personal notes scope, on-demand personal wiki, snapshot refresh (IA redesign P5b)

### DIFF
--- a/src/backend/alembic/versions/1c6c4831d80f_notes_highlights_per_user.py
+++ b/src/backend/alembic/versions/1c6c4831d80f_notes_highlights_per_user.py
@@ -1,0 +1,36 @@
+"""笔记 / 划线归属拆分（P5b）
+
+PaperNote / PaperHighlight 作用域从 project × paper 改为 paper × author：
+一个人在一篇论文上的划线与批注跨课题共享。删 project_id 列即可——
+原表按 project 隔离的行本就各归其作者，删列后天然合并，不丢行。
+
+Revision ID: 1c6c4831d80f
+Revises: 0775b55c26e4
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "1c6c4831d80f"
+down_revision: str | None = "0775b55c26e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    for table in ("paper_notes", "paper_highlights"):
+        with op.batch_alter_table(table) as batch:
+            batch.drop_index(f"ix_{table}_project_id")
+            batch.drop_column("project_id")
+
+
+def downgrade() -> None:
+    # 有损降级：project_id 数据已丢弃，只能补回可空列（原列 NOT NULL）
+    for table in ("paper_notes", "paper_highlights"):
+        with op.batch_alter_table(table) as batch:
+            batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+            batch.create_index(f"ix_{table}_project_id", ["project_id"])

--- a/src/backend/app/api/highlights.py
+++ b/src/backend/app/api/highlights.py
@@ -1,6 +1,7 @@
 """PDF 划线标注路由：论文级 CRUD（阅读器用）。
 
-权限同论文笔记：项目成员可读，作者 / 平台 admin 可改删。
+归属与权限同论文笔记（P5b）：划线挂 paper × author 跨课题共享，
+列表只返回请求者本人的划线，非作者访问单条一律 404（平台 admin 例外）。
 """
 
 import uuid
@@ -24,7 +25,6 @@ def _hl_read(hl: PaperHighlight, author_name: str) -> HighlightRead:
     return HighlightRead(
         id=hl.id,
         paper_id=hl.paper_id,
-        project_id=hl.project_id,
         author_id=hl.author_id,
         author_name=author_name,
         page=hl.page,
@@ -41,16 +41,11 @@ def _hl_read(hl: PaperHighlight, author_name: str) -> HighlightRead:
 async def _get_modifiable_highlight(
     session: AsyncSession, highlight_id: uuid.UUID, user: User
 ) -> tuple[PaperHighlight, str]:
-    """取划线：非项目成员 404；非作者且非平台 admin 403。"""
-    row = await hl_service.get_highlight_for_member(
-        session, highlight_id=highlight_id, user_id=user.id
-    )
+    """取划线：非作者（且非平台 admin）视为不存在 → 404。"""
+    row = await hl_service.get_own_highlight(session, highlight_id=highlight_id, user=user)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="HIGHLIGHT_NOT_FOUND")
-    hl, author_name = row
-    if not hl_service.can_modify_highlight(hl, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="HIGHLIGHT_FORBIDDEN")
-    return hl, author_name
+    return row
 
 
 @router.get("/papers/{paper_id}/highlights", response_model=list[HighlightRead])
@@ -62,7 +57,7 @@ async def list_paper_highlights(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    rows = await hl_service.list_paper_highlights(session, paper_id=paper_id)
+    rows = await hl_service.list_paper_highlights(session, paper_id=paper_id, author_id=user.id)
     return [_hl_read(hl, author_name) for hl, author_name in rows]
 
 
@@ -80,9 +75,7 @@ async def create_paper_highlight(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    hl = await hl_service.create_highlight(
-        session, paper_id=paper.id, project_id=paper.project_id, author=user, data=data
-    )
+    hl = await hl_service.create_highlight(session, paper_id=paper.id, author=user, data=data)
     return _hl_read(hl, author_name_of(user.display_name, user.email))
 
 

--- a/src/backend/app/api/highlights.py
+++ b/src/backend/app/api/highlights.py
@@ -54,7 +54,9 @@ async def list_paper_highlights(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[HighlightRead]:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     rows = await hl_service.list_paper_highlights(session, paper_id=paper_id, author_id=user.id)
@@ -72,7 +74,9 @@ async def create_paper_highlight(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> HighlightRead:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     hl = await hl_service.create_highlight(session, paper_id=paper.id, author=user, data=data)

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -26,7 +26,9 @@ router = APIRouter(tags=["library"])
 
 async def _get_member_paper(session: AsyncSession, paper_id: uuid.UUID, user: User) -> Paper:
     """校验论文可见性（所在方向的成员），防止越权拷快照。"""
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     return paper

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -1,4 +1,8 @@
-"""论文笔记路由（docs/api-lit.md §2）：论文级 CRUD + 项目笔记本聚合。"""
+"""论文笔记路由（docs/api-lit.md §2）：论文级 CRUD + 课题笔记本聚合。
+
+P5b 起笔记挂 paper × author（跨课题共享）：列表只返回请求者本人的笔记，
+非作者访问单条一律 404（平台 admin 例外，可管理他人笔记）。
+"""
 
 import uuid
 
@@ -21,7 +25,6 @@ def _note_read(note: PaperNote, author_name: str) -> NoteRead:
     return NoteRead(
         id=note.id,
         paper_id=note.paper_id,
-        project_id=note.project_id,
         author_id=note.author_id,
         author_name=author_name,
         content=note.content,
@@ -33,14 +36,11 @@ def _note_read(note: PaperNote, author_name: str) -> NoteRead:
 async def _get_modifiable_note(
     session: AsyncSession, note_id: uuid.UUID, user: User
 ) -> tuple[PaperNote, str]:
-    """取笔记：非项目成员 404；非作者且非平台 admin 403。"""
-    row = await notes_service.get_note_for_member(session, note_id=note_id, user_id=user.id)
+    """取笔记：非作者（且非平台 admin）视为不存在 → 404。"""
+    row = await notes_service.get_own_note(session, note_id=note_id, user=user)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="NOTE_NOT_FOUND")
-    note, author_name = row
-    if not notes_service.can_modify_note(note, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="NOTE_FORBIDDEN")
-    return note, author_name
+    return row
 
 
 @router.get("/papers/{paper_id}/notes", response_model=list[NoteRead])
@@ -52,7 +52,7 @@ async def list_paper_notes(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    rows = await notes_service.list_paper_notes(session, paper_id=paper_id)
+    rows = await notes_service.list_paper_notes(session, paper_id=paper_id, author_id=user.id)
     return [_note_read(note, author_name) for note, author_name in rows]
 
 
@@ -69,11 +69,7 @@ async def create_paper_note(
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     note = await notes_service.create_note(
-        session,
-        paper_id=paper.id,
-        project_id=paper.project_id,
-        author=user,
-        content=data.content,
+        session, paper_id=paper.id, author=user, content=data.content
     )
     return _note_read(note, notes_service.author_name_of(user.display_name, user.email))
 
@@ -110,12 +106,18 @@ async def project_notebook(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> NotebookPage:
-    """项目笔记本：全部论文笔记的聚合视图（搜索 + 分页 + 按论文过滤）。"""
+    """课题笔记本：我的论文笔记在本课题范围内的聚合视图（搜索 + 分页 + 按论文过滤）。"""
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows, total = await notes_service.list_project_notes(
-        session, project_id=project_id, q=q, paper_id=paper_id, page=page, size=size
+        session,
+        project_id=project_id,
+        author_id=user.id,
+        q=q,
+        paper_id=paper_id,
+        page=page,
+        size=size,
     )
     items = [
         NoteWithPaper(**_note_read(note, author_name).model_dump(), paper_title=paper_title)

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -49,7 +49,9 @@ async def list_paper_notes(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[NoteRead]:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     rows = await notes_service.list_paper_notes(session, paper_id=paper_id, author_id=user.id)
@@ -65,7 +67,9 @@ async def create_paper_note(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> NoteRead:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     note = await notes_service.create_note(

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -18,6 +18,7 @@ from app.api.auth import current_active_user, require_llm_chat, require_llm_task
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
+from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.paper import (
     PaperBatchIds,
@@ -32,6 +33,8 @@ from app.schemas.paper import (
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
+    PersonalWikiRead,
+    PersonalWikiRequest,
     TagRead,
 )
 from app.services import figure_annotate as figure_service
@@ -39,6 +42,7 @@ from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
+from app.services import personal_wiki as personal_wiki_service
 from app.services import projects as projects_service
 from app.services import relevance as relevance_service
 from app.services import wiki_compile as wiki_compile_service
@@ -370,6 +374,51 @@ async def recompile_paper(
         logger.warning("recompile failed for paper %s", paper_id, exc_info=True)
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
     return await _paper_detail(session, paper, user.id)
+
+
+# ---- 个人版 wiki 按需编译（P5b，docs-dev/workspace-ia-redesign.md §3.3/§4） ----
+
+
+@router.post("/papers/{paper_id}/personal-wiki", response_model=PersonalWikiRead)
+async def compile_personal_wiki(
+    paper_id: uuid.UUID,
+    data: PersonalWikiRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+) -> PersonalWikiRead:
+    """给没有库版 wiki 的池内论文（典型：个人补充入库）编译个人版 wiki。
+
+    通用模板（无 rubric），可选 topic_id 把课题 statement 当侧重提示；
+    结果写进本人个人库条目（user_library_entries.wiki_content），费用归个人。
+    已有库版 wiki → 409 LIBRARY_WIKI_EXISTS；同一 paper × user 编译进行中 →
+    409 COMPILE_IN_PROGRESS。内容池全平台可读，故不要求论文在本人方向库内。
+    """
+    paper = await session.get(Paper, paper_id)
+    if paper is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    if data.topic_id is not None:
+        # 课题归因/侧重提示：必须是自己所在课题
+        await _get_member_project(session, data.topic_id, user)
+    try:
+        compiled = await personal_wiki_service.compile_personal_wiki(
+            session, paper=paper, user_id=user.id, topic_id=data.topic_id
+        )
+    except personal_wiki_service.LibraryWikiExistsError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="LIBRARY_WIKI_EXISTS"
+        ) from None
+    except personal_wiki_service.CompileInProgressError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="COMPILE_IN_PROGRESS"
+        ) from None
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001 — LLM 空响应/调用失败等 → 502
+        logger.warning("personal wiki compile failed for paper %s", paper_id, exc_info=True)
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
+    return PersonalWikiRead(
+        paper_id=paper_id, wiki_content=compiled.content, model=compiled.model or None
+    )
 
 
 # ---- AI 伴读（docs/api-lit.md §3，SSE 流） ----

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -85,10 +85,21 @@ async def _get_member_project(session: AsyncSession, project_id: uuid.UUID, user
 
 
 async def _get_member_paper(
-    session: AsyncSession, paper_id: uuid.UUID, user: User, *, with_concepts: bool = False
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    user: User,
+    *,
+    with_concepts: bool = False,
+    include_pool: bool = False,
 ) -> papers_service.PaperView:
+    """include_pool 只给读路径开：书架/个人库可达的无库论文可读（P5b），
+    写成员行的端点（状态/删除/召回/重编译/标签）维持库可见性。"""
     paper = await papers_service.get_paper_for_user(
-        session, paper_id=paper_id, user_id=user.id, with_concepts=with_concepts
+        session,
+        paper_id=paper_id,
+        user_id=user.id,
+        with_concepts=with_concepts,
+        include_pool=include_pool,
     )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
@@ -195,7 +206,7 @@ async def get_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
-    paper = await _get_member_paper(session, paper_id, user, with_concepts=True)
+    paper = await _get_member_paper(session, paper_id, user, with_concepts=True, include_pool=True)
     return await _paper_detail(session, paper, user.id)
 
 
@@ -275,7 +286,7 @@ async def get_paper_pdf(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> FileResponse:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     if not paper.pdf_path or not Path(paper.pdf_path).exists():
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PDF_NOT_AVAILABLE")
     return FileResponse(
@@ -293,7 +304,7 @@ async def fetch_paper_pdf(
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
     """按需补下 PDF + 抽全文；已有 PDF 时幂等直接返回。"""
-    view = await _get_member_paper(session, paper_id, user, with_concepts=True)
+    view = await _get_member_paper(session, paper_id, user, with_concepts=True, include_pool=True)
     try:
         await papers_service.fetch_pdf(
             session, view.paper, user_id=user.id, project_id=view.project_id
@@ -314,7 +325,7 @@ async def list_paper_figures(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[PaperFigure]:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     return [PaperFigure(**f) for f in (paper.figures or [])]
 
 
@@ -325,7 +336,7 @@ async def get_paper_figure_image(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> FileResponse:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     known = {int(f["index"]) for f in (paper.figures or [])}
     path = figure_path(str(paper_id), index)
     if index not in known or not path.exists():
@@ -343,7 +354,7 @@ async def extract_paper_figures(
     user: User = Depends(current_active_user),
 ) -> PaperFiguresResponse:
     """提取嵌入图 + LLM 筛选注释；已有 figures 且非 force 时幂等直返。"""
-    view = await _get_member_paper(session, paper_id, user)
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
     paper = view.paper
     if paper.figures is not None and not force:
         return PaperFiguresResponse(figures=[PaperFigure(**f) for f in paper.figures])
@@ -436,15 +447,16 @@ async def chat_with_paper(
     user: User = Depends(require_llm_chat),
 ) -> StreamingResponse:
     """AI 伴读：stage=reading 流式回答；事件 delta/done/error + 15s 心跳注释。"""
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     project_id = paper.project_id
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
     llm = get_llm_router()
 
-    # 用户选中的其他文献：检索相关片段作为对比/参考上下文（跨项目引用被过滤）
+    # 用户选中的其他文献：检索相关片段作为对比/参考上下文（跨项目引用被过滤）；
+    # 池级可达的无库论文没有课题上下文（project_id 为空）→ 跳过参考文献检索
     references, sources = "", []
-    if data.context_paper_ids:
+    if data.context_paper_ids and project_id is not None:
         references, sources = await library_chat_service.build_reference_context(
             session,
             project_id=project_id,
@@ -550,7 +562,7 @@ async def set_paper_my_meta(
     user: User = Depends(current_active_user),
 ) -> PaperMyMetaRead:
     """个人星标 / 阅读状态 upsert。"""
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     meta = await papers_service.upsert_paper_user_meta(
         session,
         paper=paper,

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -44,7 +44,7 @@ async def list_shelf(
 ) -> ShelfPage:
     await _require_member(session, project_id, user)
     items, total = await shelf_service.list_shelf(
-        session, project_id=project_id, page=page, size=size
+        session, project_id=project_id, user_id=user.id, page=page, size=size
     )
     return ShelfPage(
         items=[ShelfItemRead.model_validate(i) for i in items],
@@ -131,10 +131,32 @@ async def update_shelf_note(
     await _require_member(session, project_id, user)
     try:
         item = await shelf_service.update_note(
-            session, project_id=project_id, paper_id=paper_id, note=body.note
+            session, project_id=project_id, paper_id=paper_id, user_id=user.id, note=body.note
         )
     except shelf_service.ShelfItemNotFoundError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    return ShelfItemRead.model_validate(item)
+
+
+@router.post(
+    "/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", response_model=ShelfItemRead
+)
+async def refresh_shelf_snapshot(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    """手动刷新快照：从当前可得的最优 wiki（库版 > 个人版）重拷；无来源 409。"""
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.refresh_snapshot(
+            session, project_id=project_id, paper_id=paper_id, user_id=user.id
+        )
+    except shelf_service.ShelfItemNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    except shelf_service.NoWikiSourceError:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="NO_WIKI_SOURCE") from None
     return ShelfItemRead.model_validate(item)
 
 

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -94,7 +94,7 @@ async def search(
             mode_used = "keyword"  # embedding 路由的 provider 不支持 → 回退
     if mode_used == "keyword":
         paper_rows = await papers_service.keyword_search_papers(
-            session, project_id=project_id, q=q, limit=limit
+            session, project_id=project_id, q=q, limit=limit, user_id=user.id
         )
     concept_rows = await papers_service.keyword_search_concepts(
         session, project_id=project_id, q=q, limit=limit
@@ -131,7 +131,7 @@ async def export_obsidian(
     user: User = Depends(current_active_user),
 ) -> Response:
     project = await _member_project(session, project_id, user)
-    content = await build_obsidian_zip(session, project)
+    content = await build_obsidian_zip(session, project, user_id=user.id)
     filename = f"{project.slug}-wiki.zip"
     return Response(
         content=content,

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -105,15 +105,12 @@ paper_tag_links = Table(
 
 
 class PaperNote(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """论文笔记：项目成员可读，作者（或平台 admin）可改删。"""
+    """论文笔记（paper × author）：跨课题共享，仅作者本人（或平台 admin）可见可改删。"""
 
     __tablename__ = "paper_notes"
 
     paper_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     author_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
@@ -132,16 +129,13 @@ class PaperHighlight(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     定位策略「文本锚点为主 + 归一化坐标加速」：selected_text 存选中的原文
     （PDF 换版重抽也能靠文本回锚），rects 存归一化到页面 0..1 的矩形列表
     （每行一个，渲染时按当前页宽高还原色块，缩放无关）。
-    权限同 PaperNote：项目成员可读，作者（或平台 admin）可改删。
+    归属同 PaperNote（paper × author）：跨课题共享，仅作者本人（或平台 admin）可见可改删。
     """
 
     __tablename__ = "paper_highlights"
 
     paper_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     author_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False

--- a/src/backend/app/schemas/highlight.py
+++ b/src/backend/app/schemas/highlight.py
@@ -69,7 +69,6 @@ class HighlightUpdate(BaseModel):
 class HighlightRead(BaseModel):
     id: uuid.UUID
     paper_id: uuid.UUID
-    project_id: uuid.UUID
     author_id: uuid.UUID
     author_name: str  # display_name 回退 email @ 前部分
     page: int

--- a/src/backend/app/schemas/note.py
+++ b/src/backend/app/schemas/note.py
@@ -17,7 +17,6 @@ class NoteUpdate(BaseModel):
 class NoteRead(BaseModel):
     id: uuid.UUID
     paper_id: uuid.UUID
-    project_id: uuid.UUID
     author_id: uuid.UUID
     author_name: str  # display_name 回退 email @ 前部分
     content: str

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -235,3 +235,15 @@ class SearchResponse(BaseModel):
     concepts: list[ScoredConcept]
     mode_used: Literal["keyword", "semantic"]
     reranked: bool = False  # semantic 模式下 rerank 是否成功（失败降级为纯向量分）
+
+
+class PersonalWikiRequest(BaseModel):
+    """个人版 wiki 按需编译（P5b）：可选带课题，statement 作为侧重提示 + 用量归因。"""
+
+    topic_id: uuid.UUID | None = None
+
+
+class PersonalWikiRead(BaseModel):
+    paper_id: uuid.UUID
+    wiki_content: str
+    model: str | None = None

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -28,7 +28,8 @@ class PaperRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    project_id: uuid.UUID
+    # 本次访问解析出的课题上下文；池级可达（书架/个人库）的无库论文可为 null
+    project_id: uuid.UUID | None
     title: str
     authors: list[AuthorRead] = []
     affiliations: list[str] = []  # 发表机构（LLM 从全文解析，OpenAlex 兜底；可能为空）

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ShelfItemRead(BaseModel):
-    """书架条目：论文元数据 + 备注 + 解析后的 wiki（库版实时 > 快照）。"""
+    """书架条目：论文元数据 + 备注 + 解析后的 wiki（库版实时 > 个人版 > 快照）。"""
 
     paper_id: uuid.UUID
     title: str
@@ -20,8 +20,8 @@ class ShelfItemRead(BaseModel):
     url: str | None
     tldr: str | None
     note: str | None
-    # live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读
-    wiki_source: Literal["live", "snapshot", "none"]
+    # live=库版实时可得 | personal=本人个人编译版 | snapshot=只剩入架快照 | none=没有解读
+    wiki_source: Literal["live", "personal", "snapshot", "none"]
     wiki_content: str | None
     snapshot_at: datetime | None
     source_library_id: uuid.UUID | None

--- a/src/backend/app/services/highlights.py
+++ b/src/backend/app/services/highlights.py
@@ -1,8 +1,8 @@
 """PDF 划线标注业务逻辑（不 import fastapi）。
 
-权限约定同论文笔记（services/notes.py）：
-- 读 = 项目成员（非成员视为不存在）；
-- 改 / 删 = 标注作者或平台 admin。
+归属与权限同论文笔记（services/notes.py，P5b 拆分）：
+- 划线挂 paper × author，跨课题共享；
+- 读 / 改 / 删都只限作者本人（平台 admin 可改删他人标注，管理兜底）。
 """
 
 import uuid
@@ -13,7 +13,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.paper import PaperHighlight
-from app.models.project import ProjectMember
 from app.models.user import User
 from app.schemas.highlight import HighlightCreate
 from app.services.notes import author_name_of
@@ -23,13 +22,11 @@ async def create_highlight(
     session: AsyncSession,
     *,
     paper_id: uuid.UUID,
-    project_id: uuid.UUID,
     author: User,
     data: HighlightCreate,
 ) -> PaperHighlight:
     hl = PaperHighlight(
         paper_id=paper_id,
-        project_id=project_id,
         author_id=author.id,
         page=data.page,
         rects=[r.model_dump() for r in data.rects],
@@ -45,39 +42,35 @@ async def create_highlight(
 
 
 async def list_paper_highlights(
-    session: AsyncSession, *, paper_id: uuid.UUID
+    session: AsyncSession, *, paper_id: uuid.UUID, author_id: uuid.UUID
 ) -> Sequence[tuple[PaperHighlight, str]]:
-    """某论文的划线（按页码、再按创建时间排序），附作者展示名。"""
+    """某论文下「我的」划线（按页码、再按创建时间排序），附作者展示名。"""
     stmt = (
         select(PaperHighlight, User.display_name, User.email)
         .join(User, User.id == PaperHighlight.author_id)
-        .where(PaperHighlight.paper_id == paper_id)
+        .where(PaperHighlight.paper_id == paper_id, PaperHighlight.author_id == author_id)
         .order_by(PaperHighlight.page.asc(), PaperHighlight.created_at.asc())
     )
     rows = (await session.execute(stmt)).all()
     return [(hl, author_name_of(display_name, email)) for hl, display_name, email in rows]
 
 
-async def get_highlight_for_member(
-    session: AsyncSession, *, highlight_id: uuid.UUID, user_id: uuid.UUID
+async def get_own_highlight(
+    session: AsyncSession, *, highlight_id: uuid.UUID, user: User
 ) -> tuple[PaperHighlight, str] | None:
-    """取划线（附作者展示名）；非项目成员视为不存在。"""
+    """取划线（附作者展示名）；非作者（且非平台 admin）视为不存在。"""
     stmt = (
         select(PaperHighlight, User.display_name, User.email)
         .join(User, User.id == PaperHighlight.author_id)
-        .join(ProjectMember, ProjectMember.project_id == PaperHighlight.project_id)
-        .where(PaperHighlight.id == highlight_id, ProjectMember.user_id == user_id)
+        .where(PaperHighlight.id == highlight_id)
     )
+    if user.role != "admin":
+        stmt = stmt.where(PaperHighlight.author_id == user.id)
     row = (await session.execute(stmt)).first()
     if row is None:
         return None
     hl, display_name, email = row
     return hl, author_name_of(display_name, email)
-
-
-def can_modify_highlight(hl: PaperHighlight, user: User) -> bool:
-    """改 / 删权限：标注作者或平台 admin。"""
-    return hl.author_id == user.id or user.role == "admin"
 
 
 async def update_highlight(

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -1,19 +1,21 @@
 """论文笔记业务逻辑（不 import fastapi）。
 
-权限约定（docs/api-lit.md §2）：
-- 读笔记 = 项目成员（非成员视为不存在）；
-- 改 / 删 = 笔记作者或平台 admin。
+归属与权限（P5b 拆分，docs-dev/workspace-ia-redesign.md §3.3）：
+- 笔记挂 paper × author，跨课题共享（同一篇论文的笔记在所有课题可见）；
+- 读 / 改 / 删都只限作者本人（平台 admin 可改删他人笔记，管理兜底）。
 """
 
 import uuid
 from collections.abc import Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperNote
-from app.models.project import ProjectMember
+from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.services.libraries import get_library_for_project
 
 
 def author_name_of(display_name: str | None, email: str) -> str:
@@ -22,11 +24,9 @@ def author_name_of(display_name: str | None, email: str) -> str:
 
 
 async def create_note(
-    session: AsyncSession, *, paper_id: uuid.UUID, project_id: uuid.UUID, author: User, content: str
+    session: AsyncSession, *, paper_id: uuid.UUID, author: User, content: str
 ) -> PaperNote:
-    note = PaperNote(
-        paper_id=paper_id, project_id=project_id, author_id=author.id, content=content
-    )
+    note = PaperNote(paper_id=paper_id, author_id=author.id, content=content)
     session.add(note)
     await session.commit()
     await session.refresh(note)
@@ -34,39 +34,35 @@ async def create_note(
 
 
 async def list_paper_notes(
-    session: AsyncSession, *, paper_id: uuid.UUID
+    session: AsyncSession, *, paper_id: uuid.UUID, author_id: uuid.UUID
 ) -> Sequence[tuple[PaperNote, str]]:
-    """某论文的笔记（created_at 倒序），附作者展示名。"""
+    """某论文下「我的」笔记（created_at 倒序），附作者展示名。"""
     stmt = (
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .where(PaperNote.paper_id == paper_id)
+        .where(PaperNote.paper_id == paper_id, PaperNote.author_id == author_id)
         .order_by(PaperNote.created_at.desc())
     )
     rows = (await session.execute(stmt)).all()
     return [(note, author_name_of(display_name, email)) for note, display_name, email in rows]
 
 
-async def get_note_for_member(
-    session: AsyncSession, *, note_id: uuid.UUID, user_id: uuid.UUID
+async def get_own_note(
+    session: AsyncSession, *, note_id: uuid.UUID, user: User
 ) -> tuple[PaperNote, str] | None:
-    """取笔记（附作者展示名）；非项目成员视为不存在。"""
+    """取笔记（附作者展示名）；非作者（且非平台 admin）视为不存在。"""
     stmt = (
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .join(ProjectMember, ProjectMember.project_id == PaperNote.project_id)
-        .where(PaperNote.id == note_id, ProjectMember.user_id == user_id)
+        .where(PaperNote.id == note_id)
     )
+    if user.role != "admin":
+        stmt = stmt.where(PaperNote.author_id == user.id)
     row = (await session.execute(stmt)).first()
     if row is None:
         return None
     note, display_name, email = row
     return note, author_name_of(display_name, email)
-
-
-def can_modify_note(note: PaperNote, user: User) -> bool:
-    """改 / 删权限：笔记作者或平台 admin。"""
-    return note.author_id == user.id or user.role == "admin"
 
 
 async def update_note(session: AsyncSession, note: PaperNote, *, content: str) -> PaperNote:
@@ -85,18 +81,30 @@ async def list_project_notes(
     session: AsyncSession,
     *,
     project_id: uuid.UUID,
+    author_id: uuid.UUID,
     q: str | None = None,
     paper_id: uuid.UUID | None = None,
     page: int = 1,
     size: int = 20,
 ) -> tuple[Sequence[tuple[PaperNote, str, str]], int]:
-    """项目笔记本：分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，
-    row = (note, author_name, paper_title)。"""
+    """课题笔记本：「我的」笔记里落在本课题范围（方向库 ∪ 相关研究书架）的部分。
+
+    分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，row = (note, author_name, paper_title)。
+    """
+    library = await get_library_for_project(session, project_id)
+    in_scope = or_(
+        PaperNote.paper_id.in_(
+            select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library.id)
+        ),
+        PaperNote.paper_id.in_(
+            select(TopicPaper.paper_id).where(TopicPaper.topic_id == project_id)
+        ),
+    )
     stmt = (
         select(PaperNote, User.display_name, User.email, Paper.title)
         .join(User, User.id == PaperNote.author_id)
         .join(Paper, Paper.id == PaperNote.paper_id)
-        .where(PaperNote.project_id == project_id)
+        .where(PaperNote.author_id == author_id, in_scope)
     )
     if q:
         stmt = stmt.where(PaperNote.content.ilike(f"%{q}%"))

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -25,7 +25,6 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import (
     Concept,
     Paper,
-    PaperHighlight,
     PaperNote,
     PaperTag,
     PaperUserMeta,
@@ -290,7 +289,9 @@ async def set_paper_status(session: AsyncSession, view: PaperView, status: str) 
 async def paper_extras_map(
     session: AsyncSession, *, paper_ids: Sequence[uuid.UUID], user_id: uuid.UUID
 ) -> dict[uuid.UUID, dict[str, Any]]:
-    """批量取论文的 tags / starred / reading_status / note_count（3 条聚合查询，避免 N+1）。"""
+    """批量取论文的 tags / starred / reading_status / note_count（3 条聚合查询，避免 N+1）。
+
+    note_count 是请求者本人的笔记数（P5b 起笔记 paper × author，仅作者可见）。"""
     extras: dict[uuid.UUID, dict[str, Any]] = {
         pid: {"tags": [], "starred": False, "reading_status": "unread", "note_count": 0}
         for pid in paper_ids
@@ -308,7 +309,7 @@ async def paper_extras_map(
         extras[pid]["tags"].append(name)
     note_rows = await session.execute(
         select(PaperNote.paper_id, func.count())
-        .where(PaperNote.paper_id.in_(ids))
+        .where(PaperNote.paper_id.in_(ids), PaperNote.author_id == user_id)
         .group_by(PaperNote.paper_id)
     )
     for pid, count in note_rows.all():
@@ -416,8 +417,9 @@ async def upsert_paper_user_meta(
 
 # ---- 从方向库移除论文（docs/api-lit.md §8.6） ----
 #
-# P4 全局内容池语义：删除 = 删本方向的成员行与项目侧挂件（笔记/划线/标签关联）；
-# 内容池 Paper 行与磁盘文件（PDF/全文/图）永不删除（可能被其他方向复用）。
+# P4 全局内容池语义：删除 = 删本方向的成员行与项目侧标签关联；内容池 Paper 行与
+# 磁盘文件（PDF/全文/图）永不删除（可能被其他方向复用）。个人笔记/划线（P5b 起
+# paper × author 跨课题共享）不随库剔除删除，只随内容池 Paper 级联。
 
 
 async def _delete_membership_rows(
@@ -426,20 +428,10 @@ async def _delete_membership_rows(
     project_id: uuid.UUID,
     memberships: Sequence[LibraryPaper],
 ) -> None:
-    """硬删成员行 + 本项目挂在这些论文上的笔记/划线/标签关联（不 commit）。"""
+    """硬删成员行 + 本项目挂在这些论文上的标签关联（不 commit）。"""
     paper_ids = [m.paper_id for m in memberships]
     if not paper_ids:
         return
-    await session.execute(
-        delete(PaperNote).where(
-            PaperNote.paper_id.in_(paper_ids), PaperNote.project_id == project_id
-        )
-    )
-    await session.execute(
-        delete(PaperHighlight).where(
-            PaperHighlight.paper_id.in_(paper_ids), PaperHighlight.project_id == project_id
-        )
-    )
     project_tag_ids = select(PaperTag.id).where(PaperTag.project_id == project_id)
     await session.execute(
         delete(paper_tag_links).where(
@@ -455,8 +447,8 @@ async def _delete_membership_rows(
 async def delete_paper(session: AsyncSession, view: PaperView) -> None:
     """从当前方向库彻底移除一篇论文（垃圾桶里的「彻底删除」）。
 
-    删成员行与本项目的笔记/划线/标签关联；收尾清理项目内零引用标签。
-    内容池行与落盘文件保留（其他方向可复用）。
+    删成员行与本项目的标签关联；收尾清理项目内零引用标签。
+    内容池行、落盘文件与个人笔记/划线保留（其他方向可复用）。
     """
     project_id = view.project_id
     await _delete_membership_rows(session, project_id=project_id, memberships=[view.membership])
@@ -656,30 +648,37 @@ def build_chat_messages(
 
 
 async def keyword_search_papers(
-    session: AsyncSession, *, project_id: uuid.UUID, q: str, limit: int
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    q: str,
+    limit: int,
+    user_id: uuid.UUID | None = None,
 ) -> list[tuple[PaperView, float]]:
-    """关键词检索：title/abstract/库版 wiki/笔记内容 ilike，按命中位置给启发式分。
+    """关键词检索：title/abstract/库版 wiki/我的笔记内容 ilike，按命中位置给启发式分。
 
     只检索库内文献（相关性达标）：已删除（excluded）/未筛选（candidate）不出现。
+    笔记仅作者本人可见（P5b），故只有传 user_id（用户检索入口）才并入笔记命中；
+    agent 调用（无用户语境）不搜笔记。
     """
     library = await get_library_for_project(session, project_id)
     pattern = f"%{q}%"
-    note_hit = Paper.id.in_(
-        select(PaperNote.paper_id).where(
-            PaperNote.project_id == project_id, PaperNote.content.ilike(pattern)
+    hits = [
+        Paper.title.ilike(pattern),
+        Paper.abstract.ilike(pattern),
+        LibraryPaper.wiki_content.ilike(pattern),
+    ]
+    if user_id is not None:
+        hits.append(
+            Paper.id.in_(
+                select(PaperNote.paper_id).where(
+                    PaperNote.author_id == user_id, PaperNote.content.ilike(pattern)
+                )
+            )
         )
-    )
     stmt = (
         member_paper_stmt(library.id)
-        .where(
-            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
-            or_(
-                Paper.title.ilike(pattern),
-                Paper.abstract.ilike(pattern),
-                LibraryPaper.wiki_content.ilike(pattern),
-                note_hit,
-            ),
-        )
+        .where(LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]), or_(*hits))
         .limit(limit * 3)
     )
     rows = (await session.execute(stmt)).all()

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -30,6 +30,7 @@ from app.models.paper import (
     PaperUserMeta,
     paper_tag_links,
 )
+from app.models.project import ProjectMember
 from app.services.libraries import (
     get_library_for_project,
     member_paper_stmt,
@@ -253,13 +254,55 @@ async def list_papers(
     return [PaperView(paper, membership, project_id) for paper, membership in rows], int(total)
 
 
+async def _pool_paper_view(
+    session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool
+) -> PaperView | None:
+    """池级可见性兜底（P5b）：论文不在任何可见方向库，但个人链路可达时仍可读。
+
+    可达条件：该论文在请求者任一课题的相关研究书架上，或在其个人库条目里
+    （dedup 匹配）。返回的视角带**临时成员行**（不入 session、永不落库）：
+    status=included、无判断字段；``project_id`` 取最早入架的课题（仅个人库
+    可达时为 None）。只用于读路径——写成员行的端点不开启池级兜底。
+    """
+    from app.models.topic_shelf import TopicPaper
+    from app.services import user_library
+
+    options = (selectinload(Paper.concepts),) if with_concepts else ()
+    paper = await session.get(Paper, paper_id, options=options)
+    if paper is None:
+        return None
+    stmt = (
+        select(TopicPaper.topic_id)
+        .join(ProjectMember, ProjectMember.project_id == TopicPaper.topic_id)
+        .where(TopicPaper.paper_id == paper_id, ProjectMember.user_id == user_id)
+        .order_by(TopicPaper.created_at)
+        .limit(1)
+    )
+    topic_id = (await session.execute(stmt)).scalar_one_or_none()
+    if topic_id is None:
+        entry = await user_library.entry_for_paper(session, user_id=user_id, paper=paper)
+        if entry is None:
+            return None
+    membership = LibraryPaper(
+        status="included", created_at=paper.created_at, updated_at=paper.updated_at
+    )
+    return PaperView(paper, membership, topic_id)
+
+
 async def get_paper_for_user(
-    session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool = False
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    with_concepts: bool = False,
+    include_pool: bool = False,
 ) -> PaperView | None:
     """取论文（含成员行视角）；用户任一所属方向的库里都没有时视为不存在。
 
     论文同时在多个可见方向库时取一个确定性视角：优先有 wiki 解读的成员行，
     其次最早加入的（跨方向复用的论文以先入库方向的解读为主视角）。
+    include_pool=True（只给读路径用）时再走池级兜底：书架 / 个人库可达的
+    无库论文也可读（见 :func:`_pool_paper_view`）。
     """
     stmt = (
         user_visible_paper_stmt(user_id)
@@ -270,10 +313,14 @@ async def get_paper_for_user(
     if with_concepts:
         stmt = stmt.options(selectinload(Paper.concepts))
     row = (await session.execute(stmt)).first()
-    if row is None:
+    if row is not None:
+        paper, membership, project_id = row
+        return PaperView(paper, membership, project_id)
+    if not include_pool:
         return None
-    paper, membership, project_id = row
-    return PaperView(paper, membership, project_id)
+    return await _pool_paper_view(
+        session, paper_id=paper_id, user_id=user_id, with_concepts=with_concepts
+    )
 
 
 async def set_paper_status(session: AsyncSession, view: PaperView, status: str) -> PaperView:

--- a/src/backend/app/services/personal_wiki.py
+++ b/src/backend/app/services/personal_wiki.py
@@ -1,0 +1,86 @@
+"""个人版 wiki 按需编译（P5b，不 import fastapi）。
+
+适用对象：**没有任何库版 wiki** 的内容池论文（典型：个人补充入库的库外论文，
+或入库了但还没编译的论文）。用通用模板（无 rubric）编译，可选带上课题
+statement 作为侧重提示；结果写进调用者本人的 user_library_entries.wiki_content
+（三层解析「库版实时 > 个人版 > 书架快照」的中间层）。
+
+费用归个人（LLM 用量记 user_id；给了 topic_id 时顺带归因该课题）。
+并发防抖：同一 paper × user 编译进行中时，二次请求直接抛
+CompileInProgressError（路由映射 409）——进程内 set 实现，单实例足够，
+多副本部署下最坏情况是重复编译一次、后写覆盖，无一致性风险。
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.router import get_llm_router
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.project import Project
+from app.services.user_library import set_personal_wiki
+from app.services.wiki_compile import CompiledWiki, compile_paper
+
+
+class LibraryWikiExistsError(Exception):
+    """已有库版 wiki，不需要个人编译（前端应直接展示库版）。"""
+
+
+class CompileInProgressError(Exception):
+    """同一 paper × user 的编译已在进行中。"""
+
+
+# 进行中的编译（paper_id, user_id）；见模块 docstring 的并发说明
+_COMPILING: set[tuple[uuid.UUID, uuid.UUID]] = set()
+
+
+async def has_library_wiki(session: AsyncSession, paper_id: uuid.UUID) -> bool:
+    """任一方向库的成员行上有 wiki_content 即视为「有库版」。"""
+    stmt = (
+        select(LibraryPaper.id)
+        .where(LibraryPaper.paper_id == paper_id, LibraryPaper.wiki_content.is_not(None))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).first() is not None
+
+
+async def compile_personal_wiki(
+    session: AsyncSession,
+    *,
+    paper: Paper,
+    user_id: uuid.UUID,
+    topic_id: uuid.UUID | None = None,
+) -> CompiledWiki:
+    """通用模板编译个人版 wiki 并写进本人个人库条目，返回编译结果。
+
+    topic_id（可选，调用方已验成员身份）：课题 statement 作为侧重提示，
+    同时作为 LLM 用量的课题归因。
+    """
+    if await has_library_wiki(session, paper.id):
+        raise LibraryWikiExistsError(str(paper.id))
+
+    statement: str | None = None
+    if topic_id is not None:
+        project = await session.get(Project, topic_id)
+        if project is not None:
+            definition = project.definition if isinstance(project.definition, dict) else {}
+            statement = definition.get("statement") or project.name
+
+    key = (paper.id, user_id)
+    if key in _COMPILING:
+        raise CompileInProgressError(str(paper.id))
+    _COMPILING.add(key)
+    try:
+        compiled = await compile_paper(
+            paper,
+            statement=statement,
+            llm=get_llm_router(),
+            user_id=user_id,
+            project_id=topic_id,
+        )
+    finally:
+        _COMPILING.discard(key)
+    await set_personal_wiki(session, user_id=user_id, paper=paper, wiki_content=compiled.content)
+    return compiled

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -2,7 +2,8 @@
 
 三条铁律（docs-dev/workspace-ia-redesign.md §3.4/§3.6）：
 - 论文本体纯引用（paper_id 指向全局内容池）；
-- 库版 wiki 引用为主、入架落快照兜底：展示优先级 库版实时 > 快照；
+- 库版 wiki 引用为主、入架落快照兜底：展示优先级 库版实时 > 个人编译版 >
+  快照（P5b 三层解析；个人版 = 请求者本人 user_library_entries.wiki_content）；
 - 入架必入个人库（user_library_entries，saved=true，共享同一次快照写入）；
   移出书架不动个人库。
 """
@@ -29,6 +30,10 @@ class PaperNotFoundError(Exception):
 
 class ShelfItemNotFoundError(Exception):
     """课题书架上没有这篇论文。"""
+
+
+class NoWikiSourceError(Exception):
+    """刷新快照时没有任何可用的 wiki 来源（库版 / 个人版都没有）。"""
 
 
 class _SnapshotPaper:
@@ -72,10 +77,17 @@ def _pick_live_wiki(rows: list[Any], project_id: uuid.UUID) -> str | None:
     return other.wiki_content if other is not None else None
 
 
-def _item_dict(row: TopicPaper, paper: Paper, live_wiki: str | None) -> dict[str, Any]:
-    """书架条目出参：wiki 展示优先级 库版实时 > 快照；source 标注来源状态。"""
+def _item_dict(
+    row: TopicPaper, paper: Paper, live_wiki: str | None, personal_wiki: str | None
+) -> dict[str, Any]:
+    """书架条目出参：wiki 展示优先级 库版实时 > 个人版 > 快照；source 标注来源状态。
+
+    个人库条目的 wiki 字段身兼两职（个人编译版 / 浏览与入架时的库版快照），
+    与书架快照内容相同时按快照标注（带日期更诚实），不同才算「个人版」。"""
     if live_wiki is not None:
         wiki_source, wiki_content = "live", live_wiki
+    elif personal_wiki is not None and personal_wiki != row.wiki_snapshot:
+        wiki_source, wiki_content = "personal", personal_wiki
     elif row.wiki_snapshot:
         wiki_source, wiki_content = "snapshot", row.wiki_snapshot
     else:
@@ -109,16 +121,30 @@ async def _get_row(
 
 
 async def _item_of(
-    session: AsyncSession, row: TopicPaper, paper: Paper, project_id: uuid.UUID
+    session: AsyncSession,
+    row: TopicPaper,
+    paper: Paper,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
 ) -> dict[str, Any]:
     wiki_rows = await _wiki_rows_for(session, [paper.id])
-    return _item_dict(row, paper, _pick_live_wiki(wiki_rows, project_id))
+    personal = await user_library.personal_wiki_map(session, user_id=user_id, papers=[paper])
+    return _item_dict(
+        row, paper, _pick_live_wiki(wiki_rows, project_id), personal.get(paper.id)
+    )
 
 
 async def list_shelf(
-    session: AsyncSession, *, project_id: uuid.UUID, page: int = 1, size: int = 20
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    page: int = 1,
+    size: int = 20,
 ) -> tuple[list[dict[str, Any]], int]:
-    """分页列书架（最新入架在前），每条带解析后的 wiki 内容与来源状态。"""
+    """分页列书架（最新入架在前），每条带解析后的 wiki 内容与来源状态。
+
+    个人版层按请求者（user_id）本人的个人库条目解析。"""
     base = (
         select(TopicPaper, Paper)
         .join(Paper, Paper.id == TopicPaper.paper_id)
@@ -136,8 +162,16 @@ async def list_shelf(
     by_paper: dict[uuid.UUID, list[Any]] = {}
     for r in wiki_rows:
         by_paper.setdefault(r.paper_id, []).append(r)
+    personal = await user_library.personal_wiki_map(
+        session, user_id=user_id, papers=[paper for _, paper in rows]
+    )
     items = [
-        _item_dict(row, paper, _pick_live_wiki(by_paper.get(paper.id, []), project_id))
+        _item_dict(
+            row,
+            paper,
+            _pick_live_wiki(by_paper.get(paper.id, []), project_id),
+            personal.get(paper.id),
+        )
         for row, paper in rows
     ]
     return items, int(total)
@@ -173,7 +207,7 @@ async def add_to_shelf(
         if note is not None:
             row.note = note
         await session.commit()
-        return await _item_of(session, row, paper, project_id)
+        return await _item_of(session, row, paper, project_id, user_id)
 
     wiki_rows = await _wiki_rows_for(session, [paper_id])
     live_wiki = _pick_live_wiki(wiki_rows, project_id)
@@ -196,11 +230,16 @@ async def add_to_shelf(
     await user_library.save_paper(
         session, user_id=user_id, paper=_SnapshotPaper(paper, live_wiki)
     )
-    return await _item_of(session, row, paper, project_id)
+    return await _item_of(session, row, paper, project_id, user_id)
 
 
 async def update_note(
-    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID, note: str | None
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    note: str | None,
 ) -> dict[str, Any]:
     row = await _get_row(session, project_id=project_id, paper_id=paper_id)
     if row is None:
@@ -209,7 +248,33 @@ async def update_note(
     await session.commit()
     paper = await session.get(Paper, paper_id)
     assert paper is not None  # 书架行外键保证
-    return await _item_of(session, row, paper, project_id)
+    return await _item_of(session, row, paper, project_id, user_id)
+
+
+async def refresh_snapshot(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> dict[str, Any]:
+    """手动刷新书架快照：从当前可得的最优 wiki（库版 > 个人版）重拷。
+
+    两个来源都没有 → NoWikiSourceError（路由映射 409）。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    paper = await session.get(Paper, paper_id)
+    assert paper is not None  # 书架行外键保证
+    live = _pick_live_wiki(await _wiki_rows_for(session, [paper_id]), project_id)
+    personal = await user_library.personal_wiki_map(session, user_id=user_id, papers=[paper])
+    best = live or personal.get(paper_id)
+    if best is None:
+        raise NoWikiSourceError(str(paper_id))
+    row.wiki_snapshot = best
+    row.snapshot_at = utcnow()
+    await session.commit()
+    return await _item_of(session, row, paper, project_id, user_id)
 
 
 async def remove_from_shelf(

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -25,6 +25,8 @@ def dedup_key_for_paper(paper: Paper) -> str:
 
 
 def _snapshot_fields(paper: Paper) -> dict:
+    # wiki_content 用 getattr：调用方可能传裸 Paper（内容池行没有 wiki 字段，
+    # 库版 wiki 在成员行上，由 PaperView / _SnapshotPaper 包装提供）
     return {
         "arxiv_id": paper.arxiv_id,
         "doi": paper.doi,
@@ -35,7 +37,7 @@ def _snapshot_fields(paper: Paper) -> dict:
         "abstract": paper.abstract,
         "url": paper.url,
         "tldr": paper.tldr,
-        "wiki_content": paper.wiki_content,
+        "wiki_content": getattr(paper, "wiki_content", None),
         "last_paper_id": paper.id,
     }
 
@@ -71,6 +73,10 @@ async def record_visit(
         session.add(entry)
     else:
         for field, value in _snapshot_fields(paper).items():
+            # wiki 快照只升不清：论文当前没有库版 wiki 时保留旧快照
+            # （可能是个人编译版 / 库版被删前的快照，P5b 三层解析的兜底层）
+            if field == "wiki_content" and value is None:
+                continue
             setattr(entry, field, value)
     entry.visit_count = (entry.visit_count or 0) + 1  # 未 flush 的新对象默认值尚未生效
     entry.last_visited_at = utcnow()
@@ -100,6 +106,41 @@ async def set_saved(
     await session.commit()
     await session.refresh(entry)
     return entry
+
+
+async def set_personal_wiki(
+    session: AsyncSession, *, user_id: uuid.UUID, paper: Paper, wiki_content: str
+) -> UserLibraryEntry:
+    """把个人编译版 wiki 写进本人条目（无条目则建，不动 saved/浏览统计）。"""
+    entry = await entry_for_paper(session, user_id=user_id, paper=paper)
+    if entry is None:
+        entry = UserLibraryEntry(
+            user_id=user_id, dedup_key=dedup_key_for_paper(paper), **_snapshot_fields(paper)
+        )
+        session.add(entry)
+    entry.wiki_content = wiki_content
+    await session.commit()
+    await session.refresh(entry)
+    return entry
+
+
+async def personal_wiki_map(
+    session: AsyncSession, *, user_id: uuid.UUID, papers: list[Paper]
+) -> dict[uuid.UUID, str]:
+    """paper_id → 本人条目里的 wiki（个人编译版 / 历史快照），无则不在结果里。
+
+    P5b 三层解析（库版实时 > 个人版 > 书架快照）的中间层数据源。
+    """
+    keys = {paper.id: dedup_key_for_paper(paper) for paper in papers}
+    if not keys:
+        return {}
+    stmt = select(UserLibraryEntry.dedup_key, UserLibraryEntry.wiki_content).where(
+        UserLibraryEntry.user_id == user_id,
+        UserLibraryEntry.dedup_key.in_(set(keys.values())),
+        UserLibraryEntry.wiki_content.is_not(None),
+    )
+    by_key = {key: content for key, content in (await session.execute(stmt)).all() if content}
+    return {pid: by_key[key] for pid, key in keys.items() if key in by_key}
 
 
 async def purge_entry(session: AsyncSession, *, entry: UserLibraryEntry) -> None:

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -98,8 +98,10 @@ def _figure_prompt_section(selected: list[tuple[dict[str, Any], bytes]]) -> str:
     return "\n".join(lines)
 
 
-def build_compile_prompt(paper: Paper, *, statement: str) -> tuple[str, list[bytes]]:
-    """组装编译 user prompt 与随附图片（无重要图时 images 为空 → 纯文字编译）。"""
+def build_compile_prompt(paper: Paper, *, statement: str | None) -> tuple[str, list[bytes]]:
+    """组装编译 user prompt 与随附图片（无重要图时 images 为空 → 纯文字编译）。
+
+    statement 为空 = 通用模板（个人版 wiki，无方向侧重）：不带「研究方向」行。"""
     body: str | None = None
     source = "abstract"
     if paper.full_text_path and Path(paper.full_text_path).exists():
@@ -107,9 +109,10 @@ def build_compile_prompt(paper: Paper, *, statement: str) -> tuple[str, list[byt
         source = "full_text"
     body = (body or paper.abstract or "（无正文）")[:FULLTEXT_PROMPT_CHARS]
     authors = "、".join(a.get("name", "") for a in (paper.authors or []) if isinstance(a, dict))
+    direction_line = f"研究方向：{statement}\n" if statement else ""
     prompt = (
-        f"研究方向：{statement}\n"
-        f"标题：{paper.title}\n"
+        direction_line
+        + f"标题：{paper.title}\n"
         f"作者：{authors or '未知'}\n"
         f"年份/发表：{paper.year or '未知'} {paper.venue or ''}\n"
         f"正文来源：{source}\n"
@@ -132,7 +135,7 @@ class CompiledWiki:
 async def compile_paper(
     paper: Paper,
     *,
-    statement: str,
+    statement: str | None,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,

--- a/src/backend/app/services/wiki_export.py
+++ b/src/backend/app/services/wiki_export.py
@@ -100,7 +100,10 @@ def _inline_paper_figures(
     return body, extra_lines
 
 
-async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
+async def build_obsidian_zip(
+    session: AsyncSession, project: Project, *, user_id: uuid.UUID
+) -> bytes:
+    """构建 vault zip；笔记只导出请求者本人的（P5b 笔记 paper × author，仅作者可见）。"""
     library = await get_library_for_project(session, project.id)
     paper_rows = (
         await session.execute(
@@ -129,11 +132,14 @@ async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
         .all()
     )
 
-    # 论文笔记（有笔记的论文页追加「## 笔记」小节）
+    # 论文笔记（有笔记的论文页追加「## 笔记」小节）：只带请求者自己的笔记
     note_rows = await session.execute(
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .where(PaperNote.project_id == project.id)
+        .where(
+            PaperNote.author_id == user_id,
+            PaperNote.paper_id.in_([p.id for p in papers]),
+        )
         .order_by(PaperNote.created_at)
     )
     notes_by_paper: dict[uuid.UUID, list[tuple[PaperNote, str]]] = defaultdict(list)

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -274,7 +274,7 @@ async def get_paper_citation(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 
 @tool(
     "get_paper_notes",
-    description="取某论文的项目笔记（团队共享，附作者）",
+    description="取某论文下当前用户的笔记（P5b 起笔记仅作者本人可见）",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -285,7 +285,14 @@ async def get_paper_citation(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         paper = await _project_paper(session, ctx, args.get("paper_id"))
-        rows = await notes_service.list_paper_notes(session, paper_id=paper.id)
+        # 笔记仅作者本人可见：无用户语境（系统内部调用）时返回空
+        rows = (
+            await notes_service.list_paper_notes(
+                session, paper_id=paper.id, author_id=ctx.user_id
+            )
+            if ctx.user_id is not None
+            else []
+        )
         return {
             "paper_id": str(paper.id),
             "notes": [{"author": author, "content": note.content} for note, author in rows],
@@ -294,7 +301,7 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 
 @tool(
     "get_paper_highlights",
-    description="取某论文的划线/高亮（团队共享，含所在页与选中文本）",
+    description="取某论文下当前用户的划线/高亮（含所在页与选中文本；仅作者本人可见）",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -305,7 +312,13 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 async def get_paper_highlights(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         paper = await _project_paper(session, ctx, args.get("paper_id"))
-        rows = await highlights_service.list_paper_highlights(session, paper_id=paper.id)
+        rows = (
+            await highlights_service.list_paper_highlights(
+                session, paper_id=paper.id, author_id=ctx.user_id
+            )
+            if ctx.user_id is not None
+            else []
+        )
         return {
             "paper_id": str(paper.id),
             "highlights": [

--- a/src/backend/tests/test_highlights.py
+++ b/src/backend/tests/test_highlights.py
@@ -1,4 +1,4 @@
-"""PDF 划线标注：CRUD + 颜色规整 + 排序 + 权限（同论文笔记权限模型）。"""
+"""PDF 划线标注：CRUD + 颜色规整 + 排序 + 权限（P5b 起同笔记：仅作者本人可见）。"""
 
 import uuid
 
@@ -47,24 +47,32 @@ async def test_highlight_crud_and_ordering(client):
     )
     assert resp.status_code == 201, resp.text
     hl = resp.json()
-    assert hl["paper_id"] == pid and hl["project_id"] == project_id
+    assert hl["paper_id"] == pid
+    assert "project_id" not in hl  # P5b：划线不再挂项目
     assert hl["page"] == 3 and hl["color"] == "green" and hl["note"] is None
     assert hl["style"] == "highlight"  # 默认样式
     assert hl["author_name"] == "Alice"
     assert hl["rects"] == [RECT]
     hl_id = hl["id"]
 
-    # 第 1 页再建一条（bob）
+    # alice 第 1 页再建一条；bob 也建一条（仅本人可见）
     await client.post(
         f"/api/papers/{pid}/highlights",
         json={"page": 1, "rects": [RECT], "selected_text": "encoder"},
+        headers=alice,
+    )
+    await client.post(
+        f"/api/papers/{pid}/highlights",
+        json={"page": 2, "rects": [RECT], "selected_text": "bob 的划线"},
         headers=bob,
     )
-    # 成员可读，按页码升序
-    resp = await client.get(f"/api/papers/{pid}/highlights", headers=bob)
+    # 只看到自己的，按页码升序
+    resp = await client.get(f"/api/papers/{pid}/highlights", headers=alice)
     rows = resp.json()
     assert [r["page"] for r in rows] == [1, 3]
     assert rows[0]["color"] == "yellow"  # 默认色
+    resp = await client.get(f"/api/papers/{pid}/highlights", headers=bob)
+    assert [r["selected_text"] for r in resp.json()] == ["bob 的划线"]
 
     # 作者改颜色 + 加批注
     resp = await client.patch(
@@ -81,7 +89,7 @@ async def test_highlight_crud_and_ordering(client):
     resp = await client.delete(f"/api/highlights/{hl_id}", headers=alice)
     assert resp.status_code == 204
     resp = await client.get(f"/api/papers/{pid}/highlights", headers=alice)
-    assert len(resp.json()) == 1
+    assert [r["page"] for r in resp.json()] == [1]
 
 
 async def test_highlight_style(client):
@@ -150,11 +158,11 @@ async def test_highlight_permissions(client):
     )
     hl_id = resp.json()["id"]
 
-    # 非作者成员改/删 → 403
+    # 非作者成员改/删 → 404（P5b 起他人划线不可见，视为不存在）
     assert (
         await client.patch(f"/api/highlights/{hl_id}", json={"color": "pink"}, headers=bob)
-    ).status_code == 403
-    assert (await client.delete(f"/api/highlights/{hl_id}", headers=bob)).status_code == 403
+    ).status_code == 404
+    assert (await client.delete(f"/api/highlights/{hl_id}", headers=bob)).status_code == 404
 
     # 非项目成员 → 404
     mallory = await register_and_login(client, email="mallory@example.com")

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -1,4 +1,4 @@
-"""alembic 迁移 sqlite 实跑：全链 upgrade head + 最新 revision（论文评审 M5-C）往返。"""
+"""alembic 迁移 sqlite 实跑：全链 upgrade head + 最新 revision 往返。"""
 
 from pathlib import Path
 
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a，本分支最新）
-PREV_REVISION = "fe8a86942dc7"  # 论文内容池收尾（P4 迁移 B）
+HEAD_REVISION = "1c6c4831d80f"  # 笔记/划线归属拆分（P5b，本分支最新）
+PREV_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -86,9 +86,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "experiments"
     ]
     assert {"seq", "exit_code", "pid", "started_at", "finished_at"} <= columns["experiment_runs"]
-    # M5：笔记 / 标签 / 个人状态表
+    # M5：笔记 / 标签 / 个人状态表（P5b 起笔记/划线归 paper × author，project_id 删列）
     assert {"paper_notes", "paper_tags", "paper_tag_links", "paper_user_meta"} <= columns["_tables"]
-    assert {"paper_id", "project_id", "author_id", "content"} <= columns["paper_notes"]
+    assert {"paper_id", "author_id", "content"} <= columns["paper_notes"]
+    assert "project_id" not in columns["paper_notes"]
     assert {"project_id", "name"} <= columns["paper_tags"]
     assert columns["paper_tag_links"] == {"paper_id", "tag_id"}
     assert {"paper_id", "user_id", "starred", "reading_status"} <= columns["paper_user_meta"]
@@ -132,11 +133,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_score" not in columns["papers"]
     assert "wiki_content" not in columns["papers"]
     assert "project_id" not in columns["papers"]
-    # PDF 划线标注表（上一版 paper_highlights）
+    # PDF 划线标注表（P5b 起无 project_id）
     assert "paper_highlights" in columns["_tables"]
     assert {
         "paper_id",
-        "project_id",
         "author_id",
         "page",
         "rects",
@@ -145,6 +145,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "style",
         "note",
     } <= columns["paper_highlights"]
+    assert "project_id" not in columns["paper_highlights"]
     # 稿件文件版本快照表
     assert "manuscript_file_versions" in columns["_tables"]
     assert {"file_id", "seq", "origin", "label", "content"} <= columns["manuscript_file_versions"]
@@ -221,11 +222,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "added_by",
     } <= columns["topic_papers"]
 
-    # 最新 revision 可往返（downgrade 只删 topic_papers，其余结构不动）
+    # 最新 revision 可往返（downgrade 补回可空 project_id 列，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "topic_papers" not in columns["_tables"]
+    assert "project_id" in columns["paper_notes"]
+    assert "project_id" in columns["paper_highlights"]
+    assert "topic_papers" in columns["_tables"]
     # P4 收尾后的内容池结构不受影响：判断列仍只在 library_papers 上
     assert "project_id" not in columns["papers"]
     assert "wiki_content" not in columns["papers"]
@@ -255,6 +258,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "project_id" not in columns["paper_notes"]
+    assert "project_id" not in columns["paper_highlights"]
     assert "models" in columns["llm_providers"]
     assert "owner_id" in columns["llm_providers"]
     assert "llm_self_managed" in columns["users"]

--- a/src/backend/tests/test_notes.py
+++ b/src/backend/tests/test_notes.py
@@ -1,4 +1,5 @@
-"""论文笔记（docs/api-lit.md §2）：CRUD + 权限 + 项目笔记本 + 检索并入 + 导出小节。"""
+"""论文笔记（docs/api-lit.md §2 + P5b 归属拆分）：CRUD + 仅作者可见 +
+跨课题共享 + 课题笔记本 + 检索并入 + 导出小节。"""
 
 import io
 import uuid
@@ -7,9 +8,10 @@ import zipfile
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
+from app.models.paper import PaperNote
 from app.models.user import User
 from app.services.notes import author_name_of
-from tests.conftest import add_paper, register_and_login
+from tests.conftest import add_paper, membership_of, register_and_login
 
 
 async def _setup(client):
@@ -48,7 +50,7 @@ async def _setup(client):
     return project_id, headers, bob_headers, ids
 
 
-async def test_notes_crud_and_author_name(client):
+async def test_notes_crud_and_author_only_visibility(client):
     project_id, alice, bob, ids = await _setup(client)
 
     resp = await client.post(
@@ -56,15 +58,17 @@ async def test_notes_crud_and_author_name(client):
     )
     assert resp.status_code == 201, resp.text
     note = resp.json()
-    assert note["paper_id"] == ids["p1"] and note["project_id"] == project_id
+    assert note["paper_id"] == ids["p1"]
     assert note["author_name"] == "Alice"  # display_name 优先
+    assert "project_id" not in note  # P5b：笔记不再挂项目
     note_id = note["id"]
 
-    # 成员可读（按 created_at 倒序）
+    # 仅作者可见：bob 的列表只有 bob 自己的笔记，看不到 alice 的
     await client.post(f"/api/papers/{ids['p1']}/notes", json={"content": "第二条"}, headers=bob)
     resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=bob)
-    notes = resp.json()
-    assert [n["content"] for n in notes] == ["第二条", "重点：方法部分"]
+    assert [n["content"] for n in resp.json()] == ["第二条"]
+    resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
+    assert [n["content"] for n in resp.json()] == ["重点：方法部分"]
 
     # 作者可改
     resp = await client.patch(f"/api/notes/{note_id}", json={"content": "改过了"}, headers=alice)
@@ -75,11 +79,54 @@ async def test_notes_crud_and_author_name(client):
     resp = await client.delete(f"/api/notes/{note_id}", headers=alice)
     assert resp.status_code == 204
     resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
-    assert len(resp.json()) == 1
+    assert resp.json() == []
 
     # author_name 回退 email @ 前部分
     assert author_name_of("", "carol@example.com") == "carol"
     assert author_name_of(None, "dave@example.com") == "dave"
+
+
+async def test_notes_shared_across_topics_and_survive_library_removal(client):
+    """P5b 归属拆分：同一篇论文的笔记跨课题共享；库剔除不删笔记。"""
+    project_id, alice, bob, ids = await _setup(client)
+    # alice 开第二个课题，并把 p1 也收进第二个课题的方向库
+    resp = await client.post("/api/projects", json={"name": "notes-proj-2"}, headers=alice)
+    project2_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import LibraryPaper
+        from app.services.libraries import get_library_for_project
+
+        library2 = await get_library_for_project(session, uuid.UUID(project2_id))
+        session.add(
+            LibraryPaper(
+                library_id=library2.id, paper_id=uuid.UUID(ids["p1"]), status="included"
+            )
+        )
+        await session.commit()
+
+    await client.post(
+        f"/api/papers/{ids['p1']}/notes", json={"content": "跨课题的笔记"}, headers=alice
+    )
+
+    # 两个课题的笔记本都能看到（paper × author，无课题隔离）
+    for pid in (project_id, project2_id):
+        resp = await client.get(f"/api/projects/{pid}/notes", headers=alice)
+        assert resp.status_code == 200
+        assert [n["content"] for n in resp.json()["items"]] == ["跨课题的笔记"], pid
+
+    # 从第一个课题的库硬删这篇论文 → 笔记保留（第二个课题照常可见）
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=ids["p1"])
+        await session.delete(membership)
+        await session.commit()
+    resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
+    assert [n["content"] for n in resp.json()] == ["跨课题的笔记"]
+    resp = await client.get(f"/api/projects/{project2_id}/notes", headers=alice)
+    assert resp.json()["total"] == 1
+    async with get_sessionmaker()() as session:
+        stmt = select(PaperNote).where(PaperNote.paper_id == uuid.UUID(ids["p1"]))
+        rows = (await session.execute(stmt)).scalars().all()
+        assert len(rows) == 1
 
 
 async def test_notes_permissions(client):
@@ -89,11 +136,11 @@ async def test_notes_permissions(client):
     )
     note_id = resp.json()["id"]
 
-    # 非作者成员改/删 → 403
+    # 非作者成员改/删 → 404（P5b 起他人笔记不可见，视为不存在）
     resp = await client.patch(f"/api/notes/{note_id}", json={"content": "x"}, headers=bob)
-    assert resp.status_code == 403
+    assert resp.status_code == 404
     resp = await client.delete(f"/api/notes/{note_id}", headers=bob)
-    assert resp.status_code == 403
+    assert resp.status_code == 404
 
     # 非项目成员 → 404（笔记与论文都视为不存在）
     mallory = await register_and_login(client, email="mallory@example.com")
@@ -121,15 +168,21 @@ async def test_project_notebook_pagination_and_search(client):
             f"/api/papers/{ids['p1']}/notes", json={"content": f"note-{i} 关于对齐"}, headers=alice
         )
     await client.post(
-        f"/api/papers/{ids['p2']}/notes", json={"content": "另一篇的量子笔记"}, headers=bob
+        f"/api/papers/{ids['p2']}/notes", json={"content": "另一篇的量子笔记"}, headers=alice
+    )
+    await client.post(
+        f"/api/papers/{ids['p2']}/notes", json={"content": "bob 私有笔记"}, headers=bob
     )
 
+    # 笔记本只聚合「我的」笔记（bob 的不计入）
     resp = await client.get(f"/api/projects/{project_id}/notes?size=2&page=1", headers=alice)
     body = resp.json()
     assert body["total"] == 4 and len(body["items"]) == 2
     assert body["items"][0]["content"] == "另一篇的量子笔记"  # created_at 倒序
     assert body["items"][0]["paper_title"] == "Second Paper"
-    assert body["items"][0]["author_name"] == "Alice"  # bob 注册时 display_name 也是 Alice
+    resp = await client.get(f"/api/projects/{project_id}/notes", headers=bob)
+    assert resp.json()["total"] == 1
+    assert resp.json()["items"][0]["content"] == "bob 私有笔记"
 
     # q 内容搜索 + paper_id 过滤
     resp = await client.get(f"/api/projects/{project_id}/notes?q=量子", headers=alice)
@@ -145,7 +198,7 @@ async def test_project_notebook_pagination_and_search(client):
     assert resp.status_code == 404
 
 
-async def test_keyword_search_includes_note_hits(client):
+async def test_keyword_search_includes_own_note_hits_only(client):
     project_id, alice, bob, ids = await _setup(client)
     await client.post(
         f"/api/papers/{ids['p2']}/notes", json={"content": "提到了量子退火算法"}, headers=alice
@@ -156,8 +209,14 @@ async def test_keyword_search_includes_note_hits(client):
     titles = [p["title"] for p in resp.json()["papers"]]
     assert titles == ["Second Paper"]  # 仅笔记命中也返回
 
+    # bob 搜同一关键词：alice 的私有笔记不参与命中
+    resp = await client.get(
+        f"/api/projects/{project_id}/search?q=量子退火&mode=keyword", headers=bob
+    )
+    assert resp.json()["papers"] == []
 
-async def test_obsidian_export_includes_notes_section(client):
+
+async def test_obsidian_export_includes_own_notes_section(client):
     project_id, alice, bob, ids = await _setup(client)
     await client.post(
         f"/api/papers/{ids['p1']}/notes", json={"content": "导出验证用笔记"}, headers=alice
@@ -173,3 +232,9 @@ async def test_obsidian_export_includes_notes_section(client):
     # 无笔记的论文页不加小节
     second_md = zf.read("papers/second-paper.md").decode("utf-8")
     assert "## 笔记" not in second_md
+
+    # bob 导出：alice 的笔记不出现（只导出请求者本人的）
+    resp = await client.get(f"/api/projects/{project_id}/export/obsidian", headers=bob)
+    zf_bob = zipfile.ZipFile(io.BytesIO(resp.content))
+    bob_md = zf_bob.read("papers/agent-planning-with-rl.md").decode("utf-8")
+    assert "## 笔记" not in bob_md

--- a/src/backend/tests/test_personal_wiki.py
+++ b/src/backend/tests/test_personal_wiki.py
@@ -1,0 +1,325 @@
+"""个人版 wiki 按需编译 + 三层 wiki 解析 + 书架快照手动刷新（P5b）。
+
+LLM 走 core/llm 的 fake provider（POLARIS_LLM_FAKE_FALLBACK=1，conftest）。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.llm_config import LLMUsage
+from app.models.paper import Paper
+from app.models.topic_shelf import TopicPaper
+from tests.conftest import add_paper, membership_of, register_and_login
+
+
+async def _setup(client, *, name="pw-proj", email="alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_pool_only_paper(**fields) -> str:
+    """建一篇「在池但不在任何库」的论文（个人补充入库的典型状态）。"""
+    async with get_sessionmaker()() as session:
+        paper = Paper(**({"title": "Pool Only Paper", "source": "manual"} | fields))
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def _entry_of(paper_id: str) -> UserLibraryEntry | None:
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one_or_none()
+
+
+# ---- 个人版 wiki 编译 ----
+
+
+async def test_compile_personal_wiki_writes_entry_and_bills_user(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_pool_only_paper(
+        title="Personal Supplement Paper", abstract="Outside any library."
+    )
+
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki", json={"topic_id": project_id}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["paper_id"] == paper_id
+    assert "TL;DR" in body["wiki_content"]  # fake librarian 的通用模板输出
+    assert body["model"]
+
+    # 结果写进本人个人库条目（无条目自动建）
+    entry = await _entry_of(paper_id)
+    assert entry is not None
+    assert entry.wiki_content == body["wiki_content"]
+    assert entry.saved is False  # 只写 wiki，不代收藏
+
+    # 用量归因：user + topic（stage=librarian 至少一条）
+    async with get_sessionmaker()() as session:
+        usages = (
+            (
+                await session.execute(
+                    select(LLMUsage).where(LLMUsage.stage == "librarian")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert usages, "librarian 编译必须记账"
+        assert all(u.user_id is not None for u in usages)
+        assert any(str(u.project_id) == project_id for u in usages)
+
+
+async def test_compile_personal_wiki_without_topic(client):
+    """不带 topic_id 也能编译（纯通用模板，归因只挂用户）。"""
+    _, headers = await _setup(client, name="pw-no-topic", email="carol@example.com")
+    paper_id = await _seed_pool_only_paper(title="No Topic Paper")
+
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    entry = await _entry_of(paper_id)
+    assert entry is not None and entry.wiki_content
+
+
+async def test_compile_personal_wiki_conflicts_and_missing(client):
+    project_id, headers = await _setup(client, name="pw-conflict", email="dave@example.com")
+    # 已有库版 wiki → 409（应直接展示库版）
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Compiled In Library",
+            status="compiled",
+            wiki_content="# 库版",
+        )
+        await session.commit()
+        compiled_id = str(paper.id)
+    resp = await client.post(
+        f"/api/papers/{compiled_id}/personal-wiki", json={}, headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "LIBRARY_WIKI_EXISTS"
+
+    # 池中不存在 → 404
+    resp = await client.post(
+        f"/api/papers/{uuid.uuid4()}/personal-wiki", json={}, headers=headers
+    )
+    assert resp.status_code == 404
+
+    # topic_id 不是自己的课题 → 404
+    outsider_project, _ = await _setup(client, name="pw-other", email="erin@example.com")
+    paper_id = await _seed_pool_only_paper(title="Foreign Topic Paper")
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki",
+        json={"topic_id": outsider_project},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+async def test_compile_personal_wiki_in_progress_409(client, monkeypatch):
+    """并发防抖：同一 paper × user 编译进行中时，二次请求 409 COMPILE_IN_PROGRESS。"""
+    import asyncio
+
+    from app.services import personal_wiki as pw
+    from app.services.wiki_compile import CompiledWiki
+
+    _, headers = await _setup(client, name="pw-race", email="race@example.com")
+    paper_id = await _seed_pool_only_paper(title="Race Paper")
+
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def slow_compile(paper, **kwargs):
+        started.set()
+        await release.wait()
+        return CompiledWiki(content="# 慢编译", model="fake")
+
+    monkeypatch.setattr(pw, "compile_paper", slow_compile)
+    first = asyncio.create_task(
+        client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    )
+    await asyncio.wait_for(started.wait(), timeout=5)
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "COMPILE_IN_PROGRESS"
+    release.set()
+    resp = await asyncio.wait_for(first, timeout=5)
+    assert resp.status_code == 200, resp.text
+    entry = await _entry_of(paper_id)
+    assert entry is not None and entry.wiki_content == "# 慢编译"
+
+
+# ---- 三层 wiki 解析（库版实时 > 个人版 > 快照） ----
+
+
+async def test_shelf_resolves_personal_wiki_between_live_and_snapshot(client):
+    project_id, headers = await _setup(client, name="tier-proj", email="frank@example.com")
+    paper_id = await _seed_pool_only_paper(title="Tiered Paper", arxiv_id="2403.00003")
+
+    # 入架（此时无任何 wiki）→ none
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["wiki_source"] == "none"
+
+    # 编译个人版 → personal
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    personal_wiki = resp.json()["wiki_content"]
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "personal"
+    assert item["wiki_content"] == personal_wiki
+
+    # 手动给书架行塞一份快照：个人版仍然优先于快照
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        row.wiki_snapshot = "# 旧快照"
+        await session.commit()
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["items"][0]["wiki_source"] == "personal"
+
+    # 库后来收录并编译 → 库版实时优先
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import LibraryPaper
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        session.add(
+            LibraryPaper(
+                library_id=library.id,
+                paper_id=uuid.UUID(paper_id),
+                status="compiled",
+                wiki_content="# 库版解读",
+            )
+        )
+        await session.commit()
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "live"
+    assert item["wiki_content"] == "# 库版解读"
+
+    # 个人版属于本人：其他成员（无个人条目）在库版消失后回退快照
+    bob = await register_and_login(client, email="tier-bob@example.com")
+    resp = await client.post(
+        f"/api/projects/{project_id}/members",
+        json={"email": "tier-bob@example.com", "role": "member"},
+        headers=headers,
+    )
+    assert resp.status_code == 204
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        await session.delete(membership)
+        await session.commit()
+    resp = await client.get(
+        f"/api/projects/{project_id}/shelf", headers={"Authorization": f"Bearer {bob}"}
+    )
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "snapshot"
+    assert item["wiki_content"] == "# 旧快照"
+
+
+# ---- 书架快照手动刷新 ----
+
+
+async def test_refresh_snapshot_from_live_and_personal(client):
+    project_id, headers = await _setup(client, name="snap-proj", email="grace@example.com")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Refreshable Paper",
+            status="compiled",
+            wiki_content="# 第一版",
+        )
+        await session.commit()
+        paper_id = str(paper.id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    first_snapshot_at = resp.json()["snapshot_at"]
+
+    # 库版重编译后手动刷新 → 快照跟上新库版
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        membership.wiki_content = "# 第二版"
+        await session.commit()
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        assert row.wiki_snapshot == "# 第二版"
+        assert row.snapshot_at is not None
+    assert resp.json()["snapshot_at"] >= first_snapshot_at
+
+    # 库版消失、只剩个人版 → 刷新拷个人版
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        membership.wiki_content = None
+        await session.commit()
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        entry.wiki_content = "# 个人版"
+        await session.commit()
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 200
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        assert row.wiki_snapshot == "# 个人版"
+
+
+async def test_refresh_snapshot_no_source_409(client):
+    project_id, headers = await _setup(client, name="snap-none", email="henry@example.com")
+    paper_id = await _seed_pool_only_paper(title="Sourceless Paper")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    # 入架同步建了个人库条目但无 wiki → 仍然无源
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "NO_WIKI_SOURCE"
+
+    # 书架上没有的论文 → 404
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{uuid.uuid4()}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_pool_paper_access.py
+++ b/src/backend/tests/test_pool_paper_access.py
@@ -1,0 +1,144 @@
+"""池级可见性（P5b 修复）：个人补充入库（零库成员行）的论文，
+本人经书架 / 个人库可读（详情 / 子资源 / 个人 wiki 全链路）；
+他人（未入架未收藏）与写库端点维持 404。"""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper
+from tests.conftest import register_and_login
+
+RECT = {"x0": 0.1, "y0": 0.1, "x1": 0.5, "y1": 0.12}
+
+
+async def _setup(client, *, name="pool-proj", email="pool-alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_pool_only_paper(**fields) -> str:
+    async with get_sessionmaker()() as session:
+        paper = Paper(**({"title": "Pool Access Paper", "source": "manual"} | fields))
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def test_shelved_pool_paper_full_reading_chain(client):
+    """个人补充论文（零库成员行）入架后：详情 / 笔记 / 划线 / 图片 /
+    个人库埋点 / 个人 wiki 全链路对本人可用。"""
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_pool_only_paper(
+        title="Personally Supplemented", abstract="No library membership."
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+
+    # 详情：course 上下文 = 入架课题；无判断字段但形状完整
+    resp = await client.get(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    detail = resp.json()
+    assert detail["project_id"] == project_id
+    assert detail["status"] == "included"
+    assert detail["relevance_score"] is None
+    assert detail["wiki_content"] is None and detail["has_wiki"] is False
+    assert detail["concepts"] == []
+
+    # 子资源：PDF（可见但无文件 → PDF_NOT_AVAILABLE 而非 PAPER_NOT_FOUND）/ 图片
+    resp = await client.get(f"/api/papers/{paper_id}/pdf", headers=headers)
+    assert resp.status_code == 404 and resp.json()["detail"] == "PDF_NOT_AVAILABLE"
+    resp = await client.get(f"/api/papers/{paper_id}/figures", headers=headers)
+    assert resp.status_code == 200 and resp.json() == []
+
+    # 笔记 / 划线
+    resp = await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "库外论文的笔记"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/papers/{paper_id}/notes", headers=headers)
+    assert [n["content"] for n in resp.json()] == ["库外论文的笔记"]
+    resp = await client.post(
+        f"/api/papers/{paper_id}/highlights",
+        json={"page": 1, "rects": [RECT], "selected_text": "pool highlight"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/papers/{paper_id}/highlights", headers=headers)
+    assert len(resp.json()) == 1
+
+    # 个人状态 + 个人库埋点 / 收藏态
+    resp = await client.put(
+        f"/api/papers/{paper_id}/my-meta", json={"starred": True}, headers=headers
+    )
+    assert resp.status_code == 200 and resp.json()["starred"] is True
+    resp = await client.post(
+        "/api/me/library/visits", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/me/library/state?paper_id={paper_id}", headers=headers)
+    assert resp.status_code == 200 and resp.json()["saved"] is True  # 入架已代收藏
+
+    # 个人 wiki 编译后，书架解析出 personal
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki", json={"topic_id": project_id}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["items"][0]["wiki_source"] == "personal"
+
+
+async def test_pool_paper_visible_via_personal_library_after_shelf_removal(client):
+    """移出书架后个人库条目仍在 → 仍可读，课题上下文为空。"""
+    project_id, headers = await _setup(client, name="pool-proj-2", email="pool-bob@example.com")
+    paper_id = await _seed_pool_only_paper(title="Entry Only Paper", arxiv_id="2405.00005")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers)
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] is None  # 无课题上下文（仅个人库可达）
+    resp = await client.get(f"/api/papers/{paper_id}/notes", headers=headers)
+    assert resp.status_code == 200
+
+
+async def test_pool_paper_hidden_from_others_and_write_paths(client):
+    project_id, headers = await _setup(client, name="pool-proj-3", email="pool-carol@example.com")
+    paper_id = await _seed_pool_only_paper(title="Private Chain Paper")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+
+    # 其他用户（未入架未收藏）：详情与子资源一律 404
+    stranger = await register_and_login(client, email="pool-stranger@example.com")
+    sh = {"Authorization": f"Bearer {stranger}"}
+    for url in (
+        f"/api/papers/{paper_id}",
+        f"/api/papers/{paper_id}/notes",
+        f"/api/papers/{paper_id}/highlights",
+        f"/api/papers/{paper_id}/figures",
+        f"/api/papers/{paper_id}/pdf",
+    ):
+        resp = await client.get(url, headers=sh)
+        assert resp.status_code == 404, url
+
+    # 写库成员行的端点不开池级兜底：对本人也维持 404（应走个人 wiki / 书架操作）
+    resp = await client.patch(
+        f"/api/papers/{paper_id}", json={"status": "excluded"}, headers=headers
+    )
+    assert resp.status_code == 404
+    resp = await client.post(f"/api/papers/{paper_id}/recompile", headers=headers)
+    assert resp.status_code == 404
+    resp = await client.delete(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 404
+    async with get_sessionmaker()() as session:
+        assert await session.get(Paper, uuid.UUID(paper_id)) is not None

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -1,15 +1,17 @@
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { CompileBadge } from '../../components/ui/CompileBadge';
 import { PaperStatusPill } from '../../components/ui/StatusPill';
 import { RelevanceBar } from '../../components/ui/RelevanceBar';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { FigureEmbed, FiguresSection, hasEmbeddedFigures, usePaperFigures } from '../../components/ui/FigureGallery';
+import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
 import { clickable } from '../../lib/a11y';
-import type { PaperDetail } from '../../lib/api';
+import { api, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
 
@@ -40,9 +42,37 @@ export function InfoPanel({
   onWikiLink: WikiLinkHandler;
 }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [abstractOpen, setAbstractOpen] = useState(false);
   const arxivUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : null;
   const extUrl = arxivUrl ?? paper.url;
+
+  // —— 个人版 wiki（P5b）：没有库版解读时，读本人个人库条目里的个人编译版 ——
+  const libStateQuery = useQuery({
+    queryKey: ['library-state', paper.id],
+    queryFn: () => api.getLibraryState(paper.id),
+    enabled: !paper.wiki_content,
+    retry: false,
+  });
+  const entryId = libStateQuery.data?.entry_id ?? null;
+  const entryQuery = useQuery({
+    queryKey: ['library-entry', entryId],
+    queryFn: () => api.getLibraryEntry(entryId!),
+    enabled: !paper.wiki_content && !!entryId,
+    retry: false,
+  });
+  const personalWiki = paper.wiki_content ? null : (entryQuery.data?.wiki_content ?? null);
+  const generateMutation = useMutation({
+    mutationFn: () => api.compilePersonalWiki(paper.id, paper.project_id),
+    onSuccess: () => {
+      toast(tr('个人版解读已生成', 'Personal wiki generated'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library-state', paper.id] });
+      void queryClient.invalidateQueries({ queryKey: ['library-entry'] });
+      void queryClient.invalidateQueries({ queryKey: ['library'] });
+    },
+    onError: (e) =>
+      toast(`${tr('生成失败：', 'Failed to generate: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
 
   // 正文 ![[fig:N]] 嵌入图（docs/api-lit.md §6.6）
   const figures = usePaperFigures(paper);
@@ -218,7 +248,7 @@ export function InfoPanel({
         defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)}
       />
 
-      {/* —— Wiki 正文（含 ![[fig:N]] 嵌入图） —— */}
+      {/* —— Wiki 正文（含 ![[fig:N]] 嵌入图）：库版 > 个人版 > 生成入口 —— */}
       <div style={{ marginTop: 18 }}>
         {paper.wiki_content ? (
           <>
@@ -238,13 +268,58 @@ export function InfoPanel({
               style={{ fontSize: 12.5 }}
             />
           </>
+        ) : personalWiki ? (
+          <>
+            <div
+              className="row gap8"
+              style={{ paddingBottom: 8, marginBottom: 12, borderBottom: '0.5px solid var(--border)' }}
+            >
+              <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+                {tr('AI 图文介绍', 'AI intro')}
+              </span>
+              <span
+                className="mono"
+                title={tr('公共库里没有这篇的解读，这是你自己生成的个人版。', 'No shared library wiki; this is the personal version you generated.')}
+                style={{
+                  fontSize: 10,
+                  color: 'var(--accent-text)',
+                  background: 'var(--accent-soft)',
+                  padding: '1px 7px',
+                  borderRadius: 999,
+                }}
+              >
+                {tr('个人版', 'Personal')}
+              </span>
+            </div>
+            <Markdown
+              source={personalWiki}
+              onWikiLink={onWikiLink}
+              renderFigure={renderFigure}
+              style={{ fontSize: 12.5 }}
+            />
+          </>
         ) : (
-          <EmptyState
-            compact
-            icon="pen"
-            title={tr('还没有 AI 精读页', 'No AI deep-read page yet')}
-            desc={tr('这篇论文还没被 AI 精读整理过（相关度不足，或还没运行初始建库 / 增量同步）。', 'This paper has not been deep-read by AI yet (relevance too low, or initial library build / incremental sync has not run).')}
-          />
+          <>
+            <EmptyState
+              compact
+              icon="pen"
+              title={tr('还没有 AI 精读页', 'No AI deep-read page yet')}
+              desc={tr('这篇论文还没被 AI 精读整理过（相关度不足，或还没运行初始建库 / 增量同步）。', 'This paper has not been deep-read by AI yet (relevance too low, or initial library build / incremental sync has not run).')}
+            />
+            <div className="col" style={{ alignItems: 'center', gap: 6, marginTop: 10 }}>
+              <button
+                className="btn btn-soft sm"
+                disabled={generateMutation.isPending || libStateQuery.isLoading || entryQuery.isLoading}
+                onClick={() => generateMutation.mutate()}
+              >
+                <Icon name="sparkle" size={12} />
+                {generateMutation.isPending ? tr('生成中…（约 1 分钟）', 'Generating… (~1 min)') : tr('生成 wiki', 'Generate wiki')}
+              </button>
+              <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                {tr('将使用你的模型额度，生成个人版解读。', 'Uses your model quota to generate a personal wiki.')}
+              </span>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -370,7 +370,7 @@ export function ReadingPage() {
           {panel === 'highlights' ? (
             <HighlightsPanel
               paperId={paper.id}
-              pid={paper.project_id}
+              pid={paper.project_id ?? ''}
               highlights={highlights}
               loading={highlightsQuery.isLoading}
               error={highlightsQuery.isError}
@@ -379,9 +379,9 @@ export function ReadingPage() {
               onChanged={invalidateHighlights}
             />
           ) : panel === 'notes' ? (
-            <NotesPanel paperId={paper.id} pid={paper.project_id} />
+            <NotesPanel paperId={paper.id} pid={paper.project_id ?? ''} />
           ) : panel === 'chat' ? (
-            <ChatPanel paperId={paper.id} pid={paper.project_id} />
+            <ChatPanel paperId={paper.id} pid={paper.project_id ?? ''} />
           ) : (
             <InfoPanel paper={paper} onWikiLink={onWikiLink} />
           )}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -67,6 +67,27 @@ function WikiBadge({ item }: { item: ShelfItemRead }) {
       </span>
     );
   }
+  if (item.wiki_source === 'personal') {
+    return (
+      <span
+        className="mono"
+        title={tr(
+          '这篇论文没有公共库版解读，下面显示的是你自己生成的个人版。',
+          'No shared library wiki for this paper; showing the personal version you generated.',
+        )}
+        style={{
+          fontSize: 10,
+          color: 'var(--accent-text)',
+          background: 'var(--accent-soft)',
+          padding: '1px 7px',
+          borderRadius: 999,
+          flexShrink: 0,
+        }}
+      >
+        {tr('个人版解读', 'Personal wiki')}
+      </span>
+    );
+  }
   if (item.wiki_source === 'snapshot') {
     return (
       <span
@@ -99,15 +120,25 @@ function WikiBadge({ item }: { item: ShelfItemRead }) {
 function ShelfCard({
   item,
   busy,
+  generating,
+  refreshing,
   onOpen,
   onSaveNote,
   onRemove,
+  onGenerateWiki,
+  onRefreshSnapshot,
 }: {
   item: ShelfItemRead;
   busy: boolean;
+  /** 本卡的个人版 wiki 正在生成 */
+  generating: boolean;
+  /** 本卡的快照正在刷新 */
+  refreshing: boolean;
   onOpen: () => void;
   onSaveNote: (note: string | null) => void;
   onRemove: () => void;
+  onGenerateWiki: () => void;
+  onRefreshSnapshot: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(item.note ?? '');
@@ -129,6 +160,32 @@ function ShelfCard({
           <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{item.year}</span>
         )}
         <WikiBadge item={item} />
+        {item.wiki_source === 'snapshot' && (
+          <button
+            className="icon-btn"
+            title={tr(
+              '刷新快照：重新拷一份当前可得的最新解读（库版优先，其次个人版）',
+              'Refresh snapshot: re-copy the latest available wiki (library first, then personal)',
+            )}
+            disabled={refreshing}
+            onClick={onRefreshSnapshot}
+            style={{ width: 22, height: 22 }}
+          >
+            <Icon name="refresh" size={12} />
+          </button>
+        )}
+        {item.wiki_source === 'none' && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('用 AI 生成这篇论文的个人版解读（将使用你的模型额度）', 'Generate a personal wiki with AI (uses your model quota)')}
+            disabled={generating}
+            onClick={onGenerateWiki}
+            style={{ height: 22, fontSize: 10.5, padding: '0 8px' }}
+          >
+            <Icon name="sparkle" size={11} />
+            {generating ? tr('生成中…', 'Generating…') : tr('生成 wiki', 'Generate wiki')}
+          </button>
+        )}
         <span style={{ marginLeft: 'auto' }} />
         <button
           className="icon-btn"
@@ -307,6 +364,25 @@ export function ResearchPage() {
       invalidate();
     },
     onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
+  });
+
+  // 个人版 wiki 按需生成（wiki_source=none 的论文；费用记个人额度）
+  const generateMutation = useMutation({
+    mutationFn: (paperId: string) => api.compilePersonalWiki(paperId, pid),
+    onSuccess: () => {
+      toast(tr('个人版解读已生成', 'Personal wiki generated'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('生成失败：', 'Failed to generate: ')}${errText(e)}`, 'error'),
+  });
+
+  const refreshSnapshotMutation = useMutation({
+    mutationFn: (paperId: string) => api.refreshShelfSnapshot(pid, paperId),
+    onSuccess: () => {
+      toast(tr('快照已刷新', 'Snapshot refreshed'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['shelf', pid] });
+    },
+    onError: (e) => toast(`${tr('刷新失败：', 'Failed to refresh: ')}${errText(e)}`, 'error'),
   });
 
   const submitImport = () => {
@@ -503,9 +579,15 @@ export function ResearchPage() {
               key={item.paper_id}
               item={item}
               busy={busy}
+              generating={generateMutation.isPending && generateMutation.variables === item.paper_id}
+              refreshing={
+                refreshSnapshotMutation.isPending && refreshSnapshotMutation.variables === item.paper_id
+              }
               onOpen={() => navigate(`/papers/${item.paper_id}/read`)}
               onSaveNote={(note) => noteMutation.mutate({ paperId: item.paper_id, note })}
               onRemove={() => removeMutation.mutate(item.paper_id)}
+              onGenerateWiki={() => generateMutation.mutate(item.paper_id)}
+              onRefreshSnapshot={() => refreshSnapshotMutation.mutate(item.paper_id)}
             />
           ))}
           {totalPages > 1 && (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -594,7 +594,8 @@ export interface PaperAuthor {
 
 export interface PaperRead {
   id: string;
-  project_id: string;
+  /** 本次访问解析出的课题上下文；书架/个人库可达的无库论文（个人补充）为 null */
+  project_id: string | null;
   title: string;
   authors: PaperAuthor[];
   /** 发表机构（OpenAlex 补充；可能为空） */

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -678,7 +678,6 @@ export type ReadingStatus = 'unread' | 'reading' | 'read';
 export interface NoteRead {
   id: string;
   paper_id: string;
-  project_id: string;
   author_id: string;
   /** display_name 回退 email 前缀 */
   author_name: string;
@@ -707,7 +706,6 @@ export interface HighlightRect {
 export interface HighlightRead {
   id: string;
   paper_id: string;
-  project_id: string;
   author_id: string;
   author_name: string;
   page: number; // 1-indexed
@@ -811,8 +809,8 @@ export interface SearchResult {
 // P5a · 课题「相关研究」书架 — /projects/{pid}/shelf
 // ============================================================
 
-/** 书架条目 wiki 来源：live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读。 */
-export type ShelfWikiSource = 'live' | 'snapshot' | 'none';
+/** 书架条目 wiki 来源：live=库版实时 | personal=本人个人编译版 | snapshot=只剩入架快照 | none=没有解读。 */
+export type ShelfWikiSource = 'live' | 'personal' | 'snapshot' | 'none';
 
 export interface ShelfItemRead {
   paper_id: string;
@@ -827,13 +825,20 @@ export interface ShelfItemRead {
   /** 课题语境的「为什么相关」备注 */
   note: string | null;
   wiki_source: ShelfWikiSource;
-  /** 解析后的 wiki：库版实时 > 快照；none 时为 null */
+  /** 解析后的 wiki：库版实时 > 个人版 > 快照；none 时为 null */
   wiki_content: string | null;
   /** 入架落快照的时间；没快照为 null */
   snapshot_at: string | null;
   /** 来源方向库（个人补充为 null） */
   source_library_id: string | null;
   added_at: string;
+}
+
+/** 个人版 wiki 按需编译结果（P5b）。 */
+export interface PersonalWikiRead {
+  paper_id: string;
+  wiki_content: string;
+  model: string | null;
 }
 
 /** 个人补充入库：arXiv 编号 / DOI / 标题至少给一个。 */
@@ -2623,6 +2628,18 @@ export const api = {
   /** 移出书架：只删书架行，个人库收藏不动。 */
   removeFromShelf(projectId: string, paperId: string): Promise<void> {
     return request<void>(`/projects/${projectId}/shelf/${paperId}`, { method: 'DELETE' });
+  },
+  /** 手动刷新书架快照：从当前最优 wiki（库版 > 个人版）重拷；无来源 409。 */
+  refreshShelfSnapshot(projectId: string, paperId: string): Promise<ShelfItemRead> {
+    return request<ShelfItemRead>(`/projects/${projectId}/shelf/${paperId}/refresh-snapshot`, {
+      method: 'POST',
+    });
+  },
+  /** 个人版 wiki 按需编译（无库版解读的论文；费用记个人额度）。 */
+  compilePersonalWiki(paperId: string, topicId?: string | null): Promise<PersonalWikiRead> {
+    return requestJson<PersonalWikiRead>(`/papers/${paperId}/personal-wiki`, 'POST', {
+      topic_id: topicId ?? null,
+    });
   },
 
   // —— M2 · Ingest ——


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P5b, full-stack.

## What changed

**Notes and highlights are now paper × author** (migration `1c6c4831d80f`). Your annotations follow you across every topic instead of living inside one; they survive a paper being removed from a library. Semantics change to be aware of: notes/highlights were previously visible to all project members — they are now visible only to their author (admin retains management access). Topic notebook, keyword search hits, Obsidian export, and agent tools all switch to the requester's-own scope.

**On-demand personal wiki.** `POST /papers/{id}/personal-wiki` compiles a generic-template wiki for any pool paper that has no library wiki (typical for personal imports), optionally biased by the topic statement; the result lives in the caller's personal library entry and the LLM spend is attributed to the caller. Wiki resolution everywhere is now the full three-tier priority: library live > personal compile > shelf snapshot, with source badges in the UI and a "uses your model quota" hint on the generate button.

**Shelf snapshot refresh.** `POST /projects/{pid}/shelf/{paper_id}/refresh-snapshot` re-copies the best currently available wiki; a refresh button appears on snapshot-state cards.

**Fix: pool papers without any library membership are readable.** Personal imports were 404 on the reading page; visibility now extends to any-library membership ∪ requester's shelves ∪ personal library, resolved by a single service helper.

## Tests

Full suite: 502 passed (baseline 499 + 3 new access tests), 16 pre-existing errors, 2 pre-existing env-coupled test_feedback failures — no new failures. New tests cover cross-topic note visibility, personal wiki compile attribution and preconditions, three-tier resolution, snapshot refresh, and pool-paper access. Migrations verified on sqlite round-trip and fresh postgres. Frontend tsc + build pass.