### PR TITLE
feat(assistant): list the papers a turn actually looked at, and make them clickable

### DIFF
--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -26,6 +26,7 @@ from app.agents.chat.events import (
     ErrorEvent,
     MetaEvent,
     PlanEvent,
+    SourcesEvent,
     ThinkingEvent,
     ToolCallEvent,
     ToolResultEvent,
@@ -68,6 +69,10 @@ PREVIEW_CHARS = 800
 #: 最近几轮的工具结果保持原样，更早的压成一行摘要。
 _KEEP_FULL_RESULT_ROUNDS = 2
 
+#: 一轮最多报多少篇论文。工具结果里可能有上百篇（scan_papers 一次 50 篇），
+#: 全铺到界面上就成了第二个搜索结果页，而这一栏的用处是「刚才它看了哪几篇」。
+_MAX_SOURCES = 20
+
 #: 计划工具的名字。循环认识这一个名字，是为了在它调成功后补一帧 PlanEvent——
 #: 前端不必去解析工具结果的 JSON 就能画出进度条。耦合是显式的，写在这儿。
 _PLAN_TOOL = "update_plan"
@@ -95,6 +100,8 @@ class _RoundState:
         default_factory=lambda: {"prompt_tokens": 0, "completion_tokens": 0}
     )
     blocks_by_round: list[tuple[ContentBlock, ...]] = field(default_factory=list)
+    #: 这一轮已经报给前端的论文 id，避免同一篇在多次检索里重复出现
+    sources_seen: set[str] = field(default_factory=set)
 
 
 class ChatAgentLoop:
@@ -201,6 +208,7 @@ class ChatAgentLoop:
                 return
 
             messages.append(Message(role="assistant", content=list(blocks)))
+            fresh_sources: list[dict[str, str]] = []
             # 先把「要调什么」全部播出去，再开始执行：前端据此立刻画出 running 的卡片。
             # 不这么做的话，卡片会在工具跑完的那一刻凭空出现在完成态，几秒的等待期里
             # 界面上什么都没有。
@@ -219,6 +227,18 @@ class ChatAgentLoop:
                 yield ev
                 if plan := _plan_from(ev, result):
                     yield PlanEvent(steps=plan)
+                # 「刚才它看了哪几篇」——只播**新**出现的，前端追加即可。
+                # 这一栏不声称是「回答引用了这些」：我们无从核对模型的 [n] 指的是谁，
+                # 说成引用就是在替它担保。
+                if result is not None and ev.name != _PLAN_TOOL:
+                    for ref in _paper_refs(_safe_json(result.content)):
+                        if ref["paper_id"] in state.sources_seen:
+                            continue
+                        state.sources_seen.add(ref["paper_id"])
+                        fresh_sources.append(ref)
+            if fresh_sources:
+                yield SourcesEvent(items=list(fresh_sources))
+                fresh_sources.clear()
             messages.append(Message(role="user", content=list(results)))
 
             # 技能声明了 allowed-tools 就收窄后续可用的工具面。**只能收窄，永不扩权**：
@@ -315,6 +335,50 @@ class ChatAgentLoop:
             ),
             ToolResultBlock(call.id, text, is_error=True),
         )
+
+
+def _safe_json(text: str) -> Any:
+    """工具结果文本 → 对象；解析不了返回 None（结果被截断过，未必是完整 JSON）。"""
+    try:
+        return json.loads(text)
+    except ValueError:
+        return None
+
+
+def _paper_refs(payload: Any) -> list[dict[str, str]]:
+    """从工具结果里认出论文（paper_id + title）。
+
+    通用遍历而不是按工具写死：search_papers 给 results、scan_papers 给 papers、
+    get_paper 直接就是一篇……逐个工具适配的话，每加一个工具就得记得回来改这里，
+    而漏改的表现是「引用列表少了几篇」——没人会注意到。
+
+    只收**同时有 id 和标题**的：光有 uuid 的条目在界面上没法看，与其显示一串 uuid，
+    不如不显示。
+    """
+    found: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    def walk(node: Any, depth: int = 0) -> None:
+        if depth > 6 or len(found) >= _MAX_SOURCES:
+            return
+        if isinstance(node, dict):
+            pid, title = node.get("paper_id"), node.get("title")
+            if (
+                isinstance(pid, str)
+                and isinstance(title, str)
+                and title.strip()
+                and pid not in seen
+            ):
+                seen.add(pid)
+                found.append({"paper_id": pid, "title": title.strip()[:200]})
+            for value in node.values():
+                walk(value, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(payload)
+    return found
 
 
 def _plan_from(

--- a/src/backend/tests/test_chat_agent_loop.py
+++ b/src/backend/tests/test_chat_agent_loop.py
@@ -321,3 +321,79 @@ async def test_meta_is_the_first_event(monkeypatch):
     events = await _drive(_loop(provider))
     assert isinstance(events[0], MetaEvent)
     assert events[0].conversation_id
+
+
+def test_paper_refs_are_found_wherever_they_sit_in_the_payload():
+    """论文引用走通用遍历，不跟每个工具的形状耦合。
+
+    逐个工具适配的话，每加一个工具就得记得回来改；漏改的表现是「列表少了几篇」，
+    没人会注意到。
+    """
+    from app.agents.chat.loop import _paper_refs
+
+    refs = _paper_refs(
+        {
+            "results": [{"paper_id": "a", "title": "甲", "score": 1}],
+            "nested": {"deep": [{"papers": [{"paper_id": "b", "title": "乙"}]}]},
+            "single": {"paper_id": "c", "title": "丙"},
+        }
+    )
+    assert [r["paper_id"] for r in refs] == ["a", "b", "c"]
+
+
+def test_paper_refs_skip_entries_without_a_title_and_dedupe():
+    """只收同时有 id 和标题的：光有 uuid 的条目在界面上没法看。"""
+    from app.agents.chat.loop import _paper_refs
+
+    refs = _paper_refs(
+        {
+            "a": {"paper_id": "x", "title": "标题"},
+            "b": {"paper_id": "x", "title": "同一篇又出现一次"},
+            "c": {"paper_id": "y"},  # 没标题
+            "d": {"title": "没 id"},
+            "e": {"paper_id": "z", "title": "   "},  # 空白标题不算
+        }
+    )
+    assert [r["paper_id"] for r in refs] == ["x"]
+
+
+def test_paper_refs_are_capped():
+    """scan_papers 一次能回 50 篇，全铺上去这一栏就成了第二个搜索结果页。"""
+    from app.agents.chat.loop import _MAX_SOURCES, _paper_refs
+
+    payload = {"results": [{"paper_id": str(i), "title": f"第 {i} 篇"} for i in range(80)]}
+    assert len(_paper_refs(payload)) == _MAX_SOURCES
+
+
+@pytest.mark.asyncio
+async def test_the_loop_reports_papers_it_looked_at(monkeypatch):
+    """整条链路：工具查到论文 → 循环播一帧 sources，同一篇不重复播。"""
+
+    @tool(
+        name="_probe_papers",
+        description="测试用检索",
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+    )
+    async def _probe(ctx, args):  # noqa: ANN001
+        return {
+            "results": [
+                {"paper_id": "p-1", "title": "第一篇"},
+                {"paper_id": "p-2", "title": "第二篇"},
+            ]
+        }
+
+    provider = FakeProvider()
+    provider.script(
+        [
+            [("_probe_papers", {"q": "planning"})],
+            # 第二轮又查了一次，返回同样的两篇：不该再播一遍
+            [("_probe_papers", {"q": "planning 换个说法"})],
+            "查到两篇。",
+        ]
+    )
+    events = await _drive(_loop(provider), tool_names=("_probe_papers",))
+    sources = [e for e in events if type(e).__name__ == "SourcesEvent"]
+
+    assert len(sources) == 1, f"同一批论文被播了 {len(sources)} 次"
+    assert [i["paper_id"] for i in sources[0].items] == ["p-1", "p-2"]
+    assert [i["title"] for i in sources[0].items] == ["第一篇", "第二篇"]

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -3,7 +3,12 @@ import { useLocation } from 'react-router-dom';
 import { Icon } from '../../components/ui/Icon';
 import { Markdown } from '../../lib/markdown';
 import { api } from '../../lib/api';
-import { assistantTurnSse, type AssistantBlock, type PlanStep } from '../../lib/assistantStream';
+import {
+  assistantTurnSse,
+  type AssistantBlock,
+  type PaperSource,
+  type PlanStep,
+} from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
 import { CapabilitiesBar } from './CapabilitiesBar';
 import { ToolImages } from './ToolImages';
@@ -237,9 +242,46 @@ function ThinkingView({ text, live }: { text: string; live: boolean }) {
   );
 }
 
+/** 这一轮它看过的论文。**不叫「引用」**：模型写的 [n] 指的是谁，我们无从核对，
+    叫引用就是在替它担保。点进去是论文本身——回答里提到某篇却点不进去，是这套界面
+    最容易让人卡住的地方。 */
+function SourcesCard({ papers }: { papers: PaperSource[] }) {
+  return (
+    <div style={{ margin: '10px 0 2px' }}>
+      <div style={{ fontSize: 11, color: 'var(--text-4)', marginBottom: 4 }}>
+        {tr(`本轮查看的论文 · ${papers.length}`, `Papers looked at · ${papers.length}`)}
+      </div>
+      <div className="col gap4">
+        {papers.map((paper, i) => (
+          <a
+            key={paper.paperId}
+            href={`/papers/${paper.paperId}/read`}
+            className="row gap6 hoverable"
+            style={{
+              alignItems: 'flex-start',
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: 'var(--text-2)',
+              textDecoration: 'none',
+              padding: '3px 5px',
+              borderRadius: 6,
+            }}
+          >
+            <span className="mono" style={{ color: 'var(--text-4)', flexShrink: 0 }}>
+              {i + 1}.
+            </span>
+            <span style={{ minWidth: 0 }}>{paper.title}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function BlockView({ block, live }: { block: AssistantBlock; live: boolean }) {
   if (block.kind === 'text') return <Markdown source={block.text} />;
   if (block.kind === 'plan') return <PlanCard steps={block.steps} />;
+  if (block.kind === 'sources') return <SourcesCard papers={block.papers} />;
   if (block.kind === 'thinking') return <ThinkingView text={block.text} live={live} />;
   if (block.kind === 'tool') return <ToolCard block={block} />;
   return null; // 未知块：画不出来就不画，绝不抛

--- a/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
@@ -118,3 +118,33 @@ describe('畸形输入', () => {
     }
   });
 });
+
+describe('本轮查看的论文', () => {
+  it('后端只发新出现的，这里追加并去重', () => {
+    const blocks = reduce([
+      ['sources', { items: [{ paper_id: 'a', title: '甲' }] }],
+      ['sources', { items: [{ paper_id: 'a', title: '甲' }, { paper_id: 'b', title: '乙' }] }],
+    ]);
+    const sources = blocks.filter((b) => b.kind === 'sources');
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toEqual({
+      kind: 'sources',
+      papers: [
+        { paperId: 'a', title: '甲' },
+        { paperId: 'b', title: '乙' },
+      ],
+    });
+  });
+
+  it('缺 id 或缺标题的条目丢掉——一串 uuid 在界面上没法看', () => {
+    const blocks = reduce([
+      ['sources', { items: [{ paper_id: 'a' }, { title: '没有 id' }, { paper_id: 'b', title: '乙' }] }],
+    ]);
+    expect(blocks[0]).toEqual({ kind: 'sources', papers: [{ paperId: 'b', title: '乙' }] });
+  });
+
+  it('一条都认不出时不留空块', () => {
+    expect(reduce([['sources', { items: [] }]])).toEqual([]);
+    expect(reduce([['sources', { items: '不是数组' }]])).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -16,6 +16,11 @@ export interface ImageRef {
   label?: string;
 }
 
+export interface PaperSource {
+  paperId: string;
+  title: string;
+}
+
 export interface PlanStep {
   title: string;
   status: 'pending' | 'running' | 'done';
@@ -24,6 +29,7 @@ export interface PlanStep {
 export type AssistantBlock =
   | { kind: 'text'; text: string }
   | { kind: 'plan'; steps: PlanStep[] }
+  | { kind: 'sources'; papers: PaperSource[] }
   | { kind: 'thinking'; text: string }
   | {
       kind: 'tool';
@@ -112,6 +118,27 @@ export function applyAssistantEvent(
     const block: AssistantBlock = { kind: 'plan', steps };
     if (at < 0) return [...blocks, block];
     return blocks.map((b, i) => (i === at ? block : b));
+  }
+
+  if (event === 'sources') {
+    // 「刚才它看了哪几篇」。后端只发新出现的，这里追加去重，块本身固定在末尾一处。
+    const incoming: PaperSource[] = Array.isArray(data.items)
+      ? (data.items as unknown[]).flatMap((item) => {
+          if (!item || typeof item !== 'object') return [];
+          const row = item as Record<string, unknown>;
+          const paperId = str(row.paper_id);
+          const title = str(row.title);
+          return paperId && title ? [{ paperId, title }] : [];
+        })
+      : [];
+    if (!incoming.length) return blocks;
+    const at = blocks.findIndex((b) => b.kind === 'sources');
+    if (at < 0) return [...blocks, { kind: 'sources', papers: incoming }];
+    return blocks.map((b, i) => {
+      if (i !== at || b.kind !== 'sources') return b;
+      const seen = new Set(b.papers.map((p) => p.paperId));
+      return { kind: 'sources', papers: [...b.papers, ...incoming.filter((p) => !seen.has(p.paperId))] };
+    });
   }
 
   if (event === 'tool_call') {


### PR DESCRIPTION
Buddy would mention a paper and you couldn't click it — even though it had the `paper_id` in hand from the tool result and simply never passed it to the UI. The `sources` frame has been in the event table since the beginning and nothing ever emitted it.

## How papers are found

By **walking the payload generically**, not per-tool: `search_papers` returns `results`, `scan_papers` returns `papers`, `get_paper` *is* a paper. Adapting tool by tool means remembering to come back here every time a tool is added, and the symptom of forgetting is "the list is missing a few" — which nobody notices.

Only entries with **both** an id and a title are collected; a bare uuid is useless on screen. Capped at 20 per turn: `scan_papers` alone can return 50, and dumping all of them turns this strip into a second search-results page when its job is "which ones did it just look at".

Each paper is announced once. Re-querying with different phrasings across rounds is the normal pattern, and re-announcing would grow the list without adding anything.

## What it's called matters

The UI says **"papers looked at this turn"**, not "citations". Which paper the model's `[n]` markers refer to is not something we can verify, and calling them citations would be vouching for it.

## Tests

Backend, 4: refs found at any nesting depth, entries without titles (and duplicates, and whitespace-only titles) dropped, the cap enforced, and end-to-end through the loop — two rounds returning the same papers emit exactly one `sources` frame.

Frontend, 3: incoming batches append and dedupe into one block, malformed entries are dropped, and an empty list leaves no empty block behind.

Full suite **1090 passed**, vitest **22 passed**.
