### PR TITLE
fix(ingest): drop the scored_at upper bound that only clock jumps could trip

### DIFF
--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -209,8 +209,12 @@ async def create_digest_voyage(
             .where(
                 LibraryPaper.library_id == library.id,
                 LibraryPaper.scored_at.is_not(None),
+                # 只有下界没有上界。此前这里还有 `scored_at <= now`，防的是"未来的打分
+                # 时间"——而那恰恰只有时钟跳变才制造得出来：墙钟在打分之后回拨一秒，
+                # now 就小于刚打的 scored_at，论文掉出窗口，paper_count 少一截，策略从
+                # digest_only 翻成 incremental（#234 一族的偶发）。合法数据里 scored_at
+                # 不会在未来，这个上界什么都不保护，只会翻车。
                 LibraryPaper.scored_at >= day_start,
-                LibraryPaper.scored_at <= now,
             )
             .order_by(LibraryPaper.scored_at, LibraryPaper.paper_id)
         )

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -2158,3 +2158,50 @@ async def test_run_does_not_pick_up_an_older_backlog(client, queue_stub, wiki_mo
         ).scalar_one()
         # 积压那篇原地不动：没被这次运行取全文、也没被编译
         assert stale_row.status == "scored", "历史积压被这次同步顺手带走了"
+
+
+async def test_digest_only_survives_a_backward_clock_jump(client, queue_stub, wiki_mocks):
+    """打分之后墙钟回拨一秒，手动简报仍然选 digest_only，一篇不少。
+
+    本机容器的墙钟每 10 秒跳 ±1 秒（#234 的根因）。此前 create_digest_voyage 的窗口带
+    `scored_at <= now` 上界：回拨发生在打分与建简报之间时，now 小于刚打的 scored_at，
+    论文掉出窗口——paper_count 少一截，策略翻成 incremental。合法数据里 scored_at
+    不会在未来，那个上界什么都不保护。
+    """
+    import datetime as real_datetime
+
+    from app.services import ingest as ingest_service_mod
+
+    token = await register_and_login(client, email="clock-jump@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    library_id = await _create_standalone_library(client, headers, name="独立库-时钟回拨")
+
+    bootstrap = await client.post(
+        f"/api/libraries/{library_id}/ingest/run",
+        json={"mode": "bootstrap", "knobs": KNOBS},
+        headers=headers,
+    )
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(bootstrap.json()["id"]))
+
+    # 模拟回拨：ingest 模块里的"现在"比真实时间早 2 秒——刚打的 scored_at 全在"未来"
+    class _RewoundDateTime(real_datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ANN001
+            return real_datetime.datetime.now(tz) - real_datetime.timedelta(seconds=2)
+
+    original = ingest_service_mod.datetime
+    ingest_service_mod.datetime = _RewoundDateTime
+    try:
+        resp = await client.post(
+            f"/api/libraries/{library_id}/digests/generate", headers=headers
+        )
+    finally:
+        ingest_service_mod.datetime = original
+
+    assert resp.status_code == 201, resp.text
+    launch = resp.json()
+    assert launch["strategy"] == "digest_only", (
+        f"回拨两秒就把策略翻成了 {launch['strategy']}——上界又回来了？"
+    )
+    assert launch["paper_count"] == 2, launch


### PR DESCRIPTION
One of the #234-family intermittent failures, mechanism confirmed and pinned.

## The bug

`create_digest_voyage`'s "scored today" window carried an upper bound: `scored_at <= now`. In legitimate data `scored_at` can never be in the future — the only thing that can put it there is the known clock behaviour of this dev VM (**the container wall clock jumps ±1s roughly every 10 seconds**, the documented root cause of #234). When a backward jump lands between scoring and digest creation, `now` is earlier than the just-stamped `scored_at`, papers fall out of the window, `paper_count` shrinks, and the strategy flips from `digest_only` to `incremental` — which is exactly how `test_manual_digest_reuses_today_updates_without_incremental_ingest` failed in the 08-03 full-suite run.

The upper bound protects nothing and can only misfire. Removed; the `>= day_start` lower bound stays.

## The regression test

Faithfully simulates the backward jump: the ingest module's notion of "now" is rewound by two seconds, so every freshly stamped `scored_at` sits "in the future". Asserts the strategy is still `digest_only` with no papers lost. **Fails against `origin/main`, passes with the fix.**

## What this does not claim

The other #234 member, `test_unlimited_bootstrap_uncapped`, is **not** claimed fixed. Its path has no remaining time-window comparison (the scoring window went run-id-based in #240), and it passes 6/6 in isolation across guaranteed clock jumps — pointing to cross-file interference rather than the clock. Four instrumented full-suite runs (full tracebacks preserved per run) did not reproduce it; at the historical ~1/3 failure rate, four green runs is ~20% likely by chance, so this is evidence of rarity, not absence. Findings and the instrumented-hunt recipe go to #234 so the next occurrence yields a real traceback instead of a truncated `assert ...`.

Full suite **4 × 1049 passed** during the hunt; `ruff check app` clean.