### PR TITLE
fix(daily): tell "arXiv had nothing" apart from "the pool actually stalled"

### DIFF
--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -150,6 +150,10 @@ class DailySyncStatus(BaseModel):
     """每日论文池的同步健康状况（每日页顶部展示）。"""
 
     latest_feed_date: str | None = None
+    #: fresh（已跟上）/ waiting（今天该发、还在探）/ quiet（arXiv 自己没发：周末、节假日）
+    #: / stalled（该发的日子过了却没跟上）/ failed（有分类抓失败）
+    feed_state: Literal["fresh", "waiting", "quiet", "stalled", "failed"] = "fresh"
+    #: 旧口径：只在 stalled 时为真（周末与等待中不再算「停更」）
     stale: bool = False
     last_run_id: str | None = None
     last_run_status: str | None = None

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1189,9 +1189,18 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
     # 今天还没抓到新批次时，界面上要能区分「还在探」和「探完了今天就是没有」——
     # 否则用户只看到「最新是昨天」，无从判断该等还是该查。
     probe = await probe_state(session, now=now)
+    state = feed_state(
+        latest=latest,
+        today=today,
+        probe=probe,
+        max_attempts=await get_max_probe_attempts(session),
+        failed=bool(failed),
+    )
     return {
         "latest_feed_date": latest.isoformat() if latest else None,
-        "stale": bool(latest is None or (today - latest).days > 1),
+        "feed_state": state,
+        # stale 保留旧口径的语义（「该提醒人了」），但不再把周末与等待中的情况算进来
+        "stale": state == "stalled",
         "last_run_id": str(run.id) if run is not None else None,
         "last_run_status": run.status if run is not None else None,
         "last_run_at": run.created_at.isoformat() if run is not None else None,
@@ -1202,6 +1211,57 @@ async def sync_status(session: AsyncSession) -> dict[str, Any]:
         "probe_batch_date": probe["batch_date"],
         "probe_exhausted": probe["exhausted"],
     }
+
+
+#: arXiv 的 RSS skipDays 里写明周六周日不公告；这两天没有新批次是**正常**的。
+_PUBLISHING_WEEKDAYS = frozenset({0, 1, 2, 3, 4})
+
+
+def last_publishing_day(today: dt.date) -> dt.date:
+    """今天（含）往回数，第一个 arXiv 会公告的日子。"""
+    day = today
+    while day.weekday() not in _PUBLISHING_WEEKDAYS:
+        day -= dt.timedelta(days=1)
+    return day
+
+
+def feed_state(
+    *,
+    latest: dt.date | None,
+    today: dt.date,
+    probe: dict[str, Any],
+    max_attempts: int,
+    failed: bool = False,
+) -> str:
+    """池子现在算什么状态：``fresh`` / ``waiting`` / ``quiet`` / ``stalled`` / ``failed``。
+
+    起因是界面上只有一个「已停更」：周日看到「最新 2026-07-31」就报停更，可 arXiv
+    周末本来就不公告，什么毛病也没有。把「没更新」拆成三种：
+
+    - ``waiting``：今天该公告，检查点还在探（没探满）。等就是了。
+    - ``quiet``：arXiv 自己没有更新的批次——周末/节假日，或者探满了仍是旧批次。
+      判据用探到的批次日期与池子最新日期比：两者一致说明我们与 arXiv 同步，
+      是**它**没发新的，不是我们没抓到。
+    - ``stalled``：该公告的日子过去了，池子却没跟上，也没有「arXiv 没发」的证据。
+      这才是要提醒人去查的那种。
+    """
+    if failed:
+        return "failed"
+    if latest is None:
+        return "stalled"
+    expected = last_publishing_day(today)
+    if latest >= expected:
+        return "fresh"
+    # 今天不该公告（周末），而池子已经跟上了最后一个公告日 → 正常的安静
+    if today.weekday() not in _PUBLISHING_WEEKDAYS:
+        return "quiet"
+    probe_batch = probe.get("batch_date")
+    if probe_batch and probe_batch == latest.isoformat():
+        # 探到的最新批次就是池子里这一批：arXiv 没发新的，我们没落后
+        return "quiet" if probe.get("exhausted") else "waiting"
+    if int(probe.get("attempts") or 0) < max_attempts:
+        return "waiting"
+    return "stalled"
 
 
 # ---- 抓取时刻（可配置） ----

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -942,7 +942,10 @@ async def test_sync_status_reports_failed_categories(client, monkeypatch):
     assert status["failed_categories"] == ["cs.AI"]
     assert status["last_run_status"] == "paused_error"
     assert status["per_category"]["cs.CL"]["count"] == 12
-    assert status["stale"] is True  # 池子里一条 entry 都没有
+    # 有分类抓失败时优先报失败（比「停更」更接近原因，也更可操作）；
+    # stale 现在只在 stalled 时为真，所以这里是 False。
+    assert status["feed_state"] == "failed"
+    assert status["stale"] is False
 
     resp = await client.get(
         "/api/daily/sync-status",
@@ -1215,6 +1218,102 @@ async def test_max_probe_attempts_defaults_to_ten_and_is_configurable(client):
     for bad in (0, 97):
         resp = await client.put("/api/daily/probe-attempts", json={"attempts": bad}, headers=admin)
         assert resp.status_code == 422, bad
+
+
+async def test_weekend_pool_is_quiet_not_stalled(client):
+    """周日看到「最新是周五」不该报停更——arXiv 周末本来就不公告。
+
+    界面上一度只有一个「论文池已停更」，把「周末没发」「今天还没发」「真的落后了」
+    混成一句话，于是每个周末都在报一次假警。
+    """
+    import datetime as dt
+
+    from app.services.daily_feed import feed_state
+
+    await register_and_login(client)
+    friday, saturday, sunday = dt.date(2026, 7, 31), dt.date(2026, 8, 1), dt.date(2026, 8, 2)
+    idle = {"attempts": 0, "batch_date": None, "exhausted": False}
+    # 周末拿着周五那批就是**已跟上**：更新的批次根本不存在，没什么可等的
+    assert feed_state(latest=friday, today=saturday, probe=idle, max_attempts=10) == "fresh"
+    assert feed_state(latest=friday, today=sunday, probe=idle, max_attempts=10) == "fresh"
+    assert feed_state(latest=friday, today=friday, probe=idle, max_attempts=10) == "fresh"
+    # 周末而池子还停在更早的日子（周四）→ 也不催：周末补不上，等周一
+    thursday = dt.date(2026, 7, 30)
+    assert feed_state(latest=thursday, today=sunday, probe=idle, max_attempts=10) == "quiet"
+
+
+async def test_waiting_for_todays_batch_is_not_stalled(client):
+    """工作日、检查点还在探的时候是「等待」，不是故障。"""
+    import datetime as dt
+
+    from app.services.daily_feed import feed_state
+
+    await register_and_login(client)
+    monday, tuesday = dt.date(2026, 8, 3), dt.date(2026, 8, 4)
+    probing = {"attempts": 3, "batch_date": monday.isoformat(), "exhausted": False}
+    assert feed_state(latest=monday, today=tuesday, probe=probing, max_attempts=10) == "waiting"
+
+    # 探满了，而探到的最新批次就是池子里这批 → arXiv 自己没发，我们没落后
+    done = {"attempts": 10, "batch_date": monday.isoformat(), "exhausted": True}
+    assert feed_state(latest=monday, today=tuesday, probe=done, max_attempts=10) == "quiet"
+
+
+async def test_genuinely_behind_is_reported_as_stalled(client):
+    """该公告的日子过去了、池子没跟上、又没有「arXiv 没发」的证据 → 这才要提醒人。"""
+    import datetime as dt
+
+    from app.services.daily_feed import feed_state
+
+    await register_and_login(client)
+    exhausted_no_evidence = {"attempts": 10, "batch_date": None, "exhausted": True}
+    assert (
+        feed_state(
+            latest=dt.date(2026, 7, 28),
+            today=dt.date(2026, 8, 4),
+            probe=exhausted_no_evidence,
+            max_attempts=10,
+        )
+        == "stalled"
+    )
+    # 池子空 → 一样要提醒
+    assert (
+        feed_state(
+            latest=None, today=dt.date(2026, 8, 4), probe=exhausted_no_evidence, max_attempts=10
+        )
+        == "stalled"
+    )
+    # 有分类抓失败时优先报失败
+    assert (
+        feed_state(
+            latest=dt.date(2026, 8, 4),
+            today=dt.date(2026, 8, 4),
+            probe=exhausted_no_evidence,
+            max_attempts=10,
+            failed=True,
+        )
+        == "failed"
+    )
+
+
+async def test_last_publishing_day_skips_the_weekend(client):
+    import datetime as dt
+
+    from app.services.daily_feed import last_publishing_day
+
+    await register_and_login(client)
+    friday = dt.date(2026, 7, 31)
+    assert last_publishing_day(dt.date(2026, 8, 1)) == friday  # 周六
+    assert last_publishing_day(dt.date(2026, 8, 2)) == friday  # 周日
+    assert last_publishing_day(friday) == friday
+    assert last_publishing_day(dt.date(2026, 8, 3)) == dt.date(2026, 8, 3)  # 周一
+
+
+async def test_sync_status_reports_the_feed_state(client, monkeypatch):
+    """接口要把状态发出来，而且 stale 只在 stalled 时为真（前端旧口径靠它）。"""
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    body = (await client.get("/api/daily/sync-status", headers=headers)).json()
+    assert body["feed_state"] in {"fresh", "waiting", "quiet", "stalled", "failed"}
+    assert body["stale"] is (body["feed_state"] == "stalled")
 
 
 async def test_sync_status_shows_how_far_the_probe_has_got(client, monkeypatch):

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -579,26 +579,53 @@ function SyncStatusPill() {
   if (!data) return null;
 
   const failed = data.failed_categories;
-  const bad = failed.length > 0;
-  const stale = data.stale && !bad;
-  if (!bad && !stale) {
+  const latest = data.latest_feed_date ?? '—';
+  // 旧后端没有 feed_state：按老口径折算，不然会一律显示成「已跟上」
+  const state = data.feed_state ?? (failed.length > 0 ? 'failed' : data.stale ? 'stalled' : 'fresh');
+
+  // 已跟上、以及「arXiv 自己没发」——都不是问题，用常规灰字，不摆警告
+  if (state === 'fresh' || state === 'quiet') {
     return (
       <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 10 }}>
-        {tr(`已更新至 ${data.latest_feed_date ?? '—'}`, `Updated to ${data.latest_feed_date ?? '—'}`)}
+        {state === 'quiet'
+          ? tr(`arXiv 未更新 · 最新 ${latest}`, `Nothing new on arXiv · latest ${latest}`)
+          : tr(`已更新至 ${latest}`, `Updated to ${latest}`)}
       </span>
     );
   }
-  const label = bad
-    ? tr(`${failed.join('、')} 抓取失败`, `${failed.join(', ')} failed to fetch`)
-    : tr(`论文池已停更（最新 ${data.latest_feed_date ?? '无'}）`, `Feed is stale (latest ${data.latest_feed_date ?? 'none'})`);
+
+  // 今天该公告、还在等：也不是故障，说清楚在等什么
+  if (state === 'waiting') {
+    const probed =
+      data.probe_attempts !== undefined && data.probe_max_attempts
+        ? `（${data.probe_attempts}/${data.probe_max_attempts}）`
+        : '';
+    return (
+      <span
+        className="mono"
+        style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 10 }}
+        title={tr(
+          'arXiv 每天约北京时间 12:00 放当天批次，平台从设定时刻起每 15 分钟探一次',
+          'arXiv publishes the day’s batch around 04:00 UTC; the platform probes every 15 minutes from the configured time',
+        )}
+      >
+        {tr(`等待今天的批次${probed} · 最新 ${latest}`, `Waiting for today’s batch${probed} · latest ${latest}`)}
+      </span>
+    );
+  }
+
+  const label =
+    state === 'failed'
+      ? tr(`${failed.join('、')} 抓取失败`, `${failed.join(', ')} failed to fetch`)
+      : tr(`论文池已停更（最新 ${latest}）`, `Feed is stale (latest ${latest})`);
   return (
     <span
       className={data.last_run_id ? 'pill sm hoverable' : 'pill sm'}
       style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)', marginLeft: 10 }}
       title={
-        bad
+        state === 'failed'
           ? tr('这些分类当天的新论文不会进池，各文献库也就收不到', 'Those categories will not enter the pool today, so no library will receive them')
-          : tr('每日抓取已超过一天没有成功', 'The daily fetch has not succeeded for more than a day')
+          : tr('该公告的日子已经过去，池子却没跟上——不是周末，也不是 arXiv 没发', 'A publishing day has passed without the pool catching up — not a weekend, and not arXiv having nothing')
       }
       onClick={data.last_run_id ? () => navigate(`/voyages/${data.last_run_id}`) : undefined}
     >

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2780,9 +2780,18 @@ export interface DailyCollectionsRead {
 }
 
 /** 每日论文池的同步状况。池子是所有文献库的唯一供给，抓失败=全实验室当天颗粒无收。 */
+/** 池子状态：已跟上 / 今天该发还在等 / arXiv 自己没发（周末、节假日）/ 真的落后了 / 抓取失败。 */
+export type DailyFeedState = 'fresh' | 'waiting' | 'quiet' | 'stalled' | 'failed';
+
 export interface DailySyncStatus {
   latest_feed_date: string | null;
+  feed_state: DailyFeedState;
+  /** 旧口径：只在 stalled 时为真 */
   stale: boolean;
+  probe_attempts?: number;
+  probe_max_attempts?: number;
+  probe_batch_date?: string | null;
+  probe_exhausted?: boolean;
   last_run_id: string | null;
   last_run_status: string | null;
   last_run_at: string | null;


### PR DESCRIPTION
## Why

The daily page had one warning — **"Feed is stale (latest 2026-07-31)"** — decided by "the newest day is neither today nor yesterday". On a Sunday that fires every single week: arXiv does not announce on Saturday or Sunday, so a pool holding Friday's batch is perfectly healthy. A warning that cries wolf every weekend is a warning nobody reads when it matters.

## The states

`sync_status` now returns `feed_state`:

| state | when | shown as |
|---|---|---|
| `fresh` | the pool's newest batch is at or past the **most recent publishing day** (weekends skipped) | plain grey "Updated to 07-31" |
| `waiting` | today is a publishing day and the probe is still going (attempts below the cap) | plain grey "Waiting for today's batch (3/10)" |
| `quiet` | arXiv itself has nothing newer — a weekend that cannot be caught up, or the probe exhausted on the same batch | plain grey "Nothing new on arXiv · latest …" |
| `stalled` | a publishing day has passed, the pool did not catch up, and there is no evidence arXiv had nothing | amber warning |
| `failed` | a category failed to fetch | amber warning, takes precedence |

Only `stalled` and `failed` are warnings. The case from the report — Sunday, latest 07-31 — is now `fresh`, because no newer batch exists to be waiting for.

The discriminator between "holiday" and "genuinely broken" is **the probed batch date versus the pool's newest date**. If they match, we are in step with arXiv and *it* published nothing; if the pool is behind a batch arXiv did announce, that is a real stall. That probe state was already recorded in #241 — this puts it to use.

## Contract change

`stale` is now true only for `stalled`. The existing test `test_sync_status_reports_failed_categories` asserted "empty pool → `stale is True`"; that scenario now reports `failed`, which names the cause and is more actionable than "stale". Its assertion was updated accordingly.

The frontend keeps a fallback for older backends — `feed_state ?? (failed ? 'failed' : stale ? 'stalled' : 'fresh')` — so a deployment lagging the frontend does not silently show everything as healthy.

## Tests

Five new tests covering each branch: weekends read as fresh (and as quiet when the pool is behind a weekday batch it cannot catch up over the weekend); waiting while probing, quiet once the probe exhausts on the same batch; genuinely behind, empty pool, and failed-takes-precedence; and `last_publishing_day` skipping Saturday and Sunday; plus the endpoint reporting a valid state with `stale` consistent with it.

Full backend suite **962 passed**; `ruff check app` and frontend `tsc --noEmit` clean.

Frontend wording was not verified in a running deployment — this repo has no frontend test tooling.