### PR TITLE
feat(library): delete libraries, trim copy, drop demo task, fix keyword-config link

### DIFF
--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -10,7 +10,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { AccordionSection } from '../../components/ui/Accordion';
 import { toast } from '../../components/ui/Toast';
 import { fmtTime } from '../../lib/format';
-import { api, type DirectionLibrarySummary } from '../../lib/api';
+import { api, ApiError, isAdmin, type DirectionLibrarySummary } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useLibraries, libraryPath } from './hooks';
 
@@ -40,21 +40,46 @@ function StatusBadge({ status }: { status: DirectionLibrarySummary['status'] }) 
   );
 }
 
-function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: () => void }) {
+function LibraryCard({
+  lib,
+  admin,
+  selectMode,
+  selected,
+  onOpen,
+  onToggleSelect,
+  onDelete,
+}: {
+  lib: DirectionLibrarySummary;
+  admin: boolean;
+  selectMode: boolean;
+  selected: boolean;
+  onOpen: () => void;
+  onToggleSelect: () => void;
+  onDelete: () => void;
+}) {
   const updated = lib.last_compiled_at ?? lib.last_synced_at;
+  const activate = selectMode ? onToggleSelect : onOpen;
   return (
     <div
       className="card hoverable"
       role="button"
       tabIndex={0}
-      onClick={onOpen}
+      onClick={activate}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onOpen();
+          activate();
         }
       }}
-      style={{ padding: '18px 20px', display: 'flex', flexDirection: 'column', gap: 10, cursor: 'pointer' }}
+      style={{
+        padding: '18px 20px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        cursor: 'pointer',
+        outline: selectMode && selected ? '2px solid var(--accent)' : undefined,
+        outlineOffset: -2,
+      }}
     >
       <div className="row gap8" style={{ alignItems: 'flex-start' }}>
         <span
@@ -85,7 +110,30 @@ function LibraryCard({ lib, onOpen }: { lib: DirectionLibrarySummary; onOpen: ()
             <StatusBadge status={lib.status} />
           </div>
         </div>
-        <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0, marginTop: 4 }} />
+        {selectMode ? (
+          <input
+            type="checkbox"
+            checked={selected}
+            readOnly
+            aria-label={tr('选择', 'Select')}
+            style={{ width: 16, height: 16, accentColor: 'var(--accent)', flexShrink: 0, marginTop: 3, cursor: 'pointer' }}
+          />
+        ) : admin ? (
+          <button
+            className="icon-btn"
+            title={tr('删除文献库', 'Delete library')}
+            aria-label={tr('删除文献库', 'Delete library')}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            style={{ flexShrink: 0, marginTop: -2, color: 'var(--text-4)' }}
+          >
+            <Icon name="trash" size={14} />
+          </button>
+        ) : (
+          <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0, marginTop: 4 }} />
+        )}
       </div>
       <div
         style={{
@@ -269,34 +317,157 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
 
 export function LibrariesPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { data, isLoading, isError, refetch } = useLibraries();
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
   const canCreate = !!me;
+  const admin = isAdmin(me);
   const [createOpen, setCreateOpen] = useState(false);
+  // 多选态（仅 admin 可用）：selectMode 打开后每张卡可勾选，顶部出现批量操作栏
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const libraries = data ?? [];
   // 我的课题关联的库排前面，其余按名称
   const sorted = [...libraries].sort(
     (a, b) => Number(b.is_mine) - Number(a.is_mine) || a.name.localeCompare(b.name),
   );
 
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function exitSelect() {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }
+
+  // 删除单个库：409 LIBRARY_HAS_TOPICS 时二次确认后带 force 重删。
+  // 返回 true = 已删除，false = 用户在二次确认里放弃。
+  async function deleteOne(lib: DirectionLibrarySummary): Promise<boolean> {
+    try {
+      await api.deleteLibrary(lib.id);
+      return true;
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409 && e.message.includes('LIBRARY_HAS_TOPICS')) {
+        const ok = window.confirm(
+          tr(
+            `文献库「${lib.name}」仍被课题关联，确定连同关联一起删除吗？`,
+            `Library “${lib.name}” is still linked to topics — delete it together with those links?`,
+          ),
+        );
+        if (!ok) return false;
+        await api.deleteLibrary(lib.id, true);
+        return true;
+      }
+      throw e;
+    }
+  }
+
+  // 单删 / 批量删都走这个 mutation（批量按选中项串行处理，逐个弹 409 确认）。
+  const deleteMutation = useMutation({
+    mutationFn: async (targets: DirectionLibrarySummary[]) => {
+      let deleted = 0;
+      let skipped = 0;
+      const failed: string[] = [];
+      for (const lib of targets) {
+        try {
+          if (await deleteOne(lib)) deleted += 1;
+          else skipped += 1;
+        } catch (e) {
+          failed.push(e instanceof Error ? e.message : String(e));
+        }
+      }
+      return { deleted, skipped, failed };
+    },
+    onSuccess: ({ deleted, skipped, failed }) => {
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      exitSelect();
+      if (failed.length > 0) {
+        toast(
+          tr(`已删除 ${deleted} 个，${failed.length} 个失败：${failed[0]}`, `Deleted ${deleted}, ${failed.length} failed: ${failed[0]}`),
+          'error',
+        );
+      } else if (deleted > 0) {
+        toast(
+          tr(`已删除 ${deleted} 个文献库${skipped ? `，跳过 ${skipped} 个` : ''}`, `Deleted ${deleted} librar${deleted === 1 ? 'y' : 'ies'}${skipped ? `, skipped ${skipped}` : ''}`),
+          'ok',
+        );
+      } else {
+        toast(tr('已取消删除', 'Deletion cancelled'), 'info');
+      }
+    },
+    onError: (err) => toast(`${tr('删除失败：', 'Delete failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
+  });
+
   return (
     <div className="page fadeup" style={{ maxWidth: 1200 }}>
       <PageHead
         eyebrow={tr('实验室', 'Lab')}
         title={tr('文献库', 'Libraries')}
-        sub={tr(
-          '按研究方向维护的公共文献库：解读、概念和原文对所有人开放，随便逛。',
-          'Shared per-direction libraries — wikis, concepts and full texts are open to everyone.',
-        )}
         right={
-          canCreate ? (
-            <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
-              <Icon name="plus" size={13} />
-              {tr('新建文献库', 'New library')}
-            </button>
-          ) : undefined
+          <div className="row gap8">
+            {admin && sorted.length > 0 && (
+              <button
+                className="btn btn-ghost sm"
+                onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
+              >
+                <Icon name={selectMode ? 'x' : 'check'} size={13} />
+                {selectMode ? tr('退出多选', 'Done') : tr('多选', 'Select')}
+              </button>
+            )}
+            {canCreate ? (
+              <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
+                <Icon name="plus" size={13} />
+                {tr('新建文献库', 'New library')}
+              </button>
+            ) : null}
+          </div>
         }
       />
+
+      {selectMode && (
+        <div
+          className="row gap10"
+          style={{
+            margin: '0 0 14px',
+            padding: '9px 14px',
+            borderRadius: 10,
+            background: 'var(--surface-2)',
+            border: '0.5px solid var(--border)',
+          }}
+        >
+          <span style={{ fontSize: 12.5, fontWeight: 600 }}>
+            {tr(`已选 ${selectedIds.size} 个`, `${selectedIds.size} selected`)}
+          </span>
+          <div style={{ flex: 1 }} />
+          <button className="btn btn-ghost sm" disabled={deleteMutation.isPending} onClick={exitSelect}>
+            {tr('取消', 'Cancel')}
+          </button>
+          <button
+            className="btn btn-danger sm"
+            disabled={selectedIds.size === 0 || deleteMutation.isPending}
+            onClick={() => {
+              const targets = sorted.filter((l) => selectedIds.has(l.id));
+              if (targets.length === 0) return;
+              const ok = window.confirm(
+                tr(
+                  `确定删除选中的 ${targets.length} 个文献库吗？此操作不可撤销。`,
+                  `Delete ${targets.length} selected libraries? This cannot be undone.`,
+                ),
+              );
+              if (!ok) return;
+              deleteMutation.mutate(targets);
+            }}
+          >
+            <Icon name="trash" size={13} />
+            {deleteMutation.isPending ? tr('删除中…', 'Deleting…') : tr('删除', 'Delete')}
+          </button>
+        </div>
+      )}
 
       {canCreate && <NewLibraryModal open={createOpen} onClose={() => setCreateOpen(false)} />}
 
@@ -355,7 +526,25 @@ export function LibrariesPage() {
           }}
         >
           {sorted.map((lib) => (
-            <LibraryCard key={lib.id} lib={lib} onOpen={() => navigate(libraryPath(lib.id))} />
+            <LibraryCard
+              key={lib.id}
+              lib={lib}
+              admin={admin}
+              selectMode={selectMode}
+              selected={selectedIds.has(lib.id)}
+              onOpen={() => navigate(libraryPath(lib.id))}
+              onToggleSelect={() => toggleSelect(lib.id)}
+              onDelete={() => {
+                const ok = window.confirm(
+                  tr(
+                    `确定删除文献库「${lib.name}」吗？此操作不可撤销。`,
+                    `Delete library "${lib.name}"? This cannot be undone.`,
+                  ),
+                );
+                if (!ok) return;
+                deleteMutation.mutate([lib]);
+              }}
+            />
           ))}
         </div>
       )}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -498,10 +498,6 @@ export function ResearchPage() {
       <PageHead
         eyebrow="Polaris · Related Work"
         title={tr('相关研究', 'Related Work')}
-        sub={tr(
-          '你从关联文献库里手挑进课题的论文：写下为什么相关，随手翻解读。可用语料远不止这些。',
-          'Papers you hand-picked from the linked libraries into this topic: note why they matter, read the wikis. The corpus holds far more.',
-        )}
         right={
           tab === 'list' ? (
             <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -32,15 +32,9 @@ export function StartPage() {
         >
           <Icon name="layers" size={24} />
         </div>
-        <h1 style={{ fontSize: 20, fontWeight: 700, margin: '0 0 8px' }}>
+        <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0 }}>
           {tr('选择或创建课题', 'Pick or create a topic')}
         </h1>
-        <div style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 460, margin: '0 auto', lineHeight: 1.6 }}>
-          {tr(
-            '课题是你的个人研究空间：文献追踪、想法、实验和论文都在课题里进行。创建只需名称和一句话描述。',
-            'A topic is your personal research space — literature tracking, ideas, experiments and papers all live inside one. Creating one takes just a name and one sentence.',
-          )}
-        </div>
       </div>
 
       {isLoading ? (

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -1,15 +1,11 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { StatusPill } from '../../components/ui/StatusPill';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { Modal } from '../../components/ui/Modal';
-import { FormField } from '../../components/ui/FormField';
-import { toast } from '../../components/ui/Toast';
-import { SelectMenu } from '../../components/ui/SelectMenu';
 import { useProject } from '../../app/project';
 import { api, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
 import { fmtDuration, fmtFullTime, fmtRelative } from '../../lib/format';
@@ -17,7 +13,7 @@ import { tr } from '../../lib/i18n';
 
 /* ============================================================
    /voyages — AI 任务列表：状态/类型过滤 + 行（类型徽章/目标/
-   迷你进度条/耗时/状态）+ 「新建演示任务」（POST /voyages {kind:"demo"}）。
+   迷你进度条/耗时/状态）。任务由建库/想法/实验等业务动作发起。
    ============================================================ */
 
 type Filter = 'all' | 'active' | 'paused' | 'done' | 'failed';
@@ -144,8 +140,7 @@ function SkeletonRows() {
 
 export function VoyagesPage() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { projects, currentProjectId } = useProject();
+  const { currentProjectId } = useProject();
 
   const [filter, setFilter] = useState<Filter>('all');
   const [kindFilter, setKindFilter] = useState<string>('all');
@@ -163,35 +158,12 @@ export function VoyagesPage() {
     [data, filter, kindFilter],
   );
 
-  // —— 新建演示航程 ——
-  const [createOpen, setCreateOpen] = useState(false);
-  const [goal, setGoal] = useState('演示任务');
-  const [createProjectId, setCreateProjectId] = useState<string>('');
-  const effectiveProjectId = createProjectId || currentProjectId || projects[0]?.id || '';
-
-  const createMutation = useMutation({
-    mutationFn: () => api.createVoyage({ kind: 'demo', project_id: effectiveProjectId, goal: goal.trim() }),
-    onSuccess: (v) => {
-      toast(tr('演示任务已入队', 'Demo task queued'), 'ok');
-      setCreateOpen(false);
-      void queryClient.invalidateQueries({ queryKey: ['voyages'] });
-      navigate(`/voyages/${v.id}`);
-    },
-    onError: (err) => toast(`${tr('创建失败：', 'Create failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
-  });
-
   return (
     <div className="page fadeup">
       <PageHead
         eyebrow="Polaris · Voyages"
         title={tr('任务', 'Tasks')}
         sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
-        right={
-          <button className="btn btn-primary" disabled={projects.length === 0} onClick={() => setCreateOpen(true)}>
-            <Icon name="play" size={14} />
-            {tr('新建演示任务', 'New demo task')}
-          </button>
-        }
       />
 
       <>
@@ -245,7 +217,7 @@ export function VoyagesPage() {
                 desc={
                   filter !== 'all' || kindFilter !== 'all'
                     ? tr('当前筛选条件下没有任务，换个筛选试试。', 'No tasks match the current filters — try different ones.')
-                    : tr('点击右上角的新建演示任务按钮创建第一个任务。', 'Use the "New demo task" button in the top right to create your first task.')
+                    : tr('还没有任务。发起建库、想法生成、实验等操作后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start ingest, idea generation, experiments, and so on.')
                 }
                 compact
               />
@@ -300,42 +272,6 @@ export function VoyagesPage() {
             </div>
           )}
       </>
-
-      {/* 新建演示航程 */}
-      <Modal
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-        title={
-          <>
-            <Icon name="play" size={16} style={{ color: 'var(--accent)' }} />
-            {tr('新建演示任务', 'New demo task')}
-          </>
-        }
-        sub={tr('创建一个演示任务，体验规划、执行与自动校验的完整流程。', 'Create a demo task to walk through planning, execution and auto-check.')}
-        footer={
-          <>
-            <button className="btn btn-ghost" onClick={() => setCreateOpen(false)}>{tr('取消', 'Cancel')}</button>
-            <button
-              className="btn btn-primary"
-              disabled={!goal.trim() || !effectiveProjectId || createMutation.isPending}
-              onClick={() => createMutation.mutate()}
-            >
-              {createMutation.isPending ? tr('入队中…', 'Queuing…') : tr('启动任务', 'Start task')}
-            </button>
-          </>
-        }
-      >
-        <FormField label={tr('所属课题', 'Topic')}>
-          <SelectMenu
-            value={effectiveProjectId}
-            options={projects.map((p) => ({ value: p.id, label: p.name }))}
-            onChange={setCreateProjectId}
-          />
-        </FormField>
-        <FormField label={tr('目标', 'Goal')} hint={tr('系统将围绕该目标自动生成三步计划', 'A three-step plan will be generated around this goal')}>
-          <textarea className="textarea" rows={3} value={goal} onChange={(e) => setGoal(e.target.value)} />
-        </FormField>
-      </Modal>
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -26,6 +26,8 @@ export interface IngestTabProps {
   state: IngestState | undefined;
   stateError: boolean;
   stateLoading: boolean;
+  /** 切到本工作台「收录设置」（govern）tab；关键词提示据此跳转，无则退回导航。 */
+  onGoGovern?: () => void;
 }
 
 // 模块级常量只存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
@@ -87,7 +89,7 @@ function KnobRange({
   );
 }
 
-export function IngestTab({ pid, libraryId, state, stateError, stateLoading }: IngestTabProps) {
+export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onGoGovern }: IngestTabProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const scopeId = libraryId ?? pid ?? '';
@@ -454,16 +456,16 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading }: I
               }}
             >
               {tr(
-                '这个课题还没有配置 include 关键词，无法启动文献追踪——先在课题设置里配置关键词。',
-                'This topic has no include terms yet, so literature tracking cannot start — add them in topic settings first.',
+                '这个文献库还没有配置检索关键词，无法启动文献追踪——先去收录设置配置关键词。',
+                'This library has no search terms configured yet, so literature tracking cannot start — configure them in inclusion settings first.',
               )}
               <button
                 className="btn btn-soft sm"
                 style={{ marginTop: 8, display: 'flex' }}
-                onClick={() => navigate(`/projects/${pid}`)}
+                onClick={() => onGoGovern?.()}
               >
                 <Icon name="sliders" size={13} />
-                {tr('去课题设置配置关键词', 'Configure terms in topic settings')}
+                {tr('去收录设置配置关键词', 'Configure terms in inclusion settings')}
               </button>
             </div>
           )}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -220,6 +220,7 @@ export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: st
             state={ingestQuery.data}
             stateError={ingestQuery.isError}
             stateLoading={ingestQuery.isLoading}
+            onGoGovern={libraryId ? () => setTab('govern') : undefined}
           />
         ) : tab === 'govern' && libraryId ? (
           <GovernanceTab libraryId={libraryId} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2745,6 +2745,13 @@ export const api = {
   ): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>(`/libraries/${id}`, 'PATCH', input);
   },
+  /**
+   * 删除文献库（仅平台 admin）。库仍有课题关联且未 force 时后端返回
+   * 409 LIBRARY_HAS_TOPICS；传 force=true 连同关联一起删除。返回 204 无 body。
+   */
+  deleteLibrary(id: string, force = false): Promise<void> {
+    return request<void>(`/libraries/${id}${force ? '?force=true' : ''}`, { method: 'DELETE' });
+  },
   /** 本月预算消耗（可管理者可见）。 */
   getLibraryBudget(id: string): Promise<LibraryBudgetRead> {
     return request<LibraryBudgetRead>(`/libraries/${id}/budget`);


### PR DESCRIPTION
A batch of frontend polish across the library / related-work surfaces.

## 1. Library delete + multi-select delete
- **Admin-only** (backend `DELETE /libraries/{id}` is `require_admin`; non-admins see no delete UI).
- Per-card trash icon for single delete; a multi-select mode with a batch-delete bar (`已选 N 个 · 删除`).
- Both **pre-confirm** before deleting. A library still linked to topics returns 409 `LIBRARY_HAS_TOPICS` → second confirm, then re-deletes with `?force=true`.
- New `api.deleteLibrary(id, force)`.

## 2. Trim redundant marketing copy
Removed the verbose PageHead descriptions on:
- Libraries list ("按研究方向维护的公共文献库…随便逛。" — the one called out)
- Related-work page ("你从关联文献库里手挑进课题的论文…")
- Start page ("课题是你的个人研究空间…")

Functional empty-state guidance left intact.

## 3. Remove "new demo task"
Dropped the demo-task button + modal from the Voyages page; empty state reworded to a neutral "no tasks yet" message. Backend `kind:"demo"` path left untouched.

## 4. Fix the keyword-config link (library vs topic)
`IngestTab`'s "no include keywords → configure in **project settings**" prompt was stale: since the P8 / #53 refactor, include keywords (and the scoring **rubric**) live in the **library's ingest settings** (governance tab), not the project. The button now switches to the governance tab and the copy reads "去收录设置配置关键词". Wired via a new `onGoGovern` callback from `WikiWorkbench`.

> Note: the scoring rubric was **not** lost — it moved to the library governance tab in #53. No change needed there.

## Verify
`npx tsc --noEmit` → **0 errors**. Frontend-only; no backend changes.