### PR TITLE
fix(ingest): stamp scored papers with the run id instead of a time window

### DIFF
--- a/src/backend/alembic/versions/78e222c38b3b_library_papers_scored_run_id.py
+++ b/src/backend/alembic/versions/78e222c38b3b_library_papers_scored_run_id.py
@@ -1,0 +1,47 @@
+"""stamp library_papers with the run that scored them
+
+后续步骤（取全文/编译/简报）以前按 ``scored_at >= run.created_at`` 认「本次收下的
+那批论文」，墙钟回拨或 API/worker 时钟偏差会让刚打完分的论文落在窗口外被静默丢掉。
+改成打分时记下运行 id，恒等比较，与时钟无关。
+
+Revision ID: 78e222c38b3b
+Revises: e6a1c9d4f207
+Create Date: 2026-07-30 10:30:13.041541
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "78e222c38b3b"
+down_revision: str | None = "e6a1c9d4f207"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("library_papers", sa.Column("scored_run_id", sa.Uuid(), nullable=True))
+    op.create_index(
+        "ix_library_papers_scored_run_id", "library_papers", ["scored_run_id"], unique=False
+    )
+    # sqlite 不支持 ALTER TABLE ADD CONSTRAINT（要整表重建），存量 sqlite 库跳过外键
+    if op.get_bind().dialect.name != "sqlite":
+        op.create_foreign_key(
+            "fk_library_papers_scored_run_id",
+            "library_papers",
+            "voyage_runs",
+            ["scored_run_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "sqlite":
+        op.drop_constraint("fk_library_papers_scored_run_id", "library_papers", type_="foreignkey")
+    op.drop_index("ix_library_papers_scored_run_id", table_name="library_papers")
+    op.drop_column("library_papers", "scored_run_id")

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -240,11 +240,16 @@ def _scored_in_this_run(ctx: ActionContext):
     「本次通过筛选 1 篇」后面跟着「下载 12 个 PDF」——两个数字统计的不是同一批
     论文，看着像对不上。
 
-    按 ``scored_at >= 本次运行创建时刻`` 筛，而不是靠 checkpoint 记 id：步骤中途
+    按打分时写进成员行的 ``scored_run_id`` 筛，而不是靠 checkpoint 记 id：步骤中途
     崩溃、恢复后重跑时，checkpoint 里那份记录会丢，崩溃前已打分的论文就再也进不了
-    后续步骤；而 scored_at 落在库里，恢复后照样认得出来。
+    后续步骤；而 scored_run_id 落在库里，恢复后照样认得出来。
+
+    也不用 ``scored_at >= run.created_at`` 划时间窗口：那两个时间戳分别取自建任务时刻
+    和打分时刻的系统墙钟，只要中间发生 NTP 回拨（或 API 与 worker 不在一台机器上、
+    时钟有偏差），刚打完分的论文就会落在窗口外，被静默排除在取全文/编译之外——
+    生产上「已打分却没全文」的积压正是这么来的。运行 id 是恒等比较，与时钟无关。
     """
-    return LibraryPaper.scored_at >= ctx.run.created_at
+    return LibraryPaper.scored_run_id == ctx.run.id
 
 
 async def _insert_pooled_with_retry(

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -104,6 +104,12 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 进回收站的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
     trash_reason: Mapped[str | None] = mapped_column(String(16))
     scored_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 最后一次给这行打分的同步任务 id：后续步骤（取全文/编译/简报）靠它认出「本次收下的
+    # 那批论文」。以前按 scored_at >= run.created_at 划窗口，两个时间戳分别取自不同时刻的
+    # 系统墙钟，NTP 回拨/多机时钟偏差都会让刚打完分的论文落在窗口外被静默丢掉。
+    scored_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("voyage_runs.id", ondelete="SET NULL"), index=True
+    )
     # 退役列（编译时间/模型随解读走 paper_wikis）：同上，只留存量数据。
     compiled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     compiled_model: Mapped[str | None] = mapped_column(String(255))

--- a/src/backend/app/services/paper_merge.py
+++ b/src/backend/app/services/paper_merge.py
@@ -56,6 +56,7 @@ _FILLABLE_MEMBERSHIP_FIELDS = (
     "relevance_score",
     "tldr_note",
     "scored_at",
+    "scored_run_id",  # 跟着 scored_at 走，合并后仍认得出是哪次同步收下的
 )
 
 # 阅读状态推进序（冲突时取两边更靠后的）

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -122,7 +122,7 @@ async def score_paper_relevance(
     project_id: uuid.UUID | None = None,
     voyage_id: uuid.UUID | None = None,
 ) -> RelevanceResult:
-    """对一篇论文打相关性分：写成员行 relevance_score/scored_at 与论文 tldr。
+    """对一篇论文打相关性分：写成员行 relevance_score/scored_at/scored_run_id 与论文 tldr。
 
     不改成员行 status、不 commit（由调用方决定状态转移与落库时机）。
     extra_guidance：追加到 system prompt 的补充指引（voyage 技能注入点用）。
@@ -145,6 +145,7 @@ async def score_paper_relevance(
     membership.relevance_score = score
     paper.tldr = str(data.get("tldr") or "") or paper.tldr
     membership.scored_at = utcnow()
+    membership.scored_run_id = voyage_id  # 手动加论文没有任务，留 NULL
     return RelevanceResult(score=score, reason=str(data.get("reason") or ""), tldr=paper.tldr or "")
 
 

--- a/src/backend/app/services/research_digest.py
+++ b/src/backend/app/services/research_digest.py
@@ -402,7 +402,9 @@ async def _run_members(
         if paper_ids
         else (
             LibraryPaper.scored_at.is_not(None),
-            LibraryPaper.scored_at >= run.created_at,
+            # 同 actions_wiki._scored_in_this_run：按运行 id 认本次那批，不按时间窗口
+            # （墙钟回拨/多机时钟偏差会让刚打完分的论文落在窗口外）
+            LibraryPaper.scored_run_id == run.id,
         )
     )
     return list(

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -224,7 +224,7 @@ def test_parse_and_strip_block_good():
 
 
 def test_parse_and_strip_block_bad_json():
-    content = "正文B\n<<<POLARIS_AFFILIATIONS\n[{\"name\": broken OOPS]\nPOLARIS_AFFILIATIONS>>>\n"
+    content = '正文B\n<<<POLARIS_AFFILIATIONS\n[{"name": broken OOPS]\nPOLARIS_AFFILIATIONS>>>\n'
     stripped, mapping = parse_and_strip_affiliation_block(content)
     assert "POLARIS_AFFILIATIONS" not in stripped  # 坏 JSON 也要剥净
     assert stripped == "正文B\n"
@@ -233,7 +233,7 @@ def test_parse_and_strip_block_bad_json():
 
 def test_parse_and_strip_block_unclosed_marker():
     """模型只吐了开头标记、没闭合 → 从裸标记删到文末，绝不漏进 wiki。"""
-    content = "## TL;DR\n\n正文C。\n\n---\n<<<POLARIS_AFFILIATIONS\n[{\"name\": \"Alice\"}]"
+    content = '## TL;DR\n\n正文C。\n\n---\n<<<POLARIS_AFFILIATIONS\n[{"name": "Alice"}]'
     stripped, mapping = parse_and_strip_affiliation_block(content)
     assert "POLARIS_AFFILIATIONS" not in stripped
     assert stripped == "## TL;DR\n\n正文C。\n"
@@ -386,14 +386,12 @@ async def _setup_scored_paper(
         )
         session.add_all([paper, run])
         await session.flush()
-        # 真实流程里是先建运行、再逐篇打分，所以 scored_at 一定落在运行创建之后。
-        # 取全文那步只处理「本次运行收下的」，靠的就是这个时刻。
+        # 取全文那步只处理「本次运行收下的」——打分时会把运行 id 写在成员行上，这里补齐。
         membership = (
-            await session.execute(
-                select(LibraryPaper).where(LibraryPaper.paper_id == paper.id)
-            )
+            await session.execute(select(LibraryPaper).where(LibraryPaper.paper_id == paper.id))
         ).scalar_one()
         membership.scored_at = run.created_at
+        membership.scored_run_id = run.id
         await session.commit()
         await session.refresh(paper)
         await session.refresh(run)

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
+HEAD_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
+DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
 INLINE_VECTOR_DROP_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
 VECTOR_TABLES_REVISION = "5d8ebd5cb100"  # 向量侧表建表 + 存量搬迁
 EFFORT_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
@@ -328,8 +329,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "trend_content",
     } <= columns["library_research_digests"]
     assert "relevance_reason" in columns["library_papers"]
+    assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉每日简报表与相关性理由。
+    # 最新 revision 可往返：先退掉成员行上的打分任务 id。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == DIGEST_REVISION
+    assert "scored_run_id" not in columns["library_papers"]
+
+    # 再退掉每日简报表与相关性理由。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == INLINE_VECTOR_DROP_REVISION

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import uuid
+from datetime import timedelta
 
 import fakeredis.aioredis
 import httpx
@@ -468,6 +469,48 @@ class _BreakDailyDigest(FakeProvider):
             images=images,
             effort=effort,
         )
+
+
+async def test_backwards_clock_keeps_scored_papers_in_the_run(
+    client, queue_stub, wiki_mocks, monkeypatch
+):
+    """墙钟回拨也不能把刚打完分的论文丢出本次同步（#234）。
+
+    取全文/编译/简报要认出「本次收下的那批论文」。曾按 ``scored_at >= run.created_at``
+    划时间窗口：两个时间戳分别取自建任务和打分两个时刻的系统墙钟，NTP 回拨、或 API 与
+    worker 不在一台机器上，都会让刚打完分的论文落在窗口外被静默排除——生产上「已打分
+    却没全文」的积压就是这么攒出来的。这里把打分时刻整体拨到建任务之前来钉住这个语义。
+    """
+    import app.services.relevance as relevance_module
+
+    real_utcnow = relevance_module.utcnow
+    monkeypatch.setattr(relevance_module, "utcnow", lambda: real_utcnow() - timedelta(seconds=30))
+
+    project_id, headers = await _setup_project(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/ingest",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    run_id = resp.json()["id"]
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(run_id))
+
+    detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
+    assert detail["status"] == "done", detail
+    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
+    # 3 篇候选里 1 篇不相关被淘汰，剩下 2 篇必须一路走到编译，不因时钟回拨掉队
+    assert detail["steps"][2]["observation"]["processed"] == 2  # 取全文
+    assert detail["steps"][3]["observation"]["processed"] == 2  # 编译
+
+    async with get_sessionmaker()() as session:
+        rows = await project_paper_rows(session, project_id=project_id)
+        assert [m.status for _, m in rows] == ["compiled"] * 2
+        # 打分时刻确实早于建任务（回拨生效），归属仍靠运行 id 认出来
+        run = await session.get(VoyageRun, uuid.UUID(run_id))
+        for _, m in rows:
+            assert m.scored_at < run.created_at
+            assert m.scored_run_id == run.id
 
 
 async def test_daily_digest_failure_does_not_advance_watermark(client, queue_stub, wiki_mocks):


### PR DESCRIPTION
Closes #234

## What it actually is: not test pollution, a stepping wall clock

The premise in the issue ("only fails in full-suite runs → cross-file pollution") does not hold. **Running `test_unlimited_bootstrap_uncapped` on its own fails too**, roughly 1 in 10 times (in a 20-iteration loop it failed on iterations 4, 13 and 15). `pytest-randomly` is not installed, so collection order is already deterministic — which leaves timing as the only source of the flakiness.

The database at the moment of failure:

```
fetch_extract.processed = 167  (expect 210)
by_status = {'compiled': 167, 'scored': 43}
run.created_at   = 10:20:11.963749
min scored_at    = 10:20:11.482774     ← 0.48s *before* the run was created
scored_at < run.created_at : 43
```

43 papers have a `scored_at` earlier than `run.created_at`, so `_scored_in_this_run` (`scored_at >= run.created_at`) drops the whole batch and fetch/compile process dozens fewer papers. The run still reaches `done` with every step marked `passed` — **nothing is raised, nothing is logged**.

Scoring plainly happens after the run is created, yet carries the earlier timestamp, because the dev machine's docker VM clock is not stable:

```
45s sample inside the container, realtime stepping relative to monotonic:
[(0.76s, +0.986), (8.96s, -0.992), (10.81s, +1.012), (18.96s, -1.019),
 (20.78s, +0.981), (28.97s, -0.987), (30.81s, +1.000), (38.97s, -1.006)]
```

It is stepped by ±1 second every ~10 seconds. The POST that creates the run lands in a window where the clock runs 1 second fast; by the time scoring starts the clock has stepped back, and the ordering of the two timestamps inverts.

On the issue's "clock skew is ruled out, both timestamps come from the same Python `utcnow()`": the same function is not the same clock reading. `datetime.now(UTC)` reads CLOCK_REALTIME, which is steppable — two calls to it can come back out of order.

(The assertion recorded in the issue, `["passed"] * 6`, belongs to the pre-#236 six-step version of the test. The same nondeterminism lands on different assertions across versions; on today's eight-step plan it shows up as a count mismatch.)

## This is not only a test problem

In production `run.created_at` is written by the API process and `scored_at` by the worker. **An NTP step backwards, or plain clock skew between an API host and a worker host, drops freshly scored papers out of the window** the same way — silently excluding them from fetch, compile and the digest, leaving rows stuck in `scored`. The caveat #230 left when it introduced this predicate ("runs cut short by the budget leave scored-but-unfetched papers behind") turns out to have a much wider blast radius.

## The fix

Stamp the membership row with the run that scored it (`library_papers.scored_run_id`) and have the downstream steps compare ids. Identity comparison, no clock involved.

- `app/models/library_direction.py`: new `scored_run_id` (FK → `voyage_runs.id`, `ON DELETE SET NULL`, indexed)
- `app/services/relevance.py`: `score_paper_relevance` writes `scored_run_id = voyage_id` (manually added papers have no run, so it stays NULL)
- `app/agents/voyage/actions_wiki.py`: `_scored_in_this_run` becomes `scored_run_id == ctx.run.id`
- `app/services/research_digest.py`: the same time window in the digest fallback goes too
- `app/services/paper_merge.py`: `scored_run_id` travels with `scored_at` when same-library rows are merged
- migration `78e222c38b3b` (sqlite skips ADD CONSTRAINT — column and index only)

**Resume semantics are unchanged**: the run id lives in the database just like `scored_at`, so a crashed step still recognises its own papers after recovery — unlike a checkpoint, which is exactly why #230 avoided one.

## Verification

- New `test_backwards_clock_keeps_scored_papers_in_the_run`: shifts the scoring clock 30 seconds before the run was created and asserts both papers still reach compilation. **Red against the old predicate (`0 == 2`), green after.**
- `test_unlimited_bootstrap_uncapped` passes 20 consecutive runs (before the fix it failed within 3–15).
- Full `pytest`: 932 passed, rebased onto an origin/main that includes #239.
- Two existing tests adapted: `test_affiliations.py` used to hand-align `scored_at = run.created_at` to satisfy the old predicate and now sets `scored_run_id`; `test_migrations.py` covers the new revision's upgrade/downgrade round trip.

## Upgrade note

Existing rows have `scored_run_id` NULL. This only affects syncs that are in flight at the moment of the upgrade — their fetch/compile steps will select zero papers, and re-running the sync clears it. Completed historical data is unaffected.