### PR TITLE
feat(desktop): update detection, and apply without restarting where possible

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -111,6 +111,21 @@ jobs:
           sudo chmod 4755 src/desktop/node_modules/electron/dist/chrome-sandbox
           cd src/desktop && xvfb-run -a npm run smoke
 
+      # The renderer ships separately so a frontend-only release can be applied
+      # without reinstalling: the client swaps this bundle in and reloads. The
+      # contract version in the filename tells the client whether its preload is
+      # new enough to run it — see src/desktop/src/main/updates.
+      # Built once, on Linux, since the bundle is platform-independent.
+      - name: Package renderer update
+        if: matrix.name == 'linux'
+        shell: bash
+        run: |
+          CONTRACT=$(grep -oE 'CONTRACT_VERSION = [0-9]+' src/desktop/src/shared/contract.ts | grep -oE '[0-9]+')
+          VERSION="${{ steps.meta.outputs.version }}"
+          echo "{\"version\":\"$VERSION\",\"contract\":$CONTRACT}" > src/frontend/dist/meta.json
+          mkdir -p src/desktop/release
+          tar -czf "src/desktop/release/renderer-$VERSION-c$CONTRACT.tar.gz" -C src/frontend/dist .
+
       - name: Package
         shell: bash
         working-directory: src/desktop
@@ -128,6 +143,7 @@ jobs:
             src/desktop/release/*.exe
             src/desktop/release/*.AppImage
             src/desktop/release/*.deb
+            src/desktop/release/renderer-*.tar.gz
 
   release:
     needs: build

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -20,6 +20,7 @@ import {
   type RpcRequest,
 } from '../../shared/contract';
 import { capabilityManifest } from '../capabilities';
+import { applyUpdate, checkForUpdate } from '../updates';
 import * as host from './methods.host';
 import * as local from './methods.local';
 
@@ -49,6 +50,8 @@ const HANDLERS: Record<MethodName, Handler> = {
   'host.copyText': (p) => host.copyText(asString(p, 'text')),
   'host.setBadgeCount': (p) => host.setBadgeCount(asNumber(p, 'count')),
   'host.capabilities': () => capabilityManifest(),
+  'host.update.check': () => checkForUpdate(),
+  'host.update.apply': () => applyUpdate(),
   // local.* 一期全部走到 agent 再以 ERR_CAPABILITY_UNAVAILABLE 结束（见 methods.local.ts）
   'local.latex.compile': (p) => local.latexCompile(p),
   'local.fs.pickFolder': (p) => local.pickFolder(p),

--- a/src/desktop/src/main/protocol.ts
+++ b/src/desktop/src/main/protocol.ts
@@ -21,6 +21,8 @@ import { existsSync, statSync } from 'node:fs';
 import { extname, join, normalize, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { stagedRendererDir } from './updates/renderer-store';
+
 export const APP_SCHEME = 'app';
 export const APP_HOST = 'polaris';
 export const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
@@ -43,6 +45,10 @@ export function registerAppScheme(): void {
 }
 
 function rendererRoot(): string {
+  // 热更新装好的界面优先——这就是「免重启更新」的落点：换目录 + reload。
+  // 契约版本不匹配时 stagedRendererDir() 会返回 null，自动回落包内资源。
+  const staged = stagedRendererDir();
+  if (staged) return staged;
   // 打包后 electron-builder 把 src/frontend/dist 放进 resources/renderer；
   // 本地 `npm run dev` 直接读同仓库的 frontend 构建产物。
   return app.isPackaged
@@ -89,9 +95,9 @@ export function buildCsp(serverUrl: string): string {
 }
 
 export function handleAppProtocol(getServerUrl: () => string): void {
-  const root = normalize(rendererRoot());
-
   protocol.handle(APP_SCHEME, async (request) => {
+    // 每次请求重新解析：热更新切换目录后无需重启协议处理器
+    const root = normalize(rendererRoot());
     const url = new URL(request.url);
     const pathname = decodeURIComponent(url.pathname);
     let filePath = normalize(join(root, pathname));

--- a/src/desktop/src/main/updates/index.ts
+++ b/src/desktop/src/main/updates/index.ts
@@ -1,0 +1,173 @@
+/* ============================================================
+   更新检查与应用。
+
+   两条路径，优先热更：
+   - **热更新**：界面层单独打成 renderer-<version>-c<contract>.tar.gz。契约版本
+     不高于当前外壳时，下载→解包→reload，**不重启、不碰 app bundle**。
+   - **整包更新**：preload/主进程/Electron 变了（契约升级或没有界面包）时，只能
+     下载安装器。Windows 直接拉起安装器；macOS 只能打开 dmg 让用户拖进
+     Applications——Squirrel.Mac 要求 Developer ID 签名才肯静默替换，本项目是
+     ad-hoc 签名，这条绕不过。
+
+   契约版本作判据是复用现成机制：CONTRACT_VERSION 本来就是 preload 与界面之间
+   的约定版本，界面要求的版本一旦高于外壳，说明桥接层也变了，热更就不安全。
+   ============================================================ */
+
+import { app, net, shell } from 'electron';
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CONTRACT_VERSION, type UpdateInfo } from '../../shared/contract';
+import { fail, finish, log, progress, startJob } from '../ipc/events';
+import { getWindow } from '../window';
+import { stageRenderer } from './renderer-store';
+
+const REPO = 'ZJU-REAL/Polaris';
+const RELEASES_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+const RENDERER_RE = /^renderer-(.+)-c(\d+)\.tar\.gz$/;
+
+interface Asset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+interface Release {
+  tag_name: string;
+  name: string;
+  body: string;
+  published_at: string;
+  assets: Asset[];
+}
+
+/** 只比较 major.minor.patch；带后缀的（如 0.2.1-win-test）视为该版本的预发布，更低。 */
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core, pre] = v.replace(/^v/, '').split('-', 2);
+    const nums = (core ?? '').split('.').map((n) => parseInt(n, 10) || 0);
+    return { nums, pre: pre ?? '' };
+  };
+  const x = parse(a);
+  const y = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    const d = (x.nums[i] ?? 0) - (y.nums[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  if (x.pre === y.pre) return 0;
+  if (!x.pre) return 1; // 正式版 > 预发布
+  if (!y.pre) return -1;
+  return x.pre > y.pre ? 1 : -1;
+}
+
+function installerFor(assets: Asset[]): Asset | undefined {
+  const match = (re: RegExp) => assets.find((a) => re.test(a.name));
+  if (process.platform === 'darwin') return match(/universal\.dmg$/) ?? match(/\.dmg$/);
+  if (process.platform === 'win32') return match(/\.exe$/) ?? match(/-win\.zip$/);
+  return match(/\.AppImage$/) ?? match(/\.deb$/);
+}
+
+let cached: UpdateInfo | null = null;
+
+export async function checkForUpdate(): Promise<UpdateInfo> {
+  const currentVersion = app.getVersion();
+  const base: UpdateInfo = { available: false, currentVersion };
+  try {
+    const res = await net.fetch(RELEASES_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return base;
+    const release = (await res.json()) as Release;
+    const latestVersion = (release.tag_name ?? '').replace(/^v/, '');
+    if (!latestVersion || compareVersions(latestVersion, currentVersion) <= 0) return base;
+
+    const rendererAsset = release.assets.find((a) => {
+      const m = RENDERER_RE.exec(a.name);
+      return m?.[1] === latestVersion && Number(m[2]) <= CONTRACT_VERSION;
+    });
+    const installer = installerFor(release.assets);
+    const asset = rendererAsset ?? installer;
+    if (!asset) return base;
+
+    cached = {
+      available: true,
+      currentVersion,
+      latestVersion,
+      notes: release.body ?? '',
+      publishedAt: release.published_at,
+      kind: rendererAsset ? 'hot' : 'full',
+      contract: rendererAsset ? Number(RENDERER_RE.exec(rendererAsset.name)![2]) : CONTRACT_VERSION,
+      downloadUrl: asset.browser_download_url,
+      downloadSize: asset.size,
+    };
+    return cached;
+  } catch {
+    // 检查更新失败不该打扰用户：当作没有更新
+    return base;
+  }
+}
+
+async function download(url: string, jobId: string, total: number): Promise<Buffer> {
+  const res = await net.fetch(url, { signal: AbortSignal.timeout(300_000) });
+  if (!res.ok || !res.body) throw new Error(`download failed: HTTP ${res.status}`);
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  const reader = res.body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    received += value.length;
+    progress(jobId, 'download', received, total || received);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * 下载并应用更新。立即返回 jobId，进度与结果经 job.* 事件推送。
+ * 热更成功时结果里带 reloaded: true，界面已经是新的，不需要重启。
+ */
+export function applyUpdate(): { jobId: string } {
+  const info = cached;
+  const jobId = startJob('update');
+  if (!info?.available || !info.downloadUrl) {
+    fail(jobId, 'ERR_NO_UPDATE', 'no update available; run a check first');
+    return { jobId };
+  }
+
+  void (async () => {
+    try {
+      const data = await download(info.downloadUrl!, jobId, info.downloadSize ?? 0);
+
+      if (info.kind === 'hot') {
+        log(jobId, 'installing renderer update');
+        stageRenderer(data, { version: info.latestVersion!, contract: info.contract! });
+        finish(jobId, { kind: 'hot', reloaded: true, version: info.latestVersion });
+        // 换界面即完成更新：重新加载窗口就跑在新版本上了
+        getWindow()?.webContents.reload();
+        return;
+      }
+
+      const dir = join(app.getPath('userData'), 'updates');
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, info.downloadUrl!.split('/').pop() ?? 'update');
+      writeFileSync(file, data);
+      finish(jobId, { kind: 'full', reloaded: false, path: file, version: info.latestVersion });
+
+      if (process.platform === 'win32') {
+        // NSIS 安装器不要求签名，能自己完成替换；detached 是为了让它活过本进程退出
+        spawn(file, [], { detached: true, stdio: 'ignore' }).unref();
+        app.quit();
+      } else {
+        // macOS 只能把 dmg 打开让用户拖进 Applications（无 Developer ID 签名，
+        // 静默替换会被系统拒绝）；Linux 交给文件管理器。
+        await shell.openPath(file);
+      }
+    } catch (err) {
+      fail(jobId, 'ERR_UPDATE_FAILED', err instanceof Error ? err.message : String(err));
+    }
+  })();
+
+  return { jobId };
+}

--- a/src/desktop/src/main/updates/renderer-store.ts
+++ b/src/desktop/src/main/updates/renderer-store.ts
@@ -1,0 +1,102 @@
+/* ============================================================
+   热更新的界面层：把新版界面放进 userData，由 app:// 协议优先提供。
+
+   为什么这条路走得通，而整包自动更新走不通：界面本来就是一堆静态文件，我们用
+   自己的协议处理器提供，换一份再 reload 就完成了更新——**完全不碰已签名的
+   app bundle**。macOS 的整包自动更新要求 Developer ID 签名（Squirrel.Mac 会校验
+   下载包的签名并与运行中的 app 比对，ad-hoc 一律拒绝），而热更新绕开了这条限制。
+
+   代价与边界：
+   - 只能更新界面。preload、主进程、Electron 本身变了都必须走安装器，判据是
+     contract 版本（见 index.ts 的 canHotUpdate）。
+   - 热更新等于执行下载来的 JS，绕过了操作系统的代码签名校验。信任锚点是
+     HTTPS + GitHub Releases，且必须由用户在弹窗里显式确认。
+   - 加载失败要能退回：pointer 写在单独的文件里，回滚只是删掉它。
+   ============================================================ */
+
+import { app } from 'electron';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CONTRACT_VERSION } from '../../shared/contract';
+import { extractTarGz } from './tar';
+
+/** 更新包里必须带的元信息，解包后校验。 */
+export interface RendererMeta {
+  version: string;
+  /** 这份界面要求的 IPC 契约版本；高于当前外壳就不能热更。 */
+  contract: number;
+}
+
+interface Pointer extends RendererMeta {
+  dir: string;
+}
+
+function baseDir(): string {
+  return join(app.getPath('userData'), 'renderer');
+}
+
+function pointerPath(): string {
+  return join(baseDir(), 'active.json');
+}
+
+function readPointer(): Pointer | null {
+  try {
+    const p = JSON.parse(readFileSync(pointerPath(), 'utf8')) as Pointer;
+    return p && typeof p.dir === 'string' && existsSync(join(p.dir, 'index.html')) ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 当前应当提供的界面目录；没有可用的热更新版本时返回 null，调用方回落到包内资源。
+ * 契约版本在这里再查一次：外壳可能被整包更新降级过，留着的旧 pointer 不能生效。
+ */
+export function stagedRendererDir(): string | null {
+  const p = readPointer();
+  if (!p) return null;
+  if (p.contract > CONTRACT_VERSION) return null;
+  return p.dir;
+}
+
+export function stagedVersion(): string | null {
+  return readPointer()?.version ?? null;
+}
+
+/** 解包并启用一份新界面。抛错即视为失败，调用方不应切换。 */
+export function stageRenderer(archive: Buffer, expected: RendererMeta): void {
+  const dir = join(baseDir(), expected.version);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+
+  const files = extractTarGz(archive, dir);
+  if (!files.includes('index.html')) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('update package has no index.html');
+  }
+
+  // 包里自带的 meta 必须与 release 上声明的一致，否则说明拿错了包
+  let meta: RendererMeta;
+  try {
+    meta = JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf8')) as RendererMeta;
+  } catch {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('update package has no meta.json');
+  }
+  if (meta.version !== expected.version || meta.contract !== expected.contract) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error('update package metadata does not match the release');
+  }
+
+  writeFileSync(pointerPath(), JSON.stringify({ ...meta, dir }), 'utf8');
+}
+
+/** 回滚到包内自带的界面。加载失败时由 window.ts 调用。 */
+export function clearStagedRenderer(): void {
+  try {
+    rmSync(pointerPath(), { force: true });
+  } catch {
+    /* 删不掉也不该阻断启动 */
+  }
+}

--- a/src/desktop/src/main/updates/tar.ts
+++ b/src/desktop/src/main/updates/tar.ts
@@ -1,0 +1,81 @@
+/* ============================================================
+   最小 tar.gz 解包器。
+
+   为什么自己写：这个包一直是零运行时依赖（见 store.ts 里不引 electron-store 的
+   理由），而 Node 没有内置 tar。tar 格式本身很简单——512 字节头 + 512 对齐的
+   数据块——真正需要小心的只有安全边界，那部分不该外包给一个不看源码的依赖。
+
+   解包对象是从网络下载的更新包，所以按不可信输入对待：
+   - 逐条目校验归一化后的路径仍在目标目录内（zip-slip）
+   - 只接受普通文件与目录，跳过软链/硬链/设备文件——软链是穿越的另一条路
+   - 限制单文件与总解包体积，避免解压炸弹
+   ============================================================ */
+
+import { gunzipSync } from 'node:zlib';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, normalize, sep } from 'node:path';
+
+const BLOCK = 512;
+const MAX_FILE_BYTES = 64 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 256 * 1024 * 1024;
+
+function readString(buf: Buffer, offset: number, length: number): string {
+  const raw = buf.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.length : end).toString('utf8');
+}
+
+/** tar 的 size 字段是 8 进制 ASCII。 */
+function readOctal(buf: Buffer, offset: number, length: number): number {
+  const text = readString(buf, offset, length).trim();
+  return text ? parseInt(text, 8) || 0 : 0;
+}
+
+/**
+ * 把 tar.gz 解到 destination。返回写出的相对路径列表。
+ * 任何越界或不支持的条目都直接抛错——更新包宁可整体失败，也不要半个。
+ */
+export function extractTarGz(archive: Buffer, destination: string): string[] {
+  const tar = gunzipSync(archive);
+  const root = normalize(destination);
+  const written: string[] = [];
+  let total = 0;
+
+  for (let offset = 0; offset + BLOCK <= tar.length; ) {
+    const header = tar.subarray(offset, offset + BLOCK);
+    // 连续两个空块 = 归档结束
+    if (header.every((b) => b === 0)) break;
+
+    const name = readString(header, 0, 100);
+    const size = readOctal(header, 124, 12);
+    const typeflag = readString(header, 156, 1) || '0';
+    const prefix = readString(header, 345, 155);
+    const rel = prefix ? `${prefix}/${name}` : name;
+    offset += BLOCK;
+
+    if (!rel) throw new Error('tar: empty entry name');
+    if (size < 0 || size > MAX_FILE_BYTES) throw new Error(`tar: entry too large: ${rel}`);
+    total += size;
+    if (total > MAX_TOTAL_BYTES) throw new Error('tar: archive exceeds size limit');
+
+    const target = normalize(join(root, rel));
+    if (target !== root && !target.startsWith(root + sep)) {
+      throw new Error(`tar: entry escapes destination: ${rel}`);
+    }
+
+    if (typeflag === '5') {
+      mkdirSync(target, { recursive: true });
+    } else if (typeflag === '0' || typeflag === '') {
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, tar.subarray(offset, offset + size));
+      written.push(rel);
+    } else {
+      // 1=硬链 2=软链 3/4=设备 6=fifo：更新包里不该出现，出现即视为异常
+      throw new Error(`tar: unsupported entry type '${typeflag}': ${rel}`);
+    }
+
+    offset += Math.ceil(size / BLOCK) * BLOCK;
+  }
+
+  return written;
+}

--- a/src/desktop/src/main/window.ts
+++ b/src/desktop/src/main/window.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen, shell } from 'electron';
 import { join } from 'node:path';
 
 import { APP_INDEX, APP_ORIGIN } from './protocol';
+import { clearStagedRenderer, stagedRendererDir } from './updates/renderer-store';
 import { readConfig, writeConfig, type WindowState } from './store';
 
 let current: BrowserWindow | null = null;
@@ -92,6 +93,15 @@ export function createWindow(): BrowserWindow {
   // 当前不需要摄像头/麦克风/定位等任何权限，默认全拒。
   win.webContents.session.setPermissionRequestHandler((_wc, _permission, callback) => {
     callback(false);
+  });
+
+  // 热更新装上的界面若加载不起来，退回包内自带的那份再重来一次。
+  // 只挡主框架的失败；子资源 404 由协议处理器各自处理，不该整窗回滚。
+  win.webContents.on('did-fail-load', (_e, code, desc, url, isMainFrame) => {
+    if (!isMainFrame || !stagedRendererDir()) return;
+    console.error(`[polaris] 界面加载失败（${code} ${desc} ${url}），回滚到内置版本`);
+    clearStagedRenderer();
+    void win.loadURL(APP_INDEX);
   });
 
   win.on('close', () => persistBounds(win));

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -58,6 +58,22 @@ export interface LatexCompileInput {
   engine: 'tectonic' | 'pdflatex' | 'xelatex' | 'lualatex';
 }
 
+/** 更新检查结果。available=false 时其余字段无意义。 */
+export interface UpdateInfo {
+  available: boolean;
+  currentVersion: string;
+  latestVersion?: string;
+  /** release 正文，直接当 markdown 渲染。 */
+  notes?: string;
+  publishedAt?: string;
+  /** hot=换界面即可、免重启；full=要装安装器。 */
+  kind?: 'hot' | 'full';
+  /** 该更新要求的 IPC 契约版本。 */
+  contract?: number;
+  downloadUrl?: string;
+  downloadSize?: number;
+}
+
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */
 export type ServerProbe =
   | { ok: true; version: string }
@@ -76,6 +92,10 @@ export interface Methods {
   /** Dock/任务栏角标（待审批数）。Windows 需 overlay icon，一期不做，静默忽略。 */
   'host.setBadgeCount': { params: { count: number }; result: void };
   'host.capabilities': { params: void; result: CapabilityManifest };
+  /** 查有没有新版本。失败一律当作「没有更新」，不打扰用户。 */
+  'host.update.check': { params: void; result: UpdateInfo };
+  /** 下载并应用上一次检查到的更新；进度走 job.* 事件。 */
+  'host.update.apply': { params: void; result: JobHandle };
 
   /* ---- local.*：第二期的本地计算能力 ----
      现在全部声明但不实现（一律抛 ERR_CAPABILITY_UNAVAILABLE），目的是把

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -15,12 +15,16 @@
    ============================================================ */
 
 import { BrowserWindow, app } from 'electron';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
+import { extractTarGz } from './main/updates/tar';
 import { APP_INDEX, buildCsp, handleAppProtocol, registerAppScheme } from './main/protocol';
 
 const SERVER_URL = 'https://polaris.example.edu';
@@ -313,6 +317,50 @@ void app.whenReady().then(async () => {
     for (const m of consoleErrors.slice(0, 20)) console.log('  -', m);
   }
   check('渲染进程无 console 错误', consoleErrors.length === 0);
+
+  // 更新包是从网络下载的，解包器按不可信输入处理。这段跑在主进程里，可以直接
+  // 调到解包函数，所以把安全边界直接测了，而不是只测「功能能用」。
+  console.log('\n更新包解包（安全边界）');
+  const tarEntry = (name: string, body: string, typeflag = '0'): Buffer => {
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, 'utf8');
+    header.write('000644 \0', 100, 8, 'utf8');
+    header.write(body.length.toString(8).padStart(11, '0') + ' ', 124, 12, 'utf8');
+    header.write(typeflag, 156, 1, 'utf8');
+    const data = Buffer.alloc(Math.ceil(body.length / 512) * 512);
+    data.write(body, 0, 'utf8');
+    return Buffer.concat([header, data]);
+  };
+  const gzip = (b: Buffer) => gzipSync(b);
+  const scratch = mkdtempSync(join(tmpdir(), 'polaris-tar-'));
+
+  const okArchive = gzip(Buffer.concat([tarEntry('meta.json', '{}'), Buffer.alloc(1024)]));
+  let extracted: string[] = [];
+  try {
+    extracted = extractTarGz(okArchive, scratch);
+  } catch (err) {
+    extracted = [`threw: ${String(err)}`];
+  }
+  check('正常包可解出文件', extracted.includes('meta.json'), `files=${extracted.join(',')}`);
+
+  const rejects = (label: string, archive: Buffer) => {
+    let threw = false;
+    try {
+      extractTarGz(archive, scratch);
+    } catch {
+      threw = true;
+    }
+    check(label, threw);
+  };
+  rejects(
+    '拒绝路径穿越条目（../evil）',
+    gzip(Buffer.concat([tarEntry('../evil.txt', 'x'), Buffer.alloc(1024)])),
+  );
+  rejects(
+    '拒绝软链条目（可绕过路径检查）',
+    gzip(Buffer.concat([tarEntry('link', '', '2'), Buffer.alloc(1024)])),
+  );
+  rmSync(scratch, { recursive: true, force: true });
 
   if (process.env.POLARIS_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { PolarisMark, PolarisWordmark } from '../components/ui/PolarisLogo';
 import { Drawer } from '../components/ui/Drawer';
 import { GateCard, gateTitle } from '../components/ui/GateCard';
 import { ToastHost, toast } from '../components/ui/Toast';
+import { UpdateBadge } from '../components/ui/UpdateBadge';
 import { useAuth } from './auth';
 import { topicPath, useProject } from './project';
 import { SearchPalette } from './SearchPalette';
@@ -606,6 +607,7 @@ export function AppShell() {
           )}
           <LangToggle />
           <FeedbackWidget />
+          <UpdateBadge />
           <button className="icon-btn" onClick={() => openGates(null)} title={tr('审批中心', 'Approvals')}>
             <Icon name="bell" size={16} />
             {pending.length > 0 && <span className="badge">{pending.length}</span>}

--- a/src/frontend/src/components/ui/UpdateBadge.tsx
+++ b/src/frontend/src/components/ui/UpdateBadge.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { Icon } from './Icon';
+import { Modal } from './Modal';
+import { toast } from './Toast';
+import { fmtTime } from '../../lib/format';
+import { checkUpdate, type UpdateInfo } from '../../lib/host';
+import { invokeJob } from '../../lib/host-jobs';
+import { Markdown } from '../../lib/markdown';
+import { tr } from '../../lib/i18n';
+
+/** 启动后延迟一会儿再查，别和首屏的数据请求抢；之后每 6 小时查一次。 */
+const FIRST_CHECK_MS = 20_000;
+const INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * 有新版本时在顶栏显示一个向上的箭头，点开是更新说明 + 确认/取消。
+ *
+ * 两种更新方式由主进程判定（见 src/desktop/src/main/updates）：
+ * - hot：只有界面变了，下载完直接换上并 reload，**不重启**；
+ * - full：preload/主进程也变了，只能装安装器，Windows 会自动拉起、macOS 打开 dmg。
+ *
+ * web 端 checkUpdate() 返回 null，整个组件不渲染。
+ */
+export function UpdateBadge() {
+  const [info, setInfo] = useState<UpdateInfo | null>(null);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [percent, setPercent] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const next = await checkUpdate();
+      if (!cancelled && next?.available) setInfo(next);
+    };
+    const first = setTimeout(() => void run(), FIRST_CHECK_MS);
+    const timer = setInterval(() => void run(), INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(first);
+      clearInterval(timer);
+    };
+  }, []);
+
+  if (!info?.available) return null;
+
+  const start = () => {
+    setBusy(true);
+    setPercent(0);
+    invokeJob('host.update.apply', undefined, {
+      onProgress: (p) => setPercent(p.total ? Math.round((p.done / p.total) * 100) : 0),
+      onDone: (result) => {
+        const hot = (result as { reloaded?: boolean } | null)?.reloaded === true;
+        setBusy(false);
+        setOpen(false);
+        // 热更新走到这里时窗口已经在重载，提示多半来不及看到——不影响正确性
+        if (!hot) {
+          toast(
+            tr('安装包已下载，按提示完成安装', 'Installer downloaded — follow the prompts'),
+            'ok',
+          );
+        }
+      },
+      onError: (_code, message) => {
+        setBusy(false);
+        toast(`${tr('更新失败', 'Update failed')}：${message}`, 'error');
+      },
+    });
+  };
+
+  const hot = info.kind === 'hot';
+
+  return (
+    <>
+      <button
+        className="icon-btn update-badge"
+        onClick={() => setOpen(true)}
+        title={`${tr('有新版本', 'Update available')} ${info.latestVersion ?? ''}`}
+        aria-label={tr('有新版本', 'Update available')}
+      >
+        {/* 没有专门的上箭头图标，用 chevron 旋转 */}
+        <Icon name="chevron" size={16} style={{ transform: 'rotate(-90deg)' }} />
+        <span className="badge dot-badge" />
+      </button>
+
+      <Modal
+        open={open}
+        onClose={() => !busy && setOpen(false)}
+        title={`${tr('有新版本', 'Update available')} · v${info.latestVersion}`}
+        sub={
+          <>
+            {tr('当前', 'Current')} v{info.currentVersion}
+            {info.publishedAt ? ` · ${fmtTime(info.publishedAt)}` : ''}
+            {' · '}
+            {hot
+              ? tr('本次更新无需重启', 'Applies without restarting')
+              : tr('本次更新需要重新安装', 'Requires reinstalling the app')}
+          </>
+        }
+        width={600}
+        footer={
+          <div className="row gap8" style={{ justifyContent: 'flex-end' }}>
+            {busy && (
+              <span style={{ marginRight: 'auto', fontSize: 12.5, color: 'var(--text-3)' }}>
+                {tr('下载中', 'Downloading')} {percent}%
+              </span>
+            )}
+            <button className="btn" onClick={() => setOpen(false)} disabled={busy}>
+              {tr('取消', 'Cancel')}
+            </button>
+            <button className="btn btn-primary" onClick={start} disabled={busy}>
+              <Icon name="download" size={14} />
+              {busy ? tr('更新中…', 'Updating…') : tr('立即更新', 'Update now')}
+            </button>
+          </div>
+        }
+      >
+        {info.notes ? (
+          <Markdown source={info.notes} />
+        ) : (
+          <p style={{ color: 'var(--text-3)' }}>{tr('本次更新没有说明', 'No release notes')}</p>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -118,6 +118,35 @@ export async function invokeHost(method: string, params?: unknown): Promise<unkn
   return await b.invoke(method, params);
 }
 
+/* —— 应用更新 —— */
+
+export interface UpdateInfo {
+  available: boolean;
+  currentVersion: string;
+  latestVersion?: string;
+  notes?: string;
+  publishedAt?: string;
+  /** hot=换界面即可、免重启；full=要装安装器。 */
+  kind?: 'hot' | 'full';
+  contract?: number;
+  downloadUrl?: string;
+  downloadSize?: number;
+}
+
+/** 查有没有新版本；web 端返回 null。主进程失败时返回 available:false，不抛错。 */
+export async function checkUpdate(): Promise<UpdateInfo | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('host.update.check')) as UpdateInfo;
+}
+
+/** 下载并应用更新，返回 JobHandle；进度经 job.* 事件推送（用 invokeJob 更方便）。 */
+export async function applyUpdate(): Promise<{ jobId: string } | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('host.update.apply')) as { jobId: string };
+}
+
 /** 订阅宿主事件，返回取消订阅函数（web 端返回 no-op）。 */
 export function onHostEvent(handler: (event: HostEvent) => void): () => void {
   const b = bridge();

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -281,6 +281,14 @@ input {
 .crumb .sep { color: var(--text-4); }
 .topbar .spacer { flex: 1; }
 
+/* 更新提示：箭头按钮右上角的小圆点（区别于审批的数字 badge） */
+.update-badge { position: relative; }
+.update-badge .dot-badge {
+  position: absolute; top: 5px; right: 5px;
+  width: 7px; height: 7px; min-width: 0; padding: 0;
+  border-radius: 50%; background: var(--accent);
+}
+
 .searchbox {
   display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 11px;
   background: var(--surface-2); border: 0.5px solid var(--border-2); border-radius: 8px;


### PR DESCRIPTION
Adds update detection, an arrow in the toolbar when one is available, and a dialog with the release notes plus confirm/cancel.

## The constraint that shaped it

**Silent auto-update is impossible on macOS for these builds.** electron-updater goes through Squirrel.Mac, which verifies the Developer ID signature of the downloaded build against the running app; ad-hoc signed bundles are refused. The repository has no signing credentials, so "confirm and it just updates" cannot mean "replace the app" on macOS.

Rather than degrade to *download the dmg yourself* everywhere, updates take one of two paths.

## Frontend-only releases apply hot — no restart, macOS included

The renderer is already a directory of static files served through our own `app://` handler. A new one is downloaded into `userData`, the handler starts serving it, and the window reloads. **Nothing touches the signed bundle**, which is precisely why this works where the installer path does not.

Whether a release qualifies is decided by `CONTRACT_VERSION` — the existing preload agreement between shell and renderer. A renderer that demands a newer contract than the running shell cannot be hot-applied and falls back to the installer. CI encodes it in the asset name (`renderer-<version>-c<contract>.tar.gz`) so the client can decide before downloading anything.

Everything else downloads the platform installer: Windows launches it directly (no signature needed), macOS opens the dmg for the user to drag.

## Trust model

Hot updating executes downloaded JavaScript outside the OS code-signing check. The trust anchor is HTTPS plus GitHub Releases, and it always requires explicit confirmation in the dialog — it is never silent.

The tar extractor is written against that threat model rather than for convenience: path containment per entry, no symlinks or device nodes (a symlink is the other way out of the destination), and size caps against decompression bombs. Zero runtime dependencies, consistent with the rest of this package.

A staged renderer that fails to load rolls back to the packaged one on `did-fail-load`, so a bad bundle cannot brick the app.

## Verification

Smoke covers the extractor's security boundary directly — it runs in the main process, so the function is called rather than exercised through the UI:

```
ok   正常包可解出文件
ok   拒绝路径穿越条目（../evil）
ok   拒绝软链条目（可绕过路径检查）
```

`tsc --noEmit` clean for both packages, `vite build` passes, full smoke passes.

**Not verified end to end.** The hot path cannot run until a release actually carries a `renderer-*.tar.gz`, which starts with this PR's CI change. The first real test is cutting a release after this merges and watching a client pick it up. The installer path on Windows is likewise untested — no machine here.
