### PR TITLE
feat(skills): builtin seeds, a management API, and the assistant panel's missing half

### DIFF
--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -42,6 +42,7 @@ from app.schemas.chat_agent import (
     ConversationRead,
     ConversationTurnRequest,
     MessageRead,
+    SkillImportRequest,
 )
 from app.services import agent_skills
 from app.services import conversations as store
@@ -146,6 +147,62 @@ async def list_messages(
         .all()
     )
     return [MessageRead.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.get("/skills")
+async def list_skills(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[dict[str, Any]]:
+    """我能看到的技能：内置的 + 自己的。目录预算有限，界面上要能看到谁占着位置。"""
+    _require_enabled()
+    from app.models.agent_skill import as_dict
+
+    rows = await agent_skills.visible_skills(session, user_id=user.id)
+    return [as_dict(r) | {"is_builtin": r.scope == "builtin"} for r in rows]
+
+
+@router.post("/skills", status_code=201)
+async def import_skill(
+    payload: SkillImportRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """从 SKILL.md 建/更新自己的技能（同 slug 覆盖自己的那份，碰不到内置的）。"""
+    _require_enabled()
+    from app.models.agent_skill import as_dict
+    from app.services.agent_skills import SkillParseError
+
+    try:
+        skill = await agent_skills.upsert_from_md(
+            session, text=payload.skill_md, user_id=user.id, files=payload.files or {}
+        )
+    except SkillParseError as e:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+    await session.commit()
+    return as_dict(skill)
+
+
+@router.delete("/skills/{slug}", status_code=204)
+async def delete_skill(
+    slug: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """删自己的技能。内置技能删不掉（404）：它是代码的一部分，想改就导入同名覆盖不了、
+    只能建自己的。"""
+    _require_enabled()
+    from sqlalchemy import select as _select
+
+    from app.models.agent_skill import AgentSkill
+
+    row = await session.scalar(
+        _select(AgentSkill).where(AgentSkill.slug == slug, AgentSkill.owner_id == user.id)
+    )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SKILL_NOT_FOUND")
+    await session.delete(row)
+    await session.commit()
 
 
 @router.post("/conversations/{conversation_id}/turn")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -15,6 +15,7 @@ from app.core.db import create_all, dispose_engine, get_sessionmaker
 from app.core.llm.router import LLMNotConfiguredError
 from app.core.redis import close_redis
 from app.mcp import mcp_router
+from app.services.builtin_agent_skills import ensure_builtin_agent_skills
 from app.services.crdt_rooms import reset_crdt_rooms
 from app.services.crdt_stream import get_crdt_stream_subscriber, stop_crdt_stream_subscriber
 from app.services.skills import ensure_builtin_skills
@@ -37,6 +38,7 @@ async def lifespan(app: FastAPI):
     try:
         async with get_sessionmaker()() as session:
             await ensure_builtin_skills(session)
+            await ensure_builtin_agent_skills(session)
     except Exception:  # noqa: BLE001
         logger.warning("builtin skill seeding failed (migrations pending?)", exc_info=True)
     # AI 起草流式镜像订阅（worker 发布 → 写活跃 CRDT 房间；连不上 redis 自动放弃）

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -51,3 +51,10 @@ class MessageRead(BaseModel):
     usage: dict[str, Any] | None = None
     stop_reason: str | None = None
     created_at: datetime
+
+
+class SkillImportRequest(BaseModel):
+    """从 SKILL.md 导入技能。files 是附件（相对路径 → 文本内容）。"""
+
+    skill_md: str = Field(min_length=1)
+    files: dict[str, str] | None = None

--- a/src/backend/app/services/agent_skills.py
+++ b/src/backend/app/services/agent_skills.py
@@ -206,10 +206,13 @@ async def upsert_from_md(
 ) -> AgentSkill:
     """从 SKILL.md 建/更新一个技能（同 slug 覆盖）。"""
     parsed = parse_skill_md(text)
+    # owner_id 为 None（内置技能）时必须用 IS NULL：`owner_id == None` 翻成 SQL 是
+    # `owner_id = NULL`，永远为假——那样每次启动种子都会重复插入一份。
+    owner_clause = (
+        AgentSkill.owner_id.is_(None) if user_id is None else AgentSkill.owner_id == user_id
+    )
     existing = await session.scalar(
-        select(AgentSkill).where(
-            AgentSkill.slug == parsed["slug"], AgentSkill.owner_id == user_id
-        )
+        select(AgentSkill).where(AgentSkill.slug == parsed["slug"], owner_clause)
     )
     skill = existing or AgentSkill(slug=parsed["slug"], owner_id=user_id, scope=scope)
     skill.name = parsed["name"]

--- a/src/backend/app/services/builtin_agent_skills.py
+++ b/src/backend/app/services/builtin_agent_skills.py
@@ -1,0 +1,173 @@
+"""助手的内置技能种子。
+
+写这些种子时只有一条纪律：**description 是触发条件，不是功能介绍**。它是目录里常驻
+system prompt 的唯一内容，模型全凭它判断这次要不要 skill_load。写成"这是什么"而不是
+"什么时候用"，技能就永远不会被加载——渐进披露的成败全在这一句上。
+
+数量刻意少：目录每轮都要重发，五个写得好的胜过十四个凑数的。
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.agent_skills import upsert_from_md
+
+#: (SKILL.md 文本, 附件)。附件是给模型抄的模板，不是可执行的东西。
+BUILTIN_AGENT_SKILLS: list[tuple[str, dict[str, str]]] = [
+    (
+        """\
+---
+name: polaris-search-playbook
+description: >
+  在平台里检索文献时使用：分不清该用 scan_papers、grep_fulltext、search_papers
+  还是 search_chunks，或一次检索返回空、需要换打法再试时，先加载本技能。
+invocation: auto
+---
+
+# 检索工具选型
+
+四个检索工具各管一段，选错了既费钱又查不到：
+
+- **scan_papers**：不知道语料里有什么时先用它铺开。每篇只回标题和年份，一次可以看
+  50 篇。它是地图，不是答案。
+- **grep_fulltext**：找确切的字面串（模型名、数据集名、公式符号、特定短语）。语义
+  检索对这类查询反而不准。
+- **search_papers**：按意思找"哪几篇讲了 X"。回 TL;DR，适合从题意收敛到 3~5 篇。
+- **search_chunks**：已经知道要什么、想拿能引用的原文段落时用。粒度最细也最贵。
+
+节奏：宽（scan / grep）→ 收敛（search_papers）→ 深读（read_fulltext / read_wiki）。
+跳过宽扫直接深读，容易在错的论文上花光轮次。
+
+空结果的处理：换同义词再试一次（中英文都试）；关键词模式与语义模式互换再试一次；
+两轮都空就如实说没查到，并报告试过的查法。不要用第三种说法反复试到轮次耗尽。
+""",
+        {},
+    ),
+    (
+        """\
+---
+name: literature-triage
+description: >
+  用户要求批量判断一批论文与方向的相关性时使用：例如"帮我筛一下这批论文"、
+  "这些跟我的方向相关吗"、"每日推送里哪些值得看"。
+allowed-tools: [scan_papers, search_papers, get_paper, read_wiki]
+invocation: auto
+---
+
+# 文献初筛
+
+逐篇给出「保留 / 存疑 / 剔除」三档结论，而不是每篇写一段读后感。
+
+流程：
+
+1. 先确认方向说明（research statement）。用户没给就先问，不要拿论文标题反推方向。
+2. 对每篇：标题与 TL;DR 能定档的直接定档；定不了的才 read_wiki 看解读。
+   **不要逐篇读全文**——初筛的价值就在快。
+3. 输出一张表：标题、档位、一句话理由。存疑的单独说明缺什么信息才能定档。
+
+判据优先级：研究对象是否吻合 > 方法是否在方向关心的类型里 > 仅仅共享关键词。
+只有关键词重叠的一律存疑，不要保留。
+""",
+        {},
+    ),
+    (
+        """\
+---
+name: paper-deep-read
+description: >
+  用户要求认真读一篇论文并给出结构化解读时使用：例如"帮我精读这篇"、
+  "这篇的方法到底是什么"、"这篇和我们的做法有什么区别"。
+allowed-tools: [get_paper, read_fulltext, read_wiki, get_concept, grep_fulltext]
+invocation: auto
+---
+
+# 单篇精读
+
+按 `template.md` 的结构组织产出。要点：
+
+- 先 read_wiki 看有没有现成解读；有就以它为骨架，用 read_fulltext 补关键细节，
+  不要从零重读。
+- 方法部分必须给出**机制**（怎么做到的），不是复述贡献列表（做到了什么）。
+- 实验部分挑主结果表：基线是谁、提升多少、哪个消融最说明问题。
+- 与用户方向的关系单独成段，没有把握就明说"从摘要看不出关联"。
+- 引用原文时用 grep_fulltext 定位原句，不要凭记忆转述数字。
+""",
+        {
+            "template.md": """\
+# {论文标题}
+
+## 一句话
+（它解决什么问题、用什么办法、效果如何）
+
+## 方法机制
+（关键设计怎么工作，配公式或流程；不是贡献列表）
+
+## 主要证据
+（主结果表：基线、提升幅度、最有说服力的消融）
+
+## 局限与开放问题
+
+## 与你方向的关系
+（对得上就说对在哪；对不上就明说）
+""",
+        },
+    ),
+    (
+        """\
+---
+name: citation-hygiene
+description: >
+  回答里需要引用论文、给出数字或结论出处时使用；用户质疑"这个说法哪来的"
+  或要求核对引用时也加载。
+invocation: auto
+---
+
+# 引用纪律
+
+- 每个论文相关的事实陈述都要能落到具体论文：句末标 [n]，n 是本轮工具结果里的论文。
+- **数字必须来自工具结果**。检索结果里没有的数字不要写——宁可说"原文未给出具体数值"。
+- 分清三种话并让读者也分得清：论文说的、多篇论文综合出的、你自己的判断。
+- 工具没查到某篇论文时，不要凭训练记忆补它的内容；明说"库里没有这篇"。
+- 用户质疑出处时：用 grep_fulltext 找到原句贴出来，找不到就撤回该陈述。
+""",
+        {},
+    ),
+    (
+        """\
+---
+name: research-landscape
+description: >
+  用户要求梳理一个方向的全貌时使用：例如"这个方向的相关工作有哪些"、
+  "帮我做个小综述"、"最近这个领域有什么进展"。这类任务应优先派子智能体。
+allowed-tools: [run_subagent, scan_papers, search_papers, get_concept, list_concepts]
+invocation: auto
+---
+
+# 方向梳理
+
+这类任务会产生几十条中间检索结果，**直接派 run_subagent**，不要自己逐篇扫——
+中间结果会占满我们的对话上下文，后面几轮全在重发它们。
+
+给子智能体的任务描述要自足（它看不到本对话），必须包含：方向的完整描述、期望的
+产出结构（按主题分组，每组给代表论文的标题与 id）、以及范围限制（只看库内还是
+含库外）。
+
+拿到结论后：按主题组织答案，每个主题给 2~3 篇代表作并标 [n]；说明这是基于库内
+语料的梳理，库外可能另有工作。
+""",
+        {},
+    ),
+]
+
+
+async def ensure_builtin_agent_skills(session: AsyncSession) -> int:
+    """幂等种入内置技能（按 slug；已存在则更新正文——种子是代码的一部分，跟着代码走）。
+
+    与旧系统"已存在不覆盖"不同：这些种子没有用户改动可保护（内置技能只读，想改就
+    fork），落后的种子只会误导模型。
+    """
+    count = 0
+    for md, files in BUILTIN_AGENT_SKILLS:
+        await upsert_from_md(session, text=md, user_id=None, scope="builtin", files=files)
+        count += 1
+    await session.commit()
+    return count

--- a/src/backend/tests/test_agent_skills.py
+++ b/src/backend/tests/test_agent_skills.py
@@ -230,3 +230,117 @@ async def test_skill_load_tool_reports_a_missing_skill_instead_of_raising(client
     ctx = ToolContext(project_id=uuid.uuid4(), llm=get_llm_router(), user_id=user_id)
     result = await skill_load(ctx, {"slug": "not-there"})
     assert "error" in result
+
+
+# ---- 内置种子与管理 API ----
+
+
+async def test_builtin_seeding_is_idempotent(client):
+    """种子跑两遍不重复。
+
+    第一版 upsert_from_md 里 `owner_id == user_id` 在 user_id=None 时翻成 SQL 是
+    `owner_id = NULL`，永远为假——查重必落空，每次启动都会再插一份。修法是 IS NULL。
+    """
+    from sqlalchemy import func, select
+
+    from app.models.agent_skill import AgentSkill
+    from app.services.builtin_agent_skills import ensure_builtin_agent_skills
+
+    async with get_sessionmaker()() as session:
+        first = await ensure_builtin_agent_skills(session)
+        await ensure_builtin_agent_skills(session)
+        total = await session.scalar(
+            select(func.count()).select_from(AgentSkill).where(AgentSkill.scope == "builtin")
+        )
+    assert first >= 5
+    assert total == first, f"跑两遍出现重复：{total} != {first}"
+
+
+async def test_builtin_skills_appear_in_the_catalog(client):
+    """种完之后目录不再是空的——渐进披露的 L1 真的有货了。"""
+    from app.services.builtin_agent_skills import ensure_builtin_agent_skills
+
+    user_id = await _user_id(client, "seed-catalog@example.com")
+    async with get_sessionmaker()() as session:
+        await ensure_builtin_agent_skills(session)
+        catalog = await agent_skills.render_catalog(session, user_id=user_id)
+
+    assert "polaris-search-playbook" in catalog
+    assert "literature-triage" in catalog
+    # 目录里是触发条件，不是正文
+    assert "检索工具选型" not in catalog
+
+
+async def test_seed_bodies_update_when_the_code_changes(client):
+    """种子跟代码走：正文变了重新种就该更新，落后的种子只会误导模型。"""
+    from sqlalchemy import select
+
+    from app.models.agent_skill import AgentSkill
+    from app.services import builtin_agent_skills as seeds
+
+    async with get_sessionmaker()() as session:
+        await seeds.ensure_builtin_agent_skills(session)
+        row = await session.scalar(
+            select(AgentSkill).where(
+                AgentSkill.slug == "citation-hygiene", AgentSkill.owner_id.is_(None)
+            )
+        )
+        row.body = "过时的旧正文"
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        await seeds.ensure_builtin_agent_skills(session)
+        row = await session.scalar(
+            select(AgentSkill).where(
+                AgentSkill.slug == "citation-hygiene", AgentSkill.owner_id.is_(None)
+            )
+        )
+    assert "过时的旧正文" not in row.body
+    assert "引用纪律" in row.body
+
+
+async def test_skill_api_import_list_delete(client, monkeypatch):
+    """管理 API 的最小闭环：导入 → 列表可见 → 删除；内置的删不掉。"""
+    import os
+
+    from app.core.config import get_settings
+
+    monkeypatch.setenv("POLARIS_CHAT_AGENT_ENABLED", "true")
+    get_settings.cache_clear()
+    try:
+        token = await register_and_login(client, email="skill-api@example.com")
+        headers = {"Authorization": f"Bearer {token}"}
+        md = SKILL_MD.replace("literature-triage", "my-own-skill")
+        resp = await client.post(
+            "/api/chat/skills",
+            json={"skill_md": md, "files": {"note.md": "备注"}},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["slug"] == "my-own-skill"
+
+        listed = (await client.get("/api/chat/skills", headers=headers)).json()
+        mine = [s for s in listed if s["slug"] == "my-own-skill"]
+        assert mine and mine[0]["is_builtin"] is False
+
+        # 坏 frontmatter 422 并带原因
+        bad = await client.post(
+            "/api/chat/skills", json={"skill_md": "没有 frontmatter"}, headers=headers
+        )
+        assert bad.status_code == 422
+
+        assert (
+            await client.delete("/api/chat/skills/my-own-skill", headers=headers)
+        ).status_code == 204
+        # 内置的删不掉
+        from app.core.db import get_sessionmaker as gsm
+        from app.services.builtin_agent_skills import ensure_builtin_agent_skills
+
+        async with gsm()() as session:
+            await ensure_builtin_agent_skills(session)
+        assert (
+            await client.delete("/api/chat/skills/citation-hygiene", headers=headers)
+        ).status_code == 404
+    finally:
+        os.environ.pop("POLARIS_CHAT_AGENT_ENABLED", None)
+        get_settings.cache_clear()

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -21,6 +21,30 @@ interface Turn {
   blocks: AssistantBlock[];
 }
 
+/** 服务端持久化的块 → 前端块。认不出的形状一律降级成文本，绝不抛。 */
+function restoreBlocks(m: { text: string; blocks: unknown[] }): AssistantBlock[] {
+  const out: AssistantBlock[] = [];
+  for (const raw of Array.isArray(m.blocks) ? m.blocks : []) {
+    if (!raw || typeof raw !== 'object') continue;
+    const b = raw as Record<string, unknown>;
+    if (b.kind === 'text' && typeof b.text === 'string') {
+      out.push({ kind: 'text', text: b.text });
+    } else if (b.kind === 'thinking' && typeof b.text === 'string') {
+      out.push({ kind: 'thinking', text: b.text });
+    } else if (b.kind === 'tool_use') {
+      out.push({
+        kind: 'tool',
+        id: String(b.id ?? ''),
+        name: String(b.name ?? '?'),
+        state: 'ok',
+      });
+    }
+    // tool_result 等其余块不单独渲染：它们是模型的输入，不是回答的一部分
+  }
+  if (out.length === 0 && m.text) out.push({ kind: 'text', text: m.text });
+  return out;
+}
+
 function ToolCard({ block }: { block: Extract<AssistantBlock, { kind: 'tool' }> }) {
   const [open, setOpen] = useState(false);
   const color =
@@ -100,6 +124,10 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [convId, setConvId] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [conversations, setConversations] = useState<
+    { id: string; title: string }[]
+  >([]);
   const abortRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -108,6 +136,48 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
   }, [turns]);
 
   useEffect(() => () => abortRef.current?.(), []);
+
+  const stop = useCallback(() => {
+    // 掐掉 SSE 连接。后端会把已生成的部分落库标成 interrupted，重开会话还能看到。
+    abortRef.current?.();
+    abortRef.current = null;
+    setBusy(false);
+  }, []);
+
+  const openHistory = useCallback(async () => {
+    setHistoryOpen((o) => !o);
+    try {
+      setConversations(await api.listAssistantConversations());
+    } catch {
+      setConversations([]);
+    }
+  }, []);
+
+  const loadConversation = useCallback(async (id: string) => {
+    // 服务端才是历史的权威源：本地状态直接整体替换
+    try {
+      const messages = await api.getAssistantMessages(id);
+      setConvId(id);
+      setHistoryOpen(false);
+      setTurns(
+        messages
+          .filter((m) => m.role === 'user' || m.role === 'assistant')
+          .map((m) => ({
+            role: m.role as 'user' | 'assistant',
+            blocks: restoreBlocks(m),
+          })),
+      );
+    } catch {
+      /* 载入失败保持现状 */
+    }
+  }, []);
+
+  const newConversation = useCallback(() => {
+    stop();
+    setConvId(null);
+    setTurns([]);
+    setHistoryOpen(false);
+  }, [stop]);
 
   const send = useCallback(async () => {
     const question = input.trim();
@@ -173,10 +243,61 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
         <Icon name="chat" size={15} style={{ color: 'var(--accent)' }} />
         <strong style={{ fontSize: 14 }}>{tr('Polaris 助手', 'Polaris assistant')}</strong>
         <span style={{ flex: 1 }} />
+        {busy && (
+          <button className="btn btn-ghost sm" onClick={stop} style={{ height: 24, fontSize: 11 }}>
+            <Icon name="pause" size={11} /> {tr('停止', 'Stop')}
+          </button>
+        )}
+        <button
+          className="icon-btn"
+          onClick={() => void openHistory()}
+          title={tr('历史会话', 'Conversations')}
+        >
+          <Icon name="clock" size={14} />
+        </button>
+        <button className="icon-btn" onClick={newConversation} title={tr('新会话', 'New')}>
+          <Icon name="plus" size={14} />
+        </button>
         <button className="icon-btn" onClick={onClose} title={tr('关闭（⌘J）', 'Close (⌘J)')}>
           <Icon name="x" size={14} />
         </button>
       </div>
+
+      {historyOpen && (
+        <div
+          style={{
+            borderBottom: '0.5px solid var(--border-2)',
+            maxHeight: 220,
+            overflowY: 'auto',
+            padding: '6px 8px',
+          }}
+        >
+          {conversations.length === 0 && (
+            <div style={{ fontSize: 12, color: 'var(--text-4)', padding: 8 }}>
+              {tr('还没有历史会话', 'No conversations yet')}
+            </div>
+          )}
+          {conversations.map((c) => (
+            <div
+              key={c.id}
+              className="hoverable"
+              onClick={() => void loadConversation(c.id)}
+              style={{
+                padding: '7px 9px',
+                borderRadius: 7,
+                fontSize: 12.5,
+                cursor: 'pointer',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                background: c.id === convId ? 'var(--accent-soft)' : undefined,
+              }}
+            >
+              {c.title || tr('（未命名）', '(untitled)')}
+            </div>
+          ))}
+        </div>
+      )}
 
       <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px' }}>
         {turns.length === 0 && (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4724,6 +4724,18 @@ export const api = {
    * 可直接跳任务详情看步骤与日志；409 detail=DAILY_FEED_RUNNING 表示已有一次在跑。
    */
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
+  /** 全局助手：会话列表（最近说过话的在前）。 */
+  listAssistantConversations(): Promise<
+    { id: string; title: string; last_message_at: string | null }[]
+  > {
+    return request('/chat/conversations');
+  },
+  /** 全局助手：一场会话的完整消息（含工具块；SSE 里的 preview 是截断的）。 */
+  getAssistantMessages(
+    conversationId: string,
+  ): Promise<{ role: string; text: string; blocks: unknown[]; status: string }[]> {
+    return request(`/chat/conversations/${conversationId}/messages`);
+  },
   /** 全局助手：新建一场会话（后端开关关着时 404）。 */
   createAssistantConversation(scope: { scope_kind?: string; project_id?: string } = {}): Promise<{ id: string; title: string }> {
     return requestJson<{ id: string; title: string }>('/chat/conversations', 'POST', scope);


### PR DESCRIPTION
The skill engine worked but had no fuel and no filler cap: **zero builtin skills** (the catalog was always empty, so the progressive-disclosure section never even appeared in the system prompt), **zero management endpoints**, and no way for the frontend to create one. This closes that, plus the assistant panel's missing half.

## Five builtin seeds

All written to the one discipline that matters: **description is a trigger condition, not a feature summary** — it is the only thing resident in the system prompt, and the model loads a skill purely on its strength.

- `polaris-search-playbook` — which of the four retrieval tools to use when, and how to change tack on empty results
- `literature-triage` — three-tier batch screening with an explicit criteria ordering
- `paper-deep-read` — structured single-paper reading, with a `template.md` attachment (the L3 sample)
- `citation-hygiene` — numbers must come from tool results; retract claims you cannot locate
- `research-landscape` — direction surveys go to a subagent first, with self-contained task descriptions

Seeds follow the code (existing rows are updated on startup). This deliberately differs from the old system's "never overwrite": builtin skills are read-only with no user edits to protect, and a stale seed only misleads the model.

## A bug of my own, fixed and pinned

`upsert_from_md` checked for an existing row with `owner_id == user_id`; for builtin seeds `user_id` is `None`, which compiles to `owner_id = NULL` — never true in SQL. The dedup check always missed, so **every startup would have inserted another full set of seeds**. Now `IS NULL`, with a test that runs the seeder twice and asserts no duplicates.

## Management API (minimal surface)

`GET/POST/DELETE /api/chat/skills`. Import goes through the same SKILL.md parser (bad frontmatter is a 422 with the reason); builtin skills cannot be deleted.

## Assistant panel's missing half

Stop button (aborts the SSE; the backend persists the partial answer as `interrupted`), a conversation list, loading a past conversation (the server is the authority — local state is replaced wholesale, with persisted blocks restored defensively so unknown shapes degrade to text), and a new-conversation button.

## Tests

Five new: seeding idempotency (the NULL-owner regression), builtins appearing in the catalog (bodies still excluded), seed bodies updating when code changes, and the API round-trip including builtin-deletion refusal. Full suite **1048 passed**; `tsc` and `vite build` clean.

Frontend changes verified by build only — manual script: open ⌘J, ask something, hit Stop mid-answer, open the clock icon, load the conversation back, start a new one.