### PR TITLE
feat(daily): fetch the PDF before compiling; move the lab entry to the sidebar

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -654,8 +654,8 @@ async def compile_entry_wiki(
 ) -> DailyFeedEntry:
     """通用模板编译单篇解读（全实验室共享一份），写进 entry；费用记个人。
 
-    论文已有 PDF（典型：收录后被后台补全过）时先抽图 + 标注重要图，
-    与库版重新编译同款逻辑，产出图文解读；无 PDF 则纯文字。
+    每日池论文建池时不下 PDF，直接编译只能拿摘要产出纯文字稿；故先尽力补下 PDF
+    （幂等，失败则降级），再抽图 + 标注重要图，与库版重新编译同款逻辑产出图文解读。
     """
     from pathlib import Path
 
@@ -672,6 +672,23 @@ async def compile_entry_wiki(
         raise CompileInProgressError(str(entry_id))
     _COMPILING.add(entry_id)
     try:
+        # 没 PDF 就先抓一次（顺带抽全文/分块）：图文解读的前提。best-effort——
+        # 无 arxiv_id / 下载失败时照常往下走，产出纯文字稿而不是整体失败。
+        if not paper.pdf_path:
+            from app.services.papers import (
+                PdfFetchFailedError,
+                PdfSourceUnsupportedError,
+                fetch_pdf,
+            )
+
+            try:
+                paper = await fetch_pdf(session, paper, user_id=user_id)
+            except (PdfSourceUnsupportedError, PdfFetchFailedError):
+                logger.info("daily compile: no PDF for paper %s, text-only", paper.id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — 抓取异常不阻断编译
+                logger.warning("daily compile: fetch_pdf failed for %s", paper.id, exc_info=True)
         if paper.pdf_path and Path(paper.pdf_path).exists():
             # 从未提取过，或上一轮一张重要图都没选出来 → 重提候选（对齐 recompile_paper）
             if paper.figures is None or not any(f.get("important") for f in paper.figures):

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -34,6 +34,7 @@ interface NavEntry {
 
 // 实验室级导航：跨课题的公共资产（P5c 起为共享方向文献库列表）
 const NAV_LAB: NavEntry[] = [
+  { to: '/lab', icon: 'flask', zh: '实验室工作台', en: 'Lab Workbench' },
   { to: '/libraries', icon: 'book', zh: '文献库', en: 'Libraries' },
   { to: '/daily', icon: 'heart', zh: '每日新论文', en: 'Daily Papers' },
 ];
@@ -90,7 +91,7 @@ function crumbFor(pathname: string): [string, string] {
     '/skills': ['Polaris', tr('技能', 'Skills')],
     '/settings': ['Polaris', tr('设置', 'Settings')],
     '/admin': ['Polaris', tr('管理', 'Manage')],
-    '/lab': ['Polaris', tr('实验室工作台', 'Lab Workbench')],
+    '/lab': [tr('实验室', 'Lab'), tr('实验室工作台', 'Lab Workbench')],
   };
   return table[p] ?? ['Polaris', '—'];
 }
@@ -591,16 +592,6 @@ export function AppShell() {
             <span>{tr('搜索论文 / 想法 / 实验…', 'Search papers / ideas / experiments…')}</span>
             <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>⌘K</span>
           </div>
-          {/* 实验室工作台入口（所有登录用户可见）：实验室资源概况 + 课题外任务 */}
-          <button
-            className="icon-btn"
-            onClick={() => navigate('/lab')}
-            title={tr('实验室工作台', 'Lab Workbench')}
-            aria-label={tr('实验室工作台', 'Lab Workbench')}
-            style={location.pathname === '/lab' ? { color: 'var(--accent)', background: 'var(--surface-2)' } : undefined}
-          >
-            <Icon name="flask" size={16} />
-          </button>
           {/* 管理员设置入口（仅管理员可见） */}
           {isAdmin(me) && (
             <button

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -164,12 +164,6 @@ function LibrariesCard() {
   );
 }
 
-/** 本地时区的 YYYY-MM-DD（每日新论文按日期字符串分桶）。 */
-function todayKey(): string {
-  const d = new Date();
-  const p = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
 
 /** 每日新论文汇总卡：今日新增 / 近 7 天合计 + 最近 7 天迷你分布（单色柱，标签用文本色）。 */
 function DailyCard() {
@@ -182,8 +176,9 @@ function DailyCard() {
   });
 
   const days = useMemo(() => [...(data ?? [])].sort((a, b) => a.date.localeCompare(b.date)).slice(-7), [data]);
-  const today = todayKey();
-  const todayCount = days.find((d) => d.date === today)?.count ?? 0;
+  // 「最新一批」而非「今天」：arxiv 按 UTC 出批次，用本地日期匹配会在跨时区/周末显示 0
+  const today = days.length > 0 ? days[days.length - 1]!.date : '';
+  const todayCount = days.length > 0 ? days[days.length - 1]!.count : 0;
   const weekTotal = days.reduce((acc, d) => acc + d.count, 0);
   const max = Math.max(1, ...days.map((d) => d.count));
 
@@ -229,7 +224,7 @@ function DailyCard() {
           <div className="row gap20" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
             <div>
               <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>{todayCount}</div>
-              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('今天新增', 'New today')}</div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('最新一批', 'Latest batch')}</div>
             </div>
             <div>
               <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>{weekTotal}</div>


### PR DESCRIPTION
## 1. Daily compile now produces an illustrated wiki

Daily papers enter the pool as lightweight rows — **no PDF** (the sync handles hundreds a day, so the heavy work is deferred). But the figure-extraction branch in `compile_entry_wiki` is guarded by `paper.pdf_path`, so compiling a freshly-synced paper skipped figures entirely **and** had only the abstract to work with: the result was always text-only.

Now compile fetches the PDF first (idempotent — reuses one that's already there, and also extracts full text/chunks along the way), so a single click yields the illustrated version. It stays best-effort: a paper with no arxiv id, or a failed download, still compiles — just without figures — instead of failing outright.

## 2. Lab workbench moves to the sidebar

Removed the topbar button; `/lab` now sits in the sidebar's **Lab** group, above Libraries and Daily papers.

## 3. Overview counts the latest batch, not "today"

arxiv announces in UTC batches, so matching the browser's local date showed **0** on weekends and across timezones. The card now reports the most recent day present in the data (and highlights that day in the mini distribution).

`tsc --noEmit` clean; daily tests 7 passed.