### PR TITLE
feat: key ingest tasks to libraries so standalone libraries can crawl (P9a)

### DIFF
--- a/src/backend/alembic/versions/b8919453c913_voyage_library_keying.py
+++ b/src/backend/alembic/versions/b8919453c913_voyage_library_keying.py
@@ -1,0 +1,72 @@
+"""任务系统库化：voyage_runs / activities 可挂方向库（P9a）
+
+- voyage_runs.project_id 改可空，新增 library_id（FK→direction_libraries，SET NULL，index）：
+  ingest 类任务可直接挂库运行，管理员创建的独立库（project_id=NULL）也能触发抓取；
+  起源课题的隐式库两者都带（兼容活动流/鉴权）。
+- activities.project_id 改可空，新增 library_id（SET NULL，index）：独立库的 ingest
+  活动记到库上（project_id 为空），课题活动照旧。
+
+Revision ID: b8919453c913
+Revises: b3e9c1f47a20
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b8919453c913"
+down_revision: str | None = "b3e9c1f47a20"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("voyage_runs") as batch:
+        batch.alter_column(
+            "project_id", existing_type=sa.Uuid(), nullable=True, existing_nullable=False
+        )
+        batch.add_column(sa.Column("library_id", sa.Uuid(), nullable=True))
+        batch.create_index("ix_voyage_runs_library_id", ["library_id"])
+        batch.create_foreign_key(
+            "fk_voyage_runs_library_id",
+            "direction_libraries",
+            ["library_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    with op.batch_alter_table("activities") as batch:
+        batch.alter_column(
+            "project_id", existing_type=sa.Uuid(), nullable=True, existing_nullable=False
+        )
+        batch.add_column(sa.Column("library_id", sa.Uuid(), nullable=True))
+        batch.create_index("ix_activities_library_id", ["library_id"])
+        batch.create_foreign_key(
+            "fk_activities_library_id",
+            "direction_libraries",
+            ["library_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    # 回退前把库级（无课题）行清掉：project_id 要收回 NOT NULL，独立库任务/活动无处安放。
+    op.execute("DELETE FROM activities WHERE project_id IS NULL")
+    op.execute("DELETE FROM voyage_runs WHERE project_id IS NULL")
+    with op.batch_alter_table("activities") as batch:
+        batch.drop_constraint("fk_activities_library_id", type_="foreignkey")
+        batch.drop_index("ix_activities_library_id")
+        batch.drop_column("library_id")
+        batch.alter_column(
+            "project_id", existing_type=sa.Uuid(), nullable=False, existing_nullable=True
+        )
+    with op.batch_alter_table("voyage_runs") as batch:
+        batch.drop_constraint("fk_voyage_runs_library_id", type_="foreignkey")
+        batch.drop_index("ix_voyage_runs_library_id")
+        batch.drop_column("library_id")
+        batch.alter_column(
+            "project_id", existing_type=sa.Uuid(), nullable=False, existing_nullable=True
+        )

--- a/src/backend/app/agents/voyage/actions.py
+++ b/src/backend/app/agents/voyage/actions.py
@@ -29,8 +29,9 @@ class ActionContext:
     step_id: Any | None = None  # 当前节点 id（动作查自己的闸门等；engine 注入）
 
     async def notify(self, message: dict[str, Any]) -> None:
-        """向项目通知频道发布事件（bus 未注入时为 no-op）。"""
-        if self.bus is not None:
+        """向项目通知频道发布事件（bus 未注入 / 无起源课题时为 no-op）。"""
+        # P9a：独立库任务无 project_id，无项目通知频道，静默跳过。
+        if self.bus is not None and self.run.project_id is not None:
             await self.bus.publish_notify(self.run.project_id, message)
 
     async def log(self, message: str, *, level: str = "info") -> None:
@@ -110,6 +111,7 @@ async def llm_complete(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
         messages,
         user_id=ctx.run.created_by,
         project_id=ctx.run.project_id,
+        library_id=ctx.run.library_id,
         voyage_id=ctx.run.id,
     )
     return {"content": result.content, "model": result.model, "usage": result.usage}

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -26,9 +26,8 @@ from app.agents.voyage.actions import ActionContext, register
 from app.core.db import get_sessionmaker
 from app.models.activity import Activity
 from app.models.base import utcnow
-from app.models.library_direction import LibraryPaper
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, PaperChunk
-from app.models.project import Project
 from app.services.affiliations import extract_affiliations_llm
 from app.services.chunks import embed_pending_chunks, index_paper_fulltext
 from app.services.concepts import link_all_paper_concepts
@@ -145,11 +144,18 @@ def _mode(ctx: ActionContext) -> str:
     )
 
 
-async def _get_project(session: AsyncSession, ctx: ActionContext) -> Project:
-    project = await session.get(Project, ctx.run.project_id)
-    if project is None:
-        raise ValueError(f"project not found: {ctx.run.project_id}")
-    return project
+async def _resolve_library(
+    session: AsyncSession, ctx: ActionContext
+) -> DirectionLibrary | None:
+    """P9a：库化任务优先按 ``run.library_id`` 直接定位方向库；回退起源课题解析（兼容
+    库化前建的存量 run）。独立库（无起源课题）也能由此拿到自己的库。"""
+    if ctx.run.library_id is not None:
+        library = await session.get(DirectionLibrary, ctx.run.library_id)
+        if library is not None:
+            return library
+    if ctx.run.project_id is not None:
+        return await get_library_for_project(session, ctx.run.project_id)
+    return None
 
 
 def _parse_iso(value: str | None) -> datetime | None:
@@ -240,7 +246,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
     now = utcnow()
     mode = _mode(ctx)
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library = await _resolve_library(session, ctx)
         if library is None:
             raise ValueError(f"library not found for project: {ctx.run.project_id}")
         # P8a：收录配置读库自身 definition（不再读起源课题 project.definition）
@@ -382,7 +388,7 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
     max_new = _UNLIMITED_SENTINEL if _unlimited(knobs) else int(knobs["max_papers"]) * 2
 
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library = await _resolve_library(session, ctx)
         if library is None:
             raise ValueError(f"library not found for project: {ctx.run.project_id}")
         definition = library_definition(library)
@@ -517,7 +523,7 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
     threshold = float(knobs["relevance_threshold"])
 
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library = await _resolve_library(session, ctx)
         if library is None:
             raise ValueError(f"library not found for project: {ctx.run.project_id}")
         # 稀疏 definition 容忍：rubric / questions 缺失时 prompt 只用 statement
@@ -633,7 +639,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     failed: list[dict[str, str]] = []
 
     async with get_sessionmaker()() as session:
-        library = await get_library_for_project(session, ctx.run.project_id)
+        library = await _resolve_library(session, ctx)
         pairs = (
             await session.execute(
                 select(Paper, LibraryPaper)
@@ -769,8 +775,9 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
     top_n = _compile_limit(knobs)
 
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        library = await get_library_for_project(session, project.id)
+        library = await _resolve_library(session, ctx)
+        if library is None:
+            raise ValueError(f"library not found for run: {ctx.run.id}")
         statement = library_definition(library).get("statement") or library.name
         # 幂等断点：已 compiled 的不再进入（status=fetched 才编译）。外层只查 id，每篇
         # 编译在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
@@ -877,15 +884,16 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
 @register("wiki.link_concepts")
 async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        library = await get_library_for_project(session, project.id)
+        library = await _resolve_library(session, ctx)
+        if library is None:
+            raise ValueError(f"library not found for run: {ctx.run.id}")
         # 全库上链逻辑与手动补建端点共用（services/concepts.py）
         stats, papers = await link_all_paper_concepts(
             session,
             library_id=library.id,
             llm=ctx.llm,
             user_id=ctx.run.created_by,
-            project_id=project.id,
+            project_id=ctx.run.project_id,
             voyage_id=ctx.run.id,
         )
         created = int(stats["concepts_created"])
@@ -927,7 +935,7 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             library_id=library.id,
             llm=ctx.llm,
             user_id=ctx.run.created_by,
-            project_id=project.id,
+            project_id=ctx.run.project_id,
             voyage_id=ctx.run.id,
             **embed_kwargs,
         )
@@ -952,8 +960,7 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
 @register("wiki.update_watermark")
 async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
-        project = await _get_project(session, ctx)
-        library = await get_library_for_project(session, project.id)
+        library = await _resolve_library(session, ctx)
         # 水位线权威源在库（P8a）：写 library.ingest_state；起源课题 project.ingest_state
         # 不再是权威（overview「上次同步时间」读库）。
         state = dict((library.ingest_state if library else None) or {})
@@ -967,7 +974,8 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         compiled_count = int(ctx.checkpoint.get("compiled_count") or 0)
         session.add(
             Activity(
-                project_id=project.id,
+                project_id=ctx.run.project_id,
+                library_id=library.id if library is not None else None,
                 actor="agent:librarian",
                 kind="ingest.completed",
                 message=f"文献调研完成：本次编译 {compiled_count} 篇 wiki 页",

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -158,8 +158,11 @@ class VoyageEngine:
         if self._bus is not None:
             await self._bus.publish_voyage_event(run_id, event, data)
 
-    async def _emit_notify(self, project_id: uuid.UUID, message: dict[str, Any]) -> None:
-        if self._bus is not None:
+    async def _emit_notify(
+        self, project_id: uuid.UUID | None, message: dict[str, Any]
+    ) -> None:
+        # P9a：库化任务可能无起源课题（project_id 为空）——无项目通知频道，静默跳过。
+        if project_id is not None and self._bus is not None:
             await self._bus.publish_notify(project_id, message)
 
     async def _emit_status(self, run: VoyageRun) -> None:
@@ -245,7 +248,12 @@ class VoyageEngine:
         """
         if "skills" in (run.checkpoint or {}):
             return
-        snapshot = await skills_service.snapshot_for_project(session, run.project_id)
+        # P9a：独立库任务无起源课题 → 无项目作用域技能，快照留空。
+        snapshot = (
+            await skills_service.snapshot_for_project(session, run.project_id)
+            if run.project_id is not None
+            else {}
+        )
         checkpoint = dict(run.checkpoint or {})
         checkpoint["skills"] = snapshot
         run.checkpoint = checkpoint

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -577,6 +577,7 @@ class Navigator:
                 ],
                 user_id=run.created_by,
                 project_id=run.project_id,
+                library_id=run.library_id,
                 voyage_id=run.id,
             )
             try:
@@ -664,6 +665,7 @@ class Navigator:
                 ],
                 user_id=run.created_by,
                 project_id=run.project_id,
+                library_id=run.library_id,
                 voyage_id=run.id,
             )
             try:

--- a/src/backend/app/agents/voyage/tool_loop.py
+++ b/src/backend/app/agents/voyage/tool_loop.py
@@ -60,6 +60,7 @@ async def run_tool_loop(
             messages,
             user_id=ctx.run.created_by,
             project_id=ctx.run.project_id,
+            library_id=ctx.run.library_id,
             voyage_id=ctx.run.id,
         )
         messages.append(Message(role="assistant", content=result.content))

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -32,9 +32,17 @@ async def start_ingest(
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    library = await libraries_service.get_library_for_project(session, project.id)
+    if library is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
     try:
         run = await ingest_service.create_ingest_voyage(
-            session, project=project, mode=data.mode, knobs=data.knobs, created_by=user.id
+            session,
+            library=library,
+            project=project,
+            mode=data.mode,
+            knobs=data.knobs,
+            created_by=user.id,
         )
     except ingest_service.IngestConflictError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -13,11 +13,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user, require_admin
+from app.api.auth import current_active_user, require_admin, require_llm_task
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
+from app.core.queue import TaskQueue, get_task_queue
 from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.project import Project
 from app.models.user import User
+from app.schemas.ingest import IngestRequest
 from app.schemas.libraries import (
     CuratorRead,
     CuratorsUpdate,
@@ -38,6 +41,7 @@ from app.schemas.paper import (
     ScoredPaper,
     SearchResponse,
 )
+from app.schemas.voyage import VoyageRead
 from app.services import concepts as concepts_service
 from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
@@ -178,6 +182,46 @@ async def get_library_budget(
         remaining_tokens=None if not budget else max(0, int(budget) - used),
         exhausted=bool(budget) and used >= int(budget),
     )
+
+
+@router.post(
+    "/libraries/{library_id}/ingest/run",
+    response_model=VoyageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def start_library_ingest(
+    library_id: uuid.UUID,
+    data: IngestRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> VoyageRead:
+    """对某个方向库直接触发抓取（P9a）：可管理者（成员/策展人/admin）皆可。
+
+    管理员创建的独立库（project_id 为空）由此入口驱动 ingest；起源课题的隐式库同时
+    带上 project 以兼容活动流/鉴权。互斥以库为准，超预算 409 拒绝。
+    """
+    library = await _get_managed_library(session, library_id, user)
+    project = (
+        await session.get(Project, library.project_id)
+        if library.project_id is not None
+        else None
+    )
+    try:
+        run = await ingest_service.create_ingest_voyage(
+            session,
+            library=library,
+            project=project,
+            mode=data.mode,
+            knobs=data.knobs,
+            created_by=user.id,
+        )
+    except ingest_service.IngestConflictError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
+    except ingest_service.LibraryBudgetExhaustedError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
+    await queue.enqueue("run_voyage", str(run.id))
+    return VoyageRead.model_validate(run)
 
 
 @router.get("/libraries/{library_id}/curators", response_model=list[CuratorRead])

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -39,7 +39,7 @@ async def _get_owned_voyage(
     session: AsyncSession, voyage_id: uuid.UUID, user: User, with_steps: bool = False
 ) -> VoyageRun:
     run = await voyages_service.get_voyage(
-        session, voyage_id=voyage_id, user_id=user.id, with_steps=with_steps
+        session, voyage_id=voyage_id, user_id=user.id, with_steps=with_steps, user=user
     )
     if run is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="VOYAGE_NOT_FOUND")

--- a/src/backend/app/models/activity.py
+++ b/src/backend/app/models/activity.py
@@ -13,8 +13,13 @@ from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
 class Activity(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "activities"
 
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
+    # P9a：库级活动流。挂课题的活动照旧带 project_id；管理员独立库的 ingest 活动只带
+    # library_id（project_id 为空）。隐式库两者都带。
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    library_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="SET NULL"), index=True, nullable=True
     )
     actor: Mapped[str] = mapped_column(String(255), nullable=False)  # agent 名或用户 id
     kind: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -89,8 +89,13 @@ class VoyageRun(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     checkpoint: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     budget: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # {max_tokens?, ...}
     usage: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 累计 tokens
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
+    # P9a：任务可直接挂方向库（ingest 类）。起源课题的隐式库两者都带（兼容活动流/
+    # 鉴权）；管理员创建的独立库 project_id 为空。
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    library_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="SET NULL"), index=True, nullable=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -56,7 +56,8 @@ class VoyageRead(BaseModel):
     cursor: int
     budget: dict[str, Any] | None
     usage: dict[str, Any] | None
-    project_id: uuid.UUID
+    project_id: uuid.UUID | None = None
+    library_id: uuid.UUID | None = None
     created_by: uuid.UUID | None
     created_at: datetime
     updated_at: datetime

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -100,18 +100,39 @@ async def find_running_ingest(session: AsyncSession, project_id: uuid.UUID) -> V
     return (await session.execute(stmt)).scalar_one_or_none()
 
 
+async def find_running_ingest_for_library(
+    session: AsyncSession, library_id: uuid.UUID
+) -> VoyageRun | None:
+    """该方向库是否已有 ingest 任务在跑（P9a：库化后互斥以库为准）。"""
+    stmt = (
+        select(VoyageRun)
+        .where(
+            VoyageRun.library_id == library_id,
+            VoyageRun.kind.in_(WIKI_KINDS),
+            VoyageRun.status.not_in(tuple(TERMINAL_STATUSES)),
+        )
+        .order_by(VoyageRun.created_at.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
 async def create_ingest_voyage(
     session: AsyncSession,
     *,
-    project: Project,
+    library: DirectionLibrary,
+    project: Project | None = None,
     mode: str,
     knobs: IngestKnobs,
     created_by: uuid.UUID | None,
 ) -> VoyageRun:
-    """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。"""
-    if await find_running_ingest(session, project.id) is not None:
-        raise IngestConflictError(str(project.id))
-    library = await get_library_for_project(session, project.id)
+    """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。
+
+    P9a：任务直接挂 ``library``。有起源课题的隐式库同时带上 ``project`` 以兼容活动流/
+    鉴权；管理员创建的独立库不传 project（run.project_id / activity.project_id 为空）。
+    """
+    if await find_running_ingest_for_library(session, library.id) is not None:
+        raise IngestConflictError(str(library.id))
     budget = await apply_library_budget(
         session,
         library_id=library.id,
@@ -119,11 +140,13 @@ async def create_ingest_voyage(
         budget=derive_budget(knobs),
     )
     kind = "wiki_bootstrap" if mode == "bootstrap" else "wiki_ingest"
+    target_name = project.name if project is not None else library.name
     goal = (
-        f"文献调研初始建库：{project.name}"
+        f"文献调研初始建库：{target_name}"
         if mode == "bootstrap"
-        else f"文献调研增量更新：{project.name}"
+        else f"文献调研增量更新：{target_name}"
     )
+    project_id = project.id if project is not None else None
     run = VoyageRun(
         kind=kind,
         goal=goal,
@@ -131,13 +154,15 @@ async def create_ingest_voyage(
         cursor=0,
         checkpoint={"params": {"mode": mode, "knobs": knobs.model_dump()}},
         budget=budget,
-        project_id=project.id,
+        project_id=project_id,
+        library_id=library.id,
         created_by=created_by,
     )
     session.add(run)
     session.add(
         Activity(
-            project_id=project.id,
+            project_id=project_id,
+            library_id=library.id,
             actor=f"user:{created_by}" if created_by else "system:cron",
             kind="ingest.started",
             message=f"文献调研{'初始建库' if mode == 'bootstrap' else '增量更新'}已启动",

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.project import ProjectMember
+from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.voyage import VoyageCreate
 
@@ -53,18 +54,50 @@ async def list_voyages(
     return (await session.execute(stmt)).scalars().all()
 
 
+async def _is_project_member(
+    session: AsyncSession, *, project_id: uuid.UUID, user_id: uuid.UUID
+) -> bool:
+    row = await session.execute(
+        select(ProjectMember.user_id).where(
+            ProjectMember.project_id == project_id, ProjectMember.user_id == user_id
+        )
+    )
+    return row.first() is not None
+
+
 async def get_voyage(
     session: AsyncSession,
     *,
     voyage_id: uuid.UUID,
     user_id: uuid.UUID,
     with_steps: bool = False,
+    user: User | None = None,
 ) -> VoyageRun | None:
-    """取航程；非项目成员视为不存在（返回 None）。"""
-    stmt = _member_filter(select(VoyageRun), user_id).where(VoyageRun.id == voyage_id)
+    """取航程；无访问权视为不存在（返回 None）。
+
+    访问权：起源课题成员（项目作用域任务）∪ 可管理其方向库者（P9a 库化任务——独立库
+    无课题，鉴权走库级写权限：成员/策展人/admin）。库级鉴权需要 ``user``（角色/策展人
+    判定），故 API 层传完整 user；仅传 user_id 时退化为项目成员判定。
+    """
+    stmt = select(VoyageRun).where(VoyageRun.id == voyage_id)
     if with_steps:
         stmt = stmt.options(selectinload(VoyageRun.steps))
-    return (await session.execute(stmt)).scalar_one_or_none()
+    run = (await session.execute(stmt)).scalar_one_or_none()
+    if run is None:
+        return None
+    if run.project_id is not None and await _is_project_member(
+        session, project_id=run.project_id, user_id=user_id
+    ):
+        return run
+    if run.library_id is not None and user is not None:
+        from app.services.libraries import can_manage_library, get_library
+
+        library = await get_library(session, run.library_id)
+        if library is not None and await can_manage_library(
+            session, user=user, library=library
+        ):
+            return run
+    return None
 
 
 async def cancel_voyage(session: AsyncSession, run: VoyageRun) -> VoyageRun:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b3e9c1f47a20"  # direction_libraries.definition 收录配置权威（P8a）
-PREV_REVISION = "67d18892a6ce"  # 课题 × 文献库关联 + 库生命周期独立（P7 Step 1）
+HEAD_REVISION = "b8919453c913"  # 任务系统库化：voyage_runs/activities 可挂方向库（P9a）
+PREV_REVISION = "b3e9c1f47a20"  # direction_libraries.definition 收录配置权威（P8a）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -60,6 +60,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "topic_papers",
                     "llm_usage",
                     "topic_source_libraries",
+                    "activities",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -129,6 +130,9 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "attempts",
         "provenance",
     } <= columns["voyage_steps"]
+    # 任务系统库化 P9a：voyage_runs / activities 新增 library_id（project_id 转可空）
+    assert "library_id" in columns["voyage_runs"]
+    assert "library_id" in columns["activities"]
     # 垃圾桶原因等判断字段已迁 library_papers（P4 迁移 B 删列）
     assert "trash_reason" not in columns["papers"]
     assert "status" not in columns["papers"]
@@ -230,11 +234,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "topic_source_libraries" in columns["_tables"]
     assert columns["topic_source_libraries"] == {"topic_id", "library_id", "created_at"}
 
-    # 最新 revision 可往返（downgrade 删 direction_libraries.definition，其余结构不动）
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（P8a），删 voyage_runs /
+    # activities 的 library_id 并把 project_id 收回 NOT NULL，其余结构不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "topic_source_libraries" in columns["_tables"]  # P7 表仍在（回退止于 P7）
+    assert "library_id" not in columns["voyage_runs"]  # P9a 列已回退
+    assert "library_id" not in columns["activities"]
+    assert "topic_source_libraries" in columns["_tables"]  # P7 表仍在
     assert "library_id" in columns["llm_usage"]
     assert "library_id" in columns["llm_call_logs"]
     # P5b 拆分结构不受影响：笔记/划线仍无 project_id
@@ -278,3 +285,6 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "registration_codes" in columns["_tables"]
     assert "preset_directions" in columns["registration_codes"]
     assert {"feedback", "feedback_images"} <= columns["_tables"]
+    # P9a 列在重新 upgrade 后回归
+    assert "library_id" in columns["voyage_runs"]
+    assert "library_id" in columns["activities"]

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -19,8 +19,11 @@ from app.core.db import get_sessionmaker
 from app.core.llm.fake import FakeProvider
 from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
 from app.models.paper import EMBEDDING_DIM, paper_concepts
+from app.models.user import User
+from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
 from app.services.literature import (
     ArxivClient,
@@ -776,3 +779,191 @@ async def test_daily_cron_project_selection(client, queue_stub, wiki_mocks):
     async with get_sessionmaker()() as session:
         due = await ingest_service.find_due_daily_projects(session)
         assert [p.id for p in due] == [uuid.UUID(project_id)]
+
+
+# ---- P9a：任务系统库化（VoyageRun 可挂方向库，独立库可直接触发抓取） ----
+
+
+async def _promote_admin(email: str) -> None:
+    """把已注册用户提为平台 admin（独立建库 / 库级 ingest 触发需要）。"""
+    async with get_sessionmaker()() as session:
+        user = (
+            await session.execute(select(User).where(User.email == email))
+        ).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _create_standalone_library(client, headers, *, name="独立库-自动化科研", **extra):
+    """经 POST /libraries 建一个不挂课题的独立库（project_id=NULL）。"""
+    payload = {
+        "name": name,
+        "statement": DEFINITION["statement"],
+        "rubric": DEFINITION["rubric"],
+        "anchors": DEFINITION["anchor_papers"],
+        "cadence": "daily",
+        "keywords": DEFINITION["keywords"],
+    }
+    payload.update(extra)
+    resp = await client.post("/api/libraries", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_mocks):
+    """独立库（project_id=NULL）经 /libraries/{id}/ingest/run 触发并跑通全链路。
+
+    校验：任务挂库（project_id 空、library_id 指向本库）、同库并发互斥、水位线写库、
+    库版论文编译、库级用量归因、库级活动流（project_id 空 / library_id 指向本库）。
+    """
+    token = await register_and_login(client, email="lib-admin@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("lib-admin@example.com")
+    library_id = await _create_standalone_library(client, headers)
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    voyage = resp.json()
+    assert voyage["kind"] == "wiki_bootstrap"
+    assert voyage["library_id"] == library_id
+    assert voyage["project_id"] is None  # 独立库无起源课题
+    run_id = voyage["id"]
+    assert ("run_voyage", (run_id,), {}) in queue_stub.jobs
+
+    # 同库并发互斥 → 409（库化后互斥以库为准）
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "INGEST_ALREADY_RUNNING"
+
+    engine, _bus = _make_engine()
+    await engine.run(uuid.UUID(run_id))
+
+    detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 7
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        # 水位线权威源写在库上
+        assert library.ingest_state["watermark"]
+        assert library.ingest_state["last_run"]["voyage_id"] == run_id
+
+        # 库版论文：3 arXiv 候选 + 1 雪球，3 篇编译
+        members = (
+            (
+                await session.execute(
+                    select(LibraryPaper).where(LibraryPaper.library_id == library.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(members) == 4
+        assert sum(1 for m in members if m.status == "compiled") == 3
+        assert sum(1 for m in members if m.status == "excluded") == 1
+
+        # 库级用量归因：ingest 全程 LLM 调用（打分/图注/编译/概念定义/向量化）记到库上
+        usage = (
+            (
+                await session.execute(
+                    select(LLMUsage).where(LLMUsage.library_id == library.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert usage, "库级 ingest 应产生按库归因的用量记录"
+        assert {u.library_id for u in usage} == {library.id}
+
+        # 库级活动流：project_id 为空，library_id 指向本库
+        acts = (
+            (
+                await session.execute(
+                    select(Activity).where(Activity.library_id == library.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {"ingest.started", "ingest.completed"} <= {a.kind for a in acts}
+        assert all(a.project_id is None for a in acts)
+
+
+async def test_standalone_library_ingest_budget_gate(client, queue_stub):
+    """独立库触发同样受库预算门约束：本月用尽 → 409 且不入队。"""
+    token = await register_and_login(client, email="lib-budget@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("lib-budget@example.com")
+    library_id = await _create_standalone_library(
+        client, headers, name="独立库-预算", monthly_budget=1000
+    )
+    async with get_sessionmaker()() as session:
+        session.add(
+            LLMUsage(
+                library_id=uuid.UUID(library_id),
+                stage="librarian",
+                model="fake",
+                prompt_tokens=800,
+                completion_tokens=300,  # 1100 ≥ 1000
+            )
+        )
+        await session.commit()
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap"},
+        headers=headers,
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == "LIBRARY_BUDGET_EXHAUSTED"
+    assert queue_stub.jobs == []
+
+
+async def test_standalone_library_ingest_forbidden_for_stranger(client, queue_stub):
+    """非管理者不能触发库级 ingest（成员/策展人/admin 之外 → 403）。"""
+    token = await register_and_login(client, email="lib-owner2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("lib-owner2@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-权限")
+
+    stranger = await register_and_login(client, email="lib-stranger@example.com")
+    sh = {"Authorization": f"Bearer {stranger}"}
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap"},
+        headers=sh,
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "LIBRARY_MANAGE_FORBIDDEN"
+    assert queue_stub.jobs == []
+
+
+async def test_project_ingest_run_carries_library_id(client, queue_stub, wiki_mocks):
+    """隐式库不回归：课题触发的 ingest 现在既带 project_id 也带 library_id（同库解析一致）。"""
+    project_id, headers = await _setup_project(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    voyage = resp.json()
+    assert voyage["project_id"] == project_id
+    assert voyage["library_id"] is not None
+
+    async with get_sessionmaker()() as session:
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        assert voyage["library_id"] == str(library.id)
+        run = await session.get(VoyageRun, uuid.UUID(voyage["id"]))
+        assert run.library_id == library.id
+        assert run.project_id == uuid.UUID(project_id)

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -20,6 +20,7 @@ from app.core.events import EventBus
 from app.core.redis import get_redis
 from app.schemas.ingest import IngestKnobs
 from app.services import ingest as ingest_service
+from app.services import libraries as libraries_service
 from app.services import publications as publications_service
 
 
@@ -72,9 +73,13 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
     async with get_sessionmaker()() as session:
         projects = await ingest_service.find_due_daily_projects(session)
         for project in projects:
+            library = await libraries_service.get_library_for_project(session, project.id)
+            if library is None:
+                continue  # 无语料库（理论上 find_due 已过滤，双保险）
             try:
                 run = await ingest_service.create_ingest_voyage(
                     session,
+                    library=library,
                     project=project,
                     mode="incremental",
                     knobs=IngestKnobs(),


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P9a, the engine foundation for admin/user-created standalone libraries. Backend only.

## Why
After P8 a library owns its inclusion config and watermark, but the ingest task (`VoyageRun`) was still `project_id`-required and resolved its library by reverse-lookup from the project. So an admin-created standalone library (`project_id = NULL`) could be configured but never crawl. This phase lets an ingest task run **keyed to a library**, with no project.

## What changed
- **Migration `b8919453c913`**: `voyage_runs.project_id` and `activities.project_id` become nullable; both gain a nullable `library_id` (FK → direction_libraries, SET NULL, indexed).
- **Ingest is library-first**: `create_ingest_voyage(library=, project=None)`; `actions_wiki` resolves the library from `run.library_id` (falling back to the project for implicit libraries); the dead `_get_project` path is removed. Engine notify/skills-snapshot/gate paths handle a null project.
- **Trigger endpoint**: `POST /libraries/{id}/ingest/run` (member/curator/admin via `can_manage_library`), budget-gated by the P6 per-library cap (409 when exhausted), 409 when an ingest is already running. The project-scoped `POST /projects/{id}/ingest` now resolves the library and calls the same creator.
- **Billing**: shell LLM calls now carry `run.library_id`, so standalone-library ingest is attributed to the library (lab) budget — matching the "lab pays for compilation" model.
- `get_voyage` authorization now allows origin-topic members ∪ anyone who can manage the library, so standalone-library task detail/logs/cancel/resume are visible to curators/admins.

Implicit libraries are unchanged: their ingest carries both `project_id` and `library_id`, so project activity feeds and task lists don't regress.

## Tests
536 passed (531 baseline + 5 new), 16 pre-existing errors, 1 pre-existing env-coupled feedback failure — no new failures. New tests cover the full standalone-library ingest pipeline (task keyed to library, watermark on library, library-attributed usage, library-scoped activity), budget-gate rejection, stranger-forbidden, and implicit-library non-regression. Migration sqlite roundtrip updated (PREV = `b3e9c1f47a20`) and verified; ruff clean.

## Scope
Standalone-library **management UI**, library **status/approval**, user-facing **create form**, and stopping implicit-library auto-creation are the next phases (P9b/P9c). This phase only makes the task engine able to run keyed to a library.