### PR TITLE
fix(libraries): resolve "my topic's libraries" through the link table

### DIFF
--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -248,10 +248,17 @@ def dedupe_member_rows(
 
 
 def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
-    """用户可管理论文（其所属方向的库 ∪ 被任命管理的库 ∪ 平台 admin 全库）
-    的成员行：SELECT (Paper, LibraryPaper, project_id)。P6 起策展人/管理员与
-    成员同权（docs-dev/workspace-ia-redesign.md §5）。"""
+    """用户可见论文（其课题关联的库 ∪ 被任命策展的库 ∪ 平台 admin 全库）的
+    成员行：SELECT (Paper, LibraryPaper, project_id)。
+
+    「我课题的库」走关联表 ``topic_source_libraries`` —— 课题与库是多对多关联，
+    不是 project_id 回指。按 project_id 判会漏掉课题关联的独立库（那才是常态：
+    P9c 起建课题不再自动建库），也会算进已经不再关联的历史起源库。
+    """
     my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+    my_topic_libraries = select(TopicSourceLibrary.library_id).where(
+        TopicSourceLibrary.topic_id.in_(my_projects)
+    )
     my_curated = select(DirectionLibraryCurator.library_id).where(
         DirectionLibraryCurator.user_id == user_id
     )
@@ -262,7 +269,7 @@ def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
         .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
         .where(
             or_(
-                DirectionLibrary.project_id.in_(my_projects),
+                DirectionLibrary.id.in_(my_topic_libraries),
                 DirectionLibrary.id.in_(my_curated),
                 is_admin,
             )

--- a/src/backend/app/services/publications.py
+++ b/src/backend/app/services/publications.py
@@ -10,11 +10,15 @@ import re
 import uuid
 from typing import Any, cast
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import utcnow
-from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.library_direction import (
+    DirectionLibraryCurator,
+    LibraryPaper,
+    TopicSourceLibrary,
+)
 from app.models.paper import Paper
 from app.models.project import ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
@@ -140,13 +144,27 @@ async def match_from_library(session: AsyncSession, *, user_id: uuid.UUID) -> in
     profile = await get_profile(session, user_id=user_id)
     if profile is None:
         return 0
+    # 扫描范围 = 用户课题关联的库 ∪ 被任命策展的库。走关联表而不是
+    # DirectionLibrary.project_id：后者只认「当初从这个课题建的」，会漏掉课题
+    # 关联的独立库——而独立库是常态（P9c 起建课题不再自动建库）。
+    my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+    my_libraries = select(TopicSourceLibrary.library_id).where(
+        TopicSourceLibrary.topic_id.in_(my_projects)
+    )
+    my_curated = select(DirectionLibraryCurator.library_id).where(
+        DirectionLibraryCurator.user_id == user_id
+    )
     stmt = (
         select(Paper)
         .distinct()
         .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-        .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
-        .join(ProjectMember, ProjectMember.project_id == DirectionLibrary.project_id)
-        .where(ProjectMember.user_id == user_id, LibraryPaper.status != "excluded")
+        .where(
+            or_(
+                LibraryPaper.library_id.in_(my_libraries),
+                LibraryPaper.library_id.in_(my_curated),
+            ),
+            LibraryPaper.status != "excluded",
+        )
     )
     papers = (await session.execute(stmt)).scalars().all()
     seen = await _existing_dedup_keys(session, user_id)


### PR DESCRIPTION
Topics and libraries have been many-to-many through `topic_source_libraries` for a while. But two queries still answered *"which libraries are mine?"* with `DirectionLibrary.project_id` — the pointer that records which topic a library was originally **created from**.

That's the actual coupling. The link table exists; these queries just weren't using it.

## What breaks because of it

`project_id` is set on 4 of 7 libraries here. For the other 3 — and for any library a topic links but didn't create — these queries return nothing:

**`user_visible_paper_stmt`** decides what a user may see at all. A topic that links a standalone library gave its members no visibility into that library's papers.

**`publications.match_from_library`** scans the libraries you can reach for papers matching your author profile. It joined `ProjectMember` on `DirectionLibrary.project_id`, so **it never looked at a standalone library** — the "my publications" scan silently skipped them.

Standalone is the normal case: creating a topic stopped creating a library (P9c). The `project_id` path also counts origin libraries a topic has since unlinked.

## The fix

Both resolve through `topic_source_libraries` now. Curated libraries and the platform-admin bypass are unchanged. This *widens* what topic members can see — to what the link table says they should see — as opposed to PR-3, which narrowed who may *manage* a library. Read access follows the link; manage rights follow curatorship.

## Not fixed here

`_pick_live_wiki` still prefers "this topic's library" by `project_id` when picking whose wiki to show on a shelf entry. Same class of bug, but it falls back to any library that has a wiki, so the visible effect is small, and fixing it means an extra async lookup at each of four call sites. Better on its own.

## On nulling out project_id

The original plan had a later step to null the column. **I'd drop that step.** Most remaining reads of `project_id` are LLM usage attribution — which topic to bill a call to — and nulling it would break that. The column is harmless as a record of where a library came from; what was harmful was reading ownership out of it. That's what PR-3 and this PR remove.

## Verification

48 tests green across the pool-access, shared-library, publications, authz, tag/meta and library-paper-management suites. `ruff check app` clean.
