### PR TITLE
feat(agent): subagents, agentic search primitives, and the write guard groundwork

### DIFF
--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -110,7 +110,8 @@ class ChatAgentLoop:
         self._history = list(history)
 
     async def run(self, req: ChatTurnRequest) -> AsyncIterator[ChatEvent]:
-        specs = tool_definitions(req.tool_names)
+        active_tools: tuple[str, ...] = tuple(req.tool_names)
+        specs = tool_definitions(active_tools)
         messages: list[Message] = [
             Message(
                 role="system",
@@ -203,6 +204,12 @@ class ChatAgentLoop:
                 yield ev
             messages.append(Message(role="user", content=list(results)))
 
+            # 技能声明了 allowed-tools 就收窄后续可用的工具面。**只能收窄，永不扩权**：
+            # 技能里写一个会话没给的工具名，结果是那个工具不可用，而不是把它加进来。
+            if narrowed := _skill_narrowing(results, active_tools):
+                active_tools = narrowed
+                specs = tool_definitions(active_tools)
+
             if removed := _elide_old_results(messages):
                 yield CompactionEvent(removed=removed)
 
@@ -288,6 +295,32 @@ class ChatAgentLoop:
             ),
             ToolResultBlock(call.id, text, is_error=True),
         )
+
+
+def _skill_narrowing(
+    results: list[ToolResultBlock], current: tuple[str, ...]
+) -> tuple[str, ...] | None:
+    """本轮加载的技能若声明了 allowed-tools，就据此收窄。
+
+    收窄发生在技能加载**之后**的那一轮起效——这一轮已经调过的工具不受影响，那是既成
+    事实。收窄结果为空时不生效（技能写错名字不该把助手变成哑巴）。
+    """
+    from app.services.agent_skills import narrow_tools
+
+    narrowed = current
+    for block in results:
+        if block.is_error:
+            continue
+        try:
+            payload = json.loads(block.content)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(payload, dict) or "allowed_tools" not in payload:
+            continue
+        narrowed = narrow_tools(narrowed, payload.get("allowed_tools"))
+    if narrowed == current or not narrowed:
+        return None
+    return narrowed
 
 
 def _elide_old_results(messages: list[Message]) -> int:

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -45,6 +45,7 @@ from app.schemas.chat_agent import (
 )
 from app.services import agent_skills
 from app.services import conversations as store
+from app.services import projects as projects_service
 from app.tools.context import ToolContext
 
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -87,6 +88,11 @@ async def create_conversation(
     user: User = Depends(current_active_user),
 ) -> ConversationRead:
     _require_enabled()
+    # 归属校验在入口做，垃圾不落库：project_id / scope_id 指向的课题必须是自己的。
+    # 非成员一律 404（不区分「不存在」与「无权」，防枚举——与平台其他读口一致）。
+    for pid in {payload.project_id, payload.scope_id if payload.scope_kind == "project" else None}:
+        if pid is not None and await projects_service.get_project(session, pid, user.id) is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     conv = await store.get_or_create(
         session,
         user_id=user.id,
@@ -163,13 +169,21 @@ async def run_turn(
     await store.append_message(session, conversation=conv, role="user", text=payload.question)
     await session.commit()
 
-    project_id = conv.project_id or conv.scope_id or uuid.uuid4()
-    tool_ctx = ToolContext(project_id=project_id, llm=get_llm_router(), user_id=user.id)
+    project_id = await _resolve_project(
+        session, user=user, conv=conv, requested=payload.project_id
+    )
+    # project_id 为 None（用户没有课题）时这轮不带任何工具：ToolContext 里的占位 id
+    # 不会被用到，因为没有工具可调。这与从前兜随机 UUID 的区别是**诚实**——助手不会
+    # 调工具查到零条然后说「没查到」，它根本不会声称自己查过。
+    tool_names = tuple(payload.tool_names or DEFAULT_TOOL_NAMES) if project_id else ()
+    tool_ctx = ToolContext(
+        project_id=project_id or uuid.uuid4(), llm=get_llm_router(), user_id=user.id
+    )
     loop = ChatAgentLoop(llm=get_llm_router(), tool_ctx=tool_ctx, history=history)
     req = ChatTurnRequest(
         conversation_id=conv.id,
         question=payload.question,
-        tool_names=tuple(payload.tool_names or DEFAULT_TOOL_NAMES),
+        tool_names=tool_names,
         max_rounds=payload.max_rounds,
         statement=payload.statement,
         skill_catalog=catalog,
@@ -206,6 +220,48 @@ async def run_turn(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+async def _resolve_project(
+    session: AsyncSession,
+    *,
+    user: User,
+    conv: Any,
+    requested: uuid.UUID | None,
+) -> uuid.UUID | None:
+    """定出这轮工具检索的课题作用域；``None`` = 没有课题，这轮不带工具纯对话。
+
+    此前这里是 ``conv.project_id or conv.scope_id or uuid.uuid4()``，两个都空时兜一个
+    **随机 UUID**——检索工具全按 project_id 过滤，于是助手在全局会话里永远查不到任何
+    东西，还会一本正经地说「没查到」。测试没抓住它，是因为循环测试用假工具（不看
+    project_id）、端点测试用不发工具调用的 fake，两层都绕开了「真工具 + 真作用域」。
+
+    解析顺序：本轮显式指定 → 会话上已存的 → scope 指向的课题 → 用户唯一的课题
+    （顺手存回会话，下轮不再解析）。每一步都做成员校验——课题成员资格是会变的，
+    存过不代表现在还有权。多于一个课题且没指定时 409，让前端弹选择，**绝不替用户猜**。
+    """
+    scoped = conv.scope_id if conv.scope_kind == "project" else None
+    for candidate in (requested, conv.project_id, scoped):
+        if candidate is None:
+            continue
+        if await projects_service.get_project(session, candidate, user.id) is not None:
+            if conv.project_id != candidate:
+                conv.project_id = candidate
+                await session.commit()
+            return candidate
+        if candidate == requested:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    mine = await projects_service.list_projects(session, user.id)
+    if len(mine) == 1:
+        conv.project_id = mine[0].id
+        await session.commit()
+        return mine[0].id
+    if not mine:
+        # 一个课题都没有的用户也该能纯聊天：这轮不带工具。悄悄降级成「检索不到」
+        # 是此前那个随机 UUID 的做法，绝不重蹈。
+        return None
+    # 多于一个且没指定：409 让前端弹选择，不替用户猜
+    raise HTTPException(status.HTTP_409_CONFLICT, detail="PROJECT_REQUIRED")
 
 
 async def _persist_answer(

--- a/src/backend/app/mcp/dispatch.py
+++ b/src/backend/app/mcp/dispatch.py
@@ -51,6 +51,7 @@ def tool_definitions() -> list[dict[str, Any]]:
             "inputSchema": _mcp_input_schema(spec.input_schema),
         }
         for spec in list_tools()
+        if spec.read_only  # 外部 MCP 客户端只拿只读工具，见下方注释
     ]
 
 
@@ -102,9 +103,14 @@ async def call_tool(
     if project is None:
         return _text_result("项目不存在或无权访问", is_error=True)
 
+    # allow_writes 保持默认 False：外部 MCP 客户端（Claude Desktop / Cursor）只有平台
+    # JWT，没有经过任何对话内审批，不该拿到写能力。上面的 tools/list 也只列只读工具，
+    # 两道一起才算数——只过滤清单挡不住知道名字直接调的。
     ctx = ToolContext(project_id=project_id, llm=get_llm_router(), user_id=user_id)
     try:
         result = await run_tool(ctx, name, args)
+    except PermissionError as e:
+        return _text_result(str(e), is_error=True)
     except ValueError as e:
         return _text_result(str(e), is_error=True)
     return _content_blocks(result)

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -31,6 +31,8 @@ class ConversationRead(BaseModel):
 
 class ConversationTurnRequest(BaseModel):
     question: str = Field(min_length=1)
+    #: 这轮工具检索的课题。全局会话第一次提问时带上；会话上存过就不用再传。
+    project_id: uuid.UUID | None = None
     #: 不给就用默认白名单（首期 6 个只读工具）
     tool_names: list[str] | None = None
     max_rounds: int = Field(default=8, ge=1, le=20)

--- a/src/backend/app/tools/__init__.py
+++ b/src/backend/app/tools/__init__.py
@@ -6,6 +6,7 @@
 """
 
 from app.tools import (
+    agentic_search,  # noqa: F401
     external,  # noqa: F401 — 导入即注册工具
     figures,  # noqa: F401
     knowledge,  # noqa: F401
@@ -13,6 +14,7 @@ from app.tools import (
     literature,  # noqa: F401
     project_state,  # noqa: F401
     skills,  # noqa: F401
+    subagent,  # noqa: F401
     workspace,  # noqa: F401
     writing,  # noqa: F401
 )

--- a/src/backend/app/tools/agentic_search.py
+++ b/src/backend/app/tools/agentic_search.py
@@ -1,0 +1,174 @@
+"""Agentic search 的两个原语：廉价宽扫 + 字面 grep。
+
+Claude Code 的检索之所以好用，不在于"检索得准"，而在于**把宽度和深度拆成两轮**：
+先 grep 撒一网（每条命中就一行，可以看几十条），再对少数目标 read 完整内容。
+
+平台原有的 ``search_papers`` / ``search_chunks`` 都是一步到位的 top-k：一次调用就把
+片段正文塞回来，k 稍微大一点上下文就满了，所以模型只敢要 5 条——那等于回到了 RAG。
+这里补上缺的那一半：
+
+- :func:`scan_papers`：每篇只回 ``id + 标题 + 年份``，一行。k 可以到 50。
+- :func:`grep_fulltext`：字面匹配全文，返回**命中的那几行**而不是整段，带论文 id。
+
+深读仍然用现成的 ``read_fulltext(paper_id, query)``。
+"""
+
+import re
+from typing import Any
+
+from app.core.db import get_sessionmaker
+from app.services import chunks as chunks_service
+from app.services import papers as papers_service
+from app.services.embedding import embed_query
+from app.services.libraries import get_source_library_ids
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+#: grep 每条命中回多少字符的上下文（前后各一半）
+_GREP_WINDOW = 160
+#: 每篇论文最多回几条命中，免得一篇刷屏
+_GREP_PER_PAPER = 3
+
+
+@tool(
+    name="scan_papers",
+    description=(
+        "宽扫：按查询词列出可能相关的论文，每篇只给标题和年份，不给摘要。"
+        "开销很小，可以一次要几十篇。建议先用它铺开看语料里有什么，"
+        "再用 read_fulltext 或 read_wiki 对其中少数几篇深读。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "检索词"},
+            "k": {"type": "integer", "description": "最多返回几篇（默认 30，上限 50）"},
+            "mode": {"type": "string", "enum": ["keyword", "semantic"]},
+        },
+        "required": ["query"],
+    },
+    summarize=lambda a, r: f"宽扫 {a.get('query')} → {len(r.get('results') or [])} 篇",
+)
+async def scan_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    query = str(args.get("query") or "").strip()
+    if not query:
+        return {"error": "缺少 query"}
+    k = max(1, min(int(args.get("k") or 30), 50))
+    mode = str(args.get("mode") or "semantic")
+
+    async with get_sessionmaker()() as session:
+        rows: list[tuple[Any, float]] = []
+        used = "keyword"
+        if mode == "semantic" and papers_service.semantic_search_supported(session):
+            try:
+                vector, space = await embed_query(
+                    session, query, user_id=ctx.user_id, project_id=ctx.project_id
+                )
+                rows = await papers_service.semantic_search_papers(
+                    session,
+                    project_id=ctx.project_id,
+                    query_vector=vector,
+                    space=space,
+                    limit=k,
+                )
+                used = "semantic"
+            except Exception:  # noqa: BLE001 — 向量不可用就降级，别让宽扫整个失败
+                rows = []
+        if not rows:
+            rows = await papers_service.keyword_search_papers(
+                session, project_id=ctx.project_id, q=query, limit=k
+            )
+        # 一行一篇：标题 + 年份。**刻意不回 tldr/摘要**——回了就又变成 top-k RAG，
+        # k 也就不敢往大了要。
+        return {
+            "mode": used,
+            "count": len(rows),
+            "results": [
+                {"paper_id": str(p.id), "title": p.title, "year": p.year} for p, _ in rows
+            ],
+        }
+
+
+@tool(
+    name="grep_fulltext",
+    description=(
+        "在论文全文里做字面匹配，返回命中处前后的一小段文本，而不是整个片段。"
+        "适合查找确切的术语、模型名、数据集名或公式符号，这类查询上语义检索的准确率反而更低。"
+        "拿到 paper_id 之后用 read_fulltext 查看完整上下文。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "pattern": {"type": "string", "description": "要找的字面串（不是正则）"},
+            "k": {"type": "integer", "description": "最多返回几条命中（默认 20，上限 40）"},
+        },
+        "required": ["pattern"],
+    },
+    summarize=lambda a, r: f"grep {a.get('pattern')} → {r.get('count', 0)} 处",
+)
+async def grep_fulltext(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    pattern = str(args.get("pattern") or "").strip()
+    if not pattern:
+        return {"error": "缺少 pattern"}
+    k = max(1, min(int(args.get("k") or 20), 40))
+
+    async with get_sessionmaker()() as session:
+        library_ids = await get_source_library_ids(session, ctx.project_id)
+        rows = await chunks_service.keyword_search_chunks(
+            session,
+            library_ids=library_ids or None,
+            q=pattern,
+            limit=k * 4,  # 多取一些，下面按论文去重后再截断
+        )
+        titles = await _titles(session, [c.paper_id for c, _ in rows])
+
+    hits: list[dict[str, Any]] = []
+    per_paper: dict[Any, int] = {}
+    lowered = pattern.lower()
+    for chunk, _score in rows:
+        if len(hits) >= k:
+            break
+        seen = per_paper.get(chunk.paper_id, 0)
+        if seen >= _GREP_PER_PAPER:
+            continue
+        for line in _matching_windows(chunk.text or "", lowered):
+            hits.append(
+                {
+                    "paper_id": str(chunk.paper_id),
+                    "title": titles.get(chunk.paper_id),
+                    "excerpt": line,
+                }
+            )
+            per_paper[chunk.paper_id] = seen + 1
+            break
+    return {"pattern": pattern, "count": len(hits), "hits": hits}
+
+
+async def _titles(session: Any, paper_ids: list[Any]) -> dict[Any, str]:
+    from sqlalchemy import select
+
+    from app.models.paper import Paper
+
+    if not paper_ids:
+        return {}
+    rows = await session.execute(
+        select(Paper.id, Paper.title).where(Paper.id.in_(list(set(paper_ids))))
+    )
+    return dict(rows.all())
+
+
+def _matching_windows(text: str, lowered_pattern: str) -> list[str]:
+    """命中处前后各截一段，而不是把整个 chunk 回过去。
+
+    整段回等于把 grep 变回了 RAG——一次调用几千字符，k 就再也大不起来。
+    """
+    out: list[str] = []
+    haystack = text.lower()
+    start = haystack.find(lowered_pattern)
+    if start < 0:
+        return out
+    half = _GREP_WINDOW // 2
+    left = max(0, start - half)
+    right = min(len(text), start + len(lowered_pattern) + half)
+    excerpt = text[left:right].strip().replace("\n", " ")
+    out.append(re.sub(r"\s+", " ", excerpt))
+    return out

--- a/src/backend/app/tools/context.py
+++ b/src/backend/app/tools/context.py
@@ -27,3 +27,7 @@ class ToolContext:
     llm: LLMRouter
     user_id: uuid.UUID | None = None
     voyage_id: uuid.UUID | None = None
+    #: 允许执行会改数据的工具吗。**默认 False 是整套安全性的支点**——MCP、voyage 的
+    #: tool_loop、以及所有现存调用点因此自动保持只读，一行不用改。只有明确开了它的
+    #: 调用方（走完审批的对话轮次）才拿得到写能力。
+    allow_writes: bool = False

--- a/src/backend/app/tools/registry.py
+++ b/src/backend/app/tools/registry.py
@@ -35,6 +35,18 @@ class ToolResult:
     images: tuple[ToolImage, ...] = ()
 
 
+class ToolWriteDenied(PermissionError):
+    """要执行写工具，但这个上下文没有写权限。
+
+    正常路径上不该出现——写工具只会出现在明确开了 ``allow_writes`` 的会话里。它出现
+    就说明有条路径漏了检查（比如 MCP 那边没过滤只读），所以是硬失败而不是软降级。
+    """
+
+    def __init__(self, name: str) -> None:
+        self.tool_name = name
+        super().__init__(f"工具 {name!r} 会改数据，当前上下文只读")
+
+
 # handler 可返回纯 dict（文本）或 ToolResult（文本 + 图片）
 ToolReturn = dict[str, Any] | ToolResult
 ToolHandler = Callable[[ToolContext, dict[str, Any]], Awaitable[ToolReturn]]
@@ -130,6 +142,10 @@ async def run_tool(ctx: ToolContext, name: str, args: dict[str, Any]) -> ToolRet
         raise ValueError(f"未知工具：{name}（可用：{', '.join(sorted(_REGISTRY))}）")
     if not isinstance(args, dict):
         raise ValueError("工具参数必须是 JSON 对象")
+    if not spec.read_only and not ctx.allow_writes:
+        # 默认拒绝：调用方必须显式开写权限（且已经走完审批）。这条守卫让"忘了传
+        # allow_writes"的后果是拒绝执行，而不是静默改数据。
+        raise ToolWriteDenied(name)
     return await spec.handler(ctx, args)
 
 

--- a/src/backend/app/tools/skills.py
+++ b/src/backend/app/tools/skills.py
@@ -44,8 +44,8 @@ async def skill_load(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 @tool(
     name="skill_read_file",
     description=(
-        "读技能目录里的附件（模板、参考资料、示例代码）。"
-        "技能正文里提到某个文件时才用它，不要挨个试。"
+        "读技能目录里的附件，例如模板、参考资料或示例代码。"
+        "仅在技能正文里提到了某个文件时使用，不要逐个尝试路径。"
     ),
     input_schema={
         "type": "object",

--- a/src/backend/app/tools/subagent.py
+++ b/src/backend/app/tools/subagent.py
@@ -1,0 +1,123 @@
+"""子智能体：用自己的上下文干活，只把结论带回来。
+
+这是 Claude Code 拿"宽度"而不付上下文代价的核心手法。差别在哪：
+
+- 主 agent 自己扫 40 篇论文 → 40 条结果全部进它的历史，而且**此后每一轮都要重发**，
+  几轮之后上下文就被搜索结果占满了，真正的对话反而被挤出去。
+- 派个子 agent 去扫 → 那 40 条只存在于子 agent 的上下文里，用完即弃；父上下文里
+  留下的是一段结论。
+
+代价也要说清楚：子 agent 看不到父对话的历史（这正是它省上下文的原因），所以任务描述
+必须自足——"接着刚才那个"这种话它读不懂。这条写进了工具描述里，让模型自己知道。
+"""
+
+import logging
+from typing import Any
+
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+logger = logging.getLogger(__name__)
+
+#: 子 agent 的轮次上限。比主循环短：它是来干一件具体的事的，不是来聊天的。
+SUBAGENT_MAX_ROUNDS = 6
+
+#: 子 agent 默认能用的工具。**不含 run_subagent 自己**——不允许再派子 agent，
+#: 否则一个说不清的任务能递归炸开，而且父那边完全看不见发生了什么。
+SUBAGENT_TOOLS: tuple[str, ...] = (
+    "scan_papers",
+    "grep_fulltext",
+    "search_papers",
+    "search_chunks",
+    "get_paper",
+    "read_fulltext",
+    "read_wiki",
+    "list_concepts",
+    "get_concept",
+)
+
+_SYSTEM = """\
+你是一个子任务执行者。你会拿到一件具体的事，用工具把它查清楚，然后给出结论。
+
+要求：
+- **你看不到主对话的历史**，只有下面这一条任务描述。不要假设任何未给出的上下文；
+- 先用 scan_papers 铺开看有什么，再对少数几篇 read_fulltext 深读，不要一上来就深读；
+- 结论要自足：把关键事实、论文标题与 id 都写进去，因为调用你的人只看得到这段结论；
+- 查不到就说查不到，并说明你试过哪些查法。不要编。
+"""
+
+
+@tool(
+    name="run_subagent",
+    description=(
+        "派一个子智能体去完成一件独立的、需要大量检索的任务，只把结论带回来。"
+        "适用于会产生几十条中间结果的任务，例如梳理某个方向的相关工作、"
+        "找出所有使用了某个数据集的论文。那些中间结果不会进入当前对话，只有结论会。"
+        "注意：子智能体读不到当前对话的历史，任务描述必须自足。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "要它做什么。写成完整的一句话，不要使用指代当前对话的说法",
+            },
+            "max_rounds": {
+                "type": "integer",
+                "description": f"最多几轮（默认 {SUBAGENT_MAX_ROUNDS}）",
+            },
+        },
+        "required": ["task"],
+    },
+    summarize=lambda a, r: (
+        f"子任务：{str(a.get('task') or '')[:40]}…"
+        f"（{r.get('rounds', 0)} 轮、{r.get('tool_calls', 0)} 次工具）"
+    ),
+)
+async def run_subagent(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    task = str(args.get("task") or "").strip()
+    if not task:
+        return {"error": "缺少 task"}
+    max_rounds = max(1, min(int(args.get("max_rounds") or SUBAGENT_MAX_ROUNDS), 10))
+
+    # 函数内 import：循环反过来要用工具注册表，模块级 import 会成环
+    from app.agents.chat.events import DeltaEvent, DoneEvent, ErrorEvent, ToolResultEvent
+    from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
+    from app.core.llm.router import get_llm_router
+
+    loop = ChatAgentLoop(llm=get_llm_router(), tool_ctx=ctx)
+    req = ChatTurnRequest(
+        conversation_id=ctx.project_id,  # 子 agent 不落库，这里只是个占位标识
+        question=task,
+        tool_names=SUBAGENT_TOOLS,
+        max_rounds=max_rounds,
+        extra_system=_SYSTEM,
+    )
+
+    parts: list[str] = []
+    tool_calls = 0
+    trace: list[str] = []
+    stop_reason = "stop"
+    error: str | None = None
+    async for ev in loop.run(req):
+        if isinstance(ev, DeltaEvent):
+            parts.append(ev.text)
+        elif isinstance(ev, ToolResultEvent):
+            tool_calls += 1
+            trace.append(f"{ev.name}：{ev.summary}")
+        elif isinstance(ev, DoneEvent):
+            stop_reason = ev.stop_reason
+        elif isinstance(ev, ErrorEvent):
+            error = ev.detail
+
+    conclusion = "".join(parts).strip()
+    if error and not conclusion:
+        return {"error": error, "tool_calls": tool_calls}
+    return {
+        "conclusion": conclusion or "（子任务没有产出结论）",
+        "rounds": min(max_rounds, tool_calls + 1),
+        "tool_calls": tool_calls,
+        # 只回**摘要**不回中间结果：把它们带回来就等于没派子 agent
+        "trace": trace[:20],
+        "stop_reason": stop_reason,
+    }

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -169,3 +169,128 @@ async def test_an_unknown_scope_is_rejected(client, agent_on):
         "/api/chat/conversations", json={"scope_kind": "made-up"}, headers=headers
     )
     assert resp.status_code == 422
+
+
+# ---- 作用域解析：真工具、真检索，不用替身 ----
+#
+# 此前的两层测试都绕开了这条路径：循环测试用自己注册的假工具（不看 project_id），
+# 端点测试用不发工具调用的 FakeProvider。于是 project_id 兜随机 UUID 的 bug 安然
+# 通过了全部测试——助手调真工具永远查到零条，然后一本正经说「没查到」。
+# 这里用 POLARIS_FAKE_TOOL 标记驱动**真的 search_papers**，检索**真的落库论文**。
+
+
+async def _project_with_paper(client, headers, title: str) -> str:
+    from tests.conftest import add_paper
+
+    resp = await client.post(
+        "/api/projects", json={"name": f"proj-{title[:8]}", "statement": "agent"}, headers=headers
+    )
+    project_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title=title,
+            abstract=f"{title} abstract",
+            tldr="一句话",
+            year=2026,
+            status="included",
+        )
+        await session.commit()
+    return project_id
+
+
+async def test_the_assistant_actually_finds_papers_in_the_resolved_project(client, agent_on):
+    """全局会话 + 用户只有一个课题：自动解析作用域，真工具查得到真论文。"""
+    headers = await _headers(client, "agent-scope-real@example.com")
+    await _project_with_paper(client, headers, "Tree Search Planning Methods")
+
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    marker = 'POLARIS_FAKE_TOOL:search_papers:{"query": "Tree Search", "mode": "keyword"}'
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": f"查一下 planning\n{marker}"},
+        headers=headers,
+    ) as stream:
+        assert stream.status_code == 200
+        body = (await stream.aread()).decode()
+
+    events = _parse_sse(body)
+    results = [d for e, d in events if e == "tool_result"]
+    assert results, f"没有工具结果帧：{[e for e, _ in events]}"
+    assert results[0]["ok"] is True
+    assert "Tree Search Planning Methods" in results[0]["preview"], (
+        "真工具必须查到真论文。查到零条说明作用域又丢了"
+        f"——此前这里兜的是随机 UUID：{results[0]}"
+    )
+
+
+async def test_a_turn_with_no_resolvable_project_says_so_instead_of_searching_nothing(
+    client, agent_on
+):
+    """用户有多个课题且没指定：409 PROJECT_REQUIRED，让前端弹选择。
+
+    绝不替用户猜，也绝不再兜随机 UUID 假装在查。
+    """
+    headers = await _headers(client, "agent-scope-many@example.com")
+    for name in ("proj-a", "proj-b"):
+        await client.post(
+            "/api/projects", json={"name": name, "statement": "x"}, headers=headers
+        )
+
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    resp = await client.post(
+        f"/api/chat/conversations/{conv_id}/turn", json={"question": "hi"}, headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "PROJECT_REQUIRED"
+
+
+async def test_someone_elses_project_id_is_rejected_everywhere(client, agent_on):
+    """带别人的 project_id 一律 404——建会话和跑轮次两个口都要挡。
+
+    这是比随机 UUID 更严重的洞：不挡的话，助手会拿着别人的课题作用域去检索
+    **别人的语料**。MCP 那侧一直有成员校验，这个端点此前漏了。
+    """
+    owner = await _headers(client, "agent-authz-owner@example.com")
+    intruder = await _headers(client, "agent-authz-intruder@example.com")
+    project_id = await _project_with_paper(client, owner, "Secret Corpus Paper")
+
+    # 建会话时就挡
+    resp = await client.post(
+        "/api/chat/conversations", json={"project_id": project_id}, headers=intruder
+    )
+    assert resp.status_code == 404
+
+    # 跑轮次时显式传也挡
+    conv_id = (
+        await client.post("/api/chat/conversations", json={}, headers=intruder)
+    ).json()["id"]
+    resp = await client.post(
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "hi", "project_id": project_id},
+        headers=intruder,
+    )
+    assert resp.status_code == 404
+
+
+async def test_the_resolved_project_sticks_to_the_conversation(client, agent_on):
+    """解析出的课题存回会话：第二轮不用再传，也不再走解析。"""
+    headers = await _headers(client, "agent-scope-stick@example.com")
+    project_id = await _project_with_paper(client, headers, "Sticky Scope Paper")
+
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "第一轮", "project_id": project_id},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    from app.models.conversation import Conversation
+
+    async with get_sessionmaker()() as session:
+        conv = await session.get(Conversation, uuid.UUID(conv_id))
+        assert str(conv.project_id) == project_id, "第一轮解析出的课题要存回会话"

--- a/src/backend/tests/test_subagent_and_search.py
+++ b/src/backend/tests/test_subagent_and_search.py
@@ -1,0 +1,263 @@
+"""子智能体 + agentic search 的两个原语，以及技能收窄的接线。
+
+这三件事对齐的是 Claude Code 里最实际的两条：**宽度与深度分两轮**，以及**派子 agent
+去烧它自己的上下文**。
+"""
+
+import json
+import uuid
+
+import pytest
+
+from app.agents.chat.events import DeltaEvent
+from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
+from app.core.llm.fake import FakeProvider
+from app.core.llm.router import LLMRouter
+from app.tools.context import ToolContext
+from app.tools.registry import get_tool, tool
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tool_registry():
+    """测试注册的工具用完即撤——@tool 写的是全局注册表，泄漏出去会进 MCP 的清单。"""
+    from app.tools import registry
+
+    before = dict(registry._REGISTRY)
+    yield
+    registry._REGISTRY.clear()
+    registry._REGISTRY.update(before)
+
+
+class _ScriptedRouter(LLMRouter):
+    def __init__(self, provider: FakeProvider) -> None:
+        super().__init__()
+        self._provider = provider
+
+    async def stream_events(self, stage, messages, **kwargs):  # noqa: ANN001, ANN003
+        self.last_tools = [t["name"] for t in (kwargs.get("tools") or [])]
+        async for ev in self._provider.stream_events(
+            messages,
+            model="fake",
+            tools=kwargs.get("tools"),
+            tool_choice=kwargs.get("tool_choice"),
+        ):
+            yield ev
+
+
+def _loop(provider: FakeProvider, **kw):
+    ctx = ToolContext(project_id=uuid.uuid4(), llm=LLMRouter(), user_id=uuid.uuid4())
+    return ChatAgentLoop(llm=_ScriptedRouter(provider), tool_ctx=ctx, **kw)
+
+
+# ---- agentic search：宽扫刻意不带摘要 ----
+
+
+def test_scan_returns_one_line_per_paper_not_snippets():
+    """宽扫每篇只给标题和年份。
+
+    回了摘要就又变成 top-k RAG——k 也就不敢往大了要，而"能一次看 50 篇"正是它存在的
+    理由。这条用 schema 与描述来钉：它承诺的就是便宜。
+    """
+    spec = get_tool("scan_papers")
+    assert spec is not None and spec.read_only
+    props = spec.input_schema["properties"]
+    assert props["k"]["type"] == "integer"
+    assert "不给摘要" in spec.description
+    assert "50" in props["k"]["description"]
+
+
+def test_grep_returns_excerpts_not_whole_chunks():
+    """grep 回命中处前后一小段，不是整个 chunk。"""
+    from app.tools.agentic_search import _GREP_WINDOW, _matching_windows
+
+    text = "前面很多字。" * 50 + "这里出现了 GRPO 这个词。" + "后面也很多字。" * 50
+    hits = _matching_windows(text, "grpo")
+    assert len(hits) == 1
+    assert "GRPO" in hits[0]
+    assert len(hits[0]) <= _GREP_WINDOW + 40, "不能把整段回过去"
+
+    assert _matching_windows("完全无关的文本", "grpo") == []
+
+
+# ---- 子 agent：中间结果不进父上下文 ----
+
+
+@pytest.mark.asyncio
+async def test_subagent_keeps_its_intermediate_results_out_of_the_parent():
+    """父那边只看到一条结论，子 agent 扫过的东西不进父历史。
+
+    这是子 agent 存在的**全部理由**：主 agent 自己扫 40 篇的话，那 40 条结果此后每轮
+    都要重发，几轮之内上下文就被搜索结果占满。
+    """
+    scanned: list[str] = []
+
+    # 先摘掉真工具再放替身：注册表拒绝重名（这是对的，重名注册一定是 bug），
+    # 而 fixture 会在测试结束时把整张表还原。
+    from app.tools import registry as registry_mod
+
+    registry_mod._REGISTRY.pop("scan_papers", None)
+
+    @tool(
+        name="scan_papers",  # 替身：避免碰数据库
+        description="宽扫",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    async def _scan(ctx, args):  # noqa: ANN001
+        scanned.append(args.get("query", ""))
+        # 故意回一大坨：如果它进了父上下文，下面的断言会抓到
+        return {
+            "results": [
+                {"paper_id": str(uuid.uuid4()), "title": f"论文 {i}"} for i in range(40)
+            ]
+        }
+
+    # 子 agent 内部：先扫一次，再给结论
+    child = FakeProvider()
+    child.script([[("scan_papers", {"query": "planning"})], "扫了 40 篇，主流是树搜索。"])
+
+    from app.core.llm import router as router_mod
+    from app.tools import subagent as subagent_mod
+
+    # 让子 agent 用脚本化的 provider
+    original = router_mod.get_llm_router
+    router_mod.get_llm_router = lambda: _ScriptedRouter(child)  # type: ignore[assignment]
+    try:
+        ctx = ToolContext(project_id=uuid.uuid4(), llm=LLMRouter(), user_id=uuid.uuid4())
+        result = await subagent_mod.run_subagent(ctx, {"task": "梳理 planning 的相关工作"})
+    finally:
+        router_mod.get_llm_router = original  # type: ignore[assignment]
+
+    assert scanned == ["planning"], "子 agent 真的去查了"
+    assert "树搜索" in result["conclusion"]
+    assert result["tool_calls"] == 1
+    # 结论里不该夹带 40 条中间结果
+    blob = json.dumps(result, ensure_ascii=False)
+    assert blob.count("论文 ") <= 1, "中间结果不能跟着结论回到父上下文"
+    assert len(blob) < 2000, f"回给父的东西必须是小的，实际 {len(blob)}"
+
+
+@pytest.mark.asyncio
+async def test_subagent_cannot_spawn_another_subagent():
+    """子 agent 的工具清单里没有 run_subagent——递归派发会炸开且父完全看不见。"""
+    from app.tools.subagent import SUBAGENT_TOOLS
+
+    assert "run_subagent" not in SUBAGENT_TOOLS
+    assert "scan_papers" in SUBAGENT_TOOLS and "read_fulltext" in SUBAGENT_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_subagent_reports_a_missing_task_instead_of_running():
+    ctx = ToolContext(project_id=uuid.uuid4(), llm=LLMRouter(), user_id=uuid.uuid4())
+    from app.tools.subagent import run_subagent
+
+    assert "error" in await run_subagent(ctx, {"task": "  "})
+
+
+# ---- 技能收窄：接线是否真的生效 ----
+
+
+@pytest.mark.asyncio
+async def test_a_loaded_skill_narrows_the_tools_for_later_rounds():
+    """技能声明 allowed-tools 之后，后续轮次的工具清单真的变窄了。
+
+    之前 narrow_tools 写好了但**没接进循环**，所以 allowed-tools 只是装饰。
+    """
+    @tool(
+        name="_fake_skill_load",
+        description="加载技能",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _load(ctx, args):  # noqa: ANN001
+        return {"slug": "triage", "body": "...", "allowed_tools": ["_probe_keep"]}
+
+    @tool(name="_probe_keep", description="留下", input_schema={"type": "object", "properties": {}})
+    async def _keep(ctx, args):  # noqa: ANN001
+        return {"ok": True}
+
+    @tool(
+        name="_probe_drop",
+        description="被收窄掉",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _drop(ctx, args):  # noqa: ANN001
+        return {"ok": True}
+
+    provider = FakeProvider()
+    provider.script([[("_fake_skill_load", {})], [("_probe_keep", {})], "好了。"])
+    loop = _loop(provider)
+    router = loop._llm  # type: ignore[attr-defined]
+
+    events = [
+        ev
+        async for ev in loop.run(
+            ChatTurnRequest(
+                conversation_id=uuid.uuid4(),
+                question="q",
+                tool_names=("_fake_skill_load", "_probe_keep", "_probe_drop"),
+            )
+        )
+    ]
+
+    assert any(isinstance(e, DeltaEvent) for e in events)
+    # 最后一轮送给模型的工具清单里，被技能排除的那个已经没了
+    assert "_probe_keep" in router.last_tools
+    assert "_probe_drop" not in router.last_tools, "技能的 allowed-tools 没有生效"
+
+
+@pytest.mark.asyncio
+async def test_a_skill_cannot_widen_the_tool_set():
+    """技能里写一个会话没给的工具名，不会把它加进来。"""
+    @tool(
+        name="_fake_skill_greedy",
+        description="贪心技能",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _greedy(ctx, args):  # noqa: ANN001
+        return {"allowed_tools": ["_probe_keep", "delete_everything"]}
+
+    @tool(name="_probe_keep", description="留下", input_schema={"type": "object", "properties": {}})
+    async def _keep(ctx, args):  # noqa: ANN001
+        return {"ok": True}
+
+    provider = FakeProvider()
+    provider.script([[("_fake_skill_greedy", {})], "好了。"])
+    loop = _loop(provider)
+    router = loop._llm  # type: ignore[attr-defined]
+
+    async for _ in loop.run(
+        ChatTurnRequest(
+            conversation_id=uuid.uuid4(),
+            question="q",
+            tool_names=("_fake_skill_greedy", "_probe_keep"),
+        )
+    ):
+        pass
+
+    assert "delete_everything" not in router.last_tools
+    assert "_probe_keep" in router.last_tools
+
+
+@pytest.mark.asyncio
+async def test_a_skill_with_a_wrong_tool_name_does_not_mute_the_assistant():
+    """技能把工具名写错、交集为空时不生效——否则助手会突然变成哑巴。"""
+    @tool(
+        name="_fake_skill_typo",
+        description="写错名字的技能",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def _typo(ctx, args):  # noqa: ANN001
+        return {"allowed_tools": ["serch_papers"]}  # 拼错
+
+    provider = FakeProvider()
+    provider.script([[("_fake_skill_typo", {})], "好了。"])
+    loop = _loop(provider)
+    router = loop._llm  # type: ignore[attr-defined]
+
+    async for _ in loop.run(
+        ChatTurnRequest(
+            conversation_id=uuid.uuid4(), question="q", tool_names=("_fake_skill_typo",)
+        )
+    ):
+        pass
+
+    assert router.last_tools, "交集为空时应保持原样，而不是把工具全砍光"


### PR DESCRIPTION
Three things that move the harness from "runs" toward "works like Claude Code", plus the defensive groundwork for write tools (with **no write tools included**).

## Subagents (`run_subagent`)

The entire value is measured directly by the test: the parent must not inherit the child's intermediate results. If the main agent scans 40 papers itself, those 40 rows enter its history and are **re-sent every subsequent round** — a few rounds later the context is all search results. A subagent burns its own context and hands back one conclusion; the test has the child scan 40 titles and asserts the JSON returned to the parent stays under 2 000 characters.

Costs are stated in the tool description rather than hidden: the subagent cannot see the parent conversation (that is precisely why it saves context), so task descriptions must be self-contained. Its tool list does not include `run_subagent` itself — no recursive spawning.

## Agentic search primitives

The existing `search_papers` / `search_chunks` are one-shot top-k: one call returns snippet bodies, so any large k floods the context and the model only dares ask for 5 — which is RAG again. What was missing is the cheap half of Claude Code's grep→read discipline:

- `scan_papers` — one line per paper (title + year, **deliberately no abstract**), k up to 50.
- `grep_fulltext` — literal match over full text, returning a ~160-char window around the hit, not the whole chunk. Semantic search is actively worse for exact terms, model names, dataset names.

Depth stays with the existing `read_fulltext`.

## Skill `allowed-tools` actually wired

`narrow_tools()` existed but nothing called it — the narrowing was decorative. Now, from the round after a skill loads, the tool list really shrinks; it can only narrow, never widen (pinned with `delete_everything`); and an empty intersection is ignored, because a typo in a skill must not mute the assistant.

## Write-guard groundwork (no write tools yet)

- `ToolContext.allow_writes` defaults to `False` — MCP, the voyage tool loop, and every existing call site stay read-only without touching a line.
- `run_tool` hard-rejects non-read-only tools when the flag is off (`ToolWriteDenied`).
- MCP's `tools/list` now filters to read-only **and** `call_tool` constructs an explicitly read-only context — both are needed; filtering the list alone does not stop a client that knows a name.

This closes the hole #255 demonstrated empirically when test tools leaked into the MCP list.

## Caught by an existing contract

#250 forbids dashes in tool descriptions (they glue a capability boundary to a colloquial aside; the model reads tone instead of scope). All three new descriptions violated it and the suite caught them. Rewritten.

## Tests

8 new: the scan's one-line contract, grep's window bound, the subagent context-isolation measurement, no recursive spawning, missing-task handling, narrowing takes effect / cannot widen / empty intersection ignored. Full suite **1040 passed** (one flake of the known #234-family time-window test passed alone on rerun).