### PR TITLE
fix(daily): a cached arXiv batch goes stale at UTC midnight

### DIFF
--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -196,6 +196,16 @@ def _parse_rss_item(item: ET.Element) -> dict[str, Any] | None:
     }
 
 
+def _batch_is_fresh(batch_at: datetime | None) -> bool:
+    """这批公告还算「今天的」吗。读缓存与写缓存**共用这一条判据**。
+
+    解析不出批次日期时算新鲜：宁可照常抓一次，也不能因为一个判断失灵就再也不抓。
+    """
+    if batch_at is None:
+        return True
+    return batch_at.astimezone(UTC).date() >= datetime.now(UTC).date()
+
+
 def _parse_rss(text: str) -> tuple[list[dict[str, Any]], datetime | None]:
     """解析 RSS，返回 (条目, **这一批的公告日期**)。
 
@@ -386,13 +396,18 @@ class ArxivClient:
         """
         key = cache_key("arxiv", "rss_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
-            return cached["entries"], _parse_iso_dt(cached.get("batch_at"))
+            cached_at = _parse_iso_dt(cached.get("batch_at"))
+            # **读的时候也要查新鲜度**，不是只在写的时候查：昨天 23:50 存进来的那份，
+            # 当时确实是「今天的」，跨过 UTC 零点它就成了旧批次——而缓存还有两小时
+            # 才到期。只查写不查读，等于每天 00:00–03:00 UTC（北京 08:00–11:00）的探测
+            # 全部拿到昨天那批，判定「今天那批还没出来」，白等一上午。
+            if _batch_is_fresh(cached_at):
+                return cached["entries"], cached_at
         resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
         entries, batch_at = _parse_rss(resp.text)
         # **陈旧批次不写缓存**：调用方会每 15 分钟探一次直到当天那批出现，缓存住旧批次
         # 会让接下来三小时的探测全部拿到同一份，轮询就白做了。与「失败不写缓存」同理。
-        fresh = batch_at is None or batch_at.astimezone(UTC).date() >= datetime.now(UTC).date()
-        if fresh:
+        if _batch_is_fresh(batch_at):
             await self._rss_cache.set(
                 key, {"entries": entries, "batch_at": batch_at.isoformat() if batch_at else None}
             )

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -187,6 +187,44 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
 
 
 @respx.mock
+async def test_a_cached_batch_goes_stale_at_midnight_utc(cache_redis):
+    """跨过 UTC 零点后，昨天缓存的那批不能再当「今天的」返回。
+
+    真事：08-04 23:5x UTC 存进缓存的批次，当时确实是今天的；三小时 TTL 让它一直活到
+    08-05 02:5x。读路径不查新鲜度，于是整个 00:00–03:00 UTC（北京 08:00–11:00）窗口
+    里，探测反复拿到昨天那批，判定「今天那批还没出来」——界面上就停在「等待今天的
+    批次（2/10）· 最新 08-04」，而 arXiv 早发了。写的时候查新鲜度、读的时候不查，
+    等于只挡住了一半。
+
+    直接把旧条目塞进缓存来构造这个局面，而不是去改模块里的 ``datetime``：被测的就是
+    「读路径会不会丢掉过期条目」，不必为此动全局状态。
+    """
+    import datetime as _dt
+
+    from app.services.literature.cache import cache_key
+
+    today = _dt.datetime.now(_dt.UTC).date()
+    yesterday = today - _dt.timedelta(days=1)
+    stale_at = _dt.datetime.combine(yesterday, _dt.time(23, 55), tzinfo=_dt.UTC)
+
+    client = ArxivClient(redis=cache_redis, min_interval=0)
+    # 昨天 23:55 写进去的那份：当时是新鲜的，现在不是了，但离过期还有两小时
+    await client._rss_cache.set(
+        cache_key("arxiv", "rss_new", {"category": "cs.CL"}),
+        {"entries": [{"arxiv_id": "old-batch"}], "batch_at": stale_at.isoformat()},
+    )
+    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
+        return_value=httpx.Response(200, text=_rss_with_batch_date(today))
+    )
+
+    entries, batch_at = await client.fetch_new("cs.CL")
+    assert route.call_count == 1, "过期批次不该再从缓存里返回，应该重新抓一次"
+    assert batch_at is not None and batch_at.astimezone(_dt.UTC).date() == today
+    assert [e["arxiv_id"] for e in entries] == ["2607.10001", "2607.10002"]
+    await client.aclose()
+
+
+@respx.mock
 async def test_arxiv_fetch_new_raises_after_exhausted_retries(cache_redis):
     """RSS 失败原样上抛，**不再吞成 []**。
 


### PR DESCRIPTION
**Symptom:** arXiv had published the 08-05 batch hours earlier, but the daily feed still read *"Waiting for today's batch (2/10) · latest 2026-08-04"*.

**Cause:** the RSS cache checked freshness **on write but not on read**.

```python
fresh = batch_at is None or batch_at.date() >= today   # only guarded set()
if fresh:
    await self._rss_cache.set(...)
```

A batch cached at 23:5x UTC really was "today's" at the time, so it was stored. The TTL is three hours, so it stays alive until ~02:5x the next day — and the read path handed it straight back. For the whole 00:00–03:00 UTC window (08:00–11:00 Beijing), every 15-minute probe saw yesterday's batch, concluded today's wasn't out yet, and incremented the counter. Exactly the window the user was looking at.

The write-side guard was added so that polling wouldn't get stuck on a stale batch. It only ever covered half the problem: an entry that was fresh when written goes stale on its own, and nothing re-checked it.

**Fix:** `_batch_is_fresh()`, used by both paths. Splitting the rule across two call sites is what let them drift in the first place. Unparseable batch dates still count as fresh — better to fetch once too often than to stop fetching because one check broke.

## Tests

One new, failing against `origin/main`: seed the cache with a batch stamped yesterday 23:55 UTC, then fetch — the client must go back to the network rather than return the cached entry.

Worth recording how the test got here: the first version monkeypatched the module's `datetime` to write the stale entry "as of yesterday". It passed alone and in every subset I tried, but failed in the full suite — global time-patching interacting with something I never identified. Rather than hunt it, I rewrote it to seed the cache entry directly, which is a better expression of the thing under test anyway (the read path dropping an expired entry) and mutates no global state.

Full suite **1078 passed**.

## Deploying

Nothing to run; the stale entry ages out on its own. Once deployed, the next probe fetches fresh and the batch lands.