### PR TITLE
feat(shelf,library): recycle bin for related work and my library

### DIFF
--- a/src/backend/alembic/versions/a7f4c2e91b83_shelf_and_library_trash.py
+++ b/src/backend/alembic/versions/a7f4c2e91b83_shelf_and_library_trash.py
@@ -1,0 +1,48 @@
+"""相关研究书架 + 我的文献库 回收站（软删）
+
+- topic_papers.trashed_at（timestamptz）/ trashed_by（Uuid，FK→users，SET NULL）：
+  移出书架改为软删，可召回 / 彻底删除 / 清空。唯一键 uq_topic_papers_topic_paper
+  覆盖软删行，同一篇再次入架走「复活」而不是插新行。
+  索引 ix_topic_papers_topic_trashed(topic_id, trashed_at)：默认列表 / 回收站两条取行路径。
+- user_library_entries.trashed_at（timestamptz）：取消收藏 / 删除条目进回收站，
+  不再混进浏览记录。
+
+存量行 trashed_at 全为 NULL = 都在架 / 都不在回收站，语义与迁移前一致。
+
+Revision ID: a7f4c2e91b83
+Revises: 49ddb68e7cf2
+Create Date: 2026-07-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7f4c2e91b83"
+down_revision: str | None = "49ddb68e7cf2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("topic_papers") as batch:
+        batch.add_column(sa.Column("trashed_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("trashed_by", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_topic_papers_trashed_by", "users", ["trashed_by"], ["id"], ondelete="SET NULL"
+        )
+        batch.create_index("ix_topic_papers_topic_trashed", ["topic_id", "trashed_at"])
+    op.add_column(
+        "user_library_entries", sa.Column("trashed_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_library_entries", "trashed_at")
+    with op.batch_alter_table("topic_papers") as batch:
+        batch.drop_index("ix_topic_papers_topic_trashed")
+        batch.drop_constraint("fk_topic_papers_trashed_by", type_="foreignkey")
+        batch.drop_column("trashed_by")
+        batch.drop_column("trashed_at")

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -47,7 +47,7 @@ async def _get_own_entry(session: AsyncSession, entry_id: uuid.UUID, user: User)
 
 @router.get("/me/library", response_model=LibraryPage)
 async def list_library(
-    tab: str = Query(default="history", pattern="^(saved|history)$"),
+    tab: str = Query(default="history", pattern="^(saved|history|trash)$"),
     q: str | None = Query(default=None),
     mode: str = Query(default="keyword", pattern="^(keyword|semantic)$"),
     sort: str = Query(default="recent", pattern="^(recent|title|visits|year)$"),
@@ -111,7 +111,7 @@ async def list_library(
     )
 
 
-# 注意：/visits 与 /state 必须注册在 /{entry_id} 之前，避免被路径参数抢占
+# 注意：/visits、/state、/trash/empty 必须注册在 /{entry_id} 之前，避免被路径参数抢占
 
 
 @router.post(
@@ -135,6 +135,16 @@ async def clear_history(
 ) -> None:
     """清空浏览记录：未收藏条目删除，已收藏条目保留但清零访问统计。"""
     await library_service.clear_history(session, user_id=user.id)
+
+
+@router.post("/me/library/trash/empty")
+async def empty_library_trash(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, int]:
+    """清空回收站：彻底删除本人全部已删除的条目，返回 {deleted}。"""
+    deleted = await library_service.purge_trash(session, user_id=user.id)
+    return {"deleted": deleted}
 
 
 @router.get("/me/library/state", response_model=LibraryStateRead)
@@ -213,6 +223,18 @@ async def get_entry_detail(
     return LibraryEntryDetail.model_validate(entry)
 
 
+@router.post("/me/library/{entry_id}/restore", response_model=LibraryEntryRead)
+async def restore_entry(
+    entry_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibraryEntryRead:
+    """从回收站召回：出回收站并回到收藏（与「收藏一条已有条目」同一条路径）。"""
+    entry = await _get_own_entry(session, entry_id, user)
+    entry = await library_service.set_saved(session, entry=entry, saved=True)
+    return LibraryEntryRead.model_validate(entry)
+
+
 @router.patch("/me/library/{entry_id}", response_model=LibraryEntryRead)
 async def update_entry(
     entry_id: uuid.UUID,
@@ -234,7 +256,7 @@ async def remove_entry(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """unsave=取消收藏（浏览记录保留）；purge=彻底删除该条目。"""
+    """unsave=取消收藏（条目移入回收站，可召回）；purge=彻底删除该条目。"""
     entry = await _get_own_entry(session, entry_id, user)
     if mode == "purge":
         await library_service.purge_entry(session, entry=entry)

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -2,7 +2,8 @@
 
 成员鉴权与现有 projects 一致（非成员一律 404）。业务规则在
 services/topic_shelf.py：入架落 wiki 快照 + 同步 upsert 个人库；
-移出只删书架行；个人补充入库不建方向库成员行。
+移出只动书架行（软删进回收站，可召回 / 彻底删除 / 清空）；
+个人补充入库不建方向库成员行。
 """
 
 import uuid
@@ -50,6 +51,7 @@ async def list_shelf(
     reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
     starred: bool | None = Query(default=None),
     sort: str = Query(default="added", pattern="^(added|year|relevance|title)$"),
+    trashed: bool = Query(default=False, description="true=列回收站（已移出的条目）"),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> ShelfPage:
@@ -68,6 +70,7 @@ async def list_shelf(
         reading_status=reading_status,
         starred=starred,
         sort=sort,
+        trashed=trashed,
     )
     return ShelfPage(
         items=[ShelfItemRead.model_validate(i) for i in items],
@@ -86,6 +89,18 @@ async def list_shelf_ids(
     await _require_member(session, project_id, user)
     ids = await shelf_service.shelf_paper_ids(session, project_id=project_id)
     return ShelfIdsRead(paper_ids=ids)
+
+
+@router.post("/projects/{project_id}/shelf/trash/empty")
+async def empty_shelf_trash(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, int]:
+    """清空回收站：彻底删除本课题书架上全部已移出的条目，返回 {deleted}。"""
+    await _require_member(session, project_id, user)
+    deleted = await shelf_service.empty_shelf_trash(session, project_id=project_id)
+    return {"deleted": deleted}
 
 
 @router.post(
@@ -196,20 +211,44 @@ async def refresh_shelf_snapshot(
     return ShelfItemRead.model_validate(item)
 
 
+@router.post("/projects/{project_id}/shelf/{paper_id}/restore", response_model=ShelfItemRead)
+async def restore_to_shelf(
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ShelfItemRead:
+    """从回收站召回：条目原样回到书架（不在回收站里 → 404）。"""
+    await _require_member(session, project_id, user)
+    try:
+        item = await shelf_service.restore_from_shelf(
+            session, project_id=project_id, paper_id=paper_id, user_id=user.id
+        )
+    except shelf_service.ShelfItemNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None
+    return ShelfItemRead.model_validate(item)
+
+
 @router.delete(
     "/projects/{project_id}/shelf/{paper_id}", status_code=status.HTTP_204_NO_CONTENT
 )
 async def remove_from_shelf(
     project_id: uuid.UUID,
     paper_id: uuid.UUID,
+    hard: bool = Query(default=False, description="true=彻底删除（不进回收站）"),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    """移出书架：只删书架行，个人库条目不动。"""
+    """移出书架：默认软删进回收站（可召回），hard=true 彻底删除；个人库条目都不动。"""
     await _require_member(session, project_id, user)
     try:
-        await shelf_service.remove_from_shelf(
-            session, project_id=project_id, paper_id=paper_id
-        )
+        if hard:
+            await shelf_service.purge_from_shelf(
+                session, project_id=project_id, paper_id=paper_id
+            )
+        else:
+            await shelf_service.remove_from_shelf(
+                session, project_id=project_id, paper_id=paper_id, user_id=user.id
+            )
     except shelf_service.ShelfItemNotFoundError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SHELF_ITEM_NOT_FOUND") from None

--- a/src/backend/app/models/library.py
+++ b/src/backend/app/models/library.py
@@ -16,7 +16,8 @@ class UserLibraryEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     papers 表按方向隔离且随方向级联删除，所以这里存元数据快照而非仅外键；
     last_paper_id 只是「跳回活体论文」的软引用（SET NULL）。
-    saved=false 的条目是纯浏览记录；收藏即置位 saved，取消收藏不删行。
+    saved=false 且未软删的条目是纯浏览记录；收藏即置位 saved，取消收藏不删行——
+    落 trashed_at 进回收站（可召回 / 彻底删除 / 清空）。
     """
 
     __tablename__ = "user_library_entries"
@@ -40,6 +41,9 @@ class UserLibraryEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     wiki_content: Mapped[str | None] = mapped_column(Text)
     saved: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     saved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 回收站：取消收藏 / 删除条目 = 软删（trashed_at 置位），可召回、可彻底删除、可清空。
+    # 软删条目不出现在任何 tab（含浏览记录），也不算「论文仍被引用」。
+    trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     note: Mapped[str | None] = mapped_column(Text)
     visit_count: Mapped[int] = mapped_column(default=0, nullable=False)
     last_visited_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/models/topic_shelf.py
+++ b/src/backend/app/models/topic_shelf.py
@@ -11,7 +11,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Index, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -25,6 +25,8 @@ class TopicPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "topic_papers"
     __table_args__ = (
         UniqueConstraint("topic_id", "paper_id", name="uq_topic_papers_topic_paper"),
+        # 默认列表按「课题 + 未删」取行，回收站按「课题 + 已删」取行
+        Index("ix_topic_papers_topic_trashed", "topic_id", "trashed_at"),
     )
 
     # 过渡期课题 = project（P5 拆出 Topic 实体后平移）
@@ -44,6 +46,13 @@ class TopicPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 课题语境的「为什么相关」备注
     note: Mapped[str | None] = mapped_column(Text)
     added_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+    # 回收站：移出书架 = 软删（trashed_at 置位），可召回 / 彻底删除 / 清空。
+    # 唯一键 uq_topic_papers_topic_paper 覆盖软删行，故同一篇再次入架走「复活」
+    # （services/topic_shelf.py::add_to_shelf），不插新行。
+    trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    trashed_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )
 

--- a/src/backend/app/schemas/library.py
+++ b/src/backend/app/schemas/library.py
@@ -22,6 +22,8 @@ class LibraryEntryRead(BaseModel):
     tldr: str | None
     saved: bool
     saved_at: datetime | None
+    # 非空 = 在回收站里（可召回 / 彻底删除）；回收站条目不出现在收藏与浏览记录
+    trashed_at: datetime | None = None
     note: str | None
     visit_count: int
     last_visited_at: datetime | None

--- a/src/backend/app/schemas/shelf.py
+++ b/src/backend/app/schemas/shelf.py
@@ -28,6 +28,8 @@ class ShelfItemRead(BaseModel):
     snapshot_at: datetime | None
     source_library_id: uuid.UUID | None
     added_at: datetime
+    # 非空 = 已移出书架、在课题回收站里（可召回 / 彻底删除）
+    trashed_at: datetime | None = None
     # 个人补充入架时启动的后台补全任务 id（下载/抽取/向量化）；无需补全时为 null。
     task_id: str | None = None
 

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -756,7 +756,9 @@ async def entry_collections(
     topic_ids = (
         (
             await session.execute(
-                select(TopicPaper.topic_id).where(TopicPaper.paper_id == entry.paper_id)
+                select(TopicPaper.topic_id).where(
+                    TopicPaper.paper_id == entry.paper_id, TopicPaper.trashed_at.is_(None)
+                )
             )
         )
         .scalars()
@@ -859,7 +861,10 @@ async def collect_papers(
             existing = (
                 await session.execute(
                     select(TopicPaper.id).where(
-                        TopicPaper.topic_id == topic_id, TopicPaper.paper_id == paper.id
+                        TopicPaper.topic_id == topic_id,
+                        TopicPaper.paper_id == paper.id,
+                        # 回收站里的旧行不算「已入架」：add_to_shelf 会把它复活
+                        TopicPaper.trashed_at.is_(None),
                     )
                 )
             ).scalar_one_or_none()

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -95,7 +95,9 @@ async def list_project_notes(
     library_ids = await get_source_library_ids(session, project_id)
     scope_conditions = [
         PaperNote.paper_id.in_(
-            select(TopicPaper.paper_id).where(TopicPaper.topic_id == project_id)
+            select(TopicPaper.paper_id).where(
+                TopicPaper.topic_id == project_id, TopicPaper.trashed_at.is_(None)
+            )
         )
     ]
     if library_ids:

--- a/src/backend/app/services/paper_merge.py
+++ b/src/backend/app/services/paper_merge.py
@@ -158,6 +158,10 @@ async def merge_papers(
             existing.snapshot_at = row.snapshot_at
         if not existing.note and row.note:
             existing.note = row.note
+        # 一边在架一边在回收站 → 合并后在架（别让合并把还在书架上的条目变没）
+        if existing.trashed_at is not None and row.trashed_at is None:
+            existing.trashed_at = None
+            existing.trashed_by = None
         await session.delete(row)
         shelf_merged += 1
     report["topic_papers"] = {"repointed": shelf_repointed, "merged": shelf_merged}

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -373,7 +373,11 @@ async def _pool_paper_view(
     stmt = (
         select(TopicPaper.topic_id)
         .join(ProjectMember, ProjectMember.project_id == TopicPaper.topic_id)
-        .where(TopicPaper.paper_id == paper_id, ProjectMember.user_id == user_id)
+        .where(
+            TopicPaper.paper_id == paper_id,
+            TopicPaper.trashed_at.is_(None),  # 回收站里的书架行不再是可达链路
+            ProjectMember.user_id == user_id,
+        )
         .order_by(TopicPaper.created_at)
         .limit(1)
     )
@@ -622,14 +626,18 @@ async def _delete_membership_rows(
 async def _paper_still_referenced(session: AsyncSession, paper: Paper) -> bool:
     """论文是否仍被任一「集合」引用——是则保留内容池本体。
 
-    集合 = 方向库成员 / 课题书架 / 个人文献库(仅 saved 收藏) / 每日推送 / 论著引用。个人库
-    既看软引用 last_paper_id，也看 dedup_key（论文曾被删过重加时软引用可能已断）；但只算
-    saved=True 的真收藏——saved=False 是纯浏览记录，不该让被删论文靠"看过一次"续命。派生
-    数据（笔记/划线/分块向量/个人元数据/标签关联/图片记录）不算集合，随本体级联清理。
+    集合 = 方向库成员 / 课题书架 / 个人文献库(仅 saved 收藏) / 每日推送 / 论著引用。书架与
+    个人库都只算「在架/在收藏」的行：回收站里的书架行（trashed_at 非空）不该让被删论文
+    续命。个人库既看软引用 last_paper_id，也看 dedup_key（论文曾被删过重加时软引用可能已
+    断）；但只算 saved=True 的真收藏——saved=False 是纯浏览记录（含回收站条目），不该让被
+    删论文靠"看过一次"续命。派生数据（笔记/划线/分块向量/个人元数据/标签关联/图片记录）
+    不算集合，随本体级联清理。
     """
     checks = (
         select(LibraryPaper.id).where(LibraryPaper.paper_id == paper.id),
-        select(TopicPaper.id).where(TopicPaper.paper_id == paper.id),
+        select(TopicPaper.id).where(
+            TopicPaper.paper_id == paper.id, TopicPaper.trashed_at.is_(None)
+        ),
         select(DailyFeedEntry.id).where(DailyFeedEntry.paper_id == paper.id),
         select(UserPublication.id).where(UserPublication.paper_id == paper.id),
         select(UserLibraryEntry.id).where(

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -6,6 +6,9 @@
   快照（P5b 三层解析；个人版 = 请求者本人 user_library_entries.wiki_content）；
 - 入架必入个人库（user_library_entries，saved=true，共享同一次快照写入）；
   移出书架不动个人库。
+
+移出书架是软删（trashed_at）：进课题回收站，可召回 / 彻底删除 / 清空。唯一键
+(topic_id, paper_id) 覆盖软删行，所以再次入架走「复活」而不是插新行。
 """
 
 import uuid
@@ -110,15 +113,25 @@ def _item_dict(
         "snapshot_at": row.snapshot_at,
         "source_library_id": row.source_library_id,
         "added_at": row.created_at,
+        "trashed_at": row.trashed_at,
     }
 
 
 async def _get_row(
-    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    trashed: bool | None = False,
 ) -> TopicPaper | None:
+    """取书架行：trashed=False 只取在架的、True 只取回收站里的、None 两者都取。"""
     stmt = select(TopicPaper).where(
         TopicPaper.topic_id == project_id, TopicPaper.paper_id == paper_id
     )
+    if trashed is True:
+        stmt = stmt.where(TopicPaper.trashed_at.is_not(None))
+    elif trashed is False:
+        stmt = stmt.where(TopicPaper.trashed_at.is_(None))
     return (await session.execute(stmt)).scalar_one_or_none()
 
 
@@ -151,6 +164,7 @@ async def list_shelf(
     reading_status: str | None = None,
     starred: bool | None = None,
     sort: str = "added",
+    trashed: bool = False,
 ) -> tuple[list[dict[str, Any]], int]:
     """分页列书架，每条带解析后的 wiki 内容与来源状态。
 
@@ -158,11 +172,14 @@ async def list_shelf(
     q/author/affiliation/starred/reading_status 复用 :func:`apply_paper_filters`
     （只作用于内容池 Paper / 个人视角 PaperUserMeta，不触碰方向库）；
     year 范围就地作用于 ``Paper.year``。sort：added（默认，最新入架在前）/
-    year / relevance / title。"""
+    year / relevance / title。trashed=True 列回收站（固定按移出时间倒序）。"""
     base = (
         select(TopicPaper, Paper)
         .join(Paper, Paper.id == TopicPaper.paper_id)
-        .where(TopicPaper.topic_id == project_id)
+        .where(
+            TopicPaper.topic_id == project_id,
+            TopicPaper.trashed_at.is_not(None) if trashed else TopicPaper.trashed_at.is_(None),
+        )
     )
     # 复用论文库过滤器：传 None 的库相关参数（status/created_*）不会引用/join 方向库，
     # 故过滤只作用于 Paper 本体与请求者个人视角（PaperUserMeta），书架保持方向无关。
@@ -200,6 +217,8 @@ async def list_shelf(
         order = (relevance_sub.desc().nulls_last(), TopicPaper.created_at.desc())
     else:  # added（默认，最新入架在前）
         order = (TopicPaper.created_at.desc(),)
+    if trashed:  # 回收站只按移出时间倒序（最近移出在前）
+        order = (TopicPaper.trashed_at.desc(),)
 
     rows = (
         await session.execute(
@@ -226,13 +245,28 @@ async def list_shelf(
 
 
 async def shelf_paper_ids(session: AsyncSession, *, project_id: uuid.UUID) -> list[uuid.UUID]:
-    """书架全部 paper_id（前端标记「已入架」勾选态用）。"""
+    """在架的全部 paper_id（前端标记「已入架」勾选态用；回收站里的不算）。"""
     stmt = (
         select(TopicPaper.paper_id)
-        .where(TopicPaper.topic_id == project_id)
+        .where(TopicPaper.topic_id == project_id, TopicPaper.trashed_at.is_(None))
         .order_by(TopicPaper.created_at.desc())
     )
     return list((await session.execute(stmt)).scalars().all())
+
+
+async def _snapshot_source(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
+) -> tuple[str | None, uuid.UUID | None]:
+    """入架瞬间可得的 (库版 wiki, 来源库 id)。
+
+    来源库溯源：本课题隐式库优先，其次提供快照 wiki 的库，再其次任一库；都没有 = 个人补充。
+    """
+    wiki_rows = await _wiki_rows_for(session, [paper_id])
+    live_wiki = _pick_live_wiki(wiki_rows, project_id)
+    own = next((r for r in wiki_rows if r.project_id == project_id), None)
+    with_wiki = next((r for r in wiki_rows if r.wiki_content), None)
+    source = own or with_wiki or (wiki_rows[0] if wiki_rows else None)
+    return live_wiki, source.library_id if source is not None else None
 
 
 async def add_to_shelf(
@@ -245,34 +279,45 @@ async def add_to_shelf(
 ) -> dict[str, Any]:
     """入架：落 wiki 快照 + 同步 upsert 个人库（saved，共享同一次快照）。
 
-    重复入架幂等：只更新 note（快照保持首次入架时的版本）。
+    重复入架幂等：只更新 note（快照保持首次入架时的版本）。曾被移出（回收站里）的
+    论文再次入架 = **复活那一行**——唯一键 (topic_id, paper_id) 覆盖软删行，插新行会撞键；
+    复活时清空回收站标记并按当下重取来源库 / 快照，等同一次全新入架。
     """
     paper = await session.get(Paper, paper_id)
     if paper is None:
         raise PaperNotFoundError(str(paper_id))
-    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
-    if row is not None:
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id, trashed=None)
+    if row is not None and row.trashed_at is None:
         if note is not None:
             row.note = note
         await session.commit()
         return await _item_of(session, row, paper, project_id, user_id)
 
-    wiki_rows = await _wiki_rows_for(session, [paper_id])
-    live_wiki = _pick_live_wiki(wiki_rows, project_id)
-    # 来源库溯源：本课题隐式库优先，其次提供快照 wiki 的库，再其次任一库；都没有 = 个人补充
-    own = next((r for r in wiki_rows if r.project_id == project_id), None)
-    with_wiki = next((r for r in wiki_rows if r.wiki_content), None)
-    source = own or with_wiki or (wiki_rows[0] if wiki_rows else None)
-    row = TopicPaper(
-        topic_id=project_id,
-        paper_id=paper_id,
-        source_library_id=source.library_id if source is not None else None,
-        wiki_snapshot=live_wiki,
-        snapshot_at=utcnow() if live_wiki is not None else None,
-        note=note,
-        added_by=user_id,
+    live_wiki, source_library_id = await _snapshot_source(
+        session, project_id=project_id, paper_id=paper_id
     )
-    session.add(row)
+    if row is not None:  # 回收站里的旧行复活
+        row.trashed_at = None
+        row.trashed_by = None
+        row.added_by = row.added_by or user_id
+        # 来源库按当下重取；论文已不在任何库时保留旧溯源（比抹成空更有信息量）
+        row.source_library_id = source_library_id or row.source_library_id
+        if live_wiki is not None:
+            row.wiki_snapshot = live_wiki
+            row.snapshot_at = utcnow()
+        if note is not None:
+            row.note = note
+    else:
+        row = TopicPaper(
+            topic_id=project_id,
+            paper_id=paper_id,
+            source_library_id=source_library_id,
+            wiki_snapshot=live_wiki,
+            snapshot_at=utcnow() if live_wiki is not None else None,
+            note=note,
+            added_by=user_id,
+        )
+        session.add(row)
     await session.flush()
     # 入架必入个人库（书架是个人库的课题投影）；save_paper 内部 commit 一并落书架行
     await user_library.save_paper(
@@ -326,14 +371,64 @@ async def refresh_snapshot(
 
 
 async def remove_from_shelf(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user_id: uuid.UUID | None = None,
+) -> None:
+    """移出书架 = 软删（进课题回收站）；个人库条目与内容池行都不动。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    row.trashed_at = utcnow()
+    row.trashed_by = user_id
+    await session.commit()
+
+
+async def restore_from_shelf(
+    session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID, user_id: uuid.UUID
+) -> dict[str, Any]:
+    """从回收站召回：清空回收站标记，条目原样回到书架（快照 / 备注都不动）。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id, trashed=True)
+    if row is None:
+        raise ShelfItemNotFoundError(str(paper_id))
+    row.trashed_at = None
+    row.trashed_by = None
+    await session.commit()
+    paper = await session.get(Paper, paper_id)
+    assert paper is not None  # 书架行外键保证
+    return await _item_of(session, row, paper, project_id, user_id)
+
+
+async def purge_from_shelf(
     session: AsyncSession, *, project_id: uuid.UUID, paper_id: uuid.UUID
 ) -> None:
-    """移出书架：只删书架行；个人库条目与内容池行都不动。"""
-    row = await _get_row(session, project_id=project_id, paper_id=paper_id)
+    """彻底删除一条书架行（在架的也可一步删净）；个人库条目与内容池行都不动。"""
+    row = await _get_row(session, project_id=project_id, paper_id=paper_id, trashed=None)
     if row is None:
         raise ShelfItemNotFoundError(str(paper_id))
     await session.delete(row)
     await session.commit()
+
+
+async def empty_shelf_trash(session: AsyncSession, *, project_id: uuid.UUID) -> int:
+    """清空课题回收站：彻底删除该课题全部软删书架行，返回删除条数。"""
+    rows = (
+        (
+            await session.execute(
+                select(TopicPaper).where(
+                    TopicPaper.topic_id == project_id, TopicPaper.trashed_at.is_not(None)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        await session.delete(row)
+    await session.commit()
+    return len(rows)
 
 
 class ShelfImportResult(NamedTuple):

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -1,4 +1,8 @@
-"""个人文献库：浏览记录 upsert、收藏、列表检索（用户级，方向无关）。"""
+"""个人文献库：浏览记录 upsert、收藏、列表检索、回收站（用户级，方向无关）。
+
+回收站 = trashed_at 软删：取消收藏 / 删除条目落 trashed_at，条目从所有 tab（含
+浏览记录）里消失，可召回（回到收藏）、可彻底删除、可清空。
+"""
 
 import json
 import uuid
@@ -15,7 +19,7 @@ from app.models.paper import Paper
 from app.services.dedup import dedup_key_for
 
 LIBRARY_SORTS = ("recent", "title", "visits", "year")
-LIBRARY_TABS = ("saved", "history")
+LIBRARY_TABS = ("saved", "history", "trash")
 
 
 def dedup_key_for_paper(paper: Paper) -> str:
@@ -81,6 +85,8 @@ async def record_visit(
             setattr(entry, field, value)
     entry.visit_count = (entry.visit_count or 0) + 1  # 未 flush 的新对象默认值尚未生效
     entry.last_visited_at = utcnow()
+    # 又打开了 = 又要看它：条目出回收站（否则新增的浏览在任何 tab 里都看不到）
+    entry.trashed_at = None
     await session.commit()
     await session.refresh(entry)
     return entry
@@ -102,11 +108,37 @@ async def save_paper(
 async def set_saved(
     session: AsyncSession, *, entry: UserLibraryEntry, saved: bool
 ) -> UserLibraryEntry:
+    """收藏 / 取消收藏。
+
+    取消收藏 = 移入回收站（trashed_at 置位），条目从所有 tab 里消失但可召回；
+    收藏（含从回收站召回）反过来清 trashed_at。saved_at 语义不变（只标收藏时间）。
+    """
     entry.saved = saved
     entry.saved_at = utcnow() if saved else None
+    entry.trashed_at = None if saved else utcnow()
     await session.commit()
     await session.refresh(entry)
     return entry
+
+
+async def purge_trash(session: AsyncSession, *, user_id: uuid.UUID) -> int:
+    """清空回收站：彻底删除本人全部软删条目，返回删除条数。"""
+    rows = (
+        (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.user_id == user_id,
+                    UserLibraryEntry.trashed_at.is_not(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for entry in rows:
+        await session.delete(entry)
+    await session.commit()
+    return len(rows)
 
 
 async def set_personal_wiki(
@@ -149,12 +181,13 @@ async def personal_paper_ids(
 ) -> list[uuid.UUID]:
     """个人库里能跳回活体论文的 paper_id 集合（last_paper_id 非空）。
 
-    tab="saved" 只取收藏条目；否则取全部有软引用的条目。按收藏时间→建条目时间
-    倒序（新→旧），对齐 shelf_paper_ids 形态，供个人库对话按论文集合检索用。
+    tab="saved" 只取收藏条目；否则取全部有软引用的条目（回收站里的一律不算）。按收藏
+    时间→建条目时间倒序（新→旧），对齐 shelf_paper_ids 形态，供个人库对话按论文集合检索用。
     """
     stmt = select(UserLibraryEntry.last_paper_id).where(
         UserLibraryEntry.user_id == user_id,
         UserLibraryEntry.last_paper_id.is_not(None),
+        UserLibraryEntry.trashed_at.is_(None),
     )
     if tab == "saved":
         stmt = stmt.where(UserLibraryEntry.saved.is_(True))
@@ -209,15 +242,23 @@ async def purge_entry(session: AsyncSession, *, entry: UserLibraryEntry) -> None
 
 
 async def clear_history(session: AsyncSession, *, user_id: uuid.UUID) -> None:
-    """清空浏览记录：未收藏条目删除，已收藏条目保留但清零访问统计。"""
+    """清空浏览记录：未收藏条目删除，已收藏条目保留但清零访问统计。
+
+    回收站里的条目一律不动——它们已经不在浏览记录里，清历史不该顺手清空回收站。
+    """
     await session.execute(
         delete(UserLibraryEntry).where(
-            UserLibraryEntry.user_id == user_id, UserLibraryEntry.saved.is_(False)
+            UserLibraryEntry.user_id == user_id,
+            UserLibraryEntry.saved.is_(False),
+            UserLibraryEntry.trashed_at.is_(None),
         )
     )
     await session.execute(
         update(UserLibraryEntry)
-        .where(UserLibraryEntry.user_id == user_id)
+        .where(
+            UserLibraryEntry.user_id == user_id,
+            UserLibraryEntry.trashed_at.is_(None),
+        )
         .values(visit_count=0, last_visited_at=None)
     )
     await session.commit()
@@ -239,10 +280,17 @@ async def list_entries(
     venue: str | None = None,
 ) -> tuple[list[UserLibraryEntry], int]:
     stmt = select(UserLibraryEntry).where(UserLibraryEntry.user_id == user_id)
-    if tab == "saved":
-        stmt = stmt.where(UserLibraryEntry.saved.is_(True))
+    # 回收站条目只出现在 trash tab；收藏 / 浏览记录都不含（否则删掉的会从浏览记录漏回来）
+    if tab == "trash":
+        stmt = stmt.where(UserLibraryEntry.trashed_at.is_not(None))
+    elif tab == "saved":
+        stmt = stmt.where(
+            UserLibraryEntry.saved.is_(True), UserLibraryEntry.trashed_at.is_(None)
+        )
     else:  # history：看过的条目（收藏但从未打开过的不算浏览记录）
-        stmt = stmt.where(UserLibraryEntry.visit_count > 0)
+        stmt = stmt.where(
+            UserLibraryEntry.visit_count > 0, UserLibraryEntry.trashed_at.is_(None)
+        )
     if q:
         pattern = f"%{q}%"
         stmt = stmt.where(
@@ -271,7 +319,9 @@ async def list_entries(
         stmt = stmt.where(UserLibraryEntry.year.isnot(None), UserLibraryEntry.year >= year_from)
     if year_to is not None:
         stmt = stmt.where(UserLibraryEntry.year.isnot(None), UserLibraryEntry.year <= year_to)
-    if sort == "title":
+    if tab == "trash":  # 回收站固定按移入时间倒序（最近删的在前）
+        stmt = stmt.order_by(UserLibraryEntry.trashed_at.desc())
+    elif sort == "title":
         stmt = stmt.order_by(UserLibraryEntry.title.asc())
     elif sort == "visits":
         stmt = stmt.order_by(

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -64,18 +64,22 @@ async def test_save_unsave_and_state(client):
     resp = await client.get("/api/me/library?tab=history", headers=headers)
     assert resp.json()["total"] == 0
 
-    # 取消收藏：条目保留（浏览过后进浏览记录）
+    # 取消收藏：条目进回收站（收藏与浏览记录都看不到，回收站里能看到）
     await client.post("/api/me/library/visits", json={"paper_id": paper_id}, headers=headers)
     resp = await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
     assert resp.status_code == 204
     resp = await client.get("/api/me/library?tab=saved", headers=headers)
     assert resp.json()["total"] == 0
     resp = await client.get("/api/me/library?tab=history", headers=headers)
+    assert resp.json()["total"] == 0
+    resp = await client.get("/api/me/library?tab=trash", headers=headers)
     assert resp.json()["total"] == 1
 
     # 彻底删除
     resp = await client.delete(f"/api/me/library/{entry_id}?mode=purge", headers=headers)
     assert resp.status_code == 204
+    resp = await client.get("/api/me/library?tab=trash", headers=headers)
+    assert resp.json()["total"] == 0
     resp = await client.get("/api/me/library?tab=history", headers=headers)
     assert resp.json()["total"] == 0
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "49ddb68e7cf2"  # email_verification_codes 邮箱验证码表
-PREV_REVISION = "f2d34705e152"  # 每日新论文池（Daily Paper）
+HEAD_REVISION = "a7f4c2e91b83"  # 相关研究书架 + 我的文献库 回收站（软删）
+PREV_REVISION = "49ddb68e7cf2"  # email_verification_codes 邮箱验证码表
 
 
 def _make_config(db_path: Path) -> Config:
@@ -247,14 +247,20 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：课题 × 文献库关联表（P7 Step 1）
     assert "topic_source_libraries" in columns["_tables"]
     assert columns["topic_source_libraries"] == {"topic_id", "library_id", "created_at"}
+    # 本分支新增：书架 / 个人库回收站（软删）
+    assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
+    assert "trashed_at" in columns["user_library_entries"]
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（f2d34705e152，每日新论文池）。
-    # 该步只回退本迁移（删 email_verification_codes 表），其余结构不动。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（49ddb68e7cf2，邮箱验证码表）。
+    # 该步只回退本迁移（删两张表的回收站列），其余结构不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    # 本迁移回退后验证码表消失；更早的 is_public / users.settings / P9e statement 都还在
-    assert "email_verification_codes" not in columns["_tables"]
+    # 本迁移回退后回收站列消失；更早的验证码表 / is_public / users.settings 都还在
+    assert "trashed_at" not in columns["topic_papers"]
+    assert "trashed_by" not in columns["topic_papers"]
+    assert "trashed_at" not in columns["user_library_entries"]
+    assert "email_verification_codes" in columns["_tables"]
     assert "is_public" in columns["direction_libraries"]
     assert "settings" in columns["users"]
     assert "statement" in columns["projects"]
@@ -305,6 +311,9 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    # 回收站列在重新 upgrade 后回归
+    assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
+    assert "trashed_at" in columns["user_library_entries"]
     assert "project_id" not in columns["paper_notes"]
     assert "project_id" not in columns["paper_highlights"]
     assert "models" in columns["llm_providers"]

--- a/src/backend/tests/test_shelf_and_library_trash.py
+++ b/src/backend/tests/test_shelf_and_library_trash.py
@@ -1,0 +1,340 @@
+"""相关研究书架 + 我的文献库 回收站（软删）：移出/召回/彻底删除/清空、复活、孤儿回收。"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.paper import Paper
+from app.models.topic_shelf import TopicPaper
+from app.services import papers as papers_service
+from tests.conftest import add_paper, register_and_login
+
+
+async def _setup(client, *, name="trash-proj", email="alice@example.com"):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], headers
+
+
+async def _seed_paper(project_id, **fields):
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), **fields)
+        await session.commit()
+        return str(paper.id)
+
+
+async def _shelf(client, headers, project_id, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    resp = await client.get(f"/api/projects/{project_id}/shelf?{qs}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---- 任务 A：课题相关研究书架 ----
+
+
+async def test_shelf_trash_restore_purge_and_empty(client):
+    project_id, headers = await _setup(client)
+    p1 = await _seed_paper(project_id, title="Trashable One", status="scored")
+    p2 = await _seed_paper(project_id, title="Keeper Two", status="scored")
+    for pid in (p1, p2):
+        resp = await client.post(
+            f"/api/projects/{project_id}/shelf", json={"paper_id": pid}, headers=headers
+        )
+        assert resp.status_code == 201, resp.text
+
+    # 移出 = 软删：默认列表看不到，回收站看得到
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{p1}", headers=headers)
+    assert resp.status_code == 204
+    page = await _shelf(client, headers, project_id)
+    assert [i["paper_id"] for i in page["items"]] == [p2]
+    assert page["total"] == 1
+    trash = await _shelf(client, headers, project_id, trashed="true")
+    assert [i["paper_id"] for i in trash["items"]] == [p1]
+    assert trash["items"][0]["trashed_at"] is not None
+    # ids 端点（前端「已入架」勾选态）不含回收站条目
+    resp = await client.get(f"/api/projects/{project_id}/shelf/ids", headers=headers)
+    assert resp.json()["paper_ids"] == [p2]
+    # 已在回收站里，再删一次 → 404
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{p1}", headers=headers)
+    assert resp.status_code == 404
+
+    # 召回：回到默认列表，回收站清空
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{p1}/restore", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["trashed_at"] is None
+    page = await _shelf(client, headers, project_id)
+    assert sorted(i["paper_id"] for i in page["items"]) == sorted([p1, p2])
+    assert (await _shelf(client, headers, project_id, trashed="true"))["total"] == 0
+    # 不在回收站里的条目召回 → 404
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/{p1}/restore", headers=headers
+    )
+    assert resp.status_code == 404
+
+    # 彻底删除：两边都没有
+    resp = await client.delete(
+        f"/api/projects/{project_id}/shelf/{p1}?hard=true", headers=headers
+    )
+    assert resp.status_code == 204
+    assert [i["paper_id"] for i in (await _shelf(client, headers, project_id))["items"]] == [p2]
+    assert (await _shelf(client, headers, project_id, trashed="true"))["total"] == 0
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(p1))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
+
+    # 清空回收站：只删软删行，在架的不动
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{p2}", headers=headers)
+    assert resp.status_code == 204
+    p3 = await _seed_paper(project_id, title="Still Shelved", status="scored")
+    await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": p3}, headers=headers
+    )
+    resp = await client.post(f"/api/projects/{project_id}/shelf/trash/empty", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deleted": 1}
+    assert (await _shelf(client, headers, project_id, trashed="true"))["total"] == 0
+    assert [i["paper_id"] for i in (await _shelf(client, headers, project_id))["items"]] == [p3]
+
+
+async def test_shelf_readd_after_trash_revives_row(client):
+    """软删后重新入架必须复活旧行——插新行会撞 uq_topic_papers_topic_paper 唯一键。"""
+    project_id, headers = await _setup(client, name="revive-proj")
+    resp = await client.post("/api/projects", json={"name": "revive-other"}, headers=headers)
+    other_id = resp.json()["id"]
+    # 论文最初只在本课题库里（入架时来源库 = 本课题库）
+    paper_id = await _seed_paper(
+        project_id, title="Revivable Paper", status="compiled", wiki_content="# 库版解读"
+    )
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf",
+        json={"paper_id": paper_id, "note": "初版备注"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    first_source = resp.json()["source_library_id"]
+    assert first_source is not None
+
+    resp = await client.delete(f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers)
+    assert resp.status_code == 204
+    # 同时把个人库条目也退成未收藏（模拟用户两边都清掉）
+    resp = await client.get(f"/api/me/library/state?paper_id={paper_id}", headers=headers)
+    entry_id = resp.json()["entry_id"]
+    await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+
+    # 重新入架：不撞唯一键（500），复活同一行并更新 note
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf",
+        json={"paper_id": paper_id, "note": "复活后备注"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["note"] == "复活后备注"
+    assert body["trashed_at"] is None
+    assert body["source_library_id"] == first_source  # 来源库按当下重取，仍是本课题库
+    assert body["wiki_source"] == "live"
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(TopicPaper).where(TopicPaper.paper_id == uuid.UUID(paper_id))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1  # 复活而非插新行
+        assert rows[0].trashed_at is None and rows[0].trashed_by is None
+        assert rows[0].note == "复活后备注"
+        # 入架必入个人库：个人库条目一并回到收藏、出回收站
+        entry = (
+            await session.execute(
+                select(UserLibraryEntry).where(
+                    UserLibraryEntry.last_paper_id == uuid.UUID(paper_id)
+                )
+            )
+        ).scalar_one()
+        assert entry.saved is True and entry.trashed_at is None
+
+    page = await _shelf(client, headers, project_id)
+    assert [i["paper_id"] for i in page["items"]] == [paper_id]
+    assert (await _shelf(client, headers, project_id, trashed="true"))["total"] == 0
+    # 另一个课题的书架不受影响（唯一键是 topic_id × paper_id）
+    assert (await _shelf(client, headers, other_id))["total"] == 0
+
+
+async def test_shelf_trash_requires_project_membership(client):
+    project_id, headers = await _setup(client, name="trash-authz")
+    paper_id = await _seed_paper(project_id, title="Members Only", status="scored")
+    await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": paper_id}, headers=headers
+    )
+    outsider = await register_and_login(client, email="trash-outsider@example.com")
+    outsider_headers = {"Authorization": f"Bearer {outsider}"}
+
+    for method, url in (
+        ("get", f"/api/projects/{project_id}/shelf?trashed=true"),
+        ("post", f"/api/projects/{project_id}/shelf/{paper_id}/restore"),
+        ("post", f"/api/projects/{project_id}/shelf/trash/empty"),
+        ("delete", f"/api/projects/{project_id}/shelf/{paper_id}?hard=true"),
+    ):
+        resp = await getattr(client, method)(url, headers=outsider_headers)
+        assert resp.status_code == 404, (method, url, resp.text)
+
+
+# ---- 任务 B：我的文献库 ----
+
+
+async def _library(client, headers, tab):
+    resp = await client.get(f"/api/me/library?tab={tab}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_library_unsave_goes_to_trash_and_restore(client):
+    project_id, headers = await _setup(client, name="lib-trash")
+    paper_id = await _seed_paper(project_id, title="Personal Paper", status="included")
+
+    # 浏览 + 收藏
+    await client.post("/api/me/library/visits", json={"paper_id": paper_id}, headers=headers)
+    resp = await client.post("/api/me/library", json={"paper_id": paper_id}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    entry_id = resp.json()["id"]
+    assert resp.json()["trashed_at"] is None
+
+    # 取消收藏 → 回收站；收藏 / 浏览记录都不含
+    resp = await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+    assert resp.status_code == 204
+    assert (await _library(client, headers, "saved"))["total"] == 0
+    assert (await _library(client, headers, "history"))["total"] == 0
+    trash = await _library(client, headers, "trash")
+    assert trash["total"] == 1
+    assert trash["items"][0]["id"] == entry_id
+    assert trash["items"][0]["trashed_at"] is not None
+
+    # 召回：回到收藏，回收站清空
+    resp = await client.post(f"/api/me/library/{entry_id}/restore", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["saved"] is True
+    assert resp.json()["trashed_at"] is None
+    assert (await _library(client, headers, "saved"))["total"] == 1
+    assert (await _library(client, headers, "history"))["total"] == 1
+    assert (await _library(client, headers, "trash"))["total"] == 0
+
+    # 彻底删除
+    await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+    resp = await client.delete(f"/api/me/library/{entry_id}?mode=purge", headers=headers)
+    assert resp.status_code == 204
+    assert (await _library(client, headers, "trash"))["total"] == 0
+    resp = await client.get(f"/api/me/library/{entry_id}", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_library_empty_trash_keeps_live_entries(client):
+    project_id, headers = await _setup(client, name="lib-empty-trash")
+    p1 = await _seed_paper(project_id, title="Trash Me", status="included")
+    p2 = await _seed_paper(project_id, title="Keep Me", status="included")
+    ids = {}
+    for pid in (p1, p2):
+        await client.post("/api/me/library/visits", json={"paper_id": pid}, headers=headers)
+        resp = await client.post("/api/me/library", json={"paper_id": pid}, headers=headers)
+        ids[pid] = resp.json()["id"]
+    await client.delete(f"/api/me/library/{ids[p1]}?mode=unsave", headers=headers)
+
+    resp = await client.post("/api/me/library/trash/empty", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deleted": 1}
+    assert (await _library(client, headers, "trash"))["total"] == 0
+    saved = await _library(client, headers, "saved")
+    assert [i["id"] for i in saved["items"]] == [ids[p2]]
+
+
+async def test_clear_history_keeps_trash(client):
+    """清空浏览记录不该顺手清空回收站（旧实现 delete WHERE saved=false 会误删）。"""
+    project_id, headers = await _setup(client, name="lib-clear-history")
+    p_trash = await _seed_paper(project_id, title="In Trash", status="included")
+    p_hist = await _seed_paper(project_id, title="Pure History", status="included")
+    for pid in (p_trash, p_hist):
+        await client.post("/api/me/library/visits", json={"paper_id": pid}, headers=headers)
+    resp = await client.post("/api/me/library", json={"paper_id": p_trash}, headers=headers)
+    trashed_id = resp.json()["id"]
+    await client.delete(f"/api/me/library/{trashed_id}?mode=unsave", headers=headers)
+
+    resp = await client.delete("/api/me/library/visits", headers=headers)
+    assert resp.status_code == 204
+    assert (await _library(client, headers, "history"))["total"] == 0  # 纯浏览条目被删
+    trash = await _library(client, headers, "trash")
+    assert [i["id"] for i in trash["items"]] == [trashed_id]  # 回收站原样保留
+    assert trash["items"][0]["visit_count"] == 1  # 访问统计也没被清零
+
+
+async def test_library_revisit_pulls_entry_out_of_trash(client):
+    """重新打开阅读页 = 又要看它：条目出回收站，回到浏览记录。"""
+    project_id, headers = await _setup(client, name="lib-revisit")
+    paper_id = await _seed_paper(project_id, title="Reopened Paper", status="included")
+    resp = await client.post(
+        "/api/me/library/visits", json={"paper_id": paper_id}, headers=headers
+    )
+    entry_id = resp.json()["id"]
+    await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+    assert (await _library(client, headers, "trash"))["total"] == 1
+
+    await client.post("/api/me/library/visits", json={"paper_id": paper_id}, headers=headers)
+    assert (await _library(client, headers, "trash"))["total"] == 0
+    assert (await _library(client, headers, "history"))["total"] == 1
+
+
+# ---- 孤儿回收：回收站里的引用不给内容池论文续命 ----
+
+
+async def test_trashed_shelf_row_does_not_keep_orphan_paper(client):
+    """池中论文只被一条书架行引用；该行进回收站后不再算引用，gc 应回收本体。"""
+    project_id, headers = await _setup(client, name="orphan-shelf")
+    async with get_sessionmaker()() as session:
+        paper = Paper(title="Pool Only Paper", source="manual")
+        session.add(paper)
+        await session.commit()
+        paper_id = paper.id
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf", json={"paper_id": str(paper_id)}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    # 入架同时进了个人库（saved），先取消收藏，只剩书架这一处引用
+    resp = await client.get(f"/api/me/library/state?paper_id={paper_id}", headers=headers)
+    entry_id = resp.json()["entry_id"]
+    resp = await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+    assert resp.status_code == 204
+
+    # 在架时：仍被引用，不回收
+    async with get_sessionmaker()() as session:
+        assert await papers_service.gc_orphan_papers(session, [paper_id]) == 0
+        await session.commit()
+        assert await session.get(Paper, paper_id) is not None
+
+    resp = await client.delete(
+        f"/api/projects/{project_id}/shelf/{paper_id}", headers=headers
+    )
+    assert resp.status_code == 204
+
+    # 进回收站后：不再算引用，本体被回收（书架行随外键级联清理）
+    async with get_sessionmaker()() as session:
+        assert await papers_service.gc_orphan_papers(session, [paper_id]) == 1
+        await session.commit()
+        assert await session.get(Paper, paper_id) is None

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -34,7 +34,7 @@ import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPa
 
 /* ============================================================
    /library — 我的文献库：
-   「我的收藏」+「浏览记录」+「我发表的」三个 tab；
+   「我的收藏」+「浏览记录」+「回收站」+「我发表的」等 tab；
    双栏主从布局对齐文献追踪（Stage 00）的论文库：
    左栏列表（搜索/排序/分页/行操作），右栏选中条目的详情
    （活体论文展示 wiki，快照条目展示元数据 + 外链）。
@@ -45,7 +45,7 @@ const PAGE_SIZE = 20;
 // 语义检索一次返回一组结果（不分页），上限比普通分页大些
 const SEMANTIC_SIZE = 50;
 
-/** 页面级 tab：库内两个 tab +「我赞过的」+「文献对话」+「我发表的」。 */
+/** 页面级 tab：库内三个 tab（收藏 / 浏览记录 / 回收站）+「我赞过的」+「文献对话」+「我发表的」。 */
 type PageTab = LibraryTab | 'liked' | 'publications' | 'chat';
 
 // 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
@@ -72,6 +72,7 @@ function EntryRow({
   onToggleCheck,
   onSelect,
   onToggleSave,
+  onRestore,
   onPurge,
 }: {
   entry: LibraryEntry;
@@ -83,6 +84,7 @@ function EntryRow({
   onToggleCheck: () => void;
   onSelect: () => void;
   onToggleSave: () => void;
+  onRestore: () => void;
   onPurge: () => void;
 }) {
   const authors = entry.authors.map((a) => a.name).join(', ');
@@ -148,13 +150,17 @@ function EntryRow({
               {tr('源课题已删除', 'Source topic deleted')}
             </span>
           )}
-          {entry.visit_count > 0 && (
+          {tab === 'trash' ? (
+            <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
+              {tr(`${fmtRelative(entry.trashed_at)} 移入`, `trashed ${fmtRelative(entry.trashed_at)}`)}
+            </span>
+          ) : entry.visit_count > 0 ? (
             <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
               {fmtRelative(entry.last_visited_at)}
               {' · '}
               {tr(`看过 ${entry.visit_count} 次`, `${entry.visit_count} visits`)}
             </span>
-          )}
+          ) : null}
         </div>
         <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>
           {entry.title}
@@ -199,27 +205,56 @@ function EntryRow({
         )}
       </div>
 
-      {/* —— 右：操作 —— */}
+      {/* —— 右：操作（回收站里换成召回 / 彻底删除） —— */}
       <div className="row gap6" style={{ flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
-        <button
-          className="icon-btn"
-          disabled={busy}
-          title={entry.saved ? tr('取消收藏', 'Unsave') : tr('收藏', 'Save')}
-          style={{ color: entry.saved ? 'var(--accent)' : 'var(--text-3)' }}
-          onClick={onToggleSave}
-        >
-          <Icon name={entry.saved ? 'bookmarkFill' : 'bookmark'} size={15} />
-        </button>
-        {tab === 'history' && (
-          <button
-            className="icon-btn"
-            disabled={busy}
-            title={tr('彻底删除这条记录', 'Delete this record')}
-            style={{ color: 'var(--text-3)' }}
-            onClick={onPurge}
-          >
-            <Icon name="trash" size={15} />
-          </button>
+        {tab === 'trash' ? (
+          <>
+            <button
+              className="icon-btn"
+              disabled={busy}
+              title={tr('召回到「我的收藏」', 'Restore to Saved')}
+              style={{ color: 'var(--accent)' }}
+              onClick={onRestore}
+            >
+              <Icon name="refresh" size={15} />
+            </button>
+            <button
+              className="icon-btn"
+              disabled={busy}
+              title={tr('彻底删除，无法再召回', 'Delete forever — cannot be restored')}
+              style={{ color: 'var(--danger-tx)' }}
+              onClick={onPurge}
+            >
+              <Icon name="x" size={15} />
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              className="icon-btn"
+              disabled={busy}
+              title={
+                entry.saved
+                  ? tr('取消收藏（放进回收站，可召回）', 'Unsave (goes to trash, restorable)')
+                  : tr('收藏', 'Save')
+              }
+              style={{ color: entry.saved ? 'var(--accent)' : 'var(--text-3)' }}
+              onClick={onToggleSave}
+            >
+              <Icon name={entry.saved ? 'bookmarkFill' : 'bookmark'} size={15} />
+            </button>
+            {tab === 'history' && (
+              <button
+                className="icon-btn"
+                disabled={busy}
+                title={tr('彻底删除这条记录', 'Delete this record')}
+                style={{ color: 'var(--text-3)' }}
+                onClick={onPurge}
+              >
+                <Icon name="trash" size={15} />
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -246,6 +281,7 @@ export function LibraryPage() {
   const [sort, setSort] = useState<LibrarySort>('recent');
   const [page, setPage] = useState(1);
   const [clearOpen, setClearOpen] = useState(false);
+  const [emptyTrashOpen, setEmptyTrashOpen] = useState(false);
 
   // 多选（批量导出引用）：默认关闭，仅「我的收藏」可用；选中集合按论文 id 存
   // （last_paper_id，跨页/跨搜索都能带着走；导出端点按论文 id 精确取本人收藏）
@@ -373,13 +409,17 @@ export function LibraryPage() {
     void queryClient.invalidateQueries({ queryKey: ['library-state'] });
   };
 
+  // 取消收藏 = 软删：条目进回收站，可召回（不是永久删掉）
   const toggleMutation = useMutation({
     mutationFn: (entry: LibraryEntry) =>
       entry.saved
         ? api.removeLibraryEntry(entry.id, 'unsave')
         : api.saveToLibrary({ entry_id: entry.id }).then(() => undefined),
     onSuccess: (_d, entry) => {
-      toast(entry.saved ? tr('已取消收藏', 'Unsaved') : tr('已收藏', 'Saved'), 'ok');
+      toast(
+        entry.saved ? tr('已移入回收站，可以召回', 'Moved to trash — you can restore it') : tr('已收藏', 'Saved'),
+        'ok',
+      );
       // 选中的就是这条时同步右栏快照里的收藏态
       setSelEntry((old) => (old && old.id === entry.id ? { ...old, saved: !entry.saved } : old));
       invalidate();
@@ -387,15 +427,36 @@ export function LibraryPage() {
     onError: (e) => toast(`${tr('操作失败：', 'Action failed: ')}${errText(e)}`, 'error'),
   });
 
+  const restoreMutation = useMutation({
+    mutationFn: (entry: LibraryEntry) => api.restoreLibraryEntry(entry.id),
+    onSuccess: (_d, entry) => {
+      toast(`${tr('已召回：', 'Restored: ')}${entry.title.slice(0, 30)}`, 'ok');
+      setSelEntry((old) => (old && old.id === entry.id ? null : old));
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('召回失败：', 'Restore failed: ')}${errText(e)}`, 'error'),
+  });
+
   const purgeMutation = useMutation({
     mutationFn: (entry: LibraryEntry) => api.removeLibraryEntry(entry.id, 'purge'),
     onSuccess: (_d, entry) => {
-      toast(tr('已删除这条记录', 'Record deleted'), 'ok');
+      toast(tab === 'trash' ? tr('已彻底删除', 'Permanently deleted') : tr('已删除这条记录', 'Record deleted'), 'ok');
       // 删除的是当前选中项 → 清空右栏
       setSelEntry((old) => (old && old.id === entry.id ? null : old));
       invalidate();
     },
     onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const emptyTrashMutation = useMutation({
+    mutationFn: () => api.emptyPersonalTrash(),
+    onSuccess: (res) => {
+      setEmptyTrashOpen(false);
+      setSelEntry(null);
+      toast(tr(`回收站已清空（${res.deleted} 条）`, `Trash emptied (${res.deleted} entries)`), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('清空失败：', 'Empty failed: ')}${errText(e)}`, 'error'),
   });
 
   const exportMutation = useMutation({
@@ -418,7 +479,7 @@ export function LibraryPage() {
     onError: (e) => toast(`${tr('清空失败：', 'Clear failed: ')}${errText(e)}`, 'error'),
   });
 
-  const busy = toggleMutation.isPending || purgeMutation.isPending;
+  const busy = toggleMutation.isPending || purgeMutation.isPending || restoreMutation.isPending;
 
   return (
     <div
@@ -433,6 +494,7 @@ export function LibraryPage() {
           options={[
             { v: 'saved', label: tr('我的收藏', 'Saved') },
             { v: 'history', label: tr('浏览记录', 'History') },
+            { v: 'trash', label: tr('回收站', 'Trash') },
             { v: 'liked', label: tr('我赞过的', 'Liked') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
             {
@@ -529,7 +591,7 @@ export function LibraryPage() {
             </div>
           )
         ) : (
-          /* ======== 我的收藏 / 浏览记录 ======== */
+          /* ======== 我的收藏 / 浏览记录 / 回收站 ======== */
           <div className="split">
             {/* —— 左：列表 —— */}
             <div className="split-list">
@@ -555,7 +617,9 @@ export function LibraryPage() {
                             '按语义相似度检索收藏（需已生成向量）',
                             'Semantic search over saved papers (needs embeddings)',
                           )
-                        : tr('浏览记录是流水，只支持关键词检索', 'History is a raw log — keyword search only')
+                        : tab === 'history'
+                          ? tr('浏览记录是流水，只支持关键词检索', 'History is a raw log — keyword search only')
+                          : tr('回收站只支持关键词检索', 'Trash supports keyword search only')
                     }
                   />
                   <AdvancedToggle
@@ -621,7 +685,27 @@ export function LibraryPage() {
                       {tr('清空记录', 'Clear history')}
                     </button>
                   )}
+                  {tab === 'trash' && (
+                    <button
+                      className="btn btn-ghost sm"
+                      style={{ marginLeft: 'auto', height: 26, flexShrink: 0, color: 'var(--danger-tx)' }}
+                      disabled={emptyTrashMutation.isPending || (data !== undefined && data.total === 0)}
+                      onClick={() => setEmptyTrashOpen(true)}
+                    >
+                      <Icon name="x" size={13} />
+                      {tr('清空回收站', 'Empty trash')}
+                    </button>
+                  )}
                 </div>
+
+                {tab === 'trash' && (
+                  <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-4)', lineHeight: 1.5 }}>
+                    {tr(
+                      '取消收藏的文献先放这里，召回就回到「我的收藏」；彻底删除之后找不回来。清空浏览记录不会动这里。',
+                      'Unsaved papers land here — restore one and it goes back to Saved. Deleting forever cannot be undone; clearing your history leaves this list alone.',
+                    )}
+                  </div>
+                )}
 
                 {/* 语义检索提示：回退关键词 / 覆盖范围说明 */}
                 {semantic && data?.mode_used === 'keyword' && (
@@ -661,13 +745,15 @@ export function LibraryPage() {
                 ) : entries.length === 0 ? (
                   <EmptyState
                     compact
-                    icon="bookmark"
+                    icon={tab === 'trash' ? 'trash' : 'bookmark'}
                     title={
                       q || advActive
                         ? tr('没有匹配的文献', 'No matching papers')
                         : tab === 'saved'
                           ? tr('还没有收藏的文献', 'Nothing saved yet')
-                          : tr('还没有浏览记录', 'No reading history yet')
+                          : tab === 'history'
+                            ? tr('还没有浏览记录', 'No reading history yet')
+                            : tr('回收站是空的', 'Trash is empty')
                     }
                     desc={
                       q || advActive
@@ -677,10 +763,15 @@ export function LibraryPage() {
                               '在论文阅读页点右上角的书签按钮，就能把它收进这里。',
                               'Tap the bookmark button on any paper reading page to save it here.',
                             )
-                          : tr(
-                              '打开任意论文的阅读页后，会自动记录在这里。',
-                              'Papers you open in the reader will show up here automatically.',
-                            )
+                          : tab === 'history'
+                            ? tr(
+                                '打开任意论文的阅读页后，会自动记录在这里。',
+                                'Papers you open in the reader will show up here automatically.',
+                              )
+                            : tr(
+                                '取消收藏的文献会先放进这里，随时可以召回。',
+                                'Papers you unsave land here and can be restored any time.',
+                              )
                     }
                   />
                 ) : (
@@ -705,6 +796,7 @@ export function LibraryPage() {
                       }
                       onSelect={() => setSelEntry(entry)}
                       onToggleSave={() => toggleMutation.mutate(entry)}
+                      onRestore={() => restoreMutation.mutate(entry)}
                       onPurge={() => purgeMutation.mutate(entry)}
                     />
                   ))
@@ -796,13 +888,28 @@ export function LibraryPage() {
         onClose={() => setClearOpen(false)}
         title={tr('清空浏览记录？', 'Clear reading history?')}
         message={tr(
-          '将删除全部浏览记录；已收藏的文献会保留在「我的收藏」里。此操作不可撤销。',
-          'All reading history will be deleted. Saved papers stay in the Saved tab. This cannot be undone.',
+          '将删除全部浏览记录；已收藏的文献留在「我的收藏」，回收站里的条目也不受影响。此操作不可撤销。',
+          'All reading history will be deleted. Saved papers stay in the Saved tab and the Trash tab is left alone. This cannot be undone.',
         )}
         confirmText={tr('清空', 'Clear')}
         danger
         busy={clearMutation.isPending}
         onConfirm={() => clearMutation.mutate()}
+      />
+
+      {/* —— 清空回收站确认 —— */}
+      <ConfirmModal
+        open={emptyTrashOpen}
+        onClose={() => setEmptyTrashOpen(false)}
+        title={tr('清空回收站？', 'Empty trash?')}
+        message={tr(
+          '将彻底删除回收站里的全部条目，删掉之后没法再召回。',
+          'Everything in the trash will be deleted for good — nothing can be restored afterwards.',
+        )}
+        confirmText={tr('清空回收站', 'Empty trash')}
+        danger
+        busy={emptyTrashMutation.isPending}
+        onConfirm={() => emptyTrashMutation.mutate()}
       />
     </div>
   );

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -140,7 +140,9 @@ export function ReadingPage() {
         : api.saveToLibrary({ paper_id: id }).then(() => undefined),
     onSuccess: () => {
       toast(
-        libState?.saved ? tr('已从文献库移除', 'Removed from my library') : tr('已加入文献库', 'Added to my library'),
+        libState?.saved
+          ? tr('已移入回收站，可以召回', 'Moved to trash — you can restore it')
+          : tr('已加入文献库', 'Added to my library'),
         'ok',
       );
       void queryClient.invalidateQueries({ queryKey: ['library-state', id] });
@@ -167,7 +169,7 @@ export function ReadingPage() {
     onSuccess: () => {
       toast(
         shelved
-          ? tr('已移出相关研究（个人库收藏保留）', 'Removed from related work (kept in my library)')
+          ? tr('已移入回收站，可以召回（个人库收藏保留）', 'Moved to trash — you can restore it (still saved in my library)')
           : tr('已加入相关研究', 'Added to related work'),
         'ok',
       );
@@ -285,7 +287,11 @@ export function ReadingPage() {
         </div>
         <button
           className="icon-btn"
-          title={shelved ? tr('已在相关研究 · 点击移出', 'In related work · click to remove') : tr('加入相关研究', 'Add to related work')}
+          title={
+            shelved
+              ? tr('已在相关研究 · 点击移入回收站（可召回）', 'In related work · click to move to trash (restorable)')
+              : tr('加入相关研究', 'Add to related work')
+          }
           disabled={shelfMutation.isPending || shelfIdsQuery.isLoading}
           onClick={() => shelfMutation.mutate()}
           style={{ color: shelved ? 'var(--accent)' : 'var(--text-3)' }}
@@ -294,7 +300,11 @@ export function ReadingPage() {
         </button>
         <button
           className="icon-btn"
-          title={libSaved ? tr('从文献库移除', 'Remove from my library') : tr('加入文献库', 'Add to my library')}
+          title={
+            libSaved
+              ? tr('移入回收站（可在文献库里召回）', 'Move to trash (restorable from my library)')
+              : tr('加入文献库', 'Add to my library')
+          }
           disabled={libSaveMutation.isPending || libStateQuery.isLoading}
           onClick={() => libSaveMutation.mutate()}
           style={{ color: libSaved ? 'var(--accent)' : 'var(--text-3)' }}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -17,9 +17,11 @@ import {
   type ShelfSort,
   type ShelfWikiSource,
 } from '../../lib/api';
+import { fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import { useProject } from '../../app/project';
 import { libraryPath } from '../libraries/hooks';
+import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import {
   AdvancedPanel,
   AdvancedToggle,
@@ -332,6 +334,103 @@ function LinkedLibrariesBar({
   );
 }
 
+/* ---------------- 回收站 ---------------- */
+
+/** 相关研究回收站：弹窗外壳复用共享 TrashModal，端点与行映射留在这里。
+    移出书架是软删，条目落在这里，可召回或彻底删除；个人库收藏全程不动。 */
+function ShelfTrashModal({ pid, open, onClose }: { pid: string; open: boolean; onClose: () => void }) {
+  const queryClient = useQueryClient();
+
+  const trashQuery = useQuery({
+    queryKey: ['shelf-trash', pid],
+    queryFn: () => api.listShelf(pid, { trashed: true, size: PAGE_SIZE }),
+    enabled: open && !!pid,
+    retry: false,
+  });
+  const trashed = useMemo(() => trashQuery.data?.items ?? [], [trashQuery.data]);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['shelf-trash', pid] });
+    void queryClient.invalidateQueries({ queryKey: ['shelf', pid] });
+    void queryClient.invalidateQueries({ queryKey: ['shelf-ids', pid] });
+  };
+
+  const restoreMutation = useMutation({
+    mutationFn: (paperId: string) => api.restoreShelfItem(pid, paperId),
+    onSuccess: (item) => {
+      toast(`${tr('已召回：', 'Restored: ')}${item.title.slice(0, 30)}`, 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('召回失败：', 'Restore failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const purgeMutation = useMutation({
+    mutationFn: (paperId: string) => api.removeFromShelf(pid, paperId, { hard: true }),
+    onSuccess: () => {
+      toast(tr('已彻底删除', 'Permanently deleted'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const emptyMutation = useMutation({
+    mutationFn: () => api.emptyShelfTrash(pid),
+    onSuccess: (res) => {
+      toast(tr(`回收站已清空（${res.deleted} 篇）`, `Trash emptied (${res.deleted} papers)`), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('清空失败：', 'Empty failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const items = useMemo<TrashItemView[]>(
+    () =>
+      trashed.map((item) => {
+        const authors = item.authors.map((a) => a.name).join(', ');
+        return {
+          id: item.paper_id,
+          code: item.arxiv_id ?? item.venue ?? '—',
+          year: item.year,
+          title: item.title,
+          aside: (
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+              {tr(`${fmtRelative(item.trashed_at)} 移入`, `trashed ${fmtRelative(item.trashed_at)}`)}
+            </span>
+          ),
+          desc: item.tldr ?? (authors || null),
+          searchText: [item.title, authors].join('\n'),
+        };
+      }),
+    [trashed],
+  );
+
+  return (
+    <TrashModal
+      open={open}
+      onClose={onClose}
+      sub={tr(
+        '从相关研究移出的论文；召回后回到列表，个人库里的收藏一直都在',
+        'Papers removed from related work; restoring puts them back — your saved copies are untouched',
+      )}
+      items={items}
+      total={trashQuery.data?.total}
+      loading={trashQuery.isLoading}
+      busy={restoreMutation.isPending || purgeMutation.isPending || emptyMutation.isPending}
+      emptying={emptyMutation.isPending}
+      onRestore={(id) => restoreMutation.mutate(id)}
+      onPurge={(id) => purgeMutation.mutate(id)}
+      onEmpty={() => emptyMutation.mutate()}
+      emptyWarning={(n) =>
+        tr(
+          `将彻底删除回收站里的全部 ${n} 篇，无法恢复（个人库收藏不受影响）`,
+          `This permanently deletes all ${n} papers in the trash — no undo (your saved copies stay)`,
+        )
+      }
+      restoreHint={tr('召回到相关研究', 'Restore to related work')}
+      purgeHint={tr('彻底删除，无法再召回（个人库收藏不受影响）', 'Delete forever — cannot be restored (saved copies stay)')}
+    />
+  );
+}
+
 /* ---------------- 页面 ---------------- */
 
 export function ResearchPage() {
@@ -346,6 +445,7 @@ export function ResearchPage() {
   const [filter, setFilter] = useState<ShelfFilter>('all');
   const [selId, setSelId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
+  const [trashOpen, setTrashOpen] = useState(false);
   // 个人补充入架后若后端返回 task_id，弹出分阶段处理进度
   const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
 
@@ -570,12 +670,14 @@ export function ResearchPage() {
     onError: (e) => toast(`${tr('备注保存失败：', 'Failed to save note: ')}${errText(e)}`, 'error'),
   });
 
+  // 移出 = 软删：条目进回收站，可召回；个人库收藏不动
   const removeMutation = useMutation({
     mutationFn: (paperId: string) => api.removeFromShelf(pid, paperId),
     onSuccess: (_d, paperId) => {
-      toast(tr('已移出相关研究（个人库收藏保留）', 'Removed (still saved in my library)'), 'ok');
+      toast(tr('已移入回收站，可以召回（个人库收藏保留）', 'Moved to trash — you can restore it (still saved in my library)'), 'ok');
       setSelId((old) => (old === paperId ? null : old));
       invalidate();
+      void queryClient.invalidateQueries({ queryKey: ['shelf-trash', pid] });
     },
     onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
   });
@@ -937,6 +1039,15 @@ export function ResearchPage() {
                   {tr('导出 BibTeX', 'Export BibTeX')}
                 </button>
               )}
+              <button
+                className="btn btn-ghost sm"
+                style={{ marginLeft: 'auto' }}
+                title={tr('回收站：移出的论文可以召回或彻底删除', 'Trash: removed papers — restore or delete forever')}
+                onClick={() => setTrashOpen(true)}
+              >
+                <Icon name="trash" size={13} />
+                {tr('回收站', 'Trash')}
+              </button>
             </div>
 
             {/* 底部分页栏（超过单页上限 100 才出现；语义结果不分页） */}
@@ -1038,6 +1149,9 @@ export function ResearchPage() {
         importPending={importMutation.isPending}
         onImport={(input) => importMutation.mutateAsync(input)}
       />
+
+      {/* —— 回收站（移出的论文：召回 / 彻底删除 / 清空） —— */}
+      <ShelfTrashModal pid={pid} open={trashOpen} onClose={() => setTrashOpen(false)} />
 
       {progress && (
         <PaperProgressModal

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -466,7 +466,10 @@ export function ShelfDetailPane({
         {onShelf ? (
           <button
             className="btn btn-ghost sm"
-            title={tr('移出相关研究（个人库收藏保留）', 'Remove from related work (kept in my library)')}
+            title={tr(
+              '移出相关研究，放进回收站，之后可以召回（个人库收藏保留）',
+              'Remove from related work — goes to the trash and can be restored (kept in my library)',
+            )}
             disabled={removePending}
             onClick={onRemove}
             style={{ marginLeft: 'auto', color: 'var(--danger-tx)' }}

--- a/src/frontend/src/features/shared/TrashModal.tsx
+++ b/src/frontend/src/features/shared/TrashModal.tsx
@@ -1,0 +1,266 @@
+import { useState, type ReactNode } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { SearchInput } from '../wiki/shared';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   回收站弹窗（共享外壳）：桶内客户端搜索 + 召回 / 彻底删除 /
+   清空（带二次确认）+ 空态 + 条数截断提示。
+   列表数据和四个动作全部由调用方注入，组件本身不碰任何端点，
+   实验室文献库（PapersTab）与课题相关研究（ResearchPage）共用。
+   ============================================================ */
+
+/** 回收站里一行的展示模型：调用方把自己的数据结构映射成这个。 */
+export interface TrashItemView {
+  id: string;
+  /** 顶行 mono 编号（arXiv 编号 / 期刊会议，都没有就给 '—'） */
+  code: string;
+  year: number | null;
+  title: string;
+  /** 编号 / 年份之后的小图标位（如「有解读」星标） */
+  leading?: ReactNode;
+  /** 顶行最右侧（如相关度条、移入回收站的时间） */
+  aside?: ReactNode;
+  /** 标题下方的标签行（删除原因等） */
+  tags?: ReactNode;
+  /** 标签行右侧的一句话摘要（超出省略） */
+  desc?: string | null;
+  /** 桶内客户端搜索的匹配文本（标题 + 作者，调用方拼好） */
+  searchText: string;
+}
+
+export interface TrashModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** 弹窗副标题：说明这个回收站装的是什么 */
+  sub: ReactNode;
+  items: TrashItemView[];
+  /** 后端总条数：大于已加载条数时提示「仅显示最近 N 篇」；不分页可省略 */
+  total?: number;
+  loading: boolean;
+  /** 任一动作进行中：禁用全部按钮 */
+  busy: boolean;
+  emptying: boolean;
+  onRestore: (id: string) => void;
+  onPurge: (id: string) => void;
+  onEmpty: () => void;
+  /** 清空确认里的危险说明（各处删掉的东西不一样，文案由调用方给） */
+  emptyWarning: (count: number) => ReactNode;
+  /** 行内两个按钮的 hover 说明（同上，各处含义略有差别） */
+  restoreHint?: string;
+  purgeHint?: string;
+  width?: number;
+}
+
+export function TrashModal({
+  open,
+  onClose,
+  sub,
+  items: allItems,
+  total,
+  loading,
+  busy,
+  emptying,
+  onRestore,
+  onPurge,
+  onEmpty,
+  emptyWarning,
+  restoreHint,
+  purgeHint,
+  width = 680,
+}: TrashModalProps) {
+  const [confirmEmpty, setConfirmEmpty] = useState(false);
+  const [trashQ, setTrashQ] = useState('');
+
+  // 桶内搜索：标题 / 作者（客户端过滤）
+  const kw = trashQ.trim().toLowerCase();
+  const items = kw ? allItems.filter((it) => it.searchText.toLowerCase().includes(kw)) : allItems;
+  // 清空成功后桶空了 → 自动退出确认态，footer 不会停在「确认清空 0 篇」
+  const confirming = confirmEmpty && allItems.length > 0;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={tr('回收站', 'Trash')}
+      sub={sub}
+      width={width}
+      footer={
+        <>
+          {confirming ? (
+            <>
+              <span style={{ fontSize: 12, color: 'var(--danger-tx)', marginRight: 'auto' }}>
+                {emptyWarning(allItems.length)}
+              </span>
+              <button className="btn btn-ghost sm" onClick={() => setConfirmEmpty(false)}>
+                {tr('取消', 'Cancel')}
+              </button>
+              <button
+                className="btn btn-primary sm"
+                style={{ background: 'var(--danger-tx)' }}
+                disabled={busy}
+                onClick={onEmpty}
+              >
+                {emptying ? tr('清空中…', 'Emptying…') : tr('确认清空', 'Confirm empty')}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                className="btn btn-ghost sm"
+                style={{ color: 'var(--danger-tx)', marginRight: 'auto' }}
+                disabled={allItems.length === 0 || busy}
+                onClick={() => setConfirmEmpty(true)}
+              >
+                <Icon name="x" size={12} />
+                {tr('清空回收站', 'Empty trash')}
+              </button>
+              <button className="btn btn-soft sm" onClick={onClose}>
+                {tr('关闭', 'Close')}
+              </button>
+            </>
+          )}
+        </>
+      }
+    >
+      {/* 搜索区固定不随列表滚动：列表自带滚动容器，整体高度不超出 Modal 内容区 */}
+      <div className="row gap10" style={{ marginBottom: 12 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <SearchInput value={trashQ} onChange={setTrashQ} placeholder={tr('搜索标题 / 作者…', 'Search title / author…')} />
+        </div>
+        <span className="mono muted" style={{ fontSize: 11, flexShrink: 0 }}>
+          {kw
+            ? tr(`${items.length} / ${allItems.length} 篇`, `${items.length} / ${allItems.length}`)
+            : tr(`${allItems.length} 篇`, `${allItems.length} papers`)}
+        </span>
+      </div>
+      {loading ? (
+        <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
+      ) : allItems.length === 0 ? (
+        <div className="empty" style={{ padding: 24 }}>{tr('回收站是空的', 'Trash is empty')}</div>
+      ) : items.length === 0 ? (
+        <div className="empty" style={{ padding: 24 }}>{tr('没有匹配的文献', 'No matching papers')}</div>
+      ) : (
+        <div
+          className="scroll"
+          style={{
+            maxHeight: '46vh',
+            overflowY: 'auto',
+            border: '0.5px solid var(--border)',
+            borderRadius: 10,
+          }}
+        >
+          {items.map((it, i) => (
+            <TrashRow
+              key={it.id}
+              item={it}
+              last={i === items.length - 1}
+              busy={busy}
+              restoreHint={restoreHint}
+              purgeHint={purgeHint}
+              onRestore={() => onRestore(it.id)}
+              onPurge={() => onPurge(it.id)}
+            />
+          ))}
+          {(total ?? 0) > allItems.length && (
+            <div className="muted" style={{ fontSize: 11, textAlign: 'center', padding: 8 }}>
+              {tr(
+                `仅显示最近 ${allItems.length} 篇（共 ${total} 篇）`,
+                `Showing the latest ${allItems.length} (of ${total})`,
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+/** 回收站列表行：与论文库 PaperRow 同款版式，右侧召回 / 彻底删除。 */
+function TrashRow({
+  item,
+  last,
+  busy,
+  restoreHint,
+  purgeHint,
+  onRestore,
+  onPurge,
+}: {
+  item: TrashItemView;
+  last: boolean;
+  busy: boolean;
+  restoreHint?: string;
+  purgeHint?: string;
+  onRestore: () => void;
+  onPurge: () => void;
+}) {
+  return (
+    <div
+      className="row gap10"
+      style={{
+        padding: '12px 16px',
+        borderBottom: last ? 'none' : '0.5px solid var(--border)',
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="row gap8" style={{ marginBottom: 5 }}>
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+            {item.code}
+          </span>
+          {item.year !== null && (
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+              {item.year}
+            </span>
+          )}
+          {item.leading}
+          <span style={{ marginLeft: 'auto' }}>{item.aside}</span>
+        </div>
+        <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>{item.title}</div>
+        {(item.tags || item.desc) && (
+          <div className="row gap8" style={{ marginTop: 6 }}>
+            {item.tags}
+            {item.desc && (
+              <span
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  fontSize: 11.5,
+                  color: 'var(--text-3)',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {item.desc}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="col" style={{ gap: 6, flexShrink: 0 }}>
+        <button
+          className="btn btn-soft sm"
+          style={{ height: 26 }}
+          disabled={busy}
+          title={restoreHint ?? tr('召回到论文库', 'Restore to the library')}
+          onClick={onRestore}
+        >
+          <Icon name="refresh" size={12} />
+          {tr('召回', 'Restore')}
+        </button>
+        <button
+          className="btn btn-ghost sm"
+          style={{ height: 26, color: 'var(--danger-tx)' }}
+          disabled={busy}
+          title={purgeHint ?? tr('彻底删除（连同文件，无法恢复）', 'Delete permanently (files included, no undo)')}
+          onClick={onPurge}
+        >
+          <Icon name="x" size={12} />
+          {tr('彻底删除', 'Delete forever')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -40,6 +40,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
+import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
 
@@ -455,11 +456,16 @@ export function ExportMenu({
 
 /* ---------------- 回收站 ---------------- */
 
-function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?: string; open: boolean; onClose: () => void }) {
+/** 回收站原因标签：打分淘汰 = 不相关；否则视为手动删除（老数据缺字段时按分数推断）。 */
+function trashReasonOf(p: PaperRead): 'irrelevant' | 'manual' {
+  if (p.trash_reason === 'manual' || p.trash_reason === 'irrelevant') return p.trash_reason;
+  return p.relevance_score !== null ? 'irrelevant' : 'manual';
+}
+
+/** 论文库回收站：弹窗外壳复用共享 TrashModal，端点与行映射留在这里。 */
+function PapersTrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?: string; open: boolean; onClose: () => void }) {
   const queryClient = useQueryClient();
   const scopeId = libraryId ?? pid;
-  const [confirmEmpty, setConfirmEmpty] = useState(false);
-  const [trashQ, setTrashQ] = useState('');
 
   const trashQuery = useQuery({
     queryKey: ['papers-trash', scopeId],
@@ -470,16 +476,7 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
     enabled: open,
     retry: false,
   });
-  const allItems = trashQuery.data?.items ?? [];
-  // 桶内搜索：标题 / 作者（客户端过滤）
-  const kw = trashQ.trim().toLowerCase();
-  const items = kw
-    ? allItems.filter(
-        (p) =>
-          p.title.toLowerCase().includes(kw) ||
-          p.authors.some((a) => a.name.toLowerCase().includes(kw)),
-      )
-    : allItems;
+  const papers = useMemo(() => trashQuery.data?.items ?? [], [trashQuery.data]);
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['papers-trash', scopeId] });
@@ -516,161 +513,24 @@ function TrashModal({ pid, libraryId, open, onClose }: { pid: string; libraryId?
     mutationFn: () => (libraryId ? api.emptyLibraryTrash(libraryId) : api.emptyTrash(pid)),
     onSuccess: (res) => {
       toast(tr(`回收站已清空（${res.deleted} 篇）`, `Trash emptied (${res.deleted} papers)`), 'ok');
-      setConfirmEmpty(false);
       invalidate();
     },
     onError: (e) =>
       toast(`${tr('清空失败：', 'Empty failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  const busy = restoreMutation.isPending || purgeMutation.isPending || emptyMutation.isPending;
-
-  return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      title={tr('回收站', 'Trash')}
-      sub={tr(
-        '相关性不足自动淘汰与手动删除的文献；召回后回到论文库',
-        'Papers auto-dropped for low relevance or deleted manually; restoring puts them back in the library',
-      )}
-      width={680}
-      footer={
-        <>
-          {confirmEmpty ? (
-            <>
-              <span style={{ fontSize: 12, color: 'var(--danger-tx)', marginRight: 'auto' }}>
-                {tr(
-                  `将彻底删除全部 ${allItems.length} 篇及其文件，无法恢复`,
-                  `This permanently deletes all ${allItems.length} papers and their files — no undo`,
-                )}
-              </span>
-              <button className="btn btn-ghost sm" onClick={() => setConfirmEmpty(false)}>
-                {tr('取消', 'Cancel')}
-              </button>
-              <button
-                className="btn btn-primary sm"
-                style={{ background: 'var(--danger-tx)' }}
-                disabled={busy}
-                onClick={() => emptyMutation.mutate()}
-              >
-                {emptyMutation.isPending ? tr('清空中…', 'Emptying…') : tr('确认清空', 'Confirm empty')}
-              </button>
-            </>
-          ) : (
-            <>
-              <button
-                className="btn btn-ghost sm"
-                style={{ color: 'var(--danger-tx)', marginRight: 'auto' }}
-                disabled={allItems.length === 0 || busy}
-                onClick={() => setConfirmEmpty(true)}
-              >
-                <Icon name="x" size={12} />
-                {tr('清空回收站', 'Empty trash')}
-              </button>
-              <button className="btn btn-soft sm" onClick={onClose}>
-                {tr('关闭', 'Close')}
-              </button>
-            </>
-          )}
-        </>
-      }
-    >
-      {/* 搜索区固定不随列表滚动：列表自带滚动容器，整体高度不超出 Modal 内容区 */}
-      <div className="row gap10" style={{ marginBottom: 12 }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <SearchInput value={trashQ} onChange={setTrashQ} placeholder={tr('搜索标题 / 作者…', 'Search title / author…')} />
-        </div>
-        <span className="mono muted" style={{ fontSize: 11, flexShrink: 0 }}>
-          {kw
-            ? tr(`${items.length} / ${allItems.length} 篇`, `${items.length} / ${allItems.length}`)
-            : tr(`${allItems.length} 篇`, `${allItems.length} papers`)}
-        </span>
-      </div>
-      {trashQuery.isLoading ? (
-        <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
-      ) : allItems.length === 0 ? (
-        <div className="empty" style={{ padding: 24 }}>{tr('回收站是空的', 'Trash is empty')}</div>
-      ) : items.length === 0 ? (
-        <div className="empty" style={{ padding: 24 }}>{tr('没有匹配的文献', 'No matching papers')}</div>
-      ) : (
-        <div
-          className="scroll"
-          style={{
-            maxHeight: '46vh',
-            overflowY: 'auto',
-            border: '0.5px solid var(--border)',
-            borderRadius: 10,
-          }}
-        >
-          {items.map((p, i) => (
-            <TrashRow key={p.id} p={p} last={i === items.length - 1} busy={busy}
-              onRestore={() => restoreMutation.mutate(p.id)}
-              onPurge={() => purgeMutation.mutate(p.id)}
-            />
-          ))}
-          {(trashQuery.data?.total ?? 0) > allItems.length && (
-            <div className="muted" style={{ fontSize: 11, textAlign: 'center', padding: 8 }}>
-              {tr(
-                `仅显示最近 ${allItems.length} 篇（共 ${trashQuery.data?.total} 篇）`,
-                `Showing the latest ${allItems.length} (of ${trashQuery.data?.total})`,
-              )}
-            </div>
-          )}
-        </div>
-      )}
-    </Modal>
-  );
-}
-
-/** 回收站原因标签：打分淘汰 = 不相关；否则视为手动删除（老数据缺字段时按分数推断）。 */
-function trashReasonOf(p: PaperRead): 'irrelevant' | 'manual' {
-  if (p.trash_reason === 'manual' || p.trash_reason === 'irrelevant') return p.trash_reason;
-  return p.relevance_score !== null ? 'irrelevant' : 'manual';
-}
-
-/** 回收站列表行：与论文库 PaperRow 同款版式，标签换成删除原因，右侧召回/彻底删除。 */
-function TrashRow({
-  p,
-  last,
-  busy,
-  onRestore,
-  onPurge,
-}: {
-  p: PaperRead;
-  last: boolean;
-  busy: boolean;
-  onRestore: () => void;
-  onPurge: () => void;
-}) {
-  const reason = trashReasonOf(p);
-  return (
-    <div
-      className="row gap10"
-      style={{
-        padding: '12px 16px',
-        borderBottom: last ? 'none' : '0.5px solid var(--border)',
-        alignItems: 'flex-start',
-      }}
-    >
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div className="row gap8" style={{ marginBottom: 5 }}>
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
-            {p.arxiv_id ?? p.venue ?? '—'}
-          </span>
-          {p.year !== null && (
-            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
-              {p.year}
-            </span>
-          )}
-          {p.has_wiki && <Icon name="sparkle" size={11} style={{ color: 'var(--accent)' }} />}
-          <span style={{ marginLeft: 'auto' }}>
-            <RelevanceBar value={p.relevance_score} />
-          </span>
-        </div>
-        <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>{p.title}</div>
-        <div className="row gap8" style={{ marginTop: 6 }}>
-          {reason === 'irrelevant' ? (
+  // 论文行 → 共享回收站行的展示模型（相关度条 + 删除原因标签 + tldr）
+  const items = useMemo<TrashItemView[]>(
+    () =>
+      papers.map((p) => ({
+        id: p.id,
+        code: p.arxiv_id ?? p.venue ?? '—',
+        year: p.year,
+        title: p.title,
+        leading: p.has_wiki ? <Icon name="sparkle" size={11} style={{ color: 'var(--accent)' }} /> : undefined,
+        aside: <RelevanceBar value={p.relevance_score} />,
+        tags:
+          trashReasonOf(p) === 'irrelevant' ? (
             <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
               {tr('不相关', 'Irrelevant')}
             </span>
@@ -678,47 +538,36 @@ function TrashRow({
             <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
               {tr('手动删除', 'Deleted manually')}
             </span>
-          )}
-          {p.tldr && (
-            <span
-              style={{
-                flex: 1,
-                minWidth: 0,
-                fontSize: 11.5,
-                color: 'var(--text-3)',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {p.tldr}
-            </span>
-          )}
-        </div>
-      </div>
-      <div className="col" style={{ gap: 6, flexShrink: 0 }}>
-        <button
-          className="btn btn-soft sm"
-          style={{ height: 26 }}
-          disabled={busy}
-          title={tr('召回到论文库', 'Restore to the library')}
-          onClick={onRestore}
-        >
-          <Icon name="refresh" size={12} />
-          {tr('召回', 'Restore')}
-        </button>
-        <button
-          className="btn btn-ghost sm"
-          style={{ height: 26, color: 'var(--danger-tx)' }}
-          disabled={busy}
-          title={tr('彻底删除（连同文件，无法恢复）', 'Delete permanently (files included, no undo)')}
-          onClick={onPurge}
-        >
-          <Icon name="x" size={12} />
-          {tr('彻底删除', 'Delete forever')}
-        </button>
-      </div>
-    </div>
+          ),
+        desc: p.tldr,
+        searchText: [p.title, ...p.authors.map((a) => a.name)].join('\n'),
+      })),
+    [papers],
+  );
+
+  return (
+    <TrashModal
+      open={open}
+      onClose={onClose}
+      sub={tr(
+        '相关性不足自动淘汰与手动删除的文献；召回后回到论文库',
+        'Papers auto-dropped for low relevance or deleted manually; restoring puts them back in the library',
+      )}
+      items={items}
+      total={trashQuery.data?.total}
+      loading={trashQuery.isLoading}
+      busy={restoreMutation.isPending || purgeMutation.isPending || emptyMutation.isPending}
+      emptying={emptyMutation.isPending}
+      onRestore={(id) => restoreMutation.mutate(id)}
+      onPurge={(id) => purgeMutation.mutate(id)}
+      onEmpty={() => emptyMutation.mutate()}
+      emptyWarning={(n) =>
+        tr(
+          `将彻底删除全部 ${n} 篇及其文件，无法恢复`,
+          `This permanently deletes all ${n} papers and their files — no undo`,
+        )
+      }
+    />
   );
 }
 
@@ -1867,7 +1716,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
       <AddPaperModal pid={pid ?? ''} libraryId={libraryId} open={addOpen} onClose={() => setAddOpen(false)} onImported={onSelect} />
 
       {/* —— 回收站 —— */}
-      <TrashModal pid={pid ?? ''} libraryId={libraryId} open={trashOpen} onClose={() => setTrashOpen(false)} />
+      <PapersTrashModal pid={pid ?? ''} libraryId={libraryId} open={trashOpen} onClose={() => setTrashOpen(false)} />
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -988,6 +988,8 @@ export interface ShelfItemRead {
   /** 来源方向库（个人补充为 null） */
   source_library_id: string | null;
   added_at: string;
+  /** 移入回收站的时间；在架条目为 null（旧后端可能缺字段） */
+  trashed_at?: string | null;
   /** 个人补充入架后若仍需分阶段后处理，返回可订阅进度的任务 id；已处理完整时为 null。 */
   task_id?: string | null;
 }
@@ -2245,7 +2247,7 @@ export interface FeedbackPatch {
 // 我的文献库（跨研究方向的个人收藏 + 浏览记录）— issue #108
 // ============================================================
 
-export type LibraryTab = 'saved' | 'history';
+export type LibraryTab = 'saved' | 'history' | 'trash';
 export type LibrarySort = 'recent' | 'title' | 'visits' | 'year';
 
 export interface LibraryEntry {
@@ -2267,6 +2269,8 @@ export interface LibraryEntry {
   /** 最近一次浏览对应的论文 id；为 null 表示源方向已删除，只能走外链 url。 */
   last_paper_id: string | null;
   created_at: string;
+  /** 移入回收站的时间；正常条目为 null（旧后端可能缺字段） */
+  trashed_at?: string | null;
 }
 
 export interface LibraryState {
@@ -3185,6 +3189,8 @@ export const api = {
       reading_status?: ReadingStatus;
       starred?: boolean;
       sort?: ShelfSort;
+      /** true=只列回收站里的条目；默认 false=只列在架的 */
+      trashed?: boolean;
     } = {},
   ): Promise<PageOf<ShelfItemRead>> {
     const params = new URLSearchParams();
@@ -3198,6 +3204,7 @@ export const api = {
     if (opts.reading_status) params.set('reading_status', opts.reading_status);
     if (opts.starred) params.set('starred', 'true');
     if (opts.sort) params.set('sort', opts.sort);
+    if (opts.trashed) params.set('trashed', 'true');
     const qs = params.toString();
     return request<PageOf<ShelfItemRead>>(`/projects/${projectId}/shelf${qs ? `?${qs}` : ''}`);
   },
@@ -3216,9 +3223,18 @@ export const api = {
   updateShelfNote(projectId: string, paperId: string, note: string | null): Promise<ShelfItemRead> {
     return requestJson<ShelfItemRead>(`/projects/${projectId}/shelf/${paperId}`, 'PATCH', { note });
   },
-  /** 移出书架：只删书架行，个人库收藏不动。 */
-  removeFromShelf(projectId: string, paperId: string): Promise<void> {
-    return request<void>(`/projects/${projectId}/shelf/${paperId}`, { method: 'DELETE' });
+  /** 移出书架：默认软删（移入回收站，可召回）；hard=true 才彻底删掉书架行。个人库收藏都不动。 */
+  removeFromShelf(projectId: string, paperId: string, opts: { hard?: boolean } = {}): Promise<void> {
+    const qs = opts.hard ? '?hard=true' : '';
+    return request<void>(`/projects/${projectId}/shelf/${paperId}${qs}`, { method: 'DELETE' });
+  },
+  /** 从回收站召回一篇，回到相关研究列表。 */
+  restoreShelfItem(projectId: string, paperId: string): Promise<ShelfItemRead> {
+    return request<ShelfItemRead>(`/projects/${projectId}/shelf/${paperId}/restore`, { method: 'POST' });
+  },
+  /** 清空相关研究回收站（彻底删除全部书架行）。 */
+  emptyShelfTrash(projectId: string): Promise<{ deleted: number }> {
+    return request<{ deleted: number }>(`/projects/${projectId}/shelf/trash/empty`, { method: 'POST' });
   },
   /** 手动刷新书架快照：从当前最优 wiki（库版 > 个人版）重拷；无来源 409。 */
   refreshShelfSnapshot(projectId: string, paperId: string): Promise<ShelfItemRead> {
@@ -4000,9 +4016,17 @@ export const api = {
   saveToLibrary(input: { paper_id: string } | { entry_id: string }): Promise<LibraryEntry> {
     return requestJson<LibraryEntry>('/me/library', 'POST', input);
   },
-  /** 移除条目：unsave=取消收藏但保留浏览记录；purge=彻底删除。 */
+  /** 移除条目：unsave=移入回收站（可召回）；purge=彻底删除。 */
   removeLibraryEntry(entryId: string, mode: 'unsave' | 'purge'): Promise<void> {
     return request<void>(`/me/library/${entryId}?mode=${mode}`, { method: 'DELETE' });
+  },
+  /** 从回收站召回一条，回到「我的收藏」。 */
+  restoreLibraryEntry(entryId: string): Promise<LibraryEntry> {
+    return request<LibraryEntry>(`/me/library/${entryId}/restore`, { method: 'POST' });
+  },
+  /** 清空个人库回收站（彻底删除全部回收站条目；浏览记录不受影响）。 */
+  emptyPersonalTrash(): Promise<{ deleted: number }> {
+    return request<{ deleted: number }>('/me/library/trash/empty', { method: 'POST' });
   },
 
   // —— 我发表的（作者信息绑定 + 发表同步，issue #109） ——


### PR DESCRIPTION
Removing a paper from a topic's related work physically deleted the row, and unsaving from a personal library left the entry indistinguishable from a plain visit. Neither had a recycle bin, so both were one misclick away from losing a note or a snapshot. The shared library has had one for a while; this brings the other two up to it.

Migration `a7f4c2e91b83` adds `trashed_at` to `topic_papers` (plus `trashed_by`) and to `user_library_entries`. Existing rows get NULL, i.e. "on the shelf" / "not binned" — semantics unchanged.

## API

**Shelf** — `GET /projects/{pid}/shelf?trashed=true`, `POST …/shelf/{paper_id}/restore`, `DELETE …/shelf/{paper_id}?hard=true`, `POST …/shelf/trash/empty`
**Personal library** — `GET /me/library?tab=trash`, `POST /me/library/{entry_id}/restore`, `POST /me/library/trash/empty`. `DELETE /me/library/{entry_id}?mode=unsave` now means "move to bin"; `mode=purge` is unchanged.

## The unique-key trap

`topic_papers` has a `(topic_id, paper_id)` unique constraint that a soft-deleted row still occupies. Re-adding a binned paper therefore cannot insert — `add_to_shelf` looks for the binned row first and revives it, re-resolving the source library and refreshing the snapshot. A test asserts the table never holds two rows for the same pair.

## Everything that treats a shelf row as a live reference

Adding a soft-delete state means every "is this paper still referenced" question needs `trashed_at IS NULL`, or binned rows start lying:

- **Orphan collection** — a binned row must not keep a pool paper alive
- **"Already added" checkmarks** in the paper list and the daily feed
- **Topic notebook scope**, pool-level visibility in `get_paper_for_user`
- **Clearing browse history** no longer wipes the bin (it deleted every `saved=False` row)
- **Merging two papers** keeps the live row when one side is binned — otherwise the merge silently dropped a paper that was still on someone's shelf
- **Reopening a paper in the reader** pulls its entry back out of the bin; otherwise the visit was invisible in every tab while `visit_count` kept climbing

## UI

A shared `TrashModal` shell — in-bin search, restore, delete forever, empty with confirmation, empty state, truncation notice — with all four actions injected by the caller, so the component touches no endpoints. Used by the paper workbench and related work.

The personal library gets a **tab** rather than a modal (as requested), reusing the page's existing row rendering and pagination.

Wording follows: the reader's "removed from your library" and "removed from related work" were already describing a soft delete after this change, so they now say the entry can be restored. The "clear browse history" note says the bin is unaffected.

## Deliberate omissions

- **Restoring does not bump a shelf entry to the top** — `created_at` stays honest, so a restored entry returns to its original position under the default sort. One line to change if you'd rather it surface.
- **Emptying the shelf bin does not trigger orphan collection.** Removing from a shelf never did; not widening that path here. A pool paper referenced only by shelf entries can linger as an orphan until something else triggers collection.
- No count badges on the bin entries — would need an extra always-on query. Cheapest fix if wanted: a `trash_count` in the list response.

## Verification

33 backend tests (new `test_shelf_and_library_trash.py` plus the shelf/library/migration suites), `ruff check app` clean, single alembic head, sqlite upgrade/downgrade/upgrade roundtrip. `tsc --noEmit` 0 errors, `vite build` passes. The UI was written against the API contract on a separate branch, so the two halves have not been exercised together at runtime yet.
