### PR TITLE
fix(ui): drop page-head breadcrumbs and titles, fold actions into tab rows

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -40,7 +40,7 @@ const NAV_LAB: NavEntry[] = [
 ];
 
 const NAV_MAIN: NavEntry[] = [
-  { icon: 'dashboard', zh: '工作台', en: 'Workbench' },
+  { icon: 'dashboard', zh: '课题工作台', en: 'Topic Workbench' },
   { sub: 'research', icon: 'pin', zh: '相关研究', en: 'Related Work' },
 ];
 
@@ -65,7 +65,7 @@ function crumbFor(pathname: string): [string, string] {
   // 课题作用域路径统一去掉 /t/<topicId> 前缀后按旧表匹配
   const scoped = /^\/t\/[^/]+(\/.*)?$/.exec(pathname);
   const p = scoped ? (scoped[1] ?? '/') : pathname;
-  if (p === '/') return ['Polaris', tr('工作台', 'Workbench')];
+  if (p === '/') return ['Polaris', tr('课题工作台', 'Topic Workbench')];
   if (p === '/start') return ['Polaris', tr('选择课题', 'Pick a topic')];
   if (p === '/projects/new') return [tr('课题', 'Topics'), tr('新建课题', 'New topic')];
   if (p.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];

--- a/src/frontend/src/components/ui/PageHead.tsx
+++ b/src/frontend/src/components/ui/PageHead.tsx
@@ -1,29 +1,32 @@
 import type { ReactNode } from 'react';
 
 export interface PageHeadProps {
-  /**
-   * 面包屑（如 "Polaris · My Library"）。**不再渲染** —— 侧栏和顶栏已经指明了
-   * 当前位置，页头再写一遍只是把标题往下推。保留 prop 是为了不改 18 个调用点。
-   */
+  /** 面包屑。**不再渲染** —— 侧栏和顶栏已经指明当前位置。prop 保留，免改调用点。 */
   eyebrow?: string;
-  title: string;
+  /** 大标题。**不再渲染** —— 同上，侧栏选中项就是标题。prop 保留，免改调用点。 */
+  title?: string;
+  /** 仍会渲染：这里只剩「没选课题」这类真提示，以及库详情页的方向描述。 */
   sub?: string;
   right?: ReactNode;
-  /** 紧凑：无副标题时收紧与下方内容的间距 */
+  /** 紧凑：收紧与下方内容的间距 */
   dense?: boolean;
 }
 
-/** 大标题 + 可选副标题的页头（调用方用 tr() 传入当前语言文案）。 */
-export function PageHead({ title, sub, right, dense }: PageHeadProps) {
+/**
+ * 页头：标题与面包屑都交给导航去表达，这里只剩副标题与操作区。
+ * 两者都没有时不渲染任何东西——留一个空 div 会在页面顶部留下一条孤儿空白。
+ *
+ * 有标签行（Segmented）的页面不该再用 `right`：操作应当并进标签行，
+ * 免得顶部多出一整行只放按钮。
+ */
+export function PageHead({ sub, right, dense }: PageHeadProps) {
+  if (!sub && !right) return null;
   return (
-    // 窄屏下操作区改到标题下方（见 global.css）：右侧按钮不压缩，标题的
-    // flex-basis 又是 0，同排会把标题挤成一栏窄条、逐字换行。
+    // 窄屏下操作区改到副标题下方（见 global.css）：右侧按钮不压缩，左栏的
+    // flex-basis 又是 0，同排会把文字挤成一栏窄条、逐字换行。
     // 间距写在 CSS 里而不是内联：内联优先级高于样式表，窄屏改不动。
-    <div className="row page-head" style={{ alignItems: 'flex-start', marginBottom: dense ? 12 : 18 }}>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <h1 className="h-title">{title}</h1>
-        {sub && <p className="h-sub">{sub}</p>}
-      </div>
+    <div className="row page-head" style={{ alignItems: 'flex-start', marginBottom: dense ? 12 : 16 }}>
+      <div style={{ flex: 1, minWidth: 0 }}>{sub && <p className="h-sub">{sub}</p>}</div>
       {right && <div className="row gap10 page-head-actions">{right}</div>}
     </div>
   );

--- a/src/frontend/src/components/ui/PageHead.tsx
+++ b/src/frontend/src/components/ui/PageHead.tsx
@@ -1,7 +1,11 @@
 import type { ReactNode } from 'react';
 
 export interface PageHeadProps {
-  eyebrow: string;
+  /**
+   * 面包屑（如 "Polaris · My Library"）。**不再渲染** —— 侧栏和顶栏已经指明了
+   * 当前位置，页头再写一遍只是把标题往下推。保留 prop 是为了不改 18 个调用点。
+   */
+  eyebrow?: string;
   title: string;
   sub?: string;
   right?: ReactNode;
@@ -9,15 +13,14 @@ export interface PageHeadProps {
   dense?: boolean;
 }
 
-/** Eyebrow + 大标题 + 副标题的页头（调用方用 tr() 传入当前语言文案）。 */
-export function PageHead({ eyebrow, title, sub, right, dense }: PageHeadProps) {
+/** 大标题 + 可选副标题的页头（调用方用 tr() 传入当前语言文案）。 */
+export function PageHead({ title, sub, right, dense }: PageHeadProps) {
   return (
     // 窄屏下操作区改到标题下方（见 global.css）：右侧按钮不压缩，标题的
     // flex-basis 又是 0，同排会把标题挤成一栏窄条、逐字换行。
     // 间距写在 CSS 里而不是内联：内联优先级高于样式表，窄屏改不动。
-    <div className="row page-head" style={{ alignItems: 'flex-start', marginBottom: dense ? 14 : 26 }}>
+    <div className="row page-head" style={{ alignItems: 'flex-start', marginBottom: dense ? 12 : 18 }}>
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div className="h-eyebrow">{eyebrow}</div>
         <h1 className="h-title">{title}</h1>
         {sub && <p className="h-sub">{sub}</p>}
       </div>

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -2,7 +2,6 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useLocation, useNavigate } from 'react-router-dom';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
 import {
   FigureEmbed,
@@ -756,24 +755,8 @@ export function DailyPage() {
       className="page fadeup page-fill"
       style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
-      <PageHead
-        eyebrow="Polaris · Daily Papers"
-        title={tr('每日新论文', 'Daily Papers')}
-        right={
-          (categoriesQuery.data?.categories.length ?? 0) > 0 ? (
-            <div className="row gap6 wrap" style={{ justifyContent: 'flex-end', maxWidth: 420 }}>
-              <span style={{ fontSize: 11, color: 'var(--text-4)' }}>{tr('订阅分类', 'Subscribed')}</span>
-              {categoriesQuery.data?.categories.map((c) => (
-                <span key={c} className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
-                  {c}
-                </span>
-              ))}
-            </div>
-          ) : undefined
-        }
-      />
-
-      <div className="row" style={{ marginBottom: 14 }}>
+      {/* —— 标签行：订阅分类并在同一行右侧 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
         <Segmented<DailyView>
           options={[
             { v: 'papers', label: tr('论文', 'Papers') },
@@ -782,6 +765,19 @@ export function DailyPage() {
           value={view}
           onChange={setView}
         />
+        {(categoriesQuery.data?.categories.length ?? 0) > 0 && (
+          <div
+            className="row gap6 wrap"
+            style={{ marginLeft: 'auto', justifyContent: 'flex-end', maxWidth: 420 }}
+          >
+            <span style={{ fontSize: 11, color: 'var(--text-4)' }}>{tr('订阅分类', 'Subscribed')}</span>
+            {categoriesQuery.data?.categories.map((c) => (
+              <span key={c} className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
+                {c}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       <div

--- a/src/frontend/src/features/experiment/ExperimentPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentPage.tsx
@@ -344,10 +344,12 @@ export function ExperimentPage() {
               : tr('选择一个课题', 'Pick a topic')
         }
         right={
-          <button className="btn btn-primary" disabled={!pid} onClick={() => setModalOpen(true)}>
-            <Icon name="plus" size={14} />
-            {tr('新建实验', 'New experiment')}
-          </button>
+          pid ? undefined : (
+            <button className="btn btn-primary" disabled onClick={() => setModalOpen(true)}>
+              <Icon name="plus" size={14} />
+              {tr('新建实验', 'New experiment')}
+            </button>
+          )
         }
       />
 
@@ -361,6 +363,10 @@ export function ExperimentPage() {
               { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
             ]}
           />
+          <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} onClick={() => setModalOpen(true)}>
+            <Icon name="plus" size={13} />
+            {tr('新建实验', 'New experiment')}
+          </button>
           <button
             className={`btn sm ${multiSelect ? 'btn-primary' : 'btn-soft'}`}
             onClick={toggleMultiSelect}

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -588,19 +588,19 @@ export function ForgePage() {
         )}
         <div style={{ marginLeft: 'auto' }}>
           <div className="row gap8">
-            <button className="btn btn-soft" disabled={!pid || running} onClick={() => setModalOpen(true)}>
-              <Icon name="play" size={14} />
+            <button className="btn btn-soft sm" disabled={!pid || running} onClick={() => setModalOpen(true)}>
+              <Icon name="play" size={13} />
               {tr('运行 Idea Forge', 'Run Idea Forge')}
             </button>
-            <button className="btn btn-primary" disabled={!pid || running} onClick={() => openDeepDrawer()}>
+            <button className="btn btn-primary sm" disabled={!pid || running} onClick={() => openDeepDrawer()}>
               {running ? (
                 <>
-                  <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                  <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
                   {tr('运行中…', 'Running…')}
                 </>
               ) : (
                 <>
-                  <Icon name="sparkle" size={14} />
+                  <Icon name="sparkle" size={13} />
                   {tr('深度生成', 'Deep Dive')}
                 </>
               )}

--- a/src/frontend/src/features/forge/ForgePage.tsx
+++ b/src/frontend/src/features/forge/ForgePage.tsx
@@ -572,7 +572,21 @@ export function ForgePage() {
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')
         }
-        right={
+      />
+
+      {/* —— 顶部一行：视图标签在左，运行入口在右 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
+        {pid && (
+          <Segmented<ViewMode>
+            value={view}
+            onChange={setView}
+            options={[
+              { v: 'active', label: tr('想法列表', 'Ideas') },
+              { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
+            ]}
+          />
+        )}
+        <div style={{ marginLeft: 'auto' }}>
           <div className="row gap8">
             <button className="btn btn-soft" disabled={!pid || running} onClick={() => setModalOpen(true)}>
               <Icon name="play" size={14} />
@@ -592,8 +606,8 @@ export function ForgePage() {
               )}
             </button>
           </div>
-        }
-      />
+        </div>
+      </div>
 
       {/* 待确认研究目标提示 */}
       {deep?.pending_gate_id && (
@@ -715,14 +729,6 @@ export function ForgePage() {
           </span>
           {pid && (
             <>
-              <Segmented<ViewMode>
-                value={view}
-                onChange={setView}
-                options={[
-                  { v: 'active', label: tr('想法列表', 'Ideas') },
-                  { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
-                ]}
-              />
               <button
                 className={`btn sm ${multiSelect ? 'btn-primary' : 'btn-soft'}`}
                 onClick={toggleMultiSelect}

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
@@ -459,19 +458,7 @@ export function LibrariesPage() {
 
   return (
     <div className="page fadeup" style={{ maxWidth: 1200 }}>
-      <PageHead
-        eyebrow={tr('实验室', 'Lab')}
-        title={tr('文献库', 'Libraries')}
-        right={
-          canCreate ? (
-            <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
-              <Icon name="plus" size={13} />
-              {tr('新建文献库', 'New library')}
-            </button>
-          ) : null
-        }
-      />
-
+      {/* —— 筛选行：操作并在同一行右侧 —— */}
       <div className="row gap12" style={{ margin: '0 0 16px', flexWrap: 'wrap', alignItems: 'center' }}>
         <div className="row gap8" style={{ alignItems: 'center' }}>
           <span style={{ fontSize: 12, color: 'var(--text-3)' }}>{tr('归属', 'Type')}</span>
@@ -490,6 +477,16 @@ export function LibrariesPage() {
             wrapStyle={{ width: 140 }}
           />
         </div>
+        {canCreate && (
+          <button
+            className="btn btn-primary sm"
+            style={{ marginLeft: 'auto' }}
+            onClick={() => setCreateOpen(true)}
+          >
+            <Icon name="plus" size={13} />
+            {tr('新建文献库', 'New library')}
+          </button>
+        )}
         {admin && sorted.length > 0 && (
           <button
             className={`btn sm ${selectMode ? 'btn-primary' : 'btn-soft'}`}

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -69,7 +69,7 @@ export function LibraryDetailPage() {
     <div className="page fadeup page-fill" style={{ maxWidth: 1360, paddingBottom: 24 }}>
       <PageHead
         eyebrow={tr('实验室 · 文献库', 'Lab · Library')}
-        title={`${tr('文献库', 'Library')} · ${lib.name}`}
+        title={lib.name}
         dense
         sub={lib.statement ?? undefined}
         right={

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
@@ -592,22 +591,8 @@ export function LibraryPage() {
       className="page fadeup page-fill"
       style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
-      <PageHead
-        eyebrow="Polaris · My Library"
-        title={tr('我的文献库', 'My Library')}
-        dense
-        right={
-          onLibraryTab ? (
-            <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
-              <Icon name="plus" size={13} />
-              {tr('添加文献', 'Add paper')}
-            </button>
-          ) : undefined
-        }
-      />
-
-      {/* —— tab 行 —— */}
-      <div className="row" style={{ marginBottom: 14 }}>
+      {/* —— tab 行：操作并在同一行右侧，顶部不再单占一行 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
         <Segmented<PageTab>
           options={[
             { v: 'saved', label: tr('我的收藏', 'Saved') },
@@ -646,6 +631,16 @@ export function LibraryPage() {
           value={tab}
           onChange={setTab}
         />
+        {onLibraryTab && (
+          <button
+            className="btn btn-primary sm"
+            style={{ marginLeft: 'auto' }}
+            onClick={() => setAddOpen(true)}
+          >
+            <Icon name="plus" size={13} />
+            {tr('添加文献', 'Add paper')}
+          </button>
+        )}
       </div>
 
       {/* —— 卡片容器（同文献追踪的论文库外壳） —— */}

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { PageHead } from '../../components/ui/PageHead';
+import { Segmented } from '../../components/ui/Segmented';
 import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
 import { EmptyState } from '../../components/ui/EmptyState';
@@ -855,6 +856,9 @@ function ReviewDiscussion({ sessionId }: { sessionId: string }) {
 
 /* ---------------- 页面 ---------------- */
 
+/** 评审意见（总览 + 逐评审员 + 讨论） / 核对（引用核验 + 查错清单） */
+type ReviewTab = 'opinions' | 'checks';
+
 export function PaperReviewPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -864,6 +868,7 @@ export function PaperReviewPage() {
   const [msId, setMsId] = useState<string | null>(null);
   const [roundSid, setRoundSid] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const [tab, setTab] = useState<ReviewTab>('opinions');
 
   // —— 稿件列表（只保留可评审状态：已编译 / 评审中） ——
   const manuscriptsQuery = useQuery({
@@ -1011,7 +1016,19 @@ export function PaperReviewPage() {
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')
         }
-        right={
+      />
+
+      {/* —— 顶部一行：两个视图标签在左，发起评审在右 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
+        <Segmented<ReviewTab>
+          options={[
+            { v: 'opinions', label: tr('评审意见', 'Opinions') },
+            { v: 'checks', label: tr('核对', 'Checks') },
+          ]}
+          value={tab}
+          onChange={setTab}
+        />
+        <div style={{ marginLeft: 'auto' }}>
           <button
             className="btn btn-primary"
             disabled={!msId || !!runningReview}
@@ -1036,8 +1053,8 @@ export function PaperReviewPage() {
               </>
             )}
           </button>
-        }
-      />
+        </div>
+      </div>
 
       {/* —— 稿件 + 评审轮次选择 —— */}
       <div className="card card-pad row gap10" style={{ marginBottom: 16, flexWrap: 'wrap' }}>
@@ -1191,6 +1208,8 @@ export function PaperReviewPage() {
         </div>
       ) : (
         <>
+          {tab === 'opinions' && (
+          <>
           {/* 总览 */}
           <MetaOverviewCard
             meta={meta}
@@ -1242,14 +1261,20 @@ export function PaperReviewPage() {
             )}
           </div>
 
-          {/* 引用核验 */}
-          <CitationCard check={citation} />
-
-          {/* 查错清单 */}
-          <FactCheckCard items={factItems} msId={msId} files={detail?.files} />
-
           {/* 人类讨论 */}
           {sid && <ReviewDiscussion sessionId={sid} />}
+          </>
+          )}
+
+          {tab === 'checks' && (
+          <>
+            {/* 引用核验 */}
+            <CitationCard check={citation} />
+
+            {/* 查错清单 */}
+            <FactCheckCard items={factItems} msId={msId} files={detail?.files} />
+          </>
+          )}
 
           {/* 底部操作 */}
           <div className="card card-pad row gap10" style={{ justifyContent: 'space-between', flexWrap: 'wrap' }}>

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -1030,7 +1030,7 @@ export function PaperReviewPage() {
         />
         <div style={{ marginLeft: 'auto' }}>
           <button
-            className="btn btn-primary"
+            className="btn btn-primary sm"
             disabled={!msId || !!runningReview}
             title={
               !msId
@@ -1043,12 +1043,12 @@ export function PaperReviewPage() {
           >
             {runningReview ? (
               <>
-                <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
                 {tr('评审中…', 'Reviewing…')}
               </>
             ) : (
               <>
-                <Icon name="shield" size={14} />
+                <Icon name="shield" size={13} />
                 {tr('发起同行评审', 'Start peer review')}
               </>
             )}

--- a/src/frontend/src/features/paper-review/PaperReviewPage.tsx
+++ b/src/frontend/src/features/paper-review/PaperReviewPage.tsx
@@ -1006,7 +1006,7 @@ export function PaperReviewPage() {
         title={tr('论文评审', 'Paper Review')}
         sub={
           currentProject
-            ? `${tr('当前课题', 'Current topic')}：${currentProject.name}`
+            ? undefined
             : projectsLoading
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')

--- a/src/frontend/src/features/research/ResearchPage.tsx
+++ b/src/frontend/src/features/research/ResearchPage.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { SelectMenu } from '../../components/ui/SelectMenu';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
@@ -725,22 +724,8 @@ export function ResearchPage() {
       className="page fadeup page-fill"
       style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
-      <PageHead
-        eyebrow="Polaris · Related Work"
-        title={tr('相关研究', 'Related Work')}
-        dense
-        right={
-          tab === 'list' ? (
-            <button className="btn btn-primary sm" onClick={() => setAddOpen(true)}>
-              <Icon name="plus" size={13} />
-              {tr('添加文献', 'Add paper')}
-            </button>
-          ) : undefined
-        }
-      />
-
-      {/* —— 页面级 tab：书架列表 / 相关研究对话 —— */}
-      <div className="row" style={{ marginBottom: 14 }}>
+      {/* —— 页面级 tab：书架列表 / 相关研究对话；操作并在同一行右侧 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
         <Segmented<PageTab>
           options={[
             { v: 'list', label: tr('相关研究', 'Related work') },
@@ -749,6 +734,16 @@ export function ResearchPage() {
           value={tab}
           onChange={setTab}
         />
+        {tab === 'list' && (
+          <button
+            className="btn btn-primary sm"
+            style={{ marginLeft: 'auto' }}
+            onClick={() => setAddOpen(true)}
+          >
+            <Icon name="plus" size={13} />
+            {tr('添加文献', 'Add paper')}
+          </button>
+        )}
       </div>
 
       {/* —— 卡片容器（列表用双栏；对话直接铺满） —— */}

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -600,21 +600,6 @@ export function ReviewPage() {
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')
         }
-        right={
-          <button className="btn btn-primary" disabled={!pid || !!runningVoyage} onClick={() => setModalOpen(true)}>
-            {runningVoyage ? (
-              <>
-                <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
-                {tr('运行中…', 'Running…')}
-              </>
-            ) : (
-              <>
-                <Icon name="play" size={14} />
-                {tr('运行锦标赛', 'Run tournament')}
-              </>
-            )}
-          </button>
-        }
       />
 
       {runningVoyage && (
@@ -639,7 +624,7 @@ export function ReviewPage() {
         </div>
       )}
 
-      <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
+      <div className="row page-tabs" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<ReviewTab>
           options={[
             { v: 'leaderboard', label: `${tr('排行榜', 'Leaderboard')}${rows.length ? ` · ${rows.length}` : ''}` },
@@ -648,6 +633,19 @@ export function ReviewPage() {
           value={tab}
           onChange={setTab}
         />
+          <button className="btn btn-primary" disabled={!pid || !!runningVoyage} onClick={() => setModalOpen(true)}>
+            {runningVoyage ? (
+              <>
+                <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                {tr('运行中…', 'Running…')}
+              </>
+            ) : (
+              <>
+                <Icon name="play" size={14} />
+                {tr('运行锦标赛', 'Run tournament')}
+              </>
+            )}
+          </button>
       </div>
 
       <div className="card" style={{ overflow: 'hidden', minHeight: 320 }}>

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -595,7 +595,7 @@ export function ReviewPage() {
         title={tr('想法评审', 'Idea Review')}
         sub={
           currentProject
-            ? `${tr('当前课题', 'Current topic')}：${currentProject.name}`
+            ? undefined
             : projectsLoading
               ? tr('加载课题…', 'Loading topics…')
               : tr('选择一个课题', 'Pick a topic')

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -633,15 +633,15 @@ export function ReviewPage() {
           value={tab}
           onChange={setTab}
         />
-          <button className="btn btn-primary" disabled={!pid || !!runningVoyage} onClick={() => setModalOpen(true)}>
+          <button className="btn btn-primary sm" disabled={!pid || !!runningVoyage} onClick={() => setModalOpen(true)}>
             {runningVoyage ? (
               <>
-                <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
                 {tr('运行中…', 'Running…')}
               </>
             ) : (
               <>
-                <Icon name="play" size={14} />
+                <Icon name="play" size={13} />
                 {tr('运行锦标赛', 'Run tournament')}
               </>
             )}

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -944,7 +944,7 @@ export function SkillsPage() {
       <PageHead
         eyebrow="Polaris"
         title={tr('技能', 'Skills')}
-        sub={tr('为各环节 AI 定制判断标准、评审人设与流程模板', 'Custom criteria, reviewer personas and workflow templates for each stage')}
+        sub={tr('给各环节 AI 定制判断标准与流程模板', 'Custom criteria and workflow templates for each AI stage')}
         right={
           <>
             <Segmented

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -2,7 +2,6 @@ import { useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { Modal } from '../../components/ui/Modal';
@@ -941,11 +940,8 @@ export function SkillsPage() {
 
   return (
     <div className="page fadeup">
-      <PageHead
-        eyebrow="Polaris"
-        title={tr('技能', 'Skills')}
-        sub={tr('给各环节 AI 定制判断标准与流程模板', 'Custom criteria and workflow templates for each AI stage')}
-        right={
+      {/* —— 顶部一行：技能库 / 技能市场靠左，导入与新建靠右 —— */}
+      <div className="row page-tabs skills-top" style={{ marginBottom: 14 }}>
           <>
             <Segmented
               options={[
@@ -976,8 +972,7 @@ export function SkillsPage() {
               </>
             )}
           </>
-        }
-      />
+      </div>
 
       {view === 'market' && <MarketView />}
 

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -941,37 +941,36 @@ export function SkillsPage() {
   return (
     <div className="page fadeup">
       {/* —— 顶部一行：技能库 / 技能市场靠左，导入与新建靠右 —— */}
-      <div className="row page-tabs skills-top" style={{ marginBottom: 14 }}>
-          <>
-            <Segmented
-              options={[
-                { v: 'library', label: tr('技能库', 'Library') },
-                { v: 'market', label: tr('技能市场', 'Market') },
-              ]}
-              value={view}
-              onChange={setView}
+      {/* —— 顶部一行：技能库 / 技能市场靠左，导入与新建靠右 —— */}
+      <div className="row page-tabs" style={{ marginBottom: 14 }}>
+        <Segmented
+          options={[
+            { v: 'library', label: tr('技能库', 'Library') },
+            { v: 'market', label: tr('技能市场', 'Market') },
+          ]}
+          value={view}
+          onChange={setView}
+        />
+        {view === 'library' && (
+          <div className="row gap8" style={{ marginLeft: 'auto' }}>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".json,application/json"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                void onImportFile(e.target.files?.[0]);
+                e.target.value = '';
+              }}
             />
-            {view === 'library' && (
-              <>
-                <input
-                  ref={importInputRef}
-                  type="file"
-                  accept=".json,application/json"
-                  style={{ display: 'none' }}
-                  onChange={(e) => {
-                    void onImportFile(e.target.files?.[0]);
-                    e.target.value = '';
-                  }}
-                />
-                <button className="btn btn-soft" disabled={importMutation.isPending} onClick={() => importInputRef.current?.click()}>
-                  {tr('导入', 'Import')}
-                </button>
-                <button className="btn btn-primary" onClick={() => setCreateOpen(true)}>
-                  <Icon name="plus" size={14} /> {tr('新建技能', 'New skill')}
-                </button>
-              </>
-            )}
-          </>
+            <button className="btn btn-soft" disabled={importMutation.isPending} onClick={() => importInputRef.current?.click()}>
+              {tr('导入', 'Import')}
+            </button>
+            <button className="btn btn-primary" onClick={() => setCreateOpen(true)}>
+              <Icon name="plus" size={14} /> {tr('新建技能', 'New skill')}
+            </button>
+          </div>
+        )}
       </div>
 
       {view === 'market' && <MarketView />}

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -963,11 +963,11 @@ export function SkillsPage() {
                 e.target.value = '';
               }}
             />
-            <button className="btn btn-soft" disabled={importMutation.isPending} onClick={() => importInputRef.current?.click()}>
+            <button className="btn btn-soft sm" disabled={importMutation.isPending} onClick={() => importInputRef.current?.click()}>
               {tr('导入', 'Import')}
             </button>
-            <button className="btn btn-primary" onClick={() => setCreateOpen(true)}>
-              <Icon name="plus" size={14} /> {tr('新建技能', 'New skill')}
+            <button className="btn btn-primary sm" onClick={() => setCreateOpen(true)}>
+              <Icon name="plus" size={13} /> {tr('新建技能', 'New skill')}
             </button>
           </div>
         )}

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -326,7 +326,6 @@ export function VoyagesPage() {
       <PageHead
         eyebrow="Polaris · Voyages"
         title={tr('任务', 'Tasks')}
-        sub={tr('需要人工审批时任务会自动暂停，审批通过后继续执行。', 'Tasks pause automatically when they need approval, then resume once approved.')}
       />
       <VoyagesList showScopeSwitch />
     </div>

--- a/src/frontend/src/features/writer/WriterPage.tsx
+++ b/src/frontend/src/features/writer/WriterPage.tsx
@@ -405,10 +405,12 @@ export function WriterPage() {
               : tr('选择一个课题', 'Pick a topic')
         }
         right={
-          <button className="btn btn-primary" disabled={!pid} onClick={() => setModalOpen(true)}>
-            <Icon name="plus" size={14} />
-            {tr('新建论文草稿', 'New manuscript')}
-          </button>
+          pid ? undefined : (
+            <button className="btn btn-primary" disabled onClick={() => setModalOpen(true)}>
+              <Icon name="plus" size={14} />
+              {tr('新建论文草稿', 'New manuscript')}
+            </button>
+          )
         }
       />
 
@@ -422,6 +424,10 @@ export function WriterPage() {
               { v: 'trash', label: `${tr('回收站', 'Trash')}${trashCount > 0 ? ` (${trashCount})` : ''}` },
             ]}
           />
+          <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} onClick={() => setModalOpen(true)}>
+            <Icon name="plus" size={13} />
+            {tr('新建论文草稿', 'New manuscript')}
+          </button>
           <button
             className={`btn sm ${multiSelect ? 'btn-primary' : 'btn-soft'}`}
             onClick={toggleMultiSelect}

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -286,6 +286,10 @@ input {
 .h-title { font-size: 26px; font-weight: 680; letter-spacing: -0.02em; margin: 6px 0 0; line-height: 1.15; }
 .h-sub { font-size: 14px; color: var(--text-2); margin: 8px 0 0; max-width: 720px; line-height: 1.55; }
 .h-sub .en { color: var(--text-3); font-size: 13px; }
+/* 标签行：标签在左、操作靠右（marginLeft:auto）。窄屏允许换行，
+   否则标签组和按钮同排会把两边都挤扁。 */
+.page-tabs { flex-wrap: wrap; gap: 10px; align-items: center; }
+
 /* 页头右侧操作区（原为组件内联样式，挪到这里以便窄屏覆盖） */
 .page-head-actions { flex-shrink: 0; margin-left: 16px; }
 

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -289,10 +289,6 @@ input {
 /* 标签行：标签在左、操作靠右（marginLeft:auto）。窄屏允许换行，
    否则标签组和按钮同排会把两边都挤扁。 */
 .page-tabs { flex-wrap: wrap; gap: 10px; align-items: center; }
-/* 技能页顶部行：标签靠左，其余（导入 / 新建）自动推到右侧。
-   这一行的内容来自同一个片段，没有独立容器可以挂 margin-left。 */
-.skills-top > :not(:first-child) { margin-left: 0; }
-.skills-top > :nth-child(2) { margin-left: auto; }
 
 /* 页头右侧操作区（原为组件内联样式，挪到这里以便窄屏覆盖） */
 .page-head-actions { flex-shrink: 0; margin-left: 16px; }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -289,6 +289,10 @@ input {
 /* 标签行：标签在左、操作靠右（marginLeft:auto）。窄屏允许换行，
    否则标签组和按钮同排会把两边都挤扁。 */
 .page-tabs { flex-wrap: wrap; gap: 10px; align-items: center; }
+/* 技能页顶部行：标签靠左，其余（导入 / 新建）自动推到右侧。
+   这一行的内容来自同一个片段，没有独立容器可以挂 margin-left。 */
+.skills-top > :not(:first-child) { margin-left: 0; }
+.skills-top > :nth-child(2) { margin-left: auto; }
 
 /* 页头右侧操作区（原为组件内联样式，挪到这里以便窄屏覆盖） */
 .page-head-actions { flex-shrink: 0; margin-left: 16px; }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -274,7 +274,7 @@ input {
 }
 
 .content { flex: 1; overflow-y: auto; }
-.page { max-width: 1180px; margin: 0 auto; padding: 30px 36px 80px; }
+.page { max-width: 1180px; margin: 0 auto; padding: 20px 36px 80px; }
 
 /* ============================================================
    Typography & primitives


### PR DESCRIPTION
Every page opened with two lines that said what the navigation already says: a breadcrumb ("Polaris · My Library", "Stage 04 · Paper Writer") and a title repeating the sidebar's selected item. Both are gone, and the actions that lived beside them move into each page's tab row.

`PageHead` now renders **nothing** when it has neither a subtitle nor actions — an empty div would leave a stripe of whitespace at the top. The `eyebrow` and `title` props stay so the call sites don't all need editing.

## Actions folded into the tab row

| Page | What moved |
|---|---|
| My library, related work | Add paper |
| Libraries | New library (into the filter row) |
| Daily papers | Subscribed-category chips |
| Experiment, writer | New experiment / new manuscript |
| Idea review | Run tournament |
| Idea forge | **Tabs lifted up** from the candidate-pool section to sit beside Run / Deep Dive |
| Skills | Tabs left-aligned, import and new-skill pushed right |

**Paper review had four stacked sections and no way to move between them** — summary, per-reviewer opinions, citation checks, fact checklist, discussion. Now two tabs: **opinions** (summary, reviewers, discussion) and **checks** (citations, checklist), with start-review on the same row.

Experiment and writer keep their button in the head when no topic is picked, since their tab row only exists once there is one.

## Sizes

Buttons that moved out of the head were full-size — right for a tall head, too tall next to tabs. They're now the small size the other pages' actions already used, with icons matched.

## Space reclaimed

Roughly 39px off the top of every page: the breadcrumb line and its gap, a smaller gap under the head, and 10px off the page's top padding, which had been sized for a taller head.

## Also

- The "current topic: x" subtitle in idea review and paper review, which the earlier pass missed.
- The tasks page's explanation of when a task pauses.
- The redundant "Library · " prefix on a library's title.
- The skills page's subtitle.
- The sidebar's "Workbench" under a topic is now "Topic Workbench", matching the page's own title and pairing with "Lab Workbench".

The skills page's first attempt at right-aligning used a CSS positional selector, which picked the hidden file input — React fragments produce no DOM node, so the buttons were siblings of the tabs. Replaced with a real container.

## Kept

`h-eyebrow` still styles back links on detail pages and section labels. The remaining `PageHead` subtitles are all "pick a topic" / "loading topics" prompts, plus a library's own description.

## Verification

`tsc --noEmit` 0 errors, `npm run build` passes, reviewed in local preview.