### PR TITLE
feat(manuscripts): source bundle endpoint for local compilation

### DIFF
--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -12,6 +12,7 @@ import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import FileResponse, Response, StreamingResponse
@@ -920,7 +921,45 @@ async def export_arxiv(
     safe = "".join(c if c.isalnum() or c in "-_" else "-" for c in manuscript.title)[:60] or "paper"
     headers = {"Content-Disposition": f'attachment; filename="{safe}-arxiv.tar.gz"'}
     if notes:
-        headers["X-Export-Notes"] = " | ".join(notes)
+        # HTTP 头只允许 latin-1，而提示是中文：直接塞会在 starlette 编码时 500。
+        # 百分号编码后回传，前端 decodeURIComponent 还原。
+        headers["X-Export-Notes"] = quote(" | ".join(notes))
+    return Response(content=data, media_type="application/gzip", headers=headers)
+
+
+@router.get("/manuscripts/{manuscript_id}/source-digest")
+async def source_digest(
+    manuscript_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, str]:
+    """稿件源码的内容指纹。
+
+    桌面端本地编译用它判断缓存的产物是否还新鲜——源变了 digest 就变，
+    不需要下载整个包就能知道要不要重编。
+    """
+    manuscript = await _member_manuscript(session, manuscript_id, user, with_files=True)
+    return {"digest": await latex_compile.build_source_digest(session, manuscript)}
+
+
+@router.get("/manuscripts/{manuscript_id}/source-bundle")
+async def source_bundle(
+    manuscript_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """可编译的源码包（tar.gz），供桌面端本地编译。
+
+    与 arXiv 导出不同：不重编、不生成 .bbl，纯粹是当前源码的快照。
+    组装本身依赖 DB 与活跃 CRDT 房间，只能在服务端做——所以本地编译的形态是
+    「服务器组装 → 客户端下载 → 本地编译」，而不是客户端自己组装。
+
+    digest 放在文件名里，这样客户端从同一个响应里就能拿到，不需要读自定义响应头
+    （跨域时读自定义头还要额外配 expose_headers）。
+    """
+    manuscript = await _member_manuscript(session, manuscript_id, user, with_files=True)
+    data, digest = await latex_compile.build_source_bundle(session, manuscript)
+    headers = {"Content-Disposition": f'attachment; filename="source-{digest}.tar.gz"'}
     return Response(content=data, media_type="application/gzip", headers=headers)
 
 

--- a/src/backend/app/services/latex_compile.py
+++ b/src/backend/app/services/latex_compile.py
@@ -12,6 +12,7 @@
 """
 
 import asyncio
+import hashlib
 import io
 import json
 import os
@@ -537,7 +538,8 @@ def latest_ok_pdf(manuscript: Manuscript) -> Path | None:
 # ---- arXiv 清洁包导出（源文件 + .bbl，剔除 aux/log/pdf 等编译副产物） ----
 
 # 打包时剔除的编译副产物后缀（.bbl 例外，arXiv 需要它且不一定跑 bibtex）
-_ARXIV_DROP_SUFFIXES = frozenset(
+# 确定无疑的编译中间产物，可以按后缀一刀切。
+_INTERMEDIATE_SUFFIXES = frozenset(
     {
         ".aux",
         ".log",
@@ -553,11 +555,85 @@ _ARXIV_DROP_SUFFIXES = frozenset(
         ".nav",
         ".snm",
         ".vrb",
-        ".pdf",
-        ".gz",  # synctex.gz 等
-        ".xml",  # .run.xml（biber）
     }
 )
+
+
+def _is_build_artifact(rel: str, main_stem: str | None) -> bool:
+    """是否是编译中间产物（打包时应剔除）。
+
+    .pdf / .gz / .xml 不能按后缀一刀切：.pdf 是 LaTeX 最常见的插图格式，
+    .gz 与 .xml 也可能是稿件自带的数据文件。只有编译产物本身该被剔除，
+    所以这三类按**文件名**精确匹配（main.pdf 只在包根目录才算产物；
+    figures/ 里的同名文件是插图）。
+    """
+    name = rel.rsplit("/", 1)[-1].lower()
+    if Path(name).suffix in _INTERMEDIATE_SUFFIXES:
+        return True
+    if name.endswith(".synctex.gz") or name.endswith(".run.xml"):
+        return True
+    return bool(main_stem) and "/" not in rel and name == f"{str(main_stem).lower()}.pdf"
+
+
+def _digest_of(workdir: Path, rels: list[str]) -> str:
+    """源码包内容指纹：路径 + 内容各自入哈希，路径排序保证稳定。
+
+    桌面端本地编译拿它当缓存 key——源变了 digest 就变，旧产物自然失效，
+    不需要任何额外的失效逻辑。
+    """
+    outer = hashlib.sha256()
+    for rel in rels:
+        outer.update(rel.encode("utf-8"))
+        outer.update(b"\0")
+        outer.update(hashlib.sha256((workdir / rel).read_bytes()).digest())
+        outer.update(b"\0")
+    return outer.hexdigest()
+
+
+async def _assemble_source_files(
+    session: AsyncSession, manuscript: Manuscript, workdir: Path
+) -> list[str]:
+    """只读组装稿件源码到 workdir，返回应当入包的相对路径（已排序、已剔除中间产物）。"""
+    await assemble_workdir(session, manuscript, workdir, take_snapshots=False)
+    main_name = _find_workdir_main(workdir)
+    main_stem = Path(main_name).stem if main_name else None
+    rels: list[str] = []
+    for path in sorted(workdir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(workdir).as_posix()
+        if _is_build_artifact(rel, main_stem):
+            continue
+        rels.append(rel)
+    return rels
+
+
+async def build_source_bundle(
+    session: AsyncSession, manuscript: Manuscript
+) -> tuple[bytes, str]:
+    """可编译的源码包（tar.gz）+ 内容指纹。
+
+    与 arXiv 导出的区别：不重编、不生成 .bbl——这是给桌面端拿去**本地编译**的输入。
+    组装本身深度依赖 DB 与活跃 CRDT 房间（见 assemble_workdir），所以只能在服务端做；
+    本地编译的正确形态是「服务器组装 bundle → 客户端下载 → 本地编译」。
+    """
+    buf = io.BytesIO()
+    with tempfile.TemporaryDirectory(prefix="polaris-bundle-") as tmp:
+        workdir = Path(tmp)
+        rels = await _assemble_source_files(session, manuscript, workdir)
+        digest = _digest_of(workdir, rels)
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for rel in rels:
+                tar.add(workdir / rel, arcname=rel)
+    return buf.getvalue(), digest
+
+
+async def build_source_digest(session: AsyncSession, manuscript: Manuscript) -> str:
+    """只算指纹不打包——客户端用它判断本地缓存的编译产物是否还新鲜。"""
+    with tempfile.TemporaryDirectory(prefix="polaris-digest-") as tmp:
+        workdir = Path(tmp)
+        rels = await _assemble_source_files(session, manuscript, workdir)
+        return _digest_of(workdir, rels)
 
 
 def _find_workdir_main(workdir: Path) -> str | None:
@@ -604,11 +680,19 @@ async def build_arxiv_tarball(
             if run.timed_out and not (workdir / f"{Path(main_name).stem}.bbl").is_file():
                 notes.append("生成 .bbl 超时；包内可能缺少 .bbl。")
 
+        main_stem = Path(main_name).stem if main_name else None
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
             for path in sorted(workdir.rglob("*")):
-                if not path.is_file() or path.suffix.lower() in _ARXIV_DROP_SUFFIXES:
+                if not path.is_file():
                     continue
-                tar.add(path, arcname=path.relative_to(workdir).as_posix())
+                rel = path.relative_to(workdir).as_posix()
+                # .bbl 要留（arXiv 需要），其余中间产物剔除
+                if rel.lower().endswith(".bbl"):
+                    tar.add(path, arcname=rel)
+                    continue
+                if _is_build_artifact(rel, main_stem):
+                    continue
+                tar.add(path, arcname=rel)
     return buf.getvalue(), notes
 
 

--- a/src/backend/tests/test_source_bundle.py
+++ b/src/backend/tests/test_source_bundle.py
@@ -1,0 +1,129 @@
+"""源码包（桌面端本地编译的输入）与编译产物剔除规则。
+
+同时覆盖一个既有隐患的回归：arXiv 导出原先按后缀剔除 ``.pdf``，会把插图 PDF
+一起删掉——而 PDF 是 LaTeX 最常见的插图格式。
+"""
+
+import io
+import tarfile
+
+from app.services import latex_compile
+from app.services.latex_compile import _is_build_artifact
+from tests.test_manuscript_files import _new_ms
+
+# 最小合法 PDF（当作插图用，只要求是二进制且后缀为 .pdf）
+_PDF = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"
+
+
+def _members(data: bytes) -> set[str]:
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        return {m.name for m in tar.getmembers() if m.isfile()}
+
+
+async def _upload(client, headers, ms_id, path: str, blob: bytes, mime: str):
+    return await client.post(
+        f"/api/manuscripts/{ms_id}/files/upload",
+        files={"file": (path.rsplit("/", 1)[-1], blob, mime)},
+        data={"path": path},
+        headers=headers,
+    )
+
+
+class TestBuildArtifactRules:
+    """剔除规则是纯函数，直接单测——这里最容易一改就误伤用户文件。"""
+
+    def test_drops_intermediate_suffixes(self):
+        for name in ("main.aux", "main.log", "main.fdb_latexmk", "main.bcf"):
+            assert _is_build_artifact(name, "main") is True
+
+    def test_drops_compiled_pdf_only_at_root(self):
+        assert _is_build_artifact("main.pdf", "main") is True
+        # 同名文件出现在子目录里是插图，不是编译产物
+        assert _is_build_artifact("figures/main.pdf", "main") is False
+
+    def test_keeps_figure_pdfs(self):
+        assert _is_build_artifact("img/plot.pdf", "main") is False
+        assert _is_build_artifact("figures/exp-1.pdf", "main") is False
+
+    def test_drops_synctex_and_biber_xml_by_name_not_suffix(self):
+        assert _is_build_artifact("main.synctex.gz", "main") is True
+        assert _is_build_artifact("main.run.xml", "main") is True
+        # 后缀相同但不是编译产物的文件必须留下
+        assert _is_build_artifact("data/results.xml", "main") is False
+        assert _is_build_artifact("data/corpus.gz", "main") is False
+
+    def test_no_main_stem_keeps_all_pdfs(self):
+        assert _is_build_artifact("main.pdf", None) is False
+
+
+async def test_source_bundle_contains_sources_and_figures(client):
+    headers, ms_id = await _new_ms(client)
+    resp = await _upload(client, headers, ms_id, "img/plot.pdf", _PDF, "application/pdf")
+    assert resp.status_code == 201
+
+    resp = await client.get(f"/api/manuscripts/{ms_id}/source-bundle", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/gzip"
+
+    names = _members(resp.content)
+    assert "main.tex" in names
+    # 回归点：插图 PDF 必须在包里
+    assert "img/plot.pdf" in names
+
+
+async def test_source_bundle_filename_carries_digest(client):
+    """digest 放在文件名里，客户端不必读自定义响应头（跨域读自定义头还要配 expose_headers）。"""
+    headers, ms_id = await _new_ms(client)
+
+    digest = (await client.get(f"/api/manuscripts/{ms_id}/source-digest", headers=headers)).json()[
+        "digest"
+    ]
+    assert len(digest) == 64
+
+    resp = await client.get(f"/api/manuscripts/{ms_id}/source-bundle", headers=headers)
+    assert f'filename="source-{digest}.tar.gz"' in resp.headers["content-disposition"]
+
+
+async def test_digest_is_stable_and_tracks_content(client):
+    headers, ms_id = await _new_ms(client)
+
+    async def digest() -> str:
+        resp = await client.get(f"/api/manuscripts/{ms_id}/source-digest", headers=headers)
+        assert resp.status_code == 200, resp.text
+        return resp.json()["digest"]
+
+    first = await digest()
+    assert await digest() == first  # 源没动，指纹必须稳定（否则缓存永远失效）
+
+    # 内容编辑走 CRDT，这里用「新增一个源文件」来改变源集合
+    resp = await client.post(
+        f"/api/manuscripts/{ms_id}/files",
+        json={"path": "sections/extra.tex", "content": "\\section{Extra}"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    assert await digest() != first  # 源变了指纹必须变（digest 就是缓存 key）
+
+
+async def test_arxiv_export_keeps_figure_pdfs(client, monkeypatch):
+    """回归：arXiv 导出原先按 .pdf 后缀一刀切，会把插图 PDF 删掉。"""
+    headers, ms_id = await _new_ms(client)
+    resp = await _upload(client, headers, ms_id, "img/plot.pdf", _PDF, "application/pdf")
+    assert resp.status_code == 201
+
+    # 不实际调编译器：texbase 镜像里 tectonic 是装了的，真编一遍要几十秒
+    monkeypatch.setattr(latex_compile, "_find_tectonic", lambda: None)
+
+    resp = await client.get(f"/api/manuscripts/{ms_id}/export/arxiv", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert "img/plot.pdf" in _members(resp.content)
+
+
+async def test_source_bundle_requires_membership(client):
+    from tests.test_manuscripts import _setup_project
+
+    headers, ms_id = await _new_ms(client)
+    _, other_headers = await _setup_project(client, email="mallory@example.com")
+    resp = await client.get(f"/api/manuscripts/{ms_id}/source-bundle", headers=other_headers)
+    assert resp.status_code in (403, 404)

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3583,8 +3583,10 @@ export const api = {
       }
       throw new ApiError(res.status, detail, body);
     }
+    // 后端对该头做了百分号编码（HTTP 头只能 latin-1，提示是中文）
     const raw = res.headers.get('X-Export-Notes');
-    const notes = raw ? raw.split('|').map((s) => s.trim()).filter(Boolean) : [];
+    const decoded = raw ? decodeURIComponent(raw) : '';
+    const notes = decoded ? decoded.split('|').map((s) => s.trim()).filter(Boolean) : [];
     return { blob: await res.blob(), notes };
   },
 


### PR DESCRIPTION
Adds `GET /manuscripts/{id}/source-bundle` (a compilable tar.gz) and `GET /manuscripts/{id}/source-digest` (a content fingerprint).

Independent of the desktop stack — branches off `main` and can merge on its own. It also fixes two pre-existing arXiv-export bugs found in the code it refactors.

## Why the server has to build the bundle

Local LaTeX compilation has exactly one server-side dependency, and this is it.

`assemble_workdir` reads `ManuscriptFile` rows, flushes live CRDT rooms to get the current text of files being edited, generates `references.bib` from the `Paper` table, and copies experiment figures out of `data_dir`. None of that is reproducible on a client. So the workable shape is **server assembles → client downloads → client compiles**, not "client assembles".

Worth stating plainly: the usual argument for local compilation — "it avoids uploading the manuscript" — is wrong. The sources already live in the server's database. The real wins are a dedicated CPU (the server enforces a hard 120s timeout and api/worker share one machine), the user's own TeX Live and packages, and working offline.

## The digest is the cache key

`build_source_digest` hashes each path together with a hash of its content, sorted. Local build output can be stored under `artifacts/manuscripts/<id>/<digest>/`, which means **stale artifacts expire on their own** — change the source, get a different digest, miss the cache. There is no invalidation logic to write or to get wrong.

It ships in the download filename rather than a response header: reading a custom header cross-origin requires `expose_headers` in the CORS config, and this avoids coupling to that. `/source-digest` exists separately so a client can ask "is my cache still valid?" without downloading the tarball — the common case.

## Two pre-existing bugs fixed

Both are in code this PR refactors, so fixing them here rather than filing them separately.

**1 · arXiv exports silently lost their figures.** Build artifacts were dropped by suffix, and the list contained `.pdf` — but PDF is the most common LaTeX figure format, so every figure PDF was stripped from the submission tarball. `.gz` and `.xml` were equally broad and would drop a manuscript's own data files.

Artifacts are now matched by *name*: the compiled PDF only when it sits at the bundle root (`figures/main.pdf` is a figure, not output), plus `*.synctex.gz` and `*.run.xml`. `.bbl` is still kept for arXiv.

**2 · arXiv export returned 500 on any machine without tectonic.** `X-Export-Notes` carried Chinese text in an HTTP header, and headers are latin-1 only, so starlette raised `UnicodeEncodeError` while encoding the response. The notes are only populated when no compiler is found, which is why this never showed up in CI or on the texbase image — but it is exactly what a fresh deployment would hit. The header is now percent-encoded, with `decodeURIComponent` on the client.

## Verification

New `tests/test_source_bundle.py`, 10 tests, all passing.

The artifact rules are covered as a pure unit test, since that is where a careless edit silently deletes user files:

```
drops main.aux / main.log / main.fdb_latexmk / main.bcf
drops main.pdf at the root but keeps figures/main.pdf
keeps img/plot.pdf and figures/exp-1.pdf
drops main.synctex.gz and main.run.xml, keeps data/results.xml and data/corpus.gz
```

Plus end-to-end coverage: the bundle contains sources and figure PDFs, the filename carries the digest, the digest is stable across identical reads and changes when the source set changes, arXiv export keeps figure PDFs (regression), and a non-member is refused.

`pytest tests/test_latex_compile.py tests/test_manuscripts.py tests/test_manuscript_files.py tests/test_source_bundle.py` → 29 passed. `ruff check` clean for everything this PR touches (3 remaining findings are pre-existing in `test_admin_user_crud.py` and `test_me_llm_extras.py`). Frontend `npm run build` passes.

## Follow-up, not done here

`X-Export-Notes` still cannot be read by the desktop client cross-origin — that needs `expose_headers` on the CORS middleware, which #103 already touches. Left out to avoid a rebase conflict over the same block.

Part of #97
