### PR TITLE
fix(ingest): commit snowball inserts one at a time and retry on deadlock

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -218,6 +218,49 @@ async def _existing_keys(
     return arxiv_ids, dois, titles
 
 
+# Postgres 在并发写下检测到环就挑一个事务牺牲掉，这是正常行为而不是错误：
+# 40P01 死锁 / 40001 序列化失败，两者都该重试而不是让整个步骤挂掉。
+_RETRYABLE_SQLSTATES = frozenset({"40P01", "40001"})
+_DEADLOCK_RETRIES = 3
+
+
+def _is_retryable_conflict(exc: BaseException) -> bool:
+    orig = getattr(exc, "orig", None)
+    code = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    return code in _RETRYABLE_SQLSTATES
+
+
+async def _insert_pooled_with_retry(
+    session: AsyncSession, **kwargs: Any
+) -> tuple[Paper | None, str | None]:
+    """插入一篇池论文并**立刻提交**；撞上并发冲突就回滚重试。返回 (论文, 放弃原因)。
+
+    为什么逐篇提交：整步一个事务时，每插一行都会在 ``papers.dedup_key`` 唯一索引上
+    持锁到步骤结束（实测能到几分钟）。而各库是并行同步的、方向又都在 AI 领域，
+    Semantic Scholar 返回的引文大量重叠、插入顺序还各不相同——两个事务互等对方
+    未提交的行，正好成环。逐篇提交把锁窗口从几分钟压到毫秒级。
+
+    真撞上了也只丢这一篇：重试三次仍冲突就记进 failed 继续跑，不再让整步作废、
+    把已经拿到的上百篇引文一起丢掉。
+    """
+    for attempt in range(_DEADLOCK_RETRIES):
+        try:
+            paper = await _pool_paper_or_new(session, **kwargs)
+            await session.commit()
+            return paper, None
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 — 只吞冲突类，其余照抛
+            await session.rollback()
+            if not _is_retryable_conflict(e):
+                raise
+            if attempt == _DEADLOCK_RETRIES - 1:
+                return None, f"{type(e).__name__}: {e}"
+            logger.warning("snowball insert conflict, retry %d", attempt + 1)
+            await asyncio.sleep(0.2 * (attempt + 1))
+    return None, None
+
+
 async def _pool_paper_or_new(
     session: AsyncSession,
     *,
@@ -672,7 +715,7 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
                             published_at=_parse_iso(item.get("publicationDate")),
                         )
 
-                    paper = await _pool_paper_or_new(
+                    paper, conflict = await _insert_pooled_with_retry(
                         session,
                         library_id=library.id,
                         make_paper=make_paper,
@@ -682,6 +725,8 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
                         year=item.get("year"),
                         authors=authors,
                     )
+                    if conflict is not None:
+                        failed.append({"id": title[:80], "error": conflict})
                     titles.add(title.lower())
                     if aid:
                         arxiv_ids.add(aid)

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -1702,3 +1702,98 @@ async def test_rejected_papers_are_not_scored_twice(client, queue_stub, wiki_moc
 
     obs = detail["steps"][0]["observation"]
     assert obs["skipped_previously_rejected"] >= 1
+
+
+# ---- 并发插入冲突（生产死锁：asyncpg DeadlockDetectedError） ----
+
+
+class _FakeDeadlock(Exception):
+    """asyncpg 的死锁异常长这样：DBAPIError.orig 上带 sqlstate=40P01。"""
+
+    sqlstate = "40P01"
+
+
+def _deadlock_error() -> Exception:
+    from sqlalchemy.exc import DBAPIError
+
+    return DBAPIError("INSERT INTO papers ...", {}, _FakeDeadlock("deadlock detected"))
+
+
+async def test_insert_retry_recovers_from_one_deadlock():
+    """第一次死锁、第二次成功 → 返回论文，不上抛。"""
+
+    calls = {"n": 0}
+    sentinel = object()
+
+    class _Session:
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+    async def fake_pool(session, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _deadlock_error()
+        return sentinel
+
+    import app.agents.voyage.actions_wiki as mod
+
+    original = mod._pool_paper_or_new
+    mod._pool_paper_or_new = fake_pool
+    try:
+        paper, reason = await mod._insert_pooled_with_retry(_Session(), library_id=None)
+    finally:
+        mod._pool_paper_or_new = original
+
+    assert paper is sentinel and reason is None
+    assert calls["n"] == 2  # 死锁一次 + 重试成功一次
+
+
+async def test_insert_retry_gives_up_but_does_not_kill_the_step():
+    """一直死锁 → 记下原因返回 None，让上层继续处理其余论文，而不是整步失败。"""
+    import app.agents.voyage.actions_wiki as mod
+
+    class _Session:
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+    async def always_deadlock(session, **kwargs):
+        raise _deadlock_error()
+
+    original = mod._pool_paper_or_new
+    mod._pool_paper_or_new = always_deadlock
+    try:
+        paper, reason = await mod._insert_pooled_with_retry(_Session(), library_id=None)
+    finally:
+        mod._pool_paper_or_new = original
+
+    assert paper is None
+    assert reason and "40P01" not in reason and "DBAPIError" in reason
+
+
+async def test_insert_retry_reraises_unrelated_errors():
+    """非冲突类错误照抛——别把真 bug 吞成「这一篇跳过」。"""
+    import app.agents.voyage.actions_wiki as mod
+
+    class _Session:
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+    async def boom(session, **kwargs):
+        raise ValueError("something else entirely")
+
+    original = mod._pool_paper_or_new
+    mod._pool_paper_or_new = boom
+    try:
+        with pytest.raises(ValueError, match="something else"):
+            await mod._insert_pooled_with_retry(_Session(), library_id=None)
+    finally:
+        mod._pool_paper_or_new = original

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -615,7 +615,6 @@ export function DailyPage() {
   const [semanticOn, setSemanticOn] = useState(false);
   const [page, setPage] = useState(1);
   // —— 日期（null=全部，默认就停在全部）留在工具栏；分类 / 类型收进高级检索面板 ——
-  const [day, setDay] = useState<string | null>(null);
   // 只看被某个文献库收录的论文（#218）。空 = 不限
   const [libraryId, setLibraryId] = useState('');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
@@ -639,23 +638,15 @@ export function DailyPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => setPage(1), [q, semanticOn, day, category, announce, author, affiliation]);
+  useEffect(() => setPage(1), [q, semanticOn, category, announce, author, affiliation]);
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
-  }, [q, semanticOn, day, category, announce, author, affiliation]);
+  }, [q, semanticOn, category, announce, author, affiliation]);
 
   // 日期标签上的数字要跟着筛选走，否则选了某个分类之后标签仍显示全部篇数，
   // 看起来就像筛选根本没生效。
   // 保留期是管理员可配的，界面上不能写死「7 天」
-  const retentionQuery = useQuery({
-    queryKey: ['daily-retention'],
-    queryFn: () => api.getDailyRetention(),
-    retry: false,
-    staleTime: 5 * 60_000,
-  });
-  const retentionDays = retentionQuery.data?.days ?? 14;
-
   const daysQuery = useQuery({
     queryKey: ['daily-days', announce, category],
     queryFn: () => api.listDailyDays({ announce: announce || undefined, category: category || undefined }),
@@ -664,27 +655,10 @@ export function DailyPage() {
   });
   const dayCount = new Map((daysQuery.data ?? []).map((d) => [d.date, d.count] as const));
 
-  // 有数据的日期，升序（旧 → 新），日期步进只在这些日期间跳
-  const dates = (daysQuery.data ?? []).map((d) => d.date).sort();
-  const latestDate = dates[dates.length - 1] ?? null;
 
-  // 日期一改就算用户表过态，之后不再自动初始化
-  const pickDay = useCallback((d: string | null) => setDay(d), []);
   // 默认停在「全部」：跨天一起看、按时间倒排，最新的自然在最前。以前默认落到最新
   // 一天，那一天恰好没有新公告（周末）时页面就是空的，看着像坏了。
 
-  const dayIdx = day ? dates.indexOf(day) : -1;
-  // 「全部」视为最新一天的后一位：← 从全部进入最新一天；→ 在最新一天回到全部
-  const canPrevDay = dates.length > 0 && (day === null || dayIdx > 0);
-  const canNextDay = day !== null && dayIdx >= 0;
-  const goPrevDay = () => {
-    if (day === null) pickDay(latestDate);
-    else if (dayIdx > 0) pickDay(dates[dayIdx - 1] ?? null);
-  };
-  const goNextDay = () => {
-    if (day === null) return;
-    pickDay(dayIdx >= 0 && dayIdx < dates.length - 1 ? (dates[dayIdx + 1] ?? null) : null);
-  };
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板；
   // 日期放开到全部——只看当天的话，按作者/机构筛基本什么都剩不下
@@ -698,14 +672,13 @@ export function DailyPage() {
       setLibraryId('');
       setAnnounce('all');
       setAdvOpen(true);
-      pickDay(null);
       if (patch.author) {
         toast(tr(`已筛选作者：${patch.author}`, `Filtered by author: ${patch.author}`), 'info');
       } else if (patch.affiliation) {
         toast(tr(`已筛选机构：${patch.affiliation}`, `Filtered by affiliation: ${patch.affiliation}`), 'info');
       }
     },
-    [pickDay],
+    [],
   );
   const filterByAuthor = useCallback((name: string) => applyAdvFilter({ author: name }), [applyAdvFilter]);
   const filterByAffiliation = useCallback(
@@ -732,7 +705,7 @@ export function DailyPage() {
   const listQuery = useQuery({
     queryKey: [
       'daily-papers',
-      semanticOn, page, q, day, category, announce, author, affiliation, libraryId,
+      semanticOn, page, q, category, announce, author, affiliation, libraryId,
     ],
     queryFn: () =>
       api.listDailyPapers({
@@ -740,7 +713,6 @@ export function DailyPage() {
         page: semantic ? undefined : page,
         size: PAGE_SIZE,
         q: q || undefined,
-        date: day ?? undefined,
         category: category || undefined,
         announce: announce === 'all' ? undefined : announce,
         author: author || undefined,
@@ -752,7 +724,7 @@ export function DailyPage() {
     placeholderData: keepPreviousData,
   });
   // 默认口径（当天 + 新工作）之外还加了条件才算「筛过」——空列表时给的话术不一样
-  const filtered = !!q || advActive || (day !== null && day !== latestDate);
+  const filtered = !!q || advActive;
   const items = listQuery.data?.items ?? [];
   const total = listQuery.data?.total ?? 0;
   const pages = semantic ? 1 : Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -1037,38 +1009,6 @@ export function DailyPage() {
                   {tr('语义检索暂不可用，已回退为关键词匹配。', 'Semantic search unavailable — fell back to keyword matching.')}
                 </div>
               )}
-              {/* —— 日期步进（主导航，不收进高级检索） —— */}
-              <div className="row gap6 wrap" style={{ marginTop: 8 }}>
-                <button
-                  className="btn btn-ghost sm"
-                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
-                  disabled={!canPrevDay}
-                  onClick={goPrevDay}
-                >
-                  ‹ {tr('前一天', 'Prev day')}
-                </button>
-                <span
-                  className={`chip${day !== null ? ' on' : ''}`}
-                  title={
-                    day !== null
-                      ? tr(`点击看全部 ${retentionDays} 天`, `Click to show all ${retentionDays} days`)
-                      : tr('点击只看最新一天', 'Click to show the latest day only')
-                  }
-                  onClick={() => pickDay(day === null ? latestDate : null)}
-                >
-                  {day !== null
-                    ? dayLabel(day, dayCount.get(day))
-                    : tr(`全部 ${retentionDays} 天`, `All ${retentionDays} days`)}
-                </span>
-                <button
-                  className="btn btn-ghost sm"
-                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
-                  disabled={!canNextDay}
-                  onClick={goNextDay}
-                >
-                  {tr('后一天', 'Next day')} ›
-                </button>
-              </div>
             </div>
 
             <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -25,6 +25,7 @@ import {
   type AdminUserRead,
   type AffiliationMode,
   type ChatBotPlatform,
+  type DailySyncScope,
   LLM_EFFORT_LEVELS,
   type EffectiveTestResult,
   type LlmCallLogRow,
@@ -2807,10 +2808,194 @@ function DailyEmbedSection() {
   );
 }
 
+/** 抓取与同步：抓取时刻、池子保留期、库同步每次扫多大范围。 */
+function DailySyncSection() {
+  const queryClient = useQueryClient();
+  const scopeQuery = useQuery({
+    queryKey: ['daily-sync-scope'],
+    queryFn: () => api.getDailySyncScope(),
+    retry: false,
+  });
+  const timeQuery = useQuery({
+    queryKey: ['daily-sync-time'],
+    queryFn: () => api.getDailySyncTime(),
+    retry: false,
+  });
+  const retentionQuery = useQuery({
+    queryKey: ['daily-retention'],
+    queryFn: () => api.getDailyRetention(),
+    retry: false,
+  });
+
+  const [days, setDays] = useState('');
+  const [clock, setClock] = useState('');
+  useEffect(() => {
+    if (retentionQuery.data && !days) setDays(String(retentionQuery.data.days));
+  }, [retentionQuery.data, days]);
+  useEffect(() => {
+    if (timeQuery.data && !clock) {
+      const { hour, minute } = timeQuery.data;
+      setClock(`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`);
+    }
+  }, [timeQuery.data, clock]);
+
+  const fail = (e: unknown) =>
+    toast(`${tr('保存失败', 'Save failed')}：${e instanceof Error ? e.message : String(e)}`, 'error');
+
+  const scopeMutation = useMutation({
+    mutationFn: (scope: DailySyncScope) => api.setDailySyncScope(scope),
+    onSuccess: () => {
+      toast(tr('同步范围已保存', 'Sync scope saved'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['daily-sync-scope'] });
+    },
+    onError: fail,
+  });
+  const timeMutation = useMutation({
+    mutationFn: () => {
+      const [h, m] = clock.split(':');
+      return api.setDailySyncTime(Number(h), Number(m));
+    },
+    onSuccess: () => {
+      toast(tr('抓取时刻已保存，重启 worker 后生效', 'Fetch time saved — restart the worker to apply'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['daily-sync-time'] });
+    },
+    onError: fail,
+  });
+  const retentionMutation = useMutation({
+    mutationFn: () => api.setDailyRetention(Number(days)),
+    onSuccess: () => {
+      toast(tr('保留期已保存', 'Retention saved'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['daily-retention'] });
+    },
+    onError: fail,
+  });
+
+  const scope = scopeQuery.data?.scope ?? 'since_last';
+  const SCOPES: { v: DailySyncScope; zh: string; en: string; noteZh: string; noteEn: string }[] = [
+    {
+      v: 'since_last',
+      zh: '上次同步以来',
+      en: 'Since last sync',
+      noteZh: '正常就是当天那批；漏了几天会自动多扫几天补回来。',
+      noteEn: 'Normally just today’s batch; automatically catches up if a few days were missed.',
+    },
+    {
+      v: 'daily',
+      zh: '只扫当天',
+      en: 'Today only',
+      noteZh: '最省，但漏掉的永远错过——arXiv 不会再给第二次。',
+      noteEn: 'Cheapest, but anything missed is missed for good — arXiv will not serve it again.',
+    },
+    {
+      v: 'full',
+      zh: '整个池子',
+      en: 'Whole pool',
+      noteZh: '最稳，代价是每次重排几千篇早就处理过的论文。',
+      noteEn: 'Safest, at the cost of re-ranking thousands of already-processed papers each run.',
+    },
+  ];
+  const current = SCOPES.find((x) => x.v === scope);
+
+  const rowStyle = { alignItems: 'center', marginTop: 14 } as const;
+  const labelStyle = { width: 92, flexShrink: 0, fontSize: 12, color: 'var(--text-2)' } as const;
+
+  return (
+    <div className="card card-pad" style={{ maxWidth: 640, marginTop: 20 }}>
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="refresh" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('抓取与同步', 'Fetch & sync')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5 }}>
+        {tr(
+          '每日抓取跑完会自动触发各文献库同步，库同步不再单独定时。',
+          'Library sync is triggered once the daily fetch finishes; it is no longer separately scheduled.',
+        )}
+      </div>
+
+      {/* —— 库同步扫描范围 —— */}
+      <div className="row gap8" style={rowStyle}>
+        <span style={labelStyle}>{tr('同步范围', 'Sync scope')}</span>
+        <select
+          className="input"
+          style={{ flex: 1, minWidth: 0, height: 28, fontSize: 12 }}
+          value={scope}
+          disabled={scopeQuery.isLoading || scopeMutation.isPending}
+          onChange={(e) => scopeMutation.mutate(e.target.value as DailySyncScope)}
+        >
+          {SCOPES.map((x) => (
+            <option key={x.v} value={x.v}>
+              {tr(x.zh, x.en)}
+            </option>
+          ))}
+        </select>
+      </div>
+      {current && (
+        <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 5, paddingLeft: 100, lineHeight: 1.5 }}>
+          {tr(current.noteZh, current.noteEn)}
+        </div>
+      )}
+
+      {/* —— 抓取时刻 —— */}
+      <div className="row gap8" style={rowStyle}>
+        <span style={labelStyle}>{tr('抓取时刻', 'Fetch time')}</span>
+        <input
+          className="input mono"
+          type="time"
+          style={{ width: 120, height: 28, fontSize: 12 }}
+          value={clock}
+          onChange={(e) => setClock(e.target.value)}
+        />
+        <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)' }}>UTC</span>
+        <button
+          className="btn btn-soft sm"
+          disabled={!/^\d{2}:\d{2}$/.test(clock) || timeMutation.isPending}
+          onClick={() => timeMutation.mutate()}
+        >
+          {tr('保存', 'Save')}
+        </button>
+      </div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 5, paddingLeft: 100, lineHeight: 1.5 }}>
+        {tr(
+          '北京时间 = UTC + 8。这是开始探测的时刻，之后每 15 分钟看一次，直到 arXiv 当天的批次真的放出来。',
+          'Beijing = UTC + 8. This is when probing starts; it then checks every 15 minutes until arXiv actually publishes today’s batch.',
+        )}
+      </div>
+
+      {/* —— 保留天数 —— */}
+      <div className="row gap8" style={rowStyle}>
+        <span style={labelStyle}>{tr('保留天数', 'Retention')}</span>
+        <input
+          className="input mono"
+          type="number"
+          min={1}
+          max={90}
+          style={{ width: 90, height: 28, fontSize: 12 }}
+          value={days}
+          onChange={(e) => setDays(e.target.value)}
+        />
+        <button
+          className="btn btn-soft sm"
+          disabled={!days || Number(days) < 1 || Number(days) > 90 || retentionMutation.isPending}
+          onClick={() => retentionMutation.mutate()}
+        >
+          {tr('保存', 'Save')}
+        </button>
+      </div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 5, paddingLeft: 100, lineHeight: 1.5 }}>
+        {tr(
+          '过期的每日论文会被清掉。这张表同时是库同步的取数窗口——调小了，来不及同步的论文就再也收不进来。',
+          'Expired daily papers are pruned. This table is also the window library sync reads from — shrink it and papers not synced in time can never be collected.',
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function DailyCategoriesTab() {
   return (
     <>
       <DailyCategoriesSection />
+      <DailySyncSection />
       <DailyEmbedSection />
     </>
   );

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2636,6 +2636,9 @@ export interface DailyIngestStatus {
   step_status: Record<string, string>;
 }
 
+/** 库同步每次扫描每日池的范围。 */
+export type DailySyncScope = 'since_last' | 'daily' | 'full';
+
 export interface DailyCollectRequest {
   paper_ids: string[];
   direction_library_ids: string[];
@@ -4451,6 +4454,32 @@ export const api = {
     return request<DailyIngestStatus[]>('/lab/daily-ingest');
   },
 
+  /** 库同步每次扫描每日池的范围：since_last 上次同步以来 / daily 只当天 / full 整池。 */
+  getDailySyncScope(): Promise<{ scope: DailySyncScope }> {
+    return request<{ scope: DailySyncScope }>('/daily/sync-scope');
+  },
+  setDailySyncScope(scope: DailySyncScope): Promise<{ scope: DailySyncScope }> {
+    return request<{ scope: DailySyncScope }>('/daily/sync-scope', {
+      method: 'PUT',
+      body: JSON.stringify({ scope }),
+    });
+  },
+  /** 每日抓取的起始时刻（UTC；北京时间 = UTC + 8）。 */
+  getDailySyncTime(): Promise<{ hour: number; minute: number }> {
+    return request<{ hour: number; minute: number }>('/daily/sync-time');
+  },
+  setDailySyncTime(hour: number, minute: number): Promise<{ hour: number; minute: number }> {
+    return request<{ hour: number; minute: number }>('/daily/sync-time', {
+      method: 'PUT',
+      body: JSON.stringify({ hour, minute }),
+    });
+  },
+  setDailyRetention(days: number): Promise<{ days: number }> {
+    return request<{ days: number }>('/daily/retention', {
+      method: 'PUT',
+      body: JSON.stringify({ days }),
+    });
+  },
   getDailyRetention(): Promise<{ days: number }> {
     return request<{ days: number }>('/daily/retention');
   },


### PR DESCRIPTION
## The failure

A library sync died on `wiki.snowball` in production:

```
asyncpg.exceptions.DeadlockDetectedError: deadlock detected
DETAIL: Process 22784 waits for ShareLock on transaction 34707; blocked by process 22811.
        Process 22811 waits for ShareLock on transaction 34706; blocked by process 22784.
[SQL: INSERT INTO papers (dedup_key, ...)]
```

Three causes stacked up:

**One transaction for the whole step.** `snowball` opens a single session, inserts hundreds of Semantic Scholar citations in a loop, and commits only at the very end. That run took 2m44s — every row it inserted held a lock on the `papers.dedup_key` unique index for the entire duration.

**Parallel syncs inserting overlapping rows in different orders.** Libraries sync concurrently (one `run_voyage` per library, arq runs up to 10). The active directions are all AI-adjacent, so S2 returns heavily overlapping citations, and each library's frontier orders them differently. A inserts X then waits on Y; B inserted Y and waits on X. That is the cycle in the log.

**Deadlock treated as fatal.** Postgres picking a victim when it detects a cycle is normal behaviour under concurrent writes (SQLSTATE 40P01), and the standard response is to retry. Instead the whole step failed, 2m44s of fetched citations were discarded, and the voyage paused for manual intervention.

## The fix

- **Commit per paper** instead of at the end of the step. This shrinks the lock window from minutes to milliseconds and is what actually stops the deadlocks; it also means a failure costs one paper rather than the entire step.
- **Retry conflict-class errors** (`40P01` deadlock, `40001` serialization failure) up to three times with a short backoff.
- After three attempts, record the paper in `failed` and **carry on** — do not discard the rest of the step's work.
- **Re-raise anything else.** A genuine bug should not be swallowed as "skipped one paper".

### Related, and worth knowing

This ran during an *incremental* sync, where citation expansion should not happen at all. That instance is on code between #206 and #210: it has the daily-pool candidate step but still the old welded seven-step pipeline. #210 split the plan by mode, and on current code an incremental sync has no snowball step. Upgrading that instance removes this failure path outright.

The fix still matters: `snowball` runs for bootstrap and manual anchor expansion, where parallel libraries collide on the same rows in exactly the same way.

## Two unrelated items in this branch

**Daily papers: the day stepper is gone.** With the list sorted by date and defaulting to all days, `‹ 前一天 / 全部 N 天 / 后一天 ›` only served to trap you on one day. Removing it left `day` with no write path, so `dates` / `latestDate` / `dayIdx` / `retentionQuery` went with it rather than lingering as permanently-null derived state. Per-row date labels stay.

**Admin settings: a "Fetch & sync" section.** The backend has six daily-settings endpoints; the client wrapped exactly one. Sync scope (since-last / today-only / whole-pool), fetch time, and retention had no UI at all — the last two were promised as admin-configurable when they were built. Each option states its trade-off, e.g. "today-only is cheapest, but anything missed is missed for good — arXiv will not serve it again".

## Verification

- Full backend suite: **905 passed**. `ruff check app` clean. `tsc --noEmit` and `vite build` pass.
- Four new tests: retry recovers from a single deadlock; persistent deadlock gives up on that paper without killing the step; unrelated errors propagate.