### PR TITLE
feat(frontend): related-research page redesign — two-pane workbench (P5 polish)

### DIFF
--- a/src/frontend/src/features/research/AddPaperModal.tsx
+++ b/src/frontend/src/features/research/AddPaperModal.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { api, type ShelfImportInput } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { SearchInput, useDebounced } from '../wiki/shared';
+
+/* ============================================================
+   相关研究 · 「添加论文」统一入口（弹窗，两个页签）：
+   - 从文献库：检索当前课题关联的文献库，结果行内一键添加，
+     已入架的显示勾选态；找不到时引导切到手动添加。
+   - 手动添加：arXiv 编号 / DOI，平台自动查重（池里已有直接
+     复用解析，不重复花钱）。
+   弹窗保持打开，方便连续添加多篇。
+   ============================================================ */
+
+type AddTab = 'library' | 'manual';
+
+// 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
+const TABS: { v: AddTab; zh: string; en: string }[] = [
+  { v: 'library', zh: '从文献库', en: 'From library' },
+  { v: 'manual', zh: '手动添加', en: 'By arXiv / DOI' },
+];
+
+/** 手动添加输入解析：DOI（10.xxx / doi.org 链接）之外一律按 arXiv 编号处理。 */
+function parseImportInput(raw: string): ShelfImportInput | null {
+  let v = raw.trim();
+  if (!v) return null;
+  if (v.includes('doi.org/')) v = v.slice(v.indexOf('doi.org/') + 'doi.org/'.length);
+  if (/^10\.\d{4,}/.test(v)) return { doi: v };
+  if (v.includes('arxiv.org/')) {
+    const seg = v.split('/').filter(Boolean);
+    v = (seg[seg.length - 1] ?? '').replace(/\.pdf$/, '');
+  }
+  return v ? { arxiv_id: v } : null;
+}
+
+export function AddPaperModal({
+  open,
+  onClose,
+  pid,
+  shelvedIds,
+  wikiHref,
+  addPending,
+  onAdd,
+  importPending,
+  onImport,
+}: {
+  open: boolean;
+  onClose: () => void;
+  pid: string;
+  /** 已入架论文 id 集合（勾选态用） */
+  shelvedIds: Set<string>;
+  /** 文献库入口路径（「去文献库」按钮） */
+  wikiHref: string;
+  addPending: boolean;
+  onAdd: (paperId: string) => void;
+  importPending: boolean;
+  /** 手动添加；resolve 后清空输入框 */
+  onImport: (input: ShelfImportInput) => Promise<unknown>;
+}) {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<AddTab>('library');
+  const [qInput, setQInput] = useState('');
+  const q = useDebounced(qInput.trim());
+  const [importInput, setImportInput] = useState('');
+
+  const searchQuery = useQuery({
+    queryKey: ['shelf-search', pid, q],
+    queryFn: () => api.searchProject(pid, { q, limit: 8 }),
+    enabled: !!pid && open && tab === 'library' && q.length > 0,
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+  const results = searchQuery.data?.papers ?? [];
+
+  const submitImport = () => {
+    const input = parseImportInput(importInput);
+    if (!input) {
+      toast(tr('先输入 arXiv 编号或 DOI', 'Enter an arXiv ID or DOI first'), 'info');
+      return;
+    }
+    void onImport(input)
+      .then(() => setImportInput(''))
+      .catch(() => undefined); // 报错交给外层 mutation 的 toast
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      width={600}
+      title={tr('添加论文', 'Add papers')}
+      sub={tr('加入这个课题的相关研究，可以连续添加多篇。', 'Add to related work for this topic — add several in a row.')}
+    >
+      <Segmented<AddTab> options={TABS.map((t) => ({ v: t.v, label: tr(t.zh, t.en) }))} value={tab} onChange={setTab} />
+
+      {tab === 'library' ? (
+        /* ======== 从文献库检索 ======== */
+        <div style={{ marginTop: 14 }}>
+          <div className="row gap10">
+            <SearchInput
+              value={qInput}
+              onChange={setQInput}
+              placeholder={tr('搜文献库：标题 / 摘要 / 解读…', 'Search the library: title / abstract / wiki…')}
+            />
+            <button
+              className="btn btn-ghost sm"
+              style={{ flexShrink: 0 }}
+              onClick={() => {
+                onClose();
+                navigate(wikiHref);
+              }}
+            >
+              <Icon name="book" size={13} />
+              {tr('去文献库', 'Open library')}
+            </button>
+          </div>
+
+          {q.length === 0 ? (
+            <div className="empty" style={{ padding: '28px 14px' }}>
+              {tr('输入关键词，搜这个课题关联的文献库', 'Type a keyword to search this topic’s library')}
+            </div>
+          ) : searchQuery.isLoading ? (
+            <div className="empty" style={{ padding: '28px 14px' }}>{tr('搜索中…', 'Searching…')}</div>
+          ) : results.length === 0 ? (
+            <div className="empty" style={{ padding: '28px 14px' }}>
+              {tr('文献库里没搜到，试试「手动添加」页签', 'Nothing found — try the “By arXiv / DOI” tab')}
+            </div>
+          ) : (
+            <div className="col" style={{ marginTop: 8 }}>
+              {results.map((p) => {
+                const added = shelvedIds.has(p.id);
+                return (
+                  <div
+                    key={p.id}
+                    className="row gap10"
+                    style={{ padding: '9px 4px', borderBottom: '0.5px solid var(--border)' }}
+                  >
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 12.5, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
+                      <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginTop: 2 }}>
+                        {p.arxiv_id ?? p.venue ?? '—'}
+                        {p.year !== null ? ` · ${p.year}` : ''}
+                      </div>
+                    </div>
+                    {added ? (
+                      <span className="row gap6" style={{ fontSize: 11.5, color: 'var(--ok-tx)', flexShrink: 0 }}>
+                        <Icon name="check" size={13} />
+                        {tr('已添加', 'Added')}
+                      </span>
+                    ) : (
+                      <button
+                        className="btn btn-soft sm"
+                        style={{ flexShrink: 0 }}
+                        disabled={addPending}
+                        onClick={() => onAdd(p.id)}
+                      >
+                        <Icon name="plus" size={12} />
+                        {tr('添加', 'Add')}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : (
+        /* ======== 手动添加：arXiv / DOI ======== */
+        <div style={{ marginTop: 14 }}>
+          <div className="row gap10">
+            <input
+              className="input"
+              autoFocus
+              style={{ height: 32, fontSize: 12.5, flex: 1, minWidth: 0 }}
+              value={importInput}
+              onChange={(e) => setImportInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitImport();
+              }}
+              placeholder={tr('arXiv 编号（如 2401.12345）或 DOI（如 10.1234/abc）', 'arXiv ID (e.g. 2401.12345) or DOI (e.g. 10.1234/abc)')}
+            />
+            <button
+              className="btn btn-primary sm"
+              style={{ flexShrink: 0 }}
+              disabled={importPending}
+              onClick={submitImport}
+            >
+              {importPending ? tr('解析中…', 'Resolving…') : tr('添加', 'Add')}
+            </button>
+          </div>
+          <div style={{ fontSize: 11.5, color: 'var(--text-4)', marginTop: 10, lineHeight: 1.6 }}>
+            {tr(
+              '会自动查重：平台已有这篇时直接复用，不会重复解析。文献库里没有的论文会自动抓取元数据和 PDF，只进这个课题的相关研究和你的个人文献库，不影响公共文献库。',
+              'Duplicates are detected automatically — papers already on the platform are reused without re-parsing. New papers are fetched (metadata + PDF) and go to this topic and your personal library only; the shared library is untouched.',
+            )}
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -1,218 +1,107 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
+import { Segmented } from '../../components/ui/Segmented';
+import { SelectMenu } from '../../components/ui/SelectMenu';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
-import { api, type ShelfImportInput, type ShelfItemRead } from '../../lib/api';
+import { api, type ShelfImportInput, type ShelfItemRead, type ShelfWikiSource } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath, useProject } from '../../app/project';
-import { SearchInput, useDebounced } from '../wiki/shared';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
+import { AddPaperModal } from './AddPaperModal';
+import { ShelfDetailPane, WikiBadge } from './ShelfDetailPane';
 
 /* ============================================================
-   /t/:topicId/research — 课题「相关研究」书架：
-   从方向文献库挑论文入架（引用为主、入架落 wiki 快照兜底），
-   或用 arXiv 编号 / DOI 个人补充入库；每篇可写「为什么相关」备注。
+   /t/:topicId/research — 课题「相关研究」书架。
+   双栏主从布局对齐「我的文献库」：左栏紧凑论文行（排序 / 状态
+   过滤 / 计数），右栏选中论文的完整详情（wiki 渲染、课题备注、
+   就地动作）；添加统一收进「添加论文」弹窗（从文献库 / 手动）。
    入架同时自动收藏进「我的文献库」；移出书架不动个人库。
    ============================================================ */
 
-const PAGE_SIZE = 50;
+// 后端单页上限 100；书架通常远小于此，客户端排序/过滤在页内完成
+const PAGE_SIZE = 100;
+
+type ShelfSort = 'added' | 'year';
+type ShelfFilter = 'all' | ShelfWikiSource;
+
+// 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
+const SORTS: { v: ShelfSort; zh: string; en: string }[] = [
+  { v: 'added', zh: '按添加时间', en: 'By added' },
+  { v: 'year', zh: '按年份', en: 'By year' },
+];
+const FILTERS: { v: ShelfFilter; zh: string; en: string }[] = [
+  { v: 'all', zh: '全部状态', en: 'All statuses' },
+  { v: 'live', zh: '库版解读', en: 'Library wiki' },
+  { v: 'personal', zh: '个人版解读', en: 'Personal wiki' },
+  { v: 'snapshot', zh: '快照解读', en: 'Snapshot wiki' },
+  { v: 'none', zh: '暂无解读', en: 'No wiki' },
+];
 
 function errText(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
-/** 快照日期 → 「7 月 22 日」 / "Jul 22"。 */
-function fmtSnapshotDate(iso: string | null): string {
-  if (!iso) return '—';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '—';
-  return tr(
-    `${d.getMonth() + 1} 月 ${d.getDate()} 日`,
-    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-  );
-}
+/* ---------------- 左栏列表行（同「我的文献库」EntryRow 版式） ---------------- */
 
-/** 手动添加输入解析：DOI（10.xxx / doi.org 链接）之外一律按 arXiv 编号处理。 */
-function parseImportInput(raw: string): ShelfImportInput | null {
-  let v = raw.trim();
-  if (!v) return null;
-  if (v.includes('doi.org/')) v = v.slice(v.indexOf('doi.org/') + 'doi.org/'.length);
-  if (/^10\.\d{4,}/.test(v)) return { doi: v };
-  if (v.includes('arxiv.org/')) {
-    const seg = v.split('/').filter(Boolean);
-    v = (seg[seg.length - 1] ?? '').replace(/\.pdf$/, '');
-  }
-  return v ? { arxiv_id: v } : null;
-}
-
-/* ---------------- wiki 来源徽标 ---------------- */
-
-function WikiBadge({ item }: { item: ShelfItemRead }) {
-  if (item.wiki_source === 'live') {
-    return (
-      <span
-        className="mono"
-        style={{
-          fontSize: 10,
-          color: 'var(--ok-tx)',
-          background: 'var(--ok-bg)',
-          padding: '1px 7px',
-          borderRadius: 999,
-          flexShrink: 0,
-        }}
-      >
-        {tr('解读可用', 'Wiki available')}
-      </span>
-    );
-  }
-  if (item.wiki_source === 'personal') {
-    return (
-      <span
-        className="mono"
-        title={tr(
-          '这篇论文没有公共库版解读，下面显示的是你自己生成的个人版。',
-          'No shared library wiki for this paper; showing the personal version you generated.',
-        )}
-        style={{
-          fontSize: 10,
-          color: 'var(--accent-text)',
-          background: 'var(--accent-soft)',
-          padding: '1px 7px',
-          borderRadius: 999,
-          flexShrink: 0,
-        }}
-      >
-        {tr('个人版解读', 'Personal wiki')}
-      </span>
-    );
-  }
-  if (item.wiki_source === 'snapshot') {
-    return (
-      <span
-        className="mono"
-        title={tr(
-          '这篇论文的库版解读已不可用（被移除或重编译），下面显示的是入架时的快照。',
-          'The library wiki is no longer available; showing the snapshot taken when it was shelved.',
-        )}
-        style={{
-          fontSize: 10,
-          color: 'var(--warn-tx)',
-          background: 'var(--warn-bg)',
-          padding: '1px 7px',
-          borderRadius: 999,
-          flexShrink: 0,
-        }}
-      >
-        {tr(
-          `库中版本不可用 · ${fmtSnapshotDate(item.snapshot_at)}快照`,
-          `Library copy unavailable · snapshot ${fmtSnapshotDate(item.snapshot_at)}`,
-        )}
-      </span>
-    );
-  }
-  return null;
-}
-
-/* ---------------- 书架卡片（备注内联编辑） ---------------- */
-
-function ShelfCard({
+function ShelfRow({
   item,
-  busy,
-  generating,
-  refreshing,
-  onOpen,
-  onSaveNote,
-  onRemove,
-  onGenerateWiki,
-  onRefreshSnapshot,
+  active,
+  onSelect,
 }: {
   item: ShelfItemRead;
-  busy: boolean;
-  /** 本卡的个人版 wiki 正在生成 */
-  generating: boolean;
-  /** 本卡的快照正在刷新 */
-  refreshing: boolean;
-  onOpen: () => void;
-  onSaveNote: (note: string | null) => void;
-  onRemove: () => void;
-  onGenerateWiki: () => void;
-  onRefreshSnapshot: () => void;
+  active: boolean;
+  onSelect: () => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(item.note ?? '');
   const authors = item.authors.map((a) => a.name).join(', ');
-
-  const save = () => {
-    const next = draft.trim() || null;
-    setEditing(false);
-    if (next !== (item.note ?? null)) onSaveNote(next);
-  };
-
   return (
-    <div className="card" style={{ padding: '14px 16px' }}>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      style={{
+        padding: '12px 16px',
+        borderBottom: '0.5px solid var(--border)',
+        cursor: 'pointer',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        borderLeft: active ? '2px solid var(--accent)' : '2px solid transparent',
+        transition: 'background 0.12s',
+      }}
+    >
+      {/* 顶部 mono 元信息行：编号/venue + 年份；右侧解读状态徽标 */}
       <div className="row gap8" style={{ marginBottom: 5 }}>
-        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+        <span
+          className="mono"
+          style={{
+            fontSize: 10.5,
+            color: active ? 'var(--accent-text)' : 'var(--text-3)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
           {item.arxiv_id ?? item.venue ?? '—'}
         </span>
         {item.year !== null && (
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{item.year}</span>
-        )}
-        <WikiBadge item={item} />
-        {item.wiki_source === 'snapshot' && (
-          <button
-            className="icon-btn"
-            title={tr(
-              '刷新快照：重新拷一份当前可得的最新解读（库版优先，其次个人版）',
-              'Refresh snapshot: re-copy the latest available wiki (library first, then personal)',
-            )}
-            disabled={refreshing}
-            onClick={onRefreshSnapshot}
-            style={{ width: 22, height: 22 }}
-          >
-            <Icon name="refresh" size={12} />
-          </button>
-        )}
-        {item.wiki_source === 'none' && (
-          <button
-            className="btn btn-soft sm"
-            title={tr('用 AI 生成这篇论文的个人版解读（将使用你的模型额度）', 'Generate a personal wiki with AI (uses your model quota)')}
-            disabled={generating}
-            onClick={onGenerateWiki}
-            style={{ height: 22, fontSize: 10.5, padding: '0 8px' }}
-          >
-            <Icon name="sparkle" size={11} />
-            {generating ? tr('生成中…', 'Generating…') : tr('生成 wiki', 'Generate wiki')}
-          </button>
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
+            {item.year}
+          </span>
         )}
         <span style={{ marginLeft: 'auto' }} />
-        <button
-          className="icon-btn"
-          title={tr('移出相关研究（个人库收藏保留）', 'Remove from related work (kept in my library)')}
-          disabled={busy}
-          onClick={onRemove}
-        >
-          <Icon name="trash" size={14} />
-        </button>
+        <WikiBadge source={item.wiki_source} compact />
       </div>
 
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={onOpen}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onOpen();
-          }
-        }}
-        title={tr('打开阅读页', 'Open the reading page')}
-        style={{ fontSize: 13.5, fontWeight: 620, lineHeight: 1.35, cursor: 'pointer', color: 'var(--text)' }}
-      >
-        {item.title}
-      </div>
+      <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>{item.title}</div>
+
       {(authors || item.venue) && (
         <div
           title={authors}
@@ -230,54 +119,24 @@ function ShelfCard({
         </div>
       )}
 
-      {/* —— 备注：点击进入编辑，失焦/⌘Enter 保存 —— */}
-      {editing ? (
-        <textarea
-          className="input"
-          autoFocus
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={save}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) save();
-            if (e.key === 'Escape') {
-              setDraft(item.note ?? '');
-              setEditing(false);
-            }
-          }}
-          placeholder={tr('这篇为什么和课题相关？', 'Why is this paper relevant?')}
-          style={{ marginTop: 8, width: '100%', minHeight: 54, fontSize: 12, lineHeight: 1.5, resize: 'vertical' }}
-        />
-      ) : (
-        <button
-          onClick={() => {
-            setDraft(item.note ?? '');
-            setEditing(true);
-          }}
-          title={tr('编辑备注', 'Edit note')}
-          style={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: 6,
-            width: '100%',
-            marginTop: 8,
-            padding: '6px 8px',
-            border: 'none',
-            borderRadius: 8,
-            background: item.note ? 'var(--surface-2)' : 'transparent',
-            cursor: 'text',
-            textAlign: 'left',
-            fontSize: 12,
-            lineHeight: 1.5,
-            fontFamily: 'var(--sans)',
-            color: item.note ? 'var(--text-2)' : 'var(--text-4)',
-          }}
-        >
-          <Icon name="pen" size={12} style={{ marginTop: 2, flexShrink: 0, color: 'var(--text-4)' }} />
-          <span style={{ whiteSpace: 'pre-wrap' }}>
-            {item.note ?? tr('添加备注：这篇为什么相关…', 'Add a note: why is this relevant…')}
+      {/* 备注摘要一行：写过备注才显示 */}
+      {item.note && (
+        <div className="row gap6" style={{ marginTop: 5, alignItems: 'flex-start' }}>
+          <Icon name="pen" size={11} style={{ marginTop: 2, flexShrink: 0, color: 'var(--text-4)' }} />
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 11.5,
+              color: 'var(--text-3)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {item.note}
           </span>
-        </button>
+        </div>
       )}
     </div>
   );
@@ -295,14 +154,16 @@ export function ResearchPage() {
   const wikiHref = topicLib ? libraryPath(topicLib.id) : topicPath(pid, 'wiki');
 
   const [page, setPage] = useState(1);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
-  const [qInput, setQInput] = useState('');
-  const q = useDebounced(qInput.trim());
-  const [importInput, setImportInput] = useState('');
-  const importRef = useRef<HTMLInputElement | null>(null);
+  const [sort, setSort] = useState<ShelfSort>('added');
+  const [filter, setFilter] = useState<ShelfFilter>('all');
+  const [selId, setSelId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
 
-  useEffect(() => setPage(1), [pid]);
+  useEffect(() => {
+    setPage(1);
+    setSelId(null);
+    setFilter('all');
+  }, [pid]);
 
   const shelfQuery = useQuery({
     queryKey: ['shelf', pid, page],
@@ -319,13 +180,21 @@ export function ResearchPage() {
   });
   const shelvedIds = new Set(idsQuery.data?.paper_ids ?? []);
 
-  const searchQuery = useQuery({
-    queryKey: ['shelf-search', pid, q],
-    queryFn: () => api.searchProject(pid, { q, limit: 8 }),
-    enabled: !!pid && searchOpen && q.length > 0,
-    retry: false,
-    placeholderData: keepPreviousData,
-  });
+  const data = shelfQuery.data;
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / data.size)) : 1;
+
+  // 客户端排序 + 状态过滤（书架规模小，页内完成）
+  const visible = useMemo(() => {
+    const filtered = filter === 'all' ? items : items.filter((i) => i.wiki_source === filter);
+    const sorted = [...filtered];
+    if (sort === 'year') sorted.sort((a, b) => (b.year ?? -1) - (a.year ?? -1));
+    else sorted.sort((a, b) => b.added_at.localeCompare(a.added_at));
+    return sorted;
+  }, [items, filter, sort]);
+
+  // 选中项：优先手动选择；不在可见列表（被过滤/移出）时退回第一条
+  const selected = visible.find((i) => i.paper_id === selId) ?? visible[0] ?? null;
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['shelf', pid] });
@@ -337,18 +206,19 @@ export function ResearchPage() {
 
   const addMutation = useMutation({
     mutationFn: (paperId: string) => api.addToShelf(pid, { paper_id: paperId }),
-    onSuccess: () => {
+    onSuccess: (item) => {
       toast(tr('已加入相关研究', 'Added to related work'), 'ok');
+      setSelId(item.paper_id);
       invalidate();
     },
-    onError: (e) => toast(`${tr('入架失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
+    onError: (e) => toast(`${tr('添加失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
   });
 
   const importMutation = useMutation({
     mutationFn: (input: ShelfImportInput) => api.importToShelf(pid, input),
-    onSuccess: () => {
+    onSuccess: (item) => {
       toast(tr('已添加到相关研究', 'Added to related work'), 'ok');
-      setImportInput('');
+      setSelId(item.paper_id);
       invalidate();
     },
     onError: (e) => toast(`${tr('添加失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
@@ -363,8 +233,9 @@ export function ResearchPage() {
 
   const removeMutation = useMutation({
     mutationFn: (paperId: string) => api.removeFromShelf(pid, paperId),
-    onSuccess: () => {
+    onSuccess: (_d, paperId) => {
       toast(tr('已移出相关研究（个人库收藏保留）', 'Removed (still saved in my library)'), 'ok');
+      setSelId((old) => (old === paperId ? null : old));
       invalidate();
     },
     onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
@@ -389,230 +260,204 @@ export function ResearchPage() {
     onError: (e) => toast(`${tr('刷新失败：', 'Failed to refresh: ')}${errText(e)}`, 'error'),
   });
 
-  const submitImport = () => {
-    const input = parseImportInput(importInput);
-    if (!input) {
-      toast(tr('先输入 arXiv 编号或 DOI', 'Enter an arXiv ID or DOI first'), 'info');
-      return;
-    }
-    importMutation.mutate(input);
-  };
-
-  const data = shelfQuery.data;
-  const items = data?.items ?? [];
-  const totalPages = data ? Math.max(1, Math.ceil(data.total / data.size)) : 1;
-  const busy = addMutation.isPending || removeMutation.isPending || noteMutation.isPending;
+  const countText =
+    data === undefined
+      ? ''
+      : filter === 'all'
+        ? tr(`共 ${data.total} 篇相关研究`, `${data.total} related papers`)
+        : tr(`筛出 ${visible.length} 篇 · 共 ${data.total} 篇`, `${visible.length} shown · ${data.total} total`);
 
   return (
-    <div style={{ padding: '26px 30px', maxWidth: 860 }}>
+    <div
+      className="page fadeup"
+      style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}
+    >
       <PageHead
-        eyebrow={tr('课题研究', 'Topic')}
+        eyebrow="Polaris · Related Work"
         title={tr('相关研究', 'Related Work')}
         sub={tr(
-          '这个课题直接依赖的论文书架：从文献库挑选，或手动补充库外论文。',
-          'Papers this topic builds on: pick from the library, or add ones outside it.',
+          '这个课题直接依赖的论文：从文献库挑选，写下为什么相关，随手翻解读。',
+          'Papers this topic builds on: pick from the library, note why they matter, read the wikis.',
         )}
         right={
-          <>
-            <button
-              className={'btn sm ' + (searchOpen ? 'btn-primary' : 'btn-soft')}
-              onClick={() => {
-                setSearchOpen((o) => !o);
-                setImportOpen(false);
-              }}
-            >
-              <Icon name="search" size={13} />
-              {tr('从文献库添加', 'Add from library')}
-            </button>
-            <button
-              className={'btn sm ' + (importOpen ? 'btn-primary' : 'btn-soft')}
-              onClick={() => {
-                setImportOpen((o) => !o);
-                setSearchOpen(false);
-              }}
-            >
-              <Icon name="plus" size={13} />
-              {tr('手动添加', 'Add manually')}
-            </button>
-          </>
+          <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
+            <Icon name="plus" size={13} />
+            {tr('添加论文', 'Add papers')}
+          </button>
         }
       />
 
-      {/* —— 从文献库添加：按当前课题库检索，一键入架 —— */}
-      {searchOpen && (
-        <div className="card" style={{ padding: 14, marginBottom: 16 }}>
-          <div className="row gap10">
-            <SearchInput
-              value={qInput}
-              onChange={setQInput}
-              placeholder={tr('搜文献库：标题 / 摘要 / 解读…', 'Search the library: title / abstract / wiki…')}
-            />
-            <button className="btn btn-ghost sm" onClick={() => navigate(wikiHref)}>
-              {tr('去文献库', 'Open the library')}
-            </button>
-          </div>
-          {q.length > 0 && (
-            <div className="col" style={{ marginTop: 10 }}>
-              {searchQuery.isLoading ? (
-                <div className="empty" style={{ padding: 14 }}>{tr('搜索中…', 'Searching…')}</div>
-              ) : (searchQuery.data?.papers ?? []).length === 0 ? (
-                <div className="empty" style={{ padding: 14 }}>
-                  {tr('文献库里没搜到，试试「手动添加」', 'Nothing found in the library — try “Add manually”')}
+      {/* —— 双栏卡片容器（同「我的文献库」外壳；窄屏上下堆叠） —— */}
+      <div
+        className="card"
+        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+      >
+        <div className="split split-stackable">
+          {/* —— 左：书架列表 —— */}
+          <div className="split-list">
+            {/* 工具栏：排序 + 状态过滤 + 计数 */}
+            <div style={{ padding: '12px 14px 10px', borderBottom: '0.5px solid var(--border)' }}>
+              <div className="row gap8">
+                <Segmented<ShelfSort>
+                  options={SORTS.map((s) => ({ v: s.v, label: tr(s.zh, s.en) }))}
+                  value={sort}
+                  onChange={setSort}
+                />
+                <SelectMenu
+                  value={filter}
+                  options={FILTERS.map((f) => ({ value: f.v, label: tr(f.zh, f.en) }))}
+                  onChange={(v) => setFilter(v as ShelfFilter)}
+                  wrapStyle={{ marginLeft: 'auto', width: 118, flexShrink: 0 }}
+                  style={{ height: 30, fontSize: 12 }}
+                />
+              </div>
+              <div className="mono" style={{ marginTop: 8, fontSize: 10.5, color: 'var(--text-3)' }}>
+                {countText}
+              </div>
+            </div>
+
+            {/* 列表（自滚动） */}
+            <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>
+              {shelfQuery.isLoading ? (
+                <div style={{ padding: 14 }} className="col gap12">
+                  <div className="skel" style={{ height: 84 }} />
+                  <div className="skel" style={{ height: 84 }} />
+                  <div className="skel" style={{ height: 84 }} />
                 </div>
+              ) : shelfQuery.isError ? (
+                <EmptyState
+                  compact
+                  icon="x"
+                  title={tr('加载不出相关研究', 'Cannot load related work')}
+                  desc={tr('后端暂时不可用，稍后再试。', 'The backend is unavailable — try again later.')}
+                  action={
+                    <button className="btn btn-soft sm" onClick={() => void shelfQuery.refetch()}>
+                      {tr('重试', 'Retry')}
+                    </button>
+                  }
+                />
+              ) : items.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="pin"
+                  title={tr('还没有添加论文', 'No papers yet')}
+                  desc={tr('这个课题直接依赖的论文会列在这里。', 'Papers this topic builds on will show up here.')}
+                />
+              ) : visible.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="search"
+                  title={tr('没有这个状态的论文', 'No papers in this status')}
+                  action={
+                    <button className="btn btn-soft sm" onClick={() => setFilter('all')}>
+                      {tr('清除过滤', 'Clear filter')}
+                    </button>
+                  }
+                />
               ) : (
-                (searchQuery.data?.papers ?? []).map((p) => {
-                  const added = shelvedIds.has(p.id);
-                  return (
-                    <div
-                      key={p.id}
-                      className="row gap10"
-                      style={{ padding: '8px 4px', borderBottom: '0.5px solid var(--border)' }}
-                    >
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 12.5, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
-                        <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginTop: 2 }}>
-                          {p.arxiv_id ?? p.venue ?? '—'}
-                          {p.year !== null ? ` · ${p.year}` : ''}
-                        </div>
-                      </div>
-                      {added ? (
-                        <span className="row gap6" style={{ fontSize: 11.5, color: 'var(--ok-tx)', flexShrink: 0 }}>
-                          <Icon name="check" size={13} />
-                          {tr('已入架', 'Added')}
-                        </span>
-                      ) : (
-                        <button
-                          className="btn btn-soft sm"
-                          disabled={addMutation.isPending}
-                          onClick={() => addMutation.mutate(p.id)}
-                        >
-                          <Icon name="plus" size={12} />
-                          {tr('入架', 'Add')}
-                        </button>
-                      )}
-                    </div>
-                  );
-                })
+                visible.map((item) => (
+                  <ShelfRow
+                    key={item.paper_id}
+                    item={item}
+                    active={item.paper_id === selected?.paper_id}
+                    onSelect={() => setSelId(item.paper_id)}
+                  />
+                ))
               )}
             </div>
-          )}
-        </div>
-      )}
 
-      {/* —— 手动添加：arXiv 编号 / DOI —— */}
-      {importOpen && (
-        <div className="card" style={{ padding: 14, marginBottom: 16 }}>
-          <div className="row gap10">
-            <input
-              ref={importRef}
-              className="input"
-              autoFocus
-              style={{ height: 32, fontSize: 12.5, flex: 1, minWidth: 0 }}
-              value={importInput}
-              onChange={(e) => setImportInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') submitImport();
-              }}
-              placeholder={tr('arXiv 编号（如 2401.12345）或 DOI（如 10.1234/abc）', 'arXiv ID (e.g. 2401.12345) or DOI (e.g. 10.1234/abc)')}
-            />
-            <button className="btn btn-primary sm" disabled={importMutation.isPending} onClick={submitImport}>
-              {importMutation.isPending ? tr('解析中…', 'Resolving…') : tr('添加', 'Add')}
-            </button>
+            {/* 底部分页栏（超过单页上限 100 才出现） */}
+            {totalPages > 1 && (
+              <div
+                className="row gap12"
+                style={{
+                  padding: '9px 14px',
+                  borderTop: '0.5px solid var(--border)',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+                  <Icon name="chevron" size={12} style={{ transform: 'rotate(180deg)' }} />
+                  {tr('上一页', 'Prev')}
+                </button>
+                <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                  {tr(`第 ${page} / ${totalPages} 页`, `Page ${page} / ${totalPages}`)}
+                </span>
+                <button
+                  className="btn btn-ghost sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  {tr('下一页', 'Next')}
+                  <Icon name="chevron" size={12} />
+                </button>
+              </div>
+            )}
           </div>
-          <div style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 8, lineHeight: 1.5 }}>
-            {tr(
-              '文献库里没有的论文也能加：平台会自动抓取元数据和 PDF，只进这个课题的相关研究和你的个人文献库，不影响公共文献库。',
-              'Papers outside the library work too: metadata and PDF are fetched automatically. They go to this topic and your personal library only — the shared library is untouched.',
+
+          {/* —— 右：详情 / 空态引导 —— */}
+          <div className="split-detail">
+            {selected ? (
+              <ShelfDetailPane
+                key={selected.paper_id}
+                item={selected}
+                notePending={noteMutation.isPending && noteMutation.variables?.paperId === selected.paper_id}
+                onSaveNote={(note) => noteMutation.mutate({ paperId: selected.paper_id, note })}
+                removePending={removeMutation.isPending}
+                onRemove={() => removeMutation.mutate(selected.paper_id)}
+                generating={generateMutation.isPending && generateMutation.variables === selected.paper_id}
+                onGenerateWiki={() => generateMutation.mutate(selected.paper_id)}
+                refreshing={
+                  refreshSnapshotMutation.isPending && refreshSnapshotMutation.variables === selected.paper_id
+                }
+                onRefreshSnapshot={() => refreshSnapshotMutation.mutate(selected.paper_id)}
+              />
+            ) : shelfQuery.isSuccess && items.length === 0 ? (
+              /* 书架为空 → 右栏放引导 */
+              <div style={{ margin: 'auto' }}>
+                <EmptyState
+                  icon="pin"
+                  title={tr('从文献库挑几篇开始', 'Start by picking a few papers')}
+                  desc={tr(
+                    '把这个课题直接依赖的论文放进来，给每篇写一句为什么相关——后面的想法、实验、写作都会以这里为地基。',
+                    'Shelve the papers this topic builds on and note why each matters — ideas, experiments and writing all build on this.',
+                  )}
+                  action={
+                    <div className="row gap10" style={{ justifyContent: 'center' }}>
+                      <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
+                        <Icon name="plus" size={13} />
+                        {tr('添加论文', 'Add papers')}
+                      </button>
+                      <button className="btn btn-soft sm" onClick={() => navigate(wikiHref)}>
+                        <Icon name="book" size={13} />
+                        {tr('去文献库', 'Open the library')}
+                      </button>
+                    </div>
+                  }
+                />
+              </div>
+            ) : (
+              <div className="empty" style={{ margin: 'auto' }}>
+                {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+              </div>
             )}
           </div>
         </div>
-      )}
+      </div>
 
-      {/* —— 书架列表 —— */}
-      {shelfQuery.isLoading ? (
-        <div className="col gap12">
-          <div className="skel" style={{ height: 110 }} />
-          <div className="skel" style={{ height: 110 }} />
-        </div>
-      ) : shelfQuery.isError ? (
-        <EmptyState
-          icon="x"
-          title={tr('加载不出书架', 'Cannot load the shelf')}
-          desc={tr('后端暂时不可用，稍后再试。', 'The backend is unavailable — try again later.')}
-          action={
-            <button className="btn btn-soft sm" onClick={() => void shelfQuery.refetch()}>
-              {tr('重试', 'Retry')}
-            </button>
-          }
-        />
-      ) : items.length === 0 ? (
-        <EmptyState
-          icon="pin"
-          title={tr('书架还空着', 'The shelf is empty')}
-          desc={tr(
-            '去文献库逛逛，把相关论文加进来；或直接输入 arXiv 编号添加。',
-            'Browse the library and shelve relevant papers, or add one by arXiv ID.',
-          )}
-          action={
-            <div className="row gap10">
-              <button className="btn btn-primary sm" onClick={() => navigate(wikiHref)}>
-                <Icon name="book" size={13} />
-                {tr('去文献库', 'Open the library')}
-              </button>
-              <button
-                className="btn btn-soft sm"
-                onClick={() => {
-                  setImportOpen(true);
-                  setSearchOpen(false);
-                  setTimeout(() => importRef.current?.focus(), 0);
-                }}
-              >
-                <Icon name="plus" size={13} />
-                {tr('手动添加', 'Add manually')}
-              </button>
-            </div>
-          }
-        />
-      ) : (
-        <div className="col gap12">
-          <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
-            {tr(`共 ${data?.total ?? items.length} 篇`, `${data?.total ?? items.length} papers`)}
-          </div>
-          {items.map((item) => (
-            <ShelfCard
-              key={item.paper_id}
-              item={item}
-              busy={busy}
-              generating={generateMutation.isPending && generateMutation.variables === item.paper_id}
-              refreshing={
-                refreshSnapshotMutation.isPending && refreshSnapshotMutation.variables === item.paper_id
-              }
-              onOpen={() => navigate(`/papers/${item.paper_id}/read`)}
-              onSaveNote={(note) => noteMutation.mutate({ paperId: item.paper_id, note })}
-              onRemove={() => removeMutation.mutate(item.paper_id)}
-              onGenerateWiki={() => generateMutation.mutate(item.paper_id)}
-              onRefreshSnapshot={() => refreshSnapshotMutation.mutate(item.paper_id)}
-            />
-          ))}
-          {totalPages > 1 && (
-            <div className="row gap10" style={{ justifyContent: 'center', padding: '6px 0' }}>
-              <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-                {tr('上一页', 'Prev')}
-              </button>
-              <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)' }}>
-                {page} / {totalPages}
-              </span>
-              <button
-                className="btn btn-ghost sm"
-                disabled={page >= totalPages}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                {tr('下一页', 'Next')}
-              </button>
-            </div>
-          )}
-        </div>
-      )}
+      {/* —— 添加论文（从文献库 / 手动）统一弹窗 —— */}
+      <AddPaperModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        pid={pid}
+        shelvedIds={shelvedIds}
+        wikiHref={wikiHref}
+        addPending={addMutation.isPending}
+        onAdd={(paperId) => addMutation.mutate(paperId)}
+        importPending={importMutation.isPending}
+        onImport={(input) => importMutation.mutateAsync(input)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -1,0 +1,497 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { CompileBadge } from '../../components/ui/CompileBadge';
+import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
+import { Markdown } from '../../lib/markdown';
+import { api, type ShelfItemRead, type ShelfWikiSource } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { libraryPath, useLibraries } from '../libraries/hooks';
+
+/* ============================================================
+   相关研究 · 右栏详情（与「我的文献库」LibraryDetailPane 同一版式）：
+   - 顶部：解读状态徽标 + venue，标题 + 作者，主操作行
+     （打开阅读页 / arXiv / 生成 wiki / 刷新快照 / 移出）；
+   - 课题备注「为什么相关」：多行编辑、停止输入后自动保存；
+   - frontmatter 风格元数据卡（含加入时间与来源）；
+   - TL;DR / 摘要（摘要取自论文详情接口）；
+   - wiki 正文：列表接口已按 库版实时 > 个人版 > 快照 解析好，
+     直接渲染 markdown（双链 → 来源方向库，嵌图取论文详情）。
+   ============================================================ */
+
+/* ---------------- wiki 来源徽标（四态统一） ---------------- */
+
+// 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
+const BADGE: Record<
+  ShelfWikiSource,
+  { zh: string; en: string; fg: string; bg: string; tipZh: string; tipEn: string }
+> = {
+  live: {
+    zh: '库版解读',
+    en: 'Library wiki',
+    fg: 'var(--accent-text)',
+    bg: 'var(--accent-soft)',
+    tipZh: '显示方向文献库的实时解读，库里更新会自动跟着变。',
+    tipEn: 'Live wiki from the shared direction library; follows library updates automatically.',
+  },
+  personal: {
+    zh: '个人版解读',
+    en: 'Personal wiki',
+    fg: 'var(--violet-tx)',
+    bg: 'var(--violet-bg)',
+    tipZh: '库里没有这篇的解读，显示的是你自己生成的个人版。',
+    tipEn: 'No library wiki for this paper; showing the personal version you generated.',
+  },
+  snapshot: {
+    zh: '快照解读',
+    en: 'Snapshot wiki',
+    fg: 'var(--warn-tx)',
+    bg: 'var(--warn-bg)',
+    tipZh: '库版解读已不可用（被移除或重编译），显示的是添加时保存的快照，可手动刷新。',
+    tipEn: 'The library wiki is gone (removed or recompiled); showing the snapshot saved when added. You can refresh it.',
+  },
+  none: {
+    zh: '暂无解读',
+    en: 'No wiki',
+    fg: 'var(--text-3)',
+    bg: 'var(--surface-3)',
+    tipZh: '这篇论文还没有任何解读，可以用 AI 生成个人版。',
+    tipEn: 'No wiki for this paper yet — you can generate a personal one with AI.',
+  },
+};
+
+/** 快照日期 → 「7 月 22 日」 / "Jul 22"。 */
+export function fmtSnapshotDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return tr(
+    `${d.getMonth() + 1} 月 ${d.getDate()} 日`,
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  );
+}
+
+/** 完整日期 → 「2026 年 7 月 22 日」 / "Jul 22, 2026"。 */
+function fmtDay(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return tr(
+    `${d.getFullYear()} 年 ${d.getMonth() + 1} 月 ${d.getDate()} 日`,
+    d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
+  );
+}
+
+/** wiki 来源徽标：compact 用于列表行（更小、快照不带日期）。 */
+export function WikiBadge({
+  source,
+  snapshotAt,
+  compact,
+}: {
+  source: ShelfWikiSource;
+  snapshotAt?: string | null;
+  compact?: boolean;
+}) {
+  const b = BADGE[source];
+  const label =
+    !compact && source === 'snapshot'
+      ? tr(`${b.zh} · ${fmtSnapshotDate(snapshotAt ?? null)}`, `${b.en} · ${fmtSnapshotDate(snapshotAt ?? null)}`)
+      : tr(b.zh, b.en);
+  return (
+    <span
+      className="mono"
+      title={tr(b.tipZh, b.tipEn)}
+      style={{
+        fontSize: compact ? 10 : 10.5,
+        color: b.fg,
+        background: b.bg,
+        padding: compact ? '1px 7px' : '2px 9px',
+        borderRadius: 999,
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+/* ---------------- 课题备注：多行 + 自动保存 ---------------- */
+
+const NOTE_SAVE_DELAY = 1000;
+
+function NoteEditor({
+  note,
+  pending,
+  onSave,
+}: {
+  note: string | null;
+  pending: boolean;
+  onSave: (note: string | null) => void;
+}) {
+  const [draft, setDraft] = useState(note ?? '');
+  const timerRef = useRef<number | null>(null);
+
+  // 最新 draft / note / onSave 存 ref：定时器与卸载兜底里用，避免闭包过期
+  const stateRef = useRef({ draft, note, onSave });
+  stateRef.current = { draft, note, onSave };
+
+  const commit = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const s = stateRef.current;
+    const next = s.draft.trim() || null;
+    if (next !== (s.note ?? null)) s.onSave(next);
+  }, []);
+
+  // 卸载（切换选中论文）时把没落盘的改动补交
+  useEffect(() => commit, [commit]);
+
+  const onChange = (v: string) => {
+    setDraft(v);
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(commit, NOTE_SAVE_DELAY);
+  };
+
+  const dirty = (draft.trim() || null) !== (note ?? null);
+  const status = pending
+    ? tr('保存中…', 'Saving…')
+    : dirty
+      ? tr('停下来会自动保存', 'Auto-saves when you pause')
+      : note
+        ? tr('已保存', 'Saved')
+        : '';
+
+  return (
+    <div
+      style={{
+        marginTop: 18,
+        padding: '12px 16px 10px',
+        borderRadius: 10,
+        background: 'var(--surface-2)',
+      }}
+    >
+      <div className="row gap8">
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', letterSpacing: '0.04em' }}>
+          {tr('为什么相关', 'Why relevant')}
+        </span>
+        <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
+          {status}
+        </span>
+      </div>
+      <textarea
+        value={draft}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={commit}
+        placeholder={tr('写一句为什么相关…', 'Write a line on why this matters…')}
+        style={{
+          width: '100%',
+          minHeight: 56,
+          marginTop: 6,
+          padding: 0,
+          border: 'none',
+          outline: 'none',
+          background: 'transparent',
+          resize: 'vertical',
+          fontFamily: 'var(--sans)',
+          fontSize: 12.5,
+          lineHeight: 1.65,
+          color: 'var(--text-2)',
+        }}
+      />
+    </div>
+  );
+}
+
+/* ---------------- 详情面板 ---------------- */
+
+/** frontmatter 风格元数据行（同「我的文献库」详情面板版式）。 */
+function MetaItem({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="row" style={{ gap: 12, padding: '4px 0', alignItems: 'flex-start' }}>
+      <span className="mono" style={{ fontSize: 11, color: 'var(--accent-text)', width: 88, flexShrink: 0 }}>
+        {label}
+      </span>
+      <span style={{ fontSize: 12.5, color: 'var(--text-2)', flex: 1, minWidth: 0, overflowWrap: 'break-word' }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function ShelfDetailPane({
+  item,
+  notePending,
+  onSaveNote,
+  removePending,
+  onRemove,
+  generating,
+  onGenerateWiki,
+  refreshing,
+  onRefreshSnapshot,
+}: {
+  item: ShelfItemRead;
+  notePending: boolean;
+  onSaveNote: (note: string | null) => void;
+  removePending: boolean;
+  onRemove: () => void;
+  /** 本篇的个人版 wiki 正在生成 */
+  generating: boolean;
+  onGenerateWiki: () => void;
+  /** 本篇的快照正在刷新 */
+  refreshing: boolean;
+  onRefreshSnapshot: () => void;
+}) {
+  const navigate = useNavigate();
+
+  // 摘要 / TL;DR / 嵌图 / 编译信息来自论文详情（与阅读页、文献追踪同 queryKey 缓存互通）
+  const paperQuery = useQuery({
+    queryKey: ['paper', item.paper_id],
+    queryFn: () => api.getPaper(item.paper_id),
+    retry: false,
+  });
+  const paper = paperQuery.data;
+
+  // 来源方向库名（列表小且 5 分钟缓存，直接查全量列表）
+  const libsQuery = useLibraries(item.source_library_id !== null);
+  const sourceLib = item.source_library_id
+    ? (libsQuery.data?.find((l) => l.id === item.source_library_id) ?? null)
+    : null;
+
+  // 正文 ![[fig:N]] 嵌入图（同文献追踪）
+  const figures = usePaperFigures(paper);
+  const renderFigure = useCallback(
+    (n: number) => {
+      const fig = figures.find((f) => f.index === n);
+      return fig && paper ? <FigureEmbed paperId={paper.id} fig={fig} /> : null;
+    },
+    [figures, paper],
+  );
+
+  // [[概念]] 双链 → 来源方向库的概念页；个人补充（无来源库）退到库列表
+  const onWikiLink = useCallback(
+    (name: string) =>
+      navigate(
+        item.source_library_id
+          ? libraryPath(item.source_library_id, `?concept=${encodeURIComponent(name)}`)
+          : '/libraries',
+      ),
+    [navigate, item.source_library_id],
+  );
+
+  const authors = item.authors.map((a) => a.name).join(', ');
+  const tldr = item.tldr ?? paper?.tldr ?? null;
+  const abstract = paper?.abstract ?? null;
+  const arxivUrl = item.arxiv_id ? `https://arxiv.org/abs/${item.arxiv_id}` : null;
+
+  const wikiLabel =
+    item.wiki_source === 'live'
+      ? tr('AI 图文介绍 · 库版', 'AI intro · library')
+      : item.wiki_source === 'personal'
+        ? tr('AI 图文介绍 · 个人版', 'AI intro · personal')
+        : tr(
+            `AI 图文介绍 · ${fmtSnapshotDate(item.snapshot_at)}快照`,
+            `AI intro · snapshot ${fmtSnapshotDate(item.snapshot_at)}`,
+          );
+
+  return (
+    <div className="scroll fadeup" key={item.paper_id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
+      {/* —— pills 行：解读状态 + venue —— */}
+      <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
+        <WikiBadge source={item.wiki_source} snapshotAt={item.snapshot_at} />
+        {item.venue && (
+          <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
+            {item.venue}
+          </span>
+        )}
+      </div>
+
+      {/* —— 标题 + 作者 —— */}
+      <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
+        {item.title}
+      </h1>
+      {authors && <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>{authors}</div>}
+
+      {/* —— 操作行 —— */}
+      <div className="row gap8 wrap" style={{ marginTop: 14 }}>
+        <button className="btn btn-primary sm" onClick={() => navigate(`/papers/${item.paper_id}/read`)}>
+          <Icon name="file" size={13} />
+          {tr('打开阅读页', 'Open reader')}
+        </button>
+        {arxivUrl && (
+          <a
+            className="btn btn-ghost sm"
+            href={arxivUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ textDecoration: 'none' }}
+          >
+            <Icon name="link" size={13} />
+            arXiv
+          </a>
+        )}
+        {item.url && !arxivUrl && (
+          <a
+            className="btn btn-ghost sm"
+            href={item.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ textDecoration: 'none' }}
+          >
+            <Icon name="link" size={13} />
+            {tr('原文链接', 'Source link')}
+          </a>
+        )}
+        {item.wiki_source === 'none' && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('用 AI 生成这篇论文的个人版解读（使用你的模型额度）', 'Generate a personal wiki with AI (uses your model quota)')}
+            disabled={generating}
+            onClick={onGenerateWiki}
+          >
+            <Icon name="sparkle" size={13} />
+            {generating ? tr('生成中…', 'Generating…') : tr('生成 wiki', 'Generate wiki')}
+          </button>
+        )}
+        {item.wiki_source === 'snapshot' && (
+          <button
+            className="btn btn-soft sm"
+            title={tr(
+              '重新拷一份当前可得的最新解读（库版优先，其次个人版）',
+              'Re-copy the latest available wiki (library first, then personal)',
+            )}
+            disabled={refreshing}
+            onClick={onRefreshSnapshot}
+          >
+            <Icon name="refresh" size={13} />
+            {refreshing ? tr('刷新中…', 'Refreshing…') : tr('刷新快照', 'Refresh snapshot')}
+          </button>
+        )}
+        <button
+          className="btn btn-ghost sm"
+          title={tr('移出相关研究（个人库收藏保留）', 'Remove from related work (kept in my library)')}
+          disabled={removePending}
+          onClick={onRemove}
+          style={{ marginLeft: 'auto', color: 'var(--danger-tx)' }}
+        >
+          <Icon name="trash" size={13} />
+          {tr('移出', 'Remove')}
+        </button>
+      </div>
+
+      {/* —— 课题备注：为什么相关 —— */}
+      <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />
+
+      {/* —— frontmatter 风格元数据卡 —— */}
+      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+        <MetaItem label="arxiv_id">
+          {item.arxiv_id ? <span className="mono">{item.arxiv_id}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="doi">
+          {item.doi ? <span className="mono">{item.doi}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label={tr('年份', 'year')}>
+          {item.year !== null ? <span className="mono">{item.year}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label={tr('发表于', 'venue')}>{item.venue ?? <span className="muted">—</span>}</MetaItem>
+        <MetaItem label={tr('加入时间', 'added')}>
+          <span className="mono">{fmtDay(item.added_at)}</span>
+        </MetaItem>
+        <MetaItem label={tr('来源', 'source')}>
+          {item.source_library_id ? (
+            <button
+              onClick={() => navigate(libraryPath(item.source_library_id ?? ''))}
+              style={{
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                cursor: 'pointer',
+                fontSize: 12.5,
+                fontFamily: 'var(--sans)',
+                color: 'var(--accent-text)',
+              }}
+            >
+              {sourceLib ? sourceLib.name : tr('方向文献库', 'Direction library')}
+            </button>
+          ) : (
+            tr('手动添加', 'Added manually')
+          )}
+        </MetaItem>
+      </div>
+
+      {/* —— TL;DR —— */}
+      {tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {tldr}
+        </div>
+      )}
+
+      {/* —— 摘要 —— */}
+      {abstract && (
+        <div style={{ marginTop: 18 }}>
+          <div className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em', marginBottom: 6 }}>
+            {tr('摘要', 'Abstract')}
+          </div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>{abstract}</div>
+        </div>
+      )}
+
+      {/* —— wiki 正文（库版实时 > 个人版 > 快照，接口已解析好） —— */}
+      {item.wiki_content ? (
+        <div style={{ marginTop: 22 }}>
+          <div
+            className="row gap8"
+            style={{ paddingBottom: 10, marginBottom: 16, borderBottom: '0.5px solid var(--border)' }}
+          >
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+              {wikiLabel}
+            </span>
+            {item.wiki_source === 'live' && <CompileBadge model={paper?.compiled_model} at={paper?.compiled_at} />}
+          </div>
+          <Markdown source={item.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
+        </div>
+      ) : (
+        <div
+          style={{
+            marginTop: 22,
+            padding: '18px 20px',
+            borderRadius: 10,
+            border: '1px dashed var(--border-2)',
+            textAlign: 'center',
+          }}
+        >
+          <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
+            {tr(
+              '这篇论文还没有解读。可以用 AI 生成一份个人版（使用你的模型额度）。',
+              'No wiki for this paper yet. Generate a personal one with AI (uses your model quota).',
+            )}
+          </div>
+          <button
+            className="btn btn-soft sm"
+            style={{ marginTop: 10 }}
+            disabled={generating}
+            onClick={onGenerateWiki}
+          >
+            <Icon name="sparkle" size={13} />
+            {generating ? tr('生成中…', 'Generating…') : tr('生成 wiki', 'Generate wiki')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -551,6 +551,15 @@ select.input { padding-right: 8px; cursor: pointer; }
 /* zoom 0.91 ≈ 1/1.1：右侧详情面板抵消全局放大，恢复原始大小 */
 .split-detail { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; zoom: 0.91; }
 
+/* 窄屏（相关研究等 opt-in 双栏页）：双栏改上下堆叠，列表在上、详情在下 */
+@media (max-width: 920px) {
+  .split-stackable { flex-direction: column; }
+  .split-stackable .split-list {
+    width: 100%; max-height: 44vh; flex-shrink: 0;
+    border-right: none; border-bottom: 0.5px solid var(--border);
+  }
+}
+
 input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 
 /* [[概念]] 双链 chip */


### PR DESCRIPTION
Design pass on the Related Research page (user request), frontend only.

- Two-pane master-detail layout reusing the proven library-page skeleton: compact shelf list (sort by added-time/year, wiki-state filter, note excerpts) on the left; full detail pane on the right with title/authors, actions (open reader, generate wiki, refresh snapshot, remove), frontmatter card, TL;DR, and rendered wiki with figure embeds and concept backlinks.
- Topic note ("why is this relevant") becomes a persistent autosaving editor in the detail pane.
- Adding papers collapses into one modal with two tabs — search the topic's library, or manual arXiv/DOI with dedup explanation; supports consecutive adds.
- Wiki badges unified to one four-state system (live/personal/snapshot+date/none) with consistent token colors; fixes the previous inconsistent color mapping.
- Responsive: panes stack under 920px via an opt-in rule; no other pages affected. No backend changes; tsc + build pass.