### PR TITLE
feat(experiment): give the experiment environment a place to be configured

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -47,6 +47,7 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperWiki
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import VoyageRun
+from app.services import experiment_settings as experiment_settings_service
 from app.services import experiments as experiments_service
 from app.services import ssh_exec
 from app.services.figure_annotate import prepare_image_for_llm
@@ -283,20 +284,74 @@ def _prompt_with_context(base: str, ctx: ActionContext) -> str:
     return "".join(parts)
 
 
+def _env_facts_prompt(env_settings: dict[str, str]) -> str:
+    """把「实验设置」里的环境事实拼成一段提示词，附到 codegen 的 user prompt 后面。
+
+    没配任何一项就返回空串（不往提示词里塞噪声）。这段是**事实陈述**而非建议：模型
+    对目标机器一无所知，路径全靠猜，猜错的代价是整个 voyage 跑到冒烟才失败。
+    """
+    lines: list[str] = []
+    if env_settings.get("model_root"):
+        root = env_settings["model_root"]
+        lines.append(
+            f"- 本机模型都放在 {root} 下（也可用环境变量 $POLARIS_MODEL_ROOT）。"
+            f"引用本机模型必须用这个前缀的完整路径，如 {root.rstrip('/')}/Qwen/Qwen3-1.7B；"
+            "不要自己编造别的目录层级。"
+        )
+    if env_settings.get("dataset_root"):
+        root = env_settings["dataset_root"]
+        lines.append(f"- 本机数据集都放在 {root} 下（环境变量 $POLARIS_DATASET_ROOT）。")
+    if env_settings.get("pip_index_url"):
+        lines.append(
+            f"- pip 镜像源已由平台配好（PIP_INDEX_URL={env_settings['pip_index_url']}），"
+            "requirements.txt 里不要再写 -i/--index-url。"
+        )
+    if env_settings.get("hf_endpoint"):
+        lines.append(
+            f"- HF 端点已由平台配好（HF_ENDPOINT={env_settings['hf_endpoint']}），"
+            "代码里不要再改它。"
+        )
+    if not lines:
+        return ""
+    return "\n\n本机环境（平台实配，按此写代码，不要臆测）：\n" + "\n".join(lines)
+
+
 def _platform_env_files(
-    ctx: ActionContext, *, proxy_url: str | None = None, no_proxy_extra: str = ""
+    ctx: ActionContext,
+    *,
+    proxy_url: str | None = None,
+    no_proxy_extra: str = "",
+    env_settings: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """平台生成的 env.sh（固定内容，非 LLM 产物）：恒定导出 POLARIS_WORKDIR，
     hf_mirror 时追加 HF_ENDPOINT 镜像；服务器配置了出网代理时导出 http(s)_proxy，
-    并把内网 LLM 地址列入 no_proxy（评测 API 不走代理）。模板执行前会 source。"""
+    并把内网 LLM 地址列入 no_proxy（评测 API 不走代理）。模板执行前会 source。
+
+    ``env_settings`` 是「实验设置」里配的全局环境（管理端可改，见
+    services/experiment_settings）。这些值已在服务层过白名单校验，此处直接用：
+    pip 镜像与 HF 端点导出成环境变量，模型/数据集根目录也导出，方便生成代码引用。
+    """
+    settings = env_settings or {}
     lines = [
         "export POLARIS_WORKDIR=$(pwd)",
         # 有 venv 就激活：让 LLM 代码里的裸 `python` 落到 venv（很多主机只有 python3，
         # 裸机实验实测 LLM 反复写 `python` 且修复循环绕不开 exit 127；容器模式无 .venv 为 no-op）
         "[ -f .venv/bin/activate ] && . .venv/bin/activate",
     ]
-    if _params(ctx).get("hf_mirror"):
-        lines.append(f"export HF_ENDPOINT={HF_MIRROR_ENDPOINT}")
+    # 模型/数据集根目录：导出给生成代码用，省得它靠猜路径
+    if settings.get("model_root"):
+        lines.append(f"export POLARIS_MODEL_ROOT={settings['model_root']}")
+    if settings.get("dataset_root"):
+        lines.append(f"export POLARIS_DATASET_ROOT={settings['dataset_root']}")
+    # pip 镜像：装依赖慢/连不上官方源是实验起不来的常见原因，配了就全局生效
+    if settings.get("pip_index_url"):
+        lines.append(f"export PIP_INDEX_URL={settings['pip_index_url']}")
+    # HF 端点：设置里配的优先于 hf_mirror 参数的内置镜像
+    hf_endpoint = settings.get("hf_endpoint") or (
+        HF_MIRROR_ENDPOINT if _params(ctx).get("hf_mirror") else ""
+    )
+    if hf_endpoint:
+        lines.append(f"export HF_ENDPOINT={hf_endpoint}")
     if proxy_url:
         no_proxy = "localhost,127.0.0.1"
         if _params(ctx).get("hf_mirror"):
@@ -1062,11 +1117,18 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         experiment = await _get_experiment(session, ctx)
         await _set_status(ctx, session, experiment, "setup")
 
+        # 实验的全局环境设置（管理端「实验设置」里配）：模型/数据集位置、pip 镜像、
+        # HF 端点、代理。既写进 env.sh，也**作为事实写进 codegen 提示词**——模型不知道
+        # 这台机器上模型放在哪，只能照提示词里的例子猜。实测一次失败（voyage 6c5df454）
+        # 生成了 /hf/Qwen/Qwen3-1.7B，少了一层目录，冒烟直接起不来。
+        env_settings = await experiment_settings_service.get_settings(session)
+
         files = ctx.checkpoint.get("exp_files")
         if not isinstance(files, dict):  # 断点幂等：已生成的代码不重复调 LLM
             user_prompt = (
                 f"实验计划：{json.dumps(experiment.plan or {}, ensure_ascii=False)[:8000]}\n"
                 f"预算：{json.dumps(experiment.budget or {}, ensure_ascii=False)}"
+                f"{_env_facts_prompt(env_settings)}"
             )
             files = await _complete_json(
                 ctx,
@@ -1088,8 +1150,15 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
             )
 
         executor = await _open_executor(session, ctx, experiment)
+        # 代理优先用凭据上配的（那是「这台机器」的属性），没配才回落到全局实验设置
+        proxy_url = executor.proxy_url or env_settings.get("proxy_url") or None
         platform_files = (
-            _platform_env_files(ctx, proxy_url=executor.proxy_url, no_proxy_extra=llm_host)
+            _platform_env_files(
+                ctx,
+                proxy_url=proxy_url,
+                no_proxy_extra=llm_host,
+                env_settings=env_settings,
+            )
             | eval_files
         )
         try:

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -12,12 +12,14 @@ from app.schemas.admin_settings import (
     EmbeddingSpaceAdoptResult,
     EmbeddingSpaceItem,
     EmbeddingSpaceStatus,
+    ExperimentEnvSettings,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
 )
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
 from app.services import embedding as embedding_service
+from app.services import experiment_settings as experiment_settings_service
 from app.services import lab as lab_service
 
 router = APIRouter(
@@ -128,3 +130,27 @@ async def set_lab_leaderboard(
     return LabLeaderboardSettingRead(
         enabled=await lab_service.set_leaderboard_enabled(session, payload.enabled)
     )
+
+
+@router.get("/experiment-env", response_model=ExperimentEnvSettings)
+async def get_experiment_env(
+    session: AsyncSession = Depends(get_session),
+) -> ExperimentEnvSettings:
+    """实验的全局环境设置（模型/数据集位置、pip 镜像、HF 端点、代理）。"""
+    return ExperimentEnvSettings(**await experiment_settings_service.get_settings(session))
+
+
+@router.put("/experiment-env", response_model=ExperimentEnvSettings)
+async def set_experiment_env(
+    payload: ExperimentEnvSettings,
+    session: AsyncSession = Depends(get_session),
+) -> ExperimentEnvSettings:
+    """整份覆盖写入。字段非法（会拼进远端 shell 的路径/URL）→ 422，带上是哪个字段。"""
+    try:
+        saved = await experiment_settings_service.set_settings(session, payload.model_dump())
+    except experiment_settings_service.InvalidExperimentSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_EXPERIMENT_SETTING:{exc.field}",
+        ) from exc
+    return ExperimentEnvSettings(**saved)

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -64,3 +64,17 @@ class EmbeddingSpaceAdoptResult(BaseModel):
 
     active: EmbeddingSpaceItem
     previous: str | None = None
+
+
+class ExperimentEnvSettings(BaseModel):
+    """实验的全局环境设置（所有实验共用一份）。
+
+    空字符串 = 不配置该项，各自走兜底行为（不配 pip 镜像就用官方源，等等）。
+    路径/URL 会拼进远端 shell，服务层做白名单校验，非法值直接拒收。
+    """
+
+    model_root: str = ""  # 本机模型根目录，如 /hf/model
+    dataset_root: str = ""  # 本机数据集根目录
+    pip_index_url: str = ""  # pip 镜像源
+    hf_endpoint: str = ""  # HF 镜像端点，如 https://hf-mirror.com
+    proxy_url: str = ""  # 实验机出外网的 HTTP 代理

--- a/src/backend/app/services/experiment_settings.py
+++ b/src/backend/app/services/experiment_settings.py
@@ -1,0 +1,92 @@
+"""实验的全局设置（system_settings 里一个 key 存一份，所有实验共用）。
+
+为什么做成全局一份而不是挂在 SSH 凭据上：模型/数据集放哪、用哪个 pip 镜像，实验室里
+是统一约定的，一处配好处处生效比每台机器各填一遍省事，也不会漏配。机器之间真有差异
+时再谈按机器覆盖（凭据上已有 proxy_url 是那条路的先例）。
+
+**这些值会拼进远端 shell 的 export**，所以每个字段都必须过白名单校验——校验失败即拒收，
+绝不把没校验过的字符串写进 env.sh。
+"""
+
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system_setting import SystemSetting
+
+SETTING_KEY = "experiment_env"
+
+# 主机路径：绝对或 ~ 开头，禁 shell 元字符与 ..（与 ssh_exec.validate_host_path 同口径）
+_PATH_RE = re.compile(r"^[~/][A-Za-z0-9._/~@-]*$")
+# http(s) URL；允许带路径（pip 镜像形如 https://pypi.tuna.tsinghua.edu.cn/simple）
+_URL_RE = re.compile(r"^https?://[A-Za-z0-9.\-]+(:\d+)?(/[A-Za-z0-9._~/\-]*)?$")
+
+
+class InvalidExperimentSettingError(ValueError):
+    """某个字段没过校验。``field`` 指出是哪一个，便于前端定位。"""
+
+    def __init__(self, field: str, value: str) -> None:
+        super().__init__(f"{field}={value!r}")
+        self.field = field
+        self.value = value
+
+
+#: 字段 → 校验正则。留空一律合法（= 不配置该项，走各自的兜底行为）。
+_FIELDS: dict[str, re.Pattern[str]] = {
+    "model_root": _PATH_RE,  # 本机模型根目录，如 /hf/model
+    "dataset_root": _PATH_RE,  # 本机数据集根目录
+    "pip_index_url": _URL_RE,  # pip 镜像源
+    "hf_endpoint": _URL_RE,  # HF 镜像端点，如 https://hf-mirror.com
+    "proxy_url": _URL_RE,  # 实验机出外网的 HTTP 代理
+}
+
+DEFAULTS: dict[str, str] = {
+    "model_root": "",
+    "dataset_root": "",
+    "pip_index_url": "",
+    "hf_endpoint": "",
+    "proxy_url": "",
+}
+
+
+def _clean(data: Any) -> dict[str, str]:
+    """把存量/入参规范成「只含已知字段的字符串字典」，未知键丢弃。"""
+    out = dict(DEFAULTS)
+    if isinstance(data, dict):
+        for field in _FIELDS:
+            raw = data.get(field)
+            if raw is None:
+                continue
+            out[field] = str(raw).strip()
+    return out
+
+
+def validate(data: Any) -> dict[str, str]:
+    """校验并规范化。空值 = 不配置，合法；非空则必须过该字段的白名单。"""
+    cleaned = _clean(data)
+    for field, pattern in _FIELDS.items():
+        value = cleaned[field]
+        if value and not pattern.match(value):
+            raise InvalidExperimentSettingError(field, value)
+        if value and ".." in value:  # 路径穿越，正则允许 . 但不该出现 ..
+            raise InvalidExperimentSettingError(field, value)
+    return cleaned
+
+
+async def get_settings(session: AsyncSession) -> dict[str, str]:
+    """读当前实验设置；没配过或存量值损坏都回落默认（空），绝不抛。"""
+    row = await session.get(SystemSetting, SETTING_KEY)
+    return _clean(row.value if row is not None else None)
+
+
+async def set_settings(session: AsyncSession, data: Any) -> dict[str, str]:
+    """校验后整份覆盖写入。字段非法抛 InvalidExperimentSettingError。"""
+    cleaned = validate(data)
+    row = await session.get(SystemSetting, SETTING_KEY)
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=cleaned))
+    else:
+        row.value = cleaned
+    await session.commit()
+    return cleaned

--- a/src/backend/tests/test_experiment_settings.py
+++ b/src/backend/tests/test_experiment_settings.py
@@ -1,0 +1,84 @@
+"""实验全局设置：字段校验 + 注入 env.sh / codegen 提示词。"""
+
+import pytest
+
+from app.agents.voyage import actions_experiment as ax
+from app.services import experiment_settings as es
+
+
+def test_validate_accepts_empty_and_normalizes_unknown_keys():
+    """空值 = 不配置，合法；未知键丢弃，不让它混进 env.sh。"""
+    assert es.validate({}) == es.DEFAULTS
+    out = es.validate({"model_root": " /hf/model ", "不认识的键": "x"})
+    assert out["model_root"] == "/hf/model"  # 顺手去掉首尾空白
+    assert "不认识的键" not in out
+
+
+def test_validate_rejects_shell_injection_and_traversal():
+    """这些值会拼进远端 shell 的 export，非法字符必须挡在服务层。"""
+    for bad in ("/hf/model; rm -rf /", "/hf/$(whoami)", "/hf/model && curl evil", "relative/path"):
+        with pytest.raises(es.InvalidExperimentSettingError) as exc:
+            es.validate({"model_root": bad})
+        assert exc.value.field == "model_root"  # 报错要指出是哪个字段
+    with pytest.raises(es.InvalidExperimentSettingError):
+        es.validate({"model_root": "/hf/../etc"})  # 路径穿越
+    for bad_url in ("ftp://x/y", "javascript:alert(1)", "https://pypi.org/simple; rm -rf /"):
+        with pytest.raises(es.InvalidExperimentSettingError):
+            es.validate({"pip_index_url": bad_url})
+
+
+def test_validate_accepts_real_values():
+    ok = es.validate(
+        {
+            "model_root": "/hf/model",
+            "dataset_root": "~/data",
+            "pip_index_url": "https://pypi.tuna.tsinghua.edu.cn/simple",
+            "hf_endpoint": "https://hf-mirror.com",
+            "proxy_url": "http://10.205.2.46:7899",
+        }
+    )
+    assert ok["model_root"] == "/hf/model"
+    assert ok["pip_index_url"].endswith("/simple")
+
+
+class _Ctx:
+    """_platform_env_files 只用到 ctx 的 params，给个最小替身。"""
+
+    def __init__(self, params: dict | None = None) -> None:
+        self.run = type("R", (), {"checkpoint": {"params": params or {}}})()
+        self.checkpoint = {"params": params or {}}
+
+
+def test_env_sh_exports_configured_values():
+    env = ax._platform_env_files(
+        _Ctx(),
+        proxy_url="http://10.205.2.46:7899",
+        env_settings={
+            "model_root": "/hf/model",
+            "dataset_root": "/data",
+            "pip_index_url": "https://pypi.tuna.tsinghua.edu.cn/simple",
+            "hf_endpoint": "https://hf-mirror.com",
+            "proxy_url": "",
+        },
+    )["env.sh"]
+    assert "export POLARIS_MODEL_ROOT=/hf/model" in env
+    assert "export POLARIS_DATASET_ROOT=/data" in env
+    assert "export PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple" in env
+    assert "export HF_ENDPOINT=https://hf-mirror.com" in env
+    assert "http_proxy=http://10.205.2.46:7899" in env
+
+
+def test_env_sh_omits_unconfigured_values():
+    """没配的项一行都不写——env.sh 里不该出现空值导出。"""
+    env = ax._platform_env_files(_Ctx(), env_settings=dict(es.DEFAULTS))["env.sh"]
+    for key in ("POLARIS_MODEL_ROOT", "POLARIS_DATASET_ROOT", "PIP_INDEX_URL", "HF_ENDPOINT"):
+        assert key not in env
+    assert "export POLARIS_WORKDIR=$(pwd)" in env  # 恒定项还在
+
+
+def test_codegen_prompt_states_model_root_as_fact():
+    """模型路径必须作为事实进提示词——6c5df454 就是靠猜路径猜错才失败的。"""
+    facts = ax._env_facts_prompt({"model_root": "/hf/model"})
+    assert "/hf/model" in facts
+    assert "/hf/model/Qwen/Qwen3-1.7B" in facts  # 给出完整示例，别让它少一层
+    assert ax._env_facts_prompt(dict(es.DEFAULTS)) == ""  # 没配就不塞噪声

--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
+import { ExperimentSettings } from './ExperimentSettings';
 import { FeedbackTab } from '../feedback/FeedbackTab';
 import { tr } from '../../lib/i18n';
 import { api, isAdmin } from '../../lib/api';
@@ -14,9 +15,9 @@ import { CodesTab, DailyCategoriesTab, LlmTab, UsageTab, UsersTab } from './Sett
    各标签页组件仍住在 SettingsPage.tsx（与个人设置共用一批内部小组件），这里只负责壳层。
    ============================================================ */
 
-type AdminTab = 'llm' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
+type AdminTab = 'llm' | 'experiment' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
 
-const ADMIN_TABS: AdminTab[] = ['llm', 'daily', 'users', 'codes', 'feedback', 'usage'];
+const ADMIN_TABS: AdminTab[] = ['llm', 'experiment', 'daily', 'users', 'codes', 'feedback', 'usage'];
 
 export function AdminSettingsPage() {
   const { data: me, isLoading } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
@@ -30,6 +31,7 @@ export function AdminSettingsPage() {
 
   const items: { v: AdminTab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
+    { v: 'experiment', label: tr('实验设置', 'Experiments') },
     { v: 'daily', label: tr('每日论文', 'Daily papers') },
     { v: 'users', label: tr('用户管理', 'Users') },
     { v: 'codes', label: tr('注册码', 'Codes') },
@@ -55,6 +57,7 @@ export function AdminSettingsPage() {
             <Segmented options={items} value={tab} onChange={setTab} />
           </div>
           {tab === 'llm' && <LlmTab />}
+          {tab === 'experiment' && <ExperimentSettings />}
           {tab === 'daily' && <DailyCategoriesTab />}
           {tab === 'users' && <UsersTab />}
           {tab === 'codes' && <CodesTab />}

--- a/src/frontend/src/features/settings/ExperimentSettings.tsx
+++ b/src/frontend/src/features/settings/ExperimentSettings.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { FormField } from '../../components/ui/FormField';
+import { toast } from '../../components/ui/Toast';
+import { ApiError, api, type ExperimentEnvSettings } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   实验设置（admin，全局一份，所有实验共用）
+
+   实验跑在别的机器上，平台并不知道那台机器长什么样——模型放在哪、有没有 pip 镜像、
+   要不要走代理。以前这些只能靠提示词里的例子让模型去猜，猜错的代价是整个任务跑到
+   冒烟测试才失败。这里配一次，之后写进每个实验的 env.sh，并作为**事实**进代码生成
+   的提示词。
+   ============================================================ */
+
+const EMPTY: ExperimentEnvSettings = {
+  model_root: '',
+  dataset_root: '',
+  pip_index_url: '',
+  hf_endpoint: '',
+  proxy_url: '',
+};
+
+/** 后端 422 的 detail 形如 INVALID_EXPERIMENT_SETTING:model_root，取出字段名。 */
+function invalidField(e: unknown): string | null {
+  if (e instanceof ApiError && e.message.startsWith('INVALID_EXPERIMENT_SETTING:')) {
+    return e.message.split(':')[1] ?? null;
+  }
+  return null;
+}
+
+const FIELDS: {
+  key: keyof ExperimentEnvSettings;
+  zh: string;
+  en: string;
+  placeholder: string;
+  hintZh: string;
+  hintEn: string;
+}[] = [
+  {
+    key: 'model_root',
+    zh: '模型位置',
+    en: 'Model root',
+    placeholder: '/hf/model',
+    hintZh: '实验机上本地模型的存放根目录。填了之后，生成的代码会按这个前缀引用模型，不再靠猜路径。',
+    hintEn: 'Where local models live on the experiment host. Generated code references models under this prefix instead of guessing.',
+  },
+  {
+    key: 'dataset_root',
+    zh: '数据集位置',
+    en: 'Dataset root',
+    placeholder: '/hf/dataset',
+    hintZh: '实验机上本地数据集的存放根目录。',
+    hintEn: 'Where local datasets live on the experiment host.',
+  },
+  {
+    key: 'pip_index_url',
+    zh: 'pip 镜像源',
+    en: 'pip index URL',
+    placeholder: 'https://pypi.tuna.tsinghua.edu.cn/simple',
+    hintZh: '装依赖走这个源。连不上官方源是实验起不来的常见原因，建议配上。',
+    hintEn: 'Dependency installs use this index. Unreachable upstream PyPI is a common reason experiments fail to start.',
+  },
+  {
+    key: 'hf_endpoint',
+    zh: 'HF 端点',
+    en: 'HF endpoint',
+    placeholder: 'https://hf-mirror.com',
+    hintZh: '从 HuggingFace 拉模型/数据集时用的地址。',
+    hintEn: 'Endpoint used when pulling models or datasets from HuggingFace.',
+  },
+  {
+    key: 'proxy_url',
+    zh: '出网代理',
+    en: 'Outbound proxy',
+    placeholder: 'http://10.205.2.46:7899',
+    hintZh: '实验机出外网用的 HTTP 代理。某台机器在 SSH 凭据里单独配了代理的，以凭据为准。',
+    hintEn: 'HTTP proxy for the experiment host. A proxy set on an individual SSH credential takes precedence.',
+  },
+];
+
+export function ExperimentSettings() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['experiment-env'],
+    queryFn: () => api.getExperimentEnv(),
+    retry: false,
+  });
+
+  // 本地编辑副本：首次拿到数据后接管，避免 refetch 覆盖未保存的改动
+  const [draft, setDraft] = useState<ExperimentEnvSettings | null>(null);
+  const [badField, setBadField] = useState<string | null>(null);
+  useEffect(() => {
+    if (data && draft === null) setDraft({ ...EMPTY, ...data });
+  }, [data, draft]);
+
+  const shown = draft ?? data ?? EMPTY;
+  const dirty = !!data && JSON.stringify(shown) !== JSON.stringify({ ...EMPTY, ...data });
+
+  const saveMutation = useMutation({
+    mutationFn: () => api.setExperimentEnv(shown),
+    onSuccess: (saved) => {
+      setBadField(null);
+      setDraft({ ...EMPTY, ...saved });
+      queryClient.setQueryData(['experiment-env'], saved);
+      toast(tr('实验设置已保存', 'Experiment settings saved'), 'ok');
+    },
+    onError: (e) => {
+      const field = invalidField(e);
+      setBadField(field);
+      toast(
+        field
+          ? tr(`「${labelOf(field)}」格式不对，没保存`, `Invalid ${field} — nothing saved`)
+          : `${tr('保存失败', 'Save failed')}：${e instanceof Error ? e.message : String(e)}`,
+        'error',
+      );
+    },
+  });
+
+  if (isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (isError) {
+    return (
+      <div className="empty">
+        {tr('无法加载实验设置（后端不可用）', 'Failed to load experiment settings (backend unavailable)')}
+        <div style={{ marginTop: 10 }}>
+          <button className="btn btn-soft sm" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card card-pad">
+      <div className="section-h" style={{ marginBottom: 4 }}>
+        <Icon name="flask" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('实验环境', 'Experiment environment')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6, marginBottom: 16 }}>
+        {tr(
+          '所有实验共用这一份。实验跑在别的机器上，平台不知道那台机器长什么样——配在这里之后，这些会写进每个实验的启动环境，也会作为事实告诉写代码的模型，省得它猜错路径把整个任务跑废。留空表示不配置。',
+          'Shared by every experiment. Experiments run on another machine that the platform knows nothing about — what you set here is written into each run’s environment and stated as fact to the model that writes the code, so it does not guess a wrong path and waste the whole run. Leave a field empty to skip it.',
+        )}
+      </div>
+
+      <div className="settings-fields">
+        {FIELDS.map((f) => (
+          <FormField
+            key={f.key}
+            label={tr(f.zh, f.en)}
+            hint={tr(f.hintZh, f.hintEn)}
+            error={badField === f.key ? tr('格式不对', 'Invalid format') : null}
+          >
+            <input
+              className="input mono"
+              value={shown[f.key]}
+              placeholder={f.placeholder}
+              spellCheck={false}
+              autoComplete="off"
+              onChange={(e) => {
+                setBadField(null);
+                setDraft({ ...shown, [f.key]: e.target.value });
+              }}
+            />
+          </FormField>
+        ))}
+      </div>
+
+      <div className="row" style={{ justifyContent: 'flex-end', marginTop: 6 }}>
+        <button
+          className="btn btn-primary"
+          disabled={!dirty || saveMutation.isPending}
+          onClick={() => saveMutation.mutate()}
+        >
+          {saveMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function labelOf(field: string): string {
+  return FIELDS.find((f) => f.key === field)?.zh ?? field;
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1288,6 +1288,20 @@ export interface LabLeaderboardSetting {
   enabled: boolean;
 }
 
+/** 实验的全局环境设置（所有实验共用一份）。空串 = 不配置该项。 */
+export interface ExperimentEnvSettings {
+  /** 本机模型根目录，如 /hf/model */
+  model_root: string;
+  /** 本机数据集根目录 */
+  dataset_root: string;
+  /** pip 镜像源 */
+  pip_index_url: string;
+  /** HF 镜像端点，如 https://hf-mirror.com */
+  hf_endpoint: string;
+  /** 实验机出外网的 HTTP 代理（凭据上单独配了的以凭据为准） */
+  proxy_url: string;
+}
+
 // ============================================================
 // M2 · Ingest（冷启动 / 增量同步，复用 Voyage）
 // ============================================================
@@ -4241,6 +4255,13 @@ export const api = {
   },
   setLabLeaderboardEnabled(enabled: boolean): Promise<LabLeaderboardSetting> {
     return requestJson<LabLeaderboardSetting>('/admin/settings/lab-leaderboard', 'PUT', { enabled });
+  },
+  /** 实验的全局环境设置（admin）：模型/数据集位置、pip 镜像、HF 端点、代理。 */
+  getExperimentEnv(): Promise<ExperimentEnvSettings> {
+    return request<ExperimentEnvSettings>('/admin/settings/experiment-env');
+  },
+  setExperimentEnv(payload: ExperimentEnvSettings): Promise<ExperimentEnvSettings> {
+    return requestJson<ExperimentEnvSettings>('/admin/settings/experiment-env', 'PUT', payload);
   },
   /** 给最近 7 天里还没有向量的每日论文补建向量（可能耗时几十秒）。 */
   backfillDailyEmbeddings(): Promise<DailyEmbedBackfillResult> {


### PR DESCRIPTION
Closes #283

Adds a global **Experiment settings** section (`/admin?tab=experiment`) so the platform stops guessing what the experiment host looks like.

## Why

Experiments run on a machine the platform knows nothing about. Where models live, which pip mirror to use, whether traffic needs a proxy — none of it had anywhere to be configured, so the model writing the code guessed, and a wrong guess only surfaced when the smoke test failed and the voyage was declared dead.

Voyage `6c5df454-…` referenced `/hf/Qwen/Qwen3-1.7B`; models actually live under `/hf/model/`, so transformers fell back to repo-id validation and the run died with `OSError: Can't load the configuration of '/hf/Qwen/Qwen3-1.7B'`. The only hint in the prompt was an example — `~/hf/model/...` — which does not match the real layout either. A separate failure was a dependency install timing out with no pip mirror configured for experiment hosts.

## What it does

Five fields, stored as one row in the existing `system_settings` KV table (**no migration**): model root, dataset root, pip index URL, HF endpoint, outbound proxy.

They take effect in two places:

1. **`env.sh` of every run** — `POLARIS_MODEL_ROOT`, `POLARIS_DATASET_ROOT`, `PIP_INDEX_URL`, `HF_ENDPOINT`. Unset fields emit no line at all.
2. **The code-generation prompt** — stated as fact, with a full worked path (`/hf/model/Qwen/Qwen3-1.7B`) so the model copies rather than invents. Nothing is added to the prompt when nothing is configured.

## Design notes

**Global rather than per-machine.** The lab's layout is a shared convention; configure once, applies everywhere. A proxy set on an individual SSH credential still wins, because that genuinely is a per-machine property — `executor.proxy_url or settings.proxy_url`.

**Every field is whitelist-validated server-side.** These strings end up inside an `export` on the remote host. Invalid input is rejected with the offending field name (`INVALID_EXPERIMENT_SETTING:<field>`), and the UI marks that input red rather than showing a generic toast.

## Verification

- 6 new tests: injection attempts (`;`, `&&`, `$()`), path traversal, empty-means-unset, exports present/absent in `env.sh`, and that the model root reaches the prompt with a full example.
- `pytest tests/test_experiments.py tests/test_experiment_settings.py` — 34 passed.
- Frontend typechecks clean. (`tsc` on the full tree also reports three pre-existing `Cannot find module 'vitest'` errors — vitest arrived in 08a55a6 and is simply not installed in the shared `node_modules` I linked against; unrelated to this change.)

## Follow-up

This gives the harness the facts. Still open from the same investigation: routing smoke failures by cause instead of the blanket `on_failure="fail"`, so an environment mismatch can self-correct rather than requiring a human.