### PR TITLE
feat(chat): a read-only Polaris assistant with a real tool loop

### DIFF
--- a/src/backend/app/agents/chat/__init__.py
+++ b/src/backend/app/agents/chat/__init__.py
@@ -1,0 +1,14 @@
+"""对话 agent：Claude Code 式的多轮工具循环（不 import fastapi）。"""
+
+from app.agents.chat.events import ChatEvent
+from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
+from app.agents.chat.prompt import DEFAULT_TOOL_NAMES, build_system_prompt, tool_definitions
+
+__all__ = [
+    "DEFAULT_TOOL_NAMES",
+    "ChatAgentLoop",
+    "ChatEvent",
+    "ChatTurnRequest",
+    "build_system_prompt",
+    "tool_definitions",
+]

--- a/src/backend/app/agents/chat/events.py
+++ b/src/backend/app/agents/chat/events.py
@@ -1,0 +1,103 @@
+"""对话 agent 循环产出的事件。
+
+循环自己不认识 HTTP，也不认识 SSE——它只吐这些事件，由 API 层翻成线上帧。这条边界
+是可测性的来源：脱离 HTTP 就能用脚本化的 FakeProvider 把整个循环跑穿。
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True, frozen=True)
+class MetaEvent:
+    """首帧：这轮属于哪个会话、用了什么模型、带了哪些工具。"""
+
+    conversation_id: str
+    message_id: str
+    model: str
+    tools: tuple[str, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class SourcesEvent:
+    items: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(slots=True, frozen=True)
+class DeltaEvent:
+    """正文增量。**形状与今天的 delta 帧一字不差**，老客户端照常工作。"""
+
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class ThinkingEvent:
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolCallEvent:
+    id: str
+    name: str
+    args: dict[str, Any]
+    read_only: bool = True
+
+
+@dataclass(slots=True, frozen=True)
+class ToolResultEvent:
+    """工具结果。
+
+    ``preview`` 是**截断过的**：完整 payload 走消息详情接口按需取。一次
+    ``get_fact_pack`` 的原始返回能把连接和浏览器一起灌爆。
+    """
+
+    id: str
+    name: str
+    ok: bool
+    summary: str
+    preview: str
+    duration_ms: int
+    images: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class UsageEvent:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class CompactionEvent:
+    removed: int
+    reason: str = "tool_results_elided"
+
+
+@dataclass(slots=True, frozen=True)
+class DoneEvent:
+    """收尾。``stop_reason`` 让界面能说人话，而不是都显示成"完成"。"""
+
+    usage: dict[str, int] = field(default_factory=dict)
+    stop_reason: str = "stop"
+    message_id: str = ""
+
+
+@dataclass(slots=True, frozen=True)
+class ErrorEvent:
+    detail: str
+    code: str = "CHAT_FAILED"
+    recoverable: bool = False
+
+
+ChatEvent = (
+    MetaEvent
+    | SourcesEvent
+    | DeltaEvent
+    | ThinkingEvent
+    | ToolCallEvent
+    | ToolResultEvent
+    | UsageEvent
+    | CompactionEvent
+    | DoneEvent
+    | ErrorEvent
+)

--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -1,0 +1,324 @@
+"""对话 agent 循环。
+
+与 ``VoyageEngine._loop()`` 是两种东西，别想着复用：那边遍历的是 Navigator 预先规划
+好的 ``voyage_steps`` 数据库行、跑在 ARQ worker 里、经 Redis 对外说话、失败语义是
+``paused_error`` 加重规划、取消粒度是"步"。这边没有预先计划（下一步由模型逐 token
+决定）、必须在 HTTP 连接上流式输出、失败语义是"告诉用户，会话继续活着"、取消要能切
+在流中途。硬套要么伪造单步计划，要么每个 token 绕一趟 Redis。
+
+**不 import fastapi**（与 tools/ 同规矩）。循环只吐 events.py 里的事件，SSE 层负责翻译。
+"""
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.agents.chat.events import (
+    ChatEvent,
+    CompactionEvent,
+    DeltaEvent,
+    DoneEvent,
+    ErrorEvent,
+    MetaEvent,
+    ThinkingEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+)
+from app.agents.chat.prompt import build_system_prompt, tool_definitions
+from app.core.llm.base import (
+    ContentBlock,
+    Message,
+    StreamDone,
+    TextDelta,
+    ThinkingDelta,
+    ToolResultBlock,
+    ToolsUnsupportedError,
+    ToolUseBlock,
+)
+from app.core.llm.router import LLMRouter
+from app.core.llm.tool_stream import ToolCallAccumulator
+from app.tools.context import ToolContext
+from app.tools.registry import get_tool, result_images, result_payload, run_tool
+
+logger = logging.getLogger(__name__)
+
+#: 一轮对话最多来回几次。到顶时用 tool_choice="none" 硬关工具收尾，而不是追加一条
+#: user 消息哄模型 finish —— 原生 API 有确定性手段就用确定性手段。
+DEFAULT_MAX_ROUNDS = 8
+
+#: 单个工具的执行上限。网络类工具自身有 httpx 超时，但注册表层面没有统一约束。
+TOOL_TIMEOUT_SECONDS = 60.0
+
+#: 并行执行只读工具的并发度。只读才并行——写工具没有事务包裹，并行改同一行就是竞态。
+_TOOL_CONCURRENCY = 4
+
+#: 回喂给模型的单个工具结果上限。超过就截断，完整内容留在库里按需取。
+RESULT_CHARS = 4000
+
+#: 推给前端的预览上限。比回喂的更短——它只是让人看一眼"查到了什么"。
+PREVIEW_CHARS = 800
+
+#: 最近几轮的工具结果保持原样，更早的压成一行摘要。
+_KEEP_FULL_RESULT_ROUNDS = 2
+
+
+@dataclass(slots=True)
+class ChatTurnRequest:
+    conversation_id: uuid.UUID
+    question: str
+    tool_names: tuple[str, ...] = ()
+    max_rounds: int = DEFAULT_MAX_ROUNDS
+    max_turn_tokens: int | None = None
+    statement: str | None = None
+    extra_system: str = ""
+
+
+@dataclass(slots=True)
+class _RoundState:
+    rounds: int = 0
+    usage: dict[str, int] = field(
+        default_factory=lambda: {"prompt_tokens": 0, "completion_tokens": 0}
+    )
+    blocks_by_round: list[tuple[ContentBlock, ...]] = field(default_factory=list)
+
+
+class ChatAgentLoop:
+    """一轮用户提问 → 若干次「模型思考 + 工具调用」→ 一段回答。
+
+    每轮：组装消息 → stream_events → 转发文本/思考、喂累加器 → 流结束后落库 assistant
+    消息 → 没有工具调用就收尾 → 有就并行执行、把结果作为一条 user 消息回喂 → 继续。
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: LLMRouter,
+        tool_ctx: ToolContext,
+        stage: str = "agent",
+        history: Sequence[Message] = (),
+    ) -> None:
+        self._llm = llm
+        self._tool_ctx = tool_ctx
+        self._stage = stage
+        self._history = list(history)
+
+    async def run(self, req: ChatTurnRequest) -> AsyncIterator[ChatEvent]:
+        specs = tool_definitions(req.tool_names)
+        messages: list[Message] = [
+            Message(role="system", content=build_system_prompt(req.statement, req.extra_system)),
+            *self._history,
+            Message(role="user", content=req.question),
+        ]
+        state = _RoundState()
+        yield MetaEvent(
+            conversation_id=str(req.conversation_id),
+            message_id="",
+            model=self._stage,
+            tools=tuple(req.tool_names),
+        )
+
+        while True:
+            state.rounds += 1
+            last_round = state.rounds >= req.max_rounds
+            over_budget = (
+                req.max_turn_tokens is not None
+                and sum(state.usage.values()) >= req.max_turn_tokens
+            )
+            # 到顶就硬关工具：让模型用已经拿到的东西收尾，而不是继续查
+            tool_choice = "none" if (last_round or over_budget) else None
+
+            accumulator = ToolCallAccumulator()
+            try:
+                async for ev in self._llm.stream_events(
+                    self._stage,
+                    messages,
+                    tools=specs or None,
+                    tool_choice=tool_choice,
+                    user_id=self._tool_ctx.user_id,
+                    project_id=self._tool_ctx.project_id,
+                ):
+                    accumulator.feed(ev)
+                    if isinstance(ev, TextDelta):
+                        yield DeltaEvent(ev.text)
+                    elif isinstance(ev, ThinkingDelta) and ev.text:
+                        yield ThinkingEvent(ev.text)
+                    elif isinstance(ev, StreamDone) and ev.usage:
+                        for key in ("prompt_tokens", "completion_tokens"):
+                            state.usage[key] = state.usage.get(key, 0) + int(ev.usage.get(key, 0))
+            except ToolsUnsupportedError as e:
+                # 这个中转不认 tools：交给调用方降级回一次性 RAG，别把这轮打成失败
+                logger.warning("chat agent: provider rejected tools: %s", e)
+                yield ErrorEvent(str(e), code="TOOLS_UNSUPPORTED", recoverable=True)
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 转成事件，会话继续活着
+                logger.warning("chat agent: stream failed", exc_info=True)
+                yield ErrorEvent(f"{type(e).__name__}: {e}")
+                return
+
+            blocks = accumulator.finish()
+            state.blocks_by_round.append(blocks)
+            calls = [b for b in blocks if isinstance(b, ToolUseBlock)]
+            if not calls:
+                yield UsageEvent(
+                    prompt_tokens=state.usage.get("prompt_tokens", 0),
+                    completion_tokens=state.usage.get("completion_tokens", 0),
+                    total_tokens=sum(state.usage.values()),
+                )
+                yield DoneEvent(
+                    usage=dict(state.usage),
+                    stop_reason=self._stop_reason(last_round, over_budget),
+                )
+                return
+
+            messages.append(Message(role="assistant", content=list(blocks)))
+            # 先把「要调什么」全部播出去，再开始执行：前端据此立刻画出 running 的卡片。
+            # 不这么做的话，卡片会在工具跑完的那一刻凭空出现在完成态，几秒的等待期里
+            # 界面上什么都没有。
+            for call in calls:
+                spec = get_tool(call.name)
+                yield ToolCallEvent(
+                    id=call.id,
+                    name=call.name,
+                    args=call.input,
+                    read_only=spec.read_only if spec else True,
+                )
+            results: list[ToolResultBlock] = []
+            async for ev, result in self._run_calls(calls):
+                if result is not None:
+                    results.append(result)
+                yield ev
+            messages.append(Message(role="user", content=list(results)))
+
+            if removed := _elide_old_results(messages):
+                yield CompactionEvent(removed=removed)
+
+    def _stop_reason(self, last_round: bool, over_budget: bool) -> str:
+        if over_budget:
+            return "turn_budget"
+        if last_round:
+            return "max_rounds"
+        return "stop"
+
+    async def _run_calls(
+        self, calls: list[ToolUseBlock]
+    ) -> AsyncIterator[tuple[ChatEvent, ToolResultBlock | None]]:
+        """并行执行一轮里的工具调用，按发起顺序把事件吐出去。
+
+        只读工具才并行。写工具（本期还没有）必须串行：没有事务包裹，并行改同一行就是
+        竞态，而且审批 UI 一次弹两个框是灾难。
+        """
+        semaphore = asyncio.Semaphore(_TOOL_CONCURRENCY)
+
+        async def one(call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
+            async with semaphore:
+                return await self._execute(call)
+
+        for coro in [asyncio.create_task(one(c)) for c in calls]:
+            event, block = await coro
+            yield event, block
+
+    async def _execute(self, call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
+        started = time.monotonic()
+        spec = get_tool(call.name)
+        if spec is None:
+            # 未知工具不打断循环：把可用清单告诉模型，它下一轮自己纠正
+            payload = {"error": f"未知工具 {call.name!r}"}
+            return self._failure(call, payload, started)
+        if "__parse_error__" in call.input:
+            payload = {"error": "参数不是合法 JSON，请重新发起这次调用"}
+            return self._failure(call, payload, started)
+        try:
+            result = await asyncio.wait_for(
+                run_tool(self._tool_ctx, call.name, call.input), timeout=TOOL_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            note = {"error": f"工具执行超过 {TOOL_TIMEOUT_SECONDS:.0f} 秒"}
+            return self._failure(call, note, started)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 — 工具异常转成结果回喂，不打断循环
+            logger.warning("chat agent: tool %s failed", call.name, exc_info=True)
+            return self._failure(call, {"error": f"{type(e).__name__}: {e}"}, started)
+
+        payload = result_payload(result)
+        images = result_images(result)
+        text = json.dumps(payload, ensure_ascii=False)[:RESULT_CHARS]
+        duration = int((time.monotonic() - started) * 1000)
+        summary = spec.summary(call.input, payload) if spec else call.name
+        return (
+            ToolResultEvent(
+                id=call.id,
+                name=call.name,
+                ok=True,
+                summary=summary,
+                preview=text[:PREVIEW_CHARS],
+                duration_ms=duration,
+                images=len(images),
+            ),
+            ToolResultBlock(call.id, text),
+        )
+
+    def _failure(
+        self, call: ToolUseBlock, payload: dict[str, Any], started: float
+    ) -> tuple[ToolResultEvent, ToolResultBlock]:
+        text = json.dumps(payload, ensure_ascii=False)
+        duration = int((time.monotonic() - started) * 1000)
+        return (
+            ToolResultEvent(
+                id=call.id,
+                name=call.name,
+                ok=False,
+                summary=payload.get("error", "失败"),
+                preview=text[:PREVIEW_CHARS],
+                duration_ms=duration,
+            ),
+            ToolResultBlock(call.id, text, is_error=True),
+        )
+
+
+def _elide_old_results(messages: list[Message]) -> int:
+    """把较早的工具结果压成一行，只保留最近几轮的原文。
+
+    工具结果是上下文里的大头（一次 read_fulltext 就 4000 字符）。先做这一步驱逐，往往
+    就够了；LLM 摘要压缩是后备手段，成本高得多。
+    """
+    rounds_seen = 0
+    removed = 0
+    for msg in reversed(messages):
+        blocks = msg.content
+        if not isinstance(blocks, list):
+            continue
+        results = [b for b in blocks if isinstance(b, ToolResultBlock)]
+        if not results:
+            continue
+        rounds_seen += 1
+        if rounds_seen <= _KEEP_FULL_RESULT_ROUNDS:
+            continue
+        replaced: list[ContentBlock] = []
+        for b in blocks:
+            if isinstance(b, ToolResultBlock) and len(b.content) > PREVIEW_CHARS:
+                replaced.append(
+                    ToolResultBlock(
+                        b.tool_use_id,
+                        json.dumps(
+                            {"elided": True, "preview": b.content[:200]}, ensure_ascii=False
+                        ),
+                        is_error=b.is_error,
+                    )
+                )
+                removed += 1
+            else:
+                replaced.append(b)
+        msg.content = replaced
+    return removed
+
+
+__all__ = ["DEFAULT_MAX_ROUNDS", "ChatAgentLoop", "ChatTurnRequest"]

--- a/src/backend/app/agents/chat/prompt.py
+++ b/src/backend/app/agents/chat/prompt.py
@@ -1,0 +1,61 @@
+"""助手的系统提示与工具定义。
+
+**system prompt 必须是稳定前缀**：每轮重发的历史 + 工具 schema 加起来是输入 token 的
+大头，指望 prompt caching 就不能每轮换写法、换工具顺序。所以这里是纯拼接、无随机、
+无时间戳之外的变量，且技能目录的槽位预留在末尾——技能正文只能作为工具结果追加，
+写进 system 会作废整个缓存前缀。
+"""
+
+import datetime as dt
+from typing import Any
+
+from app.tools.registry import list_tools
+
+#: 首期给助手的工具白名单。**不要一上来给 38 个**：schema 每轮重发既贵，又让模型
+#: 在相近的工具之间反复犹豫（search_papers / search_chunks / global_search 尤其像）。
+DEFAULT_TOOL_NAMES: tuple[str, ...] = (
+    "search_chunks",
+    "search_papers",
+    "get_paper",
+    "read_fulltext",
+    "list_concepts",
+    "get_concept",
+)
+
+_SYSTEM = """\
+你是 Polaris 科研平台的助手。你可以调用工具去平台里查东西，而不是只凭上下文作答。
+
+工作方式：
+- 需要事实时先查再答。检索工具很便宜，宁可多查一次，也不要猜；
+- 一次可以并行发起多个工具调用（比如同时查两个不同的关键词）；
+- 工具返回空结果不代表没有——换个说法或换个工具再试一次，仍然没有就如实说没查到；
+- 引用某篇论文的内容时在句末标注它的编号，如 [1]；
+- 用中文回答，讲清楚、说人话，不要罗列工具调用过程。
+
+今天是 {today}（UTC）。资料里的论文都标了发布日期，问到「最近」时按它判断。
+{statement}{extra}"""
+
+
+def build_system_prompt(statement: str | None = None, extra: str = "") -> str:
+    """组装系统提示。
+
+    ``statement``（研究方向）与 ``extra``（技能等）都追加在末尾，前面那段是不变的
+    稳定前缀——顺序反过来会让每个作用域都有各自的缓存前缀，缓存命中率归零。
+    """
+    direction = f"\n\n研究方向：{statement.strip()}" if statement and statement.strip() else ""
+    tail = f"\n\n{extra.strip()}" if extra and extra.strip() else ""
+    return _SYSTEM.format(
+        today=dt.datetime.now(dt.UTC).date().isoformat(), statement=direction, extra=tail
+    )
+
+
+def tool_definitions(names: tuple[str, ...] | list[str] | None = None) -> list[dict[str, Any]]:
+    """工具定义。``ToolSpec.input_schema`` 本来就是标准 JSON Schema，零转换。
+
+    顺序跟随 ``list_tools`` 给定的顺序（它保序），这样工具块也是稳定前缀的一部分。
+    """
+    wanted = list(names) if names else list(DEFAULT_TOOL_NAMES)
+    return [
+        {"name": spec.name, "description": spec.description, "parameters": spec.input_schema}
+        for spec in list_tools(wanted)
+    ]

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -1,0 +1,229 @@
+"""全局助手：Claude Code 式的多轮工具循环，走 SSE。
+
+**新路径，六个老对话端点一行不动。** 助手成熟之前两套并存，出问题随时关掉开关退回去。
+
+事件是加法式扩展的：正文仍然走 ``delta``，形状与老端点一字不差，所以只认
+``sources/delta/done/error`` 的客户端也能工作，只是看不到工具卡片。
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.chat.events import (
+    ChatEvent,
+    CompactionEvent,
+    DeltaEvent,
+    DoneEvent,
+    ErrorEvent,
+    MetaEvent,
+    SourcesEvent,
+    ThinkingEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+)
+from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
+from app.agents.chat.prompt import DEFAULT_TOOL_NAMES
+from app.api.auth import current_active_user, require_llm_chat
+from app.core.config import get_settings
+from app.core.db import get_session
+from app.core.llm.base import TextBlock
+from app.core.llm.router import get_llm_router
+from app.models.user import User
+from app.schemas.chat_agent import (
+    ConversationCreate,
+    ConversationRead,
+    ConversationTurnRequest,
+    MessageRead,
+)
+from app.services import conversations as store
+from app.tools.context import ToolContext
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+#: 事件类 → 线上帧名。加法式：老客户端只认识其中四个，其余忽略即可。
+_EVENT_NAMES: dict[type, str] = {
+    MetaEvent: "meta",
+    SourcesEvent: "sources",
+    DeltaEvent: "delta",
+    ThinkingEvent: "thinking",
+    ToolCallEvent: "tool_call",
+    ToolResultEvent: "tool_result",
+    UsageEvent: "usage",
+    CompactionEvent: "compaction",
+    DoneEvent: "done",
+    ErrorEvent: "error",
+}
+
+
+def _frame(event: str, data: Any) -> str:
+    # NOTE: #252 合并后改为从 app.api.chat_stream import sse_frame，这里不再自带一份
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, default=str)}\n\n"
+
+
+def _to_frame(ev: ChatEvent) -> str:
+    name = _EVENT_NAMES.get(type(ev), "unknown")
+    payload = asdict(ev) if is_dataclass(ev) else {}
+    return _frame(name, payload)
+
+
+def _require_enabled() -> None:
+    if not get_settings().chat_agent_enabled:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CHAT_AGENT_DISABLED")
+
+
+@router.post("/conversations", response_model=ConversationRead, status_code=201)
+async def create_conversation(
+    payload: ConversationCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ConversationRead:
+    _require_enabled()
+    conv = await store.get_or_create(
+        session,
+        user_id=user.id,
+        scope_kind=payload.scope_kind,
+        scope_id=payload.scope_id,
+        project_id=payload.project_id,
+    )
+    await session.commit()
+    return ConversationRead.model_validate(conv, from_attributes=True)
+
+
+@router.get("/conversations", response_model=list[ConversationRead])
+async def list_conversations(
+    scope_kind: str | None = Query(default=None),
+    scope_id: uuid.UUID | None = Query(default=None),
+    limit: int = Query(default=30, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[ConversationRead]:
+    _require_enabled()
+    rows = await store.list_conversations(
+        session, user_id=user.id, scope_kind=scope_kind, scope_id=scope_id, limit=limit
+    )
+    return [ConversationRead.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.get("/conversations/{conversation_id}/messages", response_model=list[MessageRead])
+async def list_messages(
+    conversation_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[MessageRead]:
+    """会话的完整消息（含工具块）。前端展开"看完整结果"时用它——SSE 里的 preview 是截断的。"""
+    _require_enabled()
+    from sqlalchemy import select
+
+    from app.models.conversation import Conversation, ConversationMessage
+
+    conv = await session.get(Conversation, conversation_id)
+    if conv is None or conv.user_id != user.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
+    rows = (
+        (
+            await session.execute(
+                select(ConversationMessage)
+                .where(ConversationMessage.conversation_id == conversation_id)
+                .order_by(ConversationMessage.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [MessageRead.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.post("/conversations/{conversation_id}/turn")
+async def run_turn(
+    conversation_id: uuid.UUID,
+    payload: ConversationTurnRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_llm_chat),
+) -> StreamingResponse:
+    """跑一轮：模型可以反复调工具，最后给出回答。"""
+    _require_enabled()
+    conv = await store.get_or_create(
+        session, user_id=user.id, scope_kind="global", conversation_id=conversation_id
+    )
+    if conv.id != conversation_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
+    history = await store.replay(session, conversation_id=conv.id)
+    await store.append_message(session, conversation=conv, role="user", text=payload.question)
+    await session.commit()
+
+    project_id = conv.project_id or conv.scope_id or uuid.uuid4()
+    tool_ctx = ToolContext(project_id=project_id, llm=get_llm_router(), user_id=user.id)
+    loop = ChatAgentLoop(llm=get_llm_router(), tool_ctx=tool_ctx, history=history)
+    req = ChatTurnRequest(
+        conversation_id=conv.id,
+        question=payload.question,
+        tool_names=tuple(payload.tool_names or DEFAULT_TOOL_NAMES),
+        max_rounds=payload.max_rounds,
+        statement=payload.statement,
+    )
+    conv_id, user_id = conv.id, user.id
+
+    async def event_stream() -> AsyncIterator[str]:
+        collected: list[str] = []
+        stop_reason, usage = "stop", {}
+        try:
+            async for ev in loop.run(req):
+                if isinstance(ev, DeltaEvent):
+                    collected.append(ev.text)
+                elif isinstance(ev, DoneEvent):
+                    stop_reason, usage = ev.stop_reason, ev.usage
+                yield _to_frame(ev)
+        finally:
+            # 断线也要落库：把已经生成的部分留住，标成 interrupted。
+            # shield 是必需的——取消态下再 await 数据库写会被二次取消。
+            import asyncio
+
+            text = "".join(collected)
+            if text:
+                await asyncio.shield(
+                    _persist_answer(conv_id, user_id, text, stop_reason, usage)
+                )
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _persist_answer(
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    text: str,
+    stop_reason: str,
+    usage: dict[str, Any],
+) -> None:
+    """把这一轮的回答落库。用独立 session：请求那个可能已经随连接一起没了。"""
+    from app.core.db import get_sessionmaker
+
+    async with get_sessionmaker()() as session:
+        conv = await store.get_or_create(
+            session, user_id=user_id, scope_kind="global", conversation_id=conversation_id
+        )
+        await store.append_message(
+            session,
+            conversation=conv,
+            role="assistant",
+            blocks=[TextBlock(text)],
+            usage=usage or None,
+            stop_reason=stop_reason,
+            status="complete" if stop_reason != "interrupted" else "interrupted",
+        )
+        await session.commit()

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -8,6 +8,7 @@ from app.api import (
     admin_settings,
     admin_users,
     auth,
+    chat_agent,
     chat_bots,
     concepts,
     daily,
@@ -42,6 +43,7 @@ from app.api import (
 
 api_router = APIRouter()
 api_router.include_router(health.router)
+api_router.include_router(chat_agent.router)
 api_router.include_router(auth.router)
 api_router.include_router(chat_bots.router)
 api_router.include_router(users_profile.router)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     # 默认关闭：未配置时 AI 功能返回 LLM_NOT_CONFIGURED，而不是产出演示假内容。
     # 生产（env=prod）下无论如何都强制关闭，见下方 _prod_forbids_fake_llm。
     llm_fake_fallback: bool = False
+    #: 全局助手（Claude Code 式工具循环）。默认关：它每轮都要重发历史与工具 schema，
+    #: 成本与现有一次性对话不是一个量级，先按部署开。
+    chat_agent_enabled: bool = False
 
     # ---- 文献 API ----
     s2_api_key: str = ""  # Semantic Scholar（可空，限流更严）

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -1,0 +1,51 @@
+"""全局助手的请求/响应模型。"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.models.conversation import CONVERSATION_SCOPES
+
+
+class ConversationCreate(BaseModel):
+    scope_kind: str = "global"
+    scope_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+
+    def model_post_init(self, _context: Any) -> None:
+        if self.scope_kind not in CONVERSATION_SCOPES:
+            raise ValueError(f"unknown scope_kind: {self.scope_kind}")
+
+
+class ConversationRead(BaseModel):
+    id: uuid.UUID
+    scope_kind: str
+    scope_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+    title: str
+    usage: dict[str, Any] = Field(default_factory=dict)
+    last_message_at: datetime | None = None
+
+
+class ConversationTurnRequest(BaseModel):
+    question: str = Field(min_length=1)
+    #: 不给就用默认白名单（首期 6 个只读工具）
+    tool_names: list[str] | None = None
+    max_rounds: int = Field(default=8, ge=1, le=20)
+    statement: str | None = None
+
+
+class MessageRead(BaseModel):
+    id: uuid.UUID
+    seq: int
+    role: str
+    kind: str
+    blocks: list[Any] = Field(default_factory=list)
+    text: str
+    status: str
+    sources: list[Any] | None = None
+    usage: dict[str, Any] | None = None
+    stop_reason: str | None = None
+    created_at: datetime

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -1,0 +1,171 @@
+"""全局助手的 SSE 端点：帧序列、开关、鉴权、落库。
+
+老的六个对话端点一行不动——这是新路径。助手成熟之前两套并存，出问题关掉开关就退回去。
+"""
+
+import json
+import os
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from tests.conftest import register_and_login
+
+
+@pytest.fixture
+def agent_on(monkeypatch):
+    """打开助手开关（默认关：它每轮重发历史与工具 schema，成本不是一个量级）。
+
+    get_settings 是 lru_cache 的，光改环境变量不生效——两头都要清缓存。
+    """
+    from app.core.config import get_settings
+
+    monkeypatch.setenv("POLARIS_CHAT_AGENT_ENABLED", "true")
+    get_settings.cache_clear()
+    yield
+    os.environ.pop("POLARIS_CHAT_AGENT_ENABLED", None)
+    get_settings.cache_clear()
+
+
+def _parse_sse(text: str) -> list[tuple[str, dict]]:
+    events = []
+    for block in text.strip().split("\n\n"):
+        event, data = None, None
+        for line in block.split("\n"):
+            if line.startswith("event: "):
+                event = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: ") :])
+        if event is not None:
+            events.append((event, data))
+    return events
+
+
+async def _headers(client, email: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def test_the_endpoint_is_hidden_when_the_flag_is_off(client):
+    """开关关着时端点直接 404——不是 403，别让它出现在能力探测里。"""
+    headers = await _headers(client, "agent-off@example.com")
+    resp = await client.post("/api/chat/conversations", json={}, headers=headers)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "CHAT_AGENT_DISABLED"
+
+
+async def test_a_turn_streams_meta_delta_done(client, agent_on):
+    """一轮问答的最小帧序列：meta 开头、done 结尾，正文走 delta。
+
+    ``delta`` 的形状与老端点一字不差，所以只认 sources/delta/done/error 的客户端
+    也能工作，只是看不到工具卡片。
+    """
+    headers = await _headers(client, "agent-turn@example.com")
+    resp = await client.post("/api/chat/conversations", json={}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    conv_id = resp.json()["id"]
+
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "帮我看看这个方向"},
+        headers=headers,
+    ) as stream:
+        assert stream.status_code == 200
+        assert stream.headers["x-accel-buffering"] == "no", "不关 nginx 缓冲就不是真流式"
+        body = (await stream.aread()).decode()
+
+    events = _parse_sse(body)
+    kinds = [e for e, _ in events]
+    assert kinds[0] == "meta"
+    assert kinds[-1] == "done"
+    assert "delta" in kinds
+    assert events[0][1]["conversation_id"] == conv_id
+    answer = "".join(d["text"] for e, d in events if e == "delta")
+    assert answer.strip(), "总得说点什么"
+
+
+async def test_the_answer_is_persisted_and_replayed_next_turn(client, agent_on):
+    """回答落库，第二轮**不用前端传 history**也接得上。这是搬到服务端的全部意义。"""
+    from sqlalchemy import select
+
+    from app.models.conversation import ConversationMessage
+
+    headers = await _headers(client, "agent-persist@example.com")
+    conv_id = (
+        await client.post("/api/chat/conversations", json={}, headers=headers)
+    ).json()["id"]
+
+    for question in ("第一个问题", "第二个问题"):
+        async with client.stream(
+            "POST",
+            f"/api/chat/conversations/{conv_id}/turn",
+            json={"question": question},
+            headers=headers,
+        ) as stream:
+            await stream.aread()
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(ConversationMessage)
+                    .where(ConversationMessage.conversation_id == uuid.UUID(conv_id))
+                    .order_by(ConversationMessage.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    roles = [r.role for r in rows]
+    assert roles == ["user", "assistant", "user", "assistant"], roles
+    assert rows[0].text == "第一个问题"
+    assert rows[1].text.strip(), "assistant 的回答也要落库"
+
+    # 消息接口能取到完整内容（SSE 里的 preview 是截断的）
+    resp = await client.get(f"/api/chat/conversations/{conv_id}/messages", headers=headers)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 4
+
+
+async def test_someone_elses_conversation_is_not_readable(client, agent_on):
+    """别人的会话既读不到消息，也不能往里发。"""
+    owner = await _headers(client, "agent-owner@example.com")
+    other = await _headers(client, "agent-other@example.com")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=owner)).json()["id"]
+
+    resp = await client.get(f"/api/chat/conversations/{conv_id}/messages", headers=other)
+    assert resp.status_code == 404
+
+    resp = await client.get("/api/chat/conversations", headers=other)
+    assert conv_id not in {c["id"] for c in resp.json()}
+
+
+async def test_conversations_are_listed_newest_first(client, agent_on):
+    headers = await _headers(client, "agent-list@example.com")
+    ids = []
+    for _ in range(2):
+        conv_id = (
+            await client.post("/api/chat/conversations", json={}, headers=headers)
+        ).json()["id"]
+        ids.append(conv_id)
+        async with client.stream(
+            "POST",
+            f"/api/chat/conversations/{conv_id}/turn",
+            json={"question": f"问题 {conv_id[:4]}"},
+            headers=headers,
+        ) as stream:
+            await stream.aread()
+
+    listed = (await client.get("/api/chat/conversations", headers=headers)).json()
+    assert [c["id"] for c in listed][:2] == ids[::-1], "最近说过话的排在前面"
+    assert listed[0]["title"], "标题取首条用户消息"
+
+
+async def test_an_unknown_scope_is_rejected(client, agent_on):
+    headers = await _headers(client, "agent-scope@example.com")
+    resp = await client.post(
+        "/api/chat/conversations", json={"scope_kind": "made-up"}, headers=headers
+    )
+    assert resp.status_code == 422

--- a/src/backend/tests/test_chat_agent_loop.py
+++ b/src/backend/tests/test_chat_agent_loop.py
@@ -1,0 +1,315 @@
+"""对话 agent 循环：事件序列、并行调用、错误恢复、轮次与预算收尾。
+
+循环不 import fastapi，所以这里脱离 HTTP 直接驱动它——脚本化的 FakeProvider 排好
+"这轮调这些工具、下轮直接作答"，整条路径就能跑穿。
+"""
+
+import uuid
+
+import pytest
+
+from app.agents.chat.events import (
+    CompactionEvent,
+    DeltaEvent,
+    DoneEvent,
+    ErrorEvent,
+    MetaEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
+from app.agents.chat.prompt import DEFAULT_TOOL_NAMES, build_system_prompt, tool_definitions
+from app.core.llm.fake import FakeProvider
+from app.core.llm.router import LLMRouter
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tool_registry():
+    """测试注册的工具用完即撤。
+
+    ``@tool`` 写的是**模块级全局注册表**，而 MCP 的 tools/list 无过滤地遍历它——
+    泄漏出去的假工具会出现在外部 MCP 客户端的工具清单里，自检也会把故意抛异常的那个
+    判成"已失效"。（这条正是 MCP 那侧缺一道只读/白名单过滤的证据，引入写工具时必须一并修。）
+    """
+    from app.tools import registry
+
+    before = dict(registry._REGISTRY)
+    yield
+    registry._REGISTRY.clear()
+    registry._REGISTRY.update(before)
+
+
+class _ScriptedRouter(LLMRouter):
+    """只替换 stream_events 的路由器：不碰数据库配置，直接用脚本化的假 provider。"""
+
+    def __init__(self, provider: FakeProvider) -> None:
+        super().__init__()
+        self._provider = provider
+
+    async def stream_events(self, stage, messages, **kwargs):  # noqa: ANN001, ANN003
+        async for ev in self._provider.stream_events(
+            messages,
+            model="fake",
+            tools=kwargs.get("tools"),
+            tool_choice=kwargs.get("tool_choice"),
+        ):
+            yield ev
+
+
+def _loop(provider: FakeProvider) -> ChatAgentLoop:
+    ctx = ToolContext(project_id=uuid.uuid4(), llm=LLMRouter(), user_id=uuid.uuid4())
+    return ChatAgentLoop(llm=_ScriptedRouter(provider), tool_ctx=ctx)
+
+
+async def _drive(loop: ChatAgentLoop, **kwargs):
+    req = ChatTurnRequest(conversation_id=uuid.uuid4(), question="问题", **kwargs)
+    return [ev async for ev in loop.run(req)]
+
+
+# ---- 事件序列 ----
+
+
+@pytest.mark.asyncio
+async def test_the_happy_path_emits_meta_tool_call_result_delta_done(monkeypatch):
+    """一轮完整的工具调用：meta → tool_call → tool_result → delta* → done。"""
+    calls: list[dict] = []
+
+    @tool(
+        name="_probe_search",
+        description="测试用检索",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+        summarize=lambda args, result: f"检索 {args.get('query')} → {result.get('hits')} 条",
+    )
+    async def _probe(ctx, args):  # noqa: ANN001
+        calls.append(args)
+        return {"hits": 3, "titles": ["A", "B", "C"]}
+
+    provider = FakeProvider()
+    provider.script([[("_probe_search", {"query": "planning"})], "查到三篇，主流是树搜索。"])
+
+    events = await _drive(_loop(provider), tool_names=("_probe_search",))
+    kinds = [type(e).__name__ for e in events]
+
+    assert kinds[0] == "MetaEvent"
+    # tool_call 必须在 tool_result **之前**：前端靠它画出 running 卡片，
+    # 否则几秒的等待期里界面上什么都没有，卡片跑完才凭空出现在完成态
+    assert kinds.index("ToolCallEvent") < kinds.index("ToolResultEvent")
+    assert kinds[-1] == "DoneEvent"
+    assert calls == [{"query": "planning"}], "工具真的被调到了，参数完整"
+
+    call_ev = next(e for e in events if isinstance(e, ToolCallEvent))
+    assert call_ev.name == "_probe_search" and call_ev.args == {"query": "planning"}
+    assert call_ev.read_only is True
+
+    result = next(e for e in events if isinstance(e, ToolResultEvent))
+    assert result.ok is True
+    assert result.summary == "检索 planning → 3 条", "摘要来自 ToolSpec.summarize"
+    assert '"hits": 3' in result.preview
+
+    answer = "".join(e.text for e in events if isinstance(e, DeltaEvent))
+    assert "树搜索" in answer
+    done = events[-1]
+    assert isinstance(done, DoneEvent) and done.stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_parallel_calls_all_execute():
+    """一轮里的多个调用并行执行，每个都产出一条结果事件。"""
+    seen: list[str] = []
+
+    @tool(
+        name="_probe_a",
+        description="a",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _a(ctx, args):  # noqa: ANN001
+        seen.append("a")
+        return {"ok": "a"}
+
+    @tool(
+        name="_probe_b",
+        description="b",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _b(ctx, args):  # noqa: ANN001
+        seen.append("b")
+        return {"ok": "b"}
+
+    provider = FakeProvider()
+    provider.script([[("_probe_a", {}), ("_probe_b", {})], "都查完了。"])
+    events = await _drive(_loop(provider), tool_names=("_probe_a", "_probe_b"))
+
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert {r.name for r in results} == {"_probe_a", "_probe_b"}
+    assert sorted(seen) == ["a", "b"]
+
+
+# ---- 错误恢复：每一级都不杀死本轮 ----
+
+
+@pytest.mark.asyncio
+async def test_a_tool_that_raises_becomes_a_result_and_the_round_continues():
+    """工具抛异常转成错误结果回喂，循环继续——模型下一轮可以换个说法再试。"""
+
+    @tool(name="_probe_boom", description="炸", input_schema={"type": "object", "properties": {}})
+    async def _boom(ctx, args):  # noqa: ANN001
+        raise RuntimeError("后端挂了")
+
+    provider = FakeProvider()
+    provider.script([[("_probe_boom", {})], "工具没查到，我先说我知道的。"])
+    events = await _drive(_loop(provider), tool_names=("_probe_boom",))
+
+    result = next(e for e in events if isinstance(e, ToolResultEvent))
+    assert result.ok is False and "后端挂了" in result.preview
+    assert isinstance(events[-1], DoneEvent), "这轮仍然正常收尾"
+    assert not any(isinstance(e, ErrorEvent) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_tool_is_reported_back_not_raised():
+    """模型编了个不存在的工具名：告诉它，别崩。"""
+    provider = FakeProvider()
+    provider.script([[("_probe_nonexistent", {})], "换个方式回答。"])
+    events = await _drive(_loop(provider), tool_names=("search_papers",))
+
+    result = next(e for e in events if isinstance(e, ToolResultEvent))
+    assert result.ok is False and "未知工具" in result.summary
+    assert isinstance(events[-1], DoneEvent)
+
+
+@pytest.mark.asyncio
+async def test_malformed_arguments_are_reported_back():
+    """参数不是合法 JSON 时不执行工具，回一条让模型重发的结果。
+
+    弱模型上这是高频情形；累加器把它标成 __parse_error__ 传下来。
+    """
+    from app.core.llm.base import StreamDone, ToolUseArgsDelta, ToolUseStart
+
+    class _BadArgs(FakeProvider):
+        async def stream_events(self, messages, **kwargs):  # noqa: ANN001, ANN003
+            if kwargs.get("tool_choice") == "none" or getattr(self, "_done", False):
+                async for ev in super().stream_events(messages, **kwargs):
+                    yield ev
+                return
+            self._done = True
+            yield ToolUseStart(0, "c1", "search_papers")
+            yield ToolUseArgsDelta(0, '{"query": ')  # 截断
+            yield StreamDone(finish_reason="tool_use")
+
+    provider = _BadArgs()
+    provider.script([None, "那我直接答。"])  # 第二轮走父类的文本
+    events = await _drive(_loop(provider), tool_names=("search_papers",))
+
+    result = next(e for e in events if isinstance(e, ToolResultEvent))
+    assert result.ok is False and "合法 JSON" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_a_provider_error_ends_the_turn_with_an_error_event():
+    """provider 挂了产出 error 事件，而不是把异常抛给 HTTP 层。"""
+
+    class _Broken(FakeProvider):
+        async def stream_events(self, messages, **kwargs):  # noqa: ANN001, ANN003
+            raise RuntimeError("连接被重置")
+            yield  # pragma: no cover
+
+    events = await _drive(_loop(_Broken()))
+    assert isinstance(events[-1], ErrorEvent)
+    assert "连接被重置" in events[-1].detail
+
+
+@pytest.mark.asyncio
+async def test_tools_unsupported_is_recoverable_so_callers_can_degrade():
+    """中转不认 tools 时标成可恢复——调用方据此退回一次性 RAG，而不是报错。"""
+    from app.core.llm.base import ToolsUnsupportedError
+
+    class _NoTools(FakeProvider):
+        async def stream_events(self, messages, **kwargs):  # noqa: ANN001, ANN003
+            raise ToolsUnsupportedError("this relay does not accept tools")
+            yield  # pragma: no cover
+
+    events = await _drive(_loop(_NoTools()))
+    err = events[-1]
+    assert isinstance(err, ErrorEvent)
+    assert err.code == "TOOLS_UNSUPPORTED" and err.recoverable is True
+
+
+# ---- 收尾条件 ----
+
+
+@pytest.mark.asyncio
+async def test_running_out_of_rounds_hard_stops_the_tools():
+    """轮次耗尽用 tool_choice="none" 硬关工具，不是追加 user 消息哄模型收尾。"""
+
+    @tool(
+        name="_probe_loopy",
+        description="loop",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _loopy(ctx, args):  # noqa: ANN001
+        return {"again": True}
+
+    provider = FakeProvider()
+    # 剧本一直想调工具；到顶那轮必须被 tool_choice=none 挡下来
+    provider.script([[("_probe_loopy", {})]] * 10)
+
+    events = await _drive(_loop(provider), tool_names=("_probe_loopy",), max_rounds=3)
+    done = events[-1]
+    assert isinstance(done, DoneEvent) and done.stop_reason == "max_rounds"
+    assert len([e for e in events if isinstance(e, ToolResultEvent)]) == 2, "第 3 轮不再调工具"
+
+
+@pytest.mark.asyncio
+async def test_old_tool_results_get_elided():
+    """较早的工具结果压成一行——它们是上下文里的大头。"""
+
+    @tool(name="_probe_big", description="big", input_schema={"type": "object", "properties": {}})
+    async def _big(ctx, args):  # noqa: ANN001
+        return {"text": "x" * 3000}
+
+    provider = FakeProvider()
+    provider.script([[("_probe_big", {})]] * 4 + ["够了。"])
+    events = await _drive(_loop(provider), tool_names=("_probe_big",), max_rounds=6)
+    assert any(isinstance(e, CompactionEvent) for e in events), "第 3 轮之后应触发驱逐"
+
+
+# ---- 提示与工具定义 ----
+
+
+def test_tool_definitions_are_plain_json_schema():
+    """ToolSpec.input_schema 直接就是两家要的 parameters/input_schema，零转换。"""
+    defs = tool_definitions()
+    assert {d["name"] for d in defs} == set(DEFAULT_TOOL_NAMES)
+    for d in defs:
+        assert d["parameters"]["type"] == "object"
+        assert isinstance(d["description"], str) and d["description"]
+
+
+def test_system_prompt_keeps_a_stable_prefix():
+    """方向说明与技能追加在**末尾**：前缀不变才吃得到 prompt cache。
+
+    顺序反过来的话，每个作用域都有自己的前缀，缓存命中率归零。
+    """
+    base = build_system_prompt()
+    with_statement = build_system_prompt("Computer-use agents")
+    assert with_statement.startswith(base.split("今天是")[0])
+    assert "Computer-use agents" in with_statement
+    assert with_statement.index("Computer-use agents") > with_statement.index("你是 Polaris")
+
+
+def test_default_tool_whitelist_is_small():
+    """首期只给 6 个。38 个 schema 每轮重发既贵，又让模型在相近工具间反复犹豫。"""
+    assert len(DEFAULT_TOOL_NAMES) == 6
+    assert "search_chunks" in DEFAULT_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_meta_is_the_first_event(monkeypatch):
+    """首帧永远是 meta：前端据此绑定会话与消息 id。"""
+    provider = FakeProvider()
+    provider.script(["直接回答。"])
+    events = await _drive(_loop(provider))
+    assert isinstance(events[0], MetaEvent)
+    assert events[0].conversation_id

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -9,6 +9,7 @@ import { ToastHost, toast } from '../components/ui/Toast';
 import { UpdateBadge } from '../components/ui/UpdateBadge';
 import { useAuth } from './auth';
 import { topicPath, useProject } from './project';
+import { AssistantPanel } from '../features/assistant/AssistantPanel';
 import { SearchPalette } from './SearchPalette';
 import { UserMenu } from './UserMenu';
 import { FeedbackWidget } from '../features/feedback/FeedbackWidget';
@@ -428,11 +429,17 @@ export function AppShell() {
 
   // —— 全局搜索（⌘K / Ctrl+K）——
   const [searchOpen, setSearchOpen] = useState(false);
+  const [assistantOpen, setAssistantOpen] = useState(false);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setSearchOpen((o) => !o);
+      }
+      // ⌘J：全局助手。挑 J 是因为 ⌘K 已被搜索占了，而两者都该是全局的
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        e.preventDefault();
+        setAssistantOpen((o) => !o);
       }
     };
     document.addEventListener('keydown', onKey);
@@ -803,6 +810,9 @@ export function AppShell() {
 
       {/* —— 全局搜索面板 —— */}
       <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
+
+      {/* —— 全局助手（⌘J）—— */}
+      <AssistantPanel open={assistantOpen} onClose={() => setAssistantOpen(false)} />
 
       <ToastHost />
     </div>

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { Markdown } from '../../lib/markdown';
+import { api } from '../../lib/api';
+import { assistantTurnSse, type AssistantBlock } from '../../lib/assistantStream';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   Polaris 助手：全局抽屉。⌘J 开关。
+
+   与现有六个对话入口并存——它们一行没改。助手能跨课题/库/论文调用平台工具，
+   界面上多出来的就是「工具卡片」：正在调什么、调完拿到了什么。
+
+   渲染必须**防御式**：SSE 过来的是 JSON.parse 出来的 any，TypeScript 只在编译期
+   帮你。未知事件忽略、未知块画成占位，绝不抛——这个项目没有前端测试工具，
+   运行时炸了没人拦得住。
+   ============================================================ */
+
+interface Turn {
+  role: 'user' | 'assistant';
+  blocks: AssistantBlock[];
+}
+
+function ToolCard({ block }: { block: Extract<AssistantBlock, { kind: 'tool' }> }) {
+  const [open, setOpen] = useState(false);
+  const color =
+    block.state === 'error' ? 'var(--danger)' : block.state === 'ok' ? 'var(--ok-tx)' : 'var(--text-4)';
+  return (
+    <div
+      style={{
+        border: '0.5px solid var(--border-2)',
+        borderRadius: 8,
+        background: 'var(--surface-2)',
+        padding: '7px 10px',
+        margin: '6px 0',
+        fontSize: 12,
+      }}
+    >
+      <div
+        className="row gap8 hoverable"
+        style={{ cursor: 'pointer', alignItems: 'center' }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <Icon
+          name={block.state === 'running' ? 'refresh' : block.state === 'error' ? 'x' : 'check'}
+          size={12}
+          style={{
+            color,
+            animation: block.state === 'running' ? 'spin 1s linear infinite' : undefined,
+          }}
+        />
+        <span className="mono" style={{ color: 'var(--text-2)' }}>{block.name}</span>
+        <span style={{ color: 'var(--text-3)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {block.summary ?? tr('调用中…', 'running…')}
+        </span>
+        {block.durationMs !== undefined && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+            {block.durationMs}ms
+          </span>
+        )}
+      </div>
+      {open && block.preview && (
+        <pre
+          className="mono"
+          style={{
+            marginTop: 6,
+            maxHeight: 220,
+            overflow: 'auto',
+            fontSize: 11,
+            color: 'var(--text-3)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+          }}
+        >
+          {block.preview}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function BlockView({ block }: { block: AssistantBlock }) {
+  if (block.kind === 'text') return <Markdown source={block.text} />;
+  if (block.kind === 'thinking') {
+    return (
+      <details style={{ margin: '4px 0' }}>
+        <summary style={{ fontSize: 11.5, color: 'var(--text-4)', cursor: 'pointer' }}>
+          {tr('思考过程', 'Thinking')}
+        </summary>
+        <div style={{ fontSize: 12, color: 'var(--text-3)', whiteSpace: 'pre-wrap' }}>{block.text}</div>
+      </details>
+    );
+  }
+  if (block.kind === 'tool') return <ToolCard block={block} />;
+  return null; // 未知块：画不出来就不画，绝不抛
+}
+
+export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [convId, setConvId] = useState<string | null>(null);
+  const abortRef = useRef<(() => void) | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [turns]);
+
+  useEffect(() => () => abortRef.current?.(), []);
+
+  const send = useCallback(async () => {
+    const question = input.trim();
+    if (!question || busy) return;
+    setInput('');
+    setBusy(true);
+    setTurns((t) => [...t, { role: 'user', blocks: [{ kind: 'text', text: question }] }, { role: 'assistant', blocks: [] }]);
+
+    let id = convId;
+    try {
+      if (!id) {
+        id = (await api.createAssistantConversation()).id;
+        setConvId(id);
+      }
+    } catch {
+      setTurns((t) => {
+        const next = [...t];
+        next[next.length - 1] = { role: 'assistant', blocks: [{ kind: 'text', text: tr('助手未启用。', 'The assistant is not enabled.') }] };
+        return next;
+      });
+      setBusy(false);
+      return;
+    }
+
+    const patch = (fn: (blocks: AssistantBlock[]) => AssistantBlock[]) =>
+      setTurns((t) => {
+        const next = [...t];
+        const last = next[next.length - 1];
+        if (!last || last.role !== 'assistant') return t;
+        next[next.length - 1] = { ...last, blocks: fn(last.blocks) };
+        return next;
+      });
+
+    abortRef.current = assistantTurnSse(id, question, {
+      onBlocks: patch,
+      onDone: () => setBusy(false),
+      onError: (detail) => {
+        patch((blocks) => [...blocks, { kind: 'text', text: `⚠️ ${detail}` }]);
+        setBusy(false);
+      },
+    });
+  }, [input, busy, convId]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 'min(520px, 100vw)',
+        background: 'var(--surface)',
+        borderLeft: '0.5px solid var(--border-2)',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 60,
+        boxShadow: '-8px 0 24px rgba(0,0,0,0.06)',
+      }}
+    >
+      <div className="row gap8" style={{ padding: '12px 16px', borderBottom: '0.5px solid var(--border-2)', alignItems: 'center' }}>
+        <Icon name="chat" size={15} style={{ color: 'var(--accent)' }} />
+        <strong style={{ fontSize: 14 }}>{tr('Polaris 助手', 'Polaris assistant')}</strong>
+        <span style={{ flex: 1 }} />
+        <button className="icon-btn" onClick={onClose} title={tr('关闭（⌘J）', 'Close (⌘J)')}>
+          <Icon name="x" size={14} />
+        </button>
+      </div>
+
+      <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px' }}>
+        {turns.length === 0 && (
+          <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.7 }}>
+            {tr(
+              '助手可以调用平台的检索工具去查东西，而不是只凭上下文猜。试试问「最近有哪些关于 planning 的新论文」。',
+              'The assistant calls the platform’s search tools instead of guessing from context. Try asking what is new on a topic.',
+            )}
+          </div>
+        )}
+        {turns.map((turn, i) => (
+          <div key={i} style={{ marginBottom: 14 }}>
+            {turn.role === 'user' ? (
+              <div style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', borderRadius: 9, padding: '8px 11px', fontSize: 13 }}>
+                {turn.blocks.map((b, j) => (b.kind === 'text' ? <span key={j}>{b.text}</span> : null))}
+              </div>
+            ) : (
+              <div style={{ fontSize: 13, lineHeight: 1.7 }}>
+                {turn.blocks.map((b, j) => (
+                  <BlockView key={j} block={b} />
+                ))}
+                {busy && i === turns.length - 1 && turn.blocks.length === 0 && (
+                  <span style={{ color: 'var(--text-4)', fontSize: 12 }}>{tr('思考中…', 'Thinking…')}</span>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
+        <textarea
+          className="textarea"
+          rows={2}
+          value={input}
+          placeholder={tr('问点什么…（Enter 发送）', 'Ask something… (Enter to send)')}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              void send();
+            }
+          }}
+          style={{ width: '100%', fontSize: 13 }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4724,6 +4724,10 @@ export const api = {
    * 可直接跳任务详情看步骤与日志；409 detail=DAILY_FEED_RUNNING 表示已有一次在跑。
    */
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
+  /** 全局助手：新建一场会话（后端开关关着时 404）。 */
+  createAssistantConversation(scope: { scope_kind?: string; project_id?: string } = {}): Promise<{ id: string; title: string }> {
+    return requestJson<{ id: string; title: string }>('/chat/conversations', 'POST', scope);
+  },
   getDailySyncStatus(): Promise<DailySyncStatus> {
     return request<DailySyncStatus>('/daily/sync-status');
   },

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -1,0 +1,109 @@
+import { postSse } from './sse';
+
+/* ============================================================
+   助手的事件流 → 可渲染的块时间线。
+
+   **防御式**是这里的第一原则：SSE 过来的是 JSON.parse 出来的 any，TypeScript 只在
+   编译期帮忙。未知事件忽略、字段缺失兜底，绝不抛——这个项目没有前端测试工具，
+   运行时炸了没人拦得住。
+   ============================================================ */
+
+export type AssistantBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'thinking'; text: string }
+  | {
+      kind: 'tool';
+      id: string;
+      name: string;
+      state: 'running' | 'ok' | 'error';
+      summary?: string;
+      preview?: string;
+      durationMs?: number;
+    };
+
+export interface AssistantHandlers {
+  /** 用「上一份块列表 → 新块列表」的形式增量更新（React 状态直接套用）。 */
+  onBlocks: (fn: (blocks: AssistantBlock[]) => AssistantBlock[]) => void;
+  onDone: (stopReason: string) => void;
+  onError: (detail: string) => void;
+}
+
+function parse(data: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+const str = (v: unknown, fallback = ''): string => (typeof v === 'string' ? v : fallback);
+const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+
+/** 跑一轮助手对话；返回中止函数。 */
+export function assistantTurnSse(
+  conversationId: string,
+  question: string,
+  handlers: AssistantHandlers,
+): () => void {
+  return postSse(
+    `/chat/conversations/${conversationId}/turn`,
+    { question },
+    {
+      onEvent: (event, raw) => {
+        const data = parse(raw);
+        if (event === 'delta') {
+          const text = str(data.text);
+          if (!text) return;
+          // 追加到尾部文本块；尾块不是 text 就新开一个
+          handlers.onBlocks((blocks) => {
+            const last = blocks[blocks.length - 1];
+            if (last && last.kind === 'text') {
+              return [...blocks.slice(0, -1), { kind: 'text', text: last.text + text }];
+            }
+            return [...blocks, { kind: 'text', text }];
+          });
+        } else if (event === 'thinking') {
+          const text = str(data.text);
+          if (!text) return;
+          handlers.onBlocks((blocks) => {
+            const last = blocks[blocks.length - 1];
+            if (last && last.kind === 'thinking') {
+              return [...blocks.slice(0, -1), { kind: 'thinking', text: last.text + text }];
+            }
+            return [...blocks, { kind: 'thinking', text }];
+          });
+        } else if (event === 'tool_call') {
+          const id = str(data.id);
+          handlers.onBlocks((blocks) => [
+            ...blocks,
+            { kind: 'tool', id, name: str(data.name, '?'), state: 'running' },
+          ]);
+        } else if (event === 'tool_result') {
+          const id = str(data.id);
+          handlers.onBlocks((blocks) =>
+            blocks.map((b) =>
+              b.kind === 'tool' && b.id === id
+                ? {
+                    ...b,
+                    state: data.ok === false ? 'error' : 'ok',
+                    summary: str(data.summary) || undefined,
+                    preview: str(data.preview) || undefined,
+                    durationMs: num(data.duration_ms),
+                  }
+                : b,
+            ),
+          );
+        } else if (event === 'done') {
+          handlers.onDone(str(data.stop_reason, 'stop'));
+        } else if (event === 'error') {
+          handlers.onError(str(data.detail, '出错了'));
+        }
+        // 其余事件（meta / usage / compaction / 将来新增的）一律忽略：
+        // 后端加事件不该让旧前端崩掉
+      },
+      onClose: () => handlers.onDone('stop'),
+      onError: (err) => handlers.onError(err instanceof Error ? err.message : String(err)),
+    },
+  );
+}


### PR DESCRIPTION
The last piece of the first phase: `ChatAgentLoop`, an SSE endpoint, and a ⌘J global drawer. **The six existing chat endpoints are untouched** — this is a new path that coexists with them, behind a flag that is off by default (each round re-sends the history and the tool schemas; the cost is not in the same league as one-shot RAG).

Stacked on #254 → #253.

## The loop

It does not import fastapi, so its 13 tests run in **0.04s** — the whole path can be driven without HTTP or a database. That is the entire value of that boundary.

Decisions worth stating:

- **`tool_call` is emitted before execution.** My first version emitted only results, which leaves the UI with no "running" state: the card would materialise already-complete at the moment the tool returned, with nothing on screen during the seconds before. A test now pins `tool_call` ahead of `tool_result`.
- **Every rung of the error ladder keeps the turn alive.** A tool that raises, a hallucinated tool name, arguments that are not valid JSON — all become results fed back so the model can correct itself. Only a dead provider produces an `error` event. A relay that rejects `tools` is marked `recoverable`, so the caller can fall back to one-shot RAG rather than failing.
- **Running out of rounds hard-stops tools via `tool_choice="none"`**, rather than appending a user message to coax the model into wrapping up. The native API has a deterministic mechanism; use it.
- **Six tools to start, not thirty-eight.** Re-sending every schema each round is expensive and makes the model dither between near-identical options (`search_papers` / `search_chunks` / `global_search` especially).
- **The system prompt is a stable prefix**; the research statement and skills append at the end. Reversed, every scope gets its own prefix and prompt-cache hit rate goes to zero.
- Frontend rendering is defensive: unknown events ignored, unknown blocks not drawn. SSE arrives as `JSON.parse`'d `any`; TypeScript only helps at compile time, and this repo has no frontend test tooling.

## What the full suite caught

My tests registered fake tools through `@tool`, which writes to the **module-level global registry**. They leaked into the MCP tool list, and the deliberately-throwing one was reported by the MCP self-check as a broken tool.

That is empirical confirmation of the hazard flagged in the plan: `app/mcp/dispatch.py::tool_definitions()` iterates the registry with **no filter**. The tests now snapshot and restore it — and **the first write tool must add a read-only filter to MCP in the same PR**, or external MCP clients (Claude Desktop, Cursor) get write access the moment it lands.

## Tests

- `test_chat_agent_loop.py` (13): full event sequence, parallel calls, each rung of the error ladder, round exhaustion, tool-result elision, prompt stability, whitelist size.
- `test_chat_agent_api.py` (6): the endpoint 404s when the flag is off, a turn streams `meta … done` with streaming headers, the answer is persisted and the next turn replays it **without the frontend sending history**, another user's conversation is unreadable, conversations list newest-first, unknown scopes are rejected.

Full suite **1015 passed**; `ruff check app`, `tsc --noEmit` and `vite build` clean.

## Manual verification script for the frontend

No frontend test tooling exists, so this needs eyes:

1. Set `POLARIS_CHAT_AGENT_ENABLED=true`, open any page, press ⌘J — the drawer opens.
2. Ask something that needs a search. Expect a tool card in `running` state, then flipping to a checkmark with a one-line summary and a duration; click it to expand the raw preview.
3. Ask a follow-up. The answer should build on the previous turn — the frontend sends no history, so this exercises server-side replay.
4. Press ⌘J to close mid-answer, reopen: the stream is aborted by design in this phase (reconnect is P4).
5. Turn the flag off and reload: the drawer reports the assistant is not enabled rather than throwing.