### PR TITLE
feat(library): add papers to my library by arXiv id, DOI or BibTeX

### DIFF
--- a/docs/literature-management.md
+++ b/docs/literature-management.md
@@ -84,6 +84,10 @@ A pool paper is created (deduped first) by one of:
 - **Manual add** (`POST /projects/{id}/papers`, `POST /libraries/{id}/papers`, shelf import): resolves
   metadata from arxiv / doi / bibtex, dedupes, creates the pool row (metadata only) + a membership,
   and hands the heavy work to a background task (below).
+- **Manual add into the personal library** (`POST /me/library/import`): same resolve-or-create pool
+  path as shelf import (`paper_import.resolve_or_create_pool_paper`) but **no membership row at
+  all** — the paper only gets a `user_library_entries` row (`saved=True`; an entry sitting in the
+  caller's trash is revived instead of duplicated). Login is the only requirement.
 - **Daily sync** (`services/daily_feed.py::sync_daily_feed`): fetches each category's new arXiv
   announcements into the pool as **lightweight rows — no PDF, no LLM** — plus a feed entry.
 - **Collect from the daily feed** (`POST /daily/collect`): distributes an existing pool paper into a

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -5,23 +5,29 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
+from app.core.redis import get_redis_dep
 from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.library import (
     LibraryEntryDetail,
     LibraryEntryRead,
+    LibraryImportRead,
     LibraryNoteUpdate,
     LibraryPage,
     LibrarySaveRequest,
     LibraryStateRead,
     LibraryVisitCreate,
 )
+from app.schemas.paper import PaperManualCreate
 from app.services import citations as citations_service
+from app.services import paper_enrich as paper_enrich_service
+from app.services import paper_import as paper_import_service
 from app.services import papers as papers_service
 from app.services import user_library as library_service
 
@@ -210,6 +216,43 @@ async def save_entry(
         entry = await _get_own_entry(session, body.entry_id, user)  # type: ignore[arg-type]
         entry = await library_service.set_saved(session, entry=entry, saved=True)
     return LibraryEntryRead.model_validate(entry)
+
+
+@router.post(
+    "/me/library/import", response_model=LibraryImportRead, status_code=status.HTTP_201_CREATED
+)
+async def import_entry(
+    body: PaperManualCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> LibraryImportRead:
+    """手动添加一篇文献到「我的收藏」：arXiv 编号 / DOI / BibTeX 三选一。
+
+    平台已有这篇时直接复用（不重复解析），没有才抓取解析入池（不进任何方向库）；同一篇
+    论文在本人回收站里时走「复活」而不是插新行（每人每篇只有一条）。新建或未处理完整时
+    启动后台补全任务（下载/抽取/向量化，无库不打分），回传 task_id 供前端显示进度。
+    """
+    try:
+        result = await paper_import_service.resolve_or_create_pool_paper(
+            session, arxiv_id=body.arxiv_id, doi=body.doi, bibtex=body.bibtex
+        )
+    except paper_import_service.ParseFailedError as e:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
+        ) from e
+    # 收藏走个人库的既有路径：已有条目（含回收站里的）复活并置 saved，不会建第二行
+    entry = await library_service.save_paper(session, user_id=user.id, paper=result.paper)
+    task_id: str | None = None
+    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+        task_id = await paper_enrich_service.launch_paper_enrichment(
+            redis=redis,
+            paper_id=result.paper.id,
+            user_id=user.id,
+            library_id=None,
+            project_id=None,
+        )
+    return LibraryImportRead.model_validate(entry).model_copy(update={"task_id": task_id})
 
 
 @router.get("/me/library/{entry_id}", response_model=LibraryEntryDetail)

--- a/src/backend/app/schemas/library.py
+++ b/src/backend/app/schemas/library.py
@@ -42,6 +42,12 @@ class LibraryEntryDetail(LibraryEntryRead):
     wiki_content: str | None
 
 
+class LibraryImportRead(LibraryEntryRead):
+    """手动添加的响应：条目本身 + 后台补全任务 id（论文已处理完整时为 null）。"""
+
+    task_id: str | None = None
+
+
 class LibraryPage(BaseModel):
     items: list[LibraryEntryRead]
     total: int

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -7,10 +7,11 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
 
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.paper import Paper
-from app.services.dedup import pool_dedup_key
+from app.services.dedup import dedup_key_for, pool_dedup_key
 from app.services.libraries import (
     ensure_membership,
     find_pool_paper,
@@ -268,6 +269,57 @@ class ManualAddResult(NamedTuple):
 
     paper: Paper
     created: bool  # True=新建池行；False=池命中（论文已存在）
+
+
+async def resolve_or_create_pool_paper(
+    session: AsyncSession,
+    *,
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    bibtex: str | None = None,
+    title: str | None = None,
+) -> ManualAddResult:
+    """个人补充入库的公共链路：先查全局内容池，命中直接复用；未命中才抓取解析入池。
+
+    **不建任何 library_papers 成员行**（「在池但不在任何库」是合法状态，§3.5）；解析计费
+    按现有归因规则记调用用户。新建池行只落元数据，PDF 下载 / 全文抽取 / 向量化交给后台
+    任务 enrich_paper。仅给标题且池中查不到时无法抓取（ParseFailedError → 路由映射 422）。
+    课题书架 import 与个人库手动添加共用这一条链路；调用方负责收尾 commit。
+    """
+    normalized_arxiv = normalize_arxiv_id(arxiv_id) if arxiv_id else None
+    clean_doi = doi.strip().removeprefix("https://doi.org/") if doi else None
+    paper = await find_pool_paper(
+        session,
+        arxiv_id=normalized_arxiv,
+        doi=clean_doi,
+        dedup_key=dedup_key_for(arxiv_id=normalized_arxiv, doi=clean_doi, title=title),
+    )
+    if paper is None and title and title.strip():
+        # 标题兜底：池键掺年份/首作者，纯标题哈希未必命中 → 退回大小写不敏感精确匹配
+        stmt = select(Paper).where(func.lower(Paper.title) == title.strip().lower()).limit(1)
+        paper = (await session.execute(stmt)).scalars().first()
+    if paper is not None:
+        return ManualAddResult(paper=paper, created=False)
+    if not (normalized_arxiv or clean_doi or (bibtex and bibtex.strip())):
+        raise ParseFailedError("按标题没有找到这篇论文，请提供 arXiv 编号或 DOI")
+    fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
+    # 解析出的规范 id 再查一次池（输入可能是版本号 / 别名，bibtex 里也可能带 DOI）
+    paper = await find_pool_paper(
+        session,
+        arxiv_id=fields.get("arxiv_id"),
+        doi=fields.get("doi"),
+        dedup_key=pool_dedup_key(
+            arxiv_id=fields.get("arxiv_id"),
+            doi=fields.get("doi"),
+            title=fields["title"],
+            year=fields.get("year"),
+            authors=fields.get("authors"),
+        ),
+    )
+    if paper is not None:
+        return ManualAddResult(paper=paper, created=False)
+    paper = await create_pool_paper_stub(session, fields=fields)
+    return ManualAddResult(paper=paper, created=True)
 
 
 async def add_manual_paper(

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -22,9 +22,6 @@ from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper
 from app.models.topic_shelf import TopicPaper
 from app.services import paper_import, user_library
-from app.services.dedup import dedup_key_for
-from app.services.libraries import find_pool_paper
-from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.papers import apply_paper_filters
 
 
@@ -450,47 +447,14 @@ async def import_to_shelf(
 ) -> ShelfImportResult:
     """个人补充入库：先按 dedup 查全局池，命中直接入架；未命中抓取解析入池后入架。
 
-    个人补充**不建任何 library_papers 成员行**（「在池但不在任何库」是合法状态，
-    §3.5）；解析计费按现有归因规则记调用用户。仅有标题且池中查不到时无法抓取
-    （paper_import.ParseFailedError → 路由映射 422）。新建池行只落元数据；PDF 下载/
-    全文抽取/向量化由后台任务补全（无 target，不打分）。
+    查池 / 抓取入池那段与个人库手动添加共用（paper_import.resolve_or_create_pool_paper，
+    不建任何 library_papers 成员行）；这里只负责把结果入架。解析失败抛
+    paper_import.ParseFailedError（路由映射 422）。
     """
-    created = False
-    normalized_arxiv = normalize_arxiv_id(arxiv_id) if arxiv_id else None
-    clean_doi = doi.strip().removeprefix("https://doi.org/") if doi else None
-    paper = await find_pool_paper(
-        session,
-        arxiv_id=normalized_arxiv,
-        doi=clean_doi,
-        dedup_key=dedup_key_for(arxiv_id=normalized_arxiv, doi=clean_doi, title=title),
+    result = await paper_import.resolve_or_create_pool_paper(
+        session, arxiv_id=arxiv_id, doi=doi, title=title
     )
-    if paper is None and title and title.strip():
-        # 标题兜底：池键掺年份/首作者，纯标题哈希未必命中 → 退回大小写不敏感精确匹配
-        stmt = select(Paper).where(func.lower(Paper.title) == title.strip().lower()).limit(1)
-        paper = (await session.execute(stmt)).scalars().first()
-    if paper is None:
-        if not (normalized_arxiv or clean_doi):
-            raise paper_import.ParseFailedError(
-                "按标题没有找到这篇论文，请提供 arXiv 编号或 DOI"
-            )
-        fields = await paper_import.resolve_fields(arxiv_id=arxiv_id, doi=doi)
-        # 解析出的规范 id 再查一次池（输入可能是版本号/别名）
-        paper = await find_pool_paper(
-            session,
-            arxiv_id=fields.get("arxiv_id"),
-            doi=fields.get("doi"),
-            dedup_key=dedup_key_for(
-                arxiv_id=fields.get("arxiv_id"),
-                doi=fields.get("doi"),
-                title=fields.get("title"),
-                year=fields.get("year"),
-                authors=fields.get("authors"),
-            ),
-        )
-        if paper is None:
-            paper = await paper_import.create_pool_paper_stub(session, fields=fields)
-            created = True
     item = await add_to_shelf(
-        session, project_id=project_id, paper_id=paper.id, user_id=user_id
+        session, project_id=project_id, paper_id=result.paper.id, user_id=user_id
     )
-    return ShelfImportResult(item=item, paper=paper, created=created)
+    return ShelfImportResult(item=item, paper=result.paper, created=result.created)

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -1,10 +1,47 @@
-"""个人文献库（issue #108）：浏览上报去重、收藏/取消、列表检索、清空记录、越权。"""
+"""个人文献库（issue #108）：浏览上报去重、收藏/取消、列表检索、清空记录、手动添加、越权。"""
 
 import uuid
 
+import fakeredis.aioredis
+import httpx
+import pytest_asyncio
+import respx
+from sqlalchemy import func, select
+
 from app.core.db import get_sessionmaker
+from app.models.library import UserLibraryEntry
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
+from app.services import paper_enrich
+from app.services.literature import reset_clients, set_clients
+from app.services.literature.arxiv import ArxivClient
+from app.services.literature.openalex import OpenAlexClient
 from tests.conftest import add_paper, register_and_login
+
+ARXIV_FEED_ONE = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2408.22222v1</id>
+    <title>Manually Added Paper</title>
+    <summary>A paper added by hand straight into the personal library.</summary>
+    <published>2026-08-01T00:00:00Z</published>
+    <author><name>Dora Lin</name></author>
+    <category term="cs.IR"/>
+  </entry>
+</feed>
+"""
+
+
+@pytest_asyncio.fixture
+async def lit_clients():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    set_clients(
+        arxiv=ArxivClient(redis=redis, min_interval=0),
+        openalex=OpenAlexClient(redis=redis, mailto="test@example.org"),
+    )
+    yield
+    reset_clients()
+    await redis.aclose()
 
 
 async def _make_project(client, headers, name="lib-proj"):
@@ -18,6 +55,14 @@ async def _make_paper(project_id: str, **kwargs) -> str:
         session.add(paper)
         await session.commit()
         return str(paper.id)
+
+
+async def _entry_count() -> int:
+    """个人库条目总行数（每个测试一套干净的表，等同于当前用户的条目数）。"""
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(select(func.count()).select_from(UserLibraryEntry))
+        ).scalar_one()
 
 
 async def test_visit_dedups_across_projects(client):
@@ -271,3 +316,143 @@ async def test_wiki_snapshot_and_detail_endpoint(client):
     resp = await client.get(f"/api/me/library/{entry['id']}", headers=headers)
     assert resp.json()["last_paper_id"] is None
     assert resp.json()["wiki_content"] == "# 摘要\n这是 wiki。"
+
+
+# ---- 手动添加（POST /me/library/import）：arXiv 编号 / DOI / BibTeX 三选一 ----
+
+
+async def test_import_pool_hit_reuses_paper_and_is_idempotent(client, fake_redis):
+    """平台已有这篇 → 直接复用池里的论文，不新建论文行；重复添加也不建第二条条目。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers, "lib-import-hit")
+    paper_id = await _make_paper(
+        project_id,
+        title="Pooled Paper",
+        arxiv_id="2405.10001",
+        pdf_path="/tmp/x.pdf",
+        full_text_path="/tmp/x.txt",
+        embedding=[0.0] * 1024,
+        status="included",
+    )
+
+    resp = await client.post(
+        "/api/me/library/import", json={"arxiv_id": "2405.10001"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["saved"] is True
+    assert body["last_paper_id"] == paper_id
+    assert body["visit_count"] == 0
+    assert body["task_id"] is None  # 池命中且已处理完整 → 无需后台补全
+
+    # 带版本号再添加一次：还是同一条条目，论文池也没有多出行
+    resp = await client.post(
+        "/api/me/library/import", json={"arxiv_id": "2405.10001v3"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["id"] == body["id"]
+    assert await _entry_count() == 1
+    async with get_sessionmaker()() as session:
+        papers = (
+            (await session.execute(select(Paper).where(Paper.arxiv_id == "2405.10001")))
+            .scalars()
+            .all()
+        )
+        assert len(papers) == 1
+
+    resp = await client.get("/api/me/library?tab=saved", headers=headers)
+    assert resp.json()["total"] == 1
+
+
+@respx.mock
+async def test_import_pool_miss_fetches_and_saves(client, lit_clients, fake_redis):
+    """池里没有 → 抓 arXiv 解析入池（不进任何方向库）并收藏，回传后台补全任务 id。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        return_value=httpx.Response(200, text=ARXIV_FEED_ONE)
+    )
+    respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(return_value=httpx.Response(404))
+
+    resp = await client.post(
+        "/api/me/library/import", json={"arxiv_id": "2408.22222v1"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == "Manually Added Paper"
+    assert body["saved"] is True
+    task_id = body["task_id"]
+    assert task_id  # 新建论文 → 启动了后台补全（下载/抽取/向量化）
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(body["last_paper_id"]))
+        assert paper is not None and paper.source == "manual"
+        # 「在池但不在任何库」：手动添加不给任何方向库建成员行
+        memberships = (
+            (await session.execute(select(LibraryPaper).where(LibraryPaper.paper_id == paper.id)))
+            .scalars()
+            .all()
+        )
+        assert memberships == []
+
+    resp = await client.get("/api/me/library?tab=saved", headers=headers)
+    assert resp.json()["total"] == 1
+
+    await paper_enrich.await_task(task_id)  # 排空后台任务（pdf 404）
+
+
+async def test_import_revives_trashed_entry(client, fake_redis):
+    """回收站里的同一篇论文再添加一次 = 复活那一行（不报错、也不建第二行）。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers, "lib-import-trash")
+    await _make_paper(
+        project_id,
+        title="Trashed Then Added Again",
+        arxiv_id="2405.10002",
+        pdf_path="/tmp/y.pdf",
+        full_text_path="/tmp/y.txt",
+        embedding=[0.0] * 1024,
+        status="included",
+    )
+
+    resp = await client.post(
+        "/api/me/library/import", json={"arxiv_id": "2405.10002"}, headers=headers
+    )
+    entry_id = resp.json()["id"]
+    resp = await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+    assert resp.status_code == 204
+    resp = await client.get("/api/me/library?tab=trash", headers=headers)
+    assert resp.json()["total"] == 1
+
+    resp = await client.post(
+        "/api/me/library/import", json={"arxiv_id": "2405.10002"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["id"] == entry_id
+    assert body["saved"] is True
+    assert body["trashed_at"] is None
+    assert await _entry_count() == 1
+    resp = await client.get("/api/me/library?tab=trash", headers=headers)
+    assert resp.json()["total"] == 0
+    resp = await client.get("/api/me/library?tab=saved", headers=headers)
+    assert resp.json()["total"] == 1
+
+
+async def test_import_requires_login_and_exactly_one_source(client):
+    resp = await client.post("/api/me/library/import", json={"arxiv_id": "2405.10003"})
+    assert resp.status_code == 401
+
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    # 三选一：一个都不给 / 给两个都不行
+    resp = await client.post("/api/me/library/import", json={}, headers=headers)
+    assert resp.status_code == 422
+    resp = await client.post(
+        "/api/me/library/import",
+        json={"arxiv_id": "2405.10003", "doi": "10.1/abc"},
+        headers=headers,
+    )
+    assert resp.status_code == 422

--- a/src/frontend/src/features/library/AddToLibraryModal.tsx
+++ b/src/frontend/src/features/library/AddToLibraryModal.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { api, ApiError, type LibraryEntry, type PaperImportInput } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { parsePaperRef } from '../../lib/paper-ref';
+import { PaperProgressModal } from './PaperProgressModal';
+
+/* ============================================================
+   我的文献库 · 「添加文献」弹窗：
+   arXiv 编号 / DOI（一个输入框自动识别，粘链接也行）或 BibTeX。
+   平台已有这篇时直接复用，没有才去抓取；添加进来的只进「我的收藏」，
+   不进任何公共文献库。需要下载/抽取时弹分阶段进度。
+   ============================================================ */
+
+type AddMethod = 'ref' | 'bibtex';
+
+export function AddToLibraryModal({
+  open,
+  onClose,
+  onAdded,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** 添加成功：外层刷新列表并选中这一条 */
+  onAdded: (entry: LibraryEntry) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [method, setMethod] = useState<AddMethod>('ref');
+  const [ref, setRef] = useState('');
+  const [bibtex, setBibtex] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  // 后端返回 task_id 时弹出分阶段处理进度（下载 / 抽取 / 向量化）
+  const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
+
+  const reset = () => {
+    setRef('');
+    setBibtex('');
+    setParseError(null);
+  };
+
+  const input: PaperImportInput | null =
+    method === 'bibtex' ? (bibtex.trim() ? { bibtex: bibtex.trim() } : null) : parsePaperRef(ref);
+
+  const importMutation = useMutation({
+    mutationFn: (inp: PaperImportInput) => api.importToLibrary(inp),
+    onSuccess: (entry) => {
+      void queryClient.invalidateQueries({ queryKey: ['library'] });
+      void queryClient.invalidateQueries({ queryKey: ['library-state'] });
+      reset();
+      onClose();
+      onAdded(entry);
+      if (entry.task_id) {
+        // 还要下载正文 → 弹进度替代成功 toast，避免重复打扰
+        setProgress({ taskId: entry.task_id, title: entry.title });
+      } else {
+        toast(tr('已加进「我的收藏」', 'Added to your saved papers'), 'ok');
+      }
+    },
+    onError: (e) => {
+      if (e instanceof ApiError && e.status === 422) {
+        setParseError(
+          e.message.replace(/^PARSE_FAILED:?\s*/, '') ||
+            tr('内容解析失败，请检查格式', 'Failed to parse — check the format'),
+        );
+      } else {
+        toast(`${tr('添加失败：', 'Failed to add: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+      }
+    },
+  });
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onClose={onClose}
+        width={520}
+        title={tr('添加文献', 'Add paper')}
+        sub={tr(
+          '加进「我的收藏」，只有你自己看得到。',
+          'Goes into your saved papers — visible only to you.',
+        )}
+        footer={
+          <>
+            <button className="btn btn-ghost sm" onClick={onClose}>
+              {tr('取消', 'Cancel')}
+            </button>
+            <button
+              className="btn btn-primary sm"
+              disabled={!input || importMutation.isPending}
+              onClick={() => input && importMutation.mutate(input)}
+            >
+              {importMutation.isPending ? (
+                <>
+                  <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
+                  {tr('添加中…', 'Adding…')}
+                </>
+              ) : (
+                <>
+                  <Icon name="plus" size={13} />
+                  {tr('添加', 'Add')}
+                </>
+              )}
+            </button>
+          </>
+        }
+      >
+        <Segmented<AddMethod>
+          options={[
+            { v: 'ref', label: tr('arXiv 编号 / DOI', 'arXiv ID / DOI') },
+            { v: 'bibtex', label: tr('粘贴 BibTeX', 'Paste BibTeX') },
+          ]}
+          value={method}
+          onChange={(m) => {
+            setMethod(m);
+            setParseError(null);
+          }}
+        />
+        <div style={{ marginTop: 14 }}>
+          {method === 'ref' ? (
+            <>
+              <input
+                className="input mono"
+                autoFocus
+                style={{ width: '100%' }}
+                placeholder={tr(
+                  '例如 2405.01234 或 10.1145/3567890.1234567',
+                  'e.g. 2405.01234 or 10.1145/3567890.1234567',
+                )}
+                value={ref}
+                onChange={(e) => {
+                  setRef(e.target.value);
+                  setParseError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && input && !importMutation.isPending) {
+                    importMutation.mutate(input);
+                  }
+                }}
+              />
+              <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
+                {tr(
+                  '编号或论文链接都行，标题、作者、摘要会自动抓取，有 PDF 的顺带下载。',
+                  'An ID or a paper link both work — title, authors and abstract are fetched automatically, plus the PDF when available.',
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <textarea
+                className="textarea mono"
+                autoFocus
+                style={{ width: '100%', minHeight: 150, resize: 'vertical', fontSize: 12 }}
+                placeholder={tr(
+                  '粘贴单条 BibTeX 条目，例如：\n@inproceedings{smith2024example,\n  title = {...},\n  author = {...},\n  year = {2024},\n}',
+                  'Paste one BibTeX entry, e.g.:\n@inproceedings{smith2024example,\n  title = {...},\n  author = {...},\n  year = {2024},\n}',
+                )}
+                value={bibtex}
+                onChange={(e) => {
+                  setBibtex(e.target.value);
+                  setParseError(null);
+                }}
+              />
+              <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
+                {tr(
+                  '一次粘贴一条；title 必填，作者/年份/期刊/DOI 能解析多少取多少。',
+                  'One entry at a time; title is required — authors/year/venue/DOI are parsed on a best-effort basis.',
+                )}
+              </div>
+            </>
+          )}
+          <div className="muted" style={{ fontSize: 11.5, marginTop: 10, lineHeight: 1.6 }}>
+            {tr(
+              '平台上已经有这篇的话直接复用，不会重复解析；已经在回收站里的会重新回到收藏。',
+              'If the paper is already on the platform it is reused instead of parsed again; one that sits in your trash comes back to your saved papers.',
+            )}
+          </div>
+          {parseError && (
+            <div
+              style={{
+                marginTop: 10,
+                fontSize: 11.5,
+                color: 'var(--danger-tx)',
+                background: 'var(--danger-bg)',
+                borderRadius: 8,
+                padding: '7px 10px',
+                lineHeight: 1.6,
+              }}
+            >
+              {tr('解析失败：', 'Parse failed: ')}
+              {parseError}
+            </div>
+          )}
+        </div>
+      </Modal>
+      {progress && (
+        <PaperProgressModal
+          taskId={progress.taskId}
+          paperTitle={progress.title}
+          onClose={() => setProgress(null)}
+          onDone={() => {
+            void queryClient.invalidateQueries({ queryKey: ['library'] });
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -30,6 +30,7 @@ import { PublicationsTab, PUBLICATIONS_PAGE_SIZE } from './PublicationsTab';
 import { PersonalChatTab } from './PersonalChatTab';
 import { DailyLikedTab } from './DailyLikedTab';
 import { AuthorBindWizard } from './AuthorBindWizard';
+import { AddToLibraryModal } from './AddToLibraryModal';
 import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPane';
 
 /* ============================================================
@@ -282,6 +283,7 @@ export function LibraryPage() {
   const [page, setPage] = useState(1);
   const [clearOpen, setClearOpen] = useState(false);
   const [emptyTrashOpen, setEmptyTrashOpen] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
 
   // 多选（批量导出引用）：默认关闭，仅「我的收藏」可用；选中集合按论文 id 存
   // （last_paper_id，跨页/跨搜索都能带着走；导出端点按论文 id 精确取本人收藏）
@@ -486,7 +488,19 @@ export function LibraryPage() {
       className="page fadeup page-fill"
       style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
-      <PageHead eyebrow="Polaris · My Library" title={tr('我的文献库', 'My Library')} dense />
+      <PageHead
+        eyebrow="Polaris · My Library"
+        title={tr('我的文献库', 'My Library')}
+        dense
+        right={
+          onLibraryTab ? (
+            <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
+              <Icon name="plus" size={13} />
+              {tr('添加文献', 'Add paper')}
+            </button>
+          ) : undefined
+        }
+      />
 
       {/* —— tab 行 —— */}
       <div className="row" style={{ marginBottom: 14 }}>
@@ -760,8 +774,8 @@ export function LibraryPage() {
                         ? tr('换个关键词或放宽高级检索条件。', 'Try another keyword or loosen the filters.')
                         : tab === 'saved'
                           ? tr(
-                              '在论文阅读页点右上角的书签按钮，就能把它收进这里。',
-                              'Tap the bookmark button on any paper reading page to save it here.',
+                              '点右上角「添加文献」，填 arXiv 编号 / DOI / BibTeX 就能直接加进来；在论文阅读页点右上角的书签按钮也能收进这里。',
+                              'Use “Add paper” in the top right — an arXiv ID, DOI or BibTeX entry is enough. You can also tap the bookmark button on any paper reading page.',
                             )
                           : tab === 'history'
                             ? tr(
@@ -772,6 +786,14 @@ export function LibraryPage() {
                                 '取消收藏的文献会先放进这里，随时可以召回。',
                                 'Papers you unsave land here and can be restored any time.',
                               )
+                    }
+                    action={
+                      tab === 'saved' && !q && !advActive ? (
+                        <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
+                          <Icon name="plus" size={13} />
+                          {tr('添加文献', 'Add paper')}
+                        </button>
+                      ) : undefined
                     }
                   />
                 ) : (
@@ -881,6 +903,18 @@ export function LibraryPage() {
           </div>
         )}
       </div>
+
+      {/* —— 添加文献（arXiv 编号 / DOI / BibTeX） —— */}
+      <AddToLibraryModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onAdded={(entry) => {
+          // 加进来的一律进「我的收藏」：切过去并选中，右栏直接看到这一条
+          setTab('saved');
+          setSelEntry(entry);
+          invalidate();
+        }}
+      />
 
       {/* —— 清空浏览记录确认 —— */}
       <ConfirmModal

--- a/src/frontend/src/features/research/AddPaperModal.tsx
+++ b/src/frontend/src/features/research/AddPaperModal.tsx
@@ -7,6 +7,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { api, type ShelfImportInput } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { parsePaperRef } from '../../lib/paper-ref';
 import { SearchInput, useDebounced } from '../wiki/shared';
 
 /* ============================================================
@@ -25,19 +26,6 @@ const TABS: { v: AddTab; zh: string; en: string }[] = [
   { v: 'library', zh: '从文献库', en: 'From library' },
   { v: 'manual', zh: '手动添加', en: 'By arXiv / DOI' },
 ];
-
-/** 手动添加输入解析：DOI（10.xxx / doi.org 链接）之外一律按 arXiv 编号处理。 */
-function parseImportInput(raw: string): ShelfImportInput | null {
-  let v = raw.trim();
-  if (!v) return null;
-  if (v.includes('doi.org/')) v = v.slice(v.indexOf('doi.org/') + 'doi.org/'.length);
-  if (/^10\.\d{4,}/.test(v)) return { doi: v };
-  if (v.includes('arxiv.org/')) {
-    const seg = v.split('/').filter(Boolean);
-    v = (seg[seg.length - 1] ?? '').replace(/\.pdf$/, '');
-  }
-  return v ? { arxiv_id: v } : null;
-}
 
 export function AddPaperModal({
   open,
@@ -82,7 +70,7 @@ export function AddPaperModal({
   const results = searchQuery.data?.papers ?? [];
 
   const submitImport = () => {
-    const input = parseImportInput(importInput);
+    const input: ShelfImportInput | null = parsePaperRef(importInput);
     if (!input) {
       toast(tr('先输入 arXiv 编号或 DOI', 'Enter an arXiv ID or DOI first'), 'info');
       return;

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2281,6 +2281,9 @@ export interface LibraryState {
 /** 单条详情 = 列表条目字段 + wiki 快照正文（列表响应不含 wiki）。 */
 export type LibraryEntryDetail = LibraryEntry & { wiki_content: string | null };
 
+/** 手动添加的返回 = 条目 + 后台补全任务 id（论文已处理完整时为 null）。 */
+export type LibraryImportResult = LibraryEntry & { task_id: string | null };
+
 /** 个人库列表响应：分页条目 + 实际使用的检索模式（语义不支持时后端回退 keyword）。 */
 export type LibraryListResult = PageOf<LibraryEntry> & { mode_used: SearchMode };
 
@@ -4015,6 +4018,10 @@ export const api = {
   /** 收藏进我的文献库（按论文 id 或已有条目 id）。 */
   saveToLibrary(input: { paper_id: string } | { entry_id: string }): Promise<LibraryEntry> {
     return requestJson<LibraryEntry>('/me/library', 'POST', input);
+  },
+  /** 手动添加一篇文献到「我的收藏」：arXiv 编号 / DOI / BibTeX 三选一（平台已有的自动复用）。 */
+  importToLibrary(input: PaperImportInput): Promise<LibraryImportResult> {
+    return requestJson<LibraryImportResult>('/me/library/import', 'POST', input);
   },
   /** 移除条目：unsave=移入回收站（可召回）；purge=彻底删除。 */
   removeLibraryEntry(entryId: string, mode: 'unsave' | 'purge'): Promise<void> {

--- a/src/frontend/src/lib/paper-ref.ts
+++ b/src/frontend/src/lib/paper-ref.ts
@@ -1,0 +1,21 @@
+/**
+ * 论文来源输入的解析（手动添加文献的公共口径）：
+ * 课题「相关研究」的手动添加与「我的文献库」的添加文献共用一份，
+ * 保证两处对同一段粘贴内容的判断一致。
+ */
+
+/** 解析结果：arXiv 编号或 DOI（字段形状同时兼容书架 import 与论文 import 两个接口）。 */
+export type PaperRefInput = { arxiv_id: string } | { doi: string };
+
+/** DOI（10.xxx / doi.org 链接）之外一律按 arXiv 编号处理；空输入返回 null。 */
+export function parsePaperRef(raw: string): PaperRefInput | null {
+  let v = raw.trim();
+  if (!v) return null;
+  if (v.includes('doi.org/')) v = v.slice(v.indexOf('doi.org/') + 'doi.org/'.length);
+  if (/^10\.\d{4,}/.test(v)) return { doi: v };
+  if (v.includes('arxiv.org/')) {
+    const seg = v.split('/').filter(Boolean);
+    v = (seg[seg.length - 1] ?? '').replace(/\.pdf$/, '');
+  }
+  return v ? { arxiv_id: v } : null;
+}


### PR DESCRIPTION
The personal library could only save papers **already in the content pool**, reached by the bookmark button on a reading page. There was no way to put a paper in it that the platform had never seen — and no add button anywhere on the page. The empty state said as much: "bookmark it from a paper's reading page."

Meanwhile a topic's related work has been able to take an arXiv id since forever. This closes the gap.

## Endpoint

```
POST /api/me/library/import
auth : logged-in user — no topic membership, this is a private shelf
body : { arxiv_id | doi | bibtex }   (exactly one, else 422)
201  : LibraryEntryRead + { task_id: string | null }
```

Reuses the shelf's import path: look in the pool first, fetch and parse only on a miss, never create a `library_papers` membership row. The save path already upserts on `(user_id, dedup_key)` and clears `trashed_at`, so **re-adding a paper sitting in the recycle bin revives that entry** rather than creating a second row.

`task_id` comes back so the page can show staged progress (downloading, vectorizing, scoring) the way the shelf and paper workbench do. It's on a subclass, so the existing save endpoint's response shape is untouched.

## Shared, not copied

The pool-resolution logic moves out of `topic_shelf.import_to_shelf` into `paper_import.resolve_or_create_pool_paper`, and the shelf now calls it — one implementation, no drift. It gains a bibtex branch on the way: bibtex parses offline, and re-checking the pool afterwards lets a DOI *inside* the bibtex hit an existing paper instead of duplicating it.

The frontend's arXiv/DOI parsing likewise moves to `lib/paper-ref.ts` and is shared with the related-work modal.

## Why a separate modal instead of reusing AddPaperModal

The related-work modal has six required props, all serving its "pick from a library" tab and the shelf. A personal library has no topic scope, so reusing it means making them all optional and null-checking throughout, and dragging a dead `searchProject` query into the page. It also takes a single input, which can't express BibTeX. What's genuinely shared — the reference parsing — was extracted; the progress modal was already a shared component.

## Verification

43 backend tests green (personal library, shelf, recycle bin, manual add, pool access), covering: pool hit plus idempotent re-add, pool miss fetches and creates zero membership rows, recycle-bin entry revives, 401 unauthenticated, 422 for not-exactly-one. `ruff check app` clean, `tsc --noEmit` 0 errors.

## Not done

- **Only the personal library page has the entry.** The daily feed and global search could reuse the same modal to drop a paper straight into your library; out of scope here.
- **One paper at a time**, matching the other two importers. A multi-entry `.bib` only takes its first record — the copy says so.
- **No rate limit.** It hits arXiv/OpenAlex and a logged-in user could hammer it, but the shelf and workbench importers have the same exposure; adding one here alone would be inconsistent.
