### PR TITLE
feat(vectors): isolate embedding spaces so vectors from different models never mix

### DIFF
--- a/docs/embedding-and-retrieval.md
+++ b/docs/embedding-and-retrieval.md
@@ -11,9 +11,9 @@ never mixed: a query is compared only against vectors of the same kind.
 
 | | Paper-level embedding | Chunk embedding |
 | --- | --- | --- |
-| Column | `papers.embedding` (one vector per paper) | `paper_chunks.embedding` (one per ~1200-char chunk, ≤120/paper) |
+| Table | `paper_vectors` (one row per paper × space) | `paper_chunk_vectors` (one per ~1200-char chunk × space) |
 | Text embedded | title + authors + abstract (see below) | the chunk's full-text slice (truncated to 2000 chars) |
-| Model / dim | BGE-M3, 1024-dim | BGE-M3, 1024-dim |
+| Model / dim | whatever the active space says (see below) | same active space |
 | Purpose | Paper-level semantic search; similarity / dedup | Fine-grained retrieval for literature chat (find the relevant passage) |
 | Cost | Cheap (one vector, batched) | Heavy (dozens of vectors per paper; needs the full text) |
 
@@ -30,12 +30,49 @@ the daily-feed batch.
 
 Author names are part of the text so that "find work by X" style queries land. The previous formula
 was `title + tldr + abstract`, which was inconsistent in practice because `tldr` only exists on
-compiled papers. Existing vectors are deliberately **not** re-embedded: the difference is dominated
-by title + abstract, so search stays usable while old vectors converge naturally as papers are
-recompiled or re-indexed.
+compiled papers. Vectors built under the older formula are deliberately **not** re-embedded: the
+difference is dominated by title + abstract, so search stays usable while old vectors converge
+naturally as papers are recompiled or re-indexed. A formula change is not a space change — the
+vectors stay comparable — so it is tracked by `text_version` on the row rather than by the space key.
 
-The **query** side embeds the user's search text as-is (`get_llm_router().embed([q])`); the
+The **query** side embeds the user's search text as-is (`embedding.py::embed_query`); the
 query-vs-document asymmetry is normal — only the document formula needs to be consistent.
+
+## Embedding spaces
+
+Vectors from different models live in unrelated coordinate systems: a cosine between them is
+noise. When the dimensions differ, Postgres errors out and the caller degrades to keyword search.
+**When the dimensions happen to match, nothing errors at all** — the ranking is simply wrong, and
+neither the caller nor the user can tell. That silent mode is what this design exists to prevent.
+
+So every vector row carries a **space** — `<model>@<dim>`, e.g. `bge-m3@1024` — and every read
+filters on it. Vectors of different spaces cannot meet in one comparison, structurally.
+
+- **One active space at a time.** `system_settings.embedding_active_space` names it. Retrieval reads
+  only that space; coverage counters (`/lab` stats, the daily-feed `vector_ready/vector_total`, the
+  per-paper index dots) count only that space, so switching models makes coverage drop honestly
+  instead of counting vectors that retrieval can no longer use.
+- **The dimension is never hardcoded.** The first successful embed defines the active space from the
+  model's *actual* returned dimension, and `paper_vectors.embedding` is a dimension-less pgvector
+  column. Moving to a 4096-dim model needs no migration and no code change (issue #191).
+- **The embedding model is global.** `embedding` is in `router.GLOBAL_ONLY_STAGES`, so a
+  self-managed user's route is ignored for it and `/me/llm/routes` rejects the stage outright. The
+  paper pool is shared; per-user embedding models would mix incomparable vectors into it *and* make
+  each user's query vector land in a different space from the documents.
+- **Writes go through one gate.** `services/embedding.py::embed_documents` resolves the space,
+  validates every returned vector's dimension, and raises `EmbeddingSpaceMismatchError` rather than
+  storing anything questionable — on SQLite the JSON column would otherwise swallow it silently.
+- **Changing the model is an explicit act.** Once the routed model differs from the active space,
+  embedding calls refuse to run. An admin confirms via
+  `POST /admin/settings/embedding-space/adopt`, which probes the model for its real dimension and
+  switches the active space. Old vectors are left in place: they stop being searchable, and adopting
+  the previous model again is a complete rollback. `GET /admin/settings/embedding-space` reports the
+  active space, the routed model, `mismatched`, and the row counts of every space in the database.
+- **Rebuilding is the existing machinery.** Every "rebuild index" entry point (per paper, per
+  library, per topic, personal library, daily backfill) treats "no vector in the active space" as
+  missing, so they refill the new space incrementally. A paper that has vectors only in an old space
+  reports `built=false, stale=true`, which the UI shows as "needs rebuild" (amber) rather than
+  "never built" (red).
 
 ## When each vector is built
 
@@ -64,6 +101,10 @@ In summary:
   never breaks the sync). Chunk vectors are not built for daily papers — they have no full text.
 
 ## Retrieval
+
+All five pgvector queries join the vector side table and filter `WHERE v.space = :space`; the query
+vector passed in must come from that same space (`embed_query` returns the pair together, so callers
+cannot mismatch them by accident).
 
 Postgres with pgvector is required for vector search: `semantic_search_supported(session)` and
 `chunk_vector_search_supported(session)` return true only on `postgresql`. On SQLite (tests / no
@@ -131,7 +172,10 @@ is shared by the shelf, personal-library and daily chats and changing it must no
 - **Two granularities, kept separate.** Paper-level for "which paper", chunk-level for "which
   passage". Never compare across kinds.
 - **One document formula.** All paper-level vectors use the same `paper_embedding_text`; otherwise the
-  space is inconsistent. Existing vectors are left to converge rather than force a costly re-embed.
+  space is inconsistent. The formula's version is stored per row (`text_version`) so a future change
+  can drive a selective rebuild; it does not affect comparability, so it is not part of the space key.
+- **Never compare across spaces, and never guess.** Every read filters by the active space; every
+  write validates the dimension. A vector whose provenance cannot be established is not stored.
 - **Idempotent and skip-aware.** Never re-download, re-slice, or re-embed something that already
   exists (`pdf_path` / existing chunks / `embedding IS NOT NULL`). Collecting an already-embedded
   daily paper into a library skips the embed step and only does the missing work.

--- a/docs/literature-management.md
+++ b/docs/literature-management.md
@@ -18,7 +18,7 @@ paper. This keeps content, files, and vectors shared, and makes cross-collection
 
 ```mermaid
 flowchart TD
-    POOL["Content pool — papers\n(metadata, pdf_path, full_text_path, embedding, figures)"]
+    POOL["Content pool — papers\n(metadata, pdf_path, full_text_path, figures)\nvectors in paper_vectors"]
     DL["Direction library\nlibrary_papers (LibraryPaper)"]
     SH["Topic related-work shelf\ntopic_papers (TopicPaper)"]
     PL["Personal library\nuser_library_entries (UserLibraryEntry)"]
@@ -41,7 +41,9 @@ The pool row (`models/paper.py::Paper`) is the single source of truth for a pape
 - Metadata: `title`, `authors` (`[{name, affiliations}]`), `affiliations`, `abstract`, `year`,
   `venue`, `arxiv_id`, `doi`, `url`, `published_at`, `dedup_key`, `source`.
 - Derived artifacts (presence = "this step ran"): `pdf_path`, `full_text_path`, `figures` (JSON),
-  `embedding` (paper-level vector), `tldr`, `relevance_score` is **not** here (it is per-collection).
+  `tldr`; the paper-level vector lives in `paper_vectors` (one row per paper × embedding space, see
+  [Embedding & Retrieval](embedding-and-retrieval.md#embedding-spaces)). `relevance_score` is **not**
+  here (it is per-collection).
 - Child tables, all `ON DELETE CASCADE` from the pool paper: `paper_wikis` (the paper's single
   compiled intro), `paper_chunks` (full-text chunks + chunk vectors), `paper_concepts` links, figures
   rows, `paper_notes`, `paper_highlights`, `paper_user_meta` (per-user reading status / star), library
@@ -176,8 +178,9 @@ A pool paper is created (deduped first) by one of:
 ### 5. Paper-level embedding · 6. Chunk embedding
 
 See [Embedding & Retrieval](embedding-and-retrieval.md) for the details. In short: the paper-level
-vector (`Paper.embedding`) is always produced by the add / ingest paths; the chunk vectors
-(`PaperChunk.embedding`) are heavier and are **gated by the per-user `chat_fulltext_index` opt-in**.
+vector (`paper_vectors`) is always produced by the add / ingest paths; the chunk vectors
+(`paper_chunk_vectors`) are heavier. Both are stamped with the embedding space they belong to, and
+"already embedded" always means "in the currently active space".
 
 ### 7. Extract figures
 
@@ -219,18 +222,18 @@ vector (`Paper.embedding`) is always produced by the add / ingest paths; the chu
 | Download PDF | ✓ | ✓ (arxiv) | ✓ | — | — |
 | Extract full text | ✓ | ✓ | ✓ | — | — |
 | Chunk | ✓ | ✓ | ✓ | — | — |
-| Paper-level embedding | ✓ | ✓ | ✓ | — | admin opt-in |
-| Chunk embedding | ✓ | user opt-in | user opt-in | — | — |
+| Paper-level embedding | ✓ | ✓ | ✓ | — | ✓ |
+| Chunk embedding | ✓ | ✓ | ✓ | — | — |
 | Extract figures | ✓ | — | — | ✓ (lazy) | — |
 | Compile wiki | ✓ | — | — | ✓ | — |
 | Score relevance | ✓ | ✓ (with target) | — | — | — |
 | Author affiliations | ✓ | `on_add` only | `on_add` only | ✓ (other modes) | — |
 
-"user opt-in" = only when that user's `chat_fulltext_index` setting is on. "admin opt-in" = only when
-`daily_feed_embed_enabled` is on (off by default); see
-[Embedding & Retrieval](embedding-and-retrieval.md). "with target" = a scoring target library was
+"with target" = a scoring target library was
 supplied — a personal-library import has none, so nothing is scored. All of these steps are
-idempotent — an existing PDF, chunk set, or vector is never redone. `enrich_paper` publishes its
+idempotent — an existing PDF, chunk set, or vector is never redone; for vectors, "existing" means
+"present in the active embedding space", so switching the embedding model makes them due again (see
+[Embedding & Retrieval](embedding-and-retrieval.md#embedding-spaces)). `enrich_paper` publishes its
 progress as the stages `download` → `extract` → `embed` → `score`; chunking and affiliation
 extraction happen inline without their own stage event.
 

--- a/src/backend/alembic/versions/5d8ebd5cb100_vector_side_tables.py
+++ b/src/backend/alembic/versions/5d8ebd5cb100_vector_side_tables.py
@@ -1,0 +1,191 @@
+"""向量搬进侧表（paper_vectors / paper_chunk_vectors / idea_vectors）
+
+向量从主表的一列搬到独立的侧表，每行带一个「向量空间」标识（``model@dim``）。
+这样一个对象可以同时持有多个空间的向量，换嵌入模型就成了「后台预建新空间 →
+改一下激活空间设置」，旧向量留在库里可随时切回；侧表的 ``embedding`` 列不带
+维度，换 4096 维的模型也不需要再改表（issue #191）。
+
+存量搬迁：旧列全是 1024 维，逐行按它自己的 ``embedding_model`` 归入
+``<model>@1024``。这一列是后加的（c4e7b2a91f38），更早的行为 NULL——拿全局
+路由表里配的嵌入模型名补上，那正是这些向量的实际出处。搬完按行数最多的空间
+设为激活空间；一行向量都没有就不写设置，留给平台第一次嵌入时按模型实际返回的
+维度自行初始化。
+
+ideas 没有任何模型信息可依据，整体归入激活空间（它们与论文向量出自同一路由、
+同一时期）。万一猜错，后果只是想法去重偶尔漏判，不会污染检索结果。
+
+Revision ID: 5d8ebd5cb100
+Revises: 510f6bde2233
+Create Date: 2026-07-27 20:44:14.225962
+
+"""
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '5d8ebd5cb100'
+down_revision: str | None = '510f6bde2233'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 旧列固定 1024 维（d6e7f8a9b0c1 起）。这是对历史的陈述，不是给新代码用的常量。
+LEGACY_DIM = 1024
+UNKNOWN_MODEL = "unknown"
+ACTIVE_SPACE_KEY = "embedding_active_space"
+
+_TABLES = (
+    ("paper_vectors", "paper_id", "papers"),
+    ("paper_chunk_vectors", "chunk_id", "paper_chunks"),
+    ("idea_vectors", "idea_id", "ideas"),
+)
+
+_settings = sa.table(
+    "system_settings",
+    sa.column("key", sa.String),
+    sa.column("value", sa.JSON().with_variant(JSONB(), "postgresql")),
+    sa.column("created_at", sa.DateTime(timezone=True)),
+    sa.column("updated_at", sa.DateTime(timezone=True)),
+)
+
+
+def _not_null(column: str, is_postgres: bool) -> str:
+    """「这一行真有向量」的判据。
+
+    sqlite 上 embedding 是 JSON 列，SQLAlchemy 把 Python None 存成字面量 ``null``，
+    只判 IS NOT NULL 会把没建向量的行也捞进来（同 services/lab.py::_has_vector）。
+    """
+    if is_postgres:
+        return f"{column} IS NOT NULL"
+    return f"{column} IS NOT NULL AND CAST({column} AS TEXT) <> 'null'"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+    # postgres 用不带维度的 pgvector 列；其他方言回退 JSON（只存不查）
+    vector_type = Vector() if is_postgres else sa.JSON()
+
+    for table, owner_column, owner_table in _TABLES:
+        op.create_table(
+            table,
+            sa.Column(
+                owner_column,
+                sa.Uuid(),
+                sa.ForeignKey(f"{owner_table}.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column("space", sa.String(length=160), primary_key=True),
+            sa.Column("dim", sa.Integer(), nullable=False),
+            sa.Column("embedding", vector_type, nullable=False),
+            sa.Column("model", sa.String(length=128), nullable=False),
+            sa.Column("text_version", sa.SmallInteger(), nullable=False, server_default="1"),
+            sa.Column("built_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index(f"ix_{table}_space", table, ["space"])
+
+    _migrate_existing_vectors(bind, is_postgres)
+
+
+def _migrate_existing_vectors(bind: sa.Connection, is_postgres: bool) -> None:
+    now = "now()" if is_postgres else "CURRENT_TIMESTAMP"
+    # 存量行的 embedding_model 为 NULL 时的兜底：全局路由表里配的嵌入模型
+    fallback = (
+        bind.execute(
+            sa.text(
+                "SELECT model FROM model_routes "
+                "WHERE stage = 'embedding' AND owner_id IS NULL LIMIT 1"
+            )
+        ).scalar()
+        or UNKNOWN_MODEL
+    )
+    params = {"fallback": fallback, "dim": LEGACY_DIM}
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO paper_vectors "
+            "(paper_id, space, dim, embedding, model, text_version, built_at) "
+            "SELECT p.id, COALESCE(p.embedding_model, :fallback) || '@' || :dim, :dim, "
+            "p.embedding, COALESCE(p.embedding_model, :fallback), 1, "
+            f"COALESCE(p.embedding_at, {now}) "
+            "FROM papers p "
+            f"WHERE {_not_null('p.embedding', is_postgres)}"
+        ),
+        params,
+    )
+    bind.execute(
+        sa.text(
+            "INSERT INTO paper_chunk_vectors "
+            "(chunk_id, space, dim, embedding, model, text_version, built_at) "
+            "SELECT c.id, "
+            "COALESCE(p.chunk_embedding_model, p.embedding_model, :fallback) || '@' || :dim, "
+            ":dim, c.embedding, "
+            "COALESCE(p.chunk_embedding_model, p.embedding_model, :fallback), 1, "
+            f"COALESCE(p.chunk_embedding_at, p.embedding_at, {now}) "
+            "FROM paper_chunks c JOIN papers p ON p.id = c.paper_id "
+            f"WHERE {_not_null('c.embedding', is_postgres)}"
+        ),
+        params,
+    )
+
+    active = _dominant_space(bind)
+    space = active or f"{fallback}@{LEGACY_DIM}"
+    model, _, dim = space.rpartition("@")
+    bind.execute(
+        sa.text(
+            "INSERT INTO idea_vectors "
+            "(idea_id, space, dim, embedding, model, text_version, built_at) "
+            "SELECT i.id, :space, :dim, i.embedding, :model, 1, "
+            f"COALESCE(i.updated_at, {now}) "
+            "FROM ideas i "
+            f"WHERE {_not_null('i.embedding', is_postgres)}"
+        ),
+        {"space": space, "model": model, "dim": int(dim)},
+    )
+
+    # 只有真搬到了向量才写激活空间：空库留给首次嵌入按模型实际维度自行初始化
+    moved = sum(
+        bind.execute(sa.text(f"SELECT COUNT(*) FROM {table}")).scalar() or 0
+        for table, _, _ in _TABLES
+    )
+    if moved:
+        stamp = datetime.now(UTC)
+        bind.execute(
+            _settings.insert().values(
+                key=ACTIVE_SPACE_KEY,
+                value={"model": model, "dim": int(dim)},
+                created_at=stamp,
+                updated_at=stamp,
+            )
+        )
+
+
+def _dominant_space(bind: sa.Connection) -> str | None:
+    """搬迁后行数最多的空间；一行向量都没有返回 None。
+
+    存量本来就混装了多个模型的向量时（用户曾自管嵌入模型），这里不做归并——
+    少数派留在库里当作另一个空间，等重建任务补齐，而不是假装它们本来就可比。
+    """
+    row = bind.execute(
+        sa.text(
+            "SELECT space, SUM(n) AS total FROM ("
+            "  SELECT space, COUNT(*) AS n FROM paper_vectors GROUP BY space"
+            "  UNION ALL"
+            "  SELECT space, COUNT(*) AS n FROM paper_chunk_vectors GROUP BY space"
+            ") s GROUP BY space ORDER BY total DESC, space LIMIT 1"
+        )
+    ).first()
+    return row[0] if row is not None else None
+
+
+def downgrade() -> None:
+    op.execute(f"DELETE FROM system_settings WHERE key = '{ACTIVE_SPACE_KEY}'")
+    op.execute("DELETE FROM system_settings WHERE key = 'embedding_building_space'")
+    for table, _, _ in _TABLES:
+        op.drop_index(f"ix_{table}_space", table_name=table)
+        op.drop_table(table)

--- a/src/backend/alembic/versions/929c05a03745_drop_inline_embedding_columns.py
+++ b/src/backend/alembic/versions/929c05a03745_drop_inline_embedding_columns.py
@@ -1,0 +1,66 @@
+"""删除主表上的向量列（向量已搬进侧表）
+
+单独一个 revision，为的是必要时能只回滚这一步：上一步只加表不动旧数据，
+两步之间的库既能被新代码读（走侧表），旧列也还在。
+
+downgrade 重建列但**不搬回数据**：旧列写死 1024 维，而侧表里的向量可能是任意
+维度，搬回去要么报错要么截断。回滚这一步的意义是让旧代码能启动，向量本身还在
+侧表里，重新 upgrade 即恢复。
+
+Revision ID: 929c05a03745
+Revises: 5d8ebd5cb100
+Create Date: 2026-07-27 20:44:14.587508
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '929c05a03745'
+down_revision: str | None = '5d8ebd5cb100'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+LEGACY_DIM = 1024
+
+# (表, 列)：向量本体 + 论文行上汇总的构建元信息
+_DROPPED = (
+    ("papers", "embedding"),
+    ("papers", "embedding_model"),
+    ("papers", "embedding_at"),
+    ("papers", "chunk_embedding_model"),
+    ("papers", "chunk_embedding_at"),
+    ("paper_chunks", "embedding"),
+    ("ideas", "embedding"),
+)
+
+
+def upgrade() -> None:
+    for table, column in _DROPPED:
+        op.drop_column(table, column)
+
+
+def downgrade() -> None:
+    is_postgres = op.get_bind().dialect.name == "postgresql"
+    embedding_type = (
+        sa.JSON().with_variant(Vector(LEGACY_DIM), "postgresql")
+        if is_postgres
+        else sa.JSON()
+    )
+    op.add_column("papers", sa.Column("embedding", embedding_type, nullable=True))
+    op.add_column("papers", sa.Column("embedding_model", sa.String(length=128), nullable=True))
+    op.add_column(
+        "papers", sa.Column("embedding_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "papers", sa.Column("chunk_embedding_model", sa.String(length=128), nullable=True)
+    )
+    op.add_column(
+        "papers", sa.Column("chunk_embedding_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column("paper_chunks", sa.Column("embedding", embedding_type, nullable=True))
+    op.add_column("ideas", sa.Column("embedding", embedding_type, nullable=True))

--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
 from app.core.db import get_sessionmaker
+from app.core.embedding_space import EmbeddingSpace
 from app.core.llm.base import Message
 from app.models.activity import Activity
 from app.models.base import utcnow
@@ -37,6 +38,7 @@ from app.models.project import Project
 from app.models.review import ReviewMessage, ReviewSession
 from app.schemas.idea import FORGE_SIGNALS
 from app.services.concepts import library_concept_ids
+from app.services.embedding import embed_documents, idea_vectors, upsert_idea_vector
 from app.services.libraries import (
     dedupe_member_rows,
     get_source_library_ids,
@@ -710,20 +712,23 @@ async def forge_dedup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, A
         return {"candidates": 0, "dropped": 0}
 
     cand_texts = [_idea_text(c["title"], c.get("summary")) for c in candidates]
-    try:
-        cand_vectors = await ctx.llm.embed(
-            cand_texts,
-            user_id=ctx.run.created_by,
-            project_id=ctx.run.project_id,
-            voyage_id=ctx.run.id,
-        )
-    except NotImplementedError:
-        # embedding 路由不可用：跳过去重（记录原因），全部候选放行
-        ctx.checkpoint["forge_dedup_done"] = True
-        return {"candidates": len(candidates), "dropped": 0, "skipped_reason": "no embedding"}
-
-    # 库内既有 idea：无向量的现场补嵌并落库
+    # 候选与库内既有想法的向量必须出自同一个模型，否则下面的阈值判定毫无意义——
+    # 所以两批都走统一入口，并且只跟激活空间下的既有向量比。
     async with get_sessionmaker()() as session:
+        try:
+            cand_vectors, space = await embed_documents(
+                session,
+                cand_texts,
+                user_id=ctx.run.created_by,
+                project_id=ctx.run.project_id,
+                voyage_id=ctx.run.id,
+            )
+        except NotImplementedError:
+            # embedding 路由不可用：跳过去重（记录原因），全部候选放行
+            ctx.checkpoint["forge_dedup_done"] = True
+            return {"candidates": len(candidates), "dropped": 0, "skipped_reason": "no embedding"}
+
+        # 库内既有 idea：激活空间下无向量的现场补嵌并落库
         existing = (
             (
                 await session.execute(
@@ -735,26 +740,29 @@ async def forge_dedup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, A
             .scalars()
             .all()
         )
-        pending = [i for i in existing if i.embedding is None]
+        known = await idea_vectors(session, [i.id for i in existing], space)
+        pending = [i for i in existing if i.id not in known]
         if pending:
             try:
-                vectors = await ctx.llm.embed(
+                vectors, _ = await embed_documents(
+                    session,
                     [_idea_text(i.title, i.summary) for i in pending],
                     user_id=ctx.run.created_by,
                     project_id=ctx.run.project_id,
                     voyage_id=ctx.run.id,
                 )
                 for idea, vector in zip(pending, vectors, strict=True):
-                    idea.embedding = vector
+                    await upsert_idea_vector(session, idea.id, vector, space)
+                    known[idea.id] = vector
                 await session.commit()
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 — 既有 idea 补嵌失败则跳过比对
-                pass
+                await session.rollback()
         existing_entries = [
-            (f"库内想法「{i.title}」", _idea_text(i.title, i.summary), list(i.embedding))
+            (f"库内想法「{i.title}」", _idea_text(i.title, i.summary), known[i.id])
             for i in existing
-            if i.embedding is not None
+            if i.id in known
         ]
 
     async def confirmed_duplicate(text: str, other_text: str, cosine: float) -> tuple[bool, float]:
@@ -820,24 +828,24 @@ async def forge_persist(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     survivors = [c for c in candidates if not c.get("duplicate")]
     parent_paper_ids = list(_context(ctx).get("paper_ids") or [])
 
-    embeddings: list[list[float] | None] = [None] * len(survivors)
-    if survivors:
-        try:
-            embeddings = list(
-                await ctx.llm.embed(
+    inserted_ids: list[str] = []
+    async with get_sessionmaker()() as session:
+        embeddings: list[list[float] | None] = [None] * len(survivors)
+        space: EmbeddingSpace | None = None
+        if survivors:
+            try:
+                embeddings, space = await embed_documents(
+                    session,
                     [_idea_text(c["title"], c.get("summary")) for c in survivors],
                     user_id=ctx.run.created_by,
                     project_id=ctx.run.project_id,
                     voyage_id=ctx.run.id,
                 )
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001 — 嵌入失败不阻塞入库（含 NotImplementedError）
-            embeddings = [None] * len(survivors)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — 嵌入失败不阻塞入库（含 NotImplementedError）
+                embeddings, space = [None] * len(survivors), None
 
-    inserted_ids: list[str] = []
-    async with get_sessionmaker()() as session:
         for cand, vector in zip(survivors, embeddings, strict=True):
             idea = Idea(
                 project_id=ctx.run.project_id,
@@ -850,10 +858,11 @@ async def forge_persist(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                 depth="sketch",
                 evidence=cand.get("evidence"),
                 parent_paper_ids=parent_paper_ids,
-                embedding=vector,
             )
             session.add(idea)
             await session.flush()
+            if vector is not None and space is not None:
+                await upsert_idea_vector(session, idea.id, vector, space)
             inserted_ids.append(str(idea.id))
         session.add(
             Activity(

--- a/src/backend/app/agents/voyage/actions_proposal.py
+++ b/src/backend/app/agents/voyage/actions_proposal.py
@@ -35,6 +35,7 @@ from app.agents.voyage.actions_ideas import (
 )
 from app.agents.voyage.tool_loop import run_tool_loop
 from app.core.db import get_sessionmaker
+from app.core.embedding_space import EmbeddingSpace
 from app.core.llm.base import Message
 from app.models.activity import Activity
 from app.models.gate import Gate
@@ -42,6 +43,12 @@ from app.models.idea import RESEARCH_TYPES, Idea
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.review import ReviewMessage, ReviewSession
+from app.services.embedding import (
+    embed_documents,
+    embed_query,
+    paper_vectors,
+    upsert_idea_vector,
+)
 from app.services.libraries import (
     dedupe_member_rows,
     get_source_library_ids,
@@ -755,49 +762,68 @@ async def proposal_experiments(ctx: ActionContext, params: dict[str, Any]) -> di
 
 
 async def _internal_similar(ctx: ActionContext, query_text: str) -> list[dict[str, Any]]:
-    """库内相似论文：embedding 余弦 top-k；embedding 不可用降级关键词检索。"""
+    """库内相似论文：向量余弦 top-k；向量不可用降级关键词检索。
+
+    postgres 上交给 pgvector 在库里排（原先是把全库论文向量拉进内存逐条算余弦，
+    库一大就是一次全表扫描 + 上万次 Python 浮点运算）；sqlite 没有 pgvector，
+    仍走内存路径，但只取激活空间下的向量。
+    """
+    from app.services.papers import semantic_search_papers, semantic_search_supported
+
     async with get_sessionmaker()() as session:
         library_ids = await get_source_library_ids(session, ctx.run.project_id)
-        papers = (
-            (
-                (
-                    await session.execute(
-                        select(Paper)
-                        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                        .where(
-                            LibraryPaper.library_id.in_(library_ids),
-                            Paper.embedding.is_not(None),
-                        )
-                        .distinct()
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            if library_ids
-            else []
-        )
-        if papers:
+        if library_ids:
             try:
-                vectors = await ctx.llm.embed(
-                    [query_text[:2000]],
+                vector, space = await embed_query(
+                    session,
+                    query_text[:2000],
                     user_id=ctx.run.created_by,
                     project_id=ctx.run.project_id,
                     voyage_id=ctx.run.id,
                 )
-                scored = [(cosine_similarity(vectors[0], list(p.embedding)), p) for p in papers]
-                scored.sort(key=lambda x: -x[0])
-                return [
-                    {
-                        "paper_id": str(p.id),
-                        "title": p.title,
-                        "similarity": round(score, 3),
-                        "tldr": p.tldr or (p.abstract or "")[:200],
-                    }
-                    for score, p in scored[:_INTERNAL_SIMILAR_K]
-                ]
             except NotImplementedError:
-                pass
+                vector, space = None, None
+            if vector is not None and space is not None:
+                if semantic_search_supported(session):
+                    rows = await semantic_search_papers(
+                        session,
+                        project_id=ctx.run.project_id,
+                        query_vector=vector,
+                        space=space,
+                        limit=_INTERNAL_SIMILAR_K,
+                    )
+                    scored = [(score, view.paper) for view, score in rows]
+                else:
+                    papers = (
+                        (
+                            await session.execute(
+                                select(Paper)
+                                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                                .where(LibraryPaper.library_id.in_(library_ids))
+                                .distinct()
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
+                    known = await paper_vectors(session, [p.id for p in papers], space)
+                    scored = [
+                        (cosine_similarity(vector, known[p.id]), p)
+                        for p in papers
+                        if p.id in known
+                    ]
+                    scored.sort(key=lambda x: -x[0])
+                    scored = scored[:_INTERNAL_SIMILAR_K]
+                if scored:
+                    return [
+                        {
+                            "paper_id": str(p.id),
+                            "title": p.title,
+                            "similarity": round(score, 3),
+                            "tldr": p.tldr or (p.abstract or "")[:200],
+                        }
+                        for score, p in scored
+                    ]
         from app.services.papers import keyword_search_papers
 
         goal = _goal(ctx)
@@ -1103,21 +1129,23 @@ async def proposal_assemble(ctx: ActionContext, params: dict[str, Any]) -> dict[
         except ValueError:
             seed_idea_id = None
 
-    embedding = None
-    try:
-        vectors = await ctx.llm.embed(
-            [f"{meta['title']}\n{meta['summary']}"[:2000]],
-            user_id=ctx.run.created_by,
-            project_id=ctx.run.project_id,
-            voyage_id=ctx.run.id,
-        )
-        embedding = vectors[0]
-    except asyncio.CancelledError:
-        raise
-    except Exception:  # noqa: BLE001 — 嵌入失败不阻塞入库
-        pass
-
     async with get_sessionmaker()() as session:
+        embedding: list[float] | None = None
+        space: EmbeddingSpace | None = None
+        try:
+            vectors, space = await embed_documents(
+                session,
+                [f"{meta['title']}\n{meta['summary']}"[:2000]],
+                user_id=ctx.run.created_by,
+                project_id=ctx.run.project_id,
+                voyage_id=ctx.run.id,
+            )
+            embedding = vectors[0]
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — 嵌入失败不阻塞入库
+            embedding, space = None, None
+
         idea = Idea(
             project_id=ctx.run.project_id,
             title=meta["title"],
@@ -1132,10 +1160,11 @@ async def proposal_assemble(ctx: ActionContext, params: dict[str, Any]) -> dict[
             evidence=evidence,
             seed_idea_id=seed_idea_id,
             parent_paper_ids=[g["paper_id"] for g in goal.get("grounding") or []],
-            embedding=embedding,
         )
         session.add(idea)
         await session.flush()
+        if embedding is not None and space is not None:
+            await upsert_idea_vector(session, idea.id, embedding, space)
         idea_id = str(idea.id)
         session.add(
             Activity(

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.voyage.actions import ActionContext, register
 from app.agents.voyage.actions_ideas import cosine_similarity
 from app.core.db import get_sessionmaker
+from app.core.embedding_space import active_space
 from app.models.activity import Activity
 from app.models.base import utcnow
 from app.models.daily_feed import DailyFeedEntry
@@ -42,6 +43,13 @@ from app.services.chunks import (
 )
 from app.services.concepts import link_all_paper_concepts
 from app.services.dedup import pool_dedup_key
+from app.services.embedding import (
+    embed_documents,
+    embed_query,
+    paper_vectors,
+    papers_with_vector,
+    upsert_paper_vector,
+)
 from app.services.figure_annotate import annotate_figures, figures_annotated
 from app.services.libraries import (
     ensure_membership,
@@ -239,7 +247,12 @@ async def _pool_paper_or_new(
 # ---- 1. 检索候选（arXiv） ----
 
 async def _rank_feed_by_similarity(
-    ctx: ActionContext, *, direction: str, papers: list[Paper], limit: int
+    ctx: ActionContext,
+    session: AsyncSession,
+    *,
+    direction: str,
+    papers: list[Paper],
+    limit: int,
 ) -> tuple[list[Paper], bool]:
     """按与研究方向的向量相似度给每日池论文粗排，取前 ``limit``。
 
@@ -250,28 +263,36 @@ async def _rank_feed_by_similarity(
     返回 (排序后的论文, 是否真的排过序)。**这是排序不是过滤**——嵌入不可用时原样返回，
     宁可多送几篇去打分，也不能因为向量缺失让这个库一篇都收不到。
 
+    只跟激活空间下的论文向量比：方向向量与论文向量必须出自同一个模型，否则这个粗排
+    就是在按噪声挑论文，而且不会有任何报错。
+
     在 Python 里算余弦而不是走 pgvector：每日池只有几百行，跨 sqlite/postgres 一致，
     测试路径不用特判。
     """
-    with_vec = [p for p in papers if p.embedding is not None]
-    if not with_vec or not direction.strip():
+    if not direction.strip():
         return papers[:limit], False
     try:
-        vectors = await ctx.llm.embed(
-            [direction[:2000]],
+        vector, space = await embed_query(
+            session,
+            direction[:2000],
             user_id=ctx.run.created_by,
             project_id=ctx.run.project_id,
             library_id=ctx.run.library_id,
             voyage_id=ctx.run.id,
         )
-    except Exception:  # noqa: BLE001 — provider 不支持嵌入等：退回不排序
+    except Exception:  # noqa: BLE001 — provider 不支持嵌入 / 尚无向量空间：退回不排序
         logger.warning("feed ranking embed failed for library %s", ctx.run.library_id)
         return papers[:limit], False
-    scored = [(cosine_similarity(vectors[0], list(p.embedding)), p) for p in with_vec]
+    vectors = await paper_vectors(session, [p.id for p in papers], space)
+    if not vectors:
+        return papers[:limit], False
+    scored = [
+        (cosine_similarity(vector, vectors[p.id]), p) for p in papers if p.id in vectors
+    ]
     scored.sort(key=lambda x: -x[0])
     ranked = [p for _, p in scored]
     # 没建向量的排在后面而不是丢掉（同上：粗排不该有排除语义）
-    ranked.extend(p for p in papers if p.embedding is None)
+    ranked.extend(p for p in papers if p.id not in vectors)
     return ranked[:limit], True
 
 
@@ -310,7 +331,7 @@ async def _collect_from_daily_feed(
     feed_latest = max((d for _, d in rows), default=None)
 
     ranked, did_rank = await _rank_feed_by_similarity(
-        ctx, direction=direction, papers=feed_papers, limit=limit
+        ctx, session, direction=direction, papers=feed_papers, limit=limit
     )
 
     arxiv_ids, dois, titles = await _existing_keys(session, library.id)
@@ -1015,27 +1036,30 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         promoted_names = list(stats["promoted_concepts"])
         new_links = int(stats["links_created"])
 
-        # embedding：编译完成且尚无向量的论文批量嵌入（provider 不支持则跳过）
+        # embedding：编译完成且在激活空间下尚无向量的论文批量嵌入（不支持则跳过）
         embedded = 0
         embed_error: str | None = None
-        pending = [p for p in papers if p.embedding is None]
+        space = await active_space(session)
+        done = (
+            await papers_with_vector(session, [p.id for p in papers], space)
+            if space is not None
+            else set()
+        )
+        pending = [p for p in papers if p.id not in done]
         if pending:
             # 文本口径与手动补全/每日池共用（services/paper_enrich.paper_embedding_text）
             texts = [paper_embedding_text(p) for p in pending]
             try:
-                vectors = await ctx.llm.embed(
+                vectors, batch_space = await embed_documents(
+                    session,
                     texts,
                     user_id=billing_user_id,
                     project_id=ctx.run.project_id,
                     library_id=library.id,
                     voyage_id=ctx.run.id,
                 )
-                embed_model = await ctx.llm.model_name("embedding", billing_user_id)
-                now = utcnow()
                 for paper, vector in zip(pending, vectors, strict=True):
-                    paper.embedding = vector
-                    paper.embedding_at = now
-                    paper.embedding_model = embed_model
+                    await upsert_paper_vector(session, paper.id, vector, batch_space)
                     embedded += 1
                 await session.commit()
             except asyncio.CancelledError:

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -9,11 +9,15 @@ from app.schemas.admin_settings import (
     AffiliationModeRead,
     AffiliationModeUpdate,
     DailyEmbedBackfillResult,
+    EmbeddingSpaceAdoptResult,
+    EmbeddingSpaceItem,
+    EmbeddingSpaceStatus,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
 )
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
+from app.services import embedding as embedding_service
 from app.services import lab as lab_service
 
 router = APIRouter(
@@ -49,6 +53,63 @@ async def backfill_daily_embed(
     """给当前窗口内还没有向量的每日论文一次性补建（开开关后补齐历史用）。费用记系统账。"""
     stats = await daily_service.backfill_embeddings(session)
     return DailyEmbedBackfillResult(**stats)
+
+
+@router.get("/embedding-space", response_model=EmbeddingSpaceStatus)
+async def get_embedding_space(
+    session: AsyncSession = Depends(get_session),
+) -> EmbeddingSpaceStatus:
+    """当前向量模型 + 库里各向量空间的规模。
+
+    ``mismatched=true`` 表示路由表里的嵌入模型已经不是建库时那个了：此时新向量一律
+    拒绝写入（不能让两个模型的向量混进同一个池子），需要 adopt 确认换用新模型。
+    """
+    inventory = await embedding_service.space_inventory(session)
+    spaces = [EmbeddingSpaceItem(**item) for item in inventory]
+    active = next((s for s in spaces if s.active), None)
+    model = await embedding_service.routed_model()
+    return EmbeddingSpaceStatus(
+        active=active,
+        routed_model=model,
+        mismatched=bool(active and model and active.model != model),
+        spaces=spaces,
+    )
+
+
+@router.post("/embedding-space/adopt", response_model=EmbeddingSpaceAdoptResult)
+async def adopt_embedding_space(
+    session: AsyncSession = Depends(get_session),
+) -> EmbeddingSpaceAdoptResult:
+    """确认换用路由表里当前的嵌入模型（换模型后必须调一次）。
+
+    现场探一次模型拿到它的实际维度，据此定义新的激活空间。旧向量留在库里不动，
+    检索覆盖率会掉下来，用各处的「重新建立索引」把新空间补齐即可；adopt 回旧模型
+    就是回滚。
+    """
+    try:
+        space, previous = await embedding_service.adopt_routed_model(session)
+    except Exception as exc:  # noqa: BLE001 — 探测要真打一次模型，上游不可达也在此收口
+        # 探不到维度就不能定义空间，硬切过去只会让之后每次嵌入都失败
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"EMBEDDING_NOT_AVAILABLE:{type(exc).__name__}: {exc}",
+        ) from exc
+    items = await embedding_service.space_inventory(session)
+    current = next(
+        (item for item in items if item["key"] == space.key),
+        {
+            "key": space.key,
+            "model": space.model,
+            "dim": space.dim,
+            "papers": 0,
+            "chunks": 0,
+            "ideas": 0,
+            "active": True,
+        },
+    )
+    return EmbeddingSpaceAdoptResult(
+        active=EmbeddingSpaceItem(**current), previous=previous
+    )
 
 
 @router.get("/lab-leaderboard", response_model=LabLeaderboardSettingRead)

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -44,6 +44,7 @@ from app.services import daily_feed as daily_service
 from app.services import library_chat as library_chat_service
 from app.services import paper_enrich as paper_enrich_service
 from app.services import papers as papers_service
+from app.services.embedding import embed_query
 
 logger = logging.getLogger(__name__)
 
@@ -88,10 +89,11 @@ async def list_papers(
     total = 0
     if mode == "semantic" and q and q.strip() and papers_service.semantic_search_supported(session):
         try:
-            vectors = await get_llm_router().embed([q.strip()], user_id=user.id)
+            vector, space = await embed_query(session, q.strip(), user_id=user.id)
             rows = await daily_service.semantic_search_daily(
                 session,
-                query_vector=vectors[0],
+                query_vector=vector,
+                space=space,
                 limit=max(papers_service.RERANK_CANDIDATES, size),
                 date=date,
                 category=category,
@@ -282,7 +284,7 @@ async def collect(
     tasks: list[DailyCollectTask] = []
     for paper_id in payload.paper_ids:
         paper = await session.get(Paper, paper_id)
-        if paper is None or paper_enrich_service.paper_processing_complete(paper):
+        if paper is None or await paper_enrich_service.paper_processing_complete(session, paper):
             continue
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -83,6 +83,7 @@ from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
+from app.services.embedding import embed_query
 from app.services.wiki_export import build_obsidian_zip_for_libraries
 
 router = APIRouter(tags=["libraries"])
@@ -639,12 +640,13 @@ async def search_library(
     paper_rows: list = []
     if mode == "semantic" and papers_service.semantic_search_supported(session):
         try:
-            vectors = await get_llm_router().embed([q], user_id=user.id)
+            vector, space = await embed_query(session, q, user_id=user.id)
             candidates = await papers_service.semantic_search_papers(
                 session,
                 library_id=library.id,
                 project_id=library.project_id,
-                query_vector=vectors[0],
+                query_vector=vector,
+                space=space,
                 limit=max(papers_service.RERANK_CANDIDATES, limit),
             )
             mode_used = "semantic"
@@ -801,7 +803,8 @@ async def add_library_paper_manually(
         ) from e
     paper_id, user_id, project_id = result.paper.id, user.id, library.project_id
     task_id: str | None = None
-    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    if result.created or not already_done:
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,
             paper_id=paper_id,

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -31,6 +31,7 @@ from app.services import paper_import as paper_import_service
 from app.services import paper_wiki as paper_wiki_service
 from app.services import papers as papers_service
 from app.services import user_library as library_service
+from app.services.embedding import embed_query
 
 router = APIRouter(tags=["library"])
 
@@ -80,11 +81,12 @@ async def list_library(
         session
     ):
         try:
-            vectors = await get_llm_router().embed([q], user_id=user.id)
+            vector, space = await embed_query(session, q, user_id=user.id)
             candidates = await library_service.semantic_saved_entries(
                 session,
                 user_id=user.id,
-                query_vector=vectors[0],
+                query_vector=vector,
+                space=space,
                 limit=max(papers_service.RERANK_CANDIDATES, size),
             )
             ranked, _reranked = await papers_service.rerank_paper_rows(
@@ -253,7 +255,8 @@ async def import_entry(
     # 收藏走个人库的既有路径：已有条目（含回收站里的）复活并置 saved，不会建第二行
     entry = await library_service.save_paper(session, user_id=user.id, paper=result.paper)
     task_id: str | None = None
-    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    if result.created or not already_done:
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,
             paper_id=result.paper.id,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -227,7 +227,8 @@ async def add_paper_manually(
     paper_id, user_id = result.paper.id, user.id
     # 后台补全：新建或未处理完整时启动（含针对起源库 definition 的打分）
     task_id: str | None = None
-    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    if result.created or not already_done:
         library = await libraries_service.get_library_for_project(session, project_id)
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,

--- a/src/backend/app/api/shelf.py
+++ b/src/backend/app/api/shelf.py
@@ -162,7 +162,8 @@ async def import_to_shelf(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"
         ) from e
     task_id: str | None = None
-    if result.created or not paper_enrich_service.paper_processing_complete(result.paper):
+    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    if result.created or not already_done:
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,
             paper_id=result.paper.id,

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -41,6 +41,7 @@ from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import papers as papers_service
 from app.services import stats as stats_service
+from app.services.embedding import embed_query
 from app.services.libraries import get_library_for_project
 from app.services.topic_shelf import shelf_paper_ids
 from app.services.user_library import personal_paper_ids
@@ -76,11 +77,14 @@ async def search(
     paper_rows: list = []
     if mode == "semantic" and papers_service.semantic_search_supported(session):
         try:
-            vectors = await get_llm_router().embed([q], user_id=user.id, project_id=project_id)
+            vector, space = await embed_query(
+                session, q, user_id=user.id, project_id=project_id
+            )
             candidates = await papers_service.semantic_search_papers(
                 session,
                 project_id=project_id,
-                query_vector=vectors[0],
+                query_vector=vector,
+                space=space,
                 limit=max(papers_service.RERANK_CANDIDATES, limit),
             )
             mode_used = "semantic"

--- a/src/backend/app/core/embedding_space.py
+++ b/src/backend/app/core/embedding_space.py
@@ -1,0 +1,102 @@
+"""向量空间：一批向量出自哪个模型、多少维（不 import fastapi）。
+
+不同嵌入模型产出的向量落在互不相通的坐标系里，跨模型算余弦相似度没有意义——
+维度不同时 postgres 会直接报错，**维度恰好相同时不报错，只是排序全乱**，后者才
+是真正危险的：调用方一路成功返回，谁也看不出结果是噪声。
+
+所以每条向量都带一个空间标识（``model@dim``），写入时打标、检索时过滤，让不同
+空间的向量在物理上进不了同一次比较。同一时刻只有一个**激活空间**对检索可见。
+
+维度不写死：平台第一次成功嵌入时，用模型实际返回的维度定义激活空间并存进
+``system_settings``。换 4096 维的模型不需要改任何代码或建表语句——这正是本模块
+存在的原因（见 issue #191）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# 激活空间：检索唯一认的空间，也是新向量的写入目标。未设置 = 平台还没建过任何向量。
+ACTIVE_SPACE_SETTING_KEY = "embedding_active_space"
+# 在建空间：后台正在预建的下一个空间（蓝绿切换用，本期只定义键，不消费）。
+BUILDING_SPACE_SETTING_KEY = "embedding_building_space"
+
+
+class EmbeddingSpaceMismatchError(RuntimeError):
+    """嵌入结果与激活空间不符——绝不能入库，否则污染整个检索。"""
+
+
+@dataclass(frozen=True)
+class EmbeddingSpace:
+    """一个向量坐标系。``key`` 是它在向量表里的标识。"""
+
+    model: str
+    dim: int
+
+    @property
+    def key(self) -> str:
+        return f"{self.model}@{self.dim}"
+
+    def __str__(self) -> str:  # 日志/报错里直接用
+        return self.key
+
+
+def _parse(value: object) -> EmbeddingSpace | None:
+    """存量/脏值一律当作「没设置」，不抛错——设置读坏了不该让全站嵌入崩掉。"""
+    if not isinstance(value, dict):
+        return None
+    model, dim = value.get("model"), value.get("dim")
+    if not isinstance(model, str) or not model.strip():
+        return None
+    if not isinstance(dim, int) or isinstance(dim, bool) or dim <= 0:
+        return None
+    return EmbeddingSpace(model=model.strip(), dim=dim)
+
+
+async def _read(session: AsyncSession, key: str) -> EmbeddingSpace | None:
+    from app.models.system_setting import SystemSetting
+
+    row = await session.get(SystemSetting, key)
+    return _parse(row.value if row is not None else None)
+
+
+async def active_space(session: AsyncSession) -> EmbeddingSpace | None:
+    """当前对检索可见的空间；None = 平台还没建过向量（检索按「没有向量」处理）。
+
+    不做缓存：这是一次主键查询，每次检索/每批嵌入才调一次，缓存换来的那点开销
+    不值得担一份「管理员刚切了空间但旧值还在缓存里」的错乱风险。
+    """
+    return await _read(session, ACTIVE_SPACE_SETTING_KEY)
+
+
+async def building_space(session: AsyncSession) -> EmbeddingSpace | None:
+    """后台正在预建的空间（尚未对检索可见）。"""
+    return await _read(session, BUILDING_SPACE_SETTING_KEY)
+
+
+async def set_active_space(session: AsyncSession, space: EmbeddingSpace) -> None:
+    """切换激活空间（调用方负责 commit）。
+
+    切换本身只是一次设置写入：旧空间的向量行原封不动留在库里，切回去即可回滚。
+    """
+    await _write(session, ACTIVE_SPACE_SETTING_KEY, space)
+
+
+async def set_building_space(
+    session: AsyncSession, space: EmbeddingSpace | None
+) -> None:
+    """设置/清空在建空间（调用方负责 commit）。"""
+    await _write(session, BUILDING_SPACE_SETTING_KEY, space)
+
+
+async def _write(session: AsyncSession, key: str, space: EmbeddingSpace | None) -> None:
+    from app.models.system_setting import SystemSetting
+
+    value = None if space is None else {"model": space.model, "dim": space.dim}
+    row = await session.get(SystemSetting, key)
+    if row is None:
+        session.add(SystemSetting(key=key, value=value))
+    else:
+        row.value = value

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -70,6 +70,13 @@ _ROUTE_CACHE_TTL = 60.0
 # （关键词检索/向量分兜底等既有路径）。
 _CAPABILITY_STAGES = frozenset({"embedding", "rerank"})
 
+# 只走全局配置的环节：忽略调用方传的 user_id，一律用 owner=NULL 的路由。
+# 嵌入在此——论文/分段/想法的向量是全平台共享的一份数据，每个自管用户各用各的
+# 模型建向量，池子里就会混进互不可比的坐标系；更要命的是查询向量也会跟着变，
+# 维度恰好相同时不报任何错，只是排序全乱。所以嵌入模型不给用户自选。
+# rerank 不在此列：它是逐条打分，不涉及跨调用可比性，各用各的没有问题。
+GLOBAL_ONLY_STAGES = frozenset({"embedding"})
+
 
 @dataclass(slots=True, frozen=True)
 class ResolvedRoute:
@@ -175,9 +182,14 @@ class LLMRouter:
         self._self_managed[user_id] = (flag, now)
         return flag
 
-    async def _effective_owner(self, user_id: uuid.UUID | None) -> uuid.UUID | None:
-        """自管用户 → 用自己的配置；否则（含无 user_id 的系统调用）→ 全局(admin)。"""
-        if user_id is None:
+    async def _effective_owner(
+        self, user_id: uuid.UUID | None, stage: str | None = None
+    ) -> uuid.UUID | None:
+        """自管用户 → 用自己的配置；否则（含无 user_id 的系统调用）→ 全局(admin)。
+
+        ``GLOBAL_ONLY_STAGES`` 里的环节例外：无条件用全局配置。
+        """
+        if user_id is None or stage in GLOBAL_ONLY_STAGES:
             return None
         return user_id if await self._is_self_managed(user_id) else None
 
@@ -204,7 +216,8 @@ class LLMRouter:
 
         owner 由 user 的接管状态决定：自管用户用自己的 owner=user 配置（admin 的
         对他失效——即"配好前不可用"）；被接管用户及无 user_id 的系统调用用
-        全局(owner=NULL, admin)配置。
+        全局(owner=NULL, admin)配置。``GLOBAL_ONLY_STAGES``（嵌入）不吃这一套，
+        无论谁调都用全局配置。
 
         能力型环节（``_CAPABILITY_STAGES``）不回退 default：对话模型没有
         embedding/rerank 能力，回退只会产生无意义调用；未显式配置时抛
@@ -214,7 +227,7 @@ class LLMRouter:
         静默回退演示用 fake provider；仅当显式开启
         ``settings.llm_fake_fallback``（测试套件 / 无 key 演示）才回退 fake。
         """
-        owner_id = await self._effective_owner(user_id)
+        owner_id = await self._effective_owner(user_id, stage)
         routes = await self._get_routes(owner_id)
         route = routes.get(stage)
         if route is None:

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -39,6 +39,7 @@ from app.models.ssh_credential import SSHCredential
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
 from app.models.voyage import VoyageRun, VoyageStep
 
 __all__ = [
@@ -56,6 +57,7 @@ __all__ = [
     "FeedbackImage",
     "Gate",
     "Idea",
+    "IdeaVector",
     "LLMCallLog",
     "LibraryPaper",
     "LLMProviderConfig",
@@ -67,10 +69,12 @@ __all__ = [
     "ModelRoute",
     "Paper",
     "PaperChunk",
+    "PaperChunkVector",
     "PaperHighlight",
     "PaperNote",
     "PaperTag",
     "PaperUserMeta",
+    "PaperVector",
     "Project",
     "ProjectInvite",
     "ProjectMember",

--- a/src/backend/app/models/idea.py
+++ b/src/backend/app/models/idea.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
 from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.paper import EmbeddingVariant
 
 # 状态流转：candidate →(锦标赛) under_review →(闸门批准) promoted；人工可置 rejected
 IDEA_STATUSES = ("candidate", "under_review", "promoted", "rejected")
@@ -42,8 +41,7 @@ class Idea(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 软删除（回收站）：非空即在回收站，列表默认过滤
     trashed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     parent_paper_ids: Mapped[list[Any] | None] = mapped_column(JSONVariant)
-    # 语义去重用：postgres pgvector(1024)，sqlite 回退 JSON（同 papers.embedding）
-    embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
+    # 语义去重用的向量存 idea_vectors（每个空间一行），不在这张表上
     # ---- Idea 2.0（docs/api-idea2.md §7） ----
     # sketch | proposal
     depth: Mapped[str] = mapped_column(String(16), default="sketch", nullable=False)

--- a/src/backend/app/models/paper.py
+++ b/src/backend/app/models/paper.py
@@ -8,9 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    JSON,
     Boolean,
     Column,
     DateTime,
@@ -27,10 +25,8 @@ from sqlalchemy.orm.attributes import set_committed_value
 from app.core.db import Base
 from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
 
-EMBEDDING_DIM = 1024  # BGE-M3（lab LiteLLM /v1/embeddings）
-
-# postgres 用 pgvector（语义检索），sqlite 等回退 JSON 存 list（仅存不查）
-EmbeddingVariant = JSON().with_variant(Vector(EMBEDDING_DIM), "postgresql")
+# 向量不在这张表上：论文级向量存 paper_vectors、分段向量存 paper_chunk_vectors，
+# 各自带「向量空间」标识（app/models/vectors.py、app/core/embedding_space.py）。
 
 # 论文在方向库内的状态流转（LibraryPaper.status）：candidate →(打分) scored | excluded
 # →(下载全文) fetched →(Librarian 编译) compiled；included/excluded 亦可人工覆盖
@@ -82,14 +78,6 @@ class Paper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 提取的论文图列表：[{index, page, width, height, caption: str|null, important: bool}]，
     # 图片文件落 <data_dir>/papers/<paper_id>/figures/fig_<index>.png（路径不出 API）
     figures: Mapped[list[Any] | None] = mapped_column(JSONVariant)
-    embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
-    # 论文级向量的构建元信息（前端索引状态悬浮显示）；存量数据 / 未建为 null
-    embedding_model: Mapped[str | None] = mapped_column(String(128))
-    embedding_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    # 分块向量最近一次补齐的元信息（分段本身在 paper_chunks，元信息汇总记这里，
-    # 避免在上百万分段行上各存一份时间/模型名）
-    chunk_embedding_model: Mapped[str | None] = mapped_column(String(128))
-    chunk_embedding_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     # 这篇论文的概念（论文详情 / 导出 / agent 工具的展示口径）：**只给转正概念**。
     # 候选词条（还只有这一篇论文用到，多半是这篇自己起的 benchmark / 模型代号）不对
@@ -168,6 +156,8 @@ class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     ``source`` 区分两类块：拿到 PDF 后重建分段会把摘要块整体替换为全文块，
     「这篇有没有全文索引」也靠它判断（不能只看有没有分段行）。
+
+    向量存 paper_chunk_vectors（每段每空间一行），不在这张表上。
     """
 
     __tablename__ = "paper_chunks"
@@ -182,7 +172,6 @@ class PaperChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     source: Mapped[str] = mapped_column(
         String(16), nullable=False, default="fulltext", server_default="fulltext"
     )
-    embedding: Mapped[list[float] | None] = mapped_column(EmbeddingVariant)
 
 
 READING_STATUSES = ("unread", "reading", "read")

--- a/src/backend/app/models/vectors.py
+++ b/src/backend/app/models/vectors.py
@@ -1,0 +1,81 @@
+"""向量侧表：论文级 / 分段级 / 想法级各一张（见 app/core/embedding_space.py）。
+
+向量从主表搬出来单独存，为的是**一个对象可以同时持有多个空间的向量**：换嵌入
+模型时，新空间的向量可以在后台慢慢建，旧空间照常服务检索；建齐后改一下激活空间
+设置就完成切换，不满意再切回去——旧向量一直都在。放在主表的一列里做不到这件事，
+一列只装得下一套向量，换模型必然经历一段「大部分论文没向量」的窗口期。
+
+``embedding`` 列**不带维度**（pgvector 允许 ``vector`` 不声明维度）。所以换一个
+4096 维的模型不需要 ALTER TABLE，只需要新的 space 值——issue #191 要的就是这个。
+代价是这样的列建不了 HNSW/IVFFlat 索引；现状五处向量检索本来就全是顺序扫描，
+将来真要上 ANN，可以给激活空间单开一张定维表。
+
+检索一律带 ``WHERE space = <激活空间>``，所以参与同一次比较的行维度必然一致。
+"""
+
+import uuid
+from datetime import datetime
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, SmallInteger, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import utcnow
+
+# postgres 用不带维度的 pgvector 列；sqlite 等回退 JSON（只存不查，与主表旧列同款）
+VectorVariant = JSON().with_variant(Vector(), "postgresql")
+
+
+class _VectorColumns:
+    """三张向量表共用的列。主键的另一半（owner 外键）由各表自己声明。"""
+
+    # "<model>@<dim>"，如 "bge-m3@1024"。检索的唯一过滤依据。
+    space: Mapped[str] = mapped_column(String(160), primary_key=True)
+    # 冗余存一份维度：不用解析 space 字符串就能做体检/统计，也便于排查脏数据
+    dim: Mapped[int] = mapped_column(nullable=False)
+    embedding: Mapped[list[float]] = mapped_column(VectorVariant, nullable=False)
+    # 建这条向量时路由表里的模型名。与 space 前半段同源，单独留一列是为了存量数据
+    # 迁移时能保住原始模型名（存量的 space 可能是归并出来的）。
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    # 文本口径版本（喂给模型的那段文本怎么拼的）。口径变化不影响向量可比性，
+    # 不进 space，只用于将来做选择性重建。
+    text_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1"
+    )
+    built_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, nullable=False
+    )
+
+
+class PaperVector(_VectorColumns, Base):
+    """论文级向量（标题+作者+摘要一条），语义检索与相似度排序用。"""
+
+    __tablename__ = "paper_vectors"
+    __table_args__ = (Index("ix_paper_vectors_space", "space"),)
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), primary_key=True
+    )
+
+
+class PaperChunkVector(_VectorColumns, Base):
+    """分段向量（每段一条），文献对话的细粒度检索用。行数比另两张高两三个数量级。"""
+
+    __tablename__ = "paper_chunk_vectors"
+    __table_args__ = (Index("ix_paper_chunk_vectors_space", "space"),)
+
+    chunk_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_chunks.id", ondelete="CASCADE"), primary_key=True
+    )
+
+
+class IdeaVector(_VectorColumns, Base):
+    """想法向量，想法语义去重用。"""
+
+    __tablename__ = "idea_vectors"
+    __table_args__ = (Index("ix_idea_vectors_space", "space"),)
+
+    idea_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("ideas.id", ondelete="CASCADE"), primary_key=True
+    )

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -31,3 +31,36 @@ class DailyEmbedBackfillResult(BaseModel):
     embedded: int
     skipped: int
     failed: int = 0
+
+
+class EmbeddingSpaceItem(BaseModel):
+    """库里出现过的一个向量空间及其规模。"""
+
+    key: str
+    model: str
+    dim: int
+    papers: int
+    chunks: int
+    ideas: int
+    active: bool
+
+
+class EmbeddingSpaceStatus(BaseModel):
+    """当前向量模型与库里各空间的分布。
+
+    ``routed_model`` 是路由表里配的嵌入模型；它与 ``active`` 的模型不一致时，
+    说明管理员换过模型而索引还没重建——此时所有嵌入调用都会拒绝执行，直到
+    调用 adopt 接口确认换用新模型（旧向量保留，可切回）。
+    """
+
+    active: EmbeddingSpaceItem | None = None
+    routed_model: str | None = None
+    mismatched: bool = False
+    spaces: list[EmbeddingSpaceItem] = []
+
+
+class EmbeddingSpaceAdoptResult(BaseModel):
+    """切换激活空间的结果：切到哪个、原先是哪个。"""
+
+    active: EmbeddingSpaceItem
+    previous: str | None = None

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -122,11 +122,17 @@ class PaperDetail(PaperRead):
 
 
 class VectorStatusRead(BaseModel):
-    """一种向量的状态（前端红绿点 + 悬浮显示构建时间与模型名）。"""
+    """一种向量的状态（前端红绿点 + 悬浮显示构建时间与模型名）。
+
+    ``built`` 只认**当前向量模型**建的向量。换过模型之后旧向量检索用不上，此时
+    ``built=false, stale=true``——前端据此显示「待重建」黄点，与「从没建过」的红点
+    区别开，否则换完模型满屏红点，看着像数据丢了。
+    """
 
     built: bool
     built_at: datetime | None = None  # 存量数据没记过，为 null
     model: str | None = None  # 构建所用嵌入模型名；存量数据为 null
+    stale: bool = False  # 建过、但出自换掉的旧模型，等重建
 
 
 class PaperIndexStatusRead(BaseModel):

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -14,14 +14,16 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, exists, func, select
 from sqlalchemy import text as sa_text
+from sqlalchemy import true as sa_true
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.embedding_space import EmbeddingSpace, active_space
 from app.core.llm.router import LLMRouter
-from app.models.base import utcnow
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperChunk
+from app.models.vectors import PaperChunkVector
 
 CHUNK_TARGET_CHARS = 1200
 CHUNK_MAX_CHARS = 1600  # 超过则硬切
@@ -115,14 +117,30 @@ async def index_paper_abstract(session: AsyncSession, paper: Paper) -> int:
     chunk = PaperChunk(
         paper_id=paper.id, seq=0, text=text[:CHUNK_MAX_CHARS], source="abstract"
     )
-    # 只在真有向量时才赋值：sqlite 分支 embedding 是 JSON 列，显式写 None 会存成
-    # JSON 'null' 而不是 SQL NULL，之后 `embedding IS NULL` 就再也筛不到这一行了。
-    if paper.embedding is not None:
-        chunk.embedding = paper.embedding
-        paper.chunk_embedding_at = paper.embedding_at
-        paper.chunk_embedding_model = paper.embedding_model
     session.add(chunk)
+    await session.flush()  # 拿到 chunk.id 才能给它挂向量
+    await _copy_paper_vector_to_chunk(session, paper_id=paper.id, chunk_id=chunk.id)
     return 1
+
+
+async def _copy_paper_vector_to_chunk(
+    session: AsyncSession, *, paper_id: uuid.UUID, chunk_id: uuid.UUID
+) -> bool:
+    """把论文级向量原样拷给摘要兜底块（同空间内的拷贝，连空间标识一起带走）。
+
+    论文级向量此刻还没建好就返回 False，等 :func:`sync_abstract_chunk_vectors` 补。
+    """
+    from app.services.embedding import paper_vectors, upsert_chunk_vector
+
+    space = await active_space(session)
+    if space is None:
+        return False
+    vectors = await paper_vectors(session, [paper_id], space)
+    vector = vectors.get(paper_id)
+    if vector is None:
+        return False
+    await upsert_chunk_vector(session, chunk_id, vector, space)
+    return True
 
 
 async def sync_abstract_chunk_vectors(
@@ -131,31 +149,44 @@ async def sync_abstract_chunk_vectors(
     """把论文级向量拷进还没有向量的摘要兜底块，返回补上的块数。调用方负责 commit。
 
     零 token 开销，所以不受任何开关控制——摘要块的存在与否决定了这篇论文能不能被
-    文献对话检索到，不该因为用户关了「全文索引」（那管的是花钱建全文块向量）就退回
-    「整篇论文搜不到」。论文级向量必须先建好，故所有调用点都排在嵌入之后。
+    文献对话检索到。论文级向量必须先建好，故所有调用点都排在嵌入之后。
+
+    「还没有向量」按**激活空间**算：换了嵌入模型之后，摘要块要在新空间里重新拿到
+    一份拷贝，旧空间那份对检索已经不可见。
     """
     if not paper_ids:
         return 0
-    rows = (
+    from app.services.embedding import chunks_with_vector, paper_vectors, upsert_chunk_vector
+
+    space = await active_space(session)
+    if space is None:
+        return 0
+    ids = list(set(paper_ids))
+    chunks = list(
         (
             await session.execute(
-                select(PaperChunk, Paper)
-                .join(Paper, Paper.id == PaperChunk.paper_id)
-                .where(
-                    PaperChunk.paper_id.in_(list(set(paper_ids))),
-                    PaperChunk.source == "abstract",
-                    PaperChunk.embedding.is_(None),
-                    Paper.embedding.is_not(None),
+                select(PaperChunk).where(
+                    PaperChunk.paper_id.in_(ids), PaperChunk.source == "abstract"
                 )
             )
         )
+        .scalars()
         .all()
     )
-    for chunk, paper in rows:
-        chunk.embedding = paper.embedding
-        paper.chunk_embedding_at = paper.embedding_at
-        paper.chunk_embedding_model = paper.embedding_model
-    return len(rows)
+    if not chunks:
+        return 0
+    done = await chunks_with_vector(session, [c.id for c in chunks], space)
+    vectors = await paper_vectors(session, [c.paper_id for c in chunks], space)
+    copied = 0
+    for chunk in chunks:
+        if chunk.id in done:
+            continue
+        vector = vectors.get(chunk.paper_id)
+        if vector is None:
+            continue
+        await upsert_chunk_vector(session, chunk.id, vector, space)
+        copied += 1
+    return copied
 
 
 async def ensure_paper_chunks(session: AsyncSession, paper: Paper) -> int:
@@ -203,14 +234,17 @@ async def _embed_chunks(
 ) -> tuple[int, str | None]:
     """分批嵌入给定的待补分段（调用方负责选出 pending），返回 (成功条数, 错误说明|None)。
 
-    顺带把「分块向量建于何时、用的哪个模型」记到所属论文行上（前端索引状态展示用）。
+    向量连同所属空间写进 paper_chunk_vectors。``llm`` 参数保留只为签名兼容，实际
+    走 services/embedding.py 的统一入口（嵌入模型全局统一，不看调用方是谁）。
     """
+    from app.services.embedding import embed_documents, upsert_chunk_vector
+
     embedded = 0
-    model = await llm.model_name("embedding", user_id)
     for i in range(0, len(pending), EMBED_BATCH):
         batch = pending[i : i + EMBED_BATCH]
         try:
-            vectors = await llm.embed(
+            vectors, space = await embed_documents(
+                session,
                 [c.text[:2000] for c in batch],
                 user_id=user_id,
                 project_id=project_id,
@@ -222,30 +256,24 @@ async def _embed_chunks(
         except Exception as e:  # noqa: BLE001 — 嵌入失败不影响主流程
             return embedded, f"{type(e).__name__}: {e}"
         for chunk, vector in zip(batch, vectors, strict=True):
-            chunk.embedding = vector
+            await upsert_chunk_vector(session, chunk.id, vector, space)
             embedded += 1
-        await _touch_chunk_embedding_meta(
-            session, {c.paper_id for c in batch}, model=model
-        )
         await session.commit()
     return embedded, None
 
 
-async def _touch_chunk_embedding_meta(
-    session: AsyncSession, paper_ids: set[uuid.UUID], *, model: str | None
-) -> None:
-    """记下这批论文的分块向量构建时间与模型名（调用方负责 commit）。"""
-    if not paper_ids:
-        return
-    now = utcnow()
-    papers = (
-        (await session.execute(select(Paper).where(Paper.id.in_(list(paper_ids)))))
-        .scalars()
-        .all()
+def missing_chunk_vector(space: EmbeddingSpace | None):
+    """「这个分段在激活空间下还没有向量」的 WHERE 条件。
+
+    还没有激活空间（平台一条向量都没建过）时所有分段都算缺——第一批嵌入会把空间
+    定下来。
+    """
+    if space is None:
+        return sa_true()
+    return ~exists().where(
+        PaperChunkVector.chunk_id == PaperChunk.id,
+        PaperChunkVector.space == space.key,
     )
-    for paper in papers:
-        paper.chunk_embedding_at = now
-        paper.chunk_embedding_model = model
 
 
 async def embed_pending_chunks(
@@ -262,6 +290,7 @@ async def embed_pending_chunks(
 
     project_id 仅用于 LLM 用量记账归属。
     """
+    space = await active_space(session)
     pending = list(
         (
             await session.execute(
@@ -269,7 +298,7 @@ async def embed_pending_chunks(
                 .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
                 .where(
                     LibraryPaper.library_id == library_id,
-                    PaperChunk.embedding.is_(None),
+                    missing_chunk_vector(space),
                     # 摘要兜底块的向量靠拷贝论文级向量（零开销），不走嵌入接口
                     PaperChunk.source == "fulltext",
                 )
@@ -307,13 +336,14 @@ async def embed_pending_chunks_for_papers(
     """
     if not paper_ids:
         return 0, None
+    space = await active_space(session)
     pending = list(
         (
             await session.execute(
                 select(PaperChunk)
                 .where(
                     PaperChunk.paper_id.in_(paper_ids),
-                    PaperChunk.embedding.is_(None),
+                    missing_chunk_vector(space),
                     # 摘要兜底块的向量靠拷贝论文级向量（零开销），不走嵌入接口
                     PaperChunk.source == "fulltext",
                 )
@@ -414,6 +444,7 @@ async def semantic_search_chunks(
     *,
     library_ids: list[uuid.UUID] | None = None,
     query_vector: list[float],
+    space: EmbeddingSpace,
     limit: int,
     paper_ids: list[uuid.UUID] | None = None,
 ) -> list[tuple[PaperChunk, float]]:
@@ -423,6 +454,9 @@ async def semantic_search_chunks(
     传 paper_ids 时把检索限制在这些论文内（伴读引用指定文献用）。
     library_ids 为空/None 且给了 paper_ids 时走「纯 paper_ids、不 join 库」分支
     （课题相关研究 / 个人库对话按论文集合直接检索）。
+
+    ``space`` 限定只跟同一个向量空间的分段比较——别的空间的向量出自别的模型，
+    算出来的余弦是噪声。调用方给的 query_vector 也必须来自这个空间。
     """
     qv = json.dumps(query_vector)
     if not library_ids and paper_ids:
@@ -431,13 +465,15 @@ async def semantic_search_chunks(
             "qv": qv,
             "pids": [str(p) for p in paper_ids],
             "k": limit,
+            "space": space.key,
         }
         rows = (
             await session.execute(
                 sa_text(
-                    "SELECT c.id, 1 - (c.embedding <=> CAST(:qv AS vector)) AS score "
-                    "FROM paper_chunks c "
-                    "WHERE c.embedding IS NOT NULL "
+                    "SELECT c.id, 1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
+                    "FROM paper_chunk_vectors v "
+                    "JOIN paper_chunks c ON c.id = v.chunk_id "
+                    "WHERE v.space = :space "
                     "AND c.paper_id = ANY(CAST(:pids AS uuid[])) "
                     "ORDER BY score DESC "
                     "LIMIT :k"
@@ -450,6 +486,7 @@ async def semantic_search_chunks(
             "qv": qv,
             "libs": [str(lid) for lid in (library_ids or [])],
             "k": limit,
+            "space": space.key,
         }
         paper_filter = ""
         if paper_ids:
@@ -458,11 +495,12 @@ async def semantic_search_chunks(
         rows = (
             await session.execute(
                 sa_text(
-                    "SELECT DISTINCT c.id, 1 - (c.embedding <=> CAST(:qv AS vector)) AS score "
-                    "FROM paper_chunks c "
+                    "SELECT DISTINCT c.id, 1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
+                    "FROM paper_chunk_vectors v "
+                    "JOIN paper_chunks c ON c.id = v.chunk_id "
                     "JOIN library_papers lp ON lp.paper_id = c.paper_id "
                     "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
-                    "WHERE c.embedding IS NOT NULL "
+                    "WHERE v.space = :space "
                     f"{paper_filter}"
                     "ORDER BY score DESC "
                     "LIMIT :k"

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -22,7 +22,7 @@ from typing import Any
 from sqlalchemy import String, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import utcnow
+from app.core.embedding_space import EmbeddingSpace, active_space
 from app.models.daily_feed import (
     DAILY_FEED_RETENTION_DAYS,
     DEFAULT_DAILY_CATEGORIES,
@@ -34,6 +34,7 @@ from app.models.paper import Paper, PaperWiki, new_paper
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.models.vectors import PaperVector
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun, VoyageStep
 from app.services import paper_wiki, user_library
 from app.services import projects as projects_service
@@ -120,12 +121,17 @@ async def embed_papers_missing_vectors(
 ) -> dict[str, int]:
     """给定论文中还没有向量的批量嵌入（幂等：已有向量的一律不动）。
 
+    「已有向量」按**激活空间**算：换了嵌入模型之后这些论文都算缺向量，会重新建。
     best-effort：整批失败只记日志并继续下一批；provider 不支持嵌入直接停手。
     返回 {embedded, skipped(已有向量), failed(嵌入未成功)}。
     """
     if not paper_ids:
         return {"embedded": 0, "skipped": 0, "failed": 0}
-    from app.core.llm.router import get_llm_router
+    from app.services.embedding import (
+        embed_documents,
+        papers_with_vector,
+        upsert_paper_vector,
+    )
     from app.services.paper_enrich import paper_embedding_text
 
     rows = (
@@ -133,17 +139,24 @@ async def embed_papers_missing_vectors(
         .scalars()
         .all()
     )
-    pending = [p for p in rows if p.embedding is None]
+    space = await active_space(session)
+    done = (
+        await papers_with_vector(session, [p.id for p in rows], space)
+        if space is not None
+        else set()
+    )
+    pending = [p for p in rows if p.id not in done]
     stats = {"embedded": 0, "skipped": len(rows) - len(pending), "failed": 0}
     if not pending:
         return stats
     # 先把文本与 id 取出来：失败回滚会让 ORM 实例过期，之后再读属性会触发意外 IO
     items = [(p.id, paper_embedding_text(p)) for p in pending]
-    llm = get_llm_router()
     for i in range(0, len(items), EMBED_BATCH):
         batch = items[i : i + EMBED_BATCH]
         try:
-            vectors = await llm.embed([t for _, t in batch], user_id=user_id)
+            vectors, batch_space = await embed_documents(
+                session, [t for _, t in batch], user_id=user_id
+            )
         except asyncio.CancelledError:
             raise
         except NotImplementedError:
@@ -155,14 +168,8 @@ async def embed_papers_missing_vectors(
             stats["failed"] += len(batch)
             continue
         try:
-            model = await llm.model_name("embedding", user_id)
-            now = utcnow()
             for (paper_id, _), vector in zip(batch, vectors, strict=True):
-                paper = await session.get(Paper, paper_id)
-                if paper is not None:
-                    paper.embedding = vector
-                    paper.embedding_at = now
-                    paper.embedding_model = model
+                await upsert_paper_vector(session, paper_id, vector, batch_space)
             await session.commit()
             stats["embedded"] += len(batch)
         except asyncio.CancelledError:
@@ -194,7 +201,11 @@ async def backfill_embeddings(
 async def embedding_coverage(
     session: AsyncSession, *, today: dt.date | None = None
 ) -> tuple[int, int]:
-    """(有向量的池论文数, 池论文总数)——语义检索结果覆盖度提示用。"""
+    """(有向量的池论文数, 池论文总数)——语义检索结果覆盖度提示用。
+
+    「有向量」按**激活空间**算：刚换过嵌入模型时覆盖率会如实掉下来，前端照此提示，
+    而不是拿旧空间的向量数充数。
+    """
     cutoff = (today or _today_utc()) - dt.timedelta(days=DAILY_FEED_RETENTION_DAYS - 1)
     base = (
         select(func.count())
@@ -203,7 +214,16 @@ async def embedding_coverage(
         .where(DailyFeedEntry.feed_date >= cutoff)
     )
     total = (await session.execute(base)).scalar_one()
-    ready = (await session.execute(base.where(Paper.embedding.is_not(None)))).scalar_one()
+    space = await active_space(session)
+    if space is None:
+        return 0, int(total)
+    ready = (
+        await session.execute(
+            base.join(PaperVector, PaperVector.paper_id == Paper.id).where(
+                PaperVector.space == space.key
+            )
+        )
+    ).scalar_one()
     return int(ready), int(total)
 
 
@@ -639,6 +659,7 @@ async def semantic_search_daily(
     session: AsyncSession,
     *,
     query_vector: list[float],
+    space: EmbeddingSpace,
     limit: int,
     date: dt.date | None = None,
     category: str | None = None,
@@ -648,11 +669,15 @@ async def semantic_search_daily(
 ) -> list[tuple[DailyFeedEntry, Paper, float]]:
     """池内向量检索（pgvector 余弦；仅 postgres，调用方先判 semantic_search_supported）。
 
-    只召回已有向量的池论文——池论文默认不建向量（管理员开关），所以结果可能不全，
-    调用方需要如实告知前端。筛选条件与关键词列表一致（日期/分类/公告类型/作者/机构）。
+    只召回**在给定空间下**已有向量的池论文，所以结果可能不全，调用方需要如实告知
+    前端。筛选条件与关键词列表一致（日期/分类/公告类型/作者/机构）。
     """
-    where = ["p.embedding IS NOT NULL"]
-    params: dict[str, Any] = {"qv": json.dumps(query_vector), "k": limit}
+    where = ["v.space = :space"]
+    params: dict[str, Any] = {
+        "qv": json.dumps(query_vector),
+        "k": limit,
+        "space": space.key,
+    }
     if date is not None:
         where.append("e.feed_date = :feed_date")
         params["feed_date"] = date
@@ -674,9 +699,10 @@ async def semantic_search_daily(
     rows = (
         await session.execute(
             text(
-                "SELECT e.id AS entry_id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
+                "SELECT e.id AS entry_id, 1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
                 "FROM daily_feed_entries e "
                 "JOIN papers p ON p.id = e.paper_id "
+                "JOIN paper_vectors v ON v.paper_id = p.id "
                 f"WHERE {' AND '.join(where)} "
                 "ORDER BY score DESC "
                 "LIMIT :k"

--- a/src/backend/app/services/embedding.py
+++ b/src/backend/app/services/embedding.py
@@ -1,0 +1,338 @@
+"""向量的统一出入口（不 import fastapi）。
+
+**所有**嵌入调用都必须经过这里，不要直接调 ``llm.embed()``。这个模块保证三件事：
+
+1. 查询向量与文档向量出自同一个模型——否则余弦排序就是噪声，而且维度恰好相同时
+   谁也不会报错（这正是改造前的状态）；
+2. 拿到的向量维度与激活空间一致才准入库，不一致直接抛错，绝不悄悄写进去；
+3. 每条向量都带上空间标识，检索时据此过滤。
+
+平台第一次成功嵌入时，按模型**实际返回的维度**定义激活空间——维度不写死在任何
+地方，换多少维的模型都不用改代码或改表（issue #191）。
+"""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.embedding_space import (
+    EmbeddingSpace,
+    EmbeddingSpaceMismatchError,
+    active_space,
+    set_active_space,
+)
+from app.models.base import utcnow
+from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
+
+EMBEDDING_STAGE = "embedding"
+
+# 文本口径版本（喂给模型的文本怎么拼的）。口径变了就 +1，不影响向量可比性，
+# 只是给将来的选择性重建留个依据。
+TEXT_VERSION = 1
+
+
+async def embed_documents(
+    session: AsyncSession,
+    texts: Sequence[str],
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> tuple[list[list[float]], EmbeddingSpace]:
+    """嵌入一批待入库的文本，返回 (向量, 它们所属的空间)。
+
+    平台还没有激活空间时，这一批就定义了它（模型名 + 实际返回的维度），设置随调用方
+    的事务一起提交。``user_id`` 等只用于用量记账，**不影响**用哪个模型——嵌入模型
+    全局统一（见 core/llm/router.py 的 GLOBAL_ONLY_STAGES）。
+
+    provider 不支持嵌入时抛 NotImplementedError（调用方按既有降级路径处理）；
+    模型或维度与激活空间不符时抛 EmbeddingSpaceMismatchError。
+    """
+    from app.core.llm.router import get_llm_router
+
+    llm = get_llm_router()
+    model = await llm.model_name(EMBEDDING_STAGE)
+    if model is None:
+        raise NotImplementedError("no embedding model configured")
+
+    space = await active_space(session)
+    if space is not None and space.model != model:
+        raise EmbeddingSpaceMismatchError(
+            f"embedding model changed from {space.model!r} to {model!r}: "
+            "existing vectors live in another space and cannot be compared with new "
+            "ones — rebuild the index under the new model or switch the model back"
+        )
+
+    vectors = [
+        list(v)
+        for v in await llm.embed(
+            list(texts),
+            stage=EMBEDDING_STAGE,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
+        )
+    ]
+    if not vectors:
+        # 空输入：没有向量可校验，也不该拿它去初始化空间
+        if space is None:
+            raise NotImplementedError("cannot resolve embedding space from an empty batch")
+        return [], space
+
+    if space is None:
+        space = EmbeddingSpace(model=model, dim=len(vectors[0]))
+        await set_active_space(session, space)
+
+    for vector in vectors:
+        if len(vector) != space.dim:
+            raise EmbeddingSpaceMismatchError(
+                f"model {model!r} returned a {len(vector)}-dim vector but the active "
+                f"space {space} expects {space.dim}"
+            )
+    return vectors, space
+
+
+async def embed_query(
+    session: AsyncSession,
+    text: str,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> tuple[list[float], EmbeddingSpace]:
+    """嵌入一条检索用文本，返回 (向量, 该向量所属空间)。
+
+    与文档向量走同一个模型，所以结果一定可比。**语义检索用不了的两种情况都抛
+    NotImplementedError**，让调用方走既有的降级路径（关键词检索 + mode_used 如实上报）：
+
+    - 平台还没建过任何向量（无激活空间）——库里一条向量都没有，无从检索；
+    - 管理员换了嵌入模型但还没确认——现有向量出自旧模型，拿新模型的查询向量去比就是
+      噪声。这里宁可降级也不能返回一个看着正常、实则乱序的结果。
+
+    写入侧（embed_documents）不做这个转换：那里必须响亮地失败，不能悄悄跳过。
+    """
+    space = await active_space(session)
+    if space is None:
+        raise NotImplementedError("no embedding space yet — nothing has been embedded")
+    try:
+        vectors, space = await embed_documents(
+            session,
+            [text],
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
+        )
+    except EmbeddingSpaceMismatchError as e:
+        raise NotImplementedError(f"semantic search unavailable: {e}") from e
+    return vectors[0], space
+
+
+# ---- 写入 ----
+
+
+async def upsert_paper_vector(
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    vector: list[float],
+    space: EmbeddingSpace,
+) -> None:
+    """写入/覆盖论文级向量（调用方负责 commit）。"""
+    await _upsert(session, PaperVector, PaperVector.paper_id, paper_id, vector, space)
+
+
+async def upsert_chunk_vector(
+    session: AsyncSession,
+    chunk_id: uuid.UUID,
+    vector: list[float],
+    space: EmbeddingSpace,
+) -> None:
+    """写入/覆盖分段向量（调用方负责 commit）。"""
+    await _upsert(
+        session, PaperChunkVector, PaperChunkVector.chunk_id, chunk_id, vector, space
+    )
+
+
+async def upsert_idea_vector(
+    session: AsyncSession,
+    idea_id: uuid.UUID,
+    vector: list[float],
+    space: EmbeddingSpace,
+) -> None:
+    """写入/覆盖想法向量（调用方负责 commit）。"""
+    await _upsert(session, IdeaVector, IdeaVector.idea_id, idea_id, vector, space)
+
+
+async def _upsert(
+    session: AsyncSession,
+    model_class: type,
+    key_column,
+    key: uuid.UUID,
+    vector: list[float],
+    space: EmbeddingSpace,
+) -> None:
+    if len(vector) != space.dim:
+        raise EmbeddingSpaceMismatchError(
+            f"refusing to store a {len(vector)}-dim vector in space {space}"
+        )
+    row = (
+        await session.execute(
+            select(model_class).where(key_column == key, model_class.space == space.key)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = model_class(**{key_column.key: key, "space": space.key})
+        session.add(row)
+    row.dim = space.dim
+    row.embedding = vector
+    row.model = space.model
+    row.text_version = TEXT_VERSION
+    row.built_at = utcnow()
+
+
+# ---- 空间管理（管理端） ----
+
+
+async def routed_model() -> str | None:
+    """路由表里当前配的嵌入模型名（未配置返回 None）。
+
+    不收 user_id：嵌入只走全局路由，问「对谁而言」是没有意义的。
+    """
+    from app.core.llm.router import get_llm_router
+
+    return await get_llm_router().model_name(EMBEDDING_STAGE)
+
+
+async def space_inventory(session: AsyncSession) -> list[dict]:
+    """库里出现过的全部向量空间及各自的行数（按论文向量数降序）。"""
+    counts: dict[str, dict[str, int]] = {}
+    for model_class, key_column, field in (
+        (PaperVector, PaperVector.paper_id, "papers"),
+        (PaperChunkVector, PaperChunkVector.chunk_id, "chunks"),
+        (IdeaVector, IdeaVector.idea_id, "ideas"),
+    ):
+        rows = (
+            await session.execute(
+                select(model_class.space, func.count(key_column)).group_by(model_class.space)
+            )
+        ).all()
+        for space_key, n in rows:
+            counts.setdefault(space_key, {"papers": 0, "chunks": 0, "ideas": 0})
+            counts[space_key][field] = int(n)
+
+    active = await active_space(session)
+    items = []
+    for space_key, n in counts.items():
+        model, _, dim = space_key.rpartition("@")
+        items.append(
+            {
+                "key": space_key,
+                "model": model or space_key,
+                "dim": int(dim) if dim.isdigit() else 0,
+                **n,
+                "active": active is not None and active.key == space_key,
+            }
+        )
+    items.sort(key=lambda item: (-item["papers"], item["key"]))
+    return items
+
+
+async def adopt_routed_model(session: AsyncSession) -> tuple[EmbeddingSpace, str | None]:
+    """把当前路由的嵌入模型定为激活空间，返回 (新空间, 旧空间 key)。
+
+    换嵌入模型的官方做法：改完路由表调用这里确认，之后新向量建到新空间，检索也只
+    认新空间——覆盖率会掉到 0 再由重建入口慢慢补回来。旧空间的向量原封不动留在库里，
+    再 adopt 回旧模型即可回滚。
+
+    维度不写死：这里现场探一次模型，用它**实际返回**的维度定义新空间。
+    """
+    from app.core.llm.router import get_llm_router
+
+    llm = get_llm_router()
+    model = await llm.model_name(EMBEDDING_STAGE)
+    if model is None:
+        raise NotImplementedError("no embedding model configured")
+    vectors = await llm.embed(["dimension probe"], stage=EMBEDDING_STAGE)
+    if not vectors or not vectors[0]:
+        raise NotImplementedError(f"model {model!r} returned no vector")
+    previous = await active_space(session)
+    space = EmbeddingSpace(model=model, dim=len(vectors[0]))
+    await set_active_space(session, space)
+    await session.commit()
+    return space, previous.key if previous is not None else None
+
+
+# ---- 读取 ----
+
+
+async def paper_vectors(
+    session: AsyncSession, paper_ids: Sequence[uuid.UUID], space: EmbeddingSpace
+) -> dict[uuid.UUID, list[float]]:
+    """取这些论文在给定空间下的向量（缺的不出现在结果里）。"""
+    if not paper_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(PaperVector.paper_id, PaperVector.embedding).where(
+                PaperVector.paper_id.in_(list(set(paper_ids))),
+                PaperVector.space == space.key,
+            )
+        )
+    ).all()
+    return {row[0]: list(row[1]) for row in rows}
+
+
+async def idea_vectors(
+    session: AsyncSession, idea_ids: Sequence[uuid.UUID], space: EmbeddingSpace
+) -> dict[uuid.UUID, list[float]]:
+    """取这些想法在给定空间下的向量（缺的不出现在结果里）。"""
+    if not idea_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(IdeaVector.idea_id, IdeaVector.embedding).where(
+                IdeaVector.idea_id.in_(list(set(idea_ids))),
+                IdeaVector.space == space.key,
+            )
+        )
+    ).all()
+    return {row[0]: list(row[1]) for row in rows}
+
+
+async def papers_with_vector(
+    session: AsyncSession, paper_ids: Sequence[uuid.UUID], space: EmbeddingSpace
+) -> set[uuid.UUID]:
+    """这些论文里哪些已在给定空间下建好向量（只查 id，不取向量本体）。"""
+    if not paper_ids:
+        return set()
+    rows = (
+        await session.execute(
+            select(PaperVector.paper_id).where(
+                PaperVector.paper_id.in_(list(set(paper_ids))),
+                PaperVector.space == space.key,
+            )
+        )
+    ).scalars()
+    return set(rows)
+
+
+async def chunks_with_vector(
+    session: AsyncSession, chunk_ids: Sequence[uuid.UUID], space: EmbeddingSpace
+) -> set[uuid.UUID]:
+    """这些分段里哪些已在给定空间下建好向量。"""
+    if not chunk_ids:
+        return set()
+    rows = (
+        await session.execute(
+            select(PaperChunkVector.chunk_id).where(
+                PaperChunkVector.chunk_id.in_(list(set(chunk_ids))),
+                PaperChunkVector.space == space.key,
+            )
+        )
+    ).scalars()
+    return set(rows)

--- a/src/backend/app/services/lab.py
+++ b/src/backend/app/services/lab.py
@@ -13,15 +13,17 @@ import uuid
 from datetime import timedelta
 from typing import Any
 
-from sqlalchemy import String, and_, cast, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.embedding_space import active_space
 from app.models.base import utcnow
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
 from app.models.paper import Concept, Paper, PaperChunk
 from app.models.system_setting import SystemSetting
 from app.models.user import User
+from app.models.vectors import PaperChunkVector, PaperVector
 from app.services import graph as graph_service
 from app.services.chunks import chunk_vector_search_supported
 from app.services.concepts import library_concept_ids
@@ -41,15 +43,7 @@ async def _count(session: AsyncSession, stmt) -> int:
     return int((await session.execute(stmt)).scalar_one())
 
 
-def _has_vector(session: AsyncSession, column):
-    """「向量已建」判定。
-
-    postgres 上是 pgvector 列，NULL 判定就够；sqlite 上是 JSON 列，SQLAlchemy 会把
-    Python None 存成字面量 ``null``，只判 IS NOT NULL 会把没建向量的也算进来。
-    """
-    if session.get_bind().dialect.name == "postgresql":
-        return column.is_not(None)
-    return and_(column.is_not(None), cast(column, String) != "null")
+# 「向量已建」不再需要方言特判：向量在侧表里，有行即已建（embedding 列 NOT NULL）。
 
 
 # ---- 可见库集合 ----
@@ -118,19 +112,35 @@ async def lab_stats(session: AsyncSession, user: User) -> dict[str, Any]:
             .select_from(PaperChunk)
             .where(PaperChunk.paper_id.in_(member_ids)),
         )
-        chunks_with_embedding = await _count(
-            session,
-            select(func.count())
-            .select_from(PaperChunk)
-            .where(
-                PaperChunk.paper_id.in_(member_ids), _has_vector(session, PaperChunk.embedding)
-            ),
+        # 覆盖率按**激活空间**算：换了嵌入模型后如实掉下来，等重建补回，
+        # 而不是拿旧模型建的、检索已经用不上的向量充数。
+        space = await active_space(session)
+        chunks_with_embedding = (
+            await _count(
+                session,
+                select(func.count())
+                .select_from(PaperChunkVector)
+                .join(PaperChunk, PaperChunk.id == PaperChunkVector.chunk_id)
+                .where(
+                    PaperChunk.paper_id.in_(member_ids),
+                    PaperChunkVector.space == space.key,
+                ),
+            )
+            if space is not None
+            else 0
         )
-        papers_with_embedding = await _count(
-            session,
-            select(func.count())
-            .select_from(Paper)
-            .where(Paper.id.in_(member_ids), _has_vector(session, Paper.embedding)),
+        papers_with_embedding = (
+            await _count(
+                session,
+                select(func.count())
+                .select_from(PaperVector)
+                .where(
+                    PaperVector.paper_id.in_(member_ids),
+                    PaperVector.space == space.key,
+                ),
+            )
+            if space is not None
+            else 0
         )
 
     return {

--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -26,6 +26,7 @@ from app.models.paper import (
 )
 from app.models.project import Project
 from app.services import chunks as chunks_service
+from app.services.embedding import embed_query
 from app.services.libraries import (
     dedupe_member_rows,
     get_source_library_ids,
@@ -87,17 +88,20 @@ async def _retrieve_chunks(
 ) -> list[tuple[PaperChunk, float]]:
     """向量检索优先（postgres + embedding 可用），否则关键词降级；任何失败都不上抛。
 
-    典型失败：paper_chunks 表未迁移、embedding provider 挂了、向量维度不匹配——
-    统一 rollback 后逐级降级（向量 → 关键词 → 空，空由调用方走论文摘要兜底）。
-    传 paper_ids 时把检索限制在这些论文内（伴读引用指定文献用）。
+    典型失败：paper_chunks 表未迁移、embedding provider 挂了、平台还没建过向量、
+    管理员换了嵌入模型而索引尚未重建——统一 rollback 后逐级降级（向量 → 关键词 →
+    空，空由调用方走论文摘要兜底）。传 paper_ids 时把检索限制在这些论文内。
     """
     if chunks_service.chunk_vector_search_supported(session):
         try:
-            vectors = await llm.embed([question], user_id=user_id, project_id=project_id)
+            vector, space = await embed_query(
+                session, question, user_id=user_id, project_id=project_id
+            )
             rows = await chunks_service.semantic_search_chunks(
                 session,
                 library_ids=library_ids,
-                query_vector=vectors[0],
+                query_vector=vector,
+                space=space,
                 limit=MAX_CHUNKS,
                 paper_ids=paper_ids,
             )

--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -19,7 +19,7 @@ from app.core.llm.anthropic import AnthropicProvider
 from app.core.llm.base import LLMProvider, Message
 from app.core.llm.fake import FakeProvider
 from app.core.llm.openai_compat import OpenAICompatProvider
-from app.core.llm.router import STAGES, get_llm_router
+from app.core.llm.router import GLOBAL_ONLY_STAGES, STAGES, get_llm_router
 from app.core.security import decrypt_secret, encrypt_secret
 from app.models.base import utcnow
 from app.models.llm_config import LLMCallLog, LLMProviderConfig, LLMUsage, ModelRoute
@@ -137,11 +137,21 @@ async def list_routes(
 async def replace_routes(
     session: AsyncSession, items: Sequence[RouteItem], owner_id: uuid.UUID | None = None
 ) -> Sequence[ModelRoute]:
-    """整表覆盖某 owner 的路由。stage 必须合法且不重复，provider 必须属于同一 owner。"""
+    """整表覆盖某 owner 的路由。stage 必须合法且不重复，provider 必须属于同一 owner。
+
+    个人路由表里不接受嵌入环节：向量是全平台共享的一份数据，每个人各用各的模型
+    建向量，池子里就会混进互不可比的坐标系（见 core/llm/router.py 的
+    ``GLOBAL_ONLY_STAGES``）。传了也不会生效，所以直接拒绝而不是静默丢弃。
+    """
     seen: set[str] = set()
     for item in items:
         if item.stage not in STAGES:
             raise InvalidRouteError(f"unknown stage: {item.stage}")
+        if owner_id is not None and item.stage in GLOBAL_ONLY_STAGES:
+            raise InvalidRouteError(
+                f"stage '{item.stage}' is set centrally by the admin and cannot be "
+                "configured per user"
+            )
         if item.stage in seen:
             raise InvalidRouteError(f"duplicate stage: {item.stage}")
         seen.add(item.stage)

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import utcnow
+from app.core.embedding_space import active_space
 from app.models.library_direction import DirectionLibrary
 from app.models.paper import Paper
 
@@ -47,16 +47,23 @@ _TASKS: dict[str, asyncio.Task] = {}
 Emit = Callable[..., Awaitable[None]]
 
 
-def paper_processing_complete(paper: Paper) -> bool:
-    """论文是否已处理完整（PDF + 全文 + 向量都在）——完整则无需再启动补全任务。"""
-    return bool(paper.pdf_path and paper.full_text_path and paper.embedding is not None)
+async def paper_processing_complete(session: AsyncSession, paper: Paper) -> bool:
+    """论文是否已处理完整（PDF + 全文 + 当前空间下的向量都在）——完整则无需再补全。
+
+    「有向量」按**激活空间**算：换了嵌入模型之后，旧空间的向量对检索已经不可见，
+    这篇论文就该重新走一遍补全，而不是因为库里还留着旧向量就认为它已就绪。
+    """
+    if not (paper.pdf_path and paper.full_text_path):
+        return False
+    return await has_current_paper_vector(session, paper)
 
 
 def paper_embedding_text(paper: Paper) -> str:
     """论文级向量的统一文本口径：标题 + 作者名 + 摘要（截断 EMBED_TEXT_MAX_CHARS 字）。
 
-    三处生成 Paper.embedding 的地方共用（手动添加补全、ingest 上链批量、每日池批量），
+    三处生成论文级向量的地方共用（手动添加补全、ingest 上链批量、每日池批量），
     保证同一批向量在同一口径下可比。作者名进文本是为了「找某人的工作」这类检索。
+    口径若要改，同时把 services/embedding.py 的 TEXT_VERSION +1。
     """
     names: list[str] = []
     for item in paper.authors or []:
@@ -67,30 +74,39 @@ def paper_embedding_text(paper: Paper) -> str:
     return "\n".join(parts)[:EMBED_TEXT_MAX_CHARS]
 
 
+async def has_current_paper_vector(session: AsyncSession, paper: Paper) -> bool:
+    """这篇论文在激活空间下已有论文级向量？（没有激活空间 = 还没建过任何向量）"""
+    space = await active_space(session)
+    if space is None:
+        return False
+    from app.services.embedding import papers_with_vector
+
+    return bool(await papers_with_vector(session, [paper.id], space))
+
+
 async def embed_paper(
+    session: AsyncSession,
     paper: Paper,
     *,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
     library_id: uuid.UUID | None = None,
 ) -> None:
-    """为论文生成 Paper.embedding（文本口径见 paper_embedding_text）。
+    """为论文建论文级向量（文本口径见 paper_embedding_text）。调用方负责 commit。
 
-    顺带记下构建时间与所用模型名（前端索引状态悬浮显示）。
-    provider 不支持嵌入时抛 NotImplementedError（调用方按 skipped 处理）。
+    向量写进 paper_vectors 并带上所属空间。provider 不支持嵌入时抛
+    NotImplementedError（调用方按 skipped 处理）。
     """
-    from app.core.llm.router import get_llm_router
+    from app.services.embedding import embed_documents, upsert_paper_vector
 
-    llm = get_llm_router()
-    vectors = await llm.embed(
+    vectors, space = await embed_documents(
+        session,
         [paper_embedding_text(paper)],
         user_id=user_id,
         project_id=project_id,
         library_id=library_id,
     )
-    paper.embedding = vectors[0]
-    paper.embedding_at = utcnow()
-    paper.embedding_model = await llm.model_name("embedding", user_id)
+    await upsert_paper_vector(session, paper.id, vectors[0], space)
 
 
 async def enrich_paper(
@@ -199,11 +215,12 @@ async def enrich_paper(
 
     # ---- embed ----
     await emit("embed", "running")
-    if paper.embedding is not None:
+    if await has_current_paper_vector(session, paper):
         await emit("embed", "skipped", "already embedded")
     else:
         try:
             await embed_paper(
+                session,
                 paper,
                 user_id=user_id,
                 project_id=project_id,

--- a/src/backend/app/services/paper_index.py
+++ b/src/backend/app/services/paper_index.py
@@ -18,8 +18,10 @@ from datetime import datetime
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.embedding_space import active_space
 from app.core.llm.router import LLMRouter
 from app.models.paper import Paper, PaperChunk
+from app.models.vectors import PaperChunkVector, PaperVector
 from app.services.chunks import (
     embed_pending_chunks_for_papers,
     index_paper_abstract,
@@ -36,11 +38,17 @@ class IndexRebuildFailedError(Exception):
 
 @dataclass
 class VectorStatus:
-    """一种向量的状态：有没有、什么时候建的、用的哪个模型。"""
+    """一种向量的状态：有没有、什么时候建的、用的哪个模型。
+
+    ``built`` 只看**当前激活空间**：换了嵌入模型之后，旧空间的向量对检索不可见，
+    这里就该显示「未建」。``stale`` 区分「从来没建过」和「建过但属于旧模型、等着
+    重建」——前端据此显示不同的提示，免得用户以为数据丢了。
+    """
 
     built: bool
     built_at: datetime | None
     model: str | None
+    stale: bool = False
 
 
 @dataclass
@@ -54,33 +62,62 @@ class PaperIndexStatus:
 
 
 async def get_index_status(session: AsyncSession, paper: Paper) -> PaperIndexStatus:
-    """查一篇论文的两种向量状态（两条聚合查询，不读向量本体）。"""
+    """查一篇论文的两种向量状态（只读元信息，不取向量本体）。"""
+    space = await active_space(session)
     row = (
         await session.execute(
-            select(
-                func.count(PaperChunk.id),
-                func.count(PaperChunk.embedding),  # count(col) 不计 NULL
-                func.max(PaperChunk.source),
-            ).where(PaperChunk.paper_id == paper.id)
+            select(func.count(PaperChunk.id), func.max(PaperChunk.source)).where(
+                PaperChunk.paper_id == paper.id
+            )
         )
     ).one()
-    chunk_count, embedded_count, source = int(row[0]), int(row[1]), row[2]
+    chunk_count, source = int(row[0]), row[1]
+
+    paper_rows = (
+        (
+            await session.execute(
+                select(PaperVector).where(PaperVector.paper_id == paper.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    chunk_rows = (
+        (
+            await session.execute(
+                select(PaperChunkVector)
+                .join(PaperChunk, PaperChunk.id == PaperChunkVector.chunk_id)
+                .where(PaperChunk.paper_id == paper.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    current_chunk_rows = [
+        v for v in chunk_rows if space is not None and v.space == space.key
+    ]
     return PaperIndexStatus(
-        paper_vector=VectorStatus(
-            built=paper.embedding is not None,
-            built_at=paper.embedding_at,
-            model=paper.embedding_model,
-        ),
-        chunk_vector=VectorStatus(
-            built=embedded_count > 0,
-            built_at=paper.chunk_embedding_at,
-            model=paper.chunk_embedding_model,
-        ),
+        paper_vector=_vector_status(paper_rows, space),
+        chunk_vector=_vector_status(chunk_rows, space),
         chunk_count=chunk_count,
-        embedded_chunk_count=embedded_count,
+        embedded_chunk_count=len(current_chunk_rows),
         has_fulltext=bool(paper.full_text_path),
         chunk_source=source,
     )
+
+
+def _vector_status(rows: list, space) -> VectorStatus:
+    """把若干空间的向量行折成一个状态：优先报激活空间那条，否则报「等待重建」。"""
+    current = [v for v in rows if space is not None and v.space == space.key]
+    if current:
+        newest = max(current, key=lambda v: v.built_at)
+        return VectorStatus(built=True, built_at=newest.built_at, model=newest.model)
+    if rows:  # 只有别的空间的向量：建过，但当前模型下不可用
+        newest = max(rows, key=lambda v: v.built_at)
+        return VectorStatus(
+            built=False, built_at=newest.built_at, model=newest.model, stale=True
+        )
+    return VectorStatus(built=False, built_at=None, model=None)
 
 
 async def rebuild_index(
@@ -105,7 +142,7 @@ async def rebuild_index(
 
     if "paper" in targets:
         try:
-            await embed_paper(paper, user_id=user_id, project_id=project_id)
+            await embed_paper(session, paper, user_id=user_id, project_id=project_id)
             await session.commit()
         except Exception as e:  # noqa: BLE001 — provider 不支持嵌入等：记下继续
             logger.warning("paper embedding rebuild failed for %s", paper.id, exc_info=True)

--- a/src/backend/app/services/paper_merge.py
+++ b/src/backend/app/services/paper_merge.py
@@ -31,6 +31,7 @@ from app.models.paper import (
 )
 from app.models.publication import UserPublication
 from app.models.topic_shelf import TopicPaper
+from app.models.vectors import PaperVector
 
 # 内容池行上「keep 缺则用 drop 补」的字段（判断性字段在成员行，另行处理）
 _FILLABLE_PAPER_FIELDS = (
@@ -45,7 +46,7 @@ _FILLABLE_PAPER_FIELDS = (
     "full_text_path",
     "tldr",
     "figures",
-    "embedding",
+    # 向量不在这张表上（paper_vectors，每个空间一行），按空间逐个补，见 _merge_paper_vectors
     "affiliations",
     "authors",
 )
@@ -61,6 +62,41 @@ _FILLABLE_MEMBERSHIP_FIELDS = (
 _READING_ORDER = {"unread": 0, "reading": 1, "read": 2}
 # 成员行状态推进序（excluded/included 人工态不参与自动升级）
 _STATUS_ORDER = {"candidate": 0, "scored": 1, "fetched": 2, "compiled": 3}
+
+
+async def _merge_paper_vectors(
+    session: AsyncSession, *, keep_id: uuid.UUID, drop_id: uuid.UUID
+) -> int:
+    """把 drop 独有空间的论文级向量搬给 keep，返回搬了几条。
+
+    按**空间**逐个补：keep 在某个空间下已经有向量就保留自己的（它是这一行的主体），
+    只有 keep 缺、drop 有的空间才搬过来。剩下的 drop 向量随 drop 行级联删除。
+    """
+    keep_spaces = set(
+        (
+            await session.execute(
+                select(PaperVector.space).where(PaperVector.paper_id == keep_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    moved = 0
+    rows = (
+        (
+            await session.execute(
+                select(PaperVector).where(PaperVector.paper_id == drop_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        if row.space in keep_spaces:
+            continue
+        row.paper_id = keep_id
+        moved += 1
+    return moved
 
 
 async def _repoint_associations(
@@ -272,6 +308,10 @@ async def merge_papers(
             or 0
         )
     report["chunks_moved"] = chunks_moved
+    # 分段向量以 chunk_id 为键，随分段一起搬走，不用单独处理；论文级向量按空间补
+    report["vectors_moved"] = await _merge_paper_vectors(
+        session, keep_id=keep_id, drop_id=drop_id
+    )
 
     # ---- 8. 内容池行缺项回填（keep 缺 → 用 drop 的） ----
     filled: list[str] = []

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -21,6 +21,7 @@ from sqlalchemy import Text as SAText
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.embedding_space import EmbeddingSpace
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
 from app.models.daily_feed import DailyFeedEntry
@@ -943,12 +944,12 @@ async def fetch_pdf(
         await ensure_paper_chunks(session, paper)
     except Exception:  # noqa: BLE001
         logger.warning("chunk indexing failed for paper %s", paper.id, exc_info=True)
-    # 论文级向量：缺就补。best-effort，不影响 PDF 落盘
-    if paper.embedding is None:
-        from app.services.paper_enrich import embed_paper
+    # 论文级向量：激活空间下缺就补。best-effort，不影响 PDF 落盘
+    from app.services.paper_enrich import embed_paper, has_current_paper_vector
 
+    if not await has_current_paper_vector(session, paper):
         try:
-            await embed_paper(paper, user_id=user_id, project_id=project_id)
+            await embed_paper(session, paper, user_id=user_id, project_id=project_id)
         except Exception:  # noqa: BLE001 — provider 不支持嵌入等：降级为无向量
             logger.warning("paper embedding failed for paper %s", paper.id, exc_info=True)
     # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
@@ -1140,9 +1141,14 @@ async def semantic_search_papers(
     project_id: uuid.UUID | None = None,
     library_id: uuid.UUID | None = None,
     query_vector: list[float],
+    space: EmbeddingSpace,
     limit: int,
 ) -> list[tuple[PaperView, float]]:
-    """pgvector 余弦检索（仅 postgres；调用方需先判 semantic_search_supported）。"""
+    """pgvector 余弦检索（仅 postgres；调用方需先判 semantic_search_supported）。
+
+    只跟 ``space`` 这一个向量空间里的论文比较——别的空间的向量出自别的模型，
+    余弦值没有可比性。
+    """
     library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
     if not library_ids:
         return []
@@ -1151,15 +1157,21 @@ async def semantic_search_papers(
     rows = (
         await session.execute(
             text(
-                "SELECT DISTINCT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
-                "FROM papers p "
+                "SELECT DISTINCT p.id, 1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM paper_vectors v "
+                "JOIN papers p ON p.id = v.paper_id "
                 "JOIN library_papers lp ON lp.paper_id = p.id "
                 "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
-                "WHERE p.embedding IS NOT NULL "
+                "WHERE v.space = :space "
                 "ORDER BY score DESC "
                 "LIMIT :k"
             ),
-            {"qv": qv, "libs": [str(lid) for lid in library_ids], "k": limit},
+            {
+                "qv": qv,
+                "libs": [str(lid) for lid in library_ids],
+                "k": limit,
+                "space": space.key,
+            },
         )
     ).all()
     if not rows:

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -13,6 +13,7 @@ from sqlalchemy import cast as sa_cast
 from sqlalchemy import delete, exists, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.embedding_space import EmbeddingSpace
 from app.models.base import utcnow
 from app.models.library import UserLibraryEntry
 from app.models.paper import Paper, PaperUserMeta, UserPaperTag
@@ -163,11 +164,12 @@ async def semantic_saved_entries(
     *,
     user_id: uuid.UUID,
     query_vector: list[float],
+    space: EmbeddingSpace,
     limit: int,
 ) -> list[tuple[UserLibraryEntry, float]]:
     """对本人收藏、且软引用论文有向量的条目跑 pgvector 余弦，返回 (条目, 相似度) 降序。
 
-    候选集 = saved 且 last_paper_id 非空的条目里，其 Paper.embedding 非空的那些
+    候选集 = saved 且 last_paper_id 非空的条目里，其论文在 ``space`` 下已建向量的那些
     （覆盖不全的已知限制：没生成向量的收藏不会命中）。仅 postgres，调用方需先判
     semantic_search_supported。条目自身带 title/authors 快照，命中即可直接渲染成个人库行。
     """
@@ -186,13 +188,18 @@ async def semantic_saved_entries(
     rows = (
         await session.execute(
             text(
-                "SELECT p.id, 1 - (p.embedding <=> CAST(:qv AS vector)) AS score "
-                "FROM papers p "
-                "WHERE p.id = ANY(CAST(:ids AS uuid[])) AND p.embedding IS NOT NULL "
+                "SELECT v.paper_id AS id, 1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM paper_vectors v "
+                "WHERE v.paper_id = ANY(CAST(:ids AS uuid[])) AND v.space = :space "
                 "ORDER BY score DESC "
                 "LIMIT :k"
             ),
-            {"qv": qv, "ids": [str(pid) for pid in by_pid], "k": limit},
+            {
+                "qv": qv,
+                "ids": [str(pid) for pid in by_pid],
+                "k": limit,
+                "space": space.key,
+            },
         )
     ).all()
     return [(by_pid[row.id], float(row.score)) for row in rows if row.id in by_pid]

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -13,6 +13,7 @@ from app.models.paper import Paper, PaperChunk
 from app.services import chunks as chunks_service
 from app.services import graph as graph_service
 from app.services import search as search_service
+from app.services.embedding import embed_query
 from app.services.libraries import get_source_library_ids, membership_for_project
 from app.tools.context import ToolContext
 from app.tools.registry import tool
@@ -52,14 +53,19 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
             and chunks_service.chunk_vector_search_supported(session)
         ):
             try:
-                vectors = await ctx.llm.embed(
-                    [query],
+                vector, space = await embed_query(
+                    session,
+                    query,
                     user_id=ctx.user_id,
                     project_id=ctx.project_id,
                     voyage_id=ctx.voyage_id,
                 )
                 rows = await chunks_service.semantic_search_chunks(
-                    session, library_ids=library_ids, query_vector=vectors[0], limit=k
+                    session,
+                    library_ids=library_ids,
+                    query_vector=vector,
+                    space=space,
+                    limit=k,
                 )
                 used_mode = "semantic"
             except Exception:  # noqa: BLE001 — embedding 服务挂了也要能用，降级到关键词

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -17,6 +17,7 @@ from app.models.paper import Concept, Paper
 from app.services import concepts as concepts_service
 from app.services import papers as papers_service
 from app.services.concepts import library_concept_ids
+from app.services.embedding import embed_query
 from app.services.libraries import get_source_library_ids, membership_for_project
 from app.services.paper_review import relevant_excerpt
 from app.services.papers import PaperView
@@ -95,14 +96,19 @@ async def search_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
         used_mode = "keyword"
         if mode == "semantic" and papers_service.semantic_search_supported(session):
             try:
-                vectors = await ctx.llm.embed(
-                    [query],
+                vector, space = await embed_query(
+                    session,
+                    query,
                     user_id=ctx.user_id,
                     project_id=ctx.project_id,
                     voyage_id=ctx.voyage_id,
                 )
                 rows = await papers_service.semantic_search_papers(
-                    session, project_id=ctx.project_id, query_vector=vectors[0], limit=k
+                    session,
+                    project_id=ctx.project_id,
+                    query_vector=vector,
+                    space=space,
+                    limit=k,
                 )
                 used_mode = "semantic"
             except Exception:  # noqa: BLE001 — embedding 服务挂了也要能用，降级到关键词

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -148,7 +148,8 @@ async def add_paper(session, *, project_id, **fields):
     """测试造数据统一入口：建内容池 Paper + 起源库成员行（+ 可选解读），返回 Paper。
 
     兼容旧单表口径：status/relevance_score 等判断字段自动落成员行，
-    wiki_content/compiled_model 落论文级唯一解读行 paper_wikis。
+    wiki_content/compiled_model 落论文级唯一解读行 paper_wikis，
+    ``embedding=[...]`` 落向量侧表 paper_vectors（激活空间，见 tests/vector_helpers.py）。
     ``concepts=[Concept, ...]`` 直接写 paper_concepts 关联（Paper.concepts 关系是只读的
     ——它只展示已转正的概念，写关联一律走关联表）。
     """
@@ -158,6 +159,7 @@ async def add_paper(session, *, project_id, **fields):
     from app.models.paper import PaperWiki, new_paper, paper_concepts
 
     concepts = fields.pop("concepts", None) or []
+    embedding = fields.pop("embedding", None)
     member_kwargs = {k: fields.pop(k) for k in list(fields) if k in _MEMBERSHIP_FIELDS}
     member_kwargs.setdefault("status", "candidate")
     wiki_kwargs = {_WIKI_FIELDS[k]: fields.pop(k) for k in list(fields) if k in _WIKI_FIELDS}
@@ -180,6 +182,10 @@ async def add_paper(session, *, project_id, **fields):
         session.add(wiki)
         paper.wiki = wiki
     await session.flush()
+    if embedding is not None:
+        from tests.vector_helpers import set_paper_vector
+
+        await set_paper_vector(session, paper.id, list(embedding))
     return paper
 
 

--- a/src/backend/tests/test_daily_embed_search_export.py
+++ b/src/backend/tests/test_daily_embed_search_export.py
@@ -10,9 +10,11 @@ from app.core.db import get_sessionmaker
 from app.core.llm.fake import fake_embedding
 from app.models.daily_feed import DailyFeedEntry
 from app.models.paper import Paper
+from app.models.vectors import PaperVector
 from app.services.paper_enrich import paper_embedding_text
 from tests.conftest import register_and_login
 from tests.test_daily_feed import _rss_entry, _run_sync
+from tests.vector_helpers import get_paper_vector, set_paper_vector
 
 pytestmark = pytest.mark.asyncio
 
@@ -63,8 +65,14 @@ async def test_embed_paper_uses_shared_text(client):
     from app.services.paper_enrich import embed_paper
 
     paper = _paper()
-    await embed_paper(paper)
-    assert paper.embedding == fake_embedding(paper_embedding_text(paper))
+    async with get_sessionmaker()() as session:
+        session.add(paper)
+        await session.flush()
+        await embed_paper(session, paper)
+        await session.commit()
+        assert await get_paper_vector(session, paper.id) == fake_embedding(
+            paper_embedding_text(paper)
+        )
 
 
 # ---- 2. 每日池建向量：开关 + 幂等 + 补建 ----
@@ -88,22 +96,25 @@ async def test_sync_embeds_every_paper_and_only_missing(client, monkeypatch):
     result = await _run_sync(monkeypatch, feed)
     assert result["created"] == 2 and result["embedded"] == 2
     papers = await _papers_in_pool()
-    for paper in papers:
-        assert paper.embedding == fake_embedding(paper_embedding_text(paper))
-        assert paper.embedding_at is not None  # 构建时间记下了
-        assert paper.embedding_model  # 模型名记下了
+    async with get_sessionmaker()() as session:
+        for paper in papers:
+            row = await session.execute(
+                select(PaperVector).where(PaperVector.paper_id == paper.id)
+            )
+            vector_row = row.scalar_one()
+            assert list(vector_row.embedding) == fake_embedding(paper_embedding_text(paper))
+            assert vector_row.built_at is not None  # 构建时间记下了
+            assert vector_row.model  # 模型名记下了
+            assert vector_row.space  # 属于哪个向量空间也记下了
 
     # 已有向量的不重嵌（哨兵向量原样保留）
-    sentinel = [0.5] * len(papers[0].embedding)
+    sentinel = [0.5] * 1024
     async with get_sessionmaker()() as session:
-        row = await session.get(Paper, papers[0].id)
-        row.embedding = sentinel
-        await session.commit()
+        await set_paper_vector(session, papers[0].id, sentinel)
     result = await _run_sync(monkeypatch, feed)
     assert result["embedded"] == 0
     async with get_sessionmaker()() as session:
-        row = await session.get(Paper, papers[0].id)
-        assert row.embedding == pytest.approx(sentinel)
+        assert await get_paper_vector(session, papers[0].id) == pytest.approx(sentinel)
 
 
 async def test_daily_papers_get_abstract_chunk(client, monkeypatch):

--- a/src/backend/tests/test_embedding_space.py
+++ b/src/backend/tests/test_embedding_space.py
@@ -1,0 +1,293 @@
+"""向量空间隔离：不同模型建的向量绝不参与同一次比较（issue #191）。
+
+改造前的失效方式是**静默的**：查询向量与文档向量出自不同模型时，维度不同才会报错，
+维度恰好相同时一路成功返回，只是排序全乱。所以这里的用例大多在验证「该拒绝的拒绝了」
+「该看不见的看不见」，而不只是happy path。
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.embedding_space import (
+    EmbeddingSpace,
+    EmbeddingSpaceMismatchError,
+    active_space,
+    set_active_space,
+)
+from app.core.llm.fake import EMBEDDING_DIM
+from app.core.llm.router import GLOBAL_ONLY_STAGES, LLMRouter
+from app.models.paper import new_paper
+from app.models.vectors import PaperVector
+from app.services.embedding import (
+    adopt_routed_model,
+    embed_documents,
+    embed_query,
+    papers_with_vector,
+    space_inventory,
+    upsert_paper_vector,
+)
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+from tests.vector_helpers import FAKE_SPACE, ensure_space, get_paper_vector, set_paper_vector
+
+OTHER_SPACE = EmbeddingSpace(model="some-other-model", dim=EMBEDDING_DIM)
+
+
+async def _pool_paper(session, title="Vector Owner") -> uuid.UUID:
+    """建一篇最简内容池论文（向量行有外键，不能挂在凭空的 id 上）。"""
+    paper = new_paper(title=title)
+    session.add(paper)
+    await session.flush()
+    return paper.id
+
+
+# ---- 1. 空间标识与首次初始化 ----
+
+
+async def test_first_embed_defines_the_space_from_the_model(client):
+    """维度不写死：平台第一次嵌入时按模型实际返回的维度定义激活空间。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        assert await active_space(session) is None  # 空库：还没有空间
+
+        vectors, space = await embed_documents(session, ["hello"])
+        await session.commit()
+
+        assert len(vectors[0]) == space.dim  # 空间维度 = 模型实际返回的维度
+        assert space.key == f"{space.model}@{space.dim}"
+        assert await active_space(session) == space  # 已持久化
+
+
+async def test_vectors_carry_their_space(client):
+    """每条向量都记着自己出自哪个模型、多少维——检索据此过滤。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        space = await ensure_space(session)
+        paper_id = await _pool_paper(session)
+        await upsert_paper_vector(session, paper_id, [0.0] * space.dim, space)
+        await session.commit()
+
+        stored = (
+            await session.execute(select(PaperVector).where(PaperVector.paper_id == paper_id))
+        ).scalar_one()
+        assert stored.space == space.key
+        assert stored.dim == space.dim
+        assert stored.model == space.model
+        assert stored.built_at is not None
+
+
+# ---- 2. 写入侧：维度/模型不符一律拒绝 ----
+
+
+async def test_wrong_dimension_is_refused_not_stored(client):
+    """维度对不上就抛错，绝不入库——sqlite 的 JSON 列本来会照单全收。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        space = await ensure_space(session)
+        paper_id = await _pool_paper(session)
+        with pytest.raises(EmbeddingSpaceMismatchError):
+            await upsert_paper_vector(session, paper_id, [0.0] * (space.dim + 1), space)
+
+
+async def test_model_change_blocks_writes_until_adopted(client, monkeypatch):
+    """换了嵌入模型但没确认 → 拒绝写入，而不是把两个模型的向量混进一个池子。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        await set_active_space(session, OTHER_SPACE)  # 假装存量向量出自别的模型
+        await session.commit()
+
+        with pytest.raises(EmbeddingSpaceMismatchError) as exc:
+            await embed_documents(session, ["hello"])
+        assert OTHER_SPACE.model in str(exc.value)
+
+
+async def test_adopt_switches_space_and_keeps_old_vectors(client):
+    """确认换用新模型：激活空间切过去，旧向量原样留在库里（可切回）。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        paper_id = await _pool_paper(session)
+        await set_active_space(session, OTHER_SPACE)
+        await session.commit()
+        await upsert_paper_vector(session, paper_id, [0.25] * OTHER_SPACE.dim, OTHER_SPACE)
+        await session.commit()
+
+        space, previous = await adopt_routed_model(session)
+        assert previous == OTHER_SPACE.key
+        assert space.key != OTHER_SPACE.key
+        assert await active_space(session) == space
+
+        # 旧向量还在，只是当前空间下查不到它
+        assert await papers_with_vector(session, [paper_id], space) == set()
+        assert await papers_with_vector(session, [paper_id], OTHER_SPACE) == {paper_id}
+
+
+# ---- 3. 读取侧：跨空间的向量看不见 ----
+
+
+async def test_lookups_never_cross_spaces(client):
+    """同一篇论文在两个空间各有一条向量，查哪个空间就只拿到哪一条。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        await ensure_space(session)
+        paper_id = await _pool_paper(session)
+        await upsert_paper_vector(session, paper_id, [0.1] * FAKE_SPACE.dim, FAKE_SPACE)
+        await upsert_paper_vector(session, paper_id, [0.9] * OTHER_SPACE.dim, OTHER_SPACE)
+        await session.commit()
+
+        assert await get_paper_vector(session, paper_id) == pytest.approx([0.1] * FAKE_SPACE.dim)
+        assert await papers_with_vector(session, [paper_id], OTHER_SPACE) == {paper_id}
+
+
+async def test_query_embedding_needs_a_space(client):
+    """平台一条向量都没建过时语义检索直接降级，不会拿无归属的向量去比。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        with pytest.raises(NotImplementedError):
+            await embed_query(session, "anything")
+
+
+async def test_model_change_degrades_search_instead_of_erroring(client):
+    """换了模型没确认时，语义检索降级到关键词，而不是 500。
+
+    读路径统一按 NotImplementedError 降级；只有写路径才把不一致当成硬错误。
+    """
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="degrade")
+    async with get_sessionmaker()() as session:
+        await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Searchable Paper",
+            doi="10.1/degrade",
+            status="compiled",
+        )
+        await session.commit()
+        await set_active_space(session, OTHER_SPACE)  # 现有向量出自别的模型
+        await session.commit()
+
+        with pytest.raises(NotImplementedError):
+            await embed_query(session, "anything")
+
+    resp = await client.get(
+        f"/api/projects/{project_id}/search",
+        params={"q": "Searchable", "mode": "semantic"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mode_used"] == "keyword", "该降级而不是报错"
+
+
+async def test_index_status_marks_stale_instead_of_missing(client):
+    """换模型后论文状态是「待重建」而不是「未构建」——不能让人以为数据丢了。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="stale")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Stale Vector", doi="10.1/stale"
+        )
+        await session.commit()
+        paper_id = paper.id
+        await set_paper_vector(session, paper_id)  # 建在 FAKE_SPACE 里
+
+    body = (await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)).json()
+    assert body["paper_vector"]["built"] is True
+    assert body["paper_vector"]["stale"] is False
+
+    # 管理员换了模型
+    async with get_sessionmaker()() as session:
+        await set_active_space(session, OTHER_SPACE)
+        await session.commit()
+
+    body = (await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)).json()
+    assert body["paper_vector"]["built"] is False, "旧空间的向量不算已建"
+    assert body["paper_vector"]["stale"] is True, "但也不是从没建过"
+    assert body["paper_vector"]["model"] == FAKE_SPACE.model  # 还能看出是谁建的
+
+
+# ---- 4. 嵌入模型不给用户自选 ----
+
+
+async def test_embedding_stage_ignores_user_routes(client):
+    """自管用户的 embedding 路由不生效：向量是全平台共享的一份数据。"""
+    assert "embedding" in GLOBAL_ONLY_STAGES
+    router = LLMRouter()
+    owner = await router._effective_owner(uuid.uuid4(), "embedding")
+    assert owner is None, "嵌入一律走全局配置"
+    # 对照：普通环节仍按用户自管状态解析
+    assert await router._effective_owner(None, "default") is None
+
+
+async def test_user_cannot_configure_embedding_route(client):
+    """个人路由表拒收 embedding 环节（填了也不会生效，所以直接报错而不是静默丢弃）。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    await client.post("/api/me/llm/self-manage", headers=headers)
+    resp = await client.post(
+        "/api/me/llm/providers",
+        json={"name": "mine", "kind": "fake", "base_url": None, "api_key": "x"},
+        headers=headers,
+    )
+    provider_id = resp.json()["id"]
+
+    resp = await client.put(
+        "/api/me/llm/routes",
+        json=[{"stage": "embedding", "provider_id": provider_id, "model": "my-embed"}],
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "embedding" in resp.json()["detail"]
+
+    # rerank 不受影响：逐条打分，没有跨调用可比性问题
+    resp = await client.put(
+        "/api/me/llm/routes",
+        json=[{"stage": "rerank", "provider_id": provider_id, "model": "my-rerank"}],
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---- 5. 管理端 ----
+
+
+async def test_admin_space_status_reports_mismatch(client):
+    """管理端如实报告「路由表配的模型 ≠ 现有向量的模型」。"""
+    token = await register_and_login(client)  # 首个用户 = admin
+    headers = {"Authorization": f"Bearer {token}"}
+    async with get_sessionmaker()() as session:
+        await set_active_space(session, OTHER_SPACE)
+        paper_id = await _pool_paper(session)
+        await session.commit()
+        await upsert_paper_vector(session, paper_id, [0.1] * OTHER_SPACE.dim, OTHER_SPACE)
+        await session.commit()
+
+    body = (await client.get("/api/admin/settings/embedding-space", headers=headers)).json()
+    assert body["active"]["model"] == OTHER_SPACE.model
+    assert body["active"]["papers"] == 1
+    assert body["mismatched"] is True, "配的模型已经不是建库那个了"
+
+    resp = await client.post("/api/admin/settings/embedding-space/adopt", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["previous"] == OTHER_SPACE.key
+
+    body = (await client.get("/api/admin/settings/embedding-space", headers=headers)).json()
+    assert body["mismatched"] is False
+    # 旧那批向量还在库里，只是不再是激活的
+    keys = {s["key"]: s["active"] for s in body["spaces"]}
+    assert keys[OTHER_SPACE.key] is False
+
+
+async def test_space_inventory_counts_each_kind(client):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        await ensure_space(session)
+        for i in range(2):
+            paper_id = await _pool_paper(session, title=f"Counted {i}")
+            await upsert_paper_vector(session, paper_id, [0.0] * FAKE_SPACE.dim, FAKE_SPACE)
+        await session.commit()
+        items = await space_inventory(session)
+    assert len(items) == 1
+    assert items[0]["papers"] == 2 and items[0]["active"] is True

--- a/src/backend/tests/test_enrich_chunk_index.py
+++ b/src/backend/tests/test_enrich_chunk_index.py
@@ -15,12 +15,15 @@ import respx
 from sqlalchemy import func, select
 
 from app.core.db import get_sessionmaker
+from app.core.embedding_space import active_space
 from app.models.paper import PaperChunk
+from app.models.vectors import PaperChunkVector
 from app.services import paper_enrich
 from app.services.literature import reset_clients, set_clients
 from app.services.literature.arxiv import ArxivClient
 from app.services.literature.openalex import OpenAlexClient
 from tests.conftest import add_paper, make_project_with_library, register_and_login
+from tests.vector_helpers import get_paper_vector, set_chunk_vector
 
 
 async def _noop_emit(stage: str, status: str, detail: str | None = None) -> None:
@@ -48,10 +51,15 @@ async def _n_chunks(session, paper_id):
 
 
 async def _n_embedded(session, paper_id):
+    """激活空间下已建向量的分段数（向量在侧表，见 app/models/vectors.py）。"""
+    space = await active_space(session)
+    if space is None:
+        return 0
     return await session.scalar(
         select(func.count())
-        .select_from(PaperChunk)
-        .where(PaperChunk.paper_id == paper_id, PaperChunk.embedding.is_not(None))
+        .select_from(PaperChunkVector)
+        .join(PaperChunk, PaperChunk.id == PaperChunkVector.chunk_id)
+        .where(PaperChunk.paper_id == paper_id, PaperChunkVector.space == space.key)
     )
 
 
@@ -98,8 +106,10 @@ async def test_enrich_does_not_reslice_existing_chunks(client, fake_redis):
         await session.commit()
         paper_id = paper.id
         # 预置一个「手工块」并打上可辨识向量
-        session.add(PaperChunk(paper_id=paper_id, seq=0, text="手工块", embedding=[0.5] * 1024))
+        chunk = PaperChunk(paper_id=paper_id, seq=0, text="手工块")
+        session.add(chunk)
         await session.commit()
+        await set_chunk_vector(session, chunk.id, [0.5] * 1024)
 
     await _run_enrich(paper_id, user_id=user_id)
 
@@ -148,7 +158,7 @@ async def test_fetch_pdf_builds_paper_vector_and_gated_blocks(client, fake_redis
         async with get_sessionmaker()() as session:
             paper = await session.get(paper_enrich.Paper, paper_id)
             assert paper.pdf_path  # 下载落盘
-            assert paper.embedding is not None  # 新增：论文级向量
+            assert await get_paper_vector(session, paper_id) is not None  # 论文级向量
             n = await _n_chunks(session, paper_id)
             assert n > 0
             assert await _n_embedded(session, paper_id) == n  # 开关开→块被嵌

--- a/src/backend/tests/test_idea_forge.py
+++ b/src/backend/tests/test_idea_forge.py
@@ -17,6 +17,7 @@ from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.idea import Idea
 from tests.conftest import RecordingBus, add_concept, add_paper, register_and_login
+from tests.vector_helpers import get_idea_vector
 
 DEFINITION = {"statement": "自动化科研 agent 的方法研究"}
 
@@ -133,7 +134,8 @@ async def test_forge_full_pipeline(client, queue_stub):
             assert all(0 <= v <= 10 for v in idea.scores.values())
             assert set(idea.score_rationale) == set(idea.scores)
             assert sorted(idea.parent_paper_ids) == sorted(paper_ids)
-            assert idea.embedding is not None and len(idea.embedding) == EMBEDDING_DIM
+            vector = await get_idea_vector(session, idea.id)
+            assert vector is not None and len(vector) == EMBEDDING_DIM
             assert "## 动机" in idea.content and "## 风险" in idea.content
             assert idea.depth == "sketch"
             assert idea.evidence and idea.evidence[0]["source"] == "signal"

--- a/src/backend/tests/test_lab_dashboard.py
+++ b/src/backend/tests/test_lab_dashboard.py
@@ -16,6 +16,7 @@ from app.models.llm_config import LLMUsage
 from app.models.paper import Concept, Paper, PaperChunk, paper_concepts
 from app.models.user import User
 from tests.conftest import register_and_login
+from tests.vector_helpers import set_chunk_vector, set_paper_vector
 
 
 async def _hdr(client, email):
@@ -50,19 +51,21 @@ async def _add_member(
     """建（或复用）一篇内容池论文并登记到若干库；可选顺带造全文分段与向量。"""
     async with get_sessionmaker()() as session:
         if paper_id is None:
-            paper = Paper(title=title, embedding=[0.1] * 4 if embedded else None)
+            paper = Paper(title=title)
             session.add(paper)
             await session.flush()
+            chunk_ids = []
             for seq in range(chunks):
-                session.add(
-                    PaperChunk(
-                        paper_id=paper.id,
-                        seq=seq,
-                        text=f"{title} chunk {seq}",
-                        embedding=[0.1] * 4 if embedded else None,
-                    )
-                )
+                chunk = PaperChunk(paper_id=paper.id, seq=seq, text=f"{title} chunk {seq}")
+                session.add(chunk)
+                await session.flush()
+                chunk_ids.append(chunk.id)
             paper_id = paper.id
+            await session.commit()
+            if embedded:
+                await set_paper_vector(session, paper_id)
+                for chunk_id in chunk_ids:
+                    await set_chunk_vector(session, chunk_id)
         for library_id in library_ids:
             session.add(
                 LibraryPaper(library_id=library_id, paper_id=paper_id, status=status)

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,9 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
+HEAD_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
+VECTOR_TABLES_REVISION = "5d8ebd5cb100"  # 向量侧表建表 + 存量搬迁
+EFFORT_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
 CHAT_BOT_REVISION = "d4e8b71c2a90"  # 每用户群机器人 Webhook 配置
 CONCEPT_STATUS_REVISION = "a9f1c62b70d5"  # 概念转正门槛（concepts.status）
 INDEX_META_REVISION = "c4e7b2a91f38"  # 分段来源标记 + 向量构建元信息
@@ -72,6 +74,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "user_library_entries",
                     "concepts",
                     "paper_chunks",
+                    "paper_vectors",
                     "paper_wikis",
                     "library_papers",
                     "daily_feed_entries",
@@ -100,13 +103,19 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
     assert "effort" in columns["model_routes"]  # 推理档位可配（NULL = 用模型默认）
-    assert "embedding" in columns["papers"]  # sqlite 分支 JSON variant 列保留
-    # 分段来源标记 + 两种向量各自的构建时间/模型名
-    assert "source" in columns["paper_chunks"]
-    assert {"embedding_model", "embedding_at"} <= columns["papers"]
-    assert {"chunk_embedding_model", "chunk_embedding_at"} <= columns["papers"]
+    # 向量搬进三张侧表，主表上的向量列与元信息列一并删除
+    assert {"paper_vectors", "paper_chunk_vectors", "idea_vectors"} <= columns["_tables"]
+    assert {"paper_id", "space", "dim", "embedding", "model", "built_at"} <= columns[
+        "paper_vectors"
+    ]
+    assert "embedding" not in columns["papers"]
+    assert not {"embedding_model", "embedding_at"} & columns["papers"]
+    assert not {"chunk_embedding_model", "chunk_embedding_at"} & columns["papers"]
+    assert "embedding" not in columns["paper_chunks"]
+    assert "embedding" not in columns["ideas"]
+    assert "source" in columns["paper_chunks"]  # 分段来源标记
     # M3 列仍在
-    assert {"score_rationale", "matches", "wins", "embedding"} <= columns["ideas"]
+    assert {"score_rationale", "matches", "wins"} <= columns["ideas"]
     assert "payload" in columns["review_sessions"]
     assert "author_name" in columns["review_messages"]
     assert "agent_persona" not in columns["review_messages"]
@@ -304,7 +313,22 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "last_delivered_at",
     } <= columns["chat_bot_configs"]
 
-    # 最新 revision 可往返：先退掉推理档位列。
+    # 最新 revision 可往返：先把主表向量列加回来（数据不搬回，见迁移 docstring）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == VECTOR_TABLES_REVISION
+    assert "embedding" in columns["papers"]
+    assert {"embedding_model", "chunk_embedding_model"} <= columns["papers"]
+    assert "paper_vectors" in columns["_tables"]  # 只退一步：侧表还在
+
+    # 再退掉三张侧表。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == EFFORT_REVISION
+    assert not {"paper_vectors", "paper_chunk_vectors", "idea_vectors"} & columns["_tables"]
+    assert "embedding" in columns["ideas"]
+
+    # 再退掉推理档位列。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == CHAT_BOT_REVISION

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -21,6 +21,12 @@ from app.models.paper import Paper, PaperChunk
 from app.services import paper_enrich
 from app.services.chunks import ensure_paper_chunks, keyword_search_chunks
 from tests.conftest import add_paper, make_project_with_library, register_and_login
+from tests.vector_helpers import (
+    get_chunk_vector,
+    get_paper_vector,
+    set_chunk_vector,
+    set_paper_vector,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -154,13 +160,10 @@ async def test_existing_fulltext_chunks_are_not_resliced(client):
         )
         await session.commit()
         paper_id = paper.id
-        session.add(
-            PaperChunk(
-                paper_id=paper_id, seq=0, text="手工全文块", source="fulltext",
-                embedding=[0.5] * 1024,
-            )
-        )
+        chunk = PaperChunk(paper_id=paper_id, seq=0, text="手工全文块", source="fulltext")
+        session.add(chunk)
         await session.commit()
+        await set_chunk_vector(session, chunk.id, [0.5] * 1024)
 
         assert await ensure_paper_chunks(session, paper) == 0
         chunks = await _chunks(session, paper_id)
@@ -183,20 +186,17 @@ async def test_abstract_chunk_copies_paper_vector(client):
             abstract="The chunk vector must be a copy.",
             doi="10.1/copyvec",
         )
-        paper.embedding = sentinel
-        paper.embedding_model = "sentinel-model"
         await session.commit()
         paper_id = paper.id
+        await set_paper_vector(session, paper_id, sentinel)
 
         await ensure_paper_chunks(session, paper)
         await session.commit()
 
         chunks = await _chunks(session, paper_id)
-        paper = await session.get(Paper, paper_id)
+        copied = await get_chunk_vector(session, chunks[0].id)
     assert len(chunks) == 1 and chunks[0].source == "abstract"
-    assert chunks[0].embedding == pytest.approx(sentinel), "摘要块向量应是论文级向量的拷贝"
-    # 元信息也跟着论文级向量走（本来就是同一份向量）
-    assert paper.chunk_embedding_model == "sentinel-model"
+    assert copied == pytest.approx(sentinel), "摘要块向量应是论文级向量的拷贝"
 
 
 async def test_abstract_chunk_vector_filled_in_later(client):
@@ -216,19 +216,19 @@ async def test_abstract_chunk_vector_filled_in_later(client):
         await session.commit()
         paper_id = paper.id
 
-        await ensure_paper_chunks(session, paper)  # 此刻 paper.embedding still None
+        await ensure_paper_chunks(session, paper)  # 此刻还没有论文级向量
         await session.commit()
-        assert (await _chunks(session, paper_id))[0].embedding is None
+        chunk_id = (await _chunks(session, paper_id))[0].id
+        assert await get_chunk_vector(session, chunk_id) is None
 
         # 论文级向量后来建好了
         sentinel = [0.375] * 1024
-        paper.embedding = sentinel
-        await session.commit()
+        await set_paper_vector(session, paper_id, sentinel)
         assert await sync_abstract_chunk_vectors(session, paper_ids=[paper_id]) == 1
         await session.commit()
 
-        chunks = await _chunks(session, paper_id)
-    assert chunks[0].embedding == pytest.approx(sentinel)
+        filled = await get_chunk_vector(session, chunk_id)
+    assert filled == pytest.approx(sentinel)
 
 
 async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
@@ -244,9 +244,9 @@ async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
             abstract="Copied vector please.",
             doi="10.1/librebuild",
         )
-        paper.embedding = sentinel  # 论文级向量已就位
         await session.commit()
         paper_id = paper.id
+        await set_paper_vector(session, paper_id, sentinel)  # 论文级向量已就位
 
     resp = await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
     assert resp.status_code == 200, resp.text
@@ -258,8 +258,9 @@ async def test_library_rebuild_copies_instead_of_embedding_abstract(client):
 
     async with get_sessionmaker()() as session:
         chunks = await _chunks(session, paper_id)
+        copied = await get_chunk_vector(session, chunks[0].id)
     assert chunks[0].source == "abstract"
-    assert chunks[0].embedding == pytest.approx(sentinel), "向量应是论文级向量的拷贝"
+    assert copied == pytest.approx(sentinel), "向量应是论文级向量的拷贝"
 
 
 # ---- 1c. 论文级向量的管理员总闸（默认开） ----
@@ -300,11 +301,12 @@ async def test_vectors_are_always_built(client, fake_redis):
     await _run_enrich(paper_id, user_id=user_id)
 
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, paper_id)
+        paper_vector = await get_paper_vector(session, paper_id)
         chunks = await _chunks(session, paper_id)
-    assert paper.embedding is not None, "论文级向量必须建"
+        chunk_vectors = [await get_chunk_vector(session, c.id) for c in chunks]
+    assert paper_vector is not None, "论文级向量必须建"
     assert chunks
-    assert all(c.embedding is not None for c in chunks), "块向量必须建"
+    assert all(v is not None for v in chunk_vectors), "块向量必须建"
 
 
 async def test_no_endpoint_can_turn_paper_embedding_off(client):
@@ -330,7 +332,12 @@ async def test_index_status_reports_time_and_model(client, fake_redis):
     resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["paper_vector"] == {"built": False, "built_at": None, "model": None}
+    assert body["paper_vector"] == {
+        "built": False,
+        "built_at": None,
+        "model": None,
+        "stale": False,
+    }
     assert body["chunk_vector"]["built"] is False
 
     await _run_enrich(paper_id, user_id=user_id)
@@ -382,11 +389,9 @@ async def test_manual_rebuild_overwrites_existing_vectors(client, fake_redis):
 
     sentinel = [0.25] * 1024
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, paper_id)
-        paper.embedding = sentinel
+        await set_paper_vector(session, paper_id, sentinel)
         for chunk in await _chunks(session, paper_id):
-            chunk.embedding = sentinel
-        await session.commit()
+            await set_chunk_vector(session, chunk.id, sentinel)
 
     resp = await client.post(f"/api/papers/{paper_id}/index/rebuild", headers=headers)
     assert resp.status_code == 200, resp.text
@@ -396,11 +401,12 @@ async def test_manual_rebuild_overwrites_existing_vectors(client, fake_redis):
     assert body["embedded_chunk_count"] == body["chunk_count"] > 0
 
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, paper_id)
+        paper_vector = await get_paper_vector(session, paper_id)
         chunks = await _chunks(session, paper_id)
-    assert paper.embedding != pytest.approx(sentinel), "论文级向量应被重建覆盖"
-    assert all(c.embedding is not None for c in chunks)
-    assert all(c.embedding != pytest.approx(sentinel) for c in chunks), "块向量应被重建覆盖"
+        chunk_vectors = [await get_chunk_vector(session, c.id) for c in chunks]
+    assert paper_vector != pytest.approx(sentinel), "论文级向量应被重建覆盖"
+    assert all(v is not None for v in chunk_vectors)
+    assert all(v != pytest.approx(sentinel) for v in chunk_vectors), "块向量应被重建覆盖"
 
 
 async def test_manual_rebuild_only_paper_vector(client, fake_redis):
@@ -412,8 +418,7 @@ async def test_manual_rebuild_only_paper_vector(client, fake_redis):
     sentinel = [0.25] * 1024
     async with get_sessionmaker()() as session:
         for chunk in await _chunks(session, paper_id):
-            chunk.embedding = sentinel
-        await session.commit()
+            await set_chunk_vector(session, chunk.id, sentinel)
 
     resp = await client.post(
         f"/api/papers/{paper_id}/index/rebuild",
@@ -424,7 +429,8 @@ async def test_manual_rebuild_only_paper_vector(client, fake_redis):
 
     async with get_sessionmaker()() as session:
         chunks = await _chunks(session, paper_id)
-    assert all(c.embedding == pytest.approx(sentinel) for c in chunks), "没请求重建就别动"
+        chunk_vectors = [await get_chunk_vector(session, c.id) for c in chunks]
+    assert all(v == pytest.approx(sentinel) for v in chunk_vectors), "没请求重建就别动"
 
 
 async def test_manual_rebuild_builds_index_from_scratch(client, fake_redis):

--- a/src/backend/tests/test_rerank.py
+++ b/src/backend/tests/test_rerank.py
@@ -19,6 +19,7 @@ from app.models.llm_config import LLMProviderConfig, LLMUsage, ModelRoute
 from app.models.paper import Paper
 from app.services import papers as papers_service
 from tests.conftest import add_paper, register_and_login
+from tests.vector_helpers import ensure_space
 
 # ---- provider 层 ----
 
@@ -160,10 +161,12 @@ async def _setup_semantic_project(client, monkeypatch):
         session.add_all([pa, pb])
         await session.commit()
         ordered_ids = [pa.id, pb.id]
+        # 语义检索要求平台已有激活向量空间（否则查询向量无从归属，直接降级关键词）
+        await ensure_space(session)
 
     monkeypatch.setattr(papers_service, "semantic_search_supported", lambda session: True)
 
-    async def fake_vector_search(session, *, project_id, query_vector, limit):
+    async def fake_vector_search(session, *, project_id, query_vector, space, limit):
         from tests.conftest import membership_of
 
         papers = (

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -16,12 +16,12 @@ from sqlalchemy import func, select
 
 from app.agents.voyage.engine import VoyageEngine
 from app.core.db import get_sessionmaker
-from app.core.llm.fake import FakeProvider
+from app.core.llm.fake import EMBEDDING_DIM, FakeProvider
 from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
-from app.models.paper import EMBEDDING_DIM, new_paper, paper_concepts
+from app.models.paper import new_paper, paper_concepts
 from app.models.user import User
 from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
@@ -41,6 +41,7 @@ from tests.conftest import (
     register_and_login,
     wiki_of,
 )
+from tests.vector_helpers import get_paper_vector
 
 DEFINITION = {
     "statement": "自动化科研 agent 的方法研究",
@@ -321,7 +322,8 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
             assert p.tldr
             assert "[[Agent]]" in wiki.content  # 双链
             assert p.full_text_path and p.pdf_path  # PDF 已抽全文
-            assert p.embedding is not None and len(p.embedding) == EMBEDDING_DIM
+            vector = await get_paper_vector(session, p.id)
+            assert vector is not None and len(vector) == EMBEDDING_DIM
             # 管线顺带提取论文图（小图被滤），compile 后由 fake VLM 注释
             assert p.figures == [
                 {

--- a/src/backend/tests/vector_helpers.py
+++ b/src/backend/tests/vector_helpers.py
@@ -1,0 +1,123 @@
+"""测试里读写向量的小工具（向量不在主表上，见 app/models/vectors.py）。
+
+fake provider 的向量是 1024 维（core/llm/fake.py），所以测试里手工造的向量默认
+也用这个维度和这个模型名，才能和走真实写入路径建出来的向量落在同一个空间里。
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.embedding_space import EmbeddingSpace, active_space, set_active_space
+from app.core.llm.fake import EMBEDDING_DIM
+from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
+from app.services.embedding import (
+    upsert_chunk_vector,
+    upsert_idea_vector,
+    upsert_paper_vector,
+)
+
+# fake provider 走的是 "fake-default" 路由（router._FALLBACK_ROUTE）
+FAKE_SPACE = EmbeddingSpace(model="fake-default", dim=EMBEDDING_DIM)
+
+
+async def ensure_space(session: AsyncSession, space: EmbeddingSpace = FAKE_SPACE):
+    """确保有激活空间（手工造向量时要先有它，否则检索侧无从过滤）。"""
+    current = await active_space(session)
+    if current is None:
+        await set_active_space(session, space)
+        await session.commit()
+        return space
+    return current
+
+
+async def set_paper_vector(
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    vector: list[float] | None = None,
+    *,
+    space: EmbeddingSpace = FAKE_SPACE,
+) -> None:
+    await ensure_space(session, space)
+    await upsert_paper_vector(session, paper_id, vector or [0.0] * space.dim, space)
+    await session.commit()
+
+
+async def set_chunk_vector(
+    session: AsyncSession,
+    chunk_id: uuid.UUID,
+    vector: list[float] | None = None,
+    *,
+    space: EmbeddingSpace = FAKE_SPACE,
+) -> None:
+    await ensure_space(session, space)
+    await upsert_chunk_vector(session, chunk_id, vector or [0.0] * space.dim, space)
+    await session.commit()
+
+
+async def set_idea_vector(
+    session: AsyncSession,
+    idea_id: uuid.UUID,
+    vector: list[float] | None = None,
+    *,
+    space: EmbeddingSpace = FAKE_SPACE,
+) -> None:
+    await ensure_space(session, space)
+    await upsert_idea_vector(session, idea_id, vector or [0.0] * space.dim, space)
+    await session.commit()
+
+
+async def get_paper_vector(
+    session: AsyncSession, paper_id: uuid.UUID
+) -> list[float] | None:
+    """该论文在激活空间下的向量（没有则 None）。"""
+    space = await active_space(session)
+    if space is None:
+        return None
+    row = (
+        await session.execute(
+            select(PaperVector.embedding).where(
+                PaperVector.paper_id == paper_id, PaperVector.space == space.key
+            )
+        )
+    ).scalar_one_or_none()
+    return list(row) if row is not None else None
+
+
+async def get_chunk_vector(
+    session: AsyncSession, chunk_id: uuid.UUID
+) -> list[float] | None:
+    space = await active_space(session)
+    if space is None:
+        return None
+    row = (
+        await session.execute(
+            select(PaperChunkVector.embedding).where(
+                PaperChunkVector.chunk_id == chunk_id,
+                PaperChunkVector.space == space.key,
+            )
+        )
+    ).scalar_one_or_none()
+    return list(row) if row is not None else None
+
+
+async def get_idea_vector(
+    session: AsyncSession, idea_id: uuid.UUID
+) -> list[float] | None:
+    space = await active_space(session)
+    if space is None:
+        return None
+    row = (
+        await session.execute(
+            select(IdeaVector.embedding).where(
+                IdeaVector.idea_id == idea_id, IdeaVector.space == space.key
+            )
+        )
+    ).scalar_one_or_none()
+    return list(row) if row is not None else None
+
+
+async def count_paper_vectors(session: AsyncSession) -> int:
+    rows = (await session.execute(select(PaperVector.paper_id))).scalars().all()
+    return len(rows)

--- a/src/frontend/src/components/ui/PaperIndexStatus.tsx
+++ b/src/frontend/src/components/ui/PaperIndexStatus.tsx
@@ -10,12 +10,22 @@ import { Icon } from './Icon';
  *
  * 红绿点鼠标悬浮显示构建时间与所用模型（存量数据没记过这两项，就只说建过了）。
  * 「构建 / 重新构建」按钮的文案随有没有索引切换——已有就是重建（覆盖旧向量）。
+ *
+ * 「待重建」（黄点）是换过向量模型之后的状态：向量还在，但出自旧模型，检索用不上
+ * 它了。与「从没建过」分开显示，否则换完模型满屏红点，看着像数据丢了。
  */
 
 function dotTitle(label: string, s: VectorStatus | undefined, note?: string): string {
   const head = (() => {
+    const when = s?.built_at ? fmtFullTime(s.built_at) : null;
+    if (s?.stale) {
+      const by = s.model ? tr(`（旧模型 ${s.model}）`, ` (old model ${s.model})`) : '';
+      return tr(
+        `${label}：待重建${by}——向量模型换过了，现有向量搜不了，重建一次即可`,
+        `${label}: needs rebuild${by} — the embedding model changed, so the existing vector is unusable; rebuild it`,
+      );
+    }
     if (!s?.built) return tr(`${label}：未构建`, `${label}: not built`);
-    const when = s.built_at ? fmtFullTime(s.built_at) : null;
     if (s.model && when) {
       return tr(`${label}：${when} 由 ${s.model} 构建`, `${label}: built ${when} by ${s.model}`);
     }
@@ -40,7 +50,14 @@ function Dot({
   partial?: boolean;
 }) {
   const built = !!status?.built;
-  const color = !built ? 'var(--danger)' : partial ? 'var(--warn)' : 'var(--ok)';
+  // 待重建也走黄点：有东西但当前用不上，和「从没建过」的红点区别开
+  const color = status?.stale
+    ? 'var(--warn)'
+    : !built
+      ? 'var(--danger)'
+      : partial
+        ? 'var(--warn)'
+        : 'var(--ok)';
   return (
     <span
       className="row gap6"

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -917,6 +917,8 @@ const MODELS_COLLAPSED = 3;
 interface LlmAdapter {
   /** query 缓存命名空间：admin 全局 'llm'，用户自管 'my-llm' */
   keyRoot: string;
+  /** 是否全局配置：向量嵌入只由管理员统一设置，个人配置里不出现这一行 */
+  global?: boolean;
   listProviders: () => Promise<LlmProviderRead[]>;
   createProvider: (input: LlmProviderInput) => Promise<LlmProviderRead>;
   patchProvider: (id: string, input: Partial<LlmProviderInput>) => Promise<LlmProviderRead>;
@@ -928,6 +930,7 @@ interface LlmAdapter {
 
 const adminLlmAdapter: LlmAdapter = {
   keyRoot: 'llm',
+  global: true,
   listProviders: () => api.listLlmProviders(),
   createProvider: (input) => api.createLlmProvider(input),
   patchProvider: (id, input) => api.patchLlmProvider(id, input),
@@ -1197,6 +1200,13 @@ const PRIMARY_STAGES: string[] = ['default', 'embedding', 'rerank'];
 /** 能力型环节：不跟随「默认」（对话模型没有嵌入/重排能力），未设置即为「未设置」。 */
 const CAPABILITY_STAGES = new Set(['embedding', 'rerank']);
 
+/**
+ * 只能由管理员统一设置的环节。向量嵌入在此：论文向量是全平台共享的一份数据，
+ * 每个人各用各的模型建向量，池子里就会混进互不可比的向量，检索排序会悄悄变乱
+ * （维度恰好一样时连报错都没有）。个人配置里直接不显示这一行，后端也会拒收。
+ */
+const GLOBAL_ONLY_STAGES = new Set(['embedding']);
+
 /** 按环节推断测试能力：embedding → embedding，rerank → rerank，其余 chat。 */
 function capabilityOf(stage: string): LlmTestCapability {
   if (stage === 'embedding') return 'embedding';
@@ -1331,6 +1341,8 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
     mutationFn: () => {
       const routes: LlmRoute[] = [];
       for (const stage of LLM_STAGES) {
+        // 个人路由表里不提交只能全局设置的环节（后端会 400）
+        if (!adapter.global && GLOBAL_ONLY_STAGES.has(stage)) continue;
         const r = rows[stage];
         if (!r || !r.provider_id || !r.model.trim()) continue;
         const t = r.temperature.trim();
@@ -1392,10 +1404,12 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
     }
   };
 
-  // 常驻行固定在顶部；展开区只包含其余环节（embedding/rerank 不重复出现）
-  const visibleStages: string[] = showAll
-    ? [...PRIMARY_STAGES, ...LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s))]
-    : PRIMARY_STAGES;
+  // 常驻行固定在顶部；展开区只包含其余环节（embedding/rerank 不重复出现）。
+  // 个人配置里去掉只能全局设置的环节（向量嵌入）——那一行填了也不会生效。
+  const allowed = (stage: string) => adapter.global || !GLOBAL_ONLY_STAGES.has(stage);
+  const visibleStages: string[] = (
+    showAll ? [...PRIMARY_STAGES, ...LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s))] : PRIMARY_STAGES
+  ).filter(allowed);
   // 收起态下有显式设置的隐藏行数（提示用）
   const hiddenExplicitCount = LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s) && rows[s]).length;
 
@@ -1406,7 +1420,9 @@ function RoutesSection({ adapter }: { adapter: LlmAdapter }) {
           <Icon name="git" size={15} style={{ color: 'var(--accent)' }} />
           {tr('模型路由表', 'Model routing')}{' '}
           <span className="en-label" style={{ fontSize: 11 }}>
-            {tr('未单独设置的环节自动跟随默认；向量嵌入/重排序需单独配置', 'stages without their own row follow "Default"; embeddings/reranking need their own config')}
+            {adapter.global
+              ? tr('未单独设置的环节自动跟随默认；向量嵌入/重排序需单独配置', 'stages without their own row follow "Default"; embeddings/reranking need their own config')
+              : tr('未单独设置的环节自动跟随默认；重排序需单独配置，向量嵌入由管理员统一设置', 'stages without their own row follow "Default"; reranking needs its own config, embeddings are set centrally by the admin')}
           </span>
         </span>
         <div className="row gap8">
@@ -1849,11 +1865,107 @@ function AffiliationModeSection() {
   );
 }
 
+/**
+ * 向量模型现状 + 换模型后的确认入口（admin）。
+ *
+ * 不同模型建出来的向量互相不能比，所以全平台同一时刻只认一批向量。换了模型之后
+ * 必须在这里确认一次：确认前新向量一律不写（不能把两个模型的向量混进一个池子），
+ * 确认后检索改认新的一批，旧的留在库里，随时可以切回去。
+ */
+function EmbeddingSpaceSection() {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: ['admin', 'embedding-space'],
+    queryFn: () => api.getEmbeddingSpace(),
+    retry: false,
+  });
+
+  const adoptMutation = useMutation({
+    mutationFn: () => api.adoptEmbeddingSpace(),
+    onSuccess: (r) => {
+      toast(
+        tr(`已改用 ${r.active.model}（${r.active.dim} 维）`, `Now using ${r.active.model} (${r.active.dim}-dim)`),
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'embedding-space'] });
+    },
+    onError: (e) => toast(`${tr('切换失败', 'Switch failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const active = data?.active ?? null;
+  const others = (data?.spaces ?? []).filter((s) => !s.active);
+
+  return (
+    <div className="card card-pad" style={{ marginTop: 20 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('向量模型', 'Embedding model')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.45, marginBottom: 12 }}>
+        {tr(
+          '语义检索靠向量。不同模型建出来的向量互相不能比，所以全平台只认一批。换模型后要在这里确认一次，确认后旧向量搜不到了，各处点「重新建立索引」逐步补回来。',
+          'Semantic search runs on vectors. Vectors from different models are not comparable, so the platform uses one batch at a time. After changing the model, confirm it here; the old vectors stop being searchable and are rebuilt gradually via "rebuild index".',
+        )}
+      </div>
+
+      {data?.mismatched && (
+        <div className="field-hint" style={{ marginBottom: 10, color: 'var(--warn-tx)' }}>
+          {tr(
+            `路由表里配的是 ${data.routed_model}，但现有向量出自 ${active?.model}。确认之前不会建任何新向量。`,
+            `Routing says ${data.routed_model}, but the existing vectors come from ${active?.model}. No new vectors are built until you confirm.`,
+          )}
+        </div>
+      )}
+
+      <div className="row gap8" style={{ alignItems: 'center' }}>
+        <div style={{ flex: 1, minWidth: 0, fontSize: 12.5 }}>
+          {active ? (
+            <>
+              <span className="mono">{active.model}</span>
+              <span style={{ color: 'var(--text-3)' }}>
+                {tr(
+                  ` · ${active.dim} 维 · 论文 ${active.papers} · 分段 ${active.chunks} · 想法 ${active.ideas}`,
+                  ` · ${active.dim}-dim · ${active.papers} papers · ${active.chunks} segments · ${active.ideas} ideas`,
+                )}
+              </span>
+            </>
+          ) : (
+            <span style={{ color: 'var(--text-3)' }}>
+              {tr('还没建过任何向量（第一次建索引时按模型实际维度自动确定）', 'No vectors yet — the first build sets the dimension from the model itself')}
+            </span>
+          )}
+        </div>
+        <button
+          className={data?.mismatched ? 'btn btn-primary sm' : 'btn btn-soft sm'}
+          disabled={adoptMutation.isPending || (!data?.routed_model)}
+          title={tr(
+            '确认改用路由表里当前的向量模型；旧向量保留，可以再切回来',
+            'Switch to the embedding model currently in the routing table; old vectors are kept and you can switch back',
+          )}
+          onClick={() => adoptMutation.mutate()}
+        >
+          <Icon name="check" size={12} />
+          {adoptMutation.isPending ? tr('切换中…', 'Switching…') : tr('确认换用当前模型', 'Use current model')}
+        </button>
+      </div>
+
+      {others.length > 0 && (
+        <div style={{ marginTop: 10, fontSize: 11.5, color: 'var(--text-3)' }}>
+          {tr('库里还留着：', 'Also kept: ')}
+          {others.map((s) => `${s.model}（${s.papers}）`).join('、')}
+          {tr('——旧向量不占检索，切回该模型即可重新用上。', ' — not searchable now; switch back to that model to use them again.')}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function LlmTab() {
   return (
     <>
       <ProvidersSection adapter={adminLlmAdapter} />
       <RoutesSection adapter={adminLlmAdapter} />
+      <EmbeddingSpaceSection />
       <AffiliationModeSection />
       <CallLogsSection />
     </>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -577,6 +577,32 @@ export interface DailyEmbedBackfillResult {
   failed: number;
 }
 
+/** 库里的一批向量：出自哪个模型、多少维、有多少条。 */
+export interface EmbeddingSpaceItem {
+  key: string;
+  model: string;
+  dim: number;
+  papers: number;
+  chunks: number;
+  ideas: number;
+  /** 检索当前用的就是这一批 */
+  active: boolean;
+}
+
+export interface EmbeddingSpaceStatus {
+  active: EmbeddingSpaceItem | null;
+  /** 路由表里现在配的向量模型 */
+  routed_model: string | null;
+  /** 配的模型已经不是建库那个了：新向量一律拒绝写入，需要确认换用 */
+  mismatched: boolean;
+  spaces: EmbeddingSpaceItem[];
+}
+
+export interface EmbeddingSpaceAdoptResult {
+  active: EmbeddingSpaceItem;
+  previous: string | null;
+}
+
 export interface LlmCallLogRow {
   id: string;
   created_at: string;
@@ -1056,9 +1082,12 @@ export interface QueuedIndexResult {
 
 /** 一种向量的状态：建没建、什么时候建的、用的哪个模型（存量数据没记过，为 null）。 */
 export interface VectorStatus {
+  /** 当前向量模型下是否已建（换过模型的话，旧向量不算） */
   built: boolean;
   built_at: string | null;
   model: string | null;
+  /** 建过、但出自换掉的旧模型，检索用不上，等重建 */
+  stale?: boolean;
 }
 
 /** 单篇论文的索引状态（docs/api-lit.md §9）。 */
@@ -3997,6 +4026,14 @@ export const api = {
   /** 给最近 7 天里还没有向量的每日论文补建向量（可能耗时几十秒）。 */
   backfillDailyEmbeddings(): Promise<DailyEmbedBackfillResult> {
     return request<DailyEmbedBackfillResult>('/admin/settings/daily-embed/backfill', { method: 'POST' });
+  },
+  /** 当前向量模型 + 库里各批向量的规模（admin）。 */
+  getEmbeddingSpace(): Promise<EmbeddingSpaceStatus> {
+    return request<EmbeddingSpaceStatus>('/admin/settings/embedding-space');
+  },
+  /** 确认换用路由表里当前的向量模型（换模型后必须调一次，admin）。 */
+  adoptEmbeddingSpace(): Promise<EmbeddingSpaceAdoptResult> {
+    return request<EmbeddingSpaceAdoptResult>('/admin/settings/embedding-space/adopt', { method: 'POST' });
   },
   putLlmCallLogSettings(enabled: boolean): Promise<LlmCallLogSettings> {
     return requestJson<LlmCallLogSettings>('/admin/llm/call-logs/settings', 'PUT', { enabled });


### PR DESCRIPTION
Vectors built by different embedding models live in unrelated coordinate systems, so a cosine
between them is noise. Polaris had no notion of that. Three consequences, the first of which fails
silently:

**1. The query vector and the document vectors could come from different models.** `embedding` was a
capability stage users could self-manage (`/me/llm`), and all eleven query-side embed calls passed
`user_id`. A self-managed user embedded their search text with *their* model and compared it against
a pool embedded with BGE-M3. When the dimensions differ, Postgres errors and the caller degrades to
keyword search. **When the dimensions happen to match — 1024 is a common size — nothing errors at
all.** The ranking is simply wrong, and neither the caller nor the user can tell.

**2. The document vectors were already mixed.** `papers.embedding` was written by three independent
paths, each using whatever the routing table said at the time. `papers.embedding_model` recorded the
name but no read path ever used it. `paper_chunks` and `ideas` had no model column at all — and
`actions_ideas` compares idea vectors against a fixed threshold.

**3. Changing the model had no migration path.** The dimension was hardcoded in two constants that
did not reference each other, and the only precedent was a hand-written migration that `UPDATE ... SET
embedding = NULL`-ed the whole column before `ALTER TYPE`. Every bulk rebuild entry point was
fill-the-gaps-only, so nothing would ever re-embed after a model change.

## What this does

Every vector row now carries a **space** — `<model>@<dim>` — and every read filters on it. Vectors
from different spaces cannot meet in one comparison, structurally.

- **Three side tables** (`paper_vectors`, `paper_chunk_vectors`, `idea_vectors`) replace the inline
  columns. One object can hold vectors in several spaces at once, which is what makes switching
  models a reversible operation instead of a destructive one. `embedding` is a **dimension-less**
  pgvector column, so moving to a 4096-dim model needs no `ALTER TABLE` — this is the direct fix for
  #191.
- **The dimension is never hardcoded.** The first successful embed defines the active space from the
  model's *actual* returned dimension.
- **One write gate.** `services/embedding.py::embed_documents` resolves the space, validates every
  returned vector's dimension, and raises rather than storing anything questionable — on SQLite the
  JSON column would otherwise swallow a wrong-sized vector silently.
- **The embedding model is global.** `embedding` joins `router.GLOBAL_ONLY_STAGES`, so a
  self-managed user's route is ignored for it and `/me/llm/routes` rejects the stage outright. The
  settings page drops the row from the personal view.
- **Changing the model is explicit.** Once the routed model differs from the active space, embedding
  refuses to run; an admin confirms via `POST /admin/settings/embedding-space/adopt`, which probes
  the model for its real dimension and switches. Old vectors stay in place, so adopting the previous
  model back is a complete rollback. A new admin card shows the active model, the row counts per
  space, and warns when the two disagree.
- **Reads degrade, they don't error.** A mismatch surfaces to search paths as the existing
  "semantic unavailable" signal, so the UI falls back to keyword and reports `mode_used` honestly
  instead of returning a plausible-looking wrong ranking.
- **Coverage tells the truth.** `/lab` stats, the daily-feed `vector_ready/vector_total`, and the
  per-paper index dots all count the active space only, so coverage drops honestly after a switch
  and the rebuild endpoints refill it. A paper whose only vectors are in an old space reports
  `stale`, shown as an amber "needs rebuild" rather than a red "never built" — otherwise a model
  change looks like data loss.

Three adjacent problems fixed along the way: `actions_proposal` pulled every vector in the library
into Python to compute cosines by hand (now pgvector on Postgres, with a bounded in-memory path on
SQLite); `ideas` vectors had no provenance at all while being compared against a fixed dedup
threshold; and `paper_merge` copied the `embedding` field between rows, which now merges per space.

## Migration

Two revisions. The first creates the tables and moves existing vectors, grouping each row by its own
`embedding_model`; rows predating that column (it was added later) are attributed to the embedding
model configured in the routing table, which is where they actually came from. The space holding the
most rows becomes active. If the pool already contains vectors from more than one model — possible
once per-user embedding routes existed — they are split into separate spaces rather than pretended
comparable. The second revision drops the old columns; it is separate so it can be rolled back on
its own.

## Tests

`ruff check app worker` clean; 806 backend tests pass (13 new ones in `test_embedding_space.py`
covering dimension refusal, cross-space invisibility, the global-route rule, search degradation on
mismatch, and the admin adopt flow); migration upgrade/downgrade round-trip extended over both new
revisions; `tsc --noEmit` and `vite build` clean.

Closes #191
