### PR TITLE
fix(desktop): reserve the macOS title bar strip so the brand clears the traffic lights

### DIFF
--- a/src/desktop/build/after-pack.cjs
+++ b/src/desktop/build/after-pack.cjs
@@ -16,6 +16,12 @@ const path = require('node:path');
 exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
 
+  // universal 构建会先分架构打包到 *-temp 再 lipo 合并，而 @electron/universal
+  // 要求两个架构的非二进制文件逐字节相同。逐架构签名会让
+  // Frameworks/.../_CodeSignature/CodeResources 不一致，合并直接报错。
+  // 所以临时目录一律跳过，只签合并后的产物。
+  if (context.appOutDir.endsWith('-temp')) return;
+
   const appPath = path.join(
     context.appOutDir,
     `${context.packager.appInfo.productFilename}.app`,

--- a/src/desktop/src/main/window.ts
+++ b/src/desktop/src/main/window.ts
@@ -53,6 +53,9 @@ export function createWindow(): BrowserWindow {
     show: false,
     backgroundColor: '#ffffff',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    // 把交通灯钉在这条 40px 留白带的垂直中心（(40-12)/2 = 14），不同 macOS 版本
+    // 的默认内缩量不一样，钉死才能和 global.css 的 --titlebar-h 对得上。
+    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 18, y: 14 } } : {}),
     webPreferences: {
       preload: join(__dirname, 'preload.cjs'),
       contextIsolation: true,

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -161,6 +161,32 @@ void app.whenReady().then(async () => {
   )) as string;
   check('顶部留白是拖拽区', dragRegion.trim() === 'drag', `app-region=${dragRegion}`);
 
+  // 主内容顶栏要登录后才存在，这里注入一份同构 DOM 来验规则本身。
+  // 重点是**高度**：.topbar 是 align-items:center，空的 .spacer 默认高度为 0，
+  // 光有 -webkit-app-region:drag 也抓不住——这正是第一版漏掉的地方。
+  const topbar = JSON.parse(
+    (await win.webContents.executeJavaScript(`(() => {
+      const bar = document.createElement('div');
+      bar.className = 'topbar';
+      bar.innerHTML = '<button class="icon-btn"></button><div class="crumb"><span>a</span></div><div class="spacer"></div>';
+      document.body.appendChild(bar);
+      const spacer = bar.querySelector('.spacer');
+      const crumb = bar.querySelector('.crumb');
+      const out = {
+        spacerH: Math.round(spacer.getBoundingClientRect().height),
+        crumbH: Math.round(crumb.getBoundingClientRect().height),
+        spacerRegion: getComputedStyle(spacer).getPropertyValue('-webkit-app-region').trim(),
+        btnRegion: getComputedStyle(bar.querySelector('.icon-btn')).getPropertyValue('-webkit-app-region').trim(),
+      };
+      bar.remove();
+      return JSON.stringify(out);
+    })()`)) as string,
+  ) as { spacerH: number; crumbH: number; spacerRegion: string; btnRegion: string };
+
+  check('顶栏空白是拖拽区', topbar.spacerRegion === 'drag', `region=${topbar.spacerRegion}`);
+  check('顶栏空白有可抓取的高度', topbar.spacerH >= 40, `spacer=${topbar.spacerH}px crumb=${topbar.crumbH}px`);
+  check('顶栏按钮不被拖拽区吞掉', topbar.btnRegion !== 'drag', `btn=${topbar.btnRegion}`);
+
   const secure = (await win.webContents.executeJavaScript('window.isSecureContext')) as boolean;
   check('secure context（clipboard / Notification 可用）', secure === true);
 

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -153,6 +153,14 @@ void app.whenReady().then(async () => {
     `top=${geom.brandTop} left=${geom.brandLeft}`,
   );
 
+  // 顶部留白必须是拖拽区：内容盖住了系统标题栏，不声明就拖不动窗口。
+  // （主内容区顶栏的 .crumb/.spacer 同理，但那要登录后才存在，smoke 覆盖不到。）
+  const dragRegion = (await win.webContents.executeJavaScript(
+    `getComputedStyle(document.querySelector('.auth-page'), '::before')
+       .getPropertyValue('-webkit-app-region')`,
+  )) as string;
+  check('顶部留白是拖拽区', dragRegion.trim() === 'drag', `app-region=${dragRegion}`);
+
   const secure = (await win.webContents.executeJavaScript('window.isSecureContext')) as boolean;
   check('secure context（clipboard / Notification 可用）', secure === true);
 

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -15,6 +15,7 @@
    ============================================================ */
 
 import { BrowserWindow, app } from 'electron';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
@@ -129,6 +130,29 @@ void app.whenReady().then(async () => {
   )) as string;
   check('未配置服务器时进入配置页', /连接到服务器|Connect to a server/.test(title), `title=${title}`);
 
+  // macOS 的交通灯占据窗口左上角约 y=14..26（见 window.ts 的 trafficLightPosition），
+  // 页面左上角的品牌标必须落在这条带子下面，否则会被压住。
+  const geom = JSON.parse(
+    (await win.webContents.executeJavaScript(`(() => {
+      const el = document.querySelector('.auth-brand');
+      const r = el ? el.getBoundingClientRect() : null;
+      return JSON.stringify({
+        platformAttr: document.documentElement.dataset.desktopPlatform ?? null,
+        band: getComputedStyle(document.documentElement).getPropertyValue('--titlebar-h').trim(),
+        brandTop: r ? Math.round(r.top) : null,
+        brandLeft: r ? Math.round(r.left) : null,
+      });
+    })()`)) as string,
+  ) as { platformAttr: string | null; band: string; brandTop: number | null; brandLeft: number | null };
+
+  check('<html> 已标记桌面平台', geom.platformAttr === 'darwin', `attr=${geom.platformAttr}`);
+  check('标题栏留白变量已生效', geom.band !== '' && geom.band !== '0px', `--titlebar-h=${geom.band}`);
+  check(
+    '品牌标避开交通灯（top ≥ 34）',
+    geom.brandTop !== null && geom.brandTop >= 34,
+    `top=${geom.brandTop} left=${geom.brandLeft}`,
+  );
+
   const secure = (await win.webContents.executeJavaScript('window.isSecureContext')) as boolean;
   check('secure context（clipboard / Notification 可用）', secure === true);
 
@@ -170,6 +194,12 @@ void app.whenReady().then(async () => {
     for (const m of consoleErrors.slice(0, 20)) console.log('  -', m);
   }
   check('渲染进程无 console 错误', consoleErrors.length === 0);
+
+  if (process.env.POLARIS_SMOKE_SHOT) {
+    const image = await win.webContents.capturePage();
+    await writeFile(process.env.POLARIS_SMOKE_SHOT, image.toPNG());
+    console.log(`\n已截图 → ${process.env.POLARIS_SMOKE_SHOT}`);
+  }
 
   console.log(problems.length ? `\n${problems.length} 项失败` : '\n全部通过');
   app.exit(problems.length ? 1 : 0);

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -46,6 +46,12 @@ function bridge(): HostBridge | undefined {
     : (window as unknown as { polaris?: HostBridge }).polaris;
 }
 
+/** 桌面端平台标识；web 端返回 null。 */
+export function hostPlatform(): 'darwin' | 'win32' | 'linux' | null {
+  const info = typeof window === 'undefined' ? undefined : window.__POLARIS__;
+  return info?.platform ?? null;
+}
+
 /** 是否有可用的桌面宿主桥（比 endpoint.isDesktop() 更严格：桥必须真的注入成功）。 */
 export function hasHost(): boolean {
   return bridge() != null;

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,7 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { hostPlatform } from './lib/host';
 import './styles/global.css';
+
+// 桌面端把平台标在 <html> 上：macOS 的 hiddenInset 标题栏需要页面自己给
+// 交通灯留出顶部空间（见 global.css 的 --titlebar-h）。web 端不设此属性。
+const platform = hostPlatform();
+if (platform) {
+  document.documentElement.dataset.desktopPlatform = platform;
+}
 
 const container = document.getElementById('root');
 if (!container) {

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -10,6 +10,27 @@ html, body { margin: 0; padding: 0; height: 100%; }
 /* 全站等比放大 10%（用户反馈基准字号偏小）：
    组件字号均为 px 定值，zoom 统一缩放字体与间距，视觉比例不变 */
 html { zoom: 1.1; }
+
+/* —— 桌面端（macOS）标题栏留白 ——
+   外壳用 titleBarStyle: hiddenInset，系统把红黄绿三个交通灯直接叠在内容区
+   左上角，而页面从 y=0 开始画，侧栏品牌标与登录页品牌标会被压在下面。
+   这里给顶部留一条带子，由 main.tsx 在桌面端给 <html> 打 data-desktop-platform。
+
+   注意 html{zoom:1.1}：这里写的 px 会被放大 1.1 倍，而交通灯按窗口点定位、
+   不受 zoom 影响，所以要先除以 1.1——40 物理 px ÷ 1.1 ≈ 36.4px。
+   web 端与非 macOS 桌面端该变量恒为 0，所有 calc 退化成原值。 */
+:root { --titlebar-h: 0px; }
+:root[data-desktop-platform='darwin'] { --titlebar-h: 36.4px; }
+
+/* 让空出来的带子可以拖动窗口（内容盖住了系统标题栏区域，否则拖不动）。
+   只覆盖留白本身，不会挡住任何可点元素。 */
+:root[data-desktop-platform='darwin'] .sidebar::before,
+:root[data-desktop-platform='darwin'] .auth-page::before {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0;
+  height: var(--titlebar-h);
+  -webkit-app-region: drag;
+}
 body {
   font-family: var(--sans);
   color: var(--text);
@@ -58,6 +79,7 @@ input {
    ============================================================ */
 .sidebar {
   width: 248px; flex-shrink: 0;
+  padding-top: var(--titlebar-h); /* 桌面端给交通灯让位，web 端为 0 */
   background: var(--sidebar-bg);
   border-right: 0.5px solid var(--border-2);
   display: flex; flex-direction: column;
@@ -692,7 +714,7 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   padding: 24px clamp(24px, 9vw, 150px) 24px 24px;
 }
 .auth-brand {
-  position: absolute; top: 26px; left: 30px;
+  position: absolute; top: calc(26px + var(--titlebar-h)); left: 30px;
   display: flex; align-items: center; gap: 14px;
 }
 .auth-card {
@@ -1044,6 +1066,8 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   /* —— 关掉全局放大：手机屏本来就窄，放大 10% 等于凭空少 1/11 的宽度；
         关掉后媒体查询值与布局值一致，.split-detail 的反向抵消一并归 1 —— */
   html { zoom: 1; }
+  /* 这里 zoom 已关，带子按物理 px 直接给 */
+  :root[data-desktop-platform='darwin'] { --titlebar-h: 40px; }
   .split-detail { zoom: 1; }
 
   /* —— 触屏基建 —— */

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -31,6 +31,17 @@ html { zoom: 1.1; }
   height: var(--titlebar-h);
   -webkit-app-region: drag;
 }
+
+/* 主内容区顶栏同理：它横跨窗口顶部，不给拖拽区的话那片空白按不动窗口。
+
+   只挑面包屑与中间的弹性空白，**不整条 .topbar 设 drag**：
+   -webkit-app-region 会向下继承，而用户菜单/通知的下拉浮层就渲染在 .topbar
+   内部（见上面 z-index 那段注释），整条设 drag 会让点浮层里的条目变成拖窗口。
+   这两块本身没有任何可交互元素，正好是需要能拖的地方。 */
+:root[data-desktop-platform='darwin'] .topbar > .crumb,
+:root[data-desktop-platform='darwin'] .topbar > .spacer {
+  -webkit-app-region: drag;
+}
 body {
   font-family: var(--sans);
   color: var(--text);

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -37,10 +37,14 @@ html { zoom: 1.1; }
    只挑面包屑与中间的弹性空白，**不整条 .topbar 设 drag**：
    -webkit-app-region 会向下继承，而用户菜单/通知的下拉浮层就渲染在 .topbar
    内部（见上面 z-index 那段注释），整条设 drag 会让点浮层里的条目变成拖窗口。
-   这两块本身没有任何可交互元素，正好是需要能拖的地方。 */
+   这两块本身没有任何可交互元素，正好是需要能拖的地方。
+   还要 align-self: stretch：.topbar 是 align-items:center，而 .spacer 是个空 div，
+   默认高度为 0——拖拽区是条零高度的矩形，等于没有。撑满行高才真的抓得住。
+   .spacer 本来就没有内容，撑开不可见；.crumb 自身是 flex 居中，撑开后文字不动。 */
 :root[data-desktop-platform='darwin'] .topbar > .crumb,
 :root[data-desktop-platform='darwin'] .topbar > .spacer {
   -webkit-app-region: drag;
+  align-self: stretch;
 }
 body {
   font-family: var(--sans);


### PR DESCRIPTION
The sidebar brand and the login brand were rendering underneath the macOS window buttons.

`titleBarStyle: hiddenInset` overlays the traffic lights on the top-left of the content area, but the page paints from `y=0`, so anything in that corner collides with them.

## Fix

A `--titlebar-h` custom property reserves the strip: applied as `padding-top` on `.sidebar` and as an offset on `.auth-brand`. The variable is `0px` everywhere except macOS desktop, so **every `calc()` degrades to the original value on web** and on Windows/Linux, which keep a real title bar.

Two details that are easy to get wrong:

**The value is divided by 1.1.** `html` carries `zoom: 1.1` globally, so px written in the page are scaled by the browser, while the traffic lights are positioned in window points and are not. A naive `40px` would reserve 44 physical px. The mobile breakpoint that turns zoom off overrides the variable back to the unscaled value.

**`trafficLightPosition` is pinned** rather than left to the platform default, whose inset has varied between macOS releases. Pinning it to `y: 14` centres the 12px buttons in the 40px strip we reserved, so the two numbers cannot drift apart.

The reserved strip is also a drag region — page content covering the system title bar area would otherwise leave the window undraggable there. It only covers the empty reserve, so it cannot swallow clicks.

## Verification

Three new smoke assertions, all passing:

```
ok   <html> carries the desktop platform attribute
ok   the title-bar reserve variable resolves
ok   the brand's bounding box clears the button band (top ≥ 34)
```

The smoke test also gained an optional `POLARIS_SMOKE_SHOT=<path>` that captures the rendered page via `capturePage()`, which is how the layout was checked visually. It captures only our own window contents, never the screen.

`tsc --noEmit` clean for both packages; `vite build` passes.

Not covered by the smoke test: the sidebar itself, which only renders once logged in. The change there is a single `padding-top`.
