### PR TITLE
feat(library): restore read parity for the regular-user library view

### DIFF
--- a/src/frontend/src/components/ui/FigureGallery.tsx
+++ b/src/frontend/src/components/ui/FigureGallery.tsx
@@ -504,11 +504,17 @@ export function FiguresSection({
   paper,
   style,
   defaultCollapsed = false,
+  readOnly = false,
 }: {
   paper: PaperDetail;
   style?: CSSProperties;
   /** 正文已内嵌图片时默认折叠画廊，避免重复视觉 */
   defaultCollapsed?: boolean;
+  /**
+   * 只读模式：不渲染「提取图片 / 重新提取配图」按钮，只展示已有的图。
+   * 给普通用户的只读文献库用——提取图片端点只对管理员开放，普通用户点必然 403。
+   */
+  readOnly?: boolean;
 }) {
   const queryClient = useQueryClient();
   const figures = usePaperFigures(paper);
@@ -554,9 +560,9 @@ export function FiguresSection({
     },
   });
 
-  // 没图：有 PDF 时给一个小按钮按需提取；没 PDF 就什么都不显示
+  // 没图：有 PDF 时给一个小按钮按需提取；没 PDF（或只读）就什么都不显示
   if (figures.length === 0) {
-    if (!paper.pdf_available) return null;
+    if (!paper.pdf_available || readOnly) return null;
     return (
       <div style={{ marginTop: 16, ...style }}>
         <button
@@ -596,7 +602,7 @@ export function FiguresSection({
             {expanded ? tr('收起', 'Collapse') : tr(`展开全部图片（${figures.length} 张）`, `Show all figures (${figures.length})`)}
           </button>
         )}
-        {paper.pdf_available && (
+        {paper.pdf_available && !readOnly && (
           <button
             className="btn btn-ghost sm"
             style={{ marginLeft: 'auto' }}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1,31 +1,53 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, memo, useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
+import {
+  FigureEmbed,
+  FiguresSection,
+  hasEmbeddedFigures,
+  usePaperFigures,
+} from '../../components/ui/FigureGallery';
+import { CompileBadge } from '../../components/ui/CompileBadge';
+import { RelevanceBar } from '../../components/ui/RelevanceBar';
+import { ScoreRing } from '../../components/ui/ScoreRing';
+import { PaperStatusPill } from '../../components/ui/StatusPill';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
-import { api, type PaperRead, type PaperSort, type ReadingStatus } from '../../lib/api';
+import { fmtTime } from '../../lib/format';
+import { clickable } from '../../lib/a11y';
+import {
+  api,
+  type MyMeta,
+  type PaperDetail,
+  type PaperRead,
+  type PaperSort,
+  type PaperStatusFilter,
+  type ReadingStatus,
+} from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { ConceptsTab } from '../wiki/ConceptsTab';
 import { LibraryChatTab } from '../wiki/LibraryChatTab';
 import { NotesTab } from '../wiki/NotesTab';
 import { GovernanceTab } from '../wiki/GovernanceTab';
 import { IngestTab } from '../wiki/IngestTab';
+import { PaperReader } from '../wiki/PaperReader';
 import {
   AdvancedPanel,
   AdvancedToggle,
   FilterInput,
+  MetaItem,
   SearchInput,
   SemanticSwitch,
   YearRangeField,
+  categoryMeta,
   parseYear,
   saveBlob,
   useDebounced,
 } from '../wiki/shared';
-import { READING_STATUS, readerFrom } from '../reading/shared';
+import { READING_STATUS, ReadingDot, readerFrom } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
@@ -41,14 +63,29 @@ type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' |
 
 const PAGE_SIZE = 20;
 
-function authorsLine(p: PaperRead): string {
-  return (p.authors ?? [])
-    .map((a) => (typeof a === 'string' ? a : a.name))
-    .filter(Boolean)
-    .join(', ');
+/** 概念 / 机构 chips 默认最多展示数，超出折叠（与文献工作台一致） */
+const CONCEPT_CHIP_LIMIT = 12;
+const AFFIL_CHIP_LIMIT = 6;
+
+/** 列表视图筛选（口径同文献工作台：全部 = 已纳入的文献） */
+type ViewFilter = 'all' | 'compiled' | 'starred';
+
+// 模块级常量存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
+const VIEW_FILTERS: { v: ViewFilter; zh: string; en: string; hintZh: string; hintEn: string }[] = [
+  { v: 'all', zh: '全部', en: 'All', hintZh: '已纳入知识库的全部文献', hintEn: 'Every paper included in the library' },
+  { v: 'compiled', zh: '已编译', en: 'Compiled', hintZh: 'AI 已精读编译出介绍', hintEn: 'Papers the AI has compiled an intro for' },
+  { v: 'starred', zh: '已星标', en: 'Starred', hintZh: '我加了星标的文献', hintEn: 'Papers I starred' },
+];
+
+function viewQuery(view: ViewFilter): { status: PaperStatusFilter; starred?: boolean } {
+  if (view === 'compiled') return { status: 'compiled_any' };
+  if (view === 'starred') return { status: 'library', starred: true };
+  return { status: 'library' };
 }
 
-function PaperRow({
+/* memo：父组件（大量筛选/选中 state）任一变更都会触发全列表重渲染。
+   忽略函数 props 的比较是安全的：两个 handler 只捕获稳定引用与 p.id。 */
+const PaperRow = memo(function PaperRow({
   p,
   active,
   checked,
@@ -63,11 +100,12 @@ function PaperRow({
   onClick: () => void;
   onToggleCheck: () => void;
 }) {
+  const tags = p.tags ?? [];
   return (
     <div
       onClick={onClick}
       style={{
-        padding: '11px 16px',
+        padding: '12px 16px',
         cursor: 'pointer',
         borderBottom: '0.5px solid var(--border)',
         background: active ? 'var(--accent-soft)' : 'transparent',
@@ -75,7 +113,7 @@ function PaperRow({
         transition: 'background 0.12s',
       }}
     >
-      <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+      <div className="row gap8" style={{ marginBottom: 5 }}>
         {/* 占位常驻：切换多选时行内容不左右跳 */}
         <input
           type="checkbox"
@@ -86,66 +124,137 @@ function PaperRow({
           style={{
             width: 13,
             height: 13,
-            margin: '2px 0 0',
+            margin: 0,
             flexShrink: 0,
             accentColor: 'var(--accent)',
             cursor: 'pointer',
             visibility: selectMode ? 'visible' : 'hidden',
           }}
         />
-        <div style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
-        <AddToButton paperId={p.id} />
-      </div>
-      <div className="row gap8" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-3)' }}>
-        {p.has_wiki && (
-          <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
-            <Icon name="sparkle" size={10} />
-            wiki
+        {p.starred && <Icon name="starFill" size={11} style={{ color: 'var(--warn-tx)', flexShrink: 0 }} />}
+        <span className="mono" style={{ fontSize: 10.5, color: active ? 'var(--accent-text)' : 'var(--text-3)' }}>
+          {p.arxiv_id ?? p.venue ?? '—'}
+        </span>
+        {p.year !== null && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+            {p.year}
           </span>
         )}
-        <span
-          style={{ flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
-          title={authorsLine(p)}
-        >
-          {authorsLine(p)}
+        {p.has_wiki && <Icon name="sparkle" size={11} style={{ color: 'var(--accent)' }} />}
+        <span style={{ marginLeft: 'auto' }}>
+          <RelevanceBar value={p.relevance_score} />
         </span>
-        {p.year !== null && <span className="mono" style={{ flexShrink: 0 }}>{p.year}</span>}
       </div>
-      {p.tldr && (
-        <div
-          style={{
-            fontSize: 11.5,
-            color: 'var(--text-3)',
-            marginTop: 3,
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {p.tldr}
+      <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>
+          {p.title}
         </div>
-      )}
+        <AddToButton paperId={p.id} />
+      </div>
+      <div className="row gap8" style={{ marginTop: 6 }}>
+        <PaperStatusPill status={p.status} sm />
+        <ReadingDot status={p.reading_status} />
+        {tags.slice(0, 2).map((t) => (
+          <span
+            key={t}
+            className="tag"
+            style={{ fontSize: 10, height: 17, padding: '0 6px', maxWidth: 90, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', lineHeight: '17px' }}
+          >
+            {t}
+          </span>
+        ))}
+        {tags.length > 2 && (
+          <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+            +{tags.length - 2}
+          </span>
+        )}
+        {(p.note_count ?? 0) > 0 && (
+          <span
+            className="row"
+            style={{ gap: 3, fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}
+            title={tr(`${p.note_count} 条笔记`, `${p.note_count} notes`)}
+          >
+            <Icon name="pen" size={10} />
+            {p.note_count}
+          </span>
+        )}
+        {p.tldr && (
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 11.5,
+              color: 'var(--text-3)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {p.tldr}
+          </span>
+        )}
+      </div>
     </div>
   );
-}
+}, (prev, next) =>
+  prev.p === next.p && prev.active === next.active && prev.checked === next.checked && prev.selectMode === next.selectMode,
+);
 
 function PaperDetailPane({
   libraryId,
   paperId,
   onWikiLink,
+  onOpenConcept,
+  onFilterAuthor,
+  onFilterAffiliation,
 }: {
   libraryId: string;
   paperId: string;
   onWikiLink: WikiLinkHandler;
+  /** 点概念 chip → 跳概念库 */
+  onOpenConcept: (id: string) => void;
+  /** 点作者名 → 列表按该作者过滤 */
+  onFilterAuthor: (name: string) => void;
+  /** 点机构 chip → 列表按该机构过滤 */
+  onFilterAffiliation: (name: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
+  const queryClient = useQueryClient();
+  const [abstractOpen, setAbstractOpen] = useState(false);
+  const [conceptsOpen, setConceptsOpen] = useState(false);
+  const [affilsOpen, setAffilsOpen] = useState(false);
+  const [readerOpen, setReaderOpen] = useState(false);
+  const [readerPrint, setReaderPrint] = useState(false);
+
   // 库作用域取详情：锁定本库那份成员行，相关度/状态/wiki 不会串到该论文在别的库的副本
   const { data: paper, isLoading, isError } = useQuery({
     queryKey: ['paper', libraryId, paperId],
     queryFn: () => api.getLibraryPaper(libraryId, paperId),
     retry: false,
   });
+
+  // 星标 / 阅读状态：个人维度，只读浏览也能改（PUT /papers/{id}/my-meta 对全员开放）
+  const metaMutation = useMutation({
+    mutationFn: (input: Partial<MyMeta>) => api.putMyMeta(paperId, input),
+    onSuccess: (meta) => {
+      queryClient.setQueryData<PaperDetail>(['paper', libraryId, paperId], (old) =>
+        old ? { ...old, starred: meta.starred, reading_status: meta.reading_status } : old,
+      );
+      void queryClient.invalidateQueries({ queryKey: ['lib-papers', libraryId] });
+      void queryClient.invalidateQueries({ queryKey: ['lib-search', libraryId] });
+    },
+    onError: (e) =>
+      toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  // 换论文时收起本地开合状态（面板不随选中项重挂载，得自己收）
+  useEffect(() => {
+    setAbstractOpen(false);
+    setConceptsOpen(false);
+    setAffilsOpen(false);
+    setReaderOpen(false);
+  }, [paperId]);
 
   // 正文 ![[fig:N]] 嵌入图（与文献追踪同款渲染；图片端点对全员开放）
   const figures = usePaperFigures(paper);
@@ -169,55 +278,338 @@ function PaperDetailPane({
     );
   }
 
-  const arxivUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : paper.url;
+  const arxivUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : null;
+  const relevance = paper.relevance_score;
+  const starred = paper.starred ?? false;
+  const readingStatus: ReadingStatus = paper.reading_status ?? 'unread';
 
   return (
     <div className="scroll fadeup" key={paper.id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
-      <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
-        {paper.venue && (
-          <span className="pill sm" style={{ background: 'var(--surface-3)' }}>{paper.venue}</span>
+      {/* —— 元数据头 —— */}
+      <div className="row" style={{ alignItems: 'flex-start', gap: 20 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
+            <PaperStatusPill status={paper.status} sm />
+            {paper.venue && (
+              <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
+                {paper.venue}
+              </span>
+            )}
+            {paper.has_wiki && (
+              <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+                <Icon name="sparkle" size={11} />
+                wiki
+              </span>
+            )}
+            {paper.pdf_available && (
+              <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+                <Icon name="file" size={11} />
+                PDF
+              </span>
+            )}
+            {(paper.note_count ?? 0) > 0 && (
+              <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
+                <Icon name="pen" size={10} />
+                {tr(`${paper.note_count} 条笔记`, `${paper.note_count} notes`)}
+              </span>
+            )}
+          </div>
+          <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
+            {paper.title}
+          </h1>
+          {paper.authors.length > 0 && (
+            <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
+              {paper.authors.map((a, i) => (
+                <span key={`${a.name}-${i}`}>
+                  {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
+                  <span
+                    className="author-link"
+                    title={tr(`只看 ${a.name} 的论文`, `Show only ${a.name}'s papers`)}
+                    {...clickable(() => onFilterAuthor(a.name))}
+                  >
+                    {a.name}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
+          {(paper.affiliations?.length ?? 0) > 0 && (
+            <div className="row gap6 wrap" style={{ marginTop: 8 }}>
+              <Icon name="pin" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+              {(affilsOpen ? paper.affiliations! : paper.affiliations!.slice(0, AFFIL_CHIP_LIMIT)).map((name) => (
+                <span
+                  key={name}
+                  className="chip"
+                  style={{ fontSize: 11 }}
+                  title={tr(`只看 ${name} 的论文`, `Show only papers from ${name}`)}
+                  {...clickable(() => onFilterAffiliation(name))}
+                >
+                  {name}
+                </span>
+              ))}
+              {paper.affiliations!.length > AFFIL_CHIP_LIMIT && (
+                <span className="chip" style={{ fontSize: 11 }} onClick={() => setAffilsOpen((o) => !o)}>
+                  {affilsOpen ? tr('收起', 'Collapse') : `+${paper.affiliations!.length - AFFIL_CHIP_LIMIT}`}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        {relevance !== null && <ScoreRing value={relevance} max={1} size={56} label={tr('相关度', 'Relevance')} />}
+      </div>
+
+      {/* —— 操作（只读视角：阅读 / 阅览 / 原文链接） —— */}
+      <div className="row gap8 wrap" style={{ marginTop: 14 }}>
+        <button
+          className="btn btn-primary sm"
+          onClick={() => navigate(`/papers/${paper.id}/read`, { state: readerFrom(location, 'wiki') })}
+        >
+          <Icon name="file" size={13} />
+          {tr('阅读原文', 'Read original')}
+        </button>
+        {paper.has_wiki && paper.wiki_content && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('全屏阅览图文介绍，可导出 PDF', 'Full-screen reading view, exportable to PDF')}
+            onClick={() => {
+              setReaderPrint(false);
+              setReaderOpen(true);
+            }}
+          >
+            <Icon name="book" size={13} />
+            {tr('阅览模式', 'Reading mode')}
+          </button>
         )}
-        {paper.year !== null && <span className="pill sm" style={{ background: 'var(--surface-3)' }}>{paper.year}</span>}
         {arxivUrl && (
-          <a className="pill sm" href={arxivUrl} target="_blank" rel="noreferrer" style={{ background: 'var(--surface-3)' }}>
-            <Icon name="link" size={11} />
-            {paper.arxiv_id ? `arXiv:${paper.arxiv_id}` : tr('原文链接', 'Source')}
+          <a
+            className="btn btn-ghost sm"
+            href={arxivUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ textDecoration: 'none' }}
+          >
+            <Icon name="link" size={13} />
+            arXiv
+          </a>
+        )}
+        {paper.url && !arxivUrl && (
+          <a
+            className="btn btn-ghost sm"
+            href={paper.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ textDecoration: 'none' }}
+          >
+            <Icon name="link" size={13} />
+            {tr('原文链接', 'Source link')}
           </a>
         )}
       </div>
-      <h1 style={{ fontSize: 21, fontWeight: 680, lineHeight: 1.3, margin: '2px 0 6px', letterSpacing: '-0.01em' }}>
-        {paper.title}
-      </h1>
-      {authorsLine(paper) && (
-        <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 14 }}>{authorsLine(paper)}</div>
-      )}
-      <div className="row gap8" style={{ marginBottom: 18 }}>
-        <button className="btn btn-primary sm" onClick={() => navigate(`/papers/${paper.id}/read`, { state: readerFrom(location, 'wiki') })}>
-          <Icon name="book" size={13} />
-          {tr('打开阅读页', 'Open reading page')}
+
+      {/* —— 个人状态：星标 + 阅读状态（只读库里也是我自己的记录） —— */}
+      <div className="row gap12 wrap" style={{ marginTop: 12 }}>
+        <button
+          className="btn btn-ghost sm"
+          disabled={metaMutation.isPending}
+          onClick={() => metaMutation.mutate({ starred: !starred })}
+          style={starred ? { color: 'var(--warn-tx)' } : undefined}
+        >
+          <Icon name={starred ? 'starFill' : 'star'} size={13} />
+          {starred ? tr('已星标', 'Starred') : tr('加星标', 'Star')}
         </button>
-        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
-          {tr('原文 PDF、配图、笔记和收藏都在阅读页里', 'PDF, figures, notes and saving live on the reading page')}
+        <span className="row gap8">
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+            {tr('阅读状态', 'Reading status')}
+          </span>
+          <Segmented<ReadingStatus>
+            options={READING_STATUS.map((m) => ({ v: m.v, label: tr(m.label, m.en) }))}
+            value={readingStatus}
+            onChange={(v) => metaMutation.mutate({ reading_status: v })}
+          />
         </span>
       </div>
 
-      {paper.wiki_content ? (
-        <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
-      ) : (
-        <>
-          {paper.abstract && (
-            <div className="card card-pad" style={{ background: 'var(--surface-2)' }}>
-              <div className="row gap8" style={{ marginBottom: 8 }}>
-                <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
-                <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
-              </div>
-              <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
+      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {(paper.tags?.length ?? 0) > 0 && (
+        <div className="row gap6 wrap" style={{ marginTop: 14 }}>
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
+            {tr('标签', 'Tags')}
+          </span>
+          {paper.tags!.map((t) => (
+            <span key={t} className="tag">
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* —— frontmatter 风格元数据卡 —— */}
+      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+        <MetaItem label="arxiv_id">
+          {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="doi">{paper.doi ? <span className="mono">{paper.doi}</span> : <span className="muted">—</span>}</MetaItem>
+        <MetaItem label="published">
+          {paper.published_at ? <span className="mono">{paper.published_at.slice(0, 10)}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="relevance">
+          {relevance !== null ? (
+            <RelevanceBar value={relevance} width={140} />
+          ) : (
+            <span className="muted">{tr('未打分', 'not scored')}</span>
+          )}
+        </MetaItem>
+        <MetaItem label={tr('入库时间', 'added at')}>
+          <span className="mono">{fmtTime(paper.created_at)}</span>
+        </MetaItem>
+        <MetaItem label={tr('编译时间', 'compiled at')}>
+          {paper.compiled_at ? (
+            <span className="mono">{fmtTime(paper.compiled_at)}</span>
+          ) : (
+            <span className="muted">{tr('未编译', 'not compiled')}</span>
+          )}
+        </MetaItem>
+      </div>
+
+      {/* —— 概念 chips（过多时折叠） —— */}
+      {paper.concepts.length > 0 && (
+        <div className="row gap8 wrap" style={{ marginTop: 16 }}>
+          {(conceptsOpen ? paper.concepts : paper.concepts.slice(0, CONCEPT_CHIP_LIMIT)).map((c) => {
+            const meta = categoryMeta(c.category);
+            return (
+              <span
+                key={c.id}
+                className="wikilink"
+                style={{ background: meta.bg, color: meta.c, height: 24 }}
+                onClick={() => onOpenConcept(c.id)}
+              >
+                {c.name}
+                <span style={{ opacity: 0.6, marginLeft: 5, fontSize: '0.85em' }}>{tr(meta.zh, meta.en)}</span>
+              </span>
+            );
+          })}
+          {paper.concepts.length > CONCEPT_CHIP_LIMIT && (
+            <span className="chip" style={{ fontSize: 11 }} onClick={() => setConceptsOpen((o) => !o)}>
+              {conceptsOpen
+                ? tr('收起', 'Collapse')
+                : tr(`+${paper.concepts.length - CONCEPT_CHIP_LIMIT} 个概念`, `+${paper.concepts.length - CONCEPT_CHIP_LIMIT} concepts`)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* —— 摘要（折叠） —— */}
+      {paper.abstract && (
+        <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
+          <div
+            className="row"
+            onClick={() => setAbstractOpen((o) => !o)}
+            style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+          >
+            <span style={{ fontSize: 12.5, fontWeight: 650 }}>{tr('摘要', 'Abstract')}</span>
+            <Icon
+              name="chevDown"
+              size={14}
+              style={{ color: 'var(--text-3)', transform: abstractOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+            />
+          </div>
+          {abstractOpen && (
+            <div style={{ padding: '0 16px 14px', fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>
+              {paper.abstract}
             </div>
           )}
+        </div>
+      )}
+
+      {/* —— TL;DR —— */}
+      {paper.tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {paper.tldr}
+        </div>
+      )}
+
+      {/* —— 重要图片画廊（只读：不给提取/重新提取入口，那是管理员操作） —— */}
+      <FiguresSection paper={paper} readOnly defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)} />
+
+      {/* —— Wiki 正文（markdown，含 ![[fig:N]] 嵌入图） —— */}
+      <div style={{ marginTop: 22 }}>
+        {paper.wiki_content ? (
+          <>
+            <div
+              className="row"
+              style={{
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                paddingBottom: 10,
+                marginBottom: 16,
+                borderBottom: '0.5px solid var(--border)',
+              }}
+            >
+              <div className="row gap8">
+                <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+                  {tr('AI 图文介绍', 'AI intro')}
+                </span>
+                <CompileBadge model={paper.compiled_model} at={paper.compiled_at} />
+              </div>
+              <div className="row gap6">
+                <button
+                  className="btn btn-soft sm"
+                  title={tr('全屏专注阅读', 'Full-screen focused reading')}
+                  onClick={() => {
+                    setReaderPrint(false);
+                    setReaderOpen(true);
+                  }}
+                >
+                  <Icon name="book" size={13} />
+                  {tr('阅览模式', 'Reading mode')}
+                </button>
+                <button
+                  className="btn btn-ghost sm"
+                  title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
+                  onClick={() => {
+                    setReaderPrint(true);
+                    setReaderOpen(true);
+                  }}
+                >
+                  <Icon name="download" size={13} />
+                  {tr('导出 PDF', 'Export PDF')}
+                </button>
+              </div>
+            </div>
+            <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
+          </>
+        ) : (
           <div className="empty" style={{ padding: 20 }}>
-            {tr('这篇还没有中文解读。', 'No wiki for this paper yet.')}
+            {tr('这篇还没有 AI 图文介绍。', 'No AI intro for this paper yet.')}
           </div>
-        </>
+        )}
+      </div>
+
+      {readerOpen && (
+        <PaperReader
+          paper={paper}
+          renderFigure={renderFigure}
+          onWikiLink={onWikiLink}
+          onFilterAuthor={(name) => {
+            setReaderOpen(false);
+            onFilterAuthor(name);
+          }}
+          autoPrint={readerPrint}
+          onClose={() => setReaderOpen(false)}
+        />
       )}
     </div>
   );
@@ -228,11 +620,13 @@ function PapersPane({
   selectedId,
   onSelect,
   onWikiLink,
+  onOpenConcept,
 }: {
   libraryId: string;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onWikiLink: WikiLinkHandler;
+  onOpenConcept: (id: string) => void;
 }) {
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
@@ -240,6 +634,9 @@ function PapersPane({
   const [semanticOn, setSemanticOn] = useState(false);
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [page, setPage] = useState(1);
+  // 视图筛选（全部 / 已编译 / 已星标）+ 标签过滤，口径同文献工作台
+  const [view, setView] = useState<ViewFilter>('all');
+  const [tagFilter, setTagFilter] = useState('');
 
   // 多选（批量导出引用）：默认关闭，底部「多选」按钮开启后行首出现复选框（只读浏览不加删除）
   const [selectMode, setSelectMode] = useState(false);
@@ -247,7 +644,7 @@ function PapersPane({
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [libraryId, q]);
+  }, [libraryId, q, view, tagFilter]);
 
   const bulkExportMutation = useMutation({
     mutationFn: () => api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] }),
@@ -275,17 +672,53 @@ function PapersPane({
 
   useEffect(
     () => setPage(1),
-    [q, sort, semanticOn, author, affiliation, yearFrom, yearTo, advReading, advStarred],
+    [q, sort, semanticOn, view, tagFilter, author, affiliation, yearFrom, yearTo, advReading, advStarred],
   );
+
+  // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板
+  const applyAdvFilter = useCallback(
+    (patch: { author?: string; affiliation?: string }) => {
+      setSemanticOn(false);
+      setQInput('');
+      setAdvAuthor(patch.author ?? '');
+      setAdvAffiliation(patch.affiliation ?? '');
+      setAdvYearFrom('');
+      setAdvYearTo('');
+      setAdvReading('');
+      setAdvStarred(false);
+      setAdvOpen(true);
+      onSelect('');
+      if (patch.author) {
+        toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
+      } else if (patch.affiliation) {
+        toast(tr(`已筛选机构：${patch.affiliation}`, `Filtered by affiliation: ${patch.affiliation}`), 'info');
+      }
+    },
+    [onSelect],
+  );
+  const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
+  const filterByAffiliation = useCallback((name: string) => applyAdvFilter({ affiliation: name }), [applyAdvFilter]);
+
+  // 库内标签（过滤下拉用；接口未就绪时静默降级）
+  const tagsQuery = useQuery({
+    queryKey: ['lib-tags', libraryId],
+    queryFn: () => api.listLibraryTags(libraryId),
+    retry: false,
+  });
+  const libraryTags = tagsQuery.data ?? [];
 
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
-      'lib-papers', libraryId, q, sort, page,
+      'lib-papers', libraryId, view, tagFilter, q, sort, page,
       author, affiliation, yearFrom, yearTo, advReading, advStarred,
     ],
-    queryFn: () =>
-      api.listLibraryPapersFull(libraryId, {
+    queryFn: () => {
+      const vq = viewQuery(view);
+      return api.listLibraryPapersFull(libraryId, {
+        status: vq.status,
+        starred: vq.starred || advStarred || undefined,
+        tag: tagFilter || undefined,
         q: q || undefined,
         sort,
         page,
@@ -295,8 +728,8 @@ function PapersPane({
         published_from: yearFrom ? `${yearFrom}-01-01T00:00:00Z` : undefined,
         published_to: yearTo ? `${yearTo}-12-31T23:59:59Z` : undefined,
         reading_status: advReading || undefined,
-        starred: advStarred || undefined,
-      }),
+      });
+    },
     enabled: !semantic,
     retry: false,
   });
@@ -318,6 +751,9 @@ function PapersPane({
   useEffect(() => {
     if (!selectedId && firstId) onSelect(firstId);
   }, [selectedId, firstId, onSelect]);
+
+  const hasFilter = !!q || advActive || view !== 'all' || !!tagFilter;
+  const filterDisabled = semantic ? { opacity: 0.45, pointerEvents: 'none' as const } : undefined;
 
   return (
     <div className="split">
@@ -407,10 +843,42 @@ function PapersPane({
               </AdvancedPanel>
             </div>
           )}
+          {/* 视图筛选：全部 / 已编译 / 已星标（语义检索时置灰） */}
+          <div className="row gap6 wrap" style={{ marginTop: 10, ...filterDisabled }}>
+            {VIEW_FILTERS.map((f) => (
+              <span
+                key={f.v}
+                className={`chip${view === f.v ? ' on' : ''}`}
+                title={tr(f.hintZh, f.hintEn)}
+                onClick={() => setView(f.v)}
+              >
+                {tr(f.zh, f.en)}
+              </span>
+            ))}
+          </div>
+          {/* 标签过滤（库作用域标签） */}
+          {libraryTags.length > 0 && (
+            <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
+              <select
+                className="input"
+                style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
+                value={tagFilter}
+                onChange={(e) => setTagFilter(e.target.value)}
+                title={tr('按标签过滤', 'Filter by tag')}
+              >
+                <option value="">{tr('全部标签', 'All tags')}</option>
+                {libraryTags.map((t) => (
+                  <option key={t.id} value={t.name}>
+                    {t.name}（{t.paper_count}）
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           {/* 排序（语义检索按相关度返回，排序无效 → 置灰） */}
           <div
             className="row gap6 wrap"
-            style={{ marginTop: 10, justifyContent: 'flex-end', ...(semantic ? { opacity: 0.45, pointerEvents: 'none' as const } : {}) }}
+            style={{ marginTop: 10, justifyContent: 'flex-end', ...filterDisabled }}
           >
             <span
               className={`chip${sort === 'relevance' ? ' on' : ''}`}
@@ -441,8 +909,8 @@ function PapersPane({
             <EmptyState
               compact
               icon="book"
-              title={q || advActive ? tr('没有匹配的论文', 'No matching papers') : tr('这个库还是空的', 'This library is empty')}
-              desc={q || advActive ? tr('换个关键词或调整高级条件试试。', 'Try a different keyword or adjust the filters.') : undefined}
+              title={hasFilter ? tr('没有匹配的论文', 'No matching papers') : tr('这个库还是空的', 'This library is empty')}
+              desc={hasFilter ? tr('换个关键词或调整筛选条件试试。', 'Try a different keyword or adjust the filters.') : undefined}
             />
           ) : (
             items.map((p) => (
@@ -515,6 +983,9 @@ function PapersPane({
             libraryId={libraryId}
             paperId={selectedId}
             onWikiLink={onWikiLink}
+            onOpenConcept={onOpenConcept}
+            onFilterAuthor={filterByAuthor}
+            onFilterAffiliation={filterByAffiliation}
           />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
@@ -601,12 +1072,15 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
     setPendingConceptName(null);
   }, [pendingConceptName, resolveQuery.data, resolveQuery.isError]);
 
+  // 论文库计数口径 = 库内（相关性达标）；旧后端无 library 字段时退回 total
+  const paperTotal = ingestQuery.data?.paper_counts?.library ?? ingestQuery.data?.paper_counts?.total;
+
   return (
     <>
       <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<BrowseTab>
           options={[
-            { v: 'papers', label: tr('论文库', 'Papers') },
+            { v: 'papers', label: `${tr('论文库', 'Papers')}${paperTotal !== undefined ? ` · ${paperTotal}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
@@ -644,6 +1118,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
             selectedId={paperId}
             onSelect={setPaperId}
             onWikiLink={onWikiLink}
+            onOpenConcept={goConcept}
           />
         ) : tab === 'concepts' ? (
           <ConceptsTab

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -31,7 +31,7 @@ import {
 import { tr } from '../../lib/i18n';
 import { usePendingByPaper } from '../../lib/pending';
 import { clickable } from '../../lib/a11y';
-import { categoryMeta, saveBlob, SearchInput, useDebounced } from './shared';
+import { categoryMeta, MetaItem, saveBlob, SearchInput, useDebounced } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
@@ -896,19 +896,6 @@ function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) 
 
 /** 概念 chips 默认最多展示数，超出折叠 */
 const CONCEPT_CHIP_LIMIT = 12;
-
-function MetaItem({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="row" style={{ gap: 12, padding: '4px 0', alignItems: 'flex-start' }}>
-      <span className="mono" style={{ fontSize: 11, color: 'var(--accent-text)', width: 88, flexShrink: 0 }}>
-        {label}
-      </span>
-      <span style={{ fontSize: 12.5, color: 'var(--text-2)', flex: 1, minWidth: 0, overflowWrap: 'break-word' }}>
-        {children}
-      </span>
-    </div>
-  );
-}
 
 /** 机构 chips 默认最多展示数，超出折叠 */
 const AFFIL_CHIP_LIMIT = 6;

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -44,6 +44,20 @@ export function Section({ title, children }: { title: ReactNode; children: React
   );
 }
 
+/** frontmatter 风格元数据行（论文详情的 arxiv_id / doi / published… 卡片用）。 */
+export function MetaItem({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="row" style={{ gap: 12, padding: '4px 0', alignItems: 'flex-start' }}>
+      <span className="mono" style={{ fontSize: 11, color: 'var(--accent-text)', width: 88, flexShrink: 0 }}>
+        {label}
+      </span>
+      <span style={{ fontSize: 12.5, color: 'var(--text-2)', flex: 1, minWidth: 0, overflowWrap: 'break-word' }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
 /** 触发浏览器下载一个 blob（导出 zip / .bib / .json 用）。 */
 export function saveBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Why

A regular user's library view (`LibraryBrowse`) showed far less than the manager view (`PapersTab`) — compile status, relevance, reading state, star, tags, concepts, figures and reading mode were all missing — **even though the backend already returned every one of those fields in the same responses**, and already allows personal-dimension writes for any viewer. The gap was purely frontend.

## What

**List rows** now show: star, arxiv/venue, **relevance bar**, **compile status**, **reading dot**, tags (first 2 + `+N`) and note count — matching `PapersTab`.

**Detail pane** gains: status / PDF / notes pills, the **relevance ring**, clickable authors and **affiliations** (wired to the existing advanced filters), the metadata card (arxiv / doi / published / relevance / added / compiled), **concept chips** (jump to the concepts tab), a persistent abstract, the TL;DR, the **figure gallery**, the compile badge, and **reading mode + PDF export**.

**Personal actions**: star and reading status are editable here — `PUT /papers/{id}/my-meta` is open to any viewer — which also closes the loop on the "starred only" and reading-status filters that could previously *filter* by state you couldn't see or change.

**List tools**: view chips (all / compiled / starred), tag filter, and the paper count on the tab.

`FiguresSection` takes a `readOnly` flag so the extract / re-extract buttons stay hidden — that endpoint became managers-only in #126.

## Not exposed

Delete, batch delete, trash, recompile, tag editing, include/exclude, manual add and the ingest forms remain manager-only, as before.

`tsc --noEmit` clean; `npm run build` passes.