### PR TITLE
chore(docker): add .dockerignore + pull-based deploy bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,77 @@
+# Docker 构建上下文过滤（compose 里 context: 仓库根）。
+# 目的：① 绝不把机密带进公开镜像；② 大幅缩小上传给 daemon 的上下文。
+# 说明：Dockerfile 的 COPY 只取 src/backend、src/frontend；此文件是显式加固，
+#       防止有人误加 COPY 或往子目录里丢机密文件时静默泄露。
+
+# ---- 机密：任何情况都不许进镜像 ----
+# 注意：.dockerignore 的 `*.pem` 只匹配上下文根目录，不像 .gitignore 递归；
+#       子目录里的机密必须用 `**/*.pem` 才能挡住，故每类都给根 + 递归两份。
+.env
+.env.*
+!.env.example
+**/.env
+**/.env.*
+*.pem
+**/*.pem
+*.key
+**/*.key
+*.p12
+**/*.p12
+*.pfx
+**/*.pfx
+id_rsa*
+**/id_rsa*
+id_ed25519*
+**/id_ed25519*
+*.db
+**/*.db
+*.sqlite
+**/*.sqlite
+*.sqlite3
+**/*.sqlite3
+secrets/
+**/secrets/
+
+# ---- 版本控制 / 本地元数据 ----
+.git
+.gitignore
+.gitattributes
+.claude/
+.vscode/
+.idea/
+.DS_Store
+
+# ---- 平行 checkout / worktree（在仓库根，非镜像所需）----
+Polaris-dev/
+pr/
+rescue/
+backup/
+
+# ---- Python 缓存与构建产物 ----
+**/__pycache__/
+**/*.py[cod]
+**/.pytest_cache/
+**/.ruff_cache/
+**/.mypy_cache/
+**/*.egg-info/
+**/build/
+**/.venv/
+**/venv/
+
+# ---- Node / 前端（镜像内 npm ci 重装，dist 由 build stage 产出）----
+**/node_modules/
+**/dist/
+**/.vite/
+npm-debug.log*
+
+# ---- 文档 / 原型 / 部署脚本（运行时不需要，减小上下文）----
+docs/
+docs-dev/
+原型.html
+*.md
+!README.md
+
+# ---- 日志 / 临时文件 ----
+*.log
+tmp/
+**/tmp/

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,45 @@
+# Polaris 部署环境变量模板。用法：cp .env.example .env 后按注释填写。
+# 与仓库根 .env.example 内容一致，另加了拉镜像部署所需的 IMAGE_PREFIX / IMAGE_TAG。
+
+# ---- 镜像来源（拉镜像部署用）----
+# 你 push 到 registry 的前缀，如 Docker Hub 用户名 "myname" → 拉 myname/polaris-api:<tag>
+POLARIS_IMAGE_PREFIX=polaris
+POLARIS_IMAGE_TAG=latest
+
+# ---- App ----
+# dev | prod（生产务必填 prod：会强制关闭 fake LLM 回退等安全默认）
+POLARIS_ENV=prod
+# JWT 签名（生成：openssl rand -hex 32）
+POLARIS_SECRET_KEY=change-me-random-64-chars
+# SSH 凭据加密（生成：python -c "from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())"）
+POLARIS_ENCRYPTION_KEY=change-me-fernet-key
+# 注册邀请码（自定义）
+POLARIS_INVITE_CODE=change-me-invite-code
+
+# ---- Database / Cache ----
+# 密码要和下方 POSTGRES_PASSWORD 一致；host 用容器名 postgres / redis
+POLARIS_DATABASE_URL=postgresql+asyncpg://polaris:change-me-db-pass@postgres:5432/polaris
+POLARIS_REDIS_URL=redis://redis:6379/0
+
+# ---- LLM providers（可留空先部署，之后在管理端配；至少配一个才有 AI 功能）----
+POLARIS_OPENAI_COMPAT_BASE_URL=https://api.deepseek.com/v1
+POLARIS_OPENAI_COMPAT_API_KEY=
+POLARIS_ANTHROPIC_API_KEY=
+# fake provider 回退（仅测试/演示，默认关闭）；POLARIS_ENV=prod 时被强制忽略
+# POLARIS_LLM_FAKE_FALLBACK=1
+
+# ---- 文献 API ----
+# Semantic Scholar（可空，限流更严）
+POLARIS_S2_API_KEY=
+# 文献 API 出站代理（arXiv/S2/OpenAlex 直连不稳时配；LLM/内网不走它）
+# docker 内访问宿主机代理用 host.docker.internal，如 http://host.docker.internal:7897
+POLARIS_OUTBOUND_PROXY=
+
+# ---- GitHub（用户反馈 → issue，可空）----
+# POLARIS_GITHUB_TOKEN=
+# POLARIS_GITHUB_REPO=ZJU-REAL/Polaris
+
+# ---- Postgres 容器初始化（用户/密码/库名，密码与上方 DATABASE_URL 一致）----
+POSTGRES_USER=polaris
+POSTGRES_PASSWORD=change-me-db-pass
+POSTGRES_DB=polaris

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,58 +1,74 @@
-# Polaris 拉镜像部署
+<!-- 语言 / Language: **English** · [中文](./README.zh-CN.md) -->
 
-从 Docker Hub（或任意 registry）拉预构建镜像部署，服务器上无需构建。
-只需 `deploy/docker-compose.yml` + 一份 `.env` 两个文件。
+# Polaris — Deploy from Pre-built Images
 
-## 一次性：推送镜像（在有镜像的机器上）
+Deploy Polaris by pulling pre-built images from Docker Hub (or any registry) —
+no build on the server. You only need two files: `deploy/docker-compose.yml`
+and a `.env`.
+
+## One-time: push the images (on a machine that has them)
 
 ```bash
 docker login
-U=<你的DockerHub用户名>
+U=<your-dockerhub-username>
 for s in api worker frontend; do
   docker tag  polaris-$s:latest $U/polaris-$s:v1
   docker push $U/polaris-$s:v1
 done
 ```
 
-> `polaris-texbase` 不用推——它是 api/worker 的构建基础镜像，层已烤进 api/worker。
+> `polaris-texbase` does not need to be pushed — it is the build-base for
+> api/worker, and its layers are already baked into those two images.
 >
-> ⚠️ **架构要匹配**：Mac 构建出的是 `arm64`，x86_64 服务器需要 `amd64` 镜像。
-> 跨架构用 `docker buildx build --platform linux/amd64 --push ...` 出对应架构镜像。
+> ⚠️ **Match the architecture**: images built on a Mac are `arm64`; an x86_64
+> server needs `amd64` images. For cross-arch, build with
+> `docker buildx build --platform linux/amd64 --push ...`.
 
-## 服务器端
+## On the server
 
 ```bash
 mkdir -p ~/polaris && cd ~/polaris
-# 拷入 deploy/docker-compose.yml 和 deploy/.env.example
+# Copy in deploy/docker-compose.yml and deploy/.env.example
 cp .env.example .env
-# 编辑 .env：
-#   - POLARIS_IMAGE_PREFIX 设为你的用户名，POLARIS_IMAGE_TAG 设为 v1
-#   - POLARIS_SECRET_KEY / POLARIS_ENCRYPTION_KEY 按注释生成
-#   - POLARIS_DATABASE_URL 里的密码与 POSTGRES_PASSWORD 一致
-#   - 至少填一个 LLM key（也可先留空，之后在管理端配）
+# Edit .env:
+#   - Set POLARIS_IMAGE_PREFIX to your username, POLARIS_IMAGE_TAG to v1
+#   - Generate POLARIS_SECRET_KEY / POLARIS_ENCRYPTION_KEY (see inline notes)
+#   - The password in POLARIS_DATABASE_URL must match POSTGRES_PASSWORD
+#   - Set at least one LLM key (or leave blank and configure later in the admin UI)
 
-docker compose pull            # 拉全部镜像
+docker compose pull            # pull all images
 docker compose up -d
-docker compose exec api alembic upgrade head   # 首次必跑：postgres 不自动建表
-docker compose ps              # 5 个服务 healthy/up
+docker compose exec api alembic upgrade head   # required on first run: postgres tables aren't auto-created
+docker compose ps              # all 5 services healthy/up
 ```
 
-浏览器访问 `http://<服务器IP>:8080`，用邀请码注册。前端 nginx 已反代 `/api`、`/ws`、`/mcp` 到 api 容器，只需开放 8080。
+Open `http://<server-ip>:8080` and register with the invite code. The frontend
+nginx already reverse-proxies `/api`, `/ws`, and `/mcp` to the api container, so
+only port 8080 needs to be exposed.
 
-## 常用运维
+## Everyday operations
 
 ```bash
-docker compose logs -f api worker                              # 看日志
+docker compose logs -f api worker                             # tail logs
 docker compose pull && docker compose up -d \
-  && docker compose exec api alembic upgrade head              # 更新到新版镜像
-docker compose down                                            # 停（数据保留在 ./data）
+  && docker compose exec api alembic upgrade head             # update to a newer image
+docker compose down                                           # stop (data kept in ./data)
 ```
 
-数据全在 `~/polaris/data/`（pgdata / redisdata / appdata / tectonic-cache）。备份 tar 该目录即可，**切勿 `docker compose down -v`**（会删数据卷）。
+All data lives under `~/polaris/data/` (pgdata / redisdata / appdata /
+tectonic-cache). Back it up by tarring that directory. **Never run
+`docker compose down -v`** — it deletes the data volumes.
 
-## 要点
+## Notes
 
-- **worker 容器不能省**：ARQ worker 跑所有长任务（文献抓取、AI 生成、实验、编译），只起 api 会让任务永久 pending。
-- **迁移必跑一次**：`alembic upgrade head`；以后有新迁移，更新镜像后再跑一次。
-- **LLM key 可事后配**：`.env` 留空也能起，进管理端配模型路由后 AI 功能即可用；`POLARIS_ENV=prod` 下 fake 回退被强制禁用，不会吐假内容。
-- **代理**：`POLARIS_OUTBOUND_PROXY` 只作用于文献 API + GitHub；LLM 若需代理走标准 `HTTPS_PROXY`/`NO_PROXY`。
+- **The worker container is not optional**: the ARQ worker runs every
+  long-running task (literature fetch, AI generation, experiments, compilation).
+  Running only the api leaves those tasks pending forever.
+- **Run the migration once**: `alembic upgrade head`; run it again after each
+  image update that ships a new migration.
+- **LLM keys can be configured later**: the stack boots with them blank; once
+  you add a model route in the admin UI, AI features become available. Under
+  `POLARIS_ENV=prod` the fake fallback is force-disabled, so it never serves
+  fake content.
+- **Proxy**: `POLARIS_OUTBOUND_PROXY` only affects the literature APIs and
+  GitHub; if the LLM needs a proxy, use the standard `HTTPS_PROXY`/`NO_PROXY`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,58 @@
+# Polaris 拉镜像部署
+
+从 Docker Hub（或任意 registry）拉预构建镜像部署，服务器上无需构建。
+只需 `deploy/docker-compose.yml` + 一份 `.env` 两个文件。
+
+## 一次性：推送镜像（在有镜像的机器上）
+
+```bash
+docker login
+U=<你的DockerHub用户名>
+for s in api worker frontend; do
+  docker tag  polaris-$s:latest $U/polaris-$s:v1
+  docker push $U/polaris-$s:v1
+done
+```
+
+> `polaris-texbase` 不用推——它是 api/worker 的构建基础镜像，层已烤进 api/worker。
+>
+> ⚠️ **架构要匹配**：Mac 构建出的是 `arm64`，x86_64 服务器需要 `amd64` 镜像。
+> 跨架构用 `docker buildx build --platform linux/amd64 --push ...` 出对应架构镜像。
+
+## 服务器端
+
+```bash
+mkdir -p ~/polaris && cd ~/polaris
+# 拷入 deploy/docker-compose.yml 和 deploy/.env.example
+cp .env.example .env
+# 编辑 .env：
+#   - POLARIS_IMAGE_PREFIX 设为你的用户名，POLARIS_IMAGE_TAG 设为 v1
+#   - POLARIS_SECRET_KEY / POLARIS_ENCRYPTION_KEY 按注释生成
+#   - POLARIS_DATABASE_URL 里的密码与 POSTGRES_PASSWORD 一致
+#   - 至少填一个 LLM key（也可先留空，之后在管理端配）
+
+docker compose pull            # 拉全部镜像
+docker compose up -d
+docker compose exec api alembic upgrade head   # 首次必跑：postgres 不自动建表
+docker compose ps              # 5 个服务 healthy/up
+```
+
+浏览器访问 `http://<服务器IP>:8080`，用邀请码注册。前端 nginx 已反代 `/api`、`/ws`、`/mcp` 到 api 容器，只需开放 8080。
+
+## 常用运维
+
+```bash
+docker compose logs -f api worker                              # 看日志
+docker compose pull && docker compose up -d \
+  && docker compose exec api alembic upgrade head              # 更新到新版镜像
+docker compose down                                            # 停（数据保留在 ./data）
+```
+
+数据全在 `~/polaris/data/`（pgdata / redisdata / appdata / tectonic-cache）。备份 tar 该目录即可，**切勿 `docker compose down -v`**（会删数据卷）。
+
+## 要点
+
+- **worker 容器不能省**：ARQ worker 跑所有长任务（文献抓取、AI 生成、实验、编译），只起 api 会让任务永久 pending。
+- **迁移必跑一次**：`alembic upgrade head`；以后有新迁移，更新镜像后再跑一次。
+- **LLM key 可事后配**：`.env` 留空也能起，进管理端配模型路由后 AI 功能即可用；`POLARIS_ENV=prod` 下 fake 回退被强制禁用，不会吐假内容。
+- **代理**：`POLARIS_OUTBOUND_PROXY` 只作用于文献 API + GitHub；LLM 若需代理走标准 `HTTPS_PROXY`/`NO_PROXY`。

--- a/deploy/README.zh-CN.md
+++ b/deploy/README.zh-CN.md
@@ -1,0 +1,60 @@
+<!-- 语言 / Language: **中文** · [English](./README.md) -->
+
+# Polaris 拉镜像部署
+
+从 Docker Hub（或任意 registry）拉预构建镜像部署，服务器上无需构建。
+只需 `deploy/docker-compose.yml` + 一份 `.env` 两个文件。
+
+## 一次性：推送镜像（在有镜像的机器上）
+
+```bash
+docker login
+U=<你的DockerHub用户名>
+for s in api worker frontend; do
+  docker tag  polaris-$s:latest $U/polaris-$s:v1
+  docker push $U/polaris-$s:v1
+done
+```
+
+> `polaris-texbase` 不用推——它是 api/worker 的构建基础镜像，层已烤进 api/worker。
+>
+> ⚠️ **架构要匹配**：Mac 构建出的是 `arm64`，x86_64 服务器需要 `amd64` 镜像。
+> 跨架构用 `docker buildx build --platform linux/amd64 --push ...` 出对应架构镜像。
+
+## 服务器端
+
+```bash
+mkdir -p ~/polaris && cd ~/polaris
+# 拷入 deploy/docker-compose.yml 和 deploy/.env.example
+cp .env.example .env
+# 编辑 .env：
+#   - POLARIS_IMAGE_PREFIX 设为你的用户名，POLARIS_IMAGE_TAG 设为 v1
+#   - POLARIS_SECRET_KEY / POLARIS_ENCRYPTION_KEY 按注释生成
+#   - POLARIS_DATABASE_URL 里的密码与 POSTGRES_PASSWORD 一致
+#   - 至少填一个 LLM key（也可先留空，之后在管理端配）
+
+docker compose pull            # 拉全部镜像
+docker compose up -d
+docker compose exec api alembic upgrade head   # 首次必跑：postgres 不自动建表
+docker compose ps              # 5 个服务 healthy/up
+```
+
+浏览器访问 `http://<服务器IP>:8080`，用邀请码注册。前端 nginx 已反代 `/api`、`/ws`、`/mcp` 到 api 容器，只需开放 8080。
+
+## 常用运维
+
+```bash
+docker compose logs -f api worker                              # 看日志
+docker compose pull && docker compose up -d \
+  && docker compose exec api alembic upgrade head              # 更新到新版镜像
+docker compose down                                            # 停（数据保留在 ./data）
+```
+
+数据全在 `~/polaris/data/`（pgdata / redisdata / appdata / tectonic-cache）。备份 tar 该目录即可，**切勿 `docker compose down -v`**（会删数据卷）。
+
+## 要点
+
+- **worker 容器不能省**：ARQ worker 跑所有长任务（文献抓取、AI 生成、实验、编译），只起 api 会让任务永久 pending。
+- **迁移必跑一次**：`alembic upgrade head`；以后有新迁移，更新镜像后再跑一次。
+- **LLM key 可事后配**：`.env` 留空也能起，进管理端配模型路由后 AI 功能即可用；`POLARIS_ENV=prod` 下 fake 回退被强制禁用，不会吐假内容。
+- **代理**：`POLARIS_OUTBOUND_PROXY` 只作用于文献 API + GitHub；LLM 若需代理走标准 `HTTPS_PROXY`/`NO_PROXY`。

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,80 @@
+# Polaris 拉镜像部署（从 Docker Hub 拉现成镜像，无需在服务器上构建）。
+#
+# 与 docker/docker-compose*.yml 的区别：那套是本地 `build:` 构建用的；
+# 本文件用 `image:` 直接拉预构建镜像，适合把镜像 push 到 registry 后在服务器上部署。
+#
+# 用法（把本目录的 docker-compose.yml + .env.example 拷到服务器某目录，如 ~/polaris）：
+#   1) cp .env.example .env  && 编辑 .env（密钥务必自己生成，见文件内注释）
+#   2) 在 .env 里设 POLARIS_IMAGE_PREFIX / POLARIS_IMAGE_TAG 指向你 push 的镜像
+#   3) docker compose pull
+#   4) docker compose up -d
+#   5) docker compose exec api alembic upgrade head   # 首次必跑：postgres 不会自动建表
+#
+# 数据持久化到 ./data（bind mount）。备份即 tar 这个目录；切勿 `down -v`（会删卷）。
+# ⚠️ 镜像架构要和服务器 CPU 一致（Mac 构建出的是 arm64，x86 服务器需 amd64 镜像）。
+
+name: polaris
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    restart: unless-stopped
+    env_file: ./.env
+    volumes:
+      - ./data/pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-polaris}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - ./data/redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  api:
+    image: ${POLARIS_IMAGE_PREFIX:-polaris}/polaris-api:${POLARIS_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: ./.env
+    environment:
+      POLARIS_DATA_DIR: /srv/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data/appdata:/srv/data
+      - ./data/tectonic-cache:/root/.cache/Tectonic
+
+  worker:
+    image: ${POLARIS_IMAGE_PREFIX:-polaris}/polaris-worker:${POLARIS_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: ./.env
+    environment:
+      POLARIS_DATA_DIR: /srv/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./data/appdata:/srv/data
+      - ./data/tectonic-cache:/root/.cache/Tectonic
+
+  frontend:
+    image: ${POLARIS_IMAGE_PREFIX:-polaris}/polaris-frontend:${POLARIS_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      - api
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Background

We are about to push the `polaris-api / worker / frontend` images to Docker Hub (**public**). Review found the repo had **no `.dockerignore`**, while the build context is the repo root (compose `context: ..`) and the backend images `COPY src/backend/ ./` the whole tree.

The currently-built images are already clean (the root `.env` is not COPYd; no hardcoded secrets in source), but that safety relied on the implicit "COPY happens not to touch secrets". If someone drops a `.env`/`*.pem`/`*.db` into `src/backend/`, or adds a `COPY . .`, it would silently be baked into a public image.

## Changes

Add a `.dockerignore` that explicitly excludes:

- **Secrets**: `.env*`, `*.pem`/`*.key`/`*.p12`/`*.pfx`, `id_rsa*`/`id_ed25519*`, `*.db`/`*.sqlite*`, `secrets/` (keeps `.env.example`)
- **VCS / local metadata**: `.git`, `.claude/`, `.vscode`, `.idea`, `.DS_Store`
- **Parallel checkouts**: `Polaris-dev/`, `pr/`, `rescue/`, `backup/`
- **Caches / build artifacts**: `__pycache__`, `.pytest_cache`, `.ruff_cache`, `*.egg-info`, `build/`, `.venv/`, `node_modules/`, `dist/`
- **Docs / logs**: `docs/`, `docs-dev/`, `*.md` (keeps README), `*.log`

Also adds a self-contained `deploy/` bundle for running Polaris from pre-built registry images: a pull-based `docker-compose.yml` (image refs via `POLARIS_IMAGE_PREFIX`/`TAG`, data on `./data` bind mounts), a `.env.example`, and a step-by-step guide in both English (`README.md`) and Chinese (`README.zh-CN.md`).

## Gotcha

`.dockerignore` globs are **not recursive like `.gitignore`**: `*.pem` only matches the context root. Nested secrets need `**/*.pem`. So every extension-based secret rule carries both a root and a `**/` variant.

## Verification

- Isolated context test (with nested `src/backend/app/dropped.pem`, `local.db`, `nested/deep/id_rsa`, `node_modules`, `.git`, `Polaris-dev`) → all excluded, only normal source remains ✅
- Real `docker build -f docker/Dockerfile.api` → builds fine, no needed files dropped ✅
- `deploy/docker-compose.yml` passes `docker compose config`, image interpolation correct ✅
