### PR TITLE
refactor(voyages): library builds belong to the lab, not to a topic

### DIFF
--- a/src/backend/alembic/versions/c5e2a90d41f7_library_voyages_leave_topic.py
+++ b/src/backend/alembic/versions/c5e2a90d41f7_library_voyages_leave_topic.py
@@ -1,0 +1,132 @@
+"""库任务归实验室：回填 library_id，清掉 project_id
+
+建库 / 增量更新是文献库自己的事，课题只是关联库来用语料。但这些任务此前
+同时写了 project_id（当时的理由是「兼容活动流与鉴权」），于是它们混在课题
+的任务列表里。
+
+两步，顺序不能反：
+1. 给还没有 library_id 的库任务回填 —— 「任务库化」改造之前建的那批只挂了
+   课题，正是靠 project_id 才找得到自己的库，先清就成了孤儿。解析口径与
+   libraries.get_library_for_project 一致：起源库优先，否则取课题关联的第一个库。
+2. 清 project_id。此时每个库任务都有 library_id，agents 解析库走的是
+   run.library_id 那条分支 —— 独立库的任务本来就是 project_id=NULL 在跑，
+   同一条已验证路径。
+
+解析不出库的任务保留 project_id 不动（宁可留在课题里，也不做成没库没课题的
+孤儿）。原值记进 _c5e2a90d_voyage_topic 备份表，downgrade 逐行还原。
+
+Revision ID: c5e2a90d41f7
+Revises: b3d81f6c05a9
+Create Date: 2026-07-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c5e2a90d41f7"
+down_revision: str | None = "b3d81f6c05a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# app.models.voyage.LIBRARY_KINDS —— 迁移不 import 应用代码（模型会漂移），这里内联
+LIBRARY_KINDS = ("wiki_bootstrap", "wiki_ingest")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "_c5e2a90d_voyage_topic",
+        sa.Column("run_id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("backfilled_library", sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint("run_id"),
+    )
+    conn = op.get_bind()
+    kinds = sa.bindparam("kinds", expanding=True)
+
+    # 1. 回填 library_id：起源库优先，否则课题关联的第一个库（关联建立时间序）
+    to_backfill = list(
+        conn.execute(
+            sa.text(
+                """
+                SELECT v.id AS run_id,
+                       v.project_id AS project_id,
+                       COALESCE(
+                           (SELECT l.id FROM direction_libraries l
+                             WHERE l.project_id = v.project_id LIMIT 1),
+                           (SELECT t.library_id FROM topic_source_libraries t
+                             WHERE t.topic_id = v.project_id
+                             ORDER BY t.created_at LIMIT 1)
+                       ) AS library_id
+                  FROM voyage_runs v
+                 WHERE v.library_id IS NULL
+                   AND v.project_id IS NOT NULL
+                   AND v.kind IN :kinds
+                """
+            ).bindparams(kinds),
+            {"kinds": list(LIBRARY_KINDS)},
+        )
+    )
+    resolved = [r for r in to_backfill if r.library_id is not None]
+    if resolved:
+        conn.execute(
+            sa.text("UPDATE voyage_runs SET library_id = :library_id WHERE id = :run_id"),
+            [{"library_id": r.library_id, "run_id": r.run_id} for r in resolved],
+        )
+
+    # 2. 清 project_id —— 只清已经有 library_id 的库任务（含刚回填的）
+    cleared = list(
+        conn.execute(
+            sa.text(
+                """
+                SELECT id AS run_id, project_id
+                  FROM voyage_runs
+                 WHERE library_id IS NOT NULL
+                   AND project_id IS NOT NULL
+                   AND kind IN :kinds
+                """
+            ).bindparams(kinds),
+            {"kinds": list(LIBRARY_KINDS)},
+        )
+    )
+    if not cleared:
+        return
+    backfilled = {r.run_id for r in resolved}
+    conn.execute(
+        sa.text(
+            "INSERT INTO _c5e2a90d_voyage_topic (run_id, project_id, backfilled_library)"
+            " VALUES (:run_id, :project_id, :backfilled_library)"
+        ),
+        [
+            {
+                "run_id": r.run_id,
+                "project_id": r.project_id,
+                "backfilled_library": r.run_id in backfilled,
+            }
+            for r in cleared
+        ],
+    )
+    conn.execute(
+        sa.text("UPDATE voyage_runs SET project_id = NULL WHERE id = :run_id"),
+        [{"run_id": r.run_id} for r in cleared],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    rows = list(conn.execute(sa.text("SELECT * FROM _c5e2a90d_voyage_topic")))
+    if rows:
+        conn.execute(
+            sa.text("UPDATE voyage_runs SET project_id = :project_id WHERE id = :run_id"),
+            [{"project_id": r.project_id, "run_id": r.run_id} for r in rows],
+        )
+        # 回填上去的 library_id 一并撤掉，回到迁移前的形态
+        revert = [r for r in rows if r.backfilled_library]
+        if revert:
+            conn.execute(
+                sa.text("UPDATE voyage_runs SET library_id = NULL WHERE id = :run_id"),
+                [{"run_id": r.run_id} for r in revert],
+            )
+    op.drop_table("_c5e2a90d_voyage_topic")

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -56,6 +56,12 @@ PIPELINE_KINDS = frozenset(
 )
 TEMPLATE_KINDS = frozenset({"idea_proposal"})
 
+# ---- 任务层级：库任务归实验室，其余归课题 ----
+# 建库 / 增量更新是文献库自己的事，与课题无关（课题只是关联库来用语料），
+# 所以它们在实验室工作台看，不进课题的任务列表。按 kind 判而不是按
+# library_id：库化改造前建的存量任务只挂了课题，没有 library_id。
+LIBRARY_KINDS = frozenset({"wiki_bootstrap", "wiki_ingest"})
+
 
 def mode_for_kind(kind: str) -> str:
     if kind in PIPELINE_KINDS:

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -86,20 +86,6 @@ def derive_budget(knobs: IngestKnobs) -> dict[str, Any]:
     return {"max_tokens": int(knobs.max_papers) * _TOKENS_PER_PAPER}
 
 
-async def find_running_ingest(session: AsyncSession, project_id: uuid.UUID) -> VoyageRun | None:
-    stmt = (
-        select(VoyageRun)
-        .where(
-            VoyageRun.project_id == project_id,
-            VoyageRun.kind.in_(WIKI_KINDS),
-            VoyageRun.status.not_in(tuple(TERMINAL_STATUSES)),
-        )
-        .order_by(VoyageRun.created_at.desc())
-        .limit(1)
-    )
-    return (await session.execute(stmt)).scalar_one_or_none()
-
-
 async def find_running_ingest_for_library(
     session: AsyncSession, library_id: uuid.UUID
 ) -> VoyageRun | None:
@@ -128,8 +114,10 @@ async def create_ingest_voyage(
 ) -> VoyageRun:
     """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。
 
-    P9a：任务直接挂 ``library``。有起源课题的隐式库同时带上 ``project`` 以兼容活动流/
-    鉴权；管理员创建的独立库不传 project（run.project_id / activity.project_id 为空）。
+    任务只挂 ``library``：建库 / 增量更新是文献库自己的事，课题只是关联库来用
+    语料。``project`` 仅用来取展示名（有起源课题时用课题名更好认），不写进
+    run.project_id —— 写了会让库任务混进课题的任务列表，鉴权走库级写权限、
+    活动流走 activity.library_id，都不需要它。
     """
     if await find_running_ingest_for_library(session, library.id) is not None:
         raise IngestConflictError(str(library.id))
@@ -146,7 +134,6 @@ async def create_ingest_voyage(
         if mode == "bootstrap"
         else f"文献调研增量更新：{target_name}"
     )
-    project_id = project.id if project is not None else None
     run = VoyageRun(
         kind=kind,
         goal=goal,
@@ -154,14 +141,12 @@ async def create_ingest_voyage(
         cursor=0,
         checkpoint={"params": {"mode": mode, "knobs": knobs.model_dump()}},
         budget=budget,
-        project_id=project_id,
         library_id=library.id,
         created_by=created_by,
     )
     session.add(run)
     session.add(
         Activity(
-            project_id=project_id,
             library_id=library.id,
             actor=f"user:{created_by}" if created_by else "system:cron",
             kind="ingest.started",
@@ -261,7 +246,10 @@ async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any
     # P8a：水位线/last_run 权威源在库（library.ingest_state）
     library = await get_library_for_project(session, project.id)
     state = (library.ingest_state if library else None) or {}
-    running = await find_running_ingest(session, project.id)
+    # 互斥以库为准：库任务不写 project_id，按课题查已经查不到在跑的任务
+    running = (
+        await find_running_ingest_for_library(session, library.id) if library else None
+    )
     return {
         "watermark": state.get("watermark"),
         "last_run": await _resolve_last_run(session, state),
@@ -305,7 +293,9 @@ async def find_due_daily_projects(session: AsyncSession) -> list[Project]:
         state = library.ingest_state or {}
         if definition.get("cadence") != "daily" or not state.get("watermark"):
             continue
-        if await find_running_ingest(session, project.id) is not None:
+        # 互斥以库为准（库任务不写 project_id）——按课题查会漏掉在跑的任务，
+        # cron 会重复启动
+        if await find_running_ingest_for_library(session, library.id) is not None:
             continue
         due.append(project)
     return due

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -3,13 +3,14 @@
 import uuid
 from collections.abc import Sequence
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.library_direction import DirectionLibraryCurator, TopicSourceLibrary
 from app.models.project import ProjectMember
 from app.models.user import User
-from app.models.voyage import TERMINAL_STATUSES, VoyageRun
+from app.models.voyage import LIBRARY_KINDS, TERMINAL_STATUSES, VoyageRun
 from app.schemas.voyage import VoyageCreate
 
 
@@ -38,19 +39,44 @@ async def create_voyage(
     return run
 
 
-def _member_filter(stmt, user_id: uuid.UUID):
-    return stmt.join(ProjectMember, ProjectMember.project_id == VoyageRun.project_id).where(
-        ProjectMember.user_id == user_id
+def _visible_filter(stmt, user_id: uuid.UUID):
+    """可见任务 = 我所在课题的任务 ∪ 我够得着的库的任务（课题关联的库 ∪ 我策展的库）。
+
+    库任务不能只靠 project_id 判：独立库的任务 project_id 为空，按课题成员 join
+    会把它们整个漏掉——而独立库是常态（P9c 起建课题不再自动建库）。
+    """
+    my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+    my_libraries = select(TopicSourceLibrary.library_id).where(
+        TopicSourceLibrary.topic_id.in_(my_projects)
+    )
+    my_curated = select(DirectionLibraryCurator.library_id).where(
+        DirectionLibraryCurator.user_id == user_id
+    )
+    is_admin = select(User.id).where(User.id == user_id, User.role == "admin").exists()
+    return stmt.where(
+        or_(
+            VoyageRun.project_id.in_(my_projects),
+            VoyageRun.library_id.in_(my_libraries),
+            VoyageRun.library_id.in_(my_curated),
+            is_admin,
+        )
     )
 
 
 async def list_voyages(
     session: AsyncSession, *, user_id: uuid.UUID, project_id: uuid.UUID | None = None
 ) -> Sequence[VoyageRun]:
-    """列出用户所在项目的航程（可按项目过滤）。"""
-    stmt = _member_filter(select(VoyageRun), user_id).order_by(VoyageRun.created_at.desc())
+    """列出用户够得着的任务；``project_id`` 只取该课题自己的任务。
+
+    按课题过滤时排除库任务（建库 / 增量更新）：那是文献库自己的事，在实验室
+    工作台看。判据是 kind 而不是 library_id —— 库化改造前建的存量任务只挂了
+    课题，没有 library_id，按后者判会把它们当成课题任务漏出来。
+    """
+    stmt = _visible_filter(select(VoyageRun), user_id).order_by(VoyageRun.created_at.desc())
     if project_id is not None:
-        stmt = stmt.where(VoyageRun.project_id == project_id)
+        stmt = stmt.where(
+            VoyageRun.project_id == project_id, VoyageRun.kind.not_in(LIBRARY_KINDS)
+        )
     return (await session.execute(stmt)).scalars().all()
 
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b3d81f6c05a9"  # 历史库的起源课题成员补成策展人
-PREV_REVISION = "a7f4c2e91b83"  # 相关研究书架 + 我的文献库 回收站（软删）
+HEAD_REVISION = "c5e2a90d41f7"  # 库任务归实验室：回填 library_id、清 project_id
+PREV_REVISION = "b3d81f6c05a9"  # 历史库的起源课题成员补成策展人
 
 
 def _make_config(db_path: Path) -> Config:
@@ -250,16 +250,18 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：书架 / 个人库回收站（软删）
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
-    # 本分支新增：策展人回填的备份表（downgrade 据此精确回滚）
+    # 本分支新增：两张回滚备份表（策展人回填 / 库任务脱离课题）
     assert "_pr3_backfilled_curators" in columns["_tables"]
+    assert "_c5e2a90d_voyage_topic" in columns["_tables"]
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（a7f4c2e91b83，回收站）。
-    # 该步只回退策展人回填（删回填的行 + 备份表），其余结构不动。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（b3d81f6c05a9，策展人回填）。
+    # 该步只回退库任务脱离课题（还原 project_id + 删备份表），其余结构不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    # 回填回退后备份表消失；上一版的回收站列仍在
-    assert "_pr3_backfilled_curators" not in columns["_tables"]
+    # 本迁移的备份表消失；上一版的备份表与回收站列都还在
+    assert "_c5e2a90d_voyage_topic" not in columns["_tables"]
+    assert "_pr3_backfilled_curators" in columns["_tables"]
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
     assert "email_verification_codes" in columns["_tables"]
@@ -313,10 +315,11 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
-    # 回收站列与回填备份表在重新 upgrade 后回归
+    # 回收站列与两张备份表在重新 upgrade 后回归
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
     assert "_pr3_backfilled_curators" in columns["_tables"]
+    assert "_c5e2a90d_voyage_topic" in columns["_tables"]
     assert "project_id" not in columns["paper_notes"]
     assert "project_id" not in columns["paper_highlights"]
     assert "models" in columns["llm_providers"]

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -1,0 +1,150 @@
+"""任务分层：建库 / 增量更新归实验室，其余归课题。
+
+课题的任务列表不含库任务（去实验室工作台看）；库任务对够得着这个库的人可见，
+不再要求「是起源课题的成员」——独立库根本没有起源课题。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
+from app.models.user import User
+from app.models.voyage import VoyageRun
+from app.services import voyages as voyages_service
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _user_id(email: str) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(select(User).where(User.email == email))
+        ).scalar_one().id
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+async def _make_run(*, kind: str, library_id=None, project_id=None) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind=kind,
+            goal=f"{kind} 测试任务",
+            status="planning",
+            cursor=0,
+            library_id=library_id,
+            project_id=project_id,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+async def _library(client, admin_hdr, owner_hdr, *, name) -> str:
+    resp = await client.post(
+        "/api/libraries", json={"name": name, "statement": "测试库"}, headers=owner_hdr
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_hdr)
+    assert resp.status_code == 200, resp.text
+    return lib_id
+
+
+async def test_library_voyages_stay_out_of_the_topic_list(client):
+    """课题任务列表不含建库 / 增量更新——哪怕它们还带着 project_id（存量任务）。"""
+    admin_email = "vscope-admin@example.com"
+    await _hdr(client, admin_email)  # 第一个注册者占掉平台 admin 位
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-owner@example.com")
+    owner_id = await _user_id("vscope-owner@example.com")
+
+    resp = await client.post(
+        "/api/projects", json={"name": "任务分层课题", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    topic_run = await _make_run(kind="idea_forge", project_id=project_id)
+    # 存量形态：库任务只挂课题，没有 library_id —— 按 library_id 判会漏，按 kind 才拦得住
+    legacy_ingest = await _make_run(kind="wiki_ingest", project_id=project_id)
+    legacy_bootstrap = await _make_run(kind="wiki_bootstrap", project_id=project_id)
+
+    async with get_sessionmaker()() as session:
+        runs = await voyages_service.list_voyages(
+            session, user_id=owner_id, project_id=project_id
+        )
+    ids = {r.id for r in runs}
+    assert topic_run in ids
+    assert legacy_ingest not in ids
+    assert legacy_bootstrap not in ids
+
+
+async def test_standalone_library_voyage_is_visible_to_its_curator(client):
+    """独立库的任务 project_id 为空——按课题成员 join 会整个漏掉，策展人得看得见。"""
+    admin_email = "vscope-curator-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-curator-owner@example.com")
+    lib_id = await _library(client, admin, owner, name="独立库·任务可见")
+
+    run_id = await _make_run(kind="wiki_ingest", library_id=uuid.UUID(lib_id))
+
+    curator_email = "vscope-curator@example.com"
+    await _hdr(client, curator_email)
+    curator_id = await _user_id(curator_email)
+    stranger_email = "vscope-stranger@example.com"
+    await _hdr(client, stranger_email)
+    stranger_id = await _user_id(stranger_email)
+
+    async with get_sessionmaker()() as session:
+        # 还不是策展人：看不到
+        runs = await voyages_service.list_voyages(session, user_id=curator_id)
+        assert run_id not in {r.id for r in runs}
+
+    async with get_sessionmaker()() as session:
+        session.add(
+            DirectionLibraryCurator(library_id=uuid.UUID(lib_id), user_id=curator_id)
+        )
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        runs = await voyages_service.list_voyages(session, user_id=curator_id)
+        assert run_id in {r.id for r in runs}
+        # 无关的人始终看不到
+        runs = await voyages_service.list_voyages(session, user_id=stranger_id)
+        assert run_id not in {r.id for r in runs}
+
+
+async def test_new_ingest_voyage_carries_no_project(client):
+    """新建的库任务不写 project_id：库任务归库，课题只是关联库来用语料。"""
+    from app.schemas.ingest import IngestKnobs
+    from app.services.ingest import create_ingest_voyage
+
+    admin_email = "vscope-ingest-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-ingest-owner@example.com")
+    lib_id = await _library(client, admin, owner, name="建库任务归属")
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(lib_id))
+        run = await create_ingest_voyage(
+            session,
+            library=library,
+            project=None,
+            mode="bootstrap",
+            knobs=IngestKnobs(),
+            created_by=None,
+        )
+        assert run.project_id is None
+        assert run.library_id == uuid.UUID(lib_id)

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -352,11 +352,12 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
         assert library.ingest_state["watermark"]
         assert library.ingest_state["last_run"]["voyage_id"] == run_id
 
+        # ingest 活动流归库（任务也归库）：按 library_id 查，不再挂课题
         activity_kinds = {
             a.kind
             for a in (
                 await session.execute(
-                    select(Activity).where(Activity.project_id == uuid.UUID(project_id))
+                    select(Activity).where(Activity.library_id == library.id)
                 )
             ).scalars()
         }
@@ -951,7 +952,7 @@ async def test_standalone_library_ingest_forbidden_for_stranger(client, queue_st
 
 
 async def test_project_ingest_run_carries_library_id(client, queue_stub, wiki_mocks):
-    """隐式库不回归：课题触发的 ingest 现在既带 project_id 也带 library_id（同库解析一致）。"""
+    """课题触发的 ingest 也只挂库：建库归实验室，不进课题的任务列表。"""
     project_id, headers = await _setup_project(client)
     resp = await client.post(
         f"/api/projects/{project_id}/ingest",
@@ -960,8 +961,9 @@ async def test_project_ingest_run_carries_library_id(client, queue_stub, wiki_mo
     )
     assert resp.status_code == 201, resp.text
     voyage = resp.json()
-    assert voyage["project_id"] == project_id
     assert voyage["library_id"] is not None
+    # 库任务不写 project_id —— 写了会混进课题的任务列表
+    assert voyage["project_id"] is None
 
     async with get_sessionmaker()() as session:
         from app.services.libraries import get_library_for_project
@@ -970,4 +972,4 @@ async def test_project_ingest_run_carries_library_id(client, queue_stub, wiki_mo
         assert voyage["library_id"] == str(library.id)
         run = await session.get(VoyageRun, uuid.UUID(voyage["id"]))
         assert run.library_id == library.id
-        assert run.project_id == uuid.UUID(project_id)
+        assert run.project_id is None


### PR DESCRIPTION
Building and syncing a library is the library's own business — a topic merely *links* libraries to use their papers. But those runs also carried a `project_id` (added back when the reason was "activity feed and authz compatibility"), so they turned up in the topic's task list.

Tasks now split by **kind**: `wiki_bootstrap` and `wiki_ingest` are lab tasks, everything else belongs to a topic.

## Why kind and not library_id

**34 of the 38 ingest runs in this database predate task-scoping and carry no `library_id` at all.** Filtering on `library_id` would let exactly the runs you see today slip through as topic tasks. Kind works for old and new rows alike.

## Cleaning up existing rows

New runs no longer write `project_id`. Migration `c5e2a90d41f7` handles the existing ones in two steps whose order cannot be swapped:

1. **Backfill `library_id`** — the pre-scoping runs need `project_id` to find their library, so clearing it first would orphan them. Resolution matches `get_library_for_project`: origin library first, else the topic's first linked library.
2. **Clear `project_id`**.

Dry-run on the current database: all 34 resolve (**zero orphans**), 37 rows get cleared. Runs that resolve to no library keep their `project_id` rather than becoming orphans. Original values go to a backup table; the downgrade restores them and undoes the backfill.

## Two things this would have broken

**The daily cron would have started a duplicate build every day.** It asked "is an ingest already running?" *by topic*. With `project_id` cleared it finds nothing and starts another. It now asks by library — which is what `create_ingest_voyage`'s own mutual-exclusion check already did. `find_running_ingest`, with no callers left and a premise that is now wrong, is deleted.

**Standalone libraries' tasks were invisible to everyone.** Task visibility joined `ProjectMember` on `project_id`, and a standalone library's run has none. Visibility is now: my topics' tasks, plus tasks of libraries I can reach (linked by my topics or curated by me), plus everything for platform admins. This is a pre-existing bug, not something this PR introduced.

The ingest activity feed follows the task onto the library — `ingest.completed` already read `run.project_id`, so it came along for free.

## Verification

New `test_voyage_scope.py` pins: a legacy-shaped library run (project only, no `library_id`) stays out of the topic list; a standalone library's run is visible to its curator and not to a stranger; a newly created ingest run carries no `project_id`.

Full backend suite: 699 passed. `test_paper_figures` fails here and on `main` alike. `ruff check app` clean, single alembic head, sqlite upgrade/downgrade/upgrade roundtrip green.

`test_wiki_ingest` needed updating — it asserted the old behaviour (run carries both ids, activity feed hangs off the topic). Those assertions now say the opposite, deliberately.
