### PR TITLE
feat(libraries): governance — curators, monthly budgets, duplicate merge (IA redesign P6)

### DIFF
--- a/src/backend/alembic/versions/3f770d85dca9_llm_usage_library_attribution.py
+++ b/src/backend/alembic/versions/3f770d85dca9_llm_usage_library_attribution.py
@@ -1,0 +1,53 @@
+"""LLM 用量按方向库归因（P6）
+
+llm_usage / llm_call_logs 加可空 library_id 列（SET NULL）：库侧 ingest
+（打分 / 图注 / wiki 编译 / 概念定义 / 向量化）的调用记到方向库账上，
+支撑库级月度预算与超限暂停；个人消费仍走 user/project 维度，两本账并行。
+
+Revision ID: 3f770d85dca9
+Revises: 1c6c4831d80f
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "3f770d85dca9"
+down_revision: str | None = "1c6c4831d80f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("llm_usage") as batch:
+        batch.add_column(sa.Column("library_id", sa.Uuid(), nullable=True))
+        batch.create_index("ix_llm_usage_library_id", ["library_id"])
+        batch.create_foreign_key(
+            "fk_llm_usage_library_id",
+            "direction_libraries",
+            ["library_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    with op.batch_alter_table("llm_call_logs") as batch:
+        batch.add_column(sa.Column("library_id", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_llm_call_logs_library_id",
+            "direction_libraries",
+            ["library_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("llm_call_logs") as batch:
+        batch.drop_constraint("fk_llm_call_logs_library_id", type_="foreignkey")
+        batch.drop_column("library_id")
+    with op.batch_alter_table("llm_usage") as batch:
+        batch.drop_constraint("fk_llm_usage_library_id", type_="foreignkey")
+        batch.drop_index("ix_llm_usage_library_id")
+        batch.drop_column("library_id")

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -682,6 +682,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     llm=ctx.llm,
                     user_id=ctx.run.created_by,
                     project_id=ctx.run.project_id,
+                    library_id=library.id,
                     voyage_id=ctx.run.id,
                 )
                 if affs:
@@ -807,6 +808,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                         llm=ctx.llm,
                         user_id=ctx.run.created_by,
                         project_id=project_id,
+                        library_id=membership.library_id,
                         voyage_id=ctx.run.id,
                     )
                     await session.commit()
@@ -821,6 +823,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                 llm=ctx.llm,
                 user_id=ctx.run.created_by,
                 project_id=project_id,
+                library_id=membership.library_id,
                 voyage_id=ctx.run.id,
                 extra_guidance=guidance,
             )
@@ -894,6 +897,7 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     texts,
                     user_id=ctx.run.created_by,
                     project_id=ctx.run.project_id,
+                    library_id=library.id,
                     voyage_id=ctx.run.id,
                 )
                 for paper, vector in zip(pending, vectors, strict=True):

--- a/src/backend/app/api/concepts.py
+++ b/src/backend/app/api/concepts.py
@@ -20,7 +20,7 @@ from app.schemas.paper import (
     ConceptRelinkResult,
 )
 from app.services import concepts as concepts_service
-from app.services import projects as projects_service
+from app.services import libraries as libraries_service
 from app.services.libraries import get_library_for_project
 
 router = APIRouter(tags=["concepts"])
@@ -47,7 +47,7 @@ async def list_concepts(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[ConceptRead]:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     library = await get_library_for_project(session, project_id)
@@ -68,7 +68,7 @@ async def relink_concepts(
     面向历史数据（编译过但概念上链步骤没跑到的论文）；新概念定义分批调 LLM，
     并回填此前留下的占位概念（「…（定义待补充）」）重新拿定义，失败降级为占位、不阻塞。
     """
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     library = await get_library_for_project(session, project_id)

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -12,7 +12,7 @@ from app.models.user import User
 from app.schemas.ingest import IngestRequest, IngestStateRead
 from app.schemas.voyage import VoyageRead
 from app.services import ingest as ingest_service
-from app.services import projects as projects_service
+from app.services import libraries as libraries_service
 
 router = APIRouter(tags=["ingest"])
 
@@ -29,7 +29,7 @@ async def start_ingest(
     user: User = Depends(require_llm_task),
     queue: TaskQueue = Depends(get_task_queue),
 ) -> VoyageRead:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     try:
@@ -48,7 +48,7 @@ async def get_ingest_state(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> IngestStateRead:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     state = await ingest_service.ingest_state(session, project)

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -38,6 +38,9 @@ async def start_ingest(
         )
     except ingest_service.IngestConflictError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
+    except ingest_service.LibraryBudgetExhaustedError as e:
+        # 本月预算已用尽：拒绝启动（下月自动恢复，或管理员调高预算）
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
     await queue.enqueue("run_voyage", str(run.id))
     return VoyageRead.model_validate(run)
 

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -10,12 +10,13 @@ project 作用域端点（鉴权同样接入库级写权限助手）。
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_admin
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
-from app.models.library_direction import DirectionLibrary
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.user import User
 from app.schemas.libraries import (
     CuratorRead,
@@ -23,7 +24,10 @@ from app.schemas.libraries import (
     DirectionLibraryDetail,
     DirectionLibrarySummary,
     DirectionLibraryUpdate,
+    DuplicateCandidateGroup,
     LibraryBudgetRead,
+    PaperMergeRequest,
+    PaperMergeResult,
 )
 from app.schemas.paper import (
     ConceptRead,
@@ -36,6 +40,7 @@ from app.schemas.paper import (
 from app.services import concepts as concepts_service
 from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
+from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
 
 router = APIRouter(tags=["libraries"])
@@ -283,3 +288,65 @@ async def search_library(
         for p, s in paper_rows
     ]
     return SearchResponse(papers=papers, concepts=concepts, mode_used=mode_used, reranked=reranked)
+
+
+# ---- P6 治理：重复论文合并 ----
+
+
+@router.get(
+    "/libraries/{library_id}/duplicate-candidates",
+    response_model=list[DuplicateCandidateGroup],
+)
+async def list_duplicate_candidates(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DuplicateCandidateGroup]:
+    """库内疑似重复论文（可管理者）：arxiv/doi 同源不同行，或规范化标题相同。"""
+    library = await _get_managed_library(session, library_id, user)
+    groups = await paper_merge_service.duplicate_candidates(session, library_id=library.id)
+    return [DuplicateCandidateGroup(**group) for group in groups]
+
+
+@router.post("/papers/merge", response_model=PaperMergeResult)
+async def merge_papers(
+    data: PaperMergeRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperMergeResult:
+    """合并重复论文（不可撤销）：drop 行的全部归属并入 keep 后删除 drop。
+
+    权限：平台 admin，或 keep/drop 任一所在方向库的可管理者。
+    """
+    if user.role != "admin":
+        libraries = (
+            (
+                await session.execute(
+                    select(DirectionLibrary)
+                    .join(LibraryPaper, LibraryPaper.library_id == DirectionLibrary.id)
+                    .where(LibraryPaper.paper_id.in_([data.keep_id, data.drop_id]))
+                    .distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        allowed = False
+        for library in libraries:
+            if await libraries_service.can_manage_library(session, user=user, library=library):
+                allowed = True
+                break
+        if not allowed:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="PAPER_MERGE_FORBIDDEN")
+    try:
+        report = await paper_merge_service.merge_papers(
+            session, keep_id=data.keep_id, drop_id=data.drop_id
+        )
+    except ValueError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return PaperMergeResult(
+        kept_id=data.keep_id,
+        dropped_id=data.drop_id,
+        dropped_dedup_key=report.pop("dropped_dedup_key"),
+        details={k: v for k, v in report.items() if k not in ("kept_id", "dropped_id")},
+    )

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -1,7 +1,9 @@
-"""共享方向库只读路由（P5c，docs-dev/workspace-ia-redesign.md §2/§6/§7）。
+"""共享方向库路由（P5c 只读 + P6 治理，docs-dev/workspace-ia-redesign.md §2/§5/§6/§7）。
 
-方向库对全实验室可读：本文件的端点只做登录校验、不做课题成员校验。
-写/管理入口（ingest、论文管理、概念补建等）仍走 project 作用域端点并校验成员。
+方向库对全实验室可读：读端点只做登录校验、不做课题成员校验。
+治理端点（库定义编辑 / 策展人任命）按库级写权限校验：成员 ∪ 策展人 ∪ 平台 admin
+（策展人任命仅平台 admin）。批量写/管理入口（ingest、论文管理、概念补建等）仍走
+project 作用域端点（鉴权同样接入库级写权限助手）。
 个人文献库路由在 ``app/api/library.py``（/me/library），勿混淆。
 """
 
@@ -10,12 +12,18 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user
+from app.api.auth import current_active_user, require_admin
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
 from app.models.library_direction import DirectionLibrary
 from app.models.user import User
-from app.schemas.libraries import DirectionLibraryDetail, DirectionLibrarySummary
+from app.schemas.libraries import (
+    CuratorRead,
+    CuratorsUpdate,
+    DirectionLibraryDetail,
+    DirectionLibrarySummary,
+    DirectionLibraryUpdate,
+)
 from app.schemas.paper import (
     ConceptRead,
     PaperListPage,
@@ -38,6 +46,16 @@ async def _get_library(session: AsyncSession, library_id: uuid.UUID) -> Directio
     return library
 
 
+async def _get_managed_library(
+    session: AsyncSession, library_id: uuid.UUID, user: User
+) -> DirectionLibrary:
+    """治理端点统一入口：库存在 + 请求者有库级写权限（成员/策展人/admin），否则 403。"""
+    library = await _get_library(session, library_id)
+    if not await libraries_service.can_manage_library(session, user=user, library=library):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_MANAGE_FORBIDDEN")
+    return library
+
+
 async def _reads_with_extras(
     session: AsyncSession, papers: list, user_id: uuid.UUID
 ) -> list[PaperRead]:
@@ -53,7 +71,7 @@ async def list_libraries(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[DirectionLibrarySummary]:
-    rows = await libraries_service.list_libraries_overview(session, user_id=user.id)
+    rows = await libraries_service.list_libraries_overview(session, user=user)
     return [DirectionLibrarySummary(**row) for row in rows]
 
 
@@ -64,8 +82,58 @@ async def get_library(
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
     library = await _get_library(session, library_id)
-    row = await libraries_service.library_overview(session, library=library, user_id=user.id)
+    row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
+
+
+@router.patch("/libraries/{library_id}", response_model=DirectionLibraryDetail)
+async def update_library(
+    library_id: uuid.UUID,
+    data: DirectionLibraryUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DirectionLibraryDetail:
+    """编辑库定义（可管理者）：name/statement/cadence/monthly_budget/rubric/anchors。
+
+    过渡期隐式库以库为权威，statement/rubric/anchors/cadence 写时同步回
+    project.definition（保持 ingest 兼容），name 同步 project.name。
+    """
+    library = await _get_managed_library(session, library_id, user)
+    fields = data.model_dump(exclude_unset=True)
+    if fields:
+        library = await libraries_service.update_library(session, library=library, fields=fields)
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
+
+
+@router.get("/libraries/{library_id}/curators", response_model=list[CuratorRead])
+async def list_curators(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[CuratorRead]:
+    """策展人名单（界面叫「文献库管理员」）；可管理者可见。"""
+    library = await _get_managed_library(session, library_id, user)
+    rows = await libraries_service.list_curators(session, library.id)
+    return [CuratorRead(**row) for row in rows]
+
+
+@router.put("/libraries/{library_id}/curators", response_model=list[CuratorRead])
+async def set_curators(
+    library_id: uuid.UUID,
+    data: CuratorsUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> list[CuratorRead]:
+    """全量替换策展人名单（仅平台 admin）。"""
+    library = await _get_library(session, library_id)
+    try:
+        rows = await libraries_service.set_curators(
+            session, library=library, user_ids=data.user_ids
+        )
+    except ValueError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return [CuratorRead(**row) for row in rows]
 
 
 @router.get("/libraries/{library_id}/papers", response_model=PaperListPage)

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -23,6 +23,7 @@ from app.schemas.libraries import (
     DirectionLibraryDetail,
     DirectionLibrarySummary,
     DirectionLibraryUpdate,
+    LibraryBudgetRead,
 )
 from app.schemas.paper import (
     ConceptRead,
@@ -33,6 +34,7 @@ from app.schemas.paper import (
     SearchResponse,
 )
 from app.services import concepts as concepts_service
+from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
 from app.services import papers as papers_service
 
@@ -104,6 +106,28 @@ async def update_library(
         library = await libraries_service.update_library(session, library=library, fields=fields)
     row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
+
+
+@router.get("/libraries/{library_id}/budget", response_model=LibraryBudgetRead)
+async def get_library_budget(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibraryBudgetRead:
+    """本月预算消耗（可管理者）：库侧 LLM 调用（打分/编译/概念定义/向量化）的聚合。"""
+    library = await _get_managed_library(session, library_id, user)
+    usage = await ingest_service.monthly_library_usage(session, library.id)
+    budget = library.monthly_budget
+    used = int(usage["total_tokens"])
+    return LibraryBudgetRead(
+        month=usage["month"],
+        monthly_budget=budget,
+        prompt_tokens=usage["prompt_tokens"],
+        completion_tokens=usage["completion_tokens"],
+        used_tokens=used,
+        remaining_tokens=None if not budget else max(0, int(budget) - used),
+        exhausted=bool(budget) and used >= int(budget),
+    )
 
 
 @router.get("/libraries/{library_id}/curators", response_model=list[CuratorRead])

--- a/src/backend/app/api/notes.py
+++ b/src/backend/app/api/notes.py
@@ -14,9 +14,9 @@ from app.core.db import get_session
 from app.models.paper import PaperNote
 from app.models.user import User
 from app.schemas.note import NotebookPage, NoteCreate, NoteRead, NoteUpdate, NoteWithPaper
+from app.services import libraries as libraries_service
 from app.services import notes as notes_service
 from app.services import papers as papers_service
-from app.services import projects as projects_service
 
 router = APIRouter(tags=["notes"])
 
@@ -111,7 +111,7 @@ async def project_notebook(
     user: User = Depends(current_active_user),
 ) -> NotebookPage:
     """课题笔记本：我的论文笔记在本课题范围内的聚合视图（搜索 + 分页 + 按论文过滤）。"""
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows, total = await notes_service.list_project_notes(

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -43,6 +43,7 @@ from app.services import library_chat as library_chat_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
 from app.services import personal_wiki as personal_wiki_service
+from app.services import projects as projects_service
 from app.services import relevance as relevance_service
 from app.services import wiki_compile as wiki_compile_service
 from app.services.literature.pdf_extract import figure_path
@@ -77,6 +78,15 @@ async def _paper_detail(
 
 
 async def _get_member_project(session: AsyncSession, project_id: uuid.UUID, user: User):
+    """严格课题成员校验（个人语境用，如个人 wiki 的课题归因）：策展人/admin 不放行。"""
+    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    return project
+
+
+async def _get_managed_project(session: AsyncSession, project_id: uuid.UUID, user: User):
+    """库管理校验（文献管理端点用）：成员 ∪ 策展人 ∪ 平台 admin（P6）。"""
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
@@ -257,7 +267,7 @@ async def batch_delete_papers(
 
     默认软删（移入垃圾桶，可召回）；hard=true 彻底删除。
     """
-    await _get_member_project(session, project_id, user)
+    await _get_managed_project(session, project_id, user)
     deleted = await papers_service.delete_papers(
         session, project_id=project_id, paper_ids=data.paper_ids, hard=data.hard
     )
@@ -271,7 +281,7 @@ async def empty_trash(
     user: User = Depends(current_active_user),
 ) -> dict[str, int]:
     """清空垃圾桶：彻底删除项目内全部已删除论文。"""
-    await _get_member_project(session, project_id, user)
+    await _get_managed_project(session, project_id, user)
     deleted = await papers_service.empty_trash(session, project_id=project_id)
     return {"deleted": deleted}
 

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -43,7 +43,6 @@ from app.services import library_chat as library_chat_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
 from app.services import personal_wiki as personal_wiki_service
-from app.services import projects as projects_service
 from app.services import relevance as relevance_service
 from app.services import wiki_compile as wiki_compile_service
 from app.services.literature.pdf_extract import figure_path
@@ -78,7 +77,7 @@ async def _paper_detail(
 
 
 async def _get_member_project(session: AsyncSession, project_id: uuid.UUID, user: User):
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     return project
@@ -126,7 +125,7 @@ async def list_papers(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperListPage:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     items, total = await papers_service.list_papers(
@@ -163,7 +162,7 @@ async def add_paper_manually(
     user: User = Depends(current_active_user),
 ) -> Any:
     """手动添加文献：arxiv_id / doi / bibtex 三选一（docs/api-lit.md §4）。"""
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     try:
@@ -534,7 +533,7 @@ async def list_project_tags(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[TagRead]:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows = await papers_service.list_project_tags(session, project_id=project_id)

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -36,9 +36,9 @@ from app.services import chunks as chunks_service
 from app.services import citations as citations_service
 from app.services import concepts as concepts_service
 from app.services import graph as graph_service
+from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import papers as papers_service
-from app.services import projects as projects_service
 from app.services import stats as stats_service
 from app.services.libraries import get_library_for_project
 from app.services.wiki_export import build_obsidian_zip
@@ -51,7 +51,7 @@ _HEARTBEAT_SECONDS = 15.0
 
 
 async def _member_project(session: AsyncSession, project_id: uuid.UUID, user: User) -> Project:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     return project

--- a/src/backend/app/core/llm/call_log.py
+++ b/src/backend/app/core/llm/call_log.py
@@ -109,6 +109,7 @@ async def record_call(
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
 ) -> None:
     """写一条调用日志（尽力而为，失败只 warning）；低频顺带清理过期日志。"""
     global _last_cleanup_at
@@ -141,6 +142,7 @@ async def record_call(
                     user_id=user_id,
                     project_id=project_id,
                     voyage_id=voyage_id,
+                    library_id=library_id,
                 )
             )
             await session.commit()

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -3,7 +3,8 @@
 - 路由表存 DB（ModelRoute + LLMProviderConfig，管理端可改），60s 进程内缓存；
 - 查不到路由时回退 settings 默认（FakeProvider，无 key 也能跑通）；
 - 每次 complete/stream 后写一条 LLMUsage 记账（拿不到 usage 时按 len/4 估算），
-  归属到 user + project + voyage。
+  归属到 user + project + voyage；库侧调用（ingest/打分/编译/概念定义/向量化）
+  另带 library_id 记到方向库账上（P6 库级月度预算的依据）。
 """
 
 import logging
@@ -233,6 +234,7 @@ class LLMRouter:
         user_id: uuid.UUID | None,
         project_id: uuid.UUID | None,
         voyage_id: uuid.UUID | None,
+        library_id: uuid.UUID | None = None,
     ) -> None:
         from app.models.llm_config import LLMUsage
 
@@ -242,6 +244,7 @@ class LLMRouter:
                     LLMUsage(
                         user_id=user_id,
                         project_id=project_id,
+                        library_id=library_id,
                         voyage_id=voyage_id,
                         stage=stage,
                         model=model,
@@ -268,6 +271,7 @@ class LLMRouter:
         user_id: uuid.UUID | None,
         project_id: uuid.UUID | None,
         voyage_id: uuid.UUID | None,
+        library_id: uuid.UUID | None = None,
     ) -> None:
         """写一条调用日志（开关打开时才被调用）。任何失败只 warning，不影响主流程。"""
         try:
@@ -286,6 +290,7 @@ class LLMRouter:
                 user_id=user_id,
                 project_id=project_id,
                 voyage_id=voyage_id,
+                library_id=library_id,
             )
         except Exception:  # noqa: BLE001 — 日志记录绝不影响业务调用
             logger.warning("llm call logging failed (stage=%s)", stage, exc_info=True)
@@ -312,6 +317,7 @@ class LLMRouter:
         images: list[bytes] | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
+        library_id: uuid.UUID | None = None,
         voyage_id: uuid.UUID | None = None,
     ) -> CompletionResult:
         provider, route = await self.resolve(stage, user_id)
@@ -346,6 +352,7 @@ class LLMRouter:
                     user_id=user_id,
                     project_id=project_id,
                     voyage_id=voyage_id,
+                    library_id=library_id,
                 )
             raise
         result.usage = self._ensure_usage(messages, result.content, result.usage)
@@ -356,6 +363,7 @@ class LLMRouter:
             user_id=user_id,
             project_id=project_id,
             voyage_id=voyage_id,
+            library_id=library_id,
         )
         if log_enabled:
             await self._log_call(
@@ -371,6 +379,7 @@ class LLMRouter:
                 user_id=user_id,
                 project_id=project_id,
                 voyage_id=voyage_id,
+                library_id=library_id,
             )
         return result
 
@@ -438,6 +447,7 @@ class LLMRouter:
         stage: str = "embedding",
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
+        library_id: uuid.UUID | None = None,
         voyage_id: uuid.UUID | None = None,
     ) -> list[list[float]]:
         """文本嵌入（stage 默认 embedding）。provider 不支持时抛 NotImplementedError。"""
@@ -468,6 +478,7 @@ class LLMRouter:
                     user_id=user_id,
                     project_id=project_id,
                     voyage_id=voyage_id,
+                    library_id=library_id,
                 )
             raise
         usage = {"prompt_tokens": sum(estimate_tokens(t) for t in texts)}
@@ -478,6 +489,7 @@ class LLMRouter:
             user_id=user_id,
             project_id=project_id,
             voyage_id=voyage_id,
+            library_id=library_id,
         )
         if log_enabled:
             dim = len(vectors[0]) if vectors else 0
@@ -494,6 +506,7 @@ class LLMRouter:
                 user_id=user_id,
                 project_id=project_id,
                 voyage_id=voyage_id,
+                library_id=library_id,
             )
         return vectors
 
@@ -506,6 +519,7 @@ class LLMRouter:
         top_n: int | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
+        library_id: uuid.UUID | None = None,
         voyage_id: uuid.UUID | None = None,
     ) -> list[tuple[int, float]]:
         """重排（stage 默认 rerank），返回 (documents 下标, 分数) 降序。
@@ -541,6 +555,7 @@ class LLMRouter:
                     user_id=user_id,
                     project_id=project_id,
                     voyage_id=voyage_id,
+                    library_id=library_id,
                 )
             raise
         total_tokens = int(result.usage.get("total_tokens", 0)) or (
@@ -553,6 +568,7 @@ class LLMRouter:
             user_id=user_id,
             project_id=project_id,
             voyage_id=voyage_id,
+            library_id=library_id,
         )
         if log_enabled:
             await self._log_call(
@@ -568,6 +584,7 @@ class LLMRouter:
                 user_id=user_id,
                 project_id=project_id,
                 voyage_id=voyage_id,
+                library_id=library_id,
             )
         return result.results
 
@@ -580,6 +597,7 @@ class LLMRouter:
         max_tokens: int | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
+        library_id: uuid.UUID | None = None,
         voyage_id: uuid.UUID | None = None,
     ) -> AsyncIterator[str]:
         provider, route = await self.resolve(stage, user_id)
@@ -610,6 +628,7 @@ class LLMRouter:
                     user_id=user_id,
                     project_id=project_id,
                     voyage_id=voyage_id,
+                    library_id=library_id,
                 )
             raise
         content = "".join(collected)
@@ -621,6 +640,7 @@ class LLMRouter:
             user_id=user_id,
             project_id=project_id,
             voyage_id=voyage_id,
+            library_id=library_id,
         )
         # 时延 = 到流结束的完整耗时；response 聚合完整输出
         if log_enabled:
@@ -637,6 +657,7 @@ class LLMRouter:
                 user_id=user_id,
                 project_id=project_id,
                 voyage_id=voyage_id,
+                library_id=library_id,
             )
 
 

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -93,6 +93,10 @@ class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("projects.id", ondelete="SET NULL"), index=True
     )
+    # 方向库归因（P6）：库侧 ingest/打分/编译/概念定义/向量化记库账，个人消费为 NULL
+    library_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="SET NULL"), index=True
+    )
     voyage_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("voyage_runs.id", ondelete="SET NULL")
     )
@@ -125,6 +129,9 @@ class LLMCallLog(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("projects.id", ondelete="SET NULL")
+    )
+    library_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="SET NULL")
     )
     voyage_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("voyage_runs.id", ondelete="SET NULL")

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -58,3 +58,15 @@ class CuratorsUpdate(BaseModel):
     """策展人名单全量替换（平台 admin）。"""
 
     user_ids: list[uuid.UUID]
+
+
+class LibraryBudgetRead(BaseModel):
+    """库预算面板（P6）：本月消耗（UTC 自然月，token 口径与 LLMUsage 记账一致）。"""
+
+    month: str  # 如 "2026-07"
+    monthly_budget: int | None  # None = 不限
+    prompt_tokens: int
+    completion_tokens: int
+    used_tokens: int
+    remaining_tokens: int | None  # 不限时为 None；用超时为 0
+    exhausted: bool  # True = 本月预算已用尽（ingest 会被拒绝启动）

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -5,8 +5,9 @@
 
 import uuid
 from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DirectionLibrarySummary(BaseModel):
@@ -19,6 +20,8 @@ class DirectionLibrarySummary(BaseModel):
     project_id: uuid.UUID | None
     # 是否「我的课题的库」（请求者是背后课题的成员 → 前端显示管理入口）
     is_mine: bool
+    # 是否可管理本库：成员 ∪ 策展人（界面叫「文献库管理员」）∪ 平台 admin（P6）
+    can_manage: bool
     paper_count: int
     concept_count: int
     last_compiled_at: datetime | None
@@ -30,3 +33,28 @@ class DirectionLibrarySummary(BaseModel):
 
 class DirectionLibraryDetail(DirectionLibrarySummary):
     cadence: str | None
+    # 每月 ingest 预算（token 数；None = 不限）
+    monthly_budget: int | None = None
+
+
+class DirectionLibraryUpdate(BaseModel):
+    """库定义编辑（PATCH /libraries/{id}）：显式传 null 可清空对应字段。"""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    statement: str | None = None
+    cadence: str | None = Field(default=None, max_length=32)
+    monthly_budget: int | None = Field(default=None, ge=0)
+    rubric: Any | None = None
+    anchors: list[Any] | None = None
+
+
+class CuratorRead(BaseModel):
+    user_id: uuid.UUID
+    email: str
+    display_name: str | None
+
+
+class CuratorsUpdate(BaseModel):
+    """策展人名单全量替换（平台 admin）。"""
+
+    user_ids: list[uuid.UUID]

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -60,6 +60,39 @@ class CuratorsUpdate(BaseModel):
     user_ids: list[uuid.UUID]
 
 
+class DuplicateCandidatePaper(BaseModel):
+    """重复候选组里的一行（对比要素：标题/年份/来源/全文分段数/wiki 有无）。"""
+
+    id: uuid.UUID
+    title: str
+    year: int | None
+    source: str | None
+    arxiv_id: str | None
+    doi: str | None
+    status: str
+    chunk_count: int
+    has_wiki: bool
+    created_at: datetime
+
+
+class DuplicateCandidateGroup(BaseModel):
+    reason: str  # arxiv | doi | title（按何种键判定为疑似重复）
+    papers: list[DuplicateCandidatePaper]  # 首行 = 建议保留行（更完整优先）
+
+
+class PaperMergeRequest(BaseModel):
+    keep_id: uuid.UUID
+    drop_id: uuid.UUID
+
+
+class PaperMergeResult(BaseModel):
+    kept_id: uuid.UUID
+    dropped_id: uuid.UUID
+    dropped_dedup_key: str | None
+    # 各表 repoint/合并计数（library_memberships/topic_papers/paper_user_meta/...）
+    details: dict[str, Any]
+
+
 class LibraryBudgetRead(BaseModel):
     """库预算面板（P6）：本月消耗（UTC 自然月，token 口径与 LLMUsage 记账一致）。"""
 

--- a/src/backend/app/services/affiliations.py
+++ b/src/backend/app/services/affiliations.py
@@ -69,6 +69,7 @@ async def extract_affiliations_llm(
     llm: LLMRouter,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> list[str] | None:
     """LLM 从论文全文标题页解析机构名列表。
@@ -88,6 +89,7 @@ async def extract_affiliations_llm(
             max_tokens=_MAX_TOKENS,
             user_id=user_id,
             project_id=project_id,
+            library_id=library_id,
             voyage_id=voyage_id,
         )
         return _parse_affiliations(result.content)

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -115,6 +115,7 @@ async def embed_pending_chunks(
                 [c.text[:2000] for c in batch],
                 user_id=user_id,
                 project_id=project_id,
+                library_id=library_id,  # 全文向量化随库 ingest 记方向库账（P6）
                 voyage_id=voyage_id,
             )
         except NotImplementedError:

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -147,6 +147,7 @@ async def fetch_concept_definitions(
     *,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> dict[str, dict[str, str]]:
     """向 LLM 要概念的一句话定义与类别；分批调用避免响应截断，失败的批重试一次后用占位兜底。"""
@@ -154,12 +155,22 @@ async def fetch_concept_definitions(
     for i in range(0, len(names), _DEF_BATCH_SIZE):
         chunk = names[i : i + _DEF_BATCH_SIZE]
         got = await _fetch_definitions_batch(
-            llm, chunk, user_id=user_id, project_id=project_id, voyage_id=voyage_id
+            llm,
+            chunk,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
         )
         if not got:
             # 高负载下的偶发超时/限流：整批失败会让本批全落占位，重试一次能救回大多数
             got = await _fetch_definitions_batch(
-                llm, chunk, user_id=user_id, project_id=project_id, voyage_id=voyage_id
+                llm,
+                chunk,
+                user_id=user_id,
+                project_id=project_id,
+                library_id=library_id,
+                voyage_id=voyage_id,
             )
         out.update(got)
     return out
@@ -171,6 +182,7 @@ async def _fetch_definitions_batch(
     *,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> dict[str, dict[str, str]]:
     """单批（≤_DEF_BATCH_SIZE 个）定义调用；失败返回空 dict（调用方用占位定义兜底）。"""
@@ -185,6 +197,7 @@ async def _fetch_definitions_batch(
             ],
             user_id=user_id,
             project_id=project_id,
+            library_id=library_id,
             voyage_id=voyage_id,
         )
         start = result.content.find("{")
@@ -322,7 +335,12 @@ async def link_all_paper_concepts(
     definitions: dict[str, dict[str, str]] = {}
     if names_to_define and llm is not None:
         definitions = await fetch_concept_definitions(
-            llm, names_to_define, user_id=user_id, project_id=project_id, voyage_id=voyage_id
+            llm,
+            names_to_define,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,  # 概念定义是库侧编译成本，记方向库账（P6）
+            voyage_id=voyage_id,
         )
 
     created = 0
@@ -452,7 +470,7 @@ async def link_paper_concepts(
     definitions: dict[str, dict[str, str]] = {}
     if new_names and llm is not None:
         definitions = await fetch_concept_definitions(
-            llm, new_names, user_id=user_id, project_id=project_id
+            llm, new_names, user_id=user_id, project_id=project_id, library_id=library_id
         )
 
     created = 0

--- a/src/backend/app/services/figure_annotate.py
+++ b/src/backend/app/services/figure_annotate.py
@@ -216,6 +216,7 @@ async def annotate_figures(
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> list[dict[str, Any]]:
     """挑重要图并配中文图注，合并结果写 Paper.figures 并返回（调用方负责 commit）。"""
@@ -246,6 +247,7 @@ async def annotate_figures(
                     images=images,
                     user_id=user_id,
                     project_id=project_id,
+                    library_id=library_id,
                     voyage_id=voyage_id,
                 )
                 merged = _merge(candidates, _extract_json_array(result.content))

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -24,6 +24,60 @@ class IngestConflictError(Exception):
     """同一项目已有 ingest voyage 在跑。"""
 
 
+class LibraryBudgetExhaustedError(Exception):
+    """方向库本月预算已用尽（P6）：拒绝启动新的 ingest。"""
+
+
+async def monthly_library_usage(
+    session: AsyncSession, library_id: uuid.UUID
+) -> dict[str, Any]:
+    """该方向库本月（UTC 自然月）的 LLM 用量聚合（口径与 LLMUsage 记账一致）。"""
+    from app.models.llm_config import LLMUsage  # 延迟导入避免模块环
+
+    now = datetime.now(UTC)
+    month_start = datetime(now.year, now.month, 1, tzinfo=UTC)
+    prompt, completion = (
+        await session.execute(
+            select(
+                func.coalesce(func.sum(LLMUsage.prompt_tokens), 0),
+                func.coalesce(func.sum(LLMUsage.completion_tokens), 0),
+            ).where(LLMUsage.library_id == library_id, LLMUsage.created_at >= month_start)
+        )
+    ).one()
+    prompt, completion = int(prompt), int(completion)
+    return {
+        "month": now.strftime("%Y-%m"),
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+
+
+async def apply_library_budget(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    monthly_budget: int | None,
+    budget: dict[str, Any],
+) -> dict[str, Any]:
+    """把库的月度预算折算进 run.budget（复用 Voyage 预算暂停语义，不另造状态机）。
+
+    - 本月已用 ≥ 上限 → 抛 LibraryBudgetExhaustedError（拒绝启动）；
+    - 否则 run.budget.max_tokens 收紧为 min(原值, 本月剩余)——运行中一旦累计
+      到剩余额度，引擎按既有预算机制收尾/暂停。
+    """
+    if not monthly_budget:
+        return budget
+    usage = await monthly_library_usage(session, library_id)
+    remaining = int(monthly_budget) - int(usage["total_tokens"])
+    if remaining <= 0:
+        raise LibraryBudgetExhaustedError(str(library_id))
+    max_tokens = budget.get("max_tokens")
+    budget = dict(budget)
+    budget["max_tokens"] = remaining if not max_tokens else min(int(max_tokens), remaining)
+    return budget
+
+
 def derive_budget(knobs: IngestKnobs) -> dict[str, Any]:
     # 最大化模式不设 token 预算：引擎 _budget_exceeded 对 falsy 的 max_tokens（None/缺失）
     # 直接跳过预算检查（engine.py），任务不会因预算暂停/降级收尾。
@@ -54,9 +108,16 @@ async def create_ingest_voyage(
     knobs: IngestKnobs,
     created_by: uuid.UUID | None,
 ) -> VoyageRun:
-    """建 ingest voyage（互斥检查 + Activity 落记录），由调用方入队 run_voyage。"""
+    """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。"""
     if await find_running_ingest(session, project.id) is not None:
         raise IngestConflictError(str(project.id))
+    library = await get_library_for_project(session, project.id)
+    budget = await apply_library_budget(
+        session,
+        library_id=library.id,
+        monthly_budget=library.monthly_budget,
+        budget=derive_budget(knobs),
+    )
     kind = "wiki_bootstrap" if mode == "bootstrap" else "wiki_ingest"
     goal = (
         f"文献调研初始建库：{project.name}"
@@ -69,7 +130,7 @@ async def create_ingest_voyage(
         status="planning",
         cursor=0,
         checkpoint={"params": {"mode": mode, "knobs": knobs.model_dump()}},
-        budget=derive_budget(knobs),
+        budget=budget,
         project_id=project.id,
         created_by=created_by,
     )

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -8,12 +8,13 @@ API 形状不变（仍收 project_id），service 层经这里解析到 Directio
 import uuid
 from typing import Any
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.paper import Concept, Paper
 from app.models.project import Project, ProjectMember
+from app.models.user import User
 
 
 def implicit_library_for(project: Project) -> DirectionLibrary:
@@ -119,13 +120,25 @@ def member_paper_stmt(library_id: uuid.UUID) -> Select:
 
 
 def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
-    """用户可见论文（其任一所属方向的库里有成员行）：SELECT (Paper, LibraryPaper, project_id)。"""
+    """用户可管理论文（其所属方向的库 ∪ 被任命管理的库 ∪ 平台 admin 全库）
+    的成员行：SELECT (Paper, LibraryPaper, project_id)。P6 起策展人/管理员与
+    成员同权（docs-dev/workspace-ia-redesign.md §5）。"""
+    my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+    my_curated = select(DirectionLibraryCurator.library_id).where(
+        DirectionLibraryCurator.user_id == user_id
+    )
+    is_admin = select(User.id).where(User.id == user_id, User.role == "admin").exists()
     return (
         select(Paper, LibraryPaper, DirectionLibrary.project_id)
         .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
         .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
-        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
-        .where(ProjectMember.user_id == user_id)
+        .where(
+            or_(
+                DirectionLibrary.project_id.in_(my_projects),
+                DirectionLibrary.id.in_(my_curated),
+                is_admin,
+            )
+        )
     )
 
 
@@ -190,6 +203,7 @@ def _overview_dict(
     library: DirectionLibrary,
     *,
     my_projects: set[uuid.UUID],
+    can_manage: bool,
     paper_count: int,
     concept_count: int,
     last_compiled_at: Any,
@@ -199,8 +213,10 @@ def _overview_dict(
         "name": library.name,
         "statement": library.statement,
         "cadence": library.cadence,
+        "monthly_budget": library.monthly_budget,
         "project_id": library.project_id,
         "is_mine": library.project_id is not None and library.project_id in my_projects,
+        "can_manage": can_manage,
         "paper_count": paper_count,
         "concept_count": concept_count,
         "last_compiled_at": last_compiled_at,
@@ -210,9 +226,7 @@ def _overview_dict(
     }
 
 
-async def list_libraries_overview(
-    session: AsyncSession, *, user_id: uuid.UUID
-) -> list[dict[str, Any]]:
+async def list_libraries_overview(session: AsyncSession, *, user: User) -> list[dict[str, Any]]:
     """全部方向库 + 概要统计（读操作对所有登录用户开放，不做成员校验）。"""
     libraries = (
         (await session.execute(select(DirectionLibrary).order_by(DirectionLibrary.created_at)))
@@ -222,11 +236,17 @@ async def list_libraries_overview(
     paper_counts, last_compiled, concept_counts = await _library_stats(
         session, [lib.id for lib in libraries]
     )
-    my_projects = await _my_project_ids(session, user_id)
+    my_projects = await _my_project_ids(session, user.id)
+    my_curated = await _my_curated_library_ids(session, user.id)
     return [
         _overview_dict(
             lib,
             my_projects=my_projects,
+            can_manage=(
+                user.role == "admin"
+                or lib.id in my_curated
+                or (lib.project_id is not None and lib.project_id in my_projects)
+            ),
             paper_count=paper_counts.get(lib.id, 0),
             concept_count=concept_counts.get(lib.id, 0),
             last_compiled_at=last_compiled.get(lib.id),
@@ -236,15 +256,162 @@ async def list_libraries_overview(
 
 
 async def library_overview(
-    session: AsyncSession, *, library: DirectionLibrary, user_id: uuid.UUID
+    session: AsyncSession, *, library: DirectionLibrary, user: User
 ) -> dict[str, Any]:
     """单库详情概要（同列表口径）。"""
     paper_counts, last_compiled, concept_counts = await _library_stats(session, [library.id])
-    my_projects = await _my_project_ids(session, user_id)
+    my_projects = await _my_project_ids(session, user.id)
     return _overview_dict(
         library,
         my_projects=my_projects,
+        can_manage=await can_manage_library(session, user=user, library=library),
         paper_count=paper_counts.get(library.id, 0),
         concept_count=concept_counts.get(library.id, 0),
         last_compiled_at=last_compiled.get(library.id),
     )
+
+
+# ---- P6 治理：策展人（界面叫「文献库管理员」）与库级写权限 ----
+
+
+async def _my_curated_library_ids(session: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    rows = await session.execute(
+        select(DirectionLibraryCurator.library_id).where(
+            DirectionLibraryCurator.user_id == user_id
+        )
+    )
+    return set(rows.scalars().all())
+
+
+async def is_library_curator(
+    session: AsyncSession, *, library_id: uuid.UUID, user_id: uuid.UUID
+) -> bool:
+    row = await session.execute(
+        select(DirectionLibraryCurator.user_id).where(
+            DirectionLibraryCurator.library_id == library_id,
+            DirectionLibraryCurator.user_id == user_id,
+        )
+    )
+    return row.first() is not None
+
+
+async def _is_project_member(
+    session: AsyncSession, *, project_id: uuid.UUID, user_id: uuid.UUID
+) -> bool:
+    row = await session.execute(
+        select(ProjectMember.user_id).where(
+            ProjectMember.project_id == project_id, ProjectMember.user_id == user_id
+        )
+    )
+    return row.first() is not None
+
+
+async def can_manage_library(
+    session: AsyncSession, *, user: User, library: DirectionLibrary
+) -> bool:
+    """库级写权限（docs-dev/workspace-ia-redesign.md §5）：
+    背后课题成员 ∪ 策展人（direction_library_curators）∪ 平台 admin。"""
+    if user.role == "admin":
+        return True
+    if library.project_id is not None and await _is_project_member(
+        session, project_id=library.project_id, user_id=user.id
+    ):
+        return True
+    return await is_library_curator(session, library_id=library.id, user_id=user.id)
+
+
+async def get_managed_project(
+    session: AsyncSession, *, project_id: uuid.UUID, user: User
+) -> Project | None:
+    """库管理入口的统一鉴权（project 作用域的文献管理端点用）：课题成员照常放行；
+    平台 admin 与该课题隐式库的策展人同权；无权限视为不存在（返回 None）。"""
+    project = await session.get(Project, project_id)
+    if project is None:
+        return None
+    if user.role == "admin":
+        return project
+    if await _is_project_member(session, project_id=project_id, user_id=user.id):
+        return project
+    library = (
+        await session.execute(
+            select(DirectionLibrary).where(DirectionLibrary.project_id == project_id)
+        )
+    ).scalar_one_or_none()
+    if library is not None and await is_library_curator(
+        session, library_id=library.id, user_id=user.id
+    ):
+        return project
+    return None
+
+
+async def list_curators(session: AsyncSession, library_id: uuid.UUID) -> list[dict[str, Any]]:
+    stmt = (
+        select(DirectionLibraryCurator.user_id, User.email, User.display_name)
+        .join(User, User.id == DirectionLibraryCurator.user_id)
+        .where(DirectionLibraryCurator.library_id == library_id)
+        .order_by(DirectionLibraryCurator.created_at)
+    )
+    return [
+        {"user_id": user_id, "email": email, "display_name": display_name}
+        for user_id, email, display_name in (await session.execute(stmt)).all()
+    ]
+
+
+async def set_curators(
+    session: AsyncSession, *, library: DirectionLibrary, user_ids: list[uuid.UUID]
+) -> list[dict[str, Any]]:
+    """全量替换策展人名单（平台 admin 专用）；未知 user_id 抛 ValueError。commit 落库。"""
+    unique_ids = list(dict.fromkeys(user_ids))
+    if unique_ids:
+        found = set(
+            (await session.execute(select(User.id).where(User.id.in_(unique_ids)))).scalars().all()
+        )
+        missing = [str(uid) for uid in unique_ids if uid not in found]
+        if missing:
+            raise ValueError(f"unknown user ids: {', '.join(missing)}")
+    await session.execute(
+        delete(DirectionLibraryCurator).where(DirectionLibraryCurator.library_id == library.id)
+    )
+    for uid in unique_ids:
+        session.add(DirectionLibraryCurator(library_id=library.id, user_id=uid))
+    await session.commit()
+    return await list_curators(session, library.id)
+
+
+# 库定义可编辑字段 → project.definition 写回键（库为权威，写时同步保持 ingest 兼容：
+# search/snowball/score/watermark 仍从 project.definition / ingest_state 取数）
+_DEFINITION_SYNC_KEYS = {
+    "statement": "statement",
+    "rubric": "rubric",
+    "anchors": "anchor_papers",
+    "cadence": "cadence",
+}
+
+
+async def update_library(
+    session: AsyncSession, *, library: DirectionLibrary, fields: dict[str, Any]
+) -> DirectionLibrary:
+    """编辑库定义（name/statement/cadence/monthly_budget/rubric/anchors，显式传 null 可清空）。
+
+    过渡期隐式库（project_id 非空）双源并存：ingest 读 project.definition——
+    这里以库为权威，写入时把 statement/rubric/anchors/cadence 同步回
+    project.definition 对应键（name 同步 project.name），两边不再漂移。
+    """
+    for key, value in fields.items():
+        setattr(library, key, value)
+    if library.project_id is not None:
+        project = await session.get(Project, library.project_id)
+        if project is not None:
+            if fields.get("name"):
+                project.name = fields["name"]
+            sync = {k: v for k, v in fields.items() if k in _DEFINITION_SYNC_KEYS}
+            if sync:
+                definition = (
+                    dict(project.definition) if isinstance(project.definition, dict) else {}
+                )
+                for key, value in sync.items():
+                    definition[_DEFINITION_SYNC_KEYS[key]] = value
+                project.definition = definition
+    await session.commit()
+    await session.refresh(library)
+    return library

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -398,6 +398,8 @@ async def update_library(
     project.definition 对应键（name 同步 project.name），两边不再漂移。
     """
     for key, value in fields.items():
+        if key == "name" and not value:
+            continue  # name 非空约束：显式 null/空串视为不改名
         setattr(library, key, value)
     if library.project_id is not None:
         project = await session.get(Project, library.project_id)

--- a/src/backend/app/services/paper_merge.py
+++ b/src/backend/app/services/paper_merge.py
@@ -1,0 +1,347 @@
+"""重复论文合并（P6 策展工具，docs-dev/rfc-paper-content-pool.md §5）。
+
+模糊去重的漏网（预印本 vs 正式版、标题变体）由策展人人工确认合并：把 drop 行的
+全部归属 repoint 到 keep 行后删除 drop。所有归属只经 paper_id 引用，合并是局部操作。
+
+约定：
+- 冲突表（同库 / 同课题 / 同用户已各有一行）按「keep 行优先、缺项用 drop 补」合并；
+- keep 行缺全文 / 图 / 元数据时从 drop 行搬运（chunks 仅在 keep 无分段时整体迁移）；
+- drop 的 dedup_key 无法与 keep 并存（UNIQUE），随行删除并写进返回报告；
+- 全程一个事务，最后统一 commit；paper 不存在或 keep==drop 抛 ValueError。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library import UserLibraryEntry
+from app.models.library_direction import LibraryPaper
+from app.models.paper import (
+    Paper,
+    PaperChunk,
+    PaperHighlight,
+    PaperNote,
+    PaperUserMeta,
+    paper_concepts,
+    paper_tag_links,
+)
+from app.models.publication import UserPublication
+from app.models.topic_shelf import TopicPaper
+
+# 内容池行上「keep 缺则用 drop 补」的字段（判断性字段在成员行，另行处理）
+_FILLABLE_PAPER_FIELDS = (
+    "arxiv_id",
+    "doi",
+    "abstract",
+    "year",
+    "venue",
+    "url",
+    "published_at",
+    "pdf_path",
+    "full_text_path",
+    "tldr",
+    "figures",
+    "embedding",
+    "affiliations",
+    "authors",
+)
+
+# 成员行上的判断字段：同库冲突时 keep 缺则补
+_FILLABLE_MEMBERSHIP_FIELDS = (
+    "relevance_score",
+    "tldr_note",
+    "wiki_content",
+    "scored_at",
+    "compiled_at",
+    "compiled_model",
+)
+
+# 阅读状态推进序（冲突时取两边更靠后的）
+_READING_ORDER = {"unread": 0, "reading": 1, "read": 2}
+# 成员行状态推进序（excluded/included 人工态不参与自动升级）
+_STATUS_ORDER = {"candidate": 0, "scored": 1, "fetched": 2, "compiled": 3}
+
+
+async def _repoint_associations(
+    session: AsyncSession, table: Any, col: str, *, keep_id: uuid.UUID, drop_id: uuid.UUID
+) -> tuple[int, int]:
+    """纯关联表（paper_concepts / paper_tag_links）：两边都有的删 drop 侧，其余 repoint。
+
+    返回 (repointed, deduped)。
+    """
+    paper_col = table.c.paper_id
+    other_col = table.c[col]
+    dup_subq = select(other_col).where(paper_col == keep_id)
+    deduped = (
+        await session.execute(
+            delete(table).where(paper_col == drop_id, other_col.in_(dup_subq))
+        )
+    ).rowcount
+    repointed = (
+        await session.execute(
+            update(table).where(paper_col == drop_id).values(paper_id=keep_id)
+        )
+    ).rowcount
+    return int(repointed or 0), int(deduped or 0)
+
+
+async def merge_papers(
+    session: AsyncSession, *, keep_id: uuid.UUID, drop_id: uuid.UUID
+) -> dict[str, Any]:
+    """把 drop 论文的所有归属并入 keep 后删除 drop 行，返回合并报告。"""
+    if keep_id == drop_id:
+        raise ValueError("keep and drop must be different papers")
+    keep = await session.get(Paper, keep_id)
+    drop = await session.get(Paper, drop_id)
+    if keep is None or drop is None:
+        raise ValueError("paper not found")
+
+    report: dict[str, Any] = {
+        "kept_id": str(keep_id),
+        "dropped_id": str(drop_id),
+        "dropped_dedup_key": drop.dedup_key,
+    }
+
+    # ---- 1. library_papers：同库冲突合并判断字段，否则 repoint ----
+    keep_members = {
+        m.library_id: m
+        for m in (
+            await session.execute(select(LibraryPaper).where(LibraryPaper.paper_id == keep_id))
+        ).scalars()
+    }
+    drop_members = list(
+        (
+            await session.execute(select(LibraryPaper).where(LibraryPaper.paper_id == drop_id))
+        ).scalars()
+    )
+    lib_repointed = lib_merged = 0
+    for membership in drop_members:
+        existing = keep_members.get(membership.library_id)
+        if existing is None:
+            membership.paper_id = keep_id
+            lib_repointed += 1
+            continue
+        for field in _FILLABLE_MEMBERSHIP_FIELDS:
+            if getattr(existing, field) is None and getattr(membership, field) is not None:
+                setattr(existing, field, getattr(membership, field))
+        # drop 侧流程走得更远（如已编译）且 keep 仍在自动流程中 → 采纳 drop 的状态
+        if (
+            existing.status in _STATUS_ORDER
+            and membership.status in _STATUS_ORDER
+            and _STATUS_ORDER[membership.status] > _STATUS_ORDER[existing.status]
+        ):
+            existing.status = membership.status
+        await session.delete(membership)
+        lib_merged += 1
+    report["library_memberships"] = {"repointed": lib_repointed, "merged": lib_merged}
+
+    # ---- 2. topic_papers：同课题冲突保留 keep 行（缺快照/备注则补），否则 repoint ----
+    keep_shelf = {
+        t.topic_id: t
+        for t in (
+            await session.execute(select(TopicPaper).where(TopicPaper.paper_id == keep_id))
+        ).scalars()
+    }
+    shelf_repointed = shelf_merged = 0
+    for row in (
+        await session.execute(select(TopicPaper).where(TopicPaper.paper_id == drop_id))
+    ).scalars():
+        existing = keep_shelf.get(row.topic_id)
+        if existing is None:
+            row.paper_id = keep_id
+            shelf_repointed += 1
+            continue
+        if existing.wiki_snapshot is None and row.wiki_snapshot is not None:
+            existing.wiki_snapshot = row.wiki_snapshot
+            existing.snapshot_at = row.snapshot_at
+        if not existing.note and row.note:
+            existing.note = row.note
+        await session.delete(row)
+        shelf_merged += 1
+    report["topic_papers"] = {"repointed": shelf_repointed, "merged": shelf_merged}
+
+    # ---- 3. paper_user_meta：同用户冲突合并（starred 取并、阅读状态取更靠后的） ----
+    keep_meta = {
+        m.user_id: m
+        for m in (
+            await session.execute(select(PaperUserMeta).where(PaperUserMeta.paper_id == keep_id))
+        ).scalars()
+    }
+    meta_repointed = meta_merged = 0
+    for meta in (
+        await session.execute(select(PaperUserMeta).where(PaperUserMeta.paper_id == drop_id))
+    ).scalars():
+        existing = keep_meta.get(meta.user_id)
+        if existing is None:
+            meta.paper_id = keep_id
+            meta_repointed += 1
+            continue
+        existing.starred = existing.starred or meta.starred
+        if _READING_ORDER.get(meta.reading_status, 0) > _READING_ORDER.get(
+            existing.reading_status, 0
+        ):
+            existing.reading_status = meta.reading_status
+        await session.delete(meta)
+        meta_merged += 1
+    report["paper_user_meta"] = {"repointed": meta_repointed, "merged": meta_merged}
+
+    # ---- 4. 笔记 / 划线：无唯一约束，整体 repoint ----
+    notes = (
+        await session.execute(
+            update(PaperNote).where(PaperNote.paper_id == drop_id).values(paper_id=keep_id)
+        )
+    ).rowcount
+    highlights = (
+        await session.execute(
+            update(PaperHighlight)
+            .where(PaperHighlight.paper_id == drop_id)
+            .values(paper_id=keep_id)
+        )
+    ).rowcount
+    report["notes_repointed"] = int(notes or 0)
+    report["highlights_repointed"] = int(highlights or 0)
+
+    # ---- 5. 概念链 / 标签链：两边都有的去重，其余 repoint ----
+    repointed, deduped = await _repoint_associations(
+        session, paper_concepts, "concept_id", keep_id=keep_id, drop_id=drop_id
+    )
+    report["concept_links"] = {"repointed": repointed, "deduped": deduped}
+    repointed, deduped = await _repoint_associations(
+        session, paper_tag_links, "tag_id", keep_id=keep_id, drop_id=drop_id
+    )
+    report["tag_links"] = {"repointed": repointed, "deduped": deduped}
+
+    # ---- 6. 软引用：个人库回跳 / 发表记录 ----
+    entries = (
+        await session.execute(
+            update(UserLibraryEntry)
+            .where(UserLibraryEntry.last_paper_id == drop_id)
+            .values(last_paper_id=keep_id)
+        )
+    ).rowcount
+    publications = (
+        await session.execute(
+            update(UserPublication)
+            .where(UserPublication.paper_id == drop_id)
+            .values(paper_id=keep_id)
+        )
+    ).rowcount
+    report["library_entries_repointed"] = int(entries or 0)
+    report["publications_repointed"] = int(publications or 0)
+
+    # ---- 7. 全文分段：keep 没有分段而 drop 有 → 整体迁移（否则随 drop 级联删除） ----
+    keep_chunks = (
+        await session.execute(
+            select(func.count()).select_from(PaperChunk).where(PaperChunk.paper_id == keep_id)
+        )
+    ).scalar_one()
+    chunks_moved = 0
+    if not keep_chunks:
+        chunks_moved = int(
+            (
+                await session.execute(
+                    update(PaperChunk)
+                    .where(PaperChunk.paper_id == drop_id)
+                    .values(paper_id=keep_id)
+                )
+            ).rowcount
+            or 0
+        )
+    report["chunks_moved"] = chunks_moved
+
+    # ---- 8. 内容池行缺项回填（keep 缺 → 用 drop 的） ----
+    filled: list[str] = []
+    for field in _FILLABLE_PAPER_FIELDS:
+        if getattr(keep, field) is None and getattr(drop, field) is not None:
+            setattr(keep, field, getattr(drop, field))
+            filled.append(field)
+    if drop.external_ids:
+        keep.external_ids = dict(drop.external_ids) | dict(keep.external_ids or {})
+    report["fields_filled"] = filled
+
+    # ---- 9. 删除 drop 行（dedup_key 随行消失；FK 级联清理剩余从属行） ----
+    await session.delete(drop)
+    await session.commit()
+    return report
+
+
+# ---- 重复候选发现（GET /libraries/{id}/duplicate-candidates） ----
+
+
+def _candidate_row(paper: Paper, membership: LibraryPaper, chunk_count: int) -> dict[str, Any]:
+    return {
+        "id": paper.id,
+        "title": paper.title,
+        "year": paper.year,
+        "source": paper.source,
+        "arxiv_id": paper.arxiv_id,
+        "doi": paper.doi,
+        "status": membership.status,
+        "chunk_count": chunk_count,
+        "has_wiki": bool(membership.wiki_content),
+        "created_at": paper.created_at,
+    }
+
+
+async def duplicate_candidates(
+    session: AsyncSession, *, library_id: uuid.UUID
+) -> list[dict[str, Any]]:
+    """库内重复候选（简单实现）：arxiv/doi 同源不同行，或规范化标题相同。
+
+    每组内按「更完整优先」排序（有 wiki > 分段多 > 入库早），首行即建议保留行；
+    同一对论文只报一次（先按 arxiv/doi 硬键，再按标题兜底）。
+    """
+    from app.services.dedup import normalize_title  # 复用全平台标题规范化
+
+    pairs = (
+        await session.execute(
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id == library_id)
+        )
+    ).all()
+    if not pairs:
+        return []
+    counts = dict(
+        (
+            await session.execute(
+                select(PaperChunk.paper_id, func.count())
+                .where(PaperChunk.paper_id.in_([p.id for p, _ in pairs]))
+                .group_by(PaperChunk.paper_id)
+            )
+        ).all()
+    )
+
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for paper, membership in pairs:
+        row = _candidate_row(paper, membership, int(counts.get(paper.id, 0)))
+        keys: list[tuple[str, str]] = []
+        if paper.arxiv_id:
+            keys.append(("arxiv", paper.arxiv_id.lower()))
+        if paper.doi:
+            keys.append(("doi", paper.doi.lower()))
+        if title_key := normalize_title(paper.title):
+            keys.append(("title", title_key))
+        for key in keys:
+            buckets.setdefault(key, []).append(row)
+
+    groups: list[dict[str, Any]] = []
+    seen_sets: list[set[uuid.UUID]] = []
+    for (reason, _), rows in sorted(
+        buckets.items(), key=lambda kv: ("arxiv", "doi", "title").index(kv[0][0])
+    ):
+        unique = {row["id"]: row for row in rows}
+        if len(unique) < 2:
+            continue
+        ids = set(unique)
+        if any(ids <= prior for prior in seen_sets):
+            continue  # 同一组已按更硬的键报过
+        seen_sets.append(ids)
+        ordered = sorted(
+            unique.values(),
+            key=lambda r: (not r["has_wiki"], -r["chunk_count"], r["created_at"]),
+        )
+        groups.append({"reason": reason, "papers": ordered})
+    return groups

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -84,6 +84,7 @@ async def score_paper_relevance(
         ],
         user_id=user_id,
         project_id=project_id,
+        library_id=membership.library_id,  # 打分是库侧判断，记方向库账（P6）
         voyage_id=voyage_id,
     )
     data = _extract_json(result.content)

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -139,6 +139,7 @@ async def compile_paper(
     llm: LLMRouter | None = None,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
     extra_guidance: str = "",
 ) -> CompiledWiki:
@@ -171,6 +172,7 @@ async def compile_paper(
             images=images or None,
             user_id=user_id,
             project_id=project_id,
+            library_id=library_id,
             voyage_id=voyage_id,
         )
         if not result.content.strip():
@@ -210,12 +212,22 @@ async def recompile_paper(
             ]
         if paper.figures:
             await annotate_figures(
-                paper, paper.figures, llm=llm, user_id=user_id, project_id=project_id
+                paper,
+                paper.figures,
+                llm=llm,
+                user_id=user_id,
+                project_id=project_id,
+                library_id=membership.library_id,
             )
         await session.commit()
 
     compiled = await compile_paper(
-        paper, statement=statement, llm=llm, user_id=user_id, project_id=project_id
+        paper,
+        statement=statement,
+        llm=llm,
+        user_id=user_id,
+        project_id=project_id,
+        library_id=membership.library_id,  # 库版重编译记方向库账（P6）
     )
     membership.wiki_content = compiled.content
     membership.compiled_at = utcnow()

--- a/src/backend/tests/test_library_budget.py
+++ b/src/backend/tests/test_library_budget.py
@@ -1,0 +1,159 @@
+"""P6 库预算（任务 2）：用量按库归因、月度聚合、超限拒绝启动与剩余额度收紧。"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.llm.base import Message
+from app.core.llm.router import get_llm_router
+from app.models.library_direction import DirectionLibrary
+from app.models.llm_config import LLMUsage
+from app.models.voyage import VoyageRun
+from app.services import ingest as ingest_service
+from tests.conftest import register_and_login
+
+
+async def _setup_project(client, email="budget-owner@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "预算方向"}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        library = (
+            await session.execute(
+                select(DirectionLibrary).where(
+                    DirectionLibrary.project_id == uuid.UUID(project_id)
+                )
+            )
+        ).scalar_one()
+        library_id = library.id
+    return headers, project_id, library_id
+
+
+async def _add_usage(library_id, *, prompt=0, completion=0, created_at=None, stage="librarian"):
+    async with get_sessionmaker()() as session:
+        row = LLMUsage(
+            library_id=library_id,
+            stage=stage,
+            model="fake",
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+        )
+        if created_at is not None:
+            row.created_at = created_at
+        session.add(row)
+        await session.commit()
+
+
+async def _set_budget(library_id, monthly_budget):
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, library_id)
+        library.monthly_budget = monthly_budget
+        await session.commit()
+
+
+async def test_monthly_usage_aggregation(client):
+    _headers, _project_id, library_id = await _setup_project(client)
+    other = uuid.uuid4()  # 无关归因（不同库/无库）不计入
+    await _add_usage(library_id, prompt=1000, completion=500)
+    await _add_usage(library_id, prompt=200, completion=300)
+    # 上月的用量不计入本月
+    last_month = datetime.now(UTC).replace(day=1) - timedelta(days=2)
+    await _add_usage(library_id, prompt=99999, created_at=last_month)
+    async with get_sessionmaker()() as session:
+        session.add(LLMUsage(stage="forge", model="fake", prompt_tokens=777, completion_tokens=0))
+        await session.commit()
+        usage = await ingest_service.monthly_library_usage(session, library_id)
+        assert usage["prompt_tokens"] == 1200
+        assert usage["completion_tokens"] == 800
+        assert usage["total_tokens"] == 2000
+        # 其他库不受影响
+        empty = await ingest_service.monthly_library_usage(session, other)
+        assert empty["total_tokens"] == 0
+
+
+async def test_ingest_rejected_when_budget_exhausted(client, queue_stub):
+    headers, project_id, library_id = await _setup_project(client, email="budget-a@example.com")
+    await _set_budget(library_id, 1000)
+    await _add_usage(library_id, prompt=800, completion=300)  # 1100 ≥ 1000
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest", json={"mode": "bootstrap"}, headers=headers
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == "LIBRARY_BUDGET_EXHAUSTED"
+    assert queue_stub.jobs == []  # 没有入队任何任务
+    # 预算面板显示已用尽
+    resp = await client.get(f"/api/libraries/{library_id}/budget", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exhausted"] is True
+    assert body["used_tokens"] == 1100
+    assert body["remaining_tokens"] == 0
+
+
+async def test_ingest_budget_capped_to_monthly_remaining(client, queue_stub):
+    headers, project_id, library_id = await _setup_project(client, email="budget-b@example.com")
+    await _set_budget(library_id, 100_000)
+    await _add_usage(library_id, prompt=20_000, completion=10_000)  # 已用 30k → 剩 70k
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": {"max_papers": 10}},  # 派生预算 200k > 剩余
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    voyage_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        assert run.budget["max_tokens"] == 70_000
+    # 无预算库不受影响：max_tokens 用 knobs 派生值
+    headers2, project_id2, _library_id2 = await _setup_project(client, email="budget-c@example.com")
+    resp = await client.post(
+        f"/api/projects/{project_id2}/ingest",
+        json={"mode": "bootstrap", "knobs": {"max_papers": 10}},
+        headers=headers2,
+    )
+    assert resp.status_code == 201, resp.text
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, uuid.UUID(resp.json()["id"]))
+        assert run.budget["max_tokens"] == 200_000
+
+
+async def test_budget_endpoint_permissions(client):
+    headers, _project_id, library_id = await _setup_project(client, email="budget-d@example.com")
+    stranger_token = await register_and_login(client, email="budget-stranger@example.com")
+    stranger = {"Authorization": f"Bearer {stranger_token}"}
+    resp = await client.get(f"/api/libraries/{library_id}/budget", headers=stranger)
+    assert resp.status_code == 403
+    resp = await client.get(f"/api/libraries/{library_id}/budget", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["monthly_budget"] is None
+    assert body["remaining_tokens"] is None
+    assert body["exhausted"] is False
+
+
+async def test_router_records_library_attribution(client):
+    """core/llm 记账入口带 library_id → LLMUsage 落库归因（fake provider）。"""
+    _headers, _project_id, library_id = await _setup_project(client, email="budget-e@example.com")
+    router = get_llm_router()
+    await router.complete(
+        "relevance",
+        [Message(role="user", content="score this paper")],
+        library_id=library_id,
+    )
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(LLMUsage).where(LLMUsage.library_id == library_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].stage == "relevance"
+        assert rows[0].prompt_tokens > 0

--- a/src/backend/tests/test_library_governance.py
+++ b/src/backend/tests/test_library_governance.py
@@ -1,0 +1,188 @@
+"""P6 库治理（任务 1）：库级写权限助手、策展人任命（仅 admin）、库定义编辑与写回同步。"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
+from app.models.project import Project
+from app.models.user import User
+from app.services import libraries as libraries_service
+from tests.conftest import register_and_login
+
+
+async def _register(client, email):
+    token = await register_and_login(client, email=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _user_id_of(email: str) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return (await session.execute(select(User.id).where(User.email == email))).scalar_one()
+
+
+async def _setup(client):
+    """第一个注册者自动成为平台 admin；owner 建课题（隐式库）。"""
+    admin = await _register(client, "gov-admin@example.com")
+    owner = await _register(client, "gov-owner@example.com")
+    curator = await _register(client, "gov-curator@example.com")
+    stranger = await _register(client, "gov-stranger@example.com")
+    resp = await client.post("/api/projects", json={"name": "治理方向"}, headers=owner)
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+    resp = await client.get("/api/libraries", headers=owner)
+    assert resp.status_code == 200, resp.text
+    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+    return admin, owner, curator, stranger, project_id, library_id
+
+
+async def _appoint(client, admin, library_id, email) -> uuid.UUID:
+    user_id = await _user_id_of(email)
+    resp = await client.put(
+        f"/api/libraries/{library_id}/curators",
+        json={"user_ids": [str(user_id)]},
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    return user_id
+
+
+async def test_can_manage_library_three_identities(client):
+    _admin, _owner, _curator, _stranger, project_id, library_id = await _setup(client)
+    curator_id = await _user_id_of("gov-curator@example.com")
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        admin_user = (
+            await session.execute(select(User).where(User.email == "gov-admin@example.com"))
+        ).scalar_one()
+        owner_user = (
+            await session.execute(select(User).where(User.email == "gov-owner@example.com"))
+        ).scalar_one()
+        stranger_user = (
+            await session.execute(select(User).where(User.email == "gov-stranger@example.com"))
+        ).scalar_one()
+        curator_user = await session.get(User, curator_id)
+
+        # 平台 admin / 背后课题成员可管理；无关用户不可
+        assert await libraries_service.can_manage_library(session, user=admin_user, library=library)
+        assert await libraries_service.can_manage_library(session, user=owner_user, library=library)
+        assert not await libraries_service.can_manage_library(
+            session, user=stranger_user, library=library
+        )
+        # 任命为策展人后可管理
+        assert not await libraries_service.can_manage_library(
+            session, user=curator_user, library=library
+        )
+        session.add(DirectionLibraryCurator(library_id=library.id, user_id=curator_id))
+        await session.commit()
+        assert await libraries_service.can_manage_library(
+            session, user=curator_user, library=library
+        )
+
+
+async def test_curator_appointment_admin_only(client):
+    admin, owner, curator, stranger, _project_id, library_id = await _setup(client)
+    curator_id = await _user_id_of("gov-curator@example.com")
+
+    # 非 admin（即使是课题 owner）不能任命
+    resp = await client.put(
+        f"/api/libraries/{library_id}/curators",
+        json={"user_ids": [str(curator_id)]},
+        headers=owner,
+    )
+    assert resp.status_code == 403
+    # admin 全量替换名单
+    resp = await client.put(
+        f"/api/libraries/{library_id}/curators",
+        json={"user_ids": [str(curator_id)]},
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    assert [row["user_id"] for row in resp.json()] == [str(curator_id)]
+    # 未知 user_id → 400
+    resp = await client.put(
+        f"/api/libraries/{library_id}/curators",
+        json={"user_ids": [str(uuid.uuid4())]},
+        headers=admin,
+    )
+    assert resp.status_code == 400
+    # 名单查看：可管理者（策展人本人）可见；无关用户 403
+    resp = await client.get(f"/api/libraries/{library_id}/curators", headers=curator)
+    assert resp.status_code == 200
+    resp = await client.get(f"/api/libraries/{library_id}/curators", headers=stranger)
+    assert resp.status_code == 403
+    # 空名单替换 = 清空
+    resp = await client.put(
+        f"/api/libraries/{library_id}/curators", json={"user_ids": []}, headers=admin
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_patch_library_permission_and_definition_sync(client):
+    admin, _owner, curator, stranger, project_id, library_id = await _setup(client)
+
+    # 无关用户 403
+    resp = await client.patch(
+        f"/api/libraries/{library_id}", json={"name": "hijack"}, headers=stranger
+    )
+    assert resp.status_code == 403
+
+    await _appoint(client, admin, library_id, "gov-curator@example.com")
+    resp = await client.patch(
+        f"/api/libraries/{library_id}",
+        json={
+            "name": "稀疏注意力",
+            "statement": "稀疏注意力机制的效率研究",
+            "cadence": "daily",
+            "monthly_budget": 500000,
+            "rubric": ["和稀疏注意力直接相关"],
+            "anchors": [{"arxiv_id": "2404.00001"}],
+        },
+        headers=curator,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "稀疏注意力"
+    assert body["monthly_budget"] == 500000
+    assert body["can_manage"] is True
+
+    # 库为权威，写时同步回 project.name / project.definition（保持 ingest 兼容）
+    async with get_sessionmaker()() as session:
+        project = await session.get(Project, uuid.UUID(project_id))
+        assert project.name == "稀疏注意力"
+        definition = project.definition
+        assert definition["statement"] == "稀疏注意力机制的效率研究"
+        assert definition["rubric"] == ["和稀疏注意力直接相关"]
+        assert definition["anchor_papers"] == [{"arxiv_id": "2404.00001"}]
+        assert definition["cadence"] == "daily"
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert library.monthly_budget == 500000
+        assert library.statement == "稀疏注意力机制的效率研究"
+
+    # 显式传 null 清空预算
+    resp = await client.patch(
+        f"/api/libraries/{library_id}", json={"monthly_budget": None}, headers=curator
+    )
+    assert resp.status_code == 200
+    assert resp.json()["monthly_budget"] is None
+
+
+async def test_curator_and_admin_can_use_project_paper_endpoints(client):
+    admin, _owner, curator, stranger, project_id, library_id = await _setup(client)
+    # 无关用户：project 作用域文献端点视为不存在
+    resp = await client.get(f"/api/projects/{project_id}/papers", headers=stranger)
+    assert resp.status_code == 404
+    # 策展人（非成员）：与成员同权
+    await _appoint(client, admin, library_id, "gov-curator@example.com")
+    resp = await client.get(f"/api/projects/{project_id}/papers", headers=curator)
+    assert resp.status_code == 200, resp.text
+    # 平台 admin：同样放行
+    resp = await client.get(f"/api/projects/{project_id}/papers", headers=admin)
+    assert resp.status_code == 200, resp.text
+    # 库列表里策展人 can_manage=True、is_mine=False
+    resp = await client.get("/api/libraries", headers=curator)
+    row = next(x for x in resp.json() if x["id"] == library_id)
+    assert row["can_manage"] is True
+    assert row["is_mine"] is False

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "1c6c4831d80f"  # 笔记/划线归属拆分（P5b，本分支最新）
-PREV_REVISION = "0775b55c26e4"  # 课题「相关研究」书架（P5a）
+HEAD_REVISION = "3f770d85dca9"  # LLM 用量按方向库归因（P6，本分支最新）
+PREV_REVISION = "1c6c4831d80f"  # 笔记/划线归属拆分（P5b）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -58,6 +58,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "user_library_entries",
                     "user_publications",
                     "topic_papers",
+                    "llm_usage",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -221,13 +222,19 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "note",
         "added_by",
     } <= columns["topic_papers"]
+    # 本分支新增：LLM 用量按方向库归因（P6）
+    assert "library_id" in columns["llm_usage"]
+    assert "library_id" in columns["llm_call_logs"]
 
-    # 最新 revision 可往返（downgrade 补回可空 project_id 列，其余结构不动）
+    # 最新 revision 可往返（downgrade 删 library_id 归因列，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "project_id" in columns["paper_notes"]
-    assert "project_id" in columns["paper_highlights"]
+    assert "library_id" not in columns["llm_usage"]
+    assert "library_id" not in columns["llm_call_logs"]
+    # P5b 拆分结构不受影响：笔记/划线仍无 project_id
+    assert "project_id" not in columns["paper_notes"]
+    assert "project_id" not in columns["paper_highlights"]
     assert "topic_papers" in columns["_tables"]
     # P4 收尾后的内容池结构不受影响：判断列仍只在 library_papers 上
     assert "project_id" not in columns["papers"]

--- a/src/backend/tests/test_paper_merge.py
+++ b/src/backend/tests/test_paper_merge.py
@@ -1,0 +1,281 @@
+"""P6 重复论文合并（任务 3）：全表 repoint（含冲突分支）、候选发现、合并权限。"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.library_direction import LibraryPaper
+from app.models.paper import (
+    Paper,
+    PaperChunk,
+    PaperHighlight,
+    PaperNote,
+    PaperUserMeta,
+    paper_concepts,
+)
+from app.models.publication import UserPublication
+from app.models.topic_shelf import TopicPaper
+from app.models.user import User
+from app.services import paper_merge as merge_service
+from app.services.libraries import get_library_for_project
+from tests.conftest import add_concept, add_paper, register_and_login
+
+
+async def _setup(client, *, email="merge-owner@example.com", name="合并方向"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return headers, resp.json()["id"]
+
+
+async def _user_id(session, email):
+    return (await session.execute(select(User.id).where(User.email == email))).scalar_one()
+
+
+async def test_merge_papers_full_repoint_with_conflicts(client):
+    headers, project_id = await _setup(client)
+    _headers_b, project_b = await _setup(client, email="merge-b@example.com", name="第二方向")
+
+    async with get_sessionmaker()() as session:
+        owner_id = await _user_id(session, "merge-owner@example.com")
+        other_id = await _user_id(session, "merge-b@example.com")
+        pid = uuid.UUID(project_id)
+        pid_b = uuid.UUID(project_b)
+        lib_a = await get_library_for_project(session, pid)
+        lib_b = await get_library_for_project(session, pid_b)
+
+        # keep：A 库 scored（无 wiki、无全文分段）
+        keep = await add_paper(
+            session,
+            project_id=project_id,
+            title="Sparse Attention Methods",
+            year=2025,
+            arxiv_id="2501.00001",
+            dedup_key="arxiv:2501.00001",
+            status="scored",
+            relevance_score=0.8,
+        )
+        # drop：A 库 compiled（有 wiki）+ B 库成员 + 分段 + 概念 + 笔记划线 + 个人视角
+        drop = await add_paper(
+            session,
+            project_id=project_id,
+            title="Sparse Attention Methods (v2)",
+            year=2025,
+            doi="10.1000/sparse",
+            dedup_key="doi:10.1000/sparse",
+            status="compiled",
+            relevance_score=0.9,
+            wiki_content="# 解读\n讲 [[Attention]]。",
+        )
+        session.add(LibraryPaper(library_id=lib_b.id, paper_id=drop.id, status="candidate"))
+        session.add(PaperChunk(paper_id=drop.id, seq=0, text="chunk one"))
+        session.add(PaperChunk(paper_id=drop.id, seq=1, text="chunk two"))
+        shared = await add_concept(
+            session, project_id=project_id, name="Attention", slug="attention"
+        )
+        only_drop = await add_concept(
+            session, project_id=project_id, name="Sparsity", slug="sparsity"
+        )
+        await session.execute(
+            paper_concepts.insert(),
+            [
+                {"paper_id": keep.id, "concept_id": shared.id},
+                {"paper_id": drop.id, "concept_id": shared.id},  # 两边都有 → 去重
+                {"paper_id": drop.id, "concept_id": only_drop.id},  # 仅 drop → repoint
+            ],
+        )
+        session.add(PaperNote(paper_id=drop.id, author_id=owner_id, content="note"))
+        session.add(
+            PaperHighlight(
+                paper_id=drop.id,
+                author_id=owner_id,
+                page=1,
+                rects=[{"x0": 0, "y0": 0, "x1": 1, "y1": 1}],
+                selected_text="hi",
+            )
+        )
+        # 个人视角冲突：keep 未读不星标，drop 已读且星标 → 合并取并/更靠后
+        session.add(PaperUserMeta(paper_id=keep.id, user_id=owner_id, starred=False))
+        session.add(
+            PaperUserMeta(
+                paper_id=drop.id, user_id=owner_id, starred=True, reading_status="read"
+            )
+        )
+        # 另一用户只有 drop 行 → repoint
+        session.add(PaperUserMeta(paper_id=drop.id, user_id=other_id, starred=True))
+        # 书架冲突：同课题两行（keep 行无快照）
+        session.add(TopicPaper(topic_id=pid, paper_id=keep.id))
+        session.add(
+            TopicPaper(topic_id=pid, paper_id=drop.id, wiki_snapshot="snap", note="why")
+        )
+        session.add(TopicPaper(topic_id=pid_b, paper_id=drop.id))  # 仅 drop → repoint
+        # 软引用
+        session.add(
+            UserLibraryEntry(
+                user_id=owner_id,
+                dedup_key="doi:10.1000/sparse",
+                title=drop.title,
+                last_paper_id=drop.id,
+            )
+        )
+        session.add(
+            UserPublication(
+                user_id=owner_id,
+                dedup_key="doi:10.1000/sparse",
+                title=drop.title,
+                source="manual",
+                paper_id=drop.id,
+            )
+        )
+        await session.commit()
+        keep_id, drop_id = keep.id, drop.id
+        lib_a_id, lib_b_id = lib_a.id, lib_b.id
+        shared_id, only_drop_id = shared.id, only_drop.id
+
+    async with get_sessionmaker()() as session:
+        report = await merge_service.merge_papers(session, keep_id=keep_id, drop_id=drop_id)
+
+    assert report["dropped_dedup_key"] == "doi:10.1000/sparse"
+    assert report["library_memberships"] == {"repointed": 1, "merged": 1}
+    assert report["topic_papers"] == {"repointed": 1, "merged": 1}
+    assert report["paper_user_meta"] == {"repointed": 1, "merged": 1}
+    assert report["notes_repointed"] == 1
+    assert report["highlights_repointed"] == 1
+    assert report["concept_links"] == {"repointed": 1, "deduped": 1}
+    assert report["chunks_moved"] == 2
+    assert report["library_entries_repointed"] == 1
+    assert report["publications_repointed"] == 1
+    assert "doi" in report["fields_filled"]
+
+    async with get_sessionmaker()() as session:
+        assert await session.get(Paper, drop_id) is None
+        keep = await session.get(Paper, keep_id)
+        assert keep.doi == "10.1000/sparse"  # 缺项回填
+        assert keep.arxiv_id == "2501.00001"  # keep 原值不被覆盖
+        # A 库成员行合并：wiki 补上、状态升为 compiled、分数保留 keep 原值
+        member_a = (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == lib_a_id, LibraryPaper.paper_id == keep_id
+                )
+            )
+        ).scalar_one()
+        assert member_a.status == "compiled"
+        assert member_a.wiki_content and "[[Attention]]" in member_a.wiki_content
+        assert member_a.relevance_score == 0.8
+        # B 库成员行 repoint 到 keep
+        member_b = (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == lib_b_id, LibraryPaper.paper_id == keep_id
+                )
+            )
+        ).scalar_one()
+        assert member_b.status == "candidate"
+        # 个人视角合并
+        owner_id = await _user_id(session, "merge-owner@example.com")
+        meta = (
+            await session.execute(
+                select(PaperUserMeta).where(
+                    PaperUserMeta.paper_id == keep_id, PaperUserMeta.user_id == owner_id
+                )
+            )
+        ).scalar_one()
+        assert meta.starred is True
+        assert meta.reading_status == "read"
+        # 概念链：shared 只剩一条、only_drop 已 repoint
+        links = (
+            await session.execute(
+                select(paper_concepts.c.concept_id).where(paper_concepts.c.paper_id == keep_id)
+            )
+        ).scalars().all()
+        assert sorted(map(str, links)) == sorted(map(str, [shared_id, only_drop_id]))
+        # 分段随合并迁移
+        chunk_count = len(
+            (
+                await session.execute(
+                    select(PaperChunk.id).where(PaperChunk.paper_id == keep_id)
+                )
+            ).all()
+        )
+        assert chunk_count == 2
+        # 书架：keep 行补了快照与备注
+        shelf = (
+            await session.execute(
+                select(TopicPaper).where(TopicPaper.paper_id == keep_id)
+            )
+        ).scalars().all()
+        assert len(shelf) == 2
+        merged_row = next(t for t in shelf if t.topic_id == uuid.UUID(project_id))
+        assert merged_row.wiki_snapshot == "snap"
+        assert merged_row.note == "why"
+        # 软引用 repoint
+        entry = (
+            (await session.execute(select(UserLibraryEntry))).scalars().first()
+        )
+        assert entry.last_paper_id == keep_id
+        pub = (await session.execute(select(UserPublication))).scalars().first()
+        assert pub.paper_id == keep_id
+
+        # 幂等：drop 已不存在 → ValueError
+        try:
+            await merge_service.merge_papers(session, keep_id=keep_id, drop_id=drop_id)
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+
+async def test_duplicate_candidates_and_merge_api(client):
+    headers, project_id = await _setup(client, email="cand-owner@example.com")
+    stranger_token = await register_and_login(client, email="cand-stranger@example.com")
+    stranger = {"Authorization": f"Bearer {stranger_token}"}
+
+    async with get_sessionmaker()() as session:
+        keep = await add_paper(
+            session,
+            project_id=project_id,
+            title="A Survey of LLM Agents",
+            year=2025,
+            status="compiled",
+            wiki_content="# wiki",
+        )
+        drop = await add_paper(
+            session,
+            project_id=project_id,
+            title="a survey of  llm-agents",  # 规范化后同标题
+            year=2025,
+            status="scored",
+        )
+        await add_paper(session, project_id=project_id, title="Unrelated Paper", status="scored")
+        await session.commit()
+        keep_id, drop_id = str(keep.id), str(drop.id)
+        library_id = str((await get_library_for_project(session, uuid.UUID(project_id))).id)
+
+    # 候选发现：无关用户 403；可管理者拿到一组（首行 = 有 wiki 的建议保留行）
+    resp = await client.get(f"/api/libraries/{library_id}/duplicate-candidates", headers=stranger)
+    assert resp.status_code == 403
+    resp = await client.get(f"/api/libraries/{library_id}/duplicate-candidates", headers=headers)
+    assert resp.status_code == 200, resp.text
+    groups = resp.json()
+    assert len(groups) == 1
+    assert groups[0]["reason"] == "title"
+    assert [p["id"] for p in groups[0]["papers"]] == [keep_id, drop_id]
+    assert groups[0]["papers"][0]["has_wiki"] is True
+
+    # 合并：无关用户 403；可管理者成功；再次合并（drop 已删）→ 400
+    body = {"keep_id": keep_id, "drop_id": drop_id}
+    resp = await client.post("/api/papers/merge", json=body, headers=stranger)
+    assert resp.status_code == 403
+    resp = await client.post("/api/papers/merge", json=body, headers=headers)
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["kept_id"] == keep_id
+    assert result["details"]["library_memberships"] == {"repointed": 0, "merged": 1}
+    resp = await client.post("/api/papers/merge", json=body, headers=headers)
+    assert resp.status_code == 400
+    # 合并后候选清空
+    resp = await client.get(f"/api/libraries/{library_id}/duplicate-candidates", headers=headers)
+    assert resp.json() == []

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -9,9 +9,10 @@ import { WikiWorkbench } from '../wiki/WikiPage';
 import { LibraryBrowse } from './LibraryBrowse';
 
 /* ============================================================
-   /libraries/:id — 文献库详情（P5c）
-   - 背后课题的成员：完整工作台（论文管理 / 概念 / 图谱 / 对话 /
-     建库与同步 / 笔记，仍走 project 作用域端点）；
+   /libraries/:id — 文献库详情（P5c + P6 治理）
+   - 可管理者（成员 / 文献库管理员 / 平台管理员）：完整工作台
+     （论文管理 / 概念 / 图谱 / 对话 / 建库与同步 / 笔记 / 治理，
+     仍走 project 作用域端点）；
    - 其他人：干净的只读浏览（论文 + 概念，走 /libraries 读端点）。
    ============================================================ */
 
@@ -60,6 +61,7 @@ export function LibraryDetailPage() {
   }
 
   const isMember = lib.is_mine && !!lib.project_id;
+  const canManage = lib.can_manage && !!lib.project_id;
 
   return (
     <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
@@ -83,7 +85,11 @@ export function LibraryDetailPage() {
           </>
         }
       />
-      {isMember ? <WikiWorkbench pid={lib.project_id!} /> : <LibraryBrowse libraryId={lib.id} />}
+      {canManage ? (
+        <WikiWorkbench pid={lib.project_id!} libraryId={lib.id} />
+      ) : (
+        <LibraryBrowse libraryId={lib.id} />
+      )}
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
-import { api, isAdmin, type DirectionLibraryDetail } from '../../lib/api';
+import { api, isAdmin, type DirectionLibraryDetail, type DuplicateCandidatePaper } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 
 /* ============================================================
@@ -10,6 +10,7 @@ import { tr } from '../../lib/i18n';
    - 库信息与预算编辑（可管理者：成员 / 文献库管理员 / 平台管理员）；
    - 本月 AI 用量进度（超限后同步任务暂停到下月）；
    - 文献库管理员名单（仅平台管理员可编辑）；
+   - 重复论文候选与合并（不可撤销）。
    ============================================================ */
 
 const CADENCES: { v: string; zh: string; en: string }[] = [
@@ -32,7 +33,121 @@ export function GovernanceTab({ libraryId }: { libraryId: string }) {
       {lib && <LibraryInfoCard lib={lib} />}
       <BudgetCard libraryId={libraryId} />
       <CuratorsCard libraryId={libraryId} canEdit={admin} />
+      <DuplicatesCard libraryId={libraryId} />
     </div>
+  );
+}
+
+/* —— 重复论文候选与合并 —— */
+
+const REASON_LABEL: Record<string, { zh: string; en: string }> = {
+  arxiv: { zh: '同一 arXiv 编号', en: 'Same arXiv id' },
+  doi: { zh: '同一 DOI', en: 'Same DOI' },
+  title: { zh: '标题相同', en: 'Same title' },
+};
+
+function DuplicatesCard({ libraryId }: { libraryId: string }) {
+  const queryClient = useQueryClient();
+  const { data: groups, isLoading, isError } = useQuery({
+    queryKey: ['library-duplicates', libraryId],
+    queryFn: () => api.listDuplicateCandidates(libraryId),
+    retry: false,
+  });
+
+  const merge = useMutation({
+    mutationFn: (input: { keep_id: string; drop_id: string }) => api.mergePapers(input),
+    onSuccess: () => {
+      toast(tr('已合并为一篇论文', 'Merged into one paper'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library-duplicates', libraryId] });
+      void queryClient.invalidateQueries({ queryKey: ['library', libraryId] });
+      void queryClient.invalidateQueries({ queryKey: ['papers'] });
+    },
+    onError: () => toast(tr('合并失败，请重试', 'Merge failed, please retry'), 'error'),
+  });
+
+  function confirmMerge(keep: DuplicateCandidatePaper, drop: DuplicateCandidatePaper) {
+    const ok = window.confirm(
+      `${tr('确定合并这两篇论文？', 'Merge these two papers?')}\n\n` +
+        `${tr('保留：', 'Keep: ')}${keep.title}\n${tr('并入后删除：', 'Merge & delete: ')}${drop.title}\n\n` +
+        tr(
+          '被删除那篇的解读、笔记、划线、收藏等会全部并到保留的那篇上。此操作不可撤销。',
+          'Its wiki, notes, highlights and stars will all move to the kept paper. This cannot be undone.',
+        ),
+    );
+    if (ok) merge.mutate({ keep_id: keep.id, drop_id: drop.id });
+  }
+
+  return (
+    <section className="card" style={{ padding: 18 }}>
+      <h3 style={{ fontSize: 14, fontWeight: 700, marginBottom: 6 }}>
+        {tr('重复论文', 'Duplicate papers')}
+      </h3>
+      <p className="muted" style={{ fontSize: 12, marginBottom: 12 }}>
+        {tr(
+          '同一篇论文可能因预印本 / 正式版等原因入库两次。确认后合并：保留更完整的一篇，另一篇的所有内容并入后删除（不可撤销）。',
+          'The same paper can be ingested twice (e.g. preprint vs published). Merging keeps the more complete row and folds the other into it — irreversible.',
+        )}
+      </p>
+      {isLoading ? (
+        <div className="skel" style={{ height: 48 }} />
+      ) : isError ? (
+        <div className="muted" style={{ fontSize: 13 }}>{tr('候选加载失败', 'Failed to load candidates')}</div>
+      ) : !groups || groups.length === 0 ? (
+        <div className="muted" style={{ fontSize: 13 }}>
+          {tr('没有发现疑似重复的论文。', 'No suspected duplicates found.')}
+        </div>
+      ) : (
+        <div className="col gap12">
+          {groups.map((group, gi) => {
+            const keep = group.papers[0];
+            if (!keep) return null;
+            return (
+              <div
+                key={`${group.reason}-${keep.id}-${gi}`}
+                style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12 }}
+              >
+                <div className="muted" style={{ fontSize: 12, marginBottom: 8 }}>
+                  {tr(REASON_LABEL[group.reason]?.zh ?? group.reason, REASON_LABEL[group.reason]?.en ?? group.reason)}
+                </div>
+                <div className="col gap8">
+                  {group.papers.map((paper, pi) => (
+                    <div key={paper.id} className="row" style={{ justifyContent: 'space-between', gap: 12 }}>
+                      <div className="col" style={{ minWidth: 0 }}>
+                        <div className="row gap8" style={{ minWidth: 0 }}>
+                          <span style={{ fontSize: 13, fontWeight: pi === 0 ? 650 : 400, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {paper.title}
+                          </span>
+                          {pi === 0 && (
+                            <span className="pill" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', flexShrink: 0 }}>
+                              {tr('建议保留', 'Suggested keep')}
+                            </span>
+                          )}
+                        </div>
+                        <span className="muted" style={{ fontSize: 12 }}>
+                          {paper.year ?? tr('年份未知', 'Year unknown')} · {paper.source ?? tr('来源未知', 'Unknown source')} ·{' '}
+                          {tr('全文分段 ', 'Chunks ')}{paper.chunk_count}
+                          {paper.has_wiki ? ` · ${tr('已有解读', 'Has wiki')}` : ''}
+                        </span>
+                      </div>
+                      {pi > 0 && (
+                        <button
+                          className="btn btn-soft sm"
+                          disabled={merge.isPending}
+                          onClick={() => confirmMerge(keep, paper)}
+                          style={{ flexShrink: 0 }}
+                        >
+                          {tr('并入保留行', 'Merge into keep')}
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -8,6 +8,7 @@ import { tr } from '../../lib/i18n';
 /* ============================================================
    文献库「治理」页签（P6）：
    - 库信息与预算编辑（可管理者：成员 / 文献库管理员 / 平台管理员）；
+   - 本月 AI 用量进度（超限后同步任务暂停到下月）；
    - 文献库管理员名单（仅平台管理员可编辑）；
    ============================================================ */
 
@@ -29,8 +30,78 @@ export function GovernanceTab({ libraryId }: { libraryId: string }) {
   return (
     <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
       {lib && <LibraryInfoCard lib={lib} />}
+      <BudgetCard libraryId={libraryId} />
       <CuratorsCard libraryId={libraryId} canEdit={admin} />
     </div>
+  );
+}
+
+/* —— 本月用量进度 —— */
+
+function BudgetCard({ libraryId }: { libraryId: string }) {
+  const { data: budget, isError } = useQuery({
+    queryKey: ['library-budget', libraryId],
+    queryFn: () => api.getLibraryBudget(libraryId),
+    retry: false,
+    refetchInterval: 60_000,
+  });
+
+  const limited = budget?.monthly_budget != null && budget.monthly_budget > 0;
+  const ratio = limited && budget ? Math.min(1, budget.used_tokens / budget.monthly_budget!) : 0;
+  const barColor = ratio >= 1 ? 'var(--danger)' : ratio >= 0.8 ? 'var(--warn)' : 'var(--accent)';
+
+  return (
+    <section className="card" style={{ padding: 18 }}>
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 8 }}>
+        <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('本月 AI 用量', 'AI usage this month')}</h3>
+        {budget && <span className="muted" style={{ fontSize: 12 }}>{budget.month}</span>}
+      </div>
+      {isError ? (
+        <div className="muted" style={{ fontSize: 13 }}>{tr('用量加载失败', 'Failed to load usage')}</div>
+      ) : !budget ? (
+        <div className="skel" style={{ height: 34 }} />
+      ) : (
+        <div className="col gap8">
+          <div className="row" style={{ justifyContent: 'space-between', fontSize: 13 }}>
+            <span>
+              {tr('已用 ', 'Used ')}
+              <strong>{budget.used_tokens.toLocaleString()}</strong>
+              {' tokens'}
+              <span className="muted" style={{ fontSize: 12, marginLeft: 8 }}>
+                {tr('输入 ', 'in ')}{budget.prompt_tokens.toLocaleString()} · {tr('输出 ', 'out ')}
+                {budget.completion_tokens.toLocaleString()}
+              </span>
+            </span>
+            <span className="muted" style={{ fontSize: 12 }}>
+              {limited
+                ? `${tr('上限 ', 'Cap ')}${budget.monthly_budget!.toLocaleString()}`
+                : tr('未设上限', 'No cap')}
+            </span>
+          </div>
+          {limited && (
+            <div style={{ height: 8, borderRadius: 4, background: 'var(--surface-3)', overflow: 'hidden' }}>
+              <div
+                style={{
+                  width: `${Math.round(ratio * 100)}%`,
+                  height: '100%',
+                  borderRadius: 4,
+                  background: barColor,
+                  transition: 'width .3s',
+                }}
+              />
+            </div>
+          )}
+          {budget.exhausted && (
+            <div style={{ color: 'var(--danger-tx)', fontSize: 13 }}>
+              {tr(
+                '本月预算已用尽：同步任务已暂停，下月自动恢复，或调高上限后再试。',
+                'Monthly budget used up: syncing is paused until next month, or raise the cap and retry.',
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import { api, isAdmin, type DirectionLibraryDetail } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   文献库「治理」页签（P6）：
+   - 库信息与预算编辑（可管理者：成员 / 文献库管理员 / 平台管理员）；
+   - 文献库管理员名单（仅平台管理员可编辑）；
+   ============================================================ */
+
+const CADENCES: { v: string; zh: string; en: string }[] = [
+  { v: '', zh: '手动同步', en: 'Manual' },
+  { v: 'daily', zh: '每天自动同步', en: 'Daily' },
+];
+
+export function GovernanceTab({ libraryId }: { libraryId: string }) {
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
+  const admin = isAdmin(me);
+
+  const { data: lib } = useQuery({
+    queryKey: ['library', libraryId],
+    queryFn: () => api.getLibrary(libraryId),
+    retry: false,
+  });
+
+  return (
+    <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
+      {lib && <LibraryInfoCard lib={lib} />}
+      <CuratorsCard libraryId={libraryId} canEdit={admin} />
+    </div>
+  );
+}
+
+/* —— 库信息与预算 —— */
+
+function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(lib.name);
+  const [statement, setStatement] = useState(lib.statement ?? '');
+  const [cadence, setCadence] = useState(lib.cadence ?? '');
+  const [budget, setBudget] = useState(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+
+  // 库切换 / 保存后回填
+  useEffect(() => {
+    setName(lib.name);
+    setStatement(lib.statement ?? '');
+    setCadence(lib.cadence ?? '');
+    setBudget(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+  }, [lib]);
+
+  const dirty =
+    name !== lib.name ||
+    statement !== (lib.statement ?? '') ||
+    cadence !== (lib.cadence ?? '') ||
+    budget !== (lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.updateLibrary(lib.id, {
+        name: name.trim() || lib.name,
+        statement: statement.trim() || null,
+        cadence: cadence || null,
+        monthly_budget: budget.trim() === '' ? null : Math.max(0, Math.floor(Number(budget))),
+      }),
+    onSuccess: () => {
+      toast(tr('库信息已保存', 'Library info saved'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library', lib.id] });
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      void queryClient.invalidateQueries({ queryKey: ['library-budget', lib.id] });
+    },
+    onError: () => toast(tr('保存失败，请重试', 'Save failed, please retry'), 'error'),
+  });
+
+  const budgetInvalid = budget.trim() !== '' && (!Number.isFinite(Number(budget)) || Number(budget) < 0);
+
+  return (
+    <section className="card" style={{ padding: 18 }}>
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 12 }}>
+        <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('库信息', 'Library info')}</h3>
+        <button
+          className="btn btn-primary sm"
+          disabled={!dirty || budgetInvalid || save.isPending || !name.trim()}
+          onClick={() => save.mutate()}
+        >
+          {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+      <div className="col gap12">
+        <label className="col gap6">
+          <span className="muted" style={{ fontSize: 12 }}>{tr('名称', 'Name')}</span>
+          <input className="input" value={name} onChange={(e) => setName(e.target.value)} maxLength={255} />
+        </label>
+        <label className="col gap6">
+          <span className="muted" style={{ fontSize: 12 }}>{tr('方向说明（一句话）', 'Statement')}</span>
+          <textarea
+            className="input"
+            rows={2}
+            value={statement}
+            onChange={(e) => setStatement(e.target.value)}
+            placeholder={tr('这个方向关注什么问题', 'What this direction is about')}
+          />
+        </label>
+        <div className="row gap12" style={{ flexWrap: 'wrap' }}>
+          <label className="col gap6" style={{ minWidth: 180 }}>
+            <span className="muted" style={{ fontSize: 12 }}>{tr('同步节奏', 'Sync cadence')}</span>
+            <select className="input" value={cadence} onChange={(e) => setCadence(e.target.value)}>
+              {CADENCES.map((c) => (
+                <option key={c.v} value={c.v}>{tr(c.zh, c.en)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="col gap6" style={{ minWidth: 220 }}>
+            <span className="muted" style={{ fontSize: 12 }}>
+              {tr('每月 AI 预算（token 数，留空 = 不限）', 'Monthly AI budget (tokens, empty = unlimited)')}
+            </span>
+            <input
+              className="input"
+              inputMode="numeric"
+              value={budget}
+              onChange={(e) => setBudget(e.target.value)}
+              placeholder={tr('如 2000000', 'e.g. 2000000')}
+            />
+          </label>
+        </div>
+        {budgetInvalid && (
+          <div style={{ color: 'var(--danger-tx)', fontSize: 12 }}>
+            {tr('预算需为不小于 0 的数字', 'Budget must be a number ≥ 0')}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* —— 文献库管理员名单 —— */
+
+function CuratorsCard({ libraryId, canEdit }: { libraryId: string; canEdit: boolean }) {
+  const queryClient = useQueryClient();
+  const [adding, setAdding] = useState(false);
+  const [pick, setPick] = useState('');
+
+  const curatorsQuery = useQuery({
+    queryKey: ['library-curators', libraryId],
+    queryFn: () => api.listLibraryCurators(libraryId),
+    retry: false,
+  });
+  const usersQuery = useQuery({
+    queryKey: ['admin-users'],
+    queryFn: () => api.adminListUsers(),
+    enabled: canEdit && adding,
+    retry: false,
+  });
+
+  const curators = curatorsQuery.data ?? [];
+  const candidates = useMemo(
+    () => (usersQuery.data ?? []).filter((u) => !curators.some((c) => c.user_id === u.id)),
+    [usersQuery.data, curators],
+  );
+
+  const replace = useMutation({
+    mutationFn: (userIds: string[]) => api.setLibraryCurators(libraryId, userIds),
+    onSuccess: (rows) => {
+      queryClient.setQueryData(['library-curators', libraryId], rows);
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      setPick('');
+      setAdding(false);
+    },
+    onError: () => toast(tr('名单更新失败', 'Failed to update the list'), 'error'),
+  });
+
+  return (
+    <section className="card" style={{ padding: 18 }}>
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 6 }}>
+        <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('文献库管理员', 'Library managers')}</h3>
+        {canEdit && !adding && (
+          <button className="btn btn-soft sm" onClick={() => setAdding(true)}>
+            <Icon name="plus" size={12} />
+            {tr('添加', 'Add')}
+          </button>
+        )}
+      </div>
+      <p className="muted" style={{ fontSize: 12, marginBottom: 12 }}>
+        {tr(
+          '管理员可以调整这个库的收录标准、编辑库信息与预算、合并重复论文；名单由平台管理员任命。',
+          'Managers can tune inclusion criteria, edit library info and budget, and merge duplicate papers. Appointed by platform admins.',
+        )}
+      </p>
+      {curatorsQuery.isError ? (
+        <div className="muted" style={{ fontSize: 13 }}>
+          {tr('名单加载失败（可能没有查看权限）', 'Failed to load (you may lack permission)')}
+        </div>
+      ) : curators.length === 0 ? (
+        <div className="muted" style={{ fontSize: 13 }}>
+          {tr('还没有任命管理员：库背后课题的成员与平台管理员可管理。', 'No managers appointed yet; topic members and platform admins can manage.')}
+        </div>
+      ) : (
+        <div className="col gap8">
+          {curators.map((c) => (
+            <div key={c.user_id} className="row" style={{ justifyContent: 'space-between' }}>
+              <div className="row gap8">
+                <Icon name="users" size={14} />
+                <span style={{ fontSize: 13 }}>{c.display_name || c.email}</span>
+                <span className="muted" style={{ fontSize: 12 }}>{c.email}</span>
+              </div>
+              {canEdit && (
+                <button
+                  className="btn btn-ghost sm"
+                  disabled={replace.isPending}
+                  onClick={() => replace.mutate(curators.filter((x) => x.user_id !== c.user_id).map((x) => x.user_id))}
+                >
+                  {tr('移除', 'Remove')}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {canEdit && adding && (
+        <div className="row gap8" style={{ marginTop: 12 }}>
+          <select className="input" value={pick} onChange={(e) => setPick(e.target.value)} style={{ flex: 1 }}>
+            <option value="">{tr('选择用户…', 'Pick a user…')}</option>
+            {candidates.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.display_name || u.email}（{u.email}）
+              </option>
+            ))}
+          </select>
+          <button
+            className="btn btn-primary sm"
+            disabled={!pick || replace.isPending}
+            onClick={() => replace.mutate([...curators.map((c) => c.user_id), pick])}
+          >
+            {tr('确认添加', 'Add')}
+          </button>
+          <button className="btn btn-ghost sm" onClick={() => { setAdding(false); setPick(''); }}>
+            {tr('取消', 'Cancel')}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -118,7 +118,12 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
       navigate(`/voyages/${v.id}`);
     },
     onError: (e) => {
-      if (e instanceof ApiError && e.status === 409) {
+      if (e instanceof ApiError && e.status === 409 && e.message === 'LIBRARY_BUDGET_EXHAUSTED') {
+        toast(
+          tr('这个文献库本月 AI 预算已用尽，同步已暂停；下月自动恢复，或请管理员调高预算。', 'This library has used up its monthly AI budget — syncing is paused until next month, or ask an admin to raise the budget.'),
+          'error',
+        );
+      } else if (e instanceof ApiError && e.status === 409) {
         toast(
           tr('该课题已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this topic — wait for it to finish.'),
           'error',

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -11,6 +11,7 @@ import { ConceptsTab } from './ConceptsTab';
 import { LibraryChatTab } from './LibraryChatTab';
 import { IngestTab } from './IngestTab';
 import { NotesTab } from './NotesTab';
+import { GovernanceTab } from './GovernanceTab';
 
 // 图谱与 PPT 弹窗体量大且非默认视图：按需加载
 const GraphTab = lazy(() => import('./GraphTab').then((m) => ({ default: m.GraphTab })));
@@ -19,14 +20,15 @@ const PresentationModal = lazy(() =>
 );
 
 /* ============================================================
-   文献库工作台（P5c 起挂在 /libraries/:id 的成员视图；原 /wiki 页面主体）
-   六个 Tab：论文库 / 概念库 / 图谱 / 文献对话 / 建库与同步 / 笔记；
-   pid = 库背后课题 id（成员视角，数据仍走 project 作用域端点）。
+   文献库工作台（P5c 起挂在 /libraries/:id 的可管理者视图；原 /wiki 页面主体）
+   Tab：论文库 / 概念库 / 图谱 / 文献对话 / 建库与同步 / 笔记，
+   传入 libraryId 时追加「治理」（P6：库信息与预算 / 文献库管理员 / 重复论文）；
+   pid = 库背后课题 id（数据仍走 project 作用域端点，策展人与 admin 同权放行）。
    ============================================================ */
 
-type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes';
+type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | 'govern';
 
-export function WikiWorkbench({ pid }: { pid: string }) {
+export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: string }) {
   const navigate = useNavigate();
 
   const [tab, setTab] = useState<WikiTab>('papers');
@@ -69,7 +71,7 @@ export function WikiWorkbench({ pid }: { pid: string }) {
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['papers', 'concepts', 'graph', 'chat', 'ingest', 'notes'].includes(tabParam)) {
+    } else if (tabParam && ['papers', 'concepts', 'graph', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -139,6 +141,7 @@ export function WikiWorkbench({ pid }: { pid: string }) {
             { v: 'chat', label: tr('文献对话', 'Chat') },
             { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
             { v: 'notes', label: tr('笔记', 'Notes') },
+            ...(libraryId ? [{ v: 'govern' as const, label: tr('治理', 'Governance') }] : []),
           ]}
           value={tab}
           onChange={setTab}
@@ -202,6 +205,8 @@ export function WikiWorkbench({ pid }: { pid: string }) {
             stateError={ingestQuery.isError}
             stateLoading={ingestQuery.isLoading}
           />
+        ) : tab === 'govern' && libraryId ? (
+          <GovernanceTab libraryId={libraryId} />
         ) : (
           <NotesTab pid={pid} />
         )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -806,6 +806,8 @@ export interface DirectionLibrarySummary {
   project_id: string | null;
   /** 是否「我的课题的库」（请求者是背后课题成员 → 显示管理页签） */
   is_mine: boolean;
+  /** 是否可管理本库：成员 ∪ 文献库管理员 ∪ 平台管理员（P6） */
+  can_manage: boolean;
   paper_count: number;
   concept_count: number;
   last_compiled_at: string | null;
@@ -817,6 +819,15 @@ export interface DirectionLibrarySummary {
 
 export interface DirectionLibraryDetail extends DirectionLibrarySummary {
   cadence: string | null;
+  /** 每月 AI 预算（token 数；null = 不限） */
+  monthly_budget: number | null;
+}
+
+/** 文献库管理员（后端叫 curator）。 */
+export interface LibraryCuratorRead {
+  user_id: string;
+  email: string;
+  display_name: string | null;
 }
 
 // ============================================================
@@ -2635,6 +2646,28 @@ export const api = {
   },
   getLibrary(id: string): Promise<DirectionLibraryDetail> {
     return request<DirectionLibraryDetail>(`/libraries/${id}`);
+  },
+  /** 编辑库信息（可管理者）；传 null 清空对应字段。 */
+  updateLibrary(
+    id: string,
+    input: {
+      name?: string;
+      statement?: string | null;
+      cadence?: string | null;
+      monthly_budget?: number | null;
+      rubric?: unknown;
+      anchors?: unknown[] | null;
+    },
+  ): Promise<DirectionLibraryDetail> {
+    return requestJson<DirectionLibraryDetail>(`/libraries/${id}`, 'PATCH', input);
+  },
+  /** 文献库管理员名单（可管理者可见）。 */
+  listLibraryCurators(id: string): Promise<LibraryCuratorRead[]> {
+    return request<LibraryCuratorRead[]>(`/libraries/${id}/curators`);
+  },
+  /** 全量替换文献库管理员名单（仅平台管理员）。 */
+  setLibraryCurators(id: string, userIds: string[]): Promise<LibraryCuratorRead[]> {
+    return requestJson<LibraryCuratorRead[]>(`/libraries/${id}/curators`, 'PUT', { user_ids: userIds });
   },
   /** 库内论文（缺省只列相关性达标的）。 */
   listLibraryPapers(

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -830,6 +830,20 @@ export interface LibraryCuratorRead {
   display_name: string | null;
 }
 
+/** 库预算面板：本月 AI 用量（token）与上限。 */
+export interface LibraryBudgetRead {
+  /** 如 "2026-07" */
+  month: string;
+  monthly_budget: number | null;
+  prompt_tokens: number;
+  completion_tokens: number;
+  used_tokens: number;
+  /** 不限时为 null */
+  remaining_tokens: number | null;
+  /** true = 本月预算已用尽（同步任务会被拒绝启动） */
+  exhausted: boolean;
+}
+
 // ============================================================
 // M2 · Search（关键词 / 语义检索）
 // ============================================================
@@ -2660,6 +2674,10 @@ export const api = {
     },
   ): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>(`/libraries/${id}`, 'PATCH', input);
+  },
+  /** 本月预算消耗（可管理者可见）。 */
+  getLibraryBudget(id: string): Promise<LibraryBudgetRead> {
+    return request<LibraryBudgetRead>(`/libraries/${id}/budget`);
   },
   /** 文献库管理员名单（可管理者可见）。 */
   listLibraryCurators(id: string): Promise<LibraryCuratorRead[]> {

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -830,6 +830,34 @@ export interface LibraryCuratorRead {
   display_name: string | null;
 }
 
+/** 重复候选组里的一行（对比要素）。 */
+export interface DuplicateCandidatePaper {
+  id: string;
+  title: string;
+  year: number | null;
+  source: string | null;
+  arxiv_id: string | null;
+  doi: string | null;
+  status: string;
+  chunk_count: number;
+  has_wiki: boolean;
+  created_at: string;
+}
+
+export interface DuplicateCandidateGroup {
+  /** 按何种键判定为疑似重复：arxiv | doi | title */
+  reason: string;
+  /** 首行 = 建议保留行（更完整优先） */
+  papers: DuplicateCandidatePaper[];
+}
+
+export interface PaperMergeResult {
+  kept_id: string;
+  dropped_id: string;
+  dropped_dedup_key: string | null;
+  details: Record<string, unknown>;
+}
+
 /** 库预算面板：本月 AI 用量（token）与上限。 */
 export interface LibraryBudgetRead {
   /** 如 "2026-07" */
@@ -2678,6 +2706,14 @@ export const api = {
   /** 本月预算消耗（可管理者可见）。 */
   getLibraryBudget(id: string): Promise<LibraryBudgetRead> {
     return request<LibraryBudgetRead>(`/libraries/${id}/budget`);
+  },
+  /** 库内疑似重复论文（可管理者）。 */
+  listDuplicateCandidates(id: string): Promise<DuplicateCandidateGroup[]> {
+    return request<DuplicateCandidateGroup[]>(`/libraries/${id}/duplicate-candidates`);
+  },
+  /** 合并重复论文（不可撤销）：drop 的全部归属并入 keep 后删除 drop。 */
+  mergePapers(input: { keep_id: string; drop_id: string }): Promise<PaperMergeResult> {
+    return requestJson<PaperMergeResult>('/papers/merge', 'POST', input);
   },
   /** 文献库管理员名单（可管理者可见）。 */
   listLibraryCurators(id: string): Promise<LibraryCuratorRead[]> {


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P6, the final planned phase.

## What changed

**Curator role and library-level write permissions.** `can_manage_library` = backing-project member ∪ appointed curator ∪ platform admin, wired through all library management surfaces (papers, concepts, wiki tools, ingest). Admins appoint curators (`PUT /libraries/{id}/curators`, full replace); `PATCH /libraries/{id}` edits name/statement/cadence/budget/rubric/anchors with the library as the authority, write-through to `project.definition` so ingest stays compatible. New Governance tab on the library workbench; curators who are not project members get the full workbench. UI copy says 文献库管理员.

**Monthly AI budgets with pause.** Migration `3f770d85dca9` adds `library_id` attribution to LLM usage/call logs; all library-side spend (scoring, wiki compile, figure annotation, concept definitions, chunk embedding, all six ingest steps) is attributed, while personal wiki compilation and ad-hoc searches stay on the individual. Ingest launches are refused with 409 when the UTC-month budget is exhausted; running ingests inherit min(derived, remaining) as their voyage budget so the existing pause mechanism enforces the cap. `GET /libraries/{id}/budget` + a progress bar in the Governance tab.

**Duplicate paper merge.** `merge_papers(keep, drop)` repoints every membership/annotation/reference table in one transaction with sensible conflict resolution and pool-field backfill; `GET /libraries/{id}/duplicate-candidates` groups by shared arxiv/doi or normalized title with a suggested keeper. Governance tab gets a comparison list with an irreversible-merge confirm.

Two regression fixes surfaced by the full suite are included (strict membership on personal-wiki topic attribution; PATCH null-name protection).

## Tests

518 passed (baseline 506 + 11 new governance/budget/merge tests + 1 env-flipped feedback test), 16 pre-existing errors, zero new failures. Migration verified on sqlite round-trip and fresh postgres up/down/up. Frontend tsc + build pass.