### PR TITLE
fix(frontend): add @types/node so the image builds, and let CI see frontend changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - "docker/**"
       - "src/backend/pyproject.toml"
+      # 前端源码也要触发：镜像构建里跑的是 `npm run build`（tsc --noEmit && vite build），
+      # 一个类型错就让整个前端镜像出不来。以前这里不含前端，于是 5a3cd37 带着编译错误
+      # 合进 main，直到部署才发现——CI 全绿，因为它根本没跑。
+      - "src/frontend/**"
       - ".github/workflows/docker-build.yml"
   workflow_dispatch:
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@types/katex": "^0.16.8",
+        "@types/node": "^22.10.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1368,6 +1369,16 @@
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2835,6 +2846,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/katex": "^0.16.8",
+    "@types/node": "^22.10.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
Closes #298

`5a3cd37` is on `main` with a frontend image that does not build. CI was green because it never ran.

## The failure

```
panelStructure.test.ts(1,30): error TS2307: Cannot find module 'node:fs' or its corresponding type declarations.
panelStructure.test.ts(2,31): error TS2307: Cannot find module 'node:url'
panelStructure.test.ts(40,37): error TS7006: Parameter 'l' implicitly has an 'any' type.
  … also 41, 45, 46
failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 2
```

## Root cause

`@types/node` was never a frontend devDependency. The new test imports `node:fs` and `node:url`; with no type declarations those imports resolve to `any`, so `source` and `lines` are `any`, and each `findIndex((l) => …)` callback trips `noImplicitAny`.

The four `TS7006` lines are **symptoms**. Annotating `l: string` would make them disappear while `readFileSync` stayed untyped and the dependency stayed missing — so this adds the dependency instead.

## Why CI did not catch it

```yaml
paths:
  - "docker/**"
  - "src/backend/pyproject.toml"
  - ".github/workflows/docker-build.yml"
```

A PR touching only `src/frontend/**` runs no checks at all — yet the frontend image build is exactly what `npm run build` (`tsc --noEmit && vite build`) guards. Any frontend type error can reach `main` unchallenged; this is the second frontend-only PR to merge with "no checks reported". `src/frontend/**` is now in `paths`.

## Verification

Run with the same command the image uses, against a real install of the updated lockfile:

- `npm run build` — passes (`tsc --noEmit` clean, `vite build` succeeds)
- `npx vitest run` — 36 passed across 4 files, including the new `panelStructure.test.ts`

## Production

Unaffected. The deploy halted at the failed build, `DEPLOYED_SHA` was never written, and zju-54 keeps serving `c1e0965`. Once this merges, the next deploy round picks up both `5a3cd37` and this fix together.