### PR TITLE
feat(papers): unify list controls across the three paper surfaces

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -44,7 +44,6 @@ import {
   PaperMyMetaRow,
   PaperMyTagsRow,
   PaperNotesSection,
-  PaperTagsRow,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
 import { DailyLikes } from './DailyLikes';
@@ -396,8 +395,8 @@ function DailyDetailPane({
         />
       )}
 
-      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
-      <PaperTagsRow tags={poolPaper?.tags} />
+      {/* —— 我的标签：就地改，只有自己看得到 —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       {poolPaper && (
         <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
       )}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -29,10 +29,9 @@ import { tr } from '../../lib/i18n';
 import {
   ConceptChips,
   PaperMyMetaRow,
+  PaperMyTagChips,
   PaperMyTagsRow,
   PaperNotesSection,
-  PaperTagChips,
-  PaperTagsRow,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
 import { ConceptsTab } from '../wiki/ConceptsTab';
@@ -73,7 +72,7 @@ type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' |
 
 const PAGE_SIZE = 20;
 
-/** 列表视图筛选（口径同文献工作台：全部 = 已纳入的文献） */
+/** 列表范围筛选（口径同文献工作台：全部 = 已纳入的文献）；收在高级检索面板里 */
 type ViewFilter = 'all' | 'compiled' | 'starred';
 
 // 模块级常量存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
@@ -159,7 +158,7 @@ const PaperRow = memo(function PaperRow({
       <div className="row gap8" style={{ marginTop: 6 }}>
         <PaperStatusPill status={p.status} sm />
         <ReadingDot status={p.reading_status} />
-        <PaperTagChips tags={p.tags} myTags={p.my_tags} />
+        <PaperMyTagChips myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
           <span
             className="row"
@@ -408,8 +407,8 @@ function PaperDetailPane({
         invalidateKeys={listKeys}
       />
 
-      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
-      <PaperTagsRow tags={paper.tags} />
+      {/* —— 我的标签：就地改，只有自己看得到 —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       <PaperMyTagsRow
         paperId={paper.id}
         myTags={paper.my_tags}
@@ -614,9 +613,8 @@ function PapersPane({
   const [semanticOn, setSemanticOn] = useState(false);
   const [sort, setSort] = useState<PaperSort>('relevance');
   const [page, setPage] = useState(1);
-  // 视图筛选（全部 / 已编译 / 已星标）+ 标签过滤，口径同文献工作台
+  // 范围筛选（全部 / 已编译 / 已星标）：收在高级检索面板里，口径同文献工作台
   const [view, setView] = useState<ViewFilter>('all');
-  const [tagFilter, setTagFilter] = useState('');
 
   // 多选（批量导出引用）：默认关闭，底部「多选」按钮开启后行首出现复选框（只读浏览不加删除）
   const [selectMode, setSelectMode] = useState(false);
@@ -624,7 +622,7 @@ function PapersPane({
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [libraryId, q, view, tagFilter]);
+  }, [libraryId, q, view]);
 
   const bulkExportMutation = useMutation({
     mutationFn: () => api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] }),
@@ -644,16 +642,16 @@ function PapersPane({
   const [advYearTo, setAdvYearTo] = useState('');
   const [advMyTag, setAdvMyTag] = useState('');
   const [advReading, setAdvReading] = useState<'' | ReadingStatus>('');
-  const [advStarred, setAdvStarred] = useState(false);
   const author = useDebounced(advAuthor.trim());
   const affiliation = useDebounced(advAffiliation.trim());
   const yearFrom = parseYear(advYearFrom);
   const yearTo = parseYear(advYearTo);
-  const advActive = !!(author || affiliation || yearFrom || yearTo || advMyTag || advReading || advStarred);
+  // 范围也算一个高级条件（「已星标」就是原来的星标筛选，不再单列）
+  const advActive = !!(author || affiliation || yearFrom || yearTo || advMyTag || advReading) || view !== 'all';
 
   useEffect(
     () => setPage(1),
-    [q, sort, semanticOn, view, tagFilter, author, affiliation, yearFrom, yearTo, advMyTag, advReading, advStarred],
+    [q, sort, semanticOn, view, author, affiliation, yearFrom, yearTo, advMyTag, advReading],
   );
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板
@@ -667,7 +665,7 @@ function PapersPane({
       setAdvYearTo('');
       setAdvMyTag('');
       setAdvReading('');
-      setAdvStarred(false);
+      setView('all');
       setAdvOpen(true);
       onSelect('');
       if (patch.author) {
@@ -681,26 +679,17 @@ function PapersPane({
   const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
   const filterByAffiliation = useCallback((name: string) => applyAdvFilter({ affiliation: name }), [applyAdvFilter]);
 
-  // 库内标签（过滤下拉用；接口未就绪时静默降级）
-  const tagsQuery = useQuery({
-    queryKey: ['lib-tags', libraryId],
-    queryFn: () => api.listLibraryTags(libraryId),
-    retry: false,
-  });
-  const libraryTags = tagsQuery.data ?? [];
-
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
-      'lib-papers', libraryId, view, tagFilter, advMyTag, q, sort, page,
-      author, affiliation, yearFrom, yearTo, advReading, advStarred,
+      'lib-papers', libraryId, view, advMyTag, q, sort, page,
+      author, affiliation, yearFrom, yearTo, advReading,
     ],
     queryFn: () => {
       const vq = viewQuery(view);
       return api.listLibraryPapersFull(libraryId, {
         status: vq.status,
-        starred: vq.starred || advStarred || undefined,
-        tag: tagFilter || undefined,
+        starred: vq.starred || undefined,
         my_tag: advMyTag || undefined,
         q: q || undefined,
         sort,
@@ -735,7 +724,7 @@ function PapersPane({
     if (!selectedId && firstId) onSelect(firstId);
   }, [selectedId, firstId, onSelect]);
 
-  const hasFilter = !!q || advActive || view !== 'all' || !!tagFilter;
+  const hasFilter = !!q || advActive;
   const filterDisabled = semantic ? { opacity: 0.45, pointerEvents: 'none' as const } : undefined;
 
   return (
@@ -758,8 +747,8 @@ function PapersPane({
               active={advActive}
               onToggle={() => setAdvOpen((o) => !o)}
               title={tr(
-                '高级检索：作者 / 机构 / 年份 / 我的标签 / 阅读状态 / 星标',
-                'Advanced search: author / affiliation / year / my tags / reading status / starred',
+                '高级检索：范围 / 作者 / 机构 / 年份 / 我的标签 / 阅读状态',
+                'Advanced search: scope / author / affiliation / year / my tags / reading status',
               )}
             />
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
@@ -778,11 +767,27 @@ function PapersPane({
                         setAdvYearTo('');
                         setAdvMyTag('');
                         setAdvReading('');
-                        setAdvStarred(false);
+                        setView('all');
                       }
                     : undefined
                 }
               >
+                {/* 范围：原来面板外的那排 chip 收进来；「已星标」即原先单列的星标筛选 */}
+                <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
+                  <span style={{ width: 52, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
+                    {tr('范围', 'Scope')}
+                  </span>
+                  {VIEW_FILTERS.map((f) => (
+                    <span
+                      key={f.v}
+                      className={`chip${view === f.v ? ' on' : ''}`}
+                      title={tr(f.hintZh, f.hintEn)}
+                      onClick={() => setView(f.v)}
+                    >
+                      {tr(f.zh, f.en)}
+                    </span>
+                  ))}
+                </div>
                 <div className="row gap8">
                   <FilterInput value={advAuthor} onChange={setAdvAuthor} placeholder={tr('作者姓名…', 'Author name…')} />
                   <FilterInput
@@ -804,48 +809,7 @@ function PapersPane({
                 />
                 <MyTagField value={advMyTag} onChange={setAdvMyTag} />
                 <ReadingStatusField value={advReading} onChange={setAdvReading} />
-                <label className="row gap6" style={{ cursor: 'pointer', userSelect: 'none', fontSize: 11.5, color: 'var(--text-2)' }}>
-                  <input
-                    type="checkbox"
-                    checked={advStarred}
-                    onChange={(e) => setAdvStarred(e.target.checked)}
-                    style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
-                  />
-                  {tr('仅看星标', 'Starred only')}
-                </label>
               </AdvancedPanel>
-            </div>
-          )}
-          {/* 视图筛选：全部 / 已编译 / 已星标（语义检索时置灰） */}
-          <div className="row gap6 wrap" style={{ marginTop: 10, ...filterDisabled }}>
-            {VIEW_FILTERS.map((f) => (
-              <span
-                key={f.v}
-                className={`chip${view === f.v ? ' on' : ''}`}
-                title={tr(f.hintZh, f.hintEn)}
-                onClick={() => setView(f.v)}
-              >
-                {tr(f.zh, f.en)}
-              </span>
-            ))}
-          </div>
-          {/* 标签过滤（库作用域标签） */}
-          {libraryTags.length > 0 && (
-            <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
-              <select
-                className="input"
-                style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
-                value={tagFilter}
-                onChange={(e) => setTagFilter(e.target.value)}
-                title={tr('按标签过滤', 'Filter by tag')}
-              >
-                <option value="">{tr('全部标签', 'All tags')}</option>
-                {libraryTags.map((t) => (
-                  <option key={t.id} value={t.name}>
-                    {t.name}（{t.paper_count}）
-                  </option>
-                ))}
-              </select>
             </div>
           )}
           {/* 排序（语义检索按相关度返回，排序无效 → 置灰） */}
@@ -935,7 +899,9 @@ function PapersPane({
             }}
           >
             <Icon name="check" size={13} />
-            {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
+            {selectMode
+              ? tr(`已选 ${selected.size} 篇`, `${selected.size} selected`)
+              : tr('多选', 'Select')}
           </button>
           {selectMode && (
             <button

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -29,7 +29,6 @@ import {
   PaperMyMetaRow,
   PaperMyTagsRow,
   PaperNotesSection,
-  PaperTagsRow,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
 
@@ -354,8 +353,8 @@ export function LibraryDetailPane({
         />
       )}
 
-      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
-      {alive && <PaperTagsRow tags={paper.tags} />}
+      {/* —— 我的标签：就地改，只有自己看得到 —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       {alive && (
         <PaperMyTagsRow
           paperId={paper.id}

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
@@ -34,11 +34,13 @@ import { PersonalChatTab } from './PersonalChatTab';
 import { DailyLikedTab } from './DailyLikedTab';
 import { AuthorBindWizard } from './AuthorBindWizard';
 import { AddToLibraryModal } from './AddToLibraryModal';
+import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPane';
 
 /* ============================================================
    /library — 我的文献库：
-   「我的收藏」+「浏览记录」+「回收站」+「我发表的」等 tab；
+   「我的收藏」+「浏览记录」+「我发表的」等 tab（回收站是列表
+   底部操作行里的弹窗入口，与实验室文献库 / 相关研究一致）；
    双栏主从布局对齐文献追踪（Stage 00）的论文库：
    左栏列表（搜索/排序/分页/行操作），右栏选中条目的详情
    （活体论文展示 wiki，快照条目展示元数据 + 外链）。
@@ -48,9 +50,14 @@ import { entrySnapshot, LibraryDetailPane, pubSnapshot } from './LibraryDetailPa
 const PAGE_SIZE = 20;
 // 语义检索一次返回一组结果（不分页），上限比普通分页大些
 const SEMANTIC_SIZE = 50;
+// 回收站弹窗一次拉这么多条（不分页，超出的在弹窗里提示总数）
+const TRASH_SIZE = 100;
 
-/** 页面级 tab：库内三个 tab（收藏 / 浏览记录 / 回收站）+「我赞过的」+「文献对话」+「我发表的」。 */
-type PageTab = LibraryTab | 'liked' | 'publications' | 'chat';
+/** 页面级 tab：库内两个 tab（收藏 / 浏览记录）+「我赞过的」+「文献对话」+「我发表的」。
+    回收站不再是 tab，改成列表底部操作行里的弹窗。 */
+type PageTab = 'saved' | 'history' | 'liked' | 'publications' | 'chat';
+/** 列表 tab：收藏 / 浏览记录（走同一套列表端点）。 */
+type ListTab = Extract<LibraryTab, 'saved' | 'history'>;
 
 // 模块级常量不调 tr()：保留 zh/en 字段，渲染处再 tr
 const SORTS: { v: LibrarySort; zh: string; en: string }[] = [
@@ -76,11 +83,10 @@ function EntryRow({
   onToggleCheck,
   onSelect,
   onToggleSave,
-  onRestore,
   onPurge,
 }: {
   entry: LibraryEntry;
-  tab: LibraryTab;
+  tab: ListTab;
   active: boolean;
   busy: boolean;
   selectMode: boolean;
@@ -88,7 +94,6 @@ function EntryRow({
   onToggleCheck: () => void;
   onSelect: () => void;
   onToggleSave: () => void;
-  onRestore: () => void;
   onPurge: () => void;
 }) {
   const authors = entry.authors.map((a) => a.name).join(', ');
@@ -126,7 +131,7 @@ function EntryRow({
         title={
           entry.last_paper_id === null
             ? tr('源方向已删除，无法导出引用', 'Source deleted — cannot export citation')
-            : tr('选中后可批量导出引用', 'Select for bulk citation export')
+            : tr('选中后可批量删除 / 导出引用', 'Select for bulk delete / citation export')
         }
         style={{
           width: 13,
@@ -154,11 +159,7 @@ function EntryRow({
               {tr('源课题已删除', 'Source topic deleted')}
             </span>
           )}
-          {tab === 'trash' ? (
-            <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
-              {tr(`${fmtRelative(entry.trashed_at)} 移入`, `trashed ${fmtRelative(entry.trashed_at)}`)}
-            </span>
-          ) : entry.visit_count > 0 ? (
+          {entry.visit_count > 0 ? (
             <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
               {fmtRelative(entry.last_visited_at)}
               {' · '}
@@ -209,56 +210,31 @@ function EntryRow({
         )}
       </div>
 
-      {/* —— 右：操作（回收站里换成召回 / 彻底删除） —— */}
+      {/* —— 右：操作（收藏开关 / 浏览记录删除） —— */}
       <div className="row gap6" style={{ flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
-        {tab === 'trash' ? (
-          <>
-            <button
-              className="icon-btn"
-              disabled={busy}
-              title={tr('召回到「我的收藏」', 'Restore to Saved')}
-              style={{ color: 'var(--accent)' }}
-              onClick={onRestore}
-            >
-              <Icon name="refresh" size={15} />
-            </button>
-            <button
-              className="icon-btn"
-              disabled={busy}
-              title={tr('彻底删除，无法再召回', 'Delete forever — cannot be restored')}
-              style={{ color: 'var(--danger-tx)' }}
-              onClick={onPurge}
-            >
-              <Icon name="x" size={15} />
-            </button>
-          </>
-        ) : (
-          <>
-            <button
-              className="icon-btn"
-              disabled={busy}
-              title={
-                entry.saved
-                  ? tr('取消收藏（放进回收站，可召回）', 'Unsave (goes to trash, restorable)')
-                  : tr('收藏', 'Save')
-              }
-              style={{ color: entry.saved ? 'var(--accent)' : 'var(--text-3)' }}
-              onClick={onToggleSave}
-            >
-              <Icon name={entry.saved ? 'bookmarkFill' : 'bookmark'} size={15} />
-            </button>
-            {tab === 'history' && (
-              <button
-                className="icon-btn"
-                disabled={busy}
-                title={tr('彻底删除这条记录', 'Delete this record')}
-                style={{ color: 'var(--text-3)' }}
-                onClick={onPurge}
-              >
-                <Icon name="trash" size={15} />
-              </button>
-            )}
-          </>
+        <button
+          className="icon-btn"
+          disabled={busy}
+          title={
+            entry.saved
+              ? tr('取消收藏（放进回收站，可召回）', 'Unsave (goes to trash, restorable)')
+              : tr('收藏', 'Save')
+          }
+          style={{ color: entry.saved ? 'var(--accent)' : 'var(--text-3)' }}
+          onClick={onToggleSave}
+        >
+          <Icon name={entry.saved ? 'bookmarkFill' : 'bookmark'} size={15} />
+        </button>
+        {tab === 'history' && (
+          <button
+            className="icon-btn"
+            disabled={busy}
+            title={tr('彻底删除这条记录', 'Delete this record')}
+            style={{ color: 'var(--text-3)' }}
+            onClick={onPurge}
+          >
+            <Icon name="trash" size={15} />
+          </button>
         )}
       </div>
     </div>
@@ -274,6 +250,108 @@ function PickHint() {
   );
 }
 
+/* ---------------- 回收站 ---------------- */
+
+/** 我的文献库回收站：弹窗外壳复用共享 TrashModal，端点与行映射留在这里。
+    取消收藏是软删，条目落在这里，可召回或彻底删除；浏览记录不受影响。 */
+function PersonalTrashModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const queryClient = useQueryClient();
+
+  const trashQuery = useQuery({
+    queryKey: ['library', 'trash', TRASH_SIZE],
+    queryFn: () => api.listLibrary({ tab: 'trash', sort: 'recent', page: 1, size: TRASH_SIZE }),
+    enabled: open,
+    retry: false,
+  });
+  const trashed = useMemo(() => trashQuery.data?.items ?? [], [trashQuery.data]);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['library'] });
+    void queryClient.invalidateQueries({ queryKey: ['library-state'] });
+  };
+
+  const restoreMutation = useMutation({
+    mutationFn: (entryId: string) => api.restoreLibraryEntry(entryId),
+    onSuccess: (entry) => {
+      toast(`${tr('已召回：', 'Restored: ')}${entry.title.slice(0, 30)}`, 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('召回失败：', 'Restore failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const purgeMutation = useMutation({
+    mutationFn: (entryId: string) => api.removeLibraryEntry(entryId, 'purge'),
+    onSuccess: () => {
+      toast(tr('已彻底删除', 'Permanently deleted'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const emptyMutation = useMutation({
+    mutationFn: () => api.emptyPersonalTrash(),
+    onSuccess: (res) => {
+      toast(tr(`回收站已清空（${res.deleted} 条）`, `Trash emptied (${res.deleted} entries)`), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('清空失败：', 'Empty failed: ')}${errText(e)}`, 'error'),
+  });
+
+  const items = useMemo<TrashItemView[]>(
+    () =>
+      trashed.map((entry) => {
+        const authors = entry.authors.map((a) => a.name).join(', ');
+        return {
+          id: entry.id,
+          code: entry.arxiv_id ?? entry.venue ?? '—',
+          year: entry.year,
+          title: entry.title,
+          leading:
+            entry.last_paper_id === null ? (
+              <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                {tr('源课题已删除', 'Source topic deleted')}
+              </span>
+            ) : undefined,
+          aside: (
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+              {tr(`${fmtRelative(entry.trashed_at)} 移入`, `trashed ${fmtRelative(entry.trashed_at)}`)}
+            </span>
+          ),
+          desc: entry.tldr ?? entry.abstract ?? (authors || null),
+          searchText: [entry.title, authors].join('\n'),
+        };
+      }),
+    [trashed],
+  );
+
+  return (
+    <TrashModal
+      open={open}
+      onClose={onClose}
+      sub={tr(
+        '取消收藏的文献放在这里；召回后回到「我的收藏」，清空浏览记录不会动这里',
+        'Papers you unsaved land here; restoring puts them back in Saved — clearing history leaves this alone',
+      )}
+      items={items}
+      total={trashQuery.data?.total}
+      loading={trashQuery.isLoading}
+      busy={restoreMutation.isPending || purgeMutation.isPending || emptyMutation.isPending}
+      emptying={emptyMutation.isPending}
+      onRestore={(id) => restoreMutation.mutate(id)}
+      onPurge={(id) => purgeMutation.mutate(id)}
+      onEmpty={() => emptyMutation.mutate()}
+      emptyWarning={(n) =>
+        tr(
+          `将彻底删除回收站里的全部 ${n} 条，无法恢复`,
+          `This permanently deletes all ${n} entries in the trash — no undo`,
+        )
+      }
+      restoreHint={tr('召回到「我的收藏」', 'Restore to Saved')}
+      purgeHint={tr('彻底删除，无法再召回', 'Delete forever — cannot be restored')}
+    />
+  );
+}
+
 export function LibraryPage() {
   const queryClient = useQueryClient();
 
@@ -285,13 +363,14 @@ export function LibraryPage() {
   const [sort, setSort] = useState<LibrarySort>('recent');
   const [page, setPage] = useState(1);
   const [clearOpen, setClearOpen] = useState(false);
-  const [emptyTrashOpen, setEmptyTrashOpen] = useState(false);
+  const [trashOpen, setTrashOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
 
-  // 多选（批量导出引用）：默认关闭，仅「我的收藏」可用；选中集合按论文 id 存
-  // （last_paper_id，跨页/跨搜索都能带着走；导出端点按论文 id 精确取本人收藏）
+  // 多选（批量删除 / 导出引用）：默认关闭，仅「我的收藏」可用。
+  // 选中集合是「条目 id → 论文 id」的映射：删除按条目 id 走个人库端点，
+  // 导出按论文 id 走引用端点；勾选时就记下映射，跨页/跨搜索都能带着走。
   const [selectMode, setSelectMode] = useState(false);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<Map<string, string>>(new Map());
 
   // 高级检索：年份区间 / 作者 / 机构 / 期刊会议 / 我的标签 / 阅读状态 / 星标（走后端）
   const [advOpen, setAdvOpen] = useState(false);
@@ -368,11 +447,11 @@ export function LibraryPage() {
 
   // 切 tab / 换搜索词 / 换检索模式时清空多选（避免选中集跨上下文残留）
   useEffect(() => {
-    setSelected(new Set());
+    setSelected(new Map());
     setSelectMode(false);
   }, [tab, q, semanticOn]);
 
-  const onLibraryTab = tab !== 'publications' && tab !== 'chat' && tab !== 'liked';
+  const onLibraryTab = tab === 'saved' || tab === 'history';
   const listQuery = useQuery({
     queryKey: [
       'library', tab, q, semantic, sort, page,
@@ -381,7 +460,7 @@ export function LibraryPage() {
     ],
     queryFn: () =>
       api.listLibrary({
-        tab: tab as LibraryTab,
+        tab: tab as ListTab,
         q: q || undefined,
         mode: semantic ? 'semantic' : undefined,
         sort,
@@ -452,20 +531,11 @@ export function LibraryPage() {
     onError: (e) => toast(`${tr('操作失败：', 'Action failed: ')}${errText(e)}`, 'error'),
   });
 
-  const restoreMutation = useMutation({
-    mutationFn: (entry: LibraryEntry) => api.restoreLibraryEntry(entry.id),
-    onSuccess: (_d, entry) => {
-      toast(`${tr('已召回：', 'Restored: ')}${entry.title.slice(0, 30)}`, 'ok');
-      setSelEntry((old) => (old && old.id === entry.id ? null : old));
-      invalidate();
-    },
-    onError: (e) => toast(`${tr('召回失败：', 'Restore failed: ')}${errText(e)}`, 'error'),
-  });
-
+  // 浏览记录里的「彻底删除这条记录」（收藏条目的软删走上面的 toggleMutation）
   const purgeMutation = useMutation({
     mutationFn: (entry: LibraryEntry) => api.removeLibraryEntry(entry.id, 'purge'),
     onSuccess: (_d, entry) => {
-      toast(tab === 'trash' ? tr('已彻底删除', 'Permanently deleted') : tr('已删除这条记录', 'Record deleted'), 'ok');
+      toast(tr('已删除这条记录', 'Record deleted'), 'ok');
       // 删除的是当前选中项 → 清空右栏
       setSelEntry((old) => (old && old.id === entry.id ? null : old));
       invalidate();
@@ -473,19 +543,24 @@ export function LibraryPage() {
     onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
   });
 
-  const emptyTrashMutation = useMutation({
-    mutationFn: () => api.emptyPersonalTrash(),
-    onSuccess: (res) => {
-      setEmptyTrashOpen(false);
-      setSelEntry(null);
-      toast(tr(`回收站已清空（${res.deleted} 条）`, `Trash emptied (${res.deleted} entries)`), 'ok');
+  // 多选批量取消收藏：后端没有批量端点，按选中集逐条调（同样是软删，落回收站）
+  const bulkUnsaveMutation = useMutation({
+    mutationFn: async (entryIds: string[]) => {
+      await Promise.all(entryIds.map((id) => api.removeLibraryEntry(id, 'unsave')));
+      return entryIds.length;
+    },
+    onSuccess: (n, entryIds) => {
+      toast(tr(`已把 ${n} 篇移入回收站，可以召回`, `Moved ${n} papers to trash — restorable`), 'ok');
+      setSelEntry((old) => (old && entryIds.includes(old.id) ? null : old));
+      setSelected(new Map());
+      setSelectMode(false);
       invalidate();
     },
-    onError: (e) => toast(`${tr('清空失败：', 'Empty failed: ')}${errText(e)}`, 'error'),
+    onError: (e) => toast(`${tr('删除失败：', 'Delete failed: ')}${errText(e)}`, 'error'),
   });
 
   const exportMutation = useMutation({
-    mutationFn: () => api.downloadPersonalCitations({ format: 'bibtex', ids: [...selected] }),
+    mutationFn: () => api.downloadPersonalCitations({ format: 'bibtex', ids: [...selected.values()] }),
     onSuccess: (blob) => {
       saveBlob(blob, 'polaris-my-library-citations.bib');
       toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
@@ -504,7 +579,7 @@ export function LibraryPage() {
     onError: (e) => toast(`${tr('清空失败：', 'Clear failed: ')}${errText(e)}`, 'error'),
   });
 
-  const busy = toggleMutation.isPending || purgeMutation.isPending || restoreMutation.isPending;
+  const busy = toggleMutation.isPending || purgeMutation.isPending || bulkUnsaveMutation.isPending;
 
   return (
     <div
@@ -531,7 +606,6 @@ export function LibraryPage() {
           options={[
             { v: 'saved', label: tr('我的收藏', 'Saved') },
             { v: 'history', label: tr('浏览记录', 'History') },
-            { v: 'trash', label: tr('回收站', 'Trash') },
             { v: 'liked', label: tr('我赞过的', 'Liked') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
             {
@@ -628,7 +702,7 @@ export function LibraryPage() {
             </div>
           )
         ) : (
-          /* ======== 我的收藏 / 浏览记录 / 回收站 ======== */
+          /* ======== 我的收藏 / 浏览记录 ======== */
           <div className="split">
             {/* —— 左：列表 —— */}
             <div className="split-list">
@@ -654,9 +728,7 @@ export function LibraryPage() {
                             '按语义相似度检索收藏（需已生成向量）',
                             'Semantic search over saved papers (needs embeddings)',
                           )
-                        : tab === 'history'
-                          ? tr('浏览记录是流水，只支持关键词检索', 'History is a raw log — keyword search only')
-                          : tr('回收站只支持关键词检索', 'Trash supports keyword search only')
+                        : tr('浏览记录是流水，只支持关键词检索', 'History is a raw log — keyword search only')
                     }
                   />
                   <AdvancedToggle
@@ -732,27 +804,7 @@ export function LibraryPage() {
                       {tr('清空记录', 'Clear history')}
                     </button>
                   )}
-                  {tab === 'trash' && (
-                    <button
-                      className="btn btn-ghost sm"
-                      style={{ marginLeft: 'auto', height: 26, flexShrink: 0, color: 'var(--danger-tx)' }}
-                      disabled={emptyTrashMutation.isPending || (data !== undefined && data.total === 0)}
-                      onClick={() => setEmptyTrashOpen(true)}
-                    >
-                      <Icon name="x" size={13} />
-                      {tr('清空回收站', 'Empty trash')}
-                    </button>
-                  )}
                 </div>
-
-                {tab === 'trash' && (
-                  <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-4)', lineHeight: 1.5 }}>
-                    {tr(
-                      '取消收藏的文献先放这里，召回就回到「我的收藏」；彻底删除之后找不回来。清空浏览记录不会动这里。',
-                      'Unsaved papers land here — restore one and it goes back to Saved. Deleting forever cannot be undone; clearing your history leaves this list alone.',
-                    )}
-                  </div>
-                )}
 
                 {/* 语义检索提示：回退关键词 / 覆盖范围说明 */}
                 {semantic && data?.mode_used === 'keyword' && (
@@ -792,15 +844,13 @@ export function LibraryPage() {
                 ) : entries.length === 0 ? (
                   <EmptyState
                     compact
-                    icon={tab === 'trash' ? 'trash' : 'bookmark'}
+                    icon="bookmark"
                     title={
                       q || advActive
                         ? tr('没有匹配的文献', 'No matching papers')
                         : tab === 'saved'
                           ? tr('还没有收藏的文献', 'Nothing saved yet')
-                          : tab === 'history'
-                            ? tr('还没有浏览记录', 'No reading history yet')
-                            : tr('回收站是空的', 'Trash is empty')
+                          : tr('还没有浏览记录', 'No reading history yet')
                     }
                     desc={
                       q || advActive
@@ -810,15 +860,10 @@ export function LibraryPage() {
                               '点右上角「添加文献」，填 arXiv 编号 / DOI / BibTeX 就能直接加进来；在论文阅读页点右上角的书签按钮也能收进这里。',
                               'Use “Add paper” in the top right — an arXiv ID, DOI or BibTeX entry is enough. You can also tap the bookmark button on any paper reading page.',
                             )
-                          : tab === 'history'
-                            ? tr(
-                                '打开任意论文的阅读页后，会自动记录在这里。',
-                                'Papers you open in the reader will show up here automatically.',
-                              )
-                            : tr(
-                                '取消收藏的文献会先放进这里，随时可以召回。',
-                                'Papers you unsave land here and can be restored any time.',
-                              )
+                          : tr(
+                              '打开任意论文的阅读页后，会自动记录在这里。',
+                              'Papers you open in the reader will show up here automatically.',
+                            )
                     }
                     action={
                       tab === 'saved' && !q && !advActive ? (
@@ -838,20 +883,19 @@ export function LibraryPage() {
                       active={entry.id === selEntry?.id}
                       busy={busy}
                       selectMode={selectMode}
-                      checked={entry.last_paper_id !== null && selected.has(entry.last_paper_id)}
+                      checked={selected.has(entry.id)}
                       onToggleCheck={() =>
                         setSelected((old) => {
                           const pid = entry.last_paper_id;
                           if (pid === null) return old;
-                          const next = new Set(old);
-                          if (next.has(pid)) next.delete(pid);
-                          else next.add(pid);
+                          const next = new Map(old);
+                          if (next.has(entry.id)) next.delete(entry.id);
+                          else next.set(entry.id, pid);
                           return next;
                         })
                       }
                       onSelect={() => setSelEntry(entry)}
                       onToggleSave={() => toggleMutation.mutate(entry)}
-                      onRestore={() => restoreMutation.mutate(entry)}
                       onPurge={() => purgeMutation.mutate(entry)}
                     />
                   ))
@@ -887,35 +931,67 @@ export function LibraryPage() {
                 </div>
               )}
 
-              {/* —— 底部操作栏：多选 + 导出引用（仅「我的收藏」；不含删除） —— */}
-              {tab === 'saved' && (
-                <div
-                  className="row gap8"
-                  style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
-                >
-                  <button
-                    className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
-                    title={tr('开启后列表出现复选框，可批量导出引用', 'Show checkboxes for bulk citation export')}
-                    onClick={() => {
-                      setSelectMode((m) => !m);
-                      setSelected(new Set());
-                    }}
-                  >
-                    <Icon name="check" size={13} />
-                    {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
-                  </button>
-                  {selectMode && (
+              {/* —— 底部操作栏：多选（删除 / 导出）+ 回收站入口，与实验室文献库 / 相关研究同款 —— */}
+              <div
+                className="row gap8"
+                style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
+              >
+                {/* 多选只对「我的收藏」有意义：浏览记录是流水，不做批量 */}
+                {tab === 'saved' && (
+                  <>
                     <button
-                      className="btn btn-ghost sm"
-                      disabled={selected.size === 0 || exportMutation.isPending}
-                      onClick={() => exportMutation.mutate()}
+                      className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
+                      title={tr(
+                        '开启后列表出现复选框，可批量删除 / 导出引用',
+                        'Show checkboxes for bulk delete / citation export',
+                      )}
+                      onClick={() => {
+                        setSelectMode((m) => !m);
+                        setSelected(new Map());
+                      }}
                     >
-                      <Icon name="download" size={12} />
-                      {tr('导出 BibTeX', 'Export BibTeX')}
+                      <Icon name="check" size={13} />
+                      {selectMode
+                        ? tr(`已选 ${selected.size} 篇`, `${selected.size} selected`)
+                        : tr('多选', 'Select')}
                     </button>
+                    {selectMode && (
+                      <>
+                        <button
+                          className="btn btn-ghost sm"
+                          style={{ color: 'var(--danger-tx)' }}
+                          title={tr('移入回收站（可召回）', 'Move to trash (restorable)')}
+                          disabled={selected.size === 0 || bulkUnsaveMutation.isPending}
+                          onClick={() => bulkUnsaveMutation.mutate([...selected.keys()])}
+                        >
+                          <Icon name="x" size={12} />
+                          {tr('删除', 'Delete')}
+                        </button>
+                        <button
+                          className="btn btn-ghost sm"
+                          disabled={selected.size === 0 || exportMutation.isPending}
+                          onClick={() => exportMutation.mutate()}
+                        >
+                          <Icon name="download" size={12} />
+                          {tr('导出 BibTeX', 'Export BibTeX')}
+                        </button>
+                      </>
+                    )}
+                  </>
+                )}
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ marginLeft: 'auto' }}
+                  title={tr(
+                    '回收站：取消收藏的文献可以召回或彻底删除',
+                    'Trash: unsaved papers — restore or delete forever',
                   )}
-                </div>
-              )}
+                  onClick={() => setTrashOpen(true)}
+                >
+                  <Icon name="trash" size={13} />
+                  {tr('回收站', 'Trash')}
+                </button>
+              </div>
             </div>
 
             {/* —— 右：详情 —— */}
@@ -956,7 +1032,7 @@ export function LibraryPage() {
         title={tr('清空浏览记录？', 'Clear reading history?')}
         message={tr(
           '将删除全部浏览记录；已收藏的文献留在「我的收藏」，回收站里的条目也不受影响。此操作不可撤销。',
-          'All reading history will be deleted. Saved papers stay in the Saved tab and the Trash tab is left alone. This cannot be undone.',
+          'All reading history will be deleted. Saved papers stay in Saved and the trash is left alone. This cannot be undone.',
         )}
         confirmText={tr('清空', 'Clear')}
         danger
@@ -964,20 +1040,8 @@ export function LibraryPage() {
         onConfirm={() => clearMutation.mutate()}
       />
 
-      {/* —— 清空回收站确认 —— */}
-      <ConfirmModal
-        open={emptyTrashOpen}
-        onClose={() => setEmptyTrashOpen(false)}
-        title={tr('清空回收站？', 'Empty trash?')}
-        message={tr(
-          '将彻底删除回收站里的全部条目，删掉之后没法再召回。',
-          'Everything in the trash will be deleted for good — nothing can be restored afterwards.',
-        )}
-        confirmText={tr('清空回收站', 'Empty trash')}
-        danger
-        busy={emptyTrashMutation.isPending}
-        onConfirm={() => emptyTrashMutation.mutate()}
-      />
+      {/* —— 回收站（取消收藏的条目：召回 / 彻底删除 / 清空） —— */}
+      <PersonalTrashModal open={trashOpen} onClose={() => setTrashOpen(false)} />
     </div>
   );
 }

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -14,7 +14,7 @@ import { clickable } from '../../lib/a11y';
 import { api, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
-import { PaperMyTagsRow, PaperTagsRow } from '../shared/PaperDetailBlocks';
+import { PaperMyTagsRow } from '../shared/PaperDetailBlocks';
 
 /* ============================================================
    阅读工作台 · 论文信息面板（PaperDetailPane 的精简版）：
@@ -182,9 +182,14 @@ export function InfoPanel({
         </MetaItem>
       </div>
 
-      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签边读边打 —— */}
-      <PaperTagsRow tags={paper.tags} style={{ marginTop: 12 }} />
-      <PaperMyTagsRow paperId={paper.id} myTags={paper.my_tags} detailKey={['paper', paper.id]} />
+      {/* —— 我的标签：边读边打，只有自己看得到 —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
+      <PaperMyTagsRow
+        paperId={paper.id}
+        myTags={paper.my_tags}
+        detailKey={['paper', paper.id]}
+        style={{ marginTop: 12 }}
+      />
 
       {/* —— 概念 chips —— */}
       {paper.concepts.length > 0 && (

--- a/src/frontend/src/features/research/AddPaperModal.tsx
+++ b/src/frontend/src/features/research/AddPaperModal.tsx
@@ -11,7 +11,7 @@ import { parsePaperRef } from '../../lib/paper-ref';
 import { SearchInput, useDebounced } from '../wiki/shared';
 
 /* ============================================================
-   相关研究 · 「添加论文」统一入口（弹窗，两个页签）：
+   相关研究 · 「添加文献」统一入口（弹窗，两个页签）：
    - 从文献库：检索当前课题关联的文献库，结果行内一键添加，
      已入架的显示勾选态；找不到时引导切到手动添加。
    - 手动添加：arXiv 编号 / DOI，平台自动查重（池里已有直接
@@ -85,7 +85,7 @@ export function AddPaperModal({
       open={open}
       onClose={onClose}
       width={600}
-      title={tr('添加论文', 'Add papers')}
+      title={tr('添加文献', 'Add paper')}
       sub={tr('加入这个课题的相关研究，可以连续添加多篇。', 'Add to related work for this topic — add several in a row.')}
     >
       <Segmented<AddTab> options={TABS.map((t) => ({ v: t.v, label: tr(t.zh, t.en) }))} value={tab} onChange={setTab} />

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -146,7 +146,7 @@ function ShelfRow({
           checked={checked}
           onClick={(e) => e.stopPropagation()}
           onChange={onToggleCheck}
-          title={tr('选中后可批量导出引用', 'Select for bulk citation export')}
+          title={tr('选中后可批量移出 / 导出引用', 'Select for bulk remove / citation export')}
           style={{
             width: 13,
             height: 13,
@@ -683,6 +683,29 @@ export function ResearchPage() {
     onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
   });
 
+  // 多选批量移出：后端没有批量端点，按选中集逐篇调（同样是软删，落回收站）
+  const bulkRemoveMutation = useMutation({
+    mutationFn: async (paperIds: string[]) => {
+      await Promise.all(paperIds.map((paperId) => api.removeFromShelf(pid, paperId)));
+      return paperIds.length;
+    },
+    onSuccess: (n, paperIds) => {
+      toast(
+        tr(
+          `已把 ${n} 篇移入回收站，可以召回（个人库收藏保留）`,
+          `Moved ${n} papers to trash — restorable (saved copies stay)`,
+        ),
+        'ok',
+      );
+      setSelId((old) => (old && paperIds.includes(old) ? null : old));
+      setCheckedIds(new Set());
+      setSelectMode(false);
+      invalidate();
+      void queryClient.invalidateQueries({ queryKey: ['shelf-trash', pid] });
+    },
+    onError: (e) => toast(`${tr('移除失败：', 'Failed to remove: ')}${errText(e)}`, 'error'),
+  });
+
   // 个人版 wiki 按需生成（wiki_source=none 的论文；费用记个人额度）
   const generateMutation = useMutation({
     mutationFn: (paperId: string) => api.compilePersonalWiki(paperId, pid),
@@ -741,11 +764,12 @@ export function ResearchPage() {
       <PageHead
         eyebrow="Polaris · Related Work"
         title={tr('相关研究', 'Related Work')}
+        dense
         right={
           tab === 'list' ? (
             <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
               <Icon name="plus" size={13} />
-              {tr('添加论文', 'Add papers')}
+              {tr('添加文献', 'Add paper')}
             </button>
           ) : undefined
         }
@@ -998,47 +1022,6 @@ export function ResearchPage() {
               )}
             </div>
 
-            {/* —— 底部操作栏：多选 + 导出 BibTeX（常驻，对齐文献库 PapersTab） —— */}
-            <div
-              className="row gap8"
-              style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
-            >
-              <button
-                className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
-                title={tr('开启后列表出现复选框，可批量导出引用', 'Show checkboxes to bulk-export citations')}
-                onClick={() => {
-                  setSelectMode((m) => !m);
-                  setCheckedIds(new Set());
-                }}
-              >
-                <Icon name="check" size={13} />
-                {selectMode ? tr(`已选 ${checkedIds.size}`, `${checkedIds.size} selected`) : tr('多选', 'Select')}
-              </button>
-              {selectMode && (
-                <button
-                  className="btn btn-ghost sm"
-                  disabled={checkedIds.size === 0 || exportMutation.isPending}
-                  onClick={() => exportMutation.mutate()}
-                >
-                  {exportMutation.isPending ? (
-                    <Icon name="refresh" size={12} style={{ animation: 'spin 1s linear infinite' }} />
-                  ) : (
-                    <Icon name="download" size={12} />
-                  )}
-                  {tr('导出 BibTeX', 'Export BibTeX')}
-                </button>
-              )}
-              <button
-                className="btn btn-ghost sm"
-                style={{ marginLeft: 'auto' }}
-                title={tr('回收站：移出的论文可以召回或彻底删除', 'Trash: removed papers — restore or delete forever')}
-                onClick={() => setTrashOpen(true)}
-              >
-                <Icon name="trash" size={13} />
-                {tr('回收站', 'Trash')}
-              </button>
-            </div>
-
             {/* 底部分页栏（超过单页上限 100 才出现；语义结果不分页） */}
             {!semantic && totalPages > 1 && (
               <div
@@ -1067,6 +1050,56 @@ export function ResearchPage() {
                 </button>
               </div>
             )}
+            {/* —— 底部操作栏：多选（删除 / 导出）+ 回收站入口，与文献工作台 / 我的文献库同款 —— */}
+            <div
+              className="row gap8"
+              style={{ padding: '9px 14px', borderTop: '0.5px solid var(--border)', flexShrink: 0 }}
+            >
+              <button
+                className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
+                title={tr('开启后列表出现复选框，可批量移出 / 导出引用', 'Show checkboxes for bulk remove / citation export')}
+                onClick={() => {
+                  setSelectMode((m) => !m);
+                  setCheckedIds(new Set());
+                }}
+              >
+                <Icon name="check" size={13} />
+                {selectMode
+                  ? tr(`已选 ${checkedIds.size} 篇`, `${checkedIds.size} selected`)
+                  : tr('多选', 'Select')}
+              </button>
+              {selectMode && (
+                <>
+                  <button
+                    className="btn btn-ghost sm"
+                    style={{ color: 'var(--danger-tx)' }}
+                    title={tr('移入回收站（可召回，个人库收藏保留）', 'Move to trash (restorable, saved copies stay)')}
+                    disabled={checkedIds.size === 0 || bulkRemoveMutation.isPending}
+                    onClick={() => bulkRemoveMutation.mutate([...checkedIds])}
+                  >
+                    <Icon name="x" size={12} />
+                    {tr('删除', 'Delete')}
+                  </button>
+                  <button
+                    className="btn btn-ghost sm"
+                    disabled={checkedIds.size === 0 || exportMutation.isPending}
+                    onClick={() => exportMutation.mutate()}
+                  >
+                    <Icon name="download" size={12} />
+                    {tr('导出 BibTeX', 'Export BibTeX')}
+                  </button>
+                </>
+              )}
+              <button
+                className="btn btn-ghost sm"
+                style={{ marginLeft: 'auto' }}
+                title={tr('回收站：移出的论文可以召回或彻底删除', 'Trash: removed papers — restore or delete forever')}
+                onClick={() => setTrashOpen(true)}
+              >
+                <Icon name="trash" size={13} />
+                {tr('回收站', 'Trash')}
+              </button>
+            </div>
           </div>
 
           {/* —— 右：详情 / 空态引导 —— */}
@@ -1105,7 +1138,7 @@ export function ResearchPage() {
                     <div className="row gap10" style={{ justifyContent: 'center' }}>
                       <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
                         <Icon name="plus" size={13} />
-                        {tr('添加论文', 'Add papers')}
+                        {tr('添加文献', 'Add paper')}
                       </button>
                       <button className="btn btn-soft sm" onClick={() => navigate(libEntryHref)}>
                         <Icon name="book" size={13} />
@@ -1125,7 +1158,7 @@ export function ResearchPage() {
         )}
       </div>
 
-      {/* —— 添加论文（从文献库 / 手动）统一弹窗 —— */}
+      {/* —— 添加文献（从文献库 / 手动）统一弹窗 —— */}
       <AddPaperModal
         open={addOpen}
         onClose={() => setAddOpen(false)}

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -22,7 +22,6 @@ import {
   PaperMyMetaRow,
   PaperMyTagsRow,
   PaperNotesSection,
-  PaperTagsRow,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
 
@@ -503,8 +502,8 @@ export function ShelfDetailPane({
         />
       )}
 
-      {/* —— 标签：库标签只读（编辑在文献工作台）+ 我的标签就地改 —— */}
-      <PaperTagsRow tags={paper?.tags} />
+      {/* —— 我的标签：就地改，只有自己看得到 —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       {paper && (
         <PaperMyTagsRow
           paperId={item.paper_id}

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -85,13 +85,12 @@ export function PaperMyMetaRow({
   );
 }
 
-/* ---------------- 标签：库标签（只读）+ 我的标签（可编辑） ---------------- */
+/* ---------------- 标签：我的标签 ---------------- */
 
-/* 两组标签是两回事，样式上一眼分开：
-   - 库标签＝实心底色（.tag 默认样式），整个文献库共用一套，编辑在文献工作台；
-   - 我的标签＝描边 + 强调色，只有自己看得到，哪儿都能改。 */
+/* 库标签（库作用域共享标签）的界面入口已移除——它是整组覆盖的共享状态，
+   一个人改会冲掉别人的；个人标签取代了它。后端端点与数据保留。 */
 
-/** 我的标签 chip 的描边样式（区别于实心的库标签）。 */
+/** 我的标签 chip 的描边样式。 */
 const myTagStyle: CSSProperties = {
   background: 'transparent',
   borderColor: 'var(--accent-soft-2)',
@@ -100,24 +99,6 @@ const myTagStyle: CSSProperties = {
   alignItems: 'center',
   gap: 4,
 };
-
-/** 库标签只读展示（编辑在文献工作台）；没有标签就不占位。 */
-export function PaperTagsRow({ tags, style }: { tags: string[] | undefined; style?: CSSProperties }) {
-  if (!tags || tags.length === 0) return null;
-  return (
-    <div className="row gap6 wrap" style={{ marginTop: 14, ...style }}>
-      <span className="row gap6 mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}>
-        <Icon name="users" size={11} />
-        {tr('库标签', 'Library tags')}
-      </span>
-      {tags.map((t) => (
-        <span key={t} className="tag">
-          {t}
-        </span>
-      ))}
-    </div>
-  );
-}
 
 /**
  * 我的标签：就地增删，只有本人可见可改。
@@ -222,19 +203,16 @@ export function PaperMyTagsRow({
   );
 }
 
-/** 列表行里的标签小 chip：库标签实心 / 我的标签描边，最多各显 2 个。 */
-export function PaperTagChips({
-  tags,
+/** 列表行里的我的标签小 chip（描边），最多显 2 个，多的折成 +N。 */
+export function PaperMyTagChips({
   myTags,
   limit = 2,
 }: {
-  tags: string[] | undefined;
   myTags: string[] | undefined;
   limit?: number;
 }) {
-  const lib = tags ?? [];
   const mine = myTags ?? [];
-  const hidden = Math.max(0, lib.length - limit) + Math.max(0, mine.length - limit);
+  const hidden = Math.max(0, mine.length - limit);
   const chipStyle: CSSProperties = {
     fontSize: 10,
     height: 17,
@@ -248,11 +226,6 @@ export function PaperTagChips({
   };
   return (
     <>
-      {lib.slice(0, limit).map((t) => (
-        <span key={`lib-${t}`} className="tag" style={chipStyle} title={tr(`库标签：${t}`, `Library tag: ${t}`)}>
-          {t}
-        </span>
-      ))}
       {mine.slice(0, limit).map((t) => (
         <span
           key={`my-${t}`}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -40,7 +40,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
-import { PaperMyTagsRow, PaperTagChips } from '../shared/PaperDetailBlocks';
+import { PaperMyTagChips, PaperMyTagsRow } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
@@ -323,7 +323,7 @@ export function ExportMenu({
   /** 库作用域（走 /libraries/{id}/export/*，独立库也可用）；优先于 pid */
   libraryId?: string;
   /** 列表过滤条件，透传给课题版引用导出；不传导出全部库内文献（库版不支持过滤） */
-  filters?: { status?: PaperStatusFilter; tag?: string; starred?: boolean };
+  filters?: { status?: PaperStatusFilter; starred?: boolean };
 }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -636,7 +636,7 @@ const PaperRow = memo(function PaperRow({
       <div className="row gap8" style={{ marginTop: 6 }}>
         <PaperStatusPill status={p.status} sm />
         <ReadingDot status={p.reading_status} />
-        <PaperTagChips tags={p.tags} myTags={p.my_tags} />
+        <PaperMyTagChips myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
           <span
             className="row"
@@ -668,85 +668,6 @@ const PaperRow = memo(function PaperRow({
 }, (prev, next) =>
   prev.p === next.p && prev.active === next.active && prev.checked === next.checked && prev.selectMode === next.selectMode,
 );
-
-/* ---------------- 库标签就地编辑（共享资产：同库的人看到同一套） ---------------- */
-
-function TagEditor({ paper, scopeId }: { paper: PaperDetail; scopeId: string }) {
-  const queryClient = useQueryClient();
-  const [adding, setAdding] = useState(false);
-  const [value, setValue] = useState('');
-  const tags = paper.tags ?? [];
-
-  const putMutation = useMutation({
-    mutationFn: (names: string[]) => api.putPaperTags(paper.id, names),
-    onSuccess: (p) => {
-      queryClient.setQueryData<PaperDetail>(['paper', scopeId, paper.id], p);
-      void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
-      void queryClient.invalidateQueries({ queryKey: ['project-tags', scopeId] });
-    },
-    onError: (e) =>
-      toast(`${tr('标签更新失败：', 'Tag update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
-
-  const commit = () => {
-    const name = value.trim();
-    setAdding(false);
-    setValue('');
-    if (!name || tags.includes(name)) return;
-    putMutation.mutate([...tags, name]);
-  };
-
-  return (
-    <div className="row gap6 wrap" style={{ marginTop: 14 }}>
-      <span
-        className="row gap6 mono"
-        style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}
-        title={tr('整个文献库共用一套，同库的人都看得到', 'Shared across the library — everyone in it sees these')}
-      >
-        <Icon name="users" size={11} />
-        {tr('库标签', 'Library tags')}
-      </span>
-      {tags.map((t) => (
-        <span key={t} className="tag" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-          {t}
-          <span
-            title={tr('移除标签', 'Remove tag')}
-            style={{ cursor: 'pointer', display: 'inline-flex', opacity: 0.6 }}
-            onClick={() => putMutation.mutate(tags.filter((x) => x !== t))}
-          >
-            <Icon name="x" size={9} />
-          </span>
-        </span>
-      ))}
-      {adding ? (
-        <input
-          className="input"
-          autoFocus
-          style={{ height: 24, fontSize: 11.5, width: 120, padding: '0 8px' }}
-          placeholder={tr('标签名，回车确定', 'Tag name, Enter to confirm')}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onBlur={commit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.nativeEvent.isComposing) commit();
-            if (e.key === 'Escape') {
-              setAdding(false);
-              setValue('');
-            }
-          }}
-        />
-      ) : (
-        <span
-          className="chip"
-          style={{ fontSize: 11, height: 20, opacity: putMutation.isPending ? 0.5 : 1 }}
-          onClick={() => !putMutation.isPending && setAdding(true)}
-        >
-          <Icon name="plus" size={10} style={{ display: 'inline-block', verticalAlign: -1 }} /> {tr('加标签', 'Add tag')}
-        </span>
-      )}
-    </div>
-  );
-}
 
 /* ---------------- 详情面板 ---------------- */
 
@@ -1010,8 +931,8 @@ function PaperDetailPane({
         </span>
       </div>
 
-      {/* —— 标签：库标签（库作用域，同库的人共用）+ 我的标签（只有自己看得到） —— */}
-      <TagEditor paper={paper} scopeId={scopeId} />
+      {/* —— 我的标签（只有自己看得到） —— */}
+      {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       <PaperMyTagsRow
         paperId={paper.id}
         myTags={paper.my_tags}
@@ -1205,8 +1126,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
 
-  // —— 文献管理增强过滤器 ——
-  const [tagFilter, setTagFilter] = useState('');
+  // —— 文献管理增强过滤器（库标签的界面入口已移除，只留我的标签 / 阅读状态） ——
   const [myTagFilter, setMyTagFilter] = useState('');
   const [readingFilter, setReadingFilter] = useState<'' | ReadingStatus>('');
   const [addOpen, setAddOpen] = useState(false);
@@ -1263,7 +1183,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [scopeId, view, q, tagFilter, myTagFilter, readingFilter]);
+  }, [scopeId, view, q, myTagFilter, readingFilter]);
 
   // 重新编译：同步等着（约 1 分钟），用户很可能切走再切回来。
   // 进行中状态按 paper id 记在列表页这一层：详情面板换论文不会丢，多篇同时编译也各记各的。
@@ -1315,27 +1235,18 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
 
   const semanticActive = mode === 'semantic' && q.length > 0;
 
-  // —— 项目标签（过滤下拉用；接口未就绪时静默降级） ——
-  const tagsQuery = useQuery({
-    queryKey: ['project-tags', scopeId],
-    queryFn: () => (libraryId ? api.listLibraryTags(libraryId) : api.listTags(scopeId)),
-    retry: false,
-  });
-  const projectTags = tagsQuery.data ?? [];
-
   // —— 我的标签（过滤下拉用；跨库共用一份，所以 queryKey 不带 scopeId） ——
   const myTagsQuery = useQuery({ queryKey: ['my-tags'], queryFn: () => api.listMyTags(), retry: false });
   const myTags = myTagsQuery.data ?? [];
 
   // —— 关键词/浏览：分页列表 ——
   const listQuery = useInfiniteQuery({
-    queryKey: ['papers', scopeId, view, q, sort, tagFilter, myTagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
+    queryKey: ['papers', scopeId, view, q, sort, myTagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
     queryFn: ({ pageParam }) => {
       const opts = {
         ...viewQuery(view),
         q: q || undefined,
         sort,
-        tag: tagFilter || undefined,
         my_tag: myTagFilter || undefined,
         reading_status: readingFilter || undefined,
         author: author || undefined,
@@ -1375,7 +1286,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   const isError = semanticActive ? semQuery.isError : listQuery.isError;
   const fallbackNotice = semanticActive && semQuery.data && semQuery.data.mode_used === 'keyword';
 
-  const hasFilter = !!q || view !== 'all' || !!tagFilter || !!myTagFilter || !!readingFilter || advActive;
+  const hasFilter = !!q || view !== 'all' || !!myTagFilter || !!readingFilter || advActive;
 
   // 列表变化后自动选中第一篇
   const firstId = papers[0]?.id ?? null;
@@ -1513,32 +1424,9 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                 {tr(f.zh, f.en)}
               </span>
             ))}
-            <span
-              className="chip"
-              style={{ marginLeft: 'auto', gap: 5 }}
-              title={tr('回收站：已删除的文献，可召回或彻底删除', 'Trash: deleted papers — restore or delete forever')}
-              onClick={() => setTrashOpen(true)}
-            >
-              <Icon name="trash" size={12} />
-              {tr('回收站', 'Trash')}
-            </span>
           </div>
-          {/* 库标签（库作用域，课题/独立库通用）/ 我的标签 / 阅读状态过滤 */}
+          {/* 我的标签 / 阅读状态过滤（库标签的界面入口已移除） */}
           <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
-            <select
-              className="input"
-              style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
-              value={tagFilter}
-              onChange={(e) => setTagFilter(e.target.value)}
-              title={tr('按库标签过滤（同库的人共用一套）', 'Filter by library tag (shared across the library)')}
-            >
-              <option value="">{tr('全部库标签', 'All library tags')}</option>
-              {projectTags.map((t) => (
-                <option key={t.id} value={t.name}>
-                  {t.name}（{t.paper_count}）
-                </option>
-              ))}
-            </select>
             <select
               className="input"
               style={{ height: 26, fontSize: 11.5, flex: 1, minWidth: 0, padding: '0 6px' }}
@@ -1682,7 +1570,9 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
             }}
           >
             <Icon name="check" size={13} />
-            {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
+            {selectMode
+              ? tr(`已选 ${selected.size} 篇`, `${selected.size} selected`)
+              : tr('多选', 'Select')}
           </button>
           {selectMode && (
             <>
@@ -1705,6 +1595,15 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
               </button>
             </>
           )}
+          <button
+            className="btn btn-ghost sm"
+            style={{ marginLeft: 'auto' }}
+            title={tr('回收站：已删除的文献可以召回或彻底删除', 'Trash: deleted papers — restore or delete forever')}
+            onClick={() => setTrashOpen(true)}
+          >
+            <Icon name="trash" size={13} />
+            {tr('回收站', 'Trash')}
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
The shared library, my library and a topic's related work had each grown their own list controls. This settles them on one shape.

- **The recycle bin moves into the multi-select row** everywhere. My library loses its separate tab for it; the workbench's moves down out of the view-chip row. All three use the shared modal, with the shelf's visual treatment as the reference.
- **Multi-select reads delete-then-export** everywhere, matching wording and spacing.
- **The shared library's view chips** (all / compiled / starred) fold into the advanced panel, merging with the starred checkbox already there. A non-default view now counts as an active filter, so collapsing the panel still shows the dot that says a filter is on.
- **"Add paper" is the same button** in both places it appears.

## Library tags lose their UI

They were library-scoped shared state written as a whole-set replace — one person's edit wiped what everyone else filed. Personal tags replace them.

**Only the interface is removed.** The endpoints, the table and every existing row are untouched, and each removal site carries a comment saying so. Personal tags (`my_tags`, the editor, the filter) are not affected.

Left with no callers: `api.listTags` / `listLibraryTags` / `putPaperTags`, the `tag` query param on list and citation-export calls, and the `['project-tags']` / `['lib-tags']` query keys. `PaperRead.tags` still exists in the type, just unread.

If those existing library tags are worth keeping, they'd need a migration converting them into someone's personal tags — and "whose?" has no answer in the data, since they're shared and carry no author. Say the word and I'll work it out.

## Two things worth knowing

**The read-only library browser gets no recycle bin.** Restore and purge are manage-scoped, so a reader would only find a button that 403s. The bin lives in the workbench — which is what someone who *can* manage that library sees. If you want readers to see the bin read-only, the backend has to open the listing up first.

**Bulk delete fans out one request per paper** on the shelf and personal library — neither has a batch endpoint. Fine for a handful; worth a real endpoint if it becomes common.

## Verification

`tsc --noEmit` 0 errors, `vite build` passes.