### PR TITLE
feat(search): index every paper, and show what is indexed

### DIFF
--- a/src/backend/alembic/versions/c4e7b2a91f38_paper_index_metadata.py
+++ b/src/backend/alembic/versions/c4e7b2a91f38_paper_index_metadata.py
@@ -1,0 +1,62 @@
+"""分段来源标记 + 向量构建元信息（索引状态展示与手动重建）
+
+文献对话只检索 paper_chunks，而分段过去只从 PDF 全文生成，没有全文的论文（每日推送
+尤其严重——抓取时根本不下 PDF）对检索完全不存在。改成每篇论文至少有一个可检索分段：
+有全文照旧按全文切，没有全文的用「标题 + 摘要」建一个块。
+
+① paper_chunks.source：fulltext | abstract，区分两类块。存量分段都来自全文，
+   server_default="fulltext" 直接回填；「这篇有没有全文索引」从此看它，不能只看
+   有没有分段行（否则摘要块会让论文永远拿不到全文块）。
+② papers 上四个向量元信息列：论文级向量与分块向量各自的构建时间与所用模型名。
+   embedding 列本身只有向量，没有时间也没有模型名，前端要显示「构建时间 + 模型」
+   就必须存。分块向量的元信息汇总记在 papers 上而不是每个 paper_chunks 行上——
+   分段行有百万量级，逐行存两列时间/模型名纯属浪费。
+
+存量数据的这四列留空（无从得知历史构建时间与模型），前端按「未构建」显示，重建一次
+即补齐。
+
+Revision ID: c4e7b2a91f38
+Revises: b6c2f81d4a09
+Create Date: 2026-07-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4e7b2a91f38"
+down_revision: str | None = "b6c2f81d4a09"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "paper_chunks",
+        sa.Column(
+            "source",
+            sa.String(length=16),
+            nullable=False,
+            server_default="fulltext",
+        ),
+    )
+    op.add_column("papers", sa.Column("embedding_model", sa.String(length=128), nullable=True))
+    op.add_column(
+        "papers", sa.Column("embedding_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "papers", sa.Column("chunk_embedding_model", sa.String(length=128), nullable=True)
+    )
+    op.add_column(
+        "papers", sa.Column("chunk_embedding_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("papers", "chunk_embedding_at")
+    op.drop_column("papers", "chunk_embedding_model")
+    op.drop_column("papers", "embedding_at")
+    op.drop_column("papers", "embedding_model")
+    op.drop_column("paper_chunks", "source")

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -27,13 +27,18 @@ from app.core.db import get_sessionmaker
 from app.models.activity import Activity
 from app.models.base import utcnow
 from app.models.library_direction import DirectionLibrary, LibraryPaper
-from app.models.paper import Paper, PaperChunk, new_paper
+from app.models.paper import Paper, new_paper
 from app.services.affiliations import (
     apply_author_affiliations,
     extract_author_affiliations_llm,
     get_affiliation_extraction_mode,
 )
-from app.services.chunks import embed_pending_chunks, index_paper_fulltext
+from app.services.chunks import (
+    embed_pending_chunks,
+    ensure_paper_chunks,
+    sync_abstract_chunk_vectors,
+    user_wants_fulltext_index,
+)
 from app.services.concepts import link_all_paper_concepts
 from app.services.dedup import pool_dedup_key
 from app.services.figure_annotate import annotate_figures, figures_annotated
@@ -46,7 +51,7 @@ from app.services.libraries import (
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
-from app.services.paper_enrich import paper_embedding_text
+from app.services.paper_enrich import paper_embedding_enabled, paper_embedding_text
 from app.services.paper_wiki import upsert_wiki
 from app.services.projects import DEFAULT_ARXIV_CATEGORIES
 from app.services.relevance import build_relevance_context, score_paper_relevance
@@ -733,27 +738,17 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     raise
                 except Exception:  # noqa: BLE001 — 机构补充尽力而为
                     logger.warning("affiliation enrich failed for %s", paper.id, exc_info=True)
-            # 全文分段索引（文献问答/idea 生成的知识底座）；失败不影响主流程。
-            # 内容池命中的论文可能已有分段（其他方向建的），有则直接复用不重建
-            if paper.full_text_path:
-                try:
-                    has_chunks = bool(
-                        (
-                            await session.execute(
-                                select(PaperChunk.id)
-                                .where(PaperChunk.paper_id == paper.id)
-                                .limit(1)
-                            )
-                        ).first()
-                    )
-                    if not has_chunks:
-                        await index_paper_fulltext(session, paper)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:  # noqa: BLE001
-                    failed.append(
-                        {"id": str(paper.id), "error": f"chunks: {type(e).__name__}: {e}"}
-                    )
+            # 分段索引（文献问答/idea 生成的知识底座）；失败不影响主流程。
+            # 有全文按全文切、没全文建「标题 + 摘要」兜底块；内容池命中的论文可能已有
+            # 全文分段（其他方向建的），有则直接复用不重建
+            try:
+                await ensure_paper_chunks(session, paper)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001
+                failed.append(
+                    {"id": str(paper.id), "error": f"chunks: {type(e).__name__}: {e}"}
+                )
             # 顺带提取候选图（基础信息 caption=null；筛选注释在 wiki.compile 后做）；
             # 失败不影响全文流程
             if paper.pdf_path and paper.figures is None:
@@ -932,6 +927,9 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         embedded = 0
         embed_error: str | None = None
         pending = [p for p in papers if p.embedding is None]
+        if pending and not await paper_embedding_enabled(session):
+            pending = []  # 管理员拉了论文级向量的总闸
+            embed_error = "paper embeddings disabled by administrator"
         if pending:
             # 文本口径与手动补全/每日池共用（services/paper_enrich.paper_embedding_text）
             texts = [paper_embedding_text(p) for p in pending]
@@ -943,8 +941,12 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     library_id=library.id,
                     voyage_id=ctx.run.id,
                 )
+                embed_model = await ctx.llm.model_name("embedding", billing_user_id)
+                now = utcnow()
                 for paper, vector in zip(pending, vectors, strict=True):
                     paper.embedding = vector
+                    paper.embedding_at = now
+                    paper.embedding_model = embed_model
                     embedded += 1
                 await session.commit()
             except asyncio.CancelledError:
@@ -954,20 +956,32 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             except Exception as e:  # noqa: BLE001 — 嵌入失败不影响上链结果
                 embed_error = f"{type(e).__name__}: {e}"
 
-        # 全文分段向量：补齐缺失的 chunk embedding（文献问答检索底座）。
+        # 摘要兜底块的向量 = 论文级向量的拷贝（零 token，不受任何开关控制），排在嵌入之后
+        await sync_abstract_chunk_vectors(session, paper_ids=[p.id for p in papers])
+        await session.commit()
+
+        # 分段向量：补齐缺失的 chunk embedding（文献问答检索底座）。受**发起人**的
+        # 「全文索引」开关控制（默认开）——与手动添加论文那条路径同一个开关，
+        # 免得同一个用户在两条路径上得到不一样的结果。公共库的账记系统（billing_user_id
+        # 为空），但发起人是有的，故开关按 ctx.run.created_by 取。
         # 最大化模式放开单次 2000 段的默认上限（否则大批量编译后向量长期欠账）
-        embed_kwargs: dict[str, Any] = (
-            {"limit": _UNLIMITED_CHUNK_SENTINEL} if _unlimited(_knobs(ctx)) else {}
-        )
-        chunks_embedded, chunk_embed_error = await embed_pending_chunks(
-            session,
-            library_id=library.id,
-            llm=ctx.llm,
-            user_id=billing_user_id,
-            project_id=ctx.run.project_id,
-            voyage_id=ctx.run.id,
-            **embed_kwargs,
-        )
+        chunks_embedded = 0
+        chunk_embed_error: str | None = None
+        if await user_wants_fulltext_index(session, ctx.run.created_by):
+            embed_kwargs: dict[str, Any] = (
+                {"limit": _UNLIMITED_CHUNK_SENTINEL} if _unlimited(_knobs(ctx)) else {}
+            )
+            chunks_embedded, chunk_embed_error = await embed_pending_chunks(
+                session,
+                library_id=library.id,
+                llm=ctx.llm,
+                user_id=billing_user_id,
+                project_id=ctx.run.project_id,
+                voyage_id=ctx.run.id,
+                **embed_kwargs,
+            )
+        else:
+            chunk_embed_error = "fulltext index disabled by user setting"
 
     return {
         "papers": len(papers),

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -1,4 +1,4 @@
-"""管理端全局设置路由（仅 role=admin）：机构抽取模式、每日新论文自动建向量等。"""
+"""管理端全局设置路由（仅 role=admin）：机构抽取模式、论文级向量总闸等。"""
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,14 +9,15 @@ from app.schemas.admin_settings import (
     AffiliationModeRead,
     AffiliationModeUpdate,
     DailyEmbedBackfillResult,
-    DailyEmbedRead,
-    DailyEmbedUpdate,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
+    PaperEmbeddingRead,
+    PaperEmbeddingUpdate,
 )
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
 from app.services import lab as lab_service
+from app.services import paper_enrich as paper_enrich_service
 
 router = APIRouter(
     prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
@@ -44,19 +45,22 @@ async def set_affiliation_mode(
     return AffiliationModeRead(mode=mode)
 
 
-@router.get("/daily-embed", response_model=DailyEmbedRead)
-async def get_daily_embed(session: AsyncSession = Depends(get_session)) -> DailyEmbedRead:
-    """每日新论文是否自动建向量（关着时每日语义检索只能命中已建向量的论文）。"""
-    return DailyEmbedRead(enabled=await daily_service.get_daily_embed_enabled(session))
+@router.get("/paper-embedding", response_model=PaperEmbeddingRead)
+async def get_paper_embedding(session: AsyncSession = Depends(get_session)) -> PaperEmbeddingRead:
+    """平台是否给论文建论文级向量（默认开，平台级总闸）。
+
+    前身是 /daily-embed（默认关、只管每日推送）；默认关意味着推送来的论文在语义检索里
+    根本搜不到，而只管一条路径也名不副实，故改名并扩到所有入库入口。"""
+    return PaperEmbeddingRead(enabled=await paper_enrich_service.paper_embedding_enabled(session))
 
 
-@router.put("/daily-embed", response_model=DailyEmbedRead)
-async def set_daily_embed(
-    payload: DailyEmbedUpdate,
+@router.put("/paper-embedding", response_model=PaperEmbeddingRead)
+async def set_paper_embedding(
+    payload: PaperEmbeddingUpdate,
     session: AsyncSession = Depends(get_session),
-) -> DailyEmbedRead:
-    return DailyEmbedRead(
-        enabled=await daily_service.set_daily_embed_enabled(session, payload.enabled)
+) -> PaperEmbeddingRead:
+    return PaperEmbeddingRead(
+        enabled=await paper_enrich_service.set_paper_embedding_enabled(session, payload.enabled)
     )
 
 

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -30,6 +30,8 @@ from app.schemas.paper import (
     PaperDetail,
     PaperFigure,
     PaperFiguresResponse,
+    PaperIndexRebuild,
+    PaperIndexStatusRead,
     PaperListPage,
     PaperManualCreate,
     PaperMyMetaRead,
@@ -46,6 +48,7 @@ from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
+from app.services import paper_index as paper_index_service
 from app.services import paper_wiki as paper_wiki_service
 from app.services import papers as papers_service
 from app.services import wiki_compile as wiki_compile_service
@@ -600,6 +603,55 @@ async def recompile_paper(
         logger.warning("recompile failed for paper %s", paper_id, exc_info=True)
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="COMPILE_FAILED") from e
     return await _paper_detail(session, paper, user.id)
+
+
+# ---- 索引状态与手动重建（docs/api-lit.md §9） ----
+
+
+@router.get("/papers/{paper_id}/index-status", response_model=PaperIndexStatusRead)
+async def get_paper_index_status(
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperIndexStatusRead:
+    """这篇论文的论文级向量与分块向量各自建没建、何时建的、用的哪个模型。
+
+    只读，权限与看论文本身一致（能看到就能看状态）。"""
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
+    status_ = await paper_index_service.get_index_status(session, view.paper)
+    return PaperIndexStatusRead.model_validate(status_, from_attributes=True)
+
+
+@router.post("/papers/{paper_id}/index/rebuild", response_model=PaperIndexStatusRead)
+async def rebuild_paper_index(
+    paper_id: uuid.UUID,
+    data: PaperIndexRebuild | None = None,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+) -> PaperIndexStatusRead:
+    """手动重建这篇论文的向量（有就覆盖，没有就新建），同步返回重建后的状态。
+
+    权限取「能看到这篇论文 + 有大模型使用权限」（require_llm_task），与重编译
+    （POST /papers/{id}/recompile）同一口径：都花 token、都是谁都能重跑以最新为准，
+    没有理由在这里额外要管理权——单篇重建的花费是一次嵌入调用，比重编译低一个量级，
+    而配额与锁定用户由 require_llm_task 统一挡住。
+    """
+    body = data or PaperIndexRebuild()
+    targets = {t for t, on in (("paper", body.paper_vector), ("chunks", body.chunks)) if on}
+    if not targets:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="NOTHING_TO_REBUILD")
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
+    try:
+        status_ = await paper_index_service.rebuild_index(
+            session,
+            view.paper,
+            llm=get_llm_router(),
+            targets=targets,
+            user_id=user.id,
+        )
+    except paper_index_service.IndexRebuildFailedError as e:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail=f"INDEX_REBUILD_FAILED:{e}") from e
+    return PaperIndexStatusRead.model_validate(status_, from_attributes=True)
 
 
 # ---- AI 伴读（docs/api-lit.md §3，SSE 流） ----

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -351,8 +351,9 @@ async def chat_with_personal_library(
 
 
 def _require_fulltext_index_enabled(user: User) -> None:
-    """可选全文索引门控：用户未在设置里开启 → 409。"""
-    if user.setting("chat_fulltext_index") is not True:
+    """全文索引门控：用户在设置里**显式关掉**才 409（默认开，与 chunks
+    .user_wants_fulltext_index 同一口径）。"""
+    if user.setting("chat_fulltext_index") is False:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INDEXING_DISABLED")
 
 
@@ -435,6 +436,7 @@ async def rebuild_fulltext_index(
             "papers_indexed": 0,
             "chunks_created": 0,
             "embedded": 0,
+            "abstract_vectors_copied": 0,
             "embed_error": None,
             "total_chunks": 0,
         }

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -230,6 +230,19 @@ class LLMRouter:
                     route = _FALLBACK_ROUTE
         return self._provider_for(route), route
 
+    async def model_name(self, stage: str, user_id: uuid.UUID | None = None) -> str | None:
+        """该环节实际会用到的模型名；未配置/不可用时 None（调用方只用于展示）。
+
+        ``embed()`` 只返回向量，模型名留在路由里；要把「这批向量是谁建的」记进库
+        （papers.embedding_model 等）就得单独问一次。resolve 有 60s 路由缓存，
+        额外开销可忽略。
+        """
+        try:
+            _, route = await self.resolve(stage, user_id)
+        except (NotImplementedError, LLMNotConfiguredError):
+            return None
+        return route.model
+
     async def _record_usage(
         self,
         *,

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -68,6 +68,13 @@ class Paper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 图片文件落 <data_dir>/papers/<paper_id>/figures/fig_<index>.png（路径不出 API）
     figures: Mapped[list[Any] | None] = mapped_column(JSONVariant)
     embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
+    # 论文级向量的构建元信息（前端索引状态悬浮显示）；存量数据 / 未建为 null
+    embedding_model: Mapped[str | None] = mapped_column(String(128))
+    embedding_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 分块向量最近一次补齐的元信息（分段本身在 paper_chunks，元信息汇总记这里，
+    # 避免在上百万分段行上各存一份时间/模型名）
+    chunk_embedding_model: Mapped[str | None] = mapped_column(String(128))
+    chunk_embedding_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     concepts: Mapped[list["Concept"]] = relationship(
         secondary=paper_concepts, back_populates="papers"
@@ -124,11 +131,20 @@ def new_paper(**fields: Any) -> Paper:
     return paper
 
 
-class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """论文全文分段（文献问答 / idea 生成的检索底座）。
+# 分段来源：fulltext=从 PDF 全文切分 | abstract=无全文时用标题+摘要兜底的单块
+CHUNK_SOURCES = ("fulltext", "abstract")
 
-    入库抽全文后确定性切分（services/chunks.py），embedding 由
-    wiki.link_concepts 步骤批量补齐（provider 不支持时留空，检索降级关键词）。
+
+class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """论文分段（文献问答 / idea 生成的检索底座）。
+
+    有全文时按全文确定性切分（services/chunks.py）；没有全文的论文退化为一个
+    「标题 + 摘要」块，保证每篇论文对检索都存在（否则每日推送这类不下 PDF 的
+    论文对文献对话完全不可见）。embedding 由 wiki.link_concepts 步骤批量补齐
+    （provider 不支持时留空，检索降级关键词）。
+
+    ``source`` 区分两类块：拿到 PDF 后重建分段会把摘要块整体替换为全文块，
+    「这篇有没有全文索引」也靠它判断（不能只看有没有分段行）。
     """
 
     __tablename__ = "paper_chunks"
@@ -139,6 +155,10 @@ class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     seq: Mapped[int] = mapped_column(nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
+    # 存量分段都来自全文，故 server_default="fulltext"
+    source: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="fulltext", server_default="fulltext"
+    )
     embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
 
 

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -15,13 +15,13 @@ class AffiliationModeUpdate(BaseModel):
     mode: AffiliationMode
 
 
-class DailyEmbedRead(BaseModel):
-    """每日新论文是否自动建向量（开了才能做语义检索；默认关）。"""
+class PaperEmbeddingRead(BaseModel):
+    """平台是否给论文建论文级向量（默认开）。关掉后语义检索只能命中已有向量的论文。"""
 
     enabled: bool
 
 
-class DailyEmbedUpdate(BaseModel):
+class PaperEmbeddingUpdate(BaseModel):
     enabled: bool
 
 

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -121,6 +121,33 @@ class PaperDetail(PaperRead):
         return v or []
 
 
+class VectorStatusRead(BaseModel):
+    """一种向量的状态（前端红绿点 + 悬浮显示构建时间与模型名）。"""
+
+    built: bool
+    built_at: datetime | None = None  # 存量数据没记过，为 null
+    model: str | None = None  # 构建所用嵌入模型名；存量数据为 null
+
+
+class PaperIndexStatusRead(BaseModel):
+    """单篇论文的索引状态（docs/api-lit.md §9）。"""
+
+    paper_vector: VectorStatusRead  # 论文级向量（标题+作者+摘要）
+    chunk_vector: VectorStatusRead  # 分块向量（文献对话检索底座）
+    chunk_count: int = 0
+    embedded_chunk_count: int = 0
+    has_fulltext: bool = False
+    # 分段来源：fulltext=按 PDF 全文切 | abstract=无全文时的标题+摘要兜底块 | null=还没分段
+    chunk_source: str | None = None
+
+
+class PaperIndexRebuild(BaseModel):
+    """要重建哪些向量；默认两种都建。"""
+
+    paper_vector: bool = True
+    chunks: bool = True
+
+
 class PaperUpdate(BaseModel):
     """人工纳入/排除。"""
 

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -1,8 +1,10 @@
-"""论文全文分段索引（文献知识底座，不 import fastapi）。
+"""论文分段索引（文献知识底座，不 import fastapi）。
 
 - 切分：确定性代码，按段落边界贪心打包到 ~CHUNK_TARGET_CHARS，超长段硬切带重叠；
+- 兜底：没有全文的论文退化成一个「标题 + 摘要」块（source="abstract"），保证每篇
+  论文对检索都存在——否则每日推送这类不下 PDF 的论文对文献对话完全不可见；
 - 嵌入：wiki.link_concepts 步骤批量补齐（provider 不支持时留空）；
-- 检索：postgres 走 pgvector 余弦，其他方言 / 无向量时降级关键词打分。
+- 检索：postgres 走 pgvector 余弦，其他方言 / 无向量时降级关键词打分（两类块不区分）。
 支撑文献库对话（services/library_chat.py）与后续 idea 生成等知识服务。
 """
 
@@ -17,6 +19,7 @@ from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.router import LLMRouter
+from app.models.base import utcnow
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperChunk
 
@@ -57,9 +60,24 @@ def split_text(full_text: str) -> list[str]:
     return chunks[:MAX_CHUNKS_PER_PAPER]
 
 
-async def replace_chunks(session: AsyncSession, paper: Paper, full_text: str) -> int:
-    """重建一篇论文的分段（旧分段删除；embedding 留空待批量补齐）。调用方负责 commit。
+def abstract_chunk_text(paper: Paper) -> str:
+    """没有全文时的兜底块文本 = 论文级向量的文本口径（标题 + 作者 + 摘要，截 2000 字）。
 
+    刻意与 ``paper_embedding_text`` 用同一份文本：兜底块的向量是**直接拷贝**论文级
+    向量的（见 :func:`sync_abstract_chunk_vectors`），文本口径不一致的话，块里写的
+    和向量表达的就不是一回事，检索命中后给模型的片段会对不上。
+    """
+    from app.services.paper_enrich import paper_embedding_text
+
+    return paper_embedding_text(paper).strip()
+
+
+async def replace_chunks(
+    session: AsyncSession, paper: Paper, full_text: str, *, source: str = "fulltext"
+) -> int:
+    """重建一篇论文的分段（旧分段**全部**删除；embedding 留空待批量补齐）。调用方负责 commit。
+
+    先删后建，所以拿到 PDF 后重建全文分段会把此前的摘要兜底块一并替换掉。
     入库前再清洗一遍控制字符：磁盘上历史抽取的 txt 可能仍带 0x00，postgres UTF8 会拒绝。
     """
     from app.services.literature.pdf_extract import sanitize_text
@@ -67,7 +85,7 @@ async def replace_chunks(session: AsyncSession, paper: Paper, full_text: str) ->
     await session.execute(delete(PaperChunk).where(PaperChunk.paper_id == paper.id))
     chunks = split_text(sanitize_text(full_text))
     for seq, chunk_text in enumerate(chunks):
-        session.add(PaperChunk(paper_id=paper.id, seq=seq, text=chunk_text))
+        session.add(PaperChunk(paper_id=paper.id, seq=seq, text=chunk_text, source=source))
     return len(chunks)
 
 
@@ -79,26 +97,116 @@ async def index_paper_fulltext(session: AsyncSession, paper: Paper) -> int:
     return await replace_chunks(session, paper, full_text)
 
 
-async def paper_has_chunks(session: AsyncSession, paper_id: uuid.UUID) -> bool:
-    """该论文是否已有分段行。用于「无块才切」——避免重切丢已补的块向量。"""
-    row = (
-        await session.execute(
-            select(PaperChunk.id).where(PaperChunk.paper_id == paper_id).limit(1)
+async def index_paper_abstract(session: AsyncSession, paper: Paper) -> int:
+    """无全文兜底：用标题+作者+摘要建**单个**块（source="abstract"）。调用方负责 commit。
+
+    向量**直接拷贝论文级向量**，不另调嵌入接口——两者文本口径完全相同，再算一遍纯属
+    浪费 token，还会让同一篇论文的两个向量出现细微差别。论文级向量此刻还没建好
+    （嵌入接口当时失败、或管理员关了总闸）就先留空，等下次
+    :func:`sync_abstract_chunk_vectors` 补上，不报错。
+
+    连标题都没有（脏数据）返回 0。已有的分段先删——调用方只在「没有全文块」时才走
+    到这里，删掉的至多是上一版摘要块。
+    """
+    text = abstract_chunk_text(paper)
+    if not text:
+        return 0
+    await session.execute(delete(PaperChunk).where(PaperChunk.paper_id == paper.id))
+    chunk = PaperChunk(
+        paper_id=paper.id, seq=0, text=text[:CHUNK_MAX_CHARS], source="abstract"
+    )
+    # 只在真有向量时才赋值：sqlite 分支 embedding 是 JSON 列，显式写 None 会存成
+    # JSON 'null' 而不是 SQL NULL，之后 `embedding IS NULL` 就再也筛不到这一行了。
+    if paper.embedding is not None:
+        chunk.embedding = paper.embedding
+        paper.chunk_embedding_at = paper.embedding_at
+        paper.chunk_embedding_model = paper.embedding_model
+    session.add(chunk)
+    return 1
+
+
+async def sync_abstract_chunk_vectors(
+    session: AsyncSession, *, paper_ids: list[uuid.UUID]
+) -> int:
+    """把论文级向量拷进还没有向量的摘要兜底块，返回补上的块数。调用方负责 commit。
+
+    零 token 开销，所以不受任何开关控制——摘要块的存在与否决定了这篇论文能不能被
+    文献对话检索到，不该因为用户关了「全文索引」（那管的是花钱建全文块向量）就退回
+    「整篇论文搜不到」。论文级向量必须先建好，故所有调用点都排在嵌入之后。
+    """
+    if not paper_ids:
+        return 0
+    rows = (
+        (
+            await session.execute(
+                select(PaperChunk, Paper)
+                .join(Paper, Paper.id == PaperChunk.paper_id)
+                .where(
+                    PaperChunk.paper_id.in_(list(set(paper_ids))),
+                    PaperChunk.source == "abstract",
+                    PaperChunk.embedding.is_(None),
+                    Paper.embedding.is_not(None),
+                )
+            )
         )
-    ).first()
-    return row is not None
+        .all()
+    )
+    for chunk, paper in rows:
+        chunk.embedding = paper.embedding
+        paper.chunk_embedding_at = paper.embedding_at
+        paper.chunk_embedding_model = paper.embedding_model
+    return len(rows)
+
+
+async def ensure_paper_chunks(session: AsyncSession, paper: Paper) -> int:
+    """确保论文有可检索分段，返回**新建**的块数（已就绪返回 0）。调用方负责 commit。
+
+    所有入库路径共用的统一入口：
+    - 有全文且尚无全文块 → 按全文切（顺带替换掉此前的摘要兜底块）；
+    - 有全文且已有全文块 → 不动（重切会丢已补的块向量）；
+    - 无全文且完全没有块 → 建一个「标题 + 摘要」兜底块。
+
+    注意判据是「有没有**全文**块」而不是「有没有块」：摘要兜底块一旦存在，按后者
+    判断的话这篇论文就再也拿不到全文分段了。
+    """
+    if paper.full_text_path and Path(paper.full_text_path).exists():
+        if await paper_has_chunks(session, paper.id, source="fulltext"):
+            return 0
+        return await index_paper_fulltext(session, paper)
+    if await paper_has_chunks(session, paper.id):
+        return 0
+    return await index_paper_abstract(session, paper)
+
+
+async def paper_has_chunks(
+    session: AsyncSession, paper_id: uuid.UUID, *, source: str | None = None
+) -> bool:
+    """该论文是否已有分段行（给了 source 就只看该来源的）。
+
+    用于「无块才切」——避免重切丢已补的块向量。
+    """
+    stmt = select(PaperChunk.id).where(PaperChunk.paper_id == paper_id)
+    if source is not None:
+        stmt = stmt.where(PaperChunk.source == source)
+    return (await session.execute(stmt.limit(1))).first() is not None
 
 
 async def user_wants_fulltext_index(
     session: AsyncSession, user_id: uuid.UUID | None
 ) -> bool:
-    """该用户是否开启了「为论文建立全文索引」（chat_fulltext_index）。user_id 空→False。"""
+    """该用户是否要为论文建分块向量（chat_fulltext_index）。**默认开**。
+
+    只有显式关掉（设置里存了 False）才不建；没设置过、查不到用户、以及无 user_id
+    的系统调用都按开处理——不建分块向量等于这篇论文对文献对话不可检索，那是坏默认。
+    """
     if user_id is None:
-        return False
+        return True
     from app.models.user import User
 
     user = await session.get(User, user_id)
-    return bool(user is not None and user.setting("chat_fulltext_index") is True)
+    if user is None:
+        return True
+    return user.setting("chat_fulltext_index") is not False
 
 
 async def _embed_chunks(
@@ -111,8 +219,12 @@ async def _embed_chunks(
     library_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> tuple[int, str | None]:
-    """分批嵌入给定的待补分段（调用方负责选出 pending），返回 (成功条数, 错误说明|None)。"""
+    """分批嵌入给定的待补分段（调用方负责选出 pending），返回 (成功条数, 错误说明|None)。
+
+    顺带把「分块向量建于何时、用的哪个模型」记到所属论文行上（前端索引状态展示用）。
+    """
     embedded = 0
+    model = await llm.model_name("embedding", user_id)
     for i in range(0, len(pending), EMBED_BATCH):
         batch = pending[i : i + EMBED_BATCH]
         try:
@@ -130,8 +242,28 @@ async def _embed_chunks(
         for chunk, vector in zip(batch, vectors, strict=True):
             chunk.embedding = vector
             embedded += 1
+        await _touch_chunk_embedding_meta(
+            session, {c.paper_id for c in batch}, model=model
+        )
         await session.commit()
     return embedded, None
+
+
+async def _touch_chunk_embedding_meta(
+    session: AsyncSession, paper_ids: set[uuid.UUID], *, model: str | None
+) -> None:
+    """记下这批论文的分块向量构建时间与模型名（调用方负责 commit）。"""
+    if not paper_ids:
+        return
+    now = utcnow()
+    papers = (
+        (await session.execute(select(Paper).where(Paper.id.in_(list(paper_ids)))))
+        .scalars()
+        .all()
+    )
+    for paper in papers:
+        paper.chunk_embedding_at = now
+        paper.chunk_embedding_model = model
 
 
 async def embed_pending_chunks(
@@ -154,7 +286,10 @@ async def embed_pending_chunks(
                 select(PaperChunk)
                 .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
                 .where(
-                    LibraryPaper.library_id == library_id, PaperChunk.embedding.is_(None)
+                    LibraryPaper.library_id == library_id,
+                    PaperChunk.embedding.is_(None),
+                    # 摘要兜底块的向量靠拷贝论文级向量（零开销），不走嵌入接口
+                    PaperChunk.source == "fulltext",
                 )
                 .order_by(PaperChunk.created_at, PaperChunk.seq)
                 .limit(limit)
@@ -194,7 +329,12 @@ async def embed_pending_chunks_for_papers(
         (
             await session.execute(
                 select(PaperChunk)
-                .where(PaperChunk.paper_id.in_(paper_ids), PaperChunk.embedding.is_(None))
+                .where(
+                    PaperChunk.paper_id.in_(paper_ids),
+                    PaperChunk.embedding.is_(None),
+                    # 摘要兜底块的向量靠拷贝论文级向量（零开销），不走嵌入接口
+                    PaperChunk.source == "fulltext",
+                )
                 .order_by(PaperChunk.created_at, PaperChunk.seq)
                 .limit(limit)
             )
@@ -220,23 +360,20 @@ async def rebuild_library_fulltext_index(
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
-    """重建某个库的全文分段索引（docs/api-lit.md §8）：给已有全文但缺分段的论文补分段并嵌入。
+    """重建某个库的分段索引（docs/api-lit.md §8）：给缺分段的论文补分段并嵌入。
 
-    幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
-    课题作用域与库作用域两个端点共用本函数（project_id 仅用于 LLM 用量记账归属）。
+    幂等：已有全文分段的论文跳过；没有全文的论文补一个「标题 + 摘要」兜底块，
+    这样整库论文都能被文献对话检索到。新入库论文由 ingest 流水线自动处理，
+    通常无需手动调用。课题作用域与库作用域两个端点共用本函数
+    （project_id 仅用于 LLM 用量记账归属）。
     paper_chunks 表尚未迁移时 ``ProgrammingError`` 原样上抛，由路由层转 503。
     """
-    chunked_ids = select(PaperChunk.paper_id)
     papers = (
         (
             await session.execute(
                 select(Paper)
                 .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(
-                    LibraryPaper.library_id == library_id,
-                    Paper.full_text_path.is_not(None),
-                    Paper.id.not_in(chunked_ids),
-                )
+                .where(LibraryPaper.library_id == library_id)
             )
         )
         .scalars()
@@ -245,7 +382,7 @@ async def rebuild_library_fulltext_index(
     indexed = 0
     chunk_count = 0
     for paper in papers:
-        n = await index_paper_fulltext(session, paper)
+        n = await ensure_paper_chunks(session, paper)
         if n:
             indexed += 1
             chunk_count += n
@@ -257,6 +394,11 @@ async def rebuild_library_fulltext_index(
         user_id=user_id,
         project_id=project_id,
     )
+    # 摘要兜底块不走嵌入接口，向量拷论文级向量（论文级向量也还没建的就先留空）
+    copied = await sync_abstract_chunk_vectors(
+        session, paper_ids=[p.id for p in papers]
+    )
+    await session.commit()
     total_chunks = int(
         (
             await session.execute(
@@ -270,7 +412,9 @@ async def rebuild_library_fulltext_index(
     return {
         "papers_indexed": indexed,
         "chunks_created": chunk_count,
+        # embedded 只数「花了嵌入调用的全文块」；摘要块的向量是拷来的，单列 copied
         "embedded": embedded,
+        "abstract_vectors_copied": copied,
         "embed_error": embed_error,
         "total_chunks": total_chunks,
     }

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -22,6 +22,7 @@ from typing import Any
 from sqlalchemy import String, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.base import utcnow
 from app.models.daily_feed import (
     DAILY_FEED_RETENTION_DAYS,
     DEFAULT_DAILY_CATEGORIES,
@@ -46,9 +47,10 @@ logger = logging.getLogger(__name__)
 
 CATEGORIES_SETTING_KEY = "daily_feed_categories"
 
-# 每日池论文是否自动建向量（管理员开关，默认关——每天上百篇，开了才花嵌入调用）
-EMBED_ENABLED_SETTING_KEY = "daily_feed_embed_enabled"
-DEFAULT_EMBED_ENABLED = False
+# 注：论文级向量的管理员开关已升格为平台总闸并改名（daily_feed_embed_enabled →
+# paper_embedding_enabled，默认从关改成开），见 services/paper_enrich.py。
+# 默认关意味着每日推送的论文连论文级向量都没有、语义检索里根本搜不到；而只管每日推送
+# 这一条路径也名不副实。本模块只管调用总闸，不再自己存开关。旧键的存量值不再读。
 
 # 批量嵌入的每批条数（与 chunks.EMBED_BATCH 对齐）
 EMBED_BATCH = 32
@@ -108,23 +110,6 @@ async def set_categories(session: AsyncSession, categories: list[str]) -> list[s
     return cleaned
 
 
-async def get_daily_embed_enabled(session: AsyncSession) -> bool:
-    """每日池论文是否自动建向量（默认关；非法存量值回落默认）。"""
-    row = await session.get(SystemSetting, EMBED_ENABLED_SETTING_KEY)
-    value = row.value if row is not None else None
-    return value if isinstance(value, bool) else DEFAULT_EMBED_ENABLED
-
-
-async def set_daily_embed_enabled(session: AsyncSession, enabled: bool) -> bool:
-    row = await session.get(SystemSetting, EMBED_ENABLED_SETTING_KEY)
-    if row is None:
-        session.add(SystemSetting(key=EMBED_ENABLED_SETTING_KEY, value=bool(enabled)))
-    else:
-        row.value = bool(enabled)
-    await session.commit()
-    return bool(enabled)
-
-
 # ---- 池论文向量（语义检索/池对话底座） ----
 
 
@@ -142,7 +127,10 @@ async def embed_papers_missing_vectors(
     if not paper_ids:
         return {"embedded": 0, "skipped": 0, "failed": 0}
     from app.core.llm.router import get_llm_router
-    from app.services.paper_enrich import paper_embedding_text
+    from app.services.paper_enrich import paper_embedding_enabled, paper_embedding_text
+
+    if not await paper_embedding_enabled(session):  # 管理员拉了总闸
+        return {"embedded": 0, "skipped": len(set(paper_ids)), "failed": 0}
 
     rows = (
         (await session.execute(select(Paper).where(Paper.id.in_(list(set(paper_ids))))))
@@ -171,10 +159,14 @@ async def embed_papers_missing_vectors(
             stats["failed"] += len(batch)
             continue
         try:
+            model = await llm.model_name("embedding", user_id)
+            now = utcnow()
             for (paper_id, _), vector in zip(batch, vectors, strict=True):
                 paper = await session.get(Paper, paper_id)
                 if paper is not None:
                     paper.embedding = vector
+                    paper.embedding_at = now
+                    paper.embedding_model = model
             await session.commit()
             stats["embedded"] += len(batch)
         except asyncio.CancelledError:
@@ -358,23 +350,67 @@ async def embed_touched_papers(
     paper_ids: list[uuid.UUID],
     user_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
-    """开了管理员开关才给本次涉及的池论文补建向量；返回 {enabled, embedded, failed}。
+    """给本次涉及的池论文建分段兜底块 + 论文级向量；返回 {enabled, embedded, failed, chunked}。
+
+    每日推送的论文抓取时不下 PDF，一篇全文都没有，过去又受一个默认关着的管理员开关
+    管着，于是这些论文既没有分段也没有论文级向量——对文献对话完全不存在。现在无条件
+    建（``enabled`` 恒为 True，保留字段是为了不动调用方与既有 observation 口径）。
 
     best-effort：向量化本来就是可选增强，失败只记日志并把原因放进 ``embed_error``
     （不放 ``error``——那会让任务这一步判失败）。
     """
     try:
-        if not await get_daily_embed_enabled(session):
-            return {"enabled": False, "embedded": 0, "failed": 0}
+        chunked = await ensure_chunks_for_papers(session, paper_ids=paper_ids)
         stats = await embed_papers_missing_vectors(
             session, paper_ids=paper_ids, user_id=user_id
         )
-        return {"enabled": True, "embedded": stats["embedded"], "failed": stats["failed"]}
+        # 兜底块的向量 = 刚建好的论文级向量的拷贝（零 token），故排在嵌入之后
+        from app.services.chunks import sync_abstract_chunk_vectors
+
+        await sync_abstract_chunk_vectors(session, paper_ids=paper_ids)
+        await session.commit()
+        return {
+            "enabled": True,
+            "embedded": stats["embedded"],
+            "failed": stats["failed"],
+            "chunked": chunked,
+        }
     except asyncio.CancelledError:
         raise
     except Exception as e:  # noqa: BLE001
         logger.warning("daily feed embedding step failed", exc_info=True)
         return {"enabled": True, "embedded": 0, "failed": 0, "embed_error": str(e)}
+
+
+async def ensure_chunks_for_papers(
+    session: AsyncSession, *, paper_ids: list[uuid.UUID]
+) -> int:
+    """给这批论文补可检索分段（没有全文→标题+摘要单块），返回新建了分段的篇数。
+
+    每日推送不下 PDF，这里建出来的基本都是摘要兜底块；日后真抓了 PDF，
+    ``ensure_paper_chunks`` 会用全文块把它整体替换掉。
+    """
+    if not paper_ids:
+        return 0
+    from app.services.chunks import ensure_paper_chunks
+
+    rows = (
+        (await session.execute(select(Paper).where(Paper.id.in_(list(set(paper_ids))))))
+        .scalars()
+        .all()
+    )
+    chunked = 0
+    for paper in rows:
+        try:
+            if await ensure_paper_chunks(session, paper):
+                chunked += 1
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — 单篇分段失败不打断整批
+            logger.warning("daily chunk indexing failed for paper %s", paper.id, exc_info=True)
+            await session.rollback()
+    await session.commit()
+    return chunked
 
 
 async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:

--- a/src/backend/app/services/fulltext_index.py
+++ b/src/backend/app/services/fulltext_index.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.router import LLMRouter
 from app.models.paper import Paper, PaperChunk
-from app.services.chunks import embed_pending_chunks_for_papers, index_paper_fulltext
+from app.services.chunks import embed_pending_chunks_for_papers, ensure_paper_chunks
 from app.services.papers import (
     PdfFetchFailedError,
     PdfSourceUnsupportedError,
@@ -43,9 +43,12 @@ async def index_papers_fulltext(
         if paper is None:
             skipped += 1
             continue
-        # 已建分段的论文不重建（index_paper_fulltext 会删旧分段，会连带丢已有向量）
+        # 已建**全文**分段的论文不重建（重切会连带丢已有向量）。判据不能是「有没有
+        # 分段」——没全文的论文有个摘要兜底块，按那个判会让它永远拿不到全文分段。
         existing = await session.scalar(
-            select(func.count()).select_from(PaperChunk).where(PaperChunk.paper_id == pid)
+            select(func.count())
+            .select_from(PaperChunk)
+            .where(PaperChunk.paper_id == pid, PaperChunk.source == "fulltext")
         )
         if existing:
             skipped += 1
@@ -62,9 +65,10 @@ async def index_papers_fulltext(
                 skipped += 1
                 continue
         try:
-            n = await index_paper_fulltext(session, paper)
+            # fetch_pdf 内部可能已经建好全文分段，ensure 在那种情况下返回 0 不重复切
+            n = await ensure_paper_chunks(session, paper)
         except Exception:  # noqa: BLE001 — 单篇分段异常不打断批处理
-            logger.warning("index_paper_fulltext failed for paper %s", pid, exc_info=True)
+            logger.warning("chunk indexing failed for paper %s", pid, exc_info=True)
             await session.rollback()
             skipped += 1
             continue

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.base import utcnow
 from app.models.library_direction import DirectionLibrary
 from app.models.paper import Paper
 
@@ -27,6 +28,34 @@ STAGES = ["download", "extract", "embed", "score"]
 
 # 论文级向量的文本上限（字符）
 EMBED_TEXT_MAX_CHARS = 2000
+
+# 论文级向量的平台总闸（管理员开关，**默认开**）：关掉后所有入库入口都不建论文级向量。
+# 前身是 daily_feed_embed_enabled（默认关、只管每日推送那一条路径）——默认关意味着
+# 推送来的论文在语义检索里根本搜不到，而只管一条路径又名不副实。旧键的存量值不迁移，
+# 读不到就取新默认（开）。
+PAPER_EMBEDDING_SETTING_KEY = "paper_embedding_enabled"
+DEFAULT_PAPER_EMBEDDING_ENABLED = True
+
+
+async def paper_embedding_enabled(session: AsyncSession) -> bool:
+    """平台是否建论文级向量（默认开；非法存量值回落默认）。"""
+    from app.models.system_setting import SystemSetting
+
+    row = await session.get(SystemSetting, PAPER_EMBEDDING_SETTING_KEY)
+    value = row.value if row is not None else None
+    return value if isinstance(value, bool) else DEFAULT_PAPER_EMBEDDING_ENABLED
+
+
+async def set_paper_embedding_enabled(session: AsyncSession, enabled: bool) -> bool:
+    from app.models.system_setting import SystemSetting
+
+    row = await session.get(SystemSetting, PAPER_EMBEDDING_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=PAPER_EMBEDDING_SETTING_KEY, value=bool(enabled)))
+    else:
+        row.value = bool(enabled)
+    await session.commit()
+    return bool(enabled)
 
 _OWNER_TTL_SECONDS = 600  # paper_task_owner 归属 key 存活时间
 
@@ -70,17 +99,21 @@ async def embed_paper(
 ) -> None:
     """为论文生成 Paper.embedding（文本口径见 paper_embedding_text）。
 
+    顺带记下构建时间与所用模型名（前端索引状态悬浮显示）。
     provider 不支持嵌入时抛 NotImplementedError（调用方按 skipped 处理）。
     """
     from app.core.llm.router import get_llm_router
 
-    vectors = await get_llm_router().embed(
+    llm = get_llm_router()
+    vectors = await llm.embed(
         [paper_embedding_text(paper)],
         user_id=user_id,
         project_id=project_id,
         library_id=library_id,
     )
     paper.embedding = vectors[0]
+    paper.embedding_at = utcnow()
+    paper.embedding_model = await llm.model_name("embedding", user_id)
 
 
 async def enrich_paper(
@@ -149,23 +182,20 @@ async def enrich_paper(
             paper = await _rollback_and_reload()
             await emit("extract", "error", f"{type(e).__name__}: {e}")
 
-    # 全文分块（文献问答底座）：抽到全文后就地建块，无块才切（避免重切丢已补的块向量）。
+    # 分块（文献问答底座）：有全文按全文切，没全文也建一个「标题 + 摘要」兜底块，
+    # 保证这篇论文对文献对话可检索。已有全文块则不重切（避免丢已补的块向量）。
     # 不单列可见进度阶段（STAGES 保持 download/extract/embed/score 不变）；块向量按用户开关
     # 在下面 embed 阶段之后补。best-effort：失败记日志、回滚重取，不阻断后续阶段。
-    if paper.full_text_path:
-        from app.services.chunks import index_paper_fulltext, paper_has_chunks
+    from app.services.chunks import ensure_paper_chunks
 
-        try:
-            if not await paper_has_chunks(session, paper_id):
-                await index_paper_fulltext(session, paper)
-                await session.commit()
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "enrich chunk indexing failed for paper %s", paper_id, exc_info=True
-            )
-            paper = await _rollback_and_reload()
+    try:
+        if await ensure_paper_chunks(session, paper):
+            await session.commit()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("enrich chunk indexing failed for paper %s", paper_id, exc_info=True)
+        paper = await _rollback_and_reload()
 
     # 作者↔机构：on_add 模式下全文到手且尚无机构时 LLM 补（非独立阶段，best-effort，不发
     # 事件）；on_compile 模式跳过，改由 wiki 编译折叠抽取
@@ -194,6 +224,8 @@ async def enrich_paper(
     await emit("embed", "running")
     if paper.embedding is not None:
         await emit("embed", "skipped", "already embedded")
+    elif not await paper_embedding_enabled(session):
+        await emit("embed", "skipped", "paper embeddings disabled by administrator")
     else:
         try:
             await embed_paper(
@@ -213,6 +245,19 @@ async def enrich_paper(
             logger.warning("enrich embed failed for paper %s", paper_id, exc_info=True)
             paper = await _rollback_and_reload()
             await emit("embed", "error", f"{type(e).__name__}: {e}")
+
+    # 摘要兜底块的向量 = 论文级向量的拷贝（零 token），故排在 embed 之后、不受开关控制。
+    # best-effort：拷不上就留空，下次补建时一起补。
+    try:
+        from app.services.chunks import sync_abstract_chunk_vectors
+
+        if await sync_abstract_chunk_vectors(session, paper_ids=[paper_id]):
+            await session.commit()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("abstract chunk vector sync failed for %s", paper_id, exc_info=True)
+        paper = await _rollback_and_reload()
 
     # 块向量：仅当用户开启全文索引开关时补（开关关只留块行，等重建/开开关再补）。
     # best-effort，不影响 embed 阶段判定；不发独立进度事件。

--- a/src/backend/app/services/paper_index.py
+++ b/src/backend/app/services/paper_index.py
@@ -1,0 +1,156 @@
+"""单篇论文的索引状态查询与手动重建（不 import fastapi）。
+
+论文有两种向量，各自可能缺席：
+- **论文级向量**（``papers.embedding``）：标题+作者+摘要一条向量，语义检索/去重用；
+- **分块向量**（``paper_chunks.embedding``）：分段各一条，文献对话检索用。
+
+两者的构建时间与模型名记在 ``papers`` 的四个元信息列上（见 models/paper.py），
+``embedding`` 列本身只有向量。存量数据这些列为空 → 前端按「未构建」显示，重建一次即补齐。
+
+单篇级操作在请求线程内做即可（一篇论文至多百来段，与重编译同量级），不必进 worker。
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.router import LLMRouter
+from app.models.paper import Paper, PaperChunk
+from app.services.chunks import (
+    embed_pending_chunks_for_papers,
+    index_paper_abstract,
+    replace_chunks,
+)
+from app.services.paper_enrich import embed_paper, paper_embedding_enabled
+
+logger = logging.getLogger(__name__)
+
+
+class IndexRebuildFailedError(Exception):
+    """请求的重建项全部失败（路由层转 502）。"""
+
+
+@dataclass
+class VectorStatus:
+    """一种向量的状态：有没有、什么时候建的、用的哪个模型。"""
+
+    built: bool
+    built_at: datetime | None
+    model: str | None
+
+
+@dataclass
+class PaperIndexStatus:
+    paper_vector: VectorStatus
+    chunk_vector: VectorStatus
+    chunk_count: int
+    embedded_chunk_count: int
+    has_fulltext: bool
+    chunk_source: str | None  # fulltext | abstract | None（还没有分段）
+
+
+async def get_index_status(session: AsyncSession, paper: Paper) -> PaperIndexStatus:
+    """查一篇论文的两种向量状态（两条聚合查询，不读向量本体）。"""
+    row = (
+        await session.execute(
+            select(
+                func.count(PaperChunk.id),
+                func.count(PaperChunk.embedding),  # count(col) 不计 NULL
+                func.max(PaperChunk.source),
+            ).where(PaperChunk.paper_id == paper.id)
+        )
+    ).one()
+    chunk_count, embedded_count, source = int(row[0]), int(row[1]), row[2]
+    return PaperIndexStatus(
+        paper_vector=VectorStatus(
+            built=paper.embedding is not None,
+            built_at=paper.embedding_at,
+            model=paper.embedding_model,
+        ),
+        chunk_vector=VectorStatus(
+            built=embedded_count > 0,
+            built_at=paper.chunk_embedding_at,
+            model=paper.chunk_embedding_model,
+        ),
+        chunk_count=chunk_count,
+        embedded_chunk_count=embedded_count,
+        has_fulltext=bool(paper.full_text_path),
+        chunk_source=source,
+    )
+
+
+async def rebuild_index(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    llm: LLMRouter,
+    targets: set[str],
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> PaperIndexStatus:
+    """手动重建这篇论文的向量，返回重建后的状态。调用方负责鉴权。
+
+    ``targets`` ⊆ {"paper", "chunks"}：
+    - paper：重算论文级向量（覆盖旧向量，无论有没有）；
+    - chunks：重切分段（有全文按全文、无全文用标题+摘要）后把全部分段重新嵌入。
+
+    「重建」是真重建：分段先删后建，向量整体覆盖，不做「只补缺失」的增量——用户点
+    这个按钮就是因为怀疑现有索引不对。单项失败不影响另一项，两项都失败才向上抛。
+    """
+    errors: list[str] = []
+
+    if "paper" in targets:
+        if not await paper_embedding_enabled(session):
+            errors.append("paper: 管理员已关闭论文级向量")
+        else:
+            try:
+                await embed_paper(paper, user_id=user_id, project_id=project_id)
+                await session.commit()
+            except Exception as e:  # noqa: BLE001 — provider 不支持嵌入等：记下继续
+                logger.warning("paper embedding rebuild failed for %s", paper.id, exc_info=True)
+                await session.rollback()
+                errors.append(f"paper: {type(e).__name__}: {e}")
+
+    if "chunks" in targets:
+        try:
+            await _rebuild_chunks(session, paper)
+            await session.commit()
+            # 分段是新的，embedding 全空 → 这里等价于「整篇重嵌」。摘要兜底块不走嵌入
+            # 接口，由 _rebuild_chunks 就地拷贝论文级向量（此刻刚重建过，是最新的）。
+            _, embed_error = await embed_pending_chunks_for_papers(
+                session,
+                paper_ids=[paper.id],
+                llm=llm,
+                user_id=user_id,
+                project_id=project_id,
+            )
+            if embed_error:
+                errors.append(f"chunks: {embed_error}")
+        except Exception as e:  # noqa: BLE001
+            logger.warning("chunk index rebuild failed for %s", paper.id, exc_info=True)
+            await session.rollback()
+            errors.append(f"chunks: {type(e).__name__}: {e}")
+
+    if errors and len(errors) == len(targets):
+        raise IndexRebuildFailedError("；".join(errors))
+    await session.refresh(paper)
+    return await get_index_status(session, paper)
+
+
+async def _rebuild_chunks(session: AsyncSession, paper: Paper) -> int:
+    """强制重切分段：有全文按全文重切，没有全文重建摘要兜底块。
+
+    两条路径都是「先删后建」（不走 ensure 的「已有块就跳过」），所以新分段的
+    embedding 一律为空，紧接着的重新嵌入就等价于覆盖旧向量——否则只补缺失，
+    点了重建却什么都没变。
+    """
+    from pathlib import Path
+
+    if paper.full_text_path and Path(paper.full_text_path).exists():
+        full_text = Path(paper.full_text_path).read_text(encoding="utf-8", errors="ignore")
+        return await replace_chunks(session, paper, full_text)
+    return await index_paper_abstract(session, paper)

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -935,23 +935,24 @@ async def fetch_pdf(
         paper.full_text_path = str(txt_path)
     except Exception:  # noqa: BLE001 — 抽取失败降级：仅有 PDF、无全文
         logger.warning("full text extraction failed for paper %s", paper.id, exc_info=True)
-    # 全文分段索引（文献问答底座）；失败不影响 PDF 落盘。无块才切，避免重切丢已补的块向量
-    if paper.full_text_path:
-        from app.services.chunks import index_paper_fulltext, paper_has_chunks
+    # 分段索引（文献问答底座）；失败不影响 PDF 落盘。抽到全文就按全文切（替换掉此前的
+    # 摘要兜底块）；已有全文块则不重切，避免丢已补的块向量
+    from app.services.chunks import ensure_paper_chunks
 
-        try:
-            if not await paper_has_chunks(session, paper.id):
-                await index_paper_fulltext(session, paper)
-        except Exception:  # noqa: BLE001
-            logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
-    # 论文级向量（此路径原先不建）：embedding 为空才补，best-effort，不影响 PDF 落盘
+    try:
+        await ensure_paper_chunks(session, paper)
+    except Exception:  # noqa: BLE001
+        logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
+    # 论文级向量（此路径原先不建）：embedding 为空、且管理员没关总闸才补。
+    # best-effort，不影响 PDF 落盘
     if paper.embedding is None:
-        from app.services.paper_enrich import embed_paper
+        from app.services.paper_enrich import embed_paper, paper_embedding_enabled
 
-        try:
-            await embed_paper(paper, user_id=user_id, project_id=project_id)
-        except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
-            logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
+        if await paper_embedding_enabled(session):
+            try:
+                await embed_paper(paper, user_id=user_id, project_id=project_id)
+            except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
+                logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
     # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
     # 机构）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响主流程
     if not paper.affiliations and paper.full_text_path:
@@ -968,26 +969,34 @@ async def fetch_pdf(
             )
             apply_author_affiliations(paper, mapping)
     await session.commit()
-    # 块向量受用户开关：开启才嵌（关时块行留着，待重建/开开关再补）。best-effort，内部自 commit
-    if paper.full_text_path:
-        from app.services.chunks import (
-            embed_pending_chunks_for_papers,
-            user_wants_fulltext_index,
-        )
+    # 摘要兜底块的向量 = 论文级向量的拷贝（零 token，不受任何开关控制）
+    from app.services.chunks import sync_abstract_chunk_vectors
 
-        if await user_wants_fulltext_index(session, user_id):
-            from app.core.llm.router import get_llm_router
+    try:
+        if await sync_abstract_chunk_vectors(session, paper_ids=[paper.id]):
+            await session.commit()
+    except Exception:  # noqa: BLE001
+        logger.warning("abstract chunk vector sync failed for %s", paper.id, exc_info=True)
 
-            try:
-                await embed_pending_chunks_for_papers(
-                    session,
-                    paper_ids=[paper.id],
-                    llm=get_llm_router(),
-                    user_id=user_id,
-                    project_id=project_id,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
+    # 块向量受用户开关（默认开）：关掉时块行留着，待重建/开开关再补。best-effort，内部自 commit
+    from app.services.chunks import (
+        embed_pending_chunks_for_papers,
+        user_wants_fulltext_index,
+    )
+
+    if await user_wants_fulltext_index(session, user_id):
+        from app.core.llm.router import get_llm_router
+
+        try:
+            await embed_pending_chunks_for_papers(
+                session,
+                paper_ids=[paper.id],
+                llm=get_llm_router(),
+                user_id=user_id,
+                project_id=project_id,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
     return paper
 

--- a/src/backend/tests/test_chat_fulltext_index.py
+++ b/src/backend/tests/test_chat_fulltext_index.py
@@ -121,10 +121,25 @@ async def _enable_index(client, headers):
     assert resp.status_code == 200
 
 
+async def _disable_index(client, headers):
+    resp = await client.patch(
+        "/api/users/me/settings", json={"chat_fulltext_index": False}, headers=headers
+    )
+    assert resp.status_code == 200
+
+
 async def test_shelf_index_rebuild_gated(client, queue_stub):
     project_id, headers = await _project(client)
 
-    # 设置关 → 409
+    # 开关默认开：没设置过也能建
+    resp = await client.post(
+        f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    queue_stub.jobs.clear()
+
+    # 显式关掉才 409
+    await _disable_index(client, headers)
     resp = await client.post(
         f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
     )
@@ -197,6 +212,13 @@ async def test_personal_index_rebuild_gated(client, queue_stub):
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
 
+    # 开关默认开：没设置过也能建
+    resp = await client.post("/api/library/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+    queue_stub.jobs.clear()
+
+    # 显式关掉才 409
+    await _disable_index(client, headers)
     resp = await client.post("/api/library/index/rebuild", headers=headers)
     assert resp.status_code == 409
     assert resp.json()["detail"] == "INDEXING_DISABLED"

--- a/src/backend/tests/test_daily_embed_search_export.py
+++ b/src/backend/tests/test_daily_embed_search_export.py
@@ -1,4 +1,4 @@
-"""每日新论文：论文级向量口径统一 + 自动建向量开关 / 补建 + 语义检索回退 + 引用导出。"""
+"""每日新论文：论文级向量口径统一 + 无条件建向量/分段 + 补建 + 语义检索回退 + 引用导出。"""
 
 import json
 import uuid
@@ -80,27 +80,18 @@ async def _papers_in_pool() -> list[Paper]:
         return list(rows)
 
 
-async def test_sync_embeds_only_when_enabled_and_only_missing(client, monkeypatch):
-    headers = await _admin_headers(client)
+async def test_sync_embeds_every_paper_and_only_missing(client, monkeypatch):
+    """每日推送的论文一律建论文级向量（不再受管理员开关管），且幂等只补缺失的。"""
     feed = {"cs.AI": [_rss_entry("2607.10001", "Alpha"), _rss_entry("2607.10002", "Beta")]}
 
-    # 开关默认关 → 同步不建向量
-    resp = await client.get("/api/admin/settings/daily-embed", headers=headers)
-    assert resp.status_code == 200 and resp.json()["enabled"] is False
+    # 无需任何开关：同步即建向量，文本口径 = 标题+作者+摘要
     result = await _run_sync(monkeypatch, feed)
-    assert result["created"] == 2 and result["embedded"] == 0
-    assert all(p.embedding is None for p in await _papers_in_pool())
-
-    # 开开关 → 再同步（无新论文）也会补上缺的向量，文本口径 = 标题+作者+摘要
-    resp = await client.put(
-        "/api/admin/settings/daily-embed", json={"enabled": True}, headers=headers
-    )
-    assert resp.status_code == 200 and resp.json()["enabled"] is True
-    result = await _run_sync(monkeypatch, feed)
-    assert result["created"] == 0 and result["embedded"] == 2
+    assert result["created"] == 2 and result["embedded"] == 2
     papers = await _papers_in_pool()
     for paper in papers:
         assert paper.embedding == fake_embedding(paper_embedding_text(paper))
+        assert paper.embedding_at is not None  # 构建时间记下了
+        assert paper.embedding_model  # 模型名记下了
 
     # 已有向量的不重嵌（哨兵向量原样保留）
     sentinel = [0.5] * len(papers[0].embedding)
@@ -115,16 +106,35 @@ async def test_sync_embeds_only_when_enabled_and_only_missing(client, monkeypatc
         assert row.embedding == pytest.approx(sentinel)
 
 
+async def test_daily_papers_get_abstract_chunk(client, monkeypatch):
+    """每日推送不下 PDF，论文靠「标题 + 摘要」兜底块进入文献对话的检索范围。"""
+    from app.models.paper import PaperChunk
+
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.10009", "Delta")]})
+    papers = await _papers_in_pool()
+    assert papers and all(p.full_text_path is None for p in papers)
+    async with get_sessionmaker()() as session:
+        chunks = (
+            (
+                await session.execute(
+                    select(PaperChunk).where(PaperChunk.paper_id == papers[0].id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(chunks) == 1  # 无全文 → 单个兜底块
+    assert chunks[0].source == "abstract"
+    assert papers[0].title in chunks[0].text
+
+
 async def test_backfill_counts(client, monkeypatch):
     headers = await _admin_headers(client)
-    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.10003", "Gamma")]})  # 开关关，无向量
+    # 同步已把向量建好，故补建端点这里全是「已有」
+    await _run_sync(monkeypatch, {"cs.AI": [_rss_entry("2607.10003", "Gamma")]})
 
     resp = await client.post("/api/admin/settings/daily-embed/backfill", headers=headers)
     assert resp.status_code == 200
-    assert resp.json()["embedded"] == 1 and resp.json()["skipped"] == 0
-
-    # 幂等：再补一次全是已有
-    resp = await client.post("/api/admin/settings/daily-embed/backfill", headers=headers)
     assert resp.json() == {"embedded": 0, "skipped": 1, "failed": 0}
 
     # 非 admin 无权

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -423,7 +423,9 @@ async def test_compile_entry_links_concepts_without_library(client, monkeypatch)
         rows = (await session.execute(select(LLMUsage))).scalars().all()
         assert rows and all(r.library_id is None for r in rows)  # 记账落平台级，不摊给某个库
         assert any(r.stage == "extract" for r in rows)  # 概念定义那次调用记在触发人名下
-        assert all(r.user_id is not None for r in rows)
+        # 编译/上链这些有发起人的调用都记在人名下；每日同步那步的向量化是定时任务
+        # 发起的系统级调用，本来就没有「人」，记平台账（user_id 空）
+        assert all(r.user_id is not None for r in rows if r.stage != "embedding")
 
         # 存量（编译过但没上链）的路径：清掉关联后重新编译能补回来
         await session.execute(delete(paper_concepts).where(paper_concepts.c.paper_id == paper_id))
@@ -609,9 +611,9 @@ async def test_daily_actions_observation_shapes(client, monkeypatch):
     obs = await get_action("daily.cleanup")(ctx, {})
     assert obs == {"expired": 1}
 
-    # 开关默认关 → 跳过，且不算失败
+    # 无条件建：论文级向量 + 无全文时的摘要兜底块（不再有管理员开关）
     obs = await get_action("daily.embed")(ctx, {})
-    assert obs == {"enabled": False, "embedded": 0, "failed": 0}
+    assert obs == {"enabled": True, "embedded": 1, "failed": 0, "chunked": 1}
     assert "error" not in obs
 
 

--- a/src/backend/tests/test_enrich_chunk_index.py
+++ b/src/backend/tests/test_enrich_chunk_index.py
@@ -35,12 +35,12 @@ def _write_fulltext() -> str:
 
 
 async def _user(client, email: str, *, index_on: bool):
+    """开关默认开，所以「关」这一路要显式 PATCH False，不能靠不设置。"""
     token = await register_and_login(client, email=email)
     headers = {"Authorization": f"Bearer {token}"}
-    if index_on:
-        await client.patch(
-            "/api/users/me/settings", json={"chat_fulltext_index": True}, headers=headers
-        )
+    await client.patch(
+        "/api/users/me/settings", json={"chat_fulltext_index": index_on}, headers=headers
+    )
     me = (await client.get("/api/users/me", headers=headers)).json()
     return uuid.UUID(me["id"]), headers
 

--- a/src/backend/tests/test_library_scoped_capabilities.py
+++ b/src/backend/tests/test_library_scoped_capabilities.py
@@ -139,16 +139,19 @@ async def test_standalone_library_index_rebuild(client):
         txt = txt_dir / f"p{i}.txt"
         txt.write_text("规划方法的细节。" * 300, encoding="utf-8")
         await _seed_paper(lib_id, title=title, full_text_path=str(txt))
-    # 没有全文的论文不参与
+    # 没有全文的论文也参与：拿不到全文就建「标题 + 摘要」兜底块，
+    # 否则这篇论文对文献对话完全不可检索
     await _seed_paper(lib_id, title="No fulltext")
 
     resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["papers_indexed"] == 2
+    assert body["papers_indexed"] == 3
     assert body["chunks_created"] > 0
     assert body["total_chunks"] == body["chunks_created"]
-    assert body["embedded"] == body["chunks_created"] and body["embed_error"] is None
+    # 两篇有全文的按全文切、走嵌入接口；第三篇只有一个摘要兜底块，向量拷论文级向量
+    # （这里论文级向量也还没建，故先留空），不占嵌入调用
+    assert body["embedded"] == body["chunks_created"] - 1 and body["embed_error"] is None
 
     # 幂等：再跑不重复建
     resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b6c2f81d4a09"  # 概念统一到论文级（concepts 去 library_id）
+HEAD_REVISION = "c4e7b2a91f38"  # 分段来源标记 + 向量构建元信息
+CONCEPTS_REVISION = "b6c2f81d4a09"  # 概念统一到论文级（本次 head 的 down_revision）
 PREV_REVISION = "a7d0c9e51b34"  # 解读统一到 paper_wikis
 
 
@@ -67,6 +68,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "feedback_images",
                     "user_library_entries",
                     "concepts",
+                    "paper_chunks",
                     "paper_wikis",
                     "library_papers",
                     "daily_feed_entries",
@@ -94,6 +96,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
     assert "embedding" in columns["papers"]  # sqlite 分支 JSON variant 列保留
+    # 分段来源标记 + 两种向量各自的构建时间/模型名
+    assert "source" in columns["paper_chunks"]
+    assert {"embedding_model", "embedding_at"} <= columns["papers"]
+    assert {"chunk_embedding_model", "chunk_embedding_at"} <= columns["papers"]
     # M3 列仍在
     assert {"score_rationale", "matches", "wins", "embedding"} <= columns["ideas"]
     assert "payload" in columns["review_sessions"]
@@ -282,7 +288,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "library_id" not in columns["concepts"]
     assert {"concepts_pre_unify", "paper_concepts_pre_unify"} <= columns["_tables"]
 
-    # 最新 revision 可往返：downgrade 一步落到 down_revision（a7d0c9e51b34，解读统一）。
+    # 最新 revision 可往返：先退掉本次的分段来源标记与向量元信息列。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CONCEPTS_REVISION
+    assert "source" not in columns["paper_chunks"]
+    assert not {"embedding_model", "embedding_at"} & columns["papers"]
+    assert not {"chunk_embedding_model", "chunk_embedding_at"} & columns["papers"]
+
+    # 再退一步落到 a7d0c9e51b34（解读统一）。
     # 概念退回按库分版本：library_id 列回来、留档表清掉、被合并的行与关联还原。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -1,0 +1,583 @@
+"""索引覆盖：无全文的论文也有可检索分段 + 索引状态查询 + 手动重建。
+
+过去分段只从 PDF 全文生成，没有全文的论文（每日推送尤其严重——抓取时根本不下 PDF）
+对文献对话完全不存在。本文件覆盖：
+- 无全文入库 → 一个「标题 + 摘要」兜底块，且真能被检索到；
+- 拿到全文后兜底块被全文块整体替换；
+- 分块向量受用户开关控制且默认开；
+- 状态端点返回两种向量的有无 / 构建时间 / 模型名；
+- 手动重建覆盖旧向量。
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper, PaperChunk
+from app.services import paper_enrich
+from app.services.chunks import ensure_paper_chunks, keyword_search_chunks
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _noop_emit(stage: str, status: str, detail: str | None = None) -> None:
+    return None
+
+
+def _write_fulltext(text: str = "规划方法的实现细节与实验。") -> str:
+    txt_dir = Path(tempfile.mkdtemp(prefix="polaris-idx-status-"))
+    txt = txt_dir / "p.txt"
+    txt.write_text(text * 200, encoding="utf-8")
+    return str(txt)
+
+
+async def _user(client, email: str, *, index_on: bool | None = None):
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    if index_on is not None:
+        resp = await client.patch(
+            "/api/users/me/settings", json={"chat_fulltext_index": index_on}, headers=headers
+        )
+        assert resp.status_code == 200
+    me = (await client.get("/api/users/me", headers=headers)).json()
+    return uuid.UUID(me["id"]), headers
+
+
+async def _chunks(session, paper_id) -> list[PaperChunk]:
+    return list(
+        (
+            await session.execute(
+                select(PaperChunk)
+                .where(PaperChunk.paper_id == paper_id)
+                .order_by(PaperChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ---- 1. 无全文 → 摘要兜底块，且可被检索到 ----
+
+
+async def test_paper_without_fulltext_gets_single_abstract_chunk(client):
+    """没有全文的论文入库后有且仅有一个摘要块，来源标成 abstract。"""
+    _, headers = await _user(client, "abs@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="abs")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Tree Search Planning for Agents",
+            abstract="We propose a tree search planner for language agents.",
+            doi="10.1/abs",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+        assert await ensure_paper_chunks(session, paper) == 1
+        await session.commit()
+
+        chunks = await _chunks(session, paper_id)
+    assert len(chunks) == 1
+    assert chunks[0].source == "abstract"
+    # 标题与摘要都进了块（「找某人在讲什么」两头都得能命中）
+    assert "Tree Search Planning for Agents" in chunks[0].text
+    assert "tree search planner" in chunks[0].text
+
+
+async def test_abstract_chunk_is_retrievable(client):
+    """兜底块进得了检索：关键词检索能命中它（sqlite 下走降级关键词分支）。"""
+    _, headers = await _user(client, "retrieve@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="retrieve")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Reflexion Self Improvement",
+            abstract="An agent reflects on failures to improve future attempts.",
+            doi="10.1/retrieve",
+        )
+        await session.commit()
+        paper_id = paper.id
+        await ensure_paper_chunks(session, paper)
+        await session.commit()
+
+        hits = await keyword_search_chunks(
+            session, library_ids=None, q="reflexion agent", limit=10, paper_ids=[paper_id]
+        )
+    assert hits, "摘要兜底块必须能被检索到——否则这篇论文对文献对话依然不存在"
+    assert all(c.paper_id == paper_id for c, _ in hits)
+
+
+async def test_fulltext_replaces_abstract_chunk(client):
+    """先无全文建了摘要块，之后拿到全文 → 摘要块被全文块整体替换。"""
+    _, headers = await _user(client, "replace@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="replace")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Later Gets Fulltext",
+            abstract="Short abstract.",
+            doi="10.1/replace",
+        )
+        await session.commit()
+        paper_id = paper.id
+        await ensure_paper_chunks(session, paper)
+        await session.commit()
+        assert [c.source for c in await _chunks(session, paper_id)] == ["abstract"]
+
+        # 拿到 PDF 全文后再跑一次
+        paper.full_text_path = _write_fulltext()
+        await session.commit()
+        assert await ensure_paper_chunks(session, paper) > 1
+        await session.commit()
+
+        chunks = await _chunks(session, paper_id)
+    assert len(chunks) > 1
+    assert {c.source for c in chunks} == {"fulltext"}  # 摘要块没留下
+    assert all("Short abstract." not in c.text for c in chunks)
+
+
+async def test_existing_fulltext_chunks_are_not_resliced(client):
+    """已有全文块的论文再 ensure 不重切（重切会丢已补的块向量）。"""
+    _, headers = await _user(client, "keepft@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="keepft")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Keep Fulltext",
+            doi="10.1/keepft",
+            full_text_path=_write_fulltext(),
+        )
+        await session.commit()
+        paper_id = paper.id
+        session.add(
+            PaperChunk(
+                paper_id=paper_id, seq=0, text="手工全文块", source="fulltext",
+                embedding=[0.5] * 1024,
+            )
+        )
+        await session.commit()
+
+        assert await ensure_paper_chunks(session, paper) == 0
+        chunks = await _chunks(session, paper_id)
+    assert len(chunks) == 1 and chunks[0].text == "手工全文块"
+
+
+# ---- 1b. 摘要块的向量 = 论文级向量的拷贝（零 token） ----
+
+
+async def test_abstract_chunk_copies_paper_vector(client):
+    """摘要块不另调嵌入接口：向量直接拷论文级向量（用哨兵向量证明是拷贝而非重算）。"""
+    _, headers = await _user(client, "copyvec@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="copyvec")
+    sentinel = [0.125] * 1024
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Copy My Vector",
+            abstract="The chunk vector must be a copy.",
+            doi="10.1/copyvec",
+        )
+        paper.embedding = sentinel
+        paper.embedding_model = "sentinel-model"
+        await session.commit()
+        paper_id = paper.id
+
+        await ensure_paper_chunks(session, paper)
+        await session.commit()
+
+        chunks = await _chunks(session, paper_id)
+        paper = await session.get(Paper, paper_id)
+    assert len(chunks) == 1 and chunks[0].source == "abstract"
+    assert chunks[0].embedding == pytest.approx(sentinel), "摘要块向量应是论文级向量的拷贝"
+    # 元信息也跟着论文级向量走（本来就是同一份向量）
+    assert paper.chunk_embedding_model == "sentinel-model"
+
+
+async def test_abstract_chunk_vector_filled_in_later(client):
+    """论文级向量当时还没建好 → 摘要块先留空，之后一次 sync 补上，不报错。"""
+    from app.services.chunks import sync_abstract_chunk_vectors
+
+    _, headers = await _user(client, "latevec@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="latevec")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Vector Comes Later",
+            abstract="No paper vector yet.",
+            doi="10.1/latevec",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+        await ensure_paper_chunks(session, paper)  # 此刻 paper.embedding still None
+        await session.commit()
+        assert (await _chunks(session, paper_id))[0].embedding is None
+
+        # 论文级向量后来建好了
+        sentinel = [0.375] * 1024
+        paper.embedding = sentinel
+        await session.commit()
+        assert await sync_abstract_chunk_vectors(session, paper_ids=[paper_id]) == 1
+        await session.commit()
+
+        chunks = await _chunks(session, paper_id)
+    assert chunks[0].embedding == pytest.approx(sentinel)
+
+
+async def test_abstract_chunk_vector_not_gated_by_user_switch(client, fake_redis):
+    """用户关掉全文索引开关，摘要块的向量照样有——拷贝不花钱，不该卡在开关后面。
+
+    否则关掉开关的用户又回到「这篇论文完全搜不到」的老问题。
+    """
+    user_id, headers = await _user(client, "abs-optout@example.com", index_on=False)
+    project_id, _ = await make_project_with_library(client, headers, name="abs-optout")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="No Fulltext And Index Off",
+            abstract="Still searchable.",
+            doi="10.1/absoptout",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        chunks = await _chunks(session, paper_id)
+    assert len(chunks) == 1 and chunks[0].source == "abstract"
+    assert paper.embedding is not None
+    assert chunks[0].embedding == pytest.approx(paper.embedding), "关了开关也得有摘要级索引"
+
+
+async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
+    """整库重建时摘要块也不花嵌入调用：向量拷论文级向量，用 abstract_vectors_copied 计数。"""
+    _, headers = await _user(client, "librebuild@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="librebuild")
+    sentinel = [0.625] * 1024
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Abstract Only In Library",
+            abstract="Copied vector please.",
+            doi="10.1/librebuild",
+        )
+        paper.embedding = sentinel  # 论文级向量已就位
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["chunks_created"] == 1
+    assert body["embedded"] == 0, "摘要块不该占用嵌入调用"
+    # 论文级向量此刻已就位 → 建块时就地拷好了，无需 sync 事后补（补的计数因此是 0）
+    assert body["abstract_vectors_copied"] == 0
+
+    async with get_sessionmaker()() as session:
+        chunks = await _chunks(session, paper_id)
+    assert chunks[0].source == "abstract"
+    assert chunks[0].embedding == pytest.approx(sentinel), "向量应是论文级向量的拷贝"
+
+
+# ---- 1c. 论文级向量的管理员总闸（默认开） ----
+
+
+async def _set_paper_embedding(client, headers, enabled: bool):
+    resp = await client.put(
+        "/api/admin/settings/paper-embedding", json={"enabled": enabled}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_paper_embedding_switch_defaults_on(client):
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
+    resp = await client.get("/api/admin/settings/paper-embedding", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is True
+
+
+async def test_admin_can_switch_off_paper_embedding(client, fake_redis):
+    """总闸关掉 → 论文级向量不建；摘要块也就没有向量可拷（如实反映，不报错）。"""
+    admin_token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    assert (await _set_paper_embedding(client, headers, False))["enabled"] is False
+
+    me = (await client.get("/api/users/me", headers=headers)).json()
+    user_id = uuid.UUID(me["id"])
+    project_id, _ = await make_project_with_library(client, headers, name="switch-off")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Admin Turned It Off",
+            abstract="No vectors for me.",
+            doi="10.1/switchoff",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        chunks = await _chunks(session, paper_id)
+    assert paper.embedding is None, "总闸关了就不该建论文级向量"
+    assert len(chunks) == 1 and chunks[0].embedding is None  # 没有向量可拷
+
+    # 状态端点如实反映
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    body = resp.json()
+    assert body["paper_vector"]["built"] is False
+    assert body["chunk_vector"]["built"] is False
+    assert body["chunk_source"] == "abstract"
+
+
+# ---- 2. 分块向量的用户开关：默认开 ----
+
+
+async def _run_enrich(paper_id, *, user_id):
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=user_id, project_id=None, emit=_noop_emit
+        )
+
+
+async def _seed_for_enrich(client, headers, *, name: str, email_key: str) -> uuid.UUID:
+    project_id, _ = await make_project_with_library(client, headers, name=name)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title=f"Paper {name}",
+            doi=f"10.1/{email_key}",
+            full_text_path=_write_fulltext(),
+        )
+        await session.commit()
+        return paper.id
+
+
+async def test_chunk_vectors_built_by_default(client, fake_redis):
+    """用户没碰过设置 → 开关默认开 → 块向量照建。"""
+    user_id, headers = await _user(client, "default-on@example.com")  # 不 PATCH 设置
+    paper_id = await _seed_for_enrich(client, headers, name="default-on", email_key="defon")
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        chunks = await _chunks(session, paper_id)
+    assert chunks
+    assert all(c.embedding is not None for c in chunks), "默认开：块向量必须建出来"
+
+
+async def test_chunk_vectors_skipped_when_user_opts_out(client, fake_redis):
+    """用户显式关掉 → 块行留着但不嵌；论文级向量不受这个开关影响，照常建。"""
+    user_id, headers = await _user(client, "opt-out@example.com", index_on=False)
+    paper_id = await _seed_for_enrich(client, headers, name="opt-out", email_key="optout")
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        chunks = await _chunks(session, paper_id)
+    assert chunks
+    assert all(c.embedding is None for c in chunks), "关掉开关就不该花嵌入调用"
+    assert paper.embedding is not None, "论文级向量不受全文索引开关管"
+
+
+# ---- 3. 状态端点 ----
+
+
+async def test_index_status_reports_time_and_model(client, fake_redis):
+    """状态端点给出两种向量的有无、构建时间与模型名。"""
+    user_id, headers = await _user(client, "status@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="status", email_key="status")
+
+    # 建之前：两种向量都没有，时间/模型为空
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["paper_vector"] == {"built": False, "built_at": None, "model": None}
+    assert body["chunk_vector"]["built"] is False
+
+    await _run_enrich(paper_id, user_id=user_id)
+
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    body = resp.json()
+    assert body["paper_vector"]["built"] is True
+    assert body["paper_vector"]["built_at"] and body["paper_vector"]["model"]
+    assert body["chunk_vector"]["built"] is True
+    assert body["chunk_vector"]["built_at"] and body["chunk_vector"]["model"]
+    assert body["chunk_count"] > 0
+    assert body["embedded_chunk_count"] == body["chunk_count"]
+    assert body["has_fulltext"] is True
+    assert body["chunk_source"] == "fulltext"
+
+
+async def test_index_status_for_paper_without_fulltext(client):
+    """没有全文的论文：状态如实报 abstract 来源、has_fulltext=False。"""
+    _, headers = await _user(client, "status-abs@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="status-abs")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="No Fulltext Here",
+            abstract="Just an abstract.",
+            doi="10.1/statusabs",
+        )
+        await session.commit()
+        paper_id = paper.id
+        await ensure_paper_chunks(session, paper)
+        await session.commit()
+
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    body = resp.json()
+    assert body["has_fulltext"] is False
+    assert body["chunk_source"] == "abstract"
+    assert body["chunk_count"] == 1
+
+
+# ---- 4. 手动重建 ----
+
+
+async def test_manual_rebuild_overwrites_existing_vectors(client, fake_redis):
+    """手动重建覆盖旧向量：预置的哨兵向量必须被换掉。"""
+    user_id, headers = await _user(client, "rebuild@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="rebuild", email_key="rebuild")
+    await _run_enrich(paper_id, user_id=user_id)
+
+    sentinel = [0.25] * 1024
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        paper.embedding = sentinel
+        for chunk in await _chunks(session, paper_id):
+            chunk.embedding = sentinel
+        await session.commit()
+
+    resp = await client.post(f"/api/papers/{paper_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["paper_vector"]["built"] is True
+    assert body["chunk_vector"]["built"] is True
+    assert body["embedded_chunk_count"] == body["chunk_count"] > 0
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        chunks = await _chunks(session, paper_id)
+    assert paper.embedding != pytest.approx(sentinel), "论文级向量应被重建覆盖"
+    assert all(c.embedding is not None for c in chunks)
+    assert all(c.embedding != pytest.approx(sentinel) for c in chunks), "块向量应被重建覆盖"
+
+
+async def test_manual_rebuild_only_paper_vector(client, fake_redis):
+    """只重建论文级向量时不动分块向量。"""
+    user_id, headers = await _user(client, "rebuild-one@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="rebuild-one", email_key="rbone")
+    await _run_enrich(paper_id, user_id=user_id)
+
+    sentinel = [0.25] * 1024
+    async with get_sessionmaker()() as session:
+        for chunk in await _chunks(session, paper_id):
+            chunk.embedding = sentinel
+        await session.commit()
+
+    resp = await client.post(
+        f"/api/papers/{paper_id}/index/rebuild",
+        json={"paper_vector": True, "chunks": False},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    async with get_sessionmaker()() as session:
+        chunks = await _chunks(session, paper_id)
+    assert all(c.embedding == pytest.approx(sentinel) for c in chunks), "没请求重建就别动"
+
+
+async def test_manual_rebuild_builds_index_from_scratch(client, fake_redis):
+    """从没建过索引的论文（无全文）也能一键建出来：摘要块 + 两种向量。"""
+    _, headers = await _user(client, "rebuild-scratch@example.com")
+    project_id, _ = await make_project_with_library(client, headers, name="scratch")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Never Indexed",
+            abstract="This paper was never indexed.",
+            doi="10.1/scratch",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.post(f"/api/papers/{paper_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["paper_vector"]["built"] is True
+    assert body["chunk_vector"]["built"] is True
+    assert body["chunk_count"] == 1 and body["chunk_source"] == "abstract"
+
+
+async def test_index_endpoints_require_visibility(client, fake_redis):
+    """权限 = 能看到这篇论文（+ 重建还要有大模型使用权限）。
+
+    孤儿论文（不在任何库、不在每日推送池、没人上架）谁都读不到，两个端点一律 404。
+    注意在公共库里的论文本来就全实验室可读（P5c），那不是越权。
+    """
+    _, headers = await _user(client, "orphan-idx@example.com")
+    async with get_sessionmaker()() as session:
+        paper = Paper(title="Orphan Paper", abstract="Nobody can reach me.")
+        session.add(paper)
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    assert resp.status_code == 404
+    resp = await client.post(f"/api/papers/{paper_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_rebuild_blocked_for_users_without_llm_access(client, fake_redis):
+    """大模型权限被锁的用户不能点重建（重建要花嵌入调用）。"""
+    from app.models.user import User
+
+    user_id, headers = await _user(client, "blocked-idx@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="blocked", email_key="blocked")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        user.llm_access = "blocked"
+        await session.commit()
+
+    resp = await client.post(f"/api/papers/{paper_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 403
+    # 只读的状态查询不受影响
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    assert resp.status_code == 200
+
+
+async def test_rebuild_rejects_empty_target(client, fake_redis):
+    _, headers = await _user(client, "empty-target@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="empty", email_key="empty")
+    resp = await client.post(
+        f"/api/papers/{paper_id}/index/rebuild",
+        json={"paper_vector": False, "chunks": False},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "NOTHING_TO_REBUILD"

--- a/src/frontend/src/components/ui/PaperIndexStatus.tsx
+++ b/src/frontend/src/components/ui/PaperIndexStatus.tsx
@@ -1,0 +1,149 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api, ApiError, type PaperIndexStatus, type VectorStatus } from '../../lib/api';
+import { fmtFullTime } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+import { toast } from './Toast';
+import { Icon } from './Icon';
+
+/**
+ * 论文检索索引状态：两个红绿点（论文级向量 / 全文分块向量）+ 手动构建按钮。
+ *
+ * 红绿点鼠标悬浮显示构建时间与所用模型（存量数据没记过这两项，就只说建过了）。
+ * 「构建 / 重新构建」按钮的文案随有没有索引切换——已有就是重建（覆盖旧向量）。
+ */
+
+function dotTitle(label: string, s: VectorStatus | undefined, note?: string): string {
+  const head = (() => {
+    if (!s?.built) return tr(`${label}：未构建`, `${label}: not built`);
+    const when = s.built_at ? fmtFullTime(s.built_at) : null;
+    if (s.model && when) {
+      return tr(`${label}：${when} 由 ${s.model} 构建`, `${label}: built ${when} by ${s.model}`);
+    }
+    if (s.model) return tr(`${label}：由 ${s.model} 构建`, `${label}: built by ${s.model}`);
+    if (when) return tr(`${label}：${when} 构建`, `${label}: built ${when}`);
+    // 存量数据：向量在，但没记过时间与模型名
+    return tr(`${label}：已构建（时间与模型未记录）`, `${label}: built (time and model not recorded)`);
+  })();
+  return note ? `${head}\n${note}` : head;
+}
+
+function Dot({
+  label,
+  status,
+  note,
+  /** 部分可用（只有摘要级索引）→ 黄点，别让人以为已经有全文索引了 */
+  partial,
+}: {
+  label: string;
+  status: VectorStatus | undefined;
+  note?: string;
+  partial?: boolean;
+}) {
+  const built = !!status?.built;
+  const color = !built ? 'var(--danger)' : partial ? 'var(--warn)' : 'var(--ok)';
+  return (
+    <span
+      className="row gap6"
+      title={dotTitle(label, status, note)}
+      style={{ alignItems: 'center', cursor: 'help' }}
+    >
+      <span
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: '50%',
+          background: color,
+          flexShrink: 0,
+          display: 'inline-block',
+        }}
+      />
+      <span style={{ color: 'var(--text-3)', fontSize: 11.5 }}>{label}</span>
+    </span>
+  );
+}
+
+export function PaperIndexStatusRow({ paperId }: { paperId: string }) {
+  const queryClient = useQueryClient();
+  const queryKey = ['paper-index-status', paperId];
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey,
+    queryFn: () => api.getPaperIndexStatus(paperId),
+    retry: false,
+  });
+
+  const rebuild = useMutation({
+    mutationFn: () => api.rebuildPaperIndex(paperId),
+    onSuccess: (status) => {
+      queryClient.setQueryData<PaperIndexStatus>(queryKey, status);
+      toast(tr('索引已构建', 'Index built'), 'ok');
+    },
+    onError: (e) => {
+      const msg =
+        e instanceof ApiError && e.status === 403
+          ? tr('没有大模型使用权限，无法构建索引', 'No LLM access — cannot build the index')
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      toast(`${tr('构建失败：', 'Build failed: ')}${msg}`, 'error');
+    },
+  });
+
+  // 状态查询失败（例如后端还没上这两个端点）就整块不渲染，不打扰阅读
+  if (isError) return null;
+
+  const built = !!data && (data.paper_vector.built || data.chunk_vector.built);
+  // 只有摘要兜底块 = 这篇没有全文索引，只是「能搜到」而已，别让绿点造成误会
+  const abstractOnly = data?.chunk_source === 'abstract';
+  const chunkLabel = abstractOnly
+    ? tr('摘要级索引', 'Abstract-level index')
+    : tr('全文分块向量', 'Chunk vectors');
+  const chunkNote = abstractOnly
+    ? tr(
+        '这篇没有全文，只用标题 + 摘要建了一个分段（向量与论文级向量是同一份）。取到 PDF 后会换成全文分块。',
+        'No full text for this paper — only one segment from title and abstract (sharing the paper vector). It is replaced by full-text chunks once a PDF is fetched.',
+      )
+    : undefined;
+
+  return (
+    <div className="row gap12 wrap" style={{ alignItems: 'center' }}>
+      <Dot label={tr('论文级向量', 'Paper vector')} status={data?.paper_vector} />
+      <Dot
+        label={chunkLabel}
+        status={data?.chunk_vector}
+        note={chunkNote}
+        partial={abstractOnly}
+      />
+      {data && data.chunk_count > 0 && !abstractOnly && (
+        <span
+          className="mono"
+          style={{ color: 'var(--text-3)', fontSize: 11 }}
+          title={tr('已建向量的分段 / 分段总数', 'Segments with vectors / total segments')}
+        >
+          {data.embedded_chunk_count}/{data.chunk_count}
+        </span>
+      )}
+      <button
+        type="button"
+        className="btn btn-ghost sm"
+        disabled={isLoading || rebuild.isPending}
+        onClick={() => rebuild.mutate()}
+        title={tr(
+          '重新计算这篇论文的检索向量（会调用一次嵌入模型）',
+          'Recompute this paper’s retrieval vectors (calls the embedding model once)',
+        )}
+      >
+        <Icon
+          name="refresh"
+          size={11}
+          style={rebuild.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
+        />
+        {rebuild.isPending
+          ? tr('构建中…', 'Building…')
+          : built
+            ? tr('重新构建', 'Rebuild')
+            : tr('构建索引', 'Build index')}
+      </button>
+    </div>
+  );
+}

--- a/src/frontend/src/features/chat/BuildIndexButton.tsx
+++ b/src/frontend/src/features/chat/BuildIndexButton.tsx
@@ -50,8 +50,8 @@ export function BuildIndexButton({ build }: { build: () => Promise<BuildIndexRes
     },
   });
 
-  // 未开启开关时不显示按钮
-  if (me?.settings?.chat_fulltext_index !== true) return null;
+  // 开关默认开，只有显式关掉才藏起按钮
+  if (me?.settings?.chat_fulltext_index === false) return null;
 
   return (
     <button

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../../components/ui/Icon';
 import { CompileBadge } from '../../components/ui/CompileBadge';
 import { PaperStatusPill } from '../../components/ui/StatusPill';
 import { RelevanceBar } from '../../components/ui/RelevanceBar';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { FigureEmbed, FiguresSection, hasEmbeddedFigures, usePaperFigures } from '../../components/ui/FigureGallery';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
@@ -152,6 +153,9 @@ export function InfoPanel({
         </MetaItem>
         <MetaItem label="ingested">
           <span className="mono">{fmtTime(paper.created_at)}</span>
+        </MetaItem>
+        <MetaItem label={tr('索引', 'index')}>
+          <PaperIndexStatusRow paperId={paper.id} />
         </MetaItem>
       </div>
 

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -232,7 +232,8 @@ function ChatPrefsTab() {
           </div>
         </div>
         <Switch
-          checked={me.settings?.chat_fulltext_index ?? false}
+          /* 默认开：没设置过等同开启（与后端 user_wants_fulltext_index 同一口径） */
+          checked={me.settings?.chat_fulltext_index !== false}
           onChange={(v) => chatIndexMutation.mutate(v)}
           disabled={chatIndexMutation.isPending}
           aria-labelledby="pref-chat-fulltext"
@@ -1628,11 +1629,70 @@ function AffiliationModeSection() {
   );
 }
 
+/** 论文级向量的平台总闸（默认开）。管的是所有入库入口，不只是每日推送。 */
+function PaperEmbeddingSection() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['paper-embedding-enabled'],
+    queryFn: () => api.getPaperEmbeddingEnabled(),
+    retry: false,
+  });
+  const enabled = data?.enabled ?? true; // 默认开
+
+  const toggleMutation = useMutation({
+    mutationFn: (next: boolean) => api.setPaperEmbeddingEnabled(next),
+    onSuccess: (r) => {
+      toast(
+        r.enabled
+          ? tr('已开启：入库的论文都会建向量', 'Enabled — papers get vectors as they are added')
+          : tr('已关闭：新入库的论文不再建向量', 'Disabled — newly added papers get no vectors'),
+        'ok',
+      );
+      queryClient.setQueryData(['paper-embedding-enabled'], r);
+    },
+    onError: (e) => toast(`${tr('设置失败', 'Failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  return (
+    <div className="card card-pad" style={{ marginTop: 20 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('论文向量', 'Paper vectors')}
+      </div>
+      <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div id="paper-embedding-toggle" style={{ fontSize: 13, lineHeight: 1.4 }}>
+            {tr('为入库的论文建立向量', 'Build vectors for papers as they are added')}
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
+            {tr(
+              '所有入库方式都适用（建库、手动添加、每日推送）。这是全平台的总开关，关掉后语义检索只能找到已经建过向量的论文，一般不用动。',
+              'Applies to every way papers are added (library builds, manual adds, daily papers). This is the platform-wide switch; when off, semantic search only finds papers that already have vectors. Rarely needs changing.',
+            )}
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          onChange={(v) => toggleMutation.mutate(v)}
+          disabled={isLoading || isError || toggleMutation.isPending}
+          aria-labelledby="paper-embedding-toggle"
+        />
+      </div>
+      {isError && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 10 }}>
+          {tr('无法加载该设置（后端不可用或无权限）', 'Failed to load this setting (backend unavailable or no permission)')}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function LlmTab() {
   return (
     <>
       <ProvidersSection adapter={adminLlmAdapter} />
       <RoutesSection adapter={adminLlmAdapter} />
+      <PaperEmbeddingSection />
       <AffiliationModeSection />
       <CallLogsSection />
     </>
@@ -2424,30 +2484,8 @@ function DailyCategoriesSection() {
   );
 }
 
-/** 每日论文是否随同步建向量 + 给最近 7 天缺向量的论文补建。 */
+/** 给最近 7 天缺向量的每日论文补建向量（新论文同步时已自动建，这里只补历史）。 */
 function DailyEmbedSection() {
-  const queryClient = useQueryClient();
-  const settingQuery = useQuery({
-    queryKey: ['daily-embed-enabled'],
-    queryFn: () => api.getDailyEmbedEnabled(),
-    retry: false,
-  });
-  const enabled = settingQuery.data?.enabled ?? false;
-
-  const toggleMutation = useMutation({
-    mutationFn: (next: boolean) => api.setDailyEmbedEnabled(next),
-    onSuccess: (r) => {
-      toast(
-        r.enabled
-          ? tr('已开启：以后每天同步的新论文都会建向量', 'Enabled — new papers will be embedded on each daily sync')
-          : tr('已关闭：每天同步不再建向量', 'Disabled — the daily sync will no longer embed papers'),
-        'ok',
-      );
-      void queryClient.invalidateQueries({ queryKey: ['daily-embed-enabled'] });
-    },
-    onError: (e) => toast(`${tr('设置失败', 'Failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
-
   const backfillMutation = useMutation({
     mutationFn: () => api.backfillDailyEmbeddings(),
     onSuccess: (r) => {
@@ -2468,40 +2506,11 @@ function DailyEmbedSection() {
         {tr('每日论文向量', 'Daily paper embeddings')}
       </div>
 
-      <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div id="daily-embed-toggle" style={{ fontSize: 13, lineHeight: 1.4 }}>
-            {tr('为每日论文建立向量', 'Embed daily papers')}
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
-            {tr(
-              '每天同步时给新论文建向量，会消耗嵌入额度；关闭则每日论文只能用关键词检索。',
-              'The daily sync embeds new papers and consumes embedding quota; when off, daily papers support keyword search only.',
-            )}
-          </div>
-        </div>
-        <Switch
-          checked={enabled}
-          onChange={(v) => toggleMutation.mutate(v)}
-          disabled={settingQuery.isLoading || settingQuery.isError || toggleMutation.isPending}
-          aria-labelledby="daily-embed-toggle"
-        />
-      </div>
-
-      {settingQuery.isError && (
-        <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 10 }}>
-          {tr('无法加载该设置（后端不可用或无权限）', 'Failed to load this setting (backend unavailable or no permission)')}
-        </div>
-      )}
-
-      <div
-        className="row gap8"
-        style={{ alignItems: 'center', marginTop: 14, paddingTop: 12, borderTop: '1px solid var(--border)' }}
-      >
+      <div className="row gap8" style={{ alignItems: 'center', marginTop: 12 }}>
         <div style={{ flex: 1, minWidth: 0, fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45 }}>
           {tr(
-            '历史论文不会自动补建，补一遍可能要跑几十秒。',
-            'Existing papers are not embedded automatically; a backfill may take tens of seconds.',
+            '每天同步的新论文都会自动建向量。更早入库的论文不会自动补，补一遍可能要跑几十秒。',
+            'Papers from each daily sync are embedded automatically. Older papers are not; a backfill may take tens of seconds.',
           )}
         </div>
         <button

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -15,6 +15,7 @@ import { citationExportItems, ExportDropdown } from '../../components/ui/ExportD
 import { PaperReader } from './PaperReader';
 import { readerFrom } from '../reading/shared';
 import { toast } from '../../components/ui/Toast';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
 import {
@@ -887,6 +888,9 @@ function PaperDetailPane({
           ) : (
             <span className="muted">{tr('未编译', 'not compiled')}</span>
           )}
+        </MetaItem>
+        <MetaItem label={tr('检索索引', 'search index')}>
+          <PaperIndexStatusRow paperId={paper.id} />
         </MetaItem>
       </div>
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -562,8 +562,8 @@ export interface AffiliationModeRead {
   mode: AffiliationMode;
 }
 
-/** 每日论文是否随同步建立向量（关闭时每日的语义检索没有数据）。 */
-export interface DailyEmbedSetting {
+/** 平台是否给论文建论文级向量（管理员总闸，默认开）。 */
+export interface PaperEmbeddingSetting {
   enabled: boolean;
 }
 /** 补建历史向量的结果计数。 */
@@ -1041,6 +1041,26 @@ export interface QueuedIndexResult {
   queued: number;
   indexable: number;
   no_fulltext: number;
+}
+
+/** 一种向量的状态：建没建、什么时候建的、用的哪个模型（存量数据没记过，为 null）。 */
+export interface VectorStatus {
+  built: boolean;
+  built_at: string | null;
+  model: string | null;
+}
+
+/** 单篇论文的索引状态（docs/api-lit.md §9）。 */
+export interface PaperIndexStatus {
+  /** 论文级向量：标题+作者+摘要一条，语义检索用 */
+  paper_vector: VectorStatus;
+  /** 分块向量：分段各一条，文献对话检索用 */
+  chunk_vector: VectorStatus;
+  chunk_count: number;
+  embedded_chunk_count: number;
+  has_fulltext: boolean;
+  /** fulltext=按 PDF 全文切 | abstract=无全文时的标题+摘要兜底块 | null=还没分段 */
+  chunk_source: 'fulltext' | 'abstract' | null;
 }
 
 // ============================================================
@@ -2839,6 +2859,20 @@ export const api = {
   recompilePaper(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}/recompile`, { method: 'POST' });
   },
+  /** 这篇论文的两种向量各自建没建、何时建的、用的哪个模型（只读，权限同看论文）。 */
+  getPaperIndexStatus(id: string): Promise<PaperIndexStatus> {
+    return request<PaperIndexStatus>(`/papers/${id}/index-status`);
+  },
+  /** 手动重建这篇论文的向量（有就覆盖，没有就新建）；同步返回重建后的状态。需大模型使用权限。 */
+  rebuildPaperIndex(
+    id: string,
+    targets: { paper_vector?: boolean; chunks?: boolean } = {},
+  ): Promise<PaperIndexStatus> {
+    return requestJson<PaperIndexStatus>(`/papers/${id}/index/rebuild`, 'POST', {
+      paper_vector: targets.paper_vector ?? true,
+      chunks: targets.chunks ?? true,
+    });
+  },
   /** 删除论文（清理落盘文件，笔记/标签/分段级联删除）。 */
   deletePaper(id: string): Promise<void> {
     return request<void>(`/papers/${id}`, { method: 'DELETE' });
@@ -3845,12 +3879,12 @@ export const api = {
   setAffiliationMode(mode: AffiliationMode): Promise<AffiliationModeRead> {
     return requestJson<AffiliationModeRead>('/admin/settings/affiliation-mode', 'PUT', { mode });
   },
-  /** 每日论文是否建立向量（admin）。关闭时每日只有关键词检索。 */
-  getDailyEmbedEnabled(): Promise<DailyEmbedSetting> {
-    return request<DailyEmbedSetting>('/admin/settings/daily-embed');
+  /** 平台是否给论文建论文级向量（admin 总闸，默认开）。关掉后语义检索只能命中已有向量的论文。 */
+  getPaperEmbeddingEnabled(): Promise<PaperEmbeddingSetting> {
+    return request<PaperEmbeddingSetting>('/admin/settings/paper-embedding');
   },
-  setDailyEmbedEnabled(enabled: boolean): Promise<DailyEmbedSetting> {
-    return requestJson<DailyEmbedSetting>('/admin/settings/daily-embed', 'PUT', { enabled });
+  setPaperEmbeddingEnabled(enabled: boolean): Promise<PaperEmbeddingSetting> {
+    return requestJson<PaperEmbeddingSetting>('/admin/settings/paper-embedding', 'PUT', { enabled });
   },
   /** 实验室概况页的用量排行榜是否对普通成员可见（admin，默认开）。 */
   getLabLeaderboardEnabled(): Promise<LabLeaderboardSetting> {


### PR DESCRIPTION
Chat only searches `paper_chunks`, and chunks only came from a downloaded PDF.

```
papers          1427
with full text   266   ← 19%
with chunks      252
chunks embedded  251
```

**82% of the library was invisible to every chat**, with nothing in the UI to say so. Daily-feed papers never download a PDF at all, so that surface fell through to "the first twelve papers the database returned" — unordered, unrelated to the question.

## Papers without full text get an abstract chunk

Built from title, authors and abstract. **Its vector is copied from the paper-level embedding, not computed** — it's the same text, so a second embedding call would spend tokens producing the same number and risk the two disagreeing.

Being free, it is **gated by neither toggle**. Gating it would put those papers straight back out of reach, which is the thing being fixed.

### The trap this uncovered

Five places skip work when a paper "already has chunks" — and an abstract chunk satisfies that. Left alone, **an abstract chunk would permanently block full text from ever being indexed** for that paper. All five now ask whether *full-text* chunks exist, which is what `paper_chunks.source` is for beyond display.

(Also: the library rebuild endpoint filtered candidates on `full_text_path IS NOT NULL`, so papers without full text couldn't even be rebuilt into. Opened up.)

## Toggles

| | Default | Governs |
|---|---|---|
| Admin | **on** | paper-level embeddings, platform-wide |
| User | **on** | full-text chunk vectors — the ones that cost money |
| — | — | abstract chunks: neither, they're free |

The admin toggle was `daily_feed_embed_enabled`, default **off**, applying to the daily feed alone — which is why those papers had no vectors at all. Renamed, defaulted on, scope widened to every ingest path.

## Status on the paper page

Two dots, build time and model on hover, and a rebuild button. **Amber rather than green when only an abstract chunk exists** — a green dot would claim full-text indexing that isn't there.

Storing that meta took four columns on `papers`; per-chunk would mean two columns across a table meant to grow to millions of rows.

**Permissions match recompiling**: see the paper, plus task permission. Requiring management rights would lock rebuild out of exactly the papers that need it most — daily-feed papers belong to no library, so nobody could manage them.

## Two things found on the way

**The daily feed never created chunks at all** — not just missing vectors, it never called the indexer. Chat searches only chunks, so paper-level vectors alone would have left those papers still invisible.

**`PaperChunk(embedding=None)` on sqlite** stores JSON `'null'`, not SQL `NULL` — after which `embedding IS NULL` never matches it again and the count treats it as embedded, turning the status dot green on an unbuilt vector. Now only assigned when a vector exists.

## Not done

**No backfill for existing data.** The 1161 papers without full text won't get abstract chunks until something rebuilds them. The per-library rebuild endpoint can do it, but there's no platform-wide entry point. That's a one-off operation over ~1161 papers — a script seems righter than an endpoint, so it's left for a decision rather than assumed.

## Verification

52 tests across chunk/embed/index/enrich/migration. `ruff check app` clean, single alembic head, `tsc --noEmit` 0 errors. Full suite reported green by the implementation run (771 passed).