### PR TITLE
fix(library): scope trash restore + permanent-delete to the current library

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -529,6 +529,59 @@ async def get_library_paper(
     return await _paper_detail(session, view, user.id)
 
 
+async def _managed_library_paper_view(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user: User,
+    with_concepts: bool = False,
+) -> papers_service.PaperView:
+    """可管理者精确锁定本库那份成员行（垃圾桶召回/彻底删除用；不跨库归并）。"""
+    library = await _get_managed_library(session, library_id, user)
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library.id,
+        project_id=library.project_id,
+        paper_id=paper_id,
+        with_concepts=with_concepts,
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    return view
+
+
+@router.post("/libraries/{library_id}/papers/{paper_id}/restore", response_model=PaperDetail)
+async def restore_library_paper(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """从**指定库**的垃圾桶召回该篇（精确锁定本库成员行，不跨库归并）。"""
+    view = await _managed_library_paper_view(
+        session, library_id=library_id, paper_id=paper_id, user=user, with_concepts=True
+    )
+    view = await papers_service.restore_paper(session, view)
+    return await _paper_detail(session, view, user.id)
+
+
+@router.delete(
+    "/libraries/{library_id}/papers/{paper_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_library_paper(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """从**指定库**彻底删除该篇（只删本库成员行，内容池论文/文件/笔记保留）。"""
+    view = await _managed_library_paper_view(
+        session, library_id=library_id, paper_id=paper_id, user=user
+    )
+    await papers_service.delete_paper(session, view)
+
+
 @router.get("/libraries/{library_id}/concepts", response_model=list[ConceptRead])
 async def list_library_concepts(
     library_id: uuid.UUID,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -308,6 +308,65 @@ async def get_project_paper(
     return await _paper_detail(session, view, user.id)
 
 
+async def _managed_project_library_view(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user: User,
+    with_concepts: bool = False,
+) -> papers_service.PaperView:
+    """课题写作用域下精确锁定起源库那份成员行（垃圾桶召回/彻底删除用）。
+
+    对照无库作用域的 ``/papers/{id}``：那条走跨库归并，会命中错误的库那份成员行。
+    """
+    await _get_managed_project(session, project_id, user)
+    library = await libraries_service.get_library_for_project(session, project_id)
+    if library is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library.id,
+        project_id=project_id,
+        paper_id=paper_id,
+        with_concepts=with_concepts,
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    return view
+
+
+@router.post("/projects/{project_id}/papers/{paper_id}/restore", response_model=PaperDetail)
+async def restore_project_paper(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """从课题起源库的垃圾桶召回该篇（精确锁定本库成员行，不跨库归并）。"""
+    view = await _managed_project_library_view(
+        session, project_id=project_id, paper_id=paper_id, user=user, with_concepts=True
+    )
+    view = await papers_service.restore_paper(session, view)
+    return await _paper_detail(session, view, user.id)
+
+
+@router.delete(
+    "/projects/{project_id}/papers/{paper_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_project_paper(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """从课题起源库彻底删除该篇（只删本库成员行，内容池论文/文件/笔记保留）。"""
+    view = await _managed_project_library_view(
+        session, project_id=project_id, paper_id=paper_id, user=user
+    )
+    await papers_service.delete_paper(session, view)
+
+
 @router.get("/papers/{paper_id}", response_model=PaperDetail)
 async def get_paper(
     paper_id: uuid.UUID,

--- a/src/backend/tests/test_scoped_trash.py
+++ b/src/backend/tests/test_scoped_trash.py
@@ -1,0 +1,110 @@
+"""库/课题作用域的垃圾桶召回 + 彻底删除。
+
+fix：无库作用域的 /papers/{id}(/restore) 走跨库归并，会命中错库那份成员行——
+彻底删除删不掉本库这份、召回也可能召回错库那份。这里验证作用域端点只动当前库。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from tests.conftest import make_project_with_library
+from tests.test_scoped_paper_detail import (
+    _add_membership,
+    _create_active_standalone,
+    _hdr,
+    _new_paper,
+    _promote_admin,
+)
+
+
+async def _statuses_by_lib(paper_id: str) -> dict[str, str]:
+    async with get_sessionmaker()() as session:
+        rows = (
+            await session.execute(
+                select(LibraryPaper).where(LibraryPaper.paper_id == uuid.UUID(paper_id))
+            )
+        ).scalars().all()
+        return {str(r.library_id): r.status for r in rows}
+
+
+async def test_scoped_purge_only_removes_current_library_membership(client):
+    """A 库在库、B 库垃圾桶：从 B 库彻底删除只删 B 那份，A 那份保留，池论文保留。"""
+    admin = await _hdr(client, "purge-admin@example.com")
+    await _promote_admin("purge-admin@example.com")
+    creator = await _hdr(client, "purge-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="A 在库")
+    lib_b = await _create_active_standalone(client, creator, admin, name="B 垃圾桶")
+
+    paper_id = await _new_paper(title="Purge from B only")
+    await _add_membership(lib_a, paper_id, status="included", relevance=0.9)
+    await _add_membership(lib_b, paper_id, status="excluded", relevance=0.2)
+
+    resp = await client.delete(f"/api/libraries/{lib_b}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 204, resp.text
+
+    by_lib = await _statuses_by_lib(paper_id)
+    assert str(lib_b) not in by_lib  # B 那份被彻底删除
+    assert by_lib.get(str(lib_a)) == "included"  # A 那份未受影响
+    async with get_sessionmaker()() as session:  # 内容池论文仍在（别的库复用）
+        assert await session.get(Paper, uuid.UUID(paper_id)) is not None
+
+
+async def test_scoped_restore_only_restores_current_library(client):
+    """A 库在库、B 库垃圾桶(打过分)：从 B 库召回只把 B 那份→scored，A 那份不动。"""
+    admin = await _hdr(client, "restore-admin@example.com")
+    await _promote_admin("restore-admin@example.com")
+    creator = await _hdr(client, "restore-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="A 在库2")
+    lib_b = await _create_active_standalone(client, creator, admin, name="B 垃圾桶2")
+
+    paper_id = await _new_paper(title="Restore in B only")
+    await _add_membership(lib_a, paper_id, status="included", relevance=0.9)
+    await _add_membership(lib_b, paper_id, status="excluded", relevance=0.3)
+
+    resp = await client.post(
+        f"/api/libraries/{lib_b}/papers/{paper_id}/restore", headers=creator
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "scored"  # 有分数无 wiki → 召回回 scored
+
+    by_lib = await _statuses_by_lib(paper_id)
+    assert by_lib.get(str(lib_b)) == "scored"  # B 那份被召回
+    assert by_lib.get(str(lib_a)) == "included"  # A 那份未动
+
+
+async def test_project_scoped_purge_hits_origin_library(client):
+    """课题起源库(垃圾桶) + 另一库(在库)：DELETE /projects/{pid}/papers/{id} 只删起源库那份。"""
+    admin = await _hdr(client, "projpurge-admin@example.com")
+    await _promote_admin("projpurge-admin@example.com")
+    creator = await _hdr(client, "projpurge-owner@example.com")
+    pid, origin_lib = await make_project_with_library(client, creator, name="课题垃圾桶")
+    other_lib = await _create_active_standalone(client, creator, admin, name="别的库2")
+
+    paper_id = await _new_paper(title="Proj purge")
+    await _add_membership(origin_lib, paper_id, status="excluded", relevance=0.2)
+    await _add_membership(other_lib, paper_id, status="included", relevance=0.8)
+
+    resp = await client.delete(f"/api/projects/{pid}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 204, resp.text
+
+    by_lib = await _statuses_by_lib(paper_id)
+    assert str(origin_lib) not in by_lib  # 起源库那份被删
+    assert by_lib.get(str(other_lib)) == "included"  # 别的库那份保留
+
+
+async def test_scoped_purge_404_when_library_lacks_paper(client):
+    admin = await _hdr(client, "purge404-admin@example.com")
+    await _promote_admin("purge404-admin@example.com")
+    creator = await _hdr(client, "purge404-owner@example.com")
+    lib_a = await _create_active_standalone(client, creator, admin, name="A 库x")
+    lib_b = await _create_active_standalone(client, creator, admin, name="B 库x")
+    paper_id = await _new_paper(title="Only in A")
+    await _add_membership(lib_a, paper_id, status="excluded", relevance=0.2)
+
+    resp = await client.delete(f"/api/libraries/{lib_b}/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "PAPER_NOT_FOUND"

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -473,7 +473,9 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
   };
 
   const restoreMutation = useMutation({
-    mutationFn: (id: string) => api.restorePaper(id),
+    // 作用域召回：锁定当前库那份成员行，避免跨库误召回（见彻底删除同理）
+    mutationFn: (id: string) =>
+      libraryId ? api.restoreLibraryPaper(libraryId, id) : api.restoreProjectPaper(pid, id),
     onSuccess: (p) => {
       toast(`${tr('已召回：', 'Restored: ')}${p.title.slice(0, 30)}`, 'ok');
       invalidate();
@@ -483,7 +485,9 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
   });
 
   const purgeMutation = useMutation({
-    mutationFn: (id: string) => api.deletePaper(id),
+    // 作用域彻底删除：只删当前库那份成员行；无库作用域会命中错误的库、删不掉本库这份
+    mutationFn: (id: string) =>
+      libraryId ? api.deleteLibraryPaper(libraryId, id) : api.deleteProjectPaper(pid, id),
     onSuccess: () => {
       toast(tr('已彻底删除', 'Permanently deleted'), 'ok');
       invalidate();

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2680,6 +2680,13 @@ export const api = {
   restorePaper(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}/restore`, { method: 'POST' });
   },
+  /** 课题起源库作用域的召回/彻底删除（精确锁定本库成员行，避免跨库误删）。 */
+  restoreProjectPaper(projectId: string, paperId: string): Promise<PaperDetail> {
+    return request<PaperDetail>(`/projects/${projectId}/papers/${paperId}/restore`, { method: 'POST' });
+  },
+  deleteProjectPaper(projectId: string, paperId: string): Promise<void> {
+    return request<void>(`/projects/${projectId}/papers/${paperId}`, { method: 'DELETE' });
+  },
   /** 清空垃圾桶：彻底删除项目内全部已删除论文。 */
   emptyTrash(projectId: string): Promise<{ deleted: number }> {
     return request<{ deleted: number }>(`/projects/${projectId}/trash/empty`, { method: 'POST' });
@@ -2988,6 +2995,13 @@ export const api = {
   /** 库作用域单篇详情：锁定该库那份成员行（相关度/状态/wiki 不跨库串味）。 */
   getLibraryPaper(id: string, paperId: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/libraries/${id}/papers/${paperId}`);
+  },
+  /** 库作用域的召回/彻底删除（精确锁定本库成员行，避免跨库误删）。 */
+  restoreLibraryPaper(id: string, paperId: string): Promise<PaperDetail> {
+    return request<PaperDetail>(`/libraries/${id}/papers/${paperId}/restore`, { method: 'POST' });
+  },
+  deleteLibraryPaper(id: string, paperId: string): Promise<void> {
+    return request<void>(`/libraries/${id}/papers/${paperId}`, { method: 'DELETE' });
   },
   /** 手动添加文献到库；409 → PAPER_EXISTS（body 含 paper_id）；422 → PARSE_FAILED。 */
   importLibraryPaper(id: string, input: PaperImportInput): Promise<PaperDetail> {


### PR DESCRIPTION
## Bug

Permanently deleting a paper from a library's **trash (垃圾桶 → 彻底删除)** appeared to do nothing — the paper stayed in the trash. (And restore had the same flaw.)

## Root cause

Follow-up to #75, same root cause. The purge (`DELETE /papers/{id}`) and restore (`POST /papers/{id}/restore`) both resolved the membership through `get_paper_for_user`, which for a paper in **multiple libraries** picks an arbitrary cross-library membership (wiki-bearing, else earliest) rather than the library you're viewing. So the purge deleted *another* library's membership (or a no-op) and left the current library's trashed row in place → the paper never left the trash.

## Fix

- Add library/project-scoped endpoints, resolving the membership via `get_library_paper_view` (the current library's row):
  - `POST /libraries/{id}/papers/{paper_id}/restore`, `DELETE /libraries/{id}/papers/{paper_id}`
  - `POST /projects/{pid}/papers/{paper_id}/restore`, `DELETE /projects/{pid}/papers/{paper_id}`
- `delete_paper` / `restore_paper` are unchanged — they already act only on the given view's membership and keep the shared pool paper + files for other libraries.
- `TrashModal` now restores/purges through the scoped endpoints (it already knows the `libraryId`/`pid` scope).

## Tests

New `test_scoped_trash.py`: purge/restore isolate the other library; project scope hits the origin library; 404 when the library lacks the paper. **All pass** (the 1 failure in the broader suite — `test_manage_endpoints_forbidden_for_non_manager` at the `ingest/state` assertion — reproduces on clean `origin/main` and is unrelated). `tsc` clean.