### PR TITLE
feat(config): hard-disable fake LLM fallback in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ POLARIS_OPENAI_COMPAT_BASE_URL=https://api.deepseek.com/v1
 POLARIS_OPENAI_COMPAT_API_KEY=
 POLARIS_ANTHROPIC_API_KEY=
 # 未配置任何 LLM 路由时是否回退内置 fake provider（仅测试/无 key 演示用，默认关闭）
+# 注意：POLARIS_ENV=prod 时此开关被强制忽略，生产永远不会回退 fake，杜绝假内容外泄
 # POLARIS_LLM_FAKE_FALLBACK=1
 
 # ---- 文献 API ----

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -4,7 +4,7 @@ import logging
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger("polaris.config")
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     # 未配置任何 LLM 路由时是否回退内置 fake provider（仅测试/无 key 演示用）。
     # 默认关闭：未配置时 AI 功能返回 LLM_NOT_CONFIGURED，而不是产出演示假内容。
+    # 生产（env=prod）下无论如何都强制关闭，见下方 _prod_forbids_fake_llm。
     llm_fake_fallback: bool = False
 
     # ---- 文献 API ----
@@ -73,6 +74,17 @@ class Settings(BaseSettings):
             logger.warning("忽略非法配置值（疑似注释混入）：%r", v[:40])
             return ""
         return v
+
+    @model_validator(mode="after")
+    def _prod_forbids_fake_llm(self) -> "Settings":
+        """生产环境结构性禁用 fake provider 回退：即便误设 POLARIS_LLM_FAKE_FALLBACK=1
+        也一律钉死为 False，杜绝把演示假内容当成真实 AI 输出发给用户。"""
+        if self.env == "prod" and self.llm_fake_fallback:
+            logger.warning(
+                "env=prod：忽略 POLARIS_LLM_FAKE_FALLBACK=1，生产禁止 fake LLM 回退"
+            )
+            object.__setattr__(self, "llm_fake_fallback", False)
+        return self
 
     @property
     def is_sqlite(self) -> bool:


### PR DESCRIPTION
## Background

Raised during deployment discussion: production must not have the `POLARIS_LLM_FAKE_FALLBACK` "fall back to fake content" capability, to prevent demo fake LLM output from being served to users as real AI results.

## Why not just delete it

`llm_fake_fallback` is **hard-depended on by the test suite**: `tests/conftest.py` sets `POLARIS_LLM_FAKE_FALLBACK=1` globally, and many tests rely on the built-in `FakeProvider` for deterministic offline, no-key runs; `test_llm_not_configured.py` even tests both the on and off paths. Deleting the feature / FakeProvider would break the whole suite.

## Changes

Add a `model_validator(mode="after")` to `Settings`: when `POLARIS_ENV=prod`, `llm_fake_fallback` is **forced to `False`** regardless of whether `POLARIS_LLM_FAKE_FALLBACK=1` was set, with a warning.

- Structurally forbids fake fallback in prod (stronger than "just don't set it").
- Tests unaffected (they run under env=dev, FakeProvider retained).
- Misconfiguration silently no-ops + logs a warning, surfacing the problem instead of serving fake content.

`.env.example` gets a matching comment noting the switch is ignored under prod.

## Verification

- `env=prod` + `FAKE=1` → `llm_fake_fallback=False` (with warning log) ✅
- `env=dev` + `FAKE=1` → `llm_fake_fallback=True` (test path retained) ✅
- `pytest tests/test_llm_not_configured.py tests/test_personal_wiki.py` → 10 passed ✅
