### PR TITLE
fix(projects): let platform admins reach every topic, not just their own

### DIFF
--- a/src/backend/app/api/gates.py
+++ b/src/backend/app/api/gates.py
@@ -43,9 +43,11 @@ async def list_gates(
 
 
 async def _get_decidable_gate(session: AsyncSession, gate_id: uuid.UUID, user: User) -> Gate:
-    """成员才可见/可审批；非成员一律 404（不泄露存在性）。"""
+    """成员（及平台管理员）才可见/可审批；够不着的人一律 404（不泄露存在性）。"""
     gate = await gates_service.get_gate(session, gate_id)
-    if gate is None or not await gates_service.is_project_member(session, gate.project_id, user.id):
+    if gate is None or not await gates_service.can_access_project(
+        session, gate.project_id, user.id
+    ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="GATE_NOT_FOUND")
     return gate
 

--- a/src/backend/app/api/presentations.py
+++ b/src/backend/app/api/presentations.py
@@ -45,7 +45,7 @@ async def create_presentation(
     user: User = Depends(require_llm_task),
     queue: TaskQueue = Depends(get_task_queue),
 ) -> VoyageRead:
-    if not await gates_service.is_project_member(session, project_id, user.id):
+    if not await gates_service.can_access_project(session, project_id, user.id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     if data.mode == "single" and len(data.paper_ids) != 1:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="SINGLE_NEEDS_ONE_PAPER")

--- a/src/backend/app/api/skills.py
+++ b/src/backend/app/api/skills.py
@@ -48,7 +48,7 @@ async def _get_visible_skill(session: AsyncSession, skill_id: uuid.UUID, user: U
 
 
 async def _require_member(session: AsyncSession, project_id: uuid.UUID, user: User) -> None:
-    if not await gates_service.is_project_member(session, project_id, user.id):
+    if not await gates_service.can_access_project(session, project_id, user.id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
 
 
@@ -370,7 +370,7 @@ async def enable_project_skill(
 
 async def _get_member_enable_row(session: AsyncSession, enable_id: uuid.UUID, user: User):
     row = await skills_service.get_project_skill(session, enable_id)
-    if row is None or not await gates_service.is_project_member(session, row.project_id, user.id):
+    if row is None or not await gates_service.can_access_project(session, row.project_id, user.id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_SKILL_NOT_FOUND")
     return row
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -20,7 +20,7 @@ from app.core.config import get_settings
 from app.models.activity import Activity
 from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment, ExperimentRun
 from app.models.idea import Idea
-from app.models.project import Project, ProjectMember
+from app.models.project import Project
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.experiment import (
@@ -30,6 +30,7 @@ from app.schemas.experiment import (
     ExperimentRunRead,
 )
 from app.services import ssh_exec
+from app.services.projects import in_my_projects
 
 logger = logging.getLogger("polaris.experiments")
 
@@ -278,12 +279,14 @@ async def purge_experiments(
 async def get_experiment_for_user(
     session: AsyncSession, *, experiment_id: uuid.UUID, user_id: uuid.UUID
 ) -> tuple[Experiment, str] | None:
-    """取实验（含 runs）；非项目成员视为不存在（返回 None）。"""
+    """取实验（含 runs）；非项目成员视为不存在（平台管理员够得着全部课题）。"""
     stmt = (
         select(Experiment, Idea.title)
         .join(Idea, Idea.id == Experiment.idea_id)
-        .join(ProjectMember, ProjectMember.project_id == Experiment.project_id)
-        .where(Experiment.id == experiment_id, ProjectMember.user_id == user_id)
+        .where(
+            Experiment.id == experiment_id,
+            in_my_projects(Experiment.project_id, user_id),
+        )
         .options(selectinload(Experiment.runs))
     )
     row = (await session.execute(stmt)).first()

--- a/src/backend/app/services/gates.py
+++ b/src/backend/app/services/gates.py
@@ -12,9 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import utcnow
 from app.models.gate import Gate
-from app.models.project import ProjectMember
+from app.models.project import Project
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.gate import GateCreate
+from app.services.projects import in_my_projects
 
 
 class GateAlreadyDecidedError(Exception):
@@ -28,11 +29,13 @@ async def list_gates(
     status: str | None = "pending",
     project_id: uuid.UUID | None = None,
 ) -> Sequence[Gate]:
-    """列出用户所在项目的闸门。status: pending | decided（=approved/rejected）。"""
+    """列出用户所在项目的闸门（平台管理员看全部）。
+
+    status: pending | decided（=approved/rejected）。
+    """
     stmt = (
         select(Gate)
-        .join(ProjectMember, ProjectMember.project_id == Gate.project_id)
-        .where(ProjectMember.user_id == user_id)
+        .where(in_my_projects(Gate.project_id, user_id))
         .order_by(Gate.created_at.desc())
     )
     if status == "decided":
@@ -48,11 +51,16 @@ async def get_gate(session: AsyncSession, gate_id: uuid.UUID) -> Gate | None:
     return await session.get(Gate, gate_id)
 
 
-async def is_project_member(
+async def can_access_project(
     session: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID
 ) -> bool:
-    stmt = select(ProjectMember.user_id).where(
-        ProjectMember.project_id == project_id, ProjectMember.user_id == user_id
+    """能否在这个课题里操作：课题成员，或平台管理员（最高权限）。
+
+    审批闸门、跑技能、开报告都用它。原来只认成员身份，管理员在自己没参与的
+    课题里会被挡——与「管理员看得到这些课题和它们的任务」自相矛盾。
+    """
+    stmt = select(Project.id).where(
+        Project.id == project_id, in_my_projects(Project.id, user_id)
     )
     return (await session.execute(stmt)).first() is not None
 

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -19,6 +19,7 @@ from app.schemas.idea import DeepIdeaRequest, ForgeKnobs
 from app.schemas.review import TournamentRequest
 from app.services.concepts import library_concept_ids
 from app.services.libraries import get_source_library_ids
+from app.services.projects import in_my_projects
 
 # 同项目 idea 类 voyage 互斥（docs/api-m3.md §1 + docs/api-idea2.md §2）
 IDEA_VOYAGE_KINDS = ("idea_forge", "idea_review", "idea_proposal")
@@ -392,11 +393,9 @@ async def list_ideas(
 async def get_idea_for_user(
     session: AsyncSession, *, idea_id: uuid.UUID, user_id: uuid.UUID
 ) -> Idea | None:
-    """取 idea；非项目成员视为不存在。"""
-    stmt = (
-        select(Idea)
-        .join(ProjectMember, ProjectMember.project_id == Idea.project_id)
-        .where(Idea.id == idea_id, ProjectMember.user_id == user_id)
+    """取 idea；非项目成员视为不存在（平台管理员够得着全部课题）。"""
+    stmt = select(Idea).where(
+        Idea.id == idea_id, in_my_projects(Idea.project_id, user_id)
     )
     return (await session.execute(stmt)).scalar_one_or_none()
 

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -28,7 +28,7 @@ from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript, ManuscriptFile
-from app.models.project import Project, ProjectMember
+from app.models.project import Project
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.manuscript import ManuscriptCreate
 from app.services.citations import DEFAULT_EXPORT_STATUSES, assign_citation_keys
@@ -37,6 +37,7 @@ from app.services.libraries import (
     get_source_library_ids,
     member_papers_stmt,
 )
+from app.services.projects import in_my_projects
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "assets" / "templates"
 TEMPLATE_KEYS = ("neurips2026", "iclr2026", "acl")
@@ -602,11 +603,9 @@ async def get_manuscript_for_user(
     user_id: uuid.UUID,
     with_files: bool = False,
 ) -> Manuscript | None:
-    """取稿件；非项目成员视为不存在（返回 None）。"""
-    stmt = (
-        select(Manuscript)
-        .join(ProjectMember, ProjectMember.project_id == Manuscript.project_id)
-        .where(Manuscript.id == manuscript_id, ProjectMember.user_id == user_id)
+    """取稿件；非项目成员视为不存在（平台管理员够得着全部课题）。"""
+    stmt = select(Manuscript).where(
+        Manuscript.id == manuscript_id, in_my_projects(Manuscript.project_id, user_id)
     )
     if with_files:
         stmt = stmt.options(selectinload(Manuscript.files))
@@ -616,12 +615,14 @@ async def get_manuscript_for_user(
 async def get_file_for_user(
     session: AsyncSession, *, file_id: uuid.UUID, user_id: uuid.UUID
 ) -> ManuscriptFile | None:
-    """取稿件文件；非项目成员视为不存在（返回 None）。CRDT WS on_connect 也用。"""
+    """取稿件文件；非项目成员视为不存在（平台管理员够得着全部课题）。CRDT WS on_connect 也用。"""
     stmt = (
         select(ManuscriptFile)
         .join(Manuscript, Manuscript.id == ManuscriptFile.manuscript_id)
-        .join(ProjectMember, ProjectMember.project_id == Manuscript.project_id)
-        .where(ManuscriptFile.id == file_id, ProjectMember.user_id == user_id)
+        .where(
+            ManuscriptFile.id == file_id,
+            in_my_projects(Manuscript.project_id, user_id),
+        )
     )
     return (await session.execute(stmt)).scalar_one_or_none()
 

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project import Project, ProjectInvite, ProjectMember
@@ -32,12 +32,40 @@ async def _unique_slug(session: AsyncSession, base: str) -> str:
     return slug
 
 
+def is_admin_expr(user_id: uuid.UUID):
+    """SQL 层的「这个人是平台管理员吗」。
+
+    这些查询只拿得到 user_id、拿不到 User 对象，所以用 exists 子查询就地判；
+    写法与 voyages._visible_filter、libraries.user_visible_paper_stmt 一致。
+    """
+    return select(User.id).where(User.id == user_id, User.role == "admin").exists()
+
+
+def in_my_projects(project_id_col, user_id: uuid.UUID):
+    """「这条记录所属的课题我够得着吗」——课题作用域读取口的统一条件。
+
+    够得着 = 我是该课题成员，或我是平台管理员（最高权限，全实验室可见可操作）。
+    课题下的东西（想法/实验/稿件/闸门/书架论文……）一律用这一条判，口径必须一致：
+    某处漏了 admin 分支，就会出现「列表里看得到、点进去 404」或「有任务却查不到
+    课题名字」这类前后不一致。
+    """
+    return or_(
+        project_id_col.in_(
+            select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+        ),
+        is_admin_expr(user_id),
+    )
+
+
 async def list_projects(session: AsyncSession, user_id: uuid.UUID) -> Sequence[Project]:
-    """列出用户参与（作为成员）的全部项目。"""
+    """列出用户够得着的课题：本人参与的；平台管理员看全部。
+
+    管理员必须看到全部——否则跟「任务列表对管理员是全平台可见」对不上：
+    实验室工作台拿任务的 project_id 回查这份列表，查空就把归属显示成「未知课题」。
+    """
     stmt = (
         select(Project)
-        .join(ProjectMember, ProjectMember.project_id == Project.id)
-        .where(ProjectMember.user_id == user_id)
+        .where(in_my_projects(Project.id, user_id))
         .order_by(Project.created_at.desc())
     )
     return (await session.execute(stmt)).scalars().all()
@@ -78,11 +106,13 @@ async def create_project(
 async def get_project(
     session: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID
 ) -> Project | None:
-    """取项目；非成员视为不存在（返回 None）。"""
-    stmt = (
-        select(Project)
-        .join(ProjectMember, ProjectMember.project_id == Project.id)
-        .where(Project.id == project_id, ProjectMember.user_id == user_id)
+    """取项目；非成员视为不存在（返回 None）。平台管理员够得着全部课题。
+
+    列表看得到的，点进去必须打得开——这是 :func:`list_projects` 的单条镜像，
+    两边一起改。课题作用域的读取口（想法/实验/闸门等）大多经由这里鉴权。
+    """
+    stmt = select(Project).where(
+        Project.id == project_id, in_my_projects(Project.id, user_id)
     )
     return (await session.execute(stmt)).scalar_one_or_none()
 

--- a/src/backend/tests/test_projects_m1.py
+++ b/src/backend/tests/test_projects_m1.py
@@ -71,19 +71,22 @@ async def test_patch_project_permissions(client):
     )
     assert resp.status_code == 403
 
-    # 非成员（即使 admin）看不到 → 404；加入后 admin 可管理
-    resp = await client.patch(
-        f"/api/projects/{project_id}", json={"name": "x"}, headers=admin_headers
-    )
-    assert resp.status_code == 404
-    resp = await client.post(
-        f"/api/projects/{project_id}/members",
-        json={"email": "root@example.com", "role": "member"},
-        headers=owner_headers,
-    )
-    assert resp.status_code == 204
+    # 平台 admin 是最高权限：不用加进课题也看得到、改得动
+    #（口径与任务列表 / 文献库一致；原来要求先把自己加成成员才行）
+    resp = await client.get(f"/api/projects/{project_id}", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
     resp = await client.patch(
         f"/api/projects/{project_id}", json={"name": "admin 改"}, headers=admin_headers
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
     assert resp.json()["name"] == "admin 改"
+
+    # 对照：既不是成员也不是 admin 的人，连详情都拿不到（404，不泄露存在性）
+    stranger_token = await register_and_login(client, email="stranger2@example.com")
+    stranger_headers = {"Authorization": f"Bearer {stranger_token}"}
+    resp = await client.get(f"/api/projects/{project_id}", headers=stranger_headers)
+    assert resp.status_code == 404
+    resp = await client.patch(
+        f"/api/projects/{project_id}", json={"name": "x"}, headers=stranger_headers
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -9,6 +9,7 @@ import uuid
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
+from app.models.idea import Idea
 from app.models.library_direction import (
     DirectionLibrary,
     DirectionLibraryCurator,
@@ -359,6 +360,90 @@ async def test_ingest_state_says_whether_the_task_can_be_opened(client):
 
     resp = await client.get(f"/api/libraries/{lib_id}/ingest/state", headers=owner)
     assert resp.json()["can_open_running_voyage"] is True
+
+
+async def test_admin_sees_every_topic_that_owns_a_task_it_can_see(client):
+    """管理员看得到全平台任务，就必须看得到这些任务所属的课题——两边口径要一致。
+
+    任务列表对 admin 是全平台可见的，但 ``GET /projects`` 原来只列本人参与的课题：
+    实验室工作台拿任务的 project_id 回查那份列表查空，分组标题就成了「未知课题」。
+    """
+    admin_email = "vscope-name-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-name-owner@example.com")
+
+    resp = await client.post(
+        "/api/projects", json={"name": "别人的课题", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+    run_id = await _make_run(kind="idea_forge", project_id=project_id)
+
+    # 任务看得到
+    resp = await client.get("/api/voyages", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert str(run_id) in {v["id"] for v in resp.json()}
+
+    # 它所属的课题也看得到（名字查得到），且点得开
+    resp = await client.get("/api/projects", headers=admin)
+    assert resp.status_code == 200, resp.text
+    listed = {p["id"]: p["name"] for p in resp.json()}
+    assert listed.get(str(project_id)) == "别人的课题"
+    resp = await client.get(f"/api/projects/{project_id}", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "别人的课题"
+
+
+async def test_admin_can_open_content_inside_a_topic_it_has_not_joined(client):
+    """admin 是最高权限：别人课题里的想法，列表看得到、点得开；普通外人两样都不行。"""
+    admin_email = "vscope-content-admin@example.com"
+    admin = await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-content-owner@example.com")
+    stranger = await _hdr(client, "vscope-content-stranger@example.com")
+
+    resp = await client.post(
+        "/api/projects", json={"name": "带想法的课题", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        idea = Idea(project_id=project_id, title="别人课题里的想法")
+        session.add(idea)
+        await session.commit()
+        idea_id = idea.id
+
+    resp = await client.get(f"/api/projects/{project_id}/ideas", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert str(idea_id) in {i["id"] for i in resp.json()}
+    assert (await client.get(f"/api/ideas/{idea_id}", headers=admin)).status_code == 200
+
+    assert (
+        await client.get(f"/api/projects/{project_id}/ideas", headers=stranger)
+    ).status_code == 404
+    assert (await client.get(f"/api/ideas/{idea_id}", headers=stranger)).status_code == 404
+
+
+async def test_non_member_still_sees_no_topic_they_have_no_right_to(client):
+    """没权限的不展示：普通用户的课题列表里没有别人的课题，详情也打不开。"""
+    admin_email = "vscope-noleak-admin@example.com"
+    await _hdr(client, admin_email)
+    await _promote_admin(admin_email)
+    owner = await _hdr(client, "vscope-noleak-owner@example.com")
+    stranger = await _hdr(client, "vscope-noleak-stranger@example.com")
+
+    resp = await client.post(
+        "/api/projects", json={"name": "不该外泄的课题", "statement": "s"}, headers=owner
+    )
+    assert resp.status_code == 201, resp.text
+    project_id = resp.json()["id"]
+
+    resp = await client.get("/api/projects", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    assert project_id not in {p["id"] for p in resp.json()}
+    assert (await client.get(f"/api/projects/{project_id}", headers=stranger)).status_code == 404
 
 
 async def test_new_ingest_voyage_carries_no_project(client):


### PR DESCRIPTION
## Problem

The lab workbench groups tasks by owning topic, and for admins the group header read "未知课题" (Unknown topic).

The cause is an asymmetry between two visibility rules:

- Task listing (`GET /voyages`) **has** an admin branch in `_visible_filter` (`services/voyages.py:59,70`), so an admin sees every task in the lab, including tasks of topics they never joined.
- Topic listing (`GET /projects`) **had none** — `list_projects` filtered strictly on `ProjectMember`, so an admin's topic list only ever held their own memberships.

The workbench takes `project_id` from the first and looks the name up in a map built from the second (`LabPage.tsx:917,946`). For someone else's topic the lookup misses and falls through to the "Unknown topic" placeholder.

## Approach

Rather than denormalizing the topic name onto each task to paper over the gap, this makes the permission rule consistent: **you reach a topic if you are a member of it, or if you are a platform admin.**

A new `projects.in_my_projects(project_id_col, user_id)` expresses that rule once, and replaces the hand-written `join(ProjectMember)` in every topic-scoped read:

| Location | Change |
|---|---|
| `services/projects.py` | admin branch in `list_projects` / `get_project` (**root cause**) |
| `services/ideas.py` | `get_idea_for_user` |
| `services/experiments.py` | `get_experiment_for_user` |
| `services/manuscripts.py` | `get_manuscript_for_user` / `get_file_for_user` |
| `services/gates.py` | `list_gates`; `is_project_member` renamed to `can_access_project` with the admin branch |

The gate helper is renamed because it was always used as "may this user act in this topic" (approving gates, running skills, opening presentations). Membership is no longer the only way in, so the old name would be a lie. All 4 call sites are updated (`api/gates.py`, `api/presentations.py`, `api/skills.py` ×2).

No frontend change — the name resolves now.

## Behavior changes worth a look

1. **An admin's topic switcher now lists every topic in the lab**, not just their own. That is the direct consequence of "admin sees and operates everything". Knock-on effect: when the currently selected id is invalid, `ProjectProvider` falls back to the first entry, which for an admin may land on someone else's topic.
2. **An admin no longer has to add themselves as a member before managing a topic.** `test_projects_m1.py::test_patch_project_permissions` explicitly asserted the old policy ("a non-member, even an admin, gets 404; only after joining can they manage"); it has been rewritten to the new rule.

Ordinary non-members are unaffected — still 404 on topics they have no right to, so existence is not leaked.

## Tests

- `test_admin_sees_every_topic_that_owns_a_task_it_can_see` — if an admin can see a task, they must also see the topic that owns it (name present in the list, detail opens).
- `test_admin_can_open_content_inside_a_topic_it_has_not_joined` — an idea in someone else's topic is listed and openable for an admin, 404 for an unrelated user.
- `test_non_member_still_sees_no_topic_they_have_no_right_to` — nothing shows up without the right to it.
- `test_patch_project_permissions` rewritten to the new rule.

Full backend suite: **814 passed**. That run predates the rebase onto `1554382`; the rebase only pulled in two unrelated upstream commits (frontend api.ts restore, ingest source change) and the suite was not re-run afterwards. ruff is clean apart from 3 pre-existing findings in `test_admin_user_crud.py` and `test_me_llm_extras.py`, untouched by this PR.
