### PR TITLE
feat(skills): SKILL.md-style skills with progressive disclosure

### DIFF
--- a/src/backend/alembic/versions/a22aa895244c_agent_skills.py
+++ b/src/backend/alembic/versions/a22aa895244c_agent_skills.py
@@ -1,0 +1,71 @@
+"""Skills v2：SKILL.md 式技能（渐进披露）
+
+与旧的 skills 表并存：那套是"人在写死的注入点上勾选、启动时全文拼进 system prompt"，
+这套是"模型自己判断要不要用，常驻的只有一句 description"。voyage 侧继续读旧表，
+行为不变；助手只认新表。
+
+Revision ID: a22aa895244c
+Revises: 581d172bd41b
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision: str = "a22aa895244c"
+down_revision: str | None = "581d172bd41b"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_JSON = sa.JSON().with_variant(JSONB(), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_skills",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("slug", sa.String(64), nullable=False),
+        sa.Column("name", sa.String(128), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("allowed_tools", _JSON, nullable=True),
+        sa.Column("invocation", sa.String(16), nullable=False, server_default="auto"),
+        sa.Column("scope", sa.String(16), nullable=False, server_default="user"),
+        sa.Column(
+            "owner_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+        ),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("load_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("owner_id", "slug", name="uq_agent_skills_owner_slug"),
+    )
+    op.create_index("ix_agent_skills_owner_id", "agent_skills", ["owner_id"])
+    op.create_index("ix_agent_skills_scope", "agent_skills", ["scope", "enabled"])
+
+    op.create_table(
+        "agent_skill_files",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "skill_id",
+            sa.Uuid(),
+            sa.ForeignKey("agent_skills.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("path", sa.String(512), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("size", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("skill_id", "path", name="uq_agent_skill_files_path"),
+    )
+    op.create_index("ix_agent_skill_files_skill_id", "agent_skill_files", ["skill_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_skill_files_skill_id", table_name="agent_skill_files")
+    op.drop_table("agent_skill_files")
+    op.drop_index("ix_agent_skills_scope", table_name="agent_skills")
+    op.drop_index("ix_agent_skills_owner_id", table_name="agent_skills")
+    op.drop_table("agent_skills")

--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -77,6 +77,7 @@ class ChatTurnRequest:
     max_turn_tokens: int | None = None
     statement: str | None = None
     extra_system: str = ""
+    skill_catalog: str = ""
 
 
 @dataclass(slots=True)
@@ -111,7 +112,12 @@ class ChatAgentLoop:
     async def run(self, req: ChatTurnRequest) -> AsyncIterator[ChatEvent]:
         specs = tool_definitions(req.tool_names)
         messages: list[Message] = [
-            Message(role="system", content=build_system_prompt(req.statement, req.extra_system)),
+            Message(
+                role="system",
+                content=build_system_prompt(
+                    req.statement, req.extra_system, req.skill_catalog
+                ),
+            ),
             *self._history,
             Message(role="user", content=req.question),
         ]

--- a/src/backend/app/agents/chat/prompt.py
+++ b/src/backend/app/agents/chat/prompt.py
@@ -20,6 +20,9 @@ DEFAULT_TOOL_NAMES: tuple[str, ...] = (
     "read_fulltext",
     "list_concepts",
     "get_concept",
+    # 渐进披露：目录常驻，正文按需取
+    "skill_load",
+    "skill_read_file",
 )
 
 _SYSTEM = """\
@@ -36,16 +39,25 @@ _SYSTEM = """\
 {statement}{extra}"""
 
 
-def build_system_prompt(statement: str | None = None, extra: str = "") -> str:
+def build_system_prompt(
+    statement: str | None = None, extra: str = "", skill_catalog: str = ""
+) -> str:
     """组装系统提示。
 
-    ``statement``（研究方向）与 ``extra``（技能等）都追加在末尾，前面那段是不变的
-    稳定前缀——顺序反过来会让每个作用域都有各自的缓存前缀，缓存命中率归零。
+    ``statement``（研究方向）、``skill_catalog``（技能目录）与 ``extra`` 都追加在末尾，
+    前面那段是不变的稳定前缀——顺序反过来会让每个作用域都有各自的缓存前缀，
+    命中率归零。
+
+    **技能正文永远不进这里**：目录里每个技能只占一行，正文由 ``skill_load`` 作为工具
+    结果追加。把正文写进 system prompt 会作废整个缓存前缀，而它是每轮都要重发的。
     """
     direction = f"\n\n研究方向：{statement.strip()}" if statement and statement.strip() else ""
+    catalog = f"\n\n{skill_catalog.strip()}" if skill_catalog and skill_catalog.strip() else ""
     tail = f"\n\n{extra.strip()}" if extra and extra.strip() else ""
     return _SYSTEM.format(
-        today=dt.datetime.now(dt.UTC).date().isoformat(), statement=direction, extra=tail
+        today=dt.datetime.now(dt.UTC).date().isoformat(),
+        statement=direction,
+        extra=catalog + tail,
     )
 
 

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -43,6 +43,7 @@ from app.schemas.chat_agent import (
     ConversationTurnRequest,
     MessageRead,
 )
+from app.services import agent_skills
 from app.services import conversations as store
 from app.tools.context import ToolContext
 
@@ -156,6 +157,9 @@ async def run_turn(
     if conv.id != conversation_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
     history = await store.replay(session, conversation_id=conv.id)
+    # L1：技能目录进 system prompt（每个技能只占一行）。正文由 skill_load 按需取，
+    # 绝不写进 system——那会作废整个 prompt cache 前缀。
+    catalog = await agent_skills.render_catalog(session, user_id=user.id)
     await store.append_message(session, conversation=conv, role="user", text=payload.question)
     await session.commit()
 
@@ -168,6 +172,7 @@ async def run_turn(
         tool_names=tuple(payload.tool_names or DEFAULT_TOOL_NAMES),
         max_rounds=payload.max_rounds,
         statement=payload.statement,
+        skill_catalog=catalog,
     )
     conv_id, user_id = conv.id, user.id
 

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy 模型包。import 本包即可把全部表注册进 Base.metadata（create_all / alembic 用）。"""
 
 from app.models.activity import Activity
+from app.models.agent_skill import AgentSkill, AgentSkillFile
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
 from app.models.chat_bot import ChatBotConfig
 from app.models.conversation import Conversation, ConversationMessage
@@ -46,6 +47,8 @@ from app.models.voyage import VoyageRun, VoyageStep
 
 __all__ = [
     "Activity",
+    "AgentSkill",
+    "AgentSkillFile",
     "ChatBotConfig",
     "Conversation",
     "ConversationMessage",

--- a/src/backend/app/models/agent_skill.py
+++ b/src/backend/app/models/agent_skill.py
@@ -1,0 +1,95 @@
+"""Agent 技能（Skills v2，照搬 SKILL.md 的形状）。
+
+与旧的 ``skills`` 表是**两套东西**，不是改造：旧那套是"人在 19 个写死的注入点上勾选、
+启动时把正文无条件全文拼进 system prompt"；这套是"模型自己判断要不要用，常驻的只有
+一句 description，正文按需加载"。
+
+三级渐进披露：
+
+1. **目录**（L1）：system prompt 里每个技能只占一行 ``name：description``，几十 token。
+2. **正文**（L2）：模型调 ``skill_load(slug)`` 才把 SKILL.md 正文取回来——作为**工具结果**
+   追加，绝不改写 system prompt（改了会作废整个 prompt cache 前缀）。
+3. **附件**（L3）：正文里提到的模板/参考资料，模型调 ``skill_read_file`` 按需读。
+
+``description`` 是这套机制的承重结构：它不是给人看的说明，是**触发条件**。写成"这是
+什么"而不是"什么时候用它"，模型就永远不会加载它。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import Boolean, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+#: auto = 模型可自主加载；manual = 只能由用户显式调用（危险或昂贵的技能用它，
+#: 也是外部导入技能的安全默认值——来路不明的东西不该被模型自主加载）
+SKILL_INVOCATIONS = ("auto", "manual")
+SKILL_SCOPES = ("builtin", "user")
+
+#: 目录里单条的长度上限。整个目录常驻 system prompt，控制不住就吃光预算。
+DESCRIPTION_MAX = 300
+#: 正文上限。渐进披露之后它不再无条件进 prompt，所以可以比旧系统的 8K 宽得多。
+BODY_MAX = 64 * 1024
+
+
+class AgentSkill(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "agent_skills"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "slug", name="uq_agent_skills_owner_slug"),
+        Index("ix_agent_skills_scope", "scope", "enabled"),
+    )
+
+    slug: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    #: **触发条件**，不是功能介绍。渐进披露的成败全在这一句写得好不好。
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    #: 收窄助手的能力面。只能收窄，永不扩权（与会话白名单求交集）。None = 不收窄。
+    allowed_tools: Mapped[list[str] | None] = mapped_column(JSONVariant, nullable=True)
+    invocation: Mapped[str] = mapped_column(String(16), nullable=False, default="auto")
+    scope: Mapped[str] = mapped_column(String(16), nullable=False, default="user")
+    #: builtin 的 owner 为空；用户技能归属本人
+    owner_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    #: 加载次数，用于目录超限时的截断排序（常用的留在目录里）
+    load_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+class AgentSkillFile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """技能目录里的附件：模板、参考资料、给模型抄的脚本。
+
+    **脚本只能被读，不能执行**：平台只有远程 SSH/容器 runner（命令走严格模板白名单，
+    LLM 不能拼 shell），没有本地沙箱。假装有会比没有更危险。
+    """
+
+    __tablename__ = "agent_skill_files"
+    __table_args__ = (UniqueConstraint("skill_id", "path", name="uq_agent_skill_files_path"),)
+
+    skill_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_skills.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    path: Mapped[str] = mapped_column(String(512), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+def skill_catalog_line(skill: AgentSkill) -> str:
+    """目录里的一行。名字 + 触发条件，不带正文。"""
+    desc = (skill.description or "").strip().replace("\n", " ")
+    return f"- {skill.slug}：{desc[:DESCRIPTION_MAX]}"
+
+
+def as_dict(skill: AgentSkill) -> dict[str, Any]:
+    return {
+        "slug": skill.slug,
+        "name": skill.name,
+        "description": skill.description,
+        "invocation": skill.invocation,
+        "allowed_tools": skill.allowed_tools,
+        "scope": skill.scope,
+    }

--- a/src/backend/app/services/agent_skills.py
+++ b/src/backend/app/services/agent_skills.py
@@ -1,0 +1,248 @@
+"""Skills v2：SKILL.md 解析、目录渲染、按需加载。
+
+渐进披露的三级在这里落地。最要紧的一条约束写在前面：**技能正文永远作为工具结果
+追加，绝不写进 system prompt**。system prompt 是稳定前缀，改它等于作废整个 prompt
+cache——而每轮重发的历史加工具 schema 本来就是输入 token 的大头。
+"""
+
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_skill import (
+    BODY_MAX,
+    SKILL_INVOCATIONS,
+    AgentSkill,
+    AgentSkillFile,
+    skill_catalog_line,
+)
+
+#: 目录整体的长度上限。超了按 load_count 降序截断——常用的留在目录里。
+CATALOG_MAX_CHARS = 4000
+#: 单个附件的大小上限
+FILE_MAX_CHARS = 256 * 1024
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}$")
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.S)
+
+
+class SkillParseError(ValueError):
+    """SKILL.md 的 frontmatter 有问题。"""
+
+
+def parse_skill_md(text: str) -> dict[str, Any]:
+    """解析 SKILL.md：YAML frontmatter + markdown 正文。
+
+    只认几个字段，而且**不引入 YAML 依赖**——frontmatter 就是几行 ``key: value``
+    加一个可选的列表，手写解析比拉一个库进来划算，也不给"技能里塞任意 YAML"留口子。
+    """
+    match = _FRONTMATTER_RE.match(text.strip())
+    if not match:
+        raise SkillParseError("缺少 --- 包裹的 frontmatter")
+    raw, body = match.group(1), match.group(2).strip()
+
+    fields: dict[str, Any] = {}
+    key: str | None = None
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        if line.lstrip().startswith("- ") and key:
+            fields.setdefault(key, [])
+            if isinstance(fields[key], list):
+                fields[key].append(line.split("- ", 1)[1].strip())
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().replace("-", "_")
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            fields[key] = [v.strip().strip("'\"") for v in value[1:-1].split(",") if v.strip()]
+        elif value in (">", "|"):
+            fields[key] = ""  # 折叠块：下面的缩进行会被下一轮当作续行拼上
+        else:
+            fields[key] = value.strip("'\"")
+
+    # 折叠块（description: > 换行缩进）的续行拼接
+    if fields.get("description") == "":
+        lines = []
+        seen = False
+        for line in raw.splitlines():
+            if line.strip().startswith("description:"):
+                seen = True
+                continue
+            if seen:
+                if line.startswith((" ", "\t")):
+                    lines.append(line.strip())
+                else:
+                    break
+        fields["description"] = " ".join(lines)
+
+    slug = str(fields.get("name") or "").strip()
+    if not _SLUG_RE.match(slug):
+        raise SkillParseError(f"name 必须是小写短横线 slug：{slug!r}")
+    description = str(fields.get("description") or "").strip()
+    if not description:
+        raise SkillParseError("description 不能为空——它是模型判断要不要加载的唯一依据")
+    invocation = str(fields.get("invocation") or "auto")
+    if invocation not in SKILL_INVOCATIONS:
+        raise SkillParseError(f"invocation 只能是 {SKILL_INVOCATIONS}")
+    tools = fields.get("allowed_tools")
+    if isinstance(tools, str):
+        tools = [t.strip() for t in tools.split(",") if t.strip()]
+    return {
+        "slug": slug,
+        "name": str(fields.get("title") or slug),
+        "description": description,
+        "invocation": invocation,
+        "allowed_tools": tools or None,
+        "body": body[:BODY_MAX],
+    }
+
+
+async def visible_skills(session: AsyncSession, *, user_id: uuid.UUID | None) -> list[AgentSkill]:
+    """这个用户能看到的技能：内置的 + 自己的。"""
+    stmt = select(AgentSkill).where(AgentSkill.enabled.is_(True))
+    if user_id is None:
+        stmt = stmt.where(AgentSkill.scope == "builtin")
+    else:
+        stmt = stmt.where(
+            (AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id)
+        )
+    stmt = stmt.order_by(AgentSkill.load_count.desc(), AgentSkill.slug)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def render_catalog(session: AsyncSession, *, user_id: uuid.UUID | None) -> str:
+    """L1：常驻 system prompt 的技能目录。只有名字和触发条件，没有正文。
+
+    超出预算时按加载次数截断——常用的留下。这比按字母序砍更合理，也比不截断安全：
+    目录是每轮都要重发的。
+    """
+    skills = [s for s in await visible_skills(session, user_id=user_id) if s.invocation == "auto"]
+    if not skills:
+        return ""
+    lines: list[str] = []
+    used = 0
+    for skill in skills:
+        line = skill_catalog_line(skill)
+        if used + len(line) > CATALOG_MAX_CHARS:
+            break
+        lines.append(line)
+        used += len(line)
+    if not lines:
+        return ""
+    return "可用技能（需要时用 skill_load 取正文，不要凭名字猜内容）：\n" + "\n".join(lines)
+
+
+async def load_skill(
+    session: AsyncSession, *, slug: str, user_id: uuid.UUID | None
+) -> dict[str, Any] | None:
+    """L2：取技能正文与附件清单。同时把加载次数加一（目录截断按它排序）。"""
+    skill = await _find(session, slug=slug, user_id=user_id)
+    if skill is None:
+        return None
+    files = (
+        (
+            await session.execute(
+                select(AgentSkillFile.path, AgentSkillFile.size).where(
+                    AgentSkillFile.skill_id == skill.id
+                )
+            )
+        )
+        .all()
+    )
+    skill.load_count += 1
+    await session.flush()
+    return {
+        "slug": skill.slug,
+        "name": skill.name,
+        "body": skill.body,
+        "allowed_tools": skill.allowed_tools,
+        "files": [{"path": p, "size": s} for p, s in files],
+    }
+
+
+async def read_skill_file(
+    session: AsyncSession, *, slug: str, path: str, user_id: uuid.UUID | None
+) -> str | None:
+    """L3：读技能目录里的一个附件。
+
+    路径不做任何拼接与规范化——附件是**表里的行**，不是文件系统里的文件，所以既没有
+    ``..`` 逃逸的问题，也不需要为此写一堆防御代码。
+    """
+    skill = await _find(session, slug=slug, user_id=user_id)
+    if skill is None:
+        return None
+    row = await session.scalar(
+        select(AgentSkillFile.content).where(
+            AgentSkillFile.skill_id == skill.id, AgentSkillFile.path == path
+        )
+    )
+    return row[:FILE_MAX_CHARS] if row is not None else None
+
+
+async def _find(
+    session: AsyncSession, *, slug: str, user_id: uuid.UUID | None
+) -> AgentSkill | None:
+    stmt = select(AgentSkill).where(AgentSkill.slug == slug, AgentSkill.enabled.is_(True))
+    if user_id is None:
+        stmt = stmt.where(AgentSkill.scope == "builtin")
+    else:
+        stmt = stmt.where((AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id))
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def upsert_from_md(
+    session: AsyncSession,
+    *,
+    text: str,
+    user_id: uuid.UUID | None,
+    scope: str = "user",
+    files: dict[str, str] | None = None,
+) -> AgentSkill:
+    """从 SKILL.md 建/更新一个技能（同 slug 覆盖）。"""
+    parsed = parse_skill_md(text)
+    existing = await session.scalar(
+        select(AgentSkill).where(
+            AgentSkill.slug == parsed["slug"], AgentSkill.owner_id == user_id
+        )
+    )
+    skill = existing or AgentSkill(slug=parsed["slug"], owner_id=user_id, scope=scope)
+    skill.name = parsed["name"]
+    skill.description = parsed["description"]
+    skill.body = parsed["body"]
+    skill.allowed_tools = parsed["allowed_tools"]
+    skill.invocation = parsed["invocation"]
+    skill.enabled = True
+    session.add(skill)
+    await session.flush()
+
+    for path, content in (files or {}).items():
+        row = await session.scalar(
+            select(AgentSkillFile).where(
+                AgentSkillFile.skill_id == skill.id, AgentSkillFile.path == path
+            )
+        )
+        if row is None:
+            row = AgentSkillFile(skill_id=skill.id, path=path)
+            session.add(row)
+        row.content = content[:FILE_MAX_CHARS]
+        row.size = len(content)
+    await session.flush()
+    return skill
+
+
+def narrow_tools(session_tools: tuple[str, ...], skill_tools: list[str] | None) -> tuple[str, ...]:
+    """技能的 allowed-tools 与会话白名单求交集。
+
+    **只能收窄，永不扩权**——技能里写一个会话没给的工具名，结果是那个工具不可用，
+    而不是把它加进来。这条是安全底线，不给配置项。
+    """
+    if not skill_tools:
+        return session_tools
+    allowed = set(skill_tools)
+    return tuple(t for t in session_tools if t in allowed)

--- a/src/backend/app/tools/__init__.py
+++ b/src/backend/app/tools/__init__.py
@@ -12,6 +12,7 @@ from app.tools import (
     libraries,  # noqa: F401
     literature,  # noqa: F401
     project_state,  # noqa: F401
+    skills,  # noqa: F401
     workspace,  # noqa: F401
     writing,  # noqa: F401
 )

--- a/src/backend/app/tools/skills.py
+++ b/src/backend/app/tools/skills.py
@@ -1,0 +1,73 @@
+"""技能加载工具：渐进披露的 L2 与 L3。
+
+这两个工具存在的全部理由，是让**技能正文不必常驻 system prompt**。常驻的只有目录里
+的一行 description；模型判断"这次用得上"才来取正文。正文作为工具结果追加，不改写
+system prompt——改了会作废整个 prompt cache 前缀。
+"""
+
+from typing import Any
+
+from app.core.db import get_sessionmaker
+from app.services import agent_skills
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+
+@tool(
+    name="skill_load",
+    description=(
+        "加载一个技能的正文。系统提示里的技能目录只给了名字和适用场景，"
+        "判断某个技能这次用得上时，用它把完整做法取回来。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {"slug": {"type": "string", "description": "技能目录里的名字"}},
+        "required": ["slug"],
+    },
+    summarize=lambda args, result: (
+        f"加载技能 {args.get('slug')}"
+        + (f"（{len(result.get('files') or [])} 个附件）" if result.get("files") else "")
+    ),
+)
+async def skill_load(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    slug = str(args.get("slug") or "").strip()
+    if not slug:
+        return {"error": "缺少 slug"}
+    async with get_sessionmaker()() as session:
+        loaded = await agent_skills.load_skill(session, slug=slug, user_id=ctx.user_id)
+        await session.commit()
+    if loaded is None:
+        return {"error": f"没有这个技能：{slug}"}
+    return loaded
+
+
+@tool(
+    name="skill_read_file",
+    description=(
+        "读技能目录里的附件（模板、参考资料、示例代码）。"
+        "技能正文里提到某个文件时才用它，不要挨个试。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "slug": {"type": "string"},
+            "path": {"type": "string", "description": "技能正文里给出的相对路径"},
+        },
+        "required": ["slug", "path"],
+    },
+    summarize=lambda args, result: f"读 {args.get('slug')}/{args.get('path')}",
+)
+async def skill_read_file(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    slug = str(args.get("slug") or "").strip()
+    path = str(args.get("path") or "").strip()
+    if not slug or not path:
+        return {"error": "缺少 slug 或 path"}
+    async with get_sessionmaker()() as session:
+        content = await agent_skills.read_skill_file(
+            session, slug=slug, path=path, user_id=ctx.user_id
+        )
+    if content is None:
+        return {"error": f"技能 {slug} 里没有 {path}"}
+    # 附件里的脚本**只能读、不能执行**：平台只有远程 SSH/容器 runner（命令走严格模板
+    # 白名单），没有本地沙箱。它是给模型抄的参考实现，不是可运行的东西。
+    return {"slug": slug, "path": path, "content": content}

--- a/src/backend/tests/test_agent_skills.py
+++ b/src/backend/tests/test_agent_skills.py
@@ -1,0 +1,232 @@
+"""Skills v2：SKILL.md 解析与三级渐进披露。
+
+与旧的 skills 表是两套东西：那套是"人在 19 个写死的注入点上勾选、启动时把正文无条件
+全文拼进 system prompt"；这套是"模型自己判断要不要用，常驻的只有一句 description"。
+
+**description 是承重结构**——它不是给人看的功能介绍，是模型判断要不要加载的唯一依据。
+写成"这是什么"而不是"什么时候用"，技能就永远不会被加载。
+"""
+
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.services import agent_skills
+from tests.conftest import register_and_login
+
+SKILL_MD = """\
+---
+name: literature-triage
+description: >
+  批量筛选候选文献并给出保留/剔除建议。当用户说"帮我筛一下这批论文"、
+  "这些跟我方向相关吗"，或需要对每日推送做初筛时使用。
+allowed-tools: [search_papers, get_paper]
+invocation: auto
+---
+
+# 文献初筛
+
+先按方向说明逐篇判断，再给出保留/剔除清单。判据见 `rubric.md`。
+"""
+
+
+async def _user_id(client, email: str) -> uuid.UUID:
+    from sqlalchemy import select
+
+    from app.models.user import User
+
+    await register_and_login(client, email=email)
+    async with get_sessionmaker()() as session:
+        return (await session.execute(select(User.id).where(User.email == email))).scalar_one()
+
+
+# ---- 解析 ----
+
+
+def test_frontmatter_is_parsed_without_a_yaml_dependency():
+    """折叠块的 description、列表形式的 allowed-tools 都要认。
+
+    手写解析而不是拉个 YAML 库进来：frontmatter 就这几个字段，而且不给「技能里塞
+    任意 YAML」留口子。
+    """
+    parsed = agent_skills.parse_skill_md(SKILL_MD)
+    assert parsed["slug"] == "literature-triage"
+    assert "帮我筛一下这批论文" in parsed["description"], "折叠块的续行要拼上"
+    assert parsed["allowed_tools"] == ["search_papers", "get_paper"]
+    assert parsed["invocation"] == "auto"
+    assert parsed["body"].startswith("# 文献初筛")
+
+
+@pytest.mark.parametrize(
+    "text,reason",
+    [
+        ("没有 frontmatter 的正文", "缺少 --- 包裹"),
+        ("---\nname: Bad Slug\ndescription: x\n---\n正文", "slug 必须小写短横线"),
+        ("---\nname: ok-slug\ndescription:\n---\n正文", "description 不能为空"),
+        ("---\nname: ok-slug\ndescription: x\ninvocation: whenever\n---\n正文", "invocation 枚举"),
+    ],
+)
+def test_bad_frontmatter_is_rejected_with_a_reason(text, reason):
+    with pytest.raises(agent_skills.SkillParseError):
+        agent_skills.parse_skill_md(text)
+
+
+# ---- L1 目录 ----
+
+
+async def test_the_catalog_carries_descriptions_but_never_bodies(client):
+    """常驻 system prompt 的目录里只有名字和触发条件。
+
+    正文进了 system prompt 就等于作废整个 prompt cache 前缀，而它每轮都要重发。
+    """
+    user_id = await _user_id(client, "skill-catalog@example.com")
+    async with get_sessionmaker()() as session:
+        await agent_skills.upsert_from_md(session, text=SKILL_MD, user_id=user_id)
+        await session.commit()
+        catalog = await agent_skills.render_catalog(session, user_id=user_id)
+
+    assert "literature-triage" in catalog
+    assert "帮我筛一下这批论文" in catalog
+    assert "# 文献初筛" not in catalog, "正文绝不能进目录"
+    assert "rubric.md" not in catalog
+
+
+async def test_manual_skills_stay_out_of_the_catalog(client):
+    """invocation=manual 的技能不进目录——模型不该自主加载危险或来路不明的东西。"""
+    user_id = await _user_id(client, "skill-manual@example.com")
+    md = SKILL_MD.replace("invocation: auto", "invocation: manual").replace(
+        "literature-triage", "danger-zone"
+    )
+    async with get_sessionmaker()() as session:
+        await agent_skills.upsert_from_md(session, text=md, user_id=user_id)
+        await session.commit()
+        catalog = await agent_skills.render_catalog(session, user_id=user_id)
+
+    assert "danger-zone" not in catalog
+
+
+async def test_the_catalog_is_capped_and_keeps_the_popular_ones(client):
+    """目录有预算上限；超了按加载次数截断，常用的留下。"""
+    user_id = await _user_id(client, "skill-cap@example.com")
+    async with get_sessionmaker()() as session:
+        for i in range(60):
+            md = SKILL_MD.replace("literature-triage", f"skill-{i:03d}")
+            skill = await agent_skills.upsert_from_md(session, text=md, user_id=user_id)
+            skill.load_count = i  # 越靠后越常用
+        await session.commit()
+        catalog = await agent_skills.render_catalog(session, user_id=user_id)
+
+    assert len(catalog) <= agent_skills.CATALOG_MAX_CHARS + 200
+    assert "skill-059" in catalog, "最常用的必须在"
+    assert "skill-000" not in catalog, "最冷门的被挤掉"
+
+
+# ---- L2 / L3 加载 ----
+
+
+async def test_loading_a_skill_returns_the_body_and_the_file_list(client):
+    user_id = await _user_id(client, "skill-load@example.com")
+    async with get_sessionmaker()() as session:
+        await agent_skills.upsert_from_md(
+            session,
+            text=SKILL_MD,
+            user_id=user_id,
+            files={"rubric.md": "# 判据\n1. 方向相关\n2. 方法新颖"},
+        )
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        loaded = await agent_skills.load_skill(
+            session, slug="literature-triage", user_id=user_id
+        )
+        await session.commit()
+
+    assert loaded is not None
+    assert "# 文献初筛" in loaded["body"]
+    rubric = "# 判据\n1. 方向相关\n2. 方法新颖"
+    assert loaded["files"] == [{"path": "rubric.md", "size": len(rubric)}]
+    assert loaded["allowed_tools"] == ["search_papers", "get_paper"]
+
+    async with get_sessionmaker()() as session:
+        content = await agent_skills.read_skill_file(
+            session, slug="literature-triage", path="rubric.md", user_id=user_id
+        )
+    assert content is not None and "方法新颖" in content
+
+
+async def test_another_users_skill_is_invisible(client):
+    """别人的技能既不进我的目录，也加载不了。"""
+    owner = await _user_id(client, "skill-owner@example.com")
+    other = await _user_id(client, "skill-other@example.com")
+    async with get_sessionmaker()() as session:
+        await agent_skills.upsert_from_md(session, text=SKILL_MD, user_id=owner)
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        catalog = await agent_skills.render_catalog(session, user_id=other)
+        loaded = await agent_skills.load_skill(
+            session, slug="literature-triage", user_id=other
+        )
+    assert "literature-triage" not in catalog
+    assert loaded is None
+
+
+async def test_loading_bumps_the_counter_used_for_truncation(client):
+    user_id = await _user_id(client, "skill-count@example.com")
+    async with get_sessionmaker()() as session:
+        await agent_skills.upsert_from_md(session, text=SKILL_MD, user_id=user_id)
+        await session.commit()
+
+    for _ in range(3):
+        async with get_sessionmaker()() as session:
+            await agent_skills.load_skill(session, slug="literature-triage", user_id=user_id)
+            await session.commit()
+
+    async with get_sessionmaker()() as session:
+        skills = await agent_skills.visible_skills(session, user_id=user_id)
+    assert skills[0].load_count == 3
+
+
+# ---- allowed-tools 只能收窄 ----
+
+
+def test_allowed_tools_can_only_narrow_never_widen():
+    """技能里写一个会话没给的工具名，结果是那个工具不可用，而不是把它加进来。
+
+    这条是安全底线，不做成配置项。
+    """
+    session_tools = ("search_papers", "get_paper", "read_fulltext")
+
+    assert agent_skills.narrow_tools(session_tools, None) == session_tools
+    assert agent_skills.narrow_tools(session_tools, ["search_papers"]) == ("search_papers",)
+    # 技能想要一个会话没给的工具：不会凭空出现
+    widened = agent_skills.narrow_tools(session_tools, ["search_papers", "delete_everything"])
+    assert widened == ("search_papers",)
+    assert "delete_everything" not in widened
+
+
+# ---- 工具层 ----
+
+
+async def test_the_skill_tools_are_registered_and_read_only(client):
+    """两个技能工具进了注册表，而且是只读的——它们会经 MCP 暴露给外部客户端。"""
+    from app.tools.registry import get_tool
+
+    for name in ("skill_load", "skill_read_file"):
+        spec = get_tool(name)
+        assert spec is not None, name
+        assert spec.read_only is True, f"{name} 必须只读"
+        assert spec.input_schema["type"] == "object"
+
+
+async def test_skill_load_tool_reports_a_missing_skill_instead_of_raising(client):
+    """加载不存在的技能返回错误结果，不抛——模型下一轮自己纠正。"""
+    from app.core.llm.router import get_llm_router
+    from app.tools.context import ToolContext
+    from app.tools.skills import skill_load
+
+    user_id = await _user_id(client, "skill-missing@example.com")
+    ctx = ToolContext(project_id=uuid.uuid4(), llm=get_llm_router(), user_id=user_id)
+    result = await skill_load(ctx, {"slug": "not-there"})
+    assert "error" in result

--- a/src/backend/tests/test_chat_agent_loop.py
+++ b/src/backend/tests/test_chat_agent_loop.py
@@ -300,9 +300,15 @@ def test_system_prompt_keeps_a_stable_prefix():
 
 
 def test_default_tool_whitelist_is_small():
-    """首期只给 6 个。38 个 schema 每轮重发既贵，又让模型在相近工具间反复犹豫。"""
-    assert len(DEFAULT_TOOL_NAMES) == 6
-    assert "search_chunks" in DEFAULT_TOOL_NAMES
+    """检索工具只给 6 个 + 两个技能加载工具。
+
+    38 个 schema 每轮重发既贵，又让模型在相近工具间反复犹豫。技能那两个是例外——
+    它们是渐进披露的入口，不给就等于没有技能系统。
+    """
+    retrieval = [t for t in DEFAULT_TOOL_NAMES if not t.startswith("skill_")]
+    assert len(retrieval) == 6
+    assert "search_chunks" in retrieval
+    assert set(DEFAULT_TOOL_NAMES) - set(retrieval) == {"skill_load", "skill_read_file"}
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,9 +9,10 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "581d172bd41b"  # 成员行记下打分它的那次同步任务 id
+HEAD_REVISION = "a22aa895244c"  # 成员行记下打分它的那次同步任务 id
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
 SCORED_RUN_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
+CONVERSATIONS_REVISION = "581d172bd41b"  # 对话搬到服务端
 INLINE_VECTOR_DROP_REVISION = "929c05a03745"  # 删除主表向量列（向量已搬进侧表）
 VECTOR_TABLES_REVISION = "5d8ebd5cb100"  # 向量侧表建表 + 存量搬迁
 EFFORT_REVISION = "510f6bde2233"  # 模型路由推理档位（model_routes.effort）
@@ -92,6 +93,8 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "library_research_digests",
                     "conversations",
                     "conversation_messages",
+                    "agent_skills",
+                    "agent_skill_files",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -111,6 +114,11 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "effort" in columns["model_routes"]  # 推理档位可配（NULL = 用模型默认）
     # 对话搬到服务端：agent 一轮里可能调好几次工具，历史不能只活在浏览器 localStorage
     assert {"conversations", "conversation_messages"} <= columns["_tables"]
+    # Skills v2：技能是「一句 description 常驻 + 正文按需加载」，附件单独一张表
+    assert {"agent_skills", "agent_skill_files"} <= columns["_tables"]
+    assert {"slug", "description", "body", "allowed_tools", "invocation"} <= columns[
+        "agent_skills"
+    ]
     assert {"scope_kind", "scope_id", "usage", "active_stream_id"} <= columns["conversations"]
     assert {"blocks", "text", "seq", "status", "sources"} <= columns["conversation_messages"]
     # 这场对话花了多少 token（voyage_id 的对偶）
@@ -342,7 +350,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉对话持久化（两张表 + 三处附带列）。
+    # 最新 revision 可往返：先退掉 Skills v2。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CONVERSATIONS_REVISION
+    assert not {"agent_skills", "agent_skill_files"} & columns["_tables"]
+
+    # 再退掉对话持久化（两张表 + 三处附带列）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == SCORED_RUN_REVISION


### PR DESCRIPTION
The skill system rebuilt on the SKILL.md shape, per the decision to model it on Claude's Agent Skills rather than extend what was there.

It **coexists** with the old `skills` table rather than replacing it in place: the old one is "a human ticks boxes against nineteen hardcoded injection points, and the body is concatenated unconditionally into the system prompt at startup". Voyage keeps reading it, unchanged. The assistant only knows the new one.

Stacked on #255 → #254 → #253.

## Three levels of progressive disclosure

1. **Catalog** — one line per skill in the system prompt (`slug: when to use it`), tens of tokens.
2. **Body** — fetched only when the model decides a skill applies, via `skill_load`. It arrives **as a tool result, never written into the system prompt**: doing that invalidates the entire prompt-cache prefix, and that prefix is re-sent every round.
3. **Attachments** — templates and reference material named in the body, read on demand via `skill_read_file`.

## Decisions

- **`description` is the load-bearing field.** It is not a human-facing summary; it is the only basis the model has for deciding whether to load the skill. Written as "what this is" rather than "when to use it", a skill will simply never be loaded. This is stated in the module docstring and pinned by tests.
- **`allowed-tools` can only narrow, never widen.** Naming a tool the session did not grant makes that tool unavailable — it does not add it. A test pins this with `delete_everything`. It is a security floor, not a configuration option.
- **Frontmatter is parsed by hand, with no YAML dependency.** There are only a handful of fields, and it avoids opening the door to arbitrary YAML inside a skill. Folded `description: >` continuations and list-form `allowed-tools` are both handled.
- **`invocation: manual` stays out of the catalog.** Dangerous or unvetted skills — including anything installed from a marketplace later — should not be model-invocable.
- **The catalog has a budget** and truncates by load count when exceeded, keeping the frequently used ones. It is re-sent every round.
- **Scripts in attachments can be read, not executed.** The platform has only the remote SSH/container runner, whose commands go through a strict template allowlist so the model cannot assemble a shell command; there is no local sandbox. Pretending otherwise would be worse than not having it.

## Tests

14 new: frontmatter parsing including folded blocks, four malformed-frontmatter cases, the catalog carrying descriptions but never bodies, manual skills excluded, budget truncation keeping popular skills, load returning body plus file list, another user's skills being invisible, the load counter, narrowing-only tool intersection, and both tools being registered as read-only (they are exposed through MCP).

The migration round-trips on SQLite — upgrade to head, step back through each revision, and back up again.

Full suite **1029 passed**; `ruff check app` clean.

## Not in this PR

The permission model (allow / ask / deny) and the first write tools. When those land, `app/mcp/dispatch.py::tool_definitions()` must gain a read-only filter **in the same PR** — it currently iterates the registry unfiltered, which #255 demonstrated empirically when test tools leaked into the MCP tool list.