### PR TITLE
feat: retire implicit libraries, slim topic wizard to linked libraries (P9c)

### DIFF
--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -220,9 +220,7 @@ async def register(
             await projects_service.create_project(
                 session,
                 owner_id=user.id,
-                data=ProjectCreate(
-                    name=direction[:255], definition={"statement": direction}
-                ),
+                data=ProjectCreate(name=direction[:255], statement=direction),
             )
         except Exception:  # noqa: BLE001
             logger.exception("preset direction project creation failed: %s", direction)

--- a/src/backend/app/models/project.py
+++ b/src/backend/app/models/project.py
@@ -16,9 +16,11 @@ class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
-    definition: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 访谈结果 JSON
-    # 文献 ingest 状态：{"watermark": iso, "last_run": {"voyage_id", "finished_at"}}
-    # 已处理论文不入此列——去重以 Paper 表（arxiv_id/doi/title）为准
+    # P9c：仅存 {"statement": 一句话}（课题语境提示）。收录配置（rubric/anchors/
+    # keywords/goals/scope/questions/cadence）权威源在文献库 definition，不再进此列。
+    definition: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    # 已退役（P8/P9c）：水位线/last_run 权威源在库 ``DirectionLibrary.ingest_state``。
+    # 此列不再被读写，保留仅为暂缓删列（后续迁移可 drop）。
     ingest_state: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     status: Mapped[str] = mapped_column(String(32), default="active", nullable=False)
     owner_id: Mapped[uuid.UUID] = mapped_column(

--- a/src/backend/app/schemas/project.py
+++ b/src/backend/app/schemas/project.py
@@ -45,9 +45,18 @@ class DraftDefinitionResponse(BaseModel):
 
 
 class ProjectCreate(BaseModel):
+    """建课题入参（P9c）：只有名称 + 一句话 + 关联哪些已有文献库。
+
+    不再接收收录配置（rubric/anchors/keywords/goals/scope/questions/cadence）——
+    那些属于文献库（独立创建、管理员审批）。``statement`` 存入 ``project.definition``
+    的 ``statement`` 键（课题语境提示，非收录配置权威）；``source_library_ids``
+    关联已有库（可为空，空=课题暂无语料）。
+    """
+
     name: str = Field(min_length=1, max_length=255)
     slug: str | None = None  # 缺省时由 name 生成
-    definition: dict[str, Any] | None = None
+    statement: str | None = Field(default=None, max_length=2000)
+    source_library_ids: list[uuid.UUID] = Field(default_factory=list)
 
 
 class ProjectUpdate(BaseModel):

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -175,7 +175,14 @@ async def create_ingest_voyage(
 
 
 async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str, int]:
+    counts = {status: 0 for status in PAPER_STATUSES}
+    # P9c：课题可无起源库（空语料）——直接给零计数，不报错。
     library = await get_library_for_project(session, project_id)
+    if library is None:
+        counts["total"] = 0
+        counts["library"] = 0
+        counts["pending_compile"] = 0
+        return counts
     rows = (
         await session.execute(
             select(LibraryPaper.status, func.count())
@@ -183,7 +190,6 @@ async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str
             .group_by(LibraryPaper.status)
         )
     ).all()
-    counts = {status: 0 for status in PAPER_STATUSES}
     total = 0
     for status, count in rows:
         counts[status] = int(count)

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -25,22 +25,6 @@ from app.models.project import Project, ProjectMember
 from app.models.user import User
 
 
-def implicit_library_for(project: Project) -> DirectionLibrary:
-    """按 project 组一个隐式库对象（继承 definition 的 statement/rubric/anchors/cadence）。"""
-    definition = project.definition if isinstance(project.definition, dict) else {}
-    return DirectionLibrary(
-        name=project.name,
-        statement=definition.get("statement"),
-        rubric=definition.get("rubric"),
-        anchors=definition.get("anchor_papers"),
-        definition=definition or None,  # P8a：库承载完整收录配置
-        ingest_state=project.ingest_state,
-        cadence=definition.get("cadence"),
-        created_by=project.owner_id,
-        project_id=project.id,
-    )
-
-
 def library_definition(library: DirectionLibrary) -> dict[str, Any]:
     """库的收录配置（P8a 权威源）：definition JSON；为空时回退标量列拼一份兼容视图。
 
@@ -71,7 +55,8 @@ async def get_library_for_project(
 
     P7 起管理/ingest 路径专用（历史 1:1 语义单库解析）；并集读路径改用
     ``get_source_libraries``/``get_source_library_ids``。不再兜底自动建库——
-    课题创建仍会建关联（services/projects.py），缺失即代表课题真的没有语料。
+    P9c 起课题创建不再自动建隐式库/建关联，缺失即代表课题真的没有语料（存量
+    隐式库仍靠 project_id 回指解析，是带起源溯源的普通独立库）。
     """
     stmt = select(DirectionLibrary).where(DirectionLibrary.project_id == project_id)
     library = (await session.execute(stmt)).scalar_one_or_none()

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -49,27 +49,30 @@ async def list_projects(session: AsyncSession, user_id: uuid.UUID) -> Sequence[P
 async def create_project(
     session: AsyncSession, owner_id: uuid.UUID, data: ProjectCreate
 ) -> Project:
-    """建项目并把 owner 记为成员（role=owner）。"""
+    """建课题并把 owner 记为成员（role=owner）。
+
+    P9c：课题不再拥有库，也不拥有收录配置——不自动建隐式库、不写收录配置。
+    只建 project（name + 一句话 statement 存入 ``definition.statement`` 供课题语境
+    提示）+ 按 ``source_library_ids`` 关联**已有**文献库（可为空，空=课题暂无语料，
+    各消费端给空态）。文献库全部是独立创建、管理员审批的（P9b）。
+    """
     slug = await _unique_slug(session, data.slug or slugify(data.name))
+    statement = (data.statement or "").strip()
     project = Project(
         name=data.name,
         slug=slug,
-        definition=data.definition,
+        definition={"statement": statement} if statement else None,
         owner_id=owner_id,
     )
     session.add(project)
     await session.flush()
     session.add(ProjectMember(project_id=project.id, user_id=owner_id, role="owner"))
-    # 过渡期：每个课题仍自动建一个起源库（论文归属经 library_papers 引用内容池）。
-    # P7 起库/课题解耦——这里同时把它记成一条关联（topic_source_libraries），
-    # 语料并集读路径与「起源库」解析口径一致；Step 3 将改为可选关联既有库，
-    # 不再强制新建。
-    from app.services.libraries import implicit_library_for, set_source_libraries
+    if data.source_library_ids:
+        from app.services.libraries import set_source_libraries
 
-    library = implicit_library_for(project)
-    session.add(library)
-    await session.flush()
-    await set_source_libraries(session, topic_id=project.id, library_ids=[library.id])
+        await set_source_libraries(
+            session, topic_id=project.id, library_ids=list(data.source_library_ids)
+        )
     await session.commit()
     await session.refresh(project)
     return project

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -115,21 +115,46 @@ _MEMBERSHIP_FIELDS = (
 )
 
 
-async def add_paper(session, *, project_id, **fields):
-    """测试造数据统一入口：建内容池 Paper + 隐式库成员行，返回 Paper。
+async def ensure_project_library(session, project_id):
+    """确保课题有一个 active 起源库并已关联；没有则新建（测试造数据用）。
 
-    兼容旧单表口径：status/relevance_score/wiki_content 等判断字段自动落成员行。
+    P9c 起 create_project 不再自动建隐式库——语料相关测试经此显式补一个
+    project_id 回指的 active 库并登记为关联，等价存量隐式库效果。
     """
     import uuid as _uuid
 
+    from app.models.library_direction import DirectionLibrary
+    from app.models.project import Project
+    from app.services.libraries import get_library_for_project, set_source_libraries
+
+    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
+    library = await get_library_for_project(session, pid)
+    if library is not None:
+        return library
+    project = await session.get(Project, pid)
+    library = DirectionLibrary(
+        name=project.name if project else "test-lib",
+        project_id=pid,
+        status="active",
+        created_by=None,
+    )
+    session.add(library)
+    await session.flush()
+    await set_source_libraries(session, topic_id=pid, library_ids=[library.id])
+    return library
+
+
+async def add_paper(session, *, project_id, **fields):
+    """测试造数据统一入口：建内容池 Paper + 起源库成员行，返回 Paper。
+
+    兼容旧单表口径：status/relevance_score/wiki_content 等判断字段自动落成员行。
+    """
     from app.models.library_direction import LibraryPaper
     from app.models.paper import Paper
-    from app.services.libraries import get_library_for_project
 
     member_kwargs = {k: fields.pop(k) for k in list(fields) if k in _MEMBERSHIP_FIELDS}
     member_kwargs.setdefault("status", "candidate")
-    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
-    library = await get_library_for_project(session, pid)
+    library = await ensure_project_library(session, project_id)
     paper = Paper(**fields)
     session.add(paper)
     await session.flush()
@@ -139,13 +164,12 @@ async def add_paper(session, *, project_id, **fields):
 
 
 async def membership_of(session, *, project_id, paper_id):
-    """取论文在某方向隐式库的成员行（断言判断字段用）。"""
+    """取论文在某课题起源库的成员行（断言判断字段用）。"""
     import uuid as _uuid
 
-    from app.services.libraries import get_library_for_project, get_membership
+    from app.services.libraries import get_membership
 
-    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
-    library = await get_library_for_project(session, pid)
+    library = await ensure_project_library(session, project_id)
     return await get_membership(
         session,
         library_id=library.id,
@@ -154,17 +178,13 @@ async def membership_of(session, *, project_id, paper_id):
 
 
 async def project_paper_rows(session, *, project_id):
-    """某方向隐式库的 (Paper, LibraryPaper) 全量列表（测试断言判断字段用）。"""
-    import uuid as _uuid
-
+    """某课题起源库的 (Paper, LibraryPaper) 全量列表（测试断言判断字段用）。"""
     from sqlalchemy import select
 
     from app.models.library_direction import LibraryPaper
     from app.models.paper import Paper
-    from app.services.libraries import get_library_for_project
 
-    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
-    library = await get_library_for_project(session, pid)
+    library = await ensure_project_library(session, project_id)
     rows = (
         await session.execute(
             select(Paper, LibraryPaper)
@@ -176,16 +196,12 @@ async def project_paper_rows(session, *, project_id):
 
 
 async def project_concepts(session, *, project_id):
-    """某方向隐式库的概念列表。"""
-    import uuid as _uuid
-
+    """某课题起源库的概念列表。"""
     from sqlalchemy import select
 
     from app.models.paper import Concept
-    from app.services.libraries import get_library_for_project
 
-    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
-    library = await get_library_for_project(session, pid)
+    library = await ensure_project_library(session, project_id)
     return list(
         (
             await session.execute(select(Concept).where(Concept.library_id == library.id))
@@ -194,18 +210,56 @@ async def project_concepts(session, *, project_id):
 
 
 async def add_concept(session, *, project_id, **fields):
-    """建方向库概念（旧 Concept(project_id=...) 口径的替代）。"""
-    import uuid as _uuid
-
+    """建课题起源库概念（旧 Concept(project_id=...) 口径的替代）。"""
     from app.models.paper import Concept
-    from app.services.libraries import get_library_for_project
 
-    pid = project_id if isinstance(project_id, _uuid.UUID) else _uuid.UUID(str(project_id))
-    library = await get_library_for_project(session, pid)
+    library = await ensure_project_library(session, project_id)
     concept = Concept(library_id=library.id, **fields)
     session.add(concept)
     await session.flush()
     return concept
+
+
+async def make_project_with_library(
+    client, headers, *, name="wiki-proj", statement=None, definition=None
+):
+    """建课题 + 一条 active 起源库（可带 definition）+ 关联，返回 (project_id, library_id)。
+
+    P9c 起 create_project 不建库；依赖库语料/ingest 的 API 测试经此显式配库
+    （project_id 回指 + 关联，等价存量隐式库）。definition 同时镜像标量列，供
+    ingest 在 definition 为空时的回退读取。project_id 以 str 返回（与 API 一致）。
+    """
+    import uuid as _uuid
+
+    from app.core.db import get_sessionmaker
+    from app.models.library_direction import DirectionLibrary
+    from app.services.libraries import set_source_libraries
+
+    payload: dict = {"name": name}
+    if statement is not None:
+        payload["statement"] = statement
+    resp = await client.post("/api/projects", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    project_id = _uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        library = DirectionLibrary(
+            name=name,
+            definition=definition,
+            project_id=project_id,
+            status="active",
+            created_by=None,
+        )
+        if definition:
+            library.statement = definition.get("statement")
+            library.rubric = definition.get("rubric")
+            library.anchors = definition.get("anchor_papers")
+            library.cadence = definition.get("cadence")
+        session.add(library)
+        await session.flush()
+        await set_source_libraries(session, topic_id=project_id, library_ids=[library.id])
+        await session.commit()
+        library_id = library.id
+    return str(project_id), library_id
 
 
 def _username_from_email(email: str) -> str:

--- a/src/backend/tests/test_idea_forge.py
+++ b/src/backend/tests/test_idea_forge.py
@@ -32,7 +32,7 @@ async def _setup_project(client, email="alice@example.com", name="forge-proj"):
     token = await register_and_login(client, email)
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post(
-        "/api/projects", json={"name": name, "definition": DEFINITION}, headers=headers
+        "/api/projects", json={"name": name, "statement": DEFINITION["statement"]}, headers=headers
     )
     assert resp.status_code == 201, resp.text
     return resp.json()["id"], headers

--- a/src/backend/tests/test_idea_proposal.py
+++ b/src/backend/tests/test_idea_proposal.py
@@ -34,7 +34,7 @@ async def _setup_project(client, *, statement=STATEMENT, email="alice@example.co
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post(
         "/api/projects",
-        json={"name": "deep-proj", "definition": {"statement": statement}},
+        json={"name": "deep-proj", "statement": statement},
         headers=headers,
     )
     assert resp.status_code == 201, resp.text

--- a/src/backend/tests/test_library_budget.py
+++ b/src/backend/tests/test_library_budget.py
@@ -12,24 +12,16 @@ from app.models.library_direction import DirectionLibrary
 from app.models.llm_config import LLMUsage
 from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
-from tests.conftest import register_and_login
+from tests.conftest import make_project_with_library, register_and_login
 
 
 async def _setup_project(client, email="budget-owner@example.com"):
     token = await register_and_login(client, email=email)
     headers = {"Authorization": f"Bearer {token}"}
-    resp = await client.post("/api/projects", json={"name": "预算方向"}, headers=headers)
-    assert resp.status_code == 201, resp.text
-    project_id = resp.json()["id"]
-    async with get_sessionmaker()() as session:
-        library = (
-            await session.execute(
-                select(DirectionLibrary).where(
-                    DirectionLibrary.project_id == uuid.UUID(project_id)
-                )
-            )
-        ).scalar_one()
-        library_id = library.id
+    # P9c：课题不再自动建库——显式配一条 active 起源库（project_id 回指）。
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="预算方向"
+    )
     return headers, project_id, library_id
 
 

--- a/src/backend/tests/test_library_chat.py
+++ b/src/backend/tests/test_library_chat.py
@@ -50,7 +50,7 @@ async def _setup(client, tmp_path_factory=None):
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post(
         "/api/projects",
-        json={"name": "lib-chat", "definition": {"statement": "LLM agent 规划"}},
+        json={"name": "lib-chat", "statement": "LLM agent 规划"},
         headers=headers,
     )
     project_id = uuid.UUID(resp.json()["id"])

--- a/src/backend/tests/test_library_governance.py
+++ b/src/backend/tests/test_library_governance.py
@@ -9,7 +9,7 @@ from app.models.library_direction import DirectionLibrary, DirectionLibraryCurat
 from app.models.project import Project
 from app.models.user import User
 from app.services import libraries as libraries_service
-from tests.conftest import register_and_login
+from tests.conftest import make_project_with_library, register_and_login
 
 
 async def _register(client, email):
@@ -28,13 +28,9 @@ async def _setup(client):
     owner = await _register(client, "gov-owner@example.com")
     curator = await _register(client, "gov-curator@example.com")
     stranger = await _register(client, "gov-stranger@example.com")
-    resp = await client.post("/api/projects", json={"name": "治理方向"}, headers=owner)
-    assert resp.status_code == 201, resp.text
-    project_id = resp.json()["id"]
-    resp = await client.get("/api/libraries", headers=owner)
-    assert resp.status_code == 200, resp.text
-    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
-    return admin, owner, curator, stranger, project_id, library_id
+    # P9c：课题不再自动建库——显式建课题 + 关联一条 active 起源库（project_id 回指）。
+    project_id, library_id = await make_project_with_library(client, owner, name="治理方向")
+    return admin, owner, curator, stranger, project_id, str(library_id)
 
 
 async def _appoint(client, admin, library_id, email) -> uuid.UUID:

--- a/src/backend/tests/test_library_lifecycle.py
+++ b/src/backend/tests/test_library_lifecycle.py
@@ -1,21 +1,27 @@
-"""P7 Step 1：课题 × 文献库关联 + 库生命周期独立。
+"""P7/P9c：课题 × 文献库关联 + 库生命周期独立（建课题不再自动建库）。
 
-- 建课题仍自动建起源库，但同时落一条 topic_source_libraries 关联行；
-- 删课题不再级联删库：direction_libraries.project_id 置 NULL，library_papers/
-  concepts/curators 全部保留，只有该课题自己的关联行随课题消失；
+- P9c：建课题只建 project（+ 按入参关联已有库），不再自动建起源库；
+- 删课题不级联删库：起源库（存量隐式库，project_id 回指）的 project_id 置 NULL，
+  library_papers/concepts/curators 全部保留，只有该课题自己的关联行随课题消失；
 - DELETE /libraries/{id}（admin）：有课题关联默认 409，force=true 才删；论文
   内容池（papers 表）行永不受影响。
 """
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.core.db import get_sessionmaker
 from app.models.library_direction import DirectionLibrary, LibraryPaper, TopicSourceLibrary
 from app.models.paper import Concept, Paper
 from app.services import libraries as libraries_service
-from tests.conftest import add_concept, add_paper, register_and_login
+from tests.conftest import (
+    add_concept,
+    add_paper,
+    ensure_project_library,
+    make_project_with_library,
+    register_and_login,
+)
 
 
 async def _register(client, email):
@@ -23,19 +29,56 @@ async def _register(client, email):
     return {"Authorization": f"Bearer {token}"}
 
 
-async def test_create_project_associates_its_own_library(client):
+async def test_create_project_does_not_build_implicit_library(client):
+    """P9c：建课题不再自动建隐式库/建关联——direction_libraries 不新增行，语料为空。"""
     admin = await _register(client, "p7-admin1@example.com")
+    async with get_sessionmaker()() as session:
+        before = (
+            await session.execute(select(func.count()).select_from(DirectionLibrary))
+        ).scalar_one()
+
     resp = await client.post("/api/projects", json={"name": "P7 课题一"}, headers=admin)
     assert resp.status_code == 201, resp.text
     project_id = uuid.UUID(resp.json()["id"])
 
     async with get_sessionmaker()() as session:
-        library_ids = await libraries_service.get_source_library_ids(session, project_id)
-        assert len(library_ids) == 1
-        library = await libraries_service.get_library_for_project(session, project_id)
-        assert library is not None
-        assert library.id == library_ids[0]
-        assert library.project_id == project_id
+        # 无关联库、无起源库
+        assert await libraries_service.get_source_library_ids(session, project_id) == []
+        assert await libraries_service.get_library_for_project(session, project_id) is None
+        after = (
+            await session.execute(select(func.count()).select_from(DirectionLibrary))
+        ).scalar_one()
+        assert after == before  # 没有新建任何库
+
+
+async def test_create_project_can_link_existing_libraries(client):
+    """P9c：建课题入参可关联已有库；语料 = 关联库并集。"""
+    admin = await _register(client, "p7-link@example.com")
+    async with get_sessionmaker()() as session:
+        lib = DirectionLibrary(name="已有库", created_by=None, project_id=None, status="active")
+        session.add(lib)
+        await session.commit()
+        lib_id = lib.id
+
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "关联课题", "statement": "一句话", "source_library_ids": [str(lib_id)]},
+        headers=admin,
+    )
+    assert resp.status_code == 201, resp.text
+    project = resp.json()
+    assert project["definition"] == {"statement": "一句话"}
+    project_id = uuid.UUID(project["id"])
+
+    async with get_sessionmaker()() as session:
+        assert await libraries_service.get_source_library_ids(session, project_id) == [lib_id]
+        # 未新建任何 project_id 回指的起源库
+        origin = (
+            await session.execute(
+                select(func.count()).where(DirectionLibrary.project_id == project_id)
+            )
+        ).scalar_one()
+        assert origin == 0
 
 
 async def test_delete_project_keeps_library_and_content_orphans_association(client):
@@ -45,8 +88,8 @@ async def test_delete_project_keeps_library_and_content_orphans_association(clie
     project_id = uuid.UUID(resp.json()["id"])
 
     async with get_sessionmaker()() as session:
-        library = await libraries_service.get_library_for_project(session, project_id)
-        assert library is not None
+        # P9c：显式给课题配一条起源库（project_id 回指，等价存量隐式库）。
+        library = await ensure_project_library(session, project_id)
         library_id = library.id
         paper = await add_paper(
             session,
@@ -97,11 +140,8 @@ async def test_delete_project_keeps_library_and_content_orphans_association(clie
 
 async def test_delete_library_requires_force_when_topics_linked(client):
     admin = await _register(client, "p7-admin3@example.com")
-    resp = await client.post("/api/projects", json={"name": "P7 课题三"}, headers=admin)
-    assert resp.status_code == 201, resp.text
-    project_id = resp.json()["id"]
-    resp = await client.get("/api/libraries", headers=admin)
-    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+    # P9c：显式建课题 + 关联一条库，制造「库仍有课题关联」的状态。
+    _project_id, library_id = await make_project_with_library(client, admin, name="P7 课题三")
 
     resp = await client.delete(f"/api/libraries/{library_id}", headers=admin)
     assert resp.status_code == 409
@@ -116,18 +156,14 @@ async def test_delete_library_requires_force_when_topics_linked(client):
 async def test_delete_library_non_admin_forbidden(client):
     await _register(client, "p7-admin4@example.com")  # 首个注册者=平台 admin，占位
     member = await _register(client, "p7-member4@example.com")
-    resp = await client.post("/api/projects", json={"name": "P7 课题四"}, headers=member)
-    assert resp.status_code == 201, resp.text
-    project_id = resp.json()["id"]
-    resp = await client.get("/api/libraries", headers=member)
-    library_id = next(x["id"] for x in resp.json() if x["project_id"] == project_id)
+    _project_id, library_id = await make_project_with_library(client, member, name="P7 课题四")
 
     resp = await client.delete(f"/api/libraries/{library_id}", headers=member)
     assert resp.status_code == 403
 
 
 async def test_delete_library_without_topics_needs_no_force(client):
-    """独立库（无课题关联）删除不受 force 影响——为 Step 3 独立建库铺路的行为先行验证。"""
+    """独立库（无课题关联）删除不受 force 影响。"""
     admin = await _register(client, "p7-admin5@example.com")
     async with get_sessionmaker()() as session:
         library = DirectionLibrary(name="孤儿库", created_by=None, project_id=None)
@@ -140,26 +176,24 @@ async def test_delete_library_without_topics_needs_no_force(client):
 
 
 async def test_get_source_libraries_returns_multiple_associations(client):
-    """手动多关联一个库：get_source_libraries 返回并集；get_library_for_project 仍优先起源库。"""
+    """手动多关联一个库：get_source_libraries 返回并集；get_library_for_project 优先起源库。"""
     admin = await _register(client, "p7-admin6@example.com")
-    resp = await client.post("/api/projects", json={"name": "P7 课题六"}, headers=admin)
-    project_id = uuid.UUID(resp.json()["id"])
+    project_id_str, origin_id = await make_project_with_library(client, admin, name="P7 课题六")
+    project_id = uuid.UUID(project_id_str)
 
     async with get_sessionmaker()() as session:
-        origin = await libraries_service.get_library_for_project(session, project_id)
-        assert origin is not None
         extra = DirectionLibrary(name="额外方向库", created_by=None, project_id=None)
         session.add(extra)
         await session.flush()
         await libraries_service.set_source_libraries(
-            session, topic_id=project_id, library_ids=[origin.id, extra.id]
+            session, topic_id=project_id, library_ids=[origin_id, extra.id]
         )
         await session.commit()
         extra_id = extra.id
 
         libraries = await libraries_service.get_source_libraries(session, project_id)
-        assert {lib.id for lib in libraries} == {origin.id, extra_id}
+        assert {lib.id for lib in libraries} == {origin_id, extra_id}
 
         resolved = await libraries_service.get_library_for_project(session, project_id)
         assert resolved is not None
-        assert resolved.id == origin.id  # 起源库优先，即便有多个关联
+        assert resolved.id == origin_id  # 起源库（project_id 回指）优先，即便有多个关联

--- a/src/backend/tests/test_notes.py
+++ b/src/backend/tests/test_notes.py
@@ -94,9 +94,9 @@ async def test_notes_shared_across_topics_and_survive_library_removal(client):
     project2_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
         from app.models.library_direction import LibraryPaper
-        from app.services.libraries import get_library_for_project
+        from tests.conftest import ensure_project_library
 
-        library2 = await get_library_for_project(session, uuid.UUID(project2_id))
+        library2 = await ensure_project_library(session, uuid.UUID(project2_id))
         session.add(
             LibraryPaper(
                 library_id=library2.id, paper_id=uuid.UUID(ids["p1"]), status="included"

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -12,7 +12,7 @@ from app.models.paper import Paper
 from app.services.literature import reset_clients, set_clients
 from app.services.literature.arxiv import ArxivClient
 from app.services.literature.openalex import OpenAlexClient
-from tests.conftest import membership_of, register_and_login
+from tests.conftest import make_project_with_library, membership_of, register_and_login
 
 ARXIV_FEED_ONE = """<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
@@ -58,8 +58,9 @@ async def lit_clients():
 async def _setup(client):
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
-    resp = await client.post("/api/projects", json={"name": "manual-proj"}, headers=headers)
-    return resp.json()["id"], headers
+    # P9c：课题不再自动建库——显式配一条 active 起源库供人工纳入落成员行。
+    project_id, _library_id = await make_project_with_library(client, headers, name="manual-proj")
+    return project_id, headers
 
 
 @respx.mock

--- a/src/backend/tests/test_paper_merge.py
+++ b/src/backend/tests/test_paper_merge.py
@@ -20,7 +20,7 @@ from app.models.topic_shelf import TopicPaper
 from app.models.user import User
 from app.services import paper_merge as merge_service
 from app.services.libraries import get_library_for_project
-from tests.conftest import add_concept, add_paper, register_and_login
+from tests.conftest import add_concept, add_paper, ensure_project_library, register_and_login
 
 
 async def _setup(client, *, email="merge-owner@example.com", name="合并方向"):
@@ -44,8 +44,8 @@ async def test_merge_papers_full_repoint_with_conflicts(client):
         other_id = await _user_id(session, "merge-b@example.com")
         pid = uuid.UUID(project_id)
         pid_b = uuid.UUID(project_b)
-        lib_a = await get_library_for_project(session, pid)
-        lib_b = await get_library_for_project(session, pid_b)
+        lib_a = await ensure_project_library(session, pid)
+        lib_b = await ensure_project_library(session, pid_b)
 
         # keep：A 库 scored（无 wiki、无全文分段）
         keep = await add_paper(

--- a/src/backend/tests/test_personal_wiki.py
+++ b/src/backend/tests/test_personal_wiki.py
@@ -200,9 +200,9 @@ async def test_shelf_resolves_personal_wiki_between_live_and_snapshot(client):
     # 库后来收录并编译 → 库版实时优先
     async with get_sessionmaker()() as session:
         from app.models.library_direction import LibraryPaper
-        from app.services.libraries import get_library_for_project
+        from tests.conftest import ensure_project_library
 
-        library = await get_library_for_project(session, uuid.UUID(project_id))
+        library = await ensure_project_library(session, uuid.UUID(project_id))
         session.add(
             LibraryPaper(
                 library_id=library.id,

--- a/src/backend/tests/test_projects.py
+++ b/src/backend/tests/test_projects.py
@@ -12,7 +12,7 @@ async def test_create_and_list_projects(client):
 
     resp = await client.post(
         "/api/projects",
-        json={"name": "LLM 推理加速", "definition": {"topic": "inference"}},
+        json={"name": "LLM 推理加速", "statement": "推理加速方法"},
         headers=headers,
     )
     assert resp.status_code == 201, resp.text
@@ -20,7 +20,8 @@ async def test_create_and_list_projects(client):
     assert project["name"] == "LLM 推理加速"
     assert project["slug"]  # 自动生成
     assert project["status"] == "active"
-    assert project["definition"] == {"topic": "inference"}
+    # P9c：一句话 statement 存入 definition.statement；不含任何收录配置
+    assert project["definition"] == {"statement": "推理加速方法"}
 
     resp = await client.post(
         "/api/projects", json={"name": "Second", "slug": "second"}, headers=headers
@@ -149,3 +150,26 @@ async def test_get_project_not_member_404(client):
     # 非成员列表为空
     resp = await client.get("/api/projects", headers={"Authorization": f"Bearer {token_b}"})
     assert resp.json() == []
+
+
+async def test_create_project_empty_corpus_consumers_ok(client):
+    """P9c：空关联课题（无库、无语料）——论文列表 / ingest 状态等消费端优雅空态，不报错。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/projects", json={"name": "空语料课题", "statement": "还没关联库"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+
+    resp = await client.get(f"/api/projects/{project_id}/papers", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] == 0
+
+    resp = await client.get(f"/api/projects/{project_id}/source-libraries", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+    resp = await client.get(f"/api/projects/{project_id}/ingest/state", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["next_sync_at"] is None

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -35,6 +35,7 @@ from app.services.literature import (
 from app.services.literature.pdf_extract import figure_path
 from tests.conftest import (
     RecordingBus,
+    make_project_with_library,
     project_concepts,
     project_paper_rows,
     register_and_login,
@@ -244,11 +245,11 @@ async def wiki_mocks(app):
 async def _setup_project(client):
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
-    resp = await client.post(
-        "/api/projects", json={"name": "wiki-proj", "definition": DEFINITION}, headers=headers
+    # P9c：课题不再自动建库——显式配一个带 DEFINITION 的 active 起源库并关联。
+    project_id, _library_id = await make_project_with_library(
+        client, headers, name="wiki-proj", definition=DEFINITION
     )
-    assert resp.status_code == 201, resp.text
-    return resp.json()["id"], headers
+    return project_id, headers
 
 
 def _make_engine() -> tuple[VoyageEngine, RecordingBus]:
@@ -519,13 +520,12 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
     """稀疏 definition（只有 statement）也能跑通 bootstrap 全链路（默认 cs.* 分类兜底）。"""
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
-    resp = await client.post(
-        "/api/projects",
-        json={"name": "sparse-proj", "definition": {"statement": "自动化科研 agent 的方法研究"}},
-        headers=headers,
+    project_id, _library_id = await make_project_with_library(
+        client,
+        headers,
+        name="sparse-proj",
+        definition={"statement": "自动化科研 agent 的方法研究"},
     )
-    assert resp.status_code == 201, resp.text
-    project_id = resp.json()["id"]
 
     resp = await client.post(
         f"/api/projects/{project_id}/ingest",

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -4,183 +4,34 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { FormField } from '../../components/ui/FormField';
-import { Segmented } from '../../components/ui/Segmented';
-import { AccordionSection } from '../../components/ui/Accordion';
 import { toast } from '../../components/ui/Toast';
 import { topicPath, useProject } from '../../app/project';
-import { api, type AnchorPaper, type ProjectDefinition, type RubricDimension } from '../../lib/api';
+import { api } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useLibraries } from '../libraries/hooks';
 import { LibraryPicker } from '../libraries/LibraryPicker';
 
 /* ============================================================
-   /projects/new — 创建页，单页为主。
-   必填只有两项：课题名称 + 一句话定义（30 秒建课题）；
-   其下一个默认折叠的「文献追踪配置」区块收纳 include 关键词、
-   arXiv 分类与全部高级分区（目标/问题/rubric/锚点/同义词/节奏），
-   可稍后在课题设置里补。
-   「AI 帮我设置」按名称与一句话草拟文献追踪配置
-   （只填空白分区，不覆盖已填内容，可反复点）。
-   创建成功后跳课题工作台。
+   /projects/new — 建课题（30 秒）。
+   只有三件事：课题名称 + 一句话 statement + 关联哪些已有文献库（可跳过）。
+   收录配置（rubric / 关键词 / arXiv 分类 / 节奏 / 锚点 …）属于文献库，在
+   建库表单里填、由文献库管理员维护；建课题不碰这些。
+   创建成功后进课题工作台。
    ============================================================ */
-
-/** 常用 arXiv 分类快捷多选。 */
-const QUICK_CATEGORIES = ['cs.CL', 'cs.AI', 'cs.LG', 'cs.CV', 'cs.MA', 'stat.ML'];
-
-const CADENCES = [
-  { v: 'daily', zh: '每日', en: 'Daily' },
-  { v: 'weekly', zh: '每周', en: 'Weekly' },
-  { v: 'manual', zh: '手动', en: 'Manual' },
-] as const;
-
-const DEFAULT_RUBRIC: RubricRow[] = [
-  { name: '新颖性', description: '与已有工作的差异化程度', weight: '1.0' },
-  { name: '可行性', description: '现有资源下能否完成实验验证', weight: '1.0' },
-];
-
-type SectionKey = 'goals' | 'questions' | 'rubric' | 'anchors' | 'synonyms' | 'cadence';
-
-const SECTIONS: { key: SectionKey; zh: string; en: string }[] = [
-  { key: 'goals', zh: '目标与范围', en: 'Goals & Scope' },
-  { key: 'questions', zh: '研究问题', en: 'Research questions' },
-  { key: 'rubric', zh: '打分 Rubric', en: 'Scoring rubric' },
-  { key: 'anchors', zh: '锚点论文', en: 'Anchor papers' },
-  { key: 'synonyms', zh: '同义词映射', en: 'Synonyms' },
-  { key: 'cadence', zh: '运行节奏', en: 'Cadence' },
-];
-
-interface RubricRow {
-  name: string;
-  description: string;
-  weight: string; // 输入态为字符串，提交时 parse
-}
-
-interface SynonymRow {
-  term: string;
-  syns: string; // 逗号分隔
-}
-
-/* 可编辑列表行的稳定 key：index 作 key 时增删行会让受控输入串位 */
-let rowSeq = 0;
-type Keyed<T> = T & { _k: number };
-function withKey<T extends object>(row: T): Keyed<T> {
-  rowSeq += 1;
-  return { ...row, _k: rowSeq };
-}
-
-/** 字符串列表编辑器（回车/按钮添加，逐条删除）。 */
-function ListEditor({
-  items,
-  onChange,
-  placeholder,
-}: {
-  items: string[];
-  onChange: (items: string[]) => void;
-  placeholder?: string;
-}) {
-  const [draft, setDraft] = useState('');
-  function add() {
-    const v = draft.trim();
-    if (!v) return;
-    if (!items.includes(v)) onChange([...items, v]);
-    setDraft('');
-  }
-  return (
-    <div className="col gap8">
-      {items.map((it, i) => (
-        <div key={i} className="row gap8 list-row">
-          <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', width: 18, textAlign: 'right', flexShrink: 0 }}>
-            {i + 1}.
-          </span>
-          <span style={{ flex: 1, fontSize: 13, lineHeight: 1.45 }}>{it}</span>
-          <button className="icon-btn" style={{ width: 24, height: 24, border: 'none', background: 'transparent' }}
-            onClick={() => onChange(items.filter((_, j) => j !== i))} title={tr('删除', 'Remove')}>
-            <Icon name="x" size={13} />
-          </button>
-        </div>
-      ))}
-      <div className="row gap8">
-        <input
-          className="input"
-          style={{ flex: 1 }}
-          placeholder={placeholder}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              add();
-            }
-          }}
-        />
-        <button className="btn btn-soft sm" style={{ height: 38 }} onClick={add}>
-          <Icon name="plus" size={13} />
-          {tr('添加', 'Add')}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-/** chips 输入：回车添加，点击 chip 移除。 */
-function ChipsInput({
-  items,
-  onChange,
-  placeholder,
-}: {
-  items: string[];
-  onChange: (items: string[]) => void;
-  placeholder?: string;
-}) {
-  const [draft, setDraft] = useState('');
-  function add() {
-    const v = draft.trim();
-    if (!v) return;
-    if (!items.includes(v)) onChange([...items, v]);
-    setDraft('');
-  }
-  return (
-    <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
-      {items.map((t) => (
-        <button key={t} type="button" className="chip on" onClick={() => onChange(items.filter((x) => x !== t))}
-          title={tr('点击移除', 'Click to remove')}>
-          {t} ×
-        </button>
-      ))}
-      <input
-        className="input"
-        style={{ width: 220 }}
-        placeholder={placeholder}
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={add}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault();
-            add();
-          }
-        }}
-      />
-    </div>
-  );
-}
 
 export function ProjectWizardPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { setCurrentProjectId } = useProject();
 
-  const [formError, setFormError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [drafting, setDrafting] = useState(false);
-
-  // —— 必填：名称 + 一句话 ——
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
-  // —— 关联文献库（可选，可全部不选） ——
+  // 只能关联已激活（active）的文献库；pending/rejected 不作为语料
   const librariesQuery = useLibraries();
-  const libraries = librariesQuery.data ?? [];
+  const libraries = (librariesQuery.data ?? []).filter((l) => l.status === 'active');
   const [selectedLibraryIds, setSelectedLibraryIds] = useState<Set<string>>(new Set());
   function toggleLibrary(libId: string) {
     setSelectedLibraryIds((prev) => {
@@ -191,174 +42,20 @@ export function ProjectWizardPage() {
     });
   }
 
-  // —— 文献追踪配置（全部可选，默认折叠） ——
-  const [trackOpen, setTrackOpen] = useState(false);
-  const [includeTerms, setIncludeTerms] = useState<string[]>([]);
-  const [categories, setCategories] = useState<string[]>(['cs.CL', 'cs.AI']);
-  const [goals, setGoals] = useState<string[]>([]);
-  const [inScope, setInScope] = useState<string[]>([]);
-  const [outScope, setOutScope] = useState<string[]>([]);
-  const [questions, setQuestions] = useState<string[]>([]);
-  const [rubric, setRubric] = useState<Keyed<RubricRow>[]>(() => DEFAULT_RUBRIC.map(withKey));
-  const [anchors, setAnchors] = useState<Keyed<AnchorPaper>[]>([]);
-  const [synonyms, setSynonyms] = useState<Keyed<SynonymRow>[]>([]);
-  const [cadence, setCadence] = useState<string>('daily');
-  const [open, setOpen] = useState<Record<SectionKey, boolean>>({
-    goals: false, questions: false, rubric: false, anchors: false, synonyms: false, cadence: false,
-  });
-  const [aiFilled, setAiFilled] = useState<Set<SectionKey>>(new Set());
-
-  function toggleSection(k: SectionKey) {
-    setOpen((o) => ({ ...o, [k]: !o[k] }));
-  }
-
-  function toggleCategory(c: string) {
-    setCategories((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
-  }
-
-  function validateBasics(): string | null {
-    if (!name.trim()) return tr('请填写课题名称', 'Please enter a topic name');
-    if (!statement.trim()) return tr('请用一句话定义这个课题', 'Please define this topic in one sentence');
-    return null;
-  }
-
-  function buildDefinition(): ProjectDefinition {
-    const def: ProjectDefinition = { statement: statement.trim() };
-    if (goals.length) def.goals = goals;
-    if (inScope.length) def.in_scope = inScope;
-    if (outScope.length) def.out_of_scope = outScope;
-    if (questions.length) def.questions = questions;
-    const dims: RubricDimension[] = rubric
-      .filter((r) => r.name.trim())
-      .map((r) => ({ name: r.name.trim(), description: r.description.trim(), weight: Number(r.weight) || 1 }));
-    if (dims.length) def.rubric = dims;
-    const papers = anchors.filter((a) => a.title.trim());
-    if (papers.length) {
-      def.anchor_papers = papers.map((a) => ({
-        title: a.title.trim(),
-        ...(a.arxiv_id?.trim() ? { arxiv_id: a.arxiv_id.trim() } : {}),
-        ...(a.url?.trim() ? { url: a.url.trim() } : {}),
-        ...(a.reason?.trim() ? { reason: a.reason.trim() } : {}),
-      }));
-    }
-    const syn: Record<string, string[]> = {};
-    for (const s of synonyms) {
-      const term = s.term.trim();
-      const list = s.syns.split(/[,，、]/).map((x) => x.trim()).filter(Boolean);
-      if (term && list.length) syn[term] = list;
-    }
-    def.keywords = {
-      ...(categories.length ? { arxiv_categories: categories } : {}),
-      include: includeTerms,
-      ...(Object.keys(syn).length ? { synonyms: syn } : {}),
-    };
-    def.cadence = cadence;
-    return def;
-  }
-
-  /** 把 AI 草稿写入第 2 步各分区状态；返回被填入的分区（用于默认展开）。 */
-  function applyDraft(d: ProjectDefinition): Set<SectionKey> {
-    const filled = new Set<SectionKey>();
-    // 只填当前为空的分区：用户已填写的内容一律不覆盖
-    if (d.goals?.length || d.in_scope?.length || d.out_of_scope?.length) {
-      if (d.goals?.length && goals.length === 0) setGoals(d.goals);
-      if (d.in_scope?.length && inScope.length === 0) setInScope(d.in_scope);
-      if (d.out_of_scope?.length && outScope.length === 0) setOutScope(d.out_of_scope);
-      filled.add('goals');
-    }
-    if (d.questions?.length && questions.length === 0) {
-      setQuestions(d.questions);
-      filled.add('questions');
-    }
-    if (d.rubric?.length && JSON.stringify(rubric.map(({ _k, ...r }) => r)) === JSON.stringify(DEFAULT_RUBRIC)) {
-      setRubric(d.rubric.map((r) => withKey({ name: r.name, description: r.description ?? '', weight: String(r.weight ?? 1) })));
-      filled.add('rubric');
-    }
-    if (d.anchor_papers?.length && anchors.length === 0) {
-      setAnchors(d.anchor_papers.map(withKey));
-      filled.add('anchors');
-    }
-    if (d.keywords) {
-      const syn = d.keywords.synonyms;
-      if (syn && Object.keys(syn).length && synonyms.length === 0) {
-        setSynonyms(Object.entries(syn).map(([term, list]) => withKey({ term, syns: list.join(', ') })));
-        filled.add('synonyms');
-      }
-      // AI 建议的分类/关键词与用户已选合并（去重）
-      if (d.keywords.arxiv_categories?.length) {
-        setCategories((prev) => [...new Set([...prev, ...d.keywords!.arxiv_categories!])]);
-      }
-      if (d.keywords.include?.length) {
-        setIncludeTerms((prev) => [...new Set([...prev, ...d.keywords!.include!])]);
-      }
-    }
-    if (d.cadence) {
-      setCadence(d.cadence);
-      filled.add('cadence');
-    }
-    // 反复点「AI 帮我设置」时：徽标与展开状态做并集，不清掉上一轮的
-    setAiFilled((prev) => new Set([...prev, ...filled]));
-    setOpen((o) => ({
-      goals: o.goals || filled.has('goals'),
-      questions: o.questions || filled.has('questions'),
-      rubric: o.rubric || filled.has('rubric'),
-      anchors: o.anchors || filled.has('anchors'),
-      synonyms: o.synonyms || filled.has('synonyms'),
-      cadence: o.cadence || filled.has('cadence'),
-    }));
-    return filled;
-  }
-
-  /** 「AI 帮我设置」：按名称与一句话草拟 definition → 填入文献追踪配置的空白分区并展开。
-      不覆盖已填内容，可反复点（每次只补当前仍为空的分区）。 */
-  async function aiDraft() {
-    const err = validateBasics();
-    setFormError(err);
-    if (err) return;
-    setDrafting(true);
-    try {
-      const res = await api.draftDefinition({
-        statement: statement.trim(),
-        name: name.trim(),
-        keywords_include: includeTerms,
-      });
-      const filled = applyDraft(res.definition ?? {});
-      if (res.source === 'fallback') {
-        toast(tr('AI 未配置，已用默认模板', 'AI not configured — used the default template'), 'info');
-      } else if (filled.size === 0) {
-        toast(tr('文献追踪配置各分区都已有内容，没有需要 AI 补的空白', 'All tracking sections already have content — nothing for AI to fill'), 'info');
-      } else {
-        toast(tr('AI 草稿已生成，可在下方微调', 'AI draft ready — tweak it below'), 'ok');
-      }
-      setTrackOpen(true);
-    } catch (e) {
-      // 端点未就绪/调用失败：优雅降级，仍可手动填写或直接创建
-      toast(tr(`AI 设置失败：${e instanceof Error ? e.message : String(e)}，可手动填写文献追踪配置`, `AI setup failed: ${e instanceof Error ? e.message : String(e)} — you can fill the tracking settings manually`), 'error');
-      setTrackOpen(true);
-    } finally {
-      setDrafting(false);
-    }
-  }
-
-  /** 创建课题：成功后直接进课题工作台。 */
+  /** 创建课题：名称 + 一句话 + 关联库，一次调用；成功后进课题工作台。 */
   async function create() {
-    const err = validateBasics();
-    if (err) {
-      setFormError(err);
+    if (!name.trim()) {
+      setFormError(tr('请填写课题名称', 'Please enter a topic name'));
       return;
     }
     setFormError(null);
     setSubmitting(true);
     try {
-      const created = await api.createProject({ name: name.trim(), definition: buildDefinition() });
-      // 额外关联已勾选的共享文献库（隐式起源库由后端自动建，不在此列）
-      if (selectedLibraryIds.size > 0) {
-        try {
-          await api.setSourceLibraries(created.id, [...selectedLibraryIds]);
-        } catch (e) {
-          toast(tr(`课题已创建，但关联文献库失败：${e instanceof Error ? e.message : String(e)}，可在课题设置里重试`, `Topic created, but linking libraries failed: ${e instanceof Error ? e.message : String(e)} — retry in topic settings`), 'error');
-        }
-      }
+      const created = await api.createProject({
+        name: name.trim(),
+        statement: statement.trim() || undefined,
+        source_library_ids: [...selectedLibraryIds],
+      });
       await queryClient.invalidateQueries({ queryKey: ['projects'] });
       setCurrentProjectId(created.id);
       toast(tr('课题已创建', 'Topic created'), 'ok');
@@ -370,23 +67,27 @@ export function ProjectWizardPage() {
     }
   }
 
-  const busy = submitting || drafting;
-
   return (
-    <div className="page fadeup" style={{ maxWidth: 860 }}>
+    <div className="page fadeup" style={{ maxWidth: 720 }}>
       <PageHead
         eyebrow="Polaris · Topics"
         title={tr('新建课题', 'New topic')}
-        sub={tr('只需名称和一句话即可创建；文献追踪配置可选，也可稍后在课题设置里补。', 'Just a name and one sentence to create — literature tracking settings are optional and can be added later in topic settings.')}
+        sub={tr(
+          '名称 + 一句话即可创建；再选几个文献库作为语料（可跳过，稍后在课题设置里加）。',
+          'Just a name and one sentence to create — then pick a few libraries as your corpus (optional, add later in topic settings).',
+        )}
       />
 
-      {/* —— 必填：名称 + 一句话 —— */}
+      {/* —— 名称 + 一句话 —— */}
       <div className="card card-pad" style={{ marginBottom: 12 }}>
         <FormField label={tr('课题名称', 'Name')} hint={tr('将显示在侧栏与课题列表中', 'Shown in the sidebar and topic list')}>
           <input className="input" value={name} onChange={(e) => setName(e.target.value)}
             placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
         </FormField>
-        <FormField label={tr('一句话定义', 'Statement')} hint={tr('用一句话说清这个课题研究什么、为什么重要', 'One sentence on what this topic studies and why it matters')}>
+        <FormField
+          label={tr('一句话定义', 'Statement')}
+          hint={tr('用一句话说清这个课题研究什么、为什么重要（可选）', 'One sentence on what this topic studies and why it matters (optional)')}
+        >
           <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
         </FormField>
@@ -408,8 +109,8 @@ export function ProjectWizardPage() {
         </div>
         <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '2px 0 12px', lineHeight: 1.6 }}>
           {tr(
-            '课题的语料 = 关联文献库的并集；可全部不选跳过，稍后在课题设置里添加。',
-            'A topic\u2019s corpus is the union of its linked libraries \u2014 you can skip this and add libraries later in topic settings.',
+            '课题的语料 = 关联文献库的并集；文献库由文献库管理员维护，可全部不选跳过。',
+            'A topic’s corpus is the union of its linked libraries, maintained by library admins — you can skip this.',
           )}
         </div>
         {librariesQuery.isLoading ? (
@@ -419,200 +120,23 @@ export function ProjectWizardPage() {
             ))}
           </div>
         ) : libraries.length === 0 ? (
-          <div className="empty" style={{ padding: '20px 14px' }}>
-            {tr('还没有文献库，可先跳过，稍后关联。', 'No libraries yet \u2014 skip for now and link one later.')}
+          <div className="empty" style={{ padding: '20px 14px', textAlign: 'center' }}>
+            <div style={{ marginBottom: 10, color: 'var(--text-3)', lineHeight: 1.6 }}>
+              {tr('还没有可关联的文献库。', 'No libraries available to link yet.')}
+            </div>
+            <button className="btn btn-soft sm" onClick={() => navigate('/libraries')}>
+              <Icon name="book" size={13} />
+              {tr('去「文献库」新建一个（需管理员审批）', 'Create one under Libraries (needs admin approval)')}
+            </button>
           </div>
         ) : (
           <LibraryPicker libraries={libraries} selectedIds={selectedLibraryIds} onToggle={toggleLibrary} />
         )}
       </div>
 
-      {/* —— 文献追踪配置（可选，默认折叠） —— */}
-      <AccordionSection
-        title="文献追踪配置（可选，可稍后在课题设置里补）"
-        en="Literature tracking · optional, editable later in topic settings"
-        open={trackOpen}
-        onToggle={() => setTrackOpen((v) => !v)}
-        badge={aiFilled.size > 0 ? tr('AI 草稿', 'AI draft') : undefined}
-      >
-        <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '8px 0 14px', lineHeight: 1.6 }}>
-          {tr(
-            '以下内容全部可选，不填也能创建课题；启动文献追踪前需要至少 1 个 include 关键词。',
-            'Everything below is optional — you can create the topic without it; starting literature tracking requires at least 1 include term.',
-          )}
-          {aiFilled.size > 0 && tr(' AI 已预填部分分区，请确认或微调。', ' AI pre-filled some sections; review or tweak them.')}
-        </div>
-        <FormField label={tr('Include 关键词', 'Include terms')} hint={tr('标题/摘要命中这些词才进入相关性判定；回车添加，点击移除', 'Papers must match these in title/abstract to be scored; Enter to add, click to remove')}>
-          <ChipsInput items={includeTerms} onChange={setIncludeTerms} placeholder={tr('如 agent、tool use，回车添加', 'e.g. agent, tool use — Enter to add')} />
-        </FormField>
-        <FormField label={tr('arXiv 分类', 'arXiv categories')} hint={tr('常用分类快捷多选；更多分类可在创建后编辑', 'Quick-pick common categories; edit more after creating')}>
-          <div className="row gap6 wrap">
-            {QUICK_CATEGORIES.map((c) => (
-              <button key={c} type="button" className={'chip mono' + (categories.includes(c) ? ' on' : '')}
-                onClick={() => toggleCategory(c)}>
-                {c}
-              </button>
-            ))}
-            {categories.filter((c) => !QUICK_CATEGORIES.includes(c)).map((c) => (
-              <button key={c} type="button" className="chip mono on" onClick={() => toggleCategory(c)} title={tr('点击移除', 'Click to remove')}>
-                {c} ×
-              </button>
-            ))}
-          </div>
-        </FormField>
-        <div className="col gap10" style={{ marginTop: 4 }}>
-            {SECTIONS.map((s) => (
-              <AccordionSection key={s.key} title={tr(s.zh, s.en)} open={open[s.key]}
-                onToggle={() => toggleSection(s.key)}
-                badge={aiFilled.has(s.key) ? tr('AI 草稿', 'AI draft') : undefined}>
-                {s.key === 'goals' && (
-                  <>
-                    <FormField label={tr('研究目标', 'Goals')} hint={tr('这个课题希望达成什么', 'What this topic aims to achieve')}>
-                      <ListEditor items={goals} onChange={setGoals} placeholder={tr('输入一个目标后回车', 'Type a goal, then press Enter')} />
-                    </FormField>
-                    <div className="row gap16" style={{ alignItems: 'flex-start' }}>
-                      <FormField label={tr('范围内', 'In scope')} style={{ flex: 1 }}>
-                        <ListEditor items={inScope} onChange={setInScope} placeholder={tr('明确包含的主题', 'Topics explicitly included')} />
-                      </FormField>
-                      <FormField label={tr('范围外', 'Out of scope')} style={{ flex: 1 }}>
-                        <ListEditor items={outScope} onChange={setOutScope} placeholder={tr('明确排除的主题', 'Topics explicitly excluded')} />
-                      </FormField>
-                    </div>
-                  </>
-                )}
-
-                {s.key === 'questions' && (
-                  <FormField label={tr('具体研究问题', 'Research questions')} hint={tr('建议 3–5 个可验证的具体问题', '3–5 specific, verifiable questions recommended')}>
-                    <ListEditor items={questions} onChange={setQuestions} placeholder={tr('如：citation-graph 重排序能否降低新颖性幻觉？', 'e.g. Can citation-graph reranking reduce novelty hallucination?')} />
-                  </FormField>
-                )}
-
-                {s.key === 'rubric' && (
-                  <>
-                    <div className="field-hint" style={{ marginBottom: 10 }}>
-                      {tr('论文相关性 / idea 质量打分标准，可增删维度与权重', 'Scoring criteria for paper relevance / idea quality; add or remove dimensions and weights')}
-                    </div>
-                    <div className="col gap10">
-                      {rubric.map((r, i) => (
-                        <div key={r._k} className="row gap8" style={{ alignItems: 'flex-start' }}>
-                          <input className="input" style={{ width: 130 }} placeholder={tr('维度名', 'Dimension')}
-                            value={r.name}
-                            onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, name: e.target.value } : x)))} />
-                          <input className="input" style={{ flex: 1 }} placeholder={tr('打分标准描述', 'Scoring criteria')}
-                            value={r.description}
-                            onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, description: e.target.value } : x)))} />
-                          <input className="input mono" style={{ width: 72 }} placeholder={tr('权重', 'Weight')} inputMode="decimal"
-                            value={r.weight}
-                            onChange={(e) => setRubric(rubric.map((x, j) => (j === i ? { ...x, weight: e.target.value } : x)))} />
-                          <button className="icon-btn" style={{ height: 38 }} title={tr('删除维度', 'Remove dimension')}
-                            onClick={() => setRubric(rubric.filter((_, j) => j !== i))}>
-                            <Icon name="trash" size={14} />
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                    <button className="btn btn-soft sm" style={{ marginTop: 12 }}
-                      onClick={() => setRubric([...rubric, withKey({ name: '', description: '', weight: '1.0' })])}>
-                      <Icon name="plus" size={13} />
-                      {tr('添加维度', 'Add dimension')}
-                    </button>
-                  </>
-                )}
-
-                {s.key === 'anchors' && (
-                  <>
-                    <div className="field-hint" style={{ marginBottom: 10 }}>
-                      {tr('体现课题研究品味的代表作（可留空）', 'Representative papers that capture the taste of this topic (optional)')}
-                    </div>
-                    <div className="col gap12">
-                      {anchors.map((a, i) => (
-                        <div key={a._k} className="card" style={{ padding: '12px 14px', background: 'var(--surface-2)' }}>
-                          <div className="row gap8" style={{ marginBottom: 8 }}>
-                            <input className="input" style={{ flex: 1 }} placeholder={tr('论文标题（必填）', 'Paper title (required)')}
-                              value={a.title}
-                              onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, title: e.target.value } : x)))} />
-                            <button className="icon-btn" style={{ height: 38 }} title={tr('删除', 'Remove')}
-                              onClick={() => setAnchors(anchors.filter((_, j) => j !== i))}>
-                              <Icon name="trash" size={14} />
-                            </button>
-                          </div>
-                          <div className="row gap8" style={{ marginBottom: 8 }}>
-                            <input className="input mono" style={{ width: 160 }} placeholder="arxiv_id"
-                              value={a.arxiv_id ?? ''}
-                              onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, arxiv_id: e.target.value } : x)))} />
-                            <input className="input" style={{ flex: 1 }} placeholder="url"
-                              value={a.url ?? ''}
-                              onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, url: e.target.value } : x)))} />
-                          </div>
-                          <input className="input" style={{ width: '100%' }} placeholder={tr('为什么它是这个课题的锚点', 'Why this paper anchors the topic')}
-                            value={a.reason ?? ''}
-                            onChange={(e) => setAnchors(anchors.map((x, j) => (j === i ? { ...x, reason: e.target.value } : x)))} />
-                        </div>
-                      ))}
-                    </div>
-                    <button className="btn btn-soft sm" style={{ marginTop: 12 }}
-                      onClick={() => setAnchors([...anchors, withKey({ title: '', arxiv_id: '', url: '', reason: '' })])}>
-                      <Icon name="plus" size={13} />
-                      {tr('添加论文', 'Add paper')}
-                    </button>
-                  </>
-                )}
-
-                {s.key === 'synonyms' && (
-                  <>
-                    <div className="field-hint" style={{ marginBottom: 10 }}>
-                      {tr('术语 → 同义词（逗号分隔），提升关键词召回', 'Term → synonyms (comma-separated) to improve keyword recall')}
-                    </div>
-                    <div className="col gap8">
-                      {synonyms.map((sy, i) => (
-                        <div key={sy._k} className="row gap8">
-                          <input className="input" style={{ width: 180 }} placeholder={tr('术语', 'Term')}
-                            value={sy.term}
-                            onChange={(e) => setSynonyms(synonyms.map((x, j) => (j === i ? { ...x, term: e.target.value } : x)))} />
-                          <span style={{ color: 'var(--text-4)' }}>→</span>
-                          <input className="input" style={{ flex: 1 }} placeholder={tr('同义词1, 同义词2, …', 'synonym 1, synonym 2, …')}
-                            value={sy.syns}
-                            onChange={(e) => setSynonyms(synonyms.map((x, j) => (j === i ? { ...x, syns: e.target.value } : x)))} />
-                          <button className="icon-btn" style={{ height: 38 }} title={tr('删除', 'Remove')}
-                            onClick={() => setSynonyms(synonyms.filter((_, j) => j !== i))}>
-                            <Icon name="trash" size={14} />
-                          </button>
-                        </div>
-                      ))}
-                      <button className="btn btn-soft sm" style={{ alignSelf: 'flex-start' }}
-                        onClick={() => setSynonyms([...synonyms, withKey({ term: '', syns: '' })])}>
-                        <Icon name="plus" size={13} />
-                        {tr('添加映射', 'Add mapping')}
-                      </button>
-                    </div>
-                  </>
-                )}
-
-                {s.key === 'cadence' && (
-                  <FormField label={tr('运行节奏', 'Cadence')} hint={tr('文献追踪等自动任务的运行频率', 'How often automatic tasks like literature tracking run')}>
-                    <div>
-                      <Segmented options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
-                        value={cadence as (typeof CADENCES)[number]['v']}
-                        onChange={(v) => setCadence(v)} />
-                    </div>
-                  </FormField>
-                )}
-              </AccordionSection>
-            ))}
-        </div>
-      </AccordionSection>
-
       {/* 底部操作栏 */}
-      <div className="row gap10" style={{ marginTop: 18 }}>
-        <span style={{ fontSize: 12, color: 'var(--text-3)' }}>
-          {tr('AI 按名称与一句话草拟文献追踪配置，只补空白分区，不覆盖你已填的内容', 'AI drafts the tracking settings from the name and statement — it only fills blank sections and never overwrites your input')}
-        </span>
-        <div style={{ flex: 1 }} />
-        <button className="btn btn-soft" onClick={() => void aiDraft()} disabled={busy}>
-          <Icon name="sparkle" size={14} />
-          {drafting ? tr('AI 草拟中…', 'AI drafting…') : tr('AI 帮我设置', 'Set up with AI')}
-        </button>
-        <button className="btn btn-primary" onClick={() => void create()} disabled={busy}>
+      <div className="row gap10" style={{ marginTop: 18, justifyContent: 'flex-end' }}>
+        <button className="btn btn-primary" onClick={() => void create()} disabled={submitting}>
           <Icon name="check" size={14} />
           {submitting ? tr('创建中…', 'Creating…') : tr('创建课题', 'Create topic')}
         </button>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2409,7 +2409,11 @@ export const api = {
   listProjects(): Promise<ProjectRead[]> {
     return request<ProjectRead[]>('/projects');
   },
-  createProject(input: { name: string; definition: ProjectDefinition }): Promise<ProjectRead> {
+  createProject(input: {
+    name: string;
+    statement?: string;
+    source_library_ids?: string[];
+  }): Promise<ProjectRead> {
     return requestJson<ProjectRead>('/projects', 'POST', input);
   },
   /** 由 LLM 根据一句话定义草拟完整 definition（目标/问题/rubric/同义词等）。 */


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P9c, the convergence step. Stacked on #36 (P9b) → #30 (P9a); merge in order (#30 → #36 → this). Completes the model: a topic is a pure personal workspace; libraries are the one kind of asset (user-created, admin-approved, lab-funded).

## What changed
- **No more implicit libraries.** `create_project` now only creates the project (name + statement) and links the chosen *existing* libraries (`source_library_ids`, may be empty). It no longer auto-creates a 1:1 `direction_libraries` row or writes any inclusion config. `ProjectCreate` is slimmed to `name / slug? / statement? / source_library_ids[]`. The dead `implicit_library_for` (the last reader of `project.definition`'s rubric/anchors/cadence) is removed.
- **Topic wizard slimmed** (622 → 146 lines): name + one-line statement + link-libraries (LibraryPicker, active-only). All inclusion-config inputs (rubric/goals/scope/questions/keywords/categories/anchors/cadence) are gone — those now live on the library. Empty library list guides the user to create one under Libraries (pending admin approval).
- **`project.definition` demoted to statement-only.** Config authority already moved to the library in P8; the column is retained because 5 paths still read `definition.statement` (topic-context statement, not config). `project.ingest_state` is now fully inert (watermark authority is the library) and retained pending a follow-up drop.
- **Fixed an empty-corpus 500**: `paper_counts` guarded for a topic with no origin library, so ingest-state returns zeros for a topic linked to zero libraries.

Existing implicit libraries are untouched — they're now just ordinary active libraries with an origin-topic tracer, still linked to their topic. Only *new* topics stop creating one.

## Tests
548 passed (546 baseline + 3 new: no implicit library on create, can link existing, empty-corpus consumers OK), 16 pre-existing errors, 1 pre-existing env feedback failure — no new failures. Sizeable conftest adaptation (helpers `ensure_project_library` / `make_project_with_library`) so corpus tests still have a library; `test_library_lifecycle` rewritten off the implicit-library premise. No new migration (columns kept). Frontend tsc + build pass; ruff clean on changed files.

## Deferred follow-ups
Physically drop the inert `projects.ingest_state` column; give Project a dedicated `statement` column and fully retire `projects.definition`; evaluate retiring the now-unused `/projects/draft-definition` endpoint.