### PR TITLE
feat(library): semantic search + multi-select export for the personal library

### DIFF
--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -1,12 +1,15 @@
 """个人文献库路由（issue #108）：/me/library，用户级、方向无关。"""
 
+import json
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
+from app.core.llm.router import get_llm_router
 from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.library import (
@@ -18,6 +21,7 @@ from app.schemas.library import (
     LibraryStateRead,
     LibraryVisitCreate,
 )
+from app.services import citations as citations_service
 from app.services import papers as papers_service
 from app.services import user_library as library_service
 
@@ -45,6 +49,7 @@ async def _get_own_entry(session: AsyncSession, entry_id: uuid.UUID, user: User)
 async def list_library(
     tab: str = Query(default="history", pattern="^(saved|history)$"),
     q: str | None = Query(default=None),
+    mode: str = Query(default="keyword", pattern="^(keyword|semantic)$"),
     sort: str = Query(default="recent", pattern="^(recent|title|visits|year)$"),
     year_from: int | None = Query(default=None),
     year_to: int | None = Query(default=None),
@@ -55,6 +60,32 @@ async def list_library(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> LibraryPage:
+    # 语义检索：仅「我的收藏」tab 有意义（浏览记录不做语义），候选=本人收藏且有向量的论文。
+    # embed/rerank 记个人账（无课题上下文）；非 postgres / provider 不支持 → 回退关键词。
+    if mode == "semantic" and tab == "saved" and q and papers_service.semantic_search_supported(
+        session
+    ):
+        try:
+            vectors = await get_llm_router().embed([q], user_id=user.id)
+            candidates = await library_service.semantic_saved_entries(
+                session,
+                user_id=user.id,
+                query_vector=vectors[0],
+                limit=max(papers_service.RERANK_CANDIDATES, size),
+            )
+            ranked, _reranked = await papers_service.rerank_paper_rows(
+                get_llm_router(), query=q, rows=candidates, limit=size, user_id=user.id
+            )
+            entries = [entry for entry, _ in ranked]
+            return LibraryPage(
+                items=[LibraryEntryRead.model_validate(e) for e in entries],
+                total=len(entries),
+                page=1,
+                size=size,
+                mode_used="semantic",
+            )
+        except NotImplementedError:
+            pass  # embedding 路由的 provider 不支持 → 回退关键词
     items, total = await library_service.list_entries(
         session,
         user_id=user.id,
@@ -73,6 +104,7 @@ async def list_library(
         total=total,
         page=page,
         size=size,
+        mode_used="keyword",
     )
 
 
@@ -111,6 +143,44 @@ async def library_state(
     paper = await _get_member_paper(session, paper_id, user)
     entry = await library_service.entry_for_paper(session, user_id=user.id, paper=paper)
     return LibraryStateRead(entry_id=entry.id if entry else None, saved=bool(entry and entry.saved))
+
+
+@router.get("/me/library/export/citations")
+async def export_personal_citations(
+    format_: str = Query(default="bibtex", alias="format", pattern="^(bibtex|csl-json)$"),
+    ids: str | None = Query(default=None, description="逗号分隔的论文 id（多选导出）"),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """个人库引用导出：BibTeX / CSL-JSON。
+
+    不传 ids 导出全部收藏；ids 指定时按 id 精确导出（多选导出），只含属于本人收藏的论文，
+    非本人 / 非收藏 / 源方向已删除（无软引用）的一律不含。
+    """
+    paper_ids: list[uuid.UUID] | None = None
+    if ids:
+        try:
+            paper_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="INVALID_IDS") from e
+    papers = await citations_service.papers_for_personal_export(
+        session, user_id=user.id, paper_ids=paper_ids
+    )
+    if format_ == "bibtex":
+        return Response(
+            content=citations_service.build_bibtex(papers),
+            media_type="text/plain; charset=utf-8",
+            headers={
+                "Content-Disposition": 'attachment; filename="polaris-my-library-citations.bib"'
+            },
+        )
+    return Response(
+        content=json.dumps(citations_service.build_csl_json(papers), ensure_ascii=False, indent=2),
+        media_type="application/json",
+        headers={
+            "Content-Disposition": 'attachment; filename="polaris-my-library-citations.json"'
+        },
+    )
 
 
 @router.post("/me/library", response_model=LibraryEntryRead, status_code=status.HTTP_201_CREATED)

--- a/src/backend/app/schemas/library.py
+++ b/src/backend/app/schemas/library.py
@@ -45,6 +45,9 @@ class LibraryPage(BaseModel):
     total: int
     page: int
     size: int
+    # 语义检索不支持时（非 postgres / embedding provider 不支持）后端回退关键词，
+    # 在此说明实际使用的模式，供前端提示用户
+    mode_used: str = "keyword"
 
 
 class LibraryVisitCreate(BaseModel):

--- a/src/backend/app/services/citations.py
+++ b/src/backend/app/services/citations.py
@@ -9,8 +9,10 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.library import UserLibraryEntry
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.services.libraries import (
@@ -255,3 +257,32 @@ async def papers_for_library_export(
     stmt = stmt.order_by(Paper.year.asc().nulls_last(), LibraryPaper.created_at.asc())
     rows = (await session.execute(stmt)).all()
     return [paper for paper, _ in rows]
+
+
+async def papers_for_personal_export(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    paper_ids: list[uuid.UUID] | None = None,
+) -> Sequence[Paper]:
+    """个人库导出对象：本人收藏条目软引用的活体论文（源方向已删除的条目无 Paper，不含）。
+
+    paper_ids 指定时按 id 精确导出（多选导出），且必须属于本人 saved 条目——
+    传入的非本人/非收藏论文一律忽略。按年份升序。
+    """
+    allowed = select(UserLibraryEntry.last_paper_id).where(
+        UserLibraryEntry.user_id == user_id,
+        UserLibraryEntry.saved.is_(True),
+        UserLibraryEntry.last_paper_id.is_not(None),
+    )
+    if paper_ids:
+        allowed = allowed.where(UserLibraryEntry.last_paper_id.in_(paper_ids))
+    allowed_ids = [pid for pid in (await session.execute(allowed)).scalars().all() if pid]
+    if not allowed_ids:
+        return []
+    stmt = (
+        select(Paper)
+        .where(Paper.id.in_(allowed_ids))
+        .order_by(Paper.year.asc().nulls_last(), Paper.title.asc())
+    )
+    return list((await session.execute(stmt)).scalars().all())

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -1,11 +1,12 @@
 """个人文献库：浏览记录 upsert、收藏、列表检索（用户级，方向无关）。"""
 
+import json
 import uuid
 from typing import cast
 
 from sqlalchemy import Text as SAText
 from sqlalchemy import cast as sa_cast
-from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import utcnow
@@ -160,6 +161,46 @@ async def personal_paper_ids(
     recency = func.coalesce(UserLibraryEntry.saved_at, UserLibraryEntry.created_at)
     stmt = stmt.order_by(recency.desc())
     return list((await session.execute(stmt)).scalars().all())
+
+
+async def semantic_saved_entries(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    query_vector: list[float],
+    limit: int,
+) -> list[tuple[UserLibraryEntry, float]]:
+    """对本人收藏、且软引用论文有向量的条目跑 pgvector 余弦，返回 (条目, 相似度) 降序。
+
+    候选集 = saved 且 last_paper_id 非空的条目里，其 Paper.embedding 非空的那些
+    （覆盖不全的已知限制：没生成向量的收藏不会命中）。仅 postgres，调用方需先判
+    semantic_search_supported。条目自身带 title/authors 快照，命中即可直接渲染成个人库行。
+    """
+    stmt = select(UserLibraryEntry).where(
+        UserLibraryEntry.user_id == user_id,
+        UserLibraryEntry.saved.is_(True),
+        UserLibraryEntry.last_paper_id.is_not(None),
+    )
+    entries = list((await session.execute(stmt)).scalars().all())
+    by_pid: dict[uuid.UUID, UserLibraryEntry] = {
+        e.last_paper_id: e for e in entries if e.last_paper_id is not None
+    }
+    if not by_pid:
+        return []
+    qv = json.dumps(query_vector)
+    rows = (
+        await session.execute(
+            text(
+                "SELECT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM papers p "
+                "WHERE p.id = ANY(CAST(:ids AS uuid[])) AND p.embedding IS NOT NULL "
+                "ORDER BY score DESC "
+                "LIMIT :k"
+            ),
+            {"qv": qv, "ids": [str(pid) for pid in by_pid], "k": limit},
+        )
+    ).all()
+    return [(by_pid[row.id], float(row.score)) for row in rows if row.id in by_pid]
 
 
 async def purge_entry(session: AsyncSession, *, entry: UserLibraryEntry) -> None:

--- a/src/backend/tests/test_personal_library_export.py
+++ b/src/backend/tests/test_personal_library_export.py
@@ -1,0 +1,158 @@
+"""个人库引用导出（GET /me/library/export/citations）+ 语义检索回退。
+
+覆盖：全部收藏导出、ids 子集导出、非本人 / 非收藏 / 浏览记录不含、csl-json、非法 format→422、
+非 postgres（sqlite）下 mode=semantic 回退 keyword。
+"""
+
+import json
+import uuid
+
+from app.core.db import get_sessionmaker
+from tests.conftest import add_paper, register_and_login
+
+
+async def _make_project(client, headers, name="pexport-proj"):
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    return resp.json()["id"]
+
+
+async def _make_paper(project_id: str, **kwargs) -> str:
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), **kwargs)
+        session.add(paper)
+        await session.commit()
+        return str(paper.id)
+
+
+async def _save(client, headers, paper_id: str) -> None:
+    resp = await client.post("/api/me/library", json={"paper_id": paper_id}, headers=headers)
+    assert resp.status_code == 201, resp.text
+
+
+async def test_personal_export_all_saved(client):
+    token = await register_and_login(client, email="pexport-all@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers)
+    p_conf = await _make_paper(
+        project_id,
+        title="The Great Agent Benchmark",
+        authors=[{"name": "Alice Smith"}],
+        year=2024,
+        venue="Proceedings of NeurIPS",
+        status="included",
+    )
+    p_arxiv = await _make_paper(
+        project_id,
+        title="Quantum Annealing Survey",
+        authors=[{"name": "张三"}],
+        year=2025,
+        arxiv_id="2501.00042",
+        status="included",
+    )
+    # 只浏览未收藏的一篇：不应出现在导出里
+    p_history = await _make_paper(project_id, title="Only Browsed", year=2020, status="included")
+    await client.post("/api/me/library/visits", json={"paper_id": p_history}, headers=headers)
+
+    await _save(client, headers, p_conf)
+    await _save(client, headers, p_arxiv)
+
+    resp = await client.get("/api/me/library/export/citations?format=bibtex", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/plain")
+    disp = resp.headers["content-disposition"]
+    assert "attachment" in disp and "polaris-my-library-citations.bib" in disp
+    bib = resp.text
+    assert "@inproceedings{smith2024great,\n" in bib
+    assert "eprint = {2501.00042}," in bib
+    assert "Only Browsed" not in bib  # 浏览记录（未收藏）不含
+
+
+async def test_personal_export_ids_subset(client):
+    token = await register_and_login(client, email="pexport-ids@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers)
+    p1 = await _make_paper(project_id, title="First Saved", year=2022, status="included")
+    p2 = await _make_paper(project_id, title="Second Saved", year=2023, status="included")
+    await _save(client, headers, p1)
+    await _save(client, headers, p2)
+
+    resp = await client.get(
+        f"/api/me/library/export/citations?format=bibtex&ids={p1}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert "First Saved" in resp.text
+    assert "Second Saved" not in resp.text
+
+
+async def test_personal_export_excludes_other_users_and_unsaved(client):
+    token = await register_and_login(client, email="pexport-owner@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers)
+    mine = await _make_paper(project_id, title="Mine Saved", year=2021, status="included")
+    unsaved = await _make_paper(project_id, title="Mine Unsaved", year=2021, status="included")
+    await _save(client, headers, mine)
+    # unsaved 仅浏览不收藏
+    await client.post("/api/me/library/visits", json={"paper_id": unsaved}, headers=headers)
+
+    # 传入本人未收藏的论文 id → 不含
+    resp = await client.get(
+        f"/api/me/library/export/citations?format=csl-json&ids={unsaved}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert json.loads(resp.text) == []
+
+    # 传入别人的论文 id（陌生 uuid）→ 不含
+    stranger = str(uuid.uuid4())
+    resp = await client.get(
+        f"/api/me/library/export/citations?format=csl-json&ids={stranger}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert json.loads(resp.text) == []
+
+    # 另一个用户的个人库导出看不到本人收藏
+    other = await register_and_login(client, email="pexport-other@example.com")
+    other_headers = {"Authorization": f"Bearer {other}"}
+    resp = await client.get(
+        "/api/me/library/export/citations?format=bibtex", headers=other_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert "Mine Saved" not in resp.text
+
+
+async def test_personal_export_csl_and_invalid_format(client):
+    token = await register_and_login(client, email="pexport-csl@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers)
+    p1 = await _make_paper(project_id, title="CSL Paper", year=2024, status="included")
+    await _save(client, headers, p1)
+
+    resp = await client.get("/api/me/library/export/citations?format=csl-json", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("application/json")
+    assert "polaris-my-library-citations.json" in resp.headers["content-disposition"]
+    titles = {item["title"] for item in json.loads(resp.text)}
+    assert titles == {"CSL Paper"}
+
+    resp = await client.get("/api/me/library/export/citations?format=ris", headers=headers)
+    assert resp.status_code == 422
+
+
+async def test_semantic_falls_back_to_keyword_on_sqlite(client):
+    """sqlite 不支持 pgvector → mode=semantic 回退 keyword，仍走关键词过滤。"""
+    token = await register_and_login(client, email="pexport-sem@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers)
+    p1 = await _make_paper(
+        project_id, title="Attention Is All You Need", year=2017, status="included"
+    )
+    p2 = await _make_paper(project_id, title="Deep Residual Learning", year=2015, status="included")
+    await _save(client, headers, p1)
+    await _save(client, headers, p2)
+
+    resp = await client.get(
+        "/api/me/library?tab=saved&mode=semantic&q=attention", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["mode_used"] == "keyword"  # 回退
+    assert [i["title"] for i in body["items"]] == ["Attention Is All You Need"]

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -6,7 +6,14 @@ import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
 import { toast } from '../../components/ui/Toast';
-import { api, type LibraryEntry, type LibrarySort, type LibraryTab, type Publication } from '../../lib/api';
+import {
+  api,
+  type LibraryEntry,
+  type LibrarySort,
+  type LibraryTab,
+  type Publication,
+  type SearchMode,
+} from '../../lib/api';
 import { fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import {
@@ -15,6 +22,7 @@ import {
   FilterInput,
   parseYear,
   SearchInput,
+  saveBlob,
   useDebounced,
   YearRangeField,
 } from '../wiki/shared';
@@ -34,6 +42,8 @@ import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPa
    ============================================================ */
 
 const PAGE_SIZE = 20;
+// 语义检索一次返回一组结果（不分页），上限比普通分页大些
+const SEMANTIC_SIZE = 50;
 
 /** 页面级 tab：库内两个 tab +「我赞过的」+「文献对话」+「我发表的」。 */
 type PageTab = LibraryTab | 'liked' | 'publications' | 'chat';
@@ -57,6 +67,9 @@ function EntryRow({
   tab,
   active,
   busy,
+  selectMode,
+  checked,
+  onToggleCheck,
   onSelect,
   onToggleSave,
   onPurge,
@@ -65,6 +78,9 @@ function EntryRow({
   tab: LibraryTab;
   active: boolean;
   busy: boolean;
+  selectMode: boolean;
+  checked: boolean;
+  onToggleCheck: () => void;
   onSelect: () => void;
   onToggleSave: () => void;
   onPurge: () => void;
@@ -94,6 +110,28 @@ function EntryRow({
         transition: 'background 0.12s',
       }}
     >
+      {/* 多选复选框：占位常驻（源方向已删除的条目无活体论文，不能导出引用 → 禁用） */}
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={entry.last_paper_id === null}
+        onClick={(e) => e.stopPropagation()}
+        onChange={onToggleCheck}
+        title={
+          entry.last_paper_id === null
+            ? tr('源方向已删除，无法导出引用', 'Source deleted — cannot export citation')
+            : tr('选中后可批量导出引用', 'Select for bulk citation export')
+        }
+        style={{
+          width: 13,
+          height: 13,
+          margin: '2px 0 0',
+          flexShrink: 0,
+          accentColor: 'var(--accent)',
+          cursor: entry.last_paper_id === null ? 'not-allowed' : 'pointer',
+          visibility: selectMode ? 'visible' : 'hidden',
+        }}
+      />
       <div style={{ flex: 1, minWidth: 0 }}>
         {/* 顶部 mono 元信息行：编号/venue + 年份 + 源方向状态；右侧浏览信息 */}
         <div className="row gap8" style={{ marginBottom: 5 }}>
@@ -203,9 +241,15 @@ export function LibraryPage() {
   const [tab, setTab] = useState<PageTab>('saved');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
+  const [scope, setScope] = useState<SearchMode>('keyword');
   const [sort, setSort] = useState<LibrarySort>('recent');
   const [page, setPage] = useState(1);
   const [clearOpen, setClearOpen] = useState(false);
+
+  // 多选（批量导出引用）：默认关闭，仅「我的收藏」可用；选中集合按论文 id 存
+  // （last_paper_id，跨页/跨搜索都能带着走；导出端点按论文 id 精确取本人收藏）
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   // 高级检索：年份区间 / 作者 / venue（走后端）
   const [advOpen, setAdvOpen] = useState(false);
@@ -230,25 +274,40 @@ export function LibraryPage() {
   // 「我发表的」：修改署名信息时整卡显示表单
   const [editingAuthor, setEditingAuthor] = useState(false);
 
-  // tab / 搜索词 / 排序 / 高级条件变化时回到第一页
+  // 语义检索：仅「我的收藏」+ 有关键词时生效（浏览记录是流水，不做语义）；
+  // 语义态不分页、高级过滤置灰（后端按向量相似度返回一组结果）
+  const semantic = tab === 'saved' && scope === 'semantic' && !!q;
+
+  // tab / 搜索词 / 检索模式 / 排序 / 高级条件变化时回到第一页
   useEffect(() => {
     setPage(1);
-  }, [tab, q, sort, author, venue, yearFrom, yearTo]);
+  }, [tab, q, scope, sort, author, venue, yearFrom, yearTo]);
+
+  // 切 tab / 换搜索词 / 换检索模式时清空多选（避免选中集跨上下文残留）
+  useEffect(() => {
+    setSelected(new Set());
+    setSelectMode(false);
+  }, [tab, q, scope]);
 
   const onLibraryTab = tab !== 'publications' && tab !== 'chat' && tab !== 'liked';
   const listQuery = useQuery({
-    queryKey: ['library', tab, q, sort, page, author.trim(), venue.trim(), yearFrom.trim(), yearTo.trim()],
+    queryKey: [
+      'library', tab, q, semantic, sort, page,
+      author.trim(), venue.trim(), yearFrom.trim(), yearTo.trim(),
+    ],
     queryFn: () =>
       api.listLibrary({
         tab: tab as LibraryTab,
         q: q || undefined,
+        mode: semantic ? 'semantic' : undefined,
         sort,
-        page,
-        size: PAGE_SIZE,
-        author: author.trim() || undefined,
-        venue: venue.trim() || undefined,
-        year_from: parseYear(yearFrom),
-        year_to: parseYear(yearTo),
+        page: semantic ? 1 : page,
+        size: semantic ? SEMANTIC_SIZE : PAGE_SIZE,
+        // 语义态不叠加高级过滤（后端语义分支忽略），关键词态照常带上
+        author: semantic ? undefined : author.trim() || undefined,
+        venue: semantic ? undefined : venue.trim() || undefined,
+        year_from: semantic ? undefined : parseYear(yearFrom),
+        year_to: semantic ? undefined : parseYear(yearTo),
       }),
     enabled: onLibraryTab,
     retry: false,
@@ -310,6 +369,15 @@ export function LibraryPage() {
       invalidate();
     },
     onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: () => api.downloadPersonalCitations({ format: 'bibtex', ids: [...selected] }),
+    onSuccess: (blob) => {
+      saveBlob(blob, 'polaris-my-library-citations.bib');
+      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+    },
+    onError: (e) => toast(`${tr('导出失败：', 'Export failed: ')}${errText(e)}`, 'error'),
   });
 
   const clearMutation = useMutation({
@@ -456,27 +524,48 @@ export function LibraryPage() {
                 </div>
 
                 {advOpen && (
-                  <AdvancedPanel onClear={advActive ? clearAdvanced : undefined}>
-                    <YearRangeField
-                      label={tr('年份', 'Year')}
-                      from={yearFrom}
-                      to={yearTo}
-                      onFrom={setYearFrom}
-                      onTo={setYearTo}
-                    />
-                    <div className="row gap8">
-                      <FilterInput
-                        value={author}
-                        onChange={setAuthor}
-                        placeholder={tr('作者姓名…', 'Author name…')}
+                  <div style={semantic ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
+                    <AdvancedPanel onClear={advActive ? clearAdvanced : undefined}>
+                      <YearRangeField
+                        label={tr('年份', 'Year')}
+                        from={yearFrom}
+                        to={yearTo}
+                        onFrom={setYearFrom}
+                        onTo={setYearTo}
                       />
-                      <FilterInput
-                        value={venue}
-                        onChange={setVenue}
-                        placeholder={tr('期刊 / 会议…', 'Venue…')}
-                      />
-                    </div>
-                  </AdvancedPanel>
+                      <div className="row gap8">
+                        <FilterInput
+                          value={author}
+                          onChange={setAuthor}
+                          placeholder={tr('作者姓名…', 'Author name…')}
+                        />
+                        <FilterInput
+                          value={venue}
+                          onChange={setVenue}
+                          placeholder={tr('期刊 / 会议…', 'Venue…')}
+                        />
+                      </div>
+                    </AdvancedPanel>
+                  </div>
+                )}
+
+                {/* 关键词 / 语义 检索模式切换（语义仅「我的收藏」有意义） */}
+                {tab === 'saved' && (
+                  <div className="row gap6 wrap" style={{ marginTop: 10 }}>
+                    <span
+                      className={`chip${scope === 'keyword' ? ' on' : ''}`}
+                      onClick={() => setScope('keyword')}
+                    >
+                      {tr('关键词', 'Keyword')}
+                    </span>
+                    <span
+                      className={`chip${scope === 'semantic' ? ' on' : ''}`}
+                      onClick={() => setScope('semantic')}
+                      title={tr('按语义相似度检索收藏（需已生成向量）', 'Semantic search over saved papers (needs embeddings)')}
+                    >
+                      {tr('语义检索', 'Semantic')}
+                    </span>
+                  </div>
                 )}
 
                 <div className="row gap8" style={{ marginTop: 10 }}>
@@ -485,20 +574,7 @@ export function LibraryPage() {
                     value={sort}
                     onChange={setSort}
                   />
-                  {tab === 'saved' && (
-                    <span
-                      className="mono"
-                      style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}
-                    >
-                      {data ? tr(`共 ${data.total} 条`, `${data.total} total`) : ''}
-                    </span>
-                  )}
-                </div>
-                {tab === 'history' && (
-                  <div className="row gap8" style={{ marginTop: 8, alignItems: 'center' }}>
-                    <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
-                      {data ? tr(`共 ${data.total} 条记录`, `Total: ${data.total} records`) : ''}
-                    </span>
+                  {tab === 'history' && (
                     <button
                       className="btn btn-ghost sm"
                       style={{ marginLeft: 'auto', height: 26, flexShrink: 0 }}
@@ -508,6 +584,24 @@ export function LibraryPage() {
                       <Icon name="trash" size={13} />
                       {tr('清空记录', 'Clear history')}
                     </button>
+                  )}
+                </div>
+
+                {/* 语义检索提示：回退关键词 / 覆盖范围说明 */}
+                {semantic && data?.mode_used === 'keyword' && (
+                  <div style={{ marginTop: 8, fontSize: 11, color: 'var(--warn-tx, var(--text-3))' }}>
+                    {tr(
+                      '当前环境暂不支持语义检索，已按关键词返回。',
+                      'Semantic search is unavailable here — showing keyword results.',
+                    )}
+                  </div>
+                )}
+                {semantic && data?.mode_used === 'semantic' && (
+                  <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-4)' }}>
+                    {tr(
+                      '语义检索只覆盖已生成向量的收藏论文，结果可能不全。',
+                      'Semantic search only covers saved papers with embeddings — results may be incomplete.',
+                    )}
                   </div>
                 )}
               </div>
@@ -561,6 +655,18 @@ export function LibraryPage() {
                       tab={tab}
                       active={entry.id === selEntry?.id}
                       busy={busy}
+                      selectMode={selectMode}
+                      checked={entry.last_paper_id !== null && selected.has(entry.last_paper_id)}
+                      onToggleCheck={() =>
+                        setSelected((old) => {
+                          const pid = entry.last_paper_id;
+                          if (pid === null) return old;
+                          const next = new Set(old);
+                          if (next.has(pid)) next.delete(pid);
+                          else next.add(pid);
+                          return next;
+                        })
+                      }
                       onSelect={() => setSelEntry(entry)}
                       onToggleSave={() => toggleMutation.mutate(entry)}
                       onPurge={() => purgeMutation.mutate(entry)}
@@ -569,8 +675,8 @@ export function LibraryPage() {
                 )}
               </div>
 
-              {/* 底部分页栏 */}
-              {data && data.total > PAGE_SIZE && (
+              {/* 底部分页栏（语义检索不分页） */}
+              {!semantic && data && data.total > PAGE_SIZE && (
                 <div
                   className="row gap12"
                   style={{
@@ -595,6 +701,36 @@ export function LibraryPage() {
                     {tr('下一页', 'Next')}
                     <Icon name="chevron" size={12} />
                   </button>
+                </div>
+              )}
+
+              {/* —— 底部操作栏：多选 + 导出引用（仅「我的收藏」；不含删除） —— */}
+              {tab === 'saved' && (
+                <div
+                  className="row gap8"
+                  style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
+                >
+                  <button
+                    className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
+                    title={tr('开启后列表出现复选框，可批量导出引用', 'Show checkboxes for bulk citation export')}
+                    onClick={() => {
+                      setSelectMode((m) => !m);
+                      setSelected(new Set());
+                    }}
+                  >
+                    <Icon name="check" size={13} />
+                    {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
+                  </button>
+                  {selectMode && (
+                    <button
+                      className="btn btn-ghost sm"
+                      disabled={selected.size === 0 || exportMutation.isPending}
+                      onClick={() => exportMutation.mutate()}
+                    >
+                      <Icon name="download" size={12} />
+                      {tr('导出 BibTeX', 'Export BibTeX')}
+                    </button>
+                  )}
                 </div>
               )}
             </div>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2217,6 +2217,9 @@ export interface LibraryState {
 /** 单条详情 = 列表条目字段 + wiki 快照正文（列表响应不含 wiki）。 */
 export type LibraryEntryDetail = LibraryEntry & { wiki_content: string | null };
 
+/** 个人库列表响应：分页条目 + 实际使用的检索模式（语义不支持时后端回退 keyword）。 */
+export type LibraryListResult = PageOf<LibraryEntry> & { mode_used: SearchMode };
+
 // ============================================================
 // 我发表的（作者信息绑定 + 发表同步）— issue #109
 // ============================================================
@@ -3830,6 +3833,8 @@ export const api = {
     opts: {
       tab: LibraryTab;
       q?: string;
+      /** 检索模式：semantic 仅「我的收藏」有意义；非 postgres/provider 不支持时后端回退 keyword。 */
+      mode?: SearchMode;
       sort?: LibrarySort;
       page?: number;
       size?: number;
@@ -3838,10 +3843,11 @@ export const api = {
       author?: string;
       venue?: string;
     },
-  ): Promise<PageOf<LibraryEntry>> {
+  ): Promise<LibraryListResult> {
     const params = new URLSearchParams();
     params.set('tab', opts.tab);
     if (opts.q) params.set('q', opts.q);
+    if (opts.mode) params.set('mode', opts.mode);
     if (opts.sort) params.set('sort', opts.sort);
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));
@@ -3849,7 +3855,13 @@ export const api = {
     if (opts.year_to != null) params.set('year_to', String(opts.year_to));
     if (opts.author) params.set('author', opts.author);
     if (opts.venue) params.set('venue', opts.venue);
-    return request<PageOf<LibraryEntry>>(`/me/library?${params.toString()}`);
+    return request<LibraryListResult>(`/me/library?${params.toString()}`);
+  },
+  /** 个人库引用导出：不传 ids 导出全部收藏，传 ids（论文 id）精确导出多选。 */
+  downloadPersonalCitations(opts: { format: CitationFormat; ids?: string[] }): Promise<Blob> {
+    const params = new URLSearchParams({ format: opts.format });
+    if (opts.ids?.length) params.set('ids', opts.ids.join(','));
+    return requestBlob(`/me/library/export/citations?${params.toString()}`);
   },
   /** 打开阅读页时上报一次浏览（自动建/更新浏览记录条目）。 */
   recordLibraryVisit(paperId: string): Promise<LibraryEntry> {


### PR DESCRIPTION
## What

Brings the personal library ("我的文献库") in line with the other surfaces.

- **Semantic search**: `GET /me/library` gains `mode=keyword|semantic`. Semantic ranks the caller's **saved** entries that have a paper-level vector (pgvector cosine + rerank) and reports `mode_used`, so the UI shows a fallback notice when semantic isn't available (non-postgres). A keyword / semantic chip toggle appears on the saved tab; advanced filters dim in semantic mode.
- **Multi-select + export**: `PapersTab`-style select mode with per-row checkboxes and an **Export BibTeX** action, backed by a new `GET /me/library/export/citations` (`citations.papers_for_personal_export`, reusing `build_bibtex` / `build_csl_json`), restricted to the caller's saved papers.
- **Removed the "共 X 条" counters** from both tabs.

## Notes

- Semantic coverage is inherently partial — it only includes saved papers that have a live pool link *and* an embedding — so the UI says so inline when semantic results are shown.
- Selection is keyed by **paper id** (`last_paper_id`), which is exactly what the export endpoint takes; entries whose source paper is gone are not selectable.

## Tests

New `test_personal_library_export.py` (own saved papers only; ids subset; history/other-user excluded; csl-json; invalid format 422; sqlite falls back to `mode_used=keyword`) — 11 passed with the library export suite. `tsc` + build clean.

Stacked on #91 (library-scoped export); merge that first.