### PR TITLE
fix(assistant): stop turns dying on serialisation, render figures, and make memory two gated actions

### DIFF
--- a/src/backend/alembic/versions/d4e8b19c7a55_memory_kind.py
+++ b/src/backend/alembic/versions/d4e8b19c7a55_memory_kind.py
@@ -1,0 +1,28 @@
+"""buddy memory kind
+
+Revision ID: d4e8b19c7a55
+Revises: 07e7faea4c7a
+Create Date: 2026-08-05
+
+记忆分两层：fact（每轮带上的稳定事实）与 note（带时间戳的片段，检索到才回上下文）。
+存量行按 fact 处理——它们本来就是用户手写的、希望一直生效的那种。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4e8b19c7a55"
+down_revision: str | None = "07e7faea4c7a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "buddy_memories",
+        sa.Column("kind", sa.String(length=16), nullable=False, server_default="fact"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("buddy_memories", "kind")

--- a/src/backend/app/agents/chat/core/helm.py
+++ b/src/backend/app/agents/chat/core/helm.py
@@ -85,9 +85,21 @@ class Helm:
             logger.warning("chat agent: tool %s failed", call.name, exc_info=True)
             return self._failure(call, {"error": f"{type(e).__name__}: {e}"}, started)
 
-        payload = result_payload(result)
-        images = result_images(result)
-        text = json.dumps(payload, ensure_ascii=False)[:RESULT_CHARS]
+        # 序列化也在 try 里：这一步同样会炸。生产上就是这么断的——get_project_status
+        # 的返回里带 datetime，json.dumps 抛 TypeError，而那行当时在 try 之外，于是异常
+        # 穿出循环、带走 SSE 连接，用户只看到一句「network error」。**「异常绝不外抛」
+        # 必须覆盖到把结果交出去为止**，否则这条保证在最后一米失效。
+        try:
+            payload = result_payload(result)
+            images = result_images(result)
+            # default=str：工具的返回里有 datetime / UUID / Decimal 是常态，不该由每个
+            # 工具各自记得转成字符串——漏一个就是一次断流。
+            text = json.dumps(payload, ensure_ascii=False, default=str)[:RESULT_CHARS]
+        except Exception as e:  # noqa: BLE001
+            logger.warning("chat agent: tool %s result not serializable", call.name, exc_info=True)
+            return self._failure(
+                call, {"error": f"结果无法序列化：{type(e).__name__}: {e}"}, started
+            )
         return (
             ToolResultEvent(
                 id=call.id,
@@ -107,7 +119,7 @@ class Helm:
     def _failure(
         self, call: ToolUseBlock, payload: dict[str, Any], started: float
     ) -> tuple[ToolResultEvent, ToolResultBlock]:
-        text = json.dumps(payload, ensure_ascii=False)
+        text = json.dumps(payload, ensure_ascii=False, default=str)
         return (
             ToolResultEvent(
                 id=call.id,

--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -146,10 +146,18 @@ class ChatAgentLoop:
             ),
         ]
         state = _RoundState()
+        # model 报**解析出来的真实模型**，不是 stage 名。界面上「这轮用的是谁」得是
+        # 用户能对得上账单的那个名字，"agent" 不是。
+        resolved_model = self._stage
+        try:
+            _, route = await self._llm.resolve(self._stage, self._tool_ctx.user_id)
+            resolved_model = route.model or self._stage
+        except Exception:  # noqa: BLE001 — 取不到就退回 stage 名，不值得为它中断一轮
+            pass
         yield MetaEvent(
             conversation_id=str(req.conversation_id),
             message_id="",
-            model=self._stage,
+            model=resolved_model,
             tools=tuple(req.tool_names),
         )
 

--- a/src/backend/app/agents/chat/prompt.py
+++ b/src/backend/app/agents/chat/prompt.py
@@ -26,17 +26,28 @@ from app.tools.registry import list_tools
 _TOOL_DENYLIST = frozenset({"get_fact_pack"})
 
 
-def default_tool_names() -> tuple[str, ...]:
+def default_tool_names(*, memory_enabled: bool = False) -> tuple[str, ...]:
     """这一轮默认给哪些工具：注册表里全部只读的，减去 denylist。
 
     动态取而不是写死一份名单：新工具加进注册表就自动可用。写死名单的问题不是麻烦，
     而是**没人会记得回来加**——助手会悄悄少一项能力，而界面上看不出任何异常。
     """
+    from app.tools.memory import MEMORY_TOOL_NAMES
     from app.tools.registry import list_tools
 
-    return tuple(
-        spec.name for spec in list_tools() if spec.read_only and spec.name not in _TOOL_DENYLIST
-    )
+    names = []
+    for spec in list_tools():
+        if spec.name in _TOOL_DENYLIST:
+            continue
+        if spec.name in MEMORY_TOOL_NAMES:
+            # 记忆没打开时这两个工具根本不进工具面：模型不知道有这回事，
+            # 也就不会假装记住——「我记下了」而其实没存，比不能记更糟。
+            if memory_enabled:
+                names.append(spec.name)
+            continue
+        if spec.read_only:
+            names.append(spec.name)
+    return tuple(names)
 
 
 #: 兼容旧引用（测试与 API 都在用这个名字）。求值时机在 import 之后，工具已注册完毕。

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -32,11 +32,11 @@ from app.agents.chat.events import (
     VerifyEvent,
 )
 from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
-from app.agents.chat.prompt import DEFAULT_TOOL_NAMES
+from app.agents.chat.prompt import default_tool_names
 from app.api.auth import current_active_user, require_llm_chat
 from app.core.config import get_settings
 from app.core.db import get_session
-from app.core.llm.base import TextBlock
+from app.core.llm.base import TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock
 from app.core.llm.router import get_llm_router
 from app.models.user import User
 from app.schemas.chat_agent import (
@@ -45,6 +45,7 @@ from app.schemas.chat_agent import (
     ConversationRenameRequest,
     ConversationTurnRequest,
     MemoryCreate,
+    MemoryToggle,
     MessageRead,
     SkillImportRequest,
 )
@@ -270,7 +271,7 @@ async def add_memory(
     """记一条。**只有用户能写**——agent 自己往里写属于写工具那一期，
     一个能改自己记忆的助手必须和权限模型、审批一起设计。"""
     _require_enabled()
-    row = await buddy.add_memory(session, user_id=user.id, text=payload.text)
+    row = await buddy.add_memory(session, user_id=user.id, text=payload.text, kind=payload.kind)
     return {"id": str(row.id), "text": row.text, "created_at": row.created_at.isoformat()}
 
 
@@ -283,6 +284,17 @@ async def delete_memory(
     _require_enabled()
     if not await buddy.delete_memory(session, user_id=user.id, memory_id=memory_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="MEMORY_NOT_FOUND")
+
+
+@router.put("/memory/enabled")
+async def set_memory_enabled(
+    payload: MemoryToggle,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, bool]:
+    """开/关记忆。**默认关**：一个会自己记东西的助手，得由用户先说「可以」。"""
+    _require_enabled()
+    return {"enabled": await buddy.set_memory_enabled(session, user=user, enabled=payload.enabled)}
 
 
 @router.get("/capabilities")
@@ -304,7 +316,7 @@ async def capabilities(
     from app.models.agent_skill import as_dict
     from app.tools.registry import get_tool
 
-    names = list(DEFAULT_TOOL_NAMES)
+    names = list(default_tool_names(memory_enabled=buddy.memory_enabled(user)))
     tools = []
     for name in names:
         spec = get_tool(name)
@@ -332,6 +344,10 @@ async def capabilities(
         # Polaris 自己就是 MCP 服务端：Buddy 用的工具与外部客户端（Claude Desktop 等）
         # 拿到的是同一批，只是外部那边只给只读的。如实说清楚，别让界面上多出一个
         # 并不存在的「已连接的 MCP 服务器」列表。
+        "memory": {
+            "enabled": buddy.memory_enabled(user),
+            "count": len(await buddy.list_memories(session, user_id=user.id)),
+        },
         "mcp": {
             "role": "server",
             "endpoint": "/mcp",
@@ -412,13 +428,22 @@ async def run_turn(
     # 一个可见库都没有 = 没有语料可查，这轮不带工具。**不假装查过**：兜一个空范围
     # 然后说「没查到」，与从前兜随机 UUID 一样是在撒谎。
     has_corpus = bool(project_id) or bool(library_ids)
-    tool_names = tuple(payload.tool_names or DEFAULT_TOOL_NAMES) if has_corpus else ()
+    memory_on = buddy.memory_enabled(user)
+    # 记忆开着时才把 remember/recall 放进工具面；也只有这时才开写权限——
+    # 而这个「写」写的只是它与用户之间的记忆，碰不到论文/想法/实验。
+    tool_names = (
+        tuple(payload.tool_names or default_tool_names(memory_enabled=memory_on))
+        if has_corpus
+        else (default_tool_names(memory_enabled=memory_on) if memory_on else ())
+    )
     tool_ctx = ToolContext(
         project_id=project_id,
         # 指定了课题就按课题算范围（library_ids=None），否则给显式的可见库集合
         library_ids=None if project_id else library_ids,
         llm=get_llm_router(),
         user_id=user.id,
+        # 只为记忆开写：工具面里唯一非只读的就是 remember
+        allow_writes=memory_on,
     )
     loop = ChatAgentLoop(llm=get_llm_router(), tool_ctx=tool_ctx, history=history)
     req = ChatTurnRequest(
@@ -434,13 +459,15 @@ async def run_turn(
     conv_id, user_id = conv.id, user.id
 
     async def event_stream() -> AsyncIterator[str]:
-        collected: list[str] = []
+        # 落库的是**整条时间线**，不只是最终文本。只存文本的后果用户一眼就能看见：
+        # 切到别的对话再切回来，思考过程和工具调用全没了，只剩一段结论——而那段结论
+        # 之所以可信，正是因为下面那些调用。
+        timeline = _TurnTimeline()
         stop_reason, usage = "stop", {}
         try:
             async for ev in loop.run(req):
-                if isinstance(ev, DeltaEvent):
-                    collected.append(ev.text)
-                elif isinstance(ev, DoneEvent):
+                timeline.feed(ev)
+                if isinstance(ev, DoneEvent):
                     stop_reason, usage = ev.stop_reason, ev.usage
                 yield _to_frame(ev)
         finally:
@@ -448,10 +475,10 @@ async def run_turn(
             # shield 是必需的——取消态下再 await 数据库写会被二次取消。
             import asyncio
 
-            text = "".join(collected)
-            if text:
+            blocks = timeline.blocks()
+            if blocks:
                 await asyncio.shield(
-                    _persist_answer(conv_id, user_id, text, stop_reason, usage)
+                    _persist_answer(conv_id, user_id, blocks, timeline.text, stop_reason, usage)
                 )
 
     return StreamingResponse(
@@ -510,9 +537,66 @@ async def _resolve_project(
     raise HTTPException(status.HTTP_409_CONFLICT, detail="PROJECT_REQUIRED")
 
 
+class _TurnTimeline:
+    """把这一轮的事件收成可落库的块。
+
+    与 SSE 帧的区别：帧是给界面看的（带 duration、preview），块是给**下一轮的模型**
+    和**回放**看的。两者都需要工具调用在场——模型需要它才能接着推理，用户需要它才
+    看得出结论是怎么来的。
+    """
+
+    def __init__(self) -> None:
+        self._blocks: list[Any] = []
+        self._text: list[str] = []
+        self._thinking: list[str] = []
+
+    @property
+    def text(self) -> str:
+        return "".join(self._text)
+
+    def feed(self, ev: ChatEvent) -> None:
+        if isinstance(ev, DeltaEvent):
+            self._flush_thinking()
+            self._text.append(ev.text)
+            self._blocks.append(TextBlock(ev.text))
+        elif isinstance(ev, ThinkingEvent):
+            # 思考是逐 token 来的：攒成一块再落，否则一轮会写出几百个一字块
+            self._thinking.append(ev.text)
+        elif isinstance(ev, ToolCallEvent):
+            self._flush_thinking()
+            self._blocks.append(ToolUseBlock(id=ev.id, name=ev.name, input=ev.args))
+        elif isinstance(ev, ToolResultEvent):
+            # 存**摘要**而不是完整结果：完整结果动辄几万字符，而回放只需要让人（和模型）
+            # 知道「调了什么、拿到了什么样的东西」。图片存引用，不存字节。
+            payload = {
+                "summary": ev.summary,
+                "preview": ev.preview,
+                "ok": ev.ok,
+                "duration_ms": ev.duration_ms,
+                "image_refs": list(ev.image_refs),
+            }
+            self._blocks.append(
+                ToolResultBlock(
+                    tool_use_id=ev.id,
+                    content=json.dumps(payload, ensure_ascii=False, default=str),
+                    is_error=not ev.ok,
+                )
+            )
+
+    def _flush_thinking(self) -> None:
+        if self._thinking:
+            self._blocks.append(ThinkingBlock("".join(self._thinking)))
+            self._thinking = []
+
+    def blocks(self) -> list[Any]:
+        self._flush_thinking()
+        return list(self._blocks)
+
+
 async def _persist_answer(
     conversation_id: uuid.UUID,
     user_id: uuid.UUID,
+    blocks: list[Any],
     text: str,
     stop_reason: str,
     usage: dict[str, Any],
@@ -528,7 +612,8 @@ async def _persist_answer(
             session,
             conversation=conv,
             role="assistant",
-            blocks=[TextBlock(text)],
+            blocks=blocks,
+            text=text,
             usage=usage or None,
             stop_reason=stop_reason,
             status="complete" if stop_reason != "interrupted" else "interrupted",

--- a/src/backend/app/models/buddy_memory.py
+++ b/src/backend/app/models/buddy_memory.py
@@ -9,7 +9,7 @@
 
 import uuid
 
-from sqlalchemy import ForeignKey, Text
+from sqlalchemy import ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
@@ -23,3 +23,6 @@ class BuddyMemory(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     text: Mapped[str] = mapped_column(Text, nullable=False)
+    #: fact = 每轮都带上的稳定事实；note = 带时间戳的片段，只在检索到时才回上下文。
+    #: 分两层是因为成本不同：事实每轮都要付钱，笔记只在用得上时付。
+    kind: Mapped[str] = mapped_column(String(16), default="fact", nullable=False)

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -29,8 +29,13 @@ class ConversationRead(BaseModel):
     last_message_at: datetime | None = None
 
 
+class MemoryToggle(BaseModel):
+    enabled: bool
+
+
 class MemoryCreate(BaseModel):
     text: str = Field(min_length=1, max_length=300)
+    kind: str = Field(default="fact", pattern="^(fact|note)$")
 
 
 class ConversationRenameRequest(BaseModel):

--- a/src/backend/app/services/buddy.py
+++ b/src/backend/app/services/buddy.py
@@ -197,8 +197,12 @@ async def list_memories(session: AsyncSession, *, user_id: uuid.UUID) -> list[Bu
     return list(rows.scalars().all())
 
 
-async def add_memory(session: AsyncSession, *, user_id: uuid.UUID, text: str) -> BuddyMemory:
-    row = BuddyMemory(user_id=user_id, text=text.strip()[:MAX_MEMORY_ITEM_CHARS])
+async def add_memory(
+    session: AsyncSession, *, user_id: uuid.UUID, text: str, kind: str = "fact"
+) -> BuddyMemory:
+    row = BuddyMemory(
+        user_id=user_id, text=text.strip()[:MAX_MEMORY_ITEM_CHARS], kind=kind or "fact"
+    )
     session.add(row)
     await session.commit()
     await session.refresh(row)
@@ -214,13 +218,30 @@ async def delete_memory(session: AsyncSession, *, user_id: uuid.UUID, memory_id:
     return True
 
 
+async def search_memories(
+    session: AsyncSession, *, user_id: uuid.UUID, query: str, limit: int
+) -> list[BuddyMemory]:
+    """在记忆里找。空查询返回最近的几条——「我上次说了什么」本来就没有关键词。
+
+    用 ilike 而不是向量：记忆是几十条量级的短句，为它建一套向量管线的收益还不如
+    诚实的字面匹配；等它真的多到检索不动了再说。
+    """
+    stmt = select(BuddyMemory).where(BuddyMemory.user_id == user_id)
+    if query.strip():
+        stmt = stmt.where(BuddyMemory.text.ilike(f"%{query.strip()}%"))
+    rows = await session.execute(stmt.order_by(BuddyMemory.created_at.desc()).limit(limit))
+    return list(rows.scalars().all())
+
+
 async def render_memories(session: AsyncSession, *, user_id: uuid.UUID) -> str:
     """记忆 → 追加进系统提示的一段；没有记忆返回空串。
 
     **总长封顶**并且按新到旧填：每轮都要重发，放任下去就是每轮都在为一堆旧便签付钱。
     填不下的直接不进——与其截断成半句话让模型猜，不如少给一条。
     """
-    rows = await list_memories(session, user_id=user_id)
+    # 只有 fact 进提示词：note 是带时间戳的片段，检索到才回上下文，
+    # 每轮都带上就是每轮为陈年琐事付钱
+    rows = [r for r in await list_memories(session, user_id=user_id) if r.kind != "note"]
     if not rows:
         return ""
     lines: list[str] = []
@@ -234,3 +255,21 @@ async def render_memories(session: AsyncSession, *, user_id: uuid.UUID) -> str:
     if not lines:
         return ""
     return "关于这位用户，你需要一直记得：\n" + "\n".join(lines)
+
+
+#: 记忆开关存在用户设置里的键。不值得为一个布尔值开一张表。
+MEMORY_ENABLED_KEY = "buddy_memory_enabled"
+
+
+def memory_enabled(user: Any) -> bool:
+    """这个人开了记忆吗。**默认关**：一个会自己记东西的助手，得由用户先说「可以」。"""
+    settings = getattr(user, "settings", None) or {}
+    return bool(settings.get(MEMORY_ENABLED_KEY, False))
+
+
+async def set_memory_enabled(session: AsyncSession, *, user: Any, enabled: bool) -> bool:
+    settings = dict(getattr(user, "settings", None) or {})
+    settings[MEMORY_ENABLED_KEY] = bool(enabled)
+    user.settings = settings
+    await session.commit()
+    return bool(enabled)

--- a/src/backend/app/tools/__init__.py
+++ b/src/backend/app/tools/__init__.py
@@ -12,6 +12,7 @@ from app.tools import (
     knowledge,  # noqa: F401
     libraries,  # noqa: F401
     literature,  # noqa: F401
+    memory,  # noqa: F401
     plan,  # noqa: F401
     project_state,  # noqa: F401
     skills,  # noqa: F401

--- a/src/backend/app/tools/memory.py
+++ b/src/backend/app/tools/memory.py
@@ -1,0 +1,99 @@
+"""Buddy 的记忆工具：自己记、自己找。
+
+这是本期唯一**会写数据**的一对工具，但写的只是它与用户之间的记忆——不碰平台里的
+论文、想法、实验。所以它不走写工具的审批面，而是走一个**用户可以关掉的开关**：
+记忆没打开时这两个工具根本不进工具面，模型不会知道有这回事，也就不会假装记住。
+
+分两层存：
+- ``fact``：抽出来的稳定事实（研究方向、偏好、约定），每轮都随提示词带上；
+- ``note``：带时间戳的对话片段，只在检索到时才回到上下文里。
+
+区分这两层是因为它们的成本不同：事实每轮都要付钱，笔记只在用得上时付。把对话历史
+一股脑当事实存，几十条之后每轮都在为陈年琐事付费。
+"""
+
+import uuid
+from typing import Any
+
+from app.core.db import get_sessionmaker
+from app.tools.context import ToolContext
+from app.tools.registry import tool
+
+#: 记忆工具的名字。开关关掉时它们不进工具面。
+MEMORY_TOOL_NAMES = ("remember", "recall")
+
+_KINDS = ("fact", "note")
+
+
+@tool(
+    "remember",
+    description=(
+        "把值得长期记住的事写进记忆。用户说明自己的方向/偏好/约定，或本轮出现了"
+        "以后还用得上的结论时调用。kind=fact 是每轮都会带上的稳定事实，"
+        "kind=note 是带时间戳的片段、只在检索到时才回到上下文。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "要记住的一句话"},
+            "kind": {"type": "string", "enum": list(_KINDS), "default": "fact"},
+        },
+        "required": ["text"],
+    },
+    read_only=False,
+    summarize=lambda a, r: f"记住（{a.get('kind', 'fact')}）：{str(a.get('text', ''))[:40]}",
+)
+async def remember(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    from app.services import buddy
+
+    text = str(args.get("text") or "").strip()
+    if not text:
+        raise ValueError("remember 需要非空 text")
+    if ctx.user_id is None:
+        raise ValueError("记忆是按人存的，这次调用没有用户身份")
+    kind = str(args.get("kind") or "fact")
+    if kind not in _KINDS:
+        kind = "fact"
+    async with get_sessionmaker()() as session:
+        row = await buddy.add_memory(session, user_id=ctx.user_id, text=text, kind=kind)
+    return {"id": str(row.id), "text": row.text, "kind": kind}
+
+
+@tool(
+    "recall",
+    description=(
+        "在长期记忆里检索。问到「我之前说过什么」「上次那个结论」，"
+        "或需要回忆用户的偏好与既往约定时调用。"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "检索词；留空则返回最近的记忆"},
+            "k": {"type": "integer", "minimum": 1, "maximum": 20, "default": 8},
+        },
+    },
+    summarize=lambda a, r: f"回忆「{a.get('query', '')}」→ {len(r.get('items') or [])} 条",
+)
+async def recall(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    from app.services import buddy
+
+    if ctx.user_id is None:
+        raise ValueError("记忆是按人存的，这次调用没有用户身份")
+    query = str(args.get("query") or "").strip()
+    k = min(20, max(1, int(args.get("k") or 8)))
+    async with get_sessionmaker()() as session:
+        rows = await buddy.search_memories(session, user_id=ctx.user_id, query=query, limit=k)
+    return {
+        "items": [
+            {
+                "text": r.text,
+                "kind": r.kind,
+                "at": r.created_at.isoformat(),
+            }
+            for r in rows
+        ]
+    }
+
+
+def _unused(_: uuid.UUID) -> None:  # pragma: no cover - 保持 uuid 导入被使用
+    return None

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -458,3 +458,71 @@ async def test_deleting_a_conversation_takes_its_messages(client, agent_on):
             .where(ConversationMessage.conversation_id == uuid.UUID(conv["id"]))
         )
     assert after == 0
+
+
+async def test_a_turn_persists_its_whole_timeline_not_just_the_answer(client, agent_on):
+    """切到别的对话再切回来，思考过程与工具调用还得在。
+
+    此前每轮只落库最终文本，于是回放只剩一段结论——而那段结论之所以可信，正是因为
+    下面那些调用。
+    """
+    headers = await _headers(client, "timeline@example.com")
+    await _project_with_paper(client, headers, "Timeline Persistence Paper")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+
+    marker = 'POLARIS_FAKE_TOOL:search_papers:{"query": "Timeline", "mode": "keyword"}'
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": f"查一下\n{marker}"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    messages = (
+        await client.get(f"/api/chat/conversations/{conv_id}/messages", headers=headers)
+    ).json()
+    assistant = [m for m in messages if m["role"] == "assistant"]
+    assert assistant, "助手消息没落库"
+    kinds = [b.get("kind") for m in assistant for b in (m["blocks"] or [])]
+    assert "tool_use" in kinds, f"工具调用没落库：{kinds}"
+    assert "tool_result" in kinds, f"工具结果没落库：{kinds}"
+    assert "text" in kinds
+
+    # 工具结果存的是摘要而不是完整 payload——回放只需要「调了什么、拿到什么样的东西」
+    results = [
+        json.loads(b["content"])
+        for m in assistant
+        for b in (m["blocks"] or [])
+        if b.get("kind") == "tool_result"
+    ]
+    assert results and {"summary", "ok"} <= set(results[0])
+
+
+async def test_a_tool_that_needs_a_topic_fails_inside_the_loop_not_on_the_wire(client, agent_on):
+    """需要课题的工具在没有课题时，必须变成**循环内的一个失败结果**，而不是把流打断。
+
+    线上现象是两张卡片停在「调用中…」然后一条 ⚠️ network error——那说明异常逃出了
+    循环、把 SSE 连接带走了。权限/参数一类的错误应该回喂给模型，由它决定下一步；
+    连接断掉的话，用户看到的是「网络坏了」，而其实是工具不适用。
+    """
+    headers = await _headers(client, "toolerr@example.com")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+
+    marker = "POLARIS_FAKE_TOOL:knowledge_graph:{}"
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": f"看看图谱\n{marker}"},
+        headers=headers,
+    ) as stream:
+        assert stream.status_code == 200
+        body = (await stream.aread()).decode()
+
+    events = _parse_sse(body)
+    names = [e for e, _ in events]
+    assert "done" in names, f"流被打断了，没有 done：{names}"
+    results = [d for e, d in events if e == "tool_result"]
+    assert results, f"没有工具结果帧：{names}"
+    assert results[0]["ok"] is False
+    assert "课题" in results[0]["summary"], results[0]

--- a/src/backend/tests/test_chat_agent_loop.py
+++ b/src/backend/tests/test_chat_agent_loop.py
@@ -311,12 +311,22 @@ def test_the_default_surface_is_every_read_only_tool_minus_a_named_few():
     会记得回来加，助手会悄悄少一项能力而界面上看不出异常。
     """
     from app.agents.chat.prompt import _TOOL_DENYLIST, default_tool_names
+    from app.tools.memory import MEMORY_TOOL_NAMES
     from app.tools.registry import list_tools
 
     names = set(default_tool_names())
     read_only = {spec.name for spec in list_tools() if spec.read_only}
 
-    assert names == read_only - _TOOL_DENYLIST
+    # 记忆没打开时 remember/recall 不在工具面里——模型不知道有这回事，也就不会假装
+    # 记住；「我记下了」而其实没存，比不能记更糟
+    assert names == read_only - _TOOL_DENYLIST - set(MEMORY_TOOL_NAMES)
+    assert not set(MEMORY_TOOL_NAMES) & names
+
+    # 打开之后两个都在，且 remember 是工具面里唯一会写的
+    with_memory = set(default_tool_names(memory_enabled=True))
+    assert set(MEMORY_TOOL_NAMES) <= with_memory
+    writers = {spec.name for spec in list_tools() if not spec.read_only}
+    assert with_memory & writers == {"remember"}
     # 用户实际撞上的那几个：取图、读解读、看实验
     assert {"get_paper_figure", "read_wiki", "get_experiment"} <= names
     # 写工具一个都不能混进来（本期仍是只读期）

--- a/src/backend/tests/test_chat_core.py
+++ b/src/backend/tests/test_chat_core.py
@@ -171,3 +171,39 @@ def test_sextant_does_not_fire_on_plain_answers():
     assert Sextant().verify(
         answer="这个问题不需要查库，我直接说说思路。", sources=0, successful_tool_calls=0
     ).passed
+
+
+async def test_helm_survives_a_result_that_cannot_be_serialized():
+    """结果序列化失败也要变成失败结果，而不是把整轮对话带走。
+
+    生产上就是这么断的：get_project_status 的返回里带 datetime，json.dumps 抛
+    TypeError，而那行当时在 try 之外——异常穿出循环、带走 SSE 连接，用户只看到
+    「network error」。「异常绝不外抛」必须覆盖到把结果交出去为止。
+    """
+    import datetime as dt
+
+    @tool(name="_dated", description="返回时间", input_schema={"type": "object", "properties": {}})
+    async def _dated(ctx, args):  # noqa: ANN001
+        return {"when": dt.datetime.now(dt.UTC)}
+
+    event, block = await Helm(_ctx()).execute(ToolUseBlock("c1", "_dated", {}))
+    # datetime 现在按 default=str 落成字符串，正常成功
+    assert event.ok is True
+    assert "when" in block.content
+
+
+async def test_helm_reports_a_truly_unserializable_result_instead_of_crashing():
+    """连 str() 都救不回来的对象（自定义 __str__ 抛异常）：报失败，不炸循环。"""
+
+    class Hostile:
+        def __str__(self) -> str:
+            raise RuntimeError("连字符串都不给")
+
+    @tool(name="_hostile", description="难缠", input_schema={"type": "object", "properties": {}})
+    async def _hostile(ctx, args):  # noqa: ANN001
+        return {"x": Hostile()}
+
+    event, block = await Helm(_ctx()).execute(ToolUseBlock("c1", "_hostile", {}))
+    assert event.ok is False
+    assert "序列化" in event.summary
+    assert block.is_error

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
+HEAD_REVISION = "d4e8b19c7a55"  # 记忆分层：fact 每轮带上 / note 检索到才回上下文
+SKILLS_GLOBAL_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
 BUDDY_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
 SKILLS_REVISION = "a22aa895244c"  # Skills v2（SKILL.md 渐进披露）
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
@@ -98,6 +99,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "agent_skills",
                     "agent_skill_files",
                     "skills",
+                    "buddy_memories",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -355,7 +357,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉技能全局化（user_skills → 空的 project_skills）。
+    # 最新 revision 可往返：先退掉记忆分层。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SKILLS_GLOBAL_REVISION
+    assert "kind" not in columns["buddy_memories"]
+
+    # 再退掉技能全局化（user_skills → 空的 project_skills）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == BUDDY_REVISION

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -57,7 +57,13 @@ def test_registry_has_expected_tools():
     # 每个工具的 input_schema 都是合法 JSON-schema object
     for spec in tools.list_tools():
         assert spec.input_schema.get("type") == "object", spec.name
-        assert spec.read_only is True
+
+    # 会写的工具必须**逐个点名**。这条原来是「全部只读」，remember 是第一个例外：
+    # 它写的只是 Buddy 与用户之间的记忆（碰不到论文/想法/实验），并且要用户先打开
+    # 记忆开关、调用方显式给 allow_writes 才跑得起来。名单写死在这里，是为了下一个
+    # 写工具进来时必须有人改这一行——而不是悄悄混进去。
+    writers = {spec.name for spec in tools.list_tools() if not spec.read_only}
+    assert writers == {"remember"}
 
 
 def test_tool_descriptions_are_formal():

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -439,6 +439,19 @@ export function AppShell() {
   const [buddyBusy, setBuddyBusy] = useState(false);
   const [nudge, setNudge] = useState<string | null>(null);
   const [buddyDragOver, setBuddyDragOver] = useState(false);
+  const [topbarMoreOpen, setTopbarMoreOpen] = useState(false);
+  // 顶栏还宽裕吗。量的是**主区**：Buddy 拉开后视口没变，变窄的是主区。
+  const mainRef = useRef<HTMLDivElement | null>(null);
+  const [topbarRoomy, setTopbarRoomy] = useState(true);
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setTopbarRoomy(entry.contentRect.width >= 880);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   // 主动提示：今天没提过才去问一次计数——大多数次打开页面连这个请求都不会发。
   // 提示必须对应一件**真事**（跑着的实验、今天到的新论文）；为了让球看起来「活着」
@@ -701,7 +714,7 @@ export function AppShell() {
       )}
 
       {/* —— 主列 —— */}
-      <div className="main">
+      <div className="main" ref={mainRef}>
         <div className="topbar">
           <button
             className="icon-btn nav-toggle"
@@ -746,12 +759,25 @@ export function AppShell() {
             <Icon name="refresh" size={15} style={refreshing ? { animation: 'spin 1s linear infinite' } : undefined} />
           </button>
           <div className="spacer" />
-          <div className="searchbox" role="button" tabIndex={0} onClick={() => setSearchOpen(true)}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSearchOpen(true); }}>
-            <Icon name="search" size={14} />
-            <span>{tr('搜索论文 / 想法 / 实验…', 'Search papers / ideas / experiments…')}</span>
-            <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>⌘K</span>
-          </div>
+          {/* 窄的时候（Buddy 一拉开就窄了）搜索框缩成一个图标：它的提示文字是奢侈品，
+              而右侧那排功能入口不是。 */}
+          {topbarRoomy ? (
+            <div className="searchbox" role="button" tabIndex={0} onClick={() => setSearchOpen(true)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSearchOpen(true); }}>
+              <Icon name="search" size={14} />
+              <span>{tr('搜索论文 / 想法 / 实验…', 'Search papers / ideas / experiments…')}</span>
+              <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>⌘K</span>
+            </div>
+          ) : (
+            <button
+              className="icon-btn"
+              onClick={() => setSearchOpen(true)}
+              title={tr('搜索（⌘K）', 'Search (⌘K)')}
+              aria-label={tr('搜索', 'Search')}
+            >
+              <Icon name="search" size={16} />
+            </button>
+          )}
           {/* PolarisBuddy：入口在顶栏右侧，不再是浮在页面上的球——球会挡住内容，
               而且没人知道它是什么。这里也是论文/选中文字的拖放落点。 */}
           <button
@@ -812,25 +838,82 @@ export function AppShell() {
             )}
           </button>
 
-          {/* 管理员设置入口（仅管理员可见） */}
-          {isAdmin(me) && (
-            <button
-              className="icon-btn"
-              onClick={() => navigate('/admin')}
-              title={tr('管理', 'Manage')}
-              aria-label={tr('管理', 'Manage')}
-              style={location.pathname === '/admin' ? { color: 'var(--accent)', background: 'var(--surface-2)' } : undefined}
-            >
-              <Icon name="settings" size={16} />
-            </button>
+          {/* 次要入口：宽时平铺，窄时收进「更多」。判据是主区实际宽度而不是视口——
+              Buddy 拉开之后视口没变，变窄的是主区，按视口判会一直以为还很宽。 */}
+          {topbarRoomy ? (
+            <>
+              {isAdmin(me) && (
+                <button
+                  className="icon-btn"
+                  onClick={() => navigate('/admin')}
+                  title={tr('管理', 'Manage')}
+                  aria-label={tr('管理', 'Manage')}
+                  style={location.pathname === '/admin' ? { color: 'var(--accent)', background: 'var(--surface-2)' } : undefined}
+                >
+                  <Icon name="settings" size={16} />
+                </button>
+              )}
+              <LangToggle />
+              <FeedbackWidget />
+              <UpdateBadge />
+              <button className="icon-btn" onClick={() => openGates(null)} title={tr('审批中心', 'Approvals')}>
+                <Icon name="bell" size={16} />
+                {pending.length > 0 && <span className="badge">{pending.length}</span>}
+              </button>
+            </>
+          ) : (
+            <div style={{ position: 'relative' }}>
+              <button
+                className="icon-btn"
+                onClick={() => setTopbarMoreOpen((o) => !o)}
+                title={tr('更多', 'More')}
+                aria-label={tr('更多', 'More')}
+              >
+                <Icon name="sliders" size={16} />
+                {pending.length > 0 && <span className="badge">{pending.length}</span>}
+              </button>
+              {topbarMoreOpen && (
+                <>
+                  {/* 点外面关掉：下拉盖着的是内容区，留着它挡路比少一次点击更糟 */}
+                  <div
+                    onClick={() => setTopbarMoreOpen(false)}
+                    style={{ position: 'fixed', inset: 0, zIndex: 39 }}
+                  />
+                  <div
+                    className="col gap4"
+                    style={{
+                      position: 'absolute',
+                      right: 0,
+                      top: 36,
+                      zIndex: 40,
+                      minWidth: 168,
+                      padding: 6,
+                      background: 'var(--surface)',
+                      border: '0.5px solid var(--border-2)',
+                      borderRadius: 10,
+                      boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+                    }}
+                    onClick={() => setTopbarMoreOpen(false)}
+                  >
+                    {isAdmin(me) && (
+                      <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => navigate('/admin')}>
+                        <Icon name="settings" size={14} /> {tr('管理', 'Manage')}
+                      </button>
+                    )}
+                    <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => openGates(null)}>
+                      <Icon name="bell" size={14} /> {tr('审批中心', 'Approvals')}
+                      {pending.length > 0 && <span className="badge" style={{ position: 'static', marginLeft: 'auto' }}>{pending.length}</span>}
+                    </button>
+                    <div className="row gap6" style={{ padding: '2px 4px' }}>
+                      <LangToggle />
+                      <FeedbackWidget />
+                      <UpdateBadge />
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
           )}
-          <LangToggle />
-          <FeedbackWidget />
-          <UpdateBadge />
-          <button className="icon-btn" onClick={() => openGates(null)} title={tr('审批中心', 'Approvals')}>
-            <Icon name="bell" size={16} />
-            {pending.length > 0 && <span className="badge">{pending.length}</span>}
-          </button>
         </div>
         <div className="content scroll">
           <Outlet context={ctx} />

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -7,11 +7,14 @@ import { api } from '../../lib/api';
 import {
   assistantTurnSse,
   type AssistantBlock,
+  type ImageRef,
   type PaperSource,
   type PlanStep,
 } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
 import { BuddyHome } from './BuddyHome';
+import { followUps } from './followups';
+import { InlineFigure } from './InlineFigure';
 import { ConversationRail } from './ConversationRail';
 import { ToolImages } from './ToolImages';
 import { pageContextFrom } from './buddyContext';
@@ -34,27 +37,76 @@ interface Turn {
   blocks: AssistantBlock[];
 }
 
-/** 服务端持久化的块 → 前端块。认不出的形状一律降级成文本，绝不抛。 */
+/** 服务端持久化的块 → 前端块。认不出的形状一律降级，绝不抛。
+
+    工具结果里存的是**摘要**（summary/preview/图片引用），不是完整 payload——回放要的
+    是「调了什么、拿到了什么样的东西」，而完整结果动辄几万字符。 */
 function restoreBlocks(m: { text: string; blocks: unknown[] }): AssistantBlock[] {
   const out: AssistantBlock[] = [];
+  const cardById = new Map<string, Extract<AssistantBlock, { kind: 'tool' }>>();
+
   for (const raw of Array.isArray(m.blocks) ? m.blocks : []) {
     if (!raw || typeof raw !== 'object') continue;
     const b = raw as Record<string, unknown>;
+
     if (b.kind === 'text' && typeof b.text === 'string') {
-      out.push({ kind: 'text', text: b.text });
+      const last = out[out.length - 1];
+      // 落库时正文是逐段写的，回放要拼回一整块，否则每个 token 都成了独立段落
+      if (last && last.kind === 'text') last.text += b.text;
+      else out.push({ kind: 'text', text: b.text });
     } else if (b.kind === 'thinking' && typeof b.text === 'string') {
       out.push({ kind: 'thinking', text: b.text });
     } else if (b.kind === 'tool_use') {
-      out.push({
+      const card: Extract<AssistantBlock, { kind: 'tool' }> = {
         kind: 'tool',
         id: String(b.id ?? ''),
         name: String(b.name ?? '?'),
+        // 结果还没读到之前先当成功：历史里的调用都已经结束了，画成 running 会骗人
         state: 'ok',
-      });
+      };
+      cardById.set(card.id, card);
+      out.push(card);
+    } else if (b.kind === 'tool_result') {
+      // 结果回填到对应卡片上（含图片引用）——切走再回来，工具过程与图片都还在
+      const card = cardById.get(String(b.tool_use_id ?? ''));
+      if (!card) continue;
+      let payload: Record<string, unknown> = {};
+      try {
+        const parsed: unknown = JSON.parse(String(b.content ?? '{}'));
+        if (parsed && typeof parsed === 'object') payload = parsed as Record<string, unknown>;
+      } catch {
+        /* 存量数据里 content 是原始结果文本，不是摘要 JSON：忽略即可 */
+      }
+      if (typeof payload.summary === 'string') card.summary = payload.summary;
+      if (typeof payload.preview === 'string') card.preview = payload.preview;
+      if (typeof payload.duration_ms === 'number') card.durationMs = payload.duration_ms;
+      if (b.is_error === true || payload.ok === false) card.state = 'error';
+      const refs = parseRestoredImageRefs(payload.image_refs);
+      if (refs.length) card.images = refs;
     }
-    // tool_result 等其余块不单独渲染：它们是模型的输入，不是回答的一部分
   }
   if (out.length === 0 && m.text) out.push({ kind: 'text', text: m.text });
+  return out;
+}
+
+/** 落库的图片引用 → 前端形状；认不出的丢掉。 */
+function parseRestoredImageRefs(raw: unknown): ImageRef[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ImageRef[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const ref = item as Record<string, unknown>;
+    if (ref.kind !== 'paper_figure') continue;
+    const paperId = typeof ref.paper_id === 'string' ? ref.paper_id : '';
+    const index = typeof ref.index === 'number' ? ref.index : undefined;
+    if (!paperId || index === undefined) continue;
+    out.push({
+      kind: 'paper_figure',
+      paperId,
+      index,
+      label: typeof ref.label === 'string' ? ref.label : undefined,
+    });
+  }
   return out;
 }
 
@@ -322,8 +374,49 @@ function VerifyCard({ notes }: { notes: string[] }) {
   );
 }
 
-function BlockView({ block, live }: { block: AssistantBlock; live: boolean }) {
-  if (block.kind === 'text') return <Markdown source={block.text} />;
+function BlockView({
+  block,
+  live,
+  sources,
+}: {
+  block: AssistantBlock;
+  live: boolean;
+  sources: PaperSource[];
+}) {
+  if (block.kind === 'text') {
+    // 模型会在正文里直接写 ![图注](paper_id/图号) 和 [1] 这类引用。Markdown 组件本来
+    // 就有 renderLibraryFigure / renderCitation 两个钩子（文献对话一直在用），Buddy
+    // 只是一个都没传——于是图不显示、引用点不动。
+    return (
+      <Markdown
+        source={block.text}
+        renderLibraryFigure={(paperId, index) => <InlineFigure paperId={paperId} index={index} />}
+        renderCitation={(n) => {
+          const src = sources[n - 1];
+          if (!src) return null;
+          return (
+            <a
+              href={`/papers/${src.paperId}/read`}
+              title={src.title}
+              style={{
+                display: 'inline-block',
+                padding: '0 4px',
+                margin: '0 1px',
+                borderRadius: 5,
+                background: 'var(--accent-soft)',
+                color: 'var(--accent-text)',
+                fontSize: '0.82em',
+                fontWeight: 650,
+                textDecoration: 'none',
+              }}
+            >
+              {n}
+            </a>
+          );
+        }}
+      />
+    );
+  }
   if (block.kind === 'plan') return <PlanCard steps={block.steps} />;
   if (block.kind === 'sources') return <SourcesCard papers={block.papers} />;
   if (block.kind === 'verify') return <VerifyCard notes={block.notes} />;
@@ -368,17 +461,26 @@ export function AssistantPanel({
     { id: string; title: string; project_id: string | null }[]
   >([]);
   const [greeting, setGreeting] = useState<string>('');
-  const [contextOn, setContextOn] = useState(true);
+  const [model, setModel] = useState<string>('');
+  // 页面上下文照常发给模型，但不在输入框上占一行——它是背景信息，不是待办事项。
+  const contextOn = true;
   const abortRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
-  // 对话里的「项目」就是平台里的课题：跟着外壳当前选中的那个走，不另设一套选择。
-  // 用户在哪个课题下工作，问出来的问题多半就属于那个课题；让他再选一次是多余的。
+  // 对话里的「项目」就是平台里的课题。**默认不绑**：绑上之后检索范围就收窄到这个
+  // 课题，而用户多数问题是跨课题的；想收窄时自己勾一下，比默认收窄再去发现「怎么
+  // 查不到别的库」要好。
   const { currentProject } = useProject();
+  const [bindProject, setBindProject] = useState(false);
   const pageContext = pageContextFrom(location.pathname);
 
+  // 只有「本来就贴着底」才跟着滚。正在往回翻的时候被拽回最新一行，是流式界面里最
+  // 烦人的一种行为——用户已经用滚动明确表达了「我在看别的地方」。
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    if (nearBottom) el.scrollTo({ top: el.scrollHeight });
   }, [turns]);
 
   useEffect(() => () => abortRef.current?.(), []);
@@ -485,20 +587,25 @@ export function AssistantPanel({
         // 那条路上的权限校验一点没少。用户可以关掉。
         page:
           contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
-        projectId: currentProject?.id ?? null,
+        projectId: bindProject ? (currentProject?.id ?? null) : null,
+        onMeta: (meta) => setModel(meta.model),
         onBlocks: patch,
         onDone: () => {
           setBusy(false);
           setRailRefresh((n) => n + 1); // 标题这时才有
         },
         onError: (detail) => {
-          patch((blocks) => [...blocks, { kind: 'text', text: `⚠️ ${errorText(detail)}` }]);
+          // 把原始细节一并留下：只写「网络错误」等于让用户和我们都无从查起
+          patch((blocks) => [
+            ...blocks,
+            { kind: 'text', text: `⚠️ ${errorText(detail)}\n\n\`${detail}\`` },
+          ]);
           setBusy(false);
         },
       },
     );
     },
-    [busy, convId, contextOn, pageContext, currentProject],
+    [busy, convId, contextOn, pageContext, currentProject, bindProject],
   );
 
   const send = useCallback(() => {
@@ -567,11 +674,23 @@ export function AssistantPanel({
           flexShrink: 0,
           padding: '0 16px',
           borderBottom: '0.5px solid var(--border)',
+          // 与 .topbar 同一底色：两栏并排时颜色差一点点，看起来像没加载完
+          background: 'rgba(247, 249, 252, 0.85)',
+          backdropFilter: 'blur(8px)',
           alignItems: 'center',
         }}
       >
         <BuddyMark busy={busy} size={17} />
         <strong style={{ fontSize: 14 }}>PolarisBuddy</strong>
+        {model && (
+          <span
+            className="mono"
+            style={{ fontSize: 10.5, color: 'var(--text-4)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            title={tr(`这轮用的模型：${model}`, `Model this turn: ${model}`)}
+          >
+            {model}
+          </span>
+        )}
         <span style={{ flex: 1 }} />
         {variant === 'dock' ? (
           <button
@@ -695,9 +814,30 @@ export function AssistantPanel({
                       key={j}
                       block={b}
                       live={busy && isLast && j === turn.blocks.length - 1}
+                      sources={
+                        (turn.blocks.find((x) => x.kind === 'sources') as
+                          | { kind: 'sources'; papers: PaperSource[] }
+                          | undefined)?.papers ?? []
+                      }
                     />
                   ))}
                   {isLast && <TurnStatus blocks={liveBlocks} busy={busy} onStop={stop} />}
+                  {/* 答完给几条可点的下一步。它们从本轮真实发生的事里出——查到了论文
+                      就问共同点，取过图就问图说明什么。凭空造的建议点一次就没人再点。 */}
+                  {isLast && !busy && followUps(turn.blocks).length > 0 && (
+                    <div className="row gap6 wrap" style={{ marginTop: 10 }}>
+                      {followUps(turn.blocks).map((q) => (
+                        <span
+                          key={q}
+                          className="chip"
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => void ask(q)}
+                        >
+                          {q}
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
             </div>
@@ -708,39 +848,24 @@ export function AssistantPanel({
       </div>
 
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
-        {/* 当前课题：自动绑定外壳里选中的那个，只作展示——换课题在左上角切，
-            这里再放一个选择器就是两个真相来源。 */}
+        {/* 课题：默认不绑（检索走全部可见文献库），需要收窄时自己勾 */}
         {currentProject && (
-          <div
+          <label
             className="row gap6"
-            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)' }}
-            title={tr('这场对话属于当前课题，跟着左上角的课题切换走', 'This chat belongs to the current topic, following the switcher in the top-left')}
-          >
-            <Icon name="layers" size={11} />
-            <span
-              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-            >
-              {currentProject.name}
-            </span>
-          </div>
-        )}
-        {pageContext && (
-          <div
-            className="row gap6"
-            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)' }}
-            title={tr(
-              '我知道你在看什么。关掉的话这轮就不带页面信息了。',
-              'I can see what you are looking at. Turn it off to leave the page out of this turn.',
-            )}
+            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)', cursor: 'pointer' }}
+            title={tr('勾上后只在这个课题的语料里查', 'Restrict retrieval to this topic when checked')}
           >
             <input
               type="checkbox"
-              checked={contextOn}
-              onChange={(e) => setContextOn(e.target.checked)}
+              checked={bindProject}
+              onChange={(e) => setBindProject(e.target.checked)}
               style={{ width: 12, height: 12, margin: 0, accentColor: 'var(--accent)', cursor: 'pointer' }}
             />
-            <span>{pageContext.label}</span>
-          </div>
+            <Icon name="layers" size={11} />
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {tr(`只查课题：${currentProject.name}`, `Only in: ${currentProject.name}`)}
+            </span>
+          </label>
         )}
         {/* 输入区：随内容长高（7 行封顶），发送/停止就在右下角——正在流的时候
             「停」应该在离手最近的位置，而不是让人回面板顶上去找。 */}

--- a/src/frontend/src/features/assistant/InlineFigure.tsx
+++ b/src/frontend/src/features/assistant/InlineFigure.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/** 正文里 ![图注](paper_id/图号) 渲染出来的配图。
+
+    与工具卡片里的图共用同一条路：`<img src>` 带不了 Bearer，所以 blob → objectURL。
+    取不到就什么都不画——正文里插一个碎图比少一张图更打断阅读。 */
+export function InlineFigure({ paperId, index }: { paperId: string; index: number }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    let objectUrl: string | null = null;
+    void api
+      .fetchFigureImage(paperId, index)
+      .then((blob) => {
+        if (!alive) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [paperId, index]);
+
+  if (failed) return null;
+  if (!url) {
+    return (
+      <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>{tr('配图加载中…', 'loading figure…')}</span>
+    );
+  }
+  return (
+    <a href={`/papers/${paperId}/read`} title={tr('点击打开论文', 'open the paper')}>
+      <img
+        src={url}
+        alt={tr('论文配图', 'paper figure')}
+        style={{
+          display: 'block',
+          maxWidth: '100%',
+          maxHeight: 280,
+          margin: '8px 0',
+          borderRadius: 8,
+          border: '0.5px solid var(--border-2)',
+        }}
+      />
+    </a>
+  );
+}

--- a/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/assistantStream.test.ts
@@ -164,3 +164,46 @@ describe('验收结论', () => {
     expect(reduce([['verify', { passed: false, notes: [] }]])).toEqual([]);
   });
 });
+
+describe('工具返回的图片', () => {
+  it('tool_result 里的图片出处要装进卡片', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 'f1', name: 'get_paper_figure' }],
+      [
+        'tool_result',
+        {
+          id: 'f1',
+          ok: true,
+          image_refs: [{ kind: 'paper_figure', paper_id: 'p-1', index: 3, label: '图注' }],
+        },
+      ],
+    ]);
+    expect(blocks[0]).toMatchObject({
+      kind: 'tool',
+      images: [{ kind: 'paper_figure', paperId: 'p-1', index: 3, label: '图注' }],
+    });
+  });
+
+  it('认不出的出处丢掉，一张都不剩时是 undefined 而不是空数组', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 'f1', name: 'get_paper_figure' }],
+      [
+        'tool_result',
+        {
+          id: 'f1',
+          ok: true,
+          image_refs: [{ kind: '未来的类型', paper_id: 'p' }, { paper_id: 'p' }, { index: 1 }],
+        },
+      ],
+    ]);
+    expect((blocks[0] as { images?: unknown }).images).toBeUndefined();
+  });
+
+  it('没有图片的工具结果不会凭空长出 images 字段', () => {
+    const blocks = reduce([
+      ['tool_call', { id: 's1', name: 'search_papers' }],
+      ['tool_result', { id: 's1', ok: true, summary: '3 篇' }],
+    ]);
+    expect((blocks[0] as { images?: unknown }).images).toBeUndefined();
+  });
+});

--- a/src/frontend/src/features/assistant/followups.ts
+++ b/src/frontend/src/features/assistant/followups.ts
@@ -1,0 +1,35 @@
+import type { AssistantBlock } from '../../lib/assistantStream';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   答完之后的几条追问。
+
+   **从这一轮真实发生的事里出**，不凭空造：查到了论文就问它们的共同点，取过图就问
+   图说明了什么，排过计划就问下一步。凭空生成的建议看起来聪明，但十条里有九条问的是
+   这轮根本没碰过的东西——用户点一次就再也不点了。
+
+   最多三条：建议是台阶，不是菜单。
+   ============================================================ */
+
+export function followUps(blocks: AssistantBlock[]): string[] {
+  const out: string[] = [];
+  const tools = blocks.filter((b) => b.kind === 'tool');
+  const sources = blocks.find((b) => b.kind === 'sources');
+  const plan = blocks.find((b) => b.kind === 'plan');
+
+  if (sources?.kind === 'sources' && sources.papers.length >= 2) {
+    out.push(tr('这几篇的共同点和分歧在哪？', 'What do these papers agree and disagree on?'));
+    out.push(tr('挑最相关的一篇，帮我精读', 'Pick the most relevant one and read it closely'));
+  }
+  if (tools.some((b) => b.kind === 'tool' && b.name.includes('figure'))) {
+    out.push(tr('这些图说明了什么问题？', 'What do these figures actually show?'));
+  }
+  if (plan?.kind === 'plan' && plan.steps.some((s) => s.status !== 'done')) {
+    out.push(tr('接着做下一步', 'Continue with the next step'));
+  }
+  if (tools.some((b) => b.kind === 'tool' && b.name.includes('experiment'))) {
+    out.push(tr('下一步实验该怎么设计？', 'How should the next experiment be designed?'));
+  }
+  // 一条都没有时不硬凑：没有台阶好过给一个假台阶
+  return out.slice(0, 3);
+}

--- a/src/frontend/src/features/settings/BuddySettings.tsx
+++ b/src/frontend/src/features/settings/BuddySettings.tsx
@@ -45,12 +45,6 @@ function SkillsCard() {
         <Icon name="sparkle" size={15} style={{ color: 'var(--accent)' }} />
         {tr('技能', 'Skills')}
       </div>
-      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7, marginBottom: 10 }}>
-        {tr(
-          '技能是「什么时候该怎么做」的说明书。目录里每条只占一行常驻，正文由 Buddy 判断需要时才加载——所以描述要写成触发条件，而不是功能介绍。',
-          'A skill describes how to handle a kind of task. Only one line per skill stays resident; the body is loaded on demand — so the description should read as a trigger condition, not a feature blurb.',
-        )}
-      </div>
       {skills.length === 0 && <div className="empty">{tr('还没有技能', 'No skills yet')}</div>}
       <div className="col gap8">
         {skills.map((skill) => (
@@ -105,6 +99,12 @@ function MemoryCard() {
     queryFn: () => api.listBuddyMemories(),
     retry: false,
   });
+  const caps = useQuery({ queryKey: ['buddy-capabilities'], queryFn: () => api.getBuddyCapabilities(), retry: false });
+  const toggle = useMutation({
+    mutationFn: (enabled: boolean) => api.setBuddyMemoryEnabled(enabled),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['buddy-capabilities'] }),
+    onError: (e) => toast(e instanceof Error ? e.message : String(e), 'error'),
+  });
   const add = useMutation({
     mutationFn: (text: string) => api.addBuddyMemory(text),
     onSuccess: () => {
@@ -122,15 +122,23 @@ function MemoryCard() {
 
   return (
     <div className="card card-pad">
-      <div className="section-h" style={{ marginBottom: 6 }}>
+      <div className="section-h row gap8" style={{ marginBottom: 10, alignItems: 'center' }}>
         <Icon name="bulb" size={15} style={{ color: 'var(--accent)' }} />
         {tr('长期记忆', 'Memory')}
-      </div>
-      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7, marginBottom: 10 }}>
-        {tr(
-          '你希望 Buddy 一直记得的事——研究方向、习惯的表达、不想被推荐的东西。每轮对话都会带上，所以宜少而准：太多会挤占它读你问题的余地。目前只有你能写，Buddy 自己往里记属于写工具那一期。',
-          'Things you want Buddy to always know. They ride along on every turn, so keep them few and sharp. Only you can write them for now; Buddy writing its own memory comes with the write-tools phase.',
-        )}
+        <span style={{ flex: 1 }} />
+        {/* 开着时 Buddy 才有 remember / recall 两个动作。默认关：一个会自己记东西的
+            助手，得先由用户说「可以」。 */}
+        <label className="row gap6" style={{ alignItems: 'center', cursor: 'pointer', fontSize: 12 }}>
+          <input
+            type="checkbox"
+            checked={caps.data?.memory?.enabled ?? false}
+            onChange={(e) => toggle.mutate(e.target.checked)}
+            style={{ width: 13, height: 13, margin: 0, accentColor: 'var(--accent)' }}
+          />
+          <span style={{ color: 'var(--text-3)' }}>
+            {tr('让 Buddy 自己记与查', 'Let Buddy write and search it')}
+          </span>
+        </label>
       </div>
       <div className="row gap8" style={{ marginBottom: 10 }}>
         <input
@@ -202,12 +210,6 @@ function McpCard() {
       <div className="section-h" style={{ marginBottom: 6 }}>
         <Icon name="git" size={15} style={{ color: 'var(--accent)' }} />
         MCP
-      </div>
-      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.7 }}>
-        {tr(
-          'Polaris 自己是 MCP 服务端：Buddy 用的工具，与 Claude Desktop 这类外部客户端拿到的是同一批（对外只给只读的）。所以这里没有「已连接的服务器」列表——我们不对外连接，列一个空表只会让人误会。',
-          'Polaris is itself an MCP server: Buddy uses the same tools external clients (Claude Desktop and the like) receive, minus anything that writes. There is no "connected servers" list because Polaris makes no outbound MCP connections.',
-        )}
       </div>
       {data && (
         <div className="row gap8" style={{ marginTop: 10, alignItems: 'center', fontSize: 12 }}>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4763,6 +4763,9 @@ export const api = {
   listBuddyMemories(): Promise<{ id: string; text: string; created_at: string }[]> {
     return request('/chat/memories');
   },
+  setBuddyMemoryEnabled(enabled: boolean): Promise<{ enabled: boolean }> {
+    return request('/chat/memory/enabled', { method: 'PUT', body: JSON.stringify({ enabled }) });
+  },
   addBuddyMemory(text: string): Promise<{ id: string; text: string; created_at: string }> {
     return request('/chat/memories', { method: 'POST', body: JSON.stringify({ text }) });
   },
@@ -4782,6 +4785,7 @@ export const api = {
   getBuddyCapabilities(): Promise<{
     tools: { name: string; description: string; read_only: boolean }[];
     skills: { slug: string; name: string; description: string; is_builtin: boolean }[];
+    memory: { enabled: boolean; count: number };
     mcp: { role: string; endpoint: string; exposed_tools: number; note: string };
   }> {
     return request('/chat/capabilities');

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -45,6 +45,8 @@ export type AssistantBlock =
     };
 
 export interface AssistantHandlers {
+  /** 首帧带来的这轮模型名——界面上要显示「这轮用的是谁」 */
+  onMeta?: (meta: { model: string; tools: string[] }) => void;
   /** 用户此刻在看的页面（PolarisBuddy 的页面感知）；不传就不带 */
   page?: { kind: string; id?: string };
   /** 这场对话属于哪个课题（= 平台的 project）。自动跟着外壳当前课题走。 */
@@ -73,6 +75,25 @@ const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : und
  * 由后端按可见性算。以前这里要传 projectId，多课题不传就 409——那是在让用户替一个
  * 纯内部的数据结构做选择题。
  */
+/** 图片出处：认不出的形状一律丢掉。少显示一张图，好过让整条时间线炸掉。
+
+    这段曾经在 #275 里写过，又在那次 rebase 解冲突时被丢掉，只剩下类型和字段的空壳——
+    于是「图片能显示」这条链路一路通到最后一米断了，而 TypeScript 看不出任何问题：
+    字段是可选的，没人填就是 undefined。 */
+function parseImageRefs(raw: unknown): ImageRef[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ImageRef[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const ref = item as Record<string, unknown>;
+    const paperId = str(ref.paper_id);
+    const index = num(ref.index);
+    if (ref.kind !== 'paper_figure' || !paperId || index === undefined) continue;
+    out.push({ kind: 'paper_figure', paperId, index, label: str(ref.label) || undefined });
+  }
+  return out.length ? out : undefined;
+}
+
 /** 一个事件作用到块时间线上，返回新的时间线。
 
     抽成纯函数是为了**能测**：这里处理的是全仓最不可信的输入——SSE 里 JSON.parse 出来
@@ -168,6 +189,7 @@ export function applyAssistantEvent(
             summary: str(data.summary) || undefined,
             preview: str(data.preview) || undefined,
             durationMs: num(data.duration_ms),
+            images: parseImageRefs(data.image_refs),
           }
         : b,
     );
@@ -192,7 +214,12 @@ export function assistantTurnSse(
     {
       onEvent: (event, raw) => {
         const data = parse(raw);
-        if (event === 'done') {
+        if (event === 'meta') {
+          handlers.onMeta?.({
+            model: str(data.model),
+            tools: Array.isArray(data.tools) ? (data.tools as unknown[]).map((t) => str(t)) : [],
+          });
+        } else if (event === 'done') {
           handlers.onDone(str(data.stop_reason, 'stop'));
         } else if (event === 'error') {
           handlers.onError(str(data.detail, '出错了'));
@@ -201,7 +228,12 @@ export function assistantTurnSse(
         }
       },
       onClose: () => handlers.onDone('stop'),
-      onError: (err) => handlers.onError(err instanceof Error ? err.message : String(err)),
+      onError: (err) => {
+        // 传输层错误的默认文案是「network error」，那句话什么都没说明——把能拿到的
+        // 细节都带上，用户至少知道是断在哪儿。
+        const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        handlers.onError(detail || 'connection closed');
+      },
     },
   );
 }


### PR DESCRIPTION
## The "⚠️ network error" was ours, and it was one line out of place

Logs from the deployment:

```
Helm.run.one() exception=TypeError('Object of type datetime is not JSON serializable')
```

`get_project_status` returns datetimes. Helm serialised the payload **after** its `try` block, so the exception escaped the loop, took the SSE connection with it, and the user saw "network error" while two tool cards sat at "calling…". Widening the tool surface in #282 is what first made those tools reachable, which is why it only surfaced now.

Serialisation moved inside the `try`, with `default=str`. "Exceptions never escape Helm" has to hold **until the result is handed over**, or the guarantee fails in the last metre. Two tests: a datetime-returning tool now succeeds, and an object whose `__str__` itself raises becomes a failed result rather than a dead turn.

## Figures never rendered during a conversation

`parseImageRefs` was written in the dock PR and **lost while resolving that branch's rebase conflict**. The `ImageRef` type and the optional `images` field survived, so nothing failed to compile — the pipeline was simply broken at the final step, and TypeScript had nothing to complain about because an optional field nobody fills is just `undefined`. Restored, with three tests pinning it.

Inline figures too: the model writes `![caption](paper_id/index)` in prose, and the Markdown component has had `renderLibraryFigure` / `renderCitation` hooks all along — the library chat uses them. Buddy passed neither, so figures didn't appear and citations weren't clickable. Both are wired now, and citations link to the paper.

## The whole turn is persisted, not just the answer

Switching conversations used to leave a bare conclusion behind — while what makes that conclusion credible is the calls underneath it. Thinking blocks, tool calls, and tool-result summaries (including image refs) are stored and restored. Results are stored as **summaries**, not full payloads: replay needs "what was called and what sort of thing came back", not tens of thousands of characters.

## Memory becomes two actions, behind a switch

`remember` and `recall`, in two tiers. `fact` rides along on every turn; `note` is timestamped and only returns when recalled. They cost differently — storing chat history as facts means paying for old trivia on every future turn.

The tools only enter the tool surface when the user turns memory on. A model that doesn't know the feature exists can't claim to have remembered something it never stored, and "I've noted that" when nothing was written is worse than not being able to remember at all.

`remember` is the first non-read-only tool in the registry. The registry test used to assert *every* tool is read-only; it now names the exception explicitly, so the next writer can't slip in quietly.

## Also in this batch

- the resolved model name is shown in the header — the name you can match against a bill, not the stage name
- topic binding is opt-in: most questions cross topics, and silently narrowing retrieval makes "why can't it find X" impossible to reason about
- transport errors carry their detail instead of the useless "network error"
- follow-up suggestions after each answer, derived from what the turn actually did (papers found → compare them; figures fetched → what do they show); nothing is suggested when the turn gives no basis for it
- secondary topbar controls (admin, language, feedback, approvals) collapse into a menu when the dock narrows the main column — measured on the main column, since opening the dock doesn't change the viewport
- auto-scroll only follows when you're already at the bottom; being yanked back to the newest line while reading earlier output is the most irritating thing a streaming UI can do
- the verbose explanatory paragraphs in the settings tab are gone

Full suite **1116 passed**, vitest **32 passed**.
