### PR TITLE
feat(daily): lab-wide daily arxiv feed with likes facepile and tree-based collection

### DIFF
--- a/src/backend/alembic/versions/f2d34705e152_daily_feed_tables.py
+++ b/src/backend/alembic/versions/f2d34705e152_daily_feed_tables.py
@@ -1,0 +1,67 @@
+"""每日新论文池（Daily Paper）
+
+新建 daily_feed_entries（池橱窗行：paper_id 唯一引用内容池、feed_date 滚动 7 天、
+分类与公告类型、共享单篇解读）与 daily_feed_likes（全实验室共享点赞，
+entry 过期删除时级联跟删）。
+
+Revision ID: f2d34705e152
+Revises: 47b973fb7e13
+Create Date: 2026-07-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+revision: str = "f2d34705e152"
+down_revision: str | None = "47b973fb7e13"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "daily_feed_entries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("paper_id", sa.Uuid(), nullable=False),
+        sa.Column("feed_date", sa.Date(), nullable=False),
+        sa.Column("primary_category", sa.String(length=32), nullable=False),
+        sa.Column("categories", _JSON, nullable=False),
+        sa.Column("announce_type", sa.String(length=16), nullable=False),
+        sa.Column("wiki_content", sa.Text(), nullable=True),
+        sa.Column("wiki_model", sa.String(length=128), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["paper_id"], ["papers.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("paper_id", name="uq_daily_feed_entries_paper_id"),
+    )
+    op.create_index("ix_daily_feed_entries_feed_date", "daily_feed_entries", ["feed_date"])
+
+    op.create_table(
+        "daily_feed_likes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("entry_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["entry_id"], ["daily_feed_entries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("entry_id", "user_id", name="uq_daily_feed_likes"),
+    )
+    op.create_index("ix_daily_feed_likes_entry_id", "daily_feed_likes", ["entry_id"])
+    op.create_index("ix_daily_feed_likes_user_id", "daily_feed_likes", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_daily_feed_likes_user_id", table_name="daily_feed_likes")
+    op.drop_index("ix_daily_feed_likes_entry_id", table_name="daily_feed_likes")
+    op.drop_table("daily_feed_likes")
+    op.drop_index("ix_daily_feed_entries_feed_date", table_name="daily_feed_entries")
+    op.drop_table("daily_feed_entries")

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -1,0 +1,189 @@
+"""每日新论文池路由：/daily。
+
+全实验室共享：登录即可浏览/点赞/收录（收录目标各自校验写权限）；
+订阅分类管理与手动刷新仅 admin。业务逻辑在 services/daily_feed.py。
+"""
+
+import datetime as dt
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user, require_admin
+from app.core.db import get_session
+from app.core.queue import TaskQueue, get_task_queue
+from app.models.user import User
+from app.schemas.daily import (
+    DailyCategoriesRead,
+    DailyCategoriesUpdate,
+    DailyCollectionsRead,
+    DailyCollectRequest,
+    DailyCollectResponse,
+    DailyDay,
+    DailyLikerFull,
+    DailyLikeState,
+    DailyPage,
+    DailyPaperDetail,
+)
+from app.services import daily_feed as daily_service
+
+router = APIRouter(prefix="/daily", tags=["daily"])
+
+_NOT_FOUND = HTTPException(status.HTTP_404_NOT_FOUND, detail="DAILY_ENTRY_NOT_FOUND")
+
+
+@router.get("/days", response_model=list[DailyDay])
+async def list_days(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DailyDay]:
+    return [DailyDay(**d) for d in await daily_service.list_days(session)]
+
+
+@router.get("/papers", response_model=DailyPage)
+async def list_papers(
+    date: dt.date | None = Query(default=None),
+    sort: str = Query(default="likes", pattern="^(likes|date)$"),
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    q: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyPage:
+    items, total = await daily_service.list_papers(
+        session, user_id=user.id, date=date, sort=sort, page=page, size=size, q=q
+    )
+    return DailyPage(items=items, total=total, page=page, size=size)
+
+
+@router.get("/liked", response_model=DailyPage)
+async def list_my_liked(
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyPage:
+    items, total = await daily_service.list_my_liked(session, user_id=user.id, page=page, size=size)
+    return DailyPage(items=items, total=total, page=page, size=size)
+
+
+@router.get("/papers/{entry_id}", response_model=DailyPaperDetail)
+async def get_paper(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyPaperDetail:
+    try:
+        item = await daily_service.get_entry_item(session, entry_id=entry_id, user_id=user.id)
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    return DailyPaperDetail(**item)
+
+
+@router.put("/papers/{entry_id}/like", response_model=DailyLikeState)
+async def like_paper(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyLikeState:
+    try:
+        state = await daily_service.set_like(
+            session, entry_id=entry_id, user_id=user.id, liked=True
+        )
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    return DailyLikeState(**state)
+
+
+@router.delete("/papers/{entry_id}/like", response_model=DailyLikeState)
+async def unlike_paper(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyLikeState:
+    try:
+        state = await daily_service.set_like(
+            session, entry_id=entry_id, user_id=user.id, liked=False
+        )
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    return DailyLikeState(**state)
+
+
+@router.get("/papers/{entry_id}/likers", response_model=list[DailyLikerFull])
+async def list_likers(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DailyLikerFull]:
+    try:
+        rows = await daily_service.list_likers(session, entry_id=entry_id)
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    return [DailyLikerFull(**r) for r in rows]
+
+
+@router.get("/papers/{entry_id}/collections", response_model=DailyCollectionsRead)
+async def get_collections(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyCollectionsRead:
+    try:
+        data = await daily_service.entry_collections(session, entry_id=entry_id, user_id=user.id)
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    return DailyCollectionsRead(**data)
+
+
+@router.post("/collect", response_model=DailyCollectResponse)
+async def collect(
+    payload: DailyCollectRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyCollectResponse:
+    results = await daily_service.collect_papers(
+        session,
+        user=user,
+        paper_ids=payload.paper_ids,
+        direction_library_ids=payload.direction_library_ids,
+        topic_ids=payload.topic_ids,
+        personal=payload.personal,
+    )
+    return DailyCollectResponse(results=results)
+
+
+@router.get("/categories", response_model=DailyCategoriesRead)
+async def get_categories(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyCategoriesRead:
+    return DailyCategoriesRead(categories=await daily_service.get_categories(session))
+
+
+@router.put("/categories", response_model=DailyCategoriesRead)
+async def set_categories(
+    payload: DailyCategoriesUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> DailyCategoriesRead:
+    try:
+        categories = await daily_service.set_categories(session, payload.categories)
+    except daily_service.InvalidCategoryError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"INVALID_CATEGORY:{exc.category}"
+        ) from exc
+    return DailyCategoriesRead(categories=categories)
+
+
+@router.post("/refresh", status_code=status.HTTP_202_ACCEPTED)
+async def refresh(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> dict[str, str]:
+    """手动触发一次同步（验证/补抓用）；job_id 按天去重防重复入队。"""
+    today = dt.datetime.now(dt.UTC).date().isoformat()
+    await queue.enqueue("daily_feed_sync", _job_id=f"daily-feed-manual-{today}")
+    return {"status": "queued"}

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -4,14 +4,18 @@
 订阅分类管理与手动刷新仅 admin。业务逻辑在 services/daily_feed.py。
 """
 
+import asyncio
 import datetime as dt
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user, require_admin
+from app.api.auth import current_active_user, require_admin, require_llm_chat, require_llm_task
 from app.core.db import get_session
+from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.user import User
 from app.schemas.daily import (
@@ -20,13 +24,18 @@ from app.schemas.daily import (
     DailyCollectionsRead,
     DailyCollectRequest,
     DailyCollectResponse,
+    DailyCompileResult,
     DailyDay,
     DailyLikerFull,
     DailyLikeState,
     DailyPage,
     DailyPaperDetail,
 )
+from app.schemas.paper import PaperChatRequest
 from app.services import daily_feed as daily_service
+from app.services import library_chat as library_chat_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/daily", tags=["daily"])
 
@@ -48,11 +57,21 @@ async def list_papers(
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
     q: str | None = Query(default=None),
+    announce: str | None = Query(default=None, pattern="^(new|cross)$"),
+    category: str | None = Query(default=None, max_length=32),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DailyPage:
     items, total = await daily_service.list_papers(
-        session, user_id=user.id, date=date, sort=sort, page=page, size=size, q=q
+        session,
+        user_id=user.id,
+        date=date,
+        sort=sort,
+        page=page,
+        size=size,
+        q=q,
+        announce=announce,
+        category=category,
     )
     return DailyPage(items=items, total=total, page=page, size=size)
 
@@ -175,6 +194,56 @@ async def set_categories(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"INVALID_CATEGORY:{exc.category}"
         ) from exc
     return DailyCategoriesRead(categories=categories)
+
+
+@router.post("/chat")
+async def chat_with_daily_pool(
+    data: PaperChatRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_chat),
+) -> StreamingResponse:
+    """池级文献对话：语料 = 当前滚动 7 天池内全部论文（摘要级，不建全文索引）。
+
+    事件序列与文献库对话一致（``sources`` → ``delta``* → ``done``）。
+    """
+    from app.api.wiki import _chat_stream_response
+
+    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    paper_ids = await daily_service.daily_paper_ids(session)
+    messages, sources = await library_chat_service.build_scoped_messages(
+        session,
+        statement=None,
+        question=data.question,
+        history=history,
+        paper_ids=paper_ids,
+        llm=get_llm_router(),
+        user_id=user.id,
+        project_id=None,
+    )
+    return _chat_stream_response(messages, sources, user_id=user.id, project_id=None)
+
+
+@router.post("/papers/{entry_id}/compile", response_model=DailyCompileResult)
+async def compile_entry(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+) -> DailyCompileResult:
+    """按需编译单篇解读（通用模板，全实验室共享一份）；进行中 → 409。"""
+    try:
+        entry = await daily_service.compile_entry_wiki(session, entry_id=entry_id, user_id=user.id)
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    except daily_service.CompileInProgressError:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="COMPILE_IN_PROGRESS") from None
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001 — LLM 空响应/调用失败等 → 502
+        logger.warning("daily wiki compile failed for entry %s", entry_id, exc_info=True)
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
+    return DailyCompileResult(
+        entry_id=entry_id, wiki_content=entry.wiki_content or "", model=entry.wiki_model
+    )
 
 
 @router.post("/refresh", status_code=status.HTTP_202_ACCEPTED)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -8,6 +8,7 @@ from app.api import (
     admin_users,
     auth,
     concepts,
+    daily,
     experiments,
     feedback,
     gates,
@@ -61,6 +62,7 @@ api_router.include_router(wiki.router)
 api_router.include_router(ideas.router)
 api_router.include_router(search.router)
 api_router.include_router(shelf.router)
+api_router.include_router(daily.router)
 api_router.include_router(skills.router)
 api_router.include_router(market.router)
 api_router.include_router(mcp_meta.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -2,6 +2,7 @@
 
 from app.models.activity import Activity
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
@@ -40,6 +41,8 @@ from app.models.voyage import VoyageRun, VoyageStep
 __all__ = [
     "Activity",
     "Concept",
+    "DailyFeedEntry",
+    "DailyFeedLike",
     "DirectionLibrary",
     "DirectionLibraryCurator",
     "Experiment",

--- a/src/backend/app/models/daily_feed.py
+++ b/src/backend/app/models/daily_feed.py
@@ -1,0 +1,62 @@
+"""实验室「每日新论文」池（Daily Paper）。
+
+每天从 arxiv 订阅分类抓 New submissions 进池，滚动保留 7 天：
+- 论文本体走全局内容池（paper_id 引用 papers，永不复制、过期不删）；
+- entry 是「橱窗」行，过期由 cron 直接删除；点赞挂 entry、FK 级联跟删，
+  因此「我赞过的」历史随池过期自然消失；
+- 收录动作（进方向库/课题书架/个人库）直接写目标库成员表，与 entry 生命周期无关。
+"""
+
+import datetime as dt
+import uuid
+from typing import Any
+
+from sqlalchemy import Date, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.paper import Paper
+
+# 默认订阅分类；可在 system_settings 的 daily_feed_categories 键覆盖
+DEFAULT_DAILY_CATEGORIES = ["cs.AI", "cs.CL", "cs.CV"]
+
+# 池滚动保留天数（含当天）
+DAILY_FEED_RETENTION_DAYS = 7
+
+
+class DailyFeedEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """每日池条目：一篇论文只一行（同日多分类命中合并进 categories）。"""
+
+    __tablename__ = "daily_feed_entries"
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    # 进池日期（UTC），清理与按天分组的扫描键
+    feed_date: Mapped[dt.date] = mapped_column(Date, index=True, nullable=False)
+    # 首个命中的订阅分类
+    primary_category: Mapped[str] = mapped_column(String(32), nullable=False)
+    # 命中的全部订阅分类，如 ["cs.AI", "cs.CL"]
+    categories: Mapped[Any] = mapped_column(JSONVariant, nullable=False, default=list)
+    # arxiv 公告类型：new（新提交）| cross（转投/交叉列表）
+    announce_type: Mapped[str] = mapped_column(String(16), nullable=False, default="new")
+    # 共享单篇解读（P2 编译产物）；收录时拷贝进目标库成员行
+    wiki_content: Mapped[str | None] = mapped_column(Text)
+    wiki_model: Mapped[str | None] = mapped_column(String(128))
+
+    paper: Mapped[Paper] = relationship()
+
+
+class DailyFeedLike(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """点赞：全实验室共享，每人每篇一赞；entry 过期删除时级联消失。"""
+
+    __tablename__ = "daily_feed_likes"
+    __table_args__ = (UniqueConstraint("entry_id", "user_id", name="uq_daily_feed_likes"),)
+
+    entry_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("daily_feed_entries.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -1,0 +1,108 @@
+"""每日新论文池（Daily Paper）schema。"""
+
+import uuid
+from datetime import date, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DailyLiker(BaseModel):
+    """点赞人（facepile 头像用）。"""
+
+    id: uuid.UUID
+    display_name: str
+    has_avatar: bool
+
+
+class DailyLikerFull(DailyLiker):
+    liked_at: datetime
+
+
+class DailyLikeState(BaseModel):
+    """一篇论文的点赞汇总（点/取消赞后返回，供前端乐观更新对账）。"""
+
+    entry_id: uuid.UUID
+    like_count: int
+    liked_by_me: bool
+    likers_preview: list[DailyLiker] = []
+
+
+class DailyPaperItem(BaseModel):
+    entry_id: uuid.UUID
+    paper_id: uuid.UUID
+    feed_date: date
+    primary_category: str
+    categories: list[str] = []
+    announce_type: Literal["new", "cross"]
+    title: str
+    authors: list[dict[str, Any]] = []
+    abstract: str | None
+    year: int | None
+    arxiv_id: str | None
+    url: str | None
+    published_at: datetime | None
+    has_wiki: bool = False
+    like_count: int = 0
+    liked_by_me: bool = False
+    likers_preview: list[DailyLiker] = []
+    # 仅「我赞过的」列表返回
+    liked_at: datetime | None = None
+
+    @field_validator("authors", mode="before")
+    @classmethod
+    def _default_authors(cls, v: Any) -> Any:
+        return v or []
+
+
+class DailyPaperDetail(DailyPaperItem):
+    wiki_content: str | None = None
+
+
+class DailyPage(BaseModel):
+    items: list[DailyPaperItem]
+    total: int
+    page: int
+    size: int
+
+
+class DailyDay(BaseModel):
+    date: date
+    count: int
+
+
+class DailyCollectRequest(BaseModel):
+    """批量收录：paper_ids × 目标（方向库 / 课题相关研究 / 个人库）。"""
+
+    paper_ids: list[uuid.UUID] = Field(min_length=1)
+    direction_library_ids: list[uuid.UUID] = []
+    topic_ids: list[uuid.UUID] = []
+    personal: bool = False
+
+
+class DailyCollectResult(BaseModel):
+    target_type: Literal["library", "topic", "personal"]
+    target_id: uuid.UUID | None
+    added: int
+    skipped_existing: int
+    forbidden: bool
+
+
+class DailyCollectResponse(BaseModel):
+    results: list[DailyCollectResult]
+
+
+class DailyCollectionsRead(BaseModel):
+    """该论文已在哪些收录目标里（树选框预勾选/禁用）。"""
+
+    direction_library_ids: list[uuid.UUID]
+    topic_ids: list[uuid.UUID]
+    in_personal: bool
+
+
+class DailyCategoriesRead(BaseModel):
+    categories: list[str]
+
+
+class DailyCategoriesUpdate(BaseModel):
+    categories: list[str] = Field(min_length=1)

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -100,6 +100,14 @@ class DailyCollectionsRead(BaseModel):
     in_personal: bool
 
 
+class DailyCompileResult(BaseModel):
+    """单篇解读编译结果（全实验室共享一份，存 entry 上）。"""
+
+    entry_id: uuid.UUID
+    wiki_content: str
+    model: str | None
+
+
 class DailyCategoriesRead(BaseModel):
     categories: list[str]
 

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1,0 +1,523 @@
+"""每日新论文池（Daily Paper）业务逻辑。
+
+- 同步：每天从 arxiv 订阅分类抓 New submissions（RSS /new，announce_type∈{new,cross}），
+  先查全局内容池去重、无则建轻量 Paper（不下 PDF、不触发 LLM——每天上百篇，重活留给
+  收录后的库流程），再 upsert 池 entry；同一篇多分类命中合并进 categories，paper_id
+  唯一约束保证同日重跑幂等。
+- 滚动 7 天：清理直接删过期 entry（likes 显式跟删，兼容 sqlite 测试无 FK 级联）；
+  内容池 Paper 与各库成员表一概不动——收录动作写的是目标库自己的表。
+- 点赞：全实验室共享，每人每篇一赞；列表按赞数排序、附前几名点赞人（facepile 用）。
+- 收录：分发到现成写路径（方向库 ensure_membership / 课题书架 add_to_shelf /
+  个人库 save_paper），无权目标单独标记 forbidden，不整体失败。
+"""
+
+import datetime as dt
+import logging
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.daily_feed import (
+    DAILY_FEED_RETENTION_DAYS,
+    DEFAULT_DAILY_CATEGORIES,
+    DailyFeedEntry,
+    DailyFeedLike,
+)
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.models.system_setting import SystemSetting
+from app.models.topic_shelf import TopicPaper
+from app.models.user import User
+from app.services import projects as projects_service
+from app.services import topic_shelf as shelf_service
+from app.services import user_library
+from app.services.dedup import pool_dedup_key
+from app.services.libraries import can_manage_library, ensure_membership, find_pool_paper
+from app.services.literature import get_arxiv_client
+from app.services.paper_import import _parse_iso
+
+logger = logging.getLogger(__name__)
+
+CATEGORIES_SETTING_KEY = "daily_feed_categories"
+
+# arXiv 分类形如 cs.AI / stat.ML / eess.IV / math.OC（主类小写，子类大写字母数字短串）
+_CATEGORY_RE = re.compile(r"^[a-z][a-z-]{1,15}(\.[A-Za-z]{2,10})?$")
+
+_MAX_LIKERS_PREVIEW = 5
+
+
+class DailyEntryNotFoundError(Exception):
+    pass
+
+
+class InvalidCategoryError(Exception):
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+def _today_utc() -> dt.date:
+    return dt.datetime.now(dt.UTC).date()
+
+
+# ---- 订阅分类配置 ----
+
+
+async def get_categories(session: AsyncSession) -> list[str]:
+    row = await session.get(SystemSetting, CATEGORIES_SETTING_KEY)
+    if row is None or not isinstance(row.value, list) or not row.value:
+        return list(DEFAULT_DAILY_CATEGORIES)
+    return [str(c) for c in row.value]
+
+
+async def set_categories(session: AsyncSession, categories: list[str]) -> list[str]:
+    cleaned: list[str] = []
+    for raw in categories:
+        cat = raw.strip()
+        if not cat:
+            continue
+        if not _CATEGORY_RE.match(cat):
+            raise InvalidCategoryError(cat)
+        if cat not in cleaned:
+            cleaned.append(cat)
+    if not cleaned:
+        raise InvalidCategoryError("(empty)")
+    row = await session.get(SystemSetting, CATEGORIES_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=CATEGORIES_SETTING_KEY, value=cleaned))
+    else:
+        row.value = cleaned
+    await session.commit()
+    return cleaned
+
+
+# ---- 每日同步（cron / 手动刷新） ----
+
+
+def _make_pool_paper(entry: dict[str, Any]) -> Paper:
+    """RSS entry → 轻量内容池 Paper（不下 PDF、不补机构——feed 量大，重活留给收录后）。"""
+    aid = entry.get("arxiv_id")
+    return Paper(
+        source="arxiv",
+        dedup_key=pool_dedup_key(
+            arxiv_id=aid,
+            doi=entry.get("doi"),
+            title=entry["title"],
+            year=entry.get("year"),
+            authors=entry.get("authors"),
+        ),
+        arxiv_id=aid,
+        doi=entry.get("doi"),
+        external_ids={"arxiv": aid} if aid else None,
+        title=entry["title"],
+        authors=entry.get("authors"),
+        abstract=entry.get("abstract"),
+        year=entry.get("year"),
+        venue=entry.get("primary_category"),
+        url=entry.get("url"),
+        published_at=_parse_iso(entry.get("published")),
+    )
+
+
+async def cleanup_expired(session: AsyncSession, *, today: dt.date | None = None) -> int:
+    """删过期 entry（保留含今天共 RETENTION 天）；likes 显式跟删（不依赖 DB 级联）。"""
+    cutoff = (today or _today_utc()) - dt.timedelta(days=DAILY_FEED_RETENTION_DAYS - 1)
+    expired_ids = select(DailyFeedEntry.id).where(DailyFeedEntry.feed_date < cutoff)
+    await session.execute(delete(DailyFeedLike).where(DailyFeedLike.entry_id.in_(expired_ids)))
+    result = await session.execute(delete(DailyFeedEntry).where(DailyFeedEntry.feed_date < cutoff))
+    return result.rowcount or 0
+
+
+async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
+    """抓订阅分类的当天新公告入池 + 清理过期；幂等（同日重跑 created=0）。"""
+    categories = await get_categories(session)
+    today = _today_utc()
+    client = get_arxiv_client()
+    fetched = created = 0
+
+    for category in categories:
+        entries = await client.fetch_new(category)  # 失败已在客户端兜底为 []
+        fetched += len(entries)
+        for entry in entries:
+            title = (entry.get("title") or "").strip()
+            arxiv_id = entry.get("arxiv_id")
+            if not title or not arxiv_id:
+                continue
+            paper = await find_pool_paper(
+                session,
+                arxiv_id=arxiv_id,
+                doi=entry.get("doi"),
+                dedup_key=pool_dedup_key(
+                    arxiv_id=arxiv_id,
+                    doi=entry.get("doi"),
+                    title=title,
+                    year=entry.get("year"),
+                    authors=entry.get("authors"),
+                ),
+            )
+            if paper is None:
+                paper = _make_pool_paper(entry)
+                session.add(paper)
+                await session.flush()
+            row = (
+                await session.execute(
+                    select(DailyFeedEntry).where(DailyFeedEntry.paper_id == paper.id)
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                session.add(
+                    DailyFeedEntry(
+                        paper_id=paper.id,
+                        feed_date=today,
+                        primary_category=category,
+                        categories=[category],
+                        announce_type=entry.get("announce_type") or "new",
+                    )
+                )
+                created += 1
+            elif category not in (row.categories or []):
+                # 同日另一分类命中（cross-list）：合并分类，不动 feed_date
+                row.categories = [*(row.categories or []), category]
+
+    expired = await cleanup_expired(session, today=today)
+    await session.commit()
+    return {"fetched": fetched, "created": created, "expired": expired, "categories": categories}
+
+
+# ---- 池浏览 ----
+
+
+def _like_count_sq() -> Any:
+    return (
+        select(func.count(DailyFeedLike.id))
+        .where(DailyFeedLike.entry_id == DailyFeedEntry.id)
+        .correlate(DailyFeedEntry)
+        .scalar_subquery()
+    )
+
+
+async def _likes_by_entry(
+    session: AsyncSession, entry_ids: list[uuid.UUID], *, user_id: uuid.UUID
+) -> dict[uuid.UUID, dict[str, Any]]:
+    """一次查出这页 entry 的全部点赞（含用户名/头像），拼 facepile 预览。"""
+    empty = {"like_count": 0, "liked_by_me": False, "likers_preview": []}
+    if not entry_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(DailyFeedLike.entry_id, User.id, User.display_name, User.avatar_path)
+            .join(User, User.id == DailyFeedLike.user_id)
+            .where(DailyFeedLike.entry_id.in_(entry_ids))
+            .order_by(DailyFeedLike.created_at.desc())
+        )
+    ).all()
+    out: dict[uuid.UUID, dict[str, Any]] = {
+        eid: dict(empty, likers_preview=[]) for eid in entry_ids
+    }
+    for entry_id, uid, display_name, avatar_path in rows:
+        info = out[entry_id]
+        info["like_count"] += 1
+        liker = {"id": uid, "display_name": display_name, "has_avatar": bool(avatar_path)}
+        if uid == user_id:
+            info["liked_by_me"] = True
+            info["likers_preview"].insert(0, liker)  # 自己永远排最前
+        else:
+            info["likers_preview"].append(liker)
+    for info in out.values():
+        info["likers_preview"] = info["likers_preview"][:_MAX_LIKERS_PREVIEW]
+    return out
+
+
+def _entry_item(entry: DailyFeedEntry, paper: Paper, likes: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "entry_id": entry.id,
+        "paper_id": paper.id,
+        "feed_date": entry.feed_date,
+        "primary_category": entry.primary_category,
+        "categories": entry.categories or [],
+        "announce_type": entry.announce_type,
+        "title": paper.title,
+        "authors": paper.authors or [],
+        "abstract": paper.abstract,
+        "year": paper.year,
+        "arxiv_id": paper.arxiv_id,
+        "url": paper.url,
+        "published_at": paper.published_at,
+        "has_wiki": bool(entry.wiki_content),
+        **likes,
+    }
+
+
+async def list_days(session: AsyncSession) -> list[dict[str, Any]]:
+    rows = (
+        await session.execute(
+            select(DailyFeedEntry.feed_date, func.count(DailyFeedEntry.id))
+            .group_by(DailyFeedEntry.feed_date)
+            .order_by(DailyFeedEntry.feed_date.desc())
+        )
+    ).all()
+    return [{"date": date, "count": count} for date, count in rows]
+
+
+async def list_papers(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    date: dt.date | None = None,
+    sort: str = "likes",
+    page: int = 1,
+    size: int = 20,
+    q: str | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
+    if date is not None:
+        stmt = stmt.where(DailyFeedEntry.feed_date == date)
+    if q:
+        stmt = stmt.where(Paper.title.ilike(f"%{q.strip()}%"))
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await session.execute(count_stmt)).scalar_one()
+
+    likes_sq = _like_count_sq()
+    if sort == "likes":
+        stmt = stmt.order_by(
+            likes_sq.desc(), DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc()
+        )
+    else:  # date
+        stmt = stmt.order_by(DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc())
+    stmt = stmt.offset((page - 1) * size).limit(size)
+
+    rows = (await session.execute(stmt)).all()
+    likes = await _likes_by_entry(session, [entry.id for entry, _ in rows], user_id=user_id)
+    empty = {"like_count": 0, "liked_by_me": False, "likers_preview": []}
+    return [_entry_item(entry, paper, likes.get(entry.id, empty)) for entry, paper in rows], total
+
+
+async def get_entry_item(
+    session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
+) -> dict[str, Any]:
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    paper = await session.get(Paper, entry.paper_id)
+    assert paper is not None  # 外键保证
+    likes = await _likes_by_entry(session, [entry.id], user_id=user_id)
+    item = _entry_item(entry, paper, likes[entry.id])
+    item["wiki_content"] = entry.wiki_content
+    return item
+
+
+# ---- 点赞 ----
+
+
+async def set_like(
+    session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID, liked: bool
+) -> dict[str, Any]:
+    """点/取消赞，幂等；返回该 entry 最新点赞汇总（乐观更新对账用）。"""
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    existing = (
+        await session.execute(
+            select(DailyFeedLike).where(
+                DailyFeedLike.entry_id == entry_id, DailyFeedLike.user_id == user_id
+            )
+        )
+    ).scalar_one_or_none()
+    if liked and existing is None:
+        session.add(DailyFeedLike(entry_id=entry_id, user_id=user_id))
+    elif not liked and existing is not None:
+        await session.delete(existing)
+    await session.commit()
+    likes = await _likes_by_entry(session, [entry_id], user_id=user_id)
+    return {"entry_id": entry_id, **likes[entry_id]}
+
+
+async def list_likers(session: AsyncSession, *, entry_id: uuid.UUID) -> list[dict[str, Any]]:
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    rows = (
+        await session.execute(
+            select(User.id, User.display_name, User.avatar_path, DailyFeedLike.created_at)
+            .join(DailyFeedLike, DailyFeedLike.user_id == User.id)
+            .where(DailyFeedLike.entry_id == entry_id)
+            .order_by(DailyFeedLike.created_at.desc())
+        )
+    ).all()
+    return [
+        {"id": uid, "display_name": name, "has_avatar": bool(avatar), "liked_at": at}
+        for uid, name, avatar, at in rows
+    ]
+
+
+async def list_my_liked(
+    session: AsyncSession, *, user_id: uuid.UUID, page: int = 1, size: int = 20
+) -> tuple[list[dict[str, Any]], int]:
+    """我赞过的（个人库历史 tab）：按点赞时间倒序，随 entry 过期自然消失。"""
+    base = (
+        select(DailyFeedEntry, Paper, DailyFeedLike.created_at)
+        .join(DailyFeedLike, DailyFeedLike.entry_id == DailyFeedEntry.id)
+        .join(Paper, Paper.id == DailyFeedEntry.paper_id)
+        .where(DailyFeedLike.user_id == user_id)
+    )
+    total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+    rows = (
+        await session.execute(
+            base.order_by(DailyFeedLike.created_at.desc()).offset((page - 1) * size).limit(size)
+        )
+    ).all()
+    likes = await _likes_by_entry(session, [entry.id for entry, _, _ in rows], user_id=user_id)
+    empty = {"like_count": 0, "liked_by_me": False, "likers_preview": []}
+    items = []
+    for entry, paper, liked_at in rows:
+        item = _entry_item(entry, paper, likes.get(entry.id, empty))
+        item["liked_at"] = liked_at
+        items.append(item)
+    return items, total
+
+
+# ---- 收录到各类库 ----
+
+
+async def entry_collections(
+    session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
+) -> dict[str, Any]:
+    """该论文已在哪些收录目标里（树选框预勾选/禁用用）。"""
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    library_ids = (
+        (
+            await session.execute(
+                select(LibraryPaper.library_id).where(LibraryPaper.paper_id == entry.paper_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    topic_ids = (
+        (
+            await session.execute(
+                select(TopicPaper.topic_id).where(TopicPaper.paper_id == entry.paper_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    paper = await session.get(Paper, entry.paper_id)
+    assert paper is not None
+    personal_entry = await user_library.entry_for_paper(session, user_id=user_id, paper=paper)
+    return {
+        "direction_library_ids": list(library_ids),
+        "topic_ids": list(topic_ids),
+        "in_personal": bool(personal_entry is not None and personal_entry.saved),
+    }
+
+
+async def collect_papers(
+    session: AsyncSession,
+    *,
+    user: User,
+    paper_ids: list[uuid.UUID],
+    direction_library_ids: list[uuid.UUID],
+    topic_ids: list[uuid.UUID],
+    personal: bool = False,
+) -> list[dict[str, Any]]:
+    """把一批论文分发进方向库 / 课题书架 / 个人库；逐目标返回结果，无权只标记不失败。"""
+    papers = [p for pid in paper_ids if (p := await session.get(Paper, pid)) is not None]
+    results: list[dict[str, Any]] = []
+
+    for library_id in direction_library_ids:
+        library = await session.get(DirectionLibrary, library_id)
+        if library is None or not await can_manage_library(session, user=user, library=library):
+            results.append(
+                {
+                    "target_type": "library",
+                    "target_id": library_id,
+                    "added": 0,
+                    "skipped_existing": 0,
+                    "forbidden": True,
+                }
+            )
+            continue
+        added = skipped = 0
+        for paper in papers:
+            _, created = await ensure_membership(
+                session, library_id=library_id, paper_id=paper.id, status="included"
+            )
+            added += int(created)
+            skipped += int(not created)
+        await session.commit()
+        results.append(
+            {
+                "target_type": "library",
+                "target_id": library_id,
+                "added": added,
+                "skipped_existing": skipped,
+                "forbidden": False,
+            }
+        )
+
+    for topic_id in topic_ids:
+        project = await projects_service.get_project(session, project_id=topic_id, user_id=user.id)
+        if project is None:
+            results.append(
+                {
+                    "target_type": "topic",
+                    "target_id": topic_id,
+                    "added": 0,
+                    "skipped_existing": 0,
+                    "forbidden": True,
+                }
+            )
+            continue
+        added = skipped = 0
+        for paper in papers:
+            existing = (
+                await session.execute(
+                    select(TopicPaper.id).where(
+                        TopicPaper.topic_id == topic_id, TopicPaper.paper_id == paper.id
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is not None:
+                skipped += 1
+                continue
+            await shelf_service.add_to_shelf(
+                session, project_id=topic_id, paper_id=paper.id, user_id=user.id
+            )
+            added += 1
+        results.append(
+            {
+                "target_type": "topic",
+                "target_id": topic_id,
+                "added": added,
+                "skipped_existing": skipped,
+                "forbidden": False,
+            }
+        )
+
+    if personal:
+        added = skipped = 0
+        for paper in papers:
+            existing = await user_library.entry_for_paper(session, user_id=user.id, paper=paper)
+            if existing is not None and existing.saved:
+                skipped += 1
+                continue
+            await user_library.save_paper(session, user_id=user.id, paper=paper)
+            added += 1
+        results.append(
+            {
+                "target_type": "personal",
+                "target_id": None,
+                "added": added,
+                "skipped_existing": skipped,
+                "forbidden": False,
+            }
+        )
+
+    return results

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -17,9 +17,10 @@ import re
 import uuid
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import String, cast, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.base import utcnow
 from app.models.daily_feed import (
     DAILY_FEED_RETENTION_DAYS,
     DEFAULT_DAILY_CATEGORIES,
@@ -51,6 +52,10 @@ _MAX_LIKERS_PREVIEW = 5
 
 class DailyEntryNotFoundError(Exception):
     pass
+
+
+class CompileInProgressError(Exception):
+    """同一 entry 的解读编译已在进行中（进程内防抖，语义同 personal_wiki）。"""
 
 
 class InvalidCategoryError(Exception):
@@ -271,12 +276,22 @@ async def list_papers(
     page: int = 1,
     size: int = 20,
     q: str | None = None,
+    announce: str | None = None,
+    category: str | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
     if date is not None:
         stmt = stmt.where(DailyFeedEntry.feed_date == date)
     if q:
         stmt = stmt.where(Paper.title.ilike(f"%{q.strip()}%"))
+    if announce in ("new", "cross"):
+        stmt = stmt.where(DailyFeedEntry.announce_type == announce)
+    if category:
+        # 命中任一分类（categories 是 JSON 数组；LIKE 序列化文本，PG/sqlite 通用）
+        stmt = stmt.where(
+            (DailyFeedEntry.primary_category == category)
+            | cast(DailyFeedEntry.categories, String).like(f'%"{category}"%')
+        )
 
     count_stmt = select(func.count()).select_from(stmt.subquery())
     total = (await session.execute(count_stmt)).scalar_one()
@@ -380,6 +395,43 @@ async def list_my_liked(
     return items, total
 
 
+# ---- 池对话与单篇解读（P2） ----
+
+
+async def daily_paper_ids(session: AsyncSession) -> list[uuid.UUID]:
+    """池内现存全部论文 id（池对话的 scope）。"""
+    return list((await session.execute(select(DailyFeedEntry.paper_id))).scalars().all())
+
+
+# 进行中的解读编译（entry_id）；单实例进程内防抖，多副本最坏重复编译一次、后写覆盖
+_COMPILING: set[uuid.UUID] = set()
+
+
+async def compile_entry_wiki(
+    session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
+) -> DailyFeedEntry:
+    """通用模板编译单篇解读（全实验室共享一份），写进 entry；费用记个人。"""
+    from app.services.wiki_compile import compile_paper
+
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    paper = await session.get(Paper, entry.paper_id)
+    assert paper is not None  # 外键保证
+    if entry_id in _COMPILING:
+        raise CompileInProgressError(str(entry_id))
+    _COMPILING.add(entry_id)
+    try:
+        compiled = await compile_paper(paper, statement=None, user_id=user_id)
+    finally:
+        _COMPILING.discard(entry_id)
+    entry.wiki_content = compiled.content
+    entry.wiki_model = compiled.model or None
+    await session.commit()
+    await session.refresh(entry)
+    return entry
+
+
 # ---- 收录到各类库 ----
 
 
@@ -427,9 +479,26 @@ async def collect_papers(
     topic_ids: list[uuid.UUID],
     personal: bool = False,
 ) -> list[dict[str, Any]]:
-    """把一批论文分发进方向库 / 课题书架 / 个人库；逐目标返回结果，无权只标记不失败。"""
+    """把一批论文分发进方向库 / 课题书架 / 个人库；逐目标返回结果，无权只标记不失败。
+
+    entry 已有共享解读（wiki_content）时顺带拷贝进目标（方向库成员行 / 书架快照 /
+    个人库条目），让解读在 entry 7 天过期后于目标库存活。
+    """
     papers = [p for pid in paper_ids if (p := await session.get(Paper, pid)) is not None]
     results: list[dict[str, Any]] = []
+    wiki_rows = (
+        (
+            await session.execute(
+                select(DailyFeedEntry).where(
+                    DailyFeedEntry.paper_id.in_([p.id for p in papers]),
+                    DailyFeedEntry.wiki_content.is_not(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    entry_wiki = {e.paper_id: e for e in wiki_rows}
 
     for library_id in direction_library_ids:
         library = await session.get(DirectionLibrary, library_id)
@@ -446,8 +515,16 @@ async def collect_papers(
             continue
         added = skipped = 0
         for paper in papers:
+            wiki = entry_wiki.get(paper.id)
+            extra: dict[str, Any] = {}
+            if wiki is not None:
+                extra = {
+                    "wiki_content": wiki.wiki_content,
+                    "compiled_at": utcnow(),
+                    "compiled_model": wiki.wiki_model,
+                }
             _, created = await ensure_membership(
-                session, library_id=library_id, paper_id=paper.id, status="included"
+                session, library_id=library_id, paper_id=paper.id, status="included", **extra
             )
             added += int(created)
             skipped += int(not created)
@@ -490,6 +567,20 @@ async def collect_papers(
             await shelf_service.add_to_shelf(
                 session, project_id=topic_id, paper_id=paper.id, user_id=user.id
             )
+            wiki = entry_wiki.get(paper.id)
+            if wiki is not None:
+                # 书架行没有库版快照时用共享解读兜底（add_to_shelf 只取库版 wiki）
+                row = (
+                    await session.execute(
+                        select(TopicPaper).where(
+                            TopicPaper.topic_id == topic_id, TopicPaper.paper_id == paper.id
+                        )
+                    )
+                ).scalar_one_or_none()
+                if row is not None and row.wiki_snapshot is None:
+                    row.wiki_snapshot = wiki.wiki_content
+                    row.snapshot_at = utcnow()
+                    await session.commit()
             added += 1
         results.append(
             {
@@ -508,7 +599,11 @@ async def collect_papers(
             if existing is not None and existing.saved:
                 skipped += 1
                 continue
-            await user_library.save_paper(session, user_id=user.id, paper=paper)
+            saved_entry = await user_library.save_paper(session, user_id=user.id, paper=paper)
+            wiki = entry_wiki.get(paper.id)
+            if wiki is not None and not saved_entry.wiki_content:
+                saved_entry.wiki_content = wiki.wiki_content
+                await session.commit()
             added += 1
         results.append(
             {

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1,0 +1,258 @@
+"""每日新论文池：同步/过期清理（service 层）+ 浏览/点赞/收录/分类（API 层）。"""
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from tests.conftest import make_project_with_library, register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+def _rss_entry(arxiv_id: str, title: str, *, announce: str = "new") -> dict:
+    return {
+        "arxiv_id": arxiv_id,
+        "title": title,
+        "abstract": f"Abstract of {title}",
+        "authors": [{"name": "Ada Lovelace"}],
+        "published": "2026-07-24T00:00:00+00:00",
+        "updated": None,
+        "year": 2026,
+        "categories": ["cs.AI"],
+        "primary_category": "cs.AI",
+        "doi": None,
+        "url": f"https://arxiv.org/abs/{arxiv_id}",
+        "pdf_url": f"https://arxiv.org/pdf/{arxiv_id}",
+        "announce_type": announce,
+    }
+
+
+class _StubArxiv:
+    """按分类返回固定 RSS 条目的假客户端。"""
+
+    def __init__(self, by_category: dict[str, list[dict]]):
+        self.by_category = by_category
+
+    async def fetch_new(self, category: str) -> list[dict]:
+        return self.by_category.get(category, [])
+
+
+async def _run_sync(monkeypatch, by_category: dict[str, list[dict]]) -> dict:
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv(by_category))
+    async with get_sessionmaker()() as session:
+        return await daily_feed.sync_daily_feed(session)
+
+
+async def test_sync_idempotent_and_cross_merge(client, monkeypatch):
+    await register_and_login(client)
+    feed = {
+        "cs.AI": [_rss_entry("2607.00001", "Paper A"), _rss_entry("2607.00002", "Paper B")],
+        # 同一篇论文在另一分类以 cross 出现 → 合并 categories，不重复建行
+        "cs.CL": [_rss_entry("2607.00001", "Paper A", announce="cross")],
+        "cs.CV": [],
+    }
+    result = await _run_sync(monkeypatch, feed)
+    assert result["fetched"] == 3
+    assert result["created"] == 2
+
+    # 同日重跑幂等
+    result2 = await _run_sync(monkeypatch, feed)
+    assert result2["created"] == 0
+
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(DailyFeedEntry))).scalars().all()
+        assert len(rows) == 2
+        merged = next(r for r in rows if "cs.CL" in (r.categories or []))
+        assert set(merged.categories) == {"cs.AI", "cs.CL"}
+
+
+async def test_cleanup_expired_keeps_paper_and_membership(client, monkeypatch):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.00010", "Old Paper")]})
+
+    resp = await client.get("/api/daily/papers", headers=headers)
+    assert resp.status_code == 200
+    item = resp.json()["items"][0]
+    entry_id, paper_id = item["entry_id"], item["paper_id"]
+
+    # 点个赞 + 收进个人库
+    resp = await client.put(f"/api/daily/papers/{entry_id}/like", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.post(
+        "/api/daily/collect", json={"paper_ids": [paper_id], "personal": True}, headers=headers
+    )
+    assert resp.status_code == 200
+
+    # 把 entry 改成 8 天前 → 再同步 → entry 与赞消失，Paper 与个人库条目仍在
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
+    from app.models.library import UserLibraryEntry
+    from app.models.paper import Paper
+
+    async with get_sessionmaker()() as session:
+        entry = await session.get(DailyFeedEntry, uuid.UUID(entry_id))
+        entry.feed_date = entry.feed_date - dt.timedelta(days=8)
+        await session.commit()
+
+    result = await _run_sync(monkeypatch, {"cs.AI": []})
+    assert result["expired"] == 1
+
+    async with get_sessionmaker()() as session:
+        assert await session.get(DailyFeedEntry, uuid.UUID(entry_id)) is None
+        likes = (await session.execute(select(DailyFeedLike))).scalars().all()
+        assert likes == []
+        assert await session.get(Paper, uuid.UUID(paper_id)) is not None
+        saved = (await session.execute(select(UserLibraryEntry))).scalars().all()
+        assert len(saved) == 1 and saved[0].saved
+
+    # 「我赞过的」也随之清空
+    resp = await client.get("/api/daily/liked", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+async def test_like_toggle_facepile_and_sort(client, monkeypatch):
+    token_a = await register_and_login(client)  # 首个 = admin
+    token_b = await register_and_login(client, email="bob@example.com")
+    ha = {"Authorization": f"Bearer {token_a}"}
+    hb = {"Authorization": f"Bearer {token_b}"}
+    await _run_sync(
+        monkeypatch,
+        {"cs.AI": [_rss_entry("2607.00021", "Hot Paper"), _rss_entry("2607.00022", "Cold Paper")]},
+    )
+    resp = await client.get("/api/daily/papers", headers=ha)
+    hot = next(i for i in resp.json()["items"] if i["title"] == "Hot Paper")
+    eid = hot["entry_id"]
+
+    # 双人点赞；重复点幂等
+    r1 = await client.put(f"/api/daily/papers/{eid}/like", headers=ha)
+    assert r1.json()["like_count"] == 1 and r1.json()["liked_by_me"] is True
+    await client.put(f"/api/daily/papers/{eid}/like", headers=hb)
+    r2 = await client.put(f"/api/daily/papers/{eid}/like", headers=hb)
+    assert r2.json()["like_count"] == 2
+
+    # facepile：本人永远排最前（display_name 夹具里都叫 Alice，按 id 断言）
+    preview = r2.json()["likers_preview"]
+    assert len(preview) == 2
+    me = await client.get("/api/users/me", headers=hb)
+    assert preview[0]["id"] == me.json()["id"]
+
+    # 默认按赞数排序：Hot 在前
+    resp = await client.get("/api/daily/papers", headers=ha)
+    assert resp.json()["items"][0]["title"] == "Hot Paper"
+    assert resp.json()["items"][0]["like_count"] == 2
+
+    # 完整名单
+    resp = await client.get(f"/api/daily/papers/{eid}/likers", headers=ha)
+    assert resp.status_code == 200 and len(resp.json()) == 2
+
+    # 取消赞
+    r3 = await client.delete(f"/api/daily/papers/{eid}/like", headers=hb)
+    assert r3.json()["like_count"] == 1 and r3.json()["liked_by_me"] is False
+    resp = await client.get("/api/daily/liked", headers=hb)
+    assert resp.json()["total"] == 0
+    resp = await client.get("/api/daily/liked", headers=ha)
+    assert resp.json()["total"] == 1
+
+
+async def test_collect_to_library_topic_personal(client, monkeypatch):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="daily-proj")
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.00031", "Collect Me")]})
+    resp = await client.get("/api/daily/papers", headers=headers)
+    item = resp.json()["items"][0]
+
+    payload = {
+        "paper_ids": [item["paper_id"]],
+        "direction_library_ids": [str(library_id)],
+        "topic_ids": [project_id],
+        "personal": True,
+    }
+    resp = await client.post("/api/daily/collect", json=payload, headers=headers)
+    assert resp.status_code == 200
+    results = {r["target_type"]: r for r in resp.json()["results"]}
+    assert results["library"]["added"] == 1 and not results["library"]["forbidden"]
+    assert results["topic"]["added"] == 1
+    # 入架必入个人库（add_to_shelf 自带同步），个人库目标看到的是「已存在」
+    assert results["personal"]["added"] + results["personal"]["skipped_existing"] == 1
+
+    # 重复收录 → skipped_existing
+    resp = await client.post("/api/daily/collect", json=payload, headers=headers)
+    results = {r["target_type"]: r for r in resp.json()["results"]}
+    assert results["library"]["skipped_existing"] == 1
+    assert results["topic"]["skipped_existing"] == 1
+    assert results["personal"]["skipped_existing"] == 1
+
+    # 成员行 status=included
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.library_direction import LibraryPaper
+
+    async with get_sessionmaker()() as session:
+        membership = (
+            await session.execute(select(LibraryPaper).where(LibraryPaper.library_id == library_id))
+        ).scalar_one()
+        assert membership.status == "included"
+
+    # collections 预勾选口径
+    resp = await client.get(f"/api/daily/papers/{item['entry_id']}/collections", headers=headers)
+    data = resp.json()
+    assert str(library_id) in data["direction_library_ids"]
+    assert project_id in data["topic_ids"]
+    assert data["in_personal"] is True
+
+    # 非成员课题 → forbidden，不整体失败
+    other = await register_and_login(client, email="eve@example.com")
+    oh = {"Authorization": f"Bearer {other}"}
+    resp = await client.post(
+        "/api/daily/collect",
+        json={"paper_ids": [item["paper_id"]], "topic_ids": [project_id]},
+        headers=oh,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["results"][0]["forbidden"] is True
+
+
+async def test_categories_admin_and_refresh(client, queue_stub):
+    admin = await register_and_login(client)  # 首个 = admin
+    member = await register_and_login(client, email="bob2@example.com")
+    ah = {"Authorization": f"Bearer {admin}"}
+    mh = {"Authorization": f"Bearer {member}"}
+
+    resp = await client.get("/api/daily/categories", headers=mh)
+    assert resp.json()["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
+
+    # 普通成员改分类 → 403
+    resp = await client.put("/api/daily/categories", json={"categories": ["cs.LG"]}, headers=mh)
+    assert resp.status_code == 403
+
+    # admin 改分类；非法格式 422
+    resp = await client.put(
+        "/api/daily/categories", json={"categories": ["cs.LG", "stat.ML"]}, headers=ah
+    )
+    assert resp.status_code == 200 and resp.json()["categories"] == ["cs.LG", "stat.ML"]
+    resp = await client.put(
+        "/api/daily/categories", json={"categories": ["Not A Cat!"]}, headers=ah
+    )
+    assert resp.status_code == 422
+
+    # 手动刷新入队（admin only）
+    resp = await client.post("/api/daily/refresh", headers=mh)
+    assert resp.status_code == 403
+    resp = await client.post("/api/daily/refresh", headers=ah)
+    assert resp.status_code == 202
+    assert queue_stub.jobs and queue_stub.jobs[0][0] == "daily_feed_sync"

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -74,6 +74,17 @@ async def test_sync_idempotent_and_cross_merge(client, monkeypatch):
         merged = next(r for r in rows if "cs.CL" in (r.categories or []))
         assert set(merged.categories) == {"cs.AI", "cs.CL"}
 
+    # 高级过滤：分类命中合并进 categories 的条目；announce 过滤
+    token = await register_and_login(client, email="filter@example.com")
+    fh = {"Authorization": f"Bearer {token}"}
+    resp = await client.get("/api/daily/papers", params={"category": "cs.CL"}, headers=fh)
+    assert resp.status_code == 200 and resp.json()["total"] == 1
+    assert resp.json()["items"][0]["title"] == "Paper A"
+    resp = await client.get("/api/daily/papers", params={"announce": "new"}, headers=fh)
+    assert resp.json()["total"] == 2  # Paper A 首见于 cs.AI 时 announce=new
+    resp = await client.get("/api/daily/papers", params={"announce": "cross"}, headers=fh)
+    assert resp.json()["total"] == 0
+
 
 async def test_cleanup_expired_keeps_paper_and_membership(client, monkeypatch):
     token = await register_and_login(client)
@@ -225,6 +236,86 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.json()["results"][0]["forbidden"] is True
+
+
+async def test_compile_entry_and_collect_copies_wiki(client, monkeypatch):
+    """单篇解读编译（fake LLM）落 entry；收录时拷进方向库成员行 / 书架快照 / 个人库条目。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="wiki-proj")
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.00041", "Compile Me")]})
+    resp = await client.get("/api/daily/papers", headers=headers)
+    item = resp.json()["items"][0]
+    entry_id, paper_id = item["entry_id"], item["paper_id"]
+    assert item["has_wiki"] is False
+
+    resp = await client.post(f"/api/daily/papers/{entry_id}/compile", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["wiki_content"].strip()
+
+    resp = await client.get(f"/api/daily/papers/{entry_id}", headers=headers)
+    assert resp.json()["has_wiki"] is True and resp.json()["wiki_content"].strip()
+
+    resp = await client.post(
+        "/api/daily/collect",
+        json={
+            "paper_ids": [paper_id],
+            "direction_library_ids": [str(library_id)],
+            "topic_ids": [project_id],
+            "personal": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.library import UserLibraryEntry
+    from app.models.library_direction import LibraryPaper
+    from app.models.topic_shelf import TopicPaper
+
+    async with get_sessionmaker()() as session:
+        membership = (
+            await session.execute(select(LibraryPaper).where(LibraryPaper.library_id == library_id))
+        ).scalar_one()
+        assert membership.wiki_content and membership.compiled_at is not None
+        shelf_row = (await session.execute(select(TopicPaper))).scalar_one()
+        assert shelf_row.wiki_snapshot
+        personal = (await session.execute(select(UserLibraryEntry))).scalar_one()
+        assert personal.wiki_content
+
+
+async def test_daily_pool_chat_sse(client, monkeypatch):
+    """池对话：scope = 池内全部论文，摘要级降级（无索引），sources → delta* → done。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.00051", "Chat About Me")]})
+
+    async with client.stream(
+        "POST",
+        "/api/daily/chat",
+        json={"question": "今天有什么值得看的论文？", "history": []},
+        headers=headers,
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = (await resp.aread()).decode("utf-8")
+
+    import json
+
+    events = []
+    for block in body.strip().split("\n\n"):
+        event, data = None, None
+        for line in block.split("\n"):
+            if line.startswith("event: "):
+                event = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: ") :])
+        if event is not None:
+            events.append((event, data))
+    kinds = [e for e, _ in events]
+    assert kinds[0] == "sources" and kinds[-1] == "done" and "error" not in kinds
 
 
 async def test_categories_admin_and_refresh(client, queue_stub):

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -6,6 +6,7 @@ from arq.connections import RedisSettings
 from app.core.config import get_settings
 from app.services.ingest import DAILY_SYNC_UTC_HOUR, DAILY_SYNC_UTC_MINUTE
 from worker.tasks import (
+    daily_feed_sync,
     daily_publication_match,
     daily_wiki_ingest,
     index_papers_fulltext_task,
@@ -28,9 +29,12 @@ class WorkerSettings:
         func(resume_voyage, timeout=VOYAGE_JOB_TIMEOUT_SECONDS),
         match_user_publications,
         index_papers_fulltext_task,
+        daily_feed_sync,
     ]
     # 每日 03:00 对 cadence=daily 且已 bootstrap 的项目触发增量 ingest（docs/api-m2.md §4）
     cron_jobs = [
+        # 每日论文池：arXiv 约 00:00 UTC 发布新公告，01:30 抓取（错开 03:00 的每日 ingest）
+        cron(daily_feed_sync, hour=1, minute=30),
         cron(daily_wiki_ingest, hour=DAILY_SYNC_UTC_HOUR, minute=DAILY_SYNC_UTC_MINUTE),
         # 每日 ingest 后一小时跑发表匹配（新入库论文 → 姓名+机构命中进待确认）
         cron(daily_publication_match, hour=DAILY_SYNC_UTC_HOUR + 1, minute=DAILY_SYNC_UTC_MINUTE),

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -126,6 +126,15 @@ async def index_papers_fulltext_task(
         )
 
 
+async def daily_feed_sync(ctx: dict[str, Any]) -> dict[str, Any]:
+    """每日 01:30 cron（arXiv 约 00:00 UTC 发布新公告）：抓订阅分类的 New submissions
+    进每日论文池 + 清理 7 天外过期条目。admin 手动刷新走同一任务（见 api/daily.py）。"""
+    from app.services import daily_feed as daily_feed_service
+
+    async with get_sessionmaker()() as session:
+        return await daily_feed_service.sync_daily_feed(session)
+
+
 async def daily_publication_match(ctx: dict[str, Any]) -> int:
     """每日 04:00 cron（每日 ingest 之后）：对开了自动匹配的绑定用户逐个跑库内匹配。"""
     async with get_sessionmaker()() as session:

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -32,6 +32,7 @@ interface NavEntry {
 // 实验室级导航：跨课题的公共资产（P5c 起为共享方向文献库列表）
 const NAV_LAB: NavEntry[] = [
   { to: '/libraries', icon: 'book', zh: '文献库', en: 'Libraries' },
+  { to: '/daily', icon: 'heart', zh: '每日新论文', en: 'Daily Papers' },
 ];
 
 const NAV_MAIN: NavEntry[] = [
@@ -68,6 +69,7 @@ function crumbFor(pathname: string): [string, string] {
   if (p.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
   if (p.startsWith('/papers/')) return [tr('文献库', 'Libraries'), tr('论文阅读', 'Paper reading')];
   if (p === '/libraries') return [tr('实验室', 'Lab'), tr('文献库', 'Libraries')];
+  if (p === '/daily') return [tr('实验室', 'Lab'), tr('每日新论文', 'Daily Papers')];
   if (p.startsWith('/libraries/')) return [tr('文献库', 'Libraries'), tr('库详情', 'Library detail')];
   if (p.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
   if (p.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -153,6 +153,8 @@ export const router = createBrowserRouter([
       // 实验室区：共享方向文献库（全实验室可读，无需课题）
       { path: 'libraries', element: page(() => import('../features/libraries/LibrariesPage'), 'LibrariesPage') },
       { path: 'libraries/:id', element: page(() => import('../features/libraries/LibraryDetailPage'), 'LibraryDetailPage') },
+      // 实验室区：每日新论文池（arxiv 每日新提交，保留最近 7 天）
+      { path: 'daily', element: page(() => import('../features/daily/DailyPage'), 'DailyPage') },
       // MCP 说明已并入设置页签，旧链接重定向
       { path: 'mcp-tools', element: <Navigate to="/settings?tab=mcp" replace /> },
       { path: 'skills', element: page(() => import('../features/skills/SkillsPage'), 'SkillsPage') },

--- a/src/frontend/src/components/ui/Facepile.tsx
+++ b/src/frontend/src/components/ui/Facepile.tsx
@@ -1,0 +1,76 @@
+import { Avatar } from './Avatar';
+
+/* ============================================================
+   头像堆（facepile）：负 margin 叠放的小头像 + 超出部分 +N 圆片。
+   点赞区、成员列表等通用；数据由外部传入，本组件纯展示。
+   ============================================================ */
+
+export interface FacepileUser {
+  id: string;
+  display_name: string;
+  has_avatar: boolean;
+}
+
+const MAX_FACES = 4;
+
+export function Facepile({
+  users,
+  total,
+  size = 20,
+  accentFirst = false,
+}: {
+  users: FacepileUser[];
+  /** 总人数（含未在 users 预览里的），超出部分渲染 +N 圆片 */
+  total: number;
+  size?: number;
+  /** 第一个头像描边用 accent 高亮（如「我赞过」时自己排第一） */
+  accentFirst?: boolean;
+}) {
+  const shown = users.slice(0, MAX_FACES);
+  const rest = total - shown.length;
+  if (shown.length === 0) return null;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', paddingLeft: 6 }}>
+      {shown.map((u, i) => (
+        <span
+          key={u.id}
+          title={u.display_name}
+          style={{
+            marginLeft: -6,
+            zIndex: shown.length - i + 1,
+            borderRadius: Math.max(3, Math.round(size * 0.14)) + 2,
+            // 外圈描边分层：第一个（自己赞过时）用 accent 高亮
+            boxShadow: `0 0 0 2px ${i === 0 && accentFirst ? 'var(--accent)' : 'var(--surface)'}`,
+            display: 'flex',
+            flexShrink: 0,
+          }}
+        >
+          <Avatar userId={u.id} hasAvatar={u.has_avatar} name={u.display_name} size={size} />
+        </span>
+      ))}
+      {rest > 0 && (
+        <span
+          className="mono"
+          style={{
+            marginLeft: -6,
+            zIndex: 1,
+            width: size,
+            height: size,
+            borderRadius: Math.max(3, Math.round(size * 0.14)),
+            background: 'var(--surface-3)',
+            color: 'var(--text-3)',
+            fontSize: Math.max(8, Math.round(size * 0.42)),
+            fontWeight: 650,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 0 0 2px var(--surface)',
+            flexShrink: 0,
+          }}
+        >
+          +{rest}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/ui/Icon.tsx
+++ b/src/frontend/src/components/ui/Icon.tsx
@@ -7,7 +7,7 @@ export type IconName =
   | 'file' | 'git' | 'chart' | 'grid' | 'layers' | 'sparkle' | 'refresh'
   | 'logout' | 'dot' | 'compass' | 'users' | 'trash'
   | 'star' | 'starFill' | 'chat' | 'download' | 'sliders' | 'sidebar' | 'minus'
-  | 'pin' | 'share' | 'bookmark' | 'bookmarkFill';
+  | 'pin' | 'share' | 'bookmark' | 'bookmarkFill' | 'heart' | 'heartFill';
 
 export interface IconProps {
   name: IconName;
@@ -65,6 +65,8 @@ export function Icon({ name, size = 17, sw = 1.6, style }: IconProps) {
     compass: <><circle cx="12" cy="12" r="9" {...p} /><path d="M15.5 8.5l-2.2 5-4.8 2 2.2-5z" {...p} /></>,
     users: <><circle cx="9" cy="8" r="3.5" {...p} /><path d="M3 20c0-3.3 2.7-6 6-6s6 2.7 6 6" {...p} /><circle cx="17" cy="9" r="2.5" {...p} /><path d="M16.5 14.6c2.6.6 4.5 2.8 4.5 5.4" {...p} /></>,
     trash: <><path d="M4 7h16M10 7V4h4v3M6 7l1 13a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-13" {...p} /><path d="M10 11v7M14 11v7" {...p} /></>,
+    heart: <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" {...p} />,
+    heartFill: <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" fill="currentColor" stroke="currentColor" strokeWidth={sw} strokeLinejoin="round" />,
     bookmark: <path d="M7 3.5h10a1 1 0 0 1 1 1v16l-6-3.9-6 3.9v-16a1 1 0 0 1 1-1z" {...p} />,
     bookmarkFill: <path d="M7 3.5h10a1 1 0 0 1 1 1v16l-6-3.9-6 3.9v-16a1 1 0 0 1 1-1z" fill="currentColor" stroke="currentColor" strokeWidth={sw} strokeLinejoin="round" />,
     star: <path d="M12 3.5l2.6 5.4 5.9.8-4.3 4.1 1 5.9-5.2-2.8-5.2 2.8 1-5.9-4.3-4.1 5.9-.8z" {...p} />,

--- a/src/frontend/src/features/daily/CollectTreeModal.tsx
+++ b/src/frontend/src/features/daily/CollectTreeModal.tsx
@@ -1,0 +1,425 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Modal } from '../../components/ui/Modal';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import { api, type DailyCollectResponse } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { useProject } from '../../app/project';
+import { useLibraries } from '../libraries/hooks';
+import { SearchInput } from '../wiki/shared';
+
+/* ============================================================
+   「收进文献库」两级树弹窗（单篇入口）：
+   实验室文献库（可管理的方向库）/ 课题相关研究（我的课题）/ 个人库。
+   已收录目标预勾选 + 禁用；提交只发新增目标。
+   ============================================================ */
+
+export interface CollectPaperRef {
+  paper_id: string;
+  entry_id: string;
+  title: string;
+}
+
+type CheckState = 'none' | 'some' | 'all';
+
+/** 三态复选框（与 LibraryPicker 勾选框同款视觉；半选用减号）。 */
+function CheckBox({ state, disabled }: { state: CheckState; disabled?: boolean }) {
+  const on = state !== 'none';
+  return (
+    <span
+      style={{
+        width: 18,
+        height: 18,
+        borderRadius: 5,
+        flexShrink: 0,
+        border: on ? 'none' : '1.5px solid var(--border-strong)',
+        background: on ? (disabled ? 'var(--border-strong)' : 'var(--accent)') : 'transparent',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#fff',
+      }}
+    >
+      {state === 'all' && <Icon name="check" size={12} />}
+      {state === 'some' && <Icon name="minus" size={12} />}
+    </span>
+  );
+}
+
+/** 父节点行：展开三角 + 三态复选框 + 名称。 */
+function ParentRow({
+  label,
+  state,
+  expanded,
+  onToggleExpand,
+  onToggleCheck,
+  disabled,
+  tail,
+}: {
+  label: string;
+  state: CheckState;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+  onToggleCheck: () => void;
+  disabled?: boolean;
+  tail?: string;
+}) {
+  return (
+    <div className="row gap8" style={{ padding: '7px 6px', borderRadius: 8 }}>
+      {onToggleExpand ? (
+        <button
+          className="icon-btn"
+          style={{ width: 20, height: 20 }}
+          onClick={onToggleExpand}
+          aria-label={expanded ? tr('收起', 'Collapse') : tr('展开', 'Expand')}
+        >
+          <Icon name={expanded ? 'chevDown' : 'chevron'} size={12} style={{ color: 'var(--text-3)' }} />
+        </button>
+      ) : (
+        <span style={{ width: 20, flexShrink: 0 }} />
+      )}
+      <div
+        className="row gap8"
+        role="button"
+        tabIndex={0}
+        onClick={disabled ? undefined : onToggleCheck}
+        onKeyDown={(e) => {
+          if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            onToggleCheck();
+          }
+        }}
+        style={{ flex: 1, minWidth: 0, cursor: disabled ? 'default' : 'pointer', userSelect: 'none' }}
+      >
+        <CheckBox state={state} disabled={disabled} />
+        <span style={{ fontSize: 12.5, fontWeight: 680, color: 'var(--text)' }}>{label}</span>
+        {tail && (
+          <span style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 'auto', flexShrink: 0 }}>{tail}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 叶子行：复选框 + 名称（+ 已在库中尾注）。 */
+function LeafRow({
+  name,
+  checked,
+  disabled,
+  onToggle,
+}: {
+  name: string;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      className="row gap8"
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onClick={disabled ? undefined : onToggle}
+      onKeyDown={(e) => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+      style={{
+        padding: '6px 6px 6px 34px',
+        borderRadius: 8,
+        cursor: disabled ? 'default' : 'pointer',
+        userSelect: 'none',
+        opacity: disabled ? 0.62 : 1,
+        background: !disabled && checked ? 'var(--accent-soft)' : 'transparent',
+      }}
+      onMouseEnter={(e) => {
+        if (!disabled && !checked) e.currentTarget.style.background = 'var(--surface-2)';
+      }}
+      onMouseLeave={(e) => {
+        if (!disabled && !checked) e.currentTarget.style.background = 'transparent';
+      }}
+    >
+      <CheckBox state={checked || disabled ? 'all' : 'none'} disabled={disabled} />
+      <span
+        style={{
+          fontSize: 12.5,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          color: 'var(--text)',
+        }}
+        title={name}
+      >
+        {name}
+      </span>
+      {disabled && (
+        <span style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 'auto', flexShrink: 0 }}>
+          {tr('已在库中', 'Already added')}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** 组三态：disabled 的叶子视为已勾选但不计入 all/none 的可操作判断。 */
+function groupState(leafIds: string[], selected: Set<string>, disabledIds: Set<string>): CheckState {
+  if (leafIds.length === 0) return 'none';
+  const selectable = leafIds.filter((id) => !disabledIds.has(id));
+  const anyChecked = leafIds.some((id) => selected.has(id) || disabledIds.has(id));
+  if (selectable.length > 0 && selectable.every((id) => selected.has(id))) return 'all';
+  if (selectable.length === 0 && anyChecked) return 'all';
+  return anyChecked ? 'some' : 'none';
+}
+
+export function CollectTreeModal({
+  paper,
+  open,
+  onClose,
+}: {
+  paper: CollectPaperRef;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { projects } = useProject();
+
+  // 只展示可管理的方向库（无写权限的目标后端也会兜底 forbidden）
+  const libsQuery = useLibraries({ status: 'active' }, open);
+  const libraries = useMemo(
+    () => (libsQuery.data ?? []).filter((l) => l.can_manage),
+    [libsQuery.data],
+  );
+
+  const collectionsQuery = useQuery({
+    queryKey: ['daily-collections', paper.entry_id],
+    queryFn: () => api.getDailyCollections(paper.entry_id),
+    enabled: open,
+    retry: false,
+  });
+  const collections = collectionsQuery.data;
+
+  // —— 勾选态（sel 集合里只放新增目标，禁用项不入集合） ——
+  const [selLibs, setSelLibs] = useState<Set<string>>(new Set());
+  const [selTopics, setSelTopics] = useState<Set<string>>(new Set());
+  const [personal, setPersonal] = useState(false);
+  const [expandLibs, setExpandLibs] = useState(true);
+  const [expandTopics, setExpandTopics] = useState(true);
+  const [q, setQ] = useState('');
+
+  // 重开 / 换论文时重置
+  useEffect(() => {
+    if (!open) return;
+    setSelLibs(new Set());
+    setSelTopics(new Set());
+    setPersonal(false);
+    setExpandLibs(true);
+    setExpandTopics(true);
+    setQ('');
+  }, [open, paper.entry_id]);
+
+  const disabledLibs = useMemo(
+    () => new Set(collections?.direction_library_ids ?? []),
+    [collections],
+  );
+  const disabledTopics = useMemo(() => new Set(collections?.topic_ids ?? []), [collections]);
+  const personalDisabled = collections?.in_personal ?? false;
+
+  // —— 搜索过滤叶子（命中时父节点强制展开） ——
+  const needle = q.trim().toLowerCase();
+  const shownLibs = needle
+    ? libraries.filter((l) => l.name.toLowerCase().includes(needle))
+    : libraries;
+  const shownTopics = needle
+    ? projects.filter((p) => p.name.toLowerCase().includes(needle))
+    : projects;
+  const personalShown = !needle || tr('个人库', 'My library').toLowerCase().includes(needle);
+  const libsOpen = expandLibs || !!needle;
+  const topicsOpen = expandTopics || !!needle;
+
+  const toggleIn = (set: Set<string>, id: string): Set<string> => {
+    const next = new Set(set);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    return next;
+  };
+  /** 父节点点击：可选叶子全选 ↔ 全不选（作用于当前过滤后的可见叶子）。 */
+  const toggleGroup = (
+    leafIds: string[],
+    disabledIds: Set<string>,
+    set: Set<string>,
+    apply: (s: Set<string>) => void,
+  ) => {
+    const selectable = leafIds.filter((id) => !disabledIds.has(id));
+    if (selectable.length === 0) return;
+    const allOn = selectable.every((id) => set.has(id));
+    const next = new Set(set);
+    for (const id of selectable) {
+      if (allOn) next.delete(id);
+      else next.add(id);
+    }
+    apply(next);
+  };
+
+  const selectedCount = selLibs.size + selTopics.size + (personal ? 1 : 0);
+
+  const collectMutation = useMutation({
+    mutationFn: () =>
+      api.collectDaily({
+        paper_ids: [paper.paper_id],
+        direction_library_ids: [...selLibs],
+        topic_ids: [...selTopics],
+        personal,
+      }),
+    onSuccess: (resp: DailyCollectResponse) => {
+      const ok = resp.results.filter((r) => !r.forbidden && r.added > 0).length;
+      const skipped = resp.results.reduce((s, r) => s + r.skipped_existing, 0);
+      const forbidden = resp.results.some((r) => r.forbidden);
+      toast(
+        tr(
+          `已收进 ${ok} 个位置${skipped > 0 ? `（${skipped} 篇本来就在）` : ''}`,
+          `Added to ${ok} places${skipped > 0 ? ` (${skipped} already there)` : ''}`,
+        ),
+        'ok',
+      );
+      if (forbidden) {
+        toast(tr('部分目标无权限，已跳过', 'Some targets were skipped: no permission'), 'error');
+      }
+      void queryClient.invalidateQueries({ queryKey: ['daily-collections', paper.entry_id] });
+      onClose();
+    },
+    onError: (e) =>
+      toast(
+        `${tr('收录失败：', 'Failed to add: ')}${e instanceof Error ? e.message : String(e)}`,
+        'error',
+      ),
+  });
+
+  const libState = groupState(
+    shownLibs.map((l) => l.id),
+    selLibs,
+    disabledLibs,
+  );
+  const topicState = groupState(
+    shownTopics.map((p) => p.id),
+    selTopics,
+    disabledTopics,
+  );
+
+  const loading = libsQuery.isLoading || collectionsQuery.isLoading;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={
+        <>
+          <Icon name="book" size={16} style={{ color: 'var(--accent)' }} />
+          {tr('收进文献库', 'Add to libraries')}
+        </>
+      }
+      sub={paper.title}
+      width={520}
+      footer={
+        <>
+          <span style={{ marginRight: 'auto', fontSize: 11.5, color: 'var(--text-3)' }}>
+            {tr(`已选 ${selectedCount} 个位置`, `${selectedCount} destinations selected`)}
+          </span>
+          <button className="btn btn-ghost sm" onClick={onClose} disabled={collectMutation.isPending}>
+            {tr('取消', 'Cancel')}
+          </button>
+          <button
+            className="btn btn-primary sm"
+            disabled={selectedCount === 0 || collectMutation.isPending}
+            onClick={() => collectMutation.mutate()}
+          >
+            {collectMutation.isPending ? tr('收录中…', 'Adding…') : tr('确认收录', 'Add')}
+          </button>
+        </>
+      }
+    >
+      <div className="row gap8" style={{ marginBottom: 10 }}>
+        <SearchInput value={q} onChange={setQ} placeholder={tr('按名称过滤…', 'Filter by name…')} />
+      </div>
+
+      {loading ? (
+        <div className="empty" style={{ padding: 24 }}>
+          {tr('加载中…', 'Loading…')}
+        </div>
+      ) : (
+        <div className="col" style={{ gap: 2 }}>
+          {/* —— 实验室文献库 —— */}
+          <ParentRow
+            label={tr('实验室文献库', 'Shared libraries')}
+            state={libState}
+            expanded={libsOpen}
+            onToggleExpand={() => setExpandLibs((o) => !o)}
+            onToggleCheck={() =>
+              toggleGroup(shownLibs.map((l) => l.id), disabledLibs, selLibs, setSelLibs)
+            }
+            tail={tr(`${shownLibs.length} 个库`, `${shownLibs.length}`)}
+          />
+          {libsOpen &&
+            (shownLibs.length === 0 ? (
+              <div style={{ padding: '2px 6px 6px 34px', fontSize: 11.5, color: 'var(--text-4)' }}>
+                {needle
+                  ? tr('没有匹配的库', 'No matching library')
+                  : tr('没有你可以管理的方向库', 'No libraries you can manage')}
+              </div>
+            ) : (
+              shownLibs.map((l) => (
+                <LeafRow
+                  key={l.id}
+                  name={l.name}
+                  checked={selLibs.has(l.id)}
+                  disabled={disabledLibs.has(l.id)}
+                  onToggle={() => setSelLibs((s) => toggleIn(s, l.id))}
+                />
+              ))
+            ))}
+
+          {/* —— 课题相关研究 —— */}
+          <ParentRow
+            label={tr('课题相关研究', 'Topic related work')}
+            state={topicState}
+            expanded={topicsOpen}
+            onToggleExpand={() => setExpandTopics((o) => !o)}
+            onToggleCheck={() =>
+              toggleGroup(shownTopics.map((p) => p.id), disabledTopics, selTopics, setSelTopics)
+            }
+            tail={tr(`${shownTopics.length} 个课题`, `${shownTopics.length}`)}
+          />
+          {topicsOpen &&
+            (shownTopics.length === 0 ? (
+              <div style={{ padding: '2px 6px 6px 34px', fontSize: 11.5, color: 'var(--text-4)' }}>
+                {needle ? tr('没有匹配的课题', 'No matching topic') : tr('还没有课题', 'No topics yet')}
+              </div>
+            ) : (
+              shownTopics.map((p) => (
+                <LeafRow
+                  key={p.id}
+                  name={p.name}
+                  checked={selTopics.has(p.id)}
+                  disabled={disabledTopics.has(p.id)}
+                  onToggle={() => setSelTopics((s) => toggleIn(s, p.id))}
+                />
+              ))
+            ))}
+
+          {/* —— 个人库（父即叶） —— */}
+          {personalShown && (
+            <ParentRow
+              label={tr('个人库', 'My library')}
+              state={personal || personalDisabled ? 'all' : 'none'}
+              onToggleCheck={() => setPersonal((v) => !v)}
+              disabled={personalDisabled}
+              tail={personalDisabled ? tr('已在库中', 'Already added') : undefined}
+            />
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/daily/DailyChatTab.tsx
+++ b/src/frontend/src/features/daily/DailyChatTab.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Markdown } from '../../lib/markdown';
+import { chatDailySse } from '../../lib/sse';
+import { tr } from '../../lib/i18n';
+import { ChatSurface } from '../chat/ChatSurface';
+import { ChatFigure, SourceList, makeCitationRenderer } from '../chat/LiteratureChatSources';
+import type { ChatMsg } from '../chat/types';
+
+/* ============================================================
+   每日新论文池对话 Tab：就最近 7 天池内的每日新论文做问答，
+   不绑课题、不需要建索引。壳复用 ChatSurface，
+   接法与 PersonalChatTab（个人库对话）完全同构。
+   ============================================================ */
+
+const SUGGESTIONS: { zh: string; en: string }[] = [
+  {
+    zh: '最近 7 天有哪些值得关注的新论文？',
+    en: 'What notable new papers appeared in the last 7 days?',
+  },
+  {
+    zh: '帮我把这几天的新论文按主题大致归归类。',
+    en: 'Roughly group the recent new papers by theme.',
+  },
+  {
+    zh: '这几天有没有和大模型智能体相关的新工作？',
+    en: 'Any new work related to LLM agents in the last few days?',
+  },
+];
+
+export function DailyChatTab() {
+  const navigate = useNavigate();
+  const openPaper = useCallback((id: string) => navigate(`/papers/${id}/read`), [navigate]);
+  const citationRenderer = useMemo(() => makeCitationRenderer(openPaper), [openPaper]);
+
+  const stream = useCallback(
+    (
+      args: { question: string; history: { role: 'user' | 'assistant'; content: string }[] },
+      ctrl: {
+        onDelta: (t: string) => void;
+        onSources?: (s: string) => void;
+        onDone: () => void;
+        onError: (d: string) => void;
+      },
+    ) =>
+      chatDailySse({ question: args.question, history: args.history }, {
+        onEvent: (event, dataStr) => {
+          if (event === 'sources') ctrl.onSources?.(dataStr);
+          else if (event === 'delta') {
+            try {
+              const t = (JSON.parse(dataStr) as { text?: string }).text ?? '';
+              if (t) ctrl.onDelta(t);
+            } catch {
+              /* ignore */
+            }
+          } else if (event === 'done') ctrl.onDone();
+          else if (event === 'error') {
+            let detail = tr('服务端出错', 'Server error');
+            try {
+              detail = (JSON.parse(dataStr) as { detail?: string }).detail ?? detail;
+            } catch {
+              /* keep */
+            }
+            ctrl.onError(detail);
+          }
+        },
+        onClose: () => ctrl.onDone(),
+        onError: (err) => ctrl.onError(err instanceof Error ? err.message : String(err)),
+      }),
+    [],
+  );
+
+  return (
+    <ChatSurface
+      surfaceKey="daily"
+      pid=""
+      title={tr('每日新论文对话', 'Daily papers chat')}
+      contextKinds={[]}
+      hint={tr(
+        '对最近 7 天的每日新论文提问；[n] 为引用来源编号。',
+        'Ask about the last 7 days of daily papers. [n] marks a source number.',
+      )}
+      emptyIcon="chat"
+      emptyTitle={tr('和最近的新论文对话', 'Chat with the latest papers')}
+      emptyDesc={tr(
+        '就池里最近 7 天的每日新论文提问：找热点、比方法、挑值得细读的都行。',
+        'Ask about the daily papers from the last 7 days — spot trends, compare methods, pick what to read.',
+      )}
+      suggestions={SUGGESTIONS}
+      placeholder={tr('就最近 7 天的新论文提问…', 'Ask about the last 7 days of new papers…')}
+      renderAssistant={(m: ChatMsg) => (
+        <Markdown
+          source={m.content}
+          style={{ fontSize: 12.5 }}
+          renderCitation={citationRenderer(m.sources)}
+          renderLibraryFigure={(paperId, index) => (
+            <ChatFigure paperId={paperId} index={index} onOpenPaper={openPaper} />
+          )}
+        />
+      )}
+      assistantExtras={(m: ChatMsg) =>
+        (m.sources?.length ?? 0) > 0 && (m.done || m.content) ? (
+          <SourceList sources={m.sources ?? []} onOpenPaper={openPaper} />
+        ) : null
+      }
+      stream={stream}
+    />
+  );
+}

--- a/src/frontend/src/features/daily/DailyLikes.tsx
+++ b/src/frontend/src/features/daily/DailyLikes.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Avatar } from '../../components/ui/Avatar';
+import { Facepile } from '../../components/ui/Facepile';
+import {
+  api,
+  type DailyLiker,
+  type DailyLikeState,
+  type DailyPage,
+  type DailyPaperDetail,
+  type DailyPaperItem,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   每日新论文的行内点赞区：[♥] [头像堆] [+N] [数字]。
+   - 点击爱心乐观更新（翻转 liked_by_me、count±1、头像堆增删自己）；
+   - 悬停头像堆 ~300ms 弹出完整点赞名单（懒加载）；
+   - like_count=0 时只渲染灰爱心 + 0，行高不抖动。
+   ============================================================ */
+
+// 点赞爱心的红色（各端点赞通用色，刻意不随主题变化的局部常量）
+const HEART_RED = '#e0245e';
+
+const POPOVER_W = 208;
+
+/** 把点赞汇总写回所有相关缓存（列表分页 / 我赞过的 / 详情）。 */
+function applyLikeState(qc: QueryClient, state: DailyLikeState) {
+  const patch = (it: DailyPaperItem): DailyPaperItem =>
+    it.entry_id === state.entry_id
+      ? {
+          ...it,
+          like_count: state.like_count,
+          liked_by_me: state.liked_by_me,
+          likers_preview: state.likers_preview,
+        }
+      : it;
+  const patchPage = (old: DailyPage | undefined): DailyPage | undefined =>
+    old ? { ...old, items: old.items.map(patch) } : old;
+  qc.setQueriesData<DailyPage>({ queryKey: ['daily-papers'] }, patchPage);
+  qc.setQueriesData<DailyPage>({ queryKey: ['daily-liked'] }, patchPage);
+  qc.setQueriesData<DailyPaperDetail>({ queryKey: ['daily-paper', state.entry_id] }, (old) =>
+    old
+      ? {
+          ...old,
+          like_count: state.like_count,
+          liked_by_me: state.liked_by_me,
+          likers_preview: state.likers_preview,
+        }
+      : old,
+  );
+}
+
+export function DailyLikes({ item }: { item: DailyPaperItem }) {
+  const qc = useQueryClient();
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: () => api.me(),
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  // 点赞瞬间爱心弹跳：key 换新触发 CSS 动画重放，不影响布局
+  const [popKey, setPopKey] = useState(0);
+
+  const likeMutation = useMutation({
+    mutationFn: (liked: boolean) =>
+      liked ? api.likeDailyPaper(item.entry_id) : api.unlikeDailyPaper(item.entry_id),
+    onMutate: (liked) => {
+      // 乐观更新：立即翻转状态；自己的头像插到堆头部 / 从堆里移除
+      let preview = item.likers_preview.filter((u) => u.id !== me?.id);
+      if (liked && me) {
+        const meLiker: DailyLiker = {
+          id: me.id,
+          display_name: me.display_name ?? me.email.split('@')[0] ?? '',
+          has_avatar: me.has_avatar ?? false,
+        };
+        preview = [meLiker, ...preview].slice(0, 5);
+      }
+      applyLikeState(qc, {
+        entry_id: item.entry_id,
+        like_count: Math.max(0, item.like_count + (liked ? 1 : -1)),
+        liked_by_me: liked,
+        likers_preview: preview,
+      });
+    },
+    onSuccess: (state) => applyLikeState(qc, state),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ['daily-papers'] });
+      void qc.invalidateQueries({ queryKey: ['daily-liked'] });
+      void qc.invalidateQueries({ queryKey: ['daily-likers', item.entry_id] });
+    },
+  });
+
+  // —— 悬停头像堆 → 延迟弹出完整名单 ——
+  const [hovered, setHovered] = useState(false);
+  const [anchor, setAnchor] = useState<{ top: number; bottom: number; right: number } | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (openTimer.current) window.clearTimeout(openTimer.current);
+      if (closeTimer.current) window.clearTimeout(closeTimer.current);
+    },
+    [],
+  );
+
+  const onEnter = () => {
+    if (closeTimer.current) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    if (hovered || openTimer.current) return;
+    openTimer.current = window.setTimeout(() => {
+      openTimer.current = null;
+      const r = wrapRef.current?.getBoundingClientRect();
+      if (r) setAnchor({ top: r.top, bottom: r.bottom, right: r.right });
+      setHovered(true);
+    }, 300);
+  };
+  const onLeave = () => {
+    if (openTimer.current) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    // 稍作延迟：从头像堆滑进弹层的途中不立即关闭
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      setHovered(false);
+    }, 180);
+  };
+
+  const likersQuery = useQuery({
+    queryKey: ['daily-likers', item.entry_id],
+    queryFn: () => api.listDailyLikers(item.entry_id),
+    enabled: hovered && item.like_count > 0,
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const toggle = () => {
+    const next = !item.liked_by_me;
+    if (next) setPopKey((k) => k + 1);
+    likeMutation.mutate(next);
+  };
+
+  // 弹层放行上方；贴近视口顶部时改放下方
+  const below = anchor !== null && anchor.top < 240;
+
+  return (
+    <div
+      className="row"
+      style={{ gap: 5, flexShrink: 0 }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        className="icon-btn"
+        style={{ width: 24, height: 24 }}
+        title={item.liked_by_me ? tr('取消点赞', 'Unlike') : tr('点赞', 'Like')}
+        onClick={toggle}
+      >
+        <span key={popKey} className={popKey > 0 ? 'heart-pop' : undefined} style={{ display: 'flex' }}>
+          <Icon
+            name={item.liked_by_me ? 'heartFill' : 'heart'}
+            size={15}
+            style={{ color: item.liked_by_me ? HEART_RED : 'var(--text-4)' }}
+          />
+        </span>
+      </button>
+
+      {item.like_count > 0 && item.likers_preview.length > 0 && (
+        <div
+          ref={wrapRef}
+          onMouseEnter={onEnter}
+          onMouseLeave={onLeave}
+          style={{ display: 'flex', position: 'relative' }}
+        >
+          <Facepile
+            users={item.likers_preview}
+            total={item.like_count}
+            size={20}
+            accentFirst={item.liked_by_me}
+          />
+
+          {hovered && anchor && (
+            <div
+              className="card"
+              style={{
+                position: 'fixed',
+                zIndex: 60,
+                width: POPOVER_W,
+                padding: '8px 0 6px',
+                boxShadow: 'var(--shadow-pop)',
+                left: Math.max(8, anchor.right - POPOVER_W),
+                ...(below
+                  ? { top: anchor.bottom + 6 }
+                  : { bottom: window.innerHeight - anchor.top + 6 }),
+                animation: 'fadeUp 0.12s ease',
+              }}
+            >
+              <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', padding: '0 12px 6px' }}>
+                {tr(`${item.like_count} 人点了赞`, `${item.like_count} likes`)}
+              </div>
+              <div className="scroll" style={{ maxHeight: 12 * 26, overflowY: 'auto' }}>
+                {likersQuery.isLoading ? (
+                  <div style={{ padding: '5px 12px', fontSize: 11.5, color: 'var(--text-4)' }}>
+                    {tr('加载中…', 'Loading…')}
+                  </div>
+                ) : likersQuery.isError ? (
+                  <div style={{ padding: '5px 12px', fontSize: 11.5, color: 'var(--text-4)' }}>
+                    {tr('名单加载失败', 'Failed to load')}
+                  </div>
+                ) : (
+                  (likersQuery.data ?? []).map((u) => (
+                    <div key={u.id} className="row gap8" style={{ padding: '5px 12px' }}>
+                      <Avatar userId={u.id} hasAvatar={u.has_avatar} name={u.display_name} size={16} />
+                      <span
+                        style={{
+                          fontSize: 12,
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          color: u.id === me?.id ? 'var(--accent-text)' : 'var(--text)',
+                          fontWeight: u.id === me?.id ? 650 : 450,
+                        }}
+                      >
+                        {u.display_name}
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <span
+        className="mono"
+        style={{
+          fontSize: 11,
+          color: item.like_count > 0 ? 'var(--text-3)' : 'var(--text-4)',
+          minWidth: 14,
+        }}
+      >
+        {item.like_count}
+      </span>
+    </div>
+  );
+}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -1,13 +1,17 @@
 import { Fragment, useEffect, useState } from 'react';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { api, type DailyPaperItem, type DailySort } from '../../lib/api';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { ApiError, api, type DailyPaperItem, type DailySort } from '../../lib/api';
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
+import { Markdown } from '../../lib/markdown';
 import { SearchInput, useDebounced } from '../wiki/shared';
 import { DailyLikes } from './DailyLikes';
+import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
 
 /* ============================================================
@@ -35,6 +39,25 @@ function authorsBrief(p: DailyPaperItem): string {
   const names = p.authors.map((a) => a.name).filter(Boolean);
   if (names.length === 0) return '';
   return names.length > 3 ? `${names.slice(0, 3).join(', ')} et al.` : names.join(', ');
+}
+
+/** 类型徽标：new=绿色 NEW；cross=「更新」（保持原角标样式，仅换文案）。 */
+function AnnounceBadge({ type }: { type: DailyPaperItem['announce_type'] }) {
+  if (type === 'new') {
+    return (
+      <span
+        className="pill sm"
+        style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)', fontWeight: 700, letterSpacing: '0.05em', flexShrink: 0 }}
+      >
+        NEW
+      </span>
+    );
+  }
+  return (
+    <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', flexShrink: 0 }}>
+      {tr('更新', 'Updated')}
+    </span>
+  );
 }
 
 function DailyRow({
@@ -65,20 +88,21 @@ function DailyRow({
             <span className="pill sm mono" style={{ background: 'var(--surface-3)', flexShrink: 0 }}>
               {p.primary_category}
             </span>
-            {p.announce_type === 'cross' && (
-              <span
-                className="pill sm"
-                style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', flexShrink: 0 }}
-              >
-                {tr('转投', 'cross')}
-              </span>
-            )}
+            <AnnounceBadge type={p.announce_type} />
             <span
               style={{ flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
               title={p.authors.map((a) => a.name).join(', ')}
             >
               {authorsBrief(p)}
             </span>
+            {p.has_wiki && (
+              <span
+                title={tr('已有 AI 解读', 'AI summary available')}
+                style={{ display: 'inline-flex', color: 'var(--accent)', flexShrink: 0 }}
+              >
+                <Icon name="file" size={11} />
+              </span>
+            )}
           </div>
         </div>
         {/* 行右侧点赞区：[♥][头像堆][+N][数字] */}
@@ -97,10 +121,29 @@ function DailyDetailPane({
   entryId: string;
   onCollect: (p: CollectPaperRef) => void;
 }) {
+  const queryClient = useQueryClient();
   const { data: paper, isLoading, isError } = useQuery({
     queryKey: ['daily-paper', entryId],
     queryFn: () => api.getDailyPaper(entryId),
     retry: false,
+  });
+
+  // 单篇 AI 解读编译：同步等待（约半分钟）；409 = 已有人在编译
+  const compileMutation = useMutation({
+    mutationFn: () => api.compileDailyPaper(entryId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+      void queryClient.invalidateQueries({ queryKey: ['daily-papers'] }); // 列表行的 has_wiki 标记
+      void queryClient.invalidateQueries({ queryKey: ['daily-liked'] });
+    },
+    onError: (e) => {
+      if (e instanceof ApiError && e.status === 409) {
+        toast(tr('已有人在生成，稍后刷新即可', 'Someone is already generating it, refresh later'), 'info');
+        void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+      } else {
+        toast(`${tr('生成解读失败', 'Failed to generate summary')}：${e instanceof Error ? e.message : String(e)}`, 'error');
+      }
+    },
   });
 
   if (isLoading) return <div className="empty">{tr('加载论文详情…', 'Loading paper…')}</div>;
@@ -125,11 +168,7 @@ function DailyDetailPane({
             {c}
           </span>
         ))}
-        {paper.announce_type === 'cross' && (
-          <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
-            {tr('转投', 'cross')}
-          </span>
-        )}
+        <AnnounceBadge type={paper.announce_type} />
         {paper.arxiv_id && (
           <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
             arXiv:{paper.arxiv_id}
@@ -176,20 +215,64 @@ function DailyDetailPane({
       ) : (
         <div className="empty" style={{ padding: 20 }}>{tr('这篇还没有摘要。', 'No abstract for this paper.')}</div>
       )}
+
+      {/* —— AI 解读：有内容直接渲染；没有则给「生成」按钮（同步编译约半分钟） —— */}
+      {paper.wiki_content ? (
+        <div className="card card-pad" style={{ background: 'var(--surface-2)', marginTop: 14 }}>
+          <div className="row gap8" style={{ marginBottom: 8 }}>
+            <Icon name="sparkle" size={14} style={{ color: 'var(--accent)' }} />
+            <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('AI 解读', 'AI summary')}</span>
+          </div>
+          <Markdown source={paper.wiki_content} style={{ fontSize: 13 }} />
+        </div>
+      ) : (
+        <div className="row gap10" style={{ marginTop: 14 }}>
+          <button
+            className="btn btn-soft sm"
+            disabled={compileMutation.isPending}
+            onClick={() => compileMutation.mutate()}
+          >
+            {compileMutation.isPending ? (
+              <>
+                <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
+                {tr('生成中…', 'Generating…')}
+              </>
+            ) : (
+              <>
+                <Icon name="sparkle" size={13} />
+                {tr('生成解读', 'Generate summary')}
+              </>
+            )}
+          </button>
+          {compileMutation.isPending && (
+            <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+              {tr('大约需要半分钟', 'Takes about half a minute')}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
+type DailyView = 'papers' | 'chat';
+type AnnounceFilter = 'all' | 'new' | 'cross';
+
 export function DailyPage() {
+  const [view, setView] = useState<DailyView>('papers');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
   const [sort, setSort] = useState<DailySort>('likes');
   const [page, setPage] = useState(1);
+  // —— 高级过滤：日期（null=全部 7 天）/ 订阅分类（''=全部）/ 类型 ——
+  const [day, setDay] = useState<string | null>(null);
+  const [category, setCategory] = useState('');
+  const [announce, setAnnounce] = useState<AnnounceFilter>('all');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
 
-  useEffect(() => setPage(1), [q, sort]);
+  useEffect(() => setPage(1), [q, sort, day, category, announce]);
 
   const daysQuery = useQuery({
     queryKey: ['daily-days'],
@@ -199,6 +282,21 @@ export function DailyPage() {
   });
   const dayCount = new Map((daysQuery.data ?? []).map((d) => [d.date, d.count] as const));
 
+  // 有数据的日期，升序（旧 → 新），日期步进只在这些日期间跳
+  const dates = (daysQuery.data ?? []).map((d) => d.date).sort();
+  const dayIdx = day ? dates.indexOf(day) : -1;
+  // 「全部」视为最新一天的后一位：← 从全部进入最新一天；→ 在最新一天回到全部
+  const canPrevDay = dates.length > 0 && (day === null || dayIdx > 0);
+  const canNextDay = day !== null && dayIdx >= 0;
+  const goPrevDay = () => {
+    if (day === null) setDay(dates[dates.length - 1] ?? null);
+    else if (dayIdx > 0) setDay(dates[dayIdx - 1] ?? null);
+  };
+  const goNextDay = () => {
+    if (day === null) return;
+    setDay(dayIdx >= 0 && dayIdx < dates.length - 1 ? (dates[dayIdx + 1] ?? null) : null);
+  };
+
   const categoriesQuery = useQuery({
     queryKey: ['daily-categories'],
     queryFn: () => api.getDailyCategories(),
@@ -207,11 +305,21 @@ export function DailyPage() {
   });
 
   const listQuery = useQuery({
-    queryKey: ['daily-papers', sort, page, q],
-    queryFn: () => api.listDailyPapers({ sort, page, size: PAGE_SIZE, q: q || undefined }),
+    queryKey: ['daily-papers', sort, page, q, day, category, announce],
+    queryFn: () =>
+      api.listDailyPapers({
+        sort,
+        page,
+        size: PAGE_SIZE,
+        q: q || undefined,
+        date: day ?? undefined,
+        category: category || undefined,
+        announce: announce === 'all' ? undefined : announce,
+      }),
     retry: false,
     placeholderData: keepPreviousData,
   });
+  const filtered = !!q || day !== null || !!category || announce !== 'all';
   const items = listQuery.data?.items ?? [];
   const total = listQuery.data?.total ?? 0;
   const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -250,10 +358,25 @@ export function DailyPage() {
         }
       />
 
+      <div className="row" style={{ marginBottom: 14 }}>
+        <Segmented<DailyView>
+          options={[
+            { v: 'papers', label: tr('论文', 'Papers') },
+            { v: 'chat', label: tr('对话', 'Chat') },
+          ]}
+          value={view}
+          onChange={setView}
+        />
+      </div>
+
       <div
         className="card"
         style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
       >
+        {view === 'chat' ? (
+          /* ======== 池对话：就最近 7 天的每日新论文问答 ======== */
+          <DailyChatTab />
+        ) : (
         <div className="split">
           {/* —— 左：按日期分组的列表 —— */}
           <div className="split-list">
@@ -268,13 +391,64 @@ export function DailyPage() {
                   {total ? tr(`${total} 篇`, `${total}`) : ''}
                 </span>
               </div>
-              <div className="row gap6" style={{ marginTop: 10 }}>
+              <div className="row gap6 wrap" style={{ marginTop: 10 }}>
                 <span className={`chip${sort === 'likes' ? ' on' : ''}`} onClick={() => setSort('likes')}>
                   {tr('按点赞', 'Most liked')}
                 </span>
                 <span className={`chip${sort === 'date' ? ' on' : ''}`} onClick={() => setSort('date')}>
                   {tr('按时间', 'Newest')}
                 </span>
+                <span style={{ width: 1, height: 14, background: 'var(--border)', margin: '0 3px', flexShrink: 0 }} />
+                {/* 类型筛选：全部 / 新工作(new) / 更新(cross) */}
+                <span className={`chip${announce === 'all' ? ' on' : ''}`} onClick={() => setAnnounce('all')}>
+                  {tr('全部', 'All')}
+                </span>
+                <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
+                  {tr('新工作', 'New')}
+                </span>
+                <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
+                  {tr('更新', 'Updated')}
+                </span>
+              </div>
+              {/* —— 日期步进 + 订阅分类下拉 —— */}
+              <div className="row gap6 wrap" style={{ marginTop: 8 }}>
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
+                  disabled={!canPrevDay}
+                  onClick={goPrevDay}
+                >
+                  ‹ {tr('前一天', 'Prev day')}
+                </button>
+                <span
+                  className={`chip${day !== null ? ' on' : ''}`}
+                  title={day !== null ? tr('点击回到全部 7 天', 'Click to show all 7 days') : undefined}
+                  onClick={() => setDay(null)}
+                >
+                  {day !== null ? dayLabel(day, dayCount.get(day)) : tr('全部 7 天', 'All 7 days')}
+                </span>
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
+                  disabled={!canNextDay}
+                  onClick={goNextDay}
+                >
+                  {tr('后一天', 'Next day')} ›
+                </button>
+                <div style={{ flex: 1 }} />
+                <select
+                  className="input mono"
+                  style={{ height: 24, fontSize: 11, padding: '0 4px', maxWidth: 128, flexShrink: 0 }}
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                >
+                  <option value="">{tr('全部分类', 'All categories')}</option>
+                  {(categoriesQuery.data?.categories ?? []).map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
 
@@ -292,10 +466,10 @@ export function DailyPage() {
                 <EmptyState
                   compact
                   icon="book"
-                  title={q ? tr('没有匹配的论文', 'No matching papers') : tr('今天还没有新论文', 'No new papers yet')}
+                  title={filtered ? tr('没有匹配的论文', 'No matching papers') : tr('今天还没有新论文', 'No new papers yet')}
                   desc={
-                    q
-                      ? tr('换个关键词试试。', 'Try a different keyword.')
+                    filtered
+                      ? tr('换个关键词或过滤条件试试。', 'Try a different keyword or filter.')
                       : tr(
                           '今天还没有新论文。arxiv 周末不发布新提交。',
                           'No new papers yet. arxiv does not announce on weekends.',
@@ -362,6 +536,7 @@ export function DailyPage() {
             )}
           </div>
         </div>
+        )}
       </div>
 
       {collectPaper && (

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -1,0 +1,372 @@
+import { Fragment, useEffect, useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { PageHead } from '../../components/ui/PageHead';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { api, type DailyPaperItem, type DailySort } from '../../lib/api';
+import { fmtTime } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+import { SearchInput, useDebounced } from '../wiki/shared';
+import { DailyLikes } from './DailyLikes';
+import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
+
+/* ============================================================
+   /daily — 每日新论文：arxiv 每日新提交（订阅分类内），保留最近 7 天。
+   双栏主从布局对齐共享库浏览（LibraryBrowse）：
+   左栏按日期分组的列表（排序 / 搜索 / 分页 / 行内点赞），右栏选中论文详情。
+   ============================================================ */
+
+const PAGE_SIZE = 20;
+
+const EN_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** 'YYYY-MM-DD' → 「7月24日 · 32 篇」/ "Jul 24 · 32 papers"（count 未知时只显示日期）。 */
+function dayLabel(iso: string, count: number | undefined): string {
+  const parts = iso.split('-');
+  const m = Number(parts[1] ?? 0);
+  const d = Number(parts[2] ?? 0);
+  const en = `${EN_MONTHS[m - 1] ?? iso} ${d}`;
+  if (count === undefined) return tr(`${m}月${d}日`, en);
+  return tr(`${m}月${d}日 · ${count} 篇`, `${en} · ${count} papers`);
+}
+
+/** 作者行：前 3 名 + et al。 */
+function authorsBrief(p: DailyPaperItem): string {
+  const names = p.authors.map((a) => a.name).filter(Boolean);
+  if (names.length === 0) return '';
+  return names.length > 3 ? `${names.slice(0, 3).join(', ')} et al.` : names.join(', ');
+}
+
+function DailyRow({
+  p,
+  active,
+  onClick,
+}: {
+  p: DailyPaperItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        padding: '11px 14px 11px 16px',
+        cursor: 'pointer',
+        borderBottom: '0.5px solid var(--border)',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        borderLeft: active ? '2px solid var(--accent)' : '2px solid transparent',
+        transition: 'background 0.12s',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
+          <div className="row gap8" style={{ marginTop: 5, fontSize: 11, color: 'var(--text-3)' }}>
+            <span className="pill sm mono" style={{ background: 'var(--surface-3)', flexShrink: 0 }}>
+              {p.primary_category}
+            </span>
+            {p.announce_type === 'cross' && (
+              <span
+                className="pill sm"
+                style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', flexShrink: 0 }}
+              >
+                {tr('转投', 'cross')}
+              </span>
+            )}
+            <span
+              style={{ flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+              title={p.authors.map((a) => a.name).join(', ')}
+            >
+              {authorsBrief(p)}
+            </span>
+          </div>
+        </div>
+        {/* 行右侧点赞区：[♥][头像堆][+N][数字] */}
+        <div style={{ paddingTop: 1 }}>
+          <DailyLikes item={p} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DailyDetailPane({
+  entryId,
+  onCollect,
+}: {
+  entryId: string;
+  onCollect: (p: CollectPaperRef) => void;
+}) {
+  const { data: paper, isLoading, isError } = useQuery({
+    queryKey: ['daily-paper', entryId],
+    queryFn: () => api.getDailyPaper(entryId),
+    retry: false,
+  });
+
+  if (isLoading) return <div className="empty">{tr('加载论文详情…', 'Loading paper…')}</div>;
+  if (isError || !paper) {
+    return (
+      <EmptyState
+        compact
+        icon="x"
+        title={tr('无法加载论文详情', 'Failed to load paper')}
+        desc={tr('后端不可用或该论文已过期。', 'Backend unavailable or the paper has expired.')}
+      />
+    );
+  }
+
+  const authors = paper.authors.map((a) => a.name).filter(Boolean).join(', ');
+
+  return (
+    <div className="scroll fadeup" key={paper.entry_id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
+      <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
+        {[paper.primary_category, ...paper.categories.filter((c) => c !== paper.primary_category)].map((c) => (
+          <span key={c} className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
+            {c}
+          </span>
+        ))}
+        {paper.announce_type === 'cross' && (
+          <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
+            {tr('转投', 'cross')}
+          </span>
+        )}
+        {paper.arxiv_id && (
+          <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
+            arXiv:{paper.arxiv_id}
+          </span>
+        )}
+      </div>
+
+      <h1 style={{ fontSize: 21, fontWeight: 680, lineHeight: 1.3, margin: '2px 0 6px', letterSpacing: '-0.01em' }}>
+        {paper.url ? (
+          <a href={paper.url} target="_blank" rel="noreferrer" style={{ color: 'inherit' }}>
+            {paper.title}
+            <Icon name="link" size={14} style={{ display: 'inline-block', marginLeft: 6, verticalAlign: 'baseline', color: 'var(--text-3)' }} />
+          </a>
+        ) : (
+          paper.title
+        )}
+      </h1>
+      {authors && <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 6 }}>{authors}</div>}
+      {paper.published_at && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-4)', marginBottom: 14 }}>
+          {tr('发布于', 'Published')} {fmtTime(paper.published_at)}
+        </div>
+      )}
+
+      <div className="row gap8" style={{ marginBottom: 18 }}>
+        <button
+          className="btn btn-primary sm"
+          onClick={() => onCollect({ paper_id: paper.paper_id, entry_id: paper.entry_id, title: paper.title })}
+        >
+          <Icon name="plus" size={13} />
+          {tr('收进文献库', 'Add to libraries')}
+        </button>
+        <DailyLikes item={paper} />
+      </div>
+
+      {paper.abstract ? (
+        <div className="card card-pad" style={{ background: 'var(--surface-2)' }}>
+          <div className="row gap8" style={{ marginBottom: 8 }}>
+            <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
+            <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
+          </div>
+          <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
+        </div>
+      ) : (
+        <div className="empty" style={{ padding: 20 }}>{tr('这篇还没有摘要。', 'No abstract for this paper.')}</div>
+      )}
+    </div>
+  );
+}
+
+export function DailyPage() {
+  const [qInput, setQInput] = useState('');
+  const q = useDebounced(qInput.trim());
+  const [sort, setSort] = useState<DailySort>('likes');
+  const [page, setPage] = useState(1);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
+  const [collectOpen, setCollectOpen] = useState(false);
+
+  useEffect(() => setPage(1), [q, sort]);
+
+  const daysQuery = useQuery({
+    queryKey: ['daily-days'],
+    queryFn: () => api.listDailyDays(),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const dayCount = new Map((daysQuery.data ?? []).map((d) => [d.date, d.count] as const));
+
+  const categoriesQuery = useQuery({
+    queryKey: ['daily-categories'],
+    queryFn: () => api.getDailyCategories(),
+    retry: false,
+    staleTime: 300_000,
+  });
+
+  const listQuery = useQuery({
+    queryKey: ['daily-papers', sort, page, q],
+    queryFn: () => api.listDailyPapers({ sort, page, size: PAGE_SIZE, q: q || undefined }),
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+  const items = listQuery.data?.items ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // 首条自动选中
+  const firstId = items[0]?.entry_id ?? null;
+  useEffect(() => {
+    if (!selectedId && firstId) setSelectedId(firstId);
+  }, [selectedId, firstId]);
+
+  const openCollect = (p: CollectPaperRef) => {
+    setCollectPaper(p);
+    setCollectOpen(true);
+  };
+
+  return (
+    <div
+      className="page fadeup"
+      style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}
+    >
+      <PageHead
+        eyebrow="Polaris · Daily Papers"
+        title={tr('每日新论文', 'Daily Papers')}
+        sub={tr('arxiv 每日新提交，保留最近 7 天', 'New arxiv submissions, kept for the last 7 days')}
+        right={
+          (categoriesQuery.data?.categories.length ?? 0) > 0 ? (
+            <div className="row gap6 wrap" style={{ justifyContent: 'flex-end', maxWidth: 420 }}>
+              <span style={{ fontSize: 11, color: 'var(--text-4)' }}>{tr('订阅分类', 'Subscribed')}</span>
+              {categoriesQuery.data?.categories.map((c) => (
+                <span key={c} className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
+                  {c}
+                </span>
+              ))}
+            </div>
+          ) : undefined
+        }
+      />
+
+      <div
+        className="card"
+        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+      >
+        <div className="split">
+          {/* —— 左：按日期分组的列表 —— */}
+          <div className="split-list">
+            <div style={{ padding: '12px 14px 10px', borderBottom: '0.5px solid var(--border)' }}>
+              <div className="row gap8">
+                <SearchInput
+                  value={qInput}
+                  onChange={setQInput}
+                  placeholder={tr('搜标题 / 摘要 / 作者…', 'Search title / abstract / authors…')}
+                />
+                <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
+                  {total ? tr(`${total} 篇`, `${total}`) : ''}
+                </span>
+              </div>
+              <div className="row gap6" style={{ marginTop: 10 }}>
+                <span className={`chip${sort === 'likes' ? ' on' : ''}`} onClick={() => setSort('likes')}>
+                  {tr('按点赞', 'Most liked')}
+                </span>
+                <span className={`chip${sort === 'date' ? ' on' : ''}`} onClick={() => setSort('date')}>
+                  {tr('按时间', 'Newest')}
+                </span>
+              </div>
+            </div>
+
+            <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>
+              {listQuery.isLoading ? (
+                <div className="empty">{tr('加载论文…', 'Loading papers…')}</div>
+              ) : listQuery.isError ? (
+                <EmptyState
+                  compact
+                  icon="x"
+                  title={tr('无法加载每日新论文', 'Failed to load daily papers')}
+                  desc={tr('后端不可用或接口尚未就绪，稍后重试。', 'Backend unavailable — try again later.')}
+                />
+              ) : items.length === 0 ? (
+                <EmptyState
+                  compact
+                  icon="book"
+                  title={q ? tr('没有匹配的论文', 'No matching papers') : tr('今天还没有新论文', 'No new papers yet')}
+                  desc={
+                    q
+                      ? tr('换个关键词试试。', 'Try a different keyword.')
+                      : tr(
+                          '今天还没有新论文。arxiv 周末不发布新提交。',
+                          'No new papers yet. arxiv does not announce on weekends.',
+                        )
+                  }
+                />
+              ) : (
+                items.map((p, i) => {
+                  // 与上一条日期不同 → 插入粘性日期头
+                  const prev = items[i - 1];
+                  const newDay = i === 0 || prev?.feed_date !== p.feed_date;
+                  return (
+                    <Fragment key={p.entry_id}>
+                      {newDay && (
+                        <div
+                          style={{
+                            position: 'sticky',
+                            top: 0,
+                            zIndex: 3,
+                            padding: '6px 16px',
+                            fontSize: 11,
+                            fontWeight: 700,
+                            color: 'var(--text-3)',
+                            background: 'var(--surface-2)',
+                            borderBottom: '0.5px solid var(--border)',
+                          }}
+                        >
+                          {dayLabel(p.feed_date, dayCount.get(p.feed_date))}
+                        </div>
+                      )}
+                      <DailyRow p={p} active={p.entry_id === selectedId} onClick={() => setSelectedId(p.entry_id)} />
+                    </Fragment>
+                  );
+                })
+              )}
+            </div>
+
+            {pages > 1 && (
+              <div
+                className="row gap8"
+                style={{ padding: '8px 14px', borderTop: '0.5px solid var(--border)', justifyContent: 'center' }}
+              >
+                <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((x) => x - 1)}>
+                  {tr('上一页', 'Prev')}
+                </button>
+                <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                  {page} / {pages}
+                </span>
+                <button className="btn btn-ghost sm" disabled={page >= pages} onClick={() => setPage((x) => x + 1)}>
+                  {tr('下一页', 'Next')}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* —— 右：详情 —— */}
+          <div className="split-detail">
+            {selectedId ? (
+              <DailyDetailPane entryId={selectedId} onCollect={openCollect} />
+            ) : (
+              <div className="empty" style={{ margin: 'auto' }}>
+                {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {collectPaper && (
+        <CollectTreeModal paper={collectPaper} open={collectOpen} onClose={() => setCollectOpen(false)} />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/library/DailyLikedTab.tsx
+++ b/src/frontend/src/features/library/DailyLikedTab.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { api, type DailyPaperItem } from '../../lib/api';
+import { fmtRelative, fmtTime } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   我的文献库 ·「我赞过的」tab：每日新论文里点过赞的论文。
+   池子只保留 7 天，过期条目会随之从这里消失。
+   左列表 + 右轻量详情（标题链接 / 作者 / 摘要）。
+   ============================================================ */
+
+const PAGE_SIZE = 20;
+
+// 点赞爱心的红色（与每日新论文页一致的局部常量，不走主题 token）
+const HEART_RED = '#e0245e';
+
+function LikedRow({
+  p,
+  active,
+  onSelect,
+}: {
+  p: DailyPaperItem;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const authors = p.authors.map((a) => a.name).filter(Boolean).join(', ');
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      style={{
+        padding: '12px 16px',
+        borderBottom: '0.5px solid var(--border)',
+        cursor: 'pointer',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        borderLeft: active ? '2px solid var(--accent)' : '2px solid transparent',
+        transition: 'background 0.12s',
+      }}
+    >
+      <div className="row gap8" style={{ marginBottom: 5 }}>
+        <span className="mono" style={{ fontSize: 10.5, color: active ? 'var(--accent-text)' : 'var(--text-3)' }}>
+          {p.arxiv_id ?? p.primary_category}
+        </span>
+        {p.year !== null && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{p.year}</span>
+        )}
+        <span className="row gap6" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
+          <span className="row" style={{ gap: 3 }}>
+            <Icon name="heartFill" size={11} style={{ color: HEART_RED }} />
+            <span className="mono">{p.like_count}</span>
+          </span>
+          {p.liked_at && (
+            <span className="mono">{tr(`赞于 ${fmtRelative(p.liked_at)}`, `liked ${fmtRelative(p.liked_at)}`)}</span>
+          )}
+        </span>
+      </div>
+      <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>{p.title}</div>
+      {authors && (
+        <div
+          title={authors}
+          style={{
+            fontSize: 11.5,
+            color: 'var(--text-3)',
+            marginTop: 3,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {authors}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 轻量详情：标题链接 / 作者全列 / 分类 / 摘要（daily 条目与库条目结构不同，单独渲染）。 */
+function LikedDetail({ p }: { p: DailyPaperItem }) {
+  const authors = p.authors.map((a) => a.name).filter(Boolean).join(', ');
+  return (
+    <div className="scroll fadeup" key={p.entry_id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
+      <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
+        <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>{p.primary_category}</span>
+        {p.arxiv_id && (
+          <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>arXiv:{p.arxiv_id}</span>
+        )}
+        {p.year !== null && <span className="pill sm" style={{ background: 'var(--surface-3)' }}>{p.year}</span>}
+      </div>
+      <h1 style={{ fontSize: 21, fontWeight: 680, lineHeight: 1.3, margin: '2px 0 6px', letterSpacing: '-0.01em' }}>
+        {p.url ? (
+          <a href={p.url} target="_blank" rel="noreferrer" style={{ color: 'inherit' }}>
+            {p.title}
+            <Icon name="link" size={14} style={{ display: 'inline-block', marginLeft: 6, verticalAlign: 'baseline', color: 'var(--text-3)' }} />
+          </a>
+        ) : (
+          p.title
+        )}
+      </h1>
+      {authors && <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 6 }}>{authors}</div>}
+      {p.published_at && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-4)', marginBottom: 14 }}>
+          {tr('发布于', 'Published')} {fmtTime(p.published_at)}
+        </div>
+      )}
+      {p.abstract ? (
+        <div className="card card-pad" style={{ background: 'var(--surface-2)' }}>
+          <div className="row gap8" style={{ marginBottom: 8 }}>
+            <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
+            <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
+          </div>
+          <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{p.abstract}</p>
+        </div>
+      ) : (
+        <div className="empty" style={{ padding: 20 }}>{tr('这篇还没有摘要。', 'No abstract for this paper.')}</div>
+      )}
+    </div>
+  );
+}
+
+export function DailyLikedTab() {
+  const [page, setPage] = useState(1);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const listQuery = useQuery({
+    queryKey: ['daily-liked', page],
+    queryFn: () => api.listMyDailyLiked({ page, size: PAGE_SIZE }),
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+  const items = listQuery.data?.items ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const selected = items.find((p) => p.entry_id === selectedId) ?? null;
+
+  return (
+    <div className="split">
+      {/* —— 左：列表 —— */}
+      <div className="split-list">
+        <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>
+          {listQuery.isLoading ? (
+            <div className="empty">{tr('加载中…', 'Loading…')}</div>
+          ) : listQuery.isError ? (
+            <EmptyState
+              compact
+              icon="x"
+              title={tr('赞过的论文暂时加载不出来', 'Failed to load liked papers')}
+              desc={tr('后端不可用或接口尚未就绪，稍后再试。', 'Backend unavailable or API not ready — try again later.')}
+              action={
+                <button className="btn btn-soft sm" onClick={() => void listQuery.refetch()}>
+                  {tr('重试', 'Retry')}
+                </button>
+              }
+            />
+          ) : items.length === 0 ? (
+            <EmptyState
+              compact
+              icon="heart"
+              title={tr('还没有赞过的论文', 'No liked papers yet')}
+              desc={tr(
+                '还没有赞过的论文。每日新论文只保留 7 天，过期后这里也会跟着清空。',
+                'No liked papers yet. Daily papers are kept for 7 days; expired ones disappear from here too.',
+              )}
+            />
+          ) : (
+            items.map((p) => (
+              <LikedRow
+                key={p.entry_id}
+                p={p}
+                active={p.entry_id === selectedId}
+                onSelect={() => setSelectedId(p.entry_id)}
+              />
+            ))
+          )}
+        </div>
+
+        {pages > 1 && (
+          <div
+            className="row gap12"
+            style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', justifyContent: 'center', flexShrink: 0 }}
+          >
+            <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              <Icon name="chevron" size={12} style={{ transform: 'rotate(180deg)' }} />
+              {tr('上一页', 'Prev')}
+            </button>
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+              {tr(`第 ${page} / ${pages} 页`, `Page ${page} / ${pages}`)}
+            </span>
+            <button className="btn btn-ghost sm" disabled={page >= pages} onClick={() => setPage((p) => p + 1)}>
+              {tr('下一页', 'Next')}
+              <Icon name="chevron" size={12} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* —— 右：轻量详情 —— */}
+      <div className="split-detail">
+        {selected ? (
+          <LikedDetail p={selected} />
+        ) : (
+          <div className="empty" style={{ margin: 'auto' }}>
+            {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../wiki/shared';
 import { PublicationsTab, PUBLICATIONS_PAGE_SIZE } from './PublicationsTab';
 import { PersonalChatTab } from './PersonalChatTab';
+import { DailyLikedTab } from './DailyLikedTab';
 import { AuthorBindWizard } from './AuthorBindWizard';
 import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPane';
 
@@ -34,8 +35,8 @@ import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPa
 
 const PAGE_SIZE = 20;
 
-/** 页面级 tab：库内两个 tab +「文献对话」+「我发表的」。 */
-type PageTab = LibraryTab | 'publications' | 'chat';
+/** 页面级 tab：库内两个 tab +「我赞过的」+「文献对话」+「我发表的」。 */
+type PageTab = LibraryTab | 'liked' | 'publications' | 'chat';
 
 // 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
 const SORTS: { v: LibrarySort; zh: string; en: string }[] = [
@@ -234,7 +235,7 @@ export function LibraryPage() {
     setPage(1);
   }, [tab, q, sort, author, venue, yearFrom, yearTo]);
 
-  const onLibraryTab = tab !== 'publications' && tab !== 'chat';
+  const onLibraryTab = tab !== 'publications' && tab !== 'chat' && tab !== 'liked';
   const listQuery = useQuery({
     queryKey: ['library', tab, q, sort, page, author.trim(), venue.trim(), yearFrom.trim(), yearTo.trim()],
     queryFn: () =>
@@ -337,6 +338,7 @@ export function LibraryPage() {
           options={[
             { v: 'saved', label: tr('我的收藏', 'Saved') },
             { v: 'history', label: tr('浏览记录', 'History') },
+            { v: 'liked', label: tr('我赞过的', 'Liked') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
             {
               v: 'publications',
@@ -380,6 +382,9 @@ export function LibraryPage() {
         {tab === 'chat' ? (
           /* ======== 个人文献库对话 ======== */
           <PersonalChatTab />
+        ) : tab === 'liked' ? (
+          /* ======== 我赞过的（每日新论文，保留 7 天） ======== */
+          <DailyLikedTab />
         ) : tab === 'publications' ? (
           /* ======== 我发表的 ======== */
           profileQuery.isLoading ? (

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -2167,7 +2167,137 @@ function MyUsageTab() {
 
 // ---------------- 页面 ----------------
 
-type Tab = 'personal' | 'ssh' | 'mymodels' | 'myusage' | 'mcp' | 'llm' | 'usage' | 'users' | 'codes' | 'feedback';
+type Tab = 'personal' | 'ssh' | 'mymodels' | 'myusage' | 'mcp' | 'llm' | 'daily' | 'usage' | 'users' | 'codes' | 'feedback';
+
+// ---------------- 每日新论文订阅分类（admin） ----------------
+
+/** arxiv 分类的大致格式：如 cs.AI / stat.ML / hep-th。 */
+const DAILY_CATEGORY_RE = /^[a-z][a-z-]+(\.[A-Za-z]{2,10})?$/;
+
+function DailyCategoriesTab() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['daily-categories'],
+    queryFn: () => api.getDailyCategories(),
+    retry: false,
+  });
+  // 本地编辑副本：首次拿到数据后接管，避免 refetch 覆盖未保存的改动
+  const [cats, setCats] = useState<string[] | null>(null);
+  const [input, setInput] = useState('');
+  useEffect(() => {
+    if (data && cats === null) setCats(data.categories);
+  }, [data, cats]);
+
+  const shown = cats ?? data?.categories ?? [];
+  const dirty = !!data && JSON.stringify(shown) !== JSON.stringify(data.categories);
+
+  const saveMutation = useMutation({
+    mutationFn: () => api.setDailyCategories(shown),
+    onSuccess: (res) => {
+      toast(tr('订阅分类已保存', 'Subscribed categories saved'), 'ok');
+      setCats(res.categories);
+      void queryClient.invalidateQueries({ queryKey: ['daily-categories'] });
+    },
+    onError: (e) => {
+      if (e instanceof ApiError && e.status === 422) {
+        toast(tr('分类格式不对', 'Invalid category format'), 'error');
+      } else {
+        toast(`${tr('保存失败', 'Save failed')}：${e instanceof Error ? e.message : String(e)}`, 'error');
+      }
+    },
+  });
+
+  const add = () => {
+    const v = input.trim();
+    if (!v) return;
+    if (!DAILY_CATEGORY_RE.test(v)) {
+      toast(tr('分类格式不对，应形如 cs.AI / stat.ML', 'Invalid format — expected e.g. cs.AI / stat.ML'), 'error');
+      return;
+    }
+    if (!shown.includes(v)) setCats([...shown, v]);
+    setInput('');
+  };
+
+  if (isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (isError) {
+    return <div className="empty">{tr('无法加载订阅分类（后端不可用）', 'Failed to load categories (backend unavailable)')}</div>;
+  }
+
+  return (
+    <div className="card card-pad" style={{ maxWidth: 640 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="book" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('每日新论文订阅分类', 'Daily papers subscribed categories')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>
+        {tr(
+          '每天从 arxiv 抓取这些分类下的新提交，全实验室共用一份。改动从下一次抓取开始生效。',
+          'New arxiv submissions in these categories are fetched daily, shared lab-wide. Changes apply from the next fetch.',
+        )}
+      </div>
+
+      <div className="row gap6 wrap" style={{ marginBottom: 12 }}>
+        {shown.length === 0 ? (
+          <span style={{ fontSize: 12, color: 'var(--text-4)' }}>
+            {tr('还没有订阅分类，先添加一个。', 'No categories yet — add one below.')}
+          </span>
+        ) : (
+          shown.map((c) => (
+            <span
+              key={c}
+              className="pill sm mono"
+              style={{ background: 'var(--surface-3)', gap: 4, paddingRight: 5 }}
+            >
+              {c}
+              <button
+                title={tr('移除', 'Remove')}
+                onClick={() => setCats(shown.filter((x) => x !== c))}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  color: 'var(--text-3)',
+                  display: 'inline-flex',
+                  padding: 1,
+                }}
+              >
+                <Icon name="x" size={10} />
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+
+      <div className="row gap8">
+        <input
+          className="input mono"
+          style={{ width: 200 }}
+          placeholder={tr('如 cs.AI，回车添加', 'e.g. cs.AI, Enter to add')}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              add();
+            }
+          }}
+        />
+        <button className="btn btn-soft sm" disabled={!input.trim()} onClick={add}>
+          <Icon name="plus" size={12} />
+          {tr('添加', 'Add')}
+        </button>
+        <div style={{ flex: 1 }} />
+        <button
+          className="btn btn-primary sm"
+          disabled={!dirty || saveMutation.isPending}
+          onClick={() => saveMutation.mutate()}
+        >
+          {saveMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 
 // ---------------- 用户管理（admin） ----------------
@@ -2979,7 +3109,7 @@ function CodesTab() {
 }
 
 const PERSONAL_TABS: Tab[] = ['personal', 'ssh', 'mymodels', 'myusage', 'mcp'];
-const ALL_TABS: Tab[] = [...PERSONAL_TABS, 'llm', 'usage', 'users', 'codes', 'feedback'];
+const ALL_TABS: Tab[] = [...PERSONAL_TABS, 'llm', 'daily', 'usage', 'users', 'codes', 'feedback'];
 
 export function SettingsPage() {
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
@@ -3000,6 +3130,7 @@ export function SettingsPage() {
   ];
   const adminItems: { v: Tab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
+    { v: 'daily', label: tr('每日论文', 'Daily papers') },
     { v: 'users', label: tr('用户管理', 'Users') },
     { v: 'codes', label: tr('注册码', 'Codes') },
     { v: 'feedback', label: tr('反馈', 'Feedback') },
@@ -3040,6 +3171,7 @@ export function SettingsPage() {
       {effectiveTab === 'myusage' && <MyUsageTab />}
       {effectiveTab === 'mcp' && <McpToolsContent />}
       {effectiveTab === 'llm' && admin && <LlmTab />}
+      {effectiveTab === 'daily' && admin && <DailyCategoriesTab />}
       {effectiveTab === 'usage' && admin && <UsageTab />}
       {effectiveTab === 'users' && admin && <UsersTab />}
       {effectiveTab === 'codes' && admin && <CodesTab />}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2244,6 +2244,94 @@ export interface PublicationPage extends PageOf<Publication> {
   counts: { pending: number; confirmed: number; rejected: number };
 }
 
+// ============================================================
+// 每日新论文池（/daily）— arxiv 每日新提交，保留最近 7 天
+// ============================================================
+
+/** 点赞人（头像堆展示用）。 */
+export interface DailyLiker {
+  id: string;
+  display_name: string;
+  has_avatar: boolean;
+}
+
+/** 完整点赞名单里的一行（点赞时间倒序）。 */
+export interface DailyLikerFull extends DailyLiker {
+  liked_at: string;
+}
+
+/** 点/取消赞后的汇总（幂等返回，供乐观更新对账）。 */
+export interface DailyLikeState {
+  entry_id: string;
+  like_count: number;
+  liked_by_me: boolean;
+  likers_preview: DailyLiker[];
+}
+
+export type DailySort = 'likes' | 'date';
+
+export interface DailyPaperItem {
+  entry_id: string;
+  paper_id: string;
+  /** YYYY-MM-DD */
+  feed_date: string;
+  primary_category: string;
+  categories: string[];
+  announce_type: 'new' | 'cross';
+  title: string;
+  authors: PaperAuthor[];
+  abstract: string | null;
+  year: number | null;
+  arxiv_id: string | null;
+  url: string | null;
+  published_at: string | null;
+  has_wiki: boolean;
+  like_count: number;
+  liked_by_me: boolean;
+  /** 预览最多 5 人；自己赞过时排第一 */
+  likers_preview: DailyLiker[];
+  /** 仅「我赞过的」列表返回 */
+  liked_at?: string | null;
+}
+
+export interface DailyPaperDetail extends DailyPaperItem {
+  wiki_content: string | null;
+}
+
+export type DailyPage = PageOf<DailyPaperItem>;
+
+export interface DailyDay {
+  /** YYYY-MM-DD */
+  date: string;
+  count: number;
+}
+
+export interface DailyCollectRequest {
+  paper_ids: string[];
+  direction_library_ids: string[];
+  topic_ids: string[];
+  personal: boolean;
+}
+
+export interface DailyCollectResult {
+  target_type: 'library' | 'topic' | 'personal';
+  target_id: string | null;
+  added: number;
+  skipped_existing: number;
+  forbidden: boolean;
+}
+
+export interface DailyCollectResponse {
+  results: DailyCollectResult[];
+}
+
+/** 该论文已在哪些收录目标里（树选框预勾选/禁用）。 */
+export interface DailyCollectionsRead {
+  direction_library_ids: string[];
+  topic_ids: string[];
+  in_personal: boolean;
+}
+
 export const api = {
   /** fastapi-users JWT login — form-encoded username/password. Returns access token. */
   async login(email: string, password: string): Promise<string> {
@@ -3756,5 +3844,58 @@ export const api = {
   /** 手动添加发表（arxiv_id / doi / bibtex 三选一）；解析失败 422。 */
   addPublication(input: { arxiv_id: string } | { doi: string } | { bibtex: string }): Promise<Publication> {
     return requestJson<Publication>('/me/publications', 'POST', input);
+  },
+
+  // —— 每日新论文池（/daily） ——
+  /** 池内现存日期（倒序）与每天篇数。 */
+  listDailyDays(): Promise<DailyDay[]> {
+    return request<DailyDay[]>('/daily/days');
+  },
+  listDailyPapers(
+    opts: { date?: string; sort?: DailySort; page?: number; size?: number; q?: string } = {},
+  ): Promise<DailyPage> {
+    const params = new URLSearchParams();
+    if (opts.date) params.set('date', opts.date);
+    if (opts.sort) params.set('sort', opts.sort);
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    if (opts.q) params.set('q', opts.q);
+    const qs = params.toString();
+    return request<DailyPage>(`/daily/papers${qs ? `?${qs}` : ''}`);
+  },
+  getDailyPaper(entryId: string): Promise<DailyPaperDetail> {
+    return request<DailyPaperDetail>(`/daily/papers/${entryId}`);
+  },
+  likeDailyPaper(entryId: string): Promise<DailyLikeState> {
+    return request<DailyLikeState>(`/daily/papers/${entryId}/like`, { method: 'PUT' });
+  },
+  unlikeDailyPaper(entryId: string): Promise<DailyLikeState> {
+    return request<DailyLikeState>(`/daily/papers/${entryId}/like`, { method: 'DELETE' });
+  },
+  /** 完整点赞名单（点赞时间倒序）。 */
+  listDailyLikers(entryId: string): Promise<DailyLikerFull[]> {
+    return request<DailyLikerFull[]>(`/daily/papers/${entryId}/likers`);
+  },
+  /** 我赞过的（随池内过期一起消失）。 */
+  listMyDailyLiked(opts: { page?: number; size?: number } = {}): Promise<DailyPage> {
+    const params = new URLSearchParams();
+    if (opts.page) params.set('page', String(opts.page));
+    if (opts.size) params.set('size', String(opts.size));
+    const qs = params.toString();
+    return request<DailyPage>(`/daily/liked${qs ? `?${qs}` : ''}`);
+  },
+  /** 批量收录：论文 × 目标（方向库 / 课题相关研究 / 个人库）。 */
+  collectDaily(input: DailyCollectRequest): Promise<DailyCollectResponse> {
+    return requestJson<DailyCollectResponse>('/daily/collect', 'POST', input);
+  },
+  getDailyCollections(entryId: string): Promise<DailyCollectionsRead> {
+    return request<DailyCollectionsRead>(`/daily/papers/${entryId}/collections`);
+  },
+  getDailyCategories(): Promise<{ categories: string[] }> {
+    return request<{ categories: string[] }>('/daily/categories');
+  },
+  /** 更新订阅分类（admin）。 */
+  setDailyCategories(categories: string[]): Promise<{ categories: string[] }> {
+    return requestJson<{ categories: string[] }>('/daily/categories', 'PUT', { categories });
   },
 };

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3852,7 +3852,17 @@ export const api = {
     return request<DailyDay[]>('/daily/days');
   },
   listDailyPapers(
-    opts: { date?: string; sort?: DailySort; page?: number; size?: number; q?: string } = {},
+    opts: {
+      date?: string;
+      sort?: DailySort;
+      page?: number;
+      size?: number;
+      q?: string;
+      /** 类型筛选：new=新工作，cross=更新（交叉提交）；不传=全部 */
+      announce?: 'new' | 'cross';
+      /** 订阅分类筛选，如 cs.AI；不传=全部分类 */
+      category?: string;
+    } = {},
   ): Promise<DailyPage> {
     const params = new URLSearchParams();
     if (opts.date) params.set('date', opts.date);
@@ -3860,6 +3870,8 @@ export const api = {
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));
     if (opts.q) params.set('q', opts.q);
+    if (opts.announce) params.set('announce', opts.announce);
+    if (opts.category) params.set('category', opts.category);
     const qs = params.toString();
     return request<DailyPage>(`/daily/papers${qs ? `?${qs}` : ''}`);
   },
@@ -3890,6 +3902,13 @@ export const api = {
   },
   getDailyCollections(entryId: string): Promise<DailyCollectionsRead> {
     return request<DailyCollectionsRead>(`/daily/papers/${entryId}/collections`);
+  },
+  /** 触发单篇 AI 解读编译（同步等待，约半分钟）；409 detail=COMPILE_IN_PROGRESS，502 编译失败。 */
+  compileDailyPaper(entryId: string): Promise<{ entry_id: string; wiki_content: string; model: string }> {
+    return request<{ entry_id: string; wiki_content: string; model: string }>(
+      `/daily/papers/${entryId}/compile`,
+      { method: 'POST' },
+    );
   },
   getDailyCategories(): Promise<{ categories: string[] }> {
     return request<{ categories: string[] }>('/daily/categories');

--- a/src/frontend/src/lib/sse.ts
+++ b/src/frontend/src/lib/sse.ts
@@ -204,6 +204,14 @@ export function chatPersonalSse(
   return postSse('/library/chat', input, handlers);
 }
 
+/** 每日新论文池对话：POST /daily/chat（sources → delta* → done/error，语料为最近 7 天的池）。 */
+export function chatDailySse(
+  input: { question: string; history: { role: 'user' | 'assistant'; content: string }[] },
+  handlers: PostSseHandlers,
+): () => void {
+  return postSse('/daily/chat', input, handlers);
+}
+
 /** 独立库对话：POST /libraries/{id}/chat（事件协议同 chatLibrarySse）。 */
 export function chatLibraryByIdSse(
   libraryId: string,

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -411,6 +411,9 @@ input {
 .fadeup { animation: fadeUp 0.3s ease; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .spin { animation: spin 1s linear infinite; }
+/* 点赞爱心弹跳（每日新论文）：scale 1 → 1.3 → 1 */
+@keyframes heartPop { 0% { transform: scale(1); } 40% { transform: scale(1.3); } 100% { transform: scale(1); } }
+.heart-pop { animation: heartPop 0.18s ease; }
 
 .empty { color: var(--text-3); font-size: 13px; text-align: center; padding: 40px; }
 


### PR DESCRIPTION
Closes #70

## What

A shared "Daily Papers" hub for the lab: every day the worker fetches New submissions from subscribed arxiv categories (default `cs.AI` / `cs.CL` / `cs.CV`, admin-configurable), keeps a rolling 7-day pool, and lets members like papers, chat over the pool, generate per-paper AI summaries, and collect papers into libraries.

## Backend

- New tables `daily_feed_entries` (unique `paper_id` referencing the global paper pool, indexed `feed_date`, merged `categories`, `announce_type` new/cross, shared `wiki_content`) and `daily_feed_likes` (`(entry_id, user_id)` unique; likes vanish with expired entries). Migration `f2d34705e152` on top of `47b973fb7e13`.
- `services/daily_feed.py`: sync (RSS `fetch_new` per category → pool dedup via `find_pool_paper` → lightweight `Paper` rows, no PDF/LLM work → idempotent entry upsert), rolling cleanup (`feed_date < today-6`; pool papers and library membership rows untouched), likes with facepile preview (self first), collection dispatch reusing existing write paths (`ensure_membership(status="included")` / `add_to_shelf` / `save_paper`) with per-target `added` / `skipped_existing` / `forbidden`, and shared-wiki copy into the target library membership / shelf snapshot / personal entry on collect.
- `/daily` API: days, papers (sort `likes`|`date`, date/`announce`/`category` filters, search, pagination), detail, like/unlike (idempotent), likers, my liked list, batch collect, per-paper collections, categories (GET member / PUT admin with format validation), manual refresh (admin, deduped job id), **pool chat** (SSE, abstract-level scope = all pool papers, same event contract as library chat), **per-paper wiki compile** (shared result on the entry, 409 while in progress).
- ARQ cron `daily_feed_sync` at 01:30 UTC (arXiv announces ~00:00 UTC; offset from the 03:00 wiki ingest). Weekend RSS is empty and no-ops.
- Tests: `tests/test_daily_feed.py` — sync idempotency + cross-list merge + announce/category filters, expiry semantics, like toggle + facepile ordering + sort, collect with permission fallback, compile + wiki copy on collect, pool chat SSE event sequence, admin categories + refresh (7 passed; ruff clean).

## Frontend

- `/daily` page with Papers / Chat tabs:
  - Papers: two-pane layout mirroring the shared-library browser; sticky per-day group headers, debounced search, sort chips (most-liked default / newest), pagination; **advanced filter bar** — prev/next day stepper over available days (with an "all 7 days" stop), subscribed-category dropdown, announce-type chips; green **NEW** badge for new submissions, "Updated" badge for cross-lists; detail pane with abstract, external link, AI summary (rendered markdown) or a "Generate summary" button (pending state, 409 toast).
  - Chat: reuses `ChatSurface` over the whole pool (citation badges + source list).
- Likes: `[♥][facepile][+N][count]` — optimistic updates across query caches, heart-pop animation, hover popover with the full liker list, self avatar highlighted first.
- `CollectTreeModal`: two-level tree (shared libraries / topic related work / personal library), tri-state parents, search filter, pre-checked disabled already-added targets, summary toast.
- Personal library "Liked" tab (`/daily/liked`) with 7-day-expiry empty state; admin settings gain a "Daily papers" tab for category management (chips + validation).
- New reusable `Facepile` composing the existing `Avatar`; `heart`/`heartFill` icons; lab-section nav entry. `tsc --noEmit` and `vite build` pass.

## Verification

- Backend: `pytest tests/test_daily_feed.py` (7 passed), `ruff check` clean on changed files.
- Frontend: `tsc --noEmit` 0 errors, `vite build` OK.
- Live preview: dev migration applied, a real sync pulled 477 RSS items → 397 pooled papers across the three default categories.