### PR TITLE
feat(auth): email verification codes, password reset and remember-me

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,26 @@ POLARIS_ANTHROPIC_API_KEY=
 # 注意：POLARIS_ENV=prod 时此开关被强制忽略，生产永远不会回退 fake，杜绝假内容外泄
 # POLARIS_LLM_FAKE_FALLBACK=1
 
+# ---- 邮件（注册验证码 / 找回密码）----
+# 不填 POLARIS_SMTP_HOST = 关闭邮件系统：注册不要验证码、登录页也不显示「忘记密码」。
+# 连接方式：ssl=建连即 TLS（465，浙大邮箱 994）| starttls=明文建连后升级（587/25）| none=不加密
+POLARIS_SMTP_HOST=
+POLARIS_SMTP_PORT=465
+POLARIS_SMTP_SECURITY=ssl
+POLARIS_SMTP_USER=
+# 邮箱的「专用密码 / 授权码」，不是登录密码
+POLARIS_SMTP_PASSWORD=
+# 发件地址（留空则用 POLARIS_SMTP_USER）与显示名
+POLARIS_SMTP_FROM=
+POLARIS_SMTP_FROM_NAME=Polaris
+POLARIS_SMTP_TIMEOUT=20
+# 浙大邮箱示例（专用密码在邮箱设置里生成，切勿把真实密码提交进仓库）：
+#   POLARIS_SMTP_HOST=smtp.zju.edu.cn
+#   POLARIS_SMTP_PORT=994
+#   POLARIS_SMTP_SECURITY=ssl
+#   POLARIS_SMTP_USER=nb00000@zju.edu.cn
+#   POLARIS_SMTP_PASSWORD=<邮箱专用密码>
+
 # ---- 文献 API ----
 # Semantic Scholar（可空，限流更严）
 POLARIS_S2_API_KEY=

--- a/src/backend/alembic/versions/49ddb68e7cf2_email_verification_codes.py
+++ b/src/backend/alembic/versions/49ddb68e7cf2_email_verification_codes.py
@@ -1,0 +1,45 @@
+"""邮箱验证码表 email_verification_codes（注册验证 / 找回密码）
+
+- email / purpose(register|reset) / code_hash / expires_at / attempts / consumed_at
+
+Revision ID: 49ddb68e7cf2
+Revises: f2d34705e152
+Create Date: 2026-07-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "49ddb68e7cf2"
+down_revision: str | None = "f2d34705e152"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "email_verification_codes",
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("purpose", sa.String(length=16), nullable=False),
+        sa.Column("code_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_email_verification_codes_email", "email_verification_codes", ["email"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_email_verification_codes_email", table_name="email_verification_codes"
+    )
+    op.drop_table("email_verification_codes")

--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -16,21 +16,41 @@ from app.core.config import get_settings
 from app.core.db import get_session
 from app.models.user import User
 from app.schemas.project import ProjectCreate
-from app.schemas.user import UserCreate, UserRead, UserUpdate
+from app.schemas.user import (
+    ResetPasswordRequest,
+    SendCodeRequest,
+    SendCodeResult,
+    UserCreate,
+    UserRead,
+    UserUpdate,
+)
+from app.services import email as email_service
 from app.services import projects as projects_service
 from app.services import registration_codes as codes_service
+from app.services import verification
 
 logger = logging.getLogger(__name__)
 
 JWT_LIFETIME_SECONDS = 60 * 60 * 24  # 24h
+MIN_PASSWORD_LENGTH = 8
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     def __init__(self, user_db: SQLAlchemyUserDatabase) -> None:
         super().__init__(user_db)
-        secret = get_settings().secret_key
+        settings = get_settings()
+        secret = settings.secret_key
         self.reset_password_token_secret = secret
         self.verification_token_secret = secret
+
+    async def validate_password(self, password: str, user: UserCreate | User) -> None:
+        """密码强度下限：≥8 位且同时含字母和数字（与前端强度条的「达标线」一致）。
+        注册与重置密码两条路径都会过这里。"""
+        if len(password) < MIN_PASSWORD_LENGTH:
+            raise exceptions.InvalidPasswordException(reason="PASSWORD_TOO_SHORT")
+        if not (any(c.isalpha() for c in password) and any(c.isdigit() for c in password)):
+            raise exceptions.InvalidPasswordException(reason="PASSWORD_NEEDS_LETTER_AND_DIGIT")
+
 
     async def on_after_register(self, user: User, request: Request | None = None) -> None:
         """首个注册用户自动提升为平台 admin（实验室自举）。"""
@@ -190,6 +210,18 @@ async def register(
     settings.invite_code 静态码（兜底，避免没建过码时无人能注册 / 把管理员锁死）。
     注册码带预设研究方向时，注册成功后自动为新用户建好对应方向的项目。
     """
+    # 邮箱验证码：开启邮件系统后必填必对（未配 SMTP 的部署跳过，否则没人能注册）
+    if get_settings().email_enabled:
+        verified = await verification.verify_code(
+            session,
+            verification.normalize_email(user_create.email),
+            verification.PURPOSE_REGISTER,
+            user_create.email_code,
+        )
+        if not verified:
+            await session.commit()  # 保留 attempts 自增
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INVALID_CODE")
+
     redeemed = await codes_service.redeem_code(session, user_create.invite_code)
     if redeemed is None and user_create.invite_code != get_settings().invite_code:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="INVALID_INVITE_CODE")
@@ -225,6 +257,87 @@ async def register(
         except Exception:  # noqa: BLE001
             logger.exception("preset direction project creation failed: %s", direction)
     return user
+
+
+@router.get("/auth/capabilities", tags=["auth"])
+async def auth_capabilities() -> dict[str, bool]:
+    """前端据此决定是否显示验证码输入与「忘记密码」——没配 SMTP 就别给走不通的入口。"""
+    enabled = get_settings().email_enabled
+    return {"email": enabled, "password_reset": enabled, "register_email_code": enabled}
+
+
+@router.post("/auth/send-code", response_model=SendCodeResult, tags=["auth"])
+async def send_code(
+    payload: SendCodeRequest,
+    session: AsyncSession = Depends(get_session),
+) -> SendCodeResult:
+    """发送邮箱验证码。
+
+    purpose=register：邮箱已注册直接报错（注册接口本来也会告知，不存在额外泄露）。
+    purpose=reset：无论邮箱是否存在都回 sent=true，只在存在时真发信——否则这就成了
+    账号枚举接口。
+    """
+    if not get_settings().email_enabled:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="EMAIL_NOT_CONFIGURED")
+
+    email = verification.normalize_email(payload.email)
+    exists = (
+        await session.execute(select(User.id).where(func.lower(User.email) == email))
+    ).first() is not None
+
+    if payload.purpose == verification.PURPOSE_REGISTER and exists:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="REGISTER_USER_ALREADY_EXISTS")
+
+    remaining = await verification.cooldown_remaining(session, email, payload.purpose)
+    if remaining > 0:
+        return SendCodeResult(sent=False, retry_after=remaining)
+
+    # 邮箱不存在时也照常签发（只是不发信）：否则「第二次请求有没有冷却」本身就能
+    # 区分邮箱是否注册过，等于留了个账号枚举的旁路。
+    code = await verification.issue_code(session, email, payload.purpose)
+    await session.commit()
+    if exists or payload.purpose == verification.PURPOSE_REGISTER:
+        await email_service.send_verification_code(
+            email, payload.purpose, code, verification.CODE_TTL_SECONDS // 60
+        )
+    return SendCodeResult(sent=True)
+
+
+@router.post("/auth/reset-password", tags=["auth"])
+async def reset_password(
+    payload: ResetPasswordRequest,
+    user_manager: UserManager = Depends(get_user_manager),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, bool]:
+    """凭邮箱验证码重设密码。验证码错误与邮箱不存在返回同一个错误码，避免枚举。"""
+    if not get_settings().email_enabled:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="EMAIL_NOT_CONFIGURED")
+
+    email = verification.normalize_email(payload.email)
+    ok = await verification.verify_code(session, email, verification.PURPOSE_RESET, payload.code)
+    if not ok:
+        await session.commit()  # 保留 attempts 自增
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INVALID_CODE")
+
+    user = (
+        await session.execute(select(User).where(func.lower(User.email) == email))
+    ).scalar_one_or_none()
+    if user is None:
+        await session.commit()
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="INVALID_CODE")
+
+    try:
+        await user_manager.validate_password(payload.password, user)
+    except exceptions.InvalidPasswordException as e:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_PASSWORD", "reason": e.reason},
+        ) from e
+
+    user.hashed_password = user_manager.password_helper.hash(payload.password)
+    await session.commit()
+    logger.info("密码已重置：user_id=%s", user.id)
+    return {"ok": True}
 
 
 @router.get("/auth/username-available", tags=["auth"])

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -51,6 +51,18 @@ class Settings(BaseSettings):
     s2_api_key: str = ""  # Semantic Scholar（可空，限流更严）
     openalex_mailto: str = "polaris@example.org"  # OpenAlex polite pool
 
+    # ---- 邮件（密码重置等事务邮件）----
+    # smtp_host 为空 = 关闭发信：忘记密码入口在前端自动隐藏（见 /auth/capabilities）。
+    smtp_host: str = ""
+    smtp_port: int = 465
+    # ssl=建连即 TLS（465/994）｜starttls=明文建连后升级（587/25）｜none=不加密（仅内网调试）
+    smtp_security: Literal["ssl", "starttls", "none"] = "ssl"
+    smtp_user: str = ""
+    smtp_password: str = ""
+    smtp_from: str = ""  # 发件地址；留空回退 smtp_user
+    smtp_from_name: str = "Polaris"
+    smtp_timeout: int = 20
+
     # ---- 文件卷（PDF/全文等产物；容器内挂 /srv/data）----
     data_dir: str = "./data"
     # 文献 API（arXiv/S2/OpenAlex）出站代理，如 http://host.docker.internal:7897；
@@ -94,6 +106,15 @@ class Settings(BaseSettings):
     @property
     def is_sqlite(self) -> bool:
         return self.database_url.startswith("sqlite")
+
+    @property
+    def email_enabled(self) -> bool:
+        """配了发信服务器才算开启；未开启时忘记密码入口整条链路都不暴露。"""
+        return bool(self.smtp_host and self.email_from_address)
+
+    @property
+    def email_from_address(self) -> str:
+        return self.smtp_from or self.smtp_user
 
     @property
     def cors_origin_list(self) -> list[str]:

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.activity import Activity
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
+from app.models.email_code import EmailVerificationCode
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
@@ -44,6 +45,7 @@ __all__ = [
     "DailyFeedEntry",
     "DailyFeedLike",
     "DirectionLibrary",
+    "EmailVerificationCode",
     "DirectionLibraryCurator",
     "Experiment",
     "ExperimentRun",

--- a/src/backend/app/models/email_code.py
+++ b/src/backend/app/models/email_code.py
@@ -1,0 +1,25 @@
+"""邮箱验证码：注册验证与找回密码共用一张表。
+
+只存 HMAC 摘要不存明文——库被看到也无法直接冒用；配合尝试次数上限与
+重发冷却，抵御暴力猜码。已消费/过期的记录由服务层顺手清理。
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class EmailVerificationCode(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "email_verification_codes"
+
+    email: Mapped[str] = mapped_column(String(320), index=True, nullable=False)
+    # register = 注册邮箱验证 | reset = 找回密码
+    purpose: Mapped[str] = mapped_column(String(16), nullable=False)
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/schemas/user.py
+++ b/src/backend/app/schemas/user.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from fastapi_users import schemas
 from pydantic import BaseModel, EmailStr, Field
@@ -42,16 +42,41 @@ class UserCreate(schemas.BaseUserCreate):
     display_name: str = Field(min_length=1, max_length=255)
     username: str = Field(pattern=USERNAME_PATTERN)
     invite_code: str  # 与 settings.invite_code 比对，见 api/auth.py
+    # 邮箱验证码（先 POST /auth/send-code 获取）；未开启邮件系统时可留空
+    email_code: str = ""
 
     def create_update_dict(self) -> dict[str, Any]:
         d = super().create_update_dict()
-        d.pop("invite_code", None)  # 非表字段，入库前剔除
+        for k in ("invite_code", "email_code"):  # 非表字段，入库前剔除
+            d.pop(k, None)
         return d
 
     def create_update_dict_superuser(self) -> dict[str, Any]:
         d = super().create_update_dict_superuser()
-        d.pop("invite_code", None)
+        for k in ("invite_code", "email_code"):
+            d.pop(k, None)
         return d
+
+
+class SendCodeRequest(BaseModel):
+    """申请邮箱验证码。"""
+
+    email: EmailStr
+    purpose: Literal["register", "reset"]
+
+
+class SendCodeResult(BaseModel):
+    sent: bool
+    # 冷却中时的剩余秒数（前端据此倒计时）
+    retry_after: int = 0
+
+
+class ResetPasswordRequest(BaseModel):
+    """凭邮箱验证码重设密码。"""
+
+    email: EmailStr
+    code: str = Field(min_length=4, max_length=8)
+    password: str = Field(min_length=8, max_length=128)
 
 
 class UserUpdate(schemas.BaseUserUpdate):

--- a/src/backend/app/services/email.py
+++ b/src/backend/app/services/email.py
@@ -1,0 +1,102 @@
+"""事务邮件发送（目前只有密码重置）。
+
+刻意用标准库 smtplib 而不是 aiosmtplib：发信都是人触发的低频动作，丢进线程池
+调一次就够，省掉一个依赖和一次镜像重建。发信失败只记日志、不向调用方抛错——
+忘记密码接口必须对「邮箱是否存在、信是否发出去」保持沉默，否则它就成了账号
+枚举接口。
+
+SMTP 连接方式由 POLARIS_SMTP_SECURITY 决定：
+  ssl       建连即 TLS（465 / 浙大 994）
+  starttls  明文建连后 STARTTLS 升级（587 / 25）
+  none      不加密，仅限内网调试
+"""
+
+import asyncio
+import logging
+import smtplib
+import ssl
+from email.message import EmailMessage
+from email.utils import formataddr
+
+from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _build_message(to: str, subject: str, text: str, html: str) -> EmailMessage:
+    settings = get_settings()
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = formataddr((settings.smtp_from_name, settings.email_from_address))
+    msg["To"] = to
+    msg.set_content(text)
+    msg.add_alternative(html, subtype="html")
+    return msg
+
+
+def _send_sync(msg: EmailMessage) -> None:
+    """阻塞发信；调用方负责丢线程池。"""
+    settings = get_settings()
+    context = ssl.create_default_context()
+    host, port, timeout = settings.smtp_host, settings.smtp_port, settings.smtp_timeout
+
+    if settings.smtp_security == "ssl":
+        server: smtplib.SMTP = smtplib.SMTP_SSL(host, port, timeout=timeout, context=context)
+    else:
+        server = smtplib.SMTP(host, port, timeout=timeout)
+    with server:
+        if settings.smtp_security == "starttls":
+            server.starttls(context=context)
+        if settings.smtp_user:
+            server.login(settings.smtp_user, settings.smtp_password)
+        server.send_message(msg)
+
+
+async def send_mail(to: str, subject: str, text: str, html: str) -> bool:
+    """发一封信，返回是否成功。异常一律吞掉并记日志（见模块 docstring）。"""
+    settings = get_settings()
+    if not settings.email_enabled:
+        logger.warning("未配置 SMTP（POLARIS_SMTP_HOST 为空），跳过发信：%s", subject)
+        return False
+    try:
+        await asyncio.to_thread(_send_sync, _build_message(to, subject, text, html))
+    except Exception:  # noqa: BLE001 —— 发信失败不能冒泡成 500
+        logger.exception("发信失败：to=%s subject=%s", to, subject)
+        return False
+    logger.info("已发信：to=%s subject=%s", to, subject)
+    return True
+
+
+_PURPOSE_COPY = {
+    "register": ("注册 Polaris 账号", "你正在注册 Polaris 账号"),
+    "reset": ("重置 Polaris 密码", "我们收到了重置你 Polaris 账号密码的请求"),
+}
+
+
+async def send_verification_code(to: str, purpose: str, code: str, minutes: int) -> bool:
+    """验证码邮件：注册验证与找回密码共用一套版式，文案按 purpose 切换。"""
+    subject_tail, lead = _PURPOSE_COPY.get(purpose, _PURPOSE_COPY["register"])
+
+    text = (
+        f"{lead}，验证码如下（{minutes} 分钟内有效）：\n\n"
+        f"    {code}\n\n"
+        "请勿把验证码转发给任何人。如果这不是你本人的操作，忽略这封邮件即可。\n\n"
+        "—— Polaris 北极星 AI 科研智能体\n"
+    )
+    html = f"""\
+<div style="font-family:-apple-system,'PingFang SC','Microsoft YaHei',sans-serif;
+            font-size:14px;line-height:1.7;color:#1c2430;max-width:520px">
+  <p>{lead}，请在页面中填入下面的验证码：</p>
+  <p style="margin:24px 0">
+    <span style="display:inline-block;background:#f2f6fc;border:1px solid #d7e3f4;
+                 border-radius:10px;padding:14px 26px;font-size:28px;font-weight:700;
+                 letter-spacing:10px;color:#126DFF">{code}</span>
+  </p>
+  <p style="color:#6b7785;font-size:12.5px">
+    验证码 <b>{minutes} 分钟</b>内有效，请勿转发给任何人。
+  </p>
+  <p style="color:#6b7785;font-size:12.5px">如果这不是你本人的操作，忽略这封邮件即可。</p>
+  <p style="color:#94a3b3;font-size:12px;margin-top:28px">—— Polaris 北极星 AI 科研智能体</p>
+</div>
+"""
+    return await send_mail(to, f"{code} —— {subject_tail}验证码", text, html)

--- a/src/backend/app/services/verification.py
+++ b/src/backend/app/services/verification.py
@@ -1,0 +1,126 @@
+"""邮箱验证码：签发、校验、重发冷却与猜码限次。
+
+注册验证与找回密码共用这套设施，靠 purpose 区分，互不通用（拿注册码去重置
+密码不成立）。库里只存 HMAC 摘要；过期时间与冷却一律在 SQL 里比较，避开
+sqlite 取回 naive datetime、与 aware 时间比较报错的老问题。
+"""
+
+import hashlib
+import hmac
+import logging
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.email_code import EmailVerificationCode
+
+logger = logging.getLogger(__name__)
+
+CODE_TTL_SECONDS = 10 * 60
+RESEND_COOLDOWN_SECONDS = 60
+MAX_ATTEMPTS = 5
+
+PURPOSE_REGISTER = "register"
+PURPOSE_RESET = "reset"
+
+
+def normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def _digest(code: str) -> str:
+    secret = get_settings().secret_key.encode()
+    return hmac.new(secret, code.encode(), hashlib.sha256).hexdigest()
+
+
+def _generate_code() -> str:
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+async def cooldown_remaining(session: AsyncSession, email: str, purpose: str) -> int:
+    """距离可以重发还剩几秒；0 = 现在就能发。"""
+    now = datetime.now(UTC)
+    since = now - timedelta(seconds=RESEND_COOLDOWN_SECONDS)
+    last = (
+        await session.execute(
+            select(EmailVerificationCode.created_at)
+            .where(
+                EmailVerificationCode.email == email,
+                EmailVerificationCode.purpose == purpose,
+                EmailVerificationCode.created_at > since,
+            )
+            .order_by(EmailVerificationCode.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if last is None:
+        return 0
+    if last.tzinfo is None:  # sqlite 取回 naive，按 UTC 解读
+        last = last.replace(tzinfo=UTC)
+    remaining = RESEND_COOLDOWN_SECONDS - int((now - last).total_seconds())
+    return max(0, remaining)
+
+
+async def issue_code(session: AsyncSession, email: str, purpose: str) -> str:
+    """签发新码并作废该邮箱同用途的旧码（旧码立刻失效，避免多码并存）。
+
+    调用方须先用 cooldown_remaining 挡住高频重发。不 commit，交给上层事务。
+    """
+    now = datetime.now(UTC)
+    await session.execute(
+        delete(EmailVerificationCode).where(
+            EmailVerificationCode.email == email,
+            EmailVerificationCode.purpose == purpose,
+        )
+    )
+    code = _generate_code()
+    session.add(
+        EmailVerificationCode(
+            email=email,
+            purpose=purpose,
+            code_hash=_digest(code),
+            expires_at=now + timedelta(seconds=CODE_TTL_SECONDS),
+        )
+    )
+    await session.flush()
+    return code
+
+
+async def verify_code(session: AsyncSession, email: str, purpose: str, code: str) -> bool:
+    """校验并消费验证码。错一次记一次，超过 MAX_ATTEMPTS 直接作废本轮码。"""
+    now = datetime.now(UTC)
+    row = (
+        await session.execute(
+            select(EmailVerificationCode)
+            .where(
+                EmailVerificationCode.email == email,
+                EmailVerificationCode.purpose == purpose,
+                EmailVerificationCode.consumed_at.is_(None),
+                EmailVerificationCode.expires_at > now,
+                EmailVerificationCode.attempts < MAX_ATTEMPTS,
+            )
+            .order_by(EmailVerificationCode.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+
+    # 先记一次尝试，再比对：即便后续抛错，这次猜测也已计入
+    await session.execute(
+        update(EmailVerificationCode)
+        .where(EmailVerificationCode.id == row.id)
+        .values(attempts=EmailVerificationCode.attempts + 1)
+    )
+    if not hmac.compare_digest(row.code_hash, _digest(code.strip())):
+        return False
+
+    await session.execute(
+        update(EmailVerificationCode)
+        .where(EmailVerificationCode.id == row.id)
+        .values(consumed_at=now)
+    )
+    return True

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -78,6 +78,16 @@ async def test_username_available(client):
     assert resp.json() == {"available": False}
 
 
+async def test_password_policy_rejects_weak(client):
+    resp = await client.post("/api/auth/register", json=_register_body(password="short1"))
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["reason"] == "PASSWORD_TOO_SHORT"
+
+    resp = await client.post("/api/auth/register", json=_register_body(password="onlyletters"))
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["reason"] == "PASSWORD_NEEDS_LETTER_AND_DIGIT"
+
+
 async def test_me_requires_auth(client):
     resp = await client.get("/api/users/me")
     assert resp.status_code == 401

--- a/src/backend/tests/test_email_auth.py
+++ b/src/backend/tests/test_email_auth.py
@@ -1,0 +1,214 @@
+"""邮箱验证码：注册验证、找回密码、冷却与限次。"""
+
+import pytest
+
+from app.core.config import get_settings
+from tests.conftest import INVITE_CODE
+
+EMAIL = "bob@example.com"
+
+
+@pytest.fixture
+def email_on():
+    """打开邮件系统（Settings 是 lru_cache 单例，直接改字段再还原）。"""
+    s = get_settings()
+    before = (s.smtp_host, s.smtp_user, s.smtp_from)
+    s.smtp_host, s.smtp_user, s.smtp_from = "smtp.test", "polaris@test", "polaris@test"
+    yield
+    s.smtp_host, s.smtp_user, s.smtp_from = before
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """截获发信，返回 [(email, purpose, code), ...]。"""
+    out: list[tuple[str, str, str]] = []
+
+    async def fake_send(to, purpose, code, minutes):
+        out.append((to, purpose, code))
+        return True
+
+    monkeypatch.setattr("app.services.email.send_verification_code", fake_send)
+    return out
+
+
+def _register_body(**overrides):
+    body = {
+        "email": EMAIL,
+        "password": "str0ng-password",
+        "display_name": "Bob",
+        "username": "bob",
+        "invite_code": INVITE_CODE,
+    }
+    body.update(overrides)
+    return body
+
+
+async def _get_code(client, sent, purpose, email=EMAIL):
+    resp = await client.post("/api/auth/send-code", json={"email": email, "purpose": purpose})
+    assert resp.status_code == 200, resp.text
+    return sent[-1][2]
+
+
+async def test_capabilities_follows_smtp_config(client, email_on):
+    assert (await client.get("/api/auth/capabilities")).json() == {
+        "email": True,
+        "password_reset": True,
+        "register_email_code": True,
+    }
+
+
+async def test_capabilities_off_without_smtp(client):
+    body = (await client.get("/api/auth/capabilities")).json()
+    assert body["email"] is False and body["password_reset"] is False
+
+
+async def test_send_code_requires_email_configured(client):
+    resp = await client.post(
+        "/api/auth/send-code", json={"email": EMAIL, "purpose": "register"}
+    )
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "EMAIL_NOT_CONFIGURED"
+
+
+async def test_register_requires_valid_email_code(client, email_on, sent):
+    # 不带验证码
+    resp = await client.post("/api/auth/register", json=_register_body())
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "INVALID_CODE"
+
+    # 带错误验证码
+    code = await _get_code(client, sent, "register")
+    wrong = "000000" if code != "000000" else "111111"
+    resp = await client.post("/api/auth/register", json=_register_body(email_code=wrong))
+    assert resp.status_code == 400
+
+    # 正确验证码
+    resp = await client.post("/api/auth/register", json=_register_body(email_code=code))
+    assert resp.status_code == 201, resp.text
+    assert sent[0][1] == "register"
+
+
+async def test_register_code_is_single_use(client, email_on, sent):
+    code = await _get_code(client, sent, "register")
+    assert (
+        await client.post("/api/auth/register", json=_register_body(email_code=code))
+    ).status_code == 201
+    resp = await client.post(
+        "/api/auth/register",
+        json=_register_body(email="other@example.com", username="other", email_code=code),
+    )
+    assert resp.status_code == 400
+
+
+async def test_send_code_rejects_registered_email(client, email_on, sent):
+    code = await _get_code(client, sent, "register")
+    await client.post("/api/auth/register", json=_register_body(email_code=code))
+
+    resp = await client.post(
+        "/api/auth/send-code", json={"email": EMAIL, "purpose": "register"}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "REGISTER_USER_ALREADY_EXISTS"
+
+
+async def test_send_code_cooldown(client, email_on, sent):
+    assert (
+        await client.post("/api/auth/send-code", json={"email": EMAIL, "purpose": "register"})
+    ).json() == {"sent": True, "retry_after": 0}
+
+    body = (
+        await client.post("/api/auth/send-code", json={"email": EMAIL, "purpose": "register"})
+    ).json()
+    assert body["sent"] is False and 0 < body["retry_after"] <= 60
+    assert len(sent) == 1  # 冷却期内不重复发信
+
+
+async def test_reset_code_silent_for_unknown_email(client, email_on, sent):
+    resp = await client.post(
+        "/api/auth/send-code", json={"email": "nobody@example.com", "purpose": "reset"}
+    )
+    assert resp.json()["sent"] is True  # 不暴露邮箱是否注册过
+    assert sent == []
+
+
+async def test_reset_cooldown_identical_for_unknown_email(client, email_on, sent):
+    """冷却行为必须与已注册邮箱一致，否则「第二次有没有冷却」就是账号枚举旁路。"""
+    known = EMAIL
+    code = await _get_code(client, sent, "register")
+    await client.post("/api/auth/register", json=_register_body(email_code=code))
+
+    async def second_call(email):
+        await client.post("/api/auth/send-code", json={"email": email, "purpose": "reset"})
+        r = await client.post("/api/auth/send-code", json={"email": email, "purpose": "reset"})
+        return r.json()
+
+    known_body = await second_call(known)
+    unknown_body = await second_call("nobody@example.com")
+    assert known_body["sent"] is False and known_body["retry_after"] > 0
+    assert unknown_body["sent"] is False and unknown_body["retry_after"] > 0
+
+
+async def test_reset_password_flow(client, email_on, sent):
+    code = await _get_code(client, sent, "register")
+    await client.post("/api/auth/register", json=_register_body(email_code=code))
+
+    reset_code = await _get_code(client, sent, "reset")
+    assert sent[-1][1] == "reset"
+
+    # 错误验证码
+    wrong = "000000" if reset_code != "000000" else "111111"
+    resp = await client.post(
+        "/api/auth/reset-password",
+        json={"email": EMAIL, "code": wrong, "password": "n3w-password"},
+    )
+    assert resp.status_code == 400 and resp.json()["detail"] == "INVALID_CODE"
+
+    # 新密码也要过强度校验
+    resp = await client.post(
+        "/api/auth/reset-password",
+        json={"email": EMAIL, "code": reset_code, "password": "alllettersonly"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["reason"] == "PASSWORD_NEEDS_LETTER_AND_DIGIT"
+
+    resp = await client.post(
+        "/api/auth/reset-password",
+        json={"email": EMAIL, "code": reset_code, "password": "n3w-password"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # 旧密码失效、新密码可登录
+    assert (
+        await client.post(
+            "/api/auth/jwt/login", data={"username": EMAIL, "password": "str0ng-password"}
+        )
+    ).status_code == 400
+    assert (
+        await client.post(
+            "/api/auth/jwt/login", data={"username": EMAIL, "password": "n3w-password"}
+        )
+    ).status_code == 200
+
+
+async def test_reset_code_cannot_be_used_for_register(client, email_on, sent):
+    """purpose 隔离：找回密码的码不能拿去注册，反之亦然。"""
+    reg_code = await _get_code(client, sent, "register")
+    await client.post("/api/auth/register", json=_register_body(email_code=reg_code))
+
+    reset_code = await _get_code(client, sent, "reset")
+    resp = await client.post(
+        "/api/auth/register",
+        json=_register_body(email="xavier@example.com", username="xavier", email_code=reset_code),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "INVALID_CODE"
+
+
+async def test_code_attempts_are_capped(client, email_on, sent):
+    code = await _get_code(client, sent, "register")
+    wrong = "000000" if code != "000000" else "111111"
+    for _ in range(5):
+        await client.post("/api/auth/register", json=_register_body(email_code=wrong))
+    # 次数用尽后，正确的码也不再被接受
+    resp = await client.post("/api/auth/register", json=_register_body(email_code=code))
+    assert resp.status_code == 400

--- a/src/frontend/src/app/auth.tsx
+++ b/src/frontend/src/app/auth.tsx
@@ -2,12 +2,13 @@ import { createContext, useCallback, useContext, useMemo, useState, type ReactNo
 import { Navigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { api, getToken, setToken, type RegisterInput } from '../lib/api';
+import { setLastAccount, setRemembered } from '../lib/token-store';
 
 interface AuthValue {
   token: string | null;
   isAuthenticated: boolean;
-  /** 登录成功后 token 写入 localStorage。 */
-  login: (email: string, password: string) => Promise<void>;
+  /** 登录成功后写入 token；remember 决定落 localStorage 还是 sessionStorage。 */
+  login: (email: string, password: string, remember?: boolean) => Promise<void>;
   /** 注册（含邀请码）后自动登录。 */
   register: (input: RegisterInput) => Promise<void>;
   logout: () => void;
@@ -20,8 +21,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
 
   const login = useCallback(
-    async (email: string, password: string) => {
+    async (email: string, password: string, remember = true) => {
       const t = await api.login(email, password);
+      // 先定偏好再写 token：writeToken 据此决定落哪个 storage
+      setRemembered(remember);
+      setLastAccount(remember ? email : null);
       setToken(t);
       setTokenState(t);
       // 切换账号：清空所有缓存查询，避免残留上一个用户的 me/项目/文献库等数据

--- a/src/frontend/src/features/auth/LoginPage.tsx
+++ b/src/frontend/src/features/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -7,12 +7,15 @@ import { PolarisMark, PolarisWordmark } from '../../components/ui/PolarisLogo';
 import { Segmented } from '../../components/ui/Segmented';
 import { useAuth } from '../../app/auth';
 import { ApiError, api } from '../../lib/api';
+import { getLastAccount, isRemembered } from '../../lib/token-store';
 import { tr } from '../../lib/i18n';
 
 type Mode = 'login' | 'register';
+type View = 'auth' | 'forgot';
 type Step = 1 | 2;
 
 const USERNAME_RE = /^[a-z0-9_]{3,32}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function errorMessage(err: unknown): string {
   if (err instanceof ApiError) {
@@ -25,8 +28,17 @@ function errorMessage(err: unknown): string {
     if (err.status === 400 && err.message.includes('USERNAME_TAKEN')) {
       return tr('用户名已被占用，换一个吧', 'Username already taken');
     }
+    if (err.status === 400 && err.message.includes('INVALID_CODE')) {
+      return tr('验证码错误或已过期，请重新获取', 'Invalid or expired code — request a new one');
+    }
+    if (err.status === 400 && err.message.includes('PASSWORD_')) {
+      return tr('密码不符合要求：至少 8 位且含字母和数字', 'Password must be 8+ chars with letters and digits');
+    }
     if (err.status === 403 && err.message.includes('INVALID_INVITE_CODE')) {
       return tr('邀请码无效', 'Invalid invite code');
+    }
+    if (err.status === 503 && err.message.includes('EMAIL_NOT_CONFIGURED')) {
+      return tr('服务器未配置邮件系统，请联系管理员', 'Email is not configured on the server — contact an admin');
     }
     return `${tr('请求失败', 'Request failed')}（${err.status}）：${err.message}`;
   }
@@ -38,7 +50,8 @@ function errorMessage(err: unknown): string {
 
 /**
  * 密码强度：0 = 未达最低要求（≥8 位且同时含字母和数字），1 弱 / 2 中 / 3 强。
- * 达标后按字符类别数（小写/大写/数字/符号）与长度加分。
+ * 达标后按字符类别数（小写/大写/数字/符号）与长度加分。后端 validate_password
+ * 用的是同一条达标线。
  */
 function passwordStrength(pw: string): 0 | 1 | 2 | 3 {
   if (pw.length < 8 || !/[a-zA-Z]/.test(pw) || !/\d/.test(pw)) return 0;
@@ -77,17 +90,127 @@ function PasswordMeter({ password }: { password: string }) {
   );
 }
 
+/** 验证码发送 + 冷却倒计时。冷却由后端裁决（retry_after），前端只做展示。 */
+function useCodeSender(purpose: 'register' | 'reset') {
+  const [cooldown, setCooldown] = useState(0);
+  const [note, setNote] = useState('');
+  const timer = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    timer.current = window.setTimeout(() => setCooldown((c) => c - 1), 1000);
+    return () => window.clearTimeout(timer.current);
+  }, [cooldown]);
+
+  const mutation = useMutation({
+    mutationFn: (email: string) => api.sendAuthCode(email, purpose),
+    onSuccess: (r) => {
+      setCooldown(r.sent ? 60 : r.retry_after);
+      setNote(
+        r.sent
+          ? tr('验证码已发送，请查收邮件', 'Code sent — check your inbox')
+          : tr('发送太频繁，请稍后再试', 'Too many requests — try again shortly'),
+      );
+    },
+  });
+
+  return { cooldown, note, send: mutation.mutate, sending: mutation.isPending, error: mutation.error };
+}
+
+/** 验证码输入框 + 右侧「获取验证码」按钮。 */
+function CodeField({
+  id,
+  code,
+  onCode,
+  email,
+  sender,
+}: {
+  id: string;
+  code: string;
+  onCode: (v: string) => void;
+  email: string;
+  sender: ReturnType<typeof useCodeSender>;
+}) {
+  const emailOk = EMAIL_RE.test(email.trim());
+  return (
+    <div className="auth-field">
+      <label htmlFor={id}>{tr('邮箱验证码', 'Email code')}</label>
+      <div className="auth-code-row">
+        <input
+          id={id}
+          className="auth-input"
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          required
+          maxLength={6}
+          placeholder={tr('6 位验证码', '6-digit code')}
+          value={code}
+          onChange={(e) => onCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+        />
+        <button
+          type="button"
+          className="btn"
+          disabled={!emailOk || sender.cooldown > 0 || sender.sending}
+          onClick={() => sender.send(email.trim())}
+        >
+          {sender.cooldown > 0
+            ? `${sender.cooldown}s`
+            : sender.sending
+              ? tr('发送中', 'Sending')
+              : tr('获取验证码', 'Send code')}
+        </button>
+      </div>
+      {(sender.note || sender.error) && (
+        <div
+          style={{
+            fontSize: 11,
+            marginTop: 4,
+            color: sender.error ? 'var(--danger-tx)' : 'var(--text-4)',
+          }}
+        >
+          {sender.error ? errorMessage(sender.error) : sender.note}
+        </div>
+      )}
+      {!emailOk && (
+        <div style={{ fontSize: 11, marginTop: 4, color: 'var(--text-4)' }}>
+          {tr('先填写上方邮箱，再获取验证码', 'Enter your email above first')}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function LoginPage() {
   const navigate = useNavigate();
   const { isAuthenticated, login, register } = useAuth();
+  const [view, setView] = useState<View>('auth');
   const [mode, setMode] = useState<Mode>('login');
   const [step, setStep] = useState<Step>(1); // 仅注册用：1 账号信息 / 2 设置密码
-  const [identifier, setIdentifier] = useState(''); // 登录：邮箱或用户名；注册：邮箱
+  const [identifier, setIdentifier] = useState(() => getLastAccount());
   const [displayName, setDisplayName] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [password2, setPassword2] = useState('');
   const [inviteCode, setInviteCode] = useState('');
+  const [emailCode, setEmailCode] = useState('');
+  const [remember, setRemember] = useState(() => isRemembered());
+
+  // 忘记密码
+  const [forgotEmail, setForgotEmail] = useState('');
+  const [forgotCode, setForgotCode] = useState('');
+  const [forgotDone, setForgotDone] = useState(false);
+
+  const capabilities = useQuery({
+    queryKey: ['auth-capabilities'],
+    queryFn: () => api.authCapabilities(),
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+  const emailOn = capabilities.data?.email ?? false;
+
+  const registerSender = useCodeSender('register');
+  const resetSender = useCodeSender('reset');
 
   const usernameValid = USERNAME_RE.test(username);
   const pwdLevel = passwordStrength(password);
@@ -113,7 +236,7 @@ export function LoginPage() {
   const mutation = useMutation({
     mutationFn: async () => {
       if (mode === 'login') {
-        await login(identifier, password);
+        await login(identifier, password, remember);
       } else {
         await register({
           email: identifier,
@@ -121,10 +244,16 @@ export function LoginPage() {
           display_name: displayName.trim(),
           username,
           invite_code: inviteCode,
+          email_code: emailCode,
         });
       }
     },
     onSuccess: () => navigate('/', { replace: true }),
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: () => api.resetPassword(forgotEmail.trim(), forgotCode, password),
+    onSuccess: () => setForgotDone(true),
   });
 
   if (isAuthenticated) {
@@ -133,19 +262,28 @@ export function LoginPage() {
 
   const isRegister = mode === 'register';
 
+  function clearPasswords() {
+    setPassword('');
+    setPassword2('');
+  }
+
   function switchMode(m: Mode) {
     setMode(m);
     setStep(1);
-    setPassword('');
-    setPassword2('');
+    clearPasswords();
+    setEmailCode('');
     mutation.reset();
   }
 
-  function backToStep1() {
-    setPassword('');
-    setPassword2('');
-    mutation.reset();
+  function toLogin() {
+    setView('auth');
+    setMode('login');
     setStep(1);
+    clearPasswords();
+    setForgotCode('');
+    setForgotDone(false);
+    resetMutation.reset();
+    mutation.reset();
   }
 
   function onSubmit(e: FormEvent) {
@@ -157,19 +295,143 @@ export function LoginPage() {
     mutation.mutate();
   }
 
-  return (
-    <div className="auth-page">
-      {/* 左上角品牌 */}
+  function onForgotSubmit(e: FormEvent) {
+    e.preventDefault();
+    resetMutation.mutate();
+  }
+
+  const brand = (
+    <>
       <div className="auth-brand">
         <PolarisMark size={56} />
         <PolarisWordmark height={32} />
       </div>
-
       <div style={{ position: 'absolute', top: 18, right: 20 }}>
         <LangToggle />
       </div>
+    </>
+  );
 
-      {/* 右侧表单卡片 */}
+  /* ---------- 忘记密码 ---------- */
+  if (view === 'forgot') {
+    return (
+      <div className="auth-page">
+        {brand}
+        <div className="auth-card fadeup">
+          <div className="auth-card-title">{tr('找回密码', 'Reset password')}</div>
+          <div className="auth-card-sub">
+            {forgotDone
+              ? tr('密码已重设，用新密码登录吧', 'Password updated — sign in with it')
+              : tr('用注册邮箱接收验证码，然后设置新密码', 'Get a code by email, then set a new password')}
+          </div>
+
+          {forgotDone ? (
+            <button
+              type="button"
+              className="btn btn-primary"
+              style={{ width: '100%', justifyContent: 'center', height: 38 }}
+              onClick={toLogin}
+            >
+              <Icon name="arrow" size={14} />
+              {tr('去登录', 'Go to sign in')}
+            </button>
+          ) : (
+            <form onSubmit={onForgotSubmit}>
+              {resetMutation.isError && (
+                <div className="auth-error">{errorMessage(resetMutation.error)}</div>
+              )}
+
+              <div className="auth-field">
+                <label htmlFor="forgot-email">{tr('注册邮箱', 'Account email')}</label>
+                <input
+                  id="forgot-email"
+                  className="auth-input"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  placeholder="you@zju.edu.cn"
+                  value={forgotEmail}
+                  onChange={(e) => setForgotEmail(e.target.value)}
+                />
+              </div>
+
+              <CodeField
+                id="forgot-code"
+                code={forgotCode}
+                onCode={setForgotCode}
+                email={forgotEmail}
+                sender={resetSender}
+              />
+
+              <div className="auth-field">
+                <label htmlFor="new-password">{tr('新密码', 'New password')}</label>
+                <input
+                  id="new-password"
+                  className="auth-input"
+                  type="password"
+                  required
+                  autoComplete="new-password"
+                  placeholder={tr('至少 8 位，含字母和数字', 'At least 8 chars, letters and digits')}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+                <PasswordMeter password={password} />
+              </div>
+
+              <div className="auth-field">
+                <label htmlFor="new-password2">{tr('确认新密码', 'Confirm new password')}</label>
+                <input
+                  id="new-password2"
+                  className="auth-input"
+                  type="password"
+                  required
+                  autoComplete="new-password"
+                  placeholder={tr('再输入一遍', 'Type it again')}
+                  value={password2}
+                  onChange={(e) => setPassword2(e.target.value)}
+                />
+                {password2 !== '' && !pwdMatch && (
+                  <div style={{ fontSize: 11, color: 'var(--danger-tx)', marginTop: 4 }}>
+                    {tr('两次输入的密码不一致', 'Passwords do not match')}
+                  </div>
+                )}
+              </div>
+
+              <div className="row" style={{ gap: 10, marginTop: 6 }}>
+                <button type="button" className="btn" style={{ height: 38 }} onClick={toLogin}>
+                  {tr('返回登录', 'Back')}
+                </button>
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={
+                    resetMutation.isPending ||
+                    forgotCode.length < 6 ||
+                    pwdLevel === 0 ||
+                    !pwdMatch
+                  }
+                  style={{ flex: 1, justifyContent: 'center', height: 38 }}
+                >
+                  {resetMutation.isPending ? (
+                    <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                  ) : (
+                    <Icon name="check" size={14} />
+                  )}
+                  {tr('重设密码', 'Reset password')}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  /* ---------- 登录 / 注册 ---------- */
+  return (
+    <div className="auth-page">
+      {brand}
+
       <div className="auth-card fadeup">
         <div className="auth-card-title">
           {isRegister ? tr('创建账号', 'Create your account') : tr('欢迎回来', 'Welcome back')}
@@ -227,6 +489,15 @@ export function LoginPage() {
 
           {isRegister && step === 1 && (
             <>
+              {emailOn && (
+                <CodeField
+                  id="register-code"
+                  code={emailCode}
+                  onCode={setEmailCode}
+                  email={identifier}
+                  sender={registerSender}
+                />
+              )}
               <div className="auth-field">
                 <label htmlFor="displayName">{tr('姓名', 'Name')}</label>
                 <input
@@ -296,21 +567,46 @@ export function LoginPage() {
             </>
           )}
 
-          {/* 登录密码 */}
+          {/* 登录密码 + 记住密码 / 忘记密码 */}
           {!isRegister && (
-            <div className="auth-field">
-              <label htmlFor="password">{tr('密码', 'Password')}</label>
-              <input
-                id="password"
-                className="auth-input"
-                type="password"
-                required
-                autoComplete="current-password"
-                placeholder={tr('输入密码', 'Enter password')}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
+            <>
+              <div className="auth-field">
+                <label htmlFor="password">{tr('密码', 'Password')}</label>
+                <input
+                  id="password"
+                  className="auth-input"
+                  type="password"
+                  required
+                  autoComplete="current-password"
+                  placeholder={tr('输入密码', 'Enter password')}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </div>
+              <div className="auth-options">
+                <label className="auth-check">
+                  <input
+                    type="checkbox"
+                    checked={remember}
+                    onChange={(e) => setRemember(e.target.checked)}
+                  />
+                  {tr('记住密码', 'Remember me')}
+                </label>
+                {capabilities.data?.password_reset && (
+                  <button
+                    type="button"
+                    className="auth-link"
+                    onClick={() => {
+                      setForgotEmail(identifier.includes('@') ? identifier : '');
+                      clearPasswords();
+                      setView('forgot');
+                    }}
+                  >
+                    {tr('忘记密码？', 'Forgot password?')}
+                  </button>
+                )}
+              </div>
+            </>
           )}
 
           {/* 注册第 2 步：设置密码 */}
@@ -359,7 +655,16 @@ export function LoginPage() {
           {/* 操作按钮 */}
           {isRegister && step === 2 ? (
             <div className="row" style={{ gap: 10, marginTop: 6 }}>
-              <button type="button" className="btn" style={{ height: 38 }} onClick={backToStep1}>
+              <button
+                type="button"
+                className="btn"
+                style={{ height: 38 }}
+                onClick={() => {
+                  clearPasswords();
+                  mutation.reset();
+                  setStep(1);
+                }}
+              >
                 {tr('上一步', 'Back')}
               </button>
               <button
@@ -380,7 +685,10 @@ export function LoginPage() {
             <button
               type="submit"
               className="btn btn-primary"
-              disabled={mutation.isPending || (isRegister && (!usernameValid || usernameTaken))}
+              disabled={
+                mutation.isPending ||
+                (isRegister && (!usernameValid || usernameTaken || (emailOn && emailCode.length < 6)))
+              }
               style={{ width: '100%', justifyContent: 'center', height: 38, marginTop: 6 }}
             >
               {mutation.isPending ? (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -212,6 +212,20 @@ export interface RegisterInput {
   display_name: string;
   username: string;
   invite_code: string;
+  /** 邮箱验证码；未开启邮件系统的部署可省略 */
+  email_code?: string;
+}
+
+export interface AuthCapabilities {
+  email: boolean;
+  password_reset: boolean;
+  register_email_code: boolean;
+}
+
+export interface SendCodeResult {
+  sent: boolean;
+  /** 冷却中的剩余秒数 */
+  retry_after: number;
 }
 
 /** admin 判定：role=admin 或 fastapi-users superuser。 */
@@ -2422,6 +2436,25 @@ export const api = {
     return request<{ available: boolean }>(
       `/auth/username-available?username=${encodeURIComponent(username)}`,
     );
+  },
+
+  /** 邮件系统是否可用（决定验证码与「忘记密码」入口是否显示）。 */
+  authCapabilities(): Promise<AuthCapabilities> {
+    return request<AuthCapabilities>('/auth/capabilities');
+  },
+
+  /** 申请邮箱验证码；冷却中返回 sent=false 与剩余秒数。 */
+  sendAuthCode(email: string, purpose: 'register' | 'reset'): Promise<SendCodeResult> {
+    return requestJson<SendCodeResult>('/auth/send-code', 'POST', { email, purpose });
+  },
+
+  /** 凭邮箱验证码重设密码。 */
+  resetPassword(email: string, code: string, password: string): Promise<{ ok: boolean }> {
+    return requestJson<{ ok: boolean }>('/auth/reset-password', 'POST', {
+      email,
+      code,
+      password,
+    });
   },
 
   /** 健康检查：{status, version}（反馈上下文里带版本号用）。 */

--- a/src/frontend/src/lib/token-store.ts
+++ b/src/frontend/src/lib/token-store.ts
@@ -1,11 +1,16 @@
 /* ============================================================
    登录 token 的存储后端 —— 可替换。
 
-   web 端与桌面端一期都用 localStorage（桌面端页面跑在 app://polaris
-   这个稳定 origin 上，localStorage 正常持久化，登录态零改动）。
-   二期若把 token 迁到 Electron 的 safeStorage（macOS Keychain /
-   Windows DPAPI / Linux libsecret），只需在启动时 setTokenStore()
-   换一个实现，api.ts / sse.ts / ws.ts / yjs-provider.ts 一行不改。
+   web 端与桌面端一期都用浏览器存储（桌面端页面跑在 app://polaris 这个稳定
+   origin 上，localStorage 正常持久化，登录态零改动）。二期若把 token 迁到
+   Electron 的 safeStorage（macOS Keychain / Windows DPAPI / Linux libsecret），
+   只需在启动时 setTokenStore() 换一个实现，api.ts / sse.ts / ws.ts /
+   yjs-provider.ts 一行不改。
+
+   「记住密码」勾选与否决定 token 落在哪儿：
+     勾选   → localStorage，关掉浏览器再回来仍是登录态
+     不勾选 → sessionStorage，标签页关掉即失效
+   读取时两处都看，所以切换偏好不会把已登录的人踢下线。
 
    注意：接口刻意保持**同步**。改成 async 会波及 request/requestBlob
    与三个 WS/SSE 调用点，那才是真正的重写。
@@ -17,19 +22,65 @@ export interface TokenStore {
 }
 
 const TOKEN_KEY = 'polaris.token';
+const REMEMBER_KEY = 'polaris.remember';
+/** 上次登录的账号，勾了「记住密码」时回填到登录框（只记账号，密码交给浏览器密码管理器）。 */
+const LAST_ACCOUNT_KEY = 'polaris.last-account';
 
-const localStorageTokenStore: TokenStore = {
-  get: () => localStorage.getItem(TOKEN_KEY),
-  set: (token) => {
-    if (token) {
-      localStorage.setItem(TOKEN_KEY, token);
-    } else {
+function safe<T>(fn: () => T, fallback: T): T {
+  // 隐私模式 / 禁用存储的浏览器里访问 storage 会抛异常
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+export function isRemembered(): boolean {
+  return safe(() => localStorage.getItem(REMEMBER_KEY) !== '0', true);
+}
+
+/** 切换「记住密码」，并把已有 token 迁到对应存储里。 */
+export function setRemembered(remember: boolean): void {
+  safe(() => {
+    localStorage.setItem(REMEMBER_KEY, remember ? '1' : '0');
+    const token = safe(
+      () => sessionStorage.getItem(TOKEN_KEY) ?? localStorage.getItem(TOKEN_KEY),
+      null,
+    );
+    localStorage.removeItem(TOKEN_KEY);
+    sessionStorage.removeItem(TOKEN_KEY);
+    if (token) (remember ? localStorage : sessionStorage).setItem(TOKEN_KEY, token);
+    return null;
+  }, null);
+}
+
+export function getLastAccount(): string {
+  return safe(() => localStorage.getItem(LAST_ACCOUNT_KEY) ?? '', '');
+}
+
+export function setLastAccount(account: string | null): void {
+  safe(() => {
+    if (account) localStorage.setItem(LAST_ACCOUNT_KEY, account);
+    else localStorage.removeItem(LAST_ACCOUNT_KEY);
+    return null;
+  }, null);
+}
+
+const browserTokenStore: TokenStore = {
+  get: () =>
+    safe(() => sessionStorage.getItem(TOKEN_KEY) ?? localStorage.getItem(TOKEN_KEY), null),
+  set: (token) =>
+    safe(() => {
       localStorage.removeItem(TOKEN_KEY);
-    }
-  },
+      sessionStorage.removeItem(TOKEN_KEY);
+      if (token) {
+        (isRemembered() ? localStorage : sessionStorage).setItem(TOKEN_KEY, token);
+      }
+      return null;
+    }, null),
 };
 
-let store: TokenStore = localStorageTokenStore;
+let store: TokenStore = browserTokenStore;
 
 /** 替换 token 存储后端（桌面端二期用）。 */
 export function setTokenStore(next: TokenStore): void {

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -747,6 +747,27 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 }
 .auth-step2-account b { color: var(--text-1); font-weight: 600; }
 
+/* 验证码：输入框 + 获取按钮 */
+.auth-code-row { display: flex; gap: 8px; }
+.auth-code-row .auth-input { flex: 1; min-width: 0; letter-spacing: 0.18em; }
+.auth-code-row .btn { height: 38px; flex-shrink: 0; white-space: nowrap; min-width: 92px; justify-content: center; }
+
+/* 记住密码 / 忘记密码 */
+.auth-options {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; margin: -4px 0 14px;
+}
+.auth-check {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12.5px; color: var(--text-2); cursor: pointer; user-select: none;
+}
+.auth-check input { width: 13px; height: 13px; accent-color: var(--accent); cursor: pointer; }
+.auth-link {
+  background: none; border: 0; padding: 0; cursor: pointer;
+  font-size: 12.5px; color: var(--accent);
+}
+.auth-link:hover { text-decoration: underline; }
+
 /* 密码强度条（三级） */
 .pwd-meter { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
 .pwd-meter-bars { display: flex; gap: 5px; flex: 1; }


### PR DESCRIPTION
Closes #110

## What this adds

**Email system.** A new `app/services/email.py` sends transactional mail over SMTP. It uses stdlib `smtplib` on a worker thread rather than adding `aiosmtplib`: sending is a rare, human-triggered action, so one thread-pool call is enough and it avoids a new dependency and an image rebuild. Connection mode is configurable (`ssl` for 465/994, `starttls` for 587/25, `none` for debugging). Send failures are logged and swallowed — a failing mail server must never turn into a 500 on the auth path, and must never let the caller tell whether an address exists.

**Verification codes.** New `email_verification_codes` table (migration `49ddb68e7cf2`) stores HMAC digests, never the code itself. Codes are 6 digits, single use, valid 10 minutes, voided after 5 wrong attempts, with a 60s resend cooldown, and scoped by `purpose` so a sign-up code cannot be replayed against a password reset. Expiry and cooldown are compared in SQL to avoid the aware/naive datetime trap SQLite sets up.

**Sign-up now verifies the address.** `POST /auth/register` requires `email_code` whenever the email system is on. The check runs before the invite code is redeemed and before the user row is created, so a failed registration does not burn either.

**Password reset by code.** `POST /auth/send-code` + `POST /auth/reset-password` replace the link-based flow. A wrong code and an unknown email return the same `INVALID_CODE`. `send-code` issues a record even for addresses that do not exist — otherwise the presence or absence of a cooldown on the second request would itself reveal whether an account exists.

**Remember me.** `token-store.ts` now picks its backing store from the checkbox: `localStorage` when checked (survives a browser restart), `sessionStorage` when not (dies with the tab); reads consult both, so toggling the preference never signs anyone out. When checked, the last account is remembered and pre-filled. The password itself is never persisted by us — that stays with the browser's password manager, which the existing `autocomplete` attributes already drive.

**Password floor on the server.** `validate_password` enforces 8+ characters containing both letters and digits, the same line the strength meter draws, on both sign-up and reset.

**Graceful degradation.** With `POLARIS_SMTP_HOST` unset, `GET /auth/capabilities` reports the email system as off; the UI then hides the code field and the "forgot password" link, and registration skips code checking. Existing deployments need no configuration change.

## Configuration

New `POLARIS_SMTP_*` keys are documented in `.env.example`, including a ZJU mail example. Real credentials belong in `.env` (gitignored) and are not in this diff.

## Verification

- Backend: 19 auth tests pass, including purpose isolation, attempt capping, single use, cooldown parity between known and unknown addresses, and old-password invalidation after reset. `ruff` clean on changed files.
- Frontend: `tsc --noEmit && vite build` passes.
- End to end against the real ZJU mail server on a throwaway database and a temporary stack (the shared dev database was not touched): sign-up with a mailed code, wrong-code rejection, password reset, old password refused and new password accepted, and remember-me placing the token in the expected store. The recipient confirmed the delivered code matched the one the server issued.