### PR TITLE
fix(docker): serve .mjs as JavaScript so the pdf.js worker loads

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,10 @@
+# nginx 自带的 mime.types 没有 .mjs，会按 application/octet-stream 发出；浏览器对
+# 模块脚本做严格 MIME 检查，于是 pdf.js 的 worker（打包产物是 .mjs）被拒绝执行，
+# 表现为 PDF 标注阅读器打不开而 iframe 的标准阅读器正常（后者不用 worker）。
+types {
+    application/javascript mjs;
+}
+
 # 上游走变量 + docker 内置 DNS 动态解析：api 容器重启换 IP 后 10s 内自动跟上，
 # 不再需要重启 frontend 容器来清 nginx 启动时缓存的旧 IP（否则会 502）。
 server {


### PR DESCRIPTION
Closes #115

## Problem

In deployed environments the PDF **Annotate** reader fails to open, while the **Standard** reader works. Local development is fine either way.

nginx's bundled `mime.types` has no `.mjs` entry, so the built pdf.js worker is served as `application/octet-stream`. Browsers apply strict MIME checking to module scripts and refuse to execute it. The standard reader is an `<iframe>` handed to the browser's built-in PDF viewer — no worker involved — which is exactly why the two behave differently. This is not tied to a particular paper: every PDF behind this nginx is affected. Local dev escapes it because vite's dev server types `.mjs` correctly.

## Change

A `types` block at the top level (http context) of `docker/nginx.conf` adds `.mjs`. It merges with the default `mime.types` rather than replacing it, so no other type is affected.

## Verification

Ran a throwaway nginx container with the patched config:

| Path | Before | After |
|---|---|---|
| `/assets/*.mjs` | `application/octet-stream` | `application/javascript` |
| `/assets/*.js` | `application/javascript` | `application/javascript` (unchanged) |
| `/` (SPA fallback) | `text/html` | `text/html` (unchanged) |