### PR TITLE
feat(papers): personal tags, separate from a library's shared tags

### DIFF
--- a/src/backend/alembic/versions/c4a91e7b2f36_user_paper_tags.py
+++ b/src/backend/alembic/versions/c4a91e7b2f36_user_paper_tags.py
@@ -1,0 +1,51 @@
+"""个人标签表 user_paper_tags
+
+每个用户给论文打自己的标签，只有本人可见可改。与库作用域的 paper_tags 完全
+独立：库标签是共享资产（整组覆盖会盖掉同库其他人打的），个人标签是私域。
+
+扁平结构（name 内联，不建独立标签实体）：个人标签没有跨用户共享语义，不需要
+「改一处到处生效」，也就不需要零引用回收。双 CASCADE 与 paper_user_meta /
+paper_notes 一致——删用户或删论文时这些行随之清理。
+
+Revision ID: c4a91e7b2f36
+Revises: b3d81f6c05a9
+Create Date: 2026-07-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4a91e7b2f36"
+down_revision: str | None = "c5e2a90d41f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_paper_tags",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("paper_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["paper_id"], ["papers.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "paper_id", "name", name="uq_user_paper_tags"),
+    )
+    op.create_index("ix_user_paper_tags_user_id", "user_paper_tags", ["user_id"])
+    op.create_index("ix_user_paper_tags_paper_id", "user_paper_tags", ["paper_id"])
+    # 「我的所有标签」列表与按标签筛选的取行路径
+    op.create_index("ix_user_paper_tags_user_name", "user_paper_tags", ["user_id", "name"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_paper_tags_user_name", table_name="user_paper_tags")
+    op.drop_index("ix_user_paper_tags_paper_id", table_name="user_paper_tags")
+    op.drop_index("ix_user_paper_tags_user_id", table_name="user_paper_tags")
+    op.drop_table("user_paper_tags")

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -100,7 +100,10 @@ async def _paper_detail(
     session: AsyncSession, view: papers_service.PaperView, user_id: uuid.UUID
 ) -> PaperDetail:
     extras = await papers_service.paper_extras_map(
-        session, paper_ids=[view.id], user_id=user_id
+        session,
+        paper_ids=[view.id],
+        user_id=user_id,
+        library_ids=[view.library_id] if view.library_id is not None else None,
     )
     return PaperDetail.model_validate(view).model_copy(update=extras[view.id])
 
@@ -134,11 +137,14 @@ async def _get_visible_library(
 
 
 async def _reads_with_extras(
-    session: AsyncSession, papers: list, user_id: uuid.UUID
+    session: AsyncSession, papers: list, user_id: uuid.UUID, *, library_id: uuid.UUID
 ) -> list[PaperRead]:
-    """ORM → schema，回填 tags/starred/reading_status/note_count（个人维度，全员可用）。"""
+    """ORM → schema，回填 tags/my_tags/starred/reading_status/note_count（个人维度，全员可用）。
+
+    库标签只取本库那些（library_id）：一篇论文可能同时在多个库，不限定会串台。
+    """
     extras = await papers_service.paper_extras_map(
-        session, paper_ids=[p.id for p in papers], user_id=user_id
+        session, paper_ids=[p.id for p in papers], user_id=user_id, library_ids=[library_id]
     )
     return [PaperRead.model_validate(p).model_copy(update=extras[p.id]) for p in papers]
 
@@ -461,6 +467,7 @@ async def list_library_papers(
     status_filter: str | None = Query(default="library", alias="status"),
     q: str | None = Query(default=None),
     tag: str | None = Query(default=None),
+    my_tag: str | None = Query(default=None, description="按我的个人标签过滤"),
     starred: bool | None = Query(default=None),
     reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
     author: str | None = Query(default=None),
@@ -488,6 +495,7 @@ async def list_library_papers(
         status=status_filter,
         q=q,
         tag=tag,
+        my_tag=my_tag,
         starred=starred,
         reading_status=reading_status,
         author=author,
@@ -502,7 +510,7 @@ async def list_library_papers(
         size=size,
     )
     return PaperListPage(
-        items=await _reads_with_extras(session, list(items), user.id),
+        items=await _reads_with_extras(session, list(items), user.id, library_id=library.id),
         total=total,
         page=page,
         size=size,
@@ -672,7 +680,7 @@ async def search_library(
             )
         )
     extras = await papers_service.paper_extras_map(
-        session, paper_ids=[p.id for p, _ in paper_rows], user_id=user.id
+        session, paper_ids=[p.id for p, _ in paper_rows], user_id=user.id, library_ids=[library.id]
     )
     papers = [
         ScoredPaper(**(PaperRead.model_validate(p).model_dump() | extras[p.id]), score=s)

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -25,6 +25,7 @@ from app.core.redis import get_redis_dep
 from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.paper import (
+    MyTagRead,
     PaperBatchIds,
     PaperChatRequest,
     PaperDetail,
@@ -34,6 +35,8 @@ from app.schemas.paper import (
     PaperManualCreate,
     PaperMyMetaRead,
     PaperMyMetaUpdate,
+    PaperMyTagsRead,
+    PaperMyTagsUpdate,
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
@@ -65,10 +68,22 @@ async def _reads_with_extras(
     user_id: uuid.UUID,
     *,
     detail: bool = False,
+    library_ids: Sequence[uuid.UUID] | None = None,
 ) -> list[PaperRead]:
-    """ORM → schema，回填 tags/starred/reading_status/note_count（聚合查询，避免 N+1）。"""
+    """ORM → schema，回填 tags/my_tags/starred/reading_status/note_count（聚合查询，避免 N+1）。
+
+    library_ids = 本次浏览的库上下文（库标签按它过滤，见 paper_extras_map）；不传时按
+    每篇论文自己解析到的成员行所属库来算，池级可达的无库论文则不显示库标签。
+    """
     extras = await papers_service.paper_extras_map(
-        session, paper_ids=[p.id for p in papers], user_id=user_id
+        session,
+        paper_ids=[p.id for p in papers],
+        user_id=user_id,
+        library_ids=(
+            library_ids
+            if library_ids is not None
+            else [p.library_id for p in papers if p.library_id is not None]
+        ),
     )
     model = PaperDetail if detail else PaperRead
     return [model.model_validate(p).model_copy(update=extras[p.id]) for p in papers]
@@ -125,6 +140,7 @@ async def list_papers(
     status_filter: str | None = Query(default=None, alias="status"),
     q: str | None = Query(default=None),
     tag: str | None = Query(default=None),
+    my_tag: str | None = Query(default=None, description="按我的个人标签过滤"),
     starred: bool | None = Query(default=None),
     reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
     author: str | None = Query(default=None, description="作者姓名（包含匹配）"),
@@ -148,6 +164,7 @@ async def list_papers(
         status=status_filter,
         q=q,
         tag=tag,
+        my_tag=my_tag,
         starred=starred,
         reading_status=reading_status,
         user_id=user.id,
@@ -161,8 +178,13 @@ async def list_papers(
         created_from=created_from,
         created_to=created_to,
     )
+    # 库标签按课题的关联库并集显示（与 tag 过滤同口径，翻页也稳定）
+    library_ids = await libraries_service.get_source_library_ids(session, project_id)
     return PaperListPage(
-        items=await _reads_with_extras(session, items, user.id), total=total, page=page, size=size
+        items=await _reads_with_extras(session, items, user.id, library_ids=library_ids),
+        total=total,
+        page=page,
+        size=size,
     )
 
 
@@ -749,6 +771,35 @@ async def set_paper_tags(
     paper = await _get_member_paper(session, paper_id, user, with_concepts=True)
     await papers_service.set_paper_tags(session, paper, data.names)
     return await _paper_detail(session, paper, user.id)
+
+
+@router.get("/me/paper-tags", response_model=list[MyTagRead])
+async def list_my_paper_tags(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[MyTagRead]:
+    """我的所有个人标签（含标了几篇）——筛选下拉 / 输入建议用。"""
+    rows = await papers_service.list_user_paper_tags(session, user_id=user.id)
+    return [MyTagRead(**row) for row in rows]
+
+
+@router.put("/papers/{paper_id}/my-tags", response_model=PaperMyTagsRead)
+async def set_paper_my_tags(
+    paper_id: uuid.UUID,
+    data: PaperMyTagsUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperMyTagsRead:
+    """整组覆盖我给这篇打的个人标签（空数组=清空），只有我自己看得到。
+
+    可达口径同 my-meta（include_pool=True）：公共库 / 书架 / 个人库 / 每日推送里
+    读得到的论文都能打——个人标签不动共享资产，不需要库管理权限。
+    """
+    paper = await _get_member_paper(session, paper_id, user, include_pool=True)
+    names = await papers_service.set_user_paper_tags(
+        session, paper_id=paper.id, user_id=user.id, names=data.names
+    )
+    return PaperMyTagsRead(my_tags=names)
 
 
 @router.put("/papers/{paper_id}/my-meta", response_model=PaperMyMetaRead)

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -118,7 +118,11 @@ async def search(
             )
         )
     extras = await papers_service.paper_extras_map(
-        session, paper_ids=[p.id for p, _ in paper_rows], user_id=user.id
+        session,
+        paper_ids=[p.id for p, _ in paper_rows],
+        user_id=user.id,
+        # 库标签按课题的关联库并集显示（同论文列表口径）
+        library_ids=await libraries_service.get_source_library_ids(session, project_id),
     )
     papers = [
         ScoredPaper(**(PaperRead.model_validate(p).model_dump() | extras[p.id]), score=s)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -25,6 +25,7 @@ from app.models.paper import (
     PaperNote,
     PaperTag,
     PaperUserMeta,
+    UserPaperTag,
     paper_concepts,
     paper_tag_links,
 )
@@ -86,6 +87,7 @@ __all__ = [
     "User",
     "UserAuthorProfile",
     "UserLibraryEntry",
+    "UserPaperTag",
     "UserPublication",
     "UUIDPrimaryKeyMixin",
     "VoyageRun",

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     String,
     Table,
     Text,
@@ -181,6 +182,31 @@ class PaperUserMeta(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     reading_status: Mapped[str] = mapped_column(
         String(16), default="unread", nullable=False
     )  # unread | reading | read
+
+
+class UserPaperTag(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """个人标签（paper × user × name）：任何登录用户都能给自己可读的论文打，
+    只有本人可见可改。与库作用域的 PaperTag 完全独立——库标签是共享资产（整组
+    覆盖会盖掉别人打的），个人标签是私域。
+
+    扁平设计：名字内联在这张表上，不另建标签实体。个人标签没有跨用户共享语义，
+    不需要「改一处到处生效」，也就不需要库标签那套零引用回收
+    （对照 papers.prune_orphan_tags）。
+    """
+
+    __tablename__ = "user_paper_tags"
+    __table_args__ = (
+        UniqueConstraint("user_id", "paper_id", "name", name="uq_user_paper_tags"),
+        Index("ix_user_paper_tags_user_name", "user_id", "name"),  # 「我的所有标签」列表 / 按标签筛
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
 
 
 class Concept(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -61,7 +61,8 @@ class PaperRead(BaseModel):
     compiled_at: datetime | None = None  # wiki 编译时间；未编译为 null
     compiled_model: str | None = None  # 编译所用模型名；未编译/存量数据为 null
     # 以下字段不来自 ORM 属性，由 service 层聚合查询后回填（见 papers.paper_extras_map）
-    tags: list[str] = []
+    tags: list[str] = []  # 库标签（共享）：本次浏览的库里打的；无库上下文时为空
+    my_tags: list[str] = []  # 个人标签：只有本人看得到、改得了
     starred: bool = False  # 当前用户视角
     reading_status: str = "unread"  # 当前用户视角：unread | reading | read
     note_count: int = 0
@@ -162,6 +163,23 @@ class PaperTagsUpdate(BaseModel):
 
 class TagRead(BaseModel):
     id: uuid.UUID
+    name: str
+    paper_count: int = 0
+
+
+class PaperMyTagsUpdate(BaseModel):
+    """整组覆盖当前用户对这篇的个人标签；空数组=清空。"""
+
+    names: list[str]
+
+
+class PaperMyTagsRead(BaseModel):
+    my_tags: list[str] = []
+
+
+class MyTagRead(BaseModel):
+    """「我的所有标签」一行（个人标签没有独立实体，所以只有名字 + 篇数）。"""
+
     name: str
     paper_count: int = 0
 

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -31,6 +31,7 @@ from app.models.paper import (
     PaperNote,
     PaperTag,
     PaperUserMeta,
+    UserPaperTag,
     paper_tag_links,
 )
 from app.models.project import ProjectMember
@@ -162,6 +163,7 @@ def apply_paper_filters(
     status: str | None = None,
     q: str | None = None,
     tag: str | None = None,
+    my_tag: str | None = None,
     starred: bool | None = None,
     reading_status: str | None = None,
     user_id: uuid.UUID | None = None,
@@ -215,6 +217,14 @@ def apply_paper_filters(
                 .where(PaperTag.library_id.in_(library_ids), PaperTag.name == tag)
             )
         )
+    if my_tag:
+        stmt = stmt.where(
+            exists().where(
+                UserPaperTag.paper_id == Paper.id,
+                UserPaperTag.user_id == user_id,
+                UserPaperTag.name == my_tag,
+            )
+        )
     if starred is not None:
         starred_exists = exists().where(
             PaperUserMeta.paper_id == Paper.id,
@@ -240,6 +250,7 @@ async def list_papers(
     status: str | None = None,
     q: str | None = None,
     tag: str | None = None,
+    my_tag: str | None = None,
     starred: bool | None = None,
     reading_status: str | None = None,
     user_id: uuid.UUID | None = None,
@@ -267,6 +278,7 @@ async def list_papers(
         status=status,
         q=q,
         tag=tag,
+        my_tag=my_tag,
         starred=starred,
         reading_status=reading_status,
         user_id=user_id,
@@ -462,26 +474,51 @@ async def set_paper_status(session: AsyncSession, view: PaperView, status: str) 
 
 
 async def paper_extras_map(
-    session: AsyncSession, *, paper_ids: Sequence[uuid.UUID], user_id: uuid.UUID
+    session: AsyncSession,
+    *,
+    paper_ids: Sequence[uuid.UUID],
+    user_id: uuid.UUID,
+    library_ids: Sequence[uuid.UUID] | None = None,
 ) -> dict[uuid.UUID, dict[str, Any]]:
-    """批量取论文的 tags / starred / reading_status / note_count（3 条聚合查询，避免 N+1）。
+    """批量取论文的 tags / my_tags / starred / reading_status / note_count（聚合查询，避免 N+1）。
 
-    note_count 是请求者本人的笔记数（P5b 起笔记 paper × author，仅作者可见）。"""
+    - ``tags`` 是**库标签**（共享），只取本次浏览上下文 ``library_ids`` 里的那些：一篇论文
+      可能同时在多个库，不限定就会把别的库打的标签串到这里来。没有库上下文（书架 /
+      个人库 / 每日推送这类池级可达的论文）时不显示库标签——无从归属，也不该把别人库
+      的整理口径漏出去。
+    - ``my_tags`` 是请求者自己的个人标签（user_paper_tags），与库无关，任何上下文都显示。
+    - ``note_count`` 是请求者本人的笔记数（P5b 起笔记 paper × author，仅作者可见）。
+    """
     extras: dict[uuid.UUID, dict[str, Any]] = {
-        pid: {"tags": [], "starred": False, "reading_status": "unread", "note_count": 0}
+        pid: {
+            "tags": [],
+            "my_tags": [],
+            "starred": False,
+            "reading_status": "unread",
+            "note_count": 0,
+        }
         for pid in paper_ids
     }
     if not extras:
         return extras
     ids = list(extras.keys())
-    tag_rows = await session.execute(
-        select(paper_tag_links.c.paper_id, PaperTag.name)
-        .join(PaperTag, PaperTag.id == paper_tag_links.c.tag_id)
-        .where(paper_tag_links.c.paper_id.in_(ids))
-        .order_by(PaperTag.name)
+    if library_ids:
+        tag_rows = await session.execute(
+            select(paper_tag_links.c.paper_id, PaperTag.name)
+            .join(PaperTag, PaperTag.id == paper_tag_links.c.tag_id)
+            .where(paper_tag_links.c.paper_id.in_(ids), PaperTag.library_id.in_(library_ids))
+            .order_by(PaperTag.name)
+        )
+        for pid, name in tag_rows.all():
+            if name not in extras[pid]["tags"]:  # 多库上下文里同名标签只算一次
+                extras[pid]["tags"].append(name)
+    my_tag_rows = await session.execute(
+        select(UserPaperTag.paper_id, UserPaperTag.name)
+        .where(UserPaperTag.paper_id.in_(ids), UserPaperTag.user_id == user_id)
+        .order_by(UserPaperTag.name)
     )
-    for pid, name in tag_rows.all():
-        extras[pid]["tags"].append(name)
+    for pid, name in my_tag_rows.all():
+        extras[pid]["my_tags"].append(name)
     note_rows = await session.execute(
         select(PaperNote.paper_id, func.count())
         .where(PaperNote.paper_id.in_(ids), PaperNote.author_id == user_id)
@@ -563,6 +600,40 @@ async def list_library_tags(
         .order_by(PaperTag.name)
     )
     return [{"id": tid, "name": name, "paper_count": int(count)} for tid, name, count in rows]
+
+
+async def set_user_paper_tags(
+    session: AsyncSession, *, paper_id: uuid.UUID, user_id: uuid.UUID, names: list[str]
+) -> list[str]:
+    """整组覆盖某人给某篇打的**个人标签**（空数组=清空），返回排序后的标签名。
+
+    与库标签的整组覆盖（:func:`set_paper_tags`）互不影响：这里只删改
+    (user_id, paper_id) 这一格，别人给同一篇打的个人标签、以及库标签都不动。
+    名字内联存，删掉最后一处引用就没了，不需要额外的零引用回收。
+    """
+    cleaned = list(dict.fromkeys(n.strip() for n in names if n and n.strip()))
+    await session.execute(
+        delete(UserPaperTag).where(
+            UserPaperTag.paper_id == paper_id, UserPaperTag.user_id == user_id
+        )
+    )
+    for name in cleaned:
+        session.add(UserPaperTag(paper_id=paper_id, user_id=user_id, name=name))
+    await session.commit()
+    return sorted(cleaned)
+
+
+async def list_user_paper_tags(
+    session: AsyncSession, *, user_id: uuid.UUID
+) -> list[dict[str, Any]]:
+    """「我的所有标签」（含标了几篇），按名称排序——给前端的筛选下拉 / 输入建议用。"""
+    rows = await session.execute(
+        select(UserPaperTag.name, func.count(UserPaperTag.paper_id))
+        .where(UserPaperTag.user_id == user_id)
+        .group_by(UserPaperTag.name)
+        .order_by(UserPaperTag.name)
+    )
+    return [{"name": name, "paper_count": int(count)} for name, count in rows]
 
 
 async def upsert_paper_user_meta(

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "c5e2a90d41f7"  # 库任务归实验室：回填 library_id、清 project_id
-PREV_REVISION = "b3d81f6c05a9"  # 历史库的起源课题成员补成策展人
+HEAD_REVISION = "c4a91e7b2f36"  # 个人标签表 user_paper_tags
+PREV_REVISION = "c5e2a90d41f7"  # 库任务归实验室：回填 library_id、清 project_id
 
 
 def _make_config(db_path: Path) -> Config:
@@ -40,6 +40,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "paper_tags",
                     "paper_tag_links",
                     "paper_user_meta",
+                    "user_paper_tags",
                     "paper_highlights",
                     "manuscripts",
                     "manuscript_files",
@@ -250,18 +251,22 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：书架 / 个人库回收站（软删）
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
-    # 本分支新增：两张回滚备份表（策展人回填 / 库任务脱离课题）
+    # 上一版的两张回滚备份表（策展人回填 / 库任务脱离课题）
     assert "_pr3_backfilled_curators" in columns["_tables"]
     assert "_c5e2a90d_voyage_topic" in columns["_tables"]
+    # 本分支新增：个人标签表（paper × user × name，与库标签完全独立）
+    assert "user_paper_tags" in columns["_tables"]
+    assert {"id", "user_id", "paper_id", "name"} <= columns["user_paper_tags"]
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（b3d81f6c05a9，策展人回填）。
-    # 该步只回退库任务脱离课题（还原 project_id + 删备份表），其余结构不动。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（c5e2a90d41f7，库任务归实验室）。
+    # 该步只删个人标签表，其余结构不动（库标签 paper_tags 一点不受影响）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    # 本迁移的备份表消失；上一版的备份表与回收站列都还在
-    assert "_c5e2a90d_voyage_topic" not in columns["_tables"]
-    assert "_pr3_backfilled_curators" in columns["_tables"]
+    # 个人标签表消失；库标签表与上一版的两张备份表、回收站列都还在
+    assert "user_paper_tags" not in columns["_tables"]
+    assert {"paper_tags", "paper_tag_links", "_pr3_backfilled_curators"} <= columns["_tables"]
+    assert "_c5e2a90d_voyage_topic" in columns["_tables"]
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
     assert "email_verification_codes" in columns["_tables"]
@@ -315,7 +320,9 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
-    # 回收站列与两张备份表在重新 upgrade 后回归
+    # 个人标签表在重新 upgrade 后回归；回收站列与两张备份表也仍在
+    assert "user_paper_tags" in columns["_tables"]
+    assert {"id", "user_id", "paper_id", "name"} <= columns["user_paper_tags"]
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
     assert "trashed_at" in columns["user_library_entries"]
     assert "_pr3_backfilled_curators" in columns["_tables"]

--- a/src/backend/tests/test_paper_tags_meta.py
+++ b/src/backend/tests/test_paper_tags_meta.py
@@ -179,3 +179,165 @@ async def test_papers_list_new_fields_and_filters(client):
         f"/api/projects/{project_id}/papers?reading_status=unread", headers=headers
     )
     assert [p["title"] for p in resp.json()["items"]] == ["Paper Two"]
+
+
+# ---- 个人标签：只有本人可见可改，与库标签互不影响 ----
+
+
+async def test_my_tags_put_overwrite_clear_and_list(client):
+    project_id, headers, ids = await _setup(client)
+
+    resp = await client.put(
+        f"/api/papers/{ids['p1']}/my-tags",
+        json={"names": ["精读", "待复现", "精读"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"my_tags": ["待复现", "精读"]}  # 去重 + 排序
+
+    # 详情 / 列表都带上 my_tags
+    resp = await client.get(f"/api/papers/{ids['p1']}", headers=headers)
+    assert resp.json()["my_tags"] == ["待复现", "精读"]
+    resp = await client.get(f"/api/projects/{project_id}/papers", headers=headers)
+    by_title = {p["title"]: p for p in resp.json()["items"]}
+    assert by_title["Paper One"]["my_tags"] == ["待复现", "精读"]
+    assert by_title["Paper Two"]["my_tags"] == []
+
+    # 「我的所有标签」含标了几篇
+    await client.put(f"/api/papers/{ids['p2']}/my-tags", json={"names": ["精读"]}, headers=headers)
+    resp = await client.get("/api/me/paper-tags", headers=headers)
+    assert resp.json() == [
+        {"name": "待复现", "paper_count": 1},
+        {"name": "精读", "paper_count": 2},
+    ]
+
+    # 整组覆盖：p1 只留「精读」
+    resp = await client.put(
+        f"/api/papers/{ids['p1']}/my-tags", json={"names": ["精读"]}, headers=headers
+    )
+    assert resp.json() == {"my_tags": ["精读"]}
+
+    # 清空
+    resp = await client.put(f"/api/papers/{ids['p1']}/my-tags", json={"names": []}, headers=headers)
+    assert resp.json() == {"my_tags": []}
+    resp = await client.get("/api/me/paper-tags", headers=headers)
+    assert resp.json() == [{"name": "精读", "paper_count": 1}]  # 只剩 p2 那条
+
+
+async def test_my_tags_are_per_user(client):
+    project_id, headers, ids = await _setup(client)
+    await client.put(f"/api/papers/{ids['p1']}/my-tags", json={"names": ["我的"]}, headers=headers)
+
+    bob = await register_and_login(client, email="bob-mytags@example.com")
+    bob_headers = {"Authorization": f"Bearer {bob}"}
+    await client.post(
+        f"/api/projects/{project_id}/members",
+        json={"email": "bob-mytags@example.com", "role": "member"},
+        headers=headers,
+    )
+
+    # 同一篇论文，看不到别人的个人标签
+    resp = await client.get(f"/api/papers/{ids['p1']}", headers=bob_headers)
+    assert resp.json()["my_tags"] == []
+    assert (await client.get("/api/me/paper-tags", headers=bob_headers)).json() == []
+
+    # 各打各的，互不覆盖
+    await client.put(
+        f"/api/papers/{ids['p1']}/my-tags", json={"names": ["他的"]}, headers=bob_headers
+    )
+    alice_view = await client.get(f"/api/papers/{ids['p1']}", headers=headers)
+    bob_view = await client.get(f"/api/papers/{ids['p1']}", headers=bob_headers)
+    assert alice_view.json()["my_tags"] == ["我的"]
+    assert bob_view.json()["my_tags"] == ["他的"]
+
+
+async def test_stranger_can_tag_paper_in_public_library(client):
+    """公共库里的陌生人也能打个人标签（放行口径对齐 my-meta）。"""
+    _project_id, headers, ids = await _setup(client)
+    stranger = await register_and_login(client, email="stranger-mytags@example.com")
+    stranger_headers = {"Authorization": f"Bearer {stranger}"}
+
+    resp = await client.put(
+        f"/api/papers/{ids['p1']}/my-tags", json={"names": ["路人的"]}, headers=stranger_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"my_tags": ["路人的"]}
+    resp = await client.get(f"/api/papers/{ids['p1']}", headers=stranger_headers)
+    assert resp.json()["my_tags"] == ["路人的"]
+    # 库归属人看不到路人的个人标签
+    assert (await client.get(f"/api/papers/{ids['p1']}", headers=headers)).json()["my_tags"] == []
+
+
+async def test_my_tag_filter_and_independence_from_library_tags(client):
+    project_id, headers, ids = await _setup(client)
+    await client.put(f"/api/papers/{ids['p1']}/tags", json={"names": ["库标签"]}, headers=headers)
+    await client.put(
+        f"/api/papers/{ids['p1']}/my-tags", json={"names": ["个人标签"]}, headers=headers
+    )
+    await client.put(f"/api/papers/{ids['p2']}/my-tags", json={"names": ["别的"]}, headers=headers)
+
+    # 按个人标签筛选
+    resp = await client.get(f"/api/projects/{project_id}/papers?my_tag=个人标签", headers=headers)
+    assert [p["title"] for p in resp.json()["items"]] == ["Paper One"]
+    resp = await client.get(f"/api/projects/{project_id}/papers?my_tag=没人用过", headers=headers)
+    assert resp.json()["items"] == []
+    # 库标签筛选不认个人标签名
+    resp = await client.get(f"/api/projects/{project_id}/papers?tag=个人标签", headers=headers)
+    assert resp.json()["items"] == []
+
+    # 两份清单互不串：库标签列表里没有个人标签，反之亦然
+    resp = await client.get(f"/api/projects/{project_id}/tags", headers=headers)
+    assert [t["name"] for t in resp.json()] == ["库标签"]
+    resp = await client.get("/api/me/paper-tags", headers=headers)
+    assert [t["name"] for t in resp.json()] == ["个人标签", "别的"]
+
+    # 覆盖库标签不动个人标签，反之亦然
+    await client.put(f"/api/papers/{ids['p1']}/tags", json={"names": []}, headers=headers)
+    body = (await client.get(f"/api/papers/{ids['p1']}", headers=headers)).json()
+    assert body["tags"] == [] and body["my_tags"] == ["个人标签"]
+    await client.put(f"/api/papers/{ids['p1']}/my-tags", json={"names": []}, headers=headers)
+    await client.put(f"/api/papers/{ids['p1']}/tags", json={"names": ["库标签"]}, headers=headers)
+    body = (await client.get(f"/api/papers/{ids['p1']}", headers=headers)).json()
+    assert body["tags"] == ["库标签"] and body["my_tags"] == []
+
+
+async def test_library_tags_scoped_to_browsing_library(client):
+    """一篇论文同时在 A、B 两个库时，在哪个库浏览就只看到哪个库打的库标签。"""
+    from sqlalchemy import insert
+
+    from app.models.library_direction import LibraryPaper
+    from app.models.paper import PaperTag, paper_tag_links
+    from tests.conftest import ensure_project_library
+
+    token = await register_and_login(client, email="two-lib@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    a_id = (await client.post("/api/projects", json={"name": "库A"}, headers=headers)).json()["id"]
+    b_id = (await client.post("/api/projects", json={"name": "库B"}, headers=headers)).json()["id"]
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(a_id), title="Cross Library Paper", status="included"
+        )
+        lib_a = await ensure_project_library(session, uuid.UUID(a_id))
+        lib_b = await ensure_project_library(session, uuid.UUID(b_id))
+        session.add(LibraryPaper(library_id=lib_b.id, paper_id=paper.id, status="included"))
+        for library_id, name in ((lib_a.id, "A库标签"), (lib_b.id, "B库标签")):
+            tag = PaperTag(library_id=library_id, name=name)
+            session.add(tag)
+            await session.flush()
+            await session.execute(insert(paper_tag_links).values(paper_id=paper.id, tag_id=tag.id))
+        await session.commit()
+        paper_id, lib_a_id, lib_b_id = str(paper.id), str(lib_a.id), str(lib_b.id)
+
+    for library_id, expected in ((lib_a_id, "A库标签"), (lib_b_id, "B库标签")):
+        resp = await client.get(f"/api/libraries/{library_id}/papers", headers=headers)
+        assert resp.status_code == 200, resp.text
+        assert [p["tags"] for p in resp.json()["items"]] == [[expected]]
+        resp = await client.get(f"/api/libraries/{library_id}/papers/{paper_id}", headers=headers)
+        assert resp.json()["tags"] == [expected]
+
+    # 课题论文列表按该课题的关联库并集显示（这里各自只关联自己那个库）
+    resp = await client.get(f"/api/projects/{a_id}/papers", headers=headers)
+    assert [p["tags"] for p in resp.json()["items"]] == [["A库标签"]]
+    resp = await client.get(f"/api/projects/{b_id}/papers", headers=headers)
+    assert [p["tags"] for p in resp.json()["items"]] == [["B库标签"]]

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -42,6 +42,7 @@ import {
 import {
   ConceptChips,
   PaperMyMetaRow,
+  PaperMyTagsRow,
   PaperNotesSection,
   PaperTagsRow,
   WikiHeaderActions,
@@ -395,8 +396,11 @@ function DailyDetailPane({
         />
       )}
 
-      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
       <PaperTagsRow tags={poolPaper?.tags} />
+      {poolPaper && (
+        <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
+      )}
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -29,7 +29,9 @@ import { tr } from '../../lib/i18n';
 import {
   ConceptChips,
   PaperMyMetaRow,
+  PaperMyTagsRow,
   PaperNotesSection,
+  PaperTagChips,
   PaperTagsRow,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
@@ -102,7 +104,6 @@ const PaperRow = memo(function PaperRow({
   onClick: () => void;
   onToggleCheck: () => void;
 }) {
-  const tags = p.tags ?? [];
   return (
     <div
       onClick={onClick}
@@ -156,20 +157,7 @@ const PaperRow = memo(function PaperRow({
       <div className="row gap8" style={{ marginTop: 6 }}>
         <PaperStatusPill status={p.status} sm />
         <ReadingDot status={p.reading_status} />
-        {tags.slice(0, 2).map((t) => (
-          <span
-            key={t}
-            className="tag"
-            style={{ fontSize: 10, height: 17, padding: '0 6px', maxWidth: 90, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', lineHeight: '17px' }}
-          >
-            {t}
-          </span>
-        ))}
-        {tags.length > 2 && (
-          <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
-            +{tags.length - 2}
-          </span>
-        )}
+        <PaperTagChips tags={p.tags} myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
           <span
             className="row"
@@ -418,8 +406,14 @@ function PaperDetailPane({
         invalidateKeys={listKeys}
       />
 
-      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
       <PaperTagsRow tags={paper.tags} />
+      <PaperMyTagsRow
+        paperId={paper.id}
+        myTags={paper.my_tags}
+        detailKey={detailKey}
+        invalidateKeys={listKeys}
+      />
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
@@ -640,23 +634,24 @@ function PapersPane({
       toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  // —— 高级检索（作者 / 机构 / 年份区间 / 阅读状态 / 星标） ——
+  // —— 高级检索（作者 / 机构 / 年份区间 / 我的标签 / 阅读状态 / 星标） ——
   const [advOpen, setAdvOpen] = useState(false);
   const [advAuthor, setAdvAuthor] = useState('');
   const [advAffiliation, setAdvAffiliation] = useState('');
   const [advYearFrom, setAdvYearFrom] = useState('');
   const [advYearTo, setAdvYearTo] = useState('');
+  const [advMyTag, setAdvMyTag] = useState('');
   const [advReading, setAdvReading] = useState<'' | ReadingStatus>('');
   const [advStarred, setAdvStarred] = useState(false);
   const author = useDebounced(advAuthor.trim());
   const affiliation = useDebounced(advAffiliation.trim());
   const yearFrom = parseYear(advYearFrom);
   const yearTo = parseYear(advYearTo);
-  const advActive = !!(author || affiliation || yearFrom || yearTo || advReading || advStarred);
+  const advActive = !!(author || affiliation || yearFrom || yearTo || advMyTag || advReading || advStarred);
 
   useEffect(
     () => setPage(1),
-    [q, sort, semanticOn, view, tagFilter, author, affiliation, yearFrom, yearTo, advReading, advStarred],
+    [q, sort, semanticOn, view, tagFilter, author, affiliation, yearFrom, yearTo, advMyTag, advReading, advStarred],
   );
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板
@@ -668,6 +663,7 @@ function PapersPane({
       setAdvAffiliation(patch.affiliation ?? '');
       setAdvYearFrom('');
       setAdvYearTo('');
+      setAdvMyTag('');
       setAdvReading('');
       setAdvStarred(false);
       setAdvOpen(true);
@@ -691,10 +687,14 @@ function PapersPane({
   });
   const libraryTags = tagsQuery.data ?? [];
 
+  // 我的标签（过滤下拉用；跨库共用一份，所以 queryKey 不带 libraryId）
+  const myTagsQuery = useQuery({ queryKey: ['my-tags'], queryFn: () => api.listMyTags(), retry: false });
+  const myTags = myTagsQuery.data ?? [];
+
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
-      'lib-papers', libraryId, view, tagFilter, q, sort, page,
+      'lib-papers', libraryId, view, tagFilter, advMyTag, q, sort, page,
       author, affiliation, yearFrom, yearTo, advReading, advStarred,
     ],
     queryFn: () => {
@@ -703,6 +703,7 @@ function PapersPane({
         status: vq.status,
         starred: vq.starred || advStarred || undefined,
         tag: tagFilter || undefined,
+        my_tag: advMyTag || undefined,
         q: q || undefined,
         sort,
         page,
@@ -758,7 +759,10 @@ function PapersPane({
               open={advOpen}
               active={advActive}
               onToggle={() => setAdvOpen((o) => !o)}
-              title={tr('高级检索：作者 / 机构 / 年份 / 阅读状态 / 星标', 'Advanced search: author / affiliation / year / reading status / starred')}
+              title={tr(
+                '高级检索：作者 / 机构 / 年份 / 我的标签 / 阅读状态 / 星标',
+                'Advanced search: author / affiliation / year / my tags / reading status / starred',
+              )}
             />
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
               {total ? tr(`${total} 篇`, `${total}`) : ''}
@@ -774,6 +778,7 @@ function PapersPane({
                         setAdvAffiliation('');
                         setAdvYearFrom('');
                         setAdvYearTo('');
+                        setAdvMyTag('');
                         setAdvReading('');
                         setAdvStarred(false);
                       }
@@ -799,6 +804,20 @@ function PapersPane({
                   onFrom={setAdvYearFrom}
                   onTo={setAdvYearTo}
                 />
+                <select
+                  className="input"
+                  style={{ height: 26, fontSize: 11.5, width: '100%', padding: '0 6px' }}
+                  value={advMyTag}
+                  onChange={(e) => setAdvMyTag(e.target.value)}
+                  title={tr('按我的标签过滤（只有你自己看得到）', 'Filter by my tag (only you can see these)')}
+                >
+                  <option value="">{tr('全部我的标签', 'All my tags')}</option>
+                  {myTags.map((t) => (
+                    <option key={t.name} value={t.name}>
+                      {t.name}（{t.paper_count}）
+                    </option>
+                  ))}
+                </select>
                 <div className="row gap6" style={{ alignItems: 'center' }}>
                   <select
                     className="input"

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -27,6 +27,7 @@ import { AffiliationChips, AuthorLinks } from '../wiki/shared';
 import {
   ConceptChips,
   PaperMyMetaRow,
+  PaperMyTagsRow,
   PaperNotesSection,
   PaperTagsRow,
   WikiHeaderActions,
@@ -353,8 +354,16 @@ export function LibraryDetailPane({
         />
       )}
 
-      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
       {alive && <PaperTagsRow tags={paper.tags} />}
+      {alive && (
+        <PaperMyTagsRow
+          paperId={paper.id}
+          myTags={paper.my_tags}
+          detailKey={detailKey}
+          invalidateKeys={listKeys}
+        />
+      )}
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -14,6 +14,7 @@ import { clickable } from '../../lib/a11y';
 import { api, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
+import { PaperMyTagsRow, PaperTagsRow } from '../shared/PaperDetailBlocks';
 
 /* ============================================================
    阅读工作台 · 论文信息面板（PaperDetailPane 的精简版）：
@@ -181,16 +182,9 @@ export function InfoPanel({
         </MetaItem>
       </div>
 
-      {/* —— 标签 —— */}
-      {(paper.tags?.length ?? 0) > 0 && (
-        <div className="row gap6 wrap" style={{ marginTop: 12 }}>
-          {paper.tags!.map((t) => (
-            <span key={t} className="tag">
-              {t}
-            </span>
-          ))}
-        </div>
-      )}
+      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签边读边打 —— */}
+      <PaperTagsRow tags={paper.tags} style={{ marginTop: 12 }} />
+      <PaperMyTagsRow paperId={paper.id} myTags={paper.my_tags} detailKey={['paper', paper.id]} />
 
       {/* —— 概念 chips —— */}
       {paper.concepts.length > 0 && (

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -20,6 +20,7 @@ import { AffiliationChips, AuthorLinks } from '../wiki/shared';
 import {
   ConceptChips,
   PaperMyMetaRow,
+  PaperMyTagsRow,
   PaperNotesSection,
   PaperTagsRow,
   WikiHeaderActions,
@@ -502,8 +503,16 @@ export function ShelfDetailPane({
         />
       )}
 
-      {/* —— 标签（只读展示，编辑在文献工作台） —— */}
+      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
       <PaperTagsRow tags={paper?.tags} />
+      {paper && (
+        <PaperMyTagsRow
+          paperId={item.paper_id}
+          myTags={paper.my_tags}
+          detailKey={detailKey}
+          invalidateKeys={listKeys}
+        />
+      )}
 
       {/* —— 课题备注：为什么相关（仅书架内论文；这条是课题里公开的说明） —— */}
       {onShelf && <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />}

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -85,15 +85,30 @@ export function PaperMyMetaRow({
   );
 }
 
-/* ---------------- 只读标签行 ---------------- */
+/* ---------------- 标签：库标签（只读）+ 我的标签（可编辑） ---------------- */
 
-/** 标签只读展示（编辑在文献工作台）。 */
+/* 两组标签是两回事，样式上一眼分开：
+   - 库标签＝实心底色（.tag 默认样式），整个文献库共用一套，编辑在文献工作台；
+   - 我的标签＝描边 + 强调色，只有自己看得到，哪儿都能改。 */
+
+/** 我的标签 chip 的描边样式（区别于实心的库标签）。 */
+const myTagStyle: CSSProperties = {
+  background: 'transparent',
+  borderColor: 'var(--accent-soft-2)',
+  color: 'var(--accent-text)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+};
+
+/** 库标签只读展示（编辑在文献工作台）；没有标签就不占位。 */
 export function PaperTagsRow({ tags, style }: { tags: string[] | undefined; style?: CSSProperties }) {
   if (!tags || tags.length === 0) return null;
   return (
     <div className="row gap6 wrap" style={{ marginTop: 14, ...style }}>
-      <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
-        {tr('标签', 'Tags')}
+      <span className="row gap6 mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
+        <Icon name="users" size={11} />
+        {tr('库标签', 'Library tags')}
       </span>
       {tags.map((t) => (
         <span key={t} className="tag">
@@ -101,6 +116,159 @@ export function PaperTagsRow({ tags, style }: { tags: string[] | undefined; styl
         </span>
       ))}
     </div>
+  );
+}
+
+/**
+ * 我的标签：就地增删，只有本人可见可改。
+ * 走 PUT /papers/{id}/my-tags（整组覆盖），可达口径同 my-meta——只读浏览、
+ * 每日新论文里也能打，不需要文献库的管理权限。
+ */
+export function PaperMyTagsRow({
+  paperId,
+  myTags,
+  detailKey,
+  invalidateKeys,
+  style,
+}: {
+  paperId: string;
+  myTags: string[] | undefined;
+  /** 详情 queryKey：给了就直接改缓存，改完立刻变，不用等列表刷新 */
+  detailKey?: QueryKey;
+  /** 改完要刷新的列表 / 搜索 queryKey */
+  invalidateKeys?: readonly QueryKey[];
+  style?: CSSProperties;
+}) {
+  const queryClient = useQueryClient();
+  const [adding, setAdding] = useState(false);
+  const [value, setValue] = useState('');
+  const tags = myTags ?? [];
+
+  const putMutation = useMutation({
+    mutationFn: (names: string[]) => api.putMyTags(paperId, names),
+    onSuccess: (res) => {
+      if (detailKey) {
+        queryClient.setQueryData<{ my_tags?: string[] }>(detailKey, (old) =>
+          old ? { ...old, my_tags: res.my_tags } : old,
+        );
+      }
+      void queryClient.invalidateQueries({ queryKey: ['my-tags'] });
+      for (const key of invalidateKeys ?? []) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+    onError: (e) =>
+      toast(`${tr('标签更新失败：', 'Tag update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const commit = () => {
+    const name = value.trim();
+    setAdding(false);
+    setValue('');
+    if (!name || tags.includes(name)) return;
+    putMutation.mutate([...tags, name]);
+  };
+
+  return (
+    <div className="row gap6 wrap" style={{ marginTop: 10, ...style }}>
+      <span
+        className="row gap6 mono"
+        style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}
+        title={tr('只有你自己看得到', 'Only you can see these')}
+      >
+        <Icon name="bookmark" size={11} />
+        {tr('我的标签', 'My tags')}
+      </span>
+      {tags.map((t) => (
+        <span key={t} className="tag" style={myTagStyle}>
+          {t}
+          <span
+            title={tr('移除标签', 'Remove tag')}
+            style={{ cursor: 'pointer', display: 'inline-flex', opacity: 0.6 }}
+            onClick={() => putMutation.mutate(tags.filter((x) => x !== t))}
+          >
+            <Icon name="x" size={9} />
+          </span>
+        </span>
+      ))}
+      {adding ? (
+        <input
+          className="input"
+          autoFocus
+          style={{ height: 24, fontSize: 11.5, width: 120, padding: '0 8px' }}
+          placeholder={tr('标签名，回车确定', 'Tag name, Enter to confirm')}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) commit();
+            if (e.key === 'Escape') {
+              setAdding(false);
+              setValue('');
+            }
+          }}
+        />
+      ) : (
+        <span
+          className="chip"
+          style={{ fontSize: 11, height: 20, opacity: putMutation.isPending ? 0.5 : 1 }}
+          onClick={() => !putMutation.isPending && setAdding(true)}
+        >
+          <Icon name="plus" size={10} style={{ display: 'inline-block', verticalAlign: -1 }} />{' '}
+          {tr('加标签', 'Add tag')}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** 列表行里的标签小 chip：库标签实心 / 我的标签描边，最多各显 2 个。 */
+export function PaperTagChips({
+  tags,
+  myTags,
+  limit = 2,
+}: {
+  tags: string[] | undefined;
+  myTags: string[] | undefined;
+  limit?: number;
+}) {
+  const lib = tags ?? [];
+  const mine = myTags ?? [];
+  const hidden = Math.max(0, lib.length - limit) + Math.max(0, mine.length - limit);
+  const chipStyle: CSSProperties = {
+    fontSize: 10,
+    height: 17,
+    padding: '0 6px',
+    maxWidth: 90,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    display: 'inline-block',
+    lineHeight: '17px',
+  };
+  return (
+    <>
+      {lib.slice(0, limit).map((t) => (
+        <span key={`lib-${t}`} className="tag" style={chipStyle} title={tr(`库标签：${t}`, `Library tag: ${t}`)}>
+          {t}
+        </span>
+      ))}
+      {mine.slice(0, limit).map((t) => (
+        <span
+          key={`my-${t}`}
+          className="tag"
+          style={{ ...chipStyle, background: 'transparent', borderColor: 'var(--accent-soft-2)', color: 'var(--accent-text)' }}
+          title={tr(`我的标签：${t}`, `My tag: ${t}`)}
+        >
+          {t}
+        </span>
+      ))}
+      {hidden > 0 && (
+        <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+          +{hidden}
+        </span>
+      )}
+    </>
   );
 }
 

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -40,6 +40,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
+import { PaperMyTagsRow, PaperTagChips } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
@@ -590,7 +591,6 @@ const PaperRow = memo(function PaperRow({
   onClick: () => void;
   onToggleCheck: () => void;
 }) {
-  const tags = p.tags ?? [];
   return (
     <div
       onClick={onClick}
@@ -636,20 +636,7 @@ const PaperRow = memo(function PaperRow({
       <div className="row gap8" style={{ marginTop: 6 }}>
         <PaperStatusPill status={p.status} sm />
         <ReadingDot status={p.reading_status} />
-        {tags.slice(0, 2).map((t) => (
-          <span
-            key={t}
-            className="tag"
-            style={{ fontSize: 10, height: 17, padding: '0 6px', maxWidth: 90, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', lineHeight: '17px' }}
-          >
-            {t}
-          </span>
-        ))}
-        {tags.length > 2 && (
-          <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
-            +{tags.length - 2}
-          </span>
-        )}
+        <PaperTagChips tags={p.tags} myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
           <span
             className="row"
@@ -682,7 +669,7 @@ const PaperRow = memo(function PaperRow({
   prev.p === next.p && prev.active === next.active && prev.checked === next.checked && prev.selectMode === next.selectMode,
 );
 
-/* ---------------- 标签就地编辑 ---------------- */
+/* ---------------- 库标签就地编辑（共享资产：同库的人看到同一套） ---------------- */
 
 function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) {
   const queryClient = useQueryClient();
@@ -711,8 +698,13 @@ function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) 
 
   return (
     <div className="row gap6 wrap" style={{ marginTop: 14 }}>
-      <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
-        {tr('标签', 'Tags')}
+      <span
+        className="row gap6 mono"
+        style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}
+        title={tr('整个文献库共用一套，同库的人都看得到', 'Shared across the library — everyone in it sees these')}
+      >
+        <Icon name="users" size={11} />
+        {tr('库标签', 'Library tags')}
       </span>
       {tags.map((t) => (
         <span key={t} className="tag" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
@@ -746,10 +738,10 @@ function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) 
       ) : (
         <span
           className="chip"
-          style={{ fontSize: 11, opacity: putMutation.isPending ? 0.5 : 1 }}
+          style={{ fontSize: 11, height: 20, opacity: putMutation.isPending ? 0.5 : 1 }}
           onClick={() => !putMutation.isPending && setAdding(true)}
         >
-          <Icon name="plus" size={10} style={{ display: 'inline-block', verticalAlign: -1 }} /> {tr('标签', 'Tag')}
+          <Icon name="plus" size={10} style={{ display: 'inline-block', verticalAlign: -1 }} /> {tr('加标签', 'Add tag')}
         </span>
       )}
     </div>
@@ -1018,8 +1010,14 @@ function PaperDetailPane({
         </span>
       </div>
 
-      {/* —— 标签（就地编辑；库作用域，课题/独立库通用） —— */}
+      {/* —— 标签：库标签（库作用域，同库的人共用）+ 我的标签（只有自己看得到） —— */}
       <TagEditor paper={paper} scopeId={scopeId} />
+      <PaperMyTagsRow
+        paperId={paper.id}
+        myTags={paper.my_tags}
+        detailKey={['paper', scopeId, paper.id]}
+        invalidateKeys={[['papers', scopeId]]}
+      />
 
       {/* —— frontmatter 风格元数据卡 —— */}
       <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
@@ -1209,6 +1207,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
 
   // —— 文献管理增强过滤器 ——
   const [tagFilter, setTagFilter] = useState('');
+  const [myTagFilter, setMyTagFilter] = useState('');
   const [readingFilter, setReadingFilter] = useState<'' | ReadingStatus>('');
   const [addOpen, setAddOpen] = useState(false);
   // 高级检索（作者/机构/发表时间/入库时间）
@@ -1264,7 +1263,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [scopeId, view, q, tagFilter, readingFilter]);
+  }, [scopeId, view, q, tagFilter, myTagFilter, readingFilter]);
 
   // 重新编译：同步等着（约 1 分钟），用户很可能切走再切回来。
   // 进行中状态按 paper id 记在列表页这一层：详情面板换论文不会丢，多篇同时编译也各记各的。
@@ -1324,15 +1323,20 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   });
   const projectTags = tagsQuery.data ?? [];
 
+  // —— 我的标签（过滤下拉用；跨库共用一份，所以 queryKey 不带 scopeId） ——
+  const myTagsQuery = useQuery({ queryKey: ['my-tags'], queryFn: () => api.listMyTags(), retry: false });
+  const myTags = myTagsQuery.data ?? [];
+
   // —— 关键词/浏览：分页列表 ——
   const listQuery = useInfiniteQuery({
-    queryKey: ['papers', scopeId, view, q, sort, tagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
+    queryKey: ['papers', scopeId, view, q, sort, tagFilter, myTagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
     queryFn: ({ pageParam }) => {
       const opts = {
         ...viewQuery(view),
         q: q || undefined,
         sort,
         tag: tagFilter || undefined,
+        my_tag: myTagFilter || undefined,
         reading_status: readingFilter || undefined,
         author: author || undefined,
         affiliation: affiliation || undefined,
@@ -1371,7 +1375,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   const isError = semanticActive ? semQuery.isError : listQuery.isError;
   const fallbackNotice = semanticActive && semQuery.data && semQuery.data.mode_used === 'keyword';
 
-  const hasFilter = !!q || view !== 'all' || !!tagFilter || !!readingFilter || advActive;
+  const hasFilter = !!q || view !== 'all' || !!tagFilter || !!myTagFilter || !!readingFilter || advActive;
 
   // 列表变化后自动选中第一篇
   const firstId = papers[0]?.id ?? null;
@@ -1519,18 +1523,32 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
               {tr('回收站', 'Trash')}
             </span>
           </div>
-          {/* 标签（库作用域，课题/独立库通用）/ 阅读状态过滤 */}
+          {/* 库标签（库作用域，课题/独立库通用）/ 我的标签 / 阅读状态过滤 */}
           <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
             <select
               className="input"
               style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
               value={tagFilter}
               onChange={(e) => setTagFilter(e.target.value)}
-              title={tr('按标签过滤', 'Filter by tag')}
+              title={tr('按库标签过滤（同库的人共用一套）', 'Filter by library tag (shared across the library)')}
             >
-              <option value="">{tr('全部标签', 'All tags')}</option>
+              <option value="">{tr('全部库标签', 'All library tags')}</option>
               {projectTags.map((t) => (
                 <option key={t.id} value={t.name}>
+                  {t.name}（{t.paper_count}）
+                </option>
+              ))}
+            </select>
+            <select
+              className="input"
+              style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
+              value={myTagFilter}
+              onChange={(e) => setMyTagFilter(e.target.value)}
+              title={tr('按我的标签过滤（只有你自己看得到）', 'Filter by my tag (only you can see these)')}
+            >
+              <option value="">{tr('全部我的标签', 'All my tags')}</option>
+              {myTags.map((t) => (
+                <option key={t.name} value={t.name}>
                   {t.name}（{t.paper_count}）
                 </option>
               ))}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -675,8 +675,10 @@ export interface PaperRead {
   /** 编译所用模型名；未编译/存量数据为 null（旧后端可能缺失） */
   compiled_model?: string | null;
   /* —— 文献管理增强字段（docs/api-lit.md §5，后端未就绪时可能缺失，均可选容错） —— */
-  /** 项目级标签 */
+  /** 库标签（共享）：本次浏览的那个库里打的；没有库上下文时为空 */
   tags?: string[];
+  /** 我的标签：只有本人看得到、改得了，跟着论文本身走（换库浏览也在） */
+  my_tags?: string[];
   /** 当前用户是否星标 */
   starred?: boolean;
   /** 当前用户阅读状态（无记录默认 unread） */
@@ -790,6 +792,12 @@ export type PaperImportInput = { arxiv_id: string } | { doi: string } | { bibtex
 
 export interface TagRead {
   id: string;
+  name: string;
+  paper_count: number;
+}
+
+/** 「我的所有标签」一行；个人标签没有独立实体，所以只有名字 + 标了几篇。 */
+export interface MyTagRead {
   name: string;
   paper_count: number;
 }
@@ -2710,8 +2718,10 @@ export const api = {
       sort?: PaperSort;
       page?: number;
       size?: number;
-      /** 按标签名过滤 */
+      /** 按库标签名过滤 */
       tag?: string;
+      /** 按我的个人标签名过滤 */
+      my_tag?: string;
       /** 仅星标 */
       starred?: boolean;
       /** 按当前用户阅读状态过滤 */
@@ -2732,6 +2742,7 @@ export const api = {
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));
     if (opts.tag) params.set('tag', opts.tag);
+    if (opts.my_tag) params.set('my_tag', opts.my_tag);
     if (opts.starred) params.set('starred', 'true');
     if (opts.reading_status) params.set('reading_status', opts.reading_status);
     if (opts.author) params.set('author', opts.author);
@@ -2872,6 +2883,14 @@ export const api = {
   /** 整组覆盖论文标签；新名字自动建 tag；空数组=清空。 */
   putPaperTags(id: string, names: string[]): Promise<PaperDetail> {
     return requestJson<PaperDetail>(`/papers/${id}/tags`, 'PUT', { names });
+  },
+  /** 我的所有个人标签（含标了几篇），给筛选下拉 / 输入建议用。 */
+  listMyTags(): Promise<MyTagRead[]> {
+    return request<MyTagRead[]>('/me/paper-tags');
+  },
+  /** 整组覆盖我给这篇打的个人标签；空数组=清空。只要读得到这篇论文就能打。 */
+  putMyTags(id: string, names: string[]): Promise<{ my_tags: string[] }> {
+    return requestJson<{ my_tags: string[] }>(`/papers/${id}/my-tags`, 'PUT', { names });
   },
   /** 个人星标 / 阅读状态。 */
   putMyMeta(id: string, input: Partial<MyMeta>): Promise<MyMeta> {
@@ -3100,6 +3119,7 @@ export const api = {
       page?: number;
       size?: number;
       tag?: string;
+      my_tag?: string;
       starred?: boolean;
       reading_status?: ReadingStatus;
       author?: string;
@@ -3117,6 +3137,7 @@ export const api = {
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));
     if (opts.tag) params.set('tag', opts.tag);
+    if (opts.my_tag) params.set('my_tag', opts.my_tag);
     if (opts.starred) params.set('starred', 'true');
     if (opts.reading_status) params.set('reading_status', opts.reading_status);
     if (opts.author) params.set('author', opts.author);


### PR DESCRIPTION
Regular users had no way to tag a paper. The existing tags are **library-scoped shared state**, and writing them replaces the whole set — so one user's edit wipes what everyone else filed. Loosening that endpoint's permission wouldn't have given users their own tags; it would have let them overwrite each other's.

## A new table, and why not the existing one

`user_paper_tags` — flat, `user × paper × name`, parallel to `PaperUserMeta` rather than folded into it: meta is *one row per paper*, tags are one-to-many, and merging them breaks its uniqueness constraint. No separate tag entity either — personal tags have no cross-user sharing, so nothing to rename in one place and no orphans to collect (skipping the whole `prune_orphan_tags` apparatus the library tags need).

Folding it into `PaperUserMeta` as a JSON column was the alternative. It saves no migration (that table has no JSON column today either), and the test suite runs on sqlite, where "filter by my tag" against JSON is close to unworkable — and that's the first follow-up anyone will ask for.

```
PUT /papers/{id}/my-tags   set the whole set for the current user
GET /me/paper-tags         my tags with counts, for the filter dropdown
```

Auth matches `my-meta` (`include_pool=True`), so anything reachable — public library, shelf, personal library, daily feed — can be tagged. Lists take a `my_tag` filter, built like the `starred` one.

## Fixes a pre-existing bug it would have made worse

`paper_extras_map` fetched a paper's tags **without filtering by library**, so a paper sitting in two libraries showed both libraries' tags no matter which one you were browsing. It now takes the library context.

Pool-level rows (shelf, personal library, daily feed) have no library, so they show **no** library tags. Leaking another library's vocabulary to a reader who may not even be able to see that library is worse than showing nothing. Personal tags always show, in every context.

## UI

Library tags stay solid and read-only (editing is still the workbench's job); personal tags are outlined, each with a remove affordance plus an add field, and a hint that only you can see them. Both appear in all four detail panes, the workbench, and the reading page's info panel; list rows show a compact chip form.

## Not done

- **No tag chips on the shelf / personal library / daily feed list rows.** Those rows aren't `PaperRead` — the backend doesn't return tags for them at all, so it needs three schema changes and their aggregate queries first. Detail panes have them.
- **No rename or merge.** Flat storage means renaming rewrites every row; a feature of its own.
- **Citation export can't filter by `my_tag`** (it has `tag` and `starred`). One line, but no stated need.

## Verification

Single alembic head, sqlite roundtrip green. New cases cover: set/clear plus the counts feed, two users' tags invisible to each other, a stranger tagging a public library's paper, `my_tag` filtering, the two tag kinds not interfering, and the cross-library leak fix. `ruff check app` clean, `tsc --noEmit` 0 errors.
