### PR TITLE
fix(library): next auto-sync follows the fetch time instead of a hardcoded 03:00 UTC

### DIFF
--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -357,25 +357,36 @@ async def paper_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str
 
 
 # 每日自动同步的触发时刻（UTC，与 worker/settings.py 的 cron 保持一致）
-DAILY_SYNC_UTC_HOUR = 3
-DAILY_SYNC_UTC_MINUTE = 0
+#: 读不到每日抓取时刻时的兜底（与 daily_feed.DEFAULT_SYNC_UTC 一致）。
+DAILY_SYNC_UTC_HOUR = 1
+DAILY_SYNC_UTC_MINUTE = 30
 
 
-def next_daily_sync_at(library: DirectionLibrary | None) -> datetime | None:
-    """下一次自动同步时间：完成初始建库的库都有；未建库返回 None。
+def next_daily_sync_at(
+    library: DirectionLibrary | None, *, fetch_at: tuple[int, int] | None = None
+) -> datetime | None:
+    """下一次自动同步的**大致**时刻：完成初始建库的库都有；未建库返回 None。
 
-    同步节奏不再可配置——每日论文池每天更新且只保留一周，任何比「每天」更稀疏的
-    节奏都意味着永久漏抓，而界面上只表现为「一直没有新论文」。
+    库同步是事件驱动的——每日论文抓完、且真有新论文入池才触发（见
+    ``actions_daily.sync_libraries``）。所以这里给的是「抓取时刻」，同步紧随其后。
+    以前这里写死 03:00 UTC，而抓取默认 01:30 UTC：界面报 11:00（北京），实际约 09:35
+    就跑完了，差着一个半小时。孤立地看这只是个小数字，但它属于「界面说的和实际发生的
+    不是一回事」那一类——用户照着它等，等到的是已经结束的东西。
+
+    ``fetch_at`` 由调用方从设置里读（本函数不碰 session）；不给就用默认时刻。
+    真正的触发还取决于 arXiv 当天几点发布，所以这是估计值，不是承诺。
+
+    同步节奏不可配置：每日论文池每天更新且只保留一周，任何比「每天」更稀疏的节奏
+    都意味着永久漏抓，而界面上只表现为「一直没有新论文」。
     """
     if library is None:
         return None
     state = library.ingest_state or {}
     if not state.get("watermark"):
         return None
+    hour, minute = fetch_at or (DAILY_SYNC_UTC_HOUR, DAILY_SYNC_UTC_MINUTE)
     now = datetime.now(UTC)
-    candidate = now.replace(
-        hour=DAILY_SYNC_UTC_HOUR, minute=DAILY_SYNC_UTC_MINUTE, second=0, microsecond=0
-    )
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
     if candidate <= now:
         candidate += timedelta(days=1)
     return candidate
@@ -420,8 +431,19 @@ async def ingest_state(session: AsyncSession, project: Project, *, user: User) -
         "paper_counts": await paper_counts(session, project.id),
         "running_voyage_id": running.id if running else None,
         "can_open_running_voyage": await _can_open(session, running, user),
-        "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
+        "next_sync_at": (
+            next_dt.isoformat()
+            if (next_dt := next_daily_sync_at(library, fetch_at=await _daily_fetch_at(session)))
+            else None
+        ),
     }
+
+
+async def _daily_fetch_at(session: AsyncSession) -> tuple[int, int]:
+    """每日论文的抓取时刻（库同步紧随其后）。延迟 import 避开循环依赖。"""
+    from app.services import daily_feed
+
+    return await daily_feed.get_sync_time(session)
 
 
 async def library_ingest_state(
@@ -440,7 +462,11 @@ async def library_ingest_state(
         "paper_counts": await library_paper_counts(session, library.id),
         "running_voyage_id": running.id if running else None,
         "can_open_running_voyage": await _can_open(session, running, user),
-        "next_sync_at": (next_dt.isoformat() if (next_dt := next_daily_sync_at(library)) else None),
+        "next_sync_at": (
+            next_dt.isoformat()
+            if (next_dt := next_daily_sync_at(library, fetch_at=await _daily_fetch_at(session)))
+            else None
+        ),
     }
 
 

--- a/src/backend/tests/test_wiki_api.py
+++ b/src/backend/tests/test_wiki_api.py
@@ -532,4 +532,8 @@ async def test_ingest_state_next_sync_at(client):
 
     resp = await client.get(f"/api/projects/{project_id}/ingest/state", headers=headers)
     nxt = resp.json()["next_sync_at"]
-    assert nxt is not None and "T03:00:00" in nxt  # 每日 03:00 UTC
+    # 跟着每日论文的抓取时刻走（库同步紧随抓取之后），不再是写死的 03:00 UTC
+    from app.services.daily_feed import DEFAULT_SYNC_UTC
+
+    hour, minute = DEFAULT_SYNC_UTC
+    assert nxt is not None and f"T{hour:02d}:{minute:02d}:00" in nxt

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -2205,3 +2205,53 @@ async def test_digest_only_survives_a_backward_clock_jump(client, queue_stub, wi
         f"回拨两秒就把策略翻成了 {launch['strategy']}——上界又回来了？"
     )
     assert launch["paper_count"] == 2, launch
+
+
+async def test_next_sync_follows_the_configured_fetch_time(client):
+    """「下次自动同步」要跟着每日抓取时刻走。
+
+    库同步是事件驱动的：每日论文抓完、且真有新论文才触发。以前这个时刻写死 03:00 UTC，
+    而抓取默认 01:30 UTC——界面报北京 11:00，实际约 09:35 就跑完了。孤立看只是个小数字，
+    但它属于「界面说的和实际发生的不是一回事」，用户照着它等，等到的是已经结束的东西。
+    """
+    import datetime as _dt
+
+    from app.models.library_direction import DirectionLibrary
+    from app.services.ingest import next_daily_sync_at
+
+    library = DirectionLibrary(name="x", definition={"statement": "s"})
+    library.ingest_state = {"watermark": "2026-08-01T00:00:00+00:00"}
+
+    at = next_daily_sync_at(library, fetch_at=(5, 45))
+    assert at is not None and (at.hour, at.minute) == (5, 45)
+    # 永远在将来：今天那个时刻已经过了就顺延到明天
+    assert at > _dt.datetime.now(_dt.UTC)
+
+    # 没建过库的库没有下次同步（不是给个假时刻）
+    library.ingest_state = {}
+    assert next_daily_sync_at(library, fetch_at=(5, 45)) is None
+
+
+async def test_next_sync_reads_the_setting_not_a_hardcoded_hour(client):
+    """端到端：改了抓取时刻，库状态里的下次同步跟着变。"""
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.library_direction import DirectionLibrary
+    from app.models.user import User
+    from app.services import daily_feed
+    from app.services.ingest import library_ingest_state
+
+    token = await register_and_login(client)
+    assert token
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_sync_time(session, 6, 15)
+        user = (await session.execute(select(User))).scalars().first()
+        library = DirectionLibrary(name="sync-time-lib", definition={"statement": "s"})
+        library.ingest_state = {"watermark": "2026-08-01T00:00:00+00:00"}
+        session.add(library)
+        await session.commit()
+        state = await library_ingest_state(session, library, user=user)
+
+    assert state["next_sync_at"]
+    assert state["next_sync_at"][11:16] == "06:15"

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -375,7 +375,15 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
                         {tr('尚未运行过初始建库', 'Initial library build has not run yet')}
                       </div>
                     )}
-                    <div style={{ fontSize: 11, color: 'var(--text-3)', margin: '10px 0 4px' }}>{tr('下次自动同步', 'Next auto sync')}</div>
+                    <div
+                      style={{ fontSize: 11, color: 'var(--text-3)', margin: '10px 0 4px' }}
+                      title={tr(
+                        '同步跟着每日论文抓取走：抓完且有新论文才同步，所以这是估计时刻，不是准点',
+                        'Sync follows the daily paper fetch and only runs if new papers arrived, so this is an estimate',
+                      )}
+                    >
+                      {tr('下次自动同步（约）', 'Next auto sync (approx.)')}
+                    </div>
                     <div className="mono" style={{ fontSize: 13, fontWeight: 650 }}>
                       {state?.next_sync_at
                         ? new Date(state.next_sync_at).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })


### PR DESCRIPTION
Found while auditing the daily pipeline for more bugs of the kind #271/#272 turned up.

Library sync became event-driven a while back: it runs right after the daily paper fetch finishes, and only if new papers actually landed. But the "next auto sync" shown on the library page was still a hardcoded 03:00 UTC, while the fetch defaults to 01:30 UTC. So the UI promised 11:00 Beijing for something that in practice finished around 09:35.

On its own that's a small number being wrong. It belongs to the same family as the bugs reported this week, though: the interface saying something different from what the system does. A user who waits for the time on screen is waiting for something that already happened.

- `next_daily_sync_at` takes `fetch_at`, read from settings by the caller (the function itself stays session-free and testable)
- the fallback constant is now the same 01:30 as `daily_feed.DEFAULT_SYNC_UTC`, instead of two modules each picking their own hour
- the label reads "next auto sync (approx.)" and explains that it follows the fetch and depends on when arXiv publishes — an estimate, not a promise

## Tests

The existing assertion (`"T03:00:00" in nxt`) pinned the behaviour being fixed, so it's rewritten to read `DEFAULT_SYNC_UTC` rather than being deleted or loosened. Two new: the function honours the passed time and always lands in the future, and end-to-end — change the fetch time setting, and the library state's `next_sync_at` moves with it.

Full suite **1079 passed**.