### PR TITLE
feat(daily): drop the Updated filter and the inline likes row, clamp titles to two lines

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -722,16 +722,22 @@ async def list_papers(
         ),
         else_=1,
     )
+    # 同分类里，新工作排在交叉提交（更新）前面：新工作才是当天真正的新东西
+    announce_rank = case((DailyFeedEntry.announce_type == "new", 0), else_=1)
     if sort == "likes":
         stmt = stmt.order_by(
             category_rank,
+            announce_rank,
             likes_sq.desc(),
             DailyFeedEntry.feed_date.desc(),
             DailyFeedEntry.created_at.desc(),
         )
     else:  # date
         stmt = stmt.order_by(
-            category_rank, DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc()
+            category_rank,
+            announce_rank,
+            DailyFeedEntry.feed_date.desc(),
+            DailyFeedEntry.created_at.desc(),
         )
     stmt = stmt.offset((page - 1) * size).limit(size)
 

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1562,3 +1562,36 @@ async def test_daily_list_puts_cscl_first_and_csro_last(client, monkeypatch):
     other = titles.index("AI Paper")
     ro = titles.index("Robot Paper")
     assert max(cl) < other < ro, f"顺序应为 cs.CL < 其他 < cs.RO：{titles}"
+
+
+async def test_new_submissions_come_before_cross_lists(client, monkeypatch):
+    """同一分类里，新工作排在交叉提交（更新）前面——当天真正的新东西优先。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.CL": [
+                    _rss_entry("2608.23001", "Cross One", announce="cross"),
+                    _rss_entry("2608.23002", "New One"),
+                    _rss_entry("2608.23003", "Cross Two", announce="cross"),
+                    _rss_entry("2608.23004", "New Two"),
+                ]
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+
+    resp = await client.get(
+        "/api/daily/papers", params={"sort": "date", "size": 50}, headers=headers
+    )
+    titles = [item["title"] for item in resp.json()["items"]]
+    news = [titles.index(t) for t in ("New One", "New Two")]
+    crosses = [titles.index(t) for t in ("Cross One", "Cross Two")]
+    assert max(news) < min(crosses), f"新工作应全部排在更新前面：{titles}"

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -57,6 +57,7 @@ import { DailyChatTab } from './DailyChatTab';
 import { CollectTreeModal, type CollectPaperRef } from './CollectTreeModal';
 import { PaperProgressModal } from '../library/PaperProgressModal';
 import { paperDragProps } from '../assistant/paperDrag';
+import { clampLines } from '../../lib/clamp';
 
 /* ============================================================
    /daily — 每日新论文：arxiv 每日新提交（订阅分类内）。保留期由管理员配置（默认 14 天）。
@@ -152,7 +153,12 @@ function DailyRow({
           }}
         />
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35 }}>{p.title}</div>
+          <div
+            style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.35, ...clampLines(2) }}
+            title={p.title}
+          >
+            {p.title}
+          </div>
           <div className="row gap8" style={{ marginTop: 5, fontSize: 11, color: 'var(--text-3)' }}>
             <span className="pill sm mono" style={{ background: 'var(--surface-3)', flexShrink: 0 }}>
               {p.primary_category}
@@ -173,8 +179,6 @@ function DailyRow({
               </span>
             )}
           </div>
-          {/* 第三行：[♥] 点赞者头像（单行，超出用 +N） …… N 人赞过 */}
-          <DailyLikes item={p} variant="row" />
         </div>
       </div>
     </div>
@@ -559,7 +563,7 @@ function DailyDetailPane({
 }
 
 type DailyView = 'papers' | 'chat';
-type AnnounceFilter = 'collected' | 'all' | 'new' | 'cross';
+type AnnounceFilter = 'collected' | 'all' | 'new';
 
 // 类型筛选默认值：只看已收录的（进了文献库的才值得先看；「恢复默认」也回到这个值）
 const DEFAULT_ANNOUNCE: AnnounceFilter = 'collected';
@@ -687,7 +691,7 @@ export function DailyPage() {
     queryKey: ['daily-days', announce, category],
     queryFn: () =>
       api.listDailyDays({
-        announce: announce === 'new' || announce === 'cross' ? announce : undefined,
+        announce: announce === 'new' ? 'new' : undefined,
         category: category || undefined,
         collected: announce === 'collected' || undefined,
       }),
@@ -758,7 +762,7 @@ export function DailyPage() {
         size: PAGE_SIZE,
         q: q || undefined,
         category: category || undefined,
-        announce: announce === 'new' || announce === 'cross' ? announce : undefined,
+        announce: announce === 'new' ? 'new' : undefined,
         collected: announce === 'collected' || undefined,
         author: author || undefined,
         affiliation: affiliation || undefined,
@@ -952,9 +956,6 @@ export function DailyPage() {
                 </span>
                 <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
                   {tr('新工作', 'New')}
-                </span>
-                <span className={`chip${announce === 'cross' ? ' on' : ''}`} onClick={() => setAnnounce('cross')}>
-                  {tr('更新', 'Updated')}
                 </span>
               </div>
 

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -63,6 +63,7 @@ import {
 import { ReadingDot, readerFrom } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 import { paperDragProps } from '../assistant/paperDrag';
+import { clampLines } from '../../lib/clamp';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
 const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
@@ -159,7 +160,18 @@ const PaperRow = memo(function PaperRow({
         </span>
       </div>
       <div className="row gap8" style={{ alignItems: 'flex-start' }}>
-        <div style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 13,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            color: 'var(--text)',
+            ...clampLines(2),
+          }}
+          title={p.title}
+        >
           {p.title}
         </div>
         <AddToButton paperId={p.id} />

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -49,6 +49,7 @@ import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperProgressModal } from '../library/PaperProgressModal';
 import { paperDragProps } from '../assistant/paperDrag';
+import { clampLines } from '../../lib/clamp';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -574,7 +575,18 @@ const PaperRow = memo(function PaperRow({
         </span>
       </div>
       <div className="row gap8" style={{ alignItems: 'flex-start' }}>
-        <div style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, lineHeight: 1.35, color: 'var(--text)' }}>
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 13,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            color: 'var(--text)',
+            ...clampLines(2),
+          }}
+          title={p.title}
+        >
           {p.title}
         </div>
         <AddToButton paperId={p.id} />

--- a/src/frontend/src/lib/clamp.ts
+++ b/src/frontend/src/lib/clamp.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from 'react';
+
+/** 限行：超出末尾自动省略号。
+
+    论文标题长短差异极大，不限行的列表会参差不齐、扫读时找不到节奏；限两行是
+    「看得出说的是什么」和「每行等高」之间的折中。`overflowWrap: anywhere` 是给
+    超长 token（DOI、无空格的模型名）留的后路，否则它们会把行撑出容器。 */
+export const clampLines = (lines: number): CSSProperties => ({
+  display: '-webkit-box',
+  WebkitLineClamp: lines,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+  overflowWrap: 'anywhere',
+});


### PR DESCRIPTION
Three list cleanups, one behavioural change in ordering.

**The "Updated" filter is gone.** Cross-lists (`announce_type=cross`) are papers re-announced under another category — almost nobody filtered *for* them, and the chip took a slot on a toolbar that now carries the filters people actually use.

**New submissions sort ahead of cross-lists.** The ordering already ranked by category (cs.CL first, cs.RO last, from #263); announce type is now the tiebreaker inside each category, because what's genuinely new that day is what you came to see. Both sort modes get it.

**The likes row leaves the list rows** (the detail pane keeps it). A row of avatars doubled the height of every row and bought very little — a list is for scanning.

**Titles clamp to two lines** in the daily feed, library browse, and related-research lists, with the full text on hover. Paper titles vary wildly in length; unclamped rows make the list ragged and there's no rhythm to scan by. The clamp style is shared in `lib/clamp.ts` — `overflowWrap: anywhere` is there for long unbroken tokens (DOIs, hyphen-free model names) that would otherwise push the line past its container.

## Tests

One new, failing against `origin/main`: seeded new + cross entries in one category, asserting every new submission sorts ahead of every cross-list. Full suite **1064 passed**; `tsc --noEmit` + `vite build` clean.