### PR TITLE
feat(assistant): conversation rail, rename/delete, and a rebuilt composer

### DIFF
--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -42,6 +42,7 @@ from app.models.user import User
 from app.schemas.chat_agent import (
     ConversationCreate,
     ConversationRead,
+    ConversationRenameRequest,
     ConversationTurnRequest,
     MemoryCreate,
     MessageRead,
@@ -54,6 +55,9 @@ from app.tools.context import ToolContext
 from app.tools.scope import visible_library_ids
 
 router = APIRouter(prefix="/chat", tags=["chat"])
+
+#: 标题长度上限（与 services.conversations 自动生成时同一口径）
+_TITLE_LIMIT = 60
 
 #: 事件类 → 线上帧名。加法式：老客户端只认识其中四个，其余忽略即可。
 _EVENT_NAMES: dict[type, str] = {
@@ -124,6 +128,39 @@ async def list_conversations(
         session, user_id=user.id, scope_kind=scope_kind, scope_id=scope_id, limit=limit
     )
     return [ConversationRead.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.patch("/conversations/{conversation_id}", response_model=ConversationRead)
+async def rename_conversation(
+    conversation_id: uuid.UUID,
+    payload: ConversationRenameRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ConversationRead:
+    """改标题。标题原本取第一句提问的前 60 字，那句话常常并不概括这场对话。"""
+    _require_enabled()
+    conv = await store.get_owned(session, conversation_id=conversation_id, user_id=user.id)
+    if conv is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
+    conv.title = payload.title.strip()[:_TITLE_LIMIT]
+    await session.commit()
+    return ConversationRead.model_validate(conv, from_attributes=True)
+
+
+@router.delete("/conversations/{conversation_id}", status_code=204)
+async def delete_conversation(
+    conversation_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    """删掉一场对话（消息随外键级联）。只能删自己的——别人的一律 404，不是 403：
+    403 等于承认「这个 id 存在」。"""
+    _require_enabled()
+    conv = await store.get_owned(session, conversation_id=conversation_id, user_id=user.id)
+    if conv is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONVERSATION_NOT_FOUND")
+    await session.delete(conv)
+    await session.commit()
 
 
 @router.get("/conversations/{conversation_id}/messages", response_model=list[MessageRead])

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -33,6 +33,10 @@ class MemoryCreate(BaseModel):
     text: str = Field(min_length=1, max_length=300)
 
 
+class ConversationRenameRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+
+
 class ConversationTurnRequest(BaseModel):
     question: str = Field(min_length=1)
     #: 这轮工具检索的课题。全局会话第一次提问时带上；会话上存过就不用再传。

--- a/src/backend/app/services/conversations.py
+++ b/src/backend/app/services/conversations.py
@@ -123,6 +123,17 @@ async def get_or_create(
     return conv
 
 
+async def get_owned(
+    session: AsyncSession, *, conversation_id: uuid.UUID, user_id: uuid.UUID
+) -> Conversation | None:
+    """取自己的那场对话；不是自己的返回 None（调用方一律 404，不给 403——
+    403 等于承认这个 id 存在）。"""
+    conv = await session.get(Conversation, conversation_id)
+    if conv is None or conv.user_id != user_id:
+        return None
+    return conv
+
+
 async def append_message(
     session: AsyncSession,
     *,

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -385,3 +385,76 @@ async def test_figure_tools_carry_a_ref_so_images_never_ride_the_stream(client, 
         id="c", name="get_paper_figure", ok=True, summary="", preview="", duration_ms=1
     )
     assert ev.image_refs == (), "默认不带图，字段存在即可"
+
+
+async def test_conversations_can_be_renamed_and_deleted(client, agent_on):
+    """标题取自第一句提问，而那句话常常并不概括整场对话——所以要能改，也要能删。"""
+    headers = await _headers(client, "conv-crud@example.com")
+    conv = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()
+
+    resp = await client.patch(
+        f"/api/chat/conversations/{conv['id']}",
+        json={"title": "  planning 相关的那次  "},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "planning 相关的那次"  # 首尾空白去掉
+
+    assert (
+        await client.delete(f"/api/chat/conversations/{conv['id']}", headers=headers)
+    ).status_code == 204
+    rows = (await client.get("/api/chat/conversations", headers=headers)).json()
+    assert conv["id"] not in {r["id"] for r in rows}
+
+
+async def test_someone_elses_conversation_is_404_not_403(client, agent_on):
+    """别人的对话一律 404。403 等于承认「这个 id 存在」——对话标题里常带着研究方向。"""
+    owner = await _headers(client, "conv-owner@example.com")
+    intruder = await _headers(client, "conv-intruder@example.com")
+    conv = (await client.post("/api/chat/conversations", json={}, headers=owner)).json()
+
+    assert (
+        await client.delete(f"/api/chat/conversations/{conv['id']}", headers=intruder)
+    ).status_code == 404
+    assert (
+        await client.patch(
+            f"/api/chat/conversations/{conv['id']}", json={"title": "x"}, headers=intruder
+        )
+    ).status_code == 404
+    # 而且真的没被删掉
+    rows = (await client.get("/api/chat/conversations", headers=owner)).json()
+    assert conv["id"] in {r["id"] for r in rows}
+
+
+async def test_deleting_a_conversation_takes_its_messages(client, agent_on):
+    """消息随对话级联删除，不留孤儿行。"""
+    from sqlalchemy import func, select
+
+    from app.models.conversation import ConversationMessage
+
+    headers = await _headers(client, "conv-cascade@example.com")
+    conv = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv['id']}/turn",
+        json={"question": "留一条消息"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    async with get_sessionmaker()() as session:
+        before = await session.scalar(
+            select(func.count())
+            .select_from(ConversationMessage)
+            .where(ConversationMessage.conversation_id == uuid.UUID(conv["id"]))
+        )
+    assert before and before > 0
+
+    await client.delete(f"/api/chat/conversations/{conv['id']}", headers=headers)
+    async with get_sessionmaker()() as session:
+        after = await session.scalar(
+            select(func.count())
+            .select_from(ConversationMessage)
+            .where(ConversationMessage.conversation_id == uuid.UUID(conv["id"]))
+        )
+    assert after == 0

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { tr } from '../../lib/i18n';
 import { BuddyHome } from './BuddyHome';
 import { CapabilitiesBar } from './CapabilitiesBar';
+import { ConversationRail } from './ConversationRail';
 import { ToolImages } from './ToolImages';
 import { pageContextFrom } from './buddyContext';
 import { useProject } from '../../app/project';
@@ -339,7 +340,12 @@ export function AssistantPanel({
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [convId, setConvId] = useState<string | null>(null);
+  // dock 形态下会话列表是常驻一栏（不再是头部时钟弹层）；overlay 形态屏幕太窄，
+  // 仍然用弹层。
+  const [railOpen, setRailOpen] = useState(true);
   const [historyOpen, setHistoryOpen] = useState(false);
+  //: 发完一轮之后标题才生成，列表要跟着刷新一次
+  const [railRefresh, setRailRefresh] = useState(0);
   const [conversations, setConversations] = useState<
     { id: string; title: string; project_id: string | null }[]
   >([]);
@@ -463,7 +469,10 @@ export function AssistantPanel({
           contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
         projectId: currentProject?.id ?? null,
         onBlocks: patch,
-        onDone: () => setBusy(false),
+        onDone: () => {
+          setBusy(false);
+          setRailRefresh((n) => n + 1); // 标题这时才有
+        },
         onError: (detail) => {
           patch((blocks) => [...blocks, { kind: 'text', text: `⚠️ ${errorText(detail)}` }]);
           setBusy(false);
@@ -548,13 +557,24 @@ export function AssistantPanel({
         <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
         <strong style={{ fontSize: 14 }}>PolarisBuddy</strong>
         <span style={{ flex: 1 }} />
-        <button
-          className="icon-btn"
-          onClick={() => void openHistory()}
-          title={tr('历史会话', 'Conversations')}
-        >
-          <Icon name="clock" size={14} />
-        </button>
+        {variant === 'dock' ? (
+          <button
+            className="icon-btn"
+            onClick={() => setRailOpen((o) => !o)}
+            title={tr('会话列表', 'Conversations')}
+            style={{ color: railOpen ? 'var(--accent)' : undefined }}
+          >
+            <Icon name="sidebar" size={14} />
+          </button>
+        ) : (
+          <button
+            className="icon-btn"
+            onClick={() => void openHistory()}
+            title={tr('历史会话', 'Conversations')}
+          >
+            <Icon name="clock" size={14} />
+          </button>
+        )}
         <button className="icon-btn" onClick={newConversation} title={tr('新会话', 'New')}>
           <Icon name="plus" size={14} />
         </button>
@@ -572,6 +592,7 @@ export function AssistantPanel({
       </div>
 
       <CapabilitiesBar loadedSkills={loadedSkills} />
+
 
       {historyOpen && (
         <div
@@ -609,7 +630,16 @@ export function AssistantPanel({
         </div>
       )}
 
-      <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px' }}>
+      <div className="row" style={{ flex: 1, minHeight: 0, alignItems: 'stretch' }}>
+      {variant === 'dock' && railOpen && (
+        <ConversationRail
+          activeId={convId}
+          onPick={(id) => void loadConversation(id)}
+          onNew={newConversation}
+          refreshKey={railRefresh}
+        />
+      )}
+      <div ref={scrollRef} style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: '14px 16px' }}>
         {turns.length === 0 && (
           <BuddyHome greeting={greeting} onPick={(prompt) => setInput(prompt)} />
         )}
@@ -636,6 +666,8 @@ export function AssistantPanel({
             </div>
           );
         })}
+      </div>
+
       </div>
 
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
@@ -673,20 +705,65 @@ export function AssistantPanel({
             <span>{pageContext.label}</span>
           </div>
         )}
-        <textarea
-          className="textarea"
-          rows={2}
-          value={input}
-          placeholder={tr('问点什么…（Enter 发送）', 'Ask something… (Enter to send)')}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              send();
-            }
+        {/* 输入区：随内容长高（7 行封顶），发送/停止就在右下角——正在流的时候
+            「停」应该在离手最近的位置，而不是让人回面板顶上去找。 */}
+        <div
+          style={{
+            border: '0.5px solid var(--border-2)',
+            borderRadius: 10,
+            background: 'var(--surface)',
+            padding: '8px 10px 6px',
           }}
-          style={{ width: '100%', fontSize: 13 }}
-        />
+        >
+          <textarea
+            className="textarea"
+            rows={1}
+            value={input}
+            placeholder={tr('问点什么…', 'Ask something…')}
+            onChange={(e) => {
+              setInput(e.target.value);
+              const el = e.target;
+              el.style.height = 'auto';
+              el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                send();
+              }
+            }}
+            style={{
+              width: '100%',
+              fontSize: 13,
+              border: 'none',
+              outline: 'none',
+              resize: 'none',
+              background: 'transparent',
+              padding: 0,
+              maxHeight: 140,
+              lineHeight: '20px',
+            }}
+          />
+          <div className="row gap8" style={{ alignItems: 'center', marginTop: 4 }}>
+            <span style={{ flex: 1, fontSize: 10.5, color: 'var(--text-4)' }}>
+              {tr('Enter 发送 · Shift+Enter 换行', 'Enter to send · Shift+Enter for a new line')}
+            </span>
+            {busy ? (
+              <button className="btn btn-ghost sm" onClick={stop} style={{ height: 26, fontSize: 11.5 }}>
+                <Icon name="pause" size={11} /> {tr('停止', 'Stop')}
+              </button>
+            ) : (
+              <button
+                className="btn btn-primary sm"
+                onClick={send}
+                disabled={!input.trim()}
+                style={{ height: 26, fontSize: 11.5 }}
+              >
+                {tr('发送', 'Send')}
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/src/features/assistant/ConversationRail.tsx
+++ b/src/frontend/src/features/assistant/ConversationRail.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   会话列表：停靠栏里的常驻一栏。
+
+   原来历史藏在头部一个时钟按钮后面，点开是个浮层——找上次那场对话得先想起来"它在
+   时钟里"。列表常驻之后，切换会话和新开一场都只要一次点击。
+
+   按最近活跃分组（今天 / 昨天 / 7 天内 / 更早）：几十场对话平铺成一列时，"上周那次"
+   根本找不到，而时间恰好是人回忆对话时用的线索。
+   ============================================================ */
+
+export interface ConversationRow {
+  id: string;
+  title: string;
+  last_message_at?: string | null;
+}
+
+/** 分组：只按天算，不显示具体时刻——对话列表要的是"哪一段时间"，不是精确到分。 */
+export function groupByRecency(
+  rows: ConversationRow[],
+  now: Date,
+): { label: string; rows: ConversationRow[] }[] {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const day = 86_400_000;
+  const today: ConversationRow[] = [];
+  const yesterday: ConversationRow[] = [];
+  const week: ConversationRow[] = [];
+  const older: ConversationRow[] = [];
+  for (const row of rows) {
+    const at = row.last_message_at ? new Date(row.last_message_at).getTime() : 0;
+    // 没有时间戳的（刚建、还没说过话）归到今天：它就在眼前，扔进「更早」很怪
+    if (!at || at >= startOfToday) today.push(row);
+    else if (at >= startOfToday - day) yesterday.push(row);
+    else if (at >= startOfToday - 7 * day) week.push(row);
+    else older.push(row);
+  }
+  return [
+    { label: tr('今天', 'Today'), rows: today },
+    { label: tr('昨天', 'Yesterday'), rows: yesterday },
+    { label: tr('7 天内', 'Previous 7 days'), rows: week },
+    { label: tr('更早', 'Older'), rows: older },
+  ].filter((b) => b.rows.length > 0);
+}
+
+export function ConversationRail({
+  activeId,
+  onPick,
+  onNew,
+  refreshKey,
+}: {
+  activeId: string | null;
+  onPick: (id: string) => void;
+  onNew: () => void;
+  /** 变一次就重拉一次列表（发完一轮之后标题才有） */
+  refreshKey: number;
+}) {
+  const [rows, setRows] = useState<ConversationRow[]>([]);
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+
+  const reload = useCallback(async () => {
+    try {
+      setRows((await api.listAssistantConversations()) as ConversationRow[]);
+    } catch {
+      setRows([]); // 拉不到就空着，不摆一个假列表
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload, refreshKey]);
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        await api.deleteAssistantConversation(id);
+      } catch {
+        return; // 删不掉就别把它从界面上抹掉，那是在骗人
+      }
+      await reload();
+      if (id === activeId) onNew();
+    },
+    [activeId, onNew, reload],
+  );
+
+  const commitRename = useCallback(
+    async (id: string) => {
+      const title = draft.trim();
+      setRenaming(null);
+      if (!title) return;
+      try {
+        await api.renameAssistantConversation(id, title);
+      } catch {
+        return;
+      }
+      await reload();
+    },
+    [draft, reload],
+  );
+
+  return (
+    <div
+      style={{
+        width: 176,
+        flexShrink: 0,
+        borderRight: '0.5px solid var(--border-2)',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--surface-2)',
+      }}
+    >
+      <button
+        className="btn btn-soft sm"
+        onClick={onNew}
+        style={{ margin: 8, height: 28, fontSize: 12, justifyContent: 'center' }}
+      >
+        <Icon name="plus" size={12} /> {tr('新对话', 'New chat')}
+      </button>
+      <div className="scroll" style={{ flex: 1, overflowY: 'auto', padding: '0 6px 8px' }}>
+        {rows.length === 0 && (
+          <div style={{ fontSize: 11, color: 'var(--text-4)', padding: '6px 6px' }}>
+            {tr('还没有对话', 'No conversations yet')}
+          </div>
+        )}
+        {groupByRecency(rows, new Date()).map((group) => (
+          <div key={group.label} style={{ marginBottom: 6 }}>
+            <div
+              style={{
+                fontSize: 10,
+                color: 'var(--text-4)',
+                padding: '6px 6px 3px',
+                letterSpacing: '0.04em',
+              }}
+            >
+              {group.label}
+            </div>
+            {group.rows.map((row) => (
+              <div
+                key={row.id}
+                className="row gap4 hoverable"
+                onClick={() => renaming !== row.id && onPick(row.id)}
+                style={{
+                  alignItems: 'center',
+                  padding: '5px 6px',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                  background: row.id === activeId ? 'var(--accent-soft)' : undefined,
+                }}
+              >
+                {renaming === row.id ? (
+                  <input
+                    className="input"
+                    autoFocus
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onBlur={() => void commitRename(row.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') void commitRename(row.id);
+                      if (e.key === 'Escape') setRenaming(null);
+                    }}
+                    style={{ height: 22, fontSize: 11.5, flex: 1, minWidth: 0 }}
+                  />
+                ) : (
+                  <>
+                    <span
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontSize: 11.5,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        color: row.id === activeId ? 'var(--accent-text)' : 'var(--text-2)',
+                      }}
+                      title={row.title || tr('（未命名）', '(untitled)')}
+                    >
+                      {row.title || tr('（未命名）', '(untitled)')}
+                    </span>
+                    <span
+                      className="icon-btn"
+                      title={tr('重命名', 'Rename')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDraft(row.title);
+                        setRenaming(row.id);
+                      }}
+                      style={{ width: 18, height: 18, flexShrink: 0 }}
+                    >
+                      <Icon name="pen" size={10} />
+                    </span>
+                    <span
+                      className="icon-btn"
+                      title={tr('删除', 'Delete')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void remove(row.id);
+                      }}
+                      style={{ width: 18, height: 18, flexShrink: 0 }}
+                    >
+                      <Icon name="trash" size={10} />
+                    </span>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/assistant/__tests__/rail.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/rail.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { groupByRecency, type ConversationRow } from '../ConversationRail';
+
+/* 会话分组：几十场对话平铺成一列时「上周那次」根本找不到，而时间正是人回忆对话
+   时用的线索。这里钉住边界——分组算错会让对话看起来「不见了」。 */
+
+const now = new Date(2026, 7, 5, 14, 30); // 本地 2026-08-05 14:30
+const row = (id: string, when: Date | null): ConversationRow => ({
+  id,
+  title: id,
+  last_message_at: when ? when.toISOString() : null,
+});
+
+describe('按最近活跃分组', () => {
+  it('今天/昨天/7 天内/更早各就各位', () => {
+    const groups = groupByRecency(
+      [
+        row('今天早些', new Date(2026, 7, 5, 1, 0)),
+        row('昨天', new Date(2026, 7, 4, 23, 59)),
+        row('三天前', new Date(2026, 7, 2, 12, 0)),
+        row('上个月', new Date(2026, 6, 1, 12, 0)),
+      ],
+      now,
+    );
+    expect(groups.map((g) => g.rows.map((r) => r.id))).toEqual([
+      ['今天早些'],
+      ['昨天'],
+      ['三天前'],
+      ['上个月'],
+    ]);
+  });
+
+  it('空分组不出现——不摆一个空标题占地方', () => {
+    const groups = groupByRecency([row('只有今天', new Date(2026, 7, 5, 9, 0))], now);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('刚建、还没说过话的归到今天：它就在眼前，扔进「更早」很怪', () => {
+    const groups = groupByRecency([row('新建的', null)], now);
+    expect(groups[0]?.rows.map((r) => r.id)).toEqual(['新建的']);
+  });
+
+  it('今天零点整算今天，差一毫秒算昨天', () => {
+    const midnight = new Date(2026, 7, 5, 0, 0, 0, 0);
+    const justBefore = new Date(midnight.getTime() - 1);
+    const groups = groupByRecency([row('零点', midnight), row('零点前', justBefore)], now);
+    expect(groups[0]?.rows.map((r) => r.id)).toEqual(['零点']);
+    expect(groups[1]?.rows.map((r) => r.id)).toEqual(['零点前']);
+  });
+});

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4749,6 +4749,15 @@ export const api = {
   deleteBuddyMemory(id: string): Promise<void> {
     return request(`/chat/memories/${id}`, { method: 'DELETE' });
   },
+  renameAssistantConversation(id: string, title: string): Promise<void> {
+    return request(`/chat/conversations/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ title }),
+    });
+  },
+  deleteAssistantConversation(id: string): Promise<void> {
+    return request(`/chat/conversations/${id}`, { method: 'DELETE' });
+  },
   /** Buddy 这一轮手里有什么：工具面、技能、MCP 暴露状况。 */
   getBuddyCapabilities(): Promise<{
     tools: { name: string; description: string; read_only: boolean }[];


### PR DESCRIPTION
Finishing the chat surface after the dock landed in #275.

## The conversation list is a rail, not a popover

Finding an earlier conversation used to mean remembering it lived behind a clock icon. Now switching conversations and starting a new one are each one click, and the list is always in view.

It groups by recency (Today / Yesterday / Previous 7 days / Older). A flat list of a few dozen conversations makes "the one from last week" unfindable, and time is exactly the cue people use when recalling a conversation. Narrow screens keep the popover — there is no room for two columns.

## Rename and delete

Titles are auto-derived from the first 60 characters of the opening question, which frequently doesn't describe what the conversation became. So they're editable now, and conversations can be deleted; messages go with them via the FK cascade, leaving no orphan rows.

Someone else's conversation returns **404, not 403**. A 403 confirms the id exists, and these titles routinely contain research directions.

## Composer

Grows with its content (capped at seven lines), with send/stop in the bottom-right corner. While a turn is streaming, "stop" belongs where the hand already is, not back up at the panel header. The Enter / Shift+Enter rule is now written under the box instead of living in the placeholder, where it disappears the moment you start typing.

## Tests

Backend, 3 new: rename trims surrounding whitespace; another user's conversation 404s on both PATCH and DELETE *and* is verified still present afterwards; deleting takes the messages with it (counted before and after).

Frontend, 4 new on the grouping boundaries: midnight exactly counts as today, one millisecond earlier is yesterday, empty groups don't render a stray heading, and a brand-new conversation with no timestamp lands in Today rather than Older.

Full suite **1089 passed**, vitest **23 passed**, `tsc --noEmit` and `vite build` clean.
