### PR TITLE
fix(library): fixed-size direction description field, relabel to 方向描述

### DIFF
--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -306,10 +306,11 @@ function LibraryInfoCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readO
           <input className="input" value={name} disabled={readOnly} onChange={(e) => setName(e.target.value)} maxLength={255} />
         </label>
         <label className="col gap6">
-          <span className="muted" style={{ fontSize: 12 }}>{tr('方向说明（一句话）', 'Statement')}</span>
+          <span className="muted" style={{ fontSize: 12 }}>{tr('方向描述', 'Description')}</span>
           <textarea
-            className="input"
-            rows={2}
+            className="textarea"
+            rows={3}
+            style={{ resize: 'none', height: 78 }}
             value={statement}
             disabled={readOnly}
             onChange={(e) => setStatement(e.target.value)}


### PR DESCRIPTION
## Summary
On `/libraries/:id` → Governance → **Library info** card, the research-direction description field had two problems (issue #80):

1. **Dimensions were not fixed.** The `<textarea>` used `className="input"`, so `.input { height: 38px }` squashed it and, because the class never sets `resize`, the browser default `resize: both` let the user drag it to arbitrary width/height.
2. **Wrong label.** It read `方向说明（一句话）`.

### Changes
- Switch the textarea to the `.textarea` style with **`rows={3}`**, an explicit **fixed height (78px ≈ three text rows)** and **`resize: 'none'`** — so it now has a fixed width (fills the field column, no longer draggable) and a fixed three-row height.
- Rename the label from **`方向说明` → `方向描述`** (English `Statement` → `Description`).

No data-model change — the field still binds to `statement`.

## Verification
- Frontend `tsc --noEmit` + `vite build` pass (built the `build` stage of `Dockerfile.frontend` against this worktree).

Closes #80