### PR TITLE
feat(app): two-column About-us modal with the finalized REAL intro

### DIFF
--- a/src/frontend/src/app/UserMenu.tsx
+++ b/src/frontend/src/app/UserMenu.tsx
@@ -12,58 +12,15 @@ import { tr } from '../lib/i18n';
 /* —— 关于我们弹窗：实验室介绍 + 主页/项目链接 + 小红书二维码 —— */
 function AboutModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
-    <Modal open={open} onClose={onClose} title={tr('关于我们', 'About us')} width={440}>
-      <div className="col gap16" style={{ padding: '2px 2px 4px' }}>
-        <div className="col gap6">
-          <div style={{ fontSize: 15, fontWeight: 700, letterSpacing: 0.2, color: 'var(--text-1)' }}>
-            {tr('浙江大学 REAL Lab', 'REAL Lab · Zhejiang University')}
-          </div>
-          <div style={{ fontSize: 12.5, fontWeight: 620, color: 'var(--accent-text)' }}>
-            {tr(
-              '会推理、有具身、能自主、可成长的真实世界智能',
-              'Reasoning · Embodied · Agentic · Lifelong-learning AI',
-            )}
-          </div>
-        </div>
-        <div style={{ fontSize: 13, lineHeight: 1.75, color: 'var(--text-2)' }}>
-          {tr(
-            'REAL 聚焦通向真实世界智能的四大核心能力：推理（Reasoning）让模型深度思考、求解复杂问题；具身（Embodied）让智能通过物理本体感知并作用于真实环境；智能体（Agentic）让系统自主规划、调用工具、执行长程任务；终身学习（Lifelong）让智能体在持续交互中不断积累经验、自我进化。四者层层递进，共同指向真正立足现实世界的通用智能。Polaris 正是 REAL Lab 面向科研全流程打造的 AI 科研智能体平台。',
-            'REAL pursues four capabilities on the path to real-world intelligence. Reasoning gives models deep thinking and complex problem-solving; Embodied lets intelligence perceive and act on the physical world through a body; Agentic lets systems plan, use tools, and carry out long-horizon tasks on their own; Lifelong lets agents keep accumulating experience and evolving. Together they build toward general intelligence grounded in the real world. Polaris is REAL Lab’s AI research-agent platform for the whole research workflow.',
-          )}
-        </div>
-        <div className="col gap8">
-          <a
-            className="row gap8"
-            href="https://zju-real.github.io/"
-            target="_blank"
-            rel="noreferrer noopener"
-            style={{ color: 'var(--accent-text)', fontSize: 12.5, textDecoration: 'none' }}
-          >
-            <Icon name="link" size={13} />
-            {tr('实验室主页', 'Lab homepage')}
-            <span className="mono" style={{ color: 'var(--text-4)', fontSize: 11 }}>zju-real.github.io</span>
-          </a>
-          <a
-            className="row gap8"
-            href="https://github.com/ZJU-REAL/Polaris"
-            target="_blank"
-            rel="noreferrer noopener"
-            style={{ color: 'var(--accent-text)', fontSize: 12.5, textDecoration: 'none' }}
-          >
-            <Icon name="link" size={13} />
-            {tr('项目地址（GitHub）', 'Project (GitHub)')}
-            <span className="mono" style={{ color: 'var(--text-4)', fontSize: 11 }}>ZJU-REAL/Polaris</span>
-          </a>
-        </div>
-        <div
-          className="col gap8"
-          style={{ alignItems: 'center', paddingTop: 6, borderTop: '0.5px solid var(--border)' }}
-        >
+    <Modal open={open} onClose={onClose} title={tr('关于我们', 'About us')} width={680}>
+      <div className="row gap20" style={{ alignItems: 'flex-start', flexWrap: 'wrap', padding: '2px 2px 4px' }}>
+        {/* 左栏：小红书二维码 */}
+        <div className="col gap8" style={{ alignItems: 'center', flexShrink: 0 }}>
           <div
             style={{
-              width: 240,
-              height: 320,
-              borderRadius: 10,
+              width: 312,
+              height: 416,
+              borderRadius: 12,
               background: 'var(--surface-2)',
               border: '0.5px solid var(--border)',
               display: 'flex',
@@ -84,6 +41,51 @@ function AboutModal({ open, onClose }: { open: boolean; onClose: () => void }) {
           <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
             {tr('扫码关注我们的小红书', 'Scan to follow us on RED')}
           </span>
+        </div>
+
+        {/* 右栏：介绍 */}
+        <div className="col gap14" style={{ flex: 1, minWidth: 280 }}>
+          <div className="col gap6">
+            <div style={{ fontSize: 15, fontWeight: 700, letterSpacing: 0.2, color: 'var(--text-1)' }}>
+              {tr('浙江大学 REAL Lab', 'REAL Lab · Zhejiang University')}
+            </div>
+            <div style={{ fontSize: 12.5, fontWeight: 620, color: 'var(--accent-text)' }}>
+              {tr(
+                '会推理、有具身、能自主、可成长，面向真实世界的通用智能',
+                'Reasoning · Embodied · Agentic · Lifelong-learning AI',
+              )}
+            </div>
+          </div>
+          <div style={{ fontSize: 13, lineHeight: 1.75, color: 'var(--text-2)' }}>
+            {tr(
+              'REAL 聚焦通向通用智能的四大核心能力：推理（Reasoning）赋予模型深度思考与复杂问题求解的能力，是智能的认知基座；具身（Embodied）让智能走出屏幕，通过物理本体感知并作用于真实环境；智能体（Agentic）使系统能够自主规划、调用工具、执行长程任务；终身学习（Lifelong）则让智能体在与环境的持续交互中不断积累经验、自我进化。四者层层递进，会思考、有身体、能行动、可成长，共同指向一个目标：构建真正走进真实世界（REAL world）的通用智能。',
+              'REAL: Reasoning, Embodied, Agentic, and Lifelong-learning AI. Toward AI that thinks, acts, and grows in the real world.',
+            )}
+          </div>
+          <div className="col gap8">
+            <a
+              className="row gap8"
+              href="https://zju-real.github.io/"
+              target="_blank"
+              rel="noreferrer noopener"
+              style={{ color: 'var(--accent-text)', fontSize: 12.5, textDecoration: 'none' }}
+            >
+              <Icon name="link" size={13} />
+              {tr('实验室主页', 'Lab homepage')}
+              <span className="mono" style={{ color: 'var(--text-4)', fontSize: 11 }}>zju-real.github.io</span>
+            </a>
+            <a
+              className="row gap8"
+              href="https://github.com/ZJU-REAL/Polaris"
+              target="_blank"
+              rel="noreferrer noopener"
+              style={{ color: 'var(--accent-text)', fontSize: 12.5, textDecoration: 'none' }}
+            >
+              <Icon name="link" size={13} />
+              {tr('项目地址（GitHub）', 'Project (GitHub)')}
+              <span className="mono" style={{ color: 'var(--text-4)', fontSize: 11 }}>ZJU-REAL/Polaris</span>
+            </a>
+          </div>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## What

Re-lay the **About Us** modal as two columns and drop in the finalized REAL copy.

- **Left column** — the RED (小红书) QR, enlarged again (240×320 → **312×416**, ~1.3×), with its "扫码关注" caption.
- **Right column** — heading (`REAL Lab · Zhejiang University`), tagline (`会推理、有具身、能自主、可成长，面向真实世界的通用智能` / `Reasoning · Embodied · Agentic · Lifelong-learning AI`), the full REAL intro paragraph (zh) with the short English version, and the homepage / GitHub links.
- Copy is the user's exact wording, still **no em-dashes**. Modal widened 440 → 680 (`min(680px, 92vw)`, so it stays responsive); columns `flex-wrap` and stack on narrow screens.

`npx tsc --noEmit` clean.