### PR TITLE
fix(ui): keep per-paper pending state from leaking across papers

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -792,7 +792,12 @@ export function DailyPage() {
           {/* —— 右：详情 —— */}
           <div className="split-detail">
             {selectedId ? (
-              <DailyDetailPane entryId={selectedId} onCollect={openCollect} />
+              <DailyDetailPane
+                /* key：换论文时重挂载，避免上一篇的「下载中 / 编译中」状态串台 */
+                key={selectedId}
+                entryId={selectedId}
+                onCollect={openCollect}
+              />
             ) : (
               <div className="empty" style={{ margin: 'auto' }}>
                 {tr('选择论文查看详情', 'Select a paper to view details')}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -499,7 +499,12 @@ function PapersPane({
 
       <div className="split-detail">
         {selectedId ? (
-          <PaperDetailPane paperId={selectedId} onWikiLink={onWikiLink} />
+          <PaperDetailPane
+            /* key：换论文时重挂载，避免上一篇的「编译中 / 下载中」状态串台 */
+            key={selectedId}
+            paperId={selectedId}
+            onWikiLink={onWikiLink}
+          />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
             {tr('从列表中选择一篇论文', 'Pick a paper from the list')}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -1872,6 +1872,8 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
       <div className="split-detail">
         {selectedId ? (
           <PaperDetailPane
+            /* key：换论文时重挂载，避免上一篇的「编译中 / 下载中」状态串台 */
+            key={selectedId}
             paperId={selectedId}
             pid={pid ?? ''}
             libraryId={libraryId}


### PR DESCRIPTION
## Bug

Start a compile (or a PDF download) on one paper, switch to another, and the second paper also shows **Compiling… / Downloading…** even though nothing is running for it.

## Root cause

Those labels come from `useMutation`'s `isPending`, which is **component state, not per-paper**. The detail panes were not remounted when the selected paper changed, so the in-flight mutation's pending flag carried over to whatever paper you switched to. (`PapersTab` had a `key` on an inner `div`, which doesn't reset the mutation.)

## Fix

Remount the detail pane on paper change via `key` in the three places that lacked it — **Daily papers**, **Library browse**, and the **papers workbench**. Related work and the personal library already keyed their panes, which is why they behaved correctly.

 clean.