### PR TITLE
fix(sync): make every library sync daily, and make the feed's health visible

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -30,12 +30,17 @@ logger = logging.getLogger(__name__)
 @register("daily.fetch")
 async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
-        categories, by_category = await daily_feed_service.fetch_new_by_category(session)
+        categories, by_category, statuses = await daily_feed_service.fetch_new_by_category(
+            session
+        )
 
-    per_category = {c: len(entries) for c, entries in by_category.items()}
-    fetched = sum(per_category.values())
-    for category, count in per_category.items():
-        await ctx.log(f"{category}：抓到 {count} 篇")
+    fetched = sum(s["count"] for s in statuses.values())
+    failed = [c for c, s in statuses.items() if s["status"] == "error"]
+    for category, state in statuses.items():
+        if state["status"] == "error":
+            await ctx.log(f"{category}：抓取失败 —— {state['detail']}", level="error")
+        else:
+            await ctx.log(f"{category}：抓到 {state['count']} 篇")
 
     # 条目原样带给下一步（daily.upsert）：重抓一次既多打一遍 arXiv，也可能拿到不同结果
     ctx.checkpoint["daily_entries"] = by_category
@@ -43,15 +48,20 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {
         "categories": categories,
         "fetched": fetched,
-        "per_category": per_category,
+        "per_category": statuses,
+        "failed_categories": failed,
     }
-    if categories and fetched == 0:
-        # 单个分类为空是正常的（周末/当天无公告），但全部分类都空基本只有一种解释：
-        # arXiv 抓不动了（客户端已把异常兜底成 []）。报错而不是假装成功。
+    if failed:
+        # **任一分类失败就报错**，不是「全都空才报」。部分失败下当天那个分类的论文会
+        # 永久缺失（RSS 只公告一次，每日池只留一周），而全实验室的文献库都靠这个池
+        # 供料——静默残缺比整体失败更危险。
         result["error"] = (
-            f"{len(categories)} 个订阅分类都没抓到新论文，"
-            "多半是 arXiv 暂时不可用或分类配置有误；稍后重试"
+            f"{len(failed)} 个分类抓取失败：{'、'.join(failed)}；"
+            "当天这些分类的新论文不会进池，请重试"
         )
+    elif categories and fetched == 0:
+        # 全部分类都抓成功但一篇没有：周末/节假日是正常的，仍提示一句便于对照
+        result["note"] = "所有订阅分类今天都没有新公告（周末或节假日时属正常）"
     return result
 
 

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
@@ -29,6 +29,7 @@ from app.models.base import utcnow
 from app.models.daily_feed import DailyFeedEntry
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, new_paper
+from app.models.voyage import VoyageStep
 from app.services.affiliations import (
     apply_author_affiliations,
     extract_author_affiliations_llm,
@@ -1092,7 +1093,21 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         # 水位线权威源在库（P8a）：写 library.ingest_state；起源课题 project.ingest_state
         # 不再是权威（overview「上次同步时间」读库）。
         state = dict((library.ingest_state if library else None) or {})
-        watermark = ctx.checkpoint.get("watermark_candidate") or state.get("watermark")
+        previous = state.get("watermark")
+
+        # 预算耗尽时引擎会把剩余步骤置 obsolete，再拿最后一个待办步骤当隐式收尾——
+        # 而本流水线的最后一步正是这里。那种情况下推进水位线等于「一篇没处理，却宣布
+        # 这段时间已经看过了」，下次同步会直接跳过这批论文。所以截断时保持原水位线。
+        truncated = (
+            await session.scalar(
+                select(func.count())
+                .select_from(VoyageStep)
+                .where(VoyageStep.run_id == ctx.run.id, VoyageStep.status == "obsolete")
+            )
+        ) or 0
+        watermark = previous if truncated else (
+            ctx.checkpoint.get("watermark_candidate") or previous
+        )
         finished_at = utcnow().isoformat()
         state["watermark"] = watermark
         state["last_run"] = {"voyage_id": str(ctx.run.id), "finished_at": finished_at}
@@ -1100,21 +1115,31 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
             library.ingest_state = state
 
         compiled_count = int(ctx.checkpoint.get("compiled_count") or 0)
+        message = (
+            f"文献调研被预算截断：本次编译 {compiled_count} 篇，水位线未推进"
+            if truncated
+            else f"文献调研完成：本次编译 {compiled_count} 篇 wiki 页"
+        )
         session.add(
             Activity(
                 project_id=ctx.run.project_id,
                 library_id=library.id if library is not None else None,
                 actor="agent:librarian",
                 kind="ingest.completed",
-                message=f"文献调研完成：本次编译 {compiled_count} 篇 wiki 页",
+                message=message,
                 payload={
                     "voyage_id": str(ctx.run.id),
                     "mode": _mode(ctx),
                     "compiled": compiled_count,
                     "watermark": watermark,
+                    "truncated": bool(truncated),
                 },
             )
         )
         await session.commit()
 
-    return {"watermark": watermark, "compiled": int(ctx.checkpoint.get("compiled_count") or 0)}
+    return {
+        "watermark": watermark,
+        "compiled": int(ctx.checkpoint.get("compiled_count") or 0),
+        "truncated": bool(truncated),
+    }

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -73,8 +73,15 @@ IDEA_KINDS = ("idea_forge", "idea_review", "idea_proposal")
 
 def wiki_plan(run: VoyageRun) -> list[dict[str, Any]]:
     """文献 ingest 固定七步计划（docs/api-m2.md §7）；knobs 从 checkpoint.params 读。"""
+    # 候选来源随模式而变：建库检索 arXiv 历史，增量只吃每日论文池（不碰 arXiv）。
+    # 步骤标题跟着变，否则任务详情页会把「从每日池筛选」写成「检索 arXiv」。
+    first = (
+        ("检索候选（arXiv）", "wiki.search_candidates", "候选论文已入库")
+        if run.kind == "wiki_bootstrap"
+        else ("从每日论文池筛选候选", "wiki.search_candidates", "候选论文已入库")
+    )
     steps = [
-        ("检索候选（arXiv）", "wiki.search_candidates", "候选论文已入库"),
+        first,
         ("参考文献扩展（Semantic Scholar）", "wiki.snowball", "参考文献扩展完成"),
         ("相关性打分（LLM）", "wiki.score_relevance", "候选论文已全部打分或排除"),
         ("下载 PDF + 抽全文", "wiki.fetch_extract", "top-N 论文全文就绪（失败降级摘要）"),
@@ -101,7 +108,7 @@ def daily_feed_plan(run: VoyageRun) -> list[dict[str, Any]]:
         ("抓取订阅分类的新论文", "daily.fetch", "订阅分类的当天新公告已抓到"),
         ("去重入池", "daily.upsert", "新论文已入池，多分类命中已合并"),
         ("清理过期推送", "daily.cleanup", "7 天外的推送与无人收藏的论文已清理"),
-        ("建立语义向量", "daily.embed", "开了自动建向量时，本次新论文已补上向量"),
+        ("建立语义向量", "daily.embed", "本次新论文已补上向量"),
     ]
     return [
         {

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -36,6 +36,7 @@ from app.schemas.daily import (
     DailyLikeState,
     DailyPage,
     DailyPaperDetail,
+    DailySyncStatus,
 )
 from app.schemas.paper import PaperChatRequest
 from app.services import citations as citations_service
@@ -293,6 +294,19 @@ async def collect(
         if task_id:
             tasks.append(DailyCollectTask(paper_id=paper_id, task_id=task_id))
     return DailyCollectResponse(results=results, tasks=tasks)
+
+
+@router.get("/sync-status", response_model=DailySyncStatus)
+async def get_sync_status(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailySyncStatus:
+    """每日论文池的同步状况（全员可读）。
+
+    池子是所有文献库的唯一供给，抓取失败会让全实验室当天颗粒无收——所以这个状态要
+    摆在每日页上，而不是只留在任务日志里。
+    """
+    return DailySyncStatus(**await daily_service.sync_status(session))
 
 
 @router.get("/categories", response_model=DailyCategoriesRead)

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -144,3 +144,16 @@ class DailyCategoriesRead(BaseModel):
 
 class DailyCategoriesUpdate(BaseModel):
     categories: list[str] = Field(min_length=1)
+
+
+class DailySyncStatus(BaseModel):
+    """每日论文池的同步健康状况（每日页顶部展示）。"""
+
+    latest_feed_date: str | None = None
+    stale: bool = False
+    last_run_id: str | None = None
+    last_run_status: str | None = None
+    last_run_at: str | None = None
+    # {分类: {count, status, detail}}
+    per_category: dict[str, Any] = Field(default_factory=dict)
+    failed_categories: list[str] = Field(default_factory=list)

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -34,7 +34,7 @@ from app.models.paper import Paper, PaperWiki, new_paper
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
-from app.models.voyage import TERMINAL_STATUSES, VoyageRun
+from app.models.voyage import TERMINAL_STATUSES, VoyageRun, VoyageStep
 from app.services import paper_wiki, user_library
 from app.services import projects as projects_service
 from app.services import topic_shelf as shelf_service
@@ -263,18 +263,37 @@ async def cleanup_expired(session: AsyncSession, *, today: dt.date | None = None
 
 async def fetch_new_by_category(
     session: AsyncSession,
-) -> tuple[list[str], dict[str, list[dict[str, Any]]]]:
-    """抓订阅分类的当天新公告；返回 (分类列表, {分类: 条目列表})。
+) -> tuple[list[str], dict[str, list[dict[str, Any]]], dict[str, dict[str, Any]]]:
+    """抓订阅分类的当天新公告；返回 (分类列表, {分类: 条目}, {分类: 状态})。
 
-    单个分类抓取/解析失败已在 arXiv 客户端内兜底成 []（不让整步崩），所以「某个分类
-    为空」是正常结果；调用方按「全部分类都空」判定这一步整体失败（见 daily.fetch）。
+    **逐个分类记录成败**：一个分类抓失败不影响其余分类，但必须如实报出来。以前的
+    做法是让客户端把异常吞成 []，于是「cs.AI 被限流」和「cs.AI 今天没有新论文」在
+    上层完全无法区分——只有全部分类都空时才会报错，部分失败则悄悄丢掉那一天那个
+    分类的全部论文。每日池是所有文献库的唯一供给，这种丢失是补不回来的。
+
+    状态取值：``ok``（抓到了，可能是 0 篇——周末/无公告是正常的）、``error``。
     """
     categories = await get_categories(session)
     client = get_arxiv_client()
     by_category: dict[str, list[dict[str, Any]]] = {}
+    statuses: dict[str, dict[str, Any]] = {}
     for category in categories:
-        by_category[category] = await client.fetch_new(category)
-    return categories, by_category
+        try:
+            entries = await client.fetch_new(category)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 — 单分类失败不打断其余分类
+            logger.warning("daily feed RSS failed for %s", category, exc_info=True)
+            by_category[category] = []
+            statuses[category] = {
+                "count": 0,
+                "status": "error",
+                "detail": f"{type(e).__name__}: {e}"[:200],
+            }
+            continue
+        by_category[category] = entries
+        statuses[category] = {"count": len(entries), "status": "ok", "detail": None}
+    return categories, by_category, statuses
 
 
 async def upsert_entries(
@@ -416,7 +435,7 @@ async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
     （app/agents/voyage/actions_daily.py），两条路径共用下面这几个步骤函数。
     """
     today = _today_utc()
-    categories, by_category = await fetch_new_by_category(session)
+    categories, by_category, _statuses = await fetch_new_by_category(session)
     fetched = sum(len(v) for v in by_category.values())
     stats = await upsert_entries(session, by_category=by_category, today=today)
     expired = await cleanup_expired(session, today=today)
@@ -1032,3 +1051,49 @@ async def collect_papers(
         )
 
     return results
+
+
+async def sync_status(session: AsyncSession) -> dict[str, Any]:
+    """每日论文池的同步健康状况（给用户看的，不是给运维看的）。
+
+    每日池现在是所有文献库的唯一供给：池子空了，全实验室当天什么都收不到。所以
+    「上次同步是什么时候、有没有分类失败、池子是不是过期了」必须摆在界面上，而不是
+    只躺在任务日志里等人去翻。
+
+    ``stale`` 的判据是「最新的一天不是今天也不是昨天」：arXiv 周末不公告，只差一天
+    属正常，差两天以上才值得提醒。
+    """
+    run = (
+        await session.execute(
+            select(VoyageRun)
+            .where(VoyageRun.kind == DAILY_FEED_VOYAGE_KIND)
+            .order_by(VoyageRun.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    per_category: dict[str, Any] = {}
+    failed: list[str] = []
+    if run is not None:
+        step = (
+            await session.execute(
+                select(VoyageStep)
+                .where(VoyageStep.run_id == run.id, VoyageStep.action == "daily.fetch")
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        obs = (step.observation if step is not None else None) or {}
+        per_category = obs.get("per_category") or {}
+        failed = list(obs.get("failed_categories") or [])
+
+    latest = await session.scalar(select(func.max(DailyFeedEntry.feed_date)))
+    today = dt.datetime.now(dt.UTC).date()
+    return {
+        "latest_feed_date": latest.isoformat() if latest else None,
+        "stale": bool(latest is None or (today - latest).days > 1),
+        "last_run_id": str(run.id) if run is not None else None,
+        "last_run_status": run.status if run is not None else None,
+        "last_run_at": run.created_at.isoformat() if run is not None else None,
+        "per_category": per_category,
+        "failed_categories": failed,
+    }

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -15,7 +15,7 @@ from app.models.project import Project
 from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
-from app.services.libraries import get_library_for_project, library_definition
+from app.services.libraries import get_library_for_project
 
 # 预算从 knobs 派生：每篇编译预留的 token 额度（打分+编译+概念定义+验证）
 _TOKENS_PER_PAPER = 20_000
@@ -207,17 +207,15 @@ DAILY_SYNC_UTC_MINUTE = 0
 
 
 def next_daily_sync_at(library: DirectionLibrary | None) -> datetime | None:
-    """下一次自动同步时间：cadence=daily 且已完成初始建库才有；否则 None。
+    """下一次自动同步时间：完成初始建库的库都有；未建库返回 None。
 
-    P8a：节奏/水位线权威源在库（library.definition.cadence / library.ingest_state）。
+    同步节奏不再可配置——每日论文池每天更新且只保留一周，任何比「每天」更稀疏的
+    节奏都意味着永久漏抓，而界面上只表现为「一直没有新论文」。
     """
-    from app.services.libraries import library_definition
-
     if library is None:
         return None
-    definition = library_definition(library)
     state = library.ingest_state or {}
-    if definition.get("cadence") != "daily" or not state.get("watermark"):
+    if not state.get("watermark"):
         return None
     now = datetime.now(UTC)
     candidate = now.replace(
@@ -295,24 +293,63 @@ async def library_ingest_state(
     }
 
 
-async def find_due_daily_projects(session: AsyncSession) -> list[Project]:
-    """每日增量对象：active、cadence=daily、已 bootstrap（有水位线）、无 ingest 在跑。"""
-    projects = (
-        (await session.execute(select(Project).where(Project.status == "active"))).scalars().all()
+# paused_error 不是终态，所以一个失败的任务会被互斥判定当成「还在跑」，把该库从每日
+# cron 里永久踢出去——生产上四个库就是这样静默停摆的。超过这个时长仍未被人处理的，
+# 由 cron 自动取消回收；留一天窗口是给人手动 resume 的机会。
+STALE_PAUSED_HOURS = 24
+
+
+async def reclaim_stale_paused_ingests(session: AsyncSession) -> list[uuid.UUID]:
+    """把长期无人处理的 paused_error 文献任务置为 cancelled，返回被回收的 id。
+
+    不这样做的话，一次瞬时故障（arXiv 429、LLM 超时）就等于让这个库再也不自动同步。
+    每日池只保留 7 天，那意味着永久漏抓，而界面上只表现为「一直没有新论文」。
+    """
+    cutoff = datetime.now(UTC) - timedelta(hours=STALE_PAUSED_HOURS)
+    runs = (
+        (
+            await session.execute(
+                select(VoyageRun).where(
+                    VoyageRun.kind.in_(WIKI_KINDS),
+                    VoyageRun.status == "paused_error",
+                    VoyageRun.updated_at < cutoff,
+                )
+            )
+        )
+        .scalars()
+        .all()
     )
-    due: list[Project] = []
-    for project in projects:
-        # P8a：节奏/水位线读起源库（project.definition 不再是权威源）
-        library = await get_library_for_project(session, project.id)
-        if library is None:
-            continue
-        definition = library_definition(library)
+    for run in runs:
+        run.status = "cancelled"
+    if runs:
+        await session.commit()
+    return [run.id for run in runs]
+
+
+async def find_due_daily_libraries(session: AsyncSession) -> list[DirectionLibrary]:
+    """每日增量的对象，**直接按文献库选**：active、已 bootstrap、无任务在跑。
+
+    以前是遍历 Project 再找库，于是 ``project_id`` 为空的独立库一个都进不来——生产上
+    11 个活跃库里有 6 个是独立库，全靠人工点击才会同步。另外那条路径也没检查库的
+    ``status``，pending/rejected 但留有历史水位线的库照样会被 cron 拉起来。
+    """
+    libraries = (
+        (
+            await session.execute(
+                select(DirectionLibrary).where(DirectionLibrary.status == "active")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    due: list[DirectionLibrary] = []
+    for library in libraries:
         state = library.ingest_state or {}
-        if definition.get("cadence") != "daily" or not state.get("watermark"):
+        if not state.get("watermark"):
             continue
-        # 互斥以库为准（库任务不写 project_id）——按课题查会漏掉在跑的任务，
-        # cron 会重复启动
         if await find_running_ingest_for_library(session, library.id) is not None:
             continue
-        due.append(project)
+        due.append(library)
     return due
+
+

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -345,23 +345,19 @@ class ArxivClient:
 
         只返回 announce_type ∈ {new, cross} 的条目（replace/replace-cross 是旧论文更新，
         已在解析时剔除）；字段与 ``search`` 返回的 entry 对齐，便于复用入库逻辑。
-        网络/解析失败一律记 warning 并返回 []（不能让整步崩），且不写缓存以便下次重试。
-        限流已在 :meth:`_request` 里重试过，走到这里的失败是真失败。
 
-        .. warning::
-           返回 [] 把「限流」和「今天确实没有新论文」压成了同一个结果，调用方无法区分。
-           库同步改为消费每日池之后，这个静默失败会放大成「全实验室当天颗粒无收」——
-           待办：改成带状态的返回值，见方案 A3。
+        **失败原样上抛**（限流已在 :meth:`_request` 里重试过，走到这里是真失败）。
+        这里曾经把任何异常吞成 []，于是「被限流」和「今天确实没有新论文」变成同一个
+        结果，谁都分不出来。每日池是所有文献库的唯一供给，一次静默的空池等于全实验室
+        当天颗粒无收却无人知晓——由调用方按分类记录成败，见
+        :func:`app.services.daily_feed.fetch_new_by_category`。
+        失败不写缓存，下次重试。
         """
         key = cache_key("arxiv", "rss_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
             return cached
-        try:
-            resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
-            entries = _parse_rss(resp.text)
-        except Exception:  # noqa: BLE001 — 新鲜源尽力而为；CancelledError 是 BaseException 不在此
-            logger.warning("arxiv RSS fetch/parse failed for %s", category, exc_info=True)
-            return []
+        resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
+        entries = _parse_rss(resp.text)
         await self._rss_cache.set(key, entries)
         return entries
 

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -605,7 +605,12 @@ async def test_daily_actions_observation_shapes(client, monkeypatch):
     obs = await get_action("daily.fetch")(ctx, {})
     assert obs["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
     assert obs["fetched"] == 3
-    assert obs["per_category"] == {"cs.AI": 2, "cs.CL": 1, "cs.CV": 0}
+    assert obs["per_category"] == {
+        "cs.AI": {"count": 2, "status": "ok", "detail": None},
+        "cs.CL": {"count": 1, "status": "ok", "detail": None},
+        "cs.CV": {"count": 0, "status": "ok", "detail": None},
+    }
+    assert obs["failed_categories"] == []
     assert "error" not in obs
     assert ctx.checkpoint["daily_entries"]  # 条目交给下一步
 
@@ -682,8 +687,42 @@ async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
     assert resp.json()["total"] == 1
 
 
-async def test_daily_fetch_reports_error_when_every_category_is_empty(client, monkeypatch):
-    """全分类颗粒无收 = 抓取多半挂了（客户端把异常兜底成 []）→ 这步必须失败。"""
+async def test_daily_fetch_fails_when_any_category_errors(client, monkeypatch):
+    """**任一分类抓失败就报错**，不是「全都空才报」。
+
+    部分失败下当天那个分类的论文会永久缺失（RSS 只公告一次、每日池只留一周），而全
+    实验室的文献库都靠这个池供料——静默残缺比整体失败更危险。
+    """
+    from app.agents.voyage.actions import get_action
+    from app.agents.voyage.checks import run_deterministic_checks
+    from app.services import daily_feed
+
+    class _PartlyBroken:
+        async def fetch_new(self, category: str):
+            if category == "cs.AI":
+                raise RuntimeError("429 Too Many Requests")
+            return [_rss_entry("2607.00099", "Fine")]
+
+    await register_and_login(client)
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _PartlyBroken())
+
+    ctx = _action_ctx()
+    obs = await get_action("daily.fetch")(ctx, {})
+    assert obs["failed_categories"] == ["cs.AI"]
+    assert obs["per_category"]["cs.AI"]["status"] == "error"
+    assert "429" in obs["per_category"]["cs.AI"]["detail"]
+    # 其余分类照常抓到，不受影响
+    assert obs["per_category"]["cs.CL"]["status"] == "ok"
+    assert obs["error"]
+
+    verdict, _ = run_deterministic_checks(
+        [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
+    )
+    assert verdict is not None and verdict["passed"] is False
+
+
+async def test_daily_fetch_notes_but_does_not_fail_on_a_quiet_day(client, monkeypatch):
+    """全部分类都抓成功但一篇没有：周末/节假日属正常，给提示而不是报错。"""
     from app.agents.voyage.actions import get_action
     from app.agents.voyage.checks import run_deterministic_checks
     from app.services import daily_feed
@@ -694,9 +733,58 @@ async def test_daily_fetch_reports_error_when_every_category_is_empty(client, mo
     ctx = _action_ctx()
     obs = await get_action("daily.fetch")(ctx, {})
     assert obs["fetched"] == 0
-    assert obs["error"]
-    # no_error 校验会判失败 → 任务进 paused_error（列表红色、可看日志、可重试）
+    assert obs["failed_categories"] == []
+    assert "error" not in obs
+    assert obs["note"]
+
     verdict, _ = run_deterministic_checks(
         [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
     )
-    assert verdict is not None and verdict["passed"] is False
+    assert verdict is None or verdict["passed"] is True
+
+
+
+
+async def test_sync_status_reports_failed_categories(client, monkeypatch):
+    """同步状况要能把「某分类抓失败」摆到界面上，而不是只留在任务日志里。"""
+    from app.core.db import get_sessionmaker
+    from app.models.voyage import VoyageRun, VoyageStep
+    from app.services import daily_feed
+
+    await register_and_login(client)
+
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(kind="daily_feed_sync", status="paused_error", goal="每日抓取")
+        session.add(run)
+        await session.flush()
+        session.add(
+            VoyageStep(
+                run_id=run.id,
+                seq=0,
+                title="抓取",
+                action="daily.fetch",
+                status="failed",
+                observation={
+                    "per_category": {
+                        "cs.AI": {"count": 0, "status": "error", "detail": "429"},
+                        "cs.CL": {"count": 12, "status": "ok", "detail": None},
+                    },
+                    "failed_categories": ["cs.AI"],
+                },
+            )
+        )
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        status = await daily_feed.sync_status(session)
+    assert status["failed_categories"] == ["cs.AI"]
+    assert status["last_run_status"] == "paused_error"
+    assert status["per_category"]["cs.CL"]["count"] == 12
+    assert status["stale"] is True  # 池子里一条 entry 都没有
+
+    resp = await client.get(
+        "/api/daily/sync-status",
+        headers={"Authorization": f"Bearer {await register_and_login(client, email='v@e.com')}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["failed_categories"] == ["cs.AI"]

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -169,13 +169,19 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
 
 
 @respx.mock
-async def test_arxiv_fetch_new_network_error_returns_empty(cache_redis):
+async def test_arxiv_fetch_new_raises_after_exhausted_retries(cache_redis):
+    """RSS 失败原样上抛，**不再吞成 []**。
+
+    吞掉的话「被限流」和「今天确实没有新论文」就成了同一个结果，而每日池是所有
+    文献库的唯一供给——静默的空池等于全实验室当天颗粒无收却无人知晓。
+    """
     route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/.*").mock(
         return_value=httpx.Response(503)
     )
     client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0, max_retries=2)
-    assert await client.fetch_new("cs.CL") == []  # 失败容错，不抛
-    assert route.call_count == 2  # 503 会重试，耗尽后才吞成 []
+    with pytest.raises(ArxivRateLimitedError):
+        await client.fetch_new("cs.CL")
+    assert route.call_count == 2
     await client.aclose()
 
 

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -794,25 +794,60 @@ async def test_unlimited_bootstrap_uncapped(client, queue_stub, wiki_mocks_big):
         assert compiled == total  # 全部编译落库，无一截断
 
 
-async def test_daily_cron_project_selection(client, queue_stub, wiki_mocks):
-    """cadence=daily 且已 bootstrap（有水位线）的项目才进入每日增量。"""
+async def test_project_backed_library_is_due_for_daily_cron(client, queue_stub, wiki_mocks):
+    """有起源课题的库也走同一条按库选表的路径；未建库（无水位线）时不选。
+
+    同步节奏不再参与判断——每日论文池只留一周，比「每天」更稀疏的节奏必然漏抓。
+    """
     project_id, headers = await _setup_project(client)
     async with get_sessionmaker()() as session:
-        due = await ingest_service.find_due_daily_projects(session)
-        assert due == []  # 尚未 bootstrap（无水位线）
+        assert await ingest_service.find_due_daily_libraries(session) == []  # 尚未 bootstrap
 
     resp = await client.post(
         f"/api/projects/{project_id}/ingest",
         json={"mode": "bootstrap", "knobs": KNOBS},
         headers=headers,
     )
-    run_id = uuid.UUID(resp.json()["id"])
     engine, _ = _make_engine()
-    await engine.run(run_id)
+    await engine.run(uuid.UUID(resp.json()["id"]))
 
     async with get_sessionmaker()() as session:
-        due = await ingest_service.find_due_daily_projects(session)
-        assert [p.id for p in due] == [uuid.UUID(project_id)]
+        due = await ingest_service.find_due_daily_libraries(session)
+        assert len(due) == 1
+        assert due[0].project_id == uuid.UUID(project_id)
+
+
+async def test_cadence_no_longer_excludes_a_library(client, queue_stub, wiki_mocks):
+    """存量库里遗留的 cadence=weekly/manual 不再让它掉出每日同步。
+
+    这些库以前压根没有 cron，只能人工点；配上每日池 7 天保留期就是永久漏抓。
+    """
+    token = await register_and_login(client, email="legacy-cadence@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("legacy-cadence@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-周更")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    # 模拟存量数据：definition 里还留着 weekly
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        library.cadence = "weekly"
+        library.definition = {**(library.definition or {}), "cadence": "weekly"}
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        due = await ingest_service.find_due_daily_libraries(session)
+        assert [str(lib.id) for lib in due] == [library_id]
+        # 「下次自动同步」也不再因为 cadence 而显示为空
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert ingest_service.next_daily_sync_at(library) is not None
 
 
 # ---- P9a：任务系统库化（VoyageRun 可挂方向库，独立库可直接触发抓取） ----
@@ -1006,3 +1041,248 @@ async def test_project_ingest_run_carries_library_id(client, queue_stub, wiki_mo
         run = await session.get(VoyageRun, uuid.UUID(voyage["id"]))
         assert run.library_id == library.id
         assert run.project_id is None
+
+
+# ---- 每日 cron 的可达性与健壮性 ----
+
+
+async def test_standalone_library_is_due_for_daily_cron(client, queue_stub, wiki_mocks):
+    """独立库（project_id=NULL）也要进每日 cron。
+
+    以前 cron 遍历的是 Project 再反查库，独立库一个都进不来——生产上 11 个活跃库里
+    有 6 个是独立库，全靠人工点击才会同步。每日池只留 7 天，漏点就是永久漏抓。
+    """
+    token = await register_and_login(client, email="due-standalone@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("due-standalone@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-cron")
+
+    async with get_sessionmaker()() as session:
+        assert await ingest_service.find_due_daily_libraries(session) == []  # 还没建库
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        due = await ingest_service.find_due_daily_libraries(session)
+        assert [str(lib.id) for lib in due] == [library_id]
+
+
+async def test_non_active_library_is_not_due(client, queue_stub, wiki_mocks):
+    """库 status 不是 active 就不该被 cron 拉起来——老的按课题选表压根没查这个字段。"""
+    token = await register_and_login(client, email="due-inactive@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("due-inactive@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-停用")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        library.status = "rejected"
+        await session.commit()
+        assert await ingest_service.find_due_daily_libraries(session) == []
+
+
+async def test_stale_paused_run_is_reclaimed_and_unblocks_the_library(
+    client, queue_stub, wiki_mocks
+):
+    """卡了一天的 paused_error 由 cron 回收，该库随即恢复可同步。
+
+    paused_error 不在 TERMINAL_STATUSES 里，互斥判定把它当「还在跑」，于是一次瞬时
+    故障（arXiv 429、LLM 超时）就让这个库**永久**退出每日同步。生产上四个库正是如此。
+    """
+    import datetime as dt
+
+    token = await register_and_login(client, email="stale-paused@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("stale-paused@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-卡住")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    # 造一个一天前就卡住的增量任务
+    async with get_sessionmaker()() as session:
+        stale = VoyageRun(
+            kind="wiki_ingest",
+            status="paused_error",
+            library_id=uuid.UUID(library_id),
+            goal="卡住的同步",
+        )
+        session.add(stale)
+        await session.flush()
+        stale.updated_at = dt.datetime.now(dt.UTC) - dt.timedelta(hours=48)
+        await session.commit()
+        stale_id = stale.id
+
+    async with get_sessionmaker()() as session:
+        assert await ingest_service.find_due_daily_libraries(session) == [], "卡住时不该被选中"
+
+    async with get_sessionmaker()() as session:
+        reclaimed = await ingest_service.reclaim_stale_paused_ingests(session)
+        assert reclaimed == [stale_id]
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, stale_id)
+        assert run.status == "cancelled"
+        due = await ingest_service.find_due_daily_libraries(session)
+        assert [str(lib.id) for lib in due] == [library_id], "回收后该库应恢复可同步"
+
+
+async def test_recent_paused_run_is_left_alone(client, queue_stub, wiki_mocks):
+    """刚失败的任务不回收——留一天窗口给人手动 resume。"""
+    token = await register_and_login(client, email="fresh-paused@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("fresh-paused@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-刚卡住")
+
+    async with get_sessionmaker()() as session:
+        fresh = VoyageRun(
+            kind="wiki_ingest",
+            status="paused_error",
+            library_id=uuid.UUID(library_id),
+            goal="刚失败",
+        )
+        session.add(fresh)
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        assert await ingest_service.reclaim_stale_paused_ingests(session) == []
+
+
+async def test_over_budget_library_does_not_stop_the_others(client, queue_stub, wiki_mocks):
+    """一个库超预算不能拖垮当天其余的库。
+
+    老写法只捕获 IngestConflictError，LibraryBudgetExhaustedError 会穿透整个循环，
+    排在后面的库当天全都不同步，而且只在 arq 日志里留个异常，界面上完全无感。
+    """
+    from worker.tasks import daily_wiki_ingest
+
+    token = await register_and_login(client, email="budget-cron@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("budget-cron@example.com")
+
+    lib_ids = []
+    for name in ("独立库-超预算", "独立库-正常"):
+        lib_id = await _create_standalone_library(client, headers, name=name)
+        resp = await client.post(
+            f"/api/libraries/{lib_id}/ingest/run",
+            json={"mode": "bootstrap", "knobs": KNOBS},
+            headers=headers,
+        )
+        engine, _ = _make_engine()
+        await engine.run(uuid.UUID(resp.json()["id"]))
+        lib_ids.append(lib_id)
+    broke_id, healthy_id = lib_ids
+
+    # 第一个库月度预算压到 1 token —— bootstrap 已经用掉不止这些，必然耗尽
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(broke_id))
+        library.monthly_budget = 1
+        await session.commit()
+
+    class _Redis:
+        def __init__(self) -> None:
+            self.jobs: list[tuple] = []
+
+        async def enqueue_job(self, name, *args, **kwargs):
+            self.jobs.append((name, args))
+
+    redis = _Redis()
+    enqueued = await daily_wiki_ingest({"redis": redis})
+
+    # 超预算的那个被跳过，正常的那个照常入队
+    async with get_sessionmaker()() as session:
+        runs = {
+            str(r.library_id): r
+            for r in (
+                await session.execute(
+                    select(VoyageRun).where(VoyageRun.id.in_([uuid.UUID(i) for i in enqueued]))
+                )
+            )
+            .scalars()
+            .all()
+        }
+    assert healthy_id in runs, "正常的库必须仍被入队"
+    assert broke_id not in runs
+    assert len(redis.jobs) == len(enqueued) == 1
+
+
+async def test_truncated_run_does_not_advance_the_watermark(client, queue_stub, wiki_mocks):
+    """被预算截断的运行不推进水位线。
+
+    预算是在**步骤之间**检查的：打分跑完把预算烧光，引擎就把剩余步骤置 obsolete，
+    再拿最后一个待办步骤当隐式收尾——而本流水线的最后一步正是 update_watermark。
+    推进水位线等于「一篇没处理，却宣布这段时间已经看过了」，下次同步直接跳过这批论文。
+    """
+    from app.agents.voyage.actions import ActionContext
+    from app.agents.voyage.actions_wiki import update_watermark
+    from app.models.voyage import VoyageStep
+
+    token = await register_and_login(client, email="truncated@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("truncated@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-截断")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        original = library.ingest_state["watermark"]
+        assert original
+
+        # 造一个被预算截断的增量运行：有步骤被置 obsolete
+        run = VoyageRun(
+            kind="wiki_ingest",
+            status="executing",
+            library_id=uuid.UUID(library_id),
+            goal="截断的同步",
+        )
+        session.add(run)
+        await session.flush()
+        session.add(
+            VoyageStep(
+                run_id=run.id, action="wiki.compile", title="编译", status="obsolete", seq=0
+            )
+        )
+        await session.commit()
+        run_id = run.id
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        ctx = ActionContext(
+            run=run,
+            llm=LLMRouter(),
+            checkpoint={"watermark_candidate": "2099-01-01T00:00:00+00:00"},
+        )
+        result = await update_watermark(ctx, {})
+
+    assert result["truncated"] is True
+    assert result["watermark"] == original, "截断的运行不该推进水位线"
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert library.ingest_state["watermark"] == original

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -11,6 +11,7 @@
   评审员×3/聚合在 actions_review + services/paper_review 内部）
 """
 
+import logging
 import uuid
 from typing import Any
 
@@ -18,10 +19,12 @@ from app.agents.voyage import VoyageEngine
 from app.core.db import get_sessionmaker
 from app.core.events import EventBus
 from app.core.redis import get_redis
+from app.models.project import Project
 from app.schemas.ingest import IngestKnobs
 from app.services import ingest as ingest_service
-from app.services import libraries as libraries_service
 from app.services import publications as publications_service
+
+logger = logging.getLogger(__name__)
 
 
 async def ping_task(ctx: dict[str, Any], message: str = "ping") -> str:
@@ -65,17 +68,30 @@ async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
 
 
 async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
-    """每日 03:00 cron：对 cadence=daily 且已 bootstrap（有水位线）的项目入队增量 ingest。
+    """每日 03:00 cron：给 cadence=daily 且已 bootstrap 的**文献库**入队增量 ingest。
+
+    按库选而不是按课题选：独立库（project_id 为空）在按课题遍历的老写法里一个都进不来。
+
+    每个库单独兜异常。以前只捕获 IngestConflictError，于是一个库超月度预算抛
+    LibraryBudgetExhaustedError 就会打断整个循环，**排在它后面的库当天全都不同步**，
+    而且只在 arq 日志里留个异常，界面上完全无感。
 
     返回本次入队的 voyage id 列表（arq 结果可查）。
     """
     enqueued: list[str] = []
     async with get_sessionmaker()() as session:
-        projects = await ingest_service.find_due_daily_projects(session)
-        for project in projects:
-            library = await libraries_service.get_library_for_project(session, project.id)
-            if library is None:
-                continue  # 无语料库（理论上 find_due 已过滤，双保险）
+        # 先回收长期卡住的 paused_error：它们会把所在库一直挡在互斥判定外面
+        reclaimed = await ingest_service.reclaim_stale_paused_ingests(session)
+        if reclaimed:
+            logger.warning("reclaimed %d stale paused ingest run(s)", len(reclaimed))
+
+        libraries = await ingest_service.find_due_daily_libraries(session)
+        for library in libraries:
+            project = (
+                await session.get(Project, library.project_id)
+                if library.project_id is not None
+                else None
+            )
             try:
                 run = await ingest_service.create_ingest_voyage(
                     session,
@@ -87,6 +103,13 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
                 )
             except ingest_service.IngestConflictError:
                 continue  # 并发保护：查表与建 run 之间有人手动触发
+            except ingest_service.LibraryBudgetExhaustedError:
+                logger.warning("daily ingest skipped, budget exhausted: %s", library.id)
+                continue
+            except Exception:  # noqa: BLE001 — 单个库出问题不能拖垮当天其余的库
+                logger.exception("daily ingest failed to start for library %s", library.id)
+                await session.rollback()
+                continue
             await ctx["redis"].enqueue_job("run_voyage", str(run.id))
             enqueued.append(str(run.id))
     return enqueued

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -555,6 +555,48 @@ const DEFAULT_ANNOUNCE: AnnounceFilter = 'new';
 // 列表固定按点赞排序（没有排序切换 UI）；语义检索时后端按相关度排，忽略这个值
 const DAILY_SORT: DailySort = 'likes';
 
+/** 每日池的同步状况。池子是所有文献库的唯一供给——抓取失败会让全实验室当天颗粒无收，
+    所以状态要摆在页面上，而不是只躺在任务日志里等人去翻。 */
+function SyncStatusPill() {
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: ['daily-sync-status'],
+    queryFn: () => api.getDailySyncStatus(),
+    retry: false,
+    refetchInterval: 60_000,
+  });
+  if (!data) return null;
+
+  const failed = data.failed_categories;
+  const bad = failed.length > 0;
+  const stale = data.stale && !bad;
+  if (!bad && !stale) {
+    return (
+      <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 10 }}>
+        {tr(`已更新至 ${data.latest_feed_date ?? '—'}`, `Updated to ${data.latest_feed_date ?? '—'}`)}
+      </span>
+    );
+  }
+  const label = bad
+    ? tr(`${failed.join('、')} 抓取失败`, `${failed.join(', ')} failed to fetch`)
+    : tr(`论文池已停更（最新 ${data.latest_feed_date ?? '无'}）`, `Feed is stale (latest ${data.latest_feed_date ?? 'none'})`);
+  return (
+    <span
+      className={data.last_run_id ? 'pill sm hoverable' : 'pill sm'}
+      style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', marginLeft: 10 }}
+      title={
+        bad
+          ? tr('这些分类当天的新论文不会进池，各文献库也就收不到', 'Those categories will not enter the pool today, so no library will receive them')
+          : tr('每日抓取已超过一天没有成功', 'The daily fetch has not succeeded for more than a day')
+      }
+      onClick={data.last_run_id ? () => navigate(`/voyages/${data.last_run_id}`) : undefined}
+    >
+      {label}
+      {data.last_run_id ? ' →' : ''}
+    </span>
+  );
+}
+
 export function DailyPage() {
   const queryClient = useQueryClient();
   const [view, setView] = useState<DailyView>('papers');
@@ -784,6 +826,7 @@ export function DailyPage() {
           value={view}
           onChange={setView}
         />
+        <SyncStatusPill />
         {(categoriesQuery.data?.categories.length ?? 0) > 0 && (
           <div
             className="row gap6 wrap"

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -52,12 +52,6 @@ function CheckBox({ checked, onToggle, title }: { checked: boolean; onToggle: ()
   );
 }
 
-const CADENCES = [
-  { v: 'daily', zh: '每日', en: 'Daily' },
-  { v: 'weekly', zh: '每周', en: 'Weekly' },
-  { v: 'manual', zh: '手动', en: 'Manual' },
-] as const;
-
 // 过滤栏：归属类型（全部/个人/公共）与生命周期状态（全部/待审批/已驳回）候选。
 const TYPE_OPTIONS = [
   { v: 'all', zh: '全部', en: 'All' },
@@ -249,7 +243,6 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
-  const [cadence, setCadence] = useState<string>('daily');
   const [incl, setIncl] = useState<InclusionValue>(EMPTY_INCLUSION);
 
   const badAnchors = incl.anchors.filter(
@@ -303,7 +296,6 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
       ...(anchors.length > 0 ? { anchors } : {}),
       ...(keywords ? { keywords } : {}),
       ...(rubric.length > 0 ? { rubric } : {}),
-      cadence,
     });
   }
 
@@ -334,12 +326,6 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
         <FormField label={tr('一句话说明', 'Statement')} hint={tr('必填，用于相关性打分', 'Required — used for relevance scoring')}>
           <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr('用一句话介绍这个文献库的方向', 'One sentence describing this library’s direction')} />
-        </FormField>
-        <FormField label={tr('运行节奏', 'Cadence')}>
-          <div>
-            <Segmented options={CADENCES.map((c) => ({ v: c.v, label: tr(c.zh, c.en) }))}
-              value={cadence as (typeof CADENCES)[number]['v']} onChange={(v) => setCadence(v)} />
-          </div>
         </FormField>
         <div className="hr" style={{ margin: '4px 0 16px' }} />
         <InclusionSettingsForm

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -295,6 +295,20 @@ function wikiStepFriendly(action: string, obs: Record<string, unknown>): WikiSte
   const failedCount = Array.isArray(obs.failed) ? obs.failed.length : 0;
   switch (action) {
     case 'wiki.search_candidates':
+      // 候选来源随模式而变：建库检索 arXiv，增量只从每日论文池里挑（观测字段完全不同，
+      // 没有 found/window_since）。按 source 分支，否则同步任务会显示「检索到 — 篇」。
+      if (obs.source === 'daily_feed') {
+        return {
+          text: tr(
+            `每日论文池 ${num(obs.feed_total)} 篇 → 按方向粗排 ${num(obs.after_vector_rank)} 篇 →`
+              + ` 已在库 ${num(obs.already_in_library)} 篇 → 新收录 ${num(obs.inserted)} 篇`,
+            `Daily pool ${num(obs.feed_total)} → ranked ${num(obs.after_vector_rank)} →`
+              + ` ${num(obs.already_in_library)} already in library → ${num(obs.inserted)} newly added`,
+          ),
+          papers: briefsOf(obs.new_papers),
+          papersTotal: num(obs.inserted),
+        };
+      }
       return {
         text: tr(
           `从 arXiv 检索到 ${num(obs.found)} 篇，去重后新收录 ${num(obs.inserted)} 篇`,

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -25,11 +25,6 @@ function fromDefinition(def: ProjectDefinition | null): InclusionValue {
    - 重复论文候选与合并（不可撤销）。
    ============================================================ */
 
-const CADENCES: { v: string; zh: string; en: string }[] = [
-  { v: '', zh: '手动同步', en: 'Manual' },
-  { v: 'daily', zh: '每天自动同步', en: 'Daily' },
-];
-
 export function GovernanceTab({ libraryId, readOnly = false }: { libraryId: string; readOnly?: boolean }) {
   const { data: me } = useQuery({
     queryKey: ['me'],
@@ -259,21 +254,18 @@ function LibraryInfoCard({
   const queryClient = useQueryClient();
   const [name, setName] = useState(lib.name);
   const [statement, setStatement] = useState(lib.statement ?? '');
-  const [cadence, setCadence] = useState(lib.cadence ?? '');
   const [budget, setBudget] = useState(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
 
   // 库切换 / 保存后回填
   useEffect(() => {
     setName(lib.name);
     setStatement(lib.statement ?? '');
-    setCadence(lib.cadence ?? '');
     setBudget(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
   }, [lib]);
 
   const dirty =
     name !== lib.name ||
     statement !== (lib.statement ?? '') ||
-    cadence !== (lib.cadence ?? '') ||
     budget !== (lib.monthly_budget == null ? '' : String(lib.monthly_budget));
 
   const save = useMutation({
@@ -281,7 +273,6 @@ function LibraryInfoCard({
       api.updateLibrary(lib.id, {
         name: name.trim() || lib.name,
         statement: statement.trim() || null,
-        cadence: cadence || null,
         monthly_budget: budget.trim() === '' ? null : Math.max(0, Math.floor(Number(budget))),
       }),
     onSuccess: () => {
@@ -340,14 +331,6 @@ function LibraryInfoCard({
         </label>
         {!readOnly && (
         <div className="row gap12" style={{ flexWrap: 'wrap' }}>
-          <label className="col gap6" style={{ minWidth: 180 }}>
-            <span className="muted" style={{ fontSize: 12 }}>{tr('同步节奏', 'Sync cadence')}</span>
-            <select className="input" value={cadence} onChange={(e) => setCadence(e.target.value)}>
-              {CADENCES.map((c) => (
-                <option key={c.v} value={c.v}>{tr(c.zh, c.en)}</option>
-              ))}
-            </select>
-          </label>
           <label className="col gap6" style={{ minWidth: 220 }}>
             <span className="muted" style={{ fontSize: 12 }}>
               {tr('每月 AI 预算（token 数，留空 = 不限）', 'Monthly AI budget (tokens, empty = unlimited)')}

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -96,7 +96,8 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
   const queryClient = useQueryClient();
   const scopeId = libraryId ?? pid ?? '';
 
-  // 无 include 关键词时 arXiv 检索会退化成无差别抓取（空转烧钱），前端禁止启动。
+  // 无 include 关键词时 arXiv 检索会退化成无差别抓取（空转烧钱），前端禁止启动**初始建库**。
+  // 增量同步不受此限：它从每日论文池按方向语义粗排，关键词不参与筛选，没配也能跑。
   const { projects } = useProject();
   const project = libraryId ? undefined : projects.find((p) => p.id === pid);
   // 库作用域：真读该库 definition 的 include 关键词是否为空（拿不到库定义时不误报）。
@@ -160,7 +161,9 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
     },
   });
 
-  const busy = running || ingestMutation.isPending || noKeywords;
+  // 建库要关键词（拼 arXiv 检索式），增量同步不要——别把同步一起锁死
+  const busy = running || ingestMutation.isPending;
+  const bootstrapBusy = busy || noKeywords;
 
   function runBootstrap() {
     ingestMutation.mutate({
@@ -319,8 +322,8 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             </div>
             <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, margin: '0 0 14px' }}>
               {tr(
-                '抓取上次同步之后发表的新论文；已建库的文献库每天也会自动同步一次。',
-                'Fetches papers published since the last sync; built libraries also sync once a day automatically.',
+                '从每日论文池里挑出与本库方向相关的新论文，打分后自动入库；本步骤不再检索 arXiv。已建库的文献库每天都会自动同步一次。',
+                'Picks papers relevant to this library from the daily pool and adds the ones that score well; this step no longer queries arXiv. Built libraries sync once a day automatically.',
               )}
             </p>
             <button className="btn btn-ghost" disabled={busy || !state?.watermark} onClick={runIncremental}>
@@ -479,7 +482,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             </div>
           )}
           <div className="row gap10" style={{ marginTop: 6 }}>
-            <button className="btn btn-primary" disabled={busy} onClick={runBootstrap}>
+            <button className="btn btn-primary" disabled={bootstrapBusy} onClick={runBootstrap}>
               {ingestMutation.isPending ? (
                 <>
                   <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2583,6 +2583,17 @@ export interface DailyCollectionsRead {
   in_personal: boolean;
 }
 
+/** 每日论文池的同步状况。池子是所有文献库的唯一供给，抓失败=全实验室当天颗粒无收。 */
+export interface DailySyncStatus {
+  latest_feed_date: string | null;
+  stale: boolean;
+  last_run_id: string | null;
+  last_run_status: string | null;
+  last_run_at: string | null;
+  per_category: Record<string, { count: number; status: string; detail: string | null }>;
+  failed_categories: string[];
+}
+
 export const api = {
   /** fastapi-users JWT login — form-encoded username/password. Returns access token. */
   async login(email: string, password: string): Promise<string> {
@@ -4392,6 +4403,10 @@ export const api = {
    * 手动触发一次每日新论文抓取（admin）。抓取在任务系统里跑，返回的 voyage_id
    * 可直接跳任务详情看步骤与日志；409 detail=DAILY_FEED_RUNNING 表示已有一次在跑。
    */
+  /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
+  getDailySyncStatus(): Promise<DailySyncStatus> {
+    return request<DailySyncStatus>('/daily/sync-status');
+  },
   refreshDailyFeed(): Promise<{ status: string; voyage_id: string }> {
     return request<{ status: string; voyage_id: string }>('/daily/refresh', { method: 'POST' });
   },


### PR DESCRIPTION
## The number that motivated this

**Only 4 of 11 active libraries on production were reachable by the daily cron.**

| Reachable | 4 | CUA, Deepresearch Agent, On-Policy Distillation, Recursive Self-Improvement |
|---|---|---|
| **Standalone — cron never saw them** | **6** | game ai, **Long-Running Agent** (221 papers), OPD+RL, Spatial Reasoning, Utility-Preserving…, VIdeo World Model |
| **weekly — no cron exists for it** | **1** | SWE |

Seven libraries synced only when a human clicked. That was a nuisance before. Now that sync draws from a feed with a **seven-day** window, a library nobody clicks for a week loses those papers permanently — arXiv will not offer them again.

## Four silent ways to stop syncing

1. **The cron iterated projects**, resolving a library from each — so `project_id IS NULL` libraries were never in the set. It also never checked `DirectionLibrary.status`, so `pending`/`rejected` libraries with an old watermark *were* synced. Now it iterates libraries and checks status.
2. **`paused_error` is not terminal**, so the mutual-exclusion check read a failed run as "still running" and skipped that library indefinitely. One transient 429 took a library dark — four were stuck this way on production. Stale ones are reclaimed after 24h, leaving a day for a human to resume.
3. **`daily_wiki_ingest` caught only `IngestConflictError`**, so one over-budget library aborted the loop and every library after it went unsynced that day — visible only as an exception in the arq log.
4. **Budget exhaustion mid-run** obsoletes the remaining steps and promotes the last pending one as an implicit wrap-up — which for this pipeline is the watermark write. It announced the window as covered while compiling nothing, so the next sync skipped those papers for good. The watermark now holds when a run was truncated.

## Cadence is gone as a setting

Anything sparser than daily cannot work against a seven-day window, and the failure presents as "no new papers" rather than as an error.

Existing `weekly`/`manual` values stay in the database and are simply **not read**, so those libraries start syncing daily. A test pins exactly that: a library whose definition still says `weekly` must appear in the due list.

## The feed's failures are now loud

The feed is every library's only supply, so a silent empty pool is a lab-wide outage nobody notices.

`fetch_new` swallowed every exception and returned `[]`, making "rate limited" and "nothing published today" the same result. The step only failed when **all** categories came back empty — so a partial failure silently dropped one category's entire day.

Now: failures propagate, each category records its own outcome, and **any** failure fails the step. An all-quiet day is reported as a `note` instead, since weekends are legitimately empty.

## Visible to users

`GET /daily/sync-status` (readable by everyone) plus a pill on the daily page — normally the date the pool is current to; when a category fails or the pool goes stale, a warning that **links to the run that failed**.

"Stale" means the newest day is neither today nor yesterday: arXiv skips weekends, so one day behind is normal.

## Two frontend bugs from the earlier sync change, both mine

- The task detail page rendered the sync step using the **bootstrap** observation's fields, so every sync showed "Found — papers on arXiv". It now branches on `source` and shows the real funnel.
- A library with **no keywords** had its sync button disabled by a gate only bootstrap needs — sync does not use keywords at all.

Also: the step title now says "从每日论文池筛选候选" for sync runs rather than "检索候选（arXiv）", and the daily embed step no longer claims to be conditional on a switch that no longer exists.

## Tests

Nine new tests: standalone library is due; non-active is not; a legacy `weekly` value does not exclude; stale paused run reclaimed and unblocks the library; a *recent* paused run is left alone; one over-budget library does not stop the others; a truncated run does not advance the watermark; any failed category fails the fetch step; a quiet day does not.

**828 passed**, `ruff` clean, `tsc --noEmit` and `vite build` exit 0.

## Note on size

This is larger than I'd like. It could have been split into cron reachability / cadence / feed monitoring, but they are one causal chain: remove cadence and every library hangs on the feed; hang everything on the feed and its health has to be visible.