### PR TITLE
feat(libraries): lab-wide shared direction libraries (IA redesign P5c)

### DIFF
--- a/src/backend/alembic/versions/1c6c4831d80f_notes_highlights_per_user.py
+++ b/src/backend/alembic/versions/1c6c4831d80f_notes_highlights_per_user.py
@@ -1,0 +1,36 @@
+"""笔记 / 划线归属拆分（P5b）
+
+PaperNote / PaperHighlight 作用域从 project × paper 改为 paper × author：
+一个人在一篇论文上的划线与批注跨课题共享。删 project_id 列即可——
+原表按 project 隔离的行本就各归其作者，删列后天然合并，不丢行。
+
+Revision ID: 1c6c4831d80f
+Revises: 0775b55c26e4
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "1c6c4831d80f"
+down_revision: str | None = "0775b55c26e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    for table in ("paper_notes", "paper_highlights"):
+        with op.batch_alter_table(table) as batch:
+            batch.drop_index(f"ix_{table}_project_id")
+            batch.drop_column("project_id")
+
+
+def downgrade() -> None:
+    # 有损降级：project_id 数据已丢弃，只能补回可空列（原列 NOT NULL）
+    for table in ("paper_notes", "paper_highlights"):
+        with op.batch_alter_table(table) as batch:
+            batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+            batch.create_index(f"ix_{table}_project_id", ["project_id"])

--- a/src/backend/app/api/concepts.py
+++ b/src/backend/app/api/concepts.py
@@ -11,7 +11,6 @@ from app.core.db import get_session
 from app.core.llm.router import get_llm_router
 from app.models.library_direction import DirectionLibrary
 from app.models.paper import Concept
-from app.models.project import ProjectMember
 from app.models.user import User
 from app.schemas.paper import (
     ConceptDetail,
@@ -27,7 +26,9 @@ from app.services.libraries import get_library_for_project
 router = APIRouter(tags=["concepts"])
 
 
-def _concept_read(concept: Concept, paper_count: int, project_id: uuid.UUID) -> ConceptRead:
+def _concept_read(
+    concept: Concept, paper_count: int, project_id: uuid.UUID | None
+) -> ConceptRead:
     return ConceptRead(
         id=concept.id,
         project_id=project_id,
@@ -88,11 +89,11 @@ async def get_concept(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> ConceptDetail:
+    # P5c：方向库全实验室可读，概念详情不做课题成员校验（登录即可）
     stmt = (
         select(Concept, DirectionLibrary.project_id)
         .join(DirectionLibrary, DirectionLibrary.id == Concept.library_id)
-        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
-        .where(Concept.id == concept_id, ProjectMember.user_id == user.id)
+        .where(Concept.id == concept_id)
     )
     row = (await session.execute(stmt)).first()
     if row is None:

--- a/src/backend/app/api/highlights.py
+++ b/src/backend/app/api/highlights.py
@@ -1,6 +1,7 @@
 """PDF 划线标注路由：论文级 CRUD（阅读器用）。
 
-权限同论文笔记：项目成员可读，作者 / 平台 admin 可改删。
+归属与权限同论文笔记（P5b）：划线挂 paper × author 跨课题共享，
+列表只返回请求者本人的划线，非作者访问单条一律 404（平台 admin 例外）。
 """
 
 import uuid
@@ -24,7 +25,6 @@ def _hl_read(hl: PaperHighlight, author_name: str) -> HighlightRead:
     return HighlightRead(
         id=hl.id,
         paper_id=hl.paper_id,
-        project_id=hl.project_id,
         author_id=hl.author_id,
         author_name=author_name,
         page=hl.page,
@@ -41,16 +41,11 @@ def _hl_read(hl: PaperHighlight, author_name: str) -> HighlightRead:
 async def _get_modifiable_highlight(
     session: AsyncSession, highlight_id: uuid.UUID, user: User
 ) -> tuple[PaperHighlight, str]:
-    """取划线：非项目成员 404；非作者且非平台 admin 403。"""
-    row = await hl_service.get_highlight_for_member(
-        session, highlight_id=highlight_id, user_id=user.id
-    )
+    """取划线：非作者（且非平台 admin）视为不存在 → 404。"""
+    row = await hl_service.get_own_highlight(session, highlight_id=highlight_id, user=user)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="HIGHLIGHT_NOT_FOUND")
-    hl, author_name = row
-    if not hl_service.can_modify_highlight(hl, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="HIGHLIGHT_FORBIDDEN")
-    return hl, author_name
+    return row
 
 
 @router.get("/papers/{paper_id}/highlights", response_model=list[HighlightRead])
@@ -62,7 +57,7 @@ async def list_paper_highlights(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    rows = await hl_service.list_paper_highlights(session, paper_id=paper_id)
+    rows = await hl_service.list_paper_highlights(session, paper_id=paper_id, author_id=user.id)
     return [_hl_read(hl, author_name) for hl, author_name in rows]
 
 
@@ -80,9 +75,7 @@ async def create_paper_highlight(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    hl = await hl_service.create_highlight(
-        session, paper_id=paper.id, project_id=paper.project_id, author=user, data=data
-    )
+    hl = await hl_service.create_highlight(session, paper_id=paper.id, author=user, data=data)
     return _hl_read(hl, author_name_of(user.display_name, user.email))
 
 

--- a/src/backend/app/api/highlights.py
+++ b/src/backend/app/api/highlights.py
@@ -54,7 +54,9 @@ async def list_paper_highlights(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[HighlightRead]:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     rows = await hl_service.list_paper_highlights(session, paper_id=paper_id, author_id=user.id)
@@ -72,7 +74,9 @@ async def create_paper_highlight(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> HighlightRead:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     hl = await hl_service.create_highlight(session, paper_id=paper.id, author=user, data=data)

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -1,0 +1,193 @@
+"""共享方向库只读路由（P5c，docs-dev/workspace-ia-redesign.md §2/§6/§7）。
+
+方向库对全实验室可读：本文件的端点只做登录校验、不做课题成员校验。
+写/管理入口（ingest、论文管理、概念补建等）仍走 project 作用域端点并校验成员。
+个人文献库路由在 ``app/api/library.py``（/me/library），勿混淆。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.core.llm.router import get_llm_router
+from app.models.library_direction import DirectionLibrary
+from app.models.user import User
+from app.schemas.libraries import DirectionLibraryDetail, DirectionLibrarySummary
+from app.schemas.paper import (
+    ConceptRead,
+    PaperListPage,
+    PaperRead,
+    ScoredConcept,
+    ScoredPaper,
+    SearchResponse,
+)
+from app.services import concepts as concepts_service
+from app.services import libraries as libraries_service
+from app.services import papers as papers_service
+
+router = APIRouter(tags=["libraries"])
+
+
+async def _get_library(session: AsyncSession, library_id: uuid.UUID) -> DirectionLibrary:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    return library
+
+
+async def _reads_with_extras(
+    session: AsyncSession, papers: list, user_id: uuid.UUID
+) -> list[PaperRead]:
+    """ORM → schema，回填 tags/starred/reading_status/note_count（个人维度，全员可用）。"""
+    extras = await papers_service.paper_extras_map(
+        session, paper_ids=[p.id for p in papers], user_id=user_id
+    )
+    return [PaperRead.model_validate(p).model_copy(update=extras[p.id]) for p in papers]
+
+
+@router.get("/libraries", response_model=list[DirectionLibrarySummary])
+async def list_libraries(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DirectionLibrarySummary]:
+    rows = await libraries_service.list_libraries_overview(session, user_id=user.id)
+    return [DirectionLibrarySummary(**row) for row in rows]
+
+
+@router.get("/libraries/{library_id}", response_model=DirectionLibraryDetail)
+async def get_library(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DirectionLibraryDetail:
+    library = await _get_library(session, library_id)
+    row = await libraries_service.library_overview(session, library=library, user_id=user.id)
+    return DirectionLibraryDetail(**row)
+
+
+@router.get("/libraries/{library_id}/papers", response_model=PaperListPage)
+async def list_library_papers(
+    library_id: uuid.UUID,
+    status_filter: str | None = Query(default="library", alias="status"),
+    q: str | None = Query(default=None),
+    sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperListPage:
+    """库内论文（分页/检索/排序）。缺省只列相关性达标的（status=library 组别名）。"""
+    library = await _get_library(session, library_id)
+    items, total = await papers_service.list_papers(
+        session,
+        library_id=library.id,
+        project_id=library.project_id,
+        status=status_filter,
+        q=q,
+        user_id=user.id,
+        sort=sort,
+        page=page,
+        size=size,
+    )
+    return PaperListPage(
+        items=await _reads_with_extras(session, list(items), user.id),
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/libraries/{library_id}/concepts", response_model=list[ConceptRead])
+async def list_library_concepts(
+    library_id: uuid.UUID,
+    category: str | None = Query(default=None),
+    q: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[ConceptRead]:
+    library = await _get_library(session, library_id)
+    rows = await concepts_service.list_concepts(
+        session, library_id=library.id, category=category, q=q
+    )
+    return [
+        ConceptRead(
+            id=concept.id,
+            project_id=library.project_id,
+            name=concept.name,
+            category=concept.category,
+            definition=concept.definition,
+            paper_count=count,
+        )
+        for concept, count in rows
+    ]
+
+
+@router.get("/libraries/{library_id}/search", response_model=SearchResponse)
+async def search_library(
+    library_id: uuid.UUID,
+    q: str = Query(min_length=1),
+    mode: str = Query(default="keyword", pattern="^(keyword|semantic)$"),
+    limit: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchResponse:
+    """库内检索（关键词/语义）。语义模式的 embed/rerank 记个人账（无课题上下文）。"""
+    library = await _get_library(session, library_id)
+
+    mode_used = "keyword"
+    reranked = False
+    paper_rows: list = []
+    if mode == "semantic" and papers_service.semantic_search_supported(session):
+        try:
+            vectors = await get_llm_router().embed([q], user_id=user.id)
+            candidates = await papers_service.semantic_search_papers(
+                session,
+                library_id=library.id,
+                project_id=library.project_id,
+                query_vector=vectors[0],
+                limit=max(papers_service.RERANK_CANDIDATES, limit),
+            )
+            mode_used = "semantic"
+            paper_rows, reranked = await papers_service.rerank_paper_rows(
+                get_llm_router(), query=q, rows=candidates, limit=limit, user_id=user.id
+            )
+        except NotImplementedError:
+            mode_used = "keyword"  # embedding 路由的 provider 不支持 → 回退
+    if mode_used == "keyword":
+        paper_rows = await papers_service.keyword_search_papers(
+            session,
+            library_id=library.id,
+            project_id=library.project_id,
+            q=q,
+            limit=limit,
+            user_id=user.id,
+        )
+    concept_rows = await papers_service.keyword_search_concepts(
+        session, library_id=library.id, q=q, limit=limit
+    )
+
+    concepts = []
+    for concept, score in concept_rows:
+        count = await concepts_service.paper_count_of(session, concept.id)
+        concepts.append(
+            ScoredConcept(
+                id=concept.id,
+                project_id=library.project_id,
+                name=concept.name,
+                category=concept.category,
+                definition=concept.definition,
+                paper_count=count,
+                score=score,
+            )
+        )
+    extras = await papers_service.paper_extras_map(
+        session, paper_ids=[p.id for p, _ in paper_rows], user_id=user.id
+    )
+    papers = [
+        ScoredPaper(**(PaperRead.model_validate(p).model_dump() | extras[p.id]), score=s)
+        for p, s in paper_rows
+    ]
+    return SearchResponse(papers=papers, concepts=concepts, mode_used=mode_used, reranked=reranked)

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -26,7 +26,9 @@ router = APIRouter(tags=["library"])
 
 async def _get_member_paper(session: AsyncSession, paper_id: uuid.UUID, user: User) -> Paper:
     """校验论文可见性（所在方向的成员），防止越权拷快照。"""
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     return paper

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -1,4 +1,8 @@
-"""论文笔记路由（docs/api-lit.md §2）：论文级 CRUD + 项目笔记本聚合。"""
+"""论文笔记路由（docs/api-lit.md §2）：论文级 CRUD + 课题笔记本聚合。
+
+P5b 起笔记挂 paper × author（跨课题共享）：列表只返回请求者本人的笔记，
+非作者访问单条一律 404（平台 admin 例外，可管理他人笔记）。
+"""
 
 import uuid
 
@@ -21,7 +25,6 @@ def _note_read(note: PaperNote, author_name: str) -> NoteRead:
     return NoteRead(
         id=note.id,
         paper_id=note.paper_id,
-        project_id=note.project_id,
         author_id=note.author_id,
         author_name=author_name,
         content=note.content,
@@ -33,14 +36,11 @@ def _note_read(note: PaperNote, author_name: str) -> NoteRead:
 async def _get_modifiable_note(
     session: AsyncSession, note_id: uuid.UUID, user: User
 ) -> tuple[PaperNote, str]:
-    """取笔记：非项目成员 404；非作者且非平台 admin 403。"""
-    row = await notes_service.get_note_for_member(session, note_id=note_id, user_id=user.id)
+    """取笔记：非作者（且非平台 admin）视为不存在 → 404。"""
+    row = await notes_service.get_own_note(session, note_id=note_id, user=user)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="NOTE_NOT_FOUND")
-    note, author_name = row
-    if not notes_service.can_modify_note(note, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="NOTE_FORBIDDEN")
-    return note, author_name
+    return row
 
 
 @router.get("/papers/{paper_id}/notes", response_model=list[NoteRead])
@@ -52,7 +52,7 @@ async def list_paper_notes(
     paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
-    rows = await notes_service.list_paper_notes(session, paper_id=paper_id)
+    rows = await notes_service.list_paper_notes(session, paper_id=paper_id, author_id=user.id)
     return [_note_read(note, author_name) for note, author_name in rows]
 
 
@@ -69,11 +69,7 @@ async def create_paper_note(
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     note = await notes_service.create_note(
-        session,
-        paper_id=paper.id,
-        project_id=paper.project_id,
-        author=user,
-        content=data.content,
+        session, paper_id=paper.id, author=user, content=data.content
     )
     return _note_read(note, notes_service.author_name_of(user.display_name, user.email))
 
@@ -110,12 +106,18 @@ async def project_notebook(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> NotebookPage:
-    """项目笔记本：全部论文笔记的聚合视图（搜索 + 分页 + 按论文过滤）。"""
+    """课题笔记本：我的论文笔记在本课题范围内的聚合视图（搜索 + 分页 + 按论文过滤）。"""
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows, total = await notes_service.list_project_notes(
-        session, project_id=project_id, q=q, paper_id=paper_id, page=page, size=size
+        session,
+        project_id=project_id,
+        author_id=user.id,
+        q=q,
+        paper_id=paper_id,
+        page=page,
+        size=size,
     )
     items = [
         NoteWithPaper(**_note_read(note, author_name).model_dump(), paper_title=paper_title)

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -49,7 +49,9 @@ async def list_paper_notes(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[NoteRead]:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     rows = await notes_service.list_paper_notes(session, paper_id=paper_id, author_id=user.id)
@@ -65,7 +67,9 @@ async def create_paper_note(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> NoteRead:
-    paper = await papers_service.get_paper_for_user(session, paper_id=paper_id, user_id=user.id)
+    paper = await papers_service.get_paper_for_user(
+        session, paper_id=paper_id, user_id=user.id, include_pool=True
+    )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
     note = await notes_service.create_note(

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -18,6 +18,7 @@ from app.api.auth import current_active_user, require_llm_chat, require_llm_task
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
+from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.paper import (
     PaperBatchIds,
@@ -32,6 +33,8 @@ from app.schemas.paper import (
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
+    PersonalWikiRead,
+    PersonalWikiRequest,
     TagRead,
 )
 from app.services import figure_annotate as figure_service
@@ -39,6 +42,7 @@ from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
+from app.services import personal_wiki as personal_wiki_service
 from app.services import projects as projects_service
 from app.services import relevance as relevance_service
 from app.services import wiki_compile as wiki_compile_service
@@ -370,6 +374,51 @@ async def recompile_paper(
         logger.warning("recompile failed for paper %s", paper_id, exc_info=True)
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
     return await _paper_detail(session, paper, user.id)
+
+
+# ---- 个人版 wiki 按需编译（P5b，docs-dev/workspace-ia-redesign.md §3.3/§4） ----
+
+
+@router.post("/papers/{paper_id}/personal-wiki", response_model=PersonalWikiRead)
+async def compile_personal_wiki(
+    paper_id: uuid.UUID,
+    data: PersonalWikiRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+) -> PersonalWikiRead:
+    """给没有库版 wiki 的池内论文（典型：个人补充入库）编译个人版 wiki。
+
+    通用模板（无 rubric），可选 topic_id 把课题 statement 当侧重提示；
+    结果写进本人个人库条目（user_library_entries.wiki_content），费用归个人。
+    已有库版 wiki → 409 LIBRARY_WIKI_EXISTS；同一 paper × user 编译进行中 →
+    409 COMPILE_IN_PROGRESS。内容池全平台可读，故不要求论文在本人方向库内。
+    """
+    paper = await session.get(Paper, paper_id)
+    if paper is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    if data.topic_id is not None:
+        # 课题归因/侧重提示：必须是自己所在课题
+        await _get_member_project(session, data.topic_id, user)
+    try:
+        compiled = await personal_wiki_service.compile_personal_wiki(
+            session, paper=paper, user_id=user.id, topic_id=data.topic_id
+        )
+    except personal_wiki_service.LibraryWikiExistsError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="LIBRARY_WIKI_EXISTS"
+        ) from None
+    except personal_wiki_service.CompileInProgressError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="COMPILE_IN_PROGRESS"
+        ) from None
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001 — LLM 空响应/调用失败等 → 502
+        logger.warning("personal wiki compile failed for paper %s", paper_id, exc_info=True)
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
+    return PersonalWikiRead(
+        paper_id=paper_id, wiki_content=compiled.content, model=compiled.model or None
+    )
 
 
 # ---- AI 伴读（docs/api-lit.md §3，SSE 流） ----

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -85,10 +85,21 @@ async def _get_member_project(session: AsyncSession, project_id: uuid.UUID, user
 
 
 async def _get_member_paper(
-    session: AsyncSession, paper_id: uuid.UUID, user: User, *, with_concepts: bool = False
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    user: User,
+    *,
+    with_concepts: bool = False,
+    include_pool: bool = False,
 ) -> papers_service.PaperView:
+    """include_pool 只给读路径开：书架/个人库可达的无库论文可读（P5b），
+    写成员行的端点（状态/删除/召回/重编译/标签）维持库可见性。"""
     paper = await papers_service.get_paper_for_user(
-        session, paper_id=paper_id, user_id=user.id, with_concepts=with_concepts
+        session,
+        paper_id=paper_id,
+        user_id=user.id,
+        with_concepts=with_concepts,
+        include_pool=include_pool,
     )
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
@@ -195,7 +206,7 @@ async def get_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
-    paper = await _get_member_paper(session, paper_id, user, with_concepts=True)
+    paper = await _get_member_paper(session, paper_id, user, with_concepts=True, include_pool=True)
     return await _paper_detail(session, paper, user.id)
 
 
@@ -275,7 +286,7 @@ async def get_paper_pdf(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> FileResponse:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     if not paper.pdf_path or not Path(paper.pdf_path).exists():
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PDF_NOT_AVAILABLE")
     return FileResponse(
@@ -293,7 +304,7 @@ async def fetch_paper_pdf(
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
     """按需补下 PDF + 抽全文；已有 PDF 时幂等直接返回。"""
-    view = await _get_member_paper(session, paper_id, user, with_concepts=True)
+    view = await _get_member_paper(session, paper_id, user, with_concepts=True, include_pool=True)
     try:
         await papers_service.fetch_pdf(
             session, view.paper, user_id=user.id, project_id=view.project_id
@@ -314,7 +325,7 @@ async def list_paper_figures(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[PaperFigure]:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     return [PaperFigure(**f) for f in (paper.figures or [])]
 
 
@@ -325,7 +336,7 @@ async def get_paper_figure_image(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> FileResponse:
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     known = {int(f["index"]) for f in (paper.figures or [])}
     path = figure_path(str(paper_id), index)
     if index not in known or not path.exists():
@@ -343,7 +354,7 @@ async def extract_paper_figures(
     user: User = Depends(current_active_user),
 ) -> PaperFiguresResponse:
     """提取嵌入图 + LLM 筛选注释；已有 figures 且非 force 时幂等直返。"""
-    view = await _get_member_paper(session, paper_id, user)
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
     paper = view.paper
     if paper.figures is not None and not force:
         return PaperFiguresResponse(figures=[PaperFigure(**f) for f in paper.figures])
@@ -436,15 +447,16 @@ async def chat_with_paper(
     user: User = Depends(require_llm_chat),
 ) -> StreamingResponse:
     """AI 伴读：stage=reading 流式回答；事件 delta/done/error + 15s 心跳注释。"""
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     project_id = paper.project_id
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
     llm = get_llm_router()
 
-    # 用户选中的其他文献：检索相关片段作为对比/参考上下文（跨项目引用被过滤）
+    # 用户选中的其他文献：检索相关片段作为对比/参考上下文（跨项目引用被过滤）；
+    # 池级可达的无库论文没有课题上下文（project_id 为空）→ 跳过参考文献检索
     references, sources = "", []
-    if data.context_paper_ids:
+    if data.context_paper_ids and project_id is not None:
         references, sources = await library_chat_service.build_reference_context(
             session,
             project_id=project_id,
@@ -550,7 +562,7 @@ async def set_paper_my_meta(
     user: User = Depends(current_active_user),
 ) -> PaperMyMetaRead:
     """个人星标 / 阅读状态 upsert。"""
-    paper = await _get_member_paper(session, paper_id, user)
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
     meta = await papers_service.upsert_paper_user_meta(
         session,
         paper=paper,

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -16,6 +16,7 @@ from app.api import (
     ideas,
     ingest,
     invites,
+    libraries,
     library,
     manuscripts,
     market,
@@ -50,6 +51,7 @@ api_router.include_router(admin_llm.router)
 api_router.include_router(me_llm.router)
 api_router.include_router(papers.router)
 api_router.include_router(library.router)
+api_router.include_router(libraries.router)
 api_router.include_router(publications.router)
 api_router.include_router(notes.router)
 api_router.include_router(highlights.router)

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -44,7 +44,7 @@ async def list_shelf(
 ) -> ShelfPage:
     await _require_member(session, project_id, user)
     items, total = await shelf_service.list_shelf(
-        session, project_id=project_id, page=page, size=size
+        session, project_id=project_id, user_id=user.id, page=page, size=size
     )
     return ShelfPage(
         items=[ShelfItemRead.model_validate(i) for i in items],
@@ -131,10 +131,32 @@ async def update_shelf_note(
     await _require_member(session, project_id, user)
     try:
         item = await shelf_service.update_note(
-            session, project_id=project_id, paper_id=paper_id, note=body.note
+            session, project_id=project_id, paper_id=paper_id, user_id=user.id, note=body.note
         )
     except shelf_service.ShelfItemNotFoundError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    return ShelfItemRead.model_validate(item)
+
+
+@router.post(
+    "/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", response_model=ShelfItemRead
+)
+async def refresh_shelf_snapshot(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    """手动刷新快照：从当前可得的最优 wiki（库版 > 个人版）重拷；无来源 409。"""
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.refresh_snapshot(
+            session, project_id=project_id, paper_id=paper_id, user_id=user.id
+        )
+    except shelf_service.ShelfItemNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    except shelf_service.NoWikiSourceError:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="NO_WIKI_SOURCE") from None
     return ShelfItemRead.model_validate(item)
 
 

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -94,7 +94,7 @@ async def search(
             mode_used = "keyword"  # embedding 路由的 provider 不支持 → 回退
     if mode_used == "keyword":
         paper_rows = await papers_service.keyword_search_papers(
-            session, project_id=project_id, q=q, limit=limit
+            session, project_id=project_id, q=q, limit=limit, user_id=user.id
         )
     concept_rows = await papers_service.keyword_search_concepts(
         session, project_id=project_id, q=q, limit=limit
@@ -131,7 +131,7 @@ async def export_obsidian(
     user: User = Depends(current_active_user),
 ) -> Response:
     project = await _member_project(session, project_id, user)
-    content = await build_obsidian_zip(session, project)
+    content = await build_obsidian_zip(session, project, user_id=user.id)
     filename = f"{project.slug}-wiki.zip"
     return Response(
         content=content,

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -105,15 +105,12 @@ paper_tag_links = Table(
 
 
 class PaperNote(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """论文笔记：项目成员可读，作者（或平台 admin）可改删。"""
+    """论文笔记（paper × author）：跨课题共享，仅作者本人（或平台 admin）可见可改删。"""
 
     __tablename__ = "paper_notes"
 
     paper_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     author_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
@@ -132,16 +129,13 @@ class PaperHighlight(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     定位策略「文本锚点为主 + 归一化坐标加速」：selected_text 存选中的原文
     （PDF 换版重抽也能靠文本回锚），rects 存归一化到页面 0..1 的矩形列表
     （每行一个，渲染时按当前页宽高还原色块，缩放无关）。
-    权限同 PaperNote：项目成员可读，作者（或平台 admin）可改删。
+    归属同 PaperNote（paper × author）：跨课题共享，仅作者本人（或平台 admin）可见可改删。
     """
 
     __tablename__ = "paper_highlights"
 
     paper_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     author_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False

--- a/src/backend/app/schemas/highlight.py
+++ b/src/backend/app/schemas/highlight.py
@@ -69,7 +69,6 @@ class HighlightUpdate(BaseModel):
 class HighlightRead(BaseModel):
     id: uuid.UUID
     paper_id: uuid.UUID
-    project_id: uuid.UUID
     author_id: uuid.UUID
     author_name: str  # display_name 回退 email @ 前部分
     page: int

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -1,0 +1,32 @@
+"""共享方向库 schema（P5c，docs-dev/workspace-ia-redesign.md §2/§6/§7）。
+
+个人文献库（/me/library）的 schema 在 ``app/schemas/library.py``，勿混淆。
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DirectionLibrarySummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    statement: str | None
+    # 过渡期隐式库回指的课题；未来共享库可为 None
+    project_id: uuid.UUID | None
+    # 是否「我的课题的库」（请求者是背后课题的成员 → 前端显示管理入口）
+    is_mine: bool
+    paper_count: int
+    concept_count: int
+    last_compiled_at: datetime | None
+    # 上次同步时间（ingest 最近一次跑完的时间，退回同步进度水位）
+    last_synced_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DirectionLibraryDetail(DirectionLibrarySummary):
+    cadence: str | None

--- a/src/backend/app/schemas/note.py
+++ b/src/backend/app/schemas/note.py
@@ -17,7 +17,6 @@ class NoteUpdate(BaseModel):
 class NoteRead(BaseModel):
     id: uuid.UUID
     paper_id: uuid.UUID
-    project_id: uuid.UUID
     author_id: uuid.UUID
     author_name: str  # display_name 回退 email @ 前部分
     content: str

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -181,7 +181,8 @@ class ConceptRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    project_id: uuid.UUID
+    # 概念所属库回指的课题；共享库（无课题回指）为 None
+    project_id: uuid.UUID | None
     name: str
     category: str | None
     definition: str | None

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -235,3 +235,15 @@ class SearchResponse(BaseModel):
     concepts: list[ScoredConcept]
     mode_used: Literal["keyword", "semantic"]
     reranked: bool = False  # semantic 模式下 rerank 是否成功（失败降级为纯向量分）
+
+
+class PersonalWikiRequest(BaseModel):
+    """个人版 wiki 按需编译（P5b）：可选带课题，statement 作为侧重提示 + 用量归因。"""
+
+    topic_id: uuid.UUID | None = None
+
+
+class PersonalWikiRead(BaseModel):
+    paper_id: uuid.UUID
+    wiki_content: str
+    model: str | None = None

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -28,7 +28,8 @@ class PaperRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    project_id: uuid.UUID
+    # 本次访问解析出的课题上下文；池级可达（书架/个人库）的无库论文可为 null
+    project_id: uuid.UUID | None
     title: str
     authors: list[AuthorRead] = []
     affiliations: list[str] = []  # 发表机构（LLM 从全文解析，OpenAlex 兜底；可能为空）

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ShelfItemRead(BaseModel):
-    """书架条目：论文元数据 + 备注 + 解析后的 wiki（库版实时 > 快照）。"""
+    """书架条目：论文元数据 + 备注 + 解析后的 wiki（库版实时 > 个人版 > 快照）。"""
 
     paper_id: uuid.UUID
     title: str
@@ -20,8 +20,8 @@ class ShelfItemRead(BaseModel):
     url: str | None
     tldr: str | None
     note: str | None
-    # live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读
-    wiki_source: Literal["live", "snapshot", "none"]
+    # live=库版实时可得 | personal=本人个人编译版 | snapshot=只剩入架快照 | none=没有解读
+    wiki_source: Literal["live", "personal", "snapshot", "none"]
     wiki_content: str | None
     snapshot_at: datetime | None
     source_library_id: uuid.UUID | None

--- a/src/backend/app/services/highlights.py
+++ b/src/backend/app/services/highlights.py
@@ -1,8 +1,8 @@
 """PDF 划线标注业务逻辑（不 import fastapi）。
 
-权限约定同论文笔记（services/notes.py）：
-- 读 = 项目成员（非成员视为不存在）；
-- 改 / 删 = 标注作者或平台 admin。
+归属与权限同论文笔记（services/notes.py，P5b 拆分）：
+- 划线挂 paper × author，跨课题共享；
+- 读 / 改 / 删都只限作者本人（平台 admin 可改删他人标注，管理兜底）。
 """
 
 import uuid
@@ -13,7 +13,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.paper import PaperHighlight
-from app.models.project import ProjectMember
 from app.models.user import User
 from app.schemas.highlight import HighlightCreate
 from app.services.notes import author_name_of
@@ -23,13 +22,11 @@ async def create_highlight(
     session: AsyncSession,
     *,
     paper_id: uuid.UUID,
-    project_id: uuid.UUID,
     author: User,
     data: HighlightCreate,
 ) -> PaperHighlight:
     hl = PaperHighlight(
         paper_id=paper_id,
-        project_id=project_id,
         author_id=author.id,
         page=data.page,
         rects=[r.model_dump() for r in data.rects],
@@ -45,39 +42,35 @@ async def create_highlight(
 
 
 async def list_paper_highlights(
-    session: AsyncSession, *, paper_id: uuid.UUID
+    session: AsyncSession, *, paper_id: uuid.UUID, author_id: uuid.UUID
 ) -> Sequence[tuple[PaperHighlight, str]]:
-    """某论文的划线（按页码、再按创建时间排序），附作者展示名。"""
+    """某论文下「我的」划线（按页码、再按创建时间排序），附作者展示名。"""
     stmt = (
         select(PaperHighlight, User.display_name, User.email)
         .join(User, User.id == PaperHighlight.author_id)
-        .where(PaperHighlight.paper_id == paper_id)
+        .where(PaperHighlight.paper_id == paper_id, PaperHighlight.author_id == author_id)
         .order_by(PaperHighlight.page.asc(), PaperHighlight.created_at.asc())
     )
     rows = (await session.execute(stmt)).all()
     return [(hl, author_name_of(display_name, email)) for hl, display_name, email in rows]
 
 
-async def get_highlight_for_member(
-    session: AsyncSession, *, highlight_id: uuid.UUID, user_id: uuid.UUID
+async def get_own_highlight(
+    session: AsyncSession, *, highlight_id: uuid.UUID, user: User
 ) -> tuple[PaperHighlight, str] | None:
-    """取划线（附作者展示名）；非项目成员视为不存在。"""
+    """取划线（附作者展示名）；非作者（且非平台 admin）视为不存在。"""
     stmt = (
         select(PaperHighlight, User.display_name, User.email)
         .join(User, User.id == PaperHighlight.author_id)
-        .join(ProjectMember, ProjectMember.project_id == PaperHighlight.project_id)
-        .where(PaperHighlight.id == highlight_id, ProjectMember.user_id == user_id)
+        .where(PaperHighlight.id == highlight_id)
     )
+    if user.role != "admin":
+        stmt = stmt.where(PaperHighlight.author_id == user.id)
     row = (await session.execute(stmt)).first()
     if row is None:
         return None
     hl, display_name, email = row
     return hl, author_name_of(display_name, email)
-
-
-def can_modify_highlight(hl: PaperHighlight, user: User) -> bool:
-    """改 / 删权限：标注作者或平台 admin。"""
-    return hl.author_id == user.id or user.role == "admin"
 
 
 async def update_highlight(

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -12,7 +12,7 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.library_direction import DirectionLibrary, LibraryPaper
-from app.models.paper import Paper
+from app.models.paper import Concept, Paper
 from app.models.project import Project, ProjectMember
 
 
@@ -126,4 +126,125 @@ def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
         .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
         .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
         .where(ProjectMember.user_id == user_id)
+    )
+
+
+# ---- 共享方向库读视图（P5c：全实验室可读，docs-dev/workspace-ia-redesign.md §2/§5） ----
+
+
+def _last_synced_of(ingest_state: Any) -> Any:
+    """从 ingest_state 提取「上次同步时间」：优先 last_run.finished_at，退回 watermark。"""
+    if not isinstance(ingest_state, dict):
+        return None
+    last_run = ingest_state.get("last_run")
+    if isinstance(last_run, dict) and last_run.get("finished_at"):
+        return last_run["finished_at"]
+    return ingest_state.get("watermark")
+
+
+async def get_library(session: AsyncSession, library_id: uuid.UUID) -> DirectionLibrary | None:
+    return await session.get(DirectionLibrary, library_id)
+
+
+async def _library_stats(
+    session: AsyncSession, library_ids: list[uuid.UUID]
+) -> tuple[dict[uuid.UUID, int], dict[uuid.UUID, Any], dict[uuid.UUID, int]]:
+    """批量聚合库统计：(库内论文数, 最近编译时间, 概念数)。
+
+    论文数口径 = 相关性达标及之后（与论文列表的 library 组别名一致）。
+    """
+    from app.services.papers import PAPER_STATUS_GROUPS  # 延迟导入避免循环依赖
+
+    if not library_ids:
+        return {}, {}, {}
+    paper_rows = await session.execute(
+        select(LibraryPaper.library_id, func.count(), func.max(LibraryPaper.compiled_at))
+        .where(
+            LibraryPaper.library_id.in_(library_ids),
+            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+        )
+        .group_by(LibraryPaper.library_id)
+    )
+    paper_counts: dict[uuid.UUID, int] = {}
+    last_compiled: dict[uuid.UUID, Any] = {}
+    for lib_id, count, compiled_at in paper_rows.all():
+        paper_counts[lib_id] = int(count)
+        last_compiled[lib_id] = compiled_at
+    concept_rows = await session.execute(
+        select(Concept.library_id, func.count())
+        .where(Concept.library_id.in_(library_ids))
+        .group_by(Concept.library_id)
+    )
+    concept_counts = {lib_id: int(count) for lib_id, count in concept_rows.all()}
+    return paper_counts, last_compiled, concept_counts
+
+
+async def _my_project_ids(session: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    rows = await session.execute(
+        select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+    )
+    return set(rows.scalars().all())
+
+
+def _overview_dict(
+    library: DirectionLibrary,
+    *,
+    my_projects: set[uuid.UUID],
+    paper_count: int,
+    concept_count: int,
+    last_compiled_at: Any,
+) -> dict[str, Any]:
+    return {
+        "id": library.id,
+        "name": library.name,
+        "statement": library.statement,
+        "cadence": library.cadence,
+        "project_id": library.project_id,
+        "is_mine": library.project_id is not None and library.project_id in my_projects,
+        "paper_count": paper_count,
+        "concept_count": concept_count,
+        "last_compiled_at": last_compiled_at,
+        "last_synced_at": _last_synced_of(library.ingest_state),
+        "created_at": library.created_at,
+        "updated_at": library.updated_at,
+    }
+
+
+async def list_libraries_overview(
+    session: AsyncSession, *, user_id: uuid.UUID
+) -> list[dict[str, Any]]:
+    """全部方向库 + 概要统计（读操作对所有登录用户开放，不做成员校验）。"""
+    libraries = (
+        (await session.execute(select(DirectionLibrary).order_by(DirectionLibrary.created_at)))
+        .scalars()
+        .all()
+    )
+    paper_counts, last_compiled, concept_counts = await _library_stats(
+        session, [lib.id for lib in libraries]
+    )
+    my_projects = await _my_project_ids(session, user_id)
+    return [
+        _overview_dict(
+            lib,
+            my_projects=my_projects,
+            paper_count=paper_counts.get(lib.id, 0),
+            concept_count=concept_counts.get(lib.id, 0),
+            last_compiled_at=last_compiled.get(lib.id),
+        )
+        for lib in libraries
+    ]
+
+
+async def library_overview(
+    session: AsyncSession, *, library: DirectionLibrary, user_id: uuid.UUID
+) -> dict[str, Any]:
+    """单库详情概要（同列表口径）。"""
+    paper_counts, last_compiled, concept_counts = await _library_stats(session, [library.id])
+    my_projects = await _my_project_ids(session, user_id)
+    return _overview_dict(
+        library,
+        my_projects=my_projects,
+        paper_count=paper_counts.get(library.id, 0),
+        concept_count=concept_counts.get(library.id, 0),
+        last_compiled_at=last_compiled.get(library.id),
     )

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -1,19 +1,21 @@
 """论文笔记业务逻辑（不 import fastapi）。
 
-权限约定（docs/api-lit.md §2）：
-- 读笔记 = 项目成员（非成员视为不存在）；
-- 改 / 删 = 笔记作者或平台 admin。
+归属与权限（P5b 拆分，docs-dev/workspace-ia-redesign.md §3.3）：
+- 笔记挂 paper × author，跨课题共享（同一篇论文的笔记在所有课题可见）；
+- 读 / 改 / 删都只限作者本人（平台 admin 可改删他人笔记，管理兜底）。
 """
 
 import uuid
 from collections.abc import Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperNote
-from app.models.project import ProjectMember
+from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.services.libraries import get_library_for_project
 
 
 def author_name_of(display_name: str | None, email: str) -> str:
@@ -22,11 +24,9 @@ def author_name_of(display_name: str | None, email: str) -> str:
 
 
 async def create_note(
-    session: AsyncSession, *, paper_id: uuid.UUID, project_id: uuid.UUID, author: User, content: str
+    session: AsyncSession, *, paper_id: uuid.UUID, author: User, content: str
 ) -> PaperNote:
-    note = PaperNote(
-        paper_id=paper_id, project_id=project_id, author_id=author.id, content=content
-    )
+    note = PaperNote(paper_id=paper_id, author_id=author.id, content=content)
     session.add(note)
     await session.commit()
     await session.refresh(note)
@@ -34,39 +34,35 @@ async def create_note(
 
 
 async def list_paper_notes(
-    session: AsyncSession, *, paper_id: uuid.UUID
+    session: AsyncSession, *, paper_id: uuid.UUID, author_id: uuid.UUID
 ) -> Sequence[tuple[PaperNote, str]]:
-    """某论文的笔记（created_at 倒序），附作者展示名。"""
+    """某论文下「我的」笔记（created_at 倒序），附作者展示名。"""
     stmt = (
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .where(PaperNote.paper_id == paper_id)
+        .where(PaperNote.paper_id == paper_id, PaperNote.author_id == author_id)
         .order_by(PaperNote.created_at.desc())
     )
     rows = (await session.execute(stmt)).all()
     return [(note, author_name_of(display_name, email)) for note, display_name, email in rows]
 
 
-async def get_note_for_member(
-    session: AsyncSession, *, note_id: uuid.UUID, user_id: uuid.UUID
+async def get_own_note(
+    session: AsyncSession, *, note_id: uuid.UUID, user: User
 ) -> tuple[PaperNote, str] | None:
-    """取笔记（附作者展示名）；非项目成员视为不存在。"""
+    """取笔记（附作者展示名）；非作者（且非平台 admin）视为不存在。"""
     stmt = (
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .join(ProjectMember, ProjectMember.project_id == PaperNote.project_id)
-        .where(PaperNote.id == note_id, ProjectMember.user_id == user_id)
+        .where(PaperNote.id == note_id)
     )
+    if user.role != "admin":
+        stmt = stmt.where(PaperNote.author_id == user.id)
     row = (await session.execute(stmt)).first()
     if row is None:
         return None
     note, display_name, email = row
     return note, author_name_of(display_name, email)
-
-
-def can_modify_note(note: PaperNote, user: User) -> bool:
-    """改 / 删权限：笔记作者或平台 admin。"""
-    return note.author_id == user.id or user.role == "admin"
 
 
 async def update_note(session: AsyncSession, note: PaperNote, *, content: str) -> PaperNote:
@@ -85,18 +81,30 @@ async def list_project_notes(
     session: AsyncSession,
     *,
     project_id: uuid.UUID,
+    author_id: uuid.UUID,
     q: str | None = None,
     paper_id: uuid.UUID | None = None,
     page: int = 1,
     size: int = 20,
 ) -> tuple[Sequence[tuple[PaperNote, str, str]], int]:
-    """项目笔记本：分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，
-    row = (note, author_name, paper_title)。"""
+    """课题笔记本：「我的」笔记里落在本课题范围（方向库 ∪ 相关研究书架）的部分。
+
+    分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，row = (note, author_name, paper_title)。
+    """
+    library = await get_library_for_project(session, project_id)
+    in_scope = or_(
+        PaperNote.paper_id.in_(
+            select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library.id)
+        ),
+        PaperNote.paper_id.in_(
+            select(TopicPaper.paper_id).where(TopicPaper.topic_id == project_id)
+        ),
+    )
     stmt = (
         select(PaperNote, User.display_name, User.email, Paper.title)
         .join(User, User.id == PaperNote.author_id)
         .join(Paper, Paper.id == PaperNote.paper_id)
-        .where(PaperNote.project_id == project_id)
+        .where(PaperNote.author_id == author_id, in_scope)
     )
     if q:
         stmt = stmt.where(PaperNote.content.ilike(f"%{q}%"))

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -25,7 +25,6 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import (
     Concept,
     Paper,
-    PaperHighlight,
     PaperNote,
     PaperTag,
     PaperUserMeta,
@@ -290,7 +289,9 @@ async def set_paper_status(session: AsyncSession, view: PaperView, status: str) 
 async def paper_extras_map(
     session: AsyncSession, *, paper_ids: Sequence[uuid.UUID], user_id: uuid.UUID
 ) -> dict[uuid.UUID, dict[str, Any]]:
-    """批量取论文的 tags / starred / reading_status / note_count（3 条聚合查询，避免 N+1）。"""
+    """批量取论文的 tags / starred / reading_status / note_count（3 条聚合查询，避免 N+1）。
+
+    note_count 是请求者本人的笔记数（P5b 起笔记 paper × author，仅作者可见）。"""
     extras: dict[uuid.UUID, dict[str, Any]] = {
         pid: {"tags": [], "starred": False, "reading_status": "unread", "note_count": 0}
         for pid in paper_ids
@@ -308,7 +309,7 @@ async def paper_extras_map(
         extras[pid]["tags"].append(name)
     note_rows = await session.execute(
         select(PaperNote.paper_id, func.count())
-        .where(PaperNote.paper_id.in_(ids))
+        .where(PaperNote.paper_id.in_(ids), PaperNote.author_id == user_id)
         .group_by(PaperNote.paper_id)
     )
     for pid, count in note_rows.all():
@@ -416,8 +417,9 @@ async def upsert_paper_user_meta(
 
 # ---- 从方向库移除论文（docs/api-lit.md §8.6） ----
 #
-# P4 全局内容池语义：删除 = 删本方向的成员行与项目侧挂件（笔记/划线/标签关联）；
-# 内容池 Paper 行与磁盘文件（PDF/全文/图）永不删除（可能被其他方向复用）。
+# P4 全局内容池语义：删除 = 删本方向的成员行与项目侧标签关联；内容池 Paper 行与
+# 磁盘文件（PDF/全文/图）永不删除（可能被其他方向复用）。个人笔记/划线（P5b 起
+# paper × author 跨课题共享）不随库剔除删除，只随内容池 Paper 级联。
 
 
 async def _delete_membership_rows(
@@ -426,20 +428,10 @@ async def _delete_membership_rows(
     project_id: uuid.UUID,
     memberships: Sequence[LibraryPaper],
 ) -> None:
-    """硬删成员行 + 本项目挂在这些论文上的笔记/划线/标签关联（不 commit）。"""
+    """硬删成员行 + 本项目挂在这些论文上的标签关联（不 commit）。"""
     paper_ids = [m.paper_id for m in memberships]
     if not paper_ids:
         return
-    await session.execute(
-        delete(PaperNote).where(
-            PaperNote.paper_id.in_(paper_ids), PaperNote.project_id == project_id
-        )
-    )
-    await session.execute(
-        delete(PaperHighlight).where(
-            PaperHighlight.paper_id.in_(paper_ids), PaperHighlight.project_id == project_id
-        )
-    )
     project_tag_ids = select(PaperTag.id).where(PaperTag.project_id == project_id)
     await session.execute(
         delete(paper_tag_links).where(
@@ -455,8 +447,8 @@ async def _delete_membership_rows(
 async def delete_paper(session: AsyncSession, view: PaperView) -> None:
     """从当前方向库彻底移除一篇论文（垃圾桶里的「彻底删除」）。
 
-    删成员行与本项目的笔记/划线/标签关联；收尾清理项目内零引用标签。
-    内容池行与落盘文件保留（其他方向可复用）。
+    删成员行与本项目的标签关联；收尾清理项目内零引用标签。
+    内容池行、落盘文件与个人笔记/划线保留（其他方向可复用）。
     """
     project_id = view.project_id
     await _delete_membership_rows(session, project_id=project_id, memberships=[view.membership])
@@ -656,30 +648,37 @@ def build_chat_messages(
 
 
 async def keyword_search_papers(
-    session: AsyncSession, *, project_id: uuid.UUID, q: str, limit: int
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    q: str,
+    limit: int,
+    user_id: uuid.UUID | None = None,
 ) -> list[tuple[PaperView, float]]:
-    """关键词检索：title/abstract/库版 wiki/笔记内容 ilike，按命中位置给启发式分。
+    """关键词检索：title/abstract/库版 wiki/我的笔记内容 ilike，按命中位置给启发式分。
 
     只检索库内文献（相关性达标）：已删除（excluded）/未筛选（candidate）不出现。
+    笔记仅作者本人可见（P5b），故只有传 user_id（用户检索入口）才并入笔记命中；
+    agent 调用（无用户语境）不搜笔记。
     """
     library = await get_library_for_project(session, project_id)
     pattern = f"%{q}%"
-    note_hit = Paper.id.in_(
-        select(PaperNote.paper_id).where(
-            PaperNote.project_id == project_id, PaperNote.content.ilike(pattern)
+    hits = [
+        Paper.title.ilike(pattern),
+        Paper.abstract.ilike(pattern),
+        LibraryPaper.wiki_content.ilike(pattern),
+    ]
+    if user_id is not None:
+        hits.append(
+            Paper.id.in_(
+                select(PaperNote.paper_id).where(
+                    PaperNote.author_id == user_id, PaperNote.content.ilike(pattern)
+                )
+            )
         )
-    )
     stmt = (
         member_paper_stmt(library.id)
-        .where(
-            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
-            or_(
-                Paper.title.ilike(pattern),
-                Paper.abstract.ilike(pattern),
-                LibraryPaper.wiki_content.ilike(pattern),
-                note_hit,
-            ),
-        )
+        .where(LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]), or_(*hits))
         .limit(limit * 3)
     )
     rows = (await session.execute(stmt)).all()

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -131,7 +131,7 @@ class PaperView:
 def apply_paper_filters(
     stmt: Select,
     *,
-    project_id: uuid.UUID,
+    project_id: uuid.UUID | None,
     status: str | None = None,
     q: str | None = None,
     tag: str | None = None,
@@ -180,7 +180,7 @@ def apply_paper_filters(
         stmt = stmt.where(LibraryPaper.created_at >= created_from)
     if created_to:
         stmt = stmt.where(LibraryPaper.created_at <= created_to)
-    if tag:
+    if tag and project_id is not None:
         stmt = stmt.where(
             Paper.id.in_(
                 select(paper_tag_links.c.paper_id)
@@ -208,7 +208,8 @@ def apply_paper_filters(
 async def list_papers(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     status: str | None = None,
     q: str | None = None,
     tag: str | None = None,
@@ -225,9 +226,13 @@ async def list_papers(
     created_from: datetime | None = None,
     created_to: datetime | None = None,
 ) -> tuple[Sequence[PaperView], int]:
-    library = await get_library_for_project(session, project_id)
+    """库内论文列表。入口二选一：project_id（成员视角，解析隐式库）或
+    library_id（共享库读视角，P5c；project_id 仅作 PaperView 的课题上下文回填）。"""
+    if library_id is None:
+        assert project_id is not None
+        library_id = (await get_library_for_project(session, project_id)).id
     stmt = apply_paper_filters(
-        member_paper_stmt(library.id),
+        member_paper_stmt(library_id),
         project_id=project_id,
         status=status,
         q=q,
@@ -271,6 +276,18 @@ async def _pool_paper_view(
     paper = await session.get(Paper, paper_id, options=options)
     if paper is None:
         return None
+    # P5c 方向库全实验室可读：论文只要在任一方向库有成员行，任何登录用户可读。
+    # 视角取确定性成员行（优先有 wiki 解读的，其次最早入库的）；无课题上下文
+    # （project_id=None：伴读不带参考检索、LLM 记账归个人）。
+    shared_stmt = (
+        select(LibraryPaper)
+        .where(LibraryPaper.paper_id == paper_id)
+        .order_by(LibraryPaper.wiki_content.is_(None), LibraryPaper.created_at)
+        .limit(1)
+    )
+    shared = (await session.execute(shared_stmt)).scalars().first()
+    if shared is not None:
+        return PaperView(paper, shared, None)
     stmt = (
         select(TopicPaper.topic_id)
         .join(ProjectMember, ProjectMember.project_id == TopicPaper.topic_id)
@@ -697,7 +714,8 @@ def build_chat_messages(
 async def keyword_search_papers(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     q: str,
     limit: int,
     user_id: uuid.UUID | None = None,
@@ -706,9 +724,11 @@ async def keyword_search_papers(
 
     只检索库内文献（相关性达标）：已删除（excluded）/未筛选（candidate）不出现。
     笔记仅作者本人可见（P5b），故只有传 user_id（用户检索入口）才并入笔记命中；
-    agent 调用（无用户语境）不搜笔记。
+    agent 调用（无用户语境）不搜笔记。入口同 list_papers：project_id 或 library_id。
     """
-    library = await get_library_for_project(session, project_id)
+    if library_id is None:
+        assert project_id is not None
+        library_id = (await get_library_for_project(session, project_id)).id
     pattern = f"%{q}%"
     hits = [
         Paper.title.ilike(pattern),
@@ -724,7 +744,7 @@ async def keyword_search_papers(
             )
         )
     stmt = (
-        member_paper_stmt(library.id)
+        member_paper_stmt(library_id)
         .where(LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]), or_(*hits))
         .limit(limit * 3)
     )
@@ -746,12 +766,19 @@ async def keyword_search_papers(
 
 
 async def keyword_search_concepts(
-    session: AsyncSession, *, project_id: uuid.UUID, q: str, limit: int
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    q: str,
+    limit: int,
 ) -> list[tuple[Concept, float]]:
-    library = await get_library_for_project(session, project_id)
+    if library_id is None:
+        assert project_id is not None
+        library_id = (await get_library_for_project(session, project_id)).id
     stmt = (
         select(Concept)
-        .where(Concept.library_id == library.id, Concept.name.ilike(f"%{q}%"))
+        .where(Concept.library_id == library_id, Concept.name.ilike(f"%{q}%"))
         .order_by(Concept.name)
         .limit(limit)
     )
@@ -763,10 +790,17 @@ def semantic_search_supported(session: AsyncSession) -> bool:
 
 
 async def semantic_search_papers(
-    session: AsyncSession, *, project_id: uuid.UUID, query_vector: list[float], limit: int
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    query_vector: list[float],
+    limit: int,
 ) -> list[tuple[PaperView, float]]:
     """pgvector 余弦检索（仅 postgres；调用方需先判 semantic_search_supported）。"""
-    library = await get_library_for_project(session, project_id)
+    if library_id is None:
+        assert project_id is not None
+        library_id = (await get_library_for_project(session, project_id)).id
     qv = json.dumps(query_vector)
     rows = (
         await session.execute(
@@ -778,16 +812,14 @@ async def semantic_search_papers(
                 "ORDER BY p.embedding <=> CAST(:qv AS vector) "
                 "LIMIT :k"
             ),
-            {"qv": qv, "lib": str(library.id), "k": limit},
+            {"qv": qv, "lib": str(library_id), "k": limit},
         )
     ).all()
     if not rows:
         return []
     scores = {row.id: float(row.score) for row in rows}
     pairs = (
-        await session.execute(
-            member_paper_stmt(library.id).where(Paper.id.in_(list(scores)))
-        )
+        await session.execute(member_paper_stmt(library_id).where(Paper.id.in_(list(scores))))
     ).all()
     by_id = {p.id: PaperView(p, m, project_id) for p, m in pairs}
     return [(by_id[pid], scores[pid]) for pid in (r.id for r in rows) if pid in by_id]

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -30,6 +30,7 @@ from app.models.paper import (
     PaperUserMeta,
     paper_tag_links,
 )
+from app.models.project import ProjectMember
 from app.services.libraries import (
     get_library_for_project,
     member_paper_stmt,
@@ -253,13 +254,55 @@ async def list_papers(
     return [PaperView(paper, membership, project_id) for paper, membership in rows], int(total)
 
 
+async def _pool_paper_view(
+    session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool
+) -> PaperView | None:
+    """池级可见性兜底（P5b）：论文不在任何可见方向库，但个人链路可达时仍可读。
+
+    可达条件：该论文在请求者任一课题的相关研究书架上，或在其个人库条目里
+    （dedup 匹配）。返回的视角带**临时成员行**（不入 session、永不落库）：
+    status=included、无判断字段；``project_id`` 取最早入架的课题（仅个人库
+    可达时为 None）。只用于读路径——写成员行的端点不开启池级兜底。
+    """
+    from app.models.topic_shelf import TopicPaper
+    from app.services import user_library
+
+    options = (selectinload(Paper.concepts),) if with_concepts else ()
+    paper = await session.get(Paper, paper_id, options=options)
+    if paper is None:
+        return None
+    stmt = (
+        select(TopicPaper.topic_id)
+        .join(ProjectMember, ProjectMember.project_id == TopicPaper.topic_id)
+        .where(TopicPaper.paper_id == paper_id, ProjectMember.user_id == user_id)
+        .order_by(TopicPaper.created_at)
+        .limit(1)
+    )
+    topic_id = (await session.execute(stmt)).scalar_one_or_none()
+    if topic_id is None:
+        entry = await user_library.entry_for_paper(session, user_id=user_id, paper=paper)
+        if entry is None:
+            return None
+    membership = LibraryPaper(
+        status="included", created_at=paper.created_at, updated_at=paper.updated_at
+    )
+    return PaperView(paper, membership, topic_id)
+
+
 async def get_paper_for_user(
-    session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool = False
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    with_concepts: bool = False,
+    include_pool: bool = False,
 ) -> PaperView | None:
     """取论文（含成员行视角）；用户任一所属方向的库里都没有时视为不存在。
 
     论文同时在多个可见方向库时取一个确定性视角：优先有 wiki 解读的成员行，
     其次最早加入的（跨方向复用的论文以先入库方向的解读为主视角）。
+    include_pool=True（只给读路径用）时再走池级兜底：书架 / 个人库可达的
+    无库论文也可读（见 :func:`_pool_paper_view`）。
     """
     stmt = (
         user_visible_paper_stmt(user_id)
@@ -270,10 +313,14 @@ async def get_paper_for_user(
     if with_concepts:
         stmt = stmt.options(selectinload(Paper.concepts))
     row = (await session.execute(stmt)).first()
-    if row is None:
+    if row is not None:
+        paper, membership, project_id = row
+        return PaperView(paper, membership, project_id)
+    if not include_pool:
         return None
-    paper, membership, project_id = row
-    return PaperView(paper, membership, project_id)
+    return await _pool_paper_view(
+        session, paper_id=paper_id, user_id=user_id, with_concepts=with_concepts
+    )
 
 
 async def set_paper_status(session: AsyncSession, view: PaperView, status: str) -> PaperView:

--- a/src/backend/app/services/personal_wiki.py
+++ b/src/backend/app/services/personal_wiki.py
@@ -1,0 +1,86 @@
+"""个人版 wiki 按需编译（P5b，不 import fastapi）。
+
+适用对象：**没有任何库版 wiki** 的内容池论文（典型：个人补充入库的库外论文，
+或入库了但还没编译的论文）。用通用模板（无 rubric）编译，可选带上课题
+statement 作为侧重提示；结果写进调用者本人的 user_library_entries.wiki_content
+（三层解析「库版实时 > 个人版 > 书架快照」的中间层）。
+
+费用归个人（LLM 用量记 user_id；给了 topic_id 时顺带归因该课题）。
+并发防抖：同一 paper × user 编译进行中时，二次请求直接抛
+CompileInProgressError（路由映射 409）——进程内 set 实现，单实例足够，
+多副本部署下最坏情况是重复编译一次、后写覆盖，无一致性风险。
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.router import get_llm_router
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.project import Project
+from app.services.user_library import set_personal_wiki
+from app.services.wiki_compile import CompiledWiki, compile_paper
+
+
+class LibraryWikiExistsError(Exception):
+    """已有库版 wiki，不需要个人编译（前端应直接展示库版）。"""
+
+
+class CompileInProgressError(Exception):
+    """同一 paper × user 的编译已在进行中。"""
+
+
+# 进行中的编译（paper_id, user_id）；见模块 docstring 的并发说明
+_COMPILING: set[tuple[uuid.UUID, uuid.UUID]] = set()
+
+
+async def has_library_wiki(session: AsyncSession, paper_id: uuid.UUID) -> bool:
+    """任一方向库的成员行上有 wiki_content 即视为「有库版」。"""
+    stmt = (
+        select(LibraryPaper.id)
+        .where(LibraryPaper.paper_id == paper_id, LibraryPaper.wiki_content.is_not(None))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).first() is not None
+
+
+async def compile_personal_wiki(
+    session: AsyncSession,
+    *,
+    paper: Paper,
+    user_id: uuid.UUID,
+    topic_id: uuid.UUID | None = None,
+) -> CompiledWiki:
+    """通用模板编译个人版 wiki 并写进本人个人库条目，返回编译结果。
+
+    topic_id（可选，调用方已验成员身份）：课题 statement 作为侧重提示，
+    同时作为 LLM 用量的课题归因。
+    """
+    if await has_library_wiki(session, paper.id):
+        raise LibraryWikiExistsError(str(paper.id))
+
+    statement: str | None = None
+    if topic_id is not None:
+        project = await session.get(Project, topic_id)
+        if project is not None:
+            definition = project.definition if isinstance(project.definition, dict) else {}
+            statement = definition.get("statement") or project.name
+
+    key = (paper.id, user_id)
+    if key in _COMPILING:
+        raise CompileInProgressError(str(paper.id))
+    _COMPILING.add(key)
+    try:
+        compiled = await compile_paper(
+            paper,
+            statement=statement,
+            llm=get_llm_router(),
+            user_id=user_id,
+            project_id=topic_id,
+        )
+    finally:
+        _COMPILING.discard(key)
+    await set_personal_wiki(session, user_id=user_id, paper=paper, wiki_content=compiled.content)
+    return compiled

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -2,7 +2,8 @@
 
 三条铁律（docs-dev/workspace-ia-redesign.md §3.4/§3.6）：
 - 论文本体纯引用（paper_id 指向全局内容池）；
-- 库版 wiki 引用为主、入架落快照兜底：展示优先级 库版实时 > 快照；
+- 库版 wiki 引用为主、入架落快照兜底：展示优先级 库版实时 > 个人编译版 >
+  快照（P5b 三层解析；个人版 = 请求者本人 user_library_entries.wiki_content）；
 - 入架必入个人库（user_library_entries，saved=true，共享同一次快照写入）；
   移出书架不动个人库。
 """
@@ -29,6 +30,10 @@ class PaperNotFoundError(Exception):
 
 class ShelfItemNotFoundError(Exception):
     """课题书架上没有这篇论文。"""
+
+
+class NoWikiSourceError(Exception):
+    """刷新快照时没有任何可用的 wiki 来源（库版 / 个人版都没有）。"""
 
 
 class _SnapshotPaper:
@@ -72,10 +77,17 @@ def _pick_live_wiki(rows: list[Any], project_id: uuid.UUID) -> str | None:
     return other.wiki_content if other is not None else None
 
 
-def _item_dict(row: TopicPaper, paper: Paper, live_wiki: str | None) -> dict[str, Any]:
-    """书架条目出参：wiki 展示优先级 库版实时 > 快照；source 标注来源状态。"""
+def _item_dict(
+    row: TopicPaper, paper: Paper, live_wiki: str | None, personal_wiki: str | None
+) -> dict[str, Any]:
+    """书架条目出参：wiki 展示优先级 库版实时 > 个人版 > 快照；source 标注来源状态。
+
+    个人库条目的 wiki 字段身兼两职（个人编译版 / 浏览与入架时的库版快照），
+    与书架快照内容相同时按快照标注（带日期更诚实），不同才算「个人版」。"""
     if live_wiki is not None:
         wiki_source, wiki_content = "live", live_wiki
+    elif personal_wiki is not None and personal_wiki != row.wiki_snapshot:
+        wiki_source, wiki_content = "personal", personal_wiki
     elif row.wiki_snapshot:
         wiki_source, wiki_content = "snapshot", row.wiki_snapshot
     else:
@@ -109,16 +121,30 @@ async def _get_row(
 
 
 async def _item_of(
-    session: AsyncSession, row: TopicPaper, paper: Paper, project_id: uuid.UUID
+    session: AsyncSession,
+    row: TopicPaper,
+    paper: Paper,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
 ) -> dict[str, Any]:
     wiki_rows = await _wiki_rows_for(session, [paper.id])
-    return _item_dict(row, paper, _pick_live_wiki(wiki_rows, project_id))
+    personal = await user_library.personal_wiki_map(session, user_id=user_id, papers=[paper])
+    return _item_dict(
+        row, paper, _pick_live_wiki(wiki_rows, project_id), personal.get(paper.id)
+    )
 
 
 async def list_shelf(
-    session: AsyncSession, *, project_id: uuid.UUID, page: int = 1, size: int = 20
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    page: int = 1,
+    size: int = 20,
 ) -> tuple[list[dict[str, Any]], int]:
-    """分页列书架（最新入架在前），每条带解析后的 wiki 内容与来源状态。"""
+    """分页列书架（最新入架在前），每条带解析后的 wiki 内容与来源状态。
+
+    个人版层按请求者（user_id）本人的个人库条目解析。"""
     base = (
         select(TopicPaper, Paper)
         .join(Paper, Paper.id == TopicPaper.paper_id)
@@ -136,8 +162,16 @@ async def list_shelf(
     by_paper: dict[uuid.UUID, list[Any]] = {}
     for r in wiki_rows:
         by_paper.setdefault(r.paper_id, []).append(r)
+    personal = await user_library.personal_wiki_map(
+        session, user_id=user_id, papers=[paper for _, paper in rows]
+    )
     items = [
-        _item_dict(row, paper, _pick_live_wiki(by_paper.get(paper.id, []), project_id))
+        _item_dict(
+            row,
+            paper,
+            _pick_live_wiki(by_paper.get(paper.id, []), project_id),
+            personal.get(paper.id),
+        )
         for row, paper in rows
     ]
     return items, int(total)
@@ -173,7 +207,7 @@ async def add_to_shelf(
         if note is not None:
             row.note = note
         await session.commit()
-        return await _item_of(session, row, paper, project_id)
+        return await _item_of(session, row, paper, project_id, user_id)
 
     wiki_rows = await _wiki_rows_for(session, [paper_id])
     live_wiki = _pick_live_wiki(wiki_rows, project_id)
@@ -196,11 +230,16 @@ async def add_to_shelf(
     await user_library.save_paper(
         session, user_id=user_id, paper=_SnapshotPaper(paper, live_wiki)
     )
-    return await _item_of(session, row, paper, project_id)
+    return await _item_of(session, row, paper, project_id, user_id)
 
 
 async def update_note(
-    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID, note: str | None
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    note: str | None,
 ) -> dict[str, Any]:
     row = await _get_row(session, project_id=project_id, paper_id=paper_id)
     if row is None:
@@ -209,7 +248,33 @@ async def update_note(
     await session.commit()
     paper = await session.get(Paper, paper_id)
     assert paper is not None  # 书架行外键保证
-    return await _item_of(session, row, paper, project_id)
+    return await _item_of(session, row, paper, project_id, user_id)
+
+
+async def refresh_snapshot(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> dict[str, Any]:
+    """手动刷新书架快照：从当前可得的最优 wiki（库版 > 个人版）重拷。
+
+    两个来源都没有 → NoWikiSourceError（路由映射 409）。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    paper = await session.get(Paper, paper_id)
+    assert paper is not None  # 书架行外键保证
+    live = _pick_live_wiki(await _wiki_rows_for(session, [paper_id]), project_id)
+    personal = await user_library.personal_wiki_map(session, user_id=user_id, papers=[paper])
+    best = live or personal.get(paper_id)
+    if best is None:
+        raise NoWikiSourceError(str(paper_id))
+    row.wiki_snapshot = best
+    row.snapshot_at = utcnow()
+    await session.commit()
+    return await _item_of(session, row, paper, project_id, user_id)
 
 
 async def remove_from_shelf(

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -25,6 +25,8 @@ def dedup_key_for_paper(paper: Paper) -> str:
 
 
 def _snapshot_fields(paper: Paper) -> dict:
+    # wiki_content 用 getattr：调用方可能传裸 Paper（内容池行没有 wiki 字段，
+    # 库版 wiki 在成员行上，由 PaperView / _SnapshotPaper 包装提供）
     return {
         "arxiv_id": paper.arxiv_id,
         "doi": paper.doi,
@@ -35,7 +37,7 @@ def _snapshot_fields(paper: Paper) -> dict:
         "abstract": paper.abstract,
         "url": paper.url,
         "tldr": paper.tldr,
-        "wiki_content": paper.wiki_content,
+        "wiki_content": getattr(paper, "wiki_content", None),
         "last_paper_id": paper.id,
     }
 
@@ -71,6 +73,10 @@ async def record_visit(
         session.add(entry)
     else:
         for field, value in _snapshot_fields(paper).items():
+            # wiki 快照只升不清：论文当前没有库版 wiki 时保留旧快照
+            # （可能是个人编译版 / 库版被删前的快照，P5b 三层解析的兜底层）
+            if field == "wiki_content" and value is None:
+                continue
             setattr(entry, field, value)
     entry.visit_count = (entry.visit_count or 0) + 1  # 未 flush 的新对象默认值尚未生效
     entry.last_visited_at = utcnow()
@@ -100,6 +106,41 @@ async def set_saved(
     await session.commit()
     await session.refresh(entry)
     return entry
+
+
+async def set_personal_wiki(
+    session: AsyncSession, *, user_id: uuid.UUID, paper: Paper, wiki_content: str
+) -> UserLibraryEntry:
+    """把个人编译版 wiki 写进本人条目（无条目则建，不动 saved/浏览统计）。"""
+    entry = await entry_for_paper(session, user_id=user_id, paper=paper)
+    if entry is None:
+        entry = UserLibraryEntry(
+            user_id=user_id, dedup_key=dedup_key_for_paper(paper), **_snapshot_fields(paper)
+        )
+        session.add(entry)
+    entry.wiki_content = wiki_content
+    await session.commit()
+    await session.refresh(entry)
+    return entry
+
+
+async def personal_wiki_map(
+    session: AsyncSession, *, user_id: uuid.UUID, papers: list[Paper]
+) -> dict[uuid.UUID, str]:
+    """paper_id → 本人条目里的 wiki（个人编译版 / 历史快照），无则不在结果里。
+
+    P5b 三层解析（库版实时 > 个人版 > 书架快照）的中间层数据源。
+    """
+    keys = {paper.id: dedup_key_for_paper(paper) for paper in papers}
+    if not keys:
+        return {}
+    stmt = select(UserLibraryEntry.dedup_key, UserLibraryEntry.wiki_content).where(
+        UserLibraryEntry.user_id == user_id,
+        UserLibraryEntry.dedup_key.in_(set(keys.values())),
+        UserLibraryEntry.wiki_content.is_not(None),
+    )
+    by_key = {key: content for key, content in (await session.execute(stmt)).all() if content}
+    return {pid: by_key[key] for pid, key in keys.items() if key in by_key}
 
 
 async def purge_entry(session: AsyncSession, *, entry: UserLibraryEntry) -> None:

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -98,8 +98,10 @@ def _figure_prompt_section(selected: list[tuple[dict[str, Any], bytes]]) -> str:
     return "\n".join(lines)
 
 
-def build_compile_prompt(paper: Paper, *, statement: str) -> tuple[str, list[bytes]]:
-    """组装编译 user prompt 与随附图片（无重要图时 images 为空 → 纯文字编译）。"""
+def build_compile_prompt(paper: Paper, *, statement: str | None) -> tuple[str, list[bytes]]:
+    """组装编译 user prompt 与随附图片（无重要图时 images 为空 → 纯文字编译）。
+
+    statement 为空 = 通用模板（个人版 wiki，无方向侧重）：不带「研究方向」行。"""
     body: str | None = None
     source = "abstract"
     if paper.full_text_path and Path(paper.full_text_path).exists():
@@ -107,9 +109,10 @@ def build_compile_prompt(paper: Paper, *, statement: str) -> tuple[str, list[byt
         source = "full_text"
     body = (body or paper.abstract or "（无正文）")[:FULLTEXT_PROMPT_CHARS]
     authors = "、".join(a.get("name", "") for a in (paper.authors or []) if isinstance(a, dict))
+    direction_line = f"研究方向：{statement}\n" if statement else ""
     prompt = (
-        f"研究方向：{statement}\n"
-        f"标题：{paper.title}\n"
+        direction_line
+        + f"标题：{paper.title}\n"
         f"作者：{authors or '未知'}\n"
         f"年份/发表：{paper.year or '未知'} {paper.venue or ''}\n"
         f"正文来源：{source}\n"
@@ -132,7 +135,7 @@ class CompiledWiki:
 async def compile_paper(
     paper: Paper,
     *,
-    statement: str,
+    statement: str | None,
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,

--- a/src/backend/app/services/wiki_export.py
+++ b/src/backend/app/services/wiki_export.py
@@ -100,7 +100,10 @@ def _inline_paper_figures(
     return body, extra_lines
 
 
-async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
+async def build_obsidian_zip(
+    session: AsyncSession, project: Project, *, user_id: uuid.UUID
+) -> bytes:
+    """构建 vault zip；笔记只导出请求者本人的（P5b 笔记 paper × author，仅作者可见）。"""
     library = await get_library_for_project(session, project.id)
     paper_rows = (
         await session.execute(
@@ -129,11 +132,14 @@ async def build_obsidian_zip(session: AsyncSession, project: Project) -> bytes:
         .all()
     )
 
-    # 论文笔记（有笔记的论文页追加「## 笔记」小节）
+    # 论文笔记（有笔记的论文页追加「## 笔记」小节）：只带请求者自己的笔记
     note_rows = await session.execute(
         select(PaperNote, User.display_name, User.email)
         .join(User, User.id == PaperNote.author_id)
-        .where(PaperNote.project_id == project.id)
+        .where(
+            PaperNote.author_id == user_id,
+            PaperNote.paper_id.in_([p.id for p in papers]),
+        )
         .order_by(PaperNote.created_at)
     )
     notes_by_paper: dict[uuid.UUID, list[tuple[PaperNote, str]]] = defaultdict(list)

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -274,7 +274,7 @@ async def get_paper_citation(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 
 @tool(
     "get_paper_notes",
-    description="取某论文的项目笔记（团队共享，附作者）",
+    description="取某论文下当前用户的笔记（P5b 起笔记仅作者本人可见）",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -285,7 +285,14 @@ async def get_paper_citation(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         paper = await _project_paper(session, ctx, args.get("paper_id"))
-        rows = await notes_service.list_paper_notes(session, paper_id=paper.id)
+        # 笔记仅作者本人可见：无用户语境（系统内部调用）时返回空
+        rows = (
+            await notes_service.list_paper_notes(
+                session, paper_id=paper.id, author_id=ctx.user_id
+            )
+            if ctx.user_id is not None
+            else []
+        )
         return {
             "paper_id": str(paper.id),
             "notes": [{"author": author, "content": note.content} for note, author in rows],
@@ -294,7 +301,7 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 
 @tool(
     "get_paper_highlights",
-    description="取某论文的划线/高亮（团队共享，含所在页与选中文本）",
+    description="取某论文下当前用户的划线/高亮（含所在页与选中文本；仅作者本人可见）",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -305,7 +312,13 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 async def get_paper_highlights(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         paper = await _project_paper(session, ctx, args.get("paper_id"))
-        rows = await highlights_service.list_paper_highlights(session, paper_id=paper.id)
+        rows = (
+            await highlights_service.list_paper_highlights(
+                session, paper_id=paper.id, author_id=ctx.user_id
+            )
+            if ctx.user_id is not None
+            else []
+        )
         return {
             "paper_id": str(paper.id),
             "highlights": [

--- a/src/backend/tests/test_highlights.py
+++ b/src/backend/tests/test_highlights.py
@@ -1,4 +1,4 @@
-"""PDF 划线标注：CRUD + 颜色规整 + 排序 + 权限（同论文笔记权限模型）。"""
+"""PDF 划线标注：CRUD + 颜色规整 + 排序 + 权限（P5b 起同笔记：仅作者本人可见）。"""
 
 import uuid
 
@@ -47,24 +47,32 @@ async def test_highlight_crud_and_ordering(client):
     )
     assert resp.status_code == 201, resp.text
     hl = resp.json()
-    assert hl["paper_id"] == pid and hl["project_id"] == project_id
+    assert hl["paper_id"] == pid
+    assert "project_id" not in hl  # P5b：划线不再挂项目
     assert hl["page"] == 3 and hl["color"] == "green" and hl["note"] is None
     assert hl["style"] == "highlight"  # 默认样式
     assert hl["author_name"] == "Alice"
     assert hl["rects"] == [RECT]
     hl_id = hl["id"]
 
-    # 第 1 页再建一条（bob）
+    # alice 第 1 页再建一条；bob 也建一条（仅本人可见）
     await client.post(
         f"/api/papers/{pid}/highlights",
         json={"page": 1, "rects": [RECT], "selected_text": "encoder"},
+        headers=alice,
+    )
+    await client.post(
+        f"/api/papers/{pid}/highlights",
+        json={"page": 2, "rects": [RECT], "selected_text": "bob 的划线"},
         headers=bob,
     )
-    # 成员可读，按页码升序
-    resp = await client.get(f"/api/papers/{pid}/highlights", headers=bob)
+    # 只看到自己的，按页码升序
+    resp = await client.get(f"/api/papers/{pid}/highlights", headers=alice)
     rows = resp.json()
     assert [r["page"] for r in rows] == [1, 3]
     assert rows[0]["color"] == "yellow"  # 默认色
+    resp = await client.get(f"/api/papers/{pid}/highlights", headers=bob)
+    assert [r["selected_text"] for r in resp.json()] == ["bob 的划线"]
 
     # 作者改颜色 + 加批注
     resp = await client.patch(
@@ -81,7 +89,7 @@ async def test_highlight_crud_and_ordering(client):
     resp = await client.delete(f"/api/highlights/{hl_id}", headers=alice)
     assert resp.status_code == 204
     resp = await client.get(f"/api/papers/{pid}/highlights", headers=alice)
-    assert len(resp.json()) == 1
+    assert [r["page"] for r in resp.json()] == [1]
 
 
 async def test_highlight_style(client):
@@ -150,11 +158,11 @@ async def test_highlight_permissions(client):
     )
     hl_id = resp.json()["id"]
 
-    # 非作者成员改/删 → 403
+    # 非作者成员改/删 → 404（P5b 起他人划线不可见，视为不存在）
     assert (
         await client.patch(f"/api/highlights/{hl_id}", json={"color": "pink"}, headers=bob)
-    ).status_code == 403
-    assert (await client.delete(f"/api/highlights/{hl_id}", headers=bob)).status_code == 403
+    ).status_code == 404
+    assert (await client.delete(f"/api/highlights/{hl_id}", headers=bob)).status_code == 404
 
     # 非项目成员 → 404
     mallory = await register_and_login(client, email="mallory@example.com")

--- a/src/backend/tests/test_highlights.py
+++ b/src/backend/tests/test_highlights.py
@@ -164,10 +164,11 @@ async def test_highlight_permissions(client):
     ).status_code == 404
     assert (await client.delete(f"/api/highlights/{hl_id}", headers=bob)).status_code == 404
 
-    # 非项目成员 → 404
+    # 非项目成员：论文可读（P5c）→ 划线列表 200 但只见本人（空）；他人划线仍不可改
     mallory = await register_and_login(client, email="mallory@example.com")
     outsider = {"Authorization": f"Bearer {mallory}"}
-    assert (await client.get(f"/api/papers/{pid}/highlights", headers=outsider)).status_code == 404
+    resp = await client.get(f"/api/papers/{pid}/highlights", headers=outsider)
+    assert resp.status_code == 200 and resp.json() == []
     assert (
         await client.patch(f"/api/highlights/{hl_id}", json={"color": "pink"}, headers=outsider)
     ).status_code == 404

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -146,19 +146,32 @@ async def test_clear_history_keeps_saved(client):
     assert resp.json()["items"][0]["visit_count"] == 0
 
 
-async def test_visit_requires_project_membership(client):
+async def test_visit_requires_paper_visibility(client):
+    """P5c 起库成员论文全员可读：他人也能浏览/收藏；
+    完全不可见的论文（不在任何库、未入架未收藏）仍 404。"""
     token_a = await register_and_login(client, email="owner@example.com")
     headers_a = {"Authorization": f"Bearer {token_a}"}
     project_id = await _make_project(client, headers_a)
-    paper_id = await _make_paper(project_id, title="Private Paper", status="included")
+    paper_id = await _make_paper(project_id, title="Shared Paper", status="included")
 
     token_b = await register_and_login(client, email="intruder@example.com")
     headers_b = {"Authorization": f"Bearer {token_b}"}
     resp = await client.post(
         "/api/me/library/visits", json={"paper_id": paper_id}, headers=headers_b
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 201
     resp = await client.post("/api/me/library", json={"paper_id": paper_id}, headers=headers_b)
+    assert resp.status_code == 201
+
+    # 池级论文（零库成员行、与 b 无个人链路）仍不可见
+    async with get_sessionmaker()() as session:
+        pool_paper = Paper(title="Invisible Pool Paper", source="manual")
+        session.add(pool_paper)
+        await session.commit()
+        pool_id = str(pool_paper.id)
+    resp = await client.post(
+        "/api/me/library/visits", json={"paper_id": pool_id}, headers=headers_b
+    )
     assert resp.status_code == 404
 
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -1,4 +1,4 @@
-"""alembic 迁移 sqlite 实跑：全链 upgrade head + 最新 revision（论文评审 M5-C）往返。"""
+"""alembic 迁移 sqlite 实跑：全链 upgrade head + 最新 revision 往返。"""
 
 from pathlib import Path
 
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a，本分支最新）
-PREV_REVISION = "fe8a86942dc7"  # 论文内容池收尾（P4 迁移 B）
+HEAD_REVISION = "1c6c4831d80f"  # 笔记/划线归属拆分（P5b，本分支最新）
+PREV_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -86,9 +86,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "experiments"
     ]
     assert {"seq", "exit_code", "pid", "started_at", "finished_at"} <= columns["experiment_runs"]
-    # M5：笔记 / 标签 / 个人状态表
+    # M5：笔记 / 标签 / 个人状态表（P5b 起笔记/划线归 paper × author，project_id 删列）
     assert {"paper_notes", "paper_tags", "paper_tag_links", "paper_user_meta"} <= columns["_tables"]
-    assert {"paper_id", "project_id", "author_id", "content"} <= columns["paper_notes"]
+    assert {"paper_id", "author_id", "content"} <= columns["paper_notes"]
+    assert "project_id" not in columns["paper_notes"]
     assert {"project_id", "name"} <= columns["paper_tags"]
     assert columns["paper_tag_links"] == {"paper_id", "tag_id"}
     assert {"paper_id", "user_id", "starred", "reading_status"} <= columns["paper_user_meta"]
@@ -132,11 +133,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_score" not in columns["papers"]
     assert "wiki_content" not in columns["papers"]
     assert "project_id" not in columns["papers"]
-    # PDF 划线标注表（上一版 paper_highlights）
+    # PDF 划线标注表（P5b 起无 project_id）
     assert "paper_highlights" in columns["_tables"]
     assert {
         "paper_id",
-        "project_id",
         "author_id",
         "page",
         "rects",
@@ -145,6 +145,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "style",
         "note",
     } <= columns["paper_highlights"]
+    assert "project_id" not in columns["paper_highlights"]
     # 稿件文件版本快照表
     assert "manuscript_file_versions" in columns["_tables"]
     assert {"file_id", "seq", "origin", "label", "content"} <= columns["manuscript_file_versions"]
@@ -221,11 +222,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "added_by",
     } <= columns["topic_papers"]
 
-    # 最新 revision 可往返（downgrade 只删 topic_papers，其余结构不动）
+    # 最新 revision 可往返（downgrade 补回可空 project_id 列，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "topic_papers" not in columns["_tables"]
+    assert "project_id" in columns["paper_notes"]
+    assert "project_id" in columns["paper_highlights"]
+    assert "topic_papers" in columns["_tables"]
     # P4 收尾后的内容池结构不受影响：判断列仍只在 library_papers 上
     assert "project_id" not in columns["papers"]
     assert "wiki_content" not in columns["papers"]
@@ -255,6 +258,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "project_id" not in columns["paper_notes"]
+    assert "project_id" not in columns["paper_highlights"]
     assert "models" in columns["llm_providers"]
     assert "owner_id" in columns["llm_providers"]
     assert "llm_self_managed" in columns["users"]

--- a/src/backend/tests/test_notes.py
+++ b/src/backend/tests/test_notes.py
@@ -142,11 +142,12 @@ async def test_notes_permissions(client):
     resp = await client.delete(f"/api/notes/{note_id}", headers=bob)
     assert resp.status_code == 404
 
-    # 非项目成员 → 404（笔记与论文都视为不存在）
+    # 非项目成员：论文可读（P5c 库成员论文全员可读）→ 笔记列表 200 但只见本人（空）；
+    # 他人笔记仍不可见不可改
     mallory = await register_and_login(client, email="mallory@example.com")
     outsider = {"Authorization": f"Bearer {mallory}"}
     resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=outsider)
-    assert resp.status_code == 404
+    assert resp.status_code == 200 and resp.json() == []
     resp = await client.patch(f"/api/notes/{note_id}", json={"content": "x"}, headers=outsider)
     assert resp.status_code == 404
 

--- a/src/backend/tests/test_notes.py
+++ b/src/backend/tests/test_notes.py
@@ -1,4 +1,5 @@
-"""论文笔记（docs/api-lit.md §2）：CRUD + 权限 + 项目笔记本 + 检索并入 + 导出小节。"""
+"""论文笔记（docs/api-lit.md §2 + P5b 归属拆分）：CRUD + 仅作者可见 +
+跨课题共享 + 课题笔记本 + 检索并入 + 导出小节。"""
 
 import io
 import uuid
@@ -7,9 +8,10 @@ import zipfile
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
+from app.models.paper import PaperNote
 from app.models.user import User
 from app.services.notes import author_name_of
-from tests.conftest import add_paper, register_and_login
+from tests.conftest import add_paper, membership_of, register_and_login
 
 
 async def _setup(client):
@@ -48,7 +50,7 @@ async def _setup(client):
     return project_id, headers, bob_headers, ids
 
 
-async def test_notes_crud_and_author_name(client):
+async def test_notes_crud_and_author_only_visibility(client):
     project_id, alice, bob, ids = await _setup(client)
 
     resp = await client.post(
@@ -56,15 +58,17 @@ async def test_notes_crud_and_author_name(client):
     )
     assert resp.status_code == 201, resp.text
     note = resp.json()
-    assert note["paper_id"] == ids["p1"] and note["project_id"] == project_id
+    assert note["paper_id"] == ids["p1"]
     assert note["author_name"] == "Alice"  # display_name 优先
+    assert "project_id" not in note  # P5b：笔记不再挂项目
     note_id = note["id"]
 
-    # 成员可读（按 created_at 倒序）
+    # 仅作者可见：bob 的列表只有 bob 自己的笔记，看不到 alice 的
     await client.post(f"/api/papers/{ids['p1']}/notes", json={"content": "第二条"}, headers=bob)
     resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=bob)
-    notes = resp.json()
-    assert [n["content"] for n in notes] == ["第二条", "重点：方法部分"]
+    assert [n["content"] for n in resp.json()] == ["第二条"]
+    resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
+    assert [n["content"] for n in resp.json()] == ["重点：方法部分"]
 
     # 作者可改
     resp = await client.patch(f"/api/notes/{note_id}", json={"content": "改过了"}, headers=alice)
@@ -75,11 +79,54 @@ async def test_notes_crud_and_author_name(client):
     resp = await client.delete(f"/api/notes/{note_id}", headers=alice)
     assert resp.status_code == 204
     resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
-    assert len(resp.json()) == 1
+    assert resp.json() == []
 
     # author_name 回退 email @ 前部分
     assert author_name_of("", "carol@example.com") == "carol"
     assert author_name_of(None, "dave@example.com") == "dave"
+
+
+async def test_notes_shared_across_topics_and_survive_library_removal(client):
+    """P5b 归属拆分：同一篇论文的笔记跨课题共享；库剔除不删笔记。"""
+    project_id, alice, bob, ids = await _setup(client)
+    # alice 开第二个课题，并把 p1 也收进第二个课题的方向库
+    resp = await client.post("/api/projects", json={"name": "notes-proj-2"}, headers=alice)
+    project2_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import LibraryPaper
+        from app.services.libraries import get_library_for_project
+
+        library2 = await get_library_for_project(session, uuid.UUID(project2_id))
+        session.add(
+            LibraryPaper(
+                library_id=library2.id, paper_id=uuid.UUID(ids["p1"]), status="included"
+            )
+        )
+        await session.commit()
+
+    await client.post(
+        f"/api/papers/{ids['p1']}/notes", json={"content": "跨课题的笔记"}, headers=alice
+    )
+
+    # 两个课题的笔记本都能看到（paper × author，无课题隔离）
+    for pid in (project_id, project2_id):
+        resp = await client.get(f"/api/projects/{pid}/notes", headers=alice)
+        assert resp.status_code == 200
+        assert [n["content"] for n in resp.json()["items"]] == ["跨课题的笔记"], pid
+
+    # 从第一个课题的库硬删这篇论文 → 笔记保留（第二个课题照常可见）
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=ids["p1"])
+        await session.delete(membership)
+        await session.commit()
+    resp = await client.get(f"/api/papers/{ids['p1']}/notes", headers=alice)
+    assert [n["content"] for n in resp.json()] == ["跨课题的笔记"]
+    resp = await client.get(f"/api/projects/{project2_id}/notes", headers=alice)
+    assert resp.json()["total"] == 1
+    async with get_sessionmaker()() as session:
+        stmt = select(PaperNote).where(PaperNote.paper_id == uuid.UUID(ids["p1"]))
+        rows = (await session.execute(stmt)).scalars().all()
+        assert len(rows) == 1
 
 
 async def test_notes_permissions(client):
@@ -89,11 +136,11 @@ async def test_notes_permissions(client):
     )
     note_id = resp.json()["id"]
 
-    # 非作者成员改/删 → 403
+    # 非作者成员改/删 → 404（P5b 起他人笔记不可见，视为不存在）
     resp = await client.patch(f"/api/notes/{note_id}", json={"content": "x"}, headers=bob)
-    assert resp.status_code == 403
+    assert resp.status_code == 404
     resp = await client.delete(f"/api/notes/{note_id}", headers=bob)
-    assert resp.status_code == 403
+    assert resp.status_code == 404
 
     # 非项目成员 → 404（笔记与论文都视为不存在）
     mallory = await register_and_login(client, email="mallory@example.com")
@@ -121,15 +168,21 @@ async def test_project_notebook_pagination_and_search(client):
             f"/api/papers/{ids['p1']}/notes", json={"content": f"note-{i} 关于对齐"}, headers=alice
         )
     await client.post(
-        f"/api/papers/{ids['p2']}/notes", json={"content": "另一篇的量子笔记"}, headers=bob
+        f"/api/papers/{ids['p2']}/notes", json={"content": "另一篇的量子笔记"}, headers=alice
+    )
+    await client.post(
+        f"/api/papers/{ids['p2']}/notes", json={"content": "bob 私有笔记"}, headers=bob
     )
 
+    # 笔记本只聚合「我的」笔记（bob 的不计入）
     resp = await client.get(f"/api/projects/{project_id}/notes?size=2&page=1", headers=alice)
     body = resp.json()
     assert body["total"] == 4 and len(body["items"]) == 2
     assert body["items"][0]["content"] == "另一篇的量子笔记"  # created_at 倒序
     assert body["items"][0]["paper_title"] == "Second Paper"
-    assert body["items"][0]["author_name"] == "Alice"  # bob 注册时 display_name 也是 Alice
+    resp = await client.get(f"/api/projects/{project_id}/notes", headers=bob)
+    assert resp.json()["total"] == 1
+    assert resp.json()["items"][0]["content"] == "bob 私有笔记"
 
     # q 内容搜索 + paper_id 过滤
     resp = await client.get(f"/api/projects/{project_id}/notes?q=量子", headers=alice)
@@ -145,7 +198,7 @@ async def test_project_notebook_pagination_and_search(client):
     assert resp.status_code == 404
 
 
-async def test_keyword_search_includes_note_hits(client):
+async def test_keyword_search_includes_own_note_hits_only(client):
     project_id, alice, bob, ids = await _setup(client)
     await client.post(
         f"/api/papers/{ids['p2']}/notes", json={"content": "提到了量子退火算法"}, headers=alice
@@ -156,8 +209,14 @@ async def test_keyword_search_includes_note_hits(client):
     titles = [p["title"] for p in resp.json()["papers"]]
     assert titles == ["Second Paper"]  # 仅笔记命中也返回
 
+    # bob 搜同一关键词：alice 的私有笔记不参与命中
+    resp = await client.get(
+        f"/api/projects/{project_id}/search?q=量子退火&mode=keyword", headers=bob
+    )
+    assert resp.json()["papers"] == []
 
-async def test_obsidian_export_includes_notes_section(client):
+
+async def test_obsidian_export_includes_own_notes_section(client):
     project_id, alice, bob, ids = await _setup(client)
     await client.post(
         f"/api/papers/{ids['p1']}/notes", json={"content": "导出验证用笔记"}, headers=alice
@@ -173,3 +232,9 @@ async def test_obsidian_export_includes_notes_section(client):
     # 无笔记的论文页不加小节
     second_md = zf.read("papers/second-paper.md").decode("utf-8")
     assert "## 笔记" not in second_md
+
+    # bob 导出：alice 的笔记不出现（只导出请求者本人的）
+    resp = await client.get(f"/api/projects/{project_id}/export/obsidian", headers=bob)
+    zf_bob = zipfile.ZipFile(io.BytesIO(resp.content))
+    bob_md = zf_bob.read("papers/agent-planning-with-rl.md").decode("utf-8")
+    assert "## 笔记" not in bob_md

--- a/src/backend/tests/test_paper_figures.py
+++ b/src/backend/tests/test_paper_figures.py
@@ -222,7 +222,7 @@ async def test_figures_api_extract_annotate_idempotent_force(client):
     assert resp.status_code == 200 and resp.json()["figures"] == figures
     assert await _librarian_usage_count() == 2
 
-    # 非项目成员 404
+    # 非项目成员也可读（P5c：库成员论文全员可读；extract 已有 figures 幂等直返）
     other = await register_and_login(client, email="fig-outsider@example.com")
     other_headers = {"Authorization": f"Bearer {other}"}
     for method, url in (
@@ -231,7 +231,7 @@ async def test_figures_api_extract_annotate_idempotent_force(client):
         ("POST", f"/api/papers/{paper_id}/extract-figures"),
     ):
         resp = await client.request(method, url, headers=other_headers)
-        assert resp.status_code == 404, url
+        assert resp.status_code == 200, url
 
 
 # ---- annotate_figures：fake 路径 + 失败降级 ----

--- a/src/backend/tests/test_paper_reading.py
+++ b/src/backend/tests/test_paper_reading.py
@@ -78,12 +78,13 @@ async def test_get_pdf_404_then_serves_file(client):
     assert resp.headers["content-type"] == "application/pdf"
     assert resp.content == content
 
-    # 非项目成员 404
+    # 非项目成员也可读（P5c：方向库全实验室可读，PDF 原文免费共享）
     other = await register_and_login(client, email="outsider@example.com")
     resp = await client.get(
         f"/api/papers/{paper_id}/pdf", headers={"Authorization": f"Bearer {other}"}
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.content == content
 
 
 @respx.mock
@@ -176,14 +177,14 @@ async def test_chat_sse_stream_and_usage(client):
         assert str(rows[0].project_id) == project_id
         assert rows[0].completion_tokens > 0
 
-    # 非项目成员 404
+    # 非项目成员也可伴读（P5c：库成员论文全员可读；费用记个人、无课题上下文）
     other = await register_and_login(client, email="chat-outsider@example.com")
     resp = await client.post(
         f"/api/papers/{paper_id}/chat",
         json={"question": "hi"},
         headers={"Authorization": f"Bearer {other}"},
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200
 
 
 async def test_chat_with_referenced_papers(client):

--- a/src/backend/tests/test_personal_wiki.py
+++ b/src/backend/tests/test_personal_wiki.py
@@ -1,0 +1,325 @@
+"""个人版 wiki 按需编译 + 三层 wiki 解析 + 书架快照手动刷新（P5b）。
+
+LLM 走 core/llm 的 fake provider（POLARIS_LLM_FAKE_FALLBACK=1，conftest）。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.llm_config import LLMUsage
+from app.models.paper import Paper
+from app.models.topic_shelf import TopicPaper
+from tests.conftest import add_paper, membership_of, register_and_login
+
+
+async def _setup(client, *, name="pw-proj", email="alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_pool_only_paper(**fields) -> str:
+    """建一篇「在池但不在任何库」的论文（个人补充入库的典型状态）。"""
+    async with get_sessionmaker()() as session:
+        paper = Paper(**({"title": "Pool Only Paper", "source": "manual"} | fields))
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def _entry_of(paper_id: str) -> UserLibraryEntry | None:
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one_or_none()
+
+
+# ---- 个人版 wiki 编译 ----
+
+
+async def test_compile_personal_wiki_writes_entry_and_bills_user(client):
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_pool_only_paper(
+        title="Personal Supplement Paper", abstract="Outside any library."
+    )
+
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki", json={"topic_id": project_id}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["paper_id"] == paper_id
+    assert "TL;DR" in body["wiki_content"]  # fake librarian 的通用模板输出
+    assert body["model"]
+
+    # 结果写进本人个人库条目（无条目自动建）
+    entry = await _entry_of(paper_id)
+    assert entry is not None
+    assert entry.wiki_content == body["wiki_content"]
+    assert entry.saved is False  # 只写 wiki，不代收藏
+
+    # 用量归因：user + topic（stage=librarian 至少一条）
+    async with get_sessionmaker()() as session:
+        usages = (
+            (
+                await session.execute(
+                    select(LLMUsage).where(LLMUsage.stage == "librarian")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert usages, "librarian 编译必须记账"
+        assert all(u.user_id is not None for u in usages)
+        assert any(str(u.project_id) == project_id for u in usages)
+
+
+async def test_compile_personal_wiki_without_topic(client):
+    """不带 topic_id 也能编译（纯通用模板，归因只挂用户）。"""
+    _, headers = await _setup(client, name="pw-no-topic", email="carol@example.com")
+    paper_id = await _seed_pool_only_paper(title="No Topic Paper")
+
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    entry = await _entry_of(paper_id)
+    assert entry is not None and entry.wiki_content
+
+
+async def test_compile_personal_wiki_conflicts_and_missing(client):
+    project_id, headers = await _setup(client, name="pw-conflict", email="dave@example.com")
+    # 已有库版 wiki → 409（应直接展示库版）
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Compiled In Library",
+            status="compiled",
+            wiki_content="# 库版",
+        )
+        await session.commit()
+        compiled_id = str(paper.id)
+    resp = await client.post(
+        f"/api/papers/{compiled_id}/personal-wiki", json={}, headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "LIBRARY_WIKI_EXISTS"
+
+    # 池中不存在 → 404
+    resp = await client.post(
+        f"/api/papers/{uuid.uuid4()}/personal-wiki", json={}, headers=headers
+    )
+    assert resp.status_code == 404
+
+    # topic_id 不是自己的课题 → 404
+    outsider_project, _ = await _setup(client, name="pw-other", email="erin@example.com")
+    paper_id = await _seed_pool_only_paper(title="Foreign Topic Paper")
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki",
+        json={"topic_id": outsider_project},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+async def test_compile_personal_wiki_in_progress_409(client, monkeypatch):
+    """并发防抖：同一 paper × user 编译进行中时，二次请求 409 COMPILE_IN_PROGRESS。"""
+    import asyncio
+
+    from app.services import personal_wiki as pw
+    from app.services.wiki_compile import CompiledWiki
+
+    _, headers = await _setup(client, name="pw-race", email="race@example.com")
+    paper_id = await _seed_pool_only_paper(title="Race Paper")
+
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def slow_compile(paper, **kwargs):
+        started.set()
+        await release.wait()
+        return CompiledWiki(content="# 慢编译", model="fake")
+
+    monkeypatch.setattr(pw, "compile_paper", slow_compile)
+    first = asyncio.create_task(
+        client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    )
+    await asyncio.wait_for(started.wait(), timeout=5)
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "COMPILE_IN_PROGRESS"
+    release.set()
+    resp = await asyncio.wait_for(first, timeout=5)
+    assert resp.status_code == 200, resp.text
+    entry = await _entry_of(paper_id)
+    assert entry is not None and entry.wiki_content == "# 慢编译"
+
+
+# ---- 三层 wiki 解析（库版实时 > 个人版 > 快照） ----
+
+
+async def test_shelf_resolves_personal_wiki_between_live_and_snapshot(client):
+    project_id, headers = await _setup(client, name="tier-proj", email="frank@example.com")
+    paper_id = await _seed_pool_only_paper(title="Tiered Paper", arxiv_id="2403.00003")
+
+    # 入架（此时无任何 wiki）→ none
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["wiki_source"] == "none"
+
+    # 编译个人版 → personal
+    resp = await client.post(f"/api/papers/{paper_id}/personal-wiki", json={}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    personal_wiki = resp.json()["wiki_content"]
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "personal"
+    assert item["wiki_content"] == personal_wiki
+
+    # 手动给书架行塞一份快照：个人版仍然优先于快照
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        row.wiki_snapshot = "# 旧快照"
+        await session.commit()
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["items"][0]["wiki_source"] == "personal"
+
+    # 库后来收录并编译 → 库版实时优先
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import LibraryPaper
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        session.add(
+            LibraryPaper(
+                library_id=library.id,
+                paper_id=uuid.UUID(paper_id),
+                status="compiled",
+                wiki_content="# 库版解读",
+            )
+        )
+        await session.commit()
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "live"
+    assert item["wiki_content"] == "# 库版解读"
+
+    # 个人版属于本人：其他成员（无个人条目）在库版消失后回退快照
+    bob = await register_and_login(client, email="tier-bob@example.com")
+    resp = await client.post(
+        f"/api/projects/{project_id}/members",
+        json={"email": "tier-bob@example.com", "role": "member"},
+        headers=headers,
+    )
+    assert resp.status_code == 204
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        await session.delete(membership)
+        await session.commit()
+    resp = await client.get(
+        f"/api/projects/{project_id}/shelf", headers={"Authorization": f"Bearer {bob}"}
+    )
+    item = resp.json()["items"][0]
+    assert item["wiki_source"] == "snapshot"
+    assert item["wiki_content"] == "# 旧快照"
+
+
+# ---- 书架快照手动刷新 ----
+
+
+async def test_refresh_snapshot_from_live_and_personal(client):
+    project_id, headers = await _setup(client, name="snap-proj", email="grace@example.com")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Refreshable Paper",
+            status="compiled",
+            wiki_content="# 第一版",
+        )
+        await session.commit()
+        paper_id = str(paper.id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    first_snapshot_at = resp.json()["snapshot_at"]
+
+    # 库版重编译后手动刷新 → 快照跟上新库版
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        membership.wiki_content = "# 第二版"
+        await session.commit()
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        assert row.wiki_snapshot == "# 第二版"
+        assert row.snapshot_at is not None
+    assert resp.json()["snapshot_at"] >= first_snapshot_at
+
+    # 库版消失、只剩个人版 → 刷新拷个人版
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
+        membership.wiki_content = None
+        await session.commit()
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        entry.wiki_content = "# 个人版"
+        await session.commit()
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 200
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalar_one()
+        assert row.wiki_snapshot == "# 个人版"
+
+
+async def test_refresh_snapshot_no_source_409(client):
+    project_id, headers = await _setup(client, name="snap-none", email="henry@example.com")
+    paper_id = await _seed_pool_only_paper(title="Sourceless Paper")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    # 入架同步建了个人库条目但无 wiki → 仍然无源
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{paper_id}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "NO_WIKI_SOURCE"
+
+    # 书架上没有的论文 → 404
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{uuid.uuid4()}/refresh-snapshot", headers=headers
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_pool_paper_access.py
+++ b/src/backend/tests/test_pool_paper_access.py
@@ -1,0 +1,144 @@
+"""池级可见性（P5b 修复）：个人补充入库（零库成员行）的论文，
+本人经书架 / 个人库可读（详情 / 子资源 / 个人 wiki 全链路）；
+他人（未入架未收藏）与写库端点维持 404。"""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper
+from tests.conftest import register_and_login
+
+RECT = {"x0": 0.1, "y0": 0.1, "x1": 0.5, "y1": 0.12}
+
+
+async def _setup(client, *, name="pool-proj", email="pool-alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_pool_only_paper(**fields) -> str:
+    async with get_sessionmaker()() as session:
+        paper = Paper(**({"title": "Pool Access Paper", "source": "manual"} | fields))
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def test_shelved_pool_paper_full_reading_chain(client):
+    """个人补充论文（零库成员行）入架后：详情 / 笔记 / 划线 / 图片 /
+    个人库埋点 / 个人 wiki 全链路对本人可用。"""
+    project_id, headers = await _setup(client)
+    paper_id = await _seed_pool_only_paper(
+        title="Personally Supplemented", abstract="No library membership."
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+
+    # 详情：course 上下文 = 入架课题；无判断字段但形状完整
+    resp = await client.get(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    detail = resp.json()
+    assert detail["project_id"] == project_id
+    assert detail["status"] == "included"
+    assert detail["relevance_score"] is None
+    assert detail["wiki_content"] is None and detail["has_wiki"] is False
+    assert detail["concepts"] == []
+
+    # 子资源：PDF（可见但无文件 → PDF_NOT_AVAILABLE 而非 PAPER_NOT_FOUND）/ 图片
+    resp = await client.get(f"/api/papers/{paper_id}/pdf", headers=headers)
+    assert resp.status_code == 404 and resp.json()["detail"] == "PDF_NOT_AVAILABLE"
+    resp = await client.get(f"/api/papers/{paper_id}/figures", headers=headers)
+    assert resp.status_code == 200 and resp.json() == []
+
+    # 笔记 / 划线
+    resp = await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "库外论文的笔记"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/papers/{paper_id}/notes", headers=headers)
+    assert [n["content"] for n in resp.json()] == ["库外论文的笔记"]
+    resp = await client.post(
+        f"/api/papers/{paper_id}/highlights",
+        json={"page": 1, "rects": [RECT], "selected_text": "pool highlight"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/papers/{paper_id}/highlights", headers=headers)
+    assert len(resp.json()) == 1
+
+    # 个人状态 + 个人库埋点 / 收藏态
+    resp = await client.put(
+        f"/api/papers/{paper_id}/my-meta", json={"starred": True}, headers=headers
+    )
+    assert resp.status_code == 200 and resp.json()["starred"] is True
+    resp = await client.post(
+        "/api/me/library/visits", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/me/library/state?paper_id={paper_id}", headers=headers)
+    assert resp.status_code == 200 and resp.json()["saved"] is True  # 入架已代收藏
+
+    # 个人 wiki 编译后，书架解析出 personal
+    resp = await client.post(
+        f"/api/papers/{paper_id}/personal-wiki", json={"topic_id": project_id}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.get(f"/api/projects/{project_id}/shelf", headers=headers)
+    assert resp.json()["items"][0]["wiki_source"] == "personal"
+
+
+async def test_pool_paper_visible_via_personal_library_after_shelf_removal(client):
+    """移出书架后个人库条目仍在 → 仍可读，课题上下文为空。"""
+    project_id, headers = await _setup(client, name="pool-proj-2", email="pool-bob@example.com")
+    paper_id = await _seed_pool_only_paper(title="Entry Only Paper", arxiv_id="2405.00005")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers)
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] is None  # 无课题上下文（仅个人库可达）
+    resp = await client.get(f"/api/papers/{paper_id}/notes", headers=headers)
+    assert resp.status_code == 200
+
+
+async def test_pool_paper_hidden_from_others_and_write_paths(client):
+    project_id, headers = await _setup(client, name="pool-proj-3", email="pool-carol@example.com")
+    paper_id = await _seed_pool_only_paper(title="Private Chain Paper")
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    assert resp.status_code == 201
+
+    # 其他用户（未入架未收藏）：详情与子资源一律 404
+    stranger = await register_and_login(client, email="pool-stranger@example.com")
+    sh = {"Authorization": f"Bearer {stranger}"}
+    for url in (
+        f"/api/papers/{paper_id}",
+        f"/api/papers/{paper_id}/notes",
+        f"/api/papers/{paper_id}/highlights",
+        f"/api/papers/{paper_id}/figures",
+        f"/api/papers/{paper_id}/pdf",
+    ):
+        resp = await client.get(url, headers=sh)
+        assert resp.status_code == 404, url
+
+    # 写库成员行的端点不开池级兜底：对本人也维持 404（应走个人 wiki / 书架操作）
+    resp = await client.patch(
+        f"/api/papers/{paper_id}", json={"status": "excluded"}, headers=headers
+    )
+    assert resp.status_code == 404
+    resp = await client.post(f"/api/papers/{paper_id}/recompile", headers=headers)
+    assert resp.status_code == 404
+    resp = await client.delete(f"/api/papers/{paper_id}", headers=headers)
+    assert resp.status_code == 404
+    async with get_sessionmaker()() as session:
+        assert await session.get(Paper, uuid.UUID(paper_id)) is not None

--- a/src/backend/tests/test_shared_libraries.py
+++ b/src/backend/tests/test_shared_libraries.py
@@ -1,0 +1,181 @@
+"""共享方向库（P5c）：库读 API 全员可读（非成员 200）、管理端点仍限成员、
+库成员论文阅读链路对全员开放（读免费共享，写/管理不放开）。"""
+
+from app.core.db import get_sessionmaker
+from tests.conftest import add_concept, add_paper, register_and_login
+
+
+async def _setup_library(client, *, email="lib-owner@example.com", name="共享方向"):
+    """建课题（隐式库）+ 一篇已编译论文 + 一个概念。
+
+    返回 (project_id, headers, paper_id, library_id)。
+    """
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            title="Shared Library Paper",
+            abstract="An abstract about agents.",
+            authors=[{"name": "Alice"}],
+            status="compiled",
+            relevance_score=0.9,
+            wiki_content="# 解读\n\n这篇论文讲 [[Agent]]。",
+        )
+        await add_paper(
+            session,
+            project_id=project_id,
+            title="Excluded Paper",
+            status="excluded",
+            trash_reason="manual",
+        )
+        await add_concept(
+            session,
+            project_id=project_id,
+            name="Agent",
+            slug="agent",
+            category="method",
+            definition="能自主行动的智能体。",
+        )
+        await session.commit()
+        paper_id = str(paper.id)
+    resp = await client.get("/api/libraries", headers=headers)
+    assert resp.status_code == 200, resp.text
+    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+    return project_id, headers, paper_id, library_id
+
+
+async def _stranger(client, email="lib-stranger@example.com"):
+    token = await register_and_login(client, email=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_library_list_and_detail_readable_by_all(client):
+    project_id, headers, _paper_id, library_id = await _setup_library(client)
+    stranger = await _stranger(client)
+
+    # 列表：全员可读；is_mine 只对背后课题成员为 True
+    resp = await client.get("/api/libraries", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    row = next(x for x in resp.json() if x["id"] == library_id)
+    assert row["is_mine"] is False
+    assert row["name"] == "共享方向"
+    assert row["paper_count"] == 1  # excluded 不计入
+    assert row["concept_count"] == 1
+    resp = await client.get("/api/libraries", headers=headers)
+    assert next(x for x in resp.json() if x["id"] == library_id)["is_mine"] is True
+
+    # 详情：非成员 200
+    resp = await client.get(f"/api/libraries/{library_id}", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    detail = resp.json()
+    assert detail["project_id"] == project_id
+    assert detail["is_mine"] is False and detail["paper_count"] == 1
+
+
+async def test_library_papers_concepts_search_readable_by_all(client):
+    _project_id, _headers, paper_id, library_id = await _setup_library(
+        client, email="lib-owner2@example.com"
+    )
+    stranger = await _stranger(client, email="lib-stranger2@example.com")
+
+    # 论文列表：缺省只列达标论文（excluded 不出现）
+    resp = await client.get(f"/api/libraries/{library_id}/papers", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["id"] == paper_id
+    assert body["items"][0]["has_wiki"] is True
+    # 关键词过滤
+    resp = await client.get(f"/api/libraries/{library_id}/papers?q=nothing", headers=stranger)
+    assert resp.json()["total"] == 0
+
+    # 概念列表
+    resp = await client.get(f"/api/libraries/{library_id}/concepts", headers=stranger)
+    assert resp.status_code == 200
+    assert [c["name"] for c in resp.json()] == ["Agent"]
+    concept_id = resp.json()[0]["id"]
+
+    # 概念详情（id 级端点同样全员可读）
+    resp = await client.get(f"/api/concepts/{concept_id}", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Agent"
+
+    # 库内检索（关键词）
+    resp = await client.get(f"/api/libraries/{library_id}/search?q=agent", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["mode_used"] == "keyword"
+    assert [p["id"] for p in body["papers"]] == [paper_id]
+    assert [c["name"] for c in body["concepts"]] == ["Agent"]
+
+    # 不存在的库 → 404
+    resp = await client.get(
+        "/api/libraries/00000000-0000-0000-0000-000000000000", headers=stranger
+    )
+    assert resp.status_code == 404
+
+
+async def test_library_member_paper_readable_by_all(client):
+    """阅读链路扩展：任何库的成员论文全员可读（详情带库版 wiki；无课题上下文）。"""
+    _project_id, _headers, paper_id, _library_id = await _setup_library(
+        client, email="lib-owner3@example.com"
+    )
+    stranger = await _stranger(client, email="lib-stranger3@example.com")
+
+    resp = await client.get(f"/api/papers/{paper_id}", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    detail = resp.json()
+    assert detail["project_id"] is None  # 非成员读共享库论文：无课题上下文
+    assert detail["status"] == "compiled"
+    assert detail["wiki_content"].startswith("# 解读")
+    # 子资源：图片列表可读；PDF 未落盘 → PDF_NOT_AVAILABLE（而非 PAPER_NOT_FOUND）
+    resp = await client.get(f"/api/papers/{paper_id}/figures", headers=stranger)
+    assert resp.status_code == 200 and resp.json() == []
+    resp = await client.get(f"/api/papers/{paper_id}/pdf", headers=stranger)
+    assert resp.status_code == 404 and resp.json()["detail"] == "PDF_NOT_AVAILABLE"
+    # 个人维度的读写（笔记/星标）归个人，允许
+    resp = await client.get(f"/api/papers/{paper_id}/notes", headers=stranger)
+    assert resp.status_code == 200 and resp.json() == []
+    resp = await client.put(
+        f"/api/papers/{paper_id}/my-meta", json={"starred": True}, headers=stranger
+    )
+    assert resp.status_code == 200 and resp.json()["starred"] is True
+
+
+async def test_library_write_and_manage_still_member_only(client):
+    """写/管理端点保持课题成员校验：非成员一律 404。"""
+    project_id, _headers, paper_id, _library_id = await _setup_library(
+        client, email="lib-owner4@example.com"
+    )
+    stranger = await _stranger(client, email="lib-stranger4@example.com")
+
+    # 库成员行写路径（人工纳入/删除/召回/标签）
+    resp = await client.patch(
+        f"/api/papers/{paper_id}", json={"status": "excluded"}, headers=stranger
+    )
+    assert resp.status_code == 404
+    resp = await client.delete(f"/api/papers/{paper_id}", headers=stranger)
+    assert resp.status_code == 404
+    resp = await client.post(f"/api/papers/{paper_id}/restore", headers=stranger)
+    assert resp.status_code == 404
+    resp = await client.put(
+        f"/api/papers/{paper_id}/tags", json={"names": ["x"]}, headers=stranger
+    )
+    assert resp.status_code == 404
+
+    # project 作用域管理端点
+    for method, url, payload in (
+        ("GET", f"/api/projects/{project_id}/papers", None),
+        ("POST", f"/api/projects/{project_id}/papers/batch-delete", {"paper_ids": [paper_id]}),
+        ("GET", f"/api/projects/{project_id}/concepts", None),
+        ("POST", f"/api/projects/{project_id}/concepts/relink", None),
+        ("GET", f"/api/projects/{project_id}/ingest/state", None),
+        ("POST", f"/api/projects/{project_id}/ingest", {"mode": "bootstrap"}),
+    ):
+        resp = await client.request(method, url, json=payload, headers=stranger)
+        assert resp.status_code == 404, url

--- a/src/backend/tests/test_wiki_api.py
+++ b/src/backend/tests/test_wiki_api.py
@@ -132,12 +132,13 @@ async def test_paper_detail_and_manual_status(client):
     )
     assert resp.status_code == 422  # 只允许 included|excluded
 
-    # 非项目成员 → 404
+    # 非项目成员也可读（P5c：库成员论文全员可读），但无课题上下文
     other = await register_and_login(client, email="mallory@example.com")
     resp = await client.get(
         f"/api/papers/{ids['p1']}", headers={"Authorization": f"Bearer {other}"}
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] is None
 
 
 async def test_concepts_list_and_detail(client):

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -27,9 +27,9 @@ interface NavEntry {
   en: string;
 }
 
-// 实验室级导航：跨课题的公共资产（文献追踪未来升级为实验室级文献库，导航先归位）
+// 实验室级导航：跨课题的公共资产（P5c 起为共享方向文献库列表）
 const NAV_LAB: NavEntry[] = [
-  { sub: 'wiki', icon: 'book', zh: '文献追踪', en: 'Research Wiki' },
+  { to: '/libraries', icon: 'book', zh: '文献库', en: 'Libraries' },
 ];
 
 const NAV_MAIN: NavEntry[] = [
@@ -64,13 +64,15 @@ function crumbFor(pathname: string): [string, string] {
   if (p.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];
   if (p === '/voyages') return ['Polaris', tr('任务', 'Tasks')];
   if (p.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
-  if (p.startsWith('/papers/')) return [tr('文献追踪', 'Research Wiki'), tr('论文阅读', 'Paper reading')];
+  if (p.startsWith('/papers/')) return [tr('文献库', 'Libraries'), tr('论文阅读', 'Paper reading')];
+  if (p === '/libraries') return [tr('实验室', 'Lab'), tr('文献库', 'Libraries')];
+  if (p.startsWith('/libraries/')) return [tr('文献库', 'Libraries'), tr('库详情', 'Library detail')];
   if (p.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
   if (p.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];
   if (p.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
   if (p.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
   const table: Record<string, [string, string]> = {
-    '/wiki': [tr('实验室', 'Lab'), tr('文献追踪', 'Research Wiki')],
+    '/wiki': [tr('实验室', 'Lab'), tr('文献库', 'Libraries')],
     '/research': [tr('课题研究', 'Topic'), tr('相关研究', 'Related Work')],
     '/forge': ['Stage 01', tr('想法生成', 'Idea Forge')],
     '/review': ['Stage 02', tr('想法评审', 'Idea Review')],

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -107,7 +107,8 @@ export const router = createBrowserRouter([
             element: <TopicScope />,
             children: [
               { index: true, element: page(() => import('../features/dashboard/DashboardPage'), 'DashboardPage') },
-              { path: 'wiki', element: page(() => import('../features/wiki/WikiPage'), 'WikiPage') },
+              // 旧文献追踪路径 → 该课题隐式库的 /libraries/:id（保留 ?paper= 等深链）
+              { path: 'wiki', element: page(() => import('../features/libraries/TopicWikiRedirect'), 'TopicWikiRedirect') },
               { path: 'research', element: page(() => import('../features/research/ResearchPage'), 'ResearchPage') },
               { path: 'forge', element: page(() => import('../features/forge/ForgePage'), 'ForgePage') },
               { path: 'review', element: page(() => import('../features/review/ReviewPage'), 'ReviewPage') },
@@ -141,6 +142,9 @@ export const router = createBrowserRouter([
       { path: 'projects/:id', element: page(() => import('../features/projects/ProjectDetailPage'), 'ProjectDetailPage') },
       { path: 'join/:token', element: page(() => import('../features/projects/JoinPage'), 'JoinPage') },
       { path: 'library', element: page(() => import('../features/library/LibraryPage'), 'LibraryPage') },
+      // 实验室区：共享方向文献库（全实验室可读，无需课题）
+      { path: 'libraries', element: page(() => import('../features/libraries/LibrariesPage'), 'LibrariesPage') },
+      { path: 'libraries/:id', element: page(() => import('../features/libraries/LibraryDetailPage'), 'LibraryDetailPage') },
       // MCP 说明已并入设置页签，旧链接重定向
       { path: 'mcp-tools', element: <Navigate to="/settings?tab=mcp" replace /> },
       { path: 'skills', element: page(() => import('../features/skills/SkillsPage'), 'SkillsPage') },

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -11,15 +11,21 @@ import { gateTitle, gateDesc, gateKindLabel } from '../../components/ui/GateCard
 import { useShell } from '../../app/AppShell';
 import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
+import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { api, type ActivityRead, type GateRead, type StatsRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { compositeOf } from '../forge/ideaShared';
 
 /** 端到端流水线各阶段的真实计数（stats 未就绪时显示 —）；path 带当前课题前缀；
     stuckKey = 当前卡住（还没有产出）的阶段，进度漏斗高亮它。 */
-function buildPipelineStages(stats: StatsRead | undefined, pid: string | null, stuckKey: string | null): PipelineStage[] {
+function buildPipelineStages(
+  stats: StatsRead | undefined,
+  pid: string | null,
+  stuckKey: string | null,
+  wikiPath: string,
+): PipelineStage[] {
   const stages: PipelineStage[] = [
-    { key: 'wiki', path: topicPath(pid, 'wiki'), no: '00', icon: 'book', zh: '文献追踪', en: 'Research Wiki', count: stats?.papers_total ?? null },
+    { key: 'wiki', path: wikiPath, no: '00', icon: 'book', zh: '文献库', en: 'Library', count: stats?.papers_total ?? null },
     { key: 'forge', path: topicPath(pid, 'forge'), no: '01', icon: 'bulb', zh: '想法生成', en: 'Idea Forge', count: stats?.ideas_candidate ?? null },
     { key: 'review', path: topicPath(pid, 'review'), no: '02', icon: 'scale', zh: '想法评审', en: 'Idea Review', count: stats?.ideas_under_review ?? null },
     {
@@ -63,7 +69,12 @@ interface PipelineProgress {
   hasManuscripts: boolean;
 }
 
-function buildNextSteps(progress: PipelineProgress, pid: string | null, hasKeywords: boolean): NextStep[] {
+function buildNextSteps(
+  progress: PipelineProgress,
+  pid: string | null,
+  hasKeywords: boolean,
+  wikiIngestPath: string,
+): NextStep[] {
   const { hasPapers, hasIdeas, hasExperiments, hasManuscripts } = progress;
   return [
     {
@@ -73,7 +84,7 @@ function buildNextSteps(progress: PipelineProgress, pid: string | null, hasKeywo
       en: 'Set up literature tracking and run the initial library build',
       actionZh: hasKeywords ? '去启动初始建库' : '先去课题设置里配置关键词',
       actionEn: hasKeywords ? 'Run the initial build' : 'Configure terms in topic settings first',
-      path: hasKeywords ? topicPath(pid, 'wiki?tab=ingest') : `/projects/${pid ?? ''}`,
+      path: hasKeywords ? wikiIngestPath : `/projects/${pid ?? ''}`,
     },
     {
       key: 'ideas',
@@ -440,6 +451,8 @@ export function DashboardPage() {
   const navigate = useNavigate();
   const { pendingGates, gatesError, openGates } = useShell();
   const { currentProject, currentProjectId } = useProject();
+  // 课题隐式库（文献库入口链接用；列表未就绪时退回旧 /wiki 路径由重定向兜底）
+  const topicLib = useTopicLibrary(currentProjectId);
 
   const statsQuery = useQuery({
     queryKey: ['stats', currentProjectId],
@@ -495,12 +508,22 @@ export function DashboardPage() {
               : null;
 
   const includeTerms = currentProject?.definition?.keywords?.include ?? [];
-  const nextSteps = buildNextSteps(progress, currentProjectId, includeTerms.length > 0);
+  const nextSteps = buildNextSteps(
+    progress,
+    currentProjectId,
+    includeTerms.length > 0,
+    topicLib ? libraryPath(topicLib.id, '?tab=ingest') : topicPath(currentProjectId, 'wiki?tab=ingest'),
+  );
   // 全流程都有产出 → 整卡隐藏
   const showChecklist = checklistReady && nextSteps.some((s) => !s.done);
 
   const statCards = buildStatCards(stats, pendingGates.length);
-  const stages = buildPipelineStages(stats, currentProjectId, stuckKey);
+  const stages = buildPipelineStages(
+    stats,
+    currentProjectId,
+    stuckKey,
+    topicLib ? libraryPath(topicLib.id) : topicPath(currentProjectId, 'wiki'),
+  );
 
   return (
     <div className="page fadeup">

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -1,0 +1,166 @@
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '../../components/ui/Icon';
+import { PageHead } from '../../components/ui/PageHead';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { fmtTime } from '../../lib/format';
+import type { DirectionLibrarySummary } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { useLibraries, libraryPath } from './hooks';
+
+/* ============================================================
+   /libraries — 文献库列表（实验室区，P5c）
+   卡片流：库名 / 方向陈述 / 论文·概念数 / 最近更新；
+   「我的课题的库」有标识；点击进 /libraries/:id 详情。
+   ============================================================ */
+
+function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: () => void }) {
+  const updated = lib.last_compiled_at ?? lib.last_synced_at;
+  return (
+    <div
+      className="card hoverable"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      style={{ padding: '18px 20px', display: 'flex', flexDirection: 'column', gap: 10, cursor: 'pointer' }}
+    >
+      <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+        <span
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            color: 'var(--accent)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <Icon name="book" size={17} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="row gap8">
+            <span style={{ fontSize: 14.5, fontWeight: 680, lineHeight: 1.3 }} title={lib.name}>
+              {lib.name}
+            </span>
+            {lib.is_mine && (
+              <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', flexShrink: 0 }}>
+                {tr('我的课题', 'My topic')}
+              </span>
+            )}
+          </div>
+        </div>
+        <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0, marginTop: 4 }} />
+      </div>
+      <div
+        style={{
+          fontSize: 12.5,
+          lineHeight: 1.55,
+          color: 'var(--text-3)',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          minHeight: 38,
+        }}
+      >
+        {lib.statement ?? tr('这个方向还没有写一句话介绍。', 'No statement for this direction yet.')}
+      </div>
+      <div className="row gap10" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+        <span className="row gap6">
+          <Icon name="file" size={12} />
+          {tr(`${lib.paper_count} 篇论文`, `${lib.paper_count} papers`)}
+        </span>
+        <span className="row gap6">
+          <Icon name="layers" size={12} />
+          {tr(`${lib.concept_count} 个概念`, `${lib.concept_count} concepts`)}
+        </span>
+        <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)' }}>
+          {updated ? `${tr('更新于', 'Updated')} ${fmtTime(updated)}` : tr('还没有内容', 'Empty')}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function LibrariesPage() {
+  const navigate = useNavigate();
+  const { data, isLoading, isError, refetch } = useLibraries();
+  const libraries = data ?? [];
+  // 我的课题的库排前面，其余按名称
+  const sorted = [...libraries].sort(
+    (a, b) => Number(b.is_mine) - Number(a.is_mine) || a.name.localeCompare(b.name),
+  );
+
+  return (
+    <div className="page fadeup" style={{ maxWidth: 1200 }}>
+      <PageHead
+        eyebrow={tr('实验室', 'Lab')}
+        title={tr('文献库', 'Libraries')}
+        sub={tr(
+          '按研究方向维护的公共文献库：解读、概念和原文对所有人开放，随便逛。',
+          'Shared per-direction libraries — wikis, concepts and full texts are open to everyone.',
+        )}
+      />
+
+      {isLoading ? (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gap: 14,
+          }}
+        >
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="skel" style={{ height: 150, borderRadius: 14 }} />
+          ))}
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载文献库列表', 'Failed to load libraries')}
+          desc={tr('后端不可用或接口尚未就绪。', 'Backend unavailable or API not ready.')}
+          action={
+            <button className="btn btn-soft sm" onClick={() => void refetch()}>
+              {tr('重试', 'Retry')}
+            </button>
+          }
+        />
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          icon="book"
+          title={tr('还没有文献库', 'No libraries yet')}
+          desc={tr(
+            '创建课题后会自动生成对应方向的文献库；先去建一个课题吧。',
+            'A direction library is created with each topic — create a topic first.',
+          )}
+          action={
+            <button className="btn btn-primary sm" onClick={() => navigate('/projects/new')}>
+              <Icon name="plus" size={13} />
+              {tr('新建课题', 'New topic')}
+            </button>
+          }
+        />
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gap: 14,
+          }}
+        >
+          {sorted.map((lib) => (
+            <LibraryCard key={lib.id} lib={lib} onOpen={() => navigate(libraryPath(lib.id))} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
+import { api, type PaperRead, type PaperSort } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { ConceptsTab } from '../wiki/ConceptsTab';
+import { SearchInput, useDebounced } from '../wiki/shared';
+
+/* ============================================================
+   共享文献库只读浏览（P5c 非成员视角）：
+   论文（列表 + 检索 + 详情解读）/ 概念 两个页签，全部走 /libraries 读端点；
+   没有任何管理入口，收藏/笔记等个人操作去阅读页做。
+   ============================================================ */
+
+type BrowseTab = 'papers' | 'concepts';
+type SearchScope = 'keyword' | 'semantic';
+
+const PAGE_SIZE = 20;
+
+function authorsLine(p: PaperRead): string {
+  return (p.authors ?? [])
+    .map((a) => (typeof a === 'string' ? a : a.name))
+    .filter(Boolean)
+    .join(', ');
+}
+
+function PaperRow({ p, active, onClick }: { p: PaperRead; active: boolean; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        padding: '11px 16px',
+        cursor: 'pointer',
+        borderBottom: '0.5px solid var(--border)',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        borderLeft: active ? '2px solid var(--accent)' : '2px solid transparent',
+        transition: 'background 0.12s',
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
+      <div className="row gap8" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-3)' }}>
+        {p.has_wiki && (
+          <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+            <Icon name="sparkle" size={10} />
+            wiki
+          </span>
+        )}
+        <span
+          style={{ flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+          title={authorsLine(p)}
+        >
+          {authorsLine(p)}
+        </span>
+        {p.year !== null && <span className="mono" style={{ flexShrink: 0 }}>{p.year}</span>}
+      </div>
+      {p.tldr && (
+        <div
+          style={{
+            fontSize: 11.5,
+            color: 'var(--text-3)',
+            marginTop: 3,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {p.tldr}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PaperDetailPane({ paperId, onWikiLink }: { paperId: string; onWikiLink: WikiLinkHandler }) {
+  const navigate = useNavigate();
+  const { data: paper, isLoading, isError } = useQuery({
+    queryKey: ['paper', paperId],
+    queryFn: () => api.getPaper(paperId),
+    retry: false,
+  });
+
+  // 正文 ![[fig:N]] 嵌入图（与文献追踪同款渲染；图片端点对全员开放）
+  const figures = usePaperFigures(paper);
+  const renderFigure = useCallback(
+    (n: number) => {
+      const fig = figures.find((f) => f.index === n);
+      return fig && paper ? <FigureEmbed paperId={paper.id} fig={fig} /> : null;
+    },
+    [figures, paper],
+  );
+
+  if (isLoading) return <div className="empty">{tr('加载论文详情…', 'Loading paper…')}</div>;
+  if (isError || !paper) {
+    return (
+      <EmptyState
+        compact
+        icon="x"
+        title={tr('无法加载论文详情', 'Failed to load paper')}
+        desc={tr('后端不可用或该论文不存在。', 'Backend unavailable or the paper does not exist.')}
+      />
+    );
+  }
+
+  const arxivUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : paper.url;
+
+  return (
+    <div className="scroll fadeup" key={paper.id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
+      <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
+        {paper.venue && (
+          <span className="pill sm" style={{ background: 'var(--surface-3)' }}>{paper.venue}</span>
+        )}
+        {paper.year !== null && <span className="pill sm" style={{ background: 'var(--surface-3)' }}>{paper.year}</span>}
+        {arxivUrl && (
+          <a className="pill sm" href={arxivUrl} target="_blank" rel="noreferrer" style={{ background: 'var(--surface-3)' }}>
+            <Icon name="link" size={11} />
+            {paper.arxiv_id ? `arXiv:${paper.arxiv_id}` : tr('原文链接', 'Source')}
+          </a>
+        )}
+      </div>
+      <h1 style={{ fontSize: 21, fontWeight: 680, lineHeight: 1.3, margin: '2px 0 6px', letterSpacing: '-0.01em' }}>
+        {paper.title}
+      </h1>
+      {authorsLine(paper) && (
+        <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 14 }}>{authorsLine(paper)}</div>
+      )}
+      <div className="row gap8" style={{ marginBottom: 18 }}>
+        <button className="btn btn-primary sm" onClick={() => navigate(`/papers/${paper.id}/read`)}>
+          <Icon name="book" size={13} />
+          {tr('打开阅读页', 'Open reading page')}
+        </button>
+        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
+          {tr('原文 PDF、配图、笔记和收藏都在阅读页里', 'PDF, figures, notes and saving live on the reading page')}
+        </span>
+      </div>
+
+      {paper.wiki_content ? (
+        <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
+      ) : (
+        <>
+          {paper.abstract && (
+            <div className="card card-pad" style={{ background: 'var(--surface-2)' }}>
+              <div className="row gap8" style={{ marginBottom: 8 }}>
+                <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
+                <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
+              </div>
+              <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
+            </div>
+          )}
+          <div className="empty" style={{ padding: 20 }}>
+            {tr('这篇还没有中文解读。', 'No wiki for this paper yet.')}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PapersPane({
+  libraryId,
+  selectedId,
+  onSelect,
+  onWikiLink,
+}: {
+  libraryId: string;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onWikiLink: WikiLinkHandler;
+}) {
+  const [qInput, setQInput] = useState('');
+  const q = useDebounced(qInput.trim());
+  const [scope, setScope] = useState<SearchScope>('keyword');
+  const [sort, setSort] = useState<PaperSort>('relevance');
+  const [page, setPage] = useState(1);
+  useEffect(() => setPage(1), [q, sort, scope]);
+
+  const semantic = !!q && scope === 'semantic';
+  const listQuery = useQuery({
+    queryKey: ['lib-papers', libraryId, q, sort, page],
+    queryFn: () =>
+      api.listLibraryPapers(libraryId, { q: q || undefined, sort, page, size: PAGE_SIZE }),
+    enabled: !semantic,
+    retry: false,
+  });
+  const semQuery = useQuery({
+    queryKey: ['lib-search', libraryId, q],
+    queryFn: () => api.searchLibrary(libraryId, { q, mode: 'semantic' }),
+    enabled: semantic,
+    retry: false,
+  });
+
+  const items: PaperRead[] = semantic ? semQuery.data?.papers ?? [] : listQuery.data?.items ?? [];
+  const total = semantic ? items.length : listQuery.data?.total ?? 0;
+  const pages = semantic ? 1 : Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const isLoading = semantic ? semQuery.isLoading : listQuery.isLoading;
+  const isError = semantic ? semQuery.isError : listQuery.isError;
+
+  // 首条自动选中
+  const firstId = items[0]?.id ?? null;
+  useEffect(() => {
+    if (!selectedId && firstId) onSelect(firstId);
+  }, [selectedId, firstId, onSelect]);
+
+  return (
+    <div className="split">
+      <div className="split-list">
+        <div style={{ padding: '12px 14px 10px', borderBottom: '0.5px solid var(--border)' }}>
+          <div className="row gap8">
+            <SearchInput
+              value={qInput}
+              onChange={setQInput}
+              placeholder={tr('搜库内论文：标题 / 摘要 / 解读…', 'Search papers: title / abstract / wiki…')}
+            />
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
+              {total ? tr(`${total} 篇`, `${total}`) : ''}
+            </span>
+          </div>
+          <div className="row gap6 wrap" style={{ marginTop: 10 }}>
+            <span className={`chip${scope === 'keyword' ? ' on' : ''}`} onClick={() => setScope('keyword')}>
+              {tr('关键词', 'Keyword')}
+            </span>
+            <span className={`chip${scope === 'semantic' ? ' on' : ''}`} onClick={() => setScope('semantic')}>
+              {tr('语义检索', 'Semantic')}
+            </span>
+            <span style={{ flex: 1 }} />
+            <span
+              className={`chip${sort === 'relevance' ? ' on' : ''}`}
+              onClick={() => setSort('relevance')}
+            >
+              {tr('按相关性', 'Relevance')}
+            </span>
+            <span
+              className={`chip${sort === '-published_at' ? ' on' : ''}`}
+              onClick={() => setSort('-published_at')}
+            >
+              {tr('按发表时间', 'Newest')}
+            </span>
+          </div>
+        </div>
+
+        <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>
+          {isLoading ? (
+            <div className="empty">{tr('加载论文…', 'Loading papers…')}</div>
+          ) : isError ? (
+            <EmptyState
+              compact
+              icon="x"
+              title={tr('无法加载论文列表', 'Failed to load papers')}
+              desc={tr('后端不可用或接口尚未就绪，稍后重试。', 'Backend unavailable — try again later.')}
+            />
+          ) : items.length === 0 ? (
+            <EmptyState
+              compact
+              icon="book"
+              title={q ? tr('没有匹配的论文', 'No matching papers') : tr('这个库还是空的', 'This library is empty')}
+              desc={q ? tr('换个关键词试试。', 'Try a different keyword.') : undefined}
+            />
+          ) : (
+            items.map((p) => (
+              <PaperRow key={p.id} p={p} active={p.id === selectedId} onClick={() => onSelect(p.id)} />
+            ))
+          )}
+        </div>
+
+        {pages > 1 && (
+          <div className="row gap8" style={{ padding: '8px 14px', borderTop: '0.5px solid var(--border)', justifyContent: 'center' }}>
+            <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((x) => x - 1)}>
+              {tr('上一页', 'Prev')}
+            </button>
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+              {page} / {pages}
+            </span>
+            <button className="btn btn-ghost sm" disabled={page >= pages} onClick={() => setPage((x) => x + 1)}>
+              {tr('下一页', 'Next')}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="split-detail">
+        {selectedId ? (
+          <PaperDetailPane paperId={selectedId} onWikiLink={onWikiLink} />
+        ) : (
+          <div className="empty" style={{ margin: 'auto' }}>
+            {tr('从左侧选择一篇论文', 'Pick a paper from the list')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function LibraryBrowse({ libraryId }: { libraryId: string }) {
+  const [tab, setTab] = useState<BrowseTab>('papers');
+  const [paperId, setPaperId] = useState<string | null>(null);
+  const [conceptId, setConceptId] = useState<string | null>(null);
+  const [pendingConceptName, setPendingConceptName] = useState<string | null>(null);
+
+  // 切库重置选中态
+  useEffect(() => {
+    setPaperId(null);
+    setConceptId(null);
+    setPendingConceptName(null);
+  }, [libraryId]);
+
+  // 深链 ?paper=<id> / ?concept=<名称>（处理后清参数；只读视角忽略其他参数）
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const p = searchParams.get('paper');
+    const c = searchParams.get('concept');
+    if (!p && !c && ![...searchParams.keys()].length) return;
+    if (p) {
+      setPaperId(p);
+      setTab('papers');
+    } else if (c) {
+      setPendingConceptName(c);
+    }
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  // [[概念名]] → 概念 id（库端点解析）
+  const resolveQuery = useQuery({
+    queryKey: ['lib-concept-resolve', libraryId, pendingConceptName],
+    queryFn: () => api.listLibraryConcepts(libraryId, { q: pendingConceptName ?? '' }),
+    enabled: !!pendingConceptName,
+    retry: false,
+  });
+  useEffect(() => {
+    if (!pendingConceptName) return;
+    if (resolveQuery.isError) {
+      toast(tr('概念解析失败（后端不可用）', 'Concept lookup failed (backend unavailable)'), 'error');
+      setPendingConceptName(null);
+      return;
+    }
+    if (!resolveQuery.data) return;
+    const name = pendingConceptName.toLowerCase();
+    const hit = resolveQuery.data.find((c) => c.name.toLowerCase() === name) ?? resolveQuery.data[0];
+    if (hit) {
+      setConceptId(hit.id);
+      setTab('concepts');
+    } else {
+      toast(tr(`概念 ${pendingConceptName} 尚未入库`, `Concept ${pendingConceptName} is not in the library yet`), 'info');
+    }
+    setPendingConceptName(null);
+  }, [pendingConceptName, resolveQuery.data, resolveQuery.isError]);
+
+  return (
+    <>
+      <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
+        <Segmented<BrowseTab>
+          options={[
+            { v: 'papers', label: tr('论文库', 'Papers') },
+            { v: 'concepts', label: tr('概念库', 'Concepts') },
+          ]}
+          value={tab}
+          onChange={setTab}
+        />
+        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
+          {tr('公共文献库 · 所有人可读', 'Shared library · readable by everyone')}
+        </span>
+      </div>
+
+      <div
+        className="card"
+        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+      >
+        {tab === 'papers' ? (
+          <PapersPane
+            libraryId={libraryId}
+            selectedId={paperId}
+            onSelect={setPaperId}
+            onWikiLink={setPendingConceptName}
+          />
+        ) : (
+          <ConceptsTab
+            libraryId={libraryId}
+            selectedId={conceptId}
+            onSelect={setConceptId}
+            onOpenPaper={(id) => {
+              setPaperId(id);
+              setTab('papers');
+            }}
+            onWikiLink={setPendingConceptName}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -1,0 +1,89 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { PageHead } from '../../components/ui/PageHead';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { WikiWorkbench } from '../wiki/WikiPage';
+import { LibraryBrowse } from './LibraryBrowse';
+
+/* ============================================================
+   /libraries/:id — 文献库详情（P5c）
+   - 背后课题的成员：完整工作台（论文管理 / 概念 / 图谱 / 对话 /
+     建库与同步 / 笔记，仍走 project 作用域端点）；
+   - 其他人：干净的只读浏览（论文 + 概念，走 /libraries 读端点）。
+   ============================================================ */
+
+export function LibraryDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+
+  const { data: lib, isLoading, isError, refetch } = useQuery({
+    queryKey: ['library', id],
+    queryFn: () => api.getLibrary(id),
+    enabled: !!id,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="page fadeup" style={{ maxWidth: 1360 }}>
+        <div className="col gap16">
+          <div className="skel" style={{ width: 260, height: 30 }} />
+          <div className="skel" style={{ width: '50%', height: 14 }} />
+          <div className="skel" style={{ width: '100%', height: 320 }} />
+        </div>
+      </div>
+    );
+  }
+  if (isError || !lib) {
+    return (
+      <div className="page fadeup" style={{ maxWidth: 1360 }}>
+        <EmptyState
+          icon="x"
+          title={tr('打不开这个文献库', 'Cannot open this library')}
+          desc={tr('文献库不存在，或后端暂时不可用。', 'It does not exist, or the backend is unavailable.')}
+          action={
+            <div className="row gap10">
+              <button className="btn btn-soft sm" onClick={() => void refetch()}>
+                {tr('重试', 'Retry')}
+              </button>
+              <button className="btn btn-ghost sm" onClick={() => navigate('/libraries')}>
+                {tr('回文献库列表', 'Back to libraries')}
+              </button>
+            </div>
+          }
+        />
+      </div>
+    );
+  }
+
+  const isMember = lib.is_mine && !!lib.project_id;
+
+  return (
+    <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
+      <PageHead
+        eyebrow={tr('实验室 · 文献库', 'Lab · Library')}
+        title={`${tr('文献库', 'Library')} · ${lib.name}`}
+        dense
+        sub={lib.statement ?? undefined}
+        right={
+          <>
+            <button className="btn btn-ghost" onClick={() => navigate('/libraries')}>
+              <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
+              {tr('全部文献库', 'All libraries')}
+            </button>
+            {isMember && (
+              <button className="btn btn-ghost" onClick={() => navigate(`/projects/${lib.project_id}`)}>
+                <Icon name="compass" size={14} />
+                {tr('课题设置', 'Topic settings')}
+              </button>
+            )}
+          </>
+        }
+      />
+      {isMember ? <WikiWorkbench pid={lib.project_id!} /> : <LibraryBrowse libraryId={lib.id} />}
+    </div>
+  );
+}

--- a/src/frontend/src/features/libraries/TopicWikiRedirect.tsx
+++ b/src/frontend/src/features/libraries/TopicWikiRedirect.tsx
@@ -1,0 +1,24 @@
+import { Navigate, useLocation, useParams } from 'react-router-dom';
+import { useLibraries, libraryPath } from './hooks';
+
+/**
+ * 旧文献追踪路径 `/t/:topicId/wiki` → 该课题隐式库的 `/libraries/{libId}`
+ * （保留查询串：?paper= / ?concept= / ?tab= 深链继续可用）。
+ * 库列表加载失败或找不到对应库时兜底跳库列表页。
+ */
+export function TopicWikiRedirect() {
+  const { topicId = '' } = useParams();
+  const location = useLocation();
+  const { data, isLoading } = useLibraries();
+  if (isLoading) {
+    return (
+      <div className="col gap16" style={{ padding: 28 }}>
+        <div className="skel" style={{ width: 220, height: 28 }} />
+        <div className="skel" style={{ width: '100%', height: 180 }} />
+      </div>
+    );
+  }
+  const lib = data?.find((l) => l.project_id === topicId);
+  if (!lib) return <Navigate to="/libraries" replace />;
+  return <Navigate to={libraryPath(lib.id) + location.search + location.hash} replace />;
+}

--- a/src/frontend/src/features/libraries/hooks.ts
+++ b/src/frontend/src/features/libraries/hooks.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { api, type DirectionLibrarySummary } from '../../lib/api';
+
+/* ============================================================
+   共享方向库（P5c）数据钩子与路径工具。
+   ============================================================ */
+
+/** 全部方向库列表（全实验室可读；列表小、5 分钟内不重拉）。 */
+export function useLibraries(enabled = true) {
+  return useQuery({
+    queryKey: ['libraries'],
+    queryFn: () => api.listLibraries(),
+    staleTime: 300_000,
+    retry: false,
+    enabled,
+  });
+}
+
+/** 课题 → 其隐式方向库（旧 /t/:id/wiki 链接改写用）；列表未就绪时返回 null。 */
+export function useTopicLibrary(topicId: string | null | undefined): DirectionLibrarySummary | null {
+  const { data } = useLibraries(!!topicId);
+  if (!topicId) return null;
+  return data?.find((l) => l.project_id === topicId) ?? null;
+}
+
+/** 库详情路径：`/libraries/<id>`（suffix 可带查询串，如 `?tab=ingest`）。 */
+export function libraryPath(libraryId: string, suffix = ''): string {
+  return `/libraries/${libraryId}${suffix}`;
+}

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -7,13 +7,13 @@ import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery'
 import { Markdown } from '../../lib/markdown';
 import { api, type LibraryEntry, type PaperAuthor, type Publication } from '../../lib/api';
 import { tr } from '../../lib/i18n';
-import { topicPath } from '../../app/project';
+import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 
 /* ============================================================
    我的文献库 · 右栏详情（三个 tab 共用）：
    - 活体论文（paperId 非 null）→ 拉论文详情；有 wiki 用文献追踪
      同款 markdown 渲染（含 ![[fig:N]] 嵌入图与 [[概念]] 双链，
-     双链跳转对齐阅读页：/wiki?concept=名称）；
+     双链跳转对齐阅读页：/libraries/<库>?concept=名称）；
    - 活体但没有 wiki → 元数据 + 摘要/TL;DR + 一句提示；
    - 快照条目（论文已删）→ 拉单条详情取 wiki 快照正文；有则渲染
      markdown（图片已随论文删除，![[fig:N]] 用灰字占位），
@@ -129,9 +129,12 @@ export function LibraryDetailPane({
   );
 
   // [[概念]] 双链 → 论文所属课题的 wiki（对齐阅读页的处理）
+  // 双链落点：论文所属课题的隐式库详情页（无课题上下文时退到库列表）
+  const topicLib = useTopicLibrary(paper?.project_id ?? null);
   const onWikiLink = useCallback(
-    (name: string) => navigate(topicPath(paper?.project_id, `wiki?concept=${encodeURIComponent(name)}`)),
-    [navigate, paper?.project_id],
+    (name: string) =>
+      navigate(topicLib ? libraryPath(topicLib.id, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
+    [navigate, topicLib],
   );
 
   if (paperId !== null && paperQuery.isLoading) {

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -1,15 +1,17 @@
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { CompileBadge } from '../../components/ui/CompileBadge';
 import { PaperStatusPill } from '../../components/ui/StatusPill';
 import { RelevanceBar } from '../../components/ui/RelevanceBar';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { FigureEmbed, FiguresSection, hasEmbeddedFigures, usePaperFigures } from '../../components/ui/FigureGallery';
+import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
 import { clickable } from '../../lib/a11y';
-import type { PaperDetail } from '../../lib/api';
+import { api, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
 
@@ -40,9 +42,37 @@ export function InfoPanel({
   onWikiLink: WikiLinkHandler;
 }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [abstractOpen, setAbstractOpen] = useState(false);
   const arxivUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : null;
   const extUrl = arxivUrl ?? paper.url;
+
+  // —— 个人版 wiki（P5b）：没有库版解读时，读本人个人库条目里的个人编译版 ——
+  const libStateQuery = useQuery({
+    queryKey: ['library-state', paper.id],
+    queryFn: () => api.getLibraryState(paper.id),
+    enabled: !paper.wiki_content,
+    retry: false,
+  });
+  const entryId = libStateQuery.data?.entry_id ?? null;
+  const entryQuery = useQuery({
+    queryKey: ['library-entry', entryId],
+    queryFn: () => api.getLibraryEntry(entryId!),
+    enabled: !paper.wiki_content && !!entryId,
+    retry: false,
+  });
+  const personalWiki = paper.wiki_content ? null : (entryQuery.data?.wiki_content ?? null);
+  const generateMutation = useMutation({
+    mutationFn: () => api.compilePersonalWiki(paper.id, paper.project_id),
+    onSuccess: () => {
+      toast(tr('个人版解读已生成', 'Personal wiki generated'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library-state', paper.id] });
+      void queryClient.invalidateQueries({ queryKey: ['library-entry'] });
+      void queryClient.invalidateQueries({ queryKey: ['library'] });
+    },
+    onError: (e) =>
+      toast(`${tr('生成失败：', 'Failed to generate: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
 
   // 正文 ![[fig:N]] 嵌入图（docs/api-lit.md §6.6）
   const figures = usePaperFigures(paper);
@@ -218,7 +248,7 @@ export function InfoPanel({
         defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)}
       />
 
-      {/* —— Wiki 正文（含 ![[fig:N]] 嵌入图） —— */}
+      {/* —— Wiki 正文（含 ![[fig:N]] 嵌入图）：库版 > 个人版 > 生成入口 —— */}
       <div style={{ marginTop: 18 }}>
         {paper.wiki_content ? (
           <>
@@ -238,13 +268,58 @@ export function InfoPanel({
               style={{ fontSize: 12.5 }}
             />
           </>
+        ) : personalWiki ? (
+          <>
+            <div
+              className="row gap8"
+              style={{ paddingBottom: 8, marginBottom: 12, borderBottom: '0.5px solid var(--border)' }}
+            >
+              <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+                {tr('AI 图文介绍', 'AI intro')}
+              </span>
+              <span
+                className="mono"
+                title={tr('公共库里没有这篇的解读，这是你自己生成的个人版。', 'No shared library wiki; this is the personal version you generated.')}
+                style={{
+                  fontSize: 10,
+                  color: 'var(--accent-text)',
+                  background: 'var(--accent-soft)',
+                  padding: '1px 7px',
+                  borderRadius: 999,
+                }}
+              >
+                {tr('个人版', 'Personal')}
+              </span>
+            </div>
+            <Markdown
+              source={personalWiki}
+              onWikiLink={onWikiLink}
+              renderFigure={renderFigure}
+              style={{ fontSize: 12.5 }}
+            />
+          </>
         ) : (
-          <EmptyState
-            compact
-            icon="pen"
-            title={tr('还没有 AI 精读页', 'No AI deep-read page yet')}
-            desc={tr('这篇论文还没被 AI 精读整理过（相关度不足，或还没运行初始建库 / 增量同步）。', 'This paper has not been deep-read by AI yet (relevance too low, or initial library build / incremental sync has not run).')}
-          />
+          <>
+            <EmptyState
+              compact
+              icon="pen"
+              title={tr('还没有 AI 精读页', 'No AI deep-read page yet')}
+              desc={tr('这篇论文还没被 AI 精读整理过（相关度不足，或还没运行初始建库 / 增量同步）。', 'This paper has not been deep-read by AI yet (relevance too low, or initial library build / incremental sync has not run).')}
+            />
+            <div className="col" style={{ alignItems: 'center', gap: 6, marginTop: 10 }}>
+              <button
+                className="btn btn-soft sm"
+                disabled={generateMutation.isPending || libStateQuery.isLoading || entryQuery.isLoading}
+                onClick={() => generateMutation.mutate()}
+              >
+                <Icon name="sparkle" size={12} />
+                {generateMutation.isPending ? tr('生成中…（约 1 分钟）', 'Generating… (~1 min)') : tr('生成 wiki', 'Generate wiki')}
+              </button>
+              <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                {tr('将使用你的模型额度，生成个人版解读。', 'Uses your model quota to generate a personal wiki.')}
+              </span>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -14,7 +14,7 @@ import {
   type ReadingStatus,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
-import { topicPath } from '../../app/project';
+import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { NotesPanel } from './NotesPanel';
 import { HighlightsPanel } from './HighlightsPanel';
 import { PdfReader, type JumpTarget } from './PdfReader';
@@ -205,9 +205,13 @@ export function ReadingPage() {
     onError: (e) => toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
+  // 论文所属课题的隐式库：返回/双链跳转的落点（无课题上下文时退到库列表）
+  const topicLib = useTopicLibrary(paper?.project_id ?? null);
+  const libHref = (suffix: string) => (topicLib ? libraryPath(topicLib.id, suffix) : '/libraries');
   const onWikiLink = useCallback(
-    (name: string) => navigate(topicPath(paper?.project_id, `wiki?concept=${encodeURIComponent(name)}`)),
-    [navigate, paper?.project_id],
+    (name: string) =>
+      navigate(topicLib ? libraryPath(topicLib.id, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
+    [navigate, topicLib],
   );
 
   const onHighlightClick = useCallback((hlId: string) => {
@@ -231,9 +235,9 @@ export function ReadingPage() {
           title={tr('打不开这篇论文', 'Cannot open this paper')}
           desc={tr('论文不存在、你不在这个课题里，或后端暂时不可用。', 'It does not exist, you are not in this topic, or the backend is unavailable.')}
           action={
-            <button className="btn btn-ghost" onClick={() => navigate('/wiki')}>
+            <button className="btn btn-ghost" onClick={() => navigate('/libraries')}>
               <Icon name="book" size={14} />
-              {tr('回文献库', 'Back to library')}
+              {tr('回文献库', 'Back to libraries')}
             </button>
           }
         />
@@ -249,7 +253,7 @@ export function ReadingPage() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', padding: '14px 18px 16px' }}>
       {/* —— 顶栏 —— */}
       <div className="row gap12" style={{ flexShrink: 0, marginBottom: 12 }}>
-        <button className="btn btn-ghost sm" onClick={() => navigate(topicPath(paper.project_id, `wiki?paper=${paper.id}`))}>
+        <button className="btn btn-ghost sm" onClick={() => navigate(libHref(`?paper=${paper.id}`))}>
           <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
           {tr('回文献库', 'Back to library')}
         </button>

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -370,7 +370,7 @@ export function ReadingPage() {
           {panel === 'highlights' ? (
             <HighlightsPanel
               paperId={paper.id}
-              pid={paper.project_id}
+              pid={paper.project_id ?? ''}
               highlights={highlights}
               loading={highlightsQuery.isLoading}
               error={highlightsQuery.isError}
@@ -379,9 +379,9 @@ export function ReadingPage() {
               onChanged={invalidateHighlights}
             />
           ) : panel === 'notes' ? (
-            <NotesPanel paperId={paper.id} pid={paper.project_id} />
+            <NotesPanel paperId={paper.id} pid={paper.project_id ?? ''} />
           ) : panel === 'chat' ? (
-            <ChatPanel paperId={paper.id} pid={paper.project_id} />
+            <ChatPanel paperId={paper.id} pid={paper.project_id ?? ''} />
           ) : (
             <InfoPanel paper={paper} onWikiLink={onWikiLink} />
           )}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -67,6 +67,27 @@ function WikiBadge({ item }: { item: ShelfItemRead }) {
       </span>
     );
   }
+  if (item.wiki_source === 'personal') {
+    return (
+      <span
+        className="mono"
+        title={tr(
+          '这篇论文没有公共库版解读，下面显示的是你自己生成的个人版。',
+          'No shared library wiki for this paper; showing the personal version you generated.',
+        )}
+        style={{
+          fontSize: 10,
+          color: 'var(--accent-text)',
+          background: 'var(--accent-soft)',
+          padding: '1px 7px',
+          borderRadius: 999,
+          flexShrink: 0,
+        }}
+      >
+        {tr('个人版解读', 'Personal wiki')}
+      </span>
+    );
+  }
   if (item.wiki_source === 'snapshot') {
     return (
       <span
@@ -99,15 +120,25 @@ function WikiBadge({ item }: { item: ShelfItemRead }) {
 function ShelfCard({
   item,
   busy,
+  generating,
+  refreshing,
   onOpen,
   onSaveNote,
   onRemove,
+  onGenerateWiki,
+  onRefreshSnapshot,
 }: {
   item: ShelfItemRead;
   busy: boolean;
+  /** 本卡的个人版 wiki 正在生成 */
+  generating: boolean;
+  /** 本卡的快照正在刷新 */
+  refreshing: boolean;
   onOpen: () => void;
   onSaveNote: (note: string | null) => void;
   onRemove: () => void;
+  onGenerateWiki: () => void;
+  onRefreshSnapshot: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(item.note ?? '');
@@ -129,6 +160,32 @@ function ShelfCard({
           <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{item.year}</span>
         )}
         <WikiBadge item={item} />
+        {item.wiki_source === 'snapshot' && (
+          <button
+            className="icon-btn"
+            title={tr(
+              '刷新快照：重新拷一份当前可得的最新解读（库版优先，其次个人版）',
+              'Refresh snapshot: re-copy the latest available wiki (library first, then personal)',
+            )}
+            disabled={refreshing}
+            onClick={onRefreshSnapshot}
+            style={{ width: 22, height: 22 }}
+          >
+            <Icon name="refresh" size={12} />
+          </button>
+        )}
+        {item.wiki_source === 'none' && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('用 AI 生成这篇论文的个人版解读（将使用你的模型额度）', 'Generate a personal wiki with AI (uses your model quota)')}
+            disabled={generating}
+            onClick={onGenerateWiki}
+            style={{ height: 22, fontSize: 10.5, padding: '0 8px' }}
+          >
+            <Icon name="sparkle" size={11} />
+            {generating ? tr('生成中…', 'Generating…') : tr('生成 wiki', 'Generate wiki')}
+          </button>
+        )}
         <span style={{ marginLeft: 'auto' }} />
         <button
           className="icon-btn"
@@ -307,6 +364,25 @@ export function ResearchPage() {
       invalidate();
     },
     onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
+  });
+
+  // 个人版 wiki 按需生成（wiki_source=none 的论文；费用记个人额度）
+  const generateMutation = useMutation({
+    mutationFn: (paperId: string) => api.compilePersonalWiki(paperId, pid),
+    onSuccess: () => {
+      toast(tr('个人版解读已生成', 'Personal wiki generated'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('生成失败：', 'Failed to generate: ')}${errText(e)}`, 'error'),
+  });
+
+  const refreshSnapshotMutation = useMutation({
+    mutationFn: (paperId: string) => api.refreshShelfSnapshot(pid, paperId),
+    onSuccess: () => {
+      toast(tr('快照已刷新', 'Snapshot refreshed'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['shelf', pid] });
+    },
+    onError: (e) => toast(`${tr('刷新失败：', 'Failed to refresh: ')}${errText(e)}`, 'error'),
   });
 
   const submitImport = () => {
@@ -503,9 +579,15 @@ export function ResearchPage() {
               key={item.paper_id}
               item={item}
               busy={busy}
+              generating={generateMutation.isPending && generateMutation.variables === item.paper_id}
+              refreshing={
+                refreshSnapshotMutation.isPending && refreshSnapshotMutation.variables === item.paper_id
+              }
               onOpen={() => navigate(`/papers/${item.paper_id}/read`)}
               onSaveNote={(note) => noteMutation.mutate({ paperId: item.paper_id, note })}
               onRemove={() => removeMutation.mutate(item.paper_id)}
+              onGenerateWiki={() => generateMutation.mutate(item.paper_id)}
+              onRefreshSnapshot={() => refreshSnapshotMutation.mutate(item.paper_id)}
             />
           ))}
           {totalPages > 1 && (

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -9,6 +9,7 @@ import { api, type ShelfImportInput, type ShelfItemRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath, useProject } from '../../app/project';
 import { SearchInput, useDebounced } from '../wiki/shared';
+import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 
 /* ============================================================
    /t/:topicId/research — 课题「相关研究」书架：
@@ -289,6 +290,9 @@ export function ResearchPage() {
   const queryClient = useQueryClient();
   const { currentProjectId } = useProject();
   const pid = currentProjectId ?? '';
+  // 文献库入口：课题隐式库详情页（列表未就绪时退回旧 /wiki 路径由重定向兜底）
+  const topicLib = useTopicLibrary(pid || null);
+  const wikiHref = topicLib ? libraryPath(topicLib.id) : topicPath(pid, 'wiki');
 
   const [page, setPage] = useState(1);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -443,8 +447,8 @@ export function ResearchPage() {
               onChange={setQInput}
               placeholder={tr('搜文献库：标题 / 摘要 / 解读…', 'Search the library: title / abstract / wiki…')}
             />
-            <button className="btn btn-ghost sm" onClick={() => navigate(topicPath(pid, 'wiki'))}>
-              {tr('去文献追踪', 'Open Research Wiki')}
+            <button className="btn btn-ghost sm" onClick={() => navigate(wikiHref)}>
+              {tr('去文献库', 'Open the library')}
             </button>
           </div>
           {q.length > 0 && (
@@ -546,14 +550,14 @@ export function ResearchPage() {
           icon="pin"
           title={tr('书架还空着', 'The shelf is empty')}
           desc={tr(
-            '去文献追踪逛逛，把相关论文加进来；或直接输入 arXiv 编号添加。',
-            'Browse the Research Wiki and shelve relevant papers, or add one by arXiv ID.',
+            '去文献库逛逛，把相关论文加进来；或直接输入 arXiv 编号添加。',
+            'Browse the library and shelve relevant papers, or add one by arXiv ID.',
           )}
           action={
             <div className="row gap10">
-              <button className="btn btn-primary sm" onClick={() => navigate(topicPath(pid, 'wiki'))}>
+              <button className="btn btn-primary sm" onClick={() => navigate(wikiHref)}>
                 <Icon name="book" size={13} />
-                {tr('去文献追踪', 'Open Research Wiki')}
+                {tr('去文献库', 'Open the library')}
               </button>
               <button
                 className="btn btn-soft sm"

--- a/src/frontend/src/features/wiki/ConceptsTab.tsx
+++ b/src/frontend/src/features/wiki/ConceptsTab.tsx
@@ -28,7 +28,10 @@ const CATEGORY_FILTERS: CategoryFilter[] = [
 ];
 
 export interface ConceptsTabProps {
-  pid: string;
+  /** 课题 id（成员视角：project 作用域端点 + 概念补建按钮）。 */
+  pid?: string;
+  /** 共享库只读视角（P5c）：给定时列表走 /libraries/{id}/concepts，隐藏补建按钮。 */
+  libraryId?: string;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onOpenPaper: (id: string) => void;
@@ -183,26 +186,24 @@ function ConceptDetailPane({
   );
 }
 
-export function ConceptsTab({ pid, selectedId, onSelect, onOpenPaper, onWikiLink }: ConceptsTabProps) {
+export function ConceptsTab({ pid, libraryId, selectedId, onSelect, onOpenPaper, onWikiLink }: ConceptsTabProps) {
   const queryClient = useQueryClient();
   const [category, setCategory] = useState<CategoryFilter>('all');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
 
+  const opts = { category: category === 'all' ? undefined : category, q: q || undefined } as const;
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['concepts', pid, category, q],
-    queryFn: () =>
-      api.listConcepts(pid, {
-        category: category === 'all' ? undefined : category,
-        q: q || undefined,
-      }),
+    queryKey: libraryId ? ['lib-concepts', libraryId, category, q] : ['concepts', pid, category, q],
+    queryFn: () => (libraryId ? api.listLibraryConcepts(libraryId, opts) : api.listConcepts(pid!, opts)),
     retry: false,
   });
   const concepts = useMemo(() => data ?? [], [data]);
 
-  // 全库概念补建：编译过但概念没上链的历史论文（比如批量任务中断）从这里补
+  // 全库概念补建：编译过但概念没上链的历史论文（比如批量任务中断）从这里补（成员视角限定）
+  const canRelink = !!pid && !libraryId;
   const relinkMutation = useMutation({
-    mutationFn: () => api.relinkConcepts(pid),
+    mutationFn: () => api.relinkConcepts(pid!),
     onSuccess: (r) => {
       if (r.concepts_created === 0 && r.links_created === 0) {
         toast(
@@ -241,22 +242,24 @@ export function ConceptsTab({ pid, selectedId, onSelect, onOpenPaper, onWikiLink
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
               {concepts.length ? tr(`${concepts.length} 个`, `${concepts.length}`) : ''}
             </span>
-            <button
-              className="icon-btn"
-              style={{ width: 26, height: 26, borderRadius: 7, flexShrink: 0 }}
-              title={tr(
-                '从已编译论文提取概念：重抽正文 [[双链]]，补建缺失的概念和关联',
-                'Extract concepts from compiled papers: re-scan [[wiki links]] and fill in missing concepts and links',
-              )}
-              disabled={relinkMutation.isPending}
-              onClick={() => relinkMutation.mutate()}
-            >
-              <Icon
-                name="refresh"
-                size={13}
-                style={relinkMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
-              />
-            </button>
+            {canRelink && (
+              <button
+                className="icon-btn"
+                style={{ width: 26, height: 26, borderRadius: 7, flexShrink: 0 }}
+                title={tr(
+                  '从已编译论文提取概念：重抽正文 [[双链]]，补建缺失的概念和关联',
+                  'Extract concepts from compiled papers: re-scan [[wiki links]] and fill in missing concepts and links',
+                )}
+                disabled={relinkMutation.isPending}
+                onClick={() => relinkMutation.mutate()}
+              >
+                <Icon
+                  name="refresh"
+                  size={13}
+                  style={relinkMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
+                />
+              </button>
+            )}
           </div>
           <div className="row gap6 wrap" style={{ marginTop: 10 }}>
             {CATEGORY_FILTERS.map((f) => {
@@ -294,7 +297,7 @@ export function ConceptsTab({ pid, selectedId, onSelect, onOpenPaper, onWikiLink
                     )
               }
               action={
-                q ? undefined : (
+                q || !canRelink ? undefined : (
                   <button
                     className="btn btn-soft sm"
                     disabled={relinkMutation.isPending}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -2,10 +2,8 @@ import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
-import { useProject } from '../../app/project';
 import { api } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { ExportMenu, PapersTab, type AdvSearchSeed } from './PapersTab';
@@ -21,17 +19,15 @@ const PresentationModal = lazy(() =>
 );
 
 /* ============================================================
-   /wiki — Research Wiki 文献调研页（M2 + 文献管理增强）
-   四个 Tab：论文库 / 概念库 / 建库与同步 / 笔记本；
-   顶部当前研究方向 + Obsidian 导出。
+   文献库工作台（P5c 起挂在 /libraries/:id 的成员视图；原 /wiki 页面主体）
+   六个 Tab：论文库 / 概念库 / 图谱 / 文献对话 / 建库与同步 / 笔记；
+   pid = 库背后课题 id（成员视角，数据仍走 project 作用域端点）。
    ============================================================ */
 
 type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes';
 
-export function WikiPage() {
+export function WikiWorkbench({ pid }: { pid: string }) {
   const navigate = useNavigate();
-  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
-  const pid = currentProjectId;
 
   const [tab, setTab] = useState<WikiTab>('papers');
   const [presentOpen, setPresentOpen] = useState(false);
@@ -42,16 +38,16 @@ export function WikiPage() {
   /** 深链带入的作者/机构筛选（seq 递增，PapersTab 据此重新应用） */
   const [advSeed, setAdvSeed] = useState<AdvSearchSeed | null>(null);
 
-  // 切换项目时重置选中态
+  // 切换课题/库时重置选中态
   useEffect(() => {
     setPaperId(null);
     setConceptId(null);
     setPendingConceptName(null);
   }, [pid]);
 
-  // 深链 /wiki?paper=<id>（idea 详情 / 阅读页返回）、/wiki?concept=<名称>
-  // （阅读页双链跳转，按名称解析）、/wiki?author= / ?affiliation=
-  // （阅读页作者/机构点击 → 论文库按其过滤）与 /wiki?tab=<tab>
+  // 深链 ?paper=<id>（idea 详情 / 阅读页返回）、?concept=<名称>
+  // （阅读页双链跳转，按名称解析）、?author= / ?affiliation=
+  // （阅读页作者/机构点击 → 论文库按其过滤）与 ?tab=<tab>
   // （工作台「下一步」直达建库面板）：处理后清掉参数
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -82,8 +78,7 @@ export function WikiPage() {
   // —— ingest 状态（tab 计数 + Ingest 面板共用） ——
   const ingestQuery = useQuery({
     queryKey: ['ingest-state', pid],
-    queryFn: () => api.getIngestState(pid!),
-    enabled: !!pid,
+    queryFn: () => api.getIngestState(pid),
     retry: false,
     refetchInterval: (q) => (q.state.data?.running_voyage_id ? 5_000 : 60_000),
   });
@@ -91,8 +86,8 @@ export function WikiPage() {
   // —— [[概念名]] → 概念 id 解析 ——
   const resolveQuery = useQuery({
     queryKey: ['concept-resolve', pid, pendingConceptName],
-    queryFn: () => api.listConcepts(pid!, { q: pendingConceptName ?? '' }),
-    enabled: !!pid && !!pendingConceptName,
+    queryFn: () => api.listConcepts(pid, { q: pendingConceptName ?? '' }),
+    enabled: !!pendingConceptName,
     retry: false,
   });
   useEffect(() => {
@@ -134,38 +129,7 @@ export function WikiPage() {
   const total = ingestQuery.data?.paper_counts?.library ?? ingestQuery.data?.paper_counts?.total;
 
   return (
-    <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
-      <PageHead
-        eyebrow="Stage 00 · Research Wiki"
-        title={tr('文献调研', 'Research Wiki')}
-        dense
-        sub={
-          currentProject
-            ? undefined
-            : projectsLoading
-              ? tr('加载课题…', 'Loading topics…')
-              : tr('选择一个课题', 'Pick a topic')
-        }
-        right={
-          <>
-            {currentProject && (
-              <button
-                className="btn btn-ghost"
-                onClick={() => navigate(`/projects/${currentProject.id}`)}
-              >
-                <Icon name="compass" size={14} />
-                {tr('课题设置', 'Topic settings')}
-              </button>
-            )}
-            <button className="btn btn-ghost" disabled={!pid} onClick={() => setPresentOpen(true)}>
-              <Icon name="chart" size={14} />
-              {tr('论文分享 PPT', 'Paper sharing PPT')}
-            </button>
-            {pid && <ExportMenu pid={pid} />}
-          </>
-        }
-      />
-
+    <>
       <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<WikiTab>
           options={[
@@ -179,16 +143,23 @@ export function WikiPage() {
           value={tab}
           onChange={setTab}
         />
-        {ingestQuery.data?.running_voyage_id && tab !== 'ingest' && (
-          <span
-            className="pill hoverable"
-            style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
-            onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
-          >
-            <span className="dot pulse" />
-            {tr('文献任务运行中 →', 'Literature task running →')}
-          </span>
-        )}
+        <div className="row gap8">
+          {ingestQuery.data?.running_voyage_id && tab !== 'ingest' && (
+            <span
+              className="pill hoverable"
+              style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
+              onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
+            >
+              <span className="dot pulse" />
+              {tr('文献任务运行中 →', 'Literature task running →')}
+            </span>
+          )}
+          <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
+            <Icon name="chart" size={13} />
+            {tr('论文分享 PPT', 'Paper sharing PPT')}
+          </button>
+          <ExportMenu pid={pid} />
+        </div>
       </div>
 
       <div
@@ -201,13 +172,7 @@ export function WikiPage() {
           minHeight: 480,
         }}
       >
-        {!pid ? (
-          <div className="empty" style={{ margin: 'auto' }}>
-            {projectsLoading
-              ? tr('加载课题…', 'Loading topics…')
-              : tr('请先选择课题', 'Pick a topic first')}
-          </div>
-        ) : tab === 'papers' ? (
+        {tab === 'papers' ? (
           <PapersTab
             pid={pid}
             selectedId={paperId}
@@ -242,7 +207,7 @@ export function WikiPage() {
         )}
       </div>
 
-      {presentOpen && pid && (
+      {presentOpen && (
         <Suspense fallback={null}>
           <PresentationModal
             projectId={pid}
@@ -251,6 +216,6 @@ export function WikiPage() {
           />
         </Suspense>
       )}
-    </div>
+    </>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -594,7 +594,8 @@ export interface PaperAuthor {
 
 export interface PaperRead {
   id: string;
-  project_id: string;
+  /** 本次访问解析出的课题上下文；书架/个人库可达的无库论文（个人补充）为 null */
+  project_id: string | null;
   title: string;
   authors: PaperAuthor[];
   /** 发表机构（OpenAlex 补充；可能为空） */

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -678,7 +678,6 @@ export type ReadingStatus = 'unread' | 'reading' | 'read';
 export interface NoteRead {
   id: string;
   paper_id: string;
-  project_id: string;
   author_id: string;
   /** display_name 回退 email 前缀 */
   author_name: string;
@@ -707,7 +706,6 @@ export interface HighlightRect {
 export interface HighlightRead {
   id: string;
   paper_id: string;
-  project_id: string;
   author_id: string;
   author_name: string;
   page: number; // 1-indexed
@@ -811,8 +809,8 @@ export interface SearchResult {
 // P5a · 课题「相关研究」书架 — /projects/{pid}/shelf
 // ============================================================
 
-/** 书架条目 wiki 来源：live=库版实时可得 | snapshot=只剩入架快照 | none=没有解读。 */
-export type ShelfWikiSource = 'live' | 'snapshot' | 'none';
+/** 书架条目 wiki 来源：live=库版实时 | personal=本人个人编译版 | snapshot=只剩入架快照 | none=没有解读。 */
+export type ShelfWikiSource = 'live' | 'personal' | 'snapshot' | 'none';
 
 export interface ShelfItemRead {
   paper_id: string;
@@ -827,13 +825,20 @@ export interface ShelfItemRead {
   /** 课题语境的「为什么相关」备注 */
   note: string | null;
   wiki_source: ShelfWikiSource;
-  /** 解析后的 wiki：库版实时 > 快照；none 时为 null */
+  /** 解析后的 wiki：库版实时 > 个人版 > 快照；none 时为 null */
   wiki_content: string | null;
   /** 入架落快照的时间；没快照为 null */
   snapshot_at: string | null;
   /** 来源方向库（个人补充为 null） */
   source_library_id: string | null;
   added_at: string;
+}
+
+/** 个人版 wiki 按需编译结果（P5b）。 */
+export interface PersonalWikiRead {
+  paper_id: string;
+  wiki_content: string;
+  model: string | null;
 }
 
 /** 个人补充入库：arXiv 编号 / DOI / 标题至少给一个。 */
@@ -2623,6 +2628,18 @@ export const api = {
   /** 移出书架：只删书架行，个人库收藏不动。 */
   removeFromShelf(projectId: string, paperId: string): Promise<void> {
     return request<void>(`/projects/${projectId}/shelf/${paperId}`, { method: 'DELETE' });
+  },
+  /** 手动刷新书架快照：从当前最优 wiki（库版 > 个人版）重拷；无来源 409。 */
+  refreshShelfSnapshot(projectId: string, paperId: string): Promise<ShelfItemRead> {
+    return request<ShelfItemRead>(`/projects/${projectId}/shelf/${paperId}/refresh-snapshot`, {
+      method: 'POST',
+    });
+  },
+  /** 个人版 wiki 按需编译（无库版解读的论文；费用记个人额度）。 */
+  compilePersonalWiki(paperId: string, topicId?: string | null): Promise<PersonalWikiRead> {
+    return requestJson<PersonalWikiRead>(`/papers/${paperId}/personal-wiki`, 'POST', {
+      topic_id: topicId ?? null,
+    });
   },
 
   // —— M2 · Ingest ——

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -765,7 +765,8 @@ export type ConceptCategory =
 
 export interface ConceptRead {
   id: string;
-  project_id: string;
+  /** 概念所属库回指的课题；共享库（无课题回指）为 null */
+  project_id: string | null;
   name: string;
   category: ConceptCategory;
   /** 一句话定义 */
@@ -791,6 +792,31 @@ export interface ConceptRelinkResult {
   concepts_created: number;
   links_created: number;
   new_concepts: string[];
+}
+
+// ============================================================
+// P5c · 共享方向库（/libraries，全实验室可读）
+// ============================================================
+
+export interface DirectionLibrarySummary {
+  id: string;
+  name: string;
+  statement: string | null;
+  /** 背后课题（过渡期隐式库 1:1 回指；未来共享库可为 null） */
+  project_id: string | null;
+  /** 是否「我的课题的库」（请求者是背后课题成员 → 显示管理页签） */
+  is_mine: boolean;
+  paper_count: number;
+  concept_count: number;
+  last_compiled_at: string | null;
+  /** 上次同步时间 */
+  last_synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DirectionLibraryDetail extends DirectionLibrarySummary {
+  cadence: string | null;
 }
 
 // ============================================================
@@ -2601,6 +2627,47 @@ export const api = {
     if (opts.mode) params.set('mode', opts.mode);
     if (opts.limit) params.set('limit', String(opts.limit));
     return request<SearchResult>(`/projects/${projectId}/search?${params.toString()}`);
+  },
+
+  // —— P5c · 共享方向库（全实验室可读） ——
+  listLibraries(): Promise<DirectionLibrarySummary[]> {
+    return request<DirectionLibrarySummary[]>('/libraries');
+  },
+  getLibrary(id: string): Promise<DirectionLibraryDetail> {
+    return request<DirectionLibraryDetail>(`/libraries/${id}`);
+  },
+  /** 库内论文（缺省只列相关性达标的）。 */
+  listLibraryPapers(
+    id: string,
+    opts: { status?: PaperStatusFilter; q?: string; sort?: PaperSort; page?: number; size?: number } = {},
+  ): Promise<PageOf<PaperRead>> {
+    const params = new URLSearchParams();
+    if (opts.status) params.set('status', opts.status);
+    if (opts.q) params.set('q', opts.q);
+    if (opts.sort) params.set('sort', opts.sort);
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    const qs = params.toString();
+    return request<PageOf<PaperRead>>(`/libraries/${id}/papers${qs ? `?${qs}` : ''}`);
+  },
+  listLibraryConcepts(
+    id: string,
+    opts: { category?: ConceptCategory; q?: string } = {},
+  ): Promise<ConceptRead[]> {
+    const params = new URLSearchParams();
+    if (opts.category) params.set('category', opts.category);
+    if (opts.q) params.set('q', opts.q);
+    const qs = params.toString();
+    return request<ConceptRead[]>(`/libraries/${id}/concepts${qs ? `?${qs}` : ''}`);
+  },
+  searchLibrary(
+    id: string,
+    opts: { q: string; mode?: SearchMode; limit?: number },
+  ): Promise<SearchResult> {
+    const params = new URLSearchParams({ q: opts.q });
+    if (opts.mode) params.set('mode', opts.mode);
+    if (opts.limit) params.set('limit', String(opts.limit));
+    return request<SearchResult>(`/libraries/${id}/search?${params.toString()}`);
   },
 
   // —— P5a · 课题「相关研究」书架 ——


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P5c, full-stack, stacked on #5 (merge that first).

## What changed

**The Lab zone becomes real.** New read-only library APIs open to every signed-in user: `GET /libraries` (overview with paper/concept counts, last compile/sync, `is_mine`), `/libraries/{id}`, plus per-library papers, concepts, and keyword/semantic search. Reading visibility extends lab-wide: any paper that belongs to a library is readable by everyone (wiki, figures, reading chat with personal billing); all write and management endpoints keep project-member checks.

**Frontend**
- `/libraries` card list (own-topic libraries badged and sorted first) replaces the sidebar Lab item "Research Tracking".
- `/libraries/{id}`: members get the full management workbench (former WikiPage with all six tabs); non-members get a clean read-only browse (papers, search, wiki detail with figures, concepts).
- `/t/:topicId/wiki` now redirects to the topic's library page preserving query strings; dashboards, checklist, shelf, and reading-page links swept to the new paths.

This closes the transitional mismatch where a Lab-zone nav item carried a topic-scoped URL.

## Tests

Full suite: 506 passed (baseline 502 + 4 new shared-library tests), 16 pre-existing errors, 2 pre-existing env-coupled test_feedback failures — no new failures. Existing assertions updated for the new lab-wide read semantics (outsider reads 200, writes still 404). Frontend tsc + build pass. No new migrations.

## Follow-ups

Deep links in SearchPalette/idea/voyage pages still go through the wiki redirect (one extra hop); curator write paths land in P6.