### PR TITLE
feat(libraries): library-scoped export, index rebuild and concept relink

### DIFF
--- a/docs/embedding-and-retrieval.md
+++ b/docs/embedding-and-retrieval.md
@@ -51,8 +51,10 @@ In summary:
   - The add paths (`enrich_paper`, `fetch_pdf`) create chunk rows but only embed them when the user
     has the opt-in on; otherwise the chunk rows sit with `NULL` embeddings, to be filled later.
   - Manual rebuild endpoints (`/projects/{id}/shelf/index/rebuild`, `/library/index/rebuild`) require
-    the opt-in; `/projects/{id}/index/rebuild` (a direction library) is a synchronous maintenance
-    endpoint that returns `{indexed, embedded, skipped}`.
+    the opt-in; `/projects/{id}/index/rebuild` and `/libraries/{id}/index/rebuild` (a direction
+    library, topic- and library-scoped forms of the same maintenance action) are synchronous
+    maintenance endpoints that return `{indexed, embedded, skipped}`. The library-scoped form needs
+    manage rights on that library and works for standalone libraries (no origin topic).
 - **Daily-feed papers are embedded only when an admin turns it on.** `sync_daily_feed` builds
   lightweight rows with no LLM, so daily papers have no vector by default. The admin setting
   **`daily_feed_embed_enabled` (off by default)** makes each sync embed the papers it touched that

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -2,8 +2,9 @@
 
 方向库对全实验室可读：读端点只做登录校验、不做课题成员校验。
 治理端点（库定义编辑 / 策展人任命）按库级写权限校验：成员 ∪ 策展人 ∪ 平台 admin
-（策展人任命仅平台 admin）。批量写/管理入口（ingest、论文管理、概念补建等）仍走
-project 作用域端点（鉴权同样接入库级写权限助手）。
+（策展人任命仅平台 admin）。集合级写/管理入口（ingest、论文管理、概念补建、全文
+索引重建等）本文件都有库作用域版本（独立库靠它们获得同等能力）；同名的 project
+作用域端点仍在 papers/wiki/concepts 路由里，鉴权同样接入库级写权限助手。
 个人文献库路由在 ``app/api/library.py``（/me/library），勿混淆。
 """
 
@@ -20,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from redis.asyncio import Redis
 from sqlalchemy import select
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import (
@@ -56,6 +58,7 @@ from app.schemas.libraries import (
 from app.schemas.note import NotebookPage, NoteWithPaper
 from app.schemas.paper import (
     ConceptRead,
+    ConceptRelinkResult,
     PaperBatchIds,
     PaperChatRequest,
     PaperDetail,
@@ -68,6 +71,7 @@ from app.schemas.paper import (
     TagRead,
 )
 from app.schemas.voyage import VoyageRead
+from app.services import chunks as chunks_service
 from app.services import citations as citations_service
 from app.services import concepts as concepts_service
 from app.services import graph as graph_service
@@ -79,6 +83,7 @@ from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
+from app.services.wiki_export import build_obsidian_zip_for_libraries
 
 router = APIRouter(tags=["libraries"])
 
@@ -719,6 +724,29 @@ async def export_library_citations(
     )
 
 
+@router.get("/libraries/{library_id}/export/obsidian")
+async def export_library_obsidian(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """库作用域 Obsidian 笔记库导出（zip；独立方向库也可用；读端点全实验室可读）。
+
+    语料 = 本库在库论文（compiled/included）+ 本库概念；笔记只含请求者本人的。
+    与课题版同一套 vault 结构，只是范围换成单个库。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    content = await build_obsidian_zip_for_libraries(
+        session, library_ids=[library.id], title=library.name, user_id=user.id
+    )
+    return Response(
+        content=content,
+        media_type="application/zip",
+        # 文件名固定 ASCII：库名多为中文，放进 Content-Disposition 会撞 latin-1 头编码
+        headers={"Content-Disposition": 'attachment; filename="polaris-library-wiki.zip"'},
+    )
+
+
 # ---- P9d 库级论文管理 / ingest 状态 / 图谱 / 对话 / 笔记（库工作台，含独立库） ----
 #
 # 说明：单篇写操作（改状态/软删召回/彻底删/重编译/标签）仍走 papers 路由的
@@ -831,6 +859,55 @@ async def get_library_ingest_state(
     library = await _get_visible_library(session, library_id, user)
     state = await ingest_service.library_ingest_state(session, library)
     return IngestStateRead(**state)
+
+
+@router.post("/libraries/{library_id}/concepts/relink", response_model=ConceptRelinkResult)
+async def relink_library_concepts(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ConceptRelinkResult:
+    """库作用域概念补建（可管理者）：对本库已编译论文重抽 [[双链]]、建缺失概念并补齐关联。
+
+    幂等；面向历史数据（编译过但概念上链没跑到的论文）。新概念定义分批调 LLM，
+    并回填此前留下的占位概念，失败降级为占位、不阻塞。计本库预算。
+    """
+    library = await _get_managed_library(session, library_id, user)
+    stats, _papers = await concepts_service.link_all_paper_concepts(
+        session,
+        library_id=library.id,
+        llm=get_llm_router(),
+        user_id=user.id,
+        project_id=library.project_id,
+        backfill=True,
+    )
+    return ConceptRelinkResult(**stats)
+
+
+@router.post("/libraries/{library_id}/index/rebuild")
+async def rebuild_library_fulltext_index(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """库作用域全文索引重建（可管理者）：给本库已有全文但缺分段的论文补分段并嵌入。
+
+    幂等：已有分段的论文跳过；新入库论文由建库流水线自动处理，通常无需手动调用。
+    """
+    library = await _get_managed_library(session, library_id, user)
+    try:
+        return await chunks_service.rebuild_library_fulltext_index(
+            session,
+            library_id=library.id,
+            llm=get_llm_router(),
+            user_id=user.id,
+            project_id=library.project_id,
+        )
+    except ProgrammingError as e:  # paper_chunks 表还没迁移
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="DB_MIGRATION_REQUIRED: 请先执行数据库迁移（make migrate）",
+        ) from e
 
 
 @router.get("/libraries/{library_id}/graph", response_model=GraphResponse)

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -21,7 +21,7 @@ from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.library_direction import LibraryPaper
-from app.models.paper import Paper, PaperChunk
+from app.models.paper import Paper
 from app.models.project import Project
 from app.models.user import User
 from app.schemas.graph import GraphResponse
@@ -433,60 +433,19 @@ async def rebuild_fulltext_index(
             "embed_error": None,
             "total_chunks": 0,
         }
-    chunked_ids = select(PaperChunk.paper_id)
     try:
-        papers = (
-            (
-                await session.execute(
-                    select(Paper)
-                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                    .where(
-                        LibraryPaper.library_id == library.id,
-                        Paper.full_text_path.is_not(None),
-                        Paper.id.not_in(chunked_ids),
-                    )
-                )
-            )
-            .scalars()
-            .all()
+        return await chunks_service.rebuild_library_fulltext_index(
+            session,
+            library_id=library.id,
+            llm=get_llm_router(),
+            user_id=user.id,
+            project_id=project_id,
         )
     except ProgrammingError as e:  # paper_chunks 表还没迁移
         raise HTTPException(
             status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="DB_MIGRATION_REQUIRED: 请先执行数据库迁移（make migrate）",
         ) from e
-    indexed = 0
-    chunk_count = 0
-    for paper in papers:
-        n = await chunks_service.index_paper_fulltext(session, paper)
-        if n:
-            indexed += 1
-            chunk_count += n
-    await session.commit()
-    embedded, embed_error = await chunks_service.embed_pending_chunks(
-        session,
-        library_id=library.id,
-        llm=get_llm_router(),
-        user_id=user.id,
-        project_id=project_id,
-    )
-    total_chunks = int(
-        (
-            await session.execute(
-                select(func.count())
-                .select_from(PaperChunk)
-                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
-                .where(LibraryPaper.library_id == library.id)
-            )
-        ).scalar_one()
-    )
-    return {
-        "papers_indexed": indexed,
-        "chunks_created": chunk_count,
-        "embedded": embedded,
-        "embed_error": embed_error,
-        "total_chunks": total_chunks,
-    }
 
 
 @router.get("/projects/{project_id}/graph", response_model=GraphResponse)

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -38,6 +38,10 @@ class PaperRead(BaseModel):
     id: uuid.UUID
     # 本次访问解析出的课题上下文；池级可达（书架/个人库）的无库论文可为 null
     project_id: uuid.UUID | None
+    # 本次访问解析出的**文献库**（成员行所属库）；池级可达的无库论文为 null。
+    # 前端凭此定位「这篇属于哪个库」（返回文献库按钮 / [[双链]] 落点），不再靠
+    # project_id 反查——库与课题解耦后 project_id 只是历史溯源指针。
+    library_id: uuid.UUID | None = None
     title: str
     authors: list[AuthorRead] = []
     affiliations: list[str] = []  # 发表机构（LLM 从全文解析，OpenAlex 兜底；可能为空）

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -10,8 +10,9 @@ import json
 import re
 import uuid
 from pathlib import Path
+from typing import Any
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -209,6 +210,70 @@ async def embed_pending_chunks_for_papers(
         project_id=project_id,
         voyage_id=voyage_id,
     )
+
+
+async def rebuild_library_fulltext_index(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    llm: LLMRouter,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """重建某个库的全文分段索引（docs/api-lit.md §8）：给已有全文但缺分段的论文补分段并嵌入。
+
+    幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
+    课题作用域与库作用域两个端点共用本函数（project_id 仅用于 LLM 用量记账归属）。
+    paper_chunks 表尚未迁移时 ``ProgrammingError`` 原样上抛，由路由层转 503。
+    """
+    chunked_ids = select(PaperChunk.paper_id)
+    papers = (
+        (
+            await session.execute(
+                select(Paper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    Paper.full_text_path.is_not(None),
+                    Paper.id.not_in(chunked_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    indexed = 0
+    chunk_count = 0
+    for paper in papers:
+        n = await index_paper_fulltext(session, paper)
+        if n:
+            indexed += 1
+            chunk_count += n
+    await session.commit()
+    embedded, embed_error = await embed_pending_chunks(
+        session,
+        library_id=library_id,
+        llm=llm,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    total_chunks = int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(PaperChunk)
+                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+                .where(LibraryPaper.library_id == library_id)
+            )
+        ).scalar_one()
+    )
+    return {
+        "papers_indexed": indexed,
+        "chunks_created": chunk_count,
+        "embedded": embedded,
+        "embed_error": embed_error,
+        "total_chunks": total_chunks,
+    }
 
 
 # ---- 检索 ----

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -100,6 +100,11 @@ class PaperView:
         return self.paper.id
 
     @property
+    def library_id(self) -> uuid.UUID | None:
+        """成员行所属库；池级兜底视角（合成的临时成员行）无库 → None。"""
+        return self.membership.library_id
+
+    @property
     def relevance_score(self) -> float | None:
         return self.membership.relevance_score
 

--- a/src/backend/app/services/wiki_export.py
+++ b/src/backend/app/services/wiki_export.py
@@ -15,6 +15,7 @@ import json
 import uuid
 import zipfile
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import select
@@ -107,20 +108,37 @@ def _inline_paper_figures(
 async def build_obsidian_zip(
     session: AsyncSession, project: Project, *, user_id: uuid.UUID
 ) -> bytes:
-    """构建 vault zip；笔记只导出请求者本人的（P5b 笔记 paper × author，仅作者可见）。"""
-    # 课题关联库并集：跨库同一论文按确定性视角归并（有 wiki 优先），再按相关性排序
+    """课题作用域导出：语料 = 课题关联库并集，标题取课题名。"""
     library_ids = await get_source_library_ids(session, project.id)
+    return await build_obsidian_zip_for_libraries(
+        session, library_ids=library_ids, title=project.name, user_id=user_id
+    )
+
+
+async def build_obsidian_zip_for_libraries(
+    session: AsyncSession,
+    *,
+    library_ids: Sequence[uuid.UUID],
+    title: str,
+    user_id: uuid.UUID,
+) -> bytes:
+    """构建 vault zip；笔记只导出请求者本人的（P5b 笔记 paper × author，仅作者可见）。
+
+    语料 = 给定库集合（课题版传关联库并集，库版传 ``[library_id]``，独立库同样可用）。
+    """
+    # 跨库同一论文按确定性视角归并（有 wiki 优先），再按相关性排序
+    ids = list(library_ids)
     paper_rows = (
         dedupe_member_rows(
             (
                 await session.execute(
-                    member_papers_stmt(library_ids)
+                    member_papers_stmt(ids)
                     .where(LibraryPaper.status.in_(("compiled", "included")))
                     .options(selectinload(Paper.concepts))
                 )
             ).all()
         )
-        if library_ids
+        if ids
         else []
     )
     paper_rows.sort(
@@ -135,7 +153,7 @@ async def build_obsidian_zip(
             (
                 await session.execute(
                     select(Concept)
-                    .where(Concept.library_id.in_(library_ids))
+                    .where(Concept.library_id.in_(ids))
                     .options(selectinload(Concept.papers))
                     .order_by(Concept.name)
                 )
@@ -143,7 +161,7 @@ async def build_obsidian_zip(
             .scalars()
             .all()
         )
-        if library_ids
+        if ids
         else []
     )
 
@@ -169,7 +187,7 @@ async def build_obsidian_zip(
         ]
 
         # index.md
-        index_lines = [f"# {project.name} · Research Wiki", ""]
+        index_lines = [f"# {title} · Research Wiki", ""]
         index_lines += ["## Papers", ""]
         index_lines += [f"- [[{slug}]] — {p.title}" for slug, p in paper_entries] or ["（暂无）"]
         index_lines += ["", "## Concepts", ""]

--- a/src/backend/tests/test_library_scoped_capabilities.py
+++ b/src/backend/tests/test_library_scoped_capabilities.py
@@ -1,0 +1,222 @@
+"""库作用域能力补齐（PR-1）：独立库（project_id=NULL）的 Obsidian 导出 /
+全文索引重建 / 概念补建，以及论文 schema 的 library_id 字段。
+
+课题作用域的同名端点不受影响（见 test_wiki_api / test_library_chat / test_concepts_relink）。
+"""
+
+import io
+import tempfile
+import uuid
+import zipfile
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _setup(client, *, prefix):
+    """admin + 创建者 + 一个 active 独立库（project_id 为空）；返回 (creator, admin, lib_id)。"""
+    admin = await _hdr(client, f"{prefix}-admin@example.com")
+    await _promote_admin(f"{prefix}-admin@example.com")
+    creator = await _hdr(client, f"{prefix}-owner@example.com")
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "独立库", "statement": "LLM agent 规划方向"},
+        headers=creator,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] is None
+    lib_id = resp.json()["id"]
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    assert resp.status_code == 200, resp.text
+    return creator, admin, lib_id
+
+
+async def _seed_paper(
+    lib_id,
+    *,
+    title,
+    status="compiled",
+    relevance=0.8,
+    wiki=None,
+    full_text_path=None,
+):
+    async with get_sessionmaker()() as session:
+        paper = Paper(
+            title=title,
+            abstract=f"{title} abstract",
+            authors=[{"name": "Alice"}],
+            year=2025,
+            source="arxiv",
+            full_text_path=full_text_path,
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            LibraryPaper(
+                library_id=uuid.UUID(str(lib_id)),
+                paper_id=paper.id,
+                status=status,
+                relevance_score=relevance,
+                wiki_content=wiki,
+            )
+        )
+        await session.commit()
+        return str(paper.id)
+
+
+# ---- 1. Obsidian 导出 ----
+
+
+async def test_standalone_library_obsidian_export(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-obs")
+    await _seed_paper(
+        lib_id,
+        title="Planning with Tree Search",
+        wiki="本文提出 [[树搜索]]，结合 [[强化学习]] 训练。",
+    )
+    await _seed_paper(lib_id, title="Trashed paper", status="excluded")
+    # 概念页要有内容 → 先补建概念
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=creator)
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.get(f"/api/libraries/{lib_id}/export/obsidian", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/zip"
+    assert "polaris-library-wiki.zip" in resp.headers["content-disposition"]
+
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        names = zf.namelist()
+        assert "index.md" in names and "trends.md" in names
+        index = zf.read("index.md").decode()
+        assert "独立库 · Research Wiki" in index
+        paper_pages = [n for n in names if n.startswith("papers/") and n.endswith(".md")]
+        assert len(paper_pages) == 1  # 垃圾桶论文不导出
+        body = zf.read(paper_pages[0]).decode()
+        assert "[[树搜索]]" in body  # 双链原样保留
+        concept_pages = [n for n in names if n.startswith("concepts/")]
+        assert len(concept_pages) == 2
+
+
+async def test_library_obsidian_export_visible_to_readers(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-obs-read")
+    await _seed_paper(lib_id, title="Readable", wiki="正文 [[概念甲]]。")
+    stranger = await _hdr(client, "libscope-obs-read-stranger@example.com")
+
+    # 公共库只读端点：非管理者也能导出（与库作用域引用导出一致）
+    resp = await client.get(f"/api/libraries/{lib_id}/export/obsidian", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    assert len(resp.content) > 0
+    # 库不存在 → 404
+    resp = await client.get(f"/api/libraries/{uuid.uuid4()}/export/obsidian", headers=creator)
+    assert resp.status_code == 404
+
+
+# ---- 2. 全文索引重建 ----
+
+
+async def test_standalone_library_index_rebuild(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-idx")
+    txt_dir = Path(tempfile.mkdtemp(prefix="polaris-libscope-"))
+    for i, title in enumerate(["Planning survey", "Reflexion"]):
+        txt = txt_dir / f"p{i}.txt"
+        txt.write_text("规划方法的细节。" * 300, encoding="utf-8")
+        await _seed_paper(lib_id, title=title, full_text_path=str(txt))
+    # 没有全文的论文不参与
+    await _seed_paper(lib_id, title="No fulltext")
+
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["papers_indexed"] == 2
+    assert body["chunks_created"] > 0
+    assert body["total_chunks"] == body["chunks_created"]
+    assert body["embedded"] == body["chunks_created"] and body["embed_error"] is None
+
+    # 幂等：再跑不重复建
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
+    assert resp.json()["papers_indexed"] == 0
+
+
+# ---- 3. 概念补建 ----
+
+
+async def test_standalone_library_concepts_relink(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-rel")
+    await _seed_paper(
+        lib_id, title="Paper A", wiki="本文提出 [[自我博弈]]，结合 [[强化学习]] 训练。"
+    )
+    await _seed_paper(
+        lib_id, title="Paper B", status="included", wiki="基于 [[强化学习]] 与 [[课程学习]]。"
+    )
+    await _seed_paper(lib_id, title="Paper C", status="candidate")  # 无 wiki 不参与
+
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=creator)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["papers"] == 2
+    assert body["concepts_created"] == 3
+    assert body["links_created"] == 4  # A:2 + B:2（强化学习共享一个概念）
+
+    resp = await client.get(f"/api/libraries/{lib_id}/concepts", headers=creator)
+    counts = {c["name"]: c["paper_count"] for c in resp.json()}
+    assert counts == {"自我博弈": 1, "强化学习": 2, "课程学习": 1}
+
+    # 幂等
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=creator)
+    assert resp.json()["concepts_created"] == 0 and resp.json()["links_created"] == 0
+
+
+# ---- 4. 维护端点鉴权 ----
+
+
+async def test_library_maintenance_endpoints_forbidden_for_non_manager(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-403")
+    await _seed_paper(lib_id, title="Guarded", wiki="正文 [[概念甲]]。")
+    stranger = await _hdr(client, "libscope-403-stranger@example.com")
+
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=stranger)
+    assert resp.status_code == 403
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=stranger)
+    assert resp.status_code == 403
+    # 库不存在 → 404（管理端点同样不泄漏）
+    resp = await client.post(f"/api/libraries/{uuid.uuid4()}/index/rebuild", headers=creator)
+    assert resp.status_code == 404
+    resp = await client.post(f"/api/libraries/{uuid.uuid4()}/concepts/relink", headers=creator)
+    assert resp.status_code == 404
+
+
+# ---- 5. PaperRead.library_id ----
+
+
+async def test_paper_read_exposes_library_id(client):
+    creator, _admin, lib_id = await _setup(client, prefix="libscope-field")
+    paper_id = await _seed_paper(lib_id, title="Field carrier", wiki="正文。")
+
+    resp = await client.get(f"/api/libraries/{lib_id}/papers", headers=creator)
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert [i["library_id"] for i in items] == [lib_id]
+
+    # 单篇详情（库工作台 + 阅读页两条路径）
+    resp = await client.get(f"/api/libraries/{lib_id}/papers/{paper_id}", headers=creator)
+    assert resp.json()["library_id"] == lib_id
+    resp = await client.get(f"/api/papers/{paper_id}", headers=creator)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["library_id"] == lib_id

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -168,13 +168,14 @@ export function LibraryDetailPane({
     [],
   );
 
-  // [[概念]] 双链 → 论文所属课题的 wiki（对齐阅读页的处理）
-  // 双链落点：论文所属课题的隐式库详情页（无课题上下文时退到库列表）
-  const topicLib = useTopicLibrary(paper?.project_id ?? null);
+  // [[概念]] 双链 → 论文所属文献库的概念页（对齐阅读页的处理；定位不到时退到库列表）。
+  // 库由后端直接给的 library_id 定位；旧后端没这个字段时退回「按起源课题反查库」
+  const topicLib = useTopicLibrary(paper?.library_id ? null : paper?.project_id ?? null);
+  const paperLibId = paper?.library_id ?? topicLib?.id ?? null;
   const onWikiLink = useCallback(
     (name: string) =>
-      navigate(topicLib ? libraryPath(topicLib.id, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
-    [navigate, topicLib],
+      navigate(paperLibId ? libraryPath(paperLibId, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
+    [navigate, paperLibId],
   );
 
   if (paperId !== null && paperQuery.isLoading) {
@@ -241,11 +242,11 @@ export function LibraryDetailPane({
           </button>
         )}
         {alive &&
-          (topicLib ? (
+          (paperLibId ? (
             <button
               className="btn btn-ghost sm"
               title={tr('打开这篇所在的方向文献库', 'Open the direction library this paper lives in')}
-              onClick={() => navigate(libraryPath(topicLib.id, `?paper=${paper.id}`))}
+              onClick={() => navigate(libraryPath(paperLibId, `?paper=${paper.id}`))}
             >
               <Icon name="book" size={13} />
               {tr('去文献库', 'Open library')}

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -208,13 +208,15 @@ export function ReadingPage() {
     onError: (e) => toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  // 论文所属课题的隐式库：返回/双链跳转的落点（无课题上下文时退到库列表）
-  const topicLib = useTopicLibrary(paper?.project_id ?? null);
-  const libHref = (suffix: string) => (topicLib ? libraryPath(topicLib.id, suffix) : '/libraries');
+  // 论文所属文献库：返回/双链跳转的落点。后端直接给 library_id；旧后端没这个字段时
+  // 退回「按起源课题反查库」（库与课题解耦后 project_id 会清空，届时只剩库列表兜底）。
+  const topicLib = useTopicLibrary(paper?.library_id ? null : paper?.project_id ?? null);
+  const paperLibId = paper?.library_id ?? topicLib?.id ?? null;
+  const libHref = (suffix: string) => (paperLibId ? libraryPath(paperLibId, suffix) : '/libraries');
   const onWikiLink = useCallback(
     (name: string) =>
-      navigate(topicLib ? libraryPath(topicLib.id, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
-    [navigate, topicLib],
+      navigate(paperLibId ? libraryPath(paperLibId, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
+    [navigate, paperLibId],
   );
 
   const onHighlightClick = useCallback((hlId: string) => {

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -313,10 +313,14 @@ function AddPaperModal({
 
 export function ExportMenu({
   pid,
+  libraryId,
   filters = {},
 }: {
-  pid: string;
-  /** 列表过滤条件，透传给引用导出；不传导出全部库内文献 */
+  /** 课题作用域（走 /projects/{pid}/export/*）；与 libraryId 二选一 */
+  pid?: string;
+  /** 库作用域（走 /libraries/{id}/export/*，独立库也可用）；优先于 pid */
+  libraryId?: string;
+  /** 列表过滤条件，透传给课题版引用导出；不传导出全部库内文献（库版不支持过滤） */
   filters?: { status?: PaperStatusFilter; tag?: string; starred?: boolean };
 }) {
   const [open, setOpen] = useState(false);
@@ -333,7 +337,8 @@ export function ExportMenu({
   }, [open]);
 
   const obsidianMutation = useMutation({
-    mutationFn: () => api.downloadObsidianExport(pid),
+    mutationFn: () =>
+      libraryId ? api.downloadLibraryObsidianExport(libraryId) : api.downloadObsidianExport(pid!),
     onSuccess: (blob) => {
       saveBlob(blob, 'polaris-wiki.zip');
       toast(tr('Obsidian 笔记库已导出', 'Obsidian vault exported'), 'ok');
@@ -343,7 +348,10 @@ export function ExportMenu({
   });
 
   const citationsMutation = useMutation({
-    mutationFn: (format: CitationFormat) => api.downloadCitations(pid, { format, ...filters }),
+    mutationFn: (format: CitationFormat) =>
+      libraryId
+        ? api.downloadLibraryCitations(libraryId, { format })
+        : api.downloadCitations(pid!, { format, ...filters }),
     onSuccess: (blob, format) => {
       saveBlob(blob, format === 'bibtex' ? 'polaris-references.bib' : 'polaris-references.json');
       toast(

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -31,7 +31,7 @@ type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | '
 export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: string }) {
   const navigate = useNavigate();
 
-  // 独立库（无起源课题）：集合级数据走 /libraries/{id}/* 端点，隐藏 PPT / 导出（均为课题域）。
+  // 独立库（无起源课题）：集合级数据与导出走 /libraries/{id}/* 端点；PPT 仍是课题域，隐藏。
   const standalone = !pid;
   const scopeId = standalone ? libraryId! : pid!;
   /** 传给各 Tab 的库作用域标识：仅独立库置位，课题库保持 undefined 走 project 端点。 */
@@ -168,14 +168,13 @@ export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: st
             </span>
           )}
           {!standalone && (
-            <>
-              <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
-                <Icon name="chart" size={13} />
-                {tr('论文分享 PPT', 'Paper sharing PPT')}
-              </button>
-              <ExportMenu pid={pid!} />
-            </>
+            <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
+              <Icon name="chart" size={13} />
+              {tr('论文分享 PPT', 'Paper sharing PPT')}
+            </button>
           )}
+          {/* 导出：课题走 project 端点，独立库走库作用域端点（PPT 仍是课题域，独立库隐藏） */}
+          <ExportMenu pid={pid} libraryId={tabLibraryId} />
         </div>
       </div>
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -646,6 +646,11 @@ export interface PaperRead {
   id: string;
   /** 本次访问解析出的课题上下文；书架/个人库可达的无库论文（个人补充）为 null */
   project_id: string | null;
+  /**
+   * 本次访问解析出的**文献库**（成员行所属库）；无库论文为 null（旧后端可能缺失）。
+   * 「这篇属于哪个库」直接看它——不要再用 project_id 反查库。
+   */
+  library_id?: string | null;
   title: string;
   authors: PaperAuthor[];
   /** 发表机构（OpenAlex 补充；可能为空） */
@@ -2908,6 +2913,12 @@ export const api = {
       method: 'POST',
     });
   },
+  /** 库作用域概念补建（独立库也可用；需该库管理权限）。 */
+  relinkLibraryConcepts(libraryId: string): Promise<ConceptRelinkResult> {
+    return request<ConceptRelinkResult>(`/libraries/${libraryId}/concepts/relink`, {
+      method: 'POST',
+    });
+  },
 
   // —— M2 · Search ——
   searchProject(
@@ -3239,6 +3250,10 @@ export const api = {
   rebuildFulltextIndex(projectId: string): Promise<RebuildIndexResult> {
     return request<RebuildIndexResult>(`/projects/${projectId}/index/rebuild`, { method: 'POST' });
   },
+  /** 库作用域全文索引重建（独立库也可用；需该库管理权限）。 */
+  rebuildLibraryFulltextIndex(libraryId: string): Promise<RebuildIndexResult> {
+    return request<RebuildIndexResult>(`/libraries/${libraryId}/index/rebuild`, { method: 'POST' });
+  },
   /** 可选全文索引：为本课题「相关研究」这批论文异步建全文索引（设置关时后端 409 INDEXING_DISABLED）。 */
   buildShelfIndex(projectId: string): Promise<QueuedIndexResult> {
     return requestJson<QueuedIndexResult>(`/projects/${projectId}/shelf/index/rebuild`, 'POST', {});
@@ -3251,6 +3266,10 @@ export const api = {
   // —— M2 · Obsidian 导出（zip blob） ——
   downloadObsidianExport(projectId: string): Promise<Blob> {
     return requestBlob(`/projects/${projectId}/export/obsidian`);
+  },
+  /** 库作用域 Obsidian 导出（独立库也可用；只读端点，全实验室可读）。 */
+  downloadLibraryObsidianExport(libraryId: string): Promise<Blob> {
+    return requestBlob(`/libraries/${libraryId}/export/obsidian`);
   },
 
   // —— M2 · Dashboard 统计 ——


### PR DESCRIPTION
Step 1 of the library/topic decoupling. Libraries are independent of topics, but three capabilities were still reachable only through a topic, so a standalone library could not use them at all.

## New endpoints

| Endpoint | Auth | Notes |
|---|---|---|
| `GET /libraries/{id}/export/obsidian` | read (`_get_visible_library`) | zip download, fixed ASCII filename (library names are Chinese and would break latin-1 header encoding, same as the existing citations export) |
| `POST /libraries/{id}/index/rebuild` | manage (`_get_managed_library`) | `ProgrammingError` maps to 503 `DB_MIGRATION_REQUIRED`, same as the topic form |
| `POST /libraries/{id}/concepts/relink` | manage | returns `ConceptRelinkResult` |

Each shares one core with its topic-scoped sibling so the two forms cannot drift:

- `wiki_export.build_obsidian_zip_for_libraries(...)` — `build_obsidian_zip(project)` is now a thin wrapper that resolves the topic's source libraries and passes the topic name as the index title.
- `chunks.rebuild_library_fulltext_index(...)` — the topic endpoint delegates to it, keeping its early return when a topic resolves to no origin library.

## `PaperRead.library_id`

Exposes the library a paper view resolved to. The reading page's back button and `[[wiki links]]` previously reverse-looked-up a library through `project_id`, which is only a provenance pointer since libraries were decoupled from topics.

`PaperView` forwards unknown attributes to the `Paper` ORM object, which has no `library_id`, so this needed an explicit property returning `membership.library_id`. Pool-reachable papers (shelf, personal library, daily feed) have a synthetic membership row with no library, so `library_id` is null there and callers keep their existing disabled-button branch.

## Scope

Additive only — no endpoint or helper removed, no auth rule changed, no migration. Removing the superseded topic-scoped routes and switching the cron over are later steps.

The relink and rebuild buttons are deliberately **not** wired up in the UI yet: `ConceptsTab` and friends are shared between the manage workbench and the read-only browse view, and both pass `libraryId`, so gating on `libraryId` alone would show 403-ing buttons to every reader of a public library. That needs an explicit `canManage` prop, which belongs to the next step. The export menu is wired, since it is read-scoped.

## Verification

- `ruff check app` clean
- 21 tests pass across `test_library_scoped_capabilities.py` (new, 6 tests), `test_shared_libraries.py`, `test_library_paper_management.py`
- Full backend suite: 167 passed
- `tsc --noEmit`: 0 errors

New tests cover the obsidian zip structure on a `project_id=NULL` library (index title, paper pages, excluded papers absent, `[[links]]` preserved, concept pages), readability by a non-manager, 404 for unknown ids, index-rebuild counts and idempotency, relink counts and idempotency, 403 for strangers on both manage endpoints, and `library_id` presence across list, library-scoped detail and `GET /papers/{id}`.
