### PR TITLE
fix(shelf): unbreak GET /projects/{id}/shelf after P9e refactor

### DIFF
--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -167,7 +167,6 @@ async def list_shelf(
     # 故过滤只作用于 Paper 本体与请求者个人视角（PaperUserMeta），书架保持方向无关。
     base = apply_paper_filters(
         base,
-        project_id=None,
         status=None,
         q=q,
         author=author,


### PR DESCRIPTION
## Urgent — main is currently broken

`GET /projects/{id}/shelf` (the related-work list) crashes on **every** call with:

```
TypeError: apply_paper_filters() got an unexpected keyword argument 'project_id'
```

### Cause
#29 (advanced shelf search) added a call `apply_paper_filters(project_id=None, …)` in `topic_shelf.list_shelf`. Independently, the P9e tag-library-scoping refactor **removed** the `project_id` parameter from `apply_paper_filters` (tags are now library-scoped). Both landed on main; the textual merge was clean but the call site is now incompatible.

### Fix
Drop the `project_id=None` argument. The call passes no `tag`, so it never actually needed that parameter (it was only there to skip the tag branch, which is now gated on `library_ids` instead).

## Verify
`pytest tests/test_topic_shelf.py` → **10 passed** (was 7 failing before).

> Note: this same fix is also included in #35, but this standalone PR lets main be unbroken immediately without pulling in the rest of that stack.