### PR TITLE
feat(papers): show the index status everywhere and fold metadata into the abstract

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -288,9 +288,6 @@ function DailyDetailPane({
           </span>
         ))}
         <AnnounceBadge type={paper.announce_type} />
-        {/* 向量索引状态跟着徽章走：这一行是「这篇论文是什么」的速览，索引建没建属于
-            同一类信息。不带重建按钮——那一行不是操作区。 */}
-        <PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />
         <CollectingLibraries paperId={paper.paper_id} />
         {paper.arxiv_id &&
           (arxivHref ? (
@@ -416,11 +413,25 @@ function DailyDetailPane({
         <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
       )}
 
+      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
+      <PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />
+
       {/* —— 概念 chips（与库版同款；点了进不限库的概念页） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={openConcept} />
 
-      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
-      <MetaFold>
+
+      {/* 摘要默认折叠，复用元信息那套折叠块的样式，两者视觉一致 */}
+      {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
+          只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
+      <MetaFold label={tr('摘要', 'Abstract')}>
+        {paper.abstract ? (
+          <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
+        ) : (
+          <p className="muted" style={{ fontSize: 12.5, margin: 0 }}>
+            {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+          </p>
+        )}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '0.5px solid var(--border)' }}>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -434,14 +445,9 @@ function DailyDetailPane({
             <span className="muted">—</span>
           )}
         </MetaItem>
+      
+        </div>
       </MetaFold>
-
-      {/* 摘要默认折叠，复用元信息那套折叠块的样式，两者视觉一致 */}
-      {paper.abstract && (
-        <MetaFold label={tr('摘要', 'Abstract')}>
-          <p style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{paper.abstract}</p>
-        </MetaFold>
-      )}
 
       {/* —— TL;DR（来自内容池详情） —— */}
       {poolPaper?.tldr && (

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -35,6 +35,7 @@ import {
   PaperNotesSection,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { ConceptsTab } from '../wiki/ConceptsTab';
 import { LibraryChatTab } from '../wiki/LibraryChatTab';
 import { NotesTab } from '../wiki/NotesTab';
@@ -373,11 +374,24 @@ function PaperDetailPane({
         invalidateKeys={listKeys}
       />
 
+      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
+      <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
+
       {/* —— 概念 chips（过多时折叠） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />
 
-      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
-      <MetaFold key={`meta-${paperId}`}>
+
+      {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
+          只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
+      <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
+        {paper.abstract ? (
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
+        ) : (
+          <p className="muted" style={{ fontSize: 12.5, margin: 0 }}>
+            {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+          </p>
+        )}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '0.5px solid var(--border)' }}>
         <MetaItem label="arxiv_id">
           {paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -395,14 +409,9 @@ function PaperDetailPane({
         <MetaItem label={tr('入库时间', 'added at')}>
           <span className="mono">{fmtTime(paper.created_at)}</span>
         </MetaItem>
+      
+        </div>
       </MetaFold>
-
-      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
-      {paper.abstract && (
-        <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
-          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
-        </MetaFold>
-      )}
 
       {/* —— TL;DR —— */}
       {paper.tldr && (

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -22,6 +22,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
   ConceptChips,
@@ -327,11 +328,24 @@ export function LibraryDetailPane({
         />
       )}
 
+      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后；快照态没有池论文，不显示） —— */}
+      {alive && <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />}
+
       {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
       {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}
 
-      {/* —— frontmatter 风格元信息（默认折叠） —— */}
-      <MetaFold>
+
+      {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
+          只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
+      <MetaFold label={tr('摘要', 'Abstract')}>
+        {abstract ? (
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{abstract}</div>
+        ) : (
+          <p className="muted" style={{ fontSize: 12.5, margin: 0 }}>
+            {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+          </p>
+        )}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '0.5px solid var(--border)' }}>
         <MetaItem label="arxiv_id">
           {arxivId ? <span className="mono">{arxivId}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -345,14 +359,9 @@ export function LibraryDetailPane({
             <span className="mono">{snapshot.citedByCount}</span>
           </MetaItem>
         )}
+      
+        </div>
       </MetaFold>
-
-      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
-      {abstract && (
-        <MetaFold label={tr('摘要', 'Abstract')}>
-          <div style={{ fontSize: 13.5, lineHeight: 1.7, margin: 0 }}>{abstract}</div>
-        </MetaFold>
-      )}
 
       {/* —— TL;DR —— */}
       {tldr && (

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -16,6 +16,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useLibraries } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
+import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
   ConceptChips,
@@ -397,14 +398,27 @@ export function ShelfDetailPane({
         />
       )}
 
+      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
+      {paper && <PaperIndexStatusRow paperId={item.paper_id} showRebuild={false} />}
+
       {/* —— 课题备注：为什么相关（仅书架内论文；这条是课题里公开的说明） —— */}
       {onShelf && <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />}
 
       {/* —— 概念 chips：点了进不限库的概念页 —— */}
       <ConceptChips concepts={paper?.concepts} onOpen={openConcept} />
 
-      {/* —— frontmatter 风格元信息（默认折叠） —— */}
-      <MetaFold>
+
+      {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
+          只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
+      <MetaFold label={tr('摘要', 'Abstract')}>
+        {abstract ? (
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{abstract}</div>
+        ) : (
+          <p className="muted" style={{ fontSize: 12.5, margin: 0 }}>
+            {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+          </p>
+        )}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '0.5px solid var(--border)' }}>
         <MetaItem label="arxiv_id">
           {item.arxiv_id ? <span className="mono">{item.arxiv_id}</span> : <span className="muted">—</span>}
         </MetaItem>
@@ -438,14 +452,9 @@ export function ShelfDetailPane({
             tr('手动添加', 'Added manually')
           )}
         </MetaItem>
+      
+        </div>
       </MetaFold>
-
-      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
-      {abstract && (
-        <MetaFold label={tr('摘要', 'Abstract')}>
-          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{abstract}</div>
-        </MetaFold>
-      )}
 
       {/* —— TL;DR —— */}
       {tldr && (

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -755,8 +755,6 @@ function PaperDetailPane({
                 wiki
               </span>
             )}
-            {/* 向量索引状态跟着徽章走；不带重建按钮——这一行是速览，不是操作区 */}
-            <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
             {paper.pdf_available && (
               <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
                 <Icon name="file" size={11} />
@@ -890,6 +888,9 @@ function PaperDetailPane({
         invalidateKeys={[['papers', scopeId]]}
       />
 
+      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
+      <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
+
       {/* —— 概念 chips（过多时折叠） —— */}
       {paper.concepts.length > 0 && (
         <div className="row gap8 wrap" style={{ marginTop: 16 }}>
@@ -917,8 +918,18 @@ function PaperDetailPane({
         </div>
       )}
 
-      {/* —— frontmatter 风格元信息（默认折叠）；编译时间在下方 AI 图文介绍那行已有 —— */}
-      <MetaFold key={`meta-${paperId}`}>
+
+      {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
+          只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
+      <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
+        {paper.abstract ? (
+          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
+        ) : (
+          <p className="muted" style={{ fontSize: 12.5, margin: 0 }}>
+            {tr('这篇还没有摘要。', 'No abstract for this paper.')}
+          </p>
+        )}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '0.5px solid var(--border)' }}>
         <MetaItem label="arxiv_id">{paper.arxiv_id ? <span className="mono">{paper.arxiv_id}</span> : <span className="muted">—</span>}</MetaItem>
         <MetaItem label="doi">{paper.doi ? <span className="mono">{paper.doi}</span> : <span className="muted">—</span>}</MetaItem>
         <MetaItem label="published">
@@ -934,14 +945,9 @@ function PaperDetailPane({
         <MetaItem label={tr('入库时间', 'added at')}>
           <span className="mono">{fmtTime(paper.created_at)}</span>
         </MetaItem>
+      
+        </div>
       </MetaFold>
-
-      {/* —— 摘要（折叠，与元信息 / 我的笔记同款） —— */}
-      {paper.abstract && (
-        <MetaFold key={`abs-${paperId}`} label={tr('摘要', 'Abstract')}>
-          <div style={{ fontSize: 13.5, lineHeight: 1.7 }}>{paper.abstract}</div>
-        </MetaFold>
-      )}
 
       {/* —— TL;DR —— */}
       {paper.tldr && (


### PR DESCRIPTION
Follow-up to #224, across all five paper detail panes: daily papers, library workbench, read-only library browse, personal library, and the related-research shelf.

## Index status is now on every pane, in one place

The paper/chunk vector status was only rendered on three surfaces (daily papers, library workbench, reading view), and it sat wedged into the top badge row. It is the only signal telling you whether a paper can be found by semantic search at all — which is exactly what a regular user needs when a search comes up short.

It now appears on **all five** panes, in the same position: directly after the **My tags** row.

Worth noting: the read endpoint never had a permission gate. `GET /papers/{id}/index-status` is `current_active_user` with "if you can see the paper you can see its status". Nothing was blocking regular users — the frontend simply did not render it on the panes they use most.

## Metadata moved inside the abstract

The standalone **元信息 / Metadata** fold is gone. `arxiv_id`, `doi`, published date, relevance and added-at now live inside the **摘要 / Abstract** block, below a hairline separator.

Metadata is something you open when verifying a claim, the same reflex as opening the abstract. Giving it its own card only cost an extra click.

The abstract card is now byte-identical to the My-notes card — `className="card" style={{ marginTop: 18, overflow: 'hidden' }}` — and stays collapsed by default.

One behaviour change worth calling out: the abstract block no longer disappears when a paper has no abstract, because the metadata still lives there. Instead it says "这篇还没有摘要" in place. Blocks with genuinely nothing to show are still dropped entirely.

## Resulting order, identical on all five panes

```
我的标签 → 向量状态 → 概念（+ 课题备注·为什么相关）→ 摘要（含元信息）
→ TL;DR → 我的笔记 → 重要图片 → AI 图文介绍
```

## Verification

Frontend-only change — no backend files touched, so no backend behaviour to re-test. `tsc --noEmit` and `vite build` both pass. Verified by reading back the block order in all five files and confirming no standalone metadata fold remains anywhere.