### PR TITLE
fix(chat): topic literature chat covers the linked-library corpus

### DIFF
--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -276,17 +276,34 @@ async def chat_with_shelf(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(require_llm_chat),
 ) -> StreamingResponse:
-    """课题相关研究对话：语料 = 该课题相关研究书架上的论文集合。
+    """课题文献对话：语料 = 课题关联文献库并集 ∪ 相关研究书架（含手动补充）。
 
-    检索只覆盖书架论文（不按方向库过滤），没索引的论文降级 TL;DR/摘要。
-    事件序列与文献库对话一致（``sources`` → ``delta``* → ``done``）。
+    覆盖课题的整个语料（关联库里的论文），外加书架上手动加进来、可能不属于
+    任何方向库的补充论文；按 paper_id 集合检索（不按方向库过滤），没索引的
+    论文降级 TL;DR/摘要。事件序列与文献库对话一致（``sources`` → ``delta``* → ``done``）。
     """
     project = await _member_project(session, project_id, user)
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     statement = project.statement or project.name
     history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
     llm = get_llm_router()
-    paper_ids = await shelf_paper_ids(session, project_id=project_id)
+    # 语料并集：关联文献库成员论文 ∪ 相关研究书架论文（去重）
+    library_ids = await libraries_service.get_source_library_ids(session, project_id)
+    corpus_ids: set[uuid.UUID] = set()
+    if library_ids:
+        corpus_ids = set(
+            (
+                await session.execute(
+                    select(LibraryPaper.paper_id)
+                    .where(LibraryPaper.library_id.in_(library_ids))
+                    .distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+    shelf_ids = await shelf_paper_ids(session, project_id=project_id)
+    paper_ids = list(corpus_ids | set(shelf_ids))
     messages, sources = await library_chat_service.build_scoped_messages(
         session,
         statement=statement,

--- a/src/backend/tests/test_scoped_chat.py
+++ b/src/backend/tests/test_scoped_chat.py
@@ -193,8 +193,36 @@ async def test_shelf_chat_sse(client):
     assert resp.status_code == 404
 
 
+async def test_shelf_chat_covers_linked_library_corpus(client):
+    """回归：课题对话语料 = 关联文献库 ∪ 相关研究书架。
+
+    论文只在课题关联库里、没入书架时，课题对话仍应感知到它们
+    （修复前 scope 只有 shelf_paper_ids，空书架 → 感知不到关联库文献）。"""
+    token = await register_and_login(client, email="scoped-corpus@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ids = await _project_with_papers(client, headers)
+    # 关键：不入书架（shelf 为空），论文只在课题关联库里
+
+    async with client.stream(
+        "POST",
+        f"/api/projects/{project_id}/shelf/chat",
+        json={"question": "planning 方向有哪些方法？", "history": []},
+        headers=headers,
+    ) as resp:
+        assert resp.status_code == 200
+        body = (await resp.aread()).decode("utf-8")
+
+    events = _parse_sse(body)
+    kinds = [e for e, _ in events]
+    assert kinds[0] == "sources" and kinds[-1] == "done" and "error" not in kinds
+    items = events[0][1]["items"]
+    assert len(items) >= 1, "关联库里的论文应进入课题对话语料，即使没入书架"
+    titles = {it["title"] for it in items}
+    assert titles & {"Planning with Tree Search", "Reflexion Self-Improvement"}
+
+
 async def test_shelf_chat_empty_corpus(client):
-    """空书架：无论文 → sources 空、仍能 done 收尾（走空语料分支）。"""
+    """空书架 + 无关联库：无论文 → sources 空、仍能 done 收尾（走空语料分支）。"""
     token = await register_and_login(client, email="scoped-empty-shelf@example.com")
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post(


### PR DESCRIPTION
## Problem

The **课题文献对话** (related-work chat, `POST /projects/{id}/shelf/chat`, added in #32) scoped its retrieval to `shelf_paper_ids` only — the hand-picked papers on the related-work shelf. So it **couldn't perceive the papers in the topic's linked direction libraries** (the actual corpus). With an empty or small shelf, the chat had nothing to draw on even when the linked library was full.

## Fix

Scope the topic chat to the **union of the linked libraries' member papers and the shelf**:

```
library_ids = get_source_library_ids(project_id)
corpus_ids  = LibraryPaper.paper_id where library_id in library_ids
paper_ids   = corpus_ids ∪ shelf_paper_ids
```

This covers the whole topic corpus while still including manually-added shelf papers that belong to no library (which `build_library_messages`/membership-based retrieval would miss). Retrieval stays paper_id-scoped (no library join), so it works for both.

## Verify
`pytest tests/test_scoped_chat.py` → **6 passed**, including a new regression test `test_shelf_chat_covers_linked_library_corpus` (empty shelf + non-empty linked library → chat still surfaces the library papers).