### PR TITLE
feat(lab): add a lab workbench with an overview and grouped tasks

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -90,6 +90,7 @@ function crumbFor(pathname: string): [string, string] {
     '/skills': ['Polaris', tr('技能', 'Skills')],
     '/settings': ['Polaris', tr('设置', 'Settings')],
     '/admin': ['Polaris', tr('管理', 'Manage')],
+    '/lab': ['Polaris', tr('实验室工作台', 'Lab Workbench')],
   };
   return table[p] ?? ['Polaris', '—'];
 }
@@ -590,6 +591,16 @@ export function AppShell() {
             <span>{tr('搜索论文 / 想法 / 实验…', 'Search papers / ideas / experiments…')}</span>
             <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>⌘K</span>
           </div>
+          {/* 实验室工作台入口（所有登录用户可见）：实验室资源概况 + 课题外任务 */}
+          <button
+            className="icon-btn"
+            onClick={() => navigate('/lab')}
+            title={tr('实验室工作台', 'Lab Workbench')}
+            aria-label={tr('实验室工作台', 'Lab Workbench')}
+            style={location.pathname === '/lab' ? { color: 'var(--accent)', background: 'var(--surface-2)' } : undefined}
+          >
+            <Icon name="flask" size={16} />
+          </button>
           {/* 管理员设置入口（仅管理员可见） */}
           {isAdmin(me) && (
             <button

--- a/src/frontend/src/app/routes.tsx
+++ b/src/frontend/src/app/routes.tsx
@@ -152,6 +152,8 @@ export const router = createBrowserRouter([
       { path: 'projects/:id', element: <ProjectSettingsRedirect /> },
       { path: 'join/:token', element: page(() => import('../features/projects/JoinPage'), 'JoinPage') },
       { path: 'library', element: page(() => import('../features/library/LibraryPage'), 'LibraryPage') },
+      // 实验室工作台：实验室资源概况 + 全部任务（含 project_id 为空的课题外任务）
+      { path: 'lab', element: page(() => import('../features/lab/LabPage'), 'LabPage') },
       // 实验室区：共享方向文献库（全实验室可读，无需课题）
       { path: 'libraries', element: page(() => import('../features/libraries/LibrariesPage'), 'LibrariesPage') },
       { path: 'libraries/:id', element: page(() => import('../features/libraries/LibraryDetailPage'), 'LibraryDetailPage') },

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -709,7 +709,8 @@ export function DashboardPage() {
           <div className="empty" style={{ padding: 60 }}>{tr('请先选择一个课题', 'Pick a topic first')}</div>
         ))}
 
-      {tab === 'tasks' && <VoyagesList />}
+      {/* 课题工作台只看本课题的任务；课题外任务在 /lab（底部引导链接） */}
+      {tab === 'tasks' && <VoyagesList labLink />}
     </div>
   );
 }

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -1,0 +1,577 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { PageHead } from '../../components/ui/PageHead';
+import { Segmented } from '../../components/ui/Segmented';
+import { StatCard } from '../../components/ui/StatCard';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { useProject } from '../../app/project';
+import { api, type DirectionLibrarySummary, type VoyageRead } from '../../lib/api';
+import { fmtFullTime, fmtRelative } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+import { useLibraries, libraryPath } from '../libraries/hooks';
+import {
+  FILTERS,
+  KIND_META,
+  SkeletonRows,
+  VoyageRow,
+  matchFilter,
+  type Filter,
+} from '../voyages/VoyagesPage';
+
+/* ============================================================
+   /lab — 实验室工作台
+   两个标签：
+   - 概况：文献库与每日新论文的汇总（全部走既有列表接口，无新增聚合端点）
+   - 任务：全部可见任务按归属分组（课题任务 / 文献库任务 / 其它），
+     覆盖课题工作台看不到的「课题外任务」（VoyageRun.project_id 可为空）
+   ============================================================ */
+
+type LabTab = 'overview' | 'tasks';
+
+/* ------------------------------------------------------------------ 概况 */
+
+/** 库状态小标：待审批 / 已驳回；已激活不额外占位（默认态不加噪）。 */
+function LibStatusPill({ status }: { status: DirectionLibrarySummary['status'] }) {
+  if (status === 'active') return null;
+  const cfg =
+    status === 'pending'
+      ? { zh: '待审批', en: 'Pending', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' }
+      : { zh: '已驳回', en: 'Rejected', bg: 'var(--danger-bg)', tx: 'var(--danger-tx)' };
+  return (
+    <span className="pill sm" style={{ background: cfg.bg, color: cfg.tx, flexShrink: 0 }}>
+      {tr(cfg.zh, cfg.en)}
+    </span>
+  );
+}
+
+/** 文献库汇总卡：公共/个人计数 + 每库一行（论文数 / 概念数 / 上次同步时间 / 状态）。 */
+function LibrariesCard() {
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useLibraries();
+  const libs = useMemo(() => {
+    const list = data ?? [];
+    // 公共库在前，其次论文多的在前
+    return [...list].sort(
+      (a, b) => Number(b.is_public) - Number(a.is_public) || b.paper_count - a.paper_count,
+    );
+  }, [data]);
+  const publicCount = libs.filter((l) => l.is_public).length;
+  const personalCount = libs.length - publicCount;
+  const paperTotal = libs.reduce((acc, l) => acc + l.paper_count, 0);
+
+  return (
+    <div className="card" style={{ overflow: 'hidden', marginBottom: 20 }}>
+      <div className="row gap10" style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--border)' }}>
+        <Icon name="book" size={15} style={{ color: 'var(--text-2)', flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 650, letterSpacing: '-0.01em' }}>
+            {tr('文献库', 'Libraries')}
+          </div>
+          <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>
+            {isLoading || isError
+              ? tr('实验室共享的方向文献库', 'Shared direction libraries')
+              : tr(
+                  `公共库 ${publicCount} 个 · 个人库 ${personalCount} 个 · 共 ${paperTotal} 篇论文`,
+                  `${publicCount} public · ${personalCount} personal · ${paperTotal} papers`,
+                )}
+          </div>
+        </div>
+        <Link className="btn btn-soft sm" to="/libraries">
+          {tr('全部文献库', 'All libraries')}
+          <Icon name="chevron" size={12} />
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="col gap10" style={{ padding: '16px 18px' }}>
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="skel" style={{ height: 14, width: `${70 - i * 12}%` }} />
+          ))}
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载文献库', 'Failed to load libraries')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+          compact
+        />
+      ) : libs.length === 0 ? (
+        <EmptyState
+          icon="book"
+          title={tr('还没有文献库', 'No libraries yet')}
+          desc={tr('新建一个文献库后，建库与同步任务会出现在「任务」标签里。', 'Create a library — its build and sync tasks will show up under the Tasks tab.')}
+          compact
+          action={
+            <Link className="btn btn-primary sm" to="/libraries">
+              {tr('去建库', 'Create one')}
+            </Link>
+          }
+        />
+      ) : (
+        <div className="table-wrap">
+          {libs.map((l, i) => (
+            <div
+              key={l.id}
+              className="voyage-row"
+              onClick={() => navigate(libraryPath(l.id))}
+              style={{ borderTop: i > 0 ? '0.5px solid var(--border)' : 'none' }}
+            >
+              <span
+                className="pill sm"
+                style={{
+                  background: l.is_public ? 'var(--ok-bg)' : 'var(--violet-bg)',
+                  color: l.is_public ? 'var(--ok-tx)' : 'var(--violet-tx)',
+                  flexShrink: 0,
+                }}
+              >
+                {l.is_public ? tr('公共', 'Public') : tr('个人', 'Personal')}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  title={l.name}
+                  style={{ fontSize: 13.5, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  {l.name}
+                </div>
+                <div className="row gap8" style={{ marginTop: 4 }}>
+                  {l.owner_name && (
+                    <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{l.owner_name}</span>
+                  )}
+                  <span style={{ fontSize: 11, color: 'var(--text-3)' }} title={fmtFullTime(l.last_synced_at)}>
+                    {l.last_synced_at
+                      ? tr(`上次同步 ${fmtRelative(l.last_synced_at)}`, `synced ${fmtRelative(l.last_synced_at)}`)
+                      : tr('还没同步过', 'never synced')}
+                  </span>
+                </div>
+              </div>
+              <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)', width: 96, flexShrink: 0, textAlign: 'right' }}>
+                {l.paper_count} {tr('篇', 'papers')}
+              </span>
+              <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)', width: 96, flexShrink: 0, textAlign: 'right' }}>
+                {l.concept_count} {tr('概念', 'concepts')}
+              </span>
+              <span style={{ width: 70, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
+                <LibStatusPill status={l.status} />
+              </span>
+              <Icon name="chevron" size={14} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 本地时区的 YYYY-MM-DD（每日新论文按日期字符串分桶）。 */
+function todayKey(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/** 每日新论文汇总卡：今日新增 / 近 7 天合计 + 最近 7 天迷你分布（单色柱，标签用文本色）。 */
+function DailyCard() {
+  const { data, isLoading, isError } = useQuery({
+    // 与 /daily 页共享缓存
+    queryKey: ['daily-days'],
+    queryFn: () => api.listDailyDays(),
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const days = useMemo(() => [...(data ?? [])].sort((a, b) => a.date.localeCompare(b.date)).slice(-7), [data]);
+  const today = todayKey();
+  const todayCount = days.find((d) => d.date === today)?.count ?? 0;
+  const weekTotal = days.reduce((acc, d) => acc + d.count, 0);
+  const max = Math.max(1, ...days.map((d) => d.count));
+
+  return (
+    <div className="card" style={{ overflow: 'hidden' }}>
+      <div className="row gap10" style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--border)' }}>
+        <Icon name="heart" size={15} style={{ color: 'var(--text-2)', flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 650, letterSpacing: '-0.01em' }}>
+            {tr('每日新论文', 'Daily Papers')}
+          </div>
+          <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>
+            {tr('arXiv 每日新提交，保留最近 7 天', 'New arXiv submissions, last 7 days kept')}
+          </div>
+        </div>
+        <Link className="btn btn-soft sm" to="/daily">
+          {tr('去浏览', 'Browse')}
+          <Icon name="chevron" size={12} />
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="col gap10" style={{ padding: '18px' }}>
+          <div className="skel" style={{ height: 14, width: '40%' }} />
+          <div className="skel" style={{ height: 56, width: '100%' }} />
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载每日新论文', 'Failed to load daily papers')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+          compact
+        />
+      ) : days.length === 0 ? (
+        <EmptyState
+          icon="heart"
+          title={tr('还没有抓取到新论文', 'No new papers yet')}
+          desc={tr('每日抓取任务跑过之后，这里会显示每天的新增量。', 'Counts show up here once the daily fetch has run.')}
+          compact
+        />
+      ) : (
+        <div style={{ padding: '16px 18px' }}>
+          <div className="row gap20" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
+            <div>
+              <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>{todayCount}</div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('今天新增', 'New today')}</div>
+            </div>
+            <div>
+              <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>{weekTotal}</div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('近 7 天合计', 'Last 7 days')}</div>
+            </div>
+          </div>
+
+          {/*
+            单序列迷你分布：柱子统一 accent 色（明度区分靠高度），标签用文本色。
+            /daily 目前不认 ?date=，柱子统一进列表页（日期在那里再选）。
+          */}
+          <div className="row" style={{ gap: 8, alignItems: 'flex-end' }}>
+            {days.map((d) => (
+              <Link
+                key={d.date}
+                to="/daily"
+                title={`${d.date} · ${d.count}`}
+                style={{ flex: 1, minWidth: 0, textDecoration: 'none', display: 'block' }}
+              >
+                <div style={{ height: 52, display: 'flex', alignItems: 'flex-end' }}>
+                  <div
+                    style={{
+                      width: '100%',
+                      height: `${Math.max(3, Math.round((d.count / max) * 52))}px`,
+                      borderRadius: '4px 4px 2px 2px',
+                      background: d.date === today ? 'var(--accent)' : 'var(--accent-soft)',
+                      border: d.date === today ? 'none' : '0.5px solid var(--border-2)',
+                    }}
+                  />
+                </div>
+                <div
+                  className="mono"
+                  style={{ fontSize: 10, color: 'var(--text-3)', textAlign: 'center', marginTop: 5 }}
+                >
+                  {d.count}
+                </div>
+                <div
+                  className="mono"
+                  style={{ fontSize: 9.5, color: 'var(--text-4)', textAlign: 'center', marginTop: 1 }}
+                >
+                  {d.date.slice(5)}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OverviewTab() {
+  const { data: libs } = useLibraries();
+  const { data: days } = useQuery({
+    queryKey: ['daily-days'],
+    queryFn: () => api.listDailyDays(),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const { data: voyages } = useQuery({
+    queryKey: ['voyages', 'all'],
+    queryFn: () => api.listVoyages(),
+    retry: false,
+    refetchInterval: 30_000,
+  });
+
+  const libList = libs ?? [];
+  const dayList = days ?? [];
+  const activeVoyages = (voyages ?? []).filter((v) => matchFilter(v, 'active') || matchFilter(v, 'paused')).length;
+
+  return (
+    <>
+      <div className="row gap16 dash-stats" style={{ marginBottom: 20 }}>
+        <StatCard
+          icon="book"
+          label="文献库"
+          en="Libraries"
+          value={libs ? libList.length : '—'}
+          sub={libs ? tr(`${libList.filter((l) => l.is_public).length} 个公共库`, `${libList.filter((l) => l.is_public).length} public`) : undefined}
+        />
+        <StatCard
+          icon="file"
+          label="论文总量"
+          en="Papers"
+          value={libs ? libList.reduce((a, l) => a + l.paper_count, 0) : '—'}
+          sub={tr('全部文献库', 'across libraries')}
+        />
+        <StatCard
+          icon="heart"
+          label="每日新论文"
+          en="Daily papers"
+          value={days ? dayList.reduce((a, d) => a + d.count, 0) : '—'}
+          sub={tr('近 7 天', 'last 7 days')}
+        />
+        <StatCard
+          icon="compass"
+          label="进行中的任务"
+          en="Running tasks"
+          value={voyages ? activeVoyages : '—'}
+          sub={tr('含等待审批', 'incl. waiting')}
+          accent
+        />
+      </div>
+
+      <LibrariesCard />
+      <DailyCard />
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ 任务 */
+
+type GroupKey = string;
+
+interface VoyageGroup {
+  key: GroupKey;
+  /** 分组标题（已本地化） */
+  title: string;
+  /** 分组说明（已本地化） */
+  hint: string;
+  icon: 'dashboard' | 'book' | 'sparkle';
+  items: VoyageRead[];
+}
+
+/** 可折叠分组：标题行 + 计数 + 行列表。 */
+function TaskGroup({ group, open, onToggle }: { group: VoyageGroup; open: boolean; onToggle: () => void }) {
+  return (
+    <div className="card" style={{ overflow: 'hidden', marginBottom: 14 }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '12px 16px',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+          fontFamily: 'var(--sans)',
+        }}
+      >
+        <Icon
+          name="chevron"
+          size={14}
+          style={{ color: 'var(--text-3)', transform: open ? 'rotate(90deg)' : 'none', transition: 'transform .15s', flexShrink: 0 }}
+        />
+        <Icon name={group.icon} size={14} style={{ color: 'var(--text-3)', flexShrink: 0 }} />
+        <span style={{ fontSize: 13, fontWeight: 650, color: 'var(--text)', letterSpacing: '-0.01em' }}>
+          {group.title}
+        </span>
+        <span style={{ fontSize: 11.5, color: 'var(--text-4)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {group.hint}
+        </span>
+        <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)', flexShrink: 0 }}>
+          {group.items.length}
+        </span>
+      </button>
+      {open && (
+        <div className="table-wrap" style={{ borderTop: '0.5px solid var(--border)' }}>
+          {/* 归属名已在组标题上，行内不再重复 */}
+          {group.items.map((v, i) => (
+            <VoyageRow key={v.id} v={v} first={i === 0} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TasksTab() {
+  const { projects } = useProject();
+  const { data: libs } = useLibraries();
+
+  const [filter, setFilter] = useState<Filter>('all');
+  const [kindFilter, setKindFilter] = useState<string>('all');
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  // 不传 project_id = 我可见的全部任务（含 project_id 为空的课题外任务）
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['voyages', 'all'],
+    queryFn: () => api.listVoyages(),
+    retry: false,
+    refetchInterval: 30_000,
+  });
+
+  const projectName = useMemo(() => new Map(projects.map((p) => [p.id, p.name] as const)), [projects]);
+  const libraryName = useMemo(() => new Map((libs ?? []).map((l) => [l.id, l.name] as const)), [libs]);
+
+  const groups = useMemo<VoyageGroup[]>(() => {
+    const rows = (data ?? []).filter(
+      (v) => matchFilter(v, filter) && (kindFilter === 'all' || v.kind === kindFilter),
+    );
+    const byProject = new Map<string, VoyageRead[]>();
+    const byLibrary = new Map<string, VoyageRead[]>();
+    const other: VoyageRead[] = [];
+    for (const v of rows) {
+      if (v.project_id) {
+        const arr = byProject.get(v.project_id) ?? [];
+        arr.push(v);
+        byProject.set(v.project_id, arr);
+      } else if (v.library_id) {
+        const arr = byLibrary.get(v.library_id) ?? [];
+        arr.push(v);
+        byLibrary.set(v.library_id, arr);
+      } else {
+        other.push(v);
+      }
+    }
+    const newest = (list: VoyageRead[]) =>
+      [...list].sort((a, b) => b.created_at.localeCompare(a.created_at));
+    const out: VoyageGroup[] = [];
+    for (const [pid, list] of byProject) {
+      out.push({
+        key: `project:${pid}`,
+        title: projectName.get(pid) ?? tr('未知课题', 'Unknown topic'),
+        hint: tr('课题任务', 'Topic tasks'),
+        icon: 'dashboard',
+        items: newest(list),
+      });
+    }
+    for (const [lid, list] of byLibrary) {
+      out.push({
+        key: `library:${lid}`,
+        title: libraryName.get(lid) ?? tr('未知文献库', 'Unknown library'),
+        hint: tr('文献库任务（课题外）', 'Library tasks (outside topics)'),
+        icon: 'book',
+        items: newest(list),
+      });
+    }
+    if (other.length > 0) {
+      out.push({
+        key: 'other',
+        title: tr('其它任务', 'Other tasks'),
+        hint: tr('既不属于课题也不属于文献库', 'Neither topic nor library'),
+        icon: 'sparkle',
+        items: newest(other),
+      });
+    }
+    // 课题组在前、文献库组次之、其它垫底；组内按任务数多的在前
+    const rank = (g: VoyageGroup) => (g.key.startsWith('project:') ? 0 : g.key.startsWith('library:') ? 1 : 2);
+    return out.sort((a, b) => rank(a) - rank(b) || b.items.length - a.items.length);
+  }, [data, filter, kindFilter, projectName, libraryName]);
+
+  return (
+    <>
+      <div className="row gap10" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
+        <Segmented options={FILTERS.map((f) => ({ v: f.v, label: tr(f.zh, f.en) }))} value={filter} onChange={setFilter} />
+        <select
+          className="input"
+          aria-label={tr('按类型筛选', 'Filter by type')}
+          value={kindFilter}
+          onChange={(e) => setKindFilter(e.target.value)}
+          style={{ height: 33, fontSize: 12.5, fontWeight: 600, width: 128, color: kindFilter === 'all' ? 'var(--text-3)' : 'var(--text)' }}
+        >
+          <option value="all">{tr('全部类型', 'All types')}</option>
+          {Object.entries(KIND_META).map(([k, m]) => (
+            <option key={k} value={k}>{tr(m.zh, m.en)}</option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading ? (
+        <SkeletonRows />
+      ) : isError ? (
+        <div className="card">
+          <EmptyState
+            icon="x"
+            title={tr('无法加载任务列表', 'Failed to load tasks')}
+            desc={tr('后端不可用或接口尚未就绪，稍后可重试。', 'Backend unavailable or endpoint not ready — try again later.')}
+            compact
+            action={
+              <button className="btn btn-soft" onClick={() => void refetch()}>
+                <Icon name="refresh" size={13} />
+                {tr('重试', 'Retry')}
+              </button>
+            }
+          />
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="card">
+          <EmptyState
+            icon="compass"
+            title={tr('暂无任务', 'No tasks yet')}
+            desc={
+              filter !== 'all' || kindFilter !== 'all'
+                ? tr('当前筛选条件下没有任务，换个筛选试试。', 'No tasks match the current filters — try different ones.')
+                : tr('还没有任务。发起建库、想法生成、实验等操作后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start ingest, idea generation, experiments, and so on.')
+            }
+            compact
+          />
+        </div>
+      ) : (
+        groups.map((g) => (
+          <TaskGroup
+            key={g.key}
+            group={g}
+            open={!collapsed[g.key]}
+            onToggle={() => setCollapsed((c) => ({ ...c, [g.key]: !c[g.key] }))}
+          />
+        ))
+      )}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ 页面 */
+
+export function LabPage() {
+  // ?tab= 深链进入后清参数（与课题工作台一致）
+  const [tab, setTab] = useState<LabTab>('overview');
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const tabParam = searchParams.get('tab');
+    if (!tabParam) return;
+    if ((['overview', 'tasks'] as const).some((t) => t === tabParam)) setTab(tabParam as LabTab);
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  return (
+    <div className="page fadeup">
+      <PageHead
+        eyebrow="Polaris · Lab"
+        title={tr('实验室工作台', 'Lab Workbench')}
+        sub={tr('实验室共享资源的总览，以及不属于任何课题的任务。', 'An overview of shared lab resources, plus tasks that belong to no topic.')}
+      />
+
+      <div style={{ marginBottom: 22 }}>
+        <Segmented
+          options={[
+            { v: 'overview' as const, label: tr('概况', 'Overview') },
+            { v: 'tasks' as const, label: tr('任务', 'Tasks') },
+          ]}
+          value={tab}
+          onChange={setTab}
+        />
+      </div>
+
+      {tab === 'overview' ? <OverviewTab /> : <TasksTab />}
+    </div>
+  );
+}

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
@@ -16,9 +16,9 @@ import { tr } from '../../lib/i18n';
    迷你进度条/耗时/状态）。任务由建库/想法/实验等业务动作发起。
    ============================================================ */
 
-type Filter = 'all' | 'active' | 'paused' | 'done' | 'failed';
+export type Filter = 'all' | 'active' | 'paused' | 'done' | 'failed';
 
-const FILTERS: { v: Filter; zh: string; en: string }[] = [
+export const FILTERS: { v: Filter; zh: string; en: string }[] = [
   { v: 'all', zh: '全部', en: 'All' },
   { v: 'active', zh: '进行中', en: 'Active' },
   { v: 'paused', zh: '等待中', en: 'Waiting' },
@@ -29,7 +29,7 @@ const FILTERS: { v: Filter; zh: string; en: string }[] = [
 /** 正在推进中的状态（列表行左缘蓝条 + 淡蓝底 + 进度条动画）。 */
 const RUNNING_STATUSES: ReadonlySet<string> = new Set(['planning', 'executing', 'verifying', 'replanning']);
 
-function matchFilter(v: VoyageRead, f: Filter): boolean {
+export function matchFilter(v: VoyageRead, f: Filter): boolean {
   switch (f) {
     case 'all':
       return true;
@@ -53,7 +53,7 @@ interface KindMeta {
   tx: string;
 }
 
-const KIND_META: Record<string, KindMeta> = {
+export const KIND_META: Record<string, KindMeta> = {
   wiki_bootstrap: { zh: '初始建库', en: 'Initial library build', icon: 'book', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
   wiki_ingest: { zh: '增量更新', en: 'Incremental sync', icon: 'refresh', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' },
   idea_forge: { zh: '想法生成', en: 'Idea forge', icon: 'bulb', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' },
@@ -114,8 +114,58 @@ function StepProgress({ v }: { v: VoyageRead }) {
   );
 }
 
+/**
+ * 任务列表的一行：类型徽章 / 目标 + id + 相对时间 / 进度 / 耗时 / 状态。
+ * 课题工作台「任务」标签与实验室工作台「任务」标签共用（外层各自套 .table-wrap）。
+ */
+export function VoyageRow({ v, first }: { v: VoyageRead; first?: boolean }) {
+  const navigate = useNavigate();
+  const active = !VOYAGE_TERMINAL.has(v.status);
+  const running = RUNNING_STATUSES.has(v.status);
+  return (
+    <div
+      className={`voyage-row${running ? ' running' : ''}`}
+      onClick={() => navigate(`/voyages/${v.id}`)}
+      style={{ borderTop: first ? 'none' : '0.5px solid var(--border)' }}
+    >
+      <KindBadge kind={v.kind} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          title={v.goal}
+          style={{ fontSize: 13.5, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {v.goal}
+        </div>
+        <div className="row gap8" style={{ marginTop: 4 }}>
+          <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>{v.id.slice(0, 8)}</span>
+          <span style={{ fontSize: 11, color: 'var(--text-3)' }} title={fmtFullTime(v.created_at)}>
+            · {fmtRelative(v.created_at)}
+          </span>
+        </div>
+      </div>
+      <span style={{ width: 130, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
+        <StepProgress v={v} />
+      </span>
+      <span
+        className="mono"
+        style={{
+          fontSize: 11.5, color: 'var(--text-3)', width: 78, flexShrink: 0,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'flex-end', gap: 4,
+        }}
+      >
+        <Icon name="clock" size={11} />
+        {fmtDuration(v.created_at, active ? null : v.updated_at)}
+      </span>
+      <span style={{ width: 134, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
+        <StatusPill status={v.status} sm />
+      </span>
+      <Icon name="chevron" size={14} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+    </div>
+  );
+}
+
 /** 加载骨架：shimmer 行，占位结构与真实行一致。 */
-function SkeletonRows() {
+export function SkeletonRows() {
   return (
     <div className="card" style={{ overflow: 'hidden' }}>
       {[0, 1, 2, 3].map((i) => (
@@ -138,9 +188,13 @@ function SkeletonRows() {
   );
 }
 
-/** 任务列表主体（过滤条 + 列表）：无自身 PageHead / 页壳，供工作台「任务」标签内嵌。 */
-export function VoyagesList() {
-  const navigate = useNavigate();
+/**
+ * 任务列表主体（过滤条 + 列表）：无自身 PageHead / 页壳，供工作台「任务」标签内嵌。
+ * - `showScopeSwitch`：是否显示「当前课题 / 全部课题」切换器。课题工作台里固定看本课题
+ *   （课题外的任务在 /lab 的「任务」标签按类型分组看），所以默认关闭。
+ * - `labLink`：底部是否显示「课题外的任务在实验室工作台」引导（课题工作台用）。
+ */
+export function VoyagesList({ showScopeSwitch = false, labLink = false }: { showScopeSwitch?: boolean; labLink?: boolean } = {}) {
   const { currentProjectId } = useProject();
 
   const [filter, setFilter] = useState<Filter>('all');
@@ -175,15 +229,19 @@ export function VoyagesList() {
                 <option key={k} value={k}>{tr(m.zh, m.en)}</option>
               ))}
             </select>
-            <div style={{ flex: 1 }} />
-            <Segmented
-              options={[
-                { v: 'current' as const, label: tr('当前课题', 'Current topic') },
-                { v: 'all' as const, label: tr('全部课题', 'All topics') },
-              ]}
-              value={scope}
-              onChange={setScope}
-            />
+            {showScopeSwitch && (
+              <>
+                <div style={{ flex: 1 }} />
+                <Segmented
+                  options={[
+                    { v: 'current' as const, label: tr('当前课题', 'Current topic') },
+                    { v: 'all' as const, label: tr('全部课题', 'All topics') },
+                  ]}
+                  value={scope}
+                  onChange={setScope}
+                />
+              </>
+            )}
           </div>
 
           {isLoading ? (
@@ -220,52 +278,20 @@ export function VoyagesList() {
             <div className="card" style={{ overflow: 'hidden' }}>
               {/* 行内定宽列合计放不下窄屏，整块横滚而不是把中间的标题列挤成 0 宽 */}
               <div className="table-wrap">
-              {voyages.map((v, i) => {
-                const active = !VOYAGE_TERMINAL.has(v.status);
-                const running = RUNNING_STATUSES.has(v.status);
-                return (
-                  <div
-                    key={v.id}
-                    className={`voyage-row${running ? ' running' : ''}`}
-                    onClick={() => navigate(`/voyages/${v.id}`)}
-                    style={{ borderTop: i > 0 ? '0.5px solid var(--border)' : 'none' }}
-                  >
-                    <KindBadge kind={v.kind} />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div
-                        title={v.goal}
-                        style={{ fontSize: 13.5, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                      >
-                        {v.goal}
-                      </div>
-                      <div className="row gap8" style={{ marginTop: 4 }}>
-                        <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>{v.id.slice(0, 8)}</span>
-                        <span style={{ fontSize: 11, color: 'var(--text-3)' }} title={fmtFullTime(v.created_at)}>
-                          · {fmtRelative(v.created_at)}
-                        </span>
-                      </div>
-                    </div>
-                    <span style={{ width: 130, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
-                      <StepProgress v={v} />
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        fontSize: 11.5, color: 'var(--text-3)', width: 78, flexShrink: 0,
-                        display: 'inline-flex', alignItems: 'center', justifyContent: 'flex-end', gap: 4,
-                      }}
-                    >
-                      <Icon name="clock" size={11} />
-                      {fmtDuration(v.created_at, active ? null : v.updated_at)}
-                    </span>
-                    <span style={{ width: 134, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
-                      <StatusPill status={v.status} sm />
-                    </span>
-                    <Icon name="chevron" size={14} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
-                  </div>
-                );
-              })}
+                {voyages.map((v, i) => (
+                  <VoyageRow key={v.id} v={v} first={i === 0} />
+                ))}
               </div>
+            </div>
+          )}
+
+          {labLink && (
+            <div className="row gap6" style={{ marginTop: 12, fontSize: 12, color: 'var(--text-3)' }}>
+              <Icon name="flask" size={13} style={{ flexShrink: 0 }} />
+              <span>{tr('这里只看当前课题的任务；课题外的任务（建库、每日新论文等）在', 'Only this topic’s tasks are listed here. Tasks outside topics (library builds, daily papers, …) live in the')}</span>
+              <Link to="/lab?tab=tasks" style={{ color: 'var(--accent)', fontWeight: 600 }}>
+                {tr('实验室工作台', 'Lab Workbench')}
+              </Link>
             </div>
           )}
     </>
@@ -280,7 +306,7 @@ export function VoyagesPage() {
         title={tr('任务', 'Tasks')}
         sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
       />
-      <VoyagesList />
+      <VoyagesList showScopeSwitch />
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -389,7 +389,10 @@ export interface VoyageRead {
   cursor: number | null;
   budget: Record<string, unknown> | null;
   usage: Record<string, unknown> | null;
-  project_id: string;
+  /** 归属课题；课题外任务（独立文献库的建库/同步等）为 null */
+  project_id: string | null;
+  /** 归属文献库；课题任务为 null */
+  library_id: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Why

Tasks were only reachable from a **topic's** Tasks tab, but `VoyageRun.project_id` is nullable — a standalone library's ingest runs have no topic. They had no proper home (you had to flip a "all topics" switch *inside* some unrelated topic to glimpse them), and a user with no topics couldn't see them at all.

## What

**New `/lab` — Lab workbench**, two tabs:

- **Overview** — four stat cards (libraries, total papers, last-7-day daily papers, running tasks), a library card listing each library with owner, last sync, paper/concept counts and status, and a daily-feed card with today's count, the 7-day total and a mini distribution. All rows link through to the library or the feed.
- **Tasks** — every visible run, **grouped by origin**: one group per topic, one per library (the topic-less runs), plus *Other*. Rows reuse the existing task row component, so the look matches the topic task list.

**Topic Tasks tab** drops the current/all switch (it only shows that topic now) and gains a link to the lab workbench for topic-less runs.

**Entry point** in the topbar (flask icon), before the admin gear, visible to all signed-in users.

## Also

Fixes the `VoyageRead` TS type, which declared `project_id` as a required `string` and omitted `library_id` — both at odds with the backend schema (`uuid | None` for each).

Frontend only; no new endpoints. `tsc --noEmit` clean; `npm run build` passes.