### PR TITLE
fix(voyages): show a task only where it can actually be opened

### DIFF
--- a/docs/task-system.md
+++ b/docs/task-system.md
@@ -212,42 +212,48 @@ scope columns are null because the daily feed is shared by the whole lab.
 clauses:
 
 1. `project_id` is one of the topics I am a member of (`project_members`);
-2. `library_id` is one of the libraries linked by a topic I am a member of
-   (`topic_source_libraries`);
-3. `library_id` is one of the libraries I curate (`direction_library_curators`);
+2. `library_id` is one of the libraries I can manage — I created it (`direction_libraries
+   .submitted_by`) or I curate it (`direction_library_curators`);
+3. I started this run myself (`voyage_runs.created_by`) **and** the run has a scope (at least one of
+   `project_id` / `library_id` is set);
 4. I am a platform admin (`users.role == "admin"`) — then everything is visible.
 
-Clauses 2 and 3 exist because a library task's `project_id` is deliberately left empty
+Clause 2 exists because a library task's `project_id` is deliberately left empty
 (`create_ingest_voyage` sets only `library_id`, so library tasks do not pollute topic task lists).
 Filtering by topic membership alone would hide them entirely, and standalone libraries with no origin
-topic are the normal case.
+topic are the normal case. Merely *linking* a library to a topic (`topic_source_libraries`) grants
+nothing here: the link means the topic consumes the library's papers, not that its members run it.
 
 Then, if `project_id` is passed as a query parameter, the list is additionally narrowed to that
 topic's own tasks **and library kinds are excluded** — those belong in the lab workspace.
 
 Note what this means for a platform-level task: `daily_feed_sync` runs have both scope ids null, so
-clauses 1–3 can never match. Only clause 4 does. **Non-admins do not see the daily fetch task at
-all.**
+clauses 1–3 can never match (clause 3 is explicitly scoped for this reason). Only clause 4 does.
+**Non-admins do not see the daily fetch task at all.**
 
-### 3.2 The detail (`get_voyage`)
+### 3.2 The detail (`can_view_voyage`)
 
-Detail, logs, SSE, cancel and retry all go through `get_voyage()`, which is stricter and checks three
-whitelists in order. No access is reported as `404 VOYAGE_NOT_FOUND`, not `403` — existence is not
-leaked.
+Detail, logs, SSE, cancel and retry all go through `get_voyage()` → `can_view_voyage()`. No access is
+reported as `404 VOYAGE_NOT_FOUND`, not `403` — existence is not leaked.
 
-1. **Topic-scoped run** (`project_id` set): the caller must be a member of that topic.
-2. **Library-scoped run** (`library_id` set): the caller must pass `can_manage_library()` — i.e. be a
-   platform admin, the creator, or a curator of that library. Note this is a *write*-level check, and
-   it is stricter than the list filter: being a member of a topic that merely links the library gets
-   you the row in the list, but not the detail page.
-3. **Platform-level run** (both scope ids null): platform admins only. Without this branch even an
-   admin would get a 404 on the daily fetch task, taking its logs, SSE stream, cancel and retry down
-   with it. The rule matches the rest of the daily feed's admin surface (managing subscribed
-   categories, manual refresh, the embedding toggle).
+1. **Platform admin**: everything.
+2. **Platform-level run** (both scope ids null, i.e. the daily fetch): admins only, so this returns
+   false for everyone else — including whoever started it. Without clause 1 even an admin would get a
+   404 there, taking its logs, SSE stream, cancel and retry down with it. The rule matches the rest of
+   the daily feed's admin surface (managing subscribed categories, manual refresh, the embedding
+   toggle).
+3. **I started it** (`created_by`): the run I kicked off stays open to me even if I later lose
+   curatorship of that library.
+4. **Topic-scoped run** (`project_id` set): the caller must be a member of that topic.
+5. **Library-scoped run** (`library_id` set): the caller must pass `can_manage_library()` — i.e. be a
+   platform admin, the creator, or a curator of that library.
 
-The library branch needs the full `User` object (for role and curator lookup), so the API layer
-always passes `user=`. Call sites that only have a `user_id` degrade to topic-membership plus a
-role lookup.
+`_visible_filter()` is the SQL mirror of this predicate and the two must be changed together:
+anything you can see in the list must open. (They used to diverge — the list counted tasks of
+libraries merely linked to my topic, the detail required library write access, so those rows 404ed.)
+
+`can_view_voyage()` needs the full `User` object (role, creator, curator lookups); `get_voyage()`
+loads it when the call site only has a `user_id`.
 
 ### 3.3 Cancel and retry
 
@@ -616,9 +622,13 @@ log. Once the network is back, `POST /voyages/{id}/resume` resets that step to `
 on. If it dies at step 5 instead, steps 1–4 are `passed` and are not redone — the crawl and the
 scoring are not repeated.
 
-**Visibility.** `project_id` is null, so this run never appears in a topic's task list. It is visible
-in the list to anyone in a topic that links the library, to its curators, and to admins; the detail
-page additionally requires manage rights on the library (creator / curator / admin).
+**Visibility.** `project_id` is null, so this run never appears in a topic's task list. List and
+detail use the same rule (§3): whoever can manage the library (creator / curator / admin), plus
+whoever started this particular run. Linking the library to a topic does not let its members open the
+task. A read-only visitor still sees "running" on the library page — `GET /libraries/{id}/ingest/
+state` returns `running_voyage_id` together with `can_open_running_voyage` (and `last_run.can_open`),
+and the frontend renders plain text instead of a link when those are false, rather than sending
+someone into a 404.
 
 ### 5.2 Daily new papers — `daily_feed_sync`
 

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -62,5 +62,5 @@ async def get_ingest_state(
     project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
-    state = await ingest_service.ingest_state(session, project)
+    state = await ingest_service.ingest_state(session, project, user=user)
     return IngestStateRead(**state)

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -867,7 +867,7 @@ async def get_library_ingest_state(
 ) -> IngestStateRead:
     """该库的建库/同步状态：上次同步时间、抓取进度计数、在跑任务、下次自动同步（可管理者）。"""
     library = await _get_visible_library(session, library_id, user)
-    state = await ingest_service.library_ingest_state(session, library)
+    state = await ingest_service.library_ingest_state(session, library, user=user)
     return IngestStateRead(**state)
 
 

--- a/src/backend/app/schemas/ingest.py
+++ b/src/backend/app/schemas/ingest.py
@@ -27,6 +27,8 @@ class IngestLastRun(BaseModel):
     voyage_id: uuid.UUID
     status: str
     finished_at: datetime | None
+    # 请求者能否打开这个任务的详情页（库可读不等于任务可见）；false 时前端只显示状态、不给跳转
+    can_open: bool = False
 
 
 class PaperCounts(BaseModel):
@@ -48,6 +50,8 @@ class IngestStateRead(BaseModel):
     last_run: IngestLastRun | None
     paper_counts: PaperCounts
     running_voyage_id: uuid.UUID | None
+    # 请求者能否打开在跑任务的详情页；false 时前端只显示「运行中」文字、不给跳转
+    can_open_running_voyage: bool = False
     # 下一次自动同步时间（cadence=daily 且已完成初始建库才有）
     next_sync_at: str | None = None
 

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -12,6 +12,7 @@ from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import PAPER_STATUSES
 from app.models.project import Project
+from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
 from app.services.libraries import get_library_for_project, library_definition
@@ -227,8 +228,19 @@ def next_daily_sync_at(library: DirectionLibrary | None) -> datetime | None:
     return candidate
 
 
+async def _can_open(session: AsyncSession, run: VoyageRun | None, user: User) -> bool:
+    """这个人能否打开该任务的详情页（与 voyages 详情鉴权同一口径）。
+
+    库能看不等于库的任务能看：只读访客看得到「正在建库」，但点不开任务详情。
+    前端据此把状态渲染成纯文字而不是链接，免得点进去 404。
+    """
+    from app.services.voyages import can_view_voyage
+
+    return run is not None and await can_view_voyage(session, run=run, user=user)
+
+
 async def _resolve_last_run(
-    session: AsyncSession, state: dict[str, Any]
+    session: AsyncSession, state: dict[str, Any], user: User
 ) -> dict[str, Any] | None:
     """从 ingest_state 里的 last_run 摘要补上当前 voyage 状态（水位线权威源在库）。"""
     last_run_raw = state.get("last_run") or None
@@ -239,10 +251,13 @@ async def _resolve_last_run(
         "voyage_id": last_run_raw["voyage_id"],
         "status": voyage.status if voyage else "unknown",
         "finished_at": last_run_raw.get("finished_at"),
+        "can_open": await _can_open(session, voyage, user),
     }
 
 
-async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any]:
+async def ingest_state(
+    session: AsyncSession, project: Project, *, user: User
+) -> dict[str, Any]:
     # P8a：水位线/last_run 权威源在库（library.ingest_state）
     library = await get_library_for_project(session, project.id)
     state = (library.ingest_state if library else None) or {}
@@ -252,15 +267,16 @@ async def ingest_state(session: AsyncSession, project: Project) -> dict[str, Any
     )
     return {
         "watermark": state.get("watermark"),
-        "last_run": await _resolve_last_run(session, state),
+        "last_run": await _resolve_last_run(session, state, user),
         "paper_counts": await paper_counts(session, project.id),
         "running_voyage_id": running.id if running else None,
+        "can_open_running_voyage": await _can_open(session, running, user),
         "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
     }
 
 
 async def library_ingest_state(
-    session: AsyncSession, library: DirectionLibrary
+    session: AsyncSession, library: DirectionLibrary, *, user: User
 ) -> dict[str, Any]:
     """某方向库的 ingest 状态（水位线/上次同步/计数/在跑任务/下次同步），库工作台用。
 
@@ -271,9 +287,10 @@ async def library_ingest_state(
     running = await find_running_ingest_for_library(session, library.id)
     return {
         "watermark": state.get("watermark"),
-        "last_run": await _resolve_last_run(session, state),
+        "last_run": await _resolve_last_run(session, state, user),
         "paper_counts": await library_paper_counts(session, library.id),
         "running_voyage_id": running.id if running else None,
+        "can_open_running_voyage": await _can_open(session, running, user),
         "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
     }
 

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -3,11 +3,11 @@
 import uuid
 from collections.abc import Sequence
 
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.library_direction import DirectionLibraryCurator, TopicSourceLibrary
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
 from app.models.project import ProjectMember
 from app.models.user import User
 from app.models.voyage import LIBRARY_KINDS, TERMINAL_STATUSES, VoyageRun
@@ -40,24 +40,33 @@ async def create_voyage(
 
 
 def _visible_filter(stmt, user_id: uuid.UUID):
-    """可见任务 = 我所在课题的任务 ∪ 我够得着的库的任务（课题关联的库 ∪ 我策展的库）。
+    """可见任务 = 我所在课题的任务 ∪ 我能管的库的任务 ∪ 我自己发起的任务（∪ admin 全部）。
 
+    这是 :func:`can_view_voyage` 的 SQL 镜像——列表里能看到的，点进去必须打得开。
     库任务不能只靠 project_id 判：独立库的任务 project_id 为空，按课题成员 join
     会把它们整个漏掉——而独立库是常态（P9c 起建课题不再自动建库）。
+
+    「课题关联了某个库」不给可见性：关联只是拿它的语料，管不了它的建库任务
+    （库级写权限 = 创建者/策展人/admin，见 libraries.can_manage_library）。
     """
     my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
-    my_libraries = select(TopicSourceLibrary.library_id).where(
-        TopicSourceLibrary.topic_id.in_(my_projects)
-    )
     my_curated = select(DirectionLibraryCurator.library_id).where(
         DirectionLibraryCurator.user_id == user_id
     )
+    my_libraries = select(DirectionLibrary.id).where(
+        or_(DirectionLibrary.submitted_by == user_id, DirectionLibrary.id.in_(my_curated))
+    )
     is_admin = select(User.id).where(User.id == user_id, User.role == "admin").exists()
+    # 「我发起的」只对有作用域的任务生效：平台级任务（两个 id 都为空）恒为 admin-only。
+    mine_scoped = and_(
+        VoyageRun.created_by == user_id,
+        or_(VoyageRun.project_id.is_not(None), VoyageRun.library_id.is_not(None)),
+    )
     return stmt.where(
         or_(
             VoyageRun.project_id.in_(my_projects),
             VoyageRun.library_id.in_(my_libraries),
-            VoyageRun.library_id.in_(my_curated),
+            mine_scoped,
             is_admin,
         )
     )
@@ -91,6 +100,41 @@ async def _is_project_member(
     return row.first() is not None
 
 
+async def can_view_voyage(
+    session: AsyncSession, *, run: VoyageRun, user: User
+) -> bool:
+    """能否查看某个任务（详情/日志/SSE/取消/重试的统一口径）。
+
+    - 平台管理员：全部；
+    - 平台级任务（两个作用域 id 都为空，如每日新论文抓取）：仅平台管理员，口径与
+      订阅分类管理、手动刷新、向量开关一致；
+    - 我发起的任务（``created_by``）：自己点的那次运行，哪怕后来不再是该库策展人也看得到；
+    - 课题作用域任务：课题成员；
+    - 库作用域任务：能管这个库的人（创建者/策展人/admin，见 libraries.can_manage_library）。
+
+    :func:`_visible_filter` 是它的 SQL 镜像，两边必须一起改。
+    """
+    if user.role == "admin":
+        return True
+    if run.project_id is None and run.library_id is None:
+        return False
+    if run.created_by is not None and run.created_by == user.id:
+        return True
+    if run.project_id is not None and await _is_project_member(
+        session, project_id=run.project_id, user_id=user.id
+    ):
+        return True
+    if run.library_id is not None:
+        from app.services.libraries import can_manage_library, get_library
+
+        library = await get_library(session, run.library_id)
+        if library is not None and await can_manage_library(
+            session, user=user, library=library
+        ):
+            return True
+    return False
+
+
 async def get_voyage(
     session: AsyncSession,
     *,
@@ -99,12 +143,9 @@ async def get_voyage(
     with_steps: bool = False,
     user: User | None = None,
 ) -> VoyageRun | None:
-    """取航程；无访问权视为不存在（返回 None）。
+    """取航程；无访问权视为不存在（返回 None）。访问权见 :func:`can_view_voyage`。
 
-    访问权：起源课题成员（项目作用域任务）∪ 可管理其方向库者（P9a 库化任务——独立库
-    无课题，鉴权走库级写权限：成员/策展人/admin）∪ 平台管理员（平台级任务——两个作用
-    域 id 都为空，如每日新论文抓取）。库级鉴权需要 ``user``（角色/策展人判定），故 API
-    层传完整 user；仅传 user_id 时退化为项目成员判定 + 回查角色。
+    鉴权要完整 ``user``（角色/创建者/策展人判定），只传 ``user_id`` 的调用点回查一次。
     """
     stmt = select(VoyageRun).where(VoyageRun.id == voyage_id)
     if with_steps:
@@ -112,32 +153,11 @@ async def get_voyage(
     run = (await session.execute(stmt)).scalar_one_or_none()
     if run is None:
         return None
-    if run.project_id is not None and await _is_project_member(
-        session, project_id=run.project_id, user_id=user_id
-    ):
-        return run
-    if run.library_id is not None and user is not None:
-        from app.services.libraries import can_manage_library, get_library
-
-        library = await get_library(session, run.library_id)
-        if library is not None and await can_manage_library(
-            session, user=user, library=library
-        ):
-            return run
-    if run.project_id is None and run.library_id is None:
-        # 平台级任务（每日新论文抓取）：既不属于课题也不属于库，上面两条白名单都不
-        # 命中——不放行的话 admin 也会 404，连带日志/SSE/取消/重试全失效。口径与订阅
-        # 分类管理、手动刷新、向量开关一致：仅平台 admin。
-        # 只传 user_id 的调用点回查一次角色（与 _visible_filter 的 is_admin 子句同口径）。
-        role = (
-            user.role
-            if user is not None
-            else (
-                await session.execute(select(User.role).where(User.id == user_id))
-            ).scalar_one_or_none()
-        )
-        return run if role == "admin" else None
-    return None
+    if user is None:
+        user = await session.get(User, user_id)
+        if user is None:
+            return None
+    return run if await can_view_voyage(session, run=run, user=user) else None
 
 
 async def cancel_voyage(session: AsyncSession, run: VoyageRun) -> VoyageRun:

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -9,7 +9,11 @@ import uuid
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
-from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
+from app.models.library_direction import (
+    DirectionLibrary,
+    DirectionLibraryCurator,
+    TopicSourceLibrary,
+)
 from app.models.user import User
 from app.models.voyage import VoyageRun
 from app.services import voyages as voyages_service
@@ -34,7 +38,7 @@ async def _promote_admin(email: str) -> None:
         await session.commit()
 
 
-async def _make_run(*, kind: str, library_id=None, project_id=None) -> uuid.UUID:
+async def _make_run(*, kind: str, library_id=None, project_id=None, created_by=None) -> uuid.UUID:
     async with get_sessionmaker()() as session:
         run = VoyageRun(
             kind=kind,
@@ -43,10 +47,27 @@ async def _make_run(*, kind: str, library_id=None, project_id=None) -> uuid.UUID
             cursor=0,
             library_id=library_id,
             project_id=project_id,
+            created_by=created_by,
         )
         session.add(run)
         await session.commit()
         return run.id
+
+
+async def _link_library(*, topic_id: uuid.UUID, library_id: uuid.UUID) -> None:
+    """把库关联给课题（课题拿它的语料用，但管不了它）。"""
+    async with get_sessionmaker()() as session:
+        session.add(TopicSourceLibrary(topic_id=topic_id, library_id=library_id))
+        await session.commit()
+
+
+async def _list_and_open(client, *, run_id: uuid.UUID, user_id: uuid.UUID, hdr) -> tuple[bool, int]:
+    """(该任务在我的任务列表里吗, 详情页 HTTP 状态码) —— 两者必须一致。"""
+    async with get_sessionmaker()() as session:
+        runs = await voyages_service.list_voyages(session, user_id=user_id)
+        listed = run_id in {r.id for r in runs}
+    resp = await client.get(f"/api/voyages/{run_id}", headers=hdr)
+    return listed, resp.status_code
 
 
 async def _library(client, admin_hdr, owner_hdr, *, name) -> str:
@@ -206,6 +227,138 @@ async def test_platform_voyage_stays_out_of_the_topic_list(client):
     ids = {r.id for r in runs}
     assert platform_run not in ids
     assert attached_run not in ids
+
+
+async def test_linked_library_alone_grants_nothing(client):
+    """课题关联了某个库、但我管不了那个库：列表看不到它的建库任务，详情也打不开。
+
+    以前列表把「课题关联的库」也算可见、详情却要库级写权限——列表看得到、点进去 404。
+    """
+    admin_email = "vscope-linked-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-linked-owner@example.com")
+    lib_id = await _library(client, admin, owner, name="别人的库·被我课题关联")
+
+    member_email = "vscope-linked-member@example.com"
+    member = await _hdr(client, member_email)
+    member_id = await _user_id(member_email)
+    resp = await client.post(
+        "/api/projects", json={"name": "借语料的课题", "statement": "s"}, headers=member
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+    await _link_library(topic_id=project_id, library_id=uuid.UUID(lib_id))
+
+    run_id = await _make_run(kind="wiki_ingest", library_id=uuid.UUID(lib_id))
+    assert await _list_and_open(client, run_id=run_id, user_id=member_id, hdr=member) == (
+        False,
+        404,
+    )
+
+    # 对照：库的创建者（能管这个库）列表看得到、详情打得开
+    owner_id = await _user_id("vscope-linked-owner@example.com")
+    assert await _list_and_open(client, run_id=run_id, user_id=owner_id, hdr=owner) == (
+        True,
+        200,
+    )
+
+
+async def test_library_voyage_visible_to_whoever_started_it(client):
+    """我亲手发起的建库任务：哪怕后来不再是该库策展人，列表仍看得到、详情仍打得开。"""
+    admin_email = "vscope-starter-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-starter-owner@example.com")
+    lib_id = await _library(client, admin, owner, name="离任策展人的库")
+
+    starter_email = "vscope-starter@example.com"
+    starter = await _hdr(client, starter_email)
+    starter_id = await _user_id(starter_email)
+
+    # 他不是创建者也不是策展人（当初是，后来被撤了）——只剩「这是我发起的那次运行」
+    mine = await _make_run(
+        kind="wiki_bootstrap", library_id=uuid.UUID(lib_id), created_by=starter_id
+    )
+    others = await _make_run(kind="wiki_bootstrap", library_id=uuid.UUID(lib_id))
+
+    assert await _list_and_open(client, run_id=mine, user_id=starter_id, hdr=starter) == (
+        True,
+        200,
+    )
+    assert await _list_and_open(client, run_id=others, user_id=starter_id, hdr=starter) == (
+        False,
+        404,
+    )
+
+
+async def test_platform_voyage_stays_admin_only_for_its_starter(client):
+    """平台级任务（每日新论文）不吃「我发起的」这条：两个作用域 id 都空 → 只有 admin。"""
+    admin_email = "vscope-platform-starter-admin@example.com"
+    await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    starter_email = "vscope-platform-starter@example.com"
+    starter = await _hdr(client, starter_email)
+    starter_id = await _user_id(starter_email)
+
+    run_id = await _make_run(kind="daily_feed_sync", created_by=starter_id)
+    assert await _list_and_open(client, run_id=run_id, user_id=starter_id, hdr=starter) == (
+        False,
+        404,
+    )
+
+
+async def test_topic_member_still_sees_topic_voyages(client):
+    """课题任务口径没被收紧：课题成员照常在列表看到、点得开自己课题的任务。"""
+    admin_email = "vscope-topic-admin@example.com"
+    await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner_email = "vscope-topic-owner@example.com"
+    owner = await _hdr(client, owner_email)
+    owner_id = await _user_id(owner_email)
+
+    resp = await client.post(
+        "/api/projects", json={"name": "课题任务照常可见", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    # 别人发起的课题任务也看得到——凭的是课题成员身份
+    run_id = await _make_run(kind="idea_forge", project_id=project_id)
+    assert await _list_and_open(client, run_id=run_id, user_id=owner_id, hdr=owner) == (
+        True,
+        200,
+    )
+
+    stranger_email = "vscope-topic-stranger@example.com"
+    stranger = await _hdr(client, stranger_email)
+    stranger_id = await _user_id(stranger_email)
+    assert await _list_and_open(client, run_id=run_id, user_id=stranger_id, hdr=stranger) == (
+        False,
+        404,
+    )
+
+
+async def test_ingest_state_says_whether_the_task_can_be_opened(client):
+    """公共库对所有人可读：只读访客看得到「正在建库」，但拿到的 can_open 是 false。"""
+    admin_email = "vscope-canopen-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-canopen-owner@example.com")
+    lib_id = await _library(client, admin, owner, name="公共库·状态可见任务不可点")
+
+    run_id = await _make_run(kind="wiki_ingest", library_id=uuid.UUID(lib_id))
+    reader = await _hdr(client, "vscope-canopen-reader@example.com")
+
+    resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=reader)
+    assert resp.status_code == 200, resp.text
+    state = resp.json()
+    assert state["running_voyage_id"] == str(run_id)  # 状态照常显示
+    assert state["can_open_running_voyage"] is False  # 但不给跳转
+    assert (await client.get(f"/api/voyages/{run_id}", headers=reader)).status_code == 404
+
+    resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=owner)
+    assert resp.json()["can_open_running_voyage"] is True
 
 
 async def test_new_ingest_voyage_carries_no_project(client):

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -938,15 +938,23 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
           onChange={setTab}
         />
         <div className="row gap8">
+          {/* 无权打开任务详情时只报状态、不给跳转（点了会 404） */}
           {ingestQuery.data?.running_voyage_id && tab !== 'ingest' && (
-            <span
-              className="pill hoverable"
-              style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
-              onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
-            >
-              <span className="dot pulse" />
-              {tr('文献任务运行中 →', 'Literature task running →')}
-            </span>
+            ingestQuery.data.can_open_running_voyage ? (
+              <span
+                className="pill hoverable"
+                style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
+                onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
+              >
+                <span className="dot pulse" />
+                {tr('文献任务运行中 →', 'Literature task running →')}
+              </span>
+            ) : (
+              <span className="pill" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+                <span className="dot pulse" />
+                {tr('文献任务运行中', 'Literature task running')}
+              </span>
+            )
           )}
           <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
             {tr('公共文献库 · 所有人可读', 'Shared library · readable by everyone')}

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -121,6 +121,8 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
   const [unlimited, setUnlimited] = useState(false);
 
   const running = !!state?.running_voyage_id;
+  // 库可读 ≠ 库的任务可见：无权打开详情就不给跳转（见后端 can_open_running_voyage）
+  const canOpenRunning = !!state?.can_open_running_voyage;
 
   const ingestMutation = useMutation({
     mutationFn: (input: { mode: IngestMode; knobs: IngestKnobs }) =>
@@ -188,11 +190,11 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
       <div className="row gap20" style={{ alignItems: 'flex-start' }}>
         {/* —— 左：状态 —— */}
         <div className="col gap16" style={{ flex: 1, minWidth: 0 }}>
-          {/* 进行中航程 */}
+          {/* 进行中航程；无权打开详情时只显示状态、不给跳转（点了会 404） */}
           {running && state?.running_voyage_id && (
             <div
-              className="card card-pad hoverable"
-              onClick={() => navigate(`/voyages/${state.running_voyage_id}`)}
+              className={canOpenRunning ? 'card card-pad hoverable' : 'card card-pad'}
+              onClick={canOpenRunning ? () => navigate(`/voyages/${state.running_voyage_id}`) : undefined}
               style={{ borderColor: 'var(--accent-soft-2)', background: 'var(--accent-soft)' }}
             >
               <div className="row gap10">
@@ -201,7 +203,9 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                   {tr('运行中', 'Running')}
                 </span>
                 <span style={{ fontSize: 13.5, fontWeight: 650 }}>{tr('文献任务进行中', 'Literature task in progress')}</span>
-                <Icon name="arrow" size={14} style={{ marginLeft: 'auto', color: 'var(--accent-text)' }} />
+                {canOpenRunning && (
+                  <Icon name="arrow" size={14} style={{ marginLeft: 'auto', color: 'var(--accent-text)' }} />
+                )}
               </div>
               <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 8 }}>
                 voyage {state.running_voyage_id.slice(0, 8)}…
@@ -273,8 +277,12 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                 <div style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 6 }}>{tr('上次运行', 'Last run')}</div>
                 {state?.last_run ? (
                   <div
-                    className="row gap10 hoverable"
-                    onClick={() => navigate(`/voyages/${state.last_run?.voyage_id ?? ''}`)}
+                    className={state.last_run.can_open ? 'row gap10 hoverable' : 'row gap10'}
+                    onClick={
+                      state.last_run.can_open
+                        ? () => navigate(`/voyages/${state.last_run?.voyage_id ?? ''}`)
+                        : undefined
+                    }
                     style={{
                       border: '0.5px solid var(--border)',
                       borderRadius: 9,
@@ -289,7 +297,9 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                     <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginLeft: 'auto' }}>
                       {state.last_run.voyage_id.slice(0, 8)}…
                     </span>
-                    <Icon name="chevron" size={13} style={{ color: 'var(--text-4)' }} />
+                    {state.last_run.can_open && (
+                      <Icon name="chevron" size={13} style={{ color: 'var(--text-4)' }} />
+                    )}
                   </div>
                 ) : (
                   <span className="muted" style={{ fontSize: 12.5 }}>{tr('暂无运行记录', 'No runs yet')}</span>

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -171,15 +171,23 @@ export function WikiWorkbench({
           onChange={setTab}
         />
         <div className="row gap8">
+          {/* 无权打开任务详情时只报状态、不给跳转（点了会 404） */}
           {ingestQuery.data?.running_voyage_id && tab !== 'ingest' && (
-            <span
-              className="pill hoverable"
-              style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
-              onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
-            >
-              <span className="dot pulse" />
-              {tr('文献任务运行中 →', 'Literature task running →')}
-            </span>
+            ingestQuery.data.can_open_running_voyage ? (
+              <span
+                className="pill hoverable"
+                style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
+                onClick={() => navigate(`/voyages/${ingestQuery.data?.running_voyage_id ?? ''}`)}
+              >
+                <span className="dot pulse" />
+                {tr('文献任务运行中 →', 'Literature task running →')}
+              </span>
+            ) : (
+              <span className="pill" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+                <span className="dot pulse" />
+                {tr('文献任务运行中', 'Literature task running')}
+              </span>
+            )
           )}
           {hasTopic && (
             <button className="btn btn-ghost sm" onClick={() => setPresentOpen(true)}>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1147,6 +1147,8 @@ export interface IngestLastRun {
   voyage_id: string;
   status: string;
   finished_at: string | null;
+  /** 能否打开该任务详情（库可读不等于任务可见）；false 时只显示状态、不给跳转 */
+  can_open?: boolean;
 }
 
 export interface PaperCounts {
@@ -1169,6 +1171,8 @@ export interface IngestState {
   last_run: IngestLastRun | null;
   paper_counts: PaperCounts;
   running_voyage_id: string | null;
+  /** 能否打开在跑任务的详情（无权限时只显示状态、不给跳转） */
+  can_open_running_voyage?: boolean;
   /** 下一次自动同步时间（ISO）；cadence 非 daily 或未完成初始建库为 null */
   next_sync_at?: string | null;
 }


### PR DESCRIPTION
Listing tasks and opening one used **different rules**, so a task could sit in your list and 404 when clicked.

The list counted any task belonging to a library your topic *links to*. The detail required being able to **manage** that library. Linking a library only borrows its papers — it doesn't grant a say over its builds — so the list was the wrong one.

Both now go through one predicate, `can_view_voyage`, with `_visible_filter` as its SQL mirror. **Whatever appears in a list opens.**

## Two gaps closed on the way

**Platform admins were in the list rule but not the detail one.** An admin could see another topic's task and 404 on it — the same bug, opposite direction.

**Whoever started a task can now open it.** Having pressed the button on a library build, you should still see how that run went even if you're no longer one of its curators. Scoped to tasks that *have* a scope, so the daily sync stays admin-only rather than becoming visible to whoever triggered it.

## The library page still reports the build

A running build is worth knowing about even if you can't inspect it. So the status still shows — but as plain text rather than a link when the viewer can't open it. No click that leads to a 404, and no permission popup either.

The two flags (`can_open_running_voyage`, and the same on the last-run card, which was equally clickable and equally 404-prone) come from that same predicate, computed on the ingest state the page already fetches. No extra request.

Existing `can_manage` couldn't serve here: it's computed inline in two places with an extra "member of the origin topic" clause, and it can't express "I started this".

## Verification

Ten tests in `test_voyage_scope.py`, each asserting list membership and detail status **together** through one helper — that pairing is the invariant that was broken. `ruff check app` clean, `tsc --noEmit` 0 errors.

`docs/task-system.md` documented the old mismatch as if it were the spec ("the list is deliberately looser"); rewritten.

## Found, not fixed

`can_manage` has two definitions: the single-library detail uses `can_manage_library`, while the two list endpoints inline an extra "I'm a member of the library's origin topic" clause. That clause was deliberately removed from `can_manage_library` when libraries were decoupled from topics (those people were backfilled as curators), so **the same library can show `can_manage=true` in a list and `false` on its own page**. It changes which management buttons appear, so it wants its own change rather than a rider on this one.