### PR TITLE
fix(daily): fetch after arXiv publishes, and trigger library sync when the pool is ready

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -1,15 +1,15 @@
 """每日新论文抓取动作（Voyage kind ``daily_feed_sync`` 的固定计划执行体）。
 
 流水线（navigator.daily_feed_plan）：
-    daily.fetch → daily.upsert → daily.cleanup → daily.embed
+    daily.fetch → daily.upsert → daily.cleanup → daily.embed → daily.sync_libraries
 
 设计约定：
 - 抓取/去重/清理全是确定性代码，不走 LLM；只有最后一步的向量化会花配额；
 - 跨步骤传值走 ``ctx.checkpoint``（抓到的条目 / 本次涉及的论文 id），断点续跑时
   引擎会把 checkpoint 原样带回来；
-- ``daily.fetch`` 全分类颗粒无收即报错：arXiv 客户端把网络/解析失败兜底成 []
-  （见 services/literature/arxiv.py），以前这类失败被整个吞掉，纳入任务系统后
-  让这一步失败 → 任务进 paused_error，列表看得见、日志查得到、可以重试；
+- ``daily.fetch`` **任一分类抓失败即报错**（不是「全都空才报」）：部分失败会让当天
+  那个分类的论文永久缺失，而全实验室的文献库都靠这个池供料；
+- ``daily.sync_libraries`` 收尾时触发各库同步：池子备好了才同步，时刻不用猜；
 - ``daily.embed`` 保持 best-effort：向量化是可选增强，失败不该让整次同步算失败。
 """
 
@@ -93,7 +93,7 @@ async def cleanup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     return {"expired": expired}
 
 
-# ---- 4. 建立语义向量（管理员开关，默认关） ----
+# ---- 4. 建立语义向量 ----
 
 
 @register("daily.embed")
@@ -109,3 +109,22 @@ async def embed(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     else:
         await ctx.log(f"建立向量 {stats['embedded']} 篇")
     return stats
+
+
+# ---- 5. 触发文献库同步 ----
+
+
+@register("daily.sync_libraries")
+async def sync_libraries(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    """新论文入池后立刻触发各文献库的同步。
+
+    以前库同步是自己定时跑的（抓取时刻 + 90 分钟），那是在赌抓取已经跑完——抓取慢一点
+    或者失败重试，同步就会在旧池子上空跑一整轮，而界面上只显示「0 篇新论文」。改成
+    事件驱动：池子备好了才同步，时刻不用猜也不用配。
+    """
+    from app.core.queue import get_task_queue
+
+    queue = await get_task_queue()
+    await queue.enqueue("daily_wiki_ingest")
+    await ctx.log("已触发各文献库同步")
+    return {"triggered": True}

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -121,6 +121,7 @@ def daily_feed_plan(run: VoyageRun) -> list[dict[str, Any]]:
         ("去重入池", "daily.upsert", "新论文已入池，多分类命中已合并"),
         ("清理过期推送", "daily.cleanup", "7 天外的推送与无人收藏的论文已清理"),
         ("建立语义向量", "daily.embed", "本次新论文已补上向量"),
+        ("触发文献库同步", "daily.sync_libraries", "各文献库的同步任务已入队"),
     ]
     return [
         {

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -37,6 +37,8 @@ from app.schemas.daily import (
     DailyPage,
     DailyPaperDetail,
     DailySyncStatus,
+    DailySyncTimeRead,
+    DailySyncTimeUpdate,
 )
 from app.schemas.paper import PaperChatRequest
 from app.services import citations as citations_service
@@ -55,10 +57,17 @@ _NOT_FOUND = HTTPException(status.HTTP_404_NOT_FOUND, detail="DAILY_ENTRY_NOT_FO
 
 @router.get("/days", response_model=list[DailyDay])
 async def list_days(
+    announce: str | None = Query(default=None, pattern="^(new|cross)$"),
+    category: str | None = Query(default=None),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[DailyDay]:
-    return [DailyDay(**d) for d in await daily_service.list_days(session)]
+    return [
+        DailyDay(**d)
+        for d in await daily_service.list_days(
+            session, announce=announce, category=category
+        )
+    ]
 
 
 @router.get("/papers", response_model=DailyPage)
@@ -309,6 +318,31 @@ async def get_sync_status(
     摆在每日页上，而不是只留在任务日志里。
     """
     return DailySyncStatus(**await daily_service.sync_status(session))
+
+
+@router.get("/sync-time", response_model=DailySyncTimeRead)
+async def get_sync_time(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailySyncTimeRead:
+    """每日论文抓取时刻（UTC，全员可读）。"""
+    hour, minute = await daily_service.get_sync_time(session)
+    return DailySyncTimeRead(hour=hour, minute=minute)
+
+
+@router.put("/sync-time", response_model=DailySyncTimeRead)
+async def set_sync_time(
+    payload: DailySyncTimeUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: User = Depends(require_admin),
+) -> DailySyncTimeRead:
+    """改抓取时刻（admin）。
+
+    arXiv 每天约北京时间 10:00 放新公告，早于这个点跑只会拿到**前一天**的列表。
+    库同步与发表匹配的时刻由它派生（+90 / +150 分钟），不必分别设置。
+    """
+    hour, minute = await daily_service.set_sync_time(session, payload.hour, payload.minute)
+    return DailySyncTimeRead(hour=hour, minute=minute)
 
 
 @router.get("/categories", response_model=DailyCategoriesRead)

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -157,3 +157,15 @@ class DailySyncStatus(BaseModel):
     # {分类: {count, status, detail}}
     per_category: dict[str, Any] = Field(default_factory=dict)
     failed_categories: list[str] = Field(default_factory=list)
+
+
+class DailySyncTimeRead(BaseModel):
+    """每日论文抓取时刻（UTC）。北京时间 = UTC + 8。"""
+
+    hour: int = Field(ge=0, le=23)
+    minute: int = Field(ge=0, le=59)
+
+
+class DailySyncTimeUpdate(BaseModel):
+    hour: int = Field(ge=0, le=23)
+    minute: int = Field(ge=0, le=59)

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -595,12 +595,28 @@ async def entry_items(
     return [_entry_item(entry, paper, likes.get(entry.id, empty)) for entry, paper in rows]
 
 
-async def list_days(session: AsyncSession) -> list[dict[str, Any]]:
+async def list_days(
+    session: AsyncSession,
+    *,
+    announce: str | None = None,
+    category: str | None = None,
+) -> list[dict[str, Any]]:
+    """每天的条目数。**按当前筛选算**——日期标签上的数字与列表里看到的必须是同一回事，
+    否则选了 cs.CV 之后标签仍显示全部篇数，看起来就像筛选没生效。
+
+    筛选条件与 :func:`list_papers` 保持同一口径。
+    """
+    stmt = select(DailyFeedEntry.feed_date, func.count(DailyFeedEntry.id))
+    if announce in ("new", "cross"):
+        stmt = stmt.where(DailyFeedEntry.announce_type == announce)
+    if category:
+        stmt = stmt.where(
+            (DailyFeedEntry.primary_category == category)
+            | cast(DailyFeedEntry.categories, String).like(f'%"{category}"%')
+        )
     rows = (
         await session.execute(
-            select(DailyFeedEntry.feed_date, func.count(DailyFeedEntry.id))
-            .group_by(DailyFeedEntry.feed_date)
-            .order_by(DailyFeedEntry.feed_date.desc())
+            stmt.group_by(DailyFeedEntry.feed_date).order_by(DailyFeedEntry.feed_date.desc())
         )
     ).all()
     return [{"date": date, "count": count} for date, count in rows]
@@ -1123,3 +1139,86 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
         "per_category": per_category,
         "failed_categories": failed,
     }
+
+
+# ---- 抓取时刻（可配置） ----
+
+SYNC_TIME_SETTING_KEY = "daily_feed_sync_time"
+
+#: 默认抓取时刻（UTC）= 北京时间 10:30。arXiv 每天约北京时间 10:00 放出新公告，
+#: 早于这个点跑就只会拿到**前一天**的列表——不是延迟一会儿，是永远差一整天。
+#: 这里留半小时余量，给 arXiv 侧的发布抖动。
+DEFAULT_SYNC_UTC = (2, 30)
+
+#: 库同步排在抓取之后多久。每日池是所有文献库的唯一供给，抓取没跑完就同步等于空跑一轮。
+LIBRARY_SYNC_DELAY_MINUTES = 90
+
+
+async def get_sync_time(session: AsyncSession) -> tuple[int, int]:
+    """抓取时刻（UTC 时、分）。存量值非法时回落默认。"""
+    row = await session.get(SystemSetting, SYNC_TIME_SETTING_KEY)
+    value = row.value if row is not None else None
+    if isinstance(value, str) and ":" in value:
+        hh, _, mm = value.partition(":")
+        try:
+            hour, minute = int(hh), int(mm)
+        except ValueError:
+            return DEFAULT_SYNC_UTC
+        if 0 <= hour < 24 and 0 <= minute < 60:
+            return hour, minute
+    return DEFAULT_SYNC_UTC
+
+
+async def set_sync_time(session: AsyncSession, hour: int, minute: int) -> tuple[int, int]:
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        raise ValueError(f"invalid time: {hour}:{minute}")
+    value = f"{hour:02d}:{minute:02d}"
+    row = await session.get(SystemSetting, SYNC_TIME_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=SYNC_TIME_SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return hour, minute
+
+
+async def due_now(session: AsyncSession, *, now: dt.datetime, delay_minutes: int = 0) -> bool:
+    """现在是否到了该跑的时刻（供每 15 分钟一次的检查点判断）。
+
+    arq 的 cron 时刻在 worker 启动时就固定了，改设置得重启才生效。所以改成让 cron 高频
+    空转、由这里判断是否真的该跑：``now`` 已过今天的目标时刻即为 True。调用方还要自己
+    确认今天没跑过（见 :func:`already_ran_today`），否则每个检查点都会重复触发。
+    """
+    hour, minute = await get_sync_time(session)
+    target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    target += dt.timedelta(minutes=delay_minutes)
+    return now >= target
+
+
+async def already_ran_today(session: AsyncSession, kind: str, *, now: dt.datetime) -> bool:
+    """今天（UTC）是否已经建过这种任务。"""
+    start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    found = await session.scalar(
+        select(VoyageRun.id)
+        .where(VoyageRun.kind == kind, VoyageRun.created_at >= start)
+        .limit(1)
+    )
+    return found is not None
+
+
+async def claim_today(session: AsyncSession, key: str, *, now: dt.datetime) -> bool:
+    """把「今天跑过了」这件事记下来；今天已被记过则返回 False。
+
+    给不建任务记录、因而无从按 VoyageRun 判重的检查点任务用（如发表匹配）。
+    先占位再干活：检查点每 15 分钟一次，不占位就会重复触发。
+    """
+    today = now.date().isoformat()
+    row = await session.get(SystemSetting, key)
+    if row is not None and row.value == today:
+        return False
+    if row is None:
+        session.add(SystemSetting(key=key, value=today))
+    else:
+        row.value = today
+    await session.commit()
+    return True

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -548,7 +548,12 @@ async def test_daily_feed_voyage_is_platform_scoped_and_singleton(client):
         assert again.id != run_id
 
 
-async def test_daily_feed_plan_is_the_four_fixed_steps():
+async def _async_value(value):
+    """把普通值包成 awaitable：get_task_queue 是 async 函数，桩也得是。"""
+    return value
+
+
+async def test_daily_feed_plan_is_the_five_fixed_steps():
     from app.agents.voyage.actions import known_actions
     from app.agents.voyage.navigator import daily_feed_plan
     from app.models.voyage import VoyageRun, mode_for_kind
@@ -560,6 +565,7 @@ async def test_daily_feed_plan_is_the_four_fixed_steps():
         "daily.upsert",
         "daily.cleanup",
         "daily.embed",
+        "daily.sync_libraries",
     ]
     assert all(s["checks"] == [{"kind": "no_error"}] for s in plan)
     # 动作必须已注册（app.agents.voyage.__init__ 导入 actions_daily），否则引擎查不到表
@@ -638,7 +644,7 @@ async def test_daily_actions_observation_shapes(client, monkeypatch):
 
 
 async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
-    """整条任务跑通：四步依次 passed、run 到 done、论文真的入了池。"""
+    """整条任务跑通：五步依次 passed、run 到 done、论文真的入了池、库同步被触发。"""
     from app.agents.voyage.engine import VoyageEngine
     from app.core.db import get_sessionmaker
     from app.core.llm.router import LLMRouter
@@ -653,11 +659,24 @@ async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
         lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00071", "E2E Paper")]}),
     )
 
+    # 最后一步会入队库同步；测试里没有真 Redis，打桩记录调用
+    from app.core import queue as queue_module
+
+    enqueued: list[tuple] = []
+
+    class _StubQueue:
+        async def enqueue(self, func, *args, **kwargs):
+            enqueued.append((func, args))
+
+    monkeypatch.setattr(queue_module, "get_task_queue", lambda: _async_value(_StubQueue()))
+
     async with get_sessionmaker()() as session:
         run = await daily_feed.create_daily_feed_voyage(session, created_by=None)
         run_id = run.id
 
     await VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter()).run(run_id)
+
+    assert enqueued == [("daily_wiki_ingest", ())], "入池后必须触发文献库同步"
 
     async with get_sessionmaker()() as session:
         from sqlalchemy import select
@@ -677,6 +696,7 @@ async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
             "daily.upsert",
             "daily.cleanup",
             "daily.embed",
+            "daily.sync_libraries",
         ]
         assert all(s.status == "passed" for s in run.steps)
 
@@ -788,3 +808,121 @@ async def test_sync_status_reports_failed_categories(client, monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["failed_categories"] == ["cs.AI"]
+
+
+# ---- 抓取时刻 ----
+
+
+async def test_default_sync_time_is_after_arxiv_publishes(client):
+    """默认抓取时刻必须**晚于** arXiv 放新公告的时间，否则永远抓到前一天的列表。
+
+    arXiv 约北京时间 10:00 更新（= UTC 02:00）。原来定在 UTC 01:30 = 北京 09:30，
+    早了半小时——这不是「延迟一会儿」，是每天都差一整天。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    async with get_sessionmaker()() as session:
+        hour, minute = await daily_feed.get_sync_time(session)
+    assert (hour, minute) == (2, 30)
+    assert hour * 60 + minute > 2 * 60, "必须晚于 UTC 02:00（北京 10:00）"
+
+
+async def test_sync_time_is_admin_configurable(client):
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    admin = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
+    resp = await client.get("/api/daily/sync-time", headers=admin)
+    assert resp.status_code == 200
+    assert resp.json() == {"hour": 2, "minute": 30}
+
+    resp = await client.put("/api/daily/sync-time", json={"hour": 3, "minute": 45}, headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"hour": 3, "minute": 45}
+
+    async with get_sessionmaker()() as session:
+        assert await daily_feed.get_sync_time(session) == (3, 45)
+
+    # 非 admin 改不了
+    other = {"Authorization": f"Bearer {await register_and_login(client, email='u2@e.com')}"}
+    resp = await client.put("/api/daily/sync-time", json={"hour": 5, "minute": 0}, headers=other)
+    assert resp.status_code == 403
+
+
+async def test_due_now_gates_on_the_configured_time(client):
+    """检查点每 15 分钟跑一次，靠 due_now 判断到点没有——没有它就会一天触发几十次。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    async with get_sessionmaker()() as session:
+        day = dt.datetime(2026, 7, 28, tzinfo=dt.UTC)
+        assert not await daily_feed.due_now(session, now=day.replace(hour=2, minute=15))
+        assert await daily_feed.due_now(session, now=day.replace(hour=2, minute=30))
+        assert await daily_feed.due_now(session, now=day.replace(hour=9, minute=0))
+
+
+async def test_claim_today_is_idempotent_within_a_day(client):
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    now = dt.datetime(2026, 7, 28, 5, 0, tzinfo=dt.UTC)
+    async with get_sessionmaker()() as session:
+        assert await daily_feed.claim_today(session, "k", now=now) is True
+        assert await daily_feed.claim_today(session, "k", now=now) is False
+        # 换一天又能占
+        assert await daily_feed.claim_today(session, "k", now=now + dt.timedelta(days=1)) is True
+
+
+async def test_day_counts_follow_the_active_filters(client, monkeypatch):
+    """日期标签上的数字要跟着筛选走。
+
+    以前 /daily/days 是无条件按天统计的，于是选了某个分类之后，标签仍显示全部篇数，
+    和下面列表里看到的对不上——看起来就像筛选根本没生效。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.AI": [
+                    _rss_entry("2607.11001", "AI One"),
+                    _rss_entry("2607.11002", "AI Two", announce="cross"),
+                ],
+                "cs.CV": [_rss_entry("2607.11003", "CV One")],
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+
+    async def days(**params):
+        resp = await client.get("/api/daily/days", params=params, headers=headers)
+        assert resp.status_code == 200, resp.text
+        return sum(d["count"] for d in resp.json())
+
+    everything = await days()
+    assert everything == 3
+
+    # 按分类筛：只剩该分类的条目
+    assert await days(category="cs.CV") == 1
+    assert await days(category="cs.AI") == 2
+
+    # 按公告类型筛
+    assert await days(announce="cross") == 1
+    assert await days(announce="new") == 2
+
+    # 与列表口径一致：同样的筛选下，两个数字必须相等
+    resp = await client.get(
+        "/api/daily/papers", params={"category": "cs.CV", "size": 50}, headers=headers
+    )
+    assert resp.json()["total"] == await days(category="cs.CV")

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -504,3 +504,34 @@ async def test_rebuild_rejects_empty_target(client, fake_redis):
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "NOTHING_TO_REBUILD"
+
+
+async def test_index_status_readable_for_a_daily_feed_paper(client):
+    """每日论文（只在内容池、不属于任何文献库）也要能看到索引状态。
+
+    每日论文详情页会显示这两个红绿点，而那些论文没有任何库成员行——端点必须
+    include_pool 才读得到，否则界面上是一片 404。
+    """
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+    from app.models.paper import new_paper
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    async with get_sessionmaker()() as session:
+        paper = new_paper(source="arxiv", arxiv_id="2607.55001", title="Pool Only", abstract="x")
+        session.add(paper)
+        await session.flush()
+        session.add(
+            DailyFeedEntry(
+                paper_id=paper.id, feed_date=dt.date(2026, 7, 28), primary_category="cs.AI"
+            )
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.get(f"/api/papers/{paper_id}/index-status", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "paper_vector" in body and "chunk_vector" in body
+    assert body["paper_vector"]["built"] is False  # 刚入池，还没建向量

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -4,11 +4,9 @@ from arq import cron, func
 from arq.connections import RedisSettings
 
 from app.core.config import get_settings
-from app.services.ingest import DAILY_SYNC_UTC_HOUR, DAILY_SYNC_UTC_MINUTE
 from worker.tasks import (
     daily_feed_sync,
     daily_publication_match,
-    daily_wiki_ingest,
     index_papers_fulltext_task,
     match_user_publications,
     ping_task,
@@ -31,13 +29,17 @@ class WorkerSettings:
         index_papers_fulltext_task,
         daily_feed_sync,
     ]
-    # 每日 03:00 对 cadence=daily 且已 bootstrap 的项目触发增量 ingest（docs/api-m2.md §4）
+    # 抓取时刻可由管理员配置（SystemSetting daily_feed_sync_time，默认 UTC 02:30 =
+    # 北京 10:30；arXiv 约北京 10:00 放新公告）。arq 的 cron 时刻在 worker 启动时就固定
+    # 了，改设置得重启才生效——所以这里让 cron 每 15 分钟空转一次，由任务自己判断到点
+    # 没有、今天跑过没有。空转一次只是一条查询，代价可以忽略。
+    #
+    # 库同步不在这里：它由「每日论文抓取」跑完后触发（daily.sync_libraries），池子备好
+    # 了才同步，时刻不用猜。发表匹配仍按时刻派生（抓取 + 150 分钟）。
+    _CHECKPOINT_MINUTES = {0, 15, 30, 45}
     cron_jobs = [
-        # 每日论文池：arXiv 约 00:00 UTC 发布新公告，01:30 抓取（错开 03:00 的每日 ingest）
-        cron(daily_feed_sync, hour=1, minute=30),
-        cron(daily_wiki_ingest, hour=DAILY_SYNC_UTC_HOUR, minute=DAILY_SYNC_UTC_MINUTE),
-        # 每日 ingest 后一小时跑发表匹配（新入库论文 → 姓名+机构命中进待确认）
-        cron(daily_publication_match, hour=DAILY_SYNC_UTC_HOUR + 1, minute=DAILY_SYNC_UTC_MINUTE),
+        cron(daily_feed_sync, minute=_CHECKPOINT_MINUTES),
+        cron(daily_publication_match, minute=_CHECKPOINT_MINUTES),
     ]
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)
     # 其余任务保持 1h 上限

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -68,7 +68,10 @@ async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
 
 
 async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
-    """每日 03:00 cron：给 cadence=daily 且已 bootstrap 的**文献库**入队增量 ingest。
+    """给已建库的**文献库**入队同步。由每日论文抓取跑完后触发（daily.sync_libraries）。
+
+    不再自己定时：定时就意味着赌抓取已经跑完，抓取慢一点或失败重试，同步就会在旧池子
+    上空跑一整轮，而界面上只显示「0 篇新论文」。每天只跑一轮（同一天重复触发会被挡）。
 
     按库选而不是按课题选：独立库（project_id 为空）在按课题遍历的老写法里一个都进不来。
 
@@ -78,8 +81,15 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
 
     返回本次入队的 voyage id 列表（arq 结果可查）。
     """
+    import datetime as dt
+
+    from app.services import daily_feed as daily_feed_service
+
+    now = dt.datetime.now(dt.UTC)
     enqueued: list[str] = []
     async with get_sessionmaker()() as session:
+        if await daily_feed_service.already_ran_today(session, "wiki_ingest", now=now):
+            return enqueued
         # 先回收长期卡住的 paused_error：它们会把所在库一直挡在互斥判定外面
         reclaimed = await ingest_service.reclaim_stale_paused_ingests(session)
         if reclaimed:
@@ -150,14 +160,26 @@ async def index_papers_fulltext_task(
 
 
 async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
-    """每日 01:30 cron（arXiv 约 00:00 UTC 发布新公告）：建一次「每日新论文抓取」任务并入队。
+    """检查点任务（每 15 分钟一次）：到点且今天没跑过，就建一次「每日新论文抓取」。
 
-    抓取/入池/清理/建向量四步都在任务系统里跑（kind=daily_feed_sync），有计划、有步骤
-    状态、有日志，失败可见可重试。返回入队的 voyage id；已有任务在跑则跳过（返回 None）。
+    抓取时刻是可配置的（默认 UTC 02:30 = 北京 10:30，arXiv 约北京 10:00 放新公告）。
+    arq 的 cron 时刻在 worker 启动时固定，改设置得重启才生效——所以这里让 cron 空转、
+    由设置决定是否真的动手。空转一次只是一条查询。
+
+    返回入队的 voyage id；未到点/今天已跑过/已有任务在跑都返回 None。
     """
+    import datetime as dt
+
     from app.services import daily_feed as daily_feed_service
 
+    now = dt.datetime.now(dt.UTC)
     async with get_sessionmaker()() as session:
+        if not await daily_feed_service.due_now(session, now=now):
+            return None
+        if await daily_feed_service.already_ran_today(
+            session, daily_feed_service.DAILY_FEED_VOYAGE_KIND, now=now
+        ):
+            return None
         try:
             run = await daily_feed_service.create_daily_feed_voyage(session, created_by=None)
         except daily_feed_service.DailyFeedConflictError:
@@ -166,9 +188,29 @@ async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
     return str(run.id)
 
 
+#: 发表匹配排在库同步之后多久（新入库论文要先落库，匹配才有东西可匹）
+_PUBLICATION_MATCH_DELAY_MINUTES = 150
+
+
 async def daily_publication_match(ctx: dict[str, Any]) -> int:
-    """每日 04:00 cron（每日 ingest 之后）：对开了自动匹配的绑定用户逐个跑库内匹配。"""
+    """检查点任务：库同步之后再跑发表匹配（新入库论文 → 姓名+机构命中进待确认）。
+
+    时刻同样跟随每日池抓取时间派生，不写死。
+    """
+    import datetime as dt
+
+    from app.services import daily_feed as daily_feed_service
+
+    now = dt.datetime.now(dt.UTC)
     async with get_sessionmaker()() as session:
+        if not await daily_feed_service.due_now(
+            session, now=now, delay_minutes=_PUBLICATION_MATCH_DELAY_MINUTES
+        ):
+            return 0
+        if not await daily_feed_service.claim_today(
+            session, "daily_publication_match_last_run", now=now
+        ):
+            return 0
         user_ids = await publications_service.profiles_for_daily_match(session)
     total = 0
     for uid in user_ids:

--- a/src/frontend/src/components/ui/PaperIndexStatus.tsx
+++ b/src/frontend/src/components/ui/PaperIndexStatus.tsx
@@ -79,7 +79,14 @@ function Dot({
   );
 }
 
-export function PaperIndexStatusRow({ paperId }: { paperId: string }) {
+export function PaperIndexStatusRow({
+  paperId,
+  showRebuild = true,
+}: {
+  paperId: string;
+  /** 放进顶部徽章行时关掉按钮：那一行是「这篇论文是什么」的速览，不是操作区。 */
+  showRebuild?: boolean;
+}) {
   const queryClient = useQueryClient();
   const queryKey = ['paper-index-status', paperId];
 
@@ -140,6 +147,7 @@ export function PaperIndexStatusRow({ paperId }: { paperId: string }) {
           {data.embedded_chunk_count}/{data.chunk_count}
         </span>
       )}
+      {showRebuild && (
       <button
         type="button"
         className="btn btn-ghost sm"
@@ -161,6 +169,7 @@ export function PaperIndexStatusRow({ paperId }: { paperId: string }) {
             ? tr('重新构建', 'Rebuild')
             : tr('构建索引', 'Build index')}
       </button>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -14,6 +14,7 @@ import { ConfirmModal } from '../../components/ui/ConfirmModal';
 import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import {
   ApiError,
   api,
@@ -286,6 +287,9 @@ function DailyDetailPane({
           </span>
         ))}
         <AnnounceBadge type={paper.announce_type} />
+        {/* 向量索引状态跟着徽章走：这一行是「这篇论文是什么」的速览，索引建没建属于
+            同一类信息。不带重建按钮——那一行不是操作区。 */}
+        <PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />
         {paper.arxiv_id &&
           (arxivHref ? (
             <a
@@ -633,9 +637,11 @@ export function DailyPage() {
     setSelectMode(false);
   }, [q, semanticOn, day, category, announce, author, affiliation]);
 
+  // 日期标签上的数字要跟着筛选走，否则选了某个分类之后标签仍显示全部篇数，
+  // 看起来就像筛选根本没生效。
   const daysQuery = useQuery({
-    queryKey: ['daily-days'],
-    queryFn: () => api.listDailyDays(),
+    queryKey: ['daily-days', announce, category],
+    queryFn: () => api.listDailyDays({ announce: announce || undefined, category: category || undefined }),
     retry: false,
     staleTime: 60_000,
   });

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -77,6 +77,8 @@ export function InfoPanel({
             {paper.note_count} {tr('条笔记', 'notes')}
           </span>
         )}
+        {/* 向量索引状态跟着徽章走；不带重建按钮——这一行是速览，不是操作区 */}
+        <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
       </div>
       <div style={{ fontSize: 14.5, fontWeight: 660, lineHeight: 1.4, marginBottom: 5 }}>{paper.title}</div>
       {paper.authors.length > 0 && (
@@ -154,9 +156,6 @@ export function InfoPanel({
         </MetaItem>
         <MetaItem label="ingested">
           <span className="mono">{fmtTime(paper.created_at)}</span>
-        </MetaItem>
-        <MetaItem label={tr('索引', 'index')}>
-          <PaperIndexStatusRow paperId={paper.id} />
         </MetaItem>
       </MetaFold>
 

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -733,6 +733,8 @@ function PaperDetailPane({
                 wiki
               </span>
             )}
+            {/* 向量索引状态跟着徽章走；不带重建按钮——这一行是速览，不是操作区 */}
+            <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
             {paper.pdf_available && (
               <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
                 <Icon name="file" size={11} />
@@ -882,9 +884,6 @@ function PaperDetailPane({
         </MetaItem>
         <MetaItem label={tr('入库时间', 'added at')}>
           <span className="mono">{fmtTime(paper.created_at)}</span>
-        </MetaItem>
-        <MetaItem label={tr('检索索引', 'search index')}>
-          <PaperIndexStatusRow paperId={paper.id} />
         </MetaItem>
       </MetaFold>
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4391,8 +4391,13 @@ export const api = {
 
   // —— 每日新论文池（/daily） ——
   /** 池内现存日期（倒序）与每天篇数。 */
-  listDailyDays(): Promise<DailyDay[]> {
-    return request<DailyDay[]>('/daily/days');
+  /** 每天的条目数。带上当前筛选，否则日期标签上的数字会和列表对不上。 */
+  listDailyDays(params: { announce?: string; category?: string } = {}): Promise<DailyDay[]> {
+    const qs = new URLSearchParams();
+    if (params.announce) qs.set('announce', params.announce);
+    if (params.category) qs.set('category', params.category);
+    const suffix = qs.toString() ? `?${qs}` : '';
+    return request<DailyDay[]>(`/daily/days${suffix}`);
   },
   listDailyPapers(
     opts: {


### PR DESCRIPTION
## The bug

The daily fetch ran at **01:30 UTC = 09:30 Beijing**. arXiv publishes at **10:00 Beijing**. So it always ran half an hour *before* the new announcements existed and picked up the previous day's list — every day, not occasionally.

Default is now **02:30 UTC (10:30 Beijing)**, leaving half an hour of slack for arXiv's own timing.

## The time is admin-configurable

`GET`/`PUT /daily/sync-time` (read by anyone, write by admins).

arq fixes cron times at worker startup, so a stored setting would need a restart to take effect. Instead the cron fires **every 15 minutes** and the task itself decides whether the configured time has passed and whether today's run already happened. An idle checkpoint is one query.

## Library sync is now event-driven

I first made it derive from the fetch time (+90 min). That is a bet that the fetch has finished — and if the fetch is slow or retries, the sync spends a whole round on yesterday's pool while the UI just says "0 new papers".

So the daily pipeline gains a fifth step, `daily.sync_libraries`, which triggers the library syncs once papers are actually in the pool. **Library sync has no schedule of its own any more.** Publication matching still derives from the fetch time (+150 min) since it does not depend on the sync's output.

Enqueue failure fails that step rather than being swallowed: if Redis is down the whole task system is down, and that should be loud. Tests inject a stub instead of softening the production path.

## Day counts ignored the filters

On the daily papers page, the count in the date label came from `/daily/days`, which counted per day **unconditionally**. Pick a category and the list filtered but that number did not move — so the filter looked broken.

`/daily/days` now takes `announce` and `category` and counts with the **same predicates** as the list. A test asserts the two endpoints agree under the same filter, because two different SQL statements returning the same number is exactly the kind of thing that drifts apart again.

## Vector status was buried

The paper-level and full-text vector indicators exist and work — I had put them inside the meta block that an earlier request made collapse by default. That request was about *identifier* metadata (arxiv_id, ingest time); index status is *actionable state*, so it does not belong there.

The dots now sit in the **top badge row** of all three paper detail views — library, reading pane, and **daily papers** (new) — without the rebuild button, since that row is a glance, not a control panel. The component gained a `showRebuild` flag rather than losing the button entirely.

A test pins that `/papers/{id}/index-status` works for a pool-only paper, which is what the daily detail depends on; without `include_pool` that view would be all 404s.

## Tests

Default fetch time must be later than 02:00 UTC (pins the bug directly); the time is admin-settable and non-admins get 403; `due_now` gates the 15-minute checkpoints; `claim_today` is idempotent within a day; the pipeline is five steps and the fifth **must** trigger library sync; day counts follow the filters and agree with the list endpoint; index status is readable for a daily-feed paper.

**866 passed**, `ruff` clean, `tsc --noEmit` and `vite build` exit 0.