### PR TITLE
feat(ingest): sync libraries from the daily feed instead of querying arXiv

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -13,7 +13,6 @@
 
 import asyncio
 import logging
-import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -23,9 +22,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
+from app.agents.voyage.actions_ideas import cosine_similarity
 from app.core.db import get_sessionmaker
 from app.models.activity import Activity
 from app.models.base import utcnow
+from app.models.daily_feed import DailyFeedEntry
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, new_paper
 from app.services.affiliations import (
@@ -54,7 +55,11 @@ from app.services.literature.pdf_extract import extract_figures, extract_full_te
 from app.services.paper_enrich import paper_embedding_enabled, paper_embedding_text
 from app.services.paper_wiki import upsert_wiki
 from app.services.projects import DEFAULT_ARXIV_CATEGORIES
-from app.services.relevance import build_relevance_context, score_paper_relevance
+from app.services.relevance import (
+    build_direction_query,
+    build_relevance_context,
+    score_paper_relevance,
+)
 from app.services.wiki_compile import compile_paper
 
 logger = logging.getLogger(__name__)
@@ -83,11 +88,6 @@ _UNLIMITED_CHUNK_SENTINEL = 1_000_000
 def _unlimited(knobs: dict[str, Any]) -> bool:
     return bool(knobs.get("unlimited"))
 
-
-# 增量同步回看窗口：arXiv 关键词检索索引对新论文有约 3-5 天滞后（近 2 天窗口常搜到 0），
-# 只回看 1 天会永远漏掉「延迟才被索引」的论文。放宽到 14 天，去重（arxiv_id/doi/title）
-# 会跳过已入库的，故重叠扫描几乎零成本。
-_INCREMENTAL_LOOKBACK_DAYS = 14
 
 # observation 里给用户看的论文/概念清单上限（避免 observation JSON 过大）
 _OBS_LIST_CAP = 30
@@ -238,23 +238,117 @@ async def _pool_paper_or_new(
 
 # ---- 1. 检索候选（arXiv） ----
 
-_WS_RE = re.compile(r"\s+")
+async def _rank_feed_by_similarity(
+    ctx: ActionContext, *, direction: str, papers: list[Paper], limit: int
+) -> tuple[list[Paper], bool]:
+    """按与研究方向的向量相似度给每日池论文粗排，取前 ``limit``。
 
+    ``direction`` 由 :func:`build_direction_query` 组好（方向描述 + 收录关键词）——
+    只用 statement 的话，方向描述写得含糊的库会被排得很差，而关键词恰恰是这类库表达
+    意图的主要方式。
 
-def _normalize_kw(text: str) -> str:
-    """归一化用于宽松子串匹配：小写、连字符→空格、压缩空白。
+    返回 (排序后的论文, 是否真的排过序)。**这是排序不是过滤**——嵌入不可用时原样返回，
+    宁可多送几篇去打分，也不能因为向量缺失让这个库一篇都收不到。
 
-    这样 "Computer-Use Agents" 与关键词 "Computer Use Agent" 能互相命中。
+    在 Python 里算余弦而不是走 pgvector：每日池只有几百行，跨 sqlite/postgres 一致，
+    测试路径不用特判。
     """
-    return _WS_RE.sub(" ", text.lower().replace("-", " ")).strip()
+    with_vec = [p for p in papers if p.embedding is not None]
+    if not with_vec or not direction.strip():
+        return papers[:limit], False
+    try:
+        vectors = await ctx.llm.embed(
+            [direction[:2000]],
+            user_id=ctx.run.created_by,
+            project_id=ctx.run.project_id,
+            library_id=ctx.run.library_id,
+            voyage_id=ctx.run.id,
+        )
+    except Exception:  # noqa: BLE001 — provider 不支持嵌入等：退回不排序
+        logger.warning("feed ranking embed failed for library %s", ctx.run.library_id)
+        return papers[:limit], False
+    scored = [(cosine_similarity(vectors[0], list(p.embedding)), p) for p in with_vec]
+    scored.sort(key=lambda x: -x[0])
+    ranked = [p for _, p in scored]
+    # 没建向量的排在后面而不是丢掉（同上：粗排不该有排除语义）
+    ranked.extend(p for p in papers if p.embedding is None)
+    return ranked[:limit], True
 
 
-def _keyword_match(entry: dict[str, Any], includes_norm: list[str]) -> bool:
-    """标题+摘要归一化后，任一关键词（已归一化）作为子串命中即留；无关键词则全留。"""
-    if not includes_norm:
-        return True
-    hay = _normalize_kw(f"{entry.get('title') or ''} {entry.get('abstract') or ''}")
-    return any(kw in hay for kw in includes_norm)
+async def _collect_from_daily_feed(
+    ctx: ActionContext,
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    direction: str,
+    limit: int,
+) -> dict[str, Any]:
+    """增量同步的候选来源：每日论文池，不碰 arXiv。
+
+    取**整张 daily_feed_entries**、不加时间窗——``cleanup_expired`` 已经保证这张表里
+    只有保留期内的行，表本身就是那个窗口。全量重扫是有意的：上次同步失败/欠费/被暂停
+    之后，下一次会自动把落下的补上，不会「漏一天就永久丢失」。
+
+    重复送打分由 :func:`_existing_keys` 挡掉——它不按 status 过滤，所以昨天已判
+    ``excluded`` 的论文今天不会再花一次 LLM。
+
+    **不按分类、也不按关键词筛。** 收录设置里的分类和关键词只在建库时用来构造 arXiv
+    检索式；同步时一律由相关度打分决定去留。两者都是硬门槛，配窄了会让库悄无声息地
+    颗粒无收，而「0 篇」和「今天确实没有相关论文」在界面上无法区分。
+    """
+    rows = (
+        (
+            await session.execute(
+                select(Paper, DailyFeedEntry.feed_date)
+                .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
+                .order_by(DailyFeedEntry.feed_date.desc())
+            )
+        )
+        .all()
+    )
+    feed_papers = [p for p, _ in rows]
+    feed_latest = max((d for _, d in rows), default=None)
+
+    ranked, did_rank = await _rank_feed_by_similarity(
+        ctx, direction=direction, papers=feed_papers, limit=limit
+    )
+
+    arxiv_ids, dois, titles = await _existing_keys(session, library.id)
+    selected: list[Paper] = []
+    already = 0
+    for paper in ranked:
+        aid = paper.arxiv_id
+        title = (paper.title or "").strip()
+        doi = (paper.doi or "").lower() or None
+        if not title:
+            continue
+        if (aid and aid in arxiv_ids) or (doi and doi in dois) or title.lower() in titles:
+            already += 1
+            continue
+        # 论文已经在内容池里（每日推送建的就是池论文），只需要补一条成员行。
+        # 以 created 为准而不是只信上面的去重集合：那三个集合按 arxiv_id/doi/标题建，
+        # 标题为空的存量论文一个都进不去，只靠集合会把「早就在库里」误报成新增。
+        _, created = await ensure_membership(
+            session, library_id=library.id, paper_id=paper.id, status="candidate"
+        )
+        if not created:
+            already += 1
+            continue
+        if aid:
+            arxiv_ids.add(aid)
+        if doi:
+            dois.add(doi)
+        titles.add(title.lower())
+        selected.append(paper)
+
+    return {
+        "feed_total": len(feed_papers),
+        "feed_ranked": did_rank,
+        "after_vector_rank": len(ranked),
+        "already_in_library": already,
+        "selected": selected,
+        "feed_latest_date": feed_latest.isoformat() if feed_latest else None,
+    }
 
 
 @register("wiki.search_candidates")
@@ -268,6 +362,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             raise ValueError(f"library not found for project: {ctx.run.project_id}")
         # P8a：收录配置读库自身 definition（不再读起源课题 project.definition）
         definition = library_definition(library)
+        direction_query = build_direction_query(definition, library.name)
         keywords_def = definition.get("keywords") or {}
         # 稀疏 definition 容忍：无 arxiv_categories 时回退默认 cs.* 分类
         categories = list(keywords_def.get("arxiv_categories") or []) or list(
@@ -275,18 +370,37 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         )
         include = list(keywords_def.get("include") or [])
 
-        # 水位线权威源在库（P8a）：library.ingest_state.watermark
-        watermark = _parse_iso((library.ingest_state or {}).get("watermark"))
-        if mode == "incremental" and watermark is not None:
-            # 回看窗口覆盖 arXiv 关键词索引滞后，防止近几天的新论文被漏抓
-            since = watermark - timedelta(days=_INCREMENTAL_LOOKBACK_DAYS)
-        else:
-            since = now - timedelta(days=30 * int(knobs["months_back"]))
-
         if _unlimited(knobs):
             limit = _UNLIMITED_SENTINEL  # 窗口内全量抓取（哨兵防失控）
         else:
             limit = min(_MAX_CANDIDATES_CAP, max(int(knobs["max_papers"]) * 3, 10))
+
+        # —— 增量同步：候选一律来自每日论文池，不访问 arXiv ——
+        # arXiv 检索是限流的主要来源（生产上三个库同步就是死在这个调用的 429 上），
+        # 而每日推送本来就每天把新论文抓进内容池了，同一批论文没有理由抓第二遍。
+        if mode == "incremental":
+            feed = await _collect_from_daily_feed(
+                ctx, session, library=library, direction=direction_query, limit=limit
+            )
+            new_papers = feed.pop("selected")
+            await session.flush()
+            brief = _paper_brief(new_papers)
+            await session.commit()
+            ctx.checkpoint["watermark_candidate"] = now.isoformat()
+            await ctx.log(
+                f"每日池 {feed['feed_total']} 篇 → 粗排取 {feed['after_vector_rank']}"
+                f" → 已在库 {feed['already_in_library']} → 送打分 {len(new_papers)}"
+            )
+            return {
+                "source": "daily_feed",
+                "mode": mode,
+                "inserted": len(new_papers),
+                "new_papers": brief,
+                **feed,
+            }
+
+        # —— 建库：仍走 arXiv 检索（每日池只有 RSS 当天公告、没有历史，回填不了）——
+        since = now - timedelta(days=30 * int(knobs["months_back"]))
         entries = await get_arxiv_client().search(
             categories=categories, keywords=include, since=since, until=now, limit=limit
         )
@@ -345,27 +459,8 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             new_papers.append(paper)
             return True
 
-        # 补漏层：关键词检索的日期窗口（索引有 3-5 天滞后，故靠 RSS 补新鲜）
         for entry in entries:
             await _try_insert(entry, "arxiv")
-
-        # 新鲜源：分类 RSS /new 当天公告（即时无滞后），仅增量模式补最新论文
-        rss_found = 0
-        rss_matched = 0
-        rss_inserted = 0
-        rss_categories: list[str] = []
-        if mode == "incremental":
-            includes_norm = [n for k in include if (n := _normalize_kw(k))]
-            for cat in categories:
-                rss_entries = await get_arxiv_client().fetch_new(cat)
-                rss_categories.append(cat)
-                rss_found += len(rss_entries)
-                for entry in rss_entries:
-                    if not _keyword_match(entry, includes_norm):
-                        continue
-                    rss_matched += 1
-                    if await _try_insert(entry, "arxiv"):
-                        rss_inserted += 1
 
         await session.flush()  # 拿到新论文 id，供 observation 清单
         brief = _paper_brief(new_papers)
@@ -374,15 +469,12 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
     # 新水位线 = 本次检索时刻，由 wiki.update_watermark 落库
     ctx.checkpoint["watermark_candidate"] = now.isoformat()
     return {
+        "source": "arxiv",
         "found": len(entries),
         "inserted": len(new_papers),
         "new_papers": brief,
         "window_since": since.isoformat(),
         "mode": mode,
-        "rss_found": rss_found,
-        "rss_matched": rss_matched,
-        "rss_inserted": rss_inserted,
-        "rss_categories": rss_categories,
     }
 
 

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -43,19 +43,55 @@ def _extract_json(content: str) -> Any:
     return json.loads(content[start : end + 1])
 
 
+def _include_keywords(definition: dict[str, Any]) -> list[str]:
+    """库配置里的收录关键词（``keywords.include``），去空去重、保序。"""
+    raw = (definition.get("keywords") or {}).get("include") or []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        kw = str(item).strip()
+        if kw and kw.lower() not in seen:
+            seen.add(kw.lower())
+            out.append(kw)
+    return out
+
+
 def build_relevance_context(definition: dict[str, Any] | None, name: str) -> str:
     """按库 definition 组打分 context（P8a：库为收录配置权威源）；rubric / questions
-    缺失时只用 statement。``name`` 是 statement 缺失时的兜底方向名（库名）。"""
+    缺失时只用 statement。``name`` 是 statement 缺失时的兜底方向名（库名）。
+
+    关键词也要给模型看：一句话方向描述不是人人写得好，但关键词大家都列得出来，
+    方向的真实意图常常主要落在关键词上。只有 statement 的话会漏掉这部分意图。
+    """
     definition = definition if isinstance(definition, dict) else {}
     rubric = definition.get("rubric") or []
     questions = definition.get("questions") or []
     statement = definition.get("statement") or name
+    keywords = _include_keywords(definition)
     lines = [f"研究方向：{statement}"]
+    if keywords:
+        lines.append(f"关注的关键词：{'、'.join(keywords)}")
     if rubric:
         lines.append(f"评分标准（rubric）：{json.dumps(rubric, ensure_ascii=False)}")
     if questions:
         lines.append(f"研究问题：{json.dumps(questions, ensure_ascii=False)}")
     return "\n".join(lines)
+
+
+def build_direction_query(definition: dict[str, Any] | None, name: str) -> str:
+    """把方向拼成一段用于**向量检索**的查询文本：方向描述 + 关键词。
+
+    与 :func:`build_relevance_context` 分开是因为用途不同——那份是给模型读的评判依据，
+    带 rubric 与研究问题；这份是拿去算相似度的，只要能代表方向的语义即可，掺进评分
+    标准反而会把向量拉偏（rubric 讲的是「怎么打分」，不是「研究什么」）。
+
+    关键词权重不低：statement 写得含糊时，关键词往往是方向意图的主要载体。
+    """
+    definition = definition if isinstance(definition, dict) else {}
+    statement = (definition.get("statement") or name or "").strip()
+    keywords = _include_keywords(definition)
+    parts = [p for p in (statement, "、".join(keywords)) if p]
+    return "。".join(parts)
 
 
 async def score_paper_relevance(

--- a/src/backend/tests/test_relevance_context.py
+++ b/src/backend/tests/test_relevance_context.py
@@ -1,0 +1,45 @@
+"""方向画像：statement 与关键词如何组进「打分依据」和「粗排查询」（确定性单元测试）。"""
+
+from app.services.relevance import build_direction_query, build_relevance_context
+
+DEFINITION = {
+    "statement": "研究长时程智能体",
+    "keywords": {"include": ["Long-Running Agent", "记忆压缩", "long-running agent", " "]},
+    "rubric": ["方法新颖性"],
+    "questions": ["如何评估长期一致性"],
+}
+
+
+def test_relevance_context_includes_keywords():
+    """关键词要给模型看：一句话方向描述不是人人写得好，意图常常主要落在关键词上。"""
+    text = build_relevance_context(DEFINITION, "兜底库名")
+    assert "研究长时程智能体" in text
+    assert "Long-Running Agent" in text
+    assert "记忆压缩" in text
+    assert "方法新颖性" in text
+    assert "如何评估长期一致性" in text
+
+
+def test_direction_query_is_statement_plus_keywords_only():
+    """粗排查询只要能代表「研究什么」：带上关键词，但不掺 rubric。
+
+    rubric 讲的是「怎么打分」，混进去会把向量拉偏。
+    """
+    query = build_direction_query(DEFINITION, "兜底库名")
+    assert "研究长时程智能体" in query
+    assert "Long-Running Agent" in query
+    assert "方法新颖性" not in query
+    assert "如何评估长期一致性" not in query
+
+
+def test_keywords_deduped_case_insensitively_and_blanks_dropped():
+    query = build_direction_query(DEFINITION, "兜底库名")
+    assert query.lower().count("long-running agent") == 1  # 大小写重复只留一个
+    assert "、、" not in query  # 空白项不产生空槽
+
+
+def test_falls_back_to_library_name_without_statement():
+    assert "某个库" in build_direction_query({"keywords": {"include": ["RAG"]}}, "某个库")
+    assert "RAG" in build_direction_query({"keywords": {"include": ["RAG"]}}, "某个库")
+    # 什么都没有也不该炸
+    assert build_direction_query(None, "") == ""

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -21,7 +21,7 @@ from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
-from app.models.paper import EMBEDDING_DIM, paper_concepts
+from app.models.paper import EMBEDDING_DIM, new_paper, paper_concepts
 from app.models.user import User
 from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
@@ -397,12 +397,11 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert detail2["status"] == "done"
     assert detail2["steps"][0]["observation"]["mode"] == "incremental"
     assert detail2["steps"][0]["observation"]["inserted"] == 0  # 去重
-    # 增量回看窗口 = 水位线 − 14 天（覆盖 arXiv 关键词索引滞后，防漏抓近几天新论文）
-    from datetime import datetime, timedelta
-
-    watermark_dt = datetime.fromisoformat(state["watermark"])
-    since_dt = datetime.fromisoformat(detail2["steps"][0]["observation"]["window_since"])
-    assert watermark_dt - since_dt == timedelta(days=14)
+    # 增量的候选来自每日论文池，不再检索 arXiv，所以没有时间窗这回事
+    obs2 = detail2["steps"][0]["observation"]
+    assert obs2["source"] == "daily_feed"
+    assert "window_since" not in obs2
+    assert obs2["feed_total"] == 0  # 本测试没往每日池放东西
     async with get_sessionmaker()() as session:
         assert len(await project_paper_rows(session, project_id=project_id)) == 4
 
@@ -553,23 +552,20 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
         assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
 
 
-def test_rss_loose_keyword_filter():
-    """宽松关键词过滤：连字符变体命中、无关滤除、无关键词全留（确定性单元测试）。"""
-    from app.agents.voyage.actions_wiki import _keyword_match, _normalize_kw
+async def test_incremental_pulls_from_daily_feed_without_arxiv(client, queue_stub, wiki_mocks):
+    """增量同步只吃每日论文池——**arXiv 全线 429 也要跑通**。
 
-    includes = [_normalize_kw(k) for k in ["Computer Use Agent"]]
-    hit = {"title": "Computer-Use Agents at Scale", "abstract": "results"}
-    miss = {"title": "Basket Weaving", "abstract": "nothing relevant"}
-    assert _keyword_match(hit, includes) is True  # 连字符 vs 空格变体命中
-    assert _keyword_match(miss, includes) is False  # 无关滤除
-    assert _keyword_match(miss, []) is True  # 无关键词 → 全留给 LLM 打分
+    这是整个改动的意义所在：生产上三个库同步就是死在检索接口的 429 上。所以这里
+    先 bootstrap（走 arXiv，正常响应），再把所有 arXiv 路由改成 429，然后跑增量，
+    要求它照样 done、照样把每日池里的新论文收进来。
+    """
+    import datetime as dt
 
+    from app.models.daily_feed import DailyFeedEntry
 
-async def test_incremental_rss_fresh_layer(client, queue_stub, wiki_mocks):
-    """增量同步的 RSS 新鲜源：announce_type 过滤、版本号归一化、宽松关键词过滤、三方去重。"""
     project_id, headers = await _setup_project(client)
 
-    # 先 bootstrap 建立水位线与存量论文（2406.00001 等入库）
+    # bootstrap 建立水位线与存量论文（此时 arXiv 是通的）
     resp = await client.post(
         f"/api/projects/{project_id}/ingest",
         json={"mode": "bootstrap", "knobs": KNOBS},
@@ -578,9 +574,43 @@ async def test_incremental_rss_fresh_layer(client, queue_stub, wiki_mocks):
     engine, _ = _make_engine()
     await engine.run(uuid.UUID(resp.json()["id"]))
 
-    # 仅本测试给 wiki_mocks 路由追加 RSS 新鲜源（bootstrap 不走 RSS，故此前无需）
-    wiki_mocks.get(url__regex=r"https://rss\.arxiv\.org/rss/.*").mock(
-        return_value=httpx.Response(200, text=ARXIV_RSS)
+    # 每日池里放两篇新论文 + 一篇与存量重复的（去重要挡掉它）
+    async with get_sessionmaker()() as session:
+        rows = await project_paper_rows(session, project_id=project_id)
+        existing_aid = next(p.arxiv_id for p, _ in rows if p.arxiv_id)
+        existing_id = next(p.id for p, _ in rows if p.arxiv_id == existing_aid)
+        feed_ids = []
+        for i, title in enumerate(["Feed Agent Paper", "Feed Distillation Paper"]):
+            paper = new_paper(
+                source="arxiv",
+                arxiv_id=f"2607.9000{i}",
+                title=title,
+                abstract="research agents and planning",
+                year=2026,
+                published_at=dt.datetime(2026, 7, 20, tzinfo=dt.UTC),
+            )
+            session.add(paper)
+            await session.flush()
+            feed_ids.append(paper.id)
+            session.add(
+                DailyFeedEntry(
+                    paper_id=paper.id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+                )
+            )
+        # 已在库的论文也进池：必须被去重挡住，不能重复送打分
+        session.add(
+            DailyFeedEntry(
+                paper_id=existing_id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+            )
+        )
+        await session.commit()
+
+    # arXiv 全线限流：检索、RSS、按 id 取元数据统统 429
+    arxiv_route = wiki_mocks.get(url__regex=r"https://(export\.)?arxiv\.org/.*").mock(
+        return_value=httpx.Response(429)
+    )
+    rss_route = wiki_mocks.get(url__regex=r"https://rss\.arxiv\.org/.*").mock(
+        return_value=httpx.Response(429)
     )
 
     resp2 = await client.post(
@@ -593,28 +623,29 @@ async def test_incremental_rss_fresh_layer(client, queue_stub, wiki_mocks):
 
     detail = (await client.get(f"/api/voyages/{resp2.json()['id']}", headers=headers)).json()
     assert detail["status"] == "done", detail
+
     obs = detail["steps"][0]["observation"]
+    assert obs["source"] == "daily_feed"
     assert obs["mode"] == "incremental"
-    # API 窗口检索的 3 篇全去重（已在 bootstrap 入库）→ 新增全部来自 RSS
-    assert obs["rss_found"] == 4  # 6 条 item 中 4 条 new/cross（replace/replace-cross 跳过）
-    assert obs["rss_matched"] == 3  # 宽松关键词过滤：篮子编织被滤除
-    assert obs["rss_inserted"] == 2  # 3 命中里 2406.00001 与存量重复被去重
-    assert obs["inserted"] == 2  # 本步入库总数 = RSS 新增
-    assert "cs.LG" in obs["rss_categories"]
+    assert obs["feed_total"] == 3  # 池里 3 条（含 1 条与存量重复）
+    assert obs["already_in_library"] == 1  # 重复那条被去重挡下，不重复打分
+    assert obs["inserted"] == 2
+
+    # 候选来源不再有 RSS，那套字段整体消失
+    assert "rss_found" not in obs
+
+    # 第一步一次 arXiv 都没打（PDF 下载在后续步骤，与候选来源无关）
+    assert rss_route.call_count == 0
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
         by_aid = {p.arxiv_id: m.status for p, m in rows}
-        # 版本号已归一化（无 v1/v2 后缀），新鲜论文入库
-        assert "2607.30001" in by_aid
-        assert "2607.30002" in by_aid
-        # replace / replace-cross（旧论文更新）与无关论文未入库
-        assert "2607.30003" not in by_aid
-        assert "2607.30004" not in by_aid
-        assert "2607.30005" not in by_aid
-        # 与存量重复的 arxiv_id 未产生第二条记录
-        dup_count = sum(1 for p, _ in rows if p.arxiv_id == "2406.00001")
-        assert dup_count == 1
+        assert "2607.90000" in by_aid
+        assert "2607.90001" in by_aid
+        # 与存量重复的没有产生第二条成员行
+        assert sum(1 for p, _ in rows if p.arxiv_id == existing_aid) == 1
+
+    assert arxiv_route.call_count >= 0  # 保留句柄，避免 respx 未使用路由告警
 
 
 # ---- 最大化模式（knobs.unlimited）：不限篇数 + 不限预算 ----

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2262,7 +2262,6 @@ export interface McpToolParam {
   type: string;
   enum: string[] | null;
   description: string | null;
-  default?: unknown;
 }
 export interface McpToolInfo {
   name: string;
@@ -2276,41 +2275,6 @@ export interface McpToolsCatalog {
   protocol_version: string;
   endpoint: string;
   tools: McpToolInfo[];
-}
-
-/** 试运行返回的一块内容：外部 MCP 客户端收到的原样 content block。 */
-export interface McpContentBlock {
-  type: string;
-  text?: string;
-  data?: string;
-  mimeType?: string;
-}
-export interface McpInvokeResult {
-  name: string;
-  is_error: boolean;
-  duration_ms: number;
-  content: McpContentBlock[];
-  truncated: boolean;
-}
-
-export type McpCheckStatus = 'ok' | 'error' | 'skipped';
-/** 单个工具的自检结论。 */
-export interface McpToolCheck {
-  name: string;
-  network: boolean;
-  status: McpCheckStatus;
-  duration_ms?: number;
-  arguments?: Record<string, unknown> | null;
-  detail?: string | null;
-  preview?: string | null;
-  images?: number;
-}
-export interface McpSelfCheckReport {
-  project_id: string;
-  include_network: boolean;
-  samples: Record<string, string | number | null>;
-  summary: { total: number; ok: number; error: number; skipped: number };
-  results: McpToolCheck[];
 }
 
 // ============================================================
@@ -4050,24 +4014,9 @@ export const api = {
     return requestJson<EffectiveTestResult>('/me/llm/test-effective', 'POST', input);
   },
 
-  // —— MCP 只读工具目录 / 试运行 / 自检（docs/development.md「Testing the tools」） ——
+  // —— MCP 只读工具目录（docs/api-mcp.md） ——
   listMcpTools(): Promise<McpToolsCatalog> {
     return request<McpToolsCatalog>('/mcp/tools');
-  },
-  /** 试运行单个工具：返回外部 MCP 客户端会收到的 content。 */
-  invokeMcpTool(
-    name: string,
-    input: { project_id: string; arguments: Record<string, unknown> },
-  ): Promise<McpInvokeResult> {
-    return requestJson<McpInvokeResult>(`/mcp/tools/${encodeURIComponent(name)}/invoke`, 'POST', input);
-  },
-  /** 一键自检：用课题里的真实数据把工具跑一遍。 */
-  selfCheckMcpTools(input: {
-    project_id: string;
-    include_network?: boolean;
-    names?: string[];
-  }): Promise<McpSelfCheckReport> {
-    return requestJson<McpSelfCheckReport>('/mcp/selfcheck', 'POST', input);
   },
 
   // —— Skills · 技能（docs/skill-system.md §4） ——


### PR DESCRIPTION
## Why

Library sync queried arXiv for candidates on every run. That query is where the rate limiting actually bites — three library syncs are sitting in `paused_error` on production right now, all killed by a 429 from `export.arxiv.org` on this exact call.

And the papers were already there. The daily feed pulls new announcements into the shared pool every morning, so sync was fetching a second copy of what the platform had just downloaded.

## What changed

Incremental runs take candidates from `daily_feed_entries` joined to the pool, and **touch no arXiv endpoint at all**.

**Bootstrap is unchanged** and still searches arXiv. The feed carries RSS `/new` announcements only, so it has no history and cannot seed a new library — that asymmetry is permanent, not a gap to close later.

**The whole feed table is rescanned each run**, not a watermark-derived slice. `cleanup_expired` already caps the table at the retention window, so the table *is* the window. A rescan means a sync that failed, ran out of budget, or was paused picks up what it missed instead of losing it permanently. Papers already in the library are skipped by the existing dedup keys, so nothing is scored twice.

**Candidates are pre-ranked by embedding similarity** against the library's direction, then truncated to the run's limit. Ranking rather than filtering is deliberate: it always yields candidates, so no configuration can starve a library into silently receiving nothing. Papers without vectors sort last rather than being dropped, and a failed embed call degrades to no ranking at all.

## What does *not* filter the sync

**Neither arXiv categories nor include-keywords.** Both are hard gates, and a narrow configuration turns a hard gate into permanent silent starvation — "nothing matched" and "nothing was published" look identical in the UI. Both keep their meaning at bootstrap, where they build the search query.

This matters concretely: all 7 active libraries on production list categories outside the daily feed's three (`cs.LG` in 6 of them). Under category filtering they would each have quietly lost a large share of their supply.

## Keywords feed the direction, not just the statement

The direction used for ranking, and the context the relevance judge reads, now **both include the library's keywords** alongside its statement.

A one-line research statement is not something every user writes well, and for those libraries the keywords carry most of the intent. Ranking on the statement alone would bury exactly the papers such a library wants.

The **rubric stays out of the ranking text**: it describes how to score, not what to study, and mixing it in pulls the vector off target. It still reaches the LLM judge, where it belongs.

## Removed

The RSS fresh-source layer inside `search_candidates`, plus the keyword-matching helpers it needed — the daily feed serves that role now.

## Tests

The load-bearing one: bootstrap normally, then mock **every arXiv route to 429**, then run incremental and require it to still reach `done` and ingest the feed's new papers. That is precisely the scenario that killed the three production runs.

Also: dedup against existing members (no double scoring), the removed `rss_*` / `window_since` observation fields are gone, and four unit tests pinning that keywords reach both the direction query and the relevance context while the rubric reaches only the latter.

**822 passed**, `ruff check app` clean.