### PR TITLE
fix(library): scope the read-only detail, and close two permission holes

### DIFF
--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -540,10 +540,14 @@ async def extract_paper_figures(
     paper_id: uuid.UUID,
     force: bool = Query(default=False),
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
+    user: User = Depends(require_llm_task),
 ) -> PaperFiguresResponse:
-    """提取嵌入图 + LLM 筛选注释；已有 figures 且非 force 时幂等直返。"""
-    view = await _get_member_paper(session, paper_id, user, include_pool=True)
+    """提取嵌入图 + LLM 筛选注释；已有 figures 且非 force 时幂等直返。
+
+    库维护动作（写共享的 paper.figures + 调视觉模型），故与重新编译同口径：
+    不开池级兜底，只有对该论文所在库有管理权的人可调。
+    """
+    view = await _get_member_paper(session, paper_id, user)
     paper = view.paper
     if paper.figures is not None and not force:
         return PaperFiguresResponse(figures=[PaperFigure(**f) for f in paper.figures])

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -342,12 +342,23 @@ async def _pool_paper_view(
     paper = await session.get(Paper, paper_id, options=options)
     if paper is None:
         return None
-    # P5c 方向库全实验室可读：论文只要在任一方向库有成员行，任何登录用户可读。
+    # P5c 公共方向库全实验室可读：论文在任一**公共**库有成员行时，任何登录用户可读；
+    # 个人库（is_public=false）只对归属人放行，与 library_visible_to 的口径一致——
+    # 否则别人私有个人库里的论文可被任意用户凭 paper_id 读到。
     # 视角取确定性成员行（优先有 wiki 解读的，其次最早入库的）；无课题上下文
     # （project_id=None：伴读不带参考检索、LLM 记账归个人）。
+    from app.models.library_direction import DirectionLibrary
+
     shared_stmt = (
         select(LibraryPaper)
-        .where(LibraryPaper.paper_id == paper_id)
+        .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
+        .where(
+            LibraryPaper.paper_id == paper_id,
+            or_(
+                DirectionLibrary.is_public.is_(True),
+                DirectionLibrary.submitted_by == user_id,
+            ),
+        )
         .order_by(LibraryPaper.wiki_content.is_(None), LibraryPaper.created_at)
         .limit(1)
     )

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -129,12 +129,21 @@ function PaperRow({
   );
 }
 
-function PaperDetailPane({ paperId, onWikiLink }: { paperId: string; onWikiLink: WikiLinkHandler }) {
+function PaperDetailPane({
+  libraryId,
+  paperId,
+  onWikiLink,
+}: {
+  libraryId: string;
+  paperId: string;
+  onWikiLink: WikiLinkHandler;
+}) {
   const navigate = useNavigate();
   const location = useLocation();
+  // 库作用域取详情：锁定本库那份成员行，相关度/状态/wiki 不会串到该论文在别的库的副本
   const { data: paper, isLoading, isError } = useQuery({
-    queryKey: ['paper', paperId],
-    queryFn: () => api.getPaper(paperId),
+    queryKey: ['paper', libraryId, paperId],
+    queryFn: () => api.getLibraryPaper(libraryId, paperId),
     retry: false,
   });
 
@@ -503,6 +512,7 @@ function PapersPane({
       <div className="split-detail">
         {selectedId ? (
           <PaperDetailPane
+            libraryId={libraryId}
             paperId={selectedId}
             onWikiLink={onWikiLink}
           />


### PR DESCRIPTION
Groundwork from an audit of the regular-user library view vs the manager view.

## 1. Read-only detail showed the wrong library's data

`LibraryBrowse`'s detail pane fetched `GET /papers/{id}` — the **unscoped** read, which resolves an arbitrary cross-library membership. So a regular user could see another library's relevance / status / wiki for the same paper (the 0.96-vs-0.18 class of bug fixed for managers in #75). It now uses the library-scoped endpoint, which was already open to any viewer, and keys the cache by library.

## 2. `extract-figures` was open to everyone

It ran with the pool fallback and without an LLM gate, so **any logged-in user** could overwrite a shared paper's `figures` and spend vision-model quota. It writes shared data, so it's a maintenance action: now managed-access only, same as recompile.

## 3. Private personal-library papers were readable by anyone

The pool fallback accepted "the paper is in *any* direction library", without checking `is_public`. That let any user read a paper that only exists in someone else's **personal** library, contradicting `library_visible_to` ("personal libraries: owner + admin only"). That branch is now restricted to public libraries, or ones the viewer owns.

## Tests

29 passed across pool-access / shared-libraries / library-management / figures suites; `tsc` clean. The single failure (`ingest/state` forbidden assertion) reproduces on clean `main` and is unrelated.

Next in this series: restoring the read-only information density (status, relevance, reading state, star, tags, concepts, figures, reading mode) and the personal-dimension actions for regular users.