### PR TITLE
fix(lab): put the AI usage bars back on one baseline

### DIFF
--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -564,11 +564,22 @@ function UsageBars({ rows }: { rows: { date: string; prompt: number; completion:
                 }}
               />
             </div>
-            {i % labelEvery === 0 && (
-              <div className="mono" style={{ fontSize: 9, color: 'var(--text-4)', textAlign: 'center', marginTop: 4 }}>
-                {r.date.slice(5)}
-              </div>
-            )}
+            {/* 标签行**每列都占位**：只给带日期的列渲染这一行的话，那几列会比邻居高出
+                一行，而外层是 flex-end 底部对齐——结果是带日期的柱子整体被顶高一截，
+                日期文字插进邻居柱子的半腰，基线也就散了。 */}
+            <div
+              className="mono"
+              style={{
+                height: 13,
+                fontSize: 9,
+                color: 'var(--text-4)',
+                textAlign: 'center',
+                marginTop: 4,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {i % labelEvery === 0 ? r.date.slice(5) : ''}
+            </div>
           </div>
         );
       })}


### PR DESCRIPTION
## The bug

In the lab's **AI usage** card, the daily bars did not share a baseline. Every fourth bar — the ones carrying a date — sat about 13px higher than its neighbours, and its date label landed halfway up the adjacent bars instead of on a row of its own.

The cause: with many bars only every *n*-th column renders a date, and the label was rendered **only for those columns**. The row is `align-items: flex-end`, so a column with a label is one line taller than one without, and bottom-aligning them pushes the labelled column's bar up by exactly the label's height.

## The fix

The label row is now present in every column at a fixed height, holding the date when there is one and empty otherwise. Every column is the same height, so the bars land on one baseline and the dates line up on a single row.

## Verification

No frontend test tooling in this repo, so beyond `tsc --noEmit` I rendered a standalone replica — same flex structure, same 88px bar box, same "label every n-th column" rule — in Chrome, before and after.

Before: the labelled bars are visibly raised and their dates sit level with the middle of neighbouring bars, exactly as reported. After: one baseline, one row of dates.

This is a replica of the layout, not the real component with real data; the change is style-only and was not verified in a running deployment.