### PR TITLE
feat(daily): date stepper back, library badge into the detail pane, latest-batch by sync

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -501,7 +501,11 @@ async def list_library_papers(
     created_from: datetime | None = Query(default=None),
     created_to: datetime | None = Query(default=None),
     daily_only: bool = Query(
-        default=False, description="只看从每日论文池自动收录的（今日新收录视图用）"
+        default=False, description="只看从每日论文池自动收录的"
+    ),
+    last_sync_only: bool = Query(
+        default=False,
+        description="只看最近一次同步新增的（没同步过则返回空；「最新收录」视图用）",
     ),
     sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
     page: int = Query(default=1, ge=1),
@@ -532,6 +536,7 @@ async def list_library_papers(
         created_from=created_from,
         created_to=created_to,
         daily_only=daily_only,
+        last_sync_only=last_sync_only,
         user_id=user.id,
         sort=sort,
         page=page,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -153,7 +153,11 @@ async def list_papers(
     created_from: datetime | None = Query(default=None),
     created_to: datetime | None = Query(default=None),
     daily_only: bool = Query(
-        default=False, description="只看从每日论文池自动收录的（今日新收录视图用）"
+        default=False, description="只看从每日论文池自动收录的"
+    ),
+    last_sync_only: bool = Query(
+        default=False,
+        description="只看最近一次同步新增的（没同步过则返回空；「最新收录」视图用）",
     ),
     sort: str = Query(default="relevance", pattern="^(relevance|-published_at)$"),
     page: int = Query(default=1, ge=1),
@@ -184,6 +188,7 @@ async def list_papers(
         created_from=created_from,
         created_to=created_to,
         daily_only=daily_only,
+        last_sync_only=last_sync_only,
     )
     # 库标签按课题的关联库并集显示（与 tag 过滤同口径，翻页也稳定）
     library_ids = await libraries_service.get_source_library_ids(session, project_id)

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import Select, and_, cast, delete, exists, func, insert, or_, select, text
+from sqlalchemy import Select, and_, cast, delete, exists, false, func, insert, or_, select, text
 from sqlalchemy import Text as SAText
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -273,6 +273,7 @@ async def list_papers(
     created_from: datetime | None = None,
     created_to: datetime | None = None,
     daily_only: bool = False,
+    last_sync_only: bool = False,
 ) -> tuple[Sequence[PaperView], int]:
     """库内论文列表。入口二选一：library_id（单库读视图/库工作台）或 project_id
     （课题成员视角 = 关联库并集，P7）。project_id 兼作 PaperView 的课题上下文回填。
@@ -282,6 +283,28 @@ async def list_papers(
     library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
     if not library_ids:
         return [], 0
+
+    # 「最近一次同步新增」：按各库自己最后一轮 ingest 的开始时刻卡。
+    # 不能用「今天入库」——上次同步要是在昨天，今天就永远是 0 篇，而用户想看的是
+    # 「上次更新带进来什么」。没跑过同步的库返回空集（0 篇），而不是退化成全部。
+    last_sync_clause = None
+    if last_sync_only:
+        from app.models.voyage import VoyageRun
+
+        rows = (
+            await session.execute(
+                select(VoyageRun.library_id, func.max(VoyageRun.created_at))
+                .where(VoyageRun.kind == "wiki_ingest", VoyageRun.library_id.in_(library_ids))
+                .group_by(VoyageRun.library_id)
+            )
+        ).all()
+        per_library = [
+            and_(LibraryPaper.library_id == lib_id, LibraryPaper.created_at >= started)
+            for lib_id, started in rows
+            if started is not None
+        ]
+        # 一次都没同步过 → 没有「上次新增」可言，给一个恒假条件而不是放行
+        last_sync_clause = or_(*per_library) if per_library else false()
 
     filter_kwargs = dict(
         library_ids=library_ids,
@@ -303,6 +326,8 @@ async def list_papers(
 
     if len(library_ids) == 1:
         stmt = apply_paper_filters(member_paper_stmt(library_ids[0]), **filter_kwargs)
+        if last_sync_clause is not None:
+            stmt = stmt.where(last_sync_clause)
         total = (await session.execute(stmt.with_only_columns(func.count()))).scalar_one()
         if sort == "-published_at":
             stmt = stmt.order_by(
@@ -318,6 +343,8 @@ async def list_papers(
 
     # 关联多库并集：过滤 → 跨库归并 → Python 排序 + 分页
     stmt = apply_paper_filters(member_papers_stmt(library_ids), **filter_kwargs)
+    if last_sync_clause is not None:
+        stmt = stmt.where(last_sync_clause)
     all_rows = dedupe_member_rows((await session.execute(stmt)).all())
     if sort == "-published_at":
         all_rows.sort(

--- a/src/backend/tests/test_daily_library_visibility.py
+++ b/src/backend/tests/test_daily_library_visibility.py
@@ -221,3 +221,71 @@ async def test_library_list_can_show_only_todays_daily_collections(client):
     assert str(collected_id) in ids
     assert str(manual_id) not in ids, "手工加的不算「从每日论文自动收录」"
     assert str(old_id) not in ids, "昨天入库的不算今天新收录"
+
+
+async def test_latest_batch_view_follows_the_last_sync_not_the_calendar(client):
+    """「最新收录」按上次同步新增算，不是按「今天入库」。
+
+    按日历卡的话，上次同步在昨天就永远显示 0 篇，而用户想看的是「上次更新带进来什么」。
+    """
+    import datetime as dt
+
+    from sqlalchemy import select as sa_select
+
+    from app.models.library_direction import LibraryPaper
+    from app.models.voyage import VoyageRun
+
+    project_id, headers, collected_id, _passed_id, library_id = await _setup(client)
+
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="wiki_ingest",
+            mode="pipeline",
+            status="done",
+            goal="上次同步",
+            library_id=library_id,
+        )
+        session.add(run)
+        await session.flush()
+        two_days_ago = dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+        run.created_at = two_days_ago
+        membership = (
+            await session.execute(
+                sa_select(LibraryPaper).where(LibraryPaper.paper_id == collected_id)
+            )
+        ).scalar_one()
+        membership.created_at = two_days_ago + dt.timedelta(minutes=1)
+        # 再放一篇「上次同步之前就在库里」的：它不该算进最新收录
+        older = await add_paper(
+            session, project_id=project_id, title="Added Long Ago", status="compiled"
+        )
+        session.add(older)
+        await session.flush()
+        older_membership = (
+            await session.execute(sa_select(LibraryPaper).where(LibraryPaper.paper_id == older.id))
+        ).scalar_one()
+        older_membership.created_at = two_days_ago - dt.timedelta(days=5)
+        older_id = older.id
+        await session.commit()
+
+    resp = await client.get(
+        f"/api/projects/{project_id}/papers",
+        params={"status": "library", "last_sync_only": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()["items"]}
+    assert str(collected_id) in ids, "上次同步（两天前）新增的那篇应当算「最新收录」"
+    assert str(older_id) not in ids, "上次同步之前就在库里的不该算新增"
+
+
+async def test_latest_batch_is_empty_when_the_library_never_synced(client):
+    """从没同步过的库：0 篇，而不是退化成全部。"""
+    project_id, headers, _c, _p, _lib = await _setup(client)
+    resp = await client.get(
+        f"/api/projects/{project_id}/papers",
+        params={"status": "library", "last_sync_only": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["items"] == []

--- a/src/frontend/src/components/ui/CollectingLibraries.tsx
+++ b/src/frontend/src/components/ui/CollectingLibraries.tsx
@@ -16,7 +16,15 @@ function scoreText(v: number | null): string {
   return v === null ? tr('未打分', 'not scored') : v.toFixed(2);
 }
 
-export function CollectingLibraries({ paperId }: { paperId: string }) {
+export function CollectingLibraries({
+  paperId,
+  standalone = false,
+}: {
+  paperId: string;
+  /** 独立成一行（详情面板用）：占整行、多摆几个、空态也出提示。
+   *  默认是挤在顶部徽章行里的紧凑形态。 */
+  standalone?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const { data } = useQuery({
     queryKey: ['paper-libraries', paperId],
@@ -25,15 +33,41 @@ export function CollectingLibraries({ paperId }: { paperId: string }) {
   });
 
   const libs: CollectingLibrary[] = data ?? [];
-  if (libs.length === 0) return null;
+  // 独立成行时，「没有任何库收录」本身是有用的信息，要说出来；挤在徽章行里则不占位
+  if (libs.length === 0) {
+    return standalone ? (
+      <div className="row gap6" style={{ alignItems: 'center', marginTop: 8, paddingLeft: 2 }}>
+        <Icon name="book" size={12} style={{ color: 'var(--text-4)' }} />
+        <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
+          {tr('还没有文献库收录这篇', 'No library has collected this paper yet')}
+        </span>
+      </div>
+    ) : null;
+  }
 
-  const shown = libs.slice(0, 2);
+  // 独立成行有整行宽度，可以多摆几个；挤在徽章行里只放两个
+  const shown = libs.slice(0, standalone ? 6 : 2);
   const rest = libs.length - shown.length;
 
   return (
     <>
-      <span className="row gap6 wrap" style={{ alignItems: 'center' }}>
-        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+      <span
+        className="row gap6 wrap"
+        style={
+          standalone
+            ? { alignItems: 'center', marginTop: 8, paddingLeft: 2 }
+            : { alignItems: 'center' }
+        }
+      >
+        <span
+          className={standalone ? 'row gap6' : 'mono'}
+          style={
+            standalone
+              ? { fontSize: 11.5, color: 'var(--text-3)', alignItems: 'center' }
+              : { fontSize: 10.5, color: 'var(--text-4)' }
+          }
+        >
+          {standalone && <Icon name="book" size={12} style={{ color: 'var(--text-4)' }} />}
           {tr('已收录', 'In')}
         </span>
         {shown.map((l) => (

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -288,7 +288,6 @@ function DailyDetailPane({
           </span>
         ))}
         <AnnounceBadge type={paper.announce_type} />
-        <CollectingLibraries paperId={paper.paper_id} />
         {paper.arxiv_id &&
           (arxivHref ? (
             <a
@@ -417,6 +416,9 @@ function DailyDetailPane({
           trailing={<PaperIndexStatusRow paperId={paper.paper_id} showRebuild={false} />}
         />
       )}
+
+      {/* —— 哪些文献库收录了这篇：紧跟标签行，两者都是「这篇在平台里的归属」 —— */}
+      <CollectingLibraries paperId={paper.paper_id} standalone />
 
       {/* —— 概念 chips（与库版同款；点了进不限库的概念页） —— */}
       <ConceptChips concepts={paper.concepts} onOpen={openConcept} />
@@ -616,9 +618,9 @@ export function DailyPage() {
   const [page, setPage] = useState(1);
   // —— 日期（null=全部，默认就停在全部）留在工具栏；分类 / 类型收进高级检索面板 ——
   // 只看被某个文献库收录的论文（#218）。空 = 不限
-  const [libraryId, setLibraryId] = useState('');
-  // 日期：空 = 全部。之前是「前一天 / 后一天」步进，只会把人困在某一天；
-  // 现在按有数据的日期直接选，跳到哪天都是一步。
+  // 日期：勾上「全部」就是跨天一起看（默认）；取消勾选后在有数据的日期间前后切换。
+  // 只在这些日期间跳，而不是任意日历日——中间没有公告的日子点进去是空的。
+  const [showAll, setShowAll] = useState(true);
   const [day, setDay] = useState('');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
   const [advOpen, setAdvOpen] = useState(true);
@@ -630,13 +632,7 @@ export function DailyPage() {
   const author = useDebounced(authorInput.trim());
   const affiliation = useDebounced(affiliationInput.trim());
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
-  const advActive =
-    !!category ||
-    announce !== DEFAULT_ANNOUNCE ||
-    !!author ||
-    !!affiliation ||
-    !!libraryId ||
-    !!day;
+  const advActive = !!category || announce !== DEFAULT_ANNOUNCE || !!author || !!affiliation;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -646,7 +642,7 @@ export function DailyPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => setPage(1), [q, semanticOn, category, announce, author, affiliation, day]);
+  useEffect(() => setPage(1), [q, semanticOn, category, announce, author, affiliation, showAll, day]);
   useEffect(() => {
     setSelected(new Set());
     setSelectMode(false);
@@ -662,6 +658,9 @@ export function DailyPage() {
     staleTime: 60_000,
   });
   const dayCount = new Map((daysQuery.data ?? []).map((d) => [d.date, d.count] as const));
+  // 有数据的日期，升序（旧 → 新）；前后切换只在这些日期间跳
+  const dates = (daysQuery.data ?? []).map((d) => d.date).sort();
+  const dayIdx = dates.indexOf(day);
 
 
   // 默认停在「全部」：跨天一起看、按时间倒排，最新的自然在最前。以前默认落到最新
@@ -677,8 +676,6 @@ export function DailyPage() {
       setAuthorInput(patch.author ?? '');
       setAffiliationInput(patch.affiliation ?? '');
       setCategory('');
-      setDay('');
-      setLibraryId('');
       setAnnounce('all');
       setAdvOpen(true);
       if (patch.author) {
@@ -701,20 +698,13 @@ export function DailyPage() {
     retry: false,
     staleTime: 300_000,
   });
-  // 按库筛选的候选：后端只回请求者看得见的库，这里照单全收
-  const librariesQuery = useQuery({
-    queryKey: ['libraries-for-daily-filter'],
-    queryFn: () => api.listLibraries(),
-    retry: false,
-    staleTime: 300_000,
-  });
 
   // 语义检索：只在有关键词时生效；结果按相关度排序、不分页
   const semantic = !!q && semanticOn;
   const listQuery = useQuery({
     queryKey: [
       'daily-papers',
-      semanticOn, page, q, category, announce, author, affiliation, libraryId, day,
+      semanticOn, page, q, category, announce, author, affiliation, showAll, day,
     ],
     queryFn: () =>
       api.listDailyPapers({
@@ -726,15 +716,15 @@ export function DailyPage() {
         announce: announce === 'all' ? undefined : announce,
         author: author || undefined,
         affiliation: affiliation || undefined,
-        libraryId: libraryId || undefined,
-        date: day || undefined,
+        date: showAll ? undefined : day || undefined,
         mode: semantic ? 'semantic' : undefined,
       }),
     retry: false,
     placeholderData: keepPreviousData,
   });
   // 默认口径（当天 + 新工作）之外还加了条件才算「筛过」——空列表时给的话术不一样
-  const filtered = !!q || advActive;
+  // 选了某一天也算「筛过」——空列表时给的话术不一样
+  const filtered = !!q || advActive || !showAll;
   const items = listQuery.data?.items ?? [];
   const total = listQuery.data?.total ?? 0;
   const pages = semantic ? 1 : Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -898,8 +888,6 @@ export function DailyPage() {
                     advActive
                       ? () => {
                           setCategory('');
-                          setDay('');
-                          setLibraryId('');
                           setAnnounce(DEFAULT_ANNOUNCE);
                           setAuthorInput('');
                           setAffiliationInput('');
@@ -907,51 +895,6 @@ export function DailyPage() {
                       : undefined
                   }
                 >
-                  <div className="row gap6" style={{ alignItems: 'center' }}>
-                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
-                      {tr('日期', 'Date')}
-                    </span>
-                    <select
-                      className="input mono"
-                      style={{ flex: 1, minWidth: 0, height: 26, fontSize: 11, padding: '0 6px' }}
-                      value={day}
-                      onChange={(e) => setDay(e.target.value)}
-                      title={tr('只看某一天公告的论文', 'Only papers announced on one day')}
-                    >
-                      <option value="">
-                        {tr(
-                          `全部（${(daysQuery.data ?? []).length} 天）`,
-                          `All (${(daysQuery.data ?? []).length} days)`,
-                        )}
-                      </option>
-                      {[...(daysQuery.data ?? [])]
-                        .sort((a, b) => b.date.localeCompare(a.date))
-                        .map((d) => (
-                          <option key={d.date} value={d.date}>
-                            {d.date} · {d.count}
-                          </option>
-                        ))}
-                    </select>
-                  </div>
-                  <div className="row gap6" style={{ alignItems: 'center' }}>
-                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
-                      {tr('文献库', 'Library')}
-                    </span>
-                    <select
-                      className="input"
-                      style={{ flex: 1, minWidth: 0, height: 26, fontSize: 11, padding: '0 6px' }}
-                      value={libraryId}
-                      onChange={(e) => setLibraryId(e.target.value)}
-                      title={tr('只看被某个文献库收录的论文', 'Only papers collected by one library')}
-                    >
-                      <option value="">{tr('全部文献库', 'All libraries')}</option>
-                      {(librariesQuery.data ?? []).map((lib) => (
-                        <option key={lib.id} value={lib.id}>
-                          {lib.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
                   <div className="row gap6" style={{ alignItems: 'center' }}>
                     <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
                       {tr('分类', 'Category')}
@@ -1046,6 +989,60 @@ export function DailyPage() {
                   {tr('语义检索暂不可用，已回退为关键词匹配。', 'Semantic search unavailable — fell back to keyword matching.')}
                 </div>
               )}
+              {/* —— 日期切换：前一天 / 当前 / 后一天，右侧勾选看全部 ——
+                  只在有数据的日期间跳：中间没公告的日子（周末）点进去是空的。 */}
+              <div className="row gap6 wrap" style={{ marginTop: 8, alignItems: 'center' }}>
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
+                  disabled={showAll || dayIdx <= 0}
+                  onClick={() => setDay(dates[dayIdx - 1] ?? day)}
+                  title={tr('前一天有公告的日期', 'Previous day with papers')}
+                >
+                  ‹ {tr('前一天', 'Prev')}
+                </button>
+                <span
+                  className="mono"
+                  style={{
+                    minWidth: 132,
+                    textAlign: 'center',
+                    fontSize: 11.5,
+                    color: showAll ? 'var(--text-4)' : 'var(--text-1)',
+                    fontWeight: showAll ? 400 : 600,
+                  }}
+                >
+                  {showAll
+                    ? tr(`全部 ${dates.length} 天`, `All ${dates.length} days`)
+                    : day
+                      ? dayLabel(day, dayCount.get(day))
+                      : tr('无数据', 'No data')}
+                </span>
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ padding: '0 7px', height: 24, fontSize: 11 }}
+                  disabled={showAll || dayIdx < 0 || dayIdx >= dates.length - 1}
+                  onClick={() => setDay(dates[dayIdx + 1] ?? day)}
+                  title={tr('后一天有公告的日期', 'Next day with papers')}
+                >
+                  {tr('后一天', 'Next')} ›
+                </button>
+                <label
+                  className="row gap6"
+                  style={{ alignItems: 'center', cursor: 'pointer', marginLeft: 4 }}
+                  title={tr('跨天一起看，按时间倒排', 'Show every day, newest first')}
+                >
+                  <input
+                    type="checkbox"
+                    checked={showAll}
+                    onChange={(e) => {
+                      setShowAll(e.target.checked);
+                      // 取消「全部」时落到最新一天，省得还要再点一次
+                      if (!e.target.checked && !day) setDay(dates[dates.length - 1] ?? '');
+                    }}
+                  />
+                  <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{tr('全部', 'All')}</span>
+                </label>
+              </div>
             </div>
 
             <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -68,19 +68,14 @@ const VIEW_FILTERS: { v: ViewFilter; zh: string; en: string; hintZh: string; hin
   { v: 'starred', zh: '已星标', en: 'Starred', hintZh: '我加了星标的文献', hintEn: 'Papers I starred' },
   {
     v: 'today',
-    zh: '今日新收录',
-    en: 'New today',
-    hintZh: '今天从每日论文自动收录进来的',
-    hintEn: 'Collected from the daily papers today',
+    zh: '最新收录',
+    en: 'Latest batch',
+    hintZh: '上次同步新增的文献（这次没新增就是 0 篇）',
+    hintEn: 'Papers added by the most recent sync (0 if it added none)',
   },
 ];
 
-/** 今天 00:00（本地）的 ISO 串——「今日新收录」按入库时间卡这条线。 */
-function startOfToday(): string {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d.toISOString();
-}
+
 
 /** 视图 → 列表查询参数（未纳入/回收站文献一律不出现在论文库）。 */
 function viewQuery(view: ViewFilter): {
@@ -88,12 +83,14 @@ function viewQuery(view: ViewFilter): {
   starred?: boolean;
   created_from?: string;
   daily_only?: boolean;
+  last_sync_only?: boolean;
 } {
   if (view === 'compiled') return { status: 'compiled_any' };
   if (view === 'starred') return { status: 'library', starred: true };
-  // 今日新收录：今天入库 + 来自每日论文池（手动加的、引文扩展来的不算）
+  // 最新收录：上次同步新增的那批。不能按「今天入库」卡——上次同步要是在昨天，
+  // 今天就永远是 0 篇，而用户想看的是「上次更新带进来什么」。
   if (view === 'today') {
-    return { status: 'library', created_from: startOfToday(), daily_only: true };
+    return { status: 'library', last_sync_only: true };
   }
   return { status: 'library' };
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3023,8 +3023,10 @@ export const api = {
       published_to?: string;
       created_from?: string;
       created_to?: string;
-      /** 只看从每日论文池自动收录的（今日新收录视图） */
+      /** 只看从每日论文池自动收录的 */
       daily_only?: boolean;
+      /** 只看最近一次同步新增的（没同步过则 0 篇） */
+      last_sync_only?: boolean;
     } = {},
   ): Promise<PageOf<PaperRead>> {
     const params = new URLSearchParams();
@@ -3044,6 +3046,7 @@ export const api = {
     if (opts.created_from) params.set('created_from', opts.created_from);
     if (opts.created_to) params.set('created_to', opts.created_to);
     if (opts.daily_only) params.set('daily_only', 'true');
+    if (opts.last_sync_only) params.set('last_sync_only', 'true');
     const qs = params.toString();
     return request<PageOf<PaperRead>>(`/projects/${projectId}/papers${qs ? `?${qs}` : ''}`);
   },
@@ -3436,8 +3439,10 @@ export const api = {
       published_to?: string;
       created_from?: string;
       created_to?: string;
-      /** 只看从每日论文池自动收录的（今日新收录视图） */
+      /** 只看从每日论文池自动收录的 */
       daily_only?: boolean;
+      /** 只看最近一次同步新增的（没同步过则 0 篇） */
+      last_sync_only?: boolean;
     } = {},
   ): Promise<PageOf<PaperRead>> {
     const params = new URLSearchParams();
@@ -3457,6 +3462,7 @@ export const api = {
     if (opts.created_from) params.set('created_from', opts.created_from);
     if (opts.created_to) params.set('created_to', opts.created_to);
     if (opts.daily_only) params.set('daily_only', 'true');
+    if (opts.last_sync_only) params.set('last_sync_only', 'true');
     const qs = params.toString();
     return request<PageOf<PaperRead>>(`/libraries/${id}/papers${qs ? `?${qs}` : ''}`);
   },


### PR DESCRIPTION
Three changes to the daily papers page and the library list.

## 1. Which libraries hold this paper — moved into the detail pane

It was wedged into the top badge row; it now sits directly under **My tags**. Both answer "where does this paper belong on the platform", so they read as one group.

`CollectingLibraries` gained a standalone variant: with a full row to work with it shows six libraries instead of two, and its empty state now says so explicitly. Squeezed into a badge row, "no libraries" should take no space; as its own row, "none yet" is itself useful information.

The library filter is gone from advanced search.

## 2. Date is a stepper again, with an "all" checkbox

```
‹ Prev    07-28 · 435    Next ›    ☑ All
```

Checked (the default) shows every day at once; unchecking enables the arrows. One detail worth stating: stepping moves between **days that actually have papers**, not calendar days — arXiv does not announce at weekends, so a calendar-based stepper walks you into empty pages. Unchecking "All" lands on the latest day so you do not have to click again.

The date field is gone from advanced search.

## 3. "New today" never matched anything — the predicate was wrong

It filtered on **added today** (`created_from = today 00:00`). If the last sync ran yesterday, today is permanently zero. That is not a display bug; the criterion itself was the wrong one.

It now filters on **what the last sync added**: the most recent `wiki_ingest` run for that library, counting memberships created at or after it. A library that has never synced returns zero rather than falling back to everything. The view is renamed **Latest batch**, since it tracks sync rounds rather than calendar days.

Implemented per library — with several libraries in scope, each contributes its own threshold, so a project spanning libraries that synced at different times still gets the right answer for each.

## Verification

Full backend suite: **915 passed**. `ruff check app tests` clean. `tsc --noEmit` and `vite build` pass.

Two new tests, both sensitivity-checked against removing the filter.

Worth recording: the first version of the "follows the last sync" test only asserted that the expected paper *was* in the results — which is also true with no filter at all, so it proved nothing. My first sensitivity check caught that, and it now also asserts that a paper added *before* the last sync is excluded. That is the assertion that actually discriminates.

`test_unlimited_bootstrap_uncapped` (issue #234) did not fire in this run.