### PR TITLE
fix(ui): track in-flight paper actions per paper, and simplify daily filters

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -10,6 +10,7 @@ import { ApiError, api, type DailyPaperItem, type DailySort, type PaperDetail } 
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import { Markdown } from '../../lib/markdown';
+import { usePendingByPaper } from '../../lib/pending';
 import { PaperReader } from '../wiki/PaperReader';
 import { readerFrom } from '../reading/shared';
 import {
@@ -149,11 +150,20 @@ function DailyRow({
 function DailyDetailPane({
   entryId,
   onCollect,
+  downloading,
+  compiling,
+  onFetchPdf,
+  onCompile,
 }: {
   entryId: string;
   onCollect: (p: CollectPaperRef) => void;
+  /** 这篇正在下载原文（状态存在父组件，切走再切回来照样是「下载中」） */
+  downloading: boolean;
+  /** 这篇正在 AI 编译 */
+  compiling: boolean;
+  onFetchPdf: (entryId: string) => void;
+  onCompile: (entryId: string) => void;
 }) {
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
   const [readerOpen, setReaderOpen] = useState(false);
@@ -163,37 +173,8 @@ function DailyDetailPane({
     retry: false,
   });
 
-  // 下载原文：把 PDF 抓进平台（顺带抽全文/分块），成功后按钮变「阅读原文」
-  const fetchPdfMutation = useMutation({
-    mutationFn: () => api.fetchDailyPaperPdf(entryId),
-    onSuccess: () => {
-      toast(tr('已下载原文，可以在线阅读了', 'PDF fetched — you can read it here now'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
-    },
-    onError: (e) =>
-      toast(
-        `${tr('下载原文失败', 'Failed to fetch the PDF')}：${e instanceof Error ? e.message : String(e)}`,
-        'error',
-      ),
-  });
-
-  // 单篇 AI 解读编译：同步等待（约半分钟）；409 = 已有人在编译
-  const compileMutation = useMutation({
-    mutationFn: () => api.compileDailyPaper(entryId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
-      void queryClient.invalidateQueries({ queryKey: ['daily-papers'] }); // 列表行的 has_wiki 标记
-      void queryClient.invalidateQueries({ queryKey: ['daily-liked'] });
-    },
-    onError: (e) => {
-      if (e instanceof ApiError && e.status === 409) {
-        toast(tr('已有人在生成，稍后刷新即可', 'Someone is already generating it, refresh later'), 'info');
-        void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
-      } else {
-        toast(`${tr('生成解读失败', 'Failed to generate summary')}：${e instanceof Error ? e.message : String(e)}`, 'error');
-      }
-    },
-  });
+  // 换论文时关掉阅览模式（面板不再随选中项重挂载，本地开合状态要自己收）
+  useEffect(() => setReaderOpen(false), [entryId]);
 
   if (isLoading) return <div className="empty">{tr('加载论文详情…', 'Loading paper…')}</div>;
   if (isError || !paper) {
@@ -275,11 +256,11 @@ function DailyDetailPane({
           (paper.arxiv_id || pdfDownloadUrl) && (
             <button
               className="btn btn-primary sm"
-              disabled={fetchPdfMutation.isPending}
-              onClick={() => fetchPdfMutation.mutate()}
+              disabled={downloading}
+              onClick={() => onFetchPdf(paper.entry_id)}
               title={tr('下载 PDF 到平台，下载后即可在线阅读', 'Fetch the PDF into Polaris so it can be read here')}
             >
-              {fetchPdfMutation.isPending ? (
+              {downloading ? (
                 <>
                   <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
                   {tr('下载中…', 'Downloading…')}
@@ -300,10 +281,10 @@ function DailyDetailPane({
               ? tr('用最新的图文模式重写这篇介绍', 'Rewrite this intro with the latest text+figures mode')
               : tr('AI 精读并编译图文介绍', 'Have the AI read and compile an illustrated intro')
           }
-          disabled={compileMutation.isPending}
-          onClick={() => compileMutation.mutate()}
+          disabled={compiling}
+          onClick={() => onCompile(paper.entry_id)}
         >
-          {compileMutation.isPending ? (
+          {compiling ? (
             <>
               <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
               {tr('AI 编译中，约半分钟…', 'Compiling — about half a minute…')}
@@ -403,17 +384,21 @@ type AnnounceFilter = 'all' | 'new' | 'cross';
 // 类型筛选默认值：只看新工作（高级检索面板里的「恢复默认」也回到这个值）
 const DEFAULT_ANNOUNCE: AnnounceFilter = 'new';
 
+// 列表固定按点赞排序（没有排序切换 UI）；语义检索时后端按相关度排，忽略这个值
+const DAILY_SORT: DailySort = 'likes';
+
 export function DailyPage() {
+  const queryClient = useQueryClient();
   const [view, setView] = useState<DailyView>('papers');
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
   // 语义检索开关（true=按意思检索，false=关键词字面匹配）
   const [semanticOn, setSemanticOn] = useState(false);
-  const [sort, setSort] = useState<DailySort>('likes');
   const [page, setPage] = useState(1);
   // —— 日期（null=全部 7 天，默认落在最新一天）留在工具栏；分类 / 类型收进高级检索面板 ——
   const [day, setDay] = useState<string | null>(null);
-  const [advOpen, setAdvOpen] = useState(false);
+  // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
+  const [advOpen, setAdvOpen] = useState(true);
   const [category, setCategory] = useState('');
   const [announce, setAnnounce] = useState<AnnounceFilter>(DEFAULT_ANNOUNCE);
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
@@ -427,7 +412,7 @@ export function DailyPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => setPage(1), [q, semanticOn, sort, day, category, announce]);
+  useEffect(() => setPage(1), [q, semanticOn, day, category, announce]);
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
@@ -481,10 +466,10 @@ export function DailyPage() {
   // 语义检索：只在有关键词时生效；结果按相关度排序、不分页
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
-    queryKey: ['daily-papers', semanticOn, sort, page, q, day, category, announce],
+    queryKey: ['daily-papers', semanticOn, page, q, day, category, announce],
     queryFn: () =>
       api.listDailyPapers({
-        sort: semantic ? undefined : sort,
+        sort: semantic ? undefined : DAILY_SORT,
         page: semantic ? undefined : page,
         size: PAGE_SIZE,
         q: q || undefined,
@@ -532,6 +517,54 @@ export function DailyPage() {
     setCollectPaper(p);
     setCollectOpen(true);
   };
+
+  // —— 两个长任务（下载原文 / AI 编译）都同步等着，用户很可能切走再切回来 ——
+  // 进行中状态按 entry_id 记在这一层：详情面板换论文不会丢，多篇同时跑也各记各的。
+  const downloadPending = usePendingByPaper();
+  const compilePending = usePendingByPaper();
+
+  const fetchPdf = useCallback(
+    (entryId: string) => {
+      void downloadPending.run(entryId, async () => {
+        try {
+          await api.fetchDailyPaperPdf(entryId);
+          toast(tr('已下载原文，可以在线阅读了', 'PDF fetched — you can read it here now'), 'ok');
+          void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+        } catch (e) {
+          toast(
+            `${tr('下载原文失败', 'Failed to fetch the PDF')}：${e instanceof Error ? e.message : String(e)}`,
+            'error',
+          );
+        }
+      });
+    },
+    [downloadPending, queryClient],
+  );
+
+  // 单篇 AI 解读编译：同步等待（约半分钟）；409 = 已有人在编译
+  const compile = useCallback(
+    (entryId: string) => {
+      void compilePending.run(entryId, async () => {
+        try {
+          await api.compileDailyPaper(entryId);
+          void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+          void queryClient.invalidateQueries({ queryKey: ['daily-papers'] }); // 列表行的 has_wiki 标记
+          void queryClient.invalidateQueries({ queryKey: ['daily-liked'] });
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 409) {
+            toast(tr('已有人在生成，稍后刷新即可', 'Someone is already generating it, refresh later'), 'info');
+            void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
+          } else {
+            toast(
+              `${tr('生成解读失败', 'Failed to generate summary')}：${e instanceof Error ? e.message : String(e)}`,
+              'error',
+            );
+          }
+        }
+      });
+    },
+    [compilePending, queryClient],
+  );
 
   return (
     <div
@@ -684,24 +717,6 @@ export function DailyPage() {
                   {tr('语义检索暂不可用，已回退为关键词匹配。', 'Semantic search unavailable — fell back to keyword matching.')}
                 </div>
               )}
-              <div className="row gap6 wrap" style={{ marginTop: 8 }}>
-                <span
-                  className={`chip${!semantic && sort === 'likes' ? ' on' : ''}`}
-                  style={semantic ? { opacity: 0.45, pointerEvents: 'none' } : undefined}
-                  title={semantic ? tr('语义检索按相关度排序', 'Semantic results are ranked by relevance') : undefined}
-                  onClick={() => setSort('likes')}
-                >
-                  {tr('按点赞', 'Most liked')}
-                </span>
-                <span
-                  className={`chip${!semantic && sort === 'date' ? ' on' : ''}`}
-                  style={semantic ? { opacity: 0.45, pointerEvents: 'none' } : undefined}
-                  title={semantic ? tr('语义检索按相关度排序', 'Semantic results are ranked by relevance') : undefined}
-                  onClick={() => setSort('date')}
-                >
-                  {tr('按时间', 'Newest')}
-                </span>
-              </div>
               {/* —— 日期步进（主导航，不收进高级检索） —— */}
               <div className="row gap6 wrap" style={{ marginTop: 8 }}>
                 <button
@@ -846,10 +861,12 @@ export function DailyPage() {
           <div className="split-detail">
             {selectedId ? (
               <DailyDetailPane
-                /* key：换论文时重挂载，避免上一篇的「下载中 / 编译中」状态串台 */
-                key={selectedId}
                 entryId={selectedId}
                 onCollect={openCollect}
+                downloading={downloadPending.has(selectedId)}
+                compiling={compilePending.has(selectedId)}
+                onFetchPdf={fetchPdf}
+                onCompile={compile}
               />
             ) : (
               <div className="empty" style={{ margin: 'auto' }}>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -503,8 +503,6 @@ function PapersPane({
       <div className="split-detail">
         {selectedId ? (
           <PaperDetailPane
-            /* key：换论文时重挂载，避免上一篇的「编译中 / 下载中」状态串台 */
-            key={selectedId}
             paperId={selectedId}
             onWikiLink={onWikiLink}
           />

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -29,6 +29,7 @@ import {
   type SearchMode,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { usePendingByPaper } from '../../lib/pending';
 import { clickable } from '../../lib/a11y';
 import { categoryMeta, saveBlob, SearchInput, useDebounced } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
@@ -921,6 +922,8 @@ function PaperDetailPane({
   onFilterAuthor,
   onFilterAffiliation,
   onDeleted,
+  compiling,
+  onRecompile,
 }: {
   paperId: string;
   pid: string;
@@ -933,6 +936,9 @@ function PaperDetailPane({
   onFilterAffiliation: (name: string) => void;
   /** 删除成功后回调（父组件清空选中，自动跳到列表第一篇） */
   onDeleted: () => void;
+  /** 这篇正在 AI 编译（状态存在列表页，切走再切回来照样是「编译中」） */
+  compiling: boolean;
+  onRecompile: (paperId: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -989,18 +995,13 @@ function PaperDetailPane({
       toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  // 重新编译：用最新的图文模式重写 wiki 页（同步调用，约 1 分钟）
-  const recompileMutation = useMutation({
-    mutationFn: () => api.recompilePaper(paperId),
-    onSuccess: () => {
-      toast(tr('编译完成，介绍已更新', 'Compiled — the intro has been updated'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['paper', scopeId, paperId] });
-      void queryClient.invalidateQueries({ queryKey: ['paper-figures', paperId] });
-      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
-    },
-    onError: (e) =>
-      toast(`${tr('重新编译失败：', 'Recompile failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
+  // 换论文时收起本地开合状态（面板不再随选中项重挂载，得自己收）
+  useEffect(() => {
+    setAbstractOpen(false);
+    setConceptsOpen(false);
+    setAffilsOpen(false);
+    setReaderOpen(false);
+  }, [paperId]);
 
   // 正文 ![[fig:N]] 嵌入图（docs/api-lit.md §6.6）
   const figures = usePaperFigures(paper);
@@ -1129,10 +1130,10 @@ function PaperDetailPane({
               ? tr('用最新的图文模式重写这篇介绍', 'Rewrite this intro with the latest text+figures mode')
               : tr('AI 精读并编译图文介绍', 'Have the AI read and compile an illustrated intro')
           }
-          disabled={recompileMutation.isPending}
-          onClick={() => recompileMutation.mutate()}
+          disabled={compiling}
+          onClick={() => onRecompile(paperId)}
         >
-          {recompileMutation.isPending ? (
+          {compiling ? (
             <>
               <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
               {tr('AI 编译中，约 1 分钟…', 'Compiling — about a minute…')}
@@ -1463,6 +1464,26 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
     setSelected(new Set());
     setSelectMode(false);
   }, [scopeId, view, q, tagFilter, readingFilter]);
+
+  // 重新编译：同步等着（约 1 分钟），用户很可能切走再切回来。
+  // 进行中状态按 paper id 记在列表页这一层：详情面板换论文不会丢，多篇同时编译也各记各的。
+  const compilePending = usePendingByPaper();
+  const recompile = useCallback(
+    (paperId: string) => {
+      void compilePending.run(paperId, async () => {
+        try {
+          await api.recompilePaper(paperId);
+          toast(tr('编译完成，介绍已更新', 'Compiled — the intro has been updated'), 'ok');
+          void queryClient.invalidateQueries({ queryKey: ['paper', scopeId, paperId] });
+          void queryClient.invalidateQueries({ queryKey: ['paper-figures', paperId] });
+          void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
+        } catch (e) {
+          toast(`${tr('重新编译失败：', 'Recompile failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+        }
+      });
+    },
+    [compilePending, queryClient, scopeId],
+  );
 
   const bulkDeleteMutation = useMutation({
     mutationFn: () => (libraryId ? api.batchDeleteLibraryPapers(libraryId, [...selected]) : api.batchDeletePapers(scopeId, [...selected])),
@@ -1872,8 +1893,6 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
       <div className="split-detail">
         {selectedId ? (
           <PaperDetailPane
-            /* key：换论文时重挂载，避免上一篇的「编译中 / 下载中」状态串台 */
-            key={selectedId}
             paperId={selectedId}
             pid={pid ?? ''}
             libraryId={libraryId}
@@ -1882,6 +1901,8 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
             onFilterAuthor={filterByAuthor}
             onFilterAffiliation={filterByAffiliation}
             onDeleted={() => onSelect('')}
+            compiling={compilePending.has(selectedId)}
+            onRecompile={recompile}
           />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>

--- a/src/frontend/src/lib/pending.ts
+++ b/src/frontend/src/lib/pending.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/* ============================================================
+   按论文 id 记录「进行中」的长任务（下载原文 / AI 编译，都是同步等着的请求）。
+
+   为什么不用组件内的 useMutation：
+   - 主从布局里详情面板是同一个组件实例复用的，useMutation 的 isPending 只认
+     「最后一次调用」，A 篇在跑、切到 B 篇就会串台；
+   - 若靠 key={selectedId} 重挂载来隔离，A 篇的进度又会随卸载一起丢，
+     切回来看不到「编译中」。
+   所以把状态按论文 id 存在**列表页（父组件）**里：父组件在切换论文时不卸载，
+   多篇同时跑也各记各的。
+   ============================================================ */
+
+export interface PendingByPaper {
+  /** 这篇论文当前是否有任务在跑 */
+  has: (id: string) => boolean;
+  /** 正在跑的论文数（做全局提示时用得上） */
+  size: number;
+  /**
+   * 包一次异步任务：开始时记上 id，结束（成功或失败）都移除。
+   * 同一 id 已在进行中时直接忽略这次调用（返回 undefined），避免重复触发。
+   * task 自己负责 toast / invalidate；抛错会原样抛出，调用方通常在 task 内部就地 catch。
+   */
+  run: <T>(id: string, task: () => Promise<T>) => Promise<T | undefined>;
+}
+
+/** 按论文 id 记录进行中的任务（id 是任意字符串，daily 用 entry_id、论文库用 paper_id）。 */
+export function usePendingByPaper(): PendingByPaper {
+  const [ids, setIds] = useState<ReadonlySet<string>>(() => new Set<string>());
+  // 事件里要读「最新值」判重，state 有异步批处理，另存一份同步镜像
+  const idsRef = useRef<ReadonlySet<string>>(ids);
+  // 组件已卸载后不再 setState（StrictMode 会先卸载再挂载，所以挂载时要重置回 true）
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const write = useCallback((next: ReadonlySet<string>) => {
+    idsRef.current = next;
+    if (aliveRef.current) setIds(next);
+  }, []);
+
+  const run = useCallback(
+    async <T>(id: string, task: () => Promise<T>): Promise<T | undefined> => {
+      if (idsRef.current.has(id)) return undefined;
+      write(new Set(idsRef.current).add(id));
+      try {
+        return await task();
+      } finally {
+        const next = new Set(idsRef.current);
+        next.delete(id);
+        write(next);
+      }
+    },
+    [write],
+  );
+
+  const has = useCallback((id: string) => ids.has(id), [ids]);
+  return useMemo(() => ({ has, size: ids.size, run }), [has, ids.size, run]);
+}


### PR DESCRIPTION
## What

#119 stopped *Compiling…* from leaking onto the next paper by remounting the detail pane — but that threw the progress away too: switch off the paper and back, and the spinner was gone. Both properties are needed:

1. start compiling A, switch to B → **B must not spin**;
2. switch back to A → **A must still spin** until that request really finishes.

## Fix

Track in-flight work **by paper id in the list page** (new `usePendingByPaper` hook in `lib/pending.ts`). The list page isn't unmounted when you pick another paper, so the state survives the switch while staying scoped to one paper.

A `Set` of ids is used rather than comparing a mutation's `variables` to the current paper: `variables` only reflects the *last* call, so two papers compiling at once would mis-report the first as idle.

Long actions (daily fetch-pdf / compile, workbench recompile) move up to the list page; the panes now take a boolean plus a callback and no longer need a remount key. Toasts and invalidations run in the always-mounted parent, so they complete even if you navigate away from the paper. Short actions (star, reading status, delete) stay in the pane. Pane-local disclosure state resets on paper change, which the remount used to do.

## Daily filters

Also drops the **likes / date** sort control (the list is always sorted by likes) and opens the **advanced panel by default**.

`tsc --noEmit` clean; `npm run build` passes.

## Known limit

Leaving the page entirely still drops the pending marks (the request finishes and invalidates in the background; the button just isn't spinning when you return). That matches the previous behavior — surviving a full page change would need a global store.