### PR TITLE
fix(voyage): "finished" must not mean "produced nothing"

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -1586,6 +1586,13 @@ async def experiment_run(ctx: ActionContext, params: dict[str, Any]) -> dict[str
         primary_value = extract_primary_value(run.metrics, pm_name)
         run.primary_value = primary_value
         if primary_value is not None:
+            # 记账：真正拿到主指标的轮次数。voyage 级完成标准据此判「这趟到底有没有
+            # 结果」——否则每轮 exit 1、指标全空，只要写出了报告就照样宣告 done
+            # （实测 voyage 6c5df454：三轮里两轮 exit 1，全被判 passed，最后 done，
+            # 报告基于空数据。比直接失败更有害，因为它看起来是成功的）。
+            iterate_cp = dict(ctx.checkpoint.get("iterate") or {})
+            iterate_cp["primary_metric_runs"] = int(iterate_cp.get("primary_metric_runs") or 0) + 1
+            ctx.checkpoint["iterate"] = iterate_cp
             if is_improvement(primary_value, best, pm_direction):
                 state["no_improve_streak"] = 0
             else:

--- a/src/backend/app/agents/voyage/checks.py
+++ b/src/backend/app/agents/voyage/checks.py
@@ -104,9 +104,17 @@ def _check_metric(check: dict, observation: dict, checkpoint: dict) -> str | Non
 
 
 def _check_min_count(check: dict, observation: dict, checkpoint: dict) -> str | None:
+    """字段数量 ≥ value。observation 里没有就去 checkpoint 找。
+
+    回落是为了让这条检查能用在 **voyage 级完成标准**上：``_finalize`` 求值时
+    observation 恒为 None（没有"当前步骤"可言），只有 checkpoint。没有回落的话，
+    完成标准里只能用 artifact_exists 判「某个键非空」，判不了「至少有 N 个」。
+    """
     field = str(check.get("field") or "")
     minimum = int(check.get("value", 1))
     value = _dig(observation, field)
+    if value is None:
+        value = _dig(checkpoint, field)
     if isinstance(value, int | float):
         count = int(value)
     elif isinstance(value, list | dict | str):

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -369,6 +369,11 @@ def experiment_plan(run: VoyageRun) -> list[dict[str, Any]]:
 _DONE_CRITERIA_BY_KIND: dict[str, dict[str, Any]] = {
     "experiment": {
         "checks": [
+            # 至少有一轮真的跑出了主指标。原来只查「停止原因」+「报告已生成」，
+            # 于是每轮 exit 1、指标全空，只要写出报告就照样 done——实测 voyage
+            # 6c5df454 三轮里两轮失败仍宣告完成，还产出了一份基于空数据的报告。
+            # 「跑完了」不等于「有结果」，完成标准必须要求后者。
+            {"kind": "min_count", "field": "iterate.primary_metric_runs", "value": 1},
             {"kind": "artifact_exists", "key": "iterate.stopped_reason"},
             {"kind": "artifact_exists", "key": "report_done"},
         ]

--- a/src/backend/tests/test_experiment_settings.py
+++ b/src/backend/tests/test_experiment_settings.py
@@ -159,3 +159,42 @@ def test_metrics_json_drops_non_finite_values():
     import json as _json
 
     _json.dumps(points, allow_nan=False)  # bool 也被挡掉，不会混进指标
+
+
+# ---- 完成标准必须要求「有结果」（voyage 6c5df454：三轮两败仍宣告 done）----
+
+
+def test_min_count_falls_back_to_checkpoint():
+    """voyage 级完成标准求值时 observation 恒为 None，只能从 checkpoint 取。"""
+    from app.agents.voyage import checks
+
+    check = {"kind": "min_count", "field": "iterate.primary_metric_runs", "value": 1}
+    # observation 没有该字段 → 回落 checkpoint
+    assert checks._check_min_count(check, {}, {"iterate": {"primary_metric_runs": 2}}) is None
+    # finalize 传的就是 None
+    assert checks._check_min_count(check, None, {"iterate": {"primary_metric_runs": 1}}) is None
+    # 一轮都没产出主指标 → 必须判失败，且理由能说清
+    reason = checks._check_min_count(check, None, {"iterate": {"stopped_reason": "max_runs"}})
+    assert reason and "primary_metric_runs" in reason
+
+
+def test_experiment_done_criteria_requires_a_result():
+    """光有「停止原因 + 报告」不够——那正是 6c5df454 假成功的组合。"""
+    from app.agents.voyage import navigator
+    from app.agents.voyage.checks import run_deterministic_checks
+
+    criteria = navigator.done_criteria_for_kind("experiment")
+    checks_list = criteria["checks"]
+
+    # 三轮全废：有停止原因、有报告，但没有任何一轮产出主指标 → 不许 done
+    empty_result = {"iterate": {"stopped_reason": "max_runs"}, "report_done": True}
+    verdict, _ = run_deterministic_checks(checks_list, observation=None, checkpoint=empty_result)
+    assert verdict is not None and not verdict["passed"]
+
+    # 至少一轮有主指标 → 通过
+    with_result = {
+        "iterate": {"stopped_reason": "max_runs", "primary_metric_runs": 1},
+        "report_done": True,
+    }
+    verdict, _ = run_deterministic_checks(checks_list, observation=None, checkpoint=with_result)
+    assert verdict is None or verdict["passed"]


### PR DESCRIPTION
Closes #292

Voyage `6c5df454-…` reached `status=done` with all 11 steps `passed` — and had produced nothing.

## What it actually did

| Step | Observation | Engine |
|---|---|---|
| Round 1 | `exit_code: 0`, `primary_value: null` — primary metric never emitted | `passed` |
| Round 2 | `exit_code: 1`, `run_status: failed`, no metrics | `passed` |
| Round 3 | `exit_code: 1`, `run_status: failed`, no metrics | `passed` |

Two of three rounds failed outright, no round produced the plan's primary metric, and the voyage still finished `done` — with a report generated on top of empty data. Worse than an honest failure, because it reads as success.

## Where the hole is

Marking a failed run `passed` is intentional (`plan_edit.py:110`): a failed training run is not a step failure; the exit code rides in the observation and `analyze` is supposed to route it to a debug branch.

The gap is the voyage-level completion standard:

```python
{"kind": "artifact_exists", "key": "iterate.stopped_reason"},
{"kind": "artifact_exists", "key": "report_done"},
```

"Something stopped the loop" and "a report exists" — neither requires a **result**. Both hold when everything failed: the loop stops on `max_runs`, and the report step writes a file regardless. The checkpoint never recorded whether a round succeeded either; `iterate` held only `started_at` and `stopped_reason`.

## Changes

1. `experiment.run` counts rounds that produced the primary metric into `checkpoint.iterate.primary_metric_runs`.
2. The completion standard requires that count ≥ 1.
3. `min_count` falls back to the checkpoint when the observation lacks the field. `_finalize` evaluates with `observation=None`, so without this a completion standard can only assert "this key is non-empty" — never "there are at least N". This makes `min_count` generally usable in `done_criteria`.

A voyage with no results now ends `paused_error` with a stated reason, which is what "ran to the end and got nothing" should look like.

## Verification

- Tests assert the exact false-success combination from `6c5df454` (stop reason + report, zero successful rounds) is rejected, and that one successful round passes.
- `min_count` fallback covered for `observation={}` and `observation=None`.
- `pytest tests/test_experiments.py tests/test_experiment_settings.py tests/test_voyage_engine.py tests/test_voyage_loop.py tests/test_voyages_api.py` — 66 passed.

## Scope

`done_criteria` is persisted per voyage at planning time, so this governs newly created voyages; existing rows keep the standard they were planned with.

## Related, deliberately not in scope

Rounds 2 and 3 exited 1 without `analyze` routing to a debug branch. The design says failures are handed to `analyze` — here that led nowhere. Worth investigating separately rather than bundling a second behavioural change into this fix.