### PR TITLE
fix(assistant): make the layout respond to the main column, and add plan / goal modes

### DIFF
--- a/src/backend/app/agents/chat/prompt.py
+++ b/src/backend/app/agents/chat/prompt.py
@@ -105,3 +105,35 @@ def tool_definitions(names: tuple[str, ...] | list[str] | None = None) -> list[d
         {"name": spec.name, "description": spec.description, "parameters": spec.input_schema}
         for spec in list_tools(wanted)
     ]
+
+
+#: 三种模式。默认那种（``chat``）行为不变。
+CHAT_MODES = ("chat", "plan", "goal")
+
+#: 计划模式的附加指令。照搬 Claude Code 的 plan mode：**只调研、不动手**，先把方案
+#: 摆出来等人点头。它的价值不在「多一个开关」，而在于把「我以为你要的是 A」这个
+#: 误会提前到花钱之前——研究任务里改错方向的代价是几个小时，不是几秒。
+_PLAN_MODE = """\
+【计划模式】这一轮**只做调研和规划，不给最终结论**。
+
+- 先用工具把事实查清楚，再用 update_plan 把打算怎么做写成分步计划；
+- 计划要具体到「每一步查什么、产出什么」，而不是「分析问题、给出结论」这种废话；
+- 讲清楚你打算怎么做、为什么这么做、哪里可能不成立；
+- 最后一句问用户这个计划行不行，等他点头再执行。**不要**在这一轮就把活干完。"""
+
+#: 目标模式的附加指令。目标随会话存着，每轮都带上——用户不必每次重述，模型也不会
+#: 在第三轮忘了最初要干什么。
+_GOAL_MODE = """\
+【目标模式】这场对话有一个持续目标：{goal}
+
+每一轮都要：先说这一轮把目标推进了多少，再说下一步做什么。已经达成的部分不要重复
+汇报；卡住了就直说卡在哪、需要什么才能继续——假装有进展比停下来更浪费时间。"""
+
+
+def mode_instructions(mode: str, *, goal: str = "") -> str:
+    """模式附加指令；``chat`` 返回空串（默认行为一个字都不变）。"""
+    if mode == "plan":
+        return _PLAN_MODE
+    if mode == "goal" and goal.strip():
+        return _GOAL_MODE.format(goal=goal.strip())
+    return ""

--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -32,7 +32,7 @@ from app.agents.chat.events import (
     VerifyEvent,
 )
 from app.agents.chat.loop import ChatAgentLoop, ChatTurnRequest
-from app.agents.chat.prompt import default_tool_names
+from app.agents.chat.prompt import default_tool_names, mode_instructions
 from app.api.auth import current_active_user, require_llm_chat
 from app.core.config import get_settings
 from app.core.db import get_session
@@ -409,6 +409,18 @@ async def run_turn(
     # 长期记忆随 extra_system 追加在末尾（与方向说明、技能目录同处）：稳定前缀不动，
     # 缓存前缀才不会每轮作废。
     memories = await buddy.render_memories(session, user_id=user.id)
+    # 目标随会话存着：用户设过一次之后每轮都带上，不必重述，模型也不会在第三轮忘了
+    # 最初要干什么。
+    settings = dict(conv.settings or {})
+    if payload.goal is not None:
+        settings["goal"] = payload.goal.strip()
+    goal = str(settings.get("goal") or "")
+    if payload.mode != settings.get("mode"):
+        settings["mode"] = payload.mode
+    if settings != (conv.settings or {}):
+        conv.settings = settings
+        await session.commit()
+    mode_note = mode_instructions(payload.mode, goal=goal)
     await store.append_message(session, conversation=conv, role="user", text=payload.question)
     await session.commit()
 
@@ -453,10 +465,11 @@ async def run_turn(
         max_rounds=payload.max_rounds,
         statement=payload.statement,
         skill_catalog=catalog,
-        extra_system=memories,
+        extra_system="\n\n".join(x for x in (memories, mode_note) if x),
         page_context=buddy.render_page_context(payload.page_kind, payload.page_id),
     )
     conv_id, user_id = conv.id, user.id
+    first_question = payload.question
 
     async def event_stream() -> AsyncIterator[str]:
         # 落库的是**整条时间线**，不只是最终文本。只存文本的后果用户一眼就能看见：
@@ -479,6 +492,11 @@ async def run_turn(
             if blocks:
                 await asyncio.shield(
                     _persist_answer(conv_id, user_id, blocks, timeline.text, stop_reason, usage)
+                )
+                await asyncio.shield(
+                    _name_conversation(
+                        conv_id, user_id, question=first_question, answer=timeline.text
+                    )
                 )
 
     return StreamingResponse(
@@ -591,6 +609,26 @@ class _TurnTimeline:
     def blocks(self) -> list[Any]:
         self._flush_thinking()
         return list(self._blocks)
+
+
+async def _name_conversation(
+    conversation_id: uuid.UUID, user_id: uuid.UUID, *, question: str, answer: str
+) -> None:
+    """第一轮结束后给这场对话起个短名字（≤15 字）。
+
+    只在**还没有名字**时起：改过名的对话不该被下一轮悄悄改回去。用最便宜那档模型，
+    失败就退回用户自己的话——导航用的标题不值得为它冒险。
+    """
+    from app.core.db import get_sessionmaker
+
+    async with get_sessionmaker()() as session:
+        conv = await store.get_owned(session, conversation_id=conversation_id, user_id=user_id)
+        if conv is None or (conv.settings or {}).get("title_generated"):
+            return
+        title = await store.generate_title(get_llm_router(), question=question, answer=answer)
+        conv.title = title
+        conv.settings = {**(conv.settings or {}), "title_generated": True}
+        await session.commit()
 
 
 async def _persist_answer(

--- a/src/backend/app/schemas/chat_agent.py
+++ b/src/backend/app/schemas/chat_agent.py
@@ -49,6 +49,10 @@ class ConversationTurnRequest(BaseModel):
     #: 不给就用默认白名单（首期 6 个只读工具）
     tool_names: list[str] | None = None
     max_rounds: int = Field(default=8, ge=1, le=20)
+    #: chat（默认，行为不变）/ plan（只调研出计划，等人点头）/ goal（带着一个持续目标）
+    mode: str = Field(default="chat", pattern="^(chat|plan|goal)$")
+    #: goal 模式的目标；不传就沿用会话上存着的那个
+    goal: str | None = Field(default=None, max_length=500)
     statement: str | None = None
     #: 用户此刻在看的页面（前端声明）。paper|idea|experiment|library|project|manuscript|daily
     page_kind: str | None = Field(default=None, max_length=32)

--- a/src/backend/app/services/conversations.py
+++ b/src/backend/app/services/conversations.py
@@ -24,6 +24,9 @@ from app.models.conversation import Conversation, ConversationMessage
 #: 标题取首条用户消息的前若干字符
 _TITLE_CHARS = 60
 
+#: 生成标题的长度上限。列表一行放得下才有用——截断的标题和没有标题差不多。
+TITLE_MAX_CHARS = 15
+
 #: 回放预算的保守缺省（字符）。管理端没在模型路由上填 context_window 时用它——
 #: 约合 16k token，给工具 schema、系统提示和本轮生成留足余量。
 DEFAULT_REPLAY_BUDGET_CHARS = 64_000
@@ -338,3 +341,23 @@ async def list_conversations(
         stmt = stmt.where(Conversation.scope_id == scope_id)
     stmt = stmt.order_by(Conversation.last_message_at.desc().nullslast()).limit(limit)
     return list((await session.execute(stmt)).scalars().all())
+
+
+async def generate_title(llm: Any, *, question: str, answer: str) -> str:
+    """给这场对话起个短名字（≤15 字）。
+
+    用**最便宜的那档**模型、只发一小段上下文：标题是导航用的，不值得为它花一次
+    正经推理。取不到就退回问题的前 15 字——那至少是用户自己的话。
+    """
+    fallback = question.strip().replace("\n", " ")[:TITLE_MAX_CHARS]
+    prompt = (
+        f"用不超过 {TITLE_MAX_CHARS} 个字概括下面这段对话的主题，只输出标题本身，"
+        "不要引号、不要标点结尾。\n\n"
+        f"问：{question.strip()[:300]}\n答：{answer.strip()[:300]}"
+    )
+    try:
+        result = await llm.complete("default", [Message(role="user", content=prompt)])
+        title = (result.content or "").strip().strip('"「」\'').splitlines()[0]
+    except Exception:  # noqa: BLE001 — 起名失败不该影响这轮对话
+        return fallback
+    return (title or fallback)[:TITLE_MAX_CHARS]

--- a/src/backend/app/tools/external.py
+++ b/src/backend/app/tools/external.py
@@ -11,10 +11,10 @@ from typing import Any
 
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper
-from app.services.libraries import membership_for_project
 from app.services.literature import get_openalex_client, get_s2_client
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import membership_in_scope
 
 _MAX_K = 10
 
@@ -88,7 +88,7 @@ async def _resolve_ref(ctx: ToolContext, args: dict[str, Any]) -> str:
     async with get_sessionmaker()() as session:
         paper = await session.get(Paper, pid)
         if paper is None or (
-            await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+            await membership_in_scope(session, ctx, pid)
         ) is None:
             raise ValueError(f"库内不存在该论文：{raw}")
         if paper.arxiv_id:

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -22,11 +22,11 @@ from app.services import citations as citations_service
 from app.services import concepts as concepts_service
 from app.services import highlights as highlights_service
 from app.services import notes as notes_service
-from app.services.libraries import membership_for_project
 from app.services.literature.pdf_extract import figure_path
 from app.tools.context import ToolContext
 from app.tools.literature import search_papers as _search_papers
 from app.tools.registry import ToolImage, ToolResult, tool
+from app.tools.scope import membership_in_scope
 
 FIGURE_KINDS = ["motivation", "method", "architecture", "experiment", "other"]
 _DEFAULT_MAX_DIM = 1600
@@ -43,7 +43,7 @@ async def _project_paper(
     opts = [selectinload(Paper.concepts)] if with_concepts else None
     paper = await session.get(Paper, pid, options=opts)
     membership = (
-        await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+        await membership_in_scope(session, ctx, pid)
         if paper is not None
         else None
     )
@@ -250,7 +250,7 @@ async def find_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
         for pid in paper_ids:
             paper = await session.get(Paper, pid)
             if paper is None or (
-                await membership_for_project(session, project_id=ctx.project_id, paper_id=pid)
+                await membership_in_scope(session, ctx, pid)
             ) is None:
                 continue
             for fig in paper.figures or []:

--- a/src/backend/app/tools/libraries.py
+++ b/src/backend/app/tools/libraries.py
@@ -20,6 +20,7 @@ from app.services import daily_feed as daily_service
 from app.services import libraries as libraries_service
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import library_ids_for
 
 _MAX_LIBRARIES = 100
 _MAX_DAILY = 50
@@ -76,7 +77,7 @@ async def list_libraries(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
     async with get_sessionmaker()() as session:
         user = await _require_user(session, ctx)
         rows = await libraries_service.list_libraries_overview(session, user=user, type=want)
-        linked_ids = set(await libraries_service.get_source_library_ids(session, ctx.project_id))
+        linked_ids = set(await library_ids_for(session, ctx))
     briefs = [_library_brief(r, linked=r["id"] in linked_ids) for r in rows]
     if linked_only:
         briefs = [b for b in briefs if b["linked_to_this_topic"]]
@@ -105,7 +106,7 @@ async def get_library(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
         if library is None or not libraries_service.library_visible_to(library, user):
             raise ValueError(f"文献库不存在或无权访问：{args.get('library_id')}")
         row = await libraries_service.library_overview(session, library=library, user=user)
-        linked_ids = set(await libraries_service.get_source_library_ids(session, ctx.project_id))
+        linked_ids = set(await library_ids_for(session, ctx))
     definition = row.get("definition") or {}
     return {
         **_library_brief(row, linked=library_id in linked_ids),

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -526,3 +526,82 @@ async def test_a_tool_that_needs_a_topic_fails_inside_the_loop_not_on_the_wire(c
     assert results, f"没有工具结果帧：{names}"
     assert results[0]["ok"] is False
     assert "课题" in results[0]["summary"], results[0]
+
+
+async def test_every_tool_module_resolves_scope_the_same_way(client, agent_on):
+    """所有工具都必须走同一条范围解析。
+
+    #269 放开检索范围时漏改了三个模块（figures / external / libraries），它们仍按
+    课题查——于是全局模式下取图必然报「库内不存在该论文」，而论文和图都好端端在那儿。
+    这条把「没有工具再自己按 project_id 判成员资格」钉住：漏一个模块，症状是某类工具
+    在全局对话里整体失灵，而其它工具一切正常，很难联想到是范围解析没统一。
+    """
+    import pathlib
+
+    tools_dir = pathlib.Path(__file__).resolve().parent.parent / "app" / "tools"
+    offenders = []
+    for path in tools_dir.glob("*.py"):
+        if path.name == "scope.py":  # 范围解析自己就住在这儿
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "membership_for_project" in text or "get_source_library_ids" in text:
+            offenders.append(path.name)
+    assert offenders == [], f"这些模块还在按课题解析范围：{offenders}"
+
+
+async def test_the_conversation_gets_a_short_name_after_the_first_turn(client, agent_on):
+    """对话要有个短名字（≤15 字），而不是把第一句提问整段截下来当标题。"""
+    from app.services.conversations import TITLE_MAX_CHARS
+
+    headers = await _headers(client, "title@example.com")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "帮我把这个方向的相关工作梳理一遍，重点看最近两年的进展"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    rows = (await client.get("/api/chat/conversations", headers=headers)).json()
+    title = next(r["title"] for r in rows if r["id"] == conv_id)
+    assert title and len(title) <= TITLE_MAX_CHARS
+
+
+async def test_renaming_survives_the_next_turn(client, agent_on):
+    """改过名的对话不该被下一轮悄悄改回去。"""
+    headers = await _headers(client, "title-keep@example.com")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "第一句"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    await client.patch(
+        f"/api/chat/conversations/{conv_id}", json={"title": "我自己起的名字"}, headers=headers
+    )
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": "第二句"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    rows = (await client.get("/api/chat/conversations", headers=headers)).json()
+    assert next(r["title"] for r in rows if r["id"] == conv_id) == "我自己起的名字"
+
+
+async def test_plan_mode_tells_the_model_to_propose_before_acting(client, agent_on):
+    """计划模式把「先出方案等人点头」写进这一轮的指令；默认模式一个字都不加。"""
+    from app.agents.chat.prompt import mode_instructions
+
+    assert mode_instructions("chat") == ""
+    assert mode_instructions("goal", goal="") == ""
+    plan = mode_instructions("plan")
+    assert "只做调研和规划" in plan and "update_plan" in plan
+    goal = mode_instructions("goal", goal="把 CUA 这条线读透")
+    assert "把 CUA 这条线读透" in goal

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -10,7 +10,7 @@ import { UpdateBadge } from '../components/ui/UpdateBadge';
 import { useAuth } from './auth';
 import { topicPath, useProject } from './project';
 import { AssistantPanel } from '../features/assistant/AssistantPanel';
-import { BuddyDock } from '../features/assistant/BuddyDock';
+import { BuddyDock, dockMaxWidth } from '../features/assistant/BuddyDock';
 import { alreadyNudgedToday, markNudged } from '../features/assistant/nudge';
 import { PAPER_DND_MIME } from '../features/assistant/paperDrag';
 import { SearchPalette } from './SearchPalette';
@@ -443,6 +443,14 @@ export function AppShell() {
   // 顶栏还宽裕吗。量的是**主区**：Buddy 拉开后视口没变，变窄的是主区。
   const mainRef = useRef<HTMLDivElement | null>(null);
   const [topbarRoomy, setTopbarRoomy] = useState(true);
+  // 窗口塞不下「侧栏 + 够用的主区 + 停靠栏」时，Buddy 改用覆盖式（就是窄屏那套）。
+  // 硬挤的结果是主区被压成竖排单字，两边都用不了——不如让一边完整。
+  const [dockFits, setDockFits] = useState(() => dockMaxWidth(window.innerWidth) > 0);
+  useEffect(() => {
+    const onResize = () => setDockFits(dockMaxWidth(window.innerWidth) > 0);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
   useEffect(() => {
     const el = mainRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
@@ -923,7 +931,7 @@ export function AppShell() {
       {/* —— PolarisBuddy 停靠栏：它是版面的一列，内容区被挤窄而不是被盖住 ——
           浮层盖住内容，「一边看论文一边问」就只能开一下关一下；停靠栏让两边同时在场。
           窄屏不走这条（挤两列谁都看不清），下面那个覆盖式抽屉才是手机形态。 */}
-      {!isMobile && assistantOpen && (
+      {!isMobile && dockFits && assistantOpen && (
         <BuddyDock>
           <AssistantPanel
             variant="dock"
@@ -1005,7 +1013,7 @@ export function AppShell() {
       {/* —— 全局搜索面板 —— */}
       <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
 
-      {isMobile && (
+      {(isMobile || !dockFits) && (
         <AssistantPanel
           open={assistantOpen}
           onClose={() => setAssistantOpen(false)}

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -462,6 +462,7 @@ export function AssistantPanel({
   >([]);
   const [greeting, setGreeting] = useState<string>('');
   const [model, setModel] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
   // 页面上下文照常发给模型，但不在输入框上占一行——它是背景信息，不是待办事项。
   const contextOn = true;
   const abortRef = useRef<(() => void) | null>(null);
@@ -472,6 +473,10 @@ export function AssistantPanel({
   // 查不到别的库」要好。
   const { currentProject } = useProject();
   const [bindProject, setBindProject] = useState(false);
+  // chat = 默认（行为一个字没变）；plan = 只调研出计划等人点头；goal = 带着一个持续目标
+  const [mode, setMode] = useState<'chat' | 'plan' | 'goal'>('chat');
+  const [goal, setGoal] = useState('');
+  const [plusOpen, setPlusOpen] = useState(false);
   const pageContext = pageContextFrom(location.pathname);
 
   // 只有「本来就贴着底」才跟着滚。正在往回翻的时候被拽回最新一行，是流式界面里最
@@ -543,6 +548,7 @@ export function AssistantPanel({
     stop();
     setConvId(null);
     setTurns([]);
+    setTitle('');
     setHistoryOpen(false);
   }, [stop]);
 
@@ -588,11 +594,18 @@ export function AssistantPanel({
         page:
           contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
         projectId: bindProject ? (currentProject?.id ?? null) : null,
+        mode,
+        goal: mode === 'goal' ? goal : undefined,
         onMeta: (meta) => setModel(meta.model),
         onBlocks: patch,
         onDone: () => {
           setBusy(false);
-          setRailRefresh((n) => n + 1); // 标题这时才有
+          setRailRefresh((n) => n + 1);
+          // 标题是这一轮结束后才生成的，回头取一次
+          void api
+            .listAssistantConversations()
+            .then((rows) => setTitle(rows.find((r) => r.id === id)?.title ?? ''))
+            .catch(() => undefined);
         },
         onError: (detail) => {
           // 把原始细节一并留下：只写「网络错误」等于让用户和我们都无从查起
@@ -605,7 +618,7 @@ export function AssistantPanel({
       },
     );
     },
-    [busy, convId, contextOn, pageContext, currentProject, bindProject],
+    [busy, convId, contextOn, pageContext, currentProject, bindProject, mode, goal],
   );
 
   const send = useCallback(() => {
@@ -681,16 +694,23 @@ export function AssistantPanel({
         }}
       >
         <BuddyMark busy={busy} size={17} />
-        <strong style={{ fontSize: 14 }}>PolarisBuddy</strong>
-        {model && (
-          <span
-            className="mono"
-            style={{ fontSize: 10.5, color: 'var(--text-4)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-            title={tr(`这轮用的模型：${model}`, `Model this turn: ${model}`)}
-          >
-            {model}
-          </span>
-        )}
+        <div style={{ minWidth: 0, display: 'flex', flexDirection: 'column', lineHeight: 1.25 }}>
+          <div className="row gap6" style={{ alignItems: 'center', minWidth: 0 }}>
+            {/* 运行中的呼吸灯：标题栏与会话列表用同一个记号，扫一眼就知道哪场还在跑 */}
+            {busy && <span className="buddy-live-dot" />}
+            <strong
+              style={{ fontSize: 13.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              title={title || 'PolarisBuddy'}
+            >
+              {title || 'PolarisBuddy'}
+            </strong>
+          </div>
+          {model && (
+            <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+              {model}
+            </span>
+          )}
+        </div>
         <span style={{ flex: 1 }} />
         {variant === 'dock' ? (
           <button
@@ -770,6 +790,7 @@ export function AssistantPanel({
           onPick={(id) => void loadConversation(id)}
           onNew={newConversation}
           refreshKey={railRefresh}
+          runningId={busy ? convId : null}
         />
       )}
       {/* overflowWrap: anywhere 是给长 URL、DOI、无空格的模型名留的后路——它们不换行，
@@ -848,25 +869,105 @@ export function AssistantPanel({
       </div>
 
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
-        {/* 课题：默认不绑（检索走全部可见文献库），需要收窄时自己勾 */}
-        {currentProject && (
-          <label
-            className="row gap6"
-            style={{ alignItems: 'center', marginBottom: 6, fontSize: 11, color: 'var(--text-4)', cursor: 'pointer' }}
-            title={tr('勾上后只在这个课题的语料里查', 'Restrict retrieval to this topic when checked')}
+        {/* 模式与课题：都摆在输入框上方一行，像 Codex 那样。默认什么都不选。 */}
+        <div className="row gap8" style={{ alignItems: 'center', marginBottom: 6, position: 'relative' }}>
+          <button
+            className="icon-btn"
+            onClick={() => setPlusOpen((o) => !o)}
+            title={tr('模式与课题', 'Mode and topic')}
+            style={{ width: 24, height: 24 }}
           >
-            <input
-              type="checkbox"
-              checked={bindProject}
-              onChange={(e) => setBindProject(e.target.checked)}
-              style={{ width: 12, height: 12, margin: 0, accentColor: 'var(--accent)', cursor: 'pointer' }}
-            />
-            <Icon name="layers" size={11} />
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {tr(`只查课题：${currentProject.name}`, `Only in: ${currentProject.name}`)}
+            <Icon name="plus" size={13} />
+          </button>
+
+          {mode !== 'chat' && (
+            <span
+              className="pill sm"
+              style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', cursor: 'pointer' }}
+              onClick={() => setMode('chat')}
+              title={tr('点掉回到普通对话', 'Click to return to plain chat')}
+            >
+              {mode === 'plan' ? tr('计划模式', 'Plan mode') : tr('目标模式', 'Goal mode')} ×
             </span>
-          </label>
-        )}
+          )}
+          {bindProject && currentProject && (
+            <span
+              className="pill sm"
+              style={{ cursor: 'pointer', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              onClick={() => setBindProject(false)}
+              title={tr('只在这个课题的语料里查；点掉恢复全部', 'Restricted to this topic; click to clear')}
+            >
+              {currentProject.name} ×
+            </span>
+          )}
+          {mode === 'goal' && (
+            <input
+              className="input"
+              value={goal}
+              placeholder={tr('这场对话要达成什么？', 'What should this conversation achieve?')}
+              onChange={(e) => setGoal(e.target.value)}
+              style={{ flex: 1, minWidth: 0, height: 24, fontSize: 11.5 }}
+            />
+          )}
+
+          {plusOpen && (
+            <>
+              <div onClick={() => setPlusOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 49 }} />
+              <div
+                className="col gap4"
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  bottom: 30,
+                  zIndex: 50,
+                  minWidth: 236,
+                  padding: 6,
+                  background: 'var(--surface)',
+                  border: '0.5px solid var(--border-2)',
+                  borderRadius: 10,
+                  boxShadow: '0 8px 24px rgba(0,0,0,0.14)',
+                }}
+                onClick={() => setPlusOpen(false)}
+              >
+                {currentProject && (
+                  <button
+                    className="btn btn-ghost sm"
+                    style={{ justifyContent: 'flex-start' }}
+                    onClick={() => setBindProject((b) => !b)}
+                  >
+                    <Icon name="layers" size={13} />
+                    <span style={{ flex: 1, textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {tr('只查课题', 'Work in a topic')} · {currentProject.name}
+                    </span>
+                    {bindProject && <Icon name="check" size={12} />}
+                  </button>
+                )}
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ justifyContent: 'flex-start' }}
+                  onClick={() => setMode(mode === 'plan' ? 'chat' : 'plan')}
+                >
+                  <Icon name="bulb" size={13} />
+                  <span style={{ flex: 1, textAlign: 'left' }}>
+                    {tr('计划模式 · 先出方案再动手', 'Plan mode · propose before doing')}
+                  </span>
+                  {mode === 'plan' && <Icon name="check" size={12} />}
+                </button>
+                <button
+                  className="btn btn-ghost sm"
+                  style={{ justifyContent: 'flex-start' }}
+                  onClick={() => setMode(mode === 'goal' ? 'chat' : 'goal')}
+                >
+                  <Icon name="compass" size={13} />
+                  <span style={{ flex: 1, textAlign: 'left' }}>
+                    {tr('目标模式 · 一直朝一个目标推进', 'Goal mode · keep pursuing one goal')}
+                  </span>
+                  {mode === 'goal' && <Icon name="check" size={12} />}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
         {/* 输入区：随内容长高（7 行封顶），发送/停止就在右下角——正在流的时候
             「停」应该在离手最近的位置，而不是让人回面板顶上去找。 */}
         <div

--- a/src/frontend/src/features/assistant/BuddyDock.tsx
+++ b/src/frontend/src/features/assistant/BuddyDock.tsx
@@ -14,8 +14,25 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const WIDTH_KEY = 'polaris.buddy.width';
 const MIN_WIDTH = 320;
-//: 上限按视口算：固定 720 在小笔记本上会把内容区挤到没法看
-const maxWidth = () => Math.max(MIN_WIDTH, Math.min(760, Math.round(window.innerWidth * 0.55)));
+
+//: 侧栏宽度（global.css 里的 .sidebar）。算可用空间时要减掉它。
+const SIDEBAR_WIDTH = 248;
+
+//: 主区的下限。比这更窄，页面里的卡片就会被压成竖排单字——那已经不是「紧凑」，
+//: 是读不了。停靠栏必须先让位，而不是把主区挤到不可用。
+export const MAIN_MIN_WIDTH = 640;
+
+//: 停靠栏的上限。对话不需要很宽（一行太长反而难读），而主区是干活的地方。
+const MAX_WIDTH = 520;
+
+/** 当前视口下停靠栏最多能有多宽；空间不够时返回 0，调用方据此改用覆盖式。 */
+export function dockMaxWidth(viewport: number): number {
+  const room = viewport - SIDEBAR_WIDTH - MAIN_MIN_WIDTH;
+  if (room < MIN_WIDTH) return 0; // 塞不下两栏了
+  return Math.min(MAX_WIDTH, room);
+}
+
+const maxWidth = () => Math.max(MIN_WIDTH, dockMaxWidth(window.innerWidth) || MIN_WIDTH);
 
 export const DEFAULT_WIDTH = 420;
 

--- a/src/frontend/src/features/assistant/ConversationRail.tsx
+++ b/src/frontend/src/features/assistant/ConversationRail.tsx
@@ -51,12 +51,15 @@ export function ConversationRail({
   onPick,
   onNew,
   refreshKey,
+  runningId,
 }: {
   activeId: string | null;
   onPick: (id: string) => void;
   onNew: () => void;
   /** 变一次就重拉一次列表（发完一轮之后标题才有） */
   refreshKey: number;
+  /** 正在跑的那场：列表里给它一个呼吸灯 */
+  runningId?: string | null;
 }) {
   const [rows, setRows] = useState<ConversationRow[]>([]);
   const [renaming, setRenaming] = useState<string | null>(null);
@@ -151,6 +154,7 @@ export function ConversationRail({
                   background: row.id === activeId ? 'var(--accent-soft)' : undefined,
                 }}
               >
+                {row.id === runningId && <span className="buddy-live-dot" />}
                 {renaming === row.id ? (
                   <input
                     className="input"

--- a/src/frontend/src/features/assistant/__tests__/rail.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/rail.test.ts
@@ -48,3 +48,17 @@ describe('按最近活跃分组', () => {
     expect(groups[1]?.rows.map((r) => r.id)).toEqual(['零点前']);
   });
 });
+
+describe('停靠栏的宽度上限', () => {
+  it('先保住主区的下限，剩下的才给停靠栏', async () => {
+    const { dockMaxWidth } = await import('../BuddyDock');
+    expect(dockMaxWidth(1920)).toBe(520);
+    expect(dockMaxWidth(1400)).toBe(512);
+  });
+
+  it('塞不下两栏时返回 0——调用方据此改用覆盖式，而不是把主区挤成竖排单字', async () => {
+    const { dockMaxWidth } = await import('../BuddyDock');
+    expect(dockMaxWidth(1180)).toBe(0);
+    expect(dockMaxWidth(900)).toBe(0);
+  });
+});

--- a/src/frontend/src/features/auth/LoginPage.tsx
+++ b/src/frontend/src/features/auth/LoginPage.tsx
@@ -438,7 +438,7 @@ export function LoginPage() {
           {isRegister ? tr('创建账号', 'Create your account') : tr('欢迎回来', 'Welcome back')}
         </div>
         <div className="auth-card-sub">
-          {tr('北极星 AI 科研智能体，让 AI 与你一起做研究', 'Polaris AI research agent — do research together with AI')}
+          {tr('北极星 AI 科研智能体，与 AI 一起做出发现', 'Polaris AI research agent — discovery, made together with AI')}
         </div>
 
         <div className="row" style={{ justifyContent: 'center', marginBottom: 18 }}>

--- a/src/frontend/src/lib/assistantStream.ts
+++ b/src/frontend/src/lib/assistantStream.ts
@@ -49,8 +49,11 @@ export interface AssistantHandlers {
   onMeta?: (meta: { model: string; tools: string[] }) => void;
   /** 用户此刻在看的页面（PolarisBuddy 的页面感知）；不传就不带 */
   page?: { kind: string; id?: string };
-  /** 这场对话属于哪个课题（= 平台的 project）。自动跟着外壳当前课题走。 */
+  /** 这场对话属于哪个课题（= 平台的 project）。默认不绑，用户勾选才收窄。 */
   projectId?: string | null;
+  /** chat（默认）/ plan（只出方案）/ goal（带着一个持续目标） */
+  mode?: 'chat' | 'plan' | 'goal';
+  goal?: string;
   /** 用「上一份块列表 → 新块列表」的形式增量更新（React 状态直接套用）。 */
   onBlocks: (fn: (blocks: AssistantBlock[]) => AssistantBlock[]) => void;
   onDone: (stopReason: string) => void;
@@ -210,6 +213,8 @@ export function assistantTurnSse(
       question,
       ...(handlers.page ? { page_kind: handlers.page.kind, page_id: handlers.page.id } : {}),
       ...(handlers.projectId ? { project_id: handlers.projectId } : {}),
+      ...(handlers.mode && handlers.mode !== 'chat' ? { mode: handlers.mode } : {}),
+      ...(handlers.goal ? { goal: handlers.goal } : {}),
     },
     {
       onEvent: (event, raw) => {

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -296,8 +296,10 @@ input {
   height: 52px; flex-shrink: 0; border-bottom: 0.5px solid var(--border);
   display: flex; align-items: center; gap: 14px; padding: 0 22px;
   /* 停靠栏一展开，主区就变窄：不允许顶栏被内容顶宽，否则右侧那排图标会被挤出去、
-     叠到面包屑上（内容溢出而不是换行，是 flex 默认 min-width:auto 的经典表现）。 */
-  min-width: 0; overflow: hidden;
+     叠到面包屑上（内容溢出而不是换行，是 flex 默认 min-width:auto 的经典表现）。
+     **不能用 overflow:hidden** —— 那会把顶栏自己的下拉菜单一起裁掉（我上一轮就是
+     这么把「更多」菜单弄没的）。溢出靠子项可压缩来治，不靠裁。 */
+  min-width: 0;
   background: rgba(247, 249, 252, 0.85); backdrop-filter: blur(8px);
   /* backdrop-filter 会新建层叠上下文；顶栏在 .content 之前渲染，
      不抬 z-index 的话下拉浮层会被下方内容盖住。抬到内容之上（低于弹窗/toast）。 */
@@ -328,7 +330,7 @@ input {
   border-radius: 50%; background: var(--accent);
 }
 
-.searchbox { min-width: 0; flex-shrink: 1;
+.searchbox { min-width: 0; flex-shrink: 1; overflow: hidden;
   display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 11px;
   background: var(--surface-2); border: 0.5px solid var(--border-2); border-radius: 8px;
   color: var(--text-3); font-size: 12.5px; min-width: 200px; cursor: text;
@@ -346,7 +348,14 @@ input {
   font-family: var(--mono);
 }
 
-.content { flex: 1; overflow-y: auto; min-width: 0; }
+.content {
+  flex: 1; overflow-y: auto; min-width: 0;
+  /* 响应式的判据是**主区多宽**，不是视口多宽。Buddy 的停靠栏一拉开，视口一点没变、
+     主区却窄了一大截——所有挂在 @media 上的规则都以为还很宽，于是卡片被压成竖排单字。
+     容器查询让这些规则跟着真正变化的那个尺寸走。 */
+  container-type: inline-size;
+  container-name: mainarea;
+}
 /* 同理：主区必须能被压缩到比内容还窄，否则挤的是停靠栏 */
 .main { min-width: 0; }
 .page { max-width: 1180px; margin: 0 auto; padding: 20px 36px 80px; }
@@ -1418,4 +1427,41 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 @keyframes buddy-breathe {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.55; transform: scale(0.94); }
+}
+
+
+/* ============================================================
+   主区变窄时（多半是 PolarisBuddy 拉开了，而不是窗口变小）
+   ============================================================ */
+@container mainarea (max-width: 900px) {
+  /* 统计卡：两列比四列挤成竖排单字强得多 */
+  .dash-stats { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dash-main { display: block; }
+  .dash-primary + .dash-side { margin-top: 20px; }
+  .dash-side { position: static; }
+  .page-head { flex-direction: column; align-items: stretch; gap: 12px; }
+  .page-head-actions { margin-left: 0; flex-wrap: wrap; }
+  .page { padding-left: 20px; padding-right: 20px; }
+}
+@container mainarea (max-width: 620px) {
+  /* 再窄就一列。卡片有下限：低于它文字必然逐字换行，不如让它们排成一列 */
+  .dash-stats { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* 统计卡与流水线节点的宽度下限：宽度低于此值时中文会被压成竖排单字，
+   那已经不是「紧凑」而是读不了。 */
+.dash-stats > * { min-width: 132px; }
+.pipeline-node { min-width: 92px; }
+
+
+/* 运行中的呼吸灯。绿色 + 呼吸而不是转圈：它要在余光里可见，又不能像 spinner 那样
+   把视线拽过去——一份对话列表里可能同时有好几个在跑。 */
+.buddy-live-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--ok-tx, #19A974); flex-shrink: 0;
+  animation: buddy-pulse 1.4s ease-in-out infinite;
+}
+@keyframes buddy-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(25, 169, 116, 0.45); }
+  50% { opacity: 0.5; box-shadow: 0 0 0 4px rgba(25, 169, 116, 0); }
 }


### PR DESCRIPTION
## Layout responded to the viewport, not to what actually changed

Opening the dock narrows the **main column** while the viewport stays exactly the same, so every `@media` rule still believed there was plenty of room. That's how the stat cards ended up squeezed into vertical single characters.

The main area is now a container (`container-type: inline-size`) and those rules are container queries, so they follow the dimension that actually moves. Cards also get a width floor: below it Chinese text wraps one character per line, which isn't "compact", it's unreadable.

## The topbar was clipping its own dropdown

`overflow: hidden` was added last round to stop content pushing the bar wider. It also cut off the "more" menu — which is exactly why the collapsed controls appeared to do nothing when clicked. Overflow is handled by making the children shrinkable instead of by cutting.

## Main gets a floor, the dock gets a ceiling

The dock takes what's left after the sidebar and a 640px main column, capped at 520px: a conversation doesn't need to be wide, and the main area is where the work happens. When the window can't fit both, the dock steps aside and Buddy opens as an overlay, the same as on a phone — one usable column beats two unusable ones.

## Three tool modules never got the scope migration

`figures`, `external` and `libraries` still resolved membership by topic. In a global conversation, fetching a figure therefore always answered "no such paper in the library" while the paper and its figures sat right there. All three now use the shared scope resolution.

A test walks `app/tools/` and asserts nobody resolves scope on their own. Missing one module makes an entire class of tools fail while everything else looks fine — nearly impossible to trace back to "scope resolution wasn't unified".

## Conversations get a real name

A short generated title (≤15 characters) instead of the first 60 characters of the opening question, produced by the cheapest model tier once the first turn lands, falling back to the user's own words when that call fails. A manual rename is never overwritten by a later turn.

The header shows that title with the model name underneath, and a green breathing dot marks a running turn — in both the header and the conversation list, so you can see at a glance which one is still working.

## Two modes, the default untouched

**Plan mode** researches and produces a plan for approval instead of doing the work. The value isn't an extra switch: it moves "I assumed you meant A" to *before* the time is spent, and in research tasks the cost of the wrong direction is hours, not seconds.

**Goal mode** keeps a stated goal on the conversation and reports progress toward it each turn, so the user doesn't restate it and the model doesn't forget it by turn three.

Both live behind the plus button next to the composer, alongside the optional topic restriction (still opt-in — most questions cross topics).

Also: the login tagline emphasises discovery rather than "do research together".

## Tests

Full suite **1132 passed**, vitest **34 passed**. One pre-existing failure on `main` (`test_debug_limit_terminates`) is unrelated — verified by stashing these changes and reproducing it.
