### PR TITLE
feat(skills): make skill enablement global instead of per-topic

### DIFF
--- a/src/backend/alembic/versions/07e7faea4c7a_user_skills_global.py
+++ b/src/backend/alembic/versions/07e7faea4c7a_user_skills_global.py
@@ -1,0 +1,113 @@
+"""skills go global: project_skills → user_skills
+
+技能启用不再绑定课题：
+- user_skills：用户 × 技能 × 注入点（可 pin 版本），uq(user, skill, target)
+- 数据搬运：project_skills 按 created_by 去重（同一用户同技能同注入点
+  在多个课题启用过的只保留最早一条），created_by 为空的行丢弃
+- skills.project_id 删列（project scope 从未投入使用）
+- 降级只重建空的 project_skills（按课题的启用关系无法还原）
+
+Revision ID: 07e7faea4c7a
+Revises: c31f7a9d40b2
+Create Date: 2026-08-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "07e7faea4c7a"
+down_revision: str | None = "c31f7a9d40b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_skills",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("skill_id", sa.Uuid(), nullable=False),
+        sa.Column("version_id", sa.Uuid(), nullable=True),
+        sa.Column("target", sa.String(length=64), nullable=False),
+        sa.Column("config", sa.JSON(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["skill_id"], ["skills.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["version_id"], ["skill_versions.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "skill_id", "target", name="uq_user_skills_target"),
+    )
+    op.create_index(op.f("ix_user_skills_user_id"), "user_skills", ["user_id"], unique=False)
+    op.create_index(op.f("ix_user_skills_skill_id"), "user_skills", ["skill_id"], unique=False)
+
+    # 同一 (created_by, skill, target) 多课题启用 → 取最早一条；无归属人的行丢弃
+    op.execute(
+        """
+        INSERT INTO user_skills
+            (id, user_id, skill_id, version_id, target, config,
+             sort_order, enabled, created_at, updated_at)
+        SELECT ps.id, ps.created_by, ps.skill_id, ps.version_id, ps.target, ps.config,
+               ps.sort_order, ps.enabled, ps.created_at, ps.updated_at
+        FROM project_skills ps
+        WHERE ps.created_by IS NOT NULL
+          AND ps.id = (
+              SELECT p2.id FROM project_skills p2
+              WHERE p2.created_by = ps.created_by
+                AND p2.skill_id = ps.skill_id
+                AND p2.target = ps.target
+              ORDER BY p2.created_at, p2.id
+              LIMIT 1
+          )
+        """
+    )
+
+    op.drop_index(op.f("ix_project_skills_skill_id"), table_name="project_skills")
+    op.drop_index(op.f("ix_project_skills_project_id"), table_name="project_skills")
+    op.drop_table("project_skills")
+
+    op.drop_index(op.f("ix_skills_project_id"), table_name="skills")
+    with op.batch_alter_table("skills") as batch:
+        batch.drop_column("project_id")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("skills") as batch:
+        batch.add_column(sa.Column("project_id", sa.Uuid(), nullable=True))
+    op.create_index(op.f("ix_skills_project_id"), "skills", ["project_id"], unique=False)
+
+    op.create_table(
+        "project_skills",
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("skill_id", sa.Uuid(), nullable=False),
+        sa.Column("version_id", sa.Uuid(), nullable=True),
+        sa.Column("target", sa.String(length=64), nullable=False),
+        sa.Column("config", sa.JSON(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_by", sa.Uuid(), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["skill_id"], ["skills.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["version_id"], ["skill_versions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("project_id", "skill_id", "target", name="uq_project_skills_target"),
+    )
+    op.create_index(
+        op.f("ix_project_skills_project_id"), "project_skills", ["project_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_project_skills_skill_id"), "project_skills", ["skill_id"], unique=False
+    )
+
+    op.drop_index(op.f("ix_user_skills_skill_id"), table_name="user_skills")
+    op.drop_index(op.f("ix_user_skills_user_id"), table_name="user_skills")
+    op.drop_table("user_skills")

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -241,17 +241,17 @@ class VoyageEngine:
                 await self._emit_status(run)
 
     async def _ensure_skills_snapshot(self, session: AsyncSession, run: VoyageRun) -> None:
-        """首次驱动时把项目生效技能内容快照进 checkpoint["skills"]（docs/skill-system.md §3.2）。
+        """首次驱动时把任务创建人的生效技能内容快照进 checkpoint["skills"]。
 
-        此后本次 run 只读快照：中途改技能不影响进行中任务，断点恢复无需再查技能表，
-        且事后可回放「本次任务用了哪些技能的哪个版本」。
+        技能全局启用（不绑定课题）；此后本次 run 只读快照：中途改技能不影响进行中任务，
+        断点恢复无需再查技能表，且事后可回放「本次任务用了哪些技能的哪个版本」。
         """
         if "skills" in (run.checkpoint or {}):
             return
-        # P9a：独立库任务无起源课题 → 无项目作用域技能，快照留空。
+        # 系统发起（无创建人）的任务不注入个人技能，快照留空。
         snapshot = (
-            await skills_service.snapshot_for_project(session, run.project_id)
-            if run.project_id is not None
+            await skills_service.snapshot_for_user(session, run.created_by)
+            if run.created_by is not None
             else {}
         )
         checkpoint = dict(run.checkpoint or {})

--- a/src/backend/app/agents/voyage/skillset.py
+++ b/src/backend/app/agents/voyage/skillset.py
@@ -1,6 +1,6 @@
 """SkillSet：读取 voyage checkpoint 的技能快照并渲染注入文本（docs/skill-system.md §3.2）。
 
-快照由 engine 在首次驱动时写入 checkpoint["skills"]（services.skills.snapshot_for_project），
+快照由 engine 在首次驱动时写入 checkpoint["skills"]（services.skills.snapshot_for_user），
 结构：{target: [{slug, name, kind, version, body, config, personas, steps}, ...]}。
 本模块只读快照、不碰 DB——断点恢复与审计回放天然自包含。
 """

--- a/src/backend/app/api/skills.py
+++ b/src/backend/app/api/skills.py
@@ -2,7 +2,7 @@
 
 - /skills：技能 CRUD / 版本 / fork（builtin 只读，user 技能仅本人可改）
 - /skills/import-md：导入 Claude 官方风格技能包（SKILL.md frontmatter + markdown）
-- /projects/{pid}/skills + /project-skills/{id}：启用到项目（项目成员）
+- /user-skills：全局启用（技能不绑定课题，对本人所有新任务生效）
 """
 
 import re
@@ -19,9 +19,6 @@ from app.core.queue import TaskQueue, get_task_queue
 from app.models.skill import Skill
 from app.models.user import User
 from app.schemas.skill import (
-    ProjectSkillCreate,
-    ProjectSkillRead,
-    ProjectSkillUpdate,
     SkillCreate,
     SkillDetail,
     SkillExport,
@@ -32,6 +29,9 @@ from app.schemas.skill import (
     SkillTestResult,
     SkillVersionCreate,
     SkillVersionRead,
+    UserSkillCreate,
+    UserSkillRead,
+    UserSkillUpdate,
 )
 from app.schemas.voyage import VoyageRead
 from app.services import gates as gates_service
@@ -320,78 +320,68 @@ async def archive_skill(
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="SKILL_READ_ONLY") from e
 
 
-# ---- 启用到项目 ----
+# ---- 全局启用（不绑定课题）----
 
 
-def _enable_read(row) -> ProjectSkillRead:  # noqa: ANN001 — ProjectSkill（惰性关系已加载）
-    read = ProjectSkillRead.model_validate(row)
+def _enable_read(row) -> UserSkillRead:  # noqa: ANN001 — UserSkill（惰性关系已加载）
+    read = UserSkillRead.model_validate(row)
     if row.skill is not None:
         read.skill = SkillRead.model_validate(row.skill)
     return read
 
 
-@router.get("/projects/{project_id}/skills", response_model=list[ProjectSkillRead])
-async def list_project_skills(
-    project_id: uuid.UUID,
+@router.get("/user-skills", response_model=list[UserSkillRead])
+async def list_user_skills(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
-) -> list[ProjectSkillRead]:
-    await _require_member(session, project_id, user)
-    rows = await skills_service.list_project_skills(session, project_id)
+) -> list[UserSkillRead]:
+    rows = await skills_service.list_user_skills(session, user.id)
     return [_enable_read(r) for r in rows]
 
 
-@router.post(
-    "/projects/{project_id}/skills",
-    response_model=ProjectSkillRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def enable_project_skill(
-    project_id: uuid.UUID,
-    data: ProjectSkillCreate,
+@router.post("/user-skills", response_model=UserSkillRead, status_code=status.HTTP_201_CREATED)
+async def enable_user_skill(
+    data: UserSkillCreate,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
-) -> ProjectSkillRead:
-    await _require_member(session, project_id, user)
+) -> UserSkillRead:
     skill = await _get_visible_skill(session, data.skill_id, user)
     try:
-        row = await skills_service.enable_skill(
-            session, project_id=project_id, user_id=user.id, data=data, skill=skill
-        )
+        row = await skills_service.enable_skill(session, user_id=user.id, data=data, skill=skill)
     except skills_service.SkillWorkflowInvalidError as e:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except IntegrityError as e:
         await session.rollback()
         raise HTTPException(status.HTTP_409_CONFLICT, detail="SKILL_ALREADY_ENABLED") from e
-    row = await skills_service.get_project_skill(session, row.id)
+    row = await skills_service.get_user_skill(session, row.id)
     assert row is not None
     return _enable_read(row)
 
 
-async def _get_member_enable_row(session: AsyncSession, enable_id: uuid.UUID, user: User):
-    row = await skills_service.get_project_skill(session, enable_id)
-    if row is None or not await gates_service.can_access_project(session, row.project_id, user.id):
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_SKILL_NOT_FOUND")
+async def _get_own_enable_row(session: AsyncSession, enable_id: uuid.UUID, user: User):
+    row = await skills_service.get_user_skill(session, enable_id)
+    if row is None or row.user_id != user.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="USER_SKILL_NOT_FOUND")
     return row
 
 
-@router.patch("/project-skills/{enable_id}", response_model=ProjectSkillRead)
-async def update_project_skill(
+@router.patch("/user-skills/{enable_id}", response_model=UserSkillRead)
+async def update_user_skill(
     enable_id: uuid.UUID,
-    data: ProjectSkillUpdate,
+    data: UserSkillUpdate,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
-) -> ProjectSkillRead:
-    row = await _get_member_enable_row(session, enable_id, user)
-    row = await skills_service.update_project_skill(session, row, data)
+) -> UserSkillRead:
+    row = await _get_own_enable_row(session, enable_id, user)
+    row = await skills_service.update_user_skill(session, row, data)
     return _enable_read(row)
 
 
-@router.delete("/project-skills/{enable_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_project_skill(
+@router.delete("/user-skills/{enable_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user_skill(
     enable_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
-    row = await _get_member_enable_row(session, enable_id, user)
-    await skills_service.delete_project_skill(session, row)
+    row = await _get_own_enable_row(session, enable_id, user)
+    await skills_service.delete_user_skill(session, row)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -38,7 +38,7 @@ from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.registration_code import RegistrationCode
 from app.models.research_digest import LibraryResearchDigest
 from app.models.review import ReviewMessage, ReviewSession
-from app.models.skill import ProjectSkill, Skill, SkillListing, SkillRating, SkillVersion
+from app.models.skill import Skill, SkillListing, SkillRating, SkillVersion, UserSkill
 from app.models.ssh_credential import SSHCredential
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
@@ -88,7 +88,6 @@ __all__ = [
     "Project",
     "ProjectInvite",
     "ProjectMember",
-    "ProjectSkill",
     "RegistrationCode",
     "ReviewMessage",
     "ReviewSession",
@@ -105,6 +104,7 @@ __all__ = [
     "UserLibraryEntry",
     "UserPaperTag",
     "UserPublication",
+    "UserSkill",
     "UUIDPrimaryKeyMixin",
     "VoyageRun",
     "VoyageStep",

--- a/src/backend/app/models/skill.py
+++ b/src/backend/app/models/skill.py
@@ -1,9 +1,10 @@
 """技能系统（docs/skill-system.md）：可版本化、可装配的判断性任务指令包。
 
-- Skill：技能主体（builtin 内置只读 / user 个人 / project 项目级）
+- Skill：技能主体（builtin 内置只读 / user 个人）
 - SkillVersion：不可变版本（manifest JSON + markdown body），只增不改；
   「当前版本」= 该技能 version 最大的一行，不另存指针
-- ProjectSkill：「启用到项目」记录：项目 × 技能 × 注入点，可 pin 版本与配置
+- UserSkill：全局启用记录：用户 × 技能 × 注入点，可 pin 版本与配置
+  （技能不绑定课题，启用后对该用户所有新任务生效）
 - SkillListing：技能市场条目（发布指向具体版本，管理员审核后可安装）
 - SkillRating：市场评分（每人每条目一条，可更新）
 """
@@ -30,13 +31,10 @@ class Skill(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     name_en: Mapped[str | None] = mapped_column(String(255))
     description: Mapped[str | None] = mapped_column(Text)
-    # builtin | user | project
+    # builtin | user
     scope: Mapped[str] = mapped_column(String(16), default="user", index=True, nullable=False)
     owner_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True
-    )
-    project_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True
     )
     is_archived: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
@@ -63,16 +61,16 @@ class SkillVersion(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     skill: Mapped[Skill] = relationship(back_populates="versions")
 
 
-class ProjectSkill(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """技能启用到项目：同一注入点可启用多个技能，按 sort_order 拼接。"""
+class UserSkill(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """技能全局启用（不绑定课题）：同一注入点可启用多个技能，按 sort_order 拼接。"""
 
-    __tablename__ = "project_skills"
+    __tablename__ = "user_skills"
     __table_args__ = (
-        UniqueConstraint("project_id", "skill_id", "target", name="uq_project_skills_target"),
+        UniqueConstraint("user_id", "skill_id", "target", name="uq_user_skills_target"),
     )
 
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
     skill_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("skills.id", ondelete="CASCADE"), index=True, nullable=False
@@ -81,15 +79,12 @@ class ProjectSkill(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     version_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("skill_versions.id", ondelete="SET NULL")
     )
-    # 注入点（docs/skill-system.md §3.1 白名单，schema 层校验）
+    # 注入点（白名单见 schemas/skill.py，schema 层校验）
     target: Mapped[str] = mapped_column(String(64), nullable=False)
     # config_schema 定义的旋钮取值
     config: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    created_by: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("users.id", ondelete="SET NULL")
-    )
 
     skill: Mapped[Skill] = relationship()
 

--- a/src/backend/app/schemas/skill.py
+++ b/src/backend/app/schemas/skill.py
@@ -8,7 +8,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SKILL_KINDS = ("guidance", "rubric", "persona", "workflow")
-SKILL_SCOPES = ("builtin", "user", "project")
+SKILL_SCOPES = ("builtin", "user")
 
 # 注入点白名单（docs/skill-system.md §3.1）。workflow 技能用虚拟注入点 navigator.free_plan
 SKILL_TARGETS = frozenset(
@@ -135,7 +135,6 @@ class SkillRead(BaseModel):
     description: str | None
     scope: str
     owner_id: uuid.UUID | None
-    project_id: uuid.UUID | None
     is_archived: bool
     created_at: datetime
     updated_at: datetime
@@ -147,7 +146,7 @@ class SkillDetail(SkillRead):
     current_version: SkillVersionRead | None = None
 
 
-class ProjectSkillCreate(BaseModel):
+class UserSkillCreate(BaseModel):
     skill_id: uuid.UUID
     target: str
     version_id: uuid.UUID | None = None  # None = 跟随最新
@@ -162,7 +161,7 @@ class ProjectSkillCreate(BaseModel):
         return v
 
 
-class ProjectSkillUpdate(BaseModel):
+class UserSkillUpdate(BaseModel):
     enabled: bool | None = None
     config: dict[str, Any] | None = None
     sort_order: int | None = None
@@ -281,11 +280,11 @@ class ListingDecision(BaseModel):
     comment: str | None = Field(default=None, max_length=2000)
 
 
-class ProjectSkillRead(BaseModel):
+class UserSkillRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    project_id: uuid.UUID
+    user_id: uuid.UUID
     skill_id: uuid.UUID
     version_id: uuid.UUID | None
     target: str

--- a/src/backend/app/services/skills.py
+++ b/src/backend/app/services/skills.py
@@ -1,8 +1,8 @@
 """技能系统业务逻辑（docs/skill-system.md；不 import fastapi）。
 
 - 技能 CRUD / 版本追加 / fork / 归档（builtin 只读）
-- 启用到项目（project_skills）
-- Voyage 快照：把项目生效技能解析成 checkpoint["skills"] 结构（§3.2）
+- 全局启用（user_skills：技能不绑定课题，对该用户所有新任务生效）
+- Voyage 快照：把任务创建人的生效技能解析成 checkpoint["skills"] 结构（§3.2）
 - 内置技能种子幂等插入
 """
 
@@ -18,13 +18,13 @@ from sqlalchemy.orm import selectinload
 if TYPE_CHECKING:
     from app.models.voyage import VoyageRun
 
-from app.models.skill import ProjectSkill, Skill, SkillVersion
+from app.models.skill import Skill, SkillVersion, UserSkill
 from app.schemas.skill import (
-    ProjectSkillCreate,
-    ProjectSkillUpdate,
     SkillCreate,
     SkillManifest,
     SkillVersionCreate,
+    UserSkillCreate,
+    UserSkillUpdate,
 )
 from app.services.builtin_skills import BUILTIN_SKILLS
 
@@ -242,17 +242,15 @@ async def archive_skill(session: AsyncSession, skill: Skill, *, user_id: uuid.UU
     await session.commit()
 
 
-# ---- 启用到项目 ----
+# ---- 全局启用（不绑定课题）----
 
 
-async def list_project_skills(
-    session: AsyncSession, project_id: uuid.UUID
-) -> Sequence[ProjectSkill]:
+async def list_user_skills(session: AsyncSession, user_id: uuid.UUID) -> Sequence[UserSkill]:
     stmt = (
-        select(ProjectSkill)
-        .where(ProjectSkill.project_id == project_id)
-        .options(selectinload(ProjectSkill.skill))
-        .order_by(ProjectSkill.target, ProjectSkill.sort_order, ProjectSkill.created_at)
+        select(UserSkill)
+        .where(UserSkill.user_id == user_id)
+        .options(selectinload(UserSkill.skill))
+        .order_by(UserSkill.target, UserSkill.sort_order, UserSkill.created_at)
     )
     return (await session.execute(stmt)).scalars().all()
 
@@ -260,24 +258,22 @@ async def list_project_skills(
 async def enable_skill(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
     user_id: uuid.UUID,
-    data: ProjectSkillCreate,
+    data: UserSkillCreate,
     skill: Skill,
-) -> ProjectSkill:
-    """同一 (project, skill, target) 唯一（DB 约束），重复启用由调用方转 409。"""
+) -> UserSkill:
+    """同一 (user, skill, target) 唯一（DB 约束），重复启用由调用方转 409。"""
     # 注入点必须是技能声明过的 target（防误挂）；manifest 未声明任何 target 时放行
     declared = _skill_targets(await _manifest_of(session, skill))
     if declared and data.target not in declared:
         raise SkillWorkflowInvalidError(f"skill {skill.slug} does not declare target {data.target}")
-    row = ProjectSkill(
-        project_id=project_id,
+    row = UserSkill(
+        user_id=user_id,
         skill_id=skill.id,
         version_id=data.version_id,
         target=data.target,
         config=data.config,
         sort_order=data.sort_order,
-        created_by=user_id,
     )
     session.add(row)
     await session.commit()
@@ -297,18 +293,18 @@ def _skill_targets(manifest: dict[str, Any] | None) -> list[str]:
     return [t for t in targets if isinstance(t, str)] if isinstance(targets, list) else []
 
 
-async def get_project_skill(session: AsyncSession, enable_id: uuid.UUID) -> ProjectSkill | None:
+async def get_user_skill(session: AsyncSession, enable_id: uuid.UUID) -> UserSkill | None:
     stmt = (
-        select(ProjectSkill)
-        .where(ProjectSkill.id == enable_id)
-        .options(selectinload(ProjectSkill.skill))
+        select(UserSkill)
+        .where(UserSkill.id == enable_id)
+        .options(selectinload(UserSkill.skill))
     )
     return (await session.execute(stmt)).scalar_one_or_none()
 
 
-async def update_project_skill(
-    session: AsyncSession, row: ProjectSkill, data: ProjectSkillUpdate
-) -> ProjectSkill:
+async def update_user_skill(
+    session: AsyncSession, row: UserSkill, data: UserSkillUpdate
+) -> UserSkill:
     if data.enabled is not None:
         row.enabled = data.enabled
     if data.config is not None:
@@ -324,7 +320,7 @@ async def update_project_skill(
     return row
 
 
-async def delete_project_skill(session: AsyncSession, row: ProjectSkill) -> None:
+async def delete_user_skill(session: AsyncSession, row: UserSkill) -> None:
     await session.delete(row)
     await session.commit()
 
@@ -332,16 +328,16 @@ async def delete_project_skill(session: AsyncSession, row: ProjectSkill) -> None
 # ---- Voyage 快照（§3.2）----
 
 
-async def snapshot_for_project(
-    session: AsyncSession, project_id: uuid.UUID
+async def snapshot_for_user(
+    session: AsyncSession, user_id: uuid.UUID
 ) -> dict[str, list[dict[str, Any]]]:
-    """项目生效技能 → checkpoint["skills"]：{target: [条目...]}，条目含完整 body。
+    """用户生效技能 → checkpoint["skills"]：{target: [条目...]}，条目含完整 body。
 
     - pin 了版本用 pin 版本，否则用最新版本；
     - 归档技能 / disabled 行跳过；
     - 结果自包含（不依赖 DB），保证断点恢复与审计回放。
     """
-    rows = await list_project_skills(session, project_id)
+    rows = await list_user_skills(session, user_id)
     snapshot: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
         if not row.enabled or row.skill is None or row.skill.is_archived:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
+HEAD_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
+BUDDY_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
 SKILLS_REVISION = "a22aa895244c"  # Skills v2（SKILL.md 渐进披露）
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
 SCORED_RUN_REVISION = "78e222c38b3b"  # 成员行记下打分它的那次同步任务 id
@@ -96,6 +97,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "conversation_messages",
                     "agent_skills",
                     "agent_skill_files",
+                    "skills",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -171,8 +173,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"depth", "research_type", "goal", "evidence", "seed_idea_id"} <= columns["ideas"]
     # 文献知识底座：paper_chunks 表
     assert "paper_chunks" in columns["_tables"]
-    # 技能系统 S1：skills / skill_versions / project_skills 表
-    assert {"skills", "skill_versions", "project_skills"} <= columns["_tables"]
+    # 技能系统 S1 + 技能全局化：skills / skill_versions / user_skills 表（project_skills 已删）
+    assert {"skills", "skill_versions", "user_skills"} <= columns["_tables"]
+    assert "project_skills" not in columns["_tables"]
+    assert "project_id" not in columns["skills"]
     # 技能市场 S4：skill_listings / skill_ratings 表
     assert {"skill_listings", "skill_ratings"} <= columns["_tables"]
     # 发表机构列（高级检索）
@@ -351,7 +355,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉 Buddy 的长期记忆。
+    # 最新 revision 可往返：先退掉技能全局化（user_skills → 空的 project_skills）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == BUDDY_REVISION
+    assert "user_skills" not in columns["_tables"]
+    assert "project_skills" in columns["_tables"]
+    assert "project_id" in columns["skills"]
+
+    # 再退掉 Buddy 的长期记忆。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == SKILLS_REVISION

--- a/src/backend/tests/test_skills_api.py
+++ b/src/backend/tests/test_skills_api.py
@@ -1,5 +1,5 @@
 """技能系统测试（docs/skill-system.md S1）：
-CRUD/版本/fork/归档 · 启用到项目 · 内置种子幂等 · Voyage 快照与 guidance 注入。"""
+CRUD/版本/fork/归档 · 全局启用（不绑定课题） · 内置种子幂等 · Voyage 快照与 guidance 注入。"""
 
 import uuid
 
@@ -9,7 +9,7 @@ from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.voyage import VoyageRun
 from app.services.builtin_skills import BUILTIN_SKILLS
-from app.services.skills import ensure_builtin_skills, snapshot_for_project
+from app.services.skills import ensure_builtin_skills, snapshot_for_user
 from tests.conftest import RecordingBus, register_and_login
 
 SKILL_BODY = "打分时优先考虑可复现性：没有开源代码的方法降一档。"
@@ -20,6 +20,10 @@ async def _setup(client, email="alice@example.com"):
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post("/api/projects", json={"name": "skill-proj"}, headers=headers)
     return headers, resp.json()["id"]
+
+
+async def _user_id(client, headers) -> uuid.UUID:
+    return uuid.UUID((await client.get("/api/users/me", headers=headers)).json()["id"])
 
 
 def _skill_payload(slug="my-scoring", targets=None):
@@ -132,15 +136,15 @@ async def test_builtin_seed_readonly_and_fork(client):
     assert fork["current_version"]["body"]  # 内容拷贝自内置当前版
 
 
-# ---- 启用到项目 ----
+# ---- 全局启用（不绑定课题）----
 
 
-async def test_enable_skill_to_project(client):
-    headers, project_id = await _setup(client)
+async def test_enable_skill_globally(client):
+    headers, _ = await _setup(client)
     skill = (await client.post("/api/skills", json=_skill_payload(), headers=headers)).json()
 
     resp = await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "forge.score", "config": {"strict": True}},
         headers=headers,
     )
@@ -151,42 +155,45 @@ async def test_enable_skill_to_project(client):
 
     # 重复启用同 target → 409；技能未声明的 target → 422
     resp = await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "forge.score"},
         headers=headers,
     )
     assert resp.status_code == 409
     resp = await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "writing.section"},
         headers=headers,
     )
     assert resp.status_code == 422
 
-    # 非成员 404
+    # 启用记录按人隔离：他人列表为空，他人改/删 → 404
     token_b = await register_and_login(client, email="bob@example.com")
-    resp = await client.get(
-        f"/api/projects/{project_id}/skills", headers={"Authorization": f"Bearer {token_b}"}
+    headers_b = {"Authorization": f"Bearer {token_b}"}
+    assert (await client.get("/api/user-skills", headers=headers_b)).json() == []
+    resp = await client.patch(
+        f"/api/user-skills/{enable['id']}", json={"enabled": False}, headers=headers_b
     )
     assert resp.status_code == 404
 
     # PATCH 停用 + DELETE
     resp = await client.patch(
-        f"/api/project-skills/{enable['id']}", json={"enabled": False}, headers=headers
+        f"/api/user-skills/{enable['id']}", json={"enabled": False}, headers=headers
     )
     assert resp.json()["enabled"] is False
-    resp = await client.delete(f"/api/project-skills/{enable['id']}", headers=headers)
+    resp = await client.delete(f"/api/user-skills/{enable['id']}", headers=headers)
     assert resp.status_code == 204
-    rows = (await client.get(f"/api/projects/{project_id}/skills", headers=headers)).json()
+    rows = (await client.get("/api/user-skills", headers=headers)).json()
     assert rows == []
 
 
 async def test_snapshot_pin_and_latest(client):
-    headers, project_id = await _setup(client)
+    headers, _ = await _setup(client)
+    user_id = await _user_id(client, headers)
     skill = (await client.post("/api/skills", json=_skill_payload(), headers=headers)).json()
     v1_id = skill["current_version"]["id"]
     await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "forge.score", "version_id": v1_id},
         headers=headers,
     )
@@ -197,18 +204,16 @@ async def test_snapshot_pin_and_latest(client):
         headers=headers,
     )
     async with get_sessionmaker()() as session:
-        snapshot = await snapshot_for_project(session, uuid.UUID(project_id))
+        snapshot = await snapshot_for_user(session, user_id)
     assert [e["version"] for e in snapshot["forge.score"]] == [1]
 
     # 解除 pin → 跟随最新
-    enable_id = (await client.get(f"/api/projects/{project_id}/skills", headers=headers)).json()[0][
-        "id"
-    ]
+    enable_id = (await client.get("/api/user-skills", headers=headers)).json()[0]["id"]
     await client.patch(
-        f"/api/project-skills/{enable_id}", json={"unpin_version": True}, headers=headers
+        f"/api/user-skills/{enable_id}", json={"unpin_version": True}, headers=headers
     )
     async with get_sessionmaker()() as session:
-        snapshot = await snapshot_for_project(session, uuid.UUID(project_id))
+        snapshot = await snapshot_for_user(session, user_id)
     assert [e["version"] for e in snapshot["forge.score"]] == [2]
     assert snapshot["forge.score"][0]["body"] == "v2 body"
 
@@ -260,7 +265,7 @@ async def test_voyage_snapshots_enabled_skills(client, queue_stub, bus_recorder)
     headers, project_id = await _setup(client)
     skill = (await client.post("/api/skills", json=_skill_payload(), headers=headers)).json()
     await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "forge.score"},
         headers=headers,
     )

--- a/src/backend/tests/test_skills_workflow.py
+++ b/src/backend/tests/test_skills_workflow.py
@@ -298,7 +298,7 @@ async def test_voyage_detail_lists_snapshot_skills(client, queue_stub, bus_recor
         )
     ).json()
     await client.post(
-        f"/api/projects/{project_id}/skills",
+        "/api/user-skills",
         json={"skill_id": skill["id"], "target": "forge.score"},
         headers=headers,
     )

--- a/src/frontend/src/features/chat/ChatSurface.tsx
+++ b/src/frontend/src/features/chat/ChatSurface.tsx
@@ -108,9 +108,8 @@ export function ChatSurface(cfg: ChatSurfaceConfig) {
   const pendingShareRef = useRef<MentionTarget | null>(null);
 
   const skillsQ = useQuery({
-    queryKey: ['project-skills', cfg.pid],
-    queryFn: () => api.listProjectSkills(cfg.pid),
-    enabled: !!cfg.pid,
+    queryKey: ['user-skills'],
+    queryFn: () => api.listUserSkills(),
     retry: false,
     staleTime: 60_000,
   });

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -17,7 +17,7 @@ import {
   skillTargetLabel,
   skillKindLabel,
   SKILL_TARGETS,
-  type ProjectSkillRead,
+  type UserSkillRead,
   type SkillDetail,
   type SkillKind,
   type SkillListingRead,
@@ -39,7 +39,7 @@ function downloadJson(filename: string, data: unknown): void {
 }
 
 /* ============================================================
-   /skills — 技能库：内置/我的技能列表 + 启用到当前研究方向。
+   /skills — 技能库：内置/我的技能列表 + 全局启用（不绑定课题）。
    - 技能 = 各环节 AI 的补充判断标准（指引/评分标准/评审人设/流程模板）
    - 详情弹窗：全文预览 / 试运行 / 启用 / 复制为我的 / 编辑（追加版本）
    - 流程模板可直接运行此流程→ 创建 AI 任务
@@ -130,7 +130,7 @@ function SkillDetailModal({
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['skills'] });
     void queryClient.invalidateQueries({ queryKey: ['skill', skillId] });
-    void queryClient.invalidateQueries({ queryKey: ['project-skills'] });
+    void queryClient.invalidateQueries({ queryKey: ['user-skills'] });
   };
 
   const testMutation = useMutation({
@@ -173,10 +173,9 @@ function SkillDetailModal({
     onError: (e) => toast(`${tr('删除失败', 'Delete failed')}：${errMsg(e)}`, 'error'),
   });
   const enableMutation = useMutation({
-    mutationFn: (target: string) =>
-      api.enableProjectSkill(currentProjectId!, { skill_id: skillId, target }),
+    mutationFn: (target: string) => api.enableUserSkill({ skill_id: skillId, target }),
     onSuccess: (row) => {
-      toast(`${tr('已启用到当前课题', 'Enabled for current topic')}：${skillTargetLabel(row.target)}`, 'ok');
+      toast(`${tr('已启用', 'Enabled')}：${skillTargetLabel(row.target)}`, 'ok');
       invalidate();
     },
     onError: (e) =>
@@ -217,7 +216,7 @@ function SkillDetailModal({
               className="btn btn-ghost"
               style={{ marginRight: 'auto', color: 'var(--danger, #c0392b)' }}
               onClick={() => {
-                if (window.confirm(tr('删除这个技能？已启用的项目会同时失效（进行中的任务不受影响）。', 'Delete this skill? Projects using it will lose it (running tasks are unaffected).'))) {
+                if (window.confirm(tr('删除这个技能？已启用的环节会同时失效（进行中的任务不受影响）。', 'Delete this skill? Stages using it will lose it (running tasks are unaffected).'))) {
                   archiveMutation.mutate();
                 }
               }}
@@ -261,7 +260,7 @@ function SkillDetailModal({
             {skillTargetLabel(t)}
           </span>
         ))}
-        {skill.kind !== 'workflow' && currentProjectId && targets.length > 0 && (
+        {skill.kind !== 'workflow' && targets.length > 0 && (
           <span className="row gap8" style={{ marginLeft: 'auto' }}>
             {targets.length > 1 && (
               <SelectMenu
@@ -279,7 +278,7 @@ function SkillDetailModal({
                 if (t) enableMutation.mutate(t);
               }}
             >
-              {tr('启用到当前课题', 'Enable for current topic')}
+              {tr('启用', 'Enable')}
             </button>
           </span>
         )}
@@ -801,29 +800,29 @@ function MarketView() {
 
 // ---- 已启用面板 ----
 
-function EnabledPanel({ projectId }: { projectId: string }) {
+function EnabledPanel() {
   const queryClient = useQueryClient();
   const { data: rows, isLoading } = useQuery({
-    queryKey: ['project-skills', projectId],
-    queryFn: () => api.listProjectSkills(projectId),
+    queryKey: ['user-skills'],
+    queryFn: () => api.listUserSkills(),
   });
 
   const patchMutation = useMutation({
-    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) => api.patchProjectSkill(id, { enabled }),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['project-skills', projectId] }),
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) => api.patchUserSkill(id, { enabled }),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['user-skills'] }),
     onError: (e) => toast(`${tr('操作失败', 'Action failed')}：${errMsg(e)}`, 'error'),
   });
   const removeMutation = useMutation({
-    mutationFn: (id: string) => api.removeProjectSkill(id),
+    mutationFn: (id: string) => api.removeUserSkill(id),
     onSuccess: () => {
-      toast(tr('已从当前课题移除', 'Removed from current topic'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['project-skills', projectId] });
+      toast(tr('已移除', 'Removed'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['user-skills'] });
     },
     onError: (e) => toast(`${tr('移除失败', 'Remove failed')}：${errMsg(e)}`, 'error'),
   });
 
   const grouped = useMemo(() => {
-    const m = new Map<string, ProjectSkillRead[]>();
+    const m = new Map<string, UserSkillRead[]>();
     for (const r of rows ?? []) {
       const list = m.get(r.target) ?? [];
       list.push(r);
@@ -834,12 +833,9 @@ function EnabledPanel({ projectId }: { projectId: string }) {
 
   return (
     <div className="card" style={{ padding: '14px 16px' }}>
-      <div style={{ fontSize: 13, fontWeight: 660, marginBottom: 4 }}>{tr('当前课题已启用', 'Enabled for current topic')}</div>
-      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 12 }}>
-        {tr('新发起的 AI 任务会按下面的技能执行；进行中的任务不受影响', 'New AI tasks will use these skills; running tasks are unaffected')}
-      </div>
+      <div style={{ fontSize: 13, fontWeight: 660, marginBottom: 12 }}>{tr('已启用的技能', 'Enabled skills')}</div>
       {isLoading ? null : grouped.length === 0 ? (
-        <EmptyState compact icon="sparkle" title={tr('还没有启用技能', 'No skills enabled yet')} desc={tr('从左侧技能列表点启用到当前课题', 'Enable one from the skill list on the left')} />
+        <EmptyState compact icon="sparkle" title={tr('还没有启用技能', 'No skills enabled yet')} desc={tr('从左侧技能列表点启用', 'Enable one from the skill list on the left')} />
       ) : (
         grouped.map(([target, list]) => (
           <div key={target} style={{ marginBottom: 12 }}>
@@ -872,7 +868,7 @@ function EnabledPanel({ projectId }: { projectId: string }) {
                   <button
                     className="icon-btn"
                     style={{ width: 24, height: 24 }}
-                    title={tr('从当前课题移除', 'Remove from current topic')}
+                    title={tr('移除', 'Remove')}
                     onClick={() => removeMutation.mutate(r.id)}
                   >
                     <Icon name="x" size={12} />
@@ -892,7 +888,6 @@ function EnabledPanel({ projectId }: { projectId: string }) {
 export function SkillsPage() {
   const compact = useIsCompact();
   const queryClient = useQueryClient();
-  const { currentProjectId } = useProject();
   const [view, setView] = useState<'library' | 'market'>('library');
   const [scope, setScope] = useState<ScopeFilter>('all');
   const [kind, setKind] = useState<KindFilter>('all');
@@ -1023,13 +1018,7 @@ export function SkillsPage() {
           )}
         </div>
 
-        {currentProjectId ? (
-          <EnabledPanel projectId={currentProjectId} />
-        ) : (
-          <div className="card" style={{ padding: '14px 16px' }}>
-            <EmptyState compact icon="compass" title={tr('未选择课题', 'No topic selected')} desc={tr('选择课题后可把技能启用到该课题', 'Pick a topic to enable skills for it')} />
-          </div>
-        )}
+        <EnabledPanel />
       </div>
 
       {openId && <SkillDetailModal skillId={openId} onClose={() => setOpenId(null)} />}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2241,7 +2241,7 @@ export interface ReviewSummary {
 // ============================================================
 
 export type SkillKind = 'guidance' | 'rubric' | 'persona' | 'workflow';
-export type SkillScope = 'builtin' | 'user' | 'project';
+export type SkillScope = 'builtin' | 'user';
 
 export interface SkillPersona {
   name: string;
@@ -2270,7 +2270,6 @@ export interface SkillRead {
   description: string | null;
   scope: SkillScope;
   owner_id: string | null;
-  project_id: string | null;
   is_archived: boolean;
   created_at: string;
   updated_at: string;
@@ -2291,9 +2290,9 @@ export interface SkillDetail extends SkillRead {
   current_version: SkillVersionRead | null;
 }
 
-export interface ProjectSkillRead {
+export interface UserSkillRead {
   id: string;
-  project_id: string;
+  user_id: string;
   skill_id: string;
   version_id: string | null;
   target: string;
@@ -4402,23 +4401,23 @@ export const api = {
   ): Promise<VoyageRead> {
     return requestJson<VoyageRead>(`/skills/${id}/run`, 'POST', input);
   },
-  listProjectSkills(projectId: string): Promise<ProjectSkillRead[]> {
-    return request<ProjectSkillRead[]>(`/projects/${projectId}/skills`);
+  /** 全局启用（技能不绑定课题，对本人所有新任务生效）。 */
+  listUserSkills(): Promise<UserSkillRead[]> {
+    return request<UserSkillRead[]>(`/user-skills`);
   },
-  enableProjectSkill(
-    projectId: string,
+  enableUserSkill(
     input: { skill_id: string; target: string; version_id?: string; config?: Record<string, unknown> },
-  ): Promise<ProjectSkillRead> {
-    return requestJson<ProjectSkillRead>(`/projects/${projectId}/skills`, 'POST', input);
+  ): Promise<UserSkillRead> {
+    return requestJson<UserSkillRead>(`/user-skills`, 'POST', input);
   },
-  patchProjectSkill(
+  patchUserSkill(
     enableId: string,
     input: { enabled?: boolean; config?: Record<string, unknown>; sort_order?: number; unpin_version?: boolean },
-  ): Promise<ProjectSkillRead> {
-    return requestJson<ProjectSkillRead>(`/project-skills/${enableId}`, 'PATCH', input);
+  ): Promise<UserSkillRead> {
+    return requestJson<UserSkillRead>(`/user-skills/${enableId}`, 'PATCH', input);
   },
-  removeProjectSkill(enableId: string): Promise<void> {
-    return request<void>(`/project-skills/${enableId}`, { method: 'DELETE' });
+  removeUserSkill(enableId: string): Promise<void> {
+    return request<void>(`/user-skills/${enableId}`, { method: 'DELETE' });
   },
   // —— 论文分享 PPT（文献追踪板块） ——
   /** 发起 PPT 生成任务：single=单篇分享 / survey=多篇主题梳理。 */


### PR DESCRIPTION
Closes #289

## What

Skills are personal judgment criteria, not topic-specific configuration. This PR removes the skill-to-topic binding entirely: a skill is enabled once per user and applies to all AI tasks that user starts, regardless of topic.

## Changes

**Backend**
- `ProjectSkill` (project x skill x target) → `UserSkill` (user x skill x target); unique per (user, skill, target), version pinning / config / sort order semantics unchanged.
- Migration `07e7faea4c7a`: creates `user_skills`, moves existing `project_skills` rows deduped by creator (same user + skill + target enabled in several topics keeps the earliest row; rows without a creator are dropped), drops `project_skills`, and drops the never-used `skills.project_id` column (project scope removed). Downgrade recreates an empty `project_skills` (per-topic enablement is not recoverable).
- Voyage engine snapshots skills from the **run creator's** enabled skills instead of the project's. Snapshot semantics unchanged: self-contained in `checkpoint["skills"]`, running tasks unaffected by later edits.
- API: `GET/POST /user-skills` and `PATCH/DELETE /user-skills/{id}` replace `/projects/{pid}/skills` + `/project-skills/{id}`. Rows are owner-scoped (others get 404).

**Frontend**
- Skills page: the enabled panel is now global — removes the "Enabled for current topic / New AI tasks will use these skills…" copy and the topic-bound enable flow; "Enable" works without selecting a topic. Running a workflow skill still requires a topic (the task itself belongs to one).
- Chat surface reads the global enabled-skill list.

## Tests

- Full backend suite in the api container: **1118 passed**.
- Migration round-trip test updated (upgrade to head + stepwise downgrade through the new revision).
- Frontend: `tsc --noEmit` clean on non-test files (pre-existing missing `vitest` dep in test files), `vite build` passes.
- Ruff: the 10 reported errors are all in files untouched by this PR.