### PR TITLE
feat(search): unify the search bar across all four paper surfaces

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -12,7 +12,14 @@ import { tr } from '../../lib/i18n';
 import { Markdown } from '../../lib/markdown';
 import { PaperReader } from '../wiki/PaperReader';
 import { readerFrom } from '../reading/shared';
-import { SearchInput, saveBlob, useDebounced } from '../wiki/shared';
+import {
+  AdvancedPanel,
+  AdvancedToggle,
+  SearchInput,
+  SemanticSwitch,
+  saveBlob,
+  useDebounced,
+} from '../wiki/shared';
 import { DailyLikes } from './DailyLikes';
 import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
@@ -392,19 +399,25 @@ function DailyDetailPane({
 
 type DailyView = 'papers' | 'chat';
 type AnnounceFilter = 'all' | 'new' | 'cross';
-type SearchScope = 'keyword' | 'semantic';
+
+// 类型筛选默认值：只看新工作（高级检索面板里的「恢复默认」也回到这个值）
+const DEFAULT_ANNOUNCE: AnnounceFilter = 'new';
 
 export function DailyPage() {
   const [view, setView] = useState<DailyView>('papers');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
-  const [scope, setScope] = useState<SearchScope>('keyword');
+  // 语义检索开关（true=按意思检索，false=关键词字面匹配）
+  const [semanticOn, setSemanticOn] = useState(false);
   const [sort, setSort] = useState<DailySort>('likes');
   const [page, setPage] = useState(1);
-  // —— 高级过滤：日期（null=全部 7 天，默认落在最新一天）/ 订阅分类（''=全部）/ 类型 ——
+  // —— 日期（null=全部 7 天，默认落在最新一天）留在工具栏；分类 / 类型收进高级检索面板 ——
   const [day, setDay] = useState<string | null>(null);
+  const [advOpen, setAdvOpen] = useState(false);
   const [category, setCategory] = useState('');
-  const [announce, setAnnounce] = useState<AnnounceFilter>('new');
+  const [announce, setAnnounce] = useState<AnnounceFilter>(DEFAULT_ANNOUNCE);
+  // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
+  const advActive = !!category || announce !== DEFAULT_ANNOUNCE;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -414,11 +427,11 @@ export function DailyPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => setPage(1), [q, scope, sort, day, category, announce]);
+  useEffect(() => setPage(1), [q, semanticOn, sort, day, category, announce]);
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [q, scope, day, category, announce]);
+  }, [q, semanticOn, day, category, announce]);
 
   const daysQuery = useQuery({
     queryKey: ['daily-days'],
@@ -466,9 +479,9 @@ export function DailyPage() {
   });
 
   // 语义检索：只在有关键词时生效；结果按相关度排序、不分页
-  const semantic = !!q && scope === 'semantic';
+  const semantic = !!q && semanticOn;
   const listQuery = useQuery({
-    queryKey: ['daily-papers', scope, sort, page, q, day, category, announce],
+    queryKey: ['daily-papers', semanticOn, sort, page, q, day, category, announce],
     queryFn: () =>
       api.listDailyPapers({
         sort: semantic ? undefined : sort,
@@ -484,7 +497,7 @@ export function DailyPage() {
     placeholderData: keepPreviousData,
   });
   // 默认口径（当天 + 新工作）之外还加了条件才算「筛过」——空列表时给的话术不一样
-  const filtered = !!q || !!category || announce !== 'new' || (day !== null && day !== latestDate);
+  const filtered = !!q || advActive || (day !== null && day !== latestDate);
   const items = listQuery.data?.items ?? [];
   const total = listQuery.data?.total ?? 0;
   const pages = semantic ? 1 : Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -568,21 +581,86 @@ export function DailyPage() {
                 <SearchInput
                   value={qInput}
                   onChange={setQInput}
-                  placeholder={tr('搜标题 / 摘要 / 作者…', 'Search title / abstract / authors…')}
+                  placeholder={
+                    semanticOn
+                      ? tr('语义检索（自然语言描述）…', 'Semantic search (natural language)…')
+                      : tr('搜标题 / 摘要 / 作者…', 'Search title / abstract / authors…')
+                  }
+                />
+                <SemanticSwitch checked={semanticOn} onChange={setSemanticOn} />
+                <AdvancedToggle
+                  open={advOpen}
+                  active={advActive}
+                  onToggle={() => setAdvOpen((o) => !o)}
+                  title={tr('高级检索：分类 / 类型', 'Advanced search: category / type')}
                 />
                 <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
                   {total ? tr(`${total} 篇`, `${total}`) : ''}
                 </span>
               </div>
-              {/* 检索方式：关键词字面匹配 / 语义检索（按意思找） */}
-              <div className="row gap6 wrap" style={{ marginTop: 10 }}>
-                <span className={`chip${scope === 'keyword' ? ' on' : ''}`} onClick={() => setScope('keyword')}>
-                  {tr('关键词', 'Keyword')}
-                </span>
-                <span className={`chip${scope === 'semantic' ? ' on' : ''}`} onClick={() => setScope('semantic')}>
-                  {tr('语义检索', 'Semantic')}
-                </span>
-              </div>
+
+              {/* 高级检索面板：分类 + 类型（日期步进和排序留在工具栏，它们是主导航） */}
+              {advOpen && (
+                <AdvancedPanel
+                  onClear={
+                    advActive
+                      ? () => {
+                          setCategory('');
+                          setAnnounce(DEFAULT_ANNOUNCE);
+                        }
+                      : undefined
+                  }
+                >
+                  <div className="row gap6" style={{ alignItems: 'center' }}>
+                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
+                      {tr('分类', 'Category')}
+                    </span>
+                    <select
+                      className="input mono"
+                      style={{ flex: 1, minWidth: 0, height: 26, fontSize: 11, padding: '0 6px' }}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      title={tr('只看某个订阅分类的论文', 'Only papers in one subscribed category')}
+                    >
+                      <option value="">{tr('全部分类', 'All categories')}</option>
+                      {(categoriesQuery.data?.categories ?? []).map((c) => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
+                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
+                      {tr('类型', 'Type')}
+                    </span>
+                    <span className={`chip${announce === 'all' ? ' on' : ''}`} onClick={() => setAnnounce('all')}>
+                      {tr('全部', 'All')}
+                    </span>
+                    <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
+                      {tr('新工作', 'New')}
+                    </span>
+                    <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
+                      {tr('更新', 'Updated')}
+                    </span>
+                  </div>
+                </AdvancedPanel>
+              )}
+              {/* 面板收起时，把正在生效的分类/类型如实说一句（默认「只看新工作」也算），
+                  免得筛选藏进面板后用户不知道列表被过滤过 */}
+              {!advOpen && (announce !== 'all' || !!category) && (
+                <div
+                  onClick={() => setAdvOpen(true)}
+                  style={{ marginTop: 6, fontSize: 11, color: 'var(--text-4)', cursor: 'pointer', lineHeight: 1.5 }}
+                  title={tr('点开高级检索改筛选条件', 'Open advanced search to change the filters')}
+                >
+                  {tr('只看：', 'Showing: ')}
+                  {announce === 'new' ? tr('新工作', 'New') : announce === 'cross' ? tr('更新', 'Updated') : ''}
+                  {announce !== 'all' && category ? ' · ' : ''}
+                  {category}
+                </div>
+              )}
+
               {semantic && (
                 <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-4)', lineHeight: 1.5 }}>
                   {tr(
@@ -623,19 +701,8 @@ export function DailyPage() {
                 >
                   {tr('按时间', 'Newest')}
                 </span>
-                <span style={{ width: 1, height: 14, background: 'var(--border)', margin: '0 3px', flexShrink: 0 }} />
-                {/* 类型筛选：全部 / 新工作(new) / 更新(cross) */}
-                <span className={`chip${announce === 'all' ? ' on' : ''}`} onClick={() => setAnnounce('all')}>
-                  {tr('全部', 'All')}
-                </span>
-                <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
-                  {tr('新工作', 'New')}
-                </span>
-                <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
-                  {tr('更新', 'Updated')}
-                </span>
               </div>
-              {/* —— 日期步进 + 订阅分类下拉 —— */}
+              {/* —— 日期步进（主导航，不收进高级检索） —— */}
               <div className="row gap6 wrap" style={{ marginTop: 8 }}>
                 <button
                   className="btn btn-ghost sm"
@@ -664,20 +731,6 @@ export function DailyPage() {
                 >
                   {tr('后一天', 'Next day')} ›
                 </button>
-                <div style={{ flex: 1 }} />
-                <select
-                  className="input mono"
-                  style={{ height: 24, fontSize: 11, padding: '0 4px', maxWidth: 128, flexShrink: 0 }}
-                  value={category}
-                  onChange={(e) => setCategory(e.target.value)}
-                >
-                  <option value="">{tr('全部分类', 'All categories')}</option>
-                  {(categoriesQuery.data?.categories ?? []).map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
               </div>
             </div>
 

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -19,6 +19,7 @@ import {
   AdvancedToggle,
   FilterInput,
   SearchInput,
+  SemanticSwitch,
   YearRangeField,
   parseYear,
   saveBlob,
@@ -37,7 +38,6 @@ const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m
    ============================================================ */
 
 type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' | 'ingest';
-type SearchScope = 'keyword' | 'semantic';
 
 const PAGE_SIZE = 20;
 
@@ -227,7 +227,8 @@ function PapersPane({
 }) {
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
-  const [scope, setScope] = useState<SearchScope>('keyword');
+  // 语义检索开关（true=按意思检索，false=关键词字面匹配）
+  const [semanticOn, setSemanticOn] = useState(false);
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [page, setPage] = useState(1);
 
@@ -265,10 +266,10 @@ function PapersPane({
 
   useEffect(
     () => setPage(1),
-    [q, sort, scope, author, affiliation, yearFrom, yearTo, advReading, advStarred],
+    [q, sort, semanticOn, author, affiliation, yearFrom, yearTo, advReading, advStarred],
   );
 
-  const semantic = !!q && scope === 'semantic';
+  const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
       'lib-papers', libraryId, q, sort, page,
@@ -317,8 +318,13 @@ function PapersPane({
             <SearchInput
               value={qInput}
               onChange={setQInput}
-              placeholder={tr('搜库内论文：标题 / 摘要 / 解读…', 'Search papers: title / abstract / wiki…')}
+              placeholder={
+                semanticOn
+                  ? tr('语义检索（自然语言描述）…', 'Semantic search (natural language)…')
+                  : tr('搜库内论文：标题 / 摘要 / 解读…', 'Search papers: title / abstract / wiki…')
+              }
             />
+            <SemanticSwitch checked={semanticOn} onChange={setSemanticOn} />
             <AdvancedToggle
               open={advOpen}
               active={advActive}
@@ -392,14 +398,11 @@ function PapersPane({
               </AdvancedPanel>
             </div>
           )}
-          <div className="row gap6 wrap" style={{ marginTop: 10 }}>
-            <span className={`chip${scope === 'keyword' ? ' on' : ''}`} onClick={() => setScope('keyword')}>
-              {tr('关键词', 'Keyword')}
-            </span>
-            <span className={`chip${scope === 'semantic' ? ' on' : ''}`} onClick={() => setScope('semantic')}>
-              {tr('语义检索', 'Semantic')}
-            </span>
-            <span style={{ flex: 1 }} />
+          {/* 排序（语义检索按相关度返回，排序无效 → 置灰） */}
+          <div
+            className="row gap6 wrap"
+            style={{ marginTop: 10, justifyContent: 'flex-end', ...(semantic ? { opacity: 0.45, pointerEvents: 'none' as const } : {}) }}
+          >
             <span
               className={`chip${sort === 'relevance' ? ' on' : ''}`}
               onClick={() => setSort('relevance')}

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -12,7 +12,6 @@ import {
   type LibrarySort,
   type LibraryTab,
   type Publication,
-  type SearchMode,
 } from '../../lib/api';
 import { fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
@@ -22,6 +21,7 @@ import {
   FilterInput,
   parseYear,
   SearchInput,
+  SemanticSwitch,
   saveBlob,
   useDebounced,
   YearRangeField,
@@ -241,7 +241,8 @@ export function LibraryPage() {
   const [tab, setTab] = useState<PageTab>('saved');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
-  const [scope, setScope] = useState<SearchMode>('keyword');
+  // 语义检索开关（true=按意思检索；只有「我的收藏」支持）
+  const [semanticOn, setSemanticOn] = useState(false);
   const [sort, setSort] = useState<LibrarySort>('recent');
   const [page, setPage] = useState(1);
   const [clearOpen, setClearOpen] = useState(false);
@@ -276,18 +277,18 @@ export function LibraryPage() {
 
   // 语义检索：仅「我的收藏」+ 有关键词时生效（浏览记录是流水，不做语义）；
   // 语义态不分页、高级过滤置灰（后端按向量相似度返回一组结果）
-  const semantic = tab === 'saved' && scope === 'semantic' && !!q;
+  const semantic = tab === 'saved' && semanticOn && !!q;
 
   // tab / 搜索词 / 检索模式 / 排序 / 高级条件变化时回到第一页
   useEffect(() => {
     setPage(1);
-  }, [tab, q, scope, sort, author, venue, yearFrom, yearTo]);
+  }, [tab, q, semanticOn, sort, author, venue, yearFrom, yearTo]);
 
   // 切 tab / 换搜索词 / 换检索模式时清空多选（避免选中集跨上下文残留）
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [tab, q, scope]);
+  }, [tab, q, semanticOn]);
 
   const onLibraryTab = tab !== 'publications' && tab !== 'chat' && tab !== 'liked';
   const listQuery = useQuery({
@@ -512,7 +513,24 @@ export function LibraryPage() {
                   <SearchInput
                     value={qInput}
                     onChange={setQInput}
-                    placeholder={tr('搜索标题 / 作者…', 'Search title / authors…')}
+                    placeholder={
+                      semanticOn && tab === 'saved'
+                        ? tr('语义检索（自然语言描述）…', 'Semantic search (natural language)…')
+                        : tr('搜索标题 / 作者…', 'Search title / authors…')
+                    }
+                  />
+                  <SemanticSwitch
+                    checked={semanticOn && tab === 'saved'}
+                    onChange={setSemanticOn}
+                    disabled={tab !== 'saved'}
+                    title={
+                      tab === 'saved'
+                        ? tr(
+                            '按语义相似度检索收藏（需已生成向量）',
+                            'Semantic search over saved papers (needs embeddings)',
+                          )
+                        : tr('浏览记录是流水，只支持关键词检索', 'History is a raw log — keyword search only')
+                    }
                   />
                   <AdvancedToggle
                     open={advOpen}
@@ -548,26 +566,7 @@ export function LibraryPage() {
                   </div>
                 )}
 
-                {/* 关键词 / 语义 检索模式切换（语义仅「我的收藏」有意义） */}
-                {tab === 'saved' && (
-                  <div className="row gap6 wrap" style={{ marginTop: 10 }}>
-                    <span
-                      className={`chip${scope === 'keyword' ? ' on' : ''}`}
-                      onClick={() => setScope('keyword')}
-                    >
-                      {tr('关键词', 'Keyword')}
-                    </span>
-                    <span
-                      className={`chip${scope === 'semantic' ? ' on' : ''}`}
-                      onClick={() => setScope('semantic')}
-                      title={tr('按语义相似度检索收藏（需已生成向量）', 'Semantic search over saved papers (needs embeddings)')}
-                    >
-                      {tr('语义检索', 'Semantic')}
-                    </span>
-                  </div>
-                )}
-
-                <div className="row gap8" style={{ marginTop: 10 }}>
+                <div className="row gap8" style={{ marginTop: 10, ...(semantic ? { opacity: 0.45, pointerEvents: 'none' as const } : {}) }}>
                   <Segmented<LibrarySort>
                     options={SORTS.map((s) => ({ v: s.v, label: tr(s.zh, s.en) }))}
                     value={sort}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -27,6 +27,7 @@ import {
   parseYear,
   saveBlob,
   SearchInput,
+  SemanticSwitch,
   useDebounced,
   YearRangeField,
 } from '../wiki/shared';
@@ -51,8 +52,6 @@ type ShelfFilter = 'all' | ShelfWikiSource;
 type PageTab = 'list' | 'chat';
 /** 阅读状态筛选：空串=不限；其余透传给后端 reading_status。 */
 type ReadingFilter = '' | ReadingStatus;
-/** 搜索作用域：关键词（后端书架过滤）/ 语义检索（课题语料向量召回）。 */
-type SearchScope = 'keyword' | 'semantic';
 
 /** 语义检索命中的 ScoredPaper（课题语料，未必已入书架）映射成书架行需要的最小字段。
     note / wiki_content / snapshot_at / source_library_id 语义结果里没有，按缺省填；
@@ -352,7 +351,8 @@ export function ResearchPage() {
   // 关键词 + 高级检索条件（走后端）
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
-  const [scope, setScope] = useState<SearchScope>('keyword');
+  // 语义检索开关（true=课题语料向量召回，false=关键词书架过滤）
+  const [semanticOn, setSemanticOn] = useState(false);
   // 多选导出：默认关闭，底部「多选」按钮开启后行首出现复选框
   const [selectMode, setSelectMode] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
@@ -388,7 +388,7 @@ export function ResearchPage() {
     setSelId(null);
     setFilter('all');
     setQInput('');
-    setScope('keyword');
+    setSemanticOn(false);
     clearAdvanced();
   }, [pid]);
 
@@ -401,10 +401,10 @@ export function ResearchPage() {
   useEffect(() => {
     setCheckedIds(new Set());
     setSelectMode(false);
-  }, [pid, q, scope, filter, sort]);
+  }, [pid, q, semanticOn, filter, sort]);
 
-  // 语义检索：有查询词且作用域为语义时激活；结果替换列表、不分页、置灰其余过滤
-  const semantic = !!q && scope === 'semantic';
+  // 语义检索：有查询词且开关打开时激活；结果替换列表、不分页、置灰其余过滤
+  const semantic = !!q && semanticOn;
 
   const shelfQuery = useQuery({
     queryKey: [
@@ -664,10 +664,15 @@ export function ResearchPage() {
                   value={qInput}
                   onChange={setQInput}
                   placeholder={
-                    scope === 'semantic'
+                    semanticOn
                       ? tr('语义检索（自然语言描述）…', 'Semantic search (natural language)…')
                       : tr('搜索标题 / 作者…', 'Search title / authors…')
                   }
+                />
+                <SemanticSwitch
+                  checked={semanticOn}
+                  onChange={setSemanticOn}
+                  title={tr('打开后用自然语言在课题语料里语义召回', 'Semantic recall over the topic corpus')}
                 />
                 <AdvancedToggle
                   open={advOpen}
@@ -678,20 +683,6 @@ export function ResearchPage() {
                     'Advanced search: author / affiliation / year / reading status',
                   )}
                 />
-              </div>
-
-              {/* 关键词 / 语义检索切换（对齐文献库 LibraryBrowse） */}
-              <div className="row gap6 wrap" style={{ marginTop: 8 }}>
-                <span className={`chip${scope === 'keyword' ? ' on' : ''}`} onClick={() => setScope('keyword')}>
-                  {tr('关键词', 'Keyword')}
-                </span>
-                <span
-                  className={`chip${scope === 'semantic' ? ' on' : ''}`}
-                  title={tr('用自然语言在课题语料里语义召回', 'Semantic recall over the topic corpus')}
-                  onClick={() => setScope('semantic')}
-                >
-                  {tr('语义检索', 'Semantic')}
-                </span>
               </div>
 
               {advOpen && (
@@ -795,7 +786,7 @@ export function ResearchPage() {
                     title={tr('语义检索失败', 'Semantic search failed')}
                     desc={tr('后端暂时不可用，稍后再试或改用关键词。', 'Backend unavailable — retry later or switch to keyword.')}
                     action={
-                      <button className="btn btn-soft sm" onClick={() => setScope('keyword')}>
+                      <button className="btn btn-soft sm" onClick={() => setSemanticOn(false)}>
                         {tr('改用关键词', 'Use keyword')}
                       </button>
                     }

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useId, useState, type ReactNode } from 'react';
 import type { ConceptCategory } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { Icon } from '../../components/ui/Icon';
+import { Switch } from '../../components/ui/Switch';
 
 /* ============================================================
    Research Wiki 页共享：概念类别配色、Section、防抖 hook。
@@ -84,6 +85,48 @@ export function SearchInput({
       placeholder={placeholder ?? tr('搜索…', 'Search…')}
       type="search"
     />
+  );
+}
+
+/** 语义检索开关（搜索框右边、高级检索按钮左边）：短标签 + Switch。
+    四处检索条统一用它，别各写各的 chip。关掉=关键词字面匹配，打开=按意思找。 */
+export function SemanticSwitch({
+  checked,
+  onChange,
+  disabled,
+  title,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  /** 悬浮说明（如「浏览记录不支持语义检索」）；不传给默认解释 */
+  title?: string;
+}) {
+  const labelId = `${useId()}-semantic`;
+  return (
+    <div
+      className="row gap6"
+      style={{ flexShrink: 0, opacity: disabled ? 0.5 : 1 }}
+      title={
+        title ??
+        tr('打开后按意思检索，而不是字面匹配关键词', 'Search by meaning instead of literal keyword matching')
+      }
+    >
+      <span
+        id={labelId}
+        onClick={() => !disabled && onChange(!checked)}
+        style={{
+          fontSize: 11.5,
+          whiteSpace: 'nowrap',
+          userSelect: 'none',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          color: checked ? 'var(--accent-text)' : 'var(--text-3)',
+        }}
+      >
+        {tr('语义检索', 'Semantic')}
+      </span>
+      <Switch checked={checked} onChange={onChange} disabled={disabled} aria-labelledby={labelId} />
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Semantic search was a pair of keyword/semantic **chips**, positioned differently on each page. Now all four surfaces share one bar: **`[search] [Semantic switch] [Advanced]`**.

- New shared `SemanticSwitch` in `features/wiki/shared.tsx` (label + `Switch`, `aria-labelledby` wired), used by all four so spacing and sizing can't drift.
- **Library browse / Related work / Personal library**: chips → switch, moved beside the search box, ahead of the advanced toggle. Personal library keeps the switch visible on the history tab but disabled (history is keyword-only), so both tabs' toolbars line up.
- **Daily papers** additionally gains an advanced panel (category + announce type). The date stepper and sort stay in the toolbar — the date is that page's primary navigation — and a summary line ("Showing: New work · cs.AI") appears while the panel is collapsed so the *new work only* default is never hidden.
- Sort controls now dim in semantic mode on the library and personal library, matching what those endpoints actually honor.

Note: the daily advanced panel stays usable in semantic mode (unlike the other three, which dim theirs) because `/daily/papers?mode=semantic` genuinely applies the date/category/announce filters — dimming would be a functional regression.

Frontend only. `tsc --noEmit` clean; `npm run build` passes.