### PR TITLE
feat(daily): run the daily paper sync as a task

### DIFF
--- a/src/backend/app/agents/voyage/__init__.py
+++ b/src/backend/app/agents/voyage/__init__.py
@@ -5,6 +5,7 @@
 """
 
 from app.agents.voyage import (
+    actions_daily,  # noqa: F401  注册 daily.*（每日新论文抓取）动作
     actions_experiment,  # noqa: F401  注册 experiment.* 动作
     actions_ideas,  # noqa: F401  注册 forge.* / review.pair 等辩论动作
     actions_present,  # noqa: F401  注册 present.*（论文分享 PPT）动作

--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -1,0 +1,101 @@
+"""每日新论文抓取动作（Voyage kind ``daily_feed_sync`` 的固定计划执行体）。
+
+流水线（navigator.daily_feed_plan）：
+    daily.fetch → daily.upsert → daily.cleanup → daily.embed
+
+设计约定：
+- 抓取/去重/清理全是确定性代码，不走 LLM；只有最后一步的向量化会花配额；
+- 跨步骤传值走 ``ctx.checkpoint``（抓到的条目 / 本次涉及的论文 id），断点续跑时
+  引擎会把 checkpoint 原样带回来；
+- ``daily.fetch`` 全分类颗粒无收即报错：arXiv 客户端把网络/解析失败兜底成 []
+  （见 services/literature/arxiv.py），以前这类失败被整个吞掉，纳入任务系统后
+  让这一步失败 → 任务进 paused_error，列表看得见、日志查得到、可以重试；
+- ``daily.embed`` 保持 best-effort：向量化是可选增强，失败不该让整次同步算失败。
+"""
+
+import logging
+import uuid
+from typing import Any
+
+from app.agents.voyage.actions import ActionContext, register
+from app.core.db import get_sessionmaker
+from app.services import daily_feed as daily_feed_service
+
+logger = logging.getLogger(__name__)
+
+
+# ---- 1. 抓取订阅分类的当天新公告 ----
+
+
+@register("daily.fetch")
+async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    async with get_sessionmaker()() as session:
+        categories, by_category = await daily_feed_service.fetch_new_by_category(session)
+
+    per_category = {c: len(entries) for c, entries in by_category.items()}
+    fetched = sum(per_category.values())
+    for category, count in per_category.items():
+        await ctx.log(f"{category}：抓到 {count} 篇")
+
+    # 条目原样带给下一步（daily.upsert）：重抓一次既多打一遍 arXiv，也可能拿到不同结果
+    ctx.checkpoint["daily_entries"] = by_category
+
+    result: dict[str, Any] = {
+        "categories": categories,
+        "fetched": fetched,
+        "per_category": per_category,
+    }
+    if categories and fetched == 0:
+        # 单个分类为空是正常的（周末/当天无公告），但全部分类都空基本只有一种解释：
+        # arXiv 抓不动了（客户端已把异常兜底成 []）。报错而不是假装成功。
+        result["error"] = (
+            f"{len(categories)} 个订阅分类都没抓到新论文，"
+            "多半是 arXiv 暂时不可用或分类配置有误；稍后重试"
+        )
+    return result
+
+
+# ---- 2. 去重入池 + 建/合并推送条目 ----
+
+
+@register("daily.upsert")
+async def upsert(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    by_category = ctx.checkpoint.get("daily_entries") or {}
+    async with get_sessionmaker()() as session:
+        stats = await daily_feed_service.upsert_entries(session, by_category=by_category)
+
+    touched = [str(pid) for pid in stats["touched"]]
+    ctx.checkpoint["daily_touched_papers"] = touched
+    ctx.checkpoint.pop("daily_entries", None)  # 已入池，不必再占着 checkpoint
+    await ctx.log(f"新增 {stats['created']} 篇，合并分类 {stats['merged']} 篇")
+    return {"created": stats["created"], "merged": stats["merged"], "papers": len(touched)}
+
+
+# ---- 3. 清理过期推送（含无人收藏论文的回收） ----
+
+
+@register("daily.cleanup")
+async def cleanup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    async with get_sessionmaker()() as session:
+        expired = await daily_feed_service.cleanup_expired(session)
+        await session.commit()
+    await ctx.log(f"清理过期推送 {expired} 条")
+    return {"expired": expired}
+
+
+# ---- 4. 建立语义向量（管理员开关，默认关） ----
+
+
+@register("daily.embed")
+async def embed(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    raw = ctx.checkpoint.get("daily_touched_papers") or []
+    paper_ids = [uuid.UUID(str(pid)) for pid in raw]
+    async with get_sessionmaker()() as session:
+        stats = await daily_feed_service.embed_touched_papers(
+            session, paper_ids=paper_ids, user_id=ctx.run.created_by
+        )
+    if not stats["enabled"]:
+        await ctx.log("未开启自动建向量，跳过")
+    else:
+        await ctx.log(f"建立向量 {stats['embedded']} 篇")
+    return stats

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -95,6 +95,27 @@ def wiki_plan(run: VoyageRun) -> list[dict[str, Any]]:
     ]
 
 
+def daily_feed_plan(run: VoyageRun) -> list[dict[str, Any]]:
+    """每日新论文抓取固定四步计划（app/agents/voyage/actions_daily.py）。"""
+    steps = [
+        ("抓取订阅分类的新论文", "daily.fetch", "订阅分类的当天新公告已抓到"),
+        ("去重入池", "daily.upsert", "新论文已入池，多分类命中已合并"),
+        ("清理过期推送", "daily.cleanup", "7 天外的推送与无人收藏的论文已清理"),
+        ("建立语义向量", "daily.embed", "开了自动建向量时，本次新论文已补上向量"),
+    ]
+    return [
+        {
+            "title": title,
+            "action": action,
+            "params": {},
+            "acceptance": acceptance,
+            "checks": [{"kind": "no_error"}],
+            "requires_gate": None,
+        }
+        for title, action, acceptance in steps
+    ]
+
+
 def forge_plan(run: VoyageRun) -> list[dict[str, Any]]:
     """idea_forge 固定七步计划（docs/api-m3.md §1 + docs/api-idea2.md §1 信号升级）。"""
     steps = [
@@ -595,6 +616,8 @@ class Navigator:
             return demo_plan(run)
         if run.kind in WIKI_KINDS:
             return wiki_plan(run)
+        if run.kind == "daily_feed_sync":
+            return daily_feed_plan(run)
         if run.kind == "idea_forge":
             return forge_plan(run)
         if run.kind == "idea_review":

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -397,7 +397,14 @@ async def refresh(
     user: User = Depends(require_admin),
     queue: TaskQueue = Depends(get_task_queue),
 ) -> dict[str, str]:
-    """手动触发一次同步（验证/补抓用）；job_id 按天去重防重复入队。"""
-    today = dt.datetime.now(dt.UTC).date().isoformat()
-    await queue.enqueue("daily_feed_sync", _job_id=f"daily-feed-manual-{today}")
-    return {"status": "queued"}
+    """手动触发一次抓取（验证/补抓用）：建任务 + 入队，返回 voyage_id 供跳转任务详情。
+
+    互斥是全局单例——已有一次抓取在跑就 409（比按天去重的 job_id 更准：同一天里
+    上一次失败后仍可立刻重来，而正在跑的绝不会被重复触发）。
+    """
+    try:
+        run = await daily_service.create_daily_feed_voyage(session, created_by=user.id)
+    except daily_service.DailyFeedConflictError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="DAILY_FEED_RUNNING") from e
+    await queue.enqueue("run_voyage", str(run.id))
+    return {"status": "queued", "voyage_id": str(run.id)}

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -47,6 +47,7 @@ PIPELINE_KINDS = frozenset(
     {
         "wiki_bootstrap",
         "wiki_ingest",
+        "daily_feed_sync",
         "idea_forge",
         "idea_review",
         "paper_writing",
@@ -60,7 +61,8 @@ TEMPLATE_KINDS = frozenset({"idea_proposal"})
 # 建库 / 增量更新是文献库自己的事，与课题无关（课题只是关联库来用语料），
 # 所以它们在实验室工作台看，不进课题的任务列表。按 kind 判而不是按
 # library_id：库化改造前建的存量任务只挂了课题，没有 library_id。
-LIBRARY_KINDS = frozenset({"wiki_bootstrap", "wiki_ingest"})
+# 每日新论文抓取同理（更彻底：全实验室共享，两个作用域 id 都为空）。
+LIBRARY_KINDS = frozenset({"wiki_bootstrap", "wiki_ingest", "daily_feed_sync"})
 
 
 def mode_for_kind(kind: str) -> str:

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -34,6 +34,7 @@ from app.models.paper import Paper
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.services import projects as projects_service
 from app.services import topic_shelf as shelf_service
 from app.services import user_library
@@ -273,17 +274,38 @@ async def cleanup_expired(session: AsyncSession, *, today: dt.date | None = None
     return len(expired_ids)
 
 
-async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
-    """抓订阅分类的当天新公告入池 + 清理过期；幂等（同日重跑 created=0）。"""
-    categories = await get_categories(session)
-    today = _today_utc()
-    client = get_arxiv_client()
-    fetched = created = 0
-    touched: list[uuid.UUID] = []  # 本次同步涉及的池论文（开了自动建向量时补嵌用）
+async def fetch_new_by_category(
+    session: AsyncSession,
+) -> tuple[list[str], dict[str, list[dict[str, Any]]]]:
+    """抓订阅分类的当天新公告；返回 (分类列表, {分类: 条目列表})。
 
+    单个分类抓取/解析失败已在 arXiv 客户端内兜底成 []（不让整步崩），所以「某个分类
+    为空」是正常结果；调用方按「全部分类都空」判定这一步整体失败（见 daily.fetch）。
+    """
+    categories = await get_categories(session)
+    client = get_arxiv_client()
+    by_category: dict[str, list[dict[str, Any]]] = {}
     for category in categories:
-        entries = await client.fetch_new(category)  # 失败已在客户端兜底为 []
-        fetched += len(entries)
+        by_category[category] = await client.fetch_new(category)
+    return categories, by_category
+
+
+async def upsert_entries(
+    session: AsyncSession,
+    *,
+    by_category: dict[str, list[dict[str, Any]]],
+    today: dt.date | None = None,
+) -> dict[str, Any]:
+    """RSS 条目 → 全局内容池去重 + 建/合并推送 entry；返回 {created, merged, touched}。
+
+    同一篇多分类命中（cross-list）合并进 categories、不重复建行；paper_id 唯一约束
+    保证同日重跑幂等（created=0）。``touched`` 是本次涉及的池论文 id（补向量用）。
+    """
+    feed_date = today or _today_utc()
+    created = merged = 0
+    touched: list[uuid.UUID] = []
+
+    for category, entries in by_category.items():
         for entry in entries:
             title = (entry.get("title") or "").strip()
             arxiv_id = entry.get("arxiv_id")
@@ -315,7 +337,7 @@ async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
                 session.add(
                     DailyFeedEntry(
                         paper_id=paper.id,
-                        feed_date=today,
+                        feed_date=feed_date,
                         primary_category=category,
                         categories=[category],
                         announce_type=entry.get("announce_type") or "new",
@@ -325,29 +347,105 @@ async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
             elif category not in (row.categories or []):
                 # 同日另一分类命中（cross-list）：合并分类，不动 feed_date
                 row.categories = [*(row.categories or []), category]
+                merged += 1
 
-    expired = await cleanup_expired(session, today=today)
     await session.commit()
+    return {"created": created, "merged": merged, "touched": touched}
 
-    # 建向量（管理员开关，默认关）：只嵌本次涉及且还没向量的论文，费用记系统账。
-    # best-effort——嵌入出问题不影响同步本身的结果。
-    embedded = 0
+
+async def embed_touched_papers(
+    session: AsyncSession,
+    *,
+    paper_ids: list[uuid.UUID],
+    user_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """开了管理员开关才给本次涉及的池论文补建向量；返回 {enabled, embedded, failed}。
+
+    best-effort：向量化本来就是可选增强，失败只记日志并把原因放进 ``embed_error``
+    （不放 ``error``——那会让任务这一步判失败）。
+    """
     try:
-        if await get_daily_embed_enabled(session):
-            stats = await embed_papers_missing_vectors(session, paper_ids=touched)
-            embedded = stats["embedded"]
+        if not await get_daily_embed_enabled(session):
+            return {"enabled": False, "embedded": 0, "failed": 0}
+        stats = await embed_papers_missing_vectors(
+            session, paper_ids=paper_ids, user_id=user_id
+        )
+        return {"enabled": True, "embedded": stats["embedded"], "failed": stats["failed"]}
     except asyncio.CancelledError:
         raise
-    except Exception:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001
         logger.warning("daily feed embedding step failed", exc_info=True)
+        return {"enabled": True, "embedded": 0, "failed": 0, "embed_error": str(e)}
 
+
+async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
+    """抓订阅分类的当天新公告入池 + 清理过期；幂等（同日重跑 created=0）。
+
+    直连入口（不建任务），供脚本/测试一把梭；线上走任务系统的 daily.* 四步动作
+    （app/agents/voyage/actions_daily.py），两条路径共用下面这几个步骤函数。
+    """
+    today = _today_utc()
+    categories, by_category = await fetch_new_by_category(session)
+    fetched = sum(len(v) for v in by_category.values())
+    stats = await upsert_entries(session, by_category=by_category, today=today)
+    expired = await cleanup_expired(session, today=today)
+    await session.commit()
+    embed = await embed_touched_papers(session, paper_ids=stats["touched"])
     return {
         "fetched": fetched,
-        "created": created,
+        "created": stats["created"],
         "expired": expired,
         "categories": categories,
-        "embedded": embedded,
+        "embedded": embed["embedded"],
     }
+
+
+# ---- 每日同步任务（voyage kind=daily_feed_sync） ----
+
+DAILY_FEED_VOYAGE_KIND = "daily_feed_sync"
+
+
+class DailyFeedConflictError(Exception):
+    """已有一个每日新论文抓取任务在跑（全局单例，无库/课题维度）。"""
+
+
+async def find_running_daily_feed_voyage(session: AsyncSession) -> VoyageRun | None:
+    """在跑的每日新论文抓取任务（全局唯一）；没有返回 None。"""
+    stmt = (
+        select(VoyageRun)
+        .where(
+            VoyageRun.kind == DAILY_FEED_VOYAGE_KIND,
+            VoyageRun.status.not_in(tuple(TERMINAL_STATUSES)),
+        )
+        .order_by(VoyageRun.created_at.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def create_daily_feed_voyage(
+    session: AsyncSession, *, created_by: uuid.UUID | None
+) -> VoyageRun:
+    """建一次「每日新论文抓取」任务（互斥检查），由调用方入队 run_voyage。
+
+    这个任务既不属于课题也不属于库（全实验室共享的每日推送），两个作用域 id 都为空；
+    可见性口径与订阅分类管理/手动刷新一致——仅平台管理员（services/voyages.py）。
+    只有最后一步「建立语义向量」可能花 token 且量很小，故不设 token 预算。
+    """
+    if await find_running_daily_feed_voyage(session) is not None:
+        raise DailyFeedConflictError(DAILY_FEED_VOYAGE_KIND)
+    run = VoyageRun(
+        kind=DAILY_FEED_VOYAGE_KIND,
+        goal=f"每日新论文抓取（{_today_utc().isoformat()}）",
+        status="planning",
+        cursor=0,
+        budget={"max_tokens": None},
+        created_by=created_by,
+    )
+    session.add(run)
+    await session.commit()
+    await session.refresh(run)
+    return run
 
 
 # ---- 池浏览 ----

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -102,8 +102,9 @@ async def get_voyage(
     """取航程；无访问权视为不存在（返回 None）。
 
     访问权：起源课题成员（项目作用域任务）∪ 可管理其方向库者（P9a 库化任务——独立库
-    无课题，鉴权走库级写权限：成员/策展人/admin）。库级鉴权需要 ``user``（角色/策展人
-    判定），故 API 层传完整 user；仅传 user_id 时退化为项目成员判定。
+    无课题，鉴权走库级写权限：成员/策展人/admin）∪ 平台管理员（平台级任务——两个作用
+    域 id 都为空，如每日新论文抓取）。库级鉴权需要 ``user``（角色/策展人判定），故 API
+    层传完整 user；仅传 user_id 时退化为项目成员判定 + 回查角色。
     """
     stmt = select(VoyageRun).where(VoyageRun.id == voyage_id)
     if with_steps:
@@ -123,6 +124,19 @@ async def get_voyage(
             session, user=user, library=library
         ):
             return run
+    if run.project_id is None and run.library_id is None:
+        # 平台级任务（每日新论文抓取）：既不属于课题也不属于库，上面两条白名单都不
+        # 命中——不放行的话 admin 也会 404，连带日志/SSE/取消/重试全失效。口径与订阅
+        # 分类管理、手动刷新、向量开关一致：仅平台 admin。
+        # 只传 user_id 的调用点回查一次角色（与 _visible_filter 的 is_admin 子句同口径）。
+        role = (
+            user.role
+            if user is not None
+            else (
+                await session.execute(select(User.role).where(User.id == user_id))
+            ).scalar_one_or_none()
+        )
+        return run if role == "admin" else None
     return None
 
 

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -421,9 +421,196 @@ async def test_categories_admin_and_refresh(client, queue_stub):
     )
     assert resp.status_code == 422
 
-    # 手动刷新入队（admin only）
+    # 手动刷新建任务 + 入队（admin only），返回 voyage_id 供前端跳任务详情
     resp = await client.post("/api/daily/refresh", headers=mh)
     assert resp.status_code == 403
     resp = await client.post("/api/daily/refresh", headers=ah)
     assert resp.status_code == 202
-    assert queue_stub.jobs and queue_stub.jobs[0][0] == "daily_feed_sync"
+    voyage_id = resp.json()["voyage_id"]
+    assert queue_stub.jobs == [("run_voyage", (voyage_id,), {})]
+
+    # 全局单例：上一次还在跑时再点 → 409
+    resp = await client.post("/api/daily/refresh", headers=ah)
+    assert resp.status_code == 409 and resp.json()["detail"] == "DAILY_FEED_RUNNING"
+
+
+# ---- 纳入任务系统（kind=daily_feed_sync）----
+
+
+async def test_daily_feed_voyage_is_platform_scoped_and_singleton(client):
+    """建出来的任务：kind 正确、两个作用域 id 都为空；在跑时再建 → 冲突。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    async with get_sessionmaker()() as session:
+        run = await daily_feed.create_daily_feed_voyage(session, created_by=None)
+        assert run.kind == "daily_feed_sync"
+        assert run.project_id is None and run.library_id is None
+        assert run.budget == {"max_tokens": None}
+        run_id = run.id
+
+        with pytest.raises(daily_feed.DailyFeedConflictError):
+            await daily_feed.create_daily_feed_voyage(session, created_by=None)
+
+        # 终态后不再互斥
+        found = await daily_feed.find_running_daily_feed_voyage(session)
+        assert found is not None and found.id == run_id
+        found.status = "done"
+        await session.commit()
+        assert await daily_feed.find_running_daily_feed_voyage(session) is None
+        again = await daily_feed.create_daily_feed_voyage(session, created_by=None)
+        assert again.id != run_id
+
+
+async def test_daily_feed_plan_is_the_four_fixed_steps():
+    from app.agents.voyage.actions import known_actions
+    from app.agents.voyage.navigator import daily_feed_plan
+    from app.models.voyage import VoyageRun, mode_for_kind
+
+    assert mode_for_kind("daily_feed_sync") == "pipeline"
+    plan = daily_feed_plan(VoyageRun(kind="daily_feed_sync", goal="每日新论文抓取"))
+    assert [s["action"] for s in plan] == [
+        "daily.fetch",
+        "daily.upsert",
+        "daily.cleanup",
+        "daily.embed",
+    ]
+    assert all(s["checks"] == [{"kind": "no_error"}] for s in plan)
+    # 动作必须已注册（app.agents.voyage.__init__ 导入 actions_daily），否则引擎查不到表
+    assert {s["action"] for s in plan} <= known_actions()
+
+
+def _action_ctx():
+    """跑单个动作用的最小上下文（无 bus，ctx.log 静默）。"""
+    import app.agents.voyage  # noqa: F401  触发 actions_daily 注册
+    from app.agents.voyage.actions import ActionContext
+    from app.core.llm.router import LLMRouter
+    from app.models.voyage import VoyageRun
+
+    run = VoyageRun(kind="daily_feed_sync", goal="每日新论文抓取", status="executing", cursor=0)
+    run.id = uuid.uuid4()
+    return ActionContext(run=run, llm=LLMRouter(), checkpoint={})
+
+
+async def test_daily_actions_observation_shapes(client, monkeypatch):
+    """四个动作各自的 observation 形状 + 跨步骤用 checkpoint 传值。"""
+    from app.agents.voyage.actions import get_action
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.AI": [
+                    _rss_entry("2607.00061", "Voyage A"),
+                    _rss_entry("2607.00062", "Voyage B"),
+                ],
+                "cs.CL": [_rss_entry("2607.00061", "Voyage A", announce="cross")],
+                "cs.CV": [],
+            }
+        ),
+    )
+    ctx = _action_ctx()
+
+    obs = await get_action("daily.fetch")(ctx, {})
+    assert obs["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
+    assert obs["fetched"] == 3
+    assert obs["per_category"] == {"cs.AI": 2, "cs.CL": 1, "cs.CV": 0}
+    assert "error" not in obs
+    assert ctx.checkpoint["daily_entries"]  # 条目交给下一步
+
+    obs = await get_action("daily.upsert")(ctx, {})
+    assert obs == {"created": 2, "merged": 1, "papers": 3}
+    touched = ctx.checkpoint["daily_touched_papers"]
+    assert len(touched) == 3 and all(isinstance(p, str) for p in touched)  # checkpoint 要可 JSON
+    assert "daily_entries" not in ctx.checkpoint
+
+    # 过期一条 → 清理这一步报出来
+    async with get_sessionmaker()() as session:
+        from sqlalchemy import select
+
+        entry = (await session.execute(select(DailyFeedEntry))).scalars().first()
+        entry.feed_date = entry.feed_date - dt.timedelta(days=8)
+        await session.commit()
+
+    obs = await get_action("daily.cleanup")(ctx, {})
+    assert obs == {"expired": 1}
+
+    # 开关默认关 → 跳过，且不算失败
+    obs = await get_action("daily.embed")(ctx, {})
+    assert obs == {"enabled": False, "embedded": 0, "failed": 0}
+    assert "error" not in obs
+
+
+async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
+    """整条任务跑通：四步依次 passed、run 到 done、论文真的入了池。"""
+    from app.agents.voyage.engine import VoyageEngine
+    from app.core.db import get_sessionmaker
+    from app.core.llm.router import LLMRouter
+    from app.models.voyage import VoyageRun
+    from app.services import daily_feed
+    from tests.conftest import RecordingBus
+
+    await register_and_login(client)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00071", "E2E Paper")]}),
+    )
+
+    async with get_sessionmaker()() as session:
+        run = await daily_feed.create_daily_feed_voyage(session, created_by=None)
+        run_id = run.id
+
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter()).run(run_id)
+
+    async with get_sessionmaker()() as session:
+        from sqlalchemy import select
+        from sqlalchemy.orm import selectinload
+
+        run = (
+            await session.execute(
+                select(VoyageRun)
+                .where(VoyageRun.id == run_id)
+                .options(selectinload(VoyageRun.steps))
+            )
+        ).scalar_one()
+        assert run.status == "done", run.status
+        assert run.mode == "pipeline"
+        assert [s.action for s in run.steps] == [
+            "daily.fetch",
+            "daily.upsert",
+            "daily.cleanup",
+            "daily.embed",
+        ]
+        assert all(s.status == "passed" for s in run.steps)
+
+    token = await register_and_login(client, email="e2e@example.com")
+    resp = await client.get(
+        "/api/daily/papers", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.json()["total"] == 1
+
+
+async def test_daily_fetch_reports_error_when_every_category_is_empty(client, monkeypatch):
+    """全分类颗粒无收 = 抓取多半挂了（客户端把异常兜底成 []）→ 这步必须失败。"""
+    from app.agents.voyage.actions import get_action
+    from app.agents.voyage.checks import run_deterministic_checks
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv({}))
+
+    ctx = _action_ctx()
+    obs = await get_action("daily.fetch")(ctx, {})
+    assert obs["fetched"] == 0
+    assert obs["error"]
+    # no_error 校验会判失败 → 任务进 paused_error（列表红色、可看日志、可重试）
+    verdict, _ = run_deterministic_checks(
+        [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
+    )
+    assert verdict is not None and verdict["passed"] is False

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -125,6 +125,89 @@ async def test_standalone_library_voyage_is_visible_to_its_curator(client):
         assert run_id not in {r.id for r in runs}
 
 
+async def test_platform_voyage_visible_and_openable_by_admin_only(client):
+    """每日新论文抓取：两个作用域 id 都为空 —— admin 列表看得到、详情页打得开。
+
+    详情鉴权原本是白名单式的（要么有 project_id 且是成员，要么有 library_id 且能管库），
+    平台级任务两条都不满足会直接 404，admin 也不例外 —— 那样日志/SSE/取消/重试全废。
+    """
+    admin_email = "vscope-daily-admin@example.com"
+    admin = await _hdr(client, admin_email)  # 第一个注册者占掉平台 admin 位
+    await _promote_admin(admin_email)
+    admin_id = await _user_id(admin_email)
+    member = await _hdr(client, "vscope-daily-member@example.com")
+    member_id = await _user_id("vscope-daily-member@example.com")
+
+    run_id = await _make_run(kind="daily_feed_sync")
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.project_id is None and run.library_id is None
+
+    async with get_sessionmaker()() as session:
+        admin_user = await session.get(User, admin_id)
+        member_user = await session.get(User, member_id)
+        # 列表：admin 看得到（is_admin 子句），普通成员看不到
+        runs = await voyages_service.list_voyages(session, user_id=admin_id)
+        assert run_id in {r.id for r in runs}
+        runs = await voyages_service.list_voyages(session, user_id=member_id)
+        assert run_id not in {r.id for r in runs}
+        # 详情：admin 拿得到，普通成员拿不到
+        assert (
+            await voyages_service.get_voyage(
+                session, voyage_id=run_id, user_id=admin_id, user=admin_user
+            )
+        ) is not None
+        assert (
+            await voyages_service.get_voyage(
+                session, voyage_id=run_id, user_id=member_id, user=member_user
+            )
+        ) is None
+        # 只传 user_id（不传 user）的调用点也要认得出 admin
+        assert (
+            await voyages_service.get_voyage(session, voyage_id=run_id, user_id=admin_id)
+        ) is not None
+        assert (
+            await voyages_service.get_voyage(session, voyage_id=run_id, user_id=member_id)
+        ) is None
+
+    # 走 HTTP 详情页：admin 200，普通成员 404
+    resp = await client.get(f"/api/voyages/{run_id}", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["kind"] == "daily_feed_sync"
+    resp = await client.get(f"/api/voyages/{run_id}", headers=member)
+    assert resp.status_code == 404
+
+
+async def test_platform_voyage_stays_out_of_the_topic_list(client):
+    """课题任务列表不含每日新论文抓取——它是全实验室的事，不属于任何课题。
+
+    正常形态 project_id 就是空、本来也进不了课题列表；这里连「万一挂上了课题」也一并
+    拦住（判据是 kind，与建库/增量更新同款）。
+    """
+    admin_email = "vscope-daily-topic-admin@example.com"
+    await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    admin_id = await _user_id(admin_email)
+    owner = await _hdr(client, "vscope-daily-owner@example.com")
+
+    resp = await client.post(
+        "/api/projects", json={"name": "每日任务不入课题", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    platform_run = await _make_run(kind="daily_feed_sync")
+    attached_run = await _make_run(kind="daily_feed_sync", project_id=project_id)
+
+    async with get_sessionmaker()() as session:
+        runs = await voyages_service.list_voyages(
+            session, user_id=admin_id, project_id=project_id
+        )
+    ids = {r.id for r in runs}
+    assert platform_run not in ids
+    assert attached_run not in ids
+
+
 async def test_new_ingest_voyage_carries_no_project(client):
     """新建的库任务不写 project_id：库任务归库，课题只是关联库来用语料。"""
     from app.schemas.ingest import IngestKnobs

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -126,13 +126,21 @@ async def index_papers_fulltext_task(
         )
 
 
-async def daily_feed_sync(ctx: dict[str, Any]) -> dict[str, Any]:
-    """每日 01:30 cron（arXiv 约 00:00 UTC 发布新公告）：抓订阅分类的 New submissions
-    进每日论文池 + 清理 7 天外过期条目。admin 手动刷新走同一任务（见 api/daily.py）。"""
+async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
+    """每日 01:30 cron（arXiv 约 00:00 UTC 发布新公告）：建一次「每日新论文抓取」任务并入队。
+
+    抓取/入池/清理/建向量四步都在任务系统里跑（kind=daily_feed_sync），有计划、有步骤
+    状态、有日志，失败可见可重试。返回入队的 voyage id；已有任务在跑则跳过（返回 None）。
+    """
     from app.services import daily_feed as daily_feed_service
 
     async with get_sessionmaker()() as session:
-        return await daily_feed_service.sync_daily_feed(session)
+        try:
+            run = await daily_feed_service.create_daily_feed_voyage(session, created_by=None)
+        except daily_feed_service.DailyFeedConflictError:
+            return None  # 并发保护：查表与建 run 之间有 admin 手动触发
+    await ctx["redis"].enqueue_job("run_voyage", str(run.id))
+    return str(run.id)
 
 
 async def daily_publication_match(ctx: dict[str, Any]) -> int:

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4193,4 +4193,11 @@ export const api = {
   setDailyCategories(categories: string[]): Promise<{ categories: string[] }> {
     return requestJson<{ categories: string[] }>('/daily/categories', 'PUT', { categories });
   },
+  /**
+   * 手动触发一次每日新论文抓取（admin）。抓取在任务系统里跑，返回的 voyage_id
+   * 可直接跳任务详情看步骤与日志；409 detail=DAILY_FEED_RUNNING 表示已有一次在跑。
+   */
+  refreshDailyFeed(): Promise<{ status: string; voyage_id: string }> {
+    return request<{ status: string; voyage_id: string }>('/daily/refresh', { method: 'POST' });
+  },
 };


### PR DESCRIPTION
The daily arXiv sync ran as a bare cron function **with no record of ever having run**.

Worse, its failures were invisible: `arxiv.fetch_new` logs a warning and returns `[]` for *any* exception, so a dead category produced "0 new papers today" and a job that looked successful. Cron doesn't retry. There was no state, no activity entry, no UI signal — **a quiet day and a broken fetch looked exactly the same**.

It's now a pipeline voyage with the same plumbing every other task has: per-step observations, terminal logs, cancel, resume.

| Step | Observation |
|---|---|
| `daily.fetch` | per-category counts — **errors when every category comes back empty**, which is the case that used to pass silently |
| `daily.upsert` | created / merged / papers |
| `daily.cleanup` | expired entries, orphaned papers collected |
| `daily.embed` | best-effort; reports under `embed_error`, never `error`, so a broken embedding provider can't fail the sync |

The mutual-exclusion check replaces the by-day job id `/daily/refresh` used to dedupe with. That endpoint now returns `voyage_id`, so a caller can open the running task rather than discovering it through a 409.

## The blocking bit: tasks with no scope

A daily sync belongs to neither a topic nor a library, so both its scope ids are null — and `get_voyage`'s authorization is a **whitelist**: be a topic member, or be able to manage the library. Neither matched, so **the detail page 404'd for everyone, admins included**, taking logs, SSE, cancel and resume with it. The list filter was fine (its `is_admin` clause already covered it), which would have made for a confusing bug: the task is right there in the list, and clicking it says it doesn't exist.

Platform tasks are now admin-only — matching how the daily feed's other controls (categories, manual refresh, embedding toggle) already work. `_visible_filter` is untouched.

The `user`-less call path looks the role up rather than denying outright: denying would have made the service contradict itself, showing an admin a run in the list that a `user_id`-only fetch then 404s on.

## No backfill

Historical syncs get no runs. There's nothing to reconstruct them from — no last-run record, no activity, and arq's job results are long expired. A fabricated `done` task with an empty plan is more confusing than an honest gap. Entries older than 7 days are pruned anyway, so backfill could cover a week at most.

## Verification

31 tests across daily-feed, voyage-scope and wiki-ingest. Includes an end-to-end run driving the real engine over a stubbed arXiv client, asserting all four steps pass, the run reaches `done` in `pipeline` mode, and the paper actually lands in the pool — that's what caught the checkpoint payload needing to round-trip through the JSON column. Full backend suite: 724 passed. `ruff check app` clean, single alembic head, `tsc --noEmit` 0 errors.

## Follow-up worth doing

Nothing exposes "a sync is running right now" to the frontend — the only signal is the 409. A `running_voyage_id` on a daily status endpoint (mirroring `ingest_state`) would let the admin UI link straight to the in-flight task.