### PR TITLE
feat(library): reading mode for a personal wiki; drop the duplicate note pill

### DIFF
--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -464,12 +464,7 @@ function PaperDetailPane({
                 PDF
               </span>
             )}
-            {(paper.note_count ?? 0) > 0 && (
-              <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
-                <Icon name="pen" size={10} />
-                {tr(`${paper.note_count} 条笔记`, `${paper.note_count} notes`)}
-              </span>
-            )}
+            {/* 笔记数不在这里重复：下方「我的笔记」区标题已带计数 */}
           </div>
           <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
             {paper.title}
@@ -776,6 +771,30 @@ function PaperDetailPane({
               >
                 {tr('个人版', 'Personal')}
               </span>
+              <div className="row gap6" style={{ marginLeft: 'auto' }}>
+                <button
+                  className="btn btn-soft sm"
+                  title={tr('全屏专注阅读', 'Full-screen focused reading')}
+                  onClick={() => {
+                    setReaderPrint(false);
+                    setReaderOpen(true);
+                  }}
+                >
+                  <Icon name="book" size={13} />
+                  {tr('阅览模式', 'Reading mode')}
+                </button>
+                <button
+                  className="btn btn-ghost sm"
+                  title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
+                  onClick={() => {
+                    setReaderPrint(true);
+                    setReaderOpen(true);
+                  }}
+                >
+                  <Icon name="download" size={13} />
+                  {tr('导出 PDF', 'Export PDF')}
+                </button>
+              </div>
             </div>
             <Markdown source={personalWiki} onWikiLink={onWikiLink} renderFigure={renderFigure} />
           </>
@@ -804,6 +823,8 @@ function PaperDetailPane({
       {readerOpen && (
         <PaperReader
           paper={paper}
+          /* 库版 wiki 不存在时阅览个人版（正文不在 paper 上，显式传入） */
+          wikiContent={paper.wiki_content ?? personalWiki}
           renderFigure={renderFigure}
           onWikiLink={onWikiLink}
           onFilterAuthor={(name) => {

--- a/src/frontend/src/features/wiki/PaperReader.tsx
+++ b/src/frontend/src/features/wiki/PaperReader.tsx
@@ -19,6 +19,7 @@ export function PaperReader({
   onFilterAuthor,
   onClose,
   autoPrint,
+  wikiContent,
 }: {
   paper: PaperDetail;
   renderFigure: (n: number) => ReactNode;
@@ -28,6 +29,8 @@ export function PaperReader({
   onClose: () => void;
   /** 打开后自动唤起打印对话框（「导出 PDF」一步直达） */
   autoPrint?: boolean;
+  /** 正文覆写：库版 wiki 不在 paper 上时（如个人版解读）传进来阅览 */
+  wikiContent?: string | null;
 }) {
   // 打开即打印：等一帧让正文（含图）渲染完再唤起打印
   useEffect(() => {
@@ -126,9 +129,13 @@ export function PaperReader({
             </div>
           )}
 
-          {paper.wiki_content ? (
+          {(wikiContent ?? paper.wiki_content) ? (
             <div className="paper-reader-body">
-              <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
+              <Markdown
+                source={(wikiContent ?? paper.wiki_content)!}
+                onWikiLink={onWikiLink}
+                renderFigure={renderFigure}
+              />
             </div>
           ) : (
             <p className="muted" style={{ fontSize: 13 }}>


### PR DESCRIPTION
Follow-ups to #130.

- **Reading mode / PDF export for a personal wiki.** `PaperReader` rendered `paper.wiki_content`, so a personal wiki — which lives on the personal-library *entry*, not on the paper — couldn't be opened full-screen. It now takes an optional `wikiContent` override, and the read-only detail pane offers the same **Reading mode** and **Export PDF** buttons on the personal version as on a library one.
- **Dropped the duplicate note pill** in the detail header: it repeated the count already shown in the *My notes* section heading. The list row keeps its pill.

`tsc --noEmit` clean.