### PR TITLE
fix(voyages): readable kind badges, and back links that know where to go

### DIFF
--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { Icon, type IconName } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { ProjectSettings } from '../projects/ProjectDetailPage';
-import { VoyagesList } from '../voyages/VoyagesPage';
+import { VoyagesList, TOPIC_TASK_KINDS } from '../voyages/VoyagesPage';
 import { PipelineFlow, type PipelineStage } from '../../components/ui/PipelineFlow';
 import { StatCard, type StatCardProps } from '../../components/ui/StatCard';
 import { StatusPill } from '../../components/ui/StatusPill';
@@ -710,7 +710,7 @@ export function DashboardPage() {
         ))}
 
       {/* 课题工作台只看本课题的任务；课题外任务在 /lab（底部引导链接） */}
-      {tab === 'tasks' && <VoyagesList labLink />}
+      {tab === 'tasks' && <VoyagesList labLink kinds={TOPIC_TASK_KINDS} />}
     </div>
   );
 }

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -14,6 +14,8 @@ import { useLibraries, libraryPath } from '../libraries/hooks';
 import {
   FILTERS,
   KIND_META,
+  LIBRARY_TASK_KINDS,
+  TOPIC_TASK_KINDS,
   SkeletonRows,
   VoyageRow,
   matchFilter,
@@ -484,9 +486,18 @@ function TasksTab() {
           style={{ height: 33, fontSize: 12.5, fontWeight: 600, width: 128, color: kindFilter === 'all' ? 'var(--text-3)' : 'var(--text)' }}
         >
           <option value="all">{tr('全部类型', 'All types')}</option>
-          {Object.entries(KIND_META).map(([k, m]) => (
-            <option key={k} value={k}>{tr(m.zh, m.en)}</option>
-          ))}
+          {/* 按任务层级分组：库任务与课题任务在实验室工作台都看得到，分开列
+              比一长串平铺好找。以后每日新论文进任务系统，在这里加一组即可。 */}
+          <optgroup label={tr('文献库任务', 'Library tasks')}>
+            {LIBRARY_TASK_KINDS.map((k) => (
+              <option key={k} value={k}>{tr(KIND_META[k]?.zh ?? k, KIND_META[k]?.en)}</option>
+            ))}
+          </optgroup>
+          <optgroup label={tr('课题任务', 'Topic tasks')}>
+            {TOPIC_TASK_KINDS.map((k) => (
+              <option key={k} value={k}>{tr(KIND_META[k]?.zh ?? k, KIND_META[k]?.en)}</option>
+            ))}
+          </optgroup>
         </select>
       </div>
 

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   type VoyageStepRead,
 } from '../../lib/api';
 import { useTaskLogHistory } from '../../lib/prefs';
+import { KindBadge } from './VoyagesPage';
 
 /* ============================================================
    /voyages/:id — 任务详情：循环感知的活动状态 + 步骤时间线 + SSE 实时。
@@ -1656,12 +1657,22 @@ export function VoyageDetailPage() {
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 20 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="h-eyebrow row gap8">
+            {/* 返回按任务层级分流：库任务（建库/增量更新）归实验室工作台，
+                其余归课题工作台。库任务的 project_id 为空，跳课题会落到首页。 */}
             <span
               className="row gap6"
               style={{ cursor: 'pointer' }}
-              onClick={() => navigate(topicPath(voyage.project_id, 'voyages'))}
+              onClick={() =>
+                navigate(
+                  WIKI_RUN_KINDS.has(voyage.kind)
+                    ? '/lab?tab=tasks'
+                    : topicPath(voyage.project_id, 'voyages'),
+                )
+              }
             >
-              ← Voyages
+              {WIKI_RUN_KINDS.has(voyage.kind)
+                ? tr('← 实验室任务', '← Lab tasks')
+                : tr('← 课题任务', '← Topic tasks')}
             </span>
             <span className="mono" style={{ textTransform: 'none', color: 'var(--text-4)' }}>{voyage.id.slice(0, 8)}</span>
             {live && (
@@ -1673,7 +1684,7 @@ export function VoyageDetailPage() {
           </div>
           <h1 className="h-title" style={{ fontSize: 21 }}>{voyage.goal}</h1>
           <div className="row gap8" style={{ marginTop: 10, flexWrap: 'wrap' }}>
-            <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>{voyage.kind}</span>
+            <KindBadge kind={voyage.kind} />
             <StatusPill status={voyage.status} sm />
             {planAdjusted && (
               <span

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -58,7 +58,10 @@ export const KIND_META: Record<string, KindMeta> = {
   wiki_ingest: { zh: '增量更新', en: 'Incremental sync', icon: 'refresh', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' },
   idea_forge: { zh: '想法生成', en: 'Idea forge', icon: 'bulb', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' },
   idea_review: { zh: '评审锦标赛', en: 'Review tournament', icon: 'scale', bg: 'var(--violet-bg)', tx: 'var(--violet-tx)' },
+  idea_proposal: { zh: '方案细化', en: 'Proposal', icon: 'bulb', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' },
   experiment: { zh: '实验', en: 'Experiment', icon: 'flask', bg: 'var(--ok-bg)', tx: 'var(--ok-tx)' },
+  paper_writing: { zh: '论文起草', en: 'Draft writing', icon: 'pen', bg: 'var(--violet-bg)', tx: 'var(--violet-tx)' },
+  paper_review: { zh: '论文评审', en: 'Paper review', icon: 'check', bg: 'var(--violet-bg)', tx: 'var(--violet-tx)' },
   presentation: { zh: '论文分享', en: 'Paper slides', icon: 'chart', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
   custom: { zh: '流程技能', en: 'Workflow skill', icon: 'sparkle', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' },
   demo: { zh: '演示', en: 'Demo', icon: 'play', bg: 'var(--surface-3)', tx: 'var(--text-2)' },
@@ -68,8 +71,17 @@ function kindMeta(kind: string): KindMeta {
   return KIND_META[kind] ?? { zh: kind, icon: 'sparkle', bg: 'var(--surface-3)', tx: 'var(--text-2)' };
 }
 
+/* —— 任务层级：与后端 app/models/voyage.py 的 LIBRARY_KINDS 对应 ——
+   文献库任务（建库/增量更新）与每日新论文任务归实验室工作台，其余归课题。
+   课题工作台的类型筛选只列课题类型：那里根本不会出现库任务，列出来只会
+   选中后永远空列表。 */
+export const LIBRARY_TASK_KINDS = ['wiki_bootstrap', 'wiki_ingest'] as const;
+export const TOPIC_TASK_KINDS = Object.keys(KIND_META).filter(
+  (k) => !(LIBRARY_TASK_KINDS as readonly string[]).includes(k),
+);
+
 /** 类型徽章：图标 + 中文标签，低饱和语义底色。 */
-function KindBadge({ kind }: { kind: string }) {
+export function KindBadge({ kind }: { kind: string }) {
   const m = kindMeta(kind);
   return (
     <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }} title={kind}>
@@ -194,7 +206,16 @@ export function SkeletonRows() {
  *   （课题外的任务在 /lab 的「任务」标签按类型分组看），所以默认关闭。
  * - `labLink`：底部是否显示「课题外的任务在实验室工作台」引导（课题工作台用）。
  */
-export function VoyagesList({ showScopeSwitch = false, labLink = false }: { showScopeSwitch?: boolean; labLink?: boolean } = {}) {
+export function VoyagesList({
+  showScopeSwitch = false,
+  labLink = false,
+  kinds,
+}: {
+  showScopeSwitch?: boolean;
+  labLink?: boolean;
+  /** 类型筛选下拉列哪些类型；不传=全部。课题工作台传课题类型，实验室传库/每日类型。 */
+  kinds?: readonly string[];
+} = {}) {
   const { currentProjectId } = useProject();
 
   const [filter, setFilter] = useState<Filter>('all');
@@ -225,8 +246,8 @@ export function VoyagesList({ showScopeSwitch = false, labLink = false }: { show
               style={{ height: 33, fontSize: 12.5, fontWeight: 600, width: 128, color: kindFilter === 'all' ? 'var(--text-3)' : 'var(--text)' }}
             >
               <option value="all">{tr('全部类型', 'All types')}</option>
-              {Object.entries(KIND_META).map(([k, m]) => (
-                <option key={k} value={k}>{tr(m.zh, m.en)}</option>
+              {(kinds ?? Object.keys(KIND_META)).map((k) => (
+                <option key={k} value={k}>{tr(KIND_META[k]?.zh ?? k, KIND_META[k]?.en)}</option>
               ))}
             </select>
             {showScopeSwitch && (
@@ -269,7 +290,7 @@ export function VoyagesList({ showScopeSwitch = false, labLink = false }: { show
                 desc={
                   filter !== 'all' || kindFilter !== 'all'
                     ? tr('当前筛选条件下没有任务，换个筛选试试。', 'No tasks match the current filters — try different ones.')
-                    : tr('还没有任务。发起建库、想法生成、实验等操作后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start ingest, idea generation, experiments, and so on.')
+                    : tr('还没有任务。想法生成、实验、论文起草等操作发起后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start idea generation, experiments, draft writing, and so on.')
                 }
                 compact
               />

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -65,6 +65,7 @@ export const KIND_META: Record<string, KindMeta> = {
   presentation: { zh: '论文分享', en: 'Paper slides', icon: 'chart', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
   custom: { zh: '流程技能', en: 'Workflow skill', icon: 'sparkle', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' },
   demo: { zh: '演示', en: 'Demo', icon: 'play', bg: 'var(--surface-3)', tx: 'var(--text-2)' },
+  daily_feed_sync: { zh: '每日新论文', en: 'Daily paper sync', icon: 'refresh', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
 };
 
 function kindMeta(kind: string): KindMeta {
@@ -75,7 +76,7 @@ function kindMeta(kind: string): KindMeta {
    文献库任务（建库/增量更新）与每日新论文任务归实验室工作台，其余归课题。
    课题工作台的类型筛选只列课题类型：那里根本不会出现库任务，列出来只会
    选中后永远空列表。 */
-export const LIBRARY_TASK_KINDS = ['wiki_bootstrap', 'wiki_ingest'] as const;
+export const LIBRARY_TASK_KINDS = ['wiki_bootstrap', 'wiki_ingest', 'daily_feed_sync'] as const;
 export const TOPIC_TASK_KINDS = Object.keys(KIND_META).filter(
   (k) => !(LIBRARY_TASK_KINDS as readonly string[]).includes(k),
 );


### PR DESCRIPTION
Three loose ends from splitting tasks by level.

## The kind badge printed raw identifiers

`paper_writing`, `paper_review` and `idea_proposal` were missing from `KIND_META`, so they fell through to the fallback and rendered an underscored English string where every other type showed a Chinese label. Added with icons and semantic colours.

The **detail page never used the badge component at all** — it rendered its own grey mono pill straight from `voyage.kind`. It now shares `KindBadge` with the list, so there's one implementation instead of two.

Also registers `daily_feed_sync` ahead of the daily-feed task work, so the badge is right the moment those runs start appearing.

## The back link went to the wrong place

It said `← Voyages` and always navigated to the topic workbench. Library builds no longer carry a `project_id`, so that link **dropped you on the home page**. It now routes by task level — library builds to the lab workbench's tasks tab, everything else to the topic's — and the label says which one.

## Type filters listed types that can't appear

The topic workbench's filter offered every kind including library builds, which can no longer show up there, so picking one gave a permanently empty list. It now lists topic kinds only, and its empty state stops telling you to "start a library build" — that isn't a topic action any more.

The lab workbench groups its filter by task level rather than one flat list, with room for the daily-feed group.

## Verification

`tsc --noEmit` 0 errors.
