### PR TITLE
feat(llm): make reasoning effort configurable per stage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,3 +71,20 @@ Beyond the provider keys above, Polaris routes each research stage to a specific
 through a DB-backed routing table, editable from the admin panel. This lets cheap models handle
 scoring while strong models handle idea debate and paper drafting. All calls go through the single
 `app/core/llm/` abstraction; see [Architecture](architecture.md#the-llm-abstraction-and-model-routing).
+
+### Reasoning effort
+
+Each route can also carry a **reasoning effort** — how much the model is allowed to think before
+answering. Leave it unset (the default) and Polaris sends no effort parameter at all, so the model
+uses its own default; existing routes are unaffected. Levels are `none`, `minimal`, `low`, `medium`,
+`high`, `xhigh`, `max`, sent as `reasoning_effort` to OpenAI-compatible endpoints and as
+`output_config.effort` to the native Anthropic API.
+
+Support varies by model, and not every level is valid on every model that accepts the parameter —
+a model may accept `low` but reject `minimal`. Polaris does not keep a per-model whitelist. If the
+server rejects the request because of the effort parameter, the call is retried once without it and
+a warning is logged, so an effort set on a model that cannot use it degrades to the model's default
+instead of breaking the stage. Embedding and rerank routes have no effort setting.
+
+Lower effort on high-volume mechanical stages (relevance scoring, extraction) cuts both cost and
+latency; raise it on stages where correctness matters more than spend (self-verification, review).

--- a/src/backend/alembic/versions/510f6bde2233_model_route_effort.py
+++ b/src/backend/alembic/versions/510f6bde2233_model_route_effort.py
@@ -1,0 +1,26 @@
+"""add reasoning effort to model routes
+
+Revision ID: 510f6bde2233
+Revises: d4e8b71c2a90
+Create Date: 2026-07-28
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "510f6bde2233"
+down_revision: str | None = "d4e8b71c2a90"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # NULL = 不发送 reasoning_effort / output_config.effort，沿用模型默认档位
+    op.add_column("model_routes", sa.Column("effort", sa.String(length=16), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("model_routes", "effort")

--- a/src/backend/app/core/llm/anthropic.py
+++ b/src/backend/app/core/llm/anthropic.py
@@ -4,16 +4,26 @@
 """
 
 import json
+import logging
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
 import httpx
 
-from app.core.llm.base import CompletionResult, LLMProvider, Message
+from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message
+
+logger = logging.getLogger("polaris.llm")
 
 _API_URL = "https://api.anthropic.com/v1/messages"
 _API_VERSION = "2023-06-01"
 _DEFAULT_MAX_TOKENS = 4096
+# 老模型不认 output_config.effort（该参数只在 4.6+ 上 GA）；命中即去掉重试一次
+_EFFORT_REJECT_MARKERS = ("effort", "output_config")
+
+
+def _rejects_effort(body: str) -> bool:
+    low = body.lower()
+    return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
 
 
 class AnthropicProvider(LLMProvider):
@@ -39,7 +49,12 @@ class AnthropicProvider(LLMProvider):
         temperature: float | None,
         max_tokens: int | None,
         stream: bool,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> dict[str, Any]:
+        if images:
+            # TODO：Anthropic 原生 image block 支持
+            raise NotImplementedError("anthropic provider does not support image inputs yet")
         # Anthropic 的 system 提示是顶层参数，不在 messages 里
         system_parts = [m.content for m in messages if m.role == "system"]
         payload: dict[str, Any] = {
@@ -52,6 +67,9 @@ class AnthropicProvider(LLMProvider):
         }
         if system_parts:
             payload["system"] = "\n\n".join(system_parts)
+        if effort is not None:
+            # Anthropic 的推理档位在 output_config 里，不是顶层参数
+            payload["output_config"] = {"effort": effort}
         return payload
 
     async def complete(
@@ -62,16 +80,26 @@ class AnthropicProvider(LLMProvider):
         temperature: float | None = None,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> CompletionResult:
         # TODO(M2): 重试/限速/错误分类
-        if images:
-            # TODO：Anthropic 原生 image block 支持
-            raise NotImplementedError("anthropic provider does not support image inputs yet")
         resp = await self._client.post(
             _API_URL,
             headers=self._headers(),
-            json=self._payload(messages, model, temperature, max_tokens, stream=False),
+            json=self._payload(
+                messages, model, temperature, max_tokens, stream=False, images=images, effort=effort
+            ),
         )
+        if effort is not None and resp.status_code == 400 and _rejects_effort(resp.text):
+            # 该模型不认这个档位：去掉参数重试一次，别让配错档位打断整个环节
+            logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试", model, effort)
+            resp = await self._client.post(
+                _API_URL,
+                headers=self._headers(),
+                json=self._payload(
+                    messages, model, temperature, max_tokens, stream=False, images=images
+                ),
+            )
         resp.raise_for_status()
         data = resp.json()
         text = "".join(block.get("text", "") for block in data.get("content", []))
@@ -90,6 +118,7 @@ class AnthropicProvider(LLMProvider):
         temperature: float | None = None,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> AsyncIterator[str]:
         # TODO(M2): 处理 message_delta 中的 usage / stop_reason
         async with self._client.stream(
@@ -97,7 +126,7 @@ class AnthropicProvider(LLMProvider):
             _API_URL,
             headers=self._headers(),
             json=self._payload(
-                messages, model, temperature, max_tokens, stream=True, images=images
+                messages, model, temperature, max_tokens, stream=True, images=images, effort=effort
             ),
         ) as resp:
             resp.raise_for_status()

--- a/src/backend/app/core/llm/base.py
+++ b/src/backend/app/core/llm/base.py
@@ -7,8 +7,14 @@
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
+from typing import Literal
 
 Role = str  # "system" | "user" | "assistant"
+
+# 推理档位（思考深度）。取值取 OpenAI 与 Anthropic 两家的并集，具体模型支持哪些子集
+# 由服务端校验（各家对不支持的档位会返回明确的 400，比在这里硬编码白名单更靠谱）。
+EffortLevel = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+EFFORT_LEVELS: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 
 @dataclass(slots=True)
@@ -47,11 +53,13 @@ class LLMProvider(ABC):
         temperature: float = 0.7,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> CompletionResult:
         """一次性补全，返回完整结果。
 
         ``images``：可选 PNG 字节列表（多模态输入，附在最后一条 user 消息上）；
         不支持视觉输入的 provider 抛 NotImplementedError。
+        ``effort``：推理档位，None = 不发送该参数（用模型默认）。
         """
 
     @abstractmethod
@@ -63,11 +71,13 @@ class LLMProvider(ABC):
         temperature: float = 0.7,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> AsyncIterator[str]:
         """流式补全，逐段 yield 文本增量（用于 SSE 转发）。
 
         ``images``：可选多模态输入（同 complete）；支持多模态流式的 provider 附在
         最后一条 user 消息上，其余忽略。
+        ``effort``：推理档位，None = 不发送该参数（用模型默认）。
         """
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -11,7 +11,7 @@ import math
 import re
 from collections.abc import AsyncIterator, Sequence
 
-from app.core.llm.base import CompletionResult, LLMProvider, Message, RerankResult
+from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message, RerankResult
 
 # 与 navigator.py / sextant.py / actions_wiki.py / actions_ideas.py /
 # services/projects.py 的 prompt 对齐的识别标记
@@ -106,6 +106,7 @@ class FakeProvider(LLMProvider):
         temperature: float = 0.7,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,  # 确定性替身不做推理，收下即忽略
     ) -> CompletionResult:
         full_text = "\n".join(m.content for m in messages)
         if images and _PAPER_REVIEWER_MARKER in full_text:
@@ -166,6 +167,7 @@ class FakeProvider(LLMProvider):
         temperature: float = 0.7,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,  # 同 complete，忽略
     ) -> AsyncIterator[str]:
         # images 仅在提供时透传（兼容未声明该参数的测试 provider 替身）
         extra = {"images": images} if images else {}

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import httpx
 
-from app.core.llm.base import CompletionResult, LLMProvider, Message, RerankResult
+from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message, RerankResult
 
 logger = logging.getLogger("polaris.llm")
 
@@ -21,6 +21,21 @@ _BACKOFF_BASE_SECONDS = 3.0
 _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 # 部分中转强制流式：非流式请求返回 400 + 该提示，此时自动改走流式并聚合
 _FORCE_STREAM_MARKER = "stream must be set to true"
+# 模型/中转不认 reasoning_effort（非推理模型、老版中转、或该模型不支持所配档位）时的
+# 400 特征。命中即去掉该参数重试一次——配错档位不该让整个环节挂掉。
+_EFFORT_REJECT_MARKERS = ("reasoning_effort", "reasoning.effort", "effort")
+
+
+class _EffortUnsupported(RuntimeError):
+    """服务端明确因 reasoning_effort 拒绝了请求；调用方去掉该参数重试。"""
+
+
+def _rejects_effort(status_code: int, body: str) -> bool:
+    """400 且错误信息提到 effort —— 仅在本次确实发了该参数时才做此判断。"""
+    if status_code != 400:
+        return False
+    low = body.lower()
+    return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
 
 
 def _retry_delay(resp: httpx.Response, attempt: int) -> float:
@@ -84,6 +99,7 @@ class OpenAICompatProvider(LLMProvider):
         max_tokens: int | None,
         stream: bool,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> dict[str, Any]:
         payload_messages: list[dict[str, Any]] = [
             {"role": m.role, "content": m.content} for m in messages
@@ -108,6 +124,8 @@ class OpenAICompatProvider(LLMProvider):
         }
         if temperature is not None:  # 新款 Claude 等模型已弃用该参数，None 则不发送
             payload["temperature"] = temperature
+        if effort is not None:  # 推理模型的思考深度；非推理模型/中转不认时不要发
+            payload["reasoning_effort"] = effort
         # Anthropic 系模型（经 LiteLLM 等代理）强制要求 max_tokens，缺省给足额度
         payload["max_tokens"] = max_tokens if max_tokens is not None else 8192
         return payload
@@ -120,13 +138,34 @@ class OpenAICompatProvider(LLMProvider):
         temperature: float | None = None,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+    ) -> CompletionResult:
+        try:
+            return await self._complete_once(
+                messages, model, temperature, max_tokens, images, effort
+            )
+        except _EffortUnsupported as e:
+            # 该模型不吃这个档位：去掉参数重试一次，别让配错档位打断整个环节
+            logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
+            return await self._complete_once(messages, model, temperature, max_tokens, images, None)
+
+    async def _complete_once(
+        self,
+        messages: Sequence[Message],
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+        images: list[bytes] | None,
+        effort: EffortLevel | None,
     ) -> CompletionResult:
         payload = self._payload(
-            messages, model, temperature, max_tokens, stream=False, images=images
+            messages, model, temperature, max_tokens, stream=False, images=images, effort=effort
         )
         resp = await self._post_with_retry(f"{self._base_url}/chat/completions", payload)
         if resp.status_code >= 400:
             body = resp.text[:500]
+            if effort is not None and _rejects_effort(resp.status_code, body):
+                raise _EffortUnsupported(body)
             if resp.status_code == 400 and _FORCE_STREAM_MARKER in body.lower():
                 # 强制流式的中转：自动改用流式请求并聚合成非流式结果
                 logger.info(
@@ -154,7 +193,14 @@ class OpenAICompatProvider(LLMProvider):
             headers=self._headers(),
             json=payload,
         ) as resp:
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                # 流式响应体要显式读出来才能看到错误内容
+                body = (await resp.aread()).decode(errors="replace")[:500]
+                if payload.get("reasoning_effort") is not None and _rejects_effort(
+                    resp.status_code, body
+                ):
+                    raise _EffortUnsupported(body)
+                resp.raise_for_status()
             async for line in resp.aiter_lines():
                 if not line.startswith("data:"):
                     continue
@@ -195,18 +241,35 @@ class OpenAICompatProvider(LLMProvider):
         temperature: float | None = None,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> AsyncIterator[str]:
         # TODO(M2): usage 统计、错误恢复
         payload = self._payload(
-            messages, model, temperature, max_tokens, stream=True, images=images
+            messages, model, temperature, max_tokens, stream=True, images=images, effort=effort
         )
-        async for data in self._stream_chunks(payload):
-            choices = data.get("choices") or []
-            if not choices:
-                continue
-            delta = choices[0].get("delta") or {}
-            if content := delta.get("content"):
-                yield content
+        emitted = False
+        try:
+            async for data in self._stream_chunks(payload):
+                choices = data.get("choices") or []
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                if content := delta.get("content"):
+                    emitted = True
+                    yield content
+        except _EffortUnsupported as e:
+            # effort 是在首个 token 之前被拒的，重试不会重复输出；真吐过内容就不冒这个险
+            if emitted:
+                raise
+            logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
+            payload.pop("reasoning_effort", None)
+            async for data in self._stream_chunks(payload):
+                choices = data.get("choices") or []
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                if content := delta.get("content"):
+                    yield content
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:
         resp = await self._post_with_retry(

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -20,7 +20,7 @@ from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.core.llm import call_log
 from app.core.llm.anthropic import AnthropicProvider
-from app.core.llm.base import CompletionResult, LLMProvider, Message
+from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message
 from app.core.llm.fake import FakeProvider, estimate_tokens
 from app.core.llm.openai_compat import OpenAICompatProvider
 from app.core.security import decrypt_secret
@@ -79,6 +79,7 @@ class ResolvedRoute:
     model: str
     temperature: float | None
     provider_name: str = "fake"  # 管理端 provider 名称（调用日志用）
+    effort: EffortLevel | None = None  # 推理档位，None = 不发送该参数（用模型默认）
 
 
 # 无 DB 路由时的兜底：确定性 fake provider
@@ -89,6 +90,7 @@ _FALLBACK_ROUTE = ResolvedRoute(
     model="fake-default",
     temperature=0.0,
     provider_name="fake",
+    effort=None,
 )
 
 
@@ -149,6 +151,7 @@ class LLMRouter:
                     model=route.model,
                     temperature=route.temperature,
                     provider_name=provider.name,
+                    effort=route.effort,
                 )
         return routes
 
@@ -333,6 +336,7 @@ class LLMRouter:
         temperature: float | None = None,
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
         library_id: uuid.UUID | None = None,
@@ -340,6 +344,7 @@ class LLMRouter:
     ) -> CompletionResult:
         provider, route = await self.resolve(stage, user_id)
         temp = route.temperature if temperature is None else temperature
+        eff = route.effort if effort is None else effort
         log_enabled = await call_log.logging_enabled()
         started_at = time.monotonic()
         try:
@@ -347,11 +352,13 @@ class LLMRouter:
             # 多模态（带图，如 wiki 精读编译）也走流式——图片附在请求上、正文照常逐段吐。
             if self.event_bus is not None and voyage_id is not None and stage in STREAM_STAGES:
                 result = await self._stream_and_broadcast(
-                    stage, provider, route, messages, temp, max_tokens, voyage_id, images
+                    stage, provider, route, messages, temp, max_tokens, voyage_id, images, eff
                 )
             else:
-                # images 仅在提供时透传（兼容未声明该参数的 provider 子类/测试替身）
+                # images/effort 仅在提供时透传（兼容未声明这些参数的 provider 子类/测试替身）
                 extra: dict[str, Any] = {"images": images} if images else {}
+                if eff is not None:
+                    extra["effort"] = eff
                 result = await provider.complete(
                     messages, model=route.model, temperature=temp, max_tokens=max_tokens, **extra
                 )
@@ -411,6 +418,7 @@ class LLMRouter:
         max_tokens: int | None,
         voyage_id: uuid.UUID,
         images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
     ) -> CompletionResult:
         """流式补全并把 token 增量节流广播成 llm_delta 事件，返回拼好的完整结果。
 
@@ -435,12 +443,14 @@ class LLMRouter:
 
         await self.event_bus.publish_voyage_event(voyage_id, "llm_start", {"stage": stage})
         try:
+            stream_extra: dict[str, Any] = {"effort": effort} if effort is not None else {}
             async for chunk in provider.stream(
                 messages,
                 model=route.model,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 images=images,
+                **stream_extra,
             ):
                 collected.append(chunk)
                 buf.append(chunk)
@@ -613,6 +623,7 @@ class LLMRouter:
         *,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        effort: EffortLevel | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
         library_id: uuid.UUID | None = None,
@@ -622,12 +633,15 @@ class LLMRouter:
         log_enabled = await call_log.logging_enabled()
         started_at = time.monotonic()
         collected: list[str] = []
+        eff = route.effort if effort is None else effort
+        extra: dict[str, Any] = {"effort": eff} if eff is not None else {}
         try:
             async for chunk in provider.stream(
                 messages,
                 model=route.model,
                 temperature=route.temperature if temperature is None else temperature,
                 max_tokens=max_tokens,
+                **extra,
             ):
                 collected.append(chunk)
                 yield chunk

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -82,6 +82,9 @@ class ModelRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     model: Mapped[str] = mapped_column(String(255), nullable=False)
     temperature: Mapped[float | None] = mapped_column(Float, nullable=True)  # None=不传该参数
+    # 推理档位（none/minimal/low/medium/high/xhigh/max，见 core/llm/base.py）。
+    # None=不传该参数，用模型默认；具体模型支持哪些档位由服务端校验。
+    effort: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     provider: Mapped[LLMProviderConfig] = relationship(back_populates="routes")
 

--- a/src/backend/app/schemas/llm_admin.py
+++ b/src/backend/app/schemas/llm_admin.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.core.llm.base import EffortLevel
+
 ProviderKind = Literal["openai_compat", "anthropic", "fake"]
 
 
@@ -44,6 +46,9 @@ class RouteItem(BaseModel):
     provider_id: uuid.UUID
     model: str = Field(min_length=1, max_length=255)
     temperature: float | None = None  # None = 用 provider 默认
+    # 推理档位；None = 不发送该参数（用模型默认）。某个模型具体支持哪几档由服务端校验，
+    # 这里只挡明显非法的取值。
+    effort: EffortLevel | None = None
 
 
 TestCapability = Literal["chat", "embedding", "rerank"]

--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -157,6 +157,7 @@ async def replace_routes(
                 provider_id=item.provider_id,
                 model=item.model,
                 temperature=item.temperature,
+                effort=item.effort,
             )
         )
     await session.commit()

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -438,3 +438,39 @@ async def test_usage_aggregation(client):
     # user 过滤（无匹配 → 空）
     resp = await client.get(f"/api/admin/llm/usage?user_id={user_id}", headers=admin)
     assert resp.json() == []
+
+
+async def test_routes_effort_roundtrip_and_validation(client):
+    """effort 可存可读；未配为 None（= 不发该参数）；非法档位 422。"""
+    admin, _ = await _admin_and_member(client)
+    resp = await client.post(
+        "/api/admin/llm/providers", json={"name": "fake", "kind": "fake"}, headers=admin
+    )
+    provider_id = resp.json()["id"]
+
+    resp = await client.put(
+        "/api/admin/llm/routes",
+        json=[
+            {"stage": "default", "provider_id": provider_id, "model": "m"},
+            {"stage": "relevance", "provider_id": provider_id, "model": "m", "effort": "low"},
+            {"stage": "sextant", "provider_id": provider_id, "model": "m", "effort": "xhigh"},
+        ],
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    got = {r["stage"]: r for r in resp.json()}
+    assert got["default"]["effort"] is None
+    assert got["relevance"]["effort"] == "low"
+    assert got["sextant"]["effort"] == "xhigh"
+
+    # 读回来还在
+    got = {r["stage"]: r for r in (await client.get("/api/admin/llm/routes", headers=admin)).json()}
+    assert got["sextant"]["effort"] == "xhigh"
+
+    # 非法档位被 schema 挡掉
+    resp = await client.put(
+        "/api/admin/llm/routes",
+        json=[{"stage": "default", "provider_id": provider_id, "model": "m", "effort": "turbo"}],
+        headers=admin,
+    )
+    assert resp.status_code == 422

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -4,7 +4,8 @@ import pytest
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
-from app.core.llm.base import Message
+from app.core.llm.base import CompletionResult, Message
+from app.core.llm.fake import FakeProvider
 from app.core.llm.router import STAGES, STREAM_STAGES, LLMRouter
 from app.core.security import encrypt_secret
 from app.models.llm_config import LLMProviderConfig, LLMUsage, ModelRoute
@@ -151,3 +152,61 @@ def test_mask_api_key():
     assert mask_api_key("") == ""
     assert mask_api_key("short") == "***"
     assert mask_api_key("sk-abcdef1234567890abcd") == "sk-...abcd"
+
+
+async def test_route_effort_reaches_provider(app):
+    """路由表上配的 effort 透传给 provider；显式传参覆盖路由默认。"""
+    async with get_sessionmaker()() as session:
+        provider = LLMProviderConfig(name="fake-db", kind="fake", enabled=True)
+        session.add(provider)
+        await session.flush()
+        session.add(
+            ModelRoute(
+                stage="default", provider_id=provider.id, model="fake-db-model", effort="high"
+            )
+        )
+        await session.commit()
+
+    router = LLMRouter()
+    _, route = await router.resolve("default")
+    assert route.effort == "high"
+
+    seen: list[str | None] = []
+
+    class _Recorder(FakeProvider):
+        async def complete(self, messages, **kwargs):  # type: ignore[override]
+            seen.append(kwargs.get("effort"))
+            return await super().complete(messages, **kwargs)
+
+    router._providers[("fake", None, "fake-db-model")] = _Recorder()
+    router._provider_for = lambda r: router._providers[("fake", None, "fake-db-model")]  # type: ignore[assignment]
+
+    await router.complete("default", [Message(role="user", content="hi")])
+    await router.complete("default", [Message(role="user", content="hi")], effort="low")
+    assert seen == ["high", "low"]
+
+
+async def test_route_without_effort_sends_nothing(app):
+    """未配 effort 的路由不给 provider 传该参数（老 provider 替身也不会因此炸掉）。"""
+    async with get_sessionmaker()() as session:
+        provider = LLMProviderConfig(name="fake-db", kind="fake", enabled=True)
+        session.add(provider)
+        await session.flush()
+        session.add(ModelRoute(stage="default", provider_id=provider.id, model="fake-db-model"))
+        await session.commit()
+
+    seen_kwargs: list[dict] = []
+
+    class _LegacyProvider(FakeProvider):
+        """故意不声明 effort 形参：模拟未跟进新接口的 provider 子类/测试替身。"""
+
+        async def complete(self, messages, *, model, temperature=0.7, max_tokens=None):  # type: ignore[override]
+            seen_kwargs.append({"model": model, "temperature": temperature})
+            return CompletionResult(content="ok", model=model)
+
+    router = LLMRouter()
+    legacy = _LegacyProvider()
+    router._provider_for = lambda r: legacy  # type: ignore[assignment]
+    result = await router.complete("default", [Message(role="user", content="hi")])
+    assert result.content == "ok"
+    assert len(seen_kwargs) == 1

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "d4e8b71c2a90"  # 每用户群机器人 Webhook 配置
+HEAD_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
+CHAT_BOT_REVISION = "d4e8b71c2a90"  # 每用户群机器人 Webhook 配置
 CONCEPT_STATUS_REVISION = "a9f1c62b70d5"  # 概念转正门槛（concepts.status）
 INDEX_META_REVISION = "c4e7b2a91f38"  # 分段来源标记 + 向量构建元信息
 CONCEPTS_REVISION = "b6c2f81d4a09"  # 概念统一到论文级
@@ -98,6 +99,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "effort" in columns["model_routes"]  # 推理档位可配（NULL = 用模型默认）
     assert "embedding" in columns["papers"]  # sqlite 分支 JSON variant 列保留
     # 分段来源标记 + 两种向量各自的构建时间/模型名
     assert "source" in columns["paper_chunks"]
@@ -302,7 +304,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "last_delivered_at",
     } <= columns["chat_bot_configs"]
 
-    # 最新 revision 可往返：先退掉群机器人配置表。
+    # 最新 revision 可往返：先退掉推理档位列。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CHAT_BOT_REVISION
+    assert "effort" not in columns["model_routes"]
+    assert {"model", "temperature"} <= columns["model_routes"]  # 同表其余列不受影响
+    assert "chat_bot_configs" in columns["_tables"]  # 只退一步：群机器人表仍在
+
+    # 再退掉群机器人配置表。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == CONCEPT_STATUS_REVISION
@@ -390,6 +400,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "effort" in columns["model_routes"]
     assert "chat_bot_configs" in columns["_tables"]
     # 索引回归；个人标签表、回收站列与两张备份表也仍在
     assert "ix_llm_usage_created_at" in _index_names(db_path, "llm_usage")

--- a/src/backend/tests/test_openai_compat.py
+++ b/src/backend/tests/test_openai_compat.py
@@ -43,6 +43,16 @@ STREAM_CHUNKS = [
 
 FORCE_STREAM_400 = httpx.Response(400, json={"detail": "Stream must be set to true"})
 
+# 非流式成功响应（effort 透传用例不关心内容，只查 payload）
+NON_STREAM_OK = {
+    "id": "c2",
+    "model": "gpt-5.6-sol",
+    "choices": [
+        {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+}
+
 
 def _stream_response() -> httpx.Response:
     return httpx.Response(
@@ -133,4 +143,131 @@ async def test_stream_still_yields_deltas():
         c async for c in provider.stream([Message(role="user", content="hi")], model="gpt-5.6-sol")
     ]
     assert "".join(got) == "Hello world"
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_sent_as_reasoning_effort():
+    """route 上配了 effort 时，payload 带 reasoning_effort（codex-relay 等推理中转认这个字段）。"""
+    route = respx.post(CHAT_URL).mock(return_value=httpx.Response(200, json=NON_STREAM_OK))
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    await provider.complete(
+        [Message(role="user", content="hi")], model="gpt-5.6-sol", effort="xhigh"
+    )
+    body = json.loads(route.calls[0].request.content)
+    assert body["reasoning_effort"] == "xhigh"
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_omitted_when_unset():
+    """不配 effort 就完全不发该字段——非推理模型/老中转收到会 400。"""
+    route = respx.post(CHAT_URL).mock(return_value=httpx.Response(200, json=NON_STREAM_OK))
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    await provider.complete([Message(role="user", content="hi")], model="gpt-5.6-sol")
+    assert "reasoning_effort" not in json.loads(route.calls[0].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_survives_force_stream_fallback():
+    """强制流式的中转（codex-relay 就是）：回退重试时 effort 不能丢。"""
+    route = respx.post(CHAT_URL).mock(side_effect=[FORCE_STREAM_400, _stream_response()])
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    result = await provider.complete(
+        [Message(role="user", content="hi")], model="gpt-5.6-sol", effort="low"
+    )
+    assert result.content == "Hello world"
+    second = json.loads(route.calls[1].request.content)
+    assert second["stream"] is True
+    assert second["reasoning_effort"] == "low"
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_sent_on_stream():
+    route = respx.post(CHAT_URL).mock(return_value=_stream_response())
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    chunks = [
+        c
+        async for c in provider.stream(
+            [Message(role="user", content="hi")], model="gpt-5.6-sol", effort="high"
+        )
+    ]
+    assert "".join(chunks) == "Hello world"
+    assert json.loads(route.calls[0].request.content)["reasoning_effort"] == "high"
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_rejected_falls_back_without_it():
+    """模型不支持所配档位时去掉 effort 重试一次，环节不挂。"""
+    reject = httpx.Response(
+        400,
+        json={
+            "error": {
+                "message": "Unsupported value: 'xhigh' is not supported with the 'gpt-4o' model.",
+                "param": "reasoning.effort",
+            }
+        },
+    )
+    route = respx.post(CHAT_URL).mock(
+        side_effect=[reject, httpx.Response(200, json=NON_STREAM_OK)]
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    result = await provider.complete(
+        [Message(role="user", content="hi")], model="gpt-4o", effort="xhigh"
+    )
+    assert result.content == "ok"
+    assert route.call_count == 2
+    assert json.loads(route.calls[0].request.content)["reasoning_effort"] == "xhigh"
+    assert "reasoning_effort" not in json.loads(route.calls[1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_unrelated_400_is_not_swallowed_as_effort_problem():
+    """与 effort 无关的 400 照常抛错，不能被降级逻辑吞掉。"""
+    route = respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(400, json={"error": {"message": "model not found"}})
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    with pytest.raises(RuntimeError, match="model not found"):
+        await provider.complete(
+            [Message(role="user", content="hi")], model="nope", effort="high"
+        )
+    assert route.call_count == 1  # 没有重试
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_rejected_on_forced_stream_relay():
+    """强制流式 + 不支持该档位：先回退流式，再去掉 effort，最终仍拿到结果。"""
+    reject = httpx.Response(400, json={"error": {"message": "unsupported reasoning_effort"}})
+    route = respx.post(CHAT_URL).mock(
+        side_effect=[FORCE_STREAM_400, reject, FORCE_STREAM_400, _stream_response()]
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    result = await provider.complete(
+        [Message(role="user", content="hi")], model="gpt-5.6-sol", effort="max"
+    )
+    assert result.content == "Hello world"
+    assert "reasoning_effort" not in json.loads(route.calls[-1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_rejected_on_stream_retries_without_it():
+    reject = httpx.Response(400, json={"error": {"message": "unsupported reasoning_effort"}})
+    route = respx.post(CHAT_URL).mock(side_effect=[reject, _stream_response()])
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    chunks = [
+        c
+        async for c in provider.stream(
+            [Message(role="user", content="hi")], model="gpt-4o", effort="xhigh"
+        )
+    ]
+    assert "".join(chunks) == "Hello world"
+    assert route.call_count == 2
+    assert "reasoning_effort" not in json.loads(route.calls[1].request.content)
     await provider.aclose()

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -25,10 +25,12 @@ import {
   type AdminUserRead,
   type AffiliationMode,
   type ChatBotPlatform,
+  LLM_EFFORT_LEVELS,
   type EffectiveTestResult,
   type LlmCallLogRow,
   type LlmProviderInput,
   type LlmProviderKind,
+  type LlmEffort,
   type LlmProviderRead,
   type LlmRoute,
   type LlmSelfConfig,
@@ -1206,6 +1208,8 @@ interface RouteDraft {
   provider_id: string;
   model: string;
   temperature: string;
+  /** '' = 不发送该参数，用模型默认档位 */
+  effort: string;
 }
 
 // ---- 模型组合框：自由输入 + 候选下拉（面板视觉复用 components/ui/SelectMenu） ----
@@ -1317,6 +1321,7 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
         provider_id: r.provider_id,
         model: r.model,
         temperature: r.temperature === null || r.temperature === undefined ? '' : String(r.temperature),
+        effort: r.effort ?? '',
       };
     }
     setRows(next);
@@ -1334,6 +1339,7 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
           provider_id: r.provider_id,
           model: r.model.trim(),
           ...(t !== '' && Number.isFinite(Number(t)) ? { temperature: Number(t) } : {}),
+          ...(r.effort ? { effort: r.effort as LlmEffort } : {}),
         });
       }
       return adapter.putRoutes(routes);
@@ -1346,7 +1352,7 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
   });
 
   const defaultRow = rows['default'];
-  const emptyDraftRow: RouteDraft = { provider_id: '', model: '', temperature: '' };
+  const emptyDraftRow: RouteDraft = { provider_id: '', model: '', temperature: '', effort: '' };
 
   // 编辑「跟随默认」的行时，以 default 的值为底稿转成显式设置；
   // 能力型环节不跟随默认，底稿从空开始
@@ -1427,6 +1433,15 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
               <th style={{ width: 170 }}>provider</th>
               <th>model</th>
               <th style={{ width: 90 }}>temperature</th>
+              <th
+                style={{ width: 110 }}
+                title={tr(
+                  '思考深度。留空即不发送该参数，用模型自带的默认档位；模型不支持所选档位时会自动去掉该参数重试，不会让环节失败。',
+                  'How hard the model thinks. Leave empty to send nothing and use the model default; if the model rejects the level, the call is retried without it instead of failing.',
+                )}
+              >
+                effort
+              </th>
               <th style={{ width: 130 }}>{tr('模型状态', 'Model status')}</th>
             </tr>
           </thead>
@@ -1509,6 +1524,19 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
                       placeholder={tr('默认', 'default')}
                       inputMode="decimal"
                       onChange={(e) => setRow(stage, { temperature: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <SelectMenu
+                      style={{ height: 32 }}
+                      muted={follows}
+                      disabled={capability}
+                      value={capability ? '' : shown.effort}
+                      options={[
+                        { value: '', label: tr('模型默认', 'Model default') },
+                        ...LLM_EFFORT_LEVELS.map((e) => ({ value: e, label: e })),
+                      ]}
+                      onChange={(v) => setRow(stage, { effort: v })}
                     />
                   </td>
                   <td>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -499,11 +499,20 @@ export interface LlmProviderInput {
   models?: string[];
 }
 
+/** 推理档位；与后端 app/core/llm/base.py 的 EFFORT_LEVELS 对齐 */
+export type LlmEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export const LLM_EFFORT_LEVELS: LlmEffort[] = [
+  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max',
+];
+
 export interface LlmRoute {
   stage: string;
   provider_id: string;
   model: string;
   temperature?: number | null;
+  /** null / 缺省 = 不发送该参数，用模型默认档位 */
+  effort?: LlmEffort | null;
 }
 
 export type LlmTestCapability = 'chat' | 'embedding' | 'rerank';


### PR DESCRIPTION
Closes #204

## Background

Six stages in production run through codex-relay, all at whatever reasoning effort the relay defaults to, because Polaris has nowhere to set it.

I measured the relay first to confirm it actually honors the parameter rather than accepting and dropping it. Same problem, gpt-5.6-sol:

| effort | wall clock | completion tokens | answer |
| --- | --- | --- | --- |
| `low` | 16.0s | 656 | 738 |
| `xhigh` | 32.0s | 1273 | 738 |

It takes `reasoning_effort` on `chat/completions` and translates it to the upstream Responses API's `reasoning.effort` — the `"param": "reasoning.effort"` in its rejection message gives the translation away.

## What this does

Threads an effort level end to end: `base.py` interface → provider passthrough → `ModelRoute.effort` column → admin schema → a new column in the settings page.

The field name is vendor-specific: OpenAI-compatible endpoints get `reasoning_effort`, the native Anthropic API gets `output_config.effort`.

## Handling models that don't support it

This is the part worth reviewing. Support is uneven, and **models that accept the parameter don't all accept the same levels** — gpt-5.6-sol takes `low` but explicitly rejects `minimal`. A hardcoded per-model whitelist would rot, so this degrades at runtime instead:

- **Unset sends nothing.** The default is `None` and the field is absent from the payload entirely, so existing routes are byte-for-byte identical on the wire to before this change.
- **When the server rejects a request because of the parameter, retry once without it** and log a warning. A misconfigured level falls back to the model's own default rather than taking the stage down. This mirrors the forced-stream fallback already in the same file.
- The retry covers the forced-stream relay path — codex-relay is one of these, and its rejection surfaces on the streaming request rather than the first one.
- A 400 unrelated to effort still raises; the degradation path does not swallow it. There's a test pinning that.
- The streaming path only retries when nothing has been emitted yet, so it can't duplicate output.
- Embedding and rerank are capability stages with no reasoning effort; the column is disabled for them.

## Drive-by fix

`AnthropicProvider.stream()` was passing `images=` to a `_payload()` that didn't accept the parameter — a TypeError on any multimodal call. Fixed while changing that signature.

## Verification

- **Full backend suite green: 830 passed.** Worth noting this repo's CI runs only desktop and docker builds, not pytest, so there is no test safety net on the PR itself — this had to pass locally.
- 12 new cases: provider passthrough, rejection-triggered degradation, unrelated 400s not swallowed, degradation on the streaming path, routing table round-trip, invalid level rejected with 422.
- Migration exercised against a real Postgres over the full chain: after upgrade `effort` is a nullable varchar, downgrade drops it cleanly, and the head chains correctly onto `d4e8b71c2a90`.
- `test_migrations.py` updated to match. That file pins the expected head and walks the newest migrations back one step at a time, so every added migration has to be folded in; the round-trip now asserts `effort` disappears on downgrade, leaves the rest of the table alone, and comes back on upgrade.
- Rebased onto `origin/main` after #206 landed. That change carried no migration, so the `down_revision` and head assertions here still hold; the only overlapping file was `api.ts` and it rebased clean. Suite and typecheck re-run after the rebase.
- `ruff check` clean for new code (the 4 pre-existing findings on main are untouched); frontend `tsc --noEmit` and `vite build` both pass.

## Known limitation

The degradation is silent — a warning in the log and nothing else. An admin who sets an unsupported level gets no signal in the UI, and that stage quietly keeps running at the model default. Surfacing it properly means persisting a "last effort rejected" state on the route row and showing it in settings, which is its own change. For now the behavior is spelled out in the column header tooltip.

## Suggested follow-up after deploy

Try one notch down on `relevance` first — highest volume, simplest judgments, so the largest cost and latency win — and watch the token curve on the usage dashboard before extending it to `extract`. `sextant` is the one to move in the other direction.