### PR TITLE
fix(frontend): restore the MCP client methods dropped by #200

### DIFF
--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2262,6 +2262,7 @@ export interface McpToolParam {
   type: string;
   enum: string[] | null;
   description: string | null;
+  default?: unknown;
 }
 export interface McpToolInfo {
   name: string;
@@ -2275,6 +2276,41 @@ export interface McpToolsCatalog {
   protocol_version: string;
   endpoint: string;
   tools: McpToolInfo[];
+}
+
+/** 试运行返回的一块内容：外部 MCP 客户端收到的原样 content block。 */
+export interface McpContentBlock {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+export interface McpInvokeResult {
+  name: string;
+  is_error: boolean;
+  duration_ms: number;
+  content: McpContentBlock[];
+  truncated: boolean;
+}
+
+export type McpCheckStatus = 'ok' | 'error' | 'skipped';
+/** 单个工具的自检结论。 */
+export interface McpToolCheck {
+  name: string;
+  network: boolean;
+  status: McpCheckStatus;
+  duration_ms?: number;
+  arguments?: Record<string, unknown> | null;
+  detail?: string | null;
+  preview?: string | null;
+  images?: number;
+}
+export interface McpSelfCheckReport {
+  project_id: string;
+  include_network: boolean;
+  samples: Record<string, string | number | null>;
+  summary: { total: number; ok: number; error: number; skipped: number };
+  results: McpToolCheck[];
 }
 
 // ============================================================
@@ -4014,9 +4050,24 @@ export const api = {
     return requestJson<EffectiveTestResult>('/me/llm/test-effective', 'POST', input);
   },
 
-  // —— MCP 只读工具目录（docs/api-mcp.md） ——
+  // —— MCP 只读工具目录 / 试运行 / 自检（docs/development.md「Testing the tools」） ——
   listMcpTools(): Promise<McpToolsCatalog> {
     return request<McpToolsCatalog>('/mcp/tools');
+  },
+  /** 试运行单个工具：返回外部 MCP 客户端会收到的 content。 */
+  invokeMcpTool(
+    name: string,
+    input: { project_id: string; arguments: Record<string, unknown> },
+  ): Promise<McpInvokeResult> {
+    return requestJson<McpInvokeResult>(`/mcp/tools/${encodeURIComponent(name)}/invoke`, 'POST', input);
+  },
+  /** 一键自检：用课题里的真实数据把工具跑一遍。 */
+  selfCheckMcpTools(input: {
+    project_id: string;
+    include_network?: boolean;
+    names?: string[];
+  }): Promise<McpSelfCheckReport> {
+    return requestJson<McpSelfCheckReport>('/mcp/selfcheck', 'POST', input);
   },
 
   // —— Skills · 技能（docs/skill-system.md §4） ——


### PR DESCRIPTION
## main does not build

#189 added the MCP playground and self-check, including the types and client methods its three components import from `lib/api`. **#200 then deleted all 52 lines of that block.**

So `McpPlayground.tsx`, `McpToolsPage.tsx` and `ToolRunner.tsx` now import members that do not exist, and every frontend build fails — `desktop-build` included:

```
error TS2305: Module '"../../lib/api"' has no exported member 'McpInvokeResult'.
error TS2305: Module '"../../lib/api"' has no exported member 'McpToolCheck'.
error TS2339: Property 'invokeMcpTool' does not exist on type ...
error TS2339: Property 'selfCheckMcpTools' does not exist on type ...
```

## How it happened

**#200 never intended to touch `lib/api.ts`.** Its branch was cut from a stale `origin/main` ref — fetched before #189 landed — and the commit was staged with `git add -A`, which swept the pre-#189 copy of the file in with the intended backend changes. The squash then applied that as a deletion of someone else's work.

Nothing flagged it: no conflict, and the PR's own CI ran against its branch, where the components and the api file were consistently old.

This is the second time staging too broadly has clobbered another batch in this repo — #182 did the same thing to `services/libraries.py`. Staging by explicit path is not enough when the working tree carries stale state; the branch has to be cut from a freshly fetched ref, and the diff read before pushing.

## The fix

Restores `lib/api.ts` to its state immediately before #200. That PR touched nothing else in this file, so a whole-file restore is exactly the intended diff — 52 lines back, 1 line removed.

`tsc --noEmit` exit 0, `vite build` exit 0.