### PR TITLE
feat(desktop): immersive title bar on Windows

### DIFF
--- a/src/desktop/src/main/menu.ts
+++ b/src/desktop/src/main/menu.ts
@@ -18,6 +18,14 @@ function openServerSetup(): void {
 export function installMenu(): void {
   const isMac = process.platform === 'darwin';
 
+  // 非 macOS：整条菜单栏都去掉。Windows/Linux 的菜单是画在窗口内部的，留着就
+  // 破坏沉浸式外观，而 macOS 的菜单在系统栏、且不注册会让 Cmd+C/V 失效，必须保留。
+  // 非 macOS 丢掉的快捷键由 window.ts 的 installKeyboardShortcuts 补回。
+  if (!isMac) {
+    Menu.setApplicationMenu(null);
+    return;
+  }
+
   const serverItem: MenuItemConstructorOptions = {
     label: 'Server…',
     accelerator: 'CmdOrCtrl+,',

--- a/src/desktop/src/main/window.ts
+++ b/src/desktop/src/main/window.ts
@@ -97,14 +97,16 @@ export function createWindow(): BrowserWindow {
     // 把交通灯钉在这条 40px 留白带的垂直中心（(40-12)/2 = 14），不同 macOS 版本
     // 的默认内缩量不一样，钉死才能和 global.css 的 --titlebar-h 对得上。
     ...(isMac ? { trafficLightPosition: { x: 18, y: 14 } } : {}),
-    // Windows 的最小化/最大化/关闭画在右上角。高度与 --titlebar-h 的 40 窗口点
-    // 对齐，配色取自 tokens.css（--app-bg / --text-2），否则按钮区会是一块白底。
+    // Windows 的最小化/最大化/关闭画在右上角，与顶栏同一行（顶栏右端由 CSS 的
+    // --winctl-w 留出等宽空位）。配色取自 tokens.css，否则按钮区会是一块白底。
     ...(isWin
       ? {
           titleBarOverlay: {
             color: '#f7f9fc',
             symbolColor: '#59637a',
-            height: 40,
+            // 与顶栏等高，按钮才会和铃铛排在同一行：顶栏是 52px CSS，
+            // 经 html{zoom:1.1} 渲染成约 57 个窗口点。
+            height: 57,
           },
         }
       : {}),

--- a/src/desktop/src/main/window.ts
+++ b/src/desktop/src/main/window.ts
@@ -45,6 +45,36 @@ function persistBounds(win: BrowserWindow): void {
   writeConfig({ window: { x: b.x, y: b.y, width: b.width, height: b.height, maximized } });
 }
 
+const isMac = process.platform === 'darwin';
+const isWin = process.platform === 'win32';
+
+/**
+ * 非 macOS 去掉了菜单栏（见 menu.ts），随之丢掉的是菜单绑定的快捷键。
+ * 剪贴板类（Ctrl+C/V/X/A/Z）由 Chromium 在渲染层直接处理，不受影响；
+ * 这里只补回重载、开发者工具与缩放这几个挂在菜单上的。
+ */
+function installKeyboardShortcuts(win: BrowserWindow): void {
+  if (isMac) return;
+  win.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return;
+    const ctrl = input.control || input.meta;
+    const key = input.key.toLowerCase();
+    const fire = (fn: () => void) => {
+      fn();
+      event.preventDefault();
+    };
+    if (key === 'f5' || (ctrl && key === 'r')) return fire(() => win.webContents.reload());
+    if (key === 'f12' || (ctrl && input.shift && key === 'i')) {
+      return fire(() => win.webContents.toggleDevTools());
+    }
+    if (!ctrl) return;
+    const zoom = win.webContents.getZoomLevel();
+    if (key === '=' || key === '+') return fire(() => win.webContents.setZoomLevel(zoom + 0.5));
+    if (key === '-') return fire(() => win.webContents.setZoomLevel(zoom - 0.5));
+    if (key === '0') return fire(() => win.webContents.setZoomLevel(0));
+  });
+}
+
 export function createWindow(): BrowserWindow {
   const config = readConfig();
   const win = new BrowserWindow({
@@ -53,10 +83,24 @@ export function createWindow(): BrowserWindow {
     minHeight: 600,
     show: false,
     backgroundColor: '#ffffff',
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    // 沉浸式标题栏：macOS 与 Windows 都不要系统标题栏，窗口控件以覆盖层形式
+    // 画在内容之上。Linux 的窗口管理器差异太大（有的根本不画覆盖层），保持原生
+    // 标题栏，稳妥。
+    titleBarStyle: isMac ? 'hiddenInset' : isWin ? 'hidden' : 'default',
     // 把交通灯钉在这条 40px 留白带的垂直中心（(40-12)/2 = 14），不同 macOS 版本
     // 的默认内缩量不一样，钉死才能和 global.css 的 --titlebar-h 对得上。
-    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 18, y: 14 } } : {}),
+    ...(isMac ? { trafficLightPosition: { x: 18, y: 14 } } : {}),
+    // Windows 的最小化/最大化/关闭画在右上角。高度与 --titlebar-h 的 40 窗口点
+    // 对齐，配色取自 tokens.css（--app-bg / --text-2），否则按钮区会是一块白底。
+    ...(isWin
+      ? {
+          titleBarOverlay: {
+            color: '#f7f9fc',
+            symbolColor: '#59637a',
+            height: 40,
+          },
+        }
+      : {}),
     webPreferences: {
       preload: join(__dirname, 'preload.cjs'),
       contextIsolation: true,
@@ -94,6 +138,8 @@ export function createWindow(): BrowserWindow {
   win.webContents.session.setPermissionRequestHandler((_wc, _permission, callback) => {
     callback(false);
   });
+
+  installKeyboardShortcuts(win);
 
   // 热更新装上的界面若加载不起来，退回包内自带的那份再重来一次。
   // 只挡主框架的失败；子资源 404 由协议处理器各自处理，不该整窗回滚。

--- a/src/desktop/src/main/window.ts
+++ b/src/desktop/src/main/window.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, screen, shell } from 'electron';
 import { join } from 'node:path';
 
+import { IPC_CHANNEL_EVENT } from '../shared/contract';
 import { APP_INDEX, APP_ORIGIN } from './protocol';
 import { clearStagedRenderer, stagedRendererDir } from './updates/renderer-store';
 import { readConfig, writeConfig, type WindowState } from './store';
@@ -51,7 +52,10 @@ const isWin = process.platform === 'win32';
 /**
  * 非 macOS 去掉了菜单栏（见 menu.ts），随之丢掉的是菜单绑定的快捷键。
  * 剪贴板类（Ctrl+C/V/X/A/Z）由 Chromium 在渲染层直接处理，不受影响；
- * 这里只补回重载、开发者工具与缩放这几个挂在菜单上的。
+ * 这里补回挂在菜单上的那些。
+ *
+ * Ctrl+, 尤其不能漏：它是「换服务器」的**唯一**入口（菜单里的 Server…）。
+ * 少了它，用户在 Windows 上只能靠删 %APPDATA%\polaris-desktop 才能改地址。
  */
 function installKeyboardShortcuts(win: BrowserWindow): void {
   if (isMac) return;
@@ -68,6 +72,9 @@ function installKeyboardShortcuts(win: BrowserWindow): void {
       return fire(() => win.webContents.toggleDevTools());
     }
     if (!ctrl) return;
+    if (key === ',') {
+      return fire(() => win.webContents.send(IPC_CHANNEL_EVENT, { type: 'host.openServerSetup' }));
+    }
     const zoom = win.webContents.getZoomLevel();
     if (key === '=' || key === '+') return fire(() => win.webContents.setZoomLevel(zoom + 0.5));
     if (key === '-') return fire(() => win.webContents.setZoomLevel(zoom - 0.5));

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -276,6 +276,37 @@ void app.whenReady().then(async () => {
     check('非 macOS 收起态侧栏保持原宽', railPt < 84, `rail=${railPt}pt`);
   }
 
+  // Windows 的窗口控件覆盖在右上角，页面靠 .app 的顶部留白避让。smoke 跑在
+  // macOS/Linux 上，所以这里临时把平台属性改成 win32 来验规则本身——CSS 完全由
+  // 属性驱动，与进程真实平台无关。
+  const winReserve = JSON.parse(
+    (await win.webContents.executeJavaScript(`(() => {
+      const root = document.documentElement;
+      const prev = { p: root.dataset.desktopPlatform, t: root.dataset.desktopTitlebar };
+      const host = document.createElement('div');
+      host.className = 'app';
+      host.style.cssText = 'position:fixed;left:0;top:0;width:600px;height:300px;display:flex';
+      host.innerHTML = '<div class="sidebar"></div><div style="flex:1"><div class="topbar"></div></div>';
+      document.body.appendChild(host);
+      const top = () => Math.round(host.querySelector('.topbar').getBoundingClientRect().top);
+      const drag = () => getComputedStyle(host, '::before').getPropertyValue('-webkit-app-region').trim();
+      root.dataset.desktopPlatform = 'win32';
+      root.dataset.desktopTitlebar = 'overlay';
+      const out = { topbarTop: top(), drag: drag() };
+      if (prev.p) root.dataset.desktopPlatform = prev.p; else delete root.dataset.desktopPlatform;
+      if (prev.t) root.dataset.desktopTitlebar = prev.t; else delete root.dataset.desktopTitlebar;
+      host.remove();
+      return JSON.stringify(out);
+    })()`)) as string,
+  ) as { topbarTop: number; drag: string };
+
+  check(
+    'Windows 顶栏避开窗口控件覆盖层',
+    winReserve.topbarTop >= 36,
+    `topbarTop=${winReserve.topbarTop}px`,
+  );
+  check('Windows 顶部留白可拖窗口', winReserve.drag === 'drag', `app-region=${winReserve.drag}`);
+
   const secure = (await win.webContents.executeJavaScript('window.isSecureContext')) as boolean;
   check('secure context（clipboard / Notification 可用）', secure === true);
 

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -276,36 +276,53 @@ void app.whenReady().then(async () => {
     check('非 macOS 收起态侧栏保持原宽', railPt < 84, `rail=${railPt}pt`);
   }
 
-  // Windows 的窗口控件覆盖在右上角，页面靠 .app 的顶部留白避让。smoke 跑在
-  // macOS/Linux 上，所以这里临时把平台属性改成 win32 来验规则本身——CSS 完全由
-  // 属性驱动，与进程真实平台无关。
+  // Windows 的窗口控件排在顶栏右端（与铃铛同一行），页面靠 --winctl-w 留出等宽
+  // 空位。smoke 跑在 macOS/Linux 上，这里临时把平台属性改成 win32 来验规则本身
+  // ——CSS 完全由属性驱动，与进程真实平台无关。
   const winReserve = JSON.parse(
     (await win.webContents.executeJavaScript(`(() => {
       const root = document.documentElement;
       const prev = { p: root.dataset.desktopPlatform, t: root.dataset.desktopTitlebar };
       const host = document.createElement('div');
-      host.className = 'app';
-      host.style.cssText = 'position:fixed;left:0;top:0;width:600px;height:300px;display:flex';
-      host.innerHTML = '<div class="sidebar"></div><div style="flex:1"><div class="topbar"></div></div>';
+      host.style.cssText = 'position:fixed;left:0;top:0;width:800px';
+      host.innerHTML = '<div class="topbar"><div class="crumb">c</div><div class="spacer"></div>' +
+        '<button class="icon-btn" id="probe-bell">b</button></div>';
       document.body.appendChild(host);
-      const top = () => Math.round(host.querySelector('.topbar').getBoundingClientRect().top);
-      const drag = () => getComputedStyle(host, '::before').getPropertyValue('-webkit-app-region').trim();
+      const bar = host.querySelector('.topbar');
+      const bell = host.querySelector('#probe-bell');
+      const read = () => ({
+        top: Math.round(bar.getBoundingClientRect().top),
+        padRight: Math.round(parseFloat(getComputedStyle(bar).paddingRight)),
+        bellGap: Math.round(bar.getBoundingClientRect().right - bell.getBoundingClientRect().right),
+        drag: getComputedStyle(host.querySelector('.spacer')).getPropertyValue('-webkit-app-region').trim(),
+      });
+      const web = read();
       root.dataset.desktopPlatform = 'win32';
       root.dataset.desktopTitlebar = 'overlay';
-      const out = { topbarTop: top(), drag: drag() };
+      const win32 = read();
       if (prev.p) root.dataset.desktopPlatform = prev.p; else delete root.dataset.desktopPlatform;
       if (prev.t) root.dataset.desktopTitlebar = prev.t; else delete root.dataset.desktopTitlebar;
       host.remove();
-      return JSON.stringify(out);
+      return JSON.stringify({ web, win32 });
     })()`)) as string,
-  ) as { topbarTop: number; drag: string };
+  ) as { web: { padRight: number }; win32: { top: number; padRight: number; bellGap: number; drag: string } };
 
   check(
-    'Windows 顶栏避开窗口控件覆盖层',
-    winReserve.topbarTop >= 36,
-    `topbarTop=${winReserve.topbarTop}px`,
+    'Windows 顶栏不下移（控件与铃铛同一行）',
+    winReserve.win32.top === 0,
+    `top=${winReserve.win32.top}px`,
   );
-  check('Windows 顶部留白可拖窗口', winReserve.drag === 'drag', `app-region=${winReserve.drag}`);
+  check(
+    'Windows 顶栏右端为控件留位',
+    winReserve.win32.bellGap > 100,
+    `bellGap=${winReserve.win32.bellGap}px padRight=${winReserve.win32.padRight}px`,
+  );
+  check('Windows 顶栏可拖窗口', winReserve.win32.drag === 'drag', `region=${winReserve.win32.drag}`);
+  check(
+    'web 端顶栏留位不变',
+    winReserve.web.padRight === 22,
+    `padRight=${winReserve.web.padRight}px`,
+  );
 
   const secure = (await win.webContents.executeJavaScript('window.isSecureContext')) as boolean;
   check('secure context（clipboard / Notification 可用）', secure === true);

--- a/src/frontend/src/features/auth/LoginPage.tsx
+++ b/src/frontend/src/features/auth/LoginPage.tsx
@@ -307,7 +307,7 @@ export function LoginPage() {
         <PolarisMark size={56} />
         <PolarisWordmark height={32} />
       </div>
-      <div style={{ position: 'absolute', top: 18, right: 20 }}>
+      <div className="auth-lang">
         <LangToggle />
       </div>
     </>

--- a/src/frontend/src/features/desktop/ServerSetupPage.tsx
+++ b/src/frontend/src/features/desktop/ServerSetupPage.tsx
@@ -67,7 +67,7 @@ export function ServerSetupPage({ onCancel }: { onCancel?: () => void }) {
         <PolarisWordmark height={32} />
       </div>
 
-      <div style={{ position: 'absolute', top: 18, right: 20 }}>
+      <div className="auth-lang">
         <LangToggle />
       </div>
 

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -9,6 +9,11 @@ import './styles/global.css';
 const platform = hostPlatform();
 if (platform) {
   document.documentElement.dataset.desktopPlatform = platform;
+  // 这两个平台都不画系统标题栏，窗口控件是覆盖在内容之上的，页面必须自己留出
+  // 顶部空间。共用的留白规则挂这个标记；控件在左还是在右的差异才按平台区分。
+  if (platform === 'darwin' || platform === 'win32') {
+    document.documentElement.dataset.desktopTitlebar = 'overlay';
+  }
 }
 
 const container = document.getElementById('root');

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -20,12 +20,12 @@ html { zoom: 1.1; }
    不受 zoom 影响，所以要先除以 1.1——40 物理 px ÷ 1.1 ≈ 36.4px。
    web 端与非 macOS 桌面端该变量恒为 0，所有 calc 退化成原值。 */
 :root { --titlebar-h: 0px; }
-:root[data-desktop-platform='darwin'] { --titlebar-h: 36.4px; }
+:root[data-desktop-titlebar='overlay'] { --titlebar-h: 36.4px; }
 
 /* 让空出来的带子可以拖动窗口（内容盖住了系统标题栏区域，否则拖不动）。
    只覆盖留白本身，不会挡住任何可点元素。 */
 :root[data-desktop-platform='darwin'] .sidebar::before,
-:root[data-desktop-platform='darwin'] .auth-page::before {
+:root[data-desktop-titlebar='overlay'] .auth-page::before {
   content: '';
   position: absolute; top: 0; left: 0; right: 0;
   height: var(--titlebar-h);
@@ -106,6 +106,24 @@ input {
 /* —— 收起态：图标轨道（只留图标，隐藏文字） ——
    图标列中心恒为**内容盒**中线（66/2 = 33px），与展开态一致，收放不跳动。 */
 .nav-collapsed .sidebar { width: 66px; }
+
+/* —— Windows 沉浸式标题栏 ——
+   窗口控件（最小化/最大化/关闭）以覆盖层画在**右上角**，而内容仍从 y=0 开始，
+   会压住顶栏右侧的搜索框与那排按钮。macOS 的交通灯在左上角、正好落在侧栏上，
+   所以那边只需给侧栏留白；Windows 的按钮在主内容列上方，只能整个应用下移。
+
+   .app 是 fixed inset:0 的外壳，给它加 padding-top 就把侧栏与主列一起推下去，
+   空出来的带子正好容纳覆盖层按钮。 */
+:root[data-desktop-platform='win32'] .app { padding-top: var(--titlebar-h); }
+/* 让这条空带子能拖动窗口。原生按钮画在网页内容之上，所以覆盖它也不会挡住点击。 */
+:root[data-desktop-platform='win32'] .app::before {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0;
+  height: var(--titlebar-h);
+  -webkit-app-region: drag;
+}
+/* 登录/配置页是独立的 fixed 浮层，不在 .app 内，右上角的语言切换要单独避让。 */
+:root[data-desktop-platform='win32'] .auth-lang { top: calc(18px + var(--titlebar-h)); }
 
 /* —— 桌面端（macOS）收起态轨道 ——
    要容得下交通灯：灯组在窗口坐标里占 x=18..70pt（window.ts 把 trafficLightPosition
@@ -770,6 +788,7 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
     radial-gradient(120% 130% at 20% 0%, #f2f5fa 0%, #e3eaf4 45%, #d3deef 100%);
   padding: 24px clamp(24px, 9vw, 150px) 24px 24px;
 }
+.auth-lang { position: absolute; top: 18px; right: 20px; }
 .auth-brand {
   position: absolute; top: calc(26px + var(--titlebar-h)); left: 30px;
   display: flex; align-items: center; gap: 14px;
@@ -1039,13 +1058,13 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
    最左侧的「退出阅览」按钮，点不到。把留白加在顶栏自身而不是外层容器上——
    打印时顶栏 display:none，这条留白也跟着消失，不会在导出的 PDF 顶部留白条。
    height 用 calc 补偿：全局 box-sizing 是 border-box，只加 padding 会压缩内容高度。 */
-:root[data-desktop-platform='darwin'] .paper-reader-topbar {
+:root[data-desktop-titlebar='overlay'] .paper-reader-topbar {
   position: relative;
   height: calc(52px + var(--titlebar-h));
   padding-top: var(--titlebar-h);
 }
 /* 留白本身可拖窗口（内容盖住了系统标题栏区域） */
-:root[data-desktop-platform='darwin'] .paper-reader-topbar::before {
+:root[data-desktop-titlebar='overlay'] .paper-reader-topbar::before {
   content: '';
   position: absolute; top: 0; left: 0; right: 0;
   height: var(--titlebar-h);
@@ -1162,7 +1181,7 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
         关掉后媒体查询值与布局值一致，.split-detail 的反向抵消一并归 1 —— */
   html { zoom: 1; }
   /* 这里 zoom 已关，带子按物理 px 直接给 */
-  :root[data-desktop-platform='darwin'] { --titlebar-h: 40px; }
+  :root[data-desktop-titlebar='overlay'] { --titlebar-h: 40px; }
   .split-detail { zoom: 1; }
 
   /* —— 触屏基建 —— */

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -20,12 +20,23 @@ html { zoom: 1.1; }
    不受 zoom 影响，所以要先除以 1.1——40 物理 px ÷ 1.1 ≈ 36.4px。
    web 端与非 macOS 桌面端该变量恒为 0，所有 calc 退化成原值。 */
 :root { --titlebar-h: 0px; }
-:root[data-desktop-titlebar='overlay'] { --titlebar-h: 36.4px; }
+:root[data-desktop-platform='darwin'] { --titlebar-h: 36.4px; }
+
+/* Windows 的窗口控件是横排在右上角的，做法与 macOS 相反：不下移内容，而是在
+   顶栏右端留出按钮宽度，让它们排在铃铛右边、同一行。
+   宽度取自 Chromium 暴露的 env(titlebar-area-*)——titlebar-area-width 是**不含**
+   按钮区的可用宽度，用视口宽减去它就是按钮区宽度，能跟随 DPI 缩放。
+   再除以 1.1：env()/vw 给的是未经 zoom 的 CSS px，而这里的 padding 会被
+   html{zoom:1.1} 放大（与 --titlebar-h 同理）。 */
+:root { --winctl-w: 0px; }
+:root[data-desktop-platform='win32'] {
+  --winctl-w: calc((100vw - env(titlebar-area-width, calc(100vw - 138px))) / 1.1);
+}
 
 /* 让空出来的带子可以拖动窗口（内容盖住了系统标题栏区域，否则拖不动）。
    只覆盖留白本身，不会挡住任何可点元素。 */
 :root[data-desktop-platform='darwin'] .sidebar::before,
-:root[data-desktop-titlebar='overlay'] .auth-page::before {
+:root[data-desktop-platform='darwin'] .auth-page::before {
   content: '';
   position: absolute; top: 0; left: 0; right: 0;
   height: var(--titlebar-h);
@@ -41,8 +52,17 @@ html { zoom: 1.1; }
    还要 align-self: stretch：.topbar 是 align-items:center，而 .spacer 是个空 div，
    默认高度为 0——拖拽区是条零高度的矩形，等于没有。撑满行高才真的抓得住。
    .spacer 本来就没有内容，撑开不可见；.crumb 自身是 flex 居中，撑开后文字不动。 */
-:root[data-desktop-platform='darwin'] .topbar > .crumb,
-:root[data-desktop-platform='darwin'] .topbar > .spacer {
+:root[data-desktop-platform='win32'] .topbar { padding-right: calc(22px + var(--winctl-w)); }
+/* 阅览浮层的顶栏同样贴着窗口右缘，「导出 PDF」会被按钮压住（原 padding: 0 18px） */
+:root[data-desktop-platform='win32'] .paper-reader-topbar {
+  padding-right: calc(18px + var(--winctl-w));
+}
+/* 登录/配置页右上角的语言切换同理 */
+:root[data-desktop-platform='win32'] .auth-lang { right: calc(20px + var(--winctl-w)); }
+
+/* 拖拽区两平台共用：顶栏没有系统标题栏可抓，得自己声明 */
+:root[data-desktop-titlebar='overlay'] .topbar > .crumb,
+:root[data-desktop-titlebar='overlay'] .topbar > .spacer {
   -webkit-app-region: drag;
   align-self: stretch;
 }
@@ -106,24 +126,6 @@ input {
 /* —— 收起态：图标轨道（只留图标，隐藏文字） ——
    图标列中心恒为**内容盒**中线（66/2 = 33px），与展开态一致，收放不跳动。 */
 .nav-collapsed .sidebar { width: 66px; }
-
-/* —— Windows 沉浸式标题栏 ——
-   窗口控件（最小化/最大化/关闭）以覆盖层画在**右上角**，而内容仍从 y=0 开始，
-   会压住顶栏右侧的搜索框与那排按钮。macOS 的交通灯在左上角、正好落在侧栏上，
-   所以那边只需给侧栏留白；Windows 的按钮在主内容列上方，只能整个应用下移。
-
-   .app 是 fixed inset:0 的外壳，给它加 padding-top 就把侧栏与主列一起推下去，
-   空出来的带子正好容纳覆盖层按钮。 */
-:root[data-desktop-platform='win32'] .app { padding-top: var(--titlebar-h); }
-/* 让这条空带子能拖动窗口。原生按钮画在网页内容之上，所以覆盖它也不会挡住点击。 */
-:root[data-desktop-platform='win32'] .app::before {
-  content: '';
-  position: absolute; top: 0; left: 0; right: 0;
-  height: var(--titlebar-h);
-  -webkit-app-region: drag;
-}
-/* 登录/配置页是独立的 fixed 浮层，不在 .app 内，右上角的语言切换要单独避让。 */
-:root[data-desktop-platform='win32'] .auth-lang { top: calc(18px + var(--titlebar-h)); }
 
 /* —— 桌面端（macOS）收起态轨道 ——
    要容得下交通灯：灯组在窗口坐标里占 x=18..70pt（window.ts 把 trafficLightPosition
@@ -1058,13 +1060,13 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
    最左侧的「退出阅览」按钮，点不到。把留白加在顶栏自身而不是外层容器上——
    打印时顶栏 display:none，这条留白也跟着消失，不会在导出的 PDF 顶部留白条。
    height 用 calc 补偿：全局 box-sizing 是 border-box，只加 padding 会压缩内容高度。 */
-:root[data-desktop-titlebar='overlay'] .paper-reader-topbar {
+:root[data-desktop-platform='darwin'] .paper-reader-topbar {
   position: relative;
   height: calc(52px + var(--titlebar-h));
   padding-top: var(--titlebar-h);
 }
 /* 留白本身可拖窗口（内容盖住了系统标题栏区域） */
-:root[data-desktop-titlebar='overlay'] .paper-reader-topbar::before {
+:root[data-desktop-platform='darwin'] .paper-reader-topbar::before {
   content: '';
   position: absolute; top: 0; left: 0; right: 0;
   height: var(--titlebar-h);
@@ -1181,7 +1183,7 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
         关掉后媒体查询值与布局值一致，.split-detail 的反向抵消一并归 1 —— */
   html { zoom: 1; }
   /* 这里 zoom 已关，带子按物理 px 直接给 */
-  :root[data-desktop-titlebar='overlay'] { --titlebar-h: 40px; }
+  :root[data-desktop-platform='darwin'] { --titlebar-h: 40px; }
   .split-detail { zoom: 1; }
 
   /* —— 触屏基建 —— */


### PR DESCRIPTION
Windows shipped the native title bar and, below it, the in-window menu bar, so the client looked nothing like it does on macOS.

Both are gone. `titleBarStyle` becomes `'hidden'` with a `titleBarOverlay` drawing the caption buttons over the content, and the application menu is removed outright on non-macOS. Linux keeps the native title bar — window managers vary too much for the overlay to be a safe default there.

## The part that needed thought

**The caption buttons are on the opposite side from macOS.** Traffic lights sit top-left, over the sidebar, which is why reserving space inside the sidebar was enough there. Windows draws its buttons top-right, over the main column and directly on top of the search box and the toolbar buttons. So the whole shell shifts down instead — `padding-top` on `.app` — and the freed band becomes a drag region. The login and reading overlays are `position: fixed` outside `.app`, so they each take the reserve individually.

**Removing the menu costs its accelerators.** Clipboard shortcuts survive because Chromium handles those in the renderer, but reload, devtools and zoom do not, so they are re-registered through `before-input-event`. macOS keeps its menu: there it lives in the system bar rather than the window, and dropping it would break Cmd+C/V outright — the opposite trade from Windows.

**Shared reserves key off a marker, not a platform list.** `data-desktop-titlebar="overlay"` covers both platforms that draw controls over content, so only genuinely side-specific rules (which edge the buttons occupy) still name `darwin` or `win32`.

## Verification

The CSS is entirely attribute-driven, so forcing the attribute exercises the real rule regardless of the host platform:

| | top bar top | drag region |
|---|---|---|
| web (no attribute) | 0px | none |
| `win32` | **40px** | **drag** |

The language toggle on the login page moves from 19.8px to 59.8px, clear of the button band. Two smoke assertions cover the reserve and the drag region, and pass.

**Not verified on Windows itself** — I have no machine to run it on. Everything here is the CSS and the Electron options; the packaged build still needs a visual check on Windows, particularly the overlay colours (`#f7f9fc` / `#59637a`, taken from `tokens.css`) and whether 40px suits the platform's button metrics.
