### PR TITLE
fix(frontend): wrap long error text instead of letting it break the card

### DIFF
--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -624,8 +624,10 @@ function SetupTab({ exp }: { exp: ExperimentDetail }) {
                         {fmtTime(s.started_at)} · {s.finished_at ? `${tr('耗时', 'took')} ${fmtDuration(s.started_at, s.finished_at)}` : tr('进行中', 'in progress')}
                       </div>
                     )}
+                    {/* 同任务详情页：reason 可能是一整条没有断点的长 URL，
+                        默认 overflow-wrap 下会溢出盒子而不是换行 */}
                     {s.verdict && !s.verdict.passed && s.verdict.reason && (
-                      <div style={{ marginTop: 7, fontSize: 12, color: 'var(--danger-tx)', lineHeight: 1.5 }}>
+                      <div style={{ marginTop: 7, fontSize: 12, color: 'var(--danger-tx)', lineHeight: 1.5, overflowWrap: 'anywhere' }}>
                         {tr('自动校验：', 'Auto check: ')}{s.verdict.reason}
                       </div>
                     )}

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -1028,9 +1028,20 @@ function StepCard({ step, planEvents }: { step: VoyageStepRead; planEvents: Voya
           </span>
         )}
       </div>
-      {/* 判定理由：通过与否都展示（通过时用弱色） */}
+      {/* 判定理由：通过与否都展示（通过时用弱色）。
+          reason 是后端原样透传的错误文本，可能整段是一条没有断点的长 URL
+          （如 arXiv 检索失败时的 query 串）。overflow-wrap 默认 normal 时这种
+          token 会直接溢出盒子而不是换行，把卡片撑破，故显式允许任意位置断行。 */}
       {step.verdict?.reason && (
-        <div style={{ marginTop: 8, fontSize: 12, color: step.verdict.passed ? 'var(--text-3)' : 'var(--danger-tx)', lineHeight: 1.5 }}>
+        <div
+          style={{
+            marginTop: 8,
+            fontSize: 12,
+            color: step.verdict.passed ? 'var(--text-3)' : 'var(--danger-tx)',
+            lineHeight: 1.5,
+            overflowWrap: 'anywhere',
+          }}
+        >
           {tr('判定理由：', 'Verdict: ')}
           {step.verdict.reason}
         </div>
@@ -1048,7 +1059,8 @@ function StepCard({ step, planEvents }: { step: VoyageStepRead; planEvents: Voya
           style={{ marginTop: 10, padding: '8px 12px', background: 'var(--accent-soft)', color: 'var(--accent-text)', borderRadius: 8, fontSize: 12.5, lineHeight: 1.5, alignItems: 'flex-start' }}
         >
           <Icon name="compass" size={13} style={{ flexShrink: 0, marginTop: 2 }} />
-          <span style={{ minWidth: 0 }}>{signalText}</span>
+          {/* 同上：signalText 会拼进 observation.error 的原文 */}
+          <span style={{ minWidth: 0, overflowWrap: 'anywhere' }}>{signalText}</span>
         </div>
       )}
       {friendly && <WikiStepSummary friendly={friendly} />}


### PR DESCRIPTION
Closes #192

## Cause

When the arXiv incremental sync fails, the backend passes the whole request URL through into the step's verdict reason — a ~900 character query string whose only separators are `+`, `%` and `&`.

The reason is rendered in a plain `<div>` with no wrap handling. Under the default `overflow-wrap: normal`, a run that long has no break opportunity, so it **overflows its box rather than wrapping**. That is why the screenshot shows most lines stopping at the card edge while a few run straight past it — the box stays card-width, the text does not.

Not a viewport-width problem: the report is from a 1704×1270 desktop, and it reproduces at any width.

## Fix

`overflow-wrap: anywhere` on the three places that render backend-supplied error text:

- `VoyageDetailPage` — the verdict reason (the one in the report)
- `VoyageDetailPage` — the step signal box, which splices in `observation.error`
- `ExperimentDetailPage` — the auto-check reason, same `verdict.reason` field

Neighbouring blocks in these files already set `word-break: break-word`; these three were simply missed. `anywhere` rather than `break-word` because it also constrains intrinsic min-content width, which matters for the signal box — it is a flex item, where `break-word` alone would still let the long token widen the row.

## Verification

`tsc --noEmit` and `vite build` pass.

The Chrome extension was disconnected, so this was measured headless against the exact URL from the report, in a 600px container:

| | text right edge | overflows |
|---|---|---|
| before | 1186px | yes — 576px past the container |
| after | 608px | no |

Not verified in the running app: reproducing it live needs a task that actually hits the arXiv 429. The CSS mechanism is confirmed above, and the change is a single declaration on three text blocks with no layout side effects — but a look at a real failed step is worth doing before release if one is available.
