### PR TITLE
feat(filters): unify clickable author/affiliation filtering across paper views

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -69,6 +69,8 @@ async def list_papers(
     q: str | None = Query(default=None),
     announce: str | None = Query(default=None, pattern="^(new|cross)$"),
     category: str | None = Query(default=None, max_length=32),
+    author: str | None = Query(default=None, max_length=200),
+    affiliation: str | None = Query(default=None, max_length=200),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DailyPage:
@@ -77,6 +79,8 @@ async def list_papers(
     mode=semantic 且有 q 时走论文向量检索（结果按相关度排序、不分页）；数据库不是
     postgres 或 provider 不支持嵌入时回退关键词，响应里 mode_used 如实反映。
     池论文默认不建向量（管理员开关），语义结果可能不全，覆盖度见 vector_ready/total。
+    author/affiliation 是详情面板里点作者、点机构带上来的过滤（JSON 文本包含匹配），
+    两种检索方式都生效。
     """
     mode_used = "keyword"
     items: list[dict] = []
@@ -91,6 +95,8 @@ async def list_papers(
                 date=date,
                 category=category,
                 announce=announce,
+                author=author,
+                affiliation=affiliation,
             )
             mode_used = "semantic"
             entry_by_paper = {paper.id: entry for entry, paper, _ in rows}
@@ -119,6 +125,8 @@ async def list_papers(
             q=q,
             announce=announce,
             category=category,
+            author=author,
+            affiliation=affiliation,
         )
         return DailyPage(items=items, total=total, page=page, size=size, mode_used=mode_used)
     ready, ready_total = await daily_service.embedding_coverage(session)

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -54,6 +54,8 @@ async def list_library(
     year_from: int | None = Query(default=None),
     year_to: int | None = Query(default=None),
     author: str | None = Query(default=None),
+    # 机构：快照里没有，按条目软引用的活体论文匹配（源论文已删的条目匹配不到）
+    affiliation: str | None = Query(default=None),
     venue: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
@@ -97,6 +99,7 @@ async def list_library(
         year_from=year_from,
         year_to=year_to,
         author=author,
+        affiliation=affiliation,
         venue=venue,
     )
     return LibraryPage(

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -37,6 +37,8 @@ class DailyPaperItem(BaseModel):
     announce_type: Literal["new", "cross"]
     title: str
     authors: list[dict[str, Any]] = []
+    # 发表机构（池论文编译后才解析得到；未编译时为空）——前端详情里可点即筛选
+    affiliations: list[str] = []
     abstract: str | None
     year: int | None
     arxiv_id: str | None
@@ -53,6 +55,11 @@ class DailyPaperItem(BaseModel):
     @classmethod
     def _default_authors(cls, v: Any) -> Any:
         return v or []
+
+    @field_validator("affiliations", mode="before")
+    @classmethod
+    def _default_affiliations(cls, v: Any) -> list[str]:
+        return [str(x) for x in v] if isinstance(v, list) else []
 
 
 class DailyPaperDetail(DailyPaperItem):

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -13,6 +13,8 @@ class ShelfItemRead(BaseModel):
     paper_id: uuid.UUID
     title: str
     authors: list[dict[str, Any]] = []
+    # 发表机构（编译 wiki 时解析，OpenAlex 兜底；可能为空）——前端详情里可点即筛选
+    affiliations: list[str] = []
     year: int | None
     venue: str | None
     arxiv_id: str | None
@@ -33,6 +35,11 @@ class ShelfItemRead(BaseModel):
     @classmethod
     def _default_authors(cls, v: Any) -> Any:
         return v or []
+
+    @field_validator("affiliations", mode="before")
+    @classmethod
+    def _default_affiliations(cls, v: Any) -> list[str]:
+        return [str(x) for x in v] if isinstance(v, list) else []
 
 
 class ShelfPage(BaseModel):

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -404,6 +404,7 @@ def _entry_item(entry: DailyFeedEntry, paper: Paper, likes: dict[str, Any]) -> d
         "announce_type": entry.announce_type,
         "title": paper.title,
         "authors": paper.authors or [],
+        "affiliations": paper.affiliations or [],
         "abstract": paper.abstract,
         "year": paper.year,
         "arxiv_id": paper.arxiv_id,
@@ -448,12 +449,19 @@ async def list_papers(
     q: str | None = None,
     announce: str | None = None,
     category: str | None = None,
+    author: str | None = None,
+    affiliation: str | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
     if date is not None:
         stmt = stmt.where(DailyFeedEntry.feed_date == date)
     if q:
         stmt = stmt.where(Paper.title.ilike(f"%{q.strip()}%"))
+    # 作者 / 机构：在 JSON 列上做文本包含匹配（同 services/papers.apply_paper_filters 口径）
+    if author:
+        stmt = stmt.where(cast(Paper.authors, String).ilike(f"%{author}%"))
+    if affiliation:
+        stmt = stmt.where(cast(Paper.affiliations, String).ilike(f"%{affiliation}%"))
     if announce in ("new", "cross"):
         stmt = stmt.where(DailyFeedEntry.announce_type == announce)
     if category:
@@ -487,11 +495,13 @@ async def semantic_search_daily(
     date: dt.date | None = None,
     category: str | None = None,
     announce: str | None = None,
+    author: str | None = None,
+    affiliation: str | None = None,
 ) -> list[tuple[DailyFeedEntry, Paper, float]]:
     """池内向量检索（pgvector 余弦；仅 postgres，调用方先判 semantic_search_supported）。
 
     只召回已有向量的池论文——池论文默认不建向量（管理员开关），所以结果可能不全，
-    调用方需要如实告知前端。筛选条件与关键词列表一致（日期/分类/公告类型）。
+    调用方需要如实告知前端。筛选条件与关键词列表一致（日期/分类/公告类型/作者/机构）。
     """
     where = ["p.embedding IS NOT NULL"]
     params: dict[str, Any] = {"qv": json.dumps(query_vector), "k": limit}
@@ -507,6 +517,12 @@ async def semantic_search_daily(
         )
         params["category"] = category
         params["category_like"] = f'%"{category}"%'
+    if author:
+        where.append("CAST(p.authors AS text) ILIKE :author_like")
+        params["author_like"] = f"%{author}%"
+    if affiliation:
+        where.append("CAST(p.affiliations AS text) ILIKE :affiliation_like")
+        params["affiliation_like"] = f"%{affiliation}%"
     rows = (
         await session.execute(
             text(

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -97,6 +97,7 @@ def _item_dict(
         "paper_id": paper.id,
         "title": paper.title,
         "authors": paper.authors or [],
+        "affiliations": paper.affiliations or [],
         "year": paper.year,
         "venue": paper.venue,
         "arxiv_id": paper.arxiv_id,

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -235,6 +235,7 @@ async def list_entries(
     year_from: int | None = None,
     year_to: int | None = None,
     author: str | None = None,
+    affiliation: str | None = None,
     venue: str | None = None,
 ) -> tuple[list[UserLibraryEntry], int]:
     stmt = select(UserLibraryEntry).where(UserLibraryEntry.user_id == user_id)
@@ -254,6 +255,16 @@ async def list_entries(
     # 高级检索：作者在 JSON 列上做文本包含匹配（同 q 里的作者匹配口径）
     if author:
         stmt = stmt.where(sa_cast(UserLibraryEntry.authors, SAText).ilike(f"%{author}%"))
+    # 机构：条目快照里没有机构字段，借软引用的活体论文（last_paper_id）匹配。
+    # 源论文已删的条目匹配不上——详情面板也只在论文还在时才显示机构，口径一致。
+    if affiliation:
+        stmt = stmt.where(
+            UserLibraryEntry.last_paper_id.in_(
+                select(Paper.id).where(
+                    sa_cast(Paper.affiliations, SAText).ilike(f"%{affiliation}%")
+                )
+            )
+        )
     if venue:
         stmt = stmt.where(UserLibraryEntry.venue.ilike(f"%{venue}%"))
     if year_from is not None:

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -134,6 +134,64 @@ async def test_cleanup_expired_keeps_paper_and_membership(client, monkeypatch):
     assert resp.json()["total"] == 0
 
 
+async def test_list_filters_by_author_and_affiliation(client, monkeypatch):
+    """详情面板里点作者 / 点机构 chip 带上来的过滤（JSON 文本包含匹配）。
+
+    机构是编译解读时才解析出来的，同步进来的池论文没有——这里直接写进论文行模拟已编译。
+    """
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.paper import Paper
+
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    await _run_sync(
+        monkeypatch,
+        {
+            "cs.AI": [
+                _rss_entry("2607.00041", "Vision Paper"),
+                _rss_entry("2607.00042", "Language Paper"),
+            ]
+        },
+    )
+    # 造作者/机构：Vision=Kaiming He@Meta AI，Language=Jacob Devlin@Google Research
+    async with get_sessionmaker()() as session:
+        papers = (await session.execute(select(Paper))).scalars().all()
+        for paper in papers:
+            if paper.title == "Vision Paper":
+                paper.authors = [{"name": "Kaiming He"}]
+                paper.affiliations = ["Meta AI"]
+            else:
+                paper.authors = [{"name": "Jacob Devlin"}]
+                paper.affiliations = ["Google Research"]
+        await session.commit()
+
+    async def query(**params):
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        resp = await client.get(f"/api/daily/papers?{qs}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        return [i["title"] for i in body["items"]], body["total"]
+
+    got, total = await query()
+    assert total == 2
+    # 机构随列表一起返回，前端详情才能画出可点的 chips
+    resp = await client.get("/api/daily/papers", headers=headers)
+    by_title = {i["title"]: i for i in resp.json()["items"]}
+    assert by_title["Vision Paper"]["affiliations"] == ["Meta AI"]
+
+    got, total = await query(author="Kaiming")
+    assert got == ["Vision Paper"] and total == 1
+    got, total = await query(affiliation="Google")
+    assert got == ["Language Paper"] and total == 1
+    got, total = await query(author="Nobody")
+    assert got == [] and total == 0
+    # 与其他条件叠加
+    got, _ = await query(affiliation="Meta", announce="new")
+    assert got == ["Vision Paper"]
+
+
 async def test_like_toggle_facepile_and_sort(client, monkeypatch):
     token_a = await register_and_login(client)  # 首个 = admin
     token_b = await register_and_login(client, email="bob@example.com")

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -135,6 +135,7 @@ async def test_library_advanced_filters_and_year_sort(client):
         project_id,
         title="Old Paper",
         authors=[{"name": "Alice Smith"}],
+        affiliations=["Stanford University"],
         year=2015,
         venue="NeurIPS",
         status="included",
@@ -143,6 +144,7 @@ async def test_library_advanced_filters_and_year_sort(client):
         project_id,
         title="Mid Paper",
         authors=[{"name": "Bob Jones"}],
+        affiliations=["Microsoft Research"],
         year=2018,
         venue="ICML",
         status="included",
@@ -151,6 +153,7 @@ async def test_library_advanced_filters_and_year_sort(client):
         project_id,
         title="New Paper",
         authors=[{"name": "Carol Lee"}],
+        affiliations=["Google DeepMind"],
         year=2021,
         venue="ICLR",
         status="included",
@@ -169,6 +172,11 @@ async def test_library_advanced_filters_and_year_sort(client):
     # author（JSON 文本包含）
     got, _ = await query(author="Bob")
     assert got == ["Mid Paper"]
+    # affiliation：条目快照没有机构字段，按软引用的活体论文匹配
+    got, total = await query(affiliation="Microsoft")
+    assert got == ["Mid Paper"] and total == 1
+    got, total = await query(affiliation="Nowhere Institute")
+    assert got == [] and total == 0
     # venue
     got, _ = await query(venue="ICLR")
     assert got == ["New Paper"]

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -22,6 +22,9 @@ import { readerFrom } from '../reading/shared';
 import {
   AdvancedPanel,
   AdvancedToggle,
+  AffiliationChips,
+  AuthorLinks,
+  FilterInput,
   SearchInput,
   SemanticSwitch,
   saveBlob,
@@ -160,6 +163,8 @@ function DailyDetailPane({
   compiling,
   onFetchPdf,
   onCompile,
+  onFilterAuthor,
+  onFilterAffiliation,
 }: {
   entryId: string;
   onCollect: (p: CollectPaperRef) => void;
@@ -169,6 +174,10 @@ function DailyDetailPane({
   compiling: boolean;
   onFetchPdf: (entryId: string) => void;
   onCompile: (entryId: string) => void;
+  /** 点作者 → 按该作者过滤列表 */
+  onFilterAuthor: (name: string) => void;
+  /** 点机构 chip → 按该机构过滤列表 */
+  onFilterAffiliation: (name: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -211,7 +220,6 @@ function DailyDetailPane({
     );
   }
 
-  const authors = paper.authors.map((a) => a.name).filter(Boolean).join(', ');
   // 「链接放 arxiv，不放标题」：优先原文 url，退回 arxiv abs 页
   const arxivHref = paper.url ?? (paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : null);
   // PDF 不可用时的下载去处：arxiv pdf，无 arxiv_id 退回原文 url
@@ -258,9 +266,11 @@ function DailyDetailPane({
       <h1 style={{ fontSize: 21, fontWeight: 680, lineHeight: 1.3, margin: '2px 0 6px', letterSpacing: '-0.01em' }}>
         {paper.title}
       </h1>
-      {authors && <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 6 }}>{authors}</div>}
+      {/* 作者 / 机构都可点：点了按它过滤列表 */}
+      <AuthorLinks authors={paper.authors} onFilter={onFilterAuthor} />
+      <AffiliationChips affiliations={paper.affiliations} onFilter={onFilterAffiliation} />
       {paper.published_at && (
-        <div style={{ fontSize: 11.5, color: 'var(--text-4)', marginBottom: 14 }}>
+        <div style={{ fontSize: 11.5, color: 'var(--text-4)', margin: '6px 0 14px' }}>
           {tr('发布于', 'Published')} {fmtTime(paper.published_at)}
         </div>
       )}
@@ -454,8 +464,13 @@ export function DailyPage() {
   const [advOpen, setAdvOpen] = useState(true);
   const [category, setCategory] = useState('');
   const [announce, setAnnounce] = useState<AnnounceFilter>(DEFAULT_ANNOUNCE);
+  // 作者 / 机构：手填，或在右栏详情里点作者名、点机构 chip 带进来
+  const [authorInput, setAuthorInput] = useState('');
+  const [affiliationInput, setAffiliationInput] = useState('');
+  const author = useDebounced(authorInput.trim());
+  const affiliation = useDebounced(affiliationInput.trim());
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
-  const advActive = !!category || announce !== DEFAULT_ANNOUNCE;
+  const advActive = !!category || announce !== DEFAULT_ANNOUNCE || !!author || !!affiliation;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -465,11 +480,11 @@ export function DailyPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => setPage(1), [q, semanticOn, day, category, announce]);
+  useEffect(() => setPage(1), [q, semanticOn, day, category, announce, author, affiliation]);
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [q, semanticOn, day, category, announce]);
+  }, [q, semanticOn, day, category, announce, author, affiliation]);
 
   const daysQuery = useQuery({
     queryKey: ['daily-days'],
@@ -509,6 +524,32 @@ export function DailyPage() {
     pickDay(dayIdx >= 0 && dayIdx < dates.length - 1 ? (dates[dayIdx + 1] ?? null) : null);
   };
 
+  // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板；
+  // 日期放开到全部 7 天——只看当天的话，按作者/机构筛基本什么都剩不下
+  const applyAdvFilter = useCallback(
+    (patch: { author?: string; affiliation?: string }) => {
+      setSemanticOn(false);
+      setQInput('');
+      setAuthorInput(patch.author ?? '');
+      setAffiliationInput(patch.affiliation ?? '');
+      setCategory('');
+      setAnnounce('all');
+      setAdvOpen(true);
+      pickDay(null);
+      if (patch.author) {
+        toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
+      } else if (patch.affiliation) {
+        toast(tr(`已筛选机构：${patch.affiliation}`, `Filtered by affiliation: ${patch.affiliation}`), 'info');
+      }
+    },
+    [pickDay],
+  );
+  const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
+  const filterByAffiliation = useCallback(
+    (name: string) => applyAdvFilter({ affiliation: name }),
+    [applyAdvFilter],
+  );
+
   const categoriesQuery = useQuery({
     queryKey: ['daily-categories'],
     queryFn: () => api.getDailyCategories(),
@@ -519,7 +560,7 @@ export function DailyPage() {
   // 语义检索：只在有关键词时生效；结果按相关度排序、不分页
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
-    queryKey: ['daily-papers', semanticOn, page, q, day, category, announce],
+    queryKey: ['daily-papers', semanticOn, page, q, day, category, announce, author, affiliation],
     queryFn: () =>
       api.listDailyPapers({
         sort: semantic ? undefined : DAILY_SORT,
@@ -529,6 +570,8 @@ export function DailyPage() {
         date: day ?? undefined,
         category: category || undefined,
         announce: announce === 'all' ? undefined : announce,
+        author: author || undefined,
+        affiliation: affiliation || undefined,
         mode: semantic ? 'semantic' : undefined,
       }),
     retry: false,
@@ -678,14 +721,17 @@ export function DailyPage() {
                   open={advOpen}
                   active={advActive}
                   onToggle={() => setAdvOpen((o) => !o)}
-                  title={tr('高级检索：分类 / 类型', 'Advanced search: category / type')}
+                  title={tr(
+                    '高级检索：分类 / 类型 / 作者 / 机构',
+                    'Advanced search: category / type / author / affiliation',
+                  )}
                 />
                 <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
                   {total ? tr(`${total} 篇`, `${total}`) : ''}
                 </span>
               </div>
 
-              {/* 高级检索面板：分类 + 类型（日期步进和排序留在工具栏，它们是主导航） */}
+              {/* 高级检索面板：分类 + 类型 + 作者 / 机构（日期步进和排序留在工具栏，它们是主导航） */}
               {advOpen && (
                 <AdvancedPanel
                   onClear={
@@ -693,6 +739,8 @@ export function DailyPage() {
                       ? () => {
                           setCategory('');
                           setAnnounce(DEFAULT_ANNOUNCE);
+                          setAuthorInput('');
+                          setAffiliationInput('');
                         }
                       : undefined
                   }
@@ -730,20 +778,41 @@ export function DailyPage() {
                       {tr('更新', 'Updated')}
                     </span>
                   </div>
+                  <div className="row gap8">
+                    <FilterInput
+                      value={authorInput}
+                      onChange={setAuthorInput}
+                      placeholder={tr('作者姓名…', 'Author name…')}
+                    />
+                    <FilterInput
+                      value={affiliationInput}
+                      onChange={setAffiliationInput}
+                      placeholder={tr('发表机构…', 'Affiliation…')}
+                      title={tr(
+                        '机构信息要等这篇编译出解读后才有，没编译过的论文匹配不到',
+                        'Affiliations only exist after a paper has been compiled here',
+                      )}
+                    />
+                  </div>
                 </AdvancedPanel>
               )}
               {/* 面板收起时，把正在生效的分类/类型如实说一句（默认「只看新工作」也算），
                   免得筛选藏进面板后用户不知道列表被过滤过 */}
-              {!advOpen && (announce !== 'all' || !!category) && (
+              {!advOpen && (announce !== 'all' || !!category || !!author || !!affiliation) && (
                 <div
                   onClick={() => setAdvOpen(true)}
                   style={{ marginTop: 6, fontSize: 11, color: 'var(--text-4)', cursor: 'pointer', lineHeight: 1.5 }}
                   title={tr('点开高级检索改筛选条件', 'Open advanced search to change the filters')}
                 >
                   {tr('只看：', 'Showing: ')}
-                  {announce === 'new' ? tr('新工作', 'New') : announce === 'cross' ? tr('更新', 'Updated') : ''}
-                  {announce !== 'all' && category ? ' · ' : ''}
-                  {category}
+                  {[
+                    announce === 'new' ? tr('新工作', 'New') : announce === 'cross' ? tr('更新', 'Updated') : '',
+                    category,
+                    author,
+                    affiliation,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
                 </div>
               )}
 
@@ -920,6 +989,8 @@ export function DailyPage() {
                 compiling={compilePending.has(selectedId)}
                 onFetchPdf={fetchPdf}
                 onCompile={compile}
+                onFilterAuthor={filterByAuthor}
+                onFilterAffiliation={filterByAffiliation}
               />
             ) : (
               <div className="empty" style={{ margin: 'auto' }}>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -17,7 +17,6 @@ import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
-import { clickable } from '../../lib/a11y';
 import {
   ApiError,
   api,
@@ -38,6 +37,8 @@ import { PaperReader } from '../wiki/PaperReader';
 import {
   AdvancedPanel,
   AdvancedToggle,
+  AffiliationChips,
+  AuthorLinks,
   FilterInput,
   MetaItem,
   SearchInput,
@@ -65,9 +66,8 @@ type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' |
 
 const PAGE_SIZE = 20;
 
-/** 概念 / 机构 chips 默认最多展示数，超出折叠（与文献工作台一致） */
+/** 概念 chips 默认最多展示数，超出折叠（与文献工作台一致；机构 chips 见 AffiliationChips） */
 const CONCEPT_CHIP_LIMIT = 12;
-const AFFIL_CHIP_LIMIT = 6;
 
 /** 列表视图筛选（口径同文献工作台：全部 = 已纳入的文献） */
 type ViewFilter = 'all' | 'compiled' | 'starred';
@@ -337,7 +337,6 @@ function PaperDetailPane({
   const queryClient = useQueryClient();
   const [abstractOpen, setAbstractOpen] = useState(false);
   const [conceptsOpen, setConceptsOpen] = useState(false);
-  const [affilsOpen, setAffilsOpen] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
 
@@ -408,7 +407,6 @@ function PaperDetailPane({
   useEffect(() => {
     setAbstractOpen(false);
     setConceptsOpen(false);
-    setAffilsOpen(false);
     setReaderOpen(false);
     resetPersonalWiki();
   }, [paperId, resetPersonalWiki]);
@@ -469,43 +467,8 @@ function PaperDetailPane({
           <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
             {paper.title}
           </h1>
-          {paper.authors.length > 0 && (
-            <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
-              {paper.authors.map((a, i) => (
-                <span key={`${a.name}-${i}`}>
-                  {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
-                  <span
-                    className="author-link"
-                    title={tr(`只看 ${a.name} 的论文`, `Show only ${a.name}'s papers`)}
-                    {...clickable(() => onFilterAuthor(a.name))}
-                  >
-                    {a.name}
-                  </span>
-                </span>
-              ))}
-            </div>
-          )}
-          {(paper.affiliations?.length ?? 0) > 0 && (
-            <div className="row gap6 wrap" style={{ marginTop: 8 }}>
-              <Icon name="pin" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
-              {(affilsOpen ? paper.affiliations! : paper.affiliations!.slice(0, AFFIL_CHIP_LIMIT)).map((name) => (
-                <span
-                  key={name}
-                  className="chip"
-                  style={{ fontSize: 11 }}
-                  title={tr(`只看 ${name} 的论文`, `Show only papers from ${name}`)}
-                  {...clickable(() => onFilterAffiliation(name))}
-                >
-                  {name}
-                </span>
-              ))}
-              {paper.affiliations!.length > AFFIL_CHIP_LIMIT && (
-                <span className="chip" style={{ fontSize: 11 }} onClick={() => setAffilsOpen((o) => !o)}>
-                  {affilsOpen ? tr('收起', 'Collapse') : `+${paper.affiliations!.length - AFFIL_CHIP_LIMIT}`}
-                </span>
-              )}
-            </div>
-          )}
+          <AuthorLinks authors={paper.authors} onFilter={onFilterAuthor} />
+          <AffiliationChips affiliations={paper.affiliations} onFilter={onFilterAffiliation} />
         </div>
         {relevance !== null && <ScoreRing value={relevance} max={1} size={56} label={tr('相关度', 'Relevance')} />}
       </div>

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -10,6 +10,7 @@ import { api, type LibraryEntry, type PaperAuthor, type Publication } from '../.
 import { tr } from '../../lib/i18n';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
+import { AffiliationChips, AuthorLinks } from '../wiki/shared';
 
 /* ============================================================
    我的文献库 · 右栏详情（三个 tab 共用）：
@@ -81,12 +82,18 @@ export function LibraryDetailPane({
   paperId,
   snapshot,
   entryId,
+  onFilterAuthor,
+  onFilterAffiliation,
 }: {
   /** 活体论文 id；null = 快照条目（论文已删，只展示快照元数据）。 */
   paperId: string | null;
   snapshot: DetailSnapshot;
   /** 收藏/浏览记录条目 id；提供后论文已删时可回退到条目的 wiki 快照（发表 tab 不传）。 */
   entryId?: string;
+  /** 点作者 → 按该作者过滤列表；不传则作者名不可点 */
+  onFilterAuthor?: (name: string) => void;
+  /** 点机构 chip → 按该机构过滤列表；不传则 chips 不可点 */
+  onFilterAffiliation?: (name: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -177,7 +184,9 @@ export function LibraryDetailPane({
   // 详情拉不到（比如论文刚被删）时退回快照展示
   const alive = paper !== undefined;
   const title = paper?.title ?? snapshot.title;
-  const authors = (paper?.authors ?? snapshot.authors).map((a) => a.name).join(', ');
+  const authors = paper?.authors ?? snapshot.authors;
+  // 机构只有活体论文有（个人库条目快照不存机构）；论文被删的条目这一行自然消失
+  const affiliations = paper?.affiliations;
   const year = paper?.year ?? snapshot.year;
   const venue = paper?.venue ?? snapshot.venue;
   const arxivId = paper?.arxiv_id ?? snapshot.arxivId;
@@ -213,13 +222,12 @@ export function LibraryDetailPane({
         )}
       </div>
 
-      {/* —— 标题 + 作者 —— */}
+      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤列表） —— */}
       <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
         {title}
       </h1>
-      {authors && (
-        <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>{authors}</div>
-      )}
+      <AuthorLinks authors={authors} onFilter={onFilterAuthor} />
+      <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
 
       {/* —— 操作：打开阅读页（仅活体论文）+ 外链 —— */}
       <div className="row gap8 wrap" style={{ marginTop: 14 }}>

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
@@ -252,20 +252,45 @@ export function LibraryPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  // 高级检索：年份区间 / 作者 / venue（走后端）
+  // 高级检索：年份区间 / 作者 / 机构 / venue（走后端）
   const [advOpen, setAdvOpen] = useState(false);
   const [author, setAuthor] = useState('');
+  const [affiliation, setAffiliation] = useState('');
   const [venue, setVenue] = useState('');
   const [yearFrom, setYearFrom] = useState('');
   const [yearTo, setYearTo] = useState('');
 
-  const advActive = !!author.trim() || !!venue.trim() || !!yearFrom.trim() || !!yearTo.trim();
+  const advActive =
+    !!author.trim() || !!affiliation.trim() || !!venue.trim() || !!yearFrom.trim() || !!yearTo.trim();
   const clearAdvanced = () => {
     setAuthor('');
+    setAffiliation('');
     setVenue('');
     setYearFrom('');
     setYearTo('');
   };
+
+  // 点作者/机构 → 列表只留匹配的条目（走已有的高级检索），其余条件重置并展开面板
+  const applyAdvFilter = useCallback((patch: { author?: string; affiliation?: string }) => {
+    setSemanticOn(false);
+    setQInput('');
+    setAuthor(patch.author ?? '');
+    setAffiliation(patch.affiliation ?? '');
+    setVenue('');
+    setYearFrom('');
+    setYearTo('');
+    setAdvOpen(true);
+    if (patch.author) {
+      toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
+    } else if (patch.affiliation) {
+      toast(tr(`已筛选机构：${patch.affiliation}`, `Filtered by affiliation: ${patch.affiliation}`), 'info');
+    }
+  }, []);
+  const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
+  const filterByAffiliation = useCallback(
+    (name: string) => applyAdvFilter({ affiliation: name }),
+    [applyAdvFilter],
+  );
 
   // 双栏选中态：收藏/记录共用一份（同一种条目），「我发表的」单独一份。
   // 翻页/搜索/切 tab 都不清空——右栏基于选中时的快照继续展示，
@@ -282,7 +307,7 @@ export function LibraryPage() {
   // tab / 搜索词 / 检索模式 / 排序 / 高级条件变化时回到第一页
   useEffect(() => {
     setPage(1);
-  }, [tab, q, semanticOn, sort, author, venue, yearFrom, yearTo]);
+  }, [tab, q, semanticOn, sort, author, affiliation, venue, yearFrom, yearTo]);
 
   // 切 tab / 换搜索词 / 换检索模式时清空多选（避免选中集跨上下文残留）
   useEffect(() => {
@@ -294,7 +319,7 @@ export function LibraryPage() {
   const listQuery = useQuery({
     queryKey: [
       'library', tab, q, semantic, sort, page,
-      author.trim(), venue.trim(), yearFrom.trim(), yearTo.trim(),
+      author.trim(), affiliation.trim(), venue.trim(), yearFrom.trim(), yearTo.trim(),
     ],
     queryFn: () =>
       api.listLibrary({
@@ -306,6 +331,7 @@ export function LibraryPage() {
         size: semantic ? SEMANTIC_SIZE : PAGE_SIZE,
         // 语义态不叠加高级过滤（后端语义分支忽略），关键词态照常带上
         author: semantic ? undefined : author.trim() || undefined,
+        affiliation: semantic ? undefined : affiliation.trim() || undefined,
         venue: semantic ? undefined : venue.trim() || undefined,
         year_from: semantic ? undefined : parseYear(yearFrom),
         year_to: semantic ? undefined : parseYear(yearTo),
@@ -536,7 +562,10 @@ export function LibraryPage() {
                     open={advOpen}
                     active={advActive}
                     onToggle={() => setAdvOpen((o) => !o)}
-                    title={tr('高级检索：年份 / 作者 / 期刊会议', 'Advanced search: year / author / venue')}
+                    title={tr(
+                      '高级检索：年份 / 作者 / 机构 / 期刊会议',
+                      'Advanced search: year / author / affiliation / venue',
+                    )}
                   />
                 </div>
 
@@ -562,6 +591,15 @@ export function LibraryPage() {
                           placeholder={tr('期刊 / 会议…', 'Venue…')}
                         />
                       </div>
+                      <FilterInput
+                        value={affiliation}
+                        onChange={setAffiliation}
+                        placeholder={tr('发表机构…', 'Affiliation…')}
+                        title={tr(
+                          '机构信息在论文那边，源论文已被删除的条目匹配不到',
+                          'Affiliations live on the paper — entries whose source paper is gone will not match',
+                        )}
+                      />
                     </AdvancedPanel>
                   </div>
                 )}
@@ -741,6 +779,8 @@ export function LibraryPage() {
                   paperId={shownEntry.last_paper_id}
                   snapshot={entrySnapshot(shownEntry)}
                   entryId={shownEntry.id}
+                  onFilterAuthor={filterByAuthor}
+                  onFilterAffiliation={filterByAffiliation}
                 />
               ) : (
                 <PickHint />

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -62,6 +62,7 @@ function scoredToShelf(p: PaperRead & { score?: number | null }): ShelfItemRead 
     paper_id: p.id,
     title: p.title,
     authors: p.authors,
+    affiliations: p.affiliations,
     year: p.year,
     venue: p.venue,
     arxiv_id: p.arxiv_id,
@@ -382,6 +383,30 @@ export function ResearchPage() {
     setReadingStatus('');
     setStarred(false);
   };
+
+  // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板
+  const applyAdvFilter = useCallback((patch: { author?: string; affiliation?: string }) => {
+    setSemanticOn(false);
+    setQInput('');
+    setAuthor(patch.author ?? '');
+    setAffiliation(patch.affiliation ?? '');
+    setYearFrom('');
+    setYearTo('');
+    setReadingStatus('');
+    setStarred(false);
+    setAdvOpen(true);
+    setSelId(null);
+    if (patch.author) {
+      toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
+    } else if (patch.affiliation) {
+      toast(tr(`已筛选机构：${patch.affiliation}`, `Filtered by affiliation: ${patch.affiliation}`), 'info');
+    }
+  }, []);
+  const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
+  const filterByAffiliation = useCallback(
+    (name: string) => applyAdvFilter({ affiliation: name }),
+    [applyAdvFilter],
+  );
 
   useEffect(() => {
     setPage(1);
@@ -963,6 +988,8 @@ export function ResearchPage() {
                 onShelf={!semantic || selectedOnShelf}
                 onAdd={() => addMutation.mutate(selected.paper_id)}
                 addPending={addMutation.isPending && addMutation.variables === selected.paper_id}
+                onFilterAuthor={filterByAuthor}
+                onFilterAffiliation={filterByAffiliation}
               />
             ) : !semantic && shelfQuery.isSuccess && items.length === 0 && !hasServerFilter ? (
               /* 书架为空 → 右栏放引导 */

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -9,6 +9,7 @@ import { api, type ShelfItemRead, type ShelfWikiSource } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { libraryPath, useLibraries } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
+import { AffiliationChips, AuthorLinks } from '../wiki/shared';
 
 /* ============================================================
    相关研究 · 右栏详情（与「我的文献库」LibraryDetailPane 同一版式）：
@@ -235,6 +236,8 @@ export function ShelfDetailPane({
   onShelf = true,
   onAdd,
   addPending = false,
+  onFilterAuthor,
+  onFilterAffiliation,
 }: {
   item: ShelfItemRead;
   notePending: boolean;
@@ -252,6 +255,10 @@ export function ShelfDetailPane({
   onShelf?: boolean;
   onAdd?: () => void;
   addPending?: boolean;
+  /** 点作者 → 按该作者过滤列表；不传则作者名不可点 */
+  onFilterAuthor?: (name: string) => void;
+  /** 点机构 chip → 按该机构过滤列表；不传则 chips 不可点 */
+  onFilterAffiliation?: (name: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -291,7 +298,8 @@ export function ShelfDetailPane({
     [navigate, item.source_library_id],
   );
 
-  const authors = item.authors.map((a) => a.name).join(', ');
+  // 机构：书架条目自带（后端从内容池论文取）；旧后端没这个字段时退回论文详情
+  const affiliations = item.affiliations ?? paper?.affiliations;
   const tldr = item.tldr ?? paper?.tldr ?? null;
   const abstract = paper?.abstract ?? null;
   const arxivUrl = item.arxiv_id ? `https://arxiv.org/abs/${item.arxiv_id}` : null;
@@ -318,11 +326,12 @@ export function ShelfDetailPane({
         )}
       </div>
 
-      {/* —— 标题 + 作者 —— */}
+      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤书架） —— */}
       <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
         {item.title}
       </h1>
-      {authors && <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>{authors}</div>}
+      <AuthorLinks authors={item.authors} onFilter={onFilterAuthor} />
+      <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
 
       {/* —— 操作行 —— */}
       <div className="row gap8 wrap" style={{ marginTop: 14 }}>

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -30,8 +30,15 @@ import {
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { usePendingByPaper } from '../../lib/pending';
-import { clickable } from '../../lib/a11y';
-import { categoryMeta, MetaItem, saveBlob, SearchInput, useDebounced } from './shared';
+import {
+  AffiliationChips,
+  AuthorLinks,
+  categoryMeta,
+  MetaItem,
+  saveBlob,
+  SearchInput,
+  useDebounced,
+} from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
@@ -897,9 +904,6 @@ function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) 
 /** 概念 chips 默认最多展示数，超出折叠 */
 const CONCEPT_CHIP_LIMIT = 12;
 
-/** 机构 chips 默认最多展示数，超出折叠 */
-const AFFIL_CHIP_LIMIT = 6;
-
 function PaperDetailPane({
   paperId,
   pid,
@@ -933,7 +937,6 @@ function PaperDetailPane({
   const scopeId = libraryId ?? pid;
   const [abstractOpen, setAbstractOpen] = useState(false);
   const [conceptsOpen, setConceptsOpen] = useState(false);
-  const [affilsOpen, setAffilsOpen] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
 
@@ -986,7 +989,6 @@ function PaperDetailPane({
   useEffect(() => {
     setAbstractOpen(false);
     setConceptsOpen(false);
-    setAffilsOpen(false);
     setReaderOpen(false);
   }, [paperId]);
 
@@ -1051,53 +1053,8 @@ function PaperDetailPane({
           <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
             {paper.title}
           </h1>
-          {paper.authors.length > 0 && (
-            <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
-              {paper.authors.map((a, i) => (
-                <span key={`${a.name}-${i}`}>
-                  {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
-                  <span
-                    className="author-link"
-                    role="button"
-                    tabIndex={0}
-                    title={tr(`只看 ${a.name} 的论文`, `Show only ${a.name}'s papers`)}
-                    onClick={() => onFilterAuthor(a.name)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        onFilterAuthor(a.name);
-                      }
-                    }}
-                  >
-                    {a.name}
-                  </span>
-                </span>
-              ))}
-            </div>
-          )}
-          {(paper.affiliations?.length ?? 0) > 0 && (
-            <div className="row gap6 wrap" style={{ marginTop: 8 }}>
-              <Icon name="pin" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
-              {(affilsOpen ? paper.affiliations! : paper.affiliations!.slice(0, AFFIL_CHIP_LIMIT)).map((name) => (
-                <span
-                  key={name}
-                  className="chip"
-                  style={{ fontSize: 11 }}
-                  title={tr(`只看 ${name} 的论文`, `Show only papers from ${name}`)}
-                  {...clickable(() => onFilterAffiliation(name))}
-                >
-                  {name}
-                </span>
-              ))}
-              {paper.affiliations!.length > AFFIL_CHIP_LIMIT && (
-                <span className="chip" style={{ fontSize: 11 }} onClick={() => setAffilsOpen((o) => !o)}>
-                  {affilsOpen
-                    ? tr('收起', 'Collapse')
-                    : `+${paper.affiliations!.length - AFFIL_CHIP_LIMIT}`}
-                </span>
-              )}
-            </div>
-          )}
+          <AuthorLinks authors={paper.authors} onFilter={onFilterAuthor} />
+          <AffiliationChips affiliations={paper.affiliations} onFilter={onFilterAffiliation} />
         </div>
         {relevance !== null && (
           <ScoreRing value={relevance} max={1} size={56} label={tr('相关度', 'Relevance')} />

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState, type ReactNode } from 'react';
-import type { ConceptCategory } from '../../lib/api';
+import type { ConceptCategory, PaperAuthor } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { clickable } from '../../lib/a11y';
 import { Icon } from '../../components/ui/Icon';
 import { Switch } from '../../components/ui/Switch';
 
@@ -241,6 +242,88 @@ export function FilterInput({
       placeholder={placeholder}
       title={title}
     />
+  );
+}
+
+/* ============================================================
+   论文详情头部：作者行 + 机构 chips（论文库 / 相关研究 / 个人库 / 每日新论文共用）。
+   给了 onFilter 就可点——点了按这个作者 / 机构过滤当前列表。
+   ============================================================ */
+
+/** 机构 chips 折叠阈值：超过这么多先收起来，点 +N 展开。 */
+export const AFFIL_CHIP_LIMIT = 6;
+
+/** 详情头的作者行：`·` 分隔；给了 onFilter 则每个名字可点。 */
+export function AuthorLinks({
+  authors,
+  onFilter,
+}: {
+  authors: PaperAuthor[];
+  onFilter?: (name: string) => void;
+}) {
+  if (authors.length === 0) return null;
+  return (
+    <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
+      {authors.map((a, i) => (
+        <span key={`${a.name}-${i}`}>
+          {i > 0 && <span style={{ color: 'var(--text-4)' }}> · </span>}
+          {onFilter ? (
+            <span
+              className="author-link"
+              title={tr(`只看 ${a.name} 的论文`, `Show only ${a.name}'s papers`)}
+              {...clickable(() => onFilter(a.name))}
+            >
+              {a.name}
+            </span>
+          ) : (
+            a.name
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** 详情头的机构 chips：超过 AFFIL_CHIP_LIMIT 个先折叠；给了 onFilter 则每个可点。 */
+export function AffiliationChips({
+  affiliations,
+  onFilter,
+}: {
+  affiliations: string[] | undefined;
+  onFilter?: (name: string) => void;
+}) {
+  // 展开态挂在「当前这组机构」上：详情面板不随选中论文重挂载，换一篇就自动收回去
+  const [openFor, setOpenFor] = useState<string | null>(null);
+  const sig = affiliations?.join('|') ?? '';
+  if (!affiliations || affiliations.length === 0) return null;
+  const open = openFor === sig;
+  const shown = open ? affiliations : affiliations.slice(0, AFFIL_CHIP_LIMIT);
+  return (
+    <div className="row gap6 wrap" style={{ marginTop: 8 }}>
+      <Icon name="pin" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+      {shown.map((name) =>
+        onFilter ? (
+          <span
+            key={name}
+            className="chip"
+            style={{ fontSize: 11 }}
+            title={tr(`只看 ${name} 的论文`, `Show only papers from ${name}`)}
+            {...clickable(() => onFilter(name))}
+          >
+            {name}
+          </span>
+        ) : (
+          <span key={name} className="chip" style={{ fontSize: 11, cursor: 'default' }}>
+            {name}
+          </span>
+        ),
+      )}
+      {affiliations.length > AFFIL_CHIP_LIMIT && (
+        <span className="chip" style={{ fontSize: 11 }} {...clickable(() => setOpenFor(open ? null : sig))}>
+          {open ? tr('收起', 'Collapse') : `+${affiliations.length - AFFIL_CHIP_LIMIT}`}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -965,6 +965,8 @@ export interface ShelfItemRead {
   paper_id: string;
   title: string;
   authors: PaperAuthor[];
+  /** 发表机构（编译 wiki 时解析；可能为空，旧后端可能缺字段） */
+  affiliations?: string[];
   year: number | null;
   venue: string | null;
   arxiv_id: string | null;
@@ -2355,6 +2357,8 @@ export interface DailyPaperItem {
   announce_type: 'new' | 'cross';
   title: string;
   authors: PaperAuthor[];
+  /** 发表机构（池论文编译后才解析；未编译为空，旧后端可能缺字段） */
+  affiliations?: string[];
   abstract: string | null;
   year: number | null;
   arxiv_id: string | null;
@@ -3927,6 +3931,8 @@ export const api = {
       year_from?: number;
       year_to?: number;
       author?: string;
+      /** 机构：条目快照没有机构字段，后端按条目软引用的活体论文匹配（源论文已删的匹配不到） */
+      affiliation?: string;
       venue?: string;
     },
   ): Promise<LibraryListResult> {
@@ -3940,6 +3946,7 @@ export const api = {
     if (opts.year_from != null) params.set('year_from', String(opts.year_from));
     if (opts.year_to != null) params.set('year_to', String(opts.year_to));
     if (opts.author) params.set('author', opts.author);
+    if (opts.affiliation) params.set('affiliation', opts.affiliation);
     if (opts.venue) params.set('venue', opts.venue);
     return request<LibraryListResult>(`/me/library?${params.toString()}`);
   },
@@ -4026,6 +4033,10 @@ export const api = {
       announce?: 'new' | 'cross';
       /** 订阅分类筛选，如 cs.AI；不传=全部分类 */
       category?: string;
+      /** 作者姓名（详情里点作者带上来）；两种检索方式都生效 */
+      author?: string;
+      /** 发表机构（详情里点机构 chip 带上来）；只有编译过的池论文才有机构元数据 */
+      affiliation?: string;
       /** 检索方式：keyword=字面匹配，semantic=向量检索（只覆盖已生成向量的论文） */
       mode?: SearchMode;
     } = {},
@@ -4038,6 +4049,8 @@ export const api = {
     if (opts.q) params.set('q', opts.q);
     if (opts.announce) params.set('announce', opts.announce);
     if (opts.category) params.set('category', opts.category);
+    if (opts.author) params.set('author', opts.author);
+    if (opts.affiliation) params.set('affiliation', opts.affiliation);
     if (opts.mode) params.set('mode', opts.mode);
     const qs = params.toString();
     return request<DailyPage>(`/daily/papers${qs ? `?${qs}` : ''}`);


### PR DESCRIPTION
Makes author and affiliation clickable filters consistent across every paper surface. Compiling a wiki extracts the author↔affiliation mapping, but only some views could show or filter by it.

## Coverage

| | author clickable | affiliations shown | affiliation clickable | filters the list | backend param |
| --- | :---: | :---: | :---: | :---: | :---: |
| Direction library (baseline) | ✅ | ✅ | ✅ | ✅ | existing |
| Topic paper library | ✅ | ✅ | ✅ | ✅ | existing |
| Related work | ✅ | ✅ | ✅ | ✅ | existing (+ `affiliations` in the payload) |
| My library | ✅ | live papers only | ✅ | live papers only | **new** `/me/library?affiliation=` |
| Daily papers | ✅ | compiled papers only | ✅ | ✅ | **new** `/daily/papers?author=&affiliation=` |

All five share one interaction, via `AuthorLinks` / `AffiliationChips` in `features/wiki/shared.tsx`: clicking turns off semantic search, clears the query, resets other advanced conditions, expands the advanced panel, and toasts what was filtered.

## Data limits (not omissions)

- **My library** stores snapshots (`UserLibraryEntry` has no affiliations), so filtering resolves through the entry's `last_paper_id` to the live paper — entries whose source paper was deleted can't match, and the detail only draws chips while the paper is alive. The advanced field says so.
- **Daily papers** only have affiliations once the paper has been compiled; uncompiled pool papers show no chips and won't match an affiliation filter.

## Tests

New: daily author/affiliation filtering (each hits the right paper, combines with `announce`, and `affiliations` is in the list payload); personal-library affiliation filtering (hit and miss). Existing coverage handles the topic library and shelf.

Backend `ruff` clean, **158 passed**; `tsc --noEmit` and `npm run build` clean. The two known-unrelated failures (`ingest/state` 403 assertion, `test_paper_review` collection errors) reproduce on clean main.
