### PR TITLE
feat(daily): show concepts and the compile badge on the daily detail

### DIFF
--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.schemas.paper import PaperConceptRead
+
 
 class DailyLiker(BaseModel):
     """点赞人（facepile 头像用）。"""
@@ -58,6 +60,11 @@ class DailyPaperItem(BaseModel):
 class DailyPaperDetail(DailyPaperItem):
     wiki_content: str | None = None
     pdf_available: bool = False
+    # 解读的编译模型与时间（编译徽标；wiki_model 在 entry 上，时间取 entry 最后更新）
+    wiki_model: str | None = None
+    compiled_at: datetime | None = None
+    # 论文已上链的概念（与库版详情同款 chips；池论文无库成员行，概念仍挂在论文上）
+    concepts: list[PaperConceptRead] = []
 
 
 class DailyPage(BaseModel):

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -540,12 +540,21 @@ async def get_entry_item(
     entry = await session.get(DailyFeedEntry, entry_id)
     if entry is None:
         raise DailyEntryNotFoundError(str(entry_id))
-    paper = await session.get(Paper, entry.paper_id)
+    from sqlalchemy.orm import selectinload
+
+    # 概念随论文一起取（详情才需要，列表不带）
+    paper = await session.get(Paper, entry.paper_id, options=[selectinload(Paper.concepts)])
     assert paper is not None  # 外键保证
     likes = await _likes_by_entry(session, [entry.id], user_id=user_id)
     item = _entry_item(entry, paper, likes[entry.id])
     item["wiki_content"] = entry.wiki_content
     item["pdf_available"] = paper.pdf_available
+    # 编译徽标：模型在 entry 上，时间用 entry 最后更新（仅在有解读时才有意义）
+    item["wiki_model"] = entry.wiki_model
+    item["compiled_at"] = entry.updated_at if entry.wiki_content else None
+    item["concepts"] = [
+        {"id": c.id, "name": c.name, "category": c.category} for c in (paper.concepts or [])
+    ]
     return item
 
 

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -10,6 +10,7 @@ import {
   hasEmbeddedFigures,
   usePaperFigures,
 } from '../../components/ui/FigureGallery';
+import { CompileBadge } from '../../components/ui/CompileBadge';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { ApiError, api, type DailyPaperItem, type DailySort, type PaperDetail } from '../../lib/api';
@@ -24,6 +25,7 @@ import {
   AdvancedToggle,
   SearchInput,
   SemanticSwitch,
+  categoryMeta,
   saveBlob,
   useDebounced,
 } from '../wiki/shared';
@@ -356,6 +358,26 @@ function DailyDetailPane({
         <div className="empty" style={{ padding: 20 }}>{tr('这篇还没有摘要。', 'No abstract for this paper.')}</div>
       )}
 
+      {/* —— 概念 chips（与库版同款；每日没有概念库 tab，故只展示不跳转） —— */}
+      {(paper.concepts?.length ?? 0) > 0 && (
+        <div className="row gap8 wrap" style={{ marginTop: 16 }}>
+          {paper.concepts!.map((c) => {
+            const meta = categoryMeta(c.category);
+            return (
+              <span
+                key={c.id}
+                className="pill sm"
+                style={{ background: meta.bg, color: meta.c, height: 24 }}
+                title={tr(meta.zh, meta.en)}
+              >
+                {c.name}
+                <span style={{ opacity: 0.6, marginLeft: 5, fontSize: '0.85em' }}>{tr(meta.zh, meta.en)}</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
       {/* —— 重要图片画廊（只读：提取/重新提取是库维护动作，普通用户没权限） —— */}
       <FiguresSection
         paper={readerPaper}
@@ -376,9 +398,12 @@ function DailyDetailPane({
               borderBottom: '0.5px solid var(--border)',
             }}
           >
-            <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
-              {tr('AI 图文介绍', 'AI intro')}
-            </span>
+            <div className="row gap8" style={{ minWidth: 0 }}>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+                {tr('AI 图文介绍', 'AI intro')}
+              </span>
+              <CompileBadge model={paper.wiki_model ?? null} at={paper.compiled_at ?? null} />
+            </div>
             <div className="row gap6">
               <button
                 className="btn btn-soft sm"

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2373,6 +2373,11 @@ export interface DailyPaperDetail extends DailyPaperItem {
   wiki_content: string | null;
   /** 内容池是否已下到 PDF：true→可进平台阅读器，false→仅能去 arxiv 下载 */
   pdf_available: boolean;
+  /** 解读的编译模型与时间（编译徽标；未编译时为 null） */
+  wiki_model?: string | null;
+  compiled_at?: string | null;
+  /** 论文已上链的概念（与库版详情同款 chips） */
+  concepts?: PaperConceptRef[];
 }
 
 /** 每日论文分页；语义检索时后端回带实际用的检索方式（旧后端不返回 → 可选）。 */


### PR DESCRIPTION
Closes the last two gaps from #132, where the daily wiki view was aligned with the library one.

`DailyPaperDetail` doesn't extend `PaperRead`, so those two pieces simply weren't in the payload:

- **`wiki_model` / `compiled_at`** — the model lives on the feed entry; the time is the entry's last update, and is only reported once a wiki exists. Rendered as the same `CompileBadge` beside the *AI intro* heading.
- **`concepts`** — the paper's linked concepts, loaded with the detail (list responses are unchanged). Rendered as chips in the library's style, but **display-only**: the daily feed has no concept-library tab to jump to.

Backend: daily tests 7 passed. Frontend: `tsc --noEmit` clean.
