### PR TITLE
feat(assistant): drop the topic picker — PolarisBuddy searches every library you can see

### DIFF
--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -49,6 +49,7 @@ from app.services import agent_skills, buddy
 from app.services import conversations as store
 from app.services import projects as projects_service
 from app.tools.context import ToolContext
+from app.tools.scope import visible_library_ids
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -259,15 +260,29 @@ async def run_turn(
     await store.append_message(session, conversation=conv, role="user", text=payload.question)
     await session.commit()
 
-    project_id = await _resolve_project(
-        session, user=user, conv=conv, requested=payload.project_id
+    # PolarisBuddy 是**全局**助手：检索范围是「这个人看得见的全部文献库」，不再要求
+    # 先选一个课题。课题从来不是权限边界，只是库的一个子集；要求先选课题，等于让用户
+    # 替一个纯内部的数据结构做选择题，而他想问的往往正好跨库。
+    #
+    # 越权由可见性这一步挡住（口径与库列表页一致：管理员看全部，普通用户看自己的
+    # 个人库加公共库），不是靠"只给一个课题"。
+    library_ids = tuple(await visible_library_ids(session, user))
+    # 本轮显式指定课题时仍然收窄到那个课题（课题里的对话还走这条路）。
+    project_id = (
+        await _resolve_project(session, user=user, conv=conv, requested=payload.project_id)
+        if payload.project_id is not None
+        else None
     )
-    # project_id 为 None（用户没有课题）时这轮不带任何工具：ToolContext 里的占位 id
-    # 不会被用到，因为没有工具可调。这与从前兜随机 UUID 的区别是**诚实**——助手不会
-    # 调工具查到零条然后说「没查到」，它根本不会声称自己查过。
-    tool_names = tuple(payload.tool_names or DEFAULT_TOOL_NAMES) if project_id else ()
+    # 一个可见库都没有 = 没有语料可查，这轮不带工具。**不假装查过**：兜一个空范围
+    # 然后说「没查到」，与从前兜随机 UUID 一样是在撒谎。
+    has_corpus = bool(project_id) or bool(library_ids)
+    tool_names = tuple(payload.tool_names or DEFAULT_TOOL_NAMES) if has_corpus else ()
     tool_ctx = ToolContext(
-        project_id=project_id or uuid.uuid4(), llm=get_llm_router(), user_id=user.id
+        project_id=project_id,
+        # 指定了课题就按课题算范围（library_ids=None），否则给显式的可见库集合
+        library_ids=None if project_id else library_ids,
+        llm=get_llm_router(),
+        user_id=user.id,
     )
     loop = ChatAgentLoop(llm=get_llm_router(), tool_ctx=tool_ctx, history=history)
     req = ChatTurnRequest(
@@ -320,7 +335,10 @@ async def _resolve_project(
     conv: Any,
     requested: uuid.UUID | None,
 ) -> uuid.UUID | None:
-    """定出这轮工具检索的课题作用域；``None`` = 没有课题，这轮不带工具纯对话。
+    """定出这轮工具检索的课题作用域；``None`` = 不收窄到某个课题（走全局可见库）。
+
+    只在**本轮显式指定了课题**时才走到这里——全局助手默认按可见库检索，不再有
+    「先选课题」这道坎。留着它是因为课题内的对话仍然需要把范围收窄到那个课题。
 
     此前这里是 ``conv.project_id or conv.scope_id or uuid.uuid4()``，两个都空时兜一个
     **随机 UUID**——检索工具全按 project_id 过滤，于是助手在全局会话里永远查不到任何

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -152,9 +152,13 @@ async def _read_library_ids(
     *,
     project_id: uuid.UUID | None,
     library_id: uuid.UUID | None,
+    library_ids: Sequence[uuid.UUID] | None = None,
 ) -> list[uuid.UUID]:
-    """并集读路径的库解析：显式 library_id（单库读视图/库工作台）→ [library_id]；
+    """并集读路径的库解析：显式 library_ids（全局助手已按可见性算好的一组库）→ 原样用；
+    显式 library_id（单库读视图/库工作台）→ [library_id]；
     否则按课题关联库并集（P7；空关联=空语料，调用方返回空态而非报错）。"""
+    if library_ids is not None:
+        return list(library_ids)
     if library_id is not None:
         return [library_id]
     assert project_id is not None
@@ -1106,6 +1110,8 @@ async def keyword_search_papers(
     *,
     project_id: uuid.UUID | None = None,
     library_id: uuid.UUID | None = None,
+    #: 显式库集合（全局助手）：给了就不看 project_id
+    library_ids: Sequence[uuid.UUID] | None = None,
     q: str,
     limit: int,
     user_id: uuid.UUID | None = None,
@@ -1116,7 +1122,9 @@ async def keyword_search_papers(
     笔记仅作者本人可见（P5b），故只有传 user_id（用户检索入口）才并入笔记命中；
     agent 调用（无用户语境）不搜笔记。入口同 list_papers：project_id 或 library_id。
     """
-    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    library_ids = await _read_library_ids(
+        session, project_id=project_id, library_id=library_id, library_ids=library_ids
+    )
     if not library_ids:
         return []
     pattern = f"%{q}%"
@@ -1187,6 +1195,8 @@ async def semantic_search_papers(
     *,
     project_id: uuid.UUID | None = None,
     library_id: uuid.UUID | None = None,
+    #: 显式库集合（全局助手）：给了就不看 project_id
+    library_ids: Sequence[uuid.UUID] | None = None,
     query_vector: list[float],
     space: EmbeddingSpace,
     limit: int,
@@ -1196,7 +1206,9 @@ async def semantic_search_papers(
     只跟 ``space`` 这一个向量空间里的论文比较——别的空间的向量出自别的模型，
     余弦值没有可比性。
     """
-    library_ids = await _read_library_ids(session, project_id=project_id, library_id=library_id)
+    library_ids = await _read_library_ids(
+        session, project_id=project_id, library_id=library_id, library_ids=library_ids
+    )
     if not library_ids:
         return []
     qv = json.dumps(query_vector)

--- a/src/backend/app/tools/agentic_search.py
+++ b/src/backend/app/tools/agentic_search.py
@@ -20,9 +20,9 @@ from app.core.db import get_sessionmaker
 from app.services import chunks as chunks_service
 from app.services import papers as papers_service
 from app.services.embedding import embed_query
-from app.services.libraries import get_source_library_ids
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import library_ids_for
 
 #: grep 每条命中回多少字符的上下文（前后各一半）
 _GREP_WINDOW = 160
@@ -66,6 +66,7 @@ async def scan_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
                 rows = await papers_service.semantic_search_papers(
                     session,
                     project_id=ctx.project_id,
+                    library_ids=await library_ids_for(session, ctx),
                     query_vector=vector,
                     space=space,
                     limit=k,
@@ -75,7 +76,11 @@ async def scan_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
                 rows = []
         if not rows:
             rows = await papers_service.keyword_search_papers(
-                session, project_id=ctx.project_id, q=query, limit=k
+                session,
+                project_id=ctx.project_id,
+                library_ids=await library_ids_for(session, ctx),
+                q=query,
+                limit=k,
             )
         # 一行一篇：标题 + 年份。**刻意不回 tldr/摘要**——回了就又变成 top-k RAG，
         # k 也就不敢往大了要。
@@ -112,7 +117,7 @@ async def grep_fulltext(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     k = max(1, min(int(args.get("k") or 20), 40))
 
     async with get_sessionmaker()() as session:
-        library_ids = await get_source_library_ids(session, ctx.project_id)
+        library_ids = await library_ids_for(session, ctx)
         rows = await chunks_service.keyword_search_chunks(
             session,
             library_ids=library_ids or None,

--- a/src/backend/app/tools/context.py
+++ b/src/backend/app/tools/context.py
@@ -17,14 +17,20 @@ from app.core.llm.router import LLMRouter
 class ToolContext:
     """只读工具的最小执行上下文。
 
-    - ``project_id``：工具的检索范围（库内论文/概念/图谱都按项目隔离）。
+    - ``project_id``：默认的检索范围（课题关联的那些库）。
+    - ``library_ids``：显式的检索范围，给了就**不看 project_id**。全局助手用它把范围
+      放到「这个人看得见的全部库」；空元组是合法值，表示没有语料（查不到，不报错）。
     - ``user_id``：归属校验用（``*_for_user`` 服务）；系统内部调用可为 None。
     - ``voyage_id``：仅用于 LLM 用量记账（embed 调用），无则不挂 voyage。
     - ``llm``：LLM 路由器，仅供需要 embedding 的工具（语义检索）使用。
     """
 
-    project_id: uuid.UUID
+    #: 课题范围。全局助手不收窄到课题时是 None——**不要编一个占位 uuid**：它会顺着
+    #: embedding 记账写进 llm_usage.project_id，撞 FK 或者更糟，悄悄记到一个不存在的
+    #: 课题头上。
+    project_id: uuid.UUID | None
     llm: LLMRouter
+    library_ids: tuple[uuid.UUID, ...] | None = None
     user_id: uuid.UUID | None = None
     voyage_id: uuid.UUID | None = None
     #: 允许执行会改数据的工具吗。**默认 False 是整套安全性的支点**——MCP、voyage 的

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -14,9 +14,9 @@ from app.services import chunks as chunks_service
 from app.services import graph as graph_service
 from app.services import search as search_service
 from app.services.embedding import embed_query
-from app.services.libraries import get_source_library_ids, membership_for_project
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import library_ids_for, membership_in_scope
 
 _CHUNK_CHARS = 1200
 _MAX_K = 12
@@ -44,7 +44,7 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     mode = str(args.get("mode") or "semantic")
 
     async with get_sessionmaker()() as session:
-        library_ids = await get_source_library_ids(session, ctx.project_id)
+        library_ids = await library_ids_for(session, ctx)
         rows: list[tuple[PaperChunk, float]] = []
         used_mode = "keyword"
         if (
@@ -123,9 +123,7 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
         )
         paper = (await session.execute(stmt)).scalar_one_or_none()
         membership = (
-            await membership_for_project(session, project_id=ctx.project_id, paper_id=paper_id)
-            if paper is not None
-            else None
+            await membership_in_scope(session, ctx, paper_id) if paper is not None else None
         )
         if paper is None or membership is None:
             raise ValueError(f"库内不存在该论文：{args.get('paper_id')}")
@@ -155,6 +153,8 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     summarize=lambda a, r: f"知识图谱（{len(r.get('nodes') or [])} 节点）",
 )
 async def knowledge_graph(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    if ctx.project_id is None:
+        raise ValueError("knowledge_graph 需要指定课题：知识图谱是按课题组织的")
     async with get_sessionmaker()() as session:
         return await graph_service.project_graph(session, project_id=ctx.project_id)
 
@@ -173,6 +173,8 @@ async def global_search(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     q = str(args.get("q") or "").strip()
     if not q:
         raise ValueError("global_search 需要非空 q")
+    if ctx.project_id is None:
+        raise ValueError("global_search 需要指定课题：它检索的是课题内的想法/实验/稿件")
     async with get_sessionmaker()() as session:
         hits = await search_service.global_search(session, project_id=ctx.project_id, q=q)
     return {"hits": [h.model_dump(mode="json") for h in hits]}

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -18,11 +18,11 @@ from app.services import concepts as concepts_service
 from app.services import papers as papers_service
 from app.services.concepts import library_concept_ids
 from app.services.embedding import embed_query
-from app.services.libraries import get_source_library_ids, membership_for_project
 from app.services.paper_review import relevant_excerpt
 from app.services.papers import PaperView
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import library_ids_for, membership_in_scope
 
 _WIKI_CHARS = 8000
 _FULLTEXT_PAGE_CHARS = 6000
@@ -61,9 +61,7 @@ async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> Pap
         raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
     paper = await session.get(Paper, paper_id)
     membership = (
-        await membership_for_project(session, project_id=ctx.project_id, paper_id=paper_id)
-        if paper is not None
-        else None
+        await membership_in_scope(session, ctx, paper_id) if paper is not None else None
     )
     if paper is None or membership is None:
         raise ValueError(f"库内不存在该论文：{raw_id}")
@@ -72,7 +70,7 @@ async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> Pap
 
 @tool(
     "search_papers",
-    description="在本课题语料内检索论文，支持关键词与语义两种模式",
+    description="在可检索的文献库内检索论文，支持关键词与语义两种模式",
     input_schema={
         "type": "object",
         "properties": {
@@ -106,6 +104,7 @@ async def search_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                 rows = await papers_service.semantic_search_papers(
                     session,
                     project_id=ctx.project_id,
+                    library_ids=await library_ids_for(session, ctx),
                     query_vector=vector,
                     space=space,
                     limit=k,
@@ -115,7 +114,11 @@ async def search_papers(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                 rows = []
         if not rows:  # semantic 不可用/无召回 → 关键词降级
             rows = await papers_service.keyword_search_papers(
-                session, project_id=ctx.project_id, q=query, limit=k
+                session,
+                project_id=ctx.project_id,
+                library_ids=await library_ids_for(session, ctx),
+                q=query,
+                limit=k,
             )
             used_mode = used_mode if rows and used_mode == "semantic" else "keyword"
         return {
@@ -224,7 +227,7 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     if not name:
         raise ValueError("get_concept 需要非空 name")
     async with get_sessionmaker()() as session:
-        library_ids = await get_source_library_ids(session, ctx.project_id)
+        library_ids = await library_ids_for(session, ctx)
         if not library_ids:
             return {"name": name, "found": False, "note": "概念库中没有该概念"}
         scoped = library_concept_ids(library_ids)
@@ -267,7 +270,7 @@ async def get_concept(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 async def list_concepts(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     category = str(args.get("category") or "").strip() or None
     async with get_sessionmaker()() as session:
-        library_ids = await get_source_library_ids(session, ctx.project_id)
+        library_ids = await library_ids_for(session, ctx)
         rows = await concepts_service.list_concepts(
             session, library_ids=library_ids, category=category
         )

--- a/src/backend/app/tools/scope.py
+++ b/src/backend/app/tools/scope.py
@@ -1,0 +1,79 @@
+"""工具的检索范围：一个课题，还是这个人能看见的全部文献库。
+
+平台里的论文本来就是**按库**组织的，「课题」只是库的一个集合（``TopicSourceLibrary``）。
+所以放开范围不需要改检索本身，只需要换一种方式回答「这次能搜哪些库」：
+
+- 课题内（voyage、课题里的对话）：课题关联的那些库；
+- 全局（PolarisBuddy）：这个人**看得见**的全部库（管理员看全部，普通用户看自己的
+  个人库加全部公共库，口径与 ``library_visible_to`` 一致）。
+
+两条路都落到同一批库 id 上，越权与否由那一步决定，检索代码不需要知道自己在哪种
+模式下跑。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.user import User
+from app.services.libraries import (
+    get_source_library_ids,
+    library_visible_to,
+    membership_rank,
+)
+from app.tools.context import ToolContext
+
+
+async def visible_library_ids(session: AsyncSession, user: User) -> list[uuid.UUID]:
+    """这个人看得见的全部库。口径与库列表页一致——助手不该比界面看得更多。"""
+    libraries = (
+        (await session.execute(select(DirectionLibrary).order_by(DirectionLibrary.created_at)))
+        .scalars()
+        .all()
+    )
+    return [lib.id for lib in libraries if library_visible_to(lib, user)]
+
+
+async def library_ids_for(session: AsyncSession, ctx: ToolContext) -> list[uuid.UUID]:
+    """这次检索能搜哪些库。
+
+    ``ctx.library_ids`` 显式给了就用它（全局助手在建 context 时已按可见性算好），
+    否则退回课题关联库。**空列表是合法结果**：没有语料就查不到东西，调用方返回
+    空态而不是报错——这与"课题没关联任何库"是同一件事。
+    """
+    if ctx.library_ids is not None:
+        return list(ctx.library_ids)
+    return await get_source_library_ids(session, ctx.project_id)
+
+
+async def membership_in_scope(
+    session: AsyncSession, ctx: ToolContext, paper_id: uuid.UUID
+) -> LibraryPaper | None:
+    """这篇论文在本次范围内的成员行；不在范围内返回 None。
+
+    这是「能不能看这篇」的唯一检查点：范围由 :func:`library_ids_for` 算出，越权
+    在那一步就已经挡住了。跨库同一篇取确定性视角（相关性高的库优先），与
+    ``membership_for_project`` 同规则。
+    """
+    library_ids = await library_ids_for(session, ctx)
+    if not library_ids:
+        return None
+    rows = (
+        (
+            await session.execute(
+                select(LibraryPaper).where(
+                    LibraryPaper.library_id.in_(library_ids),
+                    LibraryPaper.paper_id == paper_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        return None
+    return min(rows, key=membership_rank)

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -226,12 +226,11 @@ async def test_the_assistant_actually_finds_papers_in_the_resolved_project(clien
     )
 
 
-async def test_a_turn_with_no_resolvable_project_says_so_instead_of_searching_nothing(
-    client, agent_on
-):
-    """用户有多个课题且没指定：409 PROJECT_REQUIRED，让前端弹选择。
+async def test_several_projects_no_longer_block_the_turn(client, agent_on):
+    """有多个课题也不用先选一个：PolarisBuddy 是全局助手，按「看得见的库」检索。
 
-    绝不替用户猜，也绝不再兜随机 UUID 假装在查。
+    以前这里 409 PROJECT_REQUIRED，逼用户替一个纯内部的数据结构做选择题——而他想问
+    的问题往往正好跨库。越权由可见性挡住，不是靠「只给一个课题」。
     """
     headers = await _headers(client, "agent-scope-many@example.com")
     for name in ("proj-a", "proj-b"):
@@ -240,11 +239,59 @@ async def test_a_turn_with_no_resolvable_project_says_so_instead_of_searching_no
         )
 
     conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
-    resp = await client.post(
-        f"/api/chat/conversations/{conv_id}/turn", json={"question": "hi"}, headers=headers
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "hi"},
+        headers=headers,
+    ) as stream:
+        assert stream.status_code == 200
+        body = (await stream.aread()).decode()
+    assert "PROJECT_REQUIRED" not in body
+
+
+async def test_the_assistant_searches_across_libraries_without_a_project(client, agent_on):
+    """不指定课题时，检索范围是**可见的全部库**——包括不属于任何课题的库。
+
+    这条是「全局助手」的核心断言：以前论文只有挂在课题关联库上才搜得到。
+    """
+    from tests.conftest import add_paper
+
+    headers = await _headers(client, "agent-global-scope@example.com")
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary, LibraryPaper
+        from app.models.paper import new_paper
+
+        lib = DirectionLibrary(name="公共库", definition={"statement": "x"}, is_public=True)
+        session.add(lib)
+        await session.flush()
+        paper = new_paper(
+            title="Global Scope Retrieval Works",
+            abstract="a paper in a library that belongs to no project",
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            LibraryPaper(library_id=lib.id, paper_id=paper.id, status="included")
+        )
+        await session.commit()
+    assert add_paper is not None  # 用不上，但保持与其它作用域测试同一套脚手架
+
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    marker = 'POLARIS_FAKE_TOOL:search_papers:{"query": "Global Scope", "mode": "keyword"}'
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": f"查一下\n{marker}"},
+        headers=headers,
+    ) as stream:
+        body = (await stream.aread()).decode()
+
+    results = [d for e, d in _parse_sse(body) if e == "tool_result"]
+    assert results, f"没有工具结果帧：{body[:300]}"
+    assert "Global Scope Retrieval Works" in json.dumps(results, ensure_ascii=False), (
+        f"没搜到不属于任何课题的库里的论文：{results}"
     )
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "PROJECT_REQUIRED"
 
 
 async def test_someone_elses_project_id_is_rejected_everywhere(client, agent_on):

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Icon } from '../../components/ui/Icon';
 import { Markdown } from '../../lib/markdown';
-import { api, type ProjectRead } from '../../lib/api';
+import { api } from '../../lib/api';
 import { assistantTurnSse, type AssistantBlock, type PlanStep } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
 import { pageContextFrom } from './buddyContext';
@@ -50,15 +50,6 @@ function restoreBlocks(m: { text: string; blocks: unknown[] }): AssistantBlock[]
 
 /** 后端错误码 → 用户看得懂的一句话。认不出的原样透出，别把线索吃掉。 */
 function errorText(detail: string): string {
-  if (detail === 'PROJECT_REQUIRED') {
-    return tr(
-      '你有多个课题，先在上面选一个，助手才知道去哪儿查资料。',
-      'You have several topics — pick one above so the assistant knows where to search.',
-    );
-  }
-  if (detail === 'PROJECT_NOT_FOUND') {
-    return tr('这个课题不存在，或者你已经不是它的成员了。', 'That topic does not exist, or you are no longer a member.');
-  }
   if (detail === 'CHAT_AGENT_DISABLED') {
     return tr('助手在这个部署上没开启，找管理员开一下。', 'The assistant is switched off on this deployment — ask an admin to enable it.');
   }
@@ -278,12 +269,6 @@ export function AssistantPanel({
   const [conversations, setConversations] = useState<
     { id: string; title: string; project_id: string | null }[]
   >([]);
-  // 这轮检索的课题作用域。名下只有一个课题时后端会自己认，但选出来更诚实——
-  // 用户看得见助手在哪儿查。多于一个且没选，后端 409，见 errorText。
-  const [projects, setProjects] = useState<ProjectRead[]>([]);
-  const [projectId, setProjectId] = useState<string | null>(null);
-  //: 上一轮因为没选课题而失败过——把选择器点亮，别让人对着一句错误发呆
-  const [projectMissing, setProjectMissing] = useState(false);
   const [greeting, setGreeting] = useState<string>('');
   const [stats, setStats] = useState<Record<string, number>>({});
   const [contextOn, setContextOn] = useState(true);
@@ -316,26 +301,6 @@ export function AssistantPanel({
       .catch(() => setGreeting(''));
   }, [open, greeting]);
 
-  // 面板打开时才拉课题列表：关着的时候没人看得见，不值得多一个请求。
-  useEffect(() => {
-    if (!open) return;
-    let alive = true;
-    void (async () => {
-      try {
-        const rows = await api.listProjects();
-        if (!alive) return;
-        setProjects(rows);
-        // 只有一个课题就直接替他选上——这不算「替用户猜」，没有别的可能。
-        setProjectId((cur) => cur ?? (rows.length === 1 ? (rows[0]?.id ?? null) : null));
-      } catch {
-        if (alive) setProjects([]);
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [open]);
-
   const stop = useCallback(() => {
     // 掐掉 SSE 连接。后端会把已生成的部分落库标成 interrupted，重开会话还能看到。
     abortRef.current?.();
@@ -359,10 +324,7 @@ export function AssistantPanel({
         const messages = await api.getAssistantMessages(id);
         setConvId(id);
         setHistoryOpen(false);
-        setProjectMissing(false);
         // 会话上存着的课题才是这场对话真正的作用域，跟着切过去
-        const stored = conversations.find((c) => c.id === id)?.project_id ?? null;
-        if (stored) setProjectId(stored);
         setTurns(
           messages
             .filter((m) => m.role === 'user' || m.role === 'assistant')
@@ -383,7 +345,6 @@ export function AssistantPanel({
     setConvId(null);
     setTurns([]);
     setHistoryOpen(false);
-    setProjectMissing(false);
   }, [stop]);
 
   const ask = useCallback(
@@ -395,7 +356,7 @@ export function AssistantPanel({
     let id = convId;
     try {
       if (!id) {
-        id = (await api.createAssistantConversation(projectId ? { project_id: projectId } : {})).id;
+        id = (await api.createAssistantConversation({})).id;
         setConvId(id);
       }
     } catch (e) {
@@ -430,15 +391,13 @@ export function AssistantPanel({
         onBlocks: patch,
         onDone: () => setBusy(false),
         onError: (detail) => {
-          if (detail === 'PROJECT_REQUIRED') setProjectMissing(true);
           patch((blocks) => [...blocks, { kind: 'text', text: `⚠️ ${errorText(detail)}` }]);
           setBusy(false);
         },
       },
-      projectId,
     );
     },
-    [busy, convId, projectId, contextOn, pageContext],
+    [busy, convId, contextOn, pageContext],
   );
 
   const send = useCallback(() => {
@@ -521,47 +480,6 @@ export function AssistantPanel({
           <Icon name="x" size={14} />
         </button>
       </div>
-
-      {/* —— 作用域：助手拿哪个课题的资料去查 ——
-          一个课题都没有时不显示：那种情况下助手本来就不带工具，摆个空下拉只会误导。 */}
-      {projects.length > 0 && (
-        <div
-          className="row gap8"
-          style={{
-            padding: '8px 16px',
-            borderBottom: '0.5px solid var(--border-2)',
-            alignItems: 'center',
-            background: projectMissing && !projectId ? 'var(--danger-bg, var(--surface-2))' : 'var(--surface-2)',
-          }}
-        >
-          <Icon name="layers" size={13} style={{ color: 'var(--text-3)', flexShrink: 0 }} />
-          <span style={{ fontSize: 11.5, color: 'var(--text-3)', flexShrink: 0 }}>
-            {tr('查这个课题', 'Search in')}
-          </span>
-          <select
-            className="input"
-            value={projectId ?? ''}
-            onChange={(e) => {
-              setProjectId(e.target.value || null);
-              setProjectMissing(false);
-            }}
-            style={{
-              flex: 1,
-              minWidth: 0,
-              height: 26,
-              fontSize: 12,
-              borderColor: projectMissing && !projectId ? 'var(--danger)' : undefined,
-            }}
-          >
-            <option value="">{tr('未选 —— 只闲聊，不检索', 'None — chat only, no search')}</option>
-            {projects.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
 
       {historyOpen && (
         <div

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -50,21 +50,19 @@ const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : und
 
 /** 跑一轮助手对话；返回中止函数。
  *
- * ``projectId`` 是这轮检索工具的作用域。后端只在会话上还没存过课题时需要它，
- * 存过一次就自己认得；但每轮都带上是无害的，也省得前端追踪「存没存过」。
- * 不传且用户名下有多个课题时，后端返回 409 PROJECT_REQUIRED，由调用方弹选择。
+ * 不带课题作用域：PolarisBuddy 是全局助手，检索范围是「这个人看得见的全部文献库」，
+ * 由后端按可见性算。以前这里要传 projectId，多课题不传就 409——那是在让用户替一个
+ * 纯内部的数据结构做选择题。
  */
 export function assistantTurnSse(
   conversationId: string,
   question: string,
   handlers: AssistantHandlers,
-  projectId?: string | null,
 ): () => void {
   return postSse(
     `/chat/conversations/${conversationId}/turn`,
     {
       question,
-      ...(projectId ? { project_id: projectId } : {}),
       ...(handlers.page ? { page_kind: handlers.page.kind, page_id: handlers.page.id } : {}),
     },
     {


### PR DESCRIPTION
"Search in [topic]" is gone. PolarisBuddy is a global assistant now.

## Why the restriction was wrong

A topic (`project`) was never a permission boundary — it's a *subset of libraries* (`TopicSourceLibrary`). Making the user pick one before asking a question is making them answer a quiz about an internal data structure, and the questions people actually ask tend to cross libraries. Worse: a library attached to no topic at all was simply unreachable, no matter how visible it was to that user.

## What changed

Retrieval logic is untouched. Papers were already organized *by library*; widening the scope only changes how we answer "which libraries can this search see". That question now has one home, `app/tools/scope.py`:

- explicit `library_ids` (the global assistant, computed via `library_visible_to`) → use them
- otherwise fall back to the topic's linked libraries (voyages and in-topic chat still take this path)

Authorization lives in that visibility step — same rule as the libraries page (admins see all; everyone else sees their own personal libraries plus all public ones) — not in "we only gave it one topic". An empty scope stays a legal result: no corpus means no results, and the turn simply runs without tools rather than pretending to search and reporting nothing found.

## A latent bug fixed on the way

`ToolContext.project_id` used to fall back to `uuid.uuid4()` when no topic resolved. That fabricated id rode along into embedding accounting and got written to `llm_usage.project_id` — which either trips the FK or, worse, quietly bills a nonexistent topic. It's now `uuid.UUID | None`, and the two tools that genuinely need a topic (`knowledge_graph`, `global_search`, both outside the assistant's whitelist) raise a clear error instead of querying with `None`.

## Tests

The old `PROJECT_REQUIRED` test asserted the behaviour being removed, so it's replaced by two: several topics no longer block a turn, and — the load-bearing one — a paper sitting in a **public library that belongs to no topic** is found by the real `search_papers` tool driven through the SSE endpoint. That's the assertion that would have failed before this change for the exact reason users hit.

Full suite **1064 passed**; `tsc --noEmit` + `vite build` clean.