### PR TITLE
feat(workbench): topic dashboard as 3 tabs (overview/settings/tasks) + library-config tab rename

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -21,6 +21,8 @@ interface NavEntry {
   to?: string;
   /** 课题作用域子路径（渲染时经 topicPath 拼 /t/<id> 前缀）；to 与 sub 都缺省 = 工作台。 */
   sub?: string;
+  /** 覆盖高亮匹配：true 时仅精确匹配路径（工作台标签项指向 /t/<id>?tab=… 时用，避免常亮）。 */
+  end?: boolean;
   no?: string;
   icon: IconName;
   zh: string;
@@ -272,7 +274,7 @@ function TopicSwitcher({ collapsed }: { collapsed: boolean }) {
               onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
               onClick={() => {
                 setOpen(false);
-                navigate(`/projects/${currentProjectId}`);
+                navigate(topicPath(currentProjectId) + '?tab=settings');
               }}
             >
               <Icon name="settings" size={13} style={{ color: 'var(--text-3)' }} />
@@ -289,8 +291,8 @@ function NavItem({ n }: { n: NavEntry }) {
   const { currentProjectId } = useProject();
   // 课题作用域条目带 /t/<id> 前缀；无当前课题时退回旧路径，由重定向兜底
   const to = n.to ?? topicPath(currentProjectId, n.sub);
-  // 工作台（课题根路径）只在精确匹配时高亮，避免盖住全部子页面
-  const end = n.to == null && n.sub == null;
+  // 工作台（课题根路径）与其标签项只在精确匹配时高亮，避免盖住全部子页面
+  const end = n.end ?? (n.to == null && n.sub == null);
   return (
     <NavLink
       to={to}
@@ -483,9 +485,10 @@ export function AppShell() {
           }).map((n) => (
             <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
-          <NavItem n={{ sub: 'voyages', icon: 'compass', zh: '任务', en: 'Tasks' }} />
+          {/* 任务 / 课题设置已并入工作台标签：指向 /t/<id>?tab=… */}
+          <NavItem n={{ to: topicPath(currentProjectId) + '?tab=tasks', end: true, icon: 'compass', zh: '任务', en: 'Tasks' }} />
           {currentProjectId && (
-            <NavItem n={{ to: `/projects/${currentProjectId}`, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
+            <NavItem n={{ to: topicPath(currentProjectId) + '?tab=settings', end: true, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
           )}
         </div>
 

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -85,6 +85,12 @@ function LegacyTopicRedirect({ sub }: { sub?: string }) {
   return <Navigate to={topicPath(id, sub) + location.search + location.hash} replace />;
 }
 
+/** 旧课题设置页 `/projects/:id` → 工作台「课题设置」标签 `/t/:id?tab=settings`。 */
+function ProjectSettingsRedirect() {
+  const { id = '' } = useParams();
+  return <Navigate to={topicPath(id) + '?tab=settings'} replace />;
+}
+
 export const router = createBrowserRouter([
   { path: '/login', element: page(() => import('../features/auth/LoginPage'), 'LoginPage') },
   {
@@ -115,7 +121,8 @@ export const router = createBrowserRouter([
               { path: 'experiment', element: page(() => import('../features/experiment/ExperimentPage'), 'ExperimentPage') },
               { path: 'writer', element: page(() => import('../features/writer/WriterPage'), 'WriterPage') },
               { path: 'paper-review', element: page(() => import('../features/paper-review/PaperReviewPage'), 'PaperReviewPage') },
-              { path: 'voyages', element: page(() => import('../features/voyages/VoyagesPage'), 'VoyagesPage') },
+              // 任务已并入工作台「任务」标签：/t/:id/voyages → /t/:id?tab=tasks
+              { path: 'voyages', element: <Navigate to="..?tab=tasks" replace /> },
             ],
           },
           // 实体详情页：按实体 id 拉数据，保持顶层路径（分享/收藏链接稳定）
@@ -139,7 +146,8 @@ export const router = createBrowserRouter([
       // —— 非课题作用域 ——
       { path: 'start', element: page(() => import('../features/start/StartPage'), 'StartPage') },
       { path: 'projects/new', element: page(() => import('../features/projects/ProjectWizardPage'), 'ProjectWizardPage') },
-      { path: 'projects/:id', element: page(() => import('../features/projects/ProjectDetailPage'), 'ProjectDetailPage') },
+      // 课题设置已并入工作台「课题设置」标签：/projects/:id → /t/:id?tab=settings
+      { path: 'projects/:id', element: <ProjectSettingsRedirect /> },
       { path: 'join/:token', element: page(() => import('../features/projects/JoinPage'), 'JoinPage') },
       { path: 'library', element: page(() => import('../features/library/LibraryPage'), 'LibraryPage') },
       // 实验室区：共享方向文献库（全实验室可读，无需课题）

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,7 +1,11 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
+import { Segmented } from '../../components/ui/Segmented';
+import { ProjectSettings } from '../projects/ProjectDetailPage';
+import { VoyagesList } from '../voyages/VoyagesPage';
 import { PipelineFlow, type PipelineStage } from '../../components/ui/PipelineFlow';
 import { StatCard, type StatCardProps } from '../../components/ui/StatCard';
 import { StatusPill } from '../../components/ui/StatusPill';
@@ -540,10 +544,24 @@ function buildStatCards(stats: StatsRead | undefined, pendingGatesCount: number)
   ];
 }
 
+type DashTab = 'overview' | 'settings' | 'tasks';
+
 export function DashboardPage() {
   const navigate = useNavigate();
   const { pendingGates, gatesError, openGates } = useShell();
   const { currentProject, currentProjectId } = useProject();
+
+  // —— 三标签：课题概况 / 课题设置 / 任务；?tab= 深链进入后清参数（照抄 WikiPage 那套） ——
+  const [tab, setTab] = useState<DashTab>('overview');
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const tabParam = searchParams.get('tab');
+    if (!tabParam) return;
+    if ((['overview', 'settings', 'tasks'] as const).some((t) => t === tabParam)) {
+      setTab(tabParam as DashTab);
+    }
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const statsQuery = useQuery({
     queryKey: ['stats', currentProjectId],
@@ -630,54 +648,68 @@ export function DashboardPage() {
     <div className="page fadeup">
       <PageHead
         eyebrow="Polaris · Autonomous Research"
-        title={tr('工作台', 'Workbench')}
-        right={
-          <>
-            <button className="btn btn-ghost" onClick={() => navigate(topicPath(currentProjectId, 'voyages'))}>
-              <Icon name="compass" size={15} />
-              {tr('任务', 'Tasks')}
-            </button>
-            <button className="btn btn-primary" onClick={() => navigate(topicPath(currentProjectId, 'voyages'))}>
-              <Icon name="play" size={14} />
-              {tr('运行今日循环', "Run today's loop")}
-            </button>
-          </>
-        }
+        title={tr('课题工作台', 'Topic Workbench')}
+        dense
       />
 
-      {showChecklist && <NextStepsCard steps={nextSteps} onNavigate={navigate} />}
-
-      <PipelineFlow
-        stages={stages}
-        directionLabel={currentProject?.name ?? 'Polaris'}
-        onNavigate={navigate}
-      />
-
-      <LiteratureCard
-        pid={currentProjectId}
-        linkedCount={linkedCount}
-        shelfCount={shelfCount}
-        onNavigate={navigate}
-      />
-
-      <div className="row gap16" style={{ marginBottom: 24 }}>
-        {statCards.map((s) => (
-          <StatCard key={s.label} {...s} />
-        ))}
+      <div style={{ marginBottom: 22 }}>
+        <Segmented
+          options={[
+            { v: 'overview' as const, label: tr('课题概况', 'Overview') },
+            { v: 'settings' as const, label: tr('课题设置', 'Settings') },
+            { v: 'tasks' as const, label: tr('任务', 'Tasks') },
+          ]}
+          value={tab}
+          onChange={setTab}
+        />
       </div>
 
-      <div className="row gap20" style={{ alignItems: 'flex-start' }}>
-        <div className="col gap20" style={{ flex: 1.5, minWidth: 0 }}>
-          <FeaturedIdeaCard pid={currentProjectId} />
-          <ActivityFeed
-            activities={statsQuery.data?.recent_activities ?? []}
-            error={statsQuery.isError}
+      {tab === 'overview' && (
+        <>
+          {showChecklist && <NextStepsCard steps={nextSteps} onNavigate={navigate} />}
+
+          <PipelineFlow
+            stages={stages}
+            directionLabel={currentProject?.name ?? 'Polaris'}
+            onNavigate={navigate}
           />
-        </div>
-        <div style={{ flex: 1, minWidth: 0, position: 'sticky', top: 0 }}>
-          <GatePreview gates={pendingGates} gatesError={gatesError} openGates={openGates} />
-        </div>
-      </div>
+
+          <LiteratureCard
+            pid={currentProjectId}
+            linkedCount={linkedCount}
+            shelfCount={shelfCount}
+            onNavigate={navigate}
+          />
+
+          <div className="row gap16" style={{ marginBottom: 24 }}>
+            {statCards.map((s) => (
+              <StatCard key={s.label} {...s} />
+            ))}
+          </div>
+
+          <div className="row gap20" style={{ alignItems: 'flex-start' }}>
+            <div className="col gap20" style={{ flex: 1.5, minWidth: 0 }}>
+              <FeaturedIdeaCard pid={currentProjectId} />
+              <ActivityFeed
+                activities={statsQuery.data?.recent_activities ?? []}
+                error={statsQuery.isError}
+              />
+            </div>
+            <div style={{ flex: 1, minWidth: 0, position: 'sticky', top: 0 }}>
+              <GatePreview gates={pendingGates} gatesError={gatesError} openGates={openGates} />
+            </div>
+          </div>
+        </>
+      )}
+
+      {tab === 'settings' &&
+        (currentProjectId ? (
+          <ProjectSettings id={currentProjectId} embedded />
+        ) : (
+          <div className="empty" style={{ padding: 60 }}>{tr('请先选择一个课题', 'Pick a topic first')}</div>
+        ))}
+
+      {tab === 'tasks' && <VoyagesList />}
     </div>
   );
 }

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -6,7 +6,7 @@ import { StatusPill } from '../../components/ui/StatusPill';
 import { Modal } from '../../components/ui/Modal';
 import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
-import { topicPath, useProject } from '../../app/project';
+import { useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
 import { api, ApiError, type ProjectRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
@@ -82,8 +82,9 @@ function EditableText({ value, placeholder, onSave, saving }: {
   );
 }
 
-export function ProjectDetailPage() {
-  const { id = '' } = useParams();
+/** 课题设置主体（接课题 id）：既作独立页 `/projects/:id` 的内容，
+    也被工作台「课题设置」标签以 `embedded` 内嵌（内嵌时不渲染大标题/eyebrow，避免与工作台页头重复）。 */
+export function ProjectSettings({ id, embedded = false }: { id: string; embedded?: boolean }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { currentProjectId, setCurrentProjectId } = useProject();
@@ -204,17 +205,12 @@ export function ProjectDetailPage() {
   const [nameDraft, setNameDraft] = useState('');
 
   if (isLoading) {
-    return (
-      <div className="page fadeup">
-        <div className="empty" style={{ padding: 80 }}>{tr('加载中…', 'Loading…')}</div>
-      </div>
-    );
+    return <div className="empty" style={{ padding: 80 }}>{tr('加载中…', 'Loading…')}</div>;
   }
   if (isError || !project) {
     const notFound = error instanceof ApiError && error.status === 404;
     return (
-      <div className="page fadeup">
-        <div className="card card-pad" style={{ textAlign: 'center', padding: 60 }}>
+      <div className="card card-pad" style={{ textAlign: 'center', padding: 60 }}>
           <div style={{ fontSize: 15, fontWeight: 650, marginBottom: 8 }}>
             {notFound ? tr('课题不存在', 'Topic not found') : tr('无法加载课题设置', 'Failed to load topic settings')}
           </div>
@@ -225,7 +221,6 @@ export function ProjectDetailPage() {
             <button className="btn btn-soft" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
             <button className="btn btn-ghost" onClick={() => navigate('/')}>{tr('返回总览', 'Back to dashboard')}</button>
           </div>
-        </div>
       </div>
     );
   }
@@ -233,11 +228,11 @@ export function ProjectDetailPage() {
   const saving = patchMutation.isPending;
 
   return (
-    <div className="page fadeup">
-      {/* 页头 */}
+    <>
+      {/* 页头：嵌入工作台标签时降级为紧凑标题（不重复大标题 / eyebrow） */}
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 24 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="h-eyebrow">{tr('课题设置', 'Topic Settings')}</div>
+          {!embedded && <div className="h-eyebrow">{tr('课题设置', 'Topic Settings')}</div>}
           {editingName ? (
             <div className="row gap8" style={{ marginTop: 8 }}>
               <input className="input" style={{ fontSize: 17, fontWeight: 650, width: 380 }} value={nameDraft}
@@ -252,8 +247,8 @@ export function ProjectDetailPage() {
               <button className="btn btn-ghost sm" onClick={() => setEditingName(false)}>{tr('取消', 'Cancel')}</button>
             </div>
           ) : (
-            <div className="row gap10" style={{ marginTop: 6 }}>
-              <h1 className="h-title" style={{ margin: 0 }}>{project.name}</h1>
+            <div className="row gap10" style={{ marginTop: embedded ? 0 : 6 }}>
+              <h1 className="h-title" style={{ margin: 0, fontSize: embedded ? 18 : undefined }}>{project.name}</h1>
               <button className="icon-btn" style={{ width: 26, height: 26, border: 'none', background: 'transparent' }}
                 title={tr('编辑名称', 'Edit name')} onClick={() => { setNameDraft(project.name); setEditingName(true); }}>
                 <Icon name="pen" size={14} />
@@ -266,10 +261,6 @@ export function ProjectDetailPage() {
           </div>
         </div>
         <div className="row gap8">
-          <button className="btn btn-ghost" onClick={() => navigate(topicPath(id, 'voyages'))}>
-            <Icon name="compass" size={14} />
-            {tr('查看任务', 'View tasks')}
-          </button>
           <button
             className="btn btn-ghost"
             style={{ color: 'var(--danger-tx)' }}
@@ -459,6 +450,16 @@ export function ProjectDetailPage() {
           </div>
         </SectionCard>
       </div>
+    </>
+  );
+}
+
+/** 独立页 `/projects/:id`：套页壳后渲染课题设置主体。 */
+export function ProjectDetailPage() {
+  const { id = '' } = useParams();
+  return (
+    <div className="page fadeup">
+      <ProjectSettings id={id} />
     </div>
   );
 }

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -138,7 +138,8 @@ function SkeletonRows() {
   );
 }
 
-export function VoyagesPage() {
+/** 任务列表主体（过滤条 + 列表）：无自身 PageHead / 页壳，供工作台「任务」标签内嵌。 */
+export function VoyagesList() {
   const navigate = useNavigate();
   const { currentProjectId } = useProject();
 
@@ -159,14 +160,7 @@ export function VoyagesPage() {
   );
 
   return (
-    <div className="page fadeup">
-      <PageHead
-        eyebrow="Polaris · Voyages"
-        title={tr('任务', 'Tasks')}
-        sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
-      />
-
-      <>
+    <>
           <div className="row gap10" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
             <Segmented options={FILTERS.map((f) => ({ v: f.v, label: tr(f.zh, f.en) }))} value={filter} onChange={setFilter} />
             <select
@@ -271,7 +265,19 @@ export function VoyagesPage() {
               })}
             </div>
           )}
-      </>
+    </>
+  );
+}
+
+export function VoyagesPage() {
+  return (
+    <div className="page fadeup">
+      <PageHead
+        eyebrow="Polaris · Voyages"
+        title={tr('任务', 'Tasks')}
+        sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
+      />
+      <VoyagesList />
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -148,9 +148,10 @@ export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: st
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
-            { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
             { v: 'notes', label: tr('笔记', 'Notes') },
-            ...(libraryId ? [{ v: 'govern' as const, label: tr('治理', 'Governance') }] : []),
+            ...(libraryId ? [{ v: 'govern' as const, label: tr('文献库配置', 'Library config') }] : []),
+            // 建库与同步放到最后一个标签
+            { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
           ]}
           value={tab}
           onChange={setTab}


### PR DESCRIPTION
Re-opened cleanly against main (the original #61 was auto-closed when its stacked base branch #56 was deleted on merge). Same change as #61.

## Topic workbench → three tabs
`DashboardPage` becomes a three-tab workbench with `?tab=` URL sync:
- **Overview** — the existing dashboard, unchanged
- **Settings** — `ProjectDetailPage` refactored into an embeddable `ProjectSettings({id, embedded})`
- **Tasks** — `VoyagesPage` list extracted as `VoyagesList`

Removed the redundant top-right **Tasks** and **Run today's loop** buttons (the latter had no action — it only navigated to the tasks page). Old routes `/t/:id/voyages` and `/projects/:id` redirect to the matching tab; the voyage detail route is unchanged. Sidebar nav (Tasks / Settings) points at the tab URLs.

## Library workbench tabs
- Rename the **Governance** tab to **Library config**
- Move **Ingest & sync** to the last tab position

## Verify
`npx tsc --noEmit` → **0 errors** (checked on main + this change). Frontend-only.