### PR TITLE
feat(backend): allow the desktop client origin through CORS in prod

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -23,6 +23,11 @@ class Settings(BaseSettings):
     secret_key: str = "dev-only-secret-key-change-me"  # JWT 签名
     encryption_key: str = ""  # Fernet key；为空时 security.py 会从 secret_key 派生（仅限 dev）
     invite_code: str = "polaris-lab"  # 注册邀请码（实验室内部制）
+    # prod 下额外放行的跨域前端来源（逗号分隔）。桌面客户端的 app://polaris 恒在白名单内、
+    # 无需在此配置；这一项留给「前端与 API 不同域」的部署形态。web 生产走 nginx 同源反代，
+    # 根本不进 CORS 分支。用逗号分隔的 str 而非 list[str]：pydantic-settings 对 list[str]
+    # 要求 env 值是 JSON 字面量（'["a","b"]'），与本仓库 .env 的朴素风格不兼容。
+    cors_origins: str = ""
 
     # ---- GitHub（用户反馈 → issue）----
     github_token: str = ""  # PAT（repo scope）；为空时禁用「建 issue」，仅出草稿
@@ -89,6 +94,10 @@ class Settings(BaseSettings):
     @property
     def is_sqlite(self) -> bool:
         return self.database_url.startswith("sqlite")
+
+    @property
+    def cors_origin_list(self) -> list[str]:
+        return [o.strip() for o in self.cors_origins.split(",") if o.strip()]
 
 
 @lru_cache

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -21,6 +21,11 @@ from app.services.skills import ensure_builtin_skills
 
 logger = logging.getLogger(__name__)
 
+# Electron 桌面客户端的固定 origin：页面由自定义 app:// scheme 加载（见 src/desktop）。
+# 恒在 prod 白名单内且无需配置——网页无法伪造自定义 scheme 的 Origin 头，且这里
+# allow_credentials=False + Bearer 鉴权没有 ambient authority，故对 web 攻击面零增量。
+DESKTOP_ORIGIN = "app://polaris"
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -53,8 +58,11 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(
         CORSMiddleware,
-        # TODO(部署): prod 收紧为前端域名白名单
-        allow_origins=["*"] if settings.env == "dev" else [],
+        # dev 全放开；prod 只放行桌面客户端 + POLARIS_CORS_ORIGINS 里显式配置的前端域名。
+        # web 生产是 nginx 同源反代，不经过这里。
+        allow_origins=(
+            ["*"] if settings.env == "dev" else [DESKTOP_ORIGIN, *settings.cors_origin_list]
+        ),
         allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/backend/tests/test_cors_desktop.py
+++ b/src/backend/tests/test_cors_desktop.py
@@ -1,0 +1,90 @@
+"""prod 下的 CORS 白名单：放行 Electron 桌面客户端，拒绝其余 origin。
+
+背景：桌面端页面由自定义 app:// scheme 加载，请求后端属于跨域，且每个请求都带
+Authorization 头 → 必然触发预检。改造前 prod 是 allow_origins=[]，预检直接 400，
+桌面端全部 API 不可用。
+
+conftest 把 POLARIS_ENV 钉成 dev 且 Settings 走 lru_cache，所以这里显式构造一份
+prod Settings 打进 app.main，绕开缓存。
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import app.main as main_module
+from app.core.config import Settings
+from app.main import DESKTOP_ORIGIN
+
+
+@pytest.fixture
+def prod_client(monkeypatch):
+    """构造 env=prod 的应用客户端；cors_origins 模拟 POLARIS_CORS_ORIGINS。"""
+
+    def make(cors_origins: str = "") -> AsyncClient:
+        settings = Settings(env="prod", cors_origins=cors_origins)
+        monkeypatch.setattr(main_module, "get_settings", lambda: settings)
+        return AsyncClient(
+            transport=ASGITransport(app=main_module.create_app()), base_url="http://test"
+        )
+
+    return make
+
+
+async def test_preflight_allows_desktop_origin(prod_client):
+    async with prod_client() as c:
+        res = await c.options(
+            "/api/health",
+            headers={
+                "Origin": DESKTOP_ORIGIN,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "authorization",
+            },
+        )
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == DESKTOP_ORIGIN
+
+
+async def test_preflight_rejects_unknown_origin(prod_client):
+    async with prod_client() as c:
+        res = await c.options(
+            "/api/health",
+            headers={"Origin": "https://evil.example", "Access-Control-Request-Method": "GET"},
+        )
+    assert res.status_code == 400
+    assert "access-control-allow-origin" not in res.headers
+
+
+async def test_preflight_allows_configured_origin(prod_client):
+    async with prod_client("https://polaris.example.edu, https://alt.example.edu") as c:
+        res = await c.options(
+            "/api/health",
+            headers={
+                "Origin": "https://alt.example.edu",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == "https://alt.example.edu"
+
+
+async def test_simple_request_from_unknown_origin_gets_no_acao(prod_client):
+    """非预检请求本身仍然通过（CORS 是浏览器侧强制），但不回 ACAO 头。"""
+    async with prod_client() as c:
+        res = await c.get("/api/health", headers={"Origin": "https://evil.example"})
+    assert res.status_code == 200
+    assert "access-control-allow-origin" not in res.headers
+
+
+async def test_dev_still_allows_any_origin(client):
+    """dev 行为不变：conftest 的 client 就是 env=dev。"""
+    res = await client.options(
+        "/api/health",
+        headers={"Origin": "https://anything.example", "Access-Control-Request-Method": "GET"},
+    )
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == "*"
+
+
+def test_cors_origin_list_strips_and_drops_blanks():
+    assert Settings(env="prod", cors_origins=" a , ,b ").cors_origin_list == ["a", "b"]
+    assert Settings(env="prod", cors_origins="").cors_origin_list == []


### PR DESCRIPTION
Second step of the desktop client work, and the last one that is invisible to the web app. Independently reviewable and safe to merge ahead of the shell itself.

## Why this is a hard blocker

The Electron client loads the SPA from a custom `app://` scheme, so every backend call is cross-origin. Every request carries an `Authorization` header, so every request triggers a CORS preflight.

In production `allow_origins=[]`, and Starlette answers a disallowed preflight with **400** — not with a missing header. That means the desktop client cannot reach a single API endpoint.

This cannot be patched on the client side. The obvious workaround — injecting `Access-Control-Allow-Origin` via `webRequest.onHeadersReceived` — cannot change a response *status code*, so the 400 preflight still fails. The backend change is mandatory, not optional.

## What changed

- `DESKTOP_ORIGIN = "app://polaris"` is always in the prod whitelist. It needs no configuration because it is a constant of the client build.
- New `POLARIS_CORS_ORIGINS` (comma-separated) for deployments where the web frontend is served from a different domain than the API.
- Dev behaviour is unchanged (`["*"]`). Web production still goes through the nginx same-origin proxy and never reaches this branch.

This replaces the pre-existing `TODO(部署): prod 收紧为前端域名白名单`.

## Why this does not widen the web attack surface

1. `allow_credentials=False` is unchanged, and auth is a Bearer token from `localStorage` — there is no ambient authority a malicious site could ride on, even if it were allowed to send the request.
2. A web page cannot forge an `Origin` header for a custom scheme, so no browser will ever present `app://polaris`.
3. The new setting defaults to an empty string, so production gains exactly one origin, not `*`.

## Implementation note

`cors_origins` is a comma-separated `str` with a `cors_origin_list` property rather than a `list[str]` field. pydantic-settings requires a JSON literal (`'["a","b"]'`) for `list[str]`, which does not match the plain `KEY=value` style of this repo's `.env` and would be an easy foot-gun when passed through docker compose `env_file`.

## Verification

New `tests/test_cors_desktop.py` (6 tests, all passing). It builds a prod `Settings` and patches it into `app.main` to bypass the `lru_cache`, since `conftest` pins `POLARIS_ENV=dev`:

- preflight from `app://polaris` → 200 with matching ACAO
- preflight from an unknown origin → 400, no ACAO
- preflight from a configured origin → 200 with matching ACAO
- simple request from an unknown origin → still 200, but no ACAO (CORS is enforced browser-side)
- dev still answers any origin with `*`
- `cors_origin_list` strips whitespace and drops blanks

Full backend suite: `661 passed, 2 failed, 16 errors`. Those failures are **pre-existing on `origin/main`** — I ran the same subset against an untouched-backend tree at the same commit and got byte-identical results (`test_paper_review.py` and `test_manuscript_versions.py`, all `AttributeError` at collection).

Part of #97
