### PR TITLE
feat(assistant): PolarisBuddy — floating bubble, page awareness, companion greeting, live turn state

### DIFF
--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -78,6 +78,9 @@ class ChatTurnRequest:
     statement: str | None = None
     extra_system: str = ""
     skill_catalog: str = ""
+    #: 用户此刻在看什么（PolarisBuddy 的页面感知）。拼在本轮提问前面，**不进 system**：
+    #: system 是稳定前缀，每轮变一次等于 prompt cache 永不命中。
+    page_context: str = ""
 
 
 @dataclass(slots=True)
@@ -120,7 +123,14 @@ class ChatAgentLoop:
                 ),
             ),
             *self._history,
-            Message(role="user", content=req.question),
+            Message(
+                role="user",
+                content=(
+                    f"{req.page_context}\n\n{req.question}"
+                    if req.page_context
+                    else req.question
+                ),
+            ),
         ]
         state = _RoundState()
         yield MetaEvent(

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -44,7 +44,7 @@ from app.schemas.chat_agent import (
     MessageRead,
     SkillImportRequest,
 )
-from app.services import agent_skills
+from app.services import agent_skills, buddy
 from app.services import conversations as store
 from app.services import projects as projects_service
 from app.tools.context import ToolContext
@@ -205,6 +205,24 @@ async def delete_skill(
     await session.commit()
 
 
+@router.get("/buddy/greeting")
+async def buddy_greeting(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, object]:
+    """PolarisBuddy 开面板时说的那句话，外加它依据的计数。
+
+    **不过模型**：每次开面板都要出现，过 LLM 就是每次都花钱、还得等，而且模型会把
+    数字说错。句子是从真实计数里挑的，不是生成的。
+    """
+    _require_enabled()
+    stats = await buddy.collect_stats(session, user_id=user.id)
+    return {
+        "greeting": buddy.compose_greeting(stats, name=user.display_name or None),
+        "stats": stats.as_dict(),
+    }
+
+
 @router.post("/conversations/{conversation_id}/turn")
 async def run_turn(
     conversation_id: uuid.UUID,
@@ -255,6 +273,7 @@ async def run_turn(
         max_rounds=payload.max_rounds,
         statement=payload.statement,
         skill_catalog=catalog,
+        page_context=buddy.render_page_context(payload.page_kind, payload.page_id),
     )
     conv_id, user_id = conv.id, user.id
 

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -37,6 +37,9 @@ class ConversationTurnRequest(BaseModel):
     tool_names: list[str] | None = None
     max_rounds: int = Field(default=8, ge=1, le=20)
     statement: str | None = None
+    #: 用户此刻在看的页面（前端声明）。paper|idea|experiment|library|project|manuscript|daily
+    page_kind: str | None = Field(default=None, max_length=32)
+    page_id: str | None = Field(default=None, max_length=64)
 
 
 class MessageRead(BaseModel):

--- a/src/backend/app/services/buddy.py
+++ b/src/backend/app/services/buddy.py
@@ -1,0 +1,163 @@
+"""PolarisBuddy 的陪伴层：问候语与页面上下文。
+
+两条纪律：
+
+1. **问候语不过模型**。它每次开面板都要出现，过一次 LLM 就是每次开面板都花钱、
+   还得等两秒；更要命的是模型会把数字说错——"你这周读了 12 篇"必须真的是 12 篇。
+   所以数字全部来自 SQL，句子从数字里挑，一个字都不生成。
+2. **数字取不到就不说这句话**，不要兜 0 冒充。"你这周还没读论文"和"统计失败"
+   在界面上长得一样，但对用户是两回事。
+"""
+
+import datetime as dt
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.daily_feed import DailyFeedEntry
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.library import UserLibraryEntry
+from app.models.project import ProjectMember
+
+#: 「最近」的口径。七天是一周工作节奏，比"今天"稳（周一看不到上周五的成果会很挫）。
+RECENT_DAYS = 7
+
+#: 页面上下文注入的长度上限。它是前端声明的，不能无限长地进提示词。
+MAX_CONTEXT_CHARS = 200
+
+
+@dataclass(slots=True)
+class BuddyStats:
+    """全部来自 SQL 的真实计数。"""
+
+    saved_recent: int  # 最近 7 天收藏进个人库的论文（saved=false 是浏览记录，不算）
+    saved_total: int
+    ideas_recent: int  # 最近 7 天在自己参与的课题里新增的想法
+    experiments_running: int
+    daily_today: int  # 今天的新论文（全平台）
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "saved_recent": self.saved_recent,
+            "saved_total": self.saved_total,
+            "ideas_recent": self.ideas_recent,
+            "experiments_running": self.experiments_running,
+            "daily_today": self.daily_today,
+        }
+
+
+async def collect_stats(session: AsyncSession, *, user_id: uuid.UUID) -> BuddyStats:
+    """用户自己的近况。只统计他真的参与的课题——别人课题的想法数与他无关。"""
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(days=RECENT_DAYS)
+    my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
+
+    async def count(stmt: Any) -> int:
+        return int((await session.execute(stmt)).scalar_one() or 0)
+
+    saved_recent = await count(
+        select(func.count())
+        .select_from(UserLibraryEntry)
+        .where(
+            UserLibraryEntry.user_id == user_id,
+            UserLibraryEntry.saved.is_(True),
+            UserLibraryEntry.trashed_at.is_(None),
+            UserLibraryEntry.created_at >= since,
+        )
+    )
+    saved_total = await count(
+        select(func.count())
+        .select_from(UserLibraryEntry)
+        .where(
+            UserLibraryEntry.user_id == user_id,
+            UserLibraryEntry.saved.is_(True),
+            UserLibraryEntry.trashed_at.is_(None),
+        )
+    )
+    ideas_recent = await count(
+        select(func.count())
+        .select_from(Idea)
+        .where(
+            Idea.project_id.in_(my_projects),
+            Idea.created_at >= since,
+            Idea.trashed_at.is_(None),
+        )
+    )
+    experiments_running = await count(
+        select(func.count())
+        .select_from(Experiment)
+        .where(
+            Experiment.project_id.in_(my_projects),
+            Experiment.status == "running",
+            Experiment.trashed_at.is_(None),
+        )
+    )
+    daily_today = await count(
+        select(func.count())
+        .select_from(DailyFeedEntry)
+        .where(DailyFeedEntry.feed_date == dt.datetime.now(dt.UTC).date())
+    )
+    return BuddyStats(
+        saved_recent=saved_recent,
+        saved_total=saved_total,
+        ideas_recent=ideas_recent,
+        experiments_running=experiments_running,
+        daily_today=daily_today,
+    )
+
+
+def compose_greeting(stats: BuddyStats, *, name: str | None = None) -> str:
+    """从计数里挑一句话说。挑，不是生成——数字必须对得上。
+
+    优先级是「他现在最可能关心的事」：跑着的实验 > 本周的积累 > 今天的新论文 >
+    什么都没有时的开场白。一次只说一件事，问候语不是仪表盘。
+    """
+    who = f"{name}，" if name else ""
+    if stats.experiments_running:
+        return (
+            f"{who}你有 {stats.experiments_running} 个实验正在跑。"
+            "要我帮你看看进展，或者一起理下一步吗？"
+        )
+    if stats.ideas_recent:
+        return f"{who}这周你已经攒了 {stats.ideas_recent} 个新想法。想挑一个往下推推吗？"
+    if stats.saved_recent:
+        return (
+            f"{who}这周你收了 {stats.saved_recent} 篇论文进库。"
+            "要我帮你把它们串一串，看看有没有共同的线索？"
+        )
+    if stats.daily_today:
+        return f"{who}今天新到了 {stats.daily_today} 篇论文。要我先替你筛一遍吗？"
+    if stats.saved_total:
+        return f"{who}你的库里已经有 {stats.saved_total} 篇论文了。今天想从哪儿看起？"
+    return f"{who}我是 PolarisBuddy。你在平台上做的事我都能帮上手——先从一个问题开始吧。"
+
+
+#: 页面类型 → 说给模型听的一句话。键与前端 `buddyContext.ts` 的 kind 一一对应。
+_CONTEXT_LABELS = {
+    "paper": "用户正在读一篇论文",
+    "idea": "用户正在看一个研究想法",
+    "experiment": "用户正在看一个实验",
+    "library": "用户正在浏览一个文献库",
+    "project": "用户正在课题工作台",
+    "manuscript": "用户正在写论文稿",
+    "daily": "用户正在看每日新论文列表",
+}
+
+
+def render_page_context(kind: str | None, obj_id: str | None) -> str:
+    """把前端声明的页面上下文渲染成一行注入文本；认不出就返回空串。
+
+    上下文是**线索不是授权**：这里只说"用户在看什么"，Buddy 要真去读内容还得调
+    工具，那条路上的权限校验一点没少。所以前端伪造 id 最多让 Buddy 查一篇它本来
+    就有权查的东西。
+    """
+    label = _CONTEXT_LABELS.get((kind or "").strip())
+    if not label:
+        return ""
+    line = label if not obj_id else f"{label}（id: {obj_id}）"
+    return f"[当前页面] {line}。回答时优先考虑这个上下文；用户说「这篇」「这个」多半指它。"[
+        :MAX_CONTEXT_CHARS
+    ]

--- a/src/backend/tests/test_buddy.py
+++ b/src/backend/tests/test_buddy.py
@@ -1,0 +1,155 @@
+"""PolarisBuddy 的陪伴层：问候语与页面上下文。
+
+问候语的价值全在**数字是真的**上。它不过模型，所以这里能把每一句话钉死：
+数字对不上就是 bug，不是"模型今天心情不好"。
+"""
+
+import os
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.services import buddy
+from tests.conftest import register_and_login
+
+
+@pytest.fixture
+def agent_on(monkeypatch):
+    from app.core.config import get_settings
+
+    monkeypatch.setenv("POLARIS_CHAT_AGENT_ENABLED", "true")
+    get_settings.cache_clear()
+    yield
+    os.environ.pop("POLARIS_CHAT_AGENT_ENABLED", None)
+    get_settings.cache_clear()
+
+
+def _stats(**kw) -> buddy.BuddyStats:
+    base = {
+        "saved_recent": 0,
+        "saved_total": 0,
+        "ideas_recent": 0,
+        "experiments_running": 0,
+        "daily_today": 0,
+    }
+    return buddy.BuddyStats(**{**base, **kw})
+
+
+def test_greeting_reports_the_real_numbers():
+    """句子里的数字必须来自计数——这是它不过模型的全部理由。"""
+    assert "3 个实验" in buddy.compose_greeting(_stats(experiments_running=3))
+    assert "5 个新想法" in buddy.compose_greeting(_stats(ideas_recent=5))
+    assert "7 篇论文进库" in buddy.compose_greeting(_stats(saved_recent=7))
+    assert "12 篇论文" in buddy.compose_greeting(_stats(daily_today=12))
+
+
+def test_greeting_says_one_thing_at_a_time():
+    """同时有实验和想法时只说最要紧的那件事。问候语不是仪表盘。"""
+    line = buddy.compose_greeting(_stats(experiments_running=2, ideas_recent=9, saved_recent=4))
+    assert "2 个实验" in line
+    assert "9" not in line and "4 篇" not in line
+
+
+def test_greeting_without_any_data_still_greets():
+    """什么都没有时也要有一句话——新用户开面板看到空白最劝退。"""
+    line = buddy.compose_greeting(_stats(), name="小明")
+    assert line.startswith("小明，")
+    assert "PolarisBuddy" in line
+
+
+def test_page_context_renders_only_known_kinds():
+    """认不出的 kind 返回空串：前端能声明任何字符串，不能让它随便往提示词里塞话。"""
+    line = buddy.render_page_context("paper", "abc-123")
+    assert "正在读一篇论文" in line and "abc-123" in line
+    assert buddy.render_page_context("whatever", "x") == ""
+    assert buddy.render_page_context(None, None) == ""
+    # 长度封顶：它是前端声明的，不能无限长
+    assert len(buddy.render_page_context("paper", "y" * 500)) <= buddy.MAX_CONTEXT_CHARS
+
+
+async def test_stats_only_count_this_users_data(client):
+    """别人库里的论文不算在我头上；只浏览没收藏的也不算。"""
+    from app.models.library import UserLibraryEntry
+
+    token_a = await register_and_login(client, email="buddy-a@example.com")
+    token_b = await register_and_login(client, email="buddy-b@example.com")
+    assert token_a and token_b
+
+    async with get_sessionmaker()() as session:
+        from sqlalchemy import select
+
+        from app.models.user import User
+
+        users = {
+            u.email: u.id
+            for u in (await session.execute(select(User))).scalars().all()
+        }
+        a, b = users["buddy-a@example.com"], users["buddy-b@example.com"]
+        for i in range(3):
+            session.add(
+                UserLibraryEntry(
+                    user_id=a, dedup_key=str(uuid.uuid4()), title=f"A{i}", saved=True
+                )
+            )
+        # 只浏览没收藏的条目不算"收进库"
+        session.add(
+            UserLibraryEntry(user_id=a, dedup_key=str(uuid.uuid4()), title="browsed", saved=False)
+        )
+        session.add(
+            UserLibraryEntry(user_id=b, dedup_key=str(uuid.uuid4()), title="B0", saved=True)
+        )
+        await session.commit()
+
+        stats_a = await buddy.collect_stats(session, user_id=a)
+        stats_b = await buddy.collect_stats(session, user_id=b)
+    assert stats_a.saved_total == 3
+    assert stats_b.saved_total == 1
+
+
+async def test_greeting_endpoint_returns_sentence_and_counts(client, agent_on):
+    token = await register_and_login(client, email="buddy-ep@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.get("/api/chat/buddy/greeting", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["greeting"]
+    assert set(body["stats"]) == {
+        "saved_recent",
+        "saved_total",
+        "ideas_recent",
+        "experiments_running",
+        "daily_today",
+    }
+
+
+async def test_page_context_reaches_the_model_as_a_user_prefix(client, agent_on, monkeypatch):
+    """页面上下文拼在**本轮提问**前面，不进 system——system 是稳定前缀，
+    每轮变一次等于 prompt cache 永不命中。"""
+    from app.agents.chat import loop as loop_mod
+
+    seen: list[list] = []
+    original = loop_mod.ChatAgentLoop.run
+
+    def spy(self, req):
+        seen.append([req.page_context, req.question])
+        return original(self, req)
+
+    monkeypatch.setattr(loop_mod.ChatAgentLoop, "run", spy)
+
+    token = await register_and_login(client, email="buddy-ctx@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    conv = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv['id']}/turn",
+        json={"question": "这篇讲了什么", "page_kind": "paper", "page_id": "p-1"},
+        headers=headers,
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+
+    assert seen, "循环没被调用"
+    page_context, question = seen[0]
+    assert "正在读一篇论文" in page_context and "p-1" in page_context
+    assert question == "这篇讲了什么", "提问本身不该被改写"

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -10,6 +10,7 @@ import { UpdateBadge } from '../components/ui/UpdateBadge';
 import { useAuth } from './auth';
 import { topicPath, useProject } from './project';
 import { AssistantPanel } from '../features/assistant/AssistantPanel';
+import { BuddyBubble } from '../features/assistant/BuddyBubble';
 import { SearchPalette } from './SearchPalette';
 import { UserMenu } from './UserMenu';
 import { FeedbackWidget } from '../features/feedback/FeedbackWidget';
@@ -430,13 +431,16 @@ export function AppShell() {
   // —— 全局搜索（⌘K / Ctrl+K）——
   const [searchOpen, setSearchOpen] = useState(false);
   const [assistantOpen, setAssistantOpen] = useState(false);
+  // 拖到悬浮球上的论文：交给面板发起解读，取走后清空（清空由面板回调做）
+  const [droppedPaperId, setDroppedPaperId] = useState<string | null>(null);
+  const [buddyBusy, setBuddyBusy] = useState(false);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setSearchOpen((o) => !o);
       }
-      // ⌘J：全局助手。挑 J 是因为 ⌘K 已被搜索占了，而两者都该是全局的
+      // ⌘J：PolarisBuddy。挑 J 是因为 ⌘K 已被搜索占了，而两者都该是全局的
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
         e.preventDefault();
         setAssistantOpen((o) => !o);
@@ -811,8 +815,22 @@ export function AppShell() {
       {/* —— 全局搜索面板 —— */}
       <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
 
-      {/* —— 全局助手（⌘J）—— */}
-      <AssistantPanel open={assistantOpen} onClose={() => setAssistantOpen(false)} />
+      {/* —— PolarisBuddy：悬浮球 + 抽屉（⌘J）—— */}
+      <BuddyBubble
+        busy={buddyBusy}
+        onOpen={() => setAssistantOpen(true)}
+        onDropPaper={(paperId) => {
+          setDroppedPaperId(paperId);
+          setAssistantOpen(true);
+        }}
+      />
+      <AssistantPanel
+        open={assistantOpen}
+        onClose={() => setAssistantOpen(false)}
+        droppedPaperId={droppedPaperId}
+        onDroppedPaperHandled={() => setDroppedPaperId(null)}
+        onBusyChange={setBuddyBusy}
+      />
 
       <ToastHost />
     </div>

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Icon } from '../../components/ui/Icon';
 import { Markdown } from '../../lib/markdown';
 import { api, type ProjectRead } from '../../lib/api';
 import { assistantTurnSse, type AssistantBlock } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
+import { pageContextFrom } from './buddyContext';
+import { TurnStatus } from './TurnStatus';
 
 /* ============================================================
-   Polaris 助手：全局抽屉。⌘J 开关。
+   PolarisBuddy：全局抽屉。⌘J 开关，或点右下角的悬浮球。
 
-   与现有六个对话入口并存——它们一行没改。助手能跨课题/库/论文调用平台工具，
+   与现有六个对话入口并存——它们一行没改。Buddy 能跨课题/库/论文调用平台工具，
    界面上多出来的就是「工具卡片」：正在调什么、调完拿到了什么。
 
    渲染必须**防御式**：SSE 过来的是 JSON.parse 出来的 any，TypeScript 只在编译期
@@ -126,23 +129,78 @@ function ToolCard({ block }: { block: Extract<AssistantBlock, { kind: 'tool' }> 
   );
 }
 
-function BlockView({ block }: { block: AssistantBlock }) {
+/** 思考块：跑的时候只露最后一行（瞟一眼就够），停了折起来。 */
+function ThinkingView({ text, live }: { text: string; live: boolean }) {
+  const [open, setOpen] = useState(false);
+  const tail = text.trim().split('\n').filter(Boolean).slice(-1)[0] ?? '';
+  return (
+    <div style={{ margin: '4px 0' }}>
+      <div
+        className="row gap6 hoverable"
+        style={{ cursor: 'pointer', alignItems: 'center', fontSize: 11.5, color: 'var(--text-4)' }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <Icon
+          name="chevDown"
+          size={11}
+          style={{ transform: open ? undefined : 'rotate(-90deg)', transition: 'transform 0.12s' }}
+        />
+        <span>{tr('思考过程', 'Thinking')}</span>
+        {!open && live && (
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              opacity: 0.75,
+            }}
+          >
+            {tail}
+          </span>
+        )}
+      </div>
+      {open && (
+        <div
+          style={{
+            fontSize: 12,
+            color: 'var(--text-3)',
+            whiteSpace: 'pre-wrap',
+            borderLeft: '2px solid var(--border-2)',
+            paddingLeft: 9,
+            marginTop: 4,
+            lineHeight: 1.6,
+          }}
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BlockView({ block, live }: { block: AssistantBlock; live: boolean }) {
   if (block.kind === 'text') return <Markdown source={block.text} />;
-  if (block.kind === 'thinking') {
-    return (
-      <details style={{ margin: '4px 0' }}>
-        <summary style={{ fontSize: 11.5, color: 'var(--text-4)', cursor: 'pointer' }}>
-          {tr('思考过程', 'Thinking')}
-        </summary>
-        <div style={{ fontSize: 12, color: 'var(--text-3)', whiteSpace: 'pre-wrap' }}>{block.text}</div>
-      </details>
-    );
-  }
+  if (block.kind === 'thinking') return <ThinkingView text={block.text} live={live} />;
   if (block.kind === 'tool') return <ToolCard block={block} />;
   return null; // 未知块：画不出来就不画，绝不抛
 }
 
-export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function AssistantPanel({
+  open,
+  onClose,
+  droppedPaperId,
+  onDroppedPaperHandled,
+  onBusyChange,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** 拖到悬浮球上的论文 id：进来就自动问一句「解读这篇」 */
+  droppedPaperId?: string | null;
+  onDroppedPaperHandled?: () => void;
+  onBusyChange?: (busy: boolean) => void;
+}) {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
@@ -157,14 +215,37 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
   const [projectId, setProjectId] = useState<string | null>(null);
   //: 上一轮因为没选课题而失败过——把选择器点亮，别让人对着一句错误发呆
   const [projectMissing, setProjectMissing] = useState(false);
+  const [greeting, setGreeting] = useState<string>('');
+  const [stats, setStats] = useState<Record<string, number>>({});
+  const [contextOn, setContextOn] = useState(true);
   const abortRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  const pageContext = pageContextFrom(location.pathname);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
   }, [turns]);
 
   useEffect(() => () => abortRef.current?.(), []);
+
+  useEffect(() => {
+    onBusyChange?.(busy);
+  }, [busy, onBusyChange]);
+
+  // 开面板时取一次问候语。数字是 SQL 数出来的，**不过模型**——每次开面板过一次 LLM
+  // 既慢又费钱，而且模型会把数字说错。取不到就不说，不要兜一句假的（0 和「没数出来」
+  // 在界面上长得一样，对用户却是两回事）。
+  useEffect(() => {
+    if (!open || greeting) return;
+    void api
+      .getBuddyGreeting()
+      .then((g) => {
+        setGreeting(g.greeting);
+        setStats(g.stats ?? {});
+      })
+      .catch(() => setGreeting(''));
+  }, [open, greeting]);
 
   // 面板打开时才拉课题列表：关着的时候没人看得见，不值得多一个请求。
   useEffect(() => {
@@ -236,10 +317,9 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
     setProjectMissing(false);
   }, [stop]);
 
-  const send = useCallback(async () => {
-    const question = input.trim();
+  const ask = useCallback(
+    async (question: string) => {
     if (!question || busy) return;
-    setInput('');
     setBusy(true);
     setTurns((t) => [...t, { role: 'user', blocks: [{ kind: 'text', text: question }] }, { role: 'assistant', blocks: [] }]);
 
@@ -274,6 +354,10 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
       id,
       question,
       {
+        // 页面上下文是**线索不是授权**：它只说用户在看什么，真要读内容还得调工具，
+        // 那条路上的权限校验一点没少。用户可以关掉。
+        page:
+          contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
         onBlocks: patch,
         onDone: () => setBusy(false),
         onError: (detail) => {
@@ -284,9 +368,43 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
       },
       projectId,
     );
-  }, [input, busy, convId, projectId]);
+    },
+    [busy, convId, projectId, contextOn, pageContext],
+  );
+
+  const send = useCallback(() => {
+    const question = input.trim();
+    if (!question) return;
+    setInput('');
+    void ask(question);
+  }, [input, ask]);
+
+  // 论文被拖到悬浮球上：直接问一句解读。id 写进问题里，Buddy 自己去 get_paper。
+  useEffect(() => {
+    if (!droppedPaperId || busy) return;
+    onDroppedPaperHandled?.();
+    void ask(
+      tr(
+        `帮我解读这篇论文（id: ${droppedPaperId}）：它解决什么问题、方法怎么工作、证据强不强。`,
+        `Walk me through this paper (id: ${droppedPaperId}): the problem, how the method works, how strong the evidence is.`,
+      ),
+    );
+  }, [droppedPaperId, busy, ask, onDroppedPaperHandled]);
 
   if (!open) return null;
+
+  // 快捷动作按真实计数给：没有实验就不该出现「实验怎么样了」
+  const suggestions = [
+    stats.experiments_running ? tr('我的实验现在怎么样了？', 'How are my experiments doing?') : '',
+    stats.daily_today ? tr('帮我筛一遍今天的新论文', 'Triage today’s new papers for me') : '',
+    stats.saved_recent
+      ? tr('这周我收的论文有什么共同线索？', 'What connects the papers I saved this week?')
+      : '',
+    pageContext?.kind === 'paper' ? tr('解读我正在看的这篇', 'Walk me through this paper') : '',
+  ].filter(Boolean);
+
+  const lastTurn = turns[turns.length - 1];
+  const liveBlocks = busy && lastTurn?.role === 'assistant' ? lastTurn.blocks : [];
 
   return (
     <div
@@ -305,14 +423,9 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
       }}
     >
       <div className="row gap8" style={{ padding: '12px 16px', borderBottom: '0.5px solid var(--border-2)', alignItems: 'center' }}>
-        <Icon name="chat" size={15} style={{ color: 'var(--accent)' }} />
-        <strong style={{ fontSize: 14 }}>{tr('Polaris 助手', 'Polaris assistant')}</strong>
+        <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
+        <strong style={{ fontSize: 14 }}>PolarisBuddy</strong>
         <span style={{ flex: 1 }} />
-        {busy && (
-          <button className="btn btn-ghost sm" onClick={stop} style={{ height: 24, fontSize: 11 }}>
-            <Icon name="pause" size={11} /> {tr('停止', 'Stop')}
-          </button>
-        )}
         <button
           className="icon-btn"
           onClick={() => void openHistory()}
@@ -407,34 +520,86 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
 
       <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px' }}>
         {turns.length === 0 && (
-          <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.7 }}>
-            {tr(
-              '助手可以调用平台的检索工具去查东西，而不是只凭上下文猜。试试问「最近有哪些关于 planning 的新论文」。',
-              'The assistant calls the platform’s search tools instead of guessing from context. Try asking what is new on a topic.',
+          <div style={{ fontSize: 12.5, lineHeight: 1.7 }}>
+            {greeting && (
+              <div
+                style={{
+                  background: 'var(--accent-soft)',
+                  color: 'var(--accent-text)',
+                  borderRadius: 10,
+                  padding: '10px 12px',
+                  marginBottom: 10,
+                  fontSize: 13,
+                }}
+              >
+                {greeting}
+              </div>
             )}
+            <div style={{ color: 'var(--text-3)' }}>
+              {tr(
+                '我会调用平台的检索工具去查，而不是凭上下文猜。把论文拖到右下角的球上，我就替你读它。',
+                'I call the platform’s search tools instead of guessing. Drop a paper on the bubble and I’ll read it for you.',
+              )}
+            </div>
+            {/* 快捷动作只在对应数据真的存在时出现：没有实验就不该问「实验怎么样了」 */}
+            <div className="row gap6 wrap" style={{ marginTop: 10 }}>
+              {suggestions.map((text) => (
+                <span
+                  key={text}
+                  className="chip"
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => void ask(text)}
+                >
+                  {text}
+                </span>
+              ))}
+            </div>
           </div>
         )}
-        {turns.map((turn, i) => (
-          <div key={i} style={{ marginBottom: 14 }}>
-            {turn.role === 'user' ? (
-              <div style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', borderRadius: 9, padding: '8px 11px', fontSize: 13 }}>
-                {turn.blocks.map((b, j) => (b.kind === 'text' ? <span key={j}>{b.text}</span> : null))}
-              </div>
-            ) : (
-              <div style={{ fontSize: 13, lineHeight: 1.7 }}>
-                {turn.blocks.map((b, j) => (
-                  <BlockView key={j} block={b} />
-                ))}
-                {busy && i === turns.length - 1 && turn.blocks.length === 0 && (
-                  <span style={{ color: 'var(--text-4)', fontSize: 12 }}>{tr('思考中…', 'Thinking…')}</span>
-                )}
-              </div>
-            )}
-          </div>
-        ))}
+        {turns.map((turn, i) => {
+          const isLast = i === turns.length - 1;
+          return (
+            <div key={i} style={{ marginBottom: 14 }}>
+              {turn.role === 'user' ? (
+                <div style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', borderRadius: 9, padding: '8px 11px', fontSize: 13 }}>
+                  {turn.blocks.map((b, j) => (b.kind === 'text' ? <span key={j}>{b.text}</span> : null))}
+                </div>
+              ) : (
+                <div style={{ fontSize: 13, lineHeight: 1.7 }}>
+                  {turn.blocks.map((b, j) => (
+                    <BlockView
+                      key={j}
+                      block={b}
+                      live={busy && isLast && j === turn.blocks.length - 1}
+                    />
+                  ))}
+                  {isLast && <TurnStatus blocks={liveBlocks} busy={busy} onStop={stop} />}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
+        {pageContext && (
+          <div
+            className="row gap6"
+            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)' }}
+            title={tr(
+              '我知道你在看什么。关掉的话这轮就不带页面信息了。',
+              'I can see what you are looking at. Turn it off to leave the page out of this turn.',
+            )}
+          >
+            <input
+              type="checkbox"
+              checked={contextOn}
+              onChange={(e) => setContextOn(e.target.checked)}
+              style={{ width: 12, height: 12, margin: 0, accentColor: 'var(--accent)', cursor: 'pointer' }}
+            />
+            <span>{pageContext.label}</span>
+          </div>
+        )}
         <textarea
           className="textarea"
           rows={2}
@@ -444,7 +609,7 @@ export function AssistantPanel({ open, onClose }: { open: boolean; onClose: () =
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
-              void send();
+              send();
             }
           }}
           style={{ width: '100%', fontSize: 13 }}

--- a/src/frontend/src/features/assistant/BuddyBubble.tsx
+++ b/src/frontend/src/features/assistant/BuddyBubble.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   PolarisBuddy 的悬浮球。
+
+   - 可拖拽，位置记在 localStorage（下次进来还在老地方）；
+   - 点击展开对话面板；拖动结束的那一下不算点击（按位移阈值区分）；
+   - 是论文拖放的落点：论文卡片拖过来 → 高亮 → 松手把 paper_id 交给面板解读。
+   ============================================================ */
+
+const POS_KEY = 'polaris.buddy.pos';
+const CLICK_THRESHOLD_PX = 6;
+
+interface Pos {
+  right: number;
+  bottom: number;
+}
+
+function loadPos(): Pos {
+  try {
+    const raw = localStorage.getItem(POS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Pos;
+      if (typeof parsed.right === 'number' && typeof parsed.bottom === 'number') {
+        return {
+          right: Math.min(Math.max(parsed.right, 8), window.innerWidth - 64),
+          bottom: Math.min(Math.max(parsed.bottom, 8), window.innerHeight - 64),
+        };
+      }
+    }
+  } catch {
+    /* 坏数据回默认位 */
+  }
+  return { right: 24, bottom: 96 };
+}
+
+export function BuddyBubble({
+  onOpen,
+  onDropPaper,
+  busy,
+}: {
+  onOpen: () => void;
+  /** 论文被拖到球上：paper_id 交给面板发起解读 */
+  onDropPaper: (paperId: string) => void;
+  busy: boolean;
+}) {
+  const [pos, setPos] = useState<Pos>(loadPos);
+  const [dragOver, setDragOver] = useState(false);
+  const dragState = useRef<{ startX: number; startY: number; moved: boolean } | null>(null);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(POS_KEY, JSON.stringify(pos));
+    } catch {
+      /* 存不上就算了 */
+    }
+  }, [pos]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragState.current = { startX: e.clientX, startY: e.clientY, moved: false };
+      const origin = { ...pos };
+
+      const onMove = (ev: PointerEvent) => {
+        const dx = ev.clientX - (dragState.current?.startX ?? 0);
+        const dy = ev.clientY - (dragState.current?.startY ?? 0);
+        if (Math.abs(dx) + Math.abs(dy) > CLICK_THRESHOLD_PX && dragState.current) {
+          dragState.current.moved = true;
+        }
+        setPos({
+          right: Math.min(Math.max(origin.right - dx, 8), window.innerWidth - 64),
+          bottom: Math.min(Math.max(origin.bottom - dy, 8), window.innerHeight - 64),
+        });
+      };
+      const onUp = () => {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        // 没怎么动 = 点击
+        if (dragState.current && !dragState.current.moved) onOpen();
+        dragState.current = null;
+      };
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+    },
+    [pos, onOpen],
+  );
+
+  return (
+    <div
+      role="button"
+      aria-label="PolarisBuddy"
+      title={tr('PolarisBuddy（⌘J）· 可拖动 · 把论文拖过来让我解读', 'PolarisBuddy (⌘J) · drag me · drop a paper on me')}
+      onPointerDown={onPointerDown}
+      onDragOver={(e) => {
+        // 只认平台内拖出的论文
+        if (e.dataTransfer.types.includes('application/x-polaris-paper')) {
+          e.preventDefault();
+          setDragOver(true);
+        }
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOver(false);
+        const paperId = e.dataTransfer.getData('application/x-polaris-paper');
+        if (paperId) onDropPaper(paperId);
+      }}
+      style={{
+        position: 'fixed',
+        right: pos.right,
+        bottom: pos.bottom,
+        width: 52,
+        height: 52,
+        borderRadius: '50%',
+        background: dragOver ? 'var(--accent)' : 'var(--surface)',
+        border: `2px solid ${dragOver ? 'var(--accent)' : 'var(--accent-soft)'}`,
+        boxShadow: '0 4px 16px rgba(0,0,0,0.14)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'grab',
+        zIndex: 70,
+        transform: dragOver ? 'scale(1.15)' : undefined,
+        transition: 'transform 0.12s ease, background 0.12s ease',
+        touchAction: 'none',
+        userSelect: 'none',
+      }}
+    >
+      <Icon
+        name={busy ? 'refresh' : 'sparkle'}
+        size={22}
+        style={{
+          color: dragOver ? '#fff' : 'var(--accent)',
+          animation: busy ? 'spin 1.2s linear infinite' : undefined,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/features/assistant/TurnStatus.tsx
+++ b/src/frontend/src/features/assistant/TurnStatus.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import type { AssistantBlock } from '../../lib/assistantStream';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   一轮对话的「现在在干什么」。
+
+   状态**只从已收到的块推**，不另立一套状态机——界面说的和流里发生的是同一件事，
+   不会出现"显示正在检索、其实早就在写答案了"（#249 的老毛病就是两套状态各说各话）。
+
+   四态：
+     thinking  收到过 thinking、还没工具也没正文
+     tool      最后一个块是 running 的工具
+     writing   正文正在流
+     idle      本轮结束
+   ============================================================ */
+
+export type TurnPhase = 'thinking' | 'tool' | 'writing' | 'idle';
+
+export function phaseOf(blocks: AssistantBlock[], busy: boolean): TurnPhase {
+  if (!busy) return 'idle';
+  const last = blocks[blocks.length - 1];
+  if (last?.kind === 'tool' && last.state === 'running') return 'tool';
+  if (last?.kind === 'text') return 'writing';
+  if (last?.kind === 'thinking') return 'thinking';
+  return 'thinking';
+}
+
+/** 已跑过的秒数。给长轮次一个"它还活着"的凭据。 */
+function useElapsed(active: boolean) {
+  const [secs, setSecs] = useState(0);
+  const startedAt = useRef<number | null>(null);
+  useEffect(() => {
+    if (!active) {
+      startedAt.current = null;
+      setSecs(0);
+      return;
+    }
+    startedAt.current = Date.now();
+    const timer = window.setInterval(() => {
+      if (startedAt.current) setSecs(Math.round((Date.now() - startedAt.current) / 1000));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [active]);
+  return secs;
+}
+
+export function TurnStatus({
+  blocks,
+  busy,
+  onStop,
+}: {
+  blocks: AssistantBlock[];
+  busy: boolean;
+  onStop: () => void;
+}) {
+  const phase = phaseOf(blocks, busy);
+  const secs = useElapsed(busy);
+  if (phase === 'idle') return null;
+
+  const running = blocks.filter((b) => b.kind === 'tool' && b.state === 'running');
+  const label =
+    phase === 'tool'
+      ? tr(
+          `正在查：${running.map((b) => (b.kind === 'tool' ? b.name : '')).join('、')}`,
+          `Searching: ${running.map((b) => (b.kind === 'tool' ? b.name : '')).join(', ')}`,
+        )
+      : phase === 'writing'
+        ? tr('正在写答案', 'Writing')
+        : tr('正在思考', 'Thinking');
+
+  return (
+    <div
+      className="row gap8"
+      style={{
+        alignItems: 'center',
+        margin: '6px 0',
+        fontSize: 12,
+        color: 'var(--text-3)',
+      }}
+    >
+      <Icon name="refresh" size={12} style={{ color: 'var(--accent)', animation: 'spin 1.1s linear infinite' }} />
+      <span>{label}</span>
+      {secs >= 3 && (
+        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+          {secs}s
+        </span>
+      )}
+      <span style={{ flex: 1 }} />
+      <button className="btn btn-ghost sm" onClick={onStop} style={{ height: 22, fontSize: 11 }}>
+        {tr('停止', 'Stop')}
+      </button>
+    </div>
+  );
+}

--- a/src/frontend/src/features/assistant/buddyContext.ts
+++ b/src/frontend/src/features/assistant/buddyContext.ts
@@ -1,0 +1,42 @@
+/* ============================================================
+   PolarisBuddy 的页面感知：从当前路由推「用户正在看什么」。
+
+   感知完全在前端做——Buddy 挂在 AppShell 里，本来就能读路由。发问时把这份上下文
+   作为 page_context 传给后端注入本轮消息，**不新增任何后端感知机制**：上下文由前端
+   声明，天然不越权（Buddy 拿着 id 去调工具读内容时，走的还是原有的权限口）。
+   ============================================================ */
+
+export interface PageContext {
+  kind: 'paper' | 'idea' | 'experiment' | 'library' | 'project' | 'daily' | 'manuscript';
+  id?: string;
+  /** 人读的一句话，注入提示词用（"用户正在读论文 …"） */
+  label: string;
+}
+
+const PATTERNS: [RegExp, (m: RegExpMatchArray) => PageContext][] = [
+  [
+    /^\/papers\/([0-9a-f-]{36})\/read/,
+    (m) => ({ kind: 'paper', id: m[1], label: '正在读一篇论文' }),
+  ],
+  [/^\/ideas\/([0-9a-f-]{36})/, (m) => ({ kind: 'idea', id: m[1], label: '正在看一个研究想法' })],
+  [
+    /^\/experiment\/([0-9a-f-]{36})/,
+    (m) => ({ kind: 'experiment', id: m[1], label: '正在看一个实验' }),
+  ],
+  [
+    /^\/libraries\/([0-9a-f-]{36})/,
+    (m) => ({ kind: 'library', id: m[1], label: '正在浏览一个文献库' }),
+  ],
+  [/^\/writer\/([0-9a-f-]{36})/, (m) => ({ kind: 'manuscript', id: m[1], label: '正在写论文稿' })],
+  [/^\/t\/([0-9a-f-]{36})/, (m) => ({ kind: 'project', id: m[1], label: '正在课题工作台' })],
+  [/^\/daily/, () => ({ kind: 'daily', label: '正在看每日新论文' })],
+];
+
+/** 从路由 pathname 推页面上下文；认不出返回 null（Buddy 照常工作，只是不带上下文）。 */
+export function pageContextFrom(pathname: string): PageContext | null {
+  for (const [pattern, build] of PATTERNS) {
+    const m = pathname.match(pattern);
+    if (m) return build(m);
+  }
+  return null;
+}

--- a/src/frontend/src/features/assistant/paperDrag.ts
+++ b/src/frontend/src/features/assistant/paperDrag.ts
@@ -1,0 +1,21 @@
+/* ============================================================
+   把论文拖给 PolarisBuddy。
+
+   自定义 MIME `application/x-polaris-paper` 而不是 text/plain：悬浮球只接平台自己
+   拖出来的论文，从别处拖进来的文字/文件不会误触发解读。同时也放一份 text/plain，
+   拖到外部编辑器里落下的是标题，不是一串 uuid。
+   ============================================================ */
+
+export const PAPER_DND_MIME = 'application/x-polaris-paper';
+
+/** 展开到论文行/卡片上：`<div {...paperDragProps(p.id, p.title)}>`。 */
+export function paperDragProps(paperId: string, title?: string) {
+  return {
+    draggable: true,
+    onDragStart: (e: React.DragEvent) => {
+      e.dataTransfer.setData(PAPER_DND_MIME, paperId);
+      if (title) e.dataTransfer.setData('text/plain', title);
+      e.dataTransfer.effectAllowed = 'copy';
+    },
+  };
+}

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -56,6 +56,7 @@ import { DailyLikes } from './DailyLikes';
 import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
 import { PaperProgressModal } from '../library/PaperProgressModal';
+import { paperDragProps } from '../assistant/paperDrag';
 
 /* ============================================================
    /daily — 每日新论文：arxiv 每日新提交（订阅分类内）。保留期由管理员配置（默认 14 天）。
@@ -121,6 +122,8 @@ function DailyRow({
   return (
     <div
       onClick={onClick}
+      // 可以直接拖给 PolarisBuddy 解读（右下角悬浮球是落点）
+      {...paperDragProps(p.paper_id, p.title)}
       style={{
         padding: '11px 14px 11px 16px',
         cursor: 'pointer',

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -62,6 +62,7 @@ import {
 } from '../wiki/shared';
 import { ReadingDot, readerFrom } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
+import { paperDragProps } from '../assistant/paperDrag';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
 const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
@@ -115,6 +116,8 @@ const PaperRow = memo(function PaperRow({
   return (
     <div
       onClick={onClick}
+      // 可以直接拖给 PolarisBuddy 解读（右下角悬浮球是落点）
+      {...paperDragProps(p.id, p.title)}
       style={{
         padding: '12px 16px',
         cursor: 'pointer',

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -48,6 +48,7 @@ import { PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/Pa
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
+import { paperDragProps } from '../assistant/paperDrag';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -538,6 +539,8 @@ const PaperRow = memo(function PaperRow({
   return (
     <div
       onClick={onClick}
+      // 可以直接拖给 PolarisBuddy 解读（右下角悬浮球是落点）
+      {...paperDragProps(p.id, p.title)}
       style={{
         padding: '12px 16px',
         cursor: 'pointer',

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4731,6 +4731,10 @@ export const api = {
    */
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
   /** 全局助手：会话列表（最近说过话的在前）。 */
+  /** PolarisBuddy 开面板时的问候语。数字是 SQL 数出来的，不过模型。 */
+  getBuddyGreeting(): Promise<{ greeting: string; stats: Record<string, number> }> {
+    return request<{ greeting: string; stats: Record<string, number> }>('/chat/buddy/greeting');
+  },
   listAssistantConversations(): Promise<
     { id: string; title: string; last_message_at: string | null; project_id: string | null }[]
   > {

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -22,6 +22,8 @@ export type AssistantBlock =
     };
 
 export interface AssistantHandlers {
+  /** 用户此刻在看的页面（PolarisBuddy 的页面感知）；不传就不带 */
+  page?: { kind: string; id?: string };
   /** 用「上一份块列表 → 新块列表」的形式增量更新（React 状态直接套用）。 */
   onBlocks: (fn: (blocks: AssistantBlock[]) => AssistantBlock[]) => void;
   onDone: (stopReason: string) => void;
@@ -54,7 +56,11 @@ export function assistantTurnSse(
 ): () => void {
   return postSse(
     `/chat/conversations/${conversationId}/turn`,
-    projectId ? { question, project_id: projectId } : { question },
+    {
+      question,
+      ...(projectId ? { project_id: projectId } : {}),
+      ...(handlers.page ? { page_kind: handlers.page.kind, page_id: handlers.page.id } : {}),
+    },
     {
       onEvent: (event, raw) => {
         const data = parse(raw);


### PR DESCRIPTION
The assistant is renamed **PolarisBuddy** and stops being a drawer hiding behind ⌘J.

## A bubble, not a drawer

A draggable bubble sits in the corner (position remembered in `localStorage`, clamped to the viewport on restore so a resized window can't strand it off-screen). A short press opens the panel; anything past a 6px displacement is a drag, not a click. It spins while a turn is running, so you can see Buddy working with the panel closed.

It is also a **drop target**: paper rows in the library, the daily feed, and the wiki paper list are draggable, and dropping one on the bubble asks Buddy to walk you through that paper. The payload rides a custom MIME (`application/x-polaris-paper`) so dragging arbitrary text or files onto the bubble does nothing — plus a `text/plain` copy so dragging a paper into an outside editor drops a title, not a UUID.

## Page awareness

The frontend derives what you're looking at from the route (paper / idea / experiment / library / project / manuscript / daily) and sends it as `page_kind` + `page_id`. The backend renders it into one line that is prefixed to **that turn's question**, never into the system prompt — the system prompt is a stable cache prefix, and rewriting it every turn means the prompt cache never hits.

The context is **a hint, not an authorization**: it says what the user is looking at, and Buddy still has to call a tool to read anything, with every existing permission check on that path intact. A forged id at worst makes Buddy look up something the user could already read. Unknown `kind` values render to an empty string rather than being passed through — the client can declare any string, but it can't inject arbitrary text into the prompt. There's a length cap for the same reason. A checkbox above the composer turns it off per turn.

## The greeting is counted, not generated

Opening the panel shows one line based on your actual data, prioritized by what you most likely care about right now: running experiments → this week's ideas → this week's saves → today's new papers → a plain hello. It says **one** thing; a greeting is not a dashboard.

It deliberately does not go through a model. It appears on every open, so an LLM call would mean paying and waiting every single time — and, worse, a model will get the numbers wrong. "You saved 12 papers this week" has to actually be 12. Every number is a `COUNT(*)`; the sentence is *selected* from the numbers, not written. If the query fails the panel says nothing at all rather than showing a fabricated zero: "you haven't saved anything this week" and "the stats query broke" look identical on screen but mean opposite things.

Saves count only `saved=true`, non-trashed entries — browsing records are rows in the same table, and calling them "papers you collected" would be a lie of the same kind.

## Turn state

A status strip shows what's happening right now: *thinking* / *searching `<tool>`* / *writing*, with elapsed seconds after 3s and a stop button. The phase is derived purely from the blocks already received — no second state machine. That is the bug class from #249: two sources of truth disagreeing, the spinner still saying "thinking" while the answer streams. Thinking blocks show only their last line while live (glanceable), collapsed when idle, expandable always.

The empty state offers quick actions, but only ones the data supports — no "how are my experiments doing?" chip for someone with no experiments.

## Tests

7 new in `tests/test_buddy.py`: each greeting branch reports the real number, only one fact is stated when several apply, a user with no data still gets greeted, unknown page kinds render empty and long ids are capped, stats don't leak across users (a second user's saves and a browse-only row are both seeded as negatives), the endpoint returns sentence + counts, and page context reaches the loop as a user-message prefix with the question itself left unmodified.

Full suite **1056 passed**; `tsc --noEmit` + `vite build` clean.

## Manual click-through (no frontend test tooling)

1. Drag the bubble around, reload — it comes back where you left it.
2. Drag a paper row from the daily list onto it — panel opens, Buddy starts reading that paper.
3. Open it on a paper page — the composer shows the page-context line ("reading a paper") with a checkbox; uncheck it and the next turn goes without context.
4. Ask something that needs a search — status goes thinking → searching → writing; Stop cuts it mid-stream.
