### PR TITLE
fix(arxiv): share the rate limiter across processes

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -1116,7 +1116,7 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
 
         compiled_count = int(ctx.checkpoint.get("compiled_count") or 0)
         message = (
-            f"文献调研被预算截断：本次编译 {compiled_count} 篇，水位线未推进"
+            f"文献调研被预算截断：本次编译 {compiled_count} 篇；进度未记录，下次会重新处理"
             if truncated
             else f"文献调研完成：本次编译 {compiled_count} 篇 wiki 页"
         )

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -237,7 +237,8 @@ class ArxivClient:
         self._cache = ResponseCache(redis)
         # RSS 新鲜源用独立的短 TTL 缓存（3h），跨用户/项目共享当天新公告
         self._rss_cache = ResponseCache(redis, ttl=_RSS_CACHE_TTL)
-        self._limiter = MinIntervalLimiter(min_interval)
+        # 闸门放 Redis 上，让 api 与 worker 两个进程共享同一个间隔（见 MinIntervalLimiter）
+        self._limiter = MinIntervalLimiter(min_interval, redis=redis)
         self._page_size = page_size
         self._max_retries = max(1, max_retries)
         self._backoff_base = backoff_base

--- a/src/backend/app/services/literature/cache.py
+++ b/src/backend/app/services/literature/cache.py
@@ -5,6 +5,7 @@
 """
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import time
@@ -89,16 +90,65 @@ class TokenBucket:
 
 
 class MinIntervalLimiter:
-    """最小请求间隔（arXiv 礼貌限速：默认 3s）。"""
+    """最小请求间隔（arXiv 礼貌限速：默认 3s），**跨进程**。
 
-    def __init__(self, interval: float) -> None:
+    进程内的间隔是不够的：api 与 worker 是两个容器，各持一个限流器，于是 arXiv 看到的
+    实际速率是设定值的两倍——用户手点「取 PDF」的同时 worker 正在跑建库，谁也不知道
+    对方存在。所以闸门放在 Redis 上：``SET key NX PX interval`` 抢到才放行，抢不到就按
+    剩余 TTL 等一等再抢。
+
+    Redis 不可用时**降级为进程内间隔**（与 :class:`ResponseCache` 同一套优雅降级约定）：
+    降级后限速偏松，但不会因为缓存层故障就阻断文献抓取。
+    """
+
+    #: 抢闸门的最多轮次；每轮至多等一个 interval，够用且不会无限自旋
+    _MAX_GATE_ROUNDS = 40
+
+    def __init__(
+        self, interval: float, *, redis: Redis | None = None, key: str = "lit:arxiv:gate"
+    ) -> None:
         self._interval = interval
         self._last = 0.0
         self._lock = asyncio.Lock()
+        self._redis = redis
+        self._key = key
+
+    def _client(self) -> Redis | None:
+        if self._redis is not None:
+            return self._redis
+        try:
+            from app.core.redis import get_redis
+
+            return get_redis()
+        except Exception:  # noqa: BLE001 — 拿不到 redis 就降级为进程内
+            return None
 
     async def acquire(self) -> None:
         if self._interval <= 0:
             return
+        if await self._acquire_shared():
+            return
+        await self._acquire_local()
+
+    async def _acquire_shared(self) -> bool:
+        """抢 Redis 闸门；成功返回 True。Redis 不可用返回 False 交给进程内兜底。"""
+        client = self._client()
+        if client is None:
+            return False
+        px = max(1, int(self._interval * 1000))
+        try:
+            for _ in range(self._MAX_GATE_ROUNDS):
+                if await client.set(self._key, "1", nx=True, px=px):
+                    return True
+                ttl = await client.pttl(self._key)
+                # ttl<0 表示键刚过期/不存在，立刻重抢；否则等它到期
+                await asyncio.sleep(max(10, ttl) / 1000 if ttl and ttl > 0 else 0.01)
+        except Exception:  # noqa: BLE001 — redis 故障不能阻断抓取
+            return False
+        # 轮次耗尽（闸门被持续占用）：放行，让上层的重试退避去兜
+        return True
+
+    async def _acquire_local(self) -> None:
         async with self._lock:
             now = time.monotonic()
             wait = self._last + self._interval - now
@@ -107,13 +157,19 @@ class MinIntervalLimiter:
             self._last = time.monotonic()
 
     async def penalize(self, seconds: float) -> None:
-        """被限流后把「上次请求时刻」往后推，让**共享这个限流器的所有协程**一起等。
+        """被限流后让**所有共享这个闸门的调用方**一起等，而不只是撞上 429 的那个。
 
-        只让撞上 429 的那个协程 sleep 是不够的：限流器是整个客户端共享的，别的协程
-        照样会在 3 秒后继续打过去，等于没退避。推 ``_last`` 才能把惩罚摊到所有人身上。
+        只让自己 sleep 是不够的：别的协程（乃至另一个进程）照样会在 3 秒后接着打过去，
+        等于没退避。所以两件事一起做——把 Redis 闸门的 TTL 顶到惩罚时长（跨进程生效），
+        再推进程内的 ``_last``（Redis 不可用时的兜底）。
         interval<=0（测试）时是 no-op，保持限流器整体关闭的语义。
         """
         if self._interval <= 0 or seconds <= 0:
             return
+        client = self._client()
+        if client is not None:
+            # redis 故障只影响跨进程那一半，进程内的惩罚照常生效
+            with contextlib.suppress(Exception):
+                await client.set(self._key, "1", px=max(1, int(seconds * 1000)))
         async with self._lock:
             self._last = max(self._last, time.monotonic() + seconds)

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -395,3 +395,47 @@ def test_split_text_after_sanitize_has_no_nul():
 
     chunks = split_text(sanitize_text("para1 with \x00 nul\n\npara2" * 100))
     assert chunks and all("\x00" not in c for c in chunks)
+
+
+async def test_min_interval_limiter_gate_is_shared_across_instances(cache_redis):
+    """两个**独立**的限流器实例共享同一个 Redis 闸门。
+
+    这正是生产上的形状：api 与 worker 是两个容器、各建一个客户端，进程内的间隔管不到
+    对方，于是 arXiv 看到的实际速率是设定值的两倍。
+    """
+    import time as _time
+
+    a = MinIntervalLimiter(0.2, redis=cache_redis)
+    b = MinIntervalLimiter(0.2, redis=cache_redis)
+    await a.acquire()
+    start = _time.monotonic()
+    await b.acquire()  # 必须等 a 的闸门到期
+    assert _time.monotonic() - start >= 0.1
+
+
+async def test_min_interval_limiter_falls_back_when_redis_is_down(cache_redis):
+    """Redis 故障时降级为进程内间隔，而不是阻断抓取。"""
+    import time as _time
+
+    class _Broken:
+        async def set(self, *a, **k):
+            raise RuntimeError("redis down")
+
+        async def pttl(self, *a, **k):
+            raise RuntimeError("redis down")
+
+    limiter = MinIntervalLimiter(0.2, redis=_Broken())
+    await limiter.acquire()
+    start = _time.monotonic()
+    await limiter.acquire()  # 走进程内那条，仍然限速
+    assert _time.monotonic() - start >= 0.1
+
+
+async def test_penalize_extends_the_shared_gate(cache_redis):
+    """惩罚要跨进程生效：另一个实例也得等。"""
+    a = MinIntervalLimiter(0.05, redis=cache_redis)
+    b = MinIntervalLimiter(0.05, redis=cache_redis)
+    await a.penalize(2.0)
+    ttl = await cache_redis.pttl("lit:arxiv:gate")
+    assert ttl > 1000
+    assert b._interval > 0  # b 会在 acquire 时撞上这个闸门


### PR DESCRIPTION
## Why

The 3s polite interval lived in a **per-process** object, and `api` and `worker` run as separate containers with one limiter each. So arXiv saw **twice** the intended rate whenever someone fetched a PDF while the worker was building a library — neither side knew the other existed.

This is the likely main source of the 429s. #198 added retry/backoff, which made them survivable; it did not make them rarer.

## What changed

The gate moves to Redis: `SET key NX PX interval`. Whoever wins it proceeds; the others wait out the remaining TTL and retry.

**Backing off extends that TTL too**, so a 429 penalty reaches every process rather than only the coroutine that got throttled. Previously `penalize` moved a local timestamp that the other container could not see.

**Redis being down must not stop literature fetching.** Any Redis failure degrades to the previous in-process interval — the same contract `ResponseCache` already documents. Degraded means looser limiting, not none.

There is a bounded retry count on the gate. If it stays occupied, the call proceeds and the retry/backoff layer above absorbs the consequences; an unbounded spin would be worse than a slightly early request.

## Tests

- Two **independent** limiter instances sharing one Redis gate serialize against each other — that is exactly the api/worker shape, which no in-process test could have caught.
- A limiter whose Redis raises on every call still enforces the interval locally rather than letting requests through.
- `penalize` extends the shared gate, so the backoff crosses process boundaries.

**831 passed**, `ruff` clean.

## Also

Rewords the budget-truncation activity message, which said "水位线未推进". That string is read by users in the activity stream, and *watermark* is internal jargon — it now says the progress was not recorded and those papers will be handled next time.