### PR TITLE
fix(tests): library ingest state follows visibility, not the manage gate (#118)

### DIFF
--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -180,7 +180,7 @@ async def test_personal_library_hidden_from_stranger(client):
 
 
 async def test_personal_library_read_endpoints_hidden_from_stranger(client):
-    """个人库的只读端点（papers/concepts/graph/notes）对非归属人 404，不经 id 泄漏内容。
+    """个人库的只读端点（papers/concepts/graph/notes/建库同步状态）对非归属人 404，不泄漏内容。
 
     回归：修复前这些端点只做 _get_library（查存在），漏了可见性校验。转公共后陌生人可读。"""
     owner = await _hdr(client, "readvis-owner@example.com")
@@ -194,6 +194,7 @@ async def test_personal_library_read_endpoints_hidden_from_stranger(client):
         f"/api/libraries/{lib_id}/concepts",
         f"/api/libraries/{lib_id}/graph",
         f"/api/libraries/{lib_id}/notes",
+        f"/api/libraries/{lib_id}/ingest/state",
     ]
     # 陌生人：全部 404（不泄漏）
     for path in read_paths:

--- a/src/backend/tests/test_library_paper_management.py
+++ b/src/backend/tests/test_library_paper_management.py
@@ -334,5 +334,7 @@ async def test_manage_endpoints_forbidden_for_non_manager(client):
         f"/api/libraries/{lib_id}/papers", json={"bibtex": BIBTEX_ENTRY}, headers=stranger
     )
     assert resp.status_code == 403
+    # 建库/同步状态是只读端点，按库可见性放行（公共库全员可读，见 #66 的只读同步视图）；
+    # 个人库对陌生人 404 的回归在 test_library_approval 里覆盖。
     resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=stranger)
-    assert resp.status_code == 403
+    assert resp.status_code == 200


### PR DESCRIPTION
## Background

`test_library_paper_management.py::test_manage_endpoints_forbidden_for_non_manager` has been failing on main (#118): its last assertion expects `GET /api/libraries/{id}/ingest/state` to return 403 for a non-manager, but the endpoint answers 200.

## The endpoint is right; the assertion is stale

`git log -L` traces the change to #66 (`b4dd545`, regular-user read parity), which **deliberately** moved this read from `_get_managed_library` to `_get_visible_library`. From that commit message:

> ingest/state is opened from the manage gate to visible so the read-only ingest view works.

Regular users need the read-only "build & sync" panel on a public library. The 403 assertion dates from P9d and was simply missed when #66 changed the endpoint.

So this is neither a lost permission check nor an information leak: a public library is visible to everyone, and its ingest state follows that visibility; a personal library still 404s for a stranger via `library_visible_to`. (The library in this test is admin-approved, hence public — which is why `GET /papers` in the same test also returns 200.)

## Changes

- `test_manage_endpoints_forbidden_for_non_manager`: expect 200 there, with a comment noting that read-only endpoints follow library visibility. The three write endpoints keep their 403 assertions.
- `test_personal_library_read_endpoints_hidden_from_stranger`: add `ingest/state` to the personal-library read paths that must 404 for a stranger, so the leak guard stays covered.

## Verification

```
pytest tests/test_library_paper_management.py tests/test_library_approval.py -q   # 32 passed
ruff check                                                                        # clean
```

Closes #118