### PR TITLE
feat(start): surface topic-free features and a one-click sample topic

### DIFF
--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -1,18 +1,113 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Icon } from '../../components/ui/Icon';
+import { useQueryClient } from '@tanstack/react-query';
+import { Icon, type IconName } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
 import { topicPath, useProject } from '../../app/project';
+import { api } from '../../lib/api';
 import { fmtTime } from '../../lib/format';
-import { tr } from '../../lib/i18n';
+import { getLang, tr } from '../../lib/i18n';
+import { useLibraries } from '../libraries/hooks';
 
 /* ============================================================
-   /start — 选择或创建课题。
+   /start — 落地页：选择或创建课题 + 不依赖课题的功能入口。
    没有任何课题时，课题作用域路由（RequireTopic）统一重定向到这里；
    已有课题的用户手动访问也能在此快速切换。
+   下方卡片区对所有人常驻：平台有一半功能（文献库、每日新论文、
+   实验室工作台、我的文献库）不需要课题，新用户先逛这些也行。
    ============================================================ */
+
+/**
+ * 不依赖课题的功能入口。
+ * 注意：模块级常量在 import 时求值，不能用 tr()（切语言不会更新），
+ * 所以中英两份原文都存下来，渲染时按当前语言取。
+ */
+const ENTRIES: { to: string; icon: IconName; zh: [string, string]; en: [string, string] }[] = [
+  {
+    to: '/libraries',
+    icon: 'book',
+    zh: ['实验室文献库', '全实验室共享的方向文献库，可以浏览、检索、和文献对话。'],
+    en: ['Lab libraries', 'Shared topic libraries for the whole lab — browse, search and chat with the papers.'],
+  },
+  {
+    to: '/daily',
+    icon: 'heart',
+    zh: ['每日新论文', 'arXiv 每日新提交，可以点赞、收录进文献库、看 AI 解读。'],
+    en: ['Daily papers', "Fresh arXiv submissions every day — like them, add them to a library, read the AI digest."],
+  },
+  {
+    to: '/lab',
+    icon: 'flask',
+    zh: ['实验室工作台', '实验室资源概况，以及全部 AI 任务的运行情况。'],
+    en: ['Lab workbench', 'Lab resources at a glance, plus every AI task and how it is running.'],
+  },
+  {
+    to: '/library',
+    icon: 'bookmark',
+    zh: ['我的文献库', '你自己收藏的论文，随手存、随时读。'],
+    en: ['My library', 'The papers you saved yourself — stash now, read later.'],
+  },
+];
+
+/** 一键创建的示例课题预设（同上：中英两份原文，调用处再选）。 */
+const SAMPLE_TOPIC = {
+  zh: {
+    name: '示例：递归自我改进 (RSI)',
+    statement: '研究模型如何自我改进的能力边界与安全性。',
+  },
+  en: {
+    name: 'Sample: Recursive Self-Improvement (RSI)',
+    statement: 'How models improve themselves — capability limits and safety.',
+  },
+};
+/** 判重用：两种语言的名字都算「已经有示例课题了」。 */
+const SAMPLE_NAMES = [SAMPLE_TOPIC.zh.name, SAMPLE_TOPIC.en.name];
 
 export function StartPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { projects, isLoading, currentProjectId, setCurrentProjectId } = useProject();
+  const [creatingSample, setCreatingSample] = useState(false);
+
+  // 示例课题的语料：挑一个已激活的公共库；没有就空着建（允许无语料）
+  const librariesQuery = useLibraries();
+
+  function openTopic(id: string) {
+    setCurrentProjectId(id);
+    navigate(topicPath(id));
+  }
+
+  /** 一键创建示例课题；已经有同名的就直接进去，不重复建。 */
+  async function createSample() {
+    const existing = projects.find((p) => SAMPLE_NAMES.includes(p.name));
+    if (existing) {
+      toast(tr('示例课题已经有了，直接进入。', 'You already have the sample topic — opening it.'), 'info');
+      openTopic(existing.id);
+      return;
+    }
+    const preset = getLang() === 'en' ? SAMPLE_TOPIC.en : SAMPLE_TOPIC.zh;
+    const publicLib = (librariesQuery.data ?? []).find((l) => l.is_public && l.status === 'active');
+    setCreatingSample(true);
+    try {
+      const created = await api.createProject({
+        name: preset.name,
+        statement: preset.statement,
+        source_library_ids: publicLib ? [publicLib.id] : [],
+      });
+      await queryClient.invalidateQueries({ queryKey: ['projects'] });
+      toast(
+        publicLib
+          ? `${tr('示例课题已创建，语料来自：', 'Sample topic created, corpus from: ')}${publicLib.name}`
+          : tr('示例课题已创建', 'Sample topic created'),
+        'ok',
+      );
+      openTopic(created.id);
+    } catch (e) {
+      toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+    } finally {
+      setCreatingSample(false);
+    }
+  }
 
   return (
     <div className="page fadeup" style={{ maxWidth: 640, margin: '0 auto', paddingTop: 48 }}>
@@ -35,6 +130,12 @@ export function StartPage() {
         <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0 }}>
           {tr('选择或创建课题', 'Pick or create a topic')}
         </h1>
+        <div style={{ fontSize: 13, color: 'var(--text-3)', marginTop: 8, lineHeight: 1.6 }}>
+          {tr(
+            '课题是你做研究的空间。不着急建也行——文献库、每日新论文这些先逛着，随时回来建课题。',
+            'A topic is your research workspace. No rush — browse the libraries and daily papers first, and come back whenever you are ready.',
+          )}
+        </div>
       </div>
 
       {isLoading ? (
@@ -58,10 +159,7 @@ export function StartPage() {
                 textAlign: 'left',
                 fontFamily: 'var(--sans)',
               }}
-              onClick={() => {
-                setCurrentProjectId(p.id);
-                navigate(topicPath(p.id));
-              }}
+              onClick={() => openTopic(p.id)}
             >
               <span
                 style={{
@@ -105,12 +203,100 @@ export function StartPage() {
       )}
 
       <div style={{ textAlign: 'center' }}>
-        <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
-          <Icon name="plus" size={14} />
-          {tr('新建课题', 'New topic')}
-        </button>
-        <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 18, lineHeight: 1.6 }}>
+        <div className="row gap8" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button className="btn btn-primary" onClick={() => navigate('/projects/new')}>
+            <Icon name="plus" size={14} />
+            {tr('新建课题', 'New topic')}
+          </button>
+          <button className="btn btn-ghost" onClick={createSample} disabled={creatingSample}>
+            <Icon name="sparkle" size={14} />
+            {creatingSample ? tr('创建中…', 'Creating…') : tr('创建示例课题', 'Create a sample topic')}
+          </button>
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 14, lineHeight: 1.6 }}>
+          {tr('想先看看长什么样？示例课题会带一个现成的文献库。', 'Want to see what it looks like first? The sample topic comes with a ready-made library.')}
+          <br />
           {tr('拿到同事的邀请链接？直接打开即可加入。', 'Got an invite link from a teammate? Just open it to join.')}
+        </div>
+      </div>
+
+      {/* —— 不用课题也能用的功能 —— */}
+      <div style={{ marginTop: 40 }}>
+        <div style={{ textAlign: 'center', marginBottom: 14 }}>
+          <div style={{ fontSize: 13, fontWeight: 650, color: 'var(--text)' }}>
+            {tr('不用课题也能用', 'Works without a topic')}
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 5 }}>
+            {tr('这几处随时可以进，和有没有课题无关。', 'These are always open to you, topic or not.')}
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+            gap: 12,
+          }}
+        >
+          {ENTRIES.map((e) => {
+            const [title, desc] = getLang() === 'en' ? e.en : e.zh;
+            return (
+              <button
+                key={e.to}
+                className="card card-pad hoverable"
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 12,
+                  textAlign: 'left',
+                  fontFamily: 'var(--sans)',
+                  cursor: 'pointer',
+                }}
+                onClick={() => navigate(e.to)}
+              >
+                <span
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 9,
+                    flexShrink: 0,
+                    background: 'var(--accent-soft)',
+                    color: 'var(--accent)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Icon name={e.icon} size={16} />
+                </span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      fontSize: 13.5,
+                      fontWeight: 640,
+                      color: 'var(--text)',
+                    }}
+                  >
+                    {title}
+                    <Icon name="arrow" size={12} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+                  </span>
+                  <span
+                    style={{
+                      display: 'block',
+                      fontSize: 12,
+                      color: 'var(--text-3)',
+                      lineHeight: 1.6,
+                      marginTop: 5,
+                    }}
+                  >
+                    {desc}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The start page only offered *pick or create a topic*, so a new user had no way to discover that the libraries, the daily feed and the lab workbench all work perfectly well **without** one — it read as "you must create a topic first".

## Cards for the topic-free features

A new *works without a topic* grid (auto-fit, stacks on narrow screens) linking to:

| Destination | What it says |
| --- | --- |
| Libraries | lab-wide direction libraries — browse, search, chat with them |
| Daily papers | new arXiv submissions — like, collect, read the AI intro |
| Lab workbench | lab resources at a glance, plus every AI task |
| My library | your own saved papers |

Reuses the existing card / hoverable classes and sidebar icons; shown to users who already have topics too.

## One-click sample topic

A *Create a sample topic* button next to *New topic* creates a preset RSI topic (name + one-sentence statement, kept as zh/en pairs since module-level constants can't call `tr`) via the existing `createProject`, linked to the first visible **public, active** library so it has a corpus, then opens it.

It's a preset rather than a copy of anyone's real topic, so nobody's actual work is touched. Clicking again when a sample already exists just enters it instead of creating a duplicate.

`tsc --noEmit` clean; `npm run build` passes.

Two things worth knowing: the duplicate check matches on the sample's name (either language), and the linked library is simply the first visible public one — pinning a specific "getting started" corpus would need a backend marker.
