### PR TITLE
feat(library): multi-select + export citations for direction libraries

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -68,6 +68,7 @@ from app.schemas.paper import (
     TagRead,
 )
 from app.schemas.voyage import VoyageRead
+from app.services import citations as citations_service
 from app.services import concepts as concepts_service
 from app.services import graph as graph_service
 from app.services import ingest as ingest_service
@@ -673,6 +674,49 @@ async def search_library(
         for p, s in paper_rows
     ]
     return SearchResponse(papers=papers, concepts=concepts, mode_used=mode_used, reranked=reranked)
+
+
+@router.get("/libraries/{library_id}/export/citations")
+async def export_library_citations(
+    library_id: uuid.UUID,
+    format_: str = Query(default="bibtex", alias="format", pattern="^(bibtex|csl-json)$"),
+    ids: str | None = Query(default=None, description="逗号分隔的论文 id（多选导出）"),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """库作用域引用导出：BibTeX / CSL-JSON（独立方向库也可用；读端点全实验室可读）。
+
+    不传 ids 导出全库在库论文（缺省 status in compiled/included）；ids 指定时按 id
+    精确导出（多选导出），非成员/垃圾桶（excluded）不含。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    paper_ids: list[uuid.UUID] | None = None
+    if ids:
+        try:
+            paper_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="INVALID_IDS") from e
+    papers = await citations_service.papers_for_library_export(
+        session,
+        library_id=library.id,
+        user_id=user.id,
+        paper_ids=paper_ids,
+    )
+    if format_ == "bibtex":
+        return Response(
+            content=citations_service.build_bibtex(papers),
+            media_type="text/plain; charset=utf-8",
+            headers={
+                "Content-Disposition": 'attachment; filename="polaris-library-citations.bib"'
+            },
+        )
+    return Response(
+        content=json.dumps(citations_service.build_csl_json(papers), ensure_ascii=False, indent=2),
+        media_type="application/json",
+        headers={
+            "Content-Disposition": 'attachment; filename="polaris-library-citations.json"'
+        },
+    )
 
 
 # ---- P9d 库级论文管理 / ingest 状态 / 图谱 / 对话 / 笔记（库工作台，含独立库） ----

--- a/src/backend/app/services/citations.py
+++ b/src/backend/app/services/citations.py
@@ -224,3 +224,34 @@ async def papers_for_export(
     deduped = dedupe_member_rows((await session.execute(stmt)).all())
     deduped.sort(key=lambda pm: (pm[0].year is None, pm[0].year or 0, pm[1].created_at))
     return [paper for paper, _ in deduped]
+
+
+async def papers_for_library_export(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    user_id: uuid.UUID,
+    status: str | None = None,
+    paper_ids: list[uuid.UUID] | None = None,
+) -> Sequence[Paper]:
+    """库作用域导出对象：某方向库的在库成员论文（独立方向库也可用）。
+
+    缺省 status in (compiled, included)；paper_ids 指定时按 id 精确导出（多选导出），
+    仍排除该库垃圾桶（excluded）与非成员。单库无需跨库归并（每篇至多一行）。
+    """
+    library_ids = [library_id]
+    stmt = apply_paper_filters(
+        member_papers_stmt(library_ids),
+        library_ids=library_ids,
+        status=status,
+        user_id=user_id,
+    )
+    if paper_ids:
+        stmt = stmt.where(Paper.id.in_(paper_ids))
+        if not status:
+            stmt = stmt.where(LibraryPaper.status != "excluded")
+    elif not status:
+        stmt = stmt.where(LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES))
+    stmt = stmt.order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
+    rows = (await session.execute(stmt)).all()
+    return [paper for paper, _ in rows]

--- a/src/backend/tests/test_library_citations_export.py
+++ b/src/backend/tests/test_library_citations_export.py
@@ -1,0 +1,160 @@
+"""库作用域引用导出（GET /libraries/{id}/export/citations，独立方向库也可用）。
+
+覆盖：全库缺省导出（compiled/included）、按 ids 精确导出、excluded 垃圾桶与非成员不含、
+attachment header 与文件名、非法 format→422。
+"""
+
+import json
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _create_active_standalone(client, creator_headers, admin_headers):
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "引用导出库", "statement": "LLM agent 规划方向"},
+        headers=creator_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+    assert resp.json()["project_id"] is None
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    return lib_id
+
+
+async def _seed_member(lib_id, *, title, status, authors, year, venue=None, arxiv_id=None):
+    async with get_sessionmaker()() as session:
+        paper = Paper(
+            title=title,
+            authors=authors,
+            year=year,
+            venue=venue,
+            arxiv_id=arxiv_id,
+            source="arxiv",
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            LibraryPaper(
+                library_id=uuid.UUID(str(lib_id)),
+                paper_id=paper.id,
+                status=status,
+            )
+        )
+        await session.commit()
+        return str(paper.id)
+
+
+async def _setup(client, prefix):
+    admin = await _hdr(client, f"{prefix}-admin@example.com")
+    await _promote_admin(f"{prefix}-admin@example.com")
+    creator = await _hdr(client, f"{prefix}-owner@example.com")
+    lib_id = await _create_active_standalone(client, creator, admin)
+    p_conf = await _seed_member(
+        lib_id,
+        title="The Great Agent Benchmark",
+        status="included",
+        authors=[{"name": "Alice Smith"}],
+        year=2024,
+        venue="Proceedings of NeurIPS",
+    )
+    p_arxiv = await _seed_member(
+        lib_id,
+        title="Quantum Annealing Survey",
+        status="compiled",
+        authors=[{"name": "张三"}],
+        year=2025,
+        arxiv_id="2501.00042",
+    )
+    p_excluded = await _seed_member(
+        lib_id,
+        title="Excluded Paper",
+        status="excluded",
+        authors=[{"name": "Nobody"}],
+        year=2020,
+    )
+    return creator, lib_id, p_conf, p_arxiv, p_excluded
+
+
+async def test_library_bibtex_export_default_and_attachment(client):
+    creator, lib_id, _p_conf, _p_arxiv, _p_excluded = await _setup(client, "libcite-bib")
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=bibtex", headers=creator
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/plain")
+    disp = resp.headers["content-disposition"]
+    assert "attachment" in disp and "polaris-library-citations.bib" in disp
+    bib = resp.text
+    # 缺省导出在库成员（compiled/included），垃圾桶不含
+    assert "@inproceedings{smith2024great,\n" in bib
+    assert "@misc{张三2025quantum,\n" in bib
+    assert "booktitle = {Proceedings of NeurIPS}," in bib
+    assert "eprint = {2501.00042}," in bib
+    assert "Excluded Paper" not in bib
+
+
+async def test_library_export_ids_and_excluded_and_nonmember(client):
+    creator, lib_id, p_conf, _p_arxiv, p_excluded = await _setup(client, "libcite-ids")
+
+    # 按 ids 精确导出：只含选中那篇
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=bibtex&ids={p_conf}",
+        headers=creator,
+    )
+    assert resp.status_code == 200, resp.text
+    assert "The Great Agent Benchmark" in resp.text
+    assert "Quantum Annealing Survey" not in resp.text
+
+    # ids 命中 excluded（垃圾桶）成员 → 不含
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=bibtex&ids={p_excluded}",
+        headers=creator,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.text.strip() == ""
+
+    # ids 命中非成员论文（别的库/内容池）→ 不含
+    stranger_id = str(uuid.uuid4())
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=csl-json&ids={stranger_id}",
+        headers=creator,
+    )
+    assert resp.status_code == 200, resp.text
+    assert json.loads(resp.text) == []
+
+
+async def test_library_csl_json_and_invalid_format(client):
+    creator, lib_id, _p_conf, _p_arxiv, _p_excluded = await _setup(client, "libcite-csl")
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=csl-json", headers=creator
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("application/json")
+    assert "polaris-library-citations.json" in resp.headers["content-disposition"]
+    titles = {item["title"] for item in json.loads(resp.text)}
+    assert titles == {"The Great Agent Benchmark", "Quantum Annealing Survey"}
+
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/export/citations?format=ris", headers=creator
+    )
+    assert resp.status_code == 422

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
@@ -21,6 +21,7 @@ import {
   SearchInput,
   YearRangeField,
   parseYear,
+  saveBlob,
   useDebounced,
 } from '../wiki/shared';
 import { READING_STATUS, readerFrom } from '../reading/shared';
@@ -47,7 +48,21 @@ function authorsLine(p: PaperRead): string {
     .join(', ');
 }
 
-function PaperRow({ p, active, onClick }: { p: PaperRead; active: boolean; onClick: () => void }) {
+function PaperRow({
+  p,
+  active,
+  checked,
+  selectMode,
+  onClick,
+  onToggleCheck,
+}: {
+  p: PaperRead;
+  active: boolean;
+  checked: boolean;
+  selectMode: boolean;
+  onClick: () => void;
+  onToggleCheck: () => void;
+}) {
   return (
     <div
       onClick={onClick}
@@ -61,6 +76,23 @@ function PaperRow({ p, active, onClick }: { p: PaperRead; active: boolean; onCli
       }}
     >
       <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+        {/* 占位常驻：切换多选时行内容不左右跳 */}
+        <input
+          type="checkbox"
+          checked={checked}
+          onClick={(e) => e.stopPropagation()}
+          onChange={onToggleCheck}
+          title={tr('选中后可批量导出引用', 'Select for bulk citation export')}
+          style={{
+            width: 13,
+            height: 13,
+            margin: '2px 0 0',
+            flexShrink: 0,
+            accentColor: 'var(--accent)',
+            cursor: 'pointer',
+            visibility: selectMode ? 'visible' : 'hidden',
+          }}
+        />
         <div style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
         <AddToButton paperId={p.id} />
       </div>
@@ -198,6 +230,24 @@ function PapersPane({
   const [scope, setScope] = useState<SearchScope>('keyword');
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [page, setPage] = useState(1);
+
+  // 多选（批量导出引用）：默认关闭，底部「多选」按钮开启后行首出现复选框（只读浏览不加删除）
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    setSelected(new Set());
+    setSelectMode(false);
+  }, [libraryId, q]);
+
+  const bulkExportMutation = useMutation({
+    mutationFn: () => api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] }),
+    onSuccess: (blob) => {
+      saveBlob(blob, 'polaris-library-citations.bib');
+      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+    },
+    onError: (e) =>
+      toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
 
   // —— 高级检索（作者 / 机构 / 年份区间 / 阅读状态 / 星标） ——
   const [advOpen, setAdvOpen] = useState(false);
@@ -384,7 +434,22 @@ function PapersPane({
             />
           ) : (
             items.map((p) => (
-              <PaperRow key={p.id} p={p} active={p.id === selectedId} onClick={() => onSelect(p.id)} />
+              <PaperRow
+                key={p.id}
+                p={p}
+                active={p.id === selectedId}
+                checked={selected.has(p.id)}
+                selectMode={selectMode}
+                onClick={() => onSelect(p.id)}
+                onToggleCheck={() =>
+                  setSelected((old) => {
+                    const next = new Set(old);
+                    if (next.has(p.id)) next.delete(p.id);
+                    else next.add(p.id);
+                    return next;
+                  })
+                }
+              />
             ))
           )}
         </div>
@@ -402,6 +467,34 @@ function PapersPane({
             </button>
           </div>
         )}
+
+        {/* —— 底部固定操作栏：多选 + 导出引用（只读浏览不含删除） —— */}
+        <div
+          className="row gap8"
+          style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
+        >
+          <button
+            className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
+            title={tr('开启后列表出现复选框，可批量导出引用', 'Show checkboxes for bulk citation export')}
+            onClick={() => {
+              setSelectMode((m) => !m);
+              setSelected(new Set());
+            }}
+          >
+            <Icon name="check" size={13} />
+            {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
+          </button>
+          {selectMode && (
+            <button
+              className="btn btn-ghost sm"
+              disabled={selected.size === 0 || bulkExportMutation.isPending}
+              onClick={() => bulkExportMutation.mutate()}
+            >
+              <Icon name="download" size={12} />
+              {tr('导出 BibTeX', 'Export BibTeX')}
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="split-detail">

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -1480,7 +1480,10 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   });
 
   const bulkExportMutation = useMutation({
-    mutationFn: () => api.downloadCitations(pid ?? '', { format: 'bibtex', ids: [...selected] }),
+    mutationFn: () =>
+      libraryId
+        ? api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] })
+        : api.downloadCitations(pid ?? '', { format: 'bibtex', ids: [...selected] }),
     onSuccess: (blob) => {
       saveBlob(blob, 'polaris-selected.bib');
       toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
@@ -1852,16 +1855,14 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                 <Icon name="x" size={12} />
                 {tr('删除', 'Delete')}
               </button>
-              {!libraryId && (
-                <button
-                  className="btn btn-ghost sm"
-                  disabled={selected.size === 0 || bulkExportMutation.isPending}
-                  onClick={() => bulkExportMutation.mutate()}
-                >
-                  <Icon name="download" size={12} />
-                  {tr('导出 BibTeX', 'Export BibTeX')}
-                </button>
-              )}
+              <button
+                className="btn btn-ghost sm"
+                disabled={selected.size === 0 || bulkExportMutation.isPending}
+                onClick={() => bulkExportMutation.mutate()}
+              >
+                <Icon name="download" size={12} />
+                {tr('导出 BibTeX', 'Export BibTeX')}
+              </button>
             </>
           )}
         </div>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2793,6 +2793,15 @@ export const api = {
     if (opts.ids?.length) params.set('ids', opts.ids.join(','));
     return requestBlob(`/projects/${projectId}/export/citations?${params.toString()}`);
   },
+  /** 库作用域引用导出（独立方向库也可用）：不传 ids 导出全库，传 ids 精确导出多选。 */
+  downloadLibraryCitations(
+    libraryId: string,
+    opts: { format: CitationFormat; ids?: string[] },
+  ): Promise<Blob> {
+    const params = new URLSearchParams({ format: opts.format });
+    if (opts.ids?.length) params.set('ids', opts.ids.join(','));
+    return requestBlob(`/libraries/${libraryId}/export/citations?${params.toString()}`);
+  },
 
   // —— M2 · Concepts ——
   listConcepts(


### PR DESCRIPTION
## What

`downloadCitations` is project-scoped only, so a standalone direction library couldn't export citations, and the read-only browse had no multi-select at all. This adds a library-scoped export path and brings multi-select + export to the library views.

- **Backend**: `GET /libraries/{id}/export/citations` (visible-library read auth) backed by `citations.papers_for_library_export`, reusing the existing `build_bibtex` / `build_csl_json` / `assign_citation_keys`. Honors an `ids` subset and excludes trashed / non-member papers.
- **Frontend**: `api.downloadLibraryCitations`; `LibraryBrowse` (read-only) gains the `PapersTab`-style multi-select + **Export BibTeX** (no delete, since it's read-only); `PapersTab`'s export button is now enabled for the library case too.

## Tests

New `test_library_citations_export.py` (default export + attachment header; `ids` subset excludes trashed/non-member; csl-json + invalid-format 422) — 6 passed; `tsc` + build clean. The one broader-suite failure (`ingest/state` forbidden assertion) reproduces on clean main and is unrelated.