### PR TITLE
feat(lab): overview dashboard — index stats, token usage, cross-library graph

### DIFF
--- a/src/backend/alembic/versions/b7f3d21c8a05_llm_usage_created_at_index.py
+++ b/src/backend/alembic/versions/b7f3d21c8a05_llm_usage_created_at_index.py
@@ -1,0 +1,24 @@
+"""llm_usage.created_at 建索引
+
+实验室数据面板按天/周窗口聚合 token 用量（/lab/usage 与排行榜），
+llm_usage 一直没有 created_at 索引，时间窗过滤会全表扫。
+
+Revision ID: b7f3d21c8a05
+Revises: c4a91e7b2f36
+Create Date: 2026-07-25
+"""
+
+from alembic import op
+
+revision = "b7f3d21c8a05"
+down_revision = "c4a91e7b2f36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_llm_usage_created_at", "llm_usage", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_usage_created_at", table_name="llm_usage")

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -11,9 +11,12 @@ from app.schemas.admin_settings import (
     DailyEmbedBackfillResult,
     DailyEmbedRead,
     DailyEmbedUpdate,
+    LabLeaderboardSettingRead,
+    LabLeaderboardSettingUpdate,
 )
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
+from app.services import lab as lab_service
 
 router = APIRouter(
     prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
@@ -64,3 +67,21 @@ async def backfill_daily_embed(
     """给当前窗口内还没有向量的每日论文一次性补建（开开关后补齐历史用）。费用记系统账。"""
     stats = await daily_service.backfill_embeddings(session)
     return DailyEmbedBackfillResult(**stats)
+
+
+@router.get("/lab-leaderboard", response_model=LabLeaderboardSettingRead)
+async def get_lab_leaderboard(
+    session: AsyncSession = Depends(get_session),
+) -> LabLeaderboardSettingRead:
+    """实验室概况页的用量排行榜是否对普通成员可见（默认开）。"""
+    return LabLeaderboardSettingRead(enabled=await lab_service.get_leaderboard_enabled(session))
+
+
+@router.put("/lab-leaderboard", response_model=LabLeaderboardSettingRead)
+async def set_lab_leaderboard(
+    payload: LabLeaderboardSettingUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> LabLeaderboardSettingRead:
+    return LabLeaderboardSettingRead(
+        enabled=await lab_service.set_leaderboard_enabled(session, payload.enabled)
+    )

--- a/src/backend/app/api/concepts.py
+++ b/src/backend/app/api/concepts.py
@@ -32,6 +32,7 @@ def _concept_read(
     return ConceptRead(
         id=concept.id,
         project_id=project_id,
+        library_id=concept.library_id,
         name=concept.name,
         category=concept.category,
         definition=concept.definition,

--- a/src/backend/app/api/lab.py
+++ b/src/backend/app/api/lab.py
@@ -1,0 +1,72 @@
+"""实验室数据面板路由（/lab）：索引统计、token 用量与排行榜、跨库图谱。
+
+全部只读、全员可见（登录即可），数字按可见库集合收敛。排行榜额外受管理员开关
+``lab_leaderboard_enabled`` 控制：关掉后普通用户拿 403，管理员照常可看。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.user import User
+from app.schemas.graph import GraphResponse
+from app.schemas.lab import LabLeaderboardEntry, LabLeaderboardResponse, LabStats
+from app.schemas.llm_admin import UsageRow
+from app.services import lab as lab_service
+from app.services import llm_admin as llm_admin_service
+
+router = APIRouter(prefix="/lab", tags=["lab"])
+
+
+@router.get("/stats", response_model=LabStats)
+async def lab_stats(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LabStats:
+    """实验室索引与内容统计（跨库论文去重；只算当前用户看得到的库）。"""
+    return LabStats(**await lab_service.lab_stats(session, user))
+
+
+@router.get("/usage", response_model=list[UsageRow])
+async def lab_usage(
+    days: int = Query(default=30, ge=1, le=365),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[UsageRow]:
+    """全实验室最近 N 天的 token 用量（按 日期 × stage × model 聚合），全员可见。"""
+    rows = await llm_admin_service.usage_report(session, days=days)
+    return [UsageRow(**row) for row in rows]
+
+
+@router.get("/usage/leaderboard", response_model=LabLeaderboardResponse)
+async def lab_usage_leaderboard(
+    days: int = Query(default=30, ge=1, le=365),
+    limit: int = Query(default=10, ge=1, le=50),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LabLeaderboardResponse:
+    """成员 token 消耗排行榜。管理员关掉开关后，普通用户 403。"""
+    enabled = await lab_service.get_leaderboard_enabled(session)
+    if not enabled and user.role != "admin":
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LEADERBOARD_DISABLED")
+    rows = await lab_service.usage_leaderboard(session, days=days, limit=limit)
+    return LabLeaderboardResponse(
+        enabled=enabled, days=days, items=[LabLeaderboardEntry(**row) for row in rows]
+    )
+
+
+@router.get("/graph", response_model=GraphResponse)
+async def lab_graph(
+    library_id: uuid.UUID | None = Query(default=None, description="只看单个库；不传=全部可见库"),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> GraphResponse:
+    """跨库知识图谱：全部可见库的并集（确定性构建，不走 LLM）。"""
+    try:
+        data = await lab_service.lab_graph(session, user=user, library_id=library_id)
+    except lab_service.LibraryNotVisibleError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND") from exc
+    return GraphResponse(**data)

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -612,6 +612,7 @@ async def list_library_concepts(
         ConceptRead(
             id=concept.id,
             project_id=library.project_id,
+            library_id=library.id,
             name=concept.name,
             category=concept.category,
             definition=concept.definition,
@@ -672,6 +673,7 @@ async def search_library(
             ScoredConcept(
                 id=concept.id,
                 project_id=library.project_id,
+                library_id=library.id,
                 name=concept.name,
                 category=concept.category,
                 definition=concept.definition,

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -18,6 +18,7 @@ from app.api import (
     ideas,
     ingest,
     invites,
+    lab,
     libraries,
     library,
     manuscripts,
@@ -51,6 +52,7 @@ api_router.include_router(gates.router)
 api_router.include_router(voyages.router)
 api_router.include_router(admin_llm.router)
 api_router.include_router(admin_settings.router)
+api_router.include_router(lab.router)
 api_router.include_router(me_llm.router)
 api_router.include_router(papers.router)
 api_router.include_router(library.router)

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -110,6 +110,7 @@ async def search(
             ScoredConcept(
                 id=concept.id,
                 project_id=project_id,
+                library_id=concept.library_id,
                 name=concept.name,
                 category=concept.category,
                 definition=concept.definition,

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -88,6 +88,8 @@ class ModelRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
 class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "llm_usage"
+    # 用量面板按天/周窗口聚合（/lab/usage、排行榜），没这个索引就是全表扫
+    __table_args__ = (Index("ix_llm_usage_created_at", "created_at"),)
 
     user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
     project_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -25,6 +25,16 @@ class DailyEmbedUpdate(BaseModel):
     enabled: bool
 
 
+class LabLeaderboardSettingRead(BaseModel):
+    """用量排行榜是否对普通成员可见（默认开；关掉后只有管理员看得到）。"""
+
+    enabled: bool
+
+
+class LabLeaderboardSettingUpdate(BaseModel):
+    enabled: bool
+
+
 class DailyEmbedBackfillResult(BaseModel):
     """一次性补建向量的结果：本次新建 / 已有跳过 / 未成功。"""
 

--- a/src/backend/app/schemas/lab.py
+++ b/src/backend/app/schemas/lab.py
@@ -1,0 +1,62 @@
+"""实验室数据面板 schema（/lab 概况页）。"""
+
+import uuid
+
+from pydantic import BaseModel
+
+
+class LabLibraryStats(BaseModel):
+    total: int
+    public: int
+    personal: int
+
+
+class LabPaperStats(BaseModel):
+    """pool_total 是全局内容池；library_members_deduped 是可见库并集内去重后的篇数。"""
+
+    pool_total: int
+    library_members_deduped: int
+    compiled: int
+
+
+class LabConceptStats(BaseModel):
+    total: int
+
+
+class LabChunkStats(BaseModel):
+    """全文分段索引：vector_search_supported=false 时向量存了也搜不了（sqlite）。"""
+
+    papers_with_chunks: int
+    total_chunks: int
+    chunks_with_embedding: int
+    vector_search_supported: bool
+
+
+class LabVectorStats(BaseModel):
+    papers_with_embedding: int
+    papers_total: int
+
+
+class LabStats(BaseModel):
+    libraries: LabLibraryStats
+    papers: LabPaperStats
+    concepts: LabConceptStats
+    chunks: LabChunkStats
+    vectors: LabVectorStats
+    # 排行榜对普通用户是否可见（关着时普通用户不显示这一区）
+    leaderboard_enabled: bool
+
+
+class LabLeaderboardEntry(BaseModel):
+    user_id: uuid.UUID
+    display_name: str | None
+    username: str | None
+    has_avatar: bool
+    role: str
+    tokens_used: int
+
+
+class LabLeaderboardResponse(BaseModel):
+    enabled: bool
+    days: int
+    items: list[LabLeaderboardEntry]

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -216,6 +216,8 @@ class ConceptRead(BaseModel):
     id: uuid.UUID
     # 概念所属库回指的课题；共享库（无课题回指）为 None
     project_id: uuid.UUID | None
+    # 概念所属文献库（跨库场景下据此跳回它所在的库）
+    library_id: uuid.UUID
     name: str
     category: str | None
     definition: str | None

--- a/src/backend/app/services/graph.py
+++ b/src/backend/app/services/graph.py
@@ -2,8 +2,9 @@
 
 节点：论文（打分通过及之后的状态）、概念（paper_concepts 关联）、作者（Paper.authors JSON）。
 边：论文—概念（上链关系）、论文—作者（署名）。
-规模控制：论文按相关度取 top ``max_papers``；作者按关联论文数取 top ``max_authors``，
-单篇论文最多取前 ``authors_per_paper`` 位作者（长作者列表只保留头部署名）。
+规模控制：论文不再设实际上限（实验室级面板要看全量，``max_papers`` 只是个兜底的
+天花板，调用方可自定）；作者按关联论文数取 top ``max_authors``，单篇论文最多取前
+``authors_per_paper`` 位作者（长作者列表只保留头部署名）。
 """
 
 import uuid
@@ -20,8 +21,11 @@ from app.services.libraries import dedupe_member_rows, get_source_library_ids, m
 # 图上展示的论文状态（candidate 未过筛选，噪声大，不进图）
 GRAPH_PAPER_STATUSES = ("scored", "fetched", "compiled", "included")
 
-MAX_PAPERS = 150
-MAX_AUTHORS = 80
+# 论文不截断：单库/跨库都给全量（前端的网络视图自己按节点数决定要不要硬画）。
+# 留个大到不可能碰到的天花板，纯粹防御异常数据量把响应撑爆。
+MAX_PAPERS = 100_000
+# 作者只是网络视图上的配角，仍按关联论文数取头部（否则每篇 8 位作者会把图糊死）
+MAX_AUTHORS = 400
 AUTHORS_PER_PAPER = 8
 
 
@@ -64,6 +68,21 @@ async def library_graph(
     """构建单个方向库的知识图谱（库工作台入口，含独立库）。"""
     return await _graph_for_library_ids(
         session, library_ids=[library_id], max_papers=max_papers, max_authors=max_authors
+    )
+
+
+async def libraries_graph(
+    session: AsyncSession,
+    *,
+    library_ids: list[uuid.UUID],
+    max_papers: int = MAX_PAPERS,
+    max_authors: int = MAX_AUTHORS,
+) -> dict[str, Any]:
+    """构建一组库并集的知识图谱（实验室面板：全部可见库）。空集合返回空图。"""
+    if not library_ids:
+        return {"nodes": [], "edges": [], "paper_total": 0, "truncated": False}
+    return await _graph_for_library_ids(
+        session, library_ids=library_ids, max_papers=max_papers, max_authors=max_authors
     )
 
 
@@ -168,5 +187,6 @@ async def _graph_for_library_ids(
         "nodes": nodes,
         "edges": edges,
         "paper_total": paper_total,
-        "truncated": paper_total > len(papers) or len(author_papers) > len(kept_authors),
+        # 只反映论文被截断（作者取头部是固定的展示规则，不该让前端提示「论文较多」）
+        "truncated": paper_total > len(papers),
     }

--- a/src/backend/app/services/lab.py
+++ b/src/backend/app/services/lab.py
@@ -1,0 +1,221 @@
+"""实验室数据面板（/lab 概况页）业务逻辑（不 import fastapi）：
+
+- 索引与内容统计：文献库 / 论文 / 概念 / 全文分段 / 向量覆盖；
+- token 用量排行榜（全员可见，管理员可关）；
+- 跨库图谱：把「我可见的库」整体交给图谱构建。
+
+可见范围一律走 ``libraries.library_visible_to``：公共库全员可读，个人库只有创建者
+和平台管理员看得到。所有计数都先收敛到可见库集合再算，普通用户不会看到别人个人库
+的数字。跨库同一篇论文只算一次（按 ``LibraryPaper.paper_id`` 去重）。
+"""
+
+import uuid
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy import String, and_, cast, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.llm_config import LLMUsage
+from app.models.paper import Concept, Paper, PaperChunk
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+from app.services import graph as graph_service
+from app.services.chunks import chunk_vector_search_supported
+from app.services.libraries import library_visible_to
+from app.services.papers import PAPER_STATUS_GROUPS
+
+# 排行榜是否对普通用户可见（管理员开关，默认开；管理员任何时候都能看）
+LEADERBOARD_SETTING_KEY = "lab_leaderboard_enabled"
+DEFAULT_LEADERBOARD_ENABLED = True
+
+
+class LibraryNotVisibleError(Exception):
+    """请求的库对当前用户不可见（或不存在）。"""
+
+
+async def _count(session: AsyncSession, stmt) -> int:
+    return int((await session.execute(stmt)).scalar_one())
+
+
+def _has_vector(session: AsyncSession, column):
+    """「向量已建」判定。
+
+    postgres 上是 pgvector 列，NULL 判定就够；sqlite 上是 JSON 列，SQLAlchemy 会把
+    Python None 存成字面量 ``null``，只判 IS NOT NULL 会把没建向量的也算进来。
+    """
+    if session.get_bind().dialect.name == "postgresql":
+        return column.is_not(None)
+    return and_(column.is_not(None), cast(column, String) != "null")
+
+
+# ---- 可见库集合 ----
+
+
+async def visible_libraries(session: AsyncSession, user: User) -> list[DirectionLibrary]:
+    """当前用户可见的全部方向库（口径同 /libraries 列表）。"""
+    rows = (
+        (await session.execute(select(DirectionLibrary).order_by(DirectionLibrary.created_at)))
+        .scalars()
+        .all()
+    )
+    return [lib for lib in rows if library_visible_to(lib, user)]
+
+
+# ---- 索引与内容统计 ----
+
+
+async def lab_stats(session: AsyncSession, user: User) -> dict[str, Any]:
+    """实验室概况数字：库 / 论文 / 概念 / 全文分段 / 向量覆盖。"""
+    libraries = await visible_libraries(session, user)
+    library_ids = [lib.id for lib in libraries]
+    public_count = sum(1 for lib in libraries if lib.is_public)
+
+    # 内容池是全局的（每日新论文、个人库导入都落在这里），不按库可见性收敛
+    pool_total = await _count(session, select(func.count()).select_from(Paper))
+
+    members = compiled = concepts = 0
+    papers_with_chunks = total_chunks = chunks_with_embedding = papers_with_embedding = 0
+    if library_ids:
+        in_library = LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"])
+        members = await _count(
+            session,
+            select(func.count(func.distinct(LibraryPaper.paper_id))).where(
+                LibraryPaper.library_id.in_(library_ids), in_library
+            ),
+        )
+        compiled = await _count(
+            session,
+            select(func.count(func.distinct(LibraryPaper.paper_id))).where(
+                LibraryPaper.library_id.in_(library_ids),
+                LibraryPaper.status.in_(PAPER_STATUS_GROUPS["compiled_any"]),
+            ),
+        )
+        concepts = await _count(
+            session,
+            select(func.count()).select_from(Concept).where(Concept.library_id.in_(library_ids)),
+        )
+        # 库内论文 id 子查询：分段与向量统计都挂在它上面（同样天然去重）
+        member_ids = (
+            select(LibraryPaper.paper_id)
+            .where(LibraryPaper.library_id.in_(library_ids), in_library)
+            .distinct()
+        )
+        papers_with_chunks = await _count(
+            session,
+            select(func.count(func.distinct(PaperChunk.paper_id))).where(
+                PaperChunk.paper_id.in_(member_ids)
+            ),
+        )
+        total_chunks = await _count(
+            session,
+            select(func.count())
+            .select_from(PaperChunk)
+            .where(PaperChunk.paper_id.in_(member_ids)),
+        )
+        chunks_with_embedding = await _count(
+            session,
+            select(func.count())
+            .select_from(PaperChunk)
+            .where(
+                PaperChunk.paper_id.in_(member_ids), _has_vector(session, PaperChunk.embedding)
+            ),
+        )
+        papers_with_embedding = await _count(
+            session,
+            select(func.count())
+            .select_from(Paper)
+            .where(Paper.id.in_(member_ids), _has_vector(session, Paper.embedding)),
+        )
+
+    return {
+        "libraries": {
+            "total": len(libraries),
+            "public": public_count,
+            "personal": len(libraries) - public_count,
+        },
+        "papers": {
+            "pool_total": pool_total,
+            "library_members_deduped": members,
+            "compiled": compiled,
+        },
+        "concepts": {"total": concepts},
+        "chunks": {
+            "papers_with_chunks": papers_with_chunks,
+            "total_chunks": total_chunks,
+            "chunks_with_embedding": chunks_with_embedding,
+            # sqlite 下向量存了也检索不了，前端据此区分「已嵌入」和「能按语义搜」
+            "vector_search_supported": chunk_vector_search_supported(session),
+        },
+        "vectors": {"papers_with_embedding": papers_with_embedding, "papers_total": members},
+        "leaderboard_enabled": await get_leaderboard_enabled(session),
+    }
+
+
+# ---- 用量排行榜 ----
+
+
+async def get_leaderboard_enabled(session: AsyncSession) -> bool:
+    row = await session.get(SystemSetting, LEADERBOARD_SETTING_KEY)
+    return bool(row.value) if row is not None else DEFAULT_LEADERBOARD_ENABLED
+
+
+async def set_leaderboard_enabled(session: AsyncSession, enabled: bool) -> bool:
+    row = await session.get(SystemSetting, LEADERBOARD_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=LEADERBOARD_SETTING_KEY, value=enabled))
+    else:
+        row.value = enabled
+    await session.commit()
+    return enabled
+
+
+async def usage_leaderboard(
+    session: AsyncSession, *, days: int = 30, limit: int = 10
+) -> list[dict[str, Any]]:
+    """最近 N 天 token 消耗最多的前 limit 位成员（无记账记录的用户不出现）。"""
+    since = utcnow() - timedelta(days=days)
+    usage_sq = (
+        select(
+            LLMUsage.user_id.label("uid"),
+            func.sum(LLMUsage.prompt_tokens + LLMUsage.completion_tokens).label("tokens"),
+        )
+        .where(LLMUsage.created_at >= since, LLMUsage.user_id.is_not(None))
+        .group_by(LLMUsage.user_id)
+        .subquery()
+    )
+    stmt = (
+        select(User, usage_sq.c.tokens)
+        .join(usage_sq, usage_sq.c.uid == User.id)
+        .order_by(usage_sq.c.tokens.desc(), User.created_at)
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "user_id": u.id,
+            "display_name": u.display_name,
+            "username": u.username,
+            "has_avatar": u.has_avatar,
+            "role": u.role,
+            "tokens_used": int(tokens or 0),
+        }
+        for u, tokens in rows
+    ]
+
+
+# ---- 跨库图谱 ----
+
+
+async def lab_graph(
+    session: AsyncSession, *, user: User, library_id: uuid.UUID | None = None
+) -> dict[str, Any]:
+    """全部可见库的并集图谱；给了 library_id 就只看那一个库（不可见则报错）。"""
+    library_ids = [lib.id for lib in await visible_libraries(session, user)]
+    if library_id is not None:
+        if library_id not in library_ids:
+            raise LibraryNotVisibleError(str(library_id))
+        library_ids = [library_id]
+    return await graph_service.libraries_graph(session, library_ids=library_ids)

--- a/src/backend/tests/test_lab_dashboard.py
+++ b/src/backend/tests/test_lab_dashboard.py
@@ -1,0 +1,281 @@
+"""实验室数据面板（/lab）：索引统计 / 用量排行榜 / 跨库图谱。
+
+- 统计跨库去重：同一篇论文进两个库只算一次；
+- 统计按可见性收敛：普通用户看不到别人个人库的任何计数；
+- 排行榜的管理员开关：关掉后普通用户 403、管理员照常；
+- 图谱：不传 library_id = 全部可见库的并集，传了只看那一个库。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.llm_config import LLMUsage
+from app.models.paper import Concept, Paper, PaperChunk, paper_concepts
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _user_id(email: str) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        row = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        return row.id
+
+
+async def _make_library(*, name, is_public, owner_email=None) -> uuid.UUID:
+    """直接建一个 active 库（不经课题），返回库 id。"""
+    async with get_sessionmaker()() as session:
+        submitted_by = None
+        if owner_email is not None:
+            submitted_by = (
+                await session.execute(select(User).where(User.email == owner_email))
+            ).scalar_one().id
+        library = DirectionLibrary(
+            name=name, status="active", is_public=is_public, submitted_by=submitted_by
+        )
+        session.add(library)
+        await session.commit()
+        return library.id
+
+
+async def _add_member(
+    *, library_ids, title, status="compiled", paper_id=None, chunks=0, embedded=False
+) -> uuid.UUID:
+    """建（或复用）一篇内容池论文并登记到若干库；可选顺带造全文分段与向量。"""
+    async with get_sessionmaker()() as session:
+        if paper_id is None:
+            paper = Paper(title=title, embedding=[0.1] * 4 if embedded else None)
+            session.add(paper)
+            await session.flush()
+            for seq in range(chunks):
+                session.add(
+                    PaperChunk(
+                        paper_id=paper.id,
+                        seq=seq,
+                        text=f"{title} chunk {seq}",
+                        embedding=[0.1] * 4 if embedded else None,
+                    )
+                )
+            paper_id = paper.id
+        for library_id in library_ids:
+            session.add(
+                LibraryPaper(library_id=library_id, paper_id=paper_id, status=status)
+            )
+        await session.commit()
+        return paper_id
+
+
+async def _add_concept(*, library_id, name, slug, paper_id=None) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        concept = Concept(library_id=library_id, name=name, slug=slug, category="method")
+        session.add(concept)
+        await session.flush()
+        if paper_id is not None:
+            await session.execute(
+                paper_concepts.insert().values(paper_id=paper_id, concept_id=concept.id)
+            )
+        await session.commit()
+        return concept.id
+
+
+async def _promote_admin(email: str) -> None:
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user.role = "admin"
+        await session.commit()
+
+
+# ---- 统计 ----
+
+
+async def test_lab_stats_dedupes_papers_across_libraries(client):
+    """同一篇论文进两个公共库：库数 2，论文只算 1 篇（前端加总会错算成 2）。"""
+    headers = await _hdr(client, "lab-a@example.com")  # 首个用户 = admin
+    lib_a = await _make_library(name="方向甲", is_public=True)
+    lib_b = await _make_library(name="方向乙", is_public=True)
+    shared = await _add_member(library_ids=[lib_a], title="共享论文", chunks=2, embedded=True)
+    await _add_member(library_ids=[lib_b], title="共享论文", paper_id=shared)
+    # 有全文分段但还没建向量的一篇：用来区分「已分段」和「已嵌入」
+    await _add_member(library_ids=[lib_b], title="只在乙库", status="scored", chunks=1)
+
+    resp = await client.get("/api/lab/stats", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["libraries"] == {"total": 2, "public": 2, "personal": 0}
+    # 共享论文跨两个库只算一次 + 只在乙库那篇 = 2
+    assert body["papers"]["library_members_deduped"] == 2
+    assert body["papers"]["compiled"] == 1  # scored 那篇还没编译
+    assert body["papers"]["pool_total"] == 2  # 内容池里也只有两条
+    # 分段与向量同样按去重后的论文集合算
+    assert body["chunks"]["papers_with_chunks"] == 2
+    assert body["chunks"]["total_chunks"] == 3
+    assert body["chunks"]["chunks_with_embedding"] == 2  # 未建向量那篇的分段不算
+    assert body["chunks"]["vector_search_supported"] is False  # 测试跑 sqlite
+    assert body["vectors"] == {"papers_with_embedding": 1, "papers_total": 2}
+
+
+async def test_lab_stats_excludes_other_users_personal_library(client):
+    """普通用户看不到别人个人库的论文/概念计数；库归属人自己看得到。"""
+    owner = await _hdr(client, "lab-owner@example.com")  # 首个用户 = admin
+    stranger = await _hdr(client, "lab-stranger@example.com")
+    public_lib = await _make_library(name="公共方向", is_public=True)
+    personal_lib = await _make_library(
+        name="私人方向", is_public=False, owner_email="lab-stranger@example.com"
+    )
+    await _add_member(library_ids=[public_lib], title="公开论文")
+    await _add_member(library_ids=[personal_lib], title="私人论文")
+    await _add_concept(library_id=public_lib, name="Agent", slug="agent")
+    await _add_concept(library_id=personal_lib, name="Secret", slug="secret")
+
+    # 第三方（既非归属人也非管理员）：只看得到公共库那一份
+    third = await _hdr(client, "lab-third@example.com")
+    body = (await client.get("/api/lab/stats", headers=third)).json()
+    assert body["libraries"] == {"total": 1, "public": 1, "personal": 0}
+    assert body["papers"]["library_members_deduped"] == 1
+    assert body["concepts"]["total"] == 1
+
+    # 归属人自己：公共库 + 自己的个人库
+    body = (await client.get("/api/lab/stats", headers=stranger)).json()
+    assert body["libraries"] == {"total": 2, "public": 1, "personal": 1}
+    assert body["papers"]["library_members_deduped"] == 2
+    assert body["concepts"]["total"] == 2
+
+    # 管理员：全部
+    body = (await client.get("/api/lab/stats", headers=owner)).json()
+    assert body["libraries"]["total"] == 2
+    assert body["papers"]["library_members_deduped"] == 2
+
+
+# ---- 用量与排行榜 ----
+
+
+async def _add_usage(user_id: uuid.UUID, *, prompt: int, completion: int) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(
+            LLMUsage(
+                user_id=user_id,
+                stage="score",
+                model="fake-model",
+                prompt_tokens=prompt,
+                completion_tokens=completion,
+            )
+        )
+        await session.commit()
+
+
+async def test_lab_usage_visible_to_all_members(client):
+    admin = await _hdr(client, "lab-usage-admin@example.com")
+    member = await _hdr(client, "lab-usage-member@example.com")
+    await _add_usage(await _user_id("lab-usage-admin@example.com"), prompt=100, completion=20)
+
+    for headers in (admin, member):
+        resp = await client.get("/api/lab/usage?days=30", headers=headers)
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        assert len(rows) == 1
+        assert rows[0]["prompt_tokens"] == 100 and rows[0]["completion_tokens"] == 20
+
+
+async def test_leaderboard_ranks_by_tokens(client):
+    admin = await _hdr(client, "lab-lb-admin@example.com")
+    await _hdr(client, "lab-lb-small@example.com")
+    await _hdr(client, "lab-lb-big@example.com")
+    await _add_usage(await _user_id("lab-lb-small@example.com"), prompt=10, completion=5)
+    await _add_usage(await _user_id("lab-lb-big@example.com"), prompt=900, completion=100)
+
+    resp = await client.get("/api/lab/usage/leaderboard?days=30&limit=10", headers=admin)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["enabled"] is True and body["days"] == 30
+    # 用量多的在前；没有任何记账的用户不出现
+    assert [row["tokens_used"] for row in body["items"]] == [1000, 15]
+
+
+async def test_leaderboard_switch_admin_and_member(client):
+    """开关 × 角色 四种组合：关掉后只有管理员看得到。"""
+    admin = await _hdr(client, "lab-sw-admin@example.com")
+    member = await _hdr(client, "lab-sw-member@example.com")
+
+    # 默认开：两边都能看
+    assert (await client.get("/api/lab/usage/leaderboard", headers=admin)).status_code == 200
+    assert (await client.get("/api/lab/usage/leaderboard", headers=member)).status_code == 200
+
+    # 管理员关掉
+    resp = await client.put(
+        "/api/admin/settings/lab-leaderboard", json={"enabled": False}, headers=admin
+    )
+    assert resp.status_code == 200 and resp.json()["enabled"] is False
+    # 普通用户改不了这个开关
+    assert (
+        await client.put(
+            "/api/admin/settings/lab-leaderboard", json={"enabled": True}, headers=member
+        )
+    ).status_code == 403
+
+    # 关掉后：普通用户 403，管理员仍 200（带 enabled=false 提示当前是关的）
+    resp = await client.get("/api/lab/usage/leaderboard", headers=member)
+    assert resp.status_code == 403 and resp.json()["detail"] == "LEADERBOARD_DISABLED"
+    resp = await client.get("/api/lab/usage/leaderboard", headers=admin)
+    assert resp.status_code == 200 and resp.json()["enabled"] is False
+
+    # 概况页据此决定要不要显示这一区
+    stats = (await client.get("/api/lab/stats", headers=member)).json()
+    assert stats["leaderboard_enabled"] is False
+
+    # 再打开：普通用户恢复
+    await client.put("/api/admin/settings/lab-leaderboard", json={"enabled": True}, headers=admin)
+    assert (await client.get("/api/lab/usage/leaderboard", headers=member)).status_code == 200
+
+
+# ---- 跨库图谱 ----
+
+
+async def test_lab_graph_unions_visible_libraries(client):
+    headers = await _hdr(client, "lab-graph@example.com")
+    lib_a = await _make_library(name="图谱甲", is_public=True)
+    lib_b = await _make_library(name="图谱乙", is_public=True)
+    paper_a = await _add_member(library_ids=[lib_a], title="甲库论文")
+    paper_b = await _add_member(library_ids=[lib_b], title="乙库论文")
+    await _add_concept(library_id=lib_a, name="Agent", slug="agent", paper_id=paper_a)
+    await _add_concept(library_id=lib_b, name="Planner", slug="planner", paper_id=paper_b)
+
+    # 不传 library_id：两个库的并集
+    resp = await client.get("/api/lab/graph", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    labels = {n["label"] for n in body["nodes"]}
+    assert {"甲库论文", "乙库论文", "Agent", "Planner"} <= labels
+    assert body["paper_total"] == 2
+    assert body["truncated"] is False
+
+    # 传 library_id：只看那一个库
+    body = (await client.get(f"/api/lab/graph?library_id={lib_a}", headers=headers)).json()
+    labels = {n["label"] for n in body["nodes"]}
+    assert "甲库论文" in labels and "乙库论文" not in labels
+    assert body["paper_total"] == 1
+
+
+async def test_lab_graph_skips_invisible_library(client):
+    await _hdr(client, "lab-graph-admin@example.com")  # 首个用户 = admin，占位
+    owner = await _hdr(client, "lab-graph-owner@example.com")
+    stranger = await _hdr(client, "lab-graph-stranger@example.com")
+    personal = await _make_library(
+        name="私人图谱", is_public=False, owner_email="lab-graph-owner@example.com"
+    )
+    await _add_member(library_ids=[personal], title="私人图谱论文")
+
+    # 陌生人：并集里没有这个库；点名要也 404
+    body = (await client.get("/api/lab/graph", headers=stranger)).json()
+    assert body["nodes"] == [] and body["paper_total"] == 0
+    resp = await client.get(f"/api/lab/graph?library_id={personal}", headers=stranger)
+    assert resp.status_code == 404
+
+    # 归属人自己看得到
+    body = (await client.get("/api/lab/graph", headers=owner)).json()
+    assert {n["label"] for n in body["nodes"]} >= {"私人图谱论文"}

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "c4a91e7b2f36"  # 个人标签表 user_paper_tags
-PREV_REVISION = "c5e2a90d41f7"  # 库任务归实验室：回填 library_id、清 project_id
+HEAD_REVISION = "b7f3d21c8a05"  # llm_usage.created_at 索引
+PREV_REVISION = "c4a91e7b2f36"  # 个人标签表 user_paper_tags
 
 
 def _make_config(db_path: Path) -> Config:
@@ -18,6 +18,15 @@ def _make_config(db_path: Path) -> Config:
     cfg.set_main_option("script_location", str(BACKEND_DIR / "alembic"))
     cfg.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{db_path}")
     return cfg
+
+
+def _index_names(db_path: Path, table: str) -> set[str]:
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as conn:
+            return {ix["name"] for ix in inspect(conn).get_indexes(table)}
+    finally:
+        engine.dispose()
 
 
 def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
@@ -257,14 +266,17 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：个人标签表（paper × user × name，与库标签完全独立）
     assert "user_paper_tags" in columns["_tables"]
     assert {"id", "user_id", "paper_id", "name"} <= columns["user_paper_tags"]
+    # 本分支新增：用量面板按时间窗聚合用的 llm_usage.created_at 索引
+    assert "ix_llm_usage_created_at" in _index_names(db_path, "llm_usage")
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（c5e2a90d41f7，库任务归实验室）。
-    # 该步只删个人标签表，其余结构不动（库标签 paper_tags 一点不受影响）。
+    # 最新 revision 可往返：downgrade 一步落到 down_revision（c4a91e7b2f36，个人标签表）。
+    # 该步只删 llm_usage 上的索引，任何表/列都不动。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREV_REVISION
-    # 个人标签表消失；库标签表与上一版的两张备份表、回收站列都还在
-    assert "user_paper_tags" not in columns["_tables"]
+    assert "ix_llm_usage_created_at" not in _index_names(db_path, "llm_usage")
+    # 个人标签表与上一版的两张备份表、回收站列都还在
+    assert "user_paper_tags" in columns["_tables"]
     assert {"paper_tags", "paper_tag_links", "_pr3_backfilled_curators"} <= columns["_tables"]
     assert "_c5e2a90d_voyage_topic" in columns["_tables"]
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]
@@ -320,7 +332,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
-    # 个人标签表在重新 upgrade 后回归；回收站列与两张备份表也仍在
+    # 索引回归；个人标签表、回收站列与两张备份表也仍在
+    assert "ix_llm_usage_created_at" in _index_names(db_path, "llm_usage")
     assert "user_paper_tags" in columns["_tables"]
     assert {"id", "user_id", "paper_id", "name"} <= columns["user_paper_tags"]
     assert {"trashed_at", "trashed_by"} <= columns["topic_papers"]

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -1,16 +1,21 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Icon } from '../../components/ui/Icon';
+import { Avatar } from '../../components/ui/Avatar';
+import { Icon, type IconName } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
+import { toast } from '../../components/ui/Toast';
 import { Segmented } from '../../components/ui/Segmented';
 import { StatCard } from '../../components/ui/StatCard';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { useProject } from '../../app/project';
-import { api, type DirectionLibrarySummary, type VoyageRead } from '../../lib/api';
+import { api, isAdmin, type DirectionLibrarySummary, type LabStats, type VoyageRead } from '../../lib/api';
 import { fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import { useLibraries, libraryPath } from '../libraries/hooks';
+
+// 图谱体量大且不是首屏必需：按需加载（与文献库工作台同样处理）
+const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
 import {
   FILTERS,
   KIND_META,
@@ -25,7 +30,9 @@ import {
 /* ============================================================
    /lab — 实验室工作台
    两个标签：
-   - 概况：文献库与每日新论文的汇总（全部走既有列表接口，无新增聚合端点）
+   - 概况：实验室级数据面板 —— 索引与内容统计（/lab/stats，后端聚合、跨库去重、
+     按可见库收敛）、AI 用量与排行榜（/lab/usage 系列）、跨库概念图谱
+     （/lab/graph）、文献库与每日新论文汇总
    - 任务：全部可见任务按归属分组（课题任务 / 文献库任务 / 其它），
      覆盖课题工作台看不到的「课题外任务」（VoyageRun.project_id 可为空）
    ============================================================ */
@@ -61,7 +68,8 @@ function LibrariesCard() {
   }, [data]);
   const publicCount = libs.filter((l) => l.is_public).length;
   const personalCount = libs.length - publicCount;
-  const paperTotal = libs.reduce((acc, l) => acc + l.paper_count, 0);
+  // 这里不再报「共 N 篇论文」：各库论文数相加会把跨库的同一篇重复计数，
+  // 去重后的总数在上面的指标卡里（走 /lab/stats）。
 
   return (
     <div className="card" style={{ overflow: 'hidden', marginBottom: 20 }}>
@@ -75,8 +83,8 @@ function LibrariesCard() {
             {isLoading || isError
               ? tr('实验室共享的方向文献库', 'Shared direction libraries')
               : tr(
-                  `公共库 ${publicCount} 个 · 个人库 ${personalCount} 个 · 共 ${paperTotal} 篇论文`,
-                  `${publicCount} public · ${personalCount} personal · ${paperTotal} papers`,
+                  `公共库 ${publicCount} 个 · 个人库 ${personalCount} 个`,
+                  `${publicCount} public · ${personalCount} personal`,
                 )}
           </div>
         </div>
@@ -278,11 +286,495 @@ function DailyCard() {
   );
 }
 
+/* ---------- 面板通用零件 ---------- */
+
+/** 面板小节外壳：图标 + 标题 + 说明 + 右侧操作，与文献库/每日新论文两张卡同款。 */
+function PanelCard({
+  icon,
+  title,
+  hint,
+  action,
+  children,
+  style,
+}: {
+  icon: IconName;
+  title: string;
+  hint?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div className="card" style={{ overflow: 'hidden', marginBottom: 20, ...style }}>
+      <div className="row gap10" style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--border)' }}>
+        <Icon name={icon} size={15} style={{ color: 'var(--text-2)', flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 650, letterSpacing: '-0.01em' }}>{title}</div>
+          {hint && <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{hint}</div>}
+        </div>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** 「已完成 / 总数」的一行进度条。 */
+function MeterRow({ label, done, total, note }: { label: string; done: number; total: number; note?: string }) {
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
+  return (
+    <div>
+      <div className="row" style={{ justifyContent: 'space-between', alignItems: 'baseline', gap: 10 }}>
+        <span style={{ fontSize: 12.5, color: 'var(--text-2)' }}>{label}</span>
+        <span className="mono" style={{ fontSize: 12 }}>
+          {done.toLocaleString()}
+          <span style={{ color: 'var(--text-4)' }}> / {total.toLocaleString()}</span>
+        </span>
+      </div>
+      <div style={{ height: 6, borderRadius: 999, background: 'var(--surface-3)', overflow: 'hidden', marginTop: 6 }}>
+        <div style={{ width: `${pct}%`, height: '100%', borderRadius: 999, background: 'var(--accent)' }} />
+      </div>
+      {note && <div style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 4, lineHeight: 1.45 }}>{note}</div>}
+    </div>
+  );
+}
+
+/* ---------- 索引与内容统计 ---------- */
+
+/** 编译 / 全文分段 / 向量三条索引进度，数字全部来自 /lab/stats（跨库去重、按可见库收敛）。 */
+function IndexCard({ stats, isLoading, isError }: { stats?: LabStats; isLoading: boolean; isError: boolean }) {
+  return (
+    <PanelCard
+      icon="layers"
+      title={tr('索引进度', 'Index coverage')}
+      hint={tr(
+        '论文的解读、全文分段与向量建到了什么程度——决定文献对话和语义检索能不能用',
+        'How far reading notes, full-text chunks, and embeddings have been built — this decides whether chat and semantic search work',
+      )}
+    >
+      {isLoading ? (
+        <div className="col gap10" style={{ padding: '16px 18px' }}>
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="skel" style={{ height: 20, width: `${90 - i * 10}%` }} />
+          ))}
+        </div>
+      ) : isError || !stats ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载统计', 'Failed to load stats')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+          compact
+        />
+      ) : (
+        <div style={{ padding: '16px 18px' }}>
+          <div
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '16px 28px' }}
+          >
+            <MeterRow
+              label={tr('已编译解读的论文', 'Papers with reading notes')}
+              done={stats.papers.compiled}
+              total={stats.papers.library_members_deduped}
+            />
+            <MeterRow
+              label={tr('已切好全文分段的论文', 'Papers with full-text chunks')}
+              done={stats.chunks.papers_with_chunks}
+              total={stats.papers.library_members_deduped}
+              note={tr(`共 ${stats.chunks.total_chunks.toLocaleString()} 个分段`, `${stats.chunks.total_chunks.toLocaleString()} chunks in total`)}
+            />
+            <MeterRow
+              label={tr('已建向量的分段', 'Chunks embedded')}
+              done={stats.chunks.chunks_with_embedding}
+              total={stats.chunks.total_chunks}
+              note={
+                stats.chunks.vector_search_supported
+                  ? tr('这些分段可以按语义检索', 'These chunks are searchable by meaning')
+                  : tr(
+                      '当前数据库不支持向量检索，建好的向量暂时只能存着，检索会退回关键词',
+                      'This database can’t search vectors — embeddings are stored but search falls back to keywords',
+                    )
+              }
+            />
+            <MeterRow
+              label={tr('已建向量的论文', 'Papers embedded')}
+              done={stats.vectors.papers_with_embedding}
+              total={stats.vectors.papers_total}
+            />
+          </div>
+          <div
+            className="row gap16"
+            style={{ marginTop: 16, paddingTop: 14, borderTop: '0.5px solid var(--border)', flexWrap: 'wrap' }}
+          >
+            <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+              {tr(
+                `内容池共 ${stats.papers.pool_total.toLocaleString()} 篇（含每日新论文与个人收藏，不只文献库）`,
+                `${stats.papers.pool_total.toLocaleString()} papers in the shared pool (includes daily papers and personal picks, not just libraries)`,
+              )}
+            </span>
+            <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+              {tr(
+                `概念 ${stats.concepts.total.toLocaleString()} 个`,
+                `${stats.concepts.total.toLocaleString()} concepts`,
+              )}
+            </span>
+          </div>
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
+/* ---------- AI 用量与排行榜 ---------- */
+
+type UsageWindow = '7' | '30' | '90';
+
+/** 每天一根柱：下段 prompt、上段 completion（单色系明暗区分，不新造颜色）。 */
+function UsageBars({ rows }: { rows: { date: string; prompt: number; completion: number }[] }) {
+  const max = Math.max(1, ...rows.map((r) => r.prompt + r.completion));
+  // 柱子多的时候（30/90 天）只在两端标日期，免得文字糊成一片
+  const labelEvery = Math.max(1, Math.ceil(rows.length / 8));
+  return (
+    <div className="row" style={{ gap: rows.length > 40 ? 2 : 5, alignItems: 'flex-end' }}>
+      {rows.map((r, i) => {
+        const total = r.prompt + r.completion;
+        const h = Math.max(2, Math.round((total / max) * 88));
+        const promptH = total > 0 ? Math.round((r.prompt / total) * h) : h;
+        return (
+          <div key={r.date} style={{ flex: 1, minWidth: 0 }}>
+            <div
+              title={`${r.date} · ${total.toLocaleString()} tokens`}
+              style={{ height: 88, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}
+            >
+              <div
+                style={{
+                  height: h - promptH,
+                  background: 'var(--accent)',
+                  borderRadius: '3px 3px 0 0',
+                }}
+              />
+              <div
+                style={{
+                  height: promptH,
+                  background: 'var(--accent-soft)',
+                  borderRadius: h - promptH > 0 ? '0 0 2px 2px' : '3px 3px 2px 2px',
+                }}
+              />
+            </div>
+            {i % labelEvery === 0 && (
+              <div className="mono" style={{ fontSize: 9, color: 'var(--text-4)', textAlign: 'center', marginTop: 4 }}>
+                {r.date.slice(5)}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** 全实验室 AI 用量：合计 + 按天柱状 + 按环节分布。 */
+function UsageCard({ days, onDays }: { days: UsageWindow; onDays: (v: UsageWindow) => void }) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['lab-usage', days],
+    queryFn: () => api.getLabUsage(Number(days)),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const rows = useMemo(() => data ?? [], [data]);
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      prompt: acc.prompt + r.prompt_tokens,
+      completion: acc.completion + r.completion_tokens,
+      calls: acc.calls + r.calls,
+    }),
+    { prompt: 0, completion: 0, calls: 0 },
+  );
+
+  const byDay = useMemo(() => {
+    const m = new Map<string, { date: string; prompt: number; completion: number }>();
+    for (const r of rows) {
+      const cur = m.get(r.date) ?? { date: r.date, prompt: 0, completion: 0 };
+      cur.prompt += r.prompt_tokens;
+      cur.completion += r.completion_tokens;
+      m.set(r.date, cur);
+    }
+    return [...m.values()].sort((a, b) => a.date.localeCompare(b.date));
+  }, [rows]);
+
+  // 按环节（stage）分布：取消耗最多的前 6 个
+  const byStage = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const r of rows) m.set(r.stage, (m.get(r.stage) ?? 0) + r.prompt_tokens + r.completion_tokens);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6);
+  }, [rows]);
+  const stageMax = Math.max(1, ...byStage.map(([, v]) => v));
+
+  return (
+    <PanelCard
+      icon="chart"
+      title={tr('AI 用量', 'AI usage')}
+      hint={tr('全实验室的 token 消耗', 'Token consumption across the lab')}
+      action={
+        <Segmented
+          options={[
+            { v: '7' as const, label: tr('7 天', '7d') },
+            { v: '30' as const, label: tr('30 天', '30d') },
+            { v: '90' as const, label: tr('90 天', '90d') },
+          ]}
+          value={days}
+          onChange={onDays}
+        />
+      }
+      style={{ marginBottom: 0, flex: '1 1 380px', minWidth: 0 }}
+    >
+      {isLoading ? (
+        <div className="col gap10" style={{ padding: '18px' }}>
+          <div className="skel" style={{ height: 14, width: '40%' }} />
+          <div className="skel" style={{ height: 88, width: '100%' }} />
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载用量', 'Failed to load usage')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+          compact
+        />
+      ) : byDay.length === 0 ? (
+        <EmptyState
+          icon="chart"
+          title={tr('这段时间没有 AI 调用', 'No AI calls in this window')}
+          desc={tr('跑一次建库或精读编译，用量就会出现在这里。', 'Run a library build or a compile — usage shows up here afterwards.')}
+          compact
+        />
+      ) : (
+        <div style={{ padding: '16px 18px' }}>
+          <div className="row gap20" style={{ marginBottom: 14, flexWrap: 'wrap' }}>
+            <div>
+              <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>
+                {(totals.prompt + totals.completion).toLocaleString()}
+              </div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('token 合计', 'total tokens')}</div>
+            </div>
+            <div>
+              <div className="mono" style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.02em' }}>
+                {totals.calls.toLocaleString()}
+              </div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>{tr('调用次数', 'calls')}</div>
+            </div>
+          </div>
+
+          <UsageBars rows={byDay} />
+
+          <div className="row gap12" style={{ marginTop: 12, flexWrap: 'wrap' }}>
+            <span className="row gap8" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+              <span style={{ width: 9, height: 9, borderRadius: 2, background: 'var(--accent-soft)' }} />
+              {tr('输入', 'Input')} {totals.prompt.toLocaleString()}
+            </span>
+            <span className="row gap8" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+              <span style={{ width: 9, height: 9, borderRadius: 2, background: 'var(--accent)' }} />
+              {tr('输出', 'Output')} {totals.completion.toLocaleString()}
+            </span>
+          </div>
+
+          {byStage.length > 0 && (
+            <div style={{ marginTop: 16, paddingTop: 14, borderTop: '0.5px solid var(--border)' }}>
+              <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 8 }}>
+                {tr('消耗最多的环节', 'Where it goes')}
+              </div>
+              <div className="col gap8">
+                {byStage.map(([stage, value]) => (
+                  <div key={stage} className="row gap10">
+                    <span className="mono" style={{ fontSize: 11.5, width: 108, flexShrink: 0, color: 'var(--text-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {stage}
+                    </span>
+                    <span style={{ flex: 1, minWidth: 0, height: 6, borderRadius: 999, background: 'var(--surface-3)', overflow: 'hidden' }}>
+                      <span
+                        style={{ display: 'block', width: `${Math.round((value / stageMax) * 100)}%`, height: '100%', borderRadius: 999, background: 'var(--accent)' }}
+                      />
+                    </span>
+                    <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)', width: 78, textAlign: 'right', flexShrink: 0 }}>
+                      {value.toLocaleString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
+/** 成员用量排行榜：名次 + 头像 + 名称 + 用量条 + 数值。 */
+function LeaderboardCard({ days, adminView }: { days: UsageWindow; adminView: boolean }) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['lab-leaderboard', days],
+    queryFn: () => api.getLabLeaderboard({ days: Number(days), limit: 10 }),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const items = data?.items ?? [];
+  const max = Math.max(1, ...items.map((x) => x.tokens_used));
+
+  return (
+    <PanelCard
+      icon="users"
+      title={tr('用量排行榜', 'Usage leaderboard')}
+      hint={tr(`最近 ${days} 天消耗最多的成员`, `Top consumers in the last ${days} days`)}
+      action={
+        adminView && data && !data.enabled ? (
+          <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', flexShrink: 0 }}>
+            {tr('仅管理员可见', 'Admins only')}
+          </span>
+        ) : undefined
+      }
+      style={{ marginBottom: 0, flex: '1 1 340px', minWidth: 0 }}
+    >
+      {isLoading ? (
+        <div className="col gap10" style={{ padding: '16px 18px' }}>
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="skel" style={{ height: 26, width: `${95 - i * 8}%` }} />
+          ))}
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon="x"
+          title={tr('无法加载排行榜', 'Failed to load leaderboard')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+          compact
+        />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon="users"
+          title={tr('这段时间还没有人用过 AI', 'Nobody used AI in this window')}
+          desc={tr('有人跑过任务之后，排名会出现在这里。', 'Rankings show up once someone runs a task.')}
+          compact
+        />
+      ) : (
+        <div className="col gap10" style={{ padding: '14px 18px' }}>
+          {items.map((u, i) => {
+            const name = u.display_name || u.username || tr('未命名', 'Unnamed');
+            const top = i === 0;
+            return (
+              <div key={u.user_id} className="row gap10">
+                <span
+                  className="mono"
+                  style={{
+                    width: 22,
+                    height: 22,
+                    flexShrink: 0,
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 700,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: top ? 'var(--accent-soft)' : 'var(--surface-3)',
+                    color: top ? 'var(--accent-text)' : 'var(--text-3)',
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <Avatar userId={u.user_id} hasAvatar={u.has_avatar} name={name} size={24} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    title={name}
+                    style={{ fontSize: 12.5, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  >
+                    {name}
+                  </div>
+                  <div style={{ height: 5, borderRadius: 999, background: 'var(--surface-3)', overflow: 'hidden', marginTop: 5 }}>
+                    <div
+                      style={{
+                        width: `${Math.max(2, Math.round((u.tokens_used / max) * 100))}%`,
+                        height: '100%',
+                        borderRadius: 999,
+                        background: top ? 'var(--accent)' : 'var(--accent-soft)',
+                      }}
+                    />
+                  </div>
+                </div>
+                <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-2)', width: 78, textAlign: 'right', flexShrink: 0 }}>
+                  {u.tokens_used.toLocaleString()}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
+/* ---------- 跨库概念图谱 ---------- */
+
+/** 跨库图谱：默认「趋势」视图＝概念随时间的演化；可切到单个文献库。 */
+function GraphCard({ libs }: { libs: DirectionLibrarySummary[] }) {
+  const navigate = useNavigate();
+  const [libraryId, setLibraryId] = useState('');
+
+  const openPaper = useCallback((id: string) => navigate(`/papers/${id}/read`), [navigate]);
+  // 概念属于某个具体的库，先问后端它在哪个库，再跳到那个库的概念页
+  const openConcept = useCallback(
+    async (id: string) => {
+      try {
+        const concept = await api.getConcept(id);
+        navigate(`${libraryPath(concept.library_id)}?conceptId=${id}`);
+      } catch {
+        toast(tr('打不开这个概念（后端不可用）', 'Could not open this concept (backend unavailable)'), 'error');
+      }
+    },
+    [navigate],
+  );
+
+  return (
+    <PanelCard
+      icon="sparkle"
+      title={tr('概念图谱', 'Concept graph')}
+      hint={tr(
+        '默认看「趋势」：概念随时间的消长；也能切到网络、时间线、主题',
+        'Defaults to Trends — how concepts rise and fall over time; Network, Timeline, and Topics are there too',
+      )}
+      action={
+        <select
+          className="input"
+          aria-label={tr('选择文献库', 'Pick a library')}
+          value={libraryId}
+          onChange={(e) => setLibraryId(e.target.value)}
+          style={{ height: 30, fontSize: 12, maxWidth: 200, padding: '0 8px', flexShrink: 0 }}
+        >
+          <option value="">{tr('全部文献库', 'All libraries')}</option>
+          {libs.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      }
+    >
+      <div style={{ display: 'flex', height: 560 }}>
+        <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
+          <GraphTab
+            scope="lab"
+            libraryId={libraryId || undefined}
+            onOpenPaper={openPaper}
+            onOpenConcept={openConcept}
+          />
+        </Suspense>
+      </div>
+    </PanelCard>
+  );
+}
+
 function OverviewTab() {
   const { data: libs } = useLibraries();
-  const { data: days } = useQuery({
-    queryKey: ['daily-days'],
-    queryFn: () => api.listDailyDays(),
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
+  // 库/论文/概念的数字一律走后端聚合：前端把各库 paper_count 相加会把
+  // 跨库的同一篇论文重复计数，也拿不到分段与向量口径
+  const statsQuery = useQuery({
+    queryKey: ['lab-stats'],
+    queryFn: () => api.getLabStats(),
     retry: false,
     staleTime: 60_000,
   });
@@ -293,9 +785,14 @@ function OverviewTab() {
     refetchInterval: 30_000,
   });
 
+  const [usageDays, setUsageDays] = useState<UsageWindow>('30');
+
+  const stats = statsQuery.data;
   const libList = libs ?? [];
-  const dayList = days ?? [];
   const activeVoyages = (voyages ?? []).filter((v) => matchFilter(v, 'active') || matchFilter(v, 'paused')).length;
+  const admin = isAdmin(me);
+  // 开关关掉时排行榜只对管理员显示；加载中先不显示，免得闪一下又消失
+  const showLeaderboard = !!stats && (stats.leaderboard_enabled || admin);
 
   return (
     <>
@@ -304,22 +801,22 @@ function OverviewTab() {
           icon="book"
           label="文献库"
           en="Libraries"
-          value={libs ? libList.length : '—'}
-          sub={libs ? tr(`${libList.filter((l) => l.is_public).length} 个公共库`, `${libList.filter((l) => l.is_public).length} public`) : undefined}
+          value={stats ? stats.libraries.total : '—'}
+          sub={stats ? tr(`${stats.libraries.public} 个公共库`, `${stats.libraries.public} public`) : undefined}
         />
         <StatCard
           icon="file"
-          label="论文总量"
-          en="Papers"
-          value={libs ? libList.reduce((a, l) => a + l.paper_count, 0) : '—'}
-          sub={tr('全部文献库', 'across libraries')}
+          label="库内论文"
+          en="Papers in libraries"
+          value={stats ? stats.papers.library_members_deduped : '—'}
+          sub={tr('跨库同一篇只算一次', 'deduplicated across libraries')}
         />
         <StatCard
-          icon="heart"
-          label="每日新论文"
-          en="Daily papers"
-          value={days ? dayList.reduce((a, d) => a + d.count, 0) : '—'}
-          sub={tr('近 7 天', 'last 7 days')}
+          icon="sparkle"
+          label="概念"
+          en="Concepts"
+          value={stats ? stats.concepts.total : '—'}
+          sub={tr('全部文献库', 'across libraries')}
         />
         <StatCard
           icon="compass"
@@ -330,6 +827,15 @@ function OverviewTab() {
           accent
         />
       </div>
+
+      <IndexCard stats={stats} isLoading={statsQuery.isLoading} isError={statsQuery.isError} />
+
+      <div className="row gap16" style={{ marginBottom: 20, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        <UsageCard days={usageDays} onDays={setUsageDays} />
+        {showLeaderboard && <LeaderboardCard days={usageDays} adminView={admin} />}
+      </div>
+
+      <GraphCard libs={libList} />
 
       <LibrariesCard />
       <DailyCard />

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -2058,6 +2058,66 @@ function MyLlmTab() {
 
 // ---------------- 用量 ----------------
 
+/** 实验室概况页的用量排行榜是否对普通成员可见（管理员开关，默认开）。 */
+function LabLeaderboardSection() {
+  const queryClient = useQueryClient();
+  const settingQuery = useQuery({
+    queryKey: ['lab-leaderboard-enabled'],
+    queryFn: () => api.getLabLeaderboardEnabled(),
+    retry: false,
+  });
+  const enabled = settingQuery.data?.enabled ?? true;
+
+  const toggleMutation = useMutation({
+    mutationFn: (next: boolean) => api.setLabLeaderboardEnabled(next),
+    onSuccess: (r) => {
+      toast(
+        r.enabled
+          ? tr('已开启：全体成员都能看到排行榜', 'Enabled — every member can see the leaderboard')
+          : tr('已关闭：只有管理员能看到排行榜', 'Disabled — only admins can see the leaderboard'),
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['lab-leaderboard-enabled'] });
+      void queryClient.invalidateQueries({ queryKey: ['lab-stats'] });
+      void queryClient.invalidateQueries({ queryKey: ['lab-leaderboard'] });
+    },
+    onError: (e) => toast(`${tr('设置失败', 'Failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  return (
+    <div className="card card-pad" style={{ marginBottom: 20 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="chart" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('用量排行榜', 'Usage leaderboard')}
+      </div>
+      <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div id="lab-leaderboard-toggle" style={{ fontSize: 13, lineHeight: 1.4 }}>
+            {tr('在实验室概况页显示排行榜', 'Show the leaderboard on the Lab overview')}
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
+            {tr(
+              '打开后，全体成员都能在实验室工作台看到各人的 token 消耗排名。关闭后这一区只对管理员显示，成员仍然能在「设置」里看自己的用量。',
+              'When on, every member sees each person’s token consumption ranking on the Lab workbench. When off, the section shows for admins only — members can still see their own usage under Settings.',
+            )}
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          onChange={(v) => toggleMutation.mutate(v)}
+          disabled={settingQuery.isLoading || settingQuery.isError || toggleMutation.isPending}
+          aria-labelledby="lab-leaderboard-toggle"
+        />
+      </div>
+      {settingQuery.isError && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 10 }}>
+          {tr('无法加载该设置（后端不可用或无权限）', 'Failed to load this setting (backend unavailable or no permission)')}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function UsageTab() {
   const [days, setDays] = useState<'7' | '30' | '90'>('30');
   const { data, isLoading, isError, refetch } = useQuery({
@@ -2080,6 +2140,8 @@ export function UsageTab() {
   );
 
   return (
+    <>
+    <LabLeaderboardSection />
     <div className="card card-pad">
       <div className="row" style={{ justifyContent: 'space-between', marginBottom: 14 }}>
         <span className="section-h">
@@ -2135,6 +2197,7 @@ export function UsageTab() {
         </div>
       )}
     </div>
+    </>
   );
 }
 

--- a/src/frontend/src/features/wiki/GraphTab.tsx
+++ b/src/frontend/src/features/wiki/GraphTab.tsx
@@ -36,6 +36,10 @@ const TYPE_META: { v: GraphNodeType; zh: string; en: string; cssVar: string }[] 
   { v: 'author', zh: '作者', en: 'Author', cssVar: '--warn' },
 ];
 
+/** 网络图（canvas 力导向）一次能流畅推的节点数上限；超过就先提示、由用户决定要不要硬画。
+    时间线 / 趋势 / 主题都是聚合视图，不受影响。 */
+const NETWORK_NODE_LIMIT = 800;
+
 function cssColor(name: string, fallback: string): string {
   const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   return v || fallback;
@@ -1111,24 +1115,36 @@ export interface GraphTabProps {
   pid?: string;
   /** 独立库作用域：给定时图谱走 /libraries/{id}/graph */
   libraryId?: string;
+  /** 实验室作用域：走 /lab/graph（全部可见文献库的并集；同时给 libraryId 则只看那一个库） */
+  scope?: 'lab';
   onOpenPaper: (id: string) => void;
   onOpenConcept: (id: string) => void;
 }
 
-export function GraphTab({ pid, libraryId, onOpenPaper, onOpenConcept }: GraphTabProps) {
+export function GraphTab({ pid, libraryId, scope, onOpenPaper, onOpenConcept }: GraphTabProps) {
   const [view, setView] = useState<GraphView>('trends');
   const [focusConceptId, setFocusConceptId] = useState('');
-  const scopeId = libraryId ?? pid ?? '';
+  // 后端不再截断论文，全实验室能一次给上千个节点：网络图超过阈值先问一句再画
+  const [forceNetwork, setForceNetwork] = useState(false);
+  const scopeId = scope === 'lab' ? `lab:${libraryId ?? 'all'}` : (libraryId ?? pid ?? '');
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['project-graph', scopeId],
-    queryFn: () => (libraryId ? api.getLibraryGraph(libraryId) : api.getProjectGraph(scopeId)),
+    queryFn: () =>
+      scope === 'lab'
+        ? api.getLabGraph(libraryId)
+        : libraryId
+          ? api.getLibraryGraph(libraryId)
+          : api.getProjectGraph(scopeId),
     retry: false,
     staleTime: 60_000,
   });
 
-  // 切方向时清空子主题
-  useEffect(() => setFocusConceptId(''), [scopeId]);
+  // 切方向时清空子主题，并重新按节点数决定要不要拦网络图
+  useEffect(() => {
+    setFocusConceptId('');
+    setForceNetwork(false);
+  }, [scopeId]);
 
   const model = useMemo(() => (data ? buildModel(data, focusConceptId) : null), [data, focusConceptId]);
 
@@ -1161,10 +1177,17 @@ export function GraphTab({ pid, libraryId, onOpenPaper, onOpenConcept }: GraphTa
           compact
           icon="layers"
           title={tr('还没有可展示的网络', 'No network to show yet')}
-          desc={tr(
-            '先运行初始建库让论文通过筛选并完成编译，图谱会自动把论文、作者、概念连成网络。',
-            'Run the initial library build so papers get screened and compiled — the graph then links papers, authors, and concepts automatically.',
-          )}
+          desc={
+            scope === 'lab'
+              ? tr(
+                  '你能看到的文献库里还没有通过筛选并编译过的论文。任意一个库跑完初始建库后，这里会把全实验室的论文、作者、概念连成网络。',
+                  'None of the libraries you can see has screened and compiled papers yet. Once any library finishes its initial build, this links the whole lab’s papers, authors, and concepts.',
+                )
+              : tr(
+                  '先运行初始建库让论文通过筛选并完成编译，图谱会自动把论文、作者、概念连成网络。',
+                  'Run the initial library build so papers get screened and compiled — the graph then links papers, authors, and concepts automatically.',
+                )
+          }
         />
       </div>
     );
@@ -1216,7 +1239,26 @@ export function GraphTab({ pid, libraryId, onOpenPaper, onOpenConcept }: GraphTa
       </div>
 
       {model && view === 'network' && (
-        <NetworkView model={model} onOpenPaper={onOpenPaper} onOpenConcept={onOpenConcept} onFocusConcept={setFocusConceptId} />
+        model.nodes.length > NETWORK_NODE_LIMIT && !forceNetwork ? (
+          <div style={{ margin: 'auto', padding: 24 }}>
+            <EmptyState
+              compact
+              icon="layers"
+              title={tr('节点太多，网络图会很卡', 'Too many nodes for the network view')}
+              desc={tr(
+                `这一批有 ${model.nodes.length} 个节点。先用上面的「子主题」筛一下，或换「趋势」「时间线」「主题」视图看全量——它们是聚合的，不受节点数影响。`,
+                `This batch has ${model.nodes.length} nodes. Narrow it down with the subtopic filter above, or use the Trends / Timeline / Topics views — they aggregate, so node count doesn't matter.`,
+              )}
+              action={
+                <button className="btn btn-soft" onClick={() => setForceNetwork(true)}>
+                  {tr('仍然画出来', 'Render anyway')}
+                </button>
+              }
+            />
+          </div>
+        ) : (
+          <NetworkView model={model} onOpenPaper={onOpenPaper} onOpenConcept={onOpenConcept} onFocusConcept={setFocusConceptId} />
+        )
       )}
       {model && view === 'timeline' && <TimelineView model={model} onOpenPaper={onOpenPaper} />}
       {model && view === 'trends' && <TrendsView model={model} onFocusConcept={setFocusConceptId} />}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -67,20 +67,24 @@ export function WikiWorkbench({
   }, [scopeId]);
 
   // 深链 ?paper=<id>（idea 详情 / 阅读页返回）、?concept=<名称>
-  // （阅读页双链跳转，按名称解析）、?author= / ?affiliation=
-  // （阅读页作者/机构点击 → 论文库按其过滤）与 ?tab=<tab>
+  // （阅读页双链跳转，按名称解析）、?conceptId=<id>（实验室跨库图谱点概念直接进来）、
+  // ?author= / ?affiliation=（阅读页作者/机构点击 → 论文库按其过滤）与 ?tab=<tab>
   // （工作台「下一步」直达建库面板）：处理后清掉参数
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
     const p = searchParams.get('paper');
     const c = searchParams.get('concept');
+    const cid = searchParams.get('conceptId');
     const author = searchParams.get('author');
     const affiliation = searchParams.get('affiliation');
     const tabParam = searchParams.get('tab');
-    if (!p && !c && !author && !affiliation && !tabParam) return;
+    if (!p && !c && !cid && !author && !affiliation && !tabParam) return;
     if (p) {
       setPaperId(p);
       setTab('papers');
+    } else if (cid) {
+      setConceptId(cid);
+      setTab('concepts');
     } else if (c) {
       setPendingConceptName(c);
     } else if (author || affiliation) {

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -832,6 +832,8 @@ export interface ConceptRead {
   id: string;
   /** 概念所属库回指的课题；共享库（无课题回指）为 null */
   project_id: string | null;
+  /** 概念所属文献库（跨库图谱据此跳回它所在的库） */
+  library_id: string;
   name: string;
   category: ConceptCategory;
   /** 一句话定义 */
@@ -1080,6 +1082,51 @@ export interface GraphData {
   edges: GraphEdge[];
   paper_total: number;
   truncated: boolean;
+}
+
+// ============================================================
+// 实验室数据面板（/lab 概况页）
+// ============================================================
+
+export interface LabStats {
+  libraries: { total: number; public: number; personal: number };
+  papers: {
+    /** 全局内容池总量（含每日新论文、个人库导入） */
+    pool_total: number;
+    /** 可见库并集内的论文数，跨库同一篇只算一次 */
+    library_members_deduped: number;
+    compiled: number;
+  };
+  concepts: { total: number };
+  chunks: {
+    papers_with_chunks: number;
+    total_chunks: number;
+    chunks_with_embedding: number;
+    /** false 时向量存了也不能按语义搜（本机 sqlite） */
+    vector_search_supported: boolean;
+  };
+  vectors: { papers_with_embedding: number; papers_total: number };
+  /** 排行榜是否对普通成员可见（管理员开关） */
+  leaderboard_enabled: boolean;
+}
+
+export interface LabLeaderboardEntry {
+  user_id: string;
+  display_name: string | null;
+  username: string | null;
+  has_avatar: boolean;
+  role: string;
+  tokens_used: number;
+}
+
+export interface LabLeaderboardResponse {
+  enabled: boolean;
+  days: number;
+  items: LabLeaderboardEntry[];
+}
+
+export interface LabLeaderboardSetting {
+  enabled: boolean;
 }
 
 // ============================================================
@@ -3185,6 +3232,26 @@ export const api = {
   getLibraryGraph(id: string): Promise<GraphData> {
     return request<GraphData>(`/libraries/${id}/graph`);
   },
+
+  // —— 实验室数据面板（/lab 概况页） ——
+  /** 索引与内容统计（跨库论文去重，只算当前用户看得到的库）。 */
+  getLabStats(): Promise<LabStats> {
+    return request<LabStats>('/lab/stats');
+  },
+  /** 全实验室最近 N 天 token 用量（按 日期 × stage × model）。 */
+  getLabUsage(days: number): Promise<LlmUsageRow[]> {
+    return request<LlmUsageRow[]>(`/lab/usage?days=${days}`);
+  },
+  /** 成员用量排行榜；开关关掉时普通用户 403。 */
+  getLabLeaderboard(opts: { days: number; limit?: number }): Promise<LabLeaderboardResponse> {
+    const params = new URLSearchParams({ days: String(opts.days) });
+    if (opts.limit) params.set('limit', String(opts.limit));
+    return request<LabLeaderboardResponse>(`/lab/usage/leaderboard?${params}`);
+  },
+  /** 跨库图谱：不传 libraryId = 全部可见库的并集。 */
+  getLabGraph(libraryId?: string): Promise<GraphData> {
+    return request<GraphData>(`/lab/graph${libraryId ? `?library_id=${libraryId}` : ''}`);
+  },
   /** 库笔记本：全库笔记分页 + 搜索。 */
   listLibraryNotes(
     id: string,
@@ -3793,6 +3860,13 @@ export const api = {
   },
   setDailyEmbedEnabled(enabled: boolean): Promise<DailyEmbedSetting> {
     return requestJson<DailyEmbedSetting>('/admin/settings/daily-embed', 'PUT', { enabled });
+  },
+  /** 实验室概况页的用量排行榜是否对普通成员可见（admin，默认开）。 */
+  getLabLeaderboardEnabled(): Promise<LabLeaderboardSetting> {
+    return request<LabLeaderboardSetting>('/admin/settings/lab-leaderboard');
+  },
+  setLabLeaderboardEnabled(enabled: boolean): Promise<LabLeaderboardSetting> {
+    return requestJson<LabLeaderboardSetting>('/admin/settings/lab-leaderboard', 'PUT', { enabled });
   },
   /** 给最近 7 天里还没有向量的每日论文补建向量（可能耗时几十秒）。 */
   backfillDailyEmbeddings(): Promise<DailyEmbedBackfillResult> {


### PR DESCRIPTION
The lab overview computed its numbers **in the browser**, by summing the library list — which double-counted every paper sitting in more than one library. It now reads a real aggregate endpoint.

```
GET /lab/stats                    libraries · papers (deduped) · concepts · chunks · vector coverage
GET /lab/usage?days=30            token usage by day
GET /lab/usage/leaderboard        top users in a window
GET /lab/graph?library_id=…       cross-library, or one library
GET/PUT /admin/settings/lab-leaderboard
```

Stats are scoped to what the caller can see, so nobody's personal library leaks into the lab-wide totals. `/lab/graph` 404s on a library you can't see rather than confirming it exists.

## Leaderboard

Visible to everyone, with an admin toggle — `lab_leaderboard_enabled`, **default on**. Turned off, non-admins get 403 and admins still see it, marked admin-only.

Rank chip → avatar (identicon fallback) → name over a usage bar → token count. First place gets the accent treatment, bars are relative to the top scorer with a floor so small values stay visible. No new colours.

Migration `b7f3d21c8a05` indexes `llm_usage.created_at` — every windowed aggregate scans it, and unlike `llm_call_logs` it had no index.

## The graph cap is gone

`MAX_PAPERS` 150 → a defensive ceiling. **Authors stay capped**: 1066 papers at 8 authors each is ~5k author nodes that no view actually uses. Because of that, `truncated` now means *papers* were truncated — otherwise the frontend would permanently claim truncation purely because of the author cap.

**The network view refuses to render above 800 nodes.** It shows the actual count, points at the subtopic filter and the aggregate views, and offers a "draw it anyway" button. Force-drawing 3000 nodes into a force-directed canvas gives you a hairball you can't drag; better to say so than to hand you one. Trends, timeline and topics take the full set — trends is the concepts-over-time view this was all for, and it aggregates, so volume doesn't hurt it.

`ConceptRead` gains `library_id` so a concept clicked in a cross-library graph can navigate back to the library it belongs to.

## A bug found and deliberately not fixed

On sqlite, the JSON-variant embedding column stores `None` as the literal string `'null'`, so **`embedding.is_not(None)` is always true** — vector coverage reads as 100%. The stats here use a dialect-aware check. `daily_feed.embedding_coverage` has exactly the same bug; fixing it changes the numbers shown on the daily page, which is outside this. **Production Postgres is unaffected** — it only misreports in dev and test.

## Judgement call for your review

The toggle went into **admin → 用量总览** rather than next to the daily-embedding switch as specified. It governs a usage feature, and under "每日论文" nobody would find it. Same page, one tab over — easy to move.

## Verification

`ruff check app` clean, single alembic head, 26 tests across the new lab suite plus migrations, shared libraries and personal library; wider regression batches green. `tsc --noEmit` 0 errors.

`/lab/stats` issues ~8 count queries uncached — fine at 1k papers, worth revisiting an order of magnitude up.