### PR TITLE
fix(llm,latex): raise the 120s timeouts to 300s

### DIFF
--- a/src/backend/app/core/llm/anthropic.py
+++ b/src/backend/app/core/llm/anthropic.py
@@ -24,7 +24,7 @@ class AnthropicProvider(LLMProvider):
         api_key: str,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout: float = 120.0,
+        timeout: float = 300.0,
     ) -> None:
         self._api_key = api_key
         self._client = client or httpx.AsyncClient(timeout=timeout)

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -67,7 +67,7 @@ class OpenAICompatProvider(LLMProvider):
         api_key: str,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout: float = 120.0,
+        timeout: float = 300.0,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key

--- a/src/backend/app/services/latex_compile.py
+++ b/src/backend/app/services/latex_compile.py
@@ -39,7 +39,7 @@ from app.services import crdt_rooms, manuscript_versions
 from app.services import manuscripts as manuscripts_service
 from app.services.citations import build_bibtex_for
 
-COMPILE_TIMEOUT_SECONDS = 120.0
+COMPILE_TIMEOUT_SECONDS = 300.0
 TECTONIC_BIN = "tectonic"
 LATEXMK_BIN = "latexmk"
 MAIN_TEX = "main.tex"


### PR DESCRIPTION
Compiling a paper's wiki was running close to the ceiling.

## Measured, from `llm_call_logs`

| Scenario | Calls | p50 | p95 | Max |
|---|---|---|---|---|
| **Wiki compilation** (full page) | 19 | 62s | **85s** | **95s** |
| Paper review | 206 | 51s | 69s | 90s |
| Concept definitions (compilation's side calls) | 161 | 10s | 23s | — |
| Relevance scoring | 758 | 7.6s | 12s | 131s |
| Reading chat | 10 | 18s | 61s | 65s |

Against a **120s** limit, wiki compilation had ~20s of headroom — enough to lose on a long paper, a slow upstream, or a network hiccup. And a single paper is more than one call (full page plus several concept definitions), so end-to-end is longer than any row above.

## What changed

All three ceilings go to **300s**:

- `openai_compat.py` and `anthropic.py` HTTP clients — these cover wiki compilation, paper review, **figure review** (it shares the `librarian` stage: multimodal figure selection plus captions) and chat
- `latex_compile.py` — the LaTeX subprocess had the same 120s bound

Nothing outside these cuts in earlier: the voyage job timeout is 12h, arq's `job_timeout` is 1h, and the frontend sets no request deadline.

## Honest caveat

**The recorded failures were not timeouts.** All four in the log are upstream responses — three `429 Too Many Requests`, one `503 Service Unavailable` — that came back in 2–4 seconds. This raises a ceiling that was *close*, not one that was demonstrably hit. If you're seeing an actual TimeOut error, send me the page and message and I'll trace which layer it's from.

These values are still hardcoded. Making them configurable is worth doing separately — right now changing one means a code change and redeploy.

## Verification

`ruff check app` clean, backend imports, 100 tests pass across the llm/latex/compile selection.