### PR TITLE
refactor(assistant): split the chat loop into Navigator / Helm / Sextant, with real verification

### DIFF
--- a/src/backend/app/agents/chat/core/__init__.py
+++ b/src/backend/app/agents/chat/core/__init__.py
@@ -1,0 +1,22 @@
+"""对话智能体的循环内核：Navigator（定计划）· Helm（执行）· Sextant（验收）。
+
+与 Voyage 那套同名同分工，但**不是同一套代码**：Voyage 的三件套跑在 worker 里、
+遍历预先规划好的步骤行、失败语义是暂停重规划；对话没有预先计划（下一步由模型逐
+token 决定）、必须在 HTTP 连接上流式输出、失败语义是「告诉用户，会话继续活着」。
+硬套过来只会得到一个到处是 if 的四不像。
+
+共享的是**纪律**，不是实现：
+
+- Navigator 决定「下一步怎么走」——还剩几轮、这轮能用哪些工具、什么时候该收尾。
+  它不碰模型也不碰工具，因此可以脱离一切 IO 单测。
+- Helm 只管执行，**异常绝不外抛**：工具炸了、超时了、参数不是 JSON，全部转成结果
+  回喂给模型，让它自己纠正。一次工具失败不该让整轮对话死掉。
+- Sextant 做验收，**确定性检查优先**：能靠数数和对照得出的结论不花模型的钱。
+  与 Voyage 的 Sextant 同一条原则。
+"""
+
+from app.agents.chat.core.helm import Helm
+from app.agents.chat.core.navigator import Navigator, RoundPlan
+from app.agents.chat.core.sextant import Sextant, Verdict
+
+__all__ = ["Helm", "Navigator", "RoundPlan", "Sextant", "Verdict"]

--- a/src/backend/app/agents/chat/core/helm.py
+++ b/src/backend/app/agents/chat/core/helm.py
@@ -1,0 +1,121 @@
+"""Helm（掌舵 · execute）：把模型要求的工具调用真的跑起来。
+
+一条纪律压倒一切：**异常绝不外抛**。工具炸了、超时了、参数不是合法 JSON、工具名根本
+不存在——全部转成结果回喂给模型，让它自己纠正。一次工具失败不该让整轮对话死掉；
+用户等了十几秒，最差也该收到一句「这个没查着，我换个说法再试」。
+
+只读工具并行跑（信号量封顶）。写工具本期没有，将来也必须串行：没有事务包裹，并行改
+同一行就是竞态，而且审批 UI 一次弹两个框是灾难。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.agents.chat.events import ToolResultEvent
+from app.core.llm.base import ToolResultBlock, ToolUseBlock
+from app.tools.context import ToolContext
+from app.tools.registry import get_tool, result_images, result_payload, run_tool
+
+logger = logging.getLogger(__name__)
+
+#: 同时最多跑几个工具。只读工具之间没有依赖，但并发太高会把数据库连接池吃光。
+TOOL_CONCURRENCY = 4
+
+#: 单个工具的墙钟上限。卡住的工具会让整轮对话跟着卡住，用户只看到一直转圈。
+TOOL_TIMEOUT_SECONDS = 60.0
+
+#: 回喂给模型的单个工具结果上限。超过就截断，完整内容留在库里按需取。
+RESULT_CHARS = 4000
+
+#: 推给前端的预览上限。比回喂的更短——它只是让人看一眼「查到了什么」。
+PREVIEW_CHARS = 800
+
+
+class Helm:
+    def __init__(self, ctx: ToolContext) -> None:
+        self._ctx = ctx
+
+    async def run(
+        self, calls: list[ToolUseBlock]
+    ) -> AsyncIterator[tuple[ToolResultEvent, ToolResultBlock]]:
+        """并行执行一轮里的工具调用，按**发起顺序**把结果吐出去。
+
+        顺序按发起而不是按完成：界面上卡片的次序应该与模型的意图一致，谁先跑完是
+        实现细节，不该影响读者理解它在做什么。
+        """
+        semaphore = asyncio.Semaphore(TOOL_CONCURRENCY)
+
+        async def one(call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
+            async with semaphore:
+                return await self.execute(call)
+
+        for coro in [asyncio.create_task(one(c)) for c in calls]:
+            event, block = await coro
+            yield event, block
+
+    async def execute(self, call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
+        started = time.monotonic()
+        spec = get_tool(call.name)
+        if spec is None:
+            # 未知工具不打断循环：把情况告诉模型，它下一轮自己纠正
+            return self._failure(call, {"error": f"未知工具 {call.name!r}"}, started)
+        if "__parse_error__" in call.input:
+            # 弱模型上高频：参数流到一半坏掉。单独成一类，因为提示不同——它该重发这次
+            # 调用，而不是换个工具。
+            return self._failure(
+                call, {"error": "参数不是合法 JSON，请重新发起这次调用"}, started
+            )
+        try:
+            result = await asyncio.wait_for(
+                run_tool(self._ctx, call.name, call.input), timeout=TOOL_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            return self._failure(
+                call, {"error": f"工具执行超过 {TOOL_TIMEOUT_SECONDS:.0f} 秒"}, started
+            )
+        except asyncio.CancelledError:
+            raise  # 取消要往上传，否则断连时这里会把它吞掉
+        except Exception as e:  # noqa: BLE001 — 工具异常转成结果回喂，不打断循环
+            logger.warning("chat agent: tool %s failed", call.name, exc_info=True)
+            return self._failure(call, {"error": f"{type(e).__name__}: {e}"}, started)
+
+        payload = result_payload(result)
+        images = result_images(result)
+        text = json.dumps(payload, ensure_ascii=False)[:RESULT_CHARS]
+        return (
+            ToolResultEvent(
+                id=call.id,
+                name=call.name,
+                ok=True,
+                summary=spec.summary(call.input, payload),
+                preview=text[:PREVIEW_CHARS],
+                duration_ms=int((time.monotonic() - started) * 1000),
+                images=len(images),
+                image_refs=tuple(
+                    {**img.ref, "label": img.label} for img in images if img.ref is not None
+                ),
+            ),
+            ToolResultBlock(call.id, text),
+        )
+
+    def _failure(
+        self, call: ToolUseBlock, payload: dict[str, Any], started: float
+    ) -> tuple[ToolResultEvent, ToolResultBlock]:
+        text = json.dumps(payload, ensure_ascii=False)
+        return (
+            ToolResultEvent(
+                id=call.id,
+                name=call.name,
+                ok=False,
+                summary=str(payload.get("error", "失败")),
+                preview=text[:PREVIEW_CHARS],
+                duration_ms=int((time.monotonic() - started) * 1000),
+            ),
+            ToolResultBlock(call.id, text, is_error=True),
+        )

--- a/src/backend/app/agents/chat/core/navigator.py
+++ b/src/backend/app/agents/chat/core/navigator.py
@@ -1,0 +1,77 @@
+"""Navigator（领航 · plan）：决定下一步怎么走。
+
+它不调模型、不调工具、不碰数据库——因此整个类可以脱离 IO 单测。这条边界是刻意的：
+「还能调几次工具」「这轮该不该硬关工具」「技能能不能收窄工具面」这些判断，出错的
+后果（多烧一轮钱、或者提前收尾）都很贵，而它们本来就是纯逻辑。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from app.core.llm.base import ToolResultBlock
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class RoundPlan:
+    """这一轮怎么跑。"""
+
+    #: 这是最后一轮吗（到达 max_rounds）
+    last_round: bool
+    #: 本轮 token 预算已经用超了吗
+    over_budget: bool
+
+    @property
+    def tool_choice(self) -> str | None:
+        """到顶就硬关工具：让模型用已经拿到的东西收尾，而不是继续查。
+
+        不学老 tool_loop 那样追加一条 user 消息哄模型收手——那是在请求它配合，
+        而 tool_choice="none" 是让它没得选。
+        """
+        return "none" if (self.last_round or self.over_budget) else None
+
+
+class Navigator:
+    def __init__(self, *, max_rounds: int, max_turn_tokens: int | None = None) -> None:
+        self._max_rounds = max_rounds
+        self._max_turn_tokens = max_turn_tokens
+
+    def plan_round(self, *, rounds_done: int, tokens_used: int) -> RoundPlan:
+        return RoundPlan(
+            last_round=rounds_done >= self._max_rounds,
+            over_budget=(
+                self._max_turn_tokens is not None and tokens_used >= self._max_turn_tokens
+            ),
+        )
+
+    def stop_reason(self, plan: RoundPlan) -> str:
+        if plan.over_budget:
+            return "turn_budget"
+        if plan.last_round:
+            return "max_rounds"
+        return "stop"
+
+    def narrow_tools(
+        self, results: list[ToolResultBlock], active: tuple[str, ...]
+    ) -> tuple[str, ...] | None:
+        """技能声明了 allowed-tools 就收窄后续工具面；没有可收窄的返回 None。
+
+        **只能收窄，永不扩权**：技能里写一个本轮没给的工具名，结果是那个工具不可用，
+        而不是把它加进来。空交集一律忽略——技能写错名字不该让 Buddy 变成哑巴。
+        """
+        for block in results:
+            try:
+                payload = json.loads(block.content)
+            except ValueError:
+                continue
+            allowed = payload.get("allowed_tools") if isinstance(payload, dict) else None
+            if not isinstance(allowed, list) or not allowed:
+                continue
+            narrowed = tuple(name for name in active if name in {str(a) for a in allowed})
+            if narrowed:
+                return narrowed
+        return None

--- a/src/backend/app/agents/chat/core/sextant.py
+++ b/src/backend/app/agents/chat/core/sextant.py
@@ -1,0 +1,51 @@
+"""Sextant（六分仪 · verify）：这轮回答站得住吗。
+
+**确定性检查优先**，与 Voyage 的 Sextant 同一条原则：能靠数数和对照得出的结论，
+不花模型的钱、不等模型的延迟。所以这里一次 LLM 都不调。
+
+它检查的不是「答得好不好」——那不是机器该下的判断——而是三件能明确证伪的事：
+
+1. 回答用了编号引用，这轮却一篇论文都没查到；
+2. 编号超出了实际查到的篇数（[5] 但只查到 3 篇）——这是模型编号的经典跑偏；
+3. 回答声称「查到了/库里有」，而这轮没有任何一次成功的检索。
+
+命中任何一条只是**提请注意**，不改写回答、不拦截：判据是启发式的，误报要能被用户
+一眼看穿并忽略。装成权威结论反而更糟。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+#: 正文里的编号引用，如 [1]、[12]。中文方括号也认——模型经常混用。
+_CITATION_RE = re.compile(r"[\[［](\d{1,2})[\]］]")
+
+#: 「我查过了」这类断言。命中这些词却没有一次成功检索，就是在凭记忆答库内问题。
+_RETRIEVAL_CLAIMS = ("我查到", "检索到", "库里有", "库中有", "根据检索", "搜索结果显示")
+
+
+@dataclass(slots=True, frozen=True)
+class Verdict:
+    passed: bool
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+
+class Sextant:
+    def verify(
+        self, *, answer: str, sources: int, successful_tool_calls: int
+    ) -> Verdict:
+        """``sources`` = 这轮工具真的返回过的论文数；``successful_tool_calls`` = 成功的调用数。"""
+        notes: list[str] = []
+        cited = {int(m) for m in _CITATION_RE.findall(answer or "")}
+
+        if cited and sources == 0:
+            notes.append("回答里有编号引用，但这一轮没有查到任何论文")
+        elif cited and max(cited) > sources:
+            notes.append(f"引用编号最大到 [{max(cited)}]，但这一轮只查到 {sources} 篇论文")
+
+        claimed = any(claim in (answer or "") for claim in _RETRIEVAL_CLAIMS)
+        if successful_tool_calls == 0 and claimed:
+            notes.append("回答说「查到了」，但这一轮没有任何一次成功的检索")
+
+        return Verdict(passed=not notes, notes=tuple(notes))

--- a/src/backend/app/agents/chat/events.py
+++ b/src/backend/app/agents/chat/events.py
@@ -47,6 +47,18 @@ class PlanEvent:
 
 
 @dataclass(slots=True, frozen=True)
+class VerifyEvent:
+    """Sextant 的验收结论。
+
+    ``passed`` 为真时前端什么都不画——一条「一切正常」的绿条只会训练用户忽略这一栏。
+    只有站不住的地方才值得占用屏幕。
+    """
+
+    passed: bool
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
 class ToolCallEvent:
     id: str
     name: str
@@ -111,6 +123,7 @@ ChatEvent = (
     | DeltaEvent
     | ThinkingEvent
     | PlanEvent
+    | VerifyEvent
     | ToolCallEvent
     | ToolResultEvent
     | UsageEvent

--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -12,12 +12,12 @@
 import asyncio
 import json
 import logging
-import time
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.agents.chat.core import Helm, Navigator, Sextant
 from app.agents.chat.events import (
     ChatEvent,
     CompactionEvent,
@@ -31,6 +31,7 @@ from app.agents.chat.events import (
     ToolCallEvent,
     ToolResultEvent,
     UsageEvent,
+    VerifyEvent,
 )
 from app.agents.chat.prompt import build_system_prompt, tool_definitions
 from app.core.llm.base import (
@@ -46,7 +47,7 @@ from app.core.llm.base import (
 from app.core.llm.router import LLMRouter
 from app.core.llm.tool_stream import ToolCallAccumulator
 from app.tools.context import ToolContext
-from app.tools.registry import get_tool, result_images, result_payload, run_tool
+from app.tools.registry import get_tool
 
 logger = logging.getLogger(__name__)
 
@@ -152,15 +153,18 @@ class ChatAgentLoop:
             tools=tuple(req.tool_names),
         )
 
+        navigator = Navigator(max_rounds=req.max_rounds, max_turn_tokens=req.max_turn_tokens)
+        helm = Helm(self._tool_ctx)
+        sextant = Sextant()
+        answer_parts: list[str] = []
+        successful_calls = 0
+
         while True:
             state.rounds += 1
-            last_round = state.rounds >= req.max_rounds
-            over_budget = (
-                req.max_turn_tokens is not None
-                and sum(state.usage.values()) >= req.max_turn_tokens
+            round_plan = navigator.plan_round(
+                rounds_done=state.rounds, tokens_used=sum(state.usage.values())
             )
-            # 到顶就硬关工具：让模型用已经拿到的东西收尾，而不是继续查
-            tool_choice = "none" if (last_round or over_budget) else None
+            tool_choice = round_plan.tool_choice
 
             accumulator = ToolCallAccumulator()
             try:
@@ -174,6 +178,7 @@ class ChatAgentLoop:
                 ):
                     accumulator.feed(ev)
                     if isinstance(ev, TextDelta):
+                        answer_parts.append(ev.text)
                         yield DeltaEvent(ev.text)
                     elif isinstance(ev, ThinkingDelta) and ev.text:
                         yield ThinkingEvent(ev.text)
@@ -201,9 +206,17 @@ class ChatAgentLoop:
                     completion_tokens=state.usage.get("completion_tokens", 0),
                     total_tokens=sum(state.usage.values()),
                 )
+                # 验收在 done 之前：结论是这一轮的一部分，不该等下一轮才出现
+                verdict = sextant.verify(
+                    answer="".join(answer_parts),
+                    sources=len(state.sources_seen),
+                    successful_tool_calls=successful_calls,
+                )
+                if not verdict.passed:
+                    yield VerifyEvent(passed=False, notes=verdict.notes)
                 yield DoneEvent(
                     usage=dict(state.usage),
-                    stop_reason=self._stop_reason(last_round, over_budget),
+                    stop_reason=navigator.stop_reason(round_plan),
                 )
                 return
 
@@ -221,9 +234,11 @@ class ChatAgentLoop:
                     read_only=spec.read_only if spec else True,
                 )
             results: list[ToolResultBlock] = []
-            async for ev, result in self._run_calls(calls):
+            async for ev, result in helm.run(calls):
                 if result is not None:
                     results.append(result)
+                if isinstance(ev, ToolResultEvent) and ev.ok:
+                    successful_calls += 1
                 yield ev
                 if plan := _plan_from(ev, result):
                     yield PlanEvent(steps=plan)
@@ -243,99 +258,12 @@ class ChatAgentLoop:
 
             # 技能声明了 allowed-tools 就收窄后续可用的工具面。**只能收窄，永不扩权**：
             # 技能里写一个会话没给的工具名，结果是那个工具不可用，而不是把它加进来。
-            if narrowed := _skill_narrowing(results, active_tools):
+            if narrowed := navigator.narrow_tools(results, active_tools):
                 active_tools = narrowed
                 specs = tool_definitions(active_tools)
 
             if removed := _elide_old_results(messages):
                 yield CompactionEvent(removed=removed)
-
-    def _stop_reason(self, last_round: bool, over_budget: bool) -> str:
-        if over_budget:
-            return "turn_budget"
-        if last_round:
-            return "max_rounds"
-        return "stop"
-
-    async def _run_calls(
-        self, calls: list[ToolUseBlock]
-    ) -> AsyncIterator[tuple[ChatEvent, ToolResultBlock | None]]:
-        """并行执行一轮里的工具调用，按发起顺序把事件吐出去。
-
-        只读工具才并行。写工具（本期还没有）必须串行：没有事务包裹，并行改同一行就是
-        竞态，而且审批 UI 一次弹两个框是灾难。
-        """
-        semaphore = asyncio.Semaphore(_TOOL_CONCURRENCY)
-
-        async def one(call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
-            async with semaphore:
-                return await self._execute(call)
-
-        for coro in [asyncio.create_task(one(c)) for c in calls]:
-            event, block = await coro
-            yield event, block
-
-    async def _execute(self, call: ToolUseBlock) -> tuple[ToolResultEvent, ToolResultBlock]:
-        started = time.monotonic()
-        spec = get_tool(call.name)
-        if spec is None:
-            # 未知工具不打断循环：把可用清单告诉模型，它下一轮自己纠正
-            payload = {"error": f"未知工具 {call.name!r}"}
-            return self._failure(call, payload, started)
-        if "__parse_error__" in call.input:
-            payload = {"error": "参数不是合法 JSON，请重新发起这次调用"}
-            return self._failure(call, payload, started)
-        try:
-            result = await asyncio.wait_for(
-                run_tool(self._tool_ctx, call.name, call.input), timeout=TOOL_TIMEOUT_SECONDS
-            )
-        except TimeoutError:
-            note = {"error": f"工具执行超过 {TOOL_TIMEOUT_SECONDS:.0f} 秒"}
-            return self._failure(call, note, started)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:  # noqa: BLE001 — 工具异常转成结果回喂，不打断循环
-            logger.warning("chat agent: tool %s failed", call.name, exc_info=True)
-            return self._failure(call, {"error": f"{type(e).__name__}: {e}"}, started)
-
-        payload = result_payload(result)
-        images = result_images(result)
-        text = json.dumps(payload, ensure_ascii=False)[:RESULT_CHARS]
-        duration = int((time.monotonic() - started) * 1000)
-        summary = spec.summary(call.input, payload) if spec else call.name
-        return (
-            ToolResultEvent(
-                id=call.id,
-                name=call.name,
-                ok=True,
-                summary=summary,
-                preview=text[:PREVIEW_CHARS],
-                duration_ms=duration,
-                images=len(images),
-                image_refs=tuple(
-                    {**img.ref, "label": img.label} for img in images if img.ref is not None
-                ),
-            ),
-            ToolResultBlock(call.id, text),
-        )
-
-    def _failure(
-        self, call: ToolUseBlock, payload: dict[str, Any], started: float
-    ) -> tuple[ToolResultEvent, ToolResultBlock]:
-        text = json.dumps(payload, ensure_ascii=False)
-        duration = int((time.monotonic() - started) * 1000)
-        return (
-            ToolResultEvent(
-                id=call.id,
-                name=call.name,
-                ok=False,
-                summary=payload.get("error", "失败"),
-                preview=text[:PREVIEW_CHARS],
-                duration_ms=duration,
-            ),
-            ToolResultBlock(call.id, text, is_error=True),
-        )
-
 
 def _safe_json(text: str) -> Any:
     """工具结果文本 → 对象；解析不了返回 None（结果被截断过，未必是完整 JSON）。"""
@@ -401,32 +329,6 @@ def _plan_from(
     if not isinstance(steps, list):
         return None
     return tuple(s for s in steps if isinstance(s, dict))
-
-
-def _skill_narrowing(
-    results: list[ToolResultBlock], current: tuple[str, ...]
-) -> tuple[str, ...] | None:
-    """本轮加载的技能若声明了 allowed-tools，就据此收窄。
-
-    收窄发生在技能加载**之后**的那一轮起效——这一轮已经调过的工具不受影响，那是既成
-    事实。收窄结果为空时不生效（技能写错名字不该把助手变成哑巴）。
-    """
-    from app.services.agent_skills import narrow_tools
-
-    narrowed = current
-    for block in results:
-        if block.is_error:
-            continue
-        try:
-            payload = json.loads(block.content)
-        except (json.JSONDecodeError, ValueError):
-            continue
-        if not isinstance(payload, dict) or "allowed_tools" not in payload:
-            continue
-        narrowed = narrow_tools(narrowed, payload.get("allowed_tools"))
-    if narrowed == current or not narrowed:
-        return None
-    return narrowed
 
 
 def _elide_old_results(messages: list[Message]) -> int:

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -29,6 +29,7 @@ from app.agents.chat.events import (
     ToolCallEvent,
     ToolResultEvent,
     UsageEvent,
+    VerifyEvent,
 )
 from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
 from app.agents.chat.prompt import DEFAULT_TOOL_NAMES
@@ -60,6 +61,7 @@ _EVENT_NAMES: dict[type, str] = {
     DeltaEvent: "delta",
     ThinkingEvent: "thinking",
     PlanEvent: "plan",
+    VerifyEvent: "verify",
     ToolCallEvent: "tool_call",
     ToolResultEvent: "tool_result",
     UsageEvent: "usage",

--- a/src/backend/tests/test_chat_core.py
+++ b/src/backend/tests/test_chat_core.py
@@ -1,0 +1,173 @@
+"""对话循环内核：Navigator / Helm / Sextant。
+
+拆成三件套的价值就在这个文件里——Navigator 不碰 IO、Sextant 不调模型，于是
+「还剩几轮」「引用编号跑没跑偏」这类判断可以脱离一切外部依赖直接钉住。
+"""
+
+import asyncio
+import json
+import uuid
+
+import pytest
+
+from app.agents.chat.core import Helm, Navigator, Sextant
+from app.core.llm.base import ToolResultBlock, ToolUseBlock
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """@tool 注册进模块级全局表，测试注册的工具会漏进 MCP 的 tools/list。"""
+    from app.tools import registry
+
+    before = dict(registry._REGISTRY)
+    yield
+    registry._REGISTRY.clear()
+    registry._REGISTRY.update(before)
+
+
+# ---- Navigator ----
+
+
+def test_navigator_hard_closes_tools_on_the_last_round():
+    """到顶就硬关工具，而不是追加一条 user 消息哄模型收手——那是在请求它配合。"""
+    nav = Navigator(max_rounds=3)
+    assert nav.plan_round(rounds_done=1, tokens_used=0).tool_choice is None
+    assert nav.plan_round(rounds_done=3, tokens_used=0).tool_choice == "none"
+
+
+def test_navigator_stops_on_token_budget_even_mid_way():
+    nav = Navigator(max_rounds=8, max_turn_tokens=1000)
+    plan = nav.plan_round(rounds_done=2, tokens_used=1200)
+    assert plan.over_budget and plan.tool_choice == "none"
+    assert nav.stop_reason(plan) == "turn_budget"
+
+
+def test_stop_reasons_are_distinguishable():
+    """三种终态各自不同：用户看到的话术、以及要不要重试，取决于这个。"""
+    nav = Navigator(max_rounds=2, max_turn_tokens=100)
+    assert nav.stop_reason(nav.plan_round(rounds_done=1, tokens_used=0)) == "stop"
+    assert nav.stop_reason(nav.plan_round(rounds_done=2, tokens_used=0)) == "max_rounds"
+    assert nav.stop_reason(nav.plan_round(rounds_done=1, tokens_used=999)) == "turn_budget"
+
+
+def test_narrowing_can_only_shrink_the_tool_surface():
+    """技能里写一个本轮没给的工具名，结果是那个工具不可用，而不是把它加进来。"""
+    nav = Navigator(max_rounds=5)
+    active = ("search_papers", "get_paper")
+    block = ToolResultBlock("c", json.dumps({"allowed_tools": ["get_paper", "delete_everything"]}))
+    assert nav.narrow_tools([block], active) == ("get_paper",)
+
+
+def test_empty_intersection_is_ignored_rather_than_muting_the_agent():
+    """技能写错名字不该让 Buddy 变成哑巴。"""
+    nav = Navigator(max_rounds=5)
+    block = ToolResultBlock("c", json.dumps({"allowed_tools": ["拼错了"]}))
+    assert nav.narrow_tools([block], ("search_papers",)) is None
+    assert nav.narrow_tools([ToolResultBlock("c", "不是 JSON")], ("search_papers",)) is None
+
+
+# ---- Helm ----
+
+
+def _ctx() -> ToolContext:
+    return ToolContext(project_id=uuid.uuid4(), llm=None, user_id=uuid.uuid4())
+
+
+async def test_helm_turns_a_crash_into_a_result_instead_of_killing_the_turn():
+    @tool(name="_boom", description="炸给你看", input_schema={"type": "object", "properties": {}})
+    async def _boom(ctx, args):  # noqa: ANN001
+        raise RuntimeError("上游挂了")
+
+    event, block = await Helm(_ctx()).execute(ToolUseBlock("c1", "_boom", {}))
+    assert event.ok is False
+    assert "RuntimeError" in event.summary
+    assert block.is_error and "上游挂了" in block.content
+
+
+async def test_helm_reports_unknown_tools_and_broken_arguments_differently():
+    """两种失败提示不同：一个该换工具，一个该重发这次调用。
+
+    坏参数用**已注册**的工具来测——那才是真实形态：累加器标 __parse_error__ 时，
+    工具名通常是好的，坏掉的是流到一半的参数。工具名和参数同时坏掉时先报未知工具，
+    因为那条更可执行。
+    """
+
+    @tool(name="_known", description="在的", input_schema={"type": "object", "properties": {}})
+    async def _known(ctx, args):  # noqa: ANN001
+        return {}
+
+    helm = Helm(_ctx())
+    unknown, _ = await helm.execute(ToolUseBlock("c1", "_没这个工具", {}))
+    broken, _ = await helm.execute(ToolUseBlock("c2", "_known", {"__parse_error__": "..."}))
+    assert "未知工具" in unknown.summary
+    assert "重新发起" in broken.summary
+
+
+async def test_helm_times_out_instead_of_hanging_the_turn():
+    from app.agents.chat.core import helm as helm_mod
+
+    @tool(name="_slow", description="慢", input_schema={"type": "object", "properties": {}})
+    async def _slow(ctx, args):  # noqa: ANN001
+        await asyncio.sleep(5)
+        return {}
+
+    original = helm_mod.TOOL_TIMEOUT_SECONDS
+    helm_mod.TOOL_TIMEOUT_SECONDS = 0.05
+    try:
+        event, _ = await Helm(_ctx()).execute(ToolUseBlock("c1", "_slow", {}))
+    finally:
+        helm_mod.TOOL_TIMEOUT_SECONDS = original
+    assert event.ok is False and "超过" in event.summary
+
+
+async def test_helm_keeps_call_order_even_when_they_finish_out_of_order():
+    """卡片次序应与模型的意图一致；谁先跑完是实现细节。"""
+
+    @tool(name="_slowish", description="慢一点", input_schema={"type": "object", "properties": {}})
+    async def _slowish(ctx, args):  # noqa: ANN001
+        await asyncio.sleep(0.05)
+        return {"who": "slow"}
+
+    @tool(name="_fast", description="快", input_schema={"type": "object", "properties": {}})
+    async def _fast(ctx, args):  # noqa: ANN001
+        return {"who": "fast"}
+
+    calls = [ToolUseBlock("c1", "_slowish", {}), ToolUseBlock("c2", "_fast", {})]
+    seen = [ev.name async for ev, _ in Helm(_ctx()).run(calls)]
+    assert seen == ["_slowish", "_fast"]
+
+
+# ---- Sextant ----
+
+
+def test_sextant_says_nothing_when_the_answer_is_supported():
+    verdict = Sextant().verify(answer="查到三篇 [1][2][3]。", sources=3, successful_tool_calls=1)
+    assert verdict.passed and verdict.notes == ()
+
+
+def test_sextant_catches_citations_with_nothing_retrieved():
+    verdict = Sextant().verify(answer="见 [1]。", sources=0, successful_tool_calls=0)
+    assert not verdict.passed
+    assert "没有查到任何论文" in verdict.notes[0]
+
+
+def test_sextant_catches_numbering_that_runs_past_the_evidence():
+    """[5] 但只查到 3 篇——模型编号跑偏的经典形态。"""
+    verdict = Sextant().verify(answer="见 [1] 与 [5]。", sources=3, successful_tool_calls=2)
+    assert not verdict.passed
+    assert "[5]" in verdict.notes[0] and "3 篇" in verdict.notes[0]
+
+
+def test_sextant_catches_claiming_to_have_searched_without_searching():
+    verdict = Sextant().verify(answer="我查到库里有相关工作。", sources=0, successful_tool_calls=0)
+    assert not verdict.passed
+    assert any("没有任何一次成功的检索" in n for n in verdict.notes)
+
+
+def test_sextant_does_not_fire_on_plain_answers():
+    """没有编号、没有声称检索过 → 什么都不说。误报会训练用户忽略这一栏。"""
+    assert Sextant().verify(
+        answer="这个问题不需要查库，我直接说说思路。", sources=0, successful_tool_calls=0
+    ).passed

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -278,10 +278,34 @@ function SourcesCard({ papers }: { papers: PaperSource[] }) {
   );
 }
 
+/** 验收提请注意。判据是启发式的，所以措辞要让人一眼看穿并能忽略——
+    装成权威结论比不提示更糟。 */
+function VerifyCard({ notes }: { notes: string[] }) {
+  return (
+    <div
+      style={{
+        margin: '8px 0 2px',
+        padding: '7px 10px',
+        borderRadius: 8,
+        background: 'var(--warn-bg)',
+        color: 'var(--warn-tx)',
+        fontSize: 11.5,
+        lineHeight: 1.6,
+      }}
+    >
+      <div style={{ marginBottom: 2 }}>{tr('这段回答有地方对不上：', 'Something in this answer does not line up:')}</div>
+      {notes.map((note) => (
+        <div key={note}>· {note}</div>
+      ))}
+    </div>
+  );
+}
+
 function BlockView({ block, live }: { block: AssistantBlock; live: boolean }) {
   if (block.kind === 'text') return <Markdown source={block.text} />;
   if (block.kind === 'plan') return <PlanCard steps={block.steps} />;
   if (block.kind === 'sources') return <SourcesCard papers={block.papers} />;
+  if (block.kind === 'verify') return <VerifyCard notes={block.notes} />;
   if (block.kind === 'thinking') return <ThinkingView text={block.text} live={live} />;
   if (block.kind === 'tool') return <ToolCard block={block} />;
   return null; // 未知块：画不出来就不画，绝不抛

--- a/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
@@ -148,3 +148,19 @@ describe('本轮查看的论文', () => {
     expect(reduce([['sources', { items: '不是数组' }]])).toEqual([]);
   });
 });
+
+describe('验收结论', () => {
+  it('通过时不画任何东西——绿条只会训练用户忽略这一栏', () => {
+    expect(reduce([['verify', { passed: true, notes: [] }]])).toEqual([]);
+    expect(reduce([['verify', { passed: true, notes: ['理论上不该有'] }]])).toEqual([]);
+  });
+
+  it('没通过时把话说出来', () => {
+    const blocks = reduce([['verify', { passed: false, notes: ['引用编号超出查到的篇数'] }]]);
+    expect(blocks).toEqual([{ kind: 'verify', notes: ['引用编号超出查到的篇数'] }]);
+  });
+
+  it('没有具体说法就不占地方', () => {
+    expect(reduce([['verify', { passed: false, notes: [] }]])).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -30,6 +30,7 @@ export type AssistantBlock =
   | { kind: 'text'; text: string }
   | { kind: 'plan'; steps: PlanStep[] }
   | { kind: 'sources'; papers: PaperSource[] }
+  | { kind: 'verify'; notes: string[] }
   | { kind: 'thinking'; text: string }
   | {
       kind: 'tool';
@@ -139,6 +140,16 @@ export function applyAssistantEvent(
       const seen = new Set(b.papers.map((p) => p.paperId));
       return { kind: 'sources', papers: [...b.papers, ...incoming.filter((p) => !seen.has(p.paperId))] };
     });
+  }
+
+  if (event === 'verify') {
+    // 通过时后端根本不发这一帧；真发来了也只在有话说时才画——一条「一切正常」的
+    // 绿条只会训练用户忽略这一栏。
+    const notes = Array.isArray(data.notes)
+      ? (data.notes as unknown[]).map((n) => str(n)).filter(Boolean)
+      : [];
+    if (data.passed === true || !notes.length) return blocks;
+    return [...blocks, { kind: 'verify', notes }];
   }
 
   if (event === 'tool_call') {


### PR DESCRIPTION
Stacked on #277 — merge that first; this branch contains its commit.

The chat loop is now three collaborators with the same names and division of labour as the Voyage engine, but deliberately **not the same code**. Voyage's trio runs in a worker, walks pre-planned step rows, and fails by pausing for replanning. A conversation has no pre-made plan (the next step is decided token by token), must stream over an HTTP connection, and fails by telling the user while the session stays alive. What's shared is the discipline, not the implementation.

## Navigator — plan

Owns "what happens next": how many rounds remain, which tools this round may use, when to hard-close tools and wrap up, and whether a skill may narrow the tool surface. It touches no model, no tools, and no database — so for the first time those judgements are unit-testable without any IO, and they're judgements whose failure modes are expensive (burning an extra round, or wrapping up early).

Tool-narrowing keeps the rule it always had: it can only shrink. A skill naming a tool this turn didn't grant makes that tool unavailable rather than adding it, and an empty intersection is ignored — a typo in a skill shouldn't render the assistant mute.

## Helm — execute

One rule above all: **exceptions never escape**. Tool crashed, timed out, arguments weren't valid JSON, tool name doesn't exist — each becomes a result fed back to the model so it can correct itself. Read-only calls run in parallel but results are yielded in **call order**, because the card sequence on screen should follow the model's intent; which one finished first is an implementation detail.

## Sextant — verify

Zero LLM calls, matching the Voyage Sextant's deterministic-checks-first rule. It does not judge whether an answer is *good* — that isn't a machine's call. It checks three falsifiable things:

- the answer carries numbered citations but nothing was retrieved this turn
- the numbering runs past the evidence (`[5]` when only 3 papers came back) — the classic way model numbering drifts
- the answer says "I searched / the library has" while not a single tool call succeeded

A hit is a **note**, not a verdict: the answer isn't rewritten or withheld, and the wording is meant to be seen through and dismissed, because the checks are heuristic. Dressing a heuristic up as authority is worse than staying quiet. When everything checks out the frame isn't sent at all — an "all good" green bar only teaches people to ignore that strip.

## Tests

14 for the core (round/budget/stop-reason boundaries, narrowing shrink-only and both ignore paths, Helm's four failure classes plus call-order preservation under out-of-order completion, Sextant's three hits and its silence on plain answers) and 3 on the frontend reducer (silent on pass, renders on fail, no empty block).

Behaviour of the existing loop is unchanged: the 40 pre-existing agent tests pass untouched. Full suite **1104 passed**, vitest **25 passed**.
