### PR TITLE
fix(desktop): load PDFs in the annotating reader, and stream them by range

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -81,6 +81,7 @@ result and must not be recomputed remotely.
 |---|---|
 | `plugins: true` in `window.ts` | The manuscript PDF preview is an `<iframe src=blob:…pdf>` rendered by Chromium's built-in pdfium, not pdf.js. Electron disables plugins by default, so dropping this makes the preview blank |
 | `script-src 'wasm-unsafe-eval'` in the CSP | pdf.js ships openjpeg / qcms as WASM |
+| `blob:` in `connect-src` | The annotating reader hands pdf.js a `blob:` URL and pdf.js fetches it; `'self'` does not cover `blob:` in Chromium. Drop it and only that reader breaks — the standard reader is an `<iframe>` and goes through `frame-src` |
 | `style-src 'unsafe-inline'` in the CSP | CodeMirror's style-mod and KaTeX insert rules at runtime; without it the editor and formula rendering break |
 | `role: 'editMenu'` in `menu.ts` | Without it, Cmd+C/V/A/Z stop working in some controls on macOS |
 | Recreating the window after a server change | The preload injection and the CSP response header are both fixed at document load; `reload()` cannot refresh them |

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -66,6 +66,10 @@ def create_app() -> FastAPI:
         allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
+        # 跨源下这些响应头默认对 JS 不可见。pdf.js 靠 Accept-Ranges / Content-Range /
+        # Content-Length 判断服务端支不支持分段取，读不到就退回整包下载——桌面端
+        # （app://polaris 是跨源）的 PDF 阅读会因此又变回「等整份下完」。
+        expose_headers=["Accept-Ranges", "Content-Range", "Content-Length", "Content-Disposition"],
     )
 
     @app.exception_handler(LLMNotConfiguredError)

--- a/src/backend/tests/test_paper_reading.py
+++ b/src/backend/tests/test_paper_reading.py
@@ -87,6 +87,27 @@ async def test_get_pdf_404_then_serves_file(client):
     assert resp.content == content
 
 
+async def test_get_pdf_supports_range(client):
+    """阅读器把地址交给 pdf.js 按需取段，端点必须真的支持 Range，否则退回整包下载。"""
+    project_id, headers, paper_id = await _setup(client)
+    content = _pdf_bytes()
+    path = save_pdf(paper_id, content)
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(paper_id))
+        paper.pdf_path = str(path)
+        await session.commit()
+
+    full = await client.get(f"/api/papers/{paper_id}/pdf", headers=headers)
+    assert full.headers.get("accept-ranges") == "bytes"
+
+    resp = await client.get(
+        f"/api/papers/{paper_id}/pdf", headers={**headers, "Range": "bytes=0-99"}
+    )
+    assert resp.status_code == 206
+    assert resp.content == content[:100]
+    assert resp.headers["content-range"] == f"bytes 0-99/{len(content)}"
+
+
 @respx.mock
 async def test_fetch_pdf_success_idempotent_and_400(client, lit_clients):
     project_id, headers, paper_id = await _setup(client)

--- a/src/desktop/src/main/protocol.ts
+++ b/src/desktop/src/main/protocol.ts
@@ -58,7 +58,10 @@ function rendererRoot(): string {
  *   insertRule 注入样式，去掉编辑器和公式渲染会直接崩。
  */
 export function buildCsp(serverUrl: string): string {
-  const connect = new Set<string>(["'self'"]);
+  // blob: 必须显式列出：Chromium 里 'self' 不覆盖 blob: URL，而 pdf.js 标注阅读器
+  // 是 fetch(blob:…pdf) 取正文（走 connect-src），标准阅读器是 <iframe src=blob:>
+  // （走 frame-src）。少了这一项就只有标注阅读器打不开，且只在桌面端复现。
+  const connect = new Set<string>(["'self'", 'blob:']);
   if (serverUrl) {
     try {
       const u = new URL(serverUrl);

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -47,6 +47,7 @@ void app.whenReady().then(async () => {
   check("style-src 放行 unsafe-inline（CodeMirror/KaTeX）", csp.includes("style-src 'self' 'unsafe-inline'"));
   check('connect-src 含服务器 https 源', csp.includes(SERVER_URL));
   check('connect-src 含服务器 wss 源', csp.includes('wss://polaris.example.edu'));
+  check("connect-src 放行 blob:（pdf.js 取正文）", /connect-src [^;]*\bblob:/.test(csp));
   check("worker-src 放行 blob:（pdf.js worker）", csp.includes("worker-src 'self' blob:"));
   check("frame-src 放行 blob:（写作页 PDF 预览）", csp.includes('frame-src blob:'));
 

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -17,9 +17,11 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { tr } from '../../lib/i18n';
+import { apiBase } from '../../lib/endpoint';
 import {
   api,
   ApiError,
+  getToken,
   type HighlightColor,
   type HighlightCreateInput,
   type HighlightRead,
@@ -46,10 +48,15 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 // 模块级常量，避免每次 render 生成新对象触发 react-pdf 重新加载。
 // cMap / 标准字体数据必须提供，否则 pdf.js 画不出字形、整页空白（资源由 vite
 // copyPdfAssets 插件从 pdfjs-dist 拷到 public/pdfjs 下，见 vite.config.ts）。
+// disableAutoFetch：只取当前要渲染的那几段，不在后台把整份 PDF 拉完。25MB 的论文
+// 走校外代理约 0.5MB/s，整包下载要等 45 秒才出第一页；按需取段后首屏是几百 KB。
+// 服务端不支持 Range 时 pdf.js 自动退回整包下载，行为与改造前一致。
 const PDF_OPTIONS = {
   cMapUrl: '/pdfjs/cmaps/',
   cMapPacked: true,
   standardFontDataUrl: '/pdfjs/standard_fonts/',
+  disableAutoFetch: true,
+  rangeChunkSize: 262144,
 };
 
 export interface JumpTarget {
@@ -206,9 +213,23 @@ export function PdfReader({
     if (dy !== 0) el.style.top = `${parseFloat(el.style.top || '0') + dy}px`;
   }, [pending]);
 
+  // 标注阅读器把地址直接交给 pdf.js，由它按需发 Range 请求；鉴权头随请求带上，
+  // 所以这里不能用 blob。对象要 memo：react-pdf 认引用，每次新对象都会重新加载整份。
+  const pdfSource = useMemo(() => {
+    const src: { url: string; httpHeaders?: Record<string, string> } = {
+      url: `${apiBase()}/papers/${paper.id}/pdf`,
+    };
+    const token = getToken();
+    if (token) src.httpHeaders = { Authorization: `Bearer ${token}` };
+    return src;
+  }, [paper.id]);
+
+  // 标准阅读器是 <iframe>，带不了 Authorization 头，只能整包下成 blob——所以推迟到
+  // 真的切过去才下，默认的标注模式不再为它付这 25MB 的等待。
   const pdfQuery = useQuery({
     queryKey: ['paper-pdf', paper.id],
     queryFn: () => api.fetchPaperPdf(paper.id),
+    enabled: mode === 'standard' && paper.pdf_available,
     retry: false,
     staleTime: Infinity,
   });
@@ -236,7 +257,7 @@ export function PdfReader({
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [url, mode]); // 从标准模式切回时容器重新挂载，需重新测量并观察
+  }, [mode]); // 从标准模式切回时容器重新挂载，需重新测量并观察
 
   // 触控板双指捏合 / Ctrl(⌘)+滚轮 缩放：浏览器默认会整页缩放，这里拦下来只缩放 PDF。
   // 捏合手势在浏览器里表现为 ctrlKey=true 的 wheel 事件；必须用 passive:false 才能 preventDefault。
@@ -259,7 +280,7 @@ export function PdfReader({
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
-  }, [url, mode]);
+  }, [mode]);
 
   const fetchPdfMutation = useMutation({
     mutationFn: () => api.requestPaperPdf(paper.id),
@@ -393,22 +414,9 @@ export function PdfReader({
     [],
   );
 
-  if (pdfQuery.isLoading) {
-    return (
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ textAlign: 'center' }}>
-          <div
-            className="pulse"
-            style={{ width: 220, height: 300, margin: '0 auto 16px', borderRadius: 10, background: 'var(--surface-3)' }}
-          />
-          <div className="muted" style={{ fontSize: 12.5 }}>正在加载 PDF…</div>
-        </div>
-      </div>
-    );
-  }
-
-  // 无 PDF：引导获取（沿用原逻辑）
-  if (pdfQuery.isError || !url) {
+  // 无 PDF：引导获取（原先靠「先整包下一遍，404 就是没有」判断，现在直接读元数据，
+  // 免掉一次无谓的整包下载）
+  if (!paper.pdf_available) {
     const canFetch = !!paper.arxiv_id;
     return (
       <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -509,12 +517,32 @@ export function PdfReader({
       </div>
 
       {mode === 'standard' ? (
-        // 浏览器内置 PDF 阅读器：自带缩放/搜索/打印，但不承载我们的标注层
-        <iframe
-          title={paper.title}
-          src={url}
-          style={{ flex: 1, minHeight: 0, width: '100%', border: 'none', background: '#525659' }}
-        />
+        // 浏览器内置 PDF 阅读器：自带缩放/搜索/打印，但不承载我们的标注层。
+        // 它只认能直接取到的地址，带不了鉴权头，所以这里必须等整包下完拿到 blob。
+        url ? (
+          <iframe
+            title={paper.title}
+            src={url}
+            style={{ flex: 1, minHeight: 0, width: '100%', border: 'none', background: '#525659' }}
+          />
+        ) : (
+          <div
+            style={{
+              flex: 1,
+              minHeight: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: '#525659',
+              color: pdfQuery.isError ? '#fca5a5' : '#cbd5e1',
+              fontSize: 12.5,
+            }}
+          >
+            {pdfQuery.isError
+              ? tr('PDF 加载失败，可以换回标注阅读器', 'Failed to load — try the annotating reader')
+              : tr('正在下载完整 PDF…', 'Downloading the full PDF…')}
+          </div>
+        )
       ) : (
     <div
       ref={scrollRef}
@@ -524,7 +552,7 @@ export function PdfReader({
       style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: '#525659', padding: '14px 0' }}
     >
       <Document
-        file={url}
+        file={pdfSource}
         options={PDF_OPTIONS}
         onLoadSuccess={({ numPages: n }) => setNumPages(n)}
         loading={
@@ -533,8 +561,9 @@ export function PdfReader({
           </div>
         }
         error={
+          // 任何加载失败都会走到这里（文件损坏、网络中断、被拦截），别把话说死成「损坏」
           <div className="muted" style={{ textAlign: 'center', padding: 40, color: '#fca5a5' }}>
-            PDF 打不开，文件可能损坏。
+            {tr('PDF 加载失败，请稍后重试。', 'Could not load this PDF — try again later.')}
           </div>
         }
       >

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -196,6 +196,7 @@ export function PdfReader({
   const [scale, setScale] = useState(1); // 缩放倍率（1 = 适应宽度）
   const [mode, setMode] = useState<ReaderMode>('annotate'); // 标注阅读器 / 标准浏览器
   const [url, setUrl] = useState<string | null>(null);
+  const [loadPct, setLoadPct] = useState<number | null>(null); // 整包下载时的进度，null = 还没有进度事件
   const [pending, setPending] = useState<Pending | null>(null);
   const [pendingStyle, setPendingStyle] = useState<HighlightStyle>('highlight');
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -555,9 +556,15 @@ export function PdfReader({
         file={pdfSource}
         options={PDF_OPTIONS}
         onLoadSuccess={({ numPages: n }) => setNumPages(n)}
+        onLoadProgress={({ loaded, total }) =>
+          setLoadPct(total > 0 ? Math.min(99, Math.floor((loaded / total) * 100)) : null)
+        }
         loading={
+          // 网络慢时整份 PDF 可能要几分钟，不报进度的话跟卡死没有区别
           <div className="muted" style={{ textAlign: 'center', padding: 40, color: '#cbd5e1' }}>
-            正在解析 PDF…
+            {loadPct == null
+              ? tr('正在解析 PDF…', 'Loading the PDF…')
+              : tr(`正在加载 PDF… ${loadPct}%`, `Loading the PDF… ${loadPct}%`)}
           </div>
         }
         error={


### PR DESCRIPTION
Closes #166.

Two fixes to the same reader, one on top of the other.

## 1. Desktop: the annotating reader could not load any PDF

It hands pdf.js a `blob:` URL and pdf.js fetches it, so the load is checked against **connect-src** — and `'self'` does not cover `blob:` in Chromium. The fetch was refused and react-pdf fell back to its generic `error` prop, which read "文件可能损坏" for any failure at all. The standard reader was unaffected because `<iframe src=blob:>` is checked against `frame-src`, which already allowed `blob:`.

`buildCsp` now seeds `connect-src` with `blob:`; the smoke suite asserts it next to the existing worker-src / frame-src checks, and `docs/desktop.md` gains a row in "Settings that look removable and are not".

**Verified on a locally packaged macOS arm64 build against the deployed server:** the paper that previously failed now renders.

## 2. Reading a large PDF blocked on a full download

The reader downloaded the whole file into a blob before rendering anything. A 25MB paper over a link that measures ~0.55MB/s showed nothing for ~45 seconds. The backend was never the bottleneck — the same file serves in 0.087s on the server itself.

- the annotating reader now passes the URL plus the auth header to pdf.js, which fetches only the ranges it needs; `disableAutoFetch` stops it from pulling the remainder in the background
- the standard reader is an `<iframe>` and cannot carry an `Authorization` header, so it still needs the blob — that download is now deferred until the user switches to that mode, and shows its own progress text
- PDF existence now reads `paper.pdf_available` instead of being inferred from a speculative full download that 404s
- CORS exposes `Accept-Ranges` / `Content-Range` / `Content-Length`; they are invisible to cross-origin JS by default, and without them pdf.js cannot detect range support and would keep downloading whole files on desktop
- the error copy no longer asserts the file is corrupted — that wording sent this investigation down the wrong path twice

If a server does not support ranges, pdf.js falls back to a full download, so the behaviour degrades to exactly what it was before.

## Checks

- `test_get_pdf_supports_range` (new): asserts 206, the exact byte slice, `Content-Range`, and `Accept-Ranges: bytes`
- `tests/test_paper_reading.py` — 6 passed
- `ruff check` clean on both touched backend files (3 pre-existing findings elsewhere in `tests/` are untouched)
- frontend `tsc --noEmit` + `vite build` pass
- desktop smoke suite passes in full

Range streaming itself is not yet verified end-to-end in a browser — only the endpoint behaviour and the build are.