### PR TITLE
feat(llm): native tool calling for both providers, without touching 71 call sites

### DIFF
--- a/src/backend/app/api/chat_stream.py
+++ b/src/backend/app/api/chat_stream.py
@@ -92,7 +92,7 @@ def chat_stream_response(
                 elif kind == "done":
                     # usage 与 router 记账口径一致（provider 无 usage 时按 len/4 估算）
                     usage = {
-                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
+                        "prompt_tokens": sum(estimate_tokens(m.text) for m in messages),
                         "completion_tokens": estimate_tokens("".join(collected)),
                     }
                     yield sse_frame("done", {"usage": usage})

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -1100,7 +1100,7 @@ async def assist_manuscript(
                     if warnings:
                         yield _sse_frame("warnings", {"items": warnings})
                     usage = {
-                        "prompt_tokens": sum(estimate_tokens(m.content) for m in messages),
+                        "prompt_tokens": sum(estimate_tokens(m.text) for m in messages),
                         "completion_tokens": estimate_tokens(result),
                     }
                     yield _sse_frame("done", {"usage": usage})

--- a/src/backend/app/core/llm/anthropic.py
+++ b/src/backend/app/core/llm/anthropic.py
@@ -1,8 +1,9 @@
 """Anthropic Messages API Provider，基于 httpx（不依赖官方 SDK）。
 
-骨架实现：complete/stream 接口完整；tool-use、缓存、重试留 TODO。
+complete / stream / stream_events 三个接口完整；缓存与重试仍留 TODO。
 """
 
+import base64
 import json
 import logging
 from collections.abc import AsyncIterator, Sequence
@@ -10,7 +11,26 @@ from typing import Any
 
 import httpx
 
-from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message
+from app.core.llm.base import (
+    CompletionResult,
+    ContentBlock,
+    EffortLevel,
+    ImageBlock,
+    LLMProvider,
+    Message,
+    StreamDone,
+    StreamEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolResultBlock,
+    ToolUseArgsDelta,
+    ToolUseBlock,
+    ToolUseStart,
+    ToolUseStop,
+    normalize_finish_reason,
+)
 
 logger = logging.getLogger("polaris.llm")
 
@@ -26,8 +46,69 @@ def _rejects_effort(body: str) -> bool:
     return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
 
 
+def _normalize_usage(raw: dict[str, Any] | None) -> dict[str, int]:
+    """Anthropic 的 usage 键名归一成平台口径。
+
+    它给的是 ``input_tokens`` / ``output_tokens``，而记账读的是 ``prompt_tokens`` /
+    ``completion_tokens``，读不到就按 len/4 估——**所以此前走 Anthropic 的用量统计全是
+    估算值**。归一化放在 provider 里做，不污染 router。
+    """
+    if not raw:
+        return {}
+    usage = dict(raw)
+    if "input_tokens" in usage:
+        usage["prompt_tokens"] = int(usage["input_tokens"])
+    if "output_tokens" in usage:
+        usage["completion_tokens"] = int(usage["output_tokens"])
+    if "prompt_tokens" in usage and "completion_tokens" in usage:
+        usage.setdefault("total_tokens", usage["prompt_tokens"] + usage["completion_tokens"])
+    return {k: v for k, v in usage.items() if isinstance(v, int)}
+
+
+def _content_payload(block: ContentBlock) -> dict[str, Any] | None:
+    if isinstance(block, TextBlock):
+        return {"type": "text", "text": block.text} if block.text else None
+    if isinstance(block, ThinkingBlock):
+        # 签名必须原样带回，否则回放这轮会被拒
+        out: dict[str, Any] = {"type": "thinking", "thinking": block.text}
+        if block.signature:
+            out["signature"] = block.signature
+        return out
+    if isinstance(block, ToolUseBlock):
+        return {"type": "tool_use", "id": block.id, "name": block.name, "input": block.input}
+    if isinstance(block, ImageBlock):
+        return {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": block.mime,
+                "data": base64.b64encode(block.data).decode("ascii"),
+            },
+        }
+    if not isinstance(block, ToolResultBlock):  # 防御：将来加了新块类型别静默塞错形状
+        raise TypeError(f"unsupported content block: {type(block).__name__}")
+    # 图片作为工具结果内容的一部分，这是 Anthropic 原生支持的形状（OpenAI 侧做不到）
+    content: list[dict[str, Any]] = [{"type": "text", "text": block.content}]
+    for img in block.images:
+        content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": img.mime,
+                    "data": base64.b64encode(img.data).decode("ascii"),
+                },
+            }
+        )
+    out = {"type": "tool_result", "tool_use_id": block.tool_use_id, "content": content}
+    if block.is_error:
+        out["is_error"] = True
+    return out
+
+
 class AnthropicProvider(LLMProvider):
     name = "anthropic"
+    supports_tools = True
 
     def __init__(
         self,
@@ -51,18 +132,48 @@ class AnthropicProvider(LLMProvider):
         stream: bool,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> dict[str, Any]:
-        if images:
-            # TODO：Anthropic 原生 image block 支持
-            raise NotImplementedError("anthropic provider does not support image inputs yet")
         # Anthropic 的 system 提示是顶层参数，不在 messages 里
-        system_parts = [m.content for m in messages if m.role == "system"]
+        system_parts = [m.text for m in messages if m.role == "system"]
+        payload_messages: list[dict[str, Any]] = []
+        for m in messages:
+            if m.role == "system":
+                continue
+            if isinstance(m.content, str):
+                payload_messages.append({"role": m.role, "content": m.content})
+                continue
+            parts = [p for p in (_content_payload(b) for b in m.content) if p is not None]
+            payload_messages.append({"role": m.role, "content": parts})
+
+        if images and payload_messages:
+            target = next(
+                (m for m in reversed(payload_messages) if m["role"] == "user"),
+                payload_messages[-1],
+            )
+            parts = (
+                target["content"]
+                if isinstance(target["content"], list)
+                else [{"type": "text", "text": target["content"]}]
+            )
+            for image in images:
+                parts.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": base64.b64encode(image).decode("ascii"),
+                        },
+                    }
+                )
+            target["content"] = parts
+
         payload: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens or _DEFAULT_MAX_TOKENS,
-            "messages": [
-                {"role": m.role, "content": m.content} for m in messages if m.role != "system"
-            ],
+            "messages": payload_messages,
             "stream": stream,
         }
         if system_parts:
@@ -70,6 +181,22 @@ class AnthropicProvider(LLMProvider):
         if effort is not None:
             # Anthropic 的推理档位在 output_config 里，不是顶层参数
             payload["output_config"] = {"effort": effort}
+        if tools:
+            # ToolSpec.input_schema 直接就是这里要的 input_schema，零转换
+            payload["tools"] = [
+                {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "input_schema": t.get("parameters") or {"type": "object", "properties": {}},
+                }
+                for t in tools
+            ]
+            if tool_choice == "none":
+                payload["tool_choice"] = {"type": "none"}
+            elif tool_choice == "required":
+                payload["tool_choice"] = {"type": "any"}
+            elif tool_choice == "auto":
+                payload["tool_choice"] = {"type": "auto"}
         return payload
 
     async def complete(
@@ -81,13 +208,23 @@ class AnthropicProvider(LLMProvider):
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> CompletionResult:
         # TODO(M2): 重试/限速/错误分类
         resp = await self._client.post(
             _API_URL,
             headers=self._headers(),
             json=self._payload(
-                messages, model, temperature, max_tokens, stream=False, images=images, effort=effort
+                messages,
+                model,
+                temperature,
+                max_tokens,
+                stream=False,
+                images=images,
+                effort=effort,
+                tools=tools,
+                tool_choice=tool_choice,
             ),
         )
         if effort is not None and resp.status_code >= 400 and _rejects_effort(resp.text):
@@ -97,17 +234,41 @@ class AnthropicProvider(LLMProvider):
                 _API_URL,
                 headers=self._headers(),
                 json=self._payload(
-                    messages, model, temperature, max_tokens, stream=False, images=images
+                    messages,
+                    model,
+                    temperature,
+                    max_tokens,
+                    stream=False,
+                    images=images,
+                    tools=tools,
+                    tool_choice=tool_choice,
                 ),
             )
         resp.raise_for_status()
         data = resp.json()
-        text = "".join(block.get("text", "") for block in data.get("content", []))
+        blocks: list[ContentBlock] = []
+        texts: list[str] = []
+        for raw in data.get("content", []):
+            kind = raw.get("type")
+            if kind == "text":
+                texts.append(raw.get("text", ""))
+                blocks.append(TextBlock(raw.get("text", "")))
+            elif kind == "thinking":
+                blocks.append(ThinkingBlock(raw.get("thinking", ""), raw.get("signature")))
+            elif kind == "tool_use":
+                blocks.append(
+                    ToolUseBlock(
+                        str(raw.get("id") or ""),
+                        str(raw.get("name") or ""),
+                        raw.get("input") or {},
+                    )
+                )
         return CompletionResult(
-            content=text,
+            content="".join(texts),
             model=data.get("model", model),
-            finish_reason=data.get("stop_reason"),
-            usage=data.get("usage") or {},
+            finish_reason=normalize_finish_reason(data.get("stop_reason")),
+            usage=_normalize_usage(data.get("usage")),
+            blocks=tuple(blocks),
         )
 
     async def stream(
@@ -120,24 +281,91 @@ class AnthropicProvider(LLMProvider):
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
     ) -> AsyncIterator[str]:
-        # TODO(M2): 处理 message_delta 中的 usage / stop_reason
+        """纯文本流式：``stream_events`` 的过滤器（只有一份 SSE 解析）。"""
+        async for ev in self.stream_events(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            images=images,
+            effort=effort,
+        ):
+            if isinstance(ev, TextDelta):
+                yield ev.text
+
+    async def stream_events(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """按 index 归并的结构化流式。
+
+        Anthropic 的形状是 ``content_block_start``（index + tool_use 的 id/name）→
+        ``content_block_delta``（``input_json_delta.partial_json`` 逐段拼参数）→
+        ``content_block_stop``。usage 分两处给：``message_start`` 给输入，``message_delta``
+        给输出——此前这两处都没解析（代码里就写着 TODO）。
+        """
+        payload = self._payload(
+            messages,
+            model,
+            temperature,
+            max_tokens,
+            stream=True,
+            images=images,
+            effort=effort,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        usage: dict[str, Any] = {}
+        finish_reason: str | None = None
         async with self._client.stream(
-            "POST",
-            _API_URL,
-            headers=self._headers(),
-            json=self._payload(
-                messages, model, temperature, max_tokens, stream=True, images=images, effort=effort
-            ),
+            "POST", _API_URL, headers=self._headers(), json=payload
         ) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():
                 if not line.startswith("data:"):
                     continue
                 event = json.loads(line[len("data:") :].strip())
-                if event.get("type") == "content_block_delta" and (
-                    text := event.get("delta", {}).get("text")
-                ):
-                    yield text
+                kind = event.get("type")
+                if kind == "message_start":
+                    usage.update((event.get("message") or {}).get("usage") or {})
+                elif kind == "content_block_start":
+                    block = event.get("content_block") or {}
+                    if block.get("type") == "tool_use":
+                        yield ToolUseStart(
+                            int(event.get("index", 0)),
+                            str(block.get("id") or ""),
+                            str(block.get("name") or ""),
+                        )
+                elif kind == "content_block_delta":
+                    delta = event.get("delta") or {}
+                    dtype = delta.get("type")
+                    if dtype == "input_json_delta":
+                        yield ToolUseArgsDelta(
+                            int(event.get("index", 0)), delta.get("partial_json") or ""
+                        )
+                    elif dtype == "thinking_delta":
+                        yield ThinkingDelta(delta.get("thinking") or "")
+                    elif dtype == "signature_delta":
+                        yield ThinkingDelta("", delta.get("signature"))
+                    elif text := delta.get("text"):
+                        yield TextDelta(text)
+                elif kind == "content_block_stop":
+                    yield ToolUseStop(int(event.get("index", 0)))
+                elif kind == "message_delta":
+                    usage.update(event.get("usage") or {})
+                    if reason := (event.get("delta") or {}).get("stop_reason"):
+                        finish_reason = reason
+        yield StreamDone(
+            finish_reason=normalize_finish_reason(finish_reason), usage=_normalize_usage(usage)
+        )
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/src/backend/app/core/llm/base.py
+++ b/src/backend/app/core/llm/base.py
@@ -1,13 +1,27 @@
 """LLM 抽象层。
 
-业务代码只允许依赖本模块的 ``LLMProvider`` 接口（complete/stream），
+业务代码只允许依赖本模块的 ``LLMProvider`` 接口（complete/stream/stream_events），
 不允许直接 import openai/anthropic SDK。具体实现见 openai_compat.py / anthropic.py。
+
+关于 content blocks
+-------------------
+``Message.content`` 从 ``str`` 放宽成 ``str | list[ContentBlock]``，是为了装下工具调用
+（模型说"我要调 X"）与工具结果（"X 返回了这些"）。放宽而不是重做，是因为全仓有 71 处
+``Message(role=..., content="...")`` 的构造点，而 ``.content`` 的**读取点只有 12 处**且
+全部集中在本包内——所以加一个 ``.text`` 属性、只改读取点，71 处构造一行不动。
+
+工具结果**不用 ``role="tool"``**，而是以 ``ToolResultBlock`` 装在 ``role="user"`` 的消息
+里（Anthropic 的形状）。三个理由：一轮并行 N 个结果天然装在一条消息里，不用编造 N 条
+消息的顺序约定；结果里能带图片（figures 那组工具会返图），而 OpenAI 的 ``role:"tool"``
+消息在多数中转上是纯文本；从这个形状适配 OpenAI 是确定性扇出（一条 → K 条 ``role:
+"tool"``），反过来则要往回看相邻消息做归并，脆得多。
 """
 
+import json
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, ClassVar, Literal
 
 Role = str  # "system" | "user" | "assistant"
 
@@ -17,18 +31,168 @@ EffortLevel = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"
 EFFORT_LEVELS: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 
+# ---- content blocks ----
+
+
+@dataclass(slots=True, frozen=True)
+class TextBlock:
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class ImageBlock:
+    data: bytes
+    mime: str = "image/png"
+    label: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ThinkingBlock:
+    """模型的思考过程。
+
+    ``signature`` 必须原样带回：Anthropic 的 thinking 块回放时缺签名会 400。所以历史
+    里的 assistant 轮要用 ``CompletionResult.as_assistant_message()`` 重建，不能拿
+    ``content`` 字符串手工拼——那样一定丢签名。
+    """
+
+    text: str
+    signature: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ToolUseBlock:
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+@dataclass(slots=True, frozen=True)
+class ToolResultBlock:
+    tool_use_id: str
+    content: str  # JSON 序列化后的文本 payload
+    images: tuple[ImageBlock, ...] = ()
+    is_error: bool = False
+
+
+ContentBlock = TextBlock | ImageBlock | ThinkingBlock | ToolUseBlock | ToolResultBlock
+
+
+def _block_text(block: ContentBlock) -> str:
+    """块拍平成文本时的表示。非文本块给一个占位摘要，别在日志/估算里凭空消失。"""
+    if isinstance(block, TextBlock):
+        return block.text
+    if isinstance(block, ThinkingBlock):
+        return block.text
+    if isinstance(block, ToolUseBlock):
+        return f"[调用 {block.name} {json.dumps(block.input, ensure_ascii=False)}]"
+    if isinstance(block, ToolResultBlock):
+        return f"[工具结果] {block.content}"
+    return f"[图片 {block.mime}]"
+
+
 @dataclass(slots=True)
 class Message:
     role: Role
-    content: str
+    content: str | list[ContentBlock]
+
+    @property
+    def text(self) -> str:
+        """拍平成纯文本。字符串原样返回，块列表按块拼接。
+
+        token 估算、调用日志、以及所有只关心"说了什么"的地方都用它，不要再读
+        ``.content``——那个字段现在可能是列表。
+        """
+        if isinstance(self.content, str):
+            return self.content
+        return "\n".join(_block_text(b) for b in self.content)
+
+    @property
+    def blocks(self) -> tuple[ContentBlock, ...]:
+        """统一成块列表。字符串包成单个 TextBlock。"""
+        if isinstance(self.content, str):
+            return (TextBlock(self.content),)
+        return tuple(self.content)
 
 
 @dataclass(slots=True)
 class CompletionResult:
-    content: str
+    content: str  # 拼好的纯文本；19 个 stage 只读它，语义不变
     model: str
     finish_reason: str | None = None
     usage: dict[str, int] = field(default_factory=dict)  # prompt_tokens/completion_tokens/...
+    blocks: tuple[ContentBlock, ...] = ()
+
+    @property
+    def tool_calls(self) -> tuple[ToolUseBlock, ...]:
+        return tuple(b for b in self.blocks if isinstance(b, ToolUseBlock))
+
+    def as_assistant_message(self) -> Message:
+        """回喂历史时用它，不要拿 ``content`` 手工拼消息。
+
+        原始块里带着 thinking 的签名与 tool_use 的 id，丢了任何一个，下一轮请求都可能
+        被 provider 拒掉。
+        """
+        if not self.blocks:
+            return Message(role="assistant", content=self.content)
+        return Message(role="assistant", content=list(self.blocks))
+
+
+# ---- 流式事件 ----
+
+
+@dataclass(slots=True, frozen=True)
+class TextDelta:
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class ThinkingDelta:
+    text: str
+    signature: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ToolUseStart:
+    index: int
+    id: str
+    name: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolUseArgsDelta:
+    index: int
+    json_fragment: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolUseStop:
+    index: int
+
+
+@dataclass(slots=True, frozen=True)
+class StreamDone:
+    finish_reason: str | None = None
+    usage: dict[str, int] = field(default_factory=dict)
+
+
+StreamEvent = TextDelta | ThinkingDelta | ToolUseStart | ToolUseArgsDelta | ToolUseStop | StreamDone
+
+
+def normalize_finish_reason(raw: str | None) -> str | None:
+    """两家的结束原因归一化到 tool_use / max_tokens / stop，上层不要 switch 原始值。"""
+    if raw is None:
+        return None
+    if raw in ("tool_calls", "tool_use"):
+        return "tool_use"
+    if raw in ("length", "max_tokens"):
+        return "max_tokens"
+    if raw in ("stop", "end_turn", "stop_sequence"):
+        return "stop"
+    return raw
+
+
+class ToolsUnsupportedError(RuntimeError):
+    """这个模型/中转不认 tools 参数。由调用方降级（退回无工具的一次性问答）。"""
 
 
 @dataclass(slots=True)
@@ -44,6 +208,10 @@ class LLMProvider(ABC):
 
     name: str = "base"
 
+    #: 支持原生工具调用吗。默认 False —— 未重写 ``stream_events`` 的 provider（含所有
+    #: 测试替身）走下面那个只吐文本的默认实现，行为与今天完全一致。
+    supports_tools: ClassVar[bool] = False
+
     @abstractmethod
     async def complete(
         self,
@@ -54,12 +222,16 @@ class LLMProvider(ABC):
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> CompletionResult:
         """一次性补全，返回完整结果。
 
         ``images``：可选 PNG 字节列表（多模态输入，附在最后一条 user 消息上）；
         不支持视觉输入的 provider 抛 NotImplementedError。
         ``effort``：推理档位，None = 不发送该参数（用模型默认）。
+        ``tools``：``{name, description, parameters}`` 形式的工具定义（parameters 是标准
+        JSON Schema），None = 不发送。
         """
 
     @abstractmethod
@@ -75,10 +247,37 @@ class LLMProvider(ABC):
     ) -> AsyncIterator[str]:
         """流式补全，逐段 yield 文本增量（用于 SSE 转发）。
 
-        ``images``：可选多模态输入（同 complete）；支持多模态流式的 provider 附在
-        最后一条 user 消息上，其余忽略。
-        ``effort``：推理档位，None = 不发送该参数（用模型默认）。
+        签名保持不变（3 个 SSE 端点 + 写作辅助都靠它），**不给它加 tools 参数**；
+        需要工具的走 :meth:`stream_events`。
         """
+
+    async def stream_events(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """结构化流式：文本增量、思考增量、工具调用的开始/参数分片/结束。
+
+        默认实现包一层 :meth:`stream` 只吐 ``TextDelta`` + ``StreamDone``——所以没有
+        重写它的 provider（以及测试里的各种替身）零改动仍然可用，只是拿不到工具。
+        """
+        async for chunk in self.stream(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            images=images,
+            effort=effort,
+        ):
+            yield TextDelta(chunk)
+        yield StreamDone(finish_reason="stop")
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:
         """文本嵌入（语义检索用）。不支持的 provider（如 anthropic）抛 NotImplementedError。"""

--- a/src/backend/app/core/llm/call_log.py
+++ b/src/backend/app/core/llm/call_log.py
@@ -85,7 +85,7 @@ def sanitize_request(
     """messages → 可入库 JSON：内容截断到 MESSAGE_MAX_CHARS，图片只留大小占位。"""
     payload: dict[str, Any] = {
         "messages": [
-            {"role": m.role, "content": truncate_text(m.content, MESSAGE_MAX_CHARS)}
+            {"role": m.role, "content": truncate_text(m.text, MESSAGE_MAX_CHARS)}
             for m in messages
         ]
     }

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -10,8 +10,21 @@ import json
 import math
 import re
 from collections.abc import AsyncIterator, Sequence
+from typing import Any
 
-from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message, RerankResult
+from app.core.llm.base import (
+    CompletionResult,
+    EffortLevel,
+    LLMProvider,
+    Message,
+    RerankResult,
+    StreamDone,
+    StreamEvent,
+    TextDelta,
+    ToolUseArgsDelta,
+    ToolUseStart,
+    ToolUseStop,
+)
 
 # 与 navigator.py / sextant.py / actions_wiki.py / actions_ideas.py /
 # services/projects.py 的 prompt 对齐的识别标记
@@ -97,8 +110,56 @@ def fake_embedding(text: str, dim: int = EMBEDDING_DIM) -> list[float]:
     return [v / norm for v in vec]
 
 
+#: 端到端测试用的驱动标记：最后一条 user 消息里出现
+#: ``POLARIS_FAKE_TOOL:<工具名>:<json 参数>`` 时，本轮就发起这个工具调用。
+#: 拿不到 provider 实例的测试（走 llm_fake_fallback 的那些）靠它驱动工具循环。
+_TOOL_MARKER = "POLARIS_FAKE_TOOL:"
+
+
+def _slice_oddly(raw: str, size: int = 7) -> list[str]:
+    """把字符串切成不对齐的小段。段长取质数，保证切口落在键名/值/转义序列中间。"""
+    return [raw[i : i + size] for i in range(0, len(raw), size)] or [""]
+
+
 class FakeProvider(LLMProvider):
     name = "fake"
+    supports_tools = True
+
+    def __init__(self) -> None:
+        self._script: list[list[tuple[str, dict[str, Any]]] | str] = []
+        self._turn = 0
+
+    def script(self, steps: list[list[tuple[str, dict[str, Any]]] | str]) -> None:
+        """排一段剧本驱动工具循环。
+
+        每个元素要么是 ``[(工具名, 参数), ...]``（该轮发起这些并行调用），要么是一段
+        字符串（该轮直接作答）。**不排剧本时行为与从前完全一致**——这是本次改造能安全
+        落地的判据：现存所有测试一行不改仍然通过。
+        """
+        self._script = list(steps)
+        self._turn = 0
+
+    def _next_step(
+        self, messages: Sequence[Message]
+    ) -> list[tuple[str, dict[str, Any]]] | str | None:
+        """本轮该干什么：一组工具调用 / 一段直接作答 / None（按默认行为走）。"""
+        if self._script:
+            if self._turn >= len(self._script):
+                return None
+            step = self._script[self._turn]
+            self._turn += 1
+            return step
+        # 无剧本时看标记（端到端路径）
+        last_user = next((m.text for m in reversed(messages) if m.role == "user"), "")
+        if _TOOL_MARKER not in last_user:
+            return None
+        raw = last_user.split(_TOOL_MARKER, 1)[1].splitlines()[0].strip()
+        name, _, args_raw = raw.partition(":")
+        try:
+            args = json.loads(args_raw) if args_raw else {}
+        except json.JSONDecodeError:
+            args = {}
+        return [(name.strip(), args if isinstance(args, dict) else {})]
 
     async def complete(
         self,
@@ -110,13 +171,13 @@ class FakeProvider(LLMProvider):
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,  # 确定性替身不做推理，收下即忽略
     ) -> CompletionResult:
-        full_text = "\n".join(m.content for m in messages)
+        full_text = "\n".join(m.text for m in messages)
         if images and _PAPER_REVIEWER_MARKER in full_text:
             # 多模态论文评审员：确定性 JSON（人设不同分便于聚合测试）
             content = self._respond_paper_reviewer(full_text)
         elif images and _LIBRARIAN_MARKER in full_text:
             # 多模态图文编译：librarian markdown 里插入一行 ![[fig:0]] 图片标记
-            last_user = next((m.content for m in reversed(messages) if m.role == "user"), "")
+            last_user = next((m.text for m in reversed(messages) if m.role == "user"), "")
             content = self._respond_librarian(last_user, with_figure=True)
         elif images and _EXP_FIGQC_MARKER in full_text:
             # 多模态实验图表质检：确定性通过并逐图配假图注
@@ -150,7 +211,7 @@ class FakeProvider(LLMProvider):
             content = self._respond_exp_plot()
         else:
             content = self._respond(messages, model)
-        prompt_len = sum(estimate_tokens(m.content) for m in messages)
+        prompt_len = sum(estimate_tokens(m.text) for m in messages)
         return CompletionResult(
             content=content,
             model=model,
@@ -179,6 +240,47 @@ class FakeProvider(LLMProvider):
         chunk = 64
         for i in range(0, len(result.content), chunk):
             yield result.content[i : i + chunk]
+
+    async def stream_events(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """按剧本发起工具调用，否则回退到纯文本。
+
+        ``tool_choice="none"`` 时**一律不发工具**——agent 循环轮次耗尽后就是靠它硬关
+        工具收尾的，这条语义必须在假 provider 上也成立，否则那条路径没人测。
+        """
+        step = None if tool_choice == "none" else self._next_step(messages)
+        if isinstance(step, str):
+            # 剧本里排的是「这一轮直接作答」
+            for i in range(0, len(step), 16):
+                yield TextDelta(step[i : i + 16])
+            yield StreamDone(finish_reason="stop", usage={})
+            return
+        if step:
+            for index, (name, args) in enumerate(step):
+                yield ToolUseStart(index, f"call_{index}_{name}", name)
+                # 故意把 JSON 切在奇怪的位置（键名中间、值中间、转义序列中间）：
+                # 累加器的增量拼接路径只有这里能天天跑到
+                raw = json.dumps(args, ensure_ascii=False)
+                for piece in _slice_oddly(raw):
+                    yield ToolUseArgsDelta(index, piece)
+                yield ToolUseStop(index)
+            yield StreamDone(finish_reason="tool_use", usage={})
+            return
+        async for text in self.stream(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens, images=images
+        ):
+            yield TextDelta(text)
+        yield StreamDone(finish_reason="stop", usage={})
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:
         return [fake_embedding(t) for t in texts]
@@ -210,9 +312,9 @@ class FakeProvider(LLMProvider):
 
     @staticmethod
     def _respond(messages: Sequence[Message], model: str) -> str:
-        full_text = "\n".join(m.content for m in messages)
+        full_text = "\n".join(m.text for m in messages)
         last_user = next(
-            (m.content for m in reversed(messages) if m.role == "user"),
+            (m.text for m in reversed(messages) if m.role == "user"),
             full_text,
         )
         # M5-C 论文评审五 marker：prompt 内嵌 LaTeX 源/评审意见（可能撞其他 marker），

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -13,7 +13,26 @@ from typing import Any
 
 import httpx
 
-from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message, RerankResult
+from app.core.llm.base import (
+    CompletionResult,
+    EffortLevel,
+    ImageBlock,
+    LLMProvider,
+    Message,
+    RerankResult,
+    StreamDone,
+    StreamEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolResultBlock,
+    ToolUseArgsDelta,
+    ToolUseBlock,
+    ToolUseStart,
+    ToolUseStop,
+    normalize_finish_reason,
+)
 
 logger = logging.getLogger("polaris.llm")
 
@@ -73,8 +92,100 @@ def _truncate_and_normalize(vector: list[float], dimensions: int) -> list[float]
     return [value / norm for value in truncated]
 
 
+def _messages_payload(messages: Sequence[Message]) -> list[dict[str, Any]]:
+    """把消息（可能带 content blocks）翻成 OpenAI 的形状。
+
+    两处不对称，都是 OpenAI 侧的限制，不是我们的选择：
+
+    - **工具结果要扇出**：我们把一轮里的 K 个结果装在一条 ``role="user"`` 消息里
+      （Anthropic 形状），这里要拆成 K 条 ``role="tool"``。
+    - **``role="tool"`` 塞不进图片**（多数中转只认纯文本）。所以图片另起一条合成的
+      user 消息，正文写明它属于哪次调用——绑定关系靠文字，是有损的，但没有更好的办法。
+    """
+    out: list[dict[str, Any]] = []
+    for m in messages:
+        if isinstance(m.content, str):
+            out.append({"role": m.role, "content": m.content})
+            continue
+
+        blocks = list(m.content)
+        tool_results = [b for b in blocks if isinstance(b, ToolResultBlock)]
+        tool_uses = [b for b in blocks if isinstance(b, ToolUseBlock)]
+        texts = [b.text for b in blocks if isinstance(b, TextBlock | ThinkingBlock)]
+        images = [b for b in blocks if isinstance(b, ImageBlock)]
+
+        if tool_results:
+            for result in tool_results:
+                out.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": result.tool_use_id,
+                        "content": result.content,
+                    }
+                )
+            carried = [img for r in tool_results for img in r.images] + images
+            if carried:
+                parts: list[dict[str, Any]] = [
+                    {"type": "text", "text": "以下是上面工具调用返回的图片。"}
+                ]
+                for img in carried:
+                    b64 = base64.b64encode(img.data).decode("ascii")
+                    parts.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:{img.mime};base64,{b64}"},
+                        }
+                    )
+                out.append({"role": "user", "content": parts})
+            continue
+
+        entry: dict[str, Any] = {"role": m.role, "content": "\n".join(texts)}
+        if tool_uses:
+            entry["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(call.input, ensure_ascii=False),
+                    },
+                }
+                for call in tool_uses
+            ]
+            # 带 tool_calls 时 content 允许为空；有的中转对空字符串更宽容，保持 ""
+        if images:
+            parts = [{"type": "text", "text": entry["content"]}]
+            for img in images:
+                b64 = base64.b64encode(img.data).decode("ascii")
+                parts.append(
+                    {"type": "image_url", "image_url": {"url": f"data:{img.mime};base64,{b64}"}}
+                )
+            entry["content"] = parts
+        out.append(entry)
+    return out
+
+
+def _tool_call_events(delta: dict[str, Any]) -> list[StreamEvent]:
+    """把一个 chunk 里的 ``delta.tool_calls[]`` 翻成事件。
+
+    中转的三个常见差异都在这里兜住：单工具时可能**不发 index**（一律兜底 0）；``id`` /
+    ``name`` 有的只在首片发、有的每片都发（首次非空即锁定，交给累加器判重）；
+    ``arguments`` 是逐段的 JSON 字符串，这里只往下传，不解析。
+    """
+    events: list[StreamEvent] = []
+    for frag in delta.get("tool_calls") or []:
+        index = int(frag.get("index", 0) or 0)
+        fn = frag.get("function") or {}
+        if frag.get("id") or fn.get("name"):
+            events.append(ToolUseStart(index, str(frag.get("id") or ""), str(fn.get("name") or "")))
+        if (args := fn.get("arguments")) is not None:
+            events.append(ToolUseArgsDelta(index, args))
+    return events
+
+
 class OpenAICompatProvider(LLMProvider):
     name = "openai_compat"
+    supports_tools = True
 
     async def _post_with_retry(self, url: str, payload: dict[str, Any]) -> httpx.Response:
         """429/5xx/网络错误重试（指数退避，尊重 Retry-After），其余状态原样返回。"""
@@ -140,10 +251,10 @@ class OpenAICompatProvider(LLMProvider):
         stream: bool,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> dict[str, Any]:
-        payload_messages: list[dict[str, Any]] = [
-            {"role": m.role, "content": m.content} for m in messages
-        ]
+        payload_messages: list[dict[str, Any]] = _messages_payload(messages)
         if images:
             # 多模态：图片以 data-url image_url parts 附在最后一条 user 消息上
             target = next(
@@ -169,6 +280,21 @@ class OpenAICompatProvider(LLMProvider):
             payload["reasoning_effort"] = effort
         # Anthropic 系模型（经 LiteLLM 等代理）强制要求 max_tokens，缺省给足额度
         payload["max_tokens"] = max_tokens if max_tokens is not None else 8192
+        if tools:
+            # ToolSpec.input_schema 本来就是标准 JSON Schema，这里零转换
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t["name"],
+                        "description": t.get("description", ""),
+                        "parameters": t.get("parameters") or {"type": "object", "properties": {}},
+                    },
+                }
+                for t in tools
+            ]
+            if tool_choice is not None:
+                payload["tool_choice"] = tool_choice
         return payload
 
     async def complete(
@@ -180,16 +306,20 @@ class OpenAICompatProvider(LLMProvider):
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> CompletionResult:
         try:
             return await self._complete_once(
-                messages, model, temperature, max_tokens, images, effort
+                messages, model, temperature, max_tokens, images, effort, tools, tool_choice
             )
         except _EffortUnsupported as e:
             # 该模型不吃这个档位：去掉参数重试一次，别让配错档位打断整个环节
             self._effort_unsupported.add(model)
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
-            return await self._complete_once(messages, model, temperature, max_tokens, images, None)
+            return await self._complete_once(
+                messages, model, temperature, max_tokens, images, None, tools, tool_choice
+            )
 
     async def _complete_once(
         self,
@@ -199,9 +329,19 @@ class OpenAICompatProvider(LLMProvider):
         max_tokens: int | None,
         images: list[bytes] | None,
         effort: EffortLevel | None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
     ) -> CompletionResult:
         payload = self._payload(
-            messages, model, temperature, max_tokens, stream=False, images=images, effort=effort
+            messages,
+            model,
+            temperature,
+            max_tokens,
+            stream=False,
+            images=images,
+            effort=effort,
+            tools=tools,
+            tool_choice=tool_choice,
         )
         resp = await self._post_with_retry(f"{self._base_url}/chat/completions", payload)
         if resp.status_code >= 400:
@@ -217,11 +357,25 @@ class OpenAICompatProvider(LLMProvider):
             raise RuntimeError(f"openai_compat {resp.status_code} from {self._base_url}: {body}")
         data = resp.json()
         choice = data["choices"][0]
+        message = choice.get("message") or {}
+        text = message.get("content") or ""
+        blocks: list[Any] = [TextBlock(text)] if text else []
+        for call in message.get("tool_calls") or []:
+            fn = call.get("function") or {}
+            raw_args = fn.get("arguments") or "{}"
+            try:
+                parsed = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+            except (json.JSONDecodeError, ValueError):
+                # 解析不了不抛：交给上层告诉模型重发，抛出去会把整轮打断
+                parsed = {"__parse_error__": str(raw_args)[:2000]}
+            call_id = str(call.get("id") or "")
+            blocks.append(ToolUseBlock(call_id, str(fn.get("name") or ""), parsed))
         return CompletionResult(
-            content=choice["message"]["content"] or "",
+            content=text,
             model=data.get("model", model),
-            finish_reason=choice.get("finish_reason"),
+            finish_reason=normalize_finish_reason(choice.get("finish_reason")),
             usage=data.get("usage") or {},
+            blocks=tuple(blocks),
         )
 
     async def _stream_chunks(self, payload: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
@@ -283,34 +437,92 @@ class OpenAICompatProvider(LLMProvider):
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
     ) -> AsyncIterator[str]:
-        # TODO(M2): usage 统计、错误恢复
+        """纯文本流式：``stream_events`` 的过滤器。
+
+        保持这个签名不变（三个 SSE 端点 + 写作辅助都在用），也不给它加 tools——
+        只有一份 SSE 解析，就是下面那个。
+        """
+        async for ev in self.stream_events(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            images=images,
+            effort=effort,
+        ):
+            if isinstance(ev, TextDelta):
+                yield ev.text
+
+    async def stream_events(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         payload = self._payload(
-            messages, model, temperature, max_tokens, stream=True, images=images, effort=effort
+            messages,
+            model,
+            temperature,
+            max_tokens,
+            stream=True,
+            images=images,
+            effort=effort,
+            tools=tools,
+            tool_choice=tool_choice,
         )
         emitted = False
         try:
-            async for data in self._stream_chunks(payload):
-                choices = data.get("choices") or []
-                if not choices:
-                    continue
-                delta = choices[0].get("delta") or {}
-                if content := delta.get("content"):
-                    emitted = True
-                    yield content
+            async for ev in self._events_from(payload):
+                emitted = emitted or isinstance(ev, TextDelta | ToolUseStart)
+                yield ev
         except _EffortUnsupported as e:
-            # effort 是在首个 token 之前被拒的，重试不会重复输出；真吐过内容就不冒这个险
+            # effort 是在首个 token 之前被拒的，重试不会重复输出。
+            # 判据里必须带上 ToolUseStart：已经发起过工具调用还重试，会重复调用 + 双倍计费。
             if emitted:
                 raise
             self._effort_unsupported.add(model)
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试：%s", model, effort, e)
             payload.pop("reasoning_effort", None)
-            async for data in self._stream_chunks(payload):
-                choices = data.get("choices") or []
-                if not choices:
-                    continue
-                delta = choices[0].get("delta") or {}
-                if content := delta.get("content"):
-                    yield content
+            async for ev in self._events_from(payload):
+                yield ev
+
+    async def _events_from(self, payload: dict[str, Any]) -> AsyncIterator[StreamEvent]:
+        """一个 chunk 一个 chunk 地翻成结构化事件。
+
+        ``delta.content`` 与 ``delta.tool_calls`` **可能出现在同一个 chunk 里**，所以这里
+        不能写成 if/elif —— 那样会丢掉其中一个。
+        """
+        finish_reason: str | None = None
+        usage: dict[str, int] = {}
+        open_indexes: set[int] = set()
+        async for data in self._stream_chunks(payload):
+            if data.get("usage"):
+                usage = data["usage"]
+            choices = data.get("choices") or []
+            if not choices:
+                continue
+            choice = choices[0]
+            delta = choice.get("delta") or {}
+            if content := delta.get("content"):
+                yield TextDelta(content)
+            # DeepSeek 与部分中转的非标字段；有就映射成思考，没有也不强求
+            if reasoning := (delta.get("reasoning_content") or delta.get("reasoning")):
+                yield ThinkingDelta(reasoning)
+            for ev in _tool_call_events(delta):
+                if isinstance(ev, ToolUseStart):
+                    open_indexes.add(ev.index)
+                yield ev
+            if reason := choice.get("finish_reason"):
+                finish_reason = reason
+        for index in sorted(open_indexes):
+            yield ToolUseStop(index)
+        yield StreamDone(finish_reason=normalize_finish_reason(finish_reason), usage=usage)
 
     async def embed(self, texts: list[str], *, model: str) -> list[list[float]]:
         url = f"{self._base_url}/embeddings"

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -20,7 +20,15 @@ from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.core.llm import call_log
 from app.core.llm.anthropic import AnthropicProvider
-from app.core.llm.base import CompletionResult, EffortLevel, LLMProvider, Message
+from app.core.llm.base import (
+    CompletionResult,
+    EffortLevel,
+    LLMProvider,
+    Message,
+    StreamDone,
+    StreamEvent,
+    TextDelta,
+)
 from app.core.llm.fake import FakeProvider, estimate_tokens
 from app.core.llm.openai_compat import OpenAICompatProvider
 from app.core.security import decrypt_secret
@@ -43,6 +51,7 @@ class LLMNotConfiguredError(RuntimeError):
 # 结构化抽取（作者↔机构解析、概念定义批量生成、建库向导收录设置），小模型够用。
 STAGES = (
     "default",
+    "agent",
     "navigator",
     "sextant",
     "relevance",
@@ -80,7 +89,7 @@ GLOBAL_ONLY_STAGES = frozenset({"embedding"})
 # 新环节拆出来时的兼容回退：没显式配路由就沿用原来那个环节的，行为不变。
 # digest 原先是直接复用 librarian 的调用，拆开只是为了能单独设模型——
 # 存量部署不配也不该因此改变行为（default 路由指向的往往是另一类模型）。
-_STAGE_ROUTE_FALLBACKS = {"digest": "librarian"}
+_STAGE_ROUTE_FALLBACKS = {"digest": "librarian", "agent": "reading"}
 
 
 @dataclass(slots=True, frozen=True)
@@ -133,9 +142,16 @@ _LONG_CALL = (300.0, 4)
 # 但一次要为一批论文生成洞察，实测 p95 313 秒，必须给长档预算。
 _LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest"})
 
+# agent 单独一档。一轮 agent 调用 = 思考 + 发起工具调用，比短 JSON 长得多，但**不能**
+# 直接塞进长档：那是 300s × 4 尝试，最坏 20 分钟攥着一个 HTTP 连接不放，而对话是同步的，
+# 用户早走了。180s × 2 是"够想完一轮、又不至于把连接耗死"的折中。
+_AGENT_CALL = (180.0, 2)
+
 
 def call_profile(stage: str) -> tuple[float, int]:
     """该环节单次调用的 (超时, 最大尝试次数)。"""
+    if stage == "agent":
+        return _AGENT_CALL
     return _LONG_CALL if stage in _LONG_CALL_STAGES else _SHORT_CALL
 
 
@@ -385,7 +401,7 @@ class LLMRouter:
         """provider 未返回 usage 时按 len/4 估算。"""
         usage = dict(usage or {})
         if not usage.get("prompt_tokens"):
-            usage["prompt_tokens"] = sum(estimate_tokens(m.content) for m in messages)
+            usage["prompt_tokens"] = sum(estimate_tokens(m.text) for m in messages)
         if not usage.get("completion_tokens"):
             usage["completion_tokens"] = estimate_tokens(content)
         return usage
@@ -399,6 +415,8 @@ class LLMRouter:
         max_tokens: int | None = None,
         images: list[bytes] | None = None,
         effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
         user_id: uuid.UUID | None = None,
         project_id: uuid.UUID | None = None,
         library_id: uuid.UUID | None = None,
@@ -421,6 +439,12 @@ class LLMRouter:
                 extra: dict[str, Any] = {"images": images} if images else {}
                 if eff is not None:
                     extra["effort"] = eff
+                if tools:
+                    # 只在真的要用工具时才传：未声明该参数的 provider 子类/测试替身
+                    # 一旦收到未知关键字就会 TypeError，而它们本来工作得好好的
+                    extra["tools"] = tools
+                    if tool_choice is not None:
+                        extra["tool_choice"] = tool_choice
                 result = await provider.complete(
                     messages, model=route.model, temperature=temp, max_tokens=max_tokens, **extra
                 )
@@ -737,6 +761,102 @@ class LLMRouter:
             library_id=library_id,
         )
         # 时延 = 到流结束的完整耗时；response 聚合完整输出
+        if log_enabled:
+            await self._log_call(
+                stage=stage,
+                route=route,
+                model=route.model,
+                started_at=started_at,
+                status="ok",
+                error=None,
+                request=call_log.sanitize_request(messages),
+                response=content,
+                usage=usage,
+                user_id=user_id,
+                project_id=project_id,
+                voyage_id=voyage_id,
+                library_id=library_id,
+            )
+
+
+    async def stream_events(
+        self,
+        stage: str,
+        messages: Sequence[Message],
+        *,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        images: list[bytes] | None = None,
+        effort: EffortLevel | None = None,
+        tools: Sequence[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+        user_id: uuid.UUID | None = None,
+        project_id: uuid.UUID | None = None,
+        library_id: uuid.UUID | None = None,
+        voyage_id: uuid.UUID | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """结构化流式：文本 / 思考 / 工具调用。agent 循环用它，普通对话仍走 stream()。
+
+        记账与 stream() 同口径：流正常结束后写一行 LLMUsage。provider 给了 usage 就用
+        它的（Anthropic 现在也归一化过键名了），没给才按 len/4 估。
+        """
+        provider, route = await self.resolve(stage, user_id)
+        log_enabled = await call_log.logging_enabled()
+        started_at = time.monotonic()
+        collected: list[str] = []
+        reported: dict[str, int] = {}
+        eff = route.effort if effort is None else effort
+        extra: dict[str, Any] = {}
+        if eff is not None:
+            extra["effort"] = eff
+        if images:
+            extra["images"] = images
+        if tools:
+            extra["tools"] = tools
+            if tool_choice is not None:
+                extra["tool_choice"] = tool_choice
+        try:
+            async for ev in provider.stream_events(
+                messages,
+                model=route.model,
+                temperature=route.temperature if temperature is None else temperature,
+                max_tokens=max_tokens,
+                **extra,
+            ):
+                if isinstance(ev, TextDelta):
+                    collected.append(ev.text)
+                elif isinstance(ev, StreamDone) and ev.usage:
+                    reported = dict(ev.usage)
+                yield ev
+        except Exception as e:
+            if log_enabled:
+                await self._log_call(
+                    stage=stage,
+                    route=route,
+                    model=route.model,
+                    started_at=started_at,
+                    status="error",
+                    error=f"{type(e).__name__}: {e}",
+                    request=call_log.sanitize_request(messages),
+                    response="".join(collected) or None,
+                    usage={},
+                    user_id=user_id,
+                    project_id=project_id,
+                    voyage_id=voyage_id,
+                    library_id=library_id,
+                )
+            raise
+        content = "".join(collected)
+        usage = reported or self._ensure_usage(messages, content, None)
+        await self._record_usage(
+            stage=stage,
+            model=route.model,
+            usage=usage,
+            user_id=user_id,
+            project_id=project_id,
+            voyage_id=voyage_id,
+            library_id=library_id,
+        )
         if log_enabled:
             await self._log_call(
                 stage=stage,

--- a/src/backend/app/core/llm/tool_stream.py
+++ b/src/backend/app/core/llm/tool_stream.py
@@ -1,0 +1,131 @@
+"""流式工具调用的累加器。
+
+两家的协议看着不一样，本质是同一件事：**身份在 start 事件上给全，参数按 index 增量拼**。
+
+- OpenAI：``delta.tool_calls[]``，每个分片带 ``index``；``id`` 与 ``function.name`` 通常
+  只在该 index 的第一个分片出现；``function.arguments`` 是逐段的 JSON 字符串。
+- Anthropic：``content_block_start``（index + id + name）→ ``content_block_delta``
+  （``input_json_delta.partial_json``）→ ``content_block_stop``。
+
+所以归并靠 ``index`` 而不是 ``id`` —— OpenAI 的 id 有的中转只发一次、有的每片都发，
+拿它当归并键会散。
+
+本模块不做 IO、不 import provider，可以直接单测。参数分片的解析路径只有单测能天天
+跑到（真实流量里它是对的，出问题时又极难复现），所以 FakeProvider 会故意把 JSON 切在
+键名中间、值中间、转义序列中间。
+"""
+
+import json
+import logging
+from typing import Any
+
+from app.core.llm.base import (
+    ContentBlock,
+    StreamEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolUseArgsDelta,
+    ToolUseBlock,
+    ToolUseStart,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _Pending:
+    __slots__ = ("id", "name", "args")
+
+    def __init__(self, id: str, name: str) -> None:
+        self.id = id
+        self.name = name
+        self.args: list[str] = []
+
+
+class ToolCallAccumulator:
+    """把流式事件攒成完整的 content blocks。
+
+    用法：每收到一个 :class:`StreamEvent` 调一次 :meth:`feed`，流结束后调 :meth:`finish`
+    拿到块列表。文本与思考也一并攒着，因为 assistant 轮回喂时要的是**完整的块序列**
+    （thinking 的签名、tool_use 的 id 都在里面）。
+    """
+
+    def __init__(self) -> None:
+        self._text: list[str] = []
+        self._thinking: list[str] = []
+        self._thinking_signature: str | None = None
+        self._pending: dict[int, _Pending] = {}
+        self._order: list[int] = []
+
+    def feed(self, ev: StreamEvent) -> None:
+        if isinstance(ev, TextDelta):
+            self._text.append(ev.text)
+        elif isinstance(ev, ThinkingDelta):
+            self._thinking.append(ev.text)
+            if ev.signature:
+                self._thinking_signature = ev.signature
+        elif isinstance(ev, ToolUseStart):
+            if ev.index not in self._pending:
+                self._pending[ev.index] = _Pending(ev.id, ev.name)
+                self._order.append(ev.index)
+            else:
+                # 有的中转在后续分片里重发 id/name：首次非空即锁定，不覆盖
+                cur = self._pending[ev.index]
+                cur.id = cur.id or ev.id
+                cur.name = cur.name or ev.name
+        elif isinstance(ev, ToolUseArgsDelta):
+            cur = self._pending.get(ev.index)
+            if cur is None:
+                # 没见过 start 就先来了参数：补一个占位，name 留空，finish 时丢弃
+                cur = _Pending("", "")
+                self._pending[ev.index] = cur
+                self._order.append(ev.index)
+            cur.args.append(ev.json_fragment)
+        # ToolUseStop / StreamDone 不需要动作：参数一律在 finish 时统一解析
+
+    @property
+    def text(self) -> str:
+        return "".join(self._text)
+
+    @property
+    def has_calls(self) -> bool:
+        return any(p.name for p in self._pending.values())
+
+    def finish(self) -> tuple[ContentBlock, ...]:
+        """产出块列表：thinking → text → 各个 tool_use（按 index 首次出现的顺序）。"""
+        blocks: list[ContentBlock] = []
+        thinking = "".join(self._thinking)
+        if thinking:
+            blocks.append(ThinkingBlock(thinking, self._thinking_signature))
+        text = self.text
+        if text:
+            blocks.append(TextBlock(text))
+        for index in self._order:
+            pending = self._pending[index]
+            if not pending.name:
+                logger.warning("tool call at index %s has no name; dropped", index)
+                continue
+            call_id = pending.id or f"call_{index}"
+            blocks.append(ToolUseBlock(call_id, pending.name, _parse_args(pending)))
+        return tuple(blocks)
+
+
+def _parse_args(pending: _Pending) -> dict[str, Any]:
+    """把攒起来的 JSON 分片解析成参数。
+
+    空参工具会流出 ``""``（有的中转干脆一个分片都不发），这不是错误，兜底成 ``{}``。
+    真的解析不了时也**不抛**——抛出去会把整条流打断，而模型下一轮完全可以自己纠正。
+    留一个 ``__parse_error__`` 让调用方决定怎么告诉模型。
+    """
+    raw = "".join(pending.args).strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("tool %s: arguments are not valid JSON: %.200s", pending.name, raw)
+        return {"__parse_error__": raw[:2000]}
+    if not isinstance(parsed, dict):
+        return {"__parse_error__": raw[:2000]}
+    return parsed

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -1,0 +1,177 @@
+"""router 侧的工具调用：新 stage、耐心档位、tools 透传、记账，以及向后兼容。"""
+
+import pytest
+
+from app.core.llm.base import (
+    LLMProvider,
+    Message,
+    StreamDone,
+    TextDelta,
+    ToolUseBlock,
+    ToolUseStart,
+)
+from app.core.llm.fake import FakeProvider
+from app.core.llm.router import _STAGE_ROUTE_FALLBACKS, STAGES, call_profile
+from app.core.llm.tool_stream import ToolCallAccumulator
+
+
+def test_agent_stage_exists_and_falls_back_to_reading():
+    """新 stage 未配置时继承 reading 的路由——存量部署不用改任何配置就能跑。"""
+    assert "agent" in STAGES
+    assert _STAGE_ROUTE_FALLBACKS["agent"] == "reading"
+
+
+def test_agent_gets_its_own_patience_not_the_long_profile():
+    """agent 单独一档，既不是短档也不是长档。
+
+    短档（60s×2）不够想完一轮；长档（300s×4）最坏 20 分钟攥着一个 HTTP 连接不放，
+    而对话是同步的——用户早走了。
+    """
+    agent = call_profile("agent")
+    assert agent == (180.0, 2)
+    assert agent != call_profile("relevance"), "不能是短档"
+    assert agent != call_profile("librarian"), "也不能是长档"
+    # reading（现有对话）必须保持短档不变
+    assert call_profile("reading") == call_profile("relevance")
+
+
+@pytest.mark.asyncio
+async def test_a_provider_without_tool_support_still_streams():
+    """没重写 stream_events 的 provider 走默认实现，行为与从前一致。
+
+    这条是整个改造能安全落地的关键：测试里那些手写替身一行没改，仍然能用。
+    """
+
+    class OldStyleProvider(LLMProvider):
+        name = "old"
+
+        async def complete(self, messages, **kwargs):  # noqa: ANN001, ANN003
+            raise NotImplementedError
+
+        async def stream(self, messages, **kwargs):  # noqa: ANN001, ANN003
+            for piece in ("你", "好"):
+                yield piece
+
+    provider = OldStyleProvider()
+    assert provider.supports_tools is False
+    events = [
+        ev
+        async for ev in provider.stream_events([Message(role="user", content="hi")], model="m")
+    ]
+    assert [e.text for e in events if isinstance(e, TextDelta)] == ["你", "好"]
+    assert isinstance(events[-1], StreamDone)
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_without_a_script_behaves_exactly_as_before():
+    """不排剧本时假 provider 不发任何工具调用。
+
+    现存 900 多条测试全靠这一点——它们从没听说过工具。
+    """
+    provider = FakeProvider()
+    events = [
+        ev
+        async for ev in provider.stream_events(
+            [Message(role="user", content="随便问点什么")], model="m"
+        )
+    ]
+    assert not any(isinstance(e, ToolUseStart) for e in events)
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_scripted_fake_drives_parallel_tool_calls():
+    """排了剧本就按剧本发起并行调用，参数能被累加器还原。"""
+    provider = FakeProvider()
+    provider.script(
+        [
+            [("search_papers", {"query": "planning", "k": 5}), ("get_paper", {"paper_id": "p1"})],
+            "根据检索结果，主流方法是树搜索。",
+        ]
+    )
+
+    acc = ToolCallAccumulator()
+    async for ev in provider.stream_events([Message(role="user", content="q")], model="m"):
+        acc.feed(ev)
+    calls = [b for b in acc.finish() if isinstance(b, ToolUseBlock)]
+    assert [c.name for c in calls] == ["search_papers", "get_paper"]
+    assert calls[0].input == {"query": "planning", "k": 5}
+    assert calls[1].input == {"paper_id": "p1"}
+
+    # 第二轮：剧本给的是一段文本，不再发工具
+    acc2 = ToolCallAccumulator()
+    async for ev in provider.stream_events([Message(role="user", content="q")], model="m"):
+        acc2.feed(ev)
+    assert not acc2.has_calls
+    assert "树搜索" in acc2.text
+
+
+@pytest.mark.asyncio
+async def test_tool_choice_none_hard_stops_tool_calls():
+    """``tool_choice="none"`` 时一律不发工具。
+
+    agent 循环轮次耗尽后就是靠它硬关工具收尾的（而不是追加 user 消息哄模型），
+    所以这条语义在假 provider 上也必须成立，否则那条路径没人测。
+    """
+    provider = FakeProvider()
+    provider.script([[("search_papers", {"query": "x"})]])
+    events = [
+        ev
+        async for ev in provider.stream_events(
+            [Message(role="user", content="q")], model="m", tool_choice="none"
+        )
+    ]
+    assert not any(isinstance(e, ToolUseStart) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_marker_drives_tools_without_a_provider_handle():
+    """端到端路径拿不到 provider 实例，用消息里的标记驱动。"""
+    provider = FakeProvider()
+    acc = ToolCallAccumulator()
+    async for ev in provider.stream_events(
+        [Message(role="user", content='请查一下\nPOLARIS_FAKE_TOOL:search_papers:{"query": "x"}')],
+        model="m",
+    ):
+        acc.feed(ev)
+    calls = [b for b in acc.finish() if isinstance(b, ToolUseBlock)]
+    assert len(calls) == 1 and calls[0].name == "search_papers"
+    assert calls[0].input == {"query": "x"}
+
+
+def test_message_text_flattens_blocks_and_keeps_constructors_working():
+    """``.text`` 是 12 处读取点的新落点；71 处构造点一行未动。"""
+    from app.core.llm.base import TextBlock, ToolResultBlock
+
+    plain = Message(role="user", content="就是一段字符串")
+    assert plain.text == "就是一段字符串"
+    assert plain.blocks == (TextBlock("就是一段字符串"),)
+
+    mixed = Message(
+        role="assistant",
+        content=[TextBlock("我查一下"), ToolUseBlock("c1", "search_papers", {"q": "x"})],
+    )
+    assert "我查一下" in mixed.text
+    assert "search_papers" in mixed.text, "工具调用在拍平时要留下痕迹，不能凭空消失"
+
+    result = Message(role="user", content=[ToolResultBlock("c1", '{"hits": 3}')])
+    assert "hits" in result.text
+
+
+def test_completion_result_rebuilds_the_assistant_message_with_blocks():
+    """回喂历史要用 as_assistant_message，不能拿 content 手工拼——那样会丢块。"""
+    from app.core.llm.base import CompletionResult, TextBlock
+
+    result = CompletionResult(
+        content="我查一下",
+        model="m",
+        blocks=(TextBlock("我查一下"), ToolUseBlock("c1", "search_papers", {"q": "x"})),
+    )
+    assert [c.name for c in result.tool_calls] == ["search_papers"]
+    msg = result.as_assistant_message()
+    assert isinstance(msg.content, list) and len(msg.content) == 2
+
+    # 没有块时退回纯文本，与从前一致
+    plain = CompletionResult(content="hi", model="m")
+    assert plain.as_assistant_message().content == "hi"
+    assert plain.tool_calls == ()

--- a/src/backend/tests/test_llm_tool_stream.py
+++ b/src/backend/tests/test_llm_tool_stream.py
@@ -1,0 +1,391 @@
+"""流式工具调用的解析：累加器 + 两家 provider 的 chunk 形状。
+
+夹具全部手写，不联网。这里覆盖的每一条都是真实中转上见过的差异——它们在正常流量里
+不显形，出问题时又极难复现，所以只能靠这组测试天天跑。
+"""
+
+import json
+
+import httpx
+import pytest
+
+from app.core.llm.base import (
+    Message,
+    StreamDone,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolResultBlock,
+    ToolUseArgsDelta,
+    ToolUseBlock,
+    ToolUseStart,
+    ToolUseStop,
+    normalize_finish_reason,
+)
+from app.core.llm.tool_stream import ToolCallAccumulator
+
+# ---- 累加器 ----
+
+
+def test_arguments_are_reassembled_from_arbitrary_fragments():
+    """参数按 index 拼回来，切口在哪都行。
+
+    OpenAI 的 arguments 是逐段的 JSON 字符串，切口可能落在键名中间、值中间、甚至
+    转义序列中间。所以必须**按原始字符串累加、到最后才 json.loads**，中途任何一次
+    解析都会失败。
+    """
+    acc = ToolCallAccumulator()
+    raw = json.dumps({"query": '带"引号"和\\反斜杠', "k": 5}, ensure_ascii=False)
+    acc.feed(ToolUseStart(0, "call_1", "search_papers"))
+    for i in range(0, len(raw), 3):  # 3 个字符一刀，切得足够碎
+        acc.feed(ToolUseArgsDelta(0, raw[i : i + 3]))
+    acc.feed(ToolUseStop(0))
+
+    blocks = acc.finish()
+    assert len(blocks) == 1
+    call = blocks[0]
+    assert isinstance(call, ToolUseBlock)
+    assert call.name == "search_papers"
+    assert call.input == {"query": '带"引号"和\\反斜杠', "k": 5}
+
+
+def test_parallel_calls_are_merged_by_index_not_by_id():
+    """两个并行调用按 index 归并。
+
+    id 不能当归并键：有的中转只在首片发 id，有的每片都发，还有的压根不发。
+    """
+    acc = ToolCallAccumulator()
+    acc.feed(ToolUseStart(0, "a", "search_papers"))
+    acc.feed(ToolUseStart(1, "b", "get_paper"))
+    acc.feed(ToolUseArgsDelta(0, '{"query"'))
+    acc.feed(ToolUseArgsDelta(1, '{"paper_id"'))
+    acc.feed(ToolUseArgsDelta(0, ': "x"}'))
+    acc.feed(ToolUseArgsDelta(1, ': "y"}'))
+
+    calls = [b for b in acc.finish() if isinstance(b, ToolUseBlock)]
+    assert [c.name for c in calls] == ["search_papers", "get_paper"]
+    assert calls[0].input == {"query": "x"} and calls[1].input == {"paper_id": "y"}
+
+
+def test_id_locks_on_first_non_empty_value():
+    """id/name 首次非空即锁定：后续分片重发不覆盖，也不因空值把已有的抹掉。"""
+    acc = ToolCallAccumulator()
+    acc.feed(ToolUseStart(0, "real-id", "search_papers"))
+    acc.feed(ToolUseStart(0, "", ""))  # 有的中转会重发一个空壳
+    acc.feed(ToolUseArgsDelta(0, "{}"))
+    call = acc.finish()[0]
+    assert isinstance(call, ToolUseBlock)
+    assert call.id == "real-id" and call.name == "search_papers"
+
+
+def test_empty_arguments_become_an_empty_dict():
+    """空参工具流出的是 ``""``（或一片都不发），这不是错误。"""
+    acc = ToolCallAccumulator()
+    acc.feed(ToolUseStart(0, "c", "get_project_status"))
+    acc.feed(ToolUseArgsDelta(0, ""))
+    assert acc.finish()[0].input == {}
+
+    acc2 = ToolCallAccumulator()
+    acc2.feed(ToolUseStart(0, "c", "get_project_status"))
+    assert acc2.finish()[0].input == {}
+
+
+def test_malformed_arguments_do_not_raise():
+    """参数不是合法 JSON 时不抛——抛出去会把整条流打断。
+
+    弱模型上这是高频情形，模型下一轮完全可以自己纠正，所以留一个标记让调用方去告诉它。
+    """
+    acc = ToolCallAccumulator()
+    acc.feed(ToolUseStart(0, "c", "search_papers"))
+    acc.feed(ToolUseArgsDelta(0, '{"query": '))  # 截断的 JSON
+    call = acc.finish()[0]
+    assert "__parse_error__" in call.input
+
+
+def test_text_and_thinking_are_kept_with_the_signature():
+    """thinking 的签名必须留在块里：回放时缺签名会被 Anthropic 拒掉。"""
+    acc = ToolCallAccumulator()
+    acc.feed(ThinkingDelta("先想想"))
+    acc.feed(ThinkingDelta("", "sig-abc"))
+    acc.feed(TextDelta("答案是"))
+    blocks = acc.finish()
+    assert isinstance(blocks[0], ThinkingBlock)
+    assert blocks[0].text == "先想想" and blocks[0].signature == "sig-abc"
+    assert isinstance(blocks[1], TextBlock) and blocks[1].text == "答案是"
+
+
+def test_finish_reason_is_normalised():
+    assert normalize_finish_reason("tool_calls") == "tool_use"
+    assert normalize_finish_reason("tool_use") == "tool_use"
+    assert normalize_finish_reason("end_turn") == "stop"
+    assert normalize_finish_reason("length") == "max_tokens"
+    assert normalize_finish_reason(None) is None
+
+
+# ---- OpenAI 兼容 provider ----
+
+
+def _sse(chunks: list[dict]) -> bytes:
+    body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks)
+    return (body + "data: [DONE]\n\n").encode()
+
+
+def _openai_provider(chunks: list[dict]):
+    from app.core.llm.openai_compat import OpenAICompatProvider
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_sse(chunks))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return OpenAICompatProvider("http://x/v1", "k", client=client)
+
+
+async def _events(provider, **kwargs):
+    return [
+        ev
+        async for ev in provider.stream_events(
+            [Message(role="user", content="hi")], model="m", **kwargs
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_text_and_tool_call_in_the_same_chunk():
+    """``delta.content`` 与 ``delta.tool_calls`` 可能出现在**同一个 chunk** 里。
+
+    写成 if/elif 就会丢掉其中一个——这是最容易犯、也最难从现象发现的错。
+    """
+    provider = _openai_provider(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "content": "我来查一下",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "function": {"name": "search_papers", "arguments": "{}"},
+                                }
+                            ],
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        ]
+    )
+    events = await _events(provider)
+    assert any(isinstance(e, TextDelta) and e.text == "我来查一下" for e in events)
+    assert any(isinstance(e, ToolUseStart) and e.name == "search_papers" for e in events)
+    done = events[-1]
+    assert isinstance(done, StreamDone) and done.finish_reason == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_openai_tool_call_without_index_defaults_to_zero():
+    """单个工具调用时部分中转不发 index。缺了就当 0，不能抛。"""
+    provider = _openai_provider(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"id": "c1", "function": {"name": "get_paper", "arguments": '{"a"'}}
+                            ]
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"delta": {"tool_calls": [{"function": {"arguments": ': 1}'}}]}}]},
+            {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        ]
+    )
+    acc = ToolCallAccumulator()
+    for ev in await _events(provider):
+        acc.feed(ev)
+    call = [b for b in acc.finish() if isinstance(b, ToolUseBlock)][0]
+    assert call.name == "get_paper" and call.input == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_is_a_filter_over_stream_events():
+    """``stream()`` 只吐文本，且与 ``stream_events`` 共用同一份 SSE 解析。"""
+    provider = _openai_provider(
+        [
+            {"choices": [{"delta": {"content": "一"}}]},
+            {"choices": [{"delta": {"reasoning_content": "（思考）"}}]},
+            {"choices": [{"delta": {"content": "二"}, "finish_reason": "stop"}]},
+        ]
+    )
+    chunks = [
+        c async for c in provider.stream([Message(role="user", content="hi")], model="m")
+    ]
+    assert chunks == ["一", "二"], "思考不该混进正文"
+
+    events = await _events(provider)
+    assert any(isinstance(e, ThinkingDelta) for e in events), "但结构化流里要能拿到思考"
+
+
+@pytest.mark.asyncio
+async def test_openai_payload_carries_tools_and_tool_results_fan_out():
+    """工具定义按 OpenAI 形状发；一条含 K 个结果的 user 消息扇出成 K 条 role=tool。"""
+    from app.core.llm.openai_compat import OpenAICompatProvider
+
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, content=_sse([{"choices": [{"delta": {"content": "ok"}}]}]))
+
+    provider = OpenAICompatProvider(
+        "http://x/v1", "k", client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+    messages = [
+        Message(role="user", content="查一下"),
+        Message(
+            role="assistant",
+            content=[ToolUseBlock("c1", "search_papers", {"query": "x"})],
+        ),
+        Message(
+            role="user",
+            content=[
+                ToolResultBlock("c1", '{"hits": 3}'),
+                ToolResultBlock("c2", '{"hits": 0}'),
+            ],
+        ),
+    ]
+    async for _ in provider.stream_events(
+        messages,
+        model="m",
+        tools=[{"name": "search_papers", "description": "d", "parameters": {"type": "object"}}],
+        tool_choice="auto",
+    ):
+        pass
+
+    assert seen["tools"][0]["function"]["name"] == "search_papers"
+    assert seen["tool_choice"] == "auto"
+    roles = [m["role"] for m in seen["messages"]]
+    assert roles.count("tool") == 2, f"两个结果要扇出成两条 role=tool：{roles}"
+    assert seen["messages"][1]["tool_calls"][0]["id"] == "c1"
+
+
+# ---- Anthropic provider ----
+
+
+def _anthropic_provider(events: list[dict]):
+    from app.core.llm.anthropic import AnthropicProvider
+
+    body = "".join(f"data: {json.dumps(e)}\n\n" for e in events).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    return AnthropicProvider("k", client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_use_blocks_and_usage():
+    """content_block_start/input_json_delta/stop 的三段式，外加两处 usage。
+
+    usage 此前完全没解析（代码里就写着 TODO），而且键名是 input_tokens/output_tokens，
+    与记账口径不同——不归一化的话走 Anthropic 的用量全是 len/4 估算值。
+    """
+    provider = _anthropic_provider(
+        [
+            {"type": "message_start", "message": {"usage": {"input_tokens": 120}}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "t1", "name": "read_fulltext"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"paper_'},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": 'id": "p1"}'},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 45},
+            },
+        ]
+    )
+    acc = ToolCallAccumulator()
+    events = []
+    async for ev in provider.stream_events([Message(role="user", content="hi")], model="m"):
+        events.append(ev)
+        acc.feed(ev)
+
+    call = [b for b in acc.finish() if isinstance(b, ToolUseBlock)][0]
+    assert call.name == "read_fulltext" and call.input == {"paper_id": "p1"}
+
+    done = events[-1]
+    assert isinstance(done, StreamDone)
+    assert done.finish_reason == "tool_use"
+    assert done.usage["prompt_tokens"] == 120 and done.usage["completion_tokens"] == 45
+
+
+@pytest.mark.asyncio
+async def test_anthropic_thinking_signature_round_trips():
+    """签名要能完整往返，否则带 thinking 的历史回放会被 400。"""
+    provider = _anthropic_provider(
+        [
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "想一下"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig-1"},
+            },
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        ]
+    )
+    acc = ToolCallAccumulator()
+    async for ev in provider.stream_events([Message(role="user", content="hi")], model="m"):
+        acc.feed(ev)
+    block = acc.finish()[0]
+    assert isinstance(block, ThinkingBlock) and block.signature == "sig-1"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_results_carry_images_natively():
+    """Anthropic 的 tool_result 能原生带图；OpenAI 侧做不到，只能另发一条合成消息。"""
+    from app.core.llm.base import ImageBlock
+
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, content=b'data: {"type": "message_delta", "delta": {}}\n\n')
+
+    from app.core.llm.anthropic import AnthropicProvider
+
+    provider = AnthropicProvider(
+        "k", client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+    messages = [
+        Message(
+            role="user",
+            content=[ToolResultBlock("t1", '{"ok": 1}', images=(ImageBlock(b"\x89PNG"),))],
+        )
+    ]
+    async for _ in provider.stream_events(messages, model="m"):
+        pass
+
+    content = seen["messages"][0]["content"][0]
+    assert content["type"] == "tool_result" and content["tool_use_id"] == "t1"
+    kinds = [part["type"] for part in content["content"]]
+    assert kinds == ["text", "image"]


### PR DESCRIPTION
Foundation for the agent harness. The LLM layer had **no tool calling at all**: `Message.content` was a plain string, providers only read `choices[0].message.content`, and `delta.tool_calls` was ignored entirely.

## The compatibility hinge

`Message.content` widens to `str | list[ContentBlock]` and gains a `.text` property. There are **71 `Message(...)` construction sites** across the repo but only **12 read sites**, all inside `core/llm`. So the 71 stay untouched and only the 12 move to `.text`.

**963 existing tests pass unchanged** — that is the proof, not a claim.

## Why tool results are not `role="tool"`

They ride as `ToolResultBlock` inside a `role="user"` message (the Anthropic shape):

- A round of N parallel results lands naturally in one message; no invented ordering convention across N messages.
- Results can carry images — eight of the platform's tools return figures.
- Adapting *from* this shape to OpenAI is a deterministic fan-out (one message → K `role:"tool"` messages). The reverse requires looking back at neighbouring messages to merge, which is far more fragile.

The cost is documented in the code: OpenAI's `role:"tool"` messages cannot carry images, so images follow in a synthetic user message stating which call they belong to. That binding is textual and therefore lossy — there is no better option on that API. Anthropic's `tool_result` carries images natively, and a test pins that.

## Streaming

Both vendors do the same thing wearing different clothes: **identity arrives in a start event, arguments accumulate by `index`**. Merging on `id` does not work — some proxies send it only in the first fragment, some in every one, some not at all.

`ToolCallAccumulator` is a pure class with no IO; its 14 tests run in 0.04s. Each one is a difference actually seen in the wild:

- `delta.content` and `delta.tool_calls` **in the same chunk** (writing this as if/elif silently drops one)
- single tool call arriving with no `index`
- `id`/`name` re-sent on later fragments
- arguments sliced mid-key, mid-value, mid-escape-sequence
- empty arguments (`""` or no fragment at all) — not an error
- **malformed JSON does not raise** — it would kill the whole stream, and the model can correct itself next round

## Two Anthropic debts paid along the way

- **Usage key normalisation.** Anthropic returns `input_tokens`/`output_tokens`; accounting reads `prompt_tokens`/`completion_tokens` and estimates len/4 when absent. So **every Anthropic usage figure recorded so far has been an estimate**, not a measurement.
- **Streaming usage parsing** — the old code carried a `TODO` for exactly this.

## The `agent` stage

Its own patience profile, `(180s, 2)`. The short profile (60s × 2) is not enough to finish a round of thinking plus a tool call; the long one (300s × 4) can hold an HTTP connection for twenty minutes, and chat is synchronous — the user is long gone. `reading` keeps the short profile unchanged. `_STAGE_ROUTE_FALLBACKS` makes the new stage inherit the `reading` route, so existing deployments need no configuration.

## Tests

- `test_llm_tool_stream.py` (14): accumulator behaviour plus hand-written OpenAI and Anthropic chunk fixtures. No network.
- `test_llm_router_tools.py` (9): the new stage and profile, a provider that never heard of `stream_events` still streaming through the ABC default, the scripted `FakeProvider`, `tool_choice="none"` hard-stopping tool calls, and `.text` flattening.

`FakeProvider` gained a script queue, and **behaves exactly as before when no script is set** — the condition for this landing safely. It deliberately slices argument JSON at awkward offsets, since that incremental path is otherwise exercised only in production, where it is impossible to reproduce.

Full suite **986 passed**; `ruff check app` clean.

## Note on ordering

This branch and #252 both touch the `estimate_tokens(m.content)` line in `papers.py` / `libraries.py` / `wiki.py` — #252 deletes those copies, this one edits them. Whichever merges second needs a trivial rebase.