### PR TITLE
feat(daily,papers): library filter + today's sync status, a "new today" view, and one shared detail layout

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -86,6 +86,8 @@ async def list_papers(
     category: str | None = Query(default=None, max_length=32),
     author: str | None = Query(default=None, max_length=200),
     affiliation: str | None = Query(default=None, max_length=200),
+    # 只看被某个文献库收录的（每日论文页按库筛选）
+    library_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DailyPage:
@@ -113,6 +115,7 @@ async def list_papers(
                 announce=announce,
                 author=author,
                 affiliation=affiliation,
+                library_id=library_id,
             )
             mode_used = "semantic"
             entry_by_paper = {paper.id: entry for entry, paper, _ in rows}
@@ -143,6 +146,7 @@ async def list_papers(
             category=category,
             author=author,
             affiliation=affiliation,
+            library_id=library_id,
         )
         return DailyPage(items=items, total=total, page=page, size=size, mode_used=mode_used)
     ready, ready_total = await daily_service.embedding_coverage(session)

--- a/src/backend/app/api/lab.py
+++ b/src/backend/app/api/lab.py
@@ -13,7 +13,12 @@ from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.models.user import User
 from app.schemas.graph import GraphResponse
-from app.schemas.lab import LabLeaderboardEntry, LabLeaderboardResponse, LabStats
+from app.schemas.lab import (
+    DailyIngestStatusRow,
+    LabLeaderboardEntry,
+    LabLeaderboardResponse,
+    LabStats,
+)
 from app.schemas.llm_admin import UsageRow
 from app.services import lab as lab_service
 from app.services import llm_admin as llm_admin_service
@@ -28,6 +33,20 @@ async def lab_stats(
 ) -> LabStats:
     """实验室索引与内容统计（跨库论文去重；只算当前用户看得到的库）。"""
     return LabStats(**await lab_service.lab_stats(session, user))
+
+
+@router.get("/daily-ingest", response_model=list[DailyIngestStatusRow])
+async def daily_ingest_status(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DailyIngestStatusRow]:
+    """今天各库从每日论文自动收录的进展与结果（只列请求者看得见的库）。
+
+    抓取成功但一篇都没收进来，和抓取压根没触发同步，在界面上原本长得一模一样；
+    这条把每个库的漏斗摊开，让「今天到底收了什么」不用逐个点进任务详情才知道。
+    """
+    rows = await lab_service.daily_ingest_status(session, user)
+    return [DailyIngestStatusRow(**row) for row in rows]
 
 
 @router.get("/usage", response_model=list[UsageRow])

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -479,6 +479,9 @@ async def list_library_papers(
     published_to: datetime | None = Query(default=None),
     created_from: datetime | None = Query(default=None),
     created_to: datetime | None = Query(default=None),
+    daily_only: bool = Query(
+        default=False, description="只看从每日论文池自动收录的（今日新收录视图用）"
+    ),
     sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
@@ -507,6 +510,7 @@ async def list_library_papers(
         published_to=published_to,
         created_from=created_from,
         created_to=created_to,
+        daily_only=daily_only,
         user_id=user.id,
         sort=sort,
         page=page,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -152,6 +152,9 @@ async def list_papers(
     published_to: datetime | None = Query(default=None),
     created_from: datetime | None = Query(default=None),
     created_to: datetime | None = Query(default=None),
+    daily_only: bool = Query(
+        default=False, description="只看从每日论文池自动收录的（今日新收录视图用）"
+    ),
     sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
@@ -180,6 +183,7 @@ async def list_papers(
         published_to=published_to,
         created_from=created_from,
         created_to=created_to,
+        daily_only=daily_only,
     )
     # 库标签按课题的关联库并集显示（与 tag 过滤同口径，翻页也稳定）
     library_ids = await libraries_service.get_source_library_ids(session, project_id)

--- a/src/backend/app/schemas/lab.py
+++ b/src/backend/app/schemas/lab.py
@@ -1,6 +1,7 @@
 """实验室数据面板 schema（/lab 概况页）。"""
 
 import uuid
+from datetime import datetime
 
 from pydantic import BaseModel
 
@@ -60,3 +61,22 @@ class LabLeaderboardResponse(BaseModel):
     enabled: bool
     days: int
     items: list[LabLeaderboardEntry]
+
+
+class DailyIngestStatusRow(BaseModel):
+    """某个库最近一轮「从每日论文自动收录」的漏斗与状态。"""
+
+    library_id: uuid.UUID
+    library_name: str
+    is_public: bool
+    voyage_id: uuid.UUID
+    status: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    # 池子里扫了多少 → 送进打分多少 → 收下多少 / 淘汰多少 → 编译了多少
+    feed_total: int = 0
+    candidates: int = 0
+    admitted: int = 0
+    rejected: int = 0
+    compiled: int = 0
+    step_status: dict[str, str] = {}

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -642,10 +642,25 @@ async def list_papers(
     category: str | None = None,
     author: str | None = None,
     affiliation: str | None = None,
+    library_id: uuid.UUID | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
     if date is not None:
         stmt = stmt.where(DailyFeedEntry.feed_date == date)
+    if library_id is not None:
+        # 「这篇被哪个库收进去了」：只算真正收录的成员行，候选和回收站不算
+        from app.models.library_direction import LibraryPaper
+        from app.services.papers import PAPER_STATUS_GROUPS
+
+        stmt = stmt.where(
+            Paper.id.in_(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
+            )
+        )
+
     if q:
         stmt = stmt.where(Paper.title.ilike(f"%{q.strip()}%"))
     # 作者 / 机构：在 JSON 列上做文本包含匹配（同 services/papers.apply_paper_filters 口径）
@@ -689,6 +704,7 @@ async def semantic_search_daily(
     announce: str | None = None,
     author: str | None = None,
     affiliation: str | None = None,
+    library_id: uuid.UUID | None = None,
 ) -> list[tuple[DailyFeedEntry, Paper, float]]:
     """池内向量检索（pgvector 余弦；仅 postgres，调用方先判 semantic_search_supported）。
 
@@ -719,6 +735,16 @@ async def semantic_search_daily(
     if affiliation:
         where.append("CAST(p.affiliations AS text) ILIKE :affiliation_like")
         params["affiliation_like"] = f"%{affiliation}%"
+    if library_id is not None:
+        from app.services.papers import PAPER_STATUS_GROUPS
+
+        where.append(
+            "EXISTS (SELECT 1 FROM library_papers lp WHERE lp.paper_id = p.id "
+            "AND lp.library_id = :library_id "
+            "AND lp.status = ANY(CAST(:lib_statuses AS varchar[])))"
+        )
+        params["library_id"] = str(library_id)
+        params["lib_statuses"] = list(PAPER_STATUS_GROUPS["library"])
     rows = (
         await session.execute(
             text(

--- a/src/backend/app/services/lab.py
+++ b/src/backend/app/services/lab.py
@@ -10,7 +10,7 @@
 """
 
 import uuid
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import func, select
@@ -24,6 +24,7 @@ from app.models.paper import Concept, Paper, PaperChunk
 from app.models.system_setting import SystemSetting
 from app.models.user import User
 from app.models.vectors import PaperChunkVector, PaperVector
+from app.models.voyage import VoyageRun, VoyageStep
 from app.services import graph as graph_service
 from app.services.chunks import chunk_vector_search_supported
 from app.services.concepts import library_concept_ids
@@ -57,6 +58,108 @@ async def visible_libraries(session: AsyncSession, user: User) -> list[Direction
         .all()
     )
     return [lib for lib in rows if library_visible_to(lib, user)]
+
+
+# ---- 每日同步收录状态 ----
+
+
+TERMINAL_RUN_STATUSES = ("done", "failed", "cancelled")
+
+_INGEST_STEP_KEYS = {
+    "wiki.search_candidates": "candidates",
+    "wiki.score_relevance": "score",
+    "wiki.compile": "compile",
+}
+
+
+async def daily_ingest_status(
+    session: AsyncSession, user: User, *, since: datetime | None = None
+) -> list[dict[str, Any]]:
+    """各可见库最近一轮「从每日论文自动收录」的进展与结果。
+
+    每日抓取跑完会给每个到期的库起一轮 wiki_ingest；这里把那一轮的漏斗数字摊开，
+    让人在每日新论文那张卡上就能看出「今天扫了多少、收了多少、还在跑没有」，
+    而不必逐个库点进任务详情。只列请求者看得见的库。
+    """
+    libraries = await visible_libraries(session, user)
+    if not libraries:
+        return []
+    by_id = {lib.id: lib for lib in libraries}
+    if since is None:
+        now = datetime.now(UTC)
+        since = datetime(now.year, now.month, now.day, tzinfo=UTC)
+
+    runs = (
+        (
+            await session.execute(
+                select(VoyageRun)
+                .where(
+                    VoyageRun.kind == "wiki_ingest",
+                    VoyageRun.library_id.in_(list(by_id)),
+                    VoyageRun.created_at >= since,
+                )
+                .order_by(VoyageRun.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # 一个库当天可能被手动多触发几次，只看最近那轮
+    latest: dict[uuid.UUID, VoyageRun] = {}
+    for run in runs:
+        if run.library_id is not None and run.library_id not in latest:
+            latest[run.library_id] = run
+    if not latest:
+        return []
+
+    steps = (
+        (
+            await session.execute(
+                select(VoyageStep).where(VoyageStep.run_id.in_([r.id for r in latest.values()]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_run: dict[uuid.UUID, dict[str, dict[str, Any]]] = {}
+    for step in steps:
+        key = _INGEST_STEP_KEYS.get(step.action)
+        if key is None:
+            continue
+        by_run.setdefault(step.run_id, {})[key] = {
+            "status": step.status,
+            "observation": step.observation or {},
+        }
+
+    items: list[dict[str, Any]] = []
+    for library_id, run in latest.items():
+        parts = by_run.get(run.id, {})
+        candidates = parts.get("candidates", {}).get("observation", {})
+        score = parts.get("score", {}).get("observation", {})
+        compiled = parts.get("compile", {}).get("observation", {})
+        succeeded = int(score.get("succeeded") or 0)
+        rejected = int(score.get("excluded") or 0)
+        items.append(
+            {
+                "library_id": library_id,
+                "library_name": by_id[library_id].name,
+                "is_public": by_id[library_id].is_public,
+                "voyage_id": run.id,
+                "status": run.status,
+                "started_at": run.created_at,
+                # VoyageRun 没有独立的完成时间，终态时 updated_at 就是它
+                "finished_at": run.updated_at if run.status in TERMINAL_RUN_STATUSES else None,
+                # 漏斗：池子里扫了多少 → 送进打分多少 → 收下多少 → 编译了多少
+                "feed_total": int(candidates.get("feed_total") or 0),
+                "candidates": int(candidates.get("inserted") or 0),
+                "admitted": max(0, succeeded - rejected),
+                "rejected": rejected,
+                "compiled": int(compiled.get("succeeded") or 0),
+                "step_status": {k: v["status"] for k, v in parts.items()},
+            }
+        )
+    items.sort(key=lambda it: (-it["admitted"], it["library_name"]))
+    return items
 
 
 # ---- 索引与内容统计 ----

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -178,6 +178,7 @@ def apply_paper_filters(
     published_to: datetime | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
+    daily_only: bool = False,
 ) -> Select:
     """论文列表 / 引用导出共用的过滤条件（作用于已 join 成员表的语句）。
 
@@ -214,6 +215,9 @@ def apply_paper_filters(
         stmt = stmt.where(LibraryPaper.created_at >= created_from)
     if created_to:
         stmt = stmt.where(LibraryPaper.created_at <= created_to)
+    if daily_only:
+        # 「今日新收录」只认从每日论文池自动进来的：手动加的、引文扩展来的不算
+        stmt = stmt.where(Paper.id.in_(select(DailyFeedEntry.paper_id)))
     if tag and library_ids:
         stmt = stmt.where(
             Paper.id.in_(
@@ -268,6 +272,7 @@ async def list_papers(
     published_to: datetime | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
+    daily_only: bool = False,
 ) -> tuple[Sequence[PaperView], int]:
     """库内论文列表。入口二选一：library_id（单库读视图/库工作台）或 project_id
     （课题成员视角 = 关联库并集，P7）。project_id 兼作 PaperView 的课题上下文回填。
@@ -293,6 +298,7 @@ async def list_papers(
         published_to=published_to,
         created_from=created_from,
         created_to=created_to,
+        daily_only=daily_only,
     )
 
     if len(library_ids) == 1:

--- a/src/backend/tests/test_daily_library_visibility.py
+++ b/src/backend/tests/test_daily_library_visibility.py
@@ -1,0 +1,173 @@
+"""每日论文页看得见「哪个库收了它」（#218）+ 实验室工作台的同步收录状态。
+
+抓取成功但一篇都没收进来，和抓取压根没触发同步，在界面上原本长得一模一样——
+这两组接口就是为了把这层黑箱打开。
+"""
+
+import datetime as dt
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.models.daily_feed import DailyFeedEntry
+from app.models.voyage import VoyageRun, VoyageStep
+from tests.conftest import add_paper, register_and_login
+
+
+def _today() -> dt.date:
+    return dt.datetime.now(dt.UTC).date()
+
+
+async def _setup(client):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "daily-vis", "statement": "agent planning"},
+        headers=headers,
+    )
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        collected = await add_paper(
+            session, project_id=project_id, title="Collected One", status="compiled"
+        )
+        passed_over = await add_paper(
+            session, project_id=project_id, title="Passed Over", status="candidate"
+        )
+        session.add_all([collected, passed_over])
+        await session.flush()
+        # 两篇都在每日池里；只有一篇真正被库收录
+        for paper in (collected, passed_over):
+            session.add(
+                DailyFeedEntry(paper_id=paper.id, feed_date=_today(), primary_category="cs.AI")
+            )
+        library_id = collected.id  # 占位，下面用真实库 id 覆盖
+        await session.commit()
+        collected_id, passed_id = collected.id, passed_over.id
+
+    libs = (await client.get("/api/libraries", headers=headers)).json()
+    library_id = libs[0]["id"] if isinstance(libs, list) else libs["items"][0]["id"]
+    return project_id, headers, collected_id, passed_id, uuid.UUID(library_id)
+
+
+async def test_daily_list_can_filter_by_collecting_library(client):
+    _pid, headers, collected_id, passed_id, library_id = await _setup(client)
+
+    everything = (await client.get("/api/daily/papers?size=50", headers=headers)).json()
+    ids = {row["paper_id"] for row in everything["items"]}
+    assert {str(collected_id), str(passed_id)} <= ids
+
+    scoped = (
+        await client.get(f"/api/daily/papers?size=50&library_id={library_id}", headers=headers)
+    ).json()
+    scoped_ids = {row["paper_id"] for row in scoped["items"]}
+    assert str(collected_id) in scoped_ids
+    # 只是候选、还没被收录的不算「这个库收了它」
+    assert str(passed_id) not in scoped_ids
+    assert scoped["total"] == len(scoped_ids)
+
+
+async def test_daily_list_unknown_library_returns_nothing(client):
+    _pid, headers, _c, _p, _lib = await _setup(client)
+    resp = await client.get(f"/api/daily/papers?library_id={uuid.uuid4()}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+async def test_daily_ingest_status_reports_the_funnel(client):
+    _pid, headers, _c, _p, library_id = await _setup(client)
+
+    # 造一轮今天的同步任务及其三个步骤的观测
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="wiki_ingest",
+            mode="pipeline",
+            status="done",
+            goal="daily ingest",
+            library_id=library_id,
+        )
+        session.add(run)
+        await session.flush()
+        session.add_all(
+            [
+                VoyageStep(
+                    run_id=run.id,
+                    seq=1,
+                    title="候选",
+                    action="wiki.search_candidates",
+                    status="passed",
+                    observation={"feed_total": 435, "inserted": 12},
+                ),
+                VoyageStep(
+                    run_id=run.id,
+                    seq=2,
+                    title="打分",
+                    action="wiki.score_relevance",
+                    status="passed",
+                    observation={"succeeded": 12, "excluded": 4},
+                ),
+                VoyageStep(
+                    run_id=run.id,
+                    seq=3,
+                    title="编译",
+                    action="wiki.compile",
+                    status="passed",
+                    observation={"succeeded": 5},
+                ),
+            ]
+        )
+        await session.commit()
+
+    rows = (await client.get("/api/lab/daily-ingest", headers=headers)).json()
+    mine = [r for r in rows if r["library_id"] == str(library_id)]
+    assert len(mine) == 1, rows
+    row = mine[0]
+    assert row["status"] == "done"
+    assert row["feed_total"] == 435
+    assert row["candidates"] == 12
+    assert row["admitted"] == 8  # 12 打分通过 - 4 淘汰
+    assert row["rejected"] == 4
+    assert row["compiled"] == 5
+    assert row["step_status"]["candidates"] == "passed"
+
+
+async def test_daily_ingest_status_hides_other_peoples_libraries(client):
+    """只列请求者看得见的库。
+
+    课题自带的隐式库是公共的（全员可读），所以这里专门建一个**个人库**——
+    个人库只有创建者和管理员看得见，别人不该在这张状态表里看到它的同步情况。
+    """
+    _pid, headers, _c, _p, _lib = await _setup(client)
+    created = await client.post(
+        "/api/libraries",
+        json={"name": "private-lib", "definition": {"statement": "secret direction"}},
+        headers=headers,
+    )
+    assert created.status_code in (200, 201), created.text
+    private_id = uuid.UUID(created.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        session.add(
+            VoyageRun(
+                kind="wiki_ingest",
+                mode="pipeline",
+                status="done",
+                goal="x",
+                library_id=private_id,
+            )
+        )
+        await session.commit()
+
+    owner_rows = (await client.get("/api/lab/daily-ingest", headers=headers)).json()
+    assert any(r["library_id"] == str(private_id) for r in owner_rows), owner_rows
+
+    other = await register_and_login(client, email="stranger@example.com")
+    rows = (
+        await client.get("/api/lab/daily-ingest", headers={"Authorization": f"Bearer {other}"})
+    ).json()
+    assert all(r["library_id"] != str(private_id) for r in rows)
+
+
+async def test_daily_ingest_status_is_empty_without_runs(client):
+    _pid, headers, _c, _p, _lib = await _setup(client)
+    assert (await client.get("/api/lab/daily-ingest", headers=headers)).json() == []

--- a/src/backend/tests/test_daily_library_visibility.py
+++ b/src/backend/tests/test_daily_library_visibility.py
@@ -171,3 +171,51 @@ async def test_daily_ingest_status_hides_other_peoples_libraries(client):
 async def test_daily_ingest_status_is_empty_without_runs(client):
     _pid, headers, _c, _p, _lib = await _setup(client)
     assert (await client.get("/api/lab/daily-ingest", headers=headers)).json() == []
+
+
+async def test_library_list_can_show_only_todays_daily_collections(client):
+    """文献库列表的「今日新收录」：今天入库 + 来自每日论文池，两个条件都要满足。"""
+    import datetime as dt
+
+    from sqlalchemy import select as sa_select
+
+    from app.models.library_direction import LibraryPaper
+
+    project_id, headers, collected_id, _passed_id, _lib = await _setup(client)
+
+    async with get_sessionmaker()() as session:
+        # 一篇手工加的（不在每日池里），今天入库——不该出现在「今日新收录」里
+        manual = await add_paper(
+            session, project_id=project_id, title="Manually Added", status="compiled"
+        )
+        session.add(manual)
+        await session.flush()
+        manual_id = manual.id
+        # 一篇来自每日池但是昨天入库的——也不该出现
+        old = await add_paper(
+            session, project_id=project_id, title="Collected Yesterday", status="compiled"
+        )
+        session.add(old)
+        await session.flush()
+        session.add(DailyFeedEntry(paper_id=old.id, feed_date=_today(), primary_category="cs.AI"))
+        await session.flush()
+        yesterday = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+        membership = (
+            await session.execute(sa_select(LibraryPaper).where(LibraryPaper.paper_id == old.id))
+        ).scalar_one()
+        membership.created_at = yesterday
+        old_id = old.id
+        await session.commit()
+
+    since = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)).isoformat()
+    resp = await client.get(
+        f"/api/projects/{project_id}/papers",
+        # 走 params 而不是拼串：ISO 时间里的 + 号在 URL 里会被当成空格
+        params={"status": "library", "daily_only": "true", "created_from": since},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()["items"]}
+    assert str(collected_id) in ids
+    assert str(manual_id) not in ids, "手工加的不算「从每日论文自动收录」"
+    assert str(old_id) not in ids, "昨天入库的不算今天新收录"

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -416,6 +416,9 @@ function DailyDetailPane({
         <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
       )}
 
+      {/* —— 概念 chips（与库版同款；点了进不限库的概念页） —— */}
+      <ConceptChips concepts={paper.concepts} onOpen={openConcept} />
+
       {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
       <MetaFold>
         <MetaItem label="arxiv_id">
@@ -434,14 +437,10 @@ function DailyDetailPane({
       </MetaFold>
 
       {/* 摘要默认折叠，复用元信息那套折叠块的样式，两者视觉一致 */}
-      {paper.abstract ? (
+      {paper.abstract && (
         <MetaFold label={tr('摘要', 'Abstract')}>
           <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
         </MetaFold>
-      ) : (
-        <div className="empty" style={{ padding: 20, marginTop: 18 }}>
-          {tr('这篇还没有摘要。', 'No abstract for this paper.')}
-        </div>
       )}
 
       {/* —— TL;DR（来自内容池详情） —— */}
@@ -463,9 +462,6 @@ function DailyDetailPane({
           {poolPaper.tldr}
         </div>
       )}
-
-      {/* —— 概念 chips（与库版同款；点了进不限库的概念页） —— */}
-      <ConceptChips concepts={paper.concepts} onOpen={openConcept} />
 
       {/* —— 我的笔记（只有自己看得到） —— */}
       {poolPaper && (

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -612,6 +612,8 @@ export function DailyPage() {
   const [page, setPage] = useState(1);
   // —— 日期（null=全部，默认就停在全部）留在工具栏；分类 / 类型收进高级检索面板 ——
   const [day, setDay] = useState<string | null>(null);
+  // 只看被某个文献库收录的论文（#218）。空 = 不限
+  const [libraryId, setLibraryId] = useState('');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
   const [advOpen, setAdvOpen] = useState(true);
   const [category, setCategory] = useState('');
@@ -622,7 +624,8 @@ export function DailyPage() {
   const author = useDebounced(authorInput.trim());
   const affiliation = useDebounced(affiliationInput.trim());
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
-  const advActive = !!category || announce !== DEFAULT_ANNOUNCE || !!author || !!affiliation;
+  const advActive =
+    !!category || announce !== DEFAULT_ANNOUNCE || !!author || !!affiliation || !!libraryId;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -688,6 +691,7 @@ export function DailyPage() {
       setAuthorInput(patch.author ?? '');
       setAffiliationInput(patch.affiliation ?? '');
       setCategory('');
+      setLibraryId('');
       setAnnounce('all');
       setAdvOpen(true);
       pickDay(null);
@@ -711,11 +715,21 @@ export function DailyPage() {
     retry: false,
     staleTime: 300_000,
   });
+  // 按库筛选的候选：后端只回请求者看得见的库，这里照单全收
+  const librariesQuery = useQuery({
+    queryKey: ['libraries-for-daily-filter'],
+    queryFn: () => api.listLibraries(),
+    retry: false,
+    staleTime: 300_000,
+  });
 
   // 语义检索：只在有关键词时生效；结果按相关度排序、不分页
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
-    queryKey: ['daily-papers', semanticOn, page, q, day, category, announce, author, affiliation],
+    queryKey: [
+      'daily-papers',
+      semanticOn, page, q, day, category, announce, author, affiliation, libraryId,
+    ],
     queryFn: () =>
       api.listDailyPapers({
         sort: semantic ? undefined : DAILY_SORT,
@@ -727,6 +741,7 @@ export function DailyPage() {
         announce: announce === 'all' ? undefined : announce,
         author: author || undefined,
         affiliation: affiliation || undefined,
+        libraryId: libraryId || undefined,
         mode: semantic ? 'semantic' : undefined,
       }),
     retry: false,
@@ -897,6 +912,7 @@ export function DailyPage() {
                     advActive
                       ? () => {
                           setCategory('');
+                          setLibraryId('');
                           setAnnounce(DEFAULT_ANNOUNCE);
                           setAuthorInput('');
                           setAffiliationInput('');
@@ -904,6 +920,25 @@ export function DailyPage() {
                       : undefined
                   }
                 >
+                  <div className="row gap6" style={{ alignItems: 'center' }}>
+                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
+                      {tr('文献库', 'Library')}
+                    </span>
+                    <select
+                      className="input"
+                      style={{ flex: 1, minWidth: 0, height: 26, fontSize: 11, padding: '0 6px' }}
+                      value={libraryId}
+                      onChange={(e) => setLibraryId(e.target.value)}
+                      title={tr('只看被某个文献库收录的论文', 'Only papers collected by one library')}
+                    >
+                      <option value="">{tr('全部文献库', 'All libraries')}</option>
+                      {(librariesQuery.data ?? []).map((lib) => (
+                        <option key={lib.id} value={lib.id}>
+                          {lib.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                   <div className="row gap6" style={{ alignItems: 'center' }}>
                     <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
                       {tr('分类', 'Category')}

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -8,7 +8,14 @@ import { Segmented } from '../../components/ui/Segmented';
 import { StatCard } from '../../components/ui/StatCard';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { useProject } from '../../app/project';
-import { api, isAdmin, type DirectionLibrarySummary, type LabStats, type VoyageRead } from '../../lib/api';
+import {
+  api,
+  isAdmin,
+  type DailyIngestStatus,
+  type DirectionLibrarySummary,
+  type LabStats,
+  type VoyageRead,
+} from '../../lib/api';
 import { fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 import { stageLabel } from '../../lib/stageLabels';
@@ -175,6 +182,51 @@ function LibrariesCard() {
 }
 
 
+/** 一个库今天的收录情况：状态点 + 名字 + 「扫 N → 收 M」。点进去看那轮任务详情。 */
+function IngestRow({ row }: { row: DailyIngestStatus }) {
+  const running = !['done', 'failed', 'cancelled', 'paused_error'].includes(row.status);
+  const broken = row.status === 'failed' || row.status === 'paused_error';
+  const dot = running ? 'var(--accent)' : broken ? 'var(--danger)' : 'var(--ok)';
+  return (
+    <Link
+      to={`/voyages/${row.voyage_id}`}
+      className="row gap8"
+      style={{
+        alignItems: 'center', padding: '6px 0', textDecoration: 'none',
+        color: 'inherit', borderTop: '0.5px solid var(--border)',
+      }}
+      title={tr(
+        `扫过 ${row.feed_total} 篇，送评 ${row.candidates} 篇，收下 ${row.admitted} 篇，淘汰 ${row.rejected} 篇，编译 ${row.compiled} 篇`,
+        `${row.feed_total} scanned, ${row.candidates} scored, ${row.admitted} kept, ${row.rejected} dropped, ${row.compiled} compiled`,
+      )}
+    >
+      <span
+        style={{
+          width: 6, height: 6, borderRadius: '50%', background: dot, flexShrink: 0,
+          animation: running ? 'pulse 1.4s ease-in-out infinite' : undefined,
+        }}
+      />
+      <span style={{ flex: 1, minWidth: 0, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {row.library_name}
+      </span>
+      {running ? (
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+          {tr('同步中', 'Syncing')}
+        </span>
+      ) : broken ? (
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--danger)' }}>
+          {tr('未完成', 'Unfinished')}
+        </span>
+      ) : (
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+          {row.feed_total} → <span style={{ color: 'var(--text-1)', fontWeight: 650 }}>{row.admitted}</span>
+        </span>
+      )}
+      <Icon name="chevron" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+    </Link>
+  );
+}
+
 /** 每日新论文汇总卡：今日新增 / 近 7 天合计 + 最近 7 天迷你分布（单色柱，标签用文本色）。 */
 function DailyCard() {
   const { data, isLoading, isError } = useQuery({
@@ -184,6 +236,30 @@ function DailyCard() {
     retry: false,
     staleTime: 60_000,
   });
+  // 保留天数由管理员配置，别写死
+  const retentionQuery = useQuery({
+    queryKey: ['daily-retention'],
+    queryFn: () => api.getDailyRetention(),
+    retry: false,
+    staleTime: 300_000,
+  });
+  const retentionDays = retentionQuery.data?.days ?? 14;
+  // 今天各库的收录情况：抓取成功但一篇没收，和压根没触发同步，看起来是一样的
+  const ingestQuery = useQuery({
+    queryKey: ['daily-ingest-status'],
+    queryFn: () => api.listDailyIngestStatus(),
+    retry: false,
+    staleTime: 30_000,
+    // 有库还在同步时自动刷新，跑完就停
+    refetchInterval: (query) => {
+      const rows = query.state.data ?? [];
+      const busy = rows.some(
+        (r) => !['done', 'failed', 'cancelled', 'paused_error'].includes(r.status),
+      );
+      return busy ? 15_000 : false;
+    },
+  });
+  const ingestRows = ingestQuery.data ?? [];
 
   const days = useMemo(() => [...(data ?? [])].sort((a, b) => a.date.localeCompare(b.date)).slice(-7), [data]);
   // 「最新一批」而非「今天」：arxiv 按 UTC 出批次，用本地日期匹配会在跨时区/周末显示 0
@@ -201,7 +277,10 @@ function DailyCard() {
             {tr('每日新论文', 'Daily Papers')}
           </div>
           <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2 }}>
-            {tr('arXiv 每日新提交，保留最近 7 天', 'New arXiv submissions, last 7 days kept')}
+            {tr(
+              `arXiv 每日新提交，保留最近 ${retentionDays} 天`,
+              `New arXiv submissions, last ${retentionDays} days kept`,
+            )}
           </div>
         </div>
         <Link className="btn btn-soft sm" to="/daily">
@@ -279,6 +358,35 @@ function DailyCard() {
                 </div>
               </Link>
             ))}
+          </div>
+
+          {/* 今天各库收了什么。列表只到「扫了多少 → 收了多少」，完整漏斗在 title 里，
+              点进去是那轮任务详情——这里是概览，不该把五个数字都摊在卡片上。 */}
+          <div style={{ marginTop: 16 }}>
+            <div className="row gap6" style={{ alignItems: 'baseline', marginBottom: 4 }}>
+              <span style={{ fontSize: 11.5, color: 'var(--text-2)', fontWeight: 600 }}>
+                {tr('文献库自动收录', 'Auto-collected into libraries')}
+              </span>
+              <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+                {tr('今天', 'today')}
+              </span>
+            </div>
+            {ingestQuery.isLoading ? (
+              <div className="skel" style={{ height: 44, width: '100%' }} />
+            ) : ingestRows.length === 0 ? (
+              <div style={{ fontSize: 11, color: 'var(--text-4)', padding: '6px 0' }}>
+                {tr(
+                  '今天还没有文献库同步过。每日抓取跑完会自动触发。',
+                  'No library has synced today. The daily fetch triggers it once the pool is ready.',
+                )}
+              </div>
+            ) : (
+              <div className="col">
+                {ingestRows.map((row) => (
+                  <IngestRow key={row.library_id} row={row} />
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -213,7 +213,6 @@ function PaperDetailPane({
 }) {
   const navigate = useNavigate();
   const location = useLocation();
-  const [abstractOpen, setAbstractOpen] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
   const openReader = useCallback(() => {
@@ -243,9 +242,9 @@ function PaperDetailPane({
     [detailKey, libraryId],
   );
 
-  // 换论文时收起本地开合状态（面板不随选中项重挂载，得自己收）
+  // 换论文时收起本地开合状态（面板不随选中项重挂载，得自己收）。
+  // 折叠块的开合在 MetaFold 内部，用 key={paperId} 让它随论文重挂载即可。
   useEffect(() => {
-    setAbstractOpen(false);
     setReaderOpen(false);
   }, [paperId]);
 
@@ -374,8 +373,11 @@ function PaperDetailPane({
         invalidateKeys={listKeys}
       />
 
+      {/* —— 概念 chips（过多时折叠） —— */}
+      <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />
+
       {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
-      <MetaFold>
+      <MetaFold key={`meta-${paperId}`}>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -395,30 +397,11 @@ function PaperDetailPane({
         </MetaItem>
       </MetaFold>
 
-      {/* —— 概念 chips（过多时折叠） —— */}
-      <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />
-
-      {/* —— 摘要（折叠） —— */}
+      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
       {paper.abstract && (
-        <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
-          <div
-            className="row"
-            onClick={() => setAbstractOpen((o) => !o)}
-            style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
-          >
-            <span style={{ fontSize: 12.5, fontWeight: 650 }}>{tr('摘要', 'Abstract')}</span>
-            <Icon
-              name="chevDown"
-              size={14}
-              style={{ color: 'var(--text-3)', transform: abstractOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
-            />
-          </div>
-          {abstractOpen && (
-            <div style={{ padding: '0 16px 14px', fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>
-              {paper.abstract}
-            </div>
-          )}
-        </div>
+        <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
+        </MetaFold>
       )}
 
       {/* —— TL;DR —— */}

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -327,6 +327,9 @@ export function LibraryDetailPane({
         />
       )}
 
+      {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
+      {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}
+
       {/* —— frontmatter 风格元信息（默认折叠） —— */}
       <MetaFold>
         <MetaItem label="arxiv_id">
@@ -344,8 +347,12 @@ export function LibraryDetailPane({
         )}
       </MetaFold>
 
-      {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
-      {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}
+      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
+      {abstract && (
+        <MetaFold label={tr('摘要', 'Abstract')}>
+          <div style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{abstract}</div>
+        </MetaFold>
+      )}
 
       {/* —— TL;DR —— */}
       {tldr && (
@@ -364,16 +371,6 @@ export function LibraryDetailPane({
             TL;DR
           </span>
           {tldr}
-        </div>
-      )}
-
-      {/* —— 摘要 —— */}
-      {abstract && (
-        <div style={{ marginTop: 18 }}>
-          <div className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em', marginBottom: 6 }}>
-            {tr('摘要', 'Abstract')}
-          </div>
-          <div style={{ fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>{abstract}</div>
         </div>
       )}
 

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -400,14 +400,8 @@ export function ShelfDetailPane({
       {/* —— 课题备注：为什么相关（仅书架内论文；这条是课题里公开的说明） —— */}
       {onShelf && <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />}
 
-      {/* —— 我的笔记（只有自己看得到，和上面的课题备注是两回事） —— */}
-      {paper && (
-        <PaperNotesSection
-          paperId={item.paper_id}
-          noteCount={paper.note_count ?? 0}
-          invalidateKeys={noteKeys}
-        />
-      )}
+      {/* —— 概念 chips：点了进不限库的概念页 —— */}
+      <ConceptChips concepts={paper?.concepts} onOpen={openConcept} />
 
       {/* —— frontmatter 风格元信息（默认折叠） —— */}
       <MetaFold>
@@ -446,8 +440,12 @@ export function ShelfDetailPane({
         </MetaItem>
       </MetaFold>
 
-      {/* —— 概念 chips：点了进不限库的概念页 —— */}
-      <ConceptChips concepts={paper?.concepts} onOpen={openConcept} />
+      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
+      {abstract && (
+        <MetaFold label={tr('摘要', 'Abstract')}>
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{abstract}</div>
+        </MetaFold>
+      )}
 
       {/* —— TL;DR —— */}
       {tldr && (
@@ -469,14 +467,13 @@ export function ShelfDetailPane({
         </div>
       )}
 
-      {/* —— 摘要 —— */}
-      {abstract && (
-        <div style={{ marginTop: 18 }}>
-          <div className="mono" style={{ fontSize: 11, color: 'var(--text-4)', letterSpacing: '0.04em', marginBottom: 6 }}>
-            {tr('摘要', 'Abstract')}
-          </div>
-          <div style={{ fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>{abstract}</div>
-        </div>
+      {/* —— 我的笔记（只有自己看得到，和上面的课题备注是两回事） —— */}
+      {paper && (
+        <PaperNotesSection
+          paperId={item.paper_id}
+          noteCount={paper.note_count ?? 0}
+          invalidateKeys={noteKeys}
+        />
       )}
 
       {/* —— 重要图片画廊（只读：提取/重新提取是库维护动作） —— */}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -44,7 +44,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
-import { PaperMyTagChips, PaperMyTagsRow } from '../shared/PaperDetailBlocks';
+import { PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
@@ -59,19 +59,42 @@ const PAGE_SIZE = 20;
 
 /** 论文库视图（docs/api-lit.md §8.5）：全部 = 已纳入（相关性达标）的文献；
     相关性不足的进回收站，不显示不计数。 */
-type ViewFilter = 'all' | 'compiled' | 'starred';
+type ViewFilter = 'all' | 'compiled' | 'starred' | 'today';
 
 // 模块级常量存 zh/en 两份文案，渲染处再 tr（import 时求值不会随语言切换更新）
 const VIEW_FILTERS: { v: ViewFilter; zh: string; en: string; hintZh: string; hintEn: string }[] = [
   { v: 'all', zh: '全部', en: 'All', hintZh: '已纳入知识库的全部文献', hintEn: 'Every paper included in the library' },
   { v: 'compiled', zh: '已编译', en: 'Compiled', hintZh: 'AI 已精读编译出介绍', hintEn: 'Papers the AI has compiled an intro for' },
   { v: 'starred', zh: '已星标', en: 'Starred', hintZh: '我加了星标的文献', hintEn: 'Papers I starred' },
+  {
+    v: 'today',
+    zh: '今日新收录',
+    en: 'New today',
+    hintZh: '今天从每日论文自动收录进来的',
+    hintEn: 'Collected from the daily papers today',
+  },
 ];
 
+/** 今天 00:00（本地）的 ISO 串——「今日新收录」按入库时间卡这条线。 */
+function startOfToday(): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
 /** 视图 → 列表查询参数（未纳入/回收站文献一律不出现在论文库）。 */
-function viewQuery(view: ViewFilter): { status: PaperStatusFilter; starred?: boolean } {
+function viewQuery(view: ViewFilter): {
+  status: PaperStatusFilter;
+  starred?: boolean;
+  created_from?: string;
+  daily_only?: boolean;
+} {
   if (view === 'compiled') return { status: 'compiled_any' };
   if (view === 'starred') return { status: 'library', starred: true };
+  // 今日新收录：今天入库 + 来自每日论文池（手动加的、引文扩展来的不算）
+  if (view === 'today') {
+    return { status: 'library', created_from: startOfToday(), daily_only: true };
+  }
   return { status: 'library' };
 }
 
@@ -628,7 +651,6 @@ function PaperDetailPane({
   const location = useLocation();
   const queryClient = useQueryClient();
   const scopeId = libraryId ?? pid;
-  const [abstractOpen, setAbstractOpen] = useState(false);
   const [conceptsOpen, setConceptsOpen] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
   const [readerPrint, setReaderPrint] = useState(false);
@@ -680,9 +702,9 @@ function PaperDetailPane({
       toast(`${tr('更新失败：', 'Update failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  // 换论文时收起本地开合状态（面板不再随选中项重挂载，得自己收）
+  // 换论文时收起本地开合状态（面板不再随选中项重挂载，得自己收）。
+  // 折叠块的开合在 MetaFold 内部，用 key={paperId} 让它随论文重挂载即可。
   useEffect(() => {
-    setAbstractOpen(false);
     setConceptsOpen(false);
     setReaderOpen(false);
     setRecompileConfirm(false);
@@ -868,25 +890,6 @@ function PaperDetailPane({
         invalidateKeys={[['papers', scopeId]]}
       />
 
-      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
-      <MetaFold>
-        <MetaItem label="arxiv_id">{paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}</MetaItem>
-        <MetaItem label="doi">{paper.doi ? <span className="mono">{paper.doi}</span> : <span className="muted">—</span>}</MetaItem>
-        <MetaItem label="published">
-          {paper.published_at ? <span className="mono">{paper.published_at.slice(0, 10)}</span> : <span className="muted">—</span>}
-        </MetaItem>
-        <MetaItem label="relevance">
-          {relevance !== null ? (
-            <RelevanceBar value={relevance} width={140} />
-          ) : (
-            <span className="muted">{tr('未打分', 'not scored')}</span>
-          )}
-        </MetaItem>
-        <MetaItem label={tr('入库时间', 'added at')}>
-          <span className="mono">{fmtTime(paper.created_at)}</span>
-        </MetaItem>
-      </MetaFold>
-
       {/* —— 概念 chips（过多时折叠） —— */}
       {paper.concepts.length > 0 && (
         <div className="row gap8 wrap" style={{ marginTop: 16 }}>
@@ -914,27 +917,30 @@ function PaperDetailPane({
         </div>
       )}
 
-      {/* —— 摘要（折叠） —— */}
-      {paper.abstract && (
-        <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
-          <div
-            className="row"
-            onClick={() => setAbstractOpen((o) => !o)}
-            style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
-          >
-            <span style={{ fontSize: 12.5, fontWeight: 650 }}>{tr('摘要', 'Abstract')}</span>
-            <Icon
-              name="chevDown"
-              size={14}
-              style={{ color: 'var(--text-3)', transform: abstractOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
-            />
-          </div>
-          {abstractOpen && (
-            <div style={{ padding: '0 16px 14px', fontSize: 12.5, lineHeight: 1.7, color: 'var(--text-2)' }}>
-              {paper.abstract}
-            </div>
+      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
+      <MetaFold key={`meta-${paperId}`}>
+        <MetaItem label="arxiv_id">{paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}</MetaItem>
+        <MetaItem label="doi">{paper.doi ? <span className="mono">{paper.doi}</span> : <span className="muted">—</span>}</MetaItem>
+        <MetaItem label="published">
+          {paper.published_at ? <span className="mono">{paper.published_at.slice(0, 10)}</span> : <span className="muted">—</span>}
+        </MetaItem>
+        <MetaItem label="relevance">
+          {relevance !== null ? (
+            <RelevanceBar value={relevance} width={140} />
+          ) : (
+            <span className="muted">{tr('未打分', 'not scored')}</span>
           )}
-        </div>
+        </MetaItem>
+        <MetaItem label={tr('入库时间', 'added at')}>
+          <span className="mono">{fmtTime(paper.created_at)}</span>
+        </MetaItem>
+      </MetaFold>
+
+      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
+      {paper.abstract && (
+        <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
+        </MetaFold>
       )}
 
       {/* —— TL;DR —— */}
@@ -956,6 +962,13 @@ function PaperDetailPane({
           {paper.tldr}
         </div>
       )}
+
+      {/* —— 我的笔记（只有自己看得到；与其余四处详情面板同一顺序） —— */}
+      <PaperNotesSection
+        paperId={paper.id}
+        noteCount={paper.note_count ?? 0}
+        invalidateKeys={[['papers'], ['paper', paper.id]]}
+      />
 
       {/* —— 重要图片画廊（有图显示；正文已嵌图时默认折叠，避免重复视觉） —— */}
       <FiguresSection paper={paper} defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)} />
@@ -1178,8 +1191,9 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
   const listQuery = useInfiniteQuery({
     queryKey: ['papers', scopeId, view, q, sort, myTagFilter, readingFilter, author, affiliation, advPubFrom, advPubTo, advCreatedFrom, advCreatedTo],
     queryFn: ({ pageParam }) => {
+      const vq = viewQuery(view);
       const opts = {
-        ...viewQuery(view),
+        ...vq,
         q: q || undefined,
         sort,
         my_tag: myTagFilter || undefined,
@@ -1188,7 +1202,8 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
         affiliation: affiliation || undefined,
         published_from: advPubFrom ? `${advPubFrom}T00:00:00Z` : undefined,
         published_to: advPubTo ? `${advPubTo}T23:59:59Z` : undefined,
-        created_from: advCreatedFrom ? `${advCreatedFrom}T00:00:00Z` : undefined,
+        // 高级检索里显式选了入库日期就以它为准；没选则沿用视图自带的（今日新收录）
+        created_from: advCreatedFrom ? `${advCreatedFrom}T00:00:00Z` : vq.created_from,
         created_to: advCreatedTo ? `${advCreatedTo}T23:59:59Z` : undefined,
         page: pageParam,
         size: PAGE_SIZE,
@@ -1216,6 +1231,20 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
     if (semanticActive) return semQuery.data?.papers ?? [];
     return listQuery.data?.pages.flatMap((p) => p.items) ?? [];
   }, [semanticActive, semQuery.data, listQuery.data]);
+
+  // 「今日新收录」的顶行说明：这批是什么时候进来的。取最早/最晚的入库时间，
+  // 一次同步的论文时间挨得很近，所以多数时候就是一个时刻。
+  const fmtClock = (ms: number) =>
+    new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  const todayRange = useMemo(() => {
+    if (view !== 'today' || papers.length === 0) return null;
+    const times = papers
+      .map((p) => (p.created_at ? new Date(p.created_at).getTime() : 0))
+      .filter((t) => t > 0)
+      .sort((a, b) => a - b);
+    if (times.length === 0) return null;
+    return { first: times[0]!, last: times[times.length - 1]! };
+  }, [view, papers]);
 
   const isLoading = semanticActive ? semQuery.isLoading : listQuery.isLoading;
   const isError = semanticActive ? semQuery.isError : listQuery.isError;
@@ -1357,6 +1386,44 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
               </span>
             ))}
           </div>
+          {view === 'today' && (
+            <div
+              className="row gap6"
+              style={{
+                marginTop: 8, padding: '6px 9px', borderRadius: 6,
+                background: 'var(--bg-2)', fontSize: 11, color: 'var(--text-3)',
+                alignItems: 'baseline', flexWrap: 'wrap',
+              }}
+            >
+              <Icon name="refresh" size={11} style={{ color: 'var(--text-4)', flexShrink: 0 }} />
+              {todayRange ? (
+                <span>
+                  {tr(
+                    `${papers.length} 篇于今天 ${fmtClock(todayRange.first)}${
+                      fmtClock(todayRange.last) === fmtClock(todayRange.first)
+                        ? ''
+                        : `–${fmtClock(todayRange.last)}`
+                    } 从每日论文自动收录`,
+                    `${papers.length} papers auto-collected from the daily feed today at ${fmtClock(
+                      todayRange.first,
+                    )}${
+                      fmtClock(todayRange.last) === fmtClock(todayRange.first)
+                        ? ''
+                        : `–${fmtClock(todayRange.last)}`
+                    }`,
+                  )}
+                </span>
+              ) : (
+                <span>
+                  {tr(
+                    '今天还没有从每日论文自动收录进来的文献。',
+                    'Nothing has been auto-collected from the daily feed today.',
+                  )}
+                </span>
+              )}
+            </div>
+          )}
+
           {/* 我的标签 / 阅读状态过滤（库标签的界面入口已移除） */}
           <div className="row gap6" style={{ marginTop: 8, ...filterDisabled }}>
             <select

--- a/src/frontend/src/features/wiki/shared.tsx
+++ b/src/frontend/src/features/wiki/shared.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api, type ConceptCategory, type PaperAuthor, type ReadingStatus } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { clickable } from '../../lib/a11y';
-import { Icon } from '../../components/ui/Icon';
+import { Icon, type IconName } from '../../components/ui/Icon';
 import { Switch } from '../../components/ui/Switch';
 import { toast } from '../../components/ui/Toast';
 import { READING_STATUS } from '../reading/shared';
@@ -129,42 +129,52 @@ export function MetaItem({ label, children }: { label: string; children: ReactNo
 }
 
 /**
- * 元信息折叠块：论文详情四处面板（论文库 / 只读库 / 阅读页 / 个人库 / 相关研究）共用的
- * frontmatter 卡外壳。默认收起——这些字段查证时才看，别占着首屏。
+ * 详情面板的折叠块：论文详情四处面板（每日新论文 / 文献库 / 我的文献库 / 相关文献）
+ * 共用的卡外壳。元信息 / 摘要 / 我的笔记 一律用它，样式与「我的笔记」对齐，
+ * 默认全部收起——这些内容查证时才看，别占着首屏。
  */
 export function MetaFold({
   children,
   style,
   label,
+  icon,
+  count,
   defaultOpen = false,
 }: {
   children: ReactNode;
   style?: CSSProperties;
-  /** 折叠块标题，默认「元信息」。摘要等同类折叠块复用同一套样式，保持视觉一致。 */
+  /** 折叠块标题，默认「元信息」。 */
   label?: string;
+  /** 标题左侧的小图标（与「我的笔记」的笔形图标同位）。 */
+  icon?: IconName;
+  /** 标题右侧的计数（如笔记条数）；不传则不显示。 */
+  count?: number;
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <div
-      className="card"
-      style={{ margin: '18px 0 0', background: 'var(--surface-2)', overflow: 'hidden', ...style }}
-    >
+    <div className="card" style={{ marginTop: 18, overflow: 'hidden', ...style }}>
       <div
         className="row"
         {...clickable(() => setOpen((o) => !o))}
-        style={{ padding: '9px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+        style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
       >
-        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', letterSpacing: '0.04em' }}>
+        <span className="row gap6" style={{ fontSize: 12.5, fontWeight: 650 }}>
+          {icon && <Icon name={icon} size={12} style={{ color: 'var(--text-3)' }} />}
           {label ?? tr('元信息', 'Metadata')}
+          {count !== undefined && (
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 400 }}>
+              · {count}
+            </span>
+          )}
         </span>
         <Icon
           name="chevDown"
-          size={13}
+          size={14}
           style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
         />
       </div>
-      {open && <div style={{ padding: '0 16px 10px' }}>{children}</div>}
+      {open && <div style={{ padding: '0 16px 14px' }}>{children}</div>}
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2610,6 +2610,29 @@ export interface DailyDay {
   count: number;
 }
 
+/** 某个库今天从每日论文自动收录的一轮：漏斗数字 + 任务状态。 */
+export interface DailyIngestStatus {
+  library_id: string;
+  library_name: string;
+  is_public: boolean;
+  voyage_id: string;
+  /** 任务状态：executing / done / failed / paused_error / cancelled … */
+  status: string;
+  started_at: string;
+  finished_at?: string | null;
+  /** 池子里扫了多少 */
+  feed_total: number;
+  /** 送进打分的候选数 */
+  candidates: number;
+  /** 打分通过、真正收下的 */
+  admitted: number;
+  /** 相关性不够被淘汰的 */
+  rejected: number;
+  /** 编译成功的 */
+  compiled: number;
+  step_status: Record<string, string>;
+}
+
 export interface DailyCollectRequest {
   paper_ids: string[];
   direction_library_ids: string[];
@@ -4414,6 +4437,11 @@ export const api = {
   /** 池内现存日期（倒序）与每天篇数。 */
   /** 每天的条目数。带上当前筛选，否则日期标签上的数字会和列表对不上。 */
   /** 每日池保留天数（管理员可配；界面上别写死）。 */
+  /** 今天各可见库从每日论文自动收录的漏斗与状态。 */
+  listDailyIngestStatus(): Promise<DailyIngestStatus[]> {
+    return request<DailyIngestStatus[]>('/lab/daily-ingest');
+  },
+
   getDailyRetention(): Promise<{ days: number }> {
     return request<{ days: number }>('/daily/retention');
   },
@@ -4441,10 +4469,13 @@ export const api = {
       affiliation?: string;
       /** 检索方式：keyword=字面匹配，semantic=向量检索（只覆盖已生成向量的论文） */
       mode?: SearchMode;
+      /** 只看被这个文献库收录的（候选与回收站不算收录） */
+      libraryId?: string;
     } = {},
   ): Promise<DailyPage> {
     const params = new URLSearchParams();
     if (opts.date) params.set('date', opts.date);
+    if (opts.libraryId) params.set('library_id', opts.libraryId);
     if (opts.sort) params.set('sort', opts.sort);
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2993,6 +2993,8 @@ export const api = {
       published_to?: string;
       created_from?: string;
       created_to?: string;
+      /** 只看从每日论文池自动收录的（今日新收录视图） */
+      daily_only?: boolean;
     } = {},
   ): Promise<PageOf<PaperRead>> {
     const params = new URLSearchParams();
@@ -3011,6 +3013,7 @@ export const api = {
     if (opts.published_to) params.set('published_to', opts.published_to);
     if (opts.created_from) params.set('created_from', opts.created_from);
     if (opts.created_to) params.set('created_to', opts.created_to);
+    if (opts.daily_only) params.set('daily_only', 'true');
     const qs = params.toString();
     return request<PageOf<PaperRead>>(`/projects/${projectId}/papers${qs ? `?${qs}` : ''}`);
   },
@@ -3410,6 +3413,8 @@ export const api = {
       published_to?: string;
       created_from?: string;
       created_to?: string;
+      /** 只看从每日论文池自动收录的（今日新收录视图） */
+      daily_only?: boolean;
     } = {},
   ): Promise<PageOf<PaperRead>> {
     const params = new URLSearchParams();
@@ -3428,6 +3433,7 @@ export const api = {
     if (opts.published_to) params.set('published_to', opts.published_to);
     if (opts.created_from) params.set('created_from', opts.created_from);
     if (opts.created_to) params.set('created_to', opts.created_to);
+    if (opts.daily_only) params.set('daily_only', 'true');
     const qs = params.toString();
     return request<PageOf<PaperRead>>(`/libraries/${id}/papers${qs ? `?${qs}` : ''}`);
   },


### PR DESCRIPTION
Closes #218.

## Which library collected this paper — and let me filter by it (#218)

`GET /daily/papers` takes `library_id`, on both the keyword and semantic paths. It matches only real membership: a paper that is still a candidate, or sitting in the recycle bin, does not count as "this library collected it". The advanced-search panel gets a **Library** dropdown, listing only libraries the requester can see.

The other half of #218 — showing the collecting libraries on a paper — ships in #215 as the badge in the detail pane.

## Today's sync, visible without opening five task pages

A fetch that succeeded but collected nothing looks exactly like a fetch that never triggered a sync at all. That is precisely how #216 stayed hidden.

`GET /lab/daily-ingest` returns the funnel for each visible library's most recent ingest today — scanned → scored → kept/dropped → compiled — read out of that run's step observations. The lab workbench's Daily Papers card renders one row per library: status dot, name, and `scanned → kept`. The full funnel is in the tooltip, and the row links to the run. It polls every 15s while any library is still running and stops once they all finish.

The card's hard-coded "last 7 days kept" now follows the configured retention, same bug class the daily page already had fixed.

## "New today" in the library paper list

A fourth view after All / Compiled / Starred, showing only papers auto-collected from the daily feed today. Both conditions matter — **added today AND from the daily pool** — so papers added by hand or pulled in by citation expansion do not appear. The header row states when the batch arrived.

Backend takes a `daily_only` flag (default `false`, so citations export and the shelf are untouched) alongside the existing `created_from`.

## One layout across all five detail panes

Daily papers, library workbench, read-only library browse, personal library, and related-research shelf now render in the same order:

```
我的标签 → 概念（+ 课题备注·为什么相关）→ 元信息 → 摘要
→ TL;DR → 我的笔记 → 重要图片 → AI 图文介绍
```

Previously concepts sat *after* the metadata block, the abstract fold was hand-written three separate times with different styling, and in two panes the abstract was not collapsible at all. Metadata, abstract and notes now all use `MetaFold`, restyled to match the "My notes" card, all collapsed by default. Missing fields drop the whole block instead of leaving an empty "no abstract yet" box.

### One bug this would have introduced

`MetaFold` keeps its open/closed state internally, and the library workbench and browse panes do **not** remount when you switch papers (the other three are keyed at the call site). Expanding an abstract would have left the next paper's abstract expanded too. Both now pass `key={paperId}` to their folds, replacing the manual `setAbstractOpen(false)` reset those panes used to carry.

## Verification

- Backend suite: **888 passed**. `ruff check app` clean. `tsc --noEmit` and `vite build` pass.
- Six new tests: the library filter includes collected papers and excludes candidates; an unknown library id returns nothing; the ingest funnel reports the right numbers from step observations; a personal library's status is visible to its owner and hidden from a stranger (the earlier version of this test was passing vacuously — a project's implicit library is public, so it proved nothing; it now creates a real personal library); the status list is empty with no runs; and "new today" excludes both manually added papers and papers collected yesterday.
