### PR TITLE
feat(chat): bound the replay history, at turn boundaries only

### DIFF
--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -219,7 +219,18 @@ async def run_turn(
     )
     if conv.id != conversation_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
-    history = await store.replay(session, conversation_id=conv.id)
+    # 回放预算从模型路由的 context_window 推：窗口的一半给历史（字符 ≈ token×4，两个
+    # 近似相抵），另一半留给工具 schema、系统提示与本轮生成。管理端没填就用保守缺省。
+    budget_chars: int | None = None
+    try:
+        _, route = await get_llm_router().resolve("agent", user.id)
+        if route.context_window:
+            budget_chars = route.context_window * 2  # window/2 token × 4 字符/token
+    except Exception:  # noqa: BLE001 — 路由解析失败不该挡住对话，走缺省预算
+        budget_chars = None
+    history = await store.replay(
+        session, conversation_id=conv.id, budget_chars=budget_chars
+    )
     # L1：技能目录进 system prompt（每个技能只占一行）。正文由 skill_load 按需取，
     # 绝不写进 system——那会作废整个 prompt cache 前缀。
     catalog = await agent_skills.render_catalog(session, user_id=user.id)

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -101,6 +101,9 @@ class ResolvedRoute:
     temperature: float | None
     provider_name: str = "fake"  # 管理端 provider 名称（调用日志用）
     effort: EffortLevel | None = None  # 推理档位，None = 不发送该参数（用模型默认）
+    #: 模型的上下文窗口（token）。None = 管理端没填，调用方按保守常量走。
+    #: agent 的历史回放预算靠它——不知道窗口多大，裁剪阈值就只能拍脑袋。
+    context_window: int | None = None
 
 
 # 无 DB 路由时的兜底：确定性 fake provider
@@ -215,6 +218,7 @@ class LLMRouter:
                     temperature=route.temperature,
                     provider_name=provider.name,
                     effort=route.effort,
+                    context_window=route.context_window,
                 )
         return routes
 

--- a/src/backend/app/services/conversations.py
+++ b/src/backend/app/services/conversations.py
@@ -24,6 +24,14 @@ from app.models.conversation import Conversation, ConversationMessage
 #: 标题取首条用户消息的前若干字符
 _TITLE_CHARS = 60
 
+#: 回放预算的保守缺省（字符）。管理端没在模型路由上填 context_window 时用它——
+#: 约合 16k token，给工具 schema、系统提示和本轮生成留足余量。
+DEFAULT_REPLAY_BUDGET_CHARS = 64_000
+
+#: 旧轮次里单个工具结果保留多少。历史里的工具结果是 token 大头（一条 4000 字符），
+#: 而模型早已基于它作过答——保留一行出处就够了。
+_OLD_RESULT_KEEP_CHARS = 200
+
 
 def blocks_to_json(blocks: tuple[ContentBlock, ...] | list[ContentBlock]) -> list[dict[str, Any]]:
     """块 → 可落库的 JSON（provider 中立）。
@@ -171,7 +179,11 @@ async def append_message(
 
 
 async def replay(
-    session: AsyncSession, *, conversation_id: uuid.UUID, limit: int | None = None
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    limit: int | None = None,
+    budget_chars: int | None = None,
 ) -> list[Message]:
     """把会话历史翻回 ``Message`` 列表，按 seq 升序。
 
@@ -190,7 +202,84 @@ async def replay(
         stmt = stmt.limit(limit)
     rows = list((await session.execute(stmt)).scalars().all())
     rows.reverse()
-    return [Message(role=r.role, content=blocks_from_json(r.blocks)) for r in rows]
+    messages = [Message(role=r.role, content=blocks_from_json(r.blocks)) for r in rows]
+    return trim_history(messages, budget_chars=budget_chars)
+
+
+def _is_turn_start(msg: Message) -> bool:
+    """真正的用户提问（而不是装工具结果的 user 消息）——轮次从这里开始。"""
+    if msg.role != "user":
+        return False
+    blocks = msg.content
+    if isinstance(blocks, str):
+        return True
+    return not any(isinstance(b, ToolResultBlock) for b in blocks)
+
+
+def trim_history(
+    messages: list[Message], *, budget_chars: int | None = None
+) -> list[Message]:
+    """把历史裁进预算。两条硬规则：
+
+    1. **只在轮次边界裁**。一轮 = 一个用户提问到下一个提问之间的全部消息（含中间的
+       tool_use / tool_result 往返）。从半中腰切开会把 assistant 的 tool_use 和它的
+       tool_result 拆散——Anthropic 对孤儿 tool_use 直接 400，OpenAI 侧行为未定义。
+    2. **保留的旧轮次里，工具结果压成一行**。模型早已基于它作过答，整段留着只是
+       每轮重发的死重；最近一轮保留原文（追问经常要引用它）。
+
+    预算按拍平字符数算（与 estimate_tokens 的 len/4 同源），不精确但方向正确：
+    这里要防的是无界增长，不是精确计费。
+    """
+    budget = budget_chars or DEFAULT_REPLAY_BUDGET_CHARS
+    if not messages:
+        return messages
+
+    # 切成轮次（首条消息之前若有游离的 assistant 消息，归入第一轮）
+    turns: list[list[Message]] = []
+    current: list[Message] = []
+    for msg in messages:
+        if _is_turn_start(msg) and current:
+            turns.append(current)
+            current = []
+        current.append(msg)
+    if current:
+        turns.append(current)
+
+    # 从最新往回收轮次，直到预算耗尽；最新一轮永远保留（哪怕它自己就超了预算）
+    kept: list[list[Message]] = []
+    used = 0
+    for index, turn in enumerate(reversed(turns)):
+        is_latest = index == 0
+        turn = turn if is_latest else [_shrink_old_results(m) for m in turn]
+        size = sum(len(m.text) for m in turn)
+        if not is_latest and used + size > budget:
+            break
+        kept.append(turn)
+        used += size
+    kept.reverse()
+    return [msg for turn in kept for msg in turn]
+
+
+def _shrink_old_results(msg: Message) -> Message:
+    """旧轮次里的工具结果压成一行出处。"""
+    blocks = msg.content
+    if isinstance(blocks, str):
+        return msg
+    changed = False
+    out: list[ContentBlock] = []
+    for b in blocks:
+        if isinstance(b, ToolResultBlock) and len(b.content) > _OLD_RESULT_KEEP_CHARS:
+            out.append(
+                ToolResultBlock(
+                    b.tool_use_id,
+                    b.content[:_OLD_RESULT_KEEP_CHARS] + "…（历史轮次，已截断）",
+                    is_error=b.is_error,
+                )
+            )
+            changed = True
+        else:
+            out.append(b)
+    return Message(role=msg.role, content=out) if changed else msg
 
 
 async def finish_message(

--- a/src/backend/tests/test_conversations_store.py
+++ b/src/backend/tests/test_conversations_store.py
@@ -224,3 +224,113 @@ def test_blocks_round_trip_is_provider_neutral():
     assert back[3].is_error is True
     # 拍平成文本时工具调用不能凭空消失
     assert "search_papers" in Message(role="assistant", content=back).text
+
+
+# ---- 回放预算：历史不能无界增长 ----
+#
+# run_turn 此前不带任何上界地回放全部历史：会话越长每轮重发越多，token 成本平方
+# 增长，最终撑爆上下文窗口。P2 加的 model_routes.context_window 列在此之前没人读。
+
+
+def _turn(question: str, result_chars: int = 3000) -> list:
+    from app.core.llm.base import Message, TextBlock, ToolResultBlock, ToolUseBlock
+    from app.services.conversations import trim_history  # noqa: F401 — 确保可导入
+
+    return [
+        Message(role="user", content=question),
+        Message(
+            role="assistant",
+            content=[TextBlock("我查一下"), ToolUseBlock("c1", "search_papers", {"q": question})],
+        ),
+        Message(role="user", content=[ToolResultBlock("c1", "x" * result_chars)]),
+        Message(role="assistant", content=f"关于{question}的回答"),
+    ]
+
+
+def test_trim_cuts_only_at_turn_boundaries():
+    """裁剪永不把 tool_use 和它的 tool_result 拆散——孤儿 tool_use 会被 Anthropic 400。"""
+    from app.core.llm.base import Message, ToolResultBlock, ToolUseBlock
+    from app.services.conversations import trim_history
+
+    history: list[Message] = []
+    for i in range(8):
+        history += _turn(f"问题{i}")
+
+    trimmed = trim_history(history, budget_chars=8000)
+    assert trimmed, "至少保留最新一轮"
+    assert trimmed[0].role == "user", "开头必须是一个用户提问"
+
+    # 逐条核对：每个 tool_use 后面必须跟着装它 result 的消息
+    pending: set[str] = set()
+    for msg in trimmed:
+        blocks = msg.content if isinstance(msg.content, list) else []
+        for b in blocks:
+            if isinstance(b, ToolUseBlock):
+                pending.add(b.id)
+            elif isinstance(b, ToolResultBlock):
+                pending.discard(b.tool_use_id)
+    assert not pending, f"有孤儿 tool_use：{pending}"
+
+
+def test_trim_keeps_the_newest_and_drops_the_oldest():
+    from app.core.llm.base import Message
+    from app.services.conversations import trim_history
+
+    history: list[Message] = []
+    for i in range(10):
+        history += _turn(f"问题{i}")
+
+    # 预算要算上「旧轮次的工具结果会被压到 ~250 字符」：10 个轮次里最新一轮 ~3000，
+    # 旧轮次每轮 ~270——4000 的预算装得下最新 + 约 3 个旧轮次，更早的必须淘汰
+    trimmed = trim_history(history, budget_chars=4_000)
+    text = "\n".join(m.text for m in trimmed)
+    assert "问题9" in text, "最新的必须在"
+    assert "问题0" not in text, "最旧的该被裁掉"
+    assert len(trimmed) < len(history)
+
+
+def test_the_latest_turn_survives_even_when_it_alone_exceeds_the_budget():
+    """预算再小也不能把最新一轮裁没——那等于把用户刚说的话扔了。"""
+    from app.services.conversations import trim_history
+
+    history = _turn("唯一的问题", result_chars=50_000)
+    trimmed = trim_history(history, budget_chars=100)
+    assert any("唯一的问题" in m.text for m in trimmed)
+
+
+def test_old_turns_have_their_tool_results_shrunk_but_the_latest_keeps_full_text():
+    """保留的旧轮次里工具结果压成一行；最新一轮保留原文（追问经常要引用它）。"""
+    from app.core.llm.base import Message, ToolResultBlock
+    from app.services.conversations import trim_history
+
+    history: list[Message] = []
+    for i in range(3):
+        history += _turn(f"问题{i}", result_chars=3000)
+
+    trimmed = trim_history(history, budget_chars=1_000_000)  # 预算充足，全部保留
+    results = [
+        b
+        for m in trimmed
+        for b in (m.content if isinstance(m.content, list) else [])
+        if isinstance(b, ToolResultBlock)
+    ]
+    assert len(results) == 3
+    assert len(results[0].content) < 300, "旧轮次的结果该被压掉"
+    assert "已截断" in results[0].content
+    assert len(results[-1].content) >= 3000, "最新一轮的结果保留原文"
+
+
+def test_plain_conversations_without_tools_trim_cleanly():
+    """纯文本会话（没有工具块）也照常按轮次裁。"""
+    from app.core.llm.base import Message
+    from app.services.conversations import trim_history
+
+    history: list[Message] = []
+    for i in range(20):
+        history.append(Message(role="user", content=f"问题{i}" * 100))
+        history.append(Message(role="assistant", content=f"回答{i}" * 100))
+
+    trimmed = trim_history(history, budget_chars=5000)
+    assert trimmed[0].role == "user"
+    assert len(trimmed) < 40
+    assert "问题19" in trimmed[-2].text


### PR DESCRIPTION
`run_turn` replayed the entire conversation history with no bound: the longer a conversation, the more is re-sent every round — quadratic token cost, and eventually the context window bursts. The `model_routes.context_window` column added in #254 had no readers until now.

## Two hard rules

1. **Cut only at turn boundaries.** A turn is everything from one user question to the next, including the tool_use/tool_result round-trips in between. Cutting mid-turn separates an assistant's `tool_use` from its `tool_result` — Anthropic 400s on orphaned tool_use, OpenAI behaviour is undefined. The test walks the trimmed output and asserts no orphaned tool_use survives.
2. **Old turns keep their tool results as a one-line stub** (the model already answered from them; the full payload is dead weight re-sent every round). The latest turn keeps full text — follow-ups routinely quote it — and survives even when it alone exceeds the budget: however small the budget, you never throw away what the user just said.

The budget derives from the resolved route's `context_window` (half the window for history; chars≈tokens×4 and tokens≈chars/4 cancel), falling back to a conservative 64k chars when the admin left it unset. `ResolvedRoute` now carries `context_window` — the column finally has a reader.

## Tests

Five new: no orphaned tool_use after trimming, newest kept / oldest dropped under a forcing budget, the latest turn surviving a tiny budget, old results shrunk while the latest keeps full text, and plain text-only conversations trimming cleanly. Full suite **1054 passed**.

One test expectation was wrong on the first attempt and worth recording: I set a 10k budget expecting old turns to be dropped, forgetting that shrinking makes old turns ~270 chars each — they all fit. The budget in the test now actually forces eviction.