### PR TITLE
ci(desktop): generate release changelogs, and document the non-obvious steps

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,12 +1,15 @@
-# 桌面端的 PR 回归检查（不发版）：在 Linux 上真实加载一遍 SPA。
-# 与 desktop-release.yml 分工：那个负责 tag 发版出包，本文件只在 PR 上把关。
+# Regression check for the desktop client (no packaging): loads the SPA under the
+# custom app:// scheme and fails on CSP violations, console errors or a renderer
+# that does not mount. Counterpart to desktop-release.yml, which packages and
+# publishes on a tag.
 #
-# 为什么值得跑：桌面端和网页端是同一份前端代码，但桌面端多了 CSP、自定义
-# app:// 协议、preload 注入这几层约束。网页端改动（引入 CDN 字体/外链脚本/
-# 新 Worker/新 WebSocket 端点）在浏览器里完全正常，却会被桌面端的 CSP 拦掉。
-# smoke 会真的把页面加载起来并检查 CSP 违规与 console 报错，正好探这类问题。
+# The web app and the desktop client share a single frontend codebase, but the
+# client adds a Content Security Policy, a custom protocol and preload injection.
+# A CDN font, an external script, a new worker or a new WebSocket endpoint all
+# work in a browser and are blocked in the packaged app, so a frontend-only change
+# can break the client. The path filter therefore covers both trees.
 #
-# Linux 上 Electron 需要虚拟显示，所以走 xvfb-run。
+# Electron requires a display on Linux, so the smoke test runs under xvfb.
 name: desktop-build
 
 on:
@@ -32,8 +35,8 @@ jobs:
             src/frontend/package-lock.json
             src/desktop/package-lock.json
 
-      # Electron 在 Linux 上的运行时依赖（headless 也需要）
-      - name: Install system deps
+      # Shared libraries Electron links against, plus xvfb for the virtual display.
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb libnss3 libgtk-3-0 libasound2t64 || \
@@ -52,16 +55,17 @@ jobs:
       - name: Typecheck shell
         run: npm run lint --prefix src/desktop
 
-      # Electron 的 chrome-sandbox 必须是 setuid root，npm 装出来的不是，直接跑会
-      # FATAL 中止。这里修权限而不是加 --no-sandbox：沙箱该开着（docs/desktop.md
-      # 里对用户也是这么说的，CI 不该自己开例外）。
+      # Electron aborts at startup unless the SUID sandbox helper is owned by root
+      # with mode 4755, which is not how npm installs it. The permissions are
+      # corrected rather than passing --no-sandbox, because docs/desktop.md tells
+      # users not to disable the sandbox and CI should not exempt itself.
       - name: Fix chrome-sandbox permissions
         run: |
           sudo chown root:root src/desktop/node_modules/electron/dist/chrome-sandbox
           sudo chmod 4755 src/desktop/node_modules/electron/dist/chrome-sandbox
 
-      # 真实加载 app://polaris 下的 SPA：协议路由、SPA fallback、CSP、preload
-      # 注入、React 挂载、本地 agent 管道，退出码非 0 即失败
-      - name: Smoke
+      # Covers protocol routing, SPA fallback, CSP contents, preload injection,
+      # renderer mount and the local agent pipe. A non-zero exit fails the job.
+      - name: Smoke test
         working-directory: src/desktop
         run: xvfb-run -a npm run smoke

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,17 +1,28 @@
-# 桌面端发版：三平台出包并建 GitHub Release。
-# 与 desktop-build.yml 分工：那个在 PR 上只跑 smoke 做回归检查，本文件负责发版。
+# Packages the desktop client for all three platforms and publishes a GitHub
+# release. Counterpart to desktop-build.yml, which only runs the smoke test on
+# pull requests.
 #
-# 触发：push 版本 tag（v*，如 v1.0.0）时自动发版，tag 名即版本号；也可手动触发。
+# Triggered by pushing a version tag (v*, e.g. v1.0.0); the tag name is the
+# version. Manual dispatch is also supported and always produces a draft, since a
+# manual run is either a check that packaging still works or an ad-hoc build, and
+# neither should appear as a public release without review.
 #
-# 关于签名：**产物一律未签名**。macOS 侧由 electron-builder 的 afterPack 钩子补一个
-# ad-hoc 签名——不是锦上添花：electron-builder 改包会让 Electron 自带签名失效，
-# Apple Silicon 内核拒绝执行无有效签名的二进制，用户会看到「已损坏」。ad-hoc 只保证
-# 能启动，不等于公证（notarization），首次打开仍需绕 Gatekeeper，见 release 正文。
+# Signing: artifacts are unsigned. On macOS an electron-builder afterPack hook
+# applies an ad-hoc signature. This is not optional — repackaging invalidates the
+# signature the prebuilt Electron binary ships with, and the Apple Silicon kernel
+# refuses to execute a binary without a valid one, so users would see "damaged".
+# An ad-hoc signature only makes the bundle launchable; it is not notarization,
+# and first launch still requires clearing Gatekeeper as described in the notes.
 #
-# macOS 出 universal 单包（Intel + Apple Silicon 通吃），用户不必分辨自己的芯片。
-# 注意 @electron/universal 要求两个架构的非二进制文件逐字节相同才能 lipo 合并，
-# 所以 afterPack 钩子跳过 *-temp 目录、只给合并后的产物签名——逐架构签名会让
-# _CodeSignature/CodeResources 不一致，合并会直接报错。
+# Release notes are the fixed install and first-run guidance in this file followed
+# by a changelog GitHub generates from the pull requests merged since the previous
+# release. Nothing per-version is maintained by hand.
+#
+# macOS ships a single universal build so users need not identify their chip.
+# @electron/universal requires every non-binary file to be byte-identical across
+# the two architectures before it will merge them, so the afterPack hook skips the
+# *-temp directories and signs only the merged bundle; signing each architecture
+# separately leaves _CodeSignature/CodeResources differing and the merge aborts.
 name: desktop-release
 
 on:
@@ -21,11 +32,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "手动发版时的版本号（如 v0.2.0）"
+        description: "Version to build, e.g. v0.2.0"
         required: true
-
-# 手动触发一律发 draft：手动跑要么是验证三平台出包、要么是临时构建，
-# 都该先过目再公开。只有 push v* tag 才直接发布。
 
 jobs:
   build:
@@ -67,7 +75,9 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      # 让安装包文件名带上真实版本号（electron-builder 读 package.json 的 version）
+      # electron-builder takes the version from package.json, so stamp it from the
+      # tag rather than shipping installers permanently named after the checked-in
+      # version.
       - name: Stamp version
         shell: bash
         run: |
@@ -86,15 +96,17 @@ jobs:
           npm ci --prefix src/desktop
           npm run build --prefix src/desktop
 
-      # 发版前先验一遍，避免把加载不起来的包发出去（Linux 侧代表全平台的 renderer 行为）
-      - name: Smoke (linux only)
+      # Gate packaging on the smoke test so a bundle that cannot load is never
+      # published. The renderer behaves identically across platforms, so running it
+      # once on Linux is sufficient.
+      - name: Smoke test (Linux only)
         if: matrix.name == 'linux'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb libnss3 libgtk-3-0 libasound2t64 || \
           sudo apt-get install -y xvfb libnss3 libgtk-3-0 libasound2
-          # chrome-sandbox 必须 setuid root，否则 Electron FATAL 中止
+          # Electron aborts unless chrome-sandbox is setuid root; see desktop-build.yml
           sudo chown root:root src/desktop/node_modules/electron/dist/chrome-sandbox
           sudo chmod 4755 src/desktop/node_modules/electron/dist/chrome-sandbox
           cd src/desktop && xvfb-run -a npm run smoke
@@ -104,7 +116,8 @@ jobs:
         working-directory: src/desktop
         run: npx electron-builder ${{ matrix.args }} --publish never
 
-      # 只收安装包本身：release/ 下还有 *-unpacked 目录与 .blockmap，不必上传
+      # Collect installers only; release/ also holds *-unpacked directories and
+      # .blockmap files that need not be uploaded.
       - uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.name }}
@@ -179,7 +192,11 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRAFT="--draft"
           fi
+          # notes.md is prepended to the changelog GitHub derives from the pull
+          # requests merged since the previous release, so the install guidance
+          # stays fixed while the per-version content maintains itself.
           gh release create "${{ steps.meta.outputs.tag }}" $DRAFT \
             --title "Polaris ${{ steps.meta.outputs.tag }}" \
             --notes-file notes.md \
+            --generate-notes \
             dist/*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,13 +1,16 @@
-# 发布：build 并 push 镜像到 Docker Hub。
-# 与 docker-build.yml 分工：那个在 PR 上只 build 做回归检查，本文件负责发版推送。
+# Builds and pushes the image stack to Docker Hub. Counterpart to
+# docker-build.yml, which only builds on pull requests as a regression check.
 #
-# 触发：push 版本 tag（v*，如 v1.0.0）时自动发布，tag 名即镜像 tag；也可手动触发。
-# 架构：ubuntu-latest 是 x86_64，普通 docker build 出 amd64 镜像（覆盖多数服务器）。
-#       texbase 本地建好后 api/worker 直接 FROM 它，无需把 texbase 也推 registry。
+# Triggered by pushing a version tag (v*, e.g. v1.0.0); the tag name becomes the
+# image tag. Manual dispatch is also supported.
 #
-# 需要的仓库 Secrets（Settings → Secrets and variables → Actions）：
-#   DOCKERHUB_USERNAME  Docker Hub 用户名（同时用作镜像命名空间）
-#   DOCKERHUB_TOKEN     Docker Hub Personal Access Token（Read & Write）
+# Architecture: ubuntu-latest runners are x86_64, so a plain docker build produces
+# amd64 images, which covers most deployment targets. texbase is built locally and
+# consumed by the api and worker Dockerfiles via FROM, so it is never pushed.
+#
+# Required repository secrets (Settings > Secrets and variables > Actions):
+#   DOCKERHUB_USERNAME  Docker Hub account, also used as the image namespace
+#   DOCKERHUB_TOKEN     Docker Hub personal access token with read and write access
 name: docker-publish
 
 on:
@@ -17,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "手动发布时的镜像 tag（如 v1.0.0）"
+        description: "Image tag to publish, e.g. v1.0.0"
         required: true
         default: "latest"
 
@@ -42,7 +45,8 @@ jobs:
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "$NS" --password-stdin
 
-      # texbase 只进本地 daemon（不 push）；api/worker 的 Dockerfile 默认 FROM polaris-texbase:latest
+      # Stays in the local daemon; the api and worker Dockerfiles default to
+      # FROM polaris-texbase:latest.
       - name: Build texbase (base image, local only)
         run: docker build -f docker/Dockerfile.texbase -t polaris-texbase:latest docker/
 


### PR DESCRIPTION
## Release notes now carry a changelog

The notes were entirely static, so every release would have shipped identical text saying nothing about what changed.

The install and first-run guidance is genuinely invariant and stays hand-written. `--generate-notes` appends the pull requests merged since the previous release after it — `gh` supports combining the two, prepending the file contents to the generated changelog.

This suits the repository as it stands: commits follow conventional commits and pull requests are squash-merged, so the generated list reads cleanly without requiring any labelling discipline. If grouped sections are wanted later, a `.github/release.yml` can categorise entries by label on top of this.

## Headers now record why the odd steps exist

Each workflow states what it does, how it relates to its counterpart, and the reasoning behind the steps that look removable:

- ad-hoc signing is mandatory on Apple Silicon, not cosmetic — repackaging invalidates the signature Electron ships with, and the kernel then refuses to execute the binary
- `@electron/universal` requires byte-identical non-binary files across architectures, which is what decides that only the merged bundle is signed
- Electron needs `chrome-sandbox` setuid root on Linux, and CI corrects the permissions rather than disabling the sandbox
- manual dispatches publish drafts, because they are checks or ad-hoc builds rather than releases

No behavioural change beyond the changelog. All four workflows parse and their job graphs are unchanged (`desktop-build` → smoke; `desktop-release` → build, release; `docker-build` → build; `docker-publish` → publish).