### PR TITLE
feat: config decoupling — libraries own inclusion config, slim topic settings (P8)

### DIFF
--- a/src/backend/alembic/versions/b3e9c1f47a20_library_definition_authority.py
+++ b/src/backend/alembic/versions/b3e9c1f47a20_library_definition_authority.py
@@ -1,0 +1,49 @@
+"""库承载完整收录配置：direction_libraries.definition（P8a 配置权威化）
+
+给方向库一个 ``definition`` JSON 列（结构与原 ``project.definition`` 一致：
+statement/goals/in_scope/out_of_scope/questions/rubric/anchor_papers/keywords/
+cadence），成为收录配置的唯一权威。数据迁移：每个隐式库（project_id 非空）从其
+起源课题整体拷贝 definition；同时把 ingest_state（水位线/last_run）从起源课题拷回
+库上——ingest 的水位线读写自此以库为准（见 actions_wiki.update_watermark）。
+
+列到列拷贝（相关子查询 UPDATE）在 sqlite/postgres 均可用，且保留 JSON 原生表示，
+无需 Python 端序列化。
+
+Revision ID: b3e9c1f47a20
+Revises: 67d18892a6ce
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3e9c1f47a20"
+down_revision: str | None = "67d18892a6ce"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    json_type = sa.JSON().with_variant(sa.dialects.postgresql.JSONB(), "postgresql")
+    op.add_column("direction_libraries", sa.Column("definition", json_type, nullable=True))
+
+    # 隐式库从起源课题整体拷 definition + ingest_state（列到列，保留 JSON 原生表示）。
+    bind.execute(
+        sa.text(
+            "UPDATE direction_libraries SET "
+            "definition = (SELECT p.definition FROM projects p "
+            "WHERE p.id = direction_libraries.project_id), "
+            "ingest_state = (SELECT p.ingest_state FROM projects p "
+            "WHERE p.id = direction_libraries.project_id) "
+            "WHERE project_id IS NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_column("definition")

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -34,7 +34,12 @@ from app.services.chunks import embed_pending_chunks, index_paper_fulltext
 from app.services.concepts import link_all_paper_concepts
 from app.services.dedup import pool_dedup_key
 from app.services.figure_annotate import annotate_figures, figures_annotated
-from app.services.libraries import ensure_membership, find_pool_paper, get_library_for_project
+from app.services.libraries import (
+    ensure_membership,
+    find_pool_paper,
+    get_library_for_project,
+    library_definition,
+)
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
@@ -147,10 +152,6 @@ async def _get_project(session: AsyncSession, ctx: ActionContext) -> Project:
     return project
 
 
-def _definition(project: Project) -> dict[str, Any]:
-    return project.definition if isinstance(project.definition, dict) else {}
-
-
 def _parse_iso(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -239,8 +240,11 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
     now = utcnow()
     mode = _mode(ctx)
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        definition = _definition(project)
+        library = await get_library_for_project(session, ctx.run.project_id)
+        if library is None:
+            raise ValueError(f"library not found for project: {ctx.run.project_id}")
+        # P8a：收录配置读库自身 definition（不再读起源课题 project.definition）
+        definition = library_definition(library)
         keywords_def = definition.get("keywords") or {}
         # 稀疏 definition 容忍：无 arxiv_categories 时回退默认 cs.* 分类
         categories = list(keywords_def.get("arxiv_categories") or []) or list(
@@ -248,7 +252,8 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         )
         include = list(keywords_def.get("include") or [])
 
-        watermark = _parse_iso((project.ingest_state or {}).get("watermark"))
+        # 水位线权威源在库（P8a）：library.ingest_state.watermark
+        watermark = _parse_iso((library.ingest_state or {}).get("watermark"))
         if mode == "incremental" and watermark is not None:
             # 回看窗口覆盖 arXiv 关键词索引滞后，防止近几天的新论文被漏抓
             since = watermark - timedelta(days=_INCREMENTAL_LOOKBACK_DAYS)
@@ -263,7 +268,6 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             categories=categories, keywords=include, since=since, until=now, limit=limit
         )
 
-        library = await get_library_for_project(session, project.id)
         arxiv_ids, dois, titles = await _existing_keys(session, library.id)
         new_papers: list[Paper] = []
 
@@ -378,14 +382,15 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
     max_new = _UNLIMITED_SENTINEL if _unlimited(knobs) else int(knobs["max_papers"]) * 2
 
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        definition = _definition(project)
+        library = await get_library_for_project(session, ctx.run.project_id)
+        if library is None:
+            raise ValueError(f"library not found for project: {ctx.run.project_id}")
+        definition = library_definition(library)
         anchors = [
             normalize_arxiv_id(str(a.get("arxiv_id")))
             for a in (definition.get("anchor_papers") or [])
             if isinstance(a, dict) and a.get("arxiv_id")
         ]
-        library = await get_library_for_project(session, project.id)
         candidate_ids = (
             (
                 await session.execute(
@@ -512,10 +517,11 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
     threshold = float(knobs["relevance_threshold"])
 
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        library = await get_library_for_project(session, project.id)
+        library = await get_library_for_project(session, ctx.run.project_id)
+        if library is None:
+            raise ValueError(f"library not found for project: {ctx.run.project_id}")
         # 稀疏 definition 容忍：rubric / questions 缺失时 prompt 只用 statement
-        context_text = build_relevance_context(project)
+        context_text = build_relevance_context(library_definition(library), library.name)
 
         # 幂等断点：只取仍是 candidate 的成员行（已打分的不重复调 LLM）。外层只查 id，
         # 每篇打分在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
@@ -765,7 +771,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
         library = await get_library_for_project(session, project.id)
-        statement = _definition(project).get("statement") or project.name
+        statement = library_definition(library).get("statement") or library.name
         # 幂等断点：已 compiled 的不再进入（status=fetched 才编译）。外层只查 id，每篇
         # 编译在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
         rows = (
@@ -947,12 +953,16 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
 async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         project = await _get_project(session, ctx)
-        state = dict(project.ingest_state or {})
+        library = await get_library_for_project(session, project.id)
+        # 水位线权威源在库（P8a）：写 library.ingest_state；起源课题 project.ingest_state
+        # 不再是权威（overview「上次同步时间」读库）。
+        state = dict((library.ingest_state if library else None) or {})
         watermark = ctx.checkpoint.get("watermark_candidate") or state.get("watermark")
         finished_at = utcnow().isoformat()
         state["watermark"] = watermark
         state["last_run"] = {"voyage_id": str(ctx.run.id), "finished_at": finished_at}
-        project.ingest_state = state
+        if library is not None:
+            library.ingest_state = state
 
         compiled_count = int(ctx.checkpoint.get("compiled_count") or 0)
         session.add(

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -99,6 +99,7 @@ async def create_library(
         rubric=data.rubric,
         anchors=data.anchors,
         cadence=data.cadence,
+        keywords=data.keywords,
         monthly_budget=data.monthly_budget,
         created_by=user.id,
     )
@@ -125,10 +126,10 @@ async def update_library(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
-    """编辑库定义（可管理者）：name/statement/cadence/monthly_budget/rubric/anchors。
+    """编辑库定义（可管理者）：name/monthly_budget 与收录配置（statement/cadence/
+    rubric/anchors/keywords/goals/scope/questions）。
 
-    过渡期隐式库以库为权威，statement/rubric/anchors/cadence 写时同步回
-    project.definition（保持 ingest 兼容），name 同步 project.name。
+    P8a：收录配置写入 library.definition（ingest 唯一权威源），不再写回起源课题。
     """
     library = await _get_managed_library(session, library_id, user)
     fields = data.model_dump(exclude_unset=True)

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -205,7 +205,7 @@ async def add_paper_manually(
     # 顺带相关性打分（best-effort）：失败只记日志，不影响 201；不改 status（人工纳入）
     if membership is not None:
         await relevance_service.score_added_paper_best_effort(
-            session, paper, membership, project, user_id=user_id
+            session, paper, membership, project_id=project.id, user_id=user_id
         )
     # 重新加载（带 concepts eager load），避免序列化时触发 async lazy load
     view = await papers_service.get_paper_for_user(

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -30,6 +30,10 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     statement: Mapped[str | None] = mapped_column(Text)  # 方向陈述（一段话）
     rubric: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 相关性评分标准
     anchors: Mapped[list[Any] | None] = mapped_column(JSONVariant)  # 锚点论文/关键词
+    # P8a：收录配置权威源（结构同原 project.definition：statement/goals/in_scope/
+    # out_of_scope/questions/rubric/anchor_papers/keywords(含 arxiv_categories)/cadence）。
+    # 上方 statement/rubric/anchors/cadence 标量列为展示镜像，由 update_library 同步维护。
+    definition: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     # 文献 ingest 状态：{"watermark": iso, "last_run": {"voyage_id", "finished_at"}}
     ingest_state: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     cadence: Mapped[str | None] = mapped_column(String(32))  # 同步节奏：daily | weekly | ...

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -35,6 +35,9 @@ class DirectionLibraryDetail(DirectionLibrarySummary):
     cadence: str | None
     # 每月 ingest 预算（token 数；None = 不限）
     monthly_budget: int | None = None
+    # 收录配置全量（P8a 权威源）：statement/goals/in_scope/out_of_scope/questions/
+    # rubric/anchor_papers/keywords(含 arxiv_categories)/cadence，供「收录设置」编辑
+    definition: dict[str, Any] | None = None
 
 
 class LibraryCreate(BaseModel):
@@ -46,6 +49,7 @@ class LibraryCreate(BaseModel):
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
+    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, synonyms}
 
 
 class SourceLibrariesUpdate(BaseModel):
@@ -55,7 +59,13 @@ class SourceLibrariesUpdate(BaseModel):
 
 
 class DirectionLibraryUpdate(BaseModel):
-    """库定义编辑（PATCH /libraries/{id}）：显式传 null 可清空对应字段。"""
+    """库定义编辑（PATCH /libraries/{id}）：显式传 null 可清空对应字段。
+
+    P8a：收录配置写入 library.definition（ingest 权威源）。除 name/monthly_budget 外，
+    其余字段（statement/cadence/rubric/anchors/keywords/goals/scope/questions）即收录配置。
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
     statement: str | None = None
@@ -63,6 +73,11 @@ class DirectionLibraryUpdate(BaseModel):
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
+    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, synonyms}
+    goals: list[Any] | None = None
+    in_scope: list[Any] | None = None
+    out_of_scope: list[Any] | None = None
+    questions: list[Any] | None = None
 
 
 class CuratorRead(BaseModel):

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -9,12 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.navigator import WIKI_KINDS
 from app.models.activity import Activity
-from app.models.library_direction import LibraryPaper
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import PAPER_STATUSES
 from app.models.project import Project
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
-from app.services.libraries import get_library_for_project
+from app.services.libraries import get_library_for_project, library_definition
 
 # 预算从 knobs 派生：每篇编译预留的 token 额度（打分+编译+概念定义+验证）
 _TOKENS_PER_PAPER = 20_000
@@ -177,10 +177,17 @@ DAILY_SYNC_UTC_HOUR = 3
 DAILY_SYNC_UTC_MINUTE = 0
 
 
-def next_daily_sync_at(project: Project) -> datetime | None:
-    """下一次自动同步时间：cadence=daily 且已完成初始建库才有；否则 None。"""
-    definition = project.definition if isinstance(project.definition, dict) else {}
-    state = project.ingest_state or {}
+def next_daily_sync_at(library: DirectionLibrary | None) -> datetime | None:
+    """下一次自动同步时间：cadence=daily 且已完成初始建库才有；否则 None。
+
+    P8a：节奏/水位线权威源在库（library.definition.cadence / library.ingest_state）。
+    """
+    from app.services.libraries import library_definition
+
+    if library is None:
+        return None
+    definition = library_definition(library)
+    state = library.ingest_state or {}
     if definition.get("cadence") != "daily" or not state.get("watermark"):
         return None
     now = datetime.now(UTC)
@@ -193,7 +200,9 @@ def next_daily_sync_at(project: Project) -> datetime | None:
 
 
 async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any]:
-    state = project.ingest_state or {}
+    # P8a：水位线/last_run 权威源在库（library.ingest_state）
+    library = await get_library_for_project(session, project.id)
+    state = (library.ingest_state if library else None) or {}
     last_run_raw = state.get("last_run") or None
     last_run: dict[str, Any] | None = None
     if isinstance(last_run_raw, dict) and last_run_raw.get("voyage_id"):
@@ -209,7 +218,7 @@ async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any
         "last_run": last_run,
         "paper_counts": await paper_counts(session, project.id),
         "running_voyage_id": running.id if running else None,
-        "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(project)) else None),
+        "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
     }
 
 
@@ -220,8 +229,12 @@ async def find_due_daily_projects(session: AsyncSession) -> list[Project]:
     )
     due: list[Project] = []
     for project in projects:
-        definition = project.definition or {}
-        state = project.ingest_state or {}
+        # P8a：节奏/水位线读起源库（project.definition 不再是权威源）
+        library = await get_library_for_project(session, project.id)
+        if library is None:
+            continue
+        definition = library_definition(library)
+        state = library.ingest_state or {}
         if definition.get("cadence") != "daily" or not state.get("watermark"):
             continue
         if await find_running_ingest(session, project.id) is not None:

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -33,11 +33,34 @@ def implicit_library_for(project: Project) -> DirectionLibrary:
         statement=definition.get("statement"),
         rubric=definition.get("rubric"),
         anchors=definition.get("anchor_papers"),
+        definition=definition or None,  # P8a：库承载完整收录配置
         ingest_state=project.ingest_state,
         cadence=definition.get("cadence"),
         created_by=project.owner_id,
         project_id=project.id,
     )
+
+
+def library_definition(library: DirectionLibrary) -> dict[str, Any]:
+    """库的收录配置（P8a 权威源）：definition JSON；为空时回退标量列拼一份兼容视图。
+
+    ingest（检索/扩展/打分/编译）与 build_relevance_context 一律经此取 statement/
+    rubric/anchor_papers/keywords/questions/cadence，不再读起源课题 project.definition。
+    """
+    definition = library.definition if isinstance(library.definition, dict) else {}
+    if definition:
+        return definition
+    # 回退：老库或迁移前建的库 definition 为空 → 用标量列拼最小可用配置。
+    fallback: dict[str, Any] = {}
+    if library.statement:
+        fallback["statement"] = library.statement
+    if library.rubric:
+        fallback["rubric"] = library.rubric
+    if library.anchors:
+        fallback["anchor_papers"] = library.anchors
+    if library.cadence:
+        fallback["cadence"] = library.cadence
+    return fallback
 
 
 async def get_library_for_project(
@@ -312,10 +335,20 @@ async def _my_project_ids(session: AsyncSession, user_id: uuid.UUID) -> set[uuid
     return set(rows.scalars().all())
 
 
+async def _my_linked_library_ids(session: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    """被我参与的课题关联的库 id（P7：is_mine 按关联判定，而非起源课题）。"""
+    rows = await session.execute(
+        select(TopicSourceLibrary.library_id)
+        .join(ProjectMember, ProjectMember.project_id == TopicSourceLibrary.topic_id)
+        .where(ProjectMember.user_id == user_id)
+    )
+    return set(rows.scalars().all())
+
+
 def _overview_dict(
     library: DirectionLibrary,
     *,
-    my_projects: set[uuid.UUID],
+    my_linked: set[uuid.UUID],
     can_manage: bool,
     paper_count: int,
     concept_count: int,
@@ -327,8 +360,9 @@ def _overview_dict(
         "statement": library.statement,
         "cadence": library.cadence,
         "monthly_budget": library.monthly_budget,
+        "definition": library_definition(library),
         "project_id": library.project_id,
-        "is_mine": library.project_id is not None and library.project_id in my_projects,
+        "is_mine": library.id in my_linked,
         "can_manage": can_manage,
         "paper_count": paper_count,
         "concept_count": concept_count,
@@ -350,11 +384,12 @@ async def list_libraries_overview(session: AsyncSession, *, user: User) -> list[
         session, [lib.id for lib in libraries]
     )
     my_projects = await _my_project_ids(session, user.id)
+    my_linked = await _my_linked_library_ids(session, user.id)
     my_curated = await _my_curated_library_ids(session, user.id)
     return [
         _overview_dict(
             lib,
-            my_projects=my_projects,
+            my_linked=my_linked,
             can_manage=(
                 user.role == "admin"
                 or lib.id in my_curated
@@ -373,10 +408,10 @@ async def library_overview(
 ) -> dict[str, Any]:
     """单库详情概要（同列表口径）。"""
     paper_counts, last_compiled, concept_counts = await _library_stats(session, [library.id])
-    my_projects = await _my_project_ids(session, user.id)
+    my_linked = await _my_linked_library_ids(session, user.id)
     return _overview_dict(
         library,
-        my_projects=my_projects,
+        my_linked=my_linked,
         can_manage=await can_manage_library(session, user=user, library=library),
         paper_count=paper_counts.get(library.id, 0),
         concept_count=concept_counts.get(library.id, 0),
@@ -392,11 +427,12 @@ async def source_libraries_overview(
     ids = [lib.id for lib in libraries]
     paper_counts, last_compiled, concept_counts = await _library_stats(session, ids)
     my_projects = await _my_project_ids(session, user.id)
+    my_linked = await _my_linked_library_ids(session, user.id)
     my_curated = await _my_curated_library_ids(session, user.id)
     return [
         _overview_dict(
             lib,
-            my_projects=my_projects,
+            my_linked=my_linked,
             can_manage=(
                 user.role == "admin"
                 or lib.id in my_curated
@@ -418,6 +454,7 @@ async def create_library(
     rubric: Any | None = None,
     anchors: list[Any] | None = None,
     cadence: str | None = None,
+    keywords: dict[str, Any] | None = None,
     monthly_budget: int | None = None,
     created_by: uuid.UUID,
 ) -> DirectionLibrary:
@@ -425,12 +462,24 @@ async def create_library(
 
     flush + refresh，不 commit（调用方 api 层负责事务收尾）。
     """
+    definition: dict[str, Any] = {}
+    if statement:
+        definition["statement"] = statement
+    if rubric:
+        definition["rubric"] = rubric
+    if anchors:
+        definition["anchor_papers"] = anchors
+    if cadence:
+        definition["cadence"] = cadence
+    if keywords:
+        definition["keywords"] = keywords
     library = DirectionLibrary(
         name=name,
         statement=statement,
         rubric=rubric,
         anchors=anchors,
         cadence=cadence,
+        definition=definition or None,  # P8a：独立库同样以 definition 为收录配置权威源
         monthly_budget=monthly_budget,
         created_by=created_by,
         project_id=None,
@@ -548,42 +597,62 @@ async def set_curators(
     return await list_curators(session, library.id)
 
 
-# 库定义可编辑字段 → project.definition 写回键（库为权威，写时同步保持 ingest 兼容：
-# search/snowball/score/watermark 仍从 project.definition / ingest_state 取数）
-_DEFINITION_SYNC_KEYS = {
+# PATCH 顶层便捷字段 → library.definition 的键（收录配置权威源）。statement/cadence/
+# rubric 同名，anchors→anchor_papers（与原 project.definition 结构一致，ingest 直接读）。
+_CONFIG_TO_DEFINITION = {
     "statement": "statement",
+    "cadence": "cadence",
     "rubric": "rubric",
     "anchors": "anchor_papers",
+    "keywords": "keywords",
+    "goals": "goals",
+    "in_scope": "in_scope",
+    "out_of_scope": "out_of_scope",
+    "questions": "questions",
+}
+# definition 键 → 展示镜像标量列（overview/detail 读列，编辑时同步，避免同库内漂移）。
+_DEFINITION_TO_COLUMN = {
+    "statement": "statement",
     "cadence": "cadence",
+    "rubric": "rubric",
+    "anchor_papers": "anchors",
 }
 
 
 async def update_library(
     session: AsyncSession, *, library: DirectionLibrary, fields: dict[str, Any]
 ) -> DirectionLibrary:
-    """编辑库定义（name/statement/cadence/monthly_budget/rubric/anchors，显式传 null 可清空）。
+    """编辑库定义（显式传 null 可清空）。P8a：库是收录配置的唯一权威源。
 
-    过渡期隐式库（project_id 非空）双源并存：ingest 读 project.definition——
-    这里以库为权威，写入时把 statement/rubric/anchors/cadence 同步回
-    project.definition 对应键（name 同步 project.name），两边不再漂移。
+    - name / monthly_budget 落标量列；
+    - statement/cadence/rubric/anchors/keywords/questions/goals/scope 等收录配置写入
+      library.definition（ingest 从这里取数），并把有对应标量列的键镜像回列供展示；
+    - 允许整体传入 ``definition`` 一次性替换。
+    不再写回起源课题 project.definition（P8a 拆掉 P6 写回同步）。
     """
-    for key, value in fields.items():
-        if key == "name" and not value:
-            continue  # name 非空约束：显式 null/空串视为不改名
-        setattr(library, key, value)
-    if library.project_id is not None:
-        project = await session.get(Project, library.project_id)
-        if project is not None:
-            if fields.get("name"):
-                project.name = fields["name"]
-            sync = {k: v for k, v in fields.items() if k in _DEFINITION_SYNC_KEYS}
-            if sync:
-                definition = (
-                    dict(project.definition) if isinstance(project.definition, dict) else {}
-                )
-                for key, value in sync.items():
-                    definition[_DEFINITION_SYNC_KEYS[key]] = value
-                project.definition = definition
+    if fields.get("name"):
+        library.name = fields["name"]  # name 非空约束：显式 null/空串视为不改名
+    if "monthly_budget" in fields:
+        library.monthly_budget = fields["monthly_budget"]
+
+    config_keys = [k for k in fields if k in _CONFIG_TO_DEFINITION]
+    if "definition" in fields or config_keys:
+        definition = dict(library.definition) if isinstance(library.definition, dict) else {}
+        if isinstance(fields.get("definition"), dict):
+            definition = dict(fields["definition"])
+        for key in config_keys:
+            definition[_CONFIG_TO_DEFINITION[key]] = fields[key]
+        library.definition = definition or None
+        # 只镜像本次触及的键对应的标量列，不动未触及列。
+        touched_defn_keys = set()
+        if isinstance(fields.get("definition"), dict):
+            touched_defn_keys |= set(_DEFINITION_TO_COLUMN) & set(definition)
+        touched_defn_keys |= {_CONFIG_TO_DEFINITION[k] for k in config_keys}
+        for defn_key in touched_defn_keys:
+            col = _DEFINITION_TO_COLUMN.get(defn_key)
+            if col:
+                setattr(library, col, definition.get(defn_key))
+
     await session.commit()
     await session.refresh(library)
     return library

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -18,7 +18,6 @@ from app.core.llm.router import LLMRouter, get_llm_router
 from app.models.base import utcnow
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
-from app.models.project import Project
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +43,13 @@ def _extract_json(content: str) -> Any:
     return json.loads(content[start : end + 1])
 
 
-def build_relevance_context(project: Project) -> str:
-    """按项目 definition 组打分 context；rubric / questions 缺失时只用 statement。"""
-    definition = project.definition if isinstance(project.definition, dict) else {}
+def build_relevance_context(definition: dict[str, Any] | None, name: str) -> str:
+    """按库 definition 组打分 context（P8a：库为收录配置权威源）；rubric / questions
+    缺失时只用 statement。``name`` 是 statement 缺失时的兜底方向名（库名）。"""
+    definition = definition if isinstance(definition, dict) else {}
     rubric = definition.get("rubric") or []
     questions = definition.get("questions") or []
-    statement = definition.get("statement") or project.name
+    statement = definition.get("statement") or name
     lines = [f"研究方向：{statement}"]
     if rubric:
         lines.append(f"评分标准（rubric）：{json.dumps(rubric, ensure_ascii=False)}")
@@ -99,22 +99,31 @@ async def score_added_paper_best_effort(
     session: AsyncSession,
     paper: Paper,
     membership: LibraryPaper,
-    project: Project,
     *,
+    project_id: uuid.UUID | None = None,
     user_id: uuid.UUID | None = None,
 ) -> None:
     """手动添加后的顺带打分（best-effort）：成功则 commit 分数，失败只记 warning。
 
+    P8a：对照该论文所属库（membership.library_id）的 definition 打分，不再读起源课题。
     不改成员行 status（手动添加 = 人工纳入，分低也保持 included）；LLM 失败/超时时
     回滚未落库的字段改动，论文本身照常保留。
     """
+    from app.models.library_direction import DirectionLibrary
+    from app.services.libraries import library_definition
+
     try:
+        library = await session.get(DirectionLibrary, membership.library_id)
+        context_text = build_relevance_context(
+            library_definition(library) if library else None,
+            library.name if library else paper.title,
+        )
         await score_paper_relevance(
             paper,
             membership,
-            context_text=build_relevance_context(project),
+            context_text=context_text,
             user_id=user_id,
-            project_id=project.id,
+            project_id=project_id,
         )
         await session.commit()
     except Exception:  # noqa: BLE001 — 顺带增值，失败不影响添加本身

--- a/src/backend/tests/test_library_governance.py
+++ b/src/backend/tests/test_library_governance.py
@@ -1,4 +1,4 @@
-"""P6 库治理（任务 1）：库级写权限助手、策展人任命（仅 admin）、库定义编辑与写回同步。"""
+"""P6/P8a 库治理：库级写权限助手、策展人任命（仅 admin）、库定义编辑（收录配置权威源）。"""
 
 import uuid
 
@@ -120,7 +120,7 @@ async def test_curator_appointment_admin_only(client):
     assert resp.json() == []
 
 
-async def test_patch_library_permission_and_definition_sync(client):
+async def test_patch_library_permission_and_definition_authority(client):
     admin, _owner, curator, stranger, project_id, library_id = await _setup(client)
 
     # 无关用户 403
@@ -147,19 +147,24 @@ async def test_patch_library_permission_and_definition_sync(client):
     assert body["name"] == "稀疏注意力"
     assert body["monthly_budget"] == 500000
     assert body["can_manage"] is True
+    # 响应带出收录配置全量（供「收录设置」回填）
+    assert body["definition"]["rubric"] == ["和稀疏注意力直接相关"]
+    assert body["definition"]["anchor_papers"] == [{"arxiv_id": "2404.00001"}]
 
-    # 库为权威，写时同步回 project.name / project.definition（保持 ingest 兼容）
+    # P8a：库是收录配置唯一权威源——写入 library.definition，不再写回起源课题
     async with get_sessionmaker()() as session:
-        project = await session.get(Project, uuid.UUID(project_id))
-        assert project.name == "稀疏注意力"
-        definition = project.definition
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert library.name == "稀疏注意力"
+        assert library.monthly_budget == 500000
+        assert library.statement == "稀疏注意力机制的效率研究"
+        definition = library.definition
         assert definition["statement"] == "稀疏注意力机制的效率研究"
         assert definition["rubric"] == ["和稀疏注意力直接相关"]
         assert definition["anchor_papers"] == [{"arxiv_id": "2404.00001"}]
         assert definition["cadence"] == "daily"
-        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
-        assert library.monthly_budget == 500000
-        assert library.statement == "稀疏注意力机制的效率研究"
+        # 起源课题 project.definition 不再被写回同步
+        project = await session.get(Project, uuid.UUID(project_id))
+        assert (project.definition or {}).get("rubric") != ["和稀疏注意力直接相关"]
 
     # 显式传 null 清空预算
     resp = await client.patch(

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,7 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "67d18892a6ce"  # 课题 × 文献库关联 + 库生命周期独立（P7 Step 1，本分支最新）
+HEAD_REVISION = "b3e9c1f47a20"  # direction_libraries.definition 收录配置权威（P8a）
 PREV_REVISION = "3f770d85dca9"  # LLM 用量按方向库归因（P6）
 
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -10,7 +10,7 @@ from alembic import command
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
 HEAD_REVISION = "b3e9c1f47a20"  # direction_libraries.definition 收录配置权威（P8a）
-PREV_REVISION = "3f770d85dca9"  # LLM 用量按方向库归因（P6）
+PREV_REVISION = "67d18892a6ce"  # 课题 × 文献库关联 + 库生命周期独立（P7 Step 1）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -230,11 +230,11 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "topic_source_libraries" in columns["_tables"]
     assert columns["topic_source_libraries"] == {"topic_id", "library_id", "created_at"}
 
-    # 最新 revision 可往返（downgrade 删 library_id 归因列，其余结构不动）
+    # 最新 revision 可往返（downgrade 删 direction_libraries.definition，其余结构不动）
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "topic_source_libraries" not in columns["_tables"]
+    assert "topic_source_libraries" in columns["_tables"]  # P7 表仍在（回退止于 P7）
     assert "library_id" in columns["llm_usage"]
     assert "library_id" in columns["llm_call_logs"]
     # P5b 拆分结构不受影响：笔记/划线仍无 project_id

--- a/src/backend/tests/test_wiki_api.py
+++ b/src/backend/tests/test_wiki_api.py
@@ -501,12 +501,13 @@ async def test_ingest_state_next_sync_at(client):
     assert resp.json()["next_sync_at"] is None  # 未 bootstrap（无水位线）
 
     from app.core.db import get_sessionmaker
-    from app.models.project import Project
+    from app.services.libraries import get_library_for_project
 
     async with get_sessionmaker()() as session:
-        project = await session.get(Project, uuid.UUID(project_id))
-        project.definition = {"cadence": "daily"}
-        project.ingest_state = {"watermark": "2026-07-15T00:00:00+00:00"}
+        # P8a：节奏/水位线权威源在库（library.definition.cadence / library.ingest_state）
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        library.definition = {"cadence": "daily"}
+        library.ingest_state = {"watermark": "2026-07-15T00:00:00+00:00"}
         await session.commit()
 
     resp = await client.get(f"/api/projects/{project_id}/ingest/state", headers=headers)

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -21,7 +21,6 @@ from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.llm_config import LLMUsage
 from app.models.paper import EMBEDDING_DIM, paper_concepts
-from app.models.project import Project
 from app.services import ingest as ingest_service
 from app.services.literature import (
     ArxivClient,
@@ -342,9 +341,12 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
         )
         assert links == 6  # 3 篇编译论文 × 2 概念
 
-        project = await session.get(Project, uuid.UUID(project_id))
-        assert project.ingest_state["watermark"]
-        assert project.ingest_state["last_run"]["voyage_id"] == run_id
+        # P8a：水位线权威源在库（library.ingest_state），不再写起源课题
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        assert library.ingest_state["watermark"]
+        assert library.ingest_state["last_run"]["voyage_id"] == run_id
 
         activity_kinds = {
             a.kind

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -17,7 +17,7 @@ import { useLibraries, libraryPath } from './hooks';
 /* ============================================================
    /libraries — 文献库列表（实验室区，P5c）
    卡片流：库名 / 方向陈述 / 论文·概念数 / 最近更新；
-   「我的课题的库」有标识；点击进 /libraries/:id 详情。
+   「我的课题关联的库」有标识；点击进 /libraries/:id 详情。
    平台管理员可在此新建独立共享文献库（与任何课题解耦）。
    ============================================================ */
 
@@ -66,7 +66,7 @@ function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: ()
             </span>
             {lib.is_mine && (
               <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', flexShrink: 0 }}>
-                {tr('我的课题', 'My topic')}
+                {tr('我在用', 'In use')}
               </span>
             )}
           </div>
@@ -243,7 +243,7 @@ export function LibrariesPage() {
   const canCreate = isAdmin(me);
   const [createOpen, setCreateOpen] = useState(false);
   const libraries = data ?? [];
-  // 我的课题的库排前面，其余按名称
+  // 我的课题关联的库排前面，其余按名称
   const sorted = [...libraries].sort(
     (a, b) => Number(b.is_mine) - Number(a.is_mine) || a.name.localeCompare(b.name),
   );

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -60,7 +60,6 @@ export function LibraryDetailPage() {
     );
   }
 
-  const isMember = lib.is_mine && !!lib.project_id;
   const canManage = lib.can_manage && !!lib.project_id;
 
   return (
@@ -76,12 +75,6 @@ export function LibraryDetailPage() {
               <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
               {tr('全部文献库', 'All libraries')}
             </button>
-            {isMember && (
-              <button className="btn btn-ghost" onClick={() => navigate(`/projects/${lib.project_id}`)}>
-                <Icon name="compass" size={14} />
-                {tr('课题设置', 'Topic settings')}
-              </button>
-            )}
           </>
         }
       />

--- a/src/frontend/src/features/libraries/LibraryPicker.tsx
+++ b/src/frontend/src/features/libraries/LibraryPicker.tsx
@@ -61,7 +61,7 @@ export function LibraryPicker({
                 <span style={{ fontSize: 13.5, fontWeight: 650 }}>{lib.name}</span>
                 {lib.is_mine && (
                   <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
-                    {tr('我的课题', 'My topic')}
+                    {tr('我在用', 'In use')}
                   </span>
                 )}
               </div>

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { StatusPill } from '../../components/ui/StatusPill';
-import { Segmented } from '../../components/ui/Segmented';
 import { Modal } from '../../components/ui/Modal';
 import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
@@ -15,8 +14,9 @@ import { useLibraries } from '../libraries/hooks';
 import { LibraryPicker } from '../libraries/LibraryPicker';
 
 /* ============================================================
-   /projects/:id — 方向详情：definition 各节卡片化展示 + 就地编辑
-   （name/statement/goals/scope/questions/cadence）+ 成员管理。
+   /projects/:id — 课题设置：只留真正的课题属性
+   （名称 / 课题定义 statement / 关联文献库 / 成员·邀请 / 删除课题）。
+   收录配置（rubric/锚点/关键词/arXiv 分类/节奏）已迁到文献库「收录设置」（P8）。
    ============================================================ */
 
 function SectionCard({ icon, zh, en, action, children }: {
@@ -81,59 +81,6 @@ function EditableText({ value, placeholder, onSave, saving }: {
     </div>
   );
 }
-
-/** 可编辑字符串列表（view = 编号列表；edit = 一行一条 textarea）。 */
-function EditableList({ items, placeholder, onSave, saving }: {
-  items: string[];
-  placeholder: string;
-  onSave: (items: string[]) => void;
-  saving: boolean;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState('');
-  if (!editing) {
-    return (
-      <div className="row gap10" style={{ alignItems: 'flex-start' }}>
-        <div style={{ flex: 1 }}>
-          {items.length ? (
-            <ol style={{ margin: 0, paddingLeft: 20, fontSize: 13, lineHeight: 1.7, color: 'var(--text)' }}>
-              {items.map((g, i) => (
-                <li key={i}>{g}</li>
-              ))}
-            </ol>
-          ) : (
-            <div style={{ fontSize: 13, color: 'var(--text-4)' }}>{placeholder}</div>
-          )}
-        </div>
-        <EditButton editing={false} onClick={() => { setDraft(items.join('\n')); setEditing(true); }} />
-      </div>
-    );
-  }
-  return (
-    <div className="col gap8">
-      <textarea className="textarea" rows={Math.max(4, items.length + 1)} value={draft}
-        onChange={(e) => setDraft(e.target.value)} placeholder={tr('一行一条', 'One item per line')} />
-      <div className="field-hint">{tr('一行一条', 'One item per line')}</div>
-      <div className="row gap8">
-        <button className="btn btn-primary sm" disabled={saving}
-          onClick={() => {
-            onSave(draft.split('\n').map((x) => x.trim()).filter(Boolean));
-            setEditing(false);
-          }}>
-          {tr('保存', 'Save')}
-        </button>
-        <button className="btn btn-ghost sm" onClick={() => setEditing(false)}>{tr('取消', 'Cancel')}</button>
-      </div>
-    </div>
-  );
-}
-
-const CADENCES = [
-  { v: 'daily', zh: '每日', en: 'Daily' },
-  { v: 'weekly', zh: '每周', en: 'Weekly' },
-  { v: 'manual', zh: '手动', en: 'Manual' },
-] as const;
-type Cadence = (typeof CADENCES)[number]['v'];
 
 export function ProjectDetailPage() {
   const { id = '' } = useParams();
@@ -289,9 +236,6 @@ export function ProjectDetailPage() {
   const patchDef = (partial: Partial<ProjectDefinition>) =>
     patchMutation.mutate({ definition: { ...def, ...partial } });
 
-  const kw = def.keywords ?? {};
-  const synonymEntries = Object.entries(kw.synonyms ?? {});
-
   return (
     <div className="page fadeup">
       {/* 页头 */}
@@ -365,7 +309,7 @@ export function ProjectDetailPage() {
         }
       >
         <div style={{ fontSize: 13, lineHeight: 1.7, color: 'var(--text-2)' }}>
-          {tr('删除后，该课题下的', 'Deleting this topic also removes its ')}<b>{tr('论文库、概念库、笔记、AI 任务记录、想法与实验', 'paper library, concepts, notes, AI task history, ideas and experiments')}</b>{tr('都会一并删除，且', ' — and this ')}<b>{tr('无法恢复', 'cannot be undone')}</b>{tr('。确定要删除 “', '. Delete “')}{project.name}{tr('” 吗？', '”?')}
+          {tr('删除课题会移除该课题的', 'Deleting this topic removes its ')}<b>{tr('想法、实验、任务记录与文献库关联', 'ideas, experiments, task history and library links')}</b>{tr('；', '; ')}<b>{tr('文献库与论文本身保留，不受影响', 'the libraries and papers themselves are kept and unaffected')}</b>{tr('。此操作', '. This ')}<b>{tr('无法恢复', 'cannot be undone')}</b>{tr('。确定要删除 “', '. Delete “')}{project.name}{tr('” 吗？', '”?')}
         </div>
       </Modal>
 
@@ -438,129 +382,6 @@ export function ProjectDetailPage() {
               ))}
             </div>
           )}
-        </SectionCard>
-
-        {/* 目标与范围 */}
-        <div className="row gap16" style={{ alignItems: 'stretch' }}>
-          <div style={{ flex: 1.2, minWidth: 0 }}>
-            <SectionCard icon="chart" zh="研究目标" en="Goals">
-              <EditableList items={def.goals ?? []} placeholder={tr('尚未填写目标', 'No goals yet')}
-                onSave={(items) => patchDef({ goals: items })} saving={saving} />
-            </SectionCard>
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <SectionCard icon="scale" zh="范围" en="Scope">
-              <div className="field-label" style={{ marginBottom: 6 }}>{tr('范围内', 'In scope')}</div>
-              <EditableList items={def.in_scope ?? []} placeholder="—"
-                onSave={(items) => patchDef({ in_scope: items })} saving={saving} />
-              <div className="hr" style={{ margin: '12px 0' }} />
-              <div className="field-label" style={{ marginBottom: 6 }}>{tr('范围外', 'Out of scope')}</div>
-              <EditableList items={def.out_of_scope ?? []} placeholder="—"
-                onSave={(items) => patchDef({ out_of_scope: items })} saving={saving} />
-            </SectionCard>
-          </div>
-        </div>
-
-        {/* 研究问题 */}
-        <SectionCard icon="bulb" zh="研究问题" en="Questions">
-          <EditableList items={def.questions ?? []} placeholder={tr('尚未填写研究问题', 'No research questions yet')}
-            onSave={(items) => patchDef({ questions: items })} saving={saving} />
-        </SectionCard>
-
-        {/* Rubric */}
-        <SectionCard icon="scale" zh="打分 Rubric" en="Scoring rubric">
-          {def.rubric?.length ? (
-            <table className="table">
-              <thead>
-                <tr>
-                  <th style={{ width: 140 }}>{tr('维度', 'Dimension')}</th>
-                  <th>{tr('打分标准', 'Criteria')}</th>
-                  <th style={{ width: 70, textAlign: 'right' }}>{tr('权重', 'Weight')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {def.rubric.map((r, i) => (
-                  <tr key={i}>
-                    <td style={{ fontWeight: 600 }}>{r.name}</td>
-                    <td style={{ color: 'var(--text-2)' }}>{r.description}</td>
-                    <td className="mono" style={{ textAlign: 'right' }}>{r.weight}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <div style={{ fontSize: 13, color: 'var(--text-4)' }}>{tr('尚未定义打分维度', 'No scoring dimensions yet')}</div>
-          )}
-        </SectionCard>
-
-        {/* 锚点论文 */}
-        <SectionCard icon="book" zh="锚点论文" en="Anchor papers">
-          {def.anchor_papers?.length ? (
-            <div className="col gap10">
-              {def.anchor_papers.map((a, i) => (
-                <div key={i} style={{ padding: '10px 12px', background: 'var(--surface-2)', borderRadius: 10 }}>
-                  <div className="row gap8">
-                    <span style={{ fontSize: 13, fontWeight: 600, flex: 1 }}>{a.title}</span>
-                    {a.arxiv_id && <span className="tag mono">{a.arxiv_id}</span>}
-                    {a.url && (
-                      <a href={a.url} target="_blank" rel="noreferrer" className="icon-btn"
-                        style={{ width: 24, height: 24, border: 'none', background: 'transparent' }} title={a.url}>
-                        <Icon name="link" size={13} />
-                      </a>
-                    )}
-                  </div>
-                  {a.reason && <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 4, lineHeight: 1.5 }}>{a.reason}</div>}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div style={{ fontSize: 13, color: 'var(--text-4)' }}>{tr('尚未添加锚点论文', 'No anchor papers yet')}</div>
-          )}
-        </SectionCard>
-
-        {/* 关键词 */}
-        <SectionCard icon="search" zh="关键词" en="Keywords">
-          <div className="col gap12">
-            <div>
-              <div className="field-label" style={{ marginBottom: 6 }}>{tr('arXiv 分类', 'arXiv categories')}</div>
-              <div className="row gap6 wrap">
-                {kw.arxiv_categories?.length
-                  ? kw.arxiv_categories.map((c) => <span key={c} className="tag mono">{c}</span>)
-                  : <span style={{ fontSize: 12.5, color: 'var(--text-4)' }}>—</span>}
-              </div>
-            </div>
-            <div>
-              <div className="field-label" style={{ marginBottom: 6 }}>{tr('include 词', 'Include terms')}</div>
-              <div className="row gap6 wrap">
-                {kw.include?.length
-                  ? kw.include.map((c) => <span key={c} className="tag">{c}</span>)
-                  : <span style={{ fontSize: 12.5, color: 'var(--text-4)' }}>—</span>}
-              </div>
-            </div>
-            {synonymEntries.length > 0 && (
-              <div>
-                <div className="field-label" style={{ marginBottom: 6 }}>{tr('同义词映射', 'Synonyms')}</div>
-                <div className="col gap6">
-                  {synonymEntries.map(([term, syns]) => (
-                    <div key={term} className="row gap8" style={{ fontSize: 12.5 }}>
-                      <span className="tag">{term}</span>
-                      <span style={{ color: 'var(--text-4)' }}>→</span>
-                      <span style={{ color: 'var(--text-2)' }}>{syns.join(tr('，', ', '))}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </SectionCard>
-
-        {/* 节奏 */}
-        <SectionCard icon="clock" zh="运行节奏" en="Cadence">
-          <Segmented
-            options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
-            value={(CADENCES.some((c) => c.v === def.cadence) ? def.cadence : 'daily') as Cadence}
-            onChange={(v) => patchDef({ cadence: v })}
-          />
         </SectionCard>
 
         {/* 成员 */}

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
-import { api, isAdmin, type DirectionLibraryDetail, type DuplicateCandidatePaper } from '../../lib/api';
+import { api, isAdmin, type DirectionLibraryDetail, type DuplicateCandidatePaper, type RubricDimension } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 
 /* ============================================================
@@ -31,6 +31,7 @@ export function GovernanceTab({ libraryId }: { libraryId: string }) {
   return (
     <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
       {lib && <LibraryInfoCard lib={lib} />}
+      {lib && <InclusionSettingsCard lib={lib} />}
       <BudgetCard libraryId={libraryId} />
       <CuratorsCard libraryId={libraryId} canEdit={admin} />
       <DuplicatesCard libraryId={libraryId} />
@@ -314,6 +315,137 @@ function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
         {budgetInvalid && (
           <div style={{ color: 'var(--danger-tx)', fontSize: 12 }}>
             {tr('预算需为不小于 0 的数字', 'Budget must be a number ≥ 0')}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* —— 收录设置（P8：库为收录配置权威源，ingest 按此检索/打分） —— */
+
+const QUICK_CATEGORIES = ['cs.CL', 'cs.AI', 'cs.LG', 'cs.CV', 'cs.MA', 'stat.ML'];
+
+function InclusionSettingsCard({ lib }: { lib: DirectionLibraryDetail }) {
+  const queryClient = useQueryClient();
+  const def = lib.definition ?? {};
+  const [categories, setCategories] = useState<string[]>(def.keywords?.arxiv_categories ?? []);
+  const [includeStr, setIncludeStr] = useState((def.keywords?.include ?? []).join(', '));
+  const [customCat, setCustomCat] = useState('');
+  const [rubric, setRubric] = useState<RubricDimension[]>(def.rubric ?? []);
+
+  useEffect(() => {
+    const d = lib.definition ?? {};
+    setCategories(d.keywords?.arxiv_categories ?? []);
+    setIncludeStr((d.keywords?.include ?? []).join(', '));
+    setRubric(d.rubric ?? []);
+  }, [lib]);
+
+  const includeTerms = includeStr.split(/[,，\n]/).map((x) => x.trim()).filter(Boolean);
+
+  function toggleCat(c: string) {
+    setCategories((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  }
+  function addCustomCat() {
+    const c = customCat.trim();
+    if (c && !categories.includes(c)) setCategories((prev) => [...prev, c]);
+    setCustomCat('');
+  }
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.updateLibrary(lib.id, {
+        keywords: {
+          ...(lib.definition?.keywords ?? {}),
+          arxiv_categories: categories,
+          include: includeTerms,
+        },
+        rubric: rubric.filter((r) => r.name.trim()),
+      }),
+    onSuccess: () => {
+      toast(tr('收录设置已保存', 'Inclusion settings saved'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library', lib.id] });
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+    },
+    onError: () => toast(tr('保存失败，请重试', 'Save failed, please retry'), 'error'),
+  });
+
+  return (
+    <section className="card" style={{ padding: 18 }}>
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 4 }}>
+        <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('收录设置', 'Inclusion settings')}</h3>
+        <button className="btn btn-primary sm" disabled={save.isPending} onClick={() => save.mutate()}>
+          {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+      <p className="muted" style={{ fontSize: 12, marginBottom: 14 }}>
+        {tr(
+          '文献追踪按这里的 arXiv 分类与关键词检索、按打分标准判定相关性；留空则用默认分类、只按方向说明打分。',
+          'Literature tracking searches by these arXiv categories and keywords and scores relevance against the rubric; leave empty to use default categories and statement-only scoring.',
+        )}
+      </p>
+
+      <div className="col gap6" style={{ marginBottom: 14 }}>
+        <span className="muted" style={{ fontSize: 12 }}>{tr('arXiv 分类', 'arXiv categories')}</span>
+        <div className="row gap6 wrap">
+          {[...new Set([...QUICK_CATEGORIES, ...categories])].map((c) => (
+            <button key={c} type="button" className={'chip mono' + (categories.includes(c) ? ' on' : '')} onClick={() => toggleCat(c)}>
+              {c}
+            </button>
+          ))}
+        </div>
+        <div className="row gap8" style={{ marginTop: 6 }}>
+          <input
+            className="input"
+            style={{ width: 170 }}
+            placeholder={tr('自定义分类，如 cs.IR', 'custom, e.g. cs.IR')}
+            value={customCat}
+            onChange={(e) => setCustomCat(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomCat(); } }}
+          />
+          <button className="btn btn-soft sm" onClick={addCustomCat} disabled={!customCat.trim()}>{tr('添加', 'Add')}</button>
+        </div>
+      </div>
+
+      <label className="col gap6" style={{ marginBottom: 14 }}>
+        <span className="muted" style={{ fontSize: 12 }}>{tr('检索关键词（逗号分隔）', 'Include terms (comma-separated)')}</span>
+        <textarea
+          className="input"
+          rows={2}
+          value={includeStr}
+          onChange={(e) => setIncludeStr(e.target.value)}
+          placeholder={tr('如 agent, tool use, planning', 'e.g. agent, tool use, planning')}
+        />
+      </label>
+
+      <div className="col gap6">
+        <div className="row" style={{ justifyContent: 'space-between' }}>
+          <span className="muted" style={{ fontSize: 12 }}>{tr('打分标准（rubric）', 'Scoring rubric')}</span>
+          <button className="btn btn-soft sm" onClick={() => setRubric([...rubric, { name: '', description: '', weight: 1 }])}>
+            <Icon name="plus" size={12} />
+            {tr('添加维度', 'Add dimension')}
+          </button>
+        </div>
+        {rubric.length === 0 ? (
+          <div className="muted" style={{ fontSize: 12.5 }}>
+            {tr('未设打分维度：只按方向说明判定相关性。', 'No dimensions — relevance is judged by the statement only.')}
+          </div>
+        ) : (
+          <div className="col gap8">
+            {rubric.map((r, i) => (
+              <div key={i} className="row gap8" style={{ alignItems: 'flex-start' }}>
+                <input className="input" style={{ width: 120 }} placeholder={tr('维度名', 'Name')} value={r.name}
+                  onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, name: e.target.value } : x)))} />
+                <input className="input" style={{ flex: 1 }} placeholder={tr('打分标准', 'Criteria')} value={r.description}
+                  onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, description: e.target.value } : x)))} />
+                <input className="input mono" style={{ width: 64 }} inputMode="decimal" value={String(r.weight)}
+                  onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, weight: Number(e.target.value) || 0 } : x)))} />
+                <button className="icon-btn" style={{ height: 38 }} title={tr('删除维度', 'Remove dimension')}
+                  onClick={() => setRubric(rubric.filter((_, j) => j !== i))}>
+                  <Icon name="trash" size={14} />
+                </button>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -821,6 +821,8 @@ export interface DirectionLibraryDetail extends DirectionLibrarySummary {
   cadence: string | null;
   /** 每月 AI 预算（token 数；null = 不限） */
   monthly_budget: number | null;
+  /** 收录配置全量（P8：库为权威源），供「收录设置」编辑 */
+  definition: ProjectDefinition | null;
 }
 
 /** 文献库管理员（后端叫 curator）。 */
@@ -2720,8 +2722,10 @@ export const api = {
       statement?: string | null;
       cadence?: string | null;
       monthly_budget?: number | null;
-      rubric?: unknown;
-      anchors?: unknown[] | null;
+      rubric?: RubricDimension[] | null;
+      anchors?: AnchorPaper[] | null;
+      keywords?: KeywordSpec | null;
+      questions?: string[] | null;
     },
   ): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>(`/libraries/${id}`, 'PATCH', input);


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P8, the completion of the library↔topic decoupling started in #18 (P7). Fixes the historical leftover the user flagged: 「课题设置」still contained the old 「方向设置」(rubric/anchors/keywords/arXiv categories) which, after decoupling, belong to the **library**, not the topic.

## What changed

**P8a — the library owns inclusion config, ingest reads it.** New `direction_libraries.definition` JSON column (migration `b3e9c1f47a20`), backfilled from each implicit library's origin-topic `project.definition`, plus the ingest watermark (`ingest_state`) copied onto the library. Ingest (`actions_wiki` search/snowball/score/fetch/watermark, `ingest.py` cadence/watermark, `relevance.py`) now reads `library.definition` / `library.ingest_state`; the P6 write-back to `project.definition` is removed — the library is the sole authority.

**P8b — edit inclusion config on the library.** `PATCH /libraries/{id}` writes the full config into `library.definition`; `DirectionLibraryDetail` exposes it. The library Governance tab gains an "Inclusion settings"（收录设置）editor for arXiv categories, include terms, and the scoring rubric.

**P8c — topic settings are now just topic attributes.** `ProjectDetailPage` keeps only name, one-line statement, linked libraries, members/invites, and delete — the six direction-config blocks (goals/scope/questions/rubric/anchors/keywords) are gone. The delete-topic warning is corrected to P7 semantics: deleting a topic removes its ideas/experiments/task history and library links, but **the libraries and papers themselves are kept**. Also folds in two small fixes from the review: `is_mine` badge is now association-based (linked to my topics, not origin), and the stale "课题设置" button is removed from the library page.

## Validation

Migration verified on the dev database: all 4 libraries have a populated `definition` (rubric/keywords/statement) and watermark, backfilled correctly from their origin topics. ruff clean; `tsc --noEmit` and `npm run build` pass; all changed backend modules import; single migration head `b3e9c1f47a20`.

⚠️ **Full pytest could not run this session** — the environment's PyPI access was down (`pip install .[dev]` repeatedly failed on dropped connections). The first partial run before the network degraded showed 41 affected tests passing with only the expected library-authority failures, which were then fixed. **Please run `pytest -q` once the network recovers to confirm the 531 baseline before merging.**

## Deferred (documented follow-ups)

- Independent-library (`project_id = NULL`) management **workbench** (nullable-`pid` `WikiWorkbench`) and **ingest triggering** (needs `VoyageRun` library-keying — a real engine change). Config for independent libraries is API-editable today but lacks the full UI.
- Creation wizard still collects inclusion config (now seeds the implicit library, non-authoritative on the topic).
- P8d: implicit-library auto-create kept as a safe fallback; `project.definition` column retained.