### PR TITLE
fix(arxiv): retry rate limits and timeouts instead of losing the run

### DIFF
--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -1,15 +1,18 @@
 """arXiv Atom API 客户端：分类+关键词搜索（日期窗口、分页）、按 id 批量取元数据、PDF 下载。
 
-礼貌限速：官方建议请求间隔 3 秒（缓存命中不占限速额度）。
+礼貌限速：官方建议请求间隔 3 秒（缓存命中不占限速额度）。被限流时按 ``Retry-After``
+或指数退避重试，见 :meth:`ArxivClient._request`——所有出网请求都走那一个出口。
 
 另含分类 RSS「新鲜源」（``fetch_new``）：``rss.arxiv.org/rss/{category}`` 返回当天新公告，
 即时无滞后——用于绕开关键词检索索引 3-5 天的滞后（增量同步搜不到最新论文的根因）。
 """
 
+import asyncio
 import logging
+import random
 import re
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any
 
@@ -46,6 +49,41 @@ _RSS_CACHE_TTL = 3 * 3600
 _RSS_KEEP_TYPES = frozenset({"new", "cross"})
 
 _VERSION_RE = re.compile(r"v\d+$")
+
+# 值得重试的状态码。429 是标准限流；**403 也算**——arXiv 历史上对它认为过量的客户端
+# 直接返 403 而不是 429，当成永久失败会让整批论文白白丢掉。5xx 是服务端抖动。
+# 其余 4xx（如检索串写错的 400）立即抛，不能烧四次退避去撞同一堵墙。
+_RETRY_STATUSES = frozenset({403, 429, 500, 502, 503, 504})
+# 单次退避上限：Retry-After 可能给出很大的值，voyage 任务不能被一个响应头挂住半天
+_MAX_BACKOFF_SECONDS = 120.0
+
+
+class ArxivError(RuntimeError):
+    """arXiv 请求失败（重试后仍未成功）。"""
+
+
+class ArxivRateLimitedError(ArxivError):
+    """被 arXiv 限流，且重试次数耗尽。"""
+
+
+def _retry_after_seconds(resp: httpx.Response) -> float | None:
+    """解析 Retry-After：整数秒或 HTTP-date 两种形式都要认，解不出返回 None。"""
+    raw = (resp.headers.get("Retry-After") or "").strip()
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(int(raw)))
+    except ValueError:
+        pass
+    try:
+        dt = parsedate_to_datetime(raw)
+    except (TypeError, ValueError, IndexError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return max(0.0, (dt - datetime.now(UTC)).total_seconds())
 
 
 def normalize_arxiv_id(raw: str) -> str:
@@ -185,23 +223,88 @@ class ArxivClient:
         redis: Redis | None = None,
         min_interval: float = 3.0,
         page_size: int = 100,
+        max_retries: int = 4,
+        backoff_base: float = 2.0,
     ) -> None:
+        settings = get_settings()
         self._client = client or httpx.AsyncClient(
-            proxy=get_settings().outbound_proxy or None, timeout=30.0, follow_redirects=True
+            proxy=settings.outbound_proxy or None,
+            timeout=30.0,
+            follow_redirects=True,
+            # arXiv 对不表明身份的客户端限得更狠，给一个能联系到人的 UA
+            headers={"User-Agent": f"Polaris/1.0 (+mailto:{settings.openalex_mailto})"},
         )
         self._cache = ResponseCache(redis)
         # RSS 新鲜源用独立的短 TTL 缓存（3h），跨用户/项目共享当天新公告
         self._rss_cache = ResponseCache(redis, ttl=_RSS_CACHE_TTL)
         self._limiter = MinIntervalLimiter(min_interval)
         self._page_size = page_size
+        self._max_retries = max(1, max_retries)
+        self._backoff_base = backoff_base
+
+    async def _request(self, url: str, *, params: dict[str, Any] | None = None) -> httpx.Response:
+        """所有 arXiv 请求的唯一出口：限速 + 遇限流/超时退避重试。
+
+        重试覆盖两类失败，都是生产上实际见过的：``export.arxiv.org`` 返回 **429**
+        （三个库同步任务因此停在第一步），以及 ``ReadTimeout``（一个建库任务因此中断）。
+
+        退避优先听 ``Retry-After``，没有就指数退避 + **full jitter**（api 与 worker 是两个
+        进程、各自独立重试，加满抖动才能把它们错开）。退避的同时 ``penalize`` 共享限流器，
+        否则同进程里别的协程会接着打过去，等于没退避。
+        """
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            await self._limiter.acquire()
+            retry_after: float | None = None
+            try:
+                resp = await self._client.get(url, params=params)
+            except (httpx.TimeoutException, httpx.TransportError) as e:
+                # 生产上真实见过 ReadTimeout 让整个建库任务停在第一步。超时和连接错误
+                # 与限流同属「过一会儿再试就好」，同样重试。
+                last_exc = e
+                logger.warning("arxiv request failed (%s): %s", type(e).__name__, url)
+            else:
+                if resp.status_code not in _RETRY_STATUSES:
+                    resp.raise_for_status()
+                    return resp
+                retry_after = _retry_after_seconds(resp)
+                last_exc = httpx.HTTPStatusError(
+                    f"{resp.status_code} from arXiv", request=resp.request, response=resp
+                )
+                # 生产上 arXiv 返回的是 429（实测），响应头留档以便后续调整判据
+                logger.warning(
+                    "arxiv throttled: status=%s url=%s attempt=%s/%s retry_after=%s headers=%s",
+                    resp.status_code,
+                    url,
+                    attempt + 1,
+                    self._max_retries,
+                    retry_after,
+                    dict(resp.headers),
+                )
+            delay = (
+                min(_MAX_BACKOFF_SECONDS, retry_after)
+                if retry_after is not None
+                else random.uniform(0, min(_MAX_BACKOFF_SECONDS, self._backoff_base * 2**attempt))
+            )
+            logger.warning(
+                "arxiv retry in %.1fs (attempt %s/%s): %s",
+                delay,
+                attempt + 1,
+                self._max_retries,
+                url,
+            )
+            await self._limiter.penalize(delay)
+            await asyncio.sleep(delay)
+        raise ArxivRateLimitedError(
+            f"arXiv unavailable after {self._max_retries} attempts"
+            f" ({type(last_exc).__name__}): {url}"
+        ) from last_exc
 
     async def _query(self, params: dict[str, Any]) -> list[dict[str, Any]]:
         key = cache_key("arxiv", "query", params)
         if (cached := await self._cache.get(key)) is not None:
             return cached
-        await self._limiter.acquire()
-        resp = await self._client.get(API_URL, params=params)
-        resp.raise_for_status()
+        resp = await self._request(API_URL, params=params)
         root = ET.fromstring(resp.text)
         entries = [_parse_entry(e) for e in root.findall("atom:entry", _NS)]
         await self._cache.set(key, entries)
@@ -243,14 +346,18 @@ class ArxivClient:
         只返回 announce_type ∈ {new, cross} 的条目（replace/replace-cross 是旧论文更新，
         已在解析时剔除）；字段与 ``search`` 返回的 entry 对齐，便于复用入库逻辑。
         网络/解析失败一律记 warning 并返回 []（不能让整步崩），且不写缓存以便下次重试。
+        限流已在 :meth:`_request` 里重试过，走到这里的失败是真失败。
+
+        .. warning::
+           返回 [] 把「限流」和「今天确实没有新论文」压成了同一个结果，调用方无法区分。
+           库同步改为消费每日池之后，这个静默失败会放大成「全实验室当天颗粒无收」——
+           待办：改成带状态的返回值，见方案 A3。
         """
         key = cache_key("arxiv", "rss_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
             return cached
         try:
-            await self._limiter.acquire()
-            resp = await self._client.get(RSS_URL_TEMPLATE.format(category=category))
-            resp.raise_for_status()
+            resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
             entries = _parse_rss(resp.text)
         except Exception:  # noqa: BLE001 — 新鲜源尽力而为；CancelledError 是 BaseException 不在此
             logger.warning("arxiv RSS fetch/parse failed for %s", category, exc_info=True)
@@ -267,9 +374,7 @@ class ArxivClient:
 
     async def download_pdf(self, arxiv_id: str) -> bytes:
         """下载 PDF 原始字节（不缓存，交由调用方落盘）。"""
-        await self._limiter.acquire()
-        resp = await self._client.get(pdf_url(arxiv_id))
-        resp.raise_for_status()
+        resp = await self._request(pdf_url(arxiv_id))
         return resp.content
 
     async def aclose(self) -> None:

--- a/src/backend/app/services/literature/cache.py
+++ b/src/backend/app/services/literature/cache.py
@@ -105,3 +105,15 @@ class MinIntervalLimiter:
             if wait > 0:
                 await asyncio.sleep(wait)
             self._last = time.monotonic()
+
+    async def penalize(self, seconds: float) -> None:
+        """被限流后把「上次请求时刻」往后推，让**共享这个限流器的所有协程**一起等。
+
+        只让撞上 429 的那个协程 sleep 是不够的：限流器是整个客户端共享的，别的协程
+        照样会在 3 秒后继续打过去，等于没退避。推 ``_last`` 才能把惩罚摊到所有人身上。
+        interval<=0（测试）时是 no-op，保持限流器整体关闭的语义。
+        """
+        if self._interval <= 0 or seconds <= 0:
+            return
+        async with self._lock:
+            self._last = max(self._last, time.monotonic() + seconds)

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -2,10 +2,17 @@
 
 import fakeredis.aioredis
 import httpx
+import pytest
 import pytest_asyncio
 import respx
 
-from app.services.literature.arxiv import ArxivClient, build_search_query, normalize_arxiv_id
+from app.services.literature.arxiv import (
+    ArxivClient,
+    ArxivRateLimitedError,
+    build_search_query,
+    normalize_arxiv_id,
+)
+from app.services.literature.cache import MinIntervalLimiter
 from app.services.literature.openalex import OpenAlexClient
 from app.services.literature.semantic_scholar import SemanticScholarClient
 
@@ -163,10 +170,124 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
 
 @respx.mock
 async def test_arxiv_fetch_new_network_error_returns_empty(cache_redis):
-    respx.get(url__regex=r"https://rss\.arxiv\.org/rss/.*").mock(return_value=httpx.Response(503))
-    client = ArxivClient(redis=cache_redis, min_interval=0)
+    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/.*").mock(
+        return_value=httpx.Response(503)
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0, max_retries=2)
     assert await client.fetch_new("cs.CL") == []  # 失败容错，不抛
+    assert route.call_count == 2  # 503 会重试，耗尽后才吞成 []
     await client.aclose()
+
+
+# ---- 限流重试（arXiv 429/403）----
+
+
+@respx.mock
+async def test_arxiv_retries_on_429_then_succeeds(cache_redis):
+    """429 带 Retry-After（整数秒）→ 退避后重试 → 拿到正常结果。"""
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, text=ARXIV_FEED),
+        ]
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    results = await client.search(categories=["cs.LG"], limit=10)
+    assert len(results) == 2
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_arxiv_retry_after_accepts_http_date(cache_redis):
+    """Retry-After 也可能是 HTTP-date；过去的时间点等价于「立刻可重试」。"""
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}),
+            httpx.Response(200, text=ARXIV_FEED),
+        ]
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    assert len(await client.search(categories=["cs.LG"], limit=10)) == 2
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_arxiv_403_is_retried(cache_redis):
+    """arXiv 对它认为过量的客户端历史上返 403 而非 429——当成永久失败会白丢整批论文。"""
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        side_effect=[httpx.Response(403), httpx.Response(200, text=ARXIV_FEED)]
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    assert len(await client.search(categories=["cs.LG"], limit=10)) == 2
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_arxiv_raises_after_exhausting_retries(cache_redis):
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        return_value=httpx.Response(429)
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0, max_retries=3)
+    with pytest.raises(ArxivRateLimitedError):
+        await client.search(categories=["cs.LG"], limit=10)
+    assert route.call_count == 3
+    await client.aclose()
+
+
+@respx.mock
+async def test_arxiv_client_error_is_not_retried(cache_redis):
+    """400（检索式写错）要立刻失败，不能烧四次退避去撞同一堵墙。"""
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        return_value=httpx.Response(400)
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.search(categories=["cs.LG"], limit=10)
+    assert route.call_count == 1
+    await client.aclose()
+
+
+@respx.mock
+async def test_arxiv_retries_on_read_timeout(cache_redis):
+    """生产上见过 ReadTimeout 让整个建库任务停在第一步——超时同样要重试。"""
+    route = respx.get(url__regex=r"https://export\.arxiv\.org/api/query.*").mock(
+        side_effect=[httpx.ReadTimeout("timed out"), httpx.Response(200, text=ARXIV_FEED)]
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    assert len(await client.search(categories=["cs.LG"], limit=10)) == 2
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_download_pdf_retries_on_429(cache_redis):
+    """PDF 下载是 arXiv 流量的大头，必须同样享受重试。"""
+    route = respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, content=b"%PDF-1.7 stub"),
+        ]
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0)
+    assert await client.download_pdf("2406.00001") == b"%PDF-1.7 stub"
+    assert route.call_count == 2
+    await client.aclose()
+
+
+async def test_min_interval_limiter_penalize():
+    """penalize 把惩罚摊给共享限流器的所有协程；interval=0 时整体关闭，是 no-op。"""
+    limiter = MinIntervalLimiter(0.05)
+    await limiter.acquire()
+    before = limiter._last
+    await limiter.penalize(5.0)
+    assert limiter._last >= before + 4.9
+
+    off = MinIntervalLimiter(0)
+    await off.penalize(5.0)
+    assert off._last == 0.0
 
 
 @respx.mock


### PR DESCRIPTION
## Evidence from production

Four runs are sitting in `paused_error` on zju-54 right now. All four died on their **first step**, inside the arXiv client:

| kind | step | error |
|---|---|---|
| `wiki_ingest` ×3 | `wiki.search_candidates` | `HTTPStatusError: Client error '429 Unknown Error' for url 'https://export.arxiv.org/api/query?...'` |
| `wiki_bootstrap` ×1 | `wiki.search_candidates` | `ReadTimeout` |

The client had **no retry, no backoff, and no rate-limit handling at all**. One 429 ended the run. And since `paused_error` is not in `TERMINAL_STATUSES`, the daily cron then treats that library as "already running" and skips it indefinitely — so a single transient 429 takes a library dark until a human notices.

This also settles a design question empirically: **arXiv returns 429**, not 403. The retry predicate is written against what production actually sends, not a guess.

## What changed

Every arXiv call now goes through one `_request` seam, so `search`, `fetch_by_ids`, `fetch_new` and `download_pdf` all benefit.

**Retried:** 429, 403, 5xx, plus timeouts and transport errors.
**Not retried:** other 4xx. A malformed search query should fail immediately rather than burn four backoffs against the same wall.

403 is included because arXiv has historically used it for clients it deems abusive; treating that as permanent would silently discard a whole batch.

**Backoff** honours `Retry-After` in both integer-seconds and HTTP-date forms, otherwise exponential with **full jitter** — api and worker retry independently, so full jitter decorrelates them best. Capped at 120s so a hostile header cannot stall a voyage.

**Backing off penalizes the shared limiter, not just the calling coroutine.** `MinIntervalLimiter` gains `penalize(seconds)`, which pushes its `_last` forward. The limiter lives on a module-level singleton client; without this, other coroutines keep firing on the normal 3s interval and the backoff accomplishes nothing. No-op when `interval <= 0`, so the many `min_interval=0` test fixtures are unaffected.

Also sets a contactable `User-Agent` — arXiv throttles anonymous clients harder.

## This does not fix rate limiting on its own

Two things remain, both out of scope here:

1. **The limiter is per process.** `api` and `worker` are separate containers, each with its own `MinIntervalLimiter(3.0)`, so the real aggregate rate can be double the intended one. A Redis-backed shared limiter is the next step and is plausibly the larger win.
2. **`fetch_new()` still swallows every exception and returns `[]`**, so a rate-limited daily feed sync produces a silently empty feed. Harmless today; becomes serious once library sync consumes the feed as its only source. Flagged in the docstring, fixed separately.

## Tests

Eight new tests in `test_literature.py`: retry-then-succeed on 429; `Retry-After` as integer seconds and as HTTP-date; 403 retried; 400 **not** retried; `ReadTimeout` retried; retries exhausted → `ArxivRateLimitedError`; `download_pdf` retried; `penalize` moves the limiter and is a no-op at `interval=0`.

The existing 503 test now also asserts the retry count, so the swallow-to-`[]` contract is pinned rather than accidental.

45 passed across `test_literature`, `test_wiki_ingest`, `test_daily_feed`; `ruff check app` clean. The full suite (810 passed) was run on this branch before the timeout-retry commit; the delta since is the network-error branch plus its test.

## Follow-up worth doing by hand

The four `paused_error` runs on production stay stuck until someone resumes or cancels them — this PR prevents new ones, it does not clear the existing ones.