### PR TITLE
refactor(libraries): thread canManage through the shared library tabs

### DIFF
--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -1107,6 +1107,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
         ) : tab === 'concepts' ? (
           <ConceptsTab
             libraryId={libraryId}
+            canManage={false}
             selectedId={conceptId}
             onSelect={setConceptId}
             onOpenPaper={goPaper}
@@ -1117,7 +1118,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
             <GraphTab libraryId={libraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
           </Suspense>
         ) : tab === 'chat' ? (
-          <LibraryChatTab libraryId={libraryId} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
+          <LibraryChatTab libraryId={libraryId} canManage={false} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
         ) : tab === 'notes' ? (
           <NotesTab libraryId={libraryId} />
         ) : tab === 'govern' ? (

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -81,7 +81,7 @@ export function LibraryDetailPage() {
       />
       <StatusBanner lib={lib} />
       {canManage ? (
-        <WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} />
+        <WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} canManage={canManage} />
       ) : (
         <LibraryBrowse libraryId={lib.id} />
       )}

--- a/src/frontend/src/features/wiki/ConceptsTab.tsx
+++ b/src/frontend/src/features/wiki/ConceptsTab.tsx
@@ -28,10 +28,15 @@ const CATEGORY_FILTERS: CategoryFilter[] = [
 ];
 
 export interface ConceptsTabProps {
-  /** 课题 id（成员视角：project 作用域端点 + 概念补建按钮）。 */
+  /** 课题 id（给定时列表与概念补建走 project 作用域端点）。 */
   pid?: string;
-  /** 共享库只读视角（P5c）：给定时列表走 /libraries/{id}/concepts，隐藏补建按钮。 */
+  /** 库作用域：给定时列表与概念补建走 /libraries/{id}/* 端点。 */
   libraryId?: string;
+  /**
+   * 能否管理这个库。本组件同时被文献工作台和共享库只读浏览复用，两边都会传 libraryId，
+   * 所以管理操作（概念补建）只认这个开关，不能靠「有没有 libraryId」判断。
+   */
+  canManage?: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onOpenPaper: (id: string) => void;
@@ -186,7 +191,15 @@ function ConceptDetailPane({
   );
 }
 
-export function ConceptsTab({ pid, libraryId, selectedId, onSelect, onOpenPaper, onWikiLink }: ConceptsTabProps) {
+export function ConceptsTab({
+  pid,
+  libraryId,
+  canManage = false,
+  selectedId,
+  onSelect,
+  onOpenPaper,
+  onWikiLink,
+}: ConceptsTabProps) {
   const queryClient = useQueryClient();
   const [category, setCategory] = useState<CategoryFilter>('all');
   const [qInput, setQInput] = useState('');
@@ -200,10 +213,11 @@ export function ConceptsTab({ pid, libraryId, selectedId, onSelect, onOpenPaper,
   });
   const concepts = useMemo(() => data ?? [], [data]);
 
-  // 全库概念补建：编译过但概念没上链的历史论文（比如批量任务中断）从这里补（成员视角限定）
-  const canRelink = !!pid && !libraryId;
+  // 全库概念补建：编译过但概念没上链的历史论文（比如批量任务中断）从这里补。
+  // 只有能管理这个库的人看得到；库作用域优先走 /libraries 端点，否则回落课题端点。
+  const canRelink = canManage && !!(libraryId || pid);
   const relinkMutation = useMutation({
-    mutationFn: () => api.relinkConcepts(pid!),
+    mutationFn: () => (libraryId ? api.relinkLibraryConcepts(libraryId) : api.relinkConcepts(pid!)),
     onSuccess: (r) => {
       if (r.concepts_created === 0 && r.links_created === 0) {
         toast(
@@ -219,9 +233,16 @@ export function ConceptsTab({ pid, libraryId, selectedId, onSelect, onOpenPaper,
           'ok',
         );
       }
-      void queryClient.invalidateQueries({ queryKey: ['concepts', pid] });
+      // 两种作用域的 queryKey 形状不同，按当前作用域刷新对应的那组
+      if (libraryId) {
+        void queryClient.invalidateQueries({ queryKey: ['lib-concepts', libraryId] });
+        void queryClient.invalidateQueries({ queryKey: ['papers', libraryId] });
+        void queryClient.invalidateQueries({ queryKey: ['lib-papers', libraryId] });
+      } else {
+        void queryClient.invalidateQueries({ queryKey: ['concepts', pid] });
+        void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
+      }
       void queryClient.invalidateQueries({ queryKey: ['concept'] });
-      void queryClient.invalidateQueries({ queryKey: ['papers', pid] });
       void queryClient.invalidateQueries({ queryKey: ['paper'] });
     },
     onError: (e) =>

--- a/src/frontend/src/features/wiki/LibraryChatTab.tsx
+++ b/src/frontend/src/features/wiki/LibraryChatTab.tsx
@@ -211,15 +211,29 @@ export interface LibraryChatTabProps {
   pid?: string;
   /** 独立库作用域（走 /libraries/{id}/chat）；与 pid 二选一 */
   libraryId?: string;
+  /**
+   * 能否管理这个库。本组件同时被文献工作台和共享库只读浏览复用，两边都会传 libraryId，
+   * 所以「补建索引」这类管理操作只认这个开关，不能靠「有没有 libraryId」判断。
+   */
+  canManage?: boolean;
   onOpenPaper: (id: string) => void;
   /** [[概念名]] 双链点击 → 按名称跳概念库 */
   onWikiLink?: WikiLinkHandler;
 }
 
-export function LibraryChatTab({ pid, libraryId, onOpenPaper, onWikiLink }: LibraryChatTabProps) {
+export function LibraryChatTab({
+  pid,
+  libraryId,
+  canManage = false,
+  onOpenPaper,
+  onWikiLink,
+}: LibraryChatTabProps) {
   const scopePid = pid ?? '';
+  // 补建索引是管理操作：库作用域优先走 /libraries 端点，否则回落课题端点
+  const canRebuild = canManage && !!(libraryId || pid);
   const rebuildMutation = useMutation({
-    mutationFn: () => api.rebuildFulltextIndex(scopePid),
+    mutationFn: () =>
+      libraryId ? api.rebuildLibraryFulltextIndex(libraryId) : api.rebuildFulltextIndex(scopePid),
     onSuccess: (r) => {
       if (r.papers_indexed === 0) {
         toast(tr('全文索引已是最新', 'Full-text index is up to date'), 'info');
@@ -346,7 +360,7 @@ export function LibraryChatTab({ pid, libraryId, onOpenPaper, onWikiLink }: Libr
         'Answers are grounded in full-text passages from the whole library; [n] marks a source number.',
       )}
       headerAction={
-        libraryId ? undefined : (
+        !canRebuild ? undefined : (
           <button
             className="btn btn-ghost sm"
             style={{ height: 26, fontSize: 10.5, flexShrink: 0 }}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -28,7 +28,16 @@ const PresentationModal = lazy(() =>
 
 type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | 'govern';
 
-export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: string }) {
+export function WikiWorkbench({
+  pid,
+  libraryId,
+  canManage = false,
+}: {
+  pid?: string;
+  libraryId?: string;
+  /** 能否管理这个库（决定共享 Tab 里的管理操作显不显示）；由调用方按 can_manage 传入。 */
+  canManage?: boolean;
+}) {
   const navigate = useNavigate();
 
   // 独立库（无起源课题）：集合级数据与导出走 /libraries/{id}/* 端点；PPT 仍是课题域，隐藏。
@@ -202,6 +211,7 @@ export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: st
           <ConceptsTab
             pid={pid}
             libraryId={tabLibraryId}
+            canManage={canManage}
             selectedId={conceptId}
             onSelect={setConceptId}
             onOpenPaper={goPaper}
@@ -212,7 +222,13 @@ export function WikiWorkbench({ pid, libraryId }: { pid?: string; libraryId?: st
             <GraphTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
           </Suspense>
         ) : tab === 'chat' ? (
-          <LibraryChatTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onWikiLink={onWikiLink} />
+          <LibraryChatTab
+            pid={pid}
+            libraryId={tabLibraryId}
+            canManage={canManage}
+            onOpenPaper={goPaper}
+            onWikiLink={onWikiLink}
+          />
         ) : tab === 'ingest' ? (
           <IngestTab
             pid={pid}


### PR DESCRIPTION
Step 2 of the library/topic decoupling.

## The problem

`ConceptsTab`, `LibraryChatTab`, `GraphTab` and `NotesTab` are rendered both by the manage workbench and by the read-only `LibraryBrowse` — and **both pass `libraryId`**. So `libraryId` could not be used to decide whether to show a maintenance action, even though it was effectively standing in for one.

That is exactly why PR-1 left its two new endpoints unwired: gating them on `libraryId` alone would have shown 403-ing buttons to every reader browsing a public library.

## The fix

An explicit `canManage` prop, defaulting to **`false`** — a missed call site hides the action rather than exposing it.

```
LibraryDetailPage (has lib.can_manage)
  ├─ can manage → WikiWorkbench canManage
  │                 ├─ ConceptsTab canManage
  │                 └─ LibraryChatTab canManage
  └─ otherwise  → LibraryBrowse
                    ├─ ConceptsTab canManage={false}
                    └─ LibraryChatTab canManage={false}
```

The in-tab conditions move from "is there a libraryId" to "may I manage":

- `ConceptsTab`: `canRelink = canManage && !!(libraryId || pid)` (was `!!pid && !libraryId`)
- `LibraryChatTab`: `canRebuild = canManage && !!(libraryId || pid)`

## Wiring up PR-1's endpoints

Both actions prefer the library-scoped call and fall back to the topic-scoped one:

```ts
mutationFn: () => (libraryId ? api.relinkLibraryConcepts(libraryId) : api.relinkConcepts(pid!))
mutationFn: () => (libraryId ? api.rebuildLibraryFulltextIndex(libraryId) : api.rebuildFulltextIndex(scopePid))
```

Topic-backed libraries have `tabLibraryId === undefined`, so they still take the project endpoints and behave identically. Standalone libraries get both actions for the first time. Read-only visitors see neither. No topic-scoped button was removed — that's PR-4.

## Stale-cache fix

Relink's `onSuccess` invalidated `['concepts', pid]` / `['papers', pid]` unconditionally. Those match nothing in library mode, so the concept list stayed stale after a rebuild. Now branches by scope.

## Explicitly out of scope

`tabLibraryId` is untouched. Switching topic-backed libraries onto the library endpoints changes the auth rule from "member of the topic" to "curator of the library", which would strip manage rights from the people who have them today. That has to ship in the same PR as the curator backfill — PR-3.

## Personal-dimension writes, deliberately not gated

Star, reading status, personal notes, personal-wiki generation, save-to-my-library, and the chat itself stay open to everyone — they're already open in read-only browsing. Only the "rebuild index" button next to the chat is a manage action.

## Not done

- `GraphTab` / `NotesTab` get no `canManage`: neither has a single mutation, and `noUnusedParameters` would reject an unused prop. One line to add when they grow one.
- Relink doesn't invalidate the graph query. It doesn't today in topic scope either, and adding it would change topic-library behaviour, which this PR promises not to do. Left for PR-4.
- `GovernanceTab` / `IngestTab` keep their existing `readOnly` prop rather than being renamed to `canManage` — a pure rename touching files outside this PR's scope. Also PR-4.

## Verification

`tsc --noEmit` 0 errors, `npm run build` passes.
