### PR TITLE
fix(tests): point the latex stubs at the renamed compile seam

### DIFF
--- a/src/backend/tests/test_manuscript_versions.py
+++ b/src/backend/tests/test_manuscript_versions.py
@@ -23,13 +23,15 @@ async def _clean_crdt():
 
 @pytest_asyncio.fixture(autouse=True)
 def _stub_tectonic(monkeypatch):
-    def ok_run(binary: str, workdir: Path) -> TectonicRun:
+    def ok_run(engine: str, binary: str, workdir: Path, main_name: str) -> TectonicRun:
         (workdir / "main.pdf").write_bytes(b"%PDF stub")
         (workdir / "main.log").write_text("", encoding="utf-8")
         return TectonicRun(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(latex_compile, "_find_tectonic", lambda: "/usr/bin/tectonic")
-    monkeypatch.setattr(latex_compile, "_run_tectonic", ok_run)
+    monkeypatch.setattr(
+        latex_compile, "_resolve_engine", lambda requested: ("tectonic", "/usr/bin/tectonic")
+    )
+    monkeypatch.setattr(latex_compile, "_run_engine", ok_run)
 
 
 async def _setup(client):

--- a/src/backend/tests/test_paper_review.py
+++ b/src/backend/tests/test_paper_review.py
@@ -61,7 +61,7 @@ async def _clean_crdt():
 def _stub_tectonic(monkeypatch):
     """假 tectonic：用 pymupdf 产出真实可渲染的 main.pdf（评审渲染步骤走真路径）。"""
 
-    def ok_run(binary: str, workdir: Path) -> TectonicRun:
+    def ok_run(engine: str, binary: str, workdir: Path, main_name: str) -> TectonicRun:
         import pymupdf
 
         doc = pymupdf.open()
@@ -72,8 +72,10 @@ def _stub_tectonic(monkeypatch):
         (workdir / "main.log").write_text("", encoding="utf-8")
         return TectonicRun(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(latex_compile, "_find_tectonic", lambda: "/usr/bin/tectonic")
-    monkeypatch.setattr(latex_compile, "_run_tectonic", ok_run)
+    monkeypatch.setattr(
+        latex_compile, "_resolve_engine", lambda requested: ("tectonic", "/usr/bin/tectonic")
+    )
+    monkeypatch.setattr(latex_compile, "_run_engine", ok_run)
 
 
 def _make_engine() -> tuple[VoyageEngine, RecordingBus]:


### PR DESCRIPTION
## Why

#152 renamed `latex_compile._run_tectonic` to `_run_engine` and widened its signature to `(engine, binary, workdir, main_name)`. It updated the stubs in `test_latex_compile` and `test_writing_voyage` — but two other suites patch the same seam and were missed.

Since then their fixtures have been raising `AttributeError` at setup:

- `test_paper_review.py` — **16 errors**, the whole suite
- `test_manuscript_versions.py` — same fixture, same fault

So the entire paper-review pipeline has had **no test coverage running** since #152 merged.

## What changed

Both fixtures now patch `_resolve_engine` and `_run_engine` with the current four-argument signature, matching the two suites that were updated at the time. `test_paper_review` keeps its pymupdf stub that emits a genuinely renderable PDF, since the review step exercises the real render path.

## Tests

31 passed across every suite that stubs this seam: `test_paper_review`, `test_manuscript_versions`, `test_latex_compile`, `test_writing_voyage`, `test_manuscript_export`.

## Note

`monkeypatch.setattr` does raise on a missing attribute, so the drift was detected — it just surfaced as errors nobody was reading. Worth wiring the suite into CI signal if it is not already.