### PR TITLE
fix(daily): download the PDF through a daily-scoped endpoint

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -337,6 +337,29 @@ async def chat_with_daily_pool(
     return _chat_stream_response(messages, sources, user_id=user.id, project_id=None)
 
 
+@router.post("/papers/{entry_id}/fetch-pdf", response_model=DailyPaperDetail)
+async def fetch_entry_pdf(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyPaperDetail:
+    """把这篇每日论文的 PDF 下到平台（幂等），下完即可在线阅读。
+
+    每日池论文通常不属于任何库/书架，走不了 /papers/{id}/fetch-pdf 的成员可见性兜底，
+    故按 entry 授权单开一条；每日推送全实验室共享，登录即可。
+    """
+    try:
+        await daily_service.fetch_entry_pdf(session, entry_id=entry_id, user_id=user.id)
+    except daily_service.DailyEntryNotFoundError as exc:
+        raise _NOT_FOUND from exc
+    except papers_service.PdfSourceUnsupportedError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="PDF_SOURCE_UNSUPPORTED") from e
+    except papers_service.PdfFetchFailedError as e:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="PDF_FETCH_FAILED") from e
+    item = await daily_service.get_entry_item(session, entry_id=entry_id, user_id=user.id)
+    return DailyPaperDetail(**item)
+
+
 @router.post("/papers/{entry_id}/compile", response_model=DailyCompileResult)
 async def compile_entry(
     entry_id: uuid.UUID,

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -631,6 +631,24 @@ async def daily_paper_ids(session: AsyncSession) -> list[uuid.UUID]:
 _COMPILING: set[uuid.UUID] = set()
 
 
+async def fetch_entry_pdf(
+    session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
+) -> Paper:
+    """给某条每日论文补下 PDF + 抽全文（幂等：已有 PDF 直接返回）。
+
+    每日池是全实验室共享的，且池论文通常不属于任何库/书架，走不了
+    ``/papers/{id}/fetch-pdf`` 的成员可见性兜底——故按 entry 授权单开一条。
+    """
+    from app.services.papers import fetch_pdf
+
+    entry = await session.get(DailyFeedEntry, entry_id)
+    if entry is None:
+        raise DailyEntryNotFoundError(str(entry_id))
+    paper = await session.get(Paper, entry.paper_id)
+    assert paper is not None  # 外键保证
+    return await fetch_pdf(session, paper, user_id=user_id)
+
+
 async def compile_entry_wiki(
     session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
 ) -> DailyFeedEntry:

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -158,7 +158,7 @@ function DailyDetailPane({
 
   // 下载原文：把 PDF 抓进平台（顺带抽全文/分块），成功后按钮变「阅读原文」
   const fetchPdfMutation = useMutation({
-    mutationFn: () => api.requestPaperPdf(paper!.paper_id),
+    mutationFn: () => api.fetchDailyPaperPdf(entryId),
     onSuccess: () => {
       toast(tr('已下载原文，可以在线阅读了', 'PDF fetched — you can read it here now'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4040,6 +4040,10 @@ export const api = {
   getDailyCollections(entryId: string): Promise<DailyCollectionsRead> {
     return request<DailyCollectionsRead>(`/daily/papers/${entryId}/collections`);
   },
+  /** 把这篇每日论文的 PDF 下到平台（幂等）；下完可在线阅读。400=不支持的来源，502=下载失败。 */
+  fetchDailyPaperPdf(entryId: string): Promise<DailyPaperDetail> {
+    return request<DailyPaperDetail>(`/daily/papers/${entryId}/fetch-pdf`, { method: 'POST' });
+  },
   /** 触发单篇 AI 解读编译（同步等待，约半分钟）；409 detail=COMPILE_IN_PROGRESS，502 编译失败。 */
   compileDailyPaper(entryId: string): Promise<{ entry_id: string; wiki_content: string; model: string }> {
     return request<{ entry_id: string; wiki_content: string; model: string }>(


### PR DESCRIPTION
## Bug

On Daily Papers, **Download original** failed with `PAPER_NOT_FOUND`.

## Root cause

The button called `POST /papers/{id}/fetch-pdf`, which resolves the paper through `_get_member_paper(..., include_pool=True)`. That pool fallback only reaches papers that are in a visible library, on one of your shelves, or in your personal library. A daily paper you haven't collected yet is in **none** of those, so it 404s.

## Fix

Add `POST /daily/papers/{entry_id}/fetch-pdf`, authorized per feed entry like the other daily endpoints (the daily feed is lab-wide readable), backed by `daily_feed.fetch_entry_pdf` which reuses `papers.fetch_pdf` (idempotent; also extracts full text + chunks). The button now calls it and still flips to **Read original** once the PDF lands.

`tsc` clean; daily tests 7 passed.