### PR TITLE
fix(ui): breadcrumbs that follow the sidebar, a refresh button, folded metadata

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { NavLink, Outlet, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { Link, NavLink, Outlet, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon, type IconName } from '../components/ui/Icon';
 import { PolarisMark, PolarisWordmark } from '../components/ui/PolarisLogo';
@@ -33,6 +33,13 @@ interface NavEntry {
   en: string;
 }
 
+/** 侧栏三个分组的标题：面包屑第一段直接复用，保证两处永远对得上。 */
+const NAV_GROUPS = {
+  lab: { zh: '实验室', en: 'Lab' },
+  topic: { zh: '课题研究', en: 'Topic' },
+  personal: { zh: '个人', en: 'Personal' },
+} as const;
+
 // 实验室级导航：跨课题的公共资产（P5c 起为共享方向文献库列表）
 const NAV_LAB: NavEntry[] = [
   { to: '/lab', icon: 'flask', zh: '实验室工作台', en: 'Lab Workbench' },
@@ -43,6 +50,12 @@ const NAV_LAB: NavEntry[] = [
 const NAV_MAIN: NavEntry[] = [
   { icon: 'dashboard', zh: '课题工作台', en: 'Topic Workbench' },
   { sub: 'research', icon: 'pin', zh: '相关研究', en: 'Related Work' },
+];
+
+// 个人区：跨课题的个人页面（设置入口在底部头像菜单里，不重复占位）
+const NAV_PERSONAL: NavEntry[] = [
+  { to: '/library', icon: 'bookmark', zh: '我的文献库', en: 'My Library' },
+  { to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' },
 ];
 
 const NAV_PIPE: NavEntry[] = [
@@ -62,39 +75,86 @@ const FEATURE_BY_SUB: Record<string, string> = {
   'paper-review': 'paper_review',
 };
 
-function crumbFor(pathname: string): [string, string] {
-  // 课题作用域路径统一去掉 /t/<topicId> 前缀后按旧表匹配
+/** 面包屑一段；没有 to = 当前页（最后一段），不可点。 */
+interface Crumb {
+  label: string;
+  to?: string;
+}
+
+/**
+ * 侧栏条目 → 面包屑段：文案与跳转都取自 NAV_* 那一份定义，
+ * key 用条目的 to（实验室 / 个人）或 sub（课题作用域），课题工作台的 key 是空串。
+ */
+function navCrumb(key: string, pid: string | null): Crumb {
+  const entry = [...NAV_LAB, ...NAV_MAIN, ...NAV_PIPE, ...NAV_PERSONAL].find(
+    (n) => (n.to ?? n.sub ?? '') === key,
+  );
+  if (!entry) return { label: '—' };
+  return { label: tr(entry.zh, entry.en), to: entry.to ?? topicPath(pid, entry.sub) };
+}
+
+/**
+ * 当前路径 → 面包屑层级（分组 › 侧栏条目 › 当前实体），与侧栏三组保持一致。
+ * 分组段指向该组的落地页（实验室工作台 / 课题工作台 / 我的文献库）。
+ * libName：文献库详情页的库名（列表缓存里已有，取不到时退回通用文案）。
+ */
+function crumbsFor(pathname: string, pid: string | null, libName?: string | null): Crumb[] {
+  const lab: Crumb = { label: tr(NAV_GROUPS.lab.zh, NAV_GROUPS.lab.en), to: '/lab' };
+  const topic: Crumb = {
+    label: tr(NAV_GROUPS.topic.zh, NAV_GROUPS.topic.en),
+    to: pid ? topicPath(pid) : '/start',
+  };
+  const personal: Crumb = { label: tr(NAV_GROUPS.personal.zh, NAV_GROUPS.personal.en), to: '/library' };
+  const e = (key: string) => navCrumb(key, pid);
+
+  // 课题作用域路径统一去掉 /t/<topicId> 前缀后按同一张表匹配
   const scoped = /^\/t\/[^/]+(\/.*)?$/.exec(pathname);
   const p = scoped ? (scoped[1] ?? '/') : pathname;
-  if (p === '/') return ['Polaris', tr('课题工作台', 'Topic Workbench')];
-  if (p === '/start') return ['Polaris', tr('选择课题', 'Pick a topic')];
-  if (p === '/projects/new') return [tr('课题', 'Topics'), tr('新建课题', 'New topic')];
-  if (p.startsWith('/projects/')) return [tr('课题', 'Topics'), tr('课题设置', 'Topic settings')];
-  if (p === '/voyages') return ['Polaris', tr('任务', 'Tasks')];
-  if (p.startsWith('/voyages/')) return [tr('任务', 'Tasks'), tr('任务详情', 'Task detail')];
-  if (p.startsWith('/papers/')) return [tr('文献库', 'Libraries'), tr('论文阅读', 'Paper reading')];
-  if (p === '/libraries') return [tr('实验室', 'Lab'), tr('文献库', 'Libraries')];
-  if (p === '/daily') return [tr('实验室', 'Lab'), tr('每日新论文', 'Daily Papers')];
-  if (p.startsWith('/libraries/')) return [tr('文献库', 'Libraries'), tr('库详情', 'Library detail')];
-  if (p.startsWith('/ideas/')) return [tr('想法生成', 'Idea Forge'), tr('想法详情', 'Idea detail')];
-  if (p.startsWith('/join/')) return [tr('课题', 'Topics'), tr('接受邀请', 'Accept invite')];
-  if (p.startsWith('/experiment/')) return [tr('实验搭建', 'Experiment Lab'), tr('实验详情', 'Experiment detail')];
-  if (p.startsWith('/writer/')) return [tr('论文撰写', 'Paper Writer'), tr('编辑工作台', 'Editor workspace')];
-  const table: Record<string, [string, string]> = {
-    '/wiki': [tr('实验室', 'Lab'), tr('文献库', 'Libraries')],
-    '/research': [tr('课题研究', 'Topic'), tr('相关研究', 'Related Work')],
-    '/forge': ['Stage 01', tr('想法生成', 'Idea Forge')],
-    '/review': ['Stage 02', tr('想法评审', 'Idea Review')],
-    '/experiment': ['Stage 03', tr('实验搭建', 'Experiment Lab')],
-    '/writer': ['Stage 04', tr('论文撰写', 'Paper Writer')],
-    '/paper-review': ['Stage 05', tr('论文评审', 'Paper Review')],
-    '/library': ['Polaris', tr('我的文献库', 'My Library')],
-    '/skills': ['Polaris', tr('技能', 'Skills')],
-    '/settings': ['Polaris', tr('设置', 'Settings')],
-    '/admin': ['Polaris', tr('管理', 'Manage')],
-    '/lab': [tr('实验室', 'Lab'), tr('实验室工作台', 'Lab Workbench')],
-  };
-  return table[p] ?? ['Polaris', '—'];
+
+  const trail = ((): Crumb[] => {
+    // —— 课题研究组 ——
+    if (p === '/') return [topic, e('')];
+    if (p === '/research') return [topic, e('research')];
+    if (p === '/forge') return [topic, e('forge')];
+    if (p === '/review') return [topic, e('review')];
+    if (p === '/experiment') return [topic, e('experiment')];
+    if (p === '/writer') return [topic, e('writer')];
+    if (p === '/paper-review') return [topic, e('paper-review')];
+    if (p.startsWith('/ideas/')) return [topic, e('forge'), { label: tr('想法详情', 'Idea detail') }];
+    if (p.startsWith('/experiment/')) return [topic, e('experiment'), { label: tr('实验详情', 'Experiment detail') }];
+    if (p.startsWith('/writer/')) return [topic, e('writer'), { label: tr('编辑工作台', 'Editor workspace') }];
+    // 任务已并入课题工作台的「任务」标签
+    if (p === '/voyages') return [topic, e(''), { label: tr('任务', 'Tasks') }];
+    if (p.startsWith('/voyages/'))
+      return [
+        topic,
+        { ...e(''), to: topicPath(pid) + '?tab=tasks' },
+        { label: tr('任务详情', 'Task detail') },
+      ];
+    if (p === '/start') return [topic, { label: tr('选择课题', 'Pick a topic') }];
+    if (p === '/projects/new') return [topic, { label: tr('新建课题', 'New topic') }];
+    if (p.startsWith('/projects/')) return [topic, { label: tr('课题设置', 'Topic settings') }];
+    if (p.startsWith('/join/')) return [topic, { label: tr('接受邀请', 'Accept invite') }];
+
+    // —— 实验室组 ——
+    if (p === '/lab') return [lab, e('/lab')];
+    if (p === '/libraries' || p === '/wiki') return [lab, e('/libraries')];
+    if (p.startsWith('/libraries/'))
+      return [lab, e('/libraries'), { label: libName || tr('文献库详情', 'Library') }];
+    if (p === '/daily') return [lab, e('/daily')];
+    if (p.startsWith('/papers/')) return [lab, e('/libraries'), { label: tr('论文阅读', 'Paper reading') }];
+    if (p.startsWith('/concepts/')) return [lab, e('/libraries'), { label: tr('概念', 'Concept') }];
+
+    // —— 个人区 ——
+    if (p === '/library') return [personal, e('/library')];
+    if (p === '/skills') return [personal, e('/skills')];
+    if (p === '/settings') return [personal, { label: tr('设置', 'Settings') }];
+    if (p === '/admin') return [{ label: tr('管理', 'Manage') }];
+    return [{ label: 'Polaris' }];
+  })();
+
+  // 最后一段是当前页：去掉链接
+  return trail.map((c, i) => (i === trail.length - 1 ? { label: c.label } : c));
 }
 
 /** AppShell 通过 Outlet context 暴露给子页面的能力。 */
@@ -494,7 +554,29 @@ export function AppShell() {
     setBadgeCount(pending.length);
   }, [pending.length]);
 
-  const [c1, c2] = crumbFor(location.pathname);
+  // —— 面包屑（层级同侧栏）：文献库详情页多取一段库名，走详情页同一份缓存，不额外发请求 ——
+  const { currentProjectId } = useProject();
+  const crumbLibraryId = /^\/libraries\/([^/]+)$/.exec(location.pathname)?.[1] ?? null;
+  const { data: crumbLibrary } = useQuery({
+    queryKey: ['library', crumbLibraryId],
+    queryFn: () => api.getLibrary(crumbLibraryId ?? ''),
+    enabled: !!crumbLibraryId,
+    retry: false,
+    staleTime: 60_000,
+  });
+  const crumbs = crumbsFor(location.pathname, currentProjectId, crumbLibrary?.name);
+
+  // —— 刷新：让所有查询失效并重取（保留页面状态，不整页重载） ——
+  const [refreshing, setRefreshing] = useState(false);
+  async function refreshData() {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await queryClient.invalidateQueries();
+    } finally {
+      setRefreshing(false);
+    }
+  }
 
   const ctx: ShellContext = { pendingGates: pending, gatesError: pendingQuery.isError, openGates };
 
@@ -518,12 +600,12 @@ export function AppShell() {
         {/* —— 实验室 + 课题研究两组（平面分组，只靠 eyebrow + 间距区分，不加分隔线）。
             放在滚动区之外：课题切换器的下拉菜单要能向右溢出到主列上 —— */}
         <div className="sb-nav-static">
-          <div className="sb-section">{tr('实验室', 'Lab')}</div>
+          <div className="sb-section">{tr(NAV_GROUPS.lab.zh, NAV_GROUPS.lab.en)}</div>
           {NAV_LAB.map((n) => (
             <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
           ))}
 
-          <div className="sb-section">{tr('课题研究', 'Topic')}</div>
+          <div className="sb-section">{tr(NAV_GROUPS.topic.zh, NAV_GROUPS.topic.en)}</div>
           <TopicSwitcher collapsed={navCollapsed && !isMobile} />
           {NAV_MAIN.map((n) => (
             <NavItem key={n.sub ?? n.to ?? 'home'} n={n} />
@@ -539,9 +621,10 @@ export function AppShell() {
 
         {/* —— 个人区：跨课题的个人页面（设置入口在底部头像菜单里，不重复占位） —— */}
         <div className="sb-scroll scroll">
-          <div className="sb-section">{tr('个人', 'Personal')}</div>
-          <NavItem n={{ to: '/library', icon: 'bookmark', zh: '我的文献库', en: 'My Library' }} />
-          <NavItem n={{ to: '/skills', icon: 'sparkle', zh: '技能', en: 'Skills' }} />
+          <div className="sb-section">{tr(NAV_GROUPS.personal.zh, NAV_GROUPS.personal.en)}</div>
+          {NAV_PERSONAL.map((n) => (
+            <NavItem key={n.to} n={n} />
+          ))}
         </div>
         <div className="sb-foot">
           <UserMenu me={me} collapsed={navCollapsed && !isMobile} />
@@ -582,10 +665,22 @@ export function AppShell() {
             <Icon name="sidebar" size={16} />
           </button>
           <div className="crumb">
-            <span>{c1}</span>
-            <span className="sep">›</span>
-            <b>{c2}</b>
+            {crumbs.map((c, i) => (
+              <Fragment key={`${c.label}-${i}`}>
+                {i > 0 && <span className="sep">›</span>}
+                {c.to ? <Link to={c.to}>{c.label}</Link> : <b>{c.label}</b>}
+              </Fragment>
+            ))}
           </div>
+          <button
+            className="icon-btn crumb-refresh"
+            onClick={() => void refreshData()}
+            disabled={refreshing}
+            title={tr('刷新本页数据', 'Reload this page’s data')}
+            aria-label={tr('刷新本页数据', 'Reload this page’s data')}
+          >
+            <Icon name="refresh" size={15} style={refreshing ? { animation: 'spin 1s linear infinite' } : undefined} />
+          </button>
           <div className="spacer" />
           <div className="searchbox" role="button" tabIndex={0} onClick={() => setSearchOpen(true)}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSearchOpen(true); }}>

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -35,6 +35,7 @@ import {
   AffiliationChips,
   AuthorLinks,
   FilterInput,
+  MetaFold,
   MetaItem,
   SearchInput,
   SemanticSwitch,
@@ -409,8 +410,8 @@ function DailyDetailPane({
         <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
       )}
 
-      {/* —— frontmatter 风格元数据卡 —— */}
-      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
+      <MetaFold>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -424,14 +425,7 @@ function DailyDetailPane({
             <span className="muted">—</span>
           )}
         </MetaItem>
-        <MetaItem label={tr('编译时间', 'compiled at')}>
-          {paper.compiled_at ? (
-            <span className="mono">{fmtTime(paper.compiled_at)}</span>
-          ) : (
-            <span className="muted">{tr('未编译', 'not compiled')}</span>
-          )}
-        </MetaItem>
-      </div>
+      </MetaFold>
 
       {paper.abstract ? (
         <div className="card card-pad" style={{ background: 'var(--surface-2)', marginTop: 18 }}>

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -47,6 +47,7 @@ import {
   AffiliationChips,
   AuthorLinks,
   FilterInput,
+  MetaFold,
   MetaItem,
   MyTagField,
   ReadingStatusField,
@@ -373,8 +374,8 @@ function PaperDetailPane({
         invalidateKeys={listKeys}
       />
 
-      {/* —— frontmatter 风格元数据卡 —— */}
-      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
+      <MetaFold>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -392,14 +393,7 @@ function PaperDetailPane({
         <MetaItem label={tr('入库时间', 'added at')}>
           <span className="mono">{fmtTime(paper.created_at)}</span>
         </MetaItem>
-        <MetaItem label={tr('编译时间', 'compiled at')}>
-          {paper.compiled_at ? (
-            <span className="mono">{fmtTime(paper.compiled_at)}</span>
-          ) : (
-            <span className="muted">{tr('未编译', 'not compiled')}</span>
-          )}
-        </MetaItem>
-      </div>
+      </MetaFold>
 
       {/* —— 概念 chips（过多时折叠） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
-import { PageHead } from '../../components/ui/PageHead';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { api, isAdmin, type DirectionLibraryDetail } from '../../lib/api';
@@ -67,18 +66,7 @@ export function LibraryDetailPage() {
 
   return (
     <div className="page fadeup page-fill" style={{ maxWidth: 1360, paddingBottom: 24 }}>
-      <PageHead
-        eyebrow={tr('实验室 · 文献库', 'Lab · Library')}
-        title={lib.name}
-        dense
-        sub={lib.statement ?? undefined}
-        right={
-          <button className="btn btn-ghost" onClick={() => navigate('/libraries')}>
-            <Icon name="chevron" size={13} style={{ transform: 'rotate(180deg)' }} />
-            {tr('全部文献库', 'All libraries')}
-          </button>
-        }
-      />
+      {/* 库名与返回入口都在顶栏面包屑里（实验室 › 文献库 › 库名），页面不再单占一行 */}
       <StatusBanner lib={lib} />
       {canManage ? (
         <WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} canManage={canManage} />

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -22,7 +22,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
-import { AffiliationChips, AuthorLinks, usePoolConceptNav } from '../wiki/shared';
+import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
   ConceptChips,
   PaperMyMetaRow,
@@ -327,8 +327,8 @@ export function LibraryDetailPane({
         />
       )}
 
-      {/* —— frontmatter 风格元数据卡 —— */}
-      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+      {/* —— frontmatter 风格元信息（默认折叠） —— */}
+      <MetaFold>
         <MetaItem label="arxiv_id">
           {arxivId ? <span className="mono">{arxivId}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -342,7 +342,7 @@ export function LibraryDetailPane({
             <span className="mono">{snapshot.citedByCount}</span>
           </MetaItem>
         )}
-      </div>
+      </MetaFold>
 
       {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
       {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -13,6 +13,7 @@ import { type PaperConceptRef, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
 import { PaperMyTagsRow } from '../shared/PaperDetailBlocks';
+import { MetaFold } from '../wiki/shared';
 
 /* ============================================================
    阅读工作台 · 论文信息面板（PaperDetailPane 的精简版）：
@@ -132,8 +133,8 @@ export function InfoPanel({
         </a>
       )}
 
-      {/* —— 元数据卡 —— */}
-      <div className="card" style={{ margin: '14px 0 0', background: 'var(--surface-2)', padding: '10px 14px' }}>
+      {/* —— 元信息（默认折叠） —— */}
+      <MetaFold style={{ margin: '14px 0 0' }}>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -153,7 +154,7 @@ export function InfoPanel({
         <MetaItem label="ingested">
           <span className="mono">{fmtTime(paper.created_at)}</span>
         </MetaItem>
-      </div>
+      </MetaFold>
 
       {/* —— 我的标签：边读边打，只有自己看得到 —— */}
       {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -16,7 +16,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useLibraries } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
-import { AffiliationChips, AuthorLinks, usePoolConceptNav } from '../wiki/shared';
+import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
   ConceptChips,
   PaperMyMetaRow,
@@ -409,8 +409,8 @@ export function ShelfDetailPane({
         />
       )}
 
-      {/* —— frontmatter 风格元数据卡 —— */}
-      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+      {/* —— frontmatter 风格元信息（默认折叠） —— */}
+      <MetaFold>
         <MetaItem label="arxiv_id">
           {item.arxiv_id ? <span className="mono">{item.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -444,7 +444,7 @@ export function ShelfDetailPane({
             tr('手动添加', 'Added manually')
           )}
         </MetaItem>
-      </div>
+      </MetaFold>
 
       {/* —— 概念 chips：点了进不限库的概念页 —— */}
       <ConceptChips concepts={paper?.concepts} onOpen={openConcept} />

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -36,6 +36,7 @@ import {
   AffiliationChips,
   AuthorLinks,
   categoryMeta,
+  MetaFold,
   MetaItem,
   saveBlob,
   SearchInput,
@@ -864,8 +865,8 @@ function PaperDetailPane({
         invalidateKeys={[['papers', scopeId]]}
       />
 
-      {/* —— frontmatter 风格元数据卡 —— */}
-      <div className="card card-pad" style={{ margin: '18px 0 0', background: 'var(--surface-2)', padding: '14px 18px' }}>
+      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
+      <MetaFold>
         <MetaItem label="arxiv_id">{paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}</MetaItem>
         <MetaItem label="doi">{paper.doi ? <span className="mono">{paper.doi}</span> : <span className="muted">—</span>}</MetaItem>
         <MetaItem label="published">
@@ -881,14 +882,7 @@ function PaperDetailPane({
         <MetaItem label={tr('入库时间', 'added at')}>
           <span className="mono">{fmtTime(paper.created_at)}</span>
         </MetaItem>
-        <MetaItem label={tr('编译时间', 'compiled at')}>
-          {paper.compiled_at ? (
-            <span className="mono">{fmtTime(paper.compiled_at)}</span>
-          ) : (
-            <span className="muted">{tr('未编译', 'not compiled')}</span>
-          )}
-        </MetaItem>
-      </div>
+      </MetaFold>
 
       {/* —— 概念 chips（过多时折叠） —— */}
       {paper.concepts.length > 0 && (

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useState, type CSSProperties, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { api, type ConceptCategory, type PaperAuthor, type ReadingStatus } from '../../lib/api';
@@ -124,6 +124,36 @@ export function MetaItem({ label, children }: { label: string; children: ReactNo
       <span style={{ fontSize: 12.5, color: 'var(--text-2)', flex: 1, minWidth: 0, overflowWrap: 'break-word' }}>
         {children}
       </span>
+    </div>
+  );
+}
+
+/**
+ * 元信息折叠块：论文详情四处面板（论文库 / 只读库 / 阅读页 / 个人库 / 相关研究）共用的
+ * frontmatter 卡外壳。默认收起——这些字段查证时才看，别占着首屏。
+ */
+export function MetaFold({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div
+      className="card"
+      style={{ margin: '18px 0 0', background: 'var(--surface-2)', overflow: 'hidden', ...style }}
+    >
+      <div
+        className="row"
+        {...clickable(() => setOpen((o) => !o))}
+        style={{ padding: '9px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+      >
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', letterSpacing: '0.04em' }}>
+          {tr('元信息', 'Metadata')}
+        </span>
+        <Icon
+          name="chevDown"
+          size={13}
+          style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+        />
+      </div>
+      {open && <div style={{ padding: '0 16px 10px' }}>{children}</div>}
     </div>
   );
 }

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -66,6 +66,10 @@ html { zoom: 1.1; }
   -webkit-app-region: drag;
   align-self: stretch;
 }
+/* 面包屑的上级段是链接，落在拖拽区里会点不动 —— 单独还原成可点。 */
+:root[data-desktop-platform='darwin'] .topbar > .crumb a {
+  -webkit-app-region: no-drag;
+}
 body {
   font-family: var(--sans);
   color: var(--text);
@@ -297,8 +301,20 @@ input {
   position: relative; z-index: 20;
 }
 .crumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-3); }
-.crumb b { color: var(--text); font-weight: 600; }
+/* 末段可能是实体名（如库名），过长时截断，别把顶栏右侧挤没 */
+.crumb b {
+  color: var(--text); font-weight: 600;
+  max-width: 340px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 .crumb .sep { color: var(--text-4); }
+/* 上级段可点：负外边距让 hover 底色贴着文字长出来，不撑开行 */
+.crumb a {
+  color: inherit; text-decoration: none; border-radius: 6px;
+  padding: 2px 5px; margin: -2px -5px; transition: background .12s, color .12s;
+}
+.crumb a:hover { color: var(--accent-text); background: var(--surface-2); }
+/* 刷新按钮紧挨面包屑，不被中间的弹性空白推走 */
+.crumb-refresh { flex-shrink: 0; margin-left: -4px; }
 .topbar .spacer { flex: 1; }
 
 /* 更新提示：箭头按钮右上角的小圆点（区别于审批的数字 badge） */
@@ -1217,9 +1233,9 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
     padding-left: max(12px, env(safe-area-inset-left));
     padding-right: max(12px, env(safe-area-inset-right));
   }
-  /* 面包屑只留当前页，去掉上级与分隔符 */
+  /* 面包屑只留当前页，去掉上级链接与分隔符 */
   .crumb { min-width: 0; }
-  .crumb > span { display: none; }
+  .crumb > *:not(b) { display: none; }
   .crumb b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   /* 搜索框收成图标按钮（不改 DOM，只藏文字） */
   .searchbox {


### PR DESCRIPTION
## Breadcrumbs

They were two hard-coded strings per route, inventing a hierarchy the sidebar doesn't have: **"Stage 01 › Idea Forge"** when the sidebar shows neither the number nor a "pipeline" group, **"Polaris > Skills"** when the sidebar files Skills under personal. And **no segment was clickable** — a paper opened from a library had no way back to it.

Segments now derive from the same constants the sidebar renders (`NAV_GROUPS`, `NAV_LAB`, `NAV_MAIN`, `NAV_PIPE`), so the two can't drift again. Every segment except the last navigates.

```
实验室 › 文献库 › «library name»        ← middle segment goes to /libraries
课题研究 › 想法生成 › 想法详情          ← middle goes to that topic's forge
```

Two findings while aligning: the sidebar **never renders the 01–05 numbers**, and there is **no "pipeline" group** — the five stages render directly under 课题研究. Both were breadcrumb inventions and are gone.

## Refresh button

Invalidates all queries rather than reloading the page. These pages keep their tab, selection, expansion state and search terms in local state — a reload discards all of it, while the URL-driven parts (`?tab=`, `?paper=`) wouldn't change anyway. Spins while refetching.

## A library's detail page loses the row above its tabs

The name moves into the breadcrumb; **"‹ back to all libraries" is precisely what the breadcrumb's middle segment now does**; the eyebrow said "Lab · Library", which the first two segments already say. Tabs become the first row, matching my library.

## Metadata folds

arXiv id, DOI, dates are lookup fields, not things to read past on every visit. One shared component across all six detail panes.

**Compile time is dropped outright** — verified that the badge below already shows both the time and the model, so the row was pure duplication.

## Known consequence

A **read-only visitor no longer sees a library's one-line description** — it lived in the row that went, and the config tab where it also appears is manager-only. Putting it back means either a row only read-only visitors see, or keeping the old header for them; both make the two views diverge, so neither was done unasked.

## Verification

`tsc --noEmit` 0 errors, `npm run build` passes.