### PR TITLE
test(frontend): put the least trustworthy code under test (introduces vitest)

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -32,7 +32,8 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.5.4",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1417,6 +1418,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1522,6 +1646,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001805",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
@@ -1556,6 +1690,33 @@
       },
       "engines": {
         "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -1652,6 +1813,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -1697,6 +1868,13 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1747,6 +1925,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1755,6 +1943,16 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fs-constants": {
@@ -1922,6 +2120,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1930,6 +2135,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-cancellable-promise": {
@@ -2091,6 +2306,23 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pdfjs-dist": {
@@ -2393,6 +2625,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2449,6 +2688,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2511,6 +2764,50 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -2637,6 +2934,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -2650,6 +3036,23 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.4",
@@ -34,6 +35,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.4",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { applyAssistantEvent, type AssistantBlock } from '../../../lib/assistantStream';
+
+/* ============================================================
+   事件流 → 块时间线。
+
+   这段代码此前一个测试都没有，而它处理的恰好是**最不可信的输入**：SSE 里
+   JSON.parse 出来的 any。TypeScript 在这儿帮不上忙——编译期它以为自己知道形状，
+   运行时后端发什么就是什么。所以这里主要钉的不是"正常情况对不对"，而是
+   "畸形输入会不会把界面炸掉"。
+   ============================================================ */
+
+/** 把一串事件按顺序喂进去，返回最终的块列表。 */
+function reduce(events: [string, unknown][]): AssistantBlock[] {
+  let blocks: AssistantBlock[] = [];
+  for (const [event, data] of events) {
+    blocks = applyAssistantEvent(blocks, event, data);
+  }
+  return blocks;
+}
+
+describe('正文增量', () => {
+  it('连续的 delta 拼进同一个文本块', () => {
+    const blocks = reduce([
+      ['delta', { text: '这篇' }],
+      ['delta', { text: '论文' }],
+    ]);
+    expect(blocks).toEqual([{ kind: 'text', text: '这篇论文' }]);
+  });
+
+  it('工具卡片之后的 delta 另起一块，不会把答案接到卡片前面的文字上', () => {
+    const blocks = reduce([
+      ['delta', { text: '先查一下' }],
+      ['tool_call', { id: 't1', name: 'search_papers' }],
+      ['delta', { text: '查到了' }],
+    ]);
+    expect(blocks.map((b) => b.kind)).toEqual(['text', 'tool', 'text']);
+  });
+
+  it('空 delta 不产生空块', () => {
+    expect(reduce([['delta', { text: '' }]])).toEqual([]);
+  });
+});
+
+describe('工具卡片', () => {
+  it('结果按 id 回填到对应的卡片上', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 'a', name: 'search_papers' }],
+      ['tool_call', { id: 'b', name: 'get_paper' }],
+      ['tool_result', { id: 'b', ok: true, summary: '拿到了', duration_ms: 12 }],
+    ]);
+    expect(blocks[0]).toMatchObject({ id: 'a', state: 'running' });
+    expect(blocks[1]).toMatchObject({ id: 'b', state: 'ok', summary: '拿到了', durationMs: 12 });
+  });
+
+  it('认不出的 id 不会误伤别的卡片', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 'a', name: 'search_papers' }],
+      ['tool_result', { id: '不存在', ok: false }],
+    ]);
+    expect(blocks[0]).toMatchObject({ id: 'a', state: 'running' });
+  });
+
+  it('ok=false 画成失败态', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 'a', name: 'x' }],
+      ['tool_result', { id: 'a', ok: false }],
+    ]);
+    expect(blocks[0]).toMatchObject({ state: 'error' });
+  });
+});
+
+describe('计划', () => {
+  it('计划是替换不是追加——界面上永远只有一份最新的', () => {
+    const blocks = reduce([
+      ['plan', { steps: [{ title: '查', status: 'running' }] }],
+      ['plan', { steps: [{ title: '查', status: 'done' }, { title: '读', status: 'running' }] }],
+    ]);
+    expect(blocks.filter((b) => b.kind === 'plan')).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      kind: 'plan',
+      steps: [
+        { title: '查', status: 'done' },
+        { title: '读', status: 'running' },
+      ],
+    });
+  });
+
+  it('没有标题的步骤丢掉，认不出的状态退回 pending', () => {
+    const blocks = reduce([
+      ['plan', { steps: [{ title: '', status: 'done' }, { title: '读', status: '在做' }] }],
+    ]);
+    expect(blocks[0]).toEqual({ kind: 'plan', steps: [{ title: '读', status: 'pending' }] });
+  });
+
+  it('一步都不剩时不画空进度条', () => {
+    expect(reduce([['plan', { steps: [] }]])).toEqual([]);
+    expect(reduce([['plan', { steps: '不是数组' }]])).toEqual([]);
+  });
+});
+
+describe('畸形输入', () => {
+  it('未知事件忽略：后端加一个新事件不该让旧前端崩掉', () => {
+    expect(reduce([['某个将来才有的事件', { whatever: 1 }]])).toEqual([]);
+  });
+
+  it('字段缺失、类型不对都不抛', () => {
+    const cases: [string, unknown][] = [
+      ['delta', null],
+      ['delta', { text: 123 }],
+      ['thinking', {}],
+      ['tool_call', {}],
+      ['tool_result', undefined],
+      ['plan', { steps: [null, 42, { title: 7 }] }],
+    ];
+    for (const [event, data] of cases) {
+      expect(() => applyAssistantEvent([], event, data)).not.toThrow();
+    }
+  });
+});

--- a/src/frontend/src/features/assistant/__tests__/buddy.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/buddy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { pageContextFrom } from '../buddyContext';
+import { alreadyNudgedToday, markNudged, todayKey } from '../nudge';
+import { phaseOf } from '../TurnStatus';
+import type { AssistantBlock } from '../../../lib/assistantStream';
+
+describe('页面感知', () => {
+  it('从路由认出用户在看什么', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    expect(pageContextFrom(`/papers/${id}/read`)).toMatchObject({ kind: 'paper', id });
+    expect(pageContextFrom(`/ideas/${id}`)).toMatchObject({ kind: 'idea', id });
+    expect(pageContextFrom('/daily')).toMatchObject({ kind: 'daily' });
+  });
+
+  it('认不出的路由返回 null——Buddy 照常工作，只是不带上下文', () => {
+    expect(pageContextFrom('/settings')).toBeNull();
+    expect(pageContextFrom('/papers/not-a-uuid/read')).toBeNull();
+    expect(pageContextFrom('')).toBeNull();
+  });
+});
+
+describe('主动提示的记账', () => {
+  it('按本地日期算「今天」——用户感知的今天是他自己时区的今天', () => {
+    // 本地时间 2026-08-05 00:30，UTC 还是 08-04（东八区）；键要跟着本地走
+    const key = todayKey(new Date(2026, 7, 5, 0, 30));
+    expect(key).toBe('2026-8-5');
+  });
+
+  it('提过之后当天不再提', () => {
+    const store: Record<string, string> = {};
+    const now = new Date(2026, 7, 5, 9, 0);
+    expect(alreadyNudgedToday(now, () => store.k ?? null)).toBe(false);
+    markNudged(now, (v) => {
+      store.k = v;
+    });
+    expect(alreadyNudgedToday(now, () => store.k ?? null)).toBe(true);
+    // 跨到第二天又该提了
+    expect(alreadyNudgedToday(new Date(2026, 7, 6, 9, 0), () => store.k ?? null)).toBe(false);
+  });
+
+  it('读写失败当作「没提过」：重复提一次，好过因为存不下就永远不提', () => {
+    const boom = () => {
+      throw new Error('隐私模式');
+    };
+    expect(alreadyNudgedToday(new Date(), boom)).toBe(false);
+    expect(() =>
+      markNudged(new Date(), () => {
+        throw new Error('配额满');
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('本轮状态', () => {
+  const tool = (state: 'running' | 'ok'): AssistantBlock => ({
+    kind: 'tool',
+    id: 't',
+    name: 'search_papers',
+    state,
+  });
+
+  it('状态只从收到的块推，不另立状态机', () => {
+    expect(phaseOf([], false)).toBe('idle');
+    expect(phaseOf([], true)).toBe('thinking');
+    expect(phaseOf([tool('running')], true)).toBe('tool');
+    expect(phaseOf([{ kind: 'text', text: '答' }], true)).toBe('writing');
+  });
+
+  it('工具跑完就不再说「正在查」——#249 那个毛病正是两套状态各说各话', () => {
+    expect(phaseOf([tool('ok')], true)).not.toBe('tool');
+  });
+
+  it('本轮结束后一律 idle，不管最后一个块是什么', () => {
+    expect(phaseOf([tool('running')], false)).toBe('idle');
+  });
+});

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -54,6 +54,79 @@ const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : und
  * 由后端按可见性算。以前这里要传 projectId，多课题不传就 409——那是在让用户替一个
  * 纯内部的数据结构做选择题。
  */
+/** 一个事件作用到块时间线上，返回新的时间线。
+
+    抽成纯函数是为了**能测**：这里处理的是全仓最不可信的输入——SSE 里 JSON.parse 出来
+    的 any。TypeScript 在这儿帮不上忙，编译期它以为自己知道形状，运行时后端发什么就是
+    什么。认不出的事件原样返回旧时间线（后端加事件不该让旧前端崩掉），字段缺失一律
+    兜底，绝不抛。 */
+export function applyAssistantEvent(
+  blocks: AssistantBlock[],
+  event: string,
+  raw: unknown,
+): AssistantBlock[] {
+  const data: Record<string, unknown> =
+    raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+
+  if (event === 'delta' || event === 'thinking') {
+    const kind = event === 'delta' ? 'text' : 'thinking';
+    const text = str(data.text);
+    if (!text) return blocks;
+    // 追加到尾部同类块；尾块类型不同就新开一个
+    const last = blocks[blocks.length - 1];
+    if (last && last.kind === kind) {
+      return [...blocks.slice(0, -1), { kind, text: last.text + text }];
+    }
+    return [...blocks, { kind, text }];
+  }
+
+  if (event === 'plan') {
+    // 计划是**替换**不是追加：后端每次发全量，界面上永远只有一份最新的。
+    // 就地更新（而不是插到末尾）才不会让进度条在对话里越滚越多。
+    const steps = Array.isArray(data.steps)
+      ? (data.steps as unknown[]).flatMap((item) => {
+          if (!item || typeof item !== 'object') return [];
+          const step = item as Record<string, unknown>;
+          const title = str(step.title);
+          if (!title) return [];
+          const status = str(step.status, 'pending');
+          const known = (['pending', 'running', 'done'] as const).includes(
+            status as PlanStep['status'],
+          );
+          return [{ title, status: known ? (status as PlanStep['status']) : ('pending' as const) }];
+        })
+      : [];
+    // 一步都不剩就别画空进度条——空白进度条比不画更糟
+    if (!steps.length) return blocks;
+    const at = blocks.findIndex((b) => b.kind === 'plan');
+    const block: AssistantBlock = { kind: 'plan', steps };
+    if (at < 0) return [...blocks, block];
+    return blocks.map((b, i) => (i === at ? block : b));
+  }
+
+  if (event === 'tool_call') {
+    return [...blocks, { kind: 'tool', id: str(data.id), name: str(data.name, '?'), state: 'running' }];
+  }
+
+  if (event === 'tool_result') {
+    const id = str(data.id);
+    return blocks.map((b) =>
+      b.kind === 'tool' && b.id === id
+        ? {
+            ...b,
+            state: data.ok === false ? 'error' : 'ok',
+            summary: str(data.summary) || undefined,
+            preview: str(data.preview) || undefined,
+            durationMs: num(data.duration_ms),
+          }
+        : b,
+    );
+  }
+
+  // 其余事件（meta / usage / compaction / 将来新增的）一律忽略
+  return blocks;
+}
+
 export function assistantTurnSse(
   conversationId: string,
   question: string,
@@ -68,84 +141,13 @@ export function assistantTurnSse(
     {
       onEvent: (event, raw) => {
         const data = parse(raw);
-        if (event === 'delta') {
-          const text = str(data.text);
-          if (!text) return;
-          // 追加到尾部文本块；尾块不是 text 就新开一个
-          handlers.onBlocks((blocks) => {
-            const last = blocks[blocks.length - 1];
-            if (last && last.kind === 'text') {
-              return [...blocks.slice(0, -1), { kind: 'text', text: last.text + text }];
-            }
-            return [...blocks, { kind: 'text', text }];
-          });
-        } else if (event === 'thinking') {
-          const text = str(data.text);
-          if (!text) return;
-          handlers.onBlocks((blocks) => {
-            const last = blocks[blocks.length - 1];
-            if (last && last.kind === 'thinking') {
-              return [...blocks.slice(0, -1), { kind: 'thinking', text: last.text + text }];
-            }
-            return [...blocks, { kind: 'thinking', text }];
-          });
-        } else if (event === 'plan') {
-          // 计划是**替换**不是追加：后端每次发全量，界面上永远只有一份最新的。
-          // 就地更新（而不是插到末尾）才不会让进度条在对话里越滚越多。
-          const steps = Array.isArray(data.steps)
-            ? (data.steps as unknown[]).flatMap((raw) => {
-                if (!raw || typeof raw !== 'object') return [];
-                const step = raw as Record<string, unknown>;
-                const title = str(step.title);
-                if (!title) return [];
-                const status = str(step.status, 'pending');
-                return [
-                  {
-                    title,
-                    status: (['pending', 'running', 'done'] as const).includes(
-                      status as PlanStep['status'],
-                    )
-                      ? (status as PlanStep['status'])
-                      : ('pending' as const),
-                  },
-                ];
-              })
-            : [];
-          if (!steps.length) return;
-          handlers.onBlocks((blocks) => {
-            const at = blocks.findIndex((b) => b.kind === 'plan');
-            const block: AssistantBlock = { kind: 'plan', steps };
-            if (at < 0) return [...blocks, block];
-            return blocks.map((b, i) => (i === at ? block : b));
-          });
-        } else if (event === 'tool_call') {
-          const id = str(data.id);
-          handlers.onBlocks((blocks) => [
-            ...blocks,
-            { kind: 'tool', id, name: str(data.name, '?'), state: 'running' },
-          ]);
-        } else if (event === 'tool_result') {
-          const id = str(data.id);
-          handlers.onBlocks((blocks) =>
-            blocks.map((b) =>
-              b.kind === 'tool' && b.id === id
-                ? {
-                    ...b,
-                    state: data.ok === false ? 'error' : 'ok',
-                    summary: str(data.summary) || undefined,
-                    preview: str(data.preview) || undefined,
-                    durationMs: num(data.duration_ms),
-                  }
-                : b,
-            ),
-          );
-        } else if (event === 'done') {
+        if (event === 'done') {
           handlers.onDone(str(data.stop_reason, 'stop'));
         } else if (event === 'error') {
           handlers.onError(str(data.detail, '出错了'));
+        } else {
+          handlers.onBlocks((blocks) => applyAssistantEvent(blocks, event, data));
         }
-        // 其余事件（meta / usage / compaction / 将来新增的）一律忽略：
-        // 后端加事件不该让旧前端崩掉
       },
       onClose: () => handlers.onDone('stop'),
       onError: (err) => handlers.onError(err instanceof Error ? err.message : String(err)),


### PR DESCRIPTION
The frontend has had no test tooling at all, and the flimsiest thing in the assistant stack is the SSE-event → block-timeline reduction, because it handles the least trustworthy input in the repo: `JSON.parse`'d `any`. TypeScript can't help there — at compile time it believes it knows the shape; at runtime the payload is whatever the backend sent. I have written "never throws" in that file's comments repeatedly and nothing has ever checked it.

## What's here

**vitest**, dev-dependency only. `npm test` runs it; `build` deliberately does not, so building and testing stay separable for CI.

**`applyAssistantEvent(blocks, event, data)`** extracted as a pure function. Not cosmetics — it was buried in the `onEvent` closure, unreachable without standing up a real SSE connection. Pure input → output is what makes it testable, and the SSE handler now just calls it.

**19 tests**, weighted toward malformed input rather than the happy path: unknown events (a new backend event must not break an old client), missing fields, wrong types, `tool_result` for an id that isn't on screen, empty plans, unknown step statuses.

Three behaviours that have bitten before, or would:

- a plan **replaces** rather than appends, so progress bars don't pile up down the conversation
- the nudge records "already nudged" by **local** date, and treats storage failures as "not nudged" — re-nudging once beats never nudging because a key wouldn't write
- turn phase is derived only from received blocks — the #249 class of bug is exactly two state machines disagreeing, with the spinner still claiming "searching" while the answer streams

## Sensitivity check

Made the plan append instead of replace and removed the empty-plan guard: those two tests failed immediately. Restored: 19 green. `tsc --noEmit` and `vite build` clean.

This was the deferred decision from the original agent plan ("vitest pays for itself after P3"). P3 shipped several PRs ago and I've since added a nudge scheduler, a plan reducer, and a phase deriver — all pure, all previously unverifiable. If you'd rather not carry the dependency, this reverts as one PR.