### PR TITLE
fix(daily): download the PDF into Polaris; uniform white avatar rings

### DIFF
--- a/src/frontend/src/features/daily/DailyLikes.tsx
+++ b/src/frontend/src/features/daily/DailyLikes.tsx
@@ -195,12 +195,9 @@ export function DailyLikes({
               : { display: 'flex', position: 'relative' }
           }
         >
-          <Facepile
-            users={item.likers_preview}
-            total={item.like_count}
-            size={isRow ? 18 : 20}
-            accentFirst={!isRow && item.liked_by_me}
-          />
+          {/* 头像描边一律用 surface（浅色即白）：「我赞过」已由实心红心表达，
+              不再给首个头像加 accent 描边，两种排布下观感一致 */}
+          <Facepile users={item.likers_preview} total={item.like_count} size={isRow ? 18 : 20} />
 
           {hovered && anchor && (
             <div

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -156,6 +156,20 @@ function DailyDetailPane({
     retry: false,
   });
 
+  // 下载原文：把 PDF 抓进平台（顺带抽全文/分块），成功后按钮变「阅读原文」
+  const fetchPdfMutation = useMutation({
+    mutationFn: () => api.requestPaperPdf(paper!.paper_id),
+    onSuccess: () => {
+      toast(tr('已下载原文，可以在线阅读了', 'PDF fetched — you can read it here now'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+    },
+    onError: (e) =>
+      toast(
+        `${tr('下载原文失败', 'Failed to fetch the PDF')}：${e instanceof Error ? e.message : String(e)}`,
+        'error',
+      ),
+  });
+
   // 单篇 AI 解读编译：同步等待（约半分钟）；409 = 已有人在编译
   const compileMutation = useMutation({
     mutationFn: () => api.compileDailyPaper(entryId),
@@ -251,18 +265,25 @@ function DailyDetailPane({
             {tr('阅读原文', 'Read original')}
           </button>
         ) : (
-          pdfDownloadUrl && (
-            <a
+          (paper.arxiv_id || pdfDownloadUrl) && (
+            <button
               className="btn btn-primary sm"
-              href={pdfDownloadUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-              style={{ textDecoration: 'none' }}
-              title={tr('在 arXiv 打开 PDF', 'Open the PDF on arXiv')}
+              disabled={fetchPdfMutation.isPending}
+              onClick={() => fetchPdfMutation.mutate()}
+              title={tr('下载 PDF 到平台，下载后即可在线阅读', 'Fetch the PDF into Polaris so it can be read here')}
             >
-              <Icon name="download" size={13} />
-              {tr('下载原文', 'Download PDF')}
-            </a>
+              {fetchPdfMutation.isPending ? (
+                <>
+                  <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
+                  {tr('下载中…', 'Downloading…')}
+                </>
+              ) : (
+                <>
+                  <Icon name="download" size={13} />
+                  {tr('下载原文', 'Download PDF')}
+                </>
+              )}
+            </button>
           )
         )}
         <button


### PR DESCRIPTION
## What

Two fixes on the Daily Papers page.

**Download original actually downloads.** The button was a plain link that opened the arxiv PDF in a new tab — the paper stayed unreadable inside Polaris. It now calls the existing fetch-pdf endpoint (`POST /papers/{id}/fetch-pdf`), which pulls the PDF into the content pool (and extracts/chunks the full text along the way). It shows a spinner while fetching, and once it succeeds the detail refreshes and the button becomes **Read original**.

**Uniform white rings on the likes facepile.** `Facepile` draws a `var(--surface)` ring (white in light mode) around each avatar, *except* the first one when `accentFirst` is set — which the wiki/detail placement used but the list row didn't, so the two looked different. Now neither uses it: the filled red heart already says "liked by me".

`tsc --noEmit` clean.