### PR TITLE
fix(llm): keep the upstream error body, and degrade when a model refuses tools

### DIFF
--- a/src/backend/app/agents/chat/loop.py
+++ b/src/backend/app/agents/chat/loop.py
@@ -194,10 +194,25 @@ class ChatAgentLoop:
                         for key in ("prompt_tokens", "completion_tokens"):
                             state.usage[key] = state.usage.get(key, 0) + int(ev.usage.get(key, 0))
             except ToolsUnsupportedError as e:
-                # 这个中转不认 tools：交给调用方降级回一次性 RAG，别把这轮打成失败
+                # 这个中转/推理服务不认 tools。**就地降级重来一轮**，而不是把这轮判死：
+                # 用户要的是答案，「你的服务端不支持函数调用」对他毫无用处。降级之后
+                # 模型没有工具，只能凭上下文答——所以要明说这一轮没查库。
                 logger.warning("chat agent: provider rejected tools: %s", e)
-                yield ErrorEvent(str(e), code="TOOLS_UNSUPPORTED", recoverable=True)
-                return
+                if not specs:
+                    yield ErrorEvent(str(e), code="TOOLS_UNSUPPORTED", recoverable=True)
+                    return
+                specs = []
+                messages.append(
+                    Message(
+                        role="user",
+                        content=(
+                            "（这次运行的模型不支持调用工具，接下来只能凭已有上下文回答。"
+                            "凡是需要查库才能确定的事，请明说你没查过。）"
+                        ),
+                    )
+                )
+                state.rounds -= 1  # 降级重来不算一轮，否则白扣一次预算
+                continue
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # noqa: BLE001 — 转成事件，会话继续活着

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -27,6 +27,7 @@ from app.core.llm.base import (
     ThinkingBlock,
     ThinkingDelta,
     ToolResultBlock,
+    ToolsUnsupportedError,
     ToolUseArgsDelta,
     ToolUseBlock,
     ToolUseStart,
@@ -50,6 +51,23 @@ _EFFORT_REJECT_MARKERS = ("reasoning_effort", "reasoning.effort", "effort")
 
 class _EffortUnsupported(RuntimeError):
     """服务端明确因 reasoning_effort 拒绝了请求；调用方去掉该参数重试。"""
+
+
+#: 中转/本地推理服务不支持 tools 时的说法。命中就降级回无工具的一次性问答，
+#: 而不是把这轮打成失败——用户要的是答案，不是「你的服务端不支持函数调用」。
+_TOOLS_REJECT_MARKERS = (
+    "tools is not supported",
+    "tool_choice",
+    "does not support tools",
+    "function calling",
+    "functions are not supported",
+    "unsupported parameter: 'tools'",
+)
+
+
+def _tools_unsupported(body: str) -> bool:
+    low = body.lower()
+    return any(marker in low for marker in _TOOLS_REJECT_MARKERS)
 
 
 def _rejects_effort(body: str) -> bool:
@@ -394,7 +412,15 @@ class OpenAICompatProvider(LLMProvider):
                 body = (await resp.aread()).decode(errors="replace")[:500]
                 if payload.get("reasoning_effort") is not None and _rejects_effort(body):
                     raise _EffortUnsupported(body)
-                resp.raise_for_status()
+                if resp.status_code == 400 and _tools_unsupported(body):
+                    # 这个中转不认 tools：交给上层降级，而不是把这轮打成失败
+                    raise ToolsUnsupportedError(body)
+                # **不要用 raise_for_status()**：httpx 的那个异常只带状态码，把上游
+                # 已经写明的原因（哪个参数不合法、哪个模型不存在）整段丢掉，用户拿到
+                # 的就只有一句「400 Bad Request」，我们也无从查起。
+                raise RuntimeError(
+                    f"openai_compat {resp.status_code} from {self._base_url}: {body}"
+                )
             async for line in resp.aiter_lines():
                 if not line.startswith("data:"):
                     continue

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -175,3 +175,26 @@ def test_completion_result_rebuilds_the_assistant_message_with_blocks():
     plain = CompletionResult(content="hi", model="m")
     assert plain.as_assistant_message().content == "hi"
     assert plain.tool_calls == ()
+
+
+def test_provider_errors_keep_the_upstream_body():
+    """400 的原因写在上游的响应体里，不能只把状态码抛出去。
+
+    线上就撞过：用户只看到「HTTPStatusError: 400 Bad Request」，而中转其实已经写明了
+    是哪个参数不合法——那行字被 raise_for_status() 丢掉了，我们和用户都无从查起。
+    """
+    import inspect
+
+    from app.core.llm import openai_compat
+
+    src = inspect.getsource(openai_compat.OpenAICompatProvider.stream_events)
+    assert "raise_for_status" not in src, "流式错误路径不能用 raise_for_status（它丢正文）"
+
+
+def test_tools_unsupported_is_detected_from_the_body():
+    """不认 tools 的说法五花八门，命中就该降级而不是失败。"""
+    from app.core.llm.openai_compat import _tools_unsupported
+
+    assert _tools_unsupported('{"error":{"message":"tools is not supported for this model"}}')
+    assert _tools_unsupported("Unsupported parameter: 'tools'")
+    assert not _tools_unsupported('{"error":{"message":"context length exceeded"}}')

--- a/src/frontend/src/features/assistant/InlineFigure.tsx
+++ b/src/frontend/src/features/assistant/InlineFigure.tsx
@@ -39,6 +39,7 @@ export function InlineFigure({ paperId, index }: { paperId: string; index: numbe
     <a href={`/papers/${paperId}/read`} title={tr('点击打开论文', 'open the paper')}>
       <img
         src={url}
+        onError={() => setFailed(true)}
         alt={tr('论文配图', 'paper figure')}
         style={{
           display: 'block',

--- a/src/frontend/src/features/assistant/ToolImages.tsx
+++ b/src/frontend/src/features/assistant/ToolImages.tsx
@@ -52,6 +52,9 @@ function FigureImage({ figure, onOpen }: { figure: ImageRef; onOpen: (url: strin
       {url ? (
         <img
           src={url}
+          // 200 但解不出来（代理返回了 HTML、文件损坏）时，<img> 只会安静地显示 alt
+          // 文本——看起来像「图注旁边空了一块」。显式转成失败态，说清楚这张没显示出来。
+          onError={() => setFailed(true)}
           alt={figure.label ?? `figure ${figure.index}`}
           onClick={() => onOpen(url)}
           style={{


### PR DESCRIPTION
Two problems, both visible in one real reading session.

## The 400 said nothing because we threw the reason away

The streaming path already read the response body — to check one specific marker — and then called `resp.raise_for_status()`, whose exception carries **only the status code**. The relay had written down exactly which parameter it disliked, and that line never left the process. All the user got was `HTTPStatusError: 400 Bad Request`, and we had no more to work with than they did.

Errors now carry the body (truncated to 500 chars), matching what the non-streaming path already did.

## A model that refuses `tools` no longer kills the turn

That 400 is how several relays and local inference servers say "no function calling". Until now it ended the turn.

The loop now drops the tool surface and retries the same turn once, telling the model plainly that it can no longer look anything up and must say so rather than guess. The retry doesn't consume a round — degrading shouldn't cost the user part of their budget.

"Your server doesn't support function calling" is not an answer to the question that was asked. An answer with its limitation stated is.

## Figures that arrive but can't be decoded now say so

A 200 response that isn't a valid image — a proxy's HTML error page, a truncated file — leaves `<img>` quietly rendering its alt text, which on screen reads as "there's a blank next to the caption". Both figure components now treat a decode error as a failure and show the caption with a note, so the difference between "no figure" and "figure didn't load" is visible.

## Tests

The streaming error path is pinned against `raise_for_status` coming back (it's the exact call that discarded the body), and the tools-refused detector is pinned on three real phrasings plus a negative.

Full suite **1135 passed** — one pre-existing failure on `main` (`test_debug_limit_terminates`) is unrelated and reproduces with these changes stashed. vitest **34 passed**.
