### PR TITLE
fix(desktop): accept the renderer package CI actually produces

### DIFF
--- a/src/desktop/src/main/updates/index.ts
+++ b/src/desktop/src/main/updates/index.ts
@@ -100,6 +100,7 @@ export async function checkForUpdate(): Promise<UpdateInfo> {
       contract: rendererAsset ? Number(RENDERER_RE.exec(rendererAsset.name)![2]) : CONTRACT_VERSION,
       downloadUrl: asset.browser_download_url,
       downloadSize: asset.size,
+      installerUrl: installer?.browser_download_url,
     };
     return cached;
   } catch {
@@ -140,19 +141,29 @@ export function applyUpdate(): { jobId: string } {
     try {
       const data = await download(info.downloadUrl!, jobId, info.downloadSize ?? 0);
 
+      let payload = data;
       if (info.kind === 'hot') {
-        log(jobId, 'installing renderer update');
-        stageRenderer(data, { version: info.latestVersion!, contract: info.contract! });
-        finish(jobId, { kind: 'hot', reloaded: true, version: info.latestVersion });
-        // 换界面即完成更新：重新加载窗口就跑在新版本上了
-        getWindow()?.webContents.reload();
-        return;
+        try {
+          log(jobId, 'installing renderer update');
+          stageRenderer(data, { version: info.latestVersion!, contract: info.contract! });
+          finish(jobId, { kind: 'hot', reloaded: true, version: info.latestVersion });
+          // 换界面即完成更新：重新加载窗口就跑在新版本上了
+          getWindow()?.webContents.reload();
+          return;
+        } catch (err) {
+          // 界面包装不上就退回整包更新，别让用户卡在「更新失败」上。坏包、旧客户端
+          // 的解包器有 bug、契约声明与实际内容不符——都归到这条路上。
+          if (!info.installerUrl) throw err;
+          log(jobId, `renderer update failed (${String(err)}), falling back to installer`);
+          payload = await download(info.installerUrl, jobId, 0);
+        }
       }
 
       const dir = join(app.getPath('userData'), 'updates');
       mkdirSync(dir, { recursive: true });
-      const file = join(dir, info.downloadUrl!.split('/').pop() ?? 'update');
-      writeFileSync(file, data);
+      const source = payload === data ? info.downloadUrl! : info.installerUrl!;
+      const file = join(dir, source.split('/').pop() ?? 'update');
+      writeFileSync(file, payload);
       finish(jobId, { kind: 'full', reloaded: false, path: file, version: info.latestVersion });
 
       if (process.platform === 'win32') {

--- a/src/desktop/src/main/updates/renderer-store.ts
+++ b/src/desktop/src/main/updates/renderer-store.ts
@@ -70,8 +70,10 @@ export function stageRenderer(archive: Buffer, expected: RendererMeta): void {
   rmSync(dir, { recursive: true, force: true });
   mkdirSync(dir, { recursive: true });
 
-  const files = extractTarGz(archive, dir);
-  if (!files.includes('index.html')) {
+  extractTarGz(archive, dir);
+  // 查文件系统而不是查返回的路径列表：条目名的形态（./ 前缀、子目录写法）
+  // 取决于打包命令，不该让它决定更新包是否被接受。
+  if (!existsSync(join(dir, 'index.html'))) {
     rmSync(dir, { recursive: true, force: true });
     throw new Error('update package has no index.html');
   }

--- a/src/desktop/src/main/updates/tar.ts
+++ b/src/desktop/src/main/updates/tar.ts
@@ -50,10 +50,18 @@ export function extractTarGz(archive: Buffer, destination: string): string[] {
     const size = readOctal(header, 124, 12);
     const typeflag = readString(header, 156, 1) || '0';
     const prefix = readString(header, 345, 155);
-    const rel = prefix ? `${prefix}/${name}` : name;
+    const raw = prefix ? `${prefix}/${name}` : name;
     offset += BLOCK;
 
-    if (!rel) throw new Error('tar: empty entry name');
+    if (!raw) throw new Error('tar: empty entry name');
+    // CI 用 `tar -C dist .` 打包，条目名形如 ./index.html、./pdfjs/，且**第一条就是
+    // "./" 目标目录自身**。去掉 ./ 前缀与结尾斜杠得到规范相对路径；归一化后为空
+    // 说明这条就是根目录，跳过即可——不是错误。
+    const rel = raw.replace(/^\.\/+/, '').replace(/\/+$/, '');
+    if (!rel) {
+      offset += Math.ceil(size / BLOCK) * BLOCK;
+      continue;
+    }
     if (size < 0 || size > MAX_FILE_BYTES) throw new Error(`tar: entry too large: ${rel}`);
     total += size;
     if (total > MAX_TOTAL_BYTES) throw new Error('tar: archive exceeds size limit');

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -72,6 +72,8 @@ export interface UpdateInfo {
   contract?: number;
   downloadUrl?: string;
   downloadSize?: number;
+  /** 整包安装器地址；热更新装不上时退回它。 */
+  installerUrl?: string;
 }
 
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -391,6 +391,31 @@ void app.whenReady().then(async () => {
   }
   check('正常包可解出文件', extracted.includes('meta.json'), `files=${extracted.join(',')}`);
 
+  // CI 用 `tar -C dist .` 打包，条目名带 ./ 前缀。第一版漏了这个形态，导致
+  // index.html 的存在性检查永远失败、热更新必然被拒——只有对着真实产物才查得出来。
+  let dotted: string[] = [];
+  try {
+    dotted = extractTarGz(
+      gzip(Buffer.concat([tarEntry('./index.html', '<html></html>'), Buffer.alloc(1024)])),
+      scratch,
+    );
+  } catch (err) {
+    dotted = [`threw: ${String(err)}`];
+  }
+  check('./ 前缀的条目名被归一化', dotted.includes('index.html'), `files=${dotted.join(',')}`);
+
+  // 同一条命令的第一个条目是 "./" 目录本身，归一化后为空——必须跳过而不是报错。
+  let withRoot: string[] = [];
+  try {
+    withRoot = extractTarGz(
+      gzip(Buffer.concat([tarEntry('./', '', '5'), tarEntry('./index.html', 'x'), Buffer.alloc(1024)])),
+      scratch,
+    );
+  } catch (err) {
+    withRoot = [`threw: ${String(err)}`];
+  }
+  check('根目录条目 "./" 被跳过而非报错', withRoot.includes('index.html'), `files=${withRoot.join(',')}`);
+
   const rejects = (label: string, archive: Buffer) => {
     let threw = false;
     try {


### PR DESCRIPTION
**The hot-update path in #177 could never have worked.** Two bugs, both found by running the extractor against the artifact v0.3.0 actually published rather than against a hand-built archive.

## What was wrong

CI packs the bundle with `tar -C dist .`, so every entry is named `./index.html`, `./pdfjs/…` — and the very first entry is `./` itself. The extractor returned those names verbatim, and the caller asserted `files.includes('index.html')`, which is never true for `./index.html`. Every hot update would have been rejected as *"update package has no index.html"*.

Normalising the names surfaced a second failure immediately: `./` normalises to an empty string, and the extractor rejected empty names outright. So the first fix turned one guaranteed failure into another.

Entry names are now normalised, and a name that normalises to empty is understood as the destination directory and skipped. The `index.html` check reads the filesystem instead of the returned list, so how the archive was packed no longer decides whether an update is accepted.

## Why the tests missed it

The smoke assertions built archives with bare filenames (`meta.json`), which is not the shape CI produces. Both shapes are covered now — `./`-prefixed entries and the `./` root entry.

Verified against the real `renderer-0.3.0-c1.tar.gz`: 321 files extracted, `index.html` present in both the returned list and on disk, `meta.json` reading `{"version":"0.3.0","contract":1}`, nested paths normalised to `pdfjs/cmaps/…`.

## Fallback

A failed renderer install now falls back to downloading the installer instead of stopping at *"update failed"*.

This matters immediately rather than hypothetically: **v0.3.0 clients ship the broken extractor**. Without the fallback, their first update attempt would dead-end on the very bug this PR fixes, instead of offering the full package that carries the fix. With it, they take the installer path once and hot updates work from then on.
