### PR TITLE
feat(assistant): Buddy home screen, topic binding, and a settings tab for skills / memory / MCP

### DIFF
--- a/src/backend/alembic/versions/c31f7a9d40b2_buddy_memories.py
+++ b/src/backend/alembic/versions/c31f7a9d40b2_buddy_memories.py
@@ -1,0 +1,39 @@
+"""buddy memories
+
+Revision ID: c31f7a9d40b2
+Revises: a22aa895244c
+Create Date: 2026-08-05
+
+用户自己写给 Buddy 的长期记忆。本期**只有用户能写**：agent 自己往里写属于写工具那
+一期，与权限模型一起做。分表而不是塞进 users.settings，是因为它要按条增删、要有
+创建时间、将来还要有来源（谁写的、哪场对话里学到的）。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c31f7a9d40b2"
+down_revision: str | None = "a22aa895244c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "buddy_memories",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("buddy_memories")

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -43,6 +43,7 @@ from app.schemas.chat_agent import (
     ConversationCreate,
     ConversationRead,
     ConversationTurnRequest,
+    MemoryCreate,
     MessageRead,
     SkillImportRequest,
 )
@@ -210,6 +211,43 @@ async def delete_skill(
     await session.commit()
 
 
+@router.get("/memories")
+async def list_memories(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[dict[str, Any]]:
+    """我让 Buddy 一直记得的事。"""
+    _require_enabled()
+    rows = await buddy.list_memories(session, user_id=user.id)
+    return [
+        {"id": str(r.id), "text": r.text, "created_at": r.created_at.isoformat()} for r in rows
+    ]
+
+
+@router.post("/memories", status_code=201)
+async def add_memory(
+    payload: MemoryCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """记一条。**只有用户能写**——agent 自己往里写属于写工具那一期，
+    一个能改自己记忆的助手必须和权限模型、审批一起设计。"""
+    _require_enabled()
+    row = await buddy.add_memory(session, user_id=user.id, text=payload.text)
+    return {"id": str(row.id), "text": row.text, "created_at": row.created_at.isoformat()}
+
+
+@router.delete("/memories/{memory_id}", status_code=204)
+async def delete_memory(
+    memory_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    _require_enabled()
+    if not await buddy.delete_memory(session, user_id=user.id, memory_id=memory_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="MEMORY_NOT_FOUND")
+
+
 @router.get("/capabilities")
 async def capabilities(
     session: AsyncSession = Depends(get_session),
@@ -315,6 +353,9 @@ async def run_turn(
     # L1：技能目录进 system prompt（每个技能只占一行）。正文由 skill_load 按需取，
     # 绝不写进 system——那会作废整个 prompt cache 前缀。
     catalog = await agent_skills.render_catalog(session, user_id=user.id)
+    # 长期记忆随 extra_system 追加在末尾（与方向说明、技能目录同处）：稳定前缀不动，
+    # 缓存前缀才不会每轮作废。
+    memories = await buddy.render_memories(session, user_id=user.id)
     await store.append_message(session, conversation=conv, role="user", text=payload.question)
     await session.commit()
 
@@ -350,6 +391,7 @@ async def run_turn(
         max_rounds=payload.max_rounds,
         statement=payload.statement,
         skill_catalog=catalog,
+        extra_system=memories,
         page_context=buddy.render_page_context(payload.page_kind, payload.page_id),
     )
     conv_id, user_id = conv.id, user.id

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.activity import Activity
 from app.models.agent_skill import AgentSkill, AgentSkillFile
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.buddy_memory import BuddyMemory
 from app.models.chat_bot import ChatBotConfig
 from app.models.conversation import Conversation, ConversationMessage
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
@@ -48,6 +49,7 @@ from app.models.voyage import VoyageRun, VoyageStep
 __all__ = [
     "Activity",
     "AgentSkill",
+    "BuddyMemory",
     "AgentSkillFile",
     "ChatBotConfig",
     "Conversation",

--- a/src/backend/app/models/buddy_memory.py
+++ b/src/backend/app/models/buddy_memory.py
@@ -1,0 +1,25 @@
+"""Buddy 的长期记忆：用户自己写的、希望它一直记得的事。
+
+本期**只有用户能写**。agent 自己往里写属于写工具那一期——一个能自己改自己记忆的
+助手，必须和权限模型、审批一起设计，不能顺手做掉。
+
+存正文而不是键值对：记忆是说给模型听的一句话（「我做的是具身智能，别给我推 NLP
+的东西」），拆成结构化字段既没必要也会丢掉语气。
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class BuddyMemory(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "buddy_memories"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    text: Mapped[str] = mapped_column(Text, nullable=False)

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -29,6 +29,10 @@ class ConversationRead(BaseModel):
     last_message_at: datetime | None = None
 
 
+class MemoryCreate(BaseModel):
+    text: str = Field(min_length=1, max_length=300)
+
+
 class ConversationTurnRequest(BaseModel):
     question: str = Field(min_length=1)
     #: 这轮工具检索的课题。全局会话第一次提问时带上；会话上存过就不用再传。

--- a/src/backend/app/services/buddy.py
+++ b/src/backend/app/services/buddy.py
@@ -17,6 +17,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.buddy_memory import BuddyMemory
 from app.models.daily_feed import DailyFeedEntry
 from app.models.experiment import Experiment
 from app.models.idea import Idea
@@ -177,3 +178,59 @@ def render_page_context(kind: str | None, obj_id: str | None) -> str:
     return f"[当前页面] {line}。回答时优先考虑这个上下文；用户说「这篇」「这个」多半指它。"[
         :MAX_CONTEXT_CHARS
     ]
+
+
+#: 记忆注入提示词的总长上限。它每轮都要重发——放任下去就是每轮都在为一堆旧便签付钱。
+MAX_MEMORY_CHARS = 1200
+
+#: 单条记忆的长度上限。一条写成一篇文章的记忆，模型多半只会记住开头。
+MAX_MEMORY_ITEM_CHARS = 300
+
+
+async def list_memories(session: AsyncSession, *, user_id: uuid.UUID) -> list[BuddyMemory]:
+    """用户的长期记忆，新的在前。"""
+    rows = await session.execute(
+        select(BuddyMemory)
+        .where(BuddyMemory.user_id == user_id)
+        .order_by(BuddyMemory.created_at.desc())
+    )
+    return list(rows.scalars().all())
+
+
+async def add_memory(session: AsyncSession, *, user_id: uuid.UUID, text: str) -> BuddyMemory:
+    row = BuddyMemory(user_id=user_id, text=text.strip()[:MAX_MEMORY_ITEM_CHARS])
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def delete_memory(session: AsyncSession, *, user_id: uuid.UUID, memory_id: uuid.UUID) -> bool:
+    row = await session.get(BuddyMemory, memory_id)
+    if row is None or row.user_id != user_id:
+        return False
+    await session.delete(row)
+    await session.commit()
+    return True
+
+
+async def render_memories(session: AsyncSession, *, user_id: uuid.UUID) -> str:
+    """记忆 → 追加进系统提示的一段；没有记忆返回空串。
+
+    **总长封顶**并且按新到旧填：每轮都要重发，放任下去就是每轮都在为一堆旧便签付钱。
+    填不下的直接不进——与其截断成半句话让模型猜，不如少给一条。
+    """
+    rows = await list_memories(session, user_id=user_id)
+    if not rows:
+        return ""
+    lines: list[str] = []
+    used = 0
+    for row in rows:
+        line = f"- {row.text.strip()}"
+        if used + len(line) > MAX_MEMORY_CHARS:
+            break
+        lines.append(line)
+        used += len(line)
+    if not lines:
+        return ""
+    return "关于这位用户，你需要一直记得：\n" + "\n".join(lines)

--- a/src/backend/tests/test_buddy.py
+++ b/src/backend/tests/test_buddy.py
@@ -173,3 +173,58 @@ async def test_page_context_reaches_the_model_as_a_user_prefix(client, agent_on,
     page_context, question = seen[0]
     assert "正在读一篇论文" in page_context and "p-1" in page_context
     assert question == "这篇讲了什么", "提问本身不该被改写"
+
+
+async def test_memories_are_per_user_and_reach_the_prompt(client, agent_on):
+    """长期记忆：只有自己看得见，并且真的进了这一轮的提示词。"""
+    from app.core.db import get_sessionmaker
+    from app.services import buddy as buddy_service
+
+    token_a = await register_and_login(client, email="mem-a@example.com")
+    token_b = await register_and_login(client, email="mem-b@example.com")
+    mine = {"Authorization": f"Bearer {token_a}"}
+    theirs = {"Authorization": f"Bearer {token_b}"}
+
+    created = await client.post(
+        "/api/chat/memories", json={"text": "我做具身智能，别给我推纯 NLP"}, headers=mine
+    )
+    assert created.status_code == 201
+
+    assert len((await client.get("/api/chat/memories", headers=mine)).json()) == 1
+    assert (await client.get("/api/chat/memories", headers=theirs)).json() == []
+
+    # 别人的记忆删不掉（404 而不是 403：403 等于承认这条存在）
+    memory_id = created.json()["id"]
+    assert (
+        await client.delete(f"/api/chat/memories/{memory_id}", headers=theirs)
+    ).status_code == 404
+
+    async with get_sessionmaker()() as session:
+        from sqlalchemy import select
+
+        from app.models.user import User
+
+        user_id = (
+            await session.execute(select(User.id).where(User.email == "mem-a@example.com"))
+        ).scalar_one()
+        rendered = await buddy_service.render_memories(session, user_id=user_id)
+    assert "具身智能" in rendered
+
+
+async def test_memory_injection_is_capped():
+    """记忆每轮都要重发：不封顶就是每轮都在为一堆旧便签付钱。"""
+    from app.services.buddy import MAX_MEMORY_CHARS
+
+    assert MAX_MEMORY_CHARS <= 2000
+
+
+async def test_a_user_with_no_memories_adds_nothing_to_the_prompt(client, agent_on):
+    """没有记忆时一个字都不加——空标题会白占提示词，还会让模型以为该找点什么。"""
+    import uuid as _uuid
+
+    from app.core.db import get_sessionmaker
+    from app.services import buddy as buddy_service
+
+    assert await register_and_login(client, email="mem-empty@example.com")
+    async with get_sessionmaker()() as session:
+        assert await buddy_service.render_memories(session, user_id=_uuid.uuid4()) == ""

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a22aa895244c"  # 成员行记下打分它的那次同步任务 id
+HEAD_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
+SKILLS_REVISION = "a22aa895244c"  # Skills v2（SKILL.md 渐进披露）
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
 SCORED_RUN_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
 CONVERSATIONS_REVISION = "581d172bd41b"  # 对话搬到服务端
@@ -350,7 +351,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉 Skills v2。
+    # 最新 revision 可往返：先退掉 Buddy 的长期记忆。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SKILLS_REVISION
+    assert "buddy_memories" not in columns["_tables"]
+
+    # 再退掉 Skills v2。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == CONVERSATIONS_REVISION

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -10,9 +10,11 @@ import {
   type PlanStep,
 } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
+import { BuddyHome } from './BuddyHome';
 import { CapabilitiesBar } from './CapabilitiesBar';
 import { ToolImages } from './ToolImages';
 import { pageContextFrom } from './buddyContext';
+import { useProject } from '../../app/project';
 import { TurnStatus } from './TurnStatus';
 
 /* ============================================================
@@ -342,11 +344,13 @@ export function AssistantPanel({
     { id: string; title: string; project_id: string | null }[]
   >([]);
   const [greeting, setGreeting] = useState<string>('');
-  const [stats, setStats] = useState<Record<string, number>>({});
   const [contextOn, setContextOn] = useState(true);
   const abortRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
+  // 对话里的「项目」就是平台里的课题：跟着外壳当前选中的那个走，不另设一套选择。
+  // 用户在哪个课题下工作，问出来的问题多半就属于那个课题；让他再选一次是多余的。
+  const { currentProject } = useProject();
   const pageContext = pageContextFrom(location.pathname);
 
   useEffect(() => {
@@ -366,10 +370,7 @@ export function AssistantPanel({
     if (!open || greeting) return;
     void api
       .getBuddyGreeting()
-      .then((g) => {
-        setGreeting(g.greeting);
-        setStats(g.stats ?? {});
-      })
+      .then((g) => setGreeting(g.greeting))
       .catch(() => setGreeting(''));
   }, [open, greeting]);
 
@@ -460,6 +461,7 @@ export function AssistantPanel({
         // 那条路上的权限校验一点没少。用户可以关掉。
         page:
           contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
+        projectId: currentProject?.id ?? null,
         onBlocks: patch,
         onDone: () => setBusy(false),
         onError: (detail) => {
@@ -469,7 +471,7 @@ export function AssistantPanel({
       },
     );
     },
-    [busy, convId, contextOn, pageContext],
+    [busy, convId, contextOn, pageContext, currentProject],
   );
 
   const send = useCallback(() => {
@@ -506,15 +508,6 @@ export function AssistantPanel({
   if (!open) return null;
 
   // 快捷动作按真实计数给：没有实验就不该出现「实验怎么样了」
-  const suggestions = [
-    stats.experiments_running ? tr('我的实验现在怎么样了？', 'How are my experiments doing?') : '',
-    stats.daily_today ? tr('帮我筛一遍今天的新论文', 'Triage today’s new papers for me') : '',
-    stats.saved_recent
-      ? tr('这周我收的论文有什么共同线索？', 'What connects the papers I saved this week?')
-      : '',
-    pageContext?.kind === 'paper' ? tr('解读我正在看的这篇', 'Walk me through this paper') : '',
-  ].filter(Boolean);
-
   const lastTurn = turns[turns.length - 1];
   const liveBlocks = busy && lastTurn?.role === 'assistant' ? lastTurn.blocks : [];
 
@@ -618,41 +611,7 @@ export function AssistantPanel({
 
       <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px' }}>
         {turns.length === 0 && (
-          <div style={{ fontSize: 12.5, lineHeight: 1.7 }}>
-            {greeting && (
-              <div
-                style={{
-                  background: 'var(--accent-soft)',
-                  color: 'var(--accent-text)',
-                  borderRadius: 10,
-                  padding: '10px 12px',
-                  marginBottom: 10,
-                  fontSize: 13,
-                }}
-              >
-                {greeting}
-              </div>
-            )}
-            <div style={{ color: 'var(--text-3)' }}>
-              {tr(
-                '我会调用平台的检索工具去查，而不是凭上下文猜。把论文拖到右下角的球上，我就替你读它。',
-                'I call the platform’s search tools instead of guessing. Drop a paper on the bubble and I’ll read it for you.',
-              )}
-            </div>
-            {/* 快捷动作只在对应数据真的存在时出现：没有实验就不该问「实验怎么样了」 */}
-            <div className="row gap6 wrap" style={{ marginTop: 10 }}>
-              {suggestions.map((text) => (
-                <span
-                  key={text}
-                  className="chip"
-                  style={{ cursor: 'pointer' }}
-                  onClick={() => void ask(text)}
-                >
-                  {text}
-                </span>
-              ))}
-            </div>
-          </div>
+          <BuddyHome greeting={greeting} onPick={(prompt) => setInput(prompt)} />
         )}
         {turns.map((turn, i) => {
           const isLast = i === turns.length - 1;
@@ -680,6 +639,22 @@ export function AssistantPanel({
       </div>
 
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
+        {/* 当前课题：自动绑定外壳里选中的那个，只作展示——换课题在左上角切，
+            这里再放一个选择器就是两个真相来源。 */}
+        {currentProject && (
+          <div
+            className="row gap6"
+            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)' }}
+            title={tr('这场对话属于当前课题，跟着左上角的课题切换走', 'This chat belongs to the current topic, following the switcher in the top-left')}
+          >
+            <Icon name="layers" size={11} />
+            <span
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {currentProject.name}
+            </span>
+          </div>
+        )}
         {pageContext && (
           <div
             className="row gap6"

--- a/src/frontend/src/features/assistant/BuddyHome.tsx
+++ b/src/frontend/src/features/assistant/BuddyHome.tsx
@@ -1,0 +1,148 @@
+import { Icon, type IconName } from '../../components/ui/Icon';
+import { PolarisMark } from '../../components/ui/PolarisLogo';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   PolarisBuddy 的初始界面。
+
+   空对话是最难写的一屏：用户不知道它能干什么，而一段说明文字没人读。所以摆几张
+   **能直接点的卡片**——它们既是能力说明，也是入口，点一下就开始。
+
+   卡片按平台的四件事分：找文献 / 读论文 / 理想法 / 看实验。这不是随便选的四个，
+   而是平台本来的四个阶段；用户在哪个阶段，就点哪张。
+
+   标识做成大号浅灰水印：空屏需要一个视觉落点，又不该抢走卡片的注意力。
+   ============================================================ */
+
+export interface HomeCard {
+  icon: IconName;
+  title: string;
+  hint: string;
+  prompt: string;
+}
+
+/** 卡片是固定的四张。与「快捷动作」不同——那些按你的数据变，这四张是能力地图。
+
+    写成函数而不是模块级常量：顶层 tr 在模块加载时就定死了，之后切换中英文不会重算。 */
+export const homeCards = (): HomeCard[] => [
+  {
+    icon: 'search',
+    title: tr('找相关文献', 'Find related work'),
+    hint: tr('说个方向，我去库里翻', 'Name a direction, I search the libraries'),
+    prompt: tr('帮我找一下和「」相关的论文，先铺开看看有哪些。', 'Find papers related to "" — start wide.'),
+  },
+  {
+    icon: 'book',
+    title: tr('读懂一篇论文', 'Understand a paper'),
+    hint: tr('方法怎么工作、证据强不强', 'How the method works, how strong the evidence is'),
+    prompt: tr(
+      '帮我精读一篇论文：它解决什么问题、方法怎么工作、证据强不强。',
+      'Walk me through a paper: the problem, how the method works, how strong the evidence is.',
+    ),
+  },
+  {
+    icon: 'bulb',
+    title: tr('理清一个想法', 'Sharpen an idea'),
+    hint: tr('有没有人做过、差别在哪', 'Who has done it, and how yours differs'),
+    prompt: tr(
+      '我有个想法想理一理：先帮我查有没有人做过，再说说和已有工作的差别。',
+      'I have an idea — check whether it has been done, then contrast it with prior work.',
+    ),
+  },
+  {
+    icon: 'flask',
+    title: tr('看看实验进展', 'Check experiments'),
+    hint: tr('跑到哪了、下一步做什么', 'Where they stand and what is next'),
+    prompt: tr(
+      '我的实验现在什么情况？跑到哪了，下一步该做什么。',
+      'How are my experiments doing, and what is next?',
+    ),
+  },
+];
+
+export function BuddyHome({
+  greeting,
+  onPick,
+}: {
+  greeting: string;
+  onPick: (prompt: string) => void;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px 18px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* 水印：空屏的视觉落点，压到很淡，不跟卡片抢注意力 */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -58%)',
+          opacity: 0.045,
+          pointerEvents: 'none',
+        }}
+      >
+        <PolarisMark size={260} />
+      </div>
+
+      <div style={{ position: 'relative', width: '100%', maxWidth: 460 }}>
+        <div className="row gap8" style={{ alignItems: 'center', justifyContent: 'center', marginBottom: 6 }}>
+          <PolarisMark size={26} />
+          <strong style={{ fontSize: 17, letterSpacing: '-0.01em' }}>PolarisBuddy</strong>
+        </div>
+        <div
+          style={{
+            textAlign: 'center',
+            fontSize: 12.5,
+            color: 'var(--text-3)',
+            lineHeight: 1.7,
+            marginBottom: 18,
+            minHeight: 22,
+          }}
+        >
+          {/* 问候语来自真实计数；数不出来时就不说，这里也不摆占位 */}
+          {greeting}
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: 8,
+          }}
+        >
+          {homeCards().map((card) => (
+            <div
+              key={card.title}
+              className="hoverable"
+              onClick={() => onPick(card.prompt)}
+              style={{
+                border: '0.5px solid var(--border-2)',
+                borderRadius: 10,
+                padding: '11px 12px',
+                cursor: 'pointer',
+                background: 'var(--surface)',
+              }}
+            >
+              <Icon name={card.icon} size={15} style={{ color: 'var(--accent)' }} />
+              <div style={{ fontSize: 12.5, fontWeight: 600, marginTop: 6 }}>{card.title}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-4)', lineHeight: 1.5, marginTop: 2 }}>
+                {card.hint}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/settings/BuddySettings.tsx
+++ b/src/frontend/src/features/settings/BuddySettings.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   设置里的 PolarisBuddy：技能、记忆、MCP。
+
+   为什么这三样放一起：它们回答的是同一个问题——「Buddy 知道什么、能做什么」。
+   技能是按需加载的用法说明，记忆是关于你的长期事实，MCP 是工具面对外的样子。
+   分散在三处的话，用户要调整 Buddy 的行为就得先猜去哪儿找。
+   ============================================================ */
+
+function SkillsCard() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['buddy-skills'],
+    queryFn: () => api.listAssistantSkills(),
+    retry: false,
+  });
+  const remove = useMutation({
+    mutationFn: (slug: string) => api.deleteAssistantSkill(slug),
+    onSuccess: () => {
+      toast(tr('技能已删除', 'Skill deleted'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['buddy-skills'] });
+    },
+    onError: (e) => toast(e instanceof Error ? e.message : String(e), 'error'),
+  });
+
+  if (isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (isError) {
+    return (
+      <div className="empty">
+        {tr('无法加载技能（助手未启用或后端不可用）', 'Cannot load skills (assistant off or backend down)')}
+      </div>
+    );
+  }
+  const skills = data ?? [];
+
+  return (
+    <div className="card card-pad">
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('技能', 'Skills')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7, marginBottom: 10 }}>
+        {tr(
+          '技能是「什么时候该怎么做」的说明书。目录里每条只占一行常驻，正文由 Buddy 判断需要时才加载——所以描述要写成触发条件，而不是功能介绍。',
+          'A skill describes how to handle a kind of task. Only one line per skill stays resident; the body is loaded on demand — so the description should read as a trigger condition, not a feature blurb.',
+        )}
+      </div>
+      {skills.length === 0 && <div className="empty">{tr('还没有技能', 'No skills yet')}</div>}
+      <div className="col gap8">
+        {skills.map((skill) => (
+          <div
+            key={skill.slug}
+            className="row gap8"
+            style={{
+              alignItems: 'flex-start',
+              padding: '8px 10px',
+              border: '0.5px solid var(--border-2)',
+              borderRadius: 8,
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="row gap6" style={{ alignItems: 'center' }}>
+                <span className="mono" style={{ fontSize: 12.5 }}>
+                  {skill.slug}
+                </span>
+                {skill.is_builtin && (
+                  <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
+                    {tr('内置', 'built-in')}
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-4)', lineHeight: 1.6, marginTop: 2 }}>
+                {skill.description}
+              </div>
+            </div>
+            {/* 内置技能删不掉：它是代码的一部分，改了下次启动又会被种回来。
+                与其让按钮点了没反应，不如不给按钮。 */}
+            {!skill.is_builtin && (
+              <button
+                className="btn btn-ghost sm"
+                onClick={() => remove.mutate(skill.slug)}
+                style={{ height: 24, fontSize: 11 }}
+              >
+                {tr('删除', 'Delete')}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MemoryCard() {
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState('');
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['buddy-memories'],
+    queryFn: () => api.listBuddyMemories(),
+    retry: false,
+  });
+  const add = useMutation({
+    mutationFn: (text: string) => api.addBuddyMemory(text),
+    onSuccess: () => {
+      setDraft('');
+      void queryClient.invalidateQueries({ queryKey: ['buddy-memories'] });
+    },
+    onError: (e) => toast(e instanceof Error ? e.message : String(e), 'error'),
+  });
+  const remove = useMutation({
+    mutationFn: (id: string) => api.deleteBuddyMemory(id),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['buddy-memories'] }),
+  });
+
+  const memories = data ?? [];
+
+  return (
+    <div className="card card-pad">
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="bulb" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('长期记忆', 'Memory')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7, marginBottom: 10 }}>
+        {tr(
+          '你希望 Buddy 一直记得的事——研究方向、习惯的表达、不想被推荐的东西。每轮对话都会带上，所以宜少而准：太多会挤占它读你问题的余地。目前只有你能写，Buddy 自己往里记属于写工具那一期。',
+          'Things you want Buddy to always know. They ride along on every turn, so keep them few and sharp. Only you can write them for now; Buddy writing its own memory comes with the write-tools phase.',
+        )}
+      </div>
+      <div className="row gap8" style={{ marginBottom: 10 }}>
+        <input
+          className="input"
+          value={draft}
+          maxLength={300}
+          placeholder={tr('例如：我做具身智能，不用给我推纯 NLP 的工作', 'e.g. I work on embodied AI — skip pure NLP')}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && draft.trim()) add.mutate(draft.trim());
+          }}
+          style={{ flex: 1, minWidth: 0 }}
+        />
+        <button
+          className="btn btn-soft sm"
+          disabled={!draft.trim() || add.isPending}
+          onClick={() => add.mutate(draft.trim())}
+        >
+          {tr('记住', 'Remember')}
+        </button>
+      </div>
+      {isLoading && <div className="empty">{tr('加载中…', 'Loading…')}</div>}
+      {isError && (
+        <div className="empty">
+          {tr('无法加载记忆（助手未启用或后端不可用）', 'Cannot load memories (assistant off or backend down)')}
+        </div>
+      )}
+      {!isLoading && !isError && memories.length === 0 && (
+        <div className="empty">{tr('还没有记忆', 'Nothing remembered yet')}</div>
+      )}
+      <div className="col gap6">
+        {memories.map((memory) => (
+          <div
+            key={memory.id}
+            className="row gap8"
+            style={{
+              alignItems: 'flex-start',
+              padding: '7px 10px',
+              border: '0.5px solid var(--border-2)',
+              borderRadius: 8,
+              fontSize: 12.5,
+              lineHeight: 1.6,
+            }}
+          >
+            <span style={{ flex: 1, minWidth: 0 }}>{memory.text}</span>
+            <button
+              className="icon-btn"
+              title={tr('忘掉这条', 'Forget this')}
+              onClick={() => remove.mutate(memory.id)}
+            >
+              <Icon name="trash" size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function McpCard() {
+  const { data } = useQuery({
+    queryKey: ['buddy-capabilities'],
+    queryFn: () => api.getBuddyCapabilities(),
+    retry: false,
+  });
+
+  return (
+    <div className="card card-pad">
+      <div className="section-h" style={{ marginBottom: 6 }}>
+        <Icon name="git" size={15} style={{ color: 'var(--accent)' }} />
+        MCP
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7 }}>
+        {tr(
+          'Polaris 自己是 MCP 服务端：Buddy 用的工具，与 Claude Desktop 这类外部客户端拿到的是同一批（对外只给只读的）。所以这里没有「已连接的服务器」列表——我们不对外连接，列一个空表只会让人误会。',
+          'Polaris is itself an MCP server: Buddy uses the same tools external clients (Claude Desktop and the like) receive, minus anything that writes. There is no "connected servers" list because Polaris makes no outbound MCP connections.',
+        )}
+      </div>
+      {data && (
+        <div className="row gap8" style={{ marginTop: 10, alignItems: 'center', fontSize: 12 }}>
+          <span className="pill sm mono">{data.mcp.endpoint}</span>
+          <span style={{ color: 'var(--text-3)' }}>
+            {tr(`对外暴露 ${data.mcp.exposed_tools} 个只读工具`, `${data.mcp.exposed_tools} read-only tools exposed`)}
+          </span>
+          <span style={{ color: 'var(--text-4)' }}>·</span>
+          <span style={{ color: 'var(--text-3)' }}>
+            {tr(`Buddy 本轮可用 ${data.tools.length} 个`, `${data.tools.length} available to Buddy`)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function BuddySettings() {
+  return (
+    <div className="col gap14">
+      <MemoryCard />
+      <SkillsCard />
+      <McpCard />
+    </div>
+  );
+}

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -41,6 +41,7 @@ import {
   type RegistrationCodeRead,
   type SshCredentialInput,
 } from '../../lib/api';
+import { BuddySettings } from './BuddySettings';
 
 /* ============================================================
    /settings — 普通用户设置：个人信息 / 文献对话 / 界面偏好 / SSH 凭据 /
@@ -2733,7 +2734,7 @@ function MyUsageTab() {
 // ---------------- 页面 ----------------
 
 /** 普通用户设置的标签页（管理员那组在 /admin，见 AdminSettingsPage）。 */
-type Tab = 'personal' | 'prefs' | 'bots' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
+type Tab = 'personal' | 'prefs' | 'buddy' | 'bots' | 'ssh' | 'mymodels' | 'myusage' | 'mcp';
 
 /** 旧的 /settings?tab=xxx 深链里属于管理员组的值 → 统一改跳 /admin。 */
 export const ADMIN_TABS = ['llm', 'daily', 'usage', 'users', 'codes', 'feedback'] as const;
@@ -3993,6 +3994,7 @@ export function SettingsPage() {
   const items: { v: Tab; label: string }[] = [
     { v: 'personal', label: tr('个人信息', 'Profile') },
     { v: 'prefs', label: tr('界面偏好', 'Interface') },
+    { v: 'buddy', label: 'PolarisBuddy' },
     { v: 'bots', label: tr('群机器人', 'Group bots') },
     { v: 'ssh', label: tr('SSH 凭据', 'SSH credentials') },
     { v: 'mymodels', label: tr('我的模型', 'My LLM') },
@@ -4008,6 +4010,7 @@ export function SettingsPage() {
       </div>
       {tab === 'personal' && <PersonalTab />}
       {tab === 'prefs' && <PreferencesTab />}
+      {tab === 'buddy' && <BuddySettings />}
       {tab === 'bots' && <ChatBotsTab />}
       {tab === 'ssh' && <SshTab />}
       {tab === 'mymodels' && <MyLlmTab />}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4731,6 +4731,24 @@ export const api = {
    */
   /** 每日论文池的同步状况（全员可读）：最新一天、是否过期、各分类成败。 */
   /** 全局助手：会话列表（最近说过话的在前）。 */
+  listAssistantSkills(): Promise<
+    { slug: string; description: string; is_builtin: boolean }[]
+  > {
+    return request('/chat/skills');
+  },
+  deleteAssistantSkill(slug: string): Promise<void> {
+    return request(`/chat/skills/${slug}`, { method: 'DELETE' });
+  },
+  /** Buddy 的长期记忆（只有用户能写；agent 自己写属于写工具那一期）。 */
+  listBuddyMemories(): Promise<{ id: string; text: string; created_at: string }[]> {
+    return request('/chat/memories');
+  },
+  addBuddyMemory(text: string): Promise<{ id: string; text: string; created_at: string }> {
+    return request('/chat/memories', { method: 'POST', body: JSON.stringify({ text }) });
+  },
+  deleteBuddyMemory(id: string): Promise<void> {
+    return request(`/chat/memories/${id}`, { method: 'DELETE' });
+  },
   /** Buddy 这一轮手里有什么：工具面、技能、MCP 暴露状况。 */
   getBuddyCapabilities(): Promise<{
     tools: { name: string; description: string; read_only: boolean }[];

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -47,6 +47,8 @@ export type AssistantBlock =
 export interface AssistantHandlers {
   /** 用户此刻在看的页面（PolarisBuddy 的页面感知）；不传就不带 */
   page?: { kind: string; id?: string };
+  /** 这场对话属于哪个课题（= 平台的 project）。自动跟着外壳当前课题走。 */
+  projectId?: string | null;
   /** 用「上一份块列表 → 新块列表」的形式增量更新（React 状态直接套用）。 */
   onBlocks: (fn: (blocks: AssistantBlock[]) => AssistantBlock[]) => void;
   onDone: (stopReason: string) => void;
@@ -185,6 +187,7 @@ export function assistantTurnSse(
     {
       question,
       ...(handlers.page ? { page_kind: handlers.page.kind, page_id: handlers.page.id } : {}),
+      ...(handlers.projectId ? { project_id: handlers.projectId } : {}),
     },
     {
       onEvent: (event, raw) => {


### PR DESCRIPTION
Stacked on #278 (which is stacked on #277). Merge in order.

## The empty screen

An empty conversation is the hardest screen to write: the user doesn't know what the thing can do, and nobody reads a paragraph explaining it. So it now shows four **clickable cards** — find related work, understand a paper, sharpen an idea, check experiments. They double as the capability map and as the entry point.

Those four aren't arbitrary: they're the platform's own four stages, so whichever one you're in, there's a card for it. The wordmark sits behind them as a large, very light watermark — an empty screen needs a visual anchor, but it mustn't compete with the cards. The data-driven quick actions from the previous iteration are replaced by these.

## Topics bind themselves

A "project" in the conversation *is* a platform topic, and it now follows whichever topic is selected in the shell. The composer only **displays** it — no second picker. You switch topics in the top-left; adding another control here would create two sources of truth for the same fact. And whatever topic you're working in, your question almost certainly belongs to it, so asking again is busywork.

## Settings gains a PolarisBuddy tab

Three things, together because they answer one question — what does Buddy know and what can it do:

**Memory** (new). Things you want it to always know. They ride along on every turn, so the injected block is length-capped and filled newest-first; what doesn't fit is left out entirely rather than truncated mid-sentence for the model to guess at. **Only the user can write them.** Buddy writing its own memory belongs to the write-tools phase — an assistant that can edit its own memory has to be designed together with the permission model, not slipped in.

**Skills.** Which ones occupy the catalogue. Built-ins get no delete button: they're part of the code and would be re-seeded on next start, and a button that does nothing is worse than no button.

**MCP.** States plainly that Polaris is itself the server; no "connected servers" list, because there are no outbound connections.

## Tests

Backend: memories are per-user (another user sees none and gets 404 — not 403 — trying to delete one), the injected block actually reaches the prompt, the cap is pinned, and a user with none contributes nothing at all. The migration round-trip test grows a layer for the new table.

New `buddy_memories` table — its own table rather than a blob in `users.settings`, because entries are added and removed individually, need timestamps, and will later need provenance.

Full suite **1107 passed**, vitest **25 passed**, `tsc --noEmit` and `vite build` clean.
