### PR TITLE
fix(daily,voyages,llm): sort daily papers by date, add task actions, tolerate models that reject reasoning_effort

### DIFF
--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -146,6 +146,24 @@ async def cancel_voyage(
     return VoyageRead.model_validate(run)
 
 
+@router.delete("/{voyage_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_voyage(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """删除任务记录（仅限已结束的；还在跑的先取消）。
+
+    步骤与日志一并删除；**token 用量与实验记录只解引用不删**——删任务不该把花过的
+    钱从账上抹掉。
+    """
+    run = await _get_owned_voyage(session, voyage_id, user)
+    try:
+        await voyages_service.delete_voyage(session, run)
+    except voyages_service.VoyageStillRunningError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="VOYAGE_STILL_RUNNING") from e
+
+
 @router.post("/{voyage_id}/resume", response_model=VoyageRead)
 async def resume_voyage(
     voyage_id: uuid.UUID,

--- a/src/backend/app/core/llm/anthropic.py
+++ b/src/backend/app/core/llm/anthropic.py
@@ -90,7 +90,7 @@ class AnthropicProvider(LLMProvider):
                 messages, model, temperature, max_tokens, stream=False, images=images, effort=effort
             ),
         )
-        if effort is not None and resp.status_code == 400 and _rejects_effort(resp.text):
+        if effort is not None and resp.status_code >= 400 and _rejects_effort(resp.text):
             # 该模型不认这个档位：去掉参数重试一次，别让配错档位打断整个环节
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试", model, effort)
             resp = await self._client.post(

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -22,7 +22,9 @@ _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 # 部分中转强制流式：非流式请求返回 400 + 该提示，此时自动改走流式并聚合
 _FORCE_STREAM_MARKER = "stream must be set to true"
 # 模型/中转不认 reasoning_effort（非推理模型、老版中转、或该模型不支持所配档位）时的
-# 400 特征。命中即去掉该参数重试一次——配错档位不该让整个环节挂掉。
+# 错误特征。命中即去掉该参数重试一次——配错档位不该让整个环节挂掉。
+# LiteLLM 之类的中转会把 UnsupportedParamsError 包成 400 之外的状态码抛出来，
+# 所以这里只认错误内容、不认状态码；调用方已保证"本次确实发了该参数"。
 _EFFORT_REJECT_MARKERS = ("reasoning_effort", "reasoning.effort", "effort")
 
 
@@ -30,10 +32,8 @@ class _EffortUnsupported(RuntimeError):
     """服务端明确因 reasoning_effort 拒绝了请求；调用方去掉该参数重试。"""
 
 
-def _rejects_effort(status_code: int, body: str) -> bool:
-    """400 且错误信息提到 effort —— 仅在本次确实发了该参数时才做此判断。"""
-    if status_code != 400:
-        return False
+def _rejects_effort(body: str) -> bool:
+    """错误信息提到 effort —— 仅在本次确实发了该参数时才做此判断。"""
     low = body.lower()
     return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
 
@@ -61,6 +61,14 @@ class OpenAICompatProvider(LLMProvider):
                 last_exc = e
                 await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2**attempt))
                 continue
+            if (
+                resp.status_code in _RETRYABLE_STATUS
+                and payload.get("reasoning_effort") is not None
+                and _rejects_effort(resp.text)
+            ):
+                # 中转把「不支持该参数」包成了 5xx：这不是临时故障，重试多少次都一样，
+                # 直接交回上层去掉参数重试，别白烧几十秒退避。
+                return resp
             if resp.status_code in _RETRYABLE_STATUS and attempt < _MAX_ATTEMPTS - 1:
                 delay = _retry_delay(resp, attempt)
                 logger.warning(
@@ -87,6 +95,9 @@ class OpenAICompatProvider(LLMProvider):
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._client = client or httpx.AsyncClient(timeout=timeout)
+        # 已确认不吃 reasoning_effort 的 model（本进程内记忆）。provider 实例被
+        # LLMRouter 缓存复用，所以每个模型只需要付一次"失败再重试"的往返代价。
+        self._effort_unsupported: set[str] = set()
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}"}
@@ -124,7 +135,8 @@ class OpenAICompatProvider(LLMProvider):
         }
         if temperature is not None:  # 新款 Claude 等模型已弃用该参数，None 则不发送
             payload["temperature"] = temperature
-        if effort is not None:  # 推理模型的思考深度；非推理模型/中转不认时不要发
+        if effort is not None and model not in self._effort_unsupported:
+            # 推理模型的思考深度；非推理模型/中转不认时不要发
             payload["reasoning_effort"] = effort
         # Anthropic 系模型（经 LiteLLM 等代理）强制要求 max_tokens，缺省给足额度
         payload["max_tokens"] = max_tokens if max_tokens is not None else 8192
@@ -146,6 +158,7 @@ class OpenAICompatProvider(LLMProvider):
             )
         except _EffortUnsupported as e:
             # 该模型不吃这个档位：去掉参数重试一次，别让配错档位打断整个环节
+            self._effort_unsupported.add(model)
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
             return await self._complete_once(messages, model, temperature, max_tokens, images, None)
 
@@ -164,7 +177,7 @@ class OpenAICompatProvider(LLMProvider):
         resp = await self._post_with_retry(f"{self._base_url}/chat/completions", payload)
         if resp.status_code >= 400:
             body = resp.text[:500]
-            if effort is not None and _rejects_effort(resp.status_code, body):
+            if effort is not None and _rejects_effort(body):
                 raise _EffortUnsupported(body)
             if resp.status_code == 400 and _FORCE_STREAM_MARKER in body.lower():
                 # 强制流式的中转：自动改用流式请求并聚合成非流式结果
@@ -196,9 +209,7 @@ class OpenAICompatProvider(LLMProvider):
             if resp.status_code >= 400:
                 # 流式响应体要显式读出来才能看到错误内容
                 body = (await resp.aread()).decode(errors="replace")[:500]
-                if payload.get("reasoning_effort") is not None and _rejects_effort(
-                    resp.status_code, body
-                ):
+                if payload.get("reasoning_effort") is not None and _rejects_effort(body):
                     raise _EffortUnsupported(body)
                 resp.raise_for_status()
             async for line in resp.aiter_lines():
@@ -261,6 +272,7 @@ class OpenAICompatProvider(LLMProvider):
             # effort 是在首个 token 之前被拒的，重试不会重复输出；真吐过内容就不冒这个险
             if emitted:
                 raise
+            self._effort_unsupported.add(model)
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
             payload.pop("reasoning_effort", None)
             async for data in self._stream_chunks(payload):

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -160,6 +160,25 @@ async def get_voyage(
     return run if await can_view_voyage(session, run=run, user=user) else None
 
 
+class VoyageStillRunningError(Exception):
+    """任务还没结束，不能删——先取消。"""
+
+
+async def delete_voyage(session: AsyncSession, run: VoyageRun) -> None:
+    """删除任务记录。只允许删**已结束**的。
+
+    还在跑的不能删：worker 那边仍在按这个 id 执行，行没了会一路报错到不知所云的地方。
+    要删先取消（cancel 是协作式的，引擎在下一步边界自行退出）。
+
+    级联是有意设计的：步骤与日志随任务删掉，而 **token 用量与实验记录只解引用**
+    （SET NULL）——删掉一个任务不该把它花过的钱从账上抹掉。
+    """
+    if run.status not in TERMINAL_STATUSES:
+        raise VoyageStillRunningError(str(run.id))
+    await session.delete(run)
+    await session.commit()
+
+
 async def cancel_voyage(session: AsyncSession, run: VoyageRun) -> VoyageRun:
     """协作式取消：置 cancelled，运行中的引擎在下一步边界自行退出。"""
     if run.status in TERMINAL_STATUSES:

--- a/src/backend/tests/test_openai_compat.py
+++ b/src/backend/tests/test_openai_compat.py
@@ -226,6 +226,49 @@ async def test_effort_rejected_falls_back_without_it():
 
 
 @respx.mock
+async def test_litellm_unsupported_params_falls_back_regardless_of_status():
+    """LiteLLM 把 UnsupportedParamsError 包成非 400 抛出时，仍要认出是 effort 的问题。
+
+    现网实例（qwen 系走 LiteLLM 中转）报的就是这一条：判据若卡在 400 上，
+    整个环节直接挂掉。所以只认错误内容、不认状态码。
+    """
+    body = {
+        "error": {
+            "message": (
+                "litellm.UnsupportedParamsError: openai does not support parameters: "
+                "['reasoning_effort'], for model=qwen36-35b-a3b-4. To drop these, set "
+                "`litellm.drop_params=True`. Received Model Group=qwen36-35b-a3b"
+            )
+        }
+    }
+    route = respx.post(CHAT_URL).mock(
+        side_effect=[httpx.Response(500, json=body), httpx.Response(200, json=NON_STREAM_OK)]
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    result = await provider.complete(
+        [Message(role="user", content="hi")], model="qwen36-35b-a3b", effort="high"
+    )
+    assert result.content == "ok"
+    assert "reasoning_effort" not in json.loads(route.calls[-1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_effort_unsupported_is_remembered_per_model():
+    """同一 model 只付一次「先失败再重试」的往返，后续请求直接不带该参数。"""
+    reject = httpx.Response(400, json={"error": {"message": "unsupported reasoning_effort"}})
+    ok = httpx.Response(200, json=NON_STREAM_OK)
+    route = respx.post(CHAT_URL).mock(side_effect=[reject, ok, ok])
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+    args = ([Message(role="user", content="hi")],)
+    await provider.complete(*args, model="qwen36-35b-a3b", effort="high")
+    await provider.complete(*args, model="qwen36-35b-a3b", effort="high")
+    assert route.call_count == 3  # 首次 2 次（含重试），第二次只 1 次
+    assert "reasoning_effort" not in json.loads(route.calls[-1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
 async def test_unrelated_400_is_not_swallowed_as_effort_problem():
     """与 effort 无关的 400 照常抛错，不能被降级逻辑吞掉。"""
     route = respx.post(CHAT_URL).mock(

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -469,3 +469,64 @@ async def test_new_ingest_voyage_carries_no_project(client):
         )
         assert run.project_id is None
         assert run.library_id == uuid.UUID(lib_id)
+
+
+async def test_delete_voyage_only_when_finished(client):
+    """删除只允许删已结束的任务；还在跑的先取消。
+
+    还在跑就删的话，worker 那边仍在按这个 id 执行，行没了会一路报错到不知所云的地方。
+    """
+    from app.core.db import get_sessionmaker
+    from app.models.voyage import VoyageRun
+
+    token = await register_and_login(client, email="del@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    me = (await client.get("/api/users/me", headers=headers)).json()
+
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(kind="wiki_ingest", status="executing", goal="跑着的",
+                        created_by=uuid.UUID(me["id"]))
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    resp = await client.delete(f"/api/voyages/{run_id}", headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "VOYAGE_STILL_RUNNING"
+
+    # 取消后可删
+    assert (await client.post(f"/api/voyages/{run_id}/cancel", headers=headers)).status_code == 200
+    assert (await client.delete(f"/api/voyages/{run_id}", headers=headers)).status_code == 204
+    async with get_sessionmaker()() as session:
+        assert await session.get(VoyageRun, run_id) is None
+
+
+async def test_delete_voyage_keeps_token_accounting(client):
+    """删任务不该把它花过的 token 从账上抹掉——用量行只解引用，不删。"""
+    from app.core.db import get_sessionmaker
+    from app.models.llm_config import LLMUsage
+    from app.models.voyage import VoyageRun
+    from sqlalchemy import select as _select
+
+    token = await register_and_login(client, email="del2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    me = (await client.get("/api/users/me", headers=headers)).json()
+
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(kind="wiki_ingest", status="done", goal="跑完的",
+                        created_by=uuid.UUID(me["id"]))
+        session.add(run)
+        await session.flush()
+        session.add(
+            LLMUsage(
+                stage="relevance", model="fake-default",
+                prompt_tokens=100, completion_tokens=20, voyage_id=run.id,
+            )
+        )
+        await session.commit()
+        run_id = run.id
+
+    assert (await client.delete(f"/api/voyages/{run_id}", headers=headers)).status_code == 204
+    async with get_sessionmaker()() as session:
+        usage = (await session.execute(_select(LLMUsage).where(LLMUsage.model == "fake-default"))).scalars().all()
+    assert len(usage) == 1 and usage[0].voyage_id is None, "用量行必须留下，只解引用"

--- a/src/frontend/src/components/ui/VoyageActions.tsx
+++ b/src/frontend/src/components/ui/VoyageActions.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { ConfirmModal } from './ConfirmModal';
+import { Icon } from './Icon';
+import { toast } from './Toast';
+
+/* ============================================================
+   任务的三个动作，按状态给：
+
+   - 还在跑 → 取消（协作式：引擎在下一步边界退出）
+   - 因错误暂停 → 续跑（从断点继续，已完成的步骤不重跑）
+   - 已结束 → 删除
+
+   删除只对已结束的开放：还在跑就删的话，worker 那边仍在按这个 id 执行，行没了会
+   一路报到不知所云的地方。要删先取消。
+   ============================================================ */
+
+export function VoyageActions({
+  voyage,
+  onDone,
+  compact,
+  showResume = true,
+}: {
+  voyage: VoyageRead;
+  /** 删除成功后的回调（详情页用来跳回列表）。 */
+  onDone?: () => void;
+  /** 列表行里用：只出图标，不占宽度。 */
+  compact?: boolean;
+  /** 详情页把「续跑」放在报错说明旁边（那里更好理解），这里就别再出一个。 */
+  showResume?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const finished = VOYAGE_TERMINAL.has(voyage.status);
+  const canResume = showResume && voyage.status === 'paused_error';
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['voyages'] });
+    void queryClient.invalidateQueries({ queryKey: ['voyage', voyage.id] });
+  };
+
+  const cancel = useMutation({
+    mutationFn: () => api.cancelVoyage(voyage.id),
+    onSuccess: () => { toast(tr('任务已取消', 'Task cancelled'), 'ok'); invalidate(); },
+    onError: (e) => toast(`${tr('取消失败', 'Cancel failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+  const resume = useMutation({
+    mutationFn: () => api.resumeVoyage(voyage.id),
+    onSuccess: () => {
+      toast(tr('已从断点继续，已完成的步骤不会重跑', 'Resumed from the last checkpoint — finished steps will not rerun'), 'ok');
+      invalidate();
+    },
+    onError: (e) => toast(`${tr('续跑失败', 'Resume failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+  const remove = useMutation({
+    mutationFn: () => api.deleteVoyage(voyage.id),
+    onSuccess: () => { toast(tr('任务已删除', 'Task deleted'), 'ok'); invalidate(); onDone?.(); },
+    onError: (e) => toast(`${tr('删除失败', 'Delete failed')}：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const busy = cancel.isPending || resume.isPending || remove.isPending;
+  const size = compact ? 12 : 13;
+  const cls = compact ? 'btn btn-ghost sm' : 'btn btn-ghost';
+
+  return (
+    <span className="row gap6" onClick={(e) => e.stopPropagation()}>
+      {canResume && (
+        <button type="button" className={cls} disabled={busy} onClick={() => resume.mutate()}
+                title={tr('从断点继续，已完成的步骤不会重跑', 'Resume from the checkpoint — finished steps will not rerun')}>
+          <Icon name="play" size={size} />
+          {!compact && tr('续跑', 'Resume')}
+        </button>
+      )}
+      {!finished && (
+        <button type="button" className={cls} disabled={busy} onClick={() => cancel.mutate()}
+                title={tr('取消任务', 'Cancel task')}>
+          <Icon name="x" size={size} />
+          {!compact && tr('取消', 'Cancel')}
+        </button>
+      )}
+      {finished && (
+        <button type="button" className={cls} disabled={busy} onClick={() => setConfirmDelete(true)}
+                title={tr('删除任务记录', 'Delete task record')}>
+          <Icon name="trash" size={size} />
+          {!compact && tr('删除', 'Delete')}
+        </button>
+      )}
+      <ConfirmModal
+        open={confirmDelete}
+        title={tr('删除这个任务？', 'Delete this task?')}
+        message={tr(
+          '步骤与日志会一并删除，无法撤销。它花过的 token 用量会留在账上，不受影响。',
+          'Its steps and logs go with it and cannot be recovered. The tokens it spent stay on the books.',
+        )}
+        confirmText={tr('删除', 'Delete')}
+        danger
+        onConfirm={() => { setConfirmDelete(false); remove.mutate(); }}
+        onClose={() => setConfirmDelete(false)}
+      />
+    </span>
+  );
+}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -58,7 +58,7 @@ import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
 import { PaperProgressModal } from '../library/PaperProgressModal';
 
 /* ============================================================
-   /daily — 每日新论文：arxiv 每日新提交（订阅分类内），保留最近 7 天。
+   /daily — 每日新论文：arxiv 每日新提交（订阅分类内）。保留期由管理员配置（默认 14 天）。
    双栏主从布局对齐共享库浏览（LibraryBrowse）：
    左栏按日期分组的列表（排序 / 搜索 / 分页 / 行内点赞），右栏选中论文详情。
    ============================================================ */
@@ -556,7 +556,9 @@ type AnnounceFilter = 'all' | 'new' | 'cross';
 const DEFAULT_ANNOUNCE: AnnounceFilter = 'new';
 
 // 列表固定按点赞排序（没有排序切换 UI）；语义检索时后端按相关度排，忽略这个值
-const DAILY_SORT: DailySort = 'likes';
+// 时间倒排：最新的在最前。按点赞排会让一篇被点过的旧论文压在当天新论文前面，
+// 而「每日新论文」这个页面的主线本来就是时间。
+const DAILY_SORT: DailySort = 'date';
 
 /** 每日池的同步状况。池子是所有文献库的唯一供给——抓取失败会让全实验室当天颗粒无收，
     所以状态要摆在页面上，而不是只躺在任务日志里等人去翻。 */
@@ -608,7 +610,7 @@ export function DailyPage() {
   // 语义检索开关（true=按意思检索，false=关键词字面匹配）
   const [semanticOn, setSemanticOn] = useState(false);
   const [page, setPage] = useState(1);
-  // —— 日期（null=全部 7 天，默认落在最新一天）留在工具栏；分类 / 类型收进高级检索面板 ——
+  // —— 日期（null=全部，默认就停在全部）留在工具栏；分类 / 类型收进高级检索面板 ——
   const [day, setDay] = useState<string | null>(null);
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
   const [advOpen, setAdvOpen] = useState(true);
@@ -638,6 +640,15 @@ export function DailyPage() {
 
   // 日期标签上的数字要跟着筛选走，否则选了某个分类之后标签仍显示全部篇数，
   // 看起来就像筛选根本没生效。
+  // 保留期是管理员可配的，界面上不能写死「7 天」
+  const retentionQuery = useQuery({
+    queryKey: ['daily-retention'],
+    queryFn: () => api.getDailyRetention(),
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+  const retentionDays = retentionQuery.data?.days ?? 14;
+
   const daysQuery = useQuery({
     queryKey: ['daily-days', announce, category],
     queryFn: () => api.listDailyDays({ announce: announce || undefined, category: category || undefined }),
@@ -651,17 +662,9 @@ export function DailyPage() {
   const latestDate = dates[dates.length - 1] ?? null;
 
   // 日期一改就算用户表过态，之后不再自动初始化
-  const didInitDay = useRef(false);
-  const pickDay = useCallback((d: string | null) => {
-    didInitDay.current = true;
-    setDay(d);
-  }, []);
-  // 默认只看当天：日期列表到手后落到最新一天（只做一次，不覆盖用户选择）
-  useEffect(() => {
-    if (didInitDay.current || !latestDate) return;
-    didInitDay.current = true;
-    setDay(latestDate);
-  }, [latestDate]);
+  const pickDay = useCallback((d: string | null) => setDay(d), []);
+  // 默认停在「全部」：跨天一起看、按时间倒排，最新的自然在最前。以前默认落到最新
+  // 一天，那一天恰好没有新公告（周末）时页面就是空的，看着像坏了。
 
   const dayIdx = day ? dates.indexOf(day) : -1;
   // 「全部」视为最新一天的后一位：← 从全部进入最新一天；→ 在最新一天回到全部
@@ -677,7 +680,7 @@ export function DailyPage() {
   };
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板；
-  // 日期放开到全部 7 天——只看当天的话，按作者/机构筛基本什么都剩不下
+  // 日期放开到全部——只看当天的话，按作者/机构筛基本什么都剩不下
   const applyAdvFilter = useCallback(
     (patch: { author?: string; affiliation?: string }) => {
       setSemanticOn(false);
@@ -740,7 +743,7 @@ export function DailyPage() {
   // 首条自动选中
   // 默认选中列表第一篇，**并在列表变了之后跟着走**。
   // 原来只在 selectedId 为空时设一次：日期默认落到最新一天是异步的，列表先以「全部
-  // 7 天」返回，选中项就锁在了那一版的第一条——于是打开页面看到的是两天前那篇。
+  // 全部」返回，选中项就锁在了那一版的第一条——于是打开页面看到的是两天前那篇。
   const firstId = items[0]?.entry_id ?? null;
   const selectedInList = !!selectedId && items.some((p) => p.entry_id === selectedId);
   useEffect(() => {
@@ -855,7 +858,7 @@ export function DailyPage() {
         className="card split-card"
       >
         {view === 'chat' ? (
-          /* ======== 池对话：就最近 7 天的每日新论文问答 ======== */
+          /* ======== 池对话：就保留期内的每日新论文问答 ======== */
           <DailyChatTab />
         ) : (
         <div className="split">
@@ -1009,12 +1012,14 @@ export function DailyPage() {
                   className={`chip${day !== null ? ' on' : ''}`}
                   title={
                     day !== null
-                      ? tr('点击看全部 7 天', 'Click to show all 7 days')
+                      ? tr(`点击看全部 ${retentionDays} 天`, `Click to show all ${retentionDays} days`)
                       : tr('点击只看最新一天', 'Click to show the latest day only')
                   }
                   onClick={() => pickDay(day === null ? latestDate : null)}
                 >
-                  {day !== null ? dayLabel(day, dayCount.get(day)) : tr('全部 7 天', 'All 7 days')}
+                  {day !== null
+                    ? dayLabel(day, dayCount.get(day))
+                    : tr(`全部 ${retentionDays} 天`, `All ${retentionDays} days`)}
                 </span>
                 <button
                   className="btn btn-ghost sm"

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
+import { VoyageActions } from '../../components/ui/VoyageActions';
 import { StatusPill } from '../../components/ui/StatusPill';
 import { Timeline, TimelineItem } from '../../components/ui/Timeline';
 import { toast } from '../../components/ui/Toast';
@@ -1554,16 +1555,6 @@ export function VoyageDetailPage() {
     onError: (err) => toast(`${tr('重试失败：', 'Retry failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
   });
 
-  const cancelMutation = useMutation({
-    mutationFn: () => api.cancelVoyage(id),
-    onSuccess: () => {
-      toast(tr('任务已取消', 'Task cancelled'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['voyage', id] });
-      void queryClient.invalidateQueries({ queryKey: ['voyages'] });
-    },
-    onError: (err) => toast(`${tr('取消失败：', 'Cancel failed: ')}${err instanceof Error ? err.message : String(err)}`, 'error'),
-  });
-
   const active = !!voyage && !VOYAGE_TERMINAL.has(voyage.status);
 
   // —— SSE 实时订阅（活动状态时） ——
@@ -1734,12 +1725,8 @@ export function VoyageDetailPage() {
             )}
           </div>
         </div>
-        {active && (
-          <button className="btn btn-ghost" disabled={cancelMutation.isPending} onClick={() => cancelMutation.mutate()}>
-            <Icon name="x" size={13} />
-            {tr('取消任务', 'Cancel task')}
-          </button>
-        )}
+        {/* 取消 / 删除；续跑在下方 ActivityBar 里（紧挨报错说明，那里更好理解） */}
+        <VoyageActions voyage={voyage} showResume={false} onDone={() => navigate('/voyages')} />
         {voyage.kind === 'presentation' && voyage.status === 'done' && (
           <PresentationDownload voyageId={voyage.id} goal={voyage.goal} />
         )}

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -8,6 +8,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { useProject } from '../../app/project';
 import { api, LIBRARY_TASK_KINDS, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
+import { VoyageActions } from '../../components/ui/VoyageActions';
 import { fmtDuration, fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 
@@ -172,6 +173,8 @@ export function VoyageRow({ v, first }: { v: VoyageRead; first?: boolean }) {
       <span style={{ width: 134, display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
         <StatusPill status={v.status} sm />
       </span>
+      {/* 动作就地可用：不必逐个点进详情才能取消/续跑/删除 */}
+      <VoyageActions voyage={v} compact />
       <Icon name="chevron" size={14} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
     </div>
   );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2915,6 +2915,10 @@ export const api = {
   cancelVoyage(id: string): Promise<VoyageRead> {
     return request<VoyageRead>(`/voyages/${id}/cancel`, { method: 'POST' });
   },
+  /** 删除任务记录（仅限已结束的）。步骤与日志一并删；token 用量只解引用，留在账上。 */
+  deleteVoyage(id: string): Promise<void> {
+    return request<void>(`/voyages/${id}`, { method: 'DELETE' });
+  },
   /** 重试 paused_error 的航程，从断点续跑。 */
   resumeVoyage(id: string): Promise<VoyageRead> {
     return request<VoyageRead>(`/voyages/${id}/resume`, { method: 'POST' });
@@ -4409,6 +4413,10 @@ export const api = {
   // —— 每日新论文池（/daily） ——
   /** 池内现存日期（倒序）与每天篇数。 */
   /** 每天的条目数。带上当前筛选，否则日期标签上的数字会和列表对不上。 */
+  /** 每日池保留天数（管理员可配；界面上别写死）。 */
+  getDailyRetention(): Promise<{ days: number }> {
+    return request<{ days: number }>('/daily/retention');
+  },
   listDailyDays(params: { announce?: string; category?: string } = {}): Promise<DailyDay[]> {
     const qs = new URLSearchParams();
     if (params.announce) qs.set('announce', params.announce);


### PR DESCRIPTION
## Daily papers

- **List is now sorted by date.** It was sorted by likes, and 7/24 was the only day anywhere on the platform with liked entries (2 of them), so those two were hoisted above every newer paper. What the user saw was "July 24 shows only one liked paper".
- **Default view is now "all days"** instead of falling back to the latest day. On a weekend, when arXiv publishes nothing, the latest day is empty and the page looks broken.
- The "All N days" label follows the admin-configured retention period instead of being hard-coded to 7.
- Paper detail: abstract collapsed by default and styled consistently with the metadata block; the top badge row shows which lab libraries auto-collected this paper (click through for the full list with relevance scores).

## Tasks

The list rows and the detail page now offer **cancel / resume / delete** consistently. Resume previously existed only inside the detail page's ActivityBar, not on the list.

New `DELETE /voyages/{id}`, with two rules pinned by tests:

- **Only terminal runs can be deleted.** Delete one that is still running and the worker keeps executing against that id; with the row gone it fails somewhere unrelated and unreadable. Cancel first.
- **Token usage survives deletion.** The cascade is `SET NULL`, not `CASCADE` — removing a task should not erase the money it spent from the books.

## reasoning_effort compatibility

Reported from a live instance:

```
litellm.UnsupportedParamsError: openai does not support parameters:
['reasoning_effort'], for model=qwen36-35b-a3b-4
```

The code already had a "if it is rejected, drop the parameter and retry" fallback, but the check required `status_code == 400`. LiteLLM wraps `UnsupportedParamsError` in other status codes, so the fallback never recognised it and the whole stage died.

- The check now **looks only at the error body, not the status code**;
- when a relay wraps it as 5xx, the retry loop is **short-circuited** — this is not a transient failure, so burning 3+6+12 seconds of backoff before falling back is pointless;
- **models confirmed not to support it are remembered**, so later requests stop paying the fail-then-retry round trip.

## Verification

Backend suite 880 passed; `ruff check app` clean; frontend `tsc --noEmit` and `vite build` both pass. 5 new regression tests, one of which pins the reported error verbatim so a non-400 wrapping is still recognised.

Closes #219