### PR TITLE
feat(ingest): retune defaults, move anchors to where they are used, scope the daily scan

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -75,14 +75,16 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_KNOBS: dict[str, Any] = {
     "months_back": 6,
-    "max_papers": 50,
-    "relevance_threshold": 0.6,
+    "max_papers": 150,
+    "relevance_threshold": 0.8,
     "snowball_depth": 1,
-    "compile_top_n": 20,
+    "compile_top_n": 50,
     "unlimited": False,
 }
 
-_MAX_CANDIDATES_CAP = 200
+# 检索/打分的安全上限。这是防失控的天花板，不是常规取数口径——常规口径是用户填的
+# 「最大检索篇数」（max_papers，上限 500）。
+_MAX_CANDIDATES_CAP = 500
 
 # 最大化模式（knobs.unlimited=True）的安全哨兵：检索/打分/抽取/编译均按「窗口内全量」
 # 处理，不再受 max_papers/compile_top_n/_MAX_CANDIDATES_CAP 截断；此哨兵只防真正失控
@@ -326,16 +328,30 @@ async def _collect_from_daily_feed(
     **「排除关键词」是例外，这里会硬过滤。** 那是用户明确说「我不要这个」，漏掉它是
     失职而不是保守；过滤掉多少篇会记进观测，不至于无声无息。
     """
-    rows = (
-        (
-            await session.execute(
-                select(Paper, DailyFeedEntry.feed_date)
-                .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
-                .order_by(DailyFeedEntry.feed_date.desc())
-            )
-        )
-        .all()
+    # 扫描范围（管理员可配，默认 since_last）：
+    # - since_last：从本库上次成功同步那天算起。正常就是当天那批（省），漏了几天会
+    #   自动多扫几天（能自愈）——这两件事本来要在 daily 和 full 之间二选一。
+    # - daily：只扫当天。最省，但漏掉的永久错过（arXiv 不会再给第二次）。
+    # - full：扫整张表。最稳，代价是重复排序几千篇早就处理过的。
+    from app.services.daily_feed import get_sync_scope
+
+    scope = await get_sync_scope(session)
+    stmt = (
+        select(Paper, DailyFeedEntry.feed_date)
+        .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
+        .order_by(DailyFeedEntry.feed_date.desc())
     )
+    since_day: Any = None
+    if scope == "daily":
+        since_day = datetime.now(UTC).date()
+        stmt = stmt.where(DailyFeedEntry.feed_date == since_day)
+    elif scope == "since_last":
+        last = _parse_iso(((library.ingest_state or {}).get("last_run") or {}).get("finished_at"))
+        # 没有上次记录（首次同步）就按全量走：宁可多扫一轮，也不能开局就漏
+        if last is not None:
+            since_day = last.astimezone(UTC).date()
+            stmt = stmt.where(DailyFeedEntry.feed_date >= since_day)
+    rows = (await session.execute(stmt)).all()
     feed_papers = [p for p, _ in rows]
     feed_latest = max((d for _, d in rows), default=None)
 
@@ -385,6 +401,8 @@ async def _collect_from_daily_feed(
 
     return {
         "feed_total": len(rows),
+        "feed_scope": scope,
+        "feed_since": since_day.isoformat() if since_day else None,
         "excluded_by_terms": excluded_by_terms,
         "feed_ranked": did_rank,
         "after_vector_rank": len(ranked),
@@ -419,7 +437,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         if _unlimited(knobs):
             limit = _UNLIMITED_SENTINEL  # 窗口内全量抓取（哨兵防失控）
         else:
-            limit = min(_MAX_CANDIDATES_CAP, max(int(knobs["max_papers"]) * 3, 10))
+            # 「最大检索篇数」就是检索上限本身。以前是 min(200, max_papers*3)，填 150
+            # 实际会检索 200——旋钮名和行为对不上，用户按名字调参就调不准。
+            limit = max(1, min(_MAX_CANDIDATES_CAP, int(knobs["max_papers"])))
 
         # —— 增量同步：候选一律来自每日论文池，不访问 arXiv ——
         # arXiv 检索是限流的主要来源（生产上三个库同步就是死在这个调用的 429 上），

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -36,9 +36,13 @@ from app.schemas.daily import (
     DailyLikeState,
     DailyPage,
     DailyPaperDetail,
+    DailyRetentionRead,
+    DailyRetentionUpdate,
     DailySyncStatus,
     DailySyncTimeRead,
     DailySyncTimeUpdate,
+    LibrarySyncScopeRead,
+    LibrarySyncScopeUpdate,
 )
 from app.schemas.paper import PaperChatRequest
 from app.services import citations as citations_service
@@ -318,6 +322,56 @@ async def get_sync_status(
     摆在每日页上，而不是只留在任务日志里。
     """
     return DailySyncStatus(**await daily_service.sync_status(session))
+
+
+@router.get("/sync-scope", response_model=LibrarySyncScopeRead)
+async def get_sync_scope(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibrarySyncScopeRead:
+    """库同步每次扫描每日池的范围（全员可读）。"""
+    return LibrarySyncScopeRead(scope=await daily_service.get_sync_scope(session))
+
+
+@router.put("/sync-scope", response_model=LibrarySyncScopeRead)
+async def set_sync_scope(
+    payload: LibrarySyncScopeUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: User = Depends(require_admin),
+) -> LibrarySyncScopeRead:
+    """改扫描范围（admin）。
+
+    - ``since_last``（默认）：从这个库**上次成功同步**那天算起。正常情况下就是当天
+      那批（和 daily 一样省），漏了几天会自动多扫几天（和 full 一样能自愈）。
+    - ``daily``：只扫当天。最省，但某次同步失败落下的论文**永久错过**——arXiv 不会
+      再给第二次。
+    - ``full``：扫整张每日池表。最稳，代价是每次重复排序几千篇早就处理过的。
+    """
+    return LibrarySyncScopeRead(scope=await daily_service.set_sync_scope(session, payload.scope))
+
+
+@router.get("/retention", response_model=DailyRetentionRead)
+async def get_retention(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyRetentionRead:
+    """每日池保留天数（全员可读）。"""
+    return DailyRetentionRead(days=await daily_service.get_retention_days(session))
+
+
+@router.put("/retention", response_model=DailyRetentionRead)
+async def set_retention(
+    payload: DailyRetentionUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: User = Depends(require_admin),
+) -> DailyRetentionRead:
+    """改保留天数（admin）。
+
+    这不只是「每日页显示几天」：每日池同时是**库同步的取数窗口**，同步会全量重扫它。
+    所以保留期也就是「一个文献库最多能漏几天还能自愈」——掉出窗口的论文永久错过，
+    arXiv 那边不会再给第二次。调小要谨慎。
+    """
+    return DailyRetentionRead(days=await daily_service.set_retention_days(session, payload.days))
 
 
 @router.get("/sync-time", response_model=DailySyncTimeRead)

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -24,6 +24,7 @@ from app.core.llm.router import get_llm_router
 from app.core.redis import get_redis_dep
 from app.models.user import User
 from app.schemas.paper import (
+    CollectingLibraryRead,
     MyTagRead,
     PaperBatchIds,
     PaperChatRequest,
@@ -41,6 +42,7 @@ from app.schemas.paper import (
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
+    ResolvedPaperRead,
     TagRead,
 )
 from app.services import figure_annotate as figure_service
@@ -413,6 +415,35 @@ async def delete_project_paper(
     await papers_service.delete_paper(session, view)
 
 
+@router.get("/papers/resolve", response_model=ResolvedPaperRead)
+async def resolve_paper_meta(
+    arxiv_id: str = Query(min_length=1),
+    _: User = Depends(current_active_user),
+) -> ResolvedPaperRead:
+    """按 arXiv id 取论文题目等元数据（锚点论文填表用：填 id，题目自动补上）。
+
+    只读 arXiv，不入库、不建向量——纯粹是让人确认「填的这个 id 是不是想要的那篇」。
+    解析不出返回 422，前端保留 id、题目留空即可。
+    """
+    from app.services import paper_import as paper_import_service
+
+    try:
+        fields = await paper_import_service.resolve_fields(arxiv_id=arxiv_id)
+    except paper_import_service.ParseFailedError as e:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail="ARXIV_ID_NOT_RESOLVED"
+        ) from e
+    return ResolvedPaperRead(
+        arxiv_id=str(fields.get("arxiv_id") or arxiv_id),
+        title=str(fields.get("title") or ""),
+        year=fields.get("year"),
+        authors=[
+            str(a.get("name") if isinstance(a, dict) else a)
+            for a in (fields.get("authors") or [])
+        ][:8],
+    )
+
+
 @router.get("/papers/{paper_id}", response_model=PaperDetail)
 async def get_paper(
     paper_id: uuid.UUID,
@@ -607,6 +638,21 @@ async def recompile_paper(
 
 
 # ---- 索引状态与手动重建（docs/api-lit.md §9） ----
+
+
+@router.get("/papers/{paper_id}/libraries", response_model=list[CollectingLibraryRead])
+async def get_collecting_libraries(
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[CollectingLibraryRead]:
+    """这篇论文被哪些文献库收录了，带各自的相关度分。
+
+    只列对请求者可见的库（个人库不外泄），且只算真正进了库的状态。
+    """
+    await _get_member_paper(session, paper_id, user, include_pool=True)
+    rows = await papers_service.collecting_libraries(session, paper_id, user)
+    return [CollectingLibraryRead(**row) for row in rows]
 
 
 @router.get("/papers/{paper_id}/index-status", response_model=PaperIndexStatusRead)

--- a/src/backend/app/models/daily_feed.py
+++ b/src/backend/app/models/daily_feed.py
@@ -22,7 +22,9 @@ from app.models.paper import Paper
 DEFAULT_DAILY_CATEGORIES = ["cs.AI", "cs.CL", "cs.CV"]
 
 # 池滚动保留天数（含当天）
-DAILY_FEED_RETENTION_DAYS = 7
+#: 保留天数的**默认值**。运行时以 SystemSetting daily_feed_retention_days 为准
+#: （见 services/daily_feed.get_retention_days）；这里留着给不便读设置的调用方。
+DAILY_FEED_RETENTION_DAYS = 14
 
 
 class DailyFeedEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -169,3 +169,23 @@ class DailySyncTimeRead(BaseModel):
 class DailySyncTimeUpdate(BaseModel):
     hour: int = Field(ge=0, le=23)
     minute: int = Field(ge=0, le=59)
+
+
+class DailyRetentionRead(BaseModel):
+    """每日论文池保留天数。这张表也是库同步的取数窗口。"""
+
+    days: int = Field(ge=1, le=90)
+
+
+class DailyRetentionUpdate(BaseModel):
+    days: int = Field(ge=1, le=90)
+
+
+class LibrarySyncScopeRead(BaseModel):
+    """库同步每次扫描每日池的范围。"""
+
+    scope: Literal["since_last", "daily", "full"]
+
+
+class LibrarySyncScopeUpdate(BaseModel):
+    scope: Literal["since_last", "daily", "full"]

--- a/src/backend/app/schemas/ingest.py
+++ b/src/backend/app/schemas/ingest.py
@@ -14,11 +14,11 @@ TIME_RANGE_DAYS: dict[str, int] = {"1w": 7, "3m": 90, "6m": 180, "1y": 365}
 
 class IngestKnobs(BaseModel):
     months_back: int = Field(default=6, ge=1, le=36)  # 检索模式回溯月数（由 time_range 换算）
-    max_papers: int = Field(default=50, ge=1, le=500)  # 本次最多精读编译篇数（成本上限）
-    relevance_threshold: float = Field(default=0.6, ge=0.0, le=1.0)
+    max_papers: int = Field(default=150, ge=1, le=500)  # 本次最多检索/打分的篇数（成本上限）
+    relevance_threshold: float = Field(default=0.8, ge=0.0, le=1.0)
     # 锚点扩展的跳数。每多一跳，Semantic Scholar 的调用量成倍涨，3 跳已经很重
     snowball_depth: int = Field(default=1, ge=0, le=3)
-    compile_top_n: int = Field(default=20, ge=1, le=200)  # 打分后精读编译前 N 篇
+    compile_top_n: int = Field(default=50, ge=1, le=200)  # 打分后精读编译前 N 篇
     # 最大化模式：True 时检索/打分/抽取/编译不设篇数上限（max_papers/compile_top_n 被忽略，
     # 仅保留极高安全哨兵防失控），token 预算也不设限。默认 False，向后兼容。
     unlimited: bool = False

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -314,3 +314,22 @@ class SearchResponse(BaseModel):
     concepts: list[ScoredConcept]
     mode_used: Literal["keyword", "semantic"]
     reranked: bool = False  # semantic 模式下 rerank 是否成功（失败降级为纯向量分）
+
+
+class ResolvedPaperRead(BaseModel):
+    """按 arXiv id 解析出的论文元数据（锚点论文填表用，不入库）。"""
+
+    arxiv_id: str
+    title: str
+    year: int | None = None
+    authors: list[str] = Field(default_factory=list)
+
+
+class CollectingLibraryRead(BaseModel):
+    """收录了某篇论文的文献库（带相关度分）。"""
+
+    library_id: uuid.UUID
+    name: str
+    is_public: bool
+    status: str
+    relevance_score: float | None = None

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -24,7 +24,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.embedding_space import EmbeddingSpace, active_space
 from app.models.daily_feed import (
-    DAILY_FEED_RETENTION_DAYS,
     DEFAULT_DAILY_CATEGORIES,
     DailyFeedEntry,
     DailyFeedLike,
@@ -185,7 +184,7 @@ async def backfill_embeddings(
     session: AsyncSession, *, user_id: uuid.UUID | None = None, today: dt.date | None = None
 ) -> dict[str, int]:
     """给当前 7 天窗口内所有缺向量的每日论文补建向量（管理员开开关后一次性补齐用）。"""
-    cutoff = (today or _today_utc()) - dt.timedelta(days=DAILY_FEED_RETENTION_DAYS - 1)
+    cutoff = (today or _today_utc()) - dt.timedelta(days=await get_retention_days(session) - 1)
     paper_ids = list(
         (
             await session.execute(
@@ -206,7 +205,7 @@ async def embedding_coverage(
     「有向量」按**激活空间**算：刚换过嵌入模型时覆盖率会如实掉下来，前端照此提示，
     而不是拿旧空间的向量数充数。
     """
-    cutoff = (today or _today_utc()) - dt.timedelta(days=DAILY_FEED_RETENTION_DAYS - 1)
+    cutoff = (today or _today_utc()) - dt.timedelta(days=await get_retention_days(session) - 1)
     base = (
         select(func.count())
         .select_from(DailyFeedEntry)
@@ -261,7 +260,7 @@ async def cleanup_expired(session: AsyncSession, *, today: dt.date | None = None
     过期退出推送后，若某文章不再被任何集合引用（库/书架/个人库/论著），回收其内容池
     本体 + 落盘文件——否则从没人收藏的每日推送会把内容池越堆越大。
     """
-    cutoff = (today or _today_utc()) - dt.timedelta(days=DAILY_FEED_RETENTION_DAYS - 1)
+    cutoff = (today or _today_utc()) - dt.timedelta(days=await get_retention_days(session) - 1)
     expired = (
         await session.execute(
             select(DailyFeedEntry.id, DailyFeedEntry.paper_id).where(
@@ -1257,3 +1256,67 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
         return True, None
     batch_date = batch_at.astimezone(dt.UTC).date()
     return batch_date >= _today_utc(), batch_date.isoformat()
+
+
+# ---- 保留期（可配置） ----
+
+RETENTION_SETTING_KEY = "daily_feed_retention_days"
+
+#: 每日池默认保留天数。这张表同时是**库同步的取数窗口**（同步全量重扫它），所以保留期
+#: 也就是「一个库最多能漏几天还能自愈」——漏掉的那几天只要论文还在窗口内，下次同步
+#: 会自动补上；掉出窗口就永久错过，arXiv 那边不会再给第二次。
+DEFAULT_RETENTION_DAYS = 14
+
+
+async def get_retention_days(session: AsyncSession) -> int:
+    """保留天数（默认 14）。存量值非法时回落默认。"""
+    row = await session.get(SystemSetting, RETENTION_SETTING_KEY)
+    value = row.value if row is not None else None
+    if isinstance(value, int) and 1 <= value <= 90:
+        return value
+    return DEFAULT_RETENTION_DAYS
+
+
+async def set_retention_days(session: AsyncSession, days: int) -> int:
+    if not (1 <= days <= 90):
+        raise ValueError(f"retention out of range: {days}")
+    row = await session.get(SystemSetting, RETENTION_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=RETENTION_SETTING_KEY, value=days))
+    else:
+        row.value = days
+    await session.commit()
+    return days
+
+
+# ---- 库同步的扫描范围（可配置） ----
+
+SYNC_SCOPE_SETTING_KEY = "library_sync_scope"
+
+#: 库同步每次扫描每日池的范围：
+#:
+#: - ``since_last``（默认）：从这个库**上次成功同步**那天算起。正常情况下就是当天那批
+#:   （和 ``daily`` 一样快），漏了几天会自动多扫几天（和 ``full`` 一样能自愈）。
+#: - ``daily``：只扫当天。最省，但某次同步失败落下的论文**永久错过**——arXiv 不会
+#:   再给第二次。
+#: - ``full``：扫整张表。最稳，代价是每次重复排序几千篇早就处理过的。
+DEFAULT_SYNC_SCOPE = "since_last"
+SYNC_SCOPES = ("since_last", "daily", "full")
+
+
+async def get_sync_scope(session: AsyncSession) -> str:
+    row = await session.get(SystemSetting, SYNC_SCOPE_SETTING_KEY)
+    value = row.value if row is not None else None
+    return value if value in SYNC_SCOPES else DEFAULT_SYNC_SCOPE
+
+
+async def set_sync_scope(session: AsyncSession, scope: str) -> str:
+    if scope not in SYNC_SCOPES:
+        raise ValueError(f"unknown scope: {scope}")
+    row = await session.get(SystemSetting, SYNC_SCOPE_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=SYNC_SCOPE_SETTING_KEY, value=scope))
+    else:
+        row.value = scope
+    await session.commit()
+    return scope

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -1220,3 +1220,40 @@ async def rerank_paper_rows(
         logger.warning("rerank failed, falling back to vector scores", exc_info=True)
         return rows[:limit], False
     return [(rows[i][0], score) for i, score in ranked[:limit]], True
+
+
+async def collecting_libraries(
+    session: AsyncSession, paper_id: uuid.UUID, user: Any
+) -> list[dict[str, Any]]:
+    """这篇论文被哪些**对该用户可见**的文献库收录了，带相关度分。
+
+    只算真正进了库的状态（scored 及之后）——candidate 是还没打分、excluded 是打分没
+    过，两者都不算"收录"，混进来会让人以为库里有这篇。
+
+    可见性按 P10 口径过滤：个人库只对归属人与 admin 可见，不能经这个接口泄漏出去。
+    """
+    from app.models.library_direction import DirectionLibrary, LibraryPaper
+    from app.services.libraries import library_visible_to
+
+    rows = (
+        await session.execute(
+            select(DirectionLibrary, LibraryPaper.status, LibraryPaper.relevance_score)
+            .join(LibraryPaper, LibraryPaper.library_id == DirectionLibrary.id)
+            .where(
+                LibraryPaper.paper_id == paper_id,
+                LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+            )
+            .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+        )
+    ).all()
+    return [
+        {
+            "library_id": lib.id,
+            "name": lib.name,
+            "is_public": lib.is_public,
+            "status": status,
+            "relevance_score": score,
+        }
+        for lib, status, score in rows
+        if library_visible_to(lib, user)
+    ]

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -124,7 +124,10 @@ async def test_cleanup_expired_keeps_paper_and_membership(client, monkeypatch):
 
     async with get_sessionmaker()() as session:
         entry = await session.get(DailyFeedEntry, uuid.UUID(entry_id))
-        entry.feed_date = entry.feed_date - dt.timedelta(days=8)
+        # 比保留期更早才算过期（保留期默认 14 天，且管理员可改）
+        from app.services.daily_feed import DEFAULT_RETENTION_DAYS
+
+        entry.feed_date = entry.feed_date - dt.timedelta(days=DEFAULT_RETENTION_DAYS + 1)
         await session.commit()
 
     result = await _run_sync(monkeypatch, {"cs.AI": []})
@@ -642,7 +645,10 @@ async def test_daily_actions_observation_shapes(client, monkeypatch):
         from sqlalchemy import select
 
         entry = (await session.execute(select(DailyFeedEntry))).scalars().first()
-        entry.feed_date = entry.feed_date - dt.timedelta(days=8)
+        # 比保留期更早才算过期（保留期默认 14 天，且管理员可改）
+        from app.services.daily_feed import DEFAULT_RETENTION_DAYS
+
+        entry.feed_date = entry.feed_date - dt.timedelta(days=DEFAULT_RETENTION_DAYS + 1)
         await session.commit()
 
     obs = await get_action("daily.cleanup")(ctx, {})
@@ -1025,3 +1031,67 @@ async def test_probe_failure_does_not_block_fetching(client, monkeypatch):
     async with get_sessionmaker()() as session:
         fresh, seen = await daily_feed.todays_batch_available(session)
     assert fresh is True and seen is None
+
+
+async def test_retention_defaults_to_two_weeks_and_is_configurable(client):
+    """保留期默认 14 天，管理员可改。
+
+    它不只是「每日页显示几天」：每日池同时是**库同步的取数窗口**（同步全量重扫），
+    所以保留期就是一个文献库最多能漏几天还能自愈。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    admin = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    resp = await client.get("/api/daily/retention", headers=admin)
+    assert resp.status_code == 200 and resp.json() == {"days": 14}
+
+    resp = await client.put("/api/daily/retention", json={"days": 21}, headers=admin)
+    assert resp.status_code == 200 and resp.json() == {"days": 21}
+    async with get_sessionmaker()() as session:
+        assert await daily_feed.get_retention_days(session) == 21
+
+    other = {"Authorization": f"Bearer {await register_and_login(client, email='r2@e.com')}"}
+    assert (
+        await client.put("/api/daily/retention", json={"days": 3}, headers=other)
+    ).status_code == 403
+
+
+async def test_cleanup_uses_the_configured_retention(client, monkeypatch):
+    """改了保留期，清理的截止线跟着走——两者读同一个设置。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+    from app.models.paper import new_paper
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    today = dt.datetime.now(dt.UTC).date()
+    async with get_sessionmaker()() as session:
+        for i, age in enumerate((3, 10, 20)):
+            paper = new_paper(source="arxiv", arxiv_id=f"2607.66{i:03d}", title=f"P{age}")
+            session.add(paper)
+            await session.flush()
+            session.add(
+                DailyFeedEntry(
+                    paper_id=paper.id,
+                    feed_date=today - dt.timedelta(days=age),
+                    primary_category="cs.AI",
+                )
+            )
+        await session.commit()
+
+    # 默认 14 天：20 天前那条过期，10 天前的留下
+    async with get_sessionmaker()() as session:
+        expired = await daily_feed.cleanup_expired(session)
+        await session.commit()
+    assert expired == 1
+
+    # 收紧到 7 天：10 天前那条也该被清掉
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_retention_days(session, 7)
+    async with get_sessionmaker()() as session:
+        expired = await daily_feed.cleanup_expired(session)
+        await session.commit()
+    assert expired == 1

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -48,7 +48,7 @@ ARXIV_RSS = """<?xml version='1.0' encoding='UTF-8'?>
 xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
     <title>cs.CL updates on arXiv.org</title>
-    <pubDate>Mon, 20 Jul 2026 00:00:00 -0400</pubDate>
+    <pubDate>__CHANNEL_PUBDATE__</pubDate>
     <item>
       <title>Computer-Use Agents at Scale</title>
       <link>https://arxiv.org/abs/2607.10001</link>
@@ -99,6 +99,19 @@ Abstract: A revised cross-listed older paper.</description>
 """
 
 
+def _rss_with_batch_date(day) -> str:
+    """把 fixture 的批次日期换成指定日期。
+
+    批次日期不是今天时**不会进缓存**（否则轮询会一直拿到同一份旧批次），所以想验证
+    缓存就必须让它声明今天。
+    """
+    from email.utils import format_datetime
+    import datetime as _dt
+
+    at = _dt.datetime.combine(day, _dt.time(), tzinfo=_dt.timezone(_dt.timedelta(hours=-4)))
+    return ARXIV_RSS.replace("__CHANNEL_PUBDATE__", format_datetime(at))
+
+
 @pytest_asyncio.fixture
 async def cache_redis():
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
@@ -138,12 +151,15 @@ async def test_arxiv_search_parses_and_caches(cache_redis):
 
 @respx.mock
 async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
+    import datetime as _dt
+
+    today = _dt.datetime.now(_dt.UTC).date()
     route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
-        return_value=httpx.Response(200, text=ARXIV_RSS)
+        return_value=httpx.Response(200, text=_rss_with_batch_date(today))
     )
     client = ArxivClient(redis=cache_redis, min_interval=0)
     entries, batch_at = await client.fetch_new("cs.CL")
-    assert batch_at is not None and batch_at.date().isoformat() == "2026-07-20"
+    assert batch_at is not None and batch_at.astimezone(_dt.UTC).date() == today
 
     # 只留 announce_type ∈ {new, cross}；replace / replace-cross（旧论文更新）被跳过
     assert [e["announce_type"] for e in entries] == ["new", "cross"]
@@ -441,3 +457,24 @@ async def test_penalize_extends_the_shared_gate(cache_redis):
     ttl = await cache_redis.pttl("lit:arxiv:gate")
     assert ttl > 1000
     assert b._interval > 0  # b 会在 acquire 时撞上这个闸门
+
+
+@respx.mock
+async def test_stale_rss_batch_is_not_cached(cache_redis):
+    """**陈旧批次不进缓存**——这是每 15 分钟轮询能生效的前提。
+
+    RSS 缓存 3 小时。上午探到旧批次一旦被缓存住，接下来三小时的每一次探测都会拿到
+    同一份，轮询就白做了：当天批次出来了也发现不了。
+    """
+    import datetime as _dt
+
+    yesterday = _dt.datetime.now(_dt.UTC).date() - _dt.timedelta(days=1)
+    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
+        return_value=httpx.Response(200, text=_rss_with_batch_date(yesterday))
+    )
+    client = ArxivClient(redis=cache_redis, min_interval=0)
+
+    await client.fetch_new("cs.CL")
+    await client.fetch_new("cs.CL")
+    assert route.call_count == 2, "旧批次被缓存住的话，轮询永远发现不了当天那批"
+    await client.aclose()

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -535,3 +535,57 @@ async def test_index_status_readable_for_a_daily_feed_paper(client):
     body = resp.json()
     assert "paper_vector" in body and "chunk_vector" in body
     assert body["paper_vector"]["built"] is False  # 刚入池，还没建向量
+
+
+async def test_collecting_libraries_lists_only_admitted_and_visible(client):
+    """列出收录了这篇论文的文献库：只算真正进了库的状态，且只列可见的库。
+
+    candidate 是还没打分、excluded 是打分没过，两者都不算「收录」——混进来会让人
+    以为库里有这篇。个人库不能经这个接口泄漏给别人。
+    """
+    from app.models.library_direction import DirectionLibrary, LibraryPaper
+    from app.models.paper import new_paper
+    from app.models.user import User
+    from sqlalchemy import select as _select
+
+    owner_token = await register_and_login(client, email="collect-owner@example.com")
+    owner = {"Authorization": f"Bearer {owner_token}"}
+    project_id, _ = await make_project_with_library(client, owner, name="收录来源")
+
+    async with get_sessionmaker()() as session:
+        paper = new_paper(source="arxiv", arxiv_id="2607.77001", title="Collected", abstract="x")
+        session.add(paper)
+        await session.flush()
+        me = (await session.execute(_select(User).where(User.email == "collect-owner@example.com"))).scalar_one()
+        libs = {}
+        for name, status, is_public, score in (
+            ("已收录公共库", "compiled", True, 0.91),
+            ("还没打分", "candidate", True, None),
+            ("打分没过", "excluded", True, 0.2),
+            ("别人的个人库", "scored", False, 0.85),
+        ):
+            lib = DirectionLibrary(
+                name=name, status="active", is_public=is_public, submitted_by=me.id
+            )
+            session.add(lib)
+            await session.flush()
+            session.add(
+                LibraryPaper(
+                    library_id=lib.id, paper_id=paper.id, status=status, relevance_score=score
+                )
+            )
+            libs[name] = lib.id
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.get(f"/api/papers/{paper_id}/libraries", headers=owner)
+    assert resp.status_code == 200, resp.text
+    names = [r["name"] for r in resp.json()]
+    assert "已收录公共库" in names
+    assert "还没打分" not in names and "打分没过" not in names
+    assert resp.json()[0]["relevance_score"] == pytest.approx(0.91)
+
+    # 别人看不到那个个人库
+    other = {"Authorization": f"Bearer {await register_and_login(client, email='c2@e.com')}"}
+    resp = await client.get(f"/api/papers/{paper_id}/libraries", headers=other)
+    assert "别人的个人库" not in [r["name"] for r in resp.json()]

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -259,3 +259,40 @@ async def test_add_mutual_exclusion_422(client):
         headers={"Authorization": f"Bearer {other}"},
     )
     assert resp.status_code == 404
+
+
+async def test_resolve_by_arxiv_id_fills_in_the_title(client, monkeypatch):
+    """锚点论文只填 arXiv id，题目由系统补上。
+
+    路由必须排在 /papers/{paper_id} **之前**，否则 "resolve" 会被当成 paper_id
+    去解析 UUID，直接 422——这条断言就是在守那个顺序。
+    """
+    from app.services import paper_import
+
+    async def _fake(arxiv_id=None, doi=None, bibtex=None):
+        return {"arxiv_id": "2005.11401", "title": "Retrieval-Augmented Generation",
+                "year": 2020, "authors": [{"name": "Lewis"}, {"name": "Perez"}]}
+
+    monkeypatch.setattr(paper_import, "resolve_fields", _fake)
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+
+    resp = await client.get("/api/papers/resolve", params={"arxiv_id": "2005.11401"}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["title"] == "Retrieval-Augmented Generation"
+    assert body["arxiv_id"] == "2005.11401"
+    assert body["authors"] == ["Lewis", "Perez"]
+
+
+async def test_resolve_unknown_arxiv_id_is_422(client, monkeypatch):
+    """解析不出时给 422，前端保留 id、题目留空即可，不该 500。"""
+    from app.services import paper_import
+
+    async def _fail(arxiv_id=None, doi=None, bibtex=None):
+        raise paper_import.ParseFailedError("nope")
+
+    monkeypatch.setattr(paper_import, "resolve_fields", _fail)
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    resp = await client.get("/api/papers/resolve", params={"arxiv_id": "9999.99999"}, headers=headers)
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "ARXIV_ID_NOT_RESOLVED"

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -254,6 +254,13 @@ async def _setup_project(client):
     return project_id, headers
 
 
+def _today():
+    """每日池条目一律用今天：库同步默认只看「上次同步以来」的窗口。"""
+    import datetime as _dt
+
+    return _dt.datetime.now(_dt.UTC).date()
+
+
 def _make_engine() -> tuple[VoyageEngine, RecordingBus]:
     bus = RecordingBus()
     return VoyageEngine(event_bus=bus, llm_router=LLMRouter()), bus
@@ -583,20 +590,21 @@ async def test_incremental_pulls_from_daily_feed_without_arxiv(client, queue_stu
                 title=title,
                 abstract="research agents and planning",
                 year=2026,
-                published_at=dt.datetime(2026, 7, 20, tzinfo=dt.UTC),
+                published_at=dt.datetime.now(dt.UTC),
             )
             session.add(paper)
             await session.flush()
             feed_ids.append(paper.id)
+            # 用今天：库同步默认只看「上次同步以来」的窗口，固定的过去日期会被筛掉
             session.add(
                 DailyFeedEntry(
-                    paper_id=paper.id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+                    paper_id=paper.id, feed_date=_today(), primary_category="cs.AI"
                 )
             )
         # 已在库的论文也进池：必须被去重挡住，不能重复送打分
         session.add(
             DailyFeedEntry(
-                paper_id=existing_id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+                paper_id=existing_id, feed_date=_today(), primary_category="cs.AI"
             )
         )
         await session.commit()
@@ -731,7 +739,8 @@ def test_unlimited_knobs_and_budget_semantics():
 
     # 预算：unlimited → max_tokens=None；默认模式派生公式不变
     assert ingest_service.derive_budget(knobs) == {"max_tokens": None}
-    assert ingest_service.derive_budget(IngestKnobs()) == {"max_tokens": 50 * 20_000}
+    # 预算按「最大检索篇数」派生（上限而非开销；真正花钱的是编译那部分）
+    assert ingest_service.derive_budget(IngestKnobs()) == {"max_tokens": 150 * 20_000}
 
     # 引擎语义：max_tokens 为 None（falsy）不触发预算暂停，用量再大也不算超限
     run = VoyageRun(
@@ -1423,13 +1432,13 @@ async def test_exclude_terms_filter_the_daily_feed_sync(client, queue_stub, wiki
                 title=title,
                 abstract="research",
                 year=2026,
-                published_at=dt.datetime(2026, 7, 20, tzinfo=dt.UTC),
+                published_at=dt.datetime.now(dt.UTC),
             )
             session.add(paper)
             await session.flush()
             session.add(
                 DailyFeedEntry(
-                    paper_id=paper.id, feed_date=dt.date(2026, 7, 20), primary_category="cs.AI"
+                    paper_id=paper.id, feed_date=_today(), primary_category="cs.AI"
                 )
             )
         await session.commit()
@@ -1461,3 +1470,134 @@ async def test_exclude_terms_filter_the_daily_feed_sync(client, queue_stub, wiki
             .all()
         )
     assert "Speech Recognition at Scale" not in titles
+
+
+async def test_sync_scope_defaults_to_today_only(client, queue_stub, wiki_mocks):
+    """库同步默认只扫当天新入池的论文；管理员可切到扫全池。
+
+    同步由每日抓取跑完后触发，新论文本就只有那一批。扫全池的代价是重复排序几千篇
+    早就处理过的；它的价值在自愈——上次失败落下的还能补回来，所以留作可选。
+    """
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+    from app.services import daily_feed
+
+    token = await register_and_login(client, email="scope@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("scope@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-范围")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "search", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    today = dt.datetime.now(dt.UTC).date()
+    async with get_sessionmaker()() as session:
+        for i, day in enumerate((today, today - dt.timedelta(days=3))):
+            paper = new_paper(
+                source="arxiv", arxiv_id=f"2607.8100{i}", title=f"Feed {i}", abstract="research"
+            )
+            session.add(paper)
+            await session.flush()
+            session.add(
+                DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI")
+            )
+        await session.commit()
+
+    async def run_sync() -> dict:
+        r = await client.post(
+            f"/api/libraries/{library_id}/ingest/run",
+            json={"mode": "incremental", "knobs": KNOBS},
+            headers=headers,
+        )
+        eng, _ = _make_engine()
+        await eng.run(uuid.UUID(r.json()["id"]))
+        detail = (await client.get(f"/api/voyages/{r.json()['id']}", headers=headers)).json()
+        return detail["steps"][0]["observation"]
+
+    # 默认 since_last：上次同步是刚才那次建库，所以窗口从今天起 → 只看当天那条
+    obs = await run_sync()
+    assert obs["feed_scope"] == "since_last"
+    assert obs["feed_total"] == 1
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_scope(session, "daily")
+    obs = await run_sync()
+    assert obs["feed_scope"] == "daily"
+    assert obs["feed_total"] == 1, "只看当天那条"
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_scope(session, "full")
+    obs = await run_sync()
+    assert obs["feed_scope"] == "full"
+    assert obs["feed_total"] == 2, "切到 full 后旧的那条也进扫描范围"
+
+
+async def test_since_last_scope_widens_after_a_missed_sync(client, queue_stub, wiki_mocks):
+    """since_last 的价值:漏了几天会自动把那几天补扫回来。
+
+    daily 模式下漏掉就永久错过(arXiv 不会再给第二次)；full 模式每次重复排序几千篇。
+    since_last 正常时和 daily 一样省，出事时和 full 一样能自愈。
+    """
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+    from app.services import daily_feed
+
+    token = await register_and_login(client, email="sincelast@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("sincelast@example.com")
+    library_id = await _create_standalone_library(client, headers, name="独立库-自愈")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "search", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    today = dt.datetime.now(dt.UTC).date()
+    async with get_sessionmaker()() as session:
+        for i, day in enumerate((today, today - dt.timedelta(days=2))):
+            paper = new_paper(
+                source="arxiv", arxiv_id=f"2607.8200{i}", title=f"Missed {i}", abstract="research"
+            )
+            session.add(paper)
+            await session.flush()
+            session.add(
+                DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI")
+            )
+        # 模拟「上次成功同步是 3 天前」——中间那两天漏了
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        state = dict(library.ingest_state or {})
+        state["last_run"] = {
+            "voyage_id": "x",
+            "finished_at": (
+                dt.datetime.now(dt.UTC) - dt.timedelta(days=3)
+            ).isoformat(),
+        }
+        library.ingest_state = state
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_scope(session, "since_last")
+
+    r = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "incremental", "knobs": KNOBS},
+        headers=headers,
+    )
+    eng, _ = _make_engine()
+    await eng.run(uuid.UUID(r.json()["id"]))
+    obs = (await client.get(f"/api/voyages/{r.json()['id']}", headers=headers)).json()["steps"][0][
+        "observation"
+    ]
+    assert obs["feed_scope"] == "since_last"
+    assert obs["feed_since"] == (today - dt.timedelta(days=3)).isoformat()
+    assert obs["feed_total"] == 2, "漏掉那两天的论文被补扫回来"

--- a/src/frontend/src/components/ui/CollectingLibraries.tsx
+++ b/src/frontend/src/components/ui/CollectingLibraries.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api, type CollectingLibrary } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { Icon } from './Icon';
+import { Modal } from './Modal';
+
+/* ============================================================
+   「被哪些文献库收录」：行内只显示前两个 + 计数，点开看完整列表与相关度。
+
+   行内不铺开是有原因的：一篇热门论文可能同时进十几个库，全列出来会把详情页顶部
+   挤没。相关度分也只在弹窗里给——它是每个库各自打的分，并排堆在一行里没法读。
+   ============================================================ */
+
+function scoreText(v: number | null): string {
+  return v === null ? tr('未打分', 'not scored') : v.toFixed(2);
+}
+
+export function CollectingLibraries({ paperId }: { paperId: string }) {
+  const [open, setOpen] = useState(false);
+  const { data } = useQuery({
+    queryKey: ['paper-libraries', paperId],
+    queryFn: () => api.getCollectingLibraries(paperId),
+    retry: false,
+  });
+
+  const libs: CollectingLibrary[] = data ?? [];
+  if (libs.length === 0) return null;
+
+  const shown = libs.slice(0, 2);
+  const rest = libs.length - shown.length;
+
+  return (
+    <>
+      <span className="row gap6 wrap" style={{ alignItems: 'center' }}>
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+          {tr('已收录', 'In')}
+        </span>
+        {shown.map((l) => (
+          <span
+            key={l.library_id}
+            className="pill sm"
+            style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}
+            title={tr(`相关度 ${scoreText(l.relevance_score)}`, `relevance ${scoreText(l.relevance_score)}`)}
+          >
+            {l.name}
+          </span>
+        ))}
+        <button
+          type="button"
+          className="btn btn-ghost sm"
+          style={{ padding: '0 6px', height: 22, fontSize: 11 }}
+          onClick={() => setOpen(true)}
+        >
+          {rest > 0 ? tr(`还有 ${rest} 个`, `+${rest} more`) : tr('详情', 'Details')}
+        </button>
+      </span>
+
+      {open && (
+        <Modal
+          open
+          title={tr(`收录了这篇论文的文献库（${libs.length}）`, `Libraries holding this paper (${libs.length})`)}
+          onClose={() => setOpen(false)}
+        >
+          <div className="col gap8" style={{ minWidth: 320 }}>
+            {libs.map((l) => (
+              <div
+                key={l.library_id}
+                className="row"
+                style={{ justifyContent: 'space-between', alignItems: 'center', gap: 12 }}
+              >
+                <span className="row gap6" style={{ minWidth: 0 }}>
+                  <Icon name="layers" size={12} style={{ color: 'var(--text-3)' }} />
+                  <span className="ellipsis" style={{ fontSize: 13 }}>{l.name}</span>
+                  {!l.is_public && (
+                    <span className="pill sm" style={{ background: 'var(--surface-3)', fontSize: 10 }}>
+                      {tr('个人', 'personal')}
+                    </span>
+                  )}
+                </span>
+                <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                  {tr('相关度', 'relevance')} {scoreText(l.relevance_score)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -15,6 +15,7 @@ import { citationExportItems, ExportDropdown } from '../../components/ui/ExportD
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
+import { CollectingLibraries } from '../../components/ui/CollectingLibraries';
 import {
   ApiError,
   api,
@@ -290,6 +291,7 @@ function DailyDetailPane({
         {/* 向量索引状态跟着徽章走：这一行是「这篇论文是什么」的速览，索引建没建属于
             同一类信息。不带重建按钮——那一行不是操作区。 */}
         <PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />
+        <CollectingLibraries paperId={paper.paper_id} />
         {paper.arxiv_id &&
           (arxivHref ? (
             <a
@@ -431,14 +433,11 @@ function DailyDetailPane({
         </MetaItem>
       </MetaFold>
 
+      {/* 摘要默认折叠，复用元信息那套折叠块的样式，两者视觉一致 */}
       {paper.abstract ? (
-        <div className="card card-pad" style={{ background: 'var(--surface-2)', marginTop: 18 }}>
-          <div className="row gap8" style={{ marginBottom: 8 }}>
-            <Icon name="file" size={14} style={{ color: 'var(--accent)' }} />
-            <span style={{ fontSize: 12, fontWeight: 700 }}>{tr('摘要', 'Abstract')}</span>
-          </div>
+        <MetaFold label={tr('摘要', 'Abstract')}>
           <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
-        </div>
+        </MetaFold>
       ) : (
         <div className="empty" style={{ padding: 20, marginTop: 18 }}>
           {tr('这篇还没有摘要。', 'No abstract for this paper.')}
@@ -739,10 +738,14 @@ export function DailyPage() {
   const fallbackNotice = semantic && listQuery.data?.mode_used === 'keyword';
 
   // 首条自动选中
+  // 默认选中列表第一篇，**并在列表变了之后跟着走**。
+  // 原来只在 selectedId 为空时设一次：日期默认落到最新一天是异步的，列表先以「全部
+  // 7 天」返回，选中项就锁在了那一版的第一条——于是打开页面看到的是两天前那篇。
   const firstId = items[0]?.entry_id ?? null;
+  const selectedInList = !!selectedId && items.some((p) => p.entry_id === selectedId);
   useEffect(() => {
-    if (!selectedId && firstId) setSelectedId(firstId);
-  }, [selectedId, firstId]);
+    if (firstId && !selectedInList) setSelectedId(firstId);
+  }, [firstId, selectedInList]);
 
   const toggleSelected = (paperId: string) =>
     setSelected((prev) => {

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -343,7 +343,6 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
           name={name}
           statement={statement}
           showRubric
-          showAnchors
         />
       </div>
     </Modal>

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -436,7 +436,6 @@ function InclusionSettingsCard({ lib, readOnly }: { lib: DirectionLibraryDetail;
         name={lib.name}
         statement={lib.statement ?? ''}
         showRubric
-        showAnchors
         readOnly={readOnly}
       />
     </section>

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -12,6 +12,7 @@ import { fmtTime } from '../../lib/format';
 import {
   api,
   ApiError,
+  type AnchorPaper,
   type IngestStart,
   type IngestState,
   type IngestTimeRange,
@@ -97,6 +98,97 @@ function KnobRange({
   );
 }
 
+/** 锚点论文编辑器：只填 arXiv id，题目由系统补上。
+ *
+ * 从「收录设置」搬到这里——锚点是给「从锚点论文扩展」用的输入，放在收录设置里
+ * 与检索/打分的配置混在一起，用户找不到它跟哪个动作有关。 */
+function AnchorEditor({
+  libraryId,
+  anchors,
+  onChange,
+  disabled,
+}: {
+  libraryId?: string;
+  anchors: AnchorPaper[];
+  onChange: (next: AnchorPaper[]) => void;
+  disabled?: boolean;
+}) {
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function add() {
+    const id = draft.trim();
+    if (!id) return;
+    if (anchors.some((a) => (a.arxiv_id || '').trim() === id)) {
+      toast(tr('这篇已经在列表里了', 'Already in the list'), 'info');
+      return;
+    }
+    setBusy(true);
+    try {
+      // 题目自动补：解析不出也照样加进去（id 是有效输入，题目只是给人看的确认）
+      let title = '';
+      try {
+        title = (await api.resolvePaperByArxivId(id)).title;
+      } catch {
+        toast(tr('没解析出题目，已按 id 添加', 'Could not resolve the title — added by id'), 'info');
+      }
+      onChange([...anchors, { arxiv_id: id, title }]);
+      setDraft('');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="col gap8">
+      {anchors.length > 0 && (
+        <div className="col gap6">
+          {anchors.map((a, i) => (
+            <div key={`${a.arxiv_id}-${i}`} className="row gap8" style={{ alignItems: 'center' }}>
+              <span className="pill sm mono" style={{ background: 'var(--surface-3)' }}>
+                {a.arxiv_id}
+              </span>
+              <span style={{ fontSize: 12.5, flex: 1, minWidth: 0 }} className="ellipsis">
+                {a.title || <span className="muted">{tr('（题目未解析）', '(title unresolved)')}</span>}
+              </span>
+              {!disabled && (
+                <button
+                  type="button"
+                  className="btn btn-ghost sm"
+                  onClick={() => onChange(anchors.filter((_, j) => j !== i))}
+                >
+                  <Icon name="x" size={11} />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {!disabled && (
+        <div className="row gap8">
+          <input
+            className="input"
+            style={{ flex: 1 }}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void add(); } }}
+            placeholder={tr('填 arXiv id，如 2005.11401', 'arXiv id, e.g. 2005.11401')}
+          />
+          <button type="button" className="btn btn-soft sm" disabled={busy || !draft.trim()} onClick={() => void add()}>
+            {busy ? tr('解析中…', 'Resolving…') : tr('添加', 'Add')}
+          </button>
+        </div>
+      )}
+      {libraryId && anchors.length === 0 && (
+        <div className="muted" style={{ fontSize: 11.5 }}>
+          {tr('还没有锚点论文。填几篇这个方向的代表作，扩展会从它们的引用与参考文献往外走。',
+              'No anchor papers yet. Add a few representative works — the expansion walks outward from their citations and references.')}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onGoGovern, readOnly = false }: IngestTabProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -114,18 +206,29 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
     enabled: !!libraryId && !readOnly,
     retry: false,
   });
-  const anchorCount = libDef?.definition?.anchor_papers?.length ?? 0;
+  // 锚点论文：从库定义读，改完就存回（这里是它唯一的编辑入口，收录设置里已移除）
+  const anchors = libDef?.definition?.anchor_papers ?? [];
+  const anchorCount = anchors.length;
+  const saveAnchors = useMutation({
+    mutationFn: (next: AnchorPaper[]) =>
+      api.updateLibrary(libraryId as string, { anchors: next }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['library', libraryId] });
+    },
+    onError: (e) =>
+      toast(`${tr('保存锚点失败', 'Failed to save anchors')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
   const noKeywords = libraryId
     ? !!libDef && (libDef.definition?.keywords?.include?.length ?? 0) === 0
     : !!project;
 
   // —— 成本旋钮（bootstrap） ——
-  const [maxPapers, setMaxPapers] = useState(50);
-  const [threshold, setThreshold] = useState(0.6);
+  const [maxPapers, setMaxPapers] = useState(150);
+  const [threshold, setThreshold] = useState(0.8);
   const [hops, setHops] = useState<'1' | '2' | '3'>('1');
   const [queryTerms, setQueryTerms] = useState('');
   const [timeRange, setTimeRange] = useState<IngestTimeRange>('6m');
-  const [compileTopN, setCompileTopN] = useState(20);
+  const [compileTopN, setCompileTopN] = useState(50);
   // 最大化模式：不限检索/编译篇数（仅 bootstrap 表单，增量同步不受影响）
   const [unlimited, setUnlimited] = useState(false);
 
@@ -408,6 +511,17 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
               onChange={setTimeRange}
             />
           </FormField>
+          <KnobRange
+            label={tr('相关度阈值', 'Relevance threshold')}
+            en="relevance_threshold"
+            hint={tr('LLM 相关性打分低于该阈值的论文将被过滤。', 'Papers scoring below this relevance threshold are filtered out.')}
+            value={threshold}
+            min={0}
+            max={1}
+            step={0.05}
+            format={(v) => v.toFixed(2)}
+            onChange={setThreshold}
+          />
           <FormField label={tr('最大化（不限篇数）', 'Maximize (no paper cap)')} en="unlimited">
             <label className="row gap10" style={{ cursor: 'pointer', userSelect: 'none' }}>
               <input
@@ -444,27 +558,16 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             label={tr('最大检索篇数', 'Max papers')}
             en="max_papers"
             hint={tr(
-              '本次检索与参考文献扩展最多加入知识库的论文数。',
-              'Cap on papers added to the library from search plus reference expansion.',
+              '本次最多检索并打分的论文数。',
+              'How many papers this run retrieves and scores at most.',
             )}
             value={maxPapers}
             min={10}
-            max={300}
+            max={500}
             step={10}
             onChange={setMaxPapers}
             disabled={unlimited}
             disabledText={tr('无上限', 'No cap')}
-          />
-          <KnobRange
-            label={tr('相关度阈值', 'Relevance threshold')}
-            en="relevance_threshold"
-            hint={tr('LLM 相关性打分低于该阈值的论文将被过滤。', 'Papers scoring below this relevance threshold are filtered out.')}
-            value={threshold}
-            min={0}
-            max={1}
-            step={0.05}
-            format={(v) => v.toFixed(2)}
-            onChange={setThreshold}
           />
           <KnobRange
             label={tr('最大编译篇数', 'Max compiled papers')}
@@ -475,7 +578,7 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
             )}
             value={compileTopN}
             min={5}
-            max={100}
+            max={200}
             step={5}
             onChange={setCompileTopN}
             disabled={unlimited}
@@ -562,14 +665,21 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
               onChange={setHops}
             />
           </FormField>
-          {!anchorCount && (
-            <div style={{ fontSize: 11.5, color: 'var(--text-4)', margin: '4px 0 10px' }}>
-              {tr(
-                '这个文献库还没有锚点论文，先去收录设置添加几篇代表作。',
-                'This library has no anchor papers yet — add a few in inclusion settings first.',
-              )}
-            </div>
-          )}
+          <FormField
+            label={tr('锚点论文', 'Anchor papers')}
+            en="anchor_papers"
+            hint={tr(
+              '只需填 arXiv id，题目由系统自动补上。扩展从这些论文的引用与参考文献往外走。',
+              'Just the arXiv id — the title is filled in automatically. The expansion walks outward from these papers.',
+            )}
+          >
+            <AnchorEditor
+              libraryId={libraryId}
+              anchors={anchors}
+              onChange={(next) => saveAnchors.mutate(next)}
+              disabled={saveAnchors.isPending}
+            />
+          </FormField>
           <div className="row gap10" style={{ marginTop: 6 }}>
             <button
               className="btn btn-ghost"

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -132,8 +132,19 @@ export function MetaItem({ label, children }: { label: string; children: ReactNo
  * 元信息折叠块：论文详情四处面板（论文库 / 只读库 / 阅读页 / 个人库 / 相关研究）共用的
  * frontmatter 卡外壳。默认收起——这些字段查证时才看，别占着首屏。
  */
-export function MetaFold({ children, style }: { children: ReactNode; style?: CSSProperties }) {
-  const [open, setOpen] = useState(false);
+export function MetaFold({
+  children,
+  style,
+  label,
+  defaultOpen = false,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+  /** 折叠块标题，默认「元信息」。摘要等同类折叠块复用同一套样式，保持视觉一致。 */
+  label?: string;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <div
       className="card"
@@ -145,7 +156,7 @@ export function MetaFold({ children, style }: { children: ReactNode; style?: CSS
         style={{ padding: '9px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
       >
         <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', letterSpacing: '0.04em' }}>
-          {tr('元信息', 'Metadata')}
+          {label ?? tr('元信息', 'Metadata')}
         </span>
         <Icon
           name="chevDown"

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2666,6 +2666,23 @@ export interface IngestStart {
   time_range?: IngestTimeRange;
 }
 
+/** 按 arXiv id 解析出的论文元数据（锚点填表用，不入库）。 */
+export interface ResolvedPaper {
+  arxiv_id: string;
+  title: string;
+  year: number | null;
+  authors: string[];
+}
+
+/** 收录了某篇论文的文献库（带相关度分）。 */
+export interface CollectingLibrary {
+  library_id: string;
+  name: string;
+  is_public: boolean;
+  status: string;
+  relevance_score: number | null;
+}
+
 export const api = {
   /** fastapi-users JWT login — form-encoded username/password. Returns access token. */
   async login(email: string, password: string): Promise<string> {
@@ -4491,6 +4508,14 @@ export const api = {
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
   getDailySyncStatus(): Promise<DailySyncStatus> {
     return request<DailySyncStatus>('/daily/sync-status');
+  },
+  /** 按 arXiv id 取题目等元数据（只读 arXiv，不入库）。解析不出为 422。 */
+  /** 这篇论文被哪些文献库收录了（只列可见的库）。 */
+  getCollectingLibraries(paperId: string): Promise<CollectingLibrary[]> {
+    return request<CollectingLibrary[]>(`/papers/${paperId}/libraries`);
+  },
+  resolvePaperByArxivId(arxivId: string): Promise<ResolvedPaper> {
+    return request<ResolvedPaper>(`/papers/resolve?arxiv_id=${encodeURIComponent(arxivId)}`);
   },
   refreshDailyFeed(): Promise<{ status: string; voyage_id: string }> {
     return request<{ status: string; voyage_id: string }>('/daily/refresh', { method: 'POST' });


### PR DESCRIPTION
## Defaults

Relevance threshold **0.8**, retrieval cap **150**, compile cap **50**. The threshold slider moves above the maximize toggle.

The retrieval knob also **stops lying**: it was `min(200, max_papers * 3)`, so asking for 150 fetched 200 — tuning by the label's name tuned nothing. It is now the cap it claims to be.

Budget derives from `max_papers × 20k`, so the ceiling rises from 1M to 3M per run. That formula is now loose — most retrieved papers only cost one scoring call — but it is a ceiling, not a spend, so being generous is safe.

## Anchor papers move to where they are used

Out of the library's inclusion settings, into the **anchor-expansion card** — the only thing that reads them. Sitting among the search and scoring settings gave no hint of which action they fed.

Adding one now takes **just an arXiv id**; the title is filled in from a new read-only `GET /papers/resolve`.

Two details:
- That route must be registered **before** `/papers/{paper_id}`, or `"resolve"` is parsed as a paper id and 422s. A test pins the ordering.
- **Failing to resolve still adds the entry.** The id is the real input; the title is only there for a human to confirm they typed the right one.

## Daily pool retention: 14 days, admin-configurable

That window is also what library sync reads, so it is really *how many days a library can miss and still recover* — the admin copy says so, because shrinking it is not just a display change.

## Library sync no longer rescans the whole pool

Admin-configurable, three options, defaulting to **`since_last`** — from this library's last successful sync:

| scope | cost | if a run is missed |
|---|---|---|
| `since_last` (default) | normally just today's batch | widens to cover the gap |
| `daily` | cheapest | **lost permanently** — arXiv does not announce twice |
| `full` | re-ranks thousands each run | always recovers |

`since_last` is the third option you asked for after seeing that the first two forced a choice between cheap and self-healing. First sync has no previous run, so it falls back to the full window rather than starting out with a gap.

## Daily page

- **The detail pane showed a paper from two days ago.** It latched onto whatever was first in the initial "all 7 days" response and never followed the list afterwards — the day defaulting to the latest is asynchronous, so the list changes under it. It now re-selects whenever the current pick is not in the list, which covers first open, day switches and filter changes.
- **The abstract is collapsed by default**, reusing the metadata fold rather than a second fold styled to match — so they cannot drift apart later.
- **A paper shows which libraries admitted it**, two inline plus a count, with the full list and per-library relevance behind a dialog. A popular paper can sit in a dozen libraries, and the scores are per-library, so one row cannot carry them. Only admitted statuses count (`candidate` is unscored, `excluded` failed scoring — either would imply the library holds it), and personal libraries are filtered by visibility.

## Already parallel

`arq`'s `max_jobs` defaults to 10 and each library is enqueued separately, so library syncs already run concurrently. Nothing to change.

## Tests

Five existing tests failed for three distinct reasons, each fixed at the cause rather than the assertion:

- Feed entries seeded with a fixed past date fell outside the new `since_last` window → they now use today, since they test sourcing, not date windows.
- Cleanup tests hard-coded "8 days old" → they now derive from `DEFAULT_RETENTION_DAYS`, so changing retention again will not break them.
- The RSS caching test broke on a **real behaviour change**: stale batches are no longer cached, which is what makes the 15-minute polling work at all. Rather than relaxing the assertion, the fixture's batch date became settable, and **a new test pins "stale batches are not cached"** with the reason in its docstring.

New: the resolve endpoint and its route ordering, the 422 path, the three scan scopes, `since_last` widening after a missed sync, configurable retention driving cleanup, and the collecting-libraries endpoint's status and visibility filtering.

**878 passed**, `ruff` clean, `tsc --noEmit` and `vite build` exit 0.