### PR TITLE
fix(index): gate every bulk full-text rebuild behind the user's switch

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -30,6 +30,7 @@ from app.api.auth import (
     require_llm_chat,
     require_llm_task,
 )
+from app.api.wiki import require_fulltext_index_enabled
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
@@ -903,8 +904,11 @@ async def rebuild_library_fulltext_index(
     """库作用域全文索引重建（可管理者）：给本库已有全文但缺分段的论文补分段并嵌入。
 
     幂等：已有分段的论文跳过；新入库论文由建库流水线自动处理，通常无需手动调用。
+    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED），与个人库/书架/课题
+    那三个批量重建端点同一口径。
     """
     library = await _get_managed_library(session, library_id, user)
+    require_fulltext_index_enabled(user)
     try:
         return await chunks_service.rebuild_library_fulltext_index(
             session,

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -350,9 +350,14 @@ async def chat_with_personal_library(
     return _chat_stream_response(messages, sources, user_id=user_id, project_id=None)
 
 
-def _require_fulltext_index_enabled(user: User) -> None:
+def require_fulltext_index_enabled(user: User) -> None:
     """全文索引门控：用户在设置里**显式关掉**才 409（默认开，与 chunks
-    .user_wants_fulltext_index 同一口径）。"""
+    .user_wants_fulltext_index 同一口径）。
+
+    所有**批量**建索引/重建索引的端点都要过这一道（含 libraries.py 的库作用域版本），
+    否则用户关掉开关后，换个入口点一下照样烧额度。单篇的手动重建按钮不过——那是
+    用户当场指定这一篇，与「要不要自动建」是两回事。
+    """
     if user.setting("chat_fulltext_index") is False:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INDEXING_DISABLED")
 
@@ -386,7 +391,7 @@ async def rebuild_shelf_fulltext_index(
     需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。长任务走 worker。
     """
     await _member_project(session, project_id, user)
-    _require_fulltext_index_enabled(user)
+    require_fulltext_index_enabled(user)
     paper_ids = await shelf_paper_ids(session, project_id=project_id)
     indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "shelf", str(user.id), str(project_id))
@@ -407,7 +412,7 @@ async def rebuild_personal_fulltext_index(
 
     需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。长任务走 worker。
     """
-    _require_fulltext_index_enabled(user)
+    require_fulltext_index_enabled(user)
     paper_ids = await personal_paper_ids(session, user_id=user.id, tab="saved")
     indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "personal", str(user.id), None)
@@ -427,8 +432,10 @@ async def rebuild_fulltext_index(
     """重建全文分段索引（docs/api-lit.md §8）：给已有全文但缺分段的论文补分段并嵌入。
 
     幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
+    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。
     """
     await _member_project(session, project_id, user)
+    require_fulltext_index_enabled(user)
     # 分段重建是「某具体库」的维护写操作（计库预算），落在课题起源库上
     library = await get_library_for_project(session, project_id)
     if library is None:

--- a/src/backend/tests/test_chat_fulltext_index.py
+++ b/src/backend/tests/test_chat_fulltext_index.py
@@ -233,3 +233,50 @@ async def test_personal_index_rebuild_gated(client, queue_stub):
     assert func_name == "index_papers_fulltext_task"
     assert args[0] == "personal"
     assert args[2] is None
+
+
+async def test_project_index_rebuild_gated(client):
+    """课题作用域批量重建同样过门控——此前漏了，用户关掉开关换这个入口照样烧额度。"""
+    project_id, headers = await _project(client)
+
+    # 开关默认开：没设置过也能建
+    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    await _disable_index(client, headers)
+    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "INDEXING_DISABLED"
+
+    await _enable_index(client, headers)
+    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+
+
+async def test_library_index_rebuild_gated(client):
+    """库作用域批量重建同样过门控（与课题/个人库/书架同一口径）。
+
+    鉴权先于门控：无权管理的人拿到的仍是 403，不因自己关了开关就变成 409——
+    否则这个端点会把「你管不了这个库」说成「你没开索引」，误导排查方向。
+    """
+    from tests.test_library_scoped_capabilities import _hdr, _setup
+
+    creator, _admin, lib_id = await _setup(client, prefix="idxgate")
+
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
+    assert resp.status_code == 200, resp.text
+
+    await _disable_index(client, creator)
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "INDEXING_DISABLED"
+
+    # 关着开关的陌生人拿 403（鉴权先跑），不是 409
+    stranger = await _hdr(client, "idxgate-stranger@example.com")
+    await _disable_index(client, stranger)
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=stranger)
+    assert resp.status_code == 403
+
+    await _enable_index(client, creator)
+    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
+    assert resp.status_code == 200, resp.text

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -222,12 +222,12 @@ function ChatPrefsTab() {
       <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div id="pref-chat-fulltext" style={{ fontSize: 13, lineHeight: 1.4 }}>
-            {tr('为论文建立全文索引', 'Build a full-text index for papers')}
+            {tr('让文献对话能引用论文正文', 'Let literature chat cite the paper body')}
           </div>
           <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
             {tr(
-              '文献对话检索得更准；会消耗你的模型额度抓取和嵌入全文。',
-              'Literature chat retrieves more accurately; uses your model quota to fetch and embed the full text.',
+              '关掉后对话仍能找到论文，但只匹配得到标题和摘要，引不出正文细节。会消耗你的模型额度抓取和嵌入全文。',
+              'When off, chat can still find papers but only matches their title and abstract, never details from the body. Uses your model quota to fetch and embed the full text.',
             )}
           </div>
         </div>
@@ -1662,12 +1662,12 @@ function PaperEmbeddingSection() {
       <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div id="paper-embedding-toggle" style={{ fontSize: 13, lineHeight: 1.4 }}>
-            {tr('为入库的论文建立向量', 'Build vectors for papers as they are added')}
+            {tr('让论文能被语义搜索找到', 'Let papers be found by semantic search')}
           </div>
           <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
             {tr(
-              '所有入库方式都适用（建库、手动添加、每日推送）。这是全平台的总开关，关掉后语义检索只能找到已经建过向量的论文，一般不用动。',
-              'Applies to every way papers are added (library builds, manual adds, daily papers). This is the platform-wide switch; when off, semantic search only finds papers that already have vectors. Rarely needs changing.',
+              '索引标题、作者与摘要，所有入库方式都适用（建库、手动添加、每日推送）。这是全平台的总开关，关掉后语义搜索和文献对话都会失效，一般不用动。',
+              'Indexes title, authors and abstract, for every way papers are added (library builds, manual adds, daily papers). This is the platform-wide switch; when off, both semantic search and literature chat stop working. Rarely needs changing.',
             )}
           </div>
         </div>


### PR DESCRIPTION
## Why

The per-user "build a full-text index" setting was enforced on only two of the four bulk rebuild endpoints:

| Endpoint | Gated before |
|---|---|
| `POST /library/index/rebuild` (personal) | ✅ |
| `POST /projects/{id}/shelf/index/rebuild` | ✅ |
| `POST /projects/{id}/index/rebuild` | ❌ |
| `POST /libraries/{id}/index/rebuild` | ❌ |

Same action, two different behaviours depending on which button you pressed. A user who had deliberately turned the setting off could still spend model quota by rebuilding from the library or project entry point.

## What changed

`_require_fulltext_index_enabled` becomes public `require_fulltext_index_enabled` and now guards all four endpoints.

Authorization still runs first: someone who cannot manage a library gets **403**, not a message claiming their index setting is off — otherwise the error would point at the wrong thing entirely.

The **single-paper** rebuild button on the wiki page stays exempt deliberately. It acts on one paper the user just picked, which is a different question from whether to index automatically. This is now written down in the helper's docstring so it does not read as another oversight.

## Settings copy

Both vector toggles said they "build vectors" without naming what gets indexed or what stops working when off, which made them easy to confuse with each other:

- **Paper vectors** (admin) → now says it indexes title, authors and abstract, and that turning it off breaks both semantic search and literature chat.
- **Full-text index** (per user) → now says chat can still find the paper but only matches title and abstract, never details from the body.

## Tests

Two new tests in `test_chat_fulltext_index.py` covering the newly gated endpoints: default-on → 200, explicitly off → 409 `INDEXING_DISABLED`, back on → 200, plus the 403-before-409 ordering.

44 passed across the affected suites (`test_chat_fulltext_index`, `test_library_scoped_capabilities`, `test_library_authz_after_decoupling`, `test_library_chat`, `test_scoped_chat`, `test_wiki_api`); `ruff check app` clean; `tsc --noEmit` exit 0.

## Not touched

Chunk *splitting* remains ungated everywhere, and the abstract-fallback chunk still copies the paper-level vector for free on every path — a user who turns off full-text indexing keeps their papers findable in chat at abstract granularity. Verified both pending-embedding queues select `source == "fulltext"` only, so the fallback chunk never reaches the paid path.