### PR TITLE
fix(daily): poll until arXiv's batch for today is actually out

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -13,6 +13,7 @@
 - ``daily.embed`` 保持 best-effort：向量化是可选增强，失败不该让整次同步算失败。
 """
 
+import datetime as dt
 import logging
 import uuid
 from typing import Any
@@ -36,6 +37,15 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
 
     fetched = sum(s["count"] for s in statuses.values())
     failed = [c for c, s in statuses.items() if s["status"] == "error"]
+    # arXiv 声明的批次日期不是今天 = 抓早了，拿到的是上一批。这种失败原本完全无声：
+    # 条目照样几百条，只是全都昨天入过池了，去重后一条不进，而每一步都报成功。
+    # 周末除外——arXiv 的 RSS 里 skipDays 明写着周六周日不发，那时拿到周五那批是正常的。
+    weekend = dt.datetime.now(dt.UTC).weekday() >= 5
+    stale = (
+        []
+        if weekend
+        else sorted({s["batch_date"] for s in statuses.values() if s.get("stale")})
+    )
     for category, state in statuses.items():
         if state["status"] == "error":
             await ctx.log(f"{category}：抓取失败 —— {state['detail']}", level="error")
@@ -50,7 +60,14 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
         "fetched": fetched,
         "per_category": statuses,
         "failed_categories": failed,
+        "stale_batch_dates": stale,
     }
+    if stale and not failed:
+        result["error"] = (
+            f"抓到的是 {'、'.join(stale)} 的公告，不是今天的——多半是跑得比 arXiv 发布还早。"
+            "arXiv 每天约 04:00 UTC（北京 12:00）放当天批次，请把抓取时刻调到其后。"
+        )
+        return result
     if failed:
         # **任一分类失败就报错**，不是「全都空才报」。部分失败下当天那个分类的论文会
         # 永久缺失（RSS 只公告一次，每日池只留一周），而全实验室的文献库都靠这个池

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -299,7 +299,7 @@ async def fetch_new_by_category(
     statuses: dict[str, dict[str, Any]] = {}
     for category in categories:
         try:
-            entries = await client.fetch_new(category)
+            entries, batch_at = await client.fetch_new(category)
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001 — 单分类失败不打断其余分类
@@ -312,7 +312,15 @@ async def fetch_new_by_category(
             }
             continue
         by_category[category] = entries
-        statuses[category] = {"count": len(entries), "status": "ok", "detail": None}
+        batch_date = batch_at.astimezone(dt.UTC).date() if batch_at else None
+        statuses[category] = {
+            "count": len(entries),
+            "status": "ok",
+            "detail": None,
+            # arXiv 自己声明这批是哪天的公告；调用方据此判断有没有抓早了
+            "batch_date": batch_date.isoformat() if batch_date else None,
+            "stale": bool(batch_date and batch_date < _today_utc()),
+        }
     return categories, by_category, statuses
 
 
@@ -1145,10 +1153,14 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
 
 SYNC_TIME_SETTING_KEY = "daily_feed_sync_time"
 
-#: 默认抓取时刻（UTC）= 北京时间 10:30。arXiv 每天约北京时间 10:00 放出新公告，
-#: 早于这个点跑就只会拿到**前一天**的列表——不是延迟一会儿，是永远差一整天。
-#: 这里留半小时余量，给 arXiv 侧的发布抖动。
-DEFAULT_SYNC_UTC = (2, 30)
+#: 默认**开始探测**的时刻（UTC）= 北京时间 09:30。
+#:
+#: 这不是"几点抓"，是"几点开始每 15 分钟探一次"。arXiv 的实际发布时刻会飘：RSS 自己
+#: 写着 ``pubDate: 00:00 -0400`` = 04:00 UTC（北京 12:00），实测 ``lastBuildDate``
+#: 也在 04:00 UTC 附近，但没有任何保证。定死一个时刻就是在赌它不飘——赌输的表现是
+#: 拿到上一批、去重后一条不进、每一步却都报成功（生产上就是这么连丢两天的）。
+#: 改成从早探到晚：探到的批次日期不是今天就什么都不做，等下一个检查点。
+DEFAULT_SYNC_UTC = (1, 30)
 
 #: 库同步排在抓取之后多久。每日池是所有文献库的唯一供给，抓取没跑完就同步等于空跑一轮。
 LIBRARY_SYNC_DELAY_MINUTES = 90
@@ -1222,3 +1234,26 @@ async def claim_today(session: AsyncSession, key: str, *, now: dt.datetime) -> b
         row.value = today
     await session.commit()
     return True
+
+
+async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | None]:
+    """arXiv 上今天那批公告出来了没有。返回 (出来了吗, 探到的批次日期)。
+
+    只探**一个**分类：批次是全站一起发的，探一个就够，没必要为了一个判断打三次。
+    探测本身很便宜（一次 RSS，且陈旧批次不进缓存所以每次都是新的）。
+
+    拿不到批次日期（解析不出 / RSS 没给）时返回 True——宁可照常抓一次，也不能因为
+    一个判断失灵就再也不抓了。
+    """
+    categories = await get_categories(session)
+    if not categories:
+        return True, None
+    try:
+        _, batch_at = await get_arxiv_client().fetch_new(categories[0])
+    except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
+        logger.warning("daily feed probe failed", exc_info=True)
+        return True, None
+    if batch_at is None:
+        return True, None
+    batch_date = batch_at.astimezone(dt.UTC).date()
+    return batch_date >= _today_utc(), batch_date.isoformat()

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -66,6 +66,15 @@ class ArxivRateLimitedError(ArxivError):
     """被 arXiv 限流，且重试次数耗尽。"""
 
 
+def _parse_iso_dt(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
 def _retry_after_seconds(resp: httpx.Response) -> float | None:
     """解析 Retry-After：整数秒或 HTTP-date 两种形式都要认，解不出返回 None。"""
     raw = (resp.headers.get("Retry-After") or "").strip()
@@ -187,14 +196,28 @@ def _parse_rss_item(item: ET.Element) -> dict[str, Any] | None:
     }
 
 
-def _parse_rss(text: str) -> list[dict[str, Any]]:
+def _parse_rss(text: str) -> tuple[list[dict[str, Any]], datetime | None]:
+    """解析 RSS，返回 (条目, **这一批的公告日期**)。
+
+    批次日期取 channel 的 ``pubDate``（arXiv 自己声明这批是哪天的公告）。有了它，
+    「抓早了拿到上一批」就能当场识别——否则那种失败完全无声：条目照样有几百条，
+    只是全都是昨天的，去重之后一条不进，而每一步都报成功。
+    """
     root = ET.fromstring(text)
     out: list[dict[str, Any]] = []
     for item in root.findall(".//item"):
         parsed = _parse_rss_item(item)
         if parsed is not None:
             out.append(parsed)
-    return out
+    batch_at: datetime | None = None
+    channel = root.find("channel")
+    raw = channel.findtext("pubDate") if channel is not None else None
+    if raw:
+        try:
+            batch_at = parsedate_to_datetime(raw)
+        except (TypeError, ValueError, IndexError):
+            batch_at = None
+    return out, batch_at
 
 
 def build_search_query(
@@ -348,7 +371,7 @@ class ArxivClient:
             start += len(entries)
         return results[:limit]
 
-    async def fetch_new(self, category: str) -> list[dict[str, Any]]:
+    async def fetch_new(self, category: str) -> tuple[list[dict[str, Any]], datetime | None]:
         """抓一个分类的当天新公告（RSS /new，即时无索引滞后）。
 
         只返回 announce_type ∈ {new, cross} 的条目（replace/replace-cross 是旧论文更新，
@@ -363,11 +386,17 @@ class ArxivClient:
         """
         key = cache_key("arxiv", "rss_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
-            return cached
+            return cached["entries"], _parse_iso_dt(cached.get("batch_at"))
         resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
-        entries = _parse_rss(resp.text)
-        await self._rss_cache.set(key, entries)
-        return entries
+        entries, batch_at = _parse_rss(resp.text)
+        # **陈旧批次不写缓存**：调用方会每 15 分钟探一次直到当天那批出现，缓存住旧批次
+        # 会让接下来三小时的探测全部拿到同一份，轮询就白做了。与「失败不写缓存」同理。
+        fresh = batch_at is None or batch_at.astimezone(UTC).date() >= datetime.now(UTC).date()
+        if fresh:
+            await self._rss_cache.set(
+                key, {"entries": entries, "batch_at": batch_at.isoformat() if batch_at else None}
+            )
+        return entries, batch_at
 
     async def fetch_by_ids(self, arxiv_ids: list[str]) -> list[dict[str, Any]]:
         """按 id 批量取元数据。"""

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -29,13 +29,23 @@ def _rss_entry(arxiv_id: str, title: str, *, announce: str = "new") -> dict:
 
 
 class _StubArxiv:
-    """按分类返回固定 RSS 条目的假客户端。"""
+    """按分类返回固定 RSS 条目的假客户端。
 
-    def __init__(self, by_category: dict[str, list[dict]]):
+    ``batch_date`` 默认为今天：真实 RSS 会声明这批公告是哪天的，抓早了拿到旧批次会被
+    判为陈旧并报错。想验证那条路径就显式传一个过去的日期。
+    """
+
+    def __init__(self, by_category: dict[str, list[dict]], batch_date=None):
         self.by_category = by_category
+        self.batch_date = batch_date
 
-    async def fetch_new(self, category: str) -> list[dict]:
-        return self.by_category.get(category, [])
+    async def fetch_new(self, category: str):
+        import datetime as _dt
+
+        at = _dt.datetime.combine(
+            self.batch_date or _dt.datetime.now(_dt.UTC).date(), _dt.time(), tzinfo=_dt.UTC
+        )
+        return self.by_category.get(category, []), at
 
 
 async def _run_sync(monkeypatch, by_category: dict[str, list[dict]]) -> dict:
@@ -611,11 +621,12 @@ async def test_daily_actions_observation_shapes(client, monkeypatch):
     obs = await get_action("daily.fetch")(ctx, {})
     assert obs["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
     assert obs["fetched"] == 3
-    assert obs["per_category"] == {
-        "cs.AI": {"count": 2, "status": "ok", "detail": None},
-        "cs.CL": {"count": 1, "status": "ok", "detail": None},
-        "cs.CV": {"count": 0, "status": "ok", "detail": None},
+    assert {c: s["count"] for c, s in obs["per_category"].items()} == {
+        "cs.AI": 2,
+        "cs.CL": 1,
+        "cs.CV": 0,
     }
+    assert all(s["status"] == "ok" and not s["stale"] for s in obs["per_category"].values())
     assert obs["failed_categories"] == []
     assert "error" not in obs
     assert ctx.checkpoint["daily_entries"]  # 条目交给下一步
@@ -719,9 +730,12 @@ async def test_daily_fetch_fails_when_any_category_errors(client, monkeypatch):
 
     class _PartlyBroken:
         async def fetch_new(self, category: str):
+            import datetime as _dt
+
             if category == "cs.AI":
                 raise RuntimeError("429 Too Many Requests")
-            return [_rss_entry("2607.00099", "Fine")]
+            today = _dt.datetime.now(_dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+            return [_rss_entry("2607.00099", "Fine")], today
 
     await register_and_login(client)
     monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _PartlyBroken())
@@ -813,19 +827,17 @@ async def test_sync_status_reports_failed_categories(client, monkeypatch):
 # ---- 抓取时刻 ----
 
 
-async def test_default_sync_time_is_after_arxiv_publishes(client):
-    """默认抓取时刻必须**晚于** arXiv 放新公告的时间，否则永远抓到前一天的列表。
+async def test_default_probe_start_time(client):
+    """默认从 UTC 01:30（北京 09:30）开始探，之后每 15 分钟一次直到当天批次出现。
 
-    arXiv 约北京时间 10:00 更新（= UTC 02:00）。原来定在 UTC 01:30 = 北京 09:30，
-    早了半小时——这不是「延迟一会儿」，是每天都差一整天。
+    早开始是安全的——探到旧批次就什么都不做。定死一个抓取时刻才危险：发布时刻会飘，
+    赌输的表现是拿到上一批、去重后一条不进、每一步却都报成功。
     """
     from app.core.db import get_sessionmaker
     from app.services import daily_feed
 
     async with get_sessionmaker()() as session:
-        hour, minute = await daily_feed.get_sync_time(session)
-    assert (hour, minute) == (2, 30)
-    assert hour * 60 + minute > 2 * 60, "必须晚于 UTC 02:00（北京 10:00）"
+        assert await daily_feed.get_sync_time(session) == (1, 30)
 
 
 async def test_sync_time_is_admin_configurable(client):
@@ -835,7 +847,7 @@ async def test_sync_time_is_admin_configurable(client):
     admin = {"Authorization": f"Bearer {await register_and_login(client)}"}  # 首个用户=admin
     resp = await client.get("/api/daily/sync-time", headers=admin)
     assert resp.status_code == 200
-    assert resp.json() == {"hour": 2, "minute": 30}
+    assert resp.json() == {"hour": 1, "minute": 30}
 
     resp = await client.put("/api/daily/sync-time", json={"hour": 3, "minute": 45}, headers=admin)
     assert resp.status_code == 200, resp.text
@@ -859,8 +871,8 @@ async def test_due_now_gates_on_the_configured_time(client):
 
     async with get_sessionmaker()() as session:
         day = dt.datetime(2026, 7, 28, tzinfo=dt.UTC)
-        assert not await daily_feed.due_now(session, now=day.replace(hour=2, minute=15))
-        assert await daily_feed.due_now(session, now=day.replace(hour=2, minute=30))
+        assert not await daily_feed.due_now(session, now=day.replace(hour=1, minute=15))
+        assert await daily_feed.due_now(session, now=day.replace(hour=1, minute=30))
         assert await daily_feed.due_now(session, now=day.replace(hour=9, minute=0))
 
 
@@ -926,3 +938,90 @@ async def test_day_counts_follow_the_active_filters(client, monkeypatch):
         "/api/daily/papers", params={"category": "cs.CV", "size": 50}, headers=headers
     )
     assert resp.json()["total"] == await days(category="cs.CV")
+
+
+async def test_stale_batch_is_reported_instead_of_silently_creating_nothing(client, monkeypatch):
+    """抓到的不是今天那批公告 → 这一步必须失败。
+
+    生产上真实发生过：抓取跑在 arXiv 发布之前，RSS 返回上一批，条目数照样两三百，
+    但全都昨天入过池，去重后 created=0——而 fetch 报 passed、upsert 报 passed，
+    三天下来丢了两整天的论文，没有任何一处报警。
+    """
+    import datetime as dt
+
+    from app.agents.voyage.actions import get_action
+    from app.agents.voyage.checks import run_deterministic_checks
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00081", "Stale")]}, batch_date=yesterday),
+    )
+
+    ctx = _action_ctx()
+    obs = await get_action("daily.fetch")(ctx, {})
+    assert obs["stale_batch_dates"] == [yesterday.isoformat()]
+    assert obs["error"] and "不是今天的" in obs["error"]
+    assert obs["per_category"]["cs.AI"]["stale"] is True
+
+    verdict, _ = run_deterministic_checks(
+        [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
+    )
+    assert verdict is not None and verdict["passed"] is False
+
+
+async def test_fresh_batch_is_not_reported_as_stale(client, monkeypatch):
+    from app.agents.voyage.actions import get_action
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00082", "Fresh")]}),
+    )
+    obs = await get_action("daily.fetch")(_action_ctx(), {})
+    assert obs["stale_batch_dates"] == []
+    assert "error" not in obs
+
+
+async def test_probe_reports_whether_todays_batch_is_out(client, monkeypatch):
+    """轮询的判据：探到的批次日期是不是今天。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+
+    monkeypatch.setattr(
+        daily_feed, "get_arxiv_client", lambda: _StubArxiv({}, batch_date=yesterday)
+    )
+    async with get_sessionmaker()() as session:
+        fresh, seen = await daily_feed.todays_batch_available(session)
+    assert fresh is False and seen == yesterday.isoformat()
+
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv({}))
+    async with get_sessionmaker()() as session:
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is True
+
+
+async def test_probe_failure_does_not_block_fetching(client, monkeypatch):
+    """探测本身失败时按「可以抓」处理——不能因为一个判断失灵就再也不抓了。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    class _Broken:
+        async def fetch_new(self, category: str):
+            raise RuntimeError("network down")
+
+    await register_and_login(client)
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _Broken())
+    async with get_sessionmaker()() as session:
+        fresh, seen = await daily_feed.todays_batch_available(session)
+    assert fresh is True and seen is None

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -48,6 +48,7 @@ ARXIV_RSS = """<?xml version='1.0' encoding='UTF-8'?>
 xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
     <title>cs.CL updates on arXiv.org</title>
+    <pubDate>Mon, 20 Jul 2026 00:00:00 -0400</pubDate>
     <item>
       <title>Computer-Use Agents at Scale</title>
       <link>https://arxiv.org/abs/2607.10001</link>
@@ -141,7 +142,8 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
         return_value=httpx.Response(200, text=ARXIV_RSS)
     )
     client = ArxivClient(redis=cache_redis, min_interval=0)
-    entries = await client.fetch_new("cs.CL")
+    entries, batch_at = await client.fetch_new("cs.CL")
+    assert batch_at is not None and batch_at.date().isoformat() == "2026-07-20"
 
     # 只留 announce_type ∈ {new, cross}；replace / replace-cross（旧论文更新）被跳过
     assert [e["announce_type"] for e in entries] == ["new", "cross"]
@@ -162,7 +164,7 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
     assert entries[1]["arxiv_id"] == "2607.10002"  # v2 也被去版本号
 
     # 短 TTL 缓存命中：相同分类第二次调用不再发 HTTP
-    again = await client.fetch_new("cs.CL")
+    again, _ = await client.fetch_new("cs.CL")
     assert [e["arxiv_id"] for e in again] == ["2607.10001", "2607.10002"]
     assert route.call_count == 1
     await client.aclose()

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -160,13 +160,18 @@ async def index_papers_fulltext_task(
 
 
 async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
-    """检查点任务（每 15 分钟一次）：到点且今天没跑过，就建一次「每日新论文抓取」。
+    """检查点任务（每 15 分钟一次）：**探到今天那批公告出来了**才抓。
 
-    抓取时刻是可配置的（默认 UTC 02:30 = 北京 10:30，arXiv 约北京 10:00 放新公告）。
-    arq 的 cron 时刻在 worker 启动时固定，改设置得重启才生效——所以这里让 cron 空转、
-    由设置决定是否真的动手。空转一次只是一条查询。
+    起始时刻可配置（默认 UTC 01:30 = 北京 09:30），从那时起每 15 分钟探一次，直到
+    arXiv 放出当天批次。不定死"几点抓"是因为发布时刻会飘，赌一个固定点赌输的表现
+    是拿到上一批、去重后一条不进、每一步却都报成功。
 
-    返回入队的 voyage id；未到点/今天已跑过/已有任务在跑都返回 None。
+    先探再建任务，不是建了任务让它失败——否则从早到晚会攒一堆 paused_error。
+
+    arq 的 cron 时刻在 worker 启动时固定，改设置得重启才生效，所以让 cron 空转、
+    由设置决定是否动手。空转一次只是一条查询加一次 RSS 探测。
+
+    返回入队的 voyage id；未到点 / 今天已跑过 / 今天那批还没出来，都返回 None。
     """
     import datetime as dt
 
@@ -179,6 +184,10 @@ async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
         if await daily_feed_service.already_ran_today(
             session, daily_feed_service.DAILY_FEED_VOYAGE_KIND, now=now
         ):
+            return None
+        fresh, batch_date = await daily_feed_service.todays_batch_available(session)
+        if not fresh:
+            logger.info("daily feed not published yet (latest batch %s), will retry", batch_date)
             return None
         try:
             run = await daily_feed_service.create_daily_feed_voyage(session, created_by=None)


### PR DESCRIPTION
## Two days of papers vanished, silently

7/27 and 7/28 were never fetched. The pool's highest arXiv id sat at **2607.22535** while arXiv had announced up to **2607.247xx** — roughly 2000 ids missing.

Nothing reported a problem. From the stored observations:

| run | fetched | per category | **created** |
|---|---|---|---|
| 07-28 01:30 | 257 | cs.AI 143 / cs.CL 47 / cs.CV 67 | **0** |
| 07-27 01:30 | 257 | cs.AI 143 / cs.CL 47 / cs.CV 67 | 215 |
| 07-26 01:30 | 110 | cs.CL 110 | **0** |

The 7/28 run pulled **byte-identical counts** to 7/27's — the same batch. `RSS /new` only ever serves the *current* batch, so a fetch that runs before arXiv publishes gets yesterday's, and yesterday's is already deduped away. `fetch` passed (257 papers is真的), `upsert` passed (`created: 0`), and two days disappeared.

## A fixed time cannot fix this

The RSS declares `pubDate: 00:00 -0400` (04:00 UTC) and `lastBuildDate` lands near 04:00:14 — but nothing guarantees that, and **picking a clock time is a bet whose losing outcome is silent**. I had first moved the default to 10:30 Beijing on the assumption arXiv publishes at 10:00; the feed's own metadata says 12:00, so that would have kept the bug.

## So it polls

From a configurable start (default **01:30 UTC = 09:30 Beijing**) the existing 15-minute checkpoint probes the feed and **does nothing unless the batch arXiv itself declares is today's**. The judge is `channel/pubDate`, not our guess.

Three details it depends on:

- **Stale batches are not cached.** The RSS cache lives 3h; caching a stale batch at 09:30 would serve it to every probe until 12:30 and the polling would accomplish nothing. Same principle as "a failed fetch is not cached".
- **The probe runs before the voyage is created**, rather than as a failing step inside it — otherwise a morning of polling leaves a trail of `paused_error` runs.
- **A failed probe counts as "go ahead."** A broken check must not be able to stop fetching altogether.

Only one category is probed: batches are site-wide, so three requests would buy nothing.

## Belt and braces

Independently of the polling, a batch that is not today's now **fails `daily.fetch` outright**, with both dates in the message. If the polling is ever bypassed or misconfigured, the old silent failure cannot return.

Weekends are exempt — arXiv's own `skipDays` element says it does not announce on Sat/Sun, so Friday's batch on a Saturday is correct, not stale.

## Tests

A stale batch fails the step and trips the `no_error` check; a fresh one does not; the probe reports freshness correctly; a probe failure does not block fetching; `fetch_new` returns the batch date parsed from the channel.

**868 passed**, `ruff` clean.

## Not in this PR

- **7/27 and 7/28 still need recovering.** RSS cannot serve past batches; that needs the arXiv search API over a submittedDate window.
- **Deployment.** This is the fix that matters for tomorrow morning; production is still running the old schedule.