### PR TITLE
feat(ui): move library visibility into config, unify export, tidy headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,60 +1,66 @@
-# ---- 镜像来源（拉镜像部署用；本地 build 时可忽略）----
-# docker/docker-compose.yml 的 api/worker/frontend 用 <PREFIX>/polaris-*:<TAG>
-# 既作构建 tag 也作 `docker compose pull` 的来源。
+# ---- Image source (for pull-based deploys; ignore when building locally) ----
+# api/worker/frontend in docker/docker-compose.yml use <PREFIX>/polaris-*:<TAG>,
+# which is both the build tag and what `docker compose pull` fetches.
 POLARIS_IMAGE_PREFIX=tricktreat
 POLARIS_IMAGE_TAG=latest
 
 # ---- App ----
-# dev | prod（生产部署填 prod：会强制关闭 fake LLM 回退等安全默认）
+# dev | prod (use prod for deployments: forces safe defaults such as
+# disabling the fake LLM fallback)
 POLARIS_ENV=dev
-# JWT 签名（openssl rand -hex 32）
+# JWT signing key (openssl rand -hex 32)
 POLARIS_SECRET_KEY=change-me-random-64-chars
-# SSH 凭据加密（python -c "from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())"）
+# SSH credential encryption (python -c "from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())")
 POLARIS_ENCRYPTION_KEY=change-me-fernet-key
-# 注册邀请码（实验室内部制）
+# Registration invite code (the lab runs invite-only)
 POLARIS_INVITE_CODE=polaris-lab
 
 # ---- Database / Cache ----
 POLARIS_DATABASE_URL=postgresql+asyncpg://polaris:polaris@postgres:5432/polaris
 POLARIS_REDIS_URL=redis://redis:6379/0
 
-# ---- LLM providers（管理端也可在 DB 中配置，此处为初始值）----
+# ---- LLM providers (also configurable in the DB from the admin page; these are initial values) ----
 POLARIS_OPENAI_COMPAT_BASE_URL=https://api.deepseek.com/v1
 POLARIS_OPENAI_COMPAT_API_KEY=
 POLARIS_ANTHROPIC_API_KEY=
-# 未配置任何 LLM 路由时是否回退内置 fake provider（仅测试/无 key 演示用，默认关闭）
-# 注意：POLARIS_ENV=prod 时此开关被强制忽略，生产永远不会回退 fake，杜绝假内容外泄
+# Fall back to the built-in fake provider when no LLM route is configured
+# (testing / key-less demos only, off by default).
+# Ignored when POLARIS_ENV=prod, so production never serves fabricated content.
 # POLARIS_LLM_FAKE_FALLBACK=1
 
-# ---- 邮件（注册验证码 / 找回密码）----
-# 不填 POLARIS_SMTP_HOST = 关闭邮件系统：注册不要验证码、登录页也不显示「忘记密码」。
-# 连接方式：ssl=建连即 TLS（465，浙大邮箱 994）| starttls=明文建连后升级（587/25）| none=不加密
+# ---- Email (registration codes / password reset) ----
+# Leaving POLARIS_SMTP_HOST empty disables email entirely: registration asks for
+# no code and the login page hides "forgot password".
+# Security: ssl = TLS from the start (465, ZJU mail uses 994) | starttls = plain
+# connection upgraded afterwards (587/25) | none = unencrypted
 POLARIS_SMTP_HOST=
 POLARIS_SMTP_PORT=465
 POLARIS_SMTP_SECURITY=ssl
 POLARIS_SMTP_USER=
-# 邮箱的「专用密码 / 授权码」，不是登录密码
+# The mailbox's app password / authorization code — not your login password
 POLARIS_SMTP_PASSWORD=
-# 发件地址（留空则用 POLARIS_SMTP_USER）与显示名
+# Sender address (falls back to POLARIS_SMTP_USER when empty) and display name
 POLARIS_SMTP_FROM=
 POLARIS_SMTP_FROM_NAME=Polaris
 POLARIS_SMTP_TIMEOUT=20
-# 浙大邮箱示例（专用密码在邮箱设置里生成，切勿把真实密码提交进仓库）：
+# ZJU mail example (generate the app password in your mailbox settings; never
+# commit a real password):
 #   POLARIS_SMTP_HOST=smtp.zju.edu.cn
 #   POLARIS_SMTP_PORT=994
 #   POLARIS_SMTP_SECURITY=ssl
 #   POLARIS_SMTP_USER=nb00000@zju.edu.cn
-#   POLARIS_SMTP_PASSWORD=<邮箱专用密码>
+#   POLARIS_SMTP_PASSWORD=<mailbox app password>
 
-# ---- 文献 API ----
-# Semantic Scholar（可空，限流更严）
+# ---- Literature APIs ----
+# Semantic Scholar (optional; rate limits are tighter without a key)
 POLARIS_S2_API_KEY=
-# 文献 API 出站代理（arXiv/S2/OpenAlex 直连不稳时配置；LLM/内网不走它）
-# docker 内访问宿主机代理用 host.docker.internal，如：
+# Outbound proxy for literature APIs, when arXiv/S2/OpenAlex are unreliable
+# directly. LLM and intranet traffic does not go through it.
+# To reach a proxy on the host from inside docker, use host.docker.internal:
 # POLARIS_OUTBOUND_PROXY=http://host.docker.internal:7897
 POLARIS_OUTBOUND_PROXY=
 
-# ---- Postgres 容器初始化 ----
+# ---- Postgres container bootstrap ----
 POSTGRES_USER=polaris
 POSTGRES_PASSWORD=polaris
 POSTGRES_DB=polaris

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,12 +22,18 @@ body:
       description: Which part of Polaris is affected?
       options:
         - frontend
+        - desktop (Electron client)
         - backend-api
         - voyage (task loop)
         - literature / wiki
+        - daily papers
+        - idea forge
+        - experiment
         - writer
         - review
         - skills
+        - llm routing / usage
+        - auth / users
         - infra / deploy
         - docs
         - other / not sure

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,12 +22,18 @@ body:
       description: Which part of Polaris does this touch?
       options:
         - frontend
+        - desktop (Electron client)
         - backend-api
         - voyage (task loop)
         - literature / wiki
+        - daily papers
+        - idea forge
+        - experiment
         - writer
         - review
         - skills
+        - llm routing / usage
+        - auth / users
         - infra / deploy
         - docs
         - other / not sure

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -22,12 +22,18 @@ body:
       description: Which part of Polaris does this touch?
       options:
         - frontend
+        - desktop (Electron client)
         - backend-api
         - voyage (task loop)
         - literature / wiki
+        - daily papers
+        - idea forge
+        - experiment
         - writer
         - review
         - skills
+        - llm routing / usage
+        - auth / users
         - infra / deploy
         - docs
         - other / not sure

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,26 @@
 
 Closes #
 
+## Area
+
+<!-- Tick what this touches. Keep it to what actually changed. -->
+
+- [ ] frontend
+- [ ] desktop (Electron client)
+- [ ] backend-api
+- [ ] voyage (task loop)
+- [ ] literature / wiki
+- [ ] daily papers
+- [ ] idea forge
+- [ ] experiment
+- [ ] writer
+- [ ] review
+- [ ] skills
+- [ ] llm routing / usage
+- [ ] auth / users
+- [ ] infra / deploy
+- [ ] docs
+
 ## What changed
 
 -
@@ -17,6 +37,7 @@ Closes #
 - [ ] `tsc --noEmit` / frontend build passes (frontend touched)
 - [ ] Backend tests pass (backend touched)
 - [ ] Alembic `upgrade head` + downgrade roundtrip passes (migration added)
+- [ ] `alembic heads` shows a single head (migration added)
 - [ ] Manually verified in local dev
 
 ## Checklist

--- a/src/frontend/src/components/ui/ExportDropdown.tsx
+++ b/src/frontend/src/components/ui/ExportDropdown.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState, type CSSProperties } from 'react';
+import { Icon, type IconName } from './Icon';
+import { useClickOutside } from './SelectMenu';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   「导出」按钮 + 弹出菜单（文献工作台的整库导出、各列表的多选导出共用）。
+   菜单项由调用方给：某个作用域后端不支持的格式就不要传进来。
+   ============================================================ */
+
+export type ExportDropdownItem = {
+  key: string;
+  /** 主文案（调用方 tr 好） */
+  label: string;
+  /** 右侧灰字（扩展名 / 适用范围） */
+  hint?: string;
+  icon?: IconName;
+  onSelect: () => void;
+};
+
+/** 多选导出的菜单项：引用导出端点（课题 / 库 / 个人库 / 每日）都支持这两种格式；
+    Obsidian 是整库 zip 端点、不吃选中的 id，所以不放进多选菜单。 */
+export function citationExportItems(
+  onPick: (format: 'bibtex' | 'csl-json') => void,
+): ExportDropdownItem[] {
+  return [
+    { key: 'bibtex', icon: 'book', label: 'BibTeX', hint: '.bib', onSelect: () => onPick('bibtex') },
+    { key: 'csl-json', icon: 'layers', label: 'CSL-JSON', hint: '.json', onSelect: () => onPick('csl-json') },
+  ];
+}
+
+export function ExportDropdown({
+  items,
+  busy = false,
+  disabled = false,
+  sm = false,
+  /** 菜单弹出方向：底部操作栏用 'up'，页头按钮用 'down' */
+  placement = 'down',
+  /** 菜单对齐：跟随触发按钮所在的一侧 */
+  align = 'right',
+  minWidth = 200,
+}: {
+  items: ExportDropdownItem[];
+  busy?: boolean;
+  disabled?: boolean;
+  sm?: boolean;
+  placement?: 'up' | 'down';
+  align?: 'left' | 'right';
+  minWidth?: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  useClickOutside(wrapRef, open, () => setOpen(false));
+
+  const itemStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    width: '100%',
+    padding: '8px 12px',
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontFamily: 'var(--sans)',
+    color: 'var(--text)',
+    textAlign: 'left',
+  };
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        className={'btn btn-ghost' + (sm ? ' sm' : '')}
+        disabled={disabled || busy}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {busy ? (
+          <Icon name="refresh" size={sm ? 12 : 14} style={{ animation: 'spin 1s linear infinite' }} />
+        ) : (
+          <Icon name="download" size={sm ? 12 : 14} />
+        )}
+        {tr('导出', 'Export')}
+        <Icon name="chevDown" size={12} />
+      </button>
+      {open && (
+        <div
+          className="card"
+          role="menu"
+          style={{
+            position: 'absolute',
+            ...(placement === 'up' ? { bottom: 'calc(100% + 4px)' } : { top: 'calc(100% + 4px)' }),
+            ...(align === 'right' ? { right: 0 } : { left: 0 }),
+            zIndex: 30,
+            minWidth,
+            padding: '4px 0',
+            boxShadow: 'var(--shadow-pop)',
+          }}
+        >
+          {items.map((it) => (
+            <button
+              key={it.key}
+              type="button"
+              role="menuitem"
+              style={itemStyle}
+              onClick={() => {
+                setOpen(false);
+                it.onSelect();
+              }}
+            >
+              {it.icon && <Icon name={it.icon} size={13} style={{ color: 'var(--text-3)' }} />}
+              <span>
+                {it.label}
+                {it.hint && (
+                  <span className="muted" style={{ marginLeft: 5, fontSize: 10.5 }}>
+                    {it.hint}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -11,11 +11,13 @@ import {
   usePaperFigures,
 } from '../../components/ui/FigureGallery';
 import { CompileBadge } from '../../components/ui/CompileBadge';
+import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import {
   ApiError,
   api,
+  type CitationFormat,
   type DailyPaperItem,
   type DailySort,
   type PaperDetail,
@@ -685,10 +687,10 @@ export function DailyPage() {
     });
 
   const exportMutation = useMutation({
-    mutationFn: () => api.downloadDailyCitations({ format: 'bibtex', ids: [...selected] }),
-    onSuccess: (blob) => {
-      saveBlob(blob, 'polaris-daily-citations.bib');
-      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+    mutationFn: (format: CitationFormat) => api.downloadDailyCitations({ format, ids: [...selected] }),
+    onSuccess: (blob, format) => {
+      saveBlob(blob, format === 'bibtex' ? 'polaris-daily-citations.bib' : 'polaris-daily-citations.json');
+      toast(tr(`已导出 ${selected.size} 篇`, `Exported ${selected.size} papers`), 'ok');
     },
     onError: (e) =>
       toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
@@ -1054,14 +1056,14 @@ export function DailyPage() {
                 {selectMode ? tr(`已选 ${selected.size}`, `${selected.size} selected`) : tr('多选', 'Select')}
               </button>
               {selectMode && (
-                <button
-                  className="btn btn-ghost sm"
-                  disabled={selected.size === 0 || exportMutation.isPending}
-                  onClick={() => exportMutation.mutate()}
-                >
-                  <Icon name="download" size={12} />
-                  {tr('导出 BibTeX', 'Export BibTeX')}
-                </button>
+                <ExportDropdown
+                  sm
+                  placement="up"
+                  align="left"
+                  busy={exportMutation.isPending}
+                  disabled={selected.size === 0}
+                  items={citationExportItems((format) => exportMutation.mutate(format))}
+                />
               )}
             </div>
           </div>

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -182,7 +182,7 @@ export function ExperimentPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const newIdeaId = searchParams.get('new');
@@ -337,8 +337,8 @@ export function ExperimentPage() {
         eyebrow="Stage 03 · Experiment Lab"
         title={tr('实验搭建', 'Experiment Lab')}
         sub={
-          currentProject
-            ? tr(`当前课题：${currentProject.name}`, `Current topic: ${currentProject.name}`)
+          pid
+            ? undefined
             : projectsLoading
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -389,7 +389,7 @@ export function ForgePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { openGates } = useShell();
-  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProjectId } = useProject();
   const pid = currentProjectId;
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -566,8 +566,8 @@ export function ForgePage() {
         eyebrow="Stage 01 · Idea Forge"
         title={tr('想法生成', 'Idea Forge')}
         sub={
-          currentProject
-            ? tr(`当前课题：${currentProject.name}`, `Current topic: ${currentProject.name}`)
+          pid
+            ? undefined
             : projectsLoading
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -10,6 +10,7 @@ import {
   usePaperFigures,
 } from '../../components/ui/FigureGallery';
 import { CompileBadge } from '../../components/ui/CompileBadge';
+import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { RelevanceBar } from '../../components/ui/RelevanceBar';
 import { ScoreRing } from '../../components/ui/ScoreRing';
 import { PaperStatusPill } from '../../components/ui/StatusPill';
@@ -20,6 +21,7 @@ import { fmtTime } from '../../lib/format';
 import {
   ApiError,
   api,
+  type CitationFormat,
   type PaperRead,
   type PaperSort,
   type PaperStatusFilter,
@@ -624,10 +626,10 @@ function PapersPane({
   }, [libraryId, q, view]);
 
   const bulkExportMutation = useMutation({
-    mutationFn: () => api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] }),
-    onSuccess: (blob) => {
-      saveBlob(blob, 'polaris-library-citations.bib');
-      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+    mutationFn: (format: CitationFormat) => api.downloadLibraryCitations(libraryId, { format, ids: [...selected] }),
+    onSuccess: (blob, format) => {
+      saveBlob(blob, format === 'bibtex' ? 'polaris-library-citations.bib' : 'polaris-library-citations.json');
+      toast(tr(`已导出 ${selected.size} 篇`, `Exported ${selected.size} papers`), 'ok');
     },
     onError: (e) =>
       toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
@@ -897,14 +899,14 @@ function PapersPane({
               : tr('多选', 'Select')}
           </button>
           {selectMode && (
-            <button
-              className="btn btn-ghost sm"
-              disabled={selected.size === 0 || bulkExportMutation.isPending}
-              onClick={() => bulkExportMutation.mutate()}
-            >
-              <Icon name="download" size={12} />
-              {tr('导出 BibTeX', 'Export BibTeX')}
-            </button>
+            <ExportDropdown
+              sm
+              placement="up"
+              align="left"
+              busy={bulkExportMutation.isPending}
+              disabled={selected.size === 0}
+              items={citationExportItems((format) => bulkExportMutation.mutate(format))}
+            />
           )}
         </div>
       </div>

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -133,40 +133,9 @@ function StatusBanner({ lib }: { lib: DirectionLibraryDetail }) {
     onSuccess: () => { toast(tr('已撤回申请', 'Request withdrawn'), 'ok'); invalidate(); },
     onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
   });
-  const makePersonal = useMutation({
-    mutationFn: () => api.makeLibraryPersonal(lib.id),
-    onSuccess: () => { toast(tr('已转为个人文献库', 'Made personal'), 'ok'); invalidate(); },
-    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
-  });
-
   if (lib.status === 'active') {
-    // 公共库：仅平台 admin 可就地转回个人（转回后其他成员看不到）。
-    if (lib.is_public) {
-      if (!admin) return null;
-      return (
-        <div className="card" style={{ padding: '12px 16px', marginBottom: 14 }}>
-          <div className="row" style={{ justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
-            <div className="col gap4" style={{ minWidth: 0 }}>
-              <div className="row gap8" style={{ fontWeight: 680, fontSize: 13.5 }}>
-                <Icon name="book" size={14} style={{ color: 'var(--ok-tx)' }} />
-                {tr('公共文献库', 'Public library')}
-              </div>
-              <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
-                {tr(
-                  '转为个人库后仅归属人可见，其他成员将看不到。',
-                  'Making it personal hides it from everyone but its owner.',
-                )}
-              </div>
-            </div>
-            <div className="row gap8" style={{ flexShrink: 0 }}>
-              <button className="btn btn-soft sm" disabled={makePersonal.isPending} onClick={() => makePersonal.mutate()}>
-                {makePersonal.isPending ? tr('处理中…', 'Working…') : tr('转为个人文献库', 'Make personal')}
-              </button>
-            </div>
-          </div>
-        </div>
-      );
-    }
+    // 公共库：转回个人在「文献库配置 · 库信息」里，这里不再重复。
+    if (lib.is_public) return null;
     // 个人库：归属人或 admin 可发起转公共（admin 直接通过）。
     if (!(isOwner || admin)) return null;
     return (

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -5,9 +5,11 @@ import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { toast } from '../../components/ui/Toast';
 import {
   api,
+  type CitationFormat,
   type LibraryEntry,
   type LibrarySort,
   type LibraryTab,
@@ -560,10 +562,14 @@ export function LibraryPage() {
   });
 
   const exportMutation = useMutation({
-    mutationFn: () => api.downloadPersonalCitations({ format: 'bibtex', ids: [...selected.values()] }),
-    onSuccess: (blob) => {
-      saveBlob(blob, 'polaris-my-library-citations.bib');
-      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+    mutationFn: (format: CitationFormat) =>
+      api.downloadPersonalCitations({ format, ids: [...selected.values()] }),
+    onSuccess: (blob, format) => {
+      saveBlob(
+        blob,
+        format === 'bibtex' ? 'polaris-my-library-citations.bib' : 'polaris-my-library-citations.json',
+      );
+      toast(tr(`已导出 ${selected.size} 篇`, `Exported ${selected.size} papers`), 'ok');
     },
     onError: (e) => toast(`${tr('导出失败：', 'Export failed: ')}${errText(e)}`, 'error'),
   });
@@ -961,14 +967,14 @@ export function LibraryPage() {
                           <Icon name="x" size={12} />
                           {tr('删除', 'Delete')}
                         </button>
-                        <button
-                          className="btn btn-ghost sm"
-                          disabled={selected.size === 0 || exportMutation.isPending}
-                          onClick={() => exportMutation.mutate()}
-                        >
-                          <Icon name="download" size={12} />
-                          {tr('导出 BibTeX', 'Export BibTeX')}
-                        </button>
+                        <ExportDropdown
+                          sm
+                          placement="up"
+                          align="left"
+                          busy={exportMutation.isPending}
+                          disabled={selected.size === 0}
+                          items={citationExportItems((format) => exportMutation.mutate(format))}
+                        />
                       </>
                     )}
                   </>

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -6,9 +6,11 @@ import { PageHead } from '../../components/ui/PageHead';
 import { SelectMenu } from '../../components/ui/SelectMenu';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
+import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { toast } from '../../components/ui/Toast';
 import {
   api,
+  type CitationFormat,
   type DirectionLibrarySummary,
   type PaperRead,
   type ReadingStatus,
@@ -220,7 +222,7 @@ function ShelfRow({
   );
 }
 
-/* ---------------- 关联文献库区块（书架之上） ---------------- */
+/* ---------------- 关联文献库一栏（列表下方） ---------------- */
 
 /** 非 active 库的小状态徽标（待审批 / 已驳回）。 */
 function LibStatusBadge({ status }: { status: DirectionLibrarySummary['status'] }) {
@@ -236,86 +238,64 @@ function LibStatusBadge({ status }: { status: DirectionLibrarySummary['status'] 
   );
 }
 
-/** 课题关联的文献库（语料来源）：库名 + 各库论文数 + 进库入口。
-    总篇数用工作台同源的 stats.papers_total（并集去重口径），不做 per-library 相加。 */
-function LinkedLibrariesBar({
+/** 列表下方的一栏：课题关联的文献库，点库名进对应的库详情页。 */
+function LinkedLibrariesRow({
   pid,
   libs,
-  corpusTotal,
   loading,
   onNavigate,
 }: {
   pid: string;
   libs: DirectionLibrarySummary[];
-  /** 并集语料总篇数（stats.papers_total，与工作台一致）；未就绪时 null */
-  corpusTotal: number | null;
   loading: boolean;
   onNavigate: (path: string) => void;
 }) {
-  const linkedCount = libs.length;
-  const totalPart = corpusTotal !== null ? tr(` · 共 ${corpusTotal} 篇`, ` · ${corpusTotal} papers`) : '';
-  const title =
-    linkedCount === 0
-      ? tr('关联文献库', 'Linked libraries')
-      : tr(`关联文献库 · ${linkedCount} 个${totalPart}`, `Linked libraries · ${linkedCount}${totalPart}`);
+  if (loading) {
+    return (
+      <div className="row gap8" style={{ marginTop: 12, flexShrink: 0 }}>
+        <div className="skel" style={{ height: 22, width: 160 }} />
+        <div className="skel" style={{ height: 22, width: 120 }} />
+      </div>
+    );
+  }
 
   return (
-    <div className="card card-pad" style={{ marginBottom: 16, flexShrink: 0 }}>
-      <div className="row" style={{ justifyContent: 'space-between', marginBottom: linkedCount === 0 ? 0 : 12 }}>
-        <span className="section-h">
-          <Icon name="book" size={15} style={{ color: 'var(--accent)' }} />
-          {title}
-        </span>
-        <button className="btn btn-ghost sm" onClick={() => onNavigate(`/projects/${pid}`)}>
-          <Icon name="link" size={12} />
-          {tr('管理关联库', 'Linked libraries')}
-        </button>
-      </div>
-
-      {loading ? (
-        <div className="row gap8">
-          <div className="skel" style={{ height: 30, width: 180 }} />
-          <div className="skel" style={{ height: 30, width: 150 }} />
-        </div>
-      ) : linkedCount === 0 ? (
-        <div className="row gap10" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
-          <span style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.5, flex: 1, minWidth: 220 }}>
-            {tr(
-              '这个课题还没关联文献库——先去关联，才有可挑选的语料。',
-              'This topic has no linked libraries yet — link one to get a corpus to pick from.',
-            )}
+    <div
+      className="row gap8"
+      style={{ marginTop: 12, flexShrink: 0, flexWrap: 'wrap', alignItems: 'center', fontSize: 12.5 }}
+    >
+      <span className="row gap6" style={{ color: 'var(--text-3)', flexShrink: 0 }}>
+        <Icon name="book" size={13} style={{ color: 'var(--accent)' }} />
+        {tr('关联文献库', 'Linked libraries')}
+      </span>
+      {libs.length === 0 ? (
+        <>
+          <span style={{ color: 'var(--text-3)' }}>
+            {tr('还没关联，先关联一个再挑论文。', 'None yet — link one to pick papers from.')}
           </span>
-          <div className="row gap8">
-            <button className="btn btn-primary sm" onClick={() => onNavigate(`/projects/${pid}`)}>
-              <Icon name="link" size={13} />
-              {tr('去关联', 'Link a library')}
-            </button>
-            <button className="btn btn-ghost sm" onClick={() => onNavigate('/libraries')}>
-              {tr('浏览全部文献库', 'Browse all libraries')}
-            </button>
-          </div>
-        </div>
+          <button className="btn btn-ghost sm" onClick={() => onNavigate(`/projects/${pid}`)}>
+            <Icon name="link" size={12} />
+            {tr('去关联', 'Link a library')}
+          </button>
+        </>
       ) : (
-        <div className="row gap8" style={{ flexWrap: 'wrap' }}>
-          {libs.map((lib) => (
-            <button
-              key={lib.id}
-              className="btn btn-soft sm"
-              style={{ maxWidth: 300 }}
-              title={lib.name}
-              onClick={() => onNavigate(libraryPath(lib.id))}
-            >
-              <Icon name="book" size={12} style={{ flexShrink: 0 }} />
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
-                {lib.name}
-              </span>
-              <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
-                {tr(`${lib.paper_count} 篇`, `${lib.paper_count}`)}
-              </span>
-              <LibStatusBadge status={lib.status} />
-            </button>
-          ))}
-        </div>
+        libs.map((lib) => (
+          <button
+            key={lib.id}
+            className="btn btn-ghost sm"
+            style={{ maxWidth: 300 }}
+            title={lib.name}
+            onClick={() => onNavigate(libraryPath(lib.id))}
+          >
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+              {lib.name}
+            </span>
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
+              {tr(`${lib.paper_count} 篇`, `${lib.paper_count}`)}
+            </span>
+            <LibStatusBadge status={lib.status} />
+          </button>
+        ))
       )}
     </div>
   );
@@ -583,15 +563,7 @@ export function ResearchPage() {
     enabled: !!pid,
     retry: false,
   });
-  // 并集语料总篇数：与工作台完全同源（['stats', pid] → papers_total），不做 per-library 相加
-  const statsQuery = useQuery({
-    queryKey: ['stats', pid],
-    queryFn: () => api.getStats(pid),
-    enabled: !!pid,
-    retry: false,
-  });
   const libs = useMemo<DirectionLibrarySummary[]>(() => sourceLibrariesQuery.data ?? [], [sourceLibrariesQuery.data]);
-  const corpusTotal = statsQuery.data?.papers_total ?? null;
 
   // 「文献库入口」目标：正好 1 个关联库→进那个库；多个→课题设置关联区；0 个→全部文献库列表。
   // （不再指向隐式库 topicLib——新模型里课题无单一隐式库）
@@ -717,12 +689,12 @@ export function ResearchPage() {
     onError: (e) => toast(`${tr('刷新失败：', 'Failed to refresh: ')}${errText(e)}`, 'error'),
   });
 
-  // 多选导出：把勾选的 paper_id 子集导成 BibTeX（course 作用域，复用文献库同一端点）
+  // 多选导出：把勾选的 paper_id 子集导出引用（course 作用域，复用文献库同一端点）
   const exportMutation = useMutation({
-    mutationFn: () => api.downloadCitations(pid, { format: 'bibtex', ids: [...checkedIds] }),
-    onSuccess: (blob) => {
-      saveBlob(blob, 'polaris-selected.bib');
-      toast(tr(`已导出 ${checkedIds.size} 篇的 BibTeX`, `Exported BibTeX for ${checkedIds.size} papers`), 'ok');
+    mutationFn: (format: CitationFormat) => api.downloadCitations(pid, { format, ids: [...checkedIds] }),
+    onSuccess: (blob, format) => {
+      saveBlob(blob, format === 'bibtex' ? 'polaris-selected.bib' : 'polaris-selected.json');
+      toast(tr(`已导出 ${checkedIds.size} 篇`, `Exported ${checkedIds.size} papers`), 'ok');
     },
     onError: (e) => toast(`${tr('导出失败：', 'Export failed: ')}${errText(e)}`, 'error'),
   });
@@ -778,17 +750,6 @@ export function ResearchPage() {
           onChange={setTab}
         />
       </div>
-
-      {/* 关联文献库栏（语料来源）：仅列表视图显示 */}
-      {tab === 'list' && (
-        <LinkedLibrariesBar
-          pid={pid}
-          libs={libs}
-          corpusTotal={corpusTotal}
-          loading={sourceLibrariesQuery.isLoading}
-          onNavigate={(path) => navigate(path)}
-        />
-      )}
 
       {/* —— 卡片容器（列表用双栏；对话直接铺满） —— */}
 
@@ -1071,14 +1032,14 @@ export function ResearchPage() {
                     <Icon name="x" size={12} />
                     {tr('删除', 'Delete')}
                   </button>
-                  <button
-                    className="btn btn-ghost sm"
-                    disabled={checkedIds.size === 0 || exportMutation.isPending}
-                    onClick={() => exportMutation.mutate()}
-                  >
-                    <Icon name="download" size={12} />
-                    {tr('导出 BibTeX', 'Export BibTeX')}
-                  </button>
+                  <ExportDropdown
+                    sm
+                    placement="up"
+                    align="left"
+                    busy={exportMutation.isPending}
+                    disabled={checkedIds.size === 0}
+                    items={citationExportItems((format) => exportMutation.mutate(format))}
+                  />
                 </>
               )}
               <button
@@ -1148,6 +1109,16 @@ export function ResearchPage() {
         </div>
         )}
       </div>
+
+      {/* 关联文献库：列表下方一栏，点库名进对应的库 */}
+      {tab === 'list' && (
+        <LinkedLibrariesRow
+          pid={pid}
+          libs={libs}
+          loading={sourceLibrariesQuery.isLoading}
+          onNavigate={(path) => navigate(path)}
+        />
+      )}
 
       {/* —— 添加文献（从文献库 / 手动）统一弹窗 —— */}
       <AddPaperModal

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -48,7 +48,7 @@ export function GovernanceTab({ libraryId, readOnly = false }: { libraryId: stri
 
   return (
     <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
-      {lib && <LibraryInfoCard lib={lib} readOnly={readOnly} />}
+      {lib && <LibraryInfoCard lib={lib} readOnly={readOnly} admin={admin} />}
       {lib && <InclusionSettingsCard lib={lib} readOnly={readOnly} />}
       {/* 预算 / 管理员名单 / 重复论文均为管理门数据，普通用户取不到 → 只读时不渲染 */}
       {!readOnly && (
@@ -246,7 +246,16 @@ function BudgetCard({ libraryId }: { libraryId: string }) {
 
 /* —— 库信息与预算 —— */
 
-function LibraryInfoCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readOnly?: boolean }) {
+function LibraryInfoCard({
+  lib,
+  readOnly,
+  admin,
+}: {
+  lib: DirectionLibraryDetail;
+  readOnly?: boolean;
+  /** 平台管理员：可把公共库转回个人库 */
+  admin?: boolean;
+}) {
   const queryClient = useQueryClient();
   const [name, setName] = useState(lib.name);
   const [statement, setStatement] = useState(lib.statement ?? '');
@@ -285,6 +294,18 @@ function LibraryInfoCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readO
   });
 
   const budgetInvalid = budget.trim() !== '' && (!Number.isFinite(Number(budget)) || Number(budget) < 0);
+
+  // 公共库转回个人库：仅平台管理员，转回后只有归属人能看到
+  const makePersonal = useMutation({
+    mutationFn: () => api.makeLibraryPersonal(lib.id),
+    onSuccess: () => {
+      toast(tr('已转为个人文献库', 'Made personal'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['library', lib.id] });
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+    },
+    onError: () => toast(tr('操作失败，请重试', 'Action failed, please retry'), 'error'),
+  });
+  const canMakePersonal = !readOnly && !!admin && lib.is_public && lib.status === 'active';
 
   return (
     <section className="card" style={{ padding: 18 }}>
@@ -344,6 +365,30 @@ function LibraryInfoCard({ lib, readOnly }: { lib: DirectionLibraryDetail; readO
         {!readOnly && budgetInvalid && (
           <div style={{ color: 'var(--danger-tx)', fontSize: 12 }}>
             {tr('预算需为不小于 0 的数字', 'Budget must be a number ≥ 0')}
+          </div>
+        )}
+        {canMakePersonal && (
+          <div
+            className="row"
+            style={{
+              justifyContent: 'space-between',
+              alignItems: 'flex-end',
+              gap: 12,
+              flexWrap: 'wrap',
+              borderTop: '0.5px solid var(--border)',
+              paddingTop: 12,
+            }}
+          >
+            <div className="col gap6" style={{ minWidth: 0 }}>
+              <span className="muted" style={{ fontSize: 12 }}>{tr('归属', 'Ownership')}</span>
+              <span className="row gap6" style={{ fontSize: 13 }}>
+                <Icon name="book" size={13} style={{ color: 'var(--ok-tx)' }} />
+                {tr('公共文献库 · 全实验室可见', 'Public · visible to the whole lab')}
+              </span>
+            </div>
+            <button className="btn btn-soft sm" disabled={makePersonal.isPending} onClick={() => makePersonal.mutate()}>
+              {makePersonal.isPending ? tr('处理中…', 'Working…') : tr('转为个人文献库', 'Make personal')}
+            </button>
           </div>
         )}
       </div>

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -10,6 +10,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { Modal } from '../../components/ui/Modal';
 import { FigureEmbed, FiguresSection, hasEmbeddedFigures, usePaperFigures } from '../../components/ui/FigureGallery';
 import { CompileBadge } from '../../components/ui/CompileBadge';
+import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { PaperReader } from './PaperReader';
 import { readerFrom } from '../reading/shared';
 import { toast } from '../../components/ui/Toast';
@@ -315,19 +316,6 @@ export function ExportMenu({
   /** 列表过滤条件，透传给课题版引用导出；不传导出全部库内文献（库版不支持过滤） */
   filters?: { status?: PaperStatusFilter; starred?: boolean };
 }) {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
-
-  // 点外面关闭
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
-
   const obsidianMutation = useMutation({
     mutationFn: () =>
       libraryId ? api.downloadLibraryObsidianExport(libraryId) : api.downloadObsidianExport(pid!),
@@ -357,91 +345,34 @@ export function ExportMenu({
 
   const busy = obsidianMutation.isPending || citationsMutation.isPending;
 
-  const itemStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    width: '100%',
-    padding: '8px 12px',
-    border: 'none',
-    background: 'transparent',
-    cursor: 'pointer',
-    fontSize: 12,
-    fontFamily: 'var(--sans)',
-    color: 'var(--text)',
-    textAlign: 'left',
-  };
-
   return (
-    <div ref={wrapRef} style={{ position: 'relative' }}>
-      <button className="btn btn-ghost" onClick={() => setOpen((o) => !o)} disabled={busy}>
-        {busy ? (
-          <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
-        ) : (
-          <Icon name="download" size={14} />
-        )}
-        {tr('导出', 'Export')}
-        <Icon name="chevDown" size={12} />
-      </button>
-      {open && (
-        <div
-          className="card"
-          style={{
-            position: 'absolute',
-            top: 'calc(100% + 4px)',
-            right: 0,
-            zIndex: 30,
-            minWidth: 210,
-            padding: '4px 0',
-            boxShadow: 'var(--shadow-pop)',
-          }}
-        >
-          <button
-            style={itemStyle}
-            onClick={() => {
-              setOpen(false);
-              obsidianMutation.mutate();
-            }}
-          >
-            <Icon name="file" size={13} style={{ color: 'var(--text-3)' }} />
-            <span>
-              {tr('Obsidian 笔记库', 'Obsidian vault')}
-              <span className="muted" style={{ marginLeft: 5, fontSize: 10.5 }}>.zip</span>
-            </span>
-          </button>
-          <button
-            style={itemStyle}
-            onClick={() => {
-              setOpen(false);
-              citationsMutation.mutate('bibtex');
-            }}
-          >
-            <Icon name="book" size={13} style={{ color: 'var(--text-3)' }} />
-            <span>
-              {tr('BibTeX 引用', 'BibTeX citations')}
-              <span className="muted" style={{ marginLeft: 5, fontSize: 10.5 }}>
-                {tr('.bib · 全部库内文献', '.bib · whole library')}
-              </span>
-            </span>
-          </button>
-          <button
-            style={itemStyle}
-            onClick={() => {
-              setOpen(false);
-              citationsMutation.mutate('csl-json');
-            }}
-          >
-            <Icon name="layers" size={13} style={{ color: 'var(--text-3)' }} />
-            <span>
-              CSL-JSON
-              <span className="muted" style={{ marginLeft: 5, fontSize: 10.5 }}>
-                {tr('Zotero 可直接导入', 'imports straight into Zotero')}
-              </span>
-            </span>
-          </button>
-        </div>
-      )}
-    </div>
+    <ExportDropdown
+      busy={busy}
+      minWidth={210}
+      items={[
+        {
+          key: 'obsidian',
+          icon: 'file',
+          label: tr('Obsidian 笔记库', 'Obsidian vault'),
+          hint: '.zip',
+          onSelect: () => obsidianMutation.mutate(),
+        },
+        {
+          key: 'bibtex',
+          icon: 'book',
+          label: tr('BibTeX 引用', 'BibTeX citations'),
+          hint: tr('.bib · 全部库内文献', '.bib · whole library'),
+          onSelect: () => citationsMutation.mutate('bibtex'),
+        },
+        {
+          key: 'csl-json',
+          icon: 'layers',
+          label: 'CSL-JSON',
+          hint: tr('Zotero 可直接导入', 'imports straight into Zotero'),
+          onSelect: () => citationsMutation.mutate('csl-json'),
+        },
+      ]}
+    />
   );
 }
 
@@ -1207,13 +1138,13 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   });
 
   const bulkExportMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: (format: CitationFormat) =>
       libraryId
-        ? api.downloadLibraryCitations(libraryId, { format: 'bibtex', ids: [...selected] })
-        : api.downloadCitations(pid ?? '', { format: 'bibtex', ids: [...selected] }),
-    onSuccess: (blob) => {
-      saveBlob(blob, 'polaris-selected.bib');
-      toast(tr(`已导出 ${selected.size} 篇的 BibTeX`, `Exported BibTeX for ${selected.size} papers`), 'ok');
+        ? api.downloadLibraryCitations(libraryId, { format, ids: [...selected] })
+        : api.downloadCitations(pid ?? '', { format, ids: [...selected] }),
+    onSuccess: (blob, format) => {
+      saveBlob(blob, format === 'bibtex' ? 'polaris-selected.bib' : 'polaris-selected.json');
+      toast(tr(`已导出 ${selected.size} 篇`, `Exported ${selected.size} papers`), 'ok');
     },
     onError: (e) =>
       toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
@@ -1568,14 +1499,14 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
                 <Icon name="x" size={12} />
                 {tr('删除', 'Delete')}
               </button>
-              <button
-                className="btn btn-ghost sm"
-                disabled={selected.size === 0 || bulkExportMutation.isPending}
-                onClick={() => bulkExportMutation.mutate()}
-              >
-                <Icon name="download" size={12} />
-                {tr('导出 BibTeX', 'Export BibTeX')}
-              </button>
+              <ExportDropdown
+                sm
+                placement="up"
+                align="left"
+                busy={bulkExportMutation.isPending}
+                disabled={selected.size === 0}
+                items={citationExportItems((format) => bulkExportMutation.mutate(format))}
+              />
             </>
           )}
           <button

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -236,7 +236,7 @@ function ManuscriptCard({
 export function WriterPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
+  const { isLoading: projectsLoading, currentProjectId } = useProject();
   const pid = currentProjectId;
   const [modalOpen, setModalOpen] = useState(false);
   const [view, setView] = useState<ViewMode>('active');
@@ -398,8 +398,8 @@ export function WriterPage() {
         eyebrow="Stage 04 · Paper Writer"
         title={tr('论文撰写', 'Paper Writer')}
         sub={
-          currentProject
-            ? `${tr('当前课题：', 'Current topic: ')}${currentProject.name}`
+          pid
+            ? undefined
             : projectsLoading
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')


### PR DESCRIPTION
Four interface changes plus housekeeping.

## 1. "Make personal" moves into library config

The control leaves the library detail banner and lands in the **library config tab**, at the bottom of the library-info card with the rest of the library's settings. The sentence explaining what turning a library personal does is **dropped, not moved** — the button says what it does.

Same permission condition, same endpoint.

## 2. Related work: linked-libraries panel → a row under the list

The panel above the shelf is gone. The links now sit **below the list**: one small button per library carrying its paper count and approval state, each going to that library. Nothing above the list competes with the list.

The "共 N 篇" stat query that only served that panel is removed too. The manage-links entry no longer appears when libraries exist — it stays in the empty state, which is when you'd need it.

## 3. "Current topic: x" subtitle removed

Gone from idea forge, experiment and writer. The sidebar has shown the current topic all along. The no-topic-selected branch of those subtitles is kept.

## 4. Export becomes a dropdown

Five multi-select bars had a BibTeX-only button. They now get a dropdown: **BibTeX + CSL-JSON**. The workbench's whole-library menu keeps its third option (Obsidian) and is refactored onto the same shared component rather than staying a fifth implementation.

### Why Obsidian isn't on the multi-select bars

Checked the backend rather than assuming:

- The obsidian endpoints (`/projects/{id}/export/obsidian`, `/libraries/{id}/export/obsidian`) **take no `ids` parameter**. On a "N selected" bar it would silently ignore your selection and export the whole library — not an error, but the wrong thing.
- The personal library and daily feed **have no obsidian endpoint at all**.

Adding it means backend work: `ids` support on the two existing endpoints, and new endpoints for the other two surfaces.

## Housekeeping

- `.env.example` comments are English now, matching the rest of the repo. Variable names and defaults verified identical — comments only.
- The issue templates' **Area** list gains `desktop (Electron client)` plus several areas that existed in the product but were never listed (daily papers, idea forge, experiment, llm routing, auth). All three templates were identical and stay identical.
- The PR template gets the same Area list, and a `alembic heads` single-head check next to the existing migration row — that's bitten us before.

## Verification

`tsc --noEmit` 0 errors, `vite build` passes.