### PR TITLE
fix(frontend): tidy the topic workbench layout on phones

### DIFF
--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -681,21 +681,21 @@ export function DashboardPage() {
             onNavigate={navigate}
           />
 
-          <div className="row gap16" style={{ marginBottom: 24 }}>
+          <div className="row gap16 dash-stats" style={{ marginBottom: 24 }}>
             {statCards.map((s) => (
               <StatCard key={s.label} {...s} />
             ))}
           </div>
 
-          <div className="row gap20" style={{ alignItems: 'flex-start' }}>
-            <div className="col gap20" style={{ flex: 1.5, minWidth: 0 }}>
+          <div className="row gap20 dash-main" style={{ alignItems: 'flex-start' }}>
+            <div className="col gap20 dash-primary">
               <FeaturedIdeaCard pid={currentProjectId} />
               <ActivityFeed
                 activities={statsQuery.data?.recent_activities ?? []}
                 error={statsQuery.isError}
               />
             </div>
-            <div style={{ flex: 1, minWidth: 0, position: 'sticky', top: 0 }}>
+            <div className="dash-side">
               <GatePreview gates={pendingGates} gatesError={gatesError} openGates={openGates} />
             </div>
           </div>

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -252,6 +252,10 @@ input {
 /* 页头右侧操作区（原为组件内联样式，挪到这里以便窄屏覆盖） */
 .page-head-actions { flex-shrink: 0; margin-left: 16px; }
 
+/* —— 课题工作台：指标卡行 + 主次两栏（原为内联样式，挪到这里以便窄屏覆盖）—— */
+.dash-primary { flex: 1.5; min-width: 0; }
+.dash-side { flex: 1; min-width: 0; position: sticky; top: 0; }
+
 /* —— 整屏「列表 + 详情」页（相关研究 / 我的文献库 / 每日新论文 / 公共库浏览）——
    页面与卡片撑满视口高度，滚动发生在 .split 内部的两块里。原本这两组样式在
    4-5 个页面里各写了一份内联，改成共享类以便窄屏统一解除高度锁定。 */
@@ -1121,6 +1125,15 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   .split .split-list { max-height: 70vh; }
   .split-detail { display: block; }
   .split-detail > * { flex: none; overflow: visible; }
+
+  /* 工作台：4 张指标卡是 flex:1，折行后每行分到的宽度不同、大小参差；
+     改 2×2 网格，四张卡等宽等高。 */
+  .dash-stats { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  /* 主次两栏（1.5:1）的 flex-basis 是 0，窄屏下只会一起压扁而不是换行，
+     两边内容都被挤到逐字断行；直接改上下单栏。 */
+  .dash-main { display: block; }
+  .dash-primary + .dash-side { margin-top: 20px; }
+  .dash-side { position: static; }
 
   /* 页头（全站 17 个页面共用）：右侧操作区不压缩、标题 flex-basis 为 0，
      同排会把标题挤成窄条逐字换行。窄屏改成标题在上、操作区在下。 */


### PR DESCRIPTION
Follow-up to #101, from reviewing the topic workbench at phone width.

Two containers on the overview tab were left ragged. Neither clipped anything, so the automated audit passed them — they were just untidy.

**Stat cards.** The four cards are `flex: 1` with no basis, so once `.row` wraps them they split each line by content rather than evenly: the first card came out wider and taller than its neighbours, and the fourth dropped onto a line of its own. Now a 2×2 grid — four cards at an identical 170×116.

**Main / side columns.** The 1.5:1 pair below has `flex-basis: 0`, so on a narrow viewport the two columns compress side by side instead of wrapping. The featured idea broke one character per line ("SafeGRPO-OPD：校 / 准约束下的开放域混合 / 训练") and the approvals card wrapped its own title onto two lines. They now stack full-width, and the side column drops `position: sticky`, which has nothing left to stick against once stacked.

Both sets of styles moved out of inline props into CSS. Inline rules outrank the stylesheet, so the breakpoint had no way to override them — the same reason the pipeline gap and the page-head spacing were moved in #101.

## Verification

`tsc --noEmit` and `vite build` pass.

Desktop and tablet are unchanged — at 1440 and 1024 the stat row is still `flex` with four equal cards (256px / 162px), the columns are still side by side at a 1.50 ratio, and the side column keeps `position: sticky`.

Re-ran the audit from #101 across 21 routes at 390×844: zero clipped, zero collapsed.

Not addressed: the `composite` label inside the score ring sits flush against the ring edge (37.6px of text in a 38px circle). Measured at both 390 and 1440 — it does not overflow and looks identical on desktop, so it is a pre-existing tight fit rather than anything this branch introduced.
