### PR TITLE
chore(ui): cut redundant explanatory copy

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -626,7 +626,6 @@ export function AppShell() {
             <span style={{ fontSize: 15, fontWeight: 680 }}>{tr('审批中心', 'Approvals')}</span>
           </>
         }
-        sub={tr('人工审批', 'Human-in-the-loop approvals')}
       >
         <div className="row" style={{ marginBottom: 10 }}>
           <span className="sb-section" style={{ padding: 0 }}>{tr('待处理', 'Pending')} · {pending.length}</span>

--- a/src/frontend/src/app/SearchPalette.tsx
+++ b/src/frontend/src/app/SearchPalette.tsx
@@ -96,10 +96,7 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
   } else if (!showing) {
     body = (
       <div className="empty" style={{ padding: 24 }}>
-        {tr(
-          '输入关键词，搜索当前课题下的论文、概念、想法、实验、AI 任务与论文稿',
-          'Type keywords to search papers, concepts, ideas, experiments, AI tasks and drafts in this topic',
-        )}
+        {tr('输入关键词开始搜索', 'Type keywords to search')}
       </div>
     );
   } else if (query.isLoading) {

--- a/src/frontend/src/features/daily/DailyChatTab.tsx
+++ b/src/frontend/src/features/daily/DailyChatTab.tsx
@@ -83,8 +83,8 @@ export function DailyChatTab() {
       emptyIcon="chat"
       emptyTitle={tr('和最近的新论文对话', 'Chat with the latest papers')}
       emptyDesc={tr(
-        '就池里最近 7 天的每日新论文提问：找热点、比方法、挑值得细读的都行。',
-        'Ask about the daily papers from the last 7 days — spot trends, compare methods, pick what to read.',
+        '找热点、比方法、挑值得细读的都行。',
+        'Spot trends, compare methods, pick what to read.',
       )}
       suggestions={SUGGESTIONS}
       placeholder={tr('就最近 7 天的新论文提问…', 'Ask about the last 7 days of new papers…')}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -507,8 +507,8 @@ function DailyDetailPane({
           icon="pen"
           title={tr('还没有 AI 介绍', 'No AI intro yet')}
           desc={tr(
-            '点上方的编译按钮，让 AI 精读这篇论文并生成图文介绍。',
-            'Hit the compile button above to have the AI read this paper and write an illustrated intro.',
+            '点上方的编译按钮生成。',
+            'Hit the compile button above to generate one.',
           )}
         />
       )}
@@ -977,8 +977,8 @@ export function DailyPage() {
                     filtered
                       ? tr('换个关键词或过滤条件试试。', 'Try a different keyword or filter.')
                       : tr(
-                          '今天还没有新论文。arxiv 周末不发布新提交。',
-                          'No new papers yet. arxiv does not announce on weekends.',
+                          'arxiv 周末不发布新提交。',
+                          'arxiv does not announce on weekends.',
                         )
                   }
                 />

--- a/src/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/features/dashboard/DashboardPage.tsx
@@ -482,11 +482,11 @@ function LiteratureCard({
           </div>
         )}
       </div>
-      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5, marginBottom: 14 }}>
-        {hasLinked
-          ? tr('课题语料 = 关联文献库的并集；抓取论文在文献库里进行。', 'The topic corpus is the union of its linked libraries — papers are fetched inside the libraries.')
-          : tr('课题还没关联文献库；关联后即可从库里挑论文进相关研究。', 'No linked libraries yet — link one to pick papers into related work.')}
-      </div>
+      {!hasLinked && (
+        <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5, marginBottom: 14 }}>
+          {tr('课题还没关联文献库；关联后即可从库里挑论文进相关研究。', 'No linked libraries yet — link one to pick papers into related work.')}
+        </div>
+      )}
       <div className="row gap8">
         {hasLinked ? (
           <button className="btn btn-primary sm" onClick={() => onNavigate(topicPath(pid, 'research'))}>

--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -374,8 +374,8 @@ function PlanTab({ exp, onOpenGates }: { exp: ExperimentDetail; onOpenGates: () 
         >
           <Icon name="gate" size={15} />
           {tr(
-            '实验已暂停，等待算力预算审批：消耗真实算力前需人工确认方案与预算。',
-            'Experiment paused for compute budget approval: the plan and budget need a human sign-off before real compute is spent.',
+            '实验已暂停，等待算力预算审批。',
+            'Experiment paused for compute budget approval.',
           )}
           <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} onClick={onOpenGates}>
             {tr('前往审批', 'Open approvals')}
@@ -389,10 +389,6 @@ function PlanTab({ exp, onOpenGates }: { exp: ExperimentDetail; onOpenGates: () 
             compact
             icon="sparkle"
             title={exp.status === 'planning' ? tr('计划生成中…', 'Generating the plan…') : tr('计划尚未生成', 'Plan not generated yet')}
-            desc={tr(
-              '系统读入想法内容与相关文献后自动产出假设清单、复现策略与预算估计。',
-              'The system reads the idea and related papers, then produces hypotheses, a repro strategy and a budget estimate.',
-            )}
           />
         </div>
       ) : (
@@ -568,7 +564,6 @@ function SetupTab({ exp }: { exp: ExperimentDetail }) {
           compact
           icon="server"
           title={tr('尚未关联任务', 'No linked task yet')}
-          desc={tr('实验创建后会入队一个 kind=experiment 的 voyage。', 'Creating an experiment queues a kind=experiment voyage.')}
         />
       </div>
     );
@@ -674,7 +669,7 @@ function ReportTab({ exp }: { exp: ExperimentDetail }) {
             desc={
               EXPERIMENT_TERMINAL.has(exp.status)
                 ? tr('该实验未产出报告。', 'This experiment produced no report.')
-                : tr('自动迭代结束后，AI 会汇总各轮指标、图表与日志生成 markdown 报告。', 'After the auto-iteration finishes, the AI summarizes metrics, figures and logs into a markdown report.')
+                : tr('自动迭代结束后会自动生成。', 'It is generated once the auto-iteration finishes.')
             }
           />
         </div>

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -430,7 +430,6 @@ export function ExperimentPage() {
               compact
               icon="trash"
               title={tr('回收站是空的', 'Trash is empty')}
-              desc={tr('删除的实验会先进这里，可恢复或永久删除。', 'Deleted experiments land here first — restore them or delete permanently.')}
             />
           ) : (
             <EmptyState

--- a/src/frontend/src/features/experiment/NewExperimentModal.tsx
+++ b/src/frontend/src/features/experiment/NewExperimentModal.tsx
@@ -121,7 +121,6 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
           {tr('新建实验', 'New experiment')}
         </>
       }
-      sub={tr('从已晋级的想法发起实验。', 'Start an experiment from a promoted idea.')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -203,7 +202,7 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
           <input className="input mono" value={tr('2 轮', '2 runs')} disabled />
         </FormField>
       </div>
-      <FormField label={tr('GPU 提示（可选）', 'GPU hint (optional)')} en="gpu_hint" hint={tr('如 A100 / cuda:0，供计划阶段参考。', 'e.g. A100 / cuda:0 — used as a reference when planning.')}>
+      <FormField label={tr('GPU 提示（可选）', 'GPU hint (optional)')} en="gpu_hint" hint={tr('供计划阶段参考。', 'Used as a reference when planning.')}>
         <input className="input mono" value={gpuHint} onChange={(e) => setGpuHint(e.target.value)} placeholder={tr('如 1×A100', 'e.g. 1×A100')} />
       </FormField>
 
@@ -222,8 +221,8 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
             label={tr('评测模型（可选）', 'Eval model (optional)')}
             en="eval_model"
             hint={tr(
-              '实验代码将获得该模型的 API 访问（平台把接入点与密钥写入工作目录 llm_config.json），用于 ReAct 等 training-free 的 agentic 评测。',
-              'The experiment code gets API access to this model (endpoint and key written to llm_config.json in the workdir), for training-free agentic evals like ReAct.',
+              '实验代码将获得该模型的 API 访问，接入点与密钥写入工作目录 llm_config.json。',
+              'The experiment code gets API access to this model; endpoint and key are written to llm_config.json in the workdir.',
             )}
           >
             <input
@@ -247,8 +246,8 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
             label={tr('补充说明（可选）', 'Extra notes (optional)')}
             en="extra_notes"
             hint={tr(
-              '对实验的额外要求，会原文提供给计划与代码生成的 AI，比如指定数据集子集、评测协议、对比基线。',
-              'Extra requirements passed verbatim to the planning and code-writing AI, e.g. dataset subset, eval protocol, baselines to compare.',
+              '会原文提供给计划与代码生成的 AI。',
+              'Passed verbatim to the planning and code-writing AI.',
             )}
           >
             <textarea
@@ -264,8 +263,8 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
 
       <div style={{ fontSize: 11, color: 'var(--text-4)', lineHeight: 1.6 }}>
         {tr(
-          '消耗真实算力前会提交算力预算审批等待人工确认；超时/超预算自动 kill 并置 failed。进入自动迭代后，AI 每轮跑完会分析结果并决定继续改进、修错重试或停止；连续 2 轮主指标无提升也会自动停止。',
-          'Before real compute is spent, a budget approval is submitted for human sign-off; runs over time/budget are killed and marked failed. During auto-iteration the AI analyzes each run and decides to improve, debug or stop; it also stops after 2 runs in a row without metric gain.',
+          '消耗真实算力前会提交算力预算审批等待人工确认；超时或超预算会自动终止并标记失败。',
+          'Before real compute is spent, a budget approval is submitted for human sign-off; runs over time or budget are killed and marked failed.',
         )}
       </div>
     </Modal>

--- a/src/frontend/src/features/experiment/RunTab.tsx
+++ b/src/frontend/src/features/experiment/RunTab.tsx
@@ -447,7 +447,7 @@ export function RunTab({ exp, active }: { exp: ExperimentDetail; active: boolean
           <MetricChart series={[{ name: primary?.name ?? 'primary', points: primaryPoints }]} height={180} />
         ) : (
           <div className="empty" style={{ padding: 26, fontSize: 12.5 }}>
-            {tr('暂无主指标数据 · 每轮运行结束后系统会解析出主指标值画在这里', 'No primary metric data yet — each run’s value is parsed and plotted here once it finishes')}
+            {tr('暂无主指标数据', 'No primary metric data yet')}
           </div>
         )}
         <IterationStateBar exp={exp} runCount={runs.length} />
@@ -462,8 +462,8 @@ export function RunTab({ exp, active }: { exp: ExperimentDetail; active: boolean
         {runs.length === 0 ? (
           <div className="empty" style={{ padding: 28 }}>
             {tr(
-              '还没有运行记录 · 冒烟测试通过后开始自动迭代：每轮跑完 AI 会分析结果，决定继续改进、修错重试或停止',
-              'No runs yet — auto-iteration starts after the smoke test passes: the AI analyzes each run and decides to improve, debug or stop',
+              '还没有运行记录 · 冒烟测试通过后开始自动迭代',
+              'No runs yet — auto-iteration starts after the smoke test passes',
             )}
           </div>
         ) : (

--- a/src/frontend/src/features/feedback/FeedbackWidget.tsx
+++ b/src/frontend/src/features/feedback/FeedbackWidget.tsx
@@ -170,7 +170,6 @@ export function FeedbackWidget() {
             {tr('提交反馈', 'Send feedback')}
           </>
         }
-        sub={tr('缺陷、功能建议、界面体验都欢迎；截图可直接粘贴', 'Bugs, feature ideas, UI issues welcome; paste screenshots directly')}
         footer={
           <>
             <button className="btn btn-ghost" onClick={close}>{tr('取消', 'Cancel')}</button>

--- a/src/frontend/src/features/forge/DeepDiveDrawer.tsx
+++ b/src/frontend/src/features/forge/DeepDiveDrawer.tsx
@@ -137,15 +137,12 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
           <span style={{ fontSize: 15, fontWeight: 680 }}>{tr('深度生成', 'Deep Dive')}</span>
         </>
       }
-      sub={tr('AI 检索文献并起草完整研究方案，研究目标可在生成前人工确认。', 'The AI searches the literature and drafts a full proposal; the research goal can be confirmed by you first.')}
+      sub={tr('AI 检索文献并起草完整研究方案。', 'The AI searches the literature and drafts a full proposal.')}
     >
       <FormField
         label={tr('种子', 'Seed')}
         en="seed"
-        hint={tr(
-          '给 AI 一个探索起点：一段想法、一个概念、一篇论文，或把已有草案深化成完整研究方案。',
-          'Give the AI a starting point: a thought, a concept, a paper, or deepen an existing sketch into a full proposal.',
-        )}
+        hint={tr('给 AI 一个探索起点。', 'Give the AI a starting point.')}
       >
         <Segmented<DeepSeedType>
           options={SEED_TYPES.map((s) => ({ v: s.v, label: tr(s.zh, s.en) }))}
@@ -170,7 +167,7 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
       )}
 
       {seedType === 'concept' && (
-        <FormField label={tr('选择概念', 'Pick a concept')} en="concept" hint={tr('从当前课题的概念库中选一个作为探索起点。', 'Pick one from this topic’s concept library as the starting point.')}>
+        <FormField label={tr('选择概念', 'Pick a concept')} en="concept">
           <div className="col gap8">
             <input
               className="input"
@@ -192,7 +189,7 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
       )}
 
       {seedType === 'paper' && (
-        <FormField label={tr('选择论文', 'Pick a paper')} en="paper" hint={tr('从文献库中选一篇作为探索起点。', 'Pick one from the library as the starting point.')}>
+        <FormField label={tr('选择论文', 'Pick a paper')} en="paper">
           <div className="col gap8">
             <input
               className="input"
@@ -214,7 +211,7 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
       )}
 
       {seedType === 'idea' && (
-        <FormField label={tr('选择草案', 'Pick a sketch')} en="seed idea" hint={tr('把一份方向草案深化为完整研究方案，AI 会继承草案的依据文献继续探索。', 'Deepen a sketch into a full proposal; the AI inherits its evidence papers and keeps exploring.')}>
+        <FormField label={tr('选择草案', 'Pick a sketch')} en="seed idea" hint={tr('AI 会继承草案的依据文献继续探索。', 'The AI inherits the sketch’s evidence papers and keeps exploring.')}>
           <SelectMenu
             value={ideaId}
             placeholder={sketchesQuery.isLoading ? tr('加载中…', 'Loading…') : sketchesQuery.isError ? tr('（无法加载草案列表）', '(could not load sketches)') : sketches.length === 0 ? tr('（还没有草案，先运行一次想法生成）', '(no sketches yet — run idea generation first)') : tr('— 选择草案 —', '— pick a sketch —')}
@@ -233,8 +230,8 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
         label={tr('生成前人工确认研究目标', 'Confirm the research goal first')}
         en="confirm_goal"
         hint={tr(
-          'AI 构建好研究目标后先暂停等你确认（可附修改意见），确认后才继续起草方案。关闭则全程自动。',
-          'The AI pauses after building the research goal and waits for your confirmation (with optional feedback) before drafting. Turn off for fully automatic.',
+          'AI 构建好研究目标后暂停等你确认（可附修改意见），关闭则全程自动。',
+          'The AI pauses after building the research goal and waits for your confirmation (with optional feedback). Turn off for fully automatic.',
         )}
       >
         <label className="row gap8" style={{ fontSize: 12.5, cursor: 'pointer' }}>
@@ -258,8 +255,8 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
             label={tr('外部相似检索', 'External similarity search')}
             en="external_search"
             hint={tr(
-              '联网检索 Semantic Scholar / OpenAlex 做相似工作对比，新颖性核查更可靠；关闭则只查库内。',
-              'Searches Semantic Scholar / OpenAlex for similar work, making the novelty check more reliable; off means library-only.',
+              '联网检索 Semantic Scholar / OpenAlex 做相似工作对比；关闭则只查库内。',
+              'Searches Semantic Scholar / OpenAlex for similar work; off means library-only.',
             )}
           >
             <label className="row gap8" style={{ fontSize: 12.5, cursor: 'pointer' }}>
@@ -298,12 +295,6 @@ export function DeepDiveDrawer({ open, onClose, pid, initialSeedIdea }: DeepDive
           </>
         )}
       </button>
-      <div style={{ fontSize: 11, color: 'var(--text-4)', lineHeight: 1.6, marginTop: 12 }}>
-        {tr(
-          '全过程：目标构建（AI 带文献工具探索）→ 目标确认（人工）→ 方案起草（相关工作 / 设计 / 实验计划 / 新颖性核查 / 风险）→ 多评审员评审与修订 → 入候选池。进度可在任务详情页实时查看。',
-          'Full flow: goal building (AI explores with literature tools) → goal confirmation (human) → proposal drafting (related work / design / experiment plan / novelty check / risks) → multi-reviewer review & revision → into the candidate pool. Watch progress live on the task page.',
-        )}
-      </div>
     </Drawer>
   );
 }

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -329,7 +329,6 @@ function RunForgeModal({
           {tr('运行 Idea Forge', 'Run Idea Forge')}
         </>
       }
-      sub={tr('从知识库分析研究空白，生成并筛选候选想法。', 'Analyze research gaps in the knowledge base, then generate and filter candidate ideas.')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -830,13 +829,11 @@ export function ForgePage() {
               compact
               icon="trash"
               title={tr('回收站是空的', 'Trash is empty')}
-              desc={tr('删除的想法会先进这里，可恢复或永久删除。', 'Deleted ideas land here first — restore them or delete permanently.')}
             />
           ) : (
             <EmptyState
               icon="bulb"
               title={tr('候选池为空', 'The candidate pool is empty')}
-              desc={tr('运行一次想法生成，从知识库中分析研究空白并生成候选想法。', 'Run idea generation to analyze research gaps in the knowledge base and produce candidates.')}
               action={
                 <button className="btn btn-primary" disabled={running} onClick={() => setModalOpen(true)}>
                   <Icon name="play" size={14} />

--- a/src/frontend/src/features/forge/IdeaDetailPage.tsx
+++ b/src/frontend/src/features/forge/IdeaDetailPage.tsx
@@ -329,13 +329,7 @@ function RevisionTimeline({ ideaId }: { ideaId: string }) {
         <Icon name="shield" size={14} style={{ color: 'var(--accent)' }} />
         {tr('评审修订记录', 'Review & revision history')}
       </span>
-      <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.5, marginBottom: 14 }}>
-        {tr(
-          '深度生成时，多位 AI 评审员逐轮提出必须修改项，作者 AI 修订后重评（只读记录）。',
-          'During Deep Dive, multiple AI reviewers raise must-fix items each round; the author AI revises and is re-scored (read-only record).',
-        )}
-      </div>
-      <div className="scroll" style={{ maxHeight: 460, overflowY: 'auto' }}>
+      <div className="scroll" style={{ maxHeight: 460, overflowY: 'auto', marginTop: 14 }}>
         {sessions.map((s) => (
           <RevisionSessionBlock key={s.id} session={s} />
         ))}

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -111,7 +111,6 @@ function LibrariesCard() {
         <EmptyState
           icon="book"
           title={tr('还没有文献库', 'No libraries yet')}
-          desc={tr('新建一个文献库后，建库与同步任务会出现在任务标签里。', 'Create a library — its build and sync tasks will show up under the Tasks tab.')}
           compact
           action={
             <Link className="btn btn-primary sm" to="/libraries">
@@ -347,10 +346,7 @@ function IndexCard({ stats, isLoading, isError }: { stats?: LabStats; isLoading:
     <PanelCard
       icon="layers"
       title={tr('索引进度', 'Index coverage')}
-      hint={tr(
-        '论文的解读、全文分段与向量建到了什么程度——决定文献对话和语义检索能不能用',
-        'How far reading notes, full-text chunks, and embeddings have been built — this decides whether chat and semantic search work',
-      )}
+      hint={tr('决定文献对话和语义检索能不能用', 'Decides whether chat and semantic search work')}
     >
       {isLoading ? (
         <div className="col gap10" style={{ padding: '16px 18px' }}>
@@ -732,10 +728,6 @@ function GraphCard({ libs }: { libs: DirectionLibrarySummary[] }) {
     <PanelCard
       icon="sparkle"
       title={tr('概念图谱', 'Concept graph')}
-      hint={tr(
-        '默认看趋势：概念随时间的消长；也能切到网络、时间线、主题',
-        'Defaults to Trends — how concepts rise and fall over time; Network, Timeline, and Topics are there too',
-      )}
       action={
         <select
           className="input"
@@ -1032,7 +1024,7 @@ function TasksTab() {
             desc={
               filter !== 'all' || kindFilter !== 'all'
                 ? tr('当前筛选条件下没有任务，换个筛选试试。', 'No tasks match the current filters — try different ones.')
-                : tr('还没有任务。发起建库、想法生成、实验等操作后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start ingest, idea generation, experiments, and so on.')
+                : tr('发起建库、想法生成、实验等操作后，任务会出现在这里。', 'Tasks show up here once you start ingest, idea generation, experiments, and so on.')
             }
             compact
           />
@@ -1069,7 +1061,6 @@ export function LabPage() {
       <PageHead
         eyebrow="Polaris · Lab"
         title={tr('实验室工作台', 'Lab Workbench')}
-        sub={tr('实验室共享资源的总览，以及不属于任何课题的任务。', 'An overview of shared lab resources, plus tasks that belong to no topic.')}
       />
 
       <div style={{ marginBottom: 22 }}>

--- a/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
+++ b/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
@@ -152,11 +152,11 @@ export function InclusionSettingsForm({
           )}
           {suggest.isPending ? tr('生成中…', 'Generating…') : tr('AI 自动生成', 'Auto-generate with AI')}
         </button>
-        <span className="muted" style={{ fontSize: 11.5, lineHeight: 1.5 }}>
-          {canSuggest
-            ? tr('根据名称与说明推荐分类、关键词、锚点与打分标准', 'Suggests categories, keywords, anchors and rubric from the name & statement')
-            : tr('先填名称和描述', 'Fill in the name and statement first')}
-        </span>
+        {!canSuggest && (
+          <span className="muted" style={{ fontSize: 11.5, lineHeight: 1.5 }}>
+            {tr('先填名称和一句话说明', 'Fill in the name and statement first')}
+          </span>
+        )}
       </div>
       )}
 
@@ -248,11 +248,6 @@ export function InclusionSettingsForm({
             onBlur={() => { if (kwDraft.trim()) addKeywords(kwDraft); }}
             placeholder={tr('输入关键词后回车或逗号添加，如 agent', 'Type a term, press Enter or comma, e.g. agent')}
           />
-        )}
-        {!readOnly && (
-          <div className="field-hint">
-            {tr('文献追踪按这些关键词与上面的分类检索候选论文；留空则用默认分类。', 'Literature tracking searches candidates by these terms plus the categories above; leave empty for defaults.')}
-          </div>
         )}
       </div>
 

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -314,8 +314,8 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
       onClose={onClose}
       title={tr('新建文献库', 'New library')}
       sub={tr(
-        '填好方向即可创建你的个人文献库，立即可用、无需审批；之后可在库详情里申请转为公共文献库。',
-        'Fill in the direction to create your personal library — ready to use immediately, no approval needed. You can later request to make it public from the library page.',
+        '创建后是你的个人文献库，之后可在库详情里申请转为公共文献库。',
+        'Created as your personal library — you can later request to make it public from the library page.',
       )}
       width={640}
       footer={
@@ -328,15 +328,15 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
       }
     >
       <div style={{ marginTop: 4 }}>
-        <FormField label={tr('名称', 'Name')} hint={tr('将显示在文献库列表中', 'Shown in the library list')}>
+        <FormField label={tr('名称', 'Name')}>
           <input className="input" value={name} onChange={(e) => setName(e.target.value)}
             placeholder={tr('如：稀疏注意力', 'e.g. Sparse attention')} />
         </FormField>
-        <FormField label={tr('一句话说明', 'Statement')} hint={tr('这个方向研究什么（必填，用于相关性打分）', 'What this direction studies (required, used for relevance scoring)')}>
+        <FormField label={tr('一句话说明', 'Statement')} hint={tr('必填，用于相关性打分', 'Required — used for relevance scoring')}>
           <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('用一句话介绍这个文献库的方向', 'One sentence describing this library’s direction')} />
         </FormField>
-        <FormField label={tr('运行节奏', 'Cadence')} hint={tr('自动同步的运行频率', 'How often ingest runs')}>
+        <FormField label={tr('运行节奏', 'Cadence')}>
           <div>
             <Segmented options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
               value={cadence as (typeof CADENCES)[number]['v']} onChange={(v) => setCadence(v)} />
@@ -544,8 +544,8 @@ export function LibrariesPage() {
           title={tr('还没有文献库', 'No libraries yet')}
           desc={
             canCreate
-              ? tr('点右上新建文献库创建一个共享文献库。', 'Use “New library” at the top right to create a shared library.')
-              : tr('创建课题后会自动生成对应方向的文献库；先去建一个课题吧。', 'A direction library is created with each topic — create a topic first.')
+              ? undefined
+              : tr('创建课题后会自动生成对应方向的文献库。', 'A direction library is created together with each topic.')
           }
           action={
             canCreate ? (

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -124,7 +124,6 @@ const PaperRow = memo(function PaperRow({
           checked={checked}
           onClick={(e) => e.stopPropagation()}
           onChange={onToggleCheck}
-          title={tr('选中后可批量导出引用', 'Select for bulk citation export')}
           style={{
             width: 13,
             height: 13,
@@ -746,10 +745,7 @@ function PapersPane({
               open={advOpen}
               active={advActive}
               onToggle={() => setAdvOpen((o) => !o)}
-              title={tr(
-                '高级检索：范围 / 作者 / 机构 / 年份 / 我的标签 / 阅读状态',
-                'Advanced search: scope / author / affiliation / year / my tags / reading status',
-              )}
+              title={tr('高级检索', 'Advanced search')}
             />
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
               {total ? tr(`${total} 篇`, `${total}`) : ''}
@@ -794,10 +790,7 @@ function PapersPane({
                     value={advAffiliation}
                     onChange={setAdvAffiliation}
                     placeholder={tr('发表机构…', 'Affiliation…')}
-                    title={tr(
-                      '需要论文元数据带有机构信息（入库时自动从 OpenAlex 补充）',
-                      'Needs affiliation metadata (auto-filled from OpenAlex on ingest)',
-                    )}
+                    title={tr('需要论文元数据带有机构信息', 'Needs affiliation metadata on the paper')}
                   />
                 </div>
                 <YearRangeField
@@ -892,7 +885,7 @@ function PapersPane({
         >
           <button
             className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
-            title={tr('开启后列表出现复选框，可批量导出引用', 'Show checkboxes for bulk citation export')}
+            title={tr('批量导出引用', 'Bulk citation export')}
             onClick={() => {
               setSelectMode((m) => !m);
               setSelected(new Set());

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -153,8 +153,8 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
               </div>
               <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
                 {tr(
-                  '全实验室可见、维护额度由管理员承担。转为个人库后仅归属人可见，其他成员将看不到。',
-                  'Visible to the whole lab, upkeep covered by admins. Making it personal hides it from everyone but its owner.',
+                  '转为个人库后仅归属人可见，其他成员将看不到。',
+                  'Making it personal hides it from everyone but its owner.',
                 )}
               </div>
             </div>
@@ -179,8 +179,8 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
             </div>
             <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
               {tr(
-                '转为公共文献库后，本库归实验室所有、维护额度由管理员承担，你将成为该库的管理员（策展人）。',
-                'After going public it belongs to the lab, its upkeep budget is covered by admins, and you become its curator (admin).',
+                '转为公共文献库后，本库归实验室所有、维护额度由管理员承担，你将成为该库的管理员。',
+                'After going public it belongs to the lab, its upkeep budget is covered by admins, and you become its manager.',
               )}
             </div>
             {lib.review_note && (
@@ -224,10 +224,10 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
           </div>
           <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
             {pending
-              ? tr('转为公共文献库的申请正在等待管理员审批；期间本库仍照常可用。', 'The request to make this library public is awaiting an admin’s review; the library stays usable in the meantime.')
+              ? tr('等待管理员审批期间，本库仍照常可用。', 'The library stays usable while an admin reviews the request.')
               : lib.review_note
                 ? tr(`驳回理由：${lib.review_note}`, `Reason: ${lib.review_note}`)
-                : tr('未通过审批。可调整配置后请管理员重新审批。', 'Not approved. Adjust the config and ask an admin to review again.')}
+                : tr('可调整配置后请管理员重新审批。', 'Adjust the config and ask an admin to review again.')}
           </div>
         </div>
         {admin && (

--- a/src/frontend/src/features/library/AddToLibraryModal.tsx
+++ b/src/frontend/src/features/library/AddToLibraryModal.tsx
@@ -143,8 +143,8 @@ export function AddToLibraryModal({
               />
               <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
                 {tr(
-                  '编号或论文链接都行，标题、作者、摘要会自动抓取，有 PDF 的顺带下载。',
-                  'An ID or a paper link both work — title, authors and abstract are fetched automatically, plus the PDF when available.',
+                  '编号或论文链接都行，其余信息自动抓取。',
+                  'An ID or a paper link both work — the rest is fetched automatically.',
                 )}
               </div>
             </>
@@ -174,8 +174,8 @@ export function AddToLibraryModal({
           )}
           <div className="muted" style={{ fontSize: 11.5, marginTop: 10, lineHeight: 1.6 }}>
             {tr(
-              '平台上已经有这篇的话直接复用，不会重复解析；已经在回收站里的会重新回到收藏。',
-              'If the paper is already on the platform it is reused instead of parsed again; one that sits in your trash comes back to your saved papers.',
+              '已经在回收站里的会重新回到收藏。',
+              'A paper sitting in your trash comes back to your saved papers.',
             )}
           </div>
           {parseError && (

--- a/src/frontend/src/features/library/AuthorBindWizard.tsx
+++ b/src/frontend/src/features/library/AuthorBindWizard.tsx
@@ -143,8 +143,8 @@ export function AuthorBindWizard({
       </div>
       <p style={{ fontSize: 12.5, color: 'var(--text-2)', margin: '8px 0 16px', lineHeight: 1.6 }}>
         {tr(
-          '填写论文署名可能用到的姓名写法和机构，保存后每天会自动从文献库里匹配你发表的论文。',
-          'List the name spellings and affiliations you publish under. Once saved, we match your publications from the library daily.',
+          '保存后每天会自动从文献库里匹配你发表的论文。',
+          'Once saved, your publications are matched from the library daily.',
         )}
       </p>
 

--- a/src/frontend/src/features/library/DailyLikedTab.tsx
+++ b/src/frontend/src/features/library/DailyLikedTab.tsx
@@ -167,8 +167,8 @@ export function DailyLikedTab() {
               icon="heart"
               title={tr('还没有赞过的论文', 'No liked papers yet')}
               desc={tr(
-                '还没有赞过的论文。每日新论文只保留 7 天，过期后这里也会跟着清空。',
-                'No liked papers yet. Daily papers are kept for 7 days; expired ones disappear from here too.',
+                '每日新论文只保留 7 天，过期后这里也会跟着清空。',
+                'Daily papers are kept for 7 days; expired ones disappear from here too.',
               )}
             />
           ) : (

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -301,7 +301,6 @@ export function LibraryDetailPane({
           (paperLibId ? (
             <button
               className="btn btn-ghost sm"
-              title={tr('打开这篇所在的方向文献库', 'Open the direction library this paper lives in')}
               onClick={() => navigate(libraryPath(paperLibId, `?paper=${paper.id}`))}
             >
               <Icon name="book" size={13} />
@@ -491,8 +490,8 @@ export function LibraryDetailPane({
             >
               <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.6 }}>
                 {tr(
-                  '这篇论文还没有解读。可以用 AI 生成一份个人版（使用你的模型额度）。',
-                  'No wiki for this paper yet. Generate a personal one with AI (uses your model quota).',
+                  '还没有解读，可以生成一份个人版（使用你的模型额度）。',
+                  'No wiki yet — generate a personal one (uses your model quota).',
                 )}
               </div>
               <button

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -131,7 +131,7 @@ function EntryRow({
         title={
           entry.last_paper_id === null
             ? tr('源方向已删除，无法导出引用', 'Source deleted — cannot export citation')
-            : tr('选中后可批量删除 / 导出引用', 'Select for bulk delete / citation export')
+            : undefined
         }
         style={{
           width: 13,
@@ -329,8 +329,8 @@ function PersonalTrashModal({ open, onClose }: { open: boolean; onClose: () => v
       open={open}
       onClose={onClose}
       sub={tr(
-        '取消收藏的文献放在这里；召回后回到我的收藏，清空浏览记录不会动这里',
-        'Papers you unsaved land here; restoring puts them back in Saved — clearing history leaves this alone',
+        '取消收藏的文献放在这里；清空浏览记录不会动这里',
+        'Papers you unsaved land here; clearing reading history leaves this alone',
       )}
       items={items}
       total={trashQuery.data?.total}
@@ -735,10 +735,7 @@ export function LibraryPage() {
                     open={advOpen}
                     active={advActive}
                     onToggle={() => setAdvOpen((o) => !o)}
-                    title={tr(
-                      '高级检索：年份 / 作者 / 机构 / 期刊会议 / 我的标签 / 阅读状态 / 星标',
-                      'Advanced search: year / author / affiliation / venue / my tags / reading status / starred',
-                    )}
+                    title={tr('高级检索', 'Advanced search')}
                   />
                 </div>
 
@@ -857,8 +854,8 @@ export function LibraryPage() {
                         ? tr('换个关键词或放宽高级检索条件。', 'Try another keyword or loosen the filters.')
                         : tab === 'saved'
                           ? tr(
-                              '点右上角添加文献，填 arXiv 编号 / DOI / BibTeX 就能直接加进来；在论文阅读页点右上角的书签按钮也能收进这里。',
-                              'Use “Add paper” in the top right — an arXiv ID, DOI or BibTeX entry is enough. You can also tap the bookmark button on any paper reading page.',
+                              '在论文阅读页点书签按钮也能收进这里。',
+                              'Tapping the bookmark button on a paper reading page also saves it here.',
                             )
                           : tr(
                               '打开任意论文的阅读页后，会自动记录在这里。',
@@ -941,10 +938,7 @@ export function LibraryPage() {
                   <>
                     <button
                       className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
-                      title={tr(
-                        '开启后列表出现复选框，可批量删除 / 导出引用',
-                        'Show checkboxes for bulk delete / citation export',
-                      )}
+                      title={tr('批量删除 / 导出引用', 'Bulk delete / citation export')}
                       onClick={() => {
                         setSelectMode((m) => !m);
                         setSelected(new Map());
@@ -982,10 +976,6 @@ export function LibraryPage() {
                 <button
                   className="btn btn-ghost sm"
                   style={{ marginLeft: 'auto' }}
-                  title={tr(
-                    '回收站：取消收藏的文献可以召回或彻底删除',
-                    'Trash: unsaved papers — restore or delete forever',
-                  )}
                   onClick={() => setTrashOpen(true)}
                 >
                   <Icon name="trash" size={13} />

--- a/src/frontend/src/features/library/PersonalChatTab.tsx
+++ b/src/frontend/src/features/library/PersonalChatTab.tsx
@@ -86,8 +86,8 @@ export function PersonalChatTab() {
       emptyIcon="chat"
       emptyTitle={tr('和我收藏的文献对话', 'Chat with my saved papers')}
       emptyDesc={tr(
-        '跨课题地问我收藏的文献：找主题、比做法、理线索都行；/ 放入指定论文。',
-        'Ask across the papers you saved — find themes, compare methods, trace threads. Use / to pin papers.',
+        '跨课题地问我收藏的文献；输入 / 可指定某几篇。',
+        'Ask across the papers you saved; type / to pin specific ones.',
       )}
       suggestions={SUGGESTIONS}
       placeholder={tr('就我收藏的文献提问，或输入 / 放入上下文…', 'Ask about your saved papers, or type / for context…')}

--- a/src/frontend/src/features/library/PublicationsTab.tsx
+++ b/src/frontend/src/features/library/PublicationsTab.tsx
@@ -436,13 +436,9 @@ export function PublicationsTab({
       {/* —— 待确认 —— */}
       {pendingCount > 0 && (
         <section>
-          <div className="section-h">{tr(`待确认（${pendingCount}）`, `To confirm (${pendingCount})`)}</div>
-          <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '4px 0 10px', lineHeight: 1.5 }}>
-            {tr(
-              '自动匹配到的、可能是你发表的论文，确认后会进入下面的列表。',
-              'Papers matched automatically that may be yours — confirm to add them to your list.',
-            )}
-          </p>
+          <div className="section-h" style={{ marginBottom: 10 }}>
+            {tr(`待确认（${pendingCount}）`, `To confirm (${pendingCount})`)}
+          </div>
           <PubList>
             {pending.map((pub, i) => (
               <PubRow
@@ -503,10 +499,6 @@ export function PublicationsTab({
               compact
               icon="file"
               title={tr('还没有已确认的发表', 'No confirmed publications yet')}
-              desc={tr(
-                '点立即扫描文献库找找你的论文，或用手动添加补充。',
-                'Tap Scan library now to look for your papers, or add them manually.',
-              )}
             />
           ) : (
             <PubList>

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -185,10 +185,6 @@ function StartReviewModal({
           {tr('发起同行评审', 'Start peer review')}
         </>
       }
-      sub={tr(
-        '先自动核验全部引用、逐条查错，再由三位 AI 评审员从不同角度打分，最后汇总出结论',
-        'All citations are verified and facts checked automatically first, then three AI reviewers score from different angles and the results are aggregated into a conclusion',
-      )}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -212,8 +208,8 @@ function StartReviewModal({
         label={tr('评审员人设', 'Reviewer personas')}
         en="personas"
         hint={tr(
-          '每个人设是一位独立的 AI 评审员：名字 + 评审立场。默认三位可直接编辑或增删。',
-          'Each persona is an independent AI reviewer: a name plus a stance. Edit, add, or remove the three defaults directly.',
+          '每个人设是一位独立的 AI 评审员，默认三位可直接编辑或增删。',
+          'Each persona is an independent AI reviewer; edit, add, or remove the three defaults directly.',
         )}
       >
         <div className="col gap8">
@@ -817,7 +813,7 @@ function ReviewDiscussion({ sessionId }: { sessionId: string }) {
           </div>
         ) : messages.length === 0 ? (
           <div className="empty" style={{ padding: 24 }}>
-            {tr('还没有讨论 — 对评审意见有异议或补充，写在这里', 'No discussion yet — disagree with or add to the reviews here')}
+            {tr('还没有讨论', 'No discussion yet')}
           </div>
         ) : (
           messages.map((m) => <DiscussionBubble key={m.id} msg={m} />)
@@ -1112,10 +1108,7 @@ export function PaperReviewPage() {
               {tr('评审中', 'Reviewing')}
             </span>
             <span style={{ fontSize: 13.5, fontWeight: 650 }}>
-              {tr(
-                '同行评审进行中：核验引用 → 查错 → 评审员打分 → 汇总 — 点击看实时进度',
-                'Peer review in progress: citation check → fact check → reviewer scoring → aggregation — click for live progress',
-              )}
+              {tr('同行评审进行中 — 点击看实时进度', 'Peer review in progress — click for live progress')}
             </span>
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginLeft: 'auto' }}>
               {tr('任务', 'task')} {runningReview.id.slice(0, 8)}…
@@ -1138,8 +1131,8 @@ export function PaperReviewPage() {
             icon="pen"
             title={tr('还没有可评审的稿件', 'No reviewable manuscripts yet')}
             desc={tr(
-              '同行评审只对编译成功的稿件开放。先在论文撰写页完成编译，再回来发起评审。',
-              'Peer review only works on successfully compiled manuscripts. Compile on the Paper Writer page first, then come back.',
+              '同行评审只对编译成功的稿件开放。',
+              'Peer review only works on successfully compiled manuscripts.',
             )}
             action={
               <button className="btn btn-ghost" onClick={() => navigate(topicPath(pid, 'writer'))}>
@@ -1185,8 +1178,8 @@ export function PaperReviewPage() {
             icon="shield"
             title={tr('这篇稿件还没评审过', 'This manuscript has not been reviewed yet')}
             desc={tr(
-              '发起同行评审：自动核验每条引用、逐条查数字和说法的错误，再由三位不同立场的 AI 评审员打分，最后汇总出接收/拒稿建议。',
-              'Start a peer review: every citation is verified and numbers/claims are checked automatically, then three AI reviewers with different stances score the paper, aggregated into an accept/reject recommendation.',
+              '自动核验引用与数字，再由三位 AI 评审员打分，汇总出接收/拒稿建议。',
+              'Citations and numbers are checked automatically, then three AI reviewers score the paper and the results are aggregated into an accept/reject recommendation.',
             )}
             action={
               <button className="btn btn-primary" disabled={!!runningReview} onClick={() => setModalOpen(true)}>

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -308,7 +308,6 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
         open={linkOpen}
         onClose={() => setLinkOpen(false)}
         title={tr('管理关联文献库', 'Linked libraries')}
-        sub={tr('课题语料 = 所选文献库的并集；可全部不选。', 'The topic corpus is the union of the selected libraries — selecting none is allowed.')}
         width={600}
         footer={
           <>
@@ -347,9 +346,6 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
             </button>
           }
         >
-          <div className="field-hint" style={{ marginBottom: 10 }}>
-            {tr('课题语料 = 所有关联文献库的并集；想法生成、检索都跑在并集上。', 'The topic corpus is the union of all linked libraries — idea generation and search run over that union.')}
-          </div>
           {sourceLibraries === undefined ? (
             <div style={{ fontSize: 13, color: 'var(--text-4)' }}>{tr('加载中…', 'Loading…')}</div>
           ) : sourceLibraries.length === 0 ? (

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -72,21 +72,17 @@ export function ProjectWizardPage() {
       <PageHead
         eyebrow="Polaris · Topics"
         title={tr('新建课题', 'New topic')}
-        sub={tr(
-          '名称 + 一句话即可创建；再选几个文献库作为语料（可跳过，稍后在课题设置里加）。',
-          'Just a name and one sentence to create — then pick a few libraries as your corpus (optional, add later in topic settings).',
-        )}
       />
 
       {/* —— 名称 + 一句话 —— */}
       <div className="card card-pad" style={{ marginBottom: 12 }}>
-        <FormField label={tr('课题名称', 'Name')} hint={tr('将显示在侧栏与课题列表中', 'Shown in the sidebar and topic list')}>
+        <FormField label={tr('课题名称', 'Name')}>
           <input className="input" value={name} onChange={(e) => setName(e.target.value)}
             placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
         </FormField>
         <FormField
           label={tr('一句话定义', 'Statement')}
-          hint={tr('用一句话说清这个课题研究什么、为什么重要（可选）', 'One sentence on what this topic studies and why it matters (optional)')}
+          hint={tr('一句话说清研究什么（可选）', 'One sentence on what this topic studies (optional)')}
         >
           <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
@@ -109,8 +105,8 @@ export function ProjectWizardPage() {
         </div>
         <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '2px 0 12px', lineHeight: 1.6 }}>
           {tr(
-            '课题的语料 = 关联文献库的并集；文献库由文献库管理员维护，可全部不选跳过。',
-            'A topic’s corpus is the union of its linked libraries, maintained by library admins — you can skip this.',
+            '可以不选，稍后在课题设置里加。',
+            'Optional — you can add libraries later in topic settings.',
           )}
         </div>
         {librariesQuery.isLoading ? (

--- a/src/frontend/src/features/reading/ChatPanel.tsx
+++ b/src/frontend/src/features/reading/ChatPanel.tsx
@@ -152,8 +152,8 @@ export function ChatPanel({ paperId, pid }: { paperId: string; pid: string }) {
       emptyIcon="chat"
       emptyTitle={tr('问问 AI 这篇论文', 'Ask AI about this paper')}
       emptyDesc={tr(
-        '比如它解决了什么问题、方法核心、与前作差别；@ 可把推荐连同阅读链接分享给同事。',
-        'e.g. the problem, the core method, the difference from prior work; use @ to share with the read link.',
+        '比如它解决了什么问题、方法核心、与前作差别。',
+        'e.g. the problem, the core method, the difference from prior work.',
       )}
       placeholder={tr('针对这篇论文提问，或 @ 分享…', 'Ask about this paper, or @ to share…')}
       renderAssistant={(m: ChatMsg) => <Markdown source={m.content} style={{ fontSize: 12.5 }} />}

--- a/src/frontend/src/features/reading/HighlightsPanel.tsx
+++ b/src/frontend/src/features/reading/HighlightsPanel.tsx
@@ -234,7 +234,7 @@ export function HighlightsPanel({
             compact
             icon="pen"
             title="还没有划线"
-            desc="在左边 PDF 里选中句子，点弹出的颜色即可划线，之后能在这里加批注。"
+            desc="在左边 PDF 里选中句子，点弹出的颜色即可划线。"
           />
         ) : (
           highlights.map((h) => (

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -313,7 +313,7 @@ export function InfoPanel({
               compact
               icon="pen"
               title={tr('还没有 AI 精读页', 'No AI deep-read page yet')}
-              desc={tr('这篇论文还没被 AI 精读整理过（相关度不足，或还没运行初始建库 / 增量同步）。', 'This paper has not been deep-read by AI yet (relevance too low, or initial library build / incremental sync has not run).')}
+              desc={tr('可能是相关度不足，或还没运行初始建库 / 增量同步。', 'Possibly low relevance, or the initial library build / incremental sync has not run.')}
             />
             <div className="col" style={{ alignItems: 'center', gap: 6, marginTop: 10 }}>
               <button

--- a/src/frontend/src/features/reading/NotesPanel.tsx
+++ b/src/frontend/src/features/reading/NotesPanel.tsx
@@ -162,7 +162,6 @@ export function NotesPanel({ paperId, pid }: NotesPanelProps) {
             compact
             icon="pen"
             title={tr('还没有笔记', 'No notes yet')}
-            desc={tr('在下方写下第一条阅读笔记，支持 Markdown 格式。', 'Write your first reading note below — Markdown supported.')}
           />
         ) : (
           notes.map((n) => (

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -417,7 +417,7 @@ export function PdfReader({
           title="该论文还没有 PDF"
           desc={
             canFetch
-              ? '可以从 arXiv 自动下载一份，下载后就能在这里阅读、划线。'
+              ? undefined
               : '这篇论文不是 arXiv 来源，暂时不支持自动下载 PDF，可以通过右上角原文链接查看。'
           }
           action={

--- a/src/frontend/src/features/research/AddPaperModal.tsx
+++ b/src/frontend/src/features/research/AddPaperModal.tsx
@@ -86,7 +86,6 @@ export function AddPaperModal({
       onClose={onClose}
       width={600}
       title={tr('添加文献', 'Add paper')}
-      sub={tr('加入这个课题的相关研究，可以连续添加多篇。', 'Add to related work for this topic — add several in a row.')}
     >
       <Segmented<AddTab> options={TABS.map((t) => ({ v: t.v, label: tr(t.zh, t.en) }))} value={tab} onChange={setTab} />
 
@@ -187,8 +186,8 @@ export function AddPaperModal({
           </div>
           <div style={{ fontSize: 11.5, color: 'var(--text-4)', marginTop: 10, lineHeight: 1.6 }}>
             {tr(
-              '会自动查重：平台已有这篇时直接复用，不会重复解析。文献库里没有的论文会自动抓取元数据和 PDF，只进这个课题的相关研究和你的个人文献库，不影响公共文献库。',
-              'Duplicates are detected automatically — papers already on the platform are reused without re-parsing. New papers are fetched (metadata + PDF) and go to this topic and your personal library only; the shared library is untouched.',
+              '自动查重；新论文只进这个课题和你的个人文献库，不影响公共文献库。',
+              'Duplicates are reused automatically; new papers go to this topic and your personal library only — the shared library is untouched.',
             )}
           </div>
         </div>

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -296,34 +296,26 @@ function LinkedLibrariesBar({
           </div>
         </div>
       ) : (
-        <>
-          <div className="row gap8" style={{ flexWrap: 'wrap' }}>
-            {libs.map((lib) => (
-              <button
-                key={lib.id}
-                className="btn btn-soft sm"
-                style={{ maxWidth: 300 }}
-                title={lib.name}
-                onClick={() => onNavigate(libraryPath(lib.id))}
-              >
-                <Icon name="book" size={12} style={{ flexShrink: 0 }} />
-                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
-                  {lib.name}
-                </span>
-                <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
-                  {tr(`${lib.paper_count} 篇`, `${lib.paper_count}`)}
-                </span>
-                <LibStatusBadge status={lib.status} />
-              </button>
-            ))}
-          </div>
-          <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.55, marginTop: 10 }}>
-            {tr(
-              '这些库的论文并集就是课题的可用语料；下面相关研究是你从中手挑出来的一小撮，两个数不一样是正常的。',
-              'The union of these libraries is the corpus available to this topic; the related work below is the handful you hand-picked — the two counts differ by design.',
-            )}
-          </div>
-        </>
+        <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+          {libs.map((lib) => (
+            <button
+              key={lib.id}
+              className="btn btn-soft sm"
+              style={{ maxWidth: 300 }}
+              title={lib.name}
+              onClick={() => onNavigate(libraryPath(lib.id))}
+            >
+              <Icon name="book" size={12} style={{ flexShrink: 0 }} />
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+                {lib.name}
+              </span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
+                {tr(`${lib.paper_count} 篇`, `${lib.paper_count}`)}
+              </span>
+              <LibStatusBadge status={lib.status} />
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );
@@ -403,8 +395,8 @@ function ShelfTrashModal({ pid, open, onClose }: { pid: string; open: boolean; o
       open={open}
       onClose={onClose}
       sub={tr(
-        '从相关研究移出的论文；召回后回到列表，个人库里的收藏一直都在',
-        'Papers removed from related work; restoring puts them back — your saved copies are untouched',
+        '个人库里的收藏不受影响',
+        'Your saved copies in my library are untouched',
       )}
       items={items}
       total={trashQuery.data?.total}
@@ -993,7 +985,6 @@ export function ResearchPage() {
                     compact
                     icon="pin"
                     title={tr('还没有添加论文', 'No papers yet')}
-                    desc={tr('这个课题直接依赖的论文会列在这里。', 'Papers this topic builds on will show up here.')}
                   />
                 )
               ) : visible.length === 0 ? (
@@ -1131,8 +1122,8 @@ export function ResearchPage() {
                   icon="pin"
                   title={tr('从文献库挑几篇开始', 'Start by picking a few papers')}
                   desc={tr(
-                    '把这个课题直接依赖的论文放进来，给每篇写一句为什么相关——后面的想法、实验、写作都会以这里为地基。',
-                    'Shelve the papers this topic builds on and note why each matters — ideas, experiments and writing all build on this.',
+                    '把课题直接依赖的论文放进来，写一句为什么相关。',
+                    'Shelve the papers this topic builds on, and note why each matters.',
                   )}
                   action={
                     <div className="row gap10" style={{ justifyContent: 'center' }}>

--- a/src/frontend/src/features/research/ShelfChatTab.tsx
+++ b/src/frontend/src/features/research/ShelfChatTab.tsx
@@ -83,15 +83,15 @@ export function ShelfChatTab({ pid }: ShelfChatTabProps) {
       title={tr('相关研究对话', 'Related work chat')}
       contextKinds={['paper', 'idea', 'experiment', 'concept']}
       hint={tr(
-        '只就本课题相关研究里的这批论文回答，问对比、归类、找空白都行；[n] 为引用来源编号。',
-        'Answers stay within this topic’s related work; ask for comparisons, groupings or open problems. [n] marks a source number.',
+        '只回答本课题相关研究里这批论文的问题；[n] 是引用来源编号。',
+        'Answers stay within this topic’s related work; [n] marks a source number.',
       )}
       headerAction={<BuildIndexButton build={() => api.buildShelfIndex(pid)} />}
       emptyIcon="chat"
       emptyTitle={tr('和本课题的相关研究对话', 'Chat with this topic’s related work')}
       emptyDesc={tr(
-        '范围锁定在你加进相关研究的这批论文，比通用文献库更贴题；/ 放入指定论文，@ 分享给同事。',
-        'Scoped to the papers you shelved as related work — closer to your topic than the whole library. Use / to pin papers, @ to share.',
+        '范围锁定在你加进相关研究的这批论文。',
+        'Scoped to the papers you shelved as related work.',
       )}
       suggestions={SUGGESTIONS}
       placeholder={tr('就本课题相关研究提问，或输入 / 放入上下文、@ 分享…', 'Ask about this related work, or type / for context, @ to share…')}

--- a/src/frontend/src/features/review/DiscussionPanel.tsx
+++ b/src/frontend/src/features/review/DiscussionPanel.tsx
@@ -106,7 +106,7 @@ export function DiscussionPanel({ ideaId }: { ideaId: string }) {
           </div>
         ) : messages.length === 0 ? (
           <div className="empty" style={{ padding: 24 }}>
-            {tr('还没有讨论 — 说点什么，给 agent 评审提供人类视角', 'No discussion yet — say something to give the agent reviewers a human perspective')}
+            {tr('还没有讨论', 'No discussion yet')}
           </div>
         ) : (
           messages.map((m) => <DiscussionBubble key={m.id} msg={m} />)

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -88,7 +88,6 @@ function TournamentModal({ open, onClose, pid }: { open: boolean; onClose: () =>
           {tr('运行评审锦标赛', 'Run review tournament')}
         </>
       }
-      sub={tr('候选想法两两配对辩论，按胜负更新排名。', 'Candidate ideas debate in pairs; rankings update by wins and losses.')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -121,10 +120,7 @@ function TournamentModal({ open, onClose, pid }: { open: boolean; onClose: () =>
       <FormField
         label={tr('评审人设', 'Reviewer personas')}
         en="personas"
-        hint={tr(
-          '每个人设是一个 agent 评审：名字 + 立场（stance）。默认三人设可直接编辑。',
-          'Each persona is one agent reviewer: a name plus a stance. The three defaults are editable.',
-        )}
+        hint={tr('每个人设是一位 AI 评审员，默认三位可直接编辑。', 'Each persona is one AI reviewer; the three defaults are editable.')}
       >
         <div className="col gap8">
           {personas.map((p, i) => (
@@ -448,7 +444,6 @@ function MatchesTab({
           compact
           icon="scale"
           title={tr('选择一个想法', 'Pick an idea')}
-          desc={tr('从上方下拉或排行榜点入，查看其全部辩论场次。', 'Pick from the dropdown above or click through from the leaderboard to see all its debates.')}
         />
       ) : sessionsQuery.isLoading ? (
         <div className="empty" style={{ padding: 30 }}>{tr('加载场次…', 'Loading matches…')}</div>
@@ -464,7 +459,6 @@ function MatchesTab({
           compact
           icon="scale"
           title={tr('暂无对局记录', 'No matches yet')}
-          desc={tr('运行一次评审后，这里会出现该想法的每场辩论。', 'Run a review and every debate for this idea will show up here.')}
         />
       ) : (
         <div className="row gap16" style={{ alignItems: 'flex-start' }}>

--- a/src/frontend/src/features/settings/AcademicIdentitySection.tsx
+++ b/src/frontend/src/features/settings/AcademicIdentitySection.tsx
@@ -64,15 +64,9 @@ export function AcademicIdentitySection() {
 
   return (
     <div className="card card-pad" style={{ maxWidth: 560, marginTop: 20 }}>
-      <div className="section-h" style={{ marginBottom: 4 }}>
+      <div className="section-h" style={{ marginBottom: 14 }}>
         <Icon name="users" size={15} style={{ color: 'var(--accent)' }} />
         {tr('学术身份', 'Academic identity')}
-      </div>
-      <div style={{ fontSize: 12.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
-        {tr(
-          '填写论文署名用的姓名和机构，用来从文献库匹配你发表的论文；论文列表在文献库 → 我发表的里查看。',
-          'List the names and affiliations you publish under so we can match your publications from the library; see them under Library → My publications.',
-        )}
       </div>
 
       {profileQuery.isLoading ? (

--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -46,7 +46,7 @@ export function AdminSettingsPage() {
         <EmptyState
           icon="shield"
           title={tr('无权访问', 'No access')}
-          desc={tr('这些设置只对管理员开放，个人设置请到设置页。', 'These settings are admin-only. Your own settings live on the Settings page.')}
+          desc={tr('这些设置只对管理员开放。', 'These settings are admin-only.')}
           action={<Link className="btn btn-soft" to="/settings">{tr('去个人设置', 'Go to settings')}</Link>}
         />
       ) : (

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -225,8 +225,8 @@ function ChatPrefsTab() {
           </div>
           <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
             {tr(
-              '打开后可为你的相关研究/个人文献库的论文建立全文索引，让 AI 文献对话检索得更准（会消耗你的模型额度抓取和嵌入全文）。',
-              'When on, you can build a full-text index for the papers in your related work and personal library, so AI literature chat retrieves more accurately (it uses your model quota to fetch and embed the full text).',
+              '文献对话检索得更准；会消耗你的模型额度抓取和嵌入全文。',
+              'Literature chat retrieves more accurately; uses your model quota to fetch and embed the full text.',
             )}
           </div>
         </div>
@@ -257,12 +257,6 @@ function PreferencesTab() {
         <div style={{ flex: 1, minWidth: 0 }}>
           <div id="pref-task-log-history" style={{ fontSize: 13, lineHeight: 1.4 }}>
             {tr('任务终端展示历史日志', 'Show past logs in the task terminal')}
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
-            {tr(
-              '打开任务详情时加载已保存的日志与大模型输出，刷新页面或任务结束后仍可回看。',
-              'Loads saved logs and model output when you open a task, so they survive a refresh or task completion.',
-            )}
           </div>
         </div>
         <Switch
@@ -473,7 +467,6 @@ function SshTab() {
         onClose={() => setModalOpen(false)}
         width={560}
         title={tr('添加 SSH 凭据', 'Add SSH credential')}
-        sub={tr('私钥加密存储，仅用于你自己的实验任务', 'Private key stored encrypted; used only for your own experiments')}
         footer={
           <>
             <button className="btn btn-ghost" onClick={() => setModalOpen(false)}>{tr('取消', 'Cancel')}</button>
@@ -1522,8 +1515,8 @@ function CallLogsSection() {
       </div>
       <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
         {tr(
-          '开启后会记录每次 LLM API 调用的完整输入与输出（图片只存大小占位，不存原图），用于排查问题；注意存储占用，日志只保留最近 7 天。',
-          'When enabled, the full input and output of every LLM API call is recorded (images are stored as size placeholders only) for debugging. Mind the storage cost; logs are kept for 7 days only.',
+          '图片只存大小占位，不存原图；注意存储占用，日志只保留最近 7 天。',
+          'Images are stored as size placeholders only; mind the storage cost — logs are kept for 7 days.',
         )}
       </div>
 
@@ -1629,8 +1622,8 @@ function AffiliationModeSection() {
       </div>
       <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
         {tr(
-          '大模型从论文标题页解析每位作者所属机构的时机。选编译 wiki 时抽取会把机构解析折叠进精读编译那一次调用里，省下一次单独的大模型调用。（DOI 论文的机构由 OpenAlex 结构化数据直接给出，不受此设置影响。）',
-          "When the model parses each author's affiliation from the title page. \"Extract while compiling\" folds it into the deep-reading compile call, saving a separate LLM call. (Affiliations for DOI papers come straight from OpenAlex and are unaffected.)",
+          '大模型从论文标题页解析作者机构的时机；DOI 论文的机构来自 OpenAlex，不受此设置影响。',
+          "When the model parses author affiliations from the title page. DOI papers get affiliations from OpenAlex and are unaffected.",
         )}
       </div>
       {isLoading ? (
@@ -1982,8 +1975,8 @@ function MyLlmTab() {
               </div>
               <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 4, lineHeight: 1.5 }}>
                 {tr(
-                  '当前使用平台默认的 Provider 与路由表（见下方，只读）。你也可以取消接管，改用自己的 Provider 与密钥。',
-                  'You are using the platform default providers and routing (shown below, read-only). You may remove the takeover and use your own providers and keys instead.',
+                  '当前使用平台默认的 Provider 与路由表（见下方，只读）。',
+                  'You are using the platform default providers and routing (shown below, read-only).',
                 )}
               </div>
               <div style={{ marginTop: 12 }}>
@@ -2036,8 +2029,8 @@ function MyLlmTab() {
             </div>
             <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 4, lineHeight: 1.5 }}>
               {tr(
-                '下面的 Provider 与路由表只对你自己生效（BYO key，后端只写不读）。配好后即可用自己的密钥调用模型。',
-                'The providers and routing below apply only to you (BYO key, write-only on the backend). Once set up, models are called with your own keys.',
+                '下面的 Provider 与路由表只对你自己生效（BYO key，后端只写不读）。',
+                'The providers and routing below apply only to you (BYO key, write-only on the backend).',
               )}
             </div>
           </div>
@@ -2097,8 +2090,8 @@ function LabLeaderboardSection() {
           </div>
           <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
             {tr(
-              '打开后，全体成员都能在实验室工作台看到各人的 token 消耗排名。关闭后这一区只对管理员显示，成员仍然能在设置里看自己的用量。',
-              'When on, every member sees each person’s token consumption ranking on the Lab workbench. When off, the section shows for admins only — members can still see their own usage under Settings.',
+              '打开后全体成员都能看到各人的 token 消耗排名；关闭则只对管理员显示。',
+              'When on, every member sees each person’s token consumption ranking; when off, admins only.',
             )}
           </div>
         </div>
@@ -2503,8 +2496,8 @@ function DailyEmbedSection() {
           </div>
           <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
             {tr(
-              '打开后，每天同步时会给新论文生成向量（会消耗嵌入额度）；打开后每日论文的语义检索才有数据，问答也能按正文片段回答。关闭时每日论文只能用关键词检索，问答只按摘要兜底。',
-              'When on, the daily sync generates embeddings for new papers (this consumes embedding quota). Only then does semantic search over daily papers have data, and chat can answer from body passages. When off, daily papers support keyword search only and chat falls back to abstracts.',
+              '每天同步时给新论文建向量，会消耗嵌入额度；关闭则每日论文只能用关键词检索。',
+              'The daily sync embeds new papers and consumes embedding quota; when off, daily papers support keyword search only.',
             )}
           </div>
         </div>
@@ -2528,8 +2521,8 @@ function DailyEmbedSection() {
       >
         <div style={{ flex: 1, minWidth: 0, fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45 }}>
           {tr(
-            '历史论文不会自动补建。点右边的按钮，给最近 7 天里还没有向量的每日论文补一遍，可能要跑几十秒。',
-            'Existing papers are not embedded automatically. Use the button to embed the daily papers from the past 7 days that still lack vectors — it may take tens of seconds.',
+            '历史论文不会自动补建，补一遍可能要跑几十秒。',
+            'Existing papers are not embedded automatically; a backfill may take tens of seconds.',
           )}
         </div>
         <button
@@ -2655,7 +2648,6 @@ function CreateUserModal({ onClose }: { onClose: () => void }) {
       onClose={onClose}
       width={520}
       title={tr('添加用户', 'Add user')}
-      sub={tr('创建一个新账号并设定初始密码', 'Create a new account with an initial password')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -3204,7 +3196,7 @@ function CreateCodeModal({ onClose }: { onClose: () => void }) {
       onClose={onClose}
       width={440}
       title={tr('生成注册码', 'Generate registration code')}
-      sub={tr('把生成的码发给需要注册的人。可设置有效期与使用次数上限。', 'Share the code with people who need to register. You can cap its lifetime and number of uses.')}
+      sub={tr('生成后自动复制，发给需要注册的人。', 'Copied automatically once created — share it with people who need to register.')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -327,7 +327,7 @@ export function PaperNotesSection({
             />
           ) : notes.length === 0 ? (
             <div className="empty" style={{ padding: '4px 0 12px', textAlign: 'left' }}>
-              {tr('还没有笔记，在下面写第一条。', 'No notes yet — write your first one below.')}
+              {tr('还没有笔记。', 'No notes yet.')}
             </div>
           ) : (
             notes.map((n) => <NoteCard key={n.id} note={n} canEdit onSaved={refresh} />)

--- a/src/frontend/src/features/shared/UnderConstruction.tsx
+++ b/src/frontend/src/features/shared/UnderConstruction.tsx
@@ -51,10 +51,7 @@ export function UnderConstruction(props: UnderConstructionProps) {
           </span>
         </div>
         <p style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.6, margin: '14px 0 0' }}>
-          {tr(
-            `本模块为 M1 骨架占位页。当前仅提供导航与信息架构，功能实现排期见里程碑 ${milestone}（M2–M5 迭代交付）。以下为规划中的功能点：`,
-            `This module is an M1 skeleton placeholder — only navigation and information architecture for now. Implementation is scheduled for ${milestone} (delivered iteratively across M2–M5). Planned features:`,
-          )}
+          {tr('以下是规划中的功能点：', 'Planned features:')}
         </p>
       </div>
 

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -207,7 +207,7 @@ export function StartPage() {
       ) : (
         <div className="card" style={{ padding: '28px 24px', textAlign: 'center', marginBottom: 20 }}>
           <div style={{ fontSize: 13, color: 'var(--text-3)', lineHeight: 1.6 }}>
-            {tr('你还没有课题。只需名称和一句话描述，30 秒创建第一个课题。', 'You have no topics yet. With just a name and one sentence, your first topic is 30 seconds away.')}
+            {tr('你还没有课题，只需名称和一句话描述即可创建。', 'No topics yet — a name and one sentence is all it takes.')}
           </div>
         </div>
       )}

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -211,7 +211,7 @@ function ActivityBar({
       {status === 'paused_error' && (
         <div className="row gap8" style={{ marginTop: 12, padding: '10px 14px', background: 'var(--danger-bg)', color: 'var(--danger-tx)', borderRadius: 10, fontSize: 12.5 }}>
           <Icon name="x" size={14} />
-          {tr('任务因错误暂停：暂时性故障可直接重试；若是程序问题，修复后再重试，已完成的步骤不会重跑。', 'Task paused on an error. Retry directly for transient failures; for code issues, fix first then retry — finished steps will not rerun.')}
+          {tr('任务因错误暂停。重试会从断点继续，已完成的步骤不会重跑。', 'Task paused on an error. Retrying resumes from where it stopped — finished steps will not rerun.')}
           {onResume && (
             <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} disabled={resuming} onClick={onResume}>
               {resuming ? tr('重试中…', 'Retrying…') : tr('重试恢复', 'Retry & resume')}

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -291,7 +291,7 @@ export function VoyagesList({
                 desc={
                   filter !== 'all' || kindFilter !== 'all'
                     ? tr('当前筛选条件下没有任务，换个筛选试试。', 'No tasks match the current filters — try different ones.')
-                    : tr('还没有任务。想法生成、实验、论文起草等操作发起后，任务会出现在这里。', 'No tasks yet. Tasks show up here once you start idea generation, experiments, draft writing, and so on.')
+                    : tr('想法生成、实验、论文起草等操作发起后，任务会出现在这里。', 'Tasks show up here once you start idea generation, experiments, draft writing, and so on.')
                 }
                 compact
               />

--- a/src/frontend/src/features/wiki/ConceptsTab.tsx
+++ b/src/frontend/src/features/wiki/ConceptsTab.tsx
@@ -267,10 +267,7 @@ export function ConceptsTab({
               <button
                 className="icon-btn"
                 style={{ width: 26, height: 26, borderRadius: 7, flexShrink: 0 }}
-                title={tr(
-                  '从已编译论文提取概念：重抽正文 [[双链]]，补建缺失的概念和关联',
-                  'Extract concepts from compiled papers: re-scan [[wiki links]] and fill in missing concepts and links',
-                )}
+                title={tr('从已编译论文提取概念', 'Extract concepts from compiled papers')}
                 disabled={relinkMutation.isPending}
                 onClick={() => relinkMutation.mutate()}
               >
@@ -313,8 +310,8 @@ export function ConceptsTab({
                 q
                   ? tr('换个关键词试试。', 'Try a different keyword.')
                   : tr(
-                      '编译论文解读时会自动提取概念；已有解读的论文可以点下面按钮补一次。',
-                      'Concepts are extracted automatically when papers are compiled; use the button below to backfill compiled papers.',
+                      '编译论文解读时会自动提取概念。',
+                      'Concepts are extracted automatically when papers are compiled.',
                     )
               }
               action={

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -108,8 +108,8 @@ function DuplicatesCard({ libraryId }: { libraryId: string }) {
       </h3>
       <p className="muted" style={{ fontSize: 12, marginBottom: 12 }}>
         {tr(
-          '同一篇论文可能因预印本 / 正式版等原因入库两次。确认后合并：保留更完整的一篇，另一篇的所有内容并入后删除（不可撤销）。',
-          'The same paper can be ingested twice (e.g. preprint vs published). Merging keeps the more complete row and folds the other into it — irreversible.',
+          '合并会保留更完整的一篇，另一篇的内容并入后删除，不可撤销。',
+          'Merging keeps the more complete row and folds the other into it, then deletes it — irreversible.',
         )}
       </p>
       {isLoading ? (
@@ -392,10 +392,7 @@ function InclusionSettingsCard({ lib, readOnly }: { lib: DirectionLibraryDetail;
       </div>
       <p className="muted" style={{ fontSize: 12, marginBottom: 16 }}>
         {readOnly
-          ? tr(
-              '这个文献库按以下 arXiv 分类与关键词检索论文、按打分标准判定相关性（由文献库管理员维护）。',
-              'This library fetches papers by the arXiv categories and terms below and scores relevance against the rubric (maintained by library managers).',
-            )
+          ? tr('由文献库管理员维护，你只能查看。', 'Maintained by library managers — read-only for you.')
           : tr(
               '文献追踪按这里的 arXiv 分类与关键词检索、按打分标准判定相关性；留空则用默认分类、只按方向说明打分。',
               'Literature tracking searches by these arXiv categories and keywords and scores relevance against the rubric; leave empty to use default categories and statement-only scoring.',

--- a/src/frontend/src/features/wiki/GraphTab.tsx
+++ b/src/frontend/src/features/wiki/GraphTab.tsx
@@ -1277,12 +1277,12 @@ export function GraphTab({ pid, libraryId, scope, onOpenPaper, onOpenConcept }: 
           desc={
             scope === 'lab'
               ? tr(
-                  '你能看到的文献库里还没有通过筛选并编译过的论文。任意一个库跑完初始建库后，这里会把全实验室的论文、作者、概念连成网络。',
-                  'None of the libraries you can see has screened and compiled papers yet. Once any library finishes its initial build, this links the whole lab’s papers, authors, and concepts.',
+                  '你能看到的文献库里还没有通过筛选并编译过的论文。',
+                  'None of the libraries you can see has screened and compiled papers yet.',
                 )
               : tr(
-                  '先运行初始建库让论文通过筛选并完成编译，图谱会自动把论文、作者、概念连成网络。',
-                  'Run the initial library build so papers get screened and compiled — the graph then links papers, authors, and concepts automatically.',
+                  '先运行初始建库，让论文通过筛选并完成编译。',
+                  'Run the initial library build so papers get screened and compiled.',
                 )
           }
         />
@@ -1321,7 +1321,7 @@ export function GraphTab({ pid, libraryId, scope, onOpenPaper, onOpenConcept }: 
           style={{ height: 28, fontSize: 12, maxWidth: 220, padding: '0 8px' }}
           value={focusConceptId}
           onChange={(e) => setFocusConceptId(e.target.value)}
-          title={tr('选一个概念，只看它牵出的论文子图', 'Pick a concept to see only the papers it links to')}
+          title={tr('只看某个概念牵出的论文', 'Show only the papers a concept links to')}
         >
           <option value="">{tr('全部主题', 'All topics')}</option>
           {conceptOptions.map((c) => (
@@ -1352,8 +1352,8 @@ export function GraphTab({ pid, libraryId, scope, onOpenPaper, onOpenConcept }: 
               icon="layers"
               title={tr('节点太多，网络图会很卡', 'Too many nodes for the network view')}
               desc={tr(
-                `这一批有 ${model.nodes.length} 个节点。先用上面的子主题筛一下，或换趋势时间线主题视图看全量——它们是聚合的，不受节点数影响。`,
-                `This batch has ${model.nodes.length} nodes. Narrow it down with the subtopic filter above, or use the Trends / Timeline / Topics views — they aggregate, so node count doesn't matter.`,
+                `这一批有 ${model.nodes.length} 个节点。用上面的子主题筛一下，或换趋势时间线主题视图。`,
+                `This batch has ${model.nodes.length} nodes. Narrow it down with the subtopic filter above, or switch to the Trends / Timeline / Topics views.`,
               )}
               action={
                 <button className="btn btn-soft" onClick={() => setForceNetwork(true)}>

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -203,13 +203,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                 <span style={{ fontSize: 13.5, fontWeight: 650 }}>{tr('文献任务进行中', 'Literature task in progress')}</span>
                 <Icon name="arrow" size={14} style={{ marginLeft: 'auto', color: 'var(--accent-text)' }} />
               </div>
-              <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 8, lineHeight: 1.55 }}>
-                {tr(
-                  '点击查看任务实时进度（SSE 流式）。运行期间无法再次启动 ingest。',
-                  'Click to watch live progress (SSE stream). Ingest cannot be started again while it runs.',
-                )}
-              </div>
-              <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 6 }}>
+              <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 8 }}>
                 voyage {state.running_voyage_id.slice(0, 8)}…
               </div>
             </div>
@@ -315,8 +309,8 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             </div>
             <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, margin: '0 0 14px' }}>
               {tr(
-                '从上次同步时间之后抓取新论文并打分编译；已建库的项目每日也会由定时任务自动增量。',
-                'Fetch, score, and compile papers published since the last sync; built libraries also sync daily on a schedule.',
+                '抓取上次同步之后发表的新论文；已建库的文献库每天也会自动同步一次。',
+                'Fetches papers published since the last sync; built libraries also sync once a day automatically.',
               )}
             </p>
             <button className="btn btn-ghost" disabled={busy || !state?.watermark} onClick={runIncremental}>
@@ -343,8 +337,8 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
           </div>
           <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, margin: '0 0 18px' }}>
             {tr(
-              '初始建库一次性回填近 N 个月文献并做参考文献扩展，AI 打分筛选后精读编译建立知识库。以下选项控制本次开销。',
-              'The initial build backfills the last N months of papers with reference expansion, then scores, filters, and compiles them into the library. These knobs control the cost of this run.',
+              '一次性回填近 N 个月文献并做参考文献扩展，打分筛选后精读编译；下面的选项控制本次开销。',
+              'Backfills the last N months with reference expansion, then scores, filters, and compiles; the knobs below control this run’s cost.',
             )}
           </p>
 
@@ -358,14 +352,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             step={1}
             onChange={setMonthsBack}
           />
-          <FormField
-            label={tr('最大化（不限篇数）', 'Maximize (no paper cap)')}
-            en="unlimited"
-            hint={tr(
-              '开启后检索篇数与编译篇数不设上限，抓取时间窗口内的全部相关论文。',
-              'When on, search and compile have no paper caps: every relevant paper in the window is processed.',
-            )}
-          >
+          <FormField label={tr('最大化（不限篇数）', 'Maximize (no paper cap)')} en="unlimited">
             <label className="row gap10" style={{ cursor: 'pointer', userSelect: 'none' }}>
               <input
                 type="checkbox"
@@ -499,12 +486,6 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
               <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
                 {tr('已有任务运行中，暂不可启动', 'A task is already running — cannot start another')}
               </span>
-            )}
-          </div>
-          <div style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 12, lineHeight: 1.6 }}>
-            {tr(
-              '以 AI 任务呈现进度，支持断点续跑；同一项目同时只允许一个 ingest 任务。',
-              'Progress shows as an AI task and can resume from checkpoints; one ingest task per direction at a time.',
             )}
           </div>
         </div>

--- a/src/frontend/src/features/wiki/LibraryChatTab.tsx
+++ b/src/frontend/src/features/wiki/LibraryChatTab.tsx
@@ -356,7 +356,7 @@ export function LibraryChatTab({
       title={tr('文献对话', 'Library chat')}
       contextKinds={libraryId ? ['paper', 'concept'] : ['paper', 'idea', 'experiment', 'concept']}
       hint={tr(
-        '回答基于从整个文献库检索到的全文片段，可做跨文献对比与综合梳理；[n] 为引用来源编号。',
+        '回答基于从整个文献库检索到的全文片段；[n] 为引用来源编号。',
         'Answers are grounded in full-text passages from the whole library; [n] marks a source number.',
       )}
       headerAction={
@@ -376,8 +376,8 @@ export function LibraryChatTab({
       emptyIcon="chat"
       emptyTitle={tr('和整个文献库对话', 'Chat with the whole library')}
       emptyDesc={tr(
-        '跨文献的分析、比较、综合梳理都可以问；/ 放入指定论文，@ 分享推荐给同事或群。',
-        'Ask cross-paper questions; use / to pin papers, @ to share or recommend to teammates.',
+        '输入 / 可指定某几篇，@ 可分享给同事或群。',
+        'Type / to pin specific papers, @ to share with teammates.',
       )}
       suggestions={SUGGESTIONS}
       placeholder={tr('提问，或输入 / 放入上下文、@ 分享…', 'Ask, or type / for context, @ to share…')}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -181,7 +181,6 @@ function AddPaperModal({
       open={open}
       onClose={onClose}
       title={tr('添加文献', 'Add paper')}
-      sub={libraryId ? tr('手动把一篇论文加进这个文献库', 'Manually add a paper to this library') : tr('手动把一篇论文加进当前课题的论文库', 'Manually add a paper to this topic’s library')}
       width={520}
       footer={
         <>
@@ -233,12 +232,6 @@ function AddPaperModal({
                 setParseError(null);
               }}
             />
-            <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
-              {tr(
-                '填 arXiv 编号即可，标题、作者、摘要会自动抓取，并顺带下载 PDF。',
-                'Just the arXiv ID — title, authors, and abstract are fetched automatically, plus the PDF.',
-              )}
-            </div>
           </>
         ) : method === 'doi' ? (
           <>
@@ -253,10 +246,7 @@ function AddPaperModal({
               }}
             />
             <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
-              {tr(
-                '通过 DOI 反查论文信息（OpenAlex），适合期刊/会议论文。',
-                'Looks up paper metadata by DOI (OpenAlex) — good for journal/conference papers.',
-              )}
+              {tr('适合期刊 / 会议论文。', 'Best for journal and conference papers.')}
             </div>
           </>
         ) : (
@@ -551,8 +541,8 @@ function PapersTrashModal({ pid, libraryId, open, onClose }: { pid: string; libr
       open={open}
       onClose={onClose}
       sub={tr(
-        '相关性不足自动淘汰与手动删除的文献；召回后回到论文库',
-        'Papers auto-dropped for low relevance or deleted manually; restoring puts them back in the library',
+        '相关性不足自动淘汰与手动删除的文献',
+        'Papers auto-dropped for low relevance or deleted manually',
       )}
       items={items}
       total={trashQuery.data?.total}
@@ -610,7 +600,6 @@ const PaperRow = memo(function PaperRow({
           checked={checked}
           onClick={(e) => e.stopPropagation()}
           onChange={onToggleCheck}
-          title={tr('选中后可批量删除 / 导出', 'Select for bulk delete / export')}
           style={{ width: 13, height: 13, margin: 0, flexShrink: 0, accentColor: 'var(--accent)', cursor: 'pointer', visibility: selectMode ? 'visible' : 'hidden' }}
         />
         {p.starred && <Icon name="starFill" size={11} style={{ color: 'var(--warn-tx)', flexShrink: 0 }} />}
@@ -1091,10 +1080,7 @@ function PaperDetailPane({
             compact
             icon="pen"
             title={tr('还没有 AI 介绍', 'No AI intro yet')}
-            desc={tr(
-              '点上方的编译按钮，让 AI 精读这篇论文并生成图文介绍。',
-              'Hit the compile button above to have the AI read this paper and write an illustrated intro.',
-            )}
+            desc={tr('点上方的编译让 AI 精读并生成。', 'Use “Compile” above to have the AI read it and write one.')}
           />
         )}
       </div>
@@ -1328,7 +1314,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                 position: 'relative',
                 ...(advOpen || advActive ? { borderColor: 'var(--accent)', color: 'var(--accent)' } : {}),
               }}
-              title={tr('高级检索：作者 / 机构 / 发表时间 / 入库时间', 'Advanced search: author / affiliation / publish date / added date')}
+              title={tr('高级检索', 'Advanced search')}
               onClick={() => setAdvOpen((o) => !o)}
             >
               <Icon name="sliders" size={14} />
@@ -1370,10 +1356,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                   className="input"
                   style={{ flex: 1, minWidth: 0, height: 28, fontSize: 11.5 }}
                   placeholder={tr('发表机构…', 'Affiliation…')}
-                  title={tr(
-                    '需要论文元数据带有机构信息（入库时自动从 OpenAlex 补充）',
-                    'Needs affiliation metadata (auto-filled from OpenAlex on ingest)',
-                  )}
+                  title={tr('需要论文元数据带有机构信息', 'Needs affiliation metadata on the paper')}
                   value={advAffiliation}
                   onChange={(e) => setAdvAffiliation(e.target.value)}
                 />
@@ -1506,8 +1489,8 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                 hasFilter
                   ? tr('换个关键词或过滤条件试试。', 'Try a different keyword or filter.')
                   : tr(
-                      '先到建库与同步页运行初始建库，或点上方的添加文献按钮手动添加。',
-                      'Run the initial library build under Ingest & sync, or add papers manually with the button above.',
+                      '先到建库与同步运行初始建库。',
+                      'Run the initial library build under “Ingest & sync”.',
                     )
               }
             />
@@ -1563,7 +1546,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
         >
           <button
             className={'btn sm ' + (selectMode ? 'btn-primary' : 'btn-ghost')}
-            title={tr('开启后列表出现复选框，可批量删除 / 导出', 'Show checkboxes for bulk delete / export')}
+            title={tr('批量删除 / 导出', 'Bulk delete / export')}
             onClick={() => {
               setSelectMode((m) => !m);
               setSelected(new Set());
@@ -1598,7 +1581,6 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
           <button
             className="btn btn-ghost sm"
             style={{ marginLeft: 'auto' }}
-            title={tr('回收站：已删除的文献可以召回或彻底删除', 'Trash: deleted papers — restore or delete forever')}
             onClick={() => setTrashOpen(true)}
           >
             <Icon name="trash" size={13} />

--- a/src/frontend/src/features/wiki/PresentationModal.tsx
+++ b/src/frontend/src/features/wiki/PresentationModal.tsx
@@ -83,8 +83,8 @@ export function PresentationModal({
       width={640}
       title={tr('生成论文分享 PPT', 'Generate paper sharing PPT')}
       sub={tr(
-        '按实验室模板生成，可在技能页调整论文分享 PPT 制作技能的规范',
-        'Generated from the lab template — tweak the PPT skill rules on the Skills page',
+        '按实验室模板生成，模板规范可在技能页调整',
+        'Generated from the lab template — tweak the template rules on the Skills page',
       )}
       footer={
         <>
@@ -182,10 +182,7 @@ export function PresentationModal({
 
       <FormField
         label={tr('讲者备注', 'Speaker notes')}
-        hint={tr(
-          '可选：听众背景、要突出的侧重点，AI 会照顾到',
-          'Optional: audience background and points to highlight — the AI will take them into account',
-        )}
+        hint={tr('可选：听众背景、要突出的侧重点', 'Optional: audience background and points to highlight')}
       >
         <textarea
           className="textarea"

--- a/src/frontend/src/features/writer/CollaboratorsModal.tsx
+++ b/src/frontend/src/features/writer/CollaboratorsModal.tsx
@@ -177,7 +177,6 @@ export function CollaboratorsModal({ open, onClose, manuscriptId }: Collaborator
           {tr('协作者', 'Collaborators')}
         </>
       }
-      sub={tr('管理谁能协同编辑这篇论文', 'Manage who can co-edit this manuscript')}
       footer={
         <button className="btn btn-ghost sm" onClick={onClose}>
           {tr('关闭', 'Close')}

--- a/src/frontend/src/features/writer/DraftModal.tsx
+++ b/src/frontend/src/features/writer/DraftModal.tsx
@@ -126,8 +126,8 @@ export function DraftModal({ open, onClose, manuscript, onInitialized }: DraftMo
         </>
       }
       sub={tr(
-        'AI 按事实包写作：引用、图表、数字都只能来自事实包，逐节自检后经协同编辑实时写入。',
-        'AI writes from the fact pack: citations, figures and numbers may only come from it, each section is self-checked and written in via live collaborative editing.',
+        'AI 只会用事实包里的引用、图表和数字。',
+        'AI only uses the citations, figures and numbers in the fact pack.',
       )}
       footer={
         <>
@@ -221,7 +221,7 @@ export function DraftModal({ open, onClose, manuscript, onInitialized }: DraftMo
 
       <FormField
         label={tr('备注（可选）', 'Notes (optional)')}
-        hint={tr('给 AI 的额外要求，比如强调某个贡献点、写作口吻、篇幅取舍。', 'Extra instructions for the AI, e.g. which contribution to highlight, tone, or length trade-offs.')}
+        hint={tr('给 AI 的额外要求。', 'Extra instructions for the AI.')}
       >
         <textarea
           className="textarea"

--- a/src/frontend/src/features/writer/FactPackDrawer.tsx
+++ b/src/frontend/src/features/writer/FactPackDrawer.tsx
@@ -62,7 +62,7 @@ export function FactPackDrawer({ open, onClose, manuscript, canInsert, onInsertC
           <span style={{ fontSize: 14.5, fontWeight: 660 }}>{tr('事实包', 'Fact pack')}</span>
         </>
       }
-      sub={tr('AI 起草只能引用这里的引文、图表和实验数字，防止编造。', 'AI drafting may only cite the references, figures and numbers listed here, to prevent fabrication.')}
+      sub={tr('AI 起草只能引用这里的引文、图表和实验数字。', 'AI drafting may only cite the references, figures and numbers listed here.')}
     >
       <div className="row" style={{ justifyContent: 'space-between', marginBottom: 4 }}>
         <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>

--- a/src/frontend/src/features/writer/HistoryModal.tsx
+++ b/src/frontend/src/features/writer/HistoryModal.tsx
@@ -103,7 +103,7 @@ export function HistoryModal({ open, onClose, manuscriptId, file }: HistoryModal
           版本历史
         </>
       }
-      sub={`${file.path} · AI 写入前与每次编译自动存档，最多保留 50 份`}
+      sub={`${file.path} · 最多保留 50 份`}
       footer={
         <>
           <button className="btn btn-ghost sm" onClick={onClose}>

--- a/src/frontend/src/features/writer/NewManuscriptModal.tsx
+++ b/src/frontend/src/features/writer/NewManuscriptModal.tsx
@@ -196,7 +196,6 @@ export function NewManuscriptModal({ open, onClose, pid }: NewManuscriptModalPro
           {tr('新建论文草稿', 'New manuscript')}
         </>
       }
-      sub={tr('从选定模板展开文件，并自动从关联实验与文献库组装事实包', 'Expands files from the chosen template and assembles a fact pack from the linked experiment and library')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>
@@ -337,20 +336,20 @@ export function NewManuscriptModal({ open, onClose, pid }: NewManuscriptModalPro
           </div>
         )}
 
-        <div className="field-hint" style={{ marginTop: 6, color: isSeedSelected ? 'var(--accent-text, var(--accent))' : undefined }}>
-          {isSeedSelected
-            ? tr('请先等待模板下载完成，再创建草稿。', 'Please wait for the template to finish downloading before creating a manuscript.')
-            : selected?.unofficial
-              ? tr('该模板为平台内置的近似排版，非会议官方模板包，正式投稿前请换用官方模板核对格式。', 'This template is a built-in approximation, not an official venue package — switch to the official template and check formatting before submitting.')
-              : tr('选择用于展开论文文件结构的模板；也可上传自己的 zip 模板。', 'Pick a template to expand the manuscript file structure; you can also upload your own zip.')}
-        </div>
+        {(isSeedSelected || selected?.unofficial) && (
+          <div className="field-hint" style={{ marginTop: 6, color: isSeedSelected ? 'var(--accent-text, var(--accent))' : undefined }}>
+            {isSeedSelected
+              ? tr('请先等待模板下载完成，再创建草稿。', 'Please wait for the template to finish downloading before creating a manuscript.')
+              : tr('该模板不是会议官方模板包，投稿前请换官方模板核对格式。', 'Not the official venue package — switch to the official template and check formatting before submitting.')}
+          </div>
+        )}
       </div>
 
       <div className="row gap12" style={{ alignItems: 'flex-start' }}>
         <FormField
           label={tr('关联想法（可选）', 'Linked idea (optional)')}
           style={{ flex: 1, minWidth: 0 }}
-          hint={tr('论文事实包中研究想法分区的来源；仅列出已晋级的想法。', 'Source for the idea section of the fact pack; only promoted ideas are listed.')}
+          hint={tr('仅列出已晋级的想法。', 'Only promoted ideas are listed.')}
         >
           <SelectMenu
             value={ideaId}
@@ -364,7 +363,7 @@ export function NewManuscriptModal({ open, onClose, pid }: NewManuscriptModalPro
         <FormField
           label={tr('关联实验（可选）', 'Linked experiment (optional)')}
           style={{ flex: 1, minWidth: 0 }}
-          hint={tr('事实包的指标 / 图表 / 假设来源；仅列已完成实验。', 'Source of fact-pack metrics / figures / hypotheses; only finished experiments are listed.')}
+          hint={tr('仅列出已完成的实验。', 'Only finished experiments are listed.')}
         >
           <SelectMenu
             value={experimentId}

--- a/src/frontend/src/features/writer/TemplateUploadModal.tsx
+++ b/src/frontend/src/features/writer/TemplateUploadModal.tsx
@@ -91,7 +91,6 @@ export function TemplateUploadModal({ open, onClose, pid, onUploaded }: Template
           {tr('上传论文模板', 'Upload template')}
         </>
       }
-      sub={tr('上传一个含 .tex 的 zip 模板包，之后新建草稿时可选用', 'Upload a zip containing a .tex template; you can pick it when creating a manuscript')}
       footer={
         <>
           <button className="btn btn-ghost" onClick={onClose}>{tr('取消', 'Cancel')}</button>

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -75,7 +75,7 @@ function PdfPane({ msId, compile }: { msId: string; compile: CompileResult | nul
           compact
           icon="file"
           title={tr('还没有 PDF', 'No PDF yet')}
-          desc={tr('写好后点右上角的编译按钮或按 ⌘S，编译成功的 PDF 会出现在这里。', 'Click compile in the top bar or press ⌘S — a successful compile shows the PDF here.')}
+          desc={tr('点右上角的编译按钮或按 ⌘S 生成。', 'Click compile in the top bar, or press ⌘S.')}
         />
       </div>
     );

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -491,15 +491,14 @@ export function WriterPage() {
               compact
               icon="trash"
               title={tr('回收站是空的', 'Trash is empty')}
-              desc={tr('删除的论文草稿会先进这里，可恢复或永久删除。', 'Deleted manuscripts land here first — restore them or delete permanently.')}
             />
           ) : (
             <EmptyState
               icon="pen"
               title={tr('还没有论文草稿', 'No manuscripts yet')}
               desc={tr(
-                '新建一篇：选会议模板、关联已完成的实验，平台会自动组装事实包，AI 就能按真实结果起草。',
-                'Create one: pick a venue template and link a finished experiment — the platform assembles a fact pack so AI can draft from real results.',
+                '选一个会议模板新建，AI 会按关联实验的结果起草。',
+                'Pick a venue template to start — AI drafts from the linked experiment results.',
               )}
               action={
                 <button className="btn btn-primary" onClick={() => setModalOpen(true)}>


### PR DESCRIPTION
The interface had accumulated a lot of teaching text. Roughly **55 removals and 60 shortenings** across every feature area.

Both examples you named are handled: the lab workbench's subtitle is gone entirely, and related work's "the two numbers being different is normal" paragraph is deleted.

## What went

- **Subtitles that restate the title** (~14) — "manage who can co-edit" under *Collaborators*, "add a paper to this topic's related work" under *Add paper*, and so on
- **Feature explainers** (~20) — the idea drawer's "goal building → goal confirmation → draft…" walkthrough, "a kind=experiment voyage is queued when an experiment is created"
- **Hints describing the adjacent UI** (~15) — "will show in the sidebar", "tap 'New library' at the top right", a tooltip explaining a button whose label already said it
- **Recycle-bin empty states** in three modules, all variations of "deleted things land here"

## What stayed — deliberately

- **Consequences of destructive actions**: every empty-bin / delete-forever / delete-topic confirmation, untouched
- **Behaviour you can't guess**: an entry whose source paper was deleted won't match a filter · clearing browse history leaves the bin alone · "only you can see this" · papers auto-dropped for low relevance · the daily feed keeps 7 days
- **Anything about spending**: quota warnings on full-text indexing and daily embeddings, monthly budget exhaustion, "unlimited mode" cost warning
- **Approval outcomes**: what approving vs rejecting a gate actually does
- **Error causes and form format requirements**

## One thing that needs your call

`InclusionSettingsForm` said keywords could be left blank to "fall back to the default categories" — but `IngestTab` **disables** the initial build when keywords are empty, with "no search keywords configured". So blank isn't a fallback, it's a hard stop. The wrong hint is deleted (it also duplicated one in the governance tab), but **no correct constraint text was written in its place** — that changes meaning rather than trimming it, so it's yours to decide which behaviour is intended.

Six more spots are listed in my notes as judgement calls I left alone (a page whose only definition is its subtitle, an AI-reliability caveat that reads like reassurance but isn't). Say the word for another pass.

## Verification

`tsc --noEmit` 0 errors, `npm run build` passes.