### PR TITLE
fix(worker): reclaim every in-flight voyage on startup, not just executing

### DIFF
--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -37,6 +37,13 @@ VOYAGE_STATUSES = (
     "cancelled",
 )
 TERMINAL_STATUSES = frozenset({"done", "failed", "cancelled"})
+# 「有 worker 任务正持有它」的状态。worker 重启后必须把这些全部认领回来：
+# 互斥检查（find_running_ingest_for_library）把任何非终态都当成「在跑」，所以只要
+# 有一个状态漏了认领，那条运行就永远卡住，而它所属的文献库也再不能发起新同步——
+# 实测被重启掐在 planning / verifying 的三条运行卡了四个半小时，零进展。
+# paused_gate / paused_error 不在其列：它们是在等人，不是在等 worker
+# （另有 reclaim_stale_paused_ingests 按陈旧度处理）。
+IN_FLIGHT_STATUSES = frozenset({"planning", "executing", "verifying", "replanning"})
 
 # ---- 运行模式（docs/voyage-loop.md §2/§3）：由 kind 静态决定，不暴露给用户/LLM 选择 ----
 # pipeline：固定计划 + 机械校验，失败不经 LLM 重规划；

--- a/src/backend/tests/test_worker_registration.py
+++ b/src/backend/tests/test_worker_registration.py
@@ -90,3 +90,42 @@ def test_sqlite_engine_skips_pool_sizing():
 
     engine = get_engine()
     assert engine is not None  # 建得起来即说明没把池参数塞给 sqlite
+
+
+# ---- 启动对账要认领所有在途状态 ----
+
+
+async def test_reconcile_reclaims_every_in_flight_status(client, monkeypatch):
+    """worker 重启把运行掐在 planning / verifying 时，也必须重新入队。
+
+    互斥检查（find_running_ingest_for_library）把**任何非终态**都当成「正在跑」，
+    而对账以前只认领 executing。于是被掐在 planning / verifying 的运行永远没人接手，
+    它所属的文献库也再发不起新同步——生产上实测三条运行卡了四个半小时，
+    而它们的八个兄弟都已完成。
+    """
+    from app.core.db import get_sessionmaker
+    from app.models.voyage import IN_FLIGHT_STATUSES, TERMINAL_STATUSES, VoyageRun
+    from worker.tasks import reconcile_stuck_voyages
+
+    parked = ("paused_gate", "paused_error")
+    made: dict[str, str] = {}
+    async with get_sessionmaker()() as session:
+        for status in sorted(IN_FLIGHT_STATUSES | set(parked) | TERMINAL_STATUSES):
+            run = VoyageRun(kind="wiki_ingest", mode="pipeline", status=status, goal=status)
+            session.add(run)
+            await session.flush()
+            made[status] = str(run.id)
+        await session.commit()
+
+    enqueued: list[str] = []
+
+    class _Redis:
+        async def enqueue_job(self, name, run_id, **kwargs):
+            enqueued.append(run_id)
+
+    await reconcile_stuck_voyages({"redis": _Redis()})
+
+    for status in IN_FLIGHT_STATUSES:
+        assert made[status] in enqueued, f"{status} 没被认领，这条运行会永远卡住"
+    for status in (*parked, *TERMINAL_STATUSES):
+        assert made[status] not in enqueued, f"{status} 不该被自动重跑"

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -47,7 +47,7 @@ async def resume_voyage(ctx: dict[str, Any], run_id: str) -> None:
 
 
 async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
-    """worker 启动对账：认领无人执行的 executing 航程。
+    """worker 启动对账：认领无人执行的在途航程（见 IN_FLIGHT_STATUSES）。
 
     被 SIGTERM/超时打断的 ARQ 任务按任务年龄指数延迟重试，长航程会被晾数小时
     （实测：远端 run.sh 已 exit=0，平台侧 50 分钟无人收尾）。启动时把 executing
@@ -55,11 +55,17 @@ async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
     checkpoint 断点恢复），``_job_id`` 去重避免同一 voyage 重复入队。"""
     from sqlalchemy import select
 
-    from app.models.voyage import VoyageRun
+    from app.models.voyage import IN_FLIGHT_STATUSES, VoyageRun
 
     async with get_sessionmaker()() as session:
         ids = (
-            (await session.execute(select(VoyageRun.id).where(VoyageRun.status == "executing")))
+            (
+                await session.execute(
+                    select(VoyageRun.id).where(
+                        VoyageRun.status.in_(tuple(IN_FLIGHT_STATUSES))
+                    )
+                )
+            )
             .scalars()
             .all()
         )


### PR DESCRIPTION
## What was observed

Three incremental syncs sat untouched from 15:21 to 19:50 — four and a half hours, zero progress — while the other eight from the same batch finished:

| library | status when stalled | steps done |
|---|---|---:|
| game ai | `planning` | 0 |
| Utility-Preserving… | `verifying` | 1 |
| VIdeo World Model | `verifying` | 1 |

What they have in common: when the worker restart killed them, none was in `executing`.

## Two predicates that disagree

| logic | counts as "in flight" |
|---|---|
| `find_running_ingest_for_library` (mutex) | **any** non-terminal status |
| `reconcile_stuck_voyages` (startup) | `executing` only |

A run interrupted in `planning`, `verifying` or `replanning` is therefore never reclaimed — and the mutex still believes it is alive. **That library can never start another sync.** The daily job hits `IngestConflictError`, skips it, and will go on skipping it indefinitely. The damage is permanent, not transient.

## The change

`IN_FLIGHT_STATUSES` now names the states a worker task actually holds — `planning`, `executing`, `verifying`, `replanning` — and startup reconciliation reclaims all of them.

`paused_gate` and `paused_error` are deliberately excluded: those are waiting on a person, not on a worker, and `reclaim_stale_paused_ingests` already handles the stale ones on its own schedule.

## Verification

Full backend suite: **915 passed**. `ruff check app worker tests` clean.

The new test creates one run in each of the nine statuses and asserts the in-flight ones get re-enqueued while the paused and terminal ones do not. Sensitivity-checked against `origin/main`'s version of `worker/tasks.py`, which fails it.

Production's three stranded runs were re-enqueued by hand; each has since made 105–129 relevance calls and is progressing normally.

### One measurement caveat worth recording

`voyage_runs.updated_at` is not a liveness signal. The scoring step commits membership rows, not the run row, so a healthy run can look untouched for a long stretch. Whether a run is alive has to be read from `llm_call_logs`. I misread it as "not moving" at one point; the four-and-a-half-hour stall was nonetheless real, since those three had zero LLM calls across the whole window.