### PR TITLE
docs(mcp): make the tool descriptions read like an API, not like notes

### DIFF
--- a/src/backend/app/tools/external.py
+++ b/src/backend/app/tools/external.py
@@ -34,7 +34,7 @@ def _s2_brief(row: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "external_search",
-    description="库外文献检索（Semantic Scholar，失败降级 OpenAlex）——找库里还没有的论文",
+    description="检索平台文献库之外的论文，数据源为 Semantic Scholar，不可用时降级为 OpenAlex",
     input_schema={
         "type": "object",
         "properties": {
@@ -109,7 +109,7 @@ _REF_SCHEMA = {
 
 @tool(
     "get_references",
-    description="某论文引用的参考文献（它站在谁的肩膀上）",
+    description="列出某篇论文引用的参考文献",
     input_schema=_REF_SCHEMA,
     network=True,
     summarize=lambda a, r: f"参考文献 → {len(r.get('references') or [])} 篇",
@@ -122,7 +122,7 @@ async def get_references(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 
 @tool(
     "get_citations",
-    description="引用某论文的后续工作（谁在它基础上继续做）",
+    description="列出引用了某篇论文的后续工作",
     input_schema=_REF_SCHEMA,
     network=True,
     summarize=lambda a, r: f"施引文献 → {len(r.get('citations') or [])} 篇",
@@ -135,7 +135,7 @@ async def get_citations(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
 
 @tool(
     "lookup_paper",
-    description="按 DOI 查库外论文元数据（含被引数）",
+    description="按 DOI 查询库外论文的元数据，含被引数",
     input_schema={
         "type": "object",
         "properties": {"doi": {"type": "string", "description": "DOI"}},

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -92,7 +92,7 @@ def _clamp_max_dim(raw: Any) -> int:
 
 @tool(
     "list_paper_figures",
-    description="列出某论文所有图的元数据（index/页码/类型/图注），不含图片本体",
+    description="列出某篇论文全部插图的元数据，含编号、页码、类型与图注，不含图片本体",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -113,7 +113,7 @@ async def list_paper_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 
 @tool(
     "get_paper_figure",
-    description="取某论文某张图的图片（PNG）+ 图注，用于 PPT / 展示 / 视觉说明",
+    description="取某篇论文指定编号的插图，返回 PNG 图片与图注",
     input_schema={
         "type": "object",
         "properties": {
@@ -149,7 +149,7 @@ async def get_paper_figure(ctx: ToolContext, args: dict[str, Any]) -> ToolResult
 
 @tool(
     "get_paper_figures",
-    description="批量取某论文的图片（默认只取重要图，可按 kind 过滤）——做 PPT 一次拿全套",
+    description="批量取某篇论文的插图，默认只取重要图，可按类型筛选",
     input_schema={
         "type": "object",
         "properties": {
@@ -198,7 +198,9 @@ async def get_paper_figures(ctx: ToolContext, args: dict[str, Any]) -> ToolResul
 
 @tool(
     "find_figures",
-    description="跨库按主题/类型找图（返回图元数据，再用 get_paper_figure 取图本体）",
+    description=(
+        "在本课题语料内按主题或类型检索插图，返回图片元数据；取图片本体请用 get_paper_figure"
+    ),
     input_schema={
         "type": "object",
         "properties": {
@@ -251,7 +253,7 @@ async def find_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
 
 @tool(
     "get_paper_citation",
-    description="取某论文的引用条目（BibTeX 或 CSL-JSON），用于 PPT / 论文署名",
+    description="取某篇论文的引用条目，格式为 BibTeX 或 CSL-JSON",
     input_schema={
         "type": "object",
         "properties": {
@@ -276,7 +278,7 @@ async def get_paper_citation(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 
 @tool(
     "get_paper_notes",
-    description="取某论文下当前用户的笔记（P5b 起笔记仅作者本人可见）",
+    description="取当前用户在某篇论文下的笔记；笔记仅作者本人可见",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -303,7 +305,7 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 
 @tool(
     "get_paper_highlights",
-    description="取某论文下当前用户的划线/高亮（含所在页与选中文本；仅作者本人可见）",
+    description="取当前用户在某篇论文下的划线，含所在页码与选中文本；划线仅作者本人可见",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -337,7 +339,7 @@ async def get_paper_highlights(ctx: ToolContext, args: dict[str, Any]) -> dict[s
 
 @tool(
     "related_papers",
-    description="与某论文共享概念最多的近邻论文（扩展调研）",
+    description="列出与某篇论文共享概念最多的近邻论文",
     input_schema={
         "type": "object",
         "properties": {

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -24,7 +24,7 @@ _MAX_K = 12
 
 @tool(
     "search_chunks",
-    description="全文段落级语义检索（比 search_papers 更细，直接命中相关段落）",
+    description="在本课题语料内做段落级检索，直接返回相关段落，粒度比 search_papers 更细",
     input_schema={
         "type": "object",
         "properties": {
@@ -102,7 +102,7 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
 
 @tool(
     "get_paper",
-    description="取某论文的元数据 + 概念标签（不含全文，全文用 read_fulltext）",
+    description="取某篇论文的元数据与概念标签，不含全文；全文请用 read_fulltext",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -150,7 +150,7 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "knowledge_graph",
-    description="项目知识图谱：论文/概念/作者节点与关联边",
+    description="取本课题的知识图谱，含论文、概念、作者节点及其关联边",
     input_schema={"type": "object", "properties": {}},
     summarize=lambda a, r: f"知识图谱（{len(r.get('nodes') or [])} 节点）",
 )
@@ -161,7 +161,7 @@ async def knowledge_graph(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
 
 @tool(
     "global_search",
-    description="跨实体检索：论文/概念/想法/实验/稿件/任务（确定性 ilike）",
+    description="在本课题内按关键词跨实体检索论文、概念、想法、实验、稿件与任务",
     input_schema={
         "type": "object",
         "properties": {"q": {"type": "string", "description": "检索关键词"}},

--- a/src/backend/app/tools/libraries.py
+++ b/src/backend/app/tools/libraries.py
@@ -51,7 +51,7 @@ def _library_brief(row: dict[str, Any], *, linked: bool) -> dict[str, Any]:
 
 @tool(
     "list_libraries",
-    description="我能看到的方向文献库清单（含论文/概念计数、是否已关联到本课题）",
+    description="列出当前用户可见的方向文献库，含论文与概念计数，以及是否已关联到本课题",
     input_schema={
         "type": "object",
         "properties": {
@@ -85,7 +85,7 @@ async def list_libraries(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 
 @tool(
     "get_library",
-    description="文献库详情：方向说明、收录关键词与锚点论文、论文/概念计数、同步节奏",
+    description="取某个文献库的详情，含方向说明、收录关键词与锚点论文、论文与概念计数及同步节奏",
     input_schema={
         "type": "object",
         "properties": {"library_id": {"type": "string", "description": "文献库 uuid"}},
@@ -121,7 +121,7 @@ async def get_library(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "search_daily_pool",
-    description="检索每日新论文池（arXiv 当日新公告的上游候选，尚未收进任何文献库）",
+    description="检索每日新论文池，即 arXiv 当日新公告中尚未收录进任何文献库的候选论文",
     input_schema={
         "type": "object",
         "properties": {

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -72,7 +72,7 @@ async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> Pap
 
 @tool(
     "search_papers",
-    description="库内检索论文",
+    description="在本课题语料内检索论文，支持关键词与语义两种模式",
     input_schema={
         "type": "object",
         "properties": {
@@ -126,7 +126,7 @@ async def search_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
 
 @tool(
     "read_wiki",
-    description="读某论文的 wiki 综述页",
+    description="读取某篇论文的 wiki 解读页；尚未编译解读时返回摘要",
     input_schema={
         "type": "object",
         "properties": {"paper_id": {"type": "string", "description": "论文 uuid"}},
@@ -161,7 +161,7 @@ def _read_fulltext_summary(a: dict[str, Any], r: dict[str, Any]) -> str:
 
 @tool(
     "read_fulltext",
-    description="读论文全文（有 query 返回最相关段落，否则按 page 分页）",
+    description="读取论文全文；给定 query 时返回最相关段落，否则按 page 分页返回",
     input_schema={
         "type": "object",
         "properties": {
@@ -211,7 +211,7 @@ async def read_fulltext(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
 
 @tool(
     "get_concept",
-    description="概念定义 + 相关概念 + 关联论文",
+    description="查询某个概念的定义、相关概念与关联论文",
     input_schema={
         "type": "object",
         "properties": {"name": {"type": "string", "description": "概念名"}},
@@ -255,7 +255,7 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "list_concepts",
-    description="项目概念清单",
+    description="列出本课题语料中的概念，可按类别筛选",
     input_schema={
         "type": "object",
         "properties": {

--- a/src/backend/app/tools/project_state.py
+++ b/src/backend/app/tools/project_state.py
@@ -37,7 +37,7 @@ def _idea_brief(idea: Idea) -> dict[str, Any]:
 
 @tool(
     "list_ideas",
-    description="项目想法清单（可按 status/depth/research_type 过滤）",
+    description="列出本课题的想法，可按状态、深度与研究类型筛选",
     input_schema={
         "type": "object",
         "properties": {
@@ -62,7 +62,7 @@ async def list_ideas(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "get_idea",
-    description="取某想法的完整内容（动机/方法/预期实验/风险 + 结构化 goal）",
+    description="取某个想法的完整内容，含动机、方法、预期实验、风险与结构化研究目标",
     input_schema={
         "type": "object",
         "properties": {"idea_id": {"type": "string", "description": "想法 uuid"}},
@@ -88,7 +88,7 @@ async def get_idea(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "list_experiments",
-    description="项目实验清单（状态 + 关联想法标题）",
+    description="列出本课题的实验，含状态与关联想法标题",
     input_schema={"type": "object", "properties": {}},
     summarize=lambda a, r: f"实验清单（{len(r.get('experiments') or [])} 条）",
 )
@@ -109,7 +109,7 @@ async def list_experiments(ctx: ToolContext, args: dict[str, Any]) -> dict[str, 
 
 @tool(
     "get_experiment",
-    description="取某实验详情（假设/计划/运行记录与指标）",
+    description="取某个实验的详情，含假设、计划、各轮运行记录与指标",
     input_schema={
         "type": "object",
         "properties": {"experiment_id": {"type": "string", "description": "实验 uuid"}},
@@ -138,7 +138,7 @@ async def get_experiment(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 
 @tool(
     "read_experiment_logs",
-    description="读实验某一轮运行的训练日志尾部（不给 run_id 就读最近一轮）",
+    description="读取实验某一轮运行的训练日志尾部；未指定 run_id 时读取最近一轮",
     input_schema={
         "type": "object",
         "properties": {
@@ -199,7 +199,7 @@ async def read_experiment_logs(ctx: ToolContext, args: dict[str, Any]) -> dict[s
 
 @tool(
     "get_fact_pack",
-    description="取稿件的事实包：关联想法 + 实验假设/指标/图表 + 项目引用（写作取料用）",
+    description="取某份稿件的事实包，含关联想法、实验假设与指标、图表及可引用文献，供写作取材使用",
     input_schema={
         "type": "object",
         "properties": {"manuscript_id": {"type": "string", "description": "稿件 uuid"}},

--- a/src/backend/app/tools/workspace.py
+++ b/src/backend/app/tools/workspace.py
@@ -92,7 +92,7 @@ async def _get_task(session: Any, ctx: ToolContext, raw_id: Any) -> VoyageRun:
 
 @tool(
     "get_project_status",
-    description="课题总览：论文/想法/实验/稿件计数、待审闸门数、关联文献库、在跑任务、最近动态",
+    description="取本课题总览，含论文、想法、实验与稿件计数，待审闸门数量，关联文献库，进行中的任务与最近动态",
     input_schema={"type": "object", "properties": {}},
     summarize=lambda a, r: f"课题总览（{r.get('papers_total', 0)} 篇论文）",
 )
@@ -115,7 +115,7 @@ async def get_project_status(ctx: ToolContext, args: dict[str, Any]) -> dict[str
 
 @tool(
     "list_tasks",
-    description="课题的 AI 任务清单（建库抓取/想法生成/评审/实验/写作等），新→旧",
+    description="列出本课题的 AI 任务，按创建时间由新到旧排列，可按状态与类型筛选",
     input_schema={
         "type": "object",
         "properties": {
@@ -174,7 +174,7 @@ def _last_error(run: VoyageRun) -> str | None:
 
 @tool(
     "get_task",
-    description="任务详情：状态、计划步骤与判定、卡在哪个闸门、失败原因、产出物 id",
+    description="取某个任务的详情，含状态、计划步骤与判定结果、正在阻塞它的审批闸门、失败原因与产出物标识",
     input_schema={
         "type": "object",
         "properties": {
@@ -228,7 +228,7 @@ async def get_task(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 
 @tool(
     "read_task_logs",
-    description="读任务的终端日志（结构化日志行 + 大模型输出），按时间正序返回最近若干条",
+    description="读取某个任务的终端日志，含结构化日志行与模型输出，按时间正序返回最近若干条",
     input_schema={
         "type": "object",
         "properties": {
@@ -269,7 +269,7 @@ async def read_task_logs(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 
 @tool(
     "list_gates",
-    description="课题的人工审批闸门（想法晋级/算力预算/投稿等）；审批仍需在网页端操作",
+    description="列出本课题的人工审批闸门，含想法晋级、算力预算与投稿等类型；审批操作需在网页端完成",
     input_schema={
         "type": "object",
         "properties": {

--- a/src/backend/app/tools/writing.py
+++ b/src/backend/app/tools/writing.py
@@ -62,7 +62,7 @@ async def _get_manuscript(
 
 @tool(
     "list_manuscripts",
-    description="课题的稿件清单（标题/模板/状态/是否评审通过/上次编译结果）",
+    description="列出本课题的稿件，含标题、模板、状态、评审结论与上次编译结果",
     input_schema={
         "type": "object",
         "properties": {
@@ -83,7 +83,7 @@ async def list_manuscripts(ctx: ToolContext, args: dict[str, Any]) -> dict[str, 
 
 @tool(
     "get_manuscript",
-    description="稿件详情：文件树（路径/大小/是否只读）、编译入口与引擎、上次编译诊断",
+    description="取某份稿件的详情，含文件树、编译入口与引擎、上次编译诊断",
     input_schema={
         "type": "object",
         "properties": {"manuscript_id": {"type": "string", "description": "稿件 uuid"}},
@@ -117,7 +117,7 @@ async def get_manuscript(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 
 @tool(
     "read_manuscript_file",
-    description="读稿件里某个文件的内容（按 path 定位，长文件按 page 分页）",
+    description="读取稿件中某个文件的内容，按路径定位，长文件分页返回",
     input_schema={
         "type": "object",
         "properties": {

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -60,11 +60,29 @@ def test_registry_has_expected_tools():
         assert spec.read_only is True
 
 
+def test_tool_descriptions_are_formal():
+    """工具描述是外部客户端唯一的选型依据，必须正式、完整、无破折号。
+
+    破折号在这里尤其糟：它把「这个工具是什么」和一句口语补充黏成一句，
+    模型读到的是语气而不是能力边界。要补充就写成完整的一句话。
+    """
+    for spec in tools.list_tools():
+        desc = spec.description
+        assert desc and desc.strip() == desc, spec.name
+        assert "——" not in desc and "—" not in desc, f"{spec.name} 的描述里有破折号：{desc}"
+        assert "→" not in desc, f"{spec.name} 的描述里有箭头：{desc}"
+        # 参数描述同样面向模型，一并守住
+        for pname, prop in (spec.input_schema.get("properties") or {}).items():
+            pdesc = prop.get("description")
+            if pdesc:
+                assert "——" not in pdesc and "—" not in pdesc, f"{spec.name}.{pname}：{pdesc}"
+
+
 def test_render_tool_specs_subset():
     text = tools.render_tool_specs(["search_papers", "get_concept"])
     lines = text.splitlines()
     assert len(lines) == 2
-    assert lines[0].startswith("- search_papers {") and "库内检索论文" in lines[0]
+    assert lines[0].startswith("- search_papers {") and "检索论文" in lines[0]
     assert '"query"' in lines[0] and '"mode"?' in lines[0]  # required vs optional 标注
 
 


### PR DESCRIPTION
## Why

A tool's description is the only thing an external client has to choose it with. About a third of ours were written as asides rather than as API text:

- an em dash followed by a colloquial gloss: `库外文献检索（…）——找库里还没有的论文`, `批量取某论文的图片（…）——做 PPT 一次拿全套`
- a rhetorical question where the return value should be: `某论文引用的参考文献（它站在谁的肩膀上）`
- internal shorthand that means nothing outside this repo: `P5b 起笔记仅作者本人可见`, `跨实体检索：…（确定性 ilike）`

A model reading those learns the tone, not the capability boundary. The em dash is the worst offender specifically because it glues "what this tool is" to a casual aside in one breath, so the useful half stops being a definition.

## What changed

All 38 descriptions rewritten as a single formal statement of what the tool returns, with the precondition or scope stated plainly where it matters.

| Tool | Before | After |
| --- | --- | --- |
| `external_search` | 库外文献检索（Semantic Scholar，失败降级 OpenAlex）——找库里还没有的论文 | 检索平台文献库之外的论文，数据源为 Semantic Scholar，不可用时降级为 OpenAlex |
| `get_references` | 某论文引用的参考文献（它站在谁的肩膀上） | 列出某篇论文引用的参考文献 |
| `get_paper_notes` | 取某论文下当前用户的笔记（P5b 起笔记仅作者本人可见） | 取当前用户在某篇论文下的笔记；笔记仅作者本人可见 |
| `global_search` | 跨实体检索：论文/概念/想法/实验/稿件/任务（确定性 ilike） | 在本课题内按关键词跨实体检索论文、概念、想法、实验、稿件与任务 |
| `search_papers` | 库内检索论文 | 在本课题语料内检索论文，支持关键词与语义两种模式 |
| `list_tasks` | 课题的 AI 任务清单（建库抓取/想法生成/评审/实验/写作等），新→旧 | 列出本课题的 AI 任务，按创建时间由新到旧排列，可按状态与类型筛选 |

**No behaviour change.** Tool names, input schemas, and return shapes are untouched, so nothing an existing client depends on moves.

## Keeping it

`test_tool_descriptions_are_formal` rejects em dashes and arrows in both tool descriptions and parameter descriptions. Without it this is a one-off tidy-up that the next tool quietly undoes.

`test_render_tool_specs_subset` asserted on the old wording of `search_papers`; loosened to the part that is actually load-bearing (that the description reaches the rendered spec at all).

## Verification

- Full backend suite: **963 passed**.
- `ruff check` clean.
- Catalog inspected tool by tool after the rewrite: 38 descriptions, none containing an em dash, an arrow, or internal shorthand.

## Not touched

- **Task-log summary lines** (`summarize=`), e.g. `检索「x」→ 3 篇`. These render in the task terminal in the web app, not over MCP, and use `→` consistently across all tools.
- **`docs/mcp.md`**, whose English prose uses em dashes the ordinary typographic way, as the rest of `docs/` does.
