### PR TITLE
fix(daily): a candidate is not "already in the library"

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -980,6 +980,11 @@ async def compile_entry_wiki(
 # ---- 收录到各类库 ----
 
 
+#: 手动收录时可以被「提升」为 included 的既有状态。已经在库内的（scored/fetched/
+#: compiled/included）保持原样，不该被一次手动收录降级或重置。
+PROMOTABLE_ON_MANUAL_COLLECT = ("candidate", "excluded")
+
+
 async def entry_collections(
     session: AsyncSession, *, entry_id: uuid.UUID, user_id: uuid.UUID
 ) -> dict[str, Any]:
@@ -987,10 +992,18 @@ async def entry_collections(
     entry = await session.get(DailyFeedEntry, entry_id)
     if entry is None:
         raise DailyEntryNotFoundError(str(entry_id))
+    # 只算**真正进了库**的状态，与 papers.collecting_libraries 和列表口径一致。
+    # 以前不过滤，于是刚被粗排选中、还没打分的 candidate 也显示成「已在库中」，
+    # 复选框还被禁用——想手动收进去都点不了。excluded（回收站）同理。
+    from app.services.papers import PAPER_STATUS_GROUPS
+
     library_ids = (
         (
             await session.execute(
-                select(LibraryPaper.library_id).where(LibraryPaper.paper_id == entry.paper_id)
+                select(LibraryPaper.library_id).where(
+                    LibraryPaper.paper_id == entry.paper_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
             )
         )
         .scalars()
@@ -1048,11 +1061,20 @@ async def collect_papers(
             continue
         added = skipped = 0
         for paper in papers:
-            _, created = await ensure_membership(
+            membership, created = await ensure_membership(
                 session, library_id=library_id, paper_id=paper.id, status="included"
             )
-            added += int(created)
-            skipped += int(not created)
+            if created:
+                added += 1
+            elif membership.status in PROMOTABLE_ON_MANUAL_COLLECT:
+                # 人已经明确说「收进这个库」，那就照做：候选（还没轮到打分）和
+                # 回收站里的（自动淘汰过）都提升为人工纳入，而不是静默跳过——
+                # 否则勾了确认却什么也没发生。
+                membership.status = "included"
+                membership.trash_reason = None
+                added += 1
+            else:
+                skipped += 1
         await session.commit()
         results.append(
             {

--- a/src/backend/tests/test_daily_library_visibility.py
+++ b/src/backend/tests/test_daily_library_visibility.py
@@ -289,3 +289,67 @@ async def test_latest_batch_is_empty_when_the_library_never_synced(client):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["items"] == []
+
+
+async def test_candidate_is_not_reported_as_already_in_the_library(client):
+    """粗排选中但还没打分的 candidate，不能显示成「已在库中」。
+
+    线上碰到的：VetClaw 那篇刚被 CUA 的向量粗排捞进候选队列（status=candidate、
+    还没打分），收录弹窗却标成「已在库中」并把复选框禁用了——想手动收进去都点不了。
+    库内的口径是 PAPER_STATUS_GROUPS["library"]，candidate 不在其中。
+    """
+    from sqlalchemy import select as sa_select
+
+    from app.models.daily_feed import DailyFeedEntry
+    from app.models.library_direction import LibraryPaper
+
+    _pid, headers, _collected, passed_id, library_id = await _setup(client)
+
+    async with get_sessionmaker()() as session:
+        # passed_id 那篇在 _setup 里就是 candidate
+        membership = (
+            await session.execute(sa_select(LibraryPaper).where(LibraryPaper.paper_id == passed_id))
+        ).scalar_one()
+        assert membership.status == "candidate"
+        entry_id = (
+            await session.execute(
+                sa_select(DailyFeedEntry.id).where(DailyFeedEntry.paper_id == passed_id)
+            )
+        ).scalar_one()
+
+    resp = await client.get(f"/api/daily/papers/{entry_id}/collections", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert str(library_id) not in resp.json()["direction_library_ids"], (
+        "candidate 被当成了「已在库中」"
+    )
+
+
+async def test_manual_collect_promotes_a_candidate_instead_of_skipping_it(client):
+    """人明确勾选「收进这个库」时，已有的 candidate 行要提升为 included。
+
+    否则复选框放开了也没用：ensure_membership 遇到已有行直接返回，状态原封不动，
+    勾了确认却什么都没发生。
+    """
+    from sqlalchemy import select as sa_select
+
+    from app.models.library_direction import LibraryPaper
+
+    _pid, headers, _collected, passed_id, library_id = await _setup(client)
+
+    resp = await client.post(
+        "/api/daily/collect",
+        json={
+            "paper_ids": [str(passed_id)],
+            "direction_library_ids": [str(library_id)],
+            "topic_ids": [],
+            "personal": False,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    async with get_sessionmaker()() as session:
+        membership = (
+            await session.execute(sa_select(LibraryPaper).where(LibraryPaper.paper_id == passed_id))
+        ).scalar_one()
+        assert membership.status == "included", "手动收录没有把 candidate 提升为 included"

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -623,7 +623,8 @@ export function DailyPage() {
   const [showAll, setShowAll] = useState(true);
   const [day, setDay] = useState('');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
-  const [advOpen, setAdvOpen] = useState(true);
+  // 默认收起：日期切换已经在工具栏上，高级条件是偶尔才用的东西
+  const [advOpen, setAdvOpen] = useState(false);
   const [category, setCategory] = useState('');
   const [announce, setAnnounce] = useState<AnnounceFilter>(DEFAULT_ANNOUNCE);
   // 作者 / 机构：手填，或在右栏详情里点作者名、点机构 chip 带进来


### PR DESCRIPTION
## What was seen

The collect dialog listed **CUA** as *已在库中* for `VetClaw: An Edge-Cloud Multimodal Agentic System for Veterinary Disease Screening`, with the checkbox checked and disabled — so the paper could not be added to CUA by hand.

In the database that row is `status=candidate`: pulled in by the vector pre-rank, not yet scored, and by the platform's own definition **not in the library**. `PAPER_STATUS_GROUPS["library"]` is `scored / fetched / compiled / included`.

## Two layers

**The query had no status filter.**

```python
select(LibraryPaper.library_id).where(LibraryPaper.paper_id == entry.paper_id)
```

The topic branch immediately below it correctly filters `trashed_at.is_(None)`; the library side was the outlier. It now uses the same status group as `papers.collecting_libraries` and the list views, so `candidate` and `excluded` stop counting as "in".

**Fixing only that would not have helped.** Manual collection calls `ensure_membership(status="included")`, which returns an existing row untouched. Enabling the checkbox would have made ticking it a silent no-op — the row stays `candidate`, the click is counted as skipped, and nothing visibly happens.

Manual collection now promotes `candidate` and `excluded` rows to `included`. The user has explicitly said "put this in the library", which also covers pulling one back out of the recycle bin. Rows already in the library keep their status — a manual collect must not demote or reset them.

## Why the two surfaces disagreed

The **已收录 badge** in the detail pane was already correct: `collecting_libraries` filters by status, so it never listed CUA for this paper. Only the dialog was wrong, which is exactly why the UI contradicted itself.

## Also

The daily page's advanced search now starts collapsed. Date stepping moved to the toolbar in #237, so the panel holds only occasional filters.

## Verification

Full backend suite: **927 passed**. `ruff check app tests` clean. `tsc --noEmit` and `vite build` pass.

Two new tests, both sensitivity-checked by running them against `origin/main`'s `daily_feed.py`, which fails both.

## Related, not fixed here

VetClaw is a veterinary disease-screening paper; it has nothing to do with computer-use agents. It reached CUA's candidate queue because **CUA's statement is three letters**, which makes the vector pre-rank close to noise. The interview added in #232 is the fix for that, applied per library.