### PR TITLE
fix(ingest): make vector writes atomic and scope fetch/compile to the current run

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -230,6 +230,20 @@ def _is_retryable_conflict(exc: BaseException) -> bool:
     return code in _RETRYABLE_SQLSTATES
 
 
+def _scored_in_this_run(ctx: ActionContext):
+    """限定「本次运行打分收下的论文」的查询条件。
+
+    以前取全文/编译都是扫全库所有 status='scored' / 'fetched' 的行，于是
+    「本次通过筛选 1 篇」后面跟着「下载 12 个 PDF」——两个数字统计的不是同一批
+    论文，看着像对不上。
+
+    按 ``scored_at >= 本次运行创建时刻`` 筛，而不是靠 checkpoint 记 id：步骤中途
+    崩溃、恢复后重跑时，checkpoint 里那份记录会丢，崩溃前已打分的论文就再也进不了
+    后续步骤；而 scored_at 落在库里，恢复后照样认得出来。
+    """
+    return LibraryPaper.scored_at >= ctx.run.created_at
+
+
 async def _insert_pooled_with_retry(
     session: AsyncSession, **kwargs: Any
 ) -> tuple[Paper | None, str | None]:
@@ -901,15 +915,18 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         library = await _resolve_library(session, ctx)
         billing_user_id = _ingest_billing_owner(library)
         affil_mode = await get_affiliation_extraction_mode(session)
-        pairs = (
-            await session.execute(
-                select(Paper, LibraryPaper)
-                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
-                .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "scored")
-                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
-                .limit(top_n)
-            )
-        ).all()
+        # 只处理**本次**打分收下的论文，不去捞历史积压。
+        # 以前是扫全库所有 status='scored' 的行，于是「本次通过筛选 1 篇」后面
+        # 跟着「下载 12 个 PDF」——两个数字统计的不是同一批论文，看起来像对不上。
+        # 代价是被预算截断的运行会把已打分未取全文的论文留在原地，需要另行处理。
+        stmt = (
+            select(Paper, LibraryPaper)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "scored")
+            .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+            .limit(top_n)
+        )
+        pairs = (await session.execute(stmt.where(_scored_in_this_run(ctx)))).all()
         papers = [p for p, _ in pairs]
         membership_of = {p.id: m for p, m in pairs}
         # 发表日期回填：雪球/DOI 来源的论文只有年份，arXiv 能查到精确日期（时间线/趋势视图用）
@@ -1029,14 +1046,14 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
         billing_user_id = _ingest_billing_owner(library)
         # 幂等断点：已 compiled 的不再进入（status=fetched 才编译）。外层只查 id，每篇
         # 编译在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
-        rows = (
-            await session.execute(
-                select(LibraryPaper.id, LibraryPaper.paper_id)
-                .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "fetched")
-                .order_by(LibraryPaper.relevance_score.desc().nulls_last())
-                .limit(top_n)
-            )
-        ).all()
+        stmt = (
+            select(LibraryPaper.id, LibraryPaper.paper_id)
+            .where(LibraryPaper.library_id == library.id, LibraryPaper.status == "fetched")
+            .order_by(LibraryPaper.relevance_score.desc().nulls_last())
+            .limit(top_n)
+        )
+        # 同 fetch_extract：只编译本次收下的那批，不捞历史积压
+        rows = (await session.execute(stmt.where(_scored_in_this_run(ctx)))).all()
         membership_ids = [mid for mid, _ in rows]
         paper_ids = [pid for _, pid in rows]
 

--- a/src/backend/app/services/embedding.py
+++ b/src/backend/app/services/embedding.py
@@ -176,23 +176,56 @@ async def _upsert(
     vector: list[float],
     space: EmbeddingSpace,
 ) -> None:
+    """原子写入/覆盖向量（调用方负责 commit）。
+
+    必须是真 upsert，不能「先查后插」：论文在全局内容池里是共享的，多个库并行同步时
+    会同时给同一篇论文的同一段建向量，两个事务各自查到「没有」，然后一起插——
+    (chunk_id, space) 主键冲突。而挂起的 INSERT 往往由后面某个查询的 autoflush 触发，
+    于是 UniqueViolationError 会在一个看起来毫不相干的地方抛出来
+    （"raised as a result of Query-invoked autoflush"），排查成本很高。
+    """
     if len(vector) != space.dim:
         raise EmbeddingSpaceMismatchError(
             f"refusing to store a {len(vector)}-dim vector in space {space}"
         )
-    row = (
-        await session.execute(
-            select(model_class).where(key_column == key, model_class.space == space.key)
+    values = {
+        key_column.key: key,
+        "space": space.key,
+        "dim": space.dim,
+        "embedding": vector,
+        "model": space.model,
+        "text_version": TEXT_VERSION,
+        "built_at": utcnow(),
+    }
+    dialect = session.get_bind().dialect.name
+    if dialect == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as _insert
+    elif dialect == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as _insert
+    else:  # 其余方言没有 ON CONFLICT，退回先查后插（单机开发场景没有并发问题）
+        row = (
+            await session.execute(
+                select(model_class).where(key_column == key, model_class.space == space.key)
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            row = model_class(**{key_column.key: key, "space": space.key})
+            session.add(row)
+        for field, value in values.items():
+            setattr(row, field, value)
+        return
+
+    stmt = _insert(model_class).values(**values)
+    await session.execute(
+        stmt.on_conflict_do_update(
+            index_elements=[key_column.key, "space"],
+            set_={k: v for k, v in values.items() if k not in (key_column.key, "space")},
         )
-    ).scalar_one_or_none()
-    if row is None:
-        row = model_class(**{key_column.key: key, "space": space.key})
-        session.add(row)
-    row.dim = space.dim
-    row.embedding = vector
-    row.model = space.model
-    row.text_version = TEXT_VERSION
-    row.built_at = utcnow()
+    )
+    # 该行可能已在 identity map 里且被这条 INSERT 绕过了，过期它免得读到旧向量
+    existing = await session.get(model_class, (key, space.key))
+    if existing is not None:
+        await session.refresh(existing)
 
 
 # ---- 空间管理（管理端） ----

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -26,6 +26,7 @@ from app.agents.voyage import actions_wiki
 from app.agents.voyage.actions import ActionContext
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper
 from app.models.voyage import VoyageRun
 from app.services import affiliations as affil_service
@@ -384,6 +385,15 @@ async def _setup_scored_paper(
             checkpoint={"params": {}},
         )
         session.add_all([paper, run])
+        await session.flush()
+        # 真实流程里是先建运行、再逐篇打分，所以 scored_at 一定落在运行创建之后。
+        # 取全文那步只处理「本次运行收下的」，靠的就是这个时刻。
+        membership = (
+            await session.execute(
+                select(LibraryPaper).where(LibraryPaper.paper_id == paper.id)
+            )
+        ).scalar_one()
+        membership.scored_at = run.created_at
         await session.commit()
         await session.refresh(paper)
         await session.refresh(run)

--- a/src/backend/tests/test_embedding_space.py
+++ b/src/backend/tests/test_embedding_space.py
@@ -291,3 +291,127 @@ async def test_space_inventory_counts_each_kind(client):
         items = await space_inventory(session)
     assert len(items) == 1
     assert items[0]["papers"] == 2 and items[0]["active"] is True
+
+
+# ---- 并发写同一条向量（生产 UniqueViolationError 的来源）----
+
+
+async def test_upsert_same_vector_twice_overwrites_instead_of_raising(client):
+    """同一 (key, space) 写两次要覆盖，不能撞主键。
+
+    生产上报的就是这个：论文在全局内容池里共享，多个库并行同步时会同时给同一篇论文
+    的同一段建向量，两个事务各自查到「没有」然后一起插 ⇒
+      UniqueViolationError: duplicate key value violates unique constraint
+      "paper_chunk_vectors_pkey"  Key (chunk_id, space)=(..., BGE-M3@1024)
+    而且挂起的 INSERT 常由后面某个查询的 autoflush 触发，报错位置看着毫不相干。
+    """
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.core.embedding_space import EmbeddingSpace
+    from app.models.paper import PaperChunk, new_paper
+    from app.models.vectors import PaperChunkVector
+    from app.services.embedding import upsert_chunk_vector
+
+    space = EmbeddingSpace(model="BGE-M3", dim=4)
+    async with get_sessionmaker()() as session:
+        paper = new_paper(source="arxiv", arxiv_id="2699.00001", title="Dup Vector Paper")
+        session.add(paper)
+        await session.flush()
+        chunk = PaperChunk(paper_id=paper.id, seq=0, text="hello")
+        session.add(chunk)
+        await session.flush()
+        chunk_id = chunk.id
+
+        await upsert_chunk_vector(session, chunk_id, [0.1, 0.2, 0.3, 0.4], space)
+        await session.commit()
+
+        # 第二次写同一 (chunk_id, space)：覆盖，不抛
+        await upsert_chunk_vector(session, chunk_id, [0.9, 0.8, 0.7, 0.6], space)
+        await session.commit()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PaperChunkVector).where(PaperChunkVector.chunk_id == chunk_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, "同一段在同一空间里只该有一行"
+        assert [round(x, 1) for x in rows[0].embedding] == [0.9, 0.8, 0.7, 0.6], "后写的没覆盖"
+
+
+async def test_upsert_survives_a_concurrent_writer(client):
+    """交错写同一条 (key, space)：另一个会话抢先插入后，本次写入不能炸。
+
+    这条才是钉住修复的用例——上一条在单线程下「先查后插」也能过。
+    生产报错正是这个竞态：
+      UniqueViolationError: duplicate key ... "paper_chunk_vectors_pkey"
+      Key (chunk_id, space)=(..., BGE-M3@1024)
+    旧实现先 SELECT 到「没有」、把新行挂进 session，等真正 flush 时对方已经提交，
+    于是撞主键；且 flush 常由后面某个查询的 autoflush 触发，报错位置毫不相干。
+    """
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.core.embedding_space import EmbeddingSpace
+    from app.models.paper import PaperChunk, new_paper
+    from app.models.vectors import PaperChunkVector
+    from app.services.embedding import upsert_chunk_vector
+
+    space = EmbeddingSpace(model="BGE-M3", dim=4)
+    maker = get_sessionmaker()
+    async with maker() as setup:
+        paper = new_paper(source="arxiv", arxiv_id="2699.00002", title="Race Paper")
+        setup.add(paper)
+        await setup.flush()
+        chunk = PaperChunk(paper_id=paper.id, seq=0, text="race")
+        setup.add(chunk)
+        await setup.commit()
+        chunk_id = chunk.id
+
+    # 会话 B 抢先把这条写进去并提交
+    async with maker() as b:
+        await upsert_chunk_vector(b, chunk_id, [0.1, 0.1, 0.1, 0.1], space)
+        await b.commit()
+
+    # 会话 A 随后写同一条：必须覆盖而不是撞主键
+    async with maker() as a:
+        await upsert_chunk_vector(a, chunk_id, [0.5, 0.5, 0.5, 0.5], space)
+        await a.commit()
+
+    async with maker() as check:
+        rows = (
+            (
+                await check.execute(
+                    select(PaperChunkVector).where(PaperChunkVector.chunk_id == chunk_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert [round(x, 1) for x in rows[0].embedding] == [0.5, 0.5, 0.5, 0.5]
+
+
+def test_upsert_is_atomic_not_check_then_insert():
+    """守卫：``_upsert`` 必须走 ON CONFLICT，不能是「先查后插」。
+
+    生产报错来自这个竞态：A 查到「没有」把新行挂进 session，B 抢先插入并提交，
+    A 真正 flush 时撞主键 ——
+      UniqueViolationError: duplicate key ... "paper_chunk_vectors_pkey"
+      Key (chunk_id, space)=(..., BGE-M3@1024)
+
+    **这个竞态在 sqlite 上没法忠实复现**：要让 A 在未提交状态下挂着待插行，
+    A 的写锁就会把 B 挡在外面。上面两条只覆盖了「重复写入要覆盖」的行为，
+    退回旧实现照样通过——所以这里只能做源码级守卫，它比没有强，但确实不是
+    端到端验证。
+    """
+    import inspect
+
+    from app.services import embedding
+
+    src = inspect.getsource(embedding._upsert)
+    assert "on_conflict_do_update" in src, "_upsert 退回了先查后插，并发写会撞主键"

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -1797,3 +1797,60 @@ async def test_insert_retry_reraises_unrelated_errors():
             await mod._insert_pooled_with_retry(_Session(), library_id=None)
     finally:
         mod._pool_paper_or_new = original
+
+
+# ---- 只处理本次收下的，不捞历史积压 ----
+
+
+async def test_run_does_not_pick_up_an_older_backlog(client, queue_stub, wiki_mocks):
+    """库里早先积压的 scored 论文，不该被这次同步顺手带走。
+
+    以前取全文那步扫的是全库所有 status='scored' 的行，于是「本次通过筛选 1 篇」
+    后面跟着「下载 12 个 PDF」，两个数字统计的不是同一批论文。
+    """
+    import datetime as dt
+
+    from sqlalchemy import select as sa_select
+
+    from app.models.library_direction import LibraryPaper
+
+    project_id, headers = await _setup_project(client)
+    await _bootstrap(client, project_id, headers)
+
+    # 造一篇「上周就打过分、一直没取全文」的积压论文
+    async with get_sessionmaker()() as session:
+        rows = await project_paper_rows(session, project_id=project_id)
+        library_id = rows[0][1].library_id
+        stale = new_paper(
+            source="arxiv", arxiv_id="2607.97000", title="Stale Backlog Paper", year=2026
+        )
+        session.add(stale)
+        await session.flush()
+        session.add(
+            LibraryPaper(
+                library_id=library_id,
+                paper_id=stale.id,
+                status="scored",
+                relevance_score=0.95,  # 分很高，按相关度排序会排在最前
+                scored_at=dt.datetime.now(dt.UTC) - dt.timedelta(days=7),
+            )
+        )
+        await session.commit()
+        stale_id = stale.id
+
+    async with get_sessionmaker()() as session:
+        await _seed_feed(
+            session,
+            project_id,
+            [("2607.97001", "Fresh Feed Paper", "research agents and planning")],
+        )
+
+    detail = await _run_incremental(client, project_id, headers)
+    assert detail["status"] == "done", detail
+
+    async with get_sessionmaker()() as session:
+        stale_row = (
+            await session.execute(sa_select(LibraryPaper).where(LibraryPaper.paper_id == stale_id))
+        ).scalar_one()
+        # 积压那篇原地不动：没被这次运行取全文、也没被编译
+        assert stale_row.status == "scored", "历史积压被这次同步顺手带走了"


### PR DESCRIPTION
Two problems visible from the task detail page, both reported from production.

## 1. IntegrityError — concurrent writers collide on the vector primary key

```
asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique
constraint "paper_chunk_vectors_pkey"   Key (chunk_id, space)=(..., BGE-M3@1024)
```

`embedding._upsert` is named upsert but is a check-then-insert:

```python
row = SELECT ... WHERE key AND space
if row is None:
    session.add(model_class(...))
```

Papers live in a shared global pool, so two libraries syncing in parallel both embed the *same* paper's chunks. Each transaction reads "not there", then both insert. Worse, the pending INSERT is usually flushed by some later query's autoflush, so the violation surfaces somewhere unrelated — which is what `raised as a result of Query-invoked autoflush` in the error means.

Now a real `ON CONFLICT DO UPDATE`, using the postgresql or sqlite dialect as appropriate. Other dialects keep the old path (single-machine dev, no concurrency).

## 2. The numbers did not line up

A run reporting **"通过筛选 1 个"** followed by **"下载 12 个 PDF"** was not inconsistent data — the two steps were counting different populations. Scoring reports what *this run* admitted; `fetch_extract` swept **every** `status='scored'` row in the library, backlog included. `compile` did the same with `status='fetched'`.

Both steps now restrict to `scored_at >= run.created_at`.

### Why not checkpoint ids

The obvious implementation — record ids in `ctx.checkpoint` during scoring, filter on them later — is wrong, and the existing resume test caught it immediately. `checkpoint["scored_ids"]` is written at the *end* of the scoring step, so a crash mid-step loses it; on resume the step only rescores what is still `candidate`, and papers scored before the crash are excluded from every later step forever. The test went red with exactly that: two papers stuck at `scored` instead of `compiled`.

`scored_at` is in the database, so it survives the crash and the resume sees the same set.

### The cost, stated plainly

A run truncated by budget, or one that fails, now leaves its scored-but-unfetched papers where they are — nothing picks them up later. Production already has this backlog and it will freeze in place:

| library | awaiting fetch | awaiting compile |
|---|---:|---:|
| game ai | 21 | 21 |
| SWE | 19 | 45 |
| VIdeo World Model | 16 | 33 |
| Spatial Reasoning | 11 | 46 |

Draining it needs either a one-off run before this deploys, or a manual "process backlog" action. Not in this PR.

## Verification

Full backend suite: **914 passed**. `ruff check app tests` clean.

The backlog test is sensitivity-checked: removing the run-scoping predicate makes it fail (the stale paper gets swept in).

**One honest caveat about the vector tests.** The two behavioural tests I wrote first (upsert overwrites; a concurrent writer then ours wins) **do not catch this bug** — the original check-then-insert passes both. My first two "sensitivity checks" of them were also invalid: the tests lacked a database fixture and failed under `-k` filtering regardless of implementation. After fixing the fixture and re-checking properly, the original implementation passes. The real interleaving (A selects, A stages a pending row, B commits, A flushes) cannot be reproduced on sqlite, because A's uncommitted write lock blocks B. So the fix is backed by a source-level guard asserting `_upsert` uses `on_conflict_do_update`, and the test docstring says outright that this is weaker than an integration test.

`test_affiliations`'s fixture built a paper that was `scored` with a NULL `scored_at`, created *before* its run — a state the real pipeline never produces. It now creates the run first and stamps `scored_at` from it.