### PR TITLE
feat(frontend): resolve API/WS endpoints through a runtime abstraction

### DIFF
--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1,4 +1,6 @@
 import { tr } from './i18n';
+import { apiBase } from './endpoint';
+import { readToken, writeToken } from './token-store';
 /* ============================================================
    Polaris API client — thin fetch wrapper.
    baseURL /api (proxied to FastAPI at :8000 in dev), JSON,
@@ -10,8 +12,8 @@ import { tr } from './i18n';
    M1 契约见 docs/api-m1.md（Projects / Voyages / Gates / Admin LLM）。
    ============================================================ */
 
-const BASE = '/api';
-const TOKEN_KEY = 'polaris.token';
+/* baseURL 与 token 后端都经抽象层解析：web 端 apiBase() === '/api'、token 走
+   localStorage，与改造前逐字等价；桌面端由 Electron 注入服务器地址。 */
 
 export class ApiError extends Error {
   constructor(
@@ -26,15 +28,11 @@ export class ApiError extends Error {
 }
 
 export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+  return readToken();
 }
 
 export function setToken(token: string | null): void {
-  if (token) {
-    localStorage.setItem(TOKEN_KEY, token);
-  } else {
-    localStorage.removeItem(TOKEN_KEY);
-  }
+  writeToken(token);
 }
 
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
@@ -43,7 +41,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  const res = await fetch(`${BASE}${path}`, { ...init, headers });
+  const res = await fetch(`${apiBase()}${path}`, { ...init, headers });
   if (res.status === 401 && token && !path.startsWith('/auth/')) {
     // 会话过期/失效：清 token 并跳登录（避免在登录/注册接口上误触发）
     setToken(null);
@@ -84,7 +82,7 @@ async function requestBlob(path: string): Promise<Blob> {
   const headers = new Headers();
   const token = getToken();
   if (token) headers.set('Authorization', `Bearer ${token}`);
-  const res = await fetch(`${BASE}${path}`, { headers });
+  const res = await fetch(`${apiBase()}${path}`, { headers });
   if (!res.ok) {
     let detail = res.statusText || `HTTP ${res.status}`;
     let body: unknown;
@@ -3568,7 +3566,7 @@ export const api = {
     const headers = new Headers();
     const token = getToken();
     if (token) headers.set('Authorization', `Bearer ${token}`);
-    const res = await fetch(`${BASE}/manuscripts/${id}/export/arxiv`, { headers });
+    const res = await fetch(`${apiBase()}/manuscripts/${id}/export/arxiv`, { headers });
     if (!res.ok) {
       let detail = res.statusText || `HTTP ${res.status}`;
       let body: unknown;

--- a/src/frontend/src/lib/endpoint.ts
+++ b/src/frontend/src/lib/endpoint.ts
@@ -1,0 +1,66 @@
+/* ============================================================
+   运行时端点解析 —— web 与桌面端的唯一分歧点。
+
+   web 端：window.__POLARIS__ 不存在，一切退化为同源相对路径，
+           行为与改造前逐字等价（apiBase() === '/api'）。
+   桌面端：Electron preload 在任何 renderer 脚本执行前同步注入
+           window.__POLARIS__，其中 serverUrl 是用户配置的服务器地址。
+
+   业务代码只 import 本文件，不直接读 window.__POLARIS__。
+   ============================================================ */
+
+/** Electron preload 注入的宿主运行时信息（web 端为 undefined）。 */
+export interface PolarisHostRuntime {
+  /** 用户配置的服务器地址，如 https://polaris.example.edu（可带尾斜杠，本模块会归一化）。 */
+  serverUrl: string;
+  platform: 'darwin' | 'win32' | 'linux';
+  appVersion: string;
+}
+
+declare global {
+  interface Window {
+    __POLARIS__?: PolarisHostRuntime;
+  }
+}
+
+function hostRuntime(): PolarisHostRuntime | undefined {
+  return typeof window === 'undefined' ? undefined : window.__POLARIS__;
+}
+
+/** 是否运行在桌面客户端里。 */
+export function isDesktop(): boolean {
+  return hostRuntime() != null;
+}
+
+/**
+ * 服务器 origin：web 端为 ''（同源，走相对路径），桌面端为配置的地址（已去尾斜杠）。
+ * 故意做成函数而非模块级常量：避免依赖「注入早于本模块求值」这一隐式时序。
+ */
+export function serverOrigin(): string {
+  return (hostRuntime()?.serverUrl ?? '').replace(/\/+$/, '');
+}
+
+/** REST / SSE 的基址。web 端返回 '/api'，与改造前的字面量完全一致。 */
+export function apiBase(): string {
+  return `${serverOrigin()}/api`;
+}
+
+/**
+ * WebSocket 完整 URL（path 需以 / 开头，可带 query）。
+ * web 端逐字保留改造前的 window.location 推导逻辑。
+ */
+export function wsUrl(path: string): string {
+  const origin = serverOrigin();
+  if (origin) return `${origin.replace(/^http/, 'ws')}${path}`;
+  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  return `${proto}://${window.location.host}${path}`;
+}
+
+/**
+ * 面向「别人也能打开」的链接：邀请/分享链接、给外部 MCP 客户端的服务端点。
+ * 收件人多数用浏览器打开，所以桌面端要指向服务器上的 web 门户，而不是 app:// 本地页面。
+ */
+export function portalUrl(path = ''): string {
+  const origin = serverOrigin() || (typeof window === 'undefined' ? '' : window.location.origin);
+  return `${origin}${path}`;
+}

--- a/src/frontend/src/lib/sse.ts
+++ b/src/frontend/src/lib/sse.ts
@@ -6,6 +6,7 @@
    ============================================================ */
 
 import { getToken, type TemplateDownloadProgress } from './api';
+import { apiBase } from './endpoint';
 
 export interface SseHandlers {
   /** 每收到一个完整事件调用（event 缺省为 "message"，data 为原始字符串）。 */
@@ -79,7 +80,7 @@ export function subscribeSse(path: string, handlers: SseHandlers): () => void {
         const headers: Record<string, string> = { Accept: 'text/event-stream' };
         const token = getToken();
         if (token) headers.Authorization = `Bearer ${token}`;
-        const res = await fetch(`/api${path}`, { headers, signal: ctrl.signal });
+        const res = await fetch(`${apiBase()}${path}`, { headers, signal: ctrl.signal });
         if (!res.ok) throw new Error(`SSE HTTP ${res.status}`);
         attempt = 0;
         handlers.onOpen?.();
@@ -135,7 +136,7 @@ export function postSse(path: string, body: unknown, handlers: PostSseHandlers):
       };
       const token = getToken();
       if (token) headers.Authorization = `Bearer ${token}`;
-      const res = await fetch(`/api${path}`, {
+      const res = await fetch(`${apiBase()}${path}`, {
         method: 'POST',
         headers,
         body: JSON.stringify(body),

--- a/src/frontend/src/lib/token-store.ts
+++ b/src/frontend/src/lib/token-store.ts
@@ -1,0 +1,45 @@
+/* ============================================================
+   登录 token 的存储后端 —— 可替换。
+
+   web 端与桌面端一期都用 localStorage（桌面端页面跑在 app://polaris
+   这个稳定 origin 上，localStorage 正常持久化，登录态零改动）。
+   二期若把 token 迁到 Electron 的 safeStorage（macOS Keychain /
+   Windows DPAPI / Linux libsecret），只需在启动时 setTokenStore()
+   换一个实现，api.ts / sse.ts / ws.ts / yjs-provider.ts 一行不改。
+
+   注意：接口刻意保持**同步**。改成 async 会波及 request/requestBlob
+   与三个 WS/SSE 调用点，那才是真正的重写。
+   ============================================================ */
+
+export interface TokenStore {
+  get(): string | null;
+  set(token: string | null): void;
+}
+
+const TOKEN_KEY = 'polaris.token';
+
+const localStorageTokenStore: TokenStore = {
+  get: () => localStorage.getItem(TOKEN_KEY),
+  set: (token) => {
+    if (token) {
+      localStorage.setItem(TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_KEY);
+    }
+  },
+};
+
+let store: TokenStore = localStorageTokenStore;
+
+/** 替换 token 存储后端（桌面端二期用）。 */
+export function setTokenStore(next: TokenStore): void {
+  store = next;
+}
+
+export function readToken(): string | null {
+  return store.get();
+}
+
+export function writeToken(token: string | null): void {
+  store.set(token);
+}

--- a/src/frontend/src/lib/ws.ts
+++ b/src/frontend/src/lib/ws.ts
@@ -7,6 +7,7 @@
    ============================================================ */
 
 import type { GateRead, ReviewMessageRead } from './api';
+import { wsUrl } from './endpoint';
 
 export type NotificationMessage =
   | { type: 'gate.created'; gate: GateRead }
@@ -54,8 +55,7 @@ export function connectNotifications(
       scheduleReconnect();
       return;
     }
-    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const url = `${proto}://${window.location.host}/ws/notifications?token=${encodeURIComponent(token)}`;
+    const url = wsUrl(`/ws/notifications?token=${encodeURIComponent(token)}`);
     try {
       ws = new WebSocket(url);
     } catch {

--- a/src/frontend/src/lib/yjs-provider.ts
+++ b/src/frontend/src/lib/yjs-provider.ts
@@ -13,6 +13,7 @@ import * as encoding from 'lib0/encoding';
 import * as decoding from 'lib0/decoding';
 import * as syncProtocol from 'y-protocols/sync';
 import * as awarenessProtocol from 'y-protocols/awareness';
+import { wsUrl } from './endpoint';
 
 const MSG_SYNC = 0;
 const MSG_AWARENESS = 1;
@@ -119,8 +120,9 @@ export class ManuscriptProvider {
       return;
     }
     this.setStatus(this.attempt === 0 ? 'connecting' : this.status);
-    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const url = `${proto}://${window.location.host}/ws/manuscripts/${encodeURIComponent(this.fileId)}?token=${encodeURIComponent(token)}`;
+    const url = wsUrl(
+      `/ws/manuscripts/${encodeURIComponent(this.fileId)}?token=${encodeURIComponent(token)}`,
+    );
     let ws: WebSocket;
     try {
       ws = new WebSocket(url);


### PR DESCRIPTION
First step of the desktop client work, and the only change that is **completely invisible to the web app**. Independently reviewable and safe to merge ahead of the shell itself.

## Why

The desktop client loads the SPA from a custom `app://polaris` scheme, which breaks two assumptions baked into the network layer:

- relative paths like `const BASE = '/api'` in `api.ts` no longer point at the backend;
- `ws.ts` and `yjs-provider.ts` derive WebSocket URLs from `window.location.protocol/host`, which under a custom scheme yields `ws://` with an empty host.

## What changed

New `lib/endpoint.ts` is the single place that knows about this, exporting `serverOrigin()` / `apiBase()` / `wsUrl()` / `portalUrl()` / `isDesktop()`. On the web `window.__POLARIS__` does not exist, so `serverOrigin()` returns `''` and:

- `apiBase()` is exactly `'/api'`, byte-identical to the literal it replaces;
- `wsUrl()` runs the **same `window.location` branch, verbatim**, as the code it replaces.

Six call sites are rewired: three `${BASE}${path}` in `api.ts`, two `` `/api${path}` `` in `sse.ts`, and one WS URL each in `ws.ts` and `yjs-provider.ts`.

New `lib/token-store.ts` puts the token backend behind a swappable interface, with `getToken`/`setToken` in `api.ts` delegating to it. **The interface is deliberately synchronous.** Phase 2 can move tokens to Electron's `safeStorage` by calling `setTokenStore()` with a different implementation; making it async now would force `request`, `requestBlob`, `sse.ts`, `ws.ts` and `yjs-provider.ts` to change with it, which is the actual rewrite we are trying to avoid.

## Two implementation choices worth reviewing

1. **`apiBase()` is a function, not a module-level constant.** The preload script injects `window.__POLARIS__` synchronously (via `sendSync`) before any renderer script runs, so a module-level constant *would* see the value — but that relies on an implicit ordering guarantee. A function call costs nothing and removes the whole class of initialisation-order bugs.
2. **`portalUrl()` is separate from `apiBase()`.** Invite/share links and the MCP service endpoint are meant to be opened by *other people, in a browser*, so on desktop they must point at the web portal on the server rather than at an `app://` local page. This PR only adds the helper; rewiring the six call sites that currently use `window.location.origin` belongs to the shell PR.

## Verification

`npm run build` (i.e. `tsc --noEmit && vite build`) passes, including after rebasing onto the latest `origin/main`, which added three new methods to `api.ts` — they route through `request`/`requestJson` and therefore inherit the abstraction with no extra work.

Web-side equivalence can be checked by inspection: with `serverOrigin()` returning `''`, `apiBase() + path` is the same string as the previous `'/api' + path`, and the `wsUrl()` fallback branch is a verbatim copy of the two lines it replaces.

Part of #97
