### PR TITLE
feat(daily): skip the library fan-out when nothing new entered the pool

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -25,6 +25,16 @@ from app.services import daily_feed as daily_feed_service
 logger = logging.getLogger(__name__)
 
 
+def _is_weekend(now: dt.datetime | None = None) -> bool:
+    """今天 arXiv 本来就不公告吗。
+
+    RSS 的 skipDays 明写着周六周日不发，那时拿到周五那批是正常的，不该报「抓早了」。
+    单独成函数是为了能被测试固定住——直接读 now() 的话，同一条断言会随跑测试的星期
+    时对时错（这条豁免上线后第一个周六就把测试挂了）。
+    """
+    return (now or dt.datetime.now(dt.UTC)).weekday() >= 5
+
+
 # ---- 1. 抓取订阅分类的当天新公告 ----
 
 
@@ -39,11 +49,9 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     failed = [c for c, s in statuses.items() if s["status"] == "error"]
     # arXiv 声明的批次日期不是今天 = 抓早了，拿到的是上一批。这种失败原本完全无声：
     # 条目照样几百条，只是全都昨天入过池了，去重后一条不进，而每一步都报成功。
-    # 周末除外——arXiv 的 RSS 里 skipDays 明写着周六周日不发，那时拿到周五那批是正常的。
-    weekend = dt.datetime.now(dt.UTC).weekday() >= 5
     stale = (
         []
-        if weekend
+        if _is_weekend()
         else sorted({s["batch_date"] for s in statuses.values() if s.get("stale")})
     )
     for category, state in statuses.items():
@@ -100,6 +108,8 @@ async def upsert(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
 
     touched = [str(pid) for pid in stats["touched"]]
     ctx.checkpoint["daily_touched_papers"] = touched
+    # 交给 daily.sync_libraries 判断要不要触发库同步：一篇新的都没有就不必触发
+    ctx.checkpoint["daily_created"] = stats["created"]
     ctx.checkpoint.pop("daily_entries", None)  # 已入池，不必再占着 checkpoint
     await ctx.log(f"新增 {stats['created']} 篇，合并分类 {stats['merged']} 篇")
     return {"created": stats["created"], "merged": stats["merged"], "papers": len(touched)}
@@ -140,15 +150,28 @@ async def embed(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
 
 @register("daily.sync_libraries")
 async def sync_libraries(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
-    """新论文入池后立刻触发各文献库的同步。
+    """新论文入池后立刻触发各文献库的同步；一篇新的都没有就不触发。
 
     以前库同步是自己定时跑的（抓取时刻 + 90 分钟），那是在赌抓取已经跑完——抓取慢一点
     或者失败重试，同步就会在旧池子上空跑一整轮，而界面上只显示「0 篇新论文」。改成
     事件驱动：池子备好了才同步，时刻不用猜也不用配。
+
+    池里一篇新论文都没有时（周末、节假日、arXiv 当天没发）就不触发：14 个库各跑一轮
+    打分/编译，扫的是同一批昨天就打过分的论文，白花一轮钱，还在每个库下面留一条
+    「0 篇新论文」的任务记录。
+
+    判据是 **created**（真正新进池的论文数），不是抓到的条目数：抓到几百条但全是昨天
+    入过池的，去重后 created=0，对文献库来说和没抓一样。``merged`` 也不算——那是已在
+    池中的论文多挂了一个分类，而库同步不按分类筛，没有新信号。
     """
     from app.core.queue import get_task_queue
 
+    created = int(ctx.checkpoint.get("daily_created") or 0)
+    if created <= 0:
+        await ctx.log("池里没有新论文，跳过文献库同步", level="warning")
+        return {"triggered": False, "created": 0, "reason": "no_new_papers"}
+
     queue = await get_task_queue()
     await queue.enqueue("daily_wiki_ingest")
-    await ctx.log("已触发各文献库同步")
-    return {"triggered": True}
+    await ctx.log(f"已触发各文献库同步（新增 {created} 篇）")
+    return {"triggered": True, "created": created}

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -724,6 +724,128 @@ async def test_daily_feed_voyage_end_to_end(client, monkeypatch):
     assert resp.json()["total"] == 1
 
 
+async def test_weekend_batch_is_not_reported_as_stale(client, monkeypatch):
+    """周六周日 arXiv 不公告，拿到周五那批是正常的，不该报「抓早了」。
+
+    这条豁免以前只能靠「挑个周末跑测试」验证——它反过来还让另一条测试每逢周末必挂。
+    """
+    import datetime as dt
+
+    from app.agents.voyage import actions_daily
+    from app.agents.voyage.actions import get_action
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    friday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00131", "Friday")]}, batch_date=friday),
+    )
+    monkeypatch.setattr(actions_daily, "_is_weekend", lambda *a, **k: True)
+
+    obs = await get_action("daily.fetch")(_action_ctx(), {})
+    assert obs["stale_batch_dates"] == []
+    assert "error" not in obs and "note" not in obs
+
+
+async def test_is_weekend_follows_the_calendar():
+    """判据本身：周六周日为真，周一到周五为假。"""
+    import datetime as dt
+
+    from app.agents.voyage.actions_daily import _is_weekend
+
+    monday = dt.datetime(2026, 7, 27, 12, 0, tzinfo=dt.UTC)
+    for offset, expected in enumerate([False, False, False, False, False, True, True]):
+        assert _is_weekend(monday + dt.timedelta(days=offset)) is expected, offset
+
+
+async def test_no_new_papers_does_not_trigger_library_sync(client, monkeypatch):
+    """池里一篇新论文都没有（周末/节假日/当天没发）就不触发文献库同步。
+
+    否则 14 个库各跑一轮打分与编译，扫的是同一批昨天就打过分的论文，白花一轮钱，
+    还在每个库下面留一条「0 篇新论文」的任务记录。
+    """
+    from app.agents.voyage.actions import get_action
+    from app.agents.voyage.checks import run_deterministic_checks
+
+    await register_and_login(client)
+    enqueued: list[str] = []
+
+    class _Queue:
+        async def enqueue(self, name, *args, **kwargs):
+            enqueued.append(name)
+
+    from app.core import queue as queue_mod
+
+    async def _get_queue():
+        return _Queue()
+
+    monkeypatch.setattr(queue_mod, "get_task_queue", _get_queue)
+
+    ctx = _action_ctx()
+    ctx.checkpoint["daily_created"] = 0
+    obs = await get_action("daily.sync_libraries")(ctx, {})
+
+    assert obs["triggered"] is False
+    assert obs["reason"] == "no_new_papers"
+    assert enqueued == [], "没有新论文就不该入队库同步"
+
+    # 跳过是正常结果，不能把这一步判成失败
+    verdict, _ = run_deterministic_checks(
+        [{"kind": "no_error"}], observation=obs, checkpoint=ctx.checkpoint
+    )
+    assert verdict is not None and verdict["passed"] is True
+
+
+async def test_new_papers_still_trigger_library_sync(client, monkeypatch):
+    """有新论文就照常触发——跳过的判据不能把正常的一轮也挡掉。"""
+    from app.agents.voyage.actions import get_action
+
+    await register_and_login(client)
+    enqueued: list[str] = []
+
+    class _Queue:
+        async def enqueue(self, name, *args, **kwargs):
+            enqueued.append(name)
+
+    from app.core import queue as queue_mod
+
+    async def _get_queue():
+        return _Queue()
+
+    monkeypatch.setattr(queue_mod, "get_task_queue", _get_queue)
+
+    ctx = _action_ctx()
+    ctx.checkpoint["daily_created"] = 7
+    obs = await get_action("daily.sync_libraries")(ctx, {})
+
+    assert obs["triggered"] is True and obs["created"] == 7
+    assert enqueued == ["daily_wiki_ingest"]
+
+
+async def test_upsert_records_the_new_paper_count_for_the_next_step(client, monkeypatch):
+    """入池步骤要把「新增几篇」写进 checkpoint——触发与否的判据来自它，不是抓到的条目数。
+
+    抓到几百条但全是昨天入过池的，去重后 created=0，对文献库来说和没抓一样。
+    """
+    from app.agents.voyage.actions import get_action
+
+    await register_and_login(client)
+    ctx = _action_ctx()
+    ctx.checkpoint["daily_entries"] = {"cs.AI": [_rss_entry("2607.00120", "Brand new")]}
+    obs = await get_action("daily.upsert")(ctx, {})
+    assert obs["created"] == 1
+    assert ctx.checkpoint["daily_created"] == 1
+
+    # 同一篇再来一次：去重后没有新增，checkpoint 如实记 0
+    ctx2 = _action_ctx()
+    ctx2.checkpoint["daily_entries"] = {"cs.AI": [_rss_entry("2607.00120", "Brand new")]}
+    obs2 = await get_action("daily.upsert")(ctx2, {})
+    assert obs2["created"] == 0
+    assert ctx2.checkpoint["daily_created"] == 0
+
+
 async def test_daily_fetch_fails_when_any_category_errors(client, monkeypatch):
     """**任一分类抓失败就报错**，不是「全都空才报」。
 
@@ -971,6 +1093,10 @@ async def test_stale_batch_is_visible_but_does_not_fail_the_run(client, monkeypa
         "get_arxiv_client",
         lambda: _StubArxiv({"cs.AI": [_rss_entry("2607.00081", "Stale")]}, batch_date=yesterday),
     )
+    # 固定成工作日：周末 arXiv 本来就不公告，那条豁免会让这条断言随星期时对时错
+    from app.agents.voyage import actions_daily
+
+    monkeypatch.setattr(actions_daily, "_is_weekend", lambda *a, **k: False)
 
     ctx = _action_ctx()
     obs = await get_action("daily.fetch")(ctx, {})


### PR DESCRIPTION
## Why

On a weekend, a holiday, or any day arXiv publishes nothing, the pool takes in zero new papers — and the library fan-out fires anyway. Fourteen libraries each run a full scoring and compilation round over the same papers they already scored yesterday: a wasted round of spend, plus a "0 new papers" run recorded under every library.

## What changed

`daily.upsert` records `created` in the checkpoint; `daily.sync_libraries` uses it to decide whether to enqueue `daily_wiki_ingest`.

The criterion is **`created`** — papers that actually entered the pool — not the number of entries fetched. Several hundred entries that were all in the pool yesterday deduplicate down to `created = 0`, and for the libraries that is the same as not having fetched at all. `merged` does not count either: it means a paper already in the pool picked up an extra category, and library sync does not filter by category, so there is no new signal.

When it skips, the step returns `{"triggered": false, "created": 0, "reason": "no_new_papers"}` and logs a warning. The step's acceptance check is `no_error`, so skipping is a normal outcome, not a failure.

**Trade-off worth stating:** library sync is self-healing — a library that fell behind catches up on its next run because the whole pool window is rescanned. Skipping quiet days means a library that is behind waits for the next day with new papers. Over a weekend that is at most two days, and the pool is retained for 14, so nothing is lost permanently.

## A test defect fixed along the way

`daily.fetch` exempts weekends from the "fetched a stale batch" verdict, since arXiv's RSS `skipDays` says it does not publish on Saturday or Sunday. That check read `datetime.now()` directly, and the stale-batch test I added yesterday did not control the weekday — so it failed today, a Saturday.

The exemption is now `_is_weekend(now=None)`, which the test pins. Two tests cover the branch itself: a weekend batch is not reported as stale, and `_is_weekend` follows the calendar across a full week. Previously that branch was only exercised if the suite happened to run on a weekend — where it broke a different test instead.

## Tests

Five new tests: no new papers means no enqueue and the step still passes its check; new papers still trigger it; `daily.upsert` records the count (including the deduplicated-to-zero case); plus the two weekend tests. All five fail against `origin/main`.

Full backend suite **945 passed**; `ruff check app` clean.