### PR TITLE
ci(desktop): set project homepage and author so Linux packaging works

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -156,7 +156,10 @@ and publishes a GitHub release.
   first launch still needs `xattr -dr com.apple.quarantine /Applications/Polaris.app` or
   right-click → Open.
 - **Windows**: prefer the portable zip, which bypasses SmartScreen's installer check.
-- **Linux**: AppImage needs `libnss3 libgtk-3-0 libasound2` on the host. Under Ubuntu
+- **Linux**: AppImage and deb. The deb maintainer comes from `author` in
+  `src/desktop/package.json` and **must include an email**, or electron-builder aborts —
+  a macOS-only build never exercises that path, so CI is where it surfaces.
+  AppImage needs `libnss3 libgtk-3-0 libasound2` on the host. Under Ubuntu
   24.04+ AppArmor restrictions, or without a SUID `chrome-sandbox`, it needs
   `--no-sandbox` — **document that, do not disable the sandbox in code**.
 

--- a/src/desktop/electron-builder.yml
+++ b/src/desktop/electron-builder.yml
@@ -48,4 +48,6 @@ linux:
   category: Science
   target:
     - target: AppImage
+    # deb 的 maintainer 取自 package.json 的 author，**必须带邮箱**，否则
+    # electron-builder 直接报错中止（只打 macOS 时碰不到这条，CI 才会暴露）。
     - target: deb

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "version": "0.1.0",
   "description": "Polaris desktop shell (Electron)",
+  "homepage": "https://github.com/ZJU-REAL/Polaris",
+  "author": "ZJU-REAL <syl@zju.edu.cn>",
   "main": "dist/main.cjs",
   "scripts": {
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/main.cjs --external:electron",


### PR DESCRIPTION
The first three-platform release run failed on Linux. macOS universal and Windows both packaged fine; `deb` aborted:

```
Please specify project homepage …
Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer.
```

macOS builds never exercise the deb target, so this only surfaced once all three platforms ran. Both fields are now set — the deb maintainer comes from `author`, which is why it needs the email.

The release job correctly skipped after the build failure, so nothing was published.