### PR TITLE
feat(search): personal filters in my library, my-tag filter on the shelf

### DIFF
--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -63,6 +63,11 @@ async def list_library(
     # 机构：快照里没有，按条目软引用的活体论文匹配（源论文已删的条目匹配不到）
     affiliation: str | None = Query(default=None),
     venue: str | None = Query(default=None),
+    # 星标 / 阅读状态 / 我的标签：同机构，按条目软引用的活体论文匹配
+    # （源论文已删的条目一律筛不出来，含 reading_status=unread）
+    reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
+    starred: bool | None = Query(default=None),
+    my_tag: str | None = Query(default=None, description="按我的标签过滤（只有本人可见）"),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
@@ -107,6 +112,9 @@ async def list_library(
         author=author,
         affiliation=affiliation,
         venue=venue,
+        reading_status=reading_status,
+        starred=starred,
+        my_tag=my_tag,
     )
     return LibraryPage(
         items=[LibraryEntryRead.model_validate(e) for e in items],

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -50,6 +50,7 @@ async def list_shelf(
     year_to: int | None = Query(default=None),
     reading_status: str | None = Query(default=None, pattern="^(unread|reading|read)$"),
     starred: bool | None = Query(default=None),
+    my_tag: str | None = Query(default=None, description="按我的标签过滤（只有本人可见）"),
     sort: str = Query(default="added", pattern="^(added|year|relevance|title)$"),
     trashed: bool = Query(default=False, description="true=列回收站（已移出的条目）"),
     session: AsyncSession = Depends(get_session),
@@ -69,6 +70,7 @@ async def list_shelf(
         year_to=year_to,
         reading_status=reading_status,
         starred=starred,
+        my_tag=my_tag,
         sort=sort,
         trashed=trashed,
     )

--- a/src/backend/app/services/topic_shelf.py
+++ b/src/backend/app/services/topic_shelf.py
@@ -160,14 +160,15 @@ async def list_shelf(
     year_to: int | None = None,
     reading_status: str | None = None,
     starred: bool | None = None,
+    my_tag: str | None = None,
     sort: str = "added",
     trashed: bool = False,
 ) -> tuple[list[dict[str, Any]], int]:
     """分页列书架，每条带解析后的 wiki 内容与来源状态。
 
     个人版层按请求者（user_id）本人的个人库条目解析。高级检索的
-    q/author/affiliation/starred/reading_status 复用 :func:`apply_paper_filters`
-    （只作用于内容池 Paper / 个人视角 PaperUserMeta，不触碰方向库）；
+    q/author/affiliation/starred/reading_status/my_tag 复用 :func:`apply_paper_filters`
+    （只作用于内容池 Paper / 个人视角 PaperUserMeta、UserPaperTag，不触碰方向库）；
     year 范围就地作用于 ``Paper.year``。sort：added（默认，最新入架在前）/
     year / relevance / title。trashed=True 列回收站（固定按移出时间倒序）。"""
     base = (
@@ -179,7 +180,8 @@ async def list_shelf(
         )
     )
     # 复用论文库过滤器：传 None 的库相关参数（status/created_*）不会引用/join 方向库，
-    # 故过滤只作用于 Paper 本体与请求者个人视角（PaperUserMeta），书架保持方向无关。
+    # 故过滤只作用于 Paper 本体与请求者个人视角（PaperUserMeta / UserPaperTag），
+    # 书架保持方向无关（my_tag 是个人标签，同样不依赖库）。
     base = apply_paper_filters(
         base,
         status=None,
@@ -188,6 +190,7 @@ async def list_shelf(
         affiliation=affiliation,
         starred=starred,
         reading_status=reading_status,
+        my_tag=my_tag,
         user_id=user_id,
         created_from=None,
         created_to=None,

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -10,12 +10,12 @@ from typing import cast
 
 from sqlalchemy import Text as SAText
 from sqlalchemy import cast as sa_cast
-from sqlalchemy import delete, func, or_, select, text, update
+from sqlalchemy import delete, exists, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import utcnow
 from app.models.library import UserLibraryEntry
-from app.models.paper import Paper
+from app.models.paper import Paper, PaperUserMeta, UserPaperTag
 from app.services.dedup import dedup_key_for
 
 LIBRARY_SORTS = ("recent", "title", "visits", "year")
@@ -278,7 +278,18 @@ async def list_entries(
     author: str | None = None,
     affiliation: str | None = None,
     venue: str | None = None,
+    reading_status: str | None = None,
+    starred: bool | None = None,
+    my_tag: str | None = None,
 ) -> tuple[list[UserLibraryEntry], int]:
+    """分页列个人库条目（tab 决定收藏 / 浏览记录 / 回收站），带高级检索过滤。
+
+    star / 阅读状态 / 我的标签这三项是论文维度的个人属性，条目快照里没有，只能靠
+    ``last_paper_id`` 软引用去查（同 affiliation 的口径）。**源论文已删（last_paper_id
+    为空）的条目一律筛不出来**——包括 reading_status=unread：没有论文就无从判断读没读，
+    把一堆无源快照按「未读」倒进结果里只会淹掉真正没读的论文。论文还在、只是从没标过
+    状态的，仍按「未读」算（沿用 papers.apply_paper_filters 的口径）。
+    """
     stmt = select(UserLibraryEntry).where(UserLibraryEntry.user_id == user_id)
     # 回收站条目只出现在 trash tab；收藏 / 浏览记录都不含（否则删掉的会从浏览记录漏回来）
     if tab == "trash":
@@ -315,6 +326,39 @@ async def list_entries(
         )
     if venue:
         stmt = stmt.where(UserLibraryEntry.venue.ilike(f"%{venue}%"))
+    # 星标 / 阅读状态 / 我的标签：同样是论文那边的个人属性，按 last_paper_id 软引用查；
+    # 源论文已删的条目（last_paper_id 为空）在这三个过滤下一律不出现。
+    if starred is not None:
+        starred_exists = exists().where(
+            PaperUserMeta.paper_id == UserLibraryEntry.last_paper_id,
+            PaperUserMeta.user_id == user_id,
+            PaperUserMeta.starred.is_(True),
+        )
+        stmt = stmt.where(
+            UserLibraryEntry.last_paper_id.is_not(None),
+            starred_exists if starred else ~starred_exists,
+        )
+    if reading_status:
+        status_sub = (
+            select(PaperUserMeta.reading_status)
+            .where(
+                PaperUserMeta.paper_id == UserLibraryEntry.last_paper_id,
+                PaperUserMeta.user_id == user_id,
+            )
+            .scalar_subquery()
+        )
+        stmt = stmt.where(
+            UserLibraryEntry.last_paper_id.is_not(None),
+            func.coalesce(status_sub, "unread") == reading_status,
+        )
+    if my_tag:
+        stmt = stmt.where(
+            exists().where(
+                UserPaperTag.paper_id == UserLibraryEntry.last_paper_id,
+                UserPaperTag.user_id == user_id,
+                UserPaperTag.name == my_tag,
+            )
+        )
     if year_from is not None:
         stmt = stmt.where(UserLibraryEntry.year.isnot(None), UserLibraryEntry.year >= year_from)
     if year_to is not None:

--- a/src/backend/tests/test_library.py
+++ b/src/backend/tests/test_library.py
@@ -6,7 +6,7 @@ import fakeredis.aioredis
 import httpx
 import pytest_asyncio
 import respx
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select, update
 
 from app.core.db import get_sessionmaker
 from app.models.library import UserLibraryEntry
@@ -239,6 +239,111 @@ async def test_library_advanced_filters_and_year_sort(client):
     # sort=year（降序）
     got, _ = await query(sort="year")
     assert got == ["New Paper", "Mid Paper", "Old Paper"]
+
+
+async def _orphan_entry(paper_id: str) -> None:
+    """删掉源论文，让指向它的条目只剩快照（last_paper_id 软引用置空）。"""
+    async with get_sessionmaker()() as session:
+        pid = uuid.UUID(paper_id)
+        await session.execute(
+            update(UserLibraryEntry)
+            .where(UserLibraryEntry.last_paper_id == pid)
+            .values(last_paper_id=None)
+        )
+        await session.execute(delete(LibraryPaper).where(LibraryPaper.paper_id == pid))
+        await session.execute(delete(Paper).where(Paper.id == pid))
+        await session.commit()
+
+
+async def test_library_filters_by_star_reading_status_and_my_tag(client):
+    """星标 / 阅读状态 / 我的标签：靠 last_paper_id 软引用查论文那边的个人属性。
+
+    源论文已删的条目在这三个过滤下一律筛不出来（含 reading_status=unread）。"""
+    token = await register_and_login(client, email="libpersonal@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers, "lib-personal")
+    p_star = await _make_paper(project_id, title="Starred Paper", status="included")
+    p_plain = await _make_paper(project_id, title="Plain Paper", status="included")
+    p_gone = await _make_paper(project_id, title="Orphan Paper", status="included")
+    for pid in (p_star, p_plain, p_gone):
+        await client.post("/api/me/library/visits", json={"paper_id": pid}, headers=headers)
+    resp = await client.put(
+        f"/api/papers/{p_star}/my-meta",
+        json={"starred": True, "reading_status": "reading"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.put(
+        f"/api/papers/{p_star}/my-tags", json={"names": ["精读"]}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    await _orphan_entry(p_gone)
+
+    async def query(**params):
+        merged = {"tab": "history", **params}
+        qs = "&".join(f"{k}={v}" for k, v in merged.items())
+        resp = await client.get(f"/api/me/library?{qs}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        return [i["title"] for i in body["items"]], body["total"]
+
+    # 不加过滤时三条都在（只剩快照的那条照常列出）
+    got, total = await query()
+    assert sorted(got) == ["Orphan Paper", "Plain Paper", "Starred Paper"] and total == 3
+    # 星标
+    got, total = await query(starred="true")
+    assert got == ["Starred Paper"] and total == 1
+    # 未星标：只剩快照的条目判断不了，不算未星标
+    got, total = await query(starred="false")
+    assert got == ["Plain Paper"] and total == 1
+    # 阅读状态（没标过的论文算未读；只剩快照的条目同样排除）
+    got, _ = await query(reading_status="reading")
+    assert got == ["Starred Paper"]
+    got, total = await query(reading_status="unread")
+    assert got == ["Plain Paper"] and total == 1
+    got, total = await query(reading_status="read")
+    assert got == [] and total == 0
+    # 我的标签
+    got, total = await query(my_tag="精读")
+    assert got == ["Starred Paper"] and total == 1
+    got, total = await query(my_tag="没人用过")
+    assert got == [] and total == 0
+
+
+async def test_library_personal_filters_stack_with_trash_tab(client):
+    """三个新过滤与回收站 tab 正交：回收站里同样能按星标 / 阅读状态 / 我的标签筛。"""
+    token = await register_and_login(client, email="libtrashfilter@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _make_project(client, headers, "lib-trash-filter")
+    p_star = await _make_paper(project_id, title="Trashed Starred", status="included")
+    p_plain = await _make_paper(project_id, title="Trashed Plain", status="included")
+    await client.put(
+        f"/api/papers/{p_star}/my-meta",
+        json={"starred": True, "reading_status": "read"},
+        headers=headers,
+    )
+    await client.put(f"/api/papers/{p_star}/my-tags", json={"names": ["回头看"]}, headers=headers)
+    for pid in (p_star, p_plain):  # 先收藏，再取消收藏（= 移入回收站）
+        await client.post("/api/me/library/visits", json={"paper_id": pid}, headers=headers)
+        resp = await client.post("/api/me/library", json={"paper_id": pid}, headers=headers)
+        entry_id = resp.json()["id"]
+        resp = await client.delete(f"/api/me/library/{entry_id}?mode=unsave", headers=headers)
+        assert resp.status_code == 204, resp.text
+
+    async def query(**params):
+        qs = "&".join(f"{k}={v}" for k, v in {"tab": "trash", **params}.items())
+        resp = await client.get(f"/api/me/library?{qs}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        return [i["title"] for i in resp.json()["items"]]
+
+    assert sorted(await query()) == ["Trashed Plain", "Trashed Starred"]
+    assert await query(starred="true") == ["Trashed Starred"]
+    assert await query(reading_status="read") == ["Trashed Starred"]
+    assert await query(reading_status="unread") == ["Trashed Plain"]
+    assert await query(my_tag="回头看") == ["Trashed Starred"]
+    # 收藏 tab 里这两条已经不在了（回收站条目不出现在其他 tab）
+    resp = await client.get("/api/me/library?tab=saved&starred=true", headers=headers)
+    assert resp.json()["total"] == 0
 
 
 async def test_clear_history_keeps_saved(client):

--- a/src/backend/tests/test_topic_shelf.py
+++ b/src/backend/tests/test_topic_shelf.py
@@ -414,6 +414,33 @@ async def test_shelf_filters_by_personal_star_and_reading_status(client):
     assert sorted(await query(reading_status="unread")) == sorted([p2])
 
 
+async def test_shelf_filters_by_my_tag(client):
+    """我的标签（个人私域，与方向库标签无关）在书架上同样可筛。"""
+    project_id, headers = await _setup(client, name="shelf-my-tag")
+    p1 = await _seed_paper(project_id, title="Tagged One", status="scored")
+    p2 = await _seed_paper(project_id, title="Plain Two", status="scored")
+    for pid in (p1, p2):
+        await _shelve(client, headers, project_id, pid)
+    resp = await client.put(f"/api/papers/{p1}/my-tags", json={"names": ["精读"]}, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    async def query(**params):
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        resp = await client.get(f"/api/projects/{project_id}/shelf?{qs}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        return [i["paper_id"] for i in body["items"]], body["total"]
+
+    got, total = await query(my_tag="精读")
+    assert got == [p1] and total == 1
+    got, total = await query(my_tag="没人用过")
+    assert got == [] and total == 0
+    # 清掉标签后就筛不到了（个人标签是私域，与方向库标签互不影响）
+    await client.put(f"/api/papers/{p1}/my-tags", json={"names": []}, headers=headers)
+    got, total = await query(my_tag="精读")
+    assert got == [] and total == 0
+
+
 async def test_shelf_requires_project_membership(client):
     project_id, headers = await _setup(client)
     paper_id = await _seed_paper(project_id, title="Members Only", status="scored")

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -48,6 +48,8 @@ import {
   AuthorLinks,
   FilterInput,
   MetaItem,
+  MyTagField,
+  ReadingStatusField,
   SearchInput,
   SemanticSwitch,
   YearRangeField,
@@ -55,7 +57,7 @@ import {
   saveBlob,
   useDebounced,
 } from '../wiki/shared';
-import { READING_STATUS, ReadingDot, readerFrom } from '../reading/shared';
+import { ReadingDot, readerFrom } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
@@ -687,10 +689,6 @@ function PapersPane({
   });
   const libraryTags = tagsQuery.data ?? [];
 
-  // 我的标签（过滤下拉用；跨库共用一份，所以 queryKey 不带 libraryId）
-  const myTagsQuery = useQuery({ queryKey: ['my-tags'], queryFn: () => api.listMyTags(), retry: false });
-  const myTags = myTagsQuery.data ?? [];
-
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
@@ -804,45 +802,17 @@ function PapersPane({
                   onFrom={setAdvYearFrom}
                   onTo={setAdvYearTo}
                 />
-                <select
-                  className="input"
-                  style={{ height: 26, fontSize: 11.5, width: '100%', padding: '0 6px' }}
-                  value={advMyTag}
-                  onChange={(e) => setAdvMyTag(e.target.value)}
-                  title={tr('按我的标签过滤（只有你自己看得到）', 'Filter by my tag (only you can see these)')}
-                >
-                  <option value="">{tr('全部我的标签', 'All my tags')}</option>
-                  {myTags.map((t) => (
-                    <option key={t.name} value={t.name}>
-                      {t.name}（{t.paper_count}）
-                    </option>
-                  ))}
-                </select>
-                <div className="row gap6" style={{ alignItems: 'center' }}>
-                  <select
-                    className="input"
-                    style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
-                    value={advReading}
-                    onChange={(e) => setAdvReading(e.target.value as '' | ReadingStatus)}
-                    title={tr('按阅读状态过滤', 'Filter by reading status')}
-                  >
-                    <option value="">{tr('读没读', 'Read?')}</option>
-                    {READING_STATUS.map((m) => (
-                      <option key={m.v} value={m.v}>
-                        {tr(m.label, m.en)}
-                      </option>
-                    ))}
-                  </select>
-                  <label className="row gap6" style={{ cursor: 'pointer', userSelect: 'none', fontSize: 11.5, color: 'var(--text-2)' }}>
-                    <input
-                      type="checkbox"
-                      checked={advStarred}
-                      onChange={(e) => setAdvStarred(e.target.checked)}
-                      style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
-                    />
-                    {tr('仅看星标', 'Starred only')}
-                  </label>
-                </div>
+                <MyTagField value={advMyTag} onChange={setAdvMyTag} />
+                <ReadingStatusField value={advReading} onChange={setAdvReading} />
+                <label className="row gap6" style={{ cursor: 'pointer', userSelect: 'none', fontSize: 11.5, color: 'var(--text-2)' }}>
+                  <input
+                    type="checkbox"
+                    checked={advStarred}
+                    onChange={(e) => setAdvStarred(e.target.checked)}
+                    style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
+                  />
+                  {tr('仅看星标', 'Starred only')}
+                </label>
               </AdvancedPanel>
             </div>
           )}

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -12,6 +12,7 @@ import {
   type LibrarySort,
   type LibraryTab,
   type Publication,
+  type ReadingStatus,
 } from '../../lib/api';
 import { fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
@@ -19,7 +20,9 @@ import {
   AdvancedPanel,
   AdvancedToggle,
   FilterInput,
+  MyTagField,
   parseYear,
+  ReadingStatusField,
   SearchInput,
   SemanticSwitch,
   saveBlob,
@@ -290,22 +293,35 @@ export function LibraryPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  // 高级检索：年份区间 / 作者 / 机构 / venue（走后端）
+  // 高级检索：年份区间 / 作者 / 机构 / 期刊会议 / 我的标签 / 阅读状态 / 星标（走后端）
   const [advOpen, setAdvOpen] = useState(false);
   const [author, setAuthor] = useState('');
   const [affiliation, setAffiliation] = useState('');
   const [venue, setVenue] = useState('');
   const [yearFrom, setYearFrom] = useState('');
   const [yearTo, setYearTo] = useState('');
+  const [myTag, setMyTag] = useState('');
+  const [readingStatus, setReadingStatus] = useState<'' | ReadingStatus>('');
+  const [starred, setStarred] = useState(false);
 
   const advActive =
-    !!author.trim() || !!affiliation.trim() || !!venue.trim() || !!yearFrom.trim() || !!yearTo.trim();
+    !!author.trim() ||
+    !!affiliation.trim() ||
+    !!venue.trim() ||
+    !!yearFrom.trim() ||
+    !!yearTo.trim() ||
+    !!myTag ||
+    readingStatus !== '' ||
+    starred;
   const clearAdvanced = () => {
     setAuthor('');
     setAffiliation('');
     setVenue('');
     setYearFrom('');
     setYearTo('');
+    setMyTag('');
+    setReadingStatus('');
+    setStarred(false);
   };
 
   // 点作者/机构 → 列表只留匹配的条目（走已有的高级检索），其余条件重置并展开面板
@@ -317,6 +333,9 @@ export function LibraryPage() {
     setVenue('');
     setYearFrom('');
     setYearTo('');
+    setMyTag('');
+    setReadingStatus('');
+    setStarred(false);
     setAdvOpen(true);
     if (patch.author) {
       toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
@@ -345,7 +364,7 @@ export function LibraryPage() {
   // tab / 搜索词 / 检索模式 / 排序 / 高级条件变化时回到第一页
   useEffect(() => {
     setPage(1);
-  }, [tab, q, semanticOn, sort, author, affiliation, venue, yearFrom, yearTo]);
+  }, [tab, q, semanticOn, sort, author, affiliation, venue, yearFrom, yearTo, myTag, readingStatus, starred]);
 
   // 切 tab / 换搜索词 / 换检索模式时清空多选（避免选中集跨上下文残留）
   useEffect(() => {
@@ -358,6 +377,7 @@ export function LibraryPage() {
     queryKey: [
       'library', tab, q, semantic, sort, page,
       author.trim(), affiliation.trim(), venue.trim(), yearFrom.trim(), yearTo.trim(),
+      myTag, readingStatus, starred,
     ],
     queryFn: () =>
       api.listLibrary({
@@ -373,6 +393,9 @@ export function LibraryPage() {
         venue: semantic ? undefined : venue.trim() || undefined,
         year_from: semantic ? undefined : parseYear(yearFrom),
         year_to: semantic ? undefined : parseYear(yearTo),
+        my_tag: semantic ? undefined : myTag || undefined,
+        reading_status: semantic ? undefined : readingStatus || undefined,
+        starred: semantic ? undefined : starred || undefined,
       }),
     enabled: onLibraryTab,
     retry: false,
@@ -641,8 +664,8 @@ export function LibraryPage() {
                     active={advActive}
                     onToggle={() => setAdvOpen((o) => !o)}
                     title={tr(
-                      '高级检索：年份 / 作者 / 机构 / 期刊会议',
-                      'Advanced search: year / author / affiliation / venue',
+                      '高级检索：年份 / 作者 / 机构 / 期刊会议 / 我的标签 / 阅读状态 / 星标',
+                      'Advanced search: year / author / affiliation / venue / my tags / reading status / starred',
                     )}
                   />
                 </div>
@@ -678,6 +701,16 @@ export function LibraryPage() {
                           'Affiliations live on the paper — entries whose source paper is gone will not match',
                         )}
                       />
+                      {/* 我的标签 / 阅读状态 / 星标同样记在论文那边，源论文已删的条目匹配不到 */}
+                      <MyTagField value={myTag} onChange={setMyTag} />
+                      <ReadingStatusField value={readingStatus} onChange={setReadingStatus} />
+                      <label
+                        className="row gap6"
+                        style={{ fontSize: 11.5, color: 'var(--text-2)', cursor: 'pointer', alignItems: 'center' }}
+                      >
+                        <input type="checkbox" checked={starred} onChange={(e) => setStarred(e.target.checked)} />
+                        {tr('只看星标', 'Starred only')}
+                      </label>
                     </AdvancedPanel>
                   </div>
                 )}

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -26,7 +26,9 @@ import {
   AdvancedPanel,
   AdvancedToggle,
   FilterInput,
+  MyTagField,
   parseYear,
+  ReadingStatusField,
   saveBlob,
   SearchInput,
   SemanticSwitch,
@@ -94,13 +96,6 @@ const FILTERS: { v: ShelfFilter; zh: string; en: string }[] = [
   { v: 'snapshot', zh: '快照解读', en: 'Snapshot wiki' },
   { v: 'none', zh: '暂无解读', en: 'No wiki' },
 ];
-const READING_FILTERS: { v: ReadingFilter; zh: string; en: string }[] = [
-  { v: '', zh: '全部', en: 'All' },
-  { v: 'unread', zh: '未读', en: 'Unread' },
-  { v: 'reading', zh: '在读', en: 'Reading' },
-  { v: 'read', zh: '已读', en: 'Read' },
-];
-
 function errText(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
@@ -464,6 +459,7 @@ export function ResearchPage() {
   const [yearTo, setYearTo] = useState('');
   const [readingStatus, setReadingStatus] = useState<ReadingFilter>('');
   const [starred, setStarred] = useState(false);
+  const [myTag, setMyTag] = useState('');
 
   const advActive =
     !!author.trim() ||
@@ -471,7 +467,8 @@ export function ResearchPage() {
     !!yearFrom.trim() ||
     !!yearTo.trim() ||
     readingStatus !== '' ||
-    starred;
+    starred ||
+    !!myTag;
   // 是否有任何后端筛选（用于空态文案区分「没添加」vs「没匹配」）
   const hasServerFilter = !!q || advActive;
 
@@ -482,6 +479,7 @@ export function ResearchPage() {
     setYearTo('');
     setReadingStatus('');
     setStarred(false);
+    setMyTag('');
   };
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板
@@ -494,6 +492,7 @@ export function ResearchPage() {
     setYearTo('');
     setReadingStatus('');
     setStarred(false);
+    setMyTag('');
     setAdvOpen(true);
     setSelId(null);
     if (patch.author) {
@@ -520,7 +519,7 @@ export function ResearchPage() {
   // 后端筛选/排序变化时回到第一页
   useEffect(() => {
     setPage(1);
-  }, [q, sort, author, affiliation, yearFrom, yearTo, readingStatus, starred]);
+  }, [q, sort, author, affiliation, yearFrom, yearTo, readingStatus, starred, myTag]);
 
   // 切换课题 / 搜索词 / 过滤 / 作用域时退出多选（对齐文献库 PapersTab）
   useEffect(() => {
@@ -544,6 +543,7 @@ export function ResearchPage() {
       yearTo.trim(),
       readingStatus,
       starred,
+      myTag,
     ],
     queryFn: () =>
       api.listShelf(pid, {
@@ -557,6 +557,7 @@ export function ResearchPage() {
         year_to: parseYear(yearTo),
         reading_status: readingStatus || undefined,
         starred: starred || undefined,
+        my_tag: myTag || undefined,
       }),
     enabled: !!pid && !semantic,
     retry: false,
@@ -806,8 +807,8 @@ export function ResearchPage() {
                   active={advActive}
                   onToggle={() => setAdvOpen((o) => !o)}
                   title={tr(
-                    '高级检索：作者 / 机构 / 年份 / 阅读状态',
-                    'Advanced search: author / affiliation / year / reading status',
+                    '高级检索：作者 / 机构 / 年份 / 我的标签 / 阅读状态 / 星标',
+                    'Advanced search: author / affiliation / year / my tags / reading status / starred',
                   )}
                 />
               </div>
@@ -835,20 +836,8 @@ export function ResearchPage() {
                     onFrom={setYearFrom}
                     onTo={setYearTo}
                   />
-                  <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
-                    <span style={{ width: 52, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
-                      {tr('阅读状态', 'Reading')}
-                    </span>
-                    {READING_FILTERS.map((f) => (
-                      <span
-                        key={f.v || 'all'}
-                        className={`chip${readingStatus === f.v ? ' on' : ''}`}
-                        onClick={() => setReadingStatus(f.v)}
-                      >
-                        {tr(f.zh, f.en)}
-                      </span>
-                    ))}
-                  </div>
+                  <MyTagField value={myTag} onChange={setMyTag} />
+                  <ReadingStatusField value={readingStatus} onChange={setReadingStatus} />
                   <label
                     className="row gap6"
                     style={{ fontSize: 11.5, color: 'var(--text-2)', cursor: 'pointer', alignItems: 'center' }}

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useId, useState, type ReactNode } from 'react';
-import type { ConceptCategory, PaperAuthor } from '../../lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { api, type ConceptCategory, type PaperAuthor, type ReadingStatus } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { clickable } from '../../lib/a11y';
 import { Icon } from '../../components/ui/Icon';
 import { Switch } from '../../components/ui/Switch';
+import { READING_STATUS } from '../reading/shared';
 
 /* ============================================================
    Research Wiki 页共享：概念类别配色、Section、防抖 hook。
@@ -242,6 +244,68 @@ export function FilterInput({
       placeholder={placeholder}
       title={title}
     />
+  );
+}
+
+/** 高级检索：阅读状态过滤（左侧标签 + 全部/未读/在读/已读 chip 组）。
+    空串=不限，其余透传给后端 reading_status。 */
+export function ReadingStatusField({
+  value,
+  onChange,
+  label,
+}: {
+  value: '' | ReadingStatus;
+  onChange: (v: '' | ReadingStatus) => void;
+  label?: string;
+}) {
+  return (
+    <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
+      <span style={{ width: 52, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
+        {label ?? tr('阅读状态', 'Reading')}
+      </span>
+      <span className={`chip${value === '' ? ' on' : ''}`} onClick={() => onChange('')}>
+        {tr('全部', 'All')}
+      </span>
+      {READING_STATUS.map((m) => (
+        <span
+          key={m.v}
+          className={`chip${value === m.v ? ' on' : ''}`}
+          onClick={() => onChange(m.v)}
+        >
+          {tr(m.label, m.en)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** 高级检索：我的标签下拉（自带标签清单查询；跨库共用一份缓存，空串=不限）。 */
+export function MyTagField({
+  value,
+  onChange,
+  title,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  title?: string;
+}) {
+  const myTagsQuery = useQuery({ queryKey: ['my-tags'], queryFn: () => api.listMyTags(), retry: false });
+  const myTags = myTagsQuery.data ?? [];
+  return (
+    <select
+      className="input"
+      style={{ height: 26, fontSize: 11.5, width: '100%', padding: '0 6px' }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      title={title ?? tr('按我的标签过滤（只有你自己看得到）', 'Filter by my tag (only you can see these)')}
+    >
+      <option value="">{tr('全部我的标签', 'All my tags')}</option>
+      {myTags.map((t) => (
+        <option key={t.name} value={t.name}>
+          {t.name}（{t.paper_count}）
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3212,6 +3212,8 @@ export const api = {
       year_to?: number;
       reading_status?: ReadingStatus;
       starred?: boolean;
+      /** 我的标签（个人私域，只有本人可见） */
+      my_tag?: string;
       sort?: ShelfSort;
       /** true=只列回收站里的条目；默认 false=只列在架的 */
       trashed?: boolean;
@@ -3227,6 +3229,7 @@ export const api = {
     if (opts.year_to != null) params.set('year_to', String(opts.year_to));
     if (opts.reading_status) params.set('reading_status', opts.reading_status);
     if (opts.starred) params.set('starred', 'true');
+    if (opts.my_tag) params.set('my_tag', opts.my_tag);
     if (opts.sort) params.set('sort', opts.sort);
     if (opts.trashed) params.set('trashed', 'true');
     const qs = params.toString();
@@ -3998,6 +4001,10 @@ export const api = {
       /** 机构：条目快照没有机构字段，后端按条目软引用的活体论文匹配（源论文已删的匹配不到） */
       affiliation?: string;
       venue?: string;
+      /** 阅读状态 / 星标 / 我的标签：同机构，按软引用的活体论文匹配（源论文已删的匹配不到） */
+      reading_status?: ReadingStatus;
+      starred?: boolean;
+      my_tag?: string;
     },
   ): Promise<LibraryListResult> {
     const params = new URLSearchParams();
@@ -4012,6 +4019,9 @@ export const api = {
     if (opts.author) params.set('author', opts.author);
     if (opts.affiliation) params.set('affiliation', opts.affiliation);
     if (opts.venue) params.set('venue', opts.venue);
+    if (opts.reading_status) params.set('reading_status', opts.reading_status);
+    if (opts.starred) params.set('starred', 'true');
+    if (opts.my_tag) params.set('my_tag', opts.my_tag);
     return request<LibraryListResult>(`/me/library?${params.toString()}`);
   },
   /** 个人库引用导出：不传 ids 导出全部收藏，传 ids（论文 id）精确导出多选。 */


### PR DESCRIPTION
The three paper surfaces share one search bar, but their advanced panels had drifted apart:

| | Related work | My library | Shared library |
|---|---|---|---|
| Reading status | ✅ | ❌ | ✅ |
| Starred | ✅ | ❌ | ✅ |
| My tags | ❌ | ❌ | ✅ |

Now all three have all three.

## Resolving through the snapshot

A personal library entry stores a *snapshot*, not a paper — so these filters reach the data through the soft reference `last_paper_id` into `paper_user_meta` and `user_paper_tags`. The existing affiliation filter already worked this way, so it's an established shape rather than a new one.

**Entries whose paper is gone are excluded from all three, including `reading_status=unread`.** The library browser coalesces a missing meta row to "unread", which is correct when the paper exists and simply was never marked. Copying that down to the entry layer would flood "unread" with dead snapshots and bury the papers you actually haven't read. Papers that exist but were never marked still count as unread, matching the browser.

## Two shared atoms

The same two controls existed in two shapes: reading status was a chip group on the shelf and a `<select>` in the browser; the my-tag dropdown was about to be copy-pasted a third time.

- `ReadingStatusField` — settles on the shelf's chip group, which sits better beside the starred checkbox than a select did. **This changes the shared library browser's control visually**; filtering semantics are identical.
- `MyTagField` — owns its own query against the global `['my-tags']` key, so the tag list is fetched once and shared across pages.

## Known trade-off

Both surfaces can now **filter** by these, but their list rows still don't **display** star/reading-status/tags — those row schemas don't carry them. Filter-but-can't-see is the deliberate stopping point; wiring the display needs three schema changes and their aggregate queries.

`PapersTab` has its own copies of both controls and would be pure profit to convert, but it's outside what this touches.

## Verification

43 backend tests green, covering each filter on the personal library and the shelf, the orphaned-snapshot behaviour above, and stacking with the recycle-bin tab. `ruff check app` clean, `tsc --noEmit` 0 errors.
