### PR TITLE
fix(routing): let users without a topic open the reading page

### DIFF
--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -127,7 +127,6 @@ export const router = createBrowserRouter([
           },
           // 实体详情页：按实体 id 拉数据，保持顶层路径（分享/收藏链接稳定）
           { path: 'voyages/:id', element: page(() => import('../features/voyages/VoyageDetailPage'), 'VoyageDetailPage') },
-          { path: 'papers/:id/read', element: page(() => import('../features/reading/ReadingPage'), 'ReadingPage') },
           { path: 'ideas/:id', element: page(() => import('../features/forge/IdeaDetailPage'), 'IdeaDetailPage') },
           { path: 'experiment/:id', element: page(() => import('../features/experiment/ExperimentDetailPage'), 'ExperimentDetailPage') },
           { path: 'writer/:id', element: page(() => import('../features/writer/WriterEditorPage'), 'WriterEditorPage') },
@@ -144,6 +143,9 @@ export const router = createBrowserRouter([
         ],
       },
       // —— 非课题作用域 ——
+      // 阅读页按论文 id 取数，文献库 / 每日新论文的论文都可读，与课题无关：
+      // 放在守卫外，否则没有任何课题的用户点「阅读原文」会被重定向去建课题。
+      { path: 'papers/:id/read', element: page(() => import('../features/reading/ReadingPage'), 'ReadingPage') },
       { path: 'start', element: page(() => import('../features/start/StartPage'), 'StartPage') },
       { path: 'projects/new', element: page(() => import('../features/projects/ProjectWizardPage'), 'ProjectWizardPage') },
       // 课题设置已并入工作台「课题设置」标签：/projects/:id → /t/:id?tab=settings


### PR DESCRIPTION
## Bug

With **no topics created**, clicking *Read original* anywhere (a library paper, a daily paper) bounced the user to the create-a-topic page — and the paper appeared impossible to compile.

## Root cause

`papers/:id/read` was declared **inside the `RequireTopic` guard**, which redirects to `/start` whenever `projects.length === 0`. But reading a paper is keyed by paper id and has nothing to do with topics — library and daily papers are readable by any logged-in user (that's why `/libraries` and `/daily` already live outside the guard).

The "can't compile" half was the same bug: the compile action lives on the reading page, so it was simply unreachable. Compiling itself already works without a topic — the personal-wiki endpoint takes `topic_id` as **optional**, and the page passes `paper.project_id`, which is just `null` for those papers.

## Fix

Move the route out of the guard, next to the other topic-free areas.

`tsc --noEmit` clean.