### PR TITLE
fix(ui): graph defaults to Trends, drop merged sidebar items, relevance on 0-1 scale

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -311,7 +311,6 @@ function NavItem({ n }: { n: NavEntry }) {
 export function AppShell() {
   const location = useLocation();
   const queryClient = useQueryClient();
-  const { currentProjectId } = useProject();
 
   // —— 审批抽屉 ——
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -485,11 +484,7 @@ export function AppShell() {
           }).map((n) => (
             <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
-          {/* 任务 / 课题设置已并入工作台标签：指向 /t/<id>?tab=… */}
-          <NavItem n={{ to: topicPath(currentProjectId) + '?tab=tasks', end: true, icon: 'compass', zh: '任务', en: 'Tasks' }} />
-          {currentProjectId && (
-            <NavItem n={{ to: topicPath(currentProjectId) + '?tab=settings', end: true, icon: 'sliders', zh: '课题设置', en: 'Topic settings' }} />
-          )}
+          {/* 任务 / 课题设置已并入「工作台」的标签页（概况/设置/任务），侧栏不再单列 */}
         </div>
 
         {/* —— 个人区：跨课题的个人页面（设置入口在底部头像菜单里，不重复占位） —— */}

--- a/src/frontend/src/components/ui/ScoreRing.tsx
+++ b/src/frontend/src/components/ui/ScoreRing.tsx
@@ -9,7 +9,8 @@ export interface ScoreRingProps {
 export function ScoreRing({ value, max = 10, size = 46, label }: ScoreRingProps) {
   const pct = Math.max(0, Math.min(1, value / max));
   const deg = pct * 360;
-  const color = value >= 7.5 ? 'var(--ok)' : value >= 6 ? 'var(--accent)' : 'var(--warn)';
+  // 阈值按占比算，兼容不同量纲（0-10 想法评分 / 0-1 相关度）：对 max=10 等价于原来的 7.5/6
+  const color = pct >= 0.75 ? 'var(--ok)' : pct >= 0.6 ? 'var(--accent)' : 'var(--warn)';
   return (
     <div style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
       <div
@@ -33,7 +34,7 @@ export function ScoreRing({ value, max = 10, size = 46, label }: ScoreRingProps)
         }}
       >
         <span style={{ fontFamily: 'var(--mono)', fontSize: size * 0.3, fontWeight: 700, color: 'var(--text)' }}>
-          {value.toFixed(1)}
+          {value.toFixed(max <= 1 ? 2 : 1)}
         </span>
         {label && <span style={{ fontSize: 8, color: 'var(--text-3)', marginTop: -1 }}>{label}</span>}
       </div>

--- a/src/frontend/src/features/wiki/GraphTab.tsx
+++ b/src/frontend/src/features/wiki/GraphTab.tsx
@@ -1116,7 +1116,7 @@ export interface GraphTabProps {
 }
 
 export function GraphTab({ pid, libraryId, onOpenPaper, onOpenConcept }: GraphTabProps) {
-  const [view, setView] = useState<GraphView>('timeline');
+  const [view, setView] = useState<GraphView>('trends');
   const [focusConceptId, setFocusConceptId] = useState('');
   const scopeId = libraryId ?? pid ?? '';
 

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -1068,7 +1068,7 @@ function PaperDetailPane({
           )}
         </div>
         {relevance !== null && (
-          <ScoreRing value={Math.round(relevance * 100) / 10} size={56} label={tr('相关度', 'Relevance')} />
+          <ScoreRing value={relevance} max={1} size={56} label={tr('相关度', 'Relevance')} />
         )}
       </div>
 


### PR DESCRIPTION
Three small standalone UI fixes (frontend only).

## 1. Graph defaults to Trends
`GraphTab` opened on the Timeline view; default it to **Trends** instead.

## 2. Drop the sidebar Tasks / Topic-settings items
These were merged into the topic workbench tabs (#62) but the sidebar still listed them (repointed to the tab URLs). Remove the two sidebar nav items — they're reached via the **Workbench** entry's tabs (Overview / Settings / Tasks).

## 3. Relevance shown on the canonical 0-1 scale
The paper detail header rendered `relevance_score` (canonically 0-1) as `relevance*10` in a 0-10 `ScoreRing`, so a 0.93 score showed as **9.3** — contradicting the `RelevanceBar` in the same pane (and the library list) that shows the raw 0-1 value. Feed the ring the raw score with `max={1}`; make `ScoreRing`'s color thresholds proportional (`pct >= 0.75/0.6`, identical to `7.5/6` at `max=10`, so idea-score rings are unchanged) and show 2 decimals for sub-1 scales.

## Verify
`npx tsc --noEmit` → **0 errors**.