### PR TITLE
fix(chat): give the chat context real publication dates and today's date

### DIFF
--- a/src/backend/app/services/library_chat.py
+++ b/src/backend/app/services/library_chat.py
@@ -7,6 +7,7 @@
 最终兜底用高分论文的 TL;DR/摘要拼上下文。
 """
 
+import datetime as dt
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -61,11 +62,41 @@ LIBRARY_CHAT_SYSTEM_TEMPLATE = """\
 - 涉及多篇论文时主动做对比与归纳（共识、分歧、演进脉络），不要逐篇罗列了事；
 - 用中文回答，讲清楚、说人话。
 
+今天是 {today}（UTC）。资料里每篇论文都标了发布日期，问到「最近几天/最新」时按它判断。
+
 研究方向：{statement}
 
 检索到的资料（编号 = 论文）：
 {context}
 """
+
+
+def _render_system(*, statement: str, context: str) -> str:
+    """渲染对话系统提示。
+
+    独立成函数是因为模板里有「今天是哪天」——四个调用点各自 format 的话，漏掉一个
+    就会 KeyError，而且日期得在每处重算一遍。
+    """
+    return LIBRARY_CHAT_SYSTEM_TEMPLATE.format(
+        statement=statement,
+        context=context,
+        today=dt.datetime.now(dt.UTC).date().isoformat(),
+    )
+
+
+def _dateline(paper: Paper) -> str:
+    """论文在上下文里的日期标注：能给到天就给到天。
+
+    以前只给年份，于是「最近 7 天有哪些新论文」这种问题模型只能如实回答「资料里没有
+    具体发表日期，无法确认」——每日池里的论文明明都带着 published_at。
+    """
+    published = getattr(paper, "published_at", None)
+    if published is not None:
+        try:
+            return published.date().isoformat()
+        except AttributeError:  # 已经是 date
+            return published.isoformat()
+    return str(paper.year) if paper.year else "日期未知"
 
 
 @dataclass
@@ -302,7 +333,7 @@ async def build_messages_for_libraries(
         messages = [
             Message(
                 role="system",
-                content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(
+                content=_render_system(
                     statement=statement, context="（还没有关联任何文献库）"
                 ),
             )
@@ -402,7 +433,7 @@ async def build_messages_for_libraries(
         concept_line = f"\n概念：{'、'.join(names)}" if names else ""
         fig_line = _figure_hints(paper)
         blocks.append(
-            f"[{i}] {paper.title}（{paper.year or '年份未知'}）{concept_line}{fig_line}\n{body}"
+            f"[{i}] {paper.title}（{_dateline(paper)}）{concept_line}{fig_line}\n{body}"
         )
         membership = memberships.get(paper.id)
         sources.append(
@@ -421,7 +452,7 @@ async def build_messages_for_libraries(
     messages = [
         Message(
             role="system",
-            content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(statement=statement, context=context),
+            content=_render_system(statement=statement, context=context),
         )
     ]
     messages += _history_messages(turns, await _cited_titles(session, turns))
@@ -454,7 +485,7 @@ async def build_scoped_messages(
         messages = [
             Message(
                 role="system",
-                content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(
+                content=_render_system(
                     statement=statement_text, context="（还没有收藏任何论文）"
                 ),
             )
@@ -532,7 +563,7 @@ async def build_scoped_messages(
         concept_line = f"\n概念：{'、'.join(names)}" if names else ""
         fig_line = _figure_hints(paper)
         blocks.append(
-            f"[{i}] {paper.title}（{paper.year or '年份未知'}）{concept_line}{fig_line}\n{body}"
+            f"[{i}] {paper.title}（{_dateline(paper)}）{concept_line}{fig_line}\n{body}"
         )
         sources.append(
             ChatSource(
@@ -550,7 +581,7 @@ async def build_scoped_messages(
     messages = [
         Message(
             role="system",
-            content=LIBRARY_CHAT_SYSTEM_TEMPLATE.format(statement=statement_text, context=context),
+            content=_render_system(statement=statement_text, context=context),
         )
     ]
     messages += _history_messages(turns, await _cited_titles(session, turns))
@@ -611,7 +642,7 @@ async def build_reference_context(
             body = ("\n…\n".join(c.text for c in chunk_list))[:SNIPPET_CHARS]
         else:
             body = paper.tldr or (paper.abstract or "")[:400] or "（无摘要）"
-        blocks.append(f"[{i}] {paper.title}（{paper.year or '年份未知'}）\n{body}")
+        blocks.append(f"[{i}] {paper.title}（{_dateline(paper)}）\n{body}")
         membership = memberships.get(paper.id)
         sources.append(
             ChatSource(

--- a/src/backend/tests/test_library_chat.py
+++ b/src/backend/tests/test_library_chat.py
@@ -309,3 +309,56 @@ async def test_previously_cited_paper_is_pinned_into_context(client, monkeypatch
     # 检索命中的那篇仍在，且排在钉进来的前面（更贴题的占小编号）
     assert source_ids[0] == ids[0]
     assert "Reflexion Self-Improvement" in messages[0].content
+
+
+# ---- 「最近 7 天」问得出来：上下文要带日期，系统提示要带今天 ----
+
+
+async def test_context_carries_the_publication_date_not_just_the_year(client):
+    """每篇论文在上下文里要标到**天**，并且告诉模型今天是哪天。
+
+    生产上问「最近 7 天有哪些值得关注的新论文」，模型如实回答「资料均为 2025 至 2026 年
+    的研究成果，但具体发表日期未提供，无法确认是否在最近 7 天范围内」——它没说错：
+    上下文里每篇只写了年份（`（2026）`），而每日池里的论文本来都带着 published_at。
+    """
+    import datetime as dt
+
+    from sqlalchemy import select as _select
+
+    from app.models.paper import Paper
+    from app.services import library_chat as lc
+
+    project_id, headers, ids = await _setup(client)
+    await client.post(f"/api/projects/{project_id}/index/rebuild", headers=headers)
+
+    published = dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+    async with get_sessionmaker()() as session:
+        paper = (
+            await session.execute(_select(Paper).where(Paper.id == uuid.UUID(ids[0])))
+        ).scalar_one()
+        paper.published_at = published
+        await session.commit()
+
+    session, project, llm = await _project_and_router(project_id)
+    async with session:
+        messages, _ = await lc.build_library_messages(
+            session, project=project, question="最近 7 天有哪些新论文？", history=[], llm=llm
+        )
+
+    system = messages[0].content
+    assert published.date().isoformat() in system, "上下文里要给到具体日期，不能只有年份"
+    today = dt.datetime.now(dt.UTC).date().isoformat()
+    assert today in system, "不告诉模型今天几号，它算不出「最近 7 天」"
+
+
+async def test_dateline_falls_back_to_the_year_when_no_date_is_known(client):
+    """没有 published_at 的老论文退回年份，都没有则明说未知——不能因此空着。"""
+    import datetime as dt
+
+    from app.models.paper import Paper
+    from app.services.library_chat import _dateline
+
+    assert _dateline(Paper(title="t", year=2024)) == "2024"
+    assert _dateline(Paper(title="t")) == "日期未知"
+    exact = dt.datetime(2026, 7, 30, 6, 0, tzinfo=dt.UTC)
+    assert _dateline(Paper(title="t", year=2026, published_at=exact)) == "2026-07-30"


### PR DESCRIPTION
## What the user saw

Asked in the daily-papers chat: *"Which noteworthy new papers appeared in the last 7 days?"*

The answer: *"No papers published within the last 7 days were found in the library. All the material is 2025–2026 research, but no specific publication dates are given, so I cannot confirm whether any falls within the last 7 days."* — while citing eight papers, all from the pool.

## Why it happened

The model was right. Each paper enters the context as:

```
[1] Inference-Time Agentic Decision Rules …（2026）
```

Only the year. Every daily-pool paper carries a `published_at` from the RSS fetch, but it never reached the prompt, so "is this within 7 days?" was genuinely unanswerable from what the model was given.

There was a second gap: the system prompt never states today's date. Even with per-paper dates, the model cannot work out which window "the last 7 days" refers to.

## What changed

- `_dateline(paper)` — the date is given to the day when known (`2026-07-30`), falls back to the year for older papers with no `published_at`, and says `日期未知` when neither exists. Never blank.
- The system prompt now carries today's UTC date and tells the model to judge "recent / latest" by the dates in the material.
- The four places that rendered the system prompt now go through `_render_system()`. The template gained a placeholder, and four separate `.format()` calls means one missed site is a `KeyError` — plus the date would be computed independently at each.

This applies to library chat and personal-library chat too, not just the daily pool.

## Tests

Two new tests: a paper published two days ago has its exact date in the context and today's date appears in the system prompt; `_dateline` falls back correctly across the three cases. Both fail against `origin/main`.

Full backend suite **947 passed**; `ruff check app` clean.

Note: verified at the prompt-construction level — the assertion is that the date reaches the model, not that a particular model then answers the question correctly.