### PR TITLE
feat(assistant): PolarisBuddy becomes a dockable, resizable column with visible capabilities and inline figures

### DIFF
--- a/src/backend/app/agents/chat/events.py
+++ b/src/backend/app/agents/chat/events.py
@@ -69,6 +69,11 @@ class ToolResultEvent:
     preview: str
     duration_ms: int
     images: int = 0
+    #: 图片的**出处**，不是字节：[{"kind": "paper_figure", "paper_id": ..., "index": 3,
+    #: "label": 图注}]。base64 一张图几百 KB，几张就能把 SSE 连接和浏览器一起灌爆；
+    #: 前端本来就有带鉴权的取图端点，让它自己去取。给不出出处的图不进这个列表，
+    #: 但仍计入 images——「有 3 张图，其中 2 张能显示」是诚实的，假装只有 2 张不是。
+    image_refs: tuple[dict[str, Any], ...] = ()
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -292,6 +292,9 @@ class ChatAgentLoop:
                 preview=text[:PREVIEW_CHARS],
                 duration_ms=duration,
                 images=len(images),
+                image_refs=tuple(
+                    {**img.ref, "label": img.label} for img in images if img.ref is not None
+                ),
             ),
             ToolResultBlock(call.id, text),
         )

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -208,6 +208,62 @@ async def delete_skill(
     await session.commit()
 
 
+@router.get("/capabilities")
+async def capabilities(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """这一轮 Buddy 手里有什么：工具、技能、MCP。
+
+    界面上要能回答「它现在到底能干什么」。此前这个问题只能靠读代码——工具白名单写在
+    常量里，技能目录只在提示词里出现过，MCP 那套工具面是不是同一批也没人说得清。
+
+    三件事在这里合并成一个答案，因为它们本来就是同一件事的三个侧面：**平台的工具面**
+    （对内给 Buddy、对外给 MCP 客户端，是同一批），**技能**（按需加载的用法说明），
+    以及 MCP 的暴露状况。
+    """
+    _require_enabled()
+    from app.mcp.dispatch import tool_definitions as mcp_tool_definitions
+    from app.models.agent_skill import as_dict
+    from app.tools.registry import get_tool
+
+    names = list(DEFAULT_TOOL_NAMES)
+    tools = []
+    for name in names:
+        spec = get_tool(name)
+        if spec is None:
+            continue
+        tools.append(
+            {"name": spec.name, "description": spec.description, "read_only": spec.read_only}
+        )
+    skills = [
+        as_dict(r) | {"is_builtin": r.scope == "builtin"}
+        for r in await agent_skills.visible_skills(session, user_id=user.id)
+    ]
+    mcp_tools = mcp_tool_definitions()
+    return {
+        "tools": tools,
+        "skills": [
+            {
+                "slug": s["slug"],
+                "name": s.get("name") or s["slug"],
+                "description": s.get("description") or "",
+                "is_builtin": s["is_builtin"],
+            }
+            for s in skills
+        ],
+        # Polaris 自己就是 MCP 服务端：Buddy 用的工具与外部客户端（Claude Desktop 等）
+        # 拿到的是同一批，只是外部那边只给只读的。如实说清楚，别让界面上多出一个
+        # 并不存在的「已连接的 MCP 服务器」列表。
+        "mcp": {
+            "role": "server",
+            "endpoint": "/mcp",
+            "exposed_tools": len(mcp_tools),
+            "note": "Buddy 的工具与对外 MCP 暴露的是同一批（外部客户端只拿只读工具）",
+        },
+    }
+
+
 @router.get("/buddy/greeting")
 async def buddy_greeting(
     session: AsyncSession = Depends(get_session),

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -52,6 +52,12 @@ async def _project_paper(
     return paper
 
 
+def _figure_ref(paper_id: uuid.UUID, index: int) -> dict[str, Any]:
+    """图片在平台里的出处。前端拿它去 /papers/{id}/figures/{index}/image 取图——
+    那个端点本来就有、且带鉴权，对话流里没必要再造一条图片通道。"""
+    return {"kind": "paper_figure", "paper_id": str(paper_id), "index": index}
+
+
 def _fig_meta(fig: dict[str, Any]) -> dict[str, Any]:
     return {
         "index": fig.get("index"),
@@ -144,7 +150,16 @@ async def get_paper_figure(ctx: ToolContext, args: dict[str, Any]) -> ToolResult
             "title": paper.title,
             **_fig_meta(fig),
         }
-    return ToolResult(payload=payload, images=(ToolImage(data=data, label=fig.get("caption")),))
+    return ToolResult(
+        payload=payload,
+        images=(
+            ToolImage(
+                data=data,
+                label=fig.get("caption"),
+                ref=_figure_ref(paper.id, int(fig["index"])),
+            ),
+        ),
+    )
 
 
 @tool(
@@ -187,7 +202,13 @@ async def get_paper_figures(ctx: ToolContext, args: dict[str, Any]) -> ToolResul
         if not path.exists():
             continue
         try:
-            images.append(ToolImage(data=_png_bytes(path, max_dim), label=fig.get("caption")))
+            images.append(
+                ToolImage(
+                    data=_png_bytes(path, max_dim),
+                    label=fig.get("caption"),
+                    ref=_figure_ref(uuid.UUID(paper_id), int(fig["index"])),
+                )
+            )
             metas.append(_fig_meta(fig))
         except Exception:  # noqa: BLE001 — 单图解码失败跳过，不阻断其余
             continue

--- a/src/backend/app/tools/registry.py
+++ b/src/backend/app/tools/registry.py
@@ -25,6 +25,11 @@ class ToolImage:
     data: bytes
     mime: str = "image/png"
     label: str | None = None  # 图注 / alt（可选）
+    #: 这张图在平台里的出处，形如 {"kind": "paper_figure", "paper_id": ..., "index": 3}。
+    #: 对话流里**发引用不发字节**：一张图 base64 之后几百 KB，几张就能把 SSE 连接和
+    #: 浏览器一起灌爆，而前端本来就有取图的鉴权端点。给不出出处的图（将来可能有）
+    #: 就是 None，前端只显示图注。
+    ref: dict[str, Any] | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -341,3 +341,47 @@ async def test_the_resolved_project_sticks_to_the_conversation(client, agent_on)
     async with get_sessionmaker()() as session:
         conv = await session.get(Conversation, uuid.UUID(conv_id))
         assert str(conv.project_id) == project_id, "第一轮解析出的课题要存回会话"
+
+
+async def test_capabilities_reports_tools_skills_and_mcp(client, agent_on):
+    """「它现在到底能干什么」要有一个能问的地方。
+
+    此前只能靠读代码：工具白名单在常量里，技能目录只出现在提示词里，对外 MCP 暴露的
+    是不是同一批也没人说得清。
+    """
+    from app.services.builtin_agent_skills import ensure_builtin_agent_skills
+
+    headers = await _headers(client, "caps@example.com")
+    async with get_sessionmaker()() as session:
+        await ensure_builtin_agent_skills(session)  # 生产上由启动钩子种入
+    body = (await client.get("/api/chat/capabilities", headers=headers)).json()
+
+    names = {t["name"] for t in body["tools"]}
+    assert "search_papers" in names and "update_plan" in names
+    assert all(t["read_only"] for t in body["tools"]), "只读期不该有写工具混进来"
+    # 内置技能种子在启动时就位
+    assert body["skills"], "技能目录是空的"
+    assert {s["slug"] for s in body["skills"]} & {"polaris-search-playbook", "paper-deep-read"}
+    # MCP：如实说明 Polaris 是服务端，不编一个「已连接的服务器」列表
+    assert body["mcp"]["role"] == "server"
+    assert body["mcp"]["exposed_tools"] > 0
+
+
+async def test_figure_tools_carry_a_ref_so_images_never_ride_the_stream(client, agent_on):
+    """图片在对话流里只发出处，不发字节。
+
+    base64 一张图几百 KB，几张就能把 SSE 连接和浏览器一起灌爆；而平台本来就有带鉴权的
+    取图端点。
+    """
+    from app.tools.figures import _figure_ref
+
+    ref = _figure_ref(uuid.uuid4(), 3)
+    assert ref["kind"] == "paper_figure" and ref["index"] == 3
+    assert uuid.UUID(ref["paper_id"])  # 可解析回 uuid
+
+    from app.agents.chat.events import ToolResultEvent
+
+    ev = ToolResultEvent(
+        id="c", name="get_paper_figure", ok=True, summary="", preview="", duration_ms=1
+    )
+    assert ev.image_refs == (), "默认不带图，字段存在即可"

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -11,6 +11,7 @@ import { useAuth } from './auth';
 import { topicPath, useProject } from './project';
 import { AssistantPanel } from '../features/assistant/AssistantPanel';
 import { BuddyBubble } from '../features/assistant/BuddyBubble';
+import { BuddyDock } from '../features/assistant/BuddyDock';
 import { alreadyNudgedToday, markNudged } from '../features/assistant/nudge';
 import { SearchPalette } from './SearchPalette';
 import { UserMenu } from './UserMenu';
@@ -775,6 +776,24 @@ export function AppShell() {
         </div>
       </div>
 
+      {/* —— PolarisBuddy 停靠栏：它是版面的一列，内容区被挤窄而不是被盖住 ——
+          浮层盖住内容，「一边看论文一边问」就只能开一下关一下；停靠栏让两边同时在场。
+          窄屏不走这条（挤两列谁都看不清），下面那个覆盖式抽屉才是手机形态。 */}
+      {!isMobile && assistantOpen && (
+        <BuddyDock>
+          <AssistantPanel
+            variant="dock"
+            open
+            onClose={() => setAssistantOpen(false)}
+            droppedPaperId={droppedPaperId}
+            onDroppedPaperHandled={() => setDroppedPaperId(null)}
+            droppedText={droppedText}
+            onDroppedTextHandled={() => setDroppedText(null)}
+            onBusyChange={setBuddyBusy}
+          />
+        </BuddyDock>
+      )}
+
       {/* —— 审批抽屉 —— */}
       <Drawer
         open={drawerOpen}
@@ -842,7 +861,8 @@ export function AppShell() {
       {/* —— 全局搜索面板 —— */}
       <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
 
-      {/* —— PolarisBuddy：悬浮球 + 抽屉（⌘J）—— */}
+      {/* —— PolarisBuddy：悬浮球 + 抽屉（⌘J）——
+          停靠形态见下方 .app 里的 BuddyDock；这里只留窄屏的覆盖式抽屉与悬浮球。 */}
       <BuddyBubble
         busy={buddyBusy}
         nudge={nudge}
@@ -862,15 +882,17 @@ export function AppShell() {
           setAssistantOpen(true);
         }}
       />
-      <AssistantPanel
-        open={assistantOpen}
-        onClose={() => setAssistantOpen(false)}
-        droppedPaperId={droppedPaperId}
-        onDroppedPaperHandled={() => setDroppedPaperId(null)}
-        droppedText={droppedText}
-        onDroppedTextHandled={() => setDroppedText(null)}
-        onBusyChange={setBuddyBusy}
-      />
+      {isMobile && (
+        <AssistantPanel
+          open={assistantOpen}
+          onClose={() => setAssistantOpen(false)}
+          droppedPaperId={droppedPaperId}
+          onDroppedPaperHandled={() => setDroppedPaperId(null)}
+          droppedText={droppedText}
+          onDroppedTextHandled={() => setDroppedText(null)}
+          onBusyChange={setBuddyBusy}
+        />
+      )}
 
       <ToastHost />
     </div>

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -5,6 +5,8 @@ import { Markdown } from '../../lib/markdown';
 import { api } from '../../lib/api';
 import { assistantTurnSse, type AssistantBlock, type PlanStep } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
+import { CapabilitiesBar } from './CapabilitiesBar';
+import { ToolImages } from './ToolImages';
 import { pageContextFrom } from './buddyContext';
 import { TurnStatus } from './TurnStatus';
 
@@ -100,6 +102,7 @@ function ToolCard({ block }: { block: Extract<AssistantBlock, { kind: 'tool' }> 
           </span>
         )}
       </div>
+      {block.images?.length ? <ToolImages images={block.images} /> : null}
       {open && block.preview && (
         <pre
           className="mono"
@@ -250,9 +253,12 @@ export function AssistantPanel({
   droppedText,
   onDroppedTextHandled,
   onBusyChange,
+  variant = 'overlay',
 }: {
   open: boolean;
   onClose: () => void;
+  /** dock = 版面的一列（宽度与边框由 BuddyDock 负责）；overlay = 窄屏覆盖式抽屉 */
+  variant?: 'dock' | 'overlay';
   /** 拖到悬浮球上的论文 id：进来就自动问一句「解读这篇」 */
   droppedPaperId?: string | null;
   onDroppedPaperHandled?: () => void;
@@ -446,22 +452,39 @@ export function AssistantPanel({
   const lastTurn = turns[turns.length - 1];
   const liveBlocks = busy && lastTurn?.role === 'assistant' ? lastTurn.blocks : [];
 
+  // 这场对话里真的被加载过的技能。判据是 skill_load 的调用摘要——**不是**目录里
+  // 有哪些技能：目录只说明「它可能会用」，加载过才是「它真的用了」。
+  const loadedSkills = new Set<string>();
+  for (const turn of turns) {
+    for (const block of turn.blocks) {
+      if (block.kind === 'tool' && block.name === 'skill_load' && block.state === 'ok') {
+        const slug = (block.summary ?? '').match(/[a-z0-9][a-z0-9-]{2,}/i)?.[0];
+        if (slug) loadedSkills.add(slug);
+      }
+    }
+  }
+
+  // dock 形态下，外框（宽度/边框/拖拽把手）归 BuddyDock 管，这里只铺内容；
+  // overlay 形态自己是那个浮层。两种形态共用下面同一套正文，不分叉。
+  const frame: React.CSSProperties =
+    variant === 'dock'
+      ? { flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }
+      : {
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: 'min(520px, 100vw)',
+          background: 'var(--surface)',
+          borderLeft: '0.5px solid var(--border-2)',
+          display: 'flex',
+          flexDirection: 'column',
+          zIndex: 60,
+          boxShadow: '-8px 0 24px rgba(0,0,0,0.06)',
+        };
+
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        right: 0,
-        bottom: 0,
-        width: 'min(520px, 100vw)',
-        background: 'var(--surface)',
-        borderLeft: '0.5px solid var(--border-2)',
-        display: 'flex',
-        flexDirection: 'column',
-        zIndex: 60,
-        boxShadow: '-8px 0 24px rgba(0,0,0,0.06)',
-      }}
-    >
+    <div style={frame}>
       <div className="row gap8" style={{ padding: '12px 16px', borderBottom: '0.5px solid var(--border-2)', alignItems: 'center' }}>
         <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
         <strong style={{ fontSize: 14 }}>PolarisBuddy</strong>
@@ -476,10 +499,20 @@ export function AssistantPanel({
         <button className="icon-btn" onClick={newConversation} title={tr('新会话', 'New')}>
           <Icon name="plus" size={14} />
         </button>
-        <button className="icon-btn" onClick={onClose} title={tr('关闭（⌘J）', 'Close (⌘J)')}>
-          <Icon name="x" size={14} />
+        <button
+          className="icon-btn"
+          onClick={onClose}
+          title={
+            variant === 'dock'
+              ? tr('收起（⌘J）', 'Collapse (⌘J)')
+              : tr('关闭（⌘J）', 'Close (⌘J)')
+          }
+        >
+          <Icon name={variant === 'dock' ? 'chevron' : 'x'} size={14} />
         </button>
       </div>
+
+      <CapabilitiesBar loadedSkills={loadedSkills} />
 
       {historyOpen && (
         <div

--- a/src/frontend/src/features/assistant/BuddyDock.tsx
+++ b/src/frontend/src/features/assistant/BuddyDock.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/* ============================================================
+   PolarisBuddy 的停靠栏：它是**版面的一列**，不是浮在页面上的抽屉。
+
+   区别不只是观感：浮层盖住内容，于是「一边看论文一边问」在物理上做不到——用户得
+   开一下关一下。停靠栏把内容挤窄，两边同时在场，这才是 Buddy 想要的用法。
+
+   宽度可拖、记在 localStorage。拖动时才用 state 跟手，松手才落盘：每一像素写一次
+   localStorage 会让拖拽变卡。
+
+   窄屏不用这个（见 AppShell）：手机上挤两列谁都看不清，那里仍然是覆盖式抽屉。
+   ============================================================ */
+
+const WIDTH_KEY = 'polaris.buddy.width';
+const MIN_WIDTH = 320;
+//: 上限按视口算：固定 720 在小笔记本上会把内容区挤到没法看
+const maxWidth = () => Math.max(MIN_WIDTH, Math.min(760, Math.round(window.innerWidth * 0.55)));
+
+export const DEFAULT_WIDTH = 420;
+
+export function clampWidth(width: number, viewportMax: number): number {
+  return Math.min(Math.max(width, MIN_WIDTH), Math.max(MIN_WIDTH, viewportMax));
+}
+
+function loadWidth(): number {
+  try {
+    const raw = Number(localStorage.getItem(WIDTH_KEY));
+    if (Number.isFinite(raw) && raw > 0) return clampWidth(raw, maxWidth());
+  } catch {
+    /* 存量坏值不值得报错，用默认宽度 */
+  }
+  return DEFAULT_WIDTH;
+}
+
+export function BuddyDock({ children }: { children: React.ReactNode }) {
+  const [width, setWidth] = useState<number>(loadWidth);
+  const [dragging, setDragging] = useState(false);
+  const startRef = useRef<{ x: number; width: number } | null>(null);
+
+  // 视口变窄时跟着收：否则把窗口拉小之后，停靠栏能把内容区挤没
+  useEffect(() => {
+    const onResize = () => setWidth((w) => clampWidth(w, maxWidth()));
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      startRef.current = { x: e.clientX, width };
+      setDragging(true);
+
+      const onMove = (ev: PointerEvent) => {
+        const start = startRef.current;
+        if (!start) return;
+        // 停靠在右侧：往左拖是变宽
+        setWidth(clampWidth(start.width + (start.x - ev.clientX), maxWidth()));
+      };
+      const onUp = () => {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        startRef.current = null;
+        setDragging(false);
+        // 松手才落盘：拖动中每像素写一次 localStorage 会让拖拽发涩
+        setWidth((w) => {
+          try {
+            localStorage.setItem(WIDTH_KEY, String(w));
+          } catch {
+            /* 存不下就下次重来，不是错误 */
+          }
+          return w;
+        });
+      };
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+    },
+    [width],
+  );
+
+  return (
+    <div
+      style={{
+        flex: `0 0 ${width}px`,
+        minWidth: 0,
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--surface)',
+        borderLeft: '0.5px solid var(--border-2)',
+      }}
+    >
+      {/* 拖拽把手：贴在左边缘外侧一点，命中区比看得见的线宽 */}
+      <div
+        onPointerDown={onPointerDown}
+        title="拖动改变宽度"
+        style={{
+          position: 'absolute',
+          left: -3,
+          top: 0,
+          bottom: 0,
+          width: 7,
+          cursor: 'col-resize',
+          zIndex: 2,
+          background: dragging ? 'var(--accent)' : 'transparent',
+          opacity: dragging ? 0.35 : 1,
+          touchAction: 'none',
+        }}
+      />
+      {/* 拖动时全局禁选：否则光标扫过正文会把页面文字整片选中 */}
+      {dragging && (
+        <style>{`* { user-select: none !important; cursor: col-resize !important; }`}</style>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/frontend/src/features/assistant/CapabilitiesBar.tsx
+++ b/src/frontend/src/features/assistant/CapabilitiesBar.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   「它现在到底能干什么」——工具面、技能、MCP。
+
+   此前这个问题只能靠读代码回答：工具白名单写在常量里，技能目录只在提示词里出现过，
+   对外 MCP 暴露的是不是同一批也没人说得清。
+
+   一条可展开的横条，收起时只占一行。展开后如实列出三样，其中 MCP 那栏**不列
+   「已连接的服务器」**——Polaris 自己是 MCP 服务端，没有对外连接。造一个空列表出来
+   比不显示更误导。
+   ============================================================ */
+
+interface Capabilities {
+  tools: { name: string; description: string; read_only: boolean }[];
+  skills: { slug: string; name: string; description: string; is_builtin: boolean }[];
+  mcp: { role: string; endpoint: string; exposed_tools: number; note: string };
+}
+
+export function CapabilitiesBar({ loadedSkills }: { loadedSkills: Set<string> }) {
+  const [open, setOpen] = useState(false);
+  const [caps, setCaps] = useState<Capabilities | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void api
+      .getBuddyCapabilities()
+      .then((c) => {
+        if (alive) setCaps(c as Capabilities);
+      })
+      .catch(() => {
+        /* 取不到就不显示这条，不摆一个空壳 */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (!caps) return null;
+
+  return (
+    <div style={{ borderBottom: '0.5px solid var(--border-2)', background: 'var(--surface-2)' }}>
+      <div
+        className="row gap8 hoverable"
+        onClick={() => setOpen((o) => !o)}
+        style={{ padding: '6px 14px', alignItems: 'center', cursor: 'pointer', fontSize: 11.5 }}
+      >
+        <Icon
+          name="chevDown"
+          size={11}
+          style={{
+            color: 'var(--text-4)',
+            transform: open ? undefined : 'rotate(-90deg)',
+            transition: 'transform 0.12s',
+          }}
+        />
+        <span style={{ color: 'var(--text-3)' }}>
+          {tr(`工具 ${caps.tools.length}`, `${caps.tools.length} tools`)}
+        </span>
+        <span style={{ color: 'var(--text-4)' }}>·</span>
+        <span style={{ color: 'var(--text-3)' }}>
+          {tr(`技能 ${caps.skills.length}`, `${caps.skills.length} skills`)}
+          {loadedSkills.size > 0 && (
+            <span style={{ color: 'var(--accent)' }}>
+              {tr(`（本轮用了 ${loadedSkills.size}）`, ` (${loadedSkills.size} used)`)}
+            </span>
+          )}
+        </span>
+        <span style={{ color: 'var(--text-4)' }}>·</span>
+        <span style={{ color: 'var(--text-3)' }}>
+          MCP {caps.mcp.exposed_tools}
+        </span>
+      </div>
+
+      {open && (
+        <div style={{ padding: '2px 14px 10px', fontSize: 11.5, lineHeight: 1.6 }}>
+          <div style={{ color: 'var(--text-4)', marginBottom: 3 }}>{tr('本轮可用工具', 'Tools this turn')}</div>
+          <div className="row gap6 wrap" style={{ marginBottom: 9 }}>
+            {caps.tools.map((t) => (
+              <span key={t.name} className="pill sm mono" title={t.description}>
+                {t.name}
+              </span>
+            ))}
+          </div>
+
+          <div style={{ color: 'var(--text-4)', marginBottom: 3 }}>
+            {tr('技能（按需加载，不常驻提示词）', 'Skills (loaded on demand, not resident in the prompt)')}
+          </div>
+          <div className="col gap6" style={{ marginBottom: 9 }}>
+            {caps.skills.length === 0 && (
+              <span style={{ color: 'var(--text-4)' }}>{tr('还没有技能', 'No skills yet')}</span>
+            )}
+            {caps.skills.map((s) => (
+              <div key={s.slug} className="row gap6" style={{ alignItems: 'flex-start' }}>
+                <Icon
+                  name={loadedSkills.has(s.slug) ? 'check' : 'dot'}
+                  size={11}
+                  style={{
+                    marginTop: 4,
+                    flexShrink: 0,
+                    color: loadedSkills.has(s.slug) ? 'var(--ok-tx)' : 'var(--text-4)',
+                  }}
+                />
+                <div style={{ minWidth: 0 }}>
+                  <span className="mono" style={{ color: 'var(--text-2)' }}>
+                    {s.slug}
+                  </span>
+                  {s.is_builtin && (
+                    <span style={{ color: 'var(--text-4)' }}>{tr(' · 内置', ' · built-in')}</span>
+                  )}
+                  <div style={{ color: 'var(--text-4)' }}>{s.description}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ color: 'var(--text-4)', marginBottom: 3 }}>MCP</div>
+          <div style={{ color: 'var(--text-3)' }}>
+            {tr(
+              `Polaris 自己是 MCP 服务端（${caps.mcp.endpoint}），对外暴露 ${caps.mcp.exposed_tools} 个只读工具。`,
+              `Polaris is itself an MCP server (${caps.mcp.endpoint}) exposing ${caps.mcp.exposed_tools} read-only tools.`,
+            )}
+            <div style={{ color: 'var(--text-4)' }}>{caps.mcp.note}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/assistant/ToolImages.tsx
+++ b/src/frontend/src/features/assistant/ToolImages.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import type { ImageRef } from '../../lib/assistantStream';
+
+/* ============================================================
+   工具返回的图片。
+
+   对话流里传的是**出处**不是字节：一张图 base64 之后几百 KB，几张就能把 SSE 连接和
+   浏览器一起灌爆。取图走平台本来就有的鉴权端点（`<img src>` 带不了 Bearer，所以是
+   blob → objectURL，这是全仓已有的做法）。
+
+   取不到就不占位：图注还在，用户知道有这么一张图、也知道它没显示出来——比一个碎图
+   图标诚实。
+   ============================================================ */
+
+function FigureImage({ figure, onOpen }: { figure: ImageRef; onOpen: (url: string) => void }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    let objectUrl: string | null = null;
+    void api
+      .fetchFigureImage(figure.paperId, figure.index)
+      .then((blob) => {
+        if (!alive) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+      // objectURL 不撤会一直占着内存，长对话里几十张图就很可观
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [figure.paperId, figure.index]);
+
+  if (failed) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--text-4)', padding: '4px 0' }}>
+        {tr(`图 ${figure.index}`, `Figure ${figure.index}`)}
+        {figure.label ? ` · ${figure.label}` : ''}
+        {tr('（取图失败）', ' (failed to load)')}
+      </div>
+    );
+  }
+  return (
+    <figure style={{ margin: '6px 0' }}>
+      {url ? (
+        <img
+          src={url}
+          alt={figure.label ?? `figure ${figure.index}`}
+          onClick={() => onOpen(url)}
+          style={{
+            maxWidth: '100%',
+            borderRadius: 8,
+            border: '0.5px solid var(--border-2)',
+            cursor: 'zoom-in',
+            display: 'block',
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            height: 84,
+            borderRadius: 8,
+            background: 'var(--surface-2)',
+            border: '0.5px solid var(--border-2)',
+          }}
+        />
+      )}
+      {figure.label && (
+        <figcaption style={{ fontSize: 11, color: 'var(--text-4)', marginTop: 4, lineHeight: 1.5 }}>
+          {tr(`图 ${figure.index}`, `Fig. ${figure.index}`)} · {figure.label}
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+export function ToolImages({ images }: { images: ImageRef[] }) {
+  // 点开看大图。灯箱只是放大同一个 objectURL，不再取一次
+  const [zoomed, setZoomed] = useState<string | null>(null);
+  return (
+    <>
+      {images.map((figure) => (
+        <FigureImage
+          key={`${figure.paperId}-${figure.index}`}
+          figure={figure}
+          onOpen={setZoomed}
+        />
+      ))}
+      {zoomed && (
+        <div
+          onClick={() => setZoomed(null)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.72)',
+            zIndex: 90,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+            cursor: 'zoom-out',
+          }}
+        >
+          <img
+            src={zoomed}
+            alt=""
+            style={{ maxWidth: '100%', maxHeight: '100%', borderRadius: 8 }}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4731,6 +4731,14 @@ export const api = {
    */
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
   /** 全局助手：会话列表（最近说过话的在前）。 */
+  /** Buddy 这一轮手里有什么：工具面、技能、MCP 暴露状况。 */
+  getBuddyCapabilities(): Promise<{
+    tools: { name: string; description: string; read_only: boolean }[];
+    skills: { slug: string; name: string; description: string; is_builtin: boolean }[];
+    mcp: { role: string; endpoint: string; exposed_tools: number; note: string };
+  }> {
+    return request('/chat/capabilities');
+  },
   /** PolarisBuddy 开面板时的问候语。数字是 SQL 数出来的，不过模型。 */
   getBuddyGreeting(): Promise<{
     greeting: string;

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -8,6 +8,14 @@ import { postSse } from './sse';
    运行时炸了没人拦得住。
    ============================================================ */
 
+export interface ImageRef {
+  /** 目前只有 paper_figure 一种出处；认不出的一律丢掉，不猜 */
+  kind: 'paper_figure';
+  paperId: string;
+  index: number;
+  label?: string;
+}
+
 export interface PlanStep {
   title: string;
   status: 'pending' | 'running' | 'done';
@@ -25,6 +33,8 @@ export type AssistantBlock =
       summary?: string;
       preview?: string;
       durationMs?: number;
+      /** 工具返回的图片**出处**（不是字节）：前端拿它走已有的鉴权端点取图 */
+      images?: ImageRef[];
     };
 
 export interface AssistantHandlers {


### PR DESCRIPTION
Replicating three things from Claude's interface, as asked.

## It's a column, not a floating drawer

An overlay covers the content, so "read the paper while asking about it" is physically impossible — you end up toggling the panel open and shut. A dock squeezes the content instead, and both are on screen at once.

Width is draggable (floor 320px, ceiling 55% of the viewport), remembered in `localStorage`. During a drag the width lives in state and only lands in storage on release — writing `localStorage` every pixel makes the drag feel sticky. It also shrinks when the viewport does, so narrowing the window can't squeeze the content area to nothing.

Narrow screens keep the overlay drawer; two columns on a phone are unreadable. Collapsing returns to the floating bubble, and the keyboard shortcut is unchanged.

## You can see what it can do

New `GET /chat/capabilities` returns this turn's tool surface, the skill catalogue, and the MCP exposure. Until now that question could only be answered by reading source: the tool whitelist was a constant, the skill catalogue only ever appeared inside a prompt, and whether MCP exposed the same set was anyone's guess.

The UI is one collapsible strip — a single line when closed. The skills section marks the ones **actually loaded this turn** (judged by `skill_load` calls, not by what's in the catalogue: the catalogue only says what it *might* use).

The MCP section states plainly that Polaris *is* an MCP server exposing the same read-only tools, and deliberately shows **no "connected servers" list** — Polaris makes no outbound MCP connections, and rendering an empty list would imply otherwise.

## Figures render inline

Tool images now carry a provenance ref (`ToolImage.ref`), and the stream sends **the ref, not the bytes**. One base64'd figure is a few hundred KB; a handful would drown the SSE connection and the browser together. The frontend takes the ref to the platform's existing authenticated figure endpoint (an `img` tag can't carry a Bearer token, so blob to objectURL, the pattern already used elsewhere in this repo), renders inline, opens a lightbox on click, and revokes the objectURL on unmount.

Images that fail to load leave the caption behind rather than a broken-image icon — the user learns the figure exists *and* that it didn't render, which a broken icon doesn't convey.

## Tests

Two new: capabilities reports tools + seeded builtin skills + MCP as a server (and asserts no write tools slipped into the surface during the read-only phase), and figure refs are well-formed with `image_refs` defaulting to empty. Full suite **1079 passed**; `tsc --noEmit` and `vite build` clean.

## Manual click-through

1. Toggle the assistant — the page content narrows rather than being covered; drag the left edge to resize; reload and the width persists.
2. Shrink the window — the dock gives way instead of eating the page.
3. Expand the capabilities strip — tools, skills (with the ones used this turn ticked), MCP.
4. Ask for a figure from a compiled paper — it renders inline; click to zoom.
