### PR TITLE
feat(literature): add research digests and Obsidian sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 POLARIS_IMAGE_PREFIX=tricktreat
 POLARIS_IMAGE_TAG=latest
 
+# ---- Host ports ----
+# Change these when the defaults conflict with another service on the Docker host.
+POLARIS_API_PORT=8000
+POLARIS_FRONTEND_PORT=8080
+
 # ---- App ----
 # dev | prod (use prod for deployments: forces safe defaults such as
 # disabling the fake LLM fallback)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "${POLARIS_API_PORT:-8000}:8000"
     volumes:
       - appdata:/srv/data          # PDF / 编译产物等
       - tectonic-cache:/root/.cache/Tectonic   # tectonic 宏包缓存（首次编译联网下载）
@@ -72,7 +72,7 @@ services:
     depends_on:
       - api
     ports:
-      - "8080:80"
+      - "${POLARIS_FRONTEND_PORT:-8080}:80"
 
 volumes:
   pgdata:

--- a/src/backend/alembic/versions/e6a1c9d4f207_library_research_digests.py
+++ b/src/backend/alembic/versions/e6a1c9d4f207_library_research_digests.py
@@ -1,0 +1,71 @@
+"""add library research digests and relevance reasons
+
+Revision ID: e6a1c9d4f207
+Revises: 929c05a03745
+Create Date: 2026-07-29 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e6a1c9d4f207"
+down_revision: str | None = "929c05a03745"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+JSONVariant = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.add_column("library_papers", sa.Column("relevance_reason", sa.Text(), nullable=True))
+    op.create_table(
+        "library_research_digests",
+        sa.Column("library_id", sa.Uuid(), nullable=False),
+        sa.Column("voyage_id", sa.Uuid(), nullable=True),
+        sa.Column("report_date", sa.Date(), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("mode", sa.String(length=32), nullable=False),
+        sa.Column("counts", JSONVariant, nullable=False),
+        sa.Column("source_diagnostics", JSONVariant, nullable=False),
+        sa.Column("paper_insights", JSONVariant, nullable=False),
+        sa.Column("excluded_papers", JSONVariant, nullable=False),
+        sa.Column("cross_paper_signals", JSONVariant, nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=True),
+        sa.Column("rolling_trends", JSONVariant, nullable=False),
+        sa.Column("trend_content", sa.Text(), nullable=False),
+        sa.Column("trend_model", sa.String(length=128), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["library_id"], ["direction_libraries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["voyage_id"], ["voyage_runs.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "library_id",
+            "report_date",
+            "source",
+            name="uq_library_research_digests_library_date_source",
+        ),
+        sa.UniqueConstraint("voyage_id", name="uq_library_research_digests_voyage"),
+    )
+    op.create_index(
+        "ix_library_research_digests_library_date",
+        "library_research_digests",
+        ["library_id", "report_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_library_research_digests_library_date",
+        table_name="library_research_digests",
+    )
+    op.drop_table("library_research_digests")
+    op.drop_column("library_papers", "relevance_reason")

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -2,7 +2,8 @@
 
 流水线（docs/api-m2.md §7）：
     wiki.search_candidates → wiki.snowball → wiki.score_relevance →
-    wiki.fetch_extract → wiki.compile → wiki.link_concepts → wiki.update_watermark
+    wiki.fetch_extract → wiki.compile → wiki.link_concepts → wiki.daily_digest →
+    wiki.trend_synthesize → wiki.update_watermark
 
 健壮性约定：
 - 每篇论文独立 try/except，单篇失败不打断批处理；observation 汇总
@@ -30,6 +31,7 @@ from app.models.base import utcnow
 from app.models.daily_feed import DailyFeedEntry
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, new_paper
+from app.models.research_digest import LibraryResearchDigest
 from app.models.voyage import VoyageStep
 from app.schemas.ingest import TIME_RANGE_DAYS
 from app.services.affiliations import (
@@ -72,6 +74,7 @@ from app.services.relevance import (
     build_relevance_context,
     score_paper_relevance,
 )
+from app.services.research_digest import create_daily_digest, synthesize_rolling_trends
 from app.services.wiki_compile import compile_paper
 
 logger = logging.getLogger(__name__)
@@ -474,6 +477,11 @@ async def _collect_from_daily_feed(
     }
 
 
+def _latest_source_date(entries: list[dict[str, Any]]) -> str | None:
+    dates = [parsed for entry in entries if (parsed := _parse_iso(entry.get("published")))]
+    return max(dates).isoformat() if dates else None
+
+
 @register("wiki.search_candidates")
 async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     knobs = _knobs(ctx)
@@ -518,6 +526,22 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             new_papers = feed.pop("selected")
             await session.flush()
             brief = _paper_brief(new_papers)
+            messages: list[str] = []
+            if int(feed["feed_total"]) == 0:
+                messages.append("每日论文池当前为空；请检查每日抓取任务及数据源状态。")
+            if feed.get("feed_latest_date") is None:
+                messages.append("未能确认每日论文池的最新公告时间。")
+            diagnostics = {
+                "source": "daily_feed",
+                "source_fetched": int(feed["feed_total"]),
+                "prescreened": int(feed["after_vector_rank"]),
+                "inserted": len(new_papers),
+                "source_latest_at": feed.get("feed_latest_date"),
+                "status": "warning" if messages else "ok",
+                "messages": messages,
+                **feed,
+            }
+            ctx.checkpoint["ingest_search_stats"] = diagnostics
             await session.commit()
             ctx.checkpoint["watermark_candidate"] = now.isoformat()
             await ctx.log(
@@ -529,6 +553,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 "mode": mode,
                 "inserted": len(new_papers),
                 "new_papers": brief,
+                "source_latest_at": diagnostics["source_latest_at"],
+                "diagnostic_status": diagnostics["status"],
+                "diagnostic_messages": messages,
                 **feed,
             }
 
@@ -608,7 +635,30 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         brief = _paper_brief(new_papers)
         await session.commit()
 
-    # 新水位线 = 本次检索时刻，由 wiki.update_watermark 落库
+    source_latest_at = _latest_source_date(entries)
+    messages: list[str] = []
+    source_fetched = len(entries)
+    cap_hit = len(entries) >= limit
+    if source_fetched == 0:
+        messages.append("本次所有数据源均返回 0 篇；请复查检索配置、源站状态和时间窗口。")
+    if cap_hit:
+        messages.append(f"arXiv 查询达到 {limit} 篇上限，窗口内可能仍有未抓取候选。")
+    if source_latest_at is None:
+        messages.append("未能从返回结果确认数据源最新公告时间。")
+    diagnostics = {
+        "source": "arxiv",
+        "source_fetched": source_fetched,
+        "prescreened": len(entries),
+        "query_found": len(entries),
+        "inserted": len(new_papers),
+        "window_since": since.isoformat(),
+        "source_latest_at": source_latest_at,
+        "cap_hit": cap_hit,
+        "status": "warning" if messages else "ok",
+        "messages": messages,
+    }
+    ctx.checkpoint["ingest_search_stats"] = diagnostics
+    # 新水位线 = 本次检索时刻，由最后一步 wiki.update_watermark 落库
     ctx.checkpoint["watermark_candidate"] = now.isoformat()
     return {
         "source": "arxiv",
@@ -617,6 +667,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         "new_papers": brief,
         "window_since": since.isoformat(),
         "mode": mode,
+        "source_latest_at": source_latest_at,
+        "diagnostic_status": diagnostics["status"],
+        "diagnostic_messages": messages,
     }
 
 
@@ -758,6 +811,19 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
         brief = _paper_brief(new_papers)
         await session.commit()
 
+    ctx.checkpoint["ingest_snowball_inserted"] = (
+        int(ctx.checkpoint.get("ingest_snowball_inserted") or 0) + inserted
+    )
+    ctx.checkpoint["ingest_search_stats"] = {
+        "source": "semantic_scholar",
+        "source_fetched": inserted,
+        "prescreened": inserted,
+        # 插入量由 ingest_snowball_inserted 统一计数，避免简报中重复相加。
+        "inserted": 0,
+        "source_latest_at": None,
+        "status": "warning" if failed else "ok",
+        "messages": [f"Semantic Scholar 扩展有 {len(failed)} 个种子失败。"] if failed else [],
+    }
     return {
         "depth": depth,
         "processed": processed_seeds,
@@ -828,6 +894,7 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                 voyage_id=ctx.run.id,
             )
             score = scored.score
+            membership.relevance_reason = scored.reason
             passed = score >= threshold
             if passed:
                 membership.status = "scored"
@@ -844,6 +911,7 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                 "title": paper.title,
                 "score": score,
                 "passed": passed,
+                "reason": scored.reason,
             }
 
     results = await _gather_bounded(_LLM_CONCURRENCY, [score_one(mid) for mid in membership_ids])
@@ -855,6 +923,7 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
     failed: list[dict[str, str]] = []
     scored_ids: list[str] = []
     rejected_ids: list[str] = []
+    digest_excluded: list[dict[str, Any]] = []
     scored_brief: list[dict[str, Any]] = []
     for paper_id, result in zip(paper_ids, results, strict=True):
         if isinstance(result, BaseException):
@@ -867,6 +936,14 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
         if not result["passed"]:
             excluded += 1
             rejected_ids.append(result["id"])
+            digest_excluded.append(
+                {
+                    "paper_id": result["id"],
+                    "title": result["title"],
+                    "relevance_score": result["score"],
+                    "reason": result["reason"],
+                }
+            )
         if len(scored_brief) < _OBS_LIST_CAP:
             scored_brief.append(result)
 
@@ -882,6 +959,13 @@ async def score_relevance(ctx: ActionContext, params: dict[str, Any]) -> dict[st
 
     # 步内进度记入 checkpoint（审计用；幂等本身靠 Paper.status）
     ctx.checkpoint["scored_ids"] = list(ctx.checkpoint.get("scored_ids") or []) + scored_ids
+    previous_excluded = {
+        str(item.get("paper_id")): item
+        for item in (ctx.checkpoint.get("digest_excluded_papers") or [])
+        if isinstance(item, dict) and item.get("paper_id")
+    }
+    previous_excluded.update({item["paper_id"]: item for item in digest_excluded})
+    ctx.checkpoint["digest_excluded_papers"] = list(previous_excluded.values())
     return {
         "processed": len(scored_ids) + len(failed),
         "succeeded": succeeded,
@@ -1246,7 +1330,62 @@ async def link_concepts(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
     }
 
 
-# ---- 7. 更新水位线 + 活动流 ----
+# ---- 7. 每日简报（持久化；失败会阻止后续水位线提交） ----
+
+
+@register("wiki.daily_digest")
+async def daily_digest(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    async with get_sessionmaker()() as session:
+        library = await _resolve_library(session, ctx)
+        if library is None:
+            raise ValueError(f"library not found for run: {ctx.run.id}")
+        digest = await create_daily_digest(
+            session,
+            run=ctx.run,
+            library=library,
+            checkpoint=ctx.checkpoint,
+            llm=ctx.llm,
+            user_id=_ingest_billing_owner(library),
+            extra_guidance=ctx.skill_guidance("wiki.daily_digest"),
+        )
+    ctx.checkpoint["daily_digest_id"] = str(digest.id)
+    await ctx.log(f"每日简报已生成：{digest.report_date.isoformat()}", level="success")
+    return {
+        "digest_id": str(digest.id),
+        "report_date": digest.report_date.isoformat(),
+        "kept": int(digest.counts.get("kept") or 0),
+        "excluded": int(digest.counts.get("excluded") or 0),
+        "signals": len(digest.cross_paper_signals),
+    }
+
+
+# ---- 8. 滚动趋势综合（持久化快照） ----
+
+
+@register("wiki.trend_synthesize")
+async def trend_synthesize(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    async with get_sessionmaker()() as session:
+        library = await _resolve_library(session, ctx)
+        if library is None:
+            raise ValueError(f"library not found for run: {ctx.run.id}")
+        digest = await synthesize_rolling_trends(
+            session,
+            run=ctx.run,
+            library=library,
+            llm=ctx.llm,
+            user_id=_ingest_billing_owner(library),
+            extra_guidance=ctx.skill_guidance("wiki.trend_synthesize"),
+        )
+    ctx.checkpoint["trend_digest_id"] = str(digest.id)
+    await ctx.log(f"滚动趋势已更新：{len(digest.rolling_trends)} 条主线", level="success")
+    return {
+        "digest_id": str(digest.id),
+        "trends": len(digest.rolling_trends),
+        "model": digest.trend_model,
+    }
+
+
+# ---- 9. 更新水位线 + 活动流 ----
 
 
 @register("wiki.update_watermark")
@@ -1268,6 +1407,19 @@ async def update_watermark(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 .where(VoyageStep.run_id == ctx.run.id, VoyageStep.status == "obsolete")
             )
         ) or 0
+        if not truncated:
+            digest = (
+                await session.execute(
+                    select(LibraryResearchDigest).where(
+                        LibraryResearchDigest.voyage_id == ctx.run.id,
+                        LibraryResearchDigest.trend_model.is_not(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if digest is None:
+                raise ValueError(
+                    "daily digest/trend snapshot missing; refusing to advance watermark"
+                )
         watermark = (
             previous if truncated else (ctx.checkpoint.get("watermark_candidate") or previous)
         )

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -74,14 +74,31 @@ IDEA_KINDS = ("idea_forge", "idea_review", "idea_proposal")
 def wiki_plan(run: VoyageRun) -> list[dict[str, Any]]:
     """文献收集计划：每种模式只跑自己需要的步骤（docs/api-m2.md §7）。
 
-    以前三种来源焊成一条七步流水线，想只补一轮引文就得连带再检索一次 arXiv。现在按
-    ``checkpoint.params.mode`` 分叉，共用后五步（打分→取全文→编译→概念→记录进度）：
+    三种来源按 ``checkpoint.params.mode`` 分叉，共用后续步骤；简报与趋势必须成功后才
+    提交水位线。``digest_only`` 用于今日已有论文更新时跳过抓取，直接重建简报与趋势。
 
     - ``search``：按查询词走 arXiv 检索 API；
     - ``snowball``：从锚点论文出发走引用/参考；
     - ``incremental``：从每日论文池按方向挑，不访问 arXiv。
     """
     params = (run.checkpoint or {}).get("params") or {}
+    if params.get("digest_only") is True:
+        steps = [
+            ("生成每日简报", "wiki.daily_digest", "今日简报已基于今日更新论文生成"),
+            ("综合滚动趋势", "wiki.trend_synthesize", "滚动趋势快照已更新"),
+        ]
+        return [
+            {
+                "title": title,
+                "action": action,
+                "params": {},
+                "acceptance": acceptance,
+                "checks": [{"kind": "no_error"}],
+                "requires_gate": None,
+            }
+            for title, action, acceptance in steps
+        ]
+
     mode = params.get("mode") or ("incremental" if run.kind == "wiki_ingest" else "search")
     if mode == "bootstrap":  # 存量任务的旧名
         mode = "search"
@@ -99,7 +116,9 @@ def wiki_plan(run: VoyageRun) -> list[dict[str, Any]]:
         ("下载 PDF + 抽全文", "wiki.fetch_extract", "top-N 论文全文就绪（失败降级摘要）"),
         ("Librarian 编译 wiki 页", "wiki.compile", "top-N 论文已生成中文 wiki markdown"),
         ("概念上链 + embedding", "wiki.link_concepts", "双链概念已 upsert 并关联论文"),
-        ("记录收集进度", "wiki.update_watermark", "文献库同步状态已更新"),
+        ("生成每日简报", "wiki.daily_digest", "本次简报已持久化且覆盖保留/排除论文"),
+        ("综合滚动趋势", "wiki.trend_synthesize", "滚动趋势快照已更新"),
+        ("记录同步进度", "wiki.update_watermark", "文献库同步状态已更新"),
     ]
     return [
         {

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -39,7 +39,7 @@ from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.project import Project
 from app.models.user import User
 from app.schemas.graph import GraphResponse
-from app.schemas.ingest import IngestRequest, IngestStateRead
+from app.schemas.ingest import DigestGenerateRead, IngestRequest, IngestStateRead
 from app.schemas.libraries import (
     CuratorRead,
     CuratorsUpdate,
@@ -49,6 +49,8 @@ from app.schemas.libraries import (
     DuplicateCandidateGroup,
     LibraryBudgetRead,
     LibraryCreate,
+    LibraryDigestRead,
+    LibraryDigestSummary,
     LibraryReject,
     PaperMergeRequest,
     PaperMergeResult,
@@ -84,6 +86,7 @@ from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
 from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
+from app.services import research_digest as research_digest_service
 from app.services import statement_interview as interview
 from app.services.embedding import embed_query
 from app.services.wiki_export import build_obsidian_zip_for_libraries
@@ -231,9 +234,7 @@ async def statement_interview(
                 options=question.options,
             ),
         )
-    statement = await interview.compose(
-        topic=data.topic, answers=answers, llm=llm, user_id=user.id
-    )
+    statement = await interview.compose(topic=data.topic, answers=answers, llm=llm, user_id=user.id)
     return StatementInterviewResponse(done=True, step=total, total=total, statement=statement)
 
 
@@ -249,6 +250,75 @@ async def get_library(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
     row = await libraries_service.library_overview(session, library=library, user=user)
     return DirectionLibraryDetail(**row)
+
+
+@router.get("/libraries/{library_id}/digests", response_model=list[LibraryDigestSummary])
+async def list_library_digests(
+    library_id: uuid.UUID,
+    limit: int = Query(default=30, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[LibraryDigestSummary]:
+    """按日期倒序列出文献库每日简报；正文由详情端点按需读取。"""
+    library = await _get_visible_library(session, library_id, user)
+    rows = await research_digest_service.list_digest_summaries(
+        session, library_id=library.id, limit=limit
+    )
+    return [LibraryDigestSummary(**row) for row in rows]
+
+
+@router.post(
+    "/libraries/{library_id}/digests/generate",
+    response_model=DigestGenerateRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def generate_library_digest(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_task),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> DigestGenerateRead:
+    """生成今日简报：有今日更新则直接生成，否则先执行一次增量同步。"""
+    library = await _get_managed_library(session, library_id, user)
+    if library.status != "active":
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_NOT_ACTIVE")
+    project = (
+        await session.get(Project, library.project_id) if library.project_id is not None else None
+    )
+    try:
+        run, strategy, paper_count = await ingest_service.create_digest_voyage(
+            session,
+            library=library,
+            project=project,
+            created_by=user.id,
+        )
+    except ingest_service.IngestConflictError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
+    except ingest_service.LibraryBudgetExhaustedError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
+    await queue.enqueue("run_voyage", str(run.id))
+    return DigestGenerateRead(
+        voyage_id=run.id,
+        strategy=strategy,
+        paper_count=paper_count,
+    )
+
+
+@router.get("/libraries/{library_id}/digests/{digest_id}", response_model=LibraryDigestRead)
+async def get_library_digest(
+    library_id: uuid.UUID,
+    digest_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibraryDigestRead:
+    """读取一份每日简报及该次同步形成的滚动趋势快照。"""
+    library = await _get_visible_library(session, library_id, user)
+    digest = await research_digest_service.get_digest(
+        session, library_id=library.id, digest_id=digest_id
+    )
+    if digest is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_DIGEST_NOT_FOUND")
+    return LibraryDigestRead.model_validate(digest)
 
 
 @router.post("/libraries/{library_id}/request-public", response_model=DirectionLibraryDetail)
@@ -379,9 +449,7 @@ async def delete_library(
     """
     library = await _get_library(session, library_id)
     try:
-        await libraries_service.delete_library(
-            session, library=library, user=user, force=force
-        )
+        await libraries_service.delete_library(session, library=library, user=user, force=force)
     except libraries_service.LibraryDeleteForbiddenError as e:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_DELETE_FORBIDDEN") from e
     except libraries_service.LibraryHasTopicsError as e:
@@ -432,9 +500,7 @@ async def start_library_ingest(
         # 待审批 / 已驳回的库不能抓取（P9b：仅 active 且预算内可触发）。
         raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_NOT_ACTIVE")
     project = (
-        await session.get(Project, library.project_id)
-        if library.project_id is not None
-        else None
+        await session.get(Project, library.project_id) if library.project_id is not None else None
     )
     try:
         run = await ingest_service.create_ingest_voyage(
@@ -608,9 +674,7 @@ async def restore_library_paper(
     return await _paper_detail(session, view, user.id)
 
 
-@router.delete(
-    "/libraries/{library_id}/papers/{paper_id}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/libraries/{library_id}/papers/{paper_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_library_paper(
     library_id: uuid.UUID,
     paper_id: uuid.UUID,
@@ -750,16 +814,12 @@ async def export_library_citations(
         return Response(
             content=citations_service.build_bibtex(papers),
             media_type="text/plain; charset=utf-8",
-            headers={
-                "Content-Disposition": 'attachment; filename="polaris-library-citations.bib"'
-            },
+            headers={"Content-Disposition": 'attachment; filename="polaris-library-citations.bib"'},
         )
     return Response(
         content=json.dumps(citations_service.build_csl_json(papers), ensure_ascii=False, indent=2),
         media_type="application/json",
-        headers={
-            "Content-Disposition": 'attachment; filename="polaris-library-citations.json"'
-        },
+        headers={"Content-Disposition": 'attachment; filename="polaris-library-citations.json"'},
     )
 
 

--- a/src/backend/app/cli/__init__.py
+++ b/src/backend/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Operational command-line entry points for Polaris."""

--- a/src/backend/app/cli/sync_obsidian_vault.py
+++ b/src/backend/app/cli/sync_obsidian_vault.py
@@ -1,0 +1,54 @@
+"""Synchronize an auto-idea Obsidian vault into a Polaris project library."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import uuid
+from pathlib import Path
+
+from app.core.db import dispose_engine, get_sessionmaker
+from app.services.obsidian_vault_sync import sync_obsidian_vault
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("vault", type=Path, help="path to the auto-idea Obsidian vault")
+    parser.add_argument("--project-id", type=uuid.UUID, required=True)
+    parser.add_argument("--library-name", help="defaults to the project name")
+    parser.add_argument("--dry-run", action="store_true", help="inspect without changing data")
+    parser.add_argument("--overwrite-wiki", action="store_true")
+    parser.add_argument("--skip-files", action="store_true", help="do not copy PDF/TXT/figures")
+    parser.add_argument("--skip-chunks", action="store_true", help="do not build text chunks")
+    parser.add_argument("--batch-size", type=int, default=25)
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> None:
+    try:
+        async with get_sessionmaker()() as session:
+            stats = await sync_obsidian_vault(
+                session,
+                vault_path=args.vault,
+                project_id=args.project_id,
+                library_name=args.library_name,
+                dry_run=args.dry_run,
+                overwrite_wiki=args.overwrite_wiki,
+                copy_files=not args.skip_files,
+                index_chunks=not args.skip_chunks,
+                batch_size=args.batch_size,
+            )
+            print(json.dumps(stats.as_dict(), ensure_ascii=False, indent=2))
+    finally:
+        await dispose_engine()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(_run(_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -32,6 +32,8 @@ _FAKE_AFFIL_BLOCK = (
     "POLARIS_AFFILIATIONS>>>\n"
 )
 _LIBRARIAN_MARKER = "TL;DR"
+_DAILY_DIGEST_MARKER = "POLARIS_DAILY_DIGEST"
+_TREND_SYNTHESIS_MARKER = "POLARIS_TREND_SYNTHESIS"
 _INTERVIEW_MARKER = '"out_of_scope"'
 _GAPS_MARKER = '"gaps"'  # forge gap 分析
 _IDEAS_MARKER = '"ideas"'  # forge 候选生成
@@ -281,6 +283,10 @@ class FakeProvider(LLMProvider):
             return FakeProvider._respond_writing_related(last_user)
         if _WRITE_SECTION_MARKER in full_text:
             return FakeProvider._respond_writing_section(full_text, last_user)
+        if _DAILY_DIGEST_MARKER in full_text:
+            return FakeProvider._respond_daily_digest(last_user)
+        if _TREND_SYNTHESIS_MARKER in full_text:
+            return FakeProvider._respond_trend_synthesis(last_user)
         if _VERDICT_MARKER in full_text and _PLAN_MARKER not in full_text:
             return json.dumps(
                 {"passed": True, "reason": "fake-sextant: 产出满足验收标准（确定性假判定）"},
@@ -389,6 +395,58 @@ class FakeProvider(LLMProvider):
                 "score": score,
                 "reason": "fake-relevance: 依据标题/摘要关键词的确定性假打分",
                 "tldr": "（fake TL;DR）" + last_user.strip().splitlines()[-1][:120],
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_daily_digest(last_user: str) -> str:
+        """每日简报：覆盖 prompt 中每个 paper_id，供全流水线测试。"""
+        paper_ids = list(dict.fromkeys(re.findall(r'"paper_id"\s*:\s*"([^"]+)"', last_user)))
+        return json.dumps(
+            {
+                "summary": f"（fake 每日简报）本期共整理 {len(paper_ids)} 篇相关论文。",
+                "paper_insights": [
+                    {
+                        "paper_id": paper_id,
+                        "highlight": "给出了可复用的方法与实验信号（fake）。",
+                        "direction_relation": "直接回应本库的研究问题（fake）。",
+                        "concepts": ["Agent", "强化学习"],
+                    }
+                    for paper_id in paper_ids
+                ],
+                "cross_paper_signals": (
+                    [
+                        {
+                            "title": "Agent 方法持续系统化（fake）",
+                            "summary": "多篇论文共同强调规划与反馈闭环（fake）。",
+                            "paper_ids": paper_ids[:3],
+                        }
+                    ]
+                    if paper_ids
+                    else []
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_trend_synthesis(last_user: str) -> str:
+        """滚动趋势：从 prompt 取论文 id，返回一条确定性趋势。"""
+        paper_ids = list(dict.fromkeys(re.findall(r'"paper_id"\s*:\s*"([^"]+)"', last_user)))
+        return json.dumps(
+            {
+                "trends": [
+                    {
+                        "title": "可验证的 Agent 工作流（fake）",
+                        "status": "active",
+                        "summary": "研究正在从单步生成转向可验证闭环（fake）。",
+                        "evidence_trajectory": "近期论文持续补充规划、反馈与评测证据（fake）。",
+                        "concepts": ["Agent", "强化学习"],
+                        "paper_ids": paper_ids[:5],
+                        "last_seen": "2026-07-29",
+                    }
+                ]
             },
             ensure_ascii=False,
         )

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -7,6 +7,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
@@ -38,6 +39,11 @@ def _rejects_effort(body: str) -> bool:
     return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
 
 
+_MATRYOSHKA_UNSUPPORTED_MARKER = "does not support matryoshka representation"
+# PostgreSQL 的 papers/paper_chunks/ideas 向量列统一为 vector(1024)。
+_POLARIS_EMBEDDING_DIM = 1024
+
+
 def _retry_delay(resp: httpx.Response, attempt: int) -> float:
     retry_after = resp.headers.get("retry-after")
     if retry_after:
@@ -46,6 +52,25 @@ def _retry_delay(resp: httpx.Response, attempt: int) -> float:
         except ValueError:
             pass
     return _BACKOFF_BASE_SECONDS * (2**attempt)
+
+
+def _is_qwen3_embedding(model: str) -> bool:
+    """Qwen3 Embedding 支持 MRL，但旧版 vLLM 可能没有从模型配置识别出来。"""
+    normalized = model.lower().replace("-", "_")
+    return "qwen3" in normalized and "embedding" in normalized
+
+
+def _truncate_and_normalize(vector: list[float], dimensions: int) -> list[float]:
+    """按 Matryoshka 语义截取前 N 维，并恢复单位长度。"""
+    if len(vector) < dimensions:
+        raise RuntimeError(
+            f"embedding dimension mismatch: expected {dimensions}, got {len(vector)}"
+        )
+    truncated = vector[:dimensions]
+    norm = math.sqrt(math.fsum(value * value for value in truncated))
+    if norm == 0:
+        raise RuntimeError("cannot normalize a zero embedding vector")
+    return [value / norm for value in truncated]
 
 
 class OpenAICompatProvider(LLMProvider):
@@ -288,14 +313,39 @@ class OpenAICompatProvider(LLMProvider):
                     yield content
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:
-        resp = await self._post_with_retry(
-            f"{self._base_url}/embeddings", {"model": model, "input": texts}
-        )
+        url = f"{self._base_url}/embeddings"
+        payload: dict[str, Any] = {"model": model, "input": texts}
+        qwen3_embedding = _is_qwen3_embedding(model)
+        if qwen3_embedding:
+            # Qwen3 Embedding 原生支持 32..hidden_size 的 MRL 输出维度。新 vLLM
+            # 会直接返回 1024 维；旧部署若没有标记 is_matryoshka，会在下面兼容。
+            payload["dimensions"] = _POLARIS_EMBEDDING_DIM
+
+        resp = await self._post_with_retry(url, payload)
+        if (
+            qwen3_embedding
+            and resp.status_code == 400
+            and _MATRYOSHKA_UNSUPPORTED_MARKER in resp.text.lower()
+        ):
+            logger.warning(
+                "embedding backend did not recognize Qwen3 MRL; requesting the native vector "
+                "and reducing it to %d dimensions locally",
+                _POLARIS_EMBEDDING_DIM,
+            )
+            resp = await self._post_with_retry(url, {"model": model, "input": texts})
         resp.raise_for_status()
         data = resp.json()["data"]
         # 按 index 还原顺序（OpenAI 兼容端点保证有 index 字段）
         data.sort(key=lambda item: item.get("index", 0))
-        return [item["embedding"] for item in data]
+        vectors = [item["embedding"] for item in data]
+        if not qwen3_embedding:
+            return vectors
+        return [
+            vector
+            if len(vector) == _POLARIS_EMBEDDING_DIM
+            else _truncate_and_normalize(vector, _POLARIS_EMBEDDING_DIM)
+            for vector in vectors
+        ]
 
     async def rerank(
         self,

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -33,6 +33,7 @@ from app.models.paper import (
 from app.models.project import Project, ProjectInvite, ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.registration_code import RegistrationCode
+from app.models.research_digest import LibraryResearchDigest
 from app.models.review import ReviewMessage, ReviewSession
 from app.models.skill import ProjectSkill, Skill, SkillListing, SkillRating, SkillVersion
 from app.models.ssh_credential import SSHCredential
@@ -60,6 +61,7 @@ __all__ = [
     "IdeaVector",
     "LLMCallLog",
     "LibraryPaper",
+    "LibraryResearchDigest",
     "LLMProviderConfig",
     "LLMUsage",
     "Manuscript",

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -41,9 +41,7 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 生命周期（P9b）：pending 待审批 | active 已激活（可抓取）| rejected 已驳回。
     # server_default='active'——存量库与课题隐式起源库都视为已激活；用户经
     # POST /libraries 独立建的库显式落 pending，管理员审批后转 active。
-    status: Mapped[str] = mapped_column(
-        String(16), nullable=False, server_default="active"
-    )
+    status: Mapped[str] = mapped_column(String(16), nullable=False, server_default="active")
     review_note: Mapped[str | None] = mapped_column(Text)  # 驳回理由（status=rejected 时有值）
     # 归属（P10）：个人库 is_public=false（仅创建者 + admin 可见/可管理），公共库
     # is_public=true（全实验室可见，全体 admin + 创建者/策展人可管理）。个人库经
@@ -96,6 +94,7 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
     )
     relevance_score: Mapped[float | None]  # LLM 对照方向 rubric 的打分
+    relevance_reason: Mapped[str | None] = mapped_column(Text)  # 本次收录/排除的方向化理由
     tldr_note: Mapped[str | None] = mapped_column(Text)  # 库视角一句话概括（可选）
     # 退役列（解读已统一到 paper_wikis，每篇论文一份、不再按库分版本）：只留存量
     # 数据，代码不再读写；删列待确认稳定后另做迁移。

--- a/src/backend/app/models/research_digest.py
+++ b/src/backend/app/models/research_digest.py
@@ -1,0 +1,62 @@
+"""文献库每日简报与滚动趋势快照。"""
+
+import uuid
+from datetime import date
+from typing import Any
+
+from sqlalchemy import Date, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class LibraryResearchDigest(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """一次文献同步形成的、可长期回看的研究简报。
+
+    ``content`` 是面向人的 Markdown；结构化 JSON 字段供前端统计卡片、论文跳转和
+    后续趋势综合使用。Obsidian 历史简报与 Polaris 原生 Voyage 简报共用这张表。
+    """
+
+    __tablename__ = "library_research_digests"
+    __table_args__ = (
+        UniqueConstraint(
+            "library_id",
+            "report_date",
+            "source",
+            name="uq_library_research_digests_library_date_source",
+        ),
+        UniqueConstraint("voyage_id", name="uq_library_research_digests_voyage"),
+        Index("ix_library_research_digests_library_date", "library_id", "report_date"),
+    )
+
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), nullable=False
+    )
+    # Obsidian 历史导入没有 Voyage；原生流水线必须有，且一次 Voyage 至多一份简报。
+    voyage_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("voyage_runs.id", ondelete="SET NULL"), nullable=True
+    )
+    report_date: Mapped[date] = mapped_column(Date, nullable=False)
+    source: Mapped[str] = mapped_column(String(32), nullable=False)  # voyage | obsidian
+    mode: Mapped[str] = mapped_column(
+        String(32), nullable=False
+    )  # bootstrap | incremental | import
+
+    counts: Mapped[dict[str, Any]] = mapped_column(JSONVariant, nullable=False)
+    source_diagnostics: Mapped[dict[str, Any]] = mapped_column(JSONVariant, nullable=False)
+    paper_insights: Mapped[list[Any]] = mapped_column(JSONVariant, nullable=False)
+    excluded_papers: Mapped[list[Any]] = mapped_column(JSONVariant, nullable=False)
+    cross_paper_signals: Mapped[list[Any]] = mapped_column(JSONVariant, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    model: Mapped[str | None] = mapped_column(String(128))
+
+    # 趋势既保留结构化线程，也保留可直接阅读/导出的 Markdown 快照。
+    rolling_trends: Mapped[list[Any]] = mapped_column(JSONVariant, nullable=False)
+    trend_content: Mapped[str] = mapped_column(Text, nullable=False)
+    trend_model: Mapped[str | None] = mapped_column(String(128))
+
+    @property
+    def has_trends(self) -> bool:
+        return bool(self.trend_content or self.rolling_trends)

--- a/src/backend/app/schemas/ingest.py
+++ b/src/backend/app/schemas/ingest.py
@@ -44,6 +44,15 @@ class IngestRequest(BaseModel):
     time_range: Literal["1w", "3m", "6m", "1y"] | None = None
 
 
+class DigestGenerateRead(BaseModel):
+    """手动生成今日简报的启动结果。"""
+
+    voyage_id: uuid.UUID
+    # digest_only：复用今日已更新论文；incremental：今日无更新，先跑增量同步。
+    strategy: Literal["digest_only", "incremental"]
+    paper_count: int = 0
+
+
 class IngestLastRun(BaseModel):
     voyage_id: uuid.UUID
     status: str

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -4,7 +4,7 @@
 """
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -187,6 +187,49 @@ class LibraryBudgetRead(BaseModel):
     used_tokens: int
     remaining_tokens: int | None  # 不限时为 None；用超时为 0
     exhausted: bool  # True = 本月预算已用尽（ingest 会被拒绝启动）
+
+
+class LibraryDigestSummary(BaseModel):
+    """文献库每日简报列表项；正文按需从详情端点读取。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    report_date: date
+    source: str
+    mode: str
+    counts: dict[str, Any]
+    summary: str
+    voyage_id: uuid.UUID | None
+    has_trends: bool = False
+    created_at: datetime
+
+
+class LibraryDigestRead(BaseModel):
+    """每日简报完整内容与该时点的滚动趋势快照。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    library_id: uuid.UUID
+    voyage_id: uuid.UUID | None
+    report_date: date
+    source: str
+    mode: str
+    counts: dict[str, Any]
+    source_diagnostics: dict[str, Any]
+    paper_insights: list[Any]
+    excluded_papers: list[Any]
+    cross_paper_signals: list[Any]
+    summary: str
+    content: str
+    model: str | None
+    rolling_trends: list[Any]
+    trend_content: str
+    trend_model: str | None
+    has_trends: bool
+    created_at: datetime
+    updated_at: datetime
 
 
 # ---- 方向描述访谈（AI 结构化问答产出 statement） ----

--- a/src/backend/app/schemas/skill.py
+++ b/src/backend/app/schemas/skill.py
@@ -15,6 +15,8 @@ SKILL_TARGETS = frozenset(
     {
         "wiki.score_relevance",
         "wiki.compile",
+        "wiki.daily_digest",
+        "wiki.trend_synthesize",
         "forge.gap_analysis",
         "forge.generate",
         "forge.score",

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -124,8 +124,10 @@ async def _free_slug(session: AsyncSession, name: str) -> str:
     """给新概念取一个没被占用的 slug（全局唯一；撞了加随机后缀）。"""
     slug = wiki_slug(name)
     taken = (
-        await session.execute(select(Concept.slug).where(Concept.slug.like(f"{slug}%")))
-    ).scalars().all()
+        (await session.execute(select(Concept.slug).where(Concept.slug.like(f"{slug}%"))))
+        .scalars()
+        .all()
+    )
     if slug not in set(taken):
         return slug
     return f"{slug}-{uuid.uuid4().hex[:6]}"
@@ -218,9 +220,7 @@ async def papers_of_concept(
     )
     if library_id is not None:
         stmt = stmt.where(
-            Paper.id.in_(
-                select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library_id)
-            )
+            Paper.id.in_(select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library_id))
         )
     return list((await session.execute(stmt)).scalars().all())
 
@@ -397,6 +397,148 @@ async def promote_ready_concepts(
     return promoted, rejected
 
 
+def _normalize_generated_concept_names(values: Any) -> list[str]:
+    """清洗简报模型返回的概念名，保序去重并限制单篇概念数量。"""
+    if not isinstance(values, list):
+        return []
+    names: dict[str, None] = {}
+    for value in values:
+        name = " ".join(str(value or "").strip().split())
+        if name.startswith("[[") and name.endswith("]]"):
+            name = name[2:-2].strip()
+        if name.lower().startswith("concepts/"):
+            name = name[len("concepts/") :].strip()
+        name = name.split("|", 1)[0].split("#", 1)[0].strip()
+        if not name or len(name) > 255:
+            continue
+        names.setdefault(name, None)
+        if len(names) >= 6:
+            break
+    return list(names)
+
+
+async def link_generated_paper_concepts(
+    session: AsyncSession,
+    *,
+    concepts_by_paper: dict[str | uuid.UUID, list[Any]],
+    llm: LLMRouter | None = None,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> tuple[dict[str, list[str]], dict[str, int]]:
+    """把每日简报模型提取的概念落库并关联论文。
+
+    这条路径补足「今日论文已评分、但尚未精读编译」时的概念关联。它只增补关联，不清除
+    解读正文建立的既有关系；新名字仍遵循统一的候选/转正治理：至少被两篇论文复用并通过
+    有效性复核后才成为可点击的正式概念。返回值只包含正式概念，供简报生成 wikilink。
+    """
+    normalized: dict[uuid.UUID, list[str]] = {}
+    for raw_paper_id, values in concepts_by_paper.items():
+        try:
+            paper_id = uuid.UUID(str(raw_paper_id))
+        except (TypeError, ValueError):
+            continue
+        normalized[paper_id] = _normalize_generated_concept_names(values)
+
+    names = sorted({name for paper_names in normalized.values() for name in paper_names})
+    if not normalized or not names:
+        return (
+            {str(paper_id): [] for paper_id in normalized},
+            {
+                "concepts_created": 0,
+                "links_created": 0,
+                "concepts_promoted": 0,
+                "concepts_rejected": 0,
+                "active_concepts": 0,
+            },
+        )
+
+    existing = list(
+        (await session.execute(select(Concept).where(Concept.name.in_(names)))).scalars().all()
+    )
+    existing_by_name = {concept.name: concept for concept in existing}
+    by_name = {
+        name: concept
+        for name, concept in existing_by_name.items()
+        if concept.status != CONCEPT_STATUS_REJECTED
+    }
+    created = 0
+    for name in names:
+        # 已判为无效的名字保持终态，不重新创建或关联。
+        if name in existing_by_name:
+            continue
+        by_name[name] = await _new_candidate_concept(session, name)
+        created += 1
+    await session.flush()
+
+    paper_ids = list(normalized)
+    existing_pairs = {
+        (paper_id, concept_id)
+        for paper_id, concept_id in (
+            await session.execute(
+                select(paper_concepts.c.paper_id, paper_concepts.c.concept_id).where(
+                    paper_concepts.c.paper_id.in_(paper_ids)
+                )
+            )
+        ).all()
+    }
+    linked = 0
+    linked_concept_ids: set[uuid.UUID] = set()
+    for paper_id, paper_names in normalized.items():
+        for name in paper_names:
+            concept = by_name.get(name)
+            if concept is None:
+                continue
+            linked_concept_ids.add(concept.id)
+            pair = (paper_id, concept.id)
+            if pair in existing_pairs:
+                continue
+            await session.execute(
+                insert(paper_concepts).values(paper_id=paper_id, concept_id=concept.id)
+            )
+            existing_pairs.add(pair)
+            linked += 1
+
+    # 先释放写事务，再让概念复核模型通过独立连接记账，避免 SQLite 写锁互相等待。
+    await session.commit()
+    promoted, rejected = await promote_ready_concepts(
+        session,
+        concept_ids=list(linked_concept_ids),
+        llm=llm,
+        user_id=user_id,
+        project_id=project_id,
+        library_id=library_id,
+        voyage_id=voyage_id,
+    )
+    await session.commit()
+
+    active_rows = (
+        await session.execute(
+            select(paper_concepts.c.paper_id, Concept.name)
+            .join(Concept, Concept.id == paper_concepts.c.concept_id)
+            .where(
+                paper_concepts.c.paper_id.in_(paper_ids),
+                Concept.status == CONCEPT_STATUS_ACTIVE,
+                Concept.name.in_(names),
+            )
+            .order_by(Concept.name)
+        )
+    ).all()
+    active_by_paper = {str(paper_id): [] for paper_id in paper_ids}
+    for paper_id, name in active_rows:
+        if name in normalized[paper_id]:
+            active_by_paper[str(paper_id)].append(name)
+    active_names = {name for _, name in active_rows}
+    return active_by_paper, {
+        "concepts_created": created,
+        "links_created": linked,
+        "concepts_promoted": len(promoted),
+        "concepts_rejected": len(rejected),
+        "active_concepts": len(active_names),
+    }
+
+
 def _apply_verdict(concept: Concept, meta: dict[str, Any] | None) -> bool:
     """把一条判定结果写到词条上，返回它是否留在概念库（True=有效）。
 
@@ -452,9 +594,7 @@ async def _remove_stale_paper_links(
         cid
         for (cid,) in (
             await session.execute(
-                select(paper_concepts.c.concept_id).where(
-                    paper_concepts.c.paper_id == paper_id
-                )
+                select(paper_concepts.c.concept_id).where(paper_concepts.c.paper_id == paper_id)
             )
         ).all()
         if cid not in keep_concept_ids
@@ -515,9 +655,7 @@ async def link_all_paper_concepts(
 
     # 概念全平台一份：按名字查全表（别的库先建过同名词条，这里直接复用）
     existing = (
-        (await session.execute(select(Concept).where(Concept.name.in_(all_names))))
-        .scalars()
-        .all()
+        (await session.execute(select(Concept).where(Concept.name.in_(all_names)))).scalars().all()
     )
     by_name = {c.name: c for c in existing}
     new_names = [n for n in all_names if n not in by_name]
@@ -672,11 +810,7 @@ async def review_active_concepts(
         .all()
     )
     pending = sorted(
-        (
-            c
-            for c in scoped
-            if c.validated_at is None or is_placeholder_definition(c.definition)
-        ),
+        (c for c in scoped if c.validated_at is None or is_placeholder_definition(c.definition)),
         key=lambda c: (c.created_at is None, c.created_at or c.name),
     )
     if limit is not None:
@@ -731,9 +865,7 @@ async def link_paper_concepts(
     library_id = membership.library_id if membership is not None else None
     names = extract_wikilinks(paper.wiki_content)
     existing = (
-        (await session.execute(select(Concept).where(Concept.name.in_(names))))
-        .scalars()
-        .all()
+        (await session.execute(select(Concept).where(Concept.name.in_(names)))).scalars().all()
     )
     by_name = {c.name: c for c in existing}
     new_names = [n for n in names if n not in by_name]
@@ -748,9 +880,7 @@ async def link_paper_concepts(
         cid
         for (cid,) in (
             await session.execute(
-                select(paper_concepts.c.concept_id).where(
-                    paper_concepts.c.paper_id == paper.id
-                )
+                select(paper_concepts.c.concept_id).where(paper_concepts.c.paper_id == paper.id)
             )
         ).all()
     }

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -10,8 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.voyage.navigator import WIKI_KINDS
 from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
-from app.models.paper import PAPER_STATUSES
+from app.models.paper import PAPER_STATUSES, Paper
 from app.models.project import Project
+from app.models.research_digest import LibraryResearchDigest
 from app.models.user import User
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
@@ -45,9 +46,7 @@ class LibraryBudgetExhaustedError(Exception):
     """方向库本月预算已用尽（P6）：拒绝启动新的 ingest。"""
 
 
-async def monthly_library_usage(
-    session: AsyncSession, library_id: uuid.UUID
-) -> dict[str, Any]:
+async def monthly_library_usage(session: AsyncSession, library_id: uuid.UUID) -> dict[str, Any]:
     """该方向库本月（UTC 自然月）的 LLM 用量聚合（口径与 LLMUsage 记账一致）。"""
     from app.models.llm_config import LLMUsage  # 延迟导入避免模块环
 
@@ -184,6 +183,136 @@ async def create_ingest_voyage(
     return run
 
 
+async def create_digest_voyage(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    project: Project | None = None,
+    created_by: uuid.UUID | None,
+    knobs: IngestKnobs | None = None,
+) -> tuple[VoyageRun, str, int]:
+    """智能启动今日简报。
+
+    UTC 当天已有完成相关性判断的论文时，只建「简报 + 趋势」两步任务并复用这些
+    论文；当天没有论文更新时，退回正常增量 ingest。简报专用任务不包含水位线步骤，
+    因为它没有访问任何外部数据源。
+    """
+    if await find_running_ingest_for_library(session, library.id) is not None:
+        raise IngestConflictError(str(library.id))
+
+    now = datetime.now(UTC)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    rows = (
+        await session.execute(
+            select(LibraryPaper.paper_id, LibraryPaper.status, Paper.published_at)
+            .join(Paper, Paper.id == LibraryPaper.paper_id)
+            .where(
+                LibraryPaper.library_id == library.id,
+                LibraryPaper.scored_at.is_not(None),
+                LibraryPaper.scored_at >= day_start,
+                LibraryPaper.scored_at <= now,
+            )
+            .order_by(LibraryPaper.scored_at, LibraryPaper.paper_id)
+        )
+    ).all()
+    if not rows:
+        run = await create_ingest_voyage(
+            session,
+            library=library,
+            project=project,
+            mode="incremental",
+            knobs=knobs or IngestKnobs(),
+            created_by=created_by,
+        )
+        return run, "incremental", 0
+
+    actual_knobs = knobs or IngestKnobs()
+    budget = await apply_library_budget(
+        session,
+        library_id=library.id,
+        monthly_budget=library.monthly_budget,
+        budget=derive_budget(actual_knobs),
+    )
+    paper_ids = list(dict.fromkeys(row.paper_id for row in rows))
+    latest_published_at = max(
+        (row.published_at for row in rows if row.published_at is not None), default=None
+    )
+
+    # 当天已有原生简报时保留其来源统计；本次只重新综合内容，不伪装成又抓了一遍来源。
+    prior_digest = (
+        await session.execute(
+            select(LibraryResearchDigest).where(
+                LibraryResearchDigest.library_id == library.id,
+                LibraryResearchDigest.report_date == now.date(),
+                LibraryResearchDigest.source == "voyage",
+            )
+        )
+    ).scalar_one_or_none()
+    digest_counts = (
+        dict(prior_digest.counts or {})
+        if prior_digest is not None
+        else {
+            "source_fetched": 0,
+            "prescreened": len(paper_ids),
+            "inserted": 0,
+            "compiled": sum(1 for row in rows if row.status in {"compiled", "included"}),
+        }
+    )
+    diagnostics = dict(prior_digest.source_diagnostics or {}) if prior_digest is not None else {}
+    prior_messages = diagnostics.get("messages")
+    messages = list(prior_messages) if isinstance(prior_messages, list) else []
+    messages.append(
+        f"检测到今日已有 {len(paper_ids)} 篇论文完成更新；"
+        "本次跳过增量抓取，直接生成简报与滚动趋势。"
+    )
+    diagnostics.update(
+        {
+            "status": diagnostics.get("status") or "ok",
+            "messages": messages,
+            "source_latest_at": diagnostics.get("source_latest_at")
+            or (latest_published_at.isoformat() if latest_published_at else None),
+        }
+    )
+
+    target_name = project.name if project is not None else library.name
+    checkpoint = {
+        "params": {
+            "mode": "incremental",
+            "knobs": actual_knobs.model_dump(),
+            "digest_only": True,
+        },
+        "digest_paper_ids": [str(paper_id) for paper_id in paper_ids],
+        "digest_counts": digest_counts,
+        "digest_excluded_papers": list(prior_digest.excluded_papers or [])
+        if prior_digest is not None
+        else [],
+        "ingest_search_stats": diagnostics,
+    }
+    run = VoyageRun(
+        kind="wiki_ingest",
+        goal=f"生成今日文献简报：{target_name}",
+        status="planning",
+        cursor=0,
+        checkpoint=checkpoint,
+        budget=budget,
+        library_id=library.id,
+        created_by=created_by,
+    )
+    session.add(run)
+    session.add(
+        Activity(
+            library_id=library.id,
+            actor=f"user:{created_by}" if created_by else "system",
+            kind="digest.started",
+            message=f"今日简报生成已启动（复用 {len(paper_ids)} 篇今日更新论文）",
+            payload={"strategy": "digest_only", "paper_count": len(paper_ids)},
+        )
+    )
+    await session.commit()
+    await session.refresh(run)
+    return run, "digest_only", len(paper_ids)
+
+
 def _empty_counts() -> dict[str, int]:
     counts = {status: 0 for status in PAPER_STATUSES}
     counts["total"] = 0
@@ -192,9 +321,7 @@ def _empty_counts() -> dict[str, int]:
     return counts
 
 
-async def library_paper_counts(
-    session: AsyncSession, library_id: uuid.UUID
-) -> dict[str, int]:
+async def library_paper_counts(session: AsyncSession, library_id: uuid.UUID) -> dict[str, int]:
     """某方向库的论文状态计数（库级直接统计 library_papers，库工作台/ingest 面板共用）。"""
     counts = {status: 0 for status in PAPER_STATUSES}
     rows = (
@@ -277,16 +404,12 @@ async def _resolve_last_run(
     }
 
 
-async def ingest_state(
-    session: AsyncSession, project: Project, *, user: User
-) -> dict[str, Any]:
+async def ingest_state(session: AsyncSession, project: Project, *, user: User) -> dict[str, Any]:
     # P8a：水位线/last_run 权威源在库（library.ingest_state）
     library = await get_library_for_project(session, project.id)
     state = (library.ingest_state if library else None) or {}
     # 互斥以库为准：库任务不写 project_id，按课题查已经查不到在跑的任务
-    running = (
-        await find_running_ingest_for_library(session, library.id) if library else None
-    )
+    running = await find_running_ingest_for_library(session, library.id) if library else None
     return {
         "watermark": state.get("watermark"),
         "last_run": await _resolve_last_run(session, state, user),
@@ -358,11 +481,7 @@ async def find_due_daily_libraries(session: AsyncSession) -> list[DirectionLibra
     ``status``，pending/rejected 但留有历史水位线的库照样会被 cron 拉起来。
     """
     libraries = (
-        (
-            await session.execute(
-                select(DirectionLibrary).where(DirectionLibrary.status == "active")
-            )
-        )
+        (await session.execute(select(DirectionLibrary).where(DirectionLibrary.status == "active")))
         .scalars()
         .all()
     )
@@ -375,5 +494,3 @@ async def find_due_daily_libraries(session: AsyncSession) -> list[DirectionLibra
             continue
         due.append(library)
     return due
-
-

--- a/src/backend/app/services/obsidian_vault_sync.py
+++ b/src/backend/app/services/obsidian_vault_sync.py
@@ -1,0 +1,945 @@
+"""Import an auto-idea Obsidian vault into the Polaris literature pool.
+
+The importer is deliberately one-way and idempotent: the vault is read-only, papers are
+deduplicated by arXiv id, and existing Polaris content is preserved unless the caller opts in
+to overwriting imported wiki pages.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.library_direction import DirectionLibrary, LibraryPaper, TopicSourceLibrary
+from app.models.paper import Concept, Paper, PaperChunk, PaperWiki, new_paper, paper_concepts
+from app.models.project import Project
+from app.models.research_digest import LibraryResearchDigest
+from app.services.chunks import ensure_paper_chunks
+from app.services.dedup import pool_dedup_key
+from app.services.libraries import create_library, get_source_library_ids
+from app.services.literature.arxiv import normalize_arxiv_id
+from app.services.literature.pdf_extract import figure_path, papers_dir
+
+logger = logging.getLogger(__name__)
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*(?:\n|\Z)", re.DOTALL)
+_CONCEPT_LINK_RE = re.compile(r"\[\[concepts/([^\]|]+)(?:\|([^\]]+))?\]\]")
+_PAPER_LINK_RE = re.compile(r"\[\[(?:papers|surveys)/([^\]|]+)(?:\|([^\]]+))?\]\]")
+_VAULT_FIGURE_RE = re.compile(r"!\[[^\]]*\]\(\.\./\.\./raw/figures/[^)]+\.png\)")
+_LOCAL_SOURCE_FOOTER_RE = re.compile(r"\n---\s*\n本地原文：.*\Z", re.DOTALL)
+_TLDR_RE = re.compile(r"^## TL;DR\s*\n(.+?)(?=\n##\s|\Z)", re.MULTILINE | re.DOTALL)
+
+
+@dataclass(slots=True)
+class VaultPaper:
+    slug: str
+    arxiv_id: str
+    title: str
+    abstract: str | None
+    authors: list[str]
+    categories: list[str]
+    published_at: datetime | None
+    relevance_score: float | None
+    pdf_path: Path | None
+    text_path: Path | None
+    wiki_path: Path | None
+    wiki_raw: str | None
+    figure_path: Path | None
+    figure_meta: dict[str, Any] | None
+    concept_slugs: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class VaultConcept:
+    slug: str
+    name: str
+    definition: str | None
+    wiki_raw: str
+
+
+@dataclass(slots=True)
+class VaultReport:
+    report_date: date
+    wiki_raw: str
+
+
+@dataclass(slots=True)
+class VaultSnapshot:
+    root: Path
+    papers: list[VaultPaper]
+    concepts: dict[str, VaultConcept]
+    statement: str | None
+    paper_by_slug: dict[str, VaultPaper]
+    reports: list[VaultReport]
+    trends_raw: str | None
+
+
+@dataclass(slots=True)
+class SyncStats:
+    project_id: str
+    library_id: str | None = None
+    library_created: bool = False
+    scanned_papers: int = 0
+    missing_wikis: int = 0
+    new_papers: int = 0
+    reused_papers: int = 0
+    memberships_created: int = 0
+    wikis_created: int = 0
+    wikis_overwritten: int = 0
+    wikis_preserved: int = 0
+    pdfs_copied: int = 0
+    texts_copied: int = 0
+    figures_copied: int = 0
+    concepts_created: int = 0
+    concepts_reused: int = 0
+    concept_links_created: int = 0
+    papers_indexed: int = 0
+    chunks_created: int = 0
+    reports_created: int = 0
+    reports_updated: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return data
+
+
+def strip_frontmatter(markdown: str) -> str:
+    return _FRONTMATTER_RE.sub("", markdown, count=1).strip()
+
+
+def _parse_date(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_heading(markdown: str, fallback: str) -> str:
+    body = strip_frontmatter(markdown)
+    match = re.search(r"^#\s+(.+?)\s*$", body, re.MULTILINE)
+    return match.group(1).strip() if match else fallback
+
+
+def _concept_definition(markdown: str) -> str | None:
+    body = strip_frontmatter(markdown)
+    match = re.search(r"^\*\*定义\*\*[:：]\s*(.+?)\s*$", body, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def _statement(root: Path) -> str | None:
+    path = root / "research_direction.md"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^## 一句话\s*\n(.+?)(?=\n##\s|\Z)", text, re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else None
+
+
+def scan_vault(root: Path) -> VaultSnapshot:
+    """Validate and load the stable subset of an auto-idea Obsidian vault."""
+    root = root.expanduser().resolve()
+    meta_dir = root / "raw" / "meta"
+    if not meta_dir.is_dir():
+        raise ValueError(f"not an auto-idea vault (missing raw/meta): {root}")
+
+    concepts: dict[str, VaultConcept] = {}
+    concept_dir = root / "wiki" / "concepts"
+    if concept_dir.is_dir():
+        for path in sorted(concept_dir.glob("*.md")):
+            raw = path.read_text(encoding="utf-8")
+            concepts[path.stem] = VaultConcept(
+                slug=path.stem,
+                name=_first_heading(raw, path.stem.replace("-", " ")),
+                definition=_concept_definition(raw),
+                wiki_raw=raw,
+            )
+
+    reports: list[VaultReport] = []
+    report_dir = root / "report"
+    if report_dir.is_dir():
+        for path in sorted(report_dir.glob("*.md")):
+            try:
+                report_date = date.fromisoformat(path.stem)
+            except ValueError:
+                logger.warning("skip non-date vault report: %s", path)
+                continue
+            reports.append(
+                VaultReport(
+                    report_date=report_date,
+                    wiki_raw=path.read_text(encoding="utf-8"),
+                )
+            )
+    trends_path = root / "wiki" / "trends.md"
+    trends_raw = trends_path.read_text(encoding="utf-8") if trends_path.is_file() else None
+
+    papers: list[VaultPaper] = []
+    seen_arxiv: set[str] = set()
+    for meta_path in sorted(meta_dir.glob("*.json")):
+        meta = _read_json(meta_path)
+        slug = str(meta.get("slug") or meta_path.stem).strip()
+        raw_arxiv = str(meta.get("arxiv_id") or "").strip()
+        title = str(meta.get("title") or "").strip()
+        if not raw_arxiv or not title:
+            raise ValueError(f"paper needs arxiv_id and title: {meta_path}")
+        arxiv_id = normalize_arxiv_id(raw_arxiv)
+        if arxiv_id in seen_arxiv:
+            raise ValueError(f"duplicate arXiv id {arxiv_id} in {meta_path}")
+        seen_arxiv.add(arxiv_id)
+
+        wiki_candidates = [
+            root / "wiki" / "papers" / f"{slug}.md",
+            root / "wiki" / "surveys" / f"{slug}.md",
+        ]
+        wiki_path = next((p for p in wiki_candidates if p.is_file()), None)
+        wiki_raw = wiki_path.read_text(encoding="utf-8") if wiki_path else None
+        concept_slugs = set(_CONCEPT_LINK_RE.findall(wiki_raw or ""))
+        concept_slugs = {slug_value for slug_value, _label in concept_slugs}
+
+        pdf_candidate = root / "raw" / "paper" / f"{slug}.pdf"
+        text_candidate = root / "raw" / "text" / f"{slug}.txt"
+        figure_candidate = root / "raw" / "figures" / f"{slug}.png"
+        figure_meta_path = root / "raw" / "figures" / f"{slug}.json"
+        authors = meta.get("authors") if isinstance(meta.get("authors"), list) else []
+        categories = meta.get("categories") if isinstance(meta.get("categories"), list) else []
+        papers.append(
+            VaultPaper(
+                slug=slug,
+                arxiv_id=arxiv_id,
+                title=title,
+                abstract=(str(meta["abstract"]).strip() if meta.get("abstract") else None),
+                authors=[str(author).strip() for author in authors if str(author).strip()],
+                categories=[
+                    str(category).strip() for category in categories if str(category).strip()
+                ],
+                published_at=_parse_date(meta.get("published")),
+                relevance_score=_float_or_none(meta.get("relevance_score")),
+                pdf_path=pdf_candidate if pdf_candidate.is_file() else None,
+                text_path=text_candidate if text_candidate.is_file() else None,
+                wiki_path=wiki_path,
+                wiki_raw=wiki_raw,
+                figure_path=figure_candidate if figure_candidate.is_file() else None,
+                figure_meta=_read_json(figure_meta_path) if figure_meta_path.is_file() else None,
+                concept_slugs=concept_slugs,
+            )
+        )
+    if not papers:
+        raise ValueError(f"vault contains no paper metadata: {root}")
+    return VaultSnapshot(
+        root=root,
+        papers=papers,
+        concepts=concepts,
+        statement=_statement(root),
+        paper_by_slug={paper.slug: paper for paper in papers},
+        reports=reports,
+        trends_raw=trends_raw,
+    )
+
+
+def render_markdown(
+    markdown: str,
+    *,
+    snapshot: VaultSnapshot,
+    figure_index: int | None = None,
+    paper_ids_by_slug: dict[str, uuid.UUID] | None = None,
+) -> str:
+    """Rewrite vault-local links into forms understood by the Polaris markdown renderer."""
+    body = strip_frontmatter(markdown)
+    body = _LOCAL_SOURCE_FOOTER_RE.sub("", body).rstrip()
+
+    def concept_repl(match: re.Match[str]) -> str:
+        slug, label = match.group(1), match.group(2)
+        concept = snapshot.concepts.get(slug)
+        return f"[[{label or (concept.name if concept else slug.replace('-', ' '))}]]"
+
+    def paper_repl(match: re.Match[str]) -> str:
+        slug, label = match.group(1), match.group(2)
+        paper = snapshot.paper_by_slug.get(slug)
+        if paper is None:
+            return label or slug.replace("-", " ")
+        paper_id = (paper_ids_by_slug or {}).get(slug)
+        if paper_id is not None:
+            return f"[[paper:{paper_id}|{label or paper.title}]]"
+        return f"[{label or paper.title}](https://arxiv.org/abs/{paper.arxiv_id})"
+
+    body = _CONCEPT_LINK_RE.sub(concept_repl, body)
+    body = _PAPER_LINK_RE.sub(paper_repl, body)
+    if figure_index is None:
+        body = _VAULT_FIGURE_RE.sub("", body)
+    else:
+        body = _VAULT_FIGURE_RE.sub(f"![[fig:{figure_index}]]", body)
+    return body.strip()
+
+
+def extract_tldr(markdown: str | None) -> str | None:
+    if not markdown:
+        return None
+    match = _TLDR_RE.search(strip_frontmatter(markdown))
+    if not match:
+        return None
+    return " ".join(match.group(1).strip().split())
+
+
+def _atomic_copy(source: Path, destination: Path) -> bool:
+    """Copy only when missing, using a same-directory temporary file for atomic replacement."""
+    if destination.is_file():
+        return False
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        shutil.copy2(source, temporary)
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return True
+
+
+def _obsidian_figure_index(paper: Paper, slug: str) -> int | None:
+    for item in paper.figures or []:
+        if item.get("source") == "obsidian-vault" and item.get("vault_slug") == slug:
+            return int(item["index"])
+    return None
+
+
+async def _resolve_library(
+    session: AsyncSession,
+    *,
+    project: Project,
+    name: str,
+    statement: str | None,
+    dry_run: bool,
+) -> tuple[DirectionLibrary | None, bool]:
+    source_ids = await get_source_library_ids(session, project.id)
+    if source_ids:
+        linked = list(
+            (
+                await session.execute(
+                    select(DirectionLibrary).where(DirectionLibrary.id.in_(source_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        exact = next((library for library in linked if library.name == name), None)
+        if exact is not None:
+            return exact, False
+    if dry_run:
+        return None, True
+    library = await create_library(
+        session,
+        name=name,
+        statement=statement,
+        created_by=project.owner_id,
+        status="active",
+    )
+    session.add(TopicSourceLibrary(topic_id=project.id, library_id=library.id))
+    await session.commit()
+    return library, True
+
+
+async def _paper_pool(session: AsyncSession, snapshot: VaultSnapshot) -> dict[str, Paper]:
+    ids = [paper.arxiv_id for paper in snapshot.papers]
+    keys = [f"arxiv:{arxiv_id.lower()}" for arxiv_id in ids]
+    rows = list(
+        (
+            await session.execute(
+                select(Paper).where(or_(Paper.arxiv_id.in_(ids), Paper.dedup_key.in_(keys)))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    found: dict[str, Paper] = {}
+    for paper in rows:
+        if paper.arxiv_id:
+            found[normalize_arxiv_id(paper.arxiv_id)] = paper
+        elif paper.dedup_key and paper.dedup_key.startswith("arxiv:"):
+            found[paper.dedup_key.removeprefix("arxiv:")] = paper
+    return found
+
+
+async def _sync_concepts(
+    session: AsyncSession,
+    snapshot: VaultSnapshot,
+    stats: SyncStats,
+    *,
+    dry_run: bool,
+) -> dict[str, Concept]:
+    slugs = list(snapshot.concepts)
+    existing = {
+        concept.slug: concept
+        for concept in (
+            (await session.execute(select(Concept).where(Concept.slug.in_(slugs)))).scalars().all()
+            if slugs
+            else []
+        )
+    }
+    stats.concepts_reused = len(existing)
+    stats.concepts_created = len(slugs) - len(existing)
+    if dry_run:
+        return existing
+    for slug, source in snapshot.concepts.items():
+        rendered = render_markdown(source.wiki_raw, snapshot=snapshot)
+        concept = existing.get(slug)
+        if concept is None:
+            concept = Concept(
+                slug=slug,
+                name=source.name,
+                definition=source.definition,
+                wiki_content=rendered,
+                category="other",
+                status="active",
+            )
+            session.add(concept)
+            existing[slug] = concept
+        else:
+            if not concept.definition and source.definition:
+                concept.definition = source.definition
+            if not concept.wiki_content:
+                concept.wiki_content = rendered
+            if concept.status == "candidate":
+                concept.status = "active"
+    await session.flush()
+    return existing
+
+
+def _fill_missing_metadata(paper: Paper, source: VaultPaper) -> None:
+    if not paper.source:
+        paper.source = "arxiv"
+    if not paper.arxiv_id:
+        paper.arxiv_id = source.arxiv_id
+    if not paper.dedup_key:
+        paper.dedup_key = pool_dedup_key(
+            arxiv_id=source.arxiv_id,
+            doi=None,
+            title=source.title,
+            year=source.published_at.year if source.published_at else None,
+            authors=[{"name": name} for name in source.authors],
+        )
+    if not paper.abstract:
+        paper.abstract = source.abstract
+    if not paper.authors:
+        paper.authors = [{"name": name} for name in source.authors]
+    if not paper.published_at:
+        paper.published_at = source.published_at
+    if not paper.year and source.published_at:
+        paper.year = source.published_at.year
+    if not paper.url:
+        paper.url = f"https://arxiv.org/abs/{source.arxiv_id}"
+    if not paper.external_ids:
+        paper.external_ids = {"ArXiv": source.arxiv_id}
+    if not paper.tldr:
+        paper.tldr = extract_tldr(source.wiki_raw)
+
+
+def _imported_report_counts(markdown: str) -> dict[str, int]:
+    """从 auto-idea 报告标题/排除清单提取最稳定的候选、入库、排除数字。"""
+    counts = {
+        "source_fetched": 0,
+        "prescreened": 0,
+        "inserted": 0,
+        "kept": 0,
+        "excluded": 0,
+        "compiled": 0,
+    }
+    match = re.search(
+        r"排除清单[^\n]*?([0-9]+)\s*候选\s*[−-]\s*([0-9]+)\s*入库\s*=\s*([0-9]+)",
+        markdown,
+    )
+    if not match:
+        match = re.search(r"候选\s*([0-9]+).*?(?:→|->)\s*\+?([0-9]+)", markdown)
+        if match:
+            source, kept = (int(value) for value in match.groups())
+            excluded = max(0, source - kept)
+        else:
+            return counts
+    else:
+        source, kept, excluded = (int(value) for value in match.groups())
+    counts.update(
+        {
+            "source_fetched": source,
+            "prescreened": source,
+            "inserted": kept,
+            "kept": kept,
+            "excluded": excluded,
+            "compiled": kept,
+        }
+    )
+    return counts
+
+
+def _imported_report_summary(markdown: str, report_date: date) -> str:
+    body = strip_frontmatter(markdown)
+    match = re.search(r"^## 本期观察\s*\n(.+?)(?=\n##\s|\Z)", body, re.MULTILINE | re.DOTALL)
+    text = match.group(1) if match else body
+    text = re.sub(r"[#>*_`\[\]]", " ", text)
+    text = " ".join(text.split())
+    return text[:500] or f"从 Obsidian 导入的 {report_date.isoformat()} 每日简报"
+
+
+def _imported_report_papers(
+    markdown: str,
+    *,
+    snapshot: VaultSnapshot,
+    paper_ids_by_slug: dict[str, uuid.UUID],
+) -> list[dict[str, Any]]:
+    """提取日报引用论文，供前端把内部引用显示为论文标题并跳转库内详情。"""
+    insights: list[dict[str, Any]] = []
+    seen: set[uuid.UUID] = set()
+    for match in _PAPER_LINK_RE.finditer(markdown):
+        slug = match.group(1)
+        paper_id = paper_ids_by_slug.get(slug)
+        paper = snapshot.paper_by_slug.get(slug)
+        if paper_id is None or paper is None or paper_id in seen:
+            continue
+        seen.add(paper_id)
+        insights.append(
+            {
+                "paper_id": str(paper_id),
+                "title": match.group(2) or paper.title,
+                "tldr": extract_tldr(paper.wiki_raw) or paper.abstract,
+                "relevance_score": paper.relevance_score,
+                "status": "compiled" if paper.wiki_raw else "included",
+            }
+        )
+    return insights
+
+
+async def _sync_reports(
+    session: AsyncSession,
+    *,
+    snapshot: VaultSnapshot,
+    library: DirectionLibrary,
+    stats: SyncStats,
+    paper_ids_by_slug: dict[str, uuid.UUID],
+) -> None:
+    """幂等导入历史日报；最新日报附带 vault 当前滚动趋势快照。"""
+    if not snapshot.reports:
+        return
+    dates = [report.report_date for report in snapshot.reports]
+    existing = {
+        row.report_date: row
+        for row in (
+            (
+                await session.execute(
+                    select(LibraryResearchDigest).where(
+                        LibraryResearchDigest.library_id == library.id,
+                        LibraryResearchDigest.source == "obsidian",
+                        LibraryResearchDigest.report_date.in_(dates),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    }
+    latest_date = max(dates)
+    rendered_trends = (
+        render_markdown(
+            snapshot.trends_raw,
+            snapshot=snapshot,
+            paper_ids_by_slug=paper_ids_by_slug,
+        )
+        if snapshot.trends_raw
+        else ""
+    )
+    for report in snapshot.reports:
+        content = render_markdown(
+            report.wiki_raw,
+            snapshot=snapshot,
+            paper_ids_by_slug=paper_ids_by_slug,
+        )
+        counts = _imported_report_counts(content)
+        summary = _imported_report_summary(content, report.report_date)
+        paper_insights = _imported_report_papers(
+            report.wiki_raw,
+            snapshot=snapshot,
+            paper_ids_by_slug=paper_ids_by_slug,
+        )
+        trend_content = rendered_trends if report.report_date == latest_date else ""
+        row = existing.get(report.report_date)
+        if row is None:
+            session.add(
+                LibraryResearchDigest(
+                    library_id=library.id,
+                    voyage_id=None,
+                    report_date=report.report_date,
+                    source="obsidian",
+                    mode="import",
+                    counts=counts,
+                    source_diagnostics={
+                        "status": "imported",
+                        "messages": ["历史简报由 Obsidian vault 导入。"],
+                    },
+                    paper_insights=paper_insights,
+                    excluded_papers=[],
+                    cross_paper_signals=[],
+                    summary=summary,
+                    content=content,
+                    model="obsidian-vault-import",
+                    rolling_trends=[],
+                    trend_content=trend_content,
+                    trend_model="obsidian-vault-import" if trend_content else None,
+                )
+            )
+            stats.reports_created += 1
+            continue
+        changed = (
+            row.content != content
+            or row.counts != counts
+            or row.summary != summary
+            or row.paper_insights != paper_insights
+            or row.trend_content != trend_content
+        )
+        if changed:
+            row.counts = counts
+            row.summary = summary
+            row.content = content
+            row.paper_insights = paper_insights
+            row.trend_content = trend_content
+            row.trend_model = "obsidian-vault-import" if trend_content else None
+            stats.reports_updated += 1
+
+
+async def sync_obsidian_vault(
+    session: AsyncSession,
+    *,
+    vault_path: Path,
+    project_id: uuid.UUID,
+    library_name: str | None = None,
+    dry_run: bool = False,
+    overwrite_wiki: bool = False,
+    copy_files: bool = True,
+    index_chunks: bool = True,
+    batch_size: int = 25,
+) -> SyncStats:
+    """Synchronize a vault into one project-linked library and return an audit summary."""
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    snapshot = scan_vault(vault_path)
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise ValueError(f"project does not exist: {project_id}")
+    stats = SyncStats(
+        project_id=str(project.id),
+        scanned_papers=len(snapshot.papers),
+        missing_wikis=sum(paper.wiki_raw is None for paper in snapshot.papers),
+    )
+    library, library_created = await _resolve_library(
+        session,
+        project=project,
+        name=library_name or project.name,
+        statement=snapshot.statement or project.statement,
+        dry_run=dry_run,
+    )
+    stats.library_created = library_created
+    stats.library_id = str(library.id) if library else None
+
+    pool = await _paper_pool(session, snapshot)
+    stats.reused_papers = len(pool)
+    stats.new_papers = len(snapshot.papers) - len(pool)
+    concepts = await _sync_concepts(session, snapshot, stats, dry_run=dry_run)
+
+    existing_members: set[uuid.UUID] = set()
+    existing_wikis: set[uuid.UUID] = set()
+    existing_chunks: set[uuid.UUID] = set()
+    existing_associations: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    if pool:
+        paper_ids = [paper.id for paper in pool.values()]
+        existing_wikis = set(
+            (
+                await session.execute(
+                    select(PaperWiki.paper_id).where(PaperWiki.paper_id.in_(paper_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        existing_chunks = set(
+            (
+                await session.execute(
+                    select(PaperChunk.paper_id).where(PaperChunk.paper_id.in_(paper_ids)).distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if library is not None:
+            existing_members = set(
+                (
+                    await session.execute(
+                        select(LibraryPaper.paper_id).where(
+                            LibraryPaper.library_id == library.id,
+                            LibraryPaper.paper_id.in_(paper_ids),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        if concepts:
+            existing_associations = set(
+                (
+                    await session.execute(
+                        select(paper_concepts.c.paper_id, paper_concepts.c.concept_id).where(
+                            paper_concepts.c.paper_id.in_(paper_ids),
+                            paper_concepts.c.concept_id.in_(
+                                [concept.id for concept in concepts.values()]
+                            ),
+                        )
+                    )
+                ).tuples()
+            )
+
+    stats.memberships_created = len(snapshot.papers) - len(existing_members)
+    for source in snapshot.papers:
+        paper = pool.get(source.arxiv_id)
+        has_wiki = paper is not None and paper.id in existing_wikis
+        if source.wiki_raw:
+            if not has_wiki:
+                stats.wikis_created += 1
+            elif overwrite_wiki:
+                stats.wikis_overwritten += 1
+            else:
+                stats.wikis_preserved += 1
+        if copy_files:
+            if source.pdf_path and not (
+                paper and paper.pdf_path and Path(paper.pdf_path).is_file()
+            ):
+                stats.pdfs_copied += 1
+            if source.text_path and not (
+                paper and paper.full_text_path and Path(paper.full_text_path).is_file()
+            ):
+                stats.texts_copied += 1
+            if source.figure_path and not (
+                paper and _obsidian_figure_index(paper, source.slug) is not None
+            ):
+                stats.figures_copied += 1
+        if index_chunks and (paper is None or paper.id not in existing_chunks):
+            stats.papers_indexed += 1
+        if paper is None:
+            stats.concept_links_created += sum(slug in concepts for slug in source.concept_slugs)
+        else:
+            for slug in source.concept_slugs:
+                concept = concepts.get(slug)
+                if concept is not None and (paper.id, concept.id) not in existing_associations:
+                    stats.concept_links_created += 1
+    if dry_run:
+        stats.reports_created = len(snapshot.reports)
+        await session.rollback()
+        return stats
+
+    assert library is not None
+    # Recompute operation counters while applying; dry-run estimates above are replaced by facts.
+    stats.memberships_created = 0
+    stats.wikis_created = 0
+    stats.wikis_overwritten = 0
+    stats.wikis_preserved = 0
+    stats.pdfs_copied = 0
+    stats.texts_copied = 0
+    stats.figures_copied = 0
+    stats.concept_links_created = 0
+    stats.papers_indexed = 0
+
+    associated: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    concept_ids = [concept.id for concept in concepts.values()]
+    if pool and concept_ids:
+        associated = set(
+            (
+                await session.execute(
+                    select(paper_concepts.c.paper_id, paper_concepts.c.concept_id).where(
+                        paper_concepts.c.paper_id.in_([paper.id for paper in pool.values()]),
+                        paper_concepts.c.concept_id.in_(concept_ids),
+                    )
+                )
+            ).tuples()
+        )
+
+    for offset, source in enumerate(snapshot.papers, start=1):
+        paper = pool.get(source.arxiv_id)
+        if paper is None:
+            authors = [{"name": name} for name in source.authors]
+            paper = new_paper(
+                dedup_key=pool_dedup_key(
+                    arxiv_id=source.arxiv_id,
+                    doi=None,
+                    title=source.title,
+                    year=source.published_at.year if source.published_at else None,
+                    authors=authors,
+                ),
+                source="arxiv",
+                arxiv_id=source.arxiv_id,
+                external_ids={"ArXiv": source.arxiv_id},
+                title=source.title,
+                authors=authors,
+                abstract=source.abstract,
+                year=source.published_at.year if source.published_at else None,
+                url=f"https://arxiv.org/abs/{source.arxiv_id}",
+                published_at=source.published_at,
+                tldr=extract_tldr(source.wiki_raw),
+            )
+            session.add(paper)
+            await session.flush()
+            pool[source.arxiv_id] = paper
+        else:
+            _fill_missing_metadata(paper, source)
+
+        if paper.id not in existing_members:
+            session.add(
+                LibraryPaper(
+                    library_id=library.id,
+                    paper_id=paper.id,
+                    relevance_score=source.relevance_score,
+                    tldr_note=extract_tldr(source.wiki_raw),
+                    status="compiled" if source.wiki_raw else "included",
+                )
+            )
+            existing_members.add(paper.id)
+            stats.memberships_created += 1
+
+        if copy_files:
+            standard_pdf = papers_dir() / f"{paper.id}.pdf"
+            if source.pdf_path and not (paper.pdf_path and Path(paper.pdf_path).is_file()):
+                if _atomic_copy(source.pdf_path, standard_pdf):
+                    stats.pdfs_copied += 1
+                paper.pdf_path = str(standard_pdf)
+            standard_text = papers_dir() / f"{paper.id}.txt"
+            if source.text_path and not (
+                paper.full_text_path and Path(paper.full_text_path).is_file()
+            ):
+                if _atomic_copy(source.text_path, standard_text):
+                    stats.texts_copied += 1
+                paper.full_text_path = str(standard_text)
+
+        figure_index: int | None = None
+        if source.figure_path and copy_files:
+            current_figures = list(paper.figures or [])
+            figure_index = _obsidian_figure_index(paper, source.slug)
+            if figure_index is None:
+                figure_index = (
+                    max(
+                        (int(item.get("index", -1)) for item in current_figures),
+                        default=-1,
+                    )
+                    + 1
+                )
+            destination = figure_path(str(paper.id), figure_index)
+            if _atomic_copy(source.figure_path, destination):
+                meta = source.figure_meta or {}
+                if _obsidian_figure_index(paper, source.slug) is None:
+                    current_figures.append(
+                        {
+                            "index": figure_index,
+                            "page": meta.get("page"),
+                            "width": meta.get("w"),
+                            "height": meta.get("h"),
+                            "caption": meta.get("caption"),
+                            "kind": "architecture",
+                            "important": True,
+                            "source": "obsidian-vault",
+                            "vault_slug": source.slug,
+                        }
+                    )
+                    paper.figures = current_figures
+                stats.figures_copied += 1
+
+        wiki = (
+            await session.execute(select(PaperWiki).where(PaperWiki.paper_id == paper.id))
+        ).scalar_one_or_none()
+        if source.wiki_raw:
+            rendered = render_markdown(
+                source.wiki_raw,
+                snapshot=snapshot,
+                figure_index=figure_index,
+            )
+            if wiki is None:
+                session.add(
+                    PaperWiki(
+                        paper_id=paper.id,
+                        content=rendered,
+                        model="obsidian-vault-import",
+                        compiled_by=project.owner_id,
+                    )
+                )
+                stats.wikis_created += 1
+            elif overwrite_wiki:
+                wiki.content = rendered
+                wiki.model = "obsidian-vault-import"
+                wiki.compiled_by = project.owner_id
+                stats.wikis_overwritten += 1
+            else:
+                stats.wikis_preserved += 1
+
+        for slug in source.concept_slugs:
+            concept = concepts.get(slug)
+            if concept is None:
+                logger.warning("paper %s references unknown concept %s", source.slug, slug)
+                continue
+            key = (paper.id, concept.id)
+            if key not in associated:
+                await session.execute(
+                    paper_concepts.insert().values(paper_id=paper.id, concept_id=concept.id)
+                )
+                associated.add(key)
+                stats.concept_links_created += 1
+
+        if index_chunks and paper.id not in existing_chunks:
+            created = await ensure_paper_chunks(session, paper)
+            if created:
+                stats.papers_indexed += 1
+                stats.chunks_created += created
+                existing_chunks.add(paper.id)
+
+        if offset % batch_size == 0:
+            await session.commit()
+            logger.info("Obsidian sync progress: %s/%s", offset, len(snapshot.papers))
+
+    await _sync_reports(
+        session,
+        snapshot=snapshot,
+        library=library,
+        stats=stats,
+        paper_ids_by_slug={
+            source.slug: pool[source.arxiv_id].id
+            for source in snapshot.papers
+            if source.arxiv_id in pool
+        },
+    )
+    state = dict(library.ingest_state or {})
+    state["obsidian_sync"] = {
+        "source": snapshot.root.name,
+        "synced_at": utcnow().isoformat(),
+        "paper_count": len(snapshot.papers),
+    }
+    library.ingest_state = state
+    await session.commit()
+    return stats

--- a/src/backend/app/services/research_digest.py
+++ b/src/backend/app/services/research_digest.py
@@ -1,0 +1,844 @@
+"""文献库每日简报与滚动趋势的生成、持久化和读取。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import date
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.llm.base import Message
+from app.core.llm.router import LLMRouter
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.models.research_digest import LibraryResearchDigest
+from app.models.voyage import VoyageRun
+from app.services import concepts as concepts_service
+from app.services.libraries import library_definition
+
+PAPER_INSIGHTS_SYSTEM_PROMPT = """\
+POLARIS_DAILY_DIGEST
+POLARIS_DAILY_DIGEST_BATCH
+你是科研文献库的论文解读编辑。依据给出的研究方向、相关性判断、论文 TL;DR、解读摘录和
+已有概念，为本批每篇论文生成简洁、具体、可追溯的中文看点，并标注 2—4 个稳定、可复用的
+学术概念。概念应使用规范、简短且跨论文一致的中文名称，优先复用本批已有概念；不要把论文名、
+模型专名、作者名或完整句子当成概念，也不要输出 [[双链]]。不要补造输入中没有的实验数字或
+结论，也不要遗漏或合并论文。
+只输出一个 JSON 对象，不要输出 Markdown 代码块，格式：
+{"paper_insights":[
+  {"paper_id":"UUID", "highlight":"为什么值得看", "direction_relation":"与方向的具体关系",
+   "concepts":["学术概念一","学术概念二"]}
+]}
+paper_insights 必须逐一覆盖输入里的全部 paper_id，数量必须与输入论文数量一致。
+"""
+
+DIGEST_SYNTHESIS_SYSTEM_PROMPT = """\
+POLARIS_DAILY_DIGEST
+POLARIS_DAILY_DIGEST_SYNTHESIS
+你是科研文献库的每日简报主编。根据已经逐篇生成并校验完整的论文看点，综合本期总览与跨论文
+共同信号。不要重新输出逐篇看点，不要补造输入中没有的实验数字或结论。
+只输出一个 JSON 对象，不要输出 Markdown 代码块，格式：
+{"summary":"本期总览", "cross_paper_signals":[
+  {"title":"共同信号", "summary":"跨论文观察", "paper_ids":["UUID"]}
+]}
+没有可靠共同信号时 cross_paper_signals 返回空数组；信号中的 paper_ids 只能取输入已有 UUID。
+"""
+
+_DIGEST_BATCH_SIZE = 10
+_DIGEST_MAX_ATTEMPTS = 3
+_DIGEST_RETRY_DELAY_SECONDS = 0.25
+
+TREND_SYSTEM_PROMPT = """\
+POLARIS_TREND_SYNTHESIS
+你维护一个研究方向的滚动趋势。根据此前趋势和最近每日简报，更新趋势线程；不要只追加日报，
+要合并同一主线、说明证据如何变化，并保留支撑论文 id。只输出一个 JSON 对象，不要输出
+Markdown 代码块，格式：
+{"trends":[{"title":"趋势名", "status":"emerging|active|converging|stale",
+"summary":"当前判断", "evidence_trajectory":"证据如何演进", "concepts":["概念"],
+"paper_ids":["UUID"], "last_seen":"YYYY-MM-DD"}]}
+最多 12 条；没有可靠趋势时返回 {"trends":[]}。
+"""
+
+
+def _extract_json_object(content: str) -> dict[str, Any]:
+    start = content.find("{")
+    end = content.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("digest model returned no JSON object")
+    value = json.loads(content[start : end + 1])
+    if not isinstance(value, dict):
+        raise ValueError("digest model returned a non-object JSON value")
+    return value
+
+
+def _string(value: Any, fallback: str = "") -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _generated_concepts(value: Any, existing: list[Any] | None = None) -> list[str]:
+    """合并已有正式概念与模型标注，保序去重；最终可见性由概念服务统一裁决。"""
+    values = [*(existing or []), *(value if isinstance(value, list) else [])]
+    names: dict[str, None] = {}
+    for raw in values:
+        name = " ".join(str(raw or "").strip().split())
+        if name.startswith("[[") and name.endswith("]]"):
+            name = name[2:-2].strip()
+        name = name.split("|", 1)[0].split("#", 1)[0].strip()
+        if not name or len(name) > 255:
+            continue
+        names.setdefault(name, None)
+        if len(names) >= 6:
+            break
+    return list(names)
+
+
+async def _retry_pause(attempt: int) -> None:
+    """简短指数退避；attempt 从 1 开始，测试和人工触发都不会产生长时间空等。"""
+    await asyncio.sleep(_DIGEST_RETRY_DELAY_SECONDS * (2 ** (attempt - 1)))
+
+
+async def _generate_insight_batch(
+    *,
+    llm: LLMRouter,
+    run: VoyageRun,
+    library: DirectionLibrary,
+    direction: dict[str, Any],
+    papers: list[dict[str, Any]],
+    batch_index: int,
+    batch_total: int,
+    preferred_concepts: list[str],
+    user_id: uuid.UUID | None,
+    extra_guidance: str,
+) -> tuple[dict[str, dict[str, Any]], str | None, int]:
+    """生成一批逐篇看点；模型漏项时只把缺失论文送回去补跑，最多三轮。"""
+    expected = {item["paper_id"]: item for item in papers}
+    pending = list(papers)
+    collected: dict[str, dict[str, Any]] = {}
+    model: str | None = None
+    retries = 0
+    last_error: Exception | None = None
+
+    for attempt in range(1, _DIGEST_MAX_ATTEMPTS + 1):
+        retry_note = (
+            "\n这是自动补跑，只需覆盖以下仍缺失的论文；必须逐一返回全部 paper_id。"
+            if attempt > 1
+            else ""
+        )
+        prompt = (
+            f"研究方向：{json.dumps(direction, ensure_ascii=False)}\n"
+            f"优先复用的规范概念词表：{json.dumps(preferred_concepts, ensure_ascii=False)}\n"
+            f"批次：{batch_index}/{batch_total}\n"
+            f"本批论文：{json.dumps(pending, ensure_ascii=False)}"
+            f"{retry_note}"
+        )
+        try:
+            result = await llm.complete(
+                "librarian",
+                [
+                    Message(
+                        role="system",
+                        content=PAPER_INSIGHTS_SYSTEM_PROMPT + extra_guidance,
+                    ),
+                    Message(role="user", content=prompt),
+                ],
+                user_id=user_id,
+                project_id=run.project_id,
+                library_id=library.id,
+                voyage_id=run.id,
+            )
+            generated = _extract_json_object(result.content)
+            raw_insights = generated.get("paper_insights")
+            if not isinstance(raw_insights, list):
+                raise ValueError("daily digest batch JSON misses paper_insights")
+            model = result.model or model
+            for item in raw_insights:
+                if not isinstance(item, dict):
+                    continue
+                paper_id = str(item.get("paper_id") or "")
+                concepts = _generated_concepts(
+                    item.get("concepts"), expected.get(paper_id, {}).get("concepts")
+                )
+                # 概念是简报必填项；缺失时把该论文留在 pending，下一轮只补跑这一篇。
+                if paper_id in expected and concepts:
+                    collected[paper_id] = item
+            pending = [item for item in papers if item["paper_id"] not in collected]
+            if not pending:
+                return collected, model, retries
+            last_error = ValueError(
+                f"daily digest batch {batch_index}/{batch_total} omitted {len(pending)} papers"
+            )
+        except Exception as error:
+            last_error = error
+
+        if attempt < _DIGEST_MAX_ATTEMPTS:
+            retries += 1
+            await _retry_pause(attempt)
+
+    missing_ids = [item["paper_id"] for item in pending]
+    detail = f"; missing={','.join(missing_ids)}" if missing_ids else ""
+    raise ValueError(
+        f"daily digest batch {batch_index}/{batch_total} failed after "
+        f"{_DIGEST_MAX_ATTEMPTS} attempts: {last_error}{detail}"
+    )
+
+
+async def _generate_paper_insights(
+    *,
+    llm: LLMRouter,
+    run: VoyageRun,
+    library: DirectionLibrary,
+    papers: list[dict[str, Any]],
+    user_id: uuid.UUID | None,
+    extra_guidance: str,
+) -> tuple[list[dict[str, Any]], str | None, int, int]:
+    """按固定小批次生成看点，并保持最终顺序与输入论文一致。"""
+    direction = library_definition(library)
+    batches = [
+        papers[index : index + _DIGEST_BATCH_SIZE]
+        for index in range(0, len(papers), _DIGEST_BATCH_SIZE)
+    ]
+    by_id: dict[str, dict[str, Any]] = {}
+    preferred_concepts = _generated_concepts(
+        [], [concept for paper in papers for concept in (paper.get("concepts") or [])]
+    )
+    model: str | None = None
+    retries = 0
+    for index, batch in enumerate(batches, start=1):
+        generated, batch_model, batch_retries = await _generate_insight_batch(
+            llm=llm,
+            run=run,
+            library=library,
+            direction=direction,
+            papers=batch,
+            batch_index=index,
+            batch_total=len(batches),
+            preferred_concepts=preferred_concepts,
+            user_id=user_id,
+            extra_guidance=extra_guidance,
+        )
+        by_id.update(generated)
+        preferred_concepts = _generated_concepts(
+            [concept for item in generated.values() for concept in (item.get("concepts") or [])],
+            preferred_concepts,
+        )
+        model = batch_model or model
+        retries += batch_retries
+
+    insights = [
+        item
+        | {
+            "highlight": _string(by_id[item["paper_id"]].get("highlight"), item["tldr"]),
+            "direction_relation": _string(
+                by_id[item["paper_id"]].get("direction_relation"),
+                item.get("relevance_reason") or "与本库研究方向相关。",
+            ),
+            "concepts": _generated_concepts(
+                by_id[item["paper_id"]].get("concepts"), item.get("concepts")
+            ),
+        }
+        for item in papers
+    ]
+    return insights, model, retries, len(batches)
+
+
+async def _synthesize_digest_summary(
+    *,
+    llm: LLMRouter,
+    run: VoyageRun,
+    library: DirectionLibrary,
+    paper_insights: list[dict[str, Any]],
+    user_id: uuid.UUID | None,
+    extra_guidance: str,
+) -> tuple[str, list[dict[str, Any]], str | None, int]:
+    """在逐篇结果完整后综合总览/共同信号；格式错误或临时异常自动重试。"""
+    compact_insights = [
+        {
+            "paper_id": item["paper_id"],
+            "title": item["title"],
+            "tldr": _string(item.get("tldr"))[:400],
+            "highlight": item["highlight"],
+            "direction_relation": item["direction_relation"],
+            "concepts": item.get("concepts") or [],
+        }
+        for item in paper_insights
+    ]
+    valid_ids = {item["paper_id"] for item in paper_insights}
+    last_error: Exception | None = None
+    for attempt in range(1, _DIGEST_MAX_ATTEMPTS + 1):
+        prompt = (
+            "研究方向："
+            + json.dumps(library_definition(library), ensure_ascii=False)
+            + "\n已校验完整的逐篇看点："
+            + json.dumps(compact_insights, ensure_ascii=False)
+        )
+        if attempt > 1:
+            prompt += "\n上次综合输出无效，请严格按 JSON schema 重新生成。"
+        try:
+            result = await llm.complete(
+                "librarian",
+                [
+                    Message(
+                        role="system",
+                        content=DIGEST_SYNTHESIS_SYSTEM_PROMPT + extra_guidance,
+                    ),
+                    Message(role="user", content=prompt),
+                ],
+                user_id=user_id,
+                project_id=run.project_id,
+                library_id=library.id,
+                voyage_id=run.id,
+            )
+            generated = _extract_json_object(result.content)
+            if not isinstance(generated.get("cross_paper_signals"), list):
+                raise ValueError("daily digest synthesis JSON misses cross_paper_signals")
+            summary = _string(generated.get("summary"))
+            if not summary:
+                raise ValueError("daily digest synthesis JSON misses summary")
+            signals = [
+                {
+                    "title": _string(item.get("title"), "共同信号"),
+                    "summary": _string(item.get("summary")),
+                    "paper_ids": [
+                        str(paper_id)
+                        for paper_id in (item.get("paper_ids") or [])
+                        if str(paper_id) in valid_ids
+                    ],
+                }
+                for item in generated["cross_paper_signals"]
+                if isinstance(item, dict) and _string(item.get("summary"))
+            ]
+            return summary, signals, result.model or None, attempt - 1
+        except Exception as error:
+            last_error = error
+            if attempt < _DIGEST_MAX_ATTEMPTS:
+                await _retry_pause(attempt)
+
+    raise ValueError(
+        f"daily digest synthesis failed after {_DIGEST_MAX_ATTEMPTS} attempts: {last_error}"
+    )
+
+
+def _search_counts(checkpoint: dict[str, Any]) -> tuple[dict[str, int], dict[str, Any]]:
+    stats = checkpoint.get("ingest_search_stats")
+    diagnostics = dict(stats) if isinstance(stats, dict) else {}
+    override = checkpoint.get("digest_counts")
+    if isinstance(override, dict):
+        return (
+            {
+                key: int(override.get(key) or 0)
+                for key in (
+                    "source_fetched",
+                    "prescreened",
+                    "inserted",
+                    "kept",
+                    "excluded",
+                    "compiled",
+                )
+            },
+            diagnostics,
+        )
+    query_found = int(diagnostics.get("query_found") or diagnostics.get("found") or 0)
+    rss_found = int(diagnostics.get("rss_found") or 0)
+    rss_matched = int(diagnostics.get("rss_matched") or 0)
+    source_fetched = int(diagnostics.get("source_fetched") or query_found + rss_found)
+    prescreened = int(diagnostics.get("prescreened") or query_found + rss_matched)
+    counts = {
+        "source_fetched": source_fetched,
+        # API 主查询已经服务端关键词筛过；RSS 是分类全量后本地预筛。
+        "prescreened": prescreened,
+        "inserted": int(diagnostics.get("inserted") or 0)
+        + int(checkpoint.get("ingest_snowball_inserted") or 0),
+        "kept": 0,
+        "excluded": 0,
+        "compiled": int(checkpoint.get("compiled_count") or 0),
+    }
+    return counts, diagnostics
+
+
+async def _run_members(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    run: VoyageRun,
+    checkpoint: dict[str, Any],
+) -> list[tuple[Paper, LibraryPaper]]:
+    """取本次 run 实际完成过相关性评分的成员；逐篇 commit/断点恢复也不会漏。"""
+    raw_ids = checkpoint.get("digest_paper_ids")
+    paper_ids: list[uuid.UUID] = []
+    if isinstance(raw_ids, list):
+        for value in raw_ids:
+            try:
+                paper_ids.append(uuid.UUID(str(value)))
+            except (TypeError, ValueError):
+                continue
+    member_window = (
+        (LibraryPaper.paper_id.in_(paper_ids),)
+        if paper_ids
+        else (
+            LibraryPaper.scored_at.is_not(None),
+            LibraryPaper.scored_at >= run.created_at,
+        )
+    )
+    return list(
+        (
+            await session.execute(
+                select(Paper, LibraryPaper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .options(selectinload(Paper.concepts), selectinload(Paper.wiki))
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    *member_window,
+                )
+                .order_by(LibraryPaper.relevance_score.desc().nulls_last(), Paper.title)
+            )
+        ).all()
+    )
+
+
+def _paper_payload(paper: Paper, membership: LibraryPaper) -> dict[str, Any]:
+    concepts = [concept.name for concept in paper.concepts]
+    wiki_excerpt = (paper.wiki_content or "").strip().replace("\x00", "")[:900]
+    return {
+        "paper_id": str(paper.id),
+        "title": paper.title,
+        "published_at": paper.published_at.isoformat() if paper.published_at else None,
+        "year": paper.year,
+        "relevance_score": membership.relevance_score,
+        "relevance_reason": membership.relevance_reason,
+        "tldr": paper.tldr or membership.tldr_note or paper.abstract or "暂无摘要",
+        "concepts": concepts,
+        "wiki_excerpt": wiki_excerpt,
+        "status": membership.status,
+    }
+
+
+def _render_digest_markdown(
+    *,
+    report_date: date,
+    summary: str,
+    counts: dict[str, int],
+    diagnostics: dict[str, Any],
+    papers: list[dict[str, Any]],
+    signals: list[dict[str, Any]],
+    excluded: list[dict[str, Any]],
+) -> str:
+    lines = [
+        f"# 每日文献简报 · {report_date.isoformat()}",
+        "",
+        summary,
+        "",
+        "## 本次概况",
+        "",
+        f"- 来源抓取：{counts['source_fetched']} 篇；预筛后：{counts['prescreened']} 篇",
+        f"- 新候选：{counts['inserted']} 篇；保留：{counts['kept']} 篇；"
+        f"排除：{counts['excluded']} 篇",
+        f"- 完成解读：{counts['compiled']} 篇",
+    ]
+    latest = diagnostics.get("source_latest_at")
+    if latest:
+        lines.append(f"- 数据源最新公告：{latest}")
+    generation = diagnostics.get("digest_generation")
+    if isinstance(generation, dict):
+        lines.append(
+            f"- 简报生成：{int(generation.get('batches') or 0)} 批；"
+            f"自动重试：{int(generation.get('retries') or 0)} 次"
+        )
+        lines.append(
+            f"- 概念关联：{int(generation.get('active_concepts') or 0)} 个正式概念；"
+            f"新增 {int(generation.get('links_created') or 0)} 条论文关系"
+        )
+    messages = diagnostics.get("messages") if isinstance(diagnostics.get("messages"), list) else []
+    if messages:
+        lines.extend(["", "### 来源诊断", ""] + [f"- {message}" for message in messages])
+
+    lines.extend(["", "## 本期论文", ""])
+    if not papers:
+        lines.append("本次没有通过相关性阈值的新论文。")
+    for item in papers:
+        score = item.get("relevance_score")
+        score_label = f" · 相关度 {float(score):.2f}" if score is not None else ""
+        published_label = _string(item.get("published_at"))[:10]
+        if not published_label and item.get("year"):
+            published_label = str(item["year"])
+        published_label = published_label or "未知"
+        lines.extend(
+            [
+                f"### [[paper:{item['paper_id']}|{item['title']}]]{score_label}",
+                "",
+                f"- **发表时间**：{published_label}",
+                f"- **TL;DR**：{item['tldr']}",
+                f"- **看点**：{item['highlight']}",
+                f"- **与方向关系**：{item['direction_relation']}",
+            ]
+        )
+        concepts = item.get("concepts") or []
+        if concepts:
+            lines.append("- **概念**：" + " · ".join(f"[[{name}]]" for name in concepts))
+        else:
+            lines.append("- **概念**：尚无达到复用门槛的正式概念")
+        lines.append("")
+
+    lines.extend(["## 跨论文观察", ""])
+    if signals:
+        for index, signal in enumerate(signals, start=1):
+            lines.append(f"{index}. **{signal['title']}**：{signal['summary']}")
+    else:
+        lines.append("本次尚未形成可靠的跨论文共同信号。")
+
+    lines.extend(["", f"## 排除清单（{len(excluded)} 篇）", ""])
+    if excluded:
+        for item in excluded:
+            score = item.get("relevance_score")
+            score_label = f"{float(score):.2f}" if score is not None else "未评分"
+            lines.append(f"- `{score_label}` · {item['title']} — {item['reason']}")
+    else:
+        lines.append("本次没有因相关性不足而排除的论文。")
+    return "\n".join(lines).strip() + "\n"
+
+
+async def create_daily_digest(
+    session: AsyncSession,
+    *,
+    run: VoyageRun,
+    library: DirectionLibrary,
+    checkpoint: dict[str, Any],
+    llm: LLMRouter,
+    user_id: uuid.UUID | None,
+    extra_guidance: str = "",
+) -> LibraryResearchDigest:
+    """生成并持久化本次简报；模型产出无效会抛错，让 Voyage 停在水位线之前。"""
+    existing = (
+        await session.execute(
+            select(LibraryResearchDigest).where(LibraryResearchDigest.voyage_id == run.id)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    pairs = await _run_members(session, library_id=library.id, run=run, checkpoint=checkpoint)
+    kept_pairs = [(p, m) for p, m in pairs if m.status != "excluded"]
+    excluded_pairs = [(p, m) for p, m in pairs if m.status == "excluded"]
+    counts, diagnostics = _search_counts(checkpoint)
+    counts["kept"] = len(kept_pairs)
+    checkpoint_excluded = [
+        item
+        for item in (checkpoint.get("digest_excluded_papers") or [])
+        if isinstance(item, dict) and item.get("paper_id")
+    ]
+    counts["excluded"] = len(excluded_pairs) + len(checkpoint_excluded)
+
+    base_papers = [_paper_payload(paper, membership) for paper, membership in kept_pairs]
+    excluded = [
+        {
+            "paper_id": str(paper.id),
+            "title": paper.title,
+            "relevance_score": membership.relevance_score,
+            "reason": membership.relevance_reason
+            or f"相关度低于本次阈值（{membership.relevance_score or 0:.2f}）",
+        }
+        for paper, membership in excluded_pairs
+    ] + checkpoint_excluded
+
+    model: str | None = None
+    if base_papers:
+        (
+            paper_insights,
+            insight_model,
+            insight_retries,
+            batch_count,
+        ) = await _generate_paper_insights(
+            llm=llm,
+            run=run,
+            library=library,
+            papers=base_papers,
+            user_id=user_id,
+            extra_guidance=extra_guidance,
+        )
+        active_concepts, concept_stats = await concepts_service.link_generated_paper_concepts(
+            session,
+            concepts_by_paper={
+                item["paper_id"]: item.get("concepts") or [] for item in paper_insights
+            },
+            llm=llm,
+            user_id=user_id,
+            project_id=run.project_id,
+            library_id=library.id,
+            voyage_id=run.id,
+        )
+        paper_insights = [
+            item | {"concepts": active_concepts.get(item["paper_id"], [])}
+            for item in paper_insights
+        ]
+        summary, signals, synthesis_model, synthesis_retries = await _synthesize_digest_summary(
+            llm=llm,
+            run=run,
+            library=library,
+            paper_insights=paper_insights,
+            user_id=user_id,
+            extra_guidance=extra_guidance,
+        )
+        diagnostics["digest_generation"] = {
+            "batch_size": _DIGEST_BATCH_SIZE,
+            "batches": batch_count,
+            "retries": insight_retries + synthesis_retries,
+            **concept_stats,
+        }
+        model = synthesis_model or insight_model
+    else:
+        paper_insights = []
+        signals = []
+        summary = "本次没有通过相关性阈值的新论文；已保留来源诊断供复查。"
+
+    report_date = run.created_at.date()
+    content = _render_digest_markdown(
+        report_date=report_date,
+        summary=summary,
+        counts=counts,
+        diagnostics=diagnostics,
+        papers=paper_insights,
+        signals=signals,
+        excluded=excluded,
+    )
+    # 同一天重复手动同步时更新当天原生简报，而不是制造多个“每日”条目。
+    digest = (
+        await session.execute(
+            select(LibraryResearchDigest).where(
+                LibraryResearchDigest.library_id == library.id,
+                LibraryResearchDigest.report_date == report_date,
+                LibraryResearchDigest.source == "voyage",
+            )
+        )
+    ).scalar_one_or_none()
+    if digest is None:
+        digest = LibraryResearchDigest(
+            library_id=library.id,
+            voyage_id=run.id,
+            report_date=report_date,
+            source="voyage",
+            mode="bootstrap" if run.kind == "wiki_bootstrap" else "incremental",
+            counts=counts,
+            source_diagnostics=diagnostics,
+            paper_insights=paper_insights,
+            excluded_papers=excluded,
+            cross_paper_signals=signals,
+            summary=summary,
+            content=content,
+            model=model,
+            rolling_trends=[],
+            trend_content="",
+            trend_model=None,
+        )
+        session.add(digest)
+    else:
+        digest.voyage_id = run.id
+        digest.mode = "bootstrap" if run.kind == "wiki_bootstrap" else "incremental"
+        digest.counts = counts
+        digest.source_diagnostics = diagnostics
+        digest.paper_insights = paper_insights
+        digest.excluded_papers = excluded
+        digest.cross_paper_signals = signals
+        digest.summary = summary
+        digest.content = content
+        digest.model = model
+        # 新一次同步必须重新综合趋势；不能把旧快照误当成本次已完成。
+        digest.rolling_trends = []
+        digest.trend_content = ""
+        digest.trend_model = None
+    await session.commit()
+    await session.refresh(digest)
+    return digest
+
+
+def _render_trends_markdown(trends: list[dict[str, Any]], report_date: date) -> str:
+    lines = [f"# 滚动趋势 · 更新至 {report_date.isoformat()}", ""]
+    if not trends:
+        lines.append("目前尚未形成有足够证据支撑的趋势主线。")
+        return "\n".join(lines) + "\n"
+    status_labels = {
+        "emerging": "新兴",
+        "active": "活跃",
+        "converging": "收敛中",
+        "stale": "暂时沉寂",
+    }
+    for trend in trends:
+        status = status_labels.get(str(trend.get("status")), str(trend.get("status") or "活跃"))
+        lines.extend(
+            [
+                f"## {trend['title']} · {status}",
+                "",
+                trend["summary"],
+                "",
+                f"**证据轨迹**：{trend['evidence_trajectory']}",
+            ]
+        )
+        concepts = trend.get("concepts") or []
+        if concepts:
+            lines.append("\n**相关概念**：" + " · ".join(f"[[{name}]]" for name in concepts))
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+async def synthesize_rolling_trends(
+    session: AsyncSession,
+    *,
+    run: VoyageRun,
+    library: DirectionLibrary,
+    llm: LLMRouter,
+    user_id: uuid.UUID | None,
+    extra_guidance: str = "",
+) -> LibraryResearchDigest:
+    digest = (
+        await session.execute(
+            select(LibraryResearchDigest).where(LibraryResearchDigest.voyage_id == run.id)
+        )
+    ).scalar_one_or_none()
+    if digest is None:
+        raise ValueError("daily digest is missing; refusing to synthesize trends")
+    if digest.trend_model is not None:
+        return digest
+
+    previous = list(
+        (
+            await session.execute(
+                select(LibraryResearchDigest)
+                .where(
+                    LibraryResearchDigest.library_id == library.id,
+                    LibraryResearchDigest.id != digest.id,
+                )
+                .order_by(
+                    LibraryResearchDigest.report_date.desc(),
+                    LibraryResearchDigest.created_at.desc(),
+                )
+                .limit(8)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not digest.paper_insights:
+        prior = previous[0] if previous else None
+        digest.rolling_trends = list(prior.rolling_trends or []) if prior else []
+        digest.trend_content = (
+            prior.trend_content
+            if prior and prior.trend_content
+            else _render_trends_markdown([], digest.report_date)
+        )
+        digest.trend_model = "carried-forward"
+        await session.commit()
+        return digest
+
+    history = [
+        {
+            "date": item.report_date.isoformat(),
+            "summary": item.summary,
+            "signals": item.cross_paper_signals,
+        }
+        for item in reversed(previous)
+    ]
+    payload = {
+        "research_direction": library_definition(library),
+        "previous_trends": previous[0].rolling_trends if previous else [],
+        "recent_reports": history
+        + [
+            {
+                "date": digest.report_date.isoformat(),
+                "summary": digest.summary,
+                "signals": digest.cross_paper_signals,
+                "papers": digest.paper_insights,
+            }
+        ],
+    }
+    result = await llm.complete(
+        "librarian",
+        [
+            Message(role="system", content=TREND_SYSTEM_PROMPT + extra_guidance),
+            Message(role="user", content=json.dumps(payload, ensure_ascii=False)),
+        ],
+        user_id=user_id,
+        project_id=run.project_id,
+        library_id=library.id,
+        voyage_id=run.id,
+    )
+    generated = _extract_json_object(result.content)
+    if not isinstance(generated.get("trends"), list):
+        raise ValueError("trend synthesis JSON misses trends")
+    allowed_status = {"emerging", "active", "converging", "stale"}
+    trends: list[dict[str, Any]] = []
+    for item in generated["trends"][:12]:
+        if not isinstance(item, dict):
+            continue
+        title = _string(item.get("title"))
+        summary = _string(item.get("summary"))
+        trajectory = _string(item.get("evidence_trajectory"))
+        if not (title and summary and trajectory):
+            continue
+        status = str(item.get("status") or "active")
+        trends.append(
+            {
+                "title": title,
+                "status": status if status in allowed_status else "active",
+                "summary": summary,
+                "evidence_trajectory": trajectory,
+                "concepts": [str(name) for name in (item.get("concepts") or [])],
+                "paper_ids": [str(pid) for pid in (item.get("paper_ids") or [])],
+                "last_seen": _string(item.get("last_seen"), digest.report_date.isoformat()),
+            }
+        )
+    digest.rolling_trends = trends
+    digest.trend_content = _render_trends_markdown(trends, digest.report_date)
+    digest.trend_model = result.model or "unknown"
+    await session.commit()
+    return digest
+
+
+async def list_digest_summaries(
+    session: AsyncSession, *, library_id: uuid.UUID, limit: int
+) -> list[dict[str, Any]]:
+    rows = list(
+        (
+            await session.execute(
+                select(LibraryResearchDigest)
+                .where(LibraryResearchDigest.library_id == library_id)
+                .order_by(
+                    LibraryResearchDigest.report_date.desc(),
+                    LibraryResearchDigest.created_at.desc(),
+                )
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        {
+            "id": row.id,
+            "report_date": row.report_date,
+            "source": row.source,
+            "mode": row.mode,
+            "counts": row.counts,
+            "summary": row.summary,
+            "voyage_id": row.voyage_id,
+            "has_trends": bool(row.trend_content or row.rolling_trends),
+            "created_at": row.created_at,
+        }
+        for row in rows
+    ]
+
+
+async def get_digest(
+    session: AsyncSession, *, library_id: uuid.UUID, digest_id: uuid.UUID
+) -> LibraryResearchDigest | None:
+    return (
+        await session.execute(
+            select(LibraryResearchDigest).where(
+                LibraryResearchDigest.id == digest_id,
+                LibraryResearchDigest.library_id == library_id,
+            )
+        )
+    ).scalar_one_or_none()

--- a/src/backend/tests/test_concept_promotion.py
+++ b/src/backend/tests/test_concept_promotion.py
@@ -15,7 +15,11 @@ from alembic import command
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.paper import Concept, Paper, PaperWiki
-from app.services.concepts import extract_wikilinks, link_paper_concepts
+from app.services.concepts import (
+    extract_wikilinks,
+    link_generated_paper_concepts,
+    link_paper_concepts,
+)
 
 from .conftest import add_paper, membership_of, register_and_login
 
@@ -70,9 +74,7 @@ async def _link(project_id: str, paper_id: uuid.UUID) -> tuple[int, int]:
 
 async def _concept(name: str) -> Concept:
     async with get_sessionmaker()() as session:
-        return (
-            await session.execute(select(Concept).where(Concept.name == name))
-        ).scalar_one()
+        return (await session.execute(select(Concept).where(Concept.name == name))).scalar_one()
 
 
 async def test_first_reference_stays_candidate_and_invisible(client):
@@ -130,6 +132,39 @@ async def test_second_reference_promotes_and_defines(client):
     assert (await _concept("本文自造Bench")).status == "candidate"
 
 
+async def test_daily_digest_concepts_link_and_promote_shared_names(client):
+    """尚未精读的今日论文也能通过简报标注概念；只展示达到复用门槛的正式概念。"""
+    project_id, _headers, ids = await _seed(
+        client,
+        {
+            "Paper A": "尚未包含概念双链。",
+            "Paper B": "同样尚未包含概念双链。",
+        },
+    )
+    async with get_sessionmaker()() as session:
+        active_by_paper, stats = await link_generated_paper_concepts(
+            session,
+            concepts_by_paper={
+                ids["Paper A"]: ["Agent 工作流", "A 专属方法"],
+                ids["Paper B"]: ["Agent 工作流", "B 专属方法"],
+            },
+            llm=LLMRouter(),
+            project_id=uuid.UUID(project_id),
+        )
+
+    assert active_by_paper[str(ids["Paper A"])] == ["Agent 工作流"]
+    assert active_by_paper[str(ids["Paper B"])] == ["Agent 工作流"]
+    assert stats == {
+        "concepts_created": 3,
+        "links_created": 4,
+        "concepts_promoted": 1,
+        "concepts_rejected": 0,
+        "active_concepts": 1,
+    }
+    assert (await _concept("Agent 工作流")).status == "active"
+    assert (await _concept("A 专属方法")).status == "candidate"
+
+
 async def test_junk_name_is_rejected_at_promotion(client):
     """够门槛也进不来：模型判定不是概念的（漏感叹号的 fig:3）落 rejected 终态。
 
@@ -173,9 +208,7 @@ async def test_promotion_survives_recompile_of_one_paper(client):
 
     async with get_sessionmaker()() as session:
         wiki = (
-            await session.execute(
-                select(PaperWiki).where(PaperWiki.paper_id == ids["Paper A"])
-            )
+            await session.execute(select(PaperWiki).where(PaperWiki.paper_id == ids["Paper A"]))
         ).scalar_one()
         wiki.content = "改写后不再提它。"
         await session.commit()
@@ -216,9 +249,10 @@ async def test_sweep_reviews_never_validated_legacy_concepts(client):
     assert (await _concept("fig:1")).status == "rejected"
     real = await _concept("真概念")
     assert real.status == "active" and real.validated_at is not None  # 判过就不再复判
-    names = {c["name"] for c in (await client.get(
-        f"/api/projects/{project_id}/concepts", headers=headers
-    )).json()}
+    names = {
+        c["name"]
+        for c in (await client.get(f"/api/projects/{project_id}/concepts", headers=headers)).json()
+    }
     assert "fig:1" not in names and "真概念" in names
 
 
@@ -288,10 +322,7 @@ def _seed_concepts(db_path: Path) -> dict[str, uuid.UUID]:
             for concept, papers in links.items():
                 for paper in papers:
                     conn.execute(
-                        text(
-                            "INSERT INTO paper_concepts (paper_id, concept_id)"
-                            " VALUES (:p, :c)"
-                        ),
+                        text("INSERT INTO paper_concepts (paper_id, concept_id) VALUES (:p, :c)"),
                         {"p": ids[paper].hex, "c": ids[concept].hex},
                     )
     finally:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
+HEAD_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
+INLINE_VECTOR_DROP_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
 VECTOR_TABLES_REVISION = "5d8ebd5cb100"  # 向量侧表建表 + 存量搬迁
 EFFORT_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
 CHAT_BOT_REVISION = "d4e8b71c2a90"  # 每用户群机器人 Webhook 配置
@@ -86,6 +87,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "direction_libraries",
                     "projects",
                     "chat_bot_configs",
+                    "library_research_digests",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -312,8 +314,29 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "secret_encrypted",
         "last_delivered_at",
     } <= columns["chat_bot_configs"]
+    # 文献库每日简报：结构化统计/论文观察/趋势快照 + 收录或排除理由。
+    assert "library_research_digests" in columns["_tables"]
+    assert {
+        "library_id",
+        "voyage_id",
+        "report_date",
+        "counts",
+        "paper_insights",
+        "excluded_papers",
+        "cross_paper_signals",
+        "rolling_trends",
+        "trend_content",
+    } <= columns["library_research_digests"]
+    assert "relevance_reason" in columns["library_papers"]
 
-    # 最新 revision 可往返：先把主表向量列加回来（数据不搬回，见迁移 docstring）。
+    # 最新 revision 可往返：先退掉每日简报表与相关性理由。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == INLINE_VECTOR_DROP_REVISION
+    assert "library_research_digests" not in columns["_tables"]
+    assert "relevance_reason" not in columns["library_papers"]
+
+    # 再把主表向量列加回来（数据不搬回，见迁移 docstring）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == VECTOR_TABLES_REVISION

--- a/src/backend/tests/test_obsidian_vault_sync.py
+++ b/src/backend/tests/test_obsidian_vault_sync.py
@@ -1,0 +1,205 @@
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper, TopicSourceLibrary
+from app.models.paper import Concept, Paper, PaperChunk, PaperWiki, paper_concepts
+from app.models.project import Project
+from app.models.research_digest import LibraryResearchDigest
+from app.models.user import User
+from app.services.obsidian_vault_sync import render_markdown, scan_vault, sync_obsidian_vault
+
+
+def _make_vault(root: Path) -> Path:
+    for relative in (
+        "raw/meta",
+        "raw/paper",
+        "raw/text",
+        "raw/figures",
+        "wiki/papers",
+        "wiki/surveys",
+        "wiki/concepts",
+        "report",
+    ):
+        (root / relative).mkdir(parents=True)
+    (root / "research_direction.md").write_text(
+        "# Direction\n\n## 一句话\n研究 agent harness。\n\n## 范围\n测试。\n",
+        encoding="utf-8",
+    )
+    meta = {
+        "arxiv_id": "2501.01234v2",
+        "title": "Harness Paper",
+        "abstract": "An abstract",
+        "authors": ["Ada Lovelace"],
+        "categories": ["cs.AI"],
+        "published": "2025-01-02",
+        "relevance_score": 0.9,
+        "slug": "harness-paper",
+    }
+    (root / "raw/meta/harness-paper.json").write_text(json.dumps(meta), encoding="utf-8")
+    (root / "raw/paper/harness-paper.pdf").write_bytes(b"%PDF-test")
+    (root / "raw/text/harness-paper.txt").write_text(
+        "First paragraph.\n\nSecond paragraph.", encoding="utf-8"
+    )
+    (root / "raw/figures/harness-paper.png").write_bytes(b"fake-png")
+    (root / "raw/figures/harness-paper.json").write_text(
+        json.dumps({"page": 2, "w": 640, "h": 480, "caption": "Architecture"}),
+        encoding="utf-8",
+    )
+    (root / "wiki/concepts/agent-harness.md").write_text(
+        "---\ntype: concept\n---\n# Agent Harness\n\n**定义**：Agent 运行时。\n",
+        encoding="utf-8",
+    )
+    (root / "wiki/papers/harness-paper.md").write_text(
+        """---
+type: paper
+arxiv_id: "2501.01234"
+---
+# Harness Paper
+
+## TL;DR
+一篇关于 harness 的论文。
+
+## 架构图
+![架构图](../../raw/figures/harness-paper.png)
+
+## 相关概念
+- [[concepts/agent-harness]]
+
+---
+本地原文：[PDF](../../raw/paper/harness-paper.pdf)
+""",
+        encoding="utf-8",
+    )
+    (root / "report/2025-01-03.md").write_text(
+        """# 每日简报
+
+候选 3 → +1
+
+## 本期观察
+
+Agent harness 开始强调可验证的运行时。
+
+- [[papers/harness-paper|Harness Paper]] 给出运行时方案。
+
+## 排除清单（3 候选 − 1 入库 = 2 篇）
+
+- 两篇弱相关论文。
+""",
+        encoding="utf-8",
+    )
+    (root / "wiki/trends.md").write_text(
+        "# 趋势综述\n\n## 可验证运行时\n\n与 [[concepts/agent-harness]] 相关。\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_scan_and_render_vault(tmp_path):
+    snapshot = scan_vault(_make_vault(tmp_path / "vault"))
+    assert len(snapshot.papers) == 1
+    assert snapshot.papers[0].arxiv_id == "2501.01234"
+    assert snapshot.papers[0].concept_slugs == {"agent-harness"}
+    assert [report.report_date.isoformat() for report in snapshot.reports] == ["2025-01-03"]
+    assert snapshot.trends_raw
+    rendered = render_markdown(snapshot.papers[0].wiki_raw or "", snapshot=snapshot, figure_index=3)
+    assert not rendered.startswith("---")
+    assert "![[fig:3]]" in rendered
+    assert "[[Agent Harness]]" in rendered
+    assert "本地原文" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_sync_is_idempotent(app, tmp_path):
+    vault = _make_vault(tmp_path / "vault")
+    owner_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    async with get_sessionmaker()() as session:
+        owner = User(
+            id=owner_id,
+            email="owner@example.com",
+            hashed_password="test",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            display_name="Owner",
+        )
+        session.add(owner)
+        await session.flush()
+        session.add(
+            Project(
+                id=project_id,
+                name="Agent Harness",
+                slug=f"agent-harness-{project_id.hex[:8]}",
+                owner_id=owner_id,
+            )
+        )
+        await session.commit()
+
+        first = await sync_obsidian_vault(
+            session,
+            vault_path=vault,
+            project_id=project_id,
+            batch_size=1,
+        )
+        assert first.library_created is True
+        assert first.new_papers == 1
+        assert first.memberships_created == 1
+        assert first.wikis_created == 1
+        assert first.pdfs_copied == 1
+        assert first.texts_copied == 1
+        assert first.figures_copied == 1
+        assert first.concepts_created == 1
+        assert first.concept_links_created == 1
+        assert first.chunks_created == 1
+        assert first.reports_created == 1
+        second = await sync_obsidian_vault(
+            session,
+            vault_path=vault,
+            project_id=project_id,
+            batch_size=1,
+        )
+        assert second.library_created is False
+        assert second.new_papers == 0
+        assert second.reused_papers == 1
+        assert second.memberships_created == 0
+        assert second.wikis_created == 0
+        assert second.wikis_preserved == 1
+        assert second.pdfs_copied == 0
+        assert second.texts_copied == 0
+        assert second.figures_copied == 0
+        assert second.concept_links_created == 0
+        assert second.chunks_created == 0
+        assert second.reports_created == 0
+        assert second.reports_updated == 0
+
+        digest = (await session.execute(select(LibraryResearchDigest))).scalar_one()
+        paper = (await session.execute(select(Paper))).scalar_one()
+        assert f"[[paper:{paper.id}|Harness Paper]]" in digest.content
+        assert digest.paper_insights == [
+            {
+                "paper_id": str(paper.id),
+                "title": "Harness Paper",
+                "tldr": "一篇关于 harness 的论文。",
+                "relevance_score": 0.9,
+                "status": "compiled",
+            }
+        ]
+
+        singleton_models = (
+            DirectionLibrary,
+            LibraryPaper,
+            TopicSourceLibrary,
+            Paper,
+            PaperWiki,
+            Concept,
+            LibraryResearchDigest,
+        )
+        for model in singleton_models:
+            assert (await session.scalar(select(func.count()).select_from(model))) == 1
+        assert (await session.scalar(select(func.count()).select_from(PaperChunk))) == 1
+        assert (await session.scalar(select(func.count()).select_from(paper_concepts))) == 1

--- a/src/backend/tests/test_openai_compat.py
+++ b/src/backend/tests/test_openai_compat.py
@@ -13,6 +13,7 @@ from app.core.llm.openai_compat import OpenAICompatProvider
 
 BASE_URL = "http://relay.test/api/v1"
 CHAT_URL = f"{BASE_URL}/chat/completions"
+EMBEDDING_URL = f"{BASE_URL}/embeddings"
 
 
 def _sse(chunks: list[dict]) -> bytes:
@@ -160,6 +161,21 @@ async def test_effort_sent_as_reasoning_effort():
 
 
 @respx.mock
+async def test_qwen3_embedding_requests_1024_dimensions():
+    route = respx.post(EMBEDDING_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1] * 1024}]})
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+
+    vectors = await provider.embed(["hello"], model="qwen3_embedding_8b")
+
+    assert len(vectors[0]) == 1024
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["dimensions"] == 1024
+    await provider.aclose()
+
+
+@respx.mock
 async def test_effort_omitted_when_unset():
     """不配 effort 就完全不发该字段——非推理模型/老中转收到会 400。"""
     route = respx.post(CHAT_URL).mock(return_value=httpx.Response(200, json=NON_STREAM_OK))
@@ -211,9 +227,7 @@ async def test_effort_rejected_falls_back_without_it():
             }
         },
     )
-    route = respx.post(CHAT_URL).mock(
-        side_effect=[reject, httpx.Response(200, json=NON_STREAM_OK)]
-    )
+    route = respx.post(CHAT_URL).mock(side_effect=[reject, httpx.Response(200, json=NON_STREAM_OK)])
     provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
     result = await provider.complete(
         [Message(role="user", content="hi")], model="gpt-4o", effort="xhigh"
@@ -222,6 +236,38 @@ async def test_effort_rejected_falls_back_without_it():
     assert route.call_count == 2
     assert json.loads(route.calls[0].request.content)["reasoning_effort"] == "xhigh"
     assert "reasoning_effort" not in json.loads(route.calls[1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_qwen3_embedding_falls_back_for_old_vllm_and_normalizes():
+    native = [3.0, 4.0, *([0.0] * 4094)]
+    route = respx.post(EMBEDDING_URL).mock(
+        side_effect=[
+            httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": (
+                            'Model "qwen3_embedding_8b" does not support matryoshka '
+                            "representation, changing output dimensions will lead to poor results."
+                        )
+                    }
+                },
+            ),
+            httpx.Response(200, json={"data": [{"index": 0, "embedding": native}]}),
+        ]
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+
+    vectors = await provider.embed(["hello"], model="qwen3_embedding_8b")
+
+    assert route.call_count == 2
+    assert json.loads(route.calls[0].request.content)["dimensions"] == 1024
+    assert "dimensions" not in json.loads(route.calls[1].request.content)
+    assert len(vectors[0]) == 1024
+    assert vectors[0][:2] == pytest.approx([0.6, 0.8])
+    assert sum(value * value for value in vectors[0]) == pytest.approx(1.0)
     await provider.aclose()
 
 
@@ -276,9 +322,7 @@ async def test_unrelated_400_is_not_swallowed_as_effort_problem():
     )
     provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
     with pytest.raises(RuntimeError, match="model not found"):
-        await provider.complete(
-            [Message(role="user", content="hi")], model="nope", effort="high"
-        )
+        await provider.complete([Message(role="user", content="hi")], model="nope", effort="high")
     assert route.call_count == 1  # 没有重试
     await provider.aclose()
 
@@ -313,4 +357,18 @@ async def test_effort_rejected_on_stream_retries_without_it():
     assert "".join(chunks) == "Hello world"
     assert route.call_count == 2
     assert "reasoning_effort" not in json.loads(route.calls[1].request.content)
+    await provider.aclose()
+
+
+@respx.mock
+async def test_non_qwen_embedding_request_is_unchanged():
+    route = respx.post(EMBEDDING_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1] * 1024}]})
+    )
+    provider = OpenAICompatProvider(base_url=BASE_URL, api_key="sk-test")
+
+    vectors = await provider.embed(["hello"], model="bge-m3")
+
+    assert len(vectors[0]) == 1024
+    assert "dimensions" not in json.loads(route.calls.last.request.content)
     await provider.aclose()

--- a/src/backend/tests/test_research_digest_batching.py
+++ b/src/backend/tests/test_research_digest_batching.py
@@ -1,0 +1,128 @@
+"""每日简报分批生成、遗漏补跑与最终综合重试。"""
+
+import json
+import re
+import uuid
+
+import pytest
+
+from app.core.llm.base import CompletionResult
+from app.models.library_direction import DirectionLibrary
+from app.models.voyage import VoyageRun
+from app.services.research_digest import (
+    _generate_paper_insights,
+    _synthesize_digest_summary,
+)
+
+
+class _RetryingDigestLLM:
+    """首批漏一篇、首次综合返回坏 JSON，随后都成功。"""
+
+    def __init__(self) -> None:
+        self.batch_prompt_ids: list[list[str]] = []
+        self.synthesis_calls = 0
+
+    async def complete(self, stage, messages, **kwargs):
+        assert stage == "librarian"
+        system = messages[0].content
+        user = messages[-1].content
+        paper_ids = list(dict.fromkeys(re.findall(r'"paper_id"\s*:\s*"([^"]+)"', user)))
+        if "POLARIS_DAILY_DIGEST_BATCH" in system:
+            self.batch_prompt_ids.append(paper_ids)
+            returned_ids = paper_ids[:-1] if len(self.batch_prompt_ids) == 1 else paper_ids
+            return CompletionResult(
+                content=json.dumps(
+                    {
+                        "paper_insights": [
+                            {
+                                "paper_id": paper_id,
+                                "highlight": f"看点-{paper_id[-2:]}",
+                                "direction_relation": "直接相关",
+                                "concepts": ["Agent 工作流", "反馈闭环"],
+                            }
+                            for paper_id in returned_ids
+                        ]
+                    }
+                ),
+                model="fake-batch",
+            )
+
+        assert "POLARIS_DAILY_DIGEST_SYNTHESIS" in system
+        self.synthesis_calls += 1
+        if self.synthesis_calls == 1:
+            return CompletionResult(content="bad json", model="fake-summary")
+        return CompletionResult(
+            content=json.dumps(
+                {
+                    "summary": "分批结果已综合。",
+                    "cross_paper_signals": [
+                        {
+                            "title": "共同信号",
+                            "summary": "多篇论文形成共同方向。",
+                            "paper_ids": [paper_ids[0], str(uuid.uuid4())],
+                        }
+                    ],
+                }
+            ),
+            model="fake-summary",
+        )
+
+
+@pytest.mark.asyncio
+async def test_digest_batches_retry_only_missing_then_retry_synthesis():
+    library_id = uuid.uuid4()
+    library = DirectionLibrary(
+        id=library_id,
+        name="批处理测试库",
+        definition={"statement": "agent harness"},
+    )
+    run = VoyageRun(
+        id=uuid.uuid4(),
+        kind="wiki_ingest",
+        goal="生成今日简报",
+        library_id=library_id,
+        created_by=uuid.uuid4(),
+    )
+    papers = [
+        {
+            "paper_id": str(uuid.uuid4()),
+            "title": f"Paper {index}",
+            "tldr": f"TLDR {index}",
+            "relevance_reason": "符合方向",
+            "concepts": [],
+        }
+        for index in range(23)
+    ]
+    llm = _RetryingDigestLLM()
+
+    insights, model, insight_retries, batch_count = await _generate_paper_insights(
+        llm=llm,
+        run=run,
+        library=library,
+        papers=papers,
+        user_id=run.created_by,
+        extra_guidance="",
+    )
+
+    assert len(insights) == 23
+    assert [item["paper_id"] for item in insights] == [item["paper_id"] for item in papers]
+    assert model == "fake-batch"
+    assert batch_count == 3
+    assert insight_retries == 1
+    assert insights[0]["concepts"] == ["Agent 工作流", "反馈闭环"]
+    # 10 篇首批漏 1 篇后，只补跑缺失的 1 篇；其余两批仍为 10 / 3。
+    assert [len(ids) for ids in llm.batch_prompt_ids] == [10, 1, 10, 3]
+
+    summary, signals, model, synthesis_retries = await _synthesize_digest_summary(
+        llm=llm,
+        run=run,
+        library=library,
+        paper_insights=insights,
+        user_id=run.created_by,
+        extra_guidance="",
+    )
+    assert summary == "分批结果已综合。"
+    assert signals[0]["paper_ids"] == [papers[0]["paper_id"]]
+    assert model == "fake-summary"
+    assert synthesis_retries == 1
+    assert llm.synthesis_calls == 2

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -22,6 +22,7 @@ from app.models.activity import Activity
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.llm_config import LLMUsage
 from app.models.paper import Paper, new_paper, paper_concepts
+from app.models.research_digest import LibraryResearchDigest
 from app.models.user import User
 from app.models.voyage import VoyageRun
 from app.services import ingest as ingest_service
@@ -306,7 +307,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
     obs0 = detail["steps"][0]["observation"]
     assert obs0["found"] == 3 and obs0["inserted"] == 3
 
@@ -372,6 +373,32 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
             ).scalars()
         }
         assert {"ingest.started", "ingest.completed"} <= activity_kinds
+        digest = (
+            await session.execute(
+                select(LibraryResearchDigest).where(
+                    LibraryResearchDigest.voyage_id == uuid.UUID(run_id)
+                )
+            )
+        ).scalar_one()
+        assert digest.counts["kept"] == 2
+        assert digest.counts["excluded"] == 1
+        assert len(digest.paper_insights) == 2
+        assert all(item["concepts"] == ["Agent", "强化学习"] for item in digest.paper_insights)
+        assert "**发表时间**：" in digest.content
+        assert "**概念**：[[Agent]] · [[强化学习]]" in digest.content
+        assert "## 排除清单（1 篇）" in digest.content
+        assert digest.rolling_trends
+        library_id = str(library.id)
+
+    resp = await client.get(f"/api/libraries/{library_id}/digests", headers=headers)
+    assert resp.status_code == 200, resp.text
+    summaries = resp.json()
+    assert summaries[0]["counts"]["kept"] == 2
+    resp = await client.get(
+        f"/api/libraries/{library_id}/digests/{summaries[0]['id']}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["trend_content"].startswith("# 滚动趋势")
 
     # ingest/state：完成后的水位线与计数
     resp = await client.get(f"/api/projects/{project_id}/ingest/state", headers=headers)
@@ -414,6 +441,68 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     async with get_sessionmaker()() as session:
         # 仍是 2：增量这轮没有新候选，上一轮淘汰的那篇也不会复活
         assert len(await project_paper_rows(session, project_id=project_id)) == 2
+
+
+class _BreakDailyDigest(FakeProvider):
+    """让每日简报产出非法 JSON，验证水位线不会越过失败产物。"""
+
+    async def complete(
+        self,
+        messages,
+        *,
+        model,
+        temperature=0.7,
+        max_tokens=None,
+        images=None,
+        effort=None,
+    ):
+        if any("POLARIS_DAILY_DIGEST" in message.content for message in messages):
+            from app.core.llm.base import CompletionResult
+
+            return CompletionResult(content="(empty report)", model=model, finish_reason="stop")
+        return await super().complete(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            images=images,
+            effort=effort,
+        )
+
+
+async def test_daily_digest_failure_does_not_advance_watermark(client, queue_stub, wiki_mocks):
+    """成功跑完前置步骤但没有有效简报时视为空跑，趋势与 watermark 均不得推进。"""
+    project_id, headers = await _setup_project(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    run_id = uuid.UUID(resp.json()["id"])
+
+    router = LLMRouter()
+    router.override_provider(_BreakDailyDigest())
+    engine = VoyageEngine(event_bus=RecordingBus(), llm_router=router)
+    await engine.run(run_id)
+
+    detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
+    assert detail["status"] == "paused_error", detail
+    assert [step["status"] for step in detail["steps"][:5]] == ["passed"] * 5
+    assert detail["steps"][5]["status"] == "failed"
+    assert detail["steps"][5]["observation"]["error"].startswith("ValueError")
+    assert [step["status"] for step in detail["steps"][6:]] == ["pending", "pending"]
+
+    async with get_sessionmaker()() as session:
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        assert not (library.ingest_state or {}).get("watermark")
+        digest = (
+            await session.execute(
+                select(LibraryResearchDigest).where(LibraryResearchDigest.voyage_id == run_id)
+            )
+        ).scalar_one_or_none()
+        assert digest is None
 
 
 class _CrashOnNthRelevance(FakeProvider):
@@ -550,7 +639,7 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
     assert detail["steps"][0]["observation"]["inserted"] == 3  # 默认分类兜底后仍能检索
 
     async with get_sessionmaker()() as session:
@@ -776,7 +865,7 @@ async def test_unlimited_bootstrap_uncapped(client, queue_stub, wiki_mocks_big):
 
     detail = (await client.get(f"/api/voyages/{voyage['id']}", headers=headers)).json()
     assert detail["status"] == "done", detail  # 未因预算暂停
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
 
     # 检索：分页抓到全部 210 条（旧逻辑 limit=min(200, 10*3)=30）
     obs0 = detail["steps"][0]["observation"]
@@ -923,7 +1012,7 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
 
     detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 6
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
 
     async with get_sessionmaker()() as session:
         library = await session.get(DirectionLibrary, uuid.UUID(library_id))
@@ -963,6 +1052,79 @@ async def test_standalone_library_ingest_full_pipeline(client, queue_stub, wiki_
         )
         assert {"ingest.started", "ingest.completed"} <= {a.kind for a in acts}
         assert all(a.project_id is None for a in acts)
+
+
+async def test_manual_digest_reuses_today_updates_without_incremental_ingest(
+    client, queue_stub, wiki_mocks
+):
+    """今日已有评分更新时，手动简报只跑简报/趋势，不重复检索且不推进水位线。"""
+    token = await register_and_login(client, email="lib-digest@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    library_id = await _create_standalone_library(client, headers, name="独立库-今日简报")
+
+    bootstrap = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    assert bootstrap.status_code == 201, bootstrap.text
+    bootstrap_id = bootstrap.json()["id"]
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(bootstrap_id))
+    state_before = (
+        await client.get(f"/api/libraries/{library_id}/ingest/state", headers=headers)
+    ).json()
+
+    resp = await client.post(f"/api/libraries/{library_id}/digests/generate", headers=headers)
+    assert resp.status_code == 201, resp.text
+    launch = resp.json()
+    assert launch["strategy"] == "digest_only"
+    assert launch["paper_count"] == 2
+    digest_run_id = launch["voyage_id"]
+    assert ("run_voyage", (digest_run_id,), {}) in queue_stub.jobs
+
+    await engine.run(uuid.UUID(digest_run_id))
+    detail = (await client.get(f"/api/voyages/{digest_run_id}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert [step["action"] for step in detail["steps"]] == [
+        "wiki.daily_digest",
+        "wiki.trend_synthesize",
+    ]
+
+    state_after = (
+        await client.get(f"/api/libraries/{library_id}/ingest/state", headers=headers)
+    ).json()
+    assert state_after["watermark"] == state_before["watermark"]
+    assert state_after["last_run"] == state_before["last_run"]
+    async with get_sessionmaker()() as session:
+        digest = (
+            await session.execute(
+                select(LibraryResearchDigest).where(
+                    LibraryResearchDigest.voyage_id == uuid.UUID(digest_run_id)
+                )
+            )
+        ).scalar_one()
+        assert digest.counts["kept"] == 2
+        assert digest.counts["excluded"] == 1
+        assert any("跳过增量抓取" in message for message in digest.source_diagnostics["messages"])
+
+
+async def test_manual_digest_falls_back_to_incremental_when_no_today_updates(client, queue_stub):
+    """今日没有评分更新时，手动简报入口退回完整增量任务。"""
+    token = await register_and_login(client, email="lib-digest-empty@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    library_id = await _create_standalone_library(client, headers, name="独立库-无今日更新")
+
+    resp = await client.post(f"/api/libraries/{library_id}/digests/generate", headers=headers)
+    assert resp.status_code == 201, resp.text
+    launch = resp.json()
+    assert launch["strategy"] == "incremental"
+    assert launch["paper_count"] == 0
+    assert ("run_voyage", (launch["voyage_id"],), {}) in queue_stub.jobs
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, uuid.UUID(launch["voyage_id"]))
+        assert run.kind == "wiki_ingest"
+        assert run.checkpoint["params"].get("digest_only") is None
 
 
 async def test_standalone_library_ingest_budget_gate(client, queue_stub):
@@ -1320,6 +1482,8 @@ async def test_snowball_mode_skips_the_arxiv_search(client, queue_stub, wiki_moc
         "wiki.fetch_extract",
         "wiki.compile",
         "wiki.link_concepts",
+        "wiki.daily_digest",
+        "wiki.trend_synthesize",
         "wiki.update_watermark",
     ]
 

--- a/src/frontend/src/features/wiki/DailyDigestTab.tsx
+++ b/src/frontend/src/features/wiki/DailyDigestTab.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { Segmented } from '../../components/ui/Segmented';
+import { toast } from '../../components/ui/Toast';
+import { api, ApiError, type LibraryDigestCounts } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { Markdown } from '../../lib/markdown';
+import { useIsCompact } from '../../lib/useBreakpoint';
+
+type DigestView = 'brief' | 'trends';
+
+export interface DailyDigestTabProps {
+  libraryId: string;
+  onOpenPaper: (paperId: string) => void;
+  onWikiLink: (name: string) => void;
+  canGenerate?: boolean;
+  ingestRunning?: boolean;
+  hasWatermark?: boolean;
+}
+
+function displayDate(value: string): string {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleDateString();
+}
+
+function CountCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        minWidth: 104,
+        flex: '1 1 104px',
+        padding: '10px 12px',
+        borderRadius: 9,
+        background: 'var(--surface-2)',
+        border: '0.5px solid var(--border-2)',
+      }}
+    >
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{label}</div>
+      <div style={{ marginTop: 3, fontSize: 20, fontWeight: 720, color: 'var(--text)' }}>{value}</div>
+    </div>
+  );
+}
+
+function normalizeCounts(counts: Partial<LibraryDigestCounts> | undefined): LibraryDigestCounts {
+  return {
+    source_fetched: counts?.source_fetched ?? 0,
+    prescreened: counts?.prescreened ?? 0,
+    inserted: counts?.inserted ?? 0,
+    kept: counts?.kept ?? 0,
+    excluded: counts?.excluded ?? 0,
+    compiled: counts?.compiled ?? 0,
+  };
+}
+
+/** 文献库每日简报：左侧历史，右侧本次简报 / 该时点滚动趋势。 */
+export function DailyDigestTab({
+  libraryId,
+  onOpenPaper,
+  onWikiLink,
+  canGenerate = false,
+  ingestRunning = false,
+  hasWatermark = false,
+}: DailyDigestTabProps) {
+  const compact = useIsCompact();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [view, setView] = useState<DigestView>('brief');
+
+  const generateMutation = useMutation({
+    mutationFn: () => api.generateLibraryDigest(libraryId),
+    onSuccess: (result) => {
+      toast(
+        result.strategy === 'digest_only'
+          ? tr(
+              `检测到今日已有 ${result.paper_count} 篇论文更新，已跳过增量同步并直接生成简报。`,
+              `Found ${result.paper_count} papers updated today. Incremental sync was skipped and the digest is being generated directly.`,
+            )
+          : tr(
+              '今日尚无论文更新，已启动增量同步；完成后会自动生成简报与趋势。',
+              'No papers have been updated today. Incremental sync started and will generate the digest and trends when complete.',
+            ),
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['ingest-state', libraryId] });
+      void queryClient.invalidateQueries({ queryKey: ['library-digests', libraryId] });
+      navigate(`/voyages/${result.voyage_id}`);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 409) {
+        toast(
+          tr(
+            '当前已有文献任务运行中，完成后会自动生成简报。',
+            'A literature task is already running; it will generate a digest when complete.',
+          ),
+          'info',
+        );
+        void queryClient.invalidateQueries({ queryKey: ['ingest-state', libraryId] });
+        return;
+      }
+      toast(
+        `${tr('简报任务启动失败：', 'Failed to start digest task: ')}${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
+    },
+  });
+
+  const listQuery = useQuery({
+    queryKey: ['library-digests', libraryId],
+    queryFn: () => api.listLibraryDigests(libraryId, 60),
+    retry: false,
+  });
+
+  useEffect(() => {
+    const rows = listQuery.data ?? [];
+    if (!rows.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !rows.some((row) => row.id === selectedId)) {
+      setSelectedId(rows[0]?.id ?? null);
+    }
+  }, [listQuery.data, selectedId]);
+
+  const detailQuery = useQuery({
+    queryKey: ['library-digest', libraryId, selectedId],
+    queryFn: () => api.getLibraryDigest(libraryId, selectedId ?? ''),
+    enabled: !!selectedId,
+    retry: false,
+  });
+
+  const detail = detailQuery.data;
+  const counts = useMemo(() => normalizeCounts(detail?.counts), [detail?.counts]);
+  const paperTitles = useMemo(
+    () => new Map((detail?.paper_insights ?? []).map((paper) => [paper.paper_id, paper.title])),
+    [detail?.paper_insights],
+  );
+
+  if (listQuery.isLoading) {
+    return <div className="skel" style={{ flex: 1, margin: 16 }} />;
+  }
+  if (listQuery.isError) {
+    return (
+      <EmptyState
+        icon="x"
+        title={tr('每日简报加载失败', 'Failed to load daily digests')}
+        desc={tr('请检查后端服务后重试。', 'Check the backend service and try again.')}
+        action={
+          <button className="btn btn-soft sm" onClick={() => void listQuery.refetch()}>
+            {tr('重试', 'Retry')}
+          </button>
+        }
+      />
+    );
+  }
+  if (!listQuery.data?.length) {
+    return (
+      <EmptyState
+        icon="file"
+        title={tr('还没有每日简报', 'No daily digest yet')}
+        desc={tr(
+          '下一次建库或增量同步会生成简报，并在简报成功后才推进同步水位线。',
+          'The next ingest will create one, and the watermark advances only after it succeeds.',
+        )}
+        action={
+          canGenerate ? (
+            <button
+              type="button"
+              className="btn btn-primary sm"
+              disabled={ingestRunning || generateMutation.isPending || !hasWatermark}
+              title={
+                hasWatermark
+                  ? tr(
+                      '今日已有论文更新时直接生成，否则先执行增量同步',
+                      'Generate directly from today’s updates, or sync first when there are none',
+                    )
+                  : tr('需先完成一次初始建库', 'Run the initial library build first')
+              }
+              onClick={() => generateMutation.mutate()}
+            >
+              <Icon name="refresh" size={13} />
+              {tr('生成今日简报', "Generate today's digest")}
+            </button>
+          ) : undefined
+        }
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: compact ? 'column' : 'row', flex: 1, minHeight: 0 }}>
+      <aside
+        style={{
+          width: compact ? '100%' : 250,
+          maxHeight: compact ? 190 : undefined,
+          flexShrink: 0,
+          overflowY: 'auto',
+          borderRight: compact ? 'none' : '0.5px solid var(--border-2)',
+          borderBottom: compact ? '0.5px solid var(--border-2)' : 'none',
+          padding: 10,
+        }}
+      >
+        <div style={{ padding: '4px 7px 9px', fontSize: 11.5, fontWeight: 680, color: 'var(--text-3)' }}>
+          {tr('简报历史', 'Digest history')}
+        </div>
+        {listQuery.data.map((row) => {
+          const active = row.id === selectedId;
+          return (
+            <button
+              key={row.id}
+              type="button"
+              onClick={() => { setSelectedId(row.id); setView('brief'); }}
+              style={{
+                width: '100%',
+                border: 'none',
+                borderRadius: 8,
+                padding: '9px 10px',
+                marginBottom: 3,
+                textAlign: 'left',
+                cursor: 'pointer',
+                background: active ? 'var(--accent-soft)' : 'transparent',
+                color: active ? 'var(--accent)' : 'var(--text)',
+                fontFamily: 'var(--sans)',
+              }}
+            >
+              <div className="row" style={{ justifyContent: 'space-between', gap: 8 }}>
+                <span style={{ fontSize: 12.5, fontWeight: 660 }}>{displayDate(row.report_date)}</span>
+                {row.source === 'obsidian' && (
+                  <span style={{ fontSize: 10.5, color: 'var(--text-3)' }}>Obsidian</span>
+                )}
+              </div>
+              <div style={{ marginTop: 4, fontSize: 11.5, color: 'var(--text-3)' }}>
+                {tr(`收录 ${row.counts.kept ?? 0} · 排除 ${row.counts.excluded ?? 0}`, `Kept ${row.counts.kept ?? 0} · Excluded ${row.counts.excluded ?? 0}`)}
+              </div>
+            </button>
+          );
+        })}
+      </aside>
+
+      <section style={{ flex: 1, minWidth: 0, minHeight: 0, overflowY: 'auto' }}>
+        {detailQuery.isLoading ? (
+          <div className="skel" style={{ height: 360, margin: 16 }} />
+        ) : detailQuery.isError || !detail ? (
+          <EmptyState
+            compact
+            icon="x"
+            title={tr('这份简报暂时打不开', 'Cannot open this digest')}
+            action={
+              <button className="btn btn-soft sm" onClick={() => void detailQuery.refetch()}>
+                {tr('重试', 'Retry')}
+              </button>
+            }
+          />
+        ) : (
+          <div style={{ padding: compact ? 16 : 22, maxWidth: 980, margin: '0 auto' }}>
+            <div className="row" style={{ justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+              <div>
+                <div className="row gap8" style={{ fontSize: 16, fontWeight: 720 }}>
+                  <Icon name={view === 'brief' ? 'file' : 'chart'} size={17} />
+                  {displayDate(detail.report_date)}
+                </div>
+                <div style={{ marginTop: 4, fontSize: 11.5, color: 'var(--text-3)' }}>
+                  {detail.source === 'obsidian'
+                    ? tr('从 Obsidian 文献库导入', 'Imported from the Obsidian vault')
+                    : tr('由文献同步任务生成', 'Generated by the literature ingest')}
+                </div>
+              </div>
+              <div className="row gap8" style={{ flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                {canGenerate && (
+                  <button
+                    type="button"
+                    className="btn btn-primary sm"
+                    disabled={ingestRunning || generateMutation.isPending || !hasWatermark}
+                    title={
+                      hasWatermark
+                        ? tr(
+                            '今日已有论文更新时直接生成，否则先执行增量同步',
+                            'Generate directly from today’s updates, or sync first when there are none',
+                          )
+                        : tr('需先完成一次初始建库', 'Run the initial library build first')
+                    }
+                    onClick={() => generateMutation.mutate()}
+                  >
+                    <Icon
+                      name="refresh"
+                      size={13}
+                      style={generateMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
+                    />
+                    {generateMutation.isPending
+                      ? tr('启动中…', 'Starting…')
+                      : ingestRunning
+                        ? tr('文献任务进行中', 'Literature task running')
+                        : tr('生成今日简报', 'Generate today’s digest')}
+                  </button>
+                )}
+                <Segmented<DigestView>
+                  options={[
+                    { v: 'brief', label: tr('本次简报', 'Digest') },
+                    { v: 'trends', label: tr('滚动趋势', 'Rolling trends') },
+                  ]}
+                  value={view}
+                  onChange={setView}
+                />
+              </div>
+            </div>
+
+            {view === 'brief' ? (
+              <>
+                <div className="row" style={{ gap: 8, flexWrap: 'wrap', marginTop: 18 }}>
+                  <CountCard label={tr('来源抓取', 'Fetched')} value={counts.source_fetched} />
+                  <CountCard label={tr('预筛后', 'Prescreened')} value={counts.prescreened} />
+                  <CountCard label={tr('新候选', 'Inserted')} value={counts.inserted} />
+                  <CountCard label={tr('保留', 'Kept')} value={counts.kept} />
+                  <CountCard label={tr('排除', 'Excluded')} value={counts.excluded} />
+                  <CountCard label={tr('已解读', 'Compiled')} value={counts.compiled} />
+                </div>
+                {detail.source_diagnostics.status === 'warning' && (
+                  <div
+                    style={{
+                      marginTop: 14,
+                      padding: '10px 12px',
+                      borderRadius: 8,
+                      background: 'var(--warn-bg)',
+                      color: 'var(--warn-tx)',
+                      fontSize: 12.5,
+                    }}
+                  >
+                    {(detail.source_diagnostics.messages ?? []).join(' ')}
+                  </div>
+                )}
+                <Markdown
+                  source={detail.content}
+                  onWikiLink={onWikiLink}
+                  renderPaperRef={(paperId) => (
+                    <button
+                      type="button"
+                      className="btn btn-ghost sm"
+                      style={{ padding: '2px 7px', verticalAlign: 'middle' }}
+                      onClick={() => onOpenPaper(paperId)}
+                    >
+                      {paperTitles.get(paperId) ?? tr('打开论文', 'Open paper')}
+                    </button>
+                  )}
+                  style={{ marginTop: 22 }}
+                />
+              </>
+            ) : detail.trend_content ? (
+              <Markdown source={detail.trend_content} onWikiLink={onWikiLink} style={{ marginTop: 20 }} />
+            ) : (
+              <EmptyState
+                compact
+                icon="chart"
+                title={tr('这一天还没有趋势快照', 'No trend snapshot for this day')}
+                desc={tr(
+                  '历史导入只在最新一份简报保留当前趋势；新的同步会逐次生成趋势快照。',
+                  'Historical imports keep the current trends on the latest digest; future ingests create snapshots each time.',
+                )}
+              />
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -16,6 +16,9 @@ import { GovernanceTab } from './GovernanceTab';
 
 // 图谱与 PPT 弹窗体量大且非默认视图：按需加载
 const GraphTab = lazy(() => import('./GraphTab').then((m) => ({ default: m.GraphTab })));
+const DailyDigestTab = lazy(() =>
+  import('./DailyDigestTab').then((m) => ({ default: m.DailyDigestTab })),
+);
 const PresentationModal = lazy(() =>
   import('./PresentationModal').then((m) => ({ default: m.PresentationModal })),
 );
@@ -28,7 +31,7 @@ const PresentationModal = lazy(() =>
    从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
-type WikiTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'ingest' | 'notes' | 'govern';
+type WikiTab = 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'ingest' | 'notes' | 'govern';
 
 export function WikiWorkbench({
   pid,
@@ -95,7 +98,7 @@ export function WikiWorkbench({
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['papers', 'concepts', 'graph', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
+    } else if (tabParam && ['papers', 'concepts', 'graph', 'digest', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -161,6 +164,7 @@ export function WikiWorkbench({
             { v: 'papers', label: `${tr('论文库', 'Papers')}${total !== undefined ? ` · ${total}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
+            ...(libraryId ? [{ v: 'digest' as const, label: tr('每日简报', 'Daily digest') }] : []),
             { v: 'chat', label: tr('文献对话', 'Chat') },
             { v: 'notes', label: tr('笔记', 'Notes') },
             ...(libraryId ? [{ v: 'govern' as const, label: tr('文献库配置', 'Library config') }] : []),
@@ -233,6 +237,17 @@ export function WikiWorkbench({
         ) : tab === 'graph' ? (
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
             <GraphTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
+          </Suspense>
+        ) : tab === 'digest' && libraryId ? (
+          <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
+            <DailyDigestTab
+              libraryId={libraryId}
+              onOpenPaper={goPaper}
+              onWikiLink={onWikiLink}
+              canGenerate={canManage}
+              ingestRunning={!!ingestQuery.data?.running_voyage_id}
+              hasWatermark={!!ingestQuery.data?.watermark}
+            />
           </Suspense>
         ) : tab === 'chat' ? (
           <LibraryChatTab

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1161,6 +1161,88 @@ export interface GraphData {
 }
 
 // ============================================================
+// 文献库每日简报 / 滚动趋势
+// ============================================================
+
+export interface LibraryDigestCounts {
+  source_fetched: number;
+  prescreened: number;
+  inserted: number;
+  kept: number;
+  excluded: number;
+  compiled: number;
+}
+
+export interface LibraryDigestGenerateResult {
+  voyage_id: string;
+  strategy: 'digest_only' | 'incremental';
+  paper_count: number;
+}
+
+export interface LibraryPaperInsight {
+  paper_id: string;
+  title: string;
+  tldr?: string;
+  highlight?: string;
+  direction_relation?: string;
+  concepts?: string[];
+  relevance_score?: number | null;
+  status?: string;
+}
+
+export interface LibraryCrossPaperSignal {
+  title: string;
+  summary: string;
+  paper_ids?: string[];
+}
+
+export interface LibraryRollingTrend {
+  title: string;
+  status: 'emerging' | 'active' | 'converging' | 'stale';
+  summary: string;
+  evidence_trajectory: string;
+  concepts: string[];
+  paper_ids: string[];
+  last_seen: string;
+}
+
+export interface LibraryDigestSummary {
+  id: string;
+  report_date: string;
+  source: 'voyage' | 'obsidian';
+  mode: 'bootstrap' | 'incremental' | 'import';
+  counts: LibraryDigestCounts;
+  summary: string;
+  voyage_id: string | null;
+  has_trends: boolean;
+  created_at: string;
+}
+
+export interface LibraryDigestRead extends LibraryDigestSummary {
+  library_id: string;
+  source_diagnostics: {
+    status?: 'ok' | 'warning' | 'imported';
+    source_latest_at?: string | null;
+    messages?: string[];
+    [key: string]: unknown;
+  };
+  paper_insights: LibraryPaperInsight[];
+  excluded_papers: Array<{
+    paper_id?: string;
+    title: string;
+    relevance_score?: number | null;
+    reason: string;
+  }>;
+  cross_paper_signals: LibraryCrossPaperSignal[];
+  content: string;
+  model: string | null;
+  rolling_trends: LibraryRollingTrend[];
+  trend_content: string;
+  trend_model: string | null;
+  updated_at: string;
+}
+
+// ============================================================
 // 实验室数据面板（/lab 概况页）
 // ============================================================
 
@@ -3495,6 +3577,20 @@ export const api = {
   },
   getLibraryGraph(id: string): Promise<GraphData> {
     return request<GraphData>(`/libraries/${id}/graph`);
+  },
+  /** 每日简报历史（正文按选中项再取）。 */
+  listLibraryDigests(id: string, limit = 30): Promise<LibraryDigestSummary[]> {
+    return request<LibraryDigestSummary[]>(`/libraries/${id}/digests?limit=${limit}`);
+  },
+  /** 一份每日简报及该时点的滚动趋势快照。 */
+  getLibraryDigest(id: string, digestId: string): Promise<LibraryDigestRead> {
+    return request<LibraryDigestRead>(`/libraries/${id}/digests/${digestId}`);
+  },
+  /** 智能生成今日简报：今日已有论文更新则直接生成，否则先执行增量同步。 */
+  generateLibraryDigest(id: string): Promise<LibraryDigestGenerateResult> {
+    return request<LibraryDigestGenerateResult>(`/libraries/${id}/digests/generate`, {
+      method: 'POST',
+    });
   },
 
   // —— 实验室数据面板（/lab 概况页） ——


### PR DESCRIPTION
## Summary

Adds native daily literature digests, rolling trend synthesis, and idempotent Obsidian vault synchronization so research libraries retain structured, navigable updates instead of standalone Markdown. Manual digest generation reuses papers updated today, while batched paper analysis, concept linking, retries, and watermark guards make the workflow reliable at library scale.

Closes #235

## Area

- [x] frontend
- [ ] desktop (Electron client)
- [x] backend-api
- [x] voyage (task loop)
- [x] literature / wiki
- [ ] daily papers
- [ ] idea forge
- [ ] experiment
- [ ] writer
- [ ] review
- [x] skills
- [x] llm routing / usage
- [ ] auth / users
- [x] infra / deploy
- [ ] docs

## What changed

- Added persisted daily digest and rolling trend snapshots, list/detail/generate APIs, and a lazy-loaded library workbench tab.
- Added digest-only manual runs that reuse papers updated today without repeating ingestion or advancing the watermark.
- Generated per-paper insights in validated batches with omission retries, synthesis retries, publication dates, and resolvable concept links.
- Added concept persistence and promotion for digest-generated concepts while preserving existing wiki-derived relationships.
- Added an idempotent Obsidian vault importer for papers, concepts, links, historical reports, and local assets.
- Added source diagnostics, exclusion reasons, migration coverage, configurable Docker host ports, and Qwen3 embedding dimension compatibility.

## Testing

- [x] `tsc --noEmit` / frontend build passes (frontend touched)
- [x] Backend tests pass (backend touched) — 923 passed
- [x] Alembic `upgrade head` + downgrade roundtrip passes (migration added)
- [x] `alembic heads` shows a single head (migration added)
- [x] PR Python files pass Ruff check and format verification
- [ ] Manually verified in local dev

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title (`feat|fix|chore|docs(scope): …`)
- [x] New migration (if any) uses a random revision id and chains onto the current head
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [ ] Screenshots attached for UI changes

Full-repository `make lint` currently reports 10 pre-existing Ruff violations in files unchanged by this PR; all Python files changed by this PR pass both Ruff checks.
