### PR TITLE
fix(nav): file library and daily-paper tasks under the lab, not a topic

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -12,7 +12,7 @@ import { topicPath, useProject } from './project';
 import { SearchPalette } from './SearchPalette';
 import { UserMenu } from './UserMenu';
 import { FeedbackWidget } from '../features/feedback/FeedbackWidget';
-import { api, getToken, isAdmin, type GateDecision, type GateRead, type ReviewMessageRead } from '../lib/api';
+import { api, getToken, isAdmin, isLabScopedTask, type GateDecision, type GateRead, type ReviewMessageRead } from '../lib/api';
 import { tr } from '../lib/i18n';
 import { LangToggle } from '../components/ui/LangToggle';
 import { connectNotifications } from '../lib/ws';
@@ -98,7 +98,12 @@ function navCrumb(key: string, pid: string | null): Crumb {
  * 分组段指向该组的落地页（实验室工作台 / 课题工作台 / 我的文献库）。
  * libName：文献库详情页的库名（列表缓存里已有，取不到时退回通用文案）。
  */
-function crumbsFor(pathname: string, pid: string | null, libName?: string | null): Crumb[] {
+function crumbsFor(
+  pathname: string,
+  pid: string | null,
+  libName?: string | null,
+  labTask?: boolean,
+): Crumb[] {
   const lab: Crumb = { label: tr(NAV_GROUPS.lab.zh, NAV_GROUPS.lab.en), to: '/lab' };
   const topic: Crumb = {
     label: tr(NAV_GROUPS.topic.zh, NAV_GROUPS.topic.en),
@@ -125,12 +130,16 @@ function crumbsFor(pathname: string, pid: string | null, libName?: string | null
     if (p.startsWith('/writer/')) return [topic, e('writer'), { label: tr('编辑工作台', 'Editor workspace') }];
     // 任务已并入课题工作台的「任务」标签
     if (p === '/voyages') return [topic, e(''), { label: tr('任务', 'Tasks') }];
+    // 任务详情按归属分流：文献库任务 / 每日新论文（以及任何不挂课题的任务）归实验室，
+    // 其余归课题。归属要等任务本身取回来才知道，取不到时按课题走（占多数）。
     if (p.startsWith('/voyages/'))
-      return [
-        topic,
-        { ...e(''), to: topicPath(pid) + '?tab=tasks' },
-        { label: tr('任务详情', 'Task detail') },
-      ];
+      return labTask
+        ? [lab, { ...e('/lab'), to: '/lab?tab=tasks' }, { label: tr('任务详情', 'Task detail') }]
+        : [
+            topic,
+            { ...e(''), to: topicPath(pid) + '?tab=tasks' },
+            { label: tr('任务详情', 'Task detail') },
+          ];
     if (p === '/start') return [topic, { label: tr('选择课题', 'Pick a topic') }];
     if (p === '/projects/new') return [topic, { label: tr('新建课题', 'New topic') }];
     if (p.startsWith('/projects/')) return [topic, { label: tr('课题设置', 'Topic settings') }];
@@ -564,7 +573,22 @@ export function AppShell() {
     retry: false,
     staleTime: 60_000,
   });
-  const crumbs = crumbsFor(location.pathname, currentProjectId, crumbLibrary?.name);
+  // 任务详情：归属课题还是归属实验室，得看任务本身。queryKey 与详情页默认态
+  // （showObsolete=false）一致，命中的是同一份缓存，正常不会多发请求。
+  const crumbVoyageId = /^\/voyages\/([^/]+)$/.exec(location.pathname)?.[1] ?? null;
+  const { data: crumbVoyage } = useQuery({
+    queryKey: ['voyage', crumbVoyageId, false],
+    queryFn: () => api.getVoyage(crumbVoyageId ?? '', { includeObsolete: false }),
+    enabled: !!crumbVoyageId,
+    retry: false,
+    staleTime: 60_000,
+  });
+  const crumbs = crumbsFor(
+    location.pathname,
+    currentProjectId,
+    crumbLibrary?.name,
+    crumbVoyage ? isLabScopedTask(crumbVoyage) : false,
+  );
 
   // —— 刷新：让所有查询失效并重取（保留页面状态，不整页重载） ——
   const [refreshing, setRefreshing] = useState(false);

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -13,6 +13,7 @@ import { tr } from '../../lib/i18n';
 import {
   api,
   ApiError,
+  isLabScopedTask,
   VOYAGE_TERMINAL,
   type VoyageAcceptance,
   type VoyageAcceptanceCheck,
@@ -258,6 +259,8 @@ function PresentationDownload({ voyageId, goal }: { voyageId: string; goal: stri
 
 // —— 文献任务（wiki_bootstrap / wiki_ingest）：observation 的用户可读摘要 ——
 
+/** 只用来决定要不要渲染建库摘要卡；不含每日新论文（它没有这种 observation）。
+    「这个任务归实验室还是归课题」用 lib/api 的 isLabScopedTask，别拿这个判。 */
 const WIKI_RUN_KINDS = new Set(['wiki_bootstrap', 'wiki_ingest']);
 
 interface PaperBrief {
@@ -1683,20 +1686,22 @@ export function VoyageDetailPage() {
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 20 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="h-eyebrow row gap8">
-            {/* 返回按任务层级分流：库任务（建库/增量更新）归实验室工作台，
-                其余归课题工作台。库任务的 project_id 为空，跳课题会落到首页。 */}
+            {/* 返回按任务层级分流：文献库任务（建库/增量更新）与每日新论文归实验室
+                工作台，其余归课题工作台。判据与面包屑同一份（isLabScopedTask）——
+                原来这里单用 WIKI_RUN_KINDS，漏掉每日新论文，把它送去了课题工作台；
+                而它 project_id 为空，跳课题只会落到首页。 */}
             <span
               className="row gap6"
               style={{ cursor: 'pointer' }}
               onClick={() =>
                 navigate(
-                  WIKI_RUN_KINDS.has(voyage.kind)
+                  isLabScopedTask(voyage)
                     ? '/lab?tab=tasks'
                     : topicPath(voyage.project_id, 'voyages'),
                 )
               }
             >
-              {WIKI_RUN_KINDS.has(voyage.kind)
+              {isLabScopedTask(voyage)
                 ? tr('← 实验室任务', '← Lab tasks')
                 : tr('← 课题任务', '← Topic tasks')}
             </span>

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -7,7 +7,7 @@ import { StatusPill } from '../../components/ui/StatusPill';
 import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { useProject } from '../../app/project';
-import { api, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
+import { api, LIBRARY_TASK_KINDS, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
 import { fmtDuration, fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 
@@ -72,11 +72,11 @@ function kindMeta(kind: string): KindMeta {
   return KIND_META[kind] ?? { zh: kind, icon: 'sparkle', bg: 'var(--surface-3)', tx: 'var(--text-2)' };
 }
 
-/* —— 任务层级：与后端 app/models/voyage.py 的 LIBRARY_KINDS 对应 ——
-   文献库任务（建库/增量更新）与每日新论文任务归实验室工作台，其余归课题。
-   课题工作台的类型筛选只列课题类型：那里根本不会出现库任务，列出来只会
-   选中后永远空列表。 */
-export const LIBRARY_TASK_KINDS = ['wiki_bootstrap', 'wiki_ingest', 'daily_feed_sync'] as const;
+/* —— 任务层级 ——
+   LIBRARY_TASK_KINDS 现在住在 lib/api.ts（外壳的面包屑也要用，那边不能 import 本页），
+   这里转出去给既有引用方。课题工作台的类型筛选只列课题类型：那里根本不会出现库任务，
+   列出来只会选中后永远空列表。 */
+export { LIBRARY_TASK_KINDS };
 export const TOPIC_TASK_KINDS = Object.keys(KIND_META).filter(
   (k) => !(LIBRARY_TASK_KINDS as readonly string[]).includes(k),
 );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -304,6 +304,24 @@ export type VoyageStatus =
 /** 终态集合（不再产生 SSE 事件）。 */
 export const VOYAGE_TERMINAL: ReadonlySet<string> = new Set(['done', 'failed', 'cancelled']);
 
+/**
+ * 不属于任何课题的任务类型：建库 / 增量更新 / 每日新论文，归实验室。
+ * 与后端 models/voyage.py 的 LIBRARY_KINDS 同一份口径（课题任务列表按它排除）。
+ * 放在这里而不是任务页里：外壳的面包屑也要用，而任务页是懒加载的。
+ */
+export const LIBRARY_TASK_KINDS = ['wiki_bootstrap', 'wiki_ingest', 'daily_feed_sync'] as const;
+
+/**
+ * 这个任务归实验室（而不是某个课题）吗——决定面包屑挂在哪一组、返回链接跳哪。
+ * 判据用 kind 而非 library_id：库化改造前建的存量库任务只挂了课题、没有 library_id。
+ * 没有归属课题的任务（含既不属课题也不属库的）同样归实验室工作台。
+ */
+export function isLabScopedTask(task: { kind: string; project_id: string | null }): boolean {
+  return (
+    (LIBRARY_TASK_KINDS as readonly string[]).includes(task.kind) || !task.project_id
+  );
+}
+
 export interface VoyageVerdict {
   passed: boolean;
   reason: string;


### PR DESCRIPTION
## Problem

Tasks that belong to no topic — library builds, incremental updates, and the daily arXiv sync — were filed under a topic in the task detail breadcrumb.

`crumbsFor` in `AppShell.tsx` decided the trail from the **path alone**:

```js
if (p.startsWith('/voyages/'))
  return [topic, { ...e(''), to: topicPath(pid) + '?tab=tasks' }, { label: '任务详情' }];
```

Every `/voyages/<id>` got 课题研究 › 课题工作台 › 任务详情, no matter what the task actually belonged to.

The in-page back link had the same bug from a different angle: it keyed on `WIKI_RUN_KINDS = {wiki_bootstrap, wiki_ingest}`, which omits `daily_feed_sync`. So a daily-paper task offered "← 课题任务" and navigated to `topicPath(null, 'voyages')` — a topic it does not have, landing on the home page.

## Fix

Lab-scoped tasks now read **实验室 › 实验室工作台 › 任务详情**, with the middle segment linking to `/lab?tab=tasks`.

The shell needs the task's scope to pick a trail, so it reads the task with the same query key the detail page uses (`['voyage', id, false]`, matching the detail page's `showObsolete` default). On the normal path that is a cache hit, not a second request — the same pattern the library-detail crumb already uses for the library name.

Both call sites now share one predicate, `isLabScopedTask` in `lib/api.ts`:

```ts
LIBRARY_TASK_KINDS.includes(kind) || !project_id
```

Judging by `kind` rather than `library_id` mirrors the backend (`models/voyage.py:LIBRARY_KINDS`) and matters for legacy library tasks, which carry a `project_id` but no `library_id`. The `!project_id` arm also catches tasks that belong to neither a topic nor a library — the "其它任务" group in the lab workbench.

`LIBRARY_TASK_KINDS` moved from `VoyagesPage.tsx` to `lib/api.ts` (next to `VOYAGE_TERMINAL`) because the shell cannot import it from a lazy-loaded page; `VoyagesPage` re-exports it so existing consumers are untouched. `WIKI_RUN_KINDS` stays narrow — it still gates the wiki run summary card, which really is bootstrap/ingest only, and now carries a comment saying so.

## Scope check

`voyages/:id` is a top-level route (detail pages deliberately keep stable top-level paths), so there is no `/t/<topicId>/voyages/<id>` form for the shell's regex to miss. Topic tasks are unaffected — they still get the topic trail.

## Verification

`tsc --noEmit` and `vite build` both clean. Confirmed against the dev database that the tasks in question do have `project_id IS NULL` (`wiki_ingest`, `daily_feed_sync`), so the new branch is the one they take, and that topic tasks (`idea_forge`, `paper_writing`, …) carry a `project_id` and keep the old trail.

Not verified in a running browser — the browser extension was not connected, and the repo has no frontend test runner. The change is logic-level and type-checked, but the rendered breadcrumb has not been seen.
