### PR TITLE
fix(daily): collected papers get the manual-add enrichment pipeline

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -11,12 +11,16 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_admin, require_llm_chat, require_llm_task
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
+from app.core.redis import get_redis_dep
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.daily import (
     DailyCategoriesRead,
@@ -34,6 +38,7 @@ from app.schemas.daily import (
 from app.schemas.paper import PaperChatRequest
 from app.services import daily_feed as daily_service
 from app.services import library_chat as library_chat_service
+from app.services import paper_enrich as paper_enrich_service
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +166,7 @@ async def collect(
     payload: DailyCollectRequest,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
 ) -> DailyCollectResponse:
     results = await daily_service.collect_papers(
         session,
@@ -170,6 +176,27 @@ async def collect(
         topic_ids=payload.topic_ids,
         personal=payload.personal,
     )
+    # 与手动添加同款后台补全（#74：下载→抽取→补机构→向量化→打分）——池论文是轻量行，
+    # 收录后按第一个成功收录的方向库为打分目标；仅书架/个人收录则无打分目标。
+    target_library_id = next(
+        (r["target_id"] for r in results if r["target_type"] == "library" and not r["forbidden"]),
+        None,
+    )
+    project_id = None
+    if target_library_id is not None:
+        library = await session.get(DirectionLibrary, target_library_id)
+        project_id = library.project_id if library is not None else None
+    for paper_id in payload.paper_ids:
+        paper = await session.get(Paper, paper_id)
+        if paper is None or paper_enrich_service.paper_processing_complete(paper):
+            continue
+        await paper_enrich_service.launch_paper_enrichment(
+            redis=redis,
+            paper_id=paper_id,
+            user_id=user.id,
+            library_id=target_library_id,
+            project_id=project_id,
+        )
     return DailyCollectResponse(results=results)
 
 

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -410,7 +410,15 @@ _COMPILING: set[uuid.UUID] = set()
 async def compile_entry_wiki(
     session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
 ) -> DailyFeedEntry:
-    """通用模板编译单篇解读（全实验室共享一份），写进 entry；费用记个人。"""
+    """通用模板编译单篇解读（全实验室共享一份），写进 entry；费用记个人。
+
+    论文已有 PDF（典型：收录后被后台补全过）时先抽图 + 标注重要图，
+    与库版重新编译同款逻辑，产出图文解读；无 PDF 则纯文字。
+    """
+    from pathlib import Path
+
+    from app.services.figure_annotate import annotate_figures
+    from app.services.literature.pdf_extract import extract_figures
     from app.services.wiki_compile import compile_paper
 
     entry = await session.get(DailyFeedEntry, entry_id)
@@ -422,6 +430,16 @@ async def compile_entry_wiki(
         raise CompileInProgressError(str(entry_id))
     _COMPILING.add(entry_id)
     try:
+        if paper.pdf_path and Path(paper.pdf_path).exists():
+            # 从未提取过，或上一轮一张重要图都没选出来 → 重提候选（对齐 recompile_paper）
+            if paper.figures is None or not any(f.get("important") for f in paper.figures):
+                candidates = await extract_figures(str(paper.id), Path(paper.pdf_path))
+                paper.figures = [
+                    c | {"caption": None, "kind": None, "important": False} for c in candidates
+                ]
+            if paper.figures:
+                await annotate_figures(paper, paper.figures, user_id=user_id)
+            await session.commit()
         compiled = await compile_paper(paper, statement=None, user_id=user_id)
     finally:
         _COMPILING.discard(entry_id)

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -192,6 +192,17 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
         "topic_ids": [project_id],
         "personal": True,
     }
+    # 收录会启动与手动添加同款的后台补全（#74），打分目标 = 第一个成功收录的方向库
+    launched: list[dict] = []
+
+    async def _fake_launch(**kwargs):
+        launched.append(kwargs)
+        return "task-stub"
+
+    from app.services import paper_enrich
+
+    monkeypatch.setattr(paper_enrich, "launch_paper_enrichment", _fake_launch)
+
     resp = await client.post("/api/daily/collect", json=payload, headers=headers)
     assert resp.status_code == 200
     results = {r["target_type"]: r for r in resp.json()["results"]}
@@ -199,6 +210,12 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     assert results["topic"]["added"] == 1
     # 入架必入个人库（add_to_shelf 自带同步），个人库目标看到的是「已存在」
     assert results["personal"]["added"] + results["personal"]["skipped_existing"] == 1
+
+    # 池论文是轻量行（无 PDF）→ 必然触发补全，且目标库/课题归因正确
+    assert len(launched) == 1
+    assert str(launched[0]["paper_id"]) == item["paper_id"]
+    assert launched[0]["library_id"] == library_id
+    assert str(launched[0]["project_id"]) == project_id
 
     # 重复收录 → skipped_existing
     resp = await client.post("/api/daily/collect", json=payload, headers=headers)


### PR DESCRIPTION
Closes #76

Papers collected from the Daily Papers pool were second-class citizens compared to manually added ones: the pool keeps lightweight rows by design (no PDF), and collect only created membership rows, so collected papers never got affiliations, relevance scores, embeddings, or figures — and their AI summaries stayed text-only.

## Changes

- `POST /daily/collect` now launches the same background enrichment as manual add (#74: download → extract → affiliations → embed → score) for every collected paper that isn't fully processed. The score stage targets the first successfully collected direction library (its rubric + billing attribution via the library's topic); shelf/personal-only collects enrich without a scoring target, same as shelf imports.
- `POST /daily/papers/{entry_id}/compile` now mirrors library recompile: when a PDF exists and no important figures are annotated yet, it extracts + annotates figures before compiling, so enriched papers get illustrated summaries instead of text-only ones.

## Notes

- When collecting into multiple libraries at once, only the first library gets an automatic relevance score (enrichment is per-paper; stages are idempotent and skip work already done). Other libraries can score through their own pipelines.
- Test: collect asserts enrichment is launched with the right paper/library/topic attribution (7 passed; ruff clean).