### PR TITLE
fix(daily): exhausting the probes shouldn't write off the day

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1408,13 +1408,47 @@ async def probe_state(session: AsyncSession, *, now: dt.datetime) -> dict[str, A
     row = await session.get(SystemSetting, PROBE_STATE_SETTING_KEY)
     value = row.value if row is not None and isinstance(row.value, dict) else {}
     if value.get("date") != today:
-        return {"date": today, "attempts": 0, "batch_date": None, "exhausted": False}
+        return {
+            "date": today,
+            "attempts": 0,
+            "batch_date": None,
+            "exhausted": False,
+            "last_probe_at": None,
+        }
     return {
         "date": today,
         "attempts": int(value.get("attempts") or 0),
         "batch_date": value.get("batch_date"),
         "exhausted": bool(value.get("exhausted")),
+        "last_probe_at": value.get("last_probe_at"),
     }
+
+
+#: 探满之后的复查间隔（分钟）。arXiv 的 /new 只带**当天那一批**：今天的公告错过了，
+#: 明天抓的是明天那批，这一天就永久没有了。所以「探满」只该意味着别再每 15 分钟敲，
+#: 不该意味着今天就此收工——一小时一次的复查，代价是一天最多二十来个 RSS 请求，
+#: 换的是「arXiv 发晚了」不至于丢掉一整天。
+SLOW_PROBE_MINUTES = 60
+
+
+def should_probe_now(state: dict[str, Any], *, now: dt.datetime, max_attempts: int) -> bool:
+    """现在该探一次吗。
+
+    没探满：该探（由调用方的 15 分钟检查点决定频率）。
+    探满了：离上次探测够久才探（降频复查，见 :data:`SLOW_PROBE_MINUTES`）。
+    """
+    if int(state.get("attempts") or 0) < max_attempts:
+        return True
+    last = state.get("last_probe_at")
+    if not last:
+        return True
+    try:
+        last_at = dt.datetime.fromisoformat(str(last))
+    except ValueError:
+        return True
+    if last_at.tzinfo is None:
+        last_at = last_at.replace(tzinfo=dt.UTC)
+    return now - last_at >= dt.timedelta(minutes=SLOW_PROBE_MINUTES)
 
 
 async def record_probe(
@@ -1429,6 +1463,7 @@ async def record_probe(
     state["attempts"] += 1
     state["batch_date"] = batch_date
     state["exhausted"] = exhausted
+    state["last_probe_at"] = now.astimezone(dt.UTC).isoformat()
     row = await session.get(SystemSetting, PROBE_STATE_SETTING_KEY)
     if row is None:
         session.add(SystemSetting(key=PROBE_STATE_SETTING_KEY, value=state))

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1595,3 +1595,103 @@ async def test_new_submissions_come_before_cross_lists(client, monkeypatch):
     news = [titles.index(t) for t in ("New One", "New Two")]
     crosses = [titles.index(t) for t in ("Cross One", "Cross Two")]
     assert max(news) < min(crosses), f"新工作应全部排在更新前面：{titles}"
+
+
+async def test_probing_slows_down_after_exhaustion_instead_of_stopping():
+    """探满 ≠ 当天收工。
+
+    arXiv 的 /new 只带**当天那一批**：今天的公告错过了，明天抓的是明天那批，这一天
+    就永久没有了。所以探满只该意味着别再每 15 分钟敲，而不是从此不看——发晚了两小时
+    的批次不该整天丢掉。
+    """
+    from app.services.daily_feed import SLOW_PROBE_MINUTES, should_probe_now
+
+    now = dt.datetime.now(dt.UTC)
+    # 没探满：照常探
+    fresh = {"attempts": 3, "last_probe_at": now.isoformat()}
+    assert should_probe_now(fresh, now=now, max_attempts=10)
+    # 探满且刚探过：不探（这就是「别再每 15 分钟敲」）
+    just_now = (now - dt.timedelta(minutes=SLOW_PROBE_MINUTES - 5)).isoformat()
+    assert not should_probe_now(
+        {"attempts": 10, "last_probe_at": just_now}, now=now, max_attempts=10
+    )
+    # 探满但过了复查间隔：再探一次
+    long_ago = (now - dt.timedelta(minutes=SLOW_PROBE_MINUTES + 1)).isoformat()
+    assert should_probe_now(
+        {"attempts": 10, "last_probe_at": long_ago}, now=now, max_attempts=10
+    )
+
+
+async def test_probe_gate_is_permissive_when_the_timestamp_is_missing_or_broken():
+    """没有/读不懂上次探测时刻时选择「探一次」。
+
+    多探一次的代价是一个 RSS 请求；不探的代价可能是丢掉一整天的论文。存量状态里
+    没有 last_probe_at 这个字段（这次才加的），升级当天就会走到这条路上。
+    """
+    from app.services.daily_feed import should_probe_now
+
+    now = dt.datetime.now(dt.UTC)
+    assert should_probe_now({"attempts": 10}, now=now, max_attempts=10)
+    assert should_probe_now(
+        {"attempts": 10, "last_probe_at": "not-a-time"}, now=now, max_attempts=10
+    )
+
+
+async def test_record_probe_stamps_the_probe_time(client):
+    """降频判据要有依据：每次探测都记下时刻。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    assert await register_and_login(client)
+    now = dt.datetime.now(dt.UTC)
+    async with get_sessionmaker()() as session:
+        state = await daily_feed.record_probe(session, now=now, batch_date=None)
+    assert state["last_probe_at"]
+    assert dt.datetime.fromisoformat(state["last_probe_at"]).date() == now.date()
+
+
+async def test_a_late_batch_is_still_picked_up_after_the_probes_ran_out(client, monkeypatch):
+    """探满之后 arXiv 才发布：下一次降频复查要能把它接住，建出今天的任务。
+
+    这是这次事故真正会丢数据的地方——/new 只带当天那一批，今天错过就永久没有了。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+    from worker import tasks as worker_tasks
+
+    assert await register_and_login(client)
+    now = dt.datetime.now(dt.UTC)
+    async with get_sessionmaker()() as session:
+        # 今天已探满，且上次探测是两小时前（早过了复查间隔）
+        await daily_feed.set_max_probe_attempts(session, 2)
+        for _ in range(2):
+            await daily_feed.record_probe(
+                session,
+                now=now - dt.timedelta(hours=2),
+                batch_date=(now.date() - dt.timedelta(days=1)).isoformat(),
+                exhausted=True,
+            )
+        # 到点了、今天还没跑过任务
+        hour, minute = now.hour, now.minute
+        await daily_feed.set_sync_time(session, hour, minute)
+
+    # 这一刻 arXiv 那批终于出来了
+    monkeypatch.setattr(
+        daily_feed, "todays_batch_available", _fake_batch_available(now.date().isoformat())
+    )
+    enqueued: list[str] = []
+
+    class _Redis:
+        async def enqueue_job(self, name: str, *args: object) -> None:
+            enqueued.append(f"{name}:{args[0]}")
+
+    run_id = await worker_tasks.daily_feed_sync({"redis": _Redis()})
+    assert run_id, "探满之后来的批次被丢掉了"
+    assert enqueued and enqueued[0].startswith("run_voyage:")
+
+
+def _fake_batch_available(batch_date: str):
+    async def _available(session):  # noqa: ANN001
+        return True, batch_date
+
+    return _available

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -188,10 +188,11 @@ async def daily_feed_sync(ctx: dict[str, Any]) -> str | None:
         ):
             return None
         # 探测有次数上限：「今天 arXiv 就是没发」是正常情况（周末、节假日、发布故障），
-        # 不该从早探到晚。探满就当天收工，明天归零重来——这是正常结束，不是失败。
+        # 不该从早探到晚每 15 分钟敲一次。但**探满不等于当天收工**：/new 只带当天那批，
+        # 今天的公告错过了就永久没有了，所以探满之后转成一小时一次的复查。
         max_attempts = await daily_feed_service.get_max_probe_attempts(session)
         state = await daily_feed_service.probe_state(session, now=now)
-        if state["attempts"] >= max_attempts:
+        if not daily_feed_service.should_probe_now(state, now=now, max_attempts=max_attempts):
             return None
         fresh, batch_date = await daily_feed_service.todays_batch_available(session)
         if not fresh:


### PR DESCRIPTION
Follow-up to #271. Stale-cached batches fed the prober for ~2.5 hours, which is almost exactly the ten 15-minute attempts the default allows — so that bug very likely burned the whole day's budget.

That matters more than it sounds. On exhaustion the worker returned and waited for tomorrow, and arXiv's `/new` feed **only carries the current batch**: a day missed is missed permanently, because tomorrow's fetch gets tomorrow's papers. So the real cost of the caching bug wasn't "the feed is a few hours late" — it was "that day's papers never arrive".

## Change

Exhaustion now means *stop hammering*, not *stop looking*. Past the attempt limit the worker re-probes once an hour until the day rolls over. Worst case that's about twenty extra RSS requests a day; the thing it buys is that a late publication still lands on the day it was announced.

The original intent is preserved — no more probing every 15 minutes from morning to night, and the noisy per-attempt logging stops at the limit.

`probe_state` now records `last_probe_at`. When it's missing or unparseable the gate says "probe": one extra request is the cost of being wrong that way, a whole day of papers is the cost of being wrong the other way. Existing stored state has no such field, so the upgrade itself takes that path on day one.

## Tests

Four new. The load-bearing one is at worker level: today's probes are exhausted, the last was two hours ago, and arXiv's batch has just appeared — a run must be created. It fails against `origin/main` with "a batch that arrived after the probes ran out was dropped". The rest pin the gate itself (not exhausted → probe; exhausted and recent → don't; exhausted and stale → probe) and the permissive fallbacks.

Full suite **1081 passed**.

## Recovering today

Manual refresh (`POST /daily/refresh`, admin) never consulted the probe budget, so today's batch can be pulled in by hand right now without waiting for this to deploy.
