### PR TITLE
fix(experiment): one NaN metric should not take the whole round down

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -27,6 +27,7 @@ import asyncio
 import contextlib
 import functools
 import json
+import math
 import re
 import uuid
 from datetime import UTC, datetime
@@ -846,8 +847,30 @@ def validate_plot_files(data: Any) -> dict[str, str]:
 # ---- 指标解析 ----
 
 
+def _is_storable_number(value: Any) -> bool:
+    """能不能落库：必须是有限的数（NaN / ±Infinity 一律不收）。
+
+    实验算出 NaN 是家常便饭（某个条件下指标无定义、除零、空集求均值）。但 Python 的
+    ``json.loads`` **默认接受裸 NaN/Infinity 词元**，``json.dumps`` 也照原样吐出来——
+    而它们都不是合法 JSON，写进 JSONB 时 Postgres 直接拒收：
+
+        asyncpg.exceptions.InvalidTextRepresentationError:
+        invalid input syntax for type json  DETAIL: Token "NaN" is invalid.
+
+    实测（voyage 6c5df454 第 1 轮运行）：实验跑完了、指标也产出了，就因为其中一项是
+    NaN，整条 UPDATE 失败，这一轮判死。一个无定义的指标点本来就不承载信息，丢掉它
+    远比让整轮成果陪葬合理。bool 是 int 的子类，也在这里挡掉。
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return False
+    return math.isfinite(value)
+
+
 def parse_metric_lines(text: str) -> list[dict[str, Any]]:
-    """解析日志中的 ``POLARIS_METRIC {json}`` 行 → [{name, step, value}]。"""
+    """解析日志中的 ``POLARIS_METRIC {json}`` 行 → [{name, step, value}]。
+
+    非有限值（NaN/Inf）跳过——它们进不了 JSONB，见 :func:`_is_storable_number`。
+    """
     points: list[dict[str, Any]] = []
     for line in text.splitlines():
         m = METRIC_LINE_RE.search(line)
@@ -859,7 +882,7 @@ def parse_metric_lines(text: str) -> list[dict[str, Any]]:
             continue
         name = data.get("name") if isinstance(data, dict) else None
         value = data.get("value") if isinstance(data, dict) else None
-        if not isinstance(name, str) or not isinstance(value, int | float):
+        if not isinstance(name, str) or not _is_storable_number(value):
             continue
         step = data.get("step")
         points.append(
@@ -887,14 +910,14 @@ def parse_metrics_json(text: str) -> list[dict[str, Any]]:
     for name, value in data.items():
         if not isinstance(name, str):
             continue
-        if isinstance(value, int | float) and not isinstance(value, bool):
+        if _is_storable_number(value):
             points.append({"name": name, "step": None, "value": float(value)})
         elif isinstance(value, list):
             for item in value:
                 if not isinstance(item, dict):
                     continue
                 v = item.get("value")
-                if not isinstance(v, int | float) or isinstance(v, bool):
+                if not _is_storable_number(v):
                     continue
                 step = item.get("step")
                 points.append(

--- a/src/backend/tests/test_experiment_settings.py
+++ b/src/backend/tests/test_experiment_settings.py
@@ -125,3 +125,37 @@ def test_diagnose_stays_silent_when_unsure():
     """认不出就返回空串——宁可不提示，也不能给条误导的诊断。"""
     assert ax.diagnose_failure("Traceback: some entirely novel failure", {}) == ""
     assert ax.diagnose_failure("", {}) == ""
+
+
+# ---- 指标里的 NaN/Inf 不能进 JSONB（voyage 6c5df454 第 1 轮运行的真实故障）----
+
+
+def test_metric_lines_drop_non_finite_values():
+    """NaN/Inf 必须在解析阶段丢掉：它们不是合法 JSON，进 JSONB 会被 Postgres 拒收，
+    连累整轮运行判死。样本取自 6c5df454 实际产出的指标名。"""
+    log = (
+        'POLARIS_METRIC {"name": "accuracy/Qwen3-1.7B/baseline", "step": 1, "value": 0.5}\n'
+        'POLARIS_METRIC {"name": "consistency/Qwen3-1.7B/baseline", "step": 1, "value": NaN}\n'
+        'POLARIS_METRIC {"name": "ratio", "step": 1, "value": Infinity}\n'
+        'POLARIS_METRIC {"name": "neg", "step": 1, "value": -Infinity}\n'
+    )
+    points = ax.parse_metric_lines(log)
+    names = [p["name"] for p in points]
+    assert names == ["accuracy/Qwen3-1.7B/baseline"]  # 只留有限值，其余整点丢弃
+
+    # 关键断言：结果必须能被严格 JSON 序列化（allow_nan=False 即 Postgres 的口径）
+    import json as _json
+
+    _json.dumps(points, allow_nan=False)
+
+
+def test_metrics_json_drops_non_finite_values():
+    """metrics.json 两种形态（裸数值 / 点列表）都要过滤。"""
+    points = ax.parse_metrics_json(
+        '{"good": 1.5, "bad": NaN, "series": [{"step": 1, "value": 2.0},'
+        ' {"step": 2, "value": NaN}], "flag": true}'
+    )
+    assert [(p["name"], p["value"]) for p in points] == [("good", 1.5), ("series", 2.0)]
+    import json as _json
+
+    _json.dumps(points, allow_nan=False)  # bool 也被挡掉，不会混进指标


### PR DESCRIPTION
Closes #287

Found by re-running voyage `6c5df454-…` after the previous three harness fixes shipped.

## Progress first

The smoke step **passed** — it had been stuck there for two days across three attempts. The voyage moved on to the first round, ran it, and produced metrics. So the earlier work (syntax pre-check, experiment settings, failure diagnosis) did its job.

Then it died writing those metrics:

```
asyncpg.exceptions.InvalidTextRepresentationError: invalid input syntax for type json
DETAIL:  Token "NaN" is invalid.
parameters: {"accuracy/Qwen3-1.7B/baseline": [{"step": 1, "value": 0.5}],
             "consistency/Qwen3-1.7B/baseline": [{"step": 1, "value": NaN}],
             "evolution/rounds": [{"step": 1, "value": 1.0}]}
```

Two real numbers and one `NaN`. That single point took the whole round with it.

## Cause

`parse_metric_lines()` and `parse_metrics_json()` accept anything passing `isinstance(value, int | float)` — and `NaN`/`Infinity` are floats.

They reach that check because Python's `json.loads` accepts bare `NaN` / `Infinity` / `-Infinity` tokens by default, and `json.dumps` emits them unchanged. Neither is valid JSON, so Postgres rejects the entire `UPDATE` once the value hits a JSONB column.

## Fix

Filter non-finite values at parse time in both parsers via `math.isfinite`, in one shared helper. `bool` is filtered there too — it is a subclass of `int` and was previously only excluded in one of the two functions.

An undefined metric point (division by zero, mean of an empty set, consistency over a single sample) carries no information. Dropping it is far better than discarding a round of results that otherwise succeeded.

## Verification

- Tests use the real metric names from `6c5df454` and cover `NaN`, `Infinity`, `-Infinity` across both parser entry points and both `metrics.json` shapes.
- Each asserts the result survives `json.dumps(..., allow_nan=False)` — the same standard Postgres applies.
- `pytest tests/test_experiments.py tests/test_experiment_settings.py` — 40 passed.