### PR TITLE
feat: full paper-management console for standalone libraries; unify workbench (P9d)

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -7,20 +7,35 @@ project 作用域端点（鉴权同样接入库级写权限助手）。
 个人文献库路由在 ``app/api/library.py``（/me/library），勿混淆。
 """
 
+import asyncio
+import json
+import logging
 import uuid
+from collections.abc import AsyncIterator
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user, require_admin, require_llm_task
+from app.api.auth import (
+    current_active_user,
+    require_admin,
+    require_llm_chat,
+    require_llm_task,
+)
 from app.core.db import get_session
+from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.project import Project
 from app.models.user import User
-from app.schemas.ingest import IngestRequest
+from app.schemas.graph import GraphResponse
+from app.schemas.ingest import IngestRequest, IngestStateRead
 from app.schemas.libraries import (
     CuratorRead,
     CuratorsUpdate,
@@ -34,22 +49,50 @@ from app.schemas.libraries import (
     PaperMergeRequest,
     PaperMergeResult,
 )
+from app.schemas.note import NotebookPage, NoteWithPaper
 from app.schemas.paper import (
     ConceptRead,
+    PaperBatchIds,
+    PaperChatRequest,
+    PaperDetail,
     PaperListPage,
+    PaperManualCreate,
     PaperRead,
     ScoredConcept,
     ScoredPaper,
     SearchResponse,
+    TagRead,
 )
 from app.schemas.voyage import VoyageRead
 from app.services import concepts as concepts_service
+from app.services import graph as graph_service
 from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
+from app.services import library_chat as library_chat_service
+from app.services import notes as notes_service
+from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
+from app.services import relevance as relevance_service
 
 router = APIRouter(tags=["libraries"])
+
+logger = logging.getLogger(__name__)
+
+_HEARTBEAT_SECONDS = 15.0
+
+
+def _sse_frame(event: str, data: Any) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
+
+
+async def _paper_detail(
+    session: AsyncSession, view: papers_service.PaperView, user_id: uuid.UUID
+) -> PaperDetail:
+    extras = await papers_service.paper_extras_map(
+        session, paper_ids=[view.id], user_id=user_id
+    )
+    return PaperDetail.model_validate(view).model_copy(update=extras[view.id])
 
 
 async def _get_library(session: AsyncSession, library_id: uuid.UUID) -> DirectionLibrary:
@@ -296,13 +339,26 @@ async def list_library_papers(
     library_id: uuid.UUID,
     status_filter: str | None = Query(default="library", alias="status"),
     q: str | None = Query(default=None),
+    tag: str | None = Query(default=None),
+    starred: bool | None = Query(default=None),
+    reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
+    author: str | None = Query(default=None),
+    affiliation: str | None = Query(default=None),
+    published_from: datetime | None = Query(default=None),
+    published_to: datetime | None = Query(default=None),
+    created_from: datetime | None = Query(default=None),
+    created_to: datetime | None = Query(default=None),
     sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperListPage:
-    """库内论文（分页/检索/排序）。缺省只列相关性达标的（status=library 组别名）。"""
+    """库内论文（分页/检索/排序/过滤）。缺省只列相关性达标的（status=library 组别名）。
+
+    过滤参数与课题论文列表一致（星标/阅读状态/作者/机构/发表与入库时间）；
+    ``status=excluded`` 取该库垃圾桶。标签过滤仅对有起源课题的库有效（独立库无标签）。
+    """
     library = await _get_library(session, library_id)
     items, total = await papers_service.list_papers(
         session,
@@ -310,6 +366,15 @@ async def list_library_papers(
         project_id=library.project_id,
         status=status_filter,
         q=q,
+        tag=tag,
+        starred=starred,
+        reading_status=reading_status,
+        author=author,
+        affiliation=affiliation,
+        published_from=published_from,
+        published_to=published_to,
+        created_from=created_from,
+        created_to=created_to,
         user_id=user.id,
         sort=sort,
         page=page,
@@ -414,6 +479,229 @@ async def search_library(
         for p, s in paper_rows
     ]
     return SearchResponse(papers=papers, concepts=concepts, mode_used=mode_used, reranked=reranked)
+
+
+# ---- P9d 库级论文管理 / ingest 状态 / 图谱 / 对话 / 笔记（库工作台，含独立库） ----
+#
+# 说明：单篇写操作（改状态/软删召回/彻底删/重编译/标签）仍走 papers 路由的
+# paper 级端点（经库可见性解析成员行，可管理者含策展人/创建者/admin）；本节只补
+# 「集合级」库端点——课题版按 project 作用域，独立库靠这些端点获得同等管理能力。
+
+
+@router.post(
+    "/libraries/{library_id}/papers",
+    response_model=PaperDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_library_paper_manually(
+    library_id: uuid.UUID,
+    data: PaperManualCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> Any:
+    """手动把一篇文献加进该库：arxiv_id / doi / bibtex 三选一（可管理者）。"""
+    library = await _get_managed_library(session, library_id, user)
+    try:
+        paper = await paper_import_service.add_manual_paper_to_library(
+            session,
+            library=library,
+            arxiv_id=data.arxiv_id,
+            doi=data.doi,
+            bibtex=data.bibtex,
+            project_id=library.project_id,
+        )
+    except paper_import_service.DuplicatePaperError as e:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={"detail": "PAPER_EXISTS", "paper_id": str(e.paper_id)},
+        )
+    except paper_import_service.ParseFailedError as e:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
+        ) from e
+    paper_id, user_id, project_id = paper.id, user.id, library.project_id
+    membership = await libraries_service.get_membership(
+        session, library_id=library.id, paper_id=paper_id
+    )
+    if membership is not None:
+        await relevance_service.score_added_paper_best_effort(
+            session, paper, membership, project_id=project_id, user_id=user_id
+        )
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library.id,
+        project_id=project_id,
+        paper_id=paper_id,
+        with_concepts=True,
+    )
+    return await _paper_detail(session, view, user_id)
+
+
+@router.post("/libraries/{library_id}/papers/batch-delete")
+async def batch_delete_library_papers(
+    library_id: uuid.UUID,
+    data: PaperBatchIds,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, int]:
+    """批量删除库内论文（非本库的 id 忽略），返回 {deleted}。默认软删；hard=true 彻底删除。"""
+    library = await _get_managed_library(session, library_id, user)
+    deleted = await papers_service.delete_library_papers(
+        session, library=library, paper_ids=data.paper_ids, hard=data.hard
+    )
+    return {"deleted": deleted}
+
+
+@router.post("/libraries/{library_id}/trash/empty")
+async def empty_library_trash(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, int]:
+    """清空该库垃圾桶：彻底删除库内全部已删除论文成员行。"""
+    library = await _get_managed_library(session, library_id, user)
+    deleted = await papers_service.empty_library_trash(session, library=library)
+    return {"deleted": deleted}
+
+
+@router.get("/libraries/{library_id}/tags", response_model=list[TagRead])
+async def list_library_tags(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[TagRead]:
+    """库标签列表（含引用论文数）。独立库无课题作用域标签 → 空列表。"""
+    library = await _get_library(session, library_id)
+    if library.project_id is None:
+        return []
+    rows = await papers_service.list_project_tags(session, project_id=library.project_id)
+    return [TagRead(**row) for row in rows]
+
+
+@router.get("/libraries/{library_id}/ingest/state", response_model=IngestStateRead)
+async def get_library_ingest_state(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> IngestStateRead:
+    """该库的建库/同步状态：上次同步时间、抓取进度计数、在跑任务、下次自动同步（可管理者）。"""
+    library = await _get_managed_library(session, library_id, user)
+    state = await ingest_service.library_ingest_state(session, library)
+    return IngestStateRead(**state)
+
+
+@router.get("/libraries/{library_id}/graph", response_model=GraphResponse)
+async def library_graph(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> GraphResponse:
+    """库知识图谱：论文 / 作者 / 概念节点与关联边（确定性构建，不走 LLM；全实验室可读）。"""
+    library = await _get_library(session, library_id)
+    data = await graph_service.library_graph(session, library_id=library.id)
+    return GraphResponse(**data)
+
+
+@router.get("/libraries/{library_id}/notes", response_model=NotebookPage)
+async def library_notebook(
+    library_id: uuid.UUID,
+    q: str | None = Query(default=None),
+    paper_id: uuid.UUID | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> NotebookPage:
+    """库笔记本：我在该库论文上写的笔记聚合（搜索 + 分页 + 按论文过滤）。"""
+    library = await _get_library(session, library_id)
+    rows, total = await notes_service.list_library_notes(
+        session,
+        library_id=library.id,
+        author_id=user.id,
+        q=q,
+        paper_id=paper_id,
+        page=page,
+        size=size,
+    )
+    items = [
+        NoteWithPaper(
+            id=note.id,
+            paper_id=note.paper_id,
+            author_id=note.author_id,
+            author_name=author_name,
+            content=note.content,
+            created_at=note.created_at,
+            updated_at=note.updated_at,
+            paper_title=paper_title,
+        )
+        for note, author_name, paper_title in rows
+    ]
+    return NotebookPage(items=items, total=total, page=page, size=size)
+
+
+@router.post("/libraries/{library_id}/chat")
+async def chat_with_library(
+    library_id: uuid.UUID,
+    data: PaperChatRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_chat),
+) -> StreamingResponse:
+    """库文献对话：跨库内文献检索 + stage=reading 流式回答（全实验室可读，费用记个人）。
+
+    事件：``sources``（引用来源清单）→ ``delta``* → ``done``；错误 ``error`` 后关流。
+    """
+    library = await _get_library(session, library_id)
+    user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
+    project_id = library.project_id
+    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    llm = get_llm_router()
+    messages, sources = await library_chat_service.build_library_messages_for_library(
+        session, library=library, question=data.question, history=history, llm=llm, user_id=user_id
+    )
+
+    async def event_stream() -> AsyncIterator[str]:
+        yield _sse_frame("sources", {"items": [asdict(source) for source in sources]})
+        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
+
+        async def pump() -> None:
+            try:
+                async for chunk in llm.stream(
+                    "reading", messages, user_id=user_id, project_id=project_id
+                ):
+                    await queue.put(("delta", chunk))
+                await queue.put(("done", None))
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 转成 error 事件后关流
+                logger.warning("library chat stream failed", exc_info=True)
+                await queue.put(("error", f"{type(e).__name__}: {e}"))
+
+        task = asyncio.create_task(pump())
+        collected: list[str] = []
+        try:
+            while True:
+                try:
+                    kind, payload = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_SECONDS)
+                except TimeoutError:
+                    yield ": ping\n\n"
+                    continue
+                if kind == "delta":
+                    collected.append(payload or "")
+                    yield _sse_frame("delta", {"text": payload})
+                elif kind == "done":
+                    usage = {
+                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
+                        "completion_tokens": estimate_tokens("".join(collected)),
+                    }
+                    yield _sse_frame("done", {"usage": usage})
+                    return
+                else:  # error
+                    yield _sse_frame("error", {"detail": payload})
+                    return
+        finally:
+            task.cancel()
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
 # ---- P6 治理：重复论文合并 ----

--- a/src/backend/app/services/graph.py
+++ b/src/backend/app/services/graph.py
@@ -49,6 +49,32 @@ async def project_graph(
     if not library_ids:
         # 课题无关联库 = 无语料 → 空图（前端给空态引导去关联文献库）
         return {"nodes": [], "edges": [], "paper_total": 0, "truncated": False}
+    return await _graph_for_library_ids(
+        session, library_ids=library_ids, max_papers=max_papers, max_authors=max_authors
+    )
+
+
+async def library_graph(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    max_papers: int = MAX_PAPERS,
+    max_authors: int = MAX_AUTHORS,
+) -> dict[str, Any]:
+    """构建单个方向库的知识图谱（库工作台入口，含独立库）。"""
+    return await _graph_for_library_ids(
+        session, library_ids=[library_id], max_papers=max_papers, max_authors=max_authors
+    )
+
+
+async def _graph_for_library_ids(
+    session: AsyncSession,
+    *,
+    library_ids: list[uuid.UUID],
+    max_papers: int = MAX_PAPERS,
+    max_authors: int = MAX_AUTHORS,
+) -> dict[str, Any]:
+    """按一组库（并集）构图的共享实现。"""
     # 关联库并集：跨库同一论文按确定性视角归并，再按相关性排序截断 top max_papers
     dedup_rows = dedupe_member_rows(
         (

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -174,19 +174,23 @@ async def create_ingest_voyage(
     return run
 
 
-async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str, int]:
+def _empty_counts() -> dict[str, int]:
     counts = {status: 0 for status in PAPER_STATUSES}
-    # P9c：课题可无起源库（空语料）——直接给零计数，不报错。
-    library = await get_library_for_project(session, project_id)
-    if library is None:
-        counts["total"] = 0
-        counts["library"] = 0
-        counts["pending_compile"] = 0
-        return counts
+    counts["total"] = 0
+    counts["library"] = 0
+    counts["pending_compile"] = 0
+    return counts
+
+
+async def library_paper_counts(
+    session: AsyncSession, library_id: uuid.UUID
+) -> dict[str, int]:
+    """某方向库的论文状态计数（库级直接统计 library_papers，库工作台/ingest 面板共用）。"""
+    counts = {status: 0 for status in PAPER_STATUSES}
     rows = (
         await session.execute(
             select(LibraryPaper.status, func.count())
-            .where(LibraryPaper.library_id == library.id)
+            .where(LibraryPaper.library_id == library_id)
             .group_by(LibraryPaper.status)
         )
     ).all()
@@ -201,6 +205,14 @@ async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str
     )
     counts["pending_compile"] = counts["scored"] + counts["fetched"]
     return counts
+
+
+async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str, int]:
+    # P9c：课题可无起源库（空语料）——直接给零计数，不报错。
+    library = await get_library_for_project(session, project_id)
+    if library is None:
+        return _empty_counts()
+    return await library_paper_counts(session, library.id)
 
 
 # 每日自动同步的触发时刻（UTC，与 worker/settings.py 的 cron 保持一致）
@@ -230,24 +242,49 @@ def next_daily_sync_at(library: DirectionLibrary | None) -> datetime | None:
     return candidate
 
 
+async def _resolve_last_run(
+    session: AsyncSession, state: dict[str, Any]
+) -> dict[str, Any] | None:
+    """从 ingest_state 里的 last_run 摘要补上当前 voyage 状态（水位线权威源在库）。"""
+    last_run_raw = state.get("last_run") or None
+    if not (isinstance(last_run_raw, dict) and last_run_raw.get("voyage_id")):
+        return None
+    voyage = await session.get(VoyageRun, uuid.UUID(str(last_run_raw["voyage_id"])))
+    return {
+        "voyage_id": last_run_raw["voyage_id"],
+        "status": voyage.status if voyage else "unknown",
+        "finished_at": last_run_raw.get("finished_at"),
+    }
+
+
 async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any]:
     # P8a：水位线/last_run 权威源在库（library.ingest_state）
     library = await get_library_for_project(session, project.id)
     state = (library.ingest_state if library else None) or {}
-    last_run_raw = state.get("last_run") or None
-    last_run: dict[str, Any] | None = None
-    if isinstance(last_run_raw, dict) and last_run_raw.get("voyage_id"):
-        voyage = await session.get(VoyageRun, uuid.UUID(str(last_run_raw["voyage_id"])))
-        last_run = {
-            "voyage_id": last_run_raw["voyage_id"],
-            "status": voyage.status if voyage else "unknown",
-            "finished_at": last_run_raw.get("finished_at"),
-        }
     running = await find_running_ingest(session, project.id)
     return {
         "watermark": state.get("watermark"),
-        "last_run": last_run,
+        "last_run": await _resolve_last_run(session, state),
         "paper_counts": await paper_counts(session, project.id),
+        "running_voyage_id": running.id if running else None,
+        "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
+    }
+
+
+async def library_ingest_state(
+    session: AsyncSession, library: DirectionLibrary
+) -> dict[str, Any]:
+    """某方向库的 ingest 状态（水位线/上次同步/计数/在跑任务/下次同步），库工作台用。
+
+    与课题版口径一致，但一切按库直接取数：计数用 library_papers、互斥/在跑判定
+    以库为准（P9a），适用于独立库（project_id=None）。
+    """
+    state = library.ingest_state or {}
+    running = await find_running_ingest_for_library(session, library.id)
+    return {
+        "watermark": state.get("watermark"),
+        "last_run": await _resolve_last_run(session, state),
+        "paper_counts": await library_paper_counts(session, library.id),
         "running_voyage_id": running.id if running else None,
         "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
     }

--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -151,12 +151,62 @@ async def build_library_messages(
     llm: LLMRouter,
     user_id: uuid.UUID | None = None,
 ) -> tuple[list[Message], list[ChatSource]]:
-    """组装文献库对话消息，返回 (messages, 引用来源列表)。"""
+    """组装课题文献库对话消息（关联库并集），返回 (messages, 引用来源列表)。"""
     # 先取出所需字段：检索失败路径里的 rollback 会使 ORM 对象过期，之后再取属性会报错
     project_id = project.id
     definition = project.definition if isinstance(project.definition, dict) else {}
     statement = definition.get("statement") or project.name
     library_ids = await get_source_library_ids(session, project_id)
+    return await build_messages_for_libraries(
+        session,
+        statement=statement,
+        library_ids=library_ids,
+        project_id=project_id,
+        question=question,
+        history=history,
+        llm=llm,
+        user_id=user_id,
+    )
+
+
+async def build_library_messages_for_library(
+    session: AsyncSession,
+    *,
+    library,
+    question: str,
+    history: list[tuple[str, str]],
+    llm: LLMRouter,
+    user_id: uuid.UUID | None = None,
+) -> tuple[list[Message], list[ChatSource]]:
+    """组装单个方向库的对话消息（库工作台入口，含独立库 project_id=None）。"""
+    from app.services.libraries import library_definition
+
+    definition = library_definition(library)
+    statement = definition.get("statement") or library.name
+    return await build_messages_for_libraries(
+        session,
+        statement=statement,
+        library_ids=[library.id],
+        project_id=library.project_id,
+        question=question,
+        history=history,
+        llm=llm,
+        user_id=user_id,
+    )
+
+
+async def build_messages_for_libraries(
+    session: AsyncSession,
+    *,
+    statement: str,
+    library_ids: list[uuid.UUID],
+    project_id: uuid.UUID | None,
+    question: str,
+    history: list[tuple[str, str]],
+    llm: LLMRouter,
+    user_id: uuid.UUID | None = None,
+) -> tuple[list[Message], list[ChatSource]]:
+    """按一组库检索并组装对话消息的共享实现（project_id 仅用于 LLM 记账，可空）。"""
     if not library_ids:
         # 课题无关联库 = 无语料：直接给「空文献库」上下文（不抓片段、不兜底）
         messages = [

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -124,3 +124,40 @@ async def list_project_notes(
         (note, author_name_of(display_name, email), title)
         for note, display_name, email, title in rows
     ], int(total)
+
+
+async def list_library_notes(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    author_id: uuid.UUID,
+    q: str | None = None,
+    paper_id: uuid.UUID | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[Sequence[tuple[PaperNote, str, str]], int]:
+    """库笔记本：「我的」笔记里落在该方向库论文上的部分（库工作台入口，含独立库）。
+
+    范围 = 该库成员行覆盖的论文（LibraryPaper.library_id）；无课题书架维度。
+    分页 + 内容搜索 + 按论文过滤；返回 (rows, total)，row = (note, author_name, paper_title)。
+    """
+    in_scope = PaperNote.paper_id.in_(
+        select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library_id)
+    )
+    stmt = (
+        select(PaperNote, User.display_name, User.email, Paper.title)
+        .join(User, User.id == PaperNote.author_id)
+        .join(Paper, Paper.id == PaperNote.paper_id)
+        .where(PaperNote.author_id == author_id, in_scope)
+    )
+    if q:
+        stmt = stmt.where(PaperNote.content.ilike(f"%{q}%"))
+    if paper_id is not None:
+        stmt = stmt.where(PaperNote.paper_id == paper_id)
+    total = (await session.execute(select(func.count()).select_from(stmt.subquery()))).scalar_one()
+    stmt = stmt.order_by(PaperNote.created_at.desc()).offset((page - 1) * size).limit(size)
+    rows = (await session.execute(stmt)).all()
+    return [
+        (note, author_name_of(display_name, email), title)
+        for note, display_name, email, title in rows
+    ], int(total)

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -226,19 +226,39 @@ async def add_manual_paper(
     doi: str | None = None,
     bibtex: str | None = None,
 ) -> Paper:
-    """手动添加一篇文献（source=manual，成员行 status=included）。
+    """手动添加一篇文献到课题起源库（source=manual，成员行 status=included）。"""
+    # 人工导入落在课题起源库上；课题必须有一个可解析的库（隐式库常态存在）
+    library = await get_library_for_project(session, project_id)
+    if library is None:
+        raise ParseFailedError("课题未关联可写入的文献库")
+    return await add_manual_paper_to_library(
+        session,
+        library=library,
+        arxiv_id=arxiv_id,
+        doi=doi,
+        bibtex=bibtex,
+        project_id=project_id,
+    )
+
+
+async def add_manual_paper_to_library(
+    session: AsyncSession,
+    *,
+    library: Any,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    bibtex: str | None = None,
+    project_id: uuid.UUID | None = None,
+) -> Paper:
+    """手动添加一篇文献到**指定库**（库工作台入口，含独立库 project_id=None）。
 
     - 先查全局内容池（arxiv/doi/dedup_key）：池中已有则只建成员行（pool hit，
       跳过解析下载）；本库已有成员行 → DuplicatePaperError（路由映射 409）
     - 解析失败 → ParseFailedError（路由映射 422）
     - 新论文有 arxiv_id 的自动尝试补下 PDF，失败只记日志不阻塞
+    project_id 仅用于 LLM 记账归因（补机构等），独立库为空。
     """
     fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
-
-    # 人工导入落在课题起源库上；课题必须有一个可解析的库（隐式库常态存在）
-    library = await get_library_for_project(session, project_id)
-    if library is None:
-        raise ParseFailedError("课题未关联可写入的文献库")
     dedup_key = pool_dedup_key(
         arxiv_id=fields.get("arxiv_id"),
         doi=fields.get("doi"),

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -388,6 +388,30 @@ async def get_paper_for_user(
     )
 
 
+async def get_library_paper_view(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    paper_id: uuid.UUID,
+    with_concepts: bool = False,
+) -> PaperView | None:
+    """取某篇论文在**指定库**的成员行视角（库工作台的单篇管理入口）。
+
+    与 :func:`get_paper_for_user` 的确定性跨库归并不同：这里精确锁定
+    (library_id, paper_id) 的成员行，保证库工作台的写操作只动本库那份归属。
+    库不含该论文时返回 None。project_id = 库回指的课题（独立库为 None）。
+    """
+    stmt = member_paper_stmt(library_id).where(Paper.id == paper_id).limit(1)
+    if with_concepts:
+        stmt = stmt.options(selectinload(Paper.concepts))
+    row = (await session.execute(stmt)).first()
+    if row is None:
+        return None
+    paper, membership = row
+    return PaperView(paper, membership, project_id)
+
+
 async def set_paper_status(session: AsyncSession, view: PaperView, status: str) -> PaperView:
     view.membership.status = status
     await session.commit()
@@ -438,8 +462,14 @@ async def paper_extras_map(
 
 
 async def set_paper_tags(session: AsyncSession, view: PaperView, names: list[str]) -> list[str]:
-    """整组覆盖论文标签：新名字自动建 tag，空数组=清空。返回排序后的标签名。"""
+    """整组覆盖论文标签：新名字自动建 tag，空数组=清空。返回排序后的标签名。
+
+    独立库（project_id 为空）暂不支持标签：PaperTag 以 project 为键，无课题作用域
+    可挂靠——直接返回空列表（不落库、不报错），前端据此隐藏标签编辑。
+    """
     project_id = view.project_id
+    if project_id is None:
+        return []
     paper_id = view.paper.id
     cleaned = list(dict.fromkeys(n.strip() for n in names if n and n.strip()))
     existing = (
@@ -472,7 +502,7 @@ async def set_paper_tags(session: AsyncSession, view: PaperView, names: list[str
     return sorted(cleaned)
 
 
-async def prune_orphan_tags(session: AsyncSession, *, project_id: uuid.UUID) -> int:
+async def prune_orphan_tags(session: AsyncSession, *, project_id: uuid.UUID | None) -> int:
     """删除项目内零引用标签（以 paper_tag_links 计数，回收站论文的引用也算），返回删除数。
 
     不 commit，由调用方在收尾时提交；触发点：整组覆盖标签、硬删论文、清空回收站。
@@ -537,7 +567,7 @@ async def upsert_paper_user_meta(
 async def _delete_membership_rows(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    project_id: uuid.UUID | None,
     memberships: Sequence[LibraryPaper],
 ) -> None:
     """硬删成员行 + 本项目挂在这些论文上的标签关联（不 commit）。"""
@@ -568,6 +598,39 @@ async def delete_paper(session: AsyncSession, view: PaperView) -> None:
     await session.commit()
 
 
+async def _delete_or_trash_memberships(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    tag_project_id: uuid.UUID | None,
+    paper_ids: list[uuid.UUID],
+    hard: bool,
+) -> int:
+    """批量软删/硬删某库内成员行的共享实现（tag_project_id 决定清哪个课题的标签关联）。"""
+    memberships = (
+        (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id == library_id, LibraryPaper.paper_id.in_(paper_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if hard:
+        await _delete_membership_rows(
+            session, project_id=tag_project_id, memberships=memberships
+        )
+        await prune_orphan_tags(session, project_id=tag_project_id)
+    else:
+        for membership in memberships:
+            membership.status = "excluded"
+            membership.trash_reason = "manual"
+    await session.commit()
+    return len(memberships)
+
+
 async def delete_papers(
     session: AsyncSession,
     *,
@@ -583,26 +646,30 @@ async def delete_papers(
     library = await get_library_for_project(session, project_id)
     if library is None:
         return 0
-    memberships = (
-        (
-            await session.execute(
-                select(LibraryPaper).where(
-                    LibraryPaper.library_id == library.id, LibraryPaper.paper_id.in_(paper_ids)
-                )
-            )
-        )
-        .scalars()
-        .all()
+    return await _delete_or_trash_memberships(
+        session,
+        library_id=library.id,
+        tag_project_id=project_id,
+        paper_ids=paper_ids,
+        hard=hard,
     )
-    if hard:
-        await _delete_membership_rows(session, project_id=project_id, memberships=memberships)
-        await prune_orphan_tags(session, project_id=project_id)
-    else:
-        for membership in memberships:
-            membership.status = "excluded"
-            membership.trash_reason = "manual"
-    await session.commit()
-    return len(memberships)
+
+
+async def delete_library_papers(
+    session: AsyncSession,
+    *,
+    library: Any,
+    paper_ids: list[uuid.UUID],
+    hard: bool = False,
+) -> int:
+    """批量删除某方向库内论文（库工作台入口，含独立库 project_id=None）。"""
+    return await _delete_or_trash_memberships(
+        session,
+        library_id=library.id,
+        tag_project_id=library.project_id,
+        paper_ids=paper_ids,
+        hard=hard,
+    )
 
 
 def restore_status_of(membership: LibraryPaper) -> str:
@@ -623,16 +690,15 @@ async def restore_paper(session: AsyncSession, view: PaperView) -> PaperView:
     return view
 
 
-async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
-    """清空垃圾桶：彻底移除库内全部 excluded 成员行，返回删除数。"""
-    library = await get_library_for_project(session, project_id)
-    if library is None:
-        return 0
+async def _empty_trash_core(
+    session: AsyncSession, *, library_id: uuid.UUID, tag_project_id: uuid.UUID | None
+) -> int:
+    """彻底移除某库全部 excluded 成员行（tag_project_id 决定清哪个课题的标签关联）。"""
     memberships = (
         (
             await session.execute(
                 select(LibraryPaper).where(
-                    LibraryPaper.library_id == library.id, LibraryPaper.status == "excluded"
+                    LibraryPaper.library_id == library_id, LibraryPaper.status == "excluded"
                 )
             )
         )
@@ -640,10 +706,29 @@ async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
         .all()
     )
     if memberships:
-        await _delete_membership_rows(session, project_id=project_id, memberships=memberships)
-        await prune_orphan_tags(session, project_id=project_id)
+        await _delete_membership_rows(
+            session, project_id=tag_project_id, memberships=memberships
+        )
+        await prune_orphan_tags(session, project_id=tag_project_id)
     await session.commit()
     return len(memberships)
+
+
+async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
+    """清空垃圾桶：彻底移除库内全部 excluded 成员行，返回删除数。"""
+    library = await get_library_for_project(session, project_id)
+    if library is None:
+        return 0
+    return await _empty_trash_core(
+        session, library_id=library.id, tag_project_id=project_id
+    )
+
+
+async def empty_library_trash(session: AsyncSession, *, library: Any) -> int:
+    """清空某方向库的垃圾桶（库工作台入口，含独立库 project_id=None）。"""
+    return await _empty_trash_core(
+        session, library_id=library.id, tag_project_id=library.project_id
+    )
 
 
 # ---- PDF 按需补下（docs/api-lit.md §1） ----

--- a/src/backend/tests/test_library_paper_management.py
+++ b/src/backend/tests/test_library_paper_management.py
@@ -1,0 +1,313 @@
+"""P9d：独立库（project_id=NULL）的库级论文管理台。
+
+覆盖库级论文列表/过滤、软删召回、批量删除、清空垃圾桶、手动添加、标签空态、
+ingest 状态、图谱、笔记、文献对话，以及非管理者的鉴权 403。
+"""
+
+import json
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Concept, Paper, paper_concepts
+from app.models.user import User
+from tests.conftest import register_and_login
+
+BIBTEX_ENTRY = """@inproceedings{smith2025bench,
+  title = {A {Benchmark} for Agents},
+  author = {Smith, Alice and Bob Jones},
+  year = {2025},
+  booktitle = {Proceedings of NeurIPS},
+  doi = {10.1000/bench},
+  url = {https://example.org/bench},
+}
+"""
+
+
+def _parse_sse(text: str) -> list[tuple[str, dict]]:
+    events = []
+    for block in text.strip().split("\n\n"):
+        event, data = None, None
+        for line in block.split("\n"):
+            if line.startswith("event: "):
+                event = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: ") :])
+        if event is not None:
+            events.append((event, data))
+    return events
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _create_active_standalone(client, creator_headers, admin_headers, name="独立库"):
+    """创建者建 pending 独立库 → 管理员激活；返回 library_id（str）。"""
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": name, "statement": "LLM agent 规划方向"},
+        headers=creator_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+    assert resp.json()["project_id"] is None
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    return lib_id
+
+
+async def _seed_paper(
+    lib_id,
+    *,
+    title,
+    status="scored",
+    relevance=0.8,
+    wiki=None,
+    abstract="agent planning abstract",
+    authors=None,
+    year=2024,
+):
+    async with get_sessionmaker()() as session:
+        paper = Paper(
+            title=title,
+            abstract=abstract,
+            authors=authors if authors is not None else [{"name": "Alice"}],
+            year=year,
+            source="arxiv",
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            LibraryPaper(
+                library_id=uuid.UUID(str(lib_id)),
+                paper_id=paper.id,
+                status=status,
+                relevance_score=relevance,
+                wiki_content=wiki,
+            )
+        )
+        await session.commit()
+        return str(paper.id)
+
+
+async def _setup(client, *, prefix="p9d"):
+    """admin + 创建者 + 一个 active 独立库；返回 (creator_headers, admin_headers, lib_id)。"""
+    admin = await _hdr(client, f"{prefix}-admin@example.com")
+    await _promote_admin(f"{prefix}-admin@example.com")
+    creator = await _hdr(client, f"{prefix}-owner@example.com")
+    lib_id = await _create_active_standalone(client, creator, admin)
+    return creator, admin, lib_id
+
+
+async def test_standalone_papers_list_filters_and_trash(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-list")
+    p_scored = await _seed_paper(lib_id, title="Scored only", status="scored")
+    p_compiled = await _seed_paper(
+        lib_id, title="Compiled paper", status="compiled", wiki="# 解读\n\n讲 agent。"
+    )
+
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=library", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] == 2
+
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=compiled_any", headers=creator)
+    assert resp.json()["total"] == 1
+    assert resp.json()["items"][0]["id"] == p_compiled
+
+    resp = await client.patch(
+        f"/api/papers/{p_scored}", json={"status": "excluded"}, headers=creator
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=excluded", headers=creator)
+    assert [x["id"] for x in resp.json()["items"]] == [p_scored]
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=library", headers=creator)
+    assert resp.json()["total"] == 1
+
+    resp = await client.post(f"/api/papers/{p_scored}/restore", headers=creator)
+    assert resp.status_code == 200, resp.text
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=library", headers=creator)
+    assert resp.json()["total"] == 2
+
+
+async def test_standalone_batch_delete_and_empty_trash(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-batch")
+    p1 = await _seed_paper(lib_id, title="Batch 1")
+    p2 = await _seed_paper(lib_id, title="Batch 2")
+
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers/batch-delete",
+        json={"paper_ids": [p1, p2]},
+        headers=creator,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] == 2
+    resp = await client.get(f"/api/libraries/{lib_id}/papers?status=excluded", headers=creator)
+    assert resp.json()["total"] == 2
+
+    resp = await client.post(f"/api/libraries/{lib_id}/trash/empty", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] == 2
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(LibraryPaper).where(LibraryPaper.library_id == uuid.UUID(lib_id))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
+        assert await session.get(Paper, uuid.UUID(p1)) is not None
+
+
+async def test_standalone_hard_batch_delete(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-hard")
+    p1 = await _seed_paper(lib_id, title="Hard delete me")
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers/batch-delete",
+        json={"paper_ids": [p1], "hard": True},
+        headers=creator,
+    )
+    assert resp.status_code == 200 and resp.json()["deleted"] == 1
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(LibraryPaper).where(LibraryPaper.paper_id == uuid.UUID(p1))
+            )
+        ).scalar_one_or_none()
+        assert row is None
+
+
+async def test_standalone_manual_add_bibtex(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-add")
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers", json={"bibtex": BIBTEX_ENTRY}, headers=creator
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == "A Benchmark for Agents"
+    assert body["doi"] == "10.1000/bench"
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers", json={"bibtex": BIBTEX_ENTRY}, headers=creator
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "PAPER_EXISTS"
+
+
+async def test_standalone_recompile_via_paper_endpoint(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-recompile")
+    p1 = await _seed_paper(lib_id, title="Recompile me", status="scored")
+    resp = await client.post(f"/api/papers/{p1}/recompile", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["has_wiki"] is True
+
+
+async def test_standalone_tags_empty(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-tags")
+    p1 = await _seed_paper(lib_id, title="No tags here")
+    resp = await client.get(f"/api/libraries/{lib_id}/tags", headers=creator)
+    assert resp.status_code == 200 and resp.json() == []
+    resp = await client.put(f"/api/papers/{p1}/tags", json={"names": ["方法"]}, headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tags"] == []
+
+
+async def test_standalone_ingest_state(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-ingest")
+    await _seed_paper(lib_id, title="Counted 1", status="scored")
+    await _seed_paper(lib_id, title="Counted 2", status="compiled", wiki="x")
+    await _seed_paper(lib_id, title="Candidate", status="candidate")
+    resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=creator)
+    assert resp.status_code == 200, resp.text
+    counts = resp.json()["paper_counts"]
+    assert counts["library"] == 2
+    assert counts["total"] == 3
+    assert resp.json()["running_voyage_id"] is None
+
+
+async def test_standalone_graph(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-graph")
+    p1 = await _seed_paper(lib_id, title="Graph paper", status="compiled", wiki="x")
+    async with get_sessionmaker()() as session:
+        concept = Concept(
+            library_id=uuid.UUID(lib_id), name="Planning", slug="planning", category="method"
+        )
+        session.add(concept)
+        await session.flush()
+        await session.execute(
+            paper_concepts.insert().values(paper_id=uuid.UUID(p1), concept_id=concept.id)
+        )
+        await session.commit()
+    resp = await client.get(f"/api/libraries/{lib_id}/graph", headers=creator)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    types = {n["type"] for n in data["nodes"]}
+    assert "paper" in types and "concept" in types
+    assert data["paper_total"] == 1
+
+
+async def test_standalone_notes(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-notes")
+    p1 = await _seed_paper(lib_id, title="Note target")
+    resp = await client.post(
+        f"/api/papers/{p1}/notes", json={"content": "这是我的库笔记"}, headers=creator
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/libraries/{lib_id}/notes", headers=creator)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["paper_title"] == "Note target"
+    assert body["items"][0]["content"] == "这是我的库笔记"
+
+
+async def test_standalone_chat_sse(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-chat")
+    await _seed_paper(lib_id, title="Chat corpus", status="compiled", wiki="讲 agent 规划")
+    async with client.stream(
+        "POST",
+        f"/api/libraries/{lib_id}/chat",
+        json={"question": "这个方向讲了什么？", "history": []},
+        headers=creator,
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = (await resp.aread()).decode("utf-8")
+    events = _parse_sse(body)
+    kinds = [e for e, _ in events]
+    assert kinds[0] == "sources" and kinds[-1] == "done" and "error" not in kinds
+
+
+async def test_manage_endpoints_forbidden_for_non_manager(client):
+    creator, _admin, lib_id = await _setup(client, prefix="p9d-403")
+    p1 = await _seed_paper(lib_id, title="Guarded")
+    stranger = await _hdr(client, "p9d-403-stranger@example.com")
+
+    resp = await client.get(f"/api/libraries/{lib_id}/papers", headers=stranger)
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers/batch-delete",
+        json={"paper_ids": [p1]},
+        headers=stranger,
+    )
+    assert resp.status_code == 403
+    resp = await client.post(f"/api/libraries/{lib_id}/trash/empty", headers=stranger)
+    assert resp.status_code == 403
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/papers", json={"bibtex": BIBTEX_ENTRY}, headers=stranger
+    )
+    assert resp.status_code == 403
+    resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=stranger)
+    assert resp.status_code == 403

--- a/src/frontend/src/features/chat/ChatSurface.tsx
+++ b/src/frontend/src/features/chat/ChatSurface.tsx
@@ -25,6 +25,8 @@ export interface ChatSurfaceConfig {
   /** localStorage 命名空间，如 `library:${pid}` / `reading:${paperId}` */
   surfaceKey: string;
   pid: string;
+  /** 独立库作用域：透传给 Composer，让 / 选择器候选走库端点 */
+  libraryId?: string;
   title: string;
   contextKinds: ContextKind[];
   hint: ReactNode;
@@ -352,6 +354,7 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
 
         <Composer
           pid={cfg.pid}
+          libraryId={cfg.libraryId}
           streaming={streaming}
           contextKinds={cfg.contextKinds}
           attachesPaperLink={cfg.attachesPaperLink}

--- a/src/frontend/src/features/chat/Composer.tsx
+++ b/src/frontend/src/features/chat/Composer.tsx
@@ -18,6 +18,8 @@ import {
 
 interface ComposerProps {
   pid: string;
+  /** 独立库作用域：给定时 / 选择器的论文/概念候选走库端点 */
+  libraryId?: string;
   streaming: boolean;
   /** / 选择器提供哪些实体类型 */
   contextKinds: ContextKind[];
@@ -44,6 +46,7 @@ const TRIGGER_RE = /(^|\s)([/@])(\S*)$/;
 
 export function Composer({
   pid,
+  libraryId,
   streaming,
   contextKinds,
   attachesPaperLink,
@@ -62,8 +65,9 @@ export function Composer({
   // —— / 选择器候选：按需拉取真实列表 ——
   const slashOpen = menu?.type === 'slash';
   const papersQ = useQuery({
-    queryKey: ['chat-ctx-papers', pid],
-    queryFn: () => api.listPapers(pid, { size: 60 }),
+    queryKey: ['chat-ctx-papers', libraryId ?? pid],
+    queryFn: () =>
+      libraryId ? api.listLibraryPapersFull(libraryId, { size: 60 }) : api.listPapers(pid, { size: 60 }),
     enabled: slashOpen && contextKinds.includes('paper'),
     staleTime: 60_000,
   });
@@ -80,8 +84,8 @@ export function Composer({
     staleTime: 60_000,
   });
   const conceptsQ = useQuery({
-    queryKey: ['chat-ctx-concepts', pid],
-    queryFn: () => api.listConcepts(pid),
+    queryKey: ['chat-ctx-concepts', libraryId ?? pid],
+    queryFn: () => (libraryId ? api.listLibraryConcepts(libraryId) : api.listConcepts(pid)),
     enabled: slashOpen && contextKinds.includes('concept'),
     staleTime: 60_000,
   });

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -4,20 +4,17 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
-import { api, ApiError, isAdmin, type DirectionLibraryDetail, type IngestMode } from '../../lib/api';
+import { api, isAdmin, type DirectionLibraryDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { WikiWorkbench } from '../wiki/WikiPage';
-import { GovernanceTab } from '../wiki/GovernanceTab';
 import { LibraryBrowse } from './LibraryBrowse';
 
 /* ============================================================
    /libraries/:id — 文献库详情（P5c + P6 治理 + P9b 生命周期）
-   - 可管理者（成员 / 文献库管理员 / 创建者 / 平台管理员）：完整工作台。
-     · 有起源课题的库 → project 作用域工作台（论文/概念/图谱/对话/建库/笔记/治理）；
-     · 独立库（project_id=NULL）→ 库作用域管理台（论文浏览 / 建库与同步 / 治理，
-       走 /libraries 端点；对话/图谱/笔记深绑课题，独立库下暂不提供）。
+   - 可管理者（成员 / 文献库管理员 / 创建者 / 平台管理员）：完整工作台
+     （论文/概念/图谱/对话/建库/笔记/治理）。有起源课题的库走 project 作用域端点；
+     独立库（project_id=NULL）同一套工作台改走 /libraries 端点。
    - 其他人：干净的只读浏览（论文 + 概念）。
    顶部按状态显示横幅：待审批 / 已驳回；平台管理员可就地批准 / 驳回。
    ============================================================ */
@@ -67,7 +64,6 @@ export function LibraryDetailPage() {
   }
 
   const canManage = lib.can_manage;
-  const standalone = !lib.project_id;
 
   return (
     <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
@@ -84,10 +80,8 @@ export function LibraryDetailPage() {
         }
       />
       <StatusBanner lib={lib} />
-      {canManage && lib.project_id ? (
-        <WikiWorkbench pid={lib.project_id} libraryId={lib.id} />
-      ) : canManage && standalone ? (
-        <StandaloneWorkbench lib={lib} />
+      {canManage ? (
+        <WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} />
       ) : (
         <LibraryBrowse libraryId={lib.id} />
       )}
@@ -174,99 +168,6 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
           </button>
         </div>
       )}
-    </div>
-  );
-}
-
-/* —— 独立库（project_id=NULL）管理台：论文浏览 / 建库与同步 / 治理 —— */
-
-type StandaloneTab = 'browse' | 'ingest' | 'govern';
-
-function StandaloneWorkbench({ lib }: { lib: DirectionLibraryDetail }) {
-  const [tab, setTab] = useState<StandaloneTab>('browse');
-  return (
-    <>
-      <div className="row" style={{ marginBottom: 14 }}>
-        <Segmented<StandaloneTab>
-          options={[
-            { v: 'browse', label: tr('论文与概念', 'Papers & concepts') },
-            { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
-            { v: 'govern', label: tr('治理', 'Governance') },
-          ]}
-          value={tab}
-          onChange={setTab}
-        />
-      </div>
-      {tab === 'browse' ? (
-        <LibraryBrowse libraryId={lib.id} />
-      ) : tab === 'ingest' ? (
-        <div className="card" style={{ flex: 1, minHeight: 480, overflow: 'auto' }}>
-          <LibraryIngestPanel lib={lib} />
-        </div>
-      ) : (
-        <div className="card" style={{ flex: 1, minHeight: 480, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          <GovernanceTab libraryId={lib.id} />
-        </div>
-      )}
-    </>
-  );
-}
-
-/* —— 库级抓取触发（走 POST /libraries/{id}/ingest/run，P9a；仅 active 可触发） —— */
-
-function LibraryIngestPanel({ lib }: { lib: DirectionLibraryDetail }) {
-  const navigate = useNavigate();
-  const active = lib.status === 'active';
-
-  const run = useMutation({
-    mutationFn: (mode: IngestMode) => api.startLibraryIngest(lib.id, { mode }),
-    onSuccess: (voyage) => {
-      toast(tr('已开始抓取', 'Ingest started'), 'ok');
-      navigate(`/voyages/${voyage.id}`);
-    },
-    onError: (err) => {
-      const code = err instanceof ApiError ? err.message : '';
-      const msg =
-        code === 'LIBRARY_NOT_ACTIVE'
-          ? tr('文献库还未激活，无法抓取', 'Library is not active yet')
-          : code === 'INGEST_ALREADY_RUNNING'
-            ? tr('已有一个抓取任务在跑，请等它结束', 'An ingest is already running — wait for it to finish')
-            : code === 'LIBRARY_BUDGET_EXHAUSTED'
-              ? tr('本月预算已用尽，下月恢复或调高上限', 'Monthly budget is used up — resumes next month or raise the cap')
-              : tr('启动失败，请重试', 'Failed to start, please retry');
-      toast(msg, 'error');
-    },
-  });
-
-  return (
-    <div className="col gap16" style={{ padding: 20, maxWidth: 640 }}>
-      <div>
-        <h3 style={{ fontSize: 14, fontWeight: 700, marginBottom: 6 }}>{tr('建库与同步', 'Ingest & sync')}</h3>
-        <p className="muted" style={{ fontSize: 12.5, lineHeight: 1.6 }}>
-          {tr(
-            '初始建库会按收录设置检索 arXiv、做参考文献扩展、打分并编译解读；之后用增量更新只补新论文。抓取消耗记本库预算。',
-            'Bootstrap searches arXiv by the inclusion settings, expands references, scores and compiles wikis; later use incremental sync for new papers only. Token cost is billed to this library’s budget.',
-          )}
-        </p>
-      </div>
-      {!active && (
-        <div className="card" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', padding: '10px 14px', fontSize: 12.5 }}>
-          {tr('文献库待激活：管理员批准后才能开始抓取。', 'Library is not active yet — an admin must approve it before ingest can start.')}
-        </div>
-      )}
-      <div className="row gap10">
-        <button className="btn btn-primary" disabled={!active || run.isPending} onClick={() => run.mutate('bootstrap')}>
-          <Icon name="sparkle" size={14} />
-          {run.isPending ? tr('启动中…', 'Starting…') : tr('初始建库', 'Bootstrap')}
-        </button>
-        <button className="btn btn-soft" disabled={!active || run.isPending} onClick={() => run.mutate('incremental')}>
-          <Icon name="refresh" size={14} />
-          {tr('增量更新', 'Incremental sync')}
-        </button>
-      </div>
-      <p className="muted" style={{ fontSize: 11.5 }}>
-        {tr('在「治理」页签里可以调整收录分类、关键词与打分标准。', 'Tune inclusion categories, keywords and rubric in the Governance tab.')}
-      </p>
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/GraphTab.tsx
+++ b/src/frontend/src/features/wiki/GraphTab.tsx
@@ -1108,24 +1108,27 @@ function TopicsView({
 /* ---------------- Tab 主体 ---------------- */
 
 export interface GraphTabProps {
-  pid: string;
+  pid?: string;
+  /** 独立库作用域：给定时图谱走 /libraries/{id}/graph */
+  libraryId?: string;
   onOpenPaper: (id: string) => void;
   onOpenConcept: (id: string) => void;
 }
 
-export function GraphTab({ pid, onOpenPaper, onOpenConcept }: GraphTabProps) {
+export function GraphTab({ pid, libraryId, onOpenPaper, onOpenConcept }: GraphTabProps) {
   const [view, setView] = useState<GraphView>('timeline');
   const [focusConceptId, setFocusConceptId] = useState('');
+  const scopeId = libraryId ?? pid ?? '';
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['project-graph', pid],
-    queryFn: () => api.getProjectGraph(pid),
+    queryKey: ['project-graph', scopeId],
+    queryFn: () => (libraryId ? api.getLibraryGraph(libraryId) : api.getProjectGraph(scopeId)),
     retry: false,
     staleTime: 60_000,
   });
 
   // 切方向时清空子主题
-  useEffect(() => setFocusConceptId(''), [pid]);
+  useEffect(() => setFocusConceptId(''), [scopeId]);
 
   const model = useMemo(() => (data ? buildModel(data, focusConceptId) : null), [data, focusConceptId]);
 

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -20,7 +20,9 @@ import { tr } from '../../lib/i18n';
    ============================================================ */
 
 export interface IngestTabProps {
-  pid: string;
+  pid?: string;
+  /** 独立库作用域：给定时抓取走 /libraries/{id}/ingest/run，状态走库端点 */
+  libraryId?: string;
   state: IngestState | undefined;
   stateError: boolean;
   stateLoading: boolean;
@@ -85,13 +87,15 @@ function KnobRange({
   );
 }
 
-export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabProps) {
+export function IngestTab({ pid, libraryId, state, stateError, stateLoading }: IngestTabProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const scopeId = libraryId ?? pid ?? '';
 
-  // 无 include 关键词时 arXiv 检索会退化成无差别抓取（空转烧钱），前端禁止启动
+  // 无 include 关键词时 arXiv 检索会退化成无差别抓取（空转烧钱），前端禁止启动。
+  // 独立库的关键词在治理页配置、后端自行校验，这里不做课题级的关键词拦截。
   const { projects } = useProject();
-  const project = projects.find((p) => p.id === pid);
+  const project = libraryId ? undefined : projects.find((p) => p.id === pid);
   const noKeywords = !!project && (project.definition?.keywords?.include ?? []).length === 0;
 
   // —— 成本旋钮（bootstrap） ——
@@ -106,7 +110,8 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
   const running = !!state?.running_voyage_id;
 
   const ingestMutation = useMutation({
-    mutationFn: (input: { mode: IngestMode; knobs: IngestKnobs }) => api.startIngest(pid, input),
+    mutationFn: (input: { mode: IngestMode; knobs: IngestKnobs }) =>
+      libraryId ? api.startLibraryIngest(libraryId, input) : api.startIngest(scopeId, input),
     onSuccess: (v, input) => {
       toast(
         input.mode === 'bootstrap'
@@ -114,7 +119,7 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
           : tr('增量同步已开始，跳转任务详情…', 'Incremental sync started — opening task detail…'),
         'ok',
       );
-      void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
       navigate(`/voyages/${v.id}`);
     },
     onError: (e) => {
@@ -123,12 +128,17 @@ export function IngestTab({ pid, state, stateError, stateLoading }: IngestTabPro
           tr('这个文献库本月 AI 预算已用尽，同步已暂停；下月自动恢复，或请管理员调高预算。', 'This library has used up its monthly AI budget — syncing is paused until next month, or ask an admin to raise the budget.'),
           'error',
         );
-      } else if (e instanceof ApiError && e.status === 409) {
+      } else if (e instanceof ApiError && e.message === 'LIBRARY_NOT_ACTIVE') {
         toast(
-          tr('该课题已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this topic — wait for it to finish.'),
+          tr('文献库还未激活，管理员批准后才能开始抓取。', 'Library is not active yet — an admin must approve it before ingest can start.'),
           'error',
         );
-        void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
+      } else if (e instanceof ApiError && e.status === 409) {
+        toast(
+          tr('该文献库已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this library — wait for it to finish.'),
+          'error',
+        );
+        void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
       } else {
         toast(`${tr('启动失败：', 'Failed to start: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
       }

--- a/src/frontend/src/features/wiki/LibraryChatTab.tsx
+++ b/src/frontend/src/features/wiki/LibraryChatTab.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { api, type LibraryChatSource } from '../../lib/api';
-import { chatLibrarySse } from '../../lib/sse';
+import { chatLibrarySse, chatLibraryByIdSse } from '../../lib/sse';
 import { RelevanceBar } from '../../components/ui/RelevanceBar';
 import { tr } from '../../lib/i18n';
 import { ChatSurface } from '../chat/ChatSurface';
@@ -205,15 +205,19 @@ function SourceList({
 }
 
 export interface LibraryChatTabProps {
-  pid: string;
+  /** 课题作用域（成员视角，走 /projects/{pid}/chat） */
+  pid?: string;
+  /** 独立库作用域（走 /libraries/{id}/chat）；与 pid 二选一 */
+  libraryId?: string;
   onOpenPaper: (id: string) => void;
   /** [[概念名]] 双链点击 → 按名称跳概念库 */
   onWikiLink?: WikiLinkHandler;
 }
 
-export function LibraryChatTab({ pid, onOpenPaper, onWikiLink }: LibraryChatTabProps) {
+export function LibraryChatTab({ pid, libraryId, onOpenPaper, onWikiLink }: LibraryChatTabProps) {
+  const scopePid = pid ?? '';
   const rebuildMutation = useMutation({
-    mutationFn: () => api.rebuildFulltextIndex(pid),
+    mutationFn: () => api.rebuildFulltextIndex(scopePid),
     onSuccess: (r) => {
       if (r.papers_indexed === 0) {
         toast(tr('全文索引已是最新', 'Full-text index is up to date'), 'info');
@@ -276,7 +280,32 @@ export function LibraryChatTab({ pid, onOpenPaper, onWikiLink }: LibraryChatTabP
         onError: (d: string) => void;
       },
     ) =>
-      chatLibrarySse(pid, { question: args.question, history: args.history }, {
+      (libraryId
+        ? chatLibraryByIdSse(libraryId, { question: args.question, history: args.history }, {
+            onEvent: (event, dataStr) => {
+              if (event === 'sources') ctrl.onSources?.(dataStr);
+              else if (event === 'delta') {
+                try {
+                  const t = (JSON.parse(dataStr) as { text?: string }).text ?? '';
+                  if (t) ctrl.onDelta(t);
+                } catch {
+                  /* ignore */
+                }
+              } else if (event === 'done') ctrl.onDone();
+              else if (event === 'error') {
+                let detail = tr('服务端出错', 'Server error');
+                try {
+                  detail = (JSON.parse(dataStr) as { detail?: string }).detail ?? detail;
+                } catch {
+                  /* keep */
+                }
+                ctrl.onError(detail);
+              }
+            },
+            onClose: () => ctrl.onDone(),
+            onError: (err) => ctrl.onError(err instanceof Error ? err.message : String(err)),
+          })
+        : chatLibrarySse(scopePid, { question: args.question, history: args.history }, {
         onEvent: (event, dataStr) => {
           if (event === 'sources') ctrl.onSources?.(dataStr);
           else if (event === 'delta') {
@@ -299,31 +328,34 @@ export function LibraryChatTab({ pid, onOpenPaper, onWikiLink }: LibraryChatTabP
         },
         onClose: () => ctrl.onDone(),
         onError: (err) => ctrl.onError(err instanceof Error ? err.message : String(err)),
-      }),
-    [pid],
+      })),
+    [pid, libraryId, scopePid],
   );
 
   return (
     <ChatSurface
-      surfaceKey={`library:${pid}`}
-      pid={pid}
+      surfaceKey={libraryId ? `library-standalone:${libraryId}` : `library:${scopePid}`}
+      pid={scopePid}
+      libraryId={libraryId}
       title={tr('文献对话', 'Library chat')}
-      contextKinds={['paper', 'idea', 'experiment', 'concept']}
+      contextKinds={libraryId ? ['paper', 'concept'] : ['paper', 'idea', 'experiment', 'concept']}
       hint={tr(
         '回答基于从整个文献库检索到的全文片段，可做跨文献对比与综合梳理；[n] 为引用来源编号。',
         'Answers are grounded in full-text passages from the whole library; [n] marks a source number.',
       )}
       headerAction={
-        <button
-          className="btn btn-ghost sm"
-          style={{ height: 26, fontSize: 10.5, flexShrink: 0 }}
-          title={tr('给较早入库、还没建全文索引的论文补索引', 'Backfill the full-text index for older papers')}
-          disabled={rebuildMutation.isPending}
-          onClick={() => rebuildMutation.mutate()}
-        >
-          <Icon name="refresh" size={11} style={rebuildMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
-          {tr('补建索引', 'Rebuild index')}
-        </button>
+        libraryId ? undefined : (
+          <button
+            className="btn btn-ghost sm"
+            style={{ height: 26, fontSize: 10.5, flexShrink: 0 }}
+            title={tr('给较早入库、还没建全文索引的论文补索引', 'Backfill the full-text index for older papers')}
+            disabled={rebuildMutation.isPending}
+            onClick={() => rebuildMutation.mutate()}
+          >
+            <Icon name="refresh" size={11} style={rebuildMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
+            {tr('补建索引', 'Rebuild index')}
+          </button>
+        )
       }
       emptyIcon="chat"
       emptyTitle={tr('和整个文献库对话', 'Chat with the whole library')}

--- a/src/frontend/src/features/wiki/NotesTab.tsx
+++ b/src/frontend/src/features/wiki/NotesTab.tsx
@@ -52,8 +52,9 @@ function NoteItem({ note, onOpenPaper }: { note: NoteWithPaper; onOpenPaper: () 
   );
 }
 
-export function NotesTab({ pid }: { pid: string }) {
+export function NotesTab({ pid, libraryId }: { pid?: string; libraryId?: string }) {
   const navigate = useNavigate();
+  const scopeId = libraryId ?? pid ?? '';
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
   const [page, setPage] = useState(1);
@@ -64,8 +65,11 @@ export function NotesTab({ pid }: { pid: string }) {
   }, [q]);
 
   const notesQuery = useQuery({
-    queryKey: ['project-notes', pid, q, page],
-    queryFn: () => api.listProjectNotes(pid, { q: q || undefined, page, size: PAGE_SIZE }),
+    queryKey: ['project-notes', scopeId, q, page],
+    queryFn: () =>
+      libraryId
+        ? api.listLibraryNotes(libraryId, { q: q || undefined, page, size: PAGE_SIZE })
+        : api.listProjectNotes(scopeId, { q: q || undefined, page, size: PAGE_SIZE }),
     retry: false,
     placeholderData: keepPreviousData,
   });

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -66,7 +66,9 @@ export interface AdvSearchSeed {
 }
 
 export interface PapersTabProps {
-  pid: string;
+  pid?: string;
+  /** 独立库作用域：给定时集合级调用走 /libraries/{id}/* 端点，并隐藏标签编辑/过滤 */
+  libraryId?: string;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onOpenConcept: (id: string) => void;
@@ -82,17 +84,20 @@ type ImportMethod = 'arxiv' | 'doi' | 'bibtex';
 
 function AddPaperModal({
   pid,
+  libraryId,
   open,
   onClose,
   onImported,
 }: {
   pid: string;
+  libraryId?: string;
   open: boolean;
   onClose: () => void;
   /** 添加成功 / 已存在时跳转选中该论文 */
   onImported: (paperId: string) => void;
 }) {
   const queryClient = useQueryClient();
+  const scopeId = libraryId ?? pid;
   const [method, setMethod] = useState<ImportMethod>('arxiv');
   const [arxivId, setArxivId] = useState('');
   const [doi, setDoi] = useState('');
@@ -120,11 +125,11 @@ function AddPaperModal({
   };
 
   const importMutation = useMutation({
-    mutationFn: (inp: PaperImportInput) => api.importPaper(pid, inp),
+    mutationFn: (inp: PaperImportInput) => (libraryId ? api.importLibraryPaper(libraryId, inp) : api.importPaper(pid, inp)),
     onSuccess: (p) => {
       toast(tr('文献已加进论文库', 'Paper added to the library'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
       reset();
       onClose();
       onImported(p.id);
@@ -151,7 +156,7 @@ function AddPaperModal({
       open={open}
       onClose={onClose}
       title={tr('添加文献', 'Add paper')}
-      sub={tr('手动把一篇论文加进当前课题的论文库', 'Manually add a paper to this topic’s library')}
+      sub={libraryId ? tr('手动把一篇论文加进这个文献库', 'Manually add a paper to this library') : tr('手动把一篇论文加进当前课题的论文库', 'Manually add a paper to this topic’s library')}
       width={520}
       footer={
         <>
@@ -410,14 +415,18 @@ export function ExportMenu({
 
 /* ---------------- 垃圾桶 ---------------- */
 
-function TrashModal({ pid, open, onClose }: { pid: string; open: boolean; onClose: () => void }) {
+function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?: string; open: boolean; onClose: () => void }) {
   const queryClient = useQueryClient();
+  const scopeId = libraryId ?? pid;
   const [confirmEmpty, setConfirmEmpty] = useState(false);
   const [trashQ, setTrashQ] = useState('');
 
   const trashQuery = useQuery({
-    queryKey: ['papers-trash', pid],
-    queryFn: () => api.listPapers(pid, { status: 'excluded', size: 100, sort: '-published_at' }),
+    queryKey: ['papers-trash', scopeId],
+    queryFn: () =>
+      libraryId
+        ? api.listLibraryPapersFull(libraryId, { status: 'excluded', size: 100, sort: '-published_at' })
+        : api.listPapers(pid, { status: 'excluded', size: 100, sort: '-published_at' }),
     enabled: open,
     retry: false,
   });
@@ -433,10 +442,10 @@ function TrashModal({ pid, open, onClose }: { pid: string; open: boolean; onClos
     : allItems;
 
   const invalidate = () => {
-    void queryClient.invalidateQueries({ queryKey: ['papers-trash', pid] });
-    void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
-    void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
-    void queryClient.invalidateQueries({ queryKey: ['project-graph', pid] });
+    void queryClient.invalidateQueries({ queryKey: ['papers-trash', scopeId] });
+    void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+    void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
+    void queryClient.invalidateQueries({ queryKey: ['project-graph', scopeId] });
   };
 
   const restoreMutation = useMutation({
@@ -460,7 +469,7 @@ function TrashModal({ pid, open, onClose }: { pid: string; open: boolean; onClos
   });
 
   const emptyMutation = useMutation({
-    mutationFn: () => api.emptyTrash(pid),
+    mutationFn: () => (libraryId ? api.emptyLibraryTrash(libraryId) : api.emptyTrash(pid)),
     onSuccess: (res) => {
       toast(tr(`垃圾桶已清空（${res.deleted} 篇）`, `Trash emptied (${res.deleted} papers)`), 'ok');
       setConfirmEmpty(false);
@@ -873,6 +882,7 @@ const AFFIL_CHIP_LIMIT = 6;
 function PaperDetailPane({
   paperId,
   pid,
+  libraryId,
   onOpenConcept,
   onWikiLink,
   onFilterAuthor,
@@ -881,6 +891,7 @@ function PaperDetailPane({
 }: {
   paperId: string;
   pid: string;
+  libraryId?: string;
   onOpenConcept: (id: string) => void;
   onWikiLink: WikiLinkHandler;
   /** 点击作者名 → 论文库按该作者过滤 */
@@ -892,6 +903,7 @@ function PaperDetailPane({
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const scopeId = libraryId ?? pid;
   const [abstractOpen, setAbstractOpen] = useState(false);
   const [conceptsOpen, setConceptsOpen] = useState(false);
   const [affilsOpen, setAffilsOpen] = useState(false);
@@ -908,10 +920,10 @@ function PaperDetailPane({
     mutationFn: () => api.patchPaper(paperId, { status: 'excluded' }),
     onSuccess: () => {
       toast(tr('已移入垃圾桶，可在列表底部的垃圾桶中召回', 'Moved to trash — restore it from the trash any time'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['papers-trash', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['project-graph', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['papers-trash', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['project-graph', scopeId] });
       onDeleted();
     },
     onError: (e) =>
@@ -925,7 +937,7 @@ function PaperDetailPane({
       queryClient.setQueryData<PaperDetail>(['paper', paperId], (old) =>
         old ? { ...old, starred: meta.starred, reading_status: meta.reading_status } : old,
       );
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
     },
     onError: (e) =>
       toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
@@ -938,7 +950,7 @@ function PaperDetailPane({
       toast(tr('编译完成，介绍已更新', 'Compiled — the intro has been updated'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['paper', paperId] });
       void queryClient.invalidateQueries({ queryKey: ['paper-figures', paperId] });
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
     },
     onError: (e) =>
       toast(`${tr('重新编译失败：', 'Recompile failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
@@ -1158,8 +1170,8 @@ function PaperDetailPane({
         </span>
       </div>
 
-      {/* —— 标签（就地编辑） —— */}
-      <TagEditor paper={paper} pid={pid} />
+      {/* —— 标签（就地编辑；独立库不支持标签，隐藏） —— */}
+      {!libraryId && <TagEditor paper={paper} pid={pid} />}
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
@@ -1339,7 +1351,8 @@ function PaperDetailPane({
 
 /* ---------------- Tab 主体 ---------------- */
 
-export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink, advSeed }: PapersTabProps) {
+export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept, onWikiLink, advSeed }: PapersTabProps) {
+  const scopeId = libraryId ?? pid ?? '';
   const [view, setView] = useState<ViewFilter>('all');
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [mode, setMode] = useState<SearchMode>('keyword');
@@ -1403,25 +1416,25 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [pid, view, q, tagFilter, readingFilter]);
+  }, [scopeId, view, q, tagFilter, readingFilter]);
 
   const bulkDeleteMutation = useMutation({
-    mutationFn: () => api.batchDeletePapers(pid, [...selected]),
+    mutationFn: () => (libraryId ? api.batchDeleteLibraryPapers(libraryId, [...selected]) : api.batchDeletePapers(scopeId, [...selected])),
     onSuccess: (res) => {
       toast(tr(`已把 ${res.deleted} 篇移入垃圾桶，可召回`, `Moved ${res.deleted} papers to trash — restorable`), 'ok');
       if (selectedId && selected.has(selectedId)) onSelect('');
       setSelected(new Set());
       setSelectMode(false);
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['ingest-state', pid] });
-      void queryClient.invalidateQueries({ queryKey: ['project-graph', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
+      void queryClient.invalidateQueries({ queryKey: ['project-graph', scopeId] });
     },
     onError: (e) =>
       toast(`${tr('删除失败：', 'Delete failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
   const bulkExportMutation = useMutation({
-    mutationFn: () => api.downloadCitations(pid, { format: 'bibtex', ids: [...selected] }),
+    mutationFn: () => api.downloadCitations(pid ?? '', { format: 'bibtex', ids: [...selected] }),
     onSuccess: (blob) => {
       saveBlob(blob, 'polaris-selected.bib');
       toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
@@ -1434,17 +1447,18 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
 
   // —— 项目标签（过滤下拉用；接口未就绪时静默降级） ——
   const tagsQuery = useQuery({
-    queryKey: ['project-tags', pid],
-    queryFn: () => api.listTags(pid),
+    queryKey: ['project-tags', scopeId],
+    queryFn: () => (libraryId ? api.listLibraryTags(libraryId) : api.listTags(scopeId)),
     retry: false,
+    enabled: !libraryId,
   });
   const projectTags = tagsQuery.data ?? [];
 
   // —— 关键词/浏览：分页列表 ——
   const listQuery = useInfiniteQuery({
-    queryKey: ['papers', pid, view, q, sort, tagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
-    queryFn: ({ pageParam }) =>
-      api.listPapers(pid, {
+    queryKey: ['papers', scopeId, view, q, sort, tagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
+    queryFn: ({ pageParam }) => {
+      const opts = {
         ...viewQuery(view),
         q: q || undefined,
         sort,
@@ -1458,7 +1472,9 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
         created_to: advCreatedTo ? `${advCreatedTo}T23:59:59Z` : undefined,
         page: pageParam,
         size: PAGE_SIZE,
-      }),
+      };
+      return libraryId ? api.listLibraryPapersFull(libraryId, opts) : api.listPapers(scopeId, opts);
+    },
     initialPageParam: 1,
     getNextPageParam: (last) => (last.page * last.size < last.total ? last.page + 1 : undefined),
     retry: false,
@@ -1467,8 +1483,11 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
 
   // —— 语义检索 ——
   const semQuery = useQuery({
-    queryKey: ['wiki-search', pid, q],
-    queryFn: () => api.searchProject(pid, { q, mode: 'semantic', limit: 30 }),
+    queryKey: ['wiki-search', scopeId, q],
+    queryFn: () =>
+      libraryId
+        ? api.searchLibrary(libraryId, { q, mode: 'semantic', limit: 30 })
+        : api.searchProject(scopeId, { q, mode: 'semantic', limit: 30 }),
     retry: (count, e) => !(e instanceof ApiError) && count < 1,
     enabled: semanticActive,
   });
@@ -1630,22 +1649,24 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
               {tr('垃圾桶', 'Trash')}
             </span>
           </div>
-          {/* 标签 / 阅读状态 / 仅星标 过滤 */}
+          {/* 标签（独立库不支持，隐藏）/ 阅读状态过滤 */}
           <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
-            <select
-              className="input"
-              style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
-              value={tagFilter}
-              onChange={(e) => setTagFilter(e.target.value)}
-              title={tr('按标签过滤', 'Filter by tag')}
-            >
-              <option value="">{tr('全部标签', 'All tags')}</option>
-              {projectTags.map((t) => (
-                <option key={t.id} value={t.name}>
-                  {t.name}（{t.paper_count}）
-                </option>
-              ))}
-            </select>
+            {!libraryId && (
+              <select
+                className="input"
+                style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
+                value={tagFilter}
+                onChange={(e) => setTagFilter(e.target.value)}
+                title={tr('按标签过滤', 'Filter by tag')}
+              >
+                <option value="">{tr('全部标签', 'All tags')}</option>
+                {projectTags.map((t) => (
+                  <option key={t.id} value={t.name}>
+                    {t.name}（{t.paper_count}）
+                  </option>
+                ))}
+              </select>
+            )}
             <select
               className="input"
               style={{ height: 26, fontSize: 11.5, width: 88, padding: '0 6px' }}
@@ -1788,14 +1809,16 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
                 <Icon name="x" size={12} />
                 {tr('删除', 'Delete')}
               </button>
-              <button
-                className="btn btn-ghost sm"
-                disabled={selected.size === 0 || bulkExportMutation.isPending}
-                onClick={() => bulkExportMutation.mutate()}
-              >
-                <Icon name="download" size={12} />
-                {tr('导出 BibTeX', 'Export BibTeX')}
-              </button>
+              {!libraryId && (
+                <button
+                  className="btn btn-ghost sm"
+                  disabled={selected.size === 0 || bulkExportMutation.isPending}
+                  onClick={() => bulkExportMutation.mutate()}
+                >
+                  <Icon name="download" size={12} />
+                  {tr('导出 BibTeX', 'Export BibTeX')}
+                </button>
+              )}
             </>
           )}
         </div>
@@ -1806,7 +1829,8 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
         {selectedId ? (
           <PaperDetailPane
             paperId={selectedId}
-            pid={pid}
+            pid={pid ?? ''}
+            libraryId={libraryId}
             onOpenConcept={onOpenConcept}
             onWikiLink={onWikiLink}
             onFilterAuthor={filterByAuthor}
@@ -1821,10 +1845,10 @@ export function PapersTab({ pid, selectedId, onSelect, onOpenConcept, onWikiLink
       </div>
 
       {/* —— 添加文献 Modal —— */}
-      <AddPaperModal pid={pid} open={addOpen} onClose={() => setAddOpen(false)} onImported={onSelect} />
+      <AddPaperModal pid={pid ?? ''} libraryId={libraryId} open={addOpen} onClose={() => setAddOpen(false)} onImported={onSelect} />
 
       {/* —— 垃圾桶 —— */}
-      <TrashModal pid={pid} open={trashOpen} onClose={() => setTrashOpen(false)} />
+      <TrashModal pid={pid ?? ''} libraryId={libraryId} open={trashOpen} onClose={() => setTrashOpen(false)} />
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -28,8 +28,14 @@ const PresentationModal = lazy(() =>
 
 type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | 'govern';
 
-export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: string }) {
+export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: string }) {
   const navigate = useNavigate();
+
+  // 独立库（无起源课题）：集合级数据走 /libraries/{id}/* 端点，隐藏 PPT / 导出（均为课题域）。
+  const standalone = !pid;
+  const scopeId = standalone ? libraryId! : pid!;
+  /** 传给各 Tab 的库作用域标识：仅独立库置位，课题库保持 undefined 走 project 端点。 */
+  const tabLibraryId = standalone ? libraryId : undefined;
 
   const [tab, setTab] = useState<WikiTab>('papers');
   const [presentOpen, setPresentOpen] = useState(false);
@@ -45,7 +51,7 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
     setPaperId(null);
     setConceptId(null);
     setPendingConceptName(null);
-  }, [pid]);
+  }, [scopeId]);
 
   // 深链 ?paper=<id>（idea 详情 / 阅读页返回）、?concept=<名称>
   // （阅读页双链跳转，按名称解析）、?author= / ?affiliation=
@@ -79,16 +85,19 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
 
   // —— ingest 状态（tab 计数 + Ingest 面板共用） ——
   const ingestQuery = useQuery({
-    queryKey: ['ingest-state', pid],
-    queryFn: () => api.getIngestState(pid),
+    queryKey: ['ingest-state', scopeId],
+    queryFn: () => (standalone ? api.getLibraryIngestState(libraryId!) : api.getIngestState(pid!)),
     retry: false,
     refetchInterval: (q) => (q.state.data?.running_voyage_id ? 5_000 : 60_000),
   });
 
   // —— [[概念名]] → 概念 id 解析 ——
   const resolveQuery = useQuery({
-    queryKey: ['concept-resolve', pid, pendingConceptName],
-    queryFn: () => api.listConcepts(pid, { q: pendingConceptName ?? '' }),
+    queryKey: ['concept-resolve', scopeId, pendingConceptName],
+    queryFn: () =>
+      standalone
+        ? api.listLibraryConcepts(libraryId!, { q: pendingConceptName ?? '' })
+        : api.listConcepts(pid!, { q: pendingConceptName ?? '' }),
     enabled: !!pendingConceptName,
     retry: false,
   });
@@ -157,11 +166,15 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
               {tr('文献任务运行中 →', 'Literature task running →')}
             </span>
           )}
-          <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
-            <Icon name="chart" size={13} />
-            {tr('论文分享 PPT', 'Paper sharing PPT')}
-          </button>
-          <ExportMenu pid={pid} />
+          {!standalone && (
+            <>
+              <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
+                <Icon name="chart" size={13} />
+                {tr('论文分享 PPT', 'Paper sharing PPT')}
+              </button>
+              <ExportMenu pid={pid!} />
+            </>
+          )}
         </div>
       </div>
 
@@ -178,6 +191,7 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
         {tab === 'papers' ? (
           <PapersTab
             pid={pid}
+            libraryId={tabLibraryId}
             selectedId={paperId}
             onSelect={setPaperId}
             onOpenConcept={goConcept}
@@ -187,6 +201,7 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
         ) : tab === 'concepts' ? (
           <ConceptsTab
             pid={pid}
+            libraryId={tabLibraryId}
             selectedId={conceptId}
             onSelect={setConceptId}
             onOpenPaper={goPaper}
@@ -194,13 +209,14 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
           />
         ) : tab === 'graph' ? (
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
-            <GraphTab pid={pid} onOpenPaper={goPaper} onOpenConcept={goConcept} />
+            <GraphTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
           </Suspense>
         ) : tab === 'chat' ? (
-          <LibraryChatTab pid={pid} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
+          <LibraryChatTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
         ) : tab === 'ingest' ? (
           <IngestTab
             pid={pid}
+            libraryId={tabLibraryId}
             state={ingestQuery.data}
             stateError={ingestQuery.isError}
             stateLoading={ingestQuery.isLoading}
@@ -208,14 +224,14 @@ export function WikiWorkbench({ pid, libraryId }: { pid: string; libraryId?: str
         ) : tab === 'govern' && libraryId ? (
           <GovernanceTab libraryId={libraryId} />
         ) : (
-          <NotesTab pid={pid} />
+          <NotesTab pid={pid} libraryId={tabLibraryId} />
         )}
       </div>
 
-      {presentOpen && (
+      {!standalone && presentOpen && (
         <Suspense fallback={null}>
           <PresentationModal
-            projectId={pid}
+            projectId={pid!}
             initialPaperId={paperId ?? undefined}
             onClose={() => setPresentOpen(false)}
           />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2807,6 +2807,84 @@ export const api = {
     return request<SearchResult>(`/libraries/${id}/search?${params.toString()}`);
   },
 
+  // —— P9d · 独立库文献管理台（镜像 project 作用域的集合端点） ——
+  /** 库内论文（全过滤维度，同 listPapers）；status=excluded 为垃圾桶。 */
+  listLibraryPapersFull(
+    id: string,
+    opts: {
+      status?: PaperStatusFilter;
+      q?: string;
+      sort?: PaperSort;
+      page?: number;
+      size?: number;
+      tag?: string;
+      starred?: boolean;
+      reading_status?: ReadingStatus;
+      author?: string;
+      affiliation?: string;
+      published_from?: string;
+      published_to?: string;
+      created_from?: string;
+      created_to?: string;
+    } = {},
+  ): Promise<PageOf<PaperRead>> {
+    const params = new URLSearchParams();
+    if (opts.status) params.set('status', opts.status);
+    if (opts.q) params.set('q', opts.q);
+    if (opts.sort) params.set('sort', opts.sort);
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    if (opts.tag) params.set('tag', opts.tag);
+    if (opts.starred) params.set('starred', 'true');
+    if (opts.reading_status) params.set('reading_status', opts.reading_status);
+    if (opts.author) params.set('author', opts.author);
+    if (opts.affiliation) params.set('affiliation', opts.affiliation);
+    if (opts.published_from) params.set('published_from', opts.published_from);
+    if (opts.published_to) params.set('published_to', opts.published_to);
+    if (opts.created_from) params.set('created_from', opts.created_from);
+    if (opts.created_to) params.set('created_to', opts.created_to);
+    const qs = params.toString();
+    return request<PageOf<PaperRead>>(`/libraries/${id}/papers${qs ? `?${qs}` : ''}`);
+  },
+  /** 手动添加文献到库；409 → PAPER_EXISTS（body 含 paper_id）；422 → PARSE_FAILED。 */
+  importLibraryPaper(id: string, input: PaperImportInput): Promise<PaperDetail> {
+    return requestJson<PaperDetail>(`/libraries/${id}/papers`, 'POST', input);
+  },
+  /** 批量删除库内论文：默认软删（垃圾桶），hard=true 彻底删除。 */
+  batchDeleteLibraryPapers(id: string, paperIds: string[], hard = false): Promise<{ deleted: number }> {
+    return requestJson<{ deleted: number }>(`/libraries/${id}/papers/batch-delete`, 'POST', {
+      paper_ids: paperIds,
+      hard,
+    });
+  },
+  /** 清空库垃圾桶：彻底删除库内全部已删除论文。 */
+  emptyLibraryTrash(id: string): Promise<{ deleted: number }> {
+    return request<{ deleted: number }>(`/libraries/${id}/trash/empty`, { method: 'POST' });
+  },
+  /** 库标签（独立库不支持标签，恒返回 []）。 */
+  listLibraryTags(id: string): Promise<TagRead[]> {
+    return request<TagRead[]>(`/libraries/${id}/tags`);
+  },
+  getLibraryIngestState(id: string): Promise<IngestState> {
+    return request<IngestState>(`/libraries/${id}/ingest/state`);
+  },
+  getLibraryGraph(id: string): Promise<GraphData> {
+    return request<GraphData>(`/libraries/${id}/graph`);
+  },
+  /** 库笔记本：全库笔记分页 + 搜索。 */
+  listLibraryNotes(
+    id: string,
+    opts: { q?: string; paper_id?: string; page?: number; size?: number } = {},
+  ): Promise<PageOf<NoteWithPaper>> {
+    const params = new URLSearchParams();
+    if (opts.q) params.set('q', opts.q);
+    if (opts.paper_id) params.set('paper_id', opts.paper_id);
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    const qs = params.toString();
+    return request<PageOf<NoteWithPaper>>(`/libraries/${id}/notes${qs ? `?${qs}` : ''}`);
+  },
+
   // —— P5a · 课题「相关研究」书架 ——
   listShelf(projectId: string, opts: { page?: number; size?: number } = {}): Promise<PageOf<ShelfItemRead>> {
     const params = new URLSearchParams();

--- a/src/frontend/src/lib/sse.ts
+++ b/src/frontend/src/lib/sse.ts
@@ -187,6 +187,15 @@ export function chatLibrarySse(
   return postSse(`/projects/${projectId}/chat`, input, handlers);
 }
 
+/** 独立库对话：POST /libraries/{id}/chat（事件协议同 chatLibrarySse）。 */
+export function chatLibraryByIdSse(
+  libraryId: string,
+  input: { question: string; history: { role: 'user' | 'assistant'; content: string }[] },
+  handlers: PostSseHandlers,
+): () => void {
+  return postSse(`/libraries/${libraryId}/chat`, input, handlers);
+}
+
 /** 写作辅助：POST /manuscripts/{id}/assist（delta* → warnings? → done/error）。 */
 export interface AssistInput {
   mode: 'polish' | 'rewrite' | 'continue';


### PR DESCRIPTION
Part of #1 (workspace IA redesign) — phase P9d. Completes the standalone-library experience left partial by P9b: an admin/user-created library (`project_id = NULL`) now has the same full management console as a topic-originated one.

## Backend — library-scoped endpoints (no migration)
`GET/POST /libraries/{id}/papers`, `POST .../papers/batch-delete`, `POST .../trash/empty`, `GET .../tags`, `GET .../ingest/state`, `GET .../graph`, `GET .../notes`, `POST .../chat` (SSE). Managed writes require `can_manage_library` (admin ∪ curator ∪ origin-topic member ∪ creator). Single-paper mutations (status/restore/hard-delete/recompile/tags/meta) reuse the existing paper-id endpoints, which already resolve curated-library papers. Services (`papers`/`ingest`/`graph`/`library_chat`/`notes`) grew library-keyed variants; the project versions now delegate to them, so topic behavior is unchanged.

## Frontend — one workbench
`WikiWorkbench` now takes optional `pid` + `libraryId` and runs every tab in library scope; `LibraryDetailPage` renders it for both topic and standalone libraries. The temporary `StandaloneWorkbench` and the P9b tab-hiding are gone. Standalone libraries now expose Papers (list/search/add/trash/bulk/per-paper edit/recompile), Ingest & sync, Graph, Notes, Chat, Concepts, Governance — full parity.

## Documented limitations (not half-done)
- **Tags** are `PaperTag.project_id`-keyed; standalone libraries return `[]` and the tag editor/filter is hidden. Enabling tags needs a `PaperTag` re-keying migration (follow-up).
- Full-text "rebuild index", PPT/Obsidian/citations export, and chat `@`-share remain project-scoped (hidden in library scope).

## Tests
560 passed (548 baseline + 11 new: library paper CRUD/trash/recompile, ingest-state, graph, notes, chat SSE, authz 403), 16 pre-existing errors, 1 pre-existing env feedback failure — no new failures. No migration. Frontend tsc + build pass; ruff clean.