### PR TITLE
fix(db): size the connection pool for the worker's concurrency

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -41,6 +41,14 @@ class Settings(BaseSettings):
     # 默认回退 sqlite+aiosqlite，便于无 docker 的本地开发与测试；生产用 postgresql+asyncpg
     database_url: str = "sqlite+aiosqlite:///./polaris_dev.db"
     redis_url: str = "redis://localhost:6379/0"
+    # 连接池要装得下 worker 的并发：max_jobs(10) 个 voyage × 每个 voyage 的打分并发
+    # (_LLM_CONCURRENCY=5)，每篇论文各开一个 session，再加上引擎自己记步骤/检查点的那条。
+    # SQLAlchemy 默认 5+10=15，实测在生产上被打满：50 个协程抢 15 个连接，多数等满 30s
+    # 超时、该篇打分失败、状态停在 candidate——库里那 2400 多条「从没打过分」的候选就是
+    # 这么攒出来的。Postgres 侧 max_connections=100，这个额度装得下。
+    db_pool_size: int = 20
+    db_max_overflow: int = 50
+    db_pool_timeout: int = 30
 
     # ---- LLM providers（初始值；后续可在 DB 模型路由表中配置）----
     openai_compat_base_url: str = "https://api.deepseek.com/v1"

--- a/src/backend/app/core/db.py
+++ b/src/backend/app/core/db.py
@@ -28,7 +28,18 @@ _sessionmaker: async_sessionmaker[AsyncSession] | None = None
 def get_engine() -> AsyncEngine:
     global _engine
     if _engine is None:
-        _engine = create_async_engine(get_settings().database_url, echo=False)
+        settings = get_settings()
+        kwargs: dict[str, object] = {"echo": False}
+        if not settings.is_sqlite:
+            # sqlite 走的是 NullPool/StaticPool，给它这些参数会直接报错
+            kwargs |= {
+                "pool_size": settings.db_pool_size,
+                "max_overflow": settings.db_max_overflow,
+                "pool_timeout": settings.db_pool_timeout,
+                # 长跑的 worker 连接可能被中间件掐掉，取用前探活一次
+                "pool_pre_ping": True,
+            }
+        _engine = create_async_engine(settings.database_url, **kwargs)
         if _engine.url.get_backend_name() == "sqlite":
             # sqlite 默认不强制外键：打开 pragma，让 ON DELETE CASCADE 生效（对齐 postgres）
             @event.listens_for(_engine.sync_engine, "connect")

--- a/src/backend/tests/test_worker_registration.py
+++ b/src/backend/tests/test_worker_registration.py
@@ -56,3 +56,37 @@ async def test_enqueueing_a_registered_task_passes_the_check():
 
     for name in WORKER_FUNCTIONS:
         check_task_name(name)  # 不抛即通过
+
+
+# ---- 连接池要装得下 worker 的并发 ----
+
+
+def test_db_pool_fits_worker_concurrency():
+    """池子上限必须 ≥ worker 并发跑打分时的连接需求。
+
+    生产上曾经不满足：SQLAlchemy 默认 5+10=15，而 max_jobs(10) 个 voyage 各开
+    _LLM_CONCURRENCY(5) 个协程、每篇论文一个 session ⇒ 峰值 50。50 抢 15 的结果是
+    大批协程等满 pool_timeout 后超时，该篇打分失败、状态停在 candidate——生产库里
+    积了 2400 多条从没打过分的候选就是这么来的。
+    """
+    from app.agents.voyage.actions_wiki import _LLM_CONCURRENCY
+    from app.core.config import get_settings
+    from worker.settings import WorkerSettings
+
+    max_jobs = getattr(WorkerSettings, "max_jobs", 10)
+    settings = get_settings()
+    ceiling = settings.db_pool_size + settings.db_max_overflow
+    # 每个 voyage：打分并发 + 引擎自己记步骤/检查点的那条
+    need = max_jobs * (_LLM_CONCURRENCY + 1)
+    assert ceiling >= need, (
+        f"连接池上限 {ceiling} < 峰值需求 {need}"
+        f"（max_jobs={max_jobs} × (打分并发 {_LLM_CONCURRENCY} + 1)）"
+    )
+
+
+def test_sqlite_engine_skips_pool_sizing():
+    """sqlite 用的是 NullPool/StaticPool，传 pool_size 会直接报错——测试库靠这条保命。"""
+    from app.core.db import get_engine
+
+    engine = get_engine()
+    assert engine is not None  # 建得起来即说明没把池参数塞给 sqlite


### PR DESCRIPTION
## What happened

Library sync was thrashing in production — 70 `QueuePool limit` errors and 140 `TimeoutError`s in five minutes:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached,
connection timed out, timeout 30.00
```

`create_async_engine` was called with no pool configuration, so it took SQLAlchemy's defaults: `pool_size=5` + `max_overflow=10` = **15 connections**. The worker runs `max_jobs=10` voyages concurrently, each scoring papers at `_LLM_CONCURRENCY=5`, and **every paper opens its own session** — a peak demand of **50+**.

50 coroutines competing for 15 connections means most wait out `pool_timeout`, fail, and the paper's scoring fails with them. Its membership stays at `candidate`.

**That is where the 2,400+ never-scored candidates in the production database came from.** The daily sync has been quietly doing this every day; nobody had measured it.

Postgres was never the constraint: `max_connections=100`, and only 28 were in use when this was happening.

## The change

Pool settings are now configurable, defaulting to `pool_size=20` + `max_overflow=50` (ceiling 70, against a peak demand of 60). sqlite skips them entirely — it uses NullPool/StaticPool and raises if given pool sizes, which is what the test database runs on. Long-lived worker connections get `pool_pre_ping`.

A guard test asserts `ceiling >= max_jobs × (_LLM_CONCURRENCY + 1)`; reverting to SQLAlchemy's defaults makes it fail immediately (verified).

## This is a mitigation, not the cure

Stated plainly so it is not mistaken for a fix: raising the pool stops the *pool* from being the bottleneck, but the underlying problem is that **a single LLM call can hold a database connection for twenty minutes**.

Measured on production over six hours:

| stage | model | calls | p50 | p95 | max | failed |
|---|---|---:|---:|---:|---:|---:|
| relevance | gpt-5.6-luna | 538 | **13.3s** | **1215s** | 1249s | 27 |
| librarian | gpt-5.6-luna | 103 | 68.0s | 301s | 734s | **33** |
| extract | gpt-5.6-luna | 8 | 13.8s | 1009s | 1159s | 0 |
| embedding | BGE-M3 | 108 | 1.8s | 2.6s | 4.0s | 0 |

The p95 is not the model thinking slowly. `_MAX_ATTEMPTS=4` × a 300s client timeout + 3+6+12s backoff = **1221s**, against a measured p95 of 1215s and max of 1249s. Those twenty-minute calls are the retry loop sitting patiently through four consecutive five-minute timeouts — and the scoring coroutine holds its connection for all of it.

Two follow-ups, neither in this PR:

1. **Per-stage timeouts.** A stage with a 13-second median has no business waiting 300 seconds, still less four times over. Short JSON stages (relevance / sextant / extract) want a ~60s ceiling and a tighter attempt budget; long-form stages (librarian / writing) can stay generous.
2. **Do not hold a connection across the LLM call.** `score_one` currently opens a session, calls the LLM, writes, and commits. Splitting it into read-snapshot → release → call → reacquire-and-write decouples LLM latency from database pool pressure entirely.

Also worth a separate look: `librarian` failed **33 of 103** calls (32%).

## Verification

Full backend suite: **907 passed**. `ruff check app` clean. Guard test sensitivity-checked against the old defaults.