### PR TITLE
feat(frontend): mobile-responsive fallback across the app

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="zh">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover：配合 global.css 里的 env(safe-area-inset-*)，
+         让内容延伸到 iPhone 刘海/home 指示条区域而不被系统条挡住 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#f7f9fc" />
     <!-- Polaris 品牌标（与 src/components/ui/PolarisLogo.tsx 同源） -->
     <link
       rel="icon"

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -15,6 +15,7 @@ import { api, getToken, isAdmin, type GateDecision, type GateRead, type ReviewMe
 import { tr } from '../lib/i18n';
 import { LangToggle } from '../components/ui/LangToggle';
 import { connectNotifications } from '../lib/ws';
+import { useIsMobile } from '../lib/useBreakpoint';
 
 interface NavEntry {
   /** 非课题作用域页面的绝对路径（与 sub 二选一）。 */
@@ -340,6 +341,17 @@ export function AppShell() {
     });
   };
 
+  // —— 手机：侧栏改覆盖式抽屉 ——
+  // 桌面的「收起」是窄轨道（占位、可记忆），手机需要的是盖在内容上的抽屉，
+  // 语义不同，所以另起一个 state；且不进 localStorage —— 每次进站默认关闭，
+  // 否则一打开页面就被侧栏盖住。
+  const isMobile = useIsMobile();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  // 点了导航项就关抽屉，否则新页面被侧栏盖着；转桌面宽度时也一并复位。
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname, isMobile]);
+
   // —— 全局搜索（⌘K / Ctrl+K）——
   const [searchOpen, setSearchOpen] = useState(false);
   useEffect(() => {
@@ -461,13 +473,21 @@ export function AppShell() {
   const ctx: ShellContext = { pendingGates: pending, gatesError: pendingQuery.isError, openGates };
 
   return (
-    <div className={'app' + (navCollapsed ? ' nav-collapsed' : '')}>
-      {/* —— 侧栏 —— */}
+    <div
+      className={
+        'app' +
+        // 手机上不存在「图标轨道」形态：只有抽屉的开/关，桌面的收起态记忆保持不变，
+        // 转回宽屏时自动恢复。
+        (isMobile ? (mobileNavOpen ? ' nav-open' : '') : navCollapsed ? ' nav-collapsed' : '')
+      }
+    >
+      {/* —— 侧栏（手机上是覆盖式抽屉，见 global.css 响应式一节）—— */}
       <div className="sidebar">
         <div className="sb-brand">
           <PolarisMark size={41} />
-          {/* 收起后只留左侧图形标：直接不渲染字标，杜绝溢出（不靠 CSS 隐藏） */}
-          {!navCollapsed && <PolarisWordmark height={30} />}
+          {/* 收起后只留左侧图形标：直接不渲染字标，杜绝溢出（不靠 CSS 隐藏）。
+              手机抽屉是完整宽度，字标照常显示。 */}
+          {(!navCollapsed || isMobile) && <PolarisWordmark height={30} />}
         </div>
         {/* —— 实验室 + 课题研究两组（平面分组，只靠 eyebrow + 间距区分，不加分隔线）。
             放在滚动区之外：课题切换器的下拉菜单要能向右溢出到主列上 —— */}
@@ -478,7 +498,7 @@ export function AppShell() {
           ))}
 
           <div className="sb-section">{tr('课题研究', 'Topic')}</div>
-          <TopicSwitcher collapsed={navCollapsed} />
+          <TopicSwitcher collapsed={navCollapsed && !isMobile} />
           {NAV_MAIN.map((n) => (
             <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
@@ -498,18 +518,40 @@ export function AppShell() {
           <NavItem n={{ to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' }} />
         </div>
         <div className="sb-foot">
-          <UserMenu me={me} collapsed={navCollapsed} />
+          <UserMenu me={me} collapsed={navCollapsed && !isMobile} />
         </div>
       </div>
+
+      {/* —— 手机抽屉的遮罩：点它关闭 —— */}
+      {isMobile && mobileNavOpen && (
+        <div className="sidebar-scrim" onClick={() => setMobileNavOpen(false)} />
+      )}
 
       {/* —— 主列 —— */}
       <div className="main">
         <div className="topbar">
           <button
             className="icon-btn nav-toggle"
-            onClick={toggleNav}
-            title={navCollapsed ? tr('展开菜单栏', 'Expand sidebar') : tr('收起菜单栏', 'Collapse sidebar')}
-            aria-label={navCollapsed ? tr('展开菜单栏', 'Expand sidebar') : tr('收起菜单栏', 'Collapse sidebar')}
+            onClick={isMobile ? () => setMobileNavOpen((o) => !o) : toggleNav}
+            title={
+              isMobile
+                ? mobileNavOpen
+                  ? tr('关闭菜单', 'Close menu')
+                  : tr('打开菜单', 'Open menu')
+                : navCollapsed
+                  ? tr('展开菜单栏', 'Expand sidebar')
+                  : tr('收起菜单栏', 'Collapse sidebar')
+            }
+            aria-label={
+              isMobile
+                ? mobileNavOpen
+                  ? tr('关闭菜单', 'Close menu')
+                  : tr('打开菜单', 'Open menu')
+                : navCollapsed
+                  ? tr('展开菜单栏', 'Expand sidebar')
+                  : tr('收起菜单栏', 'Collapse sidebar')
+            }
+            aria-expanded={isMobile ? mobileNavOpen : undefined}
           >
             <Icon name="sidebar" size={16} />
           </button>

--- a/src/frontend/src/components/ui/PageHead.tsx
+++ b/src/frontend/src/components/ui/PageHead.tsx
@@ -12,17 +12,16 @@ export interface PageHeadProps {
 /** Eyebrow + 大标题 + 副标题的页头（调用方用 tr() 传入当前语言文案）。 */
 export function PageHead({ eyebrow, title, sub, right, dense }: PageHeadProps) {
   return (
-    <div className="row" style={{ alignItems: 'flex-start', marginBottom: dense ? 14 : 26 }}>
+    // 窄屏下操作区改到标题下方（见 global.css）：右侧按钮不压缩，标题的
+    // flex-basis 又是 0，同排会把标题挤成一栏窄条、逐字换行。
+    // 间距写在 CSS 里而不是内联：内联优先级高于样式表，窄屏改不动。
+    <div className="row page-head" style={{ alignItems: 'flex-start', marginBottom: dense ? 14 : 26 }}>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div className="h-eyebrow">{eyebrow}</div>
         <h1 className="h-title">{title}</h1>
         {sub && <p className="h-sub">{sub}</p>}
       </div>
-      {right && (
-        <div className="row gap10" style={{ flexShrink: 0, marginLeft: 16 }}>
-          {right}
-        </div>
-      )}
+      {right && <div className="row gap10 page-head-actions">{right}</div>}
     </div>
   );
 }

--- a/src/frontend/src/components/ui/PipelineFlow.tsx
+++ b/src/frontend/src/components/ui/PipelineFlow.tsx
@@ -40,7 +40,11 @@ export function PipelineFlow({ stages, directionLabel, onNavigate }: PipelineFlo
           {tr('当前课题', 'Current topic')} · {directionLabel}
         </span>
       </div>
-      <div className="row" style={{ alignItems: 'stretch', gap: 0 }}>
+      {/* 窄屏改 3 列网格并隐藏箭头（见 global.css）：折行会在行末留下指向空处的
+          箭头，且两行卡片高度不齐；网格下卡片等高，顺序由 00-05 编号表达。
+          gap 走 CSS 变量而不是写死 0：内联样式优先级高于样式表，写死会让
+          窄屏网格的间隔失效，卡片彼此贴死。桌面仍是 0（间距由箭头列撑开）。 */}
+      <div className="row pipeline-flow" style={{ alignItems: 'stretch', gap: 'var(--pipeline-gap, 0px)' }}>
         {stages.map((s, idx) => (
           <Fragment key={s.key}>
             <div
@@ -90,20 +94,20 @@ export function PipelineFlow({ stages, directionLabel, onNavigate }: PipelineFlo
               </div>
               {s.running && (
                 <div
-                  className="pulse"
+                  className="pulse pipeline-hint"
                   style={{ marginTop: 6, fontSize: 9.5, color: 'var(--accent-text)', fontWeight: 600 }}
                 >
                   ● {tr('运行中', 'Running')}
                 </div>
               )}
               {s.stuck && !s.running && (
-                <div style={{ marginTop: 6, fontSize: 9.5, color: 'var(--accent-text)', fontWeight: 650 }}>
+                <div className="pipeline-hint" style={{ marginTop: 6, fontSize: 9.5, color: 'var(--accent-text)', fontWeight: 650 }}>
                   ▸ {tr('下一步从这里继续', 'Next step starts here')}
                 </div>
               )}
             </div>
             {idx < stages.length - 1 && (
-              <div className="row" style={{ alignItems: 'center', width: 26, justifyContent: 'center', flexShrink: 0 }}>
+              <div className="row pipeline-arrow" style={{ alignItems: 'center', width: 26, justifyContent: 'center', flexShrink: 0 }}>
                 <svg width="22" height="14" viewBox="0 0 22 14">
                   <path
                     d="M1 7h17M14 2l5 5-5 5"

--- a/src/frontend/src/components/ui/Segmented.tsx
+++ b/src/frontend/src/components/ui/Segmented.tsx
@@ -15,6 +15,8 @@ export interface SegmentedProps<V extends string> {
 export function Segmented<V extends string>({ options, value, onChange }: SegmentedProps<V>) {
   return (
     <div
+      // .segmented 只为窄屏服务：手机上按钮不再被压到断词，整条改横向滚动（见 global.css）
+      className="segmented"
       style={{
         display: 'inline-flex',
         background: 'var(--surface-2)',

--- a/src/frontend/src/features/chat/ChatSurface.tsx
+++ b/src/frontend/src/features/chat/ChatSurface.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { api, skillKindLabel, type ChatTurn } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { useIsMobile } from '../../lib/useBreakpoint';
 import { useChatHistory } from './useChatHistory';
 import { Composer } from './Composer';
 import { CONTEXT_KIND_META, type ChatMsg, type ContextKind, type ContextRef, type MentionTarget } from './types';
@@ -73,6 +74,13 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
   const { activeMsgs, commit } = history;
   const [streaming, setStreaming] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(cfg.defaultDrawerOpen ?? true);
+  // 手机上历史栏是盖在对话区上的浮层（窄屏塞不下 210px 的并排列），默认收起，
+  // 否则它会一直挡着对话内容；展开仍由标题栏按钮控制。回到宽屏恢复原默认。
+  const isMobile = useIsMobile();
+  const defaultDrawerOpen = cfg.defaultDrawerOpen ?? true;
+  useEffect(() => {
+    setDrawerOpen(isMobile ? false : defaultDrawerOpen);
+  }, [isMobile, defaultDrawerOpen]);
   const stopRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // 是否「贴着底部」：用户往上滚离底部后暂停自动跟随，滚回底部再恢复
@@ -208,13 +216,31 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
 
   return (
     <div className={'chat-shell' + (drawerOpen ? '' : ' drawer-collapsed')}>
+      {/* 手机上历史栏浮在对话区之上，点它之外的地方也能收起 */}
+      {isMobile && drawerOpen && (
+        <div className="chat-history-scrim" onClick={() => setDrawerOpen(false)} />
+      )}
       {/* —— 历史抽屉 —— */}
       <div className="chat-history">
         <div className="chat-history-head">
           <span className="mono">{tr('历史对话', 'History')}</span>
-          <button className="chat-new-btn" title={tr('新建对话', 'New chat')} onClick={history.create}>
-            <Icon name="plus" size={13} />
-          </button>
+          <div className="row gap6">
+            <button className="chat-new-btn" title={tr('新建对话', 'New chat')} onClick={history.create}>
+              <Icon name="plus" size={13} />
+            </button>
+            {/* 手机上历史栏是浮层，会盖住对话区左上角那个切换按钮，
+                所以关闭入口必须放在浮层自己身上，否则打开后收不回去 */}
+            {isMobile && (
+              <button
+                className="chat-new-btn"
+                title={tr('收起历史', 'Hide history')}
+                aria-label={tr('收起历史', 'Hide history')}
+                onClick={() => setDrawerOpen(false)}
+              >
+                <Icon name="x" size={13} />
+              </button>
+            )}
+          </div>
         </div>
         <div className="chat-history-list scroll">
           {history.conversations.length === 0 ? (

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -796,7 +796,7 @@ export function DailyPage() {
               <DailyDetailPane entryId={selectedId} onCollect={openCollect} />
             ) : (
               <div className="empty" style={{ margin: 'auto' }}>
-                {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+                {tr('选择论文查看详情', 'Select a paper to view details')}
               </div>
             )}
           </div>

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -522,8 +522,8 @@ export function DailyPage() {
 
   return (
     <div
-      className="page fadeup"
-      style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}
+      className="page fadeup page-fill"
+      style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
       <PageHead
         eyebrow="Polaris · Daily Papers"
@@ -554,8 +554,7 @@ export function DailyPage() {
       </div>
 
       <div
-        className="card"
-        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+        className="card split-card"
       >
         {view === 'chat' ? (
           /* ======== 池对话：就最近 7 天的每日新论文问答 ======== */

--- a/src/frontend/src/features/experiment/CodeTab.tsx
+++ b/src/frontend/src/features/experiment/CodeTab.tsx
@@ -320,83 +320,86 @@ export function CodeTab({ exp, active }: { exp: ExperimentDetail; active: boolea
       </div>
 
       {/* VS Code 式布局：左树右编辑器 */}
-      <div
-        className="card"
-        style={{
-          display: 'grid',
-          gridTemplateColumns: `${treeW}px 5px 1fr`,
-          overflow: 'hidden',
-          height: 'calc(100vh - 290px)',
-          minHeight: 420,
-        }}
-      >
-        <div style={{ borderRight: '0.5px solid var(--border)', overflowY: 'auto', padding: '6px 0', background: 'var(--surface-2)' }}>
-          <TreeLevel
-            dir={tree}
-            depth={0}
-            selected={selected}
-            collapsed={collapsed}
-            onToggle={(p) =>
-              setCollapsed((prev) => {
-                const next = new Set(prev);
-                if (next.has(p)) next.delete(p);
-                else next.add(p);
-                return next;
-              })
-            }
-            onSelect={setSelected}
-          />
-        </div>
-        {/* 拖拽分隔条：调整文件树宽度 */}
+      {/* 手机上放不下「文件树 + 编辑器」，整体横向平移而不撑破外壳 */}
+      <div className="workbench-panx">
         <div
-          onMouseDown={onDividerDown}
-          title={tr('拖拽调整宽度', 'Drag to resize')}
-          style={{ cursor: 'col-resize', background: 'var(--border)', width: 5, opacity: 0.6 }}
-        />
-        <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-          {/* 当前文件“标签页” */}
-          <div
-            className="row gap6"
-            style={{
-              padding: '7px 14px',
-              borderBottom: '0.5px solid var(--border)',
-              alignItems: 'center',
-              background: 'var(--surface-2)',
-              flexShrink: 0,
-            }}
-          >
-            <Icon name="file" size={12} style={{ color: 'var(--accent)' }} />
-            <span className="mono" style={{ fontSize: 12, fontWeight: 600 }}>{selected ?? ''}</span>
-            {file.data?.truncated && (
-              <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)', marginLeft: 8 }}>
-                {tr('仅前 200KB', 'first 200KB')}
-              </span>
-            )}
-            {selected && (
-              <button
-                className="icon-btn"
-                style={{ width: 24, height: 24, marginLeft: 'auto' }}
-                title={tr('下载此文件', 'Download this file')}
-                onClick={() => void downloadFile(selected)}
-              >
-                <Icon name="download" size={12} />
-              </button>
-            )}
+          className="card workbench-panx-inner"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `${treeW}px 5px 1fr`,
+            overflow: 'hidden',
+            height: 'calc(100vh - 290px)',
+            minHeight: 420,
+          }}
+        >
+          <div style={{ borderRight: '0.5px solid var(--border)', overflowY: 'auto', padding: '6px 0', background: 'var(--surface-2)' }}>
+            <TreeLevel
+              dir={tree}
+              depth={0}
+              selected={selected}
+              collapsed={collapsed}
+              onToggle={(p) =>
+                setCollapsed((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(p)) next.delete(p);
+                  else next.add(p);
+                  return next;
+                })
+              }
+              onSelect={setSelected}
+            />
           </div>
-          <div style={{ flex: 1, minHeight: 0 }}>
-            {file.isLoading ? (
-              <div className="muted" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
-            ) : file.data ? (
-              file.data.binary ? (
-                <div className="muted" style={{ padding: 24, fontSize: 12.5 }}>
-                  {tr('二进制文件，不支持预览', 'Binary file, preview unavailable')} · {fmtBytes(file.data.size)}
-                </div>
+          {/* 拖拽分隔条：调整文件树宽度 */}
+          <div
+            onMouseDown={onDividerDown}
+            title={tr('拖拽调整宽度', 'Drag to resize')}
+            style={{ cursor: 'col-resize', background: 'var(--border)', width: 5, opacity: 0.6 }}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+            {/* 当前文件“标签页” */}
+            <div
+              className="row gap6"
+              style={{
+                padding: '7px 14px',
+                borderBottom: '0.5px solid var(--border)',
+                alignItems: 'center',
+                background: 'var(--surface-2)',
+                flexShrink: 0,
+              }}
+            >
+              <Icon name="file" size={12} style={{ color: 'var(--accent)' }} />
+              <span className="mono" style={{ fontSize: 12, fontWeight: 600 }}>{selected ?? ''}</span>
+              {file.data?.truncated && (
+                <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)', marginLeft: 8 }}>
+                  {tr('仅前 200KB', 'first 200KB')}
+                </span>
+              )}
+              {selected && (
+                <button
+                  className="icon-btn"
+                  style={{ width: 24, height: 24, marginLeft: 'auto' }}
+                  title={tr('下载此文件', 'Download this file')}
+                  onClick={() => void downloadFile(selected)}
+                >
+                  <Icon name="download" size={12} />
+                </button>
+              )}
+            </div>
+            <div style={{ flex: 1, minHeight: 0 }}>
+              {file.isLoading ? (
+                <div className="muted" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
+              ) : file.data ? (
+                file.data.binary ? (
+                  <div className="muted" style={{ padding: 24, fontSize: 12.5 }}>
+                    {tr('二进制文件，不支持预览', 'Binary file, preview unavailable')} · {fmtBytes(file.data.size)}
+                  </div>
+                ) : (
+                  <CodeViewer content={file.data.content} path={file.data.path} />
+                )
               ) : (
-                <CodeViewer content={file.data.content} path={file.data.path} />
-              )
-            ) : (
-              <div className="muted" style={{ padding: 24 }}>{tr('选择左侧文件查看内容', 'Select a file to view')}</div>
-            )}
+                <div className="muted" style={{ padding: 24 }}>{tr('选择左侧文件查看内容', 'Select a file to view')}</div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -454,7 +454,7 @@ export function ExperimentPage() {
         </div>
       ) : (
         <>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 14 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 14 }}>
             {experiments.map((e) => (
               <ExperimentCard
                 key={e.id}

--- a/src/frontend/src/features/feedback/FeedbackTab.tsx
+++ b/src/frontend/src/features/feedback/FeedbackTab.tsx
@@ -82,7 +82,9 @@ function FeedbackCard({
         <Icon name="chevron" size={13} style={{ color: 'var(--text-3)', transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform .12s', flexShrink: 0 }} />
         <TypePill type={fb.type} />
         <SeverityPill severity={fb.severity} />
-        <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {/* minWidth 给下限而不是 0：flex-basis 为 0 的标题在窄屏会被同排的
+            pill 挤成零宽整条消失，给下限后它会整体换行到自己一行 */}
+        <span style={{ flex: 1, minWidth: 160, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {fb.title}
         </span>
         {fb.module && (

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -847,7 +847,7 @@ export function ForgePage() {
           )}
         </div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 16 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 16 }}>
           {ideas.map((idea) => (
             <CandidateCard
               key={idea.id}

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -519,7 +519,7 @@ export function LibrariesPage() {
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))',
             gap: 14,
           }}
         >
@@ -565,7 +565,7 @@ export function LibrariesPage() {
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))',
             gap: 14,
           }}
         >

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -502,7 +502,7 @@ function PapersPane({
           <PaperDetailPane paperId={selectedId} onWikiLink={onWikiLink} />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
-            {tr('从左侧选择一篇论文', 'Pick a paper from the list')}
+            {tr('从列表中选择一篇论文', 'Pick a paper from the list')}
           </div>
         )}
       </div>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -620,8 +620,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
       </div>
 
       <div
-        className="card"
-        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+        className="card split-card"
       >
         {tab === 'papers' ? (
           <PapersPane

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -66,7 +66,7 @@ export function LibraryDetailPage() {
   const canManage = lib.can_manage;
 
   return (
-    <div className="page fadeup" style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}>
+    <div className="page fadeup page-fill" style={{ maxWidth: 1360, paddingBottom: 24 }}>
       <PageHead
         eyebrow={tr('实验室 · 文献库', 'Lab · Library')}
         title={`${tr('文献库', 'Library')} · ${lib.name}`}

--- a/src/frontend/src/features/library/AddToPopover.tsx
+++ b/src/frontend/src/features/library/AddToPopover.tsx
@@ -235,6 +235,8 @@ function Popover({
     left: anchor.left,
     ...(anchor.top !== undefined ? { top: anchor.top } : { bottom: anchor.bottom }),
     width: POP_W,
+    // 窄屏（POP_W + 16 放不下）时收进视口，否则右侧溢出
+    maxWidth: 'calc(100vw - 16px)',
     zIndex: POP_Z,
     background: 'var(--surface)',
     border: '0.5px solid var(--border-2)',

--- a/src/frontend/src/features/library/DailyLikedTab.tsx
+++ b/src/frontend/src/features/library/DailyLikedTab.tsx
@@ -209,7 +209,7 @@ export function DailyLikedTab() {
           <LikedDetail p={selected} />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
-            {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+            {tr('选择论文查看详情', 'Select a paper to view details')}
           </div>
         )}
       </div>

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -230,7 +230,7 @@ function EntryRow({
 function PickHint() {
   return (
     <div className="empty" style={{ margin: 'auto' }}>
-      {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+      {tr('选择论文查看详情', 'Select a paper to view details')}
     </div>
   );
 }

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -395,8 +395,8 @@ export function LibraryPage() {
 
   return (
     <div
-      className="page fadeup"
-      style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}
+      className="page fadeup page-fill"
+      style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
       <PageHead eyebrow="Polaris · My Library" title={tr('我的文献库', 'My Library')} dense />
 
@@ -444,8 +444,7 @@ export function LibraryPage() {
 
       {/* —— 卡片容器（同文献追踪的论文库外壳） —— */}
       <div
-        className="card"
-        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+        className="card split-card"
       >
         {tab === 'chat' ? (
           /* ======== 个人文献库对话 ======== */

--- a/src/frontend/src/features/mcp/McpToolsPage.tsx
+++ b/src/frontend/src/features/mcp/McpToolsPage.tsx
@@ -212,7 +212,7 @@ export function McpToolsContent() {
       {isLoading && <EmptyState icon="server" title={tr('加载中…', 'Loading…')} />}
       {isError && <EmptyState icon="server" title={tr('加载失败', 'Failed to load')} />}
       {data && (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 12 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))', gap: 12 }}>
           {shown.map((t) => (
             <ToolCard key={t.name} t={t} />
           ))}

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -1237,7 +1237,7 @@ export function PaperReviewPage() {
               <div
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(min(300px, 100%), 1fr))',
                   gap: 14,
                   alignItems: 'stretch',
                 }}

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -235,7 +235,7 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
           {!embedded && <div className="h-eyebrow">{tr('课题设置', 'Topic Settings')}</div>}
           {editingName ? (
             <div className="row gap8" style={{ marginTop: 8 }}>
-              <input className="input" style={{ fontSize: 17, fontWeight: 650, width: 380 }} value={nameDraft}
+              <input className="input" style={{ fontSize: 17, fontWeight: 650, width: 380, maxWidth: '100%' }} value={nameDraft}
                 onChange={(e) => setNameDraft(e.target.value)} />
               <button className="btn btn-primary sm" disabled={saving}
                 onClick={() => {

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -594,7 +594,8 @@ export function PdfReader({
             onMouseDown={(e) => e.stopPropagation()}
             style={{
               position: 'fixed',
-            left: Math.min(Math.max(pending.x, 10), window.innerWidth - 280),
+            // 外层 Math.max 兜底：视口窄于浮条（280px）时上式会算出负值，把浮条推出左边界
+            left: Math.max(8, Math.min(Math.max(pending.x, 10), window.innerWidth - 280)),
             // 下方空间不够（浮条约 40px 高）时翻到选区上方，避免超出窗口底部
             top:
               pending.y + 48 > window.innerHeight

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -323,81 +323,86 @@ export function ReadingPage() {
         </button>
       </div>
 
-      {/* —— 左右分栏：右侧可拖拽调宽 / 收起 —— */}
-      <div ref={splitRef} style={{ flex: 1, minHeight: 0, display: 'flex' }}>
-        {/* 左：PDF 阅读器（可划线） */}
-        <div
-          className="card"
-          style={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
-        >
-          <PdfReader
-            paper={paper}
-            highlights={highlights}
-            activeHighlightId={activeHl}
-            creating={createHlMutation.isPending}
-            onCreateHighlight={(input) => createHlMutation.mutate(input)}
-            onHighlightClick={onHighlightClick}
-            jumpTarget={jump}
-          />
-        </div>
-
-        {!rightCollapsed && (
-          <>
-            {/* 拖拽分隔条：拖动调宽，双击复位 */}
-            <div
-              onMouseDown={onDragStart}
-              onDoubleClick={() => setRightWidth(RIGHT_DEFAULT)}
-              title={tr('拖动调整宽度 · 双击复位', 'Drag to resize · double-click to reset')}
-              style={{
-                width: 12,
-                flexShrink: 0,
-                cursor: 'col-resize',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <div style={{ width: 3, height: 42, borderRadius: 3, background: 'var(--border-2)' }} />
-            </div>
-
-            {/* 右：四面板 */}
-            <div
-              className="card"
-              style={{ width: rightWidth, flexShrink: 0, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
-            >
-              <div style={{ padding: '10px 14px 0', flexShrink: 0 }}>
-                <Segmented<PanelTab>
-              options={[
-                { v: 'highlights', label: `${tr('标注', 'Highlights')}${highlights.length ? ` · ${highlights.length}` : ''}` },
-                { v: 'notes', label: `${tr('笔记', 'Notes')}${paper.note_count ? ` · ${paper.note_count}` : ''}` },
-                { v: 'chat', label: tr('AI 伴读', 'AI chat') },
-                { v: 'info', label: tr('论文信息', 'Paper info') },
-              ]}
-              value={panel}
-              onChange={setPanel}
+      {/* —— 左右分栏：右侧可拖拽调宽 / 收起 ——
+          外层 .workbench-panx 只在手机上发力：分栏最小可用宽约 640px，窄屏
+          放不下，整体改横向平移而不是撑破外壳（拖拽仍是鼠标事件，触屏无效，
+          待后续批次补手势）。 */}
+      <div className="workbench-panx" style={{ flex: 1, minHeight: 0 }}>
+        <div ref={splitRef} className="workbench-panx-inner" style={{ height: '100%', display: 'flex' }}>
+          {/* 左：PDF 阅读器（可划线） */}
+          <div
+            className="card"
+            style={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+          >
+            <PdfReader
+              paper={paper}
+              highlights={highlights}
+              activeHighlightId={activeHl}
+              creating={createHlMutation.isPending}
+              onCreateHighlight={(input) => createHlMutation.mutate(input)}
+              onHighlightClick={onHighlightClick}
+              jumpTarget={jump}
             />
           </div>
-          {panel === 'highlights' ? (
-            <HighlightsPanel
-              paperId={paper.id}
-              pid={paper.project_id ?? ''}
-              highlights={highlights}
-              loading={highlightsQuery.isLoading}
-              error={highlightsQuery.isError}
-              activeHighlightId={activeHl}
-              onJump={onJump}
-              onChanged={invalidateHighlights}
-            />
-          ) : panel === 'notes' ? (
-            <NotesPanel paperId={paper.id} pid={paper.project_id ?? ''} />
-          ) : panel === 'chat' ? (
-            <ChatPanel paperId={paper.id} pid={paper.project_id ?? ''} />
-          ) : (
-            <InfoPanel paper={paper} onWikiLink={onWikiLink} />
-          )}
+
+          {!rightCollapsed && (
+            <>
+              {/* 拖拽分隔条：拖动调宽，双击复位 */}
+              <div
+                onMouseDown={onDragStart}
+                onDoubleClick={() => setRightWidth(RIGHT_DEFAULT)}
+                title={tr('拖动调整宽度 · 双击复位', 'Drag to resize · double-click to reset')}
+                style={{
+                  width: 12,
+                  flexShrink: 0,
+                  cursor: 'col-resize',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <div style={{ width: 3, height: 42, borderRadius: 3, background: 'var(--border-2)' }} />
+              </div>
+
+              {/* 右：四面板 */}
+              <div
+                className="card"
+                style={{ width: rightWidth, flexShrink: 0, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+              >
+                <div style={{ padding: '10px 14px 0', flexShrink: 0 }}>
+                  <Segmented<PanelTab>
+                options={[
+                  { v: 'highlights', label: `${tr('标注', 'Highlights')}${highlights.length ? ` · ${highlights.length}` : ''}` },
+                  { v: 'notes', label: `${tr('笔记', 'Notes')}${paper.note_count ? ` · ${paper.note_count}` : ''}` },
+                  { v: 'chat', label: tr('AI 伴读', 'AI chat') },
+                  { v: 'info', label: tr('论文信息', 'Paper info') },
+                ]}
+                value={panel}
+                onChange={setPanel}
+              />
             </div>
-          </>
-        )}
+            {panel === 'highlights' ? (
+              <HighlightsPanel
+                paperId={paper.id}
+                pid={paper.project_id ?? ''}
+                highlights={highlights}
+                loading={highlightsQuery.isLoading}
+                error={highlightsQuery.isError}
+                activeHighlightId={activeHl}
+                onJump={onJump}
+                onChanged={invalidateHighlights}
+              />
+            ) : panel === 'notes' ? (
+              <NotesPanel paperId={paper.id} pid={paper.project_id ?? ''} />
+            ) : panel === 'chat' ? (
+              <ChatPanel paperId={paper.id} pid={paper.project_id ?? ''} />
+            ) : (
+              <InfoPanel paper={paper} onWikiLink={onWikiLink} />
+            )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -1000,7 +1000,7 @@ export function ResearchPage() {
               </div>
             ) : (
               <div className="empty" style={{ margin: 'auto' }}>
-                {tr('选择左侧论文查看详情', 'Select a paper to view details')}
+                {tr('选择论文查看详情', 'Select a paper to view details')}
               </div>
             )}
           </div>

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -607,8 +607,8 @@ export function ResearchPage() {
 
   return (
     <div
-      className="page fadeup"
-      style={{ maxWidth: 1360, display: 'flex', flexDirection: 'column', height: '100%', paddingBottom: 24 }}
+      className="page fadeup page-fill"
+      style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
       <PageHead
         eyebrow="Polaris · Related Work"
@@ -649,8 +649,7 @@ export function ResearchPage() {
       {/* —— 卡片容器（列表用双栏；对话直接铺满） —— */}
 
       <div
-        className="card"
-        style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 480 }}
+        className="card split-card"
       >
         {tab === 'chat' ? (
           <ShelfChatTab pid={pid} />

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -177,7 +177,10 @@ function TournamentModal({ open, onClose, pid }: { open: boolean; onClose: () =>
 // 表头与各行是独立 grid，列宽必须定宽才能上下对齐；状态列要放得下
 // 「评审中 under review」pill，操作列要放得下「图标 + 发起实验」，
 // 否则右对齐的操作区会向左溢出、盖住状态标签
-const LB_GRID = '36px minmax(0,1fr) 64px 150px 48px 48px 150px 136px';
+const LB_GRID = '36px minmax(220px,1fr) 64px 150px 48px 48px 150px 136px';
+// 标题列给 220px 下限、其余定宽列合计 632px、7 个 12px gap、左右 padding 36：
+// 合计 972。窄屏低于此宽度就整块横滚，而不是让标题列被挤成 0 宽整列消失。
+const LB_MIN_W = 972;
 
 function LeaderboardTab({
   pid,
@@ -241,117 +244,119 @@ function LeaderboardTab({
   }
 
   return (
-    <div>
-      {/* 表头 */}
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: LB_GRID,
-          gap: 12,
-          padding: '10px 18px',
-          borderBottom: '0.5px solid var(--border)',
-          fontSize: 10.5,
-          fontWeight: 650,
-          color: 'var(--text-3)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.04em',
-        }}
-      >
-        <span>#</span>
-        <span>{tr('想法', 'Idea')}</span>
-        <span style={{ textAlign: 'right' }}>Elo</span>
-        <span>{tr('四维 rubric', 'Rubric (4 dims)')}</span>
-        <span style={{ textAlign: 'right' }}>{tr('对局', 'Matches')}</span>
-        <span style={{ textAlign: 'right' }}>{tr('胜场', 'Wins')}</span>
-        <span>{tr('状态', 'Status')}</span>
-        <span />
-      </div>
-      {rows.map((r, i) => {
-        const promotable = canPromote && (r.status === 'candidate' || r.status === 'under_review');
-        return (
-          <div
-            key={r.id}
-            className="hoverable"
-            onClick={() => navigate(`/ideas/${r.id}`)}
-            style={{
-              display: 'grid',
-              gridTemplateColumns: LB_GRID,
-              gap: 12,
-              alignItems: 'center',
-              padding: '12px 18px',
-              borderBottom: '0.5px solid var(--border)',
-            }}
-          >
-            <span
-              className="mono"
-              style={{ fontSize: 14, fontWeight: 700, color: i < 3 ? 'var(--accent-text)' : 'var(--text-3)' }}
+    <div className="table-wrap">
+      <div style={{ minWidth: LB_MIN_W }}>
+        {/* 表头 */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: LB_GRID,
+            gap: 12,
+            padding: '10px 18px',
+            borderBottom: '0.5px solid var(--border)',
+            fontSize: 10.5,
+            fontWeight: 650,
+            color: 'var(--text-3)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+          }}
+        >
+          <span>#</span>
+          <span>{tr('想法', 'Idea')}</span>
+          <span style={{ textAlign: 'right' }}>Elo</span>
+          <span>{tr('四维 rubric', 'Rubric (4 dims)')}</span>
+          <span style={{ textAlign: 'right' }}>{tr('对局', 'Matches')}</span>
+          <span style={{ textAlign: 'right' }}>{tr('胜场', 'Wins')}</span>
+          <span>{tr('状态', 'Status')}</span>
+          <span />
+        </div>
+        {rows.map((r, i) => {
+          const promotable = canPromote && (r.status === 'candidate' || r.status === 'under_review');
+          return (
+            <div
+              key={r.id}
+              className="hoverable"
+              onClick={() => navigate(`/ideas/${r.id}`)}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: LB_GRID,
+                gap: 12,
+                alignItems: 'center',
+                padding: '12px 18px',
+                borderBottom: '0.5px solid var(--border)',
+              }}
             >
-              {i + 1}
-            </span>
-            <div style={{ minWidth: 0 }}>
-              <div
-                style={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
+              <span
+                className="mono"
+                style={{ fontSize: 14, fontWeight: 700, color: i < 3 ? 'var(--accent-text)' : 'var(--text-3)' }}
               >
-                {r.title}
+                {i + 1}
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {r.title}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--text-3)',
+                    marginTop: 2,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {r.summary}
+                </div>
               </div>
-              <div
-                style={{
-                  fontSize: 11,
-                  color: 'var(--text-3)',
-                  marginTop: 2,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {r.summary}
+              <span className="mono" style={{ fontSize: 14.5, fontWeight: 700, color: 'var(--accent-text)', textAlign: 'right' }}>
+                {Math.round(r.elo_rating)}
+              </span>
+              <MiniScoreBars scores={r.scores} />
+              <span className="mono" style={{ fontSize: 12.5, textAlign: 'right' }}>{r.matches}</span>
+              <span className="mono" style={{ fontSize: 12.5, textAlign: 'right', color: 'var(--ok-tx)' }}>{r.wins}</span>
+              <StatusPill status={r.status} sm />
+              <div className="row gap6" style={{ justifyContent: 'flex-end' }} onClick={(e) => e.stopPropagation()}>
+                <button
+                  className="icon-btn"
+                  title={tr('辩论记录', 'Debate history')}
+                  onClick={() => onOpenMatches(r.id)}
+                  style={{ width: 26, height: 26 }}
+                >
+                  <Icon name="scale" size={13} />
+                </button>
+                {promotable && (
+                  <button
+                    className="btn btn-primary sm"
+                    disabled={running || promoteMutation.isPending}
+                    onClick={() => promoteMutation.mutate(r.id)}
+                  >
+                    {tr('晋级', 'Promote')}
+                  </button>
+                )}
+                {r.status === 'promoted' && (
+                  <button
+                    className="btn btn-soft sm"
+                    title={tr('从该想法发起实验', 'Start an experiment from this idea')}
+                    onClick={() => navigate(topicPath(pid, `experiment?new=${r.id}`))}
+                  >
+                    <Icon name="flask" size={12} />
+                    {tr('发起实验', 'Start experiment')}
+                  </button>
+                )}
               </div>
             </div>
-            <span className="mono" style={{ fontSize: 14.5, fontWeight: 700, color: 'var(--accent-text)', textAlign: 'right' }}>
-              {Math.round(r.elo_rating)}
-            </span>
-            <MiniScoreBars scores={r.scores} />
-            <span className="mono" style={{ fontSize: 12.5, textAlign: 'right' }}>{r.matches}</span>
-            <span className="mono" style={{ fontSize: 12.5, textAlign: 'right', color: 'var(--ok-tx)' }}>{r.wins}</span>
-            <StatusPill status={r.status} sm />
-            <div className="row gap6" style={{ justifyContent: 'flex-end' }} onClick={(e) => e.stopPropagation()}>
-              <button
-                className="icon-btn"
-                title={tr('辩论记录', 'Debate history')}
-                onClick={() => onOpenMatches(r.id)}
-                style={{ width: 26, height: 26 }}
-              >
-                <Icon name="scale" size={13} />
-              </button>
-              {promotable && (
-                <button
-                  className="btn btn-primary sm"
-                  disabled={running || promoteMutation.isPending}
-                  onClick={() => promoteMutation.mutate(r.id)}
-                >
-                  {tr('晋级', 'Promote')}
-                </button>
-              )}
-              {r.status === 'promoted' && (
-                <button
-                  className="btn btn-soft sm"
-                  title={tr('从该想法发起实验', 'Start an experiment from this idea')}
-                  onClick={() => navigate(topicPath(pid, `experiment?new=${r.id}`))}
-                >
-                  <Icon name="flask" size={12} />
-                  {tr('发起实验', 'Start experiment')}
-                </button>
-              )}
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -393,76 +393,78 @@ function SshTab() {
           {tr('还没有 SSH 凭据 — 添加一台 GPU 服务器后即可在 Experiment Lab 发起实验', 'No SSH credentials yet — add a GPU server to run experiments in Experiment Lab')}
         </div>
       ) : (
-        <table className="table">
-          <thead>
-            <tr>
-              <th>{tr('名称', 'Name')}</th>
-              <th>host</th>
-              <th style={{ width: 60 }}>port</th>
-              <th>username</th>
-              <th style={{ width: 130 }}>{tr('最近验证', 'Last verified')}</th>
-              <th style={{ width: 150 }} />
-            </tr>
-          </thead>
-          <tbody>
-            {creds.map((c) => (
-              <Fragment key={c.id}>
-                <tr>
-                  <td style={{ fontWeight: 600 }}>{c.name}</td>
-                  <td className="mono" style={{ fontSize: 11.5 }}>{c.host}</td>
-                  <td className="mono" style={{ fontSize: 11.5 }}>{c.port}</td>
-                  <td className="mono" style={{ fontSize: 11.5 }}>{c.username}</td>
-                  <td className="mono" style={{ fontSize: 11, color: c.last_verified_at ? 'var(--ok-tx)' : 'var(--text-4)' }}>
-                    {c.last_verified_at ? fmtTime(c.last_verified_at) : tr('从未验证', 'Never verified')}
-                  </td>
-                  <td>
-                    <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
-                      <button
-                        className="btn btn-soft sm"
-                        onClick={() => setSysinfoId(sysinfoId === c.id ? null : c.id)}
-                      >
-                        <Icon name="cpu" size={12} />
-                        {sysinfoId === c.id ? tr('收起状态', 'Hide status') : tr('系统状态', 'System status')}
-                      </button>
-                      <button
-                        className="btn btn-soft sm"
-                        disabled={testMutation.isPending}
-                        onClick={() => testMutation.mutate(c.id)}
-                      >
-                        {testMutation.isPending && testMutation.variables === c.id ? tr('连接中…', 'Connecting…') : tr('测试连接', 'Test connection')}
-                      </button>
-                      <button
-                        className="icon-btn"
-                        style={{ width: 26, height: 26 }}
-                        title={tr('删除', 'Delete')}
-                        disabled={deleteMutation.isPending}
-                        onClick={() => {
-                          if (window.confirm(`${tr('确定删除凭据', 'Delete credential')} “${c.name}”？${tr('使用中的实验将无法再连接该服务器。', 'Experiments using it will no longer be able to reach this server.')}`)) {
-                            deleteMutation.mutate(c.id);
-                          }
-                        }}
-                      >
-                        <Icon name="trash" size={13} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-                {sysinfoId === c.id && (
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>{tr('名称', 'Name')}</th>
+                <th>host</th>
+                <th style={{ width: 60 }}>port</th>
+                <th>username</th>
+                <th style={{ width: 130 }}>{tr('最近验证', 'Last verified')}</th>
+                <th style={{ width: 150 }} />
+              </tr>
+            </thead>
+            <tbody>
+              {creds.map((c) => (
+                <Fragment key={c.id}>
                   <tr>
-                    <td colSpan={6} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
-                      <SysinfoPanel
-                        loading={sysinfoQuery.isLoading}
-                        error={sysinfoQuery.isError}
-                        info={sysinfoQuery.data}
-                        onRefresh={() => void sysinfoQuery.refetch()}
-                      />
+                    <td style={{ fontWeight: 600 }}>{c.name}</td>
+                    <td className="mono" style={{ fontSize: 11.5 }}>{c.host}</td>
+                    <td className="mono" style={{ fontSize: 11.5 }}>{c.port}</td>
+                    <td className="mono" style={{ fontSize: 11.5 }}>{c.username}</td>
+                    <td className="mono" style={{ fontSize: 11, color: c.last_verified_at ? 'var(--ok-tx)' : 'var(--text-4)' }}>
+                      {c.last_verified_at ? fmtTime(c.last_verified_at) : tr('从未验证', 'Never verified')}
+                    </td>
+                    <td>
+                      <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
+                        <button
+                          className="btn btn-soft sm"
+                          onClick={() => setSysinfoId(sysinfoId === c.id ? null : c.id)}
+                        >
+                          <Icon name="cpu" size={12} />
+                          {sysinfoId === c.id ? tr('收起状态', 'Hide status') : tr('系统状态', 'System status')}
+                        </button>
+                        <button
+                          className="btn btn-soft sm"
+                          disabled={testMutation.isPending}
+                          onClick={() => testMutation.mutate(c.id)}
+                        >
+                          {testMutation.isPending && testMutation.variables === c.id ? tr('连接中…', 'Connecting…') : tr('测试连接', 'Test connection')}
+                        </button>
+                        <button
+                          className="icon-btn"
+                          style={{ width: 26, height: 26 }}
+                          title={tr('删除', 'Delete')}
+                          disabled={deleteMutation.isPending}
+                          onClick={() => {
+                            if (window.confirm(`${tr('确定删除凭据', 'Delete credential')} “${c.name}”？${tr('使用中的实验将无法再连接该服务器。', 'Experiments using it will no longer be able to reach this server.')}`)) {
+                              deleteMutation.mutate(c.id);
+                            }
+                          }}
+                        >
+                          <Icon name="trash" size={13} />
+                        </button>
+                      </div>
                     </td>
                   </tr>
-                )}
-              </Fragment>
-            ))}
-          </tbody>
-        </table>
+                  {sysinfoId === c.id && (
+                    <tr>
+                      <td colSpan={6} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
+                        <SysinfoPanel
+                          loading={sysinfoQuery.isLoading}
+                          error={sysinfoQuery.isError}
+                          info={sysinfoQuery.data}
+                          onRefresh={() => void sysinfoQuery.refetch()}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
       <Modal
@@ -866,112 +868,114 @@ function ProvidersSection({ adapter }: { adapter: LlmAdapter }) {
       ) : providers.length === 0 ? (
         <div className="empty" style={{ padding: 24 }}>{tr('还没有 provider，先添加一个；配置好前 AI 功能不可用', 'No providers yet — add one; AI features stay unavailable until configured')}</div>
       ) : (
-        <table className="table">
-          <thead>
-            <tr>
-              <th style={{ width: 230 }}>{tr('名称', 'Name')}</th>
-              <th style={{ width: 130 }}>api_key</th>
-              <th>{tr('可用模型', 'Models')}</th>
-              <th style={{ width: 80 }}>{tr('状态', 'Status')}</th>
-              <th style={{ width: 130 }}>{tr('模型状态', 'Model status')}</th>
-              <th style={{ width: 70 }} />
-            </tr>
-          </thead>
-          <tbody>
-            {providers.map((p) => {
-              const models = p.models ?? [];
-              const firstModel = firstModelOf(p);
-              const expanded = expandedModels.has(p.id);
-              const shownModels = expanded ? models : models.slice(0, MODELS_COLLAPSED);
-              const hiddenCount = models.length - shownModels.length;
-              const state: TestState = firstModel
-                ? tests.results[testKeyOf(p.id, firstModel, 'chat')] ?? { status: 'idle' }
-                : { status: 'idle' };
-              return (
-                <tr key={p.id}>
-                  <td>
-                    <div className="row gap6" style={{ alignItems: 'center' }}>
-                      <span style={{ fontSize: 12, fontWeight: 650 }}>{p.name}</span>
-                      <span className="pill sm mono" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
-                        {p.kind}
-                      </span>
-                    </div>
-                    <div className="mono" title={p.base_url ?? undefined}
-                      style={{ fontSize: 10.5, color: 'var(--text-3)', maxWidth: 210, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {p.base_url ?? '—'}
-                    </div>
-                  </td>
-                  <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{p.api_key_masked ?? '—'}</td>
-                  <td>
-                    {models.length === 0 ? (
-                      <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('（未填写）', '(none)')}</span>
-                    ) : (
-                      <div className="row gap6" style={{ flexWrap: 'wrap' }}>
-                        {shownModels.map((m) => (
-                          <span key={m} className="tag mono" style={{ fontSize: 10.5 }}>{m}</span>
-                        ))}
-                        {hiddenCount > 0 && (
-                          <span className="tag mono" role="button" title={models.join(', ')}
-                            style={{ fontSize: 10.5, cursor: 'pointer', color: 'var(--accent-text)' }}
-                            onClick={() => toggleModelsExpanded(p.id)}>
-                            +{hiddenCount}
-                          </span>
-                        )}
-                        {expanded && models.length > MODELS_COLLAPSED && (
-                          <span className="tag" role="button"
-                            style={{ fontSize: 10.5, cursor: 'pointer', color: 'var(--text-3)' }}
-                            onClick={() => toggleModelsExpanded(p.id)}>
-                            {tr('收起', 'Collapse')}
-                          </span>
-                        )}
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th style={{ width: 230 }}>{tr('名称', 'Name')}</th>
+                <th style={{ width: 130 }}>api_key</th>
+                <th>{tr('可用模型', 'Models')}</th>
+                <th style={{ width: 80 }}>{tr('状态', 'Status')}</th>
+                <th style={{ width: 130 }}>{tr('模型状态', 'Model status')}</th>
+                <th style={{ width: 70 }} />
+              </tr>
+            </thead>
+            <tbody>
+              {providers.map((p) => {
+                const models = p.models ?? [];
+                const firstModel = firstModelOf(p);
+                const expanded = expandedModels.has(p.id);
+                const shownModels = expanded ? models : models.slice(0, MODELS_COLLAPSED);
+                const hiddenCount = models.length - shownModels.length;
+                const state: TestState = firstModel
+                  ? tests.results[testKeyOf(p.id, firstModel, 'chat')] ?? { status: 'idle' }
+                  : { status: 'idle' };
+                return (
+                  <tr key={p.id}>
+                    <td>
+                      <div className="row gap6" style={{ alignItems: 'center' }}>
+                        <span style={{ fontSize: 12, fontWeight: 650 }}>{p.name}</span>
+                        <span className="pill sm mono" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+                          {p.kind}
+                        </span>
                       </div>
-                    )}
-                  </td>
-                  <td>
-                    <span
-                      className="pill sm"
-                      role="button"
-                      title={p.enabled ? tr('点击停用', 'Click to disable') : tr('点击启用', 'Click to enable')}
-                      style={{
-                        cursor: toggleMutation.isPending ? 'default' : 'pointer',
-                        ...(p.enabled
-                          ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
-                          : { background: 'var(--surface-3)', color: 'var(--text-3)' }),
-                      }}
-                      onClick={() => { if (!toggleMutation.isPending) toggleMutation.mutate(p); }}
-                    >
-                      {p.enabled ? tr('启用', 'Enabled') : tr('停用', 'Disabled')}
-                    </span>
-                  </td>
-                  <td>
-                    <ModelStatusBadge
-                      state={state}
-                      onTest={firstModel ? () => void runProviderTests([p]) : undefined}
-                      idleHint={firstModel ? undefined : tr('先填写可用模型才能测试', 'Add models first to enable testing')}
-                    />
-                  </td>
-                  <td>
-                    <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
-                      <button className="icon-btn" style={{ width: 26, height: 26 }} title={tr('编辑', 'Edit')}
-                        onClick={() => { setDraft(draftFrom(p)); setModal(p.id); }}>
-                        <Icon name="pen" size={13} />
-                      </button>
-                      <button className="icon-btn" style={{ width: 26, height: 26 }} title={tr('删除', 'Delete')}
-                        disabled={deleteMutation.isPending}
-                        onClick={() => {
-                          if (window.confirm(`${tr('确定删除 Provider', 'Delete provider')} “${p.name}”？${tr('模型路由表里引用它的环节将失效。', 'Routing rows that reference it will stop working.')}`)) {
-                            deleteMutation.mutate(p.id);
-                          }
-                        }}>
-                        <Icon name="trash" size={13} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                      <div className="mono" title={p.base_url ?? undefined}
+                        style={{ fontSize: 10.5, color: 'var(--text-3)', maxWidth: 210, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {p.base_url ?? '—'}
+                      </div>
+                    </td>
+                    <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{p.api_key_masked ?? '—'}</td>
+                    <td>
+                      {models.length === 0 ? (
+                        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('（未填写）', '(none)')}</span>
+                      ) : (
+                        <div className="row gap6" style={{ flexWrap: 'wrap' }}>
+                          {shownModels.map((m) => (
+                            <span key={m} className="tag mono" style={{ fontSize: 10.5 }}>{m}</span>
+                          ))}
+                          {hiddenCount > 0 && (
+                            <span className="tag mono" role="button" title={models.join(', ')}
+                              style={{ fontSize: 10.5, cursor: 'pointer', color: 'var(--accent-text)' }}
+                              onClick={() => toggleModelsExpanded(p.id)}>
+                              +{hiddenCount}
+                            </span>
+                          )}
+                          {expanded && models.length > MODELS_COLLAPSED && (
+                            <span className="tag" role="button"
+                              style={{ fontSize: 10.5, cursor: 'pointer', color: 'var(--text-3)' }}
+                              onClick={() => toggleModelsExpanded(p.id)}>
+                              {tr('收起', 'Collapse')}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </td>
+                    <td>
+                      <span
+                        className="pill sm"
+                        role="button"
+                        title={p.enabled ? tr('点击停用', 'Click to disable') : tr('点击启用', 'Click to enable')}
+                        style={{
+                          cursor: toggleMutation.isPending ? 'default' : 'pointer',
+                          ...(p.enabled
+                            ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+                            : { background: 'var(--surface-3)', color: 'var(--text-3)' }),
+                        }}
+                        onClick={() => { if (!toggleMutation.isPending) toggleMutation.mutate(p); }}
+                      >
+                        {p.enabled ? tr('启用', 'Enabled') : tr('停用', 'Disabled')}
+                      </span>
+                    </td>
+                    <td>
+                      <ModelStatusBadge
+                        state={state}
+                        onTest={firstModel ? () => void runProviderTests([p]) : undefined}
+                        idleHint={firstModel ? undefined : tr('先填写可用模型才能测试', 'Add models first to enable testing')}
+                      />
+                    </td>
+                    <td>
+                      <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
+                        <button className="icon-btn" style={{ width: 26, height: 26 }} title={tr('编辑', 'Edit')}
+                          onClick={() => { setDraft(draftFrom(p)); setModal(p.id); }}>
+                          <Icon name="pen" size={13} />
+                        </button>
+                        <button className="icon-btn" style={{ width: 26, height: 26 }} title={tr('删除', 'Delete')}
+                          disabled={deleteMutation.isPending}
+                          onClick={() => {
+                            if (window.confirm(`${tr('确定删除 Provider', 'Delete provider')} “${p.name}”？${tr('模型路由表里引用它的环节将失效。', 'Routing rows that reference it will stop working.')}`)) {
+                              deleteMutation.mutate(p.id);
+                            }
+                          }}>
+                          <Icon name="trash" size={13} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
 
       <Modal
@@ -1249,109 +1253,111 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
           {tr('路由表加载失败（后端不可用），保存将覆盖整表。', 'Failed to load routes (backend unavailable); saving will overwrite the whole table.')}
         </div>
       )}
-      <table className="table">
-        <thead>
-          <tr>
-            <th style={{ width: 150 }}>{tr('环节', 'Stage')}</th>
-            <th style={{ width: 170 }}>provider</th>
-            <th>model</th>
-            <th style={{ width: 90 }}>temperature</th>
-            <th style={{ width: 130 }}>{tr('模型状态', 'Model status')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {visibleStages.map((stage) => {
-            const explicit = rows[stage] !== undefined;
-            const capability = CAPABILITY_STAGES.has(stage);
-            const follows = !explicit && stage !== 'default' && !capability;
-            const unset = capability && !explicit; // 能力型环节未设置：不跟随默认，运行时降级
-            // 展示值：显式行用自己的；跟随默认的行弱化展示 default 的 provider/模型
-            const shown = rows[stage] ?? (follows ? defaultRow : undefined) ?? emptyDraftRow;
-            const label = STAGE_LABELS[stage];
-            const eff = effectiveOf(stage);
-            const state: TestState = eff
-              ? tests.results[testKeyOf(eff.provider_id, eff.model.trim(), capabilityOf(stage))] ?? { status: 'idle' }
-              : { status: 'idle' };
-            const providerModels = providers.find((p) => p.id === shown.provider_id)?.models ?? [];
-            return (
-              <tr key={stage}>
-                <td>
-                  <div className="row gap6" style={{ alignItems: 'center' }}>
-                    <span style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : stage}</span>
-                    {follows && (
-                      <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
-                        {tr('跟随默认', 'Follows default')}
-                      </span>
-                    )}
-                    {unset && (
-                      <span
-                        className="pill sm"
-                        style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}
-                        title={tr('该环节需要专用模型，不跟随默认；未配置时相关功能自动降级', 'This stage needs a dedicated model and never follows Default; features degrade while unset')}
-                      >
-                        {tr('未设置', 'Not set')}
-                      </span>
-                    )}
-                    {explicit && stage !== 'default' && (
-                      <button
-                        className="icon-btn"
-                        style={{ width: 20, height: 20 }}
-                        title={capability
-                          ? tr('清除设置，恢复「未设置」', 'Clear — back to "Not set"')
-                          : tr('清除单独设置，恢复跟随默认', 'Clear this override and follow default again')}
-                        onClick={() => clearRow(stage)}
-                      >
-                        <Icon name="x" size={11} />
-                      </button>
-                    )}
-                  </div>
-                  <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{stage}</div>
-                </td>
-                <td>
-                  <SelectMenu
-                    style={{ height: 32 }}
-                    muted={follows}
-                    value={shown.provider_id}
-                    options={[
-                      { value: '', label: tr('（未配置）', '(not set)') },
-                      ...providers.map((p) => ({ value: p.id, label: p.name })),
-                    ]}
-                    onChange={(v) => setRow(stage, { provider_id: v, model: '' })}
-                  />
-                </td>
-                <td>
-                  <ModelCombobox
-                    value={shown.model}
-                    options={providerModels}
-                    muted={follows}
-                    placeholder={unset
-                      ? tr('未配置，相关功能将降级', 'Not set — related features degrade')
-                      : tr('如 deepseek-chat', 'e.g. deepseek-chat')}
-                    onChange={(v) => setRow(stage, { model: v })}
-                  />
-                </td>
-                <td>
-                  <input
-                    className="input mono"
-                    style={{ height: 32, width: '100%', fontSize: 12, ...(follows ? { color: 'var(--text-3)' } : {}) }}
-                    value={shown.temperature}
-                    placeholder={tr('默认', 'default')}
-                    inputMode="decimal"
-                    onChange={(e) => setRow(stage, { temperature: e.target.value })}
-                  />
-                </td>
-                <td>
-                  <ModelStatusBadge
-                    state={state}
-                    onTest={eff ? () => void runTests([stage]) : undefined}
-                    idleHint={unset ? tr('未配置，批量测试将跳过该环节', 'Not set; batch tests skip this stage') : undefined}
-                  />
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <div className="table-wrap">
+        <table className="table">
+          <thead>
+            <tr>
+              <th style={{ width: 150 }}>{tr('环节', 'Stage')}</th>
+              <th style={{ width: 170 }}>provider</th>
+              <th>model</th>
+              <th style={{ width: 90 }}>temperature</th>
+              <th style={{ width: 130 }}>{tr('模型状态', 'Model status')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleStages.map((stage) => {
+              const explicit = rows[stage] !== undefined;
+              const capability = CAPABILITY_STAGES.has(stage);
+              const follows = !explicit && stage !== 'default' && !capability;
+              const unset = capability && !explicit; // 能力型环节未设置：不跟随默认，运行时降级
+              // 展示值：显式行用自己的；跟随默认的行弱化展示 default 的 provider/模型
+              const shown = rows[stage] ?? (follows ? defaultRow : undefined) ?? emptyDraftRow;
+              const label = STAGE_LABELS[stage];
+              const eff = effectiveOf(stage);
+              const state: TestState = eff
+                ? tests.results[testKeyOf(eff.provider_id, eff.model.trim(), capabilityOf(stage))] ?? { status: 'idle' }
+                : { status: 'idle' };
+              const providerModels = providers.find((p) => p.id === shown.provider_id)?.models ?? [];
+              return (
+                <tr key={stage}>
+                  <td>
+                    <div className="row gap6" style={{ alignItems: 'center' }}>
+                      <span style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : stage}</span>
+                      {follows && (
+                        <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+                          {tr('跟随默认', 'Follows default')}
+                        </span>
+                      )}
+                      {unset && (
+                        <span
+                          className="pill sm"
+                          style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}
+                          title={tr('该环节需要专用模型，不跟随默认；未配置时相关功能自动降级', 'This stage needs a dedicated model and never follows Default; features degrade while unset')}
+                        >
+                          {tr('未设置', 'Not set')}
+                        </span>
+                      )}
+                      {explicit && stage !== 'default' && (
+                        <button
+                          className="icon-btn"
+                          style={{ width: 20, height: 20 }}
+                          title={capability
+                            ? tr('清除设置，恢复「未设置」', 'Clear — back to "Not set"')
+                            : tr('清除单独设置，恢复跟随默认', 'Clear this override and follow default again')}
+                          onClick={() => clearRow(stage)}
+                        >
+                          <Icon name="x" size={11} />
+                        </button>
+                      )}
+                    </div>
+                    <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{stage}</div>
+                  </td>
+                  <td>
+                    <SelectMenu
+                      style={{ height: 32 }}
+                      muted={follows}
+                      value={shown.provider_id}
+                      options={[
+                        { value: '', label: tr('（未配置）', '(not set)') },
+                        ...providers.map((p) => ({ value: p.id, label: p.name })),
+                      ]}
+                      onChange={(v) => setRow(stage, { provider_id: v, model: '' })}
+                    />
+                  </td>
+                  <td>
+                    <ModelCombobox
+                      value={shown.model}
+                      options={providerModels}
+                      muted={follows}
+                      placeholder={unset
+                        ? tr('未配置，相关功能将降级', 'Not set — related features degrade')
+                        : tr('如 deepseek-chat', 'e.g. deepseek-chat')}
+                      onChange={(v) => setRow(stage, { model: v })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input mono"
+                      style={{ height: 32, width: '100%', fontSize: 12, ...(follows ? { color: 'var(--text-3)' } : {}) }}
+                      value={shown.temperature}
+                      placeholder={tr('默认', 'default')}
+                      inputMode="decimal"
+                      onChange={(e) => setRow(stage, { temperature: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <ModelStatusBadge
+                      state={state}
+                      onTest={eff ? () => void runTests([stage]) : undefined}
+                      idleHint={unset ? tr('未配置，批量测试将跳过该环节', 'Not set; batch tests skip this stage') : undefined}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
       <div className="row" style={{ justifyContent: 'center', marginTop: 10 }}>
         <button className="btn btn-ghost sm" onClick={() => setShowAll((v) => !v)}>
           <Icon name="chevDown" size={12} style={showAll ? { transform: 'rotate(180deg)' } : undefined} />
@@ -1537,46 +1543,48 @@ function CallLogsSection() {
         </div>
       ) : (
         <>
-          <table className="table">
-            <thead>
-              <tr>
-                <th style={{ width: 140 }}>{tr('时间', 'Time')}</th>
-                <th style={{ width: 110 }}>{tr('环节', 'Stage')}</th>
-                <th>{tr('模型', 'Model')}</th>
-                <th style={{ width: 90, textAlign: 'right' }}>{tr('时延', 'Latency')} (ms)</th>
-                <th style={{ width: 120, textAlign: 'right' }}>tokens</th>
-                <th style={{ width: 70 }}>{tr('状态', 'Status')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((row) => (
-                <Fragment key={row.id}>
-                  <tr style={{ cursor: 'pointer' }} onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}>
-                    <td className="mono" style={{ fontSize: 11 }}>{fmtTime(row.created_at)}</td>
-                    <td className="mono" style={{ fontSize: 11.5 }}>{row.stage}</td>
-                    <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
-                      {row.model}
-                      <span style={{ color: 'var(--text-4)' }}> · {row.provider_name}</span>
-                    </td>
-                    <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{row.duration_ms.toLocaleString()}</td>
-                    <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>
-                      {row.prompt_tokens.toLocaleString()} + {row.completion_tokens.toLocaleString()}
-                    </td>
-                    <td>
-                      <span className="pill sm" style={statusPill(row)}>{row.status === 'ok' ? 'ok' : tr('出错', 'error')}</span>
-                    </td>
-                  </tr>
-                  {expandedId === row.id && (
-                    <tr>
-                      <td colSpan={6} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
-                        <CallLogDetailPanel id={row.id} />
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th style={{ width: 140 }}>{tr('时间', 'Time')}</th>
+                  <th style={{ width: 110 }}>{tr('环节', 'Stage')}</th>
+                  <th>{tr('模型', 'Model')}</th>
+                  <th style={{ width: 90, textAlign: 'right' }}>{tr('时延', 'Latency')} (ms)</th>
+                  <th style={{ width: 120, textAlign: 'right' }}>tokens</th>
+                  <th style={{ width: 70 }}>{tr('状态', 'Status')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((row) => (
+                  <Fragment key={row.id}>
+                    <tr style={{ cursor: 'pointer' }} onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}>
+                      <td className="mono" style={{ fontSize: 11 }}>{fmtTime(row.created_at)}</td>
+                      <td className="mono" style={{ fontSize: 11.5 }}>{row.stage}</td>
+                      <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                        {row.model}
+                        <span style={{ color: 'var(--text-4)' }}> · {row.provider_name}</span>
+                      </td>
+                      <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{row.duration_ms.toLocaleString()}</td>
+                      <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>
+                        {row.prompt_tokens.toLocaleString()} + {row.completion_tokens.toLocaleString()}
+                      </td>
+                      <td>
+                        <span className="pill sm" style={statusPill(row)}>{row.status === 'ok' ? 'ok' : tr('出错', 'error')}</span>
                       </td>
                     </tr>
-                  )}
-                </Fragment>
-              ))}
-            </tbody>
-          </table>
+                    {expandedId === row.id && (
+                      <tr>
+                        <td colSpan={6} style={{ background: 'var(--surface-2)', padding: '12px 16px' }}>
+                          <CallLogDetailPanel id={row.id} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
           <div className="row gap8" style={{ justifyContent: 'flex-end', marginTop: 12, alignItems: 'center' }}>
             <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
               {tr(`共 ${total} 条 · 第 ${page + 1} / ${pageCount} 页`, `${total} entries · page ${page + 1} / ${pageCount}`)}
@@ -1674,54 +1682,56 @@ function ManagedEffectiveView({ effective }: { effective: LlmSelfConfig }) {
         {effective.providers.length === 0 ? (
           <div className="empty" style={{ padding: 24 }}>{tr('管理员尚未配置任何 provider', 'The admin has not configured any provider yet')}</div>
         ) : (
-          <table className="table">
-            <thead>
-              <tr>
-                <th style={{ width: 230 }}>{tr('名称', 'Name')}</th>
-                <th style={{ width: 130 }}>api_key</th>
-                <th>{tr('可用模型', 'Models')}</th>
-                <th style={{ width: 80 }}>{tr('状态', 'Status')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {effective.providers.map((p) => {
-                const models = p.models ?? [];
-                return (
-                  <tr key={p.id}>
-                    <td>
-                      <div className="row gap6" style={{ alignItems: 'center' }}>
-                        <span style={{ fontSize: 12, fontWeight: 650 }}>{p.name}</span>
-                        <span className="pill sm mono" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>{p.kind}</span>
-                      </div>
-                      <div className="mono" title={p.base_url ?? undefined}
-                        style={{ fontSize: 10.5, color: 'var(--text-3)', maxWidth: 210, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {p.base_url ?? '—'}
-                      </div>
-                    </td>
-                    <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{p.api_key_masked ?? '—'}</td>
-                    <td>
-                      {models.length === 0 ? (
-                        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('（未填写）', '(none)')}</span>
-                      ) : (
-                        <div className="row gap6" style={{ flexWrap: 'wrap' }}>
-                          {models.map((m) => (
-                            <span key={m} className="tag mono" style={{ fontSize: 10.5 }}>{m}</span>
-                          ))}
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th style={{ width: 230 }}>{tr('名称', 'Name')}</th>
+                  <th style={{ width: 130 }}>api_key</th>
+                  <th>{tr('可用模型', 'Models')}</th>
+                  <th style={{ width: 80 }}>{tr('状态', 'Status')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {effective.providers.map((p) => {
+                  const models = p.models ?? [];
+                  return (
+                    <tr key={p.id}>
+                      <td>
+                        <div className="row gap6" style={{ alignItems: 'center' }}>
+                          <span style={{ fontSize: 12, fontWeight: 650 }}>{p.name}</span>
+                          <span className="pill sm mono" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>{p.kind}</span>
                         </div>
-                      )}
-                    </td>
-                    <td>
-                      <span className="pill sm" style={p.enabled
-                        ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
-                        : { background: 'var(--surface-3)', color: 'var(--text-3)' }}>
-                        {p.enabled ? tr('启用', 'Enabled') : tr('停用', 'Disabled')}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                        <div className="mono" title={p.base_url ?? undefined}
+                          style={{ fontSize: 10.5, color: 'var(--text-3)', maxWidth: 210, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {p.base_url ?? '—'}
+                        </div>
+                      </td>
+                      <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{p.api_key_masked ?? '—'}</td>
+                      <td>
+                        {models.length === 0 ? (
+                          <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('（未填写）', '(none)')}</span>
+                        ) : (
+                          <div className="row gap6" style={{ flexWrap: 'wrap' }}>
+                            {models.map((m) => (
+                              <span key={m} className="tag mono" style={{ fontSize: 10.5 }}>{m}</span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td>
+                        <span className="pill sm" style={p.enabled
+                          ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+                          : { background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+                          {p.enabled ? tr('启用', 'Enabled') : tr('停用', 'Disabled')}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
@@ -1734,34 +1744,36 @@ function ManagedEffectiveView({ effective }: { effective: LlmSelfConfig }) {
         {effective.routes.length === 0 ? (
           <div className="empty" style={{ padding: 24 }}>{tr('管理员尚未配置路由表', 'The admin has not configured any routing yet')}</div>
         ) : (
-          <table className="table">
-            <thead>
-              <tr>
-                <th style={{ width: 180 }}>{tr('环节', 'Stage')}</th>
-                <th style={{ width: 170 }}>provider</th>
-                <th>model</th>
-                <th style={{ width: 100 }}>temperature</th>
-              </tr>
-            </thead>
-            <tbody>
-              {effective.routes.map((r) => {
-                const label = STAGE_LABELS[r.stage];
-                return (
-                  <tr key={r.stage}>
-                    <td>
-                      <div style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : r.stage}</div>
-                      <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{r.stage}</div>
-                    </td>
-                    <td style={{ fontSize: 12 }}>{providerName(r.provider_id)}</td>
-                    <td className="mono" style={{ fontSize: 11.5 }}>{r.model}</td>
-                    <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
-                      {r.temperature === null || r.temperature === undefined ? tr('默认', 'default') : r.temperature}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th style={{ width: 180 }}>{tr('环节', 'Stage')}</th>
+                  <th style={{ width: 170 }}>provider</th>
+                  <th>model</th>
+                  <th style={{ width: 100 }}>temperature</th>
+                </tr>
+              </thead>
+              <tbody>
+                {effective.routes.map((r) => {
+                  const label = STAGE_LABELS[r.stage];
+                  return (
+                    <tr key={r.stage}>
+                      <td>
+                        <div style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : r.stage}</div>
+                        <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{r.stage}</div>
+                      </td>
+                      <td style={{ fontSize: 12 }}>{providerName(r.provider_id)}</td>
+                      <td className="mono" style={{ fontSize: 11.5 }}>{r.model}</td>
+                      <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                        {r.temperature === null || r.temperature === undefined ? tr('默认', 'default') : r.temperature}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </>
@@ -1867,45 +1879,47 @@ function MyModelStatusSection({ config }: { config: LlmSelfConfig }) {
       {routes.length === 0 ? (
         <div className="empty" style={{ padding: 24 }}>{tr('还没有生效的模型路由', 'No routes in effect yet')}</div>
       ) : (
-        <table className="table">
-          <thead>
-            <tr>
-              <th style={{ width: 180 }}>{tr('环节', 'Stage')}</th>
-              <th>provider · model</th>
-              <th style={{ width: 220 }}>{tr('状态', 'Status')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {routes.map((r) => {
-              const label = STAGE_LABELS[r.stage];
-              const state = results[r.stage];
-              return (
-                <tr key={r.stage}>
-                  <td>
-                    <div style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : r.stage}</div>
-                    <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{r.stage}</div>
-                  </td>
-                  <td className="mono" style={{ fontSize: 11.5 }}>
-                    {providerName(r.provider_id)}
-                    <span style={{ color: 'var(--text-3)' }}> · {r.model}</span>
-                  </td>
-                  <td>
-                    <div className="row gap8" style={{ alignItems: 'center' }}>
-                      <button
-                        className="btn btn-soft sm"
-                        disabled={testingAll || state?.status === 'testing'}
-                        onClick={() => void testOne(r.stage)}
-                      >
-                        {tr('测试', 'Test')}
-                      </button>
-                      {renderResult(state)}
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th style={{ width: 180 }}>{tr('环节', 'Stage')}</th>
+                <th>provider · model</th>
+                <th style={{ width: 220 }}>{tr('状态', 'Status')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {routes.map((r) => {
+                const label = STAGE_LABELS[r.stage];
+                const state = results[r.stage];
+                return (
+                  <tr key={r.stage}>
+                    <td>
+                      <div style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : r.stage}</div>
+                      <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{r.stage}</div>
+                    </td>
+                    <td className="mono" style={{ fontSize: 11.5 }}>
+                      {providerName(r.provider_id)}
+                      <span style={{ color: 'var(--text-3)' }}> · {r.model}</span>
+                    </td>
+                    <td>
+                      <div className="row gap8" style={{ alignItems: 'center' }}>
+                        <button
+                          className="btn btn-soft sm"
+                          disabled={testingAll || state?.status === 'testing'}
+                          onClick={() => void testOne(r.stage)}
+                        >
+                          {tr('测试', 'Test')}
+                        </button>
+                        {renderResult(state)}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
@@ -2086,36 +2100,38 @@ export function UsageTab() {
       ) : rows.length === 0 ? (
         <div className="empty" style={{ padding: 24 }}>{tr(`近 ${days} 天暂无用量记录`, `No usage records in the last ${days} days`)}</div>
       ) : (
-        <table className="table">
-          <thead>
-            <tr>
-              <th>{tr('日期', 'Date')}</th>
-              <th>stage</th>
-              <th>model</th>
-              <th style={{ textAlign: 'right' }}>prompt tok</th>
-              <th style={{ textAlign: 'right' }}>completion tok</th>
-              <th style={{ textAlign: 'right' }}>calls</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r, i) => (
-              <tr key={i}>
-                <td className="mono" style={{ fontSize: 11.5 }}>{r.date}</td>
-                <td className="mono" style={{ fontSize: 11.5 }}>{r.stage}</td>
-                <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{r.model}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.prompt_tokens.toLocaleString()}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.completion_tokens.toLocaleString()}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.calls.toLocaleString()}</td>
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>{tr('日期', 'Date')}</th>
+                <th>stage</th>
+                <th>model</th>
+                <th style={{ textAlign: 'right' }}>prompt tok</th>
+                <th style={{ textAlign: 'right' }}>completion tok</th>
+                <th style={{ textAlign: 'right' }}>calls</th>
               </tr>
-            ))}
-            <tr>
-              <td colSpan={3} style={{ fontWeight: 650 }}>{tr('合计', 'Total')}</td>
-              <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.prompt.toLocaleString()}</td>
-              <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.completion.toLocaleString()}</td>
-              <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.calls.toLocaleString()}</td>
-            </tr>
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i}>
+                  <td className="mono" style={{ fontSize: 11.5 }}>{r.date}</td>
+                  <td className="mono" style={{ fontSize: 11.5 }}>{r.stage}</td>
+                  <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{r.model}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.prompt_tokens.toLocaleString()}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.completion_tokens.toLocaleString()}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.calls.toLocaleString()}</td>
+                </tr>
+              ))}
+              <tr>
+                <td colSpan={3} style={{ fontWeight: 650 }}>{tr('合计', 'Total')}</td>
+                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.prompt.toLocaleString()}</td>
+                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.completion.toLocaleString()}</td>
+                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.calls.toLocaleString()}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
@@ -2196,36 +2212,38 @@ function MyUsageTab() {
         ) : rows.length === 0 ? (
           <div className="empty" style={{ padding: 24 }}>{tr(`近 ${days} 天暂无用量记录`, `No usage records in the last ${days} days`)}</div>
         ) : (
-          <table className="table">
-            <thead>
-              <tr>
-                <th>{tr('日期', 'Date')}</th>
-                <th>stage</th>
-                <th>model</th>
-                <th style={{ textAlign: 'right' }}>prompt tok</th>
-                <th style={{ textAlign: 'right' }}>completion tok</th>
-                <th style={{ textAlign: 'right' }}>calls</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r, i) => (
-                <tr key={i}>
-                  <td className="mono" style={{ fontSize: 11.5 }}>{r.date}</td>
-                  <td className="mono" style={{ fontSize: 11.5 }}>{r.stage}</td>
-                  <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{r.model}</td>
-                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.prompt_tokens.toLocaleString()}</td>
-                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.completion_tokens.toLocaleString()}</td>
-                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.calls.toLocaleString()}</td>
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>{tr('日期', 'Date')}</th>
+                  <th>stage</th>
+                  <th>model</th>
+                  <th style={{ textAlign: 'right' }}>prompt tok</th>
+                  <th style={{ textAlign: 'right' }}>completion tok</th>
+                  <th style={{ textAlign: 'right' }}>calls</th>
                 </tr>
-              ))}
-              <tr>
-                <td colSpan={3} style={{ fontWeight: 650 }}>{tr('合计', 'Total')}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.prompt.toLocaleString()}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.completion.toLocaleString()}</td>
-                <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.calls.toLocaleString()}</td>
-              </tr>
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <tr key={i}>
+                    <td className="mono" style={{ fontSize: 11.5 }}>{r.date}</td>
+                    <td className="mono" style={{ fontSize: 11.5 }}>{r.stage}</td>
+                    <td className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{r.model}</td>
+                    <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.prompt_tokens.toLocaleString()}</td>
+                    <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.completion_tokens.toLocaleString()}</td>
+                    <td className="mono" style={{ fontSize: 11.5, textAlign: 'right' }}>{r.calls.toLocaleString()}</td>
+                  </tr>
+                ))}
+                <tr>
+                  <td colSpan={3} style={{ fontWeight: 650 }}>{tr('合计', 'Total')}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.prompt.toLocaleString()}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.completion.toLocaleString()}</td>
+                  <td className="mono" style={{ fontSize: 11.5, textAlign: 'right', fontWeight: 650 }}>{totals.calls.toLocaleString()}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </>
@@ -2957,98 +2975,100 @@ export function UsersTab() {
         </div>
       </div>
       <div className="card" style={{ overflow: 'hidden' }}>
-        <table className="table">
-          <thead>
-            <tr>
-              <th style={{ width: 34 }}>
-                <input
-                  type="checkbox"
-                  checked={allChecked}
-                  onChange={() => setChecked(allChecked ? new Set() : new Set(users.map((u) => u.id)))}
-                />
-              </th>
-              <th>{tr('用户', 'User')}</th>
-              <th>{tr('角色', 'Role')}</th>
-              <th>{tr('状态', 'Status')}</th>
-              <th>{tr('AI 用量 / 配额', 'AI usage / quota')}</th>
-              <th>{tr('大模型', 'LLM')}</th>
-              <th>{tr('LLM 接管', 'LLM takeover')}</th>
-              <th>{tr('功能权限', 'Features')}</th>
-              <th style={{ width: 108 }}></th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map((u) => (
-              <tr key={u.id}>
-                <td>
-                  <input type="checkbox" checked={checked.has(u.id)} onChange={() => toggle(u.id)} />
-                </td>
-                <td>
-                  <div className="row gap10">
-                    <Avatar userId={u.id} hasAvatar={u.has_avatar} name={u.display_name || u.email} size={26} />
-                    <div>
-                      <div style={{ fontSize: 12.5, fontWeight: 600 }}>
-                        {u.display_name || '—'}
-                        {u.username && <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', fontWeight: 400, marginLeft: 6 }}>@{u.username}</span>}
-                      </div>
-                      <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{u.email}</div>
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <span className="pill sm" style={u.role === 'admin' ? { background: 'var(--accent-soft)', color: 'var(--accent-text)' } : undefined}>
-                    {u.role === 'admin' ? tr('管理员', 'Admin') : tr('成员', 'Member')}
-                  </span>
-                </td>
-                <td>
-                  <span className="pill sm" style={{ background: u.is_active ? 'var(--ok-bg)' : 'var(--surface-3)', color: u.is_active ? 'var(--ok-tx)' : 'var(--text-3)' }}>
-                    {u.is_active ? tr('启用', 'Active') : tr('停用', 'Disabled')}
-                  </span>
-                </td>
-                <td className="mono" style={{ fontSize: 11.5 }}>
-                  {u.tokens_used.toLocaleString()}
-                  <span style={{ color: 'var(--text-3)' }}> / {u.token_quota != null ? u.token_quota.toLocaleString() : tr('不限', 'unlimited')}</span>
-                </td>
-                <td style={{ fontSize: 11.5, color: 'var(--text-2)' }}>
-                  {u.llm_access === 'blocked' ? tr('锁定', 'Blocked') : u.llm_access === 'chat_only' ? tr('仅对话', 'Chat only') : tr('不限', 'Unrestricted')}
-                </td>
-                <td>
-                  <span
-                    className="pill sm"
-                    role="button"
-                    title={u.llm_self_managed
-                      ? tr('该用户自管 LLM，点击改为管理员接管', 'User manages their own LLM; click to take over')
-                      : tr('由管理员接管，点击释放给用户自管', 'Managed by admin; click to release to the user')}
-                    style={{
-                      cursor: takeoverMutation.isPending ? 'default' : 'pointer',
-                      ...(u.llm_self_managed
-                        ? { background: 'var(--surface-3)', color: 'var(--text-3)' }
-                        : { background: 'var(--accent-soft)', color: 'var(--accent-text)' }),
-                    }}
-                    onClick={() => { if (!takeoverMutation.isPending) takeoverMutation.mutate(u); }}
-                  >
-                    {u.llm_self_managed ? tr('已释放', 'Released') : tr('接管中', 'Managed')}
-                  </span>
-                </td>
-                <td style={{ fontSize: 11.5, color: 'var(--text-2)' }}>{featureSummary(u)}</td>
-                <td>
-                  <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
-                    <button className="btn btn-ghost sm" onClick={() => setEditing(u)}>{tr('编辑', 'Edit')}</button>
-                    {me?.id === u.id ? (
-                      <button className="icon-btn" disabled title={tr('不能删除自己的账号', 'You cannot delete your own account')} style={{ opacity: 0.4 }}>
-                        <Icon name="trash" size={15} />
-                      </button>
-                    ) : (
-                      <button className="icon-btn" title={tr('删除用户', 'Delete user')} style={{ color: 'var(--danger-tx)' }} onClick={() => setDeleting(u)}>
-                        <Icon name="trash" size={15} />
-                      </button>
-                    )}
-                  </div>
-                </td>
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th style={{ width: 34 }}>
+                  <input
+                    type="checkbox"
+                    checked={allChecked}
+                    onChange={() => setChecked(allChecked ? new Set() : new Set(users.map((u) => u.id)))}
+                  />
+                </th>
+                <th>{tr('用户', 'User')}</th>
+                <th>{tr('角色', 'Role')}</th>
+                <th>{tr('状态', 'Status')}</th>
+                <th>{tr('AI 用量 / 配额', 'AI usage / quota')}</th>
+                <th>{tr('大模型', 'LLM')}</th>
+                <th>{tr('LLM 接管', 'LLM takeover')}</th>
+                <th>{tr('功能权限', 'Features')}</th>
+                <th style={{ width: 108 }}></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {users.map((u) => (
+                <tr key={u.id}>
+                  <td>
+                    <input type="checkbox" checked={checked.has(u.id)} onChange={() => toggle(u.id)} />
+                  </td>
+                  <td>
+                    <div className="row gap10">
+                      <Avatar userId={u.id} hasAvatar={u.has_avatar} name={u.display_name || u.email} size={26} />
+                      <div>
+                        <div style={{ fontSize: 12.5, fontWeight: 600 }}>
+                          {u.display_name || '—'}
+                          {u.username && <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', fontWeight: 400, marginLeft: 6 }}>@{u.username}</span>}
+                        </div>
+                        <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{u.email}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span className="pill sm" style={u.role === 'admin' ? { background: 'var(--accent-soft)', color: 'var(--accent-text)' } : undefined}>
+                      {u.role === 'admin' ? tr('管理员', 'Admin') : tr('成员', 'Member')}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="pill sm" style={{ background: u.is_active ? 'var(--ok-bg)' : 'var(--surface-3)', color: u.is_active ? 'var(--ok-tx)' : 'var(--text-3)' }}>
+                      {u.is_active ? tr('启用', 'Active') : tr('停用', 'Disabled')}
+                    </span>
+                  </td>
+                  <td className="mono" style={{ fontSize: 11.5 }}>
+                    {u.tokens_used.toLocaleString()}
+                    <span style={{ color: 'var(--text-3)' }}> / {u.token_quota != null ? u.token_quota.toLocaleString() : tr('不限', 'unlimited')}</span>
+                  </td>
+                  <td style={{ fontSize: 11.5, color: 'var(--text-2)' }}>
+                    {u.llm_access === 'blocked' ? tr('锁定', 'Blocked') : u.llm_access === 'chat_only' ? tr('仅对话', 'Chat only') : tr('不限', 'Unrestricted')}
+                  </td>
+                  <td>
+                    <span
+                      className="pill sm"
+                      role="button"
+                      title={u.llm_self_managed
+                        ? tr('该用户自管 LLM，点击改为管理员接管', 'User manages their own LLM; click to take over')
+                        : tr('由管理员接管，点击释放给用户自管', 'Managed by admin; click to release to the user')}
+                      style={{
+                        cursor: takeoverMutation.isPending ? 'default' : 'pointer',
+                        ...(u.llm_self_managed
+                          ? { background: 'var(--surface-3)', color: 'var(--text-3)' }
+                          : { background: 'var(--accent-soft)', color: 'var(--accent-text)' }),
+                      }}
+                      onClick={() => { if (!takeoverMutation.isPending) takeoverMutation.mutate(u); }}
+                    >
+                      {u.llm_self_managed ? tr('已释放', 'Released') : tr('接管中', 'Managed')}
+                    </span>
+                  </td>
+                  <td style={{ fontSize: 11.5, color: 'var(--text-2)' }}>{featureSummary(u)}</td>
+                  <td>
+                    <div className="row gap6" style={{ justifyContent: 'flex-end' }}>
+                      <button className="btn btn-ghost sm" onClick={() => setEditing(u)}>{tr('编辑', 'Edit')}</button>
+                      {me?.id === u.id ? (
+                        <button className="icon-btn" disabled title={tr('不能删除自己的账号', 'You cannot delete your own account')} style={{ opacity: 0.4 }}>
+                          <Icon name="trash" size={15} />
+                        </button>
+                      ) : (
+                        <button className="icon-btn" title={tr('删除用户', 'Delete user')} style={{ color: 'var(--danger-tx)' }} onClick={() => setDeleting(u)}>
+                          <Icon name="trash" size={15} />
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
       {editing && <UserEditModal u={editing} onClose={() => setEditing(null)} />}
       {deleting && <DeleteUserModal u={deleting} onClose={() => setDeleting(null)} />}
@@ -3215,71 +3235,73 @@ export function CodesTab() {
         <div className="empty">{tr('还没有注册码，点右上角生成一个', 'No codes yet — generate one from the top right')}</div>
       ) : (
         <div style={{ overflowX: 'auto' }}>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>{tr('注册码', 'Code')}</th>
-                <th>{tr('备注', 'Note')}</th>
-                <th>{tr('预设课题', 'Topics')}</th>
-                <th>{tr('使用', 'Uses')}</th>
-                <th>{tr('有效期', 'Expiry')}</th>
-                <th>{tr('状态', 'Status')}</th>
-                <th style={{ textAlign: 'right' }}>{tr('操作', 'Actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {codes.map((c: RegistrationCodeRead) => {
-                const [zh, en, color] = CODE_STATUS_LABEL[c.status] ?? [c.status, c.status, 'var(--text-3)'];
-                return (
-                  <tr key={c.id}>
-                    <td>
-                      <button
-                        className="btn btn-ghost sm"
-                        style={{ fontFamily: 'var(--mono)', fontWeight: 600 }}
-                        title={tr('点击复制', 'Click to copy')}
-                        onClick={() => copy(c.code)}
-                      >
-                        {c.code} <Icon name="link" size={12} style={{ opacity: 0.6 }} />
-                      </button>
-                    </td>
-                    <td style={{ color: c.note ? 'var(--text)' : 'var(--text-4)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {c.note || '—'}
-                    </td>
-                    <td
-                      style={{ color: c.preset_directions.length ? 'var(--text)' : 'var(--text-4)', maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                      title={c.preset_directions.join('\n')}
-                    >
-                      {c.preset_directions.length ? c.preset_directions.join('；') : '—'}
-                    </td>
-                    <td style={{ fontFamily: 'var(--mono)' }}>
-                      {c.used_count}
-                      {c.max_uses != null ? ` / ${c.max_uses}` : tr(' / 不限', ' / ∞')}
-                    </td>
-                    <td style={{ fontSize: 12, color: 'var(--text-3)' }}>
-                      {c.expires_at ? fmtTime(c.expires_at) : tr('永久', 'Never')}
-                    </td>
-                    <td>
-                      <span className="pill" style={{ color, borderColor: 'var(--border)' }}>
-                        <span className="dot" style={{ background: color }} />
-                        {tr(zh, en)}
-                      </span>
-                    </td>
-                    <td style={{ textAlign: 'right' }}>
-                      {!c.revoked && (
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>{tr('注册码', 'Code')}</th>
+                  <th>{tr('备注', 'Note')}</th>
+                  <th>{tr('预设课题', 'Topics')}</th>
+                  <th>{tr('使用', 'Uses')}</th>
+                  <th>{tr('有效期', 'Expiry')}</th>
+                  <th>{tr('状态', 'Status')}</th>
+                  <th style={{ textAlign: 'right' }}>{tr('操作', 'Actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {codes.map((c: RegistrationCodeRead) => {
+                  const [zh, en, color] = CODE_STATUS_LABEL[c.status] ?? [c.status, c.status, 'var(--text-3)'];
+                  return (
+                    <tr key={c.id}>
+                      <td>
                         <button
                           className="btn btn-ghost sm"
-                          disabled={revokeMutation.isPending}
-                          onClick={() => revokeMutation.mutate(c.id)}
+                          style={{ fontFamily: 'var(--mono)', fontWeight: 600 }}
+                          title={tr('点击复制', 'Click to copy')}
+                          onClick={() => copy(c.code)}
                         >
-                          {tr('停用', 'Revoke')}
+                          {c.code} <Icon name="link" size={12} style={{ opacity: 0.6 }} />
                         </button>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                      </td>
+                      <td style={{ color: c.note ? 'var(--text)' : 'var(--text-4)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {c.note || '—'}
+                      </td>
+                      <td
+                        style={{ color: c.preset_directions.length ? 'var(--text)' : 'var(--text-4)', maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        title={c.preset_directions.join('\n')}
+                      >
+                        {c.preset_directions.length ? c.preset_directions.join('；') : '—'}
+                      </td>
+                      <td style={{ fontFamily: 'var(--mono)' }}>
+                        {c.used_count}
+                        {c.max_uses != null ? ` / ${c.max_uses}` : tr(' / 不限', ' / ∞')}
+                      </td>
+                      <td style={{ fontSize: 12, color: 'var(--text-3)' }}>
+                        {c.expires_at ? fmtTime(c.expires_at) : tr('永久', 'Never')}
+                      </td>
+                      <td>
+                        <span className="pill" style={{ color, borderColor: 'var(--border)' }}>
+                          <span className="dot" style={{ background: color }} />
+                          {tr(zh, en)}
+                        </span>
+                      </td>
+                      <td style={{ textAlign: 'right' }}>
+                        {!c.revoked && (
+                          <button
+                            className="btn btn-ghost sm"
+                            disabled={revokeMutation.isPending}
+                            onClick={() => revokeMutation.mutate(c.id)}
+                          >
+                            {tr('停用', 'Revoke')}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -10,6 +10,7 @@ import { FormField } from '../../components/ui/FormField';
 import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
 import { tr } from '../../lib/i18n';
+import { useIsCompact } from '../../lib/useBreakpoint';
 import { useProject } from '../../app/project';
 import {
   api,
@@ -890,6 +891,7 @@ function EnabledPanel({ projectId }: { projectId: string }) {
 // ---- 页面 ----
 
 export function SkillsPage() {
+  const compact = useIsCompact();
   const queryClient = useQueryClient();
   const { currentProjectId } = useProject();
   const [view, setView] = useState<'library' | 'market'>('library');
@@ -1002,7 +1004,8 @@ export function SkillsPage() {
       <div
         style={{
           display: view === 'library' ? 'grid' : 'none',
-          gridTemplateColumns: 'minmax(0, 1fr) 320px',
+          // 窄屏放不下 320px 侧栏，改单列上下排（内联样式吃不到媒体查询，走 JS 断点）
+          gridTemplateColumns: compact ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) 320px',
           gap: 18,
           alignItems: 'start',
         }}

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -218,6 +218,8 @@ export function VoyagesList() {
             </div>
           ) : (
             <div className="card" style={{ overflow: 'hidden' }}>
+              {/* 行内定宽列合计放不下窄屏，整块横滚而不是把中间的标题列挤成 0 宽 */}
+              <div className="table-wrap">
               {voyages.map((v, i) => {
                 const active = !VOYAGE_TERMINAL.has(v.status);
                 const running = RUNNING_STATUSES.has(v.status);
@@ -263,6 +265,7 @@ export function VoyagesList() {
                   </div>
                 );
               })}
+              </div>
             </div>
           )}
     </>

--- a/src/frontend/src/features/wiki/ConceptsTab.tsx
+++ b/src/frontend/src/features/wiki/ConceptsTab.tsx
@@ -329,7 +329,7 @@ export function ConceptsTab({ pid, libraryId, selectedId, onSelect, onOpenPaper,
           />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
-            {tr('从左侧选择一个概念', 'Pick a concept from the list')}
+            {tr('从列表中选择一个概念', 'Pick a concept from the list')}
           </div>
         )}
       </div>

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -1883,7 +1883,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
           />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
-            {tr('从左侧选择一篇论文', 'Pick a paper from the list')}
+            {tr('从列表中选择一篇论文', 'Pick a paper from the list')}
           </div>
         )}
       </div>

--- a/src/frontend/src/features/writer/FactPackDrawer.tsx
+++ b/src/frontend/src/features/writer/FactPackDrawer.tsx
@@ -119,28 +119,30 @@ export function FactPackDrawer({ open, onClose, manuscript, canInsert, onInsertC
           {metrics.length === 0 ? (
             <div style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('暂无实验指标', 'No experiment metrics')}</div>
           ) : (
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>{tr('指标', 'Metric')}</th>
-                  <th style={{ textAlign: 'right' }}>{tr('最优值', 'Best')}</th>
-                  <th style={{ textAlign: 'right' }}>{tr('轮数', 'Runs')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {metrics.map((m) => (
-                  <tr key={m.name}>
-                    <td className="mono" style={{ fontSize: 11.5 }}>{m.name}</td>
-                    <td className="mono" style={{ textAlign: 'right', fontWeight: 650 }}>
-                      {m.best ?? '—'}
-                    </td>
-                    <td className="mono" style={{ textAlign: 'right', color: 'var(--text-3)' }}>
-                      {m.runs?.length ?? 0}
-                    </td>
+            <div className="table-wrap">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>{tr('指标', 'Metric')}</th>
+                    <th style={{ textAlign: 'right' }}>{tr('最优值', 'Best')}</th>
+                    <th style={{ textAlign: 'right' }}>{tr('轮数', 'Runs')}</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {metrics.map((m) => (
+                    <tr key={m.name}>
+                      <td className="mono" style={{ fontSize: 11.5 }}>{m.name}</td>
+                      <td className="mono" style={{ textAlign: 'right', fontWeight: 650 }}>
+                        {m.best ?? '—'}
+                      </td>
+                      <td className="mono" style={{ textAlign: 'right', color: 'var(--text-3)' }}>
+                        {m.runs?.length ?? 0}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
 
           {/* —— 图表 —— */}

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -913,301 +913,303 @@ export function WriterEditorPage() {
       )}
 
       {/* —— 三栏（可拖拽调宽 / 可收起） —— */}
-      <div ref={splitRef} style={{ flex: 1, minHeight: 0, display: 'flex' }}>
-        {/* 左：文件树 */}
-        {layout.leftOpen && (
-          <div
-            style={{
-              width: layout.leftW,
-              flexShrink: 0,
-              borderRight: '0.5px solid var(--border)',
-              background: 'var(--sidebar-bg)',
-              minHeight: 0,
-              overflow: 'hidden',
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-              <FileTree
-                files={ms.files}
-                currentId={currentFileId}
-                busy={fileOpsBusy}
-                onSelect={(f) => setCurrentFileId(f.id)}
-                onCreate={(path) => createFileMutation.mutate(path)}
-                onCreateFolder={(path) => createFolderMutation.mutate(path)}
-                onUpload={(file) => uploadFileMutation.mutate(file)}
-                onRename={(f, path) => renameFileMutation.mutate({ fid: f.id, path })}
-                onDelete={(f) => deleteFileMutation.mutate(f.id)}
+      <div className="workbench-panx" style={{ flex: 1, minHeight: 0 }}>
+        <div ref={splitRef} className="workbench-panx-inner" style={{ height: '100%', display: 'flex' }}>
+          {/* 左：文件树 */}
+          {layout.leftOpen && (
+            <div
+              style={{
+                width: layout.leftW,
+                flexShrink: 0,
+                borderRight: '0.5px solid var(--border)',
+                background: 'var(--sidebar-bg)',
+                minHeight: 0,
+                overflow: 'hidden',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                <FileTree
+                  files={ms.files}
+                  currentId={currentFileId}
+                  busy={fileOpsBusy}
+                  onSelect={(f) => setCurrentFileId(f.id)}
+                  onCreate={(path) => createFileMutation.mutate(path)}
+                  onCreateFolder={(path) => createFolderMutation.mutate(path)}
+                  onUpload={(file) => uploadFileMutation.mutate(file)}
+                  onRename={(f, path) => renameFileMutation.mutate({ fid: f.id, path })}
+                  onDelete={(f) => deleteFileMutation.mutate(f.id)}
+                />
+              </div>
+              <OutlinePanel
+                content={docContent}
+                open={layout.outlineOpen}
+                onToggle={() => patchLayout({ outlineOpen: !layout.outlineOpen })}
+                onJump={(line) => {
+                  if (view) jumpToLine(view, line);
+                }}
               />
             </div>
-            <OutlinePanel
-              content={docContent}
-              open={layout.outlineOpen}
-              onToggle={() => patchLayout({ outlineOpen: !layout.outlineOpen })}
-              onJump={(line) => {
-                if (view) jumpToLine(view, line);
-              }}
-            />
-          </div>
-        )}
-        <Gutter
-          dragging={dragging === 'left'}
-          onMouseDown={layout.leftOpen ? onLeftGutterDown : undefined}
-          onReset={() => patchLayout({ leftW: DEFAULT_LAYOUT.leftW })}
-          collapsed={!layout.leftOpen}
-          onToggle={() => patchLayout({ leftOpen: !layout.leftOpen })}
-          toggleTitle={layout.leftOpen ? tr('收起文件列表', 'Collapse file list') : tr('展开文件列表', 'Expand file list')}
-          chevronDeg={layout.leftOpen ? 180 : 0}
-        />
+          )}
+          <Gutter
+            dragging={dragging === 'left'}
+            onMouseDown={layout.leftOpen ? onLeftGutterDown : undefined}
+            onReset={() => patchLayout({ leftW: DEFAULT_LAYOUT.leftW })}
+            collapsed={!layout.leftOpen}
+            onToggle={() => patchLayout({ leftOpen: !layout.leftOpen })}
+            toggleTitle={layout.leftOpen ? tr('收起文件列表', 'Collapse file list') : tr('展开文件列表', 'Expand file list')}
+            chevronDeg={layout.leftOpen ? 180 : 0}
+          />
 
-        {/* 中：编辑器 */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, background: 'var(--surface)' }}>
-          {currentFile ? (
-            currentFile.is_binary ? (
+          {/* 中：编辑器 */}
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, background: 'var(--surface)' }}>
+            {currentFile ? (
+              currentFile.is_binary ? (
+                <>
+                  <div
+                    className="row gap8"
+                    style={{ padding: '6px 14px', borderBottom: '0.5px solid var(--border)', flexShrink: 0 }}
+                  >
+                    <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>{currentFile.path}</span>
+                    <span className="pill sm" style={{ height: 17, fontSize: 9.5 }}>{tr('二进制文件', 'binary')}</span>
+                  </div>
+                  <BinaryPreview manuscriptId={ms.id} file={currentFile} />
+                </>
+              ) : (
               <>
                 <div
                   className="row gap8"
                   style={{ padding: '6px 14px', borderBottom: '0.5px solid var(--border)', flexShrink: 0 }}
                 >
                   <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>{currentFile.path}</span>
-                  <span className="pill sm" style={{ height: 17, fontSize: 9.5 }}>{tr('二进制文件', 'binary')}</span>
+                  {currentFile.readonly && (
+                    <span className="pill sm" style={{ height: 17, fontSize: 9.5 }}>{tr('只读', 'read-only')}</span>
+                  )}
+                  <button
+                    className="writer-mini-btn"
+                    style={{ marginLeft: 'auto' }}
+                    title={tr('查找 / 替换（⌘F）', 'Find / replace (⌘F)')}
+                    disabled={!view}
+                    onClick={() => view && openSearchPanel(view)}
+                  >
+                    <Icon name="search" size={11} />
+                  </button>
+                  <button
+                    className="writer-mini-btn"
+                    title={tr('版本历史（AI 写入前 / 每次编译自动存档）', 'Version history (auto-saved before each AI write and on every compile)')}
+                    onClick={() => setHistoryOpen(true)}
+                  >
+                    <Icon name="clock" size={11} />
+                  </button>
+                  <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+                    {tr('⌘S 编译', '⌘S to compile')}
+                  </span>
                 </div>
-                <BinaryPreview manuscriptId={ms.id} file={currentFile} />
-              </>
-            ) : (
-            <>
-              <div
-                className="row gap8"
-                style={{ padding: '6px 14px', borderBottom: '0.5px solid var(--border)', flexShrink: 0 }}
-              >
-                <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>{currentFile.path}</span>
-                {currentFile.readonly && (
-                  <span className="pill sm" style={{ height: 17, fontSize: 9.5 }}>{tr('只读', 'read-only')}</span>
-                )}
-                <button
-                  className="writer-mini-btn"
-                  style={{ marginLeft: 'auto' }}
-                  title={tr('查找 / 替换（⌘F）', 'Find / replace (⌘F)')}
-                  disabled={!view}
-                  onClick={() => view && openSearchPanel(view)}
-                >
-                  <Icon name="search" size={11} />
-                </button>
-                <button
-                  className="writer-mini-btn"
-                  title={tr('版本历史（AI 写入前 / 每次编译自动存档）', 'Version history (auto-saved before each AI write and on every compile)')}
-                  onClick={() => setHistoryOpen(true)}
-                >
-                  <Icon name="clock" size={11} />
-                </button>
-                <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
-                  {tr('⌘S 编译', '⌘S to compile')}
-                </span>
-              </div>
-              <EditorPane
-                key={currentFile.id}
-                manuscriptId={ms.id}
-                fileId={currentFile.id}
-                readonly={!!currentFile.readonly}
-                user={user}
-                onCompile={handleCompileShortcut}
-                onStatus={handleStatus}
-                onPeers={handlePeers}
-                onView={handleView}
-                onDocChange={handleDocChange}
-                aiTarget={aiTarget}
-              />
-              {/* 编辑器下方：内联 AI（润色 / 改写 / 续写）操作条 */}
-              {!currentFile.readonly && (
-                <div
-                  className="row gap6"
-                  style={{
-                    padding: '6px 14px',
-                    borderTop: '0.5px solid var(--border)',
-                    background: 'var(--surface-2)',
-                    flexShrink: 0,
-                  }}
-                >
-                  <span
-                    className="mono"
-                    title={writingModel ? tr(`当前撰写模型：${writingModel}`, `Current writing model: ${writingModel}`) : tr('撰写模型（未知）', 'Writing model (unknown)')}
+                <EditorPane
+                  key={currentFile.id}
+                  manuscriptId={ms.id}
+                  fileId={currentFile.id}
+                  readonly={!!currentFile.readonly}
+                  user={user}
+                  onCompile={handleCompileShortcut}
+                  onStatus={handleStatus}
+                  onPeers={handlePeers}
+                  onView={handleView}
+                  onDocChange={handleDocChange}
+                  aiTarget={aiTarget}
+                />
+                {/* 编辑器下方：内联 AI（润色 / 改写 / 续写）操作条 */}
+                {!currentFile.readonly && (
+                  <div
+                    className="row gap6"
                     style={{
-                      fontSize: 10.5,
-                      fontWeight: 600,
-                      color: 'var(--text-3)',
-                      marginRight: 4,
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 4,
-                      maxWidth: 200,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
+                      padding: '6px 14px',
+                      borderTop: '0.5px solid var(--border)',
+                      background: 'var(--surface-2)',
+                      flexShrink: 0,
                     }}
                   >
-                    <Icon name="sparkle" size={11} style={{ flexShrink: 0, color: 'var(--accent)' }} />
-                    {writingModel ?? (routesQuery.isLoading ? tr('模型加载中…', 'Loading model…') : tr('AI 辅助', 'AI assist'))}
-                  </span>
-                  <button
-                    className="btn btn-ghost sm"
-                    style={{ height: 24, fontSize: 11 }}
-                    disabled={isWriting}
-                    title={isWriting ? tr('AI 正在起草中', 'AI is drafting') : tr('AI 按事实包起草各节', 'AI drafts sections from the fact pack')}
-                    onClick={() => setDraftOpen(true)}
-                  >
-                    <Icon name="sparkle" size={11} />
-                    {isWriting ? tr('AI 起草中…', 'AI drafting…') : tr('AI 起草', 'AI draft')}
-                  </button>
-                  {(['polish', 'rewrite', 'continue'] as const).map((m) => (
+                    <span
+                      className="mono"
+                      title={writingModel ? tr(`当前撰写模型：${writingModel}`, `Current writing model: ${writingModel}`) : tr('撰写模型（未知）', 'Writing model (unknown)')}
+                      style={{
+                        fontSize: 10.5,
+                        fontWeight: 600,
+                        color: 'var(--text-3)',
+                        marginRight: 4,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 4,
+                        maxWidth: 200,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      <Icon name="sparkle" size={11} style={{ flexShrink: 0, color: 'var(--accent)' }} />
+                      {writingModel ?? (routesQuery.isLoading ? tr('模型加载中…', 'Loading model…') : tr('AI 辅助', 'AI assist'))}
+                    </span>
                     <button
-                      key={m}
-                      className={`btn sm ${assistMode === m ? 'btn-soft' : 'btn-ghost'}`}
+                      className="btn btn-ghost sm"
                       style={{ height: 24, fontSize: 11 }}
-                      disabled={!view || isWriting}
-                      title={
-                        m === 'continue'
-                          ? tr('AI 从光标处向后续写', 'AI continues from the cursor')
-                          : m === 'polish'
-                            ? tr('选中一段文字后 AI 润色', 'Select text, then AI polishes it')
-                            : tr('选中一段文字后 AI 按要求改写', 'Select text, then AI rewrites it as instructed')
-                      }
-                      onClick={() => setAssistMode((cur) => (cur === m ? null : m))}
+                      disabled={isWriting}
+                      title={isWriting ? tr('AI 正在起草中', 'AI is drafting') : tr('AI 按事实包起草各节', 'AI drafts sections from the fact pack')}
+                      onClick={() => setDraftOpen(true)}
                     >
                       <Icon name="sparkle" size={11} />
-                      {m === 'polish' ? tr('润色', 'Polish') : m === 'rewrite' ? tr('改写', 'Rewrite') : tr('续写', 'Continue')}
+                      {isWriting ? tr('AI 起草中…', 'AI drafting…') : tr('AI 起草', 'AI draft')}
                     </button>
-                  ))}
+                    {(['polish', 'rewrite', 'continue'] as const).map((m) => (
+                      <button
+                        key={m}
+                        className={`btn sm ${assistMode === m ? 'btn-soft' : 'btn-ghost'}`}
+                        style={{ height: 24, fontSize: 11 }}
+                        disabled={!view || isWriting}
+                        title={
+                          m === 'continue'
+                            ? tr('AI 从光标处向后续写', 'AI continues from the cursor')
+                            : m === 'polish'
+                              ? tr('选中一段文字后 AI 润色', 'Select text, then AI polishes it')
+                              : tr('选中一段文字后 AI 按要求改写', 'Select text, then AI rewrites it as instructed')
+                        }
+                        onClick={() => setAssistMode((cur) => (cur === m ? null : m))}
+                      >
+                        <Icon name="sparkle" size={11} />
+                        {m === 'polish' ? tr('润色', 'Polish') : m === 'rewrite' ? tr('改写', 'Rewrite') : tr('续写', 'Continue')}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {assistMode && view && currentFile && !currentFile.readonly && (
+                  <AssistPanel
+                    key={`${currentFile.id}-${assistMode}`}
+                    manuscriptId={ms.id}
+                    mode={assistMode}
+                    view={view}
+                    onClose={() => setAssistMode(null)}
+                  />
+                )}
+              </>
+              )
+            ) : (
+              <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <EmptyState compact icon="file" title={tr('还没有文件', 'No files yet')} desc={tr('点左侧 + 号新建一个 .tex 文件开始写作。', 'Click + on the left to create a .tex file and start writing.')} />
+              </div>
+            )}
+          </div>
+
+          <Gutter
+            dragging={dragging === 'right'}
+            onMouseDown={layout.rightOpen ? onRightGutterDown : undefined}
+            onReset={() => patchLayout({ rightW: DEFAULT_LAYOUT.rightW })}
+            collapsed={!layout.rightOpen}
+            onToggle={() => patchLayout({ rightOpen: !layout.rightOpen })}
+            toggleTitle={layout.rightOpen ? tr('收起预览面板', 'Collapse preview panel') : tr('展开预览面板', 'Expand preview panel')}
+            chevronDeg={layout.rightOpen ? 0 : 180}
+          />
+
+          {/* 右：PDF 预览 + 诊断 */}
+          {layout.rightOpen && (
+            <div
+              ref={rightColRef}
+              style={{
+                width: layout.rightW,
+                flexShrink: 0,
+                borderLeft: '0.5px solid var(--border)',
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: 0,
+                overflow: 'hidden',
+              }}
+            >
+              {/* 上：PDF */}
+              <div
+                style={{
+                  flex: layout.pdfOpen ? `${layout.pdfFrac} 1 0px` : '0 0 auto',
+                  minHeight: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  borderBottom: '0.5px solid var(--border)',
+                }}
+              >
+                <div className="row gap8" style={{ padding: '6px 12px', flexShrink: 0, borderBottom: layout.pdfOpen ? '0.5px solid var(--border)' : 'none', background: 'var(--surface)' }}>
+                  <button
+                    className="writer-mini-btn"
+                    title={layout.pdfOpen ? tr('收起编译预览', 'Collapse PDF preview') : tr('展开编译预览', 'Expand PDF preview')}
+                    onClick={() => patchLayout({ pdfOpen: !layout.pdfOpen })}
+                  >
+                    <Icon name="chevDown" size={11} style={{ transform: layout.pdfOpen ? 'none' : 'rotate(-90deg)', transition: 'transform .12s' }} />
+                  </button>
+                  <span style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)' }}>{tr('编译预览 · PDF', 'PDF preview')}</span>
+                  {compile && (
+                    <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)', marginLeft: 'auto' }}>
+                      v{compile.version} · {fmtRelative(compile.compiled_at)} · {(compile.duration_ms / 1000).toFixed(1)}s
+                    </span>
+                  )}
                 </div>
-              )}
-              {assistMode && view && currentFile && !currentFile.readonly && (
-                <AssistPanel
-                  key={`${currentFile.id}-${assistMode}`}
-                  manuscriptId={ms.id}
-                  mode={assistMode}
-                  view={view}
-                  onClose={() => setAssistMode(null)}
+                {layout.pdfOpen && (
+                  // 拖动分栏时挡住 iframe，避免鼠标事件被它吞掉
+                  <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', pointerEvents: dragging ? 'none' : 'auto' }}>
+                    <PdfPane msId={ms.id} compile={compile} />
+                  </div>
+                )}
+              </div>
+
+              {layout.pdfOpen && layout.diagOpen && (
+                <Gutter
+                  horizontal
+                  dragging={dragging === 'pdf'}
+                  onMouseDown={onPdfGutterDown}
+                  onReset={() => patchLayout({ pdfFrac: DEFAULT_LAYOUT.pdfFrac })}
                 />
               )}
-            </>
-            )
-          ) : (
-            <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <EmptyState compact icon="file" title={tr('还没有文件', 'No files yet')} desc={tr('点左侧 + 号新建一个 .tex 文件开始写作。', 'Click + on the left to create a .tex file and start writing.')} />
+
+              {/* 下：诊断 */}
+              <div
+                style={{
+                  flex: layout.diagOpen ? `${1 - layout.pdfFrac} 1 0px` : '0 0 auto',
+                  minHeight: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  background: 'var(--surface)',
+                }}
+              >
+                <div className="row gap8" style={{ padding: '6px 12px', flexShrink: 0, borderBottom: layout.diagOpen ? '0.5px solid var(--border)' : 'none' }}>
+                  <button
+                    className="writer-mini-btn"
+                    title={layout.diagOpen ? tr('收起编译诊断', 'Collapse build diagnostics') : tr('展开编译诊断', 'Expand build diagnostics')}
+                    onClick={() => patchLayout({ diagOpen: !layout.diagOpen })}
+                  >
+                    <Icon name="chevDown" size={11} style={{ transform: layout.diagOpen ? 'none' : 'rotate(-90deg)', transition: 'transform .12s' }} />
+                  </button>
+                  <span style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)' }}>{tr('编译诊断', 'Build diagnostics')}</span>
+                  {compile && (
+                    <span className="mono" style={{ fontSize: 10.5, marginLeft: 'auto' }}>
+                      {errCount > 0 && <span style={{ color: 'var(--danger-tx)', fontWeight: 700 }}>{errCount} {tr('错误', 'errors')}</span>}
+                      {errCount > 0 && warnCount > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
+                      {warnCount > 0 && <span style={{ color: 'var(--warn-tx)', fontWeight: 700 }}>{warnCount} {tr('警告', 'warnings')}</span>}
+                      {errCount === 0 && warnCount === 0 && <span style={{ color: 'var(--ok-tx)' }}>{tr('没有问题 ✓', 'No issues ✓')}</span>}
+                    </span>
+                  )}
+                </div>
+                {layout.diagOpen && (
+                  <div className="scroll" style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
+                    {!compile ? (
+                      <div className="empty" style={{ padding: 24, fontSize: 12 }}>{tr('还没编译过，编译后这里显示错误和警告。', 'Not compiled yet — errors and warnings will show here after a compile.')}</div>
+                    ) : compile.diagnostics.length === 0 ? (
+                      <div className="empty" style={{ padding: 24, fontSize: 12 }}>
+                        {compile.status === 'ok' ? tr('编译干净，没有错误和警告 🎉', 'Clean compile — no errors or warnings 🎉') : tr('编译未产出诊断信息。', 'The compile produced no diagnostics.')}
+                      </div>
+                    ) : (
+                      compile.diagnostics.map((d, i) => <DiagRow key={i} d={d} onClick={() => onDiagClick(d)} />)
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </div>
-
-        <Gutter
-          dragging={dragging === 'right'}
-          onMouseDown={layout.rightOpen ? onRightGutterDown : undefined}
-          onReset={() => patchLayout({ rightW: DEFAULT_LAYOUT.rightW })}
-          collapsed={!layout.rightOpen}
-          onToggle={() => patchLayout({ rightOpen: !layout.rightOpen })}
-          toggleTitle={layout.rightOpen ? tr('收起预览面板', 'Collapse preview panel') : tr('展开预览面板', 'Expand preview panel')}
-          chevronDeg={layout.rightOpen ? 0 : 180}
-        />
-
-        {/* 右：PDF 预览 + 诊断 */}
-        {layout.rightOpen && (
-          <div
-            ref={rightColRef}
-            style={{
-              width: layout.rightW,
-              flexShrink: 0,
-              borderLeft: '0.5px solid var(--border)',
-              display: 'flex',
-              flexDirection: 'column',
-              minHeight: 0,
-              overflow: 'hidden',
-            }}
-          >
-            {/* 上：PDF */}
-            <div
-              style={{
-                flex: layout.pdfOpen ? `${layout.pdfFrac} 1 0px` : '0 0 auto',
-                minHeight: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                borderBottom: '0.5px solid var(--border)',
-              }}
-            >
-              <div className="row gap8" style={{ padding: '6px 12px', flexShrink: 0, borderBottom: layout.pdfOpen ? '0.5px solid var(--border)' : 'none', background: 'var(--surface)' }}>
-                <button
-                  className="writer-mini-btn"
-                  title={layout.pdfOpen ? tr('收起编译预览', 'Collapse PDF preview') : tr('展开编译预览', 'Expand PDF preview')}
-                  onClick={() => patchLayout({ pdfOpen: !layout.pdfOpen })}
-                >
-                  <Icon name="chevDown" size={11} style={{ transform: layout.pdfOpen ? 'none' : 'rotate(-90deg)', transition: 'transform .12s' }} />
-                </button>
-                <span style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)' }}>{tr('编译预览 · PDF', 'PDF preview')}</span>
-                {compile && (
-                  <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)', marginLeft: 'auto' }}>
-                    v{compile.version} · {fmtRelative(compile.compiled_at)} · {(compile.duration_ms / 1000).toFixed(1)}s
-                  </span>
-                )}
-              </div>
-              {layout.pdfOpen && (
-                // 拖动分栏时挡住 iframe，避免鼠标事件被它吞掉
-                <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', pointerEvents: dragging ? 'none' : 'auto' }}>
-                  <PdfPane msId={ms.id} compile={compile} />
-                </div>
-              )}
-            </div>
-
-            {layout.pdfOpen && layout.diagOpen && (
-              <Gutter
-                horizontal
-                dragging={dragging === 'pdf'}
-                onMouseDown={onPdfGutterDown}
-                onReset={() => patchLayout({ pdfFrac: DEFAULT_LAYOUT.pdfFrac })}
-              />
-            )}
-
-            {/* 下：诊断 */}
-            <div
-              style={{
-                flex: layout.diagOpen ? `${1 - layout.pdfFrac} 1 0px` : '0 0 auto',
-                minHeight: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                background: 'var(--surface)',
-              }}
-            >
-              <div className="row gap8" style={{ padding: '6px 12px', flexShrink: 0, borderBottom: layout.diagOpen ? '0.5px solid var(--border)' : 'none' }}>
-                <button
-                  className="writer-mini-btn"
-                  title={layout.diagOpen ? tr('收起编译诊断', 'Collapse build diagnostics') : tr('展开编译诊断', 'Expand build diagnostics')}
-                  onClick={() => patchLayout({ diagOpen: !layout.diagOpen })}
-                >
-                  <Icon name="chevDown" size={11} style={{ transform: layout.diagOpen ? 'none' : 'rotate(-90deg)', transition: 'transform .12s' }} />
-                </button>
-                <span style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)' }}>{tr('编译诊断', 'Build diagnostics')}</span>
-                {compile && (
-                  <span className="mono" style={{ fontSize: 10.5, marginLeft: 'auto' }}>
-                    {errCount > 0 && <span style={{ color: 'var(--danger-tx)', fontWeight: 700 }}>{errCount} {tr('错误', 'errors')}</span>}
-                    {errCount > 0 && warnCount > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
-                    {warnCount > 0 && <span style={{ color: 'var(--warn-tx)', fontWeight: 700 }}>{warnCount} {tr('警告', 'warnings')}</span>}
-                    {errCount === 0 && warnCount === 0 && <span style={{ color: 'var(--ok-tx)' }}>{tr('没有问题 ✓', 'No issues ✓')}</span>}
-                  </span>
-                )}
-              </div>
-              {layout.diagOpen && (
-                <div className="scroll" style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
-                  {!compile ? (
-                    <div className="empty" style={{ padding: 24, fontSize: 12 }}>{tr('还没编译过，编译后这里显示错误和警告。', 'Not compiled yet — errors and warnings will show here after a compile.')}</div>
-                  ) : compile.diagnostics.length === 0 ? (
-                    <div className="empty" style={{ padding: 24, fontSize: 12 }}>
-                      {compile.status === 'ok' ? tr('编译干净，没有错误和警告 🎉', 'Clean compile — no errors or warnings 🎉') : tr('编译未产出诊断信息。', 'The compile produced no diagnostics.')}
-                    </div>
-                  ) : (
-                    compile.diagnostics.map((d, i) => <DiagRow key={i} d={d} onClick={() => onDiagClick(d)} />)
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
       </div>
 
       {/* —— 抽屉 / Modal —— */}

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -512,7 +512,7 @@ export function WriterPage() {
         </div>
       ) : (
         <>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 14 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 14 }}>
             {manuscripts.map((m) => (
               <ManuscriptCard
                 key={m.id}

--- a/src/frontend/src/lib/useBreakpoint.ts
+++ b/src/frontend/src/lib/useBreakpoint.ts
@@ -1,0 +1,74 @@
+import { useSyncExternalStore } from 'react';
+
+/* ============================================================
+   响应式断点（全站唯一口径）。
+   - 断点值在三处出现，必须同步：本文件的 BP、styles/tokens.css 的
+     --bp-* 变量、styles/global.css 里 @media 的字面量。
+     （CSS 变量不能用在 @media 条件里，所以媒体查询只能写字面量。）
+   - 只有内联 style 吃不到媒体查询的地方才用这里的 hook；能用 CSS
+     解决的一律写进 global.css，别在组件里手写 window.innerWidth。
+   ============================================================ */
+
+export const BP = {
+  /** 平板 / 小笔记本：双栏改上下堆叠、页面留白收窄 */
+  compact: 1024,
+  /** 手机：关掉全局 zoom、侧栏改覆盖抽屉、顶栏收窄 */
+  mobile: 768,
+} as const;
+
+type Key = keyof typeof BP;
+
+interface Store {
+  subscribe: (fn: () => void) => () => void;
+  getSnapshot: () => boolean;
+}
+
+/** 每个断点一个 store：subscribe / getSnapshot 必须是稳定引用，
+    否则 useSyncExternalStore 每次渲染都会退订重订。 */
+function makeStore(key: Key): Store {
+  const supported = typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+  if (!supported) {
+    return { subscribe: () => () => {}, getSnapshot: () => false };
+  }
+  const list = window.matchMedia(`(max-width: ${BP[key]}px)`);
+  // 缓存快照：getSnapshot 必须返回稳定值，不能每次现读 list.matches
+  // 之外再包一层新对象；布尔值本身可直接比较，读 list 也安全，但缓存
+  // 能保证订阅回调触发前后读到一致的值。
+  let snapshot = list.matches;
+  return {
+    subscribe: (fn) => {
+      const onChange = () => {
+        snapshot = list.matches;
+        fn();
+      };
+      list.addEventListener('change', onChange);
+      return () => list.removeEventListener('change', onChange);
+    },
+    getSnapshot: () => snapshot,
+  };
+}
+
+const stores: Record<Key, Store> = {
+  compact: makeStore('compact'),
+  mobile: makeStore('mobile'),
+};
+
+/** 服务端 / 无 matchMedia 环境按桌面渲染。 */
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function useBreakpoint(key: Key): boolean {
+  const store = stores[key];
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
+}
+
+/** 视口 <= 1024px（平板 / 小笔记本及以下）。 */
+export function useIsCompact(): boolean {
+  return useBreakpoint('compact');
+}
+
+/** 视口 <= 768px（手机）。 */
+export function useIsMobile(): boolean {
+  return useBreakpoint('mobile');
+}

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1090,6 +1090,15 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
         确实不能换行的行显式挂 .row-nowrap。 */
   .row { flex-wrap: wrap; }
 
+  /* 分段切换（全站 43 处标签条）：窄屏放不下时原本会把按钮压到断词
+     （「浏览记/录」），改成整条横向滚动、按钮不压缩不断词。 */
+  .segmented {
+    max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .segmented::-webkit-scrollbar { display: none; }
+  .segmented > button { flex-shrink: 0; white-space: nowrap; }
+
   /* —— 宽内容兜底 —— */
   .table-wrap > .table { min-width: 560px; }
   .workbench-panx { overflow-x: auto; overflow-y: hidden; }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -556,14 +556,8 @@ select.input { padding-right: 8px; cursor: pointer; }
 /* zoom 0.91 ≈ 1/1.1：右侧详情面板抵消全局放大，恢复原始大小 */
 .split-detail { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; zoom: 0.91; }
 
-/* 窄屏（相关研究等 opt-in 双栏页）：双栏改上下堆叠，列表在上、详情在下 */
-@media (max-width: 920px) {
-  .split-stackable { flex-direction: column; }
-  .split-stackable .split-list {
-    width: 100%; max-height: 44vh; flex-shrink: 0;
-    border-right: none; border-bottom: 0.5px solid var(--border);
-  }
-}
+/* 窄屏下双栏改上下堆叠：规则已提升为 .split 的默认行为，见文件末尾
+   「响应式断点」一节。.split-stackable 保留为无副作用的历史别名。 */
 
 input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 
@@ -987,4 +981,140 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   }
   .paper-reader-body img, .fig-embed, figure { break-inside: avoid; page-break-inside: avoid; }
   .paper-reader-header h1 { font-size: 22px; }
+}
+
+/* ============================================================
+   响应式断点 — 移动设备适配（兜底级：不破版、能读、能轻操作）
+   ------------------------------------------------------------
+   两档断点，全站唯一口径；改这里必须同改 tokens.css 的 --bp-* 与
+   lib/useBreakpoint.ts 的 BP 常量（CSS 变量不能用在 @media 条件里）。
+     1024px  平板 / 小笔记本：双栏堆叠、留白收窄
+      768px  手机：关全局 zoom、侧栏改覆盖抽屉、顶栏收窄
+
+   关于 html{zoom:1.1}：@media 求值看真实视口 px，不受 zoom 影响，但
+   内部布局的可用宽度是「视口/1.1」。把关 zoom 的断点与主重排断点都
+   定在 768px，手机分支内「媒体 px == 布局 px」，后续不必再做换算。
+   ============================================================ */
+
+/* —— 通用工具类（基础态无副作用，窄屏才发力） —— */
+
+/* 宽表格的横滚壳：桌面上 .table 是 width:100%，包一层不改变任何表现 */
+.table-wrap { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+/* 重工作台（阅读器 / 写作三栏 / 代码分栏）的窄屏兜底：本期不重排交互，
+   只让它们整体横向平移，避免撑破外壳。用法是外层挂 .workbench-panx、
+   内层唯一子元素挂 .workbench-panx-inner。基础态完全不生效。 */
+.workbench-panx { min-width: 0; }
+
+/* .row 在窄屏默认允许折行；确实不能换行的行（分页器、工具条）挂 .row-nowrap */
+.row-nowrap { flex-wrap: nowrap !important; }
+
+/* ============================================================
+   <= 1024px — 平板 / 小笔记本
+   ============================================================ */
+@media (max-width: 1024px) {
+  /* 双栏（列表 + 详情）一律上下堆叠。覆盖相关研究 / 文献库 / 每日推送 /
+     Wiki 论文与概念 / 公共库浏览等全部 .split 页面。 */
+  .split { flex-direction: column; }
+  .split .split-list {
+    width: 100%; max-height: 44vh; flex-shrink: 0;
+    border-right: none; border-bottom: 0.5px solid var(--border);
+  }
+
+  .page { padding: 22px 18px 60px; }
+
+  /* 右侧抽屉不超出视口 */
+  .drawer { width: min(420px, 100vw - 32px); }
+}
+
+/* ============================================================
+   <= 768px — 手机
+   ============================================================ */
+@media (max-width: 768px) {
+  /* —— 关掉全局放大：手机屏本来就窄，放大 10% 等于凭空少 1/11 的宽度；
+        关掉后媒体查询值与布局值一致，.split-detail 的反向抵消一并归 1 —— */
+  html { zoom: 1; }
+  .split-detail { zoom: 1; }
+
+  /* —— 触屏基建 —— */
+  * { -webkit-tap-highlight-color: transparent; }
+  .content { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
+
+  /* —— 侧栏改覆盖式抽屉（配合 AppShell 的 .app.nav-open）——
+        脱离 flex 流，主列独占全宽；默认滑出屏外，不占位也不可点。 */
+  .sidebar {
+    position: fixed; top: 0; left: 0; bottom: 0;
+    width: min(280px, 84vw);
+    transform: translateX(-100%);
+    transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+    box-shadow: 6px 0 28px rgba(10, 22, 44, 0.18);
+    z-index: 45;
+  }
+  .app.nav-open .sidebar { transform: none; }
+  .sidebar-scrim {
+    position: fixed; inset: 0; background: rgba(10, 22, 44, 0.28);
+    z-index: 44; animation: fadeUp 0.18s ease;
+  }
+  /* 手机上没有「图标轨道」形态：桌面的收起态在这里一律按完整抽屉渲染
+     （AppShell 也不会挂 .nav-collapsed，这条只是防御性兜底） */
+  .nav-collapsed .sidebar { width: min(280px, 84vw); }
+  .nav-collapsed .nav-item { justify-content: flex-start; gap: 9px; }
+  .nav-collapsed .nav-item .nav-label { display: inline; }
+
+  /* —— 顶栏收窄 —— */
+  .topbar {
+    gap: 8px;
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+  /* 面包屑只留当前页，去掉上级与分隔符 */
+  .crumb { min-width: 0; }
+  .crumb > span { display: none; }
+  .crumb b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  /* 搜索框收成图标按钮（不改 DOM，只藏文字） */
+  .searchbox {
+    min-width: 0; width: 32px; flex-shrink: 0;
+    padding: 0; justify-content: center;
+  }
+  .searchbox > span { display: none; }
+
+  /* —— 页面留白 —— */
+  .page {
+    padding: 14px 12px calc(48px + env(safe-area-inset-bottom, 0px));
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+
+  /* —— 不破版的关键一招：标签列自动折行 ——
+        全站 200+ 处「固定宽标签 + flexShrink:0」的两栏行靠这条自动堆叠。
+        确实不能换行的行显式挂 .row-nowrap。 */
+  .row { flex-wrap: wrap; }
+
+  /* —— 宽内容兜底 —— */
+  .table-wrap > .table { min-width: 560px; }
+  .workbench-panx { overflow-x: auto; overflow-y: hidden; }
+  .workbench-panx > .workbench-panx-inner { min-width: 900px; }
+
+  /* 抽屉铺满 */
+  .drawer { width: 100vw; border-left: none; }
+
+  /* 文献对话的会话历史栏：窄屏改浮层覆盖，展开时不再挤压对话区 */
+  .chat-shell { position: relative; }
+  .chat-shell .chat-history {
+    position: absolute; top: 0; left: 0; bottom: 0; z-index: 6;
+    box-shadow: 6px 0 22px rgba(10, 22, 44, 0.14);
+  }
+
+  /* 命令面板 / 弹窗贴边留白 */
+  .modal-scrim { padding: 12px; }
+}
+
+/* ============================================================
+   触屏（无 hover）：把「悬停才显形」的操作按钮改成常显，否则点不到
+   ============================================================ */
+@media (hover: none) {
+  .writer-file .writer-file-ops { display: flex; }
+  .panel-gutter .panel-gutter-btn { opacity: 1; }
+  .chat-history-item .chat-history-x { display: flex; }
+  .chat-chip-x { opacity: 1; }
 }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1101,6 +1101,9 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 
   /* —— 宽内容兜底 —— */
   .table-wrap > .table { min-width: 560px; }
+  /* 任务列表行：徽标 + 标题 + 进度 130 + 耗时 78 + 状态 134 + 箭头，定宽列
+     合计放不下窄屏，给最小宽度让整块横滚，而不是把标题列压没、时间戳折成三行 */
+  .table-wrap > .voyage-row { min-width: 720px; }
   .workbench-panx { overflow-x: auto; overflow-y: hidden; }
   .workbench-panx > .workbench-panx-inner { min-width: 900px; }
 

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1099,6 +1099,19 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   .segmented::-webkit-scrollbar { display: none; }
   .segmented > button { flex-shrink: 0; white-space: nowrap; }
 
+  /* 端到端流水线：6 张阶段卡横排放不下，折行会在行末留下指向空处的箭头、
+     且两行卡片高度不齐。窄屏改 3 列网格（卡片自动等高）并隐藏箭头连接线。 */
+  .pipeline-flow {
+    display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+    /* 组件内联 gap 读这个变量：内联优先级高于样式表，直接在这里写 gap 不生效 */
+    --pipeline-gap: 10px;
+    /* 两行等高：否则带「下一步从这里继续」的那一行会明显更高 */
+    grid-auto-rows: 1fr;
+  }
+  .pipeline-arrow { display: none; }
+  /* 卡片只有 ~104px 宽，「下一步从这里继续」会在末尾掉一个孤字；均分两行 */
+  .pipeline-hint { text-wrap: balance; }
+
   /* —— 宽内容兜底 —— */
   .table-wrap > .table { min-width: 560px; }
   /* 任务列表行：徽标 + 标题 + 进度 130 + 耗时 78 + 状态 134 + 箭头，定宽列

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -249,6 +249,16 @@ input {
 .h-title { font-size: 26px; font-weight: 680; letter-spacing: -0.02em; margin: 6px 0 0; line-height: 1.15; }
 .h-sub { font-size: 14px; color: var(--text-2); margin: 8px 0 0; max-width: 720px; line-height: 1.55; }
 .h-sub .en { color: var(--text-3); font-size: 13px; }
+/* 页头右侧操作区（原为组件内联样式，挪到这里以便窄屏覆盖） */
+.page-head-actions { flex-shrink: 0; margin-left: 16px; }
+
+/* —— 整屏「列表 + 详情」页（相关研究 / 我的文献库 / 每日新论文 / 公共库浏览）——
+   页面与卡片撑满视口高度，滚动发生在 .split 内部的两块里。原本这两组样式在
+   4-5 个页面里各写了一份内联，改成共享类以便窄屏统一解除高度锁定。 */
+.page-fill { display: flex; flex-direction: column; height: 100%; }
+.split-card {
+  overflow: hidden; display: flex; flex-direction: column; flex: 1; min-height: 480px;
+}
 .section-h { font-size: 13px; font-weight: 650; color: var(--text); display: flex; align-items: center; gap: 9px; }
 .mono { font-family: var(--mono); }
 .muted { color: var(--text-3); }
@@ -1099,6 +1109,25 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   .segmented::-webkit-scrollbar { display: none; }
   .segmented > button { flex-shrink: 0; white-space: nowrap; }
 
+  /* 双栏堆叠后的高度分配：1024 档只是改方向，容器仍被锁成视口高度，再切给
+     上下两块。像「每日新论文」这种列表区自带搜索/筛选/分页（合计 245px 固定
+     高度）的页面，44vh 里只剩 127px 放论文——一行。
+     手机上改成自然流：整页滚动，列表保留自身滚动但给到 70vh，详情在下方
+     按内容完整展开（内层 flex:1 的滚动容器在无确定高度的父级下会塌成 0，
+     所以显式解除）。 */
+  .page-fill { display: block; height: auto; }
+  .split-card { flex: none; overflow: visible; min-height: 0; }
+  .split { display: block; }
+  .split .split-list { max-height: 70vh; }
+  .split-detail { display: block; }
+  .split-detail > * { flex: none; overflow: visible; }
+
+  /* 页头（全站 17 个页面共用）：右侧操作区不压缩、标题 flex-basis 为 0，
+     同排会把标题挤成窄条逐字换行。窄屏改成标题在上、操作区在下。 */
+  .page-head { flex-direction: column; align-items: stretch; gap: 12px; }
+  .page-head-actions { margin-left: 0; flex-wrap: wrap; }
+  .h-title { font-size: 22px; }
+
   /* 端到端流水线：6 张阶段卡横排放不下，折行会在行末留下指向空处的箭头、
      且两行卡片高度不齐。窄屏改 3 列网格（卡片自动等高）并隐藏箭头连接线。 */
   .pipeline-flow {
@@ -1128,6 +1157,10 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   .chat-shell .chat-history {
     position: absolute; top: 0; left: 0; bottom: 0; z-index: 6;
     box-shadow: 6px 0 22px rgba(10, 22, 44, 0.14);
+  }
+  /* 浮层遮罩：压在历史栏之下、对话区之上 */
+  .chat-history-scrim {
+    position: absolute; inset: 0; z-index: 5; background: rgba(10, 22, 44, 0.2);
   }
 
   /* 命令面板 / 弹窗贴边留白 */

--- a/src/frontend/src/styles/tokens.css
+++ b/src/frontend/src/styles/tokens.css
@@ -91,4 +91,16 @@
   --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "PingFang SC", "Helvetica Neue",
     system-ui, sans-serif;
   --mono: "SF Mono", "JetBrains Mono", ui-monospace, "Menlo", "Cascadia Code", monospace;
+
+  /* — Breakpoints —
+     全站只有两档断点。CSS 变量不能用在 @media 条件里，所以这里只是「登记」，
+     供组件内 calc()/引用；真正的断点写在三处，改一处必须同改另两处：
+       1. 本文件的 --bp-*（登记用）
+       2. global.css 末尾 @media 块里的字面量（1024px / 768px）
+       3. lib/useBreakpoint.ts 的 BP 常量（JS 侧判断用）
+     注意 html{zoom:1.1}：@media 求值看真实视口 px，不受 zoom 影响，但内部
+     布局的可用宽度是「视口/1.1」。关 zoom 的断点与主重排断点都定在 768px，
+     所以手机分支内「媒体 px == 布局 px」，不必再做换算。 */
+  --bp-compact: 1024px;   /* 平板 / 小笔记本 */
+  --bp-mobile:  768px;    /* 手机 */
 }


### PR DESCRIPTION
Closes #100

Mobile device adaptation, **fallback level**: the layout no longer breaks on a phone — you can get in, read, and do light interactions. No heavy workbench is reflowed and no touch gestures are added; those belong to a follow-up.

## Breakpoints

Two tiers, kept in sync across three places (CSS variables can't be used in `@media` conditions, so the sync is by convention — spelled out in a `tokens.css` comment):

| Breakpoint | What changes |
|---|---|
| `1024px` tablet / small laptop | split panes stack, tighter page padding, drawer fits the viewport |
| `768px` phone | global zoom off, sidebar becomes an off-canvas drawer, topbar collapses, label columns wrap |

- `styles/tokens.css` — `--bp-compact` / `--bp-mobile` (registration + sync note)
- `styles/global.css` — the literals inside the media queries
- `lib/useBreakpoint.ts` — new; JS-side breakpoints for places inline styles can't reach

`useBreakpoint.ts` follows the existing `useSyncExternalStore` pattern from `lib/prefs.ts`, backed by `matchMedia`. One store per breakpoint so `subscribe`/`getSnapshot` are stable references and don't resubscribe every render.

## The shell

**Turn off `html{zoom:1.1}` below 768px.** That global 10% scale-up was added because the base font felt small, but on a phone it throws away 1/11 of the available width. Worse, `zoom` does not affect media-query evaluation while it does affect usable layout width, so two px scales coexist. Putting the zoom cutoff on the same breakpoint as the main reflow means that inside the phone branch *media px equals layout px*. The matching `zoom:0.91` counter-scale on `.split-detail` goes to 1 as well.

**Sidebar becomes an off-canvas drawer.** The desktop `navCollapsed` state is an icon rail — it takes up space and is remembered in localStorage. A phone needs a panel that sits *over* the content, so this is a separate, non-persisted `mobileNavOpen`; otherwise the sidebar would cover the page on every visit. It closes on navigation and on scrim click, and resets when the viewport widens. The desktop collapse memory is untouched.

**Promote `.split-stackable` to `.split`.** Previously exactly one page had opted into stacking; this covers all seven list+detail pages at once.

**`.row { flex-wrap: wrap }` below 768px.** Over 200 "fixed-width label + `flexShrink:0`" rows stack because of this one rule. There's a `.row-nowrap` escape hatch. This is the bluntest change here and the main regression risk (`.row` appears 570 times) — it cannot cause overflow, but it can misalign things locally.

**Wide content**: the 12 wide tables get a horizontal scroll shell; grid min tracks are clamped with `minmax(min(Npx, 100%), 1fr)`; the reader / writer / code workbenches pan horizontally as a unit rather than having their drag-resizable panes reflowed; `@media (hover: none)` reveals the 4 hover-gated action buttons.

## Fixes found by testing

**Fixed-column lists collapsed.** Three lists shared a shape: fixed-width columns plus a `minmax(0,1fr)` or `flex:1` title that collapses to zero width before anything wraps, with trailing columns clipped by an `overflow:hidden` card. `.row`'s wrap does not help — a `flex-basis: 0` child shrinks to nothing rather than forcing a wrap.

| Where | Symptom |
|---|---|
| Idea review leaderboard | All 8 idea titles invisible; 胜场 / 状态 / actions clipped out to 747px |
| Task list (workbench tab and `/voyages`) | Titles gone, timestamp broken onto three lines, trailing columns clipped |
| Admin → feedback | Feedback titles collapsed to 3px |

Fixed with a 220px floor on the leaderboard title track (scrolling below its 972px natural width), a 720px floor on task rows, and a `min-width` on the feedback title so it wraps to its own line.

**Segmented tab strips broke words.** `Segmented` renders a nowrap `inline-flex`, so buttons were squeezed until labels broke mid-word (`浏览记` / `录`). The strip now scrolls horizontally below 768px. One class fixes all 43 usages across 26 files.

**Placeholder copy pointed the wrong way.** The list+detail panes said "select the paper *on the left*" — wrong once `.split` stacks and the list sits above. The English strings were already direction-neutral, so only the Chinese changed, across all seven split pages.

**Pipeline wrapped badly.** Wrapping the six stage cards left a connector arrow pointing into empty space at the end of the first line, and the two lines came out at different heights. Now a 3-column grid below 768px with arrows hidden — the 00-05 numbering carries the order — and equal row heights. The gap comes from a CSS variable rather than a hardcoded inline `0`, which was silently overriding the grid gap and leaving the cards flush.

**Page head squeezed the title.** Shared by 17 pages: the actions block never shrinks and the title block has `flex-basis: 0`, so the title was compressed into a narrow column and broke one character per line. Actions now sit below the title below 768px.

**Split pages were pinned to viewport height.** Stacking alone was not enough: the page and its card are pinned to the viewport, so the list pane got 44vh, and its own search, filter chips and pagination ate 245px of that — leaving 127px, exactly one row on Daily Papers. The full-height page/card styles were duplicated inline across four pages; they are now `.page-fill` and `.split-card`, which lets the phone breakpoint release the height lock. The page scrolls as a whole, the list keeps its own scroll at up to 70vh (347px of rows, up from 127px), and the detail expands to its natural height below.

**Chat history covered the conversation.** The 210px history rail becomes an overlay on phones but defaulted to open, so it permanently covered the chat. It now starts collapsed below 768px. Opening it also covered the very toggle that closes it, so the overlay carries its own close button plus a scrim that dismisses on tap.

## Verification

`tsc --noEmit` and `vite build` pass.

**On the criterion.** The obvious assertion — `documentElement.scrollWidth <= innerWidth` — is **vacuous for this app**: `body{overflow:hidden}` plus `.app{position:fixed; inset:0; overflow:hidden}` means overflowing content is clipped, never scrolled, so it passes even when the topbar is entirely off-screen.

Two probe bugs invalidated an earlier pass and are worth recording:

1. The probe exempted anything inside a horizontal scroller. But `.content` (wrapping every page) is `overflow-y: auto`, and per CSS a box with one axis non-visible computes the other to `auto` — so *every element on every page* matched the exemption and nothing could be flagged.
2. The probe drives an iframe while the Chrome window is backgrounded, so `document.visibilityState` is `hidden` and CSS animations sit at frame 0. The approvals drawer measured at `left: 390` on a 390px viewport — parked at `translateX(100%)`, the start of its `slideIn`. Every overlay measurement was off-screen geometry. Fixed by zeroing animation and transition durations in the iframe.

The criterion actually used: an element is a problem if it is **clipped** (extends past an `overflow:hidden` ancestor or the viewport, with no ancestor that *actually* scrolls — `scrollWidth > clientWidth`), **collapsed** (multi-character text rendering under 4px wide), or **vertically truncated** (taller than an `overflow-y:hidden` container, excluding deliberate `-webkit-line-clamp`). KaTeX internals and single-character glyphs are excluded as false positives. Chrome's window resize would not produce a real narrow viewport (`innerWidth` stayed at 1000), so each route is loaded in a same-origin iframe sized to the target.

Sensitivity was confirmed before trusting the results: with the responsive rules disabled, `/settings` at 390px reports 18 clipped elements (breadcrumb out to 425, search box to 676, buttons to 787 — the whole topbar unreachable). With them on, 0.

**Coverage** — 21 routes × {390×844, 768×1024, 1440×900}, plus 32 in-page tab states and 6 overlays (approvals drawer, new-experiment, new-manuscript, deep-dive drawer, fact-pack drawer, collaborators modal). Detail pages that need runtime IDs are included: `/ideas/:id`, `/writer/:id`, `/libraries/:id`, `/voyages/:id`, `/papers/:id/read`.

| Check | Result |
|---|---|
| Horizontally clipped / unreachable | **0** |
| Collapsed to zero width | **0** |
| Vertically truncated (excluding intentional clamps) | **0** |

For reference, before the fix every route at 390px had 21–22 clipped elements, the furthest reaching 882px.

Desktop is unchanged: at 1440 the shell still measures `zoom 1.1`, sidebar `relative` 248px (66px collapsed), `.split` in a row with a 360px list, `.page` padding 30/36/80.

## Known and not fixed

**Tap-target size.** Small controls exist on most pages — icon buttons at 18–26px, and inline text acting as buttons at ~15px tall (author links, disclosure toggles); `/libraries/:id` has 33, of which 32 are author links at roughly 73×15. Left alone on purpose: the scope keeps desktop interaction logic and defers touch work, and the obvious fix — expanding hit areas with a pseudo-element — makes neighbouring targets overlap where controls sit 8px apart, as in the topbar. It belongs in the touch batch alongside the drag gutters.

**Not covered by automation**: visual spacing and alignment beyond the pages reviewed by eye, and states reachable only through multi-step flows.

## Risks

1. `.row{flex-wrap:wrap}` reaches 570 call sites — it cannot overflow, but it can misalign locally; add `.row-nowrap` where it does
2. Turning off zoom drops phone font sizes by 10%, exactly the problem the zoom was added to solve. If it reads too small, adjust the base size inside the phone breakpoint rather than restoring zoom
3. `.split` moving from opt-in to default stacking, and the extraction of `.page-fill` / `.split-card` from inline styles, both affect 4–7 pages on desktop; verified at 1440 and 1024
