### PR TITLE
fix(library): scope paper detail read + delete to the current library

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -503,6 +503,32 @@ async def list_library_papers(
     )
 
 
+@router.get("/libraries/{library_id}/papers/{paper_id}", response_model=PaperDetail)
+async def get_library_paper(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """取某篇论文在**指定库**的成员行详情（库工作台单篇详情，含独立库）。
+
+    精确锁定 (library_id, paper_id)：相关度/状态/wiki 都是本库那份成员行，不做
+    跨库归并（对照 :func:`papers_service.get_paper_for_user` 的确定性归并）。库不含
+    该论文 → 404。读端点全实验室可读（可见性同本文件其它读端点）。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library.id,
+        project_id=library.project_id,
+        paper_id=paper_id,
+        with_concepts=True,
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    return await _paper_detail(session, view, user.id)
+
+
 @router.get("/libraries/{library_id}/concepts", response_model=list[ConceptRead])
 async def list_library_concepts(
     library_id: uuid.UUID,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -279,6 +279,35 @@ async def paper_task_events(
     )
 
 
+@router.get("/projects/{project_id}/papers/{paper_id}", response_model=PaperDetail)
+async def get_project_paper(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """取某篇论文在**课题起源库**那份成员行的详情（课题论文库单篇详情）。
+
+    精确锁定起源库 (library, paper_id) 的成员行——相关度/状态/wiki 都是该库口径，
+    不做跨库归并（对照无库作用域的 ``GET /papers/{id}``）。论文不在该课题库 → 404。
+    鉴权同课题其它读端点（成员 ∪ 策展人 ∪ admin）。
+    """
+    await _get_managed_project(session, project_id, user)
+    library = await libraries_service.get_library_for_project(session, project_id)
+    if library is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library.id,
+        project_id=project_id,
+        paper_id=paper_id,
+        with_concepts=True,
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    return await _paper_detail(session, view, user.id)
+
+
 @router.get("/papers/{paper_id}", response_model=PaperDetail)
 async def get_paper(
     paper_id: uuid.UUID,

--- a/src/backend/tests/test_scoped_paper_detail.py
+++ b/src/backend/tests/test_scoped_paper_detail.py
@@ -1,0 +1,169 @@
+"""库/课题作用域的单篇详情读端点（fix：同一论文属多个库时详情读到错库那份成员行）。
+
+覆盖：
+- GET /libraries/{A}/papers/{id} 与 GET /libraries/{B}/papers/{id} 各返回本库那份
+  relevance_score/status，不做跨库归并（对照无库作用域的 get_paper_for_user）。
+- GET /projects/{pid}/papers/{id} 返回课题起源库那份成员行。
+- 通过库作用域 batch-delete 删 A 库那份后，B 库那份仍在（作用域隔离）。
+- 库不含该论文 → 404。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.user import User
+from tests.conftest import make_project_with_library, register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _create_active_standalone(client, creator_headers, admin_headers, name="独立库"):
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": name, "statement": "LLM agent 规划方向"},
+        headers=creator_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    return lib_id
+
+
+async def _new_paper(title="Shared paper") -> str:
+    async with get_sessionmaker()() as session:
+        paper = Paper(
+            title=title,
+            abstract="agent planning abstract",
+            authors=[{"name": "Alice"}],
+            year=2024,
+            source="arxiv",
+        )
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def _add_membership(lib_id, paper_id, *, status, relevance, wiki=None) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(
+            LibraryPaper(
+                library_id=uuid.UUID(str(lib_id)),
+                paper_id=uuid.UUID(str(paper_id)),
+                status=status,
+                relevance_score=relevance,
+                wiki_content=wiki,
+            )
+        )
+        await session.commit()
+
+
+async def test_library_scoped_detail_does_not_cross_libraries(client):
+    """同一论文在 A(excluded,0.18) / B(included,0.96)：各库详情读到各自那份，不串。"""
+    admin = await _hdr(client, "scoped-admin@example.com")
+    await _promote_admin("scoped-admin@example.com")
+    creator = await _hdr(client, "scoped-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="CUA 库")
+    lib_b = await _create_active_standalone(client, creator, admin, name="Spatial Reasoning 库")
+
+    paper_id = await _new_paper()
+    await _add_membership(lib_a, paper_id, status="excluded", relevance=0.18)
+    await _add_membership(lib_b, paper_id, status="included", relevance=0.96)
+
+    resp = await client.get(f"/api/libraries/{lib_a}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "excluded"
+    assert resp.json()["relevance_score"] == 0.18
+
+    resp = await client.get(f"/api/libraries/{lib_b}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "included"
+    assert resp.json()["relevance_score"] == 0.96
+
+
+async def test_library_scoped_detail_404_when_not_member(client):
+    admin = await _hdr(client, "scoped404-admin@example.com")
+    await _promote_admin("scoped404-admin@example.com")
+    creator = await _hdr(client, "scoped404-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="A 库")
+    lib_b = await _create_active_standalone(client, creator, admin, name="B 库")
+
+    paper_id = await _new_paper()
+    await _add_membership(lib_a, paper_id, status="included", relevance=0.9)
+
+    # 论文只在 A 库，问 B 库 → 404
+    resp = await client.get(f"/api/libraries/{lib_b}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "PAPER_NOT_FOUND"
+    # 完全不存在的论文 → 404
+    resp = await client.get(f"/api/libraries/{lib_a}/papers/{uuid.uuid4()}", headers=creator)
+    assert resp.status_code == 404
+
+
+async def test_project_scoped_detail_reads_origin_library(client):
+    """课题起源库(0.42) 与另一独立库(0.99) 各有一份：/projects/{pid}/papers 读起源库那份。"""
+    admin = await _hdr(client, "scopedproj-admin@example.com")
+    await _promote_admin("scopedproj-admin@example.com")
+    creator = await _hdr(client, "scopedproj-owner@example.com")
+    pid, origin_lib = await make_project_with_library(client, creator, name="课题起源库")
+    other_lib = await _create_active_standalone(client, creator, admin, name="别的库")
+
+    paper_id = await _new_paper(title="Cross-library paper")
+    await _add_membership(origin_lib, paper_id, status="scored", relevance=0.42)
+    await _add_membership(other_lib, paper_id, status="included", relevance=0.99)
+
+    resp = await client.get(f"/api/projects/{pid}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "scored"
+    assert resp.json()["relevance_score"] == 0.42
+
+    # 不在该课题任何库的论文 → 404
+    resp = await client.get(f"/api/projects/{pid}/papers/{uuid.uuid4()}", headers=creator)
+    assert resp.status_code == 404
+
+
+async def test_scoped_delete_isolates_other_library(client):
+    """删 A 库那份后：A 库论文库空、A 详情 excluded；B 库那份仍 included、列表/详情可见。"""
+    admin = await _hdr(client, "scopeddel-admin@example.com")
+    await _promote_admin("scopeddel-admin@example.com")
+    creator = await _hdr(client, "scopeddel-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="删除源库 A")
+    lib_b = await _create_active_standalone(client, creator, admin, name="保留库 B")
+
+    paper_id = await _new_paper(title="Delete-me-in-A only")
+    await _add_membership(lib_a, paper_id, status="included", relevance=0.5)
+    await _add_membership(lib_b, paper_id, status="included", relevance=0.7)
+
+    # 库作用域批删（单篇）A 库那份
+    resp = await client.post(
+        f"/api/libraries/{lib_a}/papers/batch-delete",
+        json={"paper_ids": [paper_id]},
+        headers=creator,
+    )
+    assert resp.status_code == 200 and resp.json()["deleted"] == 1
+
+    # A 库：论文库不再有它，详情读到 excluded 那份
+    resp = await client.get(f"/api/libraries/{lib_a}/papers?status=library", headers=creator)
+    assert resp.json()["total"] == 0
+    resp = await client.get(f"/api/libraries/{lib_a}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200 and resp.json()["status"] == "excluded"
+
+    # B 库：不受影响，列表可见、详情仍 included
+    resp = await client.get(f"/api/libraries/{lib_b}/papers?status=library", headers=creator)
+    assert [p["id"] for p in resp.json()["items"]] == [paper_id]
+    resp = await client.get(f"/api/libraries/{lib_b}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200 and resp.json()["status"] == "included"
+    assert resp.json()["relevance_score"] == 0.7

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -824,7 +824,7 @@ function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) 
   const putMutation = useMutation({
     mutationFn: (names: string[]) => api.putPaperTags(paper.id, names),
     onSuccess: (p) => {
-      queryClient.setQueryData<PaperDetail>(['paper', paper.id], p);
+      queryClient.setQueryData<PaperDetail>(['paper', scopeId, paper.id], p);
       void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
       void queryClient.invalidateQueries({ queryKey: ['project-tags', scopeId] });
     },
@@ -940,16 +940,28 @@ function PaperDetailPane({
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
 
+  // 作用域读：锁定当前库/课题那份成员行，避免同一论文属多个库时读到跨库归并的错行
+  // （相关度/状态/wiki）。queryKey 带 scope 隔离不同库的缓存。
   const { data: paper, isLoading, isError } = useQuery({
-    queryKey: ['paper', paperId],
-    queryFn: () => api.getPaper(paperId),
+    queryKey: ['paper', scopeId, paperId],
+    queryFn: () =>
+      libraryId
+        ? api.getLibraryPaper(libraryId, paperId)
+        : pid
+          ? api.getProjectPaper(pid, paperId)
+          : api.getPaper(paperId),
     retry: false,
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => api.patchPaper(paperId, { status: 'excluded' }),
+    // 作用域删：只删当前库那份成员行（同列表多选删除口径），不误删跨库的另一份。
+    mutationFn: () =>
+      libraryId
+        ? api.batchDeleteLibraryPapers(libraryId, [paperId])
+        : api.batchDeletePapers(scopeId, [paperId]),
     onSuccess: () => {
       toast(tr('已移入垃圾桶，可在列表底部的垃圾桶中召回', 'Moved to trash — restore it from the trash any time'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['paper', scopeId, paperId] });
       void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
       void queryClient.invalidateQueries({ queryKey: ['papers-trash', scopeId] });
       void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
@@ -964,7 +976,7 @@ function PaperDetailPane({
   const metaMutation = useMutation({
     mutationFn: (input: Partial<MyMeta>) => api.putMyMeta(paperId, input),
     onSuccess: (meta) => {
-      queryClient.setQueryData<PaperDetail>(['paper', paperId], (old) =>
+      queryClient.setQueryData<PaperDetail>(['paper', scopeId, paperId], (old) =>
         old ? { ...old, starred: meta.starred, reading_status: meta.reading_status } : old,
       );
       void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
@@ -978,7 +990,7 @@ function PaperDetailPane({
     mutationFn: () => api.recompilePaper(paperId),
     onSuccess: () => {
       toast(tr('编译完成，介绍已更新', 'Compiled — the intro has been updated'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['paper', paperId] });
+      void queryClient.invalidateQueries({ queryKey: ['paper', scopeId, paperId] });
       void queryClient.invalidateQueries({ queryKey: ['paper-figures', paperId] });
       void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
     },

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2537,6 +2537,10 @@ export const api = {
   getPaper(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}`);
   },
+  /** 课题作用域单篇详情：锁定课题起源库那份成员行（相关度/状态/wiki 不跨库串味）。 */
+  getProjectPaper(projectId: string, paperId: string): Promise<PaperDetail> {
+    return request<PaperDetail>(`/projects/${projectId}/papers/${paperId}`);
+  },
   /** 人工纳入/排除。 */
   patchPaper(id: string, input: { status: 'included' | 'excluded' }): Promise<PaperRead> {
     return requestJson<PaperRead>(`/papers/${id}`, 'PATCH', input);
@@ -2892,6 +2896,10 @@ export const api = {
     if (opts.created_to) params.set('created_to', opts.created_to);
     const qs = params.toString();
     return request<PageOf<PaperRead>>(`/libraries/${id}/papers${qs ? `?${qs}` : ''}`);
+  },
+  /** 库作用域单篇详情：锁定该库那份成员行（相关度/状态/wiki 不跨库串味）。 */
+  getLibraryPaper(id: string, paperId: string): Promise<PaperDetail> {
+    return request<PaperDetail>(`/libraries/${id}/papers/${paperId}`);
   },
   /** 手动添加文献到库；409 → PAPER_EXISTS（body 含 paper_id）；422 → PARSE_FAILED。 */
   importLibraryPaper(id: string, input: PaperImportInput): Promise<PaperDetail> {


### PR DESCRIPTION
## Bug

In a library workbench, a paper that belongs to **more than one library** showed the wrong relevance/wiki in the detail pane and **could not be deleted**.

Confirmed on the dev DB with the reported paper (`S-Agent: Spatial Tool-Use…`):

| library | status | relevance |
|---|---|---|
| CUA | excluded | 0.18 |
| Spatial Reasoning | included | 0.96 |

Viewing the **Spatial Reasoning** list (0.96), the detail pane showed **0.18** and delete did nothing.

## Root cause

The detail pane's read (`GET /papers/{id}`) and delete (`PATCH /papers/{id}`) both went through `get_paper_for_user`, which for a multi-library paper resolves an **arbitrary cross-library membership** (wiki-bearing, else earliest = CUA) rather than the library being viewed. So the pane read CUA's membership (0.18) and the delete trashed CUA (already excluded → no-op), while the Spatial-Reasoning membership stayed `included` → the paper never left the list. One root cause behind both symptoms. Pre-existing; surfaced by the same paper being in two libraries.

## Fix

- **Backend** — add library/project-scoped read endpoints `GET /libraries/{id}/papers/{paper_id}` and `GET /projects/{pid}/papers/{paper_id}`, both backed by `get_library_paper_view`, so relevance/status/wiki come from **that library's** membership. `get_paper_for_user` is **unchanged** (reading page / shelf / personal library still need the cross-library view).
- **Frontend** — `PaperDetailPane` reads via the scoped endpoint and deletes via the scoped batch-delete (`batchDeleteLibraryPapers` / `batchDeletePapers`). Detail cache key is scoped `['paper', scopeId, paperId]` so libraries don't share it.

## Tests

New `test_scoped_paper_detail.py` (4 cases: no cross-library bleed on read; 404 when library lacks the paper; project reads the origin library; scoped delete isolates the other library). `npx tsc --noEmit` clean.

The 1 pre-existing failure in the broader suite (`test_manage_endpoints_forbidden_for_non_manager` at the `ingest/state` assertion) reproduces on clean `origin/main` and is unrelated.

## Known follow-up (not in this PR)

Trash **restore** (`POST /papers/{id}/restore`) and **purge** (`DELETE /papers/{id}`) share the same cross-library resolution — a paper trashed in library B but active in library A can, on restore from B's trash, hit A's membership. Symmetric fix (scoped restore/purge endpoints) can follow if wanted.