### PR TITLE
feat(library): staged processing progress for manually added papers

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse, StreamingResponse
+from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,6 +32,7 @@ from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
+from app.core.redis import get_redis_dep
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.project import Project
 from app.models.user import User
@@ -72,10 +74,10 @@ from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import notes as notes_service
+from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
-from app.services import relevance as relevance_service
 
 router = APIRouter(tags=["libraries"])
 
@@ -611,11 +613,15 @@ async def add_library_paper_manually(
     data: PaperManualCreate,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
 ) -> Any:
-    """手动把一篇文献加进该库：arxiv_id / doi / bibtex 三选一（可管理者）。"""
+    """手动把一篇文献加进该库：arxiv_id / doi / bibtex 三选一（可管理者）。
+
+    同步只建元数据行；下载/抽取/向量化/打分由后台任务完成，响应回传 task_id。
+    """
     library = await _get_managed_library(session, library_id, user)
     try:
-        paper = await paper_import_service.add_manual_paper_to_library(
+        result = await paper_import_service.add_manual_paper_to_library(
             session,
             library=library,
             arxiv_id=data.arxiv_id,
@@ -632,13 +638,15 @@ async def add_library_paper_manually(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
         ) from e
-    paper_id, user_id, project_id = paper.id, user.id, library.project_id
-    membership = await libraries_service.get_membership(
-        session, library_id=library.id, paper_id=paper_id
-    )
-    if membership is not None:
-        await relevance_service.score_added_paper_best_effort(
-            session, paper, membership, project_id=project_id, user_id=user_id
+    paper_id, user_id, project_id = result.paper.id, user.id, library.project_id
+    task_id: str | None = None
+    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+        task_id = await paper_enrich_service.launch_paper_enrichment(
+            redis=redis,
+            paper_id=paper_id,
+            user_id=user_id,
+            library_id=library.id,
+            project_id=project_id,
         )
     view = await papers_service.get_library_paper_view(
         session,
@@ -647,7 +655,8 @@ async def add_library_paper_manually(
         paper_id=paper_id,
         with_concepts=True,
     )
-    return await _paper_detail(session, view, user_id)
+    detail = await _paper_detail(session, view, user_id)
+    return detail.model_copy(update={"task_id": task_id})
 
 
 @router.post("/libraries/{library_id}/papers/batch-delete")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import asdict
@@ -12,12 +13,15 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_llm_chat, require_llm_task
 from app.core.db import get_session
+from app.core.events import paper_task_channel
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
+from app.core.redis import get_redis_dep
 from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.paper import (
@@ -40,11 +44,11 @@ from app.schemas.paper import (
 from app.services import figure_annotate as figure_service
 from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
+from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
 from app.services import personal_wiki as personal_wiki_service
 from app.services import projects as projects_service
-from app.services import relevance as relevance_service
 from app.services import wiki_compile as wiki_compile_service
 from app.services.literature.pdf_extract import figure_path
 
@@ -170,13 +174,18 @@ async def add_paper_manually(
     data: PaperManualCreate,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
 ) -> Any:
-    """手动添加文献：arxiv_id / doi / bibtex 三选一（docs/api-lit.md §4）。"""
+    """手动添加文献：arxiv_id / doi / bibtex 三选一（docs/api-lit.md §4）。
+
+    同步只建元数据行；PDF 下载/全文抽取/向量化/相关性打分交给后台任务，响应回传
+    task_id 供前端订阅分阶段进度（论文已处理完整时为 null）。
+    """
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     try:
-        paper = await paper_import_service.add_manual_paper(
+        result = await paper_import_service.add_manual_paper(
             session,
             project_id=project_id,
             arxiv_id=data.arxiv_id,
@@ -192,26 +201,82 @@ async def add_paper_manually(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
         ) from e
-    # 打分失败会 rollback 并使本 session 的 ORM 对象过期，先留住要用的 id
-    paper_id, user_id = paper.id, user.id
-    library = await libraries_service.get_library_for_project(session, project_id)
-    membership = (
-        await libraries_service.get_membership(
-            session, library_id=library.id, paper_id=paper_id
-        )
-        if library is not None
-        else None
-    )
-    # 顺带相关性打分（best-effort）：失败只记日志，不影响 201；不改 status（人工纳入）
-    if membership is not None:
-        await relevance_service.score_added_paper_best_effort(
-            session, paper, membership, project_id=project.id, user_id=user_id
+    paper_id, user_id = result.paper.id, user.id
+    # 后台补全：新建或未处理完整时启动（含针对起源库 definition 的打分）
+    task_id: str | None = None
+    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+        library = await libraries_service.get_library_for_project(session, project_id)
+        task_id = await paper_enrich_service.launch_paper_enrichment(
+            redis=redis,
+            paper_id=paper_id,
+            user_id=user_id,
+            library_id=library.id if library is not None else None,
+            project_id=project.id,
         )
     # 重新加载（带 concepts eager load），避免序列化时触发 async lazy load
     view = await papers_service.get_paper_for_user(
         session, paper_id=paper_id, user_id=user_id, with_concepts=True
     )
-    return await _paper_detail(session, view, user_id)
+    detail = await _paper_detail(session, view, user_id)
+    return detail.model_copy(update={"task_id": task_id})
+
+
+def _sse_frame(event: str, data: Any) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
+
+
+@router.get("/paper-tasks/{task_id}/events")
+async def paper_task_events(
+    task_id: str,
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> StreamingResponse:
+    """SSE：手动添加文献的后台补全进度（下载/抽取/向量化/打分）。
+
+    鉴权：task 归属用户（redis paper_task_owner:{task_id}）须等于当前登录用户，否则 404。
+    转发 paper_task 频道事件，15s 心跳，收到 done/error 后结束流。
+    """
+    owner = await paper_enrich_service.owner_of(redis, task_id)
+    if owner is None or owner != str(user.id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_TASK_NOT_FOUND")
+
+    async def stream() -> AsyncIterator[str]:
+        pubsub = redis.pubsub()
+        await pubsub.subscribe(paper_task_channel(task_id))
+        last_ping = time.monotonic()
+        try:
+            while True:
+                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                if message is not None:
+                    raw = message["data"]
+                    if isinstance(raw, bytes):
+                        raw = raw.decode("utf-8")
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    event = str(payload.get("event", "message"))
+                    yield _sse_frame(event, payload.get("data"))
+                    if event in ("done", "error"):
+                        return
+                if time.monotonic() - last_ping >= _HEARTBEAT_SECONDS:
+                    yield ": ping\n\n"
+                    last_ping = time.monotonic()
+        except asyncio.CancelledError:
+            raise
+        finally:
+            await pubsub.unsubscribe(paper_task_channel(task_id))
+            await pubsub.aclose()
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.get("/papers/{paper_id}", response_model=PaperDetail)

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -8,10 +8,12 @@ services/topic_shelf.py：入架落 wiki 快照 + 同步 upsert 个人库；
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
+from app.core.redis import get_redis_dep
 from app.models.user import User
 from app.schemas.shelf import (
     ShelfAddRequest,
@@ -21,6 +23,7 @@ from app.schemas.shelf import (
     ShelfNoteUpdate,
     ShelfPage,
 )
+from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import projects as projects_service
 from app.services import topic_shelf as shelf_service
@@ -121,11 +124,15 @@ async def import_to_shelf(
     body: ShelfImportRequest,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
 ) -> ShelfItemRead:
-    """个人补充入库：查池命中直接入架；未命中抓取解析入池（不进任何方向库）再入架。"""
+    """个人补充入库：查池命中直接入架；未命中抓取解析入池（不进任何方向库）再入架。
+
+    新建或未处理完整时启动后台补全任务（下载/抽取/向量化，无库不打分），回传 task_id。
+    """
     await _require_member(session, project_id, user)
     try:
-        item = await shelf_service.import_to_shelf(
+        result = await shelf_service.import_to_shelf(
             session,
             project_id=project_id,
             user_id=user.id,
@@ -137,7 +144,16 @@ async def import_to_shelf(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
         ) from e
-    return ShelfItemRead.model_validate(item)
+    task_id: str | None = None
+    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+        task_id = await paper_enrich_service.launch_paper_enrichment(
+            redis=redis,
+            paper_id=result.paper.id,
+            user_id=user.id,
+            library_id=None,
+            project_id=project_id,
+        )
+    return ShelfItemRead.model_validate(result.item).model_copy(update={"task_id": task_id})
 
 
 @router.patch("/projects/{project_id}/shelf/{paper_id}", response_model=ShelfItemRead)

--- a/src/backend/app/core/events.py
+++ b/src/backend/app/core/events.py
@@ -24,6 +24,22 @@ def notify_channel(project_id: uuid.UUID | str) -> str:
     return f"notify:project:{project_id}"
 
 
+def paper_task_channel(task_id: str) -> str:
+    """手动添加文献的分阶段处理进度频道（SSE 端点订阅转发）。"""
+    return f"paper_task:{task_id}:events"
+
+
+async def publish_paper_task_event(
+    bus: "EventBus", task_id: str, event: str, data: dict[str, Any]
+) -> None:
+    """发布一条论文处理进度事件到 paper_task 频道。
+
+    与 voyage 事件不同：没有 voyage 行，故不落库，只做实时转发（进度是临时态）。
+    """
+    payload = json.dumps({"event": event, "data": data}, ensure_ascii=False, default=str)
+    await bus._redis.publish(paper_task_channel(task_id), payload)
+
+
 class EventBus:
     """薄封装：把事件序列化为 JSON 发布到对应频道。"""
 

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -96,6 +96,9 @@ class PaperDetail(PaperRead):
     pdf_available: bool = False
     concepts: list[PaperConceptRead] = []
     figures: list[PaperFigure] = []
+    # 手动添加后启动的后台补全任务 id（下载/抽取/向量化/打分）；无需补全时为 null。
+    # 前端凭此订阅 GET /paper-tasks/{task_id}/events 显示分阶段进度。
+    task_id: str | None = None
 
     @field_validator("figures", mode="before")
     @classmethod

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -26,6 +26,8 @@ class ShelfItemRead(BaseModel):
     snapshot_at: datetime | None
     source_library_id: uuid.UUID | None
     added_at: datetime
+    # 个人补充入架时启动的后台补全任务 id（下载/抽取/向量化）；无需补全时为 null。
+    task_id: str | None = None
 
     @field_validator("authors", mode="before")
     @classmethod

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -1,0 +1,298 @@
+"""手动添加文献后的分阶段后台补全（下载→抽取→向量化→打分）。
+
+同步请求只建元数据行（paper_import.create_pool_paper_stub）；重活在这里以后台
+asyncio 任务跑，自开新 AsyncSession，按阶段向 redis 频道发进度事件供前端订阅。
+
+阶段固定集合（前端按此渲染）：resolve → download → extract → embed → score。
+每阶段 best-effort：失败发 status="error" 但继续后续步骤；已就绪则 status="skipped"。
+"""
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper
+
+logger = logging.getLogger(__name__)
+
+# 前端按此固定顺序渲染进度条；事件 data.stage 取值于此
+STAGES = ["resolve", "download", "extract", "embed", "score"]
+
+_OWNER_TTL_SECONDS = 600  # paper_task_owner 归属 key 存活时间
+
+
+def paper_task_owner_key(task_id: str) -> str:
+    return f"paper_task_owner:{task_id}"
+
+
+# 已启动的后台任务引用（防止 asyncio 任务被 GC；也供测试 await 到完成）
+_TASKS: dict[str, asyncio.Task] = {}
+
+Emit = Callable[..., Awaitable[None]]
+
+
+def paper_processing_complete(paper: Paper) -> bool:
+    """论文是否已处理完整（PDF + 全文 + 向量都在）——完整则无需再启动补全任务。"""
+    return bool(paper.pdf_path and paper.full_text_path and paper.embedding is not None)
+
+
+async def embed_paper(
+    paper: Paper,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+) -> None:
+    """为论文生成 Paper.embedding（复用 wiki.link_concepts 的嵌入口径）。
+
+    provider 不支持嵌入时抛 NotImplementedError（调用方按 skipped 处理）。
+    """
+    from app.core.llm.router import get_llm_router
+
+    text = f"{paper.title}\n{paper.tldr or ''}\n{paper.abstract or ''}"[:2000]
+    vectors = await get_llm_router().embed(
+        [text],
+        user_id=user_id,
+        project_id=project_id,
+        library_id=library_id,
+    )
+    paper.embedding = vectors[0]
+
+
+async def enrich_paper(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    target: DirectionLibrary | None = None,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    emit: Emit,
+) -> None:
+    """分阶段补全一篇论文（下载→抽取→(补机构)→向量化→打分）。
+
+    - target 提供时按其 definition 打分（课题/库工作台），个人书架 import 无 target 跳过。
+    - 每步 best-effort：抛错发 error 事件但继续；已就绪发 skipped。
+    """
+    from app.services.literature import get_arxiv_client
+    from app.services.literature.pdf_extract import extract_full_text, save_pdf
+
+    # 先固定 id：rollback 会让 ORM 对象过期，之后再同步读其属性会触发意外 IO
+    paper_id = paper.id
+    target_id = target.id if target is not None else None
+
+    async def _rollback_and_reload() -> Paper:
+        """回滚失败事务并重新取回附着的 paper（rollback 会过期原实例）。"""
+        await session.rollback()
+        return await session.get(Paper, paper_id)
+
+    # resolve 已在同步请求阶段完成，补发一条 ok 让前端进度条起步
+    await emit("resolve", "ok")
+
+    # ---- download ----
+    await emit("download", "running")
+    if paper.pdf_path:
+        await emit("download", "skipped", "already downloaded")
+    elif not paper.arxiv_id:
+        await emit("download", "skipped", "no arxiv id")
+    else:
+        try:
+            content = await get_arxiv_client().download_pdf(paper.arxiv_id)
+            paper.pdf_path = str(save_pdf(str(paper_id), content))
+            await session.commit()
+            await emit("download", "ok")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            logger.warning("enrich download failed for paper %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
+            await emit("download", "error", f"{type(e).__name__}: {e}")
+
+    # ---- extract ----
+    await emit("extract", "running")
+    if paper.full_text_path:
+        await emit("extract", "skipped", "already extracted")
+    elif not paper.pdf_path:
+        await emit("extract", "skipped", "no pdf")
+    else:
+        try:
+            txt_path = await extract_full_text(str(paper_id), Path(paper.pdf_path))
+            paper.full_text_path = str(txt_path)
+            await session.commit()
+            await emit("extract", "ok")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            logger.warning("enrich extract failed for paper %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
+            await emit("extract", "error", f"{type(e).__name__}: {e}")
+
+    # 发表机构：全文到手且尚无机构时 LLM 补（非独立阶段，best-effort，不发事件）
+    if not paper.affiliations and paper.full_text_path:
+        try:
+            from app.core.llm.router import get_llm_router
+            from app.services.affiliations import extract_affiliations_llm
+
+            affs = await extract_affiliations_llm(
+                paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+            )
+            if affs:
+                paper.affiliations = affs
+                await session.commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning("enrich affiliations failed for paper %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
+
+    # ---- embed ----
+    await emit("embed", "running")
+    if paper.embedding is not None:
+        await emit("embed", "skipped", "already embedded")
+    else:
+        try:
+            await embed_paper(
+                paper,
+                user_id=user_id,
+                project_id=project_id,
+                library_id=target_id,
+            )
+            await session.commit()
+            await emit("embed", "ok")
+        except asyncio.CancelledError:
+            raise
+        except NotImplementedError:
+            paper = await _rollback_and_reload()
+            await emit("embed", "skipped", "provider does not support embeddings")
+        except Exception as e:  # noqa: BLE001
+            logger.warning("enrich embed failed for paper %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
+            await emit("embed", "error", f"{type(e).__name__}: {e}")
+
+    # ---- score ----
+    await emit("score", "running")
+    if target_id is None:
+        await emit("score", "skipped", "no target library")
+    else:
+        from app.services.libraries import get_membership
+        from app.services.relevance import score_added_paper_best_effort
+
+        membership = await get_membership(session, library_id=target_id, paper_id=paper_id)
+        if membership is None:
+            await emit("score", "skipped", "no membership")
+        else:
+            try:
+                # best-effort helper 内部吞异常并自 commit/rollback，故用打分是否落地判定 ok/error
+                await score_added_paper_best_effort(
+                    session, paper, membership, project_id=project_id, user_id=user_id
+                )
+                await session.refresh(membership)
+                if membership.relevance_score is not None:
+                    await emit("score", "ok")
+                else:
+                    await emit("score", "error", "scoring produced no score")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001
+                logger.warning("enrich score failed for paper %s", paper.id, exc_info=True)
+                await emit("score", "error", f"{type(e).__name__}: {e}")
+
+
+async def _run_enrichment(
+    *,
+    task_id: str,
+    paper_id: uuid.UUID,
+    library_id: uuid.UUID | None,
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+    redis: Redis,
+) -> None:
+    """后台任务体：自开新 session 跑 enrich_paper，收尾发 done / 出错发 error。"""
+    from app.core.db import get_sessionmaker
+    from app.core.events import EventBus, publish_paper_task_event
+
+    bus = EventBus(redis)
+
+    async def emit(stage: str, status: str, detail: str | None = None) -> None:
+        await publish_paper_task_event(
+            bus, task_id, "stage", {"stage": stage, "status": status, "detail": detail}
+        )
+
+    try:
+        async with get_sessionmaker()() as session:
+            paper = await session.get(Paper, paper_id)
+            if paper is None:
+                await publish_paper_task_event(
+                    bus, task_id, "error", {"message": "paper not found"}
+                )
+                return
+            target = (
+                await session.get(DirectionLibrary, library_id) if library_id else None
+            )
+            await enrich_paper(
+                session,
+                paper,
+                target=target,
+                user_id=user_id,
+                project_id=project_id,
+                emit=emit,
+            )
+        await publish_paper_task_event(bus, task_id, "done", {})
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("paper enrichment task failed: %s", task_id)
+        try:
+            await publish_paper_task_event(
+                bus, task_id, "error", {"message": f"{type(e).__name__}: {e}"}
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to publish paper task error event", exc_info=True)
+
+
+async def launch_paper_enrichment(
+    *,
+    redis: Redis,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID,
+    library_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> str | None:
+    """登记归属 + 起后台任务，返回 task_id；redis 不可用时降级返回 None（不阻塞添加）。"""
+    task_id = uuid.uuid4().hex
+    try:
+        await redis.setex(paper_task_owner_key(task_id), _OWNER_TTL_SECONDS, str(user_id))
+    except Exception:  # noqa: BLE001 — redis 不可达时进度追踪不可用，但添加本身已成功
+        logger.warning("paper task owner registration failed; enrichment not launched")
+        return None
+
+    task = asyncio.create_task(
+        _run_enrichment(
+            task_id=task_id,
+            paper_id=paper_id,
+            library_id=library_id,
+            user_id=user_id,
+            project_id=project_id,
+            redis=redis,
+        )
+    )
+    _TASKS[task_id] = task
+    task.add_done_callback(lambda t: _TASKS.pop(task_id, None))
+    return task_id
+
+
+async def await_task(task_id: str) -> None:
+    """等待某后台任务跑完（测试用；生产不需要）。"""
+    task = _TASKS.get(task_id)
+    if task is not None:
+        await task
+
+
+async def owner_of(redis: Redis, task_id: str) -> str | None:
+    """取任务归属用户 id（字符串），无则 None。"""
+    return await redis.get(paper_task_owner_key(task_id))

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -5,7 +5,7 @@ import logging
 import re
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -218,6 +218,54 @@ async def create_pool_paper(
     return paper
 
 
+async def create_pool_paper_stub(
+    session: AsyncSession,
+    *,
+    fields: dict[str, Any],
+) -> Paper:
+    """按解析字段建内容池 Paper（source=manual）——只落元数据，**不下载 PDF、不抽全文**。
+
+    重活（下载/抽取/向量化/打分）交给后台任务 enrich_paper 分阶段做；此处只做同步、
+    确定性的建行工作。调用方负责先查池去重（find_pool_paper）与收尾 commit。
+    """
+    external_ids: dict[str, str] = {}
+    if fields.get("arxiv_id"):
+        external_ids["arxiv"] = fields["arxiv_id"]
+    if fields.get("doi"):
+        external_ids["doi"] = fields["doi"]
+    paper = Paper(
+        source="manual",
+        dedup_key=pool_dedup_key(
+            arxiv_id=fields.get("arxiv_id"),
+            doi=fields.get("doi"),
+            title=fields["title"],
+            year=fields.get("year"),
+            authors=fields.get("authors"),
+        ),
+        arxiv_id=fields.get("arxiv_id"),
+        doi=fields.get("doi"),
+        external_ids=external_ids or None,
+        title=fields["title"],
+        authors=fields.get("authors"),
+        affiliations=fields.get("affiliations"),
+        abstract=fields.get("abstract"),
+        year=fields.get("year"),
+        venue=fields.get("venue"),
+        url=fields.get("url"),
+        published_at=fields.get("published_at"),
+    )
+    session.add(paper)
+    await session.flush()
+    return paper
+
+
+class ManualAddResult(NamedTuple):
+    """手动添加结果：paper + 是否新建了内容池行（决定是否要启动后台补全任务）。"""
+
+    paper: Paper
+    created: bool  # True=新建池行；False=池命中（论文已存在）
+
+
 async def add_manual_paper(
     session: AsyncSession,
     *,
@@ -225,8 +273,11 @@ async def add_manual_paper(
     arxiv_id: str | None = None,
     doi: str | None = None,
     bibtex: str | None = None,
-) -> Paper:
-    """手动添加一篇文献到课题起源库（source=manual，成员行 status=included）。"""
+) -> ManualAddResult:
+    """手动添加一篇文献到课题起源库（source=manual，成员行 status=included）。
+
+    只做同步的解析 + 去重 + 建行；PDF 下载/全文抽取/向量化/打分由后台任务完成。
+    """
     # 人工导入落在课题起源库上；课题必须有一个可解析的库（隐式库常态存在）
     library = await get_library_for_project(session, project_id)
     if library is None:
@@ -249,13 +300,13 @@ async def add_manual_paper_to_library(
     doi: str | None = None,
     bibtex: str | None = None,
     project_id: uuid.UUID | None = None,
-) -> Paper:
+) -> ManualAddResult:
     """手动添加一篇文献到**指定库**（库工作台入口，含独立库 project_id=None）。
 
     - 先查全局内容池（arxiv/doi/dedup_key）：池中已有则只建成员行（pool hit，
       跳过解析下载）；本库已有成员行 → DuplicatePaperError（路由映射 409）
     - 解析失败 → ParseFailedError（路由映射 422）
-    - 新论文有 arxiv_id 的自动尝试补下 PDF，失败只记日志不阻塞
+    - 新论文只落元数据行；PDF 下载/全文抽取/向量化/打分由后台任务补全
     project_id 仅用于 LLM 记账归因（补机构等），独立库为空。
     """
     fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
@@ -278,10 +329,10 @@ async def add_manual_paper_to_library(
         )
         await session.commit()
         await session.refresh(pooled)
-        return pooled
+        return ManualAddResult(paper=pooled, created=False)
 
-    paper = await create_pool_paper(session, fields=fields, project_id=project_id)
+    paper = await create_pool_paper_stub(session, fields=fields)
     await ensure_membership(session, library_id=library.id, paper_id=paper.id, status="included")
     await session.commit()
     await session.refresh(paper)
-    return paper
+    return ManualAddResult(paper=paper, created=True)

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -9,7 +9,7 @@
 """
 
 import uuid
-from typing import Any
+from typing import Any, NamedTuple
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -335,6 +335,14 @@ async def remove_from_shelf(
     await session.commit()
 
 
+class ShelfImportResult(NamedTuple):
+    """个人补充入架结果：书架条目 + paper + 是否新建了内容池行。"""
+
+    item: dict[str, Any]
+    paper: Paper
+    created: bool
+
+
 async def import_to_shelf(
     session: AsyncSession,
     *,
@@ -343,13 +351,15 @@ async def import_to_shelf(
     arxiv_id: str | None = None,
     doi: str | None = None,
     title: str | None = None,
-) -> dict[str, Any]:
+) -> ShelfImportResult:
     """个人补充入库：先按 dedup 查全局池，命中直接入架；未命中抓取解析入池后入架。
 
     个人补充**不建任何 library_papers 成员行**（「在池但不在任何库」是合法状态，
     §3.5）；解析计费按现有归因规则记调用用户。仅有标题且池中查不到时无法抓取
-    （paper_import.ParseFailedError → 路由映射 422）。
+    （paper_import.ParseFailedError → 路由映射 422）。新建池行只落元数据；PDF 下载/
+    全文抽取/向量化由后台任务补全（无 target，不打分）。
     """
+    created = False
     normalized_arxiv = normalize_arxiv_id(arxiv_id) if arxiv_id else None
     clean_doi = doi.strip().removeprefix("https://doi.org/") if doi else None
     paper = await find_pool_paper(
@@ -382,9 +392,9 @@ async def import_to_shelf(
             ),
         )
         if paper is None:
-            paper = await paper_import.create_pool_paper(
-                session, fields=fields, user_id=user_id, project_id=project_id
-            )
-    return await add_to_shelf(
+            paper = await paper_import.create_pool_paper_stub(session, fields=fields)
+            created = True
+    item = await add_to_shelf(
         session, project_id=project_id, paper_id=paper.id, user_id=user_id
     )
+    return ShelfImportResult(item=item, paper=paper, created=created)

--- a/src/backend/tests/test_paper_add_progress.py
+++ b/src/backend/tests/test_paper_add_progress.py
@@ -1,0 +1,247 @@
+"""手动添加文献的分阶段后台补全（task_id + enrich_paper 阶段事件 + SSE 鉴权），全离线。"""
+
+import asyncio
+import json
+import time
+import uuid
+
+import fakeredis.aioredis
+import httpx
+import pytest_asyncio
+import respx
+
+from app.core.db import get_sessionmaker
+from app.core.events import paper_task_channel
+from app.services import paper_enrich
+from app.services.literature import reset_clients, set_clients
+from app.services.literature.arxiv import ArxivClient
+from app.services.literature.openalex import OpenAlexClient
+from tests.conftest import (
+    add_paper,
+    make_project_with_library,
+    membership_of,
+    register_and_login,
+)
+
+ARXIV_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/{aid}v1</id>
+    <title>{title}</title>
+    <summary>Some abstract text.</summary>
+    <published>2026-06-01T00:00:00Z</published>
+    <author><name>Alice Smith</name></author>
+    <category term="cs.LG"/>
+  </entry>
+</feed>
+"""
+
+
+@pytest_asyncio.fixture
+async def lit_clients():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    set_clients(
+        arxiv=ArxivClient(redis=redis, min_interval=0),
+        openalex=OpenAlexClient(redis=redis, mailto="test@example.org"),
+    )
+    yield
+    reset_clients()
+    await redis.aclose()
+
+
+# ---- 1. 入口 task_id：新论文非空 / 池命中已完整为 null ----
+
+
+@respx.mock
+async def test_manual_add_returns_task_id_for_new_paper(client, lit_clients, fake_redis):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="add-proj")
+    feed = ARXIV_FEED.format(aid="2406.11111", title="New Paper")
+    respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        return_value=httpx.Response(200, text=feed)
+    )
+    respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(return_value=httpx.Response(404))
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/papers", json={"arxiv_id": "2406.11111"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    task_id = body["task_id"]
+    assert task_id  # 新建论文 → 启动了后台补全
+    # 同步响应不含重活结果（异步补全）
+    assert body["pdf_available"] is False
+
+    await paper_enrich.await_task(task_id)  # 排空后台任务（触发 pdf 404 download）
+
+
+async def test_manual_add_task_id_null_when_pool_hit_complete(client, fake_redis):
+    """池命中且已处理完整（有 pdf/全文/embedding）→ task_id 为 null。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    proj_a, _ = await make_project_with_library(client, headers, name="seed-proj")
+    proj_b, _ = await make_project_with_library(client, headers, name="target-proj")
+
+    async with get_sessionmaker()() as session:
+        await add_paper(
+            session,
+            project_id=uuid.UUID(proj_a),
+            title="Fully Processed Paper",
+            doi="10.5555/complete",
+            pdf_path="/tmp/x.pdf",
+            full_text_path="/tmp/x.txt",
+            embedding=[0.0] * 1024,
+        )
+        await session.commit()
+
+    # 加同一 DOI 到另一课题：池命中、本库无成员行、论文已完整 → 不启动任务
+    bibtex = "@article{c,\n title={Fully Processed Paper},\n doi={10.5555/complete},\n}"
+    resp = await client.post(
+        f"/api/projects/{proj_b}/papers", json={"bibtex": bibtex}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["task_id"] is None
+
+
+# ---- 2. enrich_paper 阶段事件顺序 + 出错继续 + done ----
+
+
+async def _collect_run_events(redis, *, task_id, **run_kwargs):
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(paper_task_channel(task_id))
+    runner = asyncio.create_task(
+        paper_enrich._run_enrichment(task_id=task_id, redis=redis, **run_kwargs)
+    )
+    events: list[dict] = []
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
+        if msg is not None:
+            payload = json.loads(msg["data"])
+            events.append(payload)
+            if payload["event"] in ("done", "error"):
+                break
+    await runner
+    await pubsub.unsubscribe(paper_task_channel(task_id))
+    await pubsub.aclose()
+    return events
+
+
+async def test_enrich_emits_all_stages_running_ok_and_done(client, fake_redis):
+    """无 arxiv 论文（download/extract 跳过）：仍按顺序发 5 个阶段 + done，embed ok。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="enrich-proj")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Bibtex Only", doi="10.1/x"
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    events = await _collect_run_events(
+        fake_redis,
+        task_id=uuid.uuid4().hex,
+        paper_id=paper_id,
+        library_id=None,
+        user_id=None,
+        project_id=None,
+    )
+    stage_events = [e["data"] for e in events if e["event"] == "stage"]
+    # 每个阶段的取值都在 STAGES 内，且顺序与 STAGES 一致
+    seen_order = [s["stage"] for s in stage_events]
+    assert seen_order[0] == "resolve"
+    # resolve/embed 都应有 ok（embed 走 fake provider）
+    assert {"stage": "resolve", "status": "ok", "detail": None} in stage_events
+    assert any(s["stage"] == "embed" and s["status"] in ("ok", "skipped") for s in stage_events)
+    # 阶段整体顺序不倒序
+    idx = [paper_enrich.STAGES.index(s) for s in seen_order]
+    assert idx == sorted(idx)
+    assert events[-1]["event"] == "done"
+
+
+async def test_enrich_error_continues_and_still_done(client, fake_redis, monkeypatch):
+    """embed 阶段抛错：发 embed/error，但 score 仍执行、最终仍 done。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="err-proj")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Boom Paper", doi="10.1/boom"
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("embed provider down")
+
+    monkeypatch.setattr(paper_enrich, "embed_paper", boom)
+
+    events = await _collect_run_events(
+        fake_redis,
+        task_id=uuid.uuid4().hex,
+        paper_id=paper_id,
+        library_id=library_id,
+        user_id=None,
+        project_id=uuid.UUID(project_id),
+    )
+    stage_events = [e["data"] for e in events if e["event"] == "stage"]
+    assert any(s["stage"] == "embed" and s["status"] == "error" for s in stage_events)
+    # embed 出错后 score 仍执行
+    assert any(s["stage"] == "score" for s in stage_events)
+    assert events[-1]["event"] == "done"
+
+
+# ---- 3. SSE 端点鉴权：非归属用户拿不到流 ----
+
+
+async def test_paper_task_events_auth(client, fake_redis):
+    token_a = await register_and_login(client, email="owner@example.com")
+    headers_a = {"Authorization": f"Bearer {token_a}"}
+    project_id, _ = await make_project_with_library(client, headers_a, name="sse-proj")
+    resp = await client.post(
+        f"/api/projects/{project_id}/papers",
+        json={"bibtex": "@article{s,\n title={SSE Paper},\n doi={10.9/sse},\n}"},
+        headers=headers_a,
+    )
+    assert resp.status_code == 201, resp.text
+    task_id = resp.json()["task_id"]
+    assert task_id
+    await paper_enrich.await_task(task_id)
+
+    # 非归属用户 → 404
+    token_b = await register_and_login(client, email="intruder@example.com")
+    resp = await client.get(
+        f"/api/paper-tasks/{task_id}/events",
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert resp.status_code == 404
+
+    # 不存在的 task_id → 404
+    resp = await client.get(
+        f"/api/paper-tasks/{uuid.uuid4().hex}/events", headers=headers_a
+    )
+    assert resp.status_code == 404
+
+
+async def test_manual_add_scores_via_background_task(client, fake_redis):
+    """打分已移入后台任务：同步响应 relevance_score 为 null，跑完任务后成员行落分。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="score-proj")
+    bibtex = "@article{r,\n title={Relevant Study},\n author={Doe, J},\n year={2024},\n}"
+    resp = await client.post(
+        f"/api/projects/{project_id}/papers", json={"bibtex": bibtex}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["relevance_score"] is None  # 异步打分，同步响应未落分
+    task_id = body["task_id"]
+    assert task_id
+    await paper_enrich.await_task(task_id)
+
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
+        assert membership.relevance_score is not None
+        assert membership.status == "included"  # 人工纳入，打分不改状态

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -69,9 +69,7 @@ async def test_add_by_arxiv_id_and_dedupe_409(client, lit_clients):
     respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
         return_value=httpx.Response(200, text=ARXIV_FEED_ONE)
     )
-    # PDF 下载失败也不阻塞创建（只记日志）
-    respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(return_value=httpx.Response(404))
-
+    # 同步请求只建元数据行（PDF 下载/抽取移入后台任务）：此处不下载 PDF
     resp = await client.post(
         f"/api/projects/{project_id}/papers", json={"arxiv_id": "2406.00001v2"}, headers=headers
     )
@@ -81,7 +79,7 @@ async def test_add_by_arxiv_id_and_dedupe_409(client, lit_clients):
     assert body["status"] == "included"
     assert body["arxiv_id"] == "2406.00001"
     assert body["authors"] == [{"name": "Alice Smith"}]
-    assert body["pdf_available"] is False  # 自动补 PDF 失败不阻塞
+    assert body["pdf_available"] is False  # 同步阶段不下载 PDF
     paper_id = body["id"]
 
     async with get_sessionmaker()() as session:
@@ -172,29 +170,31 @@ async def test_add_parse_failures_422(client, lit_clients):
     assert resp.json()["detail"].startswith("PARSE_FAILED")
 
 
-async def test_add_scores_relevance_best_effort(client):
-    """手动添加成功后顺带打相关性分（fake LLM）：分数/tldr/scored_at 落库，status 保持 included。"""
+async def test_add_scores_relevance_best_effort(client, fake_redis):
+    """打分已移入后台任务（fake LLM）：跑完后分数/tldr/scored_at 落库，status 保持 included。"""
+    from app.services import paper_enrich
+
     project_id, headers = await _setup(client)
     resp = await client.post(
         f"/api/projects/{project_id}/papers", json={"bibtex": BIBTEX_ENTRY}, headers=headers
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["relevance_score"] is not None and body["relevance_score"] > 0.6
-    assert body["tldr"]
+    assert body["relevance_score"] is None  # 同步响应尚未打分
     assert body["status"] == "included"
+    await paper_enrich.await_task(body["task_id"])
 
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, uuid.UUID(body["id"]))
         membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
-        assert membership.relevance_score == body["relevance_score"]
-        assert paper.tldr == body["tldr"]
+        assert membership.relevance_score is not None and membership.relevance_score > 0.6
         assert membership.scored_at is not None
         assert membership.status == "included"  # 人工纳入，打分不改状态
 
 
-async def test_add_low_score_keeps_included(client):
-    """分低绝不改状态：fake LLM 对含 irrelevant 的标题给低分，论文仍 included。"""
+async def test_add_low_score_keeps_included(client, fake_redis):
+    """分低绝不改状态：fake LLM 对含 irrelevant 的标题给低分（后台任务），论文仍 included。"""
+    from app.services import paper_enrich
+
     project_id, headers = await _setup(client)
     bibtex = (
         "@article{doe2024irr,\n"
@@ -208,11 +208,12 @@ async def test_add_low_score_keeps_included(client):
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["relevance_score"] is not None and body["relevance_score"] < 0.6
     assert body["status"] == "included"
+    await paper_enrich.await_task(body["task_id"])
 
     async with get_sessionmaker()() as session:
         membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
+        assert membership.relevance_score is not None and membership.relevance_score < 0.6
         assert membership.status == "included" and membership.trash_reason is None
 
 

--- a/src/backend/tests/test_topic_shelf.py
+++ b/src/backend/tests/test_topic_shelf.py
@@ -230,7 +230,7 @@ async def test_import_miss_fetches_and_creates_pool_only_paper(client, lit_clien
     respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
         return_value=httpx.Response(200, text=ARXIV_FEED_ONE)
     )
-    respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(return_value=httpx.Response(404))
+    # 同步入架只建元数据行（PDF 下载移入后台任务），此处不下载 PDF
 
     resp = await client.post(
         f"/api/projects/{project_id}/shelf/import",

--- a/src/frontend/src/features/library/PaperProgressModal.tsx
+++ b/src/frontend/src/features/library/PaperProgressModal.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useRef, useState } from 'react';
+import { Modal } from '../../components/ui/Modal';
+import { Icon } from '../../components/ui/Icon';
+import { subscribeSse } from '../../lib/sse';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   手动添加文献后的分阶段处理进度弹窗。
+   订阅 GET /paper-tasks/{taskId}/events（SSE）：
+   - event=stage → 更新对应阶段状态（best-effort：单阶段 error 不代表整体失败）
+   - event=done  → 收尾并短暂延迟后自动关闭 + 回调 onDone（刷新列表）
+   - event=error → 顶层致命错误，保留弹窗与关闭按钮，不自动关
+   阶段固定顺序：resolve → download → extract → embed → score。
+   ============================================================ */
+
+type StageId = 'resolve' | 'download' | 'extract' | 'embed' | 'score';
+type StageStatus = 'pending' | 'running' | 'ok' | 'skipped' | 'error';
+
+// 模块级常量保留 zh/en，渲染处再 tr（import 时求值不随语言切换更新）
+const STAGES: { id: StageId; zh: string; en: string }[] = [
+  { id: 'resolve', zh: '解析元数据', en: 'Resolving metadata' },
+  { id: 'download', zh: '下载 PDF', en: 'Downloading PDF' },
+  { id: 'extract', zh: '抽取正文', en: 'Extracting text' },
+  { id: 'embed', zh: '向量化', en: 'Embedding' },
+  { id: 'score', zh: '打分', en: 'Scoring' },
+];
+
+interface StageState {
+  status: StageStatus;
+  detail?: string;
+}
+
+/** 服务端 stage 事件里合法的终态/进行态（不含前端内部的 pending）。 */
+type WireStageStatus = 'running' | 'ok' | 'skipped' | 'error';
+
+function initStages(): Record<StageId, StageState> {
+  return STAGES.reduce(
+    (acc, s) => {
+      acc[s.id] = { status: 'pending' };
+      return acc;
+    },
+    {} as Record<StageId, StageState>,
+  );
+}
+
+/** 单阶段左侧的状态图标。 */
+function StageIcon({ status }: { status: StageStatus }) {
+  if (status === 'running') {
+    return <Icon name="refresh" size={14} style={{ color: 'var(--accent)', animation: 'spin 1s linear infinite' }} />;
+  }
+  if (status === 'ok') {
+    return <Icon name="check" size={15} style={{ color: 'var(--ok)' }} />;
+  }
+  if (status === 'skipped') {
+    return <Icon name="minus" size={15} style={{ color: 'var(--text-3)' }} />;
+  }
+  if (status === 'error') {
+    // 图标集里没有 warning，内联一个与 Icon 同风格（stroke / currentColor）的三角警示
+    return (
+      <svg
+        width={15}
+        height={15}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ color: 'var(--warn)' }}
+      >
+        <path d="M12 3 2.5 20h19z" />
+        <path d="M12 10v4M12 17.3h.01" />
+      </svg>
+    );
+  }
+  // pending：弱化的灰点
+  return (
+    <span
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: 'var(--muted-dot)',
+        display: 'inline-block',
+        margin: '0 3.5px',
+      }}
+    />
+  );
+}
+
+export interface PaperProgressModalProps {
+  taskId: string;
+  paperTitle?: string;
+  onClose: () => void;
+  /** 处理完整（done）后回调，通常用于 invalidate 列表 query。 */
+  onDone?: () => void;
+}
+
+export function PaperProgressModal({ taskId, paperTitle, onClose, onDone }: PaperProgressModalProps) {
+  const [stages, setStages] = useState<Record<StageId, StageState>>(initStages);
+  const [done, setDone] = useState(false);
+  const [fatal, setFatal] = useState<string | null>(null);
+
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    let stopped = false;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cancel = subscribeSse(`/paper-tasks/${taskId}/events`, {
+      onEvent: (event, data) => {
+        if (stopped) return;
+        if (event === 'stage') {
+          try {
+            const d = JSON.parse(data) as { stage: StageId; status: WireStageStatus; detail?: string };
+            setStages((prev) => (prev[d.stage] ? { ...prev, [d.stage]: { status: d.status, detail: d.detail } } : prev));
+          } catch {
+            /* 忽略解析失败的片段 */
+          }
+        } else if (event === 'done') {
+          // 仍在 running 的阶段收尾为 ok；pending 的维持原样
+          setStages((prev) => {
+            const next = { ...prev };
+            for (const s of STAGES) {
+              if (next[s.id].status === 'running') next[s.id] = { status: 'ok' };
+            }
+            return next;
+          });
+          setDone(true);
+          stopped = true;
+          cancel(); // 正常结束，主动断开避免 subscribeSse 自动重连
+          closeTimer = setTimeout(() => {
+            onDoneRef.current?.();
+            onCloseRef.current();
+          }, 1100);
+        } else if (event === 'error') {
+          let message = tr('处理失败', 'Processing failed');
+          try {
+            const m = (JSON.parse(data) as { message?: string }).message;
+            if (m) message = m;
+          } catch {
+            /* keep default */
+          }
+          setFatal(message);
+          stopped = true;
+          cancel();
+        }
+      },
+    });
+
+    return () => {
+      stopped = true;
+      cancel();
+      if (closeTimer) clearTimeout(closeTimer);
+    };
+  }, [taskId]);
+
+  const sub = paperTitle ?? (done ? tr('处理完成', 'Done') : tr('正在后台处理，请稍候…', 'Working in the background…'));
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      width={460}
+      title={
+        <>
+          <Icon
+            name={fatal ? 'x' : done ? 'check' : 'sparkle'}
+            size={15}
+            style={{ color: fatal ? 'var(--warn)' : done ? 'var(--ok)' : 'var(--accent)' }}
+          />
+          {tr('正在处理文献', 'Processing paper')}
+        </>
+      }
+      sub={sub}
+      footer={
+        <button className="btn btn-ghost sm" onClick={onClose}>
+          {done ? tr('完成', 'Done') : tr('关闭', 'Close')}
+        </button>
+      }
+    >
+      <div className="col" style={{ gap: 2 }}>
+        {STAGES.map((s) => {
+          const st = stages[s.id];
+          const dim = st.status === 'pending' || st.status === 'skipped';
+          return (
+            <div key={s.id} className="row gap10" style={{ padding: '7px 2px', alignItems: 'flex-start' }}>
+              <span
+                className="row"
+                style={{ width: 18, height: 20, justifyContent: 'center', flexShrink: 0 }}
+              >
+                <StageIcon status={st.status} />
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  className="row gap6"
+                  style={{ fontSize: 12.5, fontWeight: 560, color: dim ? 'var(--text-3)' : 'var(--text)', lineHeight: 1.4 }}
+                >
+                  {tr(s.zh, s.en)}
+                  {st.status === 'skipped' && (
+                    <span style={{ fontSize: 10.5, color: 'var(--text-3)', fontWeight: 400 }}>
+                      {tr('已跳过', 'Skipped')}
+                    </span>
+                  )}
+                </div>
+                {st.detail && (
+                  <div
+                    style={{
+                      fontSize: 10.5,
+                      lineHeight: 1.5,
+                      marginTop: 2,
+                      color: st.status === 'error' ? 'var(--warn-tx)' : 'var(--text-3)',
+                    }}
+                  >
+                    {st.detail}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {fatal && (
+        <div
+          style={{
+            marginTop: 14,
+            fontSize: 11.5,
+            lineHeight: 1.6,
+            color: 'var(--danger-tx)',
+            background: 'var(--danger-bg)',
+            borderRadius: 8,
+            padding: '9px 11px',
+          }}
+        >
+          {fatal}
+        </div>
+      )}
+      {done && !fatal && (
+        <div
+          style={{
+            marginTop: 14,
+            fontSize: 11.5,
+            lineHeight: 1.6,
+            color: 'var(--ok-tx)',
+            background: 'var(--ok-bg)',
+            borderRadius: 8,
+            padding: '9px 11px',
+          }}
+        >
+          {tr('文献已处理完成。', 'Paper processed.')}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -29,6 +29,7 @@ import {
   YearRangeField,
 } from '../wiki/shared';
 import { AddPaperModal } from './AddPaperModal';
+import { PaperProgressModal } from '../library/PaperProgressModal';
 import { ShelfChatTab } from './ShelfChatTab';
 import { ShelfDetailPane, WikiBadge } from './ShelfDetailPane';
 
@@ -294,6 +295,8 @@ export function ResearchPage() {
   const [filter, setFilter] = useState<ShelfFilter>('all');
   const [selId, setSelId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
+  // 个人补充入架后若后端返回 task_id，弹出分阶段处理进度
+  const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
 
   // 关键词 + 高级检索条件（走后端）
   const [qInput, setQInput] = useState('');
@@ -440,9 +443,14 @@ export function ResearchPage() {
   const importMutation = useMutation({
     mutationFn: (input: ShelfImportInput) => api.importToShelf(pid, input),
     onSuccess: (item) => {
-      toast(tr('已添加到相关研究', 'Added to related work'), 'ok');
       setSelId(item.paper_id);
       invalidate();
+      if (item.task_id) {
+        // 还需后处理：弹进度弹窗替代成功 toast，避免重复打扰
+        setProgress({ taskId: item.task_id, title: item.title });
+      } else {
+        toast(tr('已添加到相关研究', 'Added to related work'), 'ok');
+      }
     },
     onError: (e) => toast(`${tr('添加失败：', 'Failed to add: ')}${errText(e)}`, 'error'),
   });
@@ -793,6 +801,15 @@ export function ResearchPage() {
         importPending={importMutation.isPending}
         onImport={(input) => importMutation.mutateAsync(input)}
       />
+
+      {progress && (
+        <PaperProgressModal
+          taskId={progress.taskId}
+          paperTitle={progress.title}
+          onClose={() => setProgress(null)}
+          onDone={invalidate}
+        />
+      )}
     </div>
   );
 }

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -33,6 +33,7 @@ import { clickable } from '../../lib/a11y';
 import { categoryMeta, saveBlob, SearchInput, useDebounced } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
+import { PaperProgressModal } from '../library/PaperProgressModal';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -105,6 +106,13 @@ function AddPaperModal({
   const [doi, setDoi] = useState('');
   const [bibtex, setBibtex] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
+  // 手动添加后若后端返回 task_id，弹出分阶段处理进度
+  const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
+
+  const invalidateLists = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+    void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
+  }, [queryClient, scopeId]);
 
   const input: PaperImportInput | null =
     method === 'arxiv'
@@ -129,12 +137,16 @@ function AddPaperModal({
   const importMutation = useMutation({
     mutationFn: (inp: PaperImportInput) => (libraryId ? api.importLibraryPaper(libraryId, inp) : api.importPaper(pid, inp)),
     onSuccess: (p) => {
-      toast(tr('文献已加进论文库', 'Paper added to the library'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
-      void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
+      invalidateLists();
       reset();
       onClose();
       onImported(p.id);
+      if (p.task_id) {
+        // 还需后处理：弹进度弹窗替代成功 toast，避免重复打扰
+        setProgress({ taskId: p.task_id, title: p.title });
+      } else {
+        toast(tr('文献已加进论文库', 'Paper added to the library'), 'ok');
+      }
     },
     onError: (e) => {
       if (e instanceof ApiError && e.status === 409) {
@@ -154,6 +166,7 @@ function AddPaperModal({
   });
 
   return (
+    <>
     <Modal
       open={open}
       onClose={onClose}
@@ -276,6 +289,15 @@ function AddPaperModal({
         )}
       </div>
     </Modal>
+    {progress && (
+      <PaperProgressModal
+        taskId={progress.taskId}
+        paperTitle={progress.title}
+        onClose={() => setProgress(null)}
+        onDone={invalidateLists}
+      />
+    )}
+    </>
   );
 }
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -650,6 +650,8 @@ export interface PaperDetail extends PaperRead {
   concepts: PaperConceptRef[];
   /** 论文图片列表（后端未就绪时可能缺失） */
   figures?: FigureInfo[];
+  /** 手动添加后若仍需分阶段后处理，返回可订阅进度的任务 id；已处理完整时为 null。 */
+  task_id?: string | null;
 }
 
 export interface PageOf<T> {
@@ -918,6 +920,8 @@ export interface ShelfItemRead {
   /** 来源方向库（个人补充为 null） */
   source_library_id: string | null;
   added_at: string;
+  /** 个人补充入架后若仍需分阶段后处理，返回可订阅进度的任务 id；已处理完整时为 null。 */
+  task_id?: string | null;
 }
 
 /** 个人版 wiki 按需编译结果（P5b）。 */


### PR DESCRIPTION
## What

Manually adding a paper (arxiv / doi / bibtex) used to run download + extract (+ score) **synchronously inside the request** with no feedback. Now you get a live, staged progress popover.

- After clicking **添加文献**, the request only resolves metadata + creates the row (keeping the existing 409 already-exists / 422 parse-failed responses), then hands the heavy work to a background task.
- The task streams per-stage progress over SSE: **解析 → 下载 → 抽取 → 向量化 → 打分**. A modal lights each stage up (running / ok / skipped / error), auto-closes on done, and surfaces a fatal error otherwise.
- Adds paper-level embedding on manual add (previously only done in the Voyage ingest loop), so "向量化" is a real stage.
- Scope note: the `+` popover (add-to-topics/library, #71) does **not** process anything (pure association), so it intentionally shows no progress. This targets the manual **添加文献** flow.

## Backend

- `services/paper_enrich.py` — `enrich_paper` runs the stages, each best-effort (an errored stage still lets later stages run; already-present artifacts report `skipped`). `launch_paper_enrichment` spawns it as an `asyncio` task on its own session and registers task ownership in redis.
- `core/events.py` — `paper_task:{id}` channel + `publish_paper_task_event` (no DB logging; progress is ephemeral).
- `GET /paper-tasks/{task_id}/events` — owner-scoped SSE, forwards the channel with a 15s heartbeat, closes on `done`/`error`.
- The three manual-add endpoints (`POST /projects/{pid}/papers`, `POST /libraries/{id}/papers`, `POST /projects/{pid}/shelf/import`) return `task_id` on `PaperDetail` / `ShelfItemRead` (null when the paper is already complete → no popover, old toast).

## Frontend

- `features/library/PaperProgressModal.tsx` — subscribes the SSE stream and renders the five stages; reuses `subscribeSse`, `Modal`, `Icon`, design tokens.
- Wired into all three add entry points (course library + specific library via `PapersTab`'s `AddPaperModal`; shelf import via `ResearchPage`).

## Tests

`tests/test_paper_add_progress.py` (new) + updated manual-add / shelf tests — **24 passed**. `npx tsc --noEmit` clean.

Two failures in the broader suite (`test_library_paper_management::...forbidden_for_non_manager` at the ingest/state assertion, and `test_paper_review` `AttributeError: latex_compile has no _run_tectonic`) were verified to **reproduce on clean `origin/main`** and are unrelated to this change.