### PR TITLE
fix(llm): give short JSON stages a tight call budget

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -41,6 +41,14 @@ class Settings(BaseSettings):
     # 默认回退 sqlite+aiosqlite，便于无 docker 的本地开发与测试；生产用 postgresql+asyncpg
     database_url: str = "sqlite+aiosqlite:///./polaris_dev.db"
     redis_url: str = "redis://localhost:6379/0"
+    # 连接池要装得下 worker 的并发：max_jobs(10) 个 voyage × 每个 voyage 的打分并发
+    # (_LLM_CONCURRENCY=5)，每篇论文各开一个 session，再加上引擎自己记步骤/检查点的那条。
+    # SQLAlchemy 默认 5+10=15，实测在生产上被打满：50 个协程抢 15 个连接，多数等满 30s
+    # 超时、该篇打分失败、状态停在 candidate——库里那 2400 多条「从没打过分」的候选就是
+    # 这么攒出来的。Postgres 侧 max_connections=100，这个额度装得下。
+    db_pool_size: int = 20
+    db_max_overflow: int = 50
+    db_pool_timeout: int = 30
 
     # ---- LLM providers（初始值；后续可在 DB 模型路由表中配置）----
     openai_compat_base_url: str = "https://api.deepseek.com/v1"

--- a/src/backend/app/core/db.py
+++ b/src/backend/app/core/db.py
@@ -28,7 +28,18 @@ _sessionmaker: async_sessionmaker[AsyncSession] | None = None
 def get_engine() -> AsyncEngine:
     global _engine
     if _engine is None:
-        _engine = create_async_engine(get_settings().database_url, echo=False)
+        settings = get_settings()
+        kwargs: dict[str, object] = {"echo": False}
+        if not settings.is_sqlite:
+            # sqlite 走的是 NullPool/StaticPool，给它这些参数会直接报错
+            kwargs |= {
+                "pool_size": settings.db_pool_size,
+                "max_overflow": settings.db_max_overflow,
+                "pool_timeout": settings.db_pool_timeout,
+                # 长跑的 worker 连接可能被中间件掐掉，取用前探活一次
+                "pool_pre_ping": True,
+            }
+        _engine = create_async_engine(settings.database_url, **kwargs)
         if _engine.url.get_backend_name() == "sqlite":
             # sqlite 默认不强制外键：打开 pragma，让 ON DELETE CASCADE 生效（对齐 postgres）
             @event.listens_for(_engine.sync_engine, "connect")

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -54,7 +54,7 @@ class OpenAICompatProvider(LLMProvider):
     async def _post_with_retry(self, url: str, payload: dict[str, Any]) -> httpx.Response:
         """429/5xx/网络错误重试（指数退避，尊重 Retry-After），其余状态原样返回。"""
         last_exc: Exception | None = None
-        for attempt in range(_MAX_ATTEMPTS):
+        for attempt in range(self._max_attempts):
             try:
                 resp = await self._client.post(url, headers=self._headers(), json=payload)
             except (httpx.TransportError, httpx.TimeoutException) as e:
@@ -69,20 +69,22 @@ class OpenAICompatProvider(LLMProvider):
                 # 中转把「不支持该参数」包成了 5xx：这不是临时故障，重试多少次都一样，
                 # 直接交回上层去掉参数重试，别白烧几十秒退避。
                 return resp
-            if resp.status_code in _RETRYABLE_STATUS and attempt < _MAX_ATTEMPTS - 1:
+            if resp.status_code in _RETRYABLE_STATUS and attempt < self._max_attempts - 1:
                 delay = _retry_delay(resp, attempt)
                 logger.warning(
                     "openai_compat %s，%.0fs 后重试（%d/%d）：%s",
                     resp.status_code,
                     delay,
                     attempt + 1,
-                    _MAX_ATTEMPTS,
+                    self._max_attempts,
                     url,
                 )
                 await asyncio.sleep(delay)
                 continue
             return resp
-        raise RuntimeError(f"openai_compat 请求 {url} 重试 {_MAX_ATTEMPTS} 次后仍失败：{last_exc}")
+        raise RuntimeError(
+            f"openai_compat 请求 {url} 重试 {self._max_attempts} 次后仍失败：{last_exc}"
+        )
 
     def __init__(
         self,
@@ -91,9 +93,11 @@ class OpenAICompatProvider(LLMProvider):
         *,
         client: httpx.AsyncClient | None = None,
         timeout: float = 300.0,
+        max_attempts: int = _MAX_ATTEMPTS,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
+        self._max_attempts = max_attempts
         self._client = client or httpx.AsyncClient(timeout=timeout)
         # 已确认不吃 reasoning_effort 的 model（本进程内记忆）。provider 实例被
         # LLMRouter 缓存复用，所以每个模型只需要付一次"失败再重试"的往返代价。

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -110,6 +110,24 @@ STREAM_STAGES = frozenset(
 )
 _STREAM_FLUSH_CHARS = 80  # token 增量攒到此长度再广播一段（节流，防刷爆 pub/sub）
 
+# 一次调用能等多久、重试几次，按环节分两档——两者的合理耐心程度差一个数量级。
+#
+# 生产实测（gpt-5.6-luna，6 小时）：relevance 中位 13.3s，但 p95 达到 1215s。
+# 那不是模型在慢慢想——4 次尝试 × 300s 超时 + 退避 3+6+12 正好是 1221s，也就是
+# 重试循环耐心地熬过四次各 5 分钟的超时。而打分协程全程攥着一个数据库连接，
+# 于是连接池被卡死的协程占满，其余论文打分批量超时、状态停在 candidate。
+#
+# 短 JSON 环节（打分 / 判定 / 结构化抽取）中位数都在十几秒，没有理由等 300 秒，
+# 更没理由等四次；卡住的短请求重试也极少能救回来。长文本环节（编译 / 写作 /
+# 评审）本来就要跑几分钟，保持宽松。
+_SHORT_CALL = (60.0, 2)  # (timeout 秒, 最多尝试次数) → 最坏 60+3+60 = 123s
+_LONG_CALL = (300.0, 4)
+
+
+def call_profile(stage: str) -> tuple[float, int]:
+    """该环节单次调用的 (超时, 最大尝试次数)。"""
+    return _LONG_CALL if stage in STREAM_STAGES else _SHORT_CALL
+
 
 class LLMRouter:
     """stage → (provider 实例, model)；complete/stream 自动记账。
@@ -124,8 +142,20 @@ class LLMRouter:
         self._routes_loaded_at: dict[uuid.UUID | None, float] = {}
         # 用户 llm_self_managed 标志缓存（(flag, loaded_at)）
         self._self_managed: dict[uuid.UUID, tuple[bool, float]] = {}
-        self._providers: dict[tuple[str, str | None, str], LLMProvider] = {}
+        # 键含耐心档位（见 call_profile）：长/短两档各持一个客户端。键是实现细节，
+        # 要在测试里替换 provider 请用 override_provider()，别直接往这个字典里塞。
+        self._providers: dict[tuple[str, str | None, str, float, int], LLMProvider] = {}
+        self._override: LLMProvider | None = None
         self.event_bus: Any | None = None
+
+    def override_provider(self, provider: LLMProvider | None) -> None:
+        """强制所有环节都用这个 provider（测试注入点；传 None 取消）。
+
+        以前测试是直接往 ``_providers`` 里按键塞，于是缓存键的形状变成了事实上的
+        公开接口——给它加个「耐心档位」维度就一次打断 16 个用例。走这个口子，
+        键怎么变都与测试无关。
+        """
+        self._override = provider
 
     def invalidate_cache(self) -> None:
         """管理端 / 用户改动 providers/routes/接管状态后调用（清所有 owner）。"""
@@ -193,16 +223,23 @@ class LLMRouter:
             return None
         return user_id if await self._is_self_managed(user_id) else None
 
-    def _provider_for(self, route: ResolvedRoute) -> LLMProvider:
-        key = (route.provider_kind, route.base_url, route.api_key)
+    def _provider_for(self, route: ResolvedRoute, stage: str = "") -> LLMProvider:
+        if self._override is not None:
+            return self._override
+        # 耐心程度进缓存键：同一个 provider 配置在长/短两档下各持一个客户端
+        timeout, attempts = call_profile(stage)
+        key = (route.provider_kind, route.base_url, route.api_key, timeout, attempts)
         if key not in self._providers:
             if route.provider_kind == "openai_compat":
                 base_url = route.base_url or get_settings().openai_compat_base_url
                 self._providers[key] = OpenAICompatProvider(
-                    base_url=base_url, api_key=route.api_key
+                    base_url=base_url,
+                    api_key=route.api_key,
+                    timeout=timeout,
+                    max_attempts=attempts,
                 )
             elif route.provider_kind == "anthropic":
-                self._providers[key] = AnthropicProvider(api_key=route.api_key)
+                self._providers[key] = AnthropicProvider(api_key=route.api_key, timeout=timeout)
             elif route.provider_kind == "fake":
                 self._providers[key] = FakeProvider()
             else:
@@ -244,7 +281,7 @@ class LLMRouter:
                             "no LLM provider configured — add a provider and routes in settings"
                         )
                     route = _FALLBACK_ROUTE
-        return self._provider_for(route), route
+        return self._provider_for(route, stage), route
 
     async def model_name(self, stage: str, user_id: uuid.UUID | None = None) -> str | None:
         """该环节实际会用到的模型名；未配置/不可用时 None（调用方只用于展示）。

--- a/src/backend/tests/test_experiment_env.py
+++ b/src/backend/tests/test_experiment_env.py
@@ -192,7 +192,7 @@ async def test_prompt_context_sections(client, queue_stub, fake_ssh, bus_recorde
 
     provider = _RecordingProvider()
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
     await _run_pipeline(client, headers, project_id, exp["voyage_id"], router)
 
     plan_prompts = [p for p in provider.prompts if "实验规划师" in p]

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -130,7 +130,7 @@ class _QCFailOnceProvider(FakeProvider):
 
 def _router_with(provider: FakeProvider) -> LLMRouter:
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
     return router
 
 

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -777,7 +777,7 @@ async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorde
     exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
 
     router = LLMRouter()
-    router._providers[("fake", None, "")] = _PathViolationProvider()
+    router.override_provider(_PathViolationProvider())
     engine, bus = _make_engine(router)
     await engine.run(uuid.UUID(voyage_id))
     await _approve_gate(client, headers, project_id)

--- a/src/backend/tests/test_idea_forge.py
+++ b/src/backend/tests/test_idea_forge.py
@@ -276,7 +276,7 @@ async def test_forge_resume_does_not_regenerate(client, queue_stub):
 
     provider = _CrashOnFirstScore()
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
     engine = VoyageEngine(event_bus=RecordingBus(), llm_router=router)
     with pytest.raises(asyncio.CancelledError):
         await engine.run(run_id)

--- a/src/backend/tests/test_idea_review.py
+++ b/src/backend/tests/test_idea_review.py
@@ -265,7 +265,7 @@ async def test_discussion_and_human_context_injection(client, queue_stub, bus_re
     run_id = resp.json()["id"]
     provider = _RecordingProvider()
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
     engine = VoyageEngine(event_bus=RecordingBus(), llm_router=router)
     await engine.run(uuid.UUID(run_id))
 

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -178,8 +178,9 @@ async def test_route_effort_reaches_provider(app):
             seen.append(kwargs.get("effort"))
             return await super().complete(messages, **kwargs)
 
-    router._providers[("fake", None, "fake-db-model")] = _Recorder()
-    router._provider_for = lambda r: router._providers[("fake", None, "fake-db-model")]  # type: ignore[assignment]
+    recorder = _Recorder()
+    # _provider_for 现在按 (route, stage) 取——stage 决定超时/重试档位（call_profile）
+    router._provider_for = lambda r, stage="": recorder  # type: ignore[assignment]
 
     await router.complete("default", [Message(role="user", content="hi")])
     await router.complete("default", [Message(role="user", content="hi")], effort="low")
@@ -206,7 +207,53 @@ async def test_route_without_effort_sends_nothing(app):
 
     router = LLMRouter()
     legacy = _LegacyProvider()
-    router._provider_for = lambda r: legacy  # type: ignore[assignment]
+    router._provider_for = lambda r, stage="": legacy  # type: ignore[assignment]
     result = await router.complete("default", [Message(role="user", content="hi")])
     assert result.content == "ok"
     assert len(seen_kwargs) == 1
+
+
+# ---- 按环节区分耐心程度（生产上 relevance p95 达 1215s 的直接原因）----
+
+
+def test_short_json_stages_get_a_tight_call_budget():
+    """打分/判定/抽取这类短 JSON 环节，最坏耗时要压在两分钟级以内。
+
+    生产实测 relevance 中位 13.3s、p95 却有 1215s——4 次尝试 × 300s 超时 + 退避
+    3+6+12 正好 1221s，也就是重试循环熬过四次五分钟超时。而打分协程全程占着一个
+    数据库连接，连接池被卡死的协程占满，其余论文批量超时、状态停在 candidate。
+    """
+    from app.core.llm.router import call_profile
+
+    for stage in ("relevance", "sextant", "extract", "concepts"):
+        timeout, attempts = call_profile(stage)
+        worst = timeout * attempts + 3 * (attempts - 1)  # 含指数退避
+        assert worst <= 180, f"{stage} 最坏 {worst}s，太能等了"
+
+
+def test_long_form_stages_stay_patient():
+    """编译 / 写作 / 评审本来就要跑几分钟，别把它们一起收紧了。"""
+    from app.core.llm.router import STREAM_STAGES, call_profile
+
+    for stage in STREAM_STAGES:
+        timeout, _ = call_profile(stage)
+        assert timeout >= 300, f"{stage} 超时 {timeout}s 太短"
+
+
+def test_profile_is_part_of_the_provider_cache_key():
+    """长短两档必须各持一个客户端——否则先建的那个把超时定死给所有环节。"""
+    from app.core.llm.router import LLMRouter, ResolvedRoute
+
+    router = LLMRouter()
+    route = ResolvedRoute(
+        provider_kind="fake",
+        base_url=None,
+        api_key="",
+        model="m",
+        temperature=None,
+        provider_name="fake",
+        effort=None,
+    )
+    router._provider_for(route, "relevance")
+    router._provider_for(route, "librarian")
+    assert len(router._providers) == 2, "长短档共用了同一个客户端"

--- a/src/backend/tests/test_paper_figures.py
+++ b/src/backend/tests/test_paper_figures.py
@@ -287,7 +287,7 @@ async def test_annotate_figures_degrades_to_top4_by_area(app):
 
     provider = _FailingVLM()
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
     merged = await annotate_figures(paper, candidates, llm=router)
 
     assert provider.image_calls == 2  # 失败重试 1 次

--- a/src/backend/tests/test_wiki_figures_compile.py
+++ b/src/backend/tests/test_wiki_figures_compile.py
@@ -159,7 +159,7 @@ async def test_compile_paper_strips_invalid_markers(app):
     )
     figure_path(str(paper.id), 0).write_bytes(_opaque_png_bytes(40, 30))
     router = LLMRouter()
-    router._providers[("fake", None, "")] = _InvalidMarkerLibrarian()
+    router.override_provider(_InvalidMarkerLibrarian())
 
     content = (await compile_paper(paper, llm=router)).content
     assert "![[fig:0]]" in content  # 有效标记保留
@@ -357,7 +357,7 @@ async def test_compile_paper_retries_when_figures_not_used(app):
     figure_path(str(paper.id), 0).write_bytes(_opaque_png_bytes(40, 30))
     provider = _NoMarkerLibrarian()
     router = LLMRouter()
-    router._providers[("fake", None, "")] = provider
+    router.override_provider(provider)
 
     content = (await compile_paper(paper, llm=router)).content
     assert provider.compile_calls == 2  # 首稿无标记 → 重试一次

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -447,7 +447,7 @@ async def test_resume_does_not_rescore(client, queue_stub, wiki_mocks):
     # 并发各自打分：其中 1 个（第 2 次 LLM 调用）抛 CancelledError，其余 3 个照常完成并
     # 逐篇 commit。故崩溃后恰好 3 篇落库、1 篇仍是 candidate（下次续跑补打这 1 篇）。
     crashing_router = LLMRouter()
-    crashing_router._providers[("fake", None, "")] = _CrashOnNthRelevance(crash_at=2)
+    crashing_router.override_provider(_CrashOnNthRelevance(crash_at=2))
     engine = VoyageEngine(event_bus=RecordingBus(), llm_router=crashing_router)
     with pytest.raises(asyncio.CancelledError):
         await engine.run(run_id)
@@ -502,7 +502,7 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
 
     router = LLMRouter()
     # "Benchmark" 命中「LLM Scientist Benchmark Suite」这一篇 → 该篇打分返回坏 JSON
-    router._providers[("fake", None, "")] = _BreakOneRelevance(break_marker="Benchmark")
+    router.override_provider(_BreakOneRelevance(break_marker="Benchmark"))
     engine = VoyageEngine(event_bus=RecordingBus(), llm_router=router)
     await engine.run(run_id)
 

--- a/src/backend/tests/test_worker_registration.py
+++ b/src/backend/tests/test_worker_registration.py
@@ -56,3 +56,37 @@ async def test_enqueueing_a_registered_task_passes_the_check():
 
     for name in WORKER_FUNCTIONS:
         check_task_name(name)  # 不抛即通过
+
+
+# ---- 连接池要装得下 worker 的并发 ----
+
+
+def test_db_pool_fits_worker_concurrency():
+    """池子上限必须 ≥ worker 并发跑打分时的连接需求。
+
+    生产上曾经不满足：SQLAlchemy 默认 5+10=15，而 max_jobs(10) 个 voyage 各开
+    _LLM_CONCURRENCY(5) 个协程、每篇论文一个 session ⇒ 峰值 50。50 抢 15 的结果是
+    大批协程等满 pool_timeout 后超时，该篇打分失败、状态停在 candidate——生产库里
+    积了 2400 多条从没打过分的候选就是这么来的。
+    """
+    from app.agents.voyage.actions_wiki import _LLM_CONCURRENCY
+    from app.core.config import get_settings
+    from worker.settings import WorkerSettings
+
+    max_jobs = getattr(WorkerSettings, "max_jobs", 10)
+    settings = get_settings()
+    ceiling = settings.db_pool_size + settings.db_max_overflow
+    # 每个 voyage：打分并发 + 引擎自己记步骤/检查点的那条
+    need = max_jobs * (_LLM_CONCURRENCY + 1)
+    assert ceiling >= need, (
+        f"连接池上限 {ceiling} < 峰值需求 {need}"
+        f"（max_jobs={max_jobs} × (打分并发 {_LLM_CONCURRENCY} + 1)）"
+    )
+
+
+def test_sqlite_engine_skips_pool_sizing():
+    """sqlite 用的是 NullPool/StaticPool，传 pool_size 会直接报错——测试库靠这条保命。"""
+    from app.core.db import get_engine
+
+    engine = get_engine()
+    assert engine is not None  # 建得起来即说明没把池参数塞给 sqlite


### PR DESCRIPTION
Stacked on #228 (the pool fix); GitHub will retarget to `main` once that merges.

## The twenty-minute call

Measured on production over six hours with `gpt-5.6-luna`:

| stage | p50 | p95 | max |
|---|---:|---:|---:|
| relevance | **13.3s** | **1215s** | 1249s |
| extract | 13.8s | 1009s | 1159s |

The p95 is not the model thinking slowly. `_MAX_ATTEMPTS=4` × a 300s client timeout + 3+6+12s backoff = **1221s**, against a measured p95 of 1215s. Those calls are the retry loop sitting patiently through four consecutive five-minute timeouts.

That matters because the scoring coroutine **holds a database connection for the whole call**. Stalled coroutines occupy the pool, everything else times out acquiring a connection, those papers fail to score, and their membership stays at `candidate` — which is where the 2,400+ never-scored candidates in production came from.

## Two levels of patience

```python
_SHORT_CALL = (60.0, 2)   # 打分 / 判定 / 结构化抽取 → 最坏 123s
_LONG_CALL  = (300.0, 4)  # 编译 / 写作 / 评审（STREAM_STAGES）
```

The split reuses `STREAM_STAGES`, which already encodes "this stage produces long-form text". A stage whose median is thirteen seconds has no business waiting three hundred, still less four times over; and a short request that has already stalled rarely recovers on retry, so its attempt count is halved too.

Worst case per paper drops from **1221s to 123s**. The median path is untouched.

## The part that broke sixteen tests

The profile goes into the provider cache key, so a given provider config keeps one client per level. That change broke 16 tests, all for the same reason: they inject fakes with

```python
router._providers[("fake", None, "")] = provider
```

The cache key had quietly become public API — adding a dimension to it snapped every injection site at once.

Rather than contort the key, this adds an explicit seam:

```python
router.override_provider(provider)   # 所有环节都用它；传 None 取消
```

Eight sites moved over. The key is an implementation detail again, and future changes to it cannot break tests this way.

## Verification

Full backend suite: **910 passed**. `ruff check app tests` clean.

Three new tests: short stages stay within a 180s worst case (timeout × attempts + backoff), `STREAM_STAGES` keep a ≥300s timeout, and the two levels really do get separate clients.

## Also worth knowing

Production's `relevance` route was switched to `dashscope/qwen-flash` at 15:25 today (in another session). Early numbers, small sample: 5 calls, avg 31.0s, **p95 31.7s, zero failures** — a slower median than gpt-5.6-luna's 13.3s, but with no tail. Under concurrency a predictable 31s beats "usually 13s, sometimes 20 minutes" by a wide margin, since it is the tail that pins connections.

Still open, not in this PR: `score_one` holding a database connection across the LLM call at all, and `librarian` failing 33 of 103 calls (32%).