### PR TITLE
fix(daily): let anyone read a daily-feed paper that nobody collected

### DIFF
--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -312,13 +312,26 @@ async def list_papers(
     return [PaperView(paper, membership, project_id) for paper, membership in page_rows], int(total)
 
 
+async def _paper_in_daily_feed(session: AsyncSession, paper_id: uuid.UUID) -> bool:
+    """论文是否在当前每日推送里——每日池全实验室可读，登录用户即可读它。"""
+    from app.models.daily_feed import DailyFeedEntry
+
+    row = (
+        await session.execute(
+            select(DailyFeedEntry.id).where(DailyFeedEntry.paper_id == paper_id).limit(1)
+        )
+    ).first()
+    return row is not None
+
+
 async def _pool_paper_view(
     session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, with_concepts: bool
 ) -> PaperView | None:
     """池级可见性兜底（P5b）：论文不在任何可见方向库，但个人链路可达时仍可读。
 
-    可达条件：该论文在请求者任一课题的相关研究书架上，或在其个人库条目里
-    （dedup 匹配）。返回的视角带**临时成员行**（不入 session、永不落库）：
+    可达条件：该论文在请求者任一课题的相关研究书架上、在其个人库条目里
+    （dedup 匹配），或仍在每日推送池里（每日推送全实验室可读，未收录也能读）。
+    返回的视角带**临时成员行**（不入 session、永不落库）：
     status=included、无判断字段；``project_id`` 取最早入架的课题（仅个人库
     可达时为 None）。只用于读路径——写成员行的端点不开启池级兜底。
     """
@@ -351,7 +364,8 @@ async def _pool_paper_view(
     topic_id = (await session.execute(stmt)).scalar_one_or_none()
     if topic_id is None:
         entry = await user_library.entry_for_paper(session, user_id=user_id, paper=paper)
-        if entry is None:
+        if entry is None and not await _paper_in_daily_feed(session, paper_id):
+            # 书架 / 个人库都不可达，也不在每日推送里 → 视为不存在
             return None
     membership = LibraryPaper(
         status="included", created_at=paper.created_at, updated_at=paper.updated_at

--- a/src/backend/tests/test_pool_paper_access.py
+++ b/src/backend/tests/test_pool_paper_access.py
@@ -142,3 +142,39 @@ async def test_pool_paper_hidden_from_others_and_write_paths(client):
     assert resp.status_code == 404
     async with get_sessionmaker()() as session:
         assert await session.get(Paper, uuid.UUID(paper_id)) is not None
+
+
+async def test_daily_feed_paper_readable_without_collecting(client):
+    """每日推送里的论文未被任何人收录时，任何登录用户仍可读（详情 / 阅读页取数）。
+
+    回归：每日详情点「阅读原文」曾报 PAPER_NOT_FOUND——池级兜底只认书架 / 个人库，
+    而未收录的每日论文两者都不在。
+    """
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+
+    paper_id = await _seed_pool_only_paper(title="Daily Only Paper", source="arxiv")
+    async with get_sessionmaker()() as session:
+        session.add(
+            DailyFeedEntry(
+                paper_id=uuid.UUID(paper_id),
+                feed_date=dt.datetime.now(dt.UTC).date(),
+                primary_category="cs.AI",
+            )
+        )
+        await session.commit()
+
+    # 任意登录用户（既没入架也没收藏）都能读到详情
+    token = await register_and_login(client, email="daily-reader@example.com")
+    resp = await client.get(f"/api/papers/{paper_id}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["title"] == "Daily Only Paper"
+
+
+async def test_pool_paper_not_in_daily_feed_stays_hidden(client):
+    """不在每日推送、也没入架/收藏的池论文，对他人仍是 404（不放宽既有边界）。"""
+    paper_id = await _seed_pool_only_paper(title="Nobody's Paper")
+    token = await register_and_login(client, email="daily-stranger@example.com")
+    resp = await client.get(f"/api/papers/{paper_id}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 404


### PR DESCRIPTION
## Bug

Opening a Daily paper in the reader showed *"this paper does not exist, you are not in this topic, or the backend is unavailable"*.

## Root cause

The reader fetches `GET /papers/{id}`, which resolves pool papers via `_pool_paper_view`. That fallback only reaches a paper that is in a visible library, **on one of your shelves, or in your personal library**. A daily paper nobody has collected is in none of them — even though the daily feed itself is lab-wide readable. Same root cause as #112 (which fixed only the fetch-pdf path).

## Fix

Accept **"still in the daily feed"** as a reachability condition in that fallback. This fixes the reader plus every other pool read path (highlights, figures, personal wiki) in one place, rather than adding daily-scoped duplicates of each endpoint.

## Tests

New cases in `test_pool_paper_access.py`: an uncollected daily paper is readable by any logged-in user; a pool paper in **no** collection still 404s (the existing boundary is not widened). **32 passed** across pool-access / daily / wiki / reading suites; ruff clean.