### PR TITLE
feat(assistant): rebuild Buddy's surface in the Codex idiom

### DIFF
--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -12,6 +12,7 @@ import {
   type PlanStep,
 } from '../../lib/assistantStream';
 import { tr } from '../../lib/i18n';
+import { copyText } from '../../lib/clipboard';
 import { BuddyHome } from './BuddyHome';
 import { followUps } from './followups';
 import { InlineFigure } from './InlineFigure';
@@ -843,6 +844,43 @@ export function AssistantPanel({
                     />
                   ))}
                   {isLast && <TurnStatus blocks={liveBlocks} busy={busy} onStop={stop} />}
+                  {/* 答完之后的操作行：复制、重来。**不放点赞/点踩**——没有接收端的
+                      反馈按钮是摆设，点了之后什么都没发生比没有按钮更伤信任。 */}
+                  {!busy && turn.blocks.some((b) => b.kind === 'text') && (
+                    <div className="row gap4" style={{ marginTop: 8, alignItems: 'center' }}>
+                      <button
+                        className="icon-btn"
+                        title={tr('复制回答', 'Copy answer')}
+                        onClick={() => {
+                          const text = turn.blocks
+                            .filter((b) => b.kind === 'text')
+                            .map((b) => (b.kind === 'text' ? b.text : ''))
+                            .join('\n');
+                          void copyText(text);
+                        }}
+                        style={{ width: 24, height: 24 }}
+                      >
+                        <Icon name="file" size={12} />
+                      </button>
+                      {isLast && (
+                        <button
+                          className="icon-btn"
+                          title={tr('换一个回答', 'Answer again')}
+                          onClick={() => {
+                            const question = turns[i - 1];
+                            const text =
+                              question?.role === 'user'
+                                ? question.blocks.map((b) => (b.kind === 'text' ? b.text : '')).join('')
+                                : '';
+                            if (text) void ask(text);
+                          }}
+                          style={{ width: 24, height: 24 }}
+                        >
+                          <Icon name="refresh" size={12} />
+                        </button>
+                      )}
+                    </div>
+                  )}
                   {/* 答完给几条可点的下一步。它们从本轮真实发生的事里出——查到了论文
                       就问共同点，取过图就问图说明什么。凭空造的建议点一次就没人再点。 */}
                   {isLast && !busy && followUps(turn.blocks).length > 0 && (
@@ -866,48 +904,67 @@ export function AssistantPanel({
         })}
       </div>
 
-      </div>
-
       <div style={{ padding: 12, borderTop: '0.5px solid var(--border-2)' }}>
-        {/* 模式与课题：都摆在输入框上方一行，像 Codex 那样。默认什么都不选。 */}
-        <div className="row gap8" style={{ alignItems: 'center', marginBottom: 6, position: 'relative' }}>
+        {/* 上下文栏贴在输入框顶上（Codex 那样）：课题与模式是这次提问的前置条件，
+            放进框里会和正文抢注意力，放到别处又和输入脱节。 */}
+        <div
+          className="row gap8"
+          style={{
+            alignItems: 'center',
+            padding: '6px 10px',
+            border: '0.5px solid var(--border-2)',
+            borderBottom: 'none',
+            borderRadius: '12px 12px 0 0',
+            background: 'var(--surface-2)',
+            fontSize: 11.5,
+            color: 'var(--text-3)',
+            position: 'relative',
+          }}
+        >
           <button
             className="icon-btn"
             onClick={() => setPlusOpen((o) => !o)}
-            title={tr('模式与课题', 'Mode and topic')}
-            style={{ width: 24, height: 24 }}
+            title={tr('课题与模式', 'Topic and mode')}
+            style={{ width: 22, height: 22 }}
           >
             <Icon name="plus" size={13} />
           </button>
 
-          {mode !== 'chat' && (
+          {bindProject && currentProject ? (
             <span
-              className="pill sm"
-              style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', cursor: 'pointer' }}
-              onClick={() => setMode('chat')}
-              title={tr('点掉回到普通对话', 'Click to return to plain chat')}
-            >
-              {mode === 'plan' ? tr('计划模式', 'Plan mode') : tr('目标模式', 'Goal mode')} ×
-            </span>
-          )}
-          {bindProject && currentProject && (
-            <span
-              className="pill sm"
-              style={{ cursor: 'pointer', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              className="row gap6 hoverable"
+              style={{ alignItems: 'center', cursor: 'pointer', minWidth: 0 }}
               onClick={() => setBindProject(false)}
               title={tr('只在这个课题的语料里查；点掉恢复全部', 'Restricted to this topic; click to clear')}
             >
-              {currentProject.name} ×
+              <Icon name="layers" size={12} />
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {currentProject.name}
+              </span>
             </span>
+          ) : (
+            <span style={{ color: 'var(--text-4)' }}>{tr('全部文献库', 'All libraries')}</span>
           )}
-          {mode === 'goal' && (
-            <input
-              className="input"
-              value={goal}
-              placeholder={tr('这场对话要达成什么？', 'What should this conversation achieve?')}
-              onChange={(e) => setGoal(e.target.value)}
-              style={{ flex: 1, minWidth: 0, height: 24, fontSize: 11.5 }}
-            />
+
+          {mode !== 'chat' && (
+            <>
+              <span style={{ color: 'var(--border-2)' }}>·</span>
+              <span
+                className="hoverable"
+                style={{ cursor: 'pointer', color: 'var(--accent-text)' }}
+                onClick={() => setMode('chat')}
+                title={tr('点掉回到普通对话', 'Click to return to plain chat')}
+              >
+                {mode === 'plan' ? tr('计划模式', 'Plan mode') : tr('目标模式', 'Goal mode')}
+              </span>
+            </>
+          )}
+
+          <span style={{ flex: 1 }} />
+          {model && (
+            <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }} title={model}>
+              {model}
+            </span>
           )}
 
           {plusOpen && (
@@ -917,24 +974,20 @@ export function AssistantPanel({
                 className="col gap4"
                 style={{
                   position: 'absolute',
-                  left: 0,
-                  bottom: 30,
+                  left: 6,
+                  bottom: 34,
                   zIndex: 50,
-                  minWidth: 236,
+                  minWidth: 244,
                   padding: 6,
                   background: 'var(--surface)',
                   border: '0.5px solid var(--border-2)',
-                  borderRadius: 10,
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.14)',
+                  borderRadius: 12,
+                  boxShadow: '0 10px 28px rgba(0,0,0,0.14)',
                 }}
                 onClick={() => setPlusOpen(false)}
               >
                 {currentProject && (
-                  <button
-                    className="btn btn-ghost sm"
-                    style={{ justifyContent: 'flex-start' }}
-                    onClick={() => setBindProject((b) => !b)}
-                  >
+                  <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => setBindProject((b) => !b)}>
                     <Icon name="layers" size={13} />
                     <span style={{ flex: 1, textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                       {tr('只查课题', 'Work in a topic')} · {currentProject.name}
@@ -942,47 +995,44 @@ export function AssistantPanel({
                     {bindProject && <Icon name="check" size={12} />}
                   </button>
                 )}
-                <button
-                  className="btn btn-ghost sm"
-                  style={{ justifyContent: 'flex-start' }}
-                  onClick={() => setMode(mode === 'plan' ? 'chat' : 'plan')}
-                >
+                <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => setMode(mode === 'plan' ? 'chat' : 'plan')}>
                   <Icon name="bulb" size={13} />
-                  <span style={{ flex: 1, textAlign: 'left' }}>
-                    {tr('计划模式 · 先出方案再动手', 'Plan mode · propose before doing')}
-                  </span>
+                  <span style={{ flex: 1, textAlign: 'left' }}>{tr('计划模式 · 先出方案再动手', 'Plan mode · propose before doing')}</span>
                   {mode === 'plan' && <Icon name="check" size={12} />}
                 </button>
-                <button
-                  className="btn btn-ghost sm"
-                  style={{ justifyContent: 'flex-start' }}
-                  onClick={() => setMode(mode === 'goal' ? 'chat' : 'goal')}
-                >
+                <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => setMode(mode === 'goal' ? 'chat' : 'goal')}>
                   <Icon name="compass" size={13} />
-                  <span style={{ flex: 1, textAlign: 'left' }}>
-                    {tr('目标模式 · 一直朝一个目标推进', 'Goal mode · keep pursuing one goal')}
-                  </span>
+                  <span style={{ flex: 1, textAlign: 'left' }}>{tr('目标模式 · 一直朝一个目标推进', 'Goal mode · keep pursuing one goal')}</span>
                   {mode === 'goal' && <Icon name="check" size={12} />}
                 </button>
               </div>
             </>
           )}
         </div>
-        {/* 输入区：随内容长高（7 行封顶），发送/停止就在右下角——正在流的时候
-            「停」应该在离手最近的位置，而不是让人回面板顶上去找。 */}
+
+        {mode === 'goal' && (
+          <input
+            className="input"
+            value={goal}
+            placeholder={tr('这场对话要达成什么？', 'What should this conversation achieve?')}
+            onChange={(e) => setGoal(e.target.value)}
+            style={{ width: '100%', height: 28, fontSize: 11.5, borderRadius: 0 }}
+          />
+        )}
+
         <div
           style={{
             border: '0.5px solid var(--border-2)',
-            borderRadius: 10,
+            borderRadius: '0 0 12px 12px',
             background: 'var(--surface)',
-            padding: '8px 10px 6px',
+            padding: '10px 12px 8px',
           }}
         >
           <textarea
             className="textarea"
             rows={1}
             value={input}
-            placeholder={tr('问点什么…', 'Ask something…')}
+            placeholder={tr('问点什么…', 'Ask anything…')}
             onChange={(e) => {
               setInput(e.target.value);
               const el = e.target;
@@ -997,37 +1047,52 @@ export function AssistantPanel({
             }}
             style={{
               width: '100%',
-              fontSize: 13,
+              fontSize: 13.5,
               border: 'none',
               outline: 'none',
               resize: 'none',
               background: 'transparent',
               padding: 0,
               maxHeight: 140,
-              lineHeight: '20px',
+              lineHeight: '21px',
             }}
           />
-          <div className="row gap8" style={{ alignItems: 'center', marginTop: 4 }}>
+          <div className="row gap8" style={{ alignItems: 'center', marginTop: 6 }}>
             <span style={{ flex: 1, fontSize: 10.5, color: 'var(--text-4)' }}>
               {tr('Enter 发送 · Shift+Enter 换行', 'Enter to send · Shift+Enter for a new line')}
             </span>
             {busy ? (
-              <button className="btn btn-ghost sm" onClick={stop} style={{ height: 26, fontSize: 11.5 }}>
-                <Icon name="pause" size={11} /> {tr('停止', 'Stop')}
+              <button
+                onClick={stop}
+                title={tr('停止', 'Stop')}
+                style={{
+                  width: 28, height: 28, borderRadius: '50%', border: 'none',
+                  background: 'var(--surface-3)', cursor: 'pointer',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}
+              >
+                <Icon name="pause" size={12} />
               </button>
             ) : (
               <button
-                className="btn btn-primary sm"
                 onClick={send}
                 disabled={!input.trim()}
-                style={{ height: 26, fontSize: 11.5 }}
+                title={tr('发送', 'Send')}
+                style={{
+                  width: 28, height: 28, borderRadius: '50%', border: 'none',
+                  background: input.trim() ? 'var(--accent)' : 'var(--surface-3)',
+                  color: input.trim() ? '#fff' : 'var(--text-4)',
+                  cursor: input.trim() ? 'pointer' : 'default',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}
               >
-                {tr('发送', 'Send')}
+                <Icon name="arrow" size={13} />
               </button>
             )}
           </div>
         </div>
       </div>
+    </div>
     </div>
   );
 }

--- a/src/frontend/src/features/assistant/BuddyHome.tsx
+++ b/src/frontend/src/features/assistant/BuddyHome.tsx
@@ -3,38 +3,34 @@ import { PolarisMark } from '../../components/ui/PolarisLogo';
 import { tr } from '../../lib/i18n';
 
 /* ============================================================
-   PolarisBuddy 的初始界面。
+   PolarisBuddy 的空态。
 
-   空对话是最难写的一屏：用户不知道它能干什么，而一段说明文字没人读。所以摆几张
-   **能直接点的卡片**——它们既是能力说明，也是入口，点一下就开始。
+   照 Codex 那套排：大片留白、居中一个很淡的标识、一句大字问句，下面四张卡片。
+   卡片只留图标和标题——描述文字看似贴心，实际没人读，反而把四张卡挤成小方块。
 
-   卡片按平台的四件事分：找文献 / 读论文 / 理想法 / 看实验。这不是随便选的四个，
-   而是平台本来的四个阶段；用户在哪个阶段，就点哪张。
-
-   标识做成大号浅灰水印：空屏需要一个视觉落点，又不该抢走卡片的注意力。
+   四张卡是平台的四个阶段（找文献 / 读论文 / 理想法 / 看实验）：用户在哪个阶段就点
+   哪张，这既是能力说明也是入口。
    ============================================================ */
 
 export interface HomeCard {
   icon: IconName;
+  color: string;
   title: string;
-  hint: string;
   prompt: string;
 }
 
-/** 卡片是固定的四张。与「快捷动作」不同——那些按你的数据变，这四张是能力地图。
-
-    写成函数而不是模块级常量：顶层 tr 在模块加载时就定死了，之后切换中英文不会重算。 */
+/** 写成函数而不是模块级常量：顶层 tr 在模块加载时就定死了，切换中英文不会重算。 */
 export const homeCards = (): HomeCard[] => [
   {
     icon: 'search',
+    color: '#2C7BE5',
     title: tr('找相关文献', 'Find related work'),
-    hint: tr('说个方向，我去库里翻', 'Name a direction, I search the libraries'),
     prompt: tr('帮我找一下和「」相关的论文，先铺开看看有哪些。', 'Find papers related to "" — start wide.'),
   },
   {
     icon: 'book',
+    color: '#8B5CF6',
     title: tr('读懂一篇论文', 'Understand a paper'),
-    hint: tr('方法怎么工作、证据强不强', 'How the method works, how strong the evidence is'),
     prompt: tr(
       '帮我精读一篇论文：它解决什么问题、方法怎么工作、证据强不强。',
       'Walk me through a paper: the problem, how the method works, how strong the evidence is.',
@@ -42,8 +38,8 @@ export const homeCards = (): HomeCard[] => [
   },
   {
     icon: 'bulb',
+    color: '#19A974',
     title: tr('理清一个想法', 'Sharpen an idea'),
-    hint: tr('有没有人做过、差别在哪', 'Who has done it, and how yours differs'),
     prompt: tr(
       '我有个想法想理一理：先帮我查有没有人做过，再说说和已有工作的差别。',
       'I have an idea — check whether it has been done, then contrast it with prior work.',
@@ -51,8 +47,8 @@ export const homeCards = (): HomeCard[] => [
   },
   {
     icon: 'flask',
+    color: '#E8590C',
     title: tr('看看实验进展', 'Check experiments'),
-    hint: tr('跑到哪了、下一步做什么', 'Where they stand and what is next'),
     prompt: tr(
       '我的实验现在什么情况？跑到哪了，下一步该做什么。',
       'How are my experiments doing, and what is next?',
@@ -75,73 +71,58 @@ export function BuddyHome({
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: '24px 18px',
-        position: 'relative',
-        overflow: 'hidden',
+        padding: '32px 20px',
+        gap: 26,
       }}
     >
-      {/* 水印：空屏的视觉落点，压到很淡，不跟卡片抢注意力 */}
-      <div
-        aria-hidden
-        style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -58%)',
-          opacity: 0.045,
-          pointerEvents: 'none',
-        }}
-      >
-        <PolarisMark size={260} />
+      {/* 标识压得很淡：空屏需要一个落点，但它不该比问句更响 */}
+      <div style={{ opacity: 0.16 }}>
+        <PolarisMark size={54} dot={false} />
       </div>
 
-      <div style={{ position: 'relative', width: '100%', maxWidth: 460 }}>
-        <div className="row gap8" style={{ alignItems: 'center', justifyContent: 'center', marginBottom: 6 }}>
-          <PolarisMark size={26} />
-          <strong style={{ fontSize: 17, letterSpacing: '-0.01em' }}>PolarisBuddy</strong>
+      <div style={{ textAlign: 'center', maxWidth: 380 }}>
+        <div style={{ fontSize: 21, fontWeight: 600, letterSpacing: '-0.02em', lineHeight: 1.35 }}>
+          {tr('今天想做点什么发现？', 'What should we discover?')}
         </div>
-        <div
-          style={{
-            textAlign: 'center',
-            fontSize: 12.5,
-            color: 'var(--text-3)',
-            lineHeight: 1.7,
-            marginBottom: 18,
-            minHeight: 22,
-          }}
-        >
-          {/* 问候语来自真实计数；数不出来时就不说，这里也不摆占位 */}
-          {greeting}
-        </div>
+        {greeting && (
+          <div style={{ fontSize: 12.5, color: 'var(--text-3)', lineHeight: 1.7, marginTop: 8 }}>
+            {greeting}
+          </div>
+        )}
+      </div>
 
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-            gap: 8,
-          }}
-        >
-          {homeCards().map((card) => (
-            <div
-              key={card.title}
-              className="hoverable"
-              onClick={() => onPick(card.prompt)}
-              style={{
-                border: '0.5px solid var(--border-2)',
-                borderRadius: 10,
-                padding: '11px 12px',
-                cursor: 'pointer',
-                background: 'var(--surface)',
-              }}
-            >
-              <Icon name={card.icon} size={15} style={{ color: 'var(--accent)' }} />
-              <div style={{ fontSize: 12.5, fontWeight: 600, marginTop: 6 }}>{card.title}</div>
-              <div style={{ fontSize: 11, color: 'var(--text-4)', lineHeight: 1.5, marginTop: 2 }}>
-                {card.hint}
-              </div>
-            </div>
-          ))}
-        </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+          gap: 10,
+          width: '100%',
+          maxWidth: 460,
+        }}
+      >
+        {homeCards().map((card) => (
+          <button
+            key={card.title}
+            onClick={() => onPick(card.prompt)}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              gap: 14,
+              minHeight: 96,
+              padding: '13px 14px',
+              border: '0.5px solid var(--border-2)',
+              borderRadius: 12,
+              background: 'var(--surface)',
+              cursor: 'pointer',
+              textAlign: 'left',
+              font: 'inherit',
+            }}
+          >
+            <Icon name={card.icon} size={17} style={{ color: card.color }} />
+            <span style={{ fontSize: 13, fontWeight: 550, lineHeight: 1.4 }}>{card.title}</span>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/frontend/src/features/assistant/ConversationRail.tsx
+++ b/src/frontend/src/features/assistant/ConversationRail.tsx
@@ -108,7 +108,7 @@ export function ConversationRail({
   return (
     <div
       style={{
-        width: 176,
+        width: 184,
         flexShrink: 0,
         borderRight: '0.5px solid var(--border-2)',
         display: 'flex',
@@ -116,13 +116,23 @@ export function ConversationRail({
         background: 'var(--surface-2)',
       }}
     >
-      <button
-        className="btn btn-soft sm"
+      {/* 「新对话」按 Codex 那样是一行导航项，不是一个按钮块——它和下面的会话是
+          同一类东西，长得像按钮反而把它从列表里割出去了。 */}
+      <div
+        className="row gap8 hoverable"
         onClick={onNew}
-        style={{ margin: 8, height: 28, fontSize: 12, justifyContent: 'center' }}
+        style={{
+          alignItems: 'center',
+          margin: '8px 6px 4px',
+          padding: '6px 8px',
+          borderRadius: 7,
+          cursor: 'pointer',
+          fontSize: 12.5,
+        }}
       >
-        <Icon name="plus" size={12} /> {tr('新对话', 'New chat')}
-      </button>
+        <Icon name="pen" size={13} style={{ color: 'var(--text-3)' }} />
+        <span>{tr('新对话', 'New chat')}</span>
+      </div>
       <div className="scroll" style={{ flex: 1, overflowY: 'auto', padding: '0 6px 8px' }}>
         {rows.length === 0 && (
           <div style={{ fontSize: 11, color: 'var(--text-4)', padding: '6px 6px' }}>
@@ -133,10 +143,9 @@ export function ConversationRail({
           <div key={group.label} style={{ marginBottom: 6 }}>
             <div
               style={{
-                fontSize: 10,
+                fontSize: 10.5,
                 color: 'var(--text-4)',
-                padding: '6px 6px 3px',
-                letterSpacing: '0.04em',
+                padding: '10px 8px 4px',
               }}
             >
               {group.label}


### PR DESCRIPTION
Restyled Buddy to the Codex reference.

## Empty state

Generous whitespace, a very light mark, one large question, and four cards carrying **only an icon and a title**. The one-line descriptions under each card read as helpful and are read by nobody — what they reliably do is shrink four cards into four boxes.

The cards remain the platform's four stages (find related work / understand a paper / sharpen an idea / check experiments), so whichever stage you're in, one card is yours.

## The composer is one object, not three

The context strip (topic, mode, model) is **attached to the top of the input box** rather than floating above it. Those are preconditions for the question being typed: inside the box they compete with the text, somewhere else they detach from it.

Send and stop are a single round button in the corner that swaps in place. While a turn is streaming, "stop" belongs where the hand already is.

## Message actions

Copy, plus answer-again on the latest turn.

Deliberately **no thumbs up/down**. A feedback control with nothing behind it is a prop, and clicking something that visibly does nothing costs more trust than not offering the button at all. If feedback is wanted later it needs a destination first.

## Rail

Same idiom: "New chat" is a navigation row rather than a button block — it belongs to the same list as the conversations under it, and styling it as a button cuts it out of that list. Group labels are quiet, rows are plain text.

Frontend only, no behaviour change. vitest **34 passed**, `tsc --noEmit` and `vite build` clean; the chat API suite (22) was re-run to confirm nothing on the wire moved.
