### PR TITLE
feat(libraries): drop irrelevant papers outright and keep the recycle bin out of search

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -57,12 +57,15 @@ from app.services.libraries import (
     find_pool_paper,
     get_library_for_project,
     library_definition,
+    rejected_paper_ids,
+    remember_rejected,
 )
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
 from app.services.paper_enrich import paper_embedding_text
 from app.services.paper_wiki import upsert_wiki
+from app.services.papers import delete_membership_hard
 from app.services.projects import DEFAULT_ARXIV_CATEGORIES
 from app.services.relevance import (
     build_direction_query,
@@ -170,9 +173,7 @@ def _mode(ctx: ActionContext) -> str:
     return "incremental" if ctx.run.kind == "wiki_ingest" else "search"
 
 
-async def _resolve_library(
-    session: AsyncSession, ctx: ActionContext
-) -> DirectionLibrary | None:
+async def _resolve_library(session: AsyncSession, ctx: ActionContext) -> DirectionLibrary | None:
     """P9a：库化任务优先按 ``run.library_id`` 直接定位方向库；回退起源课题解析（兼容
     库化前建的存量 run）。独立库（无起源课题）也能由此拿到自己的库。"""
     if ctx.run.library_id is not None:
@@ -253,6 +254,7 @@ async def _pool_paper_or_new(
 
 # ---- 1. 检索候选（arXiv） ----
 
+
 async def _rank_feed_by_similarity(
     ctx: ActionContext,
     session: AsyncSession,
@@ -293,9 +295,7 @@ async def _rank_feed_by_similarity(
     vectors = await paper_vectors(session, [p.id for p in papers], space)
     if not vectors:
         return papers[:limit], False
-    scored = [
-        (cosine_similarity(vector, vectors[p.id]), p) for p in papers if p.id in vectors
-    ]
+    scored = [(cosine_similarity(vector, vectors[p.id]), p) for p in papers if p.id in vectors]
     scored.sort(key=lambda x: -x[0])
     ranked = [p for _, p in scored]
     # 没建向量的排在后面而不是丢掉（同上：粗排不该有排除语义）
@@ -352,8 +352,12 @@ async def _collect_from_daily_feed(
             since_day = last.astimezone(UTC).date()
             stmt = stmt.where(DailyFeedEntry.feed_date >= since_day)
     rows = (await session.execute(stmt)).all()
-    feed_papers = [p for p, _ in rows]
     feed_latest = max((d for _, d in rows), default=None)
+    # 判过且没通过的直接跳过：它们的成员行已被删掉，去重集合挡不住，而扫描窗口
+    # 和上次同步那天是重叠的——不挡的话今天淘汰的几百篇明天会再打一次分。
+    rejected = rejected_paper_ids(library)
+    feed_papers = [p for p, _ in rows if str(p.id) not in rejected]
+    skipped_rejected = len(rows) - len(feed_papers)
 
     excluded_by_terms = 0
     if exclude:
@@ -402,6 +406,7 @@ async def _collect_from_daily_feed(
     return {
         "feed_total": len(rows),
         "feed_scope": scope,
+        "skipped_previously_rejected": skipped_rejected,
         "feed_since": since_day.isoformat() if since_day else None,
         "excluded_by_terms": excluded_by_terms,
         "feed_ranked": did_rank,
@@ -446,8 +451,12 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         # 而每日推送本来就每天把新论文抓进内容池了，同一批论文没有理由抓第二遍。
         if mode == "incremental":
             feed = await _collect_from_daily_feed(
-                ctx, session, library=library, direction=direction_query,
-                exclude=exclude, limit=limit,
+                ctx,
+                session,
+                library=library,
+                direction=direction_query,
+                exclude=exclude,
+                limit=limit,
             )
             new_papers = feed.pop("selected")
             await session.flush()
@@ -760,15 +769,22 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                 voyage_id=ctx.run.id,
             )
             score = scored.score
-            membership.status = "scored" if score >= threshold else "excluded"
-            membership.trash_reason = None if membership.status == "scored" else "irrelevant"
+            passed = score >= threshold
+            if passed:
+                membership.status = "scored"
+                membership.trash_reason = None
+            else:
+                # 相关性不够的直接删掉成员行，不进回收站——自动淘汰每天上百篇，堆在
+                # 回收站里没人会去看，还把「用户手动删的」淹没掉。论文本体留在内容池
+                # （每日池仍引用着它），孤儿清理会在它彻底没人引用时回收。
+                await delete_membership_hard(session, membership)
             # 逐篇 commit：worker 中途被杀后按 status 断点续跑，不重复打分
             await session.commit()
             return {
                 "id": str(paper.id),
                 "title": paper.title,
                 "score": score,
-                "passed": membership.status == "scored",
+                "passed": passed,
             }
 
     results = await _gather_bounded(_LLM_CONCURRENCY, [score_one(mid) for mid in membership_ids])
@@ -779,6 +795,7 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
     excluded = 0
     failed: list[dict[str, str]] = []
     scored_ids: list[str] = []
+    rejected_ids: list[str] = []
     scored_brief: list[dict[str, Any]] = []
     for paper_id, result in zip(paper_ids, results, strict=True):
         if isinstance(result, BaseException):
@@ -790,8 +807,19 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
         scored_ids.append(result["id"])
         if not result["passed"]:
             excluded += 1
+            rejected_ids.append(result["id"])
         if len(scored_brief) < _OBS_LIST_CAP:
             scored_brief.append(result)
+
+    # 成员行删掉之后，去重集合就挡不住它们了：而 since_last 的扫描窗口和上次同步那天
+    # 是重叠的，不记一笔的话今天淘汰的几百篇明天会再花一次 LLM。所以在库上留一份
+    # 「判过且没通过」的名单（只存 id，有上限，够覆盖重叠窗口即可）。
+    if rejected_ids:
+        async with get_sessionmaker()() as session:
+            library = await _resolve_library(session, ctx)
+            if library is not None:
+                remember_rejected(library, rejected_ids)
+                await session.commit()
 
     # 步内进度记入 checkpoint（审计用；幂等本身靠 Paper.status）
     ctx.checkpoint["scored_ids"] = list(ctx.checkpoint.get("scored_ids") or []) + scored_ids
@@ -832,9 +860,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             await session.execute(
                 select(Paper, LibraryPaper)
                 .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(
-                    LibraryPaper.library_id == library.id, LibraryPaper.status == "scored"
-                )
+                .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "scored")
                 .order_by(LibraryPaper.relevance_score.desc().nulls_last())
                 .limit(top_n)
             )
@@ -914,9 +940,7 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # noqa: BLE001
-                failed.append(
-                    {"id": str(paper.id), "error": f"chunks: {type(e).__name__}: {e}"}
-                )
+                failed.append({"id": str(paper.id), "error": f"chunks: {type(e).__name__}: {e}"})
             # 顺带提取候选图（基础信息 caption=null；筛选注释在 wiki.compile 后做）；
             # 失败不影响全文流程
             if paper.pdf_path and paper.figures is None:
@@ -963,9 +987,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
         rows = (
             await session.execute(
                 select(LibraryPaper.id, LibraryPaper.paper_id)
-                .where(
-                    LibraryPaper.library_id == library.id, LibraryPaper.status == "fetched"
-                )
+                .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "fetched")
                 .order_by(LibraryPaper.relevance_score.desc().nulls_last())
                 .limit(top_n)
             )
@@ -1184,8 +1206,8 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 .where(VoyageStep.run_id == ctx.run.id, VoyageStep.status == "obsolete")
             )
         ) or 0
-        watermark = previous if truncated else (
-            ctx.checkpoint.get("watermark_candidate") or previous
+        watermark = (
+            previous if truncated else (ctx.checkpoint.get("watermark_candidate") or previous)
         )
         finished_at = utcnow().isoformat()
         state["watermark"] = watermark

--- a/src/backend/app/services/chunks.py
+++ b/src/backend/app/services/chunks.py
@@ -482,11 +482,15 @@ async def semantic_search_chunks(
             )
         ).all()
     else:
+        # 回收站里的论文不该被文献对话检索到并引用（与关键词检索口径一致）
+        from app.services.papers import PAPER_STATUS_GROUPS
+
         params = {
             "qv": qv,
             "libs": [str(lid) for lid in (library_ids or [])],
             "k": limit,
             "space": space.key,
+            "statuses": list(PAPER_STATUS_GROUPS["library"]),
         }
         paper_filter = ""
         if paper_ids:
@@ -501,6 +505,7 @@ async def semantic_search_chunks(
                     "JOIN library_papers lp ON lp.paper_id = c.paper_id "
                     "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
                     "WHERE v.space = :space "
+                    "AND lp.status = ANY(CAST(:statuses AS varchar[])) "
                     f"{paper_filter}"
                     "ORDER BY score DESC "
                     "LIMIT :k"
@@ -545,10 +550,17 @@ async def keyword_search_chunks(
         # 纯 paper_ids 分支：不 join library_papers，只按论文集合过滤
         stmt = select(PaperChunk).where(PaperChunk.paper_id.in_(paper_ids), cond)
     else:
+        from app.services.papers import PAPER_STATUS_GROUPS
+
         stmt = (
             select(PaperChunk)
             .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
-            .where(LibraryPaper.library_id.in_(library_ids or []), cond)
+            .where(
+                LibraryPaper.library_id.in_(library_ids or []),
+                # 回收站里的论文不该被检索到（与向量分支、关键词论文检索同口径）
+                LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                cond,
+            )
             .distinct()
         )
         if paper_ids:

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -32,6 +32,27 @@ from app.models.user import User
 logger = logging.getLogger(__name__)
 
 
+# 自动淘汰的论文不进回收站，而是直接删掉成员行（见 papers.delete_membership_hard）。
+# 成员行一没，库内去重集合就挡不住它们了；而 since_last 的扫描窗口与上次同步那天是
+# 重叠的，于是同一批论文明天会再花一次 LLM。这里在库上留一份「判过且没通过」的名单
+# 挡住重复。只存 id 且有上限——它是防重复的备忘，不是档案，覆盖得住重叠窗口就够。
+_MAX_REJECTED_MEMORY = 5000
+
+
+def rejected_paper_ids(library: DirectionLibrary) -> set[str]:
+    """本库判过且相关性不达标的论文 id（不再重复送打分）。"""
+    return {pid for pid in (library.ingest_state or {}).get("rejected_ids") or [] if pid}
+
+
+def remember_rejected(library: DirectionLibrary, paper_ids: Iterable[str]) -> None:
+    """把本轮淘汰的论文记进名单（最近的在前，超出上限的丢掉）。"""
+    state = dict(library.ingest_state or {})
+    previous = [pid for pid in (state.get("rejected_ids") or []) if isinstance(pid, str)]
+    merged = list(dict.fromkeys([*paper_ids, *previous]))[:_MAX_REJECTED_MEMORY]
+    state["rejected_ids"] = merged
+    library.ingest_state = state  # 整体赋值：JSON 列不跟踪原地修改
+
+
 def library_definition(library: DirectionLibrary) -> dict[str, Any]:
     """库的收录配置（P8a 权威源）：definition JSON；为空时回退标量列拼一份兼容视图。
 
@@ -108,9 +129,7 @@ async def set_source_libraries(
 ) -> None:
     """全量替换课题的关联库（去重，不存在的 library_id 静默忽略）；flush 不 commit。"""
     unique_ids = list(dict.fromkeys(library_ids))
-    await session.execute(
-        delete(TopicSourceLibrary).where(TopicSourceLibrary.topic_id == topic_id)
-    )
+    await session.execute(delete(TopicSourceLibrary).where(TopicSourceLibrary.topic_id == topic_id))
     if unique_ids:
         found = set(
             (
@@ -400,9 +419,7 @@ async def _owner_names(
     ids = {uid for uid in submitted_by if uid is not None}
     if not ids:
         return {}
-    rows = await session.execute(
-        select(User.id, User.display_name).where(User.id.in_(ids))
-    )
+    rows = await session.execute(select(User.id, User.display_name).where(User.id.in_(ids)))
     return {uid: name for uid, name in rows.all()}
 
 
@@ -445,9 +462,7 @@ async def list_libraries_overview(
             _overview_dict(
                 lib,
                 my_linked=my_linked,
-                can_manage=can_manage_library_row(
-                    user=user, library=lib, curated_ids=my_curated
-                ),
+                can_manage=can_manage_library_row(user=user, library=lib, curated_ids=my_curated),
                 paper_count=paper_counts.get(lib.id, 0),
                 concept_count=concept_counts.get(lib.id, 0),
                 last_compiled_at=last_compiled.get(lib.id),
@@ -501,9 +516,7 @@ async def source_libraries_overview(
         _overview_dict(
             lib,
             my_linked=my_linked,
-            can_manage=can_manage_library_row(
-                user=user, library=lib, curated_ids=my_curated
-            ),
+            can_manage=can_manage_library_row(user=user, library=lib, curated_ids=my_curated),
             paper_count=paper_counts.get(lib.id, 0),
             concept_count=concept_counts.get(lib.id, 0),
             last_compiled_at=last_compiled.get(lib.id),
@@ -627,9 +640,7 @@ def _coerce_anchors(value: Any) -> list[dict[str, Any]]:
             {
                 "title": title.strip(),
                 "arxiv_id": (
-                    arxiv_id.strip()
-                    if isinstance(arxiv_id, str) and arxiv_id.strip()
-                    else None
+                    arxiv_id.strip() if isinstance(arxiv_id, str) and arxiv_id.strip() else None
                 ),
                 "reason": reason.strip() if isinstance(reason, str) and reason.strip() else None,
             }
@@ -754,9 +765,7 @@ async def create_library(
     return library
 
 
-async def request_public(
-    session: AsyncSession, *, library: DirectionLibrary
-) -> DirectionLibrary:
+async def request_public(session: AsyncSession, *, library: DirectionLibrary) -> DirectionLibrary:
     """申请把个人库转为公共库（P10）：is_public 仍 false，status → pending 等 admin 审批。
 
     鉴权（仅创建者 / 策展人）由 api 层校验。幂等：重复申请只是保持 pending。commit 落库。
@@ -767,9 +776,7 @@ async def request_public(
     return library
 
 
-async def approve_library(
-    session: AsyncSession, *, library: DirectionLibrary
-) -> DirectionLibrary:
+async def approve_library(session: AsyncSession, *, library: DirectionLibrary) -> DirectionLibrary:
     """审批通过转公共库（平台 admin，P10）：is_public → true、status → active、清驳回理由。
 
     公共库全实验室可见、ingest 走系统/全局 key（token 不再记创建者账）。commit 落库。
@@ -809,9 +816,7 @@ async def cancel_request_public(
     return library
 
 
-async def make_personal(
-    session: AsyncSession, *, library: DirectionLibrary
-) -> DirectionLibrary:
+async def make_personal(session: AsyncSession, *, library: DirectionLibrary) -> DirectionLibrary:
     """管理员把公共库转回个人库（P10）：is_public → false、status=active。转回后仅
     归属人 + admin 可见（其他成员看不到）。鉴权（平台 admin）由 api 层校验。commit 落库。"""
     library.is_public = False
@@ -826,9 +831,7 @@ async def make_personal(
 
 async def _my_curated_library_ids(session: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
     rows = await session.execute(
-        select(DirectionLibraryCurator.library_id).where(
-            DirectionLibraryCurator.user_id == user_id
-        )
+        select(DirectionLibraryCurator.library_id).where(DirectionLibraryCurator.user_id == user_id)
     )
     return set(rows.scalars().all())
 

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -762,6 +762,20 @@ async def gc_orphan_papers(session: AsyncSession, paper_ids: Sequence[uuid.UUID]
     return removed
 
 
+async def delete_membership_hard(session: AsyncSession, membership: LibraryPaper) -> None:
+    """把一条成员行彻底删掉（不进回收站），并顺带清理孤儿标签与孤儿论文。
+
+    自动淘汰用这条：相关性不足的论文每天上百篇，堆进回收站没人会去翻，还会把用户
+    手动删的那几篇淹掉。论文本体只在**再没有任何集合引用它**时才回收——被每日池
+    引用着的照常留在内容池里，别的库要用还能用。
+    """
+    library_id = membership.library_id
+    paper_id = membership.paper_id
+    await _delete_membership_rows(session, library_id=library_id, memberships=[membership])
+    await prune_orphan_tags(session, library_id=library_id)
+    await gc_orphan_papers(session, [paper_id])
+
+
 async def delete_paper(session: AsyncSession, view: PaperView) -> None:
     """从当前方向库彻底移除一篇论文（回收站里的「彻底删除」）。
 
@@ -1153,7 +1167,9 @@ async def semantic_search_papers(
     if not library_ids:
         return []
     qv = json.dumps(query_vector)
-    # DISTINCT p.id：一篇论文命中多个关联库时只召回一次（分数不受成员行影响）
+    # DISTINCT p.id：一篇论文命中多个关联库时只召回一次（分数不受成员行影响）。
+    # status 过滤与 keyword_search_papers 对齐：回收站（excluded）和未筛选的候选
+    # （candidate）都不该出现在检索结果里——删掉的论文又被搜出来，比搜不到更难理解。
     rows = (
         await session.execute(
             text(
@@ -1163,6 +1179,7 @@ async def semantic_search_papers(
                 "JOIN library_papers lp ON lp.paper_id = p.id "
                 "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
                 "WHERE v.space = :space "
+                "AND lp.status = ANY(CAST(:statuses AS varchar[])) "
                 "ORDER BY score DESC "
                 "LIMIT :k"
             ),
@@ -1171,6 +1188,7 @@ async def semantic_search_papers(
                 "libs": [str(lid) for lid in library_ids],
                 "k": limit,
                 "space": space.key,
+                "statuses": list(PAPER_STATUS_GROUPS["library"]),
             },
         )
     ).all()
@@ -1179,9 +1197,7 @@ async def semantic_search_papers(
     scores = {row.id: float(row.score) for row in rows}
     pairs = dedupe_member_rows(
         (
-            await session.execute(
-                member_papers_stmt(library_ids).where(Paper.id.in_(list(scores)))
-            )
+            await session.execute(member_papers_stmt(library_ids).where(Paper.id.in_(list(scores))))
         ).all()
     )
     by_id = {p.id: PaperView(p, m, project_id) for p, m in pairs}

--- a/src/backend/app/services/user_library.py
+++ b/src/backend/app/services/user_library.py
@@ -176,6 +176,8 @@ async def semantic_saved_entries(
     stmt = select(UserLibraryEntry).where(
         UserLibraryEntry.user_id == user_id,
         UserLibraryEntry.saved.is_(True),
+        # 回收站里的收藏不参与检索（与列表路径同口径）
+        UserLibraryEntry.trashed_at.is_(None),
         UserLibraryEntry.last_paper_id.is_not(None),
     )
     entries = list((await session.execute(stmt)).scalars().all())

--- a/src/backend/tests/test_search_excludes_trash.py
+++ b/src/backend/tests/test_search_excludes_trash.py
@@ -1,0 +1,125 @@
+"""检索不得返回回收站里的论文。
+
+删掉的论文又被搜出来，比搜不到更让人困惑——尤其它在列表里已经不见了。
+关键词路径能在 sqlite 上真跑；向量路径是 pgvector 裸 SQL，测试库是 sqlite，
+只能做源码级守卫（挡住有人把过滤删掉），这一点在下面的用例里写明。
+"""
+
+import inspect
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import PaperChunk
+from app.services import chunks as chunks_service
+from app.services import papers as papers_service
+from app.services import user_library as user_library_service
+from tests.conftest import add_paper, register_and_login
+
+
+async def _setup(client):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "trash-search", "statement": "agent planning"},
+        headers=headers,
+    )
+    project_id = uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        kept = await add_paper(
+            session,
+            project_id=project_id,
+            title="Kept Planning Paper",
+            abstract="planning agents in the wild",
+            status="compiled",
+            relevance_score=0.9,
+        )
+        trashed = await add_paper(
+            session,
+            project_id=project_id,
+            title="Trashed Planning Paper",
+            abstract="planning agents in the wild",
+            status="excluded",
+            relevance_score=0.2,
+        )
+        session.add_all([kept, trashed])
+        await session.commit()
+        return project_id, headers, kept.id, trashed.id
+
+
+async def test_keyword_paper_search_skips_the_recycle_bin(client):
+    project_id, _headers, kept_id, trashed_id = await _setup(client)
+    async with get_sessionmaker()() as session:
+        rows = await papers_service.keyword_search_papers(
+            session, project_id=project_id, q="Planning", limit=20
+        )
+    found = {view.id for view, _score in rows}
+    assert kept_id in found
+    assert trashed_id not in found
+
+
+async def test_keyword_chunk_search_skips_the_recycle_bin(client):
+    """文献对话的关键词降级路径同样不能引用回收站里的论文。"""
+    project_id, _headers, kept_id, trashed_id = await _setup(client)
+    async with get_sessionmaker()() as session:
+        for pid in (kept_id, trashed_id):
+            session.add(
+                PaperChunk(paper_id=pid, seq=0, text="planning agents in the wild")
+            )
+        await session.commit()
+
+        from app.services.libraries import get_source_library_ids
+
+        library_ids = await get_source_library_ids(session, project_id)
+        hits = await chunks_service.keyword_search_chunks(
+            session, library_ids=library_ids, paper_ids=None, q="planning", limit=20
+        )
+    paper_ids = {c.paper_id for c, _score in hits}
+    assert kept_id in paper_ids
+    assert trashed_id not in paper_ids
+
+
+def test_vector_search_paths_filter_the_recycle_bin():
+    """向量检索走 pgvector 裸 SQL，sqlite 测试库跑不到，这里做源码级守卫。
+
+    删掉任一处过滤，这条会失败——比没有守卫强，但它确实不是端到端验证。
+    """
+    paper_sql = inspect.getsource(papers_service.semantic_search_papers)
+    assert "lp.status = ANY" in paper_sql, "库论文向量检索漏了回收站过滤"
+
+    chunk_sql = inspect.getsource(chunks_service.semantic_search_chunks)
+    assert "lp.status = ANY" in chunk_sql, "分块向量检索漏了回收站过滤"
+
+    personal = inspect.getsource(user_library_service.semantic_saved_entries)
+    assert "trashed_at.is_(None)" in personal, "个人库向量检索漏了回收站过滤"
+
+
+async def test_recycle_bin_listing_still_shows_them(client):
+    """过滤只作用于检索：回收站页面本身当然还要能看到它们。"""
+    project_id, headers, _kept_id, trashed_id = await _setup(client)
+    resp = await client.get(f"/api/projects/{project_id}/papers?status=excluded", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert str(trashed_id) in {row["id"] for row in resp.json()["items"]}
+
+
+async def test_chunk_search_by_paper_ids_is_unaffected(client):
+    """显式给定 paper_ids 的分支（书架/个人库对话）不受库成员状态影响。"""
+    project_id, _headers, kept_id, trashed_id = await _setup(client)
+    async with get_sessionmaker()() as session:
+        for pid in (kept_id, trashed_id):
+            session.add(
+                PaperChunk(paper_id=pid, seq=0, text="planning agents in the wild")
+            )
+        await session.commit()
+        hits = await chunks_service.keyword_search_chunks(
+            session,
+            library_ids=None,
+            paper_ids=[kept_id, trashed_id],
+            q="planning",
+            limit=20,
+        )
+    assert {c.paper_id for c, _ in hits} == {kept_id, trashed_id}
+    async with get_sessionmaker()() as session:
+        assert (await session.execute(select(PaperChunk))).scalars().first() is not None

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -312,12 +312,14 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        assert len(rows) == 3  # 检索模式只有 arXiv 候选，引文扩展是另一个模式
+        # 3 篇候选里那篇 "irrelevant" 相关性不达标，成员行被直接删掉（不进回收站），
+        # 所以库里只剩 2 行
+        assert len(rows) == 2
         by_status = {}
         for p, m in rows:
             by_status.setdefault(m.status, []).append((p, m))
-        assert len(by_status.get("excluded", [])) == 1  # "irrelevant" 论文被排除
-        assert by_status["excluded"][0][0].arxiv_id == "2406.00003"
+        assert not by_status.get("excluded")
+        assert "2406.00003" not in {p.arxiv_id for p, _ in rows}
         compiled_rows = by_status.get("compiled", [])
         assert len(compiled_rows) == 2
         for p, m in compiled_rows:
@@ -366,9 +368,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
         activity_kinds = {
             a.kind
             for a in (
-                await session.execute(
-                    select(Activity).where(Activity.library_id == library.id)
-                )
+                await session.execute(select(Activity).where(Activity.library_id == library.id))
             ).scalars()
         }
         assert {"ingest.started", "ingest.completed"} <= activity_kinds
@@ -381,7 +381,8 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert state["last_run"]["voyage_id"] == run_id
     assert state["last_run"]["status"] == "done"
     counts = state["paper_counts"]
-    assert counts["compiled"] == 2 and counts["excluded"] == 1 and counts["total"] == 3
+    # 淘汰的那篇已不在库内，所以 total 是 2 而不是 3
+    assert counts["compiled"] == 2 and counts["excluded"] == 0 and counts["total"] == 2
 
     # papers API 上能看到编译结果
     resp = await client.get(f"/api/projects/{project_id}/papers?status=compiled", headers=headers)
@@ -411,7 +412,8 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert "window_since" not in obs2
     assert obs2["feed_total"] == 0  # 本测试没往每日池放东西
     async with get_sessionmaker()() as session:
-        assert len(await project_paper_rows(session, project_id=project_id)) == 3
+        # 仍是 2：增量这轮没有新候选，上一轮淘汰的那篇也不会复活
+        assert len(await project_paper_rows(session, project_id=project_id)) == 2
 
 
 class _CrashOnNthRelevance(FakeProvider):
@@ -453,8 +455,10 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
     assert await _relevance_call_count() == 2  # 崩溃前 2 篇成功打分（并发，非串行的 1）
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        scored = sum(1 for _, m in rows if m.status in ("scored", "excluded"))
-        assert scored == 2  # 逐篇 commit：崩溃前的进度已落库
+        # 逐篇 commit：崩溃前的进度已落库。达标的留下成员行，不达标的整行删掉，
+        # 所以「已处理」= 剩下的非 candidate 行 + 消失的行
+        scored = sum(1 for _, m in rows if m.status != "candidate") + (3 - len(rows))
+        assert scored == 2
 
     # resume：从断点续跑到 done，总打分调用数 == 论文数（无重复）
     engine2, _ = _make_engine()
@@ -465,7 +469,7 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
+        assert sorted(m.status for _, m in rows) == ["compiled", "compiled"]
 
 
 class _BreakOneRelevance(FakeProvider):
@@ -517,7 +521,7 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
             by_status[m.status] = by_status.get(m.status, 0) + 1
         # 失败打分的那篇仍是 candidate（下次续跑会重试），其余照常推进
         assert by_status.get("candidate", 0) == 1
-        assert by_status.get("excluded", 0) == 1  # irrelevant 篮子编织论文
+        assert by_status.get("excluded", 0) == 0  # irrelevant 那篇整行删掉，不进回收站
         assert by_status.get("compiled", 0) == 1  # 通过阈值且未失败的那篇成功编译
 
 
@@ -551,8 +555,8 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        # 3 候选：2 编译 + 1 排除（无 rubric 时打分只用 statement）
-        assert sorted(m.status for _, m in rows) == ["compiled", "compiled", "excluded"]
+        # 3 候选：2 编译 + 1 淘汰（淘汰的整行删掉；无 rubric 时打分只用 statement）
+        assert sorted(m.status for _, m in rows) == ["compiled", "compiled"]
 
 
 async def test_incremental_pulls_from_daily_feed_without_arxiv(client, queue_stub, wiki_mocks):
@@ -597,15 +601,11 @@ async def test_incremental_pulls_from_daily_feed_without_arxiv(client, queue_stu
             feed_ids.append(paper.id)
             # 用今天：库同步默认只看「上次同步以来」的窗口，固定的过去日期会被筛掉
             session.add(
-                DailyFeedEntry(
-                    paper_id=paper.id, feed_date=_today(), primary_category="cs.AI"
-                )
+                DailyFeedEntry(paper_id=paper.id, feed_date=_today(), primary_category="cs.AI")
             )
         # 已在库的论文也进池：必须被去重挡住，不能重复送打分
         session.add(
-            DailyFeedEntry(
-                paper_id=existing_id, feed_date=_today(), primary_category="cs.AI"
-            )
+            DailyFeedEntry(paper_id=existing_id, feed_date=_today(), primary_category="cs.AI")
         )
         await session.commit()
 
@@ -860,9 +860,7 @@ async def test_cadence_no_longer_excludes_a_library(client, queue_stub, wiki_moc
 async def _promote_admin(email: str) -> None:
     """把已注册用户提为平台 admin（独立建库 / 库级 ingest 触发需要）。"""
     async with get_sessionmaker()() as session:
-        user = (
-            await session.execute(select(User).where(User.email == email))
-        ).scalar_one()
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
         user.role = "admin"
         await session.commit()
 
@@ -943,17 +941,14 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
             .scalars()
             .all()
         )
-        assert len(members) == 3
+        # 淘汰的那篇成员行被删掉，库里只剩 2 行
+        assert len(members) == 2
         assert sum(1 for m in members if m.status == "compiled") == 2
-        assert sum(1 for m in members if m.status == "excluded") == 1
+        assert sum(1 for m in members if m.status == "excluded") == 0
 
         # 库级用量归因：ingest 全程 LLM 调用（打分/图注/编译/概念定义/向量化）记到库上
         usage = (
-            (
-                await session.execute(
-                    select(LLMUsage).where(LLMUsage.library_id == library.id)
-                )
-            )
+            (await session.execute(select(LLMUsage).where(LLMUsage.library_id == library.id)))
             .scalars()
             .all()
         )
@@ -962,11 +957,7 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
 
         # 库级活动流：project_id 为空，library_id 指向本库
         acts = (
-            (
-                await session.execute(
-                    select(Activity).where(Activity.library_id == library.id)
-                )
-            )
+            (await session.execute(select(Activity).where(Activity.library_id == library.id)))
             .scalars()
             .all()
         )
@@ -1268,9 +1259,7 @@ async def test_truncated_run_does_not_advance_the_watermark(client, queue_stub, 
         session.add(run)
         await session.flush()
         session.add(
-            VoyageStep(
-                run_id=run.id, action="wiki.compile", title="编译", status="obsolete", seq=0
-            )
+            VoyageStep(run_id=run.id, action="wiki.compile", title="编译", status="obsolete", seq=0)
         )
         await session.commit()
         run_id = run.id
@@ -1361,9 +1350,7 @@ async def test_search_mode_uses_given_terms_and_time_range(client, queue_stub, w
     assert detail["steps"][0]["action"] == "wiki.search_candidates"
 
     calls = [
-        str(c.request.url)
-        for c in wiki_mocks.calls
-        if "export.arxiv.org" in str(c.request.url)
+        str(c.request.url) for c in wiki_mocks.calls if "export.arxiv.org" in str(c.request.url)
     ]
     assert calls, "检索模式必须真的打了 arXiv 检索接口"
     assert "world+model" in calls[0] or "world%20model" in calls[0]
@@ -1437,9 +1424,7 @@ async def test_exclude_terms_filter_the_daily_feed_sync(client, queue_stub, wiki
             session.add(paper)
             await session.flush()
             session.add(
-                DailyFeedEntry(
-                    paper_id=paper.id, feed_date=_today(), primary_category="cs.AI"
-                )
+                DailyFeedEntry(paper_id=paper.id, feed_date=_today(), primary_category="cs.AI")
             )
         await session.commit()
 
@@ -1504,9 +1489,7 @@ async def test_sync_scope_defaults_to_today_only(client, queue_stub, wiki_mocks)
             )
             session.add(paper)
             await session.flush()
-            session.add(
-                DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI")
-            )
+            session.add(DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI"))
         await session.commit()
 
     async def run_sync() -> dict:
@@ -1570,17 +1553,13 @@ async def test_since_last_scope_widens_after_a_missed_sync(client, queue_stub, w
             )
             session.add(paper)
             await session.flush()
-            session.add(
-                DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI")
-            )
+            session.add(DailyFeedEntry(paper_id=paper.id, feed_date=day, primary_category="cs.AI"))
         # 模拟「上次成功同步是 3 天前」——中间那两天漏了
         library = await session.get(DirectionLibrary, uuid.UUID(library_id))
         state = dict(library.ingest_state or {})
         state["last_run"] = {
             "voyage_id": "x",
-            "finished_at": (
-                dt.datetime.now(dt.UTC) - dt.timedelta(days=3)
-            ).isoformat(),
+            "finished_at": (dt.datetime.now(dt.UTC) - dt.timedelta(days=3)).isoformat(),
         }
         library.ingest_state = state
         await session.commit()
@@ -1601,3 +1580,125 @@ async def test_since_last_scope_widens_after_a_missed_sync(client, queue_stub, w
     assert obs["feed_scope"] == "since_last"
     assert obs["feed_since"] == (today - dt.timedelta(days=3)).isoformat()
     assert obs["feed_total"] == 2, "漏掉那两天的论文被补扫回来"
+
+
+# ---- 相关性不足的论文直接删除，不进回收站 ----
+
+
+async def _seed_feed(session, project_id, specs):
+    """往每日池里放几篇论文（用今天，否则会被 since_last 的窗口筛掉）。返回 id 列表。"""
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+
+    ids = []
+    for aid, title, abstract in specs:
+        paper = new_paper(
+            source="arxiv",
+            arxiv_id=aid,
+            title=title,
+            abstract=abstract,
+            year=2026,
+            published_at=dt.datetime.now(dt.UTC),
+        )
+        session.add(paper)
+        await session.flush()
+        ids.append(paper.id)
+        session.add(DailyFeedEntry(paper_id=paper.id, feed_date=_today(), primary_category="cs.AI"))
+    await session.commit()
+    return ids
+
+
+async def _run_incremental(client, project_id, headers):
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "incremental", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+    return (await client.get(f"/api/voyages/{resp.json()['id']}", headers=headers)).json()
+
+
+async def _bootstrap(client, project_id, headers):
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+
+async def test_irrelevant_papers_are_deleted_not_trashed(client, queue_stub, wiki_mocks):
+    """相关性不达标的论文直接删成员行，不落回收站；论文本体留在每日池里。
+
+    自动淘汰每天上百篇，堆在回收站里没人会去翻，还会把用户手动删的那几篇淹掉。
+    """
+    from sqlalchemy import select
+
+    from app.models.library_direction import LibraryPaper
+    from app.models.paper import Paper
+
+    project_id, headers = await _setup_project(client)
+    await _bootstrap(client, project_id, headers)
+
+    async with get_sessionmaker()() as session:
+        kept_id, dropped_id = await _seed_feed(
+            session,
+            project_id,
+            [
+                ("2607.95000", "Feed Planning Agent", "research agents and planning"),
+                ("2607.95001", "Totally irrelevant paper", "irrelevant to this direction"),
+            ],
+        )
+
+    detail = await _run_incremental(client, project_id, headers)
+    assert detail["status"] == "done", detail
+
+    async with get_sessionmaker()() as session:
+        members = {
+            m.paper_id: m
+            for m in (
+                await session.execute(
+                    select(LibraryPaper).where(LibraryPaper.paper_id.in_([kept_id, dropped_id]))
+                )
+            )
+            .scalars()
+            .all()
+        }
+        # 达标的留在库里（打分后流水线继续走，状态会推进到 fetched/compiled）
+        assert kept_id in members
+        assert members[kept_id].status in ("scored", "fetched", "compiled", "included")
+        # 关键：不是 excluded，而是**根本没有这条成员行**
+        assert dropped_id not in members
+        # 论文本体还在——每日池仍然引用着它，别的库也还用得上
+        assert await session.get(Paper, dropped_id) is not None
+
+
+async def test_rejected_papers_are_not_scored_twice(client, queue_stub, wiki_mocks):
+    """成员行删了之后仍要挡住重复打分。
+
+    since_last 的扫描窗口和上次同步那天是重叠的，不记一笔的话，今天淘汰的论文
+    明天会再花一次 LLM——每库每天几百篇。
+    """
+    project_id, headers = await _setup_project(client)
+    await _bootstrap(client, project_id, headers)
+
+    async with get_sessionmaker()() as session:
+        await _seed_feed(
+            session,
+            project_id,
+            [("2607.96000", "Another irrelevant one", "irrelevant to this direction")],
+        )
+
+    await _run_incremental(client, project_id, headers)
+    after_first = await _relevance_call_count()
+
+    # 同一批池子再同步一次：那篇被淘汰的不该再打一次分
+    detail = await _run_incremental(client, project_id, headers)
+    assert detail["status"] == "done", detail
+    assert await _relevance_call_count() == after_first
+
+    obs = detail["steps"][0]["observation"]
+    assert obs["skipped_previously_rejected"] >= 1


### PR DESCRIPTION
Two related asks about what "deleted" should mean for a library.

## Irrelevant papers are deleted, not recycled

Papers that fail the relevance threshold during bootstrap or daily sync now have their membership row removed instead of being parked at `status="excluded"`. Automatic rejection runs to hundreds of papers a day per library; nobody browses that pile, and it buries the handful a user actually deleted by hand.

The paper itself stays in the content pool. `_paper_still_referenced` counts `DailyFeedEntry`, so a rejected paper the daily feed still holds is untouched and remains available to every other library; orphan collection reclaims it once nothing references it at all.

### The part that is not obvious

Removing the row also removes the dedupe that kept rejected papers out of the funnel on the next run — `_existing_keys` deliberately ignores status precisely so yesterday's rejects do not cost another LLM call today. And the `since_last` scan window overlaps the previous sync by a day (`feed_date >= last_run_date`, deliberately `>=` so a sync that runs before the pool is complete cannot skip papers forever).

So without something in its place, every library would re-score a few hundred papers every morning — roughly 4k redundant relevance calls a day across the eleven active libraries.

Libraries now keep a capped list of paper ids they have already judged and rejected, in the existing `ingest_state` JSON column (no migration). It is a duplicate guard sized to cover the overlap window, not an archive — ids only, capped at 5000, most recent first. The collection step reports `skipped_previously_rejected` so the funnel stays legible.

## Search stops returning the recycle bin

A paper the user deleted turning up in search results is more confusing than not finding it, especially when it is already gone from the list.

`keyword_search_papers` already filtered to the `library` status group. These did not:

| Path | Used by |
|---|---|
| `semantic_search_papers` | library semantic search |
| `semantic_search_chunks` | literature chat retrieval |
| `keyword_search_chunks` | literature chat, keyword fallback |
| `semantic_saved_entries` | personal library semantic search |

All four now apply the same rule. The explicit-`paper_ids` branches (shelf and personal-library chat, which pass their own already-filtered sets) are deliberately unchanged, and a test pins that.

## Verification

- Full backend suite: **885 passed**. `ruff check app` clean.
- New: two tests for the delete behaviour (row gone rather than `excluded`; paper body survives because the daily pool still references it) and one that a second sync over the same pool does not spend another relevance call. Both confirmed to fail without the fix.
- New: `test_search_excludes_trash.py` — keyword paper search, keyword chunk search, the recycle-bin listing still showing its contents, and the explicit-`paper_ids` branch staying unfiltered. Confirmed to fail without the fix.
- **Caveat, stated plainly:** the three pgvector paths are raw SQL and the test database is sqlite, so they cannot be exercised end to end here. They are covered by a source-level guard that fails if the filter is removed. That is weaker than an integration test and the test says so in its docstring.
- Seven existing assertions in `test_wiki_ingest.py` moved from "the rejected paper sits at `status=excluded`" to "its row is gone" — behaviour change, not a test relaxation.