### PR TITLE
feat(papers): bring daily, shelf and personal-library detail to parity

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -13,7 +13,14 @@ import {
 import { CompileBadge } from '../../components/ui/CompileBadge';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
-import { ApiError, api, type DailyPaperItem, type DailySort, type PaperDetail } from '../../lib/api';
+import {
+  ApiError,
+  api,
+  type DailyPaperItem,
+  type DailySort,
+  type PaperDetail,
+  type ReadingStatus,
+} from '../../lib/api';
 import { fmtTime } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import { Markdown } from '../../lib/markdown';
@@ -26,12 +33,19 @@ import {
   AffiliationChips,
   AuthorLinks,
   FilterInput,
+  MetaItem,
   SearchInput,
   SemanticSwitch,
-  categoryMeta,
   saveBlob,
   useDebounced,
 } from '../wiki/shared';
+import {
+  ConceptChips,
+  PaperMyMetaRow,
+  PaperNotesSection,
+  PaperTagsRow,
+  WikiHeaderActions,
+} from '../shared/PaperDetailBlocks';
 import { DailyLikes } from './DailyLikes';
 import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
@@ -186,17 +200,33 @@ function DailyDetailPane({
   const [readerOpen, setReaderOpen] = useState(false);
   // 阅览模式打开后是否直接唤起打印（「导出 PDF」一步直达）
   const [readerPrint, setReaderPrint] = useState(false);
+  const openReader = useCallback(() => {
+    setReaderPrint(false);
+    setReaderOpen(true);
+  }, []);
+  const openReaderForPrint = useCallback(() => {
+    setReaderPrint(true);
+    setReaderOpen(true);
+  }, []);
   const { data: paper, isLoading, isError } = useQuery({
     queryKey: ['daily-paper', entryId],
     queryFn: () => api.getDailyPaper(entryId),
     retry: false,
   });
 
-  // 换论文时关掉阅览模式（面板不再随选中项重挂载，本地开合状态要自己收）
-  useEffect(() => {
-    setReaderOpen(false);
-    setReaderPrint(false);
-  }, [entryId]);
+  /* 内容池里这篇的常规详情：星标 / 阅读状态 / 标签 / 笔记数 / TL;DR / doi 都在这上面
+     （每日详情是榜单视角，没有这些个人维度字段）。queryKey 与文献库、相关研究、
+     我的文献库同一个 ['paper', id]，缓存互通。 */
+  const poolId = paper?.paper_id ?? null;
+  const poolPaperQuery = useQuery({
+    queryKey: ['paper', poolId],
+    queryFn: () => api.getPaper(poolId ?? ''),
+    enabled: !!poolId,
+    retry: false,
+  });
+  const poolPaper = poolPaperQuery.data;
+  const poolKey = useMemo(() => ['paper', poolId], [poolId]);
+  const poolKeys = useMemo(() => [poolKey], [poolKey]);
 
   /* 正文 ![[fig:N]] 嵌入图（与文献库详情同款渲染）。
      每日详情返回的是 DailyPaperDetail（没有 figures 字段），图片按内容池 paper_id 单独拉一次。 */
@@ -231,10 +261,12 @@ function DailyDetailPane({
     ...(paper as unknown as PaperDetail),
     id: paper.paper_id,
     venue: null,
-    tldr: null,
-    concepts: [],
+    tldr: poolPaper?.tldr ?? null,
+    concepts: paper.concepts ?? [],
     figures,
   };
+  const starred = poolPaper?.starred ?? false;
+  const readingStatus: ReadingStatus = poolPaper?.reading_status ?? 'unread';
 
   return (
     <div className="scroll fadeup" key={paper.entry_id} style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
@@ -278,7 +310,7 @@ function DailyDetailPane({
       )}
 
       {/* —— 操作栏（对齐常规论文详情 PaperDetailPane） —— */}
-      <div className="row gap8 wrap" style={{ marginBottom: 18 }}>
+      <div className="row gap8 wrap">
         {paper.pdf_available ? (
           <button
             className="btn btn-primary sm"
@@ -337,10 +369,7 @@ function DailyDetailPane({
           <button
             className="btn btn-soft sm"
             title={tr('全屏阅览图文介绍，可导出 PDF', 'Full-screen reading view, exportable to PDF')}
-            onClick={() => {
-              setReaderPrint(false);
-              setReaderOpen(true);
-            }}
+            onClick={openReader}
           >
             <Icon name="book" size={13} />
             {tr('阅览模式', 'Reading mode')}
@@ -356,8 +385,45 @@ function DailyDetailPane({
         <DailyLikes item={paper} />
       </div>
 
+      {/* —— 个人状态：星标 + 阅读状态（内容池维度，和文献库里是同一条记录） —— */}
+      {poolPaper && (
+        <PaperMyMetaRow
+          paperId={poolPaper.id}
+          starred={starred}
+          readingStatus={readingStatus}
+          detailKey={poolKey}
+        />
+      )}
+
+      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      <PaperTagsRow tags={poolPaper?.tags} />
+
+      {/* —— frontmatter 风格元数据卡 —— */}
+      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+        <MetaItem label="arxiv_id">
+          {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="doi">
+          {poolPaper?.doi ? <span className="mono">{poolPaper.doi}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="published">
+          {paper.published_at ? (
+            <span className="mono">{paper.published_at.slice(0, 10)}</span>
+          ) : (
+            <span className="muted">—</span>
+          )}
+        </MetaItem>
+        <MetaItem label={tr('编译时间', 'compiled at')}>
+          {paper.compiled_at ? (
+            <span className="mono">{fmtTime(paper.compiled_at)}</span>
+          ) : (
+            <span className="muted">{tr('未编译', 'not compiled')}</span>
+          )}
+        </MetaItem>
+      </div>
+
       {paper.abstract ? (
-        <div className="card card-pad" style={{ background: 'var(--surface-2)' }}>
+        <div className="card card-pad" style={{ background: 'var(--surface-2)', marginTop: 18 }}>
           <div className="row gap8" style={{ marginBottom: 8 }}>
             <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
             <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
@@ -365,27 +431,41 @@ function DailyDetailPane({
           <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
         </div>
       ) : (
-        <div className="empty" style={{ padding: 20 }}>{tr('这篇还没有摘要。', 'No abstract for this paper.')}</div>
+        <div className="empty" style={{ padding: 20, marginTop: 18 }}>
+          {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+        </div>
+      )}
+
+      {/* —— TL;DR（来自内容池详情） —— */}
+      {poolPaper?.tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {poolPaper.tldr}
+        </div>
       )}
 
       {/* —— 概念 chips（与库版同款；每日没有概念库 tab，故只展示不跳转） —— */}
-      {(paper.concepts?.length ?? 0) > 0 && (
-        <div className="row gap8 wrap" style={{ marginTop: 16 }}>
-          {paper.concepts!.map((c) => {
-            const meta = categoryMeta(c.category);
-            return (
-              <span
-                key={c.id}
-                className="pill sm"
-                style={{ background: meta.bg, color: meta.c, height: 24 }}
-                title={tr(meta.zh, meta.en)}
-              >
-                {c.name}
-                <span style={{ opacity: 0.6, marginLeft: 5, fontSize: '0.85em' }}>{tr(meta.zh, meta.en)}</span>
-              </span>
-            );
-          })}
-        </div>
+      <ConceptChips concepts={paper.concepts} />
+
+      {/* —— 我的笔记（只有自己看得到） —— */}
+      {poolPaper && (
+        <PaperNotesSection
+          paperId={poolPaper.id}
+          noteCount={poolPaper.note_count ?? 0}
+          invalidateKeys={poolKeys}
+        />
       )}
 
       {/* —— 重要图片画廊（只读：提取/重新提取是库维护动作，普通用户没权限） —— */}
@@ -414,30 +494,7 @@ function DailyDetailPane({
               </span>
               <CompileBadge model={paper.wiki_model ?? null} at={paper.compiled_at ?? null} />
             </div>
-            <div className="row gap6">
-              <button
-                className="btn btn-soft sm"
-                title={tr('全屏专注阅读', 'Full-screen focused reading')}
-                onClick={() => {
-                  setReaderPrint(false);
-                  setReaderOpen(true);
-                }}
-              >
-                <Icon name="book" size={13} />
-                {tr('阅览模式', 'Reading mode')}
-              </button>
-              <button
-                className="btn btn-ghost sm"
-                title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
-                onClick={() => {
-                  setReaderPrint(true);
-                  setReaderOpen(true);
-                }}
-              >
-                <Icon name="download" size={13} />
-                {tr('导出 PDF', 'Export PDF')}
-              </button>
-            </div>
+            <WikiHeaderActions onRead={openReader} onExport={openReaderForPrint} />
           </div>
           <Markdown source={paper.wiki_content} renderFigure={renderFigure} />
         </div>
@@ -671,6 +728,8 @@ export function DailyPage() {
           void queryClient.invalidateQueries({ queryKey: ['daily-paper', entryId] });
           void queryClient.invalidateQueries({ queryKey: ['daily-papers'] }); // 列表行的 has_wiki 标记
           void queryClient.invalidateQueries({ queryKey: ['daily-liked'] });
+          // 编译会写回内容池论文（TL;DR / 概念 / 机构），详情面板右侧那份也要刷
+          void queryClient.invalidateQueries({ queryKey: ['paper'] });
         } catch (e) {
           if (e instanceof ApiError && e.status === 409) {
             toast(tr('已有人在生成，稍后刷新即可', 'Someone is already generating it, refresh later'), 'info');
@@ -1008,6 +1067,8 @@ export function DailyPage() {
           <div className="split-detail">
             {selectedId ? (
               <DailyDetailPane
+                /* 换论文就重挂载：阅览模式、概念折叠等本地开合状态自动归位 */
+                key={selectedId}
                 entryId={selectedId}
                 onCollect={openCollect}
                 downloading={downloadPending.has(selectedId)}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, memo, useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -20,14 +20,19 @@ import { fmtTime } from '../../lib/format';
 import {
   ApiError,
   api,
-  type MyMeta,
-  type PaperDetail,
   type PaperRead,
   type PaperSort,
   type PaperStatusFilter,
   type ReadingStatus,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import {
+  ConceptChips,
+  PaperMyMetaRow,
+  PaperNotesSection,
+  PaperTagsRow,
+  WikiHeaderActions,
+} from '../shared/PaperDetailBlocks';
 import { ConceptsTab } from '../wiki/ConceptsTab';
 import { LibraryChatTab } from '../wiki/LibraryChatTab';
 import { NotesTab } from '../wiki/NotesTab';
@@ -44,13 +49,11 @@ import {
   SearchInput,
   SemanticSwitch,
   YearRangeField,
-  categoryMeta,
   parseYear,
   saveBlob,
   useDebounced,
 } from '../wiki/shared';
 import { READING_STATUS, ReadingDot, readerFrom } from '../reading/shared';
-import { NoteCard } from '../reading/NotesPanel';
 import { AddToButton } from '../library/AddToPopover';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
@@ -65,9 +68,6 @@ const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m
 type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' | 'ingest';
 
 const PAGE_SIZE = 20;
-
-/** 概念 chips 默认最多展示数，超出折叠（与文献工作台一致；机构 chips 见 AffiliationChips） */
-const CONCEPT_CHIP_LIMIT = 12;
 
 /** 列表视图筛选（口径同文献工作台：全部 = 已纳入的文献） */
 type ViewFilter = 'all' | 'compiled' | 'starred';
@@ -202,118 +202,6 @@ const PaperRow = memo(function PaperRow({
   prev.p === next.p && prev.active === next.active && prev.checked === next.checked && prev.selectMode === next.selectMode,
 );
 
-/* 「我的笔记」折叠区：GET/POST /papers/{id}/notes 对全员开放（内容池可读即可写自己的笔记），
-   所以非成员的只读浏览也能记笔记。后端只返回本人的笔记，因此列出来的每条都可以改/删。
-   列表按需拉取（展开才请求），收起时计数用详情里的 note_count（同样是本人条数）。 */
-function MyNotesSection({
-  libraryId,
-  paperId,
-  noteCount,
-}: {
-  libraryId: string;
-  paperId: string;
-  noteCount: number;
-}) {
-  const queryClient = useQueryClient();
-  const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState('');
-
-  const notesQuery = useQuery({
-    queryKey: ['paper-notes', paperId],
-    queryFn: () => api.listPaperNotes(paperId),
-    enabled: open,
-    retry: false,
-  });
-  const notes = notesQuery.data ?? [];
-
-  // 笔记增删改后：本身的列表 + 详情 note_count + 列表/搜索行 + 库笔记本
-  const refresh = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: ['paper-notes', paperId] });
-    void queryClient.invalidateQueries({ queryKey: ['paper', libraryId, paperId] });
-    void queryClient.invalidateQueries({ queryKey: ['lib-papers', libraryId] });
-    void queryClient.invalidateQueries({ queryKey: ['lib-search', libraryId] });
-    void queryClient.invalidateQueries({ queryKey: ['project-notes', libraryId] });
-  }, [queryClient, libraryId, paperId]);
-
-  const createMutation = useMutation({
-    mutationFn: () => api.createPaperNote(paperId, draft.trim()),
-    onSuccess: () => {
-      toast(tr('笔记已保存', 'Note saved'), 'ok');
-      setDraft('');
-      refresh();
-    },
-    onError: (e) =>
-      toast(`${tr('保存失败：', 'Save failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
-
-  const count = notesQuery.data ? notes.length : noteCount;
-
-  return (
-    <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
-      <div
-        className="row"
-        onClick={() => setOpen((o) => !o)}
-        style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
-      >
-        <span className="row gap6" style={{ fontSize: 12.5, fontWeight: 650 }}>
-          <Icon name="pen" size={12} style={{ color: 'var(--text-3)' }} />
-          {tr('我的笔记', 'My notes')}
-          <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 400 }}>
-            · {count}
-          </span>
-        </span>
-        <Icon
-          name="chevDown"
-          size={14}
-          style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
-        />
-      </div>
-      {open && (
-        <div style={{ padding: '0 16px 14px' }}>
-          {notesQuery.isLoading ? (
-            <div className="empty" style={{ padding: 12 }}>
-              {tr('加载笔记…', 'Loading notes…')}
-            </div>
-          ) : notesQuery.isError ? (
-            <EmptyState
-              compact
-              icon="x"
-              title={tr('笔记暂时加载不出来', 'Notes failed to load')}
-              desc={tr('后端不可用或接口尚未就绪，稍后再试。', 'Backend unavailable or API not ready — try again later.')}
-            />
-          ) : notes.length === 0 ? (
-            <div className="empty" style={{ padding: '4px 0 12px', textAlign: 'left' }}>
-              {tr('还没有笔记，在下面写第一条。', 'No notes yet — write your first one below.')}
-            </div>
-          ) : (
-            notes.map((n) => <NoteCard key={n.id} note={n} canEdit onSaved={refresh} />)
-          )}
-          <textarea
-            className="textarea"
-            style={{ width: '100%', minHeight: 72, maxHeight: 200, fontSize: 12.5, resize: 'vertical' }}
-            placeholder={tr('记下想法、疑问或要点，支持 Markdown…', 'Jot down ideas, questions or key points — Markdown supported…')}
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-          />
-          <div className="row" style={{ marginTop: 8, justifyContent: 'space-between', alignItems: 'center' }}>
-            <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
-              {tr('笔记只有你自己看得到。', 'Only you can see your notes.')}
-            </span>
-            <button
-              className="btn btn-primary sm"
-              disabled={createMutation.isPending || !draft.trim()}
-              onClick={() => createMutation.mutate()}
-            >
-              <Icon name="pen" size={13} />
-              {createMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存笔记', 'Save note')}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
 function PaperDetailPane({
   libraryId,
   paperId,
@@ -336,30 +224,34 @@ function PaperDetailPane({
   const location = useLocation();
   const queryClient = useQueryClient();
   const [abstractOpen, setAbstractOpen] = useState(false);
-  const [conceptsOpen, setConceptsOpen] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
+  const openReader = useCallback(() => {
+    setReaderPrint(false);
+    setReaderOpen(true);
+  }, []);
+  const openReaderForPrint = useCallback(() => {
+    setReaderPrint(true);
+    setReaderOpen(true);
+  }, []);
 
   // 库作用域取详情：锁定本库那份成员行，相关度/状态/wiki 不会串到该论文在别的库的副本
+  const detailKey = useMemo(() => ['paper', libraryId, paperId], [libraryId, paperId]);
   const { data: paper, isLoading, isError } = useQuery({
-    queryKey: ['paper', libraryId, paperId],
+    queryKey: detailKey,
     queryFn: () => api.getLibraryPaper(libraryId, paperId),
     retry: false,
   });
 
-  // 星标 / 阅读状态：个人维度，只读浏览也能改（PUT /papers/{id}/my-meta 对全员开放）
-  const metaMutation = useMutation({
-    mutationFn: (input: Partial<MyMeta>) => api.putMyMeta(paperId, input),
-    onSuccess: (meta) => {
-      queryClient.setQueryData<PaperDetail>(['paper', libraryId, paperId], (old) =>
-        old ? { ...old, starred: meta.starred, reading_status: meta.reading_status } : old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ['lib-papers', libraryId] });
-      void queryClient.invalidateQueries({ queryKey: ['lib-search', libraryId] });
-    },
-    onError: (e) =>
-      toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
+  // 星标 / 阅读状态、笔记改动后要刷新的列表（库列表 + 库内搜索 + 库笔记本）
+  const listKeys = useMemo(
+    () => [['lib-papers', libraryId], ['lib-search', libraryId]],
+    [libraryId],
+  );
+  const noteKeys = useMemo(
+    () => [detailKey, ['lib-papers', libraryId], ['lib-search', libraryId], ['project-notes', libraryId]],
+    [detailKey, libraryId],
+  );
 
   /* —— 个人版解读：这个库没编译过这篇时，读/生成本人个人库条目里的个人版（与阅读页 InfoPanel 同一套 query key）——
      POST /papers/{id}/personal-wiki 不校验成员身份（内容池全平台可读），费用记个人额度；
@@ -406,7 +298,6 @@ function PaperDetailPane({
   // 换论文时收起本地开合状态（面板不随选中项重挂载，得自己收）
   useEffect(() => {
     setAbstractOpen(false);
-    setConceptsOpen(false);
     setReaderOpen(false);
     resetPersonalWiki();
   }, [paperId, resetPersonalWiki]);
@@ -486,10 +377,7 @@ function PaperDetailPane({
           <button
             className="btn btn-soft sm"
             title={tr('全屏阅览图文介绍，可导出 PDF', 'Full-screen reading view, exportable to PDF')}
-            onClick={() => {
-              setReaderPrint(false);
-              setReaderOpen(true);
-            }}
+            onClick={openReader}
           >
             <Icon name="book" size={13} />
             {tr('阅览模式', 'Reading mode')}
@@ -522,41 +410,16 @@ function PaperDetailPane({
       </div>
 
       {/* —— 个人状态：星标 + 阅读状态（只读库里也是我自己的记录） —— */}
-      <div className="row gap12 wrap" style={{ marginTop: 12 }}>
-        <button
-          className="btn btn-ghost sm"
-          disabled={metaMutation.isPending}
-          onClick={() => metaMutation.mutate({ starred: !starred })}
-          style={starred ? { color: 'var(--warn-tx)' } : undefined}
-        >
-          <Icon name={starred ? 'starFill' : 'star'} size={13} />
-          {starred ? tr('已星标', 'Starred') : tr('加星标', 'Star')}
-        </button>
-        <span className="row gap8">
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
-            {tr('阅读状态', 'Reading status')}
-          </span>
-          <Segmented<ReadingStatus>
-            options={READING_STATUS.map((m) => ({ v: m.v, label: tr(m.label, m.en) }))}
-            value={readingStatus}
-            onChange={(v) => metaMutation.mutate({ reading_status: v })}
-          />
-        </span>
-      </div>
+      <PaperMyMetaRow
+        paperId={paper.id}
+        starred={starred}
+        readingStatus={readingStatus}
+        detailKey={detailKey}
+        invalidateKeys={listKeys}
+      />
 
       {/* —— 标签（只读展示，编辑在文献工作台） —— */}
-      {(paper.tags?.length ?? 0) > 0 && (
-        <div className="row gap6 wrap" style={{ marginTop: 14 }}>
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
-            {tr('标签', 'Tags')}
-          </span>
-          {paper.tags!.map((t) => (
-            <span key={t} className="tag">
-              {t}
-            </span>
-          ))}
-        </div>
-      )}
+      <PaperTagsRow tags={paper.tags} />
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
@@ -587,31 +450,7 @@ function PaperDetailPane({
       </div>
 
       {/* —— 概念 chips（过多时折叠） —— */}
-      {paper.concepts.length > 0 && (
-        <div className="row gap8 wrap" style={{ marginTop: 16 }}>
-          {(conceptsOpen ? paper.concepts : paper.concepts.slice(0, CONCEPT_CHIP_LIMIT)).map((c) => {
-            const meta = categoryMeta(c.category);
-            return (
-              <span
-                key={c.id}
-                className="wikilink"
-                style={{ background: meta.bg, color: meta.c, height: 24 }}
-                onClick={() => onOpenConcept(c.id)}
-              >
-                {c.name}
-                <span style={{ opacity: 0.6, marginLeft: 5, fontSize: '0.85em' }}>{tr(meta.zh, meta.en)}</span>
-              </span>
-            );
-          })}
-          {paper.concepts.length > CONCEPT_CHIP_LIMIT && (
-            <span className="chip" style={{ fontSize: 11 }} onClick={() => setConceptsOpen((o) => !o)}>
-              {conceptsOpen
-                ? tr('收起', 'Collapse')
-                : tr(`+${paper.concepts.length - CONCEPT_CHIP_LIMIT} 个概念`, `+${paper.concepts.length - CONCEPT_CHIP_LIMIT} concepts`)}
-            </span>
-          )}
-        </div>
-      )}
+      <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />
 
       {/* —— 摘要（折叠） —— */}
       {paper.abstract && (
@@ -657,7 +496,7 @@ function PaperDetailPane({
       )}
 
       {/* —— 我的笔记（个人维度，只读浏览也能写） —— */}
-      <MyNotesSection libraryId={libraryId} paperId={paper.id} noteCount={paper.note_count ?? 0} />
+      <PaperNotesSection paperId={paper.id} noteCount={paper.note_count ?? 0} invalidateKeys={noteKeys} />
 
       {/* —— 重要图片画廊（只读：不给提取/重新提取入口，那是管理员操作） —— */}
       <FiguresSection paper={paper} readOnly defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)} />
@@ -682,30 +521,7 @@ function PaperDetailPane({
                 </span>
                 <CompileBadge model={paper.compiled_model} at={paper.compiled_at} />
               </div>
-              <div className="row gap6">
-                <button
-                  className="btn btn-soft sm"
-                  title={tr('全屏专注阅读', 'Full-screen focused reading')}
-                  onClick={() => {
-                    setReaderPrint(false);
-                    setReaderOpen(true);
-                  }}
-                >
-                  <Icon name="book" size={13} />
-                  {tr('阅览模式', 'Reading mode')}
-                </button>
-                <button
-                  className="btn btn-ghost sm"
-                  title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
-                  onClick={() => {
-                    setReaderPrint(true);
-                    setReaderOpen(true);
-                  }}
-                >
-                  <Icon name="download" size={13} />
-                  {tr('导出 PDF', 'Export PDF')}
-                </button>
-              </div>
+              <WikiHeaderActions onRead={openReader} onExport={openReaderForPrint} />
             </div>
             <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
           </>
@@ -734,30 +550,11 @@ function PaperDetailPane({
               >
                 {tr('个人版', 'Personal')}
               </span>
-              <div className="row gap6" style={{ marginLeft: 'auto' }}>
-                <button
-                  className="btn btn-soft sm"
-                  title={tr('全屏专注阅读', 'Full-screen focused reading')}
-                  onClick={() => {
-                    setReaderPrint(false);
-                    setReaderOpen(true);
-                  }}
-                >
-                  <Icon name="book" size={13} />
-                  {tr('阅览模式', 'Reading mode')}
-                </button>
-                <button
-                  className="btn btn-ghost sm"
-                  title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
-                  onClick={() => {
-                    setReaderPrint(true);
-                    setReaderOpen(true);
-                  }}
-                >
-                  <Icon name="download" size={13} />
-                  {tr('导出 PDF', 'Export PDF')}
-                </button>
-              </div>
+              <WikiHeaderActions
+                onRead={openReader}
+                onExport={openReaderForPrint}
+                style={{ marginLeft: 'auto' }}
+              />
             </div>
             <Markdown source={personalWiki} onWikiLink={onWikiLink} renderFigure={renderFigure} />
           </>

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -1,16 +1,36 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { CompileBadge } from '../../components/ui/CompileBadge';
-import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
+import {
+  FigureEmbed,
+  FiguresSection,
+  hasEmbeddedFigures,
+  usePaperFigures,
+} from '../../components/ui/FigureGallery';
+import { ScoreRing } from '../../components/ui/ScoreRing';
 import { toast } from '../../components/ui/Toast';
 import { Markdown } from '../../lib/markdown';
-import { api, type LibraryEntry, type PaperAuthor, type Publication } from '../../lib/api';
+import {
+  api,
+  type LibraryEntry,
+  type PaperAuthor,
+  type Publication,
+  type ReadingStatus,
+} from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
+import { PaperReader } from '../wiki/PaperReader';
 import { AffiliationChips, AuthorLinks } from '../wiki/shared';
+import {
+  ConceptChips,
+  PaperMyMetaRow,
+  PaperNotesSection,
+  PaperTagsRow,
+  WikiHeaderActions,
+} from '../shared/PaperDetailBlocks';
 
 /* ============================================================
    我的文献库 · 右栏详情（三个 tab 共用）：
@@ -98,15 +118,31 @@ export function LibraryDetailPane({
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
+  const [readerOpen, setReaderOpen] = useState(false);
+  // 阅览模式打开后是否直接唤起打印（「导出 PDF」一步直达）
+  const [readerPrint, setReaderPrint] = useState(false);
+  const openReader = useCallback(() => {
+    setReaderPrint(false);
+    setReaderOpen(true);
+  }, []);
+  const openReaderForPrint = useCallback(() => {
+    setReaderPrint(true);
+    setReaderOpen(true);
+  }, []);
 
   // 与文献追踪详情面板同一个 queryKey（['paper', id]），缓存互通
+  const detailKey = useMemo(() => ['paper', paperId], [paperId]);
   const paperQuery = useQuery({
-    queryKey: ['paper', paperId],
+    queryKey: detailKey,
     queryFn: () => api.getPaper(paperId ?? ''),
     enabled: paperId !== null,
     retry: false,
   });
   const paper = paperId !== null && paperQuery.isSuccess ? paperQuery.data : undefined;
+
+  // 星标 / 阅读状态、笔记改完刷新个人库列表（行上有星标与笔记数）
+  const listKeys = useMemo(() => [['library']], []);
+  const noteKeys = useMemo(() => [detailKey, ['library']], [detailKey]);
 
   // 论文已删（last_paper_id 为 null，或详情拉取失败）→ 拉条目详情取 wiki 快照
   const wantSnapshotWiki = entryId !== undefined && (paperId === null || paperQuery.isError);
@@ -176,6 +212,8 @@ export function LibraryDetailPane({
       navigate(topicLib ? libraryPath(topicLib.id, `?concept=${encodeURIComponent(name)}`) : '/libraries'),
     [navigate, topicLib],
   );
+  // 概念 chip 与双链同一个落点（都按概念名去课题库里找）
+  const openConcept = useCallback((c: { name: string }) => onWikiLink(c.name), [onWikiLink]);
 
   if (paperId !== null && paperQuery.isLoading) {
     return <div className="empty" style={{ margin: 'auto' }}>{tr('加载论文详情…', 'Loading paper…')}</div>;
@@ -195,6 +233,7 @@ export function LibraryDetailPane({
   const abstract = paper?.abstract ?? snapshot.abstract ?? null;
   const tldr = paper?.tldr ?? snapshot.tldr ?? null;
   const arxivUrl = arxivId ? `https://arxiv.org/abs/${arxivId}` : null;
+  const readingStatus: ReadingStatus = paper?.reading_status ?? 'unread';
 
   return (
     <div
@@ -222,12 +261,19 @@ export function LibraryDetailPane({
         )}
       </div>
 
-      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤列表） —— */}
-      <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
-        {title}
-      </h1>
-      <AuthorLinks authors={authors} onFilter={onFilterAuthor} />
-      <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
+      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤列表）+ 相关度 —— */}
+      <div className="row" style={{ alignItems: 'flex-start', gap: 20 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
+            {title}
+          </h1>
+          <AuthorLinks authors={authors} onFilter={onFilterAuthor} />
+          <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
+        </div>
+        {alive && paper.relevance_score !== null && (
+          <ScoreRing value={paper.relevance_score} max={1} size={56} label={tr('相关度', 'Relevance')} />
+        )}
+      </div>
 
       {/* —— 操作：打开阅读页（仅活体论文）+ 外链 —— */}
       <div className="row gap8 wrap" style={{ marginTop: 14 }}>
@@ -238,6 +284,16 @@ export function LibraryDetailPane({
           >
             <Icon name="file" size={13} />
             {tr('打开阅读页', 'Open reader')}
+          </button>
+        )}
+        {alive && (paper.wiki_content || personalWiki) && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('全屏阅览图文介绍，可导出 PDF', 'Full-screen reading view, exportable to PDF')}
+            onClick={openReader}
+          >
+            <Icon name="book" size={13} />
+            {tr('阅览模式', 'Reading mode')}
           </button>
         )}
         {alive &&
@@ -285,6 +341,20 @@ export function LibraryDetailPane({
         )}
       </div>
 
+      {/* —— 个人状态：星标 + 阅读状态（论文还在才有） —— */}
+      {alive && (
+        <PaperMyMetaRow
+          paperId={paper.id}
+          starred={paper.starred ?? false}
+          readingStatus={readingStatus}
+          detailKey={detailKey}
+          invalidateKeys={listKeys}
+        />
+      )}
+
+      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {alive && <PaperTagsRow tags={paper.tags} />}
+
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
         <MetaItem label="arxiv_id">
@@ -301,6 +371,9 @@ export function LibraryDetailPane({
           </MetaItem>
         )}
       </div>
+
+      {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
+      {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}
 
       {/* —— TL;DR —— */}
       {tldr && (
@@ -332,6 +405,20 @@ export function LibraryDetailPane({
         </div>
       )}
 
+      {/* —— 我的笔记（只有自己看得到） —— */}
+      {alive && (
+        <PaperNotesSection paperId={paper.id} noteCount={paper.note_count ?? 0} invalidateKeys={noteKeys} />
+      )}
+
+      {/* —— 重要图片画廊（只读：提取/重新提取是库维护动作） —— */}
+      {alive && (
+        <FiguresSection
+          paper={paper}
+          readOnly
+          defaultCollapsed={hasEmbeddedFigures(paper.wiki_content ?? personalWiki, figures)}
+        />
+      )}
+
       {/* —— Wiki 正文（文献追踪同款 markdown 渲染） —— */}
       {alive && (
         <div style={{ marginTop: 22 }}>
@@ -345,6 +432,11 @@ export function LibraryDetailPane({
                   {tr('AI 图文介绍', 'AI intro')}
                 </span>
                 <CompileBadge model={paper.compiled_model} at={paper.compiled_at} />
+                <WikiHeaderActions
+                  onRead={openReader}
+                  onExport={openReaderForPrint}
+                  style={{ marginLeft: 'auto' }}
+                />
               </div>
               <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
             </>
@@ -370,6 +462,11 @@ export function LibraryDetailPane({
                 >
                   {tr('个人版', 'Personal')}
                 </span>
+                <WikiHeaderActions
+                  onRead={openReader}
+                  onExport={openReaderForPrint}
+                  style={{ marginLeft: 'auto' }}
+                />
               </div>
               <Markdown source={personalWiki} onWikiLink={onWikiLink} renderFigure={renderFigure} />
             </>
@@ -420,6 +517,18 @@ export function LibraryDetailPane({
           </div>
           <Markdown source={snapshotWiki} onWikiLink={onWikiLink} renderFigure={renderSnapshotFigure} />
         </div>
+      )}
+
+      {readerOpen && alive && (
+        <PaperReader
+          paper={paper}
+          /* 库版 wiki 不存在时阅览个人版（正文不在 paper 上，显式传入） */
+          wikiContent={paper.wiki_content ?? personalWiki}
+          renderFigure={renderFigure}
+          onWikiLink={onWikiLink}
+          autoPrint={readerPrint}
+          onClose={() => setReaderOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -1,15 +1,29 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { CompileBadge } from '../../components/ui/CompileBadge';
-import { FigureEmbed, usePaperFigures } from '../../components/ui/FigureGallery';
+import {
+  FigureEmbed,
+  FiguresSection,
+  hasEmbeddedFigures,
+  usePaperFigures,
+} from '../../components/ui/FigureGallery';
+import { ScoreRing } from '../../components/ui/ScoreRing';
 import { Markdown } from '../../lib/markdown';
-import { api, type ShelfItemRead, type ShelfWikiSource } from '../../lib/api';
+import { api, type ReadingStatus, type ShelfItemRead, type ShelfWikiSource } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { libraryPath, useLibraries } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
+import { PaperReader } from '../wiki/PaperReader';
 import { AffiliationChips, AuthorLinks } from '../wiki/shared';
+import {
+  ConceptChips,
+  PaperMyMetaRow,
+  PaperNotesSection,
+  PaperTagsRow,
+  WikiHeaderActions,
+} from '../shared/PaperDetailBlocks';
 
 /* ============================================================
    相关研究 · 右栏详情（与「我的文献库」LibraryDetailPane 同一版式）：
@@ -177,7 +191,7 @@ function NoteEditor({
     >
       <div className="row gap8">
         <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', letterSpacing: '0.04em' }}>
-          {tr('为什么相关', 'Why relevant')}
+          {tr('课题备注 · 为什么相关', 'Topic note · why relevant')}
         </span>
         <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
           {status}
@@ -262,14 +276,30 @@ export function ShelfDetailPane({
 }) {
   const navigate = useNavigate();
   const location = useLocation();
+  const [readerOpen, setReaderOpen] = useState(false);
+  // 阅览模式打开后是否直接唤起打印（「导出 PDF」一步直达）
+  const [readerPrint, setReaderPrint] = useState(false);
+  const openReader = useCallback(() => {
+    setReaderPrint(false);
+    setReaderOpen(true);
+  }, []);
+  const openReaderForPrint = useCallback(() => {
+    setReaderPrint(true);
+    setReaderOpen(true);
+  }, []);
 
-  // 摘要 / TL;DR / 嵌图 / 编译信息来自论文详情（与阅读页、文献追踪同 queryKey 缓存互通）
+  // 摘要 / TL;DR / 嵌图 / 编译信息 / 星标 / 标签来自论文详情（与阅读页、文献追踪同 queryKey 缓存互通）
+  const detailKey = useMemo(() => ['paper', item.paper_id], [item.paper_id]);
   const paperQuery = useQuery({
-    queryKey: ['paper', item.paper_id],
+    queryKey: detailKey,
     queryFn: () => api.getPaper(item.paper_id),
     retry: false,
   });
   const paper = paperQuery.data;
+
+  // 星标 / 阅读状态改完刷新书架列表与检索结果；笔记只影响详情里的计数
+  const listKeys = useMemo(() => [['shelf'], ['shelf-search']], []);
+  const noteKeys = useMemo(() => [detailKey], [detailKey]);
 
   // 来源方向库名（列表小且 5 分钟缓存，直接查全量列表）
   const libsQuery = useLibraries({}, item.source_library_id !== null);
@@ -297,12 +327,19 @@ export function ShelfDetailPane({
       ),
     [navigate, item.source_library_id],
   );
+  // 概念 chip 与双链同一个落点（都按概念名去来源方向库找）
+  const openConcept = useCallback(
+    (c: { name: string }) => onWikiLink(c.name),
+    [onWikiLink],
+  );
 
   // 机构：书架条目自带（后端从内容池论文取）；旧后端没这个字段时退回论文详情
   const affiliations = item.affiliations ?? paper?.affiliations;
   const tldr = item.tldr ?? paper?.tldr ?? null;
   const abstract = paper?.abstract ?? null;
   const arxivUrl = item.arxiv_id ? `https://arxiv.org/abs/${item.arxiv_id}` : null;
+  const relevance = paper?.relevance_score ?? null;
+  const readingStatus: ReadingStatus = paper?.reading_status ?? 'unread';
 
   const wikiLabel =
     item.wiki_source === 'live'
@@ -326,12 +363,17 @@ export function ShelfDetailPane({
         )}
       </div>
 
-      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤书架） —— */}
-      <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
-        {item.title}
-      </h1>
-      <AuthorLinks authors={item.authors} onFilter={onFilterAuthor} />
-      <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
+      {/* —— 标题 + 作者 + 机构（都可点：点了按它过滤书架）+ 相关度 —— */}
+      <div className="row" style={{ alignItems: 'flex-start', gap: 20 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 680, lineHeight: 1.3, margin: '0 0 6px', letterSpacing: '-0.01em' }}>
+            {item.title}
+          </h1>
+          <AuthorLinks authors={item.authors} onFilter={onFilterAuthor} />
+          <AffiliationChips affiliations={affiliations} onFilter={onFilterAffiliation} />
+        </div>
+        {relevance !== null && <ScoreRing value={relevance} max={1} size={56} label={tr('相关度', 'Relevance')} />}
+      </div>
 
       {/* —— 操作行 —— */}
       <div className="row gap8 wrap" style={{ marginTop: 14 }}>
@@ -342,6 +384,16 @@ export function ShelfDetailPane({
           <Icon name="file" size={13} />
           {tr('打开阅读页', 'Open reader')}
         </button>
+        {paper && item.wiki_content && (
+          <button
+            className="btn btn-soft sm"
+            title={tr('全屏阅览图文介绍，可导出 PDF', 'Full-screen reading view, exportable to PDF')}
+            onClick={openReader}
+          >
+            <Icon name="book" size={13} />
+            {tr('阅览模式', 'Reading mode')}
+          </button>
+        )}
         {item.source_library_id ? (
           <button
             className="btn btn-ghost sm"
@@ -436,8 +488,31 @@ export function ShelfDetailPane({
         ) : null}
       </div>
 
-      {/* —— 课题备注：为什么相关（仅书架内论文） —— */}
+      {/* —— 个人状态：星标 + 阅读状态（跟文献库里是同一条记录） —— */}
+      {paper && (
+        <PaperMyMetaRow
+          paperId={item.paper_id}
+          starred={paper.starred ?? false}
+          readingStatus={readingStatus}
+          detailKey={detailKey}
+          invalidateKeys={listKeys}
+        />
+      )}
+
+      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      <PaperTagsRow tags={paper?.tags} />
+
+      {/* —— 课题备注：为什么相关（仅书架内论文；这条是课题里公开的说明） —— */}
       {onShelf && <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />}
+
+      {/* —— 我的笔记（只有自己看得到，和上面的课题备注是两回事） —— */}
+      {paper && (
+        <PaperNotesSection
+          paperId={item.paper_id}
+          noteCount={paper.note_count ?? 0}
+          invalidateKeys={noteKeys}
+        />
+      )}
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
@@ -476,6 +551,12 @@ export function ShelfDetailPane({
         </MetaItem>
       </div>
 
+      {/* —— 概念 chips：点了跳来源方向库的概念页；手动添加的（无来源库）不可点 —— */}
+      <ConceptChips
+        concepts={paper?.concepts}
+        onOpen={item.source_library_id ? openConcept : undefined}
+      />
+
       {/* —— TL;DR —— */}
       {tldr && (
         <div
@@ -506,6 +587,15 @@ export function ShelfDetailPane({
         </div>
       )}
 
+      {/* —— 重要图片画廊（只读：提取/重新提取是库维护动作） —— */}
+      {paper && (
+        <FiguresSection
+          paper={paper}
+          readOnly
+          defaultCollapsed={hasEmbeddedFigures(item.wiki_content, figures)}
+        />
+      )}
+
       {/* —— wiki 正文（库版实时 > 个人版 > 快照，接口已解析好） —— */}
       {item.wiki_content ? (
         <div style={{ marginTop: 22 }}>
@@ -517,6 +607,13 @@ export function ShelfDetailPane({
               {wikiLabel}
             </span>
             {item.wiki_source === 'live' && <CompileBadge model={paper?.compiled_model} at={paper?.compiled_at} />}
+            {paper && (
+              <WikiHeaderActions
+                onRead={openReader}
+                onExport={openReaderForPrint}
+                style={{ marginLeft: 'auto' }}
+              />
+            )}
           </div>
           <Markdown source={item.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
         </div>
@@ -553,6 +650,18 @@ export function ShelfDetailPane({
             </button>
           )}
         </div>
+      )}
+
+      {readerOpen && paper && (
+        <PaperReader
+          paper={paper}
+          /* 书架里的正文可能是个人版或快照，不一定在 paper 上，显式传入 */
+          wikiContent={item.wiki_content}
+          renderFigure={renderFigure}
+          onWikiLink={onWikiLink}
+          autoPrint={readerPrint}
+          onClose={() => setReaderOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useState, type CSSProperties } from 'react';
+import { useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { api, type MyMeta, type PaperConceptRef, type ReadingStatus } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { NoteCard } from '../reading/NotesPanel';
+import { READING_STATUS } from '../reading/shared';
+import { categoryMeta } from '../wiki/shared';
+
+/* ============================================================
+   论文详情面板的公共小块：四处（共享文献库浏览 / 每日新论文 /
+   课题相关研究 / 我的文献库）的数据源形状差别很大，所以不抽整块
+   面板，只抽这几段跟数据源无关的 UI + 个人维度写操作。
+   ============================================================ */
+
+/** 概念 chips 默认最多展示数，超出折叠（与文献工作台一致）。 */
+export const CONCEPT_CHIP_LIMIT = 12;
+
+/* ---------------- 星标 + 阅读状态 ---------------- */
+
+/**
+ * 个人维度的两个开关：星标、阅读状态。
+ * 走 PUT /papers/{id}/my-meta（对全员开放，只读浏览也能改）。
+ */
+export function PaperMyMetaRow({
+  paperId,
+  starred,
+  readingStatus,
+  detailKey,
+  invalidateKeys,
+  style,
+}: {
+  paperId: string;
+  starred: boolean;
+  readingStatus: ReadingStatus;
+  /** 详情 queryKey：给了就直接改缓存，点完立刻变，不用等列表刷新 */
+  detailKey?: QueryKey;
+  /** 改完要刷新的列表 / 搜索 queryKey */
+  invalidateKeys?: readonly QueryKey[];
+  style?: CSSProperties;
+}) {
+  const queryClient = useQueryClient();
+
+  const metaMutation = useMutation({
+    mutationFn: (input: Partial<MyMeta>) => api.putMyMeta(paperId, input),
+    onSuccess: (meta) => {
+      if (detailKey) {
+        queryClient.setQueryData<{ starred?: boolean; reading_status?: ReadingStatus }>(detailKey, (old) =>
+          old ? { ...old, starred: meta.starred, reading_status: meta.reading_status } : old,
+        );
+      }
+      for (const key of invalidateKeys ?? []) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+    onError: (e) =>
+      toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  return (
+    <div className="row gap12 wrap" style={{ marginTop: 12, ...style }}>
+      <button
+        className="btn btn-ghost sm"
+        disabled={metaMutation.isPending}
+        onClick={() => metaMutation.mutate({ starred: !starred })}
+        style={starred ? { color: 'var(--warn-tx)' } : undefined}
+      >
+        <Icon name={starred ? 'starFill' : 'star'} size={13} />
+        {starred ? tr('已星标', 'Starred') : tr('加星标', 'Star')}
+      </button>
+      <span className="row gap8">
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+          {tr('阅读状态', 'Reading status')}
+        </span>
+        <Segmented<ReadingStatus>
+          options={READING_STATUS.map((m) => ({ v: m.v, label: tr(m.label, m.en) }))}
+          value={readingStatus}
+          onChange={(v) => metaMutation.mutate({ reading_status: v })}
+        />
+      </span>
+    </div>
+  );
+}
+
+/* ---------------- 只读标签行 ---------------- */
+
+/** 标签只读展示（编辑在文献工作台）。 */
+export function PaperTagsRow({ tags, style }: { tags: string[] | undefined; style?: CSSProperties }) {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <div className="row gap6 wrap" style={{ marginTop: 14, ...style }}>
+      <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
+        {tr('标签', 'Tags')}
+      </span>
+      {tags.map((t) => (
+        <span key={t} className="tag">
+          {t}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ---------------- 我的笔记 ---------------- */
+
+/* GET/POST /papers/{id}/notes 对全员开放（内容池可读即可写自己的笔记），
+   所以只读浏览、每日新论文里也能记笔记。后端只返回本人的笔记，因此列出来的每条都可以改/删。
+   列表按需拉取（展开才请求），收起时计数用详情里的 note_count（同样是本人条数）。 */
+export function PaperNotesSection({
+  paperId,
+  noteCount,
+  invalidateKeys,
+}: {
+  paperId: string;
+  noteCount: number;
+  /** 笔记增删改后要刷新的 queryKey（详情 note_count / 列表行 / 库笔记本…） */
+  invalidateKeys?: readonly QueryKey[];
+}) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  const notesQuery = useQuery({
+    queryKey: ['paper-notes', paperId],
+    queryFn: () => api.listPaperNotes(paperId),
+    enabled: open,
+    retry: false,
+  });
+  const notes = notesQuery.data ?? [];
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['paper-notes', paperId] });
+    for (const key of invalidateKeys ?? []) {
+      void queryClient.invalidateQueries({ queryKey: key });
+    }
+  }, [queryClient, paperId, invalidateKeys]);
+
+  const createMutation = useMutation({
+    mutationFn: () => api.createPaperNote(paperId, draft.trim()),
+    onSuccess: () => {
+      toast(tr('笔记已保存', 'Note saved'), 'ok');
+      setDraft('');
+      refresh();
+    },
+    onError: (e) =>
+      toast(`${tr('保存失败：', 'Save failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const count = notesQuery.data ? notes.length : noteCount;
+
+  return (
+    <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
+      <div
+        className="row"
+        onClick={() => setOpen((o) => !o)}
+        style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+      >
+        <span className="row gap6" style={{ fontSize: 12.5, fontWeight: 650 }}>
+          <Icon name="pen" size={12} style={{ color: 'var(--text-3)' }} />
+          {tr('我的笔记', 'My notes')}
+          <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 400 }}>
+            · {count}
+          </span>
+        </span>
+        <Icon
+          name="chevDown"
+          size={14}
+          style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+        />
+      </div>
+      {open && (
+        <div style={{ padding: '0 16px 14px' }}>
+          {notesQuery.isLoading ? (
+            <div className="empty" style={{ padding: 12 }}>
+              {tr('加载笔记…', 'Loading notes…')}
+            </div>
+          ) : notesQuery.isError ? (
+            <EmptyState
+              compact
+              icon="x"
+              title={tr('笔记暂时加载不出来', 'Notes failed to load')}
+              desc={tr('后端不可用或接口尚未就绪，稍后再试。', 'Backend unavailable or API not ready — try again later.')}
+            />
+          ) : notes.length === 0 ? (
+            <div className="empty" style={{ padding: '4px 0 12px', textAlign: 'left' }}>
+              {tr('还没有笔记，在下面写第一条。', 'No notes yet — write your first one below.')}
+            </div>
+          ) : (
+            notes.map((n) => <NoteCard key={n.id} note={n} canEdit onSaved={refresh} />)
+          )}
+          <textarea
+            className="textarea"
+            style={{ width: '100%', minHeight: 72, maxHeight: 200, fontSize: 12.5, resize: 'vertical' }}
+            placeholder={tr('记下想法、疑问或要点，支持 Markdown…', 'Jot down ideas, questions or key points — Markdown supported…')}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <div className="row" style={{ marginTop: 8, justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+              {tr('笔记只有你自己看得到。', 'Only you can see your notes.')}
+            </span>
+            <button
+              className="btn btn-primary sm"
+              disabled={createMutation.isPending || !draft.trim()}
+              onClick={() => createMutation.mutate()}
+            >
+              <Icon name="pen" size={13} />
+              {createMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存笔记', 'Save note')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ---------------- 概念 chips ---------------- */
+
+/**
+ * 论文已上链的概念 chips，超过 limit 折叠。
+ * onOpen 不传 = 不可点（每日新论文没有概念库上下文，只展示）。
+ */
+export function ConceptChips({
+  concepts,
+  onOpen,
+  limit = CONCEPT_CHIP_LIMIT,
+  style,
+}: {
+  concepts: PaperConceptRef[] | undefined;
+  /** 点 chip → 打开概念页（有的页面按 id 跳、有的按名字跳，所以整个概念传出去）；不传则 chips 不可点 */
+  onOpen?: (concept: PaperConceptRef) => void;
+  limit?: number;
+  style?: CSSProperties;
+}) {
+  const [open, setOpen] = useState(false);
+  const list = concepts ?? [];
+  if (list.length === 0) return null;
+  const shown = open ? list : list.slice(0, limit);
+
+  return (
+    <div className="row gap8 wrap" style={{ marginTop: 16, ...style }}>
+      {shown.map((c) => {
+        const meta = categoryMeta(c.category);
+        const label = (
+          <>
+            {c.name}
+            <span style={{ opacity: 0.6, marginLeft: 5, fontSize: '0.85em' }}>{tr(meta.zh, meta.en)}</span>
+          </>
+        );
+        return onOpen ? (
+          <span
+            key={c.id}
+            className="wikilink"
+            style={{ background: meta.bg, color: meta.c, height: 24 }}
+            onClick={() => onOpen(c)}
+          >
+            {label}
+          </span>
+        ) : (
+          <span
+            key={c.id}
+            className="pill sm"
+            style={{ background: meta.bg, color: meta.c, height: 24 }}
+            title={tr(meta.zh, meta.en)}
+          >
+            {label}
+          </span>
+        );
+      })}
+      {list.length > limit && (
+        <span className="chip" style={{ fontSize: 11 }} onClick={() => setOpen((o) => !o)}>
+          {open
+            ? tr('收起', 'Collapse')
+            : tr(`+${list.length - limit} 个概念`, `+${list.length - limit} concepts`)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ---------------- 阅览模式 / 导出 PDF ---------------- */
+
+/** AI 图文介绍标题行右侧那对按钮（阅览模式 + 导出 PDF）。 */
+export function WikiHeaderActions({
+  onRead,
+  onExport,
+  style,
+}: {
+  /** 打开全屏阅览 */
+  onRead: () => void;
+  /** 打开阅览并唤起打印 */
+  onExport: () => void;
+  style?: CSSProperties;
+}) {
+  return (
+    <div className="row gap6" style={style}>
+      <button className="btn btn-soft sm" title={tr('全屏专注阅读', 'Full-screen focused reading')} onClick={onRead}>
+        <Icon name="book" size={13} />
+        {tr('阅览模式', 'Reading mode')}
+      </button>
+      <button
+        className="btn btn-ghost sm"
+        title={tr('打开阅览页并唤起打印，另存为 PDF', 'Open the reader and print to save as PDF')}
+        onClick={onExport}
+      >
+        <Icon name="download" size={13} />
+        {tr('导出 PDF', 'Export PDF')}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
The shared-library browser had grown a full detail pane, while the same paper opened from the daily feed, a topic's related work, or a personal library showed a stripped-down version. Every endpoint involved already accepts pool-reachable papers (`include_pool=True`), and the daily detail already returns `concepts` — so all three gaps were frontend-only. **No backend changes.**

## What each surface was missing

| | Daily | Related work | Personal library |
|---|---|---|---|
| Concept chips | shown but not clickable | missing | missing |
| Reading mode + PDF export | had it | missing | missing |
| Figure gallery | had it | inline figures only | inline figures only |
| Star + reading status | missing | missing | missing |
| My notes | missing | missing | missing |
| Tags | missing | missing | missing |
| Relevance ring | n/a | missing | missing |
| Metadata card + TL;DR | missing | had it | had it |

## Five shared blocks, not one shared pane

`features/shared/PaperDetailBlocks.tsx` — `PaperMyMetaRow`, `PaperNotesSection`, `ConceptChips`, `PaperTagsRow`, `WikiHeaderActions`.

A single `<PaperDetailPane>` was the obvious move and it's the wrong one here. The four surfaces disagree about where their data comes from: the shelf merges `ShelfItemRead` with `PaperDetail` under a field-priority rule (`item.tldr ?? paper?.tldr`) and its wiki body may be a personal or snapshot version that isn't on `paper.wiki_content`; the personal library has a paper-is-gone snapshot branch; the daily feed keys off `entry_id` while everything else uses `paper_id`. Folding that in means twenty optional props and six capability flags — less readable than the four panes are today. The blocks only take a `paperId`, which all four surfaces have.

The shared-library browser is rewired onto the same blocks, so there's exactly one implementation of each. It loses ~290 lines and should look identical.

One deviation from the plan: `ConceptChips.onOpen` receives the whole concept, not its id — the browser jumps by concept **id**, while the other two reuse `onWikiLink`, which builds `?concept=` from the concept **name**.

## Deliberate omissions

- **No relevance on daily papers.** The score lives on the membership row and pool-level papers get a synthetic one, so it is always null there — the block would render empty.
- **Snapshot entries** (paper deleted, only a snapshot left) get no star/notes/concepts/figures: there's no `paper_id` to call the personal-dimension endpoints with.
- Shelf and personal-library list rows still show no star or note count, so those invalidations go to the detail plus a list-key prefix rather than doing finer optimistic updates.

## Also fixed along the way

- `DailyDetailPane` had a local-state reset effect but its call site had no `key` — so `readerOpen` leaked across papers. Added `key={selectedId}` and dropped the effect, which also resets the new local state.
- Daily compile now invalidates `['paper']`: compiling writes the TL;DR and concepts back to the pool paper, and the right-hand pane was showing the stale copy.
- The shelf's "why relevant" note is now titled 课题备注 · 为什么相关, with 我的笔记 below it, so the topic-visible note and the private one aren't confusable.

## Verification

`tsc --noEmit` 0 errors, `npm run build` passes.
