### PR TITLE
fix(libraries): one rule for who can manage a library

### DIFF
--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -25,7 +25,7 @@ from app.models.library_direction import (
     LibraryPaper,
     TopicSourceLibrary,
 )
-from app.models.paper import Paper, PaperWiki, paper_concepts
+from app.models.paper import CONCEPT_STATUS_ACTIVE, Concept, Paper, PaperWiki, paper_concepts
 from app.models.project import Project, ProjectMember
 from app.models.user import User
 
@@ -321,14 +321,19 @@ async def _library_stats(
     for lib_id, count, compiled_at in paper_rows.all():
         paper_counts[lib_id] = int(count)
         last_compiled[lib_id] = compiled_at
-    # 概念是全平台一份、不属于任何库：库的概念数 = 库内论文关联到的概念去重计数
+    # 概念是全平台一份、不属于任何库：库的概念数 = 库内论文关联到的**正式**概念去重计数
+    # （候选词条不对用户可见，也就不该计入库卡片上的概念数）
     concept_rows = await session.execute(
         select(
             LibraryPaper.library_id,
             func.count(func.distinct(paper_concepts.c.concept_id)),
         )
         .join(paper_concepts, paper_concepts.c.paper_id == LibraryPaper.paper_id)
-        .where(LibraryPaper.library_id.in_(library_ids))
+        .join(Concept, Concept.id == paper_concepts.c.concept_id)
+        .where(
+            LibraryPaper.library_id.in_(library_ids),
+            Concept.status == CONCEPT_STATUS_ACTIVE,
+        )
         .group_by(LibraryPaper.library_id)
     )
     concept_counts = {lib_id: int(count) for lib_id, count in concept_rows.all()}
@@ -422,7 +427,6 @@ async def list_libraries_overview(
     paper_counts, last_compiled, concept_counts = await _library_stats(
         session, [lib.id for lib in libraries]
     )
-    my_projects = await _my_project_ids(session, user.id)
     my_linked = await _my_linked_library_ids(session, user.id)
     my_curated = await _my_curated_library_ids(session, user.id)
     owner_names = await _owner_names(session, (lib.submitted_by for lib in libraries))
@@ -441,11 +445,8 @@ async def list_libraries_overview(
             _overview_dict(
                 lib,
                 my_linked=my_linked,
-                can_manage=(
-                    user.role == "admin"
-                    or lib.id in my_curated
-                    or lib.submitted_by == user.id
-                    or (lib.project_id is not None and lib.project_id in my_projects)
+                can_manage=can_manage_library_row(
+                    user=user, library=lib, curated_ids=my_curated
                 ),
                 paper_count=paper_counts.get(lib.id, 0),
                 concept_count=concept_counts.get(lib.id, 0),
@@ -493,7 +494,6 @@ async def source_libraries_overview(
     libraries = await get_source_libraries(session, topic_id)
     ids = [lib.id for lib in libraries]
     paper_counts, last_compiled, concept_counts = await _library_stats(session, ids)
-    my_projects = await _my_project_ids(session, user.id)
     my_linked = await _my_linked_library_ids(session, user.id)
     my_curated = await _my_curated_library_ids(session, user.id)
     owner_names = await _owner_names(session, (lib.submitted_by for lib in libraries))
@@ -501,11 +501,8 @@ async def source_libraries_overview(
         _overview_dict(
             lib,
             my_linked=my_linked,
-            can_manage=(
-                user.role == "admin"
-                or lib.id in my_curated
-                or lib.submitted_by == user.id
-                or (lib.project_id is not None and lib.project_id in my_projects)
+            can_manage=can_manage_library_row(
+                user=user, library=lib, curated_ids=my_curated
             ),
             paper_count=paper_counts.get(lib.id, 0),
             concept_count=concept_counts.get(lib.id, 0),
@@ -866,6 +863,23 @@ async def can_manage_library(
     if library.submitted_by is not None and library.submitted_by == user.id:
         return True
     return await is_library_curator(session, library_id=library.id, user_id=user.id)
+
+
+def can_manage_library_row(
+    *, user: User, library: DirectionLibrary, curated_ids: set[uuid.UUID]
+) -> bool:
+    """:func:`can_manage_library` 的同步批量版：规则一字不差，只是策展人判定由
+    调用方一次查好（``curated_ids`` = 该用户策展的全部库 id）。
+
+    列表页逐库 await 会变成 N 次查询，所以有这个版本；但规则**只能有一份**——
+    两处各写各的正是此前「同一个库在列表里能管、点进详情不能管」的来源。
+    改动规则时两个函数一起改。
+    """
+    if user.role == "admin":
+        return True
+    if library.submitted_by is not None and library.submitted_by == user.id:
+        return True
+    return library.id in curated_ids
 
 
 async def get_managed_project(


### PR DESCRIPTION
Closes #176.

`can_manage` was computed three ways:

| Where | How |
|---|---|
| `library_overview` (single library) | `can_manage_library(...)` |
| `list_libraries_overview` | inlined |
| `source_libraries_overview` | inlined, same expression |

Both inlined copies carried an extra clause — *"I'm a member of the library's origin topic"* — that was **deliberately dropped** from `can_manage_library` when libraries were decoupled from topics (#145). `project_id` became provenance rather than ownership, and migration `b3d81f6c05a9` backfilled everyone who had been managing through that path as an explicit curator. The inlined copies never followed.

Result: **the same library could offer management actions in a list and refuse them on its own page.**

## The fix

The rule lives in `can_manage_library`, with a synchronous batch variant (`can_manage_library_row`) for the lists — they already prefetch the curator set, so sharing the rule costs no extra queries. Both docstrings say the two must change together.

It also **saves** two queries: the topic-membership prefetch existed only to feed the stale clause, and its helper had no other callers.

## Nobody could have hit this yet

The one account on this deployment is an admin, who passes under either rule — 0 users currently match "member of a library's origin topic, not a curator, not an admin". It would have surfaced the day a second person joined a topic, in the confusing form of buttons that vanish when clicked.

## Verification

155 tests across the library, governance and authz suites. `ruff check app` clean.

Same shape as #175, where task list visibility and task detail access had drifted apart and were collapsed onto one predicate. Two definitions of one rule will always drift; this is the second instance found this week.