### PR TITLE
refactor(i18n): rename 垃圾桶/垃圾箱 to 回收站 across the UI

### DIFF
--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -102,7 +102,7 @@ async def list_experiments(
 
 
 async def _manage_exp_project(session: AsyncSession, project_id: uuid.UUID, user: User):
-    """项目 + 管理权限（垃圾箱/删除用）。"""
+    """项目 + 管理权限（回收站/删除用）。"""
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
@@ -118,11 +118,11 @@ async def delete_experiment(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """默认移入垃圾箱；permanent=true 永久删除（删本地目录，远端 workdir 不动）。仅管理者。"""
+    """默认移入回收站；permanent=true 永久删除（删本地目录，远端 workdir 不动）。仅管理者。"""
     experiment, _ = await _member_experiment(session, experiment_id, user)
     await _manage_exp_project(session, experiment.project_id, user)
     if permanent:
-        # 先移入垃圾箱再清空（purge 只删已在垃圾箱的），保证本地目录也被清理
+        # 先移入回收站再清空（purge 只删已在回收站的），保证本地目录也被清理
         if experiment.trashed_at is None:
             await experiments_service.trash_experiments(
                 session, project_id=experiment.project_id, ids=[experiment.id]

--- a/src/backend/app/api/ideas.py
+++ b/src/backend/app/api/ideas.py
@@ -173,7 +173,7 @@ async def list_ideas(
 
 
 async def _manage_idea_project(session: AsyncSession, project_id: uuid.UUID, user: User) -> Project:
-    """项目 + 管理权限（垃圾箱/删除用）。"""
+    """项目 + 管理权限（回收站/删除用）。"""
     project = await _member_project(session, project_id, user)
     if not projects_service.can_manage_project(project, user):
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
@@ -187,7 +187,7 @@ async def delete_idea(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """默认移入垃圾箱；permanent=true 永久删除（级联其实验）。仅项目管理者。"""
+    """默认移入回收站；permanent=true 永久删除（级联其实验）。仅项目管理者。"""
     idea = await _member_idea(session, idea_id, user)
     await _manage_idea_project(session, idea.project_id, user)
     if permanent:

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -473,7 +473,7 @@ async def list_library_papers(
     """库内论文（分页/检索/排序/过滤）。缺省只列相关性达标的（status=library 组别名）。
 
     过滤参数与课题论文列表一致（星标/阅读状态/标签/作者/机构/发表与入库时间）；
-    ``status=excluded`` 取该库垃圾桶。P9e 起标签是库作用域，独立库同样可用。
+    ``status=excluded`` 取该库回收站。P9e 起标签是库作用域，独立库同样可用。
     """
     library = await _get_visible_library(session, library_id, user)
     items, total = await papers_service.list_papers(
@@ -538,7 +538,7 @@ async def _managed_library_paper_view(
     user: User,
     with_concepts: bool = False,
 ) -> papers_service.PaperView:
-    """可管理者精确锁定本库那份成员行（垃圾桶召回/彻底删除用；不跨库归并）。"""
+    """可管理者精确锁定本库那份成员行（回收站召回/彻底删除用；不跨库归并）。"""
     library = await _get_managed_library(session, library_id, user)
     view = await papers_service.get_library_paper_view(
         session,
@@ -559,7 +559,7 @@ async def restore_library_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
-    """从**指定库**的垃圾桶召回该篇（精确锁定本库成员行，不跨库归并）。"""
+    """从**指定库**的回收站召回该篇（精确锁定本库成员行，不跨库归并）。"""
     view = await _managed_library_paper_view(
         session, library_id=library_id, paper_id=paper_id, user=user, with_concepts=True
     )
@@ -687,7 +687,7 @@ async def export_library_citations(
     """库作用域引用导出：BibTeX / CSL-JSON（独立方向库也可用；读端点全实验室可读）。
 
     不传 ids 导出全库在库论文（缺省 status in compiled/included）；ids 指定时按 id
-    精确导出（多选导出），非成员/垃圾桶（excluded）不含。
+    精确导出（多选导出），非成员/回收站（excluded）不含。
     """
     library = await _get_visible_library(session, library_id, user)
     paper_ids: list[uuid.UUID] | None = None
@@ -803,7 +803,7 @@ async def empty_library_trash(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> dict[str, int]:
-    """清空该库垃圾桶：彻底删除库内全部已删除论文成员行。"""
+    """清空该库回收站：彻底删除库内全部已删除论文成员行。"""
     library = await _get_managed_library(session, library_id, user)
     deleted = await papers_service.empty_library_trash(session, library=library)
     return {"deleted": deleted}

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -407,7 +407,7 @@ async def update_manuscript(
 
 
 async def _manage_manuscript_project(session: AsyncSession, manuscript: Manuscript, user: User):
-    """稿件所属项目 + 管理权限校验（垃圾箱/删除用）。"""
+    """稿件所属项目 + 管理权限校验（回收站/删除用）。"""
     project = await projects_service.get_project(
         session, project_id=manuscript.project_id, user_id=user.id
     )
@@ -423,7 +423,7 @@ async def delete_manuscript(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """默认移入垃圾箱（软删除）；permanent=true 永久删除。"""
+    """默认移入回收站（软删除）；permanent=true 永久删除。"""
     manuscript = await _member_manuscript(session, manuscript_id, user)
     await _manage_manuscript_project(session, manuscript, user)
     if permanent:
@@ -441,7 +441,7 @@ async def restore_manuscript(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> ManuscriptRead:
-    """从垃圾箱恢复。"""
+    """从回收站恢复。"""
     manuscript = await _member_manuscript(session, manuscript_id, user)
     await _manage_manuscript_project(session, manuscript, user)
     await manuscripts_service.restore_manuscripts(
@@ -458,7 +458,7 @@ async def batch_manuscripts(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> BatchResult:
-    """批量：trash 移入垃圾箱 / restore 恢复 / delete 永久删除。仅项目管理者可操作。"""
+    """批量：trash 移入回收站 / restore 恢复 / delete 永久删除。仅项目管理者可操作。"""
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
@@ -485,7 +485,7 @@ async def empty_manuscript_trash(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> BatchResult:
-    """清空垃圾箱：永久删除该项目所有已在垃圾箱的稿件。"""
+    """清空回收站：永久删除该项目所有已在回收站的稿件。"""
     project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -338,7 +338,7 @@ async def _managed_project_library_view(
     user: User,
     with_concepts: bool = False,
 ) -> papers_service.PaperView:
-    """课题写作用域下精确锁定起源库那份成员行（垃圾桶召回/彻底删除用）。
+    """课题写作用域下精确锁定起源库那份成员行（回收站召回/彻底删除用）。
 
     对照无库作用域的 ``/papers/{id}``：那条走跨库归并，会命中错误的库那份成员行。
     """
@@ -365,7 +365,7 @@ async def restore_project_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
-    """从课题起源库的垃圾桶召回该篇（精确锁定本库成员行，不跨库归并）。"""
+    """从课题起源库的回收站召回该篇（精确锁定本库成员行，不跨库归并）。"""
     view = await _managed_project_library_view(
         session, project_id=project_id, paper_id=paper_id, user=user, with_concepts=True
     )
@@ -419,7 +419,7 @@ async def delete_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """彻底删除论文（垃圾桶里的「彻底删除」）：清理落盘文件，关联数据级联删除。"""
+    """彻底删除论文（回收站里的「彻底删除」）：清理落盘文件，关联数据级联删除。"""
     paper = await _get_member_paper(session, paper_id, user)
     await papers_service.delete_paper(session, paper)
 
@@ -430,7 +430,7 @@ async def restore_paper(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> PaperDetail:
-    """从垃圾桶召回：已编译回 compiled、打过分回 scored、否则按人工精选。"""
+    """从回收站召回：已编译回 compiled、打过分回 scored、否则按人工精选。"""
     paper = await _get_member_paper(session, paper_id, user, with_concepts=True)
     paper = await papers_service.restore_paper(session, paper)
     return await _paper_detail(session, paper, user.id)
@@ -445,7 +445,7 @@ async def batch_delete_papers(
 ) -> dict[str, int]:
     """批量删除项目内论文（非本项目的 id 忽略），返回 {deleted}。
 
-    默认软删（移入垃圾桶，可召回）；hard=true 彻底删除。
+    默认软删（移入回收站，可召回）；hard=true 彻底删除。
     """
     await _get_managed_project(session, project_id, user)
     deleted = await papers_service.delete_papers(
@@ -460,7 +460,7 @@ async def empty_trash(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> dict[str, int]:
-    """清空垃圾桶：彻底删除项目内全部已删除论文。"""
+    """清空回收站：彻底删除项目内全部已删除论文。"""
     await _get_managed_project(session, project_id, user)
     deleted = await papers_service.empty_trash(session, project_id=project_id)
     return {"deleted": deleted}

--- a/src/backend/app/models/experiment.py
+++ b/src/backend/app/models/experiment.py
@@ -45,7 +45,7 @@ class Experiment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # {"hypotheses": [{text, status}], "repro_strategy", "steps", "budget_estimate"}
     plan: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     status: Mapped[str] = mapped_column(String(32), default="planning", nullable=False)
-    # 软删除（垃圾箱）：非空即在垃圾箱，列表默认过滤
+    # 软删除（回收站）：非空即在回收站，列表默认过滤
     trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     workdir: Mapped[str | None] = mapped_column(String(1024))  # ~/polaris_runs/<exp_id>
     server_host: Mapped[str | None] = mapped_column(String(255))

--- a/src/backend/app/models/idea.py
+++ b/src/backend/app/models/idea.py
@@ -39,7 +39,7 @@ class Idea(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     wins: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     # candidate | under_review | promoted | rejected
     status: Mapped[str] = mapped_column(String(32), default="candidate", nullable=False)
-    # 软删除（垃圾箱）：非空即在垃圾箱，列表默认过滤
+    # 软删除（回收站）：非空即在回收站，列表默认过滤
     trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     parent_paper_ids: Mapped[list[Any] | None] = mapped_column(JSONVariant)
     # 语义去重用：postgres pgvector(1024)，sqlite 回退 JSON（同 papers.embedding）

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -100,7 +100,7 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     wiki_content: Mapped[str | None] = mapped_column(Text)  # 库版图文解读 markdown
     # 状态流转同 PAPER_STATUSES：candidate → scored|excluded → fetched → compiled；included 人工纳入
     status: Mapped[str] = mapped_column(String(32), default="candidate", nullable=False)
-    # 进垃圾桶的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
+    # 进回收站的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
     trash_reason: Mapped[str | None] = mapped_column(String(16))
     scored_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     compiled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/models/manuscript.py
+++ b/src/backend/app/models/manuscript.py
@@ -55,7 +55,7 @@ class Manuscript(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     review_passed: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )
-    # 软删除（垃圾箱）：非空即在垃圾箱，列表默认过滤掉；清空垃圾箱才真正删除
+    # 软删除（回收站）：非空即在回收站，列表默认过滤掉；清空回收站才真正删除
     trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # 置顶：非空即置顶，列表按 pinned_at 优先排在前面
     pinned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/src/backend/app/schemas/common.py
+++ b/src/backend/app/schemas/common.py
@@ -1,4 +1,4 @@
-"""通用 schema：垃圾箱批量操作等。"""
+"""通用 schema：回收站批量操作等。"""
 
 import uuid
 from typing import Literal
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 
 class TrashBatchAction(BaseModel):
-    """批量：trash 移入垃圾箱 / restore 恢复 / delete 永久删除。"""
+    """批量：trash 移入回收站 / restore 恢复 / delete 永久删除。"""
 
     action: Literal["trash", "restore", "delete"]
     ids: list[uuid.UUID] = Field(min_length=1, max_length=500)

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -43,7 +43,7 @@ class ExperimentRead(BaseModel):
     workdir: str | None
     server_host: str | None
     budget: dict[str, Any] | None
-    trashed_at: datetime | None = None  # 非空即在垃圾箱
+    trashed_at: datetime | None = None  # 非空即在回收站
     created_at: datetime
     updated_at: datetime
 

--- a/src/backend/app/schemas/idea.py
+++ b/src/backend/app/schemas/idea.py
@@ -86,7 +86,7 @@ class IdeaRead(BaseModel):
     status: str  # candidate | under_review | promoted | rejected
     depth: str  # sketch | proposal
     research_type: str | None  # method | benchmark | analysis | survey | application | theory
-    trashed_at: datetime | None = None  # 非空即在垃圾箱
+    trashed_at: datetime | None = None  # 非空即在回收站
     created_at: datetime
 
 

--- a/src/backend/app/schemas/manuscript.py
+++ b/src/backend/app/schemas/manuscript.py
@@ -56,7 +56,7 @@ CompileEngine = Literal["tectonic", "pdflatex", "xelatex", "lualatex"]
 
 
 class ManuscriptBatchAction(BaseModel):
-    """批量操作稿件：trash 移入垃圾箱 / restore 恢复 / delete 永久删除。"""
+    """批量操作稿件：trash 移入回收站 / restore 恢复 / delete 永久删除。"""
 
     action: Literal["trash", "restore", "delete"]
     ids: list[uuid.UUID] = Field(min_length=1, max_length=500)
@@ -87,7 +87,7 @@ class ManuscriptRead(BaseModel):
     engine: str  # 编译器 tectonic | pdflatex | xelatex | lualatex
     status: str
     review_passed: bool  # M5-C：评审通过标记（submit 前置）
-    trashed_at: datetime | None = None  # 非空即在垃圾箱
+    trashed_at: datetime | None = None  # 非空即在回收站
     pinned_at: datetime | None = None  # 非空即置顶
     created_at: datetime
     updated_at: datetime

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -49,7 +49,7 @@ class PaperRead(BaseModel):
     published_at: datetime | None
     relevance_score: float | None
     status: str
-    # 垃圾桶原因（status=excluded 时有值）：irrelevant 相关性不足 | manual 手动删除
+    # 回收站原因（status=excluded 时有值）：irrelevant 相关性不足 | manual 手动删除
     trash_reason: str | None = None
     tldr: str | None
     has_wiki: bool = False
@@ -146,7 +146,7 @@ class PaperBatchIds(BaseModel):
     """批量操作（删除/导出）的论文 id 列表。"""
 
     paper_ids: list[uuid.UUID] = Field(min_length=1, max_length=500)
-    # 批量删除：默认软删（移入垃圾桶，可召回）；true = 彻底删除
+    # 批量删除：默认软删（移入回收站，可召回）；true = 彻底删除
     hard: bool = False
 
 

--- a/src/backend/app/services/citations.py
+++ b/src/backend/app/services/citations.py
@@ -241,7 +241,7 @@ async def papers_for_library_export(
     """库作用域导出对象：某方向库的在库成员论文（独立方向库也可用）。
 
     缺省 status in (compiled, included)；paper_ids 指定时按 id 精确导出（多选导出），
-    仍排除该库垃圾桶（excluded）与非成员。单库无需跨库归并（每篇至多一行）。
+    仍排除该库回收站（excluded）与非成员。单库无需跨库归并（每篇至多一行）。
     """
     library_ids = [library_id]
     stmt = apply_paper_filters(

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -254,7 +254,7 @@ async def restore_experiments(
 async def purge_experiments(
     session: AsyncSession, *, project_id: uuid.UUID, ids: list[uuid.UUID] | None = None
 ) -> int:
-    """永久删除。ids=None → 清空该项目垃圾箱。删本地目录（日志/图）；runs 走 DB 级联。
+    """永久删除。ids=None → 清空该项目回收站。删本地目录（日志/图）；runs 走 DB 级联。
     远端 workdir 不动（best-effort，避免误删共享服务器）。返回删除数量。"""
     if ids is None:
         rows = [

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -402,7 +402,7 @@ async def _owned_ideas(
 
 
 async def trash_ideas(session: AsyncSession, *, project_id: uuid.UUID, ids: list[uuid.UUID]) -> int:
-    """移入垃圾箱（软删除）；返回受影响数量。"""
+    """移入回收站（软删除）；返回受影响数量。"""
     now = datetime.now(UTC)
     n = 0
     for idea in await _owned_ideas(session, project_id=project_id, ids=ids):
@@ -428,7 +428,7 @@ async def restore_ideas(
 async def purge_ideas(
     session: AsyncSession, *, project_id: uuid.UUID, ids: list[uuid.UUID] | None = None
 ) -> int:
-    """永久删除。ids=None → 清空该项目垃圾箱；否则只删指定 id 中已在垃圾箱的。
+    """永久删除。ids=None → 清空该项目回收站；否则只删指定 id 中已在回收站的。
     级联删除其实验（DB FK ondelete=CASCADE）。返回删除数量。"""
     if ids is None:
         rows = await list_ideas(session, project_id=project_id, trashed=True)

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -523,7 +523,7 @@ async def initialize_structure(
 async def list_manuscripts(
     session: AsyncSession, *, project_id: uuid.UUID, trashed: bool = False
 ) -> list[Manuscript]:
-    """项目下的稿件；trashed=False 只列未删除（置顶优先），True 只列垃圾箱。"""
+    """项目下的稿件；trashed=False 只列未删除（置顶优先），True 只列回收站。"""
     cond = Manuscript.trashed_at.is_not(None) if trashed else Manuscript.trashed_at.is_(None)
     stmt = select(Manuscript).where(Manuscript.project_id == project_id, cond)
     if trashed:
@@ -546,7 +546,7 @@ async def _owned_manuscripts(
 async def trash_manuscripts(
     session: AsyncSession, *, project_id: uuid.UUID, ids: list[uuid.UUID]
 ) -> int:
-    """移入垃圾箱（软删除）；返回受影响数量。"""
+    """移入回收站（软删除）；返回受影响数量。"""
     rows = await _owned_manuscripts(session, project_id=project_id, ids=ids)
     now = datetime.now(UTC)
     n = 0
@@ -561,7 +561,7 @@ async def trash_manuscripts(
 async def restore_manuscripts(
     session: AsyncSession, *, project_id: uuid.UUID, ids: list[uuid.UUID]
 ) -> int:
-    """从垃圾箱恢复；返回受影响数量。"""
+    """从回收站恢复；返回受影响数量。"""
     rows = await _owned_manuscripts(session, project_id=project_id, ids=ids)
     n = 0
     for m in rows:
@@ -578,8 +578,8 @@ async def purge_manuscripts(
     project_id: uuid.UUID,
     ids: list[uuid.UUID] | None = None,
 ) -> int:
-    """永久删除。ids=None → 清空该项目垃圾箱（删所有已在垃圾箱的稿件）；
-    否则只永久删除指定 id 中已在垃圾箱的稿件（避免误删未删除的）。返回删除数量。"""
+    """永久删除。ids=None → 清空该项目回收站（删所有已在回收站的稿件）；
+    否则只永久删除指定 id 中已在回收站的稿件（避免误删未删除的）。返回删除数量。"""
     if ids is None:
         rows = await list_manuscripts(session, project_id=project_id, trashed=True)
     else:

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -53,7 +53,7 @@ PAPER_SORTS = ("relevance", "-published_at")
 RERANK_CANDIDATES = 30
 RERANK_DOC_CHARS = 512
 
-# status 组别名：可见（检索到的全部，不含垃圾桶）/ 库内（相关性达标及之后）/
+# status 组别名：可见（检索到的全部，不含回收站）/ 库内（相关性达标及之后）/
 # 待编译（达标但未编译）/ 已编译（含人工纳入的历史数据）
 PAPER_STATUS_GROUPS: dict[str, tuple[str, ...]] = {
     "visible": ("candidate", "scored", "fetched", "compiled", "included"),
@@ -674,7 +674,7 @@ async def gc_orphan_papers(session: AsyncSession, paper_ids: Sequence[uuid.UUID]
 
 
 async def delete_paper(session: AsyncSession, view: PaperView) -> None:
-    """从当前方向库彻底移除一篇论文（垃圾桶里的「彻底删除」）。
+    """从当前方向库彻底移除一篇论文（回收站里的「彻底删除」）。
 
     删本库成员行与标签关联，收尾清理库内零引用标签；若这是该论文最后一处引用（别的
     库/书架/个人库/推送/论著都没有了），连内容池本体与落盘文件一并回收（孤儿清理）。
@@ -728,9 +728,9 @@ async def delete_papers(
 ) -> int:
     """批量删除项目库内论文（非本库的 id 忽略），返回处理数。
 
-    默认软删（移入垃圾桶 = 成员行 status excluded，可召回）；hard=True 删成员行。
+    默认软删（移入回收站 = 成员行 status excluded，可召回）；hard=True 删成员行。
     """
-    # 删除/垃圾桶是课题「自己那份库」的管理操作，落在起源库上（不动共享库）
+    # 删除/回收站是课题「自己那份库」的管理操作，落在起源库上（不动共享库）
     library = await get_library_for_project(session, project_id)
     if library is None:
         return 0
@@ -759,7 +759,7 @@ async def delete_library_papers(
 
 
 def restore_status_of(membership: LibraryPaper) -> str:
-    """垃圾桶召回后的状态：已编译回 compiled；打过分回 scored；否则按人工精选处理。"""
+    """回收站召回后的状态：已编译回 compiled；打过分回 scored；否则按人工精选处理。"""
     if membership.wiki_content:
         return "compiled"
     if membership.relevance_score is not None:
@@ -768,7 +768,7 @@ def restore_status_of(membership: LibraryPaper) -> str:
 
 
 async def restore_paper(session: AsyncSession, view: PaperView) -> PaperView:
-    """从垃圾桶召回（docs/api-lit.md §8.6）。"""
+    """从回收站召回（docs/api-lit.md §8.6）。"""
     view.membership.status = restore_status_of(view.membership)
     view.membership.trash_reason = None
     await session.commit()
@@ -799,7 +799,7 @@ async def _empty_trash_core(session: AsyncSession, *, library_id: uuid.UUID) -> 
 
 
 async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
-    """清空垃圾桶：彻底移除库内全部 excluded 成员行，返回删除数。"""
+    """清空回收站：彻底移除库内全部 excluded 成员行，返回删除数。"""
     library = await get_library_for_project(session, project_id)
     if library is None:
         return 0
@@ -807,7 +807,7 @@ async def empty_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
 
 
 async def empty_library_trash(session: AsyncSession, *, library: Any) -> int:
-    """清空某方向库的垃圾桶（库工作台入口，含独立库）。"""
+    """清空某方向库的回收站（库工作台入口，含独立库）。"""
     return await _empty_trash_core(session, library_id=library.id)
 
 

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -82,7 +82,7 @@ const ExperimentCard = memo(function ExperimentCard({
   const pct = expProgress(exp.status);
   const barColor =
     exp.status === 'failed' ? 'var(--danger)' : exp.status === 'cancelled' ? 'var(--text-4)' : exp.status === 'done' ? 'var(--ok)' : 'var(--accent)';
-  // 多选：整卡点击 = 切换选择；否则活动卡点击打开详情，垃圾箱卡不可点。
+  // 多选：整卡点击 = 切换选择；否则活动卡点击打开详情，回收站卡不可点。
   const activate = multiSelect ? onToggleSelect : isTrash ? undefined : onOpen;
   return (
     <div
@@ -158,7 +158,7 @@ const ExperimentCard = memo(function ExperimentCard({
           <div className="row" style={{ marginTop: 10, justifyContent: 'flex-end' }}>
             <button
               className="btn btn-ghost sm"
-              title={tr('移入垃圾箱', 'Move to trash')}
+              title={tr('移入回收站', 'Move to trash')}
               style={{ color: 'var(--text-3)', padding: '0 7px', visibility: multiSelect ? 'hidden' : 'visible' }}
               onClick={(e) => {
                 e.stopPropagation();
@@ -270,7 +270,7 @@ export function ExperimentPage() {
     mutationFn: (id: string) => api.trashExperiment(id),
     onSuccess: () => {
       invalidateAll();
-      toast(tr('已移入垃圾箱', 'Moved to trash'), 'ok');
+      toast(tr('已移入回收站', 'Moved to trash'), 'ok');
     },
     onError: onMutError,
   });
@@ -296,7 +296,7 @@ export function ExperimentPage() {
     onSuccess: (r) => {
       invalidateAll();
       clearSelection();
-      toast(`${tr('已移入垃圾箱', 'Moved to trash')} · ${r.affected}`, 'ok');
+      toast(`${tr('已移入回收站', 'Moved to trash')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
   });
@@ -324,7 +324,7 @@ export function ExperimentPage() {
     onSuccess: (r) => {
       invalidateAll();
       clearSelection();
-      toast(`${tr('垃圾箱已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
+      toast(`${tr('回收站已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
     onSettled: () => setConfirm(null),
@@ -358,7 +358,7 @@ export function ExperimentPage() {
             onChange={setView}
             options={[
               { v: 'active', label: tr('实验列表', 'Experiments') },
-              { v: 'trash', label: `${tr('垃圾箱', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
+              { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
             ]}
           />
           <button
@@ -386,9 +386,9 @@ export function ExperimentPage() {
               style={{ marginLeft: 'auto', color: 'var(--danger)' }}
               onClick={() =>
                 setConfirm({
-                  title: tr('清空垃圾箱', 'Empty trash'),
+                  title: tr('清空回收站', 'Empty trash'),
                   message: tr(
-                    `将永久删除垃圾箱内全部 ${trashCount} 个实验，不可恢复。确定继续？`,
+                    `将永久删除回收站内全部 ${trashCount} 个实验，不可恢复。确定继续？`,
                     `This permanently deletes all ${trashCount} experiment(s) in the trash. This cannot be undone. Continue?`,
                   ),
                   confirmText: tr('清空', 'Empty'),
@@ -397,7 +397,7 @@ export function ExperimentPage() {
               }
             >
               <Icon name="trash" size={13} />
-              {tr('清空垃圾箱', 'Empty trash')}
+              {tr('清空回收站', 'Empty trash')}
             </button>
           )}
         </div>
@@ -411,7 +411,7 @@ export function ExperimentPage() {
         </div>
       ) : isLoading ? (
         <div className="card">
-          <div className="empty" style={{ padding: 60 }}>{view === 'trash' ? tr('加载垃圾箱…', 'Loading trash…') : tr('加载实验列表…', 'Loading experiments…')}</div>
+          <div className="empty" style={{ padding: 60 }}>{view === 'trash' ? tr('加载回收站…', 'Loading trash…') : tr('加载实验列表…', 'Loading experiments…')}</div>
         </div>
       ) : isError ? (
         <div className="card">
@@ -429,7 +429,7 @@ export function ExperimentPage() {
             <EmptyState
               compact
               icon="trash"
-              title={tr('垃圾箱是空的', 'Trash is empty')}
+              title={tr('回收站是空的', 'Trash is empty')}
               desc={tr('删除的实验会先进这里，可恢复或永久删除。', 'Deleted experiments land here first — restore them or delete permanently.')}
             />
           ) : (

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -159,7 +159,7 @@ const CandidateCard = memo(function CandidateCard({
   onDelete: () => void;
 }) {
   const isTrash = mode === 'trash';
-  // 多选：整卡点击 = 切换选择；否则活动卡点击打开详情，垃圾箱卡不可点。
+  // 多选：整卡点击 = 切换选择；否则活动卡点击打开详情，回收站卡不可点。
   const activate = multiSelect ? onToggleSelect : isTrash ? undefined : onOpen;
   return (
     <div
@@ -259,7 +259,7 @@ const CandidateCard = memo(function CandidateCard({
           )}
           <button
             className="btn btn-ghost sm"
-            title={tr('移入垃圾箱', 'Move to trash')}
+            title={tr('移入回收站', 'Move to trash')}
             style={{ marginLeft: 'auto', color: 'var(--text-3)', padding: '0 7px', visibility: multiSelect ? 'hidden' : 'visible' }}
             onClick={(e) => {
               e.stopPropagation();
@@ -493,7 +493,7 @@ export function ForgePage() {
     mutationFn: (id: string) => api.trashIdea(id),
     onSuccess: () => {
       invalidateIdeas();
-      toast(tr('已移入垃圾箱', 'Moved to trash'), 'ok');
+      toast(tr('已移入回收站', 'Moved to trash'), 'ok');
     },
     onError: onMutError,
   });
@@ -519,7 +519,7 @@ export function ForgePage() {
     onSuccess: (r) => {
       invalidateIdeas();
       clearSelection();
-      toast(`${tr('已移入垃圾箱', 'Moved to trash')} · ${r.affected}`, 'ok');
+      toast(`${tr('已移入回收站', 'Moved to trash')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
   });
@@ -547,7 +547,7 @@ export function ForgePage() {
     onSuccess: (r) => {
       invalidateIdeas();
       clearSelection();
-      toast(`${tr('垃圾箱已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
+      toast(`${tr('回收站已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
     onSettled: () => setConfirm(null),
@@ -721,7 +721,7 @@ export function ForgePage() {
                 onChange={setView}
                 options={[
                   { v: 'active', label: tr('想法列表', 'Ideas') },
-                  { v: 'trash', label: `${tr('垃圾箱', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
+                  { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
                 ]}
               />
               <button
@@ -749,9 +749,9 @@ export function ForgePage() {
                   style={{ color: 'var(--danger)' }}
                   onClick={() =>
                     setConfirm({
-                      title: tr('清空垃圾箱', 'Empty trash'),
+                      title: tr('清空回收站', 'Empty trash'),
                       message: tr(
-                        `将永久删除垃圾箱内全部 ${trashCount} 条想法，不可恢复。确定继续？`,
+                        `将永久删除回收站内全部 ${trashCount} 条想法，不可恢复。确定继续？`,
                         `This permanently deletes all ${trashCount} idea(s) in the trash. This cannot be undone. Continue?`,
                       ),
                       confirmText: tr('清空', 'Empty'),
@@ -760,7 +760,7 @@ export function ForgePage() {
                   }
                 >
                   <Icon name="trash" size={13} />
-                  {tr('清空垃圾箱', 'Empty trash')}
+                  {tr('清空回收站', 'Empty trash')}
                 </button>
               )}
             </>
@@ -807,7 +807,7 @@ export function ForgePage() {
         </div>
       ) : listQuery.isLoading ? (
         <div className="card">
-          <div className="empty">{view === 'trash' ? tr('加载垃圾箱…', 'Loading trash…') : tr('加载候选池…', 'Loading candidates…')}</div>
+          <div className="empty">{view === 'trash' ? tr('加载回收站…', 'Loading trash…') : tr('加载候选池…', 'Loading candidates…')}</div>
         </div>
       ) : listQuery.isError ? (
         <div className="card">
@@ -829,7 +829,7 @@ export function ForgePage() {
             <EmptyState
               compact
               icon="trash"
-              title={tr('垃圾箱是空的', 'Trash is empty')}
+              title={tr('回收站是空的', 'Trash is empty')}
               desc={tr('删除的想法会先进这里，可恢复或永久删除。', 'Deleted ideas land here first — restore them or delete permanently.')}
             />
           ) : (

--- a/src/frontend/src/features/library/PublicationsTab.tsx
+++ b/src/frontend/src/features/library/PublicationsTab.tsx
@@ -181,7 +181,7 @@ function PubRow({
   );
 }
 
-/** 发表列表的包裹容器：圆角描边，内部行用分隔线（同垃圾桶列表）。 */
+/** 发表列表的包裹容器：圆角描边，内部行用分隔线（同回收站列表）。 */
 function PubList({ children }: { children: ReactNode }) {
   return (
     <div style={{ border: '0.5px solid var(--border)', borderRadius: 10, overflow: 'hidden' }}>

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -52,7 +52,7 @@ import { PaperProgressModal } from '../library/PaperProgressModal';
 const PAGE_SIZE = 20;
 
 /** 论文库视图（docs/api-lit.md §8.5）：全部 = 已纳入（相关性达标）的文献；
-    相关性不足的进垃圾桶，不显示不计数。 */
+    相关性不足的进回收站，不显示不计数。 */
 type ViewFilter = 'all' | 'compiled' | 'starred';
 
 // 模块级常量存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
@@ -62,7 +62,7 @@ const VIEW_FILTERS: { v: ViewFilter; zh: string; en: string; hintZh: string; hin
   { v: 'starred', zh: '已星标', en: 'Starred', hintZh: '我加了星标的文献', hintEn: 'Papers I starred' },
 ];
 
-/** 视图 → 列表查询参数（未纳入/垃圾桶文献一律不出现在论文库）。 */
+/** 视图 → 列表查询参数（未纳入/回收站文献一律不出现在论文库）。 */
 function viewQuery(view: ViewFilter): { status: PaperStatusFilter; starred?: boolean } {
   if (view === 'compiled') return { status: 'compiled_any' };
   if (view === 'starred') return { status: 'library', starred: true };
@@ -445,7 +445,7 @@ export function ExportMenu({
   );
 }
 
-/* ---------------- 垃圾桶 ---------------- */
+/* ---------------- 回收站 ---------------- */
 
 function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?: string; open: boolean; onClose: () => void }) {
   const queryClient = useQueryClient();
@@ -507,7 +507,7 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
   const emptyMutation = useMutation({
     mutationFn: () => (libraryId ? api.emptyLibraryTrash(libraryId) : api.emptyTrash(pid)),
     onSuccess: (res) => {
-      toast(tr(`垃圾桶已清空（${res.deleted} 篇）`, `Trash emptied (${res.deleted} papers)`), 'ok');
+      toast(tr(`回收站已清空（${res.deleted} 篇）`, `Trash emptied (${res.deleted} papers)`), 'ok');
       setConfirmEmpty(false);
       invalidate();
     },
@@ -521,7 +521,7 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
     <Modal
       open={open}
       onClose={onClose}
-      title={tr('垃圾桶', 'Trash')}
+      title={tr('回收站', 'Trash')}
       sub={tr(
         '相关性不足自动淘汰与手动删除的文献；召回后回到论文库',
         'Papers auto-dropped for low relevance or deleted manually; restoring puts them back in the library',
@@ -558,7 +558,7 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
                 onClick={() => setConfirmEmpty(true)}
               >
                 <Icon name="x" size={12} />
-                {tr('清空垃圾桶', 'Empty trash')}
+                {tr('清空回收站', 'Empty trash')}
               </button>
               <button className="btn btn-soft sm" onClick={onClose}>
                 {tr('关闭', 'Close')}
@@ -582,7 +582,7 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
       {trashQuery.isLoading ? (
         <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
       ) : allItems.length === 0 ? (
-        <div className="empty" style={{ padding: 24 }}>{tr('垃圾桶是空的', 'Trash is empty')}</div>
+        <div className="empty" style={{ padding: 24 }}>{tr('回收站是空的', 'Trash is empty')}</div>
       ) : items.length === 0 ? (
         <div className="empty" style={{ padding: 24 }}>{tr('没有匹配的文献', 'No matching papers')}</div>
       ) : (
@@ -615,13 +615,13 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
   );
 }
 
-/** 垃圾桶原因标签：打分淘汰 = 不相关；否则视为手动删除（老数据缺字段时按分数推断）。 */
+/** 回收站原因标签：打分淘汰 = 不相关；否则视为手动删除（老数据缺字段时按分数推断）。 */
 function trashReasonOf(p: PaperRead): 'irrelevant' | 'manual' {
   if (p.trash_reason === 'manual' || p.trash_reason === 'irrelevant') return p.trash_reason;
   return p.relevance_score !== null ? 'irrelevant' : 'manual';
 }
 
-/** 垃圾桶列表行：与论文库 PaperRow 同款版式，标签换成删除原因，右侧召回/彻底删除。 */
+/** 回收站列表行：与论文库 PaperRow 同款版式，标签换成删除原因，右侧召回/彻底删除。 */
 function TrashRow({
   p,
   last,
@@ -960,7 +960,7 @@ function PaperDetailPane({
         ? api.batchDeleteLibraryPapers(libraryId, [paperId])
         : api.batchDeletePapers(scopeId, [paperId]),
     onSuccess: () => {
-      toast(tr('已移入垃圾桶，可在列表底部的垃圾桶中召回', 'Moved to trash — restore it from the trash any time'), 'ok');
+      toast(tr('已移入回收站，可在列表底部的回收站中召回', 'Moved to trash — restore it from the trash any time'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['paper', scopeId, paperId] });
       void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
       void queryClient.invalidateQueries({ queryKey: ['papers-trash', scopeId] });
@@ -1105,7 +1105,7 @@ function PaperDetailPane({
         <button
           className="btn btn-ghost sm"
           style={{ color: 'var(--danger-tx)' }}
-          title={tr('移入垃圾桶（可召回）', 'Move to trash (restorable)')}
+          title={tr('移入回收站（可召回）', 'Move to trash (restorable)')}
           disabled={deleteMutation.isPending}
           onClick={() => deleteMutation.mutate()}
         >
@@ -1432,7 +1432,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   const bulkDeleteMutation = useMutation({
     mutationFn: () => (libraryId ? api.batchDeleteLibraryPapers(libraryId, [...selected]) : api.batchDeletePapers(scopeId, [...selected])),
     onSuccess: (res) => {
-      toast(tr(`已把 ${res.deleted} 篇移入垃圾桶，可召回`, `Moved ${res.deleted} papers to trash — restorable`), 'ok');
+      toast(tr(`已把 ${res.deleted} 篇移入回收站，可召回`, `Moved ${res.deleted} papers to trash — restorable`), 'ok');
       if (selectedId && selected.has(selectedId)) onSelect('');
       setSelected(new Set());
       setSelectMode(false);
@@ -1655,11 +1655,11 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
             <span
               className="chip"
               style={{ marginLeft: 'auto', gap: 5 }}
-              title={tr('垃圾桶：已删除的文献，可召回或彻底删除', 'Trash: deleted papers — restore or delete forever')}
+              title={tr('回收站：已删除的文献，可召回或彻底删除', 'Trash: deleted papers — restore or delete forever')}
               onClick={() => setTrashOpen(true)}
             >
               <Icon name="trash" size={12} />
-              {tr('垃圾桶', 'Trash')}
+              {tr('回收站', 'Trash')}
             </span>
           </div>
           {/* 标签（库作用域，课题/独立库通用）/ 阅读状态过滤 */}
@@ -1858,7 +1858,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
       {/* —— 添加文献 Modal —— */}
       <AddPaperModal pid={pid ?? ''} libraryId={libraryId} open={addOpen} onClose={() => setAddOpen(false)} onImported={onSelect} />
 
-      {/* —— 垃圾桶 —— */}
+      {/* —— 回收站 —— */}
       <TrashModal pid={pid ?? ''} libraryId={libraryId} open={trashOpen} onClose={() => setTrashOpen(false)} />
     </div>
   );

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -19,7 +19,7 @@ import { saveBlob } from '../wiki/shared';
 /* ============================================================
    /writer — Stage 04 · Paper Writer（M5-B）列表视图。
    项目内论文卡（标题 / 模板 / 状态 / 更新时间）+ 新建论文草稿。
-   支持多选批量删除、垃圾箱（软删除 / 恢复 / 永久删除 / 清空）。
+   支持多选批量删除、回收站（软删除 / 恢复 / 永久删除 / 清空）。
    ============================================================ */
 
 type ViewMode = 'active' | 'trash';
@@ -225,7 +225,7 @@ function ManuscriptCard({
               onClick={onExport}
               disabled={exporting}
             />
-            <CardAction icon="trash" title={tr('移入垃圾箱', 'Move to trash')} onClick={onTrash} />
+            <CardAction icon="trash" title={tr('移入回收站', 'Move to trash')} onClick={onTrash} />
           </div>
         </div>
       )}
@@ -312,7 +312,7 @@ export function WriterPage() {
     mutationFn: (id: string) => api.trashManuscript(id),
     onSuccess: () => {
       invalidateAll();
-      toast(tr('已移入垃圾箱', 'Moved to trash'), 'ok');
+      toast(tr('已移入回收站', 'Moved to trash'), 'ok');
     },
     onError: onMutError,
   });
@@ -356,7 +356,7 @@ export function WriterPage() {
     onSuccess: (r) => {
       invalidateAll();
       clearSelection();
-      toast(`${tr('已移入垃圾箱', 'Moved to trash')} · ${r.affected}`, 'ok');
+      toast(`${tr('已移入回收站', 'Moved to trash')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
   });
@@ -384,7 +384,7 @@ export function WriterPage() {
     onSuccess: (r) => {
       invalidateAll();
       clearSelection();
-      toast(`${tr('垃圾箱已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
+      toast(`${tr('回收站已清空', 'Trash emptied')} · ${r.affected}`, 'ok');
     },
     onError: onMutError,
     onSettled: () => setConfirm(null),
@@ -419,7 +419,7 @@ export function WriterPage() {
             onChange={(v) => setView(v)}
             options={[
               { v: 'active', label: tr('论文列表', 'Manuscripts') },
-              { v: 'trash', label: `${tr('垃圾箱', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
+              { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
             ]}
           />
           <button
@@ -447,9 +447,9 @@ export function WriterPage() {
               style={{ marginLeft: 'auto', color: 'var(--danger)' }}
               onClick={() =>
                 setConfirm({
-                  title: tr('清空垃圾箱', 'Empty trash'),
+                  title: tr('清空回收站', 'Empty trash'),
                   message: tr(
-                    `将永久删除垃圾箱内全部 ${trashCount} 篇论文草稿，不可恢复。确定继续？`,
+                    `将永久删除回收站内全部 ${trashCount} 篇论文草稿，不可恢复。确定继续？`,
                     `This permanently deletes all ${trashCount} manuscript(s) in the trash. This cannot be undone. Continue?`,
                   ),
                   confirmText: tr('清空', 'Empty'),
@@ -458,7 +458,7 @@ export function WriterPage() {
               }
             >
               <Icon name="trash" size={13} />
-              {tr('清空垃圾箱', 'Empty trash')}
+              {tr('清空回收站', 'Empty trash')}
             </button>
           )}
         </div>
@@ -490,7 +490,7 @@ export function WriterPage() {
             <EmptyState
               compact
               icon="trash"
-              title={tr('垃圾箱是空的', 'Trash is empty')}
+              title={tr('回收站是空的', 'Trash is empty')}
               desc={tr('删除的论文草稿会先进这里，可恢复或永久删除。', 'Deleted manuscripts land here first — restore them or delete permanently.')}
             />
           ) : (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -625,7 +625,7 @@ export interface LlmCallLogDetail {
 
 export type PaperStatus = 'candidate' | 'scored' | 'excluded' | 'fetched' | 'compiled' | 'included';
 
-/** 状态组别名（docs/api-lit.md §8.5）：visible=检索到的全部（不含垃圾桶）；
+/** 状态组别名（docs/api-lit.md §8.5）：visible=检索到的全部（不含回收站）；
     library=库内（达标及之后）；pending_compile=待编译。 */
 export type PaperStatusFilter =
   | PaperStatus
@@ -659,7 +659,7 @@ export interface PaperRead {
   /** 0-1，未打分为 null */
   relevance_score: number | null;
   status: PaperStatus;
-  /** 垃圾桶原因（status=excluded 时有值）：irrelevant 相关性不足 | manual 手动删除 */
+  /** 回收站原因（status=excluded 时有值）：irrelevant 相关性不足 | manual 手动删除 */
   trash_reason?: 'irrelevant' | 'manual' | null;
   tldr: string | null;
   has_wiki: boolean;
@@ -1180,7 +1180,7 @@ export interface IdeaRead {
   /** 研究类型（method/benchmark/…）；草案通常为 null */
   research_type: string | null;
   created_at: string;
-  /** 软删除时间戳；null=活动，非 null=在垃圾箱 */
+  /** 软删除时间戳；null=活动，非 null=在回收站 */
   trashed_at?: string | null;
 }
 
@@ -1445,7 +1445,7 @@ export interface ExperimentRead {
   budget: ExperimentBudget | null;
   created_at: string;
   updated_at: string;
-  /** 软删除时间戳；null=活动，非 null=在垃圾箱 */
+  /** 软删除时间戳；null=活动，非 null=在回收站 */
   trashed_at?: string | null;
 }
 
@@ -1701,7 +1701,7 @@ export interface ManuscriptRead {
   review_passed?: boolean;
   created_at: string;
   updated_at: string;
-  /** 移入垃圾箱的时间；null / 缺失表示未删除（仍在活动列表）。 */
+  /** 移入回收站的时间；null / 缺失表示未删除（仍在活动列表）。 */
   trashed_at?: string | null;
   /** 置顶时间；非空即置顶（活动列表里置顶项排在最前）。 */
   pinned_at?: string | null;
@@ -2778,14 +2778,14 @@ export const api = {
   deletePaper(id: string): Promise<void> {
     return request<void>(`/papers/${id}`, { method: 'DELETE' });
   },
-  /** 批量删除：默认软删（移入垃圾桶，可召回）；hard=true 彻底删除。 */
+  /** 批量删除：默认软删（移入回收站，可召回）；hard=true 彻底删除。 */
   batchDeletePapers(projectId: string, paperIds: string[], hard = false): Promise<{ deleted: number }> {
     return requestJson<{ deleted: number }>(`/projects/${projectId}/papers/batch-delete`, 'POST', {
       paper_ids: paperIds,
       hard,
     });
   },
-  /** 从垃圾桶召回（已编译回 compiled、打过分回 scored、否则按人工精选）。 */
+  /** 从回收站召回（已编译回 compiled、打过分回 scored、否则按人工精选）。 */
   restorePaper(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}/restore`, { method: 'POST' });
   },
@@ -2796,7 +2796,7 @@ export const api = {
   deleteProjectPaper(projectId: string, paperId: string): Promise<void> {
     return request<void>(`/projects/${projectId}/papers/${paperId}`, { method: 'DELETE' });
   },
-  /** 清空垃圾桶：彻底删除项目内全部已删除论文。 */
+  /** 清空回收站：彻底删除项目内全部已删除论文。 */
   emptyTrash(projectId: string): Promise<{ deleted: number }> {
     return request<{ deleted: number }>(`/projects/${projectId}/trash/empty`, { method: 'POST' });
   },
@@ -3072,7 +3072,7 @@ export const api = {
   },
 
   // —— P9d · 独立库文献管理台（镜像 project 作用域的集合端点） ——
-  /** 库内论文（全过滤维度，同 listPapers）；status=excluded 为垃圾桶。 */
+  /** 库内论文（全过滤维度，同 listPapers）；status=excluded 为回收站。 */
   listLibraryPapersFull(
     id: string,
     opts: {
@@ -3125,14 +3125,14 @@ export const api = {
   importLibraryPaper(id: string, input: PaperImportInput): Promise<PaperDetail> {
     return requestJson<PaperDetail>(`/libraries/${id}/papers`, 'POST', input);
   },
-  /** 批量删除库内论文：默认软删（垃圾桶），hard=true 彻底删除。 */
+  /** 批量删除库内论文：默认软删（回收站），hard=true 彻底删除。 */
   batchDeleteLibraryPapers(id: string, paperIds: string[], hard = false): Promise<{ deleted: number }> {
     return requestJson<{ deleted: number }>(`/libraries/${id}/papers/batch-delete`, 'POST', {
       paper_ids: paperIds,
       hard,
     });
   },
-  /** 清空库垃圾桶：彻底删除库内全部已删除论文。 */
+  /** 清空库回收站：彻底删除库内全部已删除论文。 */
   emptyLibraryTrash(id: string): Promise<{ deleted: number }> {
     return request<{ deleted: number }>(`/libraries/${id}/trash/empty`, { method: 'POST' });
   },
@@ -3306,7 +3306,7 @@ export const api = {
   promoteIdea(id: string): Promise<GateRead> {
     return request<GateRead>(`/ideas/${id}/promote`, { method: 'POST' });
   },
-  /** 软删除：移入垃圾箱（仅 owner/admin，否则 403）。 */
+  /** 软删除：移入回收站（仅 owner/admin，否则 403）。 */
   trashIdea(id: string): Promise<void> {
     return request<void>(`/ideas/${id}`, { method: 'DELETE' });
   },
@@ -3314,11 +3314,11 @@ export const api = {
   deleteIdeaPermanent(id: string): Promise<void> {
     return request<void>(`/ideas/${id}?permanent=true`, { method: 'DELETE' });
   },
-  /** 从垃圾箱恢复（仅 owner/admin，否则 403）。 */
+  /** 从回收站恢复（仅 owner/admin，否则 403）。 */
   restoreIdea(id: string): Promise<IdeaRead> {
     return request<IdeaRead>(`/ideas/${id}/restore`, { method: 'POST' });
   },
-  /** 批量操作想法：trash=移入垃圾箱 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
+  /** 批量操作想法：trash=移入回收站 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
   batchIdeas(
     projectId: string,
     action: 'trash' | 'restore' | 'delete',
@@ -3330,7 +3330,7 @@ export const api = {
       { action, ids },
     );
   },
-  /** 清空垃圾箱：永久删除该研究方向下所有已软删除想法（仅 owner/admin，否则 403）。 */
+  /** 清空回收站：永久删除该研究方向下所有已软删除想法（仅 owner/admin，否则 403）。 */
   emptyIdeaTrash(projectId: string): Promise<{ affected: number }> {
     return request<{ affected: number }>(`/projects/${projectId}/ideas/trash/empty`, {
       method: 'POST',
@@ -3379,7 +3379,7 @@ export const api = {
   createExperiment(projectId: string, input: CreateExperimentInput): Promise<ExperimentRead> {
     return requestJson<ExperimentRead>(`/projects/${projectId}/experiments`, 'POST', input);
   },
-  /** 默认返回活动列表；opts.trashed=true 返回垃圾箱（已软删除的实验）。 */
+  /** 默认返回活动列表；opts.trashed=true 返回回收站（已软删除的实验）。 */
   listExperiments(projectId: string, opts?: { trashed?: boolean }): Promise<ExperimentRead[]> {
     const qs = opts?.trashed ? '?trashed=true' : '';
     return request<ExperimentRead[]>(`/projects/${projectId}/experiments${qs}`);
@@ -3387,7 +3387,7 @@ export const api = {
   getExperiment(id: string): Promise<ExperimentDetail> {
     return request<ExperimentDetail>(`/experiments/${id}`);
   },
-  /** 软删除：移入垃圾箱（仅 owner/admin，否则 403）。 */
+  /** 软删除：移入回收站（仅 owner/admin，否则 403）。 */
   trashExperiment(id: string): Promise<void> {
     return request<void>(`/experiments/${id}`, { method: 'DELETE' });
   },
@@ -3395,11 +3395,11 @@ export const api = {
   deleteExperimentPermanent(id: string): Promise<void> {
     return request<void>(`/experiments/${id}?permanent=true`, { method: 'DELETE' });
   },
-  /** 从垃圾箱恢复（仅 owner/admin，否则 403）。 */
+  /** 从回收站恢复（仅 owner/admin，否则 403）。 */
   restoreExperiment(id: string): Promise<ExperimentRead> {
     return request<ExperimentRead>(`/experiments/${id}/restore`, { method: 'POST' });
   },
-  /** 批量操作实验：trash=移入垃圾箱 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
+  /** 批量操作实验：trash=移入回收站 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
   batchExperiments(
     projectId: string,
     action: 'trash' | 'restore' | 'delete',
@@ -3411,7 +3411,7 @@ export const api = {
       { action, ids },
     );
   },
-  /** 清空垃圾箱：永久删除该研究方向下所有已软删除实验（仅 owner/admin，否则 403）。 */
+  /** 清空回收站：永久删除该研究方向下所有已软删除实验（仅 owner/admin，否则 403）。 */
   emptyExperimentTrash(projectId: string): Promise<{ affected: number }> {
     return request<{ affected: number }>(`/projects/${projectId}/experiments/trash/empty`, {
       method: 'POST',
@@ -3496,7 +3496,7 @@ export const api = {
   createManuscript(projectId: string, input: CreateManuscriptInput): Promise<ManuscriptRead> {
     return requestJson<ManuscriptRead>(`/projects/${projectId}/manuscripts`, 'POST', input);
   },
-  /** 默认返回活动列表；opts.trashed=true 返回垃圾箱（已软删除的稿件）。 */
+  /** 默认返回活动列表；opts.trashed=true 返回回收站（已软删除的稿件）。 */
   listManuscripts(projectId: string, opts?: { trashed?: boolean }): Promise<ManuscriptRead[]> {
     const qs = opts?.trashed ? '?trashed=true' : '';
     return request<ManuscriptRead[]>(`/projects/${projectId}/manuscripts${qs}`);
@@ -3514,7 +3514,7 @@ export const api = {
   deleteManuscript(id: string): Promise<void> {
     return request<void>(`/manuscripts/${id}`, { method: 'DELETE' });
   },
-  /** 软删除：移入垃圾箱（仅 owner/admin，否则 403）。 */
+  /** 软删除：移入回收站（仅 owner/admin，否则 403）。 */
   trashManuscript(id: string): Promise<void> {
     return request<void>(`/manuscripts/${id}`, { method: 'DELETE' });
   },
@@ -3522,11 +3522,11 @@ export const api = {
   deleteManuscriptPermanent(id: string): Promise<void> {
     return request<void>(`/manuscripts/${id}?permanent=true`, { method: 'DELETE' });
   },
-  /** 从垃圾箱恢复（仅 owner/admin，否则 403）。 */
+  /** 从回收站恢复（仅 owner/admin，否则 403）。 */
   restoreManuscript(id: string): Promise<ManuscriptRead> {
     return request<ManuscriptRead>(`/manuscripts/${id}/restore`, { method: 'POST' });
   },
-  /** 批量操作稿件：trash=移入垃圾箱 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
+  /** 批量操作稿件：trash=移入回收站 / restore=恢复 / delete=永久删除（仅 owner/admin，否则 403）。 */
   batchManuscripts(
     projectId: string,
     action: 'trash' | 'restore' | 'delete',
@@ -3538,7 +3538,7 @@ export const api = {
       { action, ids },
     );
   },
-  /** 清空垃圾箱：永久删除该研究方向下所有已软删除稿件（仅 owner/admin，否则 403）。 */
+  /** 清空回收站：永久删除该研究方向下所有已软删除稿件（仅 owner/admin，否则 403）。 */
   emptyManuscriptTrash(projectId: string): Promise<{ affected: number }> {
     return request<{ affected: number }>(`/projects/${projectId}/manuscripts/trash/empty`, {
       method: 'POST',


### PR DESCRIPTION
One concept, two names: the literature workbench called it 垃圾桶, while the writer, idea forge and experiment modules called it 垃圾箱. Settle on 回收站 everywhere — UI strings and Chinese comments alike.

73 occurrences in the frontend (`PapersTab`, `WriterPage`, `ForgePage`, `ExperimentPage`, `PublicationsTab`, `api.ts`) and 47 in backend docstrings. Literal substitution, so line counts and alignment are unchanged.

## The English side still says "Trash"

Every identifier around this feature is `trash`: `trash_reason`, `?view=trash`, `POST /trash/empty`, `<Icon name="trash">`, `action: 'trash'`, `trashed_at`. Renaming the visible English to "Recycle Bin" would split the vocabulary between what the UI says and what the API/URLs say, which costs an extra hop every time someone traces a bug. "Recycle Bin" is also Windows-specific — Trash is the web and macOS convention.

If you'd rather have symmetry, say so and I'll do the English side too — it's another ~25 strings, and both groups have to move together so the product doesn't end up with two English names the way it just had two Chinese ones.

## Not touched

- alembic revisions (`d2e3f4a5b6c7_paper_trash_reason.py` and friends) — applied migrations
- test fixtures, which mix comments with Chinese test data
- `docs/literature-management.md`, where "trash" describes the `trash_reason` field and endpoint semantics rather than UI copy

## Verification

`tsc --noEmit` 0 errors, `ruff check app` clean, backend imports.
