### PR TITLE
refactor(vectors): always build paper and chunk vectors, drop both switches

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -38,7 +38,6 @@ from app.services.chunks import (
     embed_pending_chunks,
     ensure_paper_chunks,
     sync_abstract_chunk_vectors,
-    user_wants_fulltext_index,
 )
 from app.services.concepts import link_all_paper_concepts
 from app.services.dedup import pool_dedup_key
@@ -52,7 +51,7 @@ from app.services.libraries import (
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
-from app.services.paper_enrich import paper_embedding_enabled, paper_embedding_text
+from app.services.paper_enrich import paper_embedding_text
 from app.services.paper_wiki import upsert_wiki
 from app.services.projects import DEFAULT_ARXIV_CATEGORIES
 from app.services.relevance import (
@@ -1019,9 +1018,6 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         embedded = 0
         embed_error: str | None = None
         pending = [p for p in papers if p.embedding is None]
-        if pending and not await paper_embedding_enabled(session):
-            pending = []  # 管理员拉了论文级向量的总闸
-            embed_error = "paper embeddings disabled by administrator"
         if pending:
             # 文本口径与手动补全/每日池共用（services/paper_enrich.paper_embedding_text）
             texts = [paper_embedding_text(p) for p in pending]
@@ -1052,28 +1048,20 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         await sync_abstract_chunk_vectors(session, paper_ids=[p.id for p in papers])
         await session.commit()
 
-        # 分段向量：补齐缺失的 chunk embedding（文献问答检索底座）。受**发起人**的
-        # 「全文索引」开关控制（默认开）——与手动添加论文那条路径同一个开关，
-        # 免得同一个用户在两条路径上得到不一样的结果。公共库的账记系统（billing_user_id
-        # 为空），但发起人是有的，故开关按 ctx.run.created_by 取。
+        # 分段向量：补齐缺失的 chunk embedding（文献问答检索底座）。
         # 最大化模式放开单次 2000 段的默认上限（否则大批量编译后向量长期欠账）
-        chunks_embedded = 0
-        chunk_embed_error: str | None = None
-        if await user_wants_fulltext_index(session, ctx.run.created_by):
-            embed_kwargs: dict[str, Any] = (
-                {"limit": _UNLIMITED_CHUNK_SENTINEL} if _unlimited(_knobs(ctx)) else {}
-            )
-            chunks_embedded, chunk_embed_error = await embed_pending_chunks(
-                session,
-                library_id=library.id,
-                llm=ctx.llm,
-                user_id=billing_user_id,
-                project_id=ctx.run.project_id,
-                voyage_id=ctx.run.id,
-                **embed_kwargs,
-            )
-        else:
-            chunk_embed_error = "fulltext index disabled by user setting"
+        embed_kwargs: dict[str, Any] = (
+            {"limit": _UNLIMITED_CHUNK_SENTINEL} if _unlimited(_knobs(ctx)) else {}
+        )
+        chunks_embedded, chunk_embed_error = await embed_pending_chunks(
+            session,
+            library_id=library.id,
+            llm=ctx.llm,
+            user_id=billing_user_id,
+            project_id=ctx.run.project_id,
+            voyage_id=ctx.run.id,
+            **embed_kwargs,
+        )
 
     return {
         "papers": len(papers),

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -11,13 +11,10 @@ from app.schemas.admin_settings import (
     DailyEmbedBackfillResult,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
-    PaperEmbeddingRead,
-    PaperEmbeddingUpdate,
 )
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
 from app.services import lab as lab_service
-from app.services import paper_enrich as paper_enrich_service
 
 router = APIRouter(
     prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
@@ -43,25 +40,6 @@ async def set_affiliation_mode(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"INVALID_AFFILIATION_MODE:{exc.mode}"
         ) from exc
     return AffiliationModeRead(mode=mode)
-
-
-@router.get("/paper-embedding", response_model=PaperEmbeddingRead)
-async def get_paper_embedding(session: AsyncSession = Depends(get_session)) -> PaperEmbeddingRead:
-    """平台是否给论文建论文级向量（默认开，平台级总闸）。
-
-    前身是 /daily-embed（默认关、只管每日推送）；默认关意味着推送来的论文在语义检索里
-    根本搜不到，而只管一条路径也名不副实，故改名并扩到所有入库入口。"""
-    return PaperEmbeddingRead(enabled=await paper_enrich_service.paper_embedding_enabled(session))
-
-
-@router.put("/paper-embedding", response_model=PaperEmbeddingRead)
-async def set_paper_embedding(
-    payload: PaperEmbeddingUpdate,
-    session: AsyncSession = Depends(get_session),
-) -> PaperEmbeddingRead:
-    return PaperEmbeddingRead(
-        enabled=await paper_enrich_service.set_paper_embedding_enabled(session, payload.enabled)
-    )
 
 
 @router.post("/daily-embed/backfill", response_model=DailyEmbedBackfillResult)

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -30,7 +30,6 @@ from app.api.auth import (
     require_llm_chat,
     require_llm_task,
 )
-from app.api.wiki import require_fulltext_index_enabled
 from app.core.db import get_session
 from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
@@ -904,11 +903,8 @@ async def rebuild_library_fulltext_index(
     """库作用域全文索引重建（可管理者）：给本库已有全文但缺分段的论文补分段并嵌入。
 
     幂等：已有分段的论文跳过；新入库论文由建库流水线自动处理，通常无需手动调用。
-    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED），与个人库/书架/课题
-    那三个批量重建端点同一口径。
     """
     library = await _get_managed_library(session, library_id, user)
-    require_fulltext_index_enabled(user)
     try:
         return await chunks_service.rebuild_library_fulltext_index(
             session,

--- a/src/backend/app/api/users_profile.py
+++ b/src/backend/app/api/users_profile.py
@@ -20,8 +20,7 @@ from app.schemas.user import (
     UsernameUpdate,
     UserRead,
     UserSearchResult,
-    UserSettingsUpdate,
-)
+    )
 from app.services import llm_admin as llm_admin_service
 from app.services import users as users_service
 from app.services.users import tokens_used_by_user
@@ -46,20 +45,6 @@ async def set_my_username(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="USERNAME_TAKEN")
     user.username = uname
     user.username_locked = True
-    await session.commit()
-    await session.refresh(user)
-    return user
-
-
-@router.patch("/users/me/settings", response_model=UserRead)
-async def set_my_settings(
-    body: UserSettingsUpdate,
-    session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
-) -> User:
-    """本人个人设置：目前仅文献对话全文索引开关（合并进 settings JSON）。"""
-    # JSON 列原地改需 flag_modified；重新赋值整 dict 最稳（触发 ORM 脏检测）。
-    user.settings = {**(user.settings or {}), "chat_fulltext_index": body.chat_fulltext_index}
     await session.commit()
     await session.refresh(user)
     return user

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -350,18 +350,6 @@ async def chat_with_personal_library(
     return _chat_stream_response(messages, sources, user_id=user_id, project_id=None)
 
 
-def require_fulltext_index_enabled(user: User) -> None:
-    """全文索引门控：用户在设置里**显式关掉**才 409（默认开，与 chunks
-    .user_wants_fulltext_index 同一口径）。
-
-    所有**批量**建索引/重建索引的端点都要过这一道（含 libraries.py 的库作用域版本），
-    否则用户关掉开关后，换个入口点一下照样烧额度。单篇的手动重建按钮不过——那是
-    用户当场指定这一篇，与「要不要自动建」是两回事。
-    """
-    if user.setting("chat_fulltext_index") is False:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="INDEXING_DISABLED")
-
-
 async def _count_with_fulltext(
     session: AsyncSession, paper_ids: list[uuid.UUID]
 ) -> int:
@@ -388,10 +376,9 @@ async def rebuild_shelf_fulltext_index(
 ) -> dict[str, Any]:
     """可选全文索引：对课题相关研究书架上的论文批量建全文索引（抓 PDF→分段→嵌入）。
 
-    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。长任务走 worker。
+    长任务走 worker。
     """
     await _member_project(session, project_id, user)
-    require_fulltext_index_enabled(user)
     paper_ids = await shelf_paper_ids(session, project_id=project_id)
     indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "shelf", str(user.id), str(project_id))
@@ -410,9 +397,8 @@ async def rebuild_personal_fulltext_index(
 ) -> dict[str, Any]:
     """可选全文索引：对本人收藏的个人库论文批量建全文索引（抓 PDF→分段→嵌入）。
 
-    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。长任务走 worker。
+    长任务走 worker。
     """
-    require_fulltext_index_enabled(user)
     paper_ids = await personal_paper_ids(session, user_id=user.id, tab="saved")
     indexable = await _count_with_fulltext(session, paper_ids)
     await queue.enqueue("index_papers_fulltext_task", "personal", str(user.id), None)
@@ -432,10 +418,8 @@ async def rebuild_fulltext_index(
     """重建全文分段索引（docs/api-lit.md §8）：给已有全文但缺分段的论文补分段并嵌入。
 
     幂等：已有分段的论文跳过；新入库论文由 ingest 流水线自动处理，通常无需手动调用。
-    需先在个人设置里开启（未开 → 409 INDEXING_DISABLED）。
     """
     await _member_project(session, project_id, user)
-    require_fulltext_index_enabled(user)
     # 分段重建是「某具体库」的维护写操作（计库预算），落在课题起源库上
     library = await get_library_for_project(session, project_id)
     if library is None:

--- a/src/backend/app/models/user.py
+++ b/src/backend/app/models/user.py
@@ -34,8 +34,9 @@ class User(SQLAlchemyBaseUserTableUUID, TimestampMixin, Base):
     token_quota: Mapped[int | None] = mapped_column(BigInteger)
     # 功能权限：{feature: bool}；None/缺键 = 允许
     features: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
-    # 用户个人设置：{key: value}（如 chat_fulltext_index=bool 开启文献对话全文索引）；
-    # 与 features（admin 权限位）分开，None/缺键 = 未设置。
+    # 用户个人设置：{key: value}。与 features（admin 权限位）分开，None/缺键 = 未设置。
+    # 目前没有任何设置项在读它——chat_fulltext_index 已废除（向量是检索的承重结构，
+    # 不再可关），存量值留在库里不清理也不读。列本身保留给后续设置项。
     settings: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
 
     @property

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -15,16 +15,6 @@ class AffiliationModeUpdate(BaseModel):
     mode: AffiliationMode
 
 
-class PaperEmbeddingRead(BaseModel):
-    """平台是否给论文建论文级向量（默认开）。关掉后语义检索只能命中已有向量的论文。"""
-
-    enabled: bool
-
-
-class PaperEmbeddingUpdate(BaseModel):
-    enabled: bool
-
-
 class LabLeaderboardSettingRead(BaseModel):
     """用量排行榜是否对普通成员可见（默认开；关掉后只有管理员看得到）。"""
 

--- a/src/backend/app/schemas/user.py
+++ b/src/backend/app/schemas/user.py
@@ -23,12 +23,6 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
     settings: dict[str, Any] | None = None
 
 
-class UserSettingsUpdate(BaseModel):
-    """本人个人设置更新（当前仅文献对话全文索引开关）。"""
-
-    chat_fulltext_index: bool
-
-
 class UserSearchResult(BaseModel):
     """平台用户查找结果（加协作者用，不含敏感字段）。"""
 

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -191,24 +191,6 @@ async def paper_has_chunks(
     return (await session.execute(stmt.limit(1))).first() is not None
 
 
-async def user_wants_fulltext_index(
-    session: AsyncSession, user_id: uuid.UUID | None
-) -> bool:
-    """该用户是否要为论文建分块向量（chat_fulltext_index）。**默认开**。
-
-    只有显式关掉（设置里存了 False）才不建；没设置过、查不到用户、以及无 user_id
-    的系统调用都按开处理——不建分块向量等于这篇论文对文献对话不可检索，那是坏默认。
-    """
-    if user_id is None:
-        return True
-    from app.models.user import User
-
-    user = await session.get(User, user_id)
-    if user is None:
-        return True
-    return user.setting("chat_fulltext_index") is not False
-
-
 async def _embed_chunks(
     session: AsyncSession,
     pending: list[PaperChunk],

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -48,7 +48,6 @@ logger = logging.getLogger(__name__)
 CATEGORIES_SETTING_KEY = "daily_feed_categories"
 
 # 注：论文级向量的管理员开关已升格为平台总闸并改名（daily_feed_embed_enabled →
-# paper_embedding_enabled，默认从关改成开），见 services/paper_enrich.py。
 # 默认关意味着每日推送的论文连论文级向量都没有、语义检索里根本搜不到；而只管每日推送
 # 这一条路径也名不副实。本模块只管调用总闸，不再自己存开关。旧键的存量值不再读。
 
@@ -127,10 +126,7 @@ async def embed_papers_missing_vectors(
     if not paper_ids:
         return {"embedded": 0, "skipped": 0, "failed": 0}
     from app.core.llm.router import get_llm_router
-    from app.services.paper_enrich import paper_embedding_enabled, paper_embedding_text
-
-    if not await paper_embedding_enabled(session):  # 管理员拉了总闸
-        return {"embedded": 0, "skipped": len(set(paper_ids)), "failed": 0}
+    from app.services.paper_enrich import paper_embedding_text
 
     rows = (
         (await session.execute(select(Paper).where(Paper.id.in_(list(set(paper_ids))))))

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -33,29 +33,6 @@ EMBED_TEXT_MAX_CHARS = 2000
 # 前身是 daily_feed_embed_enabled（默认关、只管每日推送那一条路径）——默认关意味着
 # 推送来的论文在语义检索里根本搜不到，而只管一条路径又名不副实。旧键的存量值不迁移，
 # 读不到就取新默认（开）。
-PAPER_EMBEDDING_SETTING_KEY = "paper_embedding_enabled"
-DEFAULT_PAPER_EMBEDDING_ENABLED = True
-
-
-async def paper_embedding_enabled(session: AsyncSession) -> bool:
-    """平台是否建论文级向量（默认开；非法存量值回落默认）。"""
-    from app.models.system_setting import SystemSetting
-
-    row = await session.get(SystemSetting, PAPER_EMBEDDING_SETTING_KEY)
-    value = row.value if row is not None else None
-    return value if isinstance(value, bool) else DEFAULT_PAPER_EMBEDDING_ENABLED
-
-
-async def set_paper_embedding_enabled(session: AsyncSession, enabled: bool) -> bool:
-    from app.models.system_setting import SystemSetting
-
-    row = await session.get(SystemSetting, PAPER_EMBEDDING_SETTING_KEY)
-    if row is None:
-        session.add(SystemSetting(key=PAPER_EMBEDDING_SETTING_KEY, value=bool(enabled)))
-    else:
-        row.value = bool(enabled)
-    await session.commit()
-    return bool(enabled)
 
 _OWNER_TTL_SECONDS = 600  # paper_task_owner 归属 key 存活时间
 
@@ -224,8 +201,6 @@ async def enrich_paper(
     await emit("embed", "running")
     if paper.embedding is not None:
         await emit("embed", "skipped", "already embedded")
-    elif not await paper_embedding_enabled(session):
-        await emit("embed", "skipped", "paper embeddings disabled by administrator")
     else:
         try:
             await embed_paper(
@@ -259,28 +234,23 @@ async def enrich_paper(
         logger.warning("abstract chunk vector sync failed for %s", paper_id, exc_info=True)
         paper = await _rollback_and_reload()
 
-    # 块向量：仅当用户开启全文索引开关时补（开关关只留块行，等重建/开开关再补）。
-    # best-effort，不影响 embed 阶段判定；不发独立进度事件。
-    from app.services.chunks import embed_pending_chunks_for_papers, user_wants_fulltext_index
+    # 块向量：抓到全文就一定建。best-effort，不影响 embed 阶段判定；不发独立进度事件。
+    from app.core.llm.router import get_llm_router
+    from app.services.chunks import embed_pending_chunks_for_papers
 
-    if await user_wants_fulltext_index(session, user_id):
-        from app.core.llm.router import get_llm_router
-
-        try:
-            await embed_pending_chunks_for_papers(
-                session,
-                paper_ids=[paper_id],
-                llm=get_llm_router(),
-                user_id=user_id,
-                project_id=project_id,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "enrich chunk embed failed for paper %s", paper_id, exc_info=True
-            )
-            paper = await _rollback_and_reload()
+    try:
+        await embed_pending_chunks_for_papers(
+            session,
+            paper_ids=[paper_id],
+            llm=get_llm_router(),
+            user_id=user_id,
+            project_id=project_id,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("enrich chunk embed failed for paper %s", paper_id, exc_info=True)
+        paper = await _rollback_and_reload()
 
     # ---- score ----
     await emit("score", "running")

--- a/src/backend/app/services/paper_index.py
+++ b/src/backend/app/services/paper_index.py
@@ -25,7 +25,7 @@ from app.services.chunks import (
     index_paper_abstract,
     replace_chunks,
 )
-from app.services.paper_enrich import embed_paper, paper_embedding_enabled
+from app.services.paper_enrich import embed_paper
 
 logger = logging.getLogger(__name__)
 
@@ -104,16 +104,13 @@ async def rebuild_index(
     errors: list[str] = []
 
     if "paper" in targets:
-        if not await paper_embedding_enabled(session):
-            errors.append("paper: 管理员已关闭论文级向量")
-        else:
-            try:
-                await embed_paper(paper, user_id=user_id, project_id=project_id)
-                await session.commit()
-            except Exception as e:  # noqa: BLE001 — provider 不支持嵌入等：记下继续
-                logger.warning("paper embedding rebuild failed for %s", paper.id, exc_info=True)
-                await session.rollback()
-                errors.append(f"paper: {type(e).__name__}: {e}")
+        try:
+            await embed_paper(paper, user_id=user_id, project_id=project_id)
+            await session.commit()
+        except Exception as e:  # noqa: BLE001 — provider 不支持嵌入等：记下继续
+            logger.warning("paper embedding rebuild failed for %s", paper.id, exc_info=True)
+            await session.rollback()
+            errors.append(f"paper: {type(e).__name__}: {e}")
 
     if "chunks" in targets:
         try:

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -943,16 +943,14 @@ async def fetch_pdf(
         await ensure_paper_chunks(session, paper)
     except Exception:  # noqa: BLE001
         logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
-    # 论文级向量（此路径原先不建）：embedding 为空、且管理员没关总闸才补。
-    # best-effort，不影响 PDF 落盘
+    # 论文级向量：缺就补。best-effort，不影响 PDF 落盘
     if paper.embedding is None:
-        from app.services.paper_enrich import embed_paper, paper_embedding_enabled
+        from app.services.paper_enrich import embed_paper
 
-        if await paper_embedding_enabled(session):
-            try:
-                await embed_paper(paper, user_id=user_id, project_id=project_id)
-            except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
-                logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
+        try:
+            await embed_paper(paper, user_id=user_id, project_id=project_id)
+        except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
+            logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
     # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
     # 机构）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响主流程
     if not paper.affiliations and paper.full_text_path:
@@ -978,25 +976,20 @@ async def fetch_pdf(
     except Exception:  # noqa: BLE001
         logger.warning("abstract chunk vector sync failed for %s", paper.id, exc_info=True)
 
-    # 块向量受用户开关（默认开）：关掉时块行留着，待重建/开开关再补。best-effort，内部自 commit
-    from app.services.chunks import (
-        embed_pending_chunks_for_papers,
-        user_wants_fulltext_index,
-    )
+    # 块向量：全文已经抓到了，向量就一定建。best-effort，内部自 commit
+    from app.core.llm.router import get_llm_router
+    from app.services.chunks import embed_pending_chunks_for_papers
 
-    if await user_wants_fulltext_index(session, user_id):
-        from app.core.llm.router import get_llm_router
-
-        try:
-            await embed_pending_chunks_for_papers(
-                session,
-                paper_ids=[paper.id],
-                llm=get_llm_router(),
-                user_id=user_id,
-                project_id=project_id,
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
+    try:
+        await embed_pending_chunks_for_papers(
+            session,
+            paper_ids=[paper.id],
+            llm=get_llm_router(),
+            user_id=user_id,
+            project_id=project_id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
     return paper
 

--- a/src/backend/tests/test_chat_fulltext_index.py
+++ b/src/backend/tests/test_chat_fulltext_index.py
@@ -1,4 +1,7 @@
-"""可选全文索引（Part B）：个人设置开关 + 按 scope 批量建全文索引 + 入队门控。"""
+"""全文索引：按 scope 批量建索引 + 入队。
+
+开关（个人设置 chat_fulltext_index）已废除——向量是检索的承重结构，不再可关。
+"""
 
 import tempfile
 import uuid
@@ -12,34 +15,7 @@ from app.models.paper import PaperChunk
 from app.services.fulltext_index import index_papers_fulltext
 from tests.conftest import add_paper, register_and_login
 
-# ---- 1. PATCH /users/me/settings ----
-
-
-async def test_patch_settings_and_read_back(client):
-    token = await register_and_login(client)
-    headers = {"Authorization": f"Bearer {token}"}
-
-    # 缺省未设置
-    me = (await client.get("/api/users/me", headers=headers)).json()
-    assert me.get("settings") in (None, {})
-
-    resp = await client.patch(
-        "/api/users/me/settings", json={"chat_fulltext_index": True}, headers=headers
-    )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["settings"]["chat_fulltext_index"] is True
-
-    me = (await client.get("/api/users/me", headers=headers)).json()
-    assert me["settings"]["chat_fulltext_index"] is True
-
-    # 关回去也能读到
-    resp = await client.patch(
-        "/api/users/me/settings", json={"chat_fulltext_index": False}, headers=headers
-    )
-    assert resp.json()["settings"]["chat_fulltext_index"] is False
-
-
-# ---- 3/4. 索引服务 ----
+# ---- 索引服务 ----
 
 
 async def _project(client):
@@ -111,47 +87,14 @@ async def test_index_papers_fulltext_builds_chunks_and_skips_no_source(client):
     assert again["skipped"] == 2
 
 
-# ---- 6. 入队端点 + 409 门控 ----
+# ---- 入队端点 ----
 
 
-async def _enable_index(client, headers):
-    resp = await client.patch(
-        "/api/users/me/settings", json={"chat_fulltext_index": True}, headers=headers
-    )
-    assert resp.status_code == 200
-
-
-async def _disable_index(client, headers):
-    resp = await client.patch(
-        "/api/users/me/settings", json={"chat_fulltext_index": False}, headers=headers
-    )
-    assert resp.status_code == 200
-
-
-async def test_shelf_index_rebuild_gated(client, queue_stub):
+async def test_shelf_index_rebuild_enqueues(client, queue_stub):
+    """书架批量建索引：直接入队，没有任何开关能拦住它。"""
     project_id, headers = await _project(client)
 
-    # 开关默认开：没设置过也能建
-    resp = await client.post(
-        f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
-    )
-    assert resp.status_code == 200, resp.text
-    queue_stub.jobs.clear()
-
-    # 显式关掉才 409
-    await _disable_index(client, headers)
-    resp = await client.post(
-        f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
-    )
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "INDEXING_DISABLED"
-    assert queue_stub.jobs == []
-
-    # 设置开 → 200 + 入队
-    await _enable_index(client, headers)
-    resp = await client.post(
-        f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers
-    )
+    resp = await client.post(f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers)
     assert resp.status_code == 200, resp.text
     assert "queued" in resp.json()
     assert len(queue_stub.jobs) == 1
@@ -164,7 +107,6 @@ async def test_shelf_index_rebuild_gated(client, queue_stub):
 async def test_shelf_index_rebuild_reports_indexable_counts(client, queue_stub):
     """返回体含 indexable / no_fulltext：书架上有全文的计入 indexable，其余计跳过。"""
     project_id, headers = await _project(client)
-    await _enable_index(client, headers)
 
     txt_dir = Path(tempfile.mkdtemp(prefix="polaris-idx-"))
     txt = txt_dir / "p.txt"
@@ -200,7 +142,6 @@ async def test_shelf_index_rebuild_reports_indexable_counts(client, queue_stub):
 
 async def test_shelf_index_rebuild_requires_member(client, queue_stub):
     _, headers = await _project(client)
-    await _enable_index(client, headers)
     resp = await client.post(
         f"/api/projects/{uuid.uuid4()}/shelf/index/rebuild", headers=headers
     )
@@ -208,75 +149,32 @@ async def test_shelf_index_rebuild_requires_member(client, queue_stub):
     assert queue_stub.jobs == []
 
 
-async def test_personal_index_rebuild_gated(client, queue_stub):
+async def test_personal_index_rebuild_enqueues(client, queue_stub):
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
 
-    # 开关默认开：没设置过也能建
     resp = await client.post("/api/library/index/rebuild", headers=headers)
     assert resp.status_code == 200, resp.text
-    queue_stub.jobs.clear()
-
-    # 显式关掉才 409
-    await _disable_index(client, headers)
-    resp = await client.post("/api/library/index/rebuild", headers=headers)
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "INDEXING_DISABLED"
-    assert queue_stub.jobs == []
-
-    await _enable_index(client, headers)
-    resp = await client.post("/api/library/index/rebuild", headers=headers)
-    assert resp.status_code == 200, resp.text
-    assert "queued" in resp.json()
     assert len(queue_stub.jobs) == 1
     func_name, args, _ = queue_stub.jobs[0]
     assert func_name == "index_papers_fulltext_task"
     assert args[0] == "personal"
-    assert args[2] is None
 
 
-async def test_project_index_rebuild_gated(client):
-    """课题作用域批量重建同样过门控——此前漏了，用户关掉开关换这个入口照样烧额度。"""
-    project_id, headers = await _project(client)
+async def test_no_rebuild_endpoint_is_gated_anymore(client, queue_stub):
+    """四个批量重建入口都不再有 409 门控——开关没了，就没有「未开启」这回事。
 
-    # 开关默认开：没设置过也能建
-    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
-    assert resp.status_code == 200, resp.text
-
-    await _disable_index(client, headers)
-    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "INDEXING_DISABLED"
-
-    await _enable_index(client, headers)
-    resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
-    assert resp.status_code == 200, resp.text
-
-
-async def test_library_index_rebuild_gated(client):
-    """库作用域批量重建同样过门控（与课题/个人库/书架同一口径）。
-
-    鉴权先于门控：无权管理的人拿到的仍是 403，不因自己关了开关就变成 409——
-    否则这个端点会把「你管不了这个库」说成「你没开索引」，误导排查方向。
+    #183 曾把门控补齐到这四个入口；现在开关整体废除，门控随之下线。
     """
-    from tests.test_library_scoped_capabilities import _hdr, _setup
+    project_id, headers = await _project(client)
+    from tests.test_library_scoped_capabilities import _setup
 
-    creator, _admin, lib_id = await _setup(client, prefix="idxgate")
+    creator, _admin, lib_id = await _setup(client, prefix="nogate")
 
-    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
-    assert resp.status_code == 200, resp.text
-
-    await _disable_index(client, creator)
-    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "INDEXING_DISABLED"
-
-    # 关着开关的陌生人拿 403（鉴权先跑），不是 409
-    stranger = await _hdr(client, "idxgate-stranger@example.com")
-    await _disable_index(client, stranger)
-    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=stranger)
-    assert resp.status_code == 403
-
-    await _enable_index(client, creator)
-    resp = await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator)
-    assert resp.status_code == 200, resp.text
+    for resp in (
+        await client.post(f"/api/projects/{project_id}/shelf/index/rebuild", headers=headers),
+        await client.post("/api/library/index/rebuild", headers=headers),
+        await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers),
+        await client.post(f"/api/libraries/{lib_id}/index/rebuild", headers=creator),
+    ):
+        assert resp.status_code == 200, resp.text

--- a/src/backend/tests/test_enrich_chunk_index.py
+++ b/src/backend/tests/test_enrich_chunk_index.py
@@ -1,4 +1,4 @@
-"""三路径统一「分块 + 论文级向量」，块向量受 chat_fulltext_index 开关控制。
+"""三路径统一「分块 + 论文级向量」：抓到全文就一定建块向量，没有开关。
 
 覆盖 enrich_paper（手动添加 / Daily 收录）与 papers.fetch_pdf（抓取 PDF）：
 - 抽到全文即分块（无块才切，不重切丢已补向量）；
@@ -34,13 +34,9 @@ def _write_fulltext() -> str:
     return str(txt)
 
 
-async def _user(client, email: str, *, index_on: bool):
-    """开关默认开，所以「关」这一路要显式 PATCH False，不能靠不设置。"""
+async def _user(client, email: str):
     token = await register_and_login(client, email=email)
     headers = {"Authorization": f"Bearer {token}"}
-    await client.patch(
-        "/api/users/me/settings", json={"chat_fulltext_index": index_on}, headers=headers
-    )
     me = (await client.get("/api/users/me", headers=headers)).json()
     return uuid.UUID(me["id"]), headers
 
@@ -70,30 +66,9 @@ async def _run_enrich(paper_id, *, user_id):
 # ---- enrich_paper：分块 + 论文级向量 + 块向量受开关 ----
 
 
-async def test_enrich_chunks_but_leaves_block_vectors_when_index_off(client, fake_redis):
-    """开关关：抽到全文→建块 + 论文级向量，但块行 embedding 留空。"""
-    user_id, headers = await _user(client, "off@example.com", index_on=False)
-    project_id, _ = await make_project_with_library(client, headers, name="enrich-off")
-    async with get_sessionmaker()() as session:
-        paper = await add_paper(
-            session, project_id=uuid.UUID(project_id), title="Off",
-            doi="10.1/off", full_text_path=_write_fulltext(),
-        )
-        await session.commit()
-        paper_id = paper.id
-
-    await _run_enrich(paper_id, user_id=user_id)
-
-    async with get_sessionmaker()() as session:
-        paper = await session.get(paper_enrich.Paper, paper_id)
-        assert paper.embedding is not None  # 论文级向量照常
-        assert await _n_chunks(session, paper_id) > 0  # 已分块
-        assert await _n_embedded(session, paper_id) == 0  # 开关关：块向量不补
-
-
-async def test_enrich_embeds_blocks_when_index_on(client, fake_redis):
-    """开关开：块行被嵌入。"""
-    user_id, headers = await _user(client, "on@example.com", index_on=True)
+async def test_enrich_embeds_blocks(client, fake_redis):
+    """抽到全文 → 建块 + 论文级向量 + 块向量，一步不落（没有开关可以拦下任何一步）。"""
+    user_id, headers = await _user(client, "on@example.com")
     project_id, _ = await make_project_with_library(client, headers, name="enrich-on")
     async with get_sessionmaker()() as session:
         paper = await add_paper(
@@ -113,7 +88,7 @@ async def test_enrich_embeds_blocks_when_index_on(client, fake_redis):
 
 async def test_enrich_does_not_reslice_existing_chunks(client, fake_redis):
     """已有块的论文再 enrich 不重切（无块才切），保住已补的块向量。"""
-    user_id, headers = await _user(client, "keep@example.com", index_on=True)
+    user_id, headers = await _user(client, "keep@example.com")
     project_id, _ = await make_project_with_library(client, headers, name="enrich-keep")
     async with get_sessionmaker()() as session:
         paper = await add_paper(
@@ -153,7 +128,7 @@ async def test_fetch_pdf_builds_paper_vector_and_gated_blocks(client, fake_redis
         respx.get(url__regex=r"https://arxiv\.org/pdf/.*").mock(
             return_value=httpx.Response(200, content=b"%PDF-1.4 not-a-real-pdf")
         )
-        user_id, headers = await _user(client, "fetch@example.com", index_on=True)
+        user_id, headers = await _user(client, "fetch@example.com")
         project_id, _ = await make_project_with_library(client, headers, name="fetch")
         # 预置全文（extract 抽不出也不影响；chunk 走已有 full_text_path）
         async with get_sessionmaker()() as session:

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -36,14 +36,9 @@ def _write_fulltext(text: str = "规划方法的实现细节与实验。") -> st
     return str(txt)
 
 
-async def _user(client, email: str, *, index_on: bool | None = None):
+async def _user(client, email: str):
     token = await register_and_login(client, email=email)
     headers = {"Authorization": f"Bearer {token}"}
-    if index_on is not None:
-        resp = await client.patch(
-            "/api/users/me/settings", json={"chat_fulltext_index": index_on}, headers=headers
-        )
-        assert resp.status_code == 200
     me = (await client.get("/api/users/me", headers=headers)).json()
     return uuid.UUID(me["id"]), headers
 
@@ -236,34 +231,6 @@ async def test_abstract_chunk_vector_filled_in_later(client):
     assert chunks[0].embedding == pytest.approx(sentinel)
 
 
-async def test_abstract_chunk_vector_not_gated_by_user_switch(client, fake_redis):
-    """用户关掉全文索引开关，摘要块的向量照样有——拷贝不花钱，不该卡在开关后面。
-
-    否则关掉开关的用户又回到「这篇论文完全搜不到」的老问题。
-    """
-    user_id, headers = await _user(client, "abs-optout@example.com", index_on=False)
-    project_id, _ = await make_project_with_library(client, headers, name="abs-optout")
-    async with get_sessionmaker()() as session:
-        paper = await add_paper(
-            session,
-            project_id=uuid.UUID(project_id),
-            title="No Fulltext And Index Off",
-            abstract="Still searchable.",
-            doi="10.1/absoptout",
-        )
-        await session.commit()
-        paper_id = paper.id
-
-    await _run_enrich(paper_id, user_id=user_id)
-
-    async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, paper_id)
-        chunks = await _chunks(session, paper_id)
-    assert len(chunks) == 1 and chunks[0].source == "abstract"
-    assert paper.embedding is not None
-    assert chunks[0].embedding == pytest.approx(paper.embedding), "关了开关也得有摘要级索引"
-
-
 async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
     """整库重建时摘要块也不花嵌入调用：向量拷论文级向量，用 abstract_vectors_copied 计数。"""
     _, headers = await _user(client, "librebuild@example.com")
@@ -298,60 +265,6 @@ async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
 # ---- 1c. 论文级向量的管理员总闸（默认开） ----
 
 
-async def _set_paper_embedding(client, headers, enabled: bool):
-    resp = await client.put(
-        "/api/admin/settings/paper-embedding", json={"enabled": enabled}, headers=headers
-    )
-    assert resp.status_code == 200, resp.text
-    return resp.json()
-
-
-async def test_paper_embedding_switch_defaults_on(client):
-    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
-    resp = await client.get("/api/admin/settings/paper-embedding", headers=headers)
-    assert resp.status_code == 200
-    assert resp.json()["enabled"] is True
-
-
-async def test_admin_can_switch_off_paper_embedding(client, fake_redis):
-    """总闸关掉 → 论文级向量不建；摘要块也就没有向量可拷（如实反映，不报错）。"""
-    admin_token = await register_and_login(client)
-    headers = {"Authorization": f"Bearer {admin_token}"}
-    assert (await _set_paper_embedding(client, headers, False))["enabled"] is False
-
-    me = (await client.get("/api/users/me", headers=headers)).json()
-    user_id = uuid.UUID(me["id"])
-    project_id, _ = await make_project_with_library(client, headers, name="switch-off")
-    async with get_sessionmaker()() as session:
-        paper = await add_paper(
-            session,
-            project_id=uuid.UUID(project_id),
-            title="Admin Turned It Off",
-            abstract="No vectors for me.",
-            doi="10.1/switchoff",
-        )
-        await session.commit()
-        paper_id = paper.id
-
-    await _run_enrich(paper_id, user_id=user_id)
-
-    async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, paper_id)
-        chunks = await _chunks(session, paper_id)
-    assert paper.embedding is None, "总闸关了就不该建论文级向量"
-    assert len(chunks) == 1 and chunks[0].embedding is None  # 没有向量可拷
-
-    # 状态端点如实反映
-    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
-    body = resp.json()
-    assert body["paper_vector"]["built"] is False
-    assert body["chunk_vector"]["built"] is False
-    assert body["chunk_source"] == "abstract"
-
-
-# ---- 2. 分块向量的用户开关：默认开 ----
-
-
 async def _run_enrich(paper_id, *, user_id):
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, paper_id)
@@ -374,32 +287,35 @@ async def _seed_for_enrich(client, headers, *, name: str, email_key: str) -> uui
         return paper.id
 
 
-async def test_chunk_vectors_built_by_default(client, fake_redis):
-    """用户没碰过设置 → 开关默认开 → 块向量照建。"""
-    user_id, headers = await _user(client, "default-on@example.com")  # 不 PATCH 设置
-    paper_id = await _seed_for_enrich(client, headers, name="default-on", email_key="defon")
+async def test_vectors_are_always_built(client, fake_redis):
+    """论文级向量与块向量都没有开关，入库就一定建。
 
-    await _run_enrich(paper_id, user_id=user_id)
-
-    async with get_sessionmaker()() as session:
-        chunks = await _chunks(session, paper_id)
-    assert chunks
-    assert all(c.embedding is not None for c in chunks), "默认开：块向量必须建出来"
-
-
-async def test_chunk_vectors_skipped_when_user_opts_out(client, fake_redis):
-    """用户显式关掉 → 块行留着但不嵌；论文级向量不受这个开关影响，照常建。"""
-    user_id, headers = await _user(client, "opt-out@example.com", index_on=False)
-    paper_id = await _seed_for_enrich(client, headers, name="opt-out", email_key="optout")
+    这两者曾经各有一个开关（管理员的 paper_embedding_enabled、用户的
+    chat_fulltext_index），都已废除：库同步靠向量相似度粗排每日论文池，向量成了检索的
+    承重结构——关掉任何一个都会让同步瞎掉，而界面上只会显示「0 篇」，无从察觉。
+    """
+    user_id, headers = await _user(client, "always-on@example.com")
+    paper_id = await _seed_for_enrich(client, headers, name="always-on", email_key="alwayson")
 
     await _run_enrich(paper_id, user_id=user_id)
 
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, paper_id)
         chunks = await _chunks(session, paper_id)
+    assert paper.embedding is not None, "论文级向量必须建"
     assert chunks
-    assert all(c.embedding is None for c in chunks), "关掉开关就不该花嵌入调用"
-    assert paper.embedding is not None, "论文级向量不受全文索引开关管"
+    assert all(c.embedding is not None for c in chunks), "块向量必须建"
+
+
+async def test_no_endpoint_can_turn_paper_embedding_off(client):
+    """管理员总闸连同端点一起下线了——留着入口就等于留着把检索关瞎的办法。"""
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
+    assert (await client.get("/api/admin/settings/paper-embedding", headers=headers)).status_code == 404
+    assert (
+        await client.put(
+            "/api/admin/settings/paper-embedding", json={"enabled": False}, headers=headers
+        )
+    ).status_code == 404
 
 
 # ---- 3. 状态端点 ----

--- a/src/frontend/src/features/chat/BuildIndexButton.tsx
+++ b/src/frontend/src/features/chat/BuildIndexButton.tsx
@@ -1,13 +1,12 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { ApiError, api } from '../../lib/api';
+import { useMutation } from '@tanstack/react-query';
 import { tr } from '../../lib/i18n';
 import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
 
 /* ============================================================
-   建立全文索引按钮：仅当用户在设置里打开了为论文建立全文索引
-   开关时才显示。点击后异步为对应文献批建全文索引，让文献对话检索更准。
+   建立全文索引按钮：点击后异步为对应文献批建全文索引，让文献对话检索更准。
    相关研究对话 / 个人文献库对话共用，只换 build 回调。
+   （全文索引不再是可配置项——向量是检索的承重结构，所以按钮恒显示。）
    ============================================================ */
 
 /** 建索引端点返回：异步走 {queued, indexable, no_fulltext}，同步库场景走 {indexed, skipped}。 */
@@ -36,22 +35,15 @@ function buildResultToast(data: BuildIndexResult): string {
 }
 
 export function BuildIndexButton({ build }: { build: () => Promise<BuildIndexResult> }) {
-  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
-
   const mutation = useMutation({
     mutationFn: build,
     onSuccess: (data) => toast(buildResultToast(data), 'ok'),
     onError: (e) => {
-      if (e instanceof ApiError && e.status === 409) {
-        toast(tr('请先到设置里打开为论文建立全文索引', 'Enable the full-text index in Settings first'), 'error');
-        return;
-      }
       toast(`${tr('操作失败', 'Failed')}：${e instanceof Error ? e.message : String(e)}`, 'error');
     },
   });
 
   // 开关默认开，只有显式关掉才藏起按钮
-  if (me?.settings?.chat_fulltext_index === false) return null;
 
   return (
     <button

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -200,50 +200,6 @@ function PersonalTab() {
   );
 }
 
-// ---------------- 文献对话（全文索引开关） ----------------
-
-function ChatPrefsTab() {
-  const queryClient = useQueryClient();
-  const { data: me, isLoading, isError } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
-  const chatIndexMutation = useMutation({
-    mutationFn: (v: boolean) => api.updateMySettings({ chat_fulltext_index: v }),
-    onSuccess: (_, v) => {
-      toast(v ? tr('已开启全文索引', 'Full-text index enabled') : tr('已关闭全文索引', 'Full-text index disabled'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['me'] });
-    },
-    onError: (e) => toast(`${tr('保存失败', 'Save failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
-
-  if (isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
-  if (isError || !me) return <div className="empty">{tr('无法加载用户信息（后端不可用）', 'Failed to load user info (backend unavailable)')}</div>;
-
-  return (
-    <div className="card" style={{ maxWidth: 560, padding: '14px 18px' }}>
-      <div className="section-h">{tr('文献对话', 'Literature chat')}</div>
-      <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div id="pref-chat-fulltext" style={{ fontSize: 13, lineHeight: 1.4 }}>
-            {tr('让文献对话能引用论文正文', 'Let literature chat cite the paper body')}
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
-            {tr(
-              '关掉后对话仍能找到论文，但只匹配得到标题和摘要，引不出正文细节。会消耗你的模型额度抓取和嵌入全文。',
-              'When off, chat can still find papers but only matches their title and abstract, never details from the body. Uses your model quota to fetch and embed the full text.',
-            )}
-          </div>
-        </div>
-        <Switch
-          /* 默认开：没设置过等同开启（与后端 user_wants_fulltext_index 同一口径） */
-          checked={me.settings?.chat_fulltext_index !== false}
-          onChange={(v) => chatIndexMutation.mutate(v)}
-          disabled={chatIndexMutation.isPending}
-          aria-labelledby="pref-chat-fulltext"
-        />
-      </div>
-    </div>
-  );
-}
-
 // ---------------- 界面偏好（本地，存 localStorage） ----------------
 
 function PreferencesTab() {
@@ -1865,70 +1821,11 @@ function AffiliationModeSection() {
   );
 }
 
-/** 论文级向量的平台总闸（默认开）。管的是所有入库入口，不只是每日推送。 */
-function PaperEmbeddingSection() {
-  const queryClient = useQueryClient();
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['paper-embedding-enabled'],
-    queryFn: () => api.getPaperEmbeddingEnabled(),
-    retry: false,
-  });
-  const enabled = data?.enabled ?? true; // 默认开
-
-  const toggleMutation = useMutation({
-    mutationFn: (next: boolean) => api.setPaperEmbeddingEnabled(next),
-    onSuccess: (r) => {
-      toast(
-        r.enabled
-          ? tr('已开启：入库的论文都会建向量', 'Enabled — papers get vectors as they are added')
-          : tr('已关闭：新入库的论文不再建向量', 'Disabled — newly added papers get no vectors'),
-        'ok',
-      );
-      queryClient.setQueryData(['paper-embedding-enabled'], r);
-    },
-    onError: (e) => toast(`${tr('设置失败', 'Failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
-  });
-
-  return (
-    <div className="card card-pad" style={{ marginTop: 20 }}>
-      <div className="section-h" style={{ marginBottom: 6 }}>
-        <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
-        {tr('论文向量', 'Paper vectors')}
-      </div>
-      <div className="row" style={{ gap: 16, alignItems: 'center', marginTop: 10 }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div id="paper-embedding-toggle" style={{ fontSize: 13, lineHeight: 1.4 }}>
-            {tr('让论文能被语义搜索找到', 'Let papers be found by semantic search')}
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginTop: 2 }}>
-            {tr(
-              '索引标题、作者与摘要，所有入库方式都适用（建库、手动添加、每日推送）。这是全平台的总开关，关掉后语义搜索和文献对话都会失效，一般不用动。',
-              'Indexes title, authors and abstract, for every way papers are added (library builds, manual adds, daily papers). This is the platform-wide switch; when off, both semantic search and literature chat stop working. Rarely needs changing.',
-            )}
-          </div>
-        </div>
-        <Switch
-          checked={enabled}
-          onChange={(v) => toggleMutation.mutate(v)}
-          disabled={isLoading || isError || toggleMutation.isPending}
-          aria-labelledby="paper-embedding-toggle"
-        />
-      </div>
-      {isError && (
-        <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 10 }}>
-          {tr('无法加载该设置（后端不可用或无权限）', 'Failed to load this setting (backend unavailable or no permission)')}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function LlmTab() {
   return (
     <>
       <ProvidersSection adapter={adminLlmAdapter} />
       <RoutesSection adapter={adminLlmAdapter} />
-      <PaperEmbeddingSection />
       <AffiliationModeSection />
       <CallLogsSection />
     </>
@@ -2585,7 +2482,7 @@ function MyUsageTab() {
 // ---------------- 页面 ----------------
 
 /** 普通用户设置的标签页（管理员那组在 /admin，见 AdminSettingsPage）。 */
-type Tab = 'personal' | 'chat' | 'prefs' | 'bots' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
+type Tab = 'personal' | 'prefs' | 'bots' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
 
 /** 旧的 /settings?tab=xxx 深链里属于管理员组的值 → 统一改跳 /admin。 */
 export const ADMIN_TABS = ['llm', 'daily', 'usage', 'users', 'codes', 'feedback'] as const;
@@ -3590,7 +3487,7 @@ export function CodesTab() {
   );
 }
 
-const PERSONAL_TABS: Tab[] = ['personal', 'chat', 'prefs', 'bots', 'ssh', 'mymodels', 'myusage', 'mcp'];
+const PERSONAL_TABS: Tab[] = ['personal', 'prefs', 'bots', 'ssh', 'mymodels', 'myusage', 'mcp'];
 
 export function SettingsPage() {
   // 支持 /settings?tab=mcp 这类深链（如旧 /mcp-tools 路由的重定向）
@@ -3607,7 +3504,6 @@ export function SettingsPage() {
 
   const items: { v: Tab; label: string }[] = [
     { v: 'personal', label: tr('个人信息', 'Profile') },
-    { v: 'chat', label: tr('文献对话', 'Literature chat') },
     { v: 'prefs', label: tr('界面偏好', 'Interface') },
     { v: 'bots', label: tr('群机器人', 'Group bots') },
     { v: 'ssh', label: tr('SSH 凭据', 'SSH credentials') },
@@ -3623,7 +3519,6 @@ export function SettingsPage() {
         <Segmented options={items} value={tab} onChange={setTab} />
       </div>
       {tab === 'personal' && <PersonalTab />}
-      {tab === 'chat' && <ChatPrefsTab />}
       {tab === 'prefs' && <PreferencesTab />}
       {tab === 'bots' && <ChatBotsTab />}
       {tab === 'ssh' && <SshTab />}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -149,7 +149,6 @@ export interface UserRead {
   token_quota?: number | null;
   features?: Record<string, boolean> | null;
   /** 用户个人设置（后端可能暂未返回，可选） */
-  settings?: { chat_fulltext_index?: boolean } | null;
 }
 
 export interface UsageSummary {
@@ -562,10 +561,6 @@ export interface AffiliationModeRead {
   mode: AffiliationMode;
 }
 
-/** 平台是否给论文建论文级向量（管理员总闸，默认开）。 */
-export interface PaperEmbeddingSetting {
-  enabled: boolean;
-}
 /** 补建历史向量的结果计数。 */
 export interface DailyEmbedBackfillResult {
   embedded: number;
@@ -2643,10 +2638,6 @@ export const api = {
   updateMe(input: { display_name?: string }): Promise<UserRead> {
     return requestJson<UserRead>('/users/me', 'PATCH', input);
   },
-  /** 个人设置：文献对话是否为论文建立全文索引。 */
-  updateMySettings(input: { chat_fulltext_index: boolean }): Promise<UserRead> {
-    return requestJson<UserRead>('/users/me/settings', 'PATCH', input);
-  },
   setUsername(username: string): Promise<UserRead> {
     return requestJson<UserRead>('/users/me/username', 'PATCH', { username });
   },
@@ -3975,13 +3966,6 @@ export const api = {
   },
   setAffiliationMode(mode: AffiliationMode): Promise<AffiliationModeRead> {
     return requestJson<AffiliationModeRead>('/admin/settings/affiliation-mode', 'PUT', { mode });
-  },
-  /** 平台是否给论文建论文级向量（admin 总闸，默认开）。关掉后语义检索只能命中已有向量的论文。 */
-  getPaperEmbeddingEnabled(): Promise<PaperEmbeddingSetting> {
-    return request<PaperEmbeddingSetting>('/admin/settings/paper-embedding');
-  },
-  setPaperEmbeddingEnabled(enabled: boolean): Promise<PaperEmbeddingSetting> {
-    return requestJson<PaperEmbeddingSetting>('/admin/settings/paper-embedding', 'PUT', { enabled });
   },
   /** 实验室概况页的用量排行榜是否对普通成员可见（admin，默认开）。 */
   getLabLeaderboardEnabled(): Promise<LabLeaderboardSetting> {


### PR DESCRIPTION
## Why

Library sync now ranks the daily feed by embedding similarity to decide what a library takes in (#200). Vectors stopped being an optimisation the moment that landed — they are what makes sync work at all.

Two switches could turn them off:

| Switch | Scope | Effect when off |
|---|---|---|
| `paper_embedding_enabled` | admin, platform-wide | no paper-level vectors |
| `chat_fulltext_index` | per user | no chunk vectors |

Either one, flipped, leaves sync with **nothing to rank by**. And the failure is invisible: the run still reports `done`, the library still shows "0 new papers" — indistinguishable from a genuinely quiet day.

## What changed

Both switches are removed, along with everything behind them:

- `GET`/`PUT /admin/settings/paper-embedding` — gone
- `PATCH /users/me/settings` — gone; it existed for nothing but this one flag
- Settings UI: the admin **Paper vectors** card and the personal **Literature chat** tab, which had no other content

Stored values stay in the database and are simply never read. No migration.

**Behaviour now:** every paper gets a paper-level vector; every paper whose PDF was fetched gets chunk vectors. The abstract fallback chunk still copies the paper-level vector for free rather than paying to embed identical text twice.

## Note on recent history

This reverses two decisions from the last few days — the admin switch was deliberately kept ("默认打开") in #180, and #183 spent a whole PR propagating the full-text gate to all four bulk rebuild endpoints. Both were right when retrieval was a convenience. Once sync depends on vectors, an off switch is a way to blind the platform silently, so the switches go rather than the gating being tuned.

## Tests

The switch tests are gone, but the behaviour they protected is kept and **inverted where it still matters**: `test_chunk_vectors_skipped_when_user_opts_out` becomes `test_vectors_are_always_built`, asserting both vector kinds are present.

Two new tests pin the new invariant, because a leftover endpoint or gate would be a leftover way to blind retrieval:

- `test_no_endpoint_can_turn_paper_embedding_off` — the admin routes must 404
- `test_no_rebuild_endpoint_is_gated_anymore` — none of the four bulk rebuild endpoints may return 409

**816 passed**; `ruff check app`, `tsc --noEmit` and `vite build` all clean.