### PR TITLE
fix(feedback): synthesize a locatable issue title when the feedback title is uninformative

### DIFF
--- a/src/backend/app/services/feedback.py
+++ b/src/backend/app/services/feedback.py
@@ -280,6 +280,31 @@ def _extract_json(text: str) -> dict[str, Any]:
     return json.loads(m.group(0))
 
 
+# 回退草稿标题：原标题短于此视为信息量不足（如 "无 token"），改用正文摘要 + 模块定位
+_MIN_TITLE_LEN = 8
+
+
+def _concise_summary(feedback: Feedback) -> str:
+    """从反馈正文提炼一句话（首个非空行，去掉列表/引用标记，压到 ~80 字）。"""
+    for line in (feedback.body or "").splitlines():
+        cleaned = line.strip().lstrip("-*#> ").strip()
+        if cleaned:
+            return cleaned[:80]
+    return ""
+
+
+def _fallback_title_core(feedback: Feedback) -> str:
+    """回退草稿标题主体：带上模块/路由定位；原标题信息量不足（空/过短，如
+    "无 token"）时改用正文首句，避免无意义标题直接成为 issue 标题。"""
+    scope = feedback.module or module_from_route(feedback.route)
+    raw = (feedback.title or "").strip()
+    if len(raw) >= _MIN_TITLE_LEN:
+        core = raw
+    else:
+        core = _concise_summary(feedback) or raw or "user-reported issue"
+    return f"[{scope}] {core}" if scope else core
+
+
 def _fallback_draft(feedback: Feedback, template: dict[str, Any]) -> dict[str, Any]:
     """LLM 不可用时的规则草稿：把原始反馈塞进模板骨架。"""
     ctx = feedback.context or {}
@@ -294,9 +319,9 @@ def _fallback_draft(feedback: Feedback, template: dict[str, Any]) -> dict[str, A
         f"- route: {feedback.route or '?'}",
         f"- version: {ctx.get('version', '?')} · env: {ctx.get('env', '?')}",
     ]
-    title = feedback.title
-    if not title.lower().startswith(template["title_prefix"].strip().rstrip(":")):
-        title = template["title_prefix"] + title
+    core = _fallback_title_core(feedback)
+    prefix = template["title_prefix"]
+    title = core if core.lower().startswith(prefix.strip().rstrip(":").lower()) else prefix + core
     return {"title": title[:255], "body": "\n".join(lines), "labels": list(template["labels"])}
 
 

--- a/src/backend/tests/test_feedback.py
+++ b/src/backend/tests/test_feedback.py
@@ -130,6 +130,34 @@ async def test_generate_draft_follows_template(client):
     assert "bug" in draft["labels"]
 
 
+async def test_fallback_draft_replaces_uninformative_title(client):
+    """信息量不足的反馈标题（如 "无 token"）在规则回退草稿里不应直接成为 issue 标题：
+    改用正文首句 + 模块定位（fake provider 下 generate_issue_draft 走规则回退）。"""
+    admin = await register_and_login(client, email="admin@example.com")
+    fb = (
+        await client.post(
+            "/api/feedback",
+            json={
+                "title": "无 token",
+                "type": "task",
+                "body": "点生成方案报错，提示没有可用的模型 token",
+                "route": "/wiki",
+            },
+            headers={"Authorization": f"Bearer {admin}"},
+        )
+    ).json()
+    draft = (
+        await client.post(
+            f"/api/admin/feedback/{fb['id']}/draft",
+            headers={"Authorization": f"Bearer {admin}"},
+        )
+    ).json()
+    assert draft["title"].startswith("task: ")  # 模板前缀保留
+    assert draft["title"] != "task: 无 token"  # 不再原样透传无意义标题
+    assert "[wiki]" in draft["title"]  # 带上模块定位
+    assert "没有可用的模型 token" in draft["title"]  # 用正文首句合成
+
+
 async def test_create_issue_mocked_then_conflict(client, monkeypatch):
     admin = await register_and_login(client, email="admin@example.com")
     aheaders = {"Authorization": f"Bearer {admin}"}


### PR DESCRIPTION
## Problem

The in-app **feedback → GitHub issue** pipeline (`services/feedback.py`) drafts an issue via an LLM and, when that route is unavailable, falls back to a rule-based draft. The fallback prefixed the **raw feedback title** verbatim, so a low-signal title like `无 token` became the issue title `task: 无 token`. Several such issues showed up in the tracker.

(The `无 token` reports themselves point to an unconfigured LLM route — a separate follow-up — but junk titles should never reach GitHub regardless.)

## Change

In `_fallback_draft`, when the feedback title is empty or too short (`< 8` chars), synthesize a locatable title instead of passing it through:

- `[<module/route>] <first line of the body>`, or a generic `user-reported issue` when there's no body;
- informative titles are kept as-is, but still scoped with `[<module>]` for triage;
- also fixed a latent case-sensitivity bug in the template-prefix check.

Examples (rule fallback):
- `无 token` + body → `task: [wiki] 点生成方案报错，提示没有可用的模型 token`
- empty → `task: user-reported issue`
- informative → `task: [wiki] 文献编译在插图步骤崩溃` (kept)

## Tests

Adds `test_feedback.py::test_fallback_draft_replaces_uninformative_title`; the existing `test_generate_draft_follows_template` still holds (it only asserts the template prefix). ruff clean.