### PR TITLE
fix(desktop): compare against the interface the user is actually running

### DIFF
--- a/src/desktop/src/main/ipc/methods.host.ts
+++ b/src/desktop/src/main/ipc/methods.host.ts
@@ -2,6 +2,7 @@ import { app, clipboard, net, shell } from 'electron';
 
 import type { HostInfo, ServerProbe } from '../../shared/contract';
 import { readConfig, writeConfig } from '../store';
+import { effectiveVersion } from '../updates/renderer-store';
 import { recreateWindow } from '../window';
 
 const PROBE_TIMEOUT_MS = 5_000;
@@ -10,7 +11,7 @@ export function hostInfo(): HostInfo {
   return {
     serverUrl: readConfig().serverUrl,
     platform: process.platform as HostInfo['platform'],
-    appVersion: app.getVersion(),
+    appVersion: effectiveVersion(),
   };
 }
 

--- a/src/desktop/src/main/updates/index.ts
+++ b/src/desktop/src/main/updates/index.ts
@@ -21,7 +21,8 @@ import { join } from 'node:path';
 import { CONTRACT_VERSION, type UpdateInfo } from '../../shared/contract';
 import { fail, finish, log, progress, startJob } from '../ipc/events';
 import { getWindow } from '../window';
-import { stageRenderer } from './renderer-store';
+import { effectiveVersion, stageRenderer } from './renderer-store';
+import { compareVersions } from './version';
 
 const REPO = 'ZJU-REAL/Polaris';
 const RELEASES_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
@@ -41,25 +42,6 @@ interface Release {
   assets: Asset[];
 }
 
-/** 只比较 major.minor.patch；带后缀的（如 0.2.1-win-test）视为该版本的预发布，更低。 */
-function compareVersions(a: string, b: string): number {
-  const parse = (v: string) => {
-    const [core, pre] = v.replace(/^v/, '').split('-', 2);
-    const nums = (core ?? '').split('.').map((n) => parseInt(n, 10) || 0);
-    return { nums, pre: pre ?? '' };
-  };
-  const x = parse(a);
-  const y = parse(b);
-  for (let i = 0; i < 3; i += 1) {
-    const d = (x.nums[i] ?? 0) - (y.nums[i] ?? 0);
-    if (d !== 0) return d > 0 ? 1 : -1;
-  }
-  if (x.pre === y.pre) return 0;
-  if (!x.pre) return 1; // 正式版 > 预发布
-  if (!y.pre) return -1;
-  return x.pre > y.pre ? 1 : -1;
-}
-
 function installerFor(assets: Asset[]): Asset | undefined {
   const match = (re: RegExp) => assets.find((a) => re.test(a.name));
   if (process.platform === 'darwin') return match(/universal\.dmg$/) ?? match(/\.dmg$/);
@@ -70,7 +52,7 @@ function installerFor(assets: Asset[]): Asset | undefined {
 let cached: UpdateInfo | null = null;
 
 export async function checkForUpdate(): Promise<UpdateInfo> {
-  const currentVersion = app.getVersion();
+  const currentVersion = effectiveVersion();
   const base: UpdateInfo = { available: false, currentVersion };
   try {
     const res = await net.fetch(RELEASES_URL, {

--- a/src/desktop/src/main/updates/renderer-store.ts
+++ b/src/desktop/src/main/updates/renderer-store.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 
 import { CONTRACT_VERSION } from '../../shared/contract';
 import { extractTarGz } from './tar';
+import { stagedSupersedes } from './version';
 
 /** 更新包里必须带的元信息，解包后校验。 */
 export interface RendererMeta {
@@ -57,11 +58,27 @@ export function stagedRendererDir(): string | null {
   const p = readPointer();
   if (!p) return null;
   if (p.contract > CONTRACT_VERSION) return null;
+  // 整包更新后包内自带的界面可能已经反超，那份旧的必须让位并就地清掉，
+  // 否则新外壳会一直提供旧界面。
+  if (!stagedSupersedes(p.version, app.getVersion())) {
+    clearStagedRenderer();
+    return null;
+  }
   return p.dir;
 }
 
 export function stagedVersion(): string | null {
   return readPointer()?.version ?? null;
+}
+
+/**
+ * 用户眼前这份界面的版本。更新检查与「关于」都必须用它而不是 `app.getVersion()`：
+ * 热更新不换外壳，外壳版本装完新界面也不会变。
+ */
+export function effectiveVersion(): string {
+  const staged = stagedVersion();
+  const shell = app.getVersion();
+  return staged && stagedSupersedes(staged, shell) ? staged : shell;
 }
 
 /** 解包并启用一份新界面。抛错即视为失败，调用方不应切换。 */

--- a/src/desktop/src/main/updates/version.ts
+++ b/src/desktop/src/main/updates/version.ts
@@ -1,0 +1,37 @@
+/* ============================================================
+   版本比较。单独成文件是因为两处都要用，而它们互相 import 会成环：
+   updates/index.ts（判断有没有新版）与 updates/renderer-store.ts（判断热更新
+   装的那份界面是否还比外壳自带的新）。这里不 import electron，纯函数好测。
+   ============================================================ */
+
+/** 只比较 major.minor.patch；带后缀的（如 0.2.1-win-test）视为该版本的预发布，更低。 */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core, pre] = v.replace(/^v/, '').split('-', 2);
+    const nums = (core ?? '').split('.').map((n) => parseInt(n, 10) || 0);
+    return { nums, pre: pre ?? '' };
+  };
+  const x = parse(a);
+  const y = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    const d = (x.nums[i] ?? 0) - (y.nums[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  if (x.pre === y.pre) return 0;
+  if (!x.pre) return 1; // 正式版 > 预发布
+  if (!y.pre) return -1;
+  return x.pre > y.pre ? 1 : -1;
+}
+
+/**
+ * 热更新装的那份界面是否仍然有效——即它比外壳自带的那份新。
+ *
+ * 两个方向都要靠这一条判断，漏掉任一个都会坏：
+ * - 不新了就必须丢弃。整包更新把外壳升到 0.4.0 后，留在 userData 里的 0.3.2
+ *   界面比包内自带的旧，继续提供它等于让用户在新外壳上跑旧界面。
+ * - 新的就得算数。热更新只换界面、不换外壳，`app.getVersion()` 仍是旧值；
+ *   更新检查若拿它去比，装完新界面后还会认为自己是旧版，同一个更新反复提示。
+ */
+export function stagedSupersedes(stagedVersion: string, shellVersion: string): boolean {
+  return compareVersions(stagedVersion, shellVersion) > 0;
+}

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -25,6 +25,7 @@ import { pingAgent, stopAgent } from './main/agent/supervisor';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
 import { extractTarGz } from './main/updates/tar';
+import { compareVersions, stagedSupersedes } from './main/updates/version';
 import { APP_INDEX, buildCsp, handleAppProtocol, registerAppScheme } from './main/protocol';
 
 const SERVER_URL = 'https://polaris.example.edu';
@@ -434,6 +435,14 @@ void app.whenReady().then(async () => {
     gzip(Buffer.concat([tarEntry('link', '', '2'), Buffer.alloc(1024)])),
   );
   rmSync(scratch, { recursive: true, force: true });
+
+  console.log('\n[版本比较]');
+  check('版本序：patch/minor/major', compareVersions('0.3.2', '0.3.1') > 0 && compareVersions('0.3.10', '0.3.9') > 0 && compareVersions('0.4.0', '0.3.99') > 0);
+  check('正式版高于同号预发布', compareVersions('0.3.1', '0.3.1-win-test') > 0 && compareVersions('0.3.1', '0.3.1') === 0);
+  // 热更新只换界面，外壳版本不动。装完 0.3.2 后若仍拿外壳的 0.3.1 去比，
+  // 同一个更新会被无限提示——这两条就是防这个的。
+  check('热更装上的新界面参与版本比较', stagedSupersedes('0.3.2', '0.3.1'));
+  check('整包更新反超后旧界面失效', !stagedSupersedes('0.3.2', '0.4.0') && !stagedSupersedes('0.3.2', '0.3.2'));
 
   if (process.env.POLARIS_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();


### PR DESCRIPTION
Found while preparing the v0.3.2 tag that verifies hot update end to end. Left in, that verification would have shown an update arrow that never goes away.

## The version and the interface had drifted apart

A hot update swaps the renderer and deliberately leaves the shell alone — that is the whole reason it can sidestep macOS code signing. But `app.getVersion()` reports what the *installer* wrote, and the update check compared against that. So a client that had just hot-updated to 0.3.2 still believed it was on 0.3.1, saw 0.3.2 on the releases page, and offered the update again. Every check. Forever.

The same confusion runs the other way. Once an installer moves the shell past a staged renderer, the older staged copy kept being served over the newer one the package ships with — a full update could silently leave the old interface in place.

## One question, asked in both directions

Both cases reduce to: *is the staged renderer still newer than the shell?* `compareVersions` moves out of `updates/index.ts` into `updates/version.ts` (the two callers would otherwise import each other in a cycle) alongside `stagedSupersedes`, and both sides ask it. A staged renderer that is no longer newer is dropped where it is found, rather than lingering until something else notices.

What the update check compares, what `host.info` reports, and what `app://` serves are now the same version.

## Tests

`stagedSupersedes` and `compareVersions` are pure, so smoke asserts them directly — including the two failure modes above, and that a release ranks above its own prerelease (`0.3.1` > `0.3.1-win-test`).