### PR TITLE
feat(daily): show the staged processing modal when collecting a paper

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -28,6 +28,7 @@ from app.schemas.daily import (
     DailyCollectionsRead,
     DailyCollectRequest,
     DailyCollectResponse,
+    DailyCollectTask,
     DailyCompileResult,
     DailyDay,
     DailyLikerFull,
@@ -186,18 +187,21 @@ async def collect(
     if target_library_id is not None:
         library = await session.get(DirectionLibrary, target_library_id)
         project_id = library.project_id if library is not None else None
+    tasks: list[DailyCollectTask] = []
     for paper_id in payload.paper_ids:
         paper = await session.get(Paper, paper_id)
         if paper is None or paper_enrich_service.paper_processing_complete(paper):
             continue
-        await paper_enrich_service.launch_paper_enrichment(
+        task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,
             paper_id=paper_id,
             user_id=user.id,
             library_id=target_library_id,
             project_id=project_id,
         )
-    return DailyCollectResponse(results=results)
+        if task_id:
+            tasks.append(DailyCollectTask(paper_id=paper_id, task_id=task_id))
+    return DailyCollectResponse(results=results, tasks=tasks)
 
 
 @router.get("/categories", response_model=DailyCategoriesRead)

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -88,8 +88,17 @@ class DailyCollectResult(BaseModel):
     forbidden: bool
 
 
+class DailyCollectTask(BaseModel):
+    """收录后启动的后台补全任务：paper_id → task_id，供前端订阅分阶段进度（同手动添加）。"""
+
+    paper_id: uuid.UUID
+    task_id: str
+
+
 class DailyCollectResponse(BaseModel):
     results: list[DailyCollectResult]
+    # 已启动补全的论文任务（论文已处理完整或 redis 不可用时为空），前端据此弹进度框
+    tasks: list[DailyCollectTask] = []
 
 
 class DailyCollectionsRead(BaseModel):

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -216,6 +216,11 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     assert str(launched[0]["paper_id"]) == item["paper_id"]
     assert launched[0]["library_id"] == library_id
     assert str(launched[0]["project_id"]) == project_id
+    # 响应回传补全任务，前端据此弹与手动添加同款的分阶段进度框
+    tasks = resp.json()["tasks"]
+    assert len(tasks) == 1
+    assert tasks[0]["task_id"] == "task-stub"
+    assert tasks[0]["paper_id"] == item["paper_id"]
 
     # 重复收录 → skipped_existing
     resp = await client.post("/api/daily/collect", json=payload, headers=headers)

--- a/src/frontend/src/features/daily/CollectTreeModal.tsx
+++ b/src/frontend/src/features/daily/CollectTreeModal.tsx
@@ -178,10 +178,13 @@ export function CollectTreeModal({
   paper,
   open,
   onClose,
+  onCollected,
 }: {
   paper: CollectPaperRef;
   open: boolean;
   onClose: () => void;
+  /** 收录触发了后台补全时回调（taskId + 标题），父级据此弹分阶段进度框（同手动添加）。 */
+  onCollected?: (task: { taskId: string; title: string }) => void;
 }) {
   const queryClient = useQueryClient();
   const { projects } = useProject();
@@ -289,6 +292,9 @@ export function CollectTreeModal({
       }
       void queryClient.invalidateQueries({ queryKey: ['daily-collections', paper.entry_id] });
       onClose();
+      // 收录若启动了后台补全（同手动添加），交给父级弹分阶段进度框
+      const task = resp.tasks?.find((t) => t.paper_id === paper.paper_id);
+      if (task) onCollected?.({ taskId: task.task_id, title: paper.title });
     },
     onError: (e) =>
       toast(

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -13,6 +13,7 @@ import { SearchInput, useDebounced } from '../wiki/shared';
 import { DailyLikes } from './DailyLikes';
 import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
+import { PaperProgressModal } from '../library/PaperProgressModal';
 
 /* ============================================================
    /daily — 每日新论文：arxiv 每日新提交（订阅分类内），保留最近 7 天。
@@ -271,6 +272,8 @@ export function DailyPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
+  // 收录到库/课题/个人后若启动了后台补全，弹出与手动添加同款分阶段进度框
+  const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
 
   useEffect(() => setPage(1), [q, sort, day, category, announce]);
 
@@ -540,7 +543,20 @@ export function DailyPage() {
       </div>
 
       {collectPaper && (
-        <CollectTreeModal paper={collectPaper} open={collectOpen} onClose={() => setCollectOpen(false)} />
+        <CollectTreeModal
+          paper={collectPaper}
+          open={collectOpen}
+          onClose={() => setCollectOpen(false)}
+          onCollected={(t) => setProgress(t)}
+        />
+      )}
+
+      {progress && (
+        <PaperProgressModal
+          taskId={progress.taskId}
+          paperTitle={progress.title}
+          onClose={() => setProgress(null)}
+        />
       )}
     </div>
   );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2325,8 +2325,15 @@ export interface DailyCollectResult {
   forbidden: boolean;
 }
 
+export interface DailyCollectTask {
+  paper_id: string;
+  task_id: string;
+}
+
 export interface DailyCollectResponse {
   results: DailyCollectResult[];
+  /** 收录后启动的后台补全任务（同手动添加）；订阅可显示下载/抽取/向量化/打分进度 */
+  tasks?: DailyCollectTask[];
 }
 
 /** 该论文已在哪些收录目标里（树选框预勾选/禁用）。 */


### PR DESCRIPTION
从 Daily paper 收录到库/课题/个人库时，弹出与手动添加相同的分阶段进度框（下载→抽取→向量化→打分）。

#78 收录时已在跑同款后台补全，但接口没回传 task_id，处理是隐形的。本 PR：
- `POST /daily/collect` 返回 `tasks[{paper_id, task_id}]`（对启动了补全的论文）。
- CollectTreeModal 把任务上抛给 DailyPage，复用手动添加同款 `PaperProgressModal`。

Tests: extended test_collect_to_library_topic_personal to assert the response surfaces the task; tsc clean.