### PR TITLE
feat(library): regular-user read parity, ownership refinements, and a personal-library read-leak fix

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -114,6 +114,17 @@ async def _get_managed_library(
     return library
 
 
+async def _get_visible_library(
+    session: AsyncSession, library_id: uuid.UUID, user: User
+) -> DirectionLibrary:
+    """只读端点统一入口：库存在 + 对请求者可见（P10：公共库全员，个人库仅归属人/admin）；
+    不可见按不存在处理（404），避免个人库经 id 泄漏内容。"""
+    library = await _get_library(session, library_id)
+    if not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    return library
+
+
 async def _reads_with_extras(
     session: AsyncSession, papers: list, user_id: uuid.UUID
 ) -> list[PaperRead]:
@@ -421,7 +432,7 @@ async def list_library_papers(
     过滤参数与课题论文列表一致（星标/阅读状态/标签/作者/机构/发表与入库时间）；
     ``status=excluded`` 取该库垃圾桶。P9e 起标签是库作用域，独立库同样可用。
     """
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     items, total = await papers_service.list_papers(
         session,
         library_id=library.id,
@@ -458,7 +469,7 @@ async def list_library_concepts(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[ConceptRead]:
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     rows = await concepts_service.list_concepts(
         session, library_ids=[library.id], category=category, q=q
     )
@@ -485,7 +496,7 @@ async def search_library(
     user: User = Depends(current_active_user),
 ) -> SearchResponse:
     """库内检索（关键词/语义）。语义模式的 embed/rerank 记个人账（无课题上下文）。"""
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
 
     mode_used = "keyword"
     reranked = False
@@ -633,7 +644,7 @@ async def list_library_tags(
     user: User = Depends(current_active_user),
 ) -> list[TagRead]:
     """库标签列表（含引用论文数）。"""
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     rows = await papers_service.list_library_tags(session, library_id=library.id)
     return [TagRead(**row) for row in rows]
 
@@ -645,7 +656,7 @@ async def get_library_ingest_state(
     user: User = Depends(current_active_user),
 ) -> IngestStateRead:
     """该库的建库/同步状态：上次同步时间、抓取进度计数、在跑任务、下次自动同步（可管理者）。"""
-    library = await _get_managed_library(session, library_id, user)
+    library = await _get_visible_library(session, library_id, user)
     state = await ingest_service.library_ingest_state(session, library)
     return IngestStateRead(**state)
 
@@ -657,7 +668,7 @@ async def library_graph(
     user: User = Depends(current_active_user),
 ) -> GraphResponse:
     """库知识图谱：论文 / 作者 / 概念节点与关联边（确定性构建，不走 LLM；全实验室可读）。"""
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     data = await graph_service.library_graph(session, library_id=library.id)
     return GraphResponse(**data)
 
@@ -673,7 +684,7 @@ async def library_notebook(
     user: User = Depends(current_active_user),
 ) -> NotebookPage:
     """库笔记本：我在该库论文上写的笔记聚合（搜索 + 分页 + 按论文过滤）。"""
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     rows, total = await notes_service.list_library_notes(
         session,
         library_id=library.id,
@@ -710,7 +721,7 @@ async def chat_with_library(
 
     事件：``sources``（引用来源清单）→ ``delta``* → ``done``；错误 ``error`` 后关流。
     """
-    library = await _get_library(session, library_id)
+    library = await _get_visible_library(session, library_id, user)
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     project_id = library.project_id
     history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -221,20 +221,60 @@ async def request_library_public(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
-    """申请把个人库转为公共库（P10）：仅创建者或该库策展人可发起；status → pending
-    等 admin 审批（is_public 仍 false）。无权者视为不存在（404）。
+    """申请把个人库转为公共库（P10）：创建者/策展人发起 → status=pending 等 admin 审批；
+    **平台 admin 发起则直接通过**（直接转公共，无需审批）。无权者视为不存在（404）。
     """
+    library = await _get_library(session, library_id)
+    is_admin = user.role == "admin"
+    is_owner = library.submitted_by is not None and library.submitted_by == user.id
+    is_curator = await libraries_service.is_library_curator(
+        session, library_id=library.id, user_id=user.id
+    )
+    if not (is_admin or is_owner or is_curator):
+        # 能看到但无权发起 → 403；看不到（陌生人个人库）→ 404 隐藏存在。
+        if libraries_service.library_visible_to(library, user):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_MANAGE_FORBIDDEN")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    if is_admin:
+        library = await libraries_service.approve_library(session, library=library)
+    else:
+        library = await libraries_service.request_public(session, library=library)
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
+
+
+@router.post("/libraries/{library_id}/cancel-request-public", response_model=DirectionLibraryDetail)
+async def cancel_request_library_public(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DirectionLibraryDetail:
+    """撤回转公共申请（P10）：创建者/策展人把 pending 退回可用的个人库
+    （is_public=false、status=active）。无权者视为不存在（404）。"""
     library = await _get_library(session, library_id)
     is_owner = library.submitted_by is not None and library.submitted_by == user.id
     is_curator = await libraries_service.is_library_curator(
         session, library_id=library.id, user_id=user.id
     )
-    if not (is_owner or is_curator):
-        # 能看到但无权发起（如非策展人 admin）→ 403；看不到（陌生人个人库）→ 404 隐藏存在。
+    if not (is_owner or is_curator or user.role == "admin"):
         if libraries_service.library_visible_to(library, user):
             raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_MANAGE_FORBIDDEN")
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
-    library = await libraries_service.request_public(session, library=library)
+    library = await libraries_service.cancel_request_public(session, library=library)
+    row = await libraries_service.library_overview(session, library=library, user=user)
+    return DirectionLibraryDetail(**row)
+
+
+@router.post("/libraries/{library_id}/make-personal", response_model=DirectionLibraryDetail)
+async def make_library_personal(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> DirectionLibraryDetail:
+    """把公共库转回个人库（平台 admin，P10）：is_public → false、status=active。
+    转回后仅归属人 + admin 可见，其他成员看不到。"""
+    library = await _get_library(session, library_id)
+    library = await libraries_service.make_personal(session, library=library)
     row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
 

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -775,6 +775,31 @@ async def reject_library(
     return library
 
 
+async def cancel_request_public(
+    session: AsyncSession, *, library: DirectionLibrary
+) -> DirectionLibrary:
+    """撤回转公共申请（P10）：pending → 退回可用个人库（is_public=false、status=active），
+    清驳回理由。鉴权（创建者/策展人）由 api 层校验。commit 落库。"""
+    library.is_public = False
+    library.status = "active"
+    library.review_note = None
+    await session.commit()
+    await session.refresh(library)
+    return library
+
+
+async def make_personal(
+    session: AsyncSession, *, library: DirectionLibrary
+) -> DirectionLibrary:
+    """管理员把公共库转回个人库（P10）：is_public → false、status=active。转回后仅
+    归属人 + admin 可见（其他成员看不到）。鉴权（平台 admin）由 api 层校验。commit 落库。"""
+    library.is_public = False
+    library.status = "active"
+    await session.commit()
+    await session.refresh(library)
+    return library
+
+
 # ---- P6 治理：策展人（界面叫「文献库管理员」）与库级写权限 ----
 
 

--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -323,3 +323,51 @@ def test_ingest_billing_owner_unit():
     personal = DirectionLibrary(name="me", is_public=False, submitted_by=owner_id)
     assert _ingest_billing_owner(public) is None
     assert _ingest_billing_owner(personal) == owner_id
+
+
+# ---- P10 细化：admin 直通 / 取消申请 / 转回个人 ----
+
+
+async def test_admin_request_public_auto_approves(client):
+    """平台 admin 发起 request-public → 直接转公共（跳过 pending 审批）。"""
+    admin = await _hdr(client, "auto-admin@example.com")
+    await _promote_admin("auto-admin@example.com")
+    lib_id = await _create_personal(client, admin, name="admin 自建库")
+    resp = await client.post(f"/api/libraries/{lib_id}/request-public", headers=admin)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_public"] is True and body["status"] == "active"
+
+
+async def test_cancel_request_public_returns_personal(client):
+    """归属人撤回 pending 申请 → 退回可用个人库。"""
+    await _hdr(client, "cancel-placeholder@example.com")  # 占位 admin（首个注册用户自动 admin）
+    owner = await _hdr(client, "cancel-owner@example.com")
+    lib_id = await _create_personal(client, owner)
+    await client.post(f"/api/libraries/{lib_id}/request-public", headers=owner)
+    resp = await client.post(f"/api/libraries/{lib_id}/cancel-request-public", headers=owner)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "active" and body["is_public"] is False
+
+
+async def test_make_personal_admin_only(client):
+    """admin 把公共库转回个人（其他人看不到）；非 admin 转个人 → 403。"""
+    await _hdr(client, "mp-placeholder@example.com")  # 占位 admin（首个注册用户自动 admin）
+    owner = await _hdr(client, "mp-owner@example.com")
+    admin = await _hdr(client, "mp-admin@example.com")
+    await _promote_admin("mp-admin@example.com")
+    lib_id = await _create_personal(client, owner)
+    await client.post(f"/api/libraries/{lib_id}/request-public", headers=owner)
+    await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    # 非 admin 转个人 → 403
+    resp = await client.post(f"/api/libraries/{lib_id}/make-personal", headers=owner)
+    assert resp.status_code == 403
+    # admin 转个人 → is_public false
+    resp = await client.post(f"/api/libraries/{lib_id}/make-personal", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["is_public"] is False
+    # 转回个人后，原本非归属人的陌生人看不到
+    stranger = await _hdr(client, "mp-stranger@example.com")
+    resp = await client.get(f"/api/libraries/{lib_id}", headers=stranger)
+    assert resp.status_code == 404

--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -179,6 +179,38 @@ async def test_personal_library_hidden_from_stranger(client):
     assert resp.status_code == 200
 
 
+async def test_personal_library_read_endpoints_hidden_from_stranger(client):
+    """个人库的只读端点（papers/concepts/graph/notes）对非归属人 404，不经 id 泄漏内容。
+
+    回归：修复前这些端点只做 _get_library（查存在），漏了可见性校验。转公共后陌生人可读。"""
+    owner = await _hdr(client, "readvis-owner@example.com")
+    stranger = await _hdr(client, "readvis-stranger@example.com")
+    admin = await _hdr(client, "readvis-admin@example.com")
+    await _promote_admin("readvis-admin@example.com")
+    lib_id = await _create_personal(client, owner, name="只读端点个人库")
+
+    read_paths = [
+        f"/api/libraries/{lib_id}/papers",
+        f"/api/libraries/{lib_id}/concepts",
+        f"/api/libraries/{lib_id}/graph",
+        f"/api/libraries/{lib_id}/notes",
+    ]
+    # 陌生人：全部 404（不泄漏）
+    for path in read_paths:
+        resp = await client.get(path, headers=stranger)
+        assert resp.status_code == 404, (path, resp.status_code)
+    # 归属人自己：可读
+    resp = await client.get(f"/api/libraries/{lib_id}/papers", headers=owner)
+    assert resp.status_code == 200
+
+    # 申请转公共 + admin 批准 → 陌生人可读
+    await client.post(f"/api/libraries/{lib_id}/request-public", headers=owner)
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    assert resp.status_code == 200
+    resp = await client.get(f"/api/libraries/{lib_id}/papers", headers=stranger)
+    assert resp.status_code == 200
+
+
 async def test_admin_sees_others_personal(client):
     admin = await _hdr(client, "p10-a10@example.com")
     await _promote_admin("p10-a10@example.com")

--- a/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
+++ b/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
@@ -31,6 +31,8 @@ export interface InclusionSettingsFormProps {
   statement: string;
   showRubric?: boolean;
   showAnchors?: boolean;
+  /** 只读：隐藏 AI 生成 / 增删按钮，禁用所有输入，仅展示已配置项。 */
+  readOnly?: boolean;
 }
 
 function BlockLabel({ zh, en, right }: { zh: string; en: string; right?: React.ReactNode }) {
@@ -49,6 +51,7 @@ export function InclusionSettingsForm({
   statement,
   showRubric,
   showAnchors,
+  readOnly,
 }: InclusionSettingsFormProps) {
   const { arxiv_categories, include, rubric, anchors } = value;
   const patch = (p: Partial<InclusionValue>) => onChange({ ...value, ...p });
@@ -134,6 +137,7 @@ export function InclusionSettingsForm({
   return (
     <div className="col gap16">
       {/* —— AI 自动生成 —— */}
+      {!readOnly && (
       <div className="row gap10" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
         <button
           type="button"
@@ -154,79 +158,102 @@ export function InclusionSettingsForm({
             : tr('先填名称和描述', 'Fill in the name and statement first')}
         </span>
       </div>
+      )}
 
       {/* —— arXiv 分类 —— */}
       <div className="col gap6">
         <BlockLabel zh="arXiv 分类" en="arXiv categories" />
-        <div className="row gap6 wrap">
-          {[...new Set([...QUICK_CATEGORIES, ...arxiv_categories])].map((c) => (
-            <button
-              key={c}
-              type="button"
-              className={'chip mono' + (arxiv_categories.includes(c) ? ' on' : '')}
-              onClick={() => toggleCat(c)}
-            >
-              {c}
-            </button>
-          ))}
-        </div>
-        <div className="row gap8" style={{ marginTop: 2 }}>
-          <input
-            className="input"
-            style={{ width: 170 }}
-            placeholder={tr('自定义分类，如 cs.IR', 'custom, e.g. cs.IR')}
-            value={customCat}
-            onChange={(e) => setCustomCat(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomCat(); } }}
-          />
-          <button type="button" className="btn btn-soft sm" onClick={addCustomCat} disabled={!customCat.trim()}>
-            {tr('添加', 'Add')}
-          </button>
-        </div>
+        {readOnly ? (
+          arxiv_categories.length > 0 ? (
+            <div className="row gap6 wrap">
+              {arxiv_categories.map((c) => (
+                <span key={c} className="chip mono on" style={{ cursor: 'default' }}>{c}</span>
+              ))}
+            </div>
+          ) : (
+            <div className="muted" style={{ fontSize: 12.5 }}>{tr('使用默认分类', 'Using default categories')}</div>
+          )
+        ) : (
+          <>
+            <div className="row gap6 wrap">
+              {[...new Set([...QUICK_CATEGORIES, ...arxiv_categories])].map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  className={'chip mono' + (arxiv_categories.includes(c) ? ' on' : '')}
+                  onClick={() => toggleCat(c)}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+            <div className="row gap8" style={{ marginTop: 2 }}>
+              <input
+                className="input"
+                style={{ width: 170 }}
+                placeholder={tr('自定义分类，如 cs.IR', 'custom, e.g. cs.IR')}
+                value={customCat}
+                onChange={(e) => setCustomCat(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomCat(); } }}
+              />
+              <button type="button" className="btn btn-soft sm" onClick={addCustomCat} disabled={!customCat.trim()}>
+                {tr('添加', 'Add')}
+              </button>
+            </div>
+          </>
+        )}
       </div>
 
       {/* —— 检索关键词 chips —— */}
       <div className="col gap6">
         <BlockLabel zh="检索关键词" en="Search terms" />
-        {include.length > 0 && (
+        {include.length > 0 ? (
           <div className="row gap6 wrap">
             {include.map((k) => (
               <span key={k} className="chip on" style={{ gap: 4, cursor: 'default' }}>
                 {k}
-                <button
-                  type="button"
-                  aria-label={tr('删除', 'Remove')}
-                  onClick={() => removeKeyword(k)}
-                  style={{ display: 'inline-flex', background: 'none', border: 'none', padding: 0, marginLeft: 2, cursor: 'pointer', color: 'inherit' }}
-                >
-                  <Icon name="x" size={11} />
-                </button>
+                {!readOnly && (
+                  <button
+                    type="button"
+                    aria-label={tr('删除', 'Remove')}
+                    onClick={() => removeKeyword(k)}
+                    style={{ display: 'inline-flex', background: 'none', border: 'none', padding: 0, marginLeft: 2, cursor: 'pointer', color: 'inherit' }}
+                  >
+                    <Icon name="x" size={11} />
+                  </button>
+                )}
               </span>
             ))}
           </div>
+        ) : readOnly ? (
+          <div className="muted" style={{ fontSize: 12.5 }}>{tr('未设检索关键词', 'No search terms set')}</div>
+        ) : null}
+        {!readOnly && (
+          <input
+            className="input"
+            value={kwDraft}
+            onChange={(e) => {
+              const v = e.target.value;
+              // 输入逗号即时成词
+              if (/[,，]/.test(v)) addKeywords(v);
+              else setKwDraft(v);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); addKeywords(kwDraft); }
+              else if (e.key === 'Backspace' && !kwDraft && include.length > 0) {
+                e.preventDefault();
+                removeKeyword(include[include.length - 1]!);
+              }
+            }}
+            onBlur={() => { if (kwDraft.trim()) addKeywords(kwDraft); }}
+            placeholder={tr('输入关键词后回车或逗号添加，如 agent', 'Type a term, press Enter or comma, e.g. agent')}
+          />
         )}
-        <input
-          className="input"
-          value={kwDraft}
-          onChange={(e) => {
-            const v = e.target.value;
-            // 输入逗号即时成词
-            if (/[,，]/.test(v)) addKeywords(v);
-            else setKwDraft(v);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') { e.preventDefault(); addKeywords(kwDraft); }
-            else if (e.key === 'Backspace' && !kwDraft && include.length > 0) {
-              e.preventDefault();
-              removeKeyword(include[include.length - 1]!);
-            }
-          }}
-          onBlur={() => { if (kwDraft.trim()) addKeywords(kwDraft); }}
-          placeholder={tr('输入关键词后回车或逗号添加，如 agent', 'Type a term, press Enter or comma, e.g. agent')}
-        />
-        <div className="field-hint">
-          {tr('文献追踪按这些关键词与上面的分类检索候选论文；留空则用默认分类。', 'Literature tracking searches candidates by these terms plus the categories above; leave empty for defaults.')}
-        </div>
+        {!readOnly && (
+          <div className="field-hint">
+            {tr('文献追踪按这些关键词与上面的分类检索候选论文；留空则用默认分类。', 'Literature tracking searches candidates by these terms plus the categories above; leave empty for defaults.')}
+          </div>
+        )}
       </div>
 
       {/* —— 锚点论文 —— */}
@@ -236,15 +263,19 @@ export function InclusionSettingsForm({
             zh="锚点论文"
             en="Anchor papers"
             right={
-              <button type="button" className="btn btn-soft sm" onClick={addAnchor}>
-                <Icon name="plus" size={12} />
-                {tr('添加论文', 'Add paper')}
-              </button>
+              readOnly ? undefined : (
+                <button type="button" className="btn btn-soft sm" onClick={addAnchor}>
+                  <Icon name="plus" size={12} />
+                  {tr('添加论文', 'Add paper')}
+                </button>
+              )
             }
           />
           {anchors.length === 0 ? (
             <div className="muted" style={{ fontSize: 12.5 }}>
-              {tr('可留空；抓取时会解析这些论文并做参考文献扩展。', 'Optional; ingest resolves these and expands references.')}
+              {readOnly
+                ? tr('未设锚点论文。', 'No anchor papers set.')
+                : tr('可留空；抓取时会解析这些论文并做参考文献扩展。', 'Optional; ingest resolves these and expands references.')}
             </div>
           ) : (
             <div className="col gap10">
@@ -259,6 +290,7 @@ export function InclusionSettingsForm({
                           <input
                             className="input"
                             value={a.title}
+                            disabled={readOnly}
                             onChange={(e) => updateAnchor(i, { title: e.target.value })}
                             placeholder={tr('论文标题', 'Paper title')}
                           />
@@ -270,6 +302,7 @@ export function InclusionSettingsForm({
                               className="input mono"
                               style={{ fontSize: 12.5 }}
                               value={a.arxiv_id ?? ''}
+                              disabled={readOnly}
                               onChange={(e) => updateAnchor(i, { arxiv_id: e.target.value })}
                               placeholder="2401.01234"
                             />
@@ -279,6 +312,7 @@ export function InclusionSettingsForm({
                             <input
                               className="input"
                               value={a.reason ?? ''}
+                              disabled={readOnly}
                               onChange={(e) => updateAnchor(i, { reason: e.target.value })}
                               placeholder={tr('为什么把它当作锚点', 'Why it anchors this direction')}
                             />
@@ -290,16 +324,18 @@ export function InclusionSettingsForm({
                           </div>
                         )}
                       </div>
-                      <button
-                        type="button"
-                        className="icon-btn"
-                        title={tr('删除论文', 'Remove paper')}
-                        aria-label={tr('删除论文', 'Remove paper')}
-                        onClick={() => removeAnchor(i)}
-                        style={{ flexShrink: 0 }}
-                      >
-                        <Icon name="trash" size={14} />
-                      </button>
+                      {!readOnly && (
+                        <button
+                          type="button"
+                          className="icon-btn"
+                          title={tr('删除论文', 'Remove paper')}
+                          aria-label={tr('删除论文', 'Remove paper')}
+                          onClick={() => removeAnchor(i)}
+                          style={{ flexShrink: 0 }}
+                        >
+                          <Icon name="trash" size={14} />
+                        </button>
+                      )}
                     </div>
                   </div>
                 );
@@ -316,10 +352,12 @@ export function InclusionSettingsForm({
             zh="打分标准"
             en="Scoring rubric"
             right={
-              <button type="button" className="btn btn-soft sm" onClick={addRubric}>
-                <Icon name="plus" size={12} />
-                {tr('添加维度', 'Add dimension')}
-              </button>
+              readOnly ? undefined : (
+                <button type="button" className="btn btn-soft sm" onClick={addRubric}>
+                  <Icon name="plus" size={12} />
+                  {tr('添加维度', 'Add dimension')}
+                </button>
+              )
             }
           />
           {rubric.length === 0 ? (
@@ -337,6 +375,7 @@ export function InclusionSettingsForm({
                         <input
                           className="input"
                           value={r.name}
+                          disabled={readOnly}
                           onChange={(e) => updateRubric(i, { name: e.target.value })}
                           placeholder={tr('如 方法新颖性', 'e.g. Methodological novelty')}
                         />
@@ -347,6 +386,7 @@ export function InclusionSettingsForm({
                           className="textarea"
                           rows={2}
                           value={r.description}
+                          disabled={readOnly}
                           onChange={(e) => updateRubric(i, { description: e.target.value })}
                           placeholder={tr('这一维度怎样算高分', 'Describe what a high score looks like on this dimension')}
                         />
@@ -364,21 +404,24 @@ export function InclusionSettingsForm({
                           max={3}
                           step={0.1}
                           value={r.weight}
+                          disabled={readOnly}
                           onChange={(e) => updateRubric(i, { weight: Number(e.target.value) })}
                           style={{ width: 220, maxWidth: '100%' }}
                         />
                       </div>
                     </div>
-                    <button
-                      type="button"
-                      className="icon-btn"
-                      title={tr('删除维度', 'Remove dimension')}
-                      aria-label={tr('删除维度', 'Remove dimension')}
-                      onClick={() => removeRubric(i)}
-                      style={{ flexShrink: 0 }}
-                    >
-                      <Icon name="trash" size={14} />
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        className="icon-btn"
+                        title={tr('删除维度', 'Remove dimension')}
+                        aria-label={tr('删除维度', 'Remove dimension')}
+                        onClick={() => removeRubric(i)}
+                        style={{ flexShrink: 0 }}
+                      >
+                        <Icon name="trash" size={14} />
+                      </button>
+                    )}
                   </div>
                 </div>
               ))}

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -22,6 +22,37 @@ import { InclusionSettingsForm, ARXIV_ID_RE, type InclusionValue } from './Inclu
    平台管理员可在此新建独立共享文献库（与任何课题解耦）。
    ============================================================ */
 
+/** 圆角小勾选框（体系内样式，替代原生 checkbox）。与论文撰写/实验搭建一致。 */
+function CheckBox({ checked, onToggle, title }: { checked: boolean; onToggle: () => void; title?: string }) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      style={{
+        width: 18,
+        height: 18,
+        flexShrink: 0,
+        borderRadius: 5,
+        border: `1.5px solid ${checked ? 'var(--accent)' : 'var(--border-2)'}`,
+        background: checked ? 'var(--accent)' : 'transparent',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+        padding: 0,
+        color: '#fff',
+        transition: 'all .12s',
+      }}
+    >
+      {checked && <Icon name="check" size={12} sw={2.4} />}
+    </button>
+  );
+}
+
 const CADENCES = [
   { v: 'daily', zh: '每日', en: 'Daily' },
   { v: 'weekly', zh: '每周', en: 'Weekly' },
@@ -107,11 +138,23 @@ function LibraryCard({
         flexDirection: 'column',
         gap: 10,
         cursor: 'pointer',
-        outline: selectMode && selected ? '2px solid var(--accent)' : undefined,
-        outlineOffset: -2,
+        borderColor: selectMode && selected ? 'var(--accent)' : undefined,
       }}
     >
       <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+        {/* 占位常驻（仅 admin）：切换多选时卡片尺寸/位置不变 */}
+        {admin && (
+          <div
+            style={{ paddingTop: 3, visibility: selectMode ? 'visible' : 'hidden' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CheckBox
+              checked={selected}
+              onToggle={onToggleSelect}
+              title={selected ? tr('取消选择', 'Deselect') : tr('选择', 'Select')}
+            />
+          </div>
+        )}
         <span
           style={{
             width: 34,
@@ -146,15 +189,7 @@ function LibraryCard({
             </div>
           )}
         </div>
-        {selectMode ? (
-          <input
-            type="checkbox"
-            checked={selected}
-            readOnly
-            aria-label={tr('选择', 'Select')}
-            style={{ width: 16, height: 16, accentColor: 'var(--accent)', flexShrink: 0, marginTop: 3, cursor: 'pointer' }}
-          />
-        ) : canDelete ? (
+        {canDelete ? (
           <button
             className="icon-btn"
             title={tr('删除文献库', 'Delete library')}
@@ -167,7 +202,7 @@ function LibraryCard({
           >
             <Icon name="trash" size={14} />
           </button>
-        ) : (
+        ) : selectMode ? null : (
           <Icon name="arrow" size={14} style={{ color: 'var(--text-4)', flexShrink: 0, marginTop: 4 }} />
         )}
       </div>
@@ -356,6 +391,13 @@ export function LibrariesPage() {
     setSelectMode(false);
     setSelectedIds(new Set());
   }
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+  const allSelected = sorted.length > 0 && sorted.every((l) => selectedIds.has(l.id));
+  function toggleSelectAll() {
+    setSelectedIds(allSelected ? new Set() : new Set(sorted.map((l) => l.id)));
+  }
 
   // 删除单个库：409 LIBRARY_HAS_TOPICS 时二次确认后带 force 重删。
   // 返回 true = 已删除，false = 用户在二次确认里放弃。
@@ -397,7 +439,7 @@ export function LibrariesPage() {
     },
     onSuccess: ({ deleted, skipped, failed }) => {
       void queryClient.invalidateQueries({ queryKey: ['libraries'] });
-      exitSelect();
+      clearSelection();
       if (failed.length > 0) {
         toast(
           tr(`已删除 ${deleted} 个，${failed.length} 个失败：${failed[0]}`, `Deleted ${deleted}, ${failed.length} failed: ${failed[0]}`),
@@ -421,23 +463,12 @@ export function LibrariesPage() {
         eyebrow={tr('实验室', 'Lab')}
         title={tr('文献库', 'Libraries')}
         right={
-          <div className="row gap8">
-            {admin && sorted.length > 0 && (
-              <button
-                className="btn btn-ghost sm"
-                onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
-              >
-                <Icon name={selectMode ? 'x' : 'check'} size={13} />
-                {selectMode ? tr('退出多选', 'Done') : tr('多选', 'Select')}
-              </button>
-            )}
-            {canCreate ? (
-              <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
-                <Icon name="plus" size={13} />
-                {tr('新建文献库', 'New library')}
-              </button>
-            ) : null}
-          </div>
+          canCreate ? (
+            <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
+              <Icon name="plus" size={13} />
+              {tr('新建文献库', 'New library')}
+            </button>
+          ) : null
         }
       />
 
@@ -459,47 +490,28 @@ export function LibrariesPage() {
             wrapStyle={{ width: 140 }}
           />
         </div>
-      </div>
-
-      {selectMode && (
-        <div
-          className="row gap10"
-          style={{
-            margin: '0 0 14px',
-            padding: '9px 14px',
-            borderRadius: 10,
-            background: 'var(--surface-2)',
-            border: '0.5px solid var(--border)',
-          }}
-        >
-          <span style={{ fontSize: 12.5, fontWeight: 600 }}>
-            {tr(`已选 ${selectedIds.size} 个`, `${selectedIds.size} selected`)}
-          </span>
-          <div style={{ flex: 1 }} />
-          <button className="btn btn-ghost sm" disabled={deleteMutation.isPending} onClick={exitSelect}>
-            {tr('取消', 'Cancel')}
-          </button>
+        {admin && sorted.length > 0 && (
           <button
-            className="btn btn-danger sm"
-            disabled={selectedIds.size === 0 || deleteMutation.isPending}
-            onClick={() => {
-              const targets = sorted.filter((l) => selectedIds.has(l.id));
-              if (targets.length === 0) return;
-              const ok = window.confirm(
-                tr(
-                  `确定删除选中的 ${targets.length} 个文献库吗？此操作不可撤销。`,
-                  `Delete ${targets.length} selected libraries? This cannot be undone.`,
-                ),
-              );
-              if (!ok) return;
-              deleteMutation.mutate(targets);
-            }}
+            className={`btn sm ${selectMode ? 'btn-primary' : 'btn-soft'}`}
+            onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
+            title={tr('批量选择', 'Multi-select')}
           >
-            <Icon name="trash" size={13} />
-            {deleteMutation.isPending ? tr('删除中…', 'Deleting…') : tr('删除', 'Delete')}
+            <Icon name="check" size={13} />
+            {tr('多选', 'Multi-select')}
           </button>
-        </div>
-      )}
+        )}
+        {/* 全选放工具栏：不再插入额外行导致卡片下移 */}
+        {admin && selectMode && sorted.length > 0 && (
+          <div className="row gap8" style={{ alignItems: 'center' }}>
+            <CheckBox checked={allSelected} onToggle={toggleSelectAll} title={tr('全选', 'Select all')} />
+            <span className="muted" style={{ fontSize: 12 }}>
+              {selectedIds.size > 0
+                ? tr(`已选 ${selectedIds.size} 个`, `${selectedIds.size} selected`)
+                : tr('全选', 'Select all')}
+            </span>
+          </div>
+        )}
+      </div>
 
       {canCreate && <NewLibraryModal open={createOpen} onClose={() => setCreateOpen(false)} />}
 
@@ -578,6 +590,50 @@ export function LibrariesPage() {
               }}
             />
           ))}
+        </div>
+      )}
+
+      {/* 批量操作栏（多选模式下有选中时浮出底部，与论文撰写/实验搭建一致） */}
+      {admin && selectMode && selectedIds.size > 0 && (
+        <div
+          className="card card-pad"
+          style={{
+            position: 'sticky',
+            bottom: 16,
+            marginTop: 16,
+            boxShadow: 'var(--shadow-pop)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <span style={{ fontSize: 12.5, fontWeight: 600 }}>
+            {tr(`已选 ${selectedIds.size} 个`, `${selectedIds.size} selected`)}
+          </span>
+          <div className="row gap8" style={{ marginLeft: 'auto' }}>
+            <button
+              className="btn btn-danger sm"
+              disabled={deleteMutation.isPending}
+              onClick={() => {
+                const targets = sorted.filter((l) => selectedIds.has(l.id));
+                if (targets.length === 0) return;
+                const ok = window.confirm(
+                  tr(
+                    `确定删除选中的 ${targets.length} 个文献库吗？此操作不可撤销。`,
+                    `Delete ${targets.length} selected libraries? This cannot be undone.`,
+                  ),
+                );
+                if (!ok) return;
+                deleteMutation.mutate(targets);
+              }}
+            >
+              <Icon name="trash" size={13} />
+              {deleteMutation.isPending ? tr('删除中…', 'Deleting…') : tr('批量删除', 'Delete selected')}
+            </button>
+            <button className="btn btn-ghost sm" disabled={deleteMutation.isPending} onClick={clearSelection}>
+              {tr('取消选择', 'Clear')}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -7,19 +7,34 @@ import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery'
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
-import { api, type PaperRead, type PaperSort } from '../../lib/api';
+import { api, type PaperRead, type PaperSort, type ReadingStatus } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { ConceptsTab } from '../wiki/ConceptsTab';
-import { SearchInput, useDebounced } from '../wiki/shared';
-import { readerFrom } from '../reading/shared';
+import { LibraryChatTab } from '../wiki/LibraryChatTab';
+import { NotesTab } from '../wiki/NotesTab';
+import { GovernanceTab } from '../wiki/GovernanceTab';
+import { IngestTab } from '../wiki/IngestTab';
+import {
+  AdvancedPanel,
+  AdvancedToggle,
+  FilterInput,
+  SearchInput,
+  YearRangeField,
+  parseYear,
+  useDebounced,
+} from '../wiki/shared';
+import { READING_STATUS, readerFrom } from '../reading/shared';
+
+// 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
+const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
 
 /* ============================================================
    共享文献库只读浏览（P5c 非成员视角）：
-   论文（列表 + 检索 + 详情解读）/ 概念 两个页签，全部走 /libraries 读端点；
-   没有任何管理入口，收藏/笔记等个人操作去阅读页做。
+   论文库 / 概念库 / 图谱 / 文献对话 / 笔记 / 文献库配置（只读）/ 建库与同步（只读），
+   全部走 /libraries 读端点；没有任何管理入口，收藏/笔记等个人操作去阅读页做。
    ============================================================ */
 
-type BrowseTab = 'papers' | 'concepts';
+type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' | 'ingest';
 type SearchScope = 'keyword' | 'semantic';
 
 const PAGE_SIZE = 20;
@@ -179,13 +194,45 @@ function PapersPane({
   const [scope, setScope] = useState<SearchScope>('keyword');
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [page, setPage] = useState(1);
-  useEffect(() => setPage(1), [q, sort, scope]);
+
+  // —— 高级检索（作者 / 机构 / 年份区间 / 阅读状态 / 星标） ——
+  const [advOpen, setAdvOpen] = useState(false);
+  const [advAuthor, setAdvAuthor] = useState('');
+  const [advAffiliation, setAdvAffiliation] = useState('');
+  const [advYearFrom, setAdvYearFrom] = useState('');
+  const [advYearTo, setAdvYearTo] = useState('');
+  const [advReading, setAdvReading] = useState<'' | ReadingStatus>('');
+  const [advStarred, setAdvStarred] = useState(false);
+  const author = useDebounced(advAuthor.trim());
+  const affiliation = useDebounced(advAffiliation.trim());
+  const yearFrom = parseYear(advYearFrom);
+  const yearTo = parseYear(advYearTo);
+  const advActive = !!(author || affiliation || yearFrom || yearTo || advReading || advStarred);
+
+  useEffect(
+    () => setPage(1),
+    [q, sort, scope, author, affiliation, yearFrom, yearTo, advReading, advStarred],
+  );
 
   const semantic = !!q && scope === 'semantic';
   const listQuery = useQuery({
-    queryKey: ['lib-papers', libraryId, q, sort, page],
+    queryKey: [
+      'lib-papers', libraryId, q, sort, page,
+      author, affiliation, yearFrom, yearTo, advReading, advStarred,
+    ],
     queryFn: () =>
-      api.listLibraryPapers(libraryId, { q: q || undefined, sort, page, size: PAGE_SIZE }),
+      api.listLibraryPapersFull(libraryId, {
+        q: q || undefined,
+        sort,
+        page,
+        size: PAGE_SIZE,
+        author: author || undefined,
+        affiliation: affiliation || undefined,
+        published_from: yearFrom ? `${yearFrom}-01-01T00:00:00Z` : undefined,
+        published_to: yearTo ? `${yearTo}-12-31T23:59:59Z` : undefined,
+        reading_status: advReading || undefined,
+        starred: advStarred || undefined,
+      }),
     enabled: !semantic,
     retry: false,
   });
@@ -218,10 +265,79 @@ function PapersPane({
               onChange={setQInput}
               placeholder={tr('搜库内论文：标题 / 摘要 / 解读…', 'Search papers: title / abstract / wiki…')}
             />
+            <AdvancedToggle
+              open={advOpen}
+              active={advActive}
+              onToggle={() => setAdvOpen((o) => !o)}
+              title={tr('高级检索：作者 / 机构 / 年份 / 阅读状态 / 星标', 'Advanced search: author / affiliation / year / reading status / starred')}
+            />
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
               {total ? tr(`${total} 篇`, `${total}`) : ''}
             </span>
           </div>
+          {advOpen && (
+            <div style={semantic ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
+              <AdvancedPanel
+                onClear={
+                  advActive
+                    ? () => {
+                        setAdvAuthor('');
+                        setAdvAffiliation('');
+                        setAdvYearFrom('');
+                        setAdvYearTo('');
+                        setAdvReading('');
+                        setAdvStarred(false);
+                      }
+                    : undefined
+                }
+              >
+                <div className="row gap8">
+                  <FilterInput value={advAuthor} onChange={setAdvAuthor} placeholder={tr('作者姓名…', 'Author name…')} />
+                  <FilterInput
+                    value={advAffiliation}
+                    onChange={setAdvAffiliation}
+                    placeholder={tr('发表机构…', 'Affiliation…')}
+                    title={tr(
+                      '需要论文元数据带有机构信息（入库时自动从 OpenAlex 补充）',
+                      'Needs affiliation metadata (auto-filled from OpenAlex on ingest)',
+                    )}
+                  />
+                </div>
+                <YearRangeField
+                  label={tr('发表年份', 'Year')}
+                  from={advYearFrom}
+                  to={advYearTo}
+                  onFrom={setAdvYearFrom}
+                  onTo={setAdvYearTo}
+                />
+                <div className="row gap6" style={{ alignItems: 'center' }}>
+                  <select
+                    className="input"
+                    style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
+                    value={advReading}
+                    onChange={(e) => setAdvReading(e.target.value as '' | ReadingStatus)}
+                    title={tr('按阅读状态过滤', 'Filter by reading status')}
+                  >
+                    <option value="">{tr('读没读', 'Read?')}</option>
+                    {READING_STATUS.map((m) => (
+                      <option key={m.v} value={m.v}>
+                        {tr(m.label, m.en)}
+                      </option>
+                    ))}
+                  </select>
+                  <label className="row gap6" style={{ cursor: 'pointer', userSelect: 'none', fontSize: 11.5, color: 'var(--text-2)' }}>
+                    <input
+                      type="checkbox"
+                      checked={advStarred}
+                      onChange={(e) => setAdvStarred(e.target.checked)}
+                      style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
+                    />
+                    {tr('仅看星标', 'Starred only')}
+                  </label>
+                </div>
+              </AdvancedPanel>
+            </div>
+          )}
           <div className="row gap6 wrap" style={{ marginTop: 10 }}>
             <span className={`chip${scope === 'keyword' ? ' on' : ''}`} onClick={() => setScope('keyword')}>
               {tr('关键词', 'Keyword')}
@@ -259,8 +375,8 @@ function PapersPane({
             <EmptyState
               compact
               icon="book"
-              title={q ? tr('没有匹配的论文', 'No matching papers') : tr('这个库还是空的', 'This library is empty')}
-              desc={q ? tr('换个关键词试试。', 'Try a different keyword.') : undefined}
+              title={q || advActive ? tr('没有匹配的论文', 'No matching papers') : tr('这个库还是空的', 'This library is empty')}
+              desc={q || advActive ? tr('换个关键词或调整高级条件试试。', 'Try a different keyword or adjust the filters.') : undefined}
             />
           ) : (
             items.map((p) => (
@@ -298,6 +414,7 @@ function PapersPane({
 }
 
 export function LibraryBrowse({ libraryId }: { libraryId: string }) {
+  const navigate = useNavigate();
   const [tab, setTab] = useState<BrowseTab>('papers');
   const [paperId, setPaperId] = useState<string | null>(null);
   const [conceptId, setConceptId] = useState<string | null>(null);
@@ -324,6 +441,26 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
     }
     setSearchParams({}, { replace: true });
   }, [searchParams, setSearchParams]);
+
+  // 建库与同步（只读）状态：与工作台同 queryKey，运行中加快轮询
+  const ingestQuery = useQuery({
+    queryKey: ['ingest-state', libraryId],
+    queryFn: () => api.getLibraryIngestState(libraryId),
+    retry: false,
+    refetchInterval: (query) => (query.state.data?.running_voyage_id ? 5_000 : 60_000),
+  });
+
+  const goPaper = useCallback((id: string) => {
+    setPaperId(id);
+    setTab('papers');
+  }, []);
+  const goConcept = useCallback((id: string) => {
+    setConceptId(id);
+    setTab('concepts');
+  }, []);
+  const onWikiLink = useCallback((name: string) => {
+    setPendingConceptName(name);
+  }, []);
 
   // [[概念名]] → 概念 id（库端点解析）
   const resolveQuery = useQuery({
@@ -358,13 +495,31 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
           options={[
             { v: 'papers', label: tr('论文库', 'Papers') },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
+            { v: 'graph', label: tr('图谱', 'Graph') },
+            { v: 'chat', label: tr('文献对话', 'Chat') },
+            { v: 'notes', label: tr('笔记', 'Notes') },
+            { v: 'govern', label: tr('文献库配置', 'Library config') },
+            // 建库与同步放到最后一个标签
+            { v: 'ingest', label: tr('建库与同步', 'Ingest & sync') },
           ]}
           value={tab}
           onChange={setTab}
         />
-        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
-          {tr('公共文献库 · 所有人可读', 'Shared library · readable by everyone')}
-        </span>
+        <div className="row gap8">
+          {ingestQuery.data?.running_voyage_id && tab !== 'ingest' && (
+            <span
+              className="pill hoverable"
+              style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
+              onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
+            >
+              <span className="dot pulse" />
+              {tr('文献任务运行中 →', 'Literature task running →')}
+            </span>
+          )}
+          <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
+            {tr('公共文献库 · 所有人可读', 'Shared library · readable by everyone')}
+          </span>
+        </div>
       </div>
 
       <div
@@ -376,18 +531,33 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
             libraryId={libraryId}
             selectedId={paperId}
             onSelect={setPaperId}
-            onWikiLink={setPendingConceptName}
+            onWikiLink={onWikiLink}
           />
-        ) : (
+        ) : tab === 'concepts' ? (
           <ConceptsTab
             libraryId={libraryId}
             selectedId={conceptId}
             onSelect={setConceptId}
-            onOpenPaper={(id) => {
-              setPaperId(id);
-              setTab('papers');
-            }}
-            onWikiLink={setPendingConceptName}
+            onOpenPaper={goPaper}
+            onWikiLink={onWikiLink}
+          />
+        ) : tab === 'graph' ? (
+          <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
+            <GraphTab libraryId={libraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
+          </Suspense>
+        ) : tab === 'chat' ? (
+          <LibraryChatTab libraryId={libraryId} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
+        ) : tab === 'notes' ? (
+          <NotesTab libraryId={libraryId} />
+        ) : tab === 'govern' ? (
+          <GovernanceTab libraryId={libraryId} readOnly />
+        ) : (
+          <IngestTab
+            libraryId={libraryId}
+            state={ingestQuery.data}
+            stateError={ingestQuery.isError}
+            stateLoading={ingestQuery.isLoading}
+            readOnly
           />
         )}
       </div>

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -116,20 +116,66 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
   });
   const requestPublic = useMutation({
     mutationFn: () => api.requestPublicLibrary(lib.id),
-    onSuccess: () => { toast(tr('已提交申请，等待管理员审批', 'Request submitted — waiting for an admin to review'), 'ok'); invalidate(); },
+    // admin 发起直接转公共；普通归属人发起是提交申请。
+    onSuccess: () => {
+      toast(
+        admin
+          ? tr('已转为公共文献库', 'Made public')
+          : tr('已提交申请，等待管理员审批', 'Request submitted — waiting for an admin to review'),
+        'ok',
+      );
+      invalidate();
+    },
+    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
+  });
+  const cancelRequest = useMutation({
+    mutationFn: () => api.cancelRequestPublicLibrary(lib.id),
+    onSuccess: () => { toast(tr('已撤回申请', 'Request withdrawn'), 'ok'); invalidate(); },
+    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
+  });
+  const makePersonal = useMutation({
+    mutationFn: () => api.makeLibraryPersonal(lib.id),
+    onSuccess: () => { toast(tr('已转为个人文献库', 'Made personal'), 'ok'); invalidate(); },
     onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
   });
 
-  // 个人 active 库 + 我是归属人：显示「申请转为公共文献库」入口（含被驳回后的重新申请）。
   if (lib.status === 'active') {
-    if (lib.is_public || !isOwner) return null;
+    // 公共库：仅平台 admin 可就地转回个人（转回后其他成员看不到）。
+    if (lib.is_public) {
+      if (!admin) return null;
+      return (
+        <div className="card" style={{ padding: '12px 16px', marginBottom: 14 }}>
+          <div className="row" style={{ justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+            <div className="col gap4" style={{ minWidth: 0 }}>
+              <div className="row gap8" style={{ fontWeight: 680, fontSize: 13.5 }}>
+                <Icon name="book" size={14} style={{ color: 'var(--ok-tx)' }} />
+                {tr('公共文献库', 'Public library')}
+              </div>
+              <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
+                {tr(
+                  '全实验室可见、维护额度由管理员承担。转为个人库后仅归属人可见，其他成员将看不到。',
+                  'Visible to the whole lab, upkeep covered by admins. Making it personal hides it from everyone but its owner.',
+                )}
+              </div>
+            </div>
+            <div className="row gap8" style={{ flexShrink: 0 }}>
+              <button className="btn btn-soft sm" disabled={makePersonal.isPending} onClick={() => makePersonal.mutate()}>
+                {makePersonal.isPending ? tr('处理中…', 'Working…') : tr('转为个人文献库', 'Make personal')}
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    // 个人库：归属人或 admin 可发起转公共（admin 直接通过）。
+    if (!(isOwner || admin)) return null;
     return (
       <div className="card" style={{ padding: '12px 16px', marginBottom: 14 }}>
         <div className="row" style={{ justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
           <div className="col gap4" style={{ minWidth: 0 }}>
             <div className="row gap8" style={{ fontWeight: 680, fontSize: 13.5 }}>
               <Icon name="users" size={14} style={{ color: 'var(--accent)' }} />
-              {tr('这是你的个人文献库', 'This is your personal library')}
+              {tr('个人文献库', 'Personal library')}
             </div>
             <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
               {tr(
@@ -147,15 +193,13 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
             <button
               className="btn btn-soft sm"
               disabled={requestPublic.isPending}
-              onClick={() => {
-                if (!window.confirm(tr(
-                  '确定申请把这个个人文献库转为公共文献库吗？通过后本库将归实验室所有。',
-                  'Request to make this personal library public? Once approved it belongs to the lab.',
-                ))) return;
-                requestPublic.mutate();
-              }}
+              onClick={() => requestPublic.mutate()}
             >
-              {requestPublic.isPending ? tr('提交中…', 'Submitting…') : tr('申请转为公共文献库', 'Request to make public')}
+              {requestPublic.isPending
+                ? tr('提交中…', 'Submitting…')
+                : admin
+                  ? tr('转为公共文献库', 'Make public')
+                  : tr('申请转为公共文献库', 'Request to make public')}
             </button>
           </div>
         </div>
@@ -196,6 +240,13 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
                 {tr('驳回', 'Reject')}
               </button>
             )}
+          </div>
+        )}
+        {pending && !admin && isOwner && (
+          <div className="row gap8" style={{ flexShrink: 0 }}>
+            <button className="btn btn-soft sm" disabled={cancelRequest.isPending} onClick={() => cancelRequest.mutate()}>
+              {cancelRequest.isPending ? tr('处理中…', 'Working…') : tr('取消申请', 'Withdraw request')}
+            </button>
           </div>
         )}
       </div>

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -30,8 +30,14 @@ const CADENCES: { v: string; zh: string; en: string }[] = [
   { v: 'daily', zh: '每天自动同步', en: 'Daily' },
 ];
 
-export function GovernanceTab({ libraryId }: { libraryId: string }) {
-  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
+export function GovernanceTab({ libraryId, readOnly = false }: { libraryId: string; readOnly?: boolean }) {
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: () => api.me(),
+    retry: false,
+    staleTime: 60_000,
+    enabled: !readOnly,
+  });
   const admin = isAdmin(me);
 
   const { data: lib } = useQuery({
@@ -42,11 +48,16 @@ export function GovernanceTab({ libraryId }: { libraryId: string }) {
 
   return (
     <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
-      {lib && <LibraryInfoCard lib={lib} />}
-      {lib && <InclusionSettingsCard lib={lib} />}
-      <BudgetCard libraryId={libraryId} />
-      <CuratorsCard libraryId={libraryId} canEdit={admin} />
-      <DuplicatesCard libraryId={libraryId} />
+      {lib && <LibraryInfoCard lib={lib} readOnly={readOnly} />}
+      {lib && <InclusionSettingsCard lib={lib} readOnly={readOnly} />}
+      {/* 预算 / 管理员名单 / 重复论文均为管理门数据，普通用户取不到 → 只读时不渲染 */}
+      {!readOnly && (
+        <>
+          <BudgetCard libraryId={libraryId} />
+          <CuratorsCard libraryId={libraryId} canEdit={admin} />
+          <DuplicatesCard libraryId={libraryId} />
+        </>
+      )}
     </div>
   );
 }
@@ -235,7 +246,7 @@ function BudgetCard({ libraryId }: { libraryId: string }) {
 
 /* —— 库信息与预算 —— */
 
-function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
+function LibraryInfoCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readOnly?: boolean }) {
   const queryClient = useQueryClient();
   const [name, setName] = useState(lib.name);
   const [statement, setStatement] = useState(lib.statement ?? '');
@@ -279,18 +290,20 @@ function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
     <section className="card" style={{ padding: 18 }}>
       <div className="row" style={{ justifyContent: 'space-between', marginBottom: 12 }}>
         <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('库信息', 'Library info')}</h3>
-        <button
-          className="btn btn-primary sm"
-          disabled={!dirty || budgetInvalid || save.isPending || !name.trim()}
-          onClick={() => save.mutate()}
-        >
-          {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
-        </button>
+        {!readOnly && (
+          <button
+            className="btn btn-primary sm"
+            disabled={!dirty || budgetInvalid || save.isPending || !name.trim()}
+            onClick={() => save.mutate()}
+          >
+            {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+          </button>
+        )}
       </div>
       <div className="col gap12">
         <label className="col gap6">
           <span className="muted" style={{ fontSize: 12 }}>{tr('名称', 'Name')}</span>
-          <input className="input" value={name} onChange={(e) => setName(e.target.value)} maxLength={255} />
+          <input className="input" value={name} disabled={readOnly} onChange={(e) => setName(e.target.value)} maxLength={255} />
         </label>
         <label className="col gap6">
           <span className="muted" style={{ fontSize: 12 }}>{tr('方向说明（一句话）', 'Statement')}</span>
@@ -298,10 +311,12 @@ function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
             className="input"
             rows={2}
             value={statement}
+            disabled={readOnly}
             onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('这个方向关注什么问题', 'What this direction is about')}
           />
         </label>
+        {!readOnly && (
         <div className="row gap12" style={{ flexWrap: 'wrap' }}>
           <label className="col gap6" style={{ minWidth: 180 }}>
             <span className="muted" style={{ fontSize: 12 }}>{tr('同步节奏', 'Sync cadence')}</span>
@@ -324,7 +339,8 @@ function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
             />
           </label>
         </div>
-        {budgetInvalid && (
+        )}
+        {!readOnly && budgetInvalid && (
           <div style={{ color: 'var(--danger-tx)', fontSize: 12 }}>
             {tr('预算需为不小于 0 的数字', 'Budget must be a number ≥ 0')}
           </div>
@@ -336,7 +352,7 @@ function LibraryInfoCard({ lib }: { lib: DirectionLibraryDetail }) {
 
 /* —— 收录设置（P8：库为收录配置权威源，ingest 按此检索/打分） —— */
 
-function InclusionSettingsCard({ lib }: { lib: DirectionLibraryDetail }) {
+function InclusionSettingsCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readOnly?: boolean }) {
   const queryClient = useQueryClient();
   const [value, setValue] = useState<InclusionValue>(() => fromDefinition(lib.definition));
 
@@ -367,15 +383,22 @@ function InclusionSettingsCard({ lib }: { lib: DirectionLibraryDetail }) {
     <section className="card" style={{ padding: 18 }}>
       <div className="row" style={{ justifyContent: 'space-between', marginBottom: 4 }}>
         <h3 style={{ fontSize: 14, fontWeight: 700 }}>{tr('收录设置', 'Inclusion settings')}</h3>
-        <button className="btn btn-primary sm" disabled={save.isPending} onClick={() => save.mutate()}>
-          {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
-        </button>
+        {!readOnly && (
+          <button className="btn btn-primary sm" disabled={save.isPending} onClick={() => save.mutate()}>
+            {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+          </button>
+        )}
       </div>
       <p className="muted" style={{ fontSize: 12, marginBottom: 16 }}>
-        {tr(
-          '文献追踪按这里的 arXiv 分类与关键词检索、按打分标准判定相关性；留空则用默认分类、只按方向说明打分。',
-          'Literature tracking searches by these arXiv categories and keywords and scores relevance against the rubric; leave empty to use default categories and statement-only scoring.',
-        )}
+        {readOnly
+          ? tr(
+              '这个文献库按以下 arXiv 分类与关键词检索论文、按打分标准判定相关性（由文献库管理员维护）。',
+              'This library fetches papers by the arXiv categories and terms below and scores relevance against the rubric (maintained by library managers).',
+            )
+          : tr(
+              '文献追踪按这里的 arXiv 分类与关键词检索、按打分标准判定相关性；留空则用默认分类、只按方向说明打分。',
+              'Literature tracking searches by these arXiv categories and keywords and scores relevance against the rubric; leave empty to use default categories and statement-only scoring.',
+            )}
       </p>
       <InclusionSettingsForm
         value={value}
@@ -384,6 +407,7 @@ function InclusionSettingsCard({ lib }: { lib: DirectionLibraryDetail }) {
         statement={lib.statement ?? ''}
         showRubric
         showAnchors
+        readOnly={readOnly}
       />
     </section>
   );

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -28,6 +28,8 @@ export interface IngestTabProps {
   stateLoading: boolean;
   /** 切到本工作台「收录设置」（govern）tab；关键词提示据此跳转，无则退回导航。 */
   onGoGovern?: () => void;
+  /** 只读（普通用户视角）：仅展示左侧状态列，隐藏增量同步 / 初始建库等触发入口。 */
+  readOnly?: boolean;
 }
 
 // 模块级常量只存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
@@ -89,7 +91,7 @@ function KnobRange({
   );
 }
 
-export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onGoGovern }: IngestTabProps) {
+export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onGoGovern, readOnly = false }: IngestTabProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const scopeId = libraryId ?? pid ?? '';
@@ -102,7 +104,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
   const { data: libDef } = useQuery({
     queryKey: ['library', libraryId],
     queryFn: () => api.getLibrary(libraryId as string),
-    enabled: !!libraryId,
+    enabled: !!libraryId && !readOnly,
     retry: false,
   });
   const noKeywords = libraryId
@@ -303,6 +305,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
           </div>
 
           {/* 增量同步 */}
+          {!readOnly && (
           <div className="card card-pad">
             <div className="row gap10" style={{ marginBottom: 8 }}>
               <span className="section-h">
@@ -326,9 +329,11 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
               </div>
             )}
           </div>
+          )}
         </div>
 
-        {/* —— 右：冷启动表单 —— */}
+        {/* —— 右：冷启动表单（仅可管理者） —— */}
+        {!readOnly && (
         <div className="card card-pad" style={{ flex: 1.2, minWidth: 0 }}>
           <div className="row gap10" style={{ marginBottom: 6 }}>
             <span className="section-h">
@@ -503,6 +508,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             )}
           </div>
         </div>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2711,9 +2711,17 @@ export const api = {
     const qs = params.toString();
     return request<DirectionLibrarySummary[]>(`/libraries${qs ? `?${qs}` : ''}`);
   },
-  /** 申请把个人库转为公共库（创建者调；返回更新后的库，状态转 pending 待审批）。 */
+  /** 申请把个人库转为公共库（创建者/策展人→pending；平台 admin 调则直接通过转公共）。 */
   requestPublicLibrary(id: string): Promise<DirectionLibrarySummary> {
     return requestJson<DirectionLibrarySummary>(`/libraries/${id}/request-public`, 'POST', {});
+  },
+  /** 撤回转公共申请（创建者/策展人）：pending → 退回可用个人库。 */
+  cancelRequestPublicLibrary(id: string): Promise<DirectionLibraryDetail> {
+    return requestJson<DirectionLibraryDetail>(`/libraries/${id}/cancel-request-public`, 'POST', {});
+  },
+  /** 把公共库转回个人库（平台 admin）：其他成员将看不到。 */
+  makeLibraryPersonal(id: string): Promise<DirectionLibraryDetail> {
+    return requestJson<DirectionLibraryDetail>(`/libraries/${id}/make-personal`, 'POST', {});
   },
   getLibrary(id: string): Promise<DirectionLibraryDetail> {
     return request<DirectionLibraryDetail>(`/libraries/${id}`);


### PR DESCRIPTION
Builds on the P10 ownership model (#65): read parity for regular users, ownership-flow refinements, a multi-select consistency pass, and a security fix.

## Security fix (regressed in #65)
The library read endpoints (papers/concepts/search/tags/graph/notes/chat) only checked existence, so a **personal** library's content leaked to anyone with its id. They now route through `_get_visible_library` enforcing P10 visibility (public → everyone; personal → owner/admin, else 404). `ingest/state` is opened from the manage gate to visible so the read-only ingest view works. New regression test: strangers get 404 on a personal library's read endpoints; readable once public.

## Regular-user read parity
`LibraryBrowse` (the non-manager view) grows from papers/concepts to also include **graph, chat, notes, a read-only 文献库配置, and a read-only 建库与同步**, plus **advanced search** (author/affiliation/year/reading-status/starred) on the papers pane — all via the already-open library endpoints. `GovernanceTab` / `IngestTab` / `InclusionSettingsForm` gain a `readOnly` prop that disables edits, hides triggers/AI/save, and drops manage-only cards.

## Ownership refinements
- An **admin** who applies to publish is fast-tracked straight to public (no pending step).
- Owner/curator can **withdraw** a pending publish request (`POST .../cancel-request-public`), reverting to a usable personal library.
- Admin can **revert a public library to personal** (`POST .../make-personal`), hiding it from everyone but its owner.
- The publish request no longer pops a `confirm()` alert; request/withdraw/make-personal live on the detail status banner.

## Multi-select consistency
The library list's multi-select now matches Paper Writer / Experiment Lab (toolbar toggle, self-drawn checkbox, sticky batch bar, border-color selection) instead of the ad-hoc PageHead switch.

## Verify
- Backend: `test_library_approval.py` → **21 passed** (incl. admin fast-path, withdraw, make-personal, and the read-endpoint visibility regression); `ruff` clean.
- Frontend: `npx tsc --noEmit` → **0 errors**.