### PR TITLE
refactor(llm): split librarian, drop interview, fix swapped stage labels

### DIFF
--- a/src/backend/app/agents/__init__.py
+++ b/src/backend/app/agents/__init__.py
@@ -1,7 +1,6 @@
 """Agent 编排层（M3 实现，暂为占位）。
 
 规划中的 agents：
-- interviewer: 研究方向定义访谈，产出 Project.definition
 - surveyor: 文献检索/打分/编纂（Paper/Concept wiki）
 - ideator: 想法生成 + 四维评分 + Elo 锦标赛
 - reviewer: 多人设评审（ReviewSession/ReviewMessage）

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -37,13 +37,17 @@ class LLMNotConfiguredError(RuntimeError):
 
 # 科研环节枚举（docs/api-m1.md §2；M2 新增 embedding，见 docs/api-m2.md §7；
 # 文献管理增强新增 reading（AI 伴读），见 docs/api-lit.md §3）
+#
+# librarian 与 extract 的分工：librarian = 长文本 + 多模态（wiki 图文精读编译、
+# 论文图筛选注释、幻灯片大纲/内容/视觉评审），要强模型；extract = 纯文本短 JSON
+# 结构化抽取（作者↔机构解析、概念定义批量生成、建库向导收录设置），小模型够用。
 STAGES = (
     "default",
     "navigator",
     "sextant",
-    "interview",
     "relevance",
     "librarian",
+    "extract",
     "embedding",
     "rerank",
     "forge",
@@ -90,7 +94,8 @@ _FALLBACK_ROUTE = ResolvedRoute(
 
 # 长文本生成的 stage：complete() 有 event_bus + voyage_id 时改走流式并逐段广播
 # llm_delta（任务详情页 terminal 实时展示"大模型正在输出什么"）。短 JSON 调用
-# （relevance 打分 / sextant 判定等）不流式，避免噪声。
+# （relevance 打分 / sextant 判定 / extract 结构化抽取等）不流式，避免噪声——
+# 流式路径还会把整段输出写进 voyage_terminal_logs，JSON 混进终端毫无可读性。
 STREAM_STAGES = frozenset(
     {"navigator", "debate", "experiment", "writing", "proposal", "review", "librarian"}
 )

--- a/src/backend/app/services/affiliations.py
+++ b/src/backend/app/services/affiliations.py
@@ -202,7 +202,7 @@ async def extract_author_affiliations_llm(
     known_block = "\n".join(f"- {n}" for n in known) if known else _NO_AUTHORS_HINT
     try:
         result = await llm.complete(
-            "librarian",
+            "extract",
             [
                 Message(role="system", content=AUTHOR_AFFIL_SYSTEM_PROMPT),
                 Message(

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -194,7 +194,7 @@ async def _fetch_definitions_batch(
         return {}
     try:
         result = await llm.complete(
-            "librarian",
+            "extract",
             [
                 Message(role="system", content=CONCEPT_DEF_SYSTEM_PROMPT),
                 Message(role="user", content="概念列表：" + json.dumps(names, ensure_ascii=False)),

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -668,7 +668,7 @@ async def suggest_definition(
     user_prompt = f"研究方向名称：{name.strip()}\n\n一句话描述：{statement_line}"
     try:
         result = await llm.complete(
-            "librarian",
+            "extract",
             [
                 Message(role="system", content=SUGGEST_DEFINITION_SYSTEM_PROMPT),
                 Message(role="user", content=user_prompt),

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -164,13 +164,23 @@ async def test_routes_put_get_and_validation(client):
     resp = await client.get("/api/admin/llm/routes", headers=admin)
     assert len(resp.json()) == 2
 
-    # 非法 stage → 400
+    # 非法 stage → 400（interview 已废弃移除，与随便一个不存在的 stage 同等对待）
+    for bad_stage in ("nope", "interview"):
+        resp = await client.put(
+            "/api/admin/llm/routes",
+            json=[{"stage": bad_stage, "provider_id": provider_id, "model": "m"}],
+            headers=admin,
+        )
+        assert resp.status_code == 400, bad_stage
+
+    # 新增的结构化抽取环节可配置
     resp = await client.put(
         "/api/admin/llm/routes",
-        json=[{"stage": "nope", "provider_id": provider_id, "model": "m"}],
+        json=[{"stage": "extract", "provider_id": provider_id, "model": "fake-small"}],
         headers=admin,
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 200, resp.text
+    assert [r["stage"] for r in resp.json()] == ["extract"]
 
     # 不存在的 provider → 400
     resp = await client.put(

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -118,7 +118,7 @@ async def test_extract_author_affiliations_parses_mapping(tmp_path):
         {"name": "Bob Li", "affiliations": ["Google DeepMind"]},  # strip
     ]  # 空名整项丢弃
     call = llm.calls[0]
-    assert call["stage"] == "librarian"
+    assert call["stage"] == "extract"  # 纯文本短 JSON 抽取，不占多模态 librarian 路由
     assert call["max_tokens"] == _MAX_TOKENS
     assert call["project_id"] is None
 

--- a/src/backend/tests/test_library_suggest_definition.py
+++ b/src/backend/tests/test_library_suggest_definition.py
@@ -74,7 +74,7 @@ async def test_suggest_definition_parses_and_coerces():
     assert anchors[1]["arxiv_id"] is None  # arxiv 可空
     # 调用参数：stage / 记账 / prompt 内容
     call = llm.calls[0]
-    assert call["stage"] == "librarian"
+    assert call["stage"] == "extract"  # 纯文本短 JSON 抽取，不占多模态 librarian 路由
     assert call["user_id"] is None
     assert "检索增强生成" in call["messages"][1].content
 

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
-from app.core.llm.router import LLMRouter
+from app.core.llm.router import STAGES, STREAM_STAGES, LLMRouter
 from app.core.security import encrypt_secret
 from app.models.llm_config import LLMProviderConfig, LLMUsage, ModelRoute
 from app.services.llm_admin import mask_api_key
@@ -113,6 +113,38 @@ async def test_stream_records_usage(app):
     async with get_sessionmaker()() as session:
         rows = (await session.execute(select(LLMUsage))).scalars().all()
         assert len(rows) == 1
+
+
+def test_stage_catalog():
+    """环节清单：interview 已废弃移除；extract（结构化抽取）已就位。"""
+    assert "interview" not in STAGES
+    assert "extract" in STAGES
+    assert "librarian" in STAGES
+    assert "feedback_issue" in STAGES
+    assert len(set(STAGES)) == len(STAGES)  # 无重复
+
+
+def test_extract_stage_is_not_streamed():
+    """extract 是短 JSON 抽取：不进流式广播（否则 JSON 会灌满任务终端）。"""
+    assert "extract" not in STREAM_STAGES
+    assert "librarian" in STREAM_STAGES  # 图文精读编译仍逐段广播
+
+
+async def test_extract_stage_falls_back_to_default_route(app):
+    """extract 不是能力型环节：未单独配置时平滑跟随 default。"""
+    async with get_sessionmaker()() as session:
+        provider = LLMProviderConfig(name="fake-db", kind="fake", enabled=True)
+        session.add(provider)
+        await session.flush()
+        session.add(ModelRoute(stage="default", provider_id=provider.id, model="fake-db-default"))
+        await session.commit()
+
+    router = LLMRouter()
+    result = await router.complete("extract", [Message(role="user", content="抽点 JSON")])
+    assert result.model == "fake-db-default"
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(LLMUsage))).scalars().all()
+        assert [r.stage for r in rows] == ["extract"]
 
 
 def test_mask_api_key():

--- a/src/backend/tests/test_voyage_loop.py
+++ b/src/backend/tests/test_voyage_loop.py
@@ -512,6 +512,23 @@ async def test_llm_short_stage_not_streamed(app):
     assert not any(e == "llm_delta" for _v, e, _d in bus.voyage_events)
 
 
+async def test_concept_definition_extract_stage_not_streamed(app):
+    """概念定义批量生成改走 extract：不再冒充 librarian 挤进流式广播（终端不被 JSON 灌满）。
+
+    流式路径同时是唯一把大模型全文写进 voyage_terminal_logs 的地方，
+    所以没有 llm_start/llm_delta/llm_end 就等于终端里也不会留下这段 JSON。
+    """
+    from app.core.llm.router import LLMRouter
+    from app.services.concepts import _fetch_definitions_batch
+
+    bus = RecordingBus()
+    router = LLMRouter()
+    router.event_bus = bus
+    defs = await _fetch_definitions_batch(router, ["强化学习"], voyage_id=uuid.uuid4())
+    assert defs  # 调用确实发生了（fake provider 按「概念列表：」marker 应答）
+    assert bus.voyage_events == []
+
+
 async def test_llm_multimodal_stage_also_streams(app):
     """多模态调用（带图，如 wiki 精读编译 librarian stage）现在也流式广播——
     图片附在请求上、正文照常逐段吐（终端可实时看到 wiki 生成）。"""

--- a/src/backend/tests/test_wiki_figures_compile.py
+++ b/src/backend/tests/test_wiki_figures_compile.py
@@ -223,14 +223,22 @@ async def test_recompile_with_pdf_full_flow(client):
         membership = await membership_of(session, project_id=project_id, paper_id=paper_id)
         assert membership.compiled_at is not None
         assert membership.compiled_model == "fake-default"  # 编译所用模型落库
-        # LLMUsage 记账归属 project（annotate + 编译 + 概念定义各 1 次 librarian 调用）
+        # LLMUsage 记账归属 project：annotate + 编译走 librarian（多模态），
+        # 概念定义走 extract（纯文本短 JSON）
         rows = (
             (await session.execute(select(LLMUsage).where(LLMUsage.stage == "librarian")))
             .scalars()
             .all()
         )
-        assert len(rows) == 3
+        assert len(rows) == 2
         assert all(str(r.project_id) == project_id for r in rows)
+        extract_rows = (
+            (await session.execute(select(LLMUsage).where(LLMUsage.stage == "extract")))
+            .scalars()
+            .all()
+        )
+        assert len(extract_rows) == 1
+        assert all(str(r.project_id) == project_id for r in extract_rows)
 
     # 再跑一次：覆盖 wiki_content，仍成功（重跑 annotate + 编译）
     resp = await client.post(f"/api/papers/{paper_id}/recompile", headers=headers)

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -12,6 +12,7 @@ import { useProject } from '../../app/project';
 import { api, isAdmin, type DirectionLibrarySummary, type LabStats, type VoyageRead } from '../../lib/api';
 import { fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
+import { stageLabel } from '../../lib/stageLabels';
 import { useLibraries, libraryPath } from '../libraries/hooks';
 
 // 图谱体量大且不是首屏必需：按需加载（与文献库工作台同样处理）
@@ -580,8 +581,11 @@ function UsageCard({ days, onDays }: { days: UsageWindow; onDays: (v: UsageWindo
               <div className="col gap8">
                 {byStage.map(([stage, value]) => (
                   <div key={stage} className="row gap10">
-                    <span className="mono" style={{ fontSize: 11.5, width: 108, flexShrink: 0, color: 'var(--text-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {stage}
+                    <span
+                      style={{ fontSize: 11.5, width: 108, flexShrink: 0, color: 'var(--text-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                      title={stage}
+                    >
+                      {tr(stageLabel(stage).zh, stageLabel(stage).en)}
                     </span>
                     <span style={{ flex: 1, minWidth: 0, height: 6, borderRadius: 999, background: 'var(--surface-3)', overflow: 'hidden' }}>
                       <span

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { McpToolsContent } from '../mcp/McpToolsPage';
 import { AcademicIdentitySection } from './AcademicIdentitySection';
 import { tr } from '../../lib/i18n';
 import { copyText } from '../../lib/clipboard';
+import { STAGE_LABELS } from '../../lib/stageLabels';
 import { setTaskLogHistory, useTaskLogHistory } from '../../lib/prefs';
 import {
   ApiError,
@@ -994,28 +995,6 @@ function ProvidersSection({ adapter }: { adapter: LlmAdapter }) {
 }
 
 // ---------------- 模型路由表 ----------------
-
-/** stage 标签（渲染处再 tr；代码标识符照常显示在下方）。 */
-const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
-  default: { zh: '默认', en: 'Default' },
-  navigator: { zh: '任务规划', en: 'Task planning' },
-  sextant: { zh: '自动校验', en: 'Auto verification' },
-  interview: { zh: '课题访谈', en: 'Topic interview' },
-  relevance: { zh: '相关度打分', en: 'Relevance scoring' },
-  librarian: { zh: '文献抓取', en: 'Paper fetching' },
-  reading: { zh: '精读编译', en: 'Deep reading' },
-  embedding: { zh: '向量嵌入', en: 'Embeddings' },
-  forge: { zh: '想法生成', en: 'Idea generation' },
-  forge_signal: { zh: '信号摘要', en: 'Signal digest' },
-  goal_explore: { zh: '目标构建', en: 'Goal building' },
-  proposal: { zh: '方案起草', en: 'Proposal drafting' },
-  proposal_review: { zh: '方案评审', en: 'Proposal review' },
-  debate: { zh: '辩论评审', en: 'Debate review' },
-  experiment: { zh: '实验', en: 'Experiments' },
-  writing: { zh: '论文撰写', en: 'Paper writing' },
-  review: { zh: '论文评审', en: 'Paper review' },
-  rerank: { zh: '重排序', en: 'Reranking' },
-};
 
 /** 常驻顶层的行：默认 + 两个能力型环节；其余环节收进展开区。 */
 const PRIMARY_STAGES: string[] = ['default', 'embedding', 'rerank'];

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -453,13 +453,14 @@ export interface GateRead {
 
 export type LlmProviderKind = 'openai_compat' | 'anthropic' | 'fake';
 
+/** 与后端 `app/core/llm/router.py` 的 STAGES 保持一致（大白话名字见 lib/stageLabels.ts）。 */
 export const LLM_STAGES = [
   'default',
   'navigator',
   'sextant',
-  'interview',
   'relevance',
   'librarian',
+  'extract',
   'reading',
   'embedding',
   'rerank',
@@ -472,6 +473,7 @@ export const LLM_STAGES = [
   'experiment',
   'writing',
   'review',
+  'feedback_issue',
 ] as const;
 
 export type LlmStage = (typeof LLM_STAGES)[number];

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -1,0 +1,32 @@
+/**
+ * LLM 环节（stage）的大白话名字。清单与后端 `app/core/llm/router.py` 的 STAGES
+ * 一一对应（同一份 stage 标识符在设置页配路由、在实验室页看用量分布）。
+ *
+ * 模块级常量只存 zh/en，渲染处再 tr()（见前端单语 + 中英切换约定）。
+ */
+export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
+  default: { zh: '默认', en: 'Default' },
+  navigator: { zh: '任务规划', en: 'Task planning' },
+  sextant: { zh: '自动校验', en: 'Auto verification' },
+  relevance: { zh: '相关度打分', en: 'Relevance scoring' },
+  librarian: { zh: '图文精读编译', en: 'Paper compile (with figures)' },
+  extract: { zh: '结构化抽取', en: 'Structured extraction' },
+  reading: { zh: 'AI 伴读对话', en: 'Reading companion chat' },
+  embedding: { zh: '向量嵌入', en: 'Embeddings' },
+  rerank: { zh: '重排序', en: 'Reranking' },
+  forge: { zh: '想法生成', en: 'Idea generation' },
+  forge_signal: { zh: '信号摘要', en: 'Signal digest' },
+  goal_explore: { zh: '目标构建', en: 'Goal building' },
+  proposal: { zh: '方案起草', en: 'Proposal drafting' },
+  proposal_review: { zh: '方案评审', en: 'Proposal review' },
+  debate: { zh: '辩论评审', en: 'Debate review' },
+  experiment: { zh: '实验', en: 'Experiments' },
+  writing: { zh: '论文撰写', en: 'Paper writing' },
+  review: { zh: '论文评审', en: 'Paper review' },
+  feedback_issue: { zh: '反馈整理', en: 'Feedback triage' },
+};
+
+/** 取环节的显示名；未知 stage（如历史用量里的旧标识符）回退为标识符本身。 */
+export function stageLabel(stage: string): { zh: string; en: string } {
+  return STAGE_LABELS[stage] ?? { zh: stage, en: stage };
+}


### PR DESCRIPTION
## The labels were swapped

The settings page had `librarian` and `reading` describing each other's job:

- **`librarian` → "文献抓取"**. But fetching (arXiv search, S2 expansion, PDF download) is deterministic code that never calls a model. `librarian` is image-and-text compilation.
- **`reading` → "精读编译"**. But `reading` is the interactive chat — its only three call sites are all SSE conversation streams. It never compiles anything.

An admin configuring routes from those labels would point the **live, user-waiting chat** at a slow heavyweight model and the heavy compilation at something small. Now: `librarian` → 图文精读编译, `reading` → AI 伴读对话.

## Splitting librarian

It covered **seven** kinds of work with two distinct model profiles:

| Stays `librarian` (vision, long context) | Moves to `extract` (short prompt, small JSON) |
|---|---|
| wiki compilation | author ↔ affiliation parsing |
| figure selection + captions | concept definitions |
| slide outline / content / visual review | library setup wizard |
| literature-review skill | |

Today all seven are forced onto one model, so "write definitions for 20 terms" runs on the most expensive vision model available — and concept definitions retry the whole batch on failure, multiplying it.

### A side effect this fixes

`librarian` is in `STREAM_STAGES`, so those short JSON calls were being broadcast **and written into `voyage_terminal_logs`** — against the router's own comment that short JSON calls skip streaming to avoid noise. `extract` stays out, so it stops on its own. Verified with a regression test that runs the real router over a recording bus and asserts nothing is emitted.

## Two smaller corrections

**`interview` is removed** — no callers anywhere. Note the other seven zero-traffic stages (navigator, sextant, proposal…) are **kept**: their code paths are live, the features just aren't in use. That's different from a dead role.

**`feedback_issue` is added to the frontend list.** The backend has used it 12 times in production, but the list omitted it — so it could never be assigned a route and silently followed `default`.

`STAGE_LABELS` moves to `lib/` so the lab overview stops rendering bare identifiers where the settings page shows names.

## Existing data

Untouched, and the multimodal group deliberately keeps the name `librarian` — compilation is the bulk of those rows, so nothing needs reinterpreting.

## Verification

49 tests across compile/voyage-loop/admin-llm/concepts. `ruff check app` clean, `tsc --noEmit` 0 errors.

Two suite failures predate this and were confirmed by reverting the changes and re-running — see the PR discussion for one that needs attention.