### PR TITLE
fix(daily): three fixes to the daily pipeline — probe cap, digest visibility, and the fan-out gate

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -63,10 +63,17 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
         "stale_batch_dates": stale,
     }
     if stale and not failed:
-        result["error"] = (
-            f"抓到的是 {'、'.join(stale)} 的公告，不是今天的——多半是跑得比 arXiv 发布还早。"
-            "arXiv 每天约 04:00 UTC（北京 12:00）放当天批次，请把抓取时刻调到其后。"
+        # 抓早了，拿到的是上一批。这**不算失败**：按轮询语义，「今天那批还没发布」是正常
+        # 状态——检查点会继续探（探满上限就当天收工），手动触发也可能落在发布之前。
+        # 以前这里置 error，于是一次手动点击就留下一条 paused_error，而它其实什么也没坏。
+        #
+        # 但痕迹必须留下，否则又退回最初那个问题：条目照样几百条，全是昨天入过池的，
+        # 去重后一条不进，而每一步都报成功。stale_batch_dates + 这行说明就是那道痕迹。
+        result["note"] = (
+            f"抓到的是 {'、'.join(stale)} 的公告，今天那批还没发布——本次不会有新论文入池。"
+            "arXiv 每天约 04:00 UTC（北京 12:00）放当天批次，检查点会继续探。"
         )
+        await ctx.log(result["note"], level="warning")
         return result
     if failed:
         # **任一分类失败就报错**，不是「全都空才报」。部分失败下当天那个分类的论文会

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -36,6 +36,8 @@ from app.schemas.daily import (
     DailyLikeState,
     DailyPage,
     DailyPaperDetail,
+    DailyProbeAttemptsRead,
+    DailyProbeAttemptsUpdate,
     DailyRetentionRead,
     DailyRetentionUpdate,
     DailySyncStatus,
@@ -401,6 +403,30 @@ async def set_sync_time(
     """
     hour, minute = await daily_service.set_sync_time(session, payload.hour, payload.minute)
     return DailySyncTimeRead(hour=hour, minute=minute)
+
+
+@router.get("/probe-attempts", response_model=DailyProbeAttemptsRead)
+async def get_probe_attempts(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DailyProbeAttemptsRead:
+    """一天最多探几次 arXiv 有没有发新批次（全员可读）。"""
+    return DailyProbeAttemptsRead(attempts=await daily_service.get_max_probe_attempts(session))
+
+
+@router.put("/probe-attempts", response_model=DailyProbeAttemptsRead)
+async def set_probe_attempts(
+    payload: DailyProbeAttemptsUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: User = Depends(require_admin),
+) -> DailyProbeAttemptsRead:
+    """改探测次数上限（admin）。
+
+    从抓取时刻起每 15 分钟探一次，探满这么多次仍没有今天的批次就当天收工——
+    这是**正常结束**，不会留下失败的任务。默认 10 次 ≈ 覆盖 2.5 小时。
+    """
+    attempts = await daily_service.set_max_probe_attempts(session, payload.attempts)
+    return DailyProbeAttemptsRead(attempts=attempts)
 
 
 @router.get("/categories", response_model=DailyCategoriesRead)

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -157,6 +157,11 @@ class DailySyncStatus(BaseModel):
     # {分类: {count, status, detail}}
     per_category: dict[str, Any] = Field(default_factory=dict)
     failed_categories: list[str] = Field(default_factory=list)
+    # 今天探了几次 / 上限几次 / 探到的最新批次；探满仍没有新批次是正常结束，不是故障
+    probe_attempts: int = 0
+    probe_max_attempts: int = 0
+    probe_batch_date: str | None = None
+    probe_exhausted: bool = False
 
 
 class DailySyncTimeRead(BaseModel):
@@ -169,6 +174,16 @@ class DailySyncTimeRead(BaseModel):
 class DailySyncTimeUpdate(BaseModel):
     hour: int = Field(ge=0, le=23)
     minute: int = Field(ge=0, le=59)
+
+
+class DailyProbeAttemptsRead(BaseModel):
+    """一天最多探几次 arXiv 有没有发新批次（探测每 15 分钟一次）。"""
+
+    attempts: int = Field(ge=1, le=96)
+
+
+class DailyProbeAttemptsUpdate(BaseModel):
+    attempts: int = Field(ge=1, le=96)
 
 
 class DailyRetentionRead(BaseModel):

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1184,7 +1184,11 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
         failed = list(obs.get("failed_categories") or [])
 
     latest = await session.scalar(select(func.max(DailyFeedEntry.feed_date)))
-    today = dt.datetime.now(dt.UTC).date()
+    now = dt.datetime.now(dt.UTC)
+    today = now.date()
+    # 今天还没抓到新批次时，界面上要能区分「还在探」和「探完了今天就是没有」——
+    # 否则用户只看到「最新是昨天」，无从判断该等还是该查。
+    probe = await probe_state(session, now=now)
     return {
         "latest_feed_date": latest.isoformat() if latest else None,
         "stale": bool(latest is None or (today - latest).days > 1),
@@ -1193,6 +1197,10 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
         "last_run_at": run.created_at.isoformat() if run is not None else None,
         "per_category": per_category,
         "failed_categories": failed,
+        "probe_attempts": probe["attempts"],
+        "probe_max_attempts": await get_max_probe_attempts(session),
+        "probe_batch_date": probe["batch_date"],
+        "probe_exhausted": probe["exhausted"],
     }
 
 
@@ -1239,6 +1247,74 @@ async def set_sync_time(session: AsyncSession, hour: int, minute: int) -> tuple[
         row.value = value
     await session.commit()
     return hour, minute
+
+
+# ---- 探测次数上限（可配置） ----
+
+MAX_PROBE_SETTING_KEY = "daily_feed_max_probe_attempts"
+PROBE_STATE_SETTING_KEY = "daily_feed_probe_state"
+
+#: 一天最多探几次。探测每 15 分钟一次，10 次 = 从开始时刻起覆盖 2.5 小时。
+#: 有上限是因为「今天 arXiv 就是没发」是正常情况（周末、节假日、发布故障），
+#: 不该让检查点从早探到晚——探满这个次数就当天收工，明天重新开始。
+DEFAULT_MAX_PROBE_ATTEMPTS = 10
+
+
+async def get_max_probe_attempts(session: AsyncSession) -> int:
+    """一天最多探几次（默认 10）。存量值非法时回落默认。"""
+    row = await session.get(SystemSetting, MAX_PROBE_SETTING_KEY)
+    value = row.value if row is not None else None
+    if isinstance(value, int) and 1 <= value <= 96:
+        return value
+    return DEFAULT_MAX_PROBE_ATTEMPTS
+
+
+async def set_max_probe_attempts(session: AsyncSession, attempts: int) -> int:
+    if not 1 <= attempts <= 96:
+        raise ValueError(f"invalid attempts: {attempts}")
+    row = await session.get(SystemSetting, MAX_PROBE_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=MAX_PROBE_SETTING_KEY, value=attempts))
+    else:
+        row.value = attempts
+    await session.commit()
+    return attempts
+
+
+async def probe_state(session: AsyncSession, *, now: dt.datetime) -> dict[str, Any]:
+    """今天探过几次、探到的最新批次是哪天。跨天自动归零。"""
+    today = now.astimezone(dt.UTC).date().isoformat()
+    row = await session.get(SystemSetting, PROBE_STATE_SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, dict) else {}
+    if value.get("date") != today:
+        return {"date": today, "attempts": 0, "batch_date": None, "exhausted": False}
+    return {
+        "date": today,
+        "attempts": int(value.get("attempts") or 0),
+        "batch_date": value.get("batch_date"),
+        "exhausted": bool(value.get("exhausted")),
+    }
+
+
+async def record_probe(
+    session: AsyncSession,
+    *,
+    now: dt.datetime,
+    batch_date: str | None,
+    exhausted: bool = False,
+) -> dict[str, Any]:
+    """记一次「探了但今天那批还没出来」。返回记完之后的状态。"""
+    state = await probe_state(session, now=now)
+    state["attempts"] += 1
+    state["batch_date"] = batch_date
+    state["exhausted"] = exhausted
+    row = await session.get(SystemSetting, PROBE_STATE_SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=PROBE_STATE_SETTING_KEY, value=state))
+    else:
+        row.value = dict(state)
+    await session.commit()
+    return state
 
 
 async def due_now(session: AsyncSession, *, now: dt.datetime, delay_minutes: int = 0) -> bool:

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -485,10 +485,34 @@ async def find_due_daily_libraries(session: AsyncSession) -> list[DirectionLibra
         .scalars()
         .all()
     )
+    # 今天已经**自动**同步过的库不再重复选。这一条以前写在调用方，而且是全局的：
+    # 「今天有任意一条 wiki_ingest」就整轮跳过。于是任何人手动同步任何一个库，当天
+    # 其余所有库的自动同步全部消失——生产上 07-31 就是这样，10:22 有人手动同步了
+    # rubric，10:32 每日池刚灌进 227 篇新论文，扇出却一个库都没选。
+    # 手动运行不计入：它跑在池子更新之前，不能替代这一轮。只认**跑成功**的——失败或
+    # 被回收（cancelled）的那次什么也没同步，把它算成「今天已经跑过」就等于让一次
+    # 瞬时故障吃掉这个库当天的同步。在跑的那些由下面的互斥判定各自挡住。
+    start = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    auto_today = set(
+        (
+            await session.execute(
+                select(VoyageRun.library_id).where(
+                    VoyageRun.kind == "wiki_ingest",
+                    VoyageRun.created_by.is_(None),
+                    VoyageRun.status == "done",
+                    VoyageRun.created_at >= start,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
     due: list[DirectionLibrary] = []
     for library in libraries:
         state = library.ingest_state or {}
         if not state.get("watermark"):
+            continue
+        if library.id in auto_today:
             continue
         if await find_running_ingest_for_library(session, library.id) is not None:
             continue

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -946,12 +946,17 @@ async def test_day_counts_follow_the_active_filters(client, monkeypatch):
     assert resp.json()["total"] == await days(category="cs.CV")
 
 
-async def test_stale_batch_is_reported_instead_of_silently_creating_nothing(client, monkeypatch):
-    """抓到的不是今天那批公告 → 这一步必须失败。
+async def test_stale_batch_is_visible_but_does_not_fail_the_run(client, monkeypatch):
+    """抓到的不是今天那批公告 → 留痕，但**不算失败**。
 
-    生产上真实发生过：抓取跑在 arXiv 发布之前，RSS 返回上一批，条目数照样两三百，
-    但全都昨天入过池，去重后 created=0——而 fetch 报 passed、upsert 报 passed，
-    三天下来丢了两整天的论文，没有任何一处报警。
+    两个方向都要防：
+
+    - 不能静默。生产上真实发生过：抓取跑在 arXiv 发布之前，RSS 返回上一批，条目数照样
+      两三百，但全都昨天入过池，去重后 created=0——而每一步都报 passed，三天下来丢了
+      两整天的论文，没有任何一处报警。所以 stale_batch_dates 与 note 必须留下。
+    - 也不能报错。「今天那批还没发布」是轮询语义下的正常状态：检查点会继续探，手动
+      触发也可能落在发布之前。以前这里置 error，一次早点的手动触发就留下一条
+      paused_error，而它其实什么都没坏。
     """
     import datetime as dt
 
@@ -970,13 +975,144 @@ async def test_stale_batch_is_reported_instead_of_silently_creating_nothing(clie
     ctx = _action_ctx()
     obs = await get_action("daily.fetch")(ctx, {})
     assert obs["stale_batch_dates"] == [yesterday.isoformat()]
-    assert obs["error"] and "不是今天的" in obs["error"]
     assert obs["per_category"]["cs.AI"]["stale"] is True
+    assert "error" not in obs, "还没发布不是故障"
+    assert obs["note"] and "今天那批还没发布" in obs["note"]
 
     verdict, _ = run_deterministic_checks(
         [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
     )
-    assert verdict is not None and verdict["passed"] is False
+    assert verdict is not None and verdict["passed"] is True
+
+
+async def test_probe_stops_after_the_configured_number_of_attempts(client, monkeypatch):
+    """探满上限就当天收工：不再探、不建任务，也不留失败记录。
+
+    「今天 arXiv 就是没发」是正常情况（周末、节假日、发布故障）。没有上限时检查点会
+    从早空转到晚，每 15 分钟打一次 arXiv，却永远得不出结论。
+    """
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+    from worker.tasks import daily_feed_sync
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+    monkeypatch.setattr(
+        daily_feed, "get_arxiv_client", lambda: _StubArxiv({}, batch_date=yesterday)
+    )
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_time(session, 0, 0)  # 保证 due_now 恒真
+        await daily_feed.set_max_probe_attempts(session, 3)
+
+    enqueued: list[str] = []
+
+    class _Redis:
+        async def enqueue_job(self, name, *args, **kwargs):
+            enqueued.append(name)
+
+    ctx = {"redis": _Redis()}
+    state: dict = {}
+    for expected in (1, 2, 3):
+        assert await daily_feed_sync(ctx) is None
+        async with get_sessionmaker()() as session:
+            state = await daily_feed.probe_state(session, now=dt.datetime.now(dt.UTC))
+        assert state["attempts"] == expected
+        assert state["batch_date"] == yesterday.isoformat()
+    assert state["exhausted"] is True
+
+    # 第四次：已经收工，连 arXiv 都不该再打
+    probed: list[str] = []
+
+    class _Counting:
+        async def fetch_new(self, category: str):
+            probed.append(category)
+            raise AssertionError("探满之后不该再探")
+
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _Counting())
+    assert await daily_feed_sync(ctx) is None
+    assert probed == []
+    assert enqueued == [], "全程不该建任何任务"
+
+
+async def test_probe_creates_the_run_once_the_batch_appears(client, monkeypatch):
+    """探到今天那批就建任务——次数上限不能把正常的抓取也挡掉。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+    from worker.tasks import daily_feed_sync
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+    monkeypatch.setattr(
+        daily_feed, "get_arxiv_client", lambda: _StubArxiv({}, batch_date=yesterday)
+    )
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_time(session, 0, 0)
+        await daily_feed.set_max_probe_attempts(session, 5)
+
+    enqueued: list[tuple[str, str]] = []
+
+    class _Redis:
+        async def enqueue_job(self, name, run_id, **kwargs):
+            enqueued.append((name, run_id))
+
+    ctx = {"redis": _Redis()}
+    assert await daily_feed_sync(ctx) is None  # 还没发布
+
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv({}))
+    run_id = await daily_feed_sync(ctx)
+    assert run_id is not None
+    assert enqueued == [("run_voyage", run_id)]
+
+
+async def test_max_probe_attempts_defaults_to_ten_and_is_configurable(client):
+    """默认 10 次；管理员可改，普通用户只读。"""
+    admin = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    member = {
+        "Authorization": f"Bearer {await register_and_login(client, email='probe@example.com')}"
+    }
+
+    resp = await client.get("/api/daily/probe-attempts", headers=member)
+    assert resp.status_code == 200 and resp.json()["attempts"] == 10
+
+    assert (
+        await client.put("/api/daily/probe-attempts", json={"attempts": 4}, headers=member)
+    ).status_code == 403
+
+    resp = await client.put("/api/daily/probe-attempts", json={"attempts": 4}, headers=admin)
+    assert resp.status_code == 200 and resp.json()["attempts"] == 4
+    assert (await client.get("/api/daily/probe-attempts", headers=member)).json()["attempts"] == 4
+
+    for bad in (0, 97):
+        resp = await client.put("/api/daily/probe-attempts", json={"attempts": bad}, headers=admin)
+        assert resp.status_code == 422, bad
+
+
+async def test_sync_status_shows_how_far_the_probe_has_got(client, monkeypatch):
+    """界面要能区分「还在探」和「探完了今天就是没有」，否则用户不知道该等还是该查。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+
+    body = (await client.get("/api/daily/sync-status", headers=headers)).json()
+    assert body["probe_attempts"] == 0 and body["probe_max_attempts"] == 10
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.record_probe(
+            session, now=dt.datetime.now(dt.UTC), batch_date=yesterday.isoformat()
+        )
+
+    body = (await client.get("/api/daily/sync-status", headers=headers)).json()
+    assert body["probe_attempts"] == 1
+    assert body["probe_batch_date"] == yesterday.isoformat()
+    assert body["probe_exhausted"] is False
 
 
 async def test_fresh_batch_is_not_reported_as_stale(client, monkeypatch):

--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -244,6 +244,100 @@ async def test_public_library_visible_to_all(client):
     assert resp.json()["is_public"] is True
 
 
+async def test_digest_is_readable_by_anyone_who_can_see_the_library(client):
+    """每日简报跟随**库可见性**，不跟随管理权限。
+
+    简报是读物，不是管理动作：公共库全员可读，它的简报也该全员可读。界面上一度只有
+    管理者视角（工作台）挂着「每日简报」标签，只读浏览视角没有，于是没有管理权的人
+    在有简报的库里根本看不到它——公共库里几个 submitted_by 为空的，实际就成了
+    只有平台管理员看得见。
+    """
+    import datetime as dt
+    import uuid as _uuid
+
+    from app.models.research_digest import LibraryResearchDigest
+
+    admin = await _hdr(client, "digest-admin@example.com")
+    await _promote_admin("digest-admin@example.com")
+    owner = await _hdr(client, "digest-owner@example.com")
+    stranger = await _hdr(client, "digest-stranger@example.com")
+
+    lib_id = await _create_personal(client, owner, name="有简报的库")
+    await client.post(f"/api/libraries/{lib_id}/request-public", headers=owner)
+    await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
+
+    async with get_sessionmaker()() as session:
+        session.add(
+            LibraryResearchDigest(
+                library_id=_uuid.UUID(lib_id),
+                report_date=dt.date(2026, 7, 30),
+                source="voyage",
+                mode="incremental",
+                counts={"kept": 2},
+                source_diagnostics={},
+                paper_insights=[],
+                excluded_papers=[],
+                cross_paper_signals=[],
+                summary="本期两篇。",
+                content="# 每日文献简报",
+                rolling_trends=[],
+                trend_content="",
+            )
+        )
+        await session.commit()
+
+    # 没有任何管理权的普通用户：列表读得到，正文也读得到
+    resp = await client.get(f"/api/libraries/{lib_id}/digests", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    assert len(rows) == 1 and rows[0]["counts"]["kept"] == 2
+
+    resp = await client.get(f"/api/libraries/{lib_id}/digests/{rows[0]['id']}", headers=stranger)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["content"].startswith("# 每日文献简报")
+
+    # 生成仍然是管理动作：只读的人拿不到
+    resp = await client.post(f"/api/libraries/{lib_id}/digests/generate", headers=stranger)
+    assert resp.status_code in (403, 404), resp.text
+
+
+async def test_personal_library_digest_stays_hidden_from_strangers(client):
+    """个人库的简报不能因为「简报全员可读」而漏出去——它跟随库可见性，库看不见就 404。"""
+    import datetime as dt
+    import uuid as _uuid
+
+    from app.models.research_digest import LibraryResearchDigest
+
+    owner = await _hdr(client, "digest-priv-owner@example.com")
+    stranger = await _hdr(client, "digest-priv-stranger@example.com")
+    lib_id = await _create_personal(client, owner, name="私有库")
+
+    async with get_sessionmaker()() as session:
+        session.add(
+            LibraryResearchDigest(
+                library_id=_uuid.UUID(lib_id),
+                report_date=dt.date(2026, 7, 30),
+                source="voyage",
+                mode="incremental",
+                counts={},
+                source_diagnostics={},
+                paper_insights=[],
+                excluded_papers=[],
+                cross_paper_signals=[],
+                summary="私有",
+                content="# 私有简报",
+                rolling_trends=[],
+                trend_content="",
+            )
+        )
+        await session.commit()
+
+    assert (
+        await client.get(f"/api/libraries/{lib_id}/digests", headers=stranger)
+    ).status_code == 404
+    assert (await client.get(f"/api/libraries/{lib_id}/digests", headers=owner)).status_code == 200
+
+
 async def test_list_type_filter(client):
     admin = await _hdr(client, "p10-a12@example.com")
     await _promote_admin("p10-a12@example.com")

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -1230,6 +1230,103 @@ async def test_standalone_library_is_due_for_daily_cron(client, queue_stub, wiki
         assert [str(lib.id) for lib in due] == [library_id]
 
 
+async def test_one_manual_sync_does_not_cancel_everyone_elses_daily_sync(
+    client, queue_stub, wiki_mocks
+):
+    """某个库今天被手动同步过，不影响其余库当天的自动同步。
+
+    生产上 07-31 就是这样丢了一整轮：10:22 有人手动同步了 rubric 一个库，10:32 每日池
+    刚灌进 227 篇新论文、扇出被触发，结果一个库都没选中——因为闸门是
+    ``already_ran_today("wiki_ingest")``，查的是**当天任意一条** wiki_ingest 运行，
+    不分库、也不分手动还是自动。
+    """
+    token = await register_and_login(client, email="fanout-manual@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("fanout-manual@example.com")
+
+    first = await _create_standalone_library(client, headers, name="被手动同步的库")
+    second = await _create_standalone_library(client, headers, name="等自动同步的库")
+    engine, _ = _make_engine()
+    for library_id in (first, second):
+        resp = await client.post(
+            f"/api/libraries/{library_id}/ingest/run",
+            json={"mode": "bootstrap", "knobs": KNOBS},
+            headers=headers,
+        )
+        await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        # 有人手动同步了第一个库（created_by 非空，且已跑完）
+        me = (
+            await session.execute(
+                select(User).where(User.email == "fanout-manual@example.com")
+            )
+        ).scalar_one()
+        session.add(
+            VoyageRun(
+                kind="wiki_ingest",
+                goal="手动同步",
+                status="done",
+                library_id=uuid.UUID(first),
+                created_by=me.id,
+            )
+        )
+        await session.commit()
+
+    # 走真正的扇出任务：闸门以前就在这里，直接调选库函数是测不到的
+    from worker.tasks import daily_wiki_ingest
+
+    enqueued: list[str] = []
+
+    class _Redis:
+        async def enqueue_job(self, name, run_id, **kwargs):
+            enqueued.append(run_id)
+
+    created = await daily_wiki_ingest({"redis": _Redis()})
+    assert enqueued == created
+
+    async with get_sessionmaker()() as session:
+        synced = {
+            str((await session.get(VoyageRun, uuid.UUID(rid))).library_id) for rid in created
+        }
+    assert second in synced, "别人手动同步了一个库，不该让这个库当天不再自动同步"
+    assert first in synced, "手动同步跑在池子更新之前，替代不了这一轮"
+
+
+async def test_a_library_is_only_auto_synced_once_a_day(client, queue_stub, wiki_mocks):
+    """同一个库当天已经**自动**同步过就不再选——「每天一轮」的语义按库保留。"""
+    token = await register_and_login(client, email="fanout-once@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    await _promote_admin("fanout-once@example.com")
+    library_id = await _create_standalone_library(client, headers, name="每天一轮的库")
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+
+    async with get_sessionmaker()() as session:
+        assert [str(lib.id) for lib in await ingest_service.find_due_daily_libraries(session)] == [
+            library_id
+        ]
+        session.add(
+            VoyageRun(
+                kind="wiki_ingest",
+                goal="自动同步",
+                status="done",
+                library_id=uuid.UUID(library_id),
+                created_by=None,  # 自动
+            )
+        )
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        assert await ingest_service.find_due_daily_libraries(session) == []
+
+
 async def test_non_active_library_is_not_due(client, queue_stub, wiki_mocks):
     """库 status 不是 active 就不该被 cron 拉起来——老的按课题选表压根没查这个字段。"""
     token = await register_and_login(client, email="due-inactive@example.com")

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -191,9 +191,34 @@ async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
             session, daily_feed_service.DAILY_FEED_VOYAGE_KIND, now=now
         ):
             return None
+        # 探测有次数上限：「今天 arXiv 就是没发」是正常情况（周末、节假日、发布故障），
+        # 不该从早探到晚。探满就当天收工，明天归零重来——这是正常结束，不是失败。
+        max_attempts = await daily_feed_service.get_max_probe_attempts(session)
+        state = await daily_feed_service.probe_state(session, now=now)
+        if state["attempts"] >= max_attempts:
+            return None
         fresh, batch_date = await daily_feed_service.todays_batch_available(session)
         if not fresh:
-            logger.info("daily feed not published yet (latest batch %s), will retry", batch_date)
+            state = await daily_feed_service.record_probe(
+                session,
+                now=now,
+                batch_date=batch_date,
+                exhausted=state["attempts"] + 1 >= max_attempts,
+            )
+            if state["exhausted"]:
+                logger.info(
+                    "daily feed probe exhausted after %s attempts (latest batch %s); "
+                    "no new announcement today",
+                    state["attempts"],
+                    batch_date,
+                )
+            else:
+                logger.info(
+                    "daily feed not published yet (latest batch %s), probe %s/%s",
+                    batch_date,
+                    state["attempts"],
+                    max_attempts,
+                )
             return None
         try:
             run = await daily_feed_service.create_daily_feed_voyage(session, created_by=None)

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -87,15 +87,11 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
 
     返回本次入队的 voyage id 列表（arq 结果可查）。
     """
-    import datetime as dt
-
-    from app.services import daily_feed as daily_feed_service
-
-    now = dt.datetime.now(dt.UTC)
     enqueued: list[str] = []
     async with get_sessionmaker()() as session:
-        if await daily_feed_service.already_ran_today(session, "wiki_ingest", now=now):
-            return enqueued
+        # 「今天只跑一轮」的判据在 find_due_daily_libraries 里，且是**按库**算的。
+        # 这里以前是一道全局闸门（今天有任意一条 wiki_ingest 就整轮返回），于是
+        # 任何人手动同步任何一个库，当天其余所有库的自动同步全部被吞掉。
         # 先回收长期卡住的 paused_error：它们会把所在库一直挡在互斥判定外面
         reclaimed = await ingest_service.reclaim_stale_paused_ingests(session)
         if reclaimed:

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -65,6 +65,9 @@ import { AddToButton } from '../library/AddToPopover';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
 const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
+const DailyDigestTab = lazy(() =>
+  import('../wiki/DailyDigestTab').then((m) => ({ default: m.DailyDigestTab })),
+);
 
 /* ============================================================
    共享文献库只读浏览（P5c 非成员视角）：
@@ -72,7 +75,7 @@ const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m
    全部走 /libraries 读端点；没有任何管理入口，收藏/笔记等个人操作去阅读页做。
    ============================================================ */
 
-type BrowseTab = 'papers' | 'concepts' | 'graph' | 'chat' | 'notes' | 'govern' | 'ingest';
+type BrowseTab = 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'notes' | 'govern' | 'ingest';
 
 const PAGE_SIZE = 20;
 
@@ -912,6 +915,8 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
             { v: 'papers', label: `${tr('论文库', 'Papers')}${paperTotal !== undefined ? ` · ${paperTotal}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
+            // 简报是读物，不是管理动作：能看见这个库的人就该看得见它（只是不能生成）
+            { v: 'digest', label: tr('每日简报', 'Daily digest') },
             { v: 'chat', label: tr('文献对话', 'Chat') },
             { v: 'notes', label: tr('笔记', 'Notes') },
             { v: 'govern', label: tr('文献库配置', 'Library config') },
@@ -969,6 +974,17 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
         ) : tab === 'graph' ? (
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
             <GraphTab libraryId={libraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
+          </Suspense>
+        ) : tab === 'digest' ? (
+          <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
+            <DailyDigestTab
+              libraryId={libraryId}
+              onOpenPaper={goPaper}
+              onWikiLink={onWikiLink}
+              canGenerate={false}
+              ingestRunning={!!ingestQuery.data?.running_voyage_id}
+              hasWatermark={!!ingestQuery.data?.watermark}
+            />
           </Suspense>
         ) : tab === 'chat' ? (
           <LibraryChatTab libraryId={libraryId} canManage={false} onOpenPaper={goPaper} onWikiLink={onWikiLink} />

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -2826,12 +2826,21 @@ function DailySyncSection() {
     queryFn: () => api.getDailyRetention(),
     retry: false,
   });
+  const probeQuery = useQuery({
+    queryKey: ['daily-probe-attempts'],
+    queryFn: () => api.getDailyProbeAttempts(),
+    retry: false,
+  });
 
   const [days, setDays] = useState('');
   const [clock, setClock] = useState('');
+  const [probes, setProbes] = useState('');
   useEffect(() => {
     if (retentionQuery.data && !days) setDays(String(retentionQuery.data.days));
   }, [retentionQuery.data, days]);
+  useEffect(() => {
+    if (probeQuery.data && !probes) setProbes(String(probeQuery.data.attempts));
+  }, [probeQuery.data, probes]);
   useEffect(() => {
     if (timeQuery.data && !clock) {
       const { hour, minute } = timeQuery.data;
@@ -2858,6 +2867,14 @@ function DailySyncSection() {
     onSuccess: () => {
       toast(tr('抓取时刻已保存，重启 worker 后生效', 'Fetch time saved — restart the worker to apply'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['daily-sync-time'] });
+    },
+    onError: fail,
+  });
+  const probeMutation = useMutation({
+    mutationFn: () => api.setDailyProbeAttempts(Number(probes)),
+    onSuccess: () => {
+      toast(tr('最大查询次数已保存', 'Max probe attempts saved'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['daily-probe-attempts'] });
     },
     onError: fail,
   });
@@ -2958,6 +2975,36 @@ function DailySyncSection() {
         {tr(
           '北京时间 = UTC + 8。这是开始探测的时刻，之后每 15 分钟看一次，直到 arXiv 当天的批次真的放出来。',
           'Beijing = UTC + 8. This is when probing starts; it then checks every 15 minutes until arXiv actually publishes today’s batch.',
+        )}
+      </div>
+
+      {/* —— 最大查询次数 —— */}
+      <div className="row gap8" style={rowStyle}>
+        <span style={labelStyle}>{tr('最大查询次数', 'Max probe attempts')}</span>
+        <input
+          className="input mono"
+          type="number"
+          min={1}
+          max={96}
+          style={{ width: 90, height: 28, fontSize: 12 }}
+          value={probes}
+          onChange={(e) => setProbes(e.target.value)}
+        />
+        <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)' }}>
+          {tr('次 / 天', 'per day')}
+        </span>
+        <button
+          className="btn btn-soft sm"
+          disabled={!probes || Number(probes) < 1 || Number(probes) > 96 || probeMutation.isPending}
+          onClick={() => probeMutation.mutate()}
+        >
+          {tr('保存', 'Save')}
+        </button>
+      </div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 5, paddingLeft: 100, lineHeight: 1.5 }}>
+        {tr(
+          '从抓取时刻起每 15 分钟探一次，探满这么多次仍没有今天的批次就当天收工——这是正常结束，不会留下失败的任务。默认 10 次约覆盖 2.5 小时。',
+          'From the fetch time onwards it probes every 15 minutes; after this many attempts with no batch for today, it stops for the day — a normal ending, not a failed run. The default of 10 covers about 2.5 hours.',
         )}
       </div>
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4602,6 +4602,13 @@ export const api = {
       minute,
     });
   },
+  /** 一天最多探几次 arXiv 有没有发新批次（探测每 15 分钟一次）。 */
+  getDailyProbeAttempts(): Promise<{ attempts: number }> {
+    return request<{ attempts: number }>('/daily/probe-attempts');
+  },
+  setDailyProbeAttempts(attempts: number): Promise<{ attempts: number }> {
+    return requestJson<{ attempts: number }>('/daily/probe-attempts', 'PUT', { attempts });
+  },
   setDailyRetention(days: number): Promise<{ days: number }> {
     return requestJson<{ days: number }>('/daily/retention', 'PUT', { days });
   },


### PR DESCRIPTION
Three independent problems in the daily pipeline, all found while chasing one report.

---

## 1. The fetch probe had no limit, and "not published yet" was a failure

The daily fetch is meant to poll: from a configured start time it probes every 15 minutes until arXiv publishes today's batch. Two things contradicted that.

`daily.fetch` set `observation["error"]` whenever the fetched announcement date was older than today, which fails the step's `no_error` check and parks the run in `paused_error`. But the manual **Fetch now** endpoint (`POST /daily/refresh`) creates the voyage unconditionally — it never consults the freshness probe — so clicking it before publication reliably produced a failed run that broke nothing.

And the probe never stopped: if the batch never appeared it kept polling from morning to night, hitting arXiv every 15 minutes without ever reaching a conclusion. "arXiv published nothing today" is a normal state — weekends, holidays, an outage — and deserves a normal ending.

**Fixed by:**
- A configurable attempt cap, `daily_feed_max_probe_attempts`, **default 10** (1–96, admin-writable, readable by everyone). After that many attempts the probe stops for the day and resets tomorrow. No run created, nothing marked failed. Ten attempts covers about 2.5 hours.
- A stale batch now records a `note` and a warning log instead of an `error`. The trace is deliberately kept — `stale_batch_dates` stays in the observation and the note says plainly that today's batch is not out. That visibility is why the check exists at all: production once lost two full days of papers because the fetch ran before publication, returned a few hundred entries that all deduplicated away, and every step reported success. Not failing must not mean going quiet.
- `GET /daily/sync-status` now returns `probe_attempts`, `probe_max_attempts`, `probe_batch_date`, `probe_exhausted`, so the UI can distinguish "still probing" from "probed out, there is genuinely nothing today".
- A **Max probe attempts** input in settings, next to the fetch time.

## 2. One manual library sync cancelled everyone else's daily sync

On 2026-07-31 a whole round was lost. At 10:22 a user manually synced one library (`rubric`). At 10:32 the daily pool took in 227 new papers and the fan-out fired — and selected **zero** libraries; `daily_wiki_ingest` returned `[]`.

The cause: the "once a day" gate at the top of `daily_wiki_ingest` was `already_ran_today("wiki_ingest")` — any wiki_ingest run created today, regardless of which library it belonged to or whether a human started it. So one manual sync of one library suppressed the automatic sync of every library for the rest of the UTC day.

**Fixed by** moving the gate into `find_due_daily_libraries` and making it per-library:
- only runs with `created_by IS NULL` (automatic) **and** `status = done` (actually succeeded) count;
- manual runs do not — they happen before the pool is updated and cannot stand in for this round;
- failed or reclaimed runs do not either, otherwise one transient failure eats that library's sync for the day;
- in-flight runs are still excluded by the existing mutex check.

## 3. The daily digest was effectively admin-only

The digest tab lived only in the manager view (`WikiWorkbench`). Anyone without manage rights lands in the read-only browse view (`LibraryBrowse`), which had no such tab. Since `can_manage` = platform admin ∪ creator ∪ curator, and four public libraries in production have a null `submitted_by`, their digests were visible to platform admins and nobody else.

The API was never the gate — reads go through `_get_visible_library` (public libraries: everyone; personal: owner + admin) and generation through `_get_managed_library`. **Fixed by** adding the tab to the read-only view with `canGenerate={false}`: whoever can see the library can read its digest, while generating stays a management action.

---

## Tests

- `test_daily_feed.py` — five new, one rewritten. A stale batch keeps its trace, sets no error, and now passes the deterministic check; probing stops after the configured attempts and does not touch arXiv again; the cap does not block the normal path once the batch appears; the setting defaults to 10, is admin-only for writes, and rejects 0 and 97; `sync-status` reports probe progress.
- `test_wiki_ingest.py` — two new, both driven through the real `daily_wiki_ingest` task. A manual sync of one library does not stop the others from being enqueued; a library that already had a successful automatic sync today is not selected again. (My first version called the selector directly and passed against `main` — the gate lived in the worker task, so that route never exercised it.)
- `test_library_approval.py` — two new contract guards: a plain member can read a public library's digest but cannot generate one; a personal library's digest still 404s for strangers. Note these pass on `main` too, since the API was never the restriction — the digest fix is frontend-only and this repo has no frontend test tooling, so that part is covered by `tsc` and `vite build` only.

Reverse-checked: the five daily-feed tests and the two fan-out tests all fail against `origin/main`. Full backend suite **939 passed**; `ruff check app worker` and frontend `tsc --noEmit` + `vite build` clean.

## Note on provenance

I could not find the run behind the error message that started this: no `daily.fetch` step in either the production or the local database carries that verdict, and the last six production runs all passed with fresh batches. The two paths that can produce it are the ones fixed in §1.