### PR TITLE
fix(worker): register daily_wiki_ingest so library syncs stop being dropped (#216)

### DIFF
--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -10,6 +10,36 @@ from arq.connections import ArqRedis, RedisSettings, create_pool
 
 from app.core.config import get_settings
 
+# worker 实际注册在 WorkerSettings.functions 里的任务名，单一事实来源。
+# arq 只执行注册过的函数，入队一个没注册的名字会被**静默丢弃**——#216 就是这么
+# 来的：库同步改成事件驱动后 daily_wiki_ingest 从 cron 摘掉却没进 functions，
+# 每天入队、每天被丢，而抓取步骤照报成功，连着几天没人发现。所以这里主动校验，
+# 让它当场炸掉而不是无声无息。worker/settings.py 在导入时反向核对两边一致。
+WORKER_FUNCTIONS = frozenset(
+    {
+        "ping_task",
+        "run_voyage",
+        "resume_voyage",
+        "match_user_publications",
+        "index_papers_fulltext_task",
+        "daily_feed_sync",
+        "daily_wiki_ingest",
+        "daily_publication_match",
+    }
+)
+
+
+class UnregisteredTaskError(RuntimeError):
+    """入队了一个 worker 没注册的任务名——这会被 arq 静默丢弃，直接拦下。"""
+
+
+def check_task_name(name: str) -> None:
+    if name not in WORKER_FUNCTIONS:
+        raise UnregisteredTaskError(
+            f"任务 {name!r} 不在 WorkerSettings.functions 里，入队会被 arq 丢弃；"
+            f"已注册的有：{sorted(WORKER_FUNCTIONS)}"
+        )
+
 
 class TaskQueue(Protocol):
     async def enqueue(self, func: str, *args: Any, **kwargs: Any) -> None: ...
@@ -27,6 +57,7 @@ class ArqTaskQueue:
         return self._pool
 
     async def enqueue(self, func: str, *args: Any, **kwargs: Any) -> None:
+        check_task_name(func)
         pool = await self._get_pool()
         await pool.enqueue_job(func, *args, **kwargs)
 

--- a/src/backend/tests/test_worker_registration.py
+++ b/src/backend/tests/test_worker_registration.py
@@ -1,0 +1,58 @@
+"""任务注册守卫（#216）。
+
+arq 只执行 ``WorkerSettings.functions`` 里注册过的函数，入队一个没注册的名字
+会被**静默丢弃**：入队方拿不到任何错误，worker 也只在执行时打一行
+``function 'x' not found``。库同步就是这么消失了好几天的——改成事件驱动后
+``daily_wiki_ingest`` 从 cron 摘掉却没进 functions，而抓取步骤照报成功。
+
+所以这里钉死三件事：注册表与白名单一致、代码里每个 enqueue 的名字都在白名单里、
+入队未注册的名字当场抛错。
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.core.queue import WORKER_FUNCTIONS, ArqTaskQueue, UnregisteredTaskError
+from worker.settings import registered_function_names
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+_ENQUEUE_CALL = re.compile(r"""\.enqueue\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']""")
+
+
+def test_worker_registration_matches_the_enqueue_whitelist():
+    """两边必须一字不差，否则入队会被丢。"""
+    assert registered_function_names() == set(WORKER_FUNCTIONS)
+
+
+def test_daily_wiki_ingest_is_registered():
+    """库同步由每日抓取入队触发，它必须在 functions 里（#216 的回归本身）。"""
+    assert "daily_wiki_ingest" in registered_function_names()
+
+
+def test_every_enqueued_task_name_is_registered():
+    """扫全仓的 enqueue("...")，任何一个没注册的名字都会被静默丢弃。"""
+    unregistered: dict[str, list[str]] = {}
+    for root in ("app", "worker"):
+        for path in (_BACKEND_ROOT / root).rglob("*.py"):
+            for name in _ENQUEUE_CALL.findall(path.read_text(encoding="utf-8")):
+                if name not in WORKER_FUNCTIONS:
+                    unregistered.setdefault(name, []).append(str(path.relative_to(_BACKEND_ROOT)))
+    assert not unregistered, f"入队了未注册的任务：{unregistered}"
+
+
+async def test_enqueueing_an_unregistered_task_raises():
+    """宁可当场炸，也不要像 #216 那样安安静静丢掉。"""
+    queue = ArqTaskQueue()
+    with pytest.raises(UnregisteredTaskError, match="daily_wiki_ingset"):
+        # 故意拼错：这种手滑过去会一路无声无息
+        await queue.enqueue("daily_wiki_ingset")
+
+
+async def test_enqueueing_a_registered_task_passes_the_check():
+    """校验只拦未注册的名字，不改变正常入队路径的行为。"""
+    from app.core.queue import check_task_name
+
+    for name in WORKER_FUNCTIONS:
+        check_task_name(name)  # 不抛即通过

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -4,9 +4,11 @@ from arq import cron, func
 from arq.connections import RedisSettings
 
 from app.core.config import get_settings
+from app.core.queue import WORKER_FUNCTIONS
 from worker.tasks import (
     daily_feed_sync,
     daily_publication_match,
+    daily_wiki_ingest,
     index_papers_fulltext_task,
     match_user_publications,
     ping_task,
@@ -28,6 +30,10 @@ class WorkerSettings:
         match_user_publications,
         index_papers_fulltext_task,
         daily_feed_sync,
+        # 库同步：由「每日论文抓取」跑完后入队触发。它一度只挂在 cron 上，改成
+        # 事件驱动后忘了加到这里，于是每次入队都被 arq 丢掉（#216）。
+        daily_wiki_ingest,
+        daily_publication_match,
     ]
     # 抓取时刻可由管理员配置（SystemSetting daily_feed_sync_time，默认 UTC 02:30 =
     # 北京 10:30；arXiv 约北京 10:00 放新公告）。arq 的 cron 时刻在 worker 启动时就固定
@@ -46,3 +52,19 @@ class WorkerSettings:
     job_timeout = 3600
     # 启动对账：认领无人执行的 executing 航程（重启/超时把任务弄丢时自动恢复）
     on_startup = reconcile_stuck_voyages
+
+
+def registered_function_names() -> set[str]:
+    """WorkerSettings.functions 里实际注册的任务名。"""
+    return {getattr(f, "name", None) or f.__name__ for f in WorkerSettings.functions}
+
+
+# 与入队方的白名单双向核对，导入即校验：任一边漏了都会让入队被 arq 静默丢弃（#216）。
+# 用显式抛错而不是 assert —— assert 在 python -O 下会被剥掉，那正是它最该生效的场合。
+_registered = registered_function_names()
+if _registered != WORKER_FUNCTIONS:
+    raise RuntimeError(
+        "WorkerSettings.functions 与 app.core.queue.WORKER_FUNCTIONS 不一致："
+        f"只在 worker 侧={sorted(_registered - WORKER_FUNCTIONS)}，"
+        f"只在白名单侧={sorted(WORKER_FUNCTIONS - _registered)}"
+    )


### PR DESCRIPTION
Fixes #216. The report is accurate — confirmed in the source and on the live deployment.

## Confirming it

`daily.sync_libraries`, the last step of the daily fetch, enqueues `daily_wiki_ingest`. arq only executes functions listed in `WorkerSettings.functions`, and it wasn't there — not even imported. The running worker on zju-54 says so directly:

```
09:48:12: Starting worker for 8 functions: ping_task, run_voyage, resume_voyage,
match_user_publications, index_papers_fulltext_task, daily_feed_sync,
cron:daily_feed_sync, cron:daily_publication_match
```

One detail in the report is worth correcting, because it changes the blast radius rather than the diagnosis. `voyage_runs` **does** contain `wiki_ingest` rows dated today — 11 of them, all `created_by IS NULL`, all stamped `03:00:00 UTC`. The timeline explains them:

| Time (UTC) | What happened |
|---|---|
| 03:00 | 11 automatic ingest runs — created by the **previous** worker, which was still on an image that had `cron:daily_wiki_ingest` |
| 09:48 | Worker restarted onto current code → 8 functions, `daily_wiki_ingest` gone entirely |
| 10:14 | Manual enqueue → `function 'daily_wiki_ingest' not found` |

So automatic library sync has been dead since this morning's restart, not for days. From the next daily fetch onward every enqueue is dropped. Same fix either way.

This is a regression from #212, which moved library sync off a fixed schedule onto a post-fetch trigger: the cron entry was removed and nothing added the function to `functions`.

## The fix

Register `daily_wiki_ingest` (and `daily_publication_match`, cron-only for the same reason).

Registration alone would leave the trap open, so this also closes the hole that let a dropped job look like success for as long as it did:

- **`app.core.queue.WORKER_FUNCTIONS` is now the single source of truth** for task names. `enqueue()` checks against it and raises `UnregisteredTaskError` rather than handing arq a name it will silently discard. A typo in an enqueue call now fails at the call site instead of vanishing into Redis.
- **`worker.settings` verifies both sides agree at import time** and refuses to start otherwise. A worker that cannot run its jobs should fail loudly rather than boot and drop them. Explicit `raise`, not `assert` — `-O` strips asserts exactly when this check matters most.
- **A test scans every `enqueue("...")` call site** under `app/` and `worker/` and asserts the name is registered, so the next task wired up this way fails in CI instead of in production.

The report also notes that `daily.sync_libraries` reports `{"triggered": True}` without checking the job was accepted. The enqueue guard covers that directly: an unregistered function now raises, which fails the step and surfaces the run as failed instead of green.

## Verification

- Removing `daily_wiki_ingest` from `functions` again makes `worker.settings` **fail to import** — the worker would not start at all, which is the loud failure this needed. Confirmed by temporarily reverting the registration and running the suite.
- 5 new tests: both-sides-agree, `daily_wiki_ingest` specifically registered (the regression itself), every enqueued name registered, unregistered name raises, registered names pass.
- Full backend suite: 883 passed. `ruff check app worker` clean.

## After merge

Production needs a worker restart to pick this up; the next daily fetch will then trigger library sync normally. The 6 runs still `executing` since 03:00 UTC are worth a look separately — `reconcile_stuck_voyages` ran at the 09:48 restart and did not claim them.