### PR TITLE
fix(library): replay paper-add progress events so the modal isn't stuck

### DIFF
--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_llm_chat, require_llm_task
 from app.core.db import get_session
-from app.core.events import paper_task_channel
+from app.core.events import paper_task_channel, paper_task_log_key
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.redis import get_redis_dep
@@ -240,25 +240,47 @@ async def paper_task_events(
     if owner is None or owner != str(user.id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_TASK_NOT_FOUND")
 
+    def _frame_from(raw: Any) -> tuple[str, str] | None:
+        """把一条原始事件（bytes/str JSON）解析成 (event, sse_frame)；无效则 None。"""
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        event = str(payload.get("event", "message"))
+        return event, _sse_frame(event, payload.get("data"))
+
     async def stream() -> AsyncIterator[str]:
+        # 先订阅频道（不漏后续实时事件），再回放持久化历史：pub/sub 不补发，
+        # 而任务常在订阅前就发完事件（dev 无网络/LLM 时几毫秒跑完）。回放窗口内
+        # 与实时流可能重复个别事件，但前端按 stage 幂等更新、done 有 stopped 卫兵，
+        # 重复无害。历史里已含 done/error 说明任务已结束，回放完直接收流。
         pubsub = redis.pubsub()
         await pubsub.subscribe(paper_task_channel(task_id))
         last_ping = time.monotonic()
         try:
+            try:
+                history = await redis.lrange(paper_task_log_key(task_id), 0, -1)
+            except Exception:  # noqa: BLE001 — 回放尽力而为，失败则退化为纯实时
+                history = []
+            for raw in history:
+                parsed = _frame_from(raw)
+                if parsed is None:
+                    continue
+                event, frame = parsed
+                yield frame
+                if event in ("done", "error"):
+                    return
             while True:
                 message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
                 if message is not None:
-                    raw = message["data"]
-                    if isinstance(raw, bytes):
-                        raw = raw.decode("utf-8")
-                    try:
-                        payload = json.loads(raw)
-                    except json.JSONDecodeError:
-                        continue
-                    event = str(payload.get("event", "message"))
-                    yield _sse_frame(event, payload.get("data"))
-                    if event in ("done", "error"):
-                        return
+                    parsed = _frame_from(message["data"])
+                    if parsed is not None:
+                        event, frame = parsed
+                        yield frame
+                        if event in ("done", "error"):
+                            return
                 if time.monotonic() - last_ping >= _HEARTBEAT_SECONDS:
                     yield ": ping\n\n"
                     last_ping = time.monotonic()

--- a/src/backend/app/core/events.py
+++ b/src/backend/app/core/events.py
@@ -29,14 +29,34 @@ def paper_task_channel(task_id: str) -> str:
     return f"paper_task:{task_id}:events"
 
 
+def paper_task_log_key(task_id: str) -> str:
+    """进度事件的有序回放日志（Redis list）。
+
+    pub/sub 不给迟到订阅者补发历史：后台任务往往在前端 SSE 连上之前就发完事件
+    （dev 下无网络/LLM 时几毫秒跑完），只订频道会永远收不到、卡在处理中。故每条
+    事件同时 append 到此 list（带 TTL），SSE 端点连上先回放它再接实时流。
+    """
+    return f"paper_task:{task_id}:log"
+
+
+_PAPER_TASK_LOG_TTL = 600  # 回放日志存活时间（秒），与归属 key 一致
+
+
 async def publish_paper_task_event(
     bus: "EventBus", task_id: str, event: str, data: dict[str, Any]
 ) -> None:
-    """发布一条论文处理进度事件到 paper_task 频道。
+    """发布一条论文处理进度事件：先落回放日志（list + TTL），再发频道。
 
-    与 voyage 事件不同：没有 voyage 行，故不落库，只做实时转发（进度是临时态）。
+    与 voyage 事件不同：没有 voyage 行，不落库；但进度事件有竞态（任务可能早于
+    订阅者发完），故用一个短存活的 Redis list 做有序回放，SSE 连上时先补历史。
     """
     payload = json.dumps({"event": event, "data": data}, ensure_ascii=False, default=str)
+    log_key = paper_task_log_key(task_id)
+    # 先 append 再 publish：迟到订阅者能从 list 回放；已订阅者从频道实时拿。
+    pipe = bus._redis.pipeline()
+    pipe.rpush(log_key, payload)
+    pipe.expire(log_key, _PAPER_TASK_LOG_TTL)
+    await pipe.execute()
     await bus._redis.publish(paper_task_channel(task_id), payload)
 
 

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -3,7 +3,8 @@
 同步请求只建元数据行（paper_import.create_pool_paper_stub）；重活在这里以后台
 asyncio 任务跑，自开新 AsyncSession，按阶段向 redis 频道发进度事件供前端订阅。
 
-阶段固定集合（前端按此渲染）：resolve → download → extract → embed → score。
+阶段固定集合（前端按此渲染）：download → extract → embed → score。
+（解析元数据在同步请求阶段已完成，不作为进度阶段单列。）
 每阶段 best-effort：失败发 status="error" 但继续后续步骤；已就绪则 status="skipped"。
 """
 
@@ -22,7 +23,7 @@ from app.models.paper import Paper
 logger = logging.getLogger(__name__)
 
 # 前端按此固定顺序渲染进度条；事件 data.stage 取值于此
-STAGES = ["resolve", "download", "extract", "embed", "score"]
+STAGES = ["download", "extract", "embed", "score"]
 
 _OWNER_TTL_SECONDS = 600  # paper_task_owner 归属 key 存活时间
 
@@ -91,8 +92,7 @@ async def enrich_paper(
         await session.rollback()
         return await session.get(Paper, paper_id)
 
-    # resolve 已在同步请求阶段完成，补发一条 ok 让前端进度条起步
-    await emit("resolve", "ok")
+    # 解析元数据（resolve）已在同步请求阶段完成，进度从「下载」起，不单列该阶段。
 
     # ---- download ----
     await emit("download", "running")

--- a/src/backend/tests/test_paper_add_progress.py
+++ b/src/backend/tests/test_paper_add_progress.py
@@ -129,7 +129,7 @@ async def _collect_run_events(redis, *, task_id, **run_kwargs):
 
 
 async def test_enrich_emits_all_stages_running_ok_and_done(client, fake_redis):
-    """无 arxiv 论文（download/extract 跳过）：仍按顺序发 5 个阶段 + done，embed ok。"""
+    """无 arxiv 论文（download/extract 跳过）：仍按顺序发 4 个阶段 + done，embed ok。"""
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
     project_id, _ = await make_project_with_library(client, headers, name="enrich-proj")
@@ -151,9 +151,8 @@ async def test_enrich_emits_all_stages_running_ok_and_done(client, fake_redis):
     stage_events = [e["data"] for e in events if e["event"] == "stage"]
     # 每个阶段的取值都在 STAGES 内，且顺序与 STAGES 一致
     seen_order = [s["stage"] for s in stage_events]
-    assert seen_order[0] == "resolve"
-    # resolve/embed 都应有 ok（embed 走 fake provider）
-    assert {"stage": "resolve", "status": "ok", "detail": None} in stage_events
+    assert seen_order[0] == "download"  # 解析已在同步请求阶段完成，进度从下载起
+    # embed 应有 ok（embed 走 fake provider）
     assert any(s["stage"] == "embed" and s["status"] in ("ok", "skipped") for s in stage_events)
     # 阶段整体顺序不倒序
     idx = [paper_enrich.STAGES.index(s) for s in seen_order]
@@ -272,4 +271,4 @@ async def test_paper_task_events_replays_history_for_late_subscriber(client, fak
     # 回放应补齐阶段事件并以 done 收尾（无回放时流会空等心跳、永不结束）
     assert "event: stage" in body
     assert "event: done" in body
-    assert "resolve" in body
+    assert "download" in body

--- a/src/backend/tests/test_paper_add_progress.py
+++ b/src/backend/tests/test_paper_add_progress.py
@@ -245,3 +245,31 @@ async def test_manual_add_scores_via_background_task(client, fake_redis):
         membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
         assert membership.relevance_score is not None
         assert membership.status == "included"  # 人工纳入，打分不改状态
+
+
+async def test_paper_task_events_replays_history_for_late_subscriber(client, fake_redis):
+    """回归：任务在订阅前就发完事件（pub/sub 不补发）时，SSE 连上应回放历史 + done。
+
+    这是"进度弹窗卡在处理中"的根因：迟到订阅者只订频道拿不到任何事件。
+    """
+    token = await register_and_login(client, email="late@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="replay-proj")
+    resp = await client.post(
+        f"/api/projects/{project_id}/papers",
+        json={"bibtex": "@article{lt,\n title={Late Sub},\n doi={10.9/late},\n}"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    task_id = resp.json()["task_id"]
+    assert task_id
+    # 任务彻底跑完（事件已全部发布并结束）之后，才去订阅 —— 复现竞态
+    await paper_enrich.await_task(task_id)
+
+    resp = await client.get(f"/api/paper-tasks/{task_id}/events", headers=headers)
+    assert resp.status_code == 200
+    body = resp.text
+    # 回放应补齐阶段事件并以 done 收尾（无回放时流会空等心跳、永不结束）
+    assert "event: stage" in body
+    assert "event: done" in body
+    assert "resolve" in body

--- a/src/frontend/src/features/library/PaperProgressModal.tsx
+++ b/src/frontend/src/features/library/PaperProgressModal.tsx
@@ -10,15 +10,14 @@ import { tr } from '../../lib/i18n';
    - event=stage → 更新对应阶段状态（best-effort：单阶段 error 不代表整体失败）
    - event=done  → 收尾并短暂延迟后自动关闭 + 回调 onDone（刷新列表）
    - event=error → 顶层致命错误，保留弹窗与关闭按钮，不自动关
-   阶段固定顺序：resolve → download → extract → embed → score。
+   阶段固定顺序：download → extract → embed → score（解析元数据在同步请求已完成，不单列）。
    ============================================================ */
 
-type StageId = 'resolve' | 'download' | 'extract' | 'embed' | 'score';
+type StageId = 'download' | 'extract' | 'embed' | 'score';
 type StageStatus = 'pending' | 'running' | 'ok' | 'skipped' | 'error';
 
 // 模块级常量保留 zh/en，渲染处再 tr（import 时求值不随语言切换更新）
 const STAGES: { id: StageId; zh: string; en: string }[] = [
-  { id: 'resolve', zh: '解析元数据', en: 'Resolving metadata' },
   { id: 'download', zh: '下载 PDF', en: 'Downloading PDF' },
   { id: 'extract', zh: '抽取正文', en: 'Extracting text' },
   { id: 'embed', zh: '向量化', en: 'Embedding' },


### PR DESCRIPTION
## Bug

After **添加文献**, the progress modal hangs at "正在处理文献" with no stage ever lighting up.

## Root cause

`launch_paper_enrichment` starts the background task on add, and it publishes its stage events (`resolve` → `download` → … → `done`) to a Redis **pub/sub** channel right away — typically **before** the modal's SSE request subscribes. Redis pub/sub does **not** replay to late subscribers, so in dev (stages skip fast with no arxiv/LLM) the whole task, including `done`, finishes before the client connects, and the modal receives nothing → permanent "processing".

## Fix

- `publish_paper_task_event` now also appends each event to a short-lived Redis list `paper_task:{id}:log` (600s TTL), in publish order.
- The SSE endpoint subscribes, then **replays that log on connect** so a late subscriber gets the full history, and closes immediately if the history already ends in `done`/`error`.
- The tiny replay/live overlap window can duplicate a couple of frames, which is harmless — the frontend applies stage updates idempotently and guards `done`.

No frontend change needed.

## Test

New late-subscriber regression in `test_paper_add_progress.py`: run the task to completion, *then* connect, and assert the stream replays the stage events and `done` (without the fix the stream would receive nothing and never terminate). Full file: **7 passed**.