### PR TITLE
fix(manuscripts): ensure references.bib exists when initializing draft.tex

### DIFF
--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -499,6 +499,21 @@ async def initialize_structure(
             draft.content = new_content
             draft.updated_by = user_id
 
+    # draft.tex 里带 \bibliography{references}，若工作区还没有 references.bib（遗留稿件、
+    # 或建稿模板未生成）就一并落库，否则 AI 起草后编译解析 \cite 会找不到 bib 文件。
+    if "references.bib" not in by_path:
+        from app.services import latex_compile  # 延迟导入避免循环
+
+        session.add(
+            ManuscriptFile(
+                manuscript_id=manuscript.id,
+                path="references.bib",
+                content=await latex_compile.build_references_bib(session, manuscript),
+                readonly=False,
+                updated_by=user_id,
+            )
+        )
+
     manuscript.main_tex = DRAFT_TEX  # 编译主文件切到草稿
     await session.commit()
     await session.refresh(draft)

--- a/src/backend/tests/test_manuscript_compile_settings.py
+++ b/src/backend/tests/test_manuscript_compile_settings.py
@@ -99,6 +99,8 @@ async def test_initialize_structure_creates_draft(client):
     detail = (await client.get(f"/api/manuscripts/{ms_id}", headers=headers)).json()
     paths = {f["path"] for f in detail["files"]}
     assert "draft.tex" in paths and "main.tex" in paths  # 原主文件仍在
+    # draft.tex 带 \bibliography{references}，工作区里必须有 references.bib 供编译解析 \cite
+    assert "references.bib" in paths
     assert detail["main_tex"] == "draft.tex"  # 编译主文件已切换
 
     # 原 main.tex 内容未被改动
@@ -113,3 +115,24 @@ async def test_initialize_structure_creates_draft(client):
     assert "% POLARIS_SECTION: method" in r2.json()["content"]
     detail2 = (await client.get(f"/api/manuscripts/{ms_id}", headers=headers)).json()
     assert [f["path"] for f in detail2["files"]].count("draft.tex") == 1
+
+
+async def test_initialize_structure_restores_missing_references_bib(client):
+    """遗留稿件：references.bib 被删掉后再初始化，draft.tex 的 \\bibliography 需重新有 bib 落库。"""
+    project_id, headers = await _setup_project(client)
+    ms_id = (await _create_manuscript(client, headers, project_id)).json()["id"]
+
+    async def _paths() -> set[str]:
+        detail = (await client.get(f"/api/manuscripts/{ms_id}", headers=headers)).json()
+        return {f["path"] for f in detail["files"]}
+
+    detail0 = (await client.get(f"/api/manuscripts/{ms_id}", headers=headers)).json()
+    bib0 = next(f for f in detail0["files"] if f["path"] == "references.bib")
+    r = await client.delete(f"/api/manuscripts/{ms_id}/files/{bib0['id']}", headers=headers)
+    assert r.status_code == 204, r.text
+    assert "references.bib" not in await _paths()
+
+    r = await client.post(f"/api/manuscripts/{ms_id}/initialize-structure", headers=headers)
+    assert r.status_code == 200, r.text
+    paths = await _paths()
+    assert "draft.tex" in paths and "references.bib" in paths


### PR DESCRIPTION
## 问题

论文撰写模块里 `initialize_structure()`（AI 起草前生成 `draft.tex` 的步骤）会把 `\bibliography{references}` 声明带进 draft.tex，但它**从不保证工作区里有 `references.bib` 文件**。

- 新建稿 `create_manuscript()` 会自动生成 references.bib，正常；
- 但**遗留稿件**（在 bib 自动生成逻辑之前建的），或者用户手动删了 references.bib 的稿件，初始化出来的 draft.tex 就指向一个不存在的 bib 文件 → AI 起草后编译解析 `\cite` 找不到引用。

编译期 `assemble_workdir()` 虽然对缺失 bib 有兜底，但只写进临时编译目录、不落库，文件列表里也看不到，AI/用户都无从引用。

## 改动

`initialize_structure()` 在建 draft.tex 时，若工作区缺 `references.bib`，就从 fact pack 生成一份落库（与 `create_manuscript()` 逻辑一致，幂等）。

## 测试

- `test_initialize_structure_creates_draft`：断言初始化后文件列表含 `references.bib`。
- 新增 `test_initialize_structure_restores_missing_references_bib`：删掉 references.bib → 初始化 → 断言重新落库。
- 稿件相关套件（test_manuscripts / test_latex_compile / test_manuscript_files / test_manuscript_export / test_manuscript_compile_settings）全绿，ruff 干净。