### PR TITLE
perf(reading): stop pdf.js from streaming the rest of the file

### DIFF
--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -48,14 +48,17 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 // 模块级常量，避免每次 render 生成新对象触发 react-pdf 重新加载。
 // cMap / 标准字体数据必须提供，否则 pdf.js 画不出字形、整页空白（资源由 vite
 // copyPdfAssets 插件从 pdfjs-dist 拷到 public/pdfjs 下，见 vite.config.ts）。
-// disableAutoFetch：只取当前要渲染的那几段，不在后台把整份 PDF 拉完。25MB 的论文
-// 走校外代理约 0.5MB/s，整包下载要等 45 秒才出第一页；按需取段后首屏是几百 KB。
+// 只取当前要渲染的那几段，不在后台把整份 PDF 拉完。25MB 的论文走校外代理约
+// 0.5MB/s，整包下载要等 45 秒才出第一页；按需取段后首屏是几百 KB。
+// 两个开关必须成对：disableAutoFetch 只是不主动补取缺失分段，disableStream 若不关，
+// pdf.js 仍会顺着整份文件流式读到底——实测同样渲染 3 页，关掉后传输量 8.70MB → 3.76MB。
 // 服务端不支持 Range 时 pdf.js 自动退回整包下载，行为与改造前一致。
 const PDF_OPTIONS = {
   cMapUrl: '/pdfjs/cmaps/',
   cMapPacked: true,
   standardFontDataUrl: '/pdfjs/standard_fonts/',
   disableAutoFetch: true,
+  disableStream: true,
   rangeChunkSize: 262144,
 };
 


### PR DESCRIPTION
Follow-up to #167 / #169: the reader was still pulling the whole PDF.

`disableAutoFetch` only stops pdf.js from proactively refetching *missing chunks*. `disableStream` was left at its default, so pdf.js kept reading the full file sequentially from its initial request — the access log shows complete `200` responses for the entire file sitting alongside the `206` range reads, and a probe of the live app recorded 16.27MB fetched for a 12MB paper.

The two switches have to be set together.

## Measured

13MB PDF served at 400KB/s, same three pages rendered, through a real Electron window:

| | transferred |
|---|---|
| `disableStream` default | 8.70MB |
| `disableStream: true` | **3.76MB** |

Server-side counters were taken on bytes actually written, so cancelled transfers do not inflate them.

## Checks

- frontend `tsc --noEmit` + `vite build` pass
- not yet verified against the deployed server — that needs this on main and rolled out; the plan is to re-run the same live probe afterwards and confirm no complete 200 response remains