### PR TITLE
fix(libraries): keep the library cards aligned when a name or statement is long

### DIFF
--- a/src/frontend/src/features/libraries/LibrariesPage.tsx
+++ b/src/frontend/src/features/libraries/LibrariesPage.tsx
@@ -166,7 +166,20 @@ function LibraryCard({
         </span>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="row gap8" style={{ flexWrap: 'wrap' }}>
-            <span style={{ fontSize: 14.5, fontWeight: 680, lineHeight: 1.3 }} title={lib.name}>
+            <span
+              // 长库名限两行：撑高的是整行卡片（grid 行高取最高者），不只是它自己
+              style={{
+                fontSize: 14.5,
+                fontWeight: 680,
+                lineHeight: 1.3,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                overflowWrap: 'anywhere',
+              }}
+              title={lib.name}
+            >
               {lib.name}
             </span>
             <TypeBadge isPublic={lib.is_public} />
@@ -214,7 +227,12 @@ function LibraryCard({
       >
         {lib.statement ?? tr('这个方向还没有写一句话介绍。', 'No statement for this direction yet.')}
       </div>
-      <div className="row gap10" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+      <div
+        className="row gap10"
+        // marginTop:auto —— 同一行的卡片高度由最高的那张决定，不钉底的话矮内容的卡片
+        // 会把统计行留在半空中（截图里 SWE 那张底下空一大块）
+        style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 'auto' }}
+      >
         <span className="row gap6">
           <Icon name="file" size={12} />
           {tr(`${lib.paper_count} 篇论文`, `${lib.paper_count} papers`)}


### PR DESCRIPTION
## The bug

In the library grid, cards in the same row are stretched to the height of the tallest one, but their content stays packed at the top. The result is a ragged row: the meta line (`N papers / N concepts / Updated …`) sits at a different height in every card, and the shorter cards have a large empty gap below it.

A long library name makes it obvious. `Utility-Preserving Governed Sharing in Multi-Principal LLM Agents` wraps to four lines, which raises the whole row, so its neighbours gain that much empty space at the bottom.

## The fix

- The meta line gets `marginTop: auto`, pinning it to the bottom of the card. However tall the content above it is, the meta lines across a row line up.
- The library name is clamped to two lines (`-webkit-line-clamp: 2`, `overflow-wrap: anywhere`), so one long name no longer stretches the entire row. The full name is still in the `title` attribute and shows on hover.

Both are style-only changes to `LibraryCard` in `LibrariesPage.tsx`; nothing about the data or the layout algorithm changes.

## Verification

This repo has no frontend test tooling, so beyond `tsc --noEmit` and `vite build` I rendered a standalone replica of the grid — same grid template, card padding, flex direction and clamp rules — in Chrome with the three cards from the report, before and after.

Before: the meta lines land at three different heights and two cards have a visible gap at the bottom. After: all three sit flush at the bottom of their cards.

Note this is a replica of the styles, not the real component mounted with real data — the change is style-only, but it was not verified in a running deployment.