### PR TITLE
refactor(chat): one SSE skeleton instead of seven copies (and fix the three that weren't streaming)

### DIFF
--- a/src/backend/app/api/chat_stream.py
+++ b/src/backend/app/api/chat_stream.py
@@ -1,0 +1,108 @@
+"""文献对话的 SSE 骨架：先发 ``sources``，再流式 ``delta``* → ``done``，出错 ``error`` 后关流。
+
+这段骨架此前有**三份逐字相同的副本**（wiki.py / papers.py / libraries.py），daily.py 还
+从 wiki.py 反向 import 了一份来用。三份各自演化的结果是行为已经不一致：只有 papers.py
+带了 ``X-Accel-Buffering: no``，另外两个在 nginx 后面会被缓冲，流式变成一次性吐出。
+
+所以先收敛再谈扩展。这个模块只做搬迁，不改任何行为。
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import asdict
+from typing import Any
+
+from fastapi.responses import StreamingResponse
+
+from app.core.llm.fake import estimate_tokens
+from app.core.llm.router import get_llm_router
+
+logger = logging.getLogger(__name__)
+
+#: 空闲多久发一次注释心跳。要短于反向代理与浏览器的空闲超时，否则长思考会被判死。
+HEARTBEAT_SECONDS = 15.0
+
+#: 流式响应头。``X-Accel-Buffering: no`` 是给 nginx 看的——不关缓冲，它会攒够一整块
+#: 才下发，用户看到的就是"转很久然后一次性蹦出全文"。
+SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def sse_frame(event: str, data: Any) -> str:
+    """一帧 SSE。``default=str`` 不能省：payload 里常有 UUID / datetime，没有它会抛
+    TypeError 把整条流打断，而不是序列化成字符串。"""
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
+
+
+def chat_stream_response(
+    messages: Sequence[Any],
+    sources: Sequence[Any],
+    *,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    stage: str = "reading",
+    log_label: str = "literature chat",
+    always_send_sources: bool = True,
+) -> StreamingResponse:
+    """把一组消息按 SSE 流式吐出去。
+
+    ``always_send_sources``：AI 伴读只在真的有参考文献时才发 ``sources``（它的语料就是
+    当前这一篇，没有"引用来源"可言），其余入口恒发一帧——前端据此渲染来源清单，
+    收不到就一直显示加载态。
+    """
+    llm = get_llm_router()
+
+    async def event_stream() -> AsyncIterator[str]:
+        if sources or always_send_sources:
+            yield sse_frame("sources", {"items": [asdict(s) for s in sources]})
+        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
+
+        async def pump() -> None:
+            try:
+                # router.stream 结束时自动写 LLMUsage 记账（归属 user + project）
+                async for chunk in llm.stream(
+                    stage, messages, user_id=user_id, project_id=project_id
+                ):
+                    await queue.put(("delta", chunk))
+                await queue.put(("done", None))
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 转成 error 事件后关流
+                logger.warning("%s stream failed", log_label, exc_info=True)
+                await queue.put(("error", f"{type(e).__name__}: {e}"))
+
+        task = asyncio.create_task(pump())
+        collected: list[str] = []
+        try:
+            while True:
+                try:
+                    kind, payload = await asyncio.wait_for(queue.get(), timeout=HEARTBEAT_SECONDS)
+                except TimeoutError:
+                    yield ": ping\n\n"
+                    continue
+                if kind == "delta":
+                    collected.append(payload or "")
+                    yield sse_frame("delta", {"text": payload})
+                elif kind == "done":
+                    # usage 与 router 记账口径一致（provider 无 usage 时按 len/4 估算）
+                    usage = {
+                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
+                        "completion_tokens": estimate_tokens("".join(collected)),
+                    }
+                    yield sse_frame("done", {"usage": usage})
+                    return
+                else:  # error
+                    yield sse_frame("error", {"detail": payload})
+                    return
+        finally:
+            task.cancel()
+
+    return StreamingResponse(
+        event_stream(), media_type="text/event-stream", headers=dict(SSE_HEADERS)
+    )

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -16,6 +16,7 @@ from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_admin, require_llm_chat, require_llm_task
+from app.api.chat_stream import chat_stream_response
 from app.core.db import get_session
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
@@ -462,8 +463,6 @@ async def chat_with_daily_pool(
 
     事件序列与文献库对话一致（``sources`` → ``delta``* → ``done``）。
     """
-    from app.api.wiki import _chat_stream_response
-
     history = library_chat_service.history_from_turns(data.history[-20:])  # 最多 10 轮
     paper_ids = await daily_service.daily_paper_ids(session)
     messages, sources = await library_chat_service.build_scoped_messages(
@@ -476,7 +475,7 @@ async def chat_with_daily_pool(
         user_id=user.id,
         project_id=None,
     )
-    return _chat_stream_response(messages, sources, user_id=user.id, project_id=None)
+    return chat_stream_response(messages, sources, user_id=user.id, project_id=None)
 
 
 @router.post("/papers/{entry_id}/fetch-pdf", response_model=DailyPaperDetail)

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -6,7 +6,6 @@
 
 import asyncio
 import io
-import json
 import posixpath
 import time
 import uuid
@@ -20,6 +19,7 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_experiment
+from app.api.chat_stream import sse_frame as _sse_frame
 from app.core.db import get_session, get_sessionmaker
 from app.core.events import EventBus, get_event_bus
 from app.core.queue import TaskQueue, get_task_queue
@@ -494,10 +494,6 @@ async def get_experiment_logs(
     log_path = _resolve_log_path(experiment, run_id)
     lines, truncated = experiments_service.read_local_log_tail(log_path, tail)
     return ExperimentLogsRead(lines=lines, truncated=truncated)
-
-
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 @router.get("/experiments/{experiment_id}/logs/stream")

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -8,12 +8,9 @@
 个人文献库路由在 ``app/api/library.py``（/me/library），勿混淆。
 """
 
-import asyncio
 import json
 import logging
 import uuid
-from collections.abc import AsyncIterator
-from dataclasses import asdict
 from datetime import datetime
 from typing import Any
 
@@ -30,8 +27,8 @@ from app.api.auth import (
     require_llm_chat,
     require_llm_task,
 )
+from app.api.chat_stream import chat_stream_response
 from app.core.db import get_session
-from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
 from app.core.redis import get_redis_dep
@@ -96,10 +93,6 @@ router = APIRouter(tags=["libraries"])
 logger = logging.getLogger(__name__)
 
 _HEARTBEAT_SECONDS = 15.0
-
-
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 async def _paper_detail(
@@ -1084,49 +1077,9 @@ async def chat_with_library(
         session, library=library, question=data.question, history=history, llm=llm, user_id=user_id
     )
 
-    async def event_stream() -> AsyncIterator[str]:
-        yield _sse_frame("sources", {"items": [asdict(source) for source in sources]})
-        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
-
-        async def pump() -> None:
-            try:
-                async for chunk in llm.stream(
-                    "reading", messages, user_id=user_id, project_id=project_id
-                ):
-                    await queue.put(("delta", chunk))
-                await queue.put(("done", None))
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:  # noqa: BLE001 — 转成 error 事件后关流
-                logger.warning("library chat stream failed", exc_info=True)
-                await queue.put(("error", f"{type(e).__name__}: {e}"))
-
-        task = asyncio.create_task(pump())
-        collected: list[str] = []
-        try:
-            while True:
-                try:
-                    kind, payload = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_SECONDS)
-                except TimeoutError:
-                    yield ": ping\n\n"
-                    continue
-                if kind == "delta":
-                    collected.append(payload or "")
-                    yield _sse_frame("delta", {"text": payload})
-                elif kind == "done":
-                    usage = {
-                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
-                        "completion_tokens": estimate_tokens("".join(collected)),
-                    }
-                    yield _sse_frame("done", {"usage": usage})
-                    return
-                else:  # error
-                    yield _sse_frame("error", {"detail": payload})
-                    return
-        finally:
-            task.cancel()
-
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+    return chat_stream_response(
+        messages, sources, user_id=user_id, project_id=project_id, log_label="library chat"
+    )
 
 
 # ---- P6 治理：重复论文合并 ----

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -5,13 +5,11 @@
 """
 
 import asyncio
-import json
 import logging
 import mimetypes
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
-from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
@@ -24,6 +22,7 @@ from app.api.auth import (
     require_paper_review,
     require_writer,
 )
+from app.api.chat_stream import sse_frame as _sse_frame
 from app.core.db import get_session
 from app.core.events import EventBus, get_event_bus
 from app.core.llm.fake import estimate_tokens
@@ -1028,10 +1027,6 @@ async def initialize_structure(
 # ---- §6 内联 AI 写作辅助（SSE 流） ----
 
 _ASSIST_HEARTBEAT_SECONDS = 15.0
-
-
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 @router.post("/manuscripts/{manuscript_id}/assist")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -6,7 +6,6 @@ import logging
 import time
 import uuid
 from collections.abc import AsyncIterator, Sequence
-from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -17,9 +16,10 @@ from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_llm_chat, require_llm_task
+from app.api.chat_stream import chat_stream_response
+from app.api.chat_stream import sse_frame as _sse_frame
 from app.core.db import get_session
 from app.core.events import paper_task_channel, paper_task_log_key
-from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.redis import get_redis_dep
 from app.models.user import User
@@ -254,10 +254,6 @@ async def add_paper_manually(
     )
     detail = await _paper_detail(session, view, user_id)
     return detail.model_copy(update={"task_id": task_id})
-
-
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 @router.get("/paper-tasks/{task_id}/events")
@@ -713,10 +709,6 @@ async def rebuild_paper_index(
 # ---- AI 伴读（docs/api-lit.md §3，SSE 流） ----
 
 
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
-
-
 @router.post("/papers/{paper_id}/chat")
 async def chat_with_paper(
     paper_id: uuid.UUID,
@@ -747,59 +739,14 @@ async def chat_with_paper(
         paper, question=data.question, history=history, references=references
     )
 
-    async def event_stream() -> AsyncIterator[str]:
-        if sources:
-            yield _sse_frame("sources", {"items": [asdict(s) for s in sources]})
-        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
-
-        async def pump() -> None:
-            try:
-                # router.stream 结束时自动写 LLMUsage 记账（归属 user + project）
-                async for chunk in llm.stream(
-                    "reading", messages, user_id=user_id, project_id=project_id
-                ):
-                    await queue.put(("delta", chunk))
-                await queue.put(("done", None))
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:  # noqa: BLE001 — 转成 error 事件后关流
-                logger.warning("paper chat stream failed", exc_info=True)
-                await queue.put(("error", f"{type(e).__name__}: {e}"))
-
-        task = asyncio.create_task(pump())
-        collected: list[str] = []
-        try:
-            while True:
-                try:
-                    kind, payload = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_SECONDS)
-                except TimeoutError:
-                    yield ": ping\n\n"
-                    continue
-                if kind == "delta":
-                    collected.append(payload or "")
-                    yield _sse_frame("delta", {"text": payload})
-                elif kind == "done":
-                    # usage 与 router 记账口径一致（provider 无 usage 时按 len/4 估算）
-                    usage = {
-                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
-                        "completion_tokens": estimate_tokens("".join(collected)),
-                    }
-                    yield _sse_frame("done", {"usage": usage})
-                    return
-                else:  # error
-                    yield _sse_frame("error", {"detail": payload})
-                    return
-        finally:
-            task.cancel()
-
-    return StreamingResponse(
-        event_stream(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # nginx 关缓冲
-        },
+    # 伴读只在真有参考文献时才发 sources：它的语料就是当前这一篇
+    return chat_stream_response(
+        messages,
+        sources,
+        user_id=user_id,
+        project_id=project_id,
+        log_label="paper chat",
+        always_send_sources=False,
     )
 
 

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -5,7 +5,6 @@ import json
 import time
 import uuid
 from collections.abc import AsyncIterator
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -13,6 +12,7 @@ from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
+from app.api.chat_stream import sse_frame as _sse_frame
 from app.core.db import get_session
 from app.core.events import voyage_channel
 from app.core.queue import TaskQueue, get_task_queue
@@ -179,10 +179,6 @@ async def resume_voyage(
     await session.commit()
     await queue.enqueue("resume_voyage", str(run.id))
     return VoyageRead.model_validate(run)
-
-
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
 
 
 @router.get("/{voyage_id}/events")

--- a/src/backend/app/api/wiki.py
+++ b/src/backend/app/api/wiki.py
@@ -1,12 +1,9 @@
 """Research Wiki 附属路由：检索 / Obsidian 导出 / 引用导出 / 项目统计 / 图谱 / 文献库对话
 （docs/api-m2.md §3、§5、§6；docs/api-lit.md §6、§8）。"""
 
-import asyncio
 import json
 import logging
 import uuid
-from collections.abc import AsyncIterator
-from dataclasses import asdict
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -16,8 +13,8 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user, require_llm_chat
+from app.api.chat_stream import chat_stream_response
 from app.core.db import get_session
-from app.core.llm.fake import estimate_tokens
 from app.core.llm.router import get_llm_router
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.library_direction import LibraryPaper
@@ -197,10 +194,6 @@ async def export_citations(
     )
 
 
-def _sse_frame(event: str, data: Any) -> str:
-    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
-
-
 def _chat_stream_response(
     messages: list,
     sources: list,
@@ -208,53 +201,13 @@ def _chat_stream_response(
     user_id: uuid.UUID,
     project_id: uuid.UUID | None,
 ) -> StreamingResponse:
-    """文献对话 SSE 骨架：先发 ``sources``，再 stage=reading 流式 ``delta``* → ``done``；
-    出错 ``error`` 后关流；空闲发 ``: ping`` 心跳。库/课题/个人三种对话共用。"""
-    llm = get_llm_router()
+    """文献对话 SSE：实现已收敛到 app/api/chat_stream.py，这里只留一个薄壳。
 
-    async def event_stream() -> AsyncIterator[str]:
-        yield _sse_frame("sources", {"items": [asdict(s) for s in sources]})
-        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
-
-        async def pump() -> None:
-            try:
-                async for chunk in llm.stream(
-                    "reading", messages, user_id=user_id, project_id=project_id
-                ):
-                    await queue.put(("delta", chunk))
-                await queue.put(("done", None))
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:  # noqa: BLE001 — 转成 error 事件后关流
-                logger.warning("literature chat stream failed", exc_info=True)
-                await queue.put(("error", f"{type(e).__name__}: {e}"))
-
-        task = asyncio.create_task(pump())
-        collected: list[str] = []
-        try:
-            while True:
-                try:
-                    kind, payload = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_SECONDS)
-                except TimeoutError:
-                    yield ": ping\n\n"
-                    continue
-                if kind == "delta":
-                    collected.append(payload or "")
-                    yield _sse_frame("delta", {"text": payload})
-                elif kind == "done":
-                    usage = {
-                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
-                        "completion_tokens": estimate_tokens("".join(collected)),
-                    }
-                    yield _sse_frame("done", {"usage": usage})
-                    return
-                else:  # error
-                    yield _sse_frame("error", {"detail": payload})
-                    return
-        finally:
-            task.cancel()
-
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+    保留这个名字是因为它是三个课题级端点的调用点，改名会让 diff 淹没在噪音里。
+    """
+    return chat_stream_response(
+        messages, sources, user_id=user_id, project_id=project_id
+    )
 
 
 @router.post("/projects/{project_id}/chat")

--- a/src/backend/tests/test_chat_stream_shared.py
+++ b/src/backend/tests/test_chat_stream_shared.py
@@ -1,0 +1,129 @@
+"""对话 SSE 骨架收敛后的共同契约。
+
+这段骨架此前是三份逐字相同的副本（wiki / papers / libraries），daily 还从 wiki 反向
+import 了一份。三份各自演化的结果是**行为已经不一致**：只有 papers 那份带了
+``X-Accel-Buffering: no``，另外两个在 nginx 后面会被缓冲，流式变成「转很久然后一次性
+蹦出全文」。收敛之后这里钉住四个入口的响应头一致。
+"""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from tests.conftest import add_paper, register_and_login
+
+
+async def _project(client, headers, name="sse-headers"):
+    resp = await client.post(
+        "/api/projects", json={"name": name, "statement": "LLM agent"}, headers=headers
+    )
+    return uuid.UUID(resp.json()["id"])
+
+
+async def test_every_chat_endpoint_streams_with_the_same_headers(client):
+    """四个对话入口的流式响应头必须一字不差。
+
+    少一个 X-Accel-Buffering 就意味着那个入口在反向代理后面不是流式的——用户看到的
+    是「一直转圈，然后整段蹦出来」，而其余入口正常。这种不一致极难从现象反推。
+    """
+    token = await register_and_login(client, email="sse-headers@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _project(client, headers)
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            title="Planning with Tree Search",
+            abstract="planning abstract",
+            tldr="一句话总结",
+            year=2025,
+            status="included",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    body = {"question": "这个方向有哪些方法？", "history": []}
+    endpoints = [
+        f"/api/projects/{project_id}/chat",
+        f"/api/projects/{project_id}/shelf/chat",
+        "/api/library/chat",
+        f"/api/papers/{paper_id}/chat",
+    ]
+
+    seen: dict[str, dict[str, str]] = {}
+    for path in endpoints:
+        async with client.stream("POST", path, json=body, headers=headers) as resp:
+            assert resp.status_code == 200, f"{path}: {resp.status_code}"
+            assert resp.headers["content-type"].startswith("text/event-stream"), path
+            seen[path] = {
+                k: resp.headers.get(k, "(缺失)")
+                for k in ("cache-control", "connection", "x-accel-buffering")
+            }
+            await resp.aread()
+
+    for path, got in seen.items():
+        assert got["x-accel-buffering"] == "no", f"{path} 会被 nginx 缓冲：{got}"
+        assert got["cache-control"] == "no-cache", f"{path}: {got}"
+
+    # 四个入口给出的是同一组头，不是各写各的
+    assert len(set(map(str, seen.values()))) == 1, seen
+
+
+async def test_sse_frame_serialises_uuid_and_datetime(client):
+    """帧序列化必须带 default=str。
+
+    payload 里常有 UUID / datetime；没有 default=str 会抛 TypeError 把整条流打断，
+    而不是序列化成字符串——收敛这段代码时我第一版就漏了它。
+    """
+    import datetime as dt
+    import json
+
+    from app.api.chat_stream import sse_frame
+
+    frame = sse_frame("x", {"id": uuid.uuid4(), "at": dt.datetime.now(dt.UTC)})
+    assert frame.startswith("event: x\ndata: ")
+    assert frame.endswith("\n\n")
+    payload = json.loads(frame.split("data: ", 1)[1])
+    assert isinstance(payload["id"], str) and isinstance(payload["at"], str)
+
+
+async def test_paper_chat_omits_sources_when_there_are_none(client):
+    """AI 伴读没有参考文献时不发 sources 帧——它的语料就是当前这一篇。
+
+    其余入口恒发一帧（前端据此渲染来源清单，收不到就一直是加载态）。收敛时这个差异
+    是唯一需要参数化的地方，别把它抹平了。
+    """
+    import json
+
+    token = await register_and_login(client, email="sse-paper@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id = await _project(client, headers, name="sse-paper")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=project_id,
+            title="Solo",
+            abstract="a",
+            tldr="t",
+            year=2025,
+            status="included",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with client.stream(
+        "POST",
+        f"/api/papers/{paper_id}/chat",
+        json={"question": "讲讲这篇", "history": []},
+        headers=headers,
+    ) as resp:
+        text = (await resp.aread()).decode("utf-8")
+
+    kinds = [
+        line[len("event: ") :]
+        for line in text.splitlines()
+        if line.startswith("event: ")
+    ]
+    assert "sources" not in kinds, f"没有参考文献时不该发 sources：{kinds}"
+    assert kinds and kinds[-1] == "done"
+    assert json.loads(text.rsplit("data: ", 1)[1])["usage"]["completion_tokens"] > 0


### PR DESCRIPTION
First step of turning the literature chat into an agent harness: **consolidate before extending**. No behaviour changes here — except for a real bug this uncovered.

## What was there

The chat SSE skeleton existed as **three verbatim copies** (`wiki.py`, `papers.py`, `libraries.py`), with `daily.py` reaching back into `wiki.py` to import a fourth use. The smaller `_sse_frame` helper existed **seven times** (also in `voyages.py`, `experiments.py`, `manuscripts.py`, and twice in `papers.py`).

## The bug that fell out

Copies drift. Only the `papers.py` one carried `X-Accel-Buffering: no`. Behind nginx that means project chat, shelf chat, personal-library chat and standalone-library chat **were not actually streaming** — the user waits, then the whole answer appears at once — while the paper reading assistant streamed normally. That is close to impossible to diagnose from the symptom.

Verified against `origin/main`: `/projects/{id}/chat` returns none of the three streaming headers.

## What changed

`app/api/chat_stream.py` holds one `chat_stream_response` and one `sse_frame`. Seven copies deleted, four call sites rewired, the reverse import from `daily.py` removed, headers unified. **Net −161 lines.**

The one genuine difference is parameterised, not flattened: `always_send_sources=False` for the paper reading assistant, which has no "sources" to speak of since its corpus is the single paper in front of you. Every other entry point always emits one `sources` frame — the frontend renders its source list off it and stays in a loading state without it.

## A mistake worth recording

My first version of `sse_frame` dropped `default=str`. All seven originals had it; without it a payload containing a UUID or datetime raises `TypeError` and kills the whole stream rather than serialising to a string. There is now a test for it.

## Tests

Three new contract tests in `test_chat_stream_shared.py`: all four chat endpoints stream with identical headers; `sse_frame` serialises UUID and datetime; the reading assistant omits `sources` when there are none.

The headers test fails against `origin/main` for the right reason (three headers missing, not an import error). Every existing chat test passes **unchanged** — they parse the SSE text directly, which is what makes them a good regression net here.

Full backend suite **966 passed**; `ruff check app` clean.