### PR TITLE
refactor(libraries): manage rights follow curators, not the origin topic

### DIFF
--- a/src/backend/alembic/versions/b3d81f6c05a9_backfill_library_curators.py
+++ b/src/backend/alembic/versions/b3d81f6c05a9_backfill_library_curators.py
@@ -1,0 +1,93 @@
+"""把历史库的起源课题成员补成策展人
+
+库与课题解耦后，文献库工作台改走 /libraries/{id}/* 端点，鉴权口径从
+「你是这个库起源课题的成员」变成「你是这个库的策展人，或平台管理员」。
+两个口径认的不是同一批人：靠课题成员身份在管库的人，切换后会当场失去
+管理权。
+
+这条迁移把每个 project_id 非空的库的起源课题成员，补成该库的策展人，
+让切换前后能管这个库的人保持一致。
+
+幂等：已经是策展人的跳过（主键 library_id+user_id 冲突即跳过）。回填的
+行记到 _pr3_backfilled_curators，downgrade 只删这批，不碰本来就有的策展人。
+
+Revision ID: b3d81f6c05a9
+Revises: a7f4c2e91b83
+Create Date: 2026-07-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3d81f6c05a9"
+down_revision: str | None = "a7f4c2e91b83"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 备份表：只记这次真正插进去的行，downgrade 据此精确回滚
+    op.create_table(
+        "_pr3_backfilled_curators",
+        sa.Column("library_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.PrimaryKeyConstraint("library_id", "user_id"),
+    )
+
+    conn = op.get_bind()
+
+    # 待补的（库, 用户）：起源课题的成员，且还不是该库策展人
+    missing = list(
+        conn.execute(
+            sa.text(
+                """
+                SELECT l.id AS library_id, m.user_id AS user_id
+                  FROM direction_libraries l
+                  JOIN project_members m ON m.project_id = l.project_id
+                 WHERE l.project_id IS NOT NULL
+                   AND NOT EXISTS (
+                       SELECT 1 FROM direction_library_curators c
+                        WHERE c.library_id = l.id AND c.user_id = m.user_id
+                   )
+                """
+            )
+        )
+    )
+    if not missing:
+        return
+
+    rows = [{"library_id": r.library_id, "user_id": r.user_id} for r in missing]
+    conn.execute(
+        sa.text(
+            "INSERT INTO direction_library_curators (library_id, user_id, created_at, updated_at)"
+            " VALUES (:library_id, :user_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        rows,
+    )
+    conn.execute(
+        sa.text(
+            "INSERT INTO _pr3_backfilled_curators (library_id, user_id)"
+            " VALUES (:library_id, :user_id)"
+        ),
+        rows,
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM direction_library_curators
+             WHERE EXISTS (
+                 SELECT 1 FROM _pr3_backfilled_curators b
+                  WHERE b.library_id = direction_library_curators.library_id
+                    AND b.user_id = direction_library_curators.user_id
+             )
+            """
+        )
+    )
+    op.drop_table("_pr3_backfilled_curators")

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -838,17 +838,17 @@ async def _is_project_member(
 async def can_manage_library(
     session: AsyncSession, *, user: User, library: DirectionLibrary
 ) -> bool:
-    """库级写权限（P10）：平台 admin ∪ 创建者（submitted_by）∪ 策展人 ∪ 背后课题成员。
+    """库级写权限：平台 admin ∪ 创建者（submitted_by）∪ 策展人。
 
     公共库全体 admin 都能管；个人库只创建者 + admin（策展人默认含创建者本人，仍适用）。
+
+    起源课题的成员**不再**因这层关系拿到管理权：库与课题解耦后 project_id 只是
+    「这个库当初从哪个课题建的」的历史指针，不是归属。此前靠这条在管库的人，由
+    迁移 b3d81f6c05a9 补成策展人保住权限。
     """
     if user.role == "admin":
         return True
     if library.submitted_by is not None and library.submitted_by == user.id:
-        return True
-    if library.project_id is not None and await _is_project_member(
-        session, project_id=library.project_id, user_id=user.id
-    ):
         return True
     return await is_library_curator(session, library_id=library.id, user_id=user.id)
 

--- a/src/backend/tests/test_library_authz_after_decoupling.py
+++ b/src/backend/tests/test_library_authz_after_decoupling.py
@@ -1,0 +1,139 @@
+"""解耦后的库鉴权口径（PR-3）：库工作台一律走 /libraries/{id}/*，判断
+「你是不是这个库的策展人（或平台 admin）」，不再是「你是不是起源课题的成员」。
+
+这两个口径认的不是同一批人 —— 历史库上靠课题成员身份在管库的人，切换后
+会失去管理权。迁移 b3d81f6c05a9 把他们补成策展人来兜住。本文件锁住这个
+前后关系：课题成员身份本身不给管理权，补成策展人才给。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
+from app.models.project import ProjectMember
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _user_id(email: str) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(select(User).where(User.email == email))
+        ).scalar_one().id
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _set_origin_topic(lib_id: str, project_id: uuid.UUID) -> None:
+    """把库挂成「某课题建的」——即迁移前的历史库形态。"""
+    async with get_sessionmaker()() as session:
+        lib = (
+            await session.execute(
+                select(DirectionLibrary).where(DirectionLibrary.id == uuid.UUID(lib_id))
+            )
+        ).scalar_one()
+        lib.project_id = project_id
+        await session.commit()
+
+
+async def _add_topic_member(project_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(
+            ProjectMember(project_id=project_id, user_id=user_id, role="member")
+        )
+        await session.commit()
+
+
+async def _add_curator(lib_id: str, user_id: uuid.UUID) -> None:
+    """迁移 b3d81f6c05a9 对每个历史库成员做的事。"""
+    async with get_sessionmaker()() as session:
+        session.add(
+            DirectionLibraryCurator(library_id=uuid.UUID(lib_id), user_id=user_id)
+        )
+        await session.commit()
+
+
+async def _legacy_library(client, *, prefix):
+    """造一个「有起源课题」的历史库，返回 (owner_hdr, admin_hdr, lib_id, project_id)。"""
+    admin_email = f"{prefix}-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+
+    owner = await _hdr(client, f"{prefix}-owner@example.com")
+    resp = await client.post(
+        "/api/projects",
+        json={"name": f"{prefix} 课题", "statement": "解耦前建的课题"},
+        headers=owner,
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": f"{prefix} 历史库", "statement": "当年跟着课题一起建的"},
+        headers=owner,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+    assert resp.status_code == 200, resp.text
+
+    await _set_origin_topic(lib_id, project_id)
+    return owner, admin, lib_id, project_id
+
+
+async def test_topic_membership_alone_does_not_grant_library_manage(client):
+    """课题成员身份不再等于库管理权 —— 这就是回填存在的理由。"""
+    _owner, _admin, lib_id, project_id = await _legacy_library(client, prefix="authz-member")
+
+    member_email = "authz-member-teammate@example.com"
+    member = await _hdr(client, member_email)
+    member_id = await _user_id(member_email)
+    # 他是这个库起源课题的正式成员 —— 解耦前正是靠这重身份在管库
+    await _add_topic_member(project_id, member_id)
+
+    # 但课题成员身份不给库管理权：管理端点拒绝
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=member)
+    assert resp.status_code == 403, resp.text
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=member)
+    assert resp.status_code == 403, resp.text
+
+    # 补成策展人（= 迁移做的事）后放行
+    await _add_curator(lib_id, member_id)
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=member)
+    assert resp.status_code == 200, resp.text
+    resp = await client.post(f"/api/libraries/{lib_id}/concepts/relink", headers=member)
+    assert resp.status_code == 200, resp.text
+
+
+async def test_legacy_library_serves_library_scoped_endpoints(client):
+    """有起源课题的库，集合级端点走库作用域一样能用（前端切过去的前提）。"""
+    owner, _admin, lib_id, _project_id = await _legacy_library(client, prefix="authz-scope")
+
+    for path in (
+        f"/api/libraries/{lib_id}/papers",
+        f"/api/libraries/{lib_id}/concepts",
+        f"/api/libraries/{lib_id}/ingest/state",
+        f"/api/libraries/{lib_id}/notes",
+    ):
+        resp = await client.get(path, headers=owner)
+        assert resp.status_code == 200, f"{path} -> {resp.status_code} {resp.text}"
+
+
+async def test_platform_admin_manages_legacy_library_without_backfill(client):
+    """平台 admin 本来就放行，不依赖回填 —— 本地这份数据回填是空操作的原因。"""
+    _owner, admin, lib_id, _project_id = await _legacy_library(client, prefix="authz-admin")
+
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=admin)
+    assert resp.status_code == 200, resp.text

--- a/src/backend/tests/test_library_governance.py
+++ b/src/backend/tests/test_library_governance.py
@@ -60,11 +60,15 @@ async def test_can_manage_library_three_identities(client):
         ).scalar_one()
         curator_user = await session.get(User, curator_id)
 
-        # 平台 admin / 背后课题成员可管理；无关用户不可
+        # 平台 admin 可管理；无关用户不可
         assert await libraries_service.can_manage_library(session, user=admin_user, library=library)
-        assert await libraries_service.can_manage_library(session, user=owner_user, library=library)
         assert not await libraries_service.can_manage_library(
             session, user=stranger_user, library=library
+        )
+        # 起源课题的成员（这里是建课题的 owner）不再因这层关系可管理：库与课题解耦后
+        # project_id 只是历史指针。存量的这批人由迁移 b3d81f6c05a9 补成策展人。
+        assert not await libraries_service.can_manage_library(
+            session, user=owner_user, library=library
         )
         # 任命为策展人后可管理
         assert not await libraries_service.can_manage_library(

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a7f4c2e91b83"  # 相关研究书架 + 我的文献库 回收站（软删）
-PREV_REVISION = "49ddb68e7cf2"  # email_verification_codes 邮箱验证码表
+HEAD_REVISION = "b3d81f6c05a9"  # 历史库的起源课题成员补成策展人
+PREV_REVISION = "a7f4c2e91b83"  # 相关研究书架 + 我的文献库 回收站（软删）
 
 
 def _make_config(db_path: Path) -> Config:
@@ -250,16 +250,18 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：书架 / 个人库回收站（软删）
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
+    # 本分支新增：策展人回填的备份表（downgrade 据此精确回滚）
+    assert "_pr3_backfilled_curators" in columns["_tables"]
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（49ddb68e7cf2，邮箱验证码表）。
-    # 该步只回退本迁移（删两张表的回收站列），其余结构不动。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（a7f4c2e91b83，回收站）。
+    # 该步只回退策展人回填（删回填的行 + 备份表），其余结构不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    # 本迁移回退后回收站列消失；更早的验证码表 / is_public / users.settings 都还在
-    assert "trashed_at" not in columns["topic_papers"]
-    assert "trashed_by" not in columns["topic_papers"]
-    assert "trashed_at" not in columns["user_library_entries"]
+    # 回填回退后备份表消失；上一版的回收站列仍在
+    assert "_pr3_backfilled_curators" not in columns["_tables"]
+    assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
+    assert "trashed_at" in columns["user_library_entries"]
     assert "email_verification_codes" in columns["_tables"]
     assert "is_public" in columns["direction_libraries"]
     assert "settings" in columns["users"]
@@ -311,9 +313,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
-    # 回收站列在重新 upgrade 后回归
+    # 回收站列与回填备份表在重新 upgrade 后回归
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
+    assert "_pr3_backfilled_curators" in columns["_tables"]
     assert "project_id" not in columns["paper_notes"]
     assert "project_id" not in columns["paper_highlights"]
     assert "models" in columns["llm_providers"]

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -23,7 +23,8 @@ const PresentationModal = lazy(() =>
    文献库工作台（P5c 起挂在 /libraries/:id 的可管理者视图；原 /wiki 页面主体）
    Tab：论文库 / 概念库 / 图谱 / 文献对话 / 建库与同步 / 笔记，
    传入 libraryId 时追加「治理」（P6：库信息与预算 / 文献库管理员 / 重复论文）；
-   pid = 库背后课题 id（数据仍走 project 作用域端点，策展人与 admin 同权放行）。
+   数据一律走 /libraries/{id}/* 端点（策展人与 admin 放行）。pid 只是这个库当初
+   从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
 type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | 'govern';
@@ -40,11 +41,14 @@ export function WikiWorkbench({
 }) {
   const navigate = useNavigate();
 
-  // 独立库（无起源课题）：集合级数据与导出走 /libraries/{id}/* 端点；PPT 仍是课题域，隐藏。
-  const standalone = !pid;
-  const scopeId = standalone ? libraryId! : pid!;
-  /** 传给各 Tab 的库作用域标识：仅独立库置位，课题库保持 undefined 走 project 端点。 */
-  const tabLibraryId = standalone ? libraryId : undefined;
+  // 集合级数据与导出一律走 /libraries/{id}/* 端点——库已与课题解耦，pid 只是
+  // 这个库当初从哪个课题建的，不再决定数据口径。
+  const libScope = !!libraryId;
+  const scopeId = libraryId ?? pid!;
+  /** 传给各 Tab 的库作用域标识：有库就置位。 */
+  const tabLibraryId = libraryId;
+  /** PPT 仍是课题域功能（要课题的研究方案做叙事），只对有起源课题的库显示。 */
+  const hasTopic = !!pid;
 
   const [tab, setTab] = useState<WikiTab>('papers');
   const [presentOpen, setPresentOpen] = useState(false);
@@ -95,7 +99,7 @@ export function WikiWorkbench({
   // —— ingest 状态（tab 计数 + Ingest 面板共用） ——
   const ingestQuery = useQuery({
     queryKey: ['ingest-state', scopeId],
-    queryFn: () => (standalone ? api.getLibraryIngestState(libraryId!) : api.getIngestState(pid!)),
+    queryFn: () => (libScope ? api.getLibraryIngestState(libraryId!) : api.getIngestState(pid!)),
     retry: false,
     refetchInterval: (q) => (q.state.data?.running_voyage_id ? 5_000 : 60_000),
   });
@@ -104,7 +108,7 @@ export function WikiWorkbench({
   const resolveQuery = useQuery({
     queryKey: ['concept-resolve', scopeId, pendingConceptName],
     queryFn: () =>
-      standalone
+      libScope
         ? api.listLibraryConcepts(libraryId!, { q: pendingConceptName ?? '' })
         : api.listConcepts(pid!, { q: pendingConceptName ?? '' }),
     enabled: !!pendingConceptName,
@@ -176,13 +180,13 @@ export function WikiWorkbench({
               {tr('文献任务运行中 →', 'Literature task running →')}
             </span>
           )}
-          {!standalone && (
+          {hasTopic && (
             <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>
               <Icon name="chart" size={13} />
               {tr('论文分享 PPT', 'Paper sharing PPT')}
             </button>
           )}
-          {/* 导出：课题走 project 端点，独立库走库作用域端点（PPT 仍是课题域，独立库隐藏） */}
+          {/* 导出走库作用域端点；没有库时（理论上不会发生）回落课题端点 */}
           <ExportMenu pid={pid} libraryId={tabLibraryId} />
         </div>
       </div>
@@ -245,7 +249,7 @@ export function WikiWorkbench({
         )}
       </div>
 
-      {!standalone && presentOpen && (
+      {hasTopic && presentOpen && (
         <Suspense fallback={null}>
           <PresentationModal
             projectId={pid!}


### PR DESCRIPTION
Step 3 of the library/topic decoupling — and the one that actually changes behaviour.

## What was still wrong

`LibraryDetailPage` passed `project_id` down as the workbench scope:

```tsx
<WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} />
```

So a library that merely *records* which topic it was created from still sent every request to `/projects/{id}/*`. That's why building and syncing a library appeared to happen "in the topic workbench" — the page was the library's, but the data was the topic's.

## Two ideas that `project_id` was conflating

- `libScope` — where collection-level data comes from. Always the library now.
- `hasTopic` — whether to show the topic-domain PPT, which needs a topic's research plan for its narrative.

## The part the plan missed

Pointing the frontend at the library endpoints is not enough on its own. `can_manage_library` granted rights to **four** kinds of user, and one of them was the origin topic's members:

```python
if library.project_id is not None and await _is_project_member(...):
    return True
```

This was the last place still reading `project_id` as ownership rather than provenance. Leaving it in would have made the endpoint switch a no-op for authorization: same people, same rights, just a different URL.

I found this by writing a test that asserted a topic member gets 403 — and watching it fail with 200.

Manage rights are now: platform admin, creator, curator.

## Nobody loses access

Migration `b3d81f6c05a9` backfills every (library, origin-topic member) pair that isn't already a curator. It records what it inserted into `_pr3_backfilled_curators`, and the downgrade deletes exactly those rows — pre-existing curators are never touched.

Dry-run against the current database: **4 rows, all for `admin@zju.edu.cn`**, who is a platform admin and would have passed either way. So on this data the backfill is a formality. It is written to be idempotent, so if the deployment has accounts this copy doesn't, they're covered too.

## Side effect worth having

The ingest panel in library scope reads the library's own include-keywords to decide whether it's configured, instead of falling back to the topic-era proxy.

## Not in scope

The `/wiki` redirect still finds "the topic's library" by scanning for `project_id === topicId`. That's a dead route to be removed in PR-4, not rewired here.

`ExportMenu`'s `filters` prop is ignored in library scope — but its only call site doesn't pass filters, so nothing regresses. If filtered exports ever surface in the library workbench, `papers_for_library_export` needs the parameters first.

## Verification

New `test_library_authz_after_decoupling.py` pins the before/after: a topic member of the origin topic gets 403 on the manage endpoints, and 200 once made a curator — the exact transition the migration performs. Plus: legacy libraries serve all library-scoped collection endpoints, and platform admins pass without any backfill.

45 tests green across the authz, capabilities, shared-library, paper-management and approval suites; full backend suite clean apart from the documented unrelated failures. `ruff check app` clean, `tsc --noEmit` 0 errors.
