### PR TITLE
fix(chat): keep in-flight answers alive across view switches and carry citations into later turns

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -434,7 +434,7 @@ async def chat_with_daily_pool(
     """
     from app.api.wiki import _chat_stream_response
 
-    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     paper_ids = await daily_service.daily_paper_ids(session)
     messages, sources = await library_chat_service.build_scoped_messages(
         session,

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -988,7 +988,7 @@ async def chat_with_library(
     library = await _get_visible_library(session, library_id, user)
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     project_id = library.project_id
-    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     llm = get_llm_router()
     messages, sources = await library_chat_service.build_library_messages_for_library(
         session, library=library, question=data.question, history=history, llm=llm, user_id=user_id

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -270,7 +270,7 @@ async def chat_with_library(
     """
     project = await _member_project(session, project_id, user)
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
-    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     llm = get_llm_router()
     messages, sources = await library_chat_service.build_library_messages(
         session, project=project, question=data.question, history=history, llm=llm, user_id=user_id
@@ -294,7 +294,7 @@ async def chat_with_shelf(
     project = await _member_project(session, project_id, user)
     user_id = user.id  # 先快照：检索失败路径的 rollback 会使 ORM 对象过期
     statement = project.statement or project.name
-    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     llm = get_llm_router()
     # 语料并集：关联文献库成员论文 ∪ 相关研究书架论文（去重）
     library_ids = await libraries_service.get_source_library_ids(session, project_id)
@@ -338,7 +338,7 @@ async def chat_with_personal_library(
     事件序列与文献库对话一致（``sources`` → ``delta``* → ``done``）。
     """
     user_id = user.id
-    history = [(turn.role, turn.content) for turn in data.history[-20:]]  # 最多 10 轮
+    history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     llm = get_llm_router()
     paper_ids = await personal_paper_ids(session, user_id=user_id, tab="saved")
     messages, sources = await library_chat_service.build_scoped_messages(

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -234,6 +234,10 @@ class PaperMyMetaRead(BaseModel):
 class ChatTurn(BaseModel):
     role: Literal["user", "assistant"]
     content: str
+    # assistant 轮：这一轮的 [n] 编号分别指哪几篇论文（按编号顺序）。上下文每轮都会
+    # 重新检索、重新编号，所以历史里的 [1] 和本轮的 [1] 往往不是同一篇——不带上它，
+    # 模型要么答不出「这篇文章」是谁，要么按本轮编号张冠李戴。
+    cited_paper_ids: list[uuid.UUID] = []
 
 
 class PaperChatRequest(BaseModel):

--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 _union_member_stmt = member_papers_stmt
 _dedupe = dedupe_member_rows
 
+PINNED_HISTORY_TURNS = 2  # 往回看几轮 assistant，把它们引用过的论文钉进本轮上下文
+MAX_PINNED_PAPERS = 3  # 最多补几篇（追问「这篇文章怎么样」时，光有标题没正文答不了）
 MAX_SOURCES = 8  # 上下文里最多引用的论文数
 MAX_CHUNKS = 16  # 检索片段数上限
 FALLBACK_PAPERS = 12  # 无分段时用的论文数（TL;DR/摘要）
@@ -53,6 +55,9 @@ LIBRARY_CHAT_SYSTEM_TEMPLATE = """\
   别的词不要加双链）；
 - 当某篇论文的「配图」能直观说明你的观点时，在合适位置插入该图标记 [[fig:论文id:图号]]
   （只用资料里给出的标记，别自己编图号），插图后配一句说明它画了什么、支撑了什么结论；
+- 历史轮次末尾的「本轮引用对照」说明那一轮的编号各指哪篇论文；每轮资料都是重新检索、
+  重新编号的，所以回答里的编号一律以上面「检索到的资料」为准，不要沿用历史轮次的编号。
+  用户说「这篇文章」而没指明是谁时，按最近一轮引用对照去认；
 - 涉及多篇论文时主动做对比与归纳（共识、分歧、演进脉络），不要逐篇罗列了事；
 - 用中文回答，讲清楚、说人话。
 
@@ -61,6 +66,81 @@ LIBRARY_CHAT_SYSTEM_TEMPLATE = """\
 检索到的资料（编号 = 论文）：
 {context}
 """
+
+
+@dataclass
+class HistoryTurn:
+    """一轮历史对话。``cited_paper_ids`` 只有 assistant 轮有值，按 [n] 编号顺序排列。"""
+
+    role: str
+    content: str
+    cited_paper_ids: list[uuid.UUID] = field(default_factory=list)
+
+
+def _norm_history(history) -> list[HistoryTurn]:
+    """兼容两种入参：HistoryTurn 列表，或老的 (role, content) 二元组列表。"""
+    out: list[HistoryTurn] = []
+    for item in history or []:
+        if isinstance(item, HistoryTurn):
+            out.append(item)
+        else:
+            out.append(HistoryTurn(role=item[0], content=item[1]))
+    return out
+
+
+def history_from_turns(turns) -> list[HistoryTurn]:
+    """schemas.ChatTurn 列表 → HistoryTurn 列表（API 层用）。"""
+    return [
+        HistoryTurn(
+            role=t.role,
+            content=t.content,
+            cited_paper_ids=list(getattr(t, "cited_paper_ids", []) or []),
+        )
+        for t in turns
+    ]
+
+
+def _recent_cited_ids(turns: list[HistoryTurn]) -> list[uuid.UUID]:
+    """最近几轮 assistant 引用过的论文 id（去重，越近越靠前）。"""
+    seen: list[uuid.UUID] = []
+    assistant_turns = [t for t in turns if t.role == "assistant"]
+    for turn in reversed(assistant_turns[-PINNED_HISTORY_TURNS:]):
+        for pid in turn.cited_paper_ids:
+            if pid not in seen:
+                seen.append(pid)
+    return seen
+
+
+async def _cited_titles(
+    session: AsyncSession, turns: list[HistoryTurn]
+) -> dict[uuid.UUID, tuple[str, int | None]]:
+    """历史里引用过的论文 id → (标题, 年份)。标题从库里取，不信前端传的。"""
+    ids = {pid for t in turns for pid in t.cited_paper_ids}
+    if not ids:
+        return {}
+    rows = (
+        await session.execute(select(Paper.id, Paper.title, Paper.year).where(Paper.id.in_(ids)))
+    ).all()
+    return {pid: (title, year) for pid, title, year in rows}
+
+
+def _history_messages(
+    turns: list[HistoryTurn], titles: dict[uuid.UUID, tuple[str, int | None]]
+) -> list[Message]:
+    """把历史转成 Message；assistant 轮末尾补一行「本轮引用对照」解释它自己的编号。"""
+    msgs: list[Message] = []
+    for turn in turns:
+        content = turn.content
+        if turn.role == "assistant" and turn.cited_paper_ids:
+            legend = "；".join(
+                f"[{i}]=《{titles[pid][0]}》（{titles[pid][1] or '年份未知'}）"
+                for i, pid in enumerate(turn.cited_paper_ids, start=1)
+                if pid in titles
+            )
+            if legend:
+                content = f"{content}\n（本轮引用对照：{legend}）"
+        msgs.append(Message(role=turn.role, content=content))
+    return msgs
 
 
 @dataclass
@@ -216,6 +296,7 @@ async def build_messages_for_libraries(
     user_id: uuid.UUID | None = None,
 ) -> tuple[list[Message], list[ChatSource]]:
     """按一组库检索并组装对话消息的共享实现（project_id 仅用于 LLM 记账，可空）。"""
+    turns = _norm_history(history)
     if not library_ids:
         # 课题无关联库 = 无语料：直接给「空文献库」上下文（不抓片段、不兜底）
         messages = [
@@ -226,7 +307,7 @@ async def build_messages_for_libraries(
                 ),
             )
         ]
-        messages += [Message(role=role, content=content) for role, content in history]
+        messages += _history_messages(turns, {})
         messages.append(Message(role="user", content=question))
         return messages, []
 
@@ -243,13 +324,29 @@ async def build_messages_for_libraries(
     if rows:
         paper_ids = list({c.paper_id for c, _ in rows})
         found = (
-            await session.execute(
-                _union_member_stmt(library_ids).where(Paper.id.in_(paper_ids))
-            )
+            await session.execute(_union_member_stmt(library_ids).where(Paper.id.in_(paper_ids)))
         ).all()
         deduped = _dedupe(found)
         papers = {p.id: p for p, _ in deduped}
         memberships = {p.id: m for p, m in deduped}
+
+    # 追问「这篇文章具体做了什么」时，问题本身几乎没有语义信息，按它检索大概率
+    # 捞不回上一轮那篇论文。所以把最近几轮引用过的、本轮又没检索到的论文补进来，
+    # 否则模型认得出标题却没有正文可依据。
+    pinned: list[tuple[Paper, LibraryPaper]] = []
+    recent_ids = _recent_cited_ids(turns)
+    if recent_ids:
+        missing = [pid for pid in recent_ids if pid not in papers][:MAX_PINNED_PAPERS]
+        if missing:
+            # 仍然走成员关系查询：只有本次这些库里的论文才能进上下文
+            pinned = _dedupe(
+                (
+                    await session.execute(
+                        _union_member_stmt(library_ids).where(Paper.id.in_(missing))
+                    )
+                ).all()
+            )
+            memberships |= {p.id: m for p, m in pinned}
 
     # (paper, 送入上下文的正文) 顺序清单：优先检索片段，否则高分论文摘要兜底
     entries: list[tuple[Paper, str]] = []
@@ -268,13 +365,18 @@ async def build_messages_for_libraries(
             ).all()
         )
         fallback.sort(
-            key=lambda pm: -(
-                pm[1].relevance_score if pm[1].relevance_score is not None else -1e18
-            )
+            key=lambda pm: -(pm[1].relevance_score if pm[1].relevance_score is not None else -1e18)
         )
         fallback = fallback[:FALLBACK_PAPERS]
         entries = [(p, p.tldr or (p.abstract or "")[:400] or "（无摘要）") for p, _ in fallback]
         memberships |= {p.id: m for p, m in fallback}
+
+    # 钉住的历史引用排在检索结果之后：本轮检索到的更贴题，让它们占前面的编号
+    seen_ids = {p.id for p, _ in entries}
+    for paper, _membership in pinned:
+        if paper.id not in seen_ids:
+            seen_ids.add(paper.id)
+            entries.append((paper, paper.tldr or (paper.abstract or "")[:400] or "（无摘要）"))
 
     # 涉及论文的概念清单（回答里的 [[双链]] 只允许用这些名字，保证前端可点可跳）
     concepts_by_paper: dict[uuid.UUID, list[str]] = {}
@@ -322,7 +424,7 @@ async def build_messages_for_libraries(
             content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(statement=statement, context=context),
         )
     ]
-    messages += [Message(role=role, content=content) for role, content in history]
+    messages += _history_messages(turns, await _cited_titles(session, turns))
     messages.append(Message(role="user", content=question))
     return messages, sources
 
@@ -346,6 +448,7 @@ async def build_scoped_messages(
     一致，端点可照抄 chat_with_library 的消费方式。
     """
     statement_text = statement or "（未指定研究方向）"
+    turns = _norm_history(history)
     if not paper_ids:
         # 空语料：直接给「还没有论文」上下文（不抓片段、不兜底）
         messages = [
@@ -356,7 +459,7 @@ async def build_scoped_messages(
                 ),
             )
         ]
-        messages += [Message(role=role, content=content) for role, content in history]
+        messages += _history_messages(turns, {})
         messages.append(Message(role="user", content=question))
         return messages, []
 
@@ -383,18 +486,27 @@ async def build_scoped_messages(
             entries.append((paper, snippet))
     else:
         fallback = (
-            (
-                await session.execute(
-                    select(Paper).where(Paper.id.in_(paper_ids))
-                )
-            )
-            .scalars()
-            .all()
+            (await session.execute(select(Paper).where(Paper.id.in_(paper_ids)))).scalars().all()
         )
         by_id = {p.id: p for p in fallback}
         # 保留调用方给定的论文顺序（书架/收藏已按新→旧排好）
         ordered = [by_id[pid] for pid in paper_ids if pid in by_id][:FALLBACK_PAPERS]
         entries = [(p, p.tldr or (p.abstract or "")[:400] or "（无摘要）") for p in ordered]
+
+    # 同 build_messages_for_libraries：把最近几轮引用过、本轮没检索到的论文补进来。
+    # 限定在本次作用域的 paper_ids 内，别把别处的论文漏进这场对话。
+    scoped = set(paper_ids)
+    seen_ids = {p.id for p, _ in entries}
+    missing = [pid for pid in _recent_cited_ids(turns) if pid in scoped and pid not in seen_ids][
+        :MAX_PINNED_PAPERS
+    ]
+    if missing:
+        extra = (await session.execute(select(Paper).where(Paper.id.in_(missing)))).scalars().all()
+        entries += [
+            (p, p.tldr or (p.abstract or "")[:400] or "（无摘要）")
+            for p in extra
+            if p.id not in seen_ids
+        ]
 
     # 涉及论文的概念清单（回答里的 [[双链]] 只允许用这些名字）
     concepts_by_paper: dict[uuid.UUID, list[str]] = {}
@@ -438,12 +550,10 @@ async def build_scoped_messages(
     messages = [
         Message(
             role="system",
-            content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(
-                statement=statement_text, context=context
-            ),
+            content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(statement=statement_text, context=context),
         )
     ]
-    messages += [Message(role=role, content=content) for role, content in history]
+    messages += _history_messages(turns, await _cited_titles(session, turns))
     messages.append(Message(role="user", content=question))
     return messages, sources
 
@@ -470,9 +580,7 @@ async def build_reference_context(
         return "", []
     found = _dedupe(
         (
-            await session.execute(
-                _union_member_stmt(library_ids).where(Paper.id.in_(paper_ids))
-            )
+            await session.execute(_union_member_stmt(library_ids).where(Paper.id.in_(paper_ids)))
         ).all()
     )
     papers = {p.id: p for p, _ in found}

--- a/src/backend/tests/test_library_chat.py
+++ b/src/backend/tests/test_library_chat.py
@@ -215,3 +215,97 @@ async def test_library_chat_sources_include_concepts(client):
     by_paper = {it["paper_id"]: it for it in items}
     assert "思维树" in by_paper[ids[0]]["concepts"]
     assert {"status", "relevance"} <= set(items[0])
+
+
+# ---- 多轮引用记忆（#194）----
+
+
+async def _project_and_router(project_id):
+    from sqlalchemy import select as _select
+
+    from app.core.llm.router import get_llm_router
+    from app.models.project import Project
+
+    session = get_sessionmaker()()
+    project = (
+        await session.execute(_select(Project).where(Project.id == project_id))
+    ).scalar_one()
+    return session, project, get_llm_router()
+
+
+async def test_history_carries_its_own_citation_legend(client):
+    """历史里的 [n] 必须自带对照表，否则模型分不清它和本轮的 [n] 是不是同一篇。"""
+    from app.services import library_chat as lc
+
+    project_id, headers, ids = await _setup(client)
+    await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+
+    session, project, llm = await _project_and_router(project_id)
+    async with session:
+        messages, _sources = await lc.build_library_messages(
+            session,
+            project=project,
+            question="这篇文章具体做了什么？",
+            history=[
+                lc.HistoryTurn(role="user", content="planning 有哪些方法？"),
+                lc.HistoryTurn(
+                    role="assistant",
+                    content="主流是树搜索 [1]。",
+                    cited_paper_ids=[uuid.UUID(ids[0])],
+                ),
+            ],
+            llm=llm,
+        )
+
+    assistant_msgs = [m for m in messages if m.role == "assistant"]
+    assert len(assistant_msgs) == 1
+    # 对照表里给出的是标题，模型据此认得出「这篇文章」是谁
+    assert "引用对照" in assistant_msgs[0].content
+    assert "Planning with Tree Search" in assistant_msgs[0].content
+    # 系统提示要讲清楚编号不跨轮沿用
+    assert "不要沿用历史轮次的编号" in messages[0].content
+
+
+async def test_previously_cited_paper_is_pinned_into_context(client, monkeypatch):
+    """追问「这篇文章怎么样」检索不回原文时，上一轮引用过的论文要补进上下文。
+
+    否则模型认得出标题，却没有正文可依据，只能答「未检索到相关内容」。
+    """
+    from app.services import library_chat as lc
+
+    project_id, headers, ids = await _setup(client)
+    await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+    cited = uuid.UUID(ids[1])  # 上一轮引用的是第二篇
+
+    async def only_first_paper(session, **kwargs):
+        """检索只命中第一篇，模拟追问句检索不回目标论文。"""
+        rows = (
+            await session.execute(
+                select(PaperChunk).where(PaperChunk.paper_id == uuid.UUID(ids[0])).limit(2)
+            )
+        ).scalars().all()
+        return [(c, 0.9) for c in rows]
+
+    monkeypatch.setattr(lc, "_retrieve_chunks", only_first_paper)
+
+    session, project, llm = await _project_and_router(project_id)
+    async with session:
+        messages, sources = await lc.build_library_messages(
+            session,
+            project=project,
+            question="这篇文章具体做了什么？",
+            history=[
+                lc.HistoryTurn(
+                    role="assistant",
+                    content="可以看 [1]。",
+                    cited_paper_ids=[cited],
+                )
+            ],
+            llm=llm,
+        )
+
+    source_ids = [s.paper_id for s in sources]
+    assert str(cited) in source_ids, "上一轮引用的论文没有被钉进本轮上下文"
+    # 检索命中的那篇仍在，且排在钉进来的前面（更贴题的占小编号）
+    assert source_ids[0] == ids[0]
+    assert "Reflexion Self-Improvement" in messages[0].content

--- a/src/frontend/src/features/chat/ChatSurface.tsx
+++ b/src/frontend/src/features/chat/ChatSurface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, type IconName } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
@@ -7,6 +7,14 @@ import { ApiError, api, skillKindLabel, type ChatTurn } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useIsMobile } from '../../lib/useBreakpoint';
 import { useChatHistory } from './useChatHistory';
+import {
+  isStreaming as streamIsLive,
+  startStream,
+  stopStream,
+  streamKey,
+  subscribeStream,
+  type StreamSnapshot,
+} from './liveChatStreams';
 import { Composer } from './Composer';
 import { CONTEXT_KIND_META, type ChatMsg, type ContextKind, type ContextRef, type MentionTarget } from './types';
 
@@ -93,7 +101,6 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
   useEffect(() => {
     setDrawerOpen(isMobile ? false : defaultDrawerOpen);
   }, [isMobile, defaultDrawerOpen]);
-  const stopRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // 是否「贴着底部」：用户往上滚离底部后暂停自动跟随，滚回底部再恢复
   const stickBottomRef = useRef(true);
@@ -113,7 +120,6 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
   const activeMsgsRef = useRef<ChatMsg[]>(activeMsgs);
   activeMsgsRef.current = activeMsgs;
 
-  useEffect(() => () => stopRef.current?.(), []);
   // 只有用户仍贴在底部时才自动跟随到底；往上滚阅读时不打断
   useEffect(() => {
     const el = scrollRef.current;
@@ -126,48 +132,77 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
     stickBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
   };
 
-  const finishStream = (failed: boolean, fallbackText?: string, deliverShare = true) => {
-    setStreaming(false);
-    stopRef.current = null;
-    const finalMsgs = withLastAssistant(activeMsgsRef.current, (last) => ({
-      ...last,
-      done: true,
-      failed: failed || undefined,
-      content: last.content || fallbackText || '',
-    }));
-    activeMsgsRef.current = finalMsgs;
-    commit(finalMsgs);
+  // 在途流按「会话」登记在模块级表里，组件卸载只退订、不掐流（#193）
+  const activeKey = history.activeId ? streamKey(cfg.surfaceKey, history.activeId) : null;
+  const activeKeyRef = useRef<string | null>(activeKey);
+  activeKeyRef.current = activeKey;
+  // 一条流的收尾只处理一次：重新订阅时会立刻收到一份 done 快照，别重复投递分享
+  const handledDoneRef = useRef<string | null>(null);
+
+  const deliverShare = (finalMsgs: ChatMsg[], failed: boolean) => {
     const share = pendingShareRef.current;
     pendingShareRef.current = null;
-    if (share && !failed && deliverShare) {
-      const link = cfg.shareLink ? tr('，已附论文链接', ' with paper link') : '';
-      if (share.kind === 'user') {
-        // 平台成员私信不在本次群机器人单向推送范围内，保留原有提示。
-        toast(
-          tr(`已排队分享给 ${share.label}${link}（成员分享后端待接）`, `Queued to share with ${share.label}${link} (member delivery pending)`),
-          'info',
-        );
-        return;
-      }
-      const assistant = finalMsgs[finalMsgs.length - 1];
-      const text = assistant?.role === 'assistant' ? assistant.content.trim() : '';
-      if (!text) {
-        toast(tr('回答为空，未向群机器人推送', 'The answer was empty, so nothing was sent to the group bot.'), 'error');
-        return;
-      }
-      toast(tr(`正在推送给 ${share.label}…`, `Sending to ${share.label}…`), 'info');
-      void api.sendChatBotMessage(share.kind, {
-        title: tr('Polaris AI 分享', 'Shared from Polaris AI'),
-        text,
-        ...(cfg.shareLink ? { link: cfg.shareLink } : {}),
-      }).then((result) => {
-        const parts = result.parts > 1 ? tr(`（${result.parts} 条）`, ` (${result.parts} messages)`) : '';
-        toast(tr(`已分享给 ${share.label}${link}${parts}`, `Shared with ${share.label}${link}${parts}`), 'ok');
-      }).catch((error: unknown) => {
-        toast(`${tr('分享失败', 'Share failed')}：${robotShareError(error)}`, 'error');
-      });
+    if (!share || failed) return;
+    const link = cfg.shareLink ? tr('，已附论文链接', ' with paper link') : '';
+    if (share.kind === 'user') {
+      // 平台成员私信不在本次群机器人单向推送范围内，保留原有提示。
+      toast(
+        tr(`已排队分享给 ${share.label}${link}（成员分享后端待接）`, `Queued to share with ${share.label}${link} (member delivery pending)`),
+        'info',
+      );
+      return;
+    }
+    const assistant = finalMsgs[finalMsgs.length - 1];
+    const text = assistant?.role === 'assistant' ? assistant.content.trim() : '';
+    if (!text) {
+      toast(tr('回答为空，未向群机器人推送', 'The answer was empty, so nothing was sent to the group bot.'), 'error');
+      return;
+    }
+    toast(tr(`正在推送给 ${share.label}…`, `Sending to ${share.label}…`), 'info');
+    void api.sendChatBotMessage(share.kind, {
+      title: tr('Polaris AI 分享', 'Shared from Polaris AI'),
+      text,
+      ...(cfg.shareLink ? { link: cfg.shareLink } : {}),
+    }).then((result) => {
+      const parts = result.parts > 1 ? tr(`（${result.parts} 条）`, ` (${result.parts} messages)`) : '';
+      toast(tr(`已分享给 ${share.label}${link}${parts}`, `Shared with ${share.label}${link}${parts}`), 'ok');
+    }).catch((error: unknown) => {
+      toast(`${tr('分享失败', 'Share failed')}：${robotShareError(error)}`, 'error');
+    });
+  };
+
+  // 快照 → 消息。首次订阅、逐 token 推送、切回来认领，走的都是这一条路径
+  const applySnapshot = (snap: StreamSnapshot) => {
+    const next = withLastAssistant(activeMsgsRef.current, (last) => ({
+      ...last,
+      content: snap.content,
+      ...(snap.sources ? { sources: snap.sources } : {}),
+      ...(snap.done ? { done: true } : {}),
+      ...(snap.failed ? { failed: true } : {}),
+    }));
+    activeMsgsRef.current = next;
+    commit(next);
+    if (!snap.done) return;
+    setStreaming(false);
+    const key = activeKeyRef.current;
+    if (key && handledDoneRef.current !== key) {
+      handledDoneRef.current = key;
+      deliverShare(next, snap.failed === true);
     }
   };
+  const applyRef = useRef(applySnapshot);
+  applyRef.current = applySnapshot;
+
+  // 挂载 / 切会话：认领该会话尚未结束的流，接着往下渲染
+  const stableApply = useCallback((snap: StreamSnapshot) => applyRef.current(snap), []);
+  useEffect(() => {
+    if (!activeKey) {
+      setStreaming(false);
+      return;
+    }
+    setStreaming(streamIsLive(activeKey));
+    return subscribeStream(activeKey, stableApply);
+  }, [activeKey, stableApply]);
 
   const send = (payload: { text: string; context: ContextRef[]; shareTo: MentionTarget | null }) => {
     if (streaming) return;
@@ -185,7 +220,15 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
     const history10: ChatTurn[] = activeMsgsRef.current
       .filter((m) => m.content && !m.failed)
       .slice(-MAX_HISTORY_TURNS * 2)
-      .map((m) => ({ role: m.role, content: m.content }));
+      .map((m) => ({
+        role: m.role,
+        content: m.content,
+        // 带上这一轮引用了哪几篇论文，否则后端只能看到光秃秃的 [1][2]，
+        // 下一轮追问「这篇文章」时无从对应（#194）
+        ...(m.role === 'assistant' && m.sources?.length
+          ? { cited_paper_ids: m.sources.map((s) => s.paper_id) }
+          : {}),
+      }));
 
     const userMsg: ChatMsg = {
       role: 'user',
@@ -196,47 +239,28 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
     const base = [...activeMsgsRef.current, userMsg, { role: 'assistant' as const, content: '' }];
     activeMsgsRef.current = base;
     stickBottomRef.current = true; // 新一轮提问：跟随到底，把这轮滚进视野
+    // 开流前先把会话落定：流按会话登记，切走再切回来才认领得到
+    const convId = history.ensureId();
     commit(base);
     setStreaming(true);
     pendingShareRef.current = payload.shareTo;
+    handledDoneRef.current = null;
 
-    stopRef.current = cfg.stream(
-      { question, history: history10, context: payload.context },
-      {
-        onDelta: (text) => {
-          if (!text) return;
-          const next = withLastAssistant(activeMsgsRef.current, (last) =>
-            last.done ? last : { ...last, content: last.content + text },
-          );
-          activeMsgsRef.current = next;
-          commit(next);
-        },
-        onSources: (dataStr) => {
-          let items: ChatMsg['sources'] = [];
-          try {
-            items = (JSON.parse(dataStr) as { items?: ChatMsg['sources'] }).items ?? [];
-          } catch {
-            return;
-          }
-          const next = withLastAssistant(activeMsgsRef.current, (last) =>
-            last.done ? last : { ...last, sources: items },
-          );
-          activeMsgsRef.current = next;
-          commit(next);
-        },
-        onDone: () => finishStream(false),
-        onError: (detail) => {
-          toast(`${tr('对话出错：', 'Chat error: ')}${detail}`, 'error');
-          finishStream(true, tr('（回答中断了，请重试）', '(Answer interrupted — please retry)'));
-        },
-      },
+    startStream(
+      streamKey(cfg.surfaceKey, convId),
+      cfg.surfaceKey,
+      convId,
+      (handlers) =>
+        cfg.stream({ question, history: history10, context: payload.context }, handlers),
+      (detail) => toast(`${tr('对话出错：', 'Chat error: ')}${detail}`, 'error'),
     );
   };
 
   const stop = () => {
-    stopRef.current?.();
     // 人工停止只结束本地生成，不把不完整回答发到外部群。
-    finishStream(false, undefined, false);
+    pendingShareRef.current = null;
+    if (activeKeyRef.current) stopStream(activeKeyRef.current);
+    setStreaming(false);
   };
 
   const questionFor = (idx: number): string => {

--- a/src/frontend/src/features/chat/chatStorage.ts
+++ b/src/frontend/src/features/chat/chatStorage.ts
@@ -1,0 +1,54 @@
+import type { ChatMsg, Conversation } from './types';
+
+/* ============================================================
+   对话本地存储：按 surfaceKey 命名空间存 localStorage。
+   与 React 无关，故单独成文件——在途流在组件卸载后也要往这里写。
+   ============================================================ */
+
+const NS = 'polaris.chat';
+export const MAX_CONVERSATIONS = 40;
+
+function key(surfaceKey: string): string {
+  return `${NS}:${surfaceKey}`;
+}
+
+export function load(surfaceKey: string): Conversation[] {
+  try {
+    const raw = localStorage.getItem(key(surfaceKey));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Conversation[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function save(surfaceKey: string, list: Conversation[]) {
+  try {
+    localStorage.setItem(key(surfaceKey), JSON.stringify(list.slice(0, MAX_CONVERSATIONS)));
+  } catch {
+    /* 配额/隐私模式：静默降级为仅本次会话 */
+  }
+}
+
+export function newId(): string {
+  return `c_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/** 组件已卸载、没人接管渲染时，把流式进展直接写回 localStorage。
+ *  只在无订阅者时调用（见 liveChatStreams），避免和挂载中的 commit 抢写。 */
+export function persistAssistantProgress(
+  surfaceKey: string,
+  convId: string,
+  patch: Partial<ChatMsg>,
+) {
+  const list = load(surfaceKey);
+  const conv = list.find((c) => c.id === convId);
+  if (!conv) return;
+  const last = conv.msgs[conv.msgs.length - 1];
+  if (!last || last.role !== 'assistant') return;
+  conv.msgs = [...conv.msgs.slice(0, -1), { ...last, ...patch }];
+  conv.updatedAt = Date.now();
+  list.sort((a, b) => b.updatedAt - a.updatedAt);
+  save(surfaceKey, list);
+}

--- a/src/frontend/src/features/chat/liveChatStreams.ts
+++ b/src/frontend/src/features/chat/liveChatStreams.ts
@@ -1,0 +1,171 @@
+import { persistAssistantProgress } from './chatStorage';
+import type { ChatMsg } from './types';
+
+/* ============================================================
+   在途对话流登记表（模块级，不随组件生死）。
+
+   起因：ChatSurface 过去在卸载时直接 abort 掉 SSE。用户点开一条引用、
+   切到文献窗口，对话就被掐断，回来只剩一条永远转圈的「正在思考…」。
+   现在流登记在这里，按「会话」归属：组件卸载只是取消订阅，流照跑；
+   无人订阅期间由本模块把进展写回 localStorage，切回来即可认领续看。
+   ============================================================ */
+
+export interface StreamSnapshot {
+  content: string;
+  sources?: ChatMsg['sources'];
+  done: boolean;
+  failed?: boolean;
+}
+
+type Subscriber = (snap: StreamSnapshot) => void;
+
+interface Entry extends StreamSnapshot {
+  surfaceKey: string;
+  convId: string;
+  stop: () => void;
+  subs: Set<Subscriber>;
+  /** 无人订阅时的落盘节流句柄 */
+  saveTimer: number | null;
+}
+
+const SAVE_THROTTLE_MS = 400;
+/** 结束后保留一小会儿，好让「切回来」还能认领到最终态；之后由 localStorage 兜底 */
+const KEEP_AFTER_DONE_MS = 60_000;
+
+const entries = new Map<string, Entry>();
+
+export function streamKey(surfaceKey: string, convId: string): string {
+  return `${surfaceKey}::${convId}`;
+}
+
+function snapshot(e: Entry): StreamSnapshot {
+  return { content: e.content, sources: e.sources, done: e.done, failed: e.failed };
+}
+
+function flush(e: Entry) {
+  if (e.saveTimer != null) {
+    clearTimeout(e.saveTimer);
+    e.saveTimer = null;
+  }
+  persistAssistantProgress(e.surfaceKey, e.convId, {
+    content: e.content,
+    ...(e.sources ? { sources: e.sources } : {}),
+    ...(e.done ? { done: true } : {}),
+    ...(e.failed ? { failed: true } : {}),
+  });
+}
+
+function publish(e: Entry) {
+  if (e.subs.size > 0) {
+    // 有人挂载着：由订阅方 commit（同时更新 React 状态和 localStorage），
+    // 这里不再自己写盘，免得两边互相覆盖
+    const snap = snapshot(e);
+    e.subs.forEach((fn) => fn(snap));
+    return;
+  }
+  if (e.done) {
+    flush(e);
+    return;
+  }
+  if (e.saveTimer == null) {
+    e.saveTimer = window.setTimeout(() => {
+      e.saveTimer = null;
+      if (e.subs.size === 0) flush(e);
+    }, SAVE_THROTTLE_MS);
+  }
+}
+
+export interface StreamHandlers {
+  onDelta: (text: string) => void;
+  onSources?: (dataStr: string) => void;
+  onDone: () => void;
+  onError: (detail: string) => void;
+}
+
+/**
+ * 起一条流并登记。``begin`` 收到内部 handlers，返回中止函数。
+ * ``onFail`` 在出错时调用一次（用于弹提示），组件是否还挂着都会触发。
+ */
+export function startStream(
+  key: string,
+  surfaceKey: string,
+  convId: string,
+  begin: (handlers: StreamHandlers) => () => void,
+  onFail?: (detail: string) => void,
+): void {
+  entries.get(key)?.stop();
+  const e: Entry = {
+    surfaceKey,
+    convId,
+    content: '',
+    done: false,
+    subs: new Set(),
+    saveTimer: null,
+    stop: () => {},
+  };
+  entries.set(key, e);
+
+  const finish = (failed: boolean, fallback?: string) => {
+    if (e.done) return;
+    e.done = true;
+    if (failed) {
+      e.failed = true;
+      if (!e.content && fallback) e.content = fallback;
+    }
+    publish(e);
+    window.setTimeout(() => {
+      if (entries.get(key) === e) entries.delete(key);
+    }, KEEP_AFTER_DONE_MS);
+  };
+
+  e.stop = begin({
+    onDelta: (text) => {
+      if (!text || e.done) return;
+      e.content += text;
+      publish(e);
+    },
+    onSources: (dataStr) => {
+      if (e.done) return;
+      try {
+        e.sources = (JSON.parse(dataStr) as { items?: ChatMsg['sources'] }).items ?? [];
+      } catch {
+        return;
+      }
+      publish(e);
+    },
+    onDone: () => finish(false),
+    onError: (detail) => {
+      onFail?.(detail);
+      finish(true, '（回答中断了，请重试）');
+    },
+  });
+}
+
+/** 订阅某条在途流；返回退订函数。订阅时立即推一次当前快照。 */
+export function subscribeStream(key: string, fn: Subscriber): () => void {
+  const e = entries.get(key);
+  if (!e) return () => {};
+  e.subs.add(fn);
+  fn(snapshot(e));
+  return () => {
+    e.subs.delete(fn);
+    // 最后一个订阅者走了（组件卸载）：立刻把当前进展落盘，之后由本模块接管
+    if (e.subs.size === 0) flush(e);
+  };
+}
+
+/** 该会话是否有还没结束的流（切回来时据此恢复「正在生成」状态）。 */
+export function isStreaming(key: string): boolean {
+  const e = entries.get(key);
+  return !!e && !e.done;
+}
+
+/** 用户主动停止：中止连接并按已生成内容收尾。 */
+export function stopStream(key: string): void {
+  const e = entries.get(key);
+  if (!e || e.done) return;
+  e.stop();
+  e.done = true;
+  publish(e);
+  entries.delete(key);
+}

--- a/src/frontend/src/features/chat/useChatHistory.ts
+++ b/src/frontend/src/features/chat/useChatHistory.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { load, newId, save } from './chatStorage';
 import type { ChatMsg, Conversation } from './types';
 
 /* ============================================================
@@ -6,36 +7,7 @@ import type { ChatMsg, Conversation } from './types';
    后端暂无会话持久化，这里先用本地存储把历史对话体验搭起来。
    ============================================================ */
 
-const NS = 'polaris.chat';
-const MAX_CONVERSATIONS = 40;
 const SAVE_THROTTLE_MS = 400; // 流式期间 localStorage 落盘节流间隔
-
-function key(surfaceKey: string): string {
-  return `${NS}:${surfaceKey}`;
-}
-
-function load(surfaceKey: string): Conversation[] {
-  try {
-    const raw = localStorage.getItem(key(surfaceKey));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as Conversation[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-function save(surfaceKey: string, list: Conversation[]) {
-  try {
-    localStorage.setItem(key(surfaceKey), JSON.stringify(list.slice(0, MAX_CONVERSATIONS)));
-  } catch {
-    /* 配额/隐私模式：静默降级为仅本次会话 */
-  }
-}
-
-function newId(): string {
-  return `c_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
-}
 
 /** 首条用户消息 → 会话标题（截断） */
 function titleFromMsgs(msgs: ChatMsg[]): string {
@@ -50,6 +22,8 @@ export interface ChatHistory {
   activeMsgs: ChatMsg[];
   /** 用最新消息覆盖当前会话（无会话时按需新建） */
   commit: (msgs: ChatMsg[]) => void;
+  /** 同步拿到当前会话 id（没有就地新建）。开流前要用它给流登记归属。 */
+  ensureId: () => string;
   select: (id: string) => void;
   create: () => void;
   remove: (id: string) => void;
@@ -139,6 +113,20 @@ export function useChatHistory(surfaceKey: string): ChatHistory {
     [surfaceKey, scheduleSave],
   );
 
+  const ensureId = useCallback((): string => {
+    let id = activeIdRef.current;
+    if (id) return id;
+    id = newId();
+    activeIdRef.current = id;
+    setActiveId(id);
+    setConversations((prev) =>
+      prev.some((c) => c.id === id)
+        ? prev
+        : [{ id: id!, title: '', msgs: [], updatedAt: Date.now() }, ...prev],
+    );
+    return id;
+  }, []);
+
   const select = useCallback((id: string) => setActiveId(id), []);
 
   const create = useCallback(() => {
@@ -173,5 +161,5 @@ export function useChatHistory(surfaceKey: string): ChatHistory {
     [surfaceKey, flushSave],
   );
 
-  return { conversations, activeId, activeMsgs, commit, select, create, remove };
+  return { conversations, activeId, activeMsgs, commit, ensureId, select, create, remove };
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -867,6 +867,9 @@ export type CitationFormat = 'bibtex' | 'csl-json';
 export interface ChatTurn {
   role: 'user' | 'assistant';
   content: string;
+  /** assistant：这一轮的 [n] 编号分别指哪几篇论文（按编号顺序）。上下文每轮重新
+   *  检索、重新编号，不带上它，模型会把历史里的 [1] 当成本轮的 [1]。 */
+  cited_paper_ids?: string[];
 }
 
 // ============================================================


### PR DESCRIPTION
Fixes #193 and #194. Both live in the literature chat, so they ship together.

> Based on #215; GitHub will retarget this to `main` once that merges.

## #193 — opening a citation and switching views kills the session

`ChatSurface` aborted the SSE on unmount:

```tsx
useEffect(() => () => stopRef.current?.(), []);
```

Opening a citation and switching to the literature view *is* an unmount, so the answer was cut off mid-stream. Worse, the last assistant message was left at `done: false`, so coming back showed a **spinner that never stops** — no content, no way to retry.

In-flight streams now live in a module-level registry (`liveChatStreams`), owned by the conversation rather than the component:

- **Unmounting only unsubscribes; the stream keeps running.**
- While nobody is subscribed, the registry **persists progress to localStorage** (throttled to 400ms, and mutually exclusive with the mounted component's `commit` so the two never fight over the same key).
- **Coming back re-subscribes and immediately receives the full snapshot**, then follows the rest of the stream to completion.
- Pressing stop still genuinely aborts the connection and never delivers a partial answer downstream.

This also required splitting the storage layer out of `useChatHistory` into `chatStorage` (no React import) — a stream that outlives the component cannot persist through a hook.

## #194 — later turns cannot identify papers cited earlier

Worse than the report suggests. Context is retrieved and **renumbered `[1]..[n]` on every turn**, while history carried only `role` and `content`:

```js
.map((m) => ({ role: m.role, content: m.content }))
```

So the model neither knows which paper the previous turn's `[1]` was, nor that it differs from *this* turn's `[1]`. It does not just forget — it confidently answers about **the wrong paper**.

- Assistant turns in history now carry `cited_paper_ids`, and the backend appends a "citation key" line to that turn explaining its own numbering. **Titles are read from the database, not trusted from the client.**
- The system prompt states that numbering does not carry across turns, and that an unqualified "this paper" refers to the most recent citation key.
- **Papers cited in the last two turns that this turn's retrieval missed are pinned into context** (restricted to the current scope). This is the part that actually makes follow-ups answerable: "what exactly does this paper do" carries almost no semantic signal, so retrieval will not bring that paper back, and the model would recognise the title while having no text to reason from.

All three entry points — project library, single library, and shelf/personal library — share one implementation.

## Verification

- Two new backend tests, both confirmed to **fail without the fix** (verified by temporarily reverting to the old logic): one pins the citation key on history turns, the other builds a "retrieval only hits the other paper" scenario and asserts the previously cited paper is still pinned into context, ordered after the retrieved results.
- 47 chat-related backend tests pass; `ruff check app` clean.
- #193 is pure frontend interaction and the repo has no frontend test framework. Making `liveChatStreams` / `chatStorage` React-free allowed bundling them with esbuild and running the full scenario under node: mounted receives deltas → after unmount the stream is still alive and content keeps persisting → re-subscribing yields the full text → completion pushes done → an unattended stream still persists its terminal state → stop genuinely aborts. All pass.
- `tsc --noEmit` and `vite build` pass.

Closes #193
Closes #194