### PR TITLE
feat: library lifecycle — user-created libraries with admin approval (P9b)

### DIFF
--- a/src/backend/alembic/versions/d3a7f1c9b2e4_library_lifecycle.py
+++ b/src/backend/alembic/versions/d3a7f1c9b2e4_library_lifecycle.py
@@ -1,0 +1,46 @@
+"""文献库生命周期：方向库 status/审批（P9b）
+
+- direction_libraries 新增 status（String(16)，NOT NULL，server_default='active'）：
+  pending 待审批 | active 已激活（可抓取）| rejected 已驳回。存量库与课题隐式起源库
+  经 server_default 回填为 active（不回归）；用户经 POST /libraries 独立建的库落 pending。
+- 新增 review_note（Text，驳回理由）+ submitted_by（Uuid，FK→users，SET NULL，库创建者）。
+
+Revision ID: d3a7f1c9b2e4
+Revises: b8919453c913
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d3a7f1c9b2e4"
+down_revision: str | None = "b8919453c913"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.add_column(
+            sa.Column("status", sa.String(length=16), nullable=False, server_default="active")
+        )
+        batch.add_column(sa.Column("review_note", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("submitted_by", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_direction_libraries_submitted_by",
+            "users",
+            ["submitted_by"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_constraint("fk_direction_libraries_submitted_by", type_="foreignkey")
+        batch.drop_column("submitted_by")
+        batch.drop_column("review_note")
+        batch.drop_column("status")

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -30,6 +30,7 @@ from app.schemas.libraries import (
     DuplicateCandidateGroup,
     LibraryBudgetRead,
     LibraryCreate,
+    LibraryReject,
     PaperMergeRequest,
     PaperMergeResult,
 )
@@ -93,9 +94,12 @@ async def list_libraries(
 async def create_library(
     data: LibraryCreate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(require_admin),
+    user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
-    """独立新建方向文献库（平台 admin）：不属于任何课题，课题靠关联消费其语料。"""
+    """用户独立新建方向文献库（任意登录用户，P9b）：新库 status=pending 待审批，
+    创建者记为 submitted_by 并自动成为该库策展人（文献库管理员）。仅落配置，不触发
+    抓取、不花 token；管理员审批激活后才能触发 ingest。不属于任何课题，课题靠关联消费其语料。
+    """
     library = await libraries_service.create_library(
         session,
         name=data.name,
@@ -119,6 +123,36 @@ async def get_library(
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
     library = await _get_library(session, library_id)
+    # 可见性（P9b）：pending/rejected 库仅创建者 + admin 可见，其余人视为不存在。
+    if not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
+
+
+@router.post("/libraries/{library_id}/approve", response_model=DirectionLibraryDetail)
+async def approve_library(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> DirectionLibraryDetail:
+    """审批通过（平台 admin）：pending/rejected → active，激活后可触发抓取。"""
+    library = await _get_library(session, library_id)
+    library = await libraries_service.approve_library(session, library=library)
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
+
+
+@router.post("/libraries/{library_id}/reject", response_model=DirectionLibraryDetail)
+async def reject_library(
+    library_id: uuid.UUID,
+    data: LibraryReject,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> DirectionLibraryDetail:
+    """驳回（平台 admin）：→ rejected，可带理由；创建者可改配置后再由 admin 审批。"""
+    library = await _get_library(session, library_id)
+    library = await libraries_service.reject_library(session, library=library, note=data.note)
     row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
 
@@ -202,6 +236,9 @@ async def start_library_ingest(
     带上 project 以兼容活动流/鉴权。互斥以库为准，超预算 409 拒绝。
     """
     library = await _get_managed_library(session, library_id, user)
+    if library.status != "active":
+        # 待审批 / 已驳回的库不能抓取（P9b：仅 active 且预算内可触发）。
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_NOT_ACTIVE")
     project = (
         await session.get(Project, library.project_id)
         if library.project_id is not None

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -38,6 +38,17 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     ingest_state: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     cadence: Mapped[str | None] = mapped_column(String(32))  # 同步节奏：daily | weekly | ...
     monthly_budget: Mapped[int | None]  # 每月 ingest 预算（P6 治理用）
+    # 生命周期（P9b）：pending 待审批 | active 已激活（可抓取）| rejected 已驳回。
+    # server_default='active'——存量库与课题隐式起源库都视为已激活；用户经
+    # POST /libraries 独立建的库显式落 pending，管理员审批后转 active。
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default="active"
+    )
+    review_note: Mapped[str | None] = mapped_column(Text)  # 驳回理由（status=rejected 时有值）
+    # 库创建者（P9b 用户建库）：pending/rejected 库仅创建者 + admin 可见/可管理。
+    submitted_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -18,6 +18,12 @@ class DirectionLibrarySummary(BaseModel):
     statement: str | None
     # 过渡期隐式库回指的课题；未来共享库可为 None
     project_id: uuid.UUID | None
+    # 生命周期（P9b）：pending 待审批 | active 已激活 | rejected 已驳回
+    status: str
+    # 驳回理由（status=rejected 时有值）
+    review_note: str | None = None
+    # 库创建者（用户建库；pending/rejected 库仅创建者 + admin 可见）
+    submitted_by: uuid.UUID | None = None
     # 是否「我的课题的库」（请求者是背后课题的成员 → 前端显示管理入口）
     is_mine: bool
     # 是否可管理本库：成员 ∪ 策展人（界面叫「文献库管理员」）∪ 平台 admin（P6）
@@ -41,7 +47,11 @@ class DirectionLibraryDetail(DirectionLibrarySummary):
 
 
 class LibraryCreate(BaseModel):
-    """独立新建方向文献库（POST /libraries，平台 admin）。"""
+    """独立新建方向文献库（POST /libraries，任意登录用户；新库 status=pending 待审批）。
+
+    P9b：必填仅 name + statement；anchors 只填 arxiv-id 列表（抓取时解析元数据），
+    keywords 可选。创建只是配置，不触发抓取、不花 token。
+    """
 
     name: str = Field(min_length=1, max_length=255)
     statement: str | None = None
@@ -50,6 +60,12 @@ class LibraryCreate(BaseModel):
     rubric: Any | None = None
     anchors: list[Any] | None = None
     keywords: dict[str, Any] | None = None  # {arxiv_categories, include, synonyms}
+
+
+class LibraryReject(BaseModel):
+    """驳回 pending 库（POST /libraries/{id}/reject，平台 admin）。"""
+
+    note: str | None = Field(default=None, max_length=2000)
 
 
 class SourceLibrariesUpdate(BaseModel):

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -362,6 +362,9 @@ def _overview_dict(
         "monthly_budget": library.monthly_budget,
         "definition": library_definition(library),
         "project_id": library.project_id,
+        "status": library.status,
+        "review_note": library.review_note,
+        "submitted_by": library.submitted_by,
         "is_mine": library.id in my_linked,
         "can_manage": can_manage,
         "paper_count": paper_count,
@@ -393,6 +396,7 @@ async def list_libraries_overview(session: AsyncSession, *, user: User) -> list[
             can_manage=(
                 user.role == "admin"
                 or lib.id in my_curated
+                or lib.submitted_by == user.id
                 or (lib.project_id is not None and lib.project_id in my_projects)
             ),
             paper_count=paper_counts.get(lib.id, 0),
@@ -400,7 +404,17 @@ async def list_libraries_overview(session: AsyncSession, *, user: User) -> list[
             last_compiled_at=last_compiled.get(lib.id),
         )
         for lib in libraries
+        if library_visible_to(lib, user)
     ]
+
+
+def library_visible_to(library: DirectionLibrary, user: User) -> bool:
+    """库对请求者是否可见（P9b）：active 全员可读；pending/rejected 仅创建者 + admin 可见。"""
+    if library.status == "active":
+        return True
+    if user.role == "admin":
+        return True
+    return library.submitted_by == user.id
 
 
 async def library_overview(
@@ -457,8 +471,13 @@ async def create_library(
     keywords: dict[str, Any] | None = None,
     monthly_budget: int | None = None,
     created_by: uuid.UUID,
+    status: str = "pending",
 ) -> DirectionLibrary:
-    """独立新建方向文献库（P7；``project_id`` 恒为 NULL——不属于任何课题，靠关联被消费）。
+    """用户独立新建方向文献库（P9b；``project_id`` 恒为 NULL——不属于任何课题，靠关联被消费）。
+
+    P9b：任意登录用户可建，新库默认 ``status='pending'`` 待审批（仅配置，不触发抓取、
+    不花 token）；创建者记为 ``submitted_by`` 并自动加为该库策展人（文献库管理员），
+    以便在审批前管理自己的 pending 库。管理员审批后转 active 才能触发抓取。
 
     flush + refresh，不 commit（调用方 api 层负责事务收尾）。
     """
@@ -482,10 +501,38 @@ async def create_library(
         definition=definition or None,  # P8a：独立库同样以 definition 为收录配置权威源
         monthly_budget=monthly_budget,
         created_by=created_by,
+        submitted_by=created_by,
+        status=status,
         project_id=None,
     )
     session.add(library)
     await session.flush()
+    # 创建者自动成为该库策展人（幂等：避免重复主键）。
+    if not await is_library_curator(session, library_id=library.id, user_id=created_by):
+        session.add(DirectionLibraryCurator(library_id=library.id, user_id=created_by))
+        await session.flush()
+    await session.refresh(library)
+    return library
+
+
+async def approve_library(
+    session: AsyncSession, *, library: DirectionLibrary
+) -> DirectionLibrary:
+    """审批通过（平台 admin）：pending/rejected → active，清空驳回理由。commit 落库。"""
+    library.status = "active"
+    library.review_note = None
+    await session.commit()
+    await session.refresh(library)
+    return library
+
+
+async def reject_library(
+    session: AsyncSession, *, library: DirectionLibrary, note: str | None = None
+) -> DirectionLibrary:
+    """驳回（平台 admin）：→ rejected，记录驳回理由。commit 落库。"""
+    library.status = "rejected"
+    library.review_note = note
+    await session.commit()
     await session.refresh(library)
     return library
 
@@ -531,6 +578,8 @@ async def can_manage_library(
     """库级写权限（docs-dev/workspace-ia-redesign.md §5）：
     背后课题成员 ∪ 策展人（direction_library_curators）∪ 平台 admin。"""
     if user.role == "admin":
+        return True
+    if library.submitted_by is not None and library.submitted_by == user.id:
         return True
     if library.project_id is not None and await _is_project_member(
         session, project_id=library.project_id, user_id=user.id

--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -1,0 +1,188 @@
+"""P9b：文献库生命周期 —— 用户建库（pending）+ 管理员审批 + 状态门 + 可见性过滤。
+
+- 任意登录用户可建库，新库 status=pending（仅配置，不触发抓取）；
+- 管理员 approve → active、reject → rejected（带理由）；
+- pending/rejected 库不能触发 ingest（409 LIBRARY_NOT_ACTIVE），审批激活后可抓；
+- pending/rejected 库仅创建者 + admin 可见（列表过滤 + 详情 404）；
+- 创建者可管理自己的 pending 库（can_manage / PATCH）。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _create_pending(client, headers, name="用户建的库"):
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": name, "statement": "一句话方向陈述", "anchors": ["2401.00001"]},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    return body["id"]
+
+
+async def test_user_creates_pending_library(client):
+    await _hdr(client, "p9b-a1@example.com")  # 占位 admin
+    user = await _hdr(client, "p9b-u1@example.com")
+    lib_id = await _create_pending(client, user)
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary
+
+        lib = await session.get(DirectionLibrary, uuid.UUID(lib_id))
+        assert lib.status == "pending"
+        assert lib.submitted_by is not None
+        # 锚点只存 arxiv-id 列表
+        assert lib.definition["anchor_papers"] == ["2401.00001"]
+
+
+async def test_admin_approve_library(client):
+    admin = await _hdr(client, "p9b-a2@example.com")
+    await _promote_admin("p9b-a2@example.com")
+    user = await _hdr(client, "p9b-u2@example.com")
+    lib_id = await _create_pending(client, user)
+
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    assert resp.json()["review_note"] is None
+
+
+async def test_admin_reject_library_with_note(client):
+    admin = await _hdr(client, "p9b-a3@example.com")
+    await _promote_admin("p9b-a3@example.com")
+    user = await _hdr(client, "p9b-u3@example.com")
+    lib_id = await _create_pending(client, user)
+
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/reject", json={"note": "范围太宽，请收窄"}, headers=admin
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "rejected"
+    assert resp.json()["review_note"] == "范围太宽，请收窄"
+
+
+async def test_approve_reject_admin_only(client):
+    await _hdr(client, "p9b-a4@example.com")  # 占位 admin
+    user = await _hdr(client, "p9b-u4@example.com")
+    lib_id = await _create_pending(client, user)
+    # 创建者（非 admin）不能审批自己的库
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=user)
+    assert resp.status_code == 403
+    resp = await client.post(f"/api/libraries/{lib_id}/reject", json={}, headers=user)
+    assert resp.status_code == 403
+
+
+async def test_pending_library_cannot_ingest(client, queue_stub):
+    admin = await _hdr(client, "p9b-a5@example.com")
+    await _promote_admin("p9b-a5@example.com")
+    lib_id = await _create_pending(client, admin)  # admin 建库同样落 pending
+    # 未审批激活 → 抓取被拒
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/ingest/run", json={"mode": "bootstrap"}, headers=admin
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == "LIBRARY_NOT_ACTIVE"
+    assert queue_stub.jobs == []
+
+    # 审批激活后可以触发（入队 run_voyage）
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    assert resp.status_code == 200, resp.text
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/ingest/run", json={"mode": "bootstrap"}, headers=admin
+    )
+    assert resp.status_code == 201, resp.text
+    assert queue_stub.jobs, "审批激活后触发应入队"
+
+
+async def test_rejected_library_cannot_ingest(client, queue_stub):
+    admin = await _hdr(client, "p9b-a6@example.com")
+    await _promote_admin("p9b-a6@example.com")
+    lib_id = await _create_pending(client, admin)
+    await client.post(f"/api/libraries/{lib_id}/reject", json={"note": "no"}, headers=admin)
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/ingest/run", json={"mode": "bootstrap"}, headers=admin
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "LIBRARY_NOT_ACTIVE"
+    assert queue_stub.jobs == []
+
+
+async def test_pending_library_hidden_from_stranger(client):
+    await _hdr(client, "p9b-a7@example.com")  # 占位 admin
+    owner = await _hdr(client, "p9b-owner7@example.com")
+    stranger = await _hdr(client, "p9b-stranger7@example.com")
+    lib_id = await _create_pending(client, owner, name="私有待审批库")
+
+    # 列表：创建者看得到，陌生人看不到
+    resp = await client.get("/api/libraries", headers=owner)
+    assert lib_id in {x["id"] for x in resp.json()}
+    resp = await client.get("/api/libraries", headers=stranger)
+    assert lib_id not in {x["id"] for x in resp.json()}
+
+    # 详情：陌生人 404，创建者 200
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=stranger)
+    assert resp.status_code == 404
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=owner)
+    assert resp.status_code == 200
+
+
+async def test_admin_sees_others_pending(client):
+    admin = await _hdr(client, "p9b-a8@example.com")
+    await _promote_admin("p9b-a8@example.com")
+    owner = await _hdr(client, "p9b-owner8@example.com")
+    lib_id = await _create_pending(client, owner)
+
+    resp = await client.get("/api/libraries", headers=admin)
+    assert lib_id in {x["id"] for x in resp.json()}
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=admin)
+    assert resp.status_code == 200
+
+
+async def test_creator_can_manage_and_edit_own_pending(client):
+    await _hdr(client, "p9b-a9@example.com")  # 占位 admin
+    owner = await _hdr(client, "p9b-owner9@example.com")
+    lib_id = await _create_pending(client, owner)
+
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=owner)
+    assert resp.status_code == 200
+    assert resp.json()["can_manage"] is True
+
+    # 创建者可编辑自己的 pending 库配置（审批前调整）
+    resp = await client.patch(
+        f"/api/libraries/{lib_id}", json={"statement": "收窄后的方向"}, headers=owner
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["definition"]["statement"] == "收窄后的方向"
+
+
+async def test_active_library_visible_to_all(client):
+    admin = await _hdr(client, "p9b-a10@example.com")
+    await _promote_admin("p9b-a10@example.com")
+    owner = await _hdr(client, "p9b-owner10@example.com")
+    stranger = await _hdr(client, "p9b-stranger10@example.com")
+    lib_id = await _create_pending(client, owner, name="将被激活的库")
+    await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+
+    resp = await client.get("/api/libraries", headers=stranger)
+    assert lib_id in {x["id"] for x in resp.json()}
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=stranger)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "active"

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b8919453c913"  # 任务系统库化：voyage_runs/activities 可挂方向库（P9a）
-PREV_REVISION = "b3e9c1f47a20"  # direction_libraries.definition 收录配置权威（P8a）
+HEAD_REVISION = "d3a7f1c9b2e4"  # 文献库生命周期：direction_libraries.status/审批（P9b）
+PREV_REVISION = "b8919453c913"  # 任务系统库化：voyage_runs/activities 可挂方向库（P9a）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -61,6 +61,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "llm_usage",
                     "topic_source_libraries",
                     "activities",
+                    "direction_libraries",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -133,6 +134,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 任务系统库化 P9a：voyage_runs / activities 新增 library_id（project_id 转可空）
     assert "library_id" in columns["voyage_runs"]
     assert "library_id" in columns["activities"]
+    # 文献库生命周期 P9b：direction_libraries 新增 status/review_note/submitted_by
+    assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]
     # 垃圾桶原因等判断字段已迁 library_papers（P4 迁移 B 删列）
     assert "trash_reason" not in columns["papers"]
     assert "status" not in columns["papers"]
@@ -234,13 +237,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "topic_source_libraries" in columns["_tables"]
     assert columns["topic_source_libraries"] == {"topic_id", "library_id", "created_at"}
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（P8a），删 voyage_runs /
-    # activities 的 library_id 并把 project_id 收回 NOT NULL，其余结构不动。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（P9a），删
+    # direction_libraries 的 status/review_note/submitted_by，其余结构不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    assert "library_id" not in columns["voyage_runs"]  # P9a 列已回退
-    assert "library_id" not in columns["activities"]
+    # P9b 三列已回退，P9a 的 library_id 仍在（downgrade 只退一步）
+    assert not ({"status", "review_note", "submitted_by"} & columns["direction_libraries"])
+    assert "library_id" in columns["voyage_runs"]
+    assert "library_id" in columns["activities"]
     assert "topic_source_libraries" in columns["_tables"]  # P7 表仍在
     assert "library_id" in columns["llm_usage"]
     assert "library_id" in columns["llm_call_logs"]
@@ -288,3 +293,5 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # P9a 列在重新 upgrade 后回归
     assert "library_id" in columns["voyage_runs"]
     assert "library_id" in columns["activities"]
+    # P9b 列在重新 upgrade 后回归
+    assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]

--- a/src/backend/tests/test_source_libraries.py
+++ b/src/backend/tests/test_source_libraries.py
@@ -144,13 +144,23 @@ async def test_create_library_admin_independent(client):
     assert body["name"] == "独立库"
     assert body["project_id"] is None
     assert body["is_mine"] is False
+    # P9b：新建库落 pending 待审批（即便建库人是 admin，也需显式 approve 才激活）
+    assert body["status"] == "pending"
 
 
-async def test_create_library_non_admin_forbidden(client):
-    await _hdr(client, "p7u-admin5@example.com")  # 首个注册者=平台 admin，占位
-    member = await _hdr(client, "p7u-member5@example.com")
+async def test_create_library_any_user_allowed(client):
+    """P9b：建库权限放开——任意登录用户可建，新库 pending、创建者自动成为策展人。"""
+    await _hdr(client, "p9b-admin5@example.com")  # 首个注册者=平台 admin，占位
+    member = await _hdr(client, "p9b-member5@example.com")
     resp = await client.post("/api/libraries", json={"name": "x"}, headers=member)
-    assert resp.status_code == 403
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["can_manage"] is True  # 创建者可管理自己的 pending 库
+    # 创建者被记为该库策展人
+    resp = await client.get(f"/api/libraries/{body['id']}/curators", headers=member)
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 1
 
 
 async def test_source_libraries_read_write_api(client):

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -807,7 +807,12 @@ async def _create_standalone_library(client, headers, *, name="独立库-自动�
     payload.update(extra)
     resp = await client.post("/api/libraries", json=payload, headers=headers)
     assert resp.status_code == 201, resp.text
-    return resp.json()["id"]
+    library_id = resp.json()["id"]
+    # P9b：新库 pending，需 admin 审批激活后才能触发抓取（调用方均已 promote_admin）。
+    resp = await client.post(f"/api/libraries/{library_id}/approve", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    return library_id
 
 
 async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_mocks):

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -10,7 +10,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { AccordionSection } from '../../components/ui/Accordion';
 import { toast } from '../../components/ui/Toast';
 import { fmtTime } from '../../lib/format';
-import { api, ApiError, isAdmin, type DirectionLibrarySummary } from '../../lib/api';
+import { api, type DirectionLibrarySummary } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useLibraries, libraryPath } from './hooks';
 
@@ -26,6 +26,19 @@ const CADENCES = [
   { v: 'weekly', zh: '每周', en: 'Weekly' },
   { v: 'manual', zh: '手动', en: 'Manual' },
 ] as const;
+
+function StatusBadge({ status }: { status: DirectionLibrarySummary['status'] }) {
+  if (status === 'active') return null;
+  const cfg =
+    status === 'pending'
+      ? { zh: '待审批', en: 'Pending', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' }
+      : { zh: '已驳回', en: 'Rejected', bg: 'var(--danger-bg)', tx: 'var(--danger-tx)' };
+  return (
+    <span className="pill sm" style={{ background: cfg.bg, color: cfg.tx, flexShrink: 0 }}>
+      {tr(cfg.zh, cfg.en)}
+    </span>
+  );
+}
 
 function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: () => void }) {
   const updated = lib.last_compiled_at ?? lib.last_synced_at;
@@ -69,6 +82,7 @@ function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: ()
                 {tr('我在用', 'In use')}
               </span>
             )}
+            <StatusBadge status={lib.status} />
           </div>
         </div>
         <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0, marginTop: 4 }} />
@@ -104,34 +118,54 @@ function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: ()
   );
 }
 
-/** 新建文献库弹窗（仅平台管理员）。名称必填，其余为可选高级项。 */
+const QUICK_CATEGORIES = ['cs.CL', 'cs.AI', 'cs.LG', 'cs.CV', 'cs.MA', 'stat.ML'];
+
+// arXiv id 宽松校验：2401.01234 / 2401.01234v2 / 老式 hep-th/9901001
+const ARXIV_ID_RE = /^(\d{4}\.\d{4,5}(v\d+)?|[a-z\-]+\/\d{7}(v\d+)?)$/i;
+
+/**
+ * 新建文献库弹窗（P9b：任意登录用户可建）。名称 + 一句话说明必填；
+ * 锚点论文只填 arXiv-id（一行一个，抓取时解析元数据）；关键词 / 分类可选。
+ * 提交后建 pending 库，跳详情页，等管理员审批激活后才能开始抓取。
+ */
 function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
-  const [advOpen, setAdvOpen] = useState(false);
-  const [cadence, setCadence] = useState<string>('daily');
-  const [budget, setBudget] = useState('');
-  const [rubricText, setRubricText] = useState('');
   const [anchorsText, setAnchorsText] = useState('');
+  const [advOpen, setAdvOpen] = useState(false);
+  const [includeStr, setIncludeStr] = useState('');
+  const [categories, setCategories] = useState<string[]>([]);
+  const [customCat, setCustomCat] = useState('');
+  const [cadence, setCadence] = useState<string>('daily');
+
+  const anchorLines = anchorsText.split(/[\n,，]/).map((x) => x.trim()).filter(Boolean);
+  const badAnchors = anchorLines.filter((x) => !ARXIV_ID_RE.test(x));
+  const includeTerms = includeStr.split(/[,，\n]/).map((x) => x.trim()).filter(Boolean);
+
+  function toggleCat(c: string) {
+    setCategories((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  }
+  function addCustomCat() {
+    const c = customCat.trim();
+    if (c && !categories.includes(c)) setCategories((prev) => [...prev, c]);
+    setCustomCat('');
+  }
 
   const mutation = useMutation({
     mutationFn: (input: Parameters<typeof api.createLibrary>[0]) => api.createLibrary(input),
     onSuccess: (lib) => {
-      toast(tr('文献库已创建', 'Library created'), 'ok');
+      toast(
+        tr('已提交，待管理员审批激活后即可开始抓取', 'Submitted — an admin will review and activate it before ingest can start'),
+        'ok',
+      );
       void queryClient.invalidateQueries({ queryKey: ['libraries'] });
       onClose();
       navigate(libraryPath(lib.id));
     },
     onError: (err) => {
-      const forbidden = err instanceof ApiError && err.status === 403;
-      toast(
-        forbidden
-          ? tr('只有平台管理员可以新建文献库', 'Only a platform admin can create libraries')
-          : `${tr('创建失败：', 'Create failed: ')}${err instanceof Error ? err.message : String(err)}`,
-        'error',
-      );
+      toast(`${tr('创建失败：', 'Create failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error');
     },
   });
 
@@ -140,44 +174,24 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
       toast(tr('请填写文献库名称', 'Enter a library name'), 'info');
       return;
     }
-    let rubric: unknown;
-    if (rubricText.trim()) {
-      try {
-        rubric = JSON.parse(rubricText);
-      } catch {
-        toast(tr('评审标准不是合法 JSON', 'Rubric is not valid JSON'), 'error');
-        return;
-      }
+    if (!statement.trim()) {
+      toast(tr('请填写一句话说明', 'Enter a one-sentence statement'), 'info');
+      return;
     }
-    let anchors: unknown[] | undefined;
-    if (anchorsText.trim()) {
-      try {
-        const a = JSON.parse(anchorsText);
-        if (!Array.isArray(a)) {
-          toast(tr('锚点论文需为 JSON 数组', 'Anchors must be a JSON array'), 'error');
-          return;
-        }
-        anchors = a;
-      } catch {
-        toast(tr('锚点论文不是合法 JSON', 'Anchors are not valid JSON'), 'error');
-        return;
-      }
+    if (badAnchors.length > 0) {
+      toast(tr(`这些锚点不是合法 arXiv 编号：${badAnchors.join('、')}`, `Not valid arXiv ids: ${badAnchors.join(', ')}`), 'error');
+      return;
     }
-    let monthly_budget: number | undefined;
-    if (budget.trim()) {
-      monthly_budget = Number(budget);
-      if (!Number.isFinite(monthly_budget)) {
-        toast(tr('月度预算需为数字', 'Budget must be a number'), 'error');
-        return;
-      }
-    }
+    const keywords =
+      categories.length > 0 || includeTerms.length > 0
+        ? { arxiv_categories: categories, include: includeTerms }
+        : undefined;
     mutation.mutate({
       name: name.trim(),
-      statement: statement.trim() || undefined,
-      ...(rubric !== undefined ? { rubric } : {}),
-      ...(anchors !== undefined ? { anchors } : {}),
+      statement: statement.trim(),
+      ...(anchorLines.length > 0 ? { anchors: anchorLines } : {}),
+      ...(keywords ? { keywords } : {}),
       cadence,
-      ...(monthly_budget !== undefined ? { monthly_budget } : {}),
     });
   }
 
@@ -186,13 +200,16 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
       open={open}
       onClose={onClose}
       title={tr('新建文献库', 'New library')}
-      sub={tr('独立的共享文献库，与任何课题解耦；创建后可任命策展人维护。', 'A standalone shared library, decoupled from any topic — assign curators after creating.')}
-      width={600}
+      sub={tr(
+        '先填好方向，提交后由管理员审批激活；激活后才会开始抓取，创建本身不花额度。',
+        'Describe the direction and submit; an admin activates it. Ingest starts only after activation — creating costs nothing.',
+      )}
+      width={620}
       footer={
         <>
           <button className="btn btn-ghost sm" onClick={onClose}>{tr('取消', 'Cancel')}</button>
           <button className="btn btn-primary sm" disabled={mutation.isPending} onClick={submit}>
-            {mutation.isPending ? tr('创建中…', 'Creating…') : tr('创建文献库', 'Create library')}
+            {mutation.isPending ? tr('提交中…', 'Submitting…') : tr('提交待审批', 'Submit for review')}
           </button>
         </>
       }
@@ -202,33 +219,47 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
           <input className="input" value={name} onChange={(e) => setName(e.target.value)}
             placeholder={tr('如：稀疏注意力', 'e.g. Sparse attention')} />
         </FormField>
-        <FormField label={tr('一句话说明', 'Statement')} hint={tr('这个方向研究什么', 'What this direction studies')}>
+        <FormField label={tr('一句话说明', 'Statement')} hint={tr('这个方向研究什么（必填，用于相关性打分）', 'What this direction studies (required, used for relevance scoring)')}>
           <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('用一句话介绍这个文献库的方向', 'One sentence describing this library’s direction')} />
         </FormField>
-        <AccordionSection
-          title="高级设置（可选）"
-          en="Advanced (optional)"
-          open={advOpen}
-          onToggle={() => setAdvOpen((v) => !v)}
+        <FormField
+          label={tr('锚点论文（arXiv 编号，一行一个）', 'Anchor papers (arXiv ids, one per line)')}
+          hint={tr('可留空；抓取时会解析这些论文并做参考文献扩展', 'Optional; ingest resolves these and expands references')}
         >
-          <FormField label={tr('运行节奏', 'Cadence')} hint={tr('自动同步的运行频率', 'How often ingest runs')}>
+          <textarea className="textarea mono" rows={3} value={anchorsText} onChange={(e) => setAnchorsText(e.target.value)}
+            placeholder={'2401.01234\n2312.09876v2'} style={{ fontSize: 12.5 }} />
+          {badAnchors.length > 0 && (
+            <div style={{ color: 'var(--danger-tx)', fontSize: 11.5, marginTop: 4 }}>
+              {tr(`不是合法编号：${badAnchors.join('、')}`, `Not valid ids: ${badAnchors.join(', ')}`)}
+            </div>
+          )}
+        </FormField>
+        <AccordionSection title="收录设置（可选）" en="Inclusion (optional)" open={advOpen} onToggle={() => setAdvOpen((v) => !v)}>
+          <FormField label={tr('arXiv 分类', 'arXiv categories')} hint={tr('留空用默认分类', 'Leave empty for defaults')}>
+            <div className="row gap6 wrap">
+              {[...new Set([...QUICK_CATEGORIES, ...categories])].map((c) => (
+                <button key={c} type="button" className={'chip mono' + (categories.includes(c) ? ' on' : '')} onClick={() => toggleCat(c)}>
+                  {c}
+                </button>
+              ))}
+            </div>
+            <div className="row gap8" style={{ marginTop: 6 }}>
+              <input className="input" style={{ width: 170 }} placeholder={tr('自定义分类，如 cs.IR', 'custom, e.g. cs.IR')}
+                value={customCat} onChange={(e) => setCustomCat(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomCat(); } }} />
+              <button className="btn btn-soft sm" onClick={addCustomCat} disabled={!customCat.trim()}>{tr('添加', 'Add')}</button>
+            </div>
+          </FormField>
+          <FormField label={tr('检索关键词（逗号分隔）', 'Include terms (comma-separated)')} hint={tr('可留空', 'Optional')}>
+            <textarea className="textarea" rows={2} value={includeStr} onChange={(e) => setIncludeStr(e.target.value)}
+              placeholder={tr('如 agent, tool use, planning', 'e.g. agent, tool use, planning')} />
+          </FormField>
+          <FormField label={tr('运行节奏', 'Cadence')} hint={tr('激活后自动同步的运行频率', 'How often ingest runs after activation')}>
             <div>
               <Segmented options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
                 value={cadence as (typeof CADENCES)[number]['v']} onChange={(v) => setCadence(v)} />
             </div>
-          </FormField>
-          <FormField label={tr('月度预算（token）', 'Monthly budget (tokens)')} hint={tr('留空 = 不限', 'Leave blank for unlimited')}>
-            <input className="input mono" inputMode="numeric" value={budget} onChange={(e) => setBudget(e.target.value)}
-              placeholder={tr('如 2000000', 'e.g. 2000000')} />
-          </FormField>
-          <FormField label={tr('评审标准 rubric（JSON）', 'Rubric (JSON)')} hint={tr('可留空，稍后在库管理里调', 'Optional — edit later in library management')}>
-            <textarea className="textarea mono" rows={4} value={rubricText} onChange={(e) => setRubricText(e.target.value)}
-              placeholder={'[{"name": "新颖性", "description": "…", "weight": 1.0}]'} style={{ fontSize: 12 }} />
-          </FormField>
-          <FormField label={tr('锚点论文（JSON 数组）', 'Anchor papers (JSON array)')} hint={tr('可留空', 'Optional')}>
-            <textarea className="textarea mono" rows={3} value={anchorsText} onChange={(e) => setAnchorsText(e.target.value)}
-              placeholder={'[{"title": "…", "arxiv_id": "…"}]'} style={{ fontSize: 12 }} />
           </FormField>
         </AccordionSection>
       </div>
@@ -240,7 +271,7 @@ export function LibrariesPage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, refetch } = useLibraries();
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
-  const canCreate = isAdmin(me);
+  const canCreate = !!me;
   const [createOpen, setCreateOpen] = useState(false);
   const libraries = data ?? [];
   // 我的课题关联的库排前面，其余按名称

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -1,19 +1,25 @@
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { api } from '../../lib/api';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { api, ApiError, isAdmin, type DirectionLibraryDetail, type IngestMode } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { WikiWorkbench } from '../wiki/WikiPage';
+import { GovernanceTab } from '../wiki/GovernanceTab';
 import { LibraryBrowse } from './LibraryBrowse';
 
 /* ============================================================
-   /libraries/:id — 文献库详情（P5c + P6 治理）
-   - 可管理者（成员 / 文献库管理员 / 平台管理员）：完整工作台
-     （论文管理 / 概念 / 图谱 / 对话 / 建库与同步 / 笔记 / 治理，
-     仍走 project 作用域端点）；
-   - 其他人：干净的只读浏览（论文 + 概念，走 /libraries 读端点）。
+   /libraries/:id — 文献库详情（P5c + P6 治理 + P9b 生命周期）
+   - 可管理者（成员 / 文献库管理员 / 创建者 / 平台管理员）：完整工作台。
+     · 有起源课题的库 → project 作用域工作台（论文/概念/图谱/对话/建库/笔记/治理）；
+     · 独立库（project_id=NULL）→ 库作用域管理台（论文浏览 / 建库与同步 / 治理，
+       走 /libraries 端点；对话/图谱/笔记深绑课题，独立库下暂不提供）。
+   - 其他人：干净的只读浏览（论文 + 概念）。
+   顶部按状态显示横幅：待审批 / 已驳回；平台管理员可就地批准 / 驳回。
    ============================================================ */
 
 export function LibraryDetailPage() {
@@ -60,7 +66,8 @@ export function LibraryDetailPage() {
     );
   }
 
-  const canManage = lib.can_manage && !!lib.project_id;
+  const canManage = lib.can_manage;
+  const standalone = !lib.project_id;
 
   return (
     <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
@@ -70,19 +77,196 @@ export function LibraryDetailPage() {
         dense
         sub={lib.statement ?? undefined}
         right={
-          <>
-            <button className="btn btn-ghost" onClick={() => navigate('/libraries')}>
-              <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
-              {tr('全部文献库', 'All libraries')}
-            </button>
-          </>
+          <button className="btn btn-ghost" onClick={() => navigate('/libraries')}>
+            <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
+            {tr('全部文献库', 'All libraries')}
+          </button>
         }
       />
-      {canManage ? (
-        <WikiWorkbench pid={lib.project_id!} libraryId={lib.id} />
+      <StatusBanner lib={lib} />
+      {canManage && lib.project_id ? (
+        <WikiWorkbench pid={lib.project_id} libraryId={lib.id} />
+      ) : canManage && standalone ? (
+        <StandaloneWorkbench lib={lib} />
       ) : (
         <LibraryBrowse libraryId={lib.id} />
       )}
+    </div>
+  );
+}
+
+/* —— 状态横幅：待审批 / 已驳回；平台管理员就地批准 / 驳回 —— */
+
+function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
+  const queryClient = useQueryClient();
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
+  const admin = isAdmin(me);
+  const [rejecting, setRejecting] = useState(false);
+  const [note, setNote] = useState('');
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['library', lib.id] });
+    void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+  };
+  const approve = useMutation({
+    mutationFn: () => api.approveLibrary(lib.id),
+    onSuccess: () => { toast(tr('已激活，可以开始抓取了', 'Activated — ingest can start now'), 'ok'); invalidate(); },
+    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
+  });
+  const reject = useMutation({
+    mutationFn: () => api.rejectLibrary(lib.id, note.trim() || null),
+    onSuccess: () => { toast(tr('已驳回', 'Rejected'), 'ok'); setRejecting(false); setNote(''); invalidate(); },
+    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
+  });
+
+  if (lib.status === 'active') return null;
+
+  const pending = lib.status === 'pending';
+  const bg = pending ? 'var(--warn-bg)' : 'var(--danger-bg)';
+  const tx = pending ? 'var(--warn-tx)' : 'var(--danger-tx)';
+
+  return (
+    <div
+      className="card"
+      style={{ background: bg, borderColor: tx, padding: '12px 16px', marginBottom: 14 }}
+    >
+      <div className="row" style={{ justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+        <div className="col gap4" style={{ minWidth: 0 }}>
+          <div className="row gap8" style={{ color: tx, fontWeight: 680, fontSize: 13.5 }}>
+            <Icon name={pending ? 'clock' : 'x'} size={14} />
+            {pending ? tr('待审批', 'Pending review') : tr('已驳回', 'Rejected')}
+          </div>
+          <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
+            {pending
+              ? tr('管理员激活后才能开始抓取；创建本身不花额度。', 'Ingest can start only after an admin activates it; creating costs nothing.')
+              : lib.review_note
+                ? tr(`驳回理由：${lib.review_note}`, `Reason: ${lib.review_note}`)
+                : tr('未通过审批。可调整配置后请管理员重新审批。', 'Not approved. Adjust the config and ask an admin to review again.')}
+          </div>
+        </div>
+        {admin && (
+          <div className="row gap8" style={{ flexShrink: 0 }}>
+            <button className="btn btn-primary sm" disabled={approve.isPending} onClick={() => approve.mutate()}>
+              {approve.isPending ? tr('处理中…', 'Working…') : tr('批准激活', 'Approve')}
+            </button>
+            {pending && (
+              <button className="btn btn-soft sm" disabled={reject.isPending} onClick={() => setRejecting((v) => !v)}>
+                {tr('驳回', 'Reject')}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      {admin && rejecting && (
+        <div className="row gap8" style={{ marginTop: 10 }}>
+          <input
+            className="input"
+            style={{ flex: 1 }}
+            placeholder={tr('驳回理由（可选）', 'Reason (optional)')}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          <button className="btn btn-primary sm" disabled={reject.isPending} onClick={() => reject.mutate()}>
+            {tr('确认驳回', 'Confirm reject')}
+          </button>
+          <button className="btn btn-ghost sm" onClick={() => { setRejecting(false); setNote(''); }}>
+            {tr('取消', 'Cancel')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* —— 独立库（project_id=NULL）管理台：论文浏览 / 建库与同步 / 治理 —— */
+
+type StandaloneTab = 'browse' | 'ingest' | 'govern';
+
+function StandaloneWorkbench({ lib }: { lib: DirectionLibraryDetail }) {
+  const [tab, setTab] = useState<StandaloneTab>('browse');
+  return (
+    <>
+      <div className="row" style={{ marginBottom: 14 }}>
+        <Segmented<StandaloneTab>
+          options={[
+            { v: 'browse', label: tr('论文与概念', 'Papers & concepts') },
+            { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
+            { v: 'govern', label: tr('治理', 'Governance') },
+          ]}
+          value={tab}
+          onChange={setTab}
+        />
+      </div>
+      {tab === 'browse' ? (
+        <LibraryBrowse libraryId={lib.id} />
+      ) : tab === 'ingest' ? (
+        <div className="card" style={{ flex: 1, minHeight: 480, overflow: 'auto' }}>
+          <LibraryIngestPanel lib={lib} />
+        </div>
+      ) : (
+        <div className="card" style={{ flex: 1, minHeight: 480, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <GovernanceTab libraryId={lib.id} />
+        </div>
+      )}
+    </>
+  );
+}
+
+/* —— 库级抓取触发（走 POST /libraries/{id}/ingest/run，P9a；仅 active 可触发） —— */
+
+function LibraryIngestPanel({ lib }: { lib: DirectionLibraryDetail }) {
+  const navigate = useNavigate();
+  const active = lib.status === 'active';
+
+  const run = useMutation({
+    mutationFn: (mode: IngestMode) => api.startLibraryIngest(lib.id, { mode }),
+    onSuccess: (voyage) => {
+      toast(tr('已开始抓取', 'Ingest started'), 'ok');
+      navigate(`/voyages/${voyage.id}`);
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.message : '';
+      const msg =
+        code === 'LIBRARY_NOT_ACTIVE'
+          ? tr('文献库还未激活，无法抓取', 'Library is not active yet')
+          : code === 'INGEST_ALREADY_RUNNING'
+            ? tr('已有一个抓取任务在跑，请等它结束', 'An ingest is already running — wait for it to finish')
+            : code === 'LIBRARY_BUDGET_EXHAUSTED'
+              ? tr('本月预算已用尽，下月恢复或调高上限', 'Monthly budget is used up — resumes next month or raise the cap')
+              : tr('启动失败，请重试', 'Failed to start, please retry');
+      toast(msg, 'error');
+    },
+  });
+
+  return (
+    <div className="col gap16" style={{ padding: 20, maxWidth: 640 }}>
+      <div>
+        <h3 style={{ fontSize: 14, fontWeight: 700, marginBottom: 6 }}>{tr('建库与同步', 'Ingest & sync')}</h3>
+        <p className="muted" style={{ fontSize: 12.5, lineHeight: 1.6 }}>
+          {tr(
+            '初始建库会按收录设置检索 arXiv、做参考文献扩展、打分并编译解读；之后用增量更新只补新论文。抓取消耗记本库预算。',
+            'Bootstrap searches arXiv by the inclusion settings, expands references, scores and compiles wikis; later use incremental sync for new papers only. Token cost is billed to this library’s budget.',
+          )}
+        </p>
+      </div>
+      {!active && (
+        <div className="card" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', padding: '10px 14px', fontSize: 12.5 }}>
+          {tr('文献库待激活：管理员批准后才能开始抓取。', 'Library is not active yet — an admin must approve it before ingest can start.')}
+        </div>
+      )}
+      <div className="row gap10">
+        <button className="btn btn-primary" disabled={!active || run.isPending} onClick={() => run.mutate('bootstrap')}>
+          <Icon name="sparkle" size={14} />
+          {run.isPending ? tr('启动中…', 'Starting…') : tr('初始建库', 'Bootstrap')}
+        </button>
+        <button className="btn btn-soft" disabled={!active || run.isPending} onClick={() => run.mutate('incremental')}>
+          <Icon name="refresh" size={14} />
+          {tr('增量更新', 'Incremental sync')}
+        </button>
+      </div>
+      <p className="muted" style={{ fontSize: 11.5 }}>
+        {tr('在「治理」页签里可以调整收录分类、关键词与打分标准。', 'Tune inclusion categories, keywords and rubric in the Governance tab.')}
+      </p>
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -806,8 +806,14 @@ export interface DirectionLibrarySummary {
   project_id: string | null;
   /** 是否「我的课题的库」（请求者是背后课题成员 → 显示管理页签） */
   is_mine: boolean;
-  /** 是否可管理本库：成员 ∪ 文献库管理员 ∪ 平台管理员（P6） */
+  /** 是否可管理本库：成员 ∪ 文献库管理员 ∪ 创建者 ∪ 平台管理员（P6/P9b） */
   can_manage: boolean;
+  /** 生命周期（P9b）：pending 待审批 | active 已激活 | rejected 已驳回 */
+  status: 'pending' | 'active' | 'rejected';
+  /** 驳回理由（status=rejected 时有值） */
+  review_note: string | null;
+  /** 库创建者（用户建库；pending/rejected 库仅创建者 + 平台管理员可见） */
+  submitted_by: string | null;
   paper_count: number;
   concept_count: number;
   last_compiled_at: string | null;
@@ -2691,7 +2697,7 @@ export const api = {
   getLibrary(id: string): Promise<DirectionLibraryDetail> {
     return request<DirectionLibraryDetail>(`/libraries/${id}`);
   },
-  /** 新建共享文献库（仅平台 admin；非 admin 返回 403）。 */
+  /** 新建文献库（P9b：任意登录用户可建；新库 status=pending 待管理员审批激活）。 */
   createLibrary(input: {
     name: string;
     statement?: string | null;
@@ -2699,8 +2705,21 @@ export const api = {
     anchors?: unknown[];
     cadence?: string | null;
     monthly_budget?: number | null;
+    keywords?: KeywordSpec | null;
   }): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>('/libraries', 'POST', input);
+  },
+  /** 审批通过（仅平台管理员）：pending/rejected → active，激活后可触发抓取。 */
+  approveLibrary(id: string): Promise<DirectionLibraryDetail> {
+    return request<DirectionLibraryDetail>(`/libraries/${id}/approve`, { method: 'POST' });
+  },
+  /** 驳回（仅平台管理员）：→ rejected，可带理由。 */
+  rejectLibrary(id: string, note?: string | null): Promise<DirectionLibraryDetail> {
+    return requestJson<DirectionLibraryDetail>(`/libraries/${id}/reject`, 'POST', { note: note ?? null });
+  },
+  /** 对某个方向库直接触发抓取（P9a；仅 status=active 且预算内，可管理者）。 */
+  startLibraryIngest(id: string, input: { mode: IngestMode; knobs?: IngestKnobs }): Promise<VoyageRead> {
+    return requestJson<VoyageRead>(`/libraries/${id}/ingest/run`, 'POST', input);
   },
   /** 课题当前关联的文献库摘要（顺序 = 关联建立时间）。 */
   getSourceLibraries(projectId: string): Promise<DirectionLibrarySummary[]> {


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P9b. Stacked on #30 (P9a); merge #30 first, then this retargets to main. Implements the decided model: **users create libraries, admins approve/govern, the lab pays for crawling.**

## Backend
- **Migration `d3a7f1c9b2e4`**: `direction_libraries` gains `status` (`pending`/`active`/`rejected`, server_default `active` so all existing libraries backfill to active), `review_note`, `submitted_by`.
- **`POST /libraries` opened to any signed-in user**: new libraries start `pending`, the creator is recorded as `submitted_by` and auto-added as a curator, and creation triggers **no** crawl. Anchor input is a plain arxiv-id list.
- **Approval**: `POST /libraries/{id}/approve` / `POST /libraries/{id}/reject {note}` (admin). Admins can `PATCH` config before approving.
- **Gating**: `POST /libraries/{id}/ingest/run` requires `status == active` (409 `LIBRARY_NOT_ACTIVE`), so only approved libraries spend the lab budget.
- **Visibility**: pending/rejected libraries are visible only to their creator and admins (filtered from list; detail 404s otherwise). `can_manage_library` now includes the creator.

## Frontend
- **Standalone library console**: `LibraryDetailPage` no longer gates management on a project. Standalone libraries (`project_id = NULL`) get a `StandaloneWorkbench` with three tabs — papers & concepts (read via library endpoints), crawl & sync (the P9a per-library ingest trigger), and governance — so an admin-created library can be managed, browsed, and crawled without a topic.
- **Creation form** open to all users: name + statement, arxiv-id anchor list (validated), optional keywords/categories; submits a pending library with a "waiting for admin approval" toast.
- **Approval UI**: status banner on the detail page; admins get approve/reject (with reason); ingest is disabled until active; list cards show a status badge.

## Known scope boundary
The full editing `WikiWorkbench` tabs (paper tags/trash/recompile, graph, chat, notes) remain project-keyed — they lack library-level backend endpoints. Standalone libraries therefore expose browse + crawl + governance (the three hard requirements), with those editing tabs hidden rather than half-wired. Bringing full paper management to standalone libraries needs library-level endpoints and is a separate follow-up.

## Tests
546 passed (536 baseline + 10 new approval/gating/visibility tests), 16 pre-existing errors, 1 pre-existing env feedback failure — no new failures. Migration sqlite roundtrip updated (PREV `b8919453c913`) and verified; frontend tsc + build pass; ruff clean.