### PR TITLE
feat(library): author↔affiliation mapping + admin extraction mode

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -28,7 +28,11 @@ from app.models.activity import Activity
 from app.models.base import utcnow
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, PaperChunk
-from app.services.affiliations import extract_affiliations_llm
+from app.services.affiliations import (
+    apply_author_affiliations,
+    extract_author_affiliations_llm,
+    get_affiliation_extraction_mode,
+)
 from app.services.chunks import embed_pending_chunks, index_paper_fulltext
 from app.services.concepts import link_all_paper_concepts
 from app.services.dedup import pool_dedup_key
@@ -648,6 +652,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     async with get_sessionmaker()() as session:
         library = await _resolve_library(session, ctx)
         billing_user_id = _ingest_billing_owner(library)
+        affil_mode = await get_affiliation_extraction_mode(session)
         pairs = (
             await session.execute(
                 select(Paper, LibraryPaper)
@@ -694,10 +699,11 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             except Exception as e:  # noqa: BLE001 — 下载/抽取失败降级用 abstract
                 degraded += 1
                 failed.append({"id": str(paper.id), "error": f"{type(e).__name__}: {e}"})
-            # 发表机构补充（高级检索用）：优先 LLM 从全文标题页解析（extract 内部已带
-            # 失败兜底，返回 None 不写入）；失败不影响主流程
-            if not paper.affiliations and paper.full_text_path:
-                affs = await extract_affiliations_llm(
+            # 发表机构补充（高级检索用）：on_add 模式下优先 LLM 从全文标题页逐位作者解析
+            # 机构（extract 内部已带失败兜底，返回 None 不写入）；on_compile 模式跳过该
+            # 专门调用（改折叠进 wiki.compile）。失败不影响主流程
+            if affil_mode == "on_add" and not paper.affiliations and paper.full_text_path:
+                mapping = await extract_author_affiliations_llm(
                     paper,
                     llm=ctx.llm,
                     user_id=billing_user_id,
@@ -705,10 +711,10 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     library_id=library.id,
                     voyage_id=ctx.run.id,
                 )
-                if affs:
-                    paper.affiliations = affs
-            # OpenAlex 反查兜底（无全文 / LLM 解析失败）；DOI 论文发表日期缺失时也要
-            # 反查一次（走不了上面的 arXiv 回填，与机构是否已解析无关）
+                apply_author_affiliations(paper, mapping)
+            # OpenAlex 反查兜底（无全文 / LLM 未给机构 / on_compile 模式）：OpenAlex 的
+            # authors 已带机构，用 apply_author_affiliations 逐位对齐并汇总 paper.affiliations。
+            # DOI 论文发表日期缺失时也要反查一次（走不了上面的 arXiv 回填）。
             need_date = paper.published_at is None and not paper.arxiv_id
             if (not paper.affiliations or need_date) and (paper.arxiv_id or paper.doi):
                 try:
@@ -718,7 +724,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                         else await get_openalex_client().get_by_doi(paper.doi)
                     )
                     if not paper.affiliations:
-                        paper.affiliations = (meta or {}).get("affiliations") or []
+                        apply_author_affiliations(paper, (meta or {}).get("authors"))
                     if paper.published_at is None:
                         paper.published_at = _parse_iso((meta or {}).get("published"))
                 except asyncio.CancelledError:
@@ -817,6 +823,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
             paper = await session.get(Paper, membership.paper_id)
             if paper is None:
                 return None
+            affil_mode = await get_affiliation_extraction_mode(session)
             progress["n"] += 1
             await ctx.log(f"📖 精读编译 {progress['n']}/{total}：{paper.title}")
             # ① 编译前筛选注释论文图（stage=librarian 多模态）：图文编译要用重要图；
@@ -838,7 +845,9 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                     raise
                 except Exception:  # noqa: BLE001
                     logger.warning("figure annotation failed for paper %s", paper.id, exc_info=True)
-            # ② 图文编译（重要图 ≤4 张随 prompt 送入）+ ③ 无效 ![[fig:N]] 标记剥除
+            # ② 图文编译（重要图 ≤4 张随 prompt 送入）+ ③ 无效 ![[fig:N]] 标记剥除。
+            #    on_compile 模式且尚无机构时顺带带回作者↔机构映射（省一次专门调用）。
+            collect_affs = affil_mode == "on_compile" and not paper.affiliations
             compiled = await compile_paper(
                 paper,
                 statement=statement,
@@ -848,11 +857,14 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
                 library_id=membership.library_id,
                 voyage_id=ctx.run.id,
                 extra_guidance=guidance,
+                collect_affiliations=collect_affs,
             )
             membership.wiki_content = compiled.content
             membership.compiled_at = utcnow()
             membership.compiled_model = compiled.model or None
             membership.status = "compiled"
+            if compiled.author_affiliations and not paper.affiliations:
+                apply_author_affiliations(paper, compiled.author_affiliations)
             await session.commit()
             await ctx.log(
                 f"✓ 完成 {progress['n']}/{total}：{paper.title[:50]}（{len(compiled.content)} 字）",

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -1,0 +1,34 @@
+"""管理端全局设置路由（仅 role=admin）：机构抽取模式等。"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import require_admin
+from app.core.db import get_session
+from app.schemas.admin_settings import AffiliationModeRead, AffiliationModeUpdate
+from app.services import affiliations as affiliations_service
+
+router = APIRouter(
+    prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
+)
+
+
+@router.get("/affiliation-mode", response_model=AffiliationModeRead)
+async def get_affiliation_mode(session: AsyncSession = Depends(get_session)) -> AffiliationModeRead:
+    return AffiliationModeRead(
+        mode=await affiliations_service.get_affiliation_extraction_mode(session)
+    )
+
+
+@router.put("/affiliation-mode", response_model=AffiliationModeRead)
+async def set_affiliation_mode(
+    payload: AffiliationModeUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> AffiliationModeRead:
+    try:
+        mode = await affiliations_service.set_affiliation_extraction_mode(session, payload.mode)
+    except affiliations_service.InvalidAffiliationModeError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"INVALID_AFFILIATION_MODE:{exc.mode}"
+        ) from exc
+    return AffiliationModeRead(mode=mode)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter
 from app.api import (
     admin_codes,
     admin_llm,
+    admin_settings,
     admin_users,
     auth,
     concepts,
@@ -49,6 +50,7 @@ api_router.include_router(projects.router)
 api_router.include_router(gates.router)
 api_router.include_router(voyages.router)
 api_router.include_router(admin_llm.router)
+api_router.include_router(admin_settings.router)
 api_router.include_router(me_llm.router)
 api_router.include_router(papers.router)
 api_router.include_router(library.router)

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -20,7 +20,15 @@ _PLAN_EDIT_MARKER = "POLARIS_PLAN_EDIT"  # 计划编辑（loop 失败回灌，na
 _VERDICT_MARKER = '"passed"'
 _RELEVANCE_MARKER = '"score"'
 _CONCEPTS_MARKER = "概念列表："
-_AFFILIATIONS_MARKER = "POLARIS_AFFILIATIONS"  # 发表机构解析（services/affiliations.py）
+_AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affiliations.py 专门调用）
+_AFFIL_COMPILE_MARKER = "POLARIS_AFFILIATIONS"  # on_compile 折叠进 wiki 编译的机构定界块请求
+# on_compile 模式下 librarian 编译输出附带的确定性机构定界块（与 FULL_TEXT 对齐）
+_FAKE_AFFIL_BLOCK = (
+    "\n\n<<<POLARIS_AFFILIATIONS\n"
+    '[{"name": "Alice Zhang", "affiliations": ["Zhejiang University"]}, '
+    '{"name": "Bob Li", "affiliations": ["Google DeepMind"]}]\n'
+    "POLARIS_AFFILIATIONS>>>\n"
+)
 _LIBRARIAN_MARKER = "TL;DR"
 _INTERVIEW_MARKER = '"out_of_scope"'
 _GAPS_MARKER = '"gaps"'  # forge gap 分析
@@ -246,10 +254,16 @@ class FakeProvider(LLMProvider):
                 },
                 ensure_ascii=False,
             )
-        # 发表机构解析：user prompt 内嵌论文标题页文本（可能含 TL;DR 等其他 marker），
-        # 须先于通用 marker 判断；返回确定性机构数组
+        # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
+        # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
-            return json.dumps(["Zhejiang University", "Google DeepMind"], ensure_ascii=False)
+            return json.dumps(
+                [
+                    {"name": "Alice Zhang", "affiliations": ["Zhejiang University"]},
+                    {"name": "Bob Li", "affiliations": ["Google DeepMind"]},
+                ],
+                ensure_ascii=False,
+            )
         # 伴读/文献库对话 system prompt 会内嵌论文全文/wiki（可能含 TL;DR 等其他
         # marker），须最先判断
         if _LIBRARY_MARKER in full_text:
@@ -735,6 +749,8 @@ class FakeProvider(LLMProvider):
         title = title_match.group(1).strip() if title_match else "未知论文"
         # 多模态图文编译（请求带 images）时在方法段落后插入图片标记
         figure_line = "![[fig:0]]\n\n" if with_figure else ""
+        # on_compile 模式：prompt 末尾要求附机构定界块时，在正文之后追加确定性块
+        affil_block = _FAKE_AFFIL_BLOCK if _AFFIL_COMPILE_MARKER in last_user else ""
         return (
             f"## TL;DR\n\n{title} 的一句话总结（fake librarian）。\n\n"
             "## 研究背景与动机\n\n围绕 [[Agent]] 场景的关键问题展开叙述（fake）。\n\n"
@@ -742,6 +758,7 @@ class FakeProvider(LLMProvider):
             f"{figure_line}"
             "## 实验与结果\n\n在多个基准上验证有效（fake）。\n\n"
             "## 讨论与可借鉴点\n\n可复用其训练流程，局限在于评测范围（fake）。\n"
+            f"{affil_block}"
         )
 
     # ---- Idea 2.0 深耕（actions_proposal.py 的 system prompt 对齐，docs/api-idea2.md） ----

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -1,0 +1,15 @@
+"""管理端全局设置 schema（system_settings 表读写）。"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+AffiliationMode = Literal["on_add", "on_compile"]
+
+
+class AffiliationModeRead(BaseModel):
+    mode: AffiliationMode
+
+
+class AffiliationModeUpdate(BaseModel):
+    mode: AffiliationMode

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -9,18 +9,26 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 class AuthorRead(BaseModel):
     name: str
+    # 该作者最可能的所属机构（OpenAlex 结构化 / LLM 从标题页尽力对应；可能为空）
+    affiliations: list[str] = []
 
 
-def _normalize_authors(value: Any) -> list[dict[str, str]]:
-    """兼容历史数据：字符串列表 → [{"name": ...}]。"""
+def _normalize_authors(value: Any) -> list[dict[str, Any]]:
+    """兼容历史数据：字符串列表 → [{"name": ...}]；保留每位作者的机构映射。"""
     if not isinstance(value, list):
         return []
-    normalized: list[dict[str, str]] = []
+    normalized: list[dict[str, Any]] = []
     for item in value:
         if isinstance(item, str):
             normalized.append({"name": item})
         elif isinstance(item, dict) and item.get("name"):
-            normalized.append({"name": str(item["name"])})
+            affs = item.get("affiliations")
+            normalized.append(
+                {
+                    "name": str(item["name"]),
+                    "affiliations": [str(a) for a in affs if a] if isinstance(affs, list) else [],
+                }
+            )
     return normalized
 
 

--- a/src/backend/app/services/affiliations.py
+++ b/src/backend/app/services/affiliations.py
@@ -1,41 +1,87 @@
-"""论文发表机构解析：LLM 从全文开头（标题页）提取机构名（不 import fastapi）。
+"""论文作者↔发表机构解析：LLM 从全文标题页尽力给出每位作者最可能的机构归属。
 
-全文抓取成功后优先走这里；无全文 / LLM 失败时由调用方用 OpenAlex 反查兜底。
+标题页里作者与机构的对应常不明确（上标脚注 / 邮箱 / 排版就近），所以要"最大可能"的对应
+而非严格匹配。优先把已知作者名单交给 LLM 逐一映射（保持作者顺序与规范名）。无全文 / 失败
+由调用方兜底（如 OpenAlex 反查）。DOI 论文的作者-机构映射由 OpenAlex 结构化数据直接给。
 """
 
 import asyncio
 import json
 import logging
+import re
 import uuid
 from pathlib import Path
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
 from app.models.paper import Paper
+from app.models.system_setting import SystemSetting
 
 logger = logging.getLogger(__name__)
 
-# 标题页范围：作者名单/机构/邮箱脚注都在论文开头，取前 3000 字符足够且省 token
-_HEAD_CHARS = 3000
-_MAX_TOKENS = 512  # 输出只是一个机构名数组，轻量调用
-_MAX_AFFILIATIONS = 20  # 防御 LLM 幻觉刷屏
+# ---- 抽取模式（管理员可设，存 SystemSetting）----
+# on_add：论文入库/补全阶段就用专门的 LLM 调用解析机构（默认）；
+# on_compile：跳过专门调用，把机构映射折叠进 wiki 编译那一次 LLM（省一次调用）。
+AFFILIATION_MODE_KEY = "affiliation_extraction_mode"
+AFFILIATION_MODES = ("on_add", "on_compile")
+DEFAULT_AFFILIATION_MODE = "on_add"
 
-AFFILIATIONS_SYSTEM_PROMPT = """\
-你是论文元数据抽取助手（POLARIS_AFFILIATIONS）。给你一篇论文开头的文本\
-（标题页，含作者名单、机构、邮箱脚注），请提取作者所属机构列表。
+
+class InvalidAffiliationModeError(ValueError):
+    """set_affiliation_extraction_mode 收到不在 AFFILIATION_MODES 里的取值。"""
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        super().__init__(mode)
+
+
+async def get_affiliation_extraction_mode(session: AsyncSession) -> str:
+    """读取机构抽取模式（system_settings 表，默认 on_add；非法存量值回落默认）。"""
+    row = await session.get(SystemSetting, AFFILIATION_MODE_KEY)
+    value = row.value if row is not None else None
+    return value if value in AFFILIATION_MODES else DEFAULT_AFFILIATION_MODE
+
+
+async def set_affiliation_extraction_mode(session: AsyncSession, mode: str) -> str:
+    """写入机构抽取模式；取值非法抛 InvalidAffiliationModeError。"""
+    if mode not in AFFILIATION_MODES:
+        raise InvalidAffiliationModeError(mode)
+    row = await session.get(SystemSetting, AFFILIATION_MODE_KEY)
+    if row is None:
+        session.add(SystemSetting(key=AFFILIATION_MODE_KEY, value=mode))
+    else:
+        row.value = mode
+    await session.commit()
+    return mode
+
+# 标题页范围：作者-机构对应比纯机构列表信息量大，略放宽到 3500 字符
+_HEAD_CHARS = 3500
+_MAX_TOKENS = 900  # 输出逐作者映射，比纯机构数组略大
+_MAX_AFFILIATIONS = 20  # 单篇去重后机构总数上限（防幻觉刷屏）
+_MAX_PER_AUTHOR = 4  # 单个作者机构数上限
+
+AUTHOR_AFFIL_SYSTEM_PROMPT = """\
+你是论文元数据抽取助手（POLARIS_AUTHOR_AFFIL）。给你一篇论文开头的文本（标题页，含作者\
+名单、机构、上标数字/符号脚注、邮箱），以及一份「已知作者名单」。请为每位作者给出其最\
+可能所属的机构。
 要求：
-- 机构名取到学校/公司/研究院一级（如 "Zhejiang University"、"Google DeepMind"），\
-不要院系/实验室等下级细分；
-- 保留论文中的英文原名，不要翻译；
-- 去重、按出现顺序排列；不要包含地址、城市、国家、邮箱；
-- 只输出一个 JSON 字符串数组，不要输出任何其他文字，例如：\
-["Zhejiang University", "Google DeepMind"]
-- 文本中识别不出机构时输出 []。
+- 逐位作者输出，作者名用「已知作者名单」里的原名与原顺序，不要增删或改写作者；
+- 用上标数字/符号脚注、邮箱域名、排版就近等线索推断作者与机构的对应；对应不明确时给出\
+最可能的单个机构（宁缺毋滥，可留空数组），不要硬凑；
+- 机构名取到学校/公司/研究院一级（如 "Zhejiang University"、"Google DeepMind"），不要\
+院系/实验室等下级细分；保留论文中的英文原名，不要翻译；不含地址、城市、国家、邮箱；
+- 只输出一个 JSON 数组，每项形如 {"name": "<作者名>", "affiliations": ["<机构名>", ...]}，\
+不要输出任何其他文字；
+- 完全识别不出某作者的机构时，其 affiliations 输出 []。
 """
+_NO_AUTHORS_HINT = "（已知作者名单为空：请你先从标题页识别作者，再映射其机构。）"
 
 
 def _read_head(paper: Paper) -> str | None:
-    """取全文开头 ~3000 字符（标题页）；无全文/文件缺失返回 None。"""
+    """取全文开头 ~3500 字符（标题页）；无全文 / 文件缺失返回 None。"""
     if not paper.full_text_path:
         return None
     path = Path(paper.full_text_path)
@@ -45,8 +91,19 @@ def _read_head(paper: Paper) -> str | None:
     return head or None
 
 
-def _parse_affiliations(content: str) -> list[str] | None:
-    """从 LLM 输出中解析 JSON 字符串数组，去重保序；解析失败/空返回 None。"""
+def author_names(paper: Paper) -> list[str]:
+    """已存的作者名（兼容 [{"name":...}] 与历史的纯字符串列表）。"""
+    out: list[str] = []
+    for a in paper.authors or []:
+        if isinstance(a, dict) and a.get("name"):
+            out.append(str(a["name"]).strip())
+        elif isinstance(a, str) and a.strip():
+            out.append(a.strip())
+    return out
+
+
+def _parse_mapping(content: str) -> list[dict[str, Any]] | None:
+    """解析 LLM 输出的 [{"name","affiliations"}]；去重截断；解析失败 / 空返回 None。"""
     start = content.find("[")
     end = content.rfind("]")
     if start == -1 or end <= start:
@@ -57,10 +114,161 @@ def _parse_affiliations(content: str) -> list[str] | None:
         return None
     if not isinstance(data, list):
         return None
-    names = list(
-        dict.fromkeys(name for item in data if isinstance(item, str) and (name := item.strip()))
-    )
-    return names[:_MAX_AFFILIATIONS] or None
+    result: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        raw = item.get("affiliations")
+        affs = (
+            list(dict.fromkeys(s for x in raw if isinstance(x, str) and (s := x.strip())))[
+                :_MAX_PER_AUTHOR
+            ]
+            if isinstance(raw, list)
+            else []
+        )
+        result.append({"name": name, "affiliations": affs})
+    return result or None
+
+
+def flatten_affiliations(mapping: list[dict[str, Any]]) -> list[str]:
+    """从作者→机构映射汇成去重的机构总表（供筛选 chips / 展示）。"""
+    return list(
+        dict.fromkeys(
+            aff
+            for item in mapping
+            for aff in (item.get("affiliations") or [])
+            if isinstance(aff, str) and aff
+        )
+    )[:_MAX_AFFILIATIONS]
+
+
+def apply_author_affiliations(paper: Paper, mapping: list[dict[str, Any]] | None) -> bool:
+    """把作者→机构映射写回 paper：每位作者带上 affiliations，并汇总 paper.affiliations。
+
+    按作者名（小写去空白）对齐已有作者，补 affiliations、保留原有字段；已知作者为空时直接
+    用映射建作者。返回是否写入了任何机构（无机构时不覆盖，交调用方兜底）。
+    """
+    if not mapping:
+        return False
+    by_name = {
+        str(item["name"]).strip().lower(): (item.get("affiliations") or []) for item in mapping
+    }
+    existing = paper.authors or []
+    if existing:
+        merged: list[Any] = []
+        for a in existing:
+            if isinstance(a, dict) and a.get("name"):
+                affs = by_name.get(str(a["name"]).strip().lower())
+                merged.append({**a, "affiliations": affs} if affs else dict(a))
+            elif isinstance(a, str) and a.strip():
+                affs = by_name.get(a.strip().lower())
+                merged.append(
+                    {"name": a.strip(), "affiliations": affs} if affs else {"name": a.strip()}
+                )
+            else:
+                merged.append(a)
+        paper.authors = merged
+    else:
+        paper.authors = [
+            {"name": item["name"], "affiliations": item.get("affiliations") or []}
+            for item in mapping
+        ]
+    flat = flatten_affiliations(mapping)
+    if flat:
+        paper.affiliations = flat
+    return bool(flat)
+
+
+async def extract_author_affiliations_llm(
+    paper: Paper,
+    *,
+    llm: LLMRouter,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> list[dict[str, Any]] | None:
+    """LLM 从标题页解析每位作者的最可能机构，返回 [{"name","affiliations"}]。
+
+    无全文、调用失败或解析不出都返回 None（调用方自行兜底）。
+    """
+    head = _read_head(paper)
+    if head is None:
+        return None
+    known = author_names(paper)
+    known_block = "\n".join(f"- {n}" for n in known) if known else _NO_AUTHORS_HINT
+    try:
+        result = await llm.complete(
+            "librarian",
+            [
+                Message(role="system", content=AUTHOR_AFFIL_SYSTEM_PROMPT),
+                Message(
+                    role="user",
+                    content=(
+                        f"论文标题：{paper.title}\n\n已知作者名单：\n{known_block}\n\n"
+                        f"论文开头文本：\n{head}"
+                    ),
+                ),
+            ],
+            max_tokens=_MAX_TOKENS,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
+        )
+        return _parse_mapping(result.content)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 — 解析尽力而为，失败由调用方兜底
+        logger.warning(
+            "LLM author-affiliation extraction failed for paper %s", paper.id, exc_info=True
+        )
+        return None
+
+
+# ---- on_compile 模式：折叠进 wiki 编译的作者↔机构定界块 ----
+# LLM 在正文全部结束后附上该块，供确定性解析后从正文剥离（无论解析成败都必须删干净，
+# 绝不能残留进最终 wiki）。块内是 [{"name","affiliations"}] JSON。
+_AFFIL_BLOCK_RE = re.compile(r"<<<POLARIS_AFFILIATIONS\b(.*?)POLARIS_AFFILIATIONS>>>", re.DOTALL)
+# 兜底：模型只吐了开头标记、没闭合 → 从开头标记删到文末，绝不让裸标记漏进 wiki
+_AFFIL_DANGLING_RE = re.compile(r"<<<POLARIS_AFFILIATIONS\b.*\Z", re.DOTALL)
+# 块前可能被模型顺手带出的分隔线（---）一并清掉，避免正文尾巴挂个孤零零的 hr
+_TRAILING_HR_RE = re.compile(r"\s*-{3,}[ \t]*$")
+
+AFFIL_COMPILE_INSTRUCTION = """\
+
+另外，请在上面正文**全部结束之后**，另起一段，按下面固定格式附上每位作者最可能所属的\
+机构，仅供系统解析、不属于正文的一部分：
+<<<POLARIS_AFFILIATIONS
+[{"name": "作者名", "affiliations": ["机构名"]}]
+POLARIS_AFFILIATIONS>>>
+要求：作者用上文「作者：」里的原名与顺序；机构取学校/公司/研究院一级的英文原名（不含\
+院系/城市/国家）；识别不出机构的作者其 affiliations 用 []；这一整块只在文末出现一次，\
+不要在正文里提及它。\
+"""
+
+
+def parse_and_strip_affiliation_block(content: str) -> tuple[str, list[dict[str, Any]] | None]:
+    """从编译输出剥离作者↔机构定界块并解析其中的映射。
+
+    返回 (剥离后的正文, 映射 | None)。无论块内 JSON 是否可解析，定界块都会被完整删除，
+    确保它绝不残留进最终 wiki；解析失败 / 无块时映射为 None。
+    """
+    match = _AFFIL_BLOCK_RE.search(content)
+    if match is None:
+        # 没闭合的裸开头标记也要删净（模型偶尔漏闭合），此时解析不出映射
+        if "<<<POLARIS_AFFILIATIONS" in content:
+            stripped = _AFFIL_DANGLING_RE.sub("", content).rstrip()
+            stripped = _TRAILING_HR_RE.sub("", stripped).rstrip()
+            return (stripped + "\n" if stripped else stripped), None
+        return content, None
+    stripped = _AFFIL_BLOCK_RE.sub("", content).rstrip()
+    stripped = _TRAILING_HR_RE.sub("", stripped).rstrip()
+    stripped = stripped + "\n" if stripped else stripped
+    return stripped, _parse_mapping(match.group(1))
 
 
 async def extract_affiliations_llm(
@@ -72,29 +280,15 @@ async def extract_affiliations_llm(
     library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> list[str] | None:
-    """LLM 从论文全文标题页解析机构名列表。
-
-    无全文、调用失败或解析不出结果都返回 None（调用方自行兜底，如 OpenAlex 反查）。
-    """
-    head = _read_head(paper)
-    if head is None:
+    """向后兼容：仅要去重机构总表的旧调用（内部走作者→机构映射再拍平）。"""
+    mapping = await extract_author_affiliations_llm(
+        paper,
+        llm=llm,
+        user_id=user_id,
+        project_id=project_id,
+        library_id=library_id,
+        voyage_id=voyage_id,
+    )
+    if mapping is None:
         return None
-    try:
-        result = await llm.complete(
-            "librarian",
-            [
-                Message(role="system", content=AFFILIATIONS_SYSTEM_PROMPT),
-                Message(role="user", content=f"论文标题：{paper.title}\n\n论文开头文本：\n{head}"),
-            ],
-            max_tokens=_MAX_TOKENS,
-            user_id=user_id,
-            project_id=project_id,
-            library_id=library_id,
-            voyage_id=voyage_id,
-        )
-        return _parse_affiliations(result.content)
-    except asyncio.CancelledError:
-        raise
-    except Exception:  # noqa: BLE001 — 机构解析尽力而为，失败由调用方兜底
-        logger.warning("LLM affiliation extraction failed for paper %s", paper.id, exc_info=True)
-        return None
+    return flatten_affiliations(mapping) or None

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -31,8 +31,18 @@ def _simplify(work: dict[str, Any]) -> dict[str, Any]:
         if isinstance((work.get("primary_location") or {}).get("source"), dict)
         else None,
         "cited_by_count": work.get("cited_by_count", 0),
+        # 作者 + 每位作者的机构（OpenAlex 结构化给出 authorships[].institutions）
         "authors": [
-            {"name": a.get("author", {}).get("display_name")}
+            {
+                "name": a["author"]["display_name"],
+                "affiliations": list(
+                    dict.fromkeys(
+                        inst["display_name"]
+                        for inst in (a.get("institutions") or [])
+                        if isinstance(inst, dict) and inst.get("display_name")
+                    )
+                ),
+            }
             for a in work.get("authorships", [])
             if a.get("author", {}).get("display_name")
         ],

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -132,18 +132,23 @@ async def enrich_paper(
             paper = await _rollback_and_reload()
             await emit("extract", "error", f"{type(e).__name__}: {e}")
 
-    # 发表机构：全文到手且尚无机构时 LLM 补（非独立阶段，best-effort，不发事件）
+    # 作者↔机构：on_add 模式下全文到手且尚无机构时 LLM 补（非独立阶段，best-effort，不发
+    # 事件）；on_compile 模式跳过，改由 wiki 编译折叠抽取
     if not paper.affiliations and paper.full_text_path:
         try:
             from app.core.llm.router import get_llm_router
-            from app.services.affiliations import extract_affiliations_llm
-
-            affs = await extract_affiliations_llm(
-                paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+            from app.services.affiliations import (
+                apply_author_affiliations,
+                extract_author_affiliations_llm,
+                get_affiliation_extraction_mode,
             )
-            if affs:
-                paper.affiliations = affs
-                await session.commit()
+
+            if await get_affiliation_extraction_mode(session) == "on_add":
+                mapping = await extract_author_affiliations_llm(
+                    paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+                )
+                if mapping and apply_author_affiliations(paper, mapping):
+                    await session.commit()
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -204,17 +204,21 @@ async def create_pool_paper(
         except Exception:  # noqa: BLE001
             logger.warning("auto PDF fetch failed for paper %s", paper.id, exc_info=True)
 
-    # 发表机构：全文到手后 LLM 从标题页解析（DOI 路径已有 OpenAlex 机构时不覆盖）；
-    # 失败不影响创建
+    # 作者↔机构：on_add 模式下全文到手后 LLM 从标题页解析（DOI 路径已有 OpenAlex 映射时
+    # 不覆盖）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响创建
     if not paper.affiliations and paper.full_text_path:
         from app.core.llm.router import get_llm_router
-        from app.services.affiliations import extract_affiliations_llm
-
-        affs = await extract_affiliations_llm(
-            paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+        from app.services.affiliations import (
+            apply_author_affiliations,
+            extract_author_affiliations_llm,
+            get_affiliation_extraction_mode,
         )
-        if affs:
-            paper.affiliations = affs
+
+        if await get_affiliation_extraction_mode(session) == "on_add":
+            mapping = await extract_author_affiliations_llm(
+                paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+            )
+            apply_author_affiliations(paper, mapping)
     return paper
 
 

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -830,16 +830,21 @@ async def fetch_pdf(
             await index_paper_fulltext(session, paper)
         except Exception:  # noqa: BLE001
             logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
-    # 发表机构：全文到手后 LLM 从标题页解析（此路径原先不补机构）；失败不影响主流程
+    # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
+    # 机构）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响主流程
     if not paper.affiliations and paper.full_text_path:
         from app.core.llm.router import get_llm_router
-        from app.services.affiliations import extract_affiliations_llm
-
-        affs = await extract_affiliations_llm(
-            paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+        from app.services.affiliations import (
+            apply_author_affiliations,
+            extract_author_affiliations_llm,
+            get_affiliation_extraction_mode,
         )
-        if affs:
-            paper.affiliations = affs
+
+        if await get_affiliation_extraction_mode(session) == "on_add":
+            mapping = await extract_author_affiliations_llm(
+                paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+            )
+            apply_author_affiliations(paper, mapping)
     await session.commit()
     await session.refresh(paper)
     return paper

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -20,6 +20,12 @@ from app.core.llm.router import LLMRouter, get_llm_router
 from app.models.base import utcnow
 from app.models.paper import Paper
 from app.models.project import Project
+from app.services.affiliations import (
+    AFFIL_COMPILE_INSTRUCTION,
+    apply_author_affiliations,
+    get_affiliation_extraction_mode,
+    parse_and_strip_affiliation_block,
+)
 from app.services.concepts import link_paper_concepts
 from app.services.figure_annotate import (
     FIGURE_KIND_ZH,
@@ -126,10 +132,15 @@ def build_compile_prompt(paper: Paper, *, statement: str | None) -> tuple[str, l
 
 @dataclass(slots=True)
 class CompiledWiki:
-    """compile_paper 结果：校验过标记的 wiki markdown + 实际使用的模型名。"""
+    """compile_paper 结果：校验过标记的 wiki markdown + 实际使用的模型名。
+
+    author_affiliations：仅 on_compile 模式下从编译输出的定界块解析出的作者↔机构映射
+    （解析失败 / 未开该模式为 None）；调用方据此补库。
+    """
 
     content: str
     model: str
+    author_affiliations: list[dict[str, Any]] | None = None
 
 
 async def compile_paper(
@@ -142,19 +153,26 @@ async def compile_paper(
     library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
     extra_guidance: str = "",
+    collect_affiliations: bool = False,
 ) -> CompiledWiki:
     """图文编译一篇论文，返回校验过标记的 wiki markdown 与所用模型（调用方负责落库）。
 
     模型名取自 LLM 实际返回结果（CompletionResult.model），而非路由表配置，
     避免路由中途被改导致记录偏差。
     extra_guidance：追加到 system prompt 的补充指引（wiki.compile 注入点的项目技能）。
+    collect_affiliations（on_compile 模式）：在 prompt 末尾追加指令，要求 LLM 在正文后附
+    作者↔机构定界块；拿到结果后 best-effort 解析并**无论成败都从正文剥离**该块，绝不
+    让它残留进 wiki，也绝不因解析失败让编译失败。
     """
     llm = llm or get_llm_router()
     user_prompt, images = build_compile_prompt(paper, statement=statement)
+    if collect_affiliations:
+        user_prompt += AFFIL_COMPILE_INSTRUCTION
     valid = {int(f["index"]) for f in (paper.figures or [])}
 
     content = ""
     model = ""
+    author_affiliations: list[dict[str, Any]] | None = None
     for attempt in range(2):
         prompt = user_prompt
         if attempt == 1:
@@ -177,12 +195,18 @@ async def compile_paper(
         )
         if not result.content.strip():
             raise ValueError("librarian returned empty content")
-        content = strip_invalid_figure_markers(result.content, valid)
+        body = result.content
+        if collect_affiliations:
+            # 先剥离机构定界块（无论 JSON 是否可解析都删干净）再校验图片标记
+            body, mapping = parse_and_strip_affiliation_block(body)
+            if mapping is not None:
+                author_affiliations = mapping
+        content = strip_invalid_figure_markers(body, valid)
         model = result.model
         # 有配图但一张都没插 → 带强指令重写一次；仍失败则接受纯文字稿（图库里还能看图）
         if not images or FIGURE_MARKER_RE.search(content):
             break
-    return CompiledWiki(content=content, model=model)
+    return CompiledWiki(content=content, model=model, author_affiliations=author_affiliations)
 
 
 async def recompile_paper(
@@ -222,6 +246,9 @@ async def recompile_paper(
             )
         await session.commit()
 
+    # on_compile 模式且尚无机构时，让本次编译顺带带回作者↔机构映射（省一次专门调用）
+    mode = await get_affiliation_extraction_mode(session)
+    collect_affs = mode == "on_compile" and not paper.affiliations
     compiled = await compile_paper(
         paper,
         statement=statement,
@@ -229,12 +256,15 @@ async def recompile_paper(
         user_id=user_id,
         project_id=project_id,
         library_id=membership.library_id,  # 库版重编译记方向库账（P6）
+        collect_affiliations=collect_affs,
     )
     membership.wiki_content = compiled.content
     membership.compiled_at = utcnow()
     membership.compiled_model = compiled.model or None
     if membership.status in ("scored", "fetched"):
         membership.status = "compiled"
+    if compiled.author_affiliations and not paper.affiliations:
+        apply_author_affiliations(paper, compiled.author_affiliations)
     await session.commit()
     # 单篇概念上链：新介绍里的 [[双链]] 建词条并关联（否则点击提示"概念尚未入库"）
     await link_paper_concepts(

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -1,8 +1,14 @@
-"""发表机构 LLM 解析测试（services/affiliations.py + 接线）。
+"""作者↔机构 LLM 解析 + 抽取模式测试（services/affiliations.py + 接线）。
 
-覆盖：服务函数（fake 数组写入 / 坏 JSON 兜底 None / 标题页截断 3000 字）、
-wiki.fetch_extract 优先级（有全文走 LLM 且 OpenAlex 不被调 / LLM 失败回落
-OpenAlex / 无全文直接 OpenAlex）、手动 fetch-pdf 路径补机构。
+覆盖：
+- 服务函数：逐位作者映射解析 / apply 对齐到每位作者并汇总去重总表 / 坏 JSON / 无全文 /
+  LLM 报错兜底 None / 标题页截断 / 向后兼容拍平；
+- OpenAlex `_simplify` 的 authors 现在每人带机构；
+- 抽取模式读写（默认 on_add，非法值报错）+ 管理员端点；
+- wiki.fetch_extract 接线（on_add：有全文走 LLM 映射、失败/无全文回落 OpenAlex）；
+- on_compile：enrich 不调专门抽取（计数=0）；compile_paper 折叠定界块解析 + 剥离干净
+  （坏 JSON 也剥净、映射为 None），调用方 apply 后 paper.authors 带机构；
+- 手动 fetch-pdf 路径补机构。
 """
 
 import uuid
@@ -11,6 +17,7 @@ from types import SimpleNamespace
 
 import fakeredis.aioredis
 import httpx
+import pytest
 import pytest_asyncio
 import respx
 from sqlalchemy import select
@@ -21,7 +28,19 @@ from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.paper import Paper
 from app.models.voyage import VoyageRun
-from app.services.affiliations import _HEAD_CHARS, _MAX_TOKENS, extract_affiliations_llm
+from app.services import affiliations as affil_service
+from app.services.affiliations import (
+    _HEAD_CHARS,
+    _MAX_TOKENS,
+    InvalidAffiliationModeError,
+    apply_author_affiliations,
+    extract_affiliations_llm,
+    extract_author_affiliations_llm,
+    flatten_affiliations,
+    get_affiliation_extraction_mode,
+    parse_and_strip_affiliation_block,
+    set_affiliation_extraction_mode,
+)
 from app.services.literature import (
     ArxivClient,
     OpenAlexClient,
@@ -29,6 +48,8 @@ from app.services.literature import (
     reset_clients,
     set_clients,
 )
+from app.services.literature.openalex import _simplify
+from app.services.wiki_compile import CompiledWiki, compile_paper
 from tests.conftest import add_paper, membership_of, register_and_login
 
 FULL_TEXT = (
@@ -36,6 +57,12 @@ FULL_TEXT = (
     "Alice Zhang (Zhejiang University)  Bob Li (Google DeepMind)\n"
     "alice@zju.edu.cn\n\nAbstract: something interesting.\n"
 )
+
+# fake LLM（core/llm/fake.py）对机构抽取的确定性映射输出
+FAKE_MAPPING = [
+    {"name": "Alice Zhang", "affiliations": ["Zhejiang University"]},
+    {"name": "Bob Li", "affiliations": ["Google DeepMind"]},
+]
 
 OPENALEX_WORK = {
     "id": "https://openalex.org/W1",
@@ -63,7 +90,7 @@ class _StubLLM:
         self.calls.append({"stage": stage, "messages": messages, **kwargs})
         if self.error is not None:
             raise self.error
-        return SimpleNamespace(content=self.content)
+        return SimpleNamespace(content=self.content, model="fake-model")
 
 
 def _paper(tmp_path, full_text: str | None) -> Paper:
@@ -78,47 +105,235 @@ def _paper(tmp_path, full_text: str | None) -> Paper:
 # ---- 服务函数单测（无 DB） ----
 
 
-async def test_extract_affiliations_parses_array(tmp_path):
-    llm = _StubLLM('好的，结果是：["Zhejiang University", "Zhejiang University", " MIT ", 42]')
+async def test_extract_author_affiliations_parses_mapping(tmp_path):
+    llm = _StubLLM(
+        '好的，结果：[{"name": "Alice Zhang", "affiliations": ["Zhejiang University", '
+        '"Zhejiang University"]}, {"name": "Bob Li", "affiliations": [" Google DeepMind "]}, '
+        '{"name": "", "affiliations": ["Ghost"]}]'
+    )
     paper = _paper(tmp_path, FULL_TEXT)
-    result = await extract_affiliations_llm(paper, llm=llm)
-    assert result == ["Zhejiang University", "MIT"]  # 去重、strip、丢非字符串
+    mapping = await extract_author_affiliations_llm(paper, llm=llm)
+    assert mapping == [
+        {"name": "Alice Zhang", "affiliations": ["Zhejiang University"]},  # 去重
+        {"name": "Bob Li", "affiliations": ["Google DeepMind"]},  # strip
+    ]  # 空名整项丢弃
     call = llm.calls[0]
     assert call["stage"] == "librarian"
     assert call["max_tokens"] == _MAX_TOKENS
-    assert call["project_id"] is None  # stub 未传记账归属
+    assert call["project_id"] is None
 
 
-async def test_extract_affiliations_truncates_head(tmp_path):
-    # 3000 字以后的内容（LATE_MARKER）不应进 prompt
+def test_apply_author_affiliations_attaches_per_author():
+    paper = Paper(
+        title="T",
+        authors=[{"name": "Alice Zhang"}, {"name": "Bob Li"}, {"name": "Carol"}],
+    )
+    mapping = [
+        {"name": "alice zhang", "affiliations": ["Zhejiang University"]},  # 大小写不敏感对齐
+        {"name": "Bob Li", "affiliations": ["Google DeepMind", "Zhejiang University"]},
+    ]
+    assert apply_author_affiliations(paper, mapping) is True
+    by_name = {a["name"]: a.get("affiliations") for a in paper.authors}
+    assert by_name["Alice Zhang"] == ["Zhejiang University"]
+    assert by_name["Bob Li"] == ["Google DeepMind", "Zhejiang University"]
+    assert by_name["Carol"] is None  # 未映射到的作者不带机构键
+    # paper.affiliations = 去重保序的机构总表
+    assert paper.affiliations == ["Zhejiang University", "Google DeepMind"]
+
+
+def test_apply_author_affiliations_builds_authors_when_empty():
+    paper = Paper(title="T")  # 无已知作者
+    assert apply_author_affiliations(paper, FAKE_MAPPING) is True
+    assert paper.authors == FAKE_MAPPING
+    assert paper.affiliations == ["Zhejiang University", "Google DeepMind"]
+
+
+def test_apply_author_affiliations_no_affiliations_returns_false():
+    paper = Paper(title="T", authors=[{"name": "Alice"}])
+    assert apply_author_affiliations(paper, [{"name": "Alice", "affiliations": []}]) is False
+    assert apply_author_affiliations(paper, None) is False
+    assert paper.affiliations is None
+
+
+def test_flatten_affiliations_dedup_order():
+    assert flatten_affiliations(FAKE_MAPPING) == ["Zhejiang University", "Google DeepMind"]
+
+
+async def test_extract_author_affiliations_truncates_head(tmp_path):
+    # 3500 字以后的内容（LATE_MARKER）不应进 prompt
     text = FULL_TEXT + "x" * _HEAD_CHARS + "LATE_MARKER"
-    llm = _StubLLM('["Zhejiang University"]')
+    llm = _StubLLM('[{"name": "Alice Zhang", "affiliations": ["Zhejiang University"]}]')
     paper = _paper(tmp_path, text)
-    assert await extract_affiliations_llm(paper, llm=llm) == ["Zhejiang University"]
+    assert await extract_author_affiliations_llm(paper, llm=llm) == [
+        {"name": "Alice Zhang", "affiliations": ["Zhejiang University"]}
+    ]
     user_msg = llm.calls[0]["messages"][1].content
     assert "LATE_MARKER" not in user_msg
     assert user_msg.endswith(text[:_HEAD_CHARS].strip())
     assert FULL_TEXT.strip().splitlines()[0] in user_msg  # 标题页开头在
 
 
-async def test_extract_affiliations_bad_json_returns_none(tmp_path):
-    for content in ("解析不了，抱歉", '{"affiliations": "not an array"}', "[]", '["  "]'):
+async def test_extract_author_affiliations_bad_json_returns_none(tmp_path):
+    for content in ("解析不了，抱歉", '{"name": "x"}', "[]", "[{}]", '[{"name": "  "}]'):
         paper = _paper(tmp_path, FULL_TEXT)
-        assert await extract_affiliations_llm(paper, llm=_StubLLM(content)) is None
+        assert await extract_author_affiliations_llm(paper, llm=_StubLLM(content)) is None
 
 
-async def test_extract_affiliations_llm_error_returns_none(tmp_path):
+async def test_extract_author_affiliations_llm_error_returns_none(tmp_path):
     paper = _paper(tmp_path, FULL_TEXT)
     llm = _StubLLM(error=RuntimeError("boom"))
-    assert await extract_affiliations_llm(paper, llm=llm) is None
+    assert await extract_author_affiliations_llm(paper, llm=llm) is None
 
 
-async def test_extract_affiliations_no_fulltext_returns_none(tmp_path):
-    llm = _StubLLM('["Zhejiang University"]')
-    assert await extract_affiliations_llm(_paper(tmp_path, None), llm=llm) is None
+async def test_extract_author_affiliations_no_fulltext_returns_none(tmp_path):
+    llm = _StubLLM('[{"name": "Alice", "affiliations": ["MIT"]}]')
+    assert await extract_author_affiliations_llm(_paper(tmp_path, None), llm=llm) is None
     missing = Paper(title="T", full_text_path=str(tmp_path / "nope.txt"))
-    assert await extract_affiliations_llm(missing, llm=llm) is None
+    assert await extract_author_affiliations_llm(missing, llm=llm) is None
     assert llm.calls == []
+
+
+async def test_extract_affiliations_llm_backcompat_flattens(tmp_path):
+    """向后兼容包装：只要去重机构总表。"""
+    llm = _StubLLM(
+        '[{"name": "Alice", "affiliations": ["MIT", "MIT"]}, '
+        '{"name": "Bob", "affiliations": ["CMU"]}]'
+    )
+    assert await extract_affiliations_llm(_paper(tmp_path, FULL_TEXT), llm=llm) == ["MIT", "CMU"]
+
+
+def test_openalex_simplify_authors_carry_affiliations():
+    simplified = _simplify(OPENALEX_WORK)
+    assert simplified["authors"] == [{"name": "Carol", "affiliations": ["OpenAlex University"]}]
+    assert simplified["affiliations"] == ["OpenAlex University"]
+
+
+# ---- on_compile 定界块解析/剥离（纯函数） ----
+
+
+def test_parse_and_strip_block_good():
+    content = (
+        "## TL;DR\n\n正文（fake）。\n\n---\n<<<POLARIS_AFFILIATIONS\n"
+        '[{"name": "Alice", "affiliations": ["MIT"]}]\nPOLARIS_AFFILIATIONS>>>\n'
+    )
+    stripped, mapping = parse_and_strip_affiliation_block(content)
+    assert "POLARIS_AFFILIATIONS" not in stripped  # 块 + 前置分隔线都删干净
+    assert stripped == "## TL;DR\n\n正文（fake）。\n"
+    assert mapping == [{"name": "Alice", "affiliations": ["MIT"]}]
+
+
+def test_parse_and_strip_block_bad_json():
+    content = "正文B\n<<<POLARIS_AFFILIATIONS\n[{\"name\": broken OOPS]\nPOLARIS_AFFILIATIONS>>>\n"
+    stripped, mapping = parse_and_strip_affiliation_block(content)
+    assert "POLARIS_AFFILIATIONS" not in stripped  # 坏 JSON 也要剥净
+    assert stripped == "正文B\n"
+    assert mapping is None
+
+
+def test_parse_and_strip_block_unclosed_marker():
+    """模型只吐了开头标记、没闭合 → 从裸标记删到文末，绝不漏进 wiki。"""
+    content = "## TL;DR\n\n正文C。\n\n---\n<<<POLARIS_AFFILIATIONS\n[{\"name\": \"Alice\"}]"
+    stripped, mapping = parse_and_strip_affiliation_block(content)
+    assert "POLARIS_AFFILIATIONS" not in stripped
+    assert stripped == "## TL;DR\n\n正文C。\n"
+    assert mapping is None
+
+
+def test_parse_and_strip_block_absent():
+    content = "只有正文，没有块\n"
+    assert parse_and_strip_affiliation_block(content) == (content, None)
+
+
+# ---- 抽取模式读写 + 管理员端点 ----
+
+
+async def test_affiliation_mode_default_and_roundtrip(app):
+    async with get_sessionmaker()() as session:
+        assert await get_affiliation_extraction_mode(session) == "on_add"  # 默认
+        assert await set_affiliation_extraction_mode(session, "on_compile") == "on_compile"
+    async with get_sessionmaker()() as session:
+        assert await get_affiliation_extraction_mode(session) == "on_compile"
+        assert await set_affiliation_extraction_mode(session, "on_add") == "on_add"
+
+
+async def test_affiliation_mode_rejects_invalid(app):
+    async with get_sessionmaker()() as session:
+        with pytest.raises(InvalidAffiliationModeError):
+            await set_affiliation_extraction_mode(session, "whenever")
+
+
+async def test_affiliation_mode_admin_endpoint(client):
+    admin = await register_and_login(client)  # 首个 = admin
+    member = await register_and_login(client, email="bob2@example.com")
+    ah = {"Authorization": f"Bearer {admin}"}
+    mh = {"Authorization": f"Bearer {member}"}
+
+    resp = await client.get("/api/admin/settings/affiliation-mode", headers=ah)
+    assert resp.status_code == 200 and resp.json()["mode"] == "on_add"
+    # 普通成员改 → 403
+    resp = await client.put(
+        "/api/admin/settings/affiliation-mode", json={"mode": "on_compile"}, headers=mh
+    )
+    assert resp.status_code == 403
+    # admin 改；非法值 422（schema Literal 校验）
+    resp = await client.put(
+        "/api/admin/settings/affiliation-mode", json={"mode": "on_compile"}, headers=ah
+    )
+    assert resp.status_code == 200 and resp.json()["mode"] == "on_compile"
+    resp = await client.put(
+        "/api/admin/settings/affiliation-mode", json={"mode": "nonsense"}, headers=ah
+    )
+    assert resp.status_code == 422
+
+
+# ---- compile_paper：on_compile 折叠抽取 ----
+
+_WIKI_BODY = "## TL;DR\n\n测试解读正文（fake）。\n"
+
+
+async def test_compile_paper_collects_and_strips_block():
+    paper = Paper(title="Affil Paper", abstract="some abstract", authors=[{"name": "Alice Zhang"}])
+    content = (
+        _WIKI_BODY
+        + "\n---\n<<<POLARIS_AFFILIATIONS\n"
+        + '[{"name": "Alice Zhang", "affiliations": ["Zhejiang University"]}]\n'
+        + "POLARIS_AFFILIATIONS>>>\n"
+    )
+    llm = _StubLLM(content)
+    compiled = await compile_paper(paper, statement=None, llm=llm, collect_affiliations=True)
+    assert isinstance(compiled, CompiledWiki)
+    assert "POLARIS_AFFILIATIONS" not in compiled.content  # 绝不残留进 wiki
+    assert compiled.content == _WIKI_BODY
+    assert compiled.author_affiliations == [
+        {"name": "Alice Zhang", "affiliations": ["Zhejiang University"]}
+    ]
+    # 定界块指令确有追加到 prompt
+    assert affil_service.AFFIL_COMPILE_INSTRUCTION in llm.calls[0]["messages"][1].content
+    # 调用方据此补库
+    assert apply_author_affiliations(paper, compiled.author_affiliations) is True
+    assert paper.authors[0]["affiliations"] == ["Zhejiang University"]
+    assert paper.affiliations == ["Zhejiang University"]
+
+
+async def test_compile_paper_bad_block_still_clean():
+    paper = Paper(title="Affil Paper", abstract="some abstract")
+    content = (
+        _WIKI_BODY + '\n<<<POLARIS_AFFILIATIONS\n[{"name": oops OOPS]\nPOLARIS_AFFILIATIONS>>>\n'
+    )
+    compiled = await compile_paper(
+        paper, statement=None, llm=_StubLLM(content), collect_affiliations=True
+    )
+    assert "POLARIS_AFFILIATIONS" not in compiled.content  # 坏 JSON 也剥净
+    assert compiled.content == _WIKI_BODY
+    assert compiled.author_affiliations is None  # 解析失败 → None，wiki 照常
+
+
+async def test_compile_paper_no_collect_leaves_prompt_clean():
+    paper = Paper(title="Affil Paper", abstract="some abstract")
+    llm = _StubLLM(_WIKI_BODY)
+    compiled = await compile_paper(paper, statement=None, llm=llm, collect_affiliations=False)
+    assert compiled.author_affiliations is None
+    assert affil_service.AFFIL_COMPILE_INSTRUCTION not in llm.calls[0]["messages"][1].content
 
 
 # ---- wiki.fetch_extract 接线（优先级 LLM > OpenAlex） ----
@@ -151,7 +366,8 @@ async def _setup_scored_paper(
         f.write_text(full_text, encoding="utf-8")
         txt_path = str(f)
     async with get_sessionmaker()() as session:
-        paper = await add_paper(session,
+        paper = await add_paper(
+            session,
             project_id=project_id,
             source="snowball",
             status="scored",
@@ -192,11 +408,13 @@ async def test_fetch_extract_prefers_llm_over_openalex(client, lit_clients, tmp_
     assert obs["succeeded"] == 1 and obs["failed"] == []
     assert not openalex_route.called  # 有全文 → 走 LLM，OpenAlex 不被调
     paper = await _load_paper(paper_id)
-    assert paper.affiliations == ["Zhejiang University", "Google DeepMind"]  # fake LLM 数组
+    assert paper.affiliations == ["Zhejiang University", "Google DeepMind"]  # fake LLM 映射拍平
+    # 逐位作者带机构（apply 写回 paper.authors）
+    by_name = {a["name"]: a.get("affiliations") for a in paper.authors}
+    assert by_name["Alice Zhang"] == ["Zhejiang University"]
+    assert by_name["Bob Li"] == ["Google DeepMind"]
     async with get_sessionmaker()() as session:
-        membership = await membership_of(
-            session, project_id=run.project_id, paper_id=paper_id
-        )
+        membership = await membership_of(session, project_id=run.project_id, paper_id=paper_id)
         assert membership.status == "fetched"
 
 
@@ -206,7 +424,7 @@ async def test_fetch_extract_llm_failure_falls_back_to_openalex(
     async def _fail(paper, **kwargs):
         return None  # 模拟 LLM 解析失败（extract 内部失败即返回 None）
 
-    monkeypatch.setattr(actions_wiki, "extract_affiliations_llm", _fail)
+    monkeypatch.setattr(actions_wiki, "extract_author_affiliations_llm", _fail)
     paper_id, run = await _setup_scored_paper(
         client, tmp_path, full_text=FULL_TEXT, published=False
     )
@@ -218,7 +436,7 @@ async def test_fetch_extract_llm_failure_falls_back_to_openalex(
         obs = await actions_wiki.fetch_extract(ctx, {})
     assert obs["succeeded"] == 1
     paper = await _load_paper(paper_id)
-    assert paper.affiliations == ["OpenAlex University"]  # OpenAlex 兜底
+    assert paper.affiliations == ["OpenAlex University"]  # OpenAlex 兜底（authors 带机构）
     assert paper.published_at is not None  # 顺带补 DOI 论文发表日期
 
 
@@ -227,9 +445,9 @@ async def test_fetch_extract_no_fulltext_uses_openalex(client, lit_clients, tmp_
 
     async def _count(paper, **kwargs):
         llm_calls["n"] += 1
-        return ["Should Not Appear"]
+        return FAKE_MAPPING
 
-    monkeypatch.setattr(actions_wiki, "extract_affiliations_llm", _count)
+    monkeypatch.setattr(actions_wiki, "extract_author_affiliations_llm", _count)
     paper_id, run = await _setup_scored_paper(client, tmp_path, full_text=None, published=False)
     with respx.mock(assert_all_called=False) as router:
         router.get(url__regex=r"https://api\.openalex\.org/.*").mock(
@@ -243,7 +461,79 @@ async def test_fetch_extract_no_fulltext_uses_openalex(client, lit_clients, tmp_
     assert paper.published_at is not None
 
 
-# ---- 手动 fetch-pdf 路径（此前不补机构） ----
+async def test_fetch_extract_on_compile_skips_dedicated_llm(
+    client, lit_clients, tmp_path, monkeypatch
+):
+    """on_compile：fetch_extract 不调专门抽取；无全文时 OpenAlex 兜底仍生效。"""
+    llm_calls = {"n": 0}
+
+    async def _count(paper, **kwargs):
+        llm_calls["n"] += 1
+        return FAKE_MAPPING
+
+    monkeypatch.setattr(actions_wiki, "extract_author_affiliations_llm", _count)
+    async with get_sessionmaker()() as session:
+        await set_affiliation_extraction_mode(session, "on_compile")
+    paper_id, run = await _setup_scored_paper(
+        client, tmp_path, full_text=FULL_TEXT, published=False
+    )
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__regex=r"https://api\.openalex\.org/.*").mock(
+            return_value=httpx.Response(200, json=OPENALEX_WORK)
+        )
+        ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint or {}))
+        await actions_wiki.fetch_extract(ctx, {})
+    assert llm_calls["n"] == 0  # on_compile 跳过专门抽取
+    paper = await _load_paper(paper_id)
+    assert paper.affiliations == ["OpenAlex University"]  # OpenAlex 兜底不受模式影响
+
+
+async def test_enrich_on_compile_skips_dedicated_llm(client, tmp_path, monkeypatch):
+    """on_compile：enrich 分阶段补全不调专门机构抽取（计数=0）。"""
+    from app.services import paper_enrich
+
+    calls = {"n": 0}
+
+    async def _count(paper, **kwargs):
+        calls["n"] += 1
+        return FAKE_MAPPING
+
+    # enrich 内部从 affiliations 源模块局部导入，故 patch 源符号
+    monkeypatch.setattr(affil_service, "extract_author_affiliations_llm", _count)
+
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "enrich-proj"}, headers=headers)
+    project_id = uuid.UUID(resp.json()["id"])
+    f = tmp_path / "full.txt"
+    f.write_text(FULL_TEXT, encoding="utf-8")
+    async with get_sessionmaker()() as session:
+        await set_affiliation_extraction_mode(session, "on_compile")
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            source="manual",
+            status="included",
+            title="Affil Paper",
+            full_text_path=str(f),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async def _emit(*args, **kwargs):
+        return None
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=project_id, emit=_emit
+        )
+    assert calls["n"] == 0  # on_compile 跳过专门抽取
+    paper = await _load_paper(paper_id)
+    assert not paper.affiliations  # 该阶段不补机构（留给编译）
+
+
+# ---- 手动 fetch-pdf 路径（补机构） ----
 
 
 def _make_pdf_bytes() -> bytes:
@@ -263,7 +553,8 @@ async def test_fetch_pdf_backfills_affiliations(client, lit_clients):
     resp = await client.post("/api/projects", json={"name": "affil-proj"}, headers=headers)
     project_id = uuid.UUID(resp.json()["id"])
     async with get_sessionmaker()() as session:
-        paper = await add_paper(session,
+        paper = await add_paper(
+            session,
             project_id=project_id,
             source="manual",
             status="included",

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -226,7 +226,7 @@ async def test_openalex_by_arxiv_id(cache_redis):
     assert meta is not None
     assert meta["cited_by_count"] == 42
     assert meta["doi"] == "10.48550/arXiv.2404.11111"
-    assert meta["authors"] == [{"name": "Eve"}]
+    assert meta["authors"] == [{"name": "Eve", "affiliations": []}]
     assert meta["venue"] == "arXiv"
     await client.aclose()
 

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -78,7 +78,7 @@ async def test_add_by_arxiv_id_and_dedupe_409(client, lit_clients):
     assert body["title"] == "Autonomous Research Agents"
     assert body["status"] == "included"
     assert body["arxiv_id"] == "2406.00001"
-    assert body["authors"] == [{"name": "Alice Smith"}]
+    assert body["authors"] == [{"name": "Alice Smith", "affiliations": []}]
     assert body["pdf_available"] is False  # 同步阶段不下载 PDF
     paper_id = body["id"]
 
@@ -132,7 +132,10 @@ async def test_add_by_bibtex_and_dedupe_by_doi(client):
     assert resp.status_code == 201, resp.text
     body = resp.json()
     assert body["title"] == "A Benchmark for Agents"  # 花括号剥掉
-    assert body["authors"] == [{"name": "Smith, Alice"}, {"name": "Bob Jones"}]
+    assert body["authors"] == [
+        {"name": "Smith, Alice", "affiliations": []},
+        {"name": "Bob Jones", "affiliations": []},
+    ]
     assert body["year"] == 2025
     assert body["venue"] == "Proceedings of NeurIPS"
     assert body["doi"] == "10.1000/bench"

--- a/src/backend/tests/test_wiki_api.py
+++ b/src/backend/tests/test_wiki_api.py
@@ -92,8 +92,8 @@ async def test_papers_list_filter_sort_paginate(client):
     body = resp.json()
     assert body["total"] == 2 and body["page"] == 1 and body["size"] == 20
     assert body["items"][0]["relevance_score"] == 0.9  # 默认按相关性降序
-    assert body["items"][0]["authors"] == [{"name": "Alice"}]
-    assert body["items"][1]["authors"] == [{"name": "Bob"}]  # 字符串作者归一化
+    assert body["items"][0]["authors"] == [{"name": "Alice", "affiliations": []}]
+    assert body["items"][1]["authors"] == [{"name": "Bob", "affiliations": []}]  # 字符串作者归一化
     assert body["items"][0]["has_wiki"] is True
 
     resp = await client.get(f"/api/projects/{project_id}/papers?status=compiled", headers=headers)

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -105,18 +105,28 @@ export function InfoPanel({
       <div style={{ fontSize: 14.5, fontWeight: 660, lineHeight: 1.4, marginBottom: 5 }}>{paper.title}</div>
       {paper.authors.length > 0 && (
         <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
-          {paper.authors.map((a, i) => (
-            <span key={`${a.name}-${i}`}>
-              {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
-              <span
-                className="author-link"
-                title={tr(`回文献库只看 ${a.name} 的论文`, `Back to the library, showing only ${a.name}'s papers`)}
-                {...clickable(() => navigate(topicPath(paper.project_id, `wiki?author=${encodeURIComponent(a.name)}`)))}
-              >
-                {a.name}
+          {paper.authors.map((a, i) => {
+            const affil = a.affiliations?.filter(Boolean) ?? [];
+            return (
+              <span key={`${a.name}-${i}`}>
+                {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
+                <span
+                  className="author-link"
+                  title={
+                    affil.length > 0
+                      ? `${a.name} — ${affil.join('; ')}`
+                      : tr(`回文献库只看 ${a.name} 的论文`, `Back to the library, showing only ${a.name}'s papers`)
+                  }
+                  {...clickable(() => navigate(topicPath(paper.project_id, `wiki?author=${encodeURIComponent(a.name)}`)))}
+                >
+                  {a.name}
+                </span>
+                {affil.length > 0 && (
+                  <span style={{ color: 'var(--text-4)', fontSize: 10.5 }}> ({affil[0]}{affil.length > 1 ? ` +${affil.length - 1}` : ''})</span>
+                )}
               </span>
-            </span>
-          ))}
+            );
+          })}
         </div>
       )}
       {(paper.affiliations?.length ?? 0) > 0 && (

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -23,6 +23,7 @@ import {
   api,
   isAdmin,
   type AdminUserRead,
+  type AffiliationMode,
   type EffectiveTestResult,
   type LlmCallLogRow,
   type LlmProviderInput,
@@ -1581,11 +1582,65 @@ function CallLogsSection() {
   );
 }
 
+function AffiliationModeSection() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['affiliation-mode'],
+    queryFn: () => api.getAffiliationMode(),
+    retry: false,
+  });
+  const mode: AffiliationMode = data?.mode ?? 'on_add';
+
+  const setMutation = useMutation({
+    mutationFn: (m: AffiliationMode) => api.setAffiliationMode(m),
+    onSuccess: (r) => {
+      toast(tr('已保存机构抽取时机', 'Affiliation extraction timing saved'), 'ok');
+      queryClient.setQueryData(['affiliation-mode'], r);
+    },
+    onError: (e) => toast(`${tr('保存失败', 'Save failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  return (
+    <div className="card card-pad" style={{ marginTop: 20 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="users" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('作者机构抽取', 'Author affiliation extraction')}
+      </div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
+        {tr(
+          '大模型从论文标题页解析每位作者所属机构的时机。选「编译 wiki 时抽取」会把机构解析折叠进精读编译那一次调用里，省下一次单独的大模型调用。（DOI 论文的机构由 OpenAlex 结构化数据直接给出，不受此设置影响。）',
+          "When the model parses each author's affiliation from the title page. \"Extract while compiling\" folds it into the deep-reading compile call, saving a separate LLM call. (Affiliations for DOI papers come straight from OpenAlex and are unaffected.)",
+        )}
+      </div>
+      {isLoading ? (
+        <div className="empty" style={{ padding: 16 }}>{tr('加载中…', 'Loading…')}</div>
+      ) : isError ? (
+        <div className="empty" style={{ padding: 16 }}>
+          {tr('无法加载（后端不可用或无权限）', 'Failed to load (backend unavailable or no permission)')}
+        </div>
+      ) : (
+        <Segmented
+          options={[
+            { v: 'on_add' as AffiliationMode, label: tr('添加时抽取', 'Extract on add') },
+            {
+              v: 'on_compile' as AffiliationMode,
+              label: tr('编译 wiki 时抽取（省一次调用）', 'Extract while compiling (saves a call)'),
+            },
+          ]}
+          value={mode}
+          onChange={(v) => { if (v !== mode) setMutation.mutate(v); }}
+        />
+      )}
+    </div>
+  );
+}
+
 function LlmTab() {
   return (
     <>
       <ProvidersSection adapter={adminLlmAdapter} />
       <RoutesSection adapter={adminLlmAdapter} />
+      <AffiliationModeSection />
       <CallLogsSection />
     </>
   );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -512,6 +512,12 @@ export interface LlmCallLogSettings {
   enabled: boolean;
 }
 
+/** 论文作者↔机构抽取模式：入库时抽 / 编译 wiki 时顺带抽（省一次调用）。 */
+export type AffiliationMode = 'on_add' | 'on_compile';
+export interface AffiliationModeRead {
+  mode: AffiliationMode;
+}
+
 export interface LlmCallLogRow {
   id: string;
   created_at: string;
@@ -579,6 +585,8 @@ export type PaperSort = 'relevance' | '-published_at';
 
 export interface PaperAuthor {
   name: string;
+  /** 该作者最可能的所属机构（OpenAlex 结构化 / LLM 从标题页尽力对应；可能为空） */
+  affiliations?: string[];
 }
 
 export interface PaperRead {
@@ -3604,6 +3612,13 @@ export const api = {
   },
   getLlmCallLogSettings(): Promise<LlmCallLogSettings> {
     return request<LlmCallLogSettings>('/admin/llm/call-logs/settings');
+  },
+  /** 机构抽取模式（admin）。 */
+  getAffiliationMode(): Promise<AffiliationModeRead> {
+    return request<AffiliationModeRead>('/admin/settings/affiliation-mode');
+  },
+  setAffiliationMode(mode: AffiliationMode): Promise<AffiliationModeRead> {
+    return requestJson<AffiliationModeRead>('/admin/settings/affiliation-mode', 'PUT', { mode });
   },
   putLlmCallLogSettings(enabled: boolean): Promise<LlmCallLogSettings> {
     return requestJson<LlmCallLogSettings>('/admin/llm/call-logs/settings', 'PUT', { enabled });


### PR DESCRIPTION
## What

Extraction now produces a **per-author affiliation mapping**, not just a flat list of institutions (best-effort, since a paper's title page rarely maps authors to institutions cleanly).

- `affiliations.py`: `extract_author_affiliations_llm` returns `[{name, affiliations}]`; `apply_author_affiliations` writes it back onto `paper.authors` (per author) and aggregates `paper.affiliations`.
- **OpenAlex** populates each author's institutions directly (structured data, available for DOI papers).
- Wired into every extraction caller (enrich / import / voyage `fetch_extract` / `fetch_pdf`); `AuthorRead` and the frontend `PaperAuthor` carry `affiliations`; the reading panel shows each author's institution.

## Admin extraction mode

`SystemSetting affiliation_extraction_mode`:
- **on_add** (default): a dedicated LLM call at add/enrich time.
- **on_compile** (saves a call): the add path skips the dedicated call; the wiki-compile LLM appends an author-affiliation block after the wiki, which is parsed and **stripped out** — it never leaks into the wiki, even if the model forgets to close the marker.
- `GET/PUT /admin/settings/affiliation-mode` plus a Settings toggle. DOI papers are unaffected by the mode (OpenAlex already provides institutions at metadata time).

## Tests

`test_affiliations.py` rewritten for the mapping format (27 cases incl. block strip / bad JSON / unclosed marker); wiki / literature / manual-add assertions updated for per-author affiliations. 73 passed; ruff clean; tsc 0 errors.