### PR TITLE
feat(library): chunk + paper-embed on every add path; index-count feedback

### DIFF
--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -351,6 +351,23 @@ def _require_fulltext_index_enabled(user: User) -> None:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INDEXING_DISABLED")
 
 
+async def _count_with_fulltext(
+    session: AsyncSession, paper_ids: list[uuid.UUID]
+) -> int:
+    """这批论文里有本地全文（full_text_path 非空）的篇数（一条 count，不抓 PDF）。"""
+    if not paper_ids:
+        return 0
+    return int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(Paper)
+                .where(Paper.id.in_(paper_ids), Paper.full_text_path.is_not(None))
+            )
+        ).scalar_one()
+    )
+
+
 @router.post("/projects/{project_id}/shelf/index/rebuild")
 async def rebuild_shelf_fulltext_index(
     project_id: uuid.UUID,
@@ -365,8 +382,13 @@ async def rebuild_shelf_fulltext_index(
     await _member_project(session, project_id, user)
     _require_fulltext_index_enabled(user)
     paper_ids = await shelf_paper_ids(session, project_id=project_id)
+    indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "shelf", str(user.id), str(project_id))
-    return {"queued": len(paper_ids)}
+    return {
+        "queued": len(paper_ids),
+        "indexable": indexable,
+        "no_fulltext": len(paper_ids) - indexable,
+    }
 
 
 @router.post("/library/index/rebuild")
@@ -381,8 +403,13 @@ async def rebuild_personal_fulltext_index(
     """
     _require_fulltext_index_enabled(user)
     paper_ids = await personal_paper_ids(session, user_id=user.id, tab="saved")
+    indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "personal", str(user.id), None)
-    return {"queued": len(paper_ids)}
+    return {
+        "queued": len(paper_ids),
+        "indexable": indexable,
+        "no_fulltext": len(paper_ids) - indexable,
+    }
 
 
 @router.post("/projects/{project_id}/index/rebuild")

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -78,6 +78,28 @@ async def index_paper_fulltext(session: AsyncSession, paper: Paper) -> int:
     return await replace_chunks(session, paper, full_text)
 
 
+async def paper_has_chunks(session: AsyncSession, paper_id: uuid.UUID) -> bool:
+    """该论文是否已有分段行。用于「无块才切」——避免重切丢已补的块向量。"""
+    row = (
+        await session.execute(
+            select(PaperChunk.id).where(PaperChunk.paper_id == paper_id).limit(1)
+        )
+    ).first()
+    return row is not None
+
+
+async def user_wants_fulltext_index(
+    session: AsyncSession, user_id: uuid.UUID | None
+) -> bool:
+    """该用户是否开启了「为论文建立全文索引」（chat_fulltext_index）。user_id 空→False。"""
+    if user_id is None:
+        return False
+    from app.models.user import User
+
+    user = await session.get(User, user_id)
+    return bool(user is not None and user.setting("chat_fulltext_index") is True)
+
+
 async def _embed_chunks(
     session: AsyncSession,
     pending: list[PaperChunk],

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -132,6 +132,24 @@ async def enrich_paper(
             paper = await _rollback_and_reload()
             await emit("extract", "error", f"{type(e).__name__}: {e}")
 
+    # 全文分块（文献问答底座）：抽到全文后就地建块，无块才切（避免重切丢已补的块向量）。
+    # 不单列可见进度阶段（STAGES 保持 download/extract/embed/score 不变）；块向量按用户开关
+    # 在下面 embed 阶段之后补。best-effort：失败记日志、回滚重取，不阻断后续阶段。
+    if paper.full_text_path:
+        from app.services.chunks import index_paper_fulltext, paper_has_chunks
+
+        try:
+            if not await paper_has_chunks(session, paper_id):
+                await index_paper_fulltext(session, paper)
+                await session.commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "enrich chunk indexing failed for paper %s", paper_id, exc_info=True
+            )
+            paper = await _rollback_and_reload()
+
     # 作者↔机构：on_add 模式下全文到手且尚无机构时 LLM 补（非独立阶段，best-effort，不发
     # 事件）；on_compile 模式跳过，改由 wiki 编译折叠抽取
     if not paper.affiliations and paper.full_text_path:
@@ -178,6 +196,29 @@ async def enrich_paper(
             logger.warning("enrich embed failed for paper %s", paper_id, exc_info=True)
             paper = await _rollback_and_reload()
             await emit("embed", "error", f"{type(e).__name__}: {e}")
+
+    # 块向量：仅当用户开启全文索引开关时补（开关关只留块行，等重建/开开关再补）。
+    # best-effort，不影响 embed 阶段判定；不发独立进度事件。
+    from app.services.chunks import embed_pending_chunks_for_papers, user_wants_fulltext_index
+
+    if await user_wants_fulltext_index(session, user_id):
+        from app.core.llm.router import get_llm_router
+
+        try:
+            await embed_pending_chunks_for_papers(
+                session,
+                paper_ids=[paper_id],
+                llm=get_llm_router(),
+                user_id=user_id,
+                project_id=project_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "enrich chunk embed failed for paper %s", paper_id, exc_info=True
+            )
+            paper = await _rollback_and_reload()
 
     # ---- score ----
     await emit("score", "running")

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -822,14 +822,23 @@ async def fetch_pdf(
         paper.full_text_path = str(txt_path)
     except Exception:  # noqa: BLE001 — 抽取失败降级：仅有 PDF、无全文
         logger.warning("full text extraction failed for paper %s", paper.id, exc_info=True)
-    # 全文分段索引（文献问答底座）；失败不影响 PDF 落盘
+    # 全文分段索引（文献问答底座）；失败不影响 PDF 落盘。无块才切，避免重切丢已补的块向量
     if paper.full_text_path:
-        from app.services.chunks import index_paper_fulltext
+        from app.services.chunks import index_paper_fulltext, paper_has_chunks
 
         try:
-            await index_paper_fulltext(session, paper)
+            if not await paper_has_chunks(session, paper.id):
+                await index_paper_fulltext(session, paper)
         except Exception:  # noqa: BLE001
             logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
+    # 论文级向量（此路径原先不建）：embedding 为空才补，best-effort，不影响 PDF 落盘
+    if paper.embedding is None:
+        from app.services.paper_enrich import embed_paper
+
+        try:
+            await embed_paper(paper, user_id=user_id, project_id=project_id)
+        except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
+            logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
     # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
     # 机构）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响主流程
     if not paper.affiliations and paper.full_text_path:
@@ -846,6 +855,26 @@ async def fetch_pdf(
             )
             apply_author_affiliations(paper, mapping)
     await session.commit()
+    # 块向量受用户开关：开启才嵌（关时块行留着，待重建/开开关再补）。best-effort，内部自 commit
+    if paper.full_text_path:
+        from app.services.chunks import (
+            embed_pending_chunks_for_papers,
+            user_wants_fulltext_index,
+        )
+
+        if await user_wants_fulltext_index(session, user_id):
+            from app.core.llm.router import get_llm_router
+
+            try:
+                await embed_pending_chunks_for_papers(
+                    session,
+                    paper_ids=[paper.id],
+                    llm=get_llm_router(),
+                    user_id=user_id,
+                    project_id=project_id,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
     return paper
 

--- a/src/backend/tests/test_chat_fulltext_index.py
+++ b/src/backend/tests/test_chat_fulltext_index.py
@@ -146,6 +146,43 @@ async def test_shelf_index_rebuild_gated(client, queue_stub):
     assert args[2] == str(project_id)
 
 
+async def test_shelf_index_rebuild_reports_indexable_counts(client, queue_stub):
+    """返回体含 indexable / no_fulltext：书架上有全文的计入 indexable，其余计跳过。"""
+    project_id, headers = await _project(client)
+    await _enable_index(client, headers)
+
+    txt_dir = Path(tempfile.mkdtemp(prefix="polaris-idx-"))
+    txt = txt_dir / "p.txt"
+    txt.write_text("规划方法细节。" * 50, encoding="utf-8")
+    async with get_sessionmaker()() as session:
+        with_text = await add_paper(
+            session, project_id=project_id, title="Has Full Text",
+            status="compiled", full_text_path=str(txt),
+        )
+        no_text = await add_paper(
+            session, project_id=project_id, title="No Full Text", status="candidate",
+        )
+        await session.commit()
+        # 入书架（两篇都上架，才会进 shelf_paper_ids）
+        from app.services.topic_shelf import add_to_shelf
+
+        user = (await client.get("/api/users/me", headers=headers)).json()
+        for p in (with_text, no_text):
+            await add_to_shelf(
+                session, project_id=project_id, paper_id=p.id, user_id=uuid.UUID(user["id"])
+            )
+        await session.commit()
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["queued"] == 2
+    assert body["indexable"] == 1
+    assert body["no_fulltext"] == 1
+
+
 async def test_shelf_index_rebuild_requires_member(client, queue_stub):
     _, headers = await _project(client)
     await _enable_index(client, headers)

--- a/src/backend/tests/test_enrich_chunk_index.py
+++ b/src/backend/tests/test_enrich_chunk_index.py
@@ -1,0 +1,181 @@
+"""三路径统一「分块 + 论文级向量」，块向量受 chat_fulltext_index 开关控制。
+
+覆盖 enrich_paper（手动添加 / Daily 收录）与 papers.fetch_pdf（抓取 PDF）：
+- 抽到全文即分块（无块才切，不重切丢已补向量）；
+- 论文级向量照常产出；
+- 块向量仅在用户开启开关时补齐，开关关时块行留着但 embedding 为空。
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+
+import httpx
+import respx
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import PaperChunk
+from app.services import paper_enrich
+from app.services.literature import reset_clients, set_clients
+from app.services.literature.arxiv import ArxivClient
+from app.services.literature.openalex import OpenAlexClient
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+
+async def _noop_emit(stage: str, status: str, detail: str | None = None) -> None:
+    return None
+
+
+def _write_fulltext() -> str:
+    txt_dir = Path(tempfile.mkdtemp(prefix="polaris-enrich-"))
+    txt = txt_dir / "p.txt"
+    txt.write_text("规划方法的实现细节与实验。" * 200, encoding="utf-8")
+    return str(txt)
+
+
+async def _user(client, email: str, *, index_on: bool):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    if index_on:
+        await client.patch(
+            "/api/users/me/settings", json={"chat_fulltext_index": True}, headers=headers
+        )
+    me = (await client.get("/api/users/me", headers=headers)).json()
+    return uuid.UUID(me["id"]), headers
+
+
+async def _n_chunks(session, paper_id):
+    return await session.scalar(
+        select(func.count()).select_from(PaperChunk).where(PaperChunk.paper_id == paper_id)
+    )
+
+
+async def _n_embedded(session, paper_id):
+    return await session.scalar(
+        select(func.count())
+        .select_from(PaperChunk)
+        .where(PaperChunk.paper_id == paper_id, PaperChunk.embedding.is_not(None))
+    )
+
+
+async def _run_enrich(paper_id, *, user_id):
+    async with get_sessionmaker()() as session:
+        paper = await session.get(paper_enrich.Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=user_id, project_id=None, emit=_noop_emit
+        )
+
+
+# ---- enrich_paper：分块 + 论文级向量 + 块向量受开关 ----
+
+
+async def test_enrich_chunks_but_leaves_block_vectors_when_index_off(client, fake_redis):
+    """开关关：抽到全文→建块 + 论文级向量，但块行 embedding 留空。"""
+    user_id, headers = await _user(client, "off@example.com", index_on=False)
+    project_id, _ = await make_project_with_library(client, headers, name="enrich-off")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Off",
+            doi="10.1/off", full_text_path=_write_fulltext(),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(paper_enrich.Paper, paper_id)
+        assert paper.embedding is not None  # 论文级向量照常
+        assert await _n_chunks(session, paper_id) > 0  # 已分块
+        assert await _n_embedded(session, paper_id) == 0  # 开关关：块向量不补
+
+
+async def test_enrich_embeds_blocks_when_index_on(client, fake_redis):
+    """开关开：块行被嵌入。"""
+    user_id, headers = await _user(client, "on@example.com", index_on=True)
+    project_id, _ = await make_project_with_library(client, headers, name="enrich-on")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="On",
+            doi="10.1/on", full_text_path=_write_fulltext(),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        n = await _n_chunks(session, paper_id)
+        assert n > 0
+        assert await _n_embedded(session, paper_id) == n  # 全部块被嵌入
+
+
+async def test_enrich_does_not_reslice_existing_chunks(client, fake_redis):
+    """已有块的论文再 enrich 不重切（无块才切），保住已补的块向量。"""
+    user_id, headers = await _user(client, "keep@example.com", index_on=True)
+    project_id, _ = await make_project_with_library(client, headers, name="enrich-keep")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Keep",
+            doi="10.1/keep", full_text_path=_write_fulltext(),
+        )
+        await session.commit()
+        paper_id = paper.id
+        # 预置一个「手工块」并打上可辨识向量
+        session.add(PaperChunk(paper_id=paper_id, seq=0, text="手工块", embedding=[0.5] * 1024))
+        await session.commit()
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        chunks = (
+            (await session.execute(select(PaperChunk).where(PaperChunk.paper_id == paper_id)))
+            .scalars()
+            .all()
+        )
+        assert len(chunks) == 1  # 没被重切
+        assert chunks[0].text == "手工块"
+
+
+# ---- fetch_pdf：分块 + 论文级向量 + 块向量受开关 ----
+
+
+@respx.mock
+async def test_fetch_pdf_builds_paper_vector_and_gated_blocks(client, fake_redis):
+    """fetch_pdf 现在产出论文级向量 + 分块；块向量受开关（此处开关开→嵌）。"""
+    redis = fake_redis
+    set_clients(
+        arxiv=ArxivClient(redis=redis, min_interval=0),
+        openalex=OpenAlexClient(redis=redis, mailto="t@example.org"),
+    )
+    try:
+        respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(
+            return_value=httpx.Response(200, content=b"%PDF-1.4 not-a-real-pdf")
+        )
+        user_id, headers = await _user(client, "fetch@example.com", index_on=True)
+        project_id, _ = await make_project_with_library(client, headers, name="fetch")
+        # 预置全文（extract 抽不出也不影响；chunk 走已有 full_text_path）
+        async with get_sessionmaker()() as session:
+            paper = await add_paper(
+                session, project_id=uuid.UUID(project_id), title="Fetch",
+                arxiv_id="2406.22222", full_text_path=_write_fulltext(),
+            )
+            await session.commit()
+            paper_id = paper.id
+
+        from app.services.papers import fetch_pdf
+
+        async with get_sessionmaker()() as session:
+            paper = await session.get(paper_enrich.Paper, paper_id)
+            await fetch_pdf(session, paper, user_id=user_id, project_id=None)
+
+        async with get_sessionmaker()() as session:
+            paper = await session.get(paper_enrich.Paper, paper_id)
+            assert paper.pdf_path  # 下载落盘
+            assert paper.embedding is not None  # 新增：论文级向量
+            n = await _n_chunks(session, paper_id)
+            assert n > 0
+            assert await _n_embedded(session, paper_id) == n  # 开关开→块被嵌
+    finally:
+        reset_clients()

--- a/src/frontend/src/features/chat/BuildIndexButton.tsx
+++ b/src/frontend/src/features/chat/BuildIndexButton.tsx
@@ -10,19 +10,37 @@ import { toast } from '../../components/ui/Toast';
    相关研究对话 / 个人文献库对话共用，只换 build 回调。
    ============================================================ */
 
-export function BuildIndexButton({ build }: { build: () => Promise<{ queued: number }> }) {
+/** 建索引端点返回：异步走 {queued, indexable, no_fulltext}，同步库场景走 {indexed, skipped}。 */
+type BuildIndexResult = {
+  queued?: number;
+  indexable?: number;
+  no_fulltext?: number;
+  indexed?: number;
+  skipped?: number;
+};
+
+function buildResultToast(data: BuildIndexResult): string {
+  // 兼容同步库场景（有 indexed）与异步场景（有 indexable/no_fulltext）
+  const indexable = data.indexed ?? data.indexable ?? 0;
+  const skipped = data.skipped ?? data.no_fulltext ?? 0;
+  if (skipped > 0) {
+    return tr(
+      `已排队 ${indexable} 篇建立全文索引，${skipped} 篇无全文已跳过（约需几分钟）`,
+      `Queued ${indexable} paper(s) for indexing; skipped ${skipped} without full text (takes a few minutes)`,
+    );
+  }
+  return tr(
+    `已排队 ${indexable} 篇建立全文索引，完成后对话检索会更准（约需几分钟）`,
+    `Queued ${indexable} paper(s) for full-text indexing — chat retrieval will improve once it finishes (takes a few minutes)`,
+  );
+}
+
+export function BuildIndexButton({ build }: { build: () => Promise<BuildIndexResult> }) {
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
 
   const mutation = useMutation({
     mutationFn: build,
-    onSuccess: () =>
-      toast(
-        tr(
-          '已开始建立全文索引，完成后对话检索会更准（约需几分钟）',
-          'Building the full-text index — chat retrieval will improve once it finishes (takes a few minutes)',
-        ),
-        'ok',
-      ),
+    onSuccess: (data) => toast(buildResultToast(data), 'ok'),
     onError: (e) => {
       if (e instanceof ApiError && e.status === 409) {
         toast(tr('请先到设置里打开「为论文建立全文索引」', 'Enable the full-text index in Settings first'), 'error');

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -971,6 +971,13 @@ export interface RebuildIndexResult {
   total_chunks: number;
 }
 
+/** 异步建索引端点（相关研究 / 个人库）的返回：入队总数 + 有全文可索引 / 无全文跳过 篇数。 */
+export interface QueuedIndexResult {
+  queued: number;
+  indexable: number;
+  no_fulltext: number;
+}
+
 // ============================================================
 // 知识图谱（论文 / 作者 / 概念网络）
 // ============================================================
@@ -3137,12 +3144,12 @@ export const api = {
     return request<RebuildIndexResult>(`/projects/${projectId}/index/rebuild`, { method: 'POST' });
   },
   /** 可选全文索引：为本课题「相关研究」这批论文异步建全文索引（设置关时后端 409 INDEXING_DISABLED）。 */
-  buildShelfIndex(projectId: string): Promise<{ queued: number }> {
-    return requestJson<{ queued: number }>(`/projects/${projectId}/shelf/index/rebuild`, 'POST', {});
+  buildShelfIndex(projectId: string): Promise<QueuedIndexResult> {
+    return requestJson<QueuedIndexResult>(`/projects/${projectId}/shelf/index/rebuild`, 'POST', {});
   },
   /** 可选全文索引：为「我的收藏」这批个人文献异步建全文索引。 */
-  buildPersonalIndex(): Promise<{ queued: number }> {
-    return requestJson<{ queued: number }>('/library/index/rebuild', 'POST', {});
+  buildPersonalIndex(): Promise<QueuedIndexResult> {
+    return requestJson<QueuedIndexResult>('/library/index/rebuild', 'POST', {});
   },
 
   // —— M2 · Obsidian 导出（zip blob） ——


### PR DESCRIPTION
## What

Manual add, Daily-paper collect, and fetch-PDF now **all** produce full-text chunks and a paper-level embedding, so a newly added paper becomes chat-searchable without waiting for a full library ingest. Block (chunk) embeddings stay gated by the per-user `chat_fulltext_index` opt-in.

Previously these three paths were inconsistent: manual add / collect did the paper-level embed but never chunked; fetch-PDF chunked but never produced the paper-level embed. So added papers were stuck at "has full text, no chunks" and the chat's full-text retrieval missed them.

## Changes

**Feature 1 — unify the add paths**
- `enrich_paper` (manual add + Daily collect): after extract, chunk the paper — **only when it has no chunks yet**, so existing vectors are never dropped. After the paper-level embed, embed its chunks **only if the user enabled the full-text index**. Off = chunk rows persist with null embeddings, to be filled later by a rebuild / re-run once enabled.
- `fetch_pdf`: add the missing paper-level embed, and the same gated chunk-embed; the existing chunking is kept behind the same no-op guard.
- New helpers in `chunks.py`: `paper_has_chunks(...)`, `user_wants_fulltext_index(...)`.

**Feature 2 — honest index-build feedback**
- The async shelf / personal `index/rebuild` endpoints now return `{queued, indexable, no_fulltext}` (a single synchronous count of how many target papers have full text vs not). The chat **Build full-text index** button reports it truthfully, e.g. "queued N papers, skipped M with no full text", instead of a vague "started". The sync direction-library rebuild keeps its `{indexed, embedded, skipped}` shape.

## Tests

New `test_enrich_chunk_index.py` (chunks-but-no-block-vectors when off; embeds blocks when on; never re-slices existing chunks; fetch_pdf now yields `paper.embedding` + chunks + gated block vectors) and a shelf-rebuild count test. Ingest chunking/embedding untouched (`test_wiki_ingest.py` green). **50 passed; ruff clean; tsc 0 errors.**

Stacked on #83 (already merged); rebased onto main.