### PR TITLE
feat(libraries): decouple libraries from topics — many-to-many source libraries (IA redesign P7)

### DIFF
--- a/src/backend/alembic/versions/67d18892a6ce_topic_library_associations.py
+++ b/src/backend/alembic/versions/67d18892a6ce_topic_library_associations.py
@@ -1,0 +1,100 @@
+"""课题 × 文献库关联 + 库生命周期独立（P7 Step 1）
+
+新建 topic_source_libraries（多对多关联行，回填每个课题关联自己的隐式库）；
+direction_libraries.project_id 语义降级为「起源课题」溯源，ondelete 由 CASCADE
+改 SET NULL——删课题不再级联删库（内容/成员行/概念保留，孤儿库由 admin 后续
+处理）。原 FK/unique 均未命名（inline 建表），用 inspector 探活实际约束名再
+drop，兼容 sqlite/postgres。
+
+Revision ID: 67d18892a6ce
+Revises: 3f770d85dca9
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "67d18892a6ce"
+down_revision: str | None = "3f770d85dca9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.create_table(
+        "topic_source_libraries",
+        sa.Column("topic_id", sa.Uuid(), nullable=False),
+        sa.Column("library_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["topic_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["library_id"], ["direction_libraries.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("topic_id", "library_id"),
+    )
+    op.create_index(
+        "ix_topic_source_libraries_library_id", "topic_source_libraries", ["library_id"]
+    )
+
+    # 回填：每个课题关联自己的隐式库（历史 1:1 数据）
+    rows = bind.execute(
+        sa.text(
+            "SELECT project_id, id FROM direction_libraries WHERE project_id IS NOT NULL"
+        )
+    ).fetchall()
+    if rows:
+        table = sa.table(
+            "topic_source_libraries",
+            sa.column("topic_id", sa.Uuid()),
+            sa.column("library_id", sa.Uuid()),
+            sa.column("created_at", sa.DateTime(timezone=True)),
+        )
+        now = datetime.now(UTC)
+        op.bulk_insert(
+            table,
+            [
+                {"topic_id": project_id, "library_id": library_id, "created_at": now}
+                for project_id, library_id in rows
+            ],
+        )
+
+    # direction_libraries.project_id：FK 未命名（inline 建表），探活实际约束名再改
+    # ondelete；unique 约束不动（一个课题至多起源一个库，语义不变）。
+    inspector = sa.inspect(bind)
+    fk_name = next(
+        (
+            fk["name"]
+            for fk in inspector.get_foreign_keys("direction_libraries")
+            if fk.get("constrained_columns") == ["project_id"]
+        ),
+        None,
+    )
+    with op.batch_alter_table("direction_libraries") as batch:
+        if fk_name:
+            batch.drop_constraint(fk_name, type_="foreignkey")
+        batch.create_foreign_key(
+            "fk_direction_libraries_project_id",
+            "projects",
+            ["project_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_constraint("fk_direction_libraries_project_id", type_="foreignkey")
+        batch.create_foreign_key(
+            "fk_direction_libraries_project_id",
+            "projects",
+            ["project_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    op.drop_index("ix_topic_source_libraries_library_id", table_name="topic_source_libraries")
+    op.drop_table("topic_source_libraries")

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -43,13 +43,16 @@ from app.models.base import utcnow
 from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment, ExperimentRun
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
-from app.models.paper import Paper
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import VoyageRun
 from app.services import experiments as experiments_service
 from app.services import ssh_exec
 from app.services.figure_annotate import prepare_image_for_llm
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 
 RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0）
 MAX_SETUP_FIXES = 2  # 依赖安装失败回 LLM 修 requirements/run.sh 的次数上限
@@ -873,23 +876,28 @@ async def experiment_plan(ctx: ActionContext, params: dict[str, Any]) -> dict[st
             raise ValueError("实验关联的 idea 不存在")
 
         if not isinstance(experiment.plan, dict):  # 断点幂等
-            library = await get_library_for_project(session, experiment.project_id)
-            rows = (
-                await session.execute(
-                    select(Paper.title, LibraryPaper.wiki_content)
-                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                    .where(
-                        LibraryPaper.library_id == library.id,
-                        LibraryPaper.status.in_(("compiled", "included")),
-                        LibraryPaper.wiki_content.is_not(None),
-                    )
-                    .order_by(
-                        LibraryPaper.relevance_score.desc().nulls_last(),
-                        LibraryPaper.created_at,
-                    )
-                    .limit(_WIKI_CONTEXT_PAPERS)
+            library_ids = await get_source_library_ids(session, experiment.project_id)
+            member_rows = (
+                dedupe_member_rows(
+                    (
+                        await session.execute(
+                            member_papers_stmt(library_ids).where(
+                                LibraryPaper.status.in_(("compiled", "included")),
+                                LibraryPaper.wiki_content.is_not(None),
+                            )
+                        )
+                    ).all()
                 )
-            ).all()
+                if library_ids
+                else []
+            )
+            member_rows.sort(
+                key=lambda pm: (
+                    -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18),
+                    pm[1].created_at,
+                )
+            )
+            rows = [(p.title, m.wiki_content) for p, m in member_rows[:_WIKI_CONTEXT_PAPERS]]
             wiki_context = (
                 "\n\n".join(
                     f"### {title}\n{(wiki or '')[:_WIKI_EXCERPT_CHARS]}" for title, wiki in rows

--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -36,7 +36,11 @@ from app.models.paper import Concept, Paper, paper_concepts
 from app.models.project import Project
 from app.models.review import ReviewMessage, ReviewSession
 from app.schemas.idea import FORGE_SIGNALS
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 from app.services.review import (
     DEFAULT_PERSONAS,
     elo_update,
@@ -189,35 +193,46 @@ async def forge_read_context(ctx: ActionContext, params: dict[str, Any]) -> dict
     knobs = _forge_knobs(ctx)
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
-        library = await get_library_for_project(session, project.id)
+        # 课题关联库并集：跨库同一论文按确定性视角归并（有 wiki 优先），再按相关性截断
+        library_ids = await get_source_library_ids(session, project.id)
         rows = (
-            await session.execute(
-                select(Paper, LibraryPaper.wiki_content)
-                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(
-                    LibraryPaper.library_id == library.id,
-                    LibraryPaper.status.in_(("compiled", "included")),
-                    LibraryPaper.wiki_content.is_not(None),
-                )
-                .order_by(
-                    LibraryPaper.relevance_score.desc().nulls_last(), LibraryPaper.created_at
-                )
-                .limit(int(knobs["max_context_papers"]))
+            dedupe_member_rows(
+                (
+                    await session.execute(
+                        member_papers_stmt(library_ids).where(
+                            LibraryPaper.status.in_(("compiled", "included")),
+                            LibraryPaper.wiki_content.is_not(None),
+                        )
+                    )
+                ).all()
             )
-        ).all()
+            if library_ids
+            else []
+        )
+        rows.sort(
+            key=lambda pm: (
+                -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18),
+                pm[1].created_at,
+            )
+        )
+        rows = rows[: int(knobs["max_context_papers"])]
         papers = [p for p, _ in rows]
-        wiki_of = {p.id: wiki for p, wiki in rows}
+        wiki_of = {p.id: m.wiki_content for p, m in rows}
         concept_names = (
             (
-                await session.execute(
-                    select(Concept.name)
-                    .where(Concept.library_id == library.id)
-                    .order_by(Concept.name)
-                    .limit(100)
+                (
+                    await session.execute(
+                        select(Concept.name)
+                        .where(Concept.library_id.in_(library_ids))
+                        .order_by(Concept.name)
+                        .limit(100)
+                    )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
+            if library_ids
+            else []
         )
 
     parts = []
@@ -274,12 +289,14 @@ async def _concept_paper_map(
     session: AsyncSession, project_id: uuid.UUID
 ) -> dict[uuid.UUID, tuple[str, str, set[uuid.UUID]]]:
     """概念 → (name, category, 关联论文集合)。"""
-    library = await get_library_for_project(session, project_id)
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        return {}
     rows = (
         await session.execute(
             select(Concept.id, Concept.name, Concept.category, paper_concepts.c.paper_id)
             .join(paper_concepts, paper_concepts.c.concept_id == Concept.id)
-            .where(Concept.library_id == library.id)
+            .where(Concept.library_id.in_(library_ids))
         )
     ).all()
     result: dict[uuid.UUID, tuple[str, str, set[uuid.UUID]]] = {}
@@ -325,7 +342,9 @@ def _concept_holes(
 async def _trend_concepts(session: AsyncSession, project_id: uuid.UUID) -> list[dict[str, Any]]:
     """近 90 天入库论文中的高频概念（纯代码，无 LLM）。"""
     cutoff = utcnow() - timedelta(days=_TREND_WINDOW_DAYS)
-    library = await get_library_for_project(session, project_id)
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        return []
     rows = (
         await session.execute(
             select(Concept.name, Paper.id)
@@ -334,13 +353,18 @@ async def _trend_concepts(session: AsyncSession, project_id: uuid.UUID) -> list[
             .join(
                 LibraryPaper,
                 (LibraryPaper.paper_id == Paper.id)
-                & (LibraryPaper.library_id == library.id),
+                & (LibraryPaper.library_id.in_(library_ids)),
             )
-            .where(Concept.library_id == library.id, LibraryPaper.created_at >= cutoff)
+            .where(Concept.library_id.in_(library_ids), LibraryPaper.created_at >= cutoff)
         )
     ).all()
+    # 跨库并集：同一 (概念名, 论文) 只计一次（论文可能在多个关联库、概念各库一份）
     counts: dict[str, int] = {}
-    for name, _paper_id in rows:
+    seen: set[tuple[str, uuid.UUID]] = set()
+    for name, paper_id in rows:
+        if (str(name), paper_id) in seen:
+            continue
+        seen.add((str(name), paper_id))
         counts[str(name)] = counts.get(str(name), 0) + 1
     top = sorted(counts.items(), key=lambda x: (-x[1], x[0]))[:_TREND_MAX]
     return [{"concept": name, "recent_papers": n} for name, n in top if n >= 2]
@@ -378,27 +402,28 @@ async def forge_collect_signals(ctx: ActionContext, params: dict[str, Any]) -> d
             signals["trends"] = await _trend_concepts(session, ctx.run.project_id)
         excerpt_blocks: list[str] = []
         if "limitations" in enabled:
-            library = await get_library_for_project(session, ctx.run.project_id)
-            papers = (
-                (
-                    await session.execute(
-                        select(Paper)
-                        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                        .where(
-                            LibraryPaper.library_id == library.id,
-                            Paper.full_text_path.is_not(None),
-                            LibraryPaper.status.in_(("compiled", "included")),
+            library_ids = await get_source_library_ids(session, ctx.run.project_id)
+            limit_rows = (
+                dedupe_member_rows(
+                    (
+                        await session.execute(
+                            member_papers_stmt(library_ids).where(
+                                Paper.full_text_path.is_not(None),
+                                LibraryPaper.status.in_(("compiled", "included")),
+                            )
                         )
-                        .order_by(
-                            LibraryPaper.relevance_score.desc().nulls_last(),
-                            LibraryPaper.created_at,
-                        )
-                        .limit(_LIMIT_PAPERS)
-                    )
+                    ).all()
                 )
-                .scalars()
-                .all()
+                if library_ids
+                else []
             )
+            limit_rows.sort(
+                key=lambda pm: (
+                    -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18),
+                    pm[1].created_at,
+                )
+            )
+            papers = [p for p, _ in limit_rows[:_LIMIT_PAPERS]]
             for paper in papers:
                 path = Path(paper.full_text_path or "")
                 if not path.is_file():

--- a/src/backend/app/agents/voyage/actions_present.py
+++ b/src/backend/app/agents/voyage/actions_present.py
@@ -15,16 +15,17 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
-
 from app.agents.voyage.actions import ActionContext, register
 from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
-from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.services.figure_annotate import important_figures_with_bytes
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 from app.services.presentation import (
     DeckSpec,
     build_deck,
@@ -130,15 +131,19 @@ async def _load_papers(ctx: ActionContext) -> list[tuple[Paper, str | None]]:
     """按 params.paper_ids 加载库内论文，返回 (Paper, 本方向库版 wiki) 对（保持传入顺序）。"""
     ids = [uuid.UUID(str(i)) for i in _params(ctx).get("paper_ids") or []]
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library_ids = await get_source_library_ids(session, ctx.run.project_id)
         rows = (
-            await session.execute(
-                select(Paper, LibraryPaper.wiki_content)
-                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(Paper.id.in_(ids), LibraryPaper.library_id == library.id)
+            dedupe_member_rows(
+                (
+                    await session.execute(
+                        member_papers_stmt(library_ids).where(Paper.id.in_(ids))
+                    )
+                ).all()
             )
-        ).all()
-    by_id = {p.id: (p, wiki) for p, wiki in rows}
+            if library_ids
+            else []
+        )
+    by_id = {p.id: (p, m.wiki_content) for p, m in rows}
     ordered = [by_id[i] for i in ids if i in by_id]
     if not ordered:
         raise ValueError("presentation: no papers found for given paper_ids")

--- a/src/backend/app/agents/voyage/actions_proposal.py
+++ b/src/backend/app/agents/voyage/actions_proposal.py
@@ -42,7 +42,11 @@ from app.models.idea import RESEARCH_TYPES, Idea
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.review import ReviewMessage, ReviewSession
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 from app.services.literature.openalex import OpenAlexClient
 from app.services.literature.semantic_scholar import SemanticScholarClient
 from app.services.review import serialize_message
@@ -355,10 +359,14 @@ def validate_goal(raw: Any, *, library_ids: set[str], library_size: int) -> dict
 
 async def _library_index(ctx: ActionContext) -> tuple[set[str], int]:
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library_ids = await get_source_library_ids(session, ctx.run.project_id)
+        if not library_ids:
+            return set(), 0
         rows = (
             await session.execute(
-                select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library.id)
+                select(LibraryPaper.paper_id)
+                .where(LibraryPaper.library_id.in_(library_ids))
+                .distinct()
             )
         ).all()
     ids = {str(pid) for (pid,) in rows}
@@ -516,19 +524,19 @@ async def _grounding_papers(ctx: ActionContext) -> list[tuple[Paper, str | None]
     if not ids:
         return []
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library_ids = await get_source_library_ids(session, ctx.run.project_id)
         rows = (
-            await session.execute(
-                select(Paper, LibraryPaper.wiki_content)
-                .join(
-                    LibraryPaper,
-                    (LibraryPaper.paper_id == Paper.id)
-                    & (LibraryPaper.library_id == library.id),
-                )
-                .where(Paper.id.in_(ids))
+            dedupe_member_rows(
+                (
+                    await session.execute(
+                        member_papers_stmt(library_ids).where(Paper.id.in_(ids))
+                    )
+                ).all()
             )
-        ).all()
-    by_id = {p.id: (p, wiki) for p, wiki in rows}
+            if library_ids
+            else []
+        )
+    by_id = {p.id: (p, m.wiki_content) for p, m in rows}
     return [by_id[i] for i in ids if i in by_id]
 
 
@@ -754,19 +762,25 @@ async def proposal_experiments(ctx: ActionContext, params: dict[str, Any]) -> di
 async def _internal_similar(ctx: ActionContext, query_text: str) -> list[dict[str, Any]]:
     """库内相似论文：embedding 余弦 top-k；embedding 不可用降级关键词检索。"""
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library_ids = await get_source_library_ids(session, ctx.run.project_id)
         papers = (
             (
-                await session.execute(
-                    select(Paper)
-                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                    .where(
-                        LibraryPaper.library_id == library.id, Paper.embedding.is_not(None)
+                (
+                    await session.execute(
+                        select(Paper)
+                        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                        .where(
+                            LibraryPaper.library_id.in_(library_ids),
+                            Paper.embedding.is_not(None),
+                        )
+                        .distinct()
                     )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
+            if library_ids
+            else []
         )
         if papers:
             try:

--- a/src/backend/app/api/concepts.py
+++ b/src/backend/app/api/concepts.py
@@ -21,7 +21,7 @@ from app.schemas.paper import (
 )
 from app.services import concepts as concepts_service
 from app.services import libraries as libraries_service
-from app.services.libraries import get_library_for_project
+from app.services.libraries import get_library_for_project, get_source_library_ids
 
 router = APIRouter(tags=["concepts"])
 
@@ -50,9 +50,9 @@ async def list_concepts(
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
-    library = await get_library_for_project(session, project_id)
+    library_ids = await get_source_library_ids(session, project_id)
     rows = await concepts_service.list_concepts(
-        session, library_id=library.id, category=category, q=q
+        session, library_ids=library_ids, category=category, q=q
     )
     return [_concept_read(concept, count, project_id) for concept, count in rows]
 
@@ -71,7 +71,11 @@ async def relink_concepts(
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    # 概念补建是「某具体库」的维护写操作（计库预算），落在课题的起源库上；
+    # 课题若无任何可解析的库（全部解绑）则无事可做，返回零结果。
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        return ConceptRelinkResult(papers=0, concepts_created=0, links_created=0)
     stats, _papers = await concepts_service.link_all_paper_concepts(
         session,
         library_id=library.id,

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -113,6 +113,25 @@ async def update_library(
     return DirectionLibraryDetail(**row)
 
 
+@router.delete("/libraries/{library_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_library(
+    library_id: uuid.UUID,
+    force: bool = Query(default=False),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> None:
+    """删库（平台 admin 专用）：论文内容池行不动，成员行/概念/策展人一并清除。
+
+    仍有课题关联时默认拒绝（409 LIBRARY_HAS_TOPICS），带 ``?force=true`` 才会
+    一并解除关联（不影响课题本身，课题只是失去这条语料来源）。
+    """
+    library = await _get_library(session, library_id)
+    try:
+        await libraries_service.delete_library(session, library=library, force=force)
+    except libraries_service.LibraryHasTopicsError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_HAS_TOPICS") from e
+
+
 @router.get("/libraries/{library_id}/budget", response_model=LibraryBudgetRead)
 async def get_library_budget(
     library_id: uuid.UUID,

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -26,6 +26,7 @@ from app.schemas.libraries import (
     DirectionLibraryUpdate,
     DuplicateCandidateGroup,
     LibraryBudgetRead,
+    LibraryCreate,
     PaperMergeRequest,
     PaperMergeResult,
 )
@@ -80,6 +81,30 @@ async def list_libraries(
 ) -> list[DirectionLibrarySummary]:
     rows = await libraries_service.list_libraries_overview(session, user=user)
     return [DirectionLibrarySummary(**row) for row in rows]
+
+
+@router.post(
+    "/libraries", response_model=DirectionLibraryDetail, status_code=status.HTTP_201_CREATED
+)
+async def create_library(
+    data: LibraryCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> DirectionLibraryDetail:
+    """独立新建方向文献库（平台 admin）：不属于任何课题，课题靠关联消费其语料。"""
+    library = await libraries_service.create_library(
+        session,
+        name=data.name,
+        statement=data.statement,
+        rubric=data.rubric,
+        anchors=data.anchors,
+        cadence=data.cadence,
+        monthly_budget=data.monthly_budget,
+        created_by=user.id,
+    )
+    await session.commit()
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
 
 
 @router.get("/libraries/{library_id}", response_model=DirectionLibraryDetail)
@@ -226,7 +251,7 @@ async def list_library_concepts(
 ) -> list[ConceptRead]:
     library = await _get_library(session, library_id)
     rows = await concepts_service.list_concepts(
-        session, library_id=library.id, category=category, q=q
+        session, library_ids=[library.id], category=category, q=q
     )
     return [
         ConceptRead(

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -195,13 +195,18 @@ async def add_paper_manually(
     # 打分失败会 rollback 并使本 session 的 ORM 对象过期，先留住要用的 id
     paper_id, user_id = paper.id, user.id
     library = await libraries_service.get_library_for_project(session, project_id)
-    membership = await libraries_service.get_membership(
-        session, library_id=library.id, paper_id=paper_id
+    membership = (
+        await libraries_service.get_membership(
+            session, library_id=library.id, paper_id=paper_id
+        )
+        if library is not None
+        else None
     )
     # 顺带相关性打分（best-effort）：失败只记日志，不影响 201；不改 status（人工纳入）
-    await relevance_service.score_added_paper_best_effort(
-        session, paper, membership, project, user_id=user_id
-    )
+    if membership is not None:
+        await relevance_service.score_added_paper_best_effort(
+            session, paper, membership, project, user_id=user_id
+        )
     # 重新加载（带 concepts eager load），避免序列化时触发 async lazy load
     view = await papers_service.get_paper_for_user(
         session, paper_id=paper_id, user_id=user_id, with_concepts=True

--- a/src/backend/app/api/presentations.py
+++ b/src/backend/app/api/presentations.py
@@ -50,15 +50,18 @@ async def create_presentation(
     if data.mode == "single" and len(data.paper_ids) != 1:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="SINGLE_NEEDS_ONE_PAPER")
     from app.models.library_direction import LibraryPaper
-    from app.services.libraries import get_library_for_project
+    from app.services.libraries import get_source_library_ids
 
-    library = await get_library_for_project(session, project_id)
-    stmt = (
-        select(Paper.id, Paper.title)
-        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-        .where(Paper.id.in_(data.paper_ids), LibraryPaper.library_id == library.id)
-    )
-    rows = {pid: title for pid, title in (await session.execute(stmt)).all()}
+    library_ids = await get_source_library_ids(session, project_id)
+    rows: dict = {}
+    if library_ids:
+        stmt = (
+            select(Paper.id, Paper.title)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(Paper.id.in_(data.paper_ids), LibraryPaper.library_id.in_(library_ids))
+            .distinct()
+        )
+        rows = {pid: title for pid, title in (await session.execute(stmt)).all()}
     missing = [str(i) for i in data.paper_ids if i not in rows]
     if missing:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail=f"PAPER_NOT_FOUND: {missing[0]}")

--- a/src/backend/app/api/projects.py
+++ b/src/backend/app/api/projects.py
@@ -9,6 +9,7 @@ from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.models.project import Project
 from app.models.user import User
+from app.schemas.libraries import DirectionLibrarySummary, SourceLibrariesUpdate
 from app.schemas.project import (
     DraftDefinitionRequest,
     DraftDefinitionResponse,
@@ -19,6 +20,7 @@ from app.schemas.project import (
     ProjectRead,
     ProjectUpdate,
 )
+from app.services import libraries as libraries_service
 from app.services import projects as projects_service
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -123,3 +125,39 @@ async def add_member(
     found = await projects_service.add_member(session, project.id, email=data.email, role=data.role)
     if not found:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="USER_NOT_FOUND")
+
+
+@router.get("/{project_id}/source-libraries", response_model=list[DirectionLibrarySummary])
+async def list_source_libraries(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DirectionLibrarySummary]:
+    """课题关联的文献库（课题语料 = 这些库论文的并集，按关联建立时间）。"""
+    await _get_member_project(session, project_id, user)
+    rows = await libraries_service.source_libraries_overview(
+        session, topic_id=project_id, user=user
+    )
+    return [DirectionLibrarySummary(**row) for row in rows]
+
+
+@router.put("/{project_id}/source-libraries", response_model=list[DirectionLibrarySummary])
+async def set_source_libraries(
+    project_id: uuid.UUID,
+    data: SourceLibrariesUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DirectionLibrarySummary]:
+    """全量替换课题关联库（课题成员）。空列表 = 清空关联；不存在的库 id 静默忽略。
+
+    关联为空时想法生成/检索/图谱/伴读等消费端给「还没关联文献库」空态，不报错。
+    """
+    await _get_member_project(session, project_id, user)
+    await libraries_service.set_source_libraries(
+        session, topic_id=project_id, library_ids=data.library_ids
+    )
+    await session.commit()
+    rows = await libraries_service.source_libraries_overview(
+        session, topic_id=project_id, user=user
+    )
+    return [DirectionLibrarySummary(**row) for row in rows]

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -264,7 +264,16 @@ async def rebuild_fulltext_index(
     幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
     """
     await _member_project(session, project_id, user)
+    # 分段重建是「某具体库」的维护写操作（计库预算），落在课题起源库上
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        return {
+            "papers_indexed": 0,
+            "chunks_created": 0,
+            "embedded": 0,
+            "embed_error": None,
+            "total_chunks": 0,
+        }
     chunked_ids = select(PaperChunk.paper_id)
     try:
         papers = (

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -1,12 +1,14 @@
-"""方向文献库：实验室层的文献策展单元（P4）。
+"""方向文献库：实验室层的文献策展单元（P4；P7 起课题/库解耦）。
 
 `papers` 是全局内容池（按 dedup_key 全平台唯一，只存论文本体：元数据/全文/图/embedding）；
 方向对论文的「归属 + 判断」（相关性分、状态流转、库版 wiki 解读）全部落在成员表
 `library_papers` 上——同一篇论文可以同时属于多个方向库，各自打分编译互不干扰，
 删库只删成员行，内容池行永不删除。
 
-过渡期（P4~P5）：每个 project（研究方向）对应一个 1:1 隐式库（project_id 回指），
-API 仍以 project_id 为入口，service 层经 services/libraries.py 解析到库。
+P7 起课题（`Project`）与库多对多关联（`TopicSourceLibrary`）：库不再是课题的附属物，
+`project_id` 语义降级为「起源课题」溯源（ondelete SET NULL——删课题不删库）；
+「课题关联了哪些库」一律经 `topic_source_libraries` 查，`project_id` 仅供历史
+1:1 库与管理路径（`services/libraries.py::get_library_for_project`）兜底解析。
 """
 
 import uuid
@@ -17,7 +19,7 @@ from sqlalchemy import DateTime, ForeignKey, Index, String, Text, UniqueConstrai
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
-from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin, utcnow
 from app.models.paper import Paper
 
 
@@ -35,9 +37,11 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )
-    # 过渡期隐式库 1:1 回指 project（P5 拆分课题/库后共享库此列为 NULL）
+    # 起源课题溯源（历史 1:1 库回指；SET NULL——删课题不再级联删库，孤儿库保留）。
+    # 新建的独立库（P7 起 POST /libraries）此列恒为 NULL；「课题关联了哪些库」
+    # 一律经 topic_source_libraries 查，不查这列。
     project_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), unique=True
+        ForeignKey("projects.id", ondelete="SET NULL"), unique=True
     )
 
 
@@ -82,3 +86,24 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     compiled_model: Mapped[str | None] = mapped_column(String(255))
 
     paper: Mapped[Paper] = relationship()
+
+
+class TopicSourceLibrary(Base):
+    """课题 × 文献库关联（P7）：课题的语料 = 关联库论文的并集。
+
+    多对多；课题删除级联清关联行（不动库），库删除级联清关联行（不动课题）。
+    """
+
+    __tablename__ = "topic_source_libraries"
+
+    topic_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, nullable=False
+    )

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -37,6 +37,23 @@ class DirectionLibraryDetail(DirectionLibrarySummary):
     monthly_budget: int | None = None
 
 
+class LibraryCreate(BaseModel):
+    """独立新建方向文献库（POST /libraries，平台 admin）。"""
+
+    name: str = Field(min_length=1, max_length=255)
+    statement: str | None = None
+    cadence: str | None = Field(default=None, max_length=32)
+    monthly_budget: int | None = Field(default=None, ge=0)
+    rubric: Any | None = None
+    anchors: list[Any] | None = None
+
+
+class SourceLibrariesUpdate(BaseModel):
+    """课题关联库全量替换（PUT /projects/{id}/source-libraries）；空列表 = 清空关联。"""
+
+    library_ids: list[uuid.UUID]
+
+
 class DirectionLibraryUpdate(BaseModel):
     """库定义编辑（PATCH /libraries/{id}）：显式传 null 可清空对应字段。"""
 

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -139,17 +139,22 @@ def chunk_vector_search_supported(session: AsyncSession) -> bool:
 async def semantic_search_chunks(
     session: AsyncSession,
     *,
-    library_id: uuid.UUID,
+    library_ids: list[uuid.UUID],
     query_vector: list[float],
     limit: int,
     paper_ids: list[uuid.UUID] | None = None,
 ) -> list[tuple[PaperChunk, float]]:
     """pgvector 余弦检索（仅 postgres；调用方需先判 chunk_vector_search_supported）。
 
-    传 paper_ids 时把检索限制在这些论文内（伴读引用指定文献用）。
+    关联库并集：chunk 命中多库时 DISTINCT 去重。传 paper_ids 时把检索限制在这些
+    论文内（伴读引用指定文献用）。
     """
     qv = json.dumps(query_vector)
-    params: dict[str, object] = {"qv": qv, "lib": str(library_id), "k": limit}
+    params: dict[str, object] = {
+        "qv": qv,
+        "libs": [str(lid) for lid in library_ids],
+        "k": limit,
+    }
     paper_filter = ""
     if paper_ids:
         paper_filter = "AND c.paper_id = ANY(CAST(:pids AS uuid[])) "
@@ -157,12 +162,13 @@ async def semantic_search_chunks(
     rows = (
         await session.execute(
             sa_text(
-                "SELECT c.id, 1 - (c.embedding <=> CAST(:qv AS vector)) AS score "
+                "SELECT DISTINCT c.id, 1 - (c.embedding <=> CAST(:qv AS vector)) AS score "
                 "FROM paper_chunks c "
-                "JOIN library_papers lp ON lp.paper_id = c.paper_id AND lp.library_id = :lib "
+                "JOIN library_papers lp ON lp.paper_id = c.paper_id "
+                "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
                 "WHERE c.embedding IS NOT NULL "
                 f"{paper_filter}"
-                "ORDER BY c.embedding <=> CAST(:qv AS vector) "
+                "ORDER BY score DESC "
                 "LIMIT :k"
             ),
             params,
@@ -183,14 +189,14 @@ async def semantic_search_chunks(
 async def keyword_search_chunks(
     session: AsyncSession,
     *,
-    library_id: uuid.UUID,
+    library_ids: list[uuid.UUID],
     q: str,
     limit: int,
     paper_ids: list[uuid.UUID] | None = None,
 ) -> list[tuple[PaperChunk, float]]:
     """关键词降级检索：问题分词后 ilike 命中任一词，按命中词数粗排。
 
-    传 paper_ids 时把检索限制在这些论文内。
+    关联库并集（chunk 去重）。传 paper_ids 时把检索限制在这些论文内。
     """
     terms = [t for t in _WORD_RE.findall(q.lower()) if len(t) >= 2][:8]
     if not terms:
@@ -202,7 +208,8 @@ async def keyword_search_chunks(
     stmt = (
         select(PaperChunk)
         .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
-        .where(LibraryPaper.library_id == library_id, cond)
+        .where(LibraryPaper.library_id.in_(library_ids), cond)
+        .distinct()
     )
     if paper_ids:
         stmt = stmt.where(PaperChunk.paper_id.in_(paper_ids))

--- a/src/backend/app/services/citations.py
+++ b/src/backend/app/services/citations.py
@@ -13,7 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
-from app.services.libraries import get_library_for_project, member_paper_stmt
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 from app.services.papers import apply_paper_filters
 
 # 缺省导出的论文状态（未显式指定 status 时）
@@ -200,9 +204,11 @@ async def papers_for_export(
 
     paper_ids 指定时按 id 精确导出（多选导出），忽略状态缺省过滤。
     """
-    library = await get_library_for_project(session, project_id)
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        return []  # 课题无关联库 = 无可导出语料
     stmt = apply_paper_filters(
-        member_paper_stmt(library.id),
+        member_papers_stmt(library_ids),
         project_id=project_id,
         status=status,
         tag=tag,
@@ -214,4 +220,7 @@ async def papers_for_export(
     elif not status:
         stmt = stmt.where(LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES))
     stmt = stmt.order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
-    return [paper for paper, _ in (await session.execute(stmt)).all()]
+    # 跨库同一论文按确定性视角归并（有 wiki 优先），保持年份升序
+    deduped = dedupe_member_rows((await session.execute(stmt)).all())
+    deduped.sort(key=lambda pm: (pm[0].year is None, pm[0].year or 0, pm[1].created_at))
+    return [paper for paper, _ in deduped]

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import delete, exists, func, insert, select
@@ -87,16 +88,19 @@ def normalize_category(raw: Any) -> str:
 async def list_concepts(
     session: AsyncSession,
     *,
-    library_id: uuid.UUID,
+    library_ids: Sequence[uuid.UUID],
     category: str | None = None,
     q: str | None = None,
 ) -> list[tuple[Concept, int]]:
-    """方向库概念列表（附 paper_count）。"""
+    """方向库并集概念列表（附 paper_count）。传单库时给 ``[library_id]``；课题作用域
+    传关联库并集。空列表 = 无语料，返回空。"""
+    if not library_ids:
+        return []
     paper_count = func.count(paper_concepts.c.paper_id).label("paper_count")
     stmt = (
         select(Concept, paper_count)
         .outerjoin(paper_concepts, paper_concepts.c.concept_id == Concept.id)
-        .where(Concept.library_id == library_id)
+        .where(Concept.library_id.in_(library_ids))
         .group_by(Concept.id)
         .order_by(paper_count.desc(), Concept.name)
     )

--- a/src/backend/app/services/graph.py
+++ b/src/backend/app/services/graph.py
@@ -9,13 +9,13 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.library_direction import LibraryPaper
-from app.models.paper import Concept, Paper, paper_concepts
+from app.models.paper import Concept, paper_concepts
 from app.services.concepts import wiki_slug
-from app.services.libraries import get_library_for_project
+from app.services.libraries import dedupe_member_rows, get_source_library_ids, member_papers_stmt
 
 # 图上展示的论文状态（candidate 未过筛选，噪声大，不进图）
 GRAPH_PAPER_STATUSES = ("scored", "fetched", "compiled", "included")
@@ -45,32 +45,28 @@ async def project_graph(
     max_authors: int = MAX_AUTHORS,
 ) -> dict[str, Any]:
     """构建项目知识图谱，返回 GraphResponse 形状的 dict。"""
-    library = await get_library_for_project(session, project_id)
-    paper_total = int(
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        # 课题无关联库 = 无语料 → 空图（前端给空态引导去关联文献库）
+        return {"nodes": [], "edges": [], "paper_total": 0, "truncated": False}
+    # 关联库并集：跨库同一论文按确定性视角归并，再按相关性排序截断 top max_papers
+    dedup_rows = dedupe_member_rows(
         (
             await session.execute(
-                select(func.count()).where(
-                    LibraryPaper.library_id == library.id,
-                    LibraryPaper.status.in_(GRAPH_PAPER_STATUSES),
+                member_papers_stmt(library_ids).where(
+                    LibraryPaper.status.in_(GRAPH_PAPER_STATUSES)
                 )
             )
-        ).scalar_one()
+        ).all()
     )
-    rows = (
-        await session.execute(
-            select(Paper, LibraryPaper)
-            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-            .where(
-                LibraryPaper.library_id == library.id,
-                LibraryPaper.status.in_(GRAPH_PAPER_STATUSES),
-            )
-            .order_by(
-                LibraryPaper.relevance_score.desc().nulls_last(),
-                LibraryPaper.created_at.desc(),
-            )
-            .limit(max_papers)
+    paper_total = len(dedup_rows)
+    dedup_rows.sort(
+        key=lambda pm: (
+            -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18),
+            pm[1].created_at,
         )
-    ).all()
+    )
+    rows = dedup_rows[:max_papers]
     papers = [p for p, _ in rows]
     membership_of = {p.id: m for p, m in rows}
     paper_ids = [p.id for p in papers]

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -10,13 +10,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.activity import Activity
 from app.models.gate import Gate
 from app.models.idea import IDEA_STATUSES, Idea
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper
 from app.models.project import Project, ProjectMember
 from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.idea import DeepIdeaRequest, ForgeKnobs
 from app.schemas.review import TournamentRequest
-from app.services.libraries import get_library_for_project, get_membership
+from app.services.libraries import get_source_library_ids
 
 # 同项目 idea 类 voyage 互斥（docs/api-m3.md §1 + docs/api-idea2.md §2）
 IDEA_VOYAGE_KINDS = ("idea_forge", "idea_review", "idea_proposal")
@@ -177,16 +178,26 @@ async def _validate_seed(
         paper = await session.get(Paper, target_id)
         if paper is None:
             raise InvalidSeedError(value)
-        library = await get_library_for_project(session, project_id)
-        if await get_membership(session, library_id=library.id, paper_id=paper.id) is None:
+        library_ids = await get_source_library_ids(session, project_id)
+        in_corpus = bool(library_ids) and (
+            await session.execute(
+                select(LibraryPaper.paper_id)
+                .where(
+                    LibraryPaper.library_id.in_(library_ids),
+                    LibraryPaper.paper_id == paper.id,
+                )
+                .limit(1)
+            )
+        ).first() is not None
+        if not in_corpus:
             raise InvalidSeedError(value)
         return f"论文《{paper.title[:60]}》"
     if seed_type == "concept":
         concept = await session.get(Concept, target_id)
         if concept is None:
             raise InvalidSeedError(value)
-        library = await get_library_for_project(session, project_id)
-        if concept.library_id != library.id:
+        library_ids = await get_source_library_ids(session, project_id)
+        if concept.library_id not in set(library_ids):
             raise InvalidSeedError(value)
         return f"概念「{concept.name}」"
     if seed_type == "idea":

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -1,17 +1,25 @@
-"""方向文献库解析与成员行工具（P4 过渡期：project 1:1 隐式库，不 import fastapi）。
+"""方向文献库解析与成员行工具（不 import fastapi）。
 
-API 形状不变（仍收 project_id），service 层经这里解析到 DirectionLibrary 后
-用 LibraryPaper 承接论文归属与判断字段；新 project 建库时同步建隐式库
-（services/projects.py），这里的 get-or-create 只兜底历史/直插数据。
+P7 起课题 × 库多对多关联（``topic_source_libraries``）：课题的语料 = 关联库论文
+的并集，经 ``get_source_libraries``/``get_source_library_ids`` 取数（空关联=
+无语料，调用方应给空态而非报错）。``get_library_for_project`` 是历史单库解析
+（起源库优先、否则第一个关联库、否则 None），逐步只供管理/ingest 路径使用——
+读路径（想法生成/检索/图谱/写作引用等）应改走关联库并集。
 """
 
 import uuid
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from sqlalchemy import Select, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
+from app.models.library_direction import (
+    DirectionLibrary,
+    DirectionLibraryCurator,
+    LibraryPaper,
+    TopicSourceLibrary,
+)
 from app.models.paper import Concept, Paper
 from app.models.project import Project, ProjectMember
 from app.models.user import User
@@ -34,23 +42,74 @@ def implicit_library_for(project: Project) -> DirectionLibrary:
 
 async def get_library_for_project(
     session: AsyncSession, project_id: uuid.UUID
-) -> DirectionLibrary:
-    """取 project 的隐式方向库；缺失时就地补建（flush 不 commit，随调用方事务落库）。"""
+) -> DirectionLibrary | None:
+    """解析课题的「管理库」：起源库优先（project_id 直接回指），否则取第一个
+    关联库（按关联建立时间），都没有则 None。
+
+    P7 起管理/ingest 路径专用（历史 1:1 语义单库解析）；并集读路径改用
+    ``get_source_libraries``/``get_source_library_ids``。不再兜底自动建库——
+    课题创建仍会建关联（services/projects.py），缺失即代表课题真的没有语料。
+    """
     stmt = select(DirectionLibrary).where(DirectionLibrary.project_id == project_id)
     library = (await session.execute(stmt)).scalar_one_or_none()
     if library is not None:
         return library
-    project = await session.get(Project, project_id)
-    if project is None:
-        raise ValueError(f"project not found: {project_id}")
-    library = implicit_library_for(project)
-    session.add(library)
+    libraries = await get_source_libraries(session, project_id)
+    return libraries[0] if libraries else None
+
+
+async def get_library_id_for_project(
+    session: AsyncSession, project_id: uuid.UUID
+) -> uuid.UUID | None:
+    library = await get_library_for_project(session, project_id)
+    return library.id if library else None
+
+
+async def get_source_library_ids(session: AsyncSession, topic_id: uuid.UUID) -> list[uuid.UUID]:
+    """课题关联的全部库 id（按关联建立时间；空=无语料）。"""
+    stmt = (
+        select(TopicSourceLibrary.library_id)
+        .where(TopicSourceLibrary.topic_id == topic_id)
+        .order_by(TopicSourceLibrary.created_at)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def get_source_libraries(
+    session: AsyncSession, topic_id: uuid.UUID
+) -> list[DirectionLibrary]:
+    """课题关联的全部库对象（按关联建立时间；空=无语料）。"""
+    stmt = (
+        select(DirectionLibrary)
+        .join(TopicSourceLibrary, TopicSourceLibrary.library_id == DirectionLibrary.id)
+        .where(TopicSourceLibrary.topic_id == topic_id)
+        .order_by(TopicSourceLibrary.created_at)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def set_source_libraries(
+    session: AsyncSession, *, topic_id: uuid.UUID, library_ids: list[uuid.UUID]
+) -> None:
+    """全量替换课题的关联库（去重，不存在的 library_id 静默忽略）；flush 不 commit。"""
+    unique_ids = list(dict.fromkeys(library_ids))
+    await session.execute(
+        delete(TopicSourceLibrary).where(TopicSourceLibrary.topic_id == topic_id)
+    )
+    if unique_ids:
+        found = set(
+            (
+                await session.execute(
+                    select(DirectionLibrary.id).where(DirectionLibrary.id.in_(unique_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for library_id in unique_ids:
+            if library_id in found:
+                session.add(TopicSourceLibrary(topic_id=topic_id, library_id=library_id))
     await session.flush()
-    return library
-
-
-async def get_library_id_for_project(session: AsyncSession, project_id: uuid.UUID) -> uuid.UUID:
-    return (await get_library_for_project(session, project_id)).id
 
 
 async def get_membership(
@@ -83,8 +142,13 @@ async def ensure_membership(
 async def membership_for_project(
     session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
 ) -> LibraryPaper | None:
-    """按 project 解析隐式库后取成员行（工具层「论文是否在本方向库内」的统一检查）。"""
+    """按 project 解析管理库后取成员行（工具层「论文是否在本方向库内」的统一检查）。
+
+    课题没有可解析的库（无起源库/无关联库）→ None（视为不在库内，不报错）。
+    """
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        return None
     return await get_membership(session, library_id=library.id, paper_id=paper_id)
 
 
@@ -117,6 +181,40 @@ def member_paper_stmt(library_id: uuid.UUID) -> Select:
         .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
         .where(LibraryPaper.library_id == library_id)
     )
+
+
+def member_papers_stmt(library_ids: Sequence[uuid.UUID]) -> Select:
+    """关联库并集内论文基础查询：SELECT (Paper, LibraryPaper)，跨库同一论文各一行
+    （调用方按 :func:`dedupe_member_rows` 归并出确定性单行视角）。"""
+    return (
+        select(Paper, LibraryPaper)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(LibraryPaper.library_id.in_(library_ids))
+    )
+
+
+def membership_rank(membership: LibraryPaper) -> tuple[int, float, str]:
+    """跨库同一论文的确定性视角优先级（越小越优）：有 wiki 优先、其次相关性分高、
+    再次 library_id 稳定序（docs-dev/workspace-ia-redesign.md §3.4 展示优先级）。"""
+    return (
+        0 if membership.wiki_content else 1,
+        -(membership.relevance_score if membership.relevance_score is not None else -1e18),
+        str(membership.library_id),
+    )
+
+
+def dedupe_member_rows(
+    rows: Iterable[tuple[Paper, LibraryPaper]],
+) -> list[tuple[Paper, LibraryPaper]]:
+    """并集读取的 (Paper, LibraryPaper) 行按 paper 归并成单行（membership_rank 取最优）。
+
+    入库顺序不定，返回顺序按首次出现稳定（不排序，调用方自行排序）。"""
+    best: dict[uuid.UUID, tuple[Paper, LibraryPaper]] = {}
+    for paper, membership in rows:
+        current = best.get(paper.id)
+        if current is None or membership_rank(membership) < membership_rank(current[1]):
+            best[paper.id] = (paper, membership)
+    return list(best.values())
 
 
 def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
@@ -417,3 +515,31 @@ async def update_library(
     await session.commit()
     await session.refresh(library)
     return library
+
+
+# ---- P7：库生命周期独立（创建/删除不再绑定课题） ----
+
+
+class LibraryHasTopicsError(Exception):
+    """库仍有课题关联，删除需要 force=true（先解绑或确认一并解除关联）。"""
+
+
+async def delete_library(
+    session: AsyncSession, *, library: DirectionLibrary, force: bool = False
+) -> None:
+    """删库（平台 admin 专用）：论文内容池行不动；成员行/概念/策展人/课题关联行
+    随库一并清除（DB ``ondelete=CASCADE``）。有课题关联且未 ``force`` → 拒绝
+    （``LibraryHasTopicsError``，路由映射 409，提示先解绑或带 force 确认）。
+    """
+    if not force:
+        linked = (
+            await session.execute(
+                select(TopicSourceLibrary.topic_id)
+                .where(TopicSourceLibrary.library_id == library.id)
+                .limit(1)
+            )
+        ).first()
+        if linked is not None:
+            raise LibraryHasTopicsError(str(library.id))
+    await session.delete(library)
+    await session.commit()

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -142,14 +142,29 @@ async def ensure_membership(
 async def membership_for_project(
     session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
 ) -> LibraryPaper | None:
-    """按 project 解析管理库后取成员行（工具层「论文是否在本方向库内」的统一检查）。
+    """课题关联库并集里该论文的成员行（工具层「论文是否在本课题语料内」的统一检查）。
 
-    课题没有可解析的库（无起源库/无关联库）→ None（视为不在库内，不报错）。
+    跨库同一论文取确定性视角（有 wiki 优先、其次相关性高，见 ``membership_rank``）；
+    课题没有任何关联库或论文不在其中 → None（视为不在语料内，不报错）。
     """
-    library = await get_library_for_project(session, project_id)
-    if library is None:
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
         return None
-    return await get_membership(session, library_id=library.id, paper_id=paper_id)
+    rows = (
+        (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id.in_(library_ids),
+                    LibraryPaper.paper_id == paper_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        return None
+    return min(rows, key=membership_rank)
 
 
 async def find_pool_paper(
@@ -367,6 +382,63 @@ async def library_overview(
         concept_count=concept_counts.get(library.id, 0),
         last_compiled_at=last_compiled.get(library.id),
     )
+
+
+async def source_libraries_overview(
+    session: AsyncSession, *, topic_id: uuid.UUID, user: User
+) -> list[dict[str, Any]]:
+    """课题关联库 + 概要统计（同列表口径，按关联建立时间）。"""
+    libraries = await get_source_libraries(session, topic_id)
+    ids = [lib.id for lib in libraries]
+    paper_counts, last_compiled, concept_counts = await _library_stats(session, ids)
+    my_projects = await _my_project_ids(session, user.id)
+    my_curated = await _my_curated_library_ids(session, user.id)
+    return [
+        _overview_dict(
+            lib,
+            my_projects=my_projects,
+            can_manage=(
+                user.role == "admin"
+                or lib.id in my_curated
+                or (lib.project_id is not None and lib.project_id in my_projects)
+            ),
+            paper_count=paper_counts.get(lib.id, 0),
+            concept_count=concept_counts.get(lib.id, 0),
+            last_compiled_at=last_compiled.get(lib.id),
+        )
+        for lib in libraries
+    ]
+
+
+async def create_library(
+    session: AsyncSession,
+    *,
+    name: str,
+    statement: str | None = None,
+    rubric: Any | None = None,
+    anchors: list[Any] | None = None,
+    cadence: str | None = None,
+    monthly_budget: int | None = None,
+    created_by: uuid.UUID,
+) -> DirectionLibrary:
+    """独立新建方向文献库（P7；``project_id`` 恒为 NULL——不属于任何课题，靠关联被消费）。
+
+    flush + refresh，不 commit（调用方 api 层负责事务收尾）。
+    """
+    library = DirectionLibrary(
+        name=name,
+        statement=statement,
+        rubric=rubric,
+        anchors=anchors,
+        cadence=cadence,
+        monthly_budget=monthly_budget,
+        created_by=created_by,
+        project_id=None,
+    )
+    session.add(library)
+    await session.flush()
+    await session.refresh(library)
+    return library
 
 
 # ---- P6 治理：策展人（界面叫「文献库管理员」）与库级写权限 ----

--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -20,9 +20,17 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import Concept, Paper, PaperChunk, paper_concepts
 from app.models.project import Project
 from app.services import chunks as chunks_service
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 
 logger = logging.getLogger(__name__)
+
+# 关联库并集读取的本地别名（跨库同一论文按确定性视角归并）
+_union_member_stmt = member_papers_stmt
+_dedupe = dedupe_member_rows
 
 MAX_SOURCES = 8  # 上下文里最多引用的论文数
 MAX_CHUNKS = 16  # 检索片段数上限
@@ -64,7 +72,7 @@ class ChatSource:
 async def _retrieve_chunks(
     session: AsyncSession,
     *,
-    library_id: uuid.UUID,
+    library_ids: list[uuid.UUID],
     project_id: uuid.UUID,
     question: str,
     llm: LLMRouter,
@@ -82,7 +90,7 @@ async def _retrieve_chunks(
             vectors = await llm.embed([question], user_id=user_id, project_id=project_id)
             rows = await chunks_service.semantic_search_chunks(
                 session,
-                library_id=library_id,
+                library_ids=library_ids,
                 query_vector=vectors[0],
                 limit=MAX_CHUNKS,
                 paper_ids=paper_ids,
@@ -96,7 +104,7 @@ async def _retrieve_chunks(
             await session.rollback()  # postgres 报错后事务已中止，先回滚
     try:
         return await chunks_service.keyword_search_chunks(
-            session, library_id=library_id, q=question, limit=MAX_CHUNKS, paper_ids=paper_ids
+            session, library_ids=library_ids, q=question, limit=MAX_CHUNKS, paper_ids=paper_ids
         )
     except Exception:  # noqa: BLE001
         logger.warning("chunk keyword search failed; falling back to summaries", exc_info=True)
@@ -148,11 +156,24 @@ async def build_library_messages(
     project_id = project.id
     definition = project.definition if isinstance(project.definition, dict) else {}
     statement = definition.get("statement") or project.name
-    library_id = (await get_library_for_project(session, project_id)).id
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        # 课题无关联库 = 无语料：直接给「空文献库」上下文（不抓片段、不兜底）
+        messages = [
+            Message(
+                role="system",
+                content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(
+                    statement=statement, context="（还没有关联任何文献库）"
+                ),
+            )
+        ]
+        messages += [Message(role=role, content=content) for role, content in history]
+        messages.append(Message(role="user", content=question))
+        return messages, []
 
     rows = await _retrieve_chunks(
         session,
-        library_id=library_id,
+        library_ids=library_ids,
         project_id=project_id,
         question=question,
         llm=llm,
@@ -164,13 +185,12 @@ async def build_library_messages(
         paper_ids = list({c.paper_id for c, _ in rows})
         found = (
             await session.execute(
-                select(Paper, LibraryPaper)
-                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(LibraryPaper.library_id == library_id, Paper.id.in_(paper_ids))
+                _union_member_stmt(library_ids).where(Paper.id.in_(paper_ids))
             )
         ).all()
-        papers = {p.id: p for p, _ in found}
-        memberships = {p.id: m for p, m in found}
+        deduped = _dedupe(found)
+        papers = {p.id: p for p, _ in deduped}
+        memberships = {p.id: m for p, m in deduped}
 
     # (paper, 送入上下文的正文) 顺序清单：优先检索片段，否则高分论文摘要兜底
     entries: list[tuple[Paper, str]] = []
@@ -179,18 +199,21 @@ async def build_library_messages(
             snippet = "\n…\n".join(c.text for c in chunk_list)[:SNIPPET_CHARS]
             entries.append((paper, snippet))
     else:
-        fallback = (
-            await session.execute(
-                select(Paper, LibraryPaper)
-                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(
-                    LibraryPaper.library_id == library_id,
-                    LibraryPaper.status.in_(("scored", "fetched", "compiled", "included")),
+        fallback = _dedupe(
+            (
+                await session.execute(
+                    _union_member_stmt(library_ids).where(
+                        LibraryPaper.status.in_(("scored", "fetched", "compiled", "included"))
+                    )
                 )
-                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
-                .limit(FALLBACK_PAPERS)
+            ).all()
+        )
+        fallback.sort(
+            key=lambda pm: -(
+                pm[1].relevance_score if pm[1].relevance_score is not None else -1e18
             )
-        ).all()
+        )
+        fallback = fallback[:FALLBACK_PAPERS]
         entries = [(p, p.tldr or (p.abstract or "")[:400] or "（无摘要）") for p, _ in fallback]
         memberships |= {p.id: m for p, m in fallback}
 
@@ -258,14 +281,16 @@ async def build_reference_context(
     """
     if not paper_ids:
         return "", []
-    library_id = (await get_library_for_project(session, project_id)).id
-    found = (
-        await session.execute(
-            select(Paper, LibraryPaper)
-            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-            .where(LibraryPaper.library_id == library_id, Paper.id.in_(paper_ids))
-        )
-    ).all()
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        return "", []
+    found = _dedupe(
+        (
+            await session.execute(
+                _union_member_stmt(library_ids).where(Paper.id.in_(paper_ids))
+            )
+        ).all()
+    )
     papers = {p.id: p for p, _ in found}
     memberships = {p.id: m for p, m in found}
     # 保留用户的选择顺序，并滤掉不属于本项目的
@@ -275,7 +300,7 @@ async def build_reference_context(
 
     rows = await _retrieve_chunks(
         session,
-        library_id=library_id,
+        library_ids=library_ids,
         project_id=project_id,
         question=question,
         llm=llm,

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -28,12 +28,15 @@ from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript, ManuscriptFile
-from app.models.paper import Paper
 from app.models.project import Project, ProjectMember
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.manuscript import ManuscriptCreate
 from app.services.citations import DEFAULT_EXPORT_STATUSES, assign_citation_keys
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "assets" / "templates"
 TEMPLATE_KEYS = ("neurips2026", "iclr2026", "acl")
@@ -240,17 +243,20 @@ async def _citations_pack(session: AsyncSession, *, project_id: uuid.UUID) -> li
     条目含契约字段 {bibkey, title, year}，附加内部字段 paper_id / source
     供编译时按固定 key 生成 references.bib（避免库变动导致 key 漂移）。
     """
-    library = await get_library_for_project(session, project_id)
-    stmt = (
-        select(Paper)
-        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-        .where(
-            LibraryPaper.library_id == library.id,
-            LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES),
-        )
-        .order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
+    library_ids = await get_source_library_ids(session, project_id)
+    if not library_ids:
+        return []  # 课题无关联库 = 无引用语料
+    rows = dedupe_member_rows(
+        (
+            await session.execute(
+                member_papers_stmt(library_ids).where(
+                    LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES)
+                )
+            )
+        ).all()
     )
-    papers = (await session.execute(stmt)).scalars().all()
+    rows.sort(key=lambda pm: (pm[0].year is None, pm[0].year or 0, pm[1].created_at))
+    papers = [p for p, _ in rows]
     keys = assign_citation_keys(papers)
     return [
         {

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -15,7 +15,7 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperNote
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
-from app.services.libraries import get_library_for_project
+from app.services.libraries import get_source_library_ids
 
 
 def author_name_of(display_name: str | None, email: str) -> str:
@@ -91,15 +91,22 @@ async def list_project_notes(
 
     分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，row = (note, author_name, paper_title)。
     """
-    library = await get_library_for_project(session, project_id)
-    in_scope = or_(
-        PaperNote.paper_id.in_(
-            select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library.id)
-        ),
+    # 课题范围 = 关联库并集 ∪ 相关研究书架；无关联库时只剩书架部分
+    library_ids = await get_source_library_ids(session, project_id)
+    scope_conditions = [
         PaperNote.paper_id.in_(
             select(TopicPaper.paper_id).where(TopicPaper.topic_id == project_id)
-        ),
-    )
+        )
+    ]
+    if library_ids:
+        scope_conditions.append(
+            PaperNote.paper_id.in_(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.library_id.in_(library_ids)
+                )
+            )
+        )
+    in_scope = or_(*scope_conditions)
     stmt = (
         select(PaperNote, User.display_name, User.email, Paper.title)
         .join(User, User.id == PaperNote.author_id)

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -235,7 +235,10 @@ async def add_manual_paper(
     """
     fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
 
+    # 人工导入落在课题起源库上；课题必须有一个可解析的库（隐式库常态存在）
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        raise ParseFailedError("课题未关联可写入的文献库")
     dedup_key = pool_dedup_key(
         arxiv_id=fields.get("arxiv_id"),
         doi=fields.get("doi"),

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -32,8 +32,11 @@ from app.models.paper import (
 )
 from app.models.project import ProjectMember
 from app.services.libraries import (
+    dedupe_member_rows,
     get_library_for_project,
+    get_source_library_ids,
     member_paper_stmt,
+    member_papers_stmt,
     user_visible_paper_stmt,
 )
 
@@ -126,6 +129,20 @@ class PaperView:
     @property
     def created_at(self) -> datetime:
         return self.membership.created_at
+
+
+async def _read_library_ids(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID | None,
+    library_id: uuid.UUID | None,
+) -> list[uuid.UUID]:
+    """并集读路径的库解析：显式 library_id（单库读视图/库工作台）→ [library_id]；
+    否则按课题关联库并集（P7；空关联=空语料，调用方返回空态而非报错）。"""
+    if library_id is not None:
+        return [library_id]
+    assert project_id is not None
+    return await get_source_library_ids(session, project_id)
 
 
 def apply_paper_filters(
@@ -226,13 +243,16 @@ async def list_papers(
     created_from: datetime | None = None,
     created_to: datetime | None = None,
 ) -> tuple[Sequence[PaperView], int]:
-    """库内论文列表。入口二选一：project_id（成员视角，解析隐式库）或
-    library_id（共享库读视角，P5c；project_id 仅作 PaperView 的课题上下文回填）。"""
-    if library_id is None:
-        assert project_id is not None
-        library_id = (await get_library_for_project(session, project_id)).id
-    stmt = apply_paper_filters(
-        member_paper_stmt(library_id),
+    """库内论文列表。入口二选一：library_id（单库读视图/库工作台）或 project_id
+    （课题成员视角 = 关联库并集，P7）。project_id 兼作 PaperView 的课题上下文回填。
+
+    单库（含课题只关联一个库的常见情形）走 SQL 分页快路径；课题关联多库时跨库
+    同一论文按确定性视角归并（有 wiki 优先），Python 侧排序 + 分页保证可移植。"""
+    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    if not library_ids:
+        return [], 0
+
+    filter_kwargs = dict(
         project_id=project_id,
         status=status,
         q=q,
@@ -247,16 +267,44 @@ async def list_papers(
         created_from=created_from,
         created_to=created_to,
     )
-    total = (await session.execute(stmt.with_only_columns(func.count()))).scalar_one()
+
+    if len(library_ids) == 1:
+        stmt = apply_paper_filters(member_paper_stmt(library_ids[0]), **filter_kwargs)
+        total = (await session.execute(stmt.with_only_columns(func.count()))).scalar_one()
+        if sort == "-published_at":
+            stmt = stmt.order_by(
+                Paper.published_at.desc().nulls_last(), LibraryPaper.created_at.desc()
+            )
+        else:  # relevance（默认）
+            stmt = stmt.order_by(
+                LibraryPaper.relevance_score.desc().nulls_last(), LibraryPaper.created_at.desc()
+            )
+        stmt = stmt.offset((page - 1) * size).limit(size)
+        rows = (await session.execute(stmt)).all()
+        return [PaperView(paper, membership, project_id) for paper, membership in rows], int(total)
+
+    # 关联多库并集：过滤 → 跨库归并 → Python 排序 + 分页
+    stmt = apply_paper_filters(member_papers_stmt(library_ids), **filter_kwargs)
+    all_rows = dedupe_member_rows((await session.execute(stmt)).all())
     if sort == "-published_at":
-        stmt = stmt.order_by(Paper.published_at.desc().nulls_last(), LibraryPaper.created_at.desc())
-    else:  # relevance（默认）
-        stmt = stmt.order_by(
-            LibraryPaper.relevance_score.desc().nulls_last(), LibraryPaper.created_at.desc()
+        all_rows.sort(
+            key=lambda pm: (
+                pm[0].published_at is None,
+                -(pm[0].published_at.timestamp() if pm[0].published_at else 0.0),
+                -pm[1].created_at.timestamp(),
+            )
         )
-    stmt = stmt.offset((page - 1) * size).limit(size)
-    rows = (await session.execute(stmt)).all()
-    return [PaperView(paper, membership, project_id) for paper, membership in rows], int(total)
+    else:  # relevance（默认）
+        all_rows.sort(
+            key=lambda pm: (
+                -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18),
+                -pm[1].created_at.timestamp(),
+            )
+        )
+    total = len(all_rows)
+    start = (page - 1) * size
+    page_rows = all_rows[start : start + size]
+    return [PaperView(paper, membership, project_id) for paper, membership in page_rows], int(total)
 
 
 async def _pool_paper_view(
@@ -531,7 +579,10 @@ async def delete_papers(
 
     默认软删（移入垃圾桶 = 成员行 status excluded，可召回）；hard=True 删成员行。
     """
+    # 删除/垃圾桶是课题「自己那份库」的管理操作，落在起源库上（不动共享库）
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        return 0
     memberships = (
         (
             await session.execute(
@@ -575,6 +626,8 @@ async def restore_paper(session: AsyncSession, view: PaperView) -> PaperView:
 async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
     """清空垃圾桶：彻底移除库内全部 excluded 成员行，返回删除数。"""
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        return 0
     memberships = (
         (
             await session.execute(
@@ -726,9 +779,9 @@ async def keyword_search_papers(
     笔记仅作者本人可见（P5b），故只有传 user_id（用户检索入口）才并入笔记命中；
     agent 调用（无用户语境）不搜笔记。入口同 list_papers：project_id 或 library_id。
     """
-    if library_id is None:
-        assert project_id is not None
-        library_id = (await get_library_for_project(session, project_id)).id
+    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    if not library_ids:
+        return []
     pattern = f"%{q}%"
     hits = [
         Paper.title.ilike(pattern),
@@ -744,11 +797,11 @@ async def keyword_search_papers(
             )
         )
     stmt = (
-        member_paper_stmt(library_id)
+        member_papers_stmt(library_ids)
         .where(LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]), or_(*hits))
-        .limit(limit * 3)
+        .limit(limit * 3 * len(library_ids))
     )
-    rows = (await session.execute(stmt)).all()
+    rows = dedupe_member_rows((await session.execute(stmt)).all())
     needle = q.lower()
 
     def score_of(p: Paper) -> float:
@@ -773,12 +826,12 @@ async def keyword_search_concepts(
     q: str,
     limit: int,
 ) -> list[tuple[Concept, float]]:
-    if library_id is None:
-        assert project_id is not None
-        library_id = (await get_library_for_project(session, project_id)).id
+    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    if not library_ids:
+        return []
     stmt = (
         select(Concept)
-        .where(Concept.library_id == library_id, Concept.name.ilike(f"%{q}%"))
+        .where(Concept.library_id.in_(library_ids), Concept.name.ilike(f"%{q}%"))
         .order_by(Concept.name)
         .limit(limit)
     )
@@ -798,29 +851,35 @@ async def semantic_search_papers(
     limit: int,
 ) -> list[tuple[PaperView, float]]:
     """pgvector 余弦检索（仅 postgres；调用方需先判 semantic_search_supported）。"""
-    if library_id is None:
-        assert project_id is not None
-        library_id = (await get_library_for_project(session, project_id)).id
+    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    if not library_ids:
+        return []
     qv = json.dumps(query_vector)
+    # DISTINCT p.id：一篇论文命中多个关联库时只召回一次（分数不受成员行影响）
     rows = (
         await session.execute(
             text(
-                "SELECT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
+                "SELECT DISTINCT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
                 "FROM papers p "
-                "JOIN library_papers lp ON lp.paper_id = p.id AND lp.library_id = :lib "
+                "JOIN library_papers lp ON lp.paper_id = p.id "
+                "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
                 "WHERE p.embedding IS NOT NULL "
-                "ORDER BY p.embedding <=> CAST(:qv AS vector) "
+                "ORDER BY score DESC "
                 "LIMIT :k"
             ),
-            {"qv": qv, "lib": str(library_id), "k": limit},
+            {"qv": qv, "libs": [str(lid) for lid in library_ids], "k": limit},
         )
     ).all()
     if not rows:
         return []
     scores = {row.id: float(row.score) for row in rows}
-    pairs = (
-        await session.execute(member_paper_stmt(library_id).where(Paper.id.in_(list(scores))))
-    ).all()
+    pairs = dedupe_member_rows(
+        (
+            await session.execute(
+                member_papers_stmt(library_ids).where(Paper.id.in_(list(scores)))
+            )
+        ).all()
+    )
     by_id = {p.id: PaperView(p, m, project_id) for p, m in pairs}
     return [(by_id[pid], scores[pid]) for pid in (r.id for r in rows) if pid in by_id]
 

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -60,10 +60,16 @@ async def create_project(
     session.add(project)
     await session.flush()
     session.add(ProjectMember(project_id=project.id, user_id=owner_id, role="owner"))
-    # P4 过渡期：每个方向 1:1 一个隐式文献库（论文归属经 library_papers 引用内容池）
-    from app.services.libraries import implicit_library_for
+    # 过渡期：每个课题仍自动建一个起源库（论文归属经 library_papers 引用内容池）。
+    # P7 起库/课题解耦——这里同时把它记成一条关联（topic_source_libraries），
+    # 语料并集读路径与「起源库」解析口径一致；Step 3 将改为可选关联既有库，
+    # 不再强制新建。
+    from app.services.libraries import implicit_library_for, set_source_libraries
 
-    session.add(implicit_library_for(project))
+    library = implicit_library_for(project)
+    session.add(library)
+    await session.flush()
+    await set_source_libraries(session, topic_id=project.id, library_ids=[library.id])
     await session.commit()
     await session.refresh(project)
     return project

--- a/src/backend/app/services/search.py
+++ b/src/backend/app/services/search.py
@@ -6,7 +6,7 @@
 
 import uuid
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.experiment import Experiment
@@ -16,7 +16,7 @@ from app.models.manuscript import Manuscript
 from app.models.paper import Concept, Paper
 from app.models.voyage import VoyageRun
 from app.schemas.search import GlobalSearchHit
-from app.services.libraries import get_library_for_project
+from app.services.libraries import get_source_library_ids
 
 _SNIPPET_CHARS = 120
 
@@ -37,25 +37,33 @@ async def global_search(
 ) -> list[GlobalSearchHit]:
     pattern = f"%{q}%"
     hits: list[GlobalSearchHit] = []
-    library = await get_library_for_project(session, project_id)
+    # 论文/概念按课题关联库并集检索；无关联库 = 无语料时跳过它们，
+    # ideas/实验/航程/稿件等课题作用域实体照常匹配（不受关联库影响）。
+    library_ids = await get_source_library_ids(session, project_id)
 
+    # 跨库并集：group_by(Paper.id) 去掉同一论文命中多库的重复行（状态取任一非回收站行）
     paper_rows = (
-        await session.execute(
-            select(Paper, LibraryPaper.status)
-            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-            .where(
-                LibraryPaper.library_id == library.id,
-                LibraryPaper.status != "excluded",  # 回收站不出现在搜索里
-                or_(
-                    Paper.title.ilike(pattern),
-                    Paper.abstract.ilike(pattern),
-                    Paper.tldr.ilike(pattern),
-                ),
+        (
+            await session.execute(
+                select(Paper, func.min(LibraryPaper.status))
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id.in_(library_ids),
+                    LibraryPaper.status != "excluded",  # 回收站不出现在搜索里
+                    or_(
+                        Paper.title.ilike(pattern),
+                        Paper.abstract.ilike(pattern),
+                        Paper.tldr.ilike(pattern),
+                    ),
+                )
+                .group_by(Paper.id)
+                .order_by(func.max(Paper.updated_at).desc())
+                .limit(limit_per_type)
             )
-            .order_by(Paper.updated_at.desc())
-            .limit(limit_per_type)
-        )
-    ).all()
+        ).all()
+        if library_ids
+        else []
+    )
     hits += [
         GlobalSearchHit(
             type="paper",
@@ -69,18 +77,22 @@ async def global_search(
 
     concepts = (
         (
-            await session.execute(
-                select(Concept)
-                .where(
-                    Concept.library_id == library.id,
-                    or_(Concept.name.ilike(pattern), Concept.definition.ilike(pattern)),
+            (
+                await session.execute(
+                    select(Concept)
+                    .where(
+                        Concept.library_id.in_(library_ids),
+                        or_(Concept.name.ilike(pattern), Concept.definition.ilike(pattern)),
+                    )
+                    .order_by(Concept.updated_at.desc())
+                    .limit(limit_per_type)
                 )
-                .order_by(Concept.updated_at.desc())
-                .limit(limit_per_type)
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
+        if library_ids
+        else []
     )
     hits += [
         GlobalSearchHit(type="concept", id=c.id, title=c.name, snippet=_snippet(c.definition))

--- a/src/backend/app/services/stats.py
+++ b/src/backend/app/services/stats.py
@@ -13,7 +13,7 @@ from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript
-from app.services.libraries import get_library_for_project
+from app.services.libraries import get_source_library_ids
 from app.services.papers import PAPER_STATUS_GROUPS
 
 
@@ -25,20 +25,27 @@ async def project_stats(session: AsyncSession, project_id: uuid.UUID) -> dict[st
     today_start = datetime.combine(datetime.now(UTC).date(), time.min, tzinfo=UTC)
     # 「知识库论文」与文献页口径一致：只算库内（相关性达标及之后），
     # 不含回收站（excluded）与尚未打分的中间状态（candidate）
-    library = await get_library_for_project(session, project_id)
+    # 「知识库论文」= 关联库并集内（相关性达标及之后），跨库同一论文只计一次
+    library_ids = await get_source_library_ids(session, project_id)
     in_library = LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"])
-    papers_total = await _count(
-        session,
-        select(func.count()).where(LibraryPaper.library_id == library.id, in_library),
-    )
-    papers_today = await _count(
-        session,
-        select(func.count()).where(
-            LibraryPaper.library_id == library.id,
-            in_library,
-            LibraryPaper.created_at >= today_start,
-        ),
-    )
+    if library_ids:
+        papers_total = await _count(
+            session,
+            select(func.count(func.distinct(LibraryPaper.paper_id))).where(
+                LibraryPaper.library_id.in_(library_ids), in_library
+            ),
+        )
+        papers_today = await _count(
+            session,
+            select(func.count(func.distinct(LibraryPaper.paper_id))).where(
+                LibraryPaper.library_id.in_(library_ids),
+                in_library,
+                LibraryPaper.created_at >= today_start,
+            ),
+        )
+    else:
+        papers_total = 0
+        papers_today = 0
     ideas_candidate = await _count(
         session,
         select(func.count()).where(Idea.project_id == project_id, Idea.status == "candidate"),

--- a/src/backend/app/services/wiki_export.py
+++ b/src/backend/app/services/wiki_export.py
@@ -26,7 +26,11 @@ from app.models.paper import Concept, Paper, PaperNote
 from app.models.project import Project
 from app.models.user import User
 from app.services.concepts import wiki_slug
-from app.services.libraries import get_library_for_project
+from app.services.libraries import (
+    dedupe_member_rows,
+    get_source_library_ids,
+    member_papers_stmt,
+)
 from app.services.literature.pdf_extract import figure_path
 from app.services.notes import author_name_of
 from app.services.wiki_compile import FIGURE_MARKER_RE
@@ -104,32 +108,43 @@ async def build_obsidian_zip(
     session: AsyncSession, project: Project, *, user_id: uuid.UUID
 ) -> bytes:
     """构建 vault zip；笔记只导出请求者本人的（P5b 笔记 paper × author，仅作者可见）。"""
-    library = await get_library_for_project(session, project.id)
+    # 课题关联库并集：跨库同一论文按确定性视角归并（有 wiki 优先），再按相关性排序
+    library_ids = await get_source_library_ids(session, project.id)
     paper_rows = (
-        await session.execute(
-            select(Paper, LibraryPaper)
-            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-            .where(
-                LibraryPaper.library_id == library.id,
-                LibraryPaper.status.in_(("compiled", "included")),
-            )
-            .options(selectinload(Paper.concepts))
-            .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+        dedupe_member_rows(
+            (
+                await session.execute(
+                    member_papers_stmt(library_ids)
+                    .where(LibraryPaper.status.in_(("compiled", "included")))
+                    .options(selectinload(Paper.concepts))
+                )
+            ).all()
         )
-    ).all()
+        if library_ids
+        else []
+    )
+    paper_rows.sort(
+        key=lambda pm: -(
+            pm[1].relevance_score if pm[1].relevance_score is not None else -1e18
+        )
+    )
     papers = [p for p, _ in paper_rows]
     membership_of = {p.id: m for p, m in paper_rows}
     concepts = (
         (
-            await session.execute(
-                select(Concept)
-                .where(Concept.library_id == library.id)
-                .options(selectinload(Concept.papers))
-                .order_by(Concept.name)
+            (
+                await session.execute(
+                    select(Concept)
+                    .where(Concept.library_id.in_(library_ids))
+                    .options(selectinload(Concept.papers))
+                    .order_by(Concept.name)
+                )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
+        if library_ids
+        else []
     )
 
     # 论文笔记（有笔记的论文页追加「## 笔记」小节）：只带请求者自己的笔记

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -13,7 +13,7 @@ from app.models.paper import Paper, PaperChunk
 from app.services import chunks as chunks_service
 from app.services import graph as graph_service
 from app.services import search as search_service
-from app.services.libraries import get_library_for_project, membership_for_project
+from app.services.libraries import get_source_library_ids, membership_for_project
 from app.tools.context import ToolContext
 from app.tools.registry import tool
 
@@ -41,10 +41,10 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     k = min(_MAX_K, max(1, int(args.get("k") or 6)))
 
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.project_id)
+        library_ids = await get_source_library_ids(session, ctx.project_id)
         rows: list[tuple[PaperChunk, float]] = []
         used_mode = "keyword"
-        if chunks_service.chunk_vector_search_supported(session):
+        if library_ids and chunks_service.chunk_vector_search_supported(session):
             try:
                 vectors = await ctx.llm.embed(
                     [query],
@@ -53,14 +53,14 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                     voyage_id=ctx.voyage_id,
                 )
                 rows = await chunks_service.semantic_search_chunks(
-                    session, library_id=library.id, query_vector=vectors[0], limit=k
+                    session, library_ids=library_ids, query_vector=vectors[0], limit=k
                 )
                 used_mode = "semantic"
             except NotImplementedError:
                 rows = []
-        if not rows:
+        if not rows and library_ids:
             rows = await chunks_service.keyword_search_chunks(
-                session, library_id=library.id, q=query, limit=k
+                session, library_ids=library_ids, q=query, limit=k
             )
             used_mode = used_mode if rows and used_mode == "semantic" else "keyword"
 

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -16,7 +16,7 @@ from app.core.db import get_sessionmaker
 from app.models.paper import Concept, Paper
 from app.services import concepts as concepts_service
 from app.services import papers as papers_service
-from app.services.libraries import get_library_for_project, membership_for_project
+from app.services.libraries import get_source_library_ids, membership_for_project
 from app.services.paper_review import relevant_excerpt
 from app.services.papers import PaperView
 from app.tools.context import ToolContext
@@ -217,13 +217,17 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     if not name:
         raise ValueError("get_concept 需要非空 name")
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.project_id)
-        stmt = select(Concept).where(Concept.library_id == library.id, Concept.name.ilike(name))
+        library_ids = await get_source_library_ids(session, ctx.project_id)
+        if not library_ids:
+            return {"name": name, "found": False, "note": "概念库中没有该概念"}
+        stmt = select(Concept).where(
+            Concept.library_id.in_(library_ids), Concept.name.ilike(name)
+        )
         concept = (await session.execute(stmt)).scalars().first()
         if concept is None:  # 精确不中再模糊
             stmt = (
                 select(Concept)
-                .where(Concept.library_id == library.id, Concept.name.ilike(f"%{name}%"))
+                .where(Concept.library_id.in_(library_ids), Concept.name.ilike(f"%{name}%"))
                 .order_by(Concept.name)
             )
             concept = (await session.execute(stmt)).scalars().first()
@@ -257,9 +261,9 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 async def list_concepts(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     category = str(args.get("category") or "").strip() or None
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.project_id)
+        library_ids = await get_source_library_ids(session, ctx.project_id)
         rows = await concepts_service.list_concepts(
-            session, library_id=library.id, category=category
+            session, library_ids=library_ids, category=category
         )
     return {
         "concepts": [

--- a/src/backend/tests/test_library_lifecycle.py
+++ b/src/backend/tests/test_library_lifecycle.py
@@ -1,0 +1,165 @@
+"""P7 Step 1：课题 × 文献库关联 + 库生命周期独立。
+
+- 建课题仍自动建起源库，但同时落一条 topic_source_libraries 关联行；
+- 删课题不再级联删库：direction_libraries.project_id 置 NULL，library_papers/
+  concepts/curators 全部保留，只有该课题自己的关联行随课题消失；
+- DELETE /libraries/{id}（admin）：有课题关联默认 409，force=true 才删；论文
+  内容池（papers 表）行永不受影响。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper, TopicSourceLibrary
+from app.models.paper import Concept, Paper
+from app.services import libraries as libraries_service
+from tests.conftest import add_concept, add_paper, register_and_login
+
+
+async def _register(client, email):
+    token = await register_and_login(client, email=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_create_project_associates_its_own_library(client):
+    admin = await _register(client, "p7-admin1@example.com")
+    resp = await client.post("/api/projects", json={"name": "P7 课题一"}, headers=admin)
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        library_ids = await libraries_service.get_source_library_ids(session, project_id)
+        assert len(library_ids) == 1
+        library = await libraries_service.get_library_for_project(session, project_id)
+        assert library is not None
+        assert library.id == library_ids[0]
+        assert library.project_id == project_id
+
+
+async def test_delete_project_keeps_library_and_content_orphans_association(client):
+    admin = await _register(client, "p7-admin2@example.com")
+    resp = await client.post("/api/projects", json={"name": "P7 课题二"}, headers=admin)
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        library = await libraries_service.get_library_for_project(session, project_id)
+        assert library is not None
+        library_id = library.id
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            title="Survives Project Deletion",
+            status="compiled",
+            relevance_score=0.8,
+            wiki_content="# 解读",
+        )
+        await add_concept(
+            session, project_id=project_id, name="X", slug="x", definition="定义"
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.delete(f"/api/projects/{project_id}", headers=admin)
+    assert resp.status_code == 204, resp.text
+
+    async with get_sessionmaker()() as session:
+        # 库本体、成员行、概念都还在；只有 project_id 回指置空
+        refreshed = await session.get(DirectionLibrary, library_id)
+        assert refreshed is not None
+        assert refreshed.project_id is None
+        membership = (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == library_id, LibraryPaper.paper_id == paper_id
+                )
+            )
+        ).scalar_one_or_none()
+        assert membership is not None
+        concept_count = (
+            await session.execute(
+                select(Concept).where(Concept.library_id == library_id)
+            )
+        ).scalars().all()
+        assert len(concept_count) == 1
+        # 论文内容池行本身也不动
+        assert await session.get(Paper, paper_id) is not None
+        # 课题自己的关联行随课题消失
+        assoc = (
+            await session.execute(
+                select(TopicSourceLibrary).where(TopicSourceLibrary.topic_id == project_id)
+            )
+        ).scalar_one_or_none()
+        assert assoc is None
+
+
+async def test_delete_library_requires_force_when_topics_linked(client):
+    admin = await _register(client, "p7-admin3@example.com")
+    resp = await client.post("/api/projects", json={"name": "P7 课题三"}, headers=admin)
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+    resp = await client.get("/api/libraries", headers=admin)
+    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+
+    resp = await client.delete(f"/api/libraries/{library_id}", headers=admin)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "LIBRARY_HAS_TOPICS"
+
+    resp = await client.delete(f"/api/libraries/{library_id}?force=true", headers=admin)
+    assert resp.status_code == 204, resp.text
+    resp = await client.get(f"/api/libraries/{library_id}", headers=admin)
+    assert resp.status_code == 404
+
+
+async def test_delete_library_non_admin_forbidden(client):
+    await _register(client, "p7-admin4@example.com")  # 首个注册者=平台 admin，占位
+    member = await _register(client, "p7-member4@example.com")
+    resp = await client.post("/api/projects", json={"name": "P7 课题四"}, headers=member)
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+    resp = await client.get("/api/libraries", headers=member)
+    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+
+    resp = await client.delete(f"/api/libraries/{library_id}", headers=member)
+    assert resp.status_code == 403
+
+
+async def test_delete_library_without_topics_needs_no_force(client):
+    """独立库（无课题关联）删除不受 force 影响——为 Step 3 独立建库铺路的行为先行验证。"""
+    admin = await _register(client, "p7-admin5@example.com")
+    async with get_sessionmaker()() as session:
+        library = DirectionLibrary(name="孤儿库", created_by=None, project_id=None)
+        session.add(library)
+        await session.commit()
+        library_id = library.id
+
+    resp = await client.delete(f"/api/libraries/{library_id}", headers=admin)
+    assert resp.status_code == 204, resp.text
+
+
+async def test_get_source_libraries_returns_multiple_associations(client):
+    """手动多关联一个库：get_source_libraries 返回并集；get_library_for_project 仍优先起源库。"""
+    admin = await _register(client, "p7-admin6@example.com")
+    resp = await client.post("/api/projects", json={"name": "P7 课题六"}, headers=admin)
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        origin = await libraries_service.get_library_for_project(session, project_id)
+        assert origin is not None
+        extra = DirectionLibrary(name="额外方向库", created_by=None, project_id=None)
+        session.add(extra)
+        await session.flush()
+        await libraries_service.set_source_libraries(
+            session, topic_id=project_id, library_ids=[origin.id, extra.id]
+        )
+        await session.commit()
+        extra_id = extra.id
+
+        libraries = await libraries_service.get_source_libraries(session, project_id)
+        assert {lib.id for lib in libraries} == {origin.id, extra_id}
+
+        resolved = await libraries_service.get_library_for_project(session, project_id)
+        assert resolved is not None
+        assert resolved.id == origin.id  # 起源库优先，即便有多个关联

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "3f770d85dca9"  # LLM 用量按方向库归因（P6，本分支最新）
-PREV_REVISION = "1c6c4831d80f"  # 笔记/划线归属拆分（P5b）
+HEAD_REVISION = "67d18892a6ce"  # 课题 × 文献库关联 + 库生命周期独立（P7 Step 1，本分支最新）
+PREV_REVISION = "3f770d85dca9"  # LLM 用量按方向库归因（P6）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -59,6 +59,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "user_publications",
                     "topic_papers",
                     "llm_usage",
+                    "topic_source_libraries",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -225,13 +226,17 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：LLM 用量按方向库归因（P6）
     assert "library_id" in columns["llm_usage"]
     assert "library_id" in columns["llm_call_logs"]
+    # 本分支新增：课题 × 文献库关联表（P7 Step 1）
+    assert "topic_source_libraries" in columns["_tables"]
+    assert columns["topic_source_libraries"] == {"topic_id", "library_id", "created_at"}
 
     # 最新 revision 可往返（downgrade 删 library_id 归因列，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "library_id" not in columns["llm_usage"]
-    assert "library_id" not in columns["llm_call_logs"]
+    assert "topic_source_libraries" not in columns["_tables"]
+    assert "library_id" in columns["llm_usage"]
+    assert "library_id" in columns["llm_call_logs"]
     # P5b 拆分结构不受影响：笔记/划线仍无 project_id
     assert "project_id" not in columns["paper_notes"]
     assert "project_id" not in columns["paper_highlights"]

--- a/src/backend/tests/test_projects.py
+++ b/src/backend/tests/test_projects.py
@@ -45,7 +45,7 @@ async def test_delete_project(client):
     resp = await client.post("/api/projects", json={"name": "to-delete"}, headers=headers)
     project_id = resp.json()["id"]
 
-    # 方向下的论文随删除级联清掉
+    # P7：删课题保留库与内容池，只解除关联（下方断言）
     import uuid as _uuid
 
     from sqlalchemy import func, select
@@ -67,9 +67,14 @@ async def test_delete_project(client):
     resp = await client.get(f"/api/projects/{project_id}", headers=headers)
     assert resp.status_code == 404
     async with get_sessionmaker()() as session:
-        from app.models.library_direction import DirectionLibrary, LibraryPaper
+        from app.models.library_direction import (
+            DirectionLibrary,
+            LibraryPaper,
+            TopicSourceLibrary,
+        )
 
-        # 隐式库与成员行随方向级联删除；内容池 Paper 行保留（全局复用，P4 语义）
+        # P7：删课题不再删库——起源库 project_id 置 NULL、成员行与内容池 Paper 都保留；
+        # 只有课题自己的关联行随课题消失（library 变孤儿，admin 可后续删库）。
         libs = (
             await session.execute(
                 select(func.count()).where(
@@ -77,11 +82,23 @@ async def test_delete_project(client):
                 )
             )
         ).scalar_one()
-        assert libs == 0
+        assert libs == 0  # 无库仍回指这个已删课题
+        total_libs = (
+            await session.execute(select(func.count()).select_from(DirectionLibrary))
+        ).scalar_one()
+        assert total_libs == 1  # 库本体存活（project_id 已 SET NULL）
         memberships = (
             await session.execute(select(func.count()).select_from(LibraryPaper))
         ).scalar_one()
-        assert memberships == 0
+        assert memberships == 1  # 成员行随库存活
+        assoc = (
+            await session.execute(
+                select(func.count()).where(
+                    TopicSourceLibrary.topic_id == _uuid.UUID(project_id)
+                )
+            )
+        ).scalar_one()
+        assert assoc == 0  # 课题自己的关联行随课题删除
         pool = (await session.execute(select(func.count()).select_from(Paper))).scalar_one()
         assert pool == 1
 

--- a/src/backend/tests/test_source_libraries.py
+++ b/src/backend/tests/test_source_libraries.py
@@ -1,0 +1,199 @@
+"""P7 Step 2/3：课题关联库并集读取 + 独立建库 + 关联读写 API。
+
+- 课题关联多个库 → 论文列表/检索是关联库论文的并集（跨库同一论文归并成一行）；
+- 关联清空 → 语料为空，消费端返回空态而非报错；
+- POST /libraries（admin）独立建库，project_id 恒为 NULL；
+- GET/PUT /projects/{id}/source-libraries 读写课题关联。
+"""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.services import libraries as libraries_service
+from app.services import papers as papers_service
+from tests.conftest import add_paper, register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _extra_library_with_paper(session, *, name, title, score=0.5):
+    """独立库 + 一篇库内论文（compiled + wiki），返回 (library, paper)。"""
+    lib = DirectionLibrary(name=name, created_by=None, project_id=None)
+    session.add(lib)
+    await session.flush()
+    paper = Paper(title=title)
+    session.add(paper)
+    await session.flush()
+    session.add(
+        LibraryPaper(
+            library_id=lib.id,
+            paper_id=paper.id,
+            status="compiled",
+            relevance_score=score,
+            wiki_content="# 解读",
+        )
+    )
+    await session.flush()
+    return lib, paper
+
+
+async def test_list_papers_union_across_linked_libraries(client):
+    admin = await _hdr(client, "p7u-1@example.com")
+    resp = await client.post("/api/projects", json={"name": "并集课题"}, headers=admin)
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        await add_paper(
+            session,
+            project_id=project_id,
+            title="Origin Paper",
+            status="compiled",
+            relevance_score=0.9,
+            wiki_content="# o",
+        )
+        extra, _ = await _extra_library_with_paper(session, name="额外库", title="Extra Paper")
+        origin = await libraries_service.get_library_for_project(session, project_id)
+        await libraries_service.set_source_libraries(
+            session, topic_id=project_id, library_ids=[origin.id, extra.id]
+        )
+        await session.commit()
+
+        items, total = await papers_service.list_papers(
+            session, project_id=project_id, status="library", size=50
+        )
+        titles = {v.paper.title for v in items}
+
+    assert total == 2
+    assert {"Origin Paper", "Extra Paper"} <= titles
+
+
+async def test_list_papers_union_dedupes_shared_paper(client):
+    """同一篇论文同时在两个关联库 → 并集列表只出现一次。"""
+    admin = await _hdr(client, "p7u-2@example.com")
+    resp = await client.post("/api/projects", json={"name": "去重课题"}, headers=admin)
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            title="Shared Paper",
+            status="compiled",
+            relevance_score=0.6,
+        )
+        origin = await libraries_service.get_library_for_project(session, project_id)
+        extra = DirectionLibrary(name="第二库", created_by=None, project_id=None)
+        session.add(extra)
+        await session.flush()
+        # 同一篇论文在第二个库也有成员行（且带 wiki，视角应优先它）
+        session.add(
+            LibraryPaper(
+                library_id=extra.id,
+                paper_id=paper.id,
+                status="compiled",
+                relevance_score=0.95,
+                wiki_content="# 更好的解读",
+            )
+        )
+        await libraries_service.set_source_libraries(
+            session, topic_id=project_id, library_ids=[origin.id, extra.id]
+        )
+        await session.commit()
+
+        items, total = await papers_service.list_papers(
+            session, project_id=project_id, status="library", size=50
+        )
+
+    assert total == 1
+    assert items[0].paper.title == "Shared Paper"
+    assert items[0].membership.wiki_content == "# 更好的解读"  # 有 wiki 的视角优先
+
+
+async def test_empty_source_libraries_yields_empty_corpus(client):
+    """关联清空 → list_papers 空、不报错。"""
+    admin = await _hdr(client, "p7u-3@example.com")
+    resp = await client.post("/api/projects", json={"name": "空语料课题"}, headers=admin)
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        await libraries_service.set_source_libraries(
+            session, topic_id=project_id, library_ids=[]
+        )
+        await session.commit()
+        items, total = await papers_service.list_papers(
+            session, project_id=project_id, status="library"
+        )
+
+    assert items == []
+    assert total == 0
+
+
+async def test_create_library_admin_independent(client):
+    admin = await _hdr(client, "p7u-4@example.com")
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "独立库", "statement": "一句话", "cadence": "weekly"},
+        headers=admin,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "独立库"
+    assert body["project_id"] is None
+    assert body["is_mine"] is False
+
+
+async def test_create_library_non_admin_forbidden(client):
+    await _hdr(client, "p7u-admin5@example.com")  # 首个注册者=平台 admin，占位
+    member = await _hdr(client, "p7u-member5@example.com")
+    resp = await client.post("/api/libraries", json={"name": "x"}, headers=member)
+    assert resp.status_code == 403
+
+
+async def test_source_libraries_read_write_api(client):
+    admin = await _hdr(client, "p7u-6@example.com")
+    resp = await client.post("/api/libraries", json={"name": "可关联库"}, headers=admin)
+    lib_id = resp.json()["id"]
+    resp = await client.post("/api/projects", json={"name": "关联课题"}, headers=admin)
+    project_id = resp.json()["id"]
+
+    # 全量替换关联为 [新独立库]（覆盖掉建课题时自动关联的起源库）
+    resp = await client.put(
+        f"/api/projects/{project_id}/source-libraries",
+        json={"library_ids": [lib_id]},
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    assert {x["id"] for x in resp.json()} == {lib_id}
+
+    resp = await client.get(f"/api/projects/{project_id}/source-libraries", headers=admin)
+    assert resp.status_code == 200
+    assert {x["id"] for x in resp.json()} == {lib_id}
+
+    # 清空
+    resp = await client.put(
+        f"/api/projects/{project_id}/source-libraries",
+        json={"library_ids": []},
+        headers=admin,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_source_libraries_requires_membership(client):
+    """非课题成员不能读/写别人课题的关联库。"""
+    owner = await _hdr(client, "p7u-owner7@example.com")
+    resp = await client.post("/api/projects", json={"name": "私有课题"}, headers=owner)
+    project_id = resp.json()["id"]
+    outsider = await _hdr(client, "p7u-outsider7@example.com")
+    resp = await client.get(f"/api/projects/{project_id}/source-libraries", headers=outsider)
+    assert resp.status_code == 404
+    resp = await client.put(
+        f"/api/projects/{project_id}/source-libraries",
+        json={"library_ids": []},
+        headers=outsider,
+    )
+    assert resp.status_code == 404

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -1,9 +1,16 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
+import { Modal } from '../../components/ui/Modal';
+import { FormField } from '../../components/ui/FormField';
+import { Segmented } from '../../components/ui/Segmented';
+import { AccordionSection } from '../../components/ui/Accordion';
+import { toast } from '../../components/ui/Toast';
 import { fmtTime } from '../../lib/format';
-import type { DirectionLibrarySummary } from '../../lib/api';
+import { api, ApiError, isAdmin, type DirectionLibrarySummary } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useLibraries, libraryPath } from './hooks';
 
@@ -11,7 +18,14 @@ import { useLibraries, libraryPath } from './hooks';
    /libraries — 文献库列表（实验室区，P5c）
    卡片流：库名 / 方向陈述 / 论文·概念数 / 最近更新；
    「我的课题的库」有标识；点击进 /libraries/:id 详情。
+   平台管理员可在此新建独立共享文献库（与任何课题解耦）。
    ============================================================ */
+
+const CADENCES = [
+  { v: 'daily', zh: '每日', en: 'Daily' },
+  { v: 'weekly', zh: '每周', en: 'Weekly' },
+  { v: 'manual', zh: '手动', en: 'Manual' },
+] as const;
 
 function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: () => void }) {
   const updated = lib.last_compiled_at ?? lib.last_synced_at;
@@ -90,9 +104,144 @@ function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: ()
   );
 }
 
+/** 新建文献库弹窗（仅平台管理员）。名称必填，其余为可选高级项。 */
+function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [statement, setStatement] = useState('');
+  const [advOpen, setAdvOpen] = useState(false);
+  const [cadence, setCadence] = useState<string>('daily');
+  const [budget, setBudget] = useState('');
+  const [rubricText, setRubricText] = useState('');
+  const [anchorsText, setAnchorsText] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: (input: Parameters<typeof api.createLibrary>[0]) => api.createLibrary(input),
+    onSuccess: (lib) => {
+      toast(tr('文献库已创建', 'Library created'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      onClose();
+      navigate(libraryPath(lib.id));
+    },
+    onError: (err) => {
+      const forbidden = err instanceof ApiError && err.status === 403;
+      toast(
+        forbidden
+          ? tr('只有平台管理员可以新建文献库', 'Only a platform admin can create libraries')
+          : `${tr('创建失败：', 'Create failed: ')}${err instanceof Error ? err.message : String(err)}`,
+        'error',
+      );
+    },
+  });
+
+  function submit() {
+    if (!name.trim()) {
+      toast(tr('请填写文献库名称', 'Enter a library name'), 'info');
+      return;
+    }
+    let rubric: unknown;
+    if (rubricText.trim()) {
+      try {
+        rubric = JSON.parse(rubricText);
+      } catch {
+        toast(tr('评审标准不是合法 JSON', 'Rubric is not valid JSON'), 'error');
+        return;
+      }
+    }
+    let anchors: unknown[] | undefined;
+    if (anchorsText.trim()) {
+      try {
+        const a = JSON.parse(anchorsText);
+        if (!Array.isArray(a)) {
+          toast(tr('锚点论文需为 JSON 数组', 'Anchors must be a JSON array'), 'error');
+          return;
+        }
+        anchors = a;
+      } catch {
+        toast(tr('锚点论文不是合法 JSON', 'Anchors are not valid JSON'), 'error');
+        return;
+      }
+    }
+    let monthly_budget: number | undefined;
+    if (budget.trim()) {
+      monthly_budget = Number(budget);
+      if (!Number.isFinite(monthly_budget)) {
+        toast(tr('月度预算需为数字', 'Budget must be a number'), 'error');
+        return;
+      }
+    }
+    mutation.mutate({
+      name: name.trim(),
+      statement: statement.trim() || undefined,
+      ...(rubric !== undefined ? { rubric } : {}),
+      ...(anchors !== undefined ? { anchors } : {}),
+      cadence,
+      ...(monthly_budget !== undefined ? { monthly_budget } : {}),
+    });
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={tr('新建文献库', 'New library')}
+      sub={tr('独立的共享文献库，与任何课题解耦；创建后可任命策展人维护。', 'A standalone shared library, decoupled from any topic — assign curators after creating.')}
+      width={600}
+      footer={
+        <>
+          <button className="btn btn-ghost sm" onClick={onClose}>{tr('取消', 'Cancel')}</button>
+          <button className="btn btn-primary sm" disabled={mutation.isPending} onClick={submit}>
+            {mutation.isPending ? tr('创建中…', 'Creating…') : tr('创建文献库', 'Create library')}
+          </button>
+        </>
+      }
+    >
+      <div style={{ marginTop: 4 }}>
+        <FormField label={tr('名称', 'Name')} hint={tr('将显示在文献库列表中', 'Shown in the library list')}>
+          <input className="input" value={name} onChange={(e) => setName(e.target.value)}
+            placeholder={tr('如：稀疏注意力', 'e.g. Sparse attention')} />
+        </FormField>
+        <FormField label={tr('一句话说明', 'Statement')} hint={tr('这个方向研究什么', 'What this direction studies')}>
+          <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
+            placeholder={tr('用一句话介绍这个文献库的方向', 'One sentence describing this library’s direction')} />
+        </FormField>
+        <AccordionSection
+          title="高级设置（可选）"
+          en="Advanced (optional)"
+          open={advOpen}
+          onToggle={() => setAdvOpen((v) => !v)}
+        >
+          <FormField label={tr('运行节奏', 'Cadence')} hint={tr('自动同步的运行频率', 'How often ingest runs')}>
+            <div>
+              <Segmented options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
+                value={cadence as (typeof CADENCES)[number]['v']} onChange={(v) => setCadence(v)} />
+            </div>
+          </FormField>
+          <FormField label={tr('月度预算（token）', 'Monthly budget (tokens)')} hint={tr('留空 = 不限', 'Leave blank for unlimited')}>
+            <input className="input mono" inputMode="numeric" value={budget} onChange={(e) => setBudget(e.target.value)}
+              placeholder={tr('如 2000000', 'e.g. 2000000')} />
+          </FormField>
+          <FormField label={tr('评审标准 rubric（JSON）', 'Rubric (JSON)')} hint={tr('可留空，稍后在库管理里调', 'Optional — edit later in library management')}>
+            <textarea className="textarea mono" rows={4} value={rubricText} onChange={(e) => setRubricText(e.target.value)}
+              placeholder={'[{"name": "新颖性", "description": "…", "weight": 1.0}]'} style={{ fontSize: 12 }} />
+          </FormField>
+          <FormField label={tr('锚点论文（JSON 数组）', 'Anchor papers (JSON array)')} hint={tr('可留空', 'Optional')}>
+            <textarea className="textarea mono" rows={3} value={anchorsText} onChange={(e) => setAnchorsText(e.target.value)}
+              placeholder={'[{"title": "…", "arxiv_id": "…"}]'} style={{ fontSize: 12 }} />
+          </FormField>
+        </AccordionSection>
+      </div>
+    </Modal>
+  );
+}
+
 export function LibrariesPage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, refetch } = useLibraries();
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
+  const canCreate = isAdmin(me);
+  const [createOpen, setCreateOpen] = useState(false);
   const libraries = data ?? [];
   // 我的课题的库排前面，其余按名称
   const sorted = [...libraries].sort(
@@ -108,7 +257,17 @@ export function LibrariesPage() {
           '按研究方向维护的公共文献库：解读、概念和原文对所有人开放，随便逛。',
           'Shared per-direction libraries — wikis, concepts and full texts are open to everyone.',
         )}
+        right={
+          canCreate ? (
+            <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
+              <Icon name="plus" size={13} />
+              {tr('新建文献库', 'New library')}
+            </button>
+          ) : undefined
+        }
       />
+
+      {canCreate && <NewLibraryModal open={createOpen} onClose={() => setCreateOpen(false)} />}
 
       {isLoading ? (
         <div
@@ -137,15 +296,23 @@ export function LibrariesPage() {
         <EmptyState
           icon="book"
           title={tr('还没有文献库', 'No libraries yet')}
-          desc={tr(
-            '创建课题后会自动生成对应方向的文献库；先去建一个课题吧。',
-            'A direction library is created with each topic — create a topic first.',
-          )}
+          desc={
+            canCreate
+              ? tr('点右上「新建文献库」创建一个共享文献库。', 'Use “New library” at the top right to create a shared library.')
+              : tr('创建课题后会自动生成对应方向的文献库；先去建一个课题吧。', 'A direction library is created with each topic — create a topic first.')
+          }
           action={
-            <button className="btn btn-primary sm" onClick={() => navigate('/projects/new')}>
-              <Icon name="plus" size={13} />
-              {tr('新建课题', 'New topic')}
-            </button>
+            canCreate ? (
+              <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
+                <Icon name="plus" size={13} />
+                {tr('新建文献库', 'New library')}
+              </button>
+            ) : (
+              <button className="btn btn-primary sm" onClick={() => navigate('/projects/new')}>
+                <Icon name="plus" size={13} />
+                {tr('新建课题', 'New topic')}
+              </button>
+            )
           }
         />
       ) : (

--- a/src/frontend/src/features/libraries/LibraryPicker.tsx
+++ b/src/frontend/src/features/libraries/LibraryPicker.tsx
@@ -1,0 +1,92 @@
+import { Icon } from '../../components/ui/Icon';
+import type { DirectionLibrarySummary } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   文献库多选清单：勾选卡片。库列表与选中态由外部传入，
+   建课题向导与课题设置的「关联文献库」共用。
+   ============================================================ */
+
+export function LibraryPicker({
+  libraries,
+  selectedIds,
+  onToggle,
+  disabled,
+}: {
+  libraries: DirectionLibrarySummary[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="col gap8">
+      {libraries.map((lib) => {
+        const on = selectedIds.has(lib.id);
+        return (
+          <button
+            key={lib.id}
+            type="button"
+            disabled={disabled}
+            className="card hoverable"
+            onClick={() => onToggle(lib.id)}
+            style={{
+              padding: '12px 14px',
+              display: 'flex',
+              gap: 12,
+              alignItems: 'center',
+              textAlign: 'left',
+              cursor: disabled ? 'default' : 'pointer',
+              border: on ? '1px solid var(--accent)' : '0.5px solid var(--border)',
+              background: on ? 'var(--accent-soft)' : 'var(--surface)',
+            }}
+          >
+            <span
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 6,
+                flexShrink: 0,
+                border: on ? 'none' : '1.5px solid var(--border)',
+                background: on ? 'var(--accent)' : 'transparent',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+              }}
+            >
+              {on && <Icon name="check" size={13} />}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="row gap8">
+                <span style={{ fontSize: 13.5, fontWeight: 650 }}>{lib.name}</span>
+                {lib.is_mine && (
+                  <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+                    {tr('我的课题', 'My topic')}
+                  </span>
+                )}
+              </div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-3)',
+                  marginTop: 3,
+                  lineHeight: 1.5,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {lib.statement ?? tr('这个方向还没有写一句话介绍。', 'No statement yet.')}
+              </div>
+              <div className="row gap10" style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 4 }}>
+                <span>{tr(`${lib.paper_count} 篇论文`, `${lib.paper_count} papers`)}</span>
+                <span>{tr(`${lib.concept_count} 个概念`, `${lib.concept_count} concepts`)}</span>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -11,6 +11,8 @@ import { topicPath, useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { api, ApiError, type ProjectDefinition, type ProjectRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { useLibraries } from '../libraries/hooks';
+import { LibraryPicker } from '../libraries/LibraryPicker';
 
 /* ============================================================
    /projects/:id — 方向详情：definition 各节卡片化展示 + 就地编辑
@@ -173,6 +175,44 @@ export function ProjectDetailPage() {
     onError: (err) => toast(`${tr('保存失败：', 'Save failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
   });
 
+  // —— 关联文献库 ——
+  const { data: sourceLibraries } = useQuery({
+    queryKey: ['sourceLibraries', id],
+    queryFn: () => api.getSourceLibraries(id),
+    retry: false,
+    enabled: !!id,
+  });
+  const librariesQuery = useLibraries();
+  const allLibraries = librariesQuery.data ?? [];
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkDraft, setLinkDraft] = useState<Set<string>>(new Set());
+  function openLinkEditor() {
+    setLinkDraft(new Set((sourceLibraries ?? []).map((l) => l.id)));
+    setLinkOpen(true);
+  }
+  function toggleLinkDraft(libId: string) {
+    setLinkDraft((prev) => {
+      const next = new Set(prev);
+      if (next.has(libId)) next.delete(libId);
+      else next.add(libId);
+      return next;
+    });
+  }
+  const setSourceLibsMutation = useMutation({
+    mutationFn: (ids: string[]) => api.setSourceLibraries(id, ids),
+    onSuccess: (libs) => {
+      queryClient.setQueryData(['sourceLibraries', id], libs);
+      // 课题语料 = 关联库并集：相关缓存全部失效
+      void queryClient.invalidateQueries({ queryKey: ['papers', id] });
+      void queryClient.invalidateQueries({ queryKey: ['project-graph', id] });
+      void queryClient.invalidateQueries({ queryKey: ['concepts', id] });
+      void queryClient.invalidateQueries({ queryKey: ['shelf', id] });
+      setLinkOpen(false);
+      toast(tr('关联文献库已更新', 'Linked libraries updated'), 'ok');
+    },
+    onError: (err) => toast(`${tr('更新失败：', 'Update failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
+  });
+
   // —— 成员 ——
   const [memberEmail, setMemberEmail] = useState('');
   const [memberRole, setMemberRole] = useState<'member' | 'owner'>('member');
@@ -329,11 +369,75 @@ export function ProjectDetailPage() {
         </div>
       </Modal>
 
+      {/* —— 管理关联文献库 —— */}
+      <Modal
+        open={linkOpen}
+        onClose={() => setLinkOpen(false)}
+        title={tr('管理关联文献库', 'Linked libraries')}
+        sub={tr('课题语料 = 所选文献库的并集；可全部不选。', 'The topic corpus is the union of the selected libraries — selecting none is allowed.')}
+        width={600}
+        footer={
+          <>
+            <button className="btn btn-ghost sm" onClick={() => setLinkOpen(false)}>{tr('取消', 'Cancel')}</button>
+            <button className="btn btn-primary sm" disabled={setSourceLibsMutation.isPending}
+              onClick={() => setSourceLibsMutation.mutate([...linkDraft])}>
+              {setSourceLibsMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+            </button>
+          </>
+        }
+      >
+        {librariesQuery.isLoading ? (
+          <div className="empty" style={{ padding: 30 }}>{tr('加载中…', 'Loading…')}</div>
+        ) : allLibraries.length === 0 ? (
+          <div className="empty" style={{ padding: 30 }}>{tr('平台还没有文献库。', 'No libraries on the platform yet.')}</div>
+        ) : (
+          <div style={{ maxHeight: '55vh', overflowY: 'auto', marginTop: 4 }}>
+            <LibraryPicker libraries={allLibraries} selectedIds={linkDraft} onToggle={toggleLinkDraft} disabled={setSourceLibsMutation.isPending} />
+          </div>
+        )}
+      </Modal>
+
       <div className="col gap16">
         {/* 一句话定义 */}
         <SectionCard icon="sparkle" zh="课题定义" en="Statement">
           <EditableText value={def.statement ?? ''} placeholder={tr('尚未填写一句话定义', 'No one-line statement yet')}
             onSave={(v) => patchDef({ statement: v })} saving={saving} />
+        </SectionCard>
+
+        {/* 关联文献库 */}
+        <SectionCard icon="book" zh="关联文献库" en="Linked libraries"
+          action={
+            <button className="btn btn-soft sm" onClick={openLinkEditor}>
+              <Icon name="pen" size={12} />
+              {tr('管理', 'Manage')}
+            </button>
+          }
+        >
+          <div className="field-hint" style={{ marginBottom: 10 }}>
+            {tr('课题语料 = 所有关联文献库的并集；想法生成、检索都跑在并集上。', 'The topic corpus is the union of all linked libraries — idea generation and search run over that union.')}
+          </div>
+          {sourceLibraries === undefined ? (
+            <div style={{ fontSize: 13, color: 'var(--text-4)' }}>{tr('加载中…', 'Loading…')}</div>
+          ) : sourceLibraries.length === 0 ? (
+            <div style={{ fontSize: 13, color: 'var(--text-4)' }}>
+              {tr('尚未关联任何文献库；点右上「管理」添加。', 'No linked libraries yet — use “Manage” to add.')}
+            </div>
+          ) : (
+            <div className="col gap8">
+              {sourceLibraries.map((lib) => (
+                <div key={lib.id} className="row gap10" style={{ padding: '9px 11px', background: 'var(--surface-2)', borderRadius: 9 }}>
+                  <span style={{ width: 26, height: 26, borderRadius: 8, background: 'var(--accent-soft)', color: 'var(--accent)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                    <Icon name="book" size={14} />
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 600 }}>{lib.name}</div>
+                    {lib.statement && <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2, lineHeight: 1.4 }}>{lib.statement}</div>}
+                  </div>
+                  <span className="mono muted" style={{ fontSize: 11, flexShrink: 0 }}>{tr(`${lib.paper_count} 篇`, `${lib.paper_count} papers`)}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </SectionCard>
 
         {/* 目标与范围 */}

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -10,6 +10,8 @@ import { toast } from '../../components/ui/Toast';
 import { topicPath, useProject } from '../../app/project';
 import { api, type AnchorPaper, type ProjectDefinition, type RubricDimension } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { useLibraries } from '../libraries/hooks';
+import { LibraryPicker } from '../libraries/LibraryPicker';
 
 /* ============================================================
    /projects/new — 创建页，单页为主。
@@ -176,6 +178,19 @@ export function ProjectWizardPage() {
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
 
+  // —— 关联文献库（可选，可全部不选） ——
+  const librariesQuery = useLibraries();
+  const libraries = librariesQuery.data ?? [];
+  const [selectedLibraryIds, setSelectedLibraryIds] = useState<Set<string>>(new Set());
+  function toggleLibrary(libId: string) {
+    setSelectedLibraryIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(libId)) next.delete(libId);
+      else next.add(libId);
+      return next;
+    });
+  }
+
   // —— 文献追踪配置（全部可选，默认折叠） ——
   const [trackOpen, setTrackOpen] = useState(false);
   const [includeTerms, setIncludeTerms] = useState<string[]>([]);
@@ -336,6 +351,14 @@ export function ProjectWizardPage() {
     setSubmitting(true);
     try {
       const created = await api.createProject({ name: name.trim(), definition: buildDefinition() });
+      // 额外关联已勾选的共享文献库（隐式起源库由后端自动建，不在此列）
+      if (selectedLibraryIds.size > 0) {
+        try {
+          await api.setSourceLibraries(created.id, [...selectedLibraryIds]);
+        } catch (e) {
+          toast(tr(`课题已创建，但关联文献库失败：${e instanceof Error ? e.message : String(e)}，可在课题设置里重试`, `Topic created, but linking libraries failed: ${e instanceof Error ? e.message : String(e)} — retry in topic settings`), 'error');
+        }
+      }
       await queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(created.id);
       toast(tr('课题已创建', 'Topic created'), 'ok');
@@ -368,6 +391,40 @@ export function ProjectWizardPage() {
             placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
         </FormField>
         {formError && <div className="field-error" style={{ marginTop: 4 }}>{formError}</div>}
+      </div>
+
+      {/* —— 关联文献库（可选，可全部不选） —— */}
+      <div className="card card-pad" style={{ marginBottom: 12 }}>
+        <div className="row" style={{ justifyContent: 'space-between', marginBottom: 4 }}>
+          <span className="section-h">
+            <Icon name="book" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('关联文献库', 'Linked libraries')}
+          </span>
+          {libraries.length > 0 && (
+            <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+              {tr(`已选 ${selectedLibraryIds.size} 个`, `${selectedLibraryIds.size} selected`)}
+            </span>
+          )}
+        </div>
+        <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '2px 0 12px', lineHeight: 1.6 }}>
+          {tr(
+            '课题的语料 = 关联文献库的并集；可全部不选跳过，稍后在课题设置里添加。',
+            'A topic\u2019s corpus is the union of its linked libraries \u2014 you can skip this and add libraries later in topic settings.',
+          )}
+        </div>
+        {librariesQuery.isLoading ? (
+          <div className="col gap8">
+            {[0, 1].map((i) => (
+              <div key={i} className="skel" style={{ height: 64, borderRadius: 12 }} />
+            ))}
+          </div>
+        ) : libraries.length === 0 ? (
+          <div className="empty" style={{ padding: '20px 14px' }}>
+            {tr('还没有文献库，可先跳过，稍后关联。', 'No libraries yet \u2014 skip for now and link one later.')}
+          </div>
+        ) : (
+          <LibraryPicker libraries={libraries} selectedIds={selectedLibraryIds} onToggle={toggleLibrary} />
+        )}
       </div>
 
       {/* —— 文献追踪配置（可选，默认折叠） —— */}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2689,6 +2689,29 @@ export const api = {
   getLibrary(id: string): Promise<DirectionLibraryDetail> {
     return request<DirectionLibraryDetail>(`/libraries/${id}`);
   },
+  /** 新建共享文献库（仅平台 admin；非 admin 返回 403）。 */
+  createLibrary(input: {
+    name: string;
+    statement?: string | null;
+    rubric?: unknown;
+    anchors?: unknown[];
+    cadence?: string | null;
+    monthly_budget?: number | null;
+  }): Promise<DirectionLibraryDetail> {
+    return requestJson<DirectionLibraryDetail>('/libraries', 'POST', input);
+  },
+  /** 课题当前关联的文献库摘要（顺序 = 关联建立时间）。 */
+  getSourceLibraries(projectId: string): Promise<DirectionLibrarySummary[]> {
+    return request<DirectionLibrarySummary[]>(`/projects/${projectId}/source-libraries`);
+  },
+  /** 全量替换课题关联的文献库（空数组合法 = 课题 0 关联）。 */
+  setSourceLibraries(projectId: string, libraryIds: string[]): Promise<DirectionLibrarySummary[]> {
+    return requestJson<DirectionLibrarySummary[]>(
+      `/projects/${projectId}/source-libraries`,
+      'PUT',
+      { library_ids: libraryIds },
+    );
+  },
   /** 编辑库信息（可管理者）；传 null 清空对应字段。 */
   updateLibrary(
     id: string,


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P7. Turns the 1:1 implicit library-per-topic into a many-to-many association: libraries are lab-level assets a topic *links to*, and a topic's corpus is the union of its linked libraries.

## What changed

**Lifecycle decoupled (step 1).** New `topic_source_libraries` association table (backfilled 1:1 from existing implicit libraries). `direction_libraries.project_id` demoted to an origin tracer with `ON DELETE SET NULL` — deleting a topic no longer deletes its library; content, memberships, and concepts survive as an admin-owned orphan. Migration `67d18892a6ce`.

**Corpus reads become a union (step 2).** Every corpus-consumption read path resolves a topic to its linked-library id list and queries the union (papers list/search, chunks, reading chat, global search, fact-pack/citations, graph, notes/stats/export, idea seed validation, concept list, agent literature/knowledge tools, voyage forge/proposal/present/experiment context). Management and ingest paths stay on the single origin library (None-guarded). `list_papers` keeps a single-library SQL fast path and adds a Python dedupe/paginate path for multi-library topics. Fixed two defects the in-progress work left: `search.py` skipped project-scoped entities when a topic had no linked libraries, and `tools/knowledge.py` still used the old chunk-search signature.

**APIs (step 3).** `POST /libraries` (admin independent create, `project_id` null), `GET/PUT /projects/{id}/source-libraries` (member-checked full replace, empty allowed).

**Frontend.** Wizard step to link libraries, a source-library management section in topic settings, an admin "new library" entry on the libraries page, and the `LibraryPicker` component.

## Deferred (tracked in the design doc)

- Ingest authority still reads the origin library's rubric/anchors/watermark; switching ingest to the library's own fields (so a library need not map 1:1 to a topic) is the main remaining P7 step.
- New topics still auto-create an implicit origin library as a backward-compatible fallback; the end-state "no implicit library" is deferred.

## Tests

531 passed (baseline ~518 + 7 new `test_source_libraries.py`), 16 pre-existing errors, 1 pre-existing env-coupled feedback failure — no new failures. ruff clean; frontend tsc + build pass. Migration verified on sqlite round-trip.