### PR TITLE
feat(chat): move conversations to the server, with three overdue fixes alongside

### DIFF
--- a/src/backend/alembic/versions/581d172bd41b_conversations.py
+++ b/src/backend/alembic/versions/581d172bd41b_conversations.py
@@ -1,0 +1,102 @@
+"""对话服务端持久化 + 三处附带改动
+
+对话历史此前只存在浏览器 localStorage。agent 一轮里可能调好几次工具、中途会断线、
+事后要能审计，所以搬到服务端。
+
+顺带三处：
+- ``llm_usage.conversation_id``：``voyage_id`` 的天然对偶，让"这场对话花了多少"可回答；
+- ``ix_llm_usage_user_id``：user_id 上一直没有索引（project_id/library_id 有），
+  agent 循环里要按用户查配额，没索引就是全表扫；
+- ``model_routes.context_window``：router 现在不知道模型的上下文有多大，压缩阈值
+  只能拍脑袋。
+
+Revision ID: 581d172bd41b
+Revises: 78e222c38b3b
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "581d172bd41b"
+down_revision: str | None = "78e222c38b3b"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_JSON = sa.JSON().with_variant(JSONB(), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversations",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("scope_kind", sa.String(16), nullable=False),
+        sa.Column("scope_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "project_id", sa.Uuid(), sa.ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+        ),
+        sa.Column("title", sa.String(255), nullable=False, server_default=""),
+        sa.Column("status", sa.String(16), nullable=False, server_default="active"),
+        sa.Column("settings", _JSON, nullable=False, server_default="{}"),
+        sa.Column("usage", _JSON, nullable=False, server_default="{}"),
+        sa.Column("active_stream_id", sa.Uuid(), nullable=True),
+        sa.Column("last_message_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
+    op.create_index("ix_conversations_project_id", "conversations", ["project_id"])
+    op.create_index(
+        "ix_conversations_user_scope",
+        "conversations",
+        ["user_id", "scope_kind", "scope_id", "last_message_at"],
+    )
+
+    op.create_table(
+        "conversation_messages",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            sa.Uuid(),
+            sa.ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(16), nullable=False),
+        sa.Column("kind", sa.String(16), nullable=False, server_default="normal"),
+        sa.Column("blocks", _JSON, nullable=False, server_default="[]"),
+        sa.Column("text", sa.Text(), nullable=False, server_default=""),
+        sa.Column("status", sa.String(16), nullable=False, server_default="complete"),
+        sa.Column("sources", _JSON, nullable=True),
+        sa.Column("usage", _JSON, nullable=True),
+        sa.Column("model", sa.String(128), nullable=True),
+        sa.Column("stop_reason", sa.String(32), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("conversation_id", "seq", name="uq_conversation_messages_seq"),
+    )
+    op.create_index(
+        "ix_conversation_messages_conversation_id", "conversation_messages", ["conversation_id"]
+    )
+
+    op.add_column("llm_usage", sa.Column("conversation_id", sa.Uuid(), nullable=True))
+    op.create_index("ix_llm_usage_conversation_id", "llm_usage", ["conversation_id"])
+    # user_id 一直没索引，而配额查询按它过滤
+    op.create_index("ix_llm_usage_user_id", "llm_usage", ["user_id"])
+
+    op.add_column("model_routes", sa.Column("context_window", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("model_routes", "context_window")
+    op.drop_index("ix_llm_usage_user_id", table_name="llm_usage")
+    op.drop_index("ix_llm_usage_conversation_id", table_name="llm_usage")
+    op.drop_column("llm_usage", "conversation_id")
+    op.drop_index("ix_conversation_messages_conversation_id", table_name="conversation_messages")
+    op.drop_table("conversation_messages")
+    op.drop_index("ix_conversations_user_scope", table_name="conversations")
+    op.drop_index("ix_conversations_project_id", table_name="conversations")
+    op.drop_index("ix_conversations_user_id", table_name="conversations")
+    op.drop_table("conversations")

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.activity import Activity
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
 from app.models.chat_bot import ChatBotConfig
+from app.models.conversation import Conversation, ConversationMessage
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
 from app.models.email_code import EmailVerificationCode
 from app.models.experiment import Experiment, ExperimentRun
@@ -46,6 +47,8 @@ from app.models.voyage import VoyageRun, VoyageStep
 __all__ = [
     "Activity",
     "ChatBotConfig",
+    "Conversation",
+    "ConversationMessage",
     "Concept",
     "DailyFeedEntry",
     "DailyFeedLike",

--- a/src/backend/app/models/conversation.py
+++ b/src/backend/app/models/conversation.py
@@ -1,0 +1,98 @@
+"""对话会话与消息。
+
+此前对话历史**只存在浏览器 localStorage**：每次请求前端把最近 10 轮原样 POST 回来，
+服务端无状态。这对一问一答够用，对 agent 不够——一轮里模型可能调好几次工具，中途
+断线要能续，事后要能审计"它到底查了什么"。
+
+两条设计约束值得写在这里：
+
+1. **``blocks`` 存 provider 中立的块**，不存任何一家的原始 payload。管理端随时能改
+   ``ModelRoute``，存了 OpenAI 形状的历史就没法喂给 Anthropic 续跑。
+2. **不要对 ``blocks`` 写 JSON path 查询**。测试跑 SQLite、生产跑 Postgres JSONB，
+   过滤条件一律走反范式出来的列（``text`` / ``status`` / ``kind``）。
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+#: 对话的作用域类型。与前端 chatStorage 的 surfaceKey 一一对应，所以本地历史
+#: 迁移到服务端时是直接映射，不用猜。
+CONVERSATION_SCOPES = (
+    "project",  # 课题文献对话
+    "shelf",  # 课题相关研究书架
+    "library",  # 单个方向库
+    "personal",  # 个人收藏
+    "daily",  # 每日论文池
+    "paper",  # 单篇伴读
+    "global",  # 全局助手（不限作用域）
+)
+
+
+class Conversation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "conversations"
+    __table_args__ = (
+        Index(
+            "ix_conversations_user_scope",
+            "user_id",
+            "scope_kind",
+            "scope_id",
+            "last_message_at",
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    #: 用 (scope_kind, scope_id) 而不是六个可空外键：加一个新入口不用改表，而且它就是
+    #: 前端 surfaceKey 的形状。代价是拿不到外键级联——但对话是用户资产，课题删了对话
+    #: 还留着反而是想要的行为。
+    scope_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    scope_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    #: 单独一列：记账与鉴权都按课题走，而 scope_id 在 personal/daily 下是空的
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    title: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="active")
+    #: {tool_names, effort, stage, ...}
+    settings: Mapped[dict[str, Any]] = mapped_column(JSONVariant, nullable=False, default=dict)
+    #: 累计 {prompt_tokens, completion_tokens, total_tokens}
+    usage: Mapped[dict[str, Any]] = mapped_column(JSONVariant, nullable=False, default=dict)
+    #: 有值 = 有一轮正在跑（重连与"别并发发第二轮"都看它）
+    active_stream_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    last_message_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class ConversationMessage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "conversation_messages"
+    __table_args__ = (
+        UniqueConstraint("conversation_id", "seq", name="uq_conversation_messages_seq"),
+    )
+
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    role: Mapped[str] = mapped_column(String(16), nullable=False)
+    #: normal | compaction（压缩产生的摘要行，UI 折叠显示"已压缩 N 条"）
+    kind: Mapped[str] = mapped_column(String(16), nullable=False, default="normal")
+    #: 序列化后的 ContentBlock 列表（provider 中立）
+    blocks: Mapped[list[Any]] = mapped_column(JSONVariant, nullable=False, default=list)
+    #: 拍平的纯文本。反范式出来，列表/标题/搜索都不用碰 JSON——SQLite 上也能查
+    text: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="complete")
+    #: 该轮引用的论文（ChatSource 列表）。此前它只在 SSE 里飘过一次，从不落库，
+    #: 刷新页面就没了。
+    sources: Mapped[list[Any] | None] = mapped_column(JSONVariant, nullable=True)
+    usage: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant, nullable=True)
+    model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    stop_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -84,6 +84,8 @@ class ModelRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     temperature: Mapped[float | None] = mapped_column(Float, nullable=True)  # None=不传该参数
     # 推理档位（none/minimal/low/medium/high/xhigh/max，见 core/llm/base.py）。
     # None=不传该参数，用模型默认；具体模型支持哪些档位由服务端校验。
+    #: 该模型的上下文窗口（token）。压缩阈值要用它；None 时调用方按保守常量走。
+    context_window: Mapped[int | None] = mapped_column(Integer, nullable=True)
     effort: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     provider: Mapped[LLMProviderConfig] = relationship(back_populates="routes")
@@ -94,7 +96,11 @@ class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 用量面板按天/周窗口聚合（/lab/usage、排行榜），没这个索引就是全表扫
     __table_args__ = (Index("ix_llm_usage_created_at", "created_at"),)
 
-    user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
+    #: index=True：配额检查按用户过滤，而这一列此前**没有索引**（project_id/library_id
+    #: 都有），agent 循环里每轮查一次配额就是一次全表扫。
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), index=True
+    )
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("projects.id", ondelete="SET NULL"), index=True
     )
@@ -102,6 +108,8 @@ class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     library_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("direction_libraries.id", ondelete="SET NULL"), index=True
     )
+    #: 这一行属于哪场对话（voyage_id 的对偶）。让"这场对话花了多少 token"可回答。
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True, index=True)
     voyage_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("voyage_runs.id", ondelete="SET NULL")
     )

--- a/src/backend/app/services/conversations.py
+++ b/src/backend/app/services/conversations.py
@@ -1,0 +1,240 @@
+"""对话会话的读写。
+
+``replay()`` 是**唯一**把数据库行翻回 ``Message`` 的地方——压缩、图片降级、块的还原
+都收在这里，别在调用方各写一份。
+"""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.base import (
+    ContentBlock,
+    Message,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from app.models.conversation import Conversation, ConversationMessage
+
+#: 标题取首条用户消息的前若干字符
+_TITLE_CHARS = 60
+
+
+def blocks_to_json(blocks: tuple[ContentBlock, ...] | list[ContentBlock]) -> list[dict[str, Any]]:
+    """块 → 可落库的 JSON（provider 中立）。
+
+    **图片不落 base64**。一次取图工具能返回好几张，二十轮对话的 JSON 就爆了；而且
+    存了也没用——回放时喂给模型的历史带着几十张图，token 立刻见底。这里只留一行占位，
+    模型对"历史里少张图"的容忍度远高于"历史里有个截断的 base64"。
+    """
+    out: list[dict[str, Any]] = []
+    for b in blocks:
+        if isinstance(b, TextBlock):
+            out.append({"kind": "text", "text": b.text})
+        elif isinstance(b, ThinkingBlock):
+            out.append({"kind": "thinking", "text": b.text, "signature": b.signature})
+        elif isinstance(b, ToolUseBlock):
+            out.append({"kind": "tool_use", "id": b.id, "name": b.name, "input": b.input})
+        elif isinstance(b, ToolResultBlock):
+            out.append(
+                {
+                    "kind": "tool_result",
+                    "tool_use_id": b.tool_use_id,
+                    "content": b.content,
+                    "is_error": b.is_error,
+                    "images": len(b.images),  # 只记数量，见上
+                }
+            )
+        else:  # ImageBlock
+            out.append({"kind": "image", "mime": b.mime, "label": b.label})
+    return out
+
+
+def blocks_from_json(raw: list[dict[str, Any]] | None) -> list[ContentBlock]:
+    """JSON → 块。未知 kind 一律忽略（存量数据与将来的新块类型都不该炸这里）。"""
+    blocks: list[ContentBlock] = []
+    for item in raw or []:
+        kind = item.get("kind")
+        if kind == "text":
+            blocks.append(TextBlock(item.get("text") or ""))
+        elif kind == "thinking":
+            blocks.append(ThinkingBlock(item.get("text") or "", item.get("signature")))
+        elif kind == "tool_use":
+            blocks.append(
+                ToolUseBlock(
+                    str(item.get("id") or ""), str(item.get("name") or ""), item.get("input") or {}
+                )
+            )
+        elif kind == "tool_result":
+            note = ""
+            if count := int(item.get("images") or 0):
+                note = f"\n（另有 {count} 张图片，历史回放中已省略）"
+            blocks.append(
+                ToolResultBlock(
+                    str(item.get("tool_use_id") or ""),
+                    (item.get("content") or "") + note,
+                    is_error=bool(item.get("is_error")),
+                )
+            )
+        elif kind == "image":
+            blocks.append(TextBlock(f"[图片 {item.get('label') or item.get('mime') or ''}]"))
+    return blocks
+
+
+async def get_or_create(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    scope_kind: str,
+    scope_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    conversation_id: uuid.UUID | None = None,
+) -> Conversation:
+    """拿到会话；``conversation_id`` 给了就按它取（**并校验归属**），否则新建。"""
+    if conversation_id is not None:
+        conv = await session.get(Conversation, conversation_id)
+        if conv is not None and conv.user_id == user_id:
+            return conv
+        # 归属对不上按不存在处理，另开一条——别把别人的会话续下去
+    conv = Conversation(
+        user_id=user_id,
+        scope_kind=scope_kind,
+        scope_id=scope_id,
+        project_id=project_id,
+        title="",
+        settings={},
+        usage={},
+    )
+    session.add(conv)
+    await session.flush()
+    return conv
+
+
+async def append_message(
+    session: AsyncSession,
+    *,
+    conversation: Conversation,
+    role: str,
+    blocks: tuple[ContentBlock, ...] | list[ContentBlock] | None = None,
+    text: str | None = None,
+    kind: str = "normal",
+    sources: list[Any] | None = None,
+    usage: dict[str, Any] | None = None,
+    model: str | None = None,
+    stop_reason: str | None = None,
+    status: str = "complete",
+    error: str | None = None,
+) -> ConversationMessage:
+    """追加一条消息。``seq`` 在会话内自增（唯一约束兜底并发）。"""
+    blocks = list(blocks or ([TextBlock(text)] if text else []))
+    flat = text if text is not None else Message(role=role, content=blocks).text
+    next_seq = (
+        await session.scalar(
+            select(func.coalesce(func.max(ConversationMessage.seq), -1) + 1).where(
+                ConversationMessage.conversation_id == conversation.id
+            )
+        )
+    ) or 0
+    row = ConversationMessage(
+        conversation_id=conversation.id,
+        seq=int(next_seq),
+        role=role,
+        kind=kind,
+        blocks=blocks_to_json(blocks),
+        text=flat,
+        status=status,
+        sources=sources,
+        usage=usage,
+        model=model,
+        stop_reason=stop_reason,
+        error=error,
+    )
+    session.add(row)
+    conversation.last_message_at = datetime.now(UTC)
+    if not conversation.title and role == "user" and flat:
+        conversation.title = flat.strip()[:_TITLE_CHARS]
+    if usage:
+        acc = dict(conversation.usage or {})
+        for key in ("prompt_tokens", "completion_tokens"):
+            acc[key] = int(acc.get(key, 0)) + int(usage.get(key, 0) or 0)
+        acc["total_tokens"] = int(acc.get("prompt_tokens", 0)) + int(
+            acc.get("completion_tokens", 0)
+        )
+        conversation.usage = acc
+    await session.flush()
+    return row
+
+
+async def replay(
+    session: AsyncSession, *, conversation_id: uuid.UUID, limit: int | None = None
+) -> list[Message]:
+    """把会话历史翻回 ``Message`` 列表，按 seq 升序。
+
+    只回放 ``complete`` 的消息：中断/出错那条留在库里给人看，但不该喂回给模型——
+    半截的 assistant 轮会让它以为自己说过那些话。
+    """
+    stmt = (
+        select(ConversationMessage)
+        .where(
+            ConversationMessage.conversation_id == conversation_id,
+            ConversationMessage.status == "complete",
+        )
+        .order_by(ConversationMessage.seq.desc())
+    )
+    if limit:
+        stmt = stmt.limit(limit)
+    rows = list((await session.execute(stmt)).scalars().all())
+    rows.reverse()
+    return [Message(role=r.role, content=blocks_from_json(r.blocks)) for r in rows]
+
+
+async def finish_message(
+    session: AsyncSession,
+    *,
+    message: ConversationMessage,
+    blocks: tuple[ContentBlock, ...] | list[ContentBlock] | None = None,
+    status: str = "complete",
+    usage: dict[str, Any] | None = None,
+    model: str | None = None,
+    stop_reason: str | None = None,
+    error: str | None = None,
+) -> ConversationMessage:
+    """收尾一条 streaming 中的消息（正常结束 / 被中断 / 出错都走它）。"""
+    if blocks is not None:
+        message.blocks = blocks_to_json(blocks)
+        message.text = Message(role=message.role, content=list(blocks)).text
+    message.status = status
+    if usage:
+        message.usage = usage
+    if model:
+        message.model = model
+    if stop_reason:
+        message.stop_reason = stop_reason
+    if error:
+        message.error = error
+    await session.flush()
+    return message
+
+
+async def list_conversations(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    scope_kind: str | None = None,
+    scope_id: uuid.UUID | None = None,
+    limit: int = 30,
+) -> list[Conversation]:
+    stmt = select(Conversation).where(
+        Conversation.user_id == user_id, Conversation.status == "active"
+    )
+    if scope_kind:
+        stmt = stmt.where(Conversation.scope_kind == scope_kind)
+    if scope_id is not None:
+        stmt = stmt.where(Conversation.scope_id == scope_id)
+    stmt = stmt.order_by(Conversation.last_message_at.desc().nullslast()).limit(limit)
+    return list((await session.execute(stmt)).scalars().all())

--- a/src/backend/tests/test_conversations_store.py
+++ b/src/backend/tests/test_conversations_store.py
@@ -1,0 +1,226 @@
+"""对话的服务端持久化。
+
+此前历史只在浏览器 localStorage 里，每次请求前端把最近 10 轮原样 POST 回来。这对
+一问一答够用，对 agent 不够：一轮里模型可能调好几次工具、中途会断线、事后要能审计
+"它到底查了什么"。
+"""
+
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.core.llm.base import (
+    ImageBlock,
+    Message,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from app.services import conversations as store
+from tests.conftest import register_and_login
+
+
+async def _user_id(client, email: str) -> uuid.UUID:
+    from sqlalchemy import select
+
+    from app.models.user import User
+
+    await register_and_login(client, email=email)
+    async with get_sessionmaker()() as session:
+        return (await session.execute(select(User.id).where(User.email == email))).scalar_one()
+
+
+async def test_a_tool_using_round_survives_a_round_trip(client):
+    """带工具调用的一轮存下去、读回来，形状不丢。
+
+    这是整件事的核心契约：第二轮**不用前端传 history**，服务端自己重放得出上下文。
+    """
+    user_id = await _user_id(client, "conv-store@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=user_id, scope_kind="global")
+        await store.append_message(session, conversation=conv, role="user", text="查一下 planning")
+        await store.append_message(
+            session,
+            conversation=conv,
+            role="assistant",
+            blocks=[
+                ThinkingBlock("先检索", "sig-1"),
+                TextBlock("我来查一下"),
+                ToolUseBlock("c1", "search_papers", {"query": "planning"}),
+            ],
+            usage={"prompt_tokens": 100, "completion_tokens": 20},
+        )
+        await store.append_message(
+            session,
+            conversation=conv,
+            role="user",
+            blocks=[ToolResultBlock("c1", '{"hits": 3}')],
+        )
+        await session.commit()
+        conv_id = conv.id
+
+    async with get_sessionmaker()() as session:
+        history = await store.replay(session, conversation_id=conv_id)
+
+    assert [m.role for m in history] == ["user", "assistant", "user"]
+    assistant_blocks = history[1].content
+    assert isinstance(assistant_blocks, list)
+    kinds = [type(b).__name__ for b in assistant_blocks]
+    assert kinds == ["ThinkingBlock", "TextBlock", "ToolUseBlock"]
+    # 签名必须活着：缺了它这轮回放会被 Anthropic 拒掉
+    assert assistant_blocks[0].signature == "sig-1"
+    call = assistant_blocks[2]
+    assert call.name == "search_papers" and call.input == {"query": "planning"}
+    assert isinstance(history[2].content[0], ToolResultBlock)
+
+
+async def test_images_are_not_persisted_as_base64(client):
+    """工具结果里的图片不落 base64，只留一句占位。
+
+    一次取图工具能返回好几张，二十轮下来 JSON 就爆了；而且存了也没用——回放时把
+    几十张图喂回去，token 立刻见底。模型对"历史里少张图"的容忍度高得多。
+    """
+    user_id = await _user_id(client, "conv-img@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=user_id, scope_kind="global")
+        row = await store.append_message(
+            session,
+            conversation=conv,
+            role="user",
+            blocks=[
+                ToolResultBlock(
+                    "c1", '{"figures": 2}', images=(ImageBlock(b"\x89PNG" * 500), ImageBlock(b"x"))
+                )
+            ],
+        )
+        await session.commit()
+        raw, conv_id = row.blocks, conv.id
+
+    assert raw[0]["images"] == 2, "只记数量"
+    assert "PNG" not in str(raw), "绝不能把图片字节写进 JSON"
+
+    async with get_sessionmaker()() as session:
+        history = await store.replay(session, conversation_id=conv_id)
+    assert "2 张图片" in history[0].content[0].content
+
+
+async def test_interrupted_messages_stay_in_the_table_but_out_of_the_replay(client):
+    """中断/出错的消息留在库里给人看，但不喂回给模型。
+
+    半截的 assistant 轮会让模型以为自己说过那些话，接着往下编。
+    """
+    user_id = await _user_id(client, "conv-interrupt@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=user_id, scope_kind="global")
+        await store.append_message(session, conversation=conv, role="user", text="问题")
+        partial = await store.append_message(
+            session,
+            conversation=conv,
+            role="assistant",
+            blocks=[TextBlock("说到一半就")],
+            status="streaming",
+        )
+        await store.finish_message(session, message=partial, status="interrupted")
+        await session.commit()
+        conv_id = conv.id
+
+    async with get_sessionmaker()() as session:
+        history = await store.replay(session, conversation_id=conv_id)
+        from sqlalchemy import func, select
+
+        from app.models.conversation import ConversationMessage
+
+        total = await session.scalar(
+            select(func.count())
+            .select_from(ConversationMessage)
+            .where(ConversationMessage.conversation_id == conv_id)
+        )
+
+    assert [m.role for m in history] == ["user"], "中断那条不该进重放"
+    assert total == 2, "但它必须留在库里"
+
+
+async def test_usage_accumulates_on_the_conversation(client):
+    """每轮的 token 累加到会话上——"这场对话花了多少"要能一眼看到。"""
+    user_id = await _user_id(client, "conv-usage@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=user_id, scope_kind="global")
+        for _ in range(3):
+            await store.append_message(
+                session,
+                conversation=conv,
+                role="assistant",
+                text="答",
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            )
+        await session.commit()
+        usage = dict(conv.usage)
+
+    assert usage["prompt_tokens"] == 30
+    assert usage["completion_tokens"] == 15
+    assert usage["total_tokens"] == 45
+
+
+async def test_title_comes_from_the_first_user_message(client):
+    user_id = await _user_id(client, "conv-title@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=user_id, scope_kind="global")
+        await store.append_message(
+            session, conversation=conv, role="user", text="  最近有哪些值得关注的新论文？  "
+        )
+        await store.append_message(session, conversation=conv, role="user", text="第二个问题")
+        await session.commit()
+        title = conv.title
+
+    assert title == "最近有哪些值得关注的新论文？", "取首条、去空白、不被第二条覆盖"
+
+
+async def test_someone_elses_conversation_is_never_continued(client):
+    """带着别人的 conversation_id 来，不能把那场对话续下去。"""
+    owner = await _user_id(client, "conv-owner@example.com")
+    other = await _user_id(client, "conv-other@example.com")
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(session, user_id=owner, scope_kind="global")
+        await session.commit()
+        owned_id = conv.id
+
+    async with get_sessionmaker()() as session:
+        got = await store.get_or_create(
+            session, user_id=other, scope_kind="global", conversation_id=owned_id
+        )
+        await session.commit()
+
+    assert got.id != owned_id, "归属对不上就该另开一条，而不是接管"
+    assert got.user_id == other
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        [{"kind": "who-knows", "text": "x"}],  # 将来的新块类型
+        [{"kind": "text"}],  # 缺字段
+        None,  # 空
+    ],
+)
+def test_unknown_blocks_never_raise(raw):
+    """存量数据与将来的新块类型都不该炸在反序列化这一步。"""
+    assert isinstance(store.blocks_from_json(raw), list)
+
+
+def test_blocks_round_trip_is_provider_neutral():
+    """块存的是中立形状，不是某一家的 payload——管理端随时能改模型路由。"""
+    blocks = [
+        TextBlock("t"),
+        ThinkingBlock("think", "sig"),
+        ToolUseBlock("c1", "search_papers", {"q": 1}),
+        ToolResultBlock("c1", "{}", is_error=True),
+    ]
+    raw = store.blocks_to_json(blocks)
+    assert [b["kind"] for b in raw] == ["text", "thinking", "tool_use", "tool_result"]
+    back = store.blocks_from_json(raw)
+    assert [type(b).__name__ for b in back] == [type(b).__name__ for b in blocks]
+    assert back[3].is_error is True
+    # 拍平成文本时工具调用不能凭空消失
+    assert "search_papers" in Message(role="assistant", content=back).text

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,9 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
+HEAD_REVISION = "581d172bd41b"  # 成员行记下打分它的那次同步任务 id
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
+SCORED_RUN_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
 INLINE_VECTOR_DROP_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
 VECTOR_TABLES_REVISION = "5d8ebd5cb100"  # 向量侧表建表 + 存量搬迁
 EFFORT_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
@@ -89,6 +90,8 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "projects",
                     "chat_bot_configs",
                     "library_research_digests",
+                    "conversations",
+                    "conversation_messages",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -106,6 +109,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
     assert "effort" in columns["model_routes"]  # 推理档位可配（NULL = 用模型默认）
+    # 对话搬到服务端：agent 一轮里可能调好几次工具，历史不能只活在浏览器 localStorage
+    assert {"conversations", "conversation_messages"} <= columns["_tables"]
+    assert {"scope_kind", "scope_id", "usage", "active_stream_id"} <= columns["conversations"]
+    assert {"blocks", "text", "seq", "status", "sources"} <= columns["conversation_messages"]
+    # 这场对话花了多少 token（voyage_id 的对偶）
+    assert "conversation_id" in columns["llm_usage"]
+    # 压缩阈值要知道模型的窗口有多大，此前 router 只能拍脑袋
+    assert "context_window" in columns["model_routes"]
     # 向量搬进三张侧表，主表上的向量列与元信息列一并删除
     assert {"paper_vectors", "paper_chunk_vectors", "idea_vectors"} <= columns["_tables"]
     assert {"paper_id", "space", "dim", "embedding", "model", "built_at"} <= columns[
@@ -331,7 +342,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉成员行上的打分任务 id。
+    # 最新 revision 可往返：先退掉对话持久化（两张表 + 三处附带列）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SCORED_RUN_REVISION
+    assert not {"conversations", "conversation_messages"} & columns["_tables"]
+    assert "conversation_id" not in columns["llm_usage"]
+    assert "context_window" not in columns["model_routes"]
+
+    # 再退掉成员行上的打分任务 id。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == DIGEST_REVISION


### PR DESCRIPTION
Conversation history lived **only in the browser's localStorage**: every request re-POSTed the last ten turns and the server kept nothing. Fine for question-and-answer; not enough for an agent, where a single turn may call several tools, the connection may drop mid-round, and you later want to audit what it actually looked at.

Stacked on #253 (needs `ContentBlock`).

## Two tables plus a store

`conversations` is keyed by `(scope_kind, scope_id)` rather than six nullable foreign keys — that pair *is* the frontend's `surfaceKey`, so migrating local history later is a direct mapping, and adding a new entry point needs no schema change.

Decisions worth stating:

- **`blocks` stores provider-neutral blocks**, never one vendor's raw payload. An admin can change `ModelRoute` at any time; history stored in OpenAI shape could not be replayed to Anthropic.
- **Images are counted, not stored as base64.** One figure tool can return several images; twenty turns of that and the JSON is unusable — and storing them buys nothing, since replaying dozens of images exhausts the context immediately. Replay degrades to a one-line placeholder. Models tolerate "an image is missing from history" far better than "history contains a truncated base64 blob".
- **Interrupted messages stay in the table but stay out of the replay.** A half-finished assistant turn fed back makes the model believe it said those things and continue from there. The row is kept for humans to read.
- **Someone else's `conversation_id` starts a new conversation**, it does not take over theirs.
- No JSON-path queries against `blocks` — tests run SQLite, production runs Postgres JSONB, so all filtering goes through denormalised columns.

`replay()` is the single place that turns database rows back into `Message` objects; compaction and image degradation belong there, not scattered across callers.

## Three overdue fixes in the same migration

- **`llm_usage.conversation_id`** — the natural dual of `voyage_id`, making "what did this conversation cost" answerable.
- **`ix_llm_usage_user_id`** — this column had **no index**, while `project_id` and `library_id` both did. Quota checks filter on it, so an agent loop checking quota per round would mean a full table scan per round.
- **`model_routes.context_window`** — compaction thresholds need it; the router currently has no idea how large a model's window is.

## Tests

Ten new tests: a tool-using round survives the round trip with the thinking signature intact; images are not persisted as base64; interrupted messages are excluded from replay but present in the table; usage accumulates on the conversation; the title comes from the first user message only; another user's conversation is never continued; unknown block kinds never raise (three parametrised cases); blocks round-trip provider-neutrally.

The migration test now covers the new tables and the full downgrade path — upgrade to head, step back through each revision, and back up again.

Full suite **996 passed**; `ruff check app` clean.

## A mistake worth recording

I picked `a1b2c3d4e5f6` as the revision id — a suspiciously tidy one, already taken by `ssh_credential_proxy`. Alembic reported "revision present more than once". Replaced with a random id.