### PR TITLE
fix(vectors): give the backfill separate params for the space suffix and the dim

### DIFF
--- a/src/backend/alembic/versions/5d8ebd5cb100_vector_side_tables.py
+++ b/src/backend/alembic/versions/5d8ebd5cb100_vector_side_tables.py
@@ -104,13 +104,16 @@ def _migrate_existing_vectors(bind: sa.Connection, is_postgres: bool) -> None:
         ).scalar()
         or UNKNOWN_MODEL
     )
-    params = {"fallback": fallback, "dim": LEGACY_DIM}
+    # suffix 与 dim 必须是两个参数：同一个参数既参与字符串拼接又要塞进 integer 列时，
+    # postgres 会按第一次出现把它推断成 text，之后插 integer 列直接 DatatypeMismatch。
+    # （sqlite 类型宽松，不会暴露这个问题。）
+    params = {"fallback": fallback, "dim": LEGACY_DIM, "suffix": f"@{LEGACY_DIM}"}
 
     bind.execute(
         sa.text(
             "INSERT INTO paper_vectors "
             "(paper_id, space, dim, embedding, model, text_version, built_at) "
-            "SELECT p.id, COALESCE(p.embedding_model, :fallback) || '@' || :dim, :dim, "
+            "SELECT p.id, COALESCE(p.embedding_model, :fallback) || :suffix, :dim, "
             "p.embedding, COALESCE(p.embedding_model, :fallback), 1, "
             f"COALESCE(p.embedding_at, {now}) "
             "FROM papers p "
@@ -123,7 +126,7 @@ def _migrate_existing_vectors(bind: sa.Connection, is_postgres: bool) -> None:
             "INSERT INTO paper_chunk_vectors "
             "(chunk_id, space, dim, embedding, model, text_version, built_at) "
             "SELECT c.id, "
-            "COALESCE(p.chunk_embedding_model, p.embedding_model, :fallback) || '@' || :dim, "
+            "COALESCE(p.chunk_embedding_model, p.embedding_model, :fallback) || :suffix, "
             ":dim, c.embedding, "
             "COALESCE(p.chunk_embedding_model, p.embedding_model, :fallback), 1, "
             f"COALESCE(p.chunk_embedding_at, p.embedding_at, {now}) "


### PR DESCRIPTION
The vector backfill added in #208 fails on Postgres.

`_migrate_existing_vectors` passed a single `:dim` parameter to two different
things: a string concatenation building the space key (`|| '@' || :dim`) and the
integer `dim` column. Postgres infers a parameter's type from its first use, so
`:dim` became text and the insert failed:

```
DatatypeMismatchError: column "dim" is of type integer but expression is of type text
```

SQLite is permissive about types, so `test_migrations.py` — which runs the whole
chain on SQLite — never saw it. The failure appears only on a real Postgres
database, which is every deployment: `alembic upgrade head` aborts and the
backend cannot start (the ORM expects `paper_vectors`).

The fix splits the two uses into `:suffix` (text, `"@1024"`) and `:dim`
(integer). No behaviour change.

## Verified against a real Postgres + pgvector

Ran the full chain on the dev database rather than trusting SQLite again:

- `510f6bde2233 → 5d8ebd5cb100 → 929c05a03745` applies cleanly
- 267 paper vectors, 15968 chunk vectors, 27 idea vectors moved, all into a
  single `BGE-M3@1024` space (no split)
- `embedding_active_space` written as `{"model": "BGE-M3", "dim": 1024}`
- `paper_vectors.embedding` created as a dimension-less `vector` column — the
  point of #191, now confirmed on real pgvector
- a cosine query over the side table returns correctly (267 rows)
- API restarts clean against the migrated schema

The failed first attempt rolled back fully (transactional DDL), so no partial
state was left behind.
