### PR TITLE
feat(papers): put tags and index status on one row, and TL;DR above the abstract

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -410,17 +410,39 @@ function DailyDetailPane({
       {/* —— 我的标签：就地改，只有自己看得到 —— */}
       {/* 库标签的界面入口已移除，个人标签取代了它；后端端点与数据保留。 */}
       {poolPaper && (
-        <PaperMyTagsRow paperId={poolPaper.id} myTags={poolPaper.my_tags} detailKey={poolKey} />
+        <PaperMyTagsRow
+          paperId={poolPaper.id}
+          myTags={poolPaper.my_tags}
+          detailKey={poolKey}
+          trailing={<PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />}
+        />
       )}
-
-      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
-      <PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />
 
       {/* —— 概念 chips（与库版同款；点了进不限库的概念页） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={openConcept} />
 
 
       {/* 摘要默认折叠，复用元信息那套折叠块的样式，两者视觉一致 */}
+      {/* —— TL;DR（来自内容池详情） —— */}
+      {poolPaper?.tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {poolPaper.tldr}
+        </div>
+      )}
+
       {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
           只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
       <MetaFold label={tr('摘要', 'Abstract')}>
@@ -448,26 +470,6 @@ function DailyDetailPane({
       
         </div>
       </MetaFold>
-
-      {/* —— TL;DR（来自内容池详情） —— */}
-      {poolPaper?.tldr && (
-        <div
-          style={{
-            marginTop: 18,
-            padding: '12px 16px',
-            borderRadius: 10,
-            background: 'var(--accent-soft)',
-            fontSize: 13,
-            lineHeight: 1.65,
-            color: 'var(--text)',
-          }}
-        >
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
-            TL;DR
-          </span>
-          {poolPaper.tldr}
-        </div>
-      )}
 
       {/* —— 我的笔记（只有自己看得到） —— */}
       {poolPaper && (

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -372,14 +372,32 @@ function PaperDetailPane({
         myTags={paper.my_tags}
         detailKey={detailKey}
         invalidateKeys={listKeys}
+        trailing={<PaperIndexStatusRow paperId={paper.id} showRebuild={false} />}
       />
-
-      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
-      <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
 
       {/* —— 概念 chips（过多时折叠） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={(c) => onOpenConcept(c.id)} />
 
+
+      {/* —— TL;DR —— */}
+      {paper.tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {paper.tldr}
+        </div>
+      )}
 
       {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
           只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
@@ -412,26 +430,6 @@ function PaperDetailPane({
       
         </div>
       </MetaFold>
-
-      {/* —— TL;DR —— */}
-      {paper.tldr && (
-        <div
-          style={{
-            marginTop: 18,
-            padding: '12px 16px',
-            borderRadius: 10,
-            background: 'var(--accent-soft)',
-            fontSize: 13,
-            lineHeight: 1.65,
-            color: 'var(--text)',
-          }}
-        >
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
-            TL;DR
-          </span>
-          {paper.tldr}
-        </div>
-      )}
 
       {/* —— 我的笔记（个人维度，只读浏览也能写） —— */}
       <PaperNotesSection paperId={paper.id} noteCount={paper.note_count ?? 0} invalidateKeys={noteKeys} />

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -325,15 +325,33 @@ export function LibraryDetailPane({
           myTags={paper.my_tags}
           detailKey={detailKey}
           invalidateKeys={listKeys}
+          trailing={<PaperIndexStatusRow paperId={paper.id} showRebuild={false} />}
         />
       )}
-
-      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后；快照态没有池论文，不显示） —— */}
-      {alive && <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />}
 
       {/* —— 概念 chips：点了跳所属课题库的概念页 —— */}
       {alive && <ConceptChips concepts={paper.concepts} onOpen={openConcept} />}
 
+
+      {/* —— TL;DR —— */}
+      {tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {tldr}
+        </div>
+      )}
 
       {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
           只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
@@ -362,26 +380,6 @@ export function LibraryDetailPane({
       
         </div>
       </MetaFold>
-
-      {/* —— TL;DR —— */}
-      {tldr && (
-        <div
-          style={{
-            marginTop: 18,
-            padding: '12px 16px',
-            borderRadius: 10,
-            background: 'var(--accent-soft)',
-            fontSize: 13,
-            lineHeight: 1.65,
-            color: 'var(--text)',
-          }}
-        >
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
-            TL;DR
-          </span>
-          {tldr}
-        </div>
-      )}
 
       {/* —— 我的笔记（只有自己看得到） —— */}
       {alive && (

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -395,11 +395,9 @@ export function ShelfDetailPane({
           myTags={paper.my_tags}
           detailKey={detailKey}
           invalidateKeys={listKeys}
+          trailing={<PaperIndexStatusRow paperId={item.paper_id} showRebuild={false} />}
         />
       )}
-
-      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
-      {paper && <PaperIndexStatusRow paperId={item.paper_id} showRebuild={false} />}
 
       {/* —— 课题备注：为什么相关（仅书架内论文；这条是课题里公开的说明） —— */}
       {onShelf && <NoteEditor key={item.paper_id} note={item.note} pending={notePending} onSave={onSaveNote} />}
@@ -407,6 +405,26 @@ export function ShelfDetailPane({
       {/* —— 概念 chips：点了进不限库的概念页 —— */}
       <ConceptChips concepts={paper?.concepts} onOpen={openConcept} />
 
+
+      {/* —— TL;DR —— */}
+      {tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {tldr}
+        </div>
+      )}
 
       {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
           只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
@@ -455,26 +473,6 @@ export function ShelfDetailPane({
       
         </div>
       </MetaFold>
-
-      {/* —— TL;DR —— */}
-      {tldr && (
-        <div
-          style={{
-            marginTop: 18,
-            padding: '12px 16px',
-            borderRadius: 10,
-            background: 'var(--accent-soft)',
-            fontSize: 13,
-            lineHeight: 1.65,
-            color: 'var(--text)',
-          }}
-        >
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
-            TL;DR
-          </span>
-          {tldr}
-        </div>
-      )}
 
       {/* —— 我的笔记（只有自己看得到，和上面的课题备注是两回事） —— */}
       {paper && (

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type CSSProperties } from 'react';
+import { useCallback, useState, type CSSProperties, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
@@ -111,6 +111,7 @@ export function PaperMyTagsRow({
   detailKey,
   invalidateKeys,
   style,
+  trailing,
 }: {
   paperId: string;
   myTags: string[] | undefined;
@@ -119,6 +120,8 @@ export function PaperMyTagsRow({
   /** 改完要刷新的列表 / 搜索 queryKey */
   invalidateKeys?: readonly QueryKey[];
   style?: CSSProperties;
+  /** 同一行右侧的附加内容（各详情面板放向量索引状态）。 */
+  trailing?: ReactNode;
 }) {
   const queryClient = useQueryClient();
   const [adding, setAdding] = useState(false);
@@ -151,13 +154,26 @@ export function PaperMyTagsRow({
   };
 
   return (
-    <div className="row gap6 wrap" style={{ marginTop: 10, ...style }}>
+    /* 标签与向量状态同一行：两者都是「这篇论文在我这儿是什么情况」，分两行摆
+       会让它们看起来是两件事。收进一张浅底卡里，与上方的操作按钮区分开。 */
+    <div
+      className="row gap8 wrap"
+      style={{
+        marginTop: 12,
+        alignItems: 'center',
+        padding: '8px 12px',
+        borderRadius: 8,
+        background: 'var(--surface-2)',
+        border: '0.5px solid var(--border)',
+        ...style,
+      }}
+    >
       <span
-        className="row gap6 mono"
-        style={{ fontSize: 10.5, color: 'var(--text-3)', marginRight: 2 }}
+        className="row gap6"
+        style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginRight: 2 }}
         title={tr('只有你自己看得到', 'Only you can see these')}
       >
-        <Icon name="bookmark" size={11} />
+        <Icon name="bookmark" size={12} style={{ color: 'var(--text-3)' }} />
         {tr('我的标签', 'My tags')}
       </span>
       {tags.map((t) => (
@@ -198,6 +214,11 @@ export function PaperMyTagsRow({
           <Icon name="plus" size={10} style={{ display: 'inline-block', verticalAlign: -1 }} />{' '}
           {tr('加标签', 'Add tag')}
         </span>
+      )}
+      {trailing && (
+        <div className="row gap10" style={{ marginLeft: 'auto', alignItems: 'center' }}>
+          {trailing}
+        </div>
       )}
     </div>
   );

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -886,10 +886,8 @@ function PaperDetailPane({
         myTags={paper.my_tags}
         detailKey={['paper', scopeId, paper.id]}
         invalidateKeys={[['papers', scopeId]]}
+        trailing={<PaperIndexStatusRow paperId={paper.id} showRebuild={false} />}
       />
-
-      {/* —— 向量索引状态（五处详情面板同一位置：标签行之后） —— */}
-      <PaperIndexStatusRow paperId={paper.id} showRebuild={false} />
 
       {/* —— 概念 chips（过多时折叠） —— */}
       {paper.concepts.length > 0 && (
@@ -918,6 +916,26 @@ function PaperDetailPane({
         </div>
       )}
 
+
+      {/* —— TL;DR —— */}
+      {paper.tldr && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: '12px 16px',
+            borderRadius: 10,
+            background: 'var(--accent-soft)',
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: 'var(--text)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
+            TL;DR
+          </span>
+          {paper.tldr}
+        </div>
+      )}
 
       {/* 摘要 + 元信息合成一块：元信息本来就是查证时才看的东西，单独一张卡
           只是多一次点击。样式与「我的笔记」同款，默认收起。 */}
@@ -948,26 +966,6 @@ function PaperDetailPane({
       
         </div>
       </MetaFold>
-
-      {/* —— TL;DR —— */}
-      {paper.tldr && (
-        <div
-          style={{
-            marginTop: 18,
-            padding: '12px 16px',
-            borderRadius: 10,
-            background: 'var(--accent-soft)',
-            fontSize: 13,
-            lineHeight: 1.65,
-            color: 'var(--text)',
-          }}
-        >
-          <span className="mono" style={{ fontSize: 10.5, color: 'var(--accent-text)', display: 'block', marginBottom: 4 }}>
-            TL;DR
-          </span>
-          {paper.tldr}
-        </div>
-      )}
 
       {/* —— 我的笔记（只有自己看得到；与其余四处详情面板同一顺序） —— */}
       <PaperNotesSection


### PR DESCRIPTION
Follow-up to #225, same five panes.

## Tags and index status share one row

They were stacked on two lines, which read as two unrelated things. They are not — both answer "what is the state of this paper *for me*". They now sit on one row: tags on the left, index status pushed right, the whole thing inside a soft `surface-2` card with a hairline border so it separates cleanly from the action buttons above it.

**My tags** goes from `mono 10.5` to `12` semibold with a matching larger icon. At the old size it read like a footnote rather than the label for the row.

Implemented as a `trailing` slot on `PaperMyTagsRow` rather than duplicating layout in five files.

## TL;DR moved above the abstract

It is the one-sentence conclusion — it should be the first thing you read, not the thing below a collapsed block. The abstract now also carries the metadata (#225), which makes it even more clearly a "open this when verifying something" block.

## Resulting order, identical on all five panes

```
我的标签 + 向量状态（同一行）→ 概念（+ 课题备注·为什么相关）
→ TL;DR → 摘要（含元信息）→ 我的笔记 → 重要图片 → AI 图文介绍
```

## Verification

Frontend-only — no backend files touched. `tsc --noEmit` and `vite build` pass. Block order verified by reading it back out of all five files.

One thing caught during the edit and worth recording: the first pass anchored on `invalidateKeys={listKeys}` and landed the `trailing` prop on `PaperMyMetaRow` (the starred / reading-status row) in three of the five files, since both components end with the same prop. `tsc` rejected it, and it was moved onto `PaperMyTagsRow` in each.