### PR TITLE
feat(libraries): guide the statement, add exclude terms, split manual collection into two modes

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -31,6 +31,7 @@ from app.models.daily_feed import DailyFeedEntry
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, new_paper
 from app.models.voyage import VoyageStep
+from app.schemas.ingest import TIME_RANGE_DAYS
 from app.services.affiliations import (
     apply_author_affiliations,
     extract_author_affiliations_llm,
@@ -155,12 +156,16 @@ def _knobs(ctx: ActionContext) -> dict[str, Any]:
 
 
 def _mode(ctx: ActionContext) -> str:
+    """本次运行的收集模式：``search`` | ``snowball`` | ``incremental``。
+
+    ``bootstrap`` 是 ``search`` 的旧名；存量任务的 checkpoint 里还写着它。
+    """
     mode = _params(ctx).get("mode")
-    return (
-        mode
-        if mode in ("bootstrap", "incremental")
-        else ("bootstrap" if ctx.run.kind == "wiki_bootstrap" else "incremental")
-    )
+    if mode == "bootstrap":
+        return "search"
+    if mode in ("search", "snowball", "incremental"):
+        return mode
+    return "incremental" if ctx.run.kind == "wiki_ingest" else "search"
 
 
 async def _resolve_library(
@@ -302,6 +307,7 @@ async def _collect_from_daily_feed(
     *,
     library: DirectionLibrary,
     direction: str,
+    exclude: list[str],
     limit: int,
 ) -> dict[str, Any]:
     """增量同步的候选来源：每日论文池，不碰 arXiv。
@@ -313,9 +319,12 @@ async def _collect_from_daily_feed(
     重复送打分由 :func:`_existing_keys` 挡掉——它不按 status 过滤，所以昨天已判
     ``excluded`` 的论文今天不会再花一次 LLM。
 
-    **不按分类、也不按关键词筛。** 收录设置里的分类和关键词只在建库时用来构造 arXiv
-    检索式；同步时一律由相关度打分决定去留。两者都是硬门槛，配窄了会让库悄无声息地
-    颗粒无收，而「0 篇」和「今天确实没有相关论文」在界面上无法区分。
+    **不按分类、也不按「包括关键词」筛**：它们只在检索模式下用来构造 arXiv 查询。两者
+    都是硬门槛，配窄了会让库悄无声息颗粒无收，而「0 篇」和「今天确实没有相关论文」在
+    界面上无法区分。
+
+    **「排除关键词」是例外，这里会硬过滤。** 那是用户明确说「我不要这个」，漏掉它是
+    失职而不是保守；过滤掉多少篇会记进观测，不至于无声无息。
     """
     rows = (
         (
@@ -329,6 +338,18 @@ async def _collect_from_daily_feed(
     )
     feed_papers = [p for p, _ in rows]
     feed_latest = max((d for _, d in rows), default=None)
+
+    excluded_by_terms = 0
+    if exclude:
+        norm = [e.lower() for e in exclude if e.strip()]
+        kept: list[Paper] = []
+        for paper in feed_papers:
+            hay = f"{paper.title or ''} {paper.abstract or ''}".lower()
+            if any(term in hay for term in norm):
+                excluded_by_terms += 1
+                continue
+            kept.append(paper)
+        feed_papers = kept
 
     ranked, did_rank = await _rank_feed_by_similarity(
         ctx, session, direction=direction, papers=feed_papers, limit=limit
@@ -363,7 +384,8 @@ async def _collect_from_daily_feed(
         selected.append(paper)
 
     return {
-        "feed_total": len(feed_papers),
+        "feed_total": len(rows),
+        "excluded_by_terms": excluded_by_terms,
         "feed_ranked": did_rank,
         "after_vector_rank": len(ranked),
         "already_in_library": already,
@@ -390,6 +412,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             DEFAULT_ARXIV_CATEGORIES
         )
         include = list(keywords_def.get("include") or [])
+        # 排除词与包括词不同：包括词配窄了会让库悄无声息收不到东西，所以同步时不拿它筛；
+        # 排除词是用户明确说「我不要这个」，漏掉它反而是失职，三条路径一律生效。
+        exclude = list(keywords_def.get("exclude") or [])
 
         if _unlimited(knobs):
             limit = _UNLIMITED_SENTINEL  # 窗口内全量抓取（哨兵防失控）
@@ -401,7 +426,8 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         # 而每日推送本来就每天把新论文抓进内容池了，同一批论文没有理由抓第二遍。
         if mode == "incremental":
             feed = await _collect_from_daily_feed(
-                ctx, session, library=library, direction=direction_query, limit=limit
+                ctx, session, library=library, direction=direction_query,
+                exclude=exclude, limit=limit,
             )
             new_papers = feed.pop("selected")
             await session.flush()
@@ -420,10 +446,19 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 **feed,
             }
 
-        # —— 建库：仍走 arXiv 检索（每日池只有 RSS 当天公告、没有历史，回填不了）——
-        since = now - timedelta(days=30 * int(knobs["months_back"]))
+        # —— 检索模式：走 arXiv 检索 API（每日池只有当天公告、没有历史，回填不了）——
+        # 查询词优先用本次指定的；没指定就退回库配置里的「包括关键词」
+        params = _params(ctx)
+        terms = [t for t in (params.get("query_terms") or []) if str(t).strip()] or include
+        days = TIME_RANGE_DAYS.get(str(params.get("time_range") or ""))
+        since = now - timedelta(days=days or 30 * int(knobs["months_back"]))
         entries = await get_arxiv_client().search(
-            categories=categories, keywords=include, since=since, until=now, limit=limit
+            categories=categories,
+            keywords=terms,
+            exclude=exclude,
+            since=since,
+            until=now,
+            limit=limit,
         )
 
         arxiv_ids, dois, titles = await _existing_keys(session, library.id)

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -72,22 +72,34 @@ IDEA_KINDS = ("idea_forge", "idea_review", "idea_proposal")
 
 
 def wiki_plan(run: VoyageRun) -> list[dict[str, Any]]:
-    """文献 ingest 固定七步计划（docs/api-m2.md §7）；knobs 从 checkpoint.params 读。"""
-    # 候选来源随模式而变：建库检索 arXiv 历史，增量只吃每日论文池（不碰 arXiv）。
-    # 步骤标题跟着变，否则任务详情页会把「从每日池筛选」写成「检索 arXiv」。
-    first = (
-        ("检索候选（arXiv）", "wiki.search_candidates", "候选论文已入库")
-        if run.kind == "wiki_bootstrap"
-        else ("从每日论文池筛选候选", "wiki.search_candidates", "候选论文已入库")
-    )
+    """文献收集计划：每种模式只跑自己需要的步骤（docs/api-m2.md §7）。
+
+    以前三种来源焊成一条七步流水线，想只补一轮引文就得连带再检索一次 arXiv。现在按
+    ``checkpoint.params.mode`` 分叉，共用后五步（打分→取全文→编译→概念→记录进度）：
+
+    - ``search``：按查询词走 arXiv 检索 API；
+    - ``snowball``：从锚点论文出发走引用/参考；
+    - ``incremental``：从每日论文池按方向挑，不访问 arXiv。
+    """
+    params = (run.checkpoint or {}).get("params") or {}
+    mode = params.get("mode") or ("incremental" if run.kind == "wiki_ingest" else "search")
+    if mode == "bootstrap":  # 存量任务的旧名
+        mode = "search"
+
+    if mode == "snowball":
+        first = ("从锚点论文扩展（Semantic Scholar）", "wiki.snowball", "引用/参考已扩展")
+    elif mode == "incremental":
+        first = ("从每日论文池筛选候选", "wiki.search_candidates", "候选论文已入库")
+    else:
+        first = ("按查询词检索 arXiv", "wiki.search_candidates", "候选论文已入库")
+
     steps = [
         first,
-        ("参考文献扩展（Semantic Scholar）", "wiki.snowball", "参考文献扩展完成"),
         ("相关性打分（LLM）", "wiki.score_relevance", "候选论文已全部打分或排除"),
         ("下载 PDF + 抽全文", "wiki.fetch_extract", "top-N 论文全文就绪（失败降级摘要）"),
         ("Librarian 编译 wiki 页", "wiki.compile", "top-N 论文已生成中文 wiki markdown"),
         ("概念上链 + embedding", "wiki.link_concepts", "双链概念已 upsert 并关联论文"),
-        ("记录同步进度", "wiki.update_watermark", "项目 ingest_state 已更新"),
+        ("记录收集进度", "wiki.update_watermark", "文献库同步状态已更新"),
     ]
     return [
         {

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -42,6 +42,8 @@ async def start_ingest(
             project=project,
             mode=data.mode,
             knobs=data.knobs,
+            query_terms=data.query_terms,
+            time_range=data.time_range,
             created_by=user.id,
         )
     except ingest_service.IngestConflictError as e:

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -422,6 +422,8 @@ async def start_library_ingest(
             project=project,
             mode=data.mode,
             knobs=data.knobs,
+            query_terms=data.query_terms,
+            time_range=data.time_range,
             created_by=user.id,
         )
     except ingest_service.IngestConflictError as e:

--- a/src/backend/app/schemas/ingest.py
+++ b/src/backend/app/schemas/ingest.py
@@ -6,12 +6,18 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+#: 检索模式的时间范围 → 回溯**天数**。给固定档而不是让人填数字：这是「最近多久的
+#: 论文」这种粗粒度选择，开放输入只会让人纠结 5 个月和 6 个月的差别。
+#: 用天而不是月，否则「一周」会被月粒度吃掉。
+TIME_RANGE_DAYS: dict[str, int] = {"1w": 7, "3m": 90, "6m": 180, "1y": 365}
+
 
 class IngestKnobs(BaseModel):
-    months_back: int = Field(default=6, ge=1, le=36)  # bootstrap 回填月数
+    months_back: int = Field(default=6, ge=1, le=36)  # 检索模式回溯月数（由 time_range 换算）
     max_papers: int = Field(default=50, ge=1, le=500)  # 本次最多精读编译篇数（成本上限）
     relevance_threshold: float = Field(default=0.6, ge=0.0, le=1.0)
-    snowball_depth: int = Field(default=1, ge=0, le=2)  # 引文雪球层数
+    # 锚点扩展的跳数。每多一跳，Semantic Scholar 的调用量成倍涨，3 跳已经很重
+    snowball_depth: int = Field(default=1, ge=0, le=3)
     compile_top_n: int = Field(default=20, ge=1, le=200)  # 打分后精读编译前 N 篇
     # 最大化模式：True 时检索/打分/抽取/编译不设篇数上限（max_papers/compile_top_n 被忽略，
     # 仅保留极高安全哨兵防失控），token 预算也不设限。默认 False，向后兼容。
@@ -19,8 +25,23 @@ class IngestKnobs(BaseModel):
 
 
 class IngestRequest(BaseModel):
-    mode: Literal["bootstrap", "incremental"]
+    """启动一次文献收集。
+
+    三种模式，各跑各自需要的步骤：
+
+    - ``search``：按查询词走 arXiv 检索 API，可选时间范围。建库和日后扩充都用它。
+    - ``snowball``：从锚点论文出发走引用/参考，跳数可设。
+    - ``incremental``：自动模式，从每日论文池里按方向挑（不访问 arXiv）。
+
+    ``bootstrap`` 是 ``search`` 的旧名，保留以兼容存量调用与历史任务。
+    """
+
+    mode: Literal["search", "snowball", "incremental", "bootstrap"]
     knobs: IngestKnobs = IngestKnobs()
+    #: search 模式的查询词；留空则用库配置里的「包括关键词」
+    query_terms: list[str] | None = None
+    #: search 模式的时间范围（TIME_RANGES 的键）；给了就覆盖 knobs.months_back
+    time_range: Literal["1w", "3m", "6m", "1y"] | None = None
 
 
 class IngestLastRun(BaseModel):

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -65,7 +65,7 @@ class LibraryCreate(BaseModel):
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
-    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, synonyms}
+    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, exclude, synonyms}
 
 
 class SuggestDefinitionRequest(BaseModel):
@@ -83,6 +83,7 @@ class SuggestedKeywords(BaseModel):
 
     arxiv_categories: list[str] = Field(default_factory=list)  # arXiv 分类代码
     include: list[str] = Field(default_factory=list)  # 检索关键词/术语
+    exclude: list[str] = Field(default_factory=list)  # 排除关键词（命中即不收）
 
 
 class SuggestedRubricDimension(BaseModel):
@@ -136,7 +137,7 @@ class DirectionLibraryUpdate(BaseModel):
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
-    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, synonyms}
+    keywords: dict[str, Any] | None = None  # {arxiv_categories, include, exclude, synonyms}
     goals: list[Any] | None = None
     in_scope: list[Any] | None = None
     out_of_scope: list[Any] | None = None

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -21,6 +21,22 @@ from app.services.libraries import get_library_for_project
 _TOKENS_PER_PAPER = 20_000
 
 
+#: 三种收集模式。search/snowball 是人主动发起的两条补充路径，incremental 是每天自动
+#: 从每日论文池挑。``bootstrap`` 是 ``search`` 的旧名，只做入口兼容，不再往下传。
+MODE_LABELS: dict[str, str] = {
+    "search": "按查询词检索入库",
+    "snowball": "从锚点论文扩展",
+    "incremental": "每日自动同步",
+}
+
+
+def normalize_mode(mode: str) -> str:
+    """把存量的 ``bootstrap`` 折算成 ``search``；未知值一律按 ``search`` 处理。"""
+    if mode == "bootstrap":
+        return "search"
+    return mode if mode in MODE_LABELS else "search"
+
+
 class IngestConflictError(Exception):
     """同一项目已有 ingest voyage 在跑。"""
 
@@ -112,6 +128,8 @@ async def create_ingest_voyage(
     mode: str,
     knobs: IngestKnobs,
     created_by: uuid.UUID | None,
+    query_terms: list[str] | None = None,
+    time_range: str | None = None,
 ) -> VoyageRun:
     """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。
 
@@ -128,19 +146,25 @@ async def create_ingest_voyage(
         monthly_budget=library.monthly_budget,
         budget=derive_budget(knobs),
     )
-    kind = "wiki_bootstrap" if mode == "bootstrap" else "wiki_ingest"
+    mode = normalize_mode(mode)
+    # 手动的两种模式（search/snowball）沿用 wiki_bootstrap 这个 kind：它们都是"人主动去
+    # 拉一批"，与自动的每日同步区分开即可；kind 是存量数据的形状，不为了新名字去迁移。
+    kind = "wiki_ingest" if mode == "incremental" else "wiki_bootstrap"
     target_name = project.name if project is not None else library.name
-    goal = (
-        f"文献调研初始建库：{target_name}"
-        if mode == "bootstrap"
-        else f"文献调研增量更新：{target_name}"
-    )
+    goal = f"{MODE_LABELS[mode]}：{target_name}"
     run = VoyageRun(
         kind=kind,
         goal=goal,
         status="planning",
         cursor=0,
-        checkpoint={"params": {"mode": mode, "knobs": knobs.model_dump()}},
+        checkpoint={
+            "params": {
+                "mode": mode,
+                "knobs": knobs.model_dump(),
+                "query_terms": query_terms or None,
+                "time_range": time_range,
+            }
+        },
         budget=budget,
         library_id=library.id,
         created_by=created_by,
@@ -151,7 +175,7 @@ async def create_ingest_voyage(
             library_id=library.id,
             actor=f"user:{created_by}" if created_by else "system:cron",
             kind="ingest.started",
-            message=f"文献调研{'初始建库' if mode == 'bootstrap' else '增量更新'}已启动",
+            message=f"{MODE_LABELS[mode]}已启动",
             payload={"mode": mode, "knobs": knobs.model_dump()},
         )
     )

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -518,6 +518,7 @@ async def source_libraries_overview(
 
 _SUGGEST_MAX_TOKENS = 2048
 _SUGGEST_MAX_CATEGORIES = 12
+_SUGGEST_MAX_EXCLUDES = 20
 _SUGGEST_MAX_KEYWORDS = 30
 _SUGGEST_MAX_RUBRIC = 6
 _SUGGEST_MAX_ANCHORS = 8
@@ -530,7 +531,8 @@ SUGGEST_DEFINITION_SYSTEM_PROMPT = """\
 {
   "keywords": {
     "arxiv_categories": ["cs.CL", "cs.AI", "cs.LG"],
-    "include": ["retrieval-augmented generation", "in-context learning"]
+    "include": ["retrieval-augmented generation", "in-context learning"],
+    "exclude": ["speech recognition", "protein folding"]
   },
   "rubric": [
     {"name": "任务相关性", "description": "论文直接研究该方向核心任务时得高分", "weight": 0.4}
@@ -543,6 +545,8 @@ SUGGEST_DEFINITION_SYSTEM_PROMPT = """\
 - arxiv_categories：从名称/描述推断的相关 arXiv 分类代码（如 cs.CL、cs.AI、cs.LG、stat.ML 等），\
 最相关的在前，最多 12 个；
 - include：英文为主的检索关键词/术语，覆盖该方向核心概念、方法名、任务名，最多 30 个；
+- exclude：容易和该方向撞词、但明确不该收录的术语（如同名的其他领域用法），最多 20 个；\
+拿不准就给空列表，宁缺毋滥——排除词会直接把论文挡在门外；
 - rubric：3-5 条相关性打分维度，每条含 name（简短中文维度名）、description（什么样的论文在\
 这一维得高分）、weight（0-1 之间的小数，各条 weight 之和约等于 1）；
 - anchors：3-6 篇该方向的代表性锚点论文，每条含 title（英文原题）、arxiv_id（可留空或省略，\
@@ -553,7 +557,11 @@ SUGGEST_DEFINITION_SYSTEM_PROMPT = """\
 
 def _empty_suggestion() -> dict[str, Any]:
     """结构完整的空兜底（解析失败/调用失败时返回，字段与成功时同形）。"""
-    return {"keywords": {"arxiv_categories": [], "include": []}, "rubric": [], "anchors": []}
+    return {
+        "keywords": {"arxiv_categories": [], "include": [], "exclude": []},
+        "rubric": [],
+        "anchors": [],
+    }
 
 
 def _coerce_str_list(value: Any, *, cap: int) -> list[str]:
@@ -651,6 +659,7 @@ def _parse_suggestion(content: str) -> dict[str, Any]:
                 keywords.get("arxiv_categories"), cap=_SUGGEST_MAX_CATEGORIES
             ),
             "include": _coerce_str_list(keywords.get("include"), cap=_SUGGEST_MAX_KEYWORDS),
+            "exclude": _coerce_str_list(keywords.get("exclude"), cap=_SUGGEST_MAX_EXCLUDES),
         },
         "rubric": _coerce_rubric(data.get("rubric")),
         "anchors": _coerce_anchors(data.get("anchors")),

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -202,7 +202,9 @@ def build_search_query(
     keywords: list[str],
     since: datetime | None = None,
     until: datetime | None = None,
+    exclude: list[str] | None = None,
 ) -> str:
+    """拼 arXiv 检索式。``exclude`` 走 ANDNOT，直接在检索端把不想要的挡掉。"""
     parts: list[str] = []
     if categories:
         parts.append("(" + " OR ".join(f"cat:{c}" for c in categories) + ")")
@@ -212,7 +214,11 @@ def build_search_query(
         lo = since.strftime("%Y%m%d%H%M") if since else "000001010000"
         hi = until.strftime("%Y%m%d%H%M") if until else "999912312359"
         parts.append(f"submittedDate:[{lo} TO {hi}]")
-    return " AND ".join(parts) if parts else "all:*"
+    query = " AND ".join(parts) if parts else "all:*"
+    terms = [t for t in (exclude or []) if str(t).strip()]
+    if terms:
+        query += "".join(f' ANDNOT all:"{t}"' for t in terms)
+    return query
 
 
 class ArxivClient:
@@ -318,10 +324,11 @@ class ArxivClient:
         keywords: list[str] | None = None,
         since: datetime | None = None,
         until: datetime | None = None,
+        exclude: list[str] | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """分类+关键词搜索（日期窗口），自动翻页至 limit。"""
-        query = build_search_query(categories or [], keywords or [], since, until)
+        """分类+关键词搜索（日期窗口、可排除词），自动翻页至 limit。"""
+        query = build_search_query(categories or [], keywords or [], since, until, exclude)
         results: list[dict[str, Any]] = []
         start = 0
         while len(results) < limit:

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -56,6 +56,19 @@ def _include_keywords(definition: dict[str, Any]) -> list[str]:
     return out
 
 
+def _exclude_keywords(definition: dict[str, Any]) -> list[str]:
+    """库配置里的排除关键词（``keywords.exclude``），去空去重、保序。"""
+    raw = (definition.get("keywords") or {}).get("exclude") or []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        kw = str(item).strip()
+        if kw and kw.lower() not in seen:
+            seen.add(kw.lower())
+            out.append(kw)
+    return out
+
+
 def build_relevance_context(definition: dict[str, Any] | None, name: str) -> str:
     """按库 definition 组打分 context（P8a：库为收录配置权威源）；rubric / questions
     缺失时只用 statement。``name`` 是 statement 缺失时的兜底方向名（库名）。
@@ -68,9 +81,13 @@ def build_relevance_context(definition: dict[str, Any] | None, name: str) -> str
     questions = definition.get("questions") or []
     statement = definition.get("statement") or name
     keywords = _include_keywords(definition)
+    excluded = _exclude_keywords(definition)
     lines = [f"研究方向：{statement}"]
     if keywords:
         lines.append(f"关注的关键词：{'、'.join(keywords)}")
+    if excluded:
+        # 明确说出不要什么，比只说要什么更能压住边缘命中
+        lines.append(f"明确不收的方向：{'、'.join(excluded)}")
     if rubric:
         lines.append(f"评分标准（rubric）：{json.dumps(rubric, ensure_ascii=False)}")
     if questions:

--- a/src/backend/tests/test_library_suggest_definition.py
+++ b/src/backend/tests/test_library_suggest_definition.py
@@ -85,7 +85,7 @@ async def test_suggest_definition_bad_json_returns_empty():
             name="X", statement="Y", llm=_StubLLM(content)
         )
         assert result == {
-            "keywords": {"arxiv_categories": [], "include": []},
+            "keywords": {"arxiv_categories": [], "include": [], "exclude": []},
             "rubric": [],
             "anchors": [],
         }
@@ -97,7 +97,7 @@ async def test_suggest_definition_missing_fields_are_structurally_complete():
         name="X", statement="", llm=_StubLLM('{"keywords": {"include": ["a"]}}')
     )
     assert result == {
-        "keywords": {"arxiv_categories": [], "include": ["a"]},
+        "keywords": {"arxiv_categories": [], "include": ["a"], "exclude": []},
         "rubric": [],
         "anchors": [],
     }
@@ -107,7 +107,7 @@ async def test_suggest_definition_llm_error_returns_empty():
     llm = _StubLLM(error=RuntimeError("boom"))
     result = await libraries_service.suggest_definition(name="X", statement="Y", llm=llm)
     assert result == {
-        "keywords": {"arxiv_categories": [], "include": []},
+        "keywords": {"arxiv_categories": [], "include": [], "exclude": []},
         "rubric": [],
         "anchors": [],
     }
@@ -154,7 +154,7 @@ async def test_suggest_endpoint_bad_json_returns_empty_200(client, monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json() == {
-        "keywords": {"arxiv_categories": [], "include": []},
+        "keywords": {"arxiv_categories": [], "include": [], "exclude": []},
         "rubric": [],
         "anchors": [],
     }

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -312,7 +312,8 @@ async def test_vectors_are_always_built(client, fake_redis):
 async def test_no_endpoint_can_turn_paper_embedding_off(client):
     """管理员总闸连同端点一起下线了——留着入口就等于留着把检索关瞎的办法。"""
     headers = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
-    assert (await client.get("/api/admin/settings/paper-embedding", headers=headers)).status_code == 404
+    resp = await client.get("/api/admin/settings/paper-embedding", headers=headers)
+    assert resp.status_code == 404
     assert (
         await client.put(
             "/api/admin/settings/paper-embedding", json={"enabled": False}, headers=headers

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -1,6 +1,6 @@
 """wiki ingest 全流程测试：respx mock 文献 API + fake LLM，直接驱动 VoyageEngine。
 
-覆盖：bootstrap 冷启动全链路（候选→雪球→打分→全文→编译→概念→水位线）、
+覆盖：检索模式全链路（检索→打分→全文→编译→概念→记录进度）、锚点扩展模式、
 并发 409、断点恢复不重复打分（fake LLM 调用计数）、增量续跑、每日 cron 选表。
 """
 
@@ -21,7 +21,7 @@ from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
-from app.models.paper import new_paper, paper_concepts
+from app.models.paper import Paper, new_paper, paper_concepts
 from app.models.user import User
 from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
@@ -299,21 +299,20 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 7
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
     obs0 = detail["steps"][0]["observation"]
     assert obs0["found"] == 3 and obs0["inserted"] == 3
-    assert detail["steps"][1]["observation"]["inserted"] == 1  # 雪球 1 篇
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        assert len(rows) == 4  # 3 arXiv 候选 + 1 雪球
+        assert len(rows) == 3  # 检索模式只有 arXiv 候选，引文扩展是另一个模式
         by_status = {}
         for p, m in rows:
             by_status.setdefault(m.status, []).append((p, m))
         assert len(by_status.get("excluded", [])) == 1  # "irrelevant" 论文被排除
         assert by_status["excluded"][0][0].arxiv_id == "2406.00003"
         compiled_rows = by_status.get("compiled", [])
-        assert len(compiled_rows) == 3
+        assert len(compiled_rows) == 2
         for p, m in compiled_rows:
             assert m.relevance_score is not None and m.relevance_score >= 0.6
             assert m.scored_at is not None
@@ -347,7 +346,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
         links = int(
             (await session.execute(select(func.count()).select_from(paper_concepts))).scalar_one()
         )
-        assert links == 6  # 3 篇编译论文 × 2 概念
+        assert links == 4  # 2 篇编译论文 × 2 概念
 
         # P8a：水位线权威源在库（library.ingest_state），不再写起源课题
         from app.services.libraries import get_library_for_project
@@ -375,12 +374,12 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert state["last_run"]["voyage_id"] == run_id
     assert state["last_run"]["status"] == "done"
     counts = state["paper_counts"]
-    assert counts["compiled"] == 3 and counts["excluded"] == 1 and counts["total"] == 4
+    assert counts["compiled"] == 2 and counts["excluded"] == 1 and counts["total"] == 3
 
     # papers API 上能看到编译结果
     resp = await client.get(f"/api/projects/{project_id}/papers?status=compiled", headers=headers)
     body = resp.json()
-    assert body["total"] == 3
+    assert body["total"] == 2
     assert all(item["has_wiki"] for item in body["items"])
 
     # 增量续跑：水位线窗口 + 全量去重，不产生新论文
@@ -405,7 +404,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert "window_since" not in obs2
     assert obs2["feed_total"] == 0  # 本测试没往每日池放东西
     async with get_sessionmaker()() as session:
-        assert len(await project_paper_rows(session, project_id=project_id)) == 4
+        assert len(await project_paper_rows(session, project_id=project_id)) == 3
 
 
 class _CrashOnNthRelevance(FakeProvider):
@@ -444,27 +443,22 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
     with pytest.raises(asyncio.CancelledError):
         await engine.run(run_id)
 
-    assert await _relevance_call_count() == 3  # 崩溃前 3 篇成功打分（并发，非串行的 1）
+    assert await _relevance_call_count() == 2  # 崩溃前 2 篇成功打分（并发，非串行的 1）
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
         scored = sum(1 for _, m in rows if m.status in ("scored", "excluded"))
-        assert scored == 3  # 逐篇 commit：崩溃前的进度已落库
+        assert scored == 2  # 逐篇 commit：崩溃前的进度已落库
 
     # resume：从断点续跑到 done，总打分调用数 == 论文数（无重复）
     engine2, _ = _make_engine()
     await engine2.resume(run_id)
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     assert resp.json()["status"] == "done"
-    assert await _relevance_call_count() == 4  # 4 篇论文各打分一次
+    assert await _relevance_call_count() == 3  # 3 篇论文各打分一次
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        assert sorted(m.status for _, m in rows) == [
-            "compiled",
-            "compiled",
-            "compiled",
-            "excluded",
-        ]
+        assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
 
 
 class _BreakOneRelevance(FakeProvider):
@@ -504,11 +498,11 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    score_obs = detail["steps"][2]["observation"]  # 0 检索 / 1 雪球 / 2 打分
+    score_obs = detail["steps"][1]["observation"]  # 0 检索 / 1 打分
     assert len(score_obs["failed"]) == 1  # 恰好坏掉的那一篇进 failed
     assert score_obs["failed"][0]["error"].startswith("ValueError")
-    assert score_obs["succeeded"] == 3  # 其余 3 篇并发打分照常完成（4 候选 − 1 失败）
-    assert score_obs["processed"] == 4
+    assert score_obs["succeeded"] == 2  # 其余 2 篇并发打分照常完成（3 候选 − 1 失败）
+    assert score_obs["processed"] == 3
 
     async with get_sessionmaker()() as session:
         by_status: dict[str, int] = {}
@@ -517,7 +511,7 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
         # 失败打分的那篇仍是 candidate（下次续跑会重试），其余照常推进
         assert by_status.get("candidate", 0) == 1
         assert by_status.get("excluded", 0) == 1  # irrelevant 篮子编织论文
-        assert by_status.get("compiled", 0) == 2  # 两篇通过阈值的论文成功编译
+        assert by_status.get("compiled", 0) == 1  # 通过阈值且未失败的那篇成功编译
 
 
 async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks):
@@ -545,12 +539,12 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 7
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
     assert detail["steps"][0]["observation"]["inserted"] == 3  # 默认分类兜底后仍能检索
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        # 无锚点论文 → 雪球 0 篇；3 候选：2 编译 + 1 排除（无 rubric 时打分只用 statement）
+        # 3 候选：2 编译 + 1 排除（无 rubric 时打分只用 statement）
         assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
 
 
@@ -773,21 +767,20 @@ async def test_unlimited_bootstrap_uncapped(client, queue_stub, wiki_mocks_big):
 
     detail = (await client.get(f"/api/voyages/{voyage['id']}", headers=headers)).json()
     assert detail["status"] == "done", detail  # 未因预算暂停
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 7
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
 
     # 检索：分页抓到全部 210 条（旧逻辑 limit=min(200, 10*3)=30）
     obs0 = detail["steps"][0]["observation"]
     assert obs0["found"] == _BIG_N and obs0["inserted"] == _BIG_N
-    # 雪球：锚点扩展 1 篇（上限放开后不受 max_papers*2 影响）
-    assert detail["steps"][1]["observation"]["inserted"] == 1
-    total = _BIG_N + 1
-    # 打分：211 篇全部处理（旧逻辑截 200）
-    score_obs = detail["steps"][2]["observation"]
+    # 检索模式不含引文扩展（那是 snowball 模式），所以总数就是检索到的篇数
+    total = _BIG_N
+    # 打分：210 篇全部处理（旧逻辑截 200）
+    score_obs = detail["steps"][1]["observation"]
     assert score_obs["processed"] == total and score_obs["succeeded"] == total
     assert score_obs["excluded"] == 0  # 全部相关（fake 打 0.88 ≥ 0.6）
-    # 抽取/编译：211 篇全部进入（旧逻辑截 min(compile_top_n=5, max_papers=10)=5）
-    assert detail["steps"][3]["observation"]["processed"] == total
-    compile_obs = detail["steps"][4]["observation"]
+    # 抽取/编译：210 篇全部进入（旧逻辑截 min(compile_top_n=5, max_papers=10)=5）
+    assert detail["steps"][2]["observation"]["processed"] == total
+    compile_obs = detail["steps"][3]["observation"]
     assert compile_obs["processed"] == total and compile_obs["succeeded"] == total
 
     async with get_sessionmaker()() as session:
@@ -923,7 +916,7 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
 
     detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 7
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
 
     async with get_sessionmaker()() as session:
         library = await session.get(DirectionLibrary, uuid.UUID(library_id))
@@ -931,7 +924,7 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
         assert library.ingest_state["watermark"]
         assert library.ingest_state["last_run"]["voyage_id"] == run_id
 
-        # 库版论文：3 arXiv 候选 + 1 雪球，3 篇编译
+        # 库版论文：3 arXiv 候选，3 篇编译
         members = (
             (
                 await session.execute(
@@ -941,8 +934,8 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
             .scalars()
             .all()
         )
-        assert len(members) == 4
-        assert sum(1 for m in members if m.status == "compiled") == 3
+        assert len(members) == 3
+        assert sum(1 for m in members if m.status == "compiled") == 2
         assert sum(1 for m in members if m.status == "excluded") == 1
 
         # 库级用量归因：ingest 全程 LLM 调用（打分/图注/编译/概念定义/向量化）记到库上
@@ -1288,3 +1281,183 @@ async def test_truncated_run_does_not_advance_the_watermark(client, queue_stub, 
     async with get_sessionmaker()() as session:
         library = await session.get(DirectionLibrary, uuid.UUID(library_id))
         assert library.ingest_state["watermark"] == original
+
+
+# ---- 三种收集模式 ----
+
+
+def test_search_query_puts_exclusions_behind_andnot():
+    from app.services.literature.arxiv import build_search_query
+
+    q = build_search_query(["cs.AI"], ["agent"], exclude=["speech recognition"])
+    assert q.startswith('(cat:cs.AI) AND (all:"agent")')
+    assert 'ANDNOT all:"speech recognition"' in q
+    # 没有排除词就不该多出尾巴
+    assert "ANDNOT" not in build_search_query(["cs.AI"], ["agent"])
+
+
+async def test_snowball_mode_skips_the_arxiv_search(client, queue_stub, wiki_mocks):
+    """锚点扩展模式只走引文扩展，不检索 arXiv——想补一轮引文不必连带再搜一次。"""
+    token = await register_and_login(client, email="mode-snowball@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("mode-snowball@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-锚点")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "snowball", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    detail = (await client.get(f"/api/voyages/{resp.json()['id']}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert detail["steps"][0]["action"] == "wiki.snowball"
+    assert "锚点" in detail["steps"][0]["title"]
+    assert [s["action"] for s in detail["steps"]] == [
+        "wiki.snowball",
+        "wiki.score_relevance",
+        "wiki.fetch_extract",
+        "wiki.compile",
+        "wiki.link_concepts",
+        "wiki.update_watermark",
+    ]
+
+
+async def test_search_mode_uses_given_terms_and_time_range(client, queue_stub, wiki_mocks):
+    """检索模式：本次指定的查询词与时间范围要真的进检索式。"""
+    token = await register_and_login(client, email="mode-search@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("mode-search@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-检索")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={
+            "mode": "search",
+            "knobs": KNOBS,
+            "query_terms": ["world model"],
+            "time_range": "1w",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    detail = (await client.get(f"/api/voyages/{resp.json()['id']}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert detail["steps"][0]["action"] == "wiki.search_candidates"
+
+    calls = [
+        str(c.request.url)
+        for c in wiki_mocks.calls
+        if "export.arxiv.org" in str(c.request.url)
+    ]
+    assert calls, "检索模式必须真的打了 arXiv 检索接口"
+    assert "world+model" in calls[0] or "world%20model" in calls[0]
+    # 一周窗口：起始日期应当离今天很近（而不是默认的半年）
+    import re as _re
+
+    lo = _re.search(r"submittedDate%3A%5B(\d{8})", calls[0])
+    assert lo, calls[0]
+    from datetime import UTC, datetime, timedelta
+
+    since = datetime.strptime(lo.group(1), "%Y%m%d").replace(tzinfo=UTC)
+    assert datetime.now(UTC) - since < timedelta(days=10)
+
+
+async def test_legacy_bootstrap_mode_still_works(client, queue_stub, wiki_mocks):
+    """存量调用传的 bootstrap 折算成 search，不报错、不改变步骤形状。"""
+    project_id, headers = await _setup_project(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+    detail = (await client.get(f"/api/voyages/{resp.json()['id']}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert detail["steps"][0]["action"] == "wiki.search_candidates"
+
+
+async def test_exclude_terms_filter_the_daily_feed_sync(client, queue_stub, wiki_mocks):
+    """排除关键词在每日池同步时**硬过滤**，并把滤掉的篇数报进观测。
+
+    与「包括关键词」区别对待：include 配窄了会让库悄无声息颗粒无收，所以同步时不拿它
+    筛；exclude 是用户明确说「我不要这个」，漏掉它是失职。
+    """
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+
+    token = await register_and_login(client, email="excl@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("excl@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-排除词")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "search", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        definition = dict(library.definition or {})
+        definition["keywords"] = {
+            **(definition.get("keywords") or {}),
+            "exclude": ["speech recognition"],
+        }
+        library.definition = definition
+        for i, title in enumerate(["Planning Agents", "Speech Recognition at Scale"]):
+            paper = new_paper(
+                source="arxiv",
+                arxiv_id=f"2607.7000{i}",
+                title=title,
+                abstract="research",
+                year=2026,
+                published_at=dt.datetime(2026, 7, 20, tzinfo=dt.UTC),
+            )
+            session.add(paper)
+            await session.flush()
+            session.add(
+                DailyFeedEntry(
+                    paper_id=paper.id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+                )
+            )
+        await session.commit()
+
+    resp2 = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "incremental", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine2, _ = _make_engine()
+    await engine2.run(uuid.UUID(resp2.json()["id"]))
+
+    detail = (await client.get(f"/api/voyages/{resp2.json()['id']}", headers=headers)).json()
+    obs = detail["steps"][0]["observation"]
+    assert obs["feed_total"] == 2
+    assert obs["excluded_by_terms"] == 1  # 命中排除词的那篇被挡下，且报了出来
+    assert obs["inserted"] == 1
+
+    async with get_sessionmaker()() as session:
+        titles = set(
+            (
+                await session.execute(
+                    select(Paper.title)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                    .where(LibraryPaper.library_id == uuid.UUID(library_id))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert "Speech Recognition at Scale" not in titles

--- a/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
+++ b/src/frontend/src/features/libraries/InclusionSettingsForm.tsx
@@ -19,6 +19,8 @@ export const ARXIV_ID_RE = /^(\d{4}\.\d{4,5}(v\d+)?|[a-z-]+\/\d{7}(v\d+)?)$/i;
 export interface InclusionValue {
   arxiv_categories: string[];
   include: string[];
+  /** 排除关键词：命中即挡在门外。与 include 不同，它在每日同步时也硬过滤。 */
+  exclude: string[];
   rubric: RubricDimension[];
   anchors: AnchorPaper[];
 }
@@ -54,10 +56,12 @@ export function InclusionSettingsForm({
   readOnly,
 }: InclusionSettingsFormProps) {
   const { arxiv_categories, include, rubric, anchors } = value;
+  const exclude = value.exclude ?? [];
   const patch = (p: Partial<InclusionValue>) => onChange({ ...value, ...p });
 
   const [customCat, setCustomCat] = useState('');
   const [kwDraft, setKwDraft] = useState('');
+  const [exDraft, setExDraft] = useState('');
 
   // —— AI 自动生成 ——
   const canSuggest = name.trim().length > 0 && statement.trim().length > 0;
@@ -78,6 +82,12 @@ export function InclusionSettingsForm({
       onChange({
         arxiv_categories: cats,
         include: inc,
+        exclude: [
+          ...exclude,
+          ...(d.keywords.exclude ?? []).filter(
+            (x) => x.trim() && !new Set(exclude.map((y) => y.toLowerCase())).has(x.trim().toLowerCase()),
+          ),
+        ],
         rubric: showRubric ? rub : rubric,
         anchors: showAnchors ? anc : anchors,
       });
@@ -96,20 +106,22 @@ export function InclusionSettingsForm({
     setCustomCat('');
   }
 
-  // —— 检索关键词 chips ——
-  function addKeywords(raw: string) {
+  // —— 关键词 chips（包括 / 排除共用一套增删） ——
+  function addKeywords(field: 'include' | 'exclude', raw: string) {
     const parts = raw.split(/[,，]/).map((x) => x.trim()).filter(Boolean);
     if (parts.length === 0) return;
-    const seen = new Set(include.map((x) => x.toLowerCase()));
-    const next = [...include];
+    const current = field === 'include' ? include : exclude;
+    const seen = new Set(current.map((x) => x.toLowerCase()));
+    const next = [...current];
     for (const p of parts) {
       if (!seen.has(p.toLowerCase())) { next.push(p); seen.add(p.toLowerCase()); }
     }
-    patch({ include: next });
-    setKwDraft('');
+    patch({ [field]: next } as Partial<InclusionValue>);
+    if (field === 'include') setKwDraft(''); else setExDraft('');
   }
-  function removeKeyword(k: string) {
-    patch({ include: include.filter((x) => x !== k) });
+  function removeKeyword(field: 'include' | 'exclude', k: string) {
+    const current = field === 'include' ? include : exclude;
+    patch({ [field]: current.filter((x) => x !== k) } as Partial<InclusionValue>);
   }
 
   // —— 锚点论文 ——
@@ -206,7 +218,7 @@ export function InclusionSettingsForm({
 
       {/* —— 检索关键词 chips —— */}
       <div className="col gap6">
-        <BlockLabel zh="检索关键词" en="Search terms" />
+        <BlockLabel zh="包括关键词" en="Include terms" />
         {include.length > 0 ? (
           <div className="row gap6 wrap">
             {include.map((k) => (
@@ -216,7 +228,7 @@ export function InclusionSettingsForm({
                   <button
                     type="button"
                     aria-label={tr('删除', 'Remove')}
-                    onClick={() => removeKeyword(k)}
+                    onClick={() => removeKeyword('include', k)}
                     style={{ display: 'inline-flex', background: 'none', border: 'none', padding: 0, marginLeft: 2, cursor: 'pointer', color: 'inherit' }}
                   >
                     <Icon name="x" size={11} />
@@ -235,18 +247,70 @@ export function InclusionSettingsForm({
             onChange={(e) => {
               const v = e.target.value;
               // 输入逗号即时成词
-              if (/[,，]/.test(v)) addKeywords(v);
+              if (/[,，]/.test(v)) addKeywords('include', v);
               else setKwDraft(v);
             }}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); addKeywords(kwDraft); }
+              if (e.key === 'Enter') { e.preventDefault(); addKeywords('include', kwDraft); }
               else if (e.key === 'Backspace' && !kwDraft && include.length > 0) {
                 e.preventDefault();
-                removeKeyword(include[include.length - 1]!);
+                removeKeyword('include', include[include.length - 1]!);
               }
             }}
-            onBlur={() => { if (kwDraft.trim()) addKeywords(kwDraft); }}
+            onBlur={() => { if (kwDraft.trim()) addKeywords('include', kwDraft); }}
             placeholder={tr('输入关键词后回车或逗号添加，如 agent', 'Type a term, press Enter or comma, e.g. agent')}
+          />
+        )}
+      </div>
+
+      {/* —— 排除关键词 chips —— */}
+      <div className="col gap6">
+        <BlockLabel zh="排除关键词" en="Exclude terms" />
+        <div className="muted" style={{ fontSize: 11.5, lineHeight: 1.5 }}>
+          {tr(
+            '命中就不收，检索、打分、每日同步三处都生效。用来挡掉和本方向撞词的其他领域，宁缺毋滥。',
+            'Matching papers are never admitted — in search, in scoring, and in the daily sync. Use it for other fields that share vocabulary with yours; keep it short.',
+          )}
+        </div>
+        {exclude.length > 0 ? (
+          <div className="row gap6 wrap">
+            {exclude.map((k) => (
+              <span key={k} className="chip" style={{ gap: 4, cursor: 'default' }}>
+                {k}
+                {!readOnly && (
+                  <button
+                    type="button"
+                    aria-label={tr('删除', 'Remove')}
+                    onClick={() => removeKeyword('exclude', k)}
+                    style={{ display: 'inline-flex', background: 'none', border: 'none', padding: 0, marginLeft: 2, cursor: 'pointer', color: 'inherit' }}
+                  >
+                    <Icon name="x" size={11} />
+                  </button>
+                )}
+              </span>
+            ))}
+          </div>
+        ) : readOnly ? (
+          <div className="muted" style={{ fontSize: 12.5 }}>{tr('未设排除关键词', 'No exclude terms set')}</div>
+        ) : null}
+        {!readOnly && (
+          <input
+            className="input"
+            value={exDraft}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (/[,，]/.test(v)) addKeywords('exclude', v);
+              else setExDraft(v);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); addKeywords('exclude', exDraft); }
+              else if (e.key === 'Backspace' && !exDraft && exclude.length > 0) {
+                e.preventDefault();
+                removeKeyword('exclude', exclude[exclude.length - 1]!);
+              }
+            }}
+            onBlur={() => { if (exDraft.trim()) addKeywords('exclude', exDraft); }}
+            placeholder={tr('输入后回车或逗号添加，如 speech recognition', 'Type a term, press Enter or comma')}
           />
         )}
       </div>

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -230,7 +230,7 @@ function LibraryCard({
   );
 }
 
-const EMPTY_INCLUSION: InclusionValue = { arxiv_categories: [], include: [], rubric: [], anchors: [] };
+const EMPTY_INCLUSION: InclusionValue = { arxiv_categories: [], include: [], exclude: [], rubric: [], anchors: [] };
 
 /**
  * 新建文献库弹窗（P9b：任意登录用户可建）。名称 + 一句话说明必填；
@@ -325,7 +325,16 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
         </FormField>
         <FormField label={tr('一句话说明', 'Statement')} hint={tr('必填，用于相关性打分', 'Required — used for relevance scoring')}>
           <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
-            placeholder={tr('用一句话介绍这个文献库的方向', 'One sentence describing this library’s direction')} />
+            placeholder={tr(
+              '例：研究长时程运行的 LLM 智能体。关注记忆压缩、错误恢复、长期一致性评测；偏重方法与系统设计，不收纯 prompt 工程和纯应用报告。',
+              'e.g. Long-running LLM agents. Focus on memory compaction, error recovery and long-horizon consistency evaluation; methods and system design rather than prompt engineering or application reports.',
+            )} />
+          <div className="muted" style={{ fontSize: 11.5, lineHeight: 1.5, marginTop: 4 }}>
+            {tr(
+              '写清四件事效果最好：研究对象、关注的子问题、偏重什么、明确不要什么。这段描述既用来自动挑论文，也用来给论文打分，写得越具体收得越准。',
+              'Four things help most: the subject, the sub-problems you care about, what you favour, and what you explicitly do not want. This text both selects and scores papers, so specifics pay off.',
+            )}
+          </div>
         </FormField>
         <div className="hr" style={{ margin: '4px 0 16px' }} />
         <InclusionSettingsForm

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -12,6 +12,7 @@ function fromDefinition(def: ProjectDefinition | null): InclusionValue {
   return {
     arxiv_categories: d.keywords?.arxiv_categories ?? [],
     include: d.keywords?.include ?? [],
+    exclude: d.keywords?.exclude ?? [],
     rubric: d.rubric ?? [],
     anchors: d.anchor_papers ?? [],
   };
@@ -326,7 +327,10 @@ function LibraryInfoCard({
             value={statement}
             disabled={readOnly}
             onChange={(e) => setStatement(e.target.value)}
-            placeholder={tr('这个方向关注什么问题', 'What this direction is about')}
+            placeholder={tr(
+              '例：研究长时程运行的 LLM 智能体。关注记忆压缩、错误恢复、长期一致性评测；偏重方法与系统设计，不收纯 prompt 工程和纯应用报告。',
+              'e.g. Long-running LLM agents. Focus on memory compaction, error recovery and long-horizon consistency evaluation; methods and system design rather than prompt engineering or application reports.',
+            )}
           />
         </label>
         {!readOnly && (

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -9,11 +9,17 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { useProject } from '../../app/project';
 import { fmtTime } from '../../lib/format';
-import { api, ApiError, type IngestKnobs, type IngestMode, type IngestState } from '../../lib/api';
+import {
+  api,
+  ApiError,
+  type IngestStart,
+  type IngestState,
+  type IngestTimeRange,
+} from '../../lib/api';
 import { tr } from '../../lib/i18n';
 
 /* ============================================================
-   冷启动 / 增量同步 Tab：
+   文献收集 Tab：
    - ingest 状态（水位线 / 论文计数 / 上次运行 / 进行中航程）
    - bootstrap 成本旋钮表单 → POST /ingest {mode:"bootstrap"}
    - 增量同步按钮 → {mode:"incremental"}
@@ -108,15 +114,17 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
     enabled: !!libraryId && !readOnly,
     retry: false,
   });
+  const anchorCount = libDef?.definition?.anchor_papers?.length ?? 0;
   const noKeywords = libraryId
     ? !!libDef && (libDef.definition?.keywords?.include?.length ?? 0) === 0
     : !!project;
 
   // —— 成本旋钮（bootstrap） ——
-  const [monthsBack, setMonthsBack] = useState(6);
   const [maxPapers, setMaxPapers] = useState(50);
   const [threshold, setThreshold] = useState(0.6);
-  const [snowballDepth, setSnowballDepth] = useState<'0' | '1' | '2'>('1');
+  const [hops, setHops] = useState<'1' | '2' | '3'>('1');
+  const [queryTerms, setQueryTerms] = useState('');
+  const [timeRange, setTimeRange] = useState<IngestTimeRange>('6m');
   const [compileTopN, setCompileTopN] = useState(20);
   // 最大化模式：不限检索/编译篇数（仅 bootstrap 表单，增量同步不受影响）
   const [unlimited, setUnlimited] = useState(false);
@@ -126,13 +134,16 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
   const canOpenRunning = !!state?.can_open_running_voyage;
 
   const ingestMutation = useMutation({
-    mutationFn: (input: { mode: IngestMode; knobs: IngestKnobs }) =>
+    mutationFn: (input: IngestStart) =>
       libraryId ? api.startLibraryIngest(libraryId, input) : api.startIngest(scopeId, input),
     onSuccess: (v, input) => {
       toast(
-        input.mode === 'bootstrap'
-          ? tr('初始建库已开始，跳转任务详情…', 'Initial library build started — opening task detail…')
-          : tr('增量同步已开始，跳转任务详情…', 'Incremental sync started — opening task detail…'),
+        {
+          search: tr('检索入库已开始，跳转任务详情…', 'Search started — opening task detail…'),
+          snowball: tr('锚点扩展已开始，跳转任务详情…', 'Anchor expansion started — opening task detail…'),
+          incremental: tr('同步已开始，跳转任务详情…', 'Sync started — opening task detail…'),
+          bootstrap: tr('检索入库已开始，跳转任务详情…', 'Search started — opening task detail…'),
+        }[input.mode],
         'ok',
       );
       void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
@@ -165,14 +176,29 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
   const busy = running || ingestMutation.isPending;
   const bootstrapBusy = busy || noKeywords;
 
-  function runBootstrap() {
+  /** 模式一：按查询词检索 arXiv。查询词留空时后端退回库里的「包括关键词」。 */
+  function runSearch() {
     ingestMutation.mutate({
-      mode: 'bootstrap',
+      mode: 'search',
       knobs: {
-        months_back: monthsBack,
         max_papers: maxPapers,
         relevance_threshold: threshold,
-        snowball_depth: Number(snowballDepth),
+        compile_top_n: compileTopN,
+        unlimited,
+      },
+      query_terms: queryTerms.split(/[,，]/).map((x) => x.trim()).filter(Boolean),
+      time_range: timeRange,
+    });
+  }
+
+  /** 模式二：从锚点论文出发走引用/参考。不检索 arXiv。 */
+  function runSnowball() {
+    ingestMutation.mutate({
+      mode: 'snowball',
+      knobs: {
+        max_papers: maxPapers,
+        relevance_threshold: threshold,
+        snowball_depth: Number(hops),
         compile_top_n: compileTopN,
         unlimited,
       },
@@ -345,26 +371,43 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
           <div className="row gap10" style={{ marginBottom: 6 }}>
             <span className="section-h">
               <Icon name="play" size={15} style={{ color: 'var(--accent)' }} />
-              {tr('初始建库', 'Initial library build')}
+              {tr('按查询词检索入库', 'Search and admit')}
             </span>
           </div>
           <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, margin: '0 0 18px' }}>
             {tr(
-              '一次性回填近 N 个月文献并做参考文献扩展，打分筛选后精读编译；下面的选项控制本次开销。',
-              'Backfills the last N months with reference expansion, then scores, filters, and compiles; the knobs below control this run’s cost.',
+              '按查询词走 arXiv 检索，打分筛选后精读编译。建库和日后扩充都用它；下面的选项控制本次开销。',
+              'Searches arXiv by query terms, then scores, filters and compiles. Used both to build a library and to expand it later; the knobs below control this run’s cost.',
             )}
           </p>
 
-          <KnobRange
-            label={tr('回填月数', 'Months back')}
-            en="months_back"
-            hint={tr('从今天往回抓取候选论文的时间窗口（3-24 个月）。', 'How far back from today to fetch candidate papers (3-24 months).')}
-            value={monthsBack}
-            min={3}
-            max={24}
-            step={1}
-            onChange={setMonthsBack}
-          />
+          <FormField
+            label={tr('查询词', 'Query terms')}
+            en="query_terms"
+            hint={tr(
+              '留空就用收录设置里的「包括关键词」。多个词用逗号分隔。',
+              'Leave empty to use the library’s include terms. Separate multiple terms with commas.',
+            )}
+          >
+            <input
+              className="input"
+              value={queryTerms}
+              onChange={(e) => setQueryTerms(e.target.value)}
+              placeholder={tr('如 world model, video prediction', 'e.g. world model, video prediction')}
+            />
+          </FormField>
+          <FormField label={tr('时间范围', 'Time range')} en="time_range">
+            <Segmented<IngestTimeRange>
+              options={[
+                { v: '1w', label: tr('近一周', '1 week') },
+                { v: '3m', label: tr('近三个月', '3 months') },
+                { v: '6m', label: tr('近半年', '6 months') },
+                { v: '1y', label: tr('近一年', '1 year') },
+              ]}
+              value={timeRange}
+              onChange={setTimeRange}
+            />
+          </FormField>
           <FormField label={tr('最大化（不限篇数）', 'Maximize (no paper cap)')} en="unlimited">
             <label className="row gap10" style={{ cursor: 'pointer', userSelect: 'none' }}>
               <input
@@ -423,21 +466,6 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             format={(v) => v.toFixed(2)}
             onChange={setThreshold}
           />
-          <FormField
-            label={tr('参考文献扩展层数', 'Reference expansion depth')}
-            en="snowball_depth"
-            hint={tr('沿引用关系扩展检索的层数；0 为不扩展。', 'How many hops to expand along citations; 0 disables expansion.')}
-          >
-            <Segmented<'0' | '1' | '2'>
-              options={[
-                { v: '0', label: tr('0 · 关', '0 · off') },
-                { v: '1', label: tr('1 层', '1 hop') },
-                { v: '2', label: tr('2 层', '2 hops') },
-              ]}
-              value={snowballDepth}
-              onChange={setSnowballDepth}
-            />
-          </FormField>
           <KnobRange
             label={tr('最大编译篇数', 'Max compiled papers')}
             en="compile_top_n"
@@ -482,7 +510,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             </div>
           )}
           <div className="row gap10" style={{ marginTop: 6 }}>
-            <button className="btn btn-primary" disabled={bootstrapBusy} onClick={runBootstrap}>
+            <button className="btn btn-primary" disabled={bootstrapBusy} onClick={runSearch}>
               {ingestMutation.isPending ? (
                 <>
                   <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
@@ -491,7 +519,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
               ) : (
                 <>
                   <Icon name="play" size={14} />
-                  {tr('运行初始建库', 'Run initial library build')}
+                  {tr('开始检索入库', 'Run search')}
                 </>
               )}
             </button>
@@ -500,6 +528,57 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                 {tr('已有任务运行中，暂不可启动', 'A task is already running — cannot start another')}
               </span>
             )}
+          </div>
+
+          {/* —— 模式二：从锚点论文扩展 —— */}
+          <div className="hr" style={{ margin: '20px 0 16px' }} />
+          <div className="row gap10" style={{ marginBottom: 6 }}>
+            <span className="section-h">
+              <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+              {tr('从锚点论文扩展', 'Expand from anchor papers')}
+            </span>
+          </div>
+          <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, margin: '0 0 14px' }}>
+            {tr(
+              '从收录设置里的锚点论文出发，沿引用与参考文献往外走，打分筛选后精读编译。不检索 arXiv。',
+              'Walks citations and references outward from the library’s anchor papers, then scores, filters and compiles. Does not query arXiv.',
+            )}
+          </p>
+          <FormField
+            label={tr('跳数', 'Hops')}
+            en="snowball_depth"
+            hint={tr(
+              '沿引用关系往外走几层。每多一跳调用量成倍增长，3 跳很重，先试 1 跳。',
+              'How many hops to walk. Each hop multiplies the API calls — 3 is heavy, start with 1.',
+            )}
+          >
+            <Segmented<'1' | '2' | '3'>
+              options={[
+                { v: '1', label: tr('1 跳', '1 hop') },
+                { v: '2', label: tr('2 跳', '2 hops') },
+                { v: '3', label: tr('3 跳', '3 hops') },
+              ]}
+              value={hops}
+              onChange={setHops}
+            />
+          </FormField>
+          {!anchorCount && (
+            <div style={{ fontSize: 11.5, color: 'var(--text-4)', margin: '4px 0 10px' }}>
+              {tr(
+                '这个文献库还没有锚点论文，先去收录设置添加几篇代表作。',
+                'This library has no anchor papers yet — add a few in inclusion settings first.',
+              )}
+            </div>
+          )}
+          <div className="row gap10" style={{ marginTop: 6 }}>
+            <button
+              className="btn btn-ghost"
+              disabled={busy || !anchorCount}
+              onClick={runSnowball}
+            >
+              <Icon name="layers" size={14} />
+              {tr('开始锚点扩展', 'Run anchor expansion')}
+            </button>
           </div>
         </div>
         )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -252,6 +252,8 @@ export interface AnchorPaper {
 export interface KeywordSpec {
   arxiv_categories?: string[];
   include?: string[];
+  /** 排除关键词：命中即不收；检索、打分、每日同步三处都生效。 */
+  exclude?: string[];
   synonyms?: Record<string, string[]>;
 }
 
@@ -1186,7 +1188,9 @@ export interface LabLeaderboardSetting {
 // M2 · Ingest（冷启动 / 增量同步，复用 Voyage）
 // ============================================================
 
-export type IngestMode = 'bootstrap' | 'incremental';
+/** 收集模式：search=按查询词检索 arXiv，snowball=从锚点论文扩展，incremental=每日池自动同步。
+    bootstrap 是 search 的旧名，仅入口兼容。 */
+export type IngestMode = 'search' | 'snowball' | 'incremental' | 'bootstrap';
 
 export interface IngestKnobs {
   /** bootstrap 回填月数（3-24） */
@@ -2632,6 +2636,18 @@ export interface DailySyncStatus {
   failed_categories: string[];
 }
 
+/** 检索模式的时间范围档位。 */
+export type IngestTimeRange = '1w' | '3m' | '6m' | '1y';
+
+export interface IngestStart {
+  mode: IngestMode;
+  knobs?: IngestKnobs;
+  /** search 模式的查询词；留空则用库配置里的「包括关键词」 */
+  query_terms?: string[];
+  /** search 模式的时间范围；给了就覆盖 knobs.months_back */
+  time_range?: IngestTimeRange;
+}
+
 export const api = {
   /** fastapi-users JWT login — form-encoded username/password. Returns access token. */
   async login(email: string, password: string): Promise<string> {
@@ -3205,7 +3221,7 @@ export const api = {
    * 供建库与收录设置的「AI 自动生成」按钮调用；结果填进表单供用户修改后保存。
    */
   suggestLibraryDefinition(input: { name: string; statement: string }): Promise<{
-    keywords: { arxiv_categories: string[]; include: string[] };
+    keywords: { arxiv_categories: string[]; include: string[]; exclude?: string[] };
     rubric: RubricDimension[];
     anchors: AnchorPaper[];
   }> {
@@ -3220,7 +3236,7 @@ export const api = {
     return requestJson<DirectionLibraryDetail>(`/libraries/${id}/reject`, 'POST', { note: note ?? null });
   },
   /** 对某个方向库直接触发抓取（P9a；仅 status=active 且预算内，可管理者）。 */
-  startLibraryIngest(id: string, input: { mode: IngestMode; knobs?: IngestKnobs }): Promise<VoyageRead> {
+  startLibraryIngest(id: string, input: IngestStart): Promise<VoyageRead> {
     return requestJson<VoyageRead>(`/libraries/${id}/ingest/run`, 'POST', input);
   },
   /** 课题当前关联的文献库摘要（顺序 = 关联建立时间）。 */
@@ -3489,7 +3505,7 @@ export const api = {
   },
 
   // —— M2 · Ingest ——
-  startIngest(projectId: string, input: { mode: IngestMode; knobs?: IngestKnobs }): Promise<VoyageRead> {
+  startIngest(projectId: string, input: IngestStart): Promise<VoyageRead> {
     return requestJson<VoyageRead>(`/projects/${projectId}/ingest`, 'POST', input);
   },
   getIngestState(projectId: string): Promise<IngestState> {


### PR DESCRIPTION
Three changes that all serve the same end: making a library's definition good enough that retrieval and scoring actually find the right papers.

## 1. The statement now carries real weight

It feeds **both** the vector ranking that picks candidates out of the daily pool **and** the LLM that scores them. A vague statement hurts twice, so the placeholder stops saying "one sentence describing this direction" and shows a worked example, with a hint naming the four things worth stating: **the subject, the sub-problems, what you favour, and what you explicitly do not want**.

Both the create dialog and the inclusion settings get it.

## 2. Include *and* exclude terms

`keywords.exclude` is new, and the two kinds are deliberately **not** treated alike:

| | include | exclude |
|---|---|---|
| arXiv query | `all:"kw" OR …` | `ANDNOT all:"kw"` |
| Scoring context | "关注的关键词" | "明确不收的方向" |
| Daily-pool sync | **not used to filter** | **hard filter** |

Include terms configured too narrowly starve a library silently — "0 papers" and "nothing relevant today" look identical — so the sync does not gate on them. Exclude terms are the user saying *I do not want this*; ignoring them would be a dereliction, not caution. The count filtered out is reported in the step observation, so it is never silent.

The AI settings generator produces exclude terms too, with an explicit instruction to leave the list empty when unsure — an exclude term keeps papers out entirely.

## 3. Manual collection splits into two modes

`mode` goes from `bootstrap | incremental` to **`search` | `snowball` | `incremental`**, and each runs only the steps it needs:

- **Search** — query terms (defaulting to the library's include terms) + a time range of 1 week / 3 months / 6 months / 1 year, against the arXiv API.
- **Anchor expansion** — walks citations and references out from the anchor papers, 1–3 hops. Does not query arXiv.
- **Incremental** — the automatic daily pass over the daily pool, unchanged.

`bootstrap` maps to `search`, so existing calls and stored runs keep working; a test pins that.

**Behaviour change worth flagging:** the old "initial build" ran search *and* citation expansion fused together. Building a library now does search only, and citation expansion is a second, separate click. The upside is that expanding along citations no longer forces another arXiv search — which is the whole reason to separate them.

Time ranges are stored in **days** (`1w` = 7), not months; a month-granularity window would swallow "one week" entirely.

## Tests

New: exclusions land behind `ANDNOT`; snowball mode's plan starts at `wiki.snowball` and never calls the search API; search mode's query terms and time range reach the actual request URL; the legacy `bootstrap` value still works; exclude terms filter the daily-pool sync and the filtered count is reported.

Six existing tests changed their paper counts because search mode no longer includes citation expansion — each was checked against what the pipeline should now do rather than adjusted until green.

**860 passed**, `ruff` clean, `tsc --noEmit` and `vite build` exit 0. Rebased onto #208/#209 (vector-space isolation), which had already migrated this branch's ranking helper to the new `paper_vectors` API.