### PR TITLE
feat(libraries): write the statement through a structured AI interview

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -52,6 +52,9 @@ from app.schemas.libraries import (
     LibraryReject,
     PaperMergeRequest,
     PaperMergeResult,
+    StatementInterviewQuestion,
+    StatementInterviewRequest,
+    StatementInterviewResponse,
     SuggestDefinitionRequest,
     SuggestDefinitionResponse,
 )
@@ -83,6 +86,7 @@ from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
+from app.services import statement_interview as interview
 from app.services.embedding import embed_query
 from app.services.wiki_export import build_obsidian_zip_for_libraries
 
@@ -194,6 +198,45 @@ async def create_library(
     await session.commit()
     row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
+
+
+@router.post("/libraries/statement-interview", response_model=StatementInterviewResponse)
+async def statement_interview(
+    data: StatementInterviewRequest,
+    user: User = Depends(require_llm_task),
+) -> StatementInterviewResponse:
+    """结构化访谈产出文献库的方向描述：问四个环节，每题给几个可勾选的候选。
+
+    为什么不让人自己写：statement 同时决定粗排挑哪些论文、以及 LLM 怎么打分，写含糊了
+    后果很实在——生产上 12 个库全是 3~31 字符的标签，其中一个只有三个字母，导致向量
+    排在最前的是与方向完全无关的论文。写作提示解决不了这个问题，得改成引导式产出。
+
+    无状态：前端每次把已答内容全量带回来。答满四个环节后本接口直接返回写好的英文描述。
+    """
+    answers = [
+        interview.Answer(stage=a.stage, selected=list(a.selected), custom=a.custom)
+        for a in data.answers
+    ]
+    llm = get_llm_router()
+    total = len(interview.STAGE_KEYS)
+    question = await interview.ask(topic=data.topic, answers=answers, llm=llm, user_id=user.id)
+    if question is not None:
+        return StatementInterviewResponse(
+            done=False,
+            step=interview.STAGE_KEYS.index(question.stage) + 1,
+            total=total,
+            question=StatementInterviewQuestion(
+                stage=question.stage,
+                title=question.title,
+                hint=question.hint,
+                question=question.question,
+                options=question.options,
+            ),
+        )
+    statement = await interview.compose(
+        topic=data.topic, answers=answers, llm=llm, user_id=user.id
+    )
+    return StatementInterviewResponse(done=True, step=total, total=total, statement=statement)
 
 
 @router.post("/libraries/suggest-definition", response_model=SuggestDefinitionResponse)

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -60,7 +60,13 @@ class LibraryCreate(BaseModel):
     """
 
     name: str = Field(min_length=1, max_length=255)
-    statement: str | None = None
+    # 必填：它同时决定粗排挑哪些论文和 LLM 怎么打分。以前可空，结果生产上 12 个库的
+    # statement 全是 3~31 字符的标签（有一个只有三个字母），向量排序完全失真。
+    #
+    # 只要求非空，不设长度门槛——长度不等于质量，10 个字的描述照样没用，而门槛会误伤
+    # 正当的短描述。质量靠界面上的 AI 访谈（POST /libraries/statement-interview）引导，
+    # 那才是能真正问出「研究问题/对象/子问题/方法类型」的东西。
+    statement: str = Field(min_length=1, max_length=4000)
     cadence: str | None = Field(default=None, max_length=32)
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
@@ -199,3 +205,44 @@ class LibraryBudgetRead(BaseModel):
     used_tokens: int
     remaining_tokens: int | None  # 不限时为 None；用超时为 0
     exhausted: bool  # True = 本月预算已用尽（ingest 会被拒绝启动）
+
+
+# ---- 方向描述访谈（AI 结构化问答产出 statement） ----
+
+
+class InterviewAnswer(BaseModel):
+    """用户对某一环节的回答：勾选项 + 自己补充的。两者都可为空（= 跳过）。"""
+
+    stage: str = Field(max_length=32)
+    selected: list[str] = Field(default_factory=list)
+    custom: str = Field(default="", max_length=2000)
+
+
+class StatementInterviewRequest(BaseModel):
+    """无状态访谈：每次把已答内容全量带回来，服务端据此决定下一题或收尾。
+
+    这样刷新页面、换设备都不丢进度，也省掉一张会话表。
+    """
+
+    topic: str = Field(min_length=1, max_length=255)
+    answers: list[InterviewAnswer] = Field(default_factory=list)
+
+
+class StatementInterviewQuestion(BaseModel):
+    stage: str
+    title: str
+    hint: str
+    question: str
+    # LLM 不可用时为空列表——此时前端只显示「其他」输入框，访谈仍能走完
+    options: list[str] = Field(default_factory=list)
+
+
+class StatementInterviewResponse(BaseModel):
+    """要么给下一题，要么给写好的 statement（英文）。"""
+
+    done: bool
+    # 第几步 / 共几步，供前端显示进度
+    step: int
+    total: int
+    question: StatementInterviewQuestion | None = None
+    statement: str | None = None

--- a/src/backend/app/services/statement_interview.py
+++ b/src/backend/app/services/statement_interview.py
@@ -1,0 +1,215 @@
+"""用一轮结构化访谈问出文献库的研究方向描述（不 import fastapi）。
+
+为什么要访谈而不是让人自己写：statement 同时决定「粗排挑哪些论文」和「LLM 怎么打分」，
+写得含糊后果很实在——生产上 12 个库的 statement 全是 3~31 字符的标签，其中一个只有
+三个字母（``CUA``）。拿缩写去嵌入，排在最前的是超图小样本学习和医学影像论文，而真正
+的 GUI agent 论文排在几百名之后。换成一段正常描述后，那些无关论文掉到 200~600 名开外。
+
+**输出为英文**：statement 有两处用途——向量嵌入与 LLM 打分提示。后者中英皆可，前者对
+语言敏感，而语料是英文 arXiv 摘要（实测中文 statement 会把中文相关的论文整体抬高，
+把「中文歇后语」这类论文顶进前十）。
+
+访谈是**无状态**的：前端每次把已答内容全量带回来，服务端据此决定下一题或收尾。这样
+刷新页面、换设备都不会丢，也省掉一张会话表。
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.llm.base import Message
+from app.core.llm.router import LLMRouter
+
+logger = logging.getLogger(__name__)
+
+# 访谈骨架固定，内容由 LLM 按主题现生成：骨架保证每次体验一致、LLM 不会跑题，
+# 生成的选项保证问题贴着这个方向而不是泛泛而问。
+STAGES: tuple[tuple[str, str, str], ...] = (
+    (
+        "question",
+        "研究问题",
+        "这个方向想回答的核心问题是什么",
+    ),
+    (
+        "subject",
+        "研究对象",
+        "研究的是哪一类系统、模型或数据",
+    ),
+    (
+        "subproblems",
+        "研究子问题",
+        "方向内部具体关心哪几个子问题",
+    ),
+    (
+        "methods",
+        "关心的方法类型",
+        "偏重哪类方法、以及明确不想要什么",
+    ),
+)
+STAGE_KEYS = tuple(k for k, _, _ in STAGES)
+OPTIONS_PER_QUESTION = 3
+
+_QUESTION_PROMPT = """\
+你是科研文献库的访谈助手（POLARIS_STATEMENT_INTERVIEW）。你要通过几个问题，帮用户把\
+一个模糊的研究方向名称，变成一段能用于自动筛选论文的方向描述。
+
+现在请针对「{stage_title}」这一环节提问：{stage_hint}。
+
+要求：
+- 问题要**贴着这个具体方向**问，不要问放之四海皆准的空话；
+- 给出 {n} 个候选答案，每个都是一个具体、可勾选的短句（不超过 30 个字），彼此不重叠；
+- 候选答案要覆盖这个方向下最可能的几种情况，让用户多选；
+- 已经答过的内容不要重复问。
+
+只输出一个 JSON 对象，不要解释、不要代码块围栏：
+{{"question": "问题正文", "options": ["选项1", "选项2", "选项3"]}}
+"""
+
+_STATEMENT_PROMPT = """\
+你是科研文献库的方向描述撰写助手（POLARIS_STATEMENT_WRITER）。根据下面的访谈记录，\
+写一段**英文**的研究方向描述，它会被用于两件事：计算论文的向量相似度、以及让大模型\
+给论文打相关性分。
+
+要求：
+- **只输出英文**，不要中文，不要标题，不要列表，不要代码块围栏；
+- 一段连贯的散文，3~5 句，120~200 个词；
+- 必须写清四件事：研究什么问题、研究对象是什么、包含哪些子问题、偏重哪类方法\
+（若访谈里提到不要什么，也写进去）；
+- 多用该领域的**具体术语**（模型名、任务名、评测集名、方法名），它们是向量匹配的锚点；
+- 不要出现「本文献库」「我们」这类自指，直接描述方向本身。
+"""
+
+
+@dataclass
+class Answer:
+    """用户对某一环节的回答：勾选项 + 自己补充的内容。"""
+
+    stage: str
+    selected: list[str]
+    custom: str = ""
+
+    def as_text(self) -> str:
+        parts = [*self.selected]
+        if self.custom.strip():
+            parts.append(self.custom.strip())
+        return "；".join(parts) or "（跳过）"
+
+
+@dataclass
+class Question:
+    stage: str
+    title: str
+    hint: str
+    question: str
+    options: list[str]
+
+
+def _stage_meta(stage: str) -> tuple[str, str]:
+    for key, title, hint in STAGES:
+        if key == stage:
+            return title, hint
+    return stage, ""
+
+
+def next_stage(answers: list[Answer]) -> str | None:
+    """还没答的第一个环节；全部答完返回 None。"""
+    answered = {a.stage for a in answers}
+    for key in STAGE_KEYS:
+        if key not in answered:
+            return key
+    return None
+
+
+def _transcript(topic: str, answers: list[Answer]) -> str:
+    lines = [f"研究方向名称：{topic.strip() or '（未填写）'}"]
+    for a in answers:
+        title, _ = _stage_meta(a.stage)
+        lines.append(f"{title}：{a.as_text()}")
+    return "\n".join(lines)
+
+
+def _json_object(content: str) -> dict[str, Any] | None:
+    """从模型输出里抠出第一个 JSON 对象；抠不出返回 None（调用方走兜底）。"""
+    start, end = content.find("{"), content.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        parsed = json.loads(content[start : end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _fallback_question(stage: str) -> Question:
+    """LLM 不可用时也要能往下走：给一个没有选项的开放题，用户自己填。"""
+    title, hint = _stage_meta(stage)
+    return Question(stage=stage, title=title, hint=hint, question=f"{hint}？", options=[])
+
+
+async def ask(
+    *,
+    topic: str,
+    answers: list[Answer],
+    llm: LLMRouter,
+    user_id: Any = None,
+) -> Question | None:
+    """生成下一题；全部答完返回 None。
+
+    模型挂了不抛错——退回一个开放题让用户自己写，访谈不能因为 LLM 不可用就走不下去。
+    """
+    stage = next_stage(answers)
+    if stage is None:
+        return None
+    title, hint = _stage_meta(stage)
+    system = _QUESTION_PROMPT.format(stage_title=title, stage_hint=hint, n=OPTIONS_PER_QUESTION)
+    try:
+        result = await llm.complete(
+            "extract",
+            [
+                Message(role="system", content=system),
+                Message(role="user", content=_transcript(topic, answers)),
+            ],
+            user_id=user_id,
+        )
+    except Exception:  # noqa: BLE001 — 访谈不能被 LLM 故障卡死
+        logger.warning("statement interview: question generation failed", exc_info=True)
+        return _fallback_question(stage)
+
+    data = _json_object(result.content or "")
+    if not data:
+        return _fallback_question(stage)
+    options = [
+        str(o).strip()
+        for o in (data.get("options") or [])
+        if isinstance(o, str | int | float) and str(o).strip()
+    ][:OPTIONS_PER_QUESTION]
+    question = str(data.get("question") or "").strip() or f"{hint}？"
+    return Question(stage=stage, title=title, hint=hint, question=question, options=options)
+
+
+async def compose(
+    *,
+    topic: str,
+    answers: list[Answer],
+    llm: LLMRouter,
+    user_id: Any = None,
+) -> str:
+    """把访谈记录写成一段英文方向描述。失败时返回空串，由调用方决定怎么提示。"""
+    try:
+        result = await llm.complete(
+            "extract",
+            [
+                Message(role="system", content=_STATEMENT_PROMPT),
+                Message(role="user", content=_transcript(topic, answers)),
+            ],
+            user_id=user_id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("statement interview: compose failed", exc_info=True)
+        return ""
+    text = (result.content or "").strip()
+    # 模型偶尔会裹一层代码块围栏
+    if text.startswith("```"):
+        text = text.strip("`").split("\n", 1)[-1].rsplit("```", 1)[0]
+    return text.strip()

--- a/src/backend/tests/test_daily_library_visibility.py
+++ b/src/backend/tests/test_daily_library_visibility.py
@@ -140,7 +140,9 @@ async def test_daily_ingest_status_hides_other_peoples_libraries(client):
     _pid, headers, _c, _p, _lib = await _setup(client)
     created = await client.post(
         "/api/libraries",
-        json={"name": "private-lib", "definition": {"statement": "secret direction"}},
+        # statement 是顶层字段，不是 definition 里的——之前写错了位置，
+        # 因为当时它可空所以静默通过，建出来的库其实没有描述
+        json={"name": "private-lib", "statement": "A private direction on secret topics."},
         headers=headers,
     )
     assert created.status_code in (200, 201), created.text

--- a/src/backend/tests/test_source_libraries.py
+++ b/src/backend/tests/test_source_libraries.py
@@ -120,9 +120,7 @@ async def test_empty_source_libraries_yields_empty_corpus(client):
     project_id = uuid.UUID(resp.json()["id"])
 
     async with get_sessionmaker()() as session:
-        await libraries_service.set_source_libraries(
-            session, topic_id=project_id, library_ids=[]
-        )
+        await libraries_service.set_source_libraries(session, topic_id=project_id, library_ids=[])
         await session.commit()
         items, total = await papers_service.list_papers(
             session, project_id=project_id, status="library"
@@ -136,7 +134,11 @@ async def test_create_library_admin_independent(client):
     admin = await _hdr(client, "p7u-4@example.com")
     resp = await client.post(
         "/api/libraries",
-        json={"name": "独立库", "statement": "一句话", "cadence": "weekly"},
+        json={
+            "name": "独立库",
+            "statement": "Sparse attention methods for long-context language models.",
+            "cadence": "weekly",
+        },
         headers=admin,
     )
     assert resp.status_code == 201, resp.text
@@ -153,7 +155,11 @@ async def test_create_library_any_user_allowed(client):
     """P10：建库权限放开——任意登录用户可建，新库 active 个人库、创建者自动成为策展人。"""
     await _hdr(client, "p9b-admin5@example.com")  # 首个注册者=平台 admin，占位
     member = await _hdr(client, "p9b-member5@example.com")
-    resp = await client.post("/api/libraries", json={"name": "x"}, headers=member)
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "x", "statement": "Retrieval-augmented generation for scientific QA."},
+        headers=member,
+    )
     assert resp.status_code == 201, resp.text
     body = resp.json()
     assert body["status"] == "active"
@@ -167,7 +173,11 @@ async def test_create_library_any_user_allowed(client):
 
 async def test_source_libraries_read_write_api(client):
     admin = await _hdr(client, "p7u-6@example.com")
-    resp = await client.post("/api/libraries", json={"name": "可关联库"}, headers=admin)
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "可关联库", "statement": "Tool-using agents and their benchmarks."},
+        headers=admin,
+    )
     lib_id = resp.json()["id"]
     resp = await client.post("/api/projects", json={"name": "关联课题"}, headers=admin)
     project_id = resp.json()["id"]

--- a/src/backend/tests/test_statement_interview.py
+++ b/src/backend/tests/test_statement_interview.py
@@ -1,0 +1,128 @@
+"""方向描述访谈：结构化问答产出 statement。
+
+起因是生产上 12 个文献库的 statement 全是 3~31 字符的标签，其中 CUA 那个只有三个字母。
+拿缩写去嵌入，全池排第一的是超图小样本学习论文，而真正的 GUI agent 论文排在几百名开外；
+换成一段正常描述后那些无关论文掉到 200~600 名。写作提示挡不住这个，得改成引导式产出。
+"""
+
+import uuid
+
+from app.services import statement_interview as interview
+from tests.conftest import register_and_login
+
+
+async def _headers(client, email="interview@example.com"):
+    token = await register_and_login(client, email=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_interview_walks_four_stages_then_writes_a_statement(client):
+    """四个环节逐题问，答满之后直接给出写好的描述。"""
+    headers = await _headers(client)
+    answers: list[dict] = []
+    seen: list[str] = []
+
+    for expected_step in (1, 2, 3, 4):
+        resp = await client.post(
+            "/api/libraries/statement-interview",
+            json={"topic": "Computer-use agents", "answers": answers},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["done"] is False
+        assert body["step"] == expected_step and body["total"] == 4
+        q = body["question"]
+        assert q["question"].strip(), "问题不能是空的"
+        seen.append(q["stage"])
+        answers.append({"stage": q["stage"], "selected": q["options"][:1], "custom": ""})
+
+    assert seen == list(interview.STAGE_KEYS), "环节顺序应当是固定的"
+
+    resp = await client.post(
+        "/api/libraries/statement-interview",
+        json={"topic": "Computer-use agents", "answers": answers},
+        headers=headers,
+    )
+    body = resp.json()
+    assert body["done"] is True
+    assert body["question"] is None
+    assert isinstance(body["statement"], str)
+
+
+async def test_interview_is_stateless_and_resumes_from_answers(client):
+    """只带前两个环节的回答，服务端就该问第三个——不依赖任何会话状态。"""
+    headers = await _headers(client, email="resume@example.com")
+    partial = [
+        {"stage": "question", "selected": ["a"], "custom": ""},
+        {"stage": "subject", "selected": [], "custom": "GUI 智能体"},
+    ]
+    resp = await client.post(
+        "/api/libraries/statement-interview",
+        json={"topic": "CUA", "answers": partial},
+        headers=headers,
+    )
+    body = resp.json()
+    assert body["done"] is False
+    assert body["question"]["stage"] == "subproblems"
+    assert body["step"] == 3
+
+
+async def test_interview_survives_an_unavailable_model(client, monkeypatch):
+    """模型挂了也要能往下走：退回开放题让用户自己写，不能把访谈卡死。"""
+    headers = await _headers(client, email="llmdown@example.com")
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("model unavailable")
+
+    from app.core.llm.router import LLMRouter
+
+    monkeypatch.setattr(LLMRouter, "complete", boom)
+
+    resp = await client.post(
+        "/api/libraries/statement-interview",
+        json={"topic": "CUA", "answers": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["done"] is False
+    assert body["question"]["options"] == [], "拿不到候选时应当只留自由填写"
+    assert body["question"]["question"].strip()
+
+
+def test_answer_text_joins_selection_and_custom():
+    a = interview.Answer(stage="methods", selected=["方法 A", "方法 B"], custom="另外还要 C")
+    assert a.as_text() == "方法 A；方法 B；另外还要 C"
+    assert interview.Answer(stage="methods", selected=[], custom="").as_text() == "（跳过）"
+
+
+def test_next_stage_follows_the_fixed_order():
+    assert interview.next_stage([]) == "question"
+    answered = [interview.Answer(stage=k, selected=[]) for k in interview.STAGE_KEYS[:3]]
+    assert interview.next_stage(answered) == "methods"
+    all_done = [interview.Answer(stage=k, selected=[]) for k in interview.STAGE_KEYS]
+    assert interview.next_stage(all_done) is None
+
+
+async def test_creating_a_library_now_requires_a_real_statement(client):
+    """statement 变必填。
+
+    只挡空值，不挡短值——长度不是质量的代理，「CUA」这类标签靠界面上的访谈来避免，
+    而不是靠一个武断的字数门槛（它会误伤正当的短描述）。
+    """
+    headers = await _headers(client, email="required@example.com")
+
+    resp = await client.post("/api/libraries", json={"name": "CUA"}, headers=headers)
+    assert resp.status_code == 422, "缺 statement 应当被拒"
+
+    good = (
+        "Computer-use agents that operate graphical interfaces: GUI agents on desktop and "
+        "mobile, browser-use agents, screen understanding and action grounding, and the "
+        "benchmarks used to evaluate them."
+    )
+    resp = await client.post(
+        "/api/libraries", json={"name": "CUA", "statement": good}, headers=headers
+    )
+    assert resp.status_code in (200, 201), resp.text
+    assert uuid.UUID(resp.json()["id"])

--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -11,6 +11,7 @@ import { toast } from '../../components/ui/Toast';
 import { fmtTime } from '../../lib/format';
 import { api, ApiError, isAdmin, type DirectionLibrarySummary } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { StatementInterview } from './StatementInterview';
 import { useLibraries, libraryPath, type LibraryFilters } from './hooks';
 import { InclusionSettingsForm, ARXIV_ID_RE, type InclusionValue } from './InclusionSettingsForm';
 
@@ -243,6 +244,7 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
+  const [interviewOpen, setInterviewOpen] = useState(false);
   const [incl, setIncl] = useState<InclusionValue>(EMPTY_INCLUSION);
 
   const badAnchors = incl.anchors.filter(
@@ -323,7 +325,28 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
           <input className="input" value={name} onChange={(e) => setName(e.target.value)}
             placeholder={tr('如：稀疏注意力', 'e.g. Sparse attention')} />
         </FormField>
-        <FormField label={tr('一句话说明', 'Statement')} hint={tr('必填，用于相关性打分', 'Required — used for relevance scoring')}>
+        <FormField
+          label={tr('方向描述', 'Statement')}
+          hint={tr('必填，用于挑论文和打分', 'Required — selects and scores papers')}
+        >
+          <div className="row gap8" style={{ alignItems: 'center', marginBottom: 6 }}>
+            <button
+              className="btn btn-soft sm"
+              disabled={!name.trim()}
+              title={
+                name.trim()
+                  ? tr('AI 按四个环节提问，帮你把方向说清楚', 'AI asks four questions to pin the direction down')
+                  : tr('先填名称', 'Enter a name first')
+              }
+              onClick={() => setInterviewOpen(true)}
+            >
+              <Icon name="sparkle" size={12} />
+              {tr('AI 访谈生成', 'Write it with AI')}
+            </button>
+            <span className="muted" style={{ fontSize: 11.5 }}>
+              {tr('不知道怎么写就用它', 'Use this if you are unsure what to write')}
+            </span>
+          </div>
           <textarea className="textarea" rows={2} value={statement} onChange={(e) => setStatement(e.target.value)}
             placeholder={tr(
               '例：研究长时程运行的 LLM 智能体。关注记忆压缩、错误恢复、长期一致性评测；偏重方法与系统设计，不收纯 prompt 工程和纯应用报告。',
@@ -331,8 +354,8 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
             )} />
           <div className="muted" style={{ fontSize: 11.5, lineHeight: 1.5, marginTop: 4 }}>
             {tr(
-              '写清四件事效果最好：研究对象、关注的子问题、偏重什么、明确不要什么。这段描述既用来自动挑论文，也用来给论文打分，写得越具体收得越准。',
-              'Four things help most: the subject, the sub-problems you care about, what you favour, and what you explicitly do not want. This text both selects and scores papers, so specifics pay off.',
+              '写清四件事效果最好：研究问题、研究对象、关注的子问题、偏重哪类方法。用英文写——语料是英文论文摘要，中文描述会让向量匹配失准。',
+              'Four things help most: the research question, the subject, the sub-problems, and which kinds of method you favour. Write it in English — the corpus is English abstracts, and a Chinese statement skews vector matching.',
             )}
           </div>
         </FormField>
@@ -345,6 +368,12 @@ function NewLibraryModal({ open, onClose }: { open: boolean; onClose: () => void
           showRubric
         />
       </div>
+      <StatementInterview
+        open={interviewOpen}
+        topic={name}
+        onClose={() => setInterviewOpen(false)}
+        onDone={setStatement}
+      />
     </Modal>
   );
 }

--- a/src/frontend/src/features/libraries/StatementInterview.tsx
+++ b/src/frontend/src/features/libraries/StatementInterview.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { toast } from '../../components/ui/Toast';
+import {
+  api,
+  type StatementInterviewAnswer,
+  type StatementInterviewQuestion,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   方向描述访谈：AI 按「研究问题 / 研究对象 / 子问题 / 方法类型」四个环节提问，
+   每题给几个可勾选的候选，末尾生成一段英文描述。
+
+   为什么要有这个：statement 同时决定粗排挑哪些论文和 LLM 怎么打分，写含糊了后果很实在
+   ——线上 12 个库的 statement 全是 3~31 字符的标签（有一个只有三个字母），向量排在
+   最前的是与方向毫不相干的论文。光给写作提示挡不住，得改成引导式产出。
+   ============================================================ */
+
+export function StatementInterview({
+  open,
+  topic,
+  onClose,
+  onDone,
+}: {
+  open: boolean;
+  /** 研究方向名称，作为访谈的出发点 */
+  topic: string;
+  onClose: () => void;
+  /** 用户确认后回填的描述 */
+  onDone: (statement: string) => void;
+}) {
+  const [answers, setAnswers] = useState<StatementInterviewAnswer[]>([]);
+  const [question, setQuestion] = useState<StatementInterviewQuestion | null>(null);
+  const [step, setStep] = useState(1);
+  const [total, setTotal] = useState(4);
+  const [picked, setPicked] = useState<string[]>([]);
+  const [custom, setCustom] = useState('');
+  const [statement, setStatement] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const advance = useCallback(
+    async (next: StatementInterviewAnswer[]) => {
+      setBusy(true);
+      try {
+        const res = await api.statementInterview(topic, next);
+        setStep(res.step);
+        setTotal(res.total);
+        if (res.done) {
+          setQuestion(null);
+          setStatement(res.statement ?? '');
+        } else {
+          setQuestion(res.question ?? null);
+          setPicked([]);
+          setCustom('');
+        }
+      } catch (e) {
+        toast(
+          `${tr('访谈出错：', 'Interview failed: ')}${e instanceof Error ? e.message : String(e)}`,
+          'error',
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [topic],
+  );
+
+  // 打开时从头开始；关掉后再打开是一次新访谈（题目可能已经改了）
+  useEffect(() => {
+    if (!open) return;
+    setAnswers([]);
+    setQuestion(null);
+    setStatement('');
+    setPicked([]);
+    setCustom('');
+    void advance([]);
+  }, [open, advance]);
+
+  const submitAnswer = () => {
+    if (!question) return;
+    const next = [
+      ...answers,
+      { stage: question.stage, selected: picked, custom: custom.trim() },
+    ];
+    setAnswers(next);
+    void advance(next);
+  };
+
+  const toggle = (opt: string) =>
+    setPicked((prev) => (prev.includes(opt) ? prev.filter((x) => x !== opt) : [...prev, opt]));
+
+  const nothingChosen = picked.length === 0 && !custom.trim();
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={tr('AI 访谈：把方向说清楚', 'AI interview: pin down the direction')}
+      sub={tr(
+        '这段描述既用来自动挑论文，也用来给论文打分——写得越具体，收得越准。',
+        'This text both selects and scores papers, so specifics pay off.',
+      )}
+      width={620}
+      footer={
+        statement ? (
+          <>
+            <button className="btn btn-ghost sm" onClick={onClose}>
+              {tr('取消', 'Cancel')}
+            </button>
+            <button
+              className="btn btn-primary sm"
+              disabled={statement.trim().length < 10}
+              onClick={() => {
+                onDone(statement.trim());
+                onClose();
+              }}
+            >
+              {tr('用这段描述', 'Use this statement')}
+            </button>
+          </>
+        ) : (
+          <>
+            <button className="btn btn-ghost sm" onClick={onClose}>
+              {tr('取消', 'Cancel')}
+            </button>
+            <button
+              className="btn btn-primary sm"
+              disabled={busy || !question || nothingChosen}
+              title={nothingChosen ? tr('至少选一项或自己写一句', 'Pick at least one, or write your own') : undefined}
+              onClick={submitAnswer}
+            >
+              {busy ? tr('思考中…', 'Thinking…') : tr('下一步', 'Next')}
+            </button>
+          </>
+        )
+      }
+    >
+      {/* 进度 */}
+      <div className="row gap6" style={{ alignItems: 'center', margin: '2px 0 14px' }}>
+        {Array.from({ length: total }, (_, i) => (
+          <span
+            key={i}
+            style={{
+              flex: 1,
+              height: 3,
+              borderRadius: 2,
+              background: i < step ? 'var(--accent)' : 'var(--border)',
+            }}
+          />
+        ))}
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginLeft: 4 }}>
+          {statement ? tr('完成', 'done') : `${step}/${total}`}
+        </span>
+      </div>
+
+      {statement ? (
+        <div className="col gap8">
+          <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5 }}>
+            {tr(
+              '按访谈内容写的英文描述——语料是英文论文摘要，中文描述会让匹配失准。可以直接改。',
+              'Written in English: the corpus is English paper abstracts, and a Chinese statement skews the matching. Edit freely.',
+            )}
+          </div>
+          <textarea
+            className="textarea"
+            rows={8}
+            value={statement}
+            onChange={(e) => setStatement(e.target.value)}
+          />
+        </div>
+      ) : busy && !question ? (
+        <div className="empty" style={{ padding: 24 }}>
+          {tr('正在准备问题…', 'Preparing the question…')}
+        </div>
+      ) : question ? (
+        <div className="col gap10">
+          <div>
+            <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', letterSpacing: '0.04em' }}>
+              {question.title}
+            </div>
+            <div style={{ fontSize: 13.5, fontWeight: 600, marginTop: 4, lineHeight: 1.5 }}>
+              {question.question}
+            </div>
+          </div>
+
+          {question.options.length > 0 && (
+            <div className="col gap6">
+              {question.options.map((opt) => {
+                const on = picked.includes(opt);
+                return (
+                  <label
+                    key={opt}
+                    className="row gap8"
+                    style={{
+                      alignItems: 'flex-start',
+                      padding: '9px 11px',
+                      borderRadius: 8,
+                      cursor: 'pointer',
+                      border: `0.5px solid ${on ? 'var(--accent)' : 'var(--border)'}`,
+                      background: on ? 'var(--accent-soft)' : 'transparent',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={on}
+                      onChange={() => toggle(opt)}
+                      style={{ marginTop: 2, flexShrink: 0 }}
+                    />
+                    <span style={{ fontSize: 12.5, lineHeight: 1.5 }}>{opt}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="col gap4">
+            <span className="row gap6" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+              <Icon name="pen" size={11} />
+              {question.options.length > 0
+                ? tr('其他（自己写，可与上面同时选）', 'Other — write your own, combines with the above')
+                : tr('请自己写（这次没能给出候选）', 'Write your own — no suggestions this time')}
+            </span>
+            <textarea
+              className="textarea"
+              rows={2}
+              value={custom}
+              onChange={(e) => setCustom(e.target.value)}
+              placeholder={tr('补充这个环节的具体内容…', 'Add specifics for this step…')}
+            />
+          </div>
+        </div>
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2639,6 +2639,30 @@ export interface DailyIngestStatus {
 /** 库同步每次扫描每日池的范围。 */
 export type DailySyncScope = 'since_last' | 'daily' | 'full';
 
+/** 方向描述访谈：一次问一个环节，多选 + 自由补充；答满四个环节后返回写好的英文描述。 */
+export interface StatementInterviewAnswer {
+  stage: string;
+  selected: string[];
+  custom: string;
+}
+
+export interface StatementInterviewQuestion {
+  stage: string;
+  title: string;
+  hint: string;
+  question: string;
+  /** 模型不可用时为空——此时只显示自由填写框，访谈仍能走完 */
+  options: string[];
+}
+
+export interface StatementInterviewResponse {
+  done: boolean;
+  step: number;
+  total: number;
+  question?: StatementInterviewQuestion | null;
+  statement?: string | null;
+}
+
 export interface DailyCollectRequest {
   paper_ids: string[];
   direction_library_ids: string[];
@@ -4455,6 +4479,17 @@ export const api = {
   },
 
   /** 库同步每次扫描每日池的范围：since_last 上次同步以来 / daily 只当天 / full 整池。 */
+  /** 方向描述访谈的下一步（无状态：把已答内容全量带上）。 */
+  statementInterview(
+    topic: string,
+    answers: StatementInterviewAnswer[],
+  ): Promise<StatementInterviewResponse> {
+    return request<StatementInterviewResponse>('/libraries/statement-interview', {
+      method: 'POST',
+      body: JSON.stringify({ topic, answers }),
+    });
+  },
+
   getDailySyncScope(): Promise<{ scope: DailySyncScope }> {
     return request<{ scope: DailySyncScope }>('/daily/sync-scope');
   },


### PR DESCRIPTION
## Why

A library's `statement` decides two things: which papers the vector pre-rank surfaces, and how the LLM scores them. Writing it vaguely has concrete consequences, and production shows exactly that — all twelve libraries have a statement between **3 and 31 characters**, and one of them is literally three letters:

| library | statement |
|---|---|
| CUA | `CUA` |
| game ai | 搜集和游戏智能体相关的论文和评测集 |
| On-Policy Distillation | `On-Policy Distillation` |
| VIdeo World Model | *(empty)* |

Embedding a three-letter acronym produces a near-meaningless query vector. Measured against the live daily pool, the **top-ranked paper for `CUA` was a hypergraph few-shot learning paper**; UAV tracking ranked 6th and medical imaging 8th, while genuine GUI-agent papers sat several hundred places down. Rewriting the statement as a normal paragraph dropped those irrelevant papers to 201st, 534th and 602nd.

#210 already added writing guidance next to the field. It did not work — people still typed `CUA`. Guidance does not fix this; guided production does.

## The interview

Four fixed stages — research question, subject, sub-problems, kinds of method — with the wording and three candidate answers generated by the LLM from the direction name plus what has been answered so far. The fixed spine keeps the experience predictable and stops the model wandering; the generated content keeps the questions about *this* direction rather than generic. Each question is multi-select, plus an "other" free-text box that combines with the checkboxes.

**Stateless.** The client sends every prior answer back on each call, and the server decides the next question or finishes. Refreshing the page or switching devices loses nothing, and there is no session table.

**Degrades rather than blocks.** If the model is unavailable, the stage falls back to an open question with no options; the interview still completes. Pinned by a test.

**Output is English.** The statement is used for vector embedding and for the scoring prompt. The latter is language-agnostic; the former is not, and the corpus is English arXiv abstracts. A Chinese statement measurably skews it — for the `game ai` library, a paper on **Chinese Xiehouyu riddles** ranked in the top ten purely on language affinity, and switching the statement to English removed it.

## `statement` is now required

`LibraryCreate.statement` is required — but **only non-empty, with no length floor**.

I first set `min_length=10` and it broke 29 tests. That was my own addition, not part of the request, and it is the wrong instrument: length is not a proxy for quality (a ten-character statement is just as useless), and a floor punishes legitimately terse descriptions. The interview is what raises quality.

Making the field required immediately exposed a bug in one of my own earlier tests: `test_daily_library_visibility` passed the statement inside `definition` instead of as the top-level field. It silently passed while the field was optional, and the library it created had no statement at all.

## Verification

Full backend suite: **920 passed**. `ruff check app tests` clean. `tsc --noEmit` and `vite build` pass.

Six new tests: the four stages run in fixed order and then produce a statement; the flow resumes from answers alone with no server state; an unavailable model degrades to an open question; answer text joins selections with free text; stage ordering; and creation rejects a missing statement.

## Not in this PR

Existing libraries are unaffected — the requirement applies to creation. Eleven of the twelve in production still have label-length statements, and one is empty. Adding the interview to the library settings page, and whether to force existing libraries to fill it in, are open questions.