### PR TITLE
feat(chat): add per-user group bot delivery

### DIFF
--- a/src/backend/alembic/versions/d4e8b71c2a90_chat_bot_configs.py
+++ b/src/backend/alembic/versions/d4e8b71c2a90_chat_bot_configs.py
@@ -1,0 +1,47 @@
+"""add per-user chat bot webhook configs
+
+Revision ID: d4e8b71c2a90
+Revises: a9f1c62b70d5
+Create Date: 2026-07-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4e8b71c2a90"
+down_revision: str | None = "a9f1c62b70d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_bot_configs",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("platform", sa.String(length=16), nullable=False),
+        sa.Column("robot_id_encrypted", sa.Text(), nullable=False),
+        sa.Column("secret_encrypted", sa.Text(), nullable=True),
+        sa.Column("last_delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "platform IN ('dingtalk', 'feishu')", name="ck_chat_bot_configs_platform"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "platform", name="uq_chat_bot_configs_user_platform"
+        ),
+    )
+    op.create_index(
+        op.f("ix_chat_bot_configs_user_id"), "chat_bot_configs", ["user_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_chat_bot_configs_user_id"), table_name="chat_bot_configs")
+    op.drop_table("chat_bot_configs")

--- a/src/backend/app/api/chat_bots.py
+++ b/src/backend/app/api/chat_bots.py
@@ -1,0 +1,114 @@
+"""本人群机器人配置与单向消息推送 API。"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.chat_bot import ChatBotConfig
+from app.models.user import User
+from app.schemas.chat_bot import (
+    ChatBotConfigRead,
+    ChatBotConfigUpsert,
+    ChatBotDeliveryRead,
+    ChatBotMessageCreate,
+    ChatBotPlatform,
+)
+from app.services import chat_bots as chat_bots_service
+
+router = APIRouter(prefix="/chat-bots", tags=["chat-bots"])
+_PLATFORMS: tuple[ChatBotPlatform, ...] = ("dingtalk", "feishu")
+
+
+def _read(platform: ChatBotPlatform, row: ChatBotConfig | None) -> ChatBotConfigRead:
+    return ChatBotConfigRead(
+        platform=platform,
+        configured=row is not None,
+        has_secret=bool(row and row.secret_encrypted),
+        updated_at=row.updated_at if row else None,
+        last_delivered_at=row.last_delivered_at if row else None,
+    )
+
+
+@router.get("", response_model=list[ChatBotConfigRead])
+async def list_configs(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[ChatBotConfigRead]:
+    rows = await chat_bots_service.list_configs(session, user_id=user.id)
+    by_platform = {row.platform: row for row in rows}
+    return [_read(platform, by_platform.get(platform)) for platform in _PLATFORMS]
+
+
+@router.put("/{platform}", response_model=ChatBotConfigRead)
+async def save_config(
+    platform: ChatBotPlatform,
+    body: ChatBotConfigUpsert,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ChatBotConfigRead:
+    try:
+        row = await chat_bots_service.upsert_config(
+            session,
+            user_id=user.id,
+            platform=platform,
+            robot_id=body.robot_id,
+            secret=body.secret,
+            replace_secret="secret" in body.model_fields_set,
+        )
+    except chat_bots_service.InvalidChatBotIdError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="INVALID_CHAT_BOT_ID"
+        ) from exc
+    return _read(platform, row)
+
+
+@router.delete("/{platform}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_config(
+    platform: ChatBotPlatform,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    row = await chat_bots_service.get_config(session, user_id=user.id, platform=platform)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CHAT_BOT_NOT_CONFIGURED")
+    await chat_bots_service.delete_config(session, row)
+
+
+@router.post("/{platform}/messages", response_model=ChatBotDeliveryRead)
+async def send_message(
+    platform: ChatBotPlatform,
+    body: ChatBotMessageCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ChatBotDeliveryRead:
+    try:
+        parts = await chat_bots_service.deliver_message(
+            session,
+            user_id=user.id,
+            platform=platform,
+            title=body.title,
+            text=body.text,
+            link=body.link,
+        )
+    except chat_bots_service.ChatBotNotConfiguredError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="CHAT_BOT_NOT_CONFIGURED") from exc
+    except chat_bots_service.ChatBotDeliveryError as exc:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY, detail=f"CHAT_BOT_DELIVERY_FAILED:{exc.reason}"
+        ) from exc
+    return ChatBotDeliveryRead(platform=platform, delivered=True, parts=parts)
+
+
+@router.post("/{platform}/test", response_model=ChatBotDeliveryRead)
+async def test_config(
+    platform: ChatBotPlatform,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ChatBotDeliveryRead:
+    """显式测试会向目标群发送一条测试消息。"""
+    body = ChatBotMessageCreate(
+        title="Polaris 连接测试",
+        text="Polaris 群机器人已连接成功，之后可在文献对话中通过 @ 选择此机器人分享回答。",
+    )
+    return await send_message(platform, body, session, user)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -8,6 +8,7 @@ from app.api import (
     admin_settings,
     admin_users,
     auth,
+    chat_bots,
     concepts,
     daily,
     experiments,
@@ -42,6 +43,7 @@ from app.api import (
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(auth.router)
+api_router.include_router(chat_bots.router)
 api_router.include_router(users_profile.router)
 api_router.include_router(invites.router)
 api_router.include_router(admin_users.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -2,6 +2,7 @@
 
 from app.models.activity import Activity
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.chat_bot import ChatBotConfig
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
 from app.models.email_code import EmailVerificationCode
 from app.models.experiment import Experiment, ExperimentRun
@@ -42,6 +43,7 @@ from app.models.voyage import VoyageRun, VoyageStep
 
 __all__ = [
     "Activity",
+    "ChatBotConfig",
     "Concept",
     "DailyFeedEntry",
     "DailyFeedLike",

--- a/src/backend/app/models/chat_bot.py
+++ b/src/backend/app/models/chat_bot.py
@@ -1,0 +1,31 @@
+"""每用户私有的群机器人 Webhook 配置（凭据加密入库）。"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class ChatBotConfig(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """钉钉/飞书群自定义机器人；一个用户每个平台至多一条。"""
+
+    __tablename__ = "chat_bot_configs"
+    __table_args__ = (
+        UniqueConstraint("user_id", "platform", name="uq_chat_bot_configs_user_platform"),
+        CheckConstraint(
+            "platform IN ('dingtalk', 'feishu')", name="ck_chat_bot_configs_platform"
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    platform: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Webhook 中的 access_token / hook id 与签名密钥都能直接授权发群消息，均加密落库。
+    robot_id_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    secret_encrypted: Mapped[str | None] = mapped_column(Text)
+    last_delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/schemas/chat_bot.py
+++ b/src/backend/app/schemas/chat_bot.py
@@ -1,0 +1,55 @@
+"""群机器人配置与单向推送 API schema。"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+ChatBotPlatform = Literal["dingtalk", "feishu"]
+
+
+class ChatBotConfigUpsert(BaseModel):
+    # 可填完整官方 Webhook，也可只填其中的 access_token / hook id。
+    robot_id: str = Field(min_length=8, max_length=2048)
+    secret: str | None = Field(default=None, max_length=512)
+
+    @field_validator("robot_id", mode="before")
+    @classmethod
+    def clean_robot_id(cls, value: object) -> object:
+        return value.strip() if isinstance(value, str) else value
+
+    @field_validator("secret", mode="before")
+    @classmethod
+    def clean_secret(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            cleaned = value.strip()
+            return cleaned or None
+        return value
+
+
+class ChatBotConfigRead(BaseModel):
+    platform: ChatBotPlatform
+    configured: bool
+    has_secret: bool
+    updated_at: datetime | None = None
+    last_delivered_at: datetime | None = None
+
+
+class ChatBotMessageCreate(BaseModel):
+    title: str = Field(default="Polaris 分享", min_length=1, max_length=200)
+    # 服务层会按平台单请求上限拆段；总长仍设硬上限，避免一次请求无限占用连接。
+    text: str = Field(min_length=1, max_length=50_000)
+    link: str | None = Field(default=None, max_length=2048, pattern=r"^https?://")
+
+    @field_validator("title", "text", mode="before")
+    @classmethod
+    def clean_required_text(cls, value: object) -> object:
+        return value.strip() if isinstance(value, str) else value
+
+
+class ChatBotDeliveryRead(BaseModel):
+    platform: ChatBotPlatform
+    delivered: bool
+    parts: int = Field(ge=1)

--- a/src/backend/app/services/chat_bots.py
+++ b/src/backend/app/services/chat_bots.py
@@ -1,0 +1,295 @@
+"""群自定义机器人：用户配置管理、签名与单向 Webhook 推送。
+
+仅允许钉钉/飞书官方 Webhook host，并从完整 URL 中提取 token 后按固定 endpoint
+重建请求，避免用户可控 URL 形成 SSRF。机器人凭据由调用方在入库前/出库后加解密。
+"""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import re
+import time
+import uuid
+from collections.abc import Sequence
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import decrypt_secret, encrypt_secret
+from app.models.base import utcnow
+from app.models.chat_bot import ChatBotConfig
+from app.schemas.chat_bot import ChatBotPlatform
+
+DINGTALK_WEBHOOK = "https://oapi.dingtalk.com/robot/send"
+FEISHU_WEBHOOK_PREFIX = "https://open.feishu.cn/open-apis/bot/v2/hook/"
+_SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{8,512}$")
+_FEISHU_PATH_RE = re.compile(r"^/open-apis/bot/v2/hook/([^/]+)$")
+# 留出标题、链接、JSON 结构和签名字段的余量，确保飞书单请求小于官方 20 KB 上限。
+_PART_TEXT_BYTES = 12 * 1024
+
+
+class InvalidChatBotIdError(ValueError):
+    pass
+
+
+class ChatBotNotConfiguredError(LookupError):
+    pass
+
+
+class ChatBotDeliveryError(RuntimeError):
+    """上游拒绝或网络失败；异常文本绝不包含 token / secret。"""
+
+    def __init__(self, reason: str = "upstream_error") -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def normalize_robot_id(platform: ChatBotPlatform, raw: str) -> str:
+    """接受完整官方 Webhook 或裸 token，最终只保存 token。"""
+    value = raw.strip()
+    if value.startswith(("http://", "https://")):
+        try:
+            parsed = urlsplit(value)
+            port = parsed.port
+        except ValueError as exc:
+            raise InvalidChatBotIdError from exc
+        if parsed.scheme != "https" or parsed.username or parsed.password or port:
+            raise InvalidChatBotIdError
+        if platform == "dingtalk":
+            if parsed.hostname != "oapi.dingtalk.com" or parsed.path != "/robot/send":
+                raise InvalidChatBotIdError
+            values = parse_qs(parsed.query, strict_parsing=False).get("access_token", [])
+            if len(values) != 1:
+                raise InvalidChatBotIdError
+            value = values[0]
+        else:
+            if parsed.hostname != "open.feishu.cn" or parsed.query or parsed.fragment:
+                raise InvalidChatBotIdError
+            matched = _FEISHU_PATH_RE.fullmatch(parsed.path)
+            if matched is None:
+                raise InvalidChatBotIdError
+            value = matched.group(1)
+    if _SAFE_TOKEN_RE.fullmatch(value) is None:
+        raise InvalidChatBotIdError
+    return value
+
+
+async def list_configs(
+    session: AsyncSession, *, user_id: uuid.UUID
+) -> Sequence[ChatBotConfig]:
+    stmt = select(ChatBotConfig).where(ChatBotConfig.user_id == user_id)
+    return (await session.execute(stmt)).scalars().all()
+
+
+async def get_config(
+    session: AsyncSession, *, user_id: uuid.UUID, platform: ChatBotPlatform
+) -> ChatBotConfig | None:
+    stmt = select(ChatBotConfig).where(
+        ChatBotConfig.user_id == user_id,
+        ChatBotConfig.platform == platform,
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def upsert_config(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    platform: ChatBotPlatform,
+    robot_id: str,
+    secret: str | None,
+    replace_secret: bool = True,
+) -> ChatBotConfig:
+    normalized_id = normalize_robot_id(platform, robot_id)
+    row = await get_config(session, user_id=user_id, platform=platform)
+    if row is None:
+        row = ChatBotConfig(user_id=user_id, platform=platform)
+        session.add(row)
+    row.robot_id_encrypted = encrypt_secret(normalized_id)
+    # 更新 Webhook 时若请求没带 secret，保留已经保存的签名密钥；显式 null/空串才清除。
+    if replace_secret or row.secret_encrypted is None:
+        row.secret_encrypted = encrypt_secret(secret) if secret else None
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def delete_config(session: AsyncSession, config: ChatBotConfig) -> None:
+    await session.delete(config)
+    await session.commit()
+
+
+def _dingtalk_signature(secret: str, timestamp_ms: int) -> str:
+    string_to_sign = f"{timestamp_ms}\n{secret}".encode()
+    digest = hmac.new(secret.encode(), string_to_sign, digestmod=hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _feishu_signature(secret: str, timestamp_s: int) -> str:
+    # 飞书以 "timestamp\nsecret" 作为 HMAC key，对空字节串求 SHA-256。
+    key = f"{timestamp_s}\n{secret}".encode()
+    digest = hmac.new(key, b"", digestmod=hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _split_text(text: str) -> list[str]:
+    """按 UTF-8 字节切分，不截断 Unicode 字符；优先在换行处断开。"""
+    chunks: list[str] = []
+    remaining = text.strip()
+    while len(remaining.encode("utf-8")) > _PART_TEXT_BYTES:
+        used = 0
+        cut = 0
+        last_newline = -1
+        last_newline_bytes = -1
+        for index, char in enumerate(remaining):
+            width = len(char.encode("utf-8"))
+            if used + width > _PART_TEXT_BYTES:
+                break
+            used += width
+            cut = index + 1
+            if char == "\n":
+                last_newline = cut
+                last_newline_bytes = used
+        if last_newline_bytes >= _PART_TEXT_BYTES // 3:
+            cut = last_newline
+        chunks.append(remaining[:cut].strip())
+        remaining = remaining[cut:].strip()
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def _part_title(title: str, part: int, total: int) -> str:
+    return title if total == 1 else f"{title}（{part}/{total}）"
+
+
+def _dingtalk_payload(title: str, text: str, link: str | None) -> dict:
+    body = text
+    if link:
+        body += f"\n\n[在 Polaris 中打开]({link})"
+    return {"msgtype": "markdown", "markdown": {"title": title, "text": body}}
+
+
+def _feishu_payload(
+    title: str,
+    text: str,
+    link: str | None,
+    *,
+    secret: str | None,
+    timestamp_s: int,
+) -> dict:
+    paragraphs: list[list[dict[str, str]]] = [[{"tag": "text", "text": text}]]
+    if link:
+        paragraphs.append([{"tag": "a", "text": "在 Polaris 中打开", "href": link}])
+    payload: dict = {
+        "msg_type": "post",
+        "content": {"post": {"zh_cn": {"title": title, "content": paragraphs}}},
+    }
+    if secret:
+        payload.update(
+            {"timestamp": str(timestamp_s), "sign": _feishu_signature(secret, timestamp_s)}
+        )
+    return payload
+
+
+def _upstream_success(platform: ChatBotPlatform, response: httpx.Response) -> bool:
+    if not 200 <= response.status_code < 300:
+        return False
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(body, dict):
+        return False
+    if platform == "dingtalk":
+        return body.get("errcode") == 0
+    return body.get("code", body.get("StatusCode")) == 0
+
+
+async def _send_part(
+    client: httpx.AsyncClient,
+    *,
+    platform: ChatBotPlatform,
+    robot_id: str,
+    secret: str | None,
+    title: str,
+    text: str,
+    link: str | None,
+) -> None:
+    try:
+        if platform == "dingtalk":
+            timestamp_ms = int(time.time() * 1000)
+            params = {"access_token": robot_id}
+            if secret:
+                params.update(
+                    {
+                        "timestamp": str(timestamp_ms),
+                        "sign": _dingtalk_signature(secret, timestamp_ms),
+                    }
+                )
+            response = await client.post(
+                DINGTALK_WEBHOOK,
+                params=params,
+                json=_dingtalk_payload(title, text, link),
+            )
+        else:
+            timestamp_s = int(time.time())
+            response = await client.post(
+                f"{FEISHU_WEBHOOK_PREFIX}{robot_id}",
+                json=_feishu_payload(
+                    title, text, link, secret=secret, timestamp_s=timestamp_s
+                ),
+            )
+    except httpx.RequestError as exc:
+        raise ChatBotDeliveryError("network_error") from exc
+    if not _upstream_success(platform, response):
+        raise ChatBotDeliveryError("upstream_rejected")
+
+
+async def deliver_message(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    platform: ChatBotPlatform,
+    title: str,
+    text: str,
+    link: str | None,
+    client: httpx.AsyncClient | None = None,
+) -> int:
+    config = await get_config(session, user_id=user_id, platform=platform)
+    if config is None:
+        raise ChatBotNotConfiguredError
+
+    robot_id = decrypt_secret(config.robot_id_encrypted)
+    secret = decrypt_secret(config.secret_encrypted) if config.secret_encrypted else None
+    parts = _split_text(text)
+    owns_client = client is None
+    http_client = client or httpx.AsyncClient(
+        timeout=httpx.Timeout(10.0),
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    try:
+        for index, part in enumerate(parts, start=1):
+            await _send_part(
+                http_client,
+                platform=platform,
+                robot_id=robot_id,
+                secret=secret,
+                title=_part_title(title, index, len(parts)),
+                text=part,
+                link=link,
+            )
+            # 多段消息稍作间隔，兼容飞书 5 次/秒的单机器人频控。
+            if index < len(parts):
+                await asyncio.sleep(0.22)
+    finally:
+        if owns_client:
+            await http_client.aclose()
+
+    config.last_delivered_at = utcnow()
+    await session.commit()
+    return len(parts)

--- a/src/backend/tests/test_chat_bots.py
+++ b/src/backend/tests/test_chat_bots.py
@@ -1,0 +1,270 @@
+"""钉钉/飞书群机器人：配置隔离、密文存储、签名与单向推送。"""
+
+import json
+import uuid
+
+import httpx
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.security import decrypt_secret
+from app.models.chat_bot import ChatBotConfig
+from app.services import chat_bots
+from tests.conftest import register_and_login
+
+
+async def _auth(client, email: str = "alice@example.com") -> tuple[dict[str, str], uuid.UUID]:
+    token = await register_and_login(client, email)
+    headers = {"Authorization": f"Bearer {token}"}
+    me = await client.get("/api/users/me", headers=headers)
+    return headers, uuid.UUID(me.json()["id"])
+
+
+def test_normalize_robot_id_accepts_only_fixed_official_webhooks():
+    ding_token = "ding_token_0123456789"
+    feishu_token = "f99fed8d-9b01-4dfe-ab56-0123456789ab"
+    assert (
+        chat_bots.normalize_robot_id(
+            "dingtalk",
+            f"https://oapi.dingtalk.com/robot/send?access_token={ding_token}",
+        )
+        == ding_token
+    )
+    assert (
+        chat_bots.normalize_robot_id(
+            "feishu", f"https://open.feishu.cn/open-apis/bot/v2/hook/{feishu_token}"
+        )
+        == feishu_token
+    )
+    assert chat_bots.normalize_robot_id("dingtalk", ding_token) == ding_token
+
+    bad = (
+        "http://oapi.dingtalk.com/robot/send?access_token=ding_token_0123456789",
+        "https://evil.example/robot/send?access_token=ding_token_0123456789",
+        "https://oapi.dingtalk.com.evil.example/robot/send?access_token=x01234567",
+        "https://open.feishu.cn@evil.example/open-apis/bot/v2/hook/x01234567",
+    )
+    for value in bad:
+        platform = "feishu" if "feishu" in value else "dingtalk"
+        try:
+            chat_bots.normalize_robot_id(platform, value)  # type: ignore[arg-type]
+        except chat_bots.InvalidChatBotIdError:
+            pass
+        else:
+            raise AssertionError(f"unsafe webhook accepted: {value}")
+
+
+async def test_config_crud_is_encrypted_write_only_and_per_user(client):
+    alice, alice_id = await _auth(client)
+    bob, _ = await _auth(client, "bob@example.com")
+    webhook = (
+        "https://oapi.dingtalk.com/robot/send?"
+        "access_token=ding_token_0123456789abcdef"
+    )
+
+    empty = await client.get("/api/chat-bots", headers=alice)
+    assert empty.status_code == 200
+    assert empty.json() == [
+        {
+            "platform": "dingtalk",
+            "configured": False,
+            "has_secret": False,
+            "updated_at": None,
+            "last_delivered_at": None,
+        },
+        {
+            "platform": "feishu",
+            "configured": False,
+            "has_secret": False,
+            "updated_at": None,
+            "last_delivered_at": None,
+        },
+    ]
+
+    saved = await client.put(
+        "/api/chat-bots/dingtalk",
+        headers=alice,
+        json={"robot_id": webhook, "secret": "SEC-ding-signing-secret"},
+    )
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["configured"] is True
+    assert saved.json()["has_secret"] is True
+    assert "robot_id" not in saved.json() and "secret" not in saved.json()
+
+    # 只更新 Webhook、不填写 Secret 时保留旧密钥，避免设置页的写-only 输入误清配置。
+    updated = await client.put(
+        "/api/chat-bots/dingtalk",
+        headers=alice,
+        json={"robot_id": "ding_token_replaced_0123456789"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["has_secret"] is True
+
+    async with get_sessionmaker()() as session:
+        row = (
+            await session.execute(
+                select(ChatBotConfig).where(ChatBotConfig.user_id == alice_id)
+            )
+        ).scalar_one()
+        assert "ding_token_0123456789abcdef" not in row.robot_id_encrypted
+        assert "SEC-ding-signing-secret" not in (row.secret_encrypted or "")
+        assert decrypt_secret(row.robot_id_encrypted) == "ding_token_replaced_0123456789"
+        assert decrypt_secret(row.secret_encrypted or "") == "SEC-ding-signing-secret"
+
+    # 另一用户既看不到，也不能借用 Alice 的配置发送。
+    other = await client.get("/api/chat-bots", headers=bob)
+    assert all(not item["configured"] for item in other.json())
+    missing = await client.post(
+        "/api/chat-bots/dingtalk/messages",
+        headers=bob,
+        json={"text": "should not send"},
+    )
+    assert missing.status_code == 409
+    assert missing.json()["detail"] == "CHAT_BOT_NOT_CONFIGURED"
+
+    deleted = await client.delete("/api/chat-bots/dingtalk", headers=alice)
+    assert deleted.status_code == 204
+    assert all(
+        not item["configured"]
+        for item in (await client.get("/api/chat-bots", headers=alice)).json()
+    )
+
+
+async def test_config_rejects_arbitrary_webhook_host(client):
+    headers, _ = await _auth(client)
+    response = await client.put(
+        "/api/chat-bots/feishu",
+        headers=headers,
+        json={"robot_id": "https://attacker.example/open-apis/bot/v2/hook/abcdefgh"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "INVALID_CHAT_BOT_ID"
+
+    whitespace = await client.post(
+        "/api/chat-bots/feishu/messages",
+        headers=headers,
+        json={"text": "   "},
+    )
+    assert whitespace.status_code == 422
+
+
+async def test_dingtalk_delivery_uses_query_signature_and_markdown(client):
+    headers, user_id = await _auth(client)
+    await client.put(
+        "/api/chat-bots/dingtalk",
+        headers=headers,
+        json={
+            "robot_id": "ding_token_0123456789abcdef",
+            "secret": "SEC-ding-signing-secret",
+        },
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"errcode": 0, "errmsg": "ok"})
+
+    async with get_sessionmaker()() as session:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as upstream:
+            parts = await chat_bots.deliver_message(
+                session,
+                user_id=user_id,
+                platform="dingtalk",
+                title="论文推荐",
+                text="这篇论文值得阅读。",
+                link="https://polaris.example/papers/1/read",
+                client=upstream,
+            )
+        row = (
+            await session.execute(
+                select(ChatBotConfig).where(ChatBotConfig.user_id == user_id)
+            )
+        ).scalar_one()
+        assert row.last_delivered_at is not None
+
+    assert parts == 1 and len(requests) == 1
+    request = requests[0]
+    assert request.url.host == "oapi.dingtalk.com"
+    assert request.url.params["access_token"] == "ding_token_0123456789abcdef"
+    timestamp = int(request.url.params["timestamp"])
+    assert request.url.params["sign"] == chat_bots._dingtalk_signature(  # noqa: SLF001
+        "SEC-ding-signing-secret", timestamp
+    )
+    payload = json.loads(request.content)
+    assert payload["msgtype"] == "markdown"
+    assert payload["markdown"]["title"] == "论文推荐"
+    assert "这篇论文值得阅读。" in payload["markdown"]["text"]
+    assert "https://polaris.example/papers/1/read" in payload["markdown"]["text"]
+
+
+async def test_feishu_delivery_uses_body_signature_and_post_link(client):
+    headers, user_id = await _auth(client)
+    hook_id = "f99fed8d-9b01-4dfe-ab56-0123456789ab"
+    await client.put(
+        "/api/chat-bots/feishu",
+        headers=headers,
+        json={"robot_id": hook_id, "secret": "feishu-signing-secret"},
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"code": 0, "msg": "success", "data": {}})
+
+    async with (
+        get_sessionmaker()() as session,
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)) as upstream,
+    ):
+        parts = await chat_bots.deliver_message(
+            session,
+            user_id=user_id,
+            platform="feishu",
+            title="Polaris 分享",
+            text="结论正文",
+            link="https://polaris.example/papers/2/read",
+            client=upstream,
+        )
+
+    assert parts == 1 and len(requests) == 1
+    request = requests[0]
+    assert request.url == f"https://open.feishu.cn/open-apis/bot/v2/hook/{hook_id}"
+    payload = json.loads(request.content)
+    timestamp = int(payload["timestamp"])
+    assert payload["sign"] == chat_bots._feishu_signature(  # noqa: SLF001
+        "feishu-signing-secret", timestamp
+    )
+    assert payload["msg_type"] == "post"
+    post = payload["content"]["post"]["zh_cn"]
+    assert post["content"][0][0] == {"tag": "text", "text": "结论正文"}
+    assert post["content"][1][0]["href"] == "https://polaris.example/papers/2/read"
+    assert len(request.content) < 20 * 1024
+
+
+async def test_upstream_rejection_maps_to_safe_502(client, monkeypatch):
+    headers, _ = await _auth(client)
+    await client.put(
+        "/api/chat-bots/feishu",
+        headers=headers,
+        json={"robot_id": "feishu_hook_0123456789"},
+    )
+
+    async def rejected(*_args, **_kwargs):
+        raise chat_bots.ChatBotDeliveryError("upstream_rejected")
+
+    monkeypatch.setattr(chat_bots, "deliver_message", rejected)
+    response = await client.post(
+        "/api/chat-bots/feishu/messages",
+        headers=headers,
+        json={"text": "hello"},
+    )
+    assert response.status_code == 502
+    assert response.json()["detail"] == "CHAT_BOT_DELIVERY_FAILED:upstream_rejected"
+    assert "feishu_hook_0123456789" not in response.text
+
+
+def test_long_unicode_text_is_split_without_data_loss():
+    text = ("研究结论一。\n" * 1800).strip()
+    parts = chat_bots._split_text(text)  # noqa: SLF001
+    assert len(parts) > 1
+    assert all(len(part.encode("utf-8")) <= 12 * 1024 for part in parts)
+    assert "".join(parts).replace("\n", "") == text.replace("\n", "")

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a9f1c62b70d5"  # 概念转正门槛（concepts.status）
+HEAD_REVISION = "d4e8b71c2a90"  # 每用户群机器人 Webhook 配置
+CONCEPT_STATUS_REVISION = "a9f1c62b70d5"  # 概念转正门槛（concepts.status）
 INDEX_META_REVISION = "c4e7b2a91f38"  # 分段来源标记 + 向量构建元信息
 CONCEPTS_REVISION = "b6c2f81d4a09"  # 概念统一到论文级
 PREV_REVISION = "a7d0c9e51b34"  # 解读统一到 paper_wikis
@@ -80,6 +81,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "activities",
                     "direction_libraries",
                     "projects",
+                    "chat_bot_configs",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -290,8 +292,24 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"concepts_pre_unify", "paper_concepts_pre_unify"} <= columns["_tables"]
     # 本分支新增：概念转正门槛（candidate / active）
     assert "status" in columns["concepts"]
+    # 每用户群机器人配置：token / secret 只存密文，用户 × 平台唯一约束由迁移创建。
+    assert "chat_bot_configs" in columns["_tables"]
+    assert {
+        "user_id",
+        "platform",
+        "robot_id_encrypted",
+        "secret_encrypted",
+        "last_delivered_at",
+    } <= columns["chat_bot_configs"]
 
-    # 最新 revision 可往返：先退掉本次的概念状态列。
+    # 最新 revision 可往返：先退掉群机器人配置表。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CONCEPT_STATUS_REVISION
+    assert "chat_bot_configs" not in columns["_tables"]
+    assert "status" in columns["concepts"]
+
+    # 再退掉概念状态列。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == INDEX_META_REVISION
@@ -372,6 +390,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "chat_bot_configs" in columns["_tables"]
     # 索引回归；个人标签表、回收站列与两张备份表也仍在
     assert "ix_llm_usage_created_at" in _index_names(db_path, "llm_usage")
     assert "user_paper_tags" in columns["_tables"]

--- a/src/frontend/src/features/chat/ChatSurface.tsx
+++ b/src/frontend/src/features/chat/ChatSurface.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
-import { api, skillKindLabel, type ChatTurn } from '../../lib/api';
+import { ApiError, api, skillKindLabel, type ChatTurn } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useIsMobile } from '../../lib/useBreakpoint';
 import { useChatHistory } from './useChatHistory';
@@ -69,6 +69,18 @@ function recommendPrompt(context: ContextRef[], shareLink?: string | null): stri
   ].filter(Boolean).join('\n\n');
 }
 
+function robotShareError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.message === 'CHAT_BOT_NOT_CONFIGURED') {
+      return tr('尚未配置该机器人，请先到“设置 → 群机器人”填写 ID 和 Secret', 'This bot is not configured. Add its ID and secret under Settings → Group bots.');
+    }
+    if (error.message.startsWith('CHAT_BOT_DELIVERY_FAILED')) {
+      return tr('机器人拒绝了推送，请检查 ID、Secret 与群安全设置', 'The bot rejected delivery. Check its ID, secret, and group security settings.');
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function ChatSurface(cfg: ChatSurfaceConfig) {
   const history = useChatHistory(cfg.surfaceKey);
   const { activeMsgs, commit } = history;
@@ -85,7 +97,7 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // 是否「贴着底部」：用户往上滚离底部后暂停自动跟随，滚回底部再恢复
   const stickBottomRef = useRef(true);
-  // 提交后待发的分享目标（回答完成时触发桩投递提示）
+  // 提交后待发的分享目标（回答完成时触发平台用户提示或群机器人真实投递）
   const pendingShareRef = useRef<MentionTarget | null>(null);
 
   const skillsQ = useQuery({
@@ -114,26 +126,46 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
     stickBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
   };
 
-  const finishStream = (failed: boolean, fallbackText?: string) => {
+  const finishStream = (failed: boolean, fallbackText?: string, deliverShare = true) => {
     setStreaming(false);
     stopRef.current = null;
-    commit(
-      withLastAssistant(activeMsgsRef.current, (last) => ({
-        ...last,
-        done: true,
-        failed: failed || undefined,
-        content: last.content || fallbackText || '',
-      })),
-    );
-    // 桩投递：回答完成后提示「已排队，后端待接」
+    const finalMsgs = withLastAssistant(activeMsgsRef.current, (last) => ({
+      ...last,
+      done: true,
+      failed: failed || undefined,
+      content: last.content || fallbackText || '',
+    }));
+    activeMsgsRef.current = finalMsgs;
+    commit(finalMsgs);
     const share = pendingShareRef.current;
     pendingShareRef.current = null;
-    if (share && !failed) {
+    if (share && !failed && deliverShare) {
       const link = cfg.shareLink ? tr('，已附论文链接', ' with paper link') : '';
-      toast(
-        tr(`已排队分享给 ${share.label}${link}（后端待接）`, `Queued to share with ${share.label}${link} (backend pending)`),
-        'ok',
-      );
+      if (share.kind === 'user') {
+        // 平台成员私信不在本次群机器人单向推送范围内，保留原有提示。
+        toast(
+          tr(`已排队分享给 ${share.label}${link}（成员分享后端待接）`, `Queued to share with ${share.label}${link} (member delivery pending)`),
+          'info',
+        );
+        return;
+      }
+      const assistant = finalMsgs[finalMsgs.length - 1];
+      const text = assistant?.role === 'assistant' ? assistant.content.trim() : '';
+      if (!text) {
+        toast(tr('回答为空，未向群机器人推送', 'The answer was empty, so nothing was sent to the group bot.'), 'error');
+        return;
+      }
+      toast(tr(`正在推送给 ${share.label}…`, `Sending to ${share.label}…`), 'info');
+      void api.sendChatBotMessage(share.kind, {
+        title: tr('Polaris AI 分享', 'Shared from Polaris AI'),
+        text,
+        ...(cfg.shareLink ? { link: cfg.shareLink } : {}),
+      }).then((result) => {
+        const parts = result.parts > 1 ? tr(`（${result.parts} 条）`, ` (${result.parts} messages)`) : '';
+        toast(tr(`已分享给 ${share.label}${link}${parts}`, `Shared with ${share.label}${link}${parts}`), 'ok');
+      }).catch((error: unknown) => {
+        toast(`${tr('分享失败', 'Share failed')}：${robotShareError(error)}`, 'error');
+      });
     }
   };
 
@@ -203,7 +235,8 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
 
   const stop = () => {
     stopRef.current?.();
-    finishStream(false);
+    // 人工停止只结束本地生成，不把不完整回答发到外部群。
+    finishStream(false, undefined, false);
   };
 
   const questionFor = (idx: number): string => {

--- a/src/frontend/src/features/chat/Composer.tsx
+++ b/src/frontend/src/features/chat/Composer.tsx
@@ -62,6 +62,14 @@ export function Composer({
   const [hi, setHi] = useState(0);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
+  const botConfigsQ = useQuery({
+    queryKey: ['chat-bots'],
+    queryFn: () => api.listChatBotConfigs(),
+    enabled: menu?.type === 'mention',
+    retry: false,
+    staleTime: 60_000,
+  });
+
   // —— / 选择器候选：按需拉取真实列表 ——
   const slashOpen = menu?.type === 'slash';
   const papersQ = useQuery({
@@ -124,10 +132,17 @@ export function Composer({
         label: m.display_name || m.email || tr('成员', 'Member'),
         sub: m.email ?? undefined,
       }));
-    const all = [...users, ...BOTS];
+    const bots = BOTS.map((bot) => {
+      const config = botConfigsQ.data?.find((item) => item.platform === bot.kind);
+      const status = config?.configured
+        ? tr('已配置', 'Configured')
+        : tr('未配置 · 请先到设置页填写', 'Not configured · set it up in Settings');
+      return { ...bot, sub: `${bot.sub} · ${status}` };
+    });
+    const all = [...users, ...bots];
     const q = menu.query.toLowerCase();
     return all.filter((t) => !q || t.label.toLowerCase().includes(q) || (t.sub ?? '').toLowerCase().includes(q));
-  }, [menu, currentProject?.members]);
+  }, [menu, currentProject?.members, botConfigsQ.data]);
 
   const menuLen = slashOpen ? slashItems.length : mentionItems.length;
   useEffect(() => {

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -24,6 +24,7 @@ import {
   api,
   type AdminUserRead,
   type AffiliationMode,
+  type ChatBotPlatform,
   type EffectiveTestResult,
   type LlmCallLogRow,
   type LlmProviderInput,
@@ -266,6 +267,241 @@ function PreferencesTab() {
           onChange={setTaskLogHistory}
           aria-labelledby="pref-task-log-history"
         />
+      </div>
+    </div>
+  );
+}
+
+// ---------------- 群机器人（单向 Webhook 推送） ----------------
+
+const CHAT_BOT_PLATFORMS: ChatBotPlatform[] = ['dingtalk', 'feishu'];
+const CHAT_BOT_META: Record<ChatBotPlatform, {
+  zh: string;
+  en: string;
+  idZh: string;
+  idEn: string;
+  placeholder: string;
+  docs: string;
+}> = {
+  dingtalk: {
+    zh: '钉钉机器人',
+    en: 'DingTalk bot',
+    idZh: '机器人 ID / Webhook',
+    idEn: 'Bot ID / Webhook',
+    placeholder: 'https://oapi.dingtalk.com/robot/send?access_token=…',
+    docs: 'https://open.dingtalk.com/document/orgapp/custom-robot-access',
+  },
+  feishu: {
+    zh: '飞书机器人',
+    en: 'Feishu bot',
+    idZh: '机器人 ID / Webhook',
+    idEn: 'Bot ID / Webhook',
+    placeholder: 'https://open.feishu.cn/open-apis/bot/v2/hook/…',
+    docs: 'https://open.feishu.cn/document/ukTMukTMukTM/ucTM5YjL3ETO24yNxkjN',
+  },
+};
+
+interface ChatBotDraft {
+  robot_id: string;
+  secret: string;
+}
+
+const EMPTY_CHAT_BOT_DRAFTS: Record<ChatBotPlatform, ChatBotDraft> = {
+  dingtalk: { robot_id: '', secret: '' },
+  feishu: { robot_id: '', secret: '' },
+};
+
+function chatBotError(e: unknown): string {
+  if (e instanceof ApiError) {
+    if (e.message === 'INVALID_CHAT_BOT_ID') {
+      return tr('机器人 ID / Webhook 格式不正确，请粘贴官方地址', 'Invalid bot ID / Webhook; paste the official URL');
+    }
+    if (e.message === 'CHAT_BOT_NOT_CONFIGURED') {
+      return tr('机器人尚未配置', 'Bot is not configured');
+    }
+    if (e.message.startsWith('CHAT_BOT_DELIVERY_FAILED')) {
+      return tr('推送失败，请检查机器人 ID、Secret 和群安全设置', 'Delivery failed; check the bot ID, secret, and group security settings');
+    }
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+function ChatBotsTab() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['chat-bots'],
+    queryFn: () => api.listChatBotConfigs(),
+    retry: false,
+  });
+  const [drafts, setDrafts] = useState<Record<ChatBotPlatform, ChatBotDraft>>(
+    EMPTY_CHAT_BOT_DRAFTS,
+  );
+
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['chat-bots'] });
+  const saveMutation = useMutation({
+    mutationFn: (platform: ChatBotPlatform) => {
+      const draft = drafts[platform];
+      return api.saveChatBotConfig(platform, {
+        robot_id: draft.robot_id.trim(),
+        ...(draft.secret.trim() ? { secret: draft.secret.trim() } : {}),
+      });
+    },
+    onSuccess: (_, platform) => {
+      setDrafts((current) => ({ ...current, [platform]: { robot_id: '', secret: '' } }));
+      invalidate();
+      toast(tr(`${CHAT_BOT_META[platform].zh}配置已加密保存`, `${CHAT_BOT_META[platform].en} configuration saved encrypted`), 'ok');
+    },
+    onError: (e) => toast(`${tr('保存失败', 'Save failed')}：${chatBotError(e)}`, 'error'),
+  });
+  const testMutation = useMutation({
+    mutationFn: (platform: ChatBotPlatform) => api.testChatBotConfig(platform),
+    onSuccess: (_, platform) => {
+      invalidate();
+      toast(tr(`测试消息已发送到${CHAT_BOT_META[platform].zh}群`, `Test message sent to the ${CHAT_BOT_META[platform].en} group`), 'ok');
+    },
+    onError: (e) => toast(`${tr('测试失败', 'Test failed')}：${chatBotError(e)}`, 'error'),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (platform: ChatBotPlatform) => api.deleteChatBotConfig(platform),
+    onSuccess: (_, platform) => {
+      invalidate();
+      toast(tr(`${CHAT_BOT_META[platform].zh}配置已删除`, `${CHAT_BOT_META[platform].en} configuration deleted`), 'ok');
+    },
+    onError: (e) => toast(`${tr('删除失败', 'Delete failed')}：${chatBotError(e)}`, 'error'),
+  });
+
+  if (isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (isError || !data) {
+    return (
+      <div className="empty">
+        {tr('无法加载群机器人配置', 'Failed to load bot configurations')}
+        <div style={{ marginTop: 10 }}>
+          <button className="btn btn-soft sm" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 760 }}>
+      <div className="card card-pad" style={{ marginBottom: 14 }}>
+        <div className="section-h">{tr('群机器人单向推送', 'One-way group bot delivery')}</div>
+        <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.65, marginTop: 6 }}>
+          {tr(
+            '在钉钉或飞书目标群中添加“自定义机器人”，开启“签名校验”，然后把 Webhook（或其中的机器人 ID）和 Secret 填在下面。之后在文献对话或 AI 伴读里输入 @ 并选择机器人，Polaris 会在回答完成后直接推送到群；群成员无需再 @ 机器人。',
+            'Add a custom bot to the target DingTalk or Feishu group, enable signature verification, then enter its Webhook (or bot ID) and secret below. In literature chat or AI reading, type @ and select the bot; Polaris pushes the completed answer directly to the group, with no need to mention the bot there.',
+          )}
+        </div>
+      </div>
+
+      <div className="col gap14">
+        {CHAT_BOT_PLATFORMS.map((platform) => {
+          const meta = CHAT_BOT_META[platform];
+          const config = data.find((item) => item.platform === platform);
+          const draft = drafts[platform];
+          const busy =
+            (saveMutation.isPending && saveMutation.variables === platform) ||
+            (testMutation.isPending && testMutation.variables === platform) ||
+            (deleteMutation.isPending && deleteMutation.variables === platform);
+          return (
+            <div key={platform} className="card card-pad">
+              <div className="row gap10" style={{ marginBottom: 14, alignItems: 'center' }}>
+                <Icon name="chat" size={16} style={{ color: 'var(--accent)' }} />
+                <span className="section-h">{tr(meta.zh, meta.en)}</span>
+                <span
+                  className="pill sm"
+                  style={config?.configured
+                    ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+                    : { background: 'var(--surface-3)', color: 'var(--text-3)' }}
+                >
+                  {config?.configured
+                    ? tr(config.has_secret ? '已配置 · 已加签' : '已配置 · 未加签', config.has_secret ? 'Configured · signed' : 'Configured · unsigned')
+                    : tr('未配置', 'Not configured')}
+                </span>
+                <a href={meta.docs} target="_blank" rel="noreferrer noopener" className="btn btn-ghost sm" style={{ marginLeft: 'auto' }}>
+                  {tr('官方配置说明', 'Official setup guide')}
+                </a>
+              </div>
+
+              <FormField
+                label={tr(meta.idZh, meta.idEn)}
+                hint={tr(
+                  '推荐直接粘贴完整 Webhook；后端只保存提取出的 ID，并拒绝非官方域名。已配置的值不会回传，更新时请重新填写。',
+                  'Paste the full Webhook. The backend stores only the extracted ID and rejects non-official hosts. Saved values are write-only; re-enter them to update.',
+                )}
+              >
+                <input
+                  className="input mono"
+                  value={draft.robot_id}
+                  onChange={(e) => setDrafts((current) => ({
+                    ...current,
+                    [platform]: { ...current[platform], robot_id: e.target.value },
+                  }))}
+                  placeholder={config?.configured ? tr('已加密保存；填写新值可替换', 'Saved encrypted; enter a new value to replace') : meta.placeholder}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </FormField>
+              <FormField
+                label={tr('签名 Secret', 'Signing secret')}
+                hint={tr(
+                  '推荐在机器人安全设置中开启“签名校验”并填写。若机器人没有开启签名校验，可留空。',
+                  'Recommended: enable signature verification in the bot security settings and enter the secret. Leave blank only if signing is disabled for the bot.',
+                )}
+              >
+                <input
+                  className="input mono"
+                  type="password"
+                  value={draft.secret}
+                  onChange={(e) => setDrafts((current) => ({
+                    ...current,
+                    [platform]: { ...current[platform], secret: e.target.value },
+                  }))}
+                  placeholder={config?.has_secret ? tr('已加密保存', 'Saved encrypted') : tr('可选', 'Optional')}
+                  autoComplete="new-password"
+                />
+              </FormField>
+
+              <div className="row gap8" style={{ justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+                {config?.last_delivered_at && (
+                  <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginRight: 'auto' }}>
+                    {tr('最近发送', 'Last sent')}：{fmtTime(config.last_delivered_at)}
+                  </span>
+                )}
+                {config?.configured && (
+                  <>
+                    <button
+                      className="btn btn-soft sm"
+                      disabled={busy}
+                      title={tr('会向目标群实际发送一条测试消息', 'Sends a real test message to the target group')}
+                      onClick={() => testMutation.mutate(platform)}
+                    >
+                      {testMutation.isPending && testMutation.variables === platform ? tr('发送中…', 'Sending…') : tr('发送测试消息', 'Send test message')}
+                    </button>
+                    <button
+                      className="btn btn-ghost sm"
+                      disabled={busy}
+                      onClick={() => {
+                        if (window.confirm(tr(`删除${meta.zh}配置？`, `Delete the ${meta.en} configuration?`))) {
+                          deleteMutation.mutate(platform);
+                        }
+                      }}
+                    >
+                      {tr('删除配置', 'Delete')}
+                    </button>
+                  </>
+                )}
+                <button
+                  className="btn btn-primary sm"
+                  disabled={busy || draft.robot_id.trim() === ''}
+                  onClick={() => saveMutation.mutate(platform)}
+                >
+                  {saveMutation.isPending && saveMutation.variables === platform ? tr('保存中…', 'Saving…') : tr('保存配置', 'Save')}
+                </button>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -2349,7 +2585,7 @@ function MyUsageTab() {
 // ---------------- 页面 ----------------
 
 /** 普通用户设置的标签页（管理员那组在 /admin，见 AdminSettingsPage）。 */
-type Tab = 'personal' | 'chat' | 'prefs' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
+type Tab = 'personal' | 'chat' | 'prefs' | 'bots' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
 
 /** 旧的 /settings?tab=xxx 深链里属于管理员组的值 → 统一改跳 /admin。 */
 export const ADMIN_TABS = ['llm', 'daily', 'usage', 'users', 'codes', 'feedback'] as const;
@@ -3354,7 +3590,7 @@ export function CodesTab() {
   );
 }
 
-const PERSONAL_TABS: Tab[] = ['personal', 'chat', 'prefs', 'ssh', 'mymodels', 'myusage', 'mcp'];
+const PERSONAL_TABS: Tab[] = ['personal', 'chat', 'prefs', 'bots', 'ssh', 'mymodels', 'myusage', 'mcp'];
 
 export function SettingsPage() {
   // 支持 /settings?tab=mcp 这类深链（如旧 /mcp-tools 路由的重定向）
@@ -3373,6 +3609,7 @@ export function SettingsPage() {
     { v: 'personal', label: tr('个人信息', 'Profile') },
     { v: 'chat', label: tr('文献对话', 'Literature chat') },
     { v: 'prefs', label: tr('界面偏好', 'Interface') },
+    { v: 'bots', label: tr('群机器人', 'Group bots') },
     { v: 'ssh', label: tr('SSH 凭据', 'SSH credentials') },
     { v: 'mymodels', label: tr('我的模型', 'My LLM') },
     { v: 'myusage', label: tr('用量', 'Usage') },
@@ -3388,6 +3625,7 @@ export function SettingsPage() {
       {tab === 'personal' && <PersonalTab />}
       {tab === 'chat' && <ChatPrefsTab />}
       {tab === 'prefs' && <PreferencesTab />}
+      {tab === 'bots' && <ChatBotsTab />}
       {tab === 'ssh' && <SshTab />}
       {tab === 'mymodels' && <MyLlmTab />}
       {tab === 'myusage' && <MyUsageTab />}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1496,6 +1496,39 @@ export interface SshSysinfo {
 }
 
 // ============================================================
+// 群机器人（每用户私有配置；只做单向 Webhook 推送）
+// ============================================================
+
+export type ChatBotPlatform = 'dingtalk' | 'feishu';
+
+export interface ChatBotConfigRead {
+  platform: ChatBotPlatform;
+  configured: boolean;
+  has_secret: boolean;
+  updated_at: string | null;
+  last_delivered_at: string | null;
+}
+
+export interface ChatBotConfigInput {
+  /** 可填完整官方 Webhook，或其中的 access_token / hook id。 */
+  robot_id: string;
+  /** 开启机器人「签名校验」时填写；明文只在本次请求中出现。 */
+  secret?: string;
+}
+
+export interface ChatBotMessageInput {
+  title?: string;
+  text: string;
+  link?: string;
+}
+
+export interface ChatBotDeliveryRead {
+  platform: ChatBotPlatform;
+  delivered: boolean;
+  parts: number;
+}
+
+// ============================================================
 // M4 · Experiments（实验，与 kind=experiment 的 voyage 1:1）
 // ============================================================
 
@@ -3519,6 +3552,23 @@ export const api = {
   },
   postSessionMessage(sessionId: string, content: string): Promise<ReviewMessageRead> {
     return requestJson<ReviewMessageRead>(`/sessions/${sessionId}/messages`, 'POST', { content });
+  },
+
+  // —— 群机器人：本人配置 + 单向推送 ——
+  listChatBotConfigs(): Promise<ChatBotConfigRead[]> {
+    return request<ChatBotConfigRead[]>('/chat-bots');
+  },
+  saveChatBotConfig(platform: ChatBotPlatform, input: ChatBotConfigInput): Promise<ChatBotConfigRead> {
+    return requestJson<ChatBotConfigRead>(`/chat-bots/${platform}`, 'PUT', input);
+  },
+  deleteChatBotConfig(platform: ChatBotPlatform): Promise<void> {
+    return request<void>(`/chat-bots/${platform}`, { method: 'DELETE' });
+  },
+  testChatBotConfig(platform: ChatBotPlatform): Promise<ChatBotDeliveryRead> {
+    return request<ChatBotDeliveryRead>(`/chat-bots/${platform}/test`, { method: 'POST' });
+  },
+  sendChatBotMessage(platform: ChatBotPlatform, input: ChatBotMessageInput): Promise<ChatBotDeliveryRead> {
+    return requestJson<ChatBotDeliveryRead>(`/chat-bots/${platform}/messages`, 'POST', input);
   },
 
   // —— M4 · SSH 凭据 ——


### PR DESCRIPTION
## Summary

- add per-user DingTalk and Feishu group bot configuration under **Settings → Group bots**
- validate official webhook URLs, extract bot tokens, and encrypt bot tokens and signing secrets at rest
- add authenticated CRUD, connection testing, and message delivery APIs backed by a new Alembic migration
- deliver completed literature chat and AI reading answers to the selected group bot, including signed requests, safe error handling, and oversized-message splitting
- show configuration status in the `@` mention picker

## Why

Users previously had no place in their personal settings to configure group bot delivery. Bot mentions in chat only produced a placeholder notification and did not send the completed answer to DingTalk or Feishu.

## User impact

Each user can configure one target group bot per supported platform. The webhook token identifies the destination group, while the optional secret is used only for signature verification. Users can save, test, replace, or remove their own configuration without exposing stored credentials through the API.

## Validation

- `.venv/bin/pytest -q tests/test_chat_bots.py tests/test_migrations.py` — 8 passed
- `.venv/bin/ruff check ...` — passed
- `npm run build` — passed
- Docker API, worker, and frontend images rebuilt successfully
- Alembic upgraded to `d4e8b71c2a90 (head)`
- API and proxied frontend health checks returned `status: ok`
