### PR TITLE
feat(digest): give the daily digest its own model route, and degrade instead of failing the sync

### DIFF
--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -77,6 +77,11 @@ _CAPABILITY_STAGES = frozenset({"embedding", "rerank"})
 # rerank 不在此列：它是逐条打分，不涉及跨调用可比性，各用各的没有问题。
 GLOBAL_ONLY_STAGES = frozenset({"embedding"})
 
+# 新环节拆出来时的兼容回退：没显式配路由就沿用原来那个环节的，行为不变。
+# digest 原先是直接复用 librarian 的调用，拆开只是为了能单独设模型——
+# 存量部署不配也不该因此改变行为（default 路由指向的往往是另一类模型）。
+_STAGE_ROUTE_FALLBACKS = {"digest": "librarian"}
+
 
 @dataclass(slots=True, frozen=True)
 class ResolvedRoute:
@@ -123,10 +128,15 @@ _STREAM_FLUSH_CHARS = 80  # token 增量攒到此长度再广播一段（节流�
 _SHORT_CALL = (60.0, 2)  # (timeout 秒, 最多尝试次数) → 最坏 60+3+60 = 123s
 _LONG_CALL = (300.0, 4)
 
+# 「要给长耐心」与「要流式播出去」是两件事，不能共用一个集合。
+# digest 就是反例：它输出 JSON（不该流式，否则整段 JSON 灌进任务终端日志），
+# 但一次要为一批论文生成洞察，实测 p95 313 秒，必须给长档预算。
+_LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest"})
+
 
 def call_profile(stage: str) -> tuple[float, int]:
     """该环节单次调用的 (超时, 最大尝试次数)。"""
-    return _LONG_CALL if stage in STREAM_STAGES else _SHORT_CALL
+    return _LONG_CALL if stage in _LONG_CALL_STAGES else _SHORT_CALL
 
 
 class LLMRouter:
@@ -267,6 +277,8 @@ class LLMRouter:
         owner_id = await self._effective_owner(user_id, stage)
         routes = await self._get_routes(owner_id)
         route = routes.get(stage)
+        if route is None and (inherited := _STAGE_ROUTE_FALLBACKS.get(stage)):
+            route = routes.get(inherited)
         if route is None:
             if stage in _CAPABILITY_STAGES:
                 if not routes and get_settings().llm_fake_fallback:

--- a/src/backend/app/services/research_digest.py
+++ b/src/backend/app/services/research_digest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from datetime import date
 from typing import Any
@@ -20,6 +21,8 @@ from app.models.research_digest import LibraryResearchDigest
 from app.models.voyage import VoyageRun
 from app.services import concepts as concepts_service
 from app.services.libraries import library_definition
+
+logger = logging.getLogger(__name__)
 
 PAPER_INSIGHTS_SYSTEM_PROMPT = """\
 POLARIS_DAILY_DIGEST
@@ -115,8 +118,13 @@ async def _generate_insight_batch(
     preferred_concepts: list[str],
     user_id: uuid.UUID | None,
     extra_guidance: str,
-) -> tuple[dict[str, dict[str, Any]], str | None, int]:
-    """生成一批逐篇看点；模型漏项时只把缺失论文送回去补跑，最多三轮。"""
+) -> tuple[dict[str, dict[str, Any]], str | None, int, str | None]:
+    """生成一批逐篇看点；模型漏项时只把缺失论文送回去补跑，最多三轮。
+
+    返回 (已生成的洞察, 模型名, 重试次数, 失败原因或 None)。三轮之后仍有缺失也
+    **不抛错**：把已经拿到的那部分交回去，缺的记进原因。摘要是附加产物，不该因为
+    模型偶尔漏几篇就把整轮同步打成 paused_error——前面的候选、打分、取全文、编译、
+    概念上链都已经落库了。"""
     expected = {item["paper_id"]: item for item in papers}
     pending = list(papers)
     collected: dict[str, dict[str, Any]] = {}
@@ -139,7 +147,7 @@ async def _generate_insight_batch(
         )
         try:
             result = await llm.complete(
-                "librarian",
+                "digest",
                 [
                     Message(
                         role="system",
@@ -169,7 +177,7 @@ async def _generate_insight_batch(
                     collected[paper_id] = item
             pending = [item for item in papers if item["paper_id"] not in collected]
             if not pending:
-                return collected, model, retries
+                return collected, model, retries, None
             last_error = ValueError(
                 f"daily digest batch {batch_index}/{batch_total} omitted {len(pending)} papers"
             )
@@ -180,12 +188,19 @@ async def _generate_insight_batch(
             retries += 1
             await _retry_pause(attempt)
 
+    # 这一批没能生成洞察：记下原因交回给调用方，**不抛错**。
+    # 以前是直接 raise，于是整轮同步被打成 paused_error——前面五步（候选、打分、
+    # 取全文、编译、概念上链）的成果全被最后一步的摘要生成拖死，而摘要本身只是
+    # 附加产物。模型偶尔不把一批论文的 id 全数返回是常态，不该升级成致命错误。
     missing_ids = [item["paper_id"] for item in pending]
     detail = f"; missing={','.join(missing_ids)}" if missing_ids else ""
-    raise ValueError(
-        f"daily digest batch {batch_index}/{batch_total} failed after "
+    reason = (
+        f"batch {batch_index}/{batch_total} failed after "
         f"{_DIGEST_MAX_ATTEMPTS} attempts: {last_error}{detail}"
     )
+    logger.warning("daily digest %s", reason)
+    # 交回**已经生成的**部分，而不是整批丢掉：前几轮拿到的洞察是有效的
+    return collected, model, retries, reason
 
 
 async def _generate_paper_insights(
@@ -196,7 +211,7 @@ async def _generate_paper_insights(
     papers: list[dict[str, Any]],
     user_id: uuid.UUID | None,
     extra_guidance: str,
-) -> tuple[list[dict[str, Any]], str | None, int, int]:
+) -> tuple[list[dict[str, Any]], str | None, int, int, list[str]]:
     """按固定小批次生成看点，并保持最终顺序与输入论文一致。"""
     direction = library_definition(library)
     batches = [
@@ -209,8 +224,9 @@ async def _generate_paper_insights(
     )
     model: str | None = None
     retries = 0
+    failed_batches: list[str] = []
     for index, batch in enumerate(batches, start=1):
-        generated, batch_model, batch_retries = await _generate_insight_batch(
+        generated, batch_model, batch_retries, failure = await _generate_insight_batch(
             llm=llm,
             run=run,
             library=library,
@@ -229,22 +245,26 @@ async def _generate_paper_insights(
         )
         model = batch_model or model
         retries += batch_retries
+        if failure:
+            failed_batches.append(failure)
 
+    # 批次彻底失败时 by_id 不再覆盖全部论文：缺项的论文照样列出来，只是看点退回它自己的
+    # TL;DR。少一句模型措辞，好过让这篇论文从简报里凭空消失。
     insights = [
         item
         | {
-            "highlight": _string(by_id[item["paper_id"]].get("highlight"), item["tldr"]),
+            "highlight": _string(by_id.get(item["paper_id"], {}).get("highlight"), item["tldr"]),
             "direction_relation": _string(
-                by_id[item["paper_id"]].get("direction_relation"),
+                by_id.get(item["paper_id"], {}).get("direction_relation"),
                 item.get("relevance_reason") or "与本库研究方向相关。",
             ),
             "concepts": _generated_concepts(
-                by_id[item["paper_id"]].get("concepts"), item.get("concepts")
+                by_id.get(item["paper_id"], {}).get("concepts"), item.get("concepts")
             ),
         }
         for item in papers
     ]
-    return insights, model, retries, len(batches)
+    return insights, model, retries, len(batches), failed_batches
 
 
 async def _synthesize_digest_summary(
@@ -281,7 +301,7 @@ async def _synthesize_digest_summary(
             prompt += "\n上次综合输出无效，请严格按 JSON schema 重新生成。"
         try:
             result = await llm.complete(
-                "librarian",
+                "digest",
                 [
                     Message(
                         role="system",
@@ -453,6 +473,14 @@ def _render_digest_markdown(
             f"- 概念关联：{int(generation.get('active_concepts') or 0)} 个正式概念；"
             f"新增 {int(generation.get('links_created') or 0)} 条论文关系"
         )
+        failed = generation.get("failed_batches")
+        if isinstance(failed, list) and failed:
+            # 降级说明必须写在正文里：这几批的论文只有 TL;DR，没有模型写的看点，
+            # 否则读者会以为看点写得敷衍，而不知道是模型没出结果。
+            lines.append(
+                f"- ⚠️ {len(failed)} 批未能生成看点，相关论文暂以 TL;DR 代替："
+                + "；".join(str(item) for item in failed)
+            )
     messages = diagnostics.get("messages") if isinstance(diagnostics.get("messages"), list) else []
     if messages:
         lines.extend(["", "### 来源诊断", ""] + [f"- {message}" for message in messages])
@@ -552,6 +580,7 @@ async def create_daily_digest(
             insight_model,
             insight_retries,
             batch_count,
+            insight_failures,
         ) = await _generate_paper_insights(
             llm=llm,
             run=run,
@@ -587,6 +616,8 @@ async def create_daily_digest(
             "batch_size": _DIGEST_BATCH_SIZE,
             "batches": batch_count,
             "retries": insight_retries + synthesis_retries,
+            # 哪几批没能生成洞察（以前这里是直接抛错、整轮同步被打成 paused_error）
+            "failed_batches": insight_failures,
             **concept_stats,
         }
         model = synthesis_model or insight_model
@@ -755,7 +786,7 @@ async def synthesize_rolling_trends(
         ],
     }
     result = await llm.complete(
-        "librarian",
+        "digest",
         [
             Message(role="system", content=TREND_SYSTEM_PROMPT + extra_guidance),
             Message(role="user", content=json.dumps(payload, ensure_ascii=False)),

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -257,3 +257,82 @@ def test_profile_is_part_of_the_provider_cache_key():
     router._provider_for(route, "relevance")
     router._provider_for(route, "librarian")
     assert len(router._providers) == 2, "长短档共用了同一个客户端"
+
+
+# ---- digest 拆成独立 stage（可单独设模型）----
+
+
+def test_digest_gets_the_long_call_budget_without_streaming():
+    """digest 输出 JSON，不该流式；但它一次为一批论文生成洞察，必须给长档预算。
+
+    「要给长耐心」与「要流式播出去」是两件事。#229 里我把耐心绑在 STREAM_STAGES 上，
+    digest 正是反例——流式会把整段 JSON 灌进任务终端日志，而 60 秒预算又盖不住它
+    实测 313 秒的 p95。
+    """
+    from app.core.llm.router import STREAM_STAGES, call_profile
+
+    timeout, attempts = call_profile("digest")
+    assert timeout >= 300, f"digest 超时 {timeout}s 太短，实测 p95 就有 313s"
+    assert attempts >= 3
+    assert "digest" not in STREAM_STAGES, "digest 输出 JSON，不该流式"
+
+
+async def test_digest_falls_back_to_the_librarian_route_when_unset(client, monkeypatch):
+    """没显式配 digest 路由时沿用 librarian 的，存量部署行为不变。
+
+    digest 原先就是直接复用 librarian 的调用，拆出来只为能单独设模型。若回退到
+    default，存量部署会悄悄换成另一类模型——那不是拆分该带来的后果。
+    """
+    from app.core.llm.router import LLMRouter, ResolvedRoute
+
+    router = LLMRouter()
+    librarian_route = ResolvedRoute(
+        provider_kind="fake",
+        base_url=None,
+        api_key="",
+        model="librarian-model",
+        temperature=None,
+        provider_name="fake",
+        effort=None,
+    )
+    default_route = ResolvedRoute(
+        provider_kind="fake",
+        base_url=None,
+        api_key="",
+        model="default-model",
+        temperature=None,
+        provider_name="fake",
+        effort=None,
+    )
+
+    async def fake_routes(owner_id):
+        return {"librarian": librarian_route, "default": default_route}
+
+    monkeypatch.setattr(router, "_get_routes", fake_routes)
+    _provider, route = await router.resolve("digest")
+    assert route.model == "librarian-model", "应当沿用 librarian，而不是掉到 default"
+
+
+async def test_an_explicit_digest_route_wins_over_the_fallback(client, monkeypatch):
+    """显式配了 digest 就用它——拆分的意义就在这里。"""
+    from app.core.llm.router import LLMRouter, ResolvedRoute
+
+    router = LLMRouter()
+
+    def _route(model):
+        return ResolvedRoute(
+            provider_kind="fake",
+            base_url=None,
+            api_key="",
+            model=model,
+            temperature=None,
+            provider_name="fake",
+            effort=None,
+        )
+
+    async def fake_routes(owner_id):
+        return {"digest": _route("digest-model"), "librarian": _route("librarian-model")}
+
+    monkeypatch.setattr(router, "_get_routes", fake_routes)
+    _provider, route = await router.resolve("digest")
+    assert route.model == "digest-model"

--- a/src/backend/tests/test_research_digest_batching.py
+++ b/src/backend/tests/test_research_digest_batching.py
@@ -23,7 +23,7 @@ class _RetryingDigestLLM:
         self.synthesis_calls = 0
 
     async def complete(self, stage, messages, **kwargs):
-        assert stage == "librarian"
+        assert stage == "digest"
         system = messages[0].content
         user = messages[-1].content
         paper_ids = list(dict.fromkeys(re.findall(r'"paper_id"\s*:\s*"([^"]+)"', user)))
@@ -95,7 +95,13 @@ async def test_digest_batches_retry_only_missing_then_retry_synthesis():
     ]
     llm = _RetryingDigestLLM()
 
-    insights, model, insight_retries, batch_count = await _generate_paper_insights(
+    (
+        insights,
+        model,
+        insight_retries,
+        batch_count,
+        failures,
+    ) = await _generate_paper_insights(
         llm=llm,
         run=run,
         library=library,
@@ -112,6 +118,7 @@ async def test_digest_batches_retry_only_missing_then_retry_synthesis():
     assert insights[0]["concepts"] == ["Agent 工作流", "反馈闭环"]
     # 10 篇首批漏 1 篇后，只补跑缺失的 1 篇；其余两批仍为 10 / 3。
     assert [len(ids) for ids in llm.batch_prompt_ids] == [10, 1, 10, 3]
+    assert failures == [], "补跑成功就不该记失败"
 
     summary, signals, model, synthesis_retries = await _synthesize_digest_summary(
         llm=llm,
@@ -126,3 +133,93 @@ async def test_digest_batches_retry_only_missing_then_retry_synthesis():
     assert model == "fake-summary"
     assert synthesis_retries == 1
     assert llm.synthesis_calls == 2
+
+
+class _AlwaysMissingDigestLLM:
+    """指定的几篇论文永远不返回，其余都正常——模拟模型对某几篇死活不出结果。"""
+
+    def __init__(self, doomed_ids: set[str]) -> None:
+        self.doomed_ids = doomed_ids
+        self.calls = 0
+
+    async def complete(self, stage, messages, **kwargs):
+        assert stage == "digest"
+        user = messages[-1].content
+        paper_ids = list(dict.fromkeys(re.findall(r'"paper_id"\s*:\s*"([^"]+)"', user)))
+        self.calls += 1
+        return CompletionResult(
+            content=json.dumps(
+                {
+                    "paper_insights": [
+                        {
+                            "paper_id": paper_id,
+                            "highlight": f"看点-{paper_id[-2:]}",
+                            "direction_relation": "直接相关",
+                            # 概念是简报必填项，空数组会被当成漏项——这里给足，只用
+                            # doomed_ids 控制"哪几篇模型死活不返回"。
+                            "concepts": ["Agent 工作流"],
+                        }
+                        for paper_id in paper_ids
+                        if paper_id not in self.doomed_ids
+                    ]
+                }
+            ),
+            model="fake-batch",
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_batch_that_never_completes_degrades_instead_of_raising():
+    """一批三轮补跑仍缺，就交回已拿到的部分并记原因——不能把整轮同步打成 paused_error。
+
+    简报是附加产物：以前这里抛 RuntimeError，模型偶尔漏几篇就会让整次库同步失败，
+    连已经打分入库的论文都看不到简报。
+    """
+    library_id = uuid.uuid4()
+    library = DirectionLibrary(
+        id=library_id, name="降级测试库", definition={"statement": "agent harness"}
+    )
+    run = VoyageRun(
+        id=uuid.uuid4(),
+        kind="wiki_ingest",
+        goal="生成今日简报",
+        library_id=library_id,
+        created_by=uuid.uuid4(),
+    )
+    papers = [
+        {
+            "paper_id": str(uuid.uuid4()),
+            "title": f"Paper {index}",
+            "tldr": f"TLDR {index}",
+            "relevance_reason": "符合方向",
+            "concepts": [],
+        }
+        for index in range(20)
+    ]
+
+    # 只让第二批里的一篇死活不出结果
+    llm = _AlwaysMissingDigestLLM(doomed_ids={papers[12]["paper_id"]})
+    insights, model, retries, batch_count, failures = await _generate_paper_insights(
+        llm=llm,
+        run=run,
+        library=library,
+        papers=papers,
+        user_id=run.created_by,
+        extra_guidance="",
+    )
+
+    assert batch_count == 2
+    assert model == "fake-batch"
+    assert len(failures) == 1, f"坏批次应当恰好记一条原因：{failures}"
+    assert "batch 2/2" in failures[0] and papers[12]["paper_id"] in failures[0]
+    # 20 篇一篇不少，其余 19 篇拿到模型的看点，缺的那篇退回自己的 TL;DR
+    assert [item["paper_id"] for item in insights] == [item["paper_id"] for item in papers]
+    stuck = next(i for i in insights if i["paper_id"] == papers[12]["paper_id"])
+    assert stuck["highlight"] == papers[12]["tldr"]
+    assert stuck["direction_relation"] == "符合方向"
+    assert all(
+        item["highlight"].startswith("看点-")
+        for item in insights
+        if item["paper_id"] != papers[12]["paper_id"]
+    )
+    assert retries == 2, "该批应当补跑到上限（共三轮）"

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -479,6 +479,7 @@ export const LLM_STAGES = [
   'sextant',
   'relevance',
   'librarian',
+  'digest',
   'extract',
   'reading',
   'embedding',

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -10,6 +10,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   sextant: { zh: '自动校验', en: 'Auto verification' },
   relevance: { zh: '相关度打分', en: 'Relevance scoring' },
   librarian: { zh: '图文精读编译', en: 'Paper compile (with figures)' },
+  digest: { zh: '每日研究简报', en: 'Daily research digest' },
   extract: { zh: '结构化抽取', en: 'Structured extraction' },
   reading: { zh: 'AI 伴读对话', en: 'Reading companion chat' },
   embedding: { zh: '向量嵌入', en: 'Embeddings' },


### PR DESCRIPTION
## Why

Two problems with the daily research digest, both surfaced while operating it in production.

**1. Its model was not independently configurable.** The digest borrowed the `librarian` route, so pointing it at a different model also moved wiki compilation. `librarian` currently averages 122.9s with 11% failures — you may well want the digest somewhere else, but not at the cost of changing compilation too.

**2. One incomplete batch failed the entire sync.** If the model omitted paper ids from a batch three attempts in a row, `_generate_insight_batch` raised. The digest is the last step of `wiki_ingest`, so the whole run went to `paused_error` — throwing away the visible outcome of the five steps before it (candidates, relevance scoring, full-text fetch, compilation, concept linking). The digest is an additive product; a model that skips a few ids is routine, not fatal.

## What changed

**Its own stage**
- New `digest` route in the admin model-routing table, plus its label in the frontend.
- `_STAGE_ROUTE_FALLBACKS = {"digest": "librarian"}` — an unset `digest` route inherits the `librarian` one, so existing deployments keep their current model instead of silently dropping to `default`.
- Patience is now decoupled from streaming. `call_profile()` used to grant the long profile (300s, 4 attempts) only to `STREAM_STAGES`; the digest does not stream but needs exactly that patience, hence `_LONG_CALL_STAGES = STREAM_STAGES | {"digest"}`.

**Degrade instead of fail**
- `_generate_insight_batch` no longer raises. It returns the insights it did collect plus a reason string; earlier attempts' results are kept rather than discarded.
- Reasons land in `digest_generation.failed_batches` and in a `logger.warning`.
- Papers with no model insight still appear in the digest, with their own TL;DR as the highlight. A missing sentence of model prose beats a paper vanishing from the report.
- The digest body carries a visible line about the degradation — otherwise a reader assumes the highlights were written lazily rather than not written at all.

## On streaming

Not added. All three digest prompts (`PAPER_INSIGHTS_SYSTEM_PROMPT`, `DIGEST_SYNTHESIS_SYSTEM_PROMPT`, `TREND_SYSTEM_PROMPT`) instruct the model to emit a single JSON object, so streaming would push raw JSON into `voyage_terminal_logs` with nothing readable in it. The patience change above is what the digest actually needed from the streaming stages. Flipping streaming on is a one-line change if progress visibility turns out to be worth the noise.

## Tests

- `test_llm_router.py` (3 new): digest gets the 300s profile and is not in `STREAM_STAGES`; an unset digest route falls back to librarian; an explicit digest route wins.
- `test_research_digest_batching.py` (1 new + updated): a batch whose papers the model never returns degrades — 20 papers still come back, 19 with model highlights, the stuck one with its own TL;DR, exactly one failure reason recorded, and no exception. The existing retry test now asserts `failed_batches == []`.
- Reverse-checked: both digest tests fail against `origin/main`'s `research_digest.py`.
- Full backend suite: **931 passed**. `ruff check app` and frontend `tsc --noEmit` clean.

Touches the code path added by #236.