### PR TITLE
feat(daily): default to the latest day and to collected papers, cs.CL first

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -66,13 +66,14 @@ _NOT_FOUND = HTTPException(status.HTTP_404_NOT_FOUND, detail="DAILY_ENTRY_NOT_FO
 async def list_days(
     announce: str | None = Query(default=None, pattern="^(new|cross)$"),
     category: str | None = Query(default=None),
+    collected: bool = Query(default=False),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[DailyDay]:
     return [
         DailyDay(**d)
         for d in await daily_service.list_days(
-            session, announce=announce, category=category
+            session, announce=announce, category=category, collected=collected
         )
     ]
 
@@ -91,6 +92,8 @@ async def list_papers(
     affiliation: str | None = Query(default=None, max_length=200),
     # 只看被某个文献库收录的（每日论文页按库筛选）
     library_id: uuid.UUID | None = Query(default=None),
+    # 只看被**任意**文献库收录的（每日页的默认视角）
+    collected: bool = Query(default=False),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DailyPage:
@@ -119,6 +122,7 @@ async def list_papers(
                 author=author,
                 affiliation=affiliation,
                 library_id=library_id,
+                collected=collected,
             )
             mode_used = "semantic"
             entry_by_paper = {paper.id: entry for entry, paper, _ in rows}
@@ -150,6 +154,7 @@ async def list_papers(
             author=author,
             affiliation=affiliation,
             library_id=library_id,
+            collected=collected,
         )
         return DailyPage(items=items, total=total, page=page, size=size, mode_used=mode_used)
     ready, ready_total = await daily_service.embedding_coverage(session)

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -19,7 +19,7 @@ import re
 import uuid
 from typing import Any
 
-from sqlalchemy import String, cast, delete, func, select, text
+from sqlalchemy import String, case, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.embedding_space import EmbeddingSpace, active_space
@@ -607,6 +607,7 @@ async def list_days(
     *,
     announce: str | None = None,
     category: str | None = None,
+    collected: bool = False,
 ) -> list[dict[str, Any]]:
     """每天的条目数。**按当前筛选算**——日期标签上的数字与列表里看到的必须是同一回事，
     否则选了 cs.CV 之后标签仍显示全部篇数，看起来就像筛选没生效。
@@ -614,6 +615,17 @@ async def list_days(
     筛选条件与 :func:`list_papers` 保持同一口径。
     """
     stmt = select(DailyFeedEntry.feed_date, func.count(DailyFeedEntry.id))
+    if collected:
+        from app.models.library_direction import LibraryPaper
+        from app.services.papers import PAPER_STATUS_GROUPS
+
+        stmt = stmt.where(
+            DailyFeedEntry.paper_id.in_(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"])
+                )
+            )
+        )
     if announce in ("new", "cross"):
         stmt = stmt.where(DailyFeedEntry.announce_type == announce)
     if category:
@@ -643,8 +655,22 @@ async def list_papers(
     author: str | None = None,
     affiliation: str | None = None,
     library_id: uuid.UUID | None = None,
+    collected: bool = False,
 ) -> tuple[list[dict[str, Any]], int]:
     stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
+    if collected:
+        # 「已收录」：被**任意**文献库真正收进去的（候选/回收站不算）。与 library_id
+        # 的区别是不限定哪个库——它是每日页的默认视角：只看进了库的。
+        from app.models.library_direction import LibraryPaper
+        from app.services.papers import PAPER_STATUS_GROUPS
+
+        stmt = stmt.where(
+            Paper.id.in_(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"])
+                )
+            )
+        )
     if date is not None:
         stmt = stmt.where(DailyFeedEntry.feed_date == date)
     if library_id is not None:
@@ -681,12 +707,32 @@ async def list_papers(
     total = (await session.execute(count_stmt)).scalar_one()
 
     likes_sq = _like_count_sq()
+    # 分类优先级打头：cs.CL 的排最前，cs.RO 的排最后（一篇同时挂两者按 cs.CL 算）。
+    # LIKE 序列化文本的写法与上面 category 过滤同口径，PG/sqlite 通用。
+    category_rank = case(
+        (
+            (DailyFeedEntry.primary_category == "cs.CL")
+            | cast(DailyFeedEntry.categories, String).like('%"cs.CL"%'),
+            0,
+        ),
+        (
+            (DailyFeedEntry.primary_category == "cs.RO")
+            | cast(DailyFeedEntry.categories, String).like('%"cs.RO"%'),
+            2,
+        ),
+        else_=1,
+    )
     if sort == "likes":
         stmt = stmt.order_by(
-            likes_sq.desc(), DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc()
+            category_rank,
+            likes_sq.desc(),
+            DailyFeedEntry.feed_date.desc(),
+            DailyFeedEntry.created_at.desc(),
         )
     else:  # date
-        stmt = stmt.order_by(DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc())
+        stmt = stmt.order_by(
+            category_rank, DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc()
+        )
     stmt = stmt.offset((page - 1) * size).limit(size)
 
     rows = (await session.execute(stmt)).all()
@@ -705,6 +751,7 @@ async def semantic_search_daily(
     author: str | None = None,
     affiliation: str | None = None,
     library_id: uuid.UUID | None = None,
+    collected: bool = False,
 ) -> list[tuple[DailyFeedEntry, Paper, float]]:
     """池内向量检索（pgvector 余弦；仅 postgres，调用方先判 semantic_search_supported）。
 
@@ -745,6 +792,14 @@ async def semantic_search_daily(
         )
         params["library_id"] = str(library_id)
         params["lib_statuses"] = list(PAPER_STATUS_GROUPS["library"])
+    if collected:
+        from app.services.papers import PAPER_STATUS_GROUPS
+
+        where.append(
+            "EXISTS (SELECT 1 FROM library_papers lpc WHERE lpc.paper_id = p.id "
+            "AND lpc.status = ANY(CAST(:collected_statuses AS varchar[])))"
+        )
+        params["collected_statuses"] = list(PAPER_STATUS_GROUPS["library"])
     rows = (
         await session.execute(
             text(

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1456,3 +1456,109 @@ async def test_cleanup_uses_the_configured_retention(client, monkeypatch):
         expired = await daily_feed.cleanup_expired(session)
         await session.commit()
     assert expired == 1
+
+
+async def test_collected_filter_shows_only_library_members(client, monkeypatch):
+    """「已收录」= 被任意文献库真正收进去的；候选与回收站不算。这是每日页的默认视角。"""
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.library_direction import DirectionLibrary, LibraryPaper
+    from app.models.paper import Paper
+    from app.services import daily_feed
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.CL": [
+                    _rss_entry("2608.21001", "Collected Paper"),
+                    _rss_entry("2608.21002", "Candidate Paper"),
+                    _rss_entry("2608.21003", "Loose Paper"),
+                ]
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+        lib = DirectionLibrary(name="收录测试库", definition={"statement": "x"})
+        session.add(lib)
+        await session.flush()
+        papers = {
+            p.title: p
+            for p in (
+                (await session.execute(select(Paper).where(Paper.title.like("%Paper%"))))
+                .scalars()
+                .all()
+            )
+        }
+        session.add(
+            LibraryPaper(
+                library_id=lib.id, paper_id=papers["Collected Paper"].id, status="included"
+            )
+        )
+        # candidate 不算收录
+        session.add(
+            LibraryPaper(
+                library_id=lib.id, paper_id=papers["Candidate Paper"].id, status="candidate"
+            )
+        )
+        await session.commit()
+
+    resp = await client.get(
+        "/api/daily/papers", params={"collected": "true", "size": 50}, headers=headers
+    )
+    titles = [item["title"] for item in resp.json()["items"]]
+    assert titles == ["Collected Paper"], f"只该剩真正收录的：{titles}"
+
+    # 日期标签的数字同口径
+    days = (
+        await client.get("/api/daily/days", params={"collected": "true"}, headers=headers)
+    ).json()
+    assert sum(d["count"] for d in days) == 1
+
+
+async def test_daily_list_puts_cscl_first_and_csro_last(client, monkeypatch):
+    """列表按分类优先级排：cs.CL 的在前，cs.RO 的在最后，其余居中。
+
+    一篇同时挂 cs.CL 和 cs.RO 的按 cs.CL 算（排前面）。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.RO": [_rss_entry("2608.22001", "Robot Paper")],
+                "cs.AI": [_rss_entry("2608.22002", "AI Paper")],
+                "cs.CL": [
+                    _rss_entry("2608.22003", "Language Paper"),
+                    # 同一篇也出现在 cs.RO：合并后同时挂两个分类，按 cs.CL 排前面
+                    _rss_entry("2608.22004", "Both Paper"),
+                ],
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        # cs.RO 不在默认订阅里，先配上，否则抓取不会去拉它
+        await daily_feed.set_categories(session, ["cs.CL", "cs.AI", "cs.RO"])
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+        # 把 Both Paper 也并进 cs.RO 的分类（模拟跨列合并）
+        by_ro = {"cs.RO": [_rss_entry("2608.22004", "Both Paper")]}
+        await daily_feed.upsert_entries(session, by_category=by_ro)
+
+    resp = await client.get(
+        "/api/daily/papers", params={"sort": "date", "size": 50}, headers=headers
+    )
+    titles = [item["title"] for item in resp.json()["items"]]
+    cl = [titles.index(t) for t in ("Language Paper", "Both Paper")]
+    other = titles.index("AI Paper")
+    ro = titles.index("Robot Paper")
+    assert max(cl) < other < ro, f"顺序应为 cs.CL < 其他 < cs.RO：{titles}"

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -556,10 +556,10 @@ function DailyDetailPane({
 }
 
 type DailyView = 'papers' | 'chat';
-type AnnounceFilter = 'all' | 'new' | 'cross';
+type AnnounceFilter = 'collected' | 'all' | 'new' | 'cross';
 
-// 类型筛选默认值：只看新工作（高级检索面板里的「恢复默认」也回到这个值）
-const DEFAULT_ANNOUNCE: AnnounceFilter = 'new';
+// 类型筛选默认值：只看已收录的（进了文献库的才值得先看；「恢复默认」也回到这个值）
+const DEFAULT_ANNOUNCE: AnnounceFilter = 'collected';
 
 // 列表固定按点赞排序（没有排序切换 UI）；语义检索时后端按相关度排，忽略这个值
 // 时间倒排：最新的在最前。按点赞排会让一篇被点过的旧论文压在当天新论文前面，
@@ -647,7 +647,7 @@ export function DailyPage() {
   // 只看被某个文献库收录的论文（#218）。空 = 不限
   // 日期：勾上「全部」就是跨天一起看（默认）；取消勾选后在有数据的日期间前后切换。
   // 只在这些日期间跳，而不是任意日历日——中间没有公告的日子点进去是空的。
-  const [showAll, setShowAll] = useState(true);
+  const [showAll, setShowAll] = useState(false);
   const [day, setDay] = useState('');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
   // 默认收起：日期切换已经在工具栏上，高级条件是偶尔才用的东西
@@ -660,7 +660,8 @@ export function DailyPage() {
   const author = useDebounced(authorInput.trim());
   const affiliation = useDebounced(affiliationInput.trim());
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
-  const advActive = !!category || announce !== DEFAULT_ANNOUNCE || !!author || !!affiliation;
+  // 分类/类型已上工具栏；高级检索只剩作者与机构
+  const advActive = !!author || !!affiliation;
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -681,7 +682,12 @@ export function DailyPage() {
   // 保留期是管理员可配的，界面上不能写死「7 天」
   const daysQuery = useQuery({
     queryKey: ['daily-days', announce, category],
-    queryFn: () => api.listDailyDays({ announce: announce || undefined, category: category || undefined }),
+    queryFn: () =>
+      api.listDailyDays({
+        announce: announce === 'new' || announce === 'cross' ? announce : undefined,
+        category: category || undefined,
+        collected: announce === 'collected' || undefined,
+      }),
     retry: false,
     staleTime: 60_000,
   });
@@ -689,6 +695,14 @@ export function DailyPage() {
   // 有数据的日期，升序（旧 → 新）；前后切换只在这些日期间跳
   const dates = (daysQuery.data ?? []).map((d) => d.date).sort();
   const dayIdx = dates.indexOf(day);
+
+  // 默认停在最近一天。以前默认落到「今天」，周末没公告时页面是空的看着像坏了；
+  // 落到「最新**有数据**的一天」没有这个问题——dates 本来就只含有数据的日期。
+  useEffect(() => {
+    const latest = dates[dates.length - 1];
+    if (!showAll && !day && latest) setDay(latest);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAll, day, dates.join(',')]);
 
 
   // 默认停在「全部」：跨天一起看、按时间倒排，最新的自然在最前。以前默认落到最新
@@ -741,7 +755,8 @@ export function DailyPage() {
         size: PAGE_SIZE,
         q: q || undefined,
         category: category || undefined,
-        announce: announce === 'all' ? undefined : announce,
+        announce: announce === 'new' || announce === 'cross' ? announce : undefined,
+        collected: announce === 'collected' || undefined,
         author: author || undefined,
         affiliation: affiliation || undefined,
         date: showAll ? undefined : day || undefined,
@@ -899,63 +914,59 @@ export function DailyPage() {
                   open={advOpen}
                   active={advActive}
                   onToggle={() => setAdvOpen((o) => !o)}
-                  title={tr(
-                    '高级检索：分类 / 类型 / 作者 / 机构',
-                    'Advanced search: category / type / author / affiliation',
-                  )}
+                  title={tr('高级检索：作者 / 机构', 'Advanced search: author / affiliation')}
                 />
                 <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)', flexShrink: 0 }}>
                   {total ? tr(`${total} 篇`, `${total}`) : ''}
                 </span>
               </div>
 
-              {/* 高级检索面板：分类 + 类型 + 作者 / 机构（日期步进和排序留在工具栏，它们是主导航） */}
+              {/* 分类与类型是主筛选，直接摆在工具栏上（作者/机构才收进高级检索） */}
+              <div className="row gap6 wrap" style={{ marginTop: 8, alignItems: 'center' }}>
+                <select
+                  className="input mono"
+                  style={{ width: 120, height: 26, fontSize: 11, padding: '0 6px', flexShrink: 0 }}
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  title={tr('只看某个订阅分类的论文', 'Only papers in one subscribed category')}
+                >
+                  <option value="">{tr('全部分类', 'All categories')}</option>
+                  {(categoriesQuery.data?.categories ?? []).map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                <span
+                  className={`chip${announce === 'collected' ? ' on' : ''}`}
+                  onClick={() => setAnnounce('collected')}
+                  title={tr('只看已被文献库收录的（默认）', 'Only papers collected into a library (default)')}
+                >
+                  {tr('已收录', 'Collected')}
+                </span>
+                <span className={`chip${announce === 'all' ? ' on' : ''}`} onClick={() => setAnnounce('all')}>
+                  {tr('全部', 'All')}
+                </span>
+                <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
+                  {tr('新工作', 'New')}
+                </span>
+                <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
+                  {tr('更新', 'Updated')}
+                </span>
+              </div>
+
+              {/* 高级检索面板：作者 / 机构（分类与类型已上工具栏） */}
               {advOpen && (
                 <AdvancedPanel
                   onClear={
                     advActive
                       ? () => {
-                          setCategory('');
-                          setAnnounce(DEFAULT_ANNOUNCE);
                           setAuthorInput('');
                           setAffiliationInput('');
                         }
                       : undefined
                   }
                 >
-                  <div className="row gap6" style={{ alignItems: 'center' }}>
-                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
-                      {tr('分类', 'Category')}
-                    </span>
-                    <select
-                      className="input mono"
-                      style={{ flex: 1, minWidth: 0, height: 26, fontSize: 11, padding: '0 6px' }}
-                      value={category}
-                      onChange={(e) => setCategory(e.target.value)}
-                      title={tr('只看某个订阅分类的论文', 'Only papers in one subscribed category')}
-                    >
-                      <option value="">{tr('全部分类', 'All categories')}</option>
-                      {(categoriesQuery.data?.categories ?? []).map((c) => (
-                        <option key={c} value={c}>
-                          {c}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="row gap6 wrap" style={{ alignItems: 'center' }}>
-                    <span style={{ width: 34, flexShrink: 0, fontSize: 11, color: 'var(--text-3)' }}>
-                      {tr('类型', 'Type')}
-                    </span>
-                    <span className={`chip${announce === 'all' ? ' on' : ''}`} onClick={() => setAnnounce('all')}>
-                      {tr('全部', 'All')}
-                    </span>
-                    <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
-                      {tr('新工作', 'New')}
-                    </span>
-                    <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
-                      {tr('更新', 'Updated')}
-                    </span>
-                  </div>
                   <div className="row gap8">
                     <FilterInput
                       value={authorInput}
@@ -976,21 +987,14 @@ export function DailyPage() {
               )}
               {/* 面板收起时，把正在生效的分类/类型如实说一句（默认「只看新工作」也算），
                   免得筛选藏进面板后用户不知道列表被过滤过 */}
-              {!advOpen && (announce !== 'all' || !!category || !!author || !!affiliation) && (
+              {!advOpen && (!!author || !!affiliation) && (
                 <div
                   onClick={() => setAdvOpen(true)}
                   style={{ marginTop: 6, fontSize: 11, color: 'var(--text-4)', cursor: 'pointer', lineHeight: 1.5 }}
                   title={tr('点开高级检索改筛选条件', 'Open advanced search to change the filters')}
                 >
                   {tr('只看：', 'Showing: ')}
-                  {[
-                    announce === 'new' ? tr('新工作', 'New') : announce === 'cross' ? tr('更新', 'Updated') : '',
-                    category,
-                    author,
-                    affiliation,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')}
+                  {[author, affiliation].filter(Boolean).join(' · ')}
                 </div>
               )}
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4624,10 +4624,13 @@ export const api = {
   getDailyRetention(): Promise<{ days: number }> {
     return request<{ days: number }>('/daily/retention');
   },
-  listDailyDays(params: { announce?: string; category?: string } = {}): Promise<DailyDay[]> {
+  listDailyDays(
+    params: { announce?: string; category?: string; collected?: boolean } = {},
+  ): Promise<DailyDay[]> {
     const qs = new URLSearchParams();
     if (params.announce) qs.set('announce', params.announce);
     if (params.category) qs.set('category', params.category);
+    if (params.collected) qs.set('collected', 'true');
     const suffix = qs.toString() ? `?${qs}` : '';
     return request<DailyDay[]>(`/daily/days${suffix}`);
   },
@@ -4650,11 +4653,14 @@ export const api = {
       mode?: SearchMode;
       /** 只看被这个文献库收录的（候选与回收站不算收录） */
       libraryId?: string;
+      /** 只看被任意文献库收录的（每日页的默认视角） */
+      collected?: boolean;
     } = {},
   ): Promise<DailyPage> {
     const params = new URLSearchParams();
     if (opts.date) params.set('date', opts.date);
     if (opts.libraryId) params.set('library_id', opts.libraryId);
+    if (opts.collected) params.set('collected', 'true');
     if (opts.sort) params.set('sort', opts.sort);
     if (opts.page) params.set('page', String(opts.page));
     if (opts.size) params.set('size', String(opts.size));


### PR DESCRIPTION
The daily page opened on **all days × new submissions only** — a screenful of cross-day mixing, with the two filters people actually reach for (category, type) hidden inside the advanced-search panel.

## Changes

**Defaults.** The page now lands on the newest day that *has* papers, not on "today" — weekends have no announcements, and defaulting to today showed an empty page that looked broken. The type filter gains **Collected** and makes it the default: only papers a library has actually taken in (candidates and trash do not count).

**Ordering.** The list is ranked by category before anything else: `cs.CL` first, `cs.RO` last, everything else in between. A paper carrying both counts as `cs.CL` and sorts to the front. Ranking is a SQL `CASE` over the same serialized-JSON `LIKE` the category filter already uses, so Postgres and the SQLite test DB agree.

**Layout.** Category select and type chips moved out of the advanced panel onto the toolbar; the panel is now author/affiliation only, and the "showing:" hint below it no longer repeats filters that are visible on screen.

`/daily/days` takes `collected` too — the count on the date label has to mean the same thing as the list under it, otherwise the filter looks broken.

## Tests

Two new, both failing against `origin/main`: `collected` returns only real library members (a `candidate` row is seeded specifically to be excluded, and the day counts are asserted alongside), and the ordering test seeds cs.RO / cs.AI / cs.CL plus one paper in both cs.CL and cs.RO, asserting `cs.CL < other < cs.RO`. Full suite **1051 passed**; frontend `tsc --noEmit` + `vite build` clean.

One thing the ordering test taught me: cs.RO is not in the default subscription list, so the fixture had to subscribe it before the stub fetch would return anything for it.