### PR TITLE
feat(mcp): self-check, try-it and a playground for the MCP tool catalog

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -133,3 +133,26 @@ The read-only tool registry in `app/tools/` is the single source of truth for re
 both by the internal agent loop and by the external MCP server in `app/mcp/`. Adding a tool is a
 single handler in `app/tools/`; it then becomes visible to both consumers. See the tool layer in
 [Core Concepts](concepts.md#the-mcp-read-only-tool-layer).
+
+### Testing the tools
+
+Tool handlers call into `services/*`, so a refactor there (changed signature, dropped field, new
+table layout) does not break imports — it breaks the tool at call time. Two endpoints exist to catch
+that, both routed through `app/mcp/dispatch.call_tool`, the exact path external MCP clients take:
+
+| Endpoint | What it does |
+| --- | --- |
+| `POST /api/mcp/tools/{name}/invoke` | Runs one tool with arguments you supply and returns the raw MCP content blocks (text plus inline images), so you see what a client would see. |
+| `POST /api/mcp/selfcheck` | Collects sample data from a topic (a paper, a figure, a concept, an idea, an experiment, a manuscript), fills each tool's required arguments, and runs the whole catalog, reporting `ok` / `error` / `skipped` per tool. |
+
+Both live behind the **Settings → MCP** page: a topic picker, a one-click self-check that badges
+every tool card, and a per-tool "try it" panel prefilled with the self-check's sample arguments.
+
+Sample arguments are chosen to keep a self-check cheap and deterministic: filter-style optional
+parameters are left unset, `mode` is pinned to `keyword` so no embedding call is made, and figure
+tools render at 512 px. Network tools are skipped unless `include_network` is set, since they really
+call Semantic Scholar and OpenAlex. A tool whose required argument has no sample in that topic (no
+manuscript yet, no extracted figures) is reported as `skipped`, not as a failure.
+
+`tests/test_mcp_server.py::test_selfcheck` runs the same self-check against the test fixtures and
+fails if any tool reports `error`, so tool rot surfaces in CI rather than in a client.

--- a/docs/development.md
+++ b/docs/development.md
@@ -145,14 +145,25 @@ that, both routed through `app/mcp/dispatch.call_tool`, the exact path external 
 | `POST /api/mcp/tools/{name}/invoke` | Runs one tool with arguments you supply and returns the raw MCP content blocks (text plus inline images), so you see what a client would see. |
 | `POST /api/mcp/selfcheck` | Collects sample data from a topic (a paper, a figure, a concept, an idea, an experiment, a manuscript), fills each tool's required arguments, and runs the whole catalog, reporting `ok` / `error` / `skipped` per tool. |
 
-Both live behind the **Settings → MCP** page: a topic picker, a one-click self-check that badges
-every tool card, and a per-tool "try it" panel prefilled with the self-check's sample arguments.
+Both live behind the **Settings → MCP** page, which has two views:
+
+- **Tool catalog** — every tool as a card, badged with its self-check result, each with an inline
+  "try it" panel prefilled with the self-check's sample arguments.
+- **Playground** — a searchable tool list plus a full debugging panel: a schema-generated argument
+  form or hand-written JSON, the response rendered exactly as a client receives it (text and inline
+  images), the equivalent JSON-RPC `tools/call` request (copyable, to replay from your own client),
+  and this session's call history, where clicking an entry replays its arguments and result.
 
 Sample arguments are chosen to keep a self-check cheap and deterministic: filter-style optional
 parameters are left unset, `mode` is pinned to `keyword` so no embedding call is made, and figure
 tools render at 512 px. Network tools are skipped unless `include_network` is set, since they really
 call Semantic Scholar and OpenAlex. A tool whose required argument has no sample in that topic (no
 manuscript yet, no extracted figures) is reported as `skipped`, not as a failure.
+
+`search_papers`, `search_chunks`, and `find_figures` all take `mode` (`keyword` | `semantic`), and
+all three fall back to keyword search when the embedding call fails for any reason — the embedding
+service being unreachable degrades result quality, it does not take the tool down. Without that
+fallback a dead embedding host turned into a ~48s retry storm and a red self-check.
 
 `tests/test_mcp_server.py::test_selfcheck` runs the same self-check against the test fixtures and
 fails if any tool reports `error`, so tool rot surfaces in CI rather than in a client.

--- a/src/backend/app/api/mcp_meta.py
+++ b/src/backend/app/api/mcp_meta.py
@@ -1,19 +1,35 @@
-"""MCP 元信息（供前端「MCP 工具」页展示工具目录与接入信息）。
+"""MCP 元信息与工具测试（供前端「MCP 接入」页展示目录、试运行、一键自检）。
 
-只读、非项目相关：任何登录用户都可看工具目录。MCP 协议本身在 ``POST /mcp``
-（见 app/mcp/http.py、docs/api-mcp.md）；这里只返回给前端渲染用的静态目录。
+- ``GET  /mcp/tools``：工具目录 + 接入信息（只读、非项目相关）。
+- ``POST /mcp/tools/{name}/invoke``：单个工具试运行，返回 MCP 客户端会收到的原始 content。
+- ``POST /mcp/selfcheck``：用课题里的真实数据把所有工具跑一遍，报告哪些已失效。
+
+后两个都走 ``app.mcp.dispatch.call_tool``——和外部 MCP 客户端完全同一条路径
+（含课题成员校验），所以页面上跑通 = 客户端也跑得通。
+MCP 协议本身在 ``POST /mcp``（见 app/mcp/http.py、docs/development.md「Testing the tools」）。
 """
 
+import asyncio
+import time
+import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
-from app.mcp.dispatch import PROTOCOL_VERSION, SERVER_INFO
+from app.core.db import get_session
+from app.mcp.dispatch import PROTOCOL_VERSION, SERVER_INFO, call_tool
+from app.mcp.selfcheck import TOOL_TIMEOUT, run_selfcheck
 from app.models.user import User
-from app.tools import list_tools
+from app.services import projects as projects_service
+from app.tools import get_tool, list_tools
 
 router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+_INVOKE_TEXT_CHARS = 20000  # 试运行的文本上限：够看清结构，又不至于撑爆页面
+_INVOKE_MAX_IMAGES = 4
 
 
 def _params(input_schema: dict[str, Any]) -> list[dict[str, Any]]:
@@ -28,6 +44,7 @@ def _params(input_schema: dict[str, Any]) -> list[dict[str, Any]]:
                 "type": schema.get("type", "string"),
                 "enum": schema.get("enum"),
                 "description": schema.get("description"),
+                "default": schema.get("default"),
             }
         )
     return out
@@ -51,3 +68,112 @@ async def list_mcp_tools(_user: User = Depends(current_active_user)) -> dict[str
             for spec in list_tools()
         ],
     }
+
+
+class ToolInvokeRequest(BaseModel):
+    """试运行入参：project_id 由服务端注入，arguments 是工具自己的参数。"""
+
+    project_id: uuid.UUID
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+def _trim_content(blocks: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """限流返回体：长文本截断、图片最多留几张（页面只是预览）。"""
+    out: list[dict[str, Any]] = []
+    truncated = False
+    images = 0
+    for block in blocks:
+        if block.get("type") == "text":
+            text = str(block.get("text") or "")
+            if len(text) > _INVOKE_TEXT_CHARS:
+                text, truncated = text[:_INVOKE_TEXT_CHARS], True
+            out.append({"type": "text", "text": text})
+        elif block.get("type") == "image":
+            if images >= _INVOKE_MAX_IMAGES:
+                truncated = True
+                continue
+            images += 1
+            out.append(block)
+        else:
+            out.append(block)
+    return out, truncated
+
+
+@router.post("/tools/{name}/invoke")
+async def invoke_mcp_tool(
+    name: str,
+    body: ToolInvokeRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """试运行单个工具：返回外部 MCP 客户端会收到的 content（文本 + 图片）。"""
+    if get_tool(name) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"未知工具：{name}")
+
+    started = time.perf_counter()
+
+    def _elapsed() -> int:
+        return round((time.perf_counter() - started) * 1000)
+
+    def _failure(text: str) -> dict[str, Any]:
+        return {
+            "name": name,
+            "is_error": True,
+            "duration_ms": _elapsed(),
+            "content": [{"type": "text", "text": text}],
+            "truncated": False,
+        }
+
+    try:
+        result = await asyncio.wait_for(
+            call_tool(
+                session,
+                user_id=user.id,
+                name=name,
+                arguments={**body.arguments, "project_id": str(body.project_id)},
+            ),
+            TOOL_TIMEOUT,
+        )
+    except TimeoutError:
+        return _failure(f"超时（>{TOOL_TIMEOUT:.0f}s）")
+    except Exception as e:  # noqa: BLE001 — 试运行要把真实异常原样回给页面
+        return _failure(f"{type(e).__name__}: {e}")
+
+    content, truncated = _trim_content(result.get("content") or [])
+    return {
+        "name": name,
+        "is_error": bool(result.get("isError")),
+        "duration_ms": _elapsed(),
+        "content": content,
+        "truncated": truncated,
+    }
+
+
+class SelfCheckRequest(BaseModel):
+    """一键自检入参。"""
+
+    project_id: uuid.UUID
+    include_network: bool = False
+    names: list[str] | None = None
+
+
+@router.post("/selfcheck")
+async def selfcheck_mcp_tools(
+    body: SelfCheckRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """用课题里的真实数据把每个工具跑一遍，报告哪些还能用、哪些已失效。"""
+    # 报告里带课题内的样本 id，必须先过成员校验（非成员一律当作课题不存在）
+    project = await projects_service.get_project(
+        session, project_id=body.project_id, user_id=user.id
+    )
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "课题不存在或无权访问")
+    return await run_selfcheck(
+        session,
+        user_id=user.id,
+        project_id=body.project_id,
+        include_network=body.include_network,
+        names=body.names,
+    )

--- a/src/backend/app/mcp/selfcheck.py
+++ b/src/backend/app/mcp/selfcheck.py
@@ -1,0 +1,336 @@
+"""MCP 工具自检：用课题里的真实数据自动配样例参数，把每个工具真跑一遍。
+
+为什么需要：工具 handler 依赖 ``services/*``，底层重构（签名变了、字段没了、
+表结构改了）不会让 import 失败，只会在**调用时**炸——静态检查看不出来，
+只有真跑一遍才知道哪个工具已经失效。
+
+自检走的正是外部 MCP 客户端的同一条路径（``dispatch.call_tool``，含成员校验 +
+project_id 注入），因此这里的结果就是 Claude Desktop / Cursor 会拿到的结果。
+
+样例参数策略（``sample_arguments``）：
+- 只填「能从课题里取到真实样本」的参数（论文/概念/想法/实验/稿件 id、检索词、图编号）；
+- 过滤类可选参数（kind/category/status/format/k/page…）一律不填，避免把结果筛空；
+- ``mode`` 固定取 keyword：确定性、且不触发 embedding（不烧钱、不受外部服务影响）；
+- 样本缺失（比如库里没有论文）→ 该工具标 skipped 并说明原因，不算失败。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp.dispatch import call_tool
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.library_direction import LibraryPaper
+from app.models.manuscript import Manuscript
+from app.models.paper import Concept, Paper
+from app.services.concepts import library_concept_ids
+from app.services.libraries import get_source_library_ids
+from app.tools import ToolSpec, list_tools
+
+# 单个工具的超时：卡死算失败，不拖垮整轮自检（联网工具也共用这个上限）
+TOOL_TIMEOUT = 60.0
+_PREVIEW_CHARS = 400
+_SAMPLE_PAPERS = 40  # 取多少篇论文来找样本（找带图的、带 DOI 的）
+_PROBE_MAX_DIM = 512  # 自检取图时缩到小图：只验证能不能取出来，不需要原尺寸
+
+# 样本缺失时给用户看的原因（大白话）
+_MISSING_REASON = {
+    "paper_id": "课题语料里还没有论文",
+    "index": "库内没有已抽取图片的论文",
+    "name": "库内还没有概念",
+    "idea_id": "课题里还没有想法",
+    "experiment_id": "课题里还没有实验",
+    "manuscript_id": "课题里还没有稿件",
+    "doi": "库内论文都没有 DOI",
+}
+
+_FALLBACK_QUERY = "learning"
+
+
+@dataclass(slots=True, frozen=True)
+class ProjectSamples:
+    """从课题里捞出来的样例数据，用于给工具配参数。"""
+
+    query: str = _FALLBACK_QUERY
+    paper_id: str | None = None
+    figure_paper_id: str | None = None
+    figure_index: int | None = None
+    doi: str | None = None
+    concept_name: str | None = None
+    idea_id: str | None = None
+    experiment_id: str | None = None
+    manuscript_id: str | None = None
+
+
+def _query_from_title(title: str | None) -> str:
+    """从论文标题里取一个检索词（最长的字母词，退化到前 12 个字符）。"""
+    if not title:
+        return _FALLBACK_QUERY
+    words = [w for w in re.findall(r"[A-Za-z][A-Za-z-]{3,}", title)]
+    if words:
+        return max(words, key=len)
+    stripped = title.strip()
+    return stripped[:12] or _FALLBACK_QUERY
+
+
+def _pick_figure(paper: Paper) -> int | None:
+    """论文里挑一张图的 index：优先「重要图」。"""
+    figs = [f for f in (paper.figures or []) if isinstance(f, dict) and f.get("index") is not None]
+    if not figs:
+        return None
+    chosen = next((f for f in figs if f.get("important")), figs[0])
+    try:
+        return int(chosen["index"])
+    except (TypeError, ValueError):
+        return None
+
+
+async def collect_samples(session: AsyncSession, *, project_id: uuid.UUID) -> ProjectSamples:
+    """扫一遍课题数据，凑出各类工具需要的样例入参。"""
+    library_ids = await get_source_library_ids(session, project_id)
+
+    papers: list[Paper] = []
+    if library_ids:
+        stmt = (
+            select(Paper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id.in_(library_ids))
+            .order_by(LibraryPaper.created_at.desc())
+            .limit(_SAMPLE_PAPERS)
+        )
+        papers = list((await session.execute(stmt)).scalars().unique())
+
+    figure_paper_id: str | None = None
+    figure_index: int | None = None
+    for paper in papers:
+        index = _pick_figure(paper)
+        if index is not None:
+            figure_paper_id, figure_index = str(paper.id), index
+            break
+
+    concept: Concept | None = None
+    if library_ids:
+        concept = (
+            (
+                await session.execute(
+                    select(Concept)
+                    .where(Concept.id.in_(library_concept_ids(library_ids)))
+                    .order_by(Concept.name)
+                    .limit(1)
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+    async def _first_id(model: Any) -> str | None:
+        row = (
+            (
+                await session.execute(
+                    select(model.id)
+                    .where(model.project_id == project_id, model.trashed_at.is_(None))
+                    .limit(1)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        return str(row) if row is not None else None
+
+    return ProjectSamples(
+        query=_query_from_title(papers[0].title if papers else None),
+        paper_id=str(papers[0].id) if papers else None,
+        figure_paper_id=figure_paper_id,
+        figure_index=figure_index,
+        doi=next((p.doi for p in papers if p.doi), None),
+        concept_name=concept.name if concept is not None else None,
+        idea_id=await _first_id(Idea),
+        experiment_id=await _first_id(Experiment),
+        manuscript_id=await _first_id(Manuscript),
+    )
+
+
+def _sample_value(
+    name: str, schema: dict[str, Any], samples: ProjectSamples, *, prefer_figure_paper: bool
+) -> Any:
+    """按参数名给一个样例值；给不出（没有样本 / 属于过滤类参数）返回 None。"""
+    if name == "paper_id":
+        if prefer_figure_paper:
+            return samples.figure_paper_id or samples.paper_id
+        return samples.paper_id
+    if name in ("query", "q"):
+        return samples.query
+    if name == "name":
+        return samples.concept_name
+    if name == "index":
+        return samples.figure_index
+    if name == "doi":
+        return samples.doi
+    if name in ("idea_id", "experiment_id", "manuscript_id"):
+        return getattr(samples, name)
+    if name == "mode" and "keyword" in (schema.get("enum") or []):
+        return "keyword"  # 确定性、不触发 embedding
+    if name == "max_dim":
+        return _PROBE_MAX_DIM
+    return None  # 过滤类可选参数（kind/category/status/format/k/page…）不填
+
+
+def sample_arguments(
+    spec: ToolSpec, samples: ProjectSamples
+) -> tuple[dict[str, Any] | None, str | None]:
+    """给工具配一组样例参数；必填项没有样本时返回 ``(None, 跳过原因)``。"""
+    props: dict[str, Any] = spec.input_schema.get("properties") or {}
+    required = set(spec.input_schema.get("required") or [])
+    # 图片类工具用「有图的论文」当样本，否则随便一篇都行
+    prefer_figure_paper = "index" in props or "figure" in spec.name
+
+    args: dict[str, Any] = {}
+    for name, schema in props.items():
+        value = _sample_value(name, schema or {}, samples, prefer_figure_paper=prefer_figure_paper)
+        if value is None:
+            if name in required:
+                return None, _MISSING_REASON.get(name, f"没有可用的样例参数 {name}")
+            continue
+        args[name] = value
+
+    # 引文类工具两个入参都可选，但至少得给一个，否则工具自己会报错
+    if spec.name in ("get_references", "get_citations") and not args.get("paper_id"):
+        return None, _MISSING_REASON["paper_id"]
+    return args, None
+
+
+def _summarize_content(result: dict[str, Any]) -> tuple[str, int]:
+    """从 MCP 返回的 content blocks 里取「首个文本 + 图片张数」。"""
+    text = ""
+    images = 0
+    for block in result.get("content") or []:
+        if block.get("type") == "text" and not text:
+            text = str(block.get("text") or "")
+        elif block.get("type") == "image":
+            images += 1
+    return text, images
+
+
+async def check_tool(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    spec: ToolSpec,
+    samples: ProjectSamples,
+) -> dict[str, Any]:
+    """跑一个工具并给出 ok / error / skipped 结论。"""
+    base = {"name": spec.name, "network": spec.network}
+    args, skip_reason = sample_arguments(spec, samples)
+    if args is None:
+        return {**base, "status": "skipped", "arguments": None, "detail": skip_reason}
+
+    started = time.perf_counter()
+    try:
+        result = await asyncio.wait_for(
+            call_tool(
+                session,
+                user_id=user_id,
+                name=spec.name,
+                arguments={**args, "project_id": str(project_id)},
+            ),
+            TOOL_TIMEOUT,
+        )
+    except TimeoutError:
+        return {
+            **base,
+            "status": "error",
+            "arguments": args,
+            "duration_ms": round((time.perf_counter() - started) * 1000),
+            "detail": f"超时（>{TOOL_TIMEOUT:.0f}s）",
+        }
+    except Exception as e:  # noqa: BLE001 — 未捕获异常正是「工具已失效」的信号
+        return {
+            **base,
+            "status": "error",
+            "arguments": args,
+            "duration_ms": round((time.perf_counter() - started) * 1000),
+            "detail": f"{type(e).__name__}: {e}",
+        }
+
+    duration_ms = round((time.perf_counter() - started) * 1000)
+    text, images = _summarize_content(result)
+    if result.get("isError"):
+        return {
+            **base,
+            "status": "error",
+            "arguments": args,
+            "duration_ms": duration_ms,
+            "detail": text,
+        }
+    return {
+        **base,
+        "status": "ok",
+        "arguments": args,
+        "duration_ms": duration_ms,
+        "preview": text[:_PREVIEW_CHARS],
+        "images": images,
+    }
+
+
+async def run_selfcheck(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    include_network: bool = False,
+    names: list[str] | None = None,
+) -> dict[str, Any]:
+    """把工具目录整体跑一遍。串行执行：一个 AsyncSession 不能并发使用。
+
+    联网工具默认只标 skipped（真跑会打外部接口、受限速影响），
+    ``include_network=True`` 时才实际调用。
+    """
+    samples = await collect_samples(session, project_id=project_id)
+    results: list[dict[str, Any]] = []
+    for spec in list_tools(names):
+        if spec.network and not include_network:
+            results.append(
+                {
+                    "name": spec.name,
+                    "network": True,
+                    "status": "skipped",
+                    "arguments": None,
+                    "detail": "默认不测联网工具（会真的请求外部文献接口）",
+                }
+            )
+            continue
+        results.append(
+            await check_tool(
+                session, user_id=user_id, project_id=project_id, spec=spec, samples=samples
+            )
+        )
+
+    counts = {"ok": 0, "error": 0, "skipped": 0}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    return {
+        "project_id": str(project_id),
+        "include_network": include_network,
+        "samples": {
+            "paper_id": samples.paper_id,
+            "figure_paper_id": samples.figure_paper_id,
+            "figure_index": samples.figure_index,
+            "concept_name": samples.concept_name,
+            "idea_id": samples.idea_id,
+            "experiment_id": samples.experiment_id,
+            "manuscript_id": samples.manuscript_id,
+            "query": samples.query,
+        },
+        "summary": {"total": len(results), **counts},
+        "results": results,
+    }

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -204,6 +204,7 @@ async def get_paper_figures(ctx: ToolContext, args: dict[str, Any]) -> ToolResul
         "properties": {
             "query": {"type": "string", "description": "主题关键词，如 检索增强 方法图"},
             "kind": {"type": "string", "enum": FIGURE_KINDS, "description": "只找某类型（可选）"},
+            "mode": {"type": "string", "enum": ["keyword", "semantic"], "default": "semantic"},
             "k": {"type": "integer", "minimum": 1, "maximum": 20, "description": "最多图数,默认8"},
         },
         "required": ["query"],
@@ -216,9 +217,10 @@ async def find_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
         raise ValueError("find_figures 需要非空 query")
     kind = str(args.get("kind") or "").strip() or None
     k = max(1, min(20, int(args.get("k") or 8)))
+    mode = str(args.get("mode") or "semantic")
 
-    # 复用库内论文检索，再从命中论文里收重要图
-    search = await _search_papers(ctx, {"query": query, "k": 8})
+    # 复用库内论文检索，再从命中论文里收重要图（mode 透传：keyword 不碰 embedding）
+    search = await _search_papers(ctx, {"query": query, "k": 8, "mode": mode})
     paper_ids = [uuid.UUID(p["paper_id"]) for p in search.get("results", [])]
     out: list[dict[str, Any]] = []
     async with get_sessionmaker()() as session:

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -28,6 +28,7 @@ _MAX_K = 12
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "检索问题/关键词"},
+            "mode": {"type": "string", "enum": ["keyword", "semantic"], "default": "semantic"},
             "k": {"type": "integer", "minimum": 1, "maximum": _MAX_K, "default": 6},
         },
         "required": ["query"],
@@ -39,12 +40,17 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     if not query:
         raise ValueError("search_chunks 需要非空 query")
     k = min(_MAX_K, max(1, int(args.get("k") or 6)))
+    mode = str(args.get("mode") or "semantic")
 
     async with get_sessionmaker()() as session:
         library_ids = await get_source_library_ids(session, ctx.project_id)
         rows: list[tuple[PaperChunk, float]] = []
         used_mode = "keyword"
-        if library_ids and chunks_service.chunk_vector_search_supported(session):
+        if (
+            mode == "semantic"
+            and library_ids
+            and chunks_service.chunk_vector_search_supported(session)
+        ):
             try:
                 vectors = await ctx.llm.embed(
                     [query],
@@ -56,7 +62,7 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                     session, library_ids=library_ids, query_vector=vectors[0], limit=k
                 )
                 used_mode = "semantic"
-            except NotImplementedError:
+            except Exception:  # noqa: BLE001 — embedding 服务挂了也要能用，降级到关键词
                 rows = []
         if not rows and library_ids:
             rows = await chunks_service.keyword_search_chunks(

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -105,7 +105,7 @@ async def search_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                     session, project_id=ctx.project_id, query_vector=vectors[0], limit=k
                 )
                 used_mode = "semantic"
-            except NotImplementedError:
+            except Exception:  # noqa: BLE001 — embedding 服务挂了也要能用，降级到关键词
                 rows = []
         if not rows:  # semantic 不可用/无召回 → 关键词降级
             rows = await papers_service.keyword_search_papers(

--- a/src/backend/tests/test_mcp_server.py
+++ b/src/backend/tests/test_mcp_server.py
@@ -149,6 +149,119 @@ async def test_catalog_endpoint(client):
     assert (await client.get("/api/mcp/tools")).status_code == 401
 
 
+async def test_invoke_tool(client):
+    """POST /api/mcp/tools/{name}/invoke：页面上的「试运行」，走的是真实 MCP 调用路径。"""
+    project_id, headers = await _setup(client, email="invoke@example.com")
+
+    resp = await client.post(
+        "/api/mcp/tools/search_papers/invoke",
+        json={"project_id": project_id, "arguments": {"query": "retrieval", "mode": "keyword"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_error"] is False
+    assert body["duration_ms"] >= 0
+    payload = json.loads(body["content"][0]["text"])
+    assert any(p["title"] == "MCP retrieval paper" for p in payload["results"])
+
+
+async def test_invoke_reports_tool_error(client):
+    """工具自己报错（缺参数）→ is_error，错误消息原样回给页面。"""
+    project_id, headers = await _setup(client, email="invoke-err@example.com")
+
+    resp = await client.post(
+        "/api/mcp/tools/search_papers/invoke",
+        json={"project_id": project_id, "arguments": {}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_error"] is True
+    assert "query" in body["content"][0]["text"]
+
+
+async def test_invoke_unknown_tool_and_auth(client):
+    project_id, headers = await _setup(client, email="invoke-404@example.com")
+    resp = await client.post(
+        "/api/mcp/tools/no_such_tool/invoke",
+        json={"project_id": project_id, "arguments": {}},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    # 需登录
+    resp = await client.post(
+        "/api/mcp/tools/search_papers/invoke",
+        json={"project_id": project_id, "arguments": {}},
+    )
+    assert resp.status_code == 401
+
+
+async def test_invoke_cross_project_denied(client):
+    """试运行同样过成员校验：拿别人的课题 id 一律当作不存在。"""
+    project_a, _ = await _setup(client, email="invoke-a@example.com")
+    _, headers_b = await _setup(client, email="invoke-b@example.com")
+
+    resp = await client.post(
+        "/api/mcp/tools/search_papers/invoke",
+        json={"project_id": project_a, "arguments": {"query": "retrieval"}},
+        headers=headers_b,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_error"] is True
+    assert "无权访问" in body["content"][0]["text"]
+
+
+async def test_selfcheck(client):
+    """POST /api/mcp/selfcheck：把工具跑一遍，报告哪些还能用、哪些已失效。"""
+    project_id, headers = await _setup(client, email="selfcheck@example.com")
+
+    resp = await client.post("/api/mcp/selfcheck", json={"project_id": project_id}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    by_name = {r["name"]: r for r in body["results"]}
+
+    # 底层重构把工具搞挂了 → 这里会红：任何工具都不许 error
+    broken = {n: r["detail"] for n, r in by_name.items() if r["status"] == "error"}
+    assert not broken, f"MCP 工具已失效：{broken}"
+
+    assert body["summary"]["total"] == len(by_name)
+    assert body["summary"]["ok"] >= 5
+    # 库内检索类工具有论文样本 → 必须真跑过
+    assert by_name["search_papers"]["status"] == "ok"
+    assert by_name["search_papers"]["arguments"]["query"]
+    assert by_name["get_paper"]["status"] == "ok"
+    # 联网工具默认不实测
+    assert by_name["external_search"]["status"] == "skipped"
+    # 没有稿件 → 跳过并说明原因，不算失败
+    assert by_name["get_fact_pack"]["status"] == "skipped"
+    assert "稿件" in by_name["get_fact_pack"]["detail"]
+    # 没有图片 → 取图类工具跳过
+    assert by_name["get_paper_figure"]["status"] == "skipped"
+
+
+async def test_selfcheck_names_and_cross_project(client):
+    """names 过滤只跑指定工具；非成员课题直接 404（报告里带样本 id，不能泄露）。"""
+    project_a, headers_a = await _setup(client, email="sc-a@example.com")
+    _, headers_b = await _setup(client, email="sc-b@example.com")
+
+    resp = await client.post(
+        "/api/mcp/selfcheck",
+        json={"project_id": project_a, "names": ["list_concepts"]},
+        headers=headers_a,
+    )
+    assert resp.status_code == 200, resp.text
+    assert [r["name"] for r in resp.json()["results"]] == ["list_concepts"]
+
+    resp = await client.post(
+        "/api/mcp/selfcheck",
+        json={"project_id": project_a, "names": ["list_concepts"]},
+        headers=headers_b,
+    )
+    assert resp.status_code == 404, resp.text
+
+
 async def test_unknown_method(client):
     _, headers = await _setup(client)
     resp = await client.post(

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -8,6 +8,8 @@ import app.tools as tools
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.idea import Idea
+from app.services import chunks as chunks_service
+from app.services import papers as papers_service
 from app.tools import ToolContext
 from tests.conftest import add_concept, add_paper
 
@@ -72,6 +74,64 @@ async def test_run_tool_unknown_and_bad_args():
         await tools.run_tool(ctx, "nope", {})
     with pytest.raises(ValueError, match="JSON 对象"):
         await tools.run_tool(ctx, "search_papers", ["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+async def test_search_tools_fall_back_when_embedding_is_down(client, monkeypatch):
+    """embedding 服务挂了 → 语义检索降级到关键词，而不是整个工具报错。
+
+    线上真出过：embedding 机器不可达，router 重试 4 次后抛 RuntimeError，
+    search_chunks / find_figures 直接失败（各卡 48s）。库内检索本来就有关键词兜底，
+    不该因为向量那一路挂了就整个不能用。
+    """
+    project_id = await _project(client, email="embed-down@example.com")
+    async with get_sessionmaker()() as session:
+        session.add(
+            await add_paper(
+                session,
+                project_id=project_id,
+                source="manual",
+                title="Retrieval Augmented Agents",
+                abstract="retrieval augmented generation for research agents",
+                status="compiled",
+            )
+        )
+        await session.commit()
+
+    # 假装向量检索可用（sqlite 本来会直接走关键词，测不到降级路径）
+    monkeypatch.setattr(papers_service, "semantic_search_supported", lambda session: True)
+    monkeypatch.setattr(chunks_service, "chunk_vector_search_supported", lambda session: True)
+
+    async def _embedding_down(*args, **kwargs):
+        raise RuntimeError("openai_compat 请求 embeddings 重试 4 次后仍失败")
+
+    monkeypatch.setattr(LLMRouter, "embed", _embedding_down)
+    ctx = _ctx(project_id)
+
+    res = await tools.run_tool(ctx, "search_papers", {"query": "retrieval", "mode": "semantic"})
+    assert res["mode"] == "keyword"
+    assert any("Retrieval" in p["title"] for p in res["results"])
+
+    res = await tools.run_tool(ctx, "search_chunks", {"query": "retrieval"})
+    assert res["mode"] == "keyword"
+
+    # find_figures 内部复用 search_papers，同样不该被 embedding 拖垮
+    res = await tools.run_tool(ctx, "find_figures", {"query": "retrieval"})
+    assert res["figures"] == []
+
+
+async def test_search_chunks_keyword_mode_skips_embedding(client, monkeypatch):
+    """mode=keyword 时压根不碰 embedding —— 自检就是靠这个保持便宜、确定。"""
+    project_id = await _project(client, email="chunks-keyword@example.com")
+
+    monkeypatch.setattr(chunks_service, "chunk_vector_search_supported", lambda session: True)
+
+    async def _must_not_be_called(*args, **kwargs):
+        raise AssertionError("mode=keyword 不该调用 embedding")
+
+    monkeypatch.setattr(LLMRouter, "embed", _must_not_be_called)
+
+    res = await tools.run_tool(_ctx(project_id), "search_chunks", {"query": "x", "mode": "keyword"})
+    assert res["mode"] == "keyword"
 
 
 # ---- 端到端：库内只读工具（走真实 DB，离线 fake LLM） ----

--- a/src/frontend/src/features/mcp/McpPlayground.tsx
+++ b/src/frontend/src/features/mcp/McpPlayground.tsx
@@ -1,0 +1,471 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Segmented } from '../../components/ui/Segmented';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { toast } from '../../components/ui/Toast';
+import { tr } from '../../lib/i18n';
+import { copyText } from '../../lib/clipboard';
+import { api, type McpInvokeResult, type McpToolCheck, type McpToolInfo } from '../../lib/api';
+import { ParamField, ResultView, RESULT_BOX, coerce, toFormValues } from './ToolRunner';
+
+/* ============================================================
+   MCP 调试台：挑一个工具 → 填参数（表单或直接写 JSON）→ 运行 → 看返回。
+
+   和工具卡片里的「试运行」是同一条路径（POST /mcp/tools/{name}/invoke →
+   dispatch.call_tool），这里多的是：工具搜索、原始 JSON 入参、可复制的
+   JSON-RPC 请求体（拿去自己的客户端里对拍）、以及本次会话的调用历史。
+   ============================================================ */
+
+const LABEL: CSSProperties = { fontSize: 11.5, color: 'var(--text-3)', marginBottom: 5 };
+
+interface HistoryEntry {
+  id: number;
+  tool: string;
+  args: Record<string, unknown>;
+  result: McpInvokeResult;
+  at: string;
+}
+
+/** 工具返回的文本多半是 JSON：能解析就缩进美化，解析不了就原样。 */
+function prettify(result: McpInvokeResult): McpInvokeResult {
+  return {
+    ...result,
+    content: result.content.map((b) => {
+      if (b.type !== 'text' || !b.text) return b;
+      try {
+        return { ...b, text: JSON.stringify(JSON.parse(b.text), null, 2) };
+      } catch {
+        return b;
+      }
+    }),
+  };
+}
+
+/** 外部 MCP 客户端发的那条 tools/call 请求（project_id 由服务端注入，这里显式写出来）。 */
+function rpcRequest(tool: string, projectId: string | null, args: Record<string, unknown>): string {
+  return JSON.stringify(
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: tool, arguments: { project_id: projectId ?? '<PROJECT_ID>', ...args } },
+    },
+    null,
+    2,
+  );
+}
+
+function ToolListItem({
+  tool,
+  check,
+  active,
+  onPick,
+}: {
+  tool: McpToolInfo;
+  check?: McpToolCheck;
+  active: boolean;
+  onPick: () => void;
+}) {
+  const dot =
+    check?.status === 'ok'
+      ? 'var(--ok-tx)'
+      : check?.status === 'error'
+        ? 'var(--danger-tx)'
+        : 'var(--text-4)';
+  return (
+    <button
+      onClick={onPick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 7,
+        width: '100%',
+        textAlign: 'left',
+        padding: '6px 8px',
+        borderRadius: 'var(--radius-sm)',
+        border: 'none',
+        cursor: 'pointer',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        color: active ? 'var(--accent-text)' : 'var(--text-2)',
+        fontFamily: 'var(--mono)',
+        fontSize: 12,
+        fontWeight: active ? 600 : 500,
+        minWidth: 0,
+      }}
+    >
+      {check && (
+        <span
+          title={check.detail ?? undefined}
+          style={{ width: 6, height: 6, borderRadius: '50%', background: dot, flexShrink: 0 }}
+        />
+      )}
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {tool.name}
+      </span>
+      {tool.network && (
+        <span
+          className="pill sm"
+          style={{ marginLeft: 'auto', background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}
+        >
+          {tr('联网', 'Net')}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function McpPlayground({
+  tools,
+  projectId,
+  checks,
+}: {
+  tools: McpToolInfo[];
+  projectId: string | null;
+  /** 自检结果：给工具列表打状态点，并给参数表单提供样例初值。 */
+  checks: Map<string, McpToolCheck>;
+}) {
+  const [q, setQ] = useState('');
+  const [picked, setPicked] = useState<string | null>(null);
+  const [mode, setMode] = useState<'form' | 'json'>('form');
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [jsonText, setJsonText] = useState('{}');
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [result, setResult] = useState<McpInvokeResult | null>(null);
+
+  const tool = useMemo(
+    () => tools.find((t) => t.name === picked) ?? tools[0] ?? null,
+    [tools, picked],
+  );
+  const shown = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return tools;
+    return tools.filter(
+      (t) =>
+        t.name.toLowerCase().includes(needle) || t.description.toLowerCase().includes(needle),
+    );
+  }, [tools, q]);
+
+  // 换工具：用自检的样例参数当初值，清掉上一个工具的结果
+  useEffect(() => {
+    if (!tool) return;
+    const sample = toFormValues(checks.get(tool.name)?.arguments);
+    setValues(sample);
+    setJsonText(JSON.stringify(coerce(tool.params, sample), null, 2));
+    setJsonError(null);
+    setResult(null);
+  }, [tool?.name]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  /** 当前入参：表单模式按类型转换，JSON 模式解析文本框（写坏了给 null）。纯函数，渲染期可用。 */
+  const args = useMemo<Record<string, unknown> | null>(() => {
+    if (!tool) return null;
+    if (mode === 'form') return coerce(tool.params, values);
+    try {
+      const parsed: unknown = JSON.parse(jsonText || '{}');
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+      return parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, [tool, mode, values, jsonText]);
+
+  const run = useMutation({
+    mutationFn: async () => {
+      if (!tool || args === null) {
+        setJsonError(tr('入参必须是合法的 JSON 对象', 'Arguments must be a valid JSON object'));
+        throw new Error(tr('入参有误', 'Invalid arguments'));
+      }
+      setJsonError(null);
+      const raw = await api.invokeMcpTool(tool.name, {
+        project_id: projectId as string,
+        arguments: args,
+      });
+      return { raw: prettify(raw), args } as { raw: McpInvokeResult; args: Record<string, unknown> };
+    },
+    onSuccess: ({ raw, args }) => {
+      setResult(raw);
+      setHistory((prev) =>
+        [
+          {
+            id: (prev[0]?.id ?? 0) + 1,
+            tool: raw.name,
+            args,
+            result: raw,
+            at: new Date().toLocaleTimeString(),
+          },
+          ...prev,
+        ].slice(0, 20),
+      );
+    },
+  });
+
+  /** 从历史里回放一次调用：入参回填表单，结果直接显示。 */
+  const replay = (entry: HistoryEntry) => {
+    setPicked(entry.tool);
+    setValues(toFormValues(entry.args));
+    setJsonText(JSON.stringify(entry.args, null, 2));
+    setResult(entry.result);
+  };
+
+  const copyRpc = () => {
+    if (!tool || args === null) {
+      setJsonError(tr('入参必须是合法的 JSON 对象', 'Arguments must be a valid JSON object'));
+      return;
+    }
+    void copyText(rpcRequest(tool.name, projectId, args)).then((ok) =>
+      toast(ok ? tr('已复制请求', 'Request copied') : tr('复制失败', 'Copy failed'), ok ? 'ok' : 'error'),
+    );
+  };
+
+  if (!tool) return <EmptyState icon="server" title={tr('没有可用的工具', 'No tools available')} />;
+
+  const check = checks.get(tool.name);
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 220px) minmax(0, 1fr)',
+        gap: 14,
+        alignItems: 'start',
+      }}
+      className="mcp-playground"
+    >
+      {/* 左：工具清单 */}
+      <div className="card" style={{ padding: 10, display: 'grid', gap: 8, minWidth: 0 }}>
+        <input
+          className="input"
+          style={{ height: 30, fontSize: 12 }}
+          placeholder={tr('搜工具…', 'Search tools…')}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <div style={{ display: 'grid', gap: 2, maxHeight: 420, overflowY: 'auto' }} className="scroll">
+          {shown.map((t) => (
+            <ToolListItem
+              key={t.name}
+              tool={t}
+              check={checks.get(t.name)}
+              active={t.name === tool.name}
+              onPick={() => setPicked(t.name)}
+            />
+          ))}
+          {shown.length === 0 && (
+            <div style={{ fontSize: 11.5, color: 'var(--text-3)', padding: '6px 8px' }}>
+              {tr('没有匹配的工具', 'No matching tool')}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 右：入参 → 运行 → 结果 */}
+      <div style={{ display: 'grid', gap: 14, minWidth: 0 }}>
+        <div className="card" style={{ padding: '14px 16px', display: 'grid', gap: 12, minWidth: 0 }}>
+          <div className="row wrap gap8" style={{ alignItems: 'center', minWidth: 0 }}>
+            <code style={{ fontFamily: 'var(--mono)', fontSize: 14, fontWeight: 600 }}>{tool.name}</code>
+            <span
+              className="pill sm"
+              style={
+                tool.network
+                  ? { background: 'var(--warn-bg)', color: 'var(--warn-tx)' }
+                  : { background: 'var(--info-bg)', color: 'var(--info-tx)' }
+              }
+            >
+              {tool.network ? tr('联网', 'Network') : tr('库内', 'Library')}
+            </span>
+            {check?.status === 'ok' && (
+              <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+                {tr('自检正常', 'Self-check OK')}
+              </span>
+            )}
+            {check?.status === 'error' && (
+              <span className="pill sm" style={{ background: 'var(--danger-bg)', color: 'var(--danger-tx)' }}>
+                {tr('自检失效', 'Self-check broken')}
+              </span>
+            )}
+            <div style={{ marginLeft: 'auto' }}>
+              <Segmented
+                options={[
+                  { v: 'form', label: tr('表单', 'Form') },
+                  { v: 'json', label: 'JSON' },
+                ]}
+                value={mode}
+                onChange={(v) => {
+                  // 表单 → JSON：把当前表单值序列化过去，两边始终看到同一组入参
+                  if (v === 'json') setJsonText(JSON.stringify(coerce(tool.params, values), null, 2));
+                  else {
+                    try {
+                      setValues(toFormValues(JSON.parse(jsonText || '{}')));
+                    } catch {
+                      /* JSON 写坏了就保留表单原值 */
+                    }
+                  }
+                  setMode(v);
+                }}
+              />
+            </div>
+          </div>
+          <div style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.5 }}>{tool.description}</div>
+
+          {mode === 'form' ? (
+            tool.params.length ? (
+              <div style={{ display: 'grid', gap: 8, minWidth: 0 }}>
+                {tool.params.map((p) => (
+                  <ParamField
+                    key={p.name}
+                    param={p}
+                    value={values[p.name] ?? ''}
+                    onChange={(v) => setValues((prev) => ({ ...prev, [p.name]: v }))}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+                {tr('这个工具不需要参数。', 'This tool takes no arguments.')}
+              </div>
+            )
+          ) : (
+            <div style={{ minWidth: 0 }}>
+              <div style={LABEL}>
+                {tr('入参 JSON（project_id 由服务端注入，不用写）', 'Arguments JSON (project_id is injected server-side)')}
+              </div>
+              <textarea
+                className="textarea mono"
+                style={{ width: '100%', minHeight: 130, fontSize: 12 }}
+                value={jsonText}
+                spellCheck={false}
+                onChange={(e) => {
+                  setJsonText(e.target.value);
+                  setJsonError(null);
+                }}
+              />
+              {jsonError && (
+                <div style={{ fontSize: 11.5, color: 'var(--danger-tx)', marginTop: 4 }}>{jsonError}</div>
+              )}
+            </div>
+          )}
+
+          <div className="row wrap gap8">
+            <button
+              className="btn btn-primary sm"
+              onClick={() => run.mutate()}
+              disabled={!projectId || run.isPending}
+            >
+              <Icon name="play" /> {run.isPending ? tr('运行中…', 'Running…') : tr('运行', 'Run')}
+            </button>
+            <button className="btn btn-soft sm" onClick={copyRpc}>
+              <Icon name="file" /> {tr('复制 JSON-RPC 请求', 'Copy JSON-RPC request')}
+            </button>
+            {tool.network && (
+              <span style={{ fontSize: 11.5, color: 'var(--warn-tx)', alignSelf: 'center' }}>
+                {tr('会真的请求外部文献接口', 'Really calls the external literature API')}
+              </span>
+            )}
+            {!projectId && (
+              <span style={{ fontSize: 11.5, color: 'var(--text-3)', alignSelf: 'center' }}>
+                {tr('先在上方选一个课题', 'Pick a topic above first')}
+              </span>
+            )}
+          </div>
+          {run.isError && (
+            <div style={{ fontSize: 12, color: 'var(--danger-tx)' }}>
+              {tr('请求失败：', 'Request failed: ')}
+              {(run.error as Error).message}
+            </div>
+          )}
+
+          <div style={{ minWidth: 0 }}>
+            <div style={LABEL}>
+              {tr(
+                '外部 MCP 客户端要发的就是这条请求',
+                'This is the request an external MCP client would send',
+              )}
+            </div>
+            <pre style={{ ...RESULT_BOX, maxHeight: 180 }}>
+              {rpcRequest(tool.name, projectId, args ?? {})}
+            </pre>
+          </div>
+        </div>
+
+        {result && (
+          <div className="card" style={{ padding: '14px 16px', display: 'grid', gap: 10, minWidth: 0 }}>
+            <div className="row gap8" style={{ alignItems: 'center' }}>
+              <strong style={{ fontSize: 13 }}>{tr('返回内容', 'Response')}</strong>
+              <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                {tr('外部客户端收到的就是这些', 'This is exactly what a client receives')}
+              </span>
+            </div>
+            <ResultView result={result} />
+          </div>
+        )}
+
+        {history.length > 0 && (
+          <div className="card" style={{ padding: '14px 16px', display: 'grid', gap: 8, minWidth: 0 }}>
+            <div className="row gap8" style={{ alignItems: 'center' }}>
+              <strong style={{ fontSize: 13 }}>{tr('调用记录', 'Call history')}</strong>
+              <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                {tr('点一条可回放入参与结果', 'Click one to replay its arguments and result')}
+              </span>
+              <button
+                className="btn btn-ghost sm"
+                style={{ marginLeft: 'auto' }}
+                onClick={() => setHistory([])}
+              >
+                {tr('清空', 'Clear')}
+              </button>
+            </div>
+            <div style={{ display: 'grid', gap: 4 }}>
+              {history.map((h) => (
+                <button
+                  key={h.id}
+                  onClick={() => replay(h)}
+                  className="row gap8"
+                  style={{
+                    alignItems: 'center',
+                    padding: '5px 8px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: '0.5px solid var(--border)',
+                    background: 'var(--surface-2)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    minWidth: 0,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: '50%',
+                      background: h.result.is_error ? 'var(--danger-tx)' : 'var(--ok-tx)',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <code style={{ fontFamily: 'var(--mono)', fontSize: 11.5, color: 'var(--text-2)' }}>
+                    {h.tool}
+                  </code>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: 'var(--text-3)',
+                      fontFamily: 'var(--mono)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      minWidth: 0,
+                    }}
+                  >
+                    {JSON.stringify(h.args)}
+                  </span>
+                  <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
+                    {h.result.duration_ms} ms · {h.at}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/mcp/McpToolsPage.tsx
+++ b/src/frontend/src/features/mcp/McpToolsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type CSSProperties } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
@@ -7,7 +7,9 @@ import { toast } from '../../components/ui/Toast';
 import { tr } from '../../lib/i18n';
 import { portalUrl } from '../../lib/endpoint';
 import { copyText } from '../../lib/clipboard';
-import { api, getToken, type McpToolInfo } from '../../lib/api';
+import { useProject } from '../../app/project';
+import { api, getToken, type McpToolCheck, type McpToolInfo } from '../../lib/api';
+import { ToolRunner } from './ToolRunner';
 
 function copy(text: string) {
   void copyText(text).then((ok) =>
@@ -24,6 +26,31 @@ const CODE_BOX: CSSProperties = {
   padding: '8px 10px',
   color: 'var(--text)',
 };
+
+/** 参数 chip：长枚举必须能换行，否则会顶破卡片（.tag 本身是定高 inline-flex + 不换行）。 */
+const PARAM_CHIP: CSSProperties = {
+  display: 'inline-block',
+  height: 'auto',
+  maxWidth: '100%',
+  padding: '2px 8px',
+  lineHeight: 1.5,
+  whiteSpace: 'normal',
+  overflowWrap: 'anywhere',
+  fontFamily: 'var(--mono)',
+  fontSize: 11,
+};
+
+const CHECK_STYLE: Record<string, CSSProperties> = {
+  ok: { background: 'var(--ok-bg)', color: 'var(--ok-tx)' },
+  error: { background: 'var(--danger-bg)', color: 'var(--danger-tx)' },
+  skipped: { background: 'var(--surface-3)', color: 'var(--text-3)' },
+};
+
+function checkLabel(check: McpToolCheck): string {
+  if (check.status === 'ok') return `${tr('正常', 'OK')} · ${check.duration_ms ?? 0} ms`;
+  if (check.status === 'error') return tr('失效', 'Broken');
+  return tr('未测', 'Not tested');
+}
 
 /** 标签 + 可复制的等宽值行；secret 时可隐藏（token）。 */
 function CopyRow({ label, value, secret }: { label: string; value: string; secret?: boolean }) {
@@ -58,15 +85,37 @@ function CopyRow({ label, value, secret }: { label: string; value: string; secre
   );
 }
 
-function ToolCard({ t }: { t: McpToolInfo }) {
+function ToolCard({
+  t,
+  check,
+  projectId,
+}: {
+  t: McpToolInfo;
+  check?: McpToolCheck;
+  projectId: string | null;
+}) {
+  const [open, setOpen] = useState(false);
   return (
-    <div className="card" style={{ padding: '13px 15px', display: 'grid', gap: 8 }}>
-      <div className="row gap8" style={{ alignItems: 'center' }}>
-        <code style={{ fontFamily: 'var(--mono)', fontSize: 13, fontWeight: 600, color: 'var(--text)' }}>
+    <div className="card" style={{ padding: '13px 15px', display: 'grid', gap: 8, minWidth: 0 }}>
+      <div className="row wrap gap8" style={{ alignItems: 'center', minWidth: 0 }}>
+        <code
+          style={{
+            fontFamily: 'var(--mono)',
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'var(--text)',
+            overflowWrap: 'anywhere',
+          }}
+        >
           {t.name}
         </code>
         <span
           className="pill sm"
+          title={
+            t.network
+              ? tr('会请求库外的文献接口', 'Calls external literature APIs')
+              : tr('只查本平台库内数据', 'Reads only this platform’s own data')
+          }
           style={
             t.network
               ? { background: 'var(--warn-bg)', color: 'var(--warn-tx)' }
@@ -75,29 +124,65 @@ function ToolCard({ t }: { t: McpToolInfo }) {
         >
           {t.network ? tr('联网', 'Network') : tr('库内', 'Library')}
         </span>
-        <span className="pill sm" style={{ marginLeft: 'auto', background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+        {check && (
+          <span className="pill sm" style={CHECK_STYLE[check.status]} title={check.detail ?? undefined}>
+            {checkLabel(check)}
+          </span>
+        )}
+        <span
+          className="pill sm"
+          style={{ marginLeft: 'auto', background: 'var(--surface-3)', color: 'var(--text-3)' }}
+        >
           {tr('只读', 'read-only')}
         </span>
       </div>
-      <div style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.5 }}>{t.description}</div>
+      <div style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.5, overflowWrap: 'anywhere' }}>
+        {t.description}
+      </div>
       {t.params.length > 0 && (
-        <div className="row" style={{ flexWrap: 'wrap', gap: 6 }}>
+        <div className="row wrap" style={{ gap: 6, minWidth: 0 }}>
           {t.params.map((p) => (
             <span
               key={p.name}
               className="tag"
               title={p.description ?? undefined}
-              style={{ fontFamily: 'var(--mono)', fontSize: 11, fontWeight: p.required ? 600 : 500 }}
+              style={{ ...PARAM_CHIP, fontWeight: p.required ? 600 : 500 }}
             >
               {p.name}
               {p.required ? '*' : ''}
               <span style={{ color: 'var(--text-3)', marginLeft: 3 }}>
-                {p.enum ? p.enum.join('|') : p.type}
+                {p.enum ? p.enum.join(' | ') : p.type}
               </span>
             </span>
           ))}
         </div>
       )}
+      {check?.status === 'error' && check.detail && (
+        <div
+          style={{
+            fontSize: 11.5,
+            color: 'var(--danger-tx)',
+            background: 'var(--danger-bg)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '6px 8px',
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {check.detail}
+        </div>
+      )}
+      {check?.status === 'skipped' && check.detail && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-3)', overflowWrap: 'anywhere' }}>
+          {check.detail}
+        </div>
+      )}
+      <div>
+        <button className="btn btn-ghost sm" onClick={() => setOpen((v) => !v)}>
+          <Icon name={open ? 'chevDown' : 'play'} />
+          {open ? tr('收起', 'Hide') : tr('试运行', 'Try it')}
+        </button>
+      </div>
+      {open && <ToolRunner tool={t} projectId={projectId} sampleArgs={check?.arguments} />}
     </div>
   );
 }
@@ -109,7 +194,12 @@ export function McpToolsContent() {
     queryFn: () => api.listMcpTools(),
     retry: false,
   });
-  const [filter, setFilter] = useState<'all' | 'library' | 'network'>('all');
+  const [filter, setFilter] = useState<'all' | 'library' | 'network' | 'failed'>('all');
+
+  const { projects, currentProjectId } = useProject();
+  const [pickedProjectId, setPickedProjectId] = useState<string | null>(null);
+  const projectId = pickedProjectId ?? currentProjectId;
+  const [includeNetwork, setIncludeNetwork] = useState(false);
 
   const origin = portalUrl();
   const httpUrl = `${origin}${data?.endpoint ?? '/mcp'}`;
@@ -129,10 +219,25 @@ export function McpToolsContent() {
     [httpUrl, token],
   );
 
+  const selfcheck = useMutation({
+    mutationFn: () =>
+      api.selfCheckMcpTools({ project_id: projectId as string, include_network: includeNetwork }),
+    onError: (e: Error) => toast(tr('自检失败：', 'Self-check failed: ') + e.message, 'error'),
+  });
+  const report = selfcheck.data;
+  const checks = useMemo(() => {
+    const map = new Map<string, McpToolCheck>();
+    for (const r of report?.results ?? []) map.set(r.name, r);
+    return map;
+  }, [report]);
+
   const tools = data?.tools ?? [];
-  const shown = tools.filter((t) =>
-    filter === 'all' ? true : filter === 'network' ? t.network : !t.network,
-  );
+  const shown = tools.filter((t) => {
+    if (filter === 'network') return t.network;
+    if (filter === 'library') return !t.network;
+    if (filter === 'failed') return checks.get(t.name)?.status === 'error';
+    return true;
+  });
 
   return (
     <div>
@@ -187,14 +292,86 @@ export function McpToolsContent() {
         </div>
         <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.55 }}>
           {tr(
-            '调用工具时需在参数里带 project_id（目标课题 uuid），服务端会校验你是否为该课题成员。本地桌面客户端也可用 stdio：python -m app.mcp（详见 docs/api-mcp.md）。',
-            'Each tool call takes a project_id (target topic uuid); the server verifies your membership. Local desktop clients can also use stdio: python -m app.mcp (see docs/api-mcp.md).',
+            '调用工具时需在参数里带 project_id（目标课题 uuid），服务端会校验你是否为该课题成员。本地桌面客户端也可用 stdio：python -m app.mcp（详见 docs/concepts.md）。',
+            'Each tool call takes a project_id (target topic uuid); the server verifies your membership. Local desktop clients can also use stdio: python -m app.mcp (see docs/concepts.md).',
           )}
         </div>
       </div>
 
+      {/* 工具测试：选课题 → 一键自检（用课题里的真实数据把每个工具跑一遍） */}
+      <div className="card" style={{ padding: '14px 16px', display: 'grid', gap: 10, marginBottom: 18 }}>
+        <div className="row wrap gap8" style={{ alignItems: 'center' }}>
+          <Icon name="shield" />
+          <strong style={{ fontSize: 14 }}>{tr('工具测试', 'Tool test')}</strong>
+          <span style={{ fontSize: 12, color: 'var(--text-3)' }}>
+            {tr(
+              '用课题里的真实数据跑一遍，看哪些工具还能用',
+              'Runs every tool against real data from a topic to see what still works',
+            )}
+          </span>
+        </div>
+        <div className="row wrap gap8" style={{ alignItems: 'center' }}>
+          <select
+            className="input"
+            style={{ height: 34, maxWidth: 280 }}
+            value={projectId ?? ''}
+            onChange={(e) => setPickedProjectId(e.target.value || null)}
+          >
+            <option value="">{tr('选择课题…', 'Pick a topic…')}</option>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <label className="row gap6" style={{ fontSize: 12.5, color: 'var(--text-2)', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={includeNetwork}
+              onChange={(e) => setIncludeNetwork(e.target.checked)}
+            />
+            {tr(
+              '连联网工具一起测（会真的请求外部接口，慢一些）',
+              'Include network tools (really calls external APIs, slower)',
+            )}
+          </label>
+          <button
+            className="btn btn-primary sm"
+            onClick={() => selfcheck.mutate()}
+            disabled={!projectId || selfcheck.isPending}
+          >
+            <Icon name="refresh" />
+            {selfcheck.isPending ? tr('自检中…', 'Checking…') : tr('一键自检', 'Run self-check')}
+          </button>
+        </div>
+        {report && (
+          <div className="row wrap gap8" style={{ alignItems: 'center', fontSize: 12.5 }}>
+            <span className="pill sm" style={CHECK_STYLE.ok}>
+              {tr('正常', 'OK')} {report.summary.ok}
+            </span>
+            <span className="pill sm" style={report.summary.error ? CHECK_STYLE.error : CHECK_STYLE.skipped}>
+              {tr('失效', 'Broken')} {report.summary.error}
+            </span>
+            <span className="pill sm" style={CHECK_STYLE.skipped}>
+              {tr('未测', 'Not tested')} {report.summary.skipped}
+            </span>
+            <span style={{ color: 'var(--text-3)' }}>
+              {tr('共', 'of')} {report.summary.total} {tr('个工具', 'tools')}
+            </span>
+          </div>
+        )}
+        {report && report.summary.skipped > 0 && (
+          <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.55 }}>
+            {tr(
+              '「未测」= 课题里缺少对应的样本数据（比如还没有稿件），或该工具需要联网而没有勾选，不代表工具有问题。',
+              '“Not tested” means the topic lacks sample data (e.g. no manuscript yet) or the tool needs network access you didn’t enable — not a failure.',
+            )}
+          </div>
+        )}
+      </div>
+
       {/* 工具目录 */}
-      <div className="row gap8" style={{ marginBottom: 14, alignItems: 'center' }}>
+      <div className="row wrap gap8" style={{ marginBottom: 14, alignItems: 'center' }}>
         <strong style={{ fontSize: 14 }}>{tr('工具目录', 'Tool catalog')}</strong>
         {data && <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>{tools.length}</span>}
         <div style={{ marginLeft: 'auto' }}>
@@ -203,6 +380,9 @@ export function McpToolsContent() {
               { v: 'all', label: tr('全部', 'All') },
               { v: 'library', label: tr('库内', 'Library') },
               { v: 'network', label: tr('联网', 'Network') },
+              ...(report && report.summary.error > 0
+                ? [{ v: 'failed' as const, label: tr('失效', 'Broken') }]
+                : []),
             ]}
             value={filter}
             onChange={setFilter}
@@ -215,7 +395,7 @@ export function McpToolsContent() {
       {data && (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))', gap: 12 }}>
           {shown.map((t) => (
-            <ToolCard key={t.name} t={t} />
+            <ToolCard key={t.name} t={t} check={checks.get(t.name)} projectId={projectId} />
           ))}
         </div>
       )}

--- a/src/frontend/src/features/mcp/McpToolsPage.tsx
+++ b/src/frontend/src/features/mcp/McpToolsPage.tsx
@@ -10,6 +10,7 @@ import { copyText } from '../../lib/clipboard';
 import { useProject } from '../../app/project';
 import { api, getToken, type McpToolCheck, type McpToolInfo } from '../../lib/api';
 import { ToolRunner } from './ToolRunner';
+import { McpPlayground } from './McpPlayground';
 
 function copy(text: string) {
   void copyText(text).then((ok) =>
@@ -195,6 +196,7 @@ export function McpToolsContent() {
     retry: false,
   });
   const [filter, setFilter] = useState<'all' | 'library' | 'network' | 'failed'>('all');
+  const [view, setView] = useState<'catalog' | 'playground'>('catalog');
 
   const { projects, currentProjectId } = useProject();
   const [pickedProjectId, setPickedProjectId] = useState<string | null>(null);
@@ -370,29 +372,45 @@ export function McpToolsContent() {
         )}
       </div>
 
-      {/* 工具目录 */}
+      {/* 工具目录 / 调试台 */}
       <div className="row wrap gap8" style={{ marginBottom: 14, alignItems: 'center' }}>
-        <strong style={{ fontSize: 14 }}>{tr('工具目录', 'Tool catalog')}</strong>
-        {data && <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>{tools.length}</span>}
-        <div style={{ marginLeft: 'auto' }}>
-          <Segmented
-            options={[
-              { v: 'all', label: tr('全部', 'All') },
-              { v: 'library', label: tr('库内', 'Library') },
-              { v: 'network', label: tr('联网', 'Network') },
-              ...(report && report.summary.error > 0
-                ? [{ v: 'failed' as const, label: tr('失效', 'Broken') }]
-                : []),
-            ]}
-            value={filter}
-            onChange={setFilter}
-          />
-        </div>
+        <Segmented
+          options={[
+            { v: 'catalog', label: tr('工具目录', 'Tool catalog') },
+            { v: 'playground', label: tr('调试台', 'Playground') },
+          ]}
+          value={view}
+          onChange={setView}
+        />
+        {data && (
+          <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+            {tools.length}
+          </span>
+        )}
+        {view === 'catalog' && (
+          <div style={{ marginLeft: 'auto' }}>
+            <Segmented
+              options={[
+                { v: 'all', label: tr('全部', 'All') },
+                { v: 'library', label: tr('库内', 'Library') },
+                { v: 'network', label: tr('联网', 'Network') },
+                ...(report && report.summary.error > 0
+                  ? [{ v: 'failed' as const, label: tr('失效', 'Broken') }]
+                  : []),
+              ]}
+              value={filter}
+              onChange={setFilter}
+            />
+          </div>
+        )}
       </div>
 
       {isLoading && <EmptyState icon="server" title={tr('加载中…', 'Loading…')} />}
       {isError && <EmptyState icon="server" title={tr('加载失败', 'Failed to load')} />}
-      {data && (
+      {data && view === 'playground' && (
+        <McpPlayground tools={tools} projectId={projectId} checks={checks} />
+      )}
+      {data && view === 'catalog' && (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))', gap: 12 }}>
           {shown.map((t) => (
             <ToolCard key={t.name} t={t} check={checks.get(t.name)} projectId={projectId} />

--- a/src/frontend/src/features/mcp/ToolRunner.tsx
+++ b/src/frontend/src/features/mcp/ToolRunner.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { tr } from '../../lib/i18n';
+import { api, type McpInvokeResult, type McpToolInfo, type McpToolParam } from '../../lib/api';
+
+/* ============================================================
+   单个 MCP 工具的试运行面板：填参数 → 运行 → 看外部客户端会收到的内容。
+   走 POST /mcp/tools/{name}/invoke，与真实 MCP 调用同一条路径。
+   ============================================================ */
+
+const RESULT_BOX: CSSProperties = {
+  fontFamily: 'var(--mono)',
+  fontSize: 11.5,
+  lineHeight: 1.55,
+  background: 'var(--surface-3)',
+  border: '0.5px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  padding: '8px 10px',
+  margin: 0,
+  maxHeight: 260,
+  overflow: 'auto',
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+  color: 'var(--text-2)',
+};
+
+/** 把表单里的字符串按参数类型还原成 JSON 值；空串 = 不传该参数。 */
+function coerce(params: McpToolParam[], raw: Record<string, string>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const p of params) {
+    const value = (raw[p.name] ?? '').trim();
+    if (!value) continue;
+    if (p.type === 'boolean') out[p.name] = value === 'true';
+    else if (p.type === 'integer' || p.type === 'number') {
+      const n = Number(value);
+      if (!Number.isNaN(n)) out[p.name] = n;
+    } else out[p.name] = value;
+  }
+  return out;
+}
+
+/** 自检给出的样例参数 → 表单初值（数字/布尔转成字符串）。 */
+function toFormValues(args: Record<string, unknown> | null | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(args ?? {})) {
+    if (v === null || v === undefined) continue;
+    out[k] = typeof v === 'boolean' ? String(v) : String(v);
+  }
+  return out;
+}
+
+function ParamField({
+  param,
+  value,
+  onChange,
+}: {
+  param: McpToolParam;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const hint = param.description ?? '';
+  const label = (
+    <div style={{ fontSize: 11.5, color: 'var(--text-3)', display: 'flex', gap: 5, alignItems: 'baseline' }}>
+      <code style={{ fontFamily: 'var(--mono)', fontWeight: param.required ? 600 : 500, color: 'var(--text-2)' }}>
+        {param.name}
+        {param.required ? '*' : ''}
+      </code>
+      {hint && <span style={{ minWidth: 0, overflowWrap: 'anywhere' }}>{hint}</span>}
+    </div>
+  );
+
+  const options = param.type === 'boolean' ? ['true', 'false'] : param.enum;
+  return (
+    <label style={{ display: 'grid', gap: 4, minWidth: 0 }}>
+      {label}
+      {options ? (
+        <select className="input mono" style={{ height: 32 }} value={value} onChange={(e) => onChange(e.target.value)}>
+          <option value="">{tr('（不传）', '(omit)')}</option>
+          {options.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          className="input mono"
+          style={{ height: 32 }}
+          type={param.type === 'integer' || param.type === 'number' ? 'number' : 'text'}
+          value={value}
+          placeholder={param.required ? tr('必填', 'required') : tr('可选', 'optional')}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
+    </label>
+  );
+}
+
+/** 结果区：文本块原样展示，图片块转 data URL 预览。 */
+function ResultView({ result }: { result: McpInvokeResult }) {
+  const texts = result.content.filter((b) => b.type === 'text');
+  const images = result.content.filter((b) => b.type === 'image' && b.data);
+  return (
+    <div style={{ display: 'grid', gap: 8, minWidth: 0 }}>
+      <div className="row gap8" style={{ fontSize: 11.5 }}>
+        <span
+          className="pill sm"
+          style={
+            result.is_error
+              ? { background: 'var(--danger-bg)', color: 'var(--danger-tx)' }
+              : { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+          }
+        >
+          {result.is_error ? tr('调用失败', 'Failed') : tr('调用成功', 'Success')}
+        </span>
+        <span style={{ color: 'var(--text-3)' }}>{result.duration_ms} ms</span>
+        {images.length > 0 && (
+          <span style={{ color: 'var(--text-3)' }}>
+            {tr('图片', 'Images')} × {images.length}
+          </span>
+        )}
+        {result.truncated && (
+          <span style={{ color: 'var(--text-3)' }}>{tr('（内容已截断）', '(truncated)')}</span>
+        )}
+      </div>
+      {texts.map((b, i) => (
+        <pre key={i} style={RESULT_BOX}>
+          {b.text}
+        </pre>
+      ))}
+      {images.length > 0 && (
+        <div className="row wrap gap8">
+          {images.map((b, i) => (
+            <img
+              key={i}
+              src={`data:${b.mimeType || 'image/png'};base64,${b.data}`}
+              alt={`figure-${i}`}
+              style={{
+                maxWidth: 180,
+                maxHeight: 140,
+                objectFit: 'contain',
+                borderRadius: 'var(--radius-sm)',
+                border: '0.5px solid var(--border)',
+                background: 'var(--surface)',
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ToolRunner({
+  tool,
+  projectId,
+  sampleArgs,
+}: {
+  tool: McpToolInfo;
+  projectId: string | null;
+  /** 自检跑出来的样例参数，用作表单初值（省得手填 uuid）。 */
+  sampleArgs?: Record<string, unknown> | null;
+}) {
+  const [values, setValues] = useState<Record<string, string>>(() => toFormValues(sampleArgs));
+  const sampleKey = useMemo(() => JSON.stringify(sampleArgs ?? null), [sampleArgs]);
+
+  // 自检跑完拿到样例参数后，把还空着的表单填上（不覆盖用户已经改过的值）
+  useEffect(() => {
+    const next = toFormValues(sampleArgs);
+    if (!Object.keys(next).length) return;
+    setValues((prev) => {
+      const merged = { ...prev };
+      for (const [k, v] of Object.entries(next)) if (!merged[k]) merged[k] = v;
+      return merged;
+    });
+  }, [sampleKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const run = useMutation({
+    mutationFn: () =>
+      api.invokeMcpTool(tool.name, {
+        project_id: projectId as string,
+        arguments: coerce(tool.params, values),
+      }),
+  });
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 10,
+        minWidth: 0,
+        borderTop: '0.5px dashed var(--border)',
+        paddingTop: 10,
+      }}
+    >
+      {tool.params.length > 0 && (
+        <div style={{ display: 'grid', gap: 8, minWidth: 0 }}>
+          {tool.params.map((p) => (
+            <ParamField
+              key={p.name}
+              param={p}
+              value={values[p.name] ?? ''}
+              onChange={(v) => setValues((prev) => ({ ...prev, [p.name]: v }))}
+            />
+          ))}
+        </div>
+      )}
+      <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+        <button
+          className="btn btn-primary sm"
+          onClick={() => run.mutate()}
+          disabled={!projectId || run.isPending}
+        >
+          <Icon name="play" /> {run.isPending ? tr('运行中…', 'Running…') : tr('运行', 'Run')}
+        </button>
+        {tool.network && (
+          <span style={{ fontSize: 11.5, color: 'var(--warn-tx)' }}>
+            {tr('会真的请求外部文献接口', 'Really calls the external literature API')}
+          </span>
+        )}
+        {!projectId && (
+          <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+            {tr('先在上方选一个课题', 'Pick a topic above first')}
+          </span>
+        )}
+      </div>
+      {run.isError && (
+        <div style={{ fontSize: 12, color: 'var(--danger-tx)' }}>
+          {tr('请求失败：', 'Request failed: ')}
+          {(run.error as Error).message}
+        </div>
+      )}
+      {run.data && <ResultView result={run.data} />}
+    </div>
+  );
+}

--- a/src/frontend/src/features/mcp/ToolRunner.tsx
+++ b/src/frontend/src/features/mcp/ToolRunner.tsx
@@ -7,9 +7,12 @@ import { api, type McpInvokeResult, type McpToolInfo, type McpToolParam } from '
 /* ============================================================
    单个 MCP 工具的试运行面板：填参数 → 运行 → 看外部客户端会收到的内容。
    走 POST /mcp/tools/{name}/invoke，与真实 MCP 调用同一条路径。
+
+   表单控件、参数转换与结果渲染在这里定义并导出，调试台（McpPlayground）复用同一套，
+   保证「卡片里试一下」和「调试台里试一下」跑出来的东西逐字一致。
    ============================================================ */
 
-const RESULT_BOX: CSSProperties = {
+export const RESULT_BOX: CSSProperties = {
   fontFamily: 'var(--mono)',
   fontSize: 11.5,
   lineHeight: 1.55,
@@ -26,7 +29,7 @@ const RESULT_BOX: CSSProperties = {
 };
 
 /** 把表单里的字符串按参数类型还原成 JSON 值；空串 = 不传该参数。 */
-function coerce(params: McpToolParam[], raw: Record<string, string>): Record<string, unknown> {
+export function coerce(params: McpToolParam[], raw: Record<string, string>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const p of params) {
     const value = (raw[p.name] ?? '').trim();
@@ -41,7 +44,7 @@ function coerce(params: McpToolParam[], raw: Record<string, string>): Record<str
 }
 
 /** 自检给出的样例参数 → 表单初值（数字/布尔转成字符串）。 */
-function toFormValues(args: Record<string, unknown> | null | undefined): Record<string, string> {
+export function toFormValues(args: Record<string, unknown> | null | undefined): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(args ?? {})) {
     if (v === null || v === undefined) continue;
@@ -50,7 +53,7 @@ function toFormValues(args: Record<string, unknown> | null | undefined): Record<
   return out;
 }
 
-function ParamField({
+export function ParamField({
   param,
   value,
   onChange,
@@ -98,7 +101,7 @@ function ParamField({
 }
 
 /** 结果区：文本块原样展示，图片块转 data URL 预览。 */
-function ResultView({ result }: { result: McpInvokeResult }) {
+export function ResultView({ result }: { result: McpInvokeResult }) {
   const texts = result.content.filter((b) => b.type === 'text');
   const images = result.content.filter((b) => b.type === 'image' && b.data);
   return (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2229,6 +2229,7 @@ export interface McpToolParam {
   type: string;
   enum: string[] | null;
   description: string | null;
+  default?: unknown;
 }
 export interface McpToolInfo {
   name: string;
@@ -2242,6 +2243,41 @@ export interface McpToolsCatalog {
   protocol_version: string;
   endpoint: string;
   tools: McpToolInfo[];
+}
+
+/** 试运行返回的一块内容：外部 MCP 客户端收到的原样 content block。 */
+export interface McpContentBlock {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+export interface McpInvokeResult {
+  name: string;
+  is_error: boolean;
+  duration_ms: number;
+  content: McpContentBlock[];
+  truncated: boolean;
+}
+
+export type McpCheckStatus = 'ok' | 'error' | 'skipped';
+/** 单个工具的自检结论。 */
+export interface McpToolCheck {
+  name: string;
+  network: boolean;
+  status: McpCheckStatus;
+  duration_ms?: number;
+  arguments?: Record<string, unknown> | null;
+  detail?: string | null;
+  preview?: string | null;
+  images?: number;
+}
+export interface McpSelfCheckReport {
+  project_id: string;
+  include_network: boolean;
+  samples: Record<string, string | number | null>;
+  summary: { total: number; ok: number; error: number; skipped: number };
+  results: McpToolCheck[];
 }
 
 // ============================================================
@@ -3964,9 +4000,24 @@ export const api = {
     return requestJson<EffectiveTestResult>('/me/llm/test-effective', 'POST', input);
   },
 
-  // —— MCP 只读工具目录（docs/api-mcp.md） ——
+  // —— MCP 只读工具目录 / 试运行 / 自检（docs/development.md「Testing the tools」） ——
   listMcpTools(): Promise<McpToolsCatalog> {
     return request<McpToolsCatalog>('/mcp/tools');
+  },
+  /** 试运行单个工具：返回外部 MCP 客户端会收到的 content。 */
+  invokeMcpTool(
+    name: string,
+    input: { project_id: string; arguments: Record<string, unknown> },
+  ): Promise<McpInvokeResult> {
+    return requestJson<McpInvokeResult>(`/mcp/tools/${encodeURIComponent(name)}/invoke`, 'POST', input);
+  },
+  /** 一键自检：用课题里的真实数据把工具跑一遍。 */
+  selfCheckMcpTools(input: {
+    project_id: string;
+    include_network?: boolean;
+    names?: string[];
+  }): Promise<McpSelfCheckReport> {
+    return requestJson<McpSelfCheckReport>('/mcp/selfcheck', 'POST', input);
   },
 
   // —— Skills · 技能（docs/skill-system.md §4） ——

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1206,6 +1206,9 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   * { -webkit-tap-highlight-color: transparent; }
   .content { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
 
+  /* MCP 调试台：工具清单 + 调试区在窄屏上下堆叠（覆盖组件里的两列内联样式） */
+  .mcp-playground { grid-template-columns: minmax(0, 1fr) !important; }
+
   /* —— 侧栏改覆盖式抽屉（配合 AppShell 的 .app.nav-open）——
         脱离 flex 流，主列独占全宽；默认滑出屏外，不占位也不可点。 */
   .sidebar {


### PR DESCRIPTION
Closes #188
Closes #196
Closes #197

## First: are any of the MCP tools dead?

No — but one class of failure was hiding in plain sight, see §3. All 26 tools were run against real data in the local dev stack (topic `Recursive Self-Improvement`, a library of 1427 papers):

| Group | Result |
| --- | --- |
| In-library tools (22) | all **working**, 0 broken |
| Network tools (4) | tested separately, all **working** |

- `get_fact_pack` had no sample in that topic (no manuscript yet), so it was re-tested against the `OPSD` topic, which has one → working.
- **The "库内 / 联网" (Library / Network) badges are still accurate**: Library = reads only this platform's own data, Network = calls arXiv / Semantic Scholar / OpenAlex. One nuance worth knowing: semantic mode in `search_papers` / `search_chunks` calls the embedding service, so those are not strictly offline — but their search scope really is in-library, so the badge is right.
- One weakness found and left alone: `external_search` hits noticeable rate limiting on the Semantic Scholar search endpoint (8–35s per call) and silently falls back to OpenAlex, whose results are considerably weaker.

## What changed

### 1. The display bug (#188)

Parameters with many enum values (`list_concepts`'s 7 categories) overflowed the right edge of their card, because `.tag` is a fixed-height `inline-flex` that never wraps. Parameter chips now wrap inside the card; the card, its rows, and the title got `minWidth: 0` / `overflowWrap`.

Verified in a browser: squeezing a card down to 363px (the grid column's minimum) and scanning every element inside every card, **nothing overflows**.

### 2. Self-check and try-it (#188)

Two new endpoints, both routed through `app/mcp/dispatch.call_tool` — the exact path an external MCP client takes, membership check included — so anything that works on the page works in a client:

| Endpoint | What it does |
| --- | --- |
| `POST /api/mcp/tools/{name}/invoke` | Runs one tool with the arguments you supply and returns the raw MCP content blocks (text plus inline images). |
| `POST /api/mcp/selfcheck` | Collects sample data from a topic (paper, figure, concept, idea, experiment, manuscript), fills each tool's required arguments, and runs the whole catalog, reporting ok / error / skipped per tool. |

Sample arguments (`app/mcp/selfcheck.py`) are deliberately cheap and deterministic: filter-style optional parameters are left unset (so results aren't narrowed to nothing), `mode` is pinned to `keyword` so no embedding call is made, figures render at 512px, and network tools are only run on request. A required argument with no sample in that topic (no manuscript yet, no extracted figures) is reported as **skipped with the reason**, not as a failure.

**An authorization hole closed along the way**: the self-check report carries sample ids from the topic, so the endpoint verifies membership up front and 404s for non-members (rather than letting each tool fail individually, which would still leak the sample ids).

### 3. Tools no longer die when the embedding service does (#197)

Testing the playground against the live stack caught a real failure. The embedding host (`10.130.138.46:8010`) was unreachable; the LLM router retried four times and raised `RuntimeError`; `search_chunks` and `find_figures` (which reuses `search_papers` in semantic mode) died with it — ~48s each, a **97s self-check reporting two tools broken**.

Both tools already had a keyword fallback for "semantic unavailable", but it only caught `NotImplementedError`, so a provider-level failure went straight past it. Now any embedding failure degrades to keyword search, and `search_chunks` / `find_figures` take the explicit `mode` (`keyword` | `semantic`) that `search_papers` already had, so a caller — including the self-check — can skip embeddings outright.

Same self-check, same dead embedding host: **0.73s, nothing broken.**

### 4. The playground (#196)

Settings → MCP now has two views. **Tool catalog** is the card grid with self-check badges and an inline try-it. **Playground** is the debugging surface:

- Searchable tool list, each entry dotted with its self-check status
- Arguments as the schema-generated form **or** raw JSON, the two kept in sync
- Response rendered as a client receives it: pretty-printed JSON plus inline image previews
- The equivalent JSON-RPC `tools/call` request, copyable, so a call can be replayed from Claude Desktop or Cursor
- Session call history; clicking an entry replays its arguments and result

Form controls, argument coercion, and result rendering now live in `ToolRunner` and are shared, so a call made from a card and the same call made from the playground go through identical code.

## Verification

- Full backend suite: **804 passed**
- 9 new cases: invoke success / tool-level error / 404 / cross-project denial; self-check results / `names` filter / non-member 404; plus two pinning the embedding fallback (`search_papers`, `search_chunks`, `find_figures` all degrade to keyword when `embed` raises; `mode=keyword` never touches the embedding service). `test_selfcheck` **fails if any tool reports error**, so a future refactor that breaks a tool turns CI red instead of surfacing in a client.
- Frontend `tsc --noEmit` + `vite build` pass.
- End-to-end in a real browser: self-check (21 OK / 0 broken / 5 not tested), catalog try-it, and — via CDP after the browser extension dropped — the playground: tool search, argument prefill, form ↔ JSON round-trip, malformed-JSON handling, `get_paper_figure` rendering a 512px image, history replay, and an overflow scan across every playground card.

## Note

`docs/api-mcp.md`, referenced in several places in the code, no longer exists after the docs reorganization. This PR only fixes the three references it touched (page copy, `mcp_meta.py`, `api.ts`), pointing them at `docs/concepts.md` / `docs/development.md`; the stale references in `app/tools/__init__.py`, `figures.py`, `main.py`, and `vite.config.ts` are left alone.

The ~48s the router spends retrying a dead embedding host is a retry/timeout policy question and is not addressed here.
