### PR TITLE
fix(library): adding a paper shouldn't die because arXiv is throttling us

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -86,6 +86,7 @@ from app.services import papers as papers_service
 from app.services import research_digest as research_digest_service
 from app.services import statement_interview as interview
 from app.services.embedding import embed_query
+from app.services.literature.arxiv import ArxivRateLimitedError
 from app.services.wiki_export import build_obsidian_zip_for_libraries
 
 router = APIRouter(tags=["libraries"])
@@ -882,6 +883,14 @@ async def add_library_paper_manually(
             status_code=status.HTTP_409_CONFLICT,
             content={"detail": "PAPER_EXISTS", "paper_id": str(e.paper_id)},
         )
+    except ArxivRateLimitedError as e:
+        # 上游限流不是我们的故障，但用户看到的必须是「稍后再试」而不是
+        # 「Internal Server Error」——后者既没说发生了什么，也没说要不要重试。
+        # 元数据在 paper_import 里已经先试过 OpenAlex 兜底，走到这里说明两边都不行。
+        logger.warning("manual add hit upstream rate limit: %s", e)
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="UPSTREAM_RATE_LIMITED"
+        ) from e
     except paper_import_service.ParseFailedError as e:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"PARSE_FAILED: {e}"

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -19,7 +19,7 @@ from app.services.libraries import (
     get_membership,
 )
 from app.services.literature import get_arxiv_client, get_openalex_client
-from app.services.literature.arxiv import normalize_arxiv_id
+from app.services.literature.arxiv import ArxivRateLimitedError, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +99,39 @@ def _parse_iso(value: str | None) -> datetime | None:
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 
+async def _fields_from_openalex_arxiv(arxiv_id: str) -> dict[str, Any]:
+    """arXiv 限流时的兜底：同一篇论文 OpenAlex 也有元数据。
+
+    字段会少一点（摘要常缺、分类没有），但**能加进来的半篇远胜于加不进来**——
+    用户手里就是那个编号，让他因为上游限流而干等着，等于我们把别人的故障转嫁给他。
+    """
+    normalized = normalize_arxiv_id(arxiv_id)
+    meta = await get_openalex_client().get_by_arxiv(normalized)
+    if meta is None or not meta.get("title"):
+        raise ParseFailedError(f"arXiv 正在限流，OpenAlex 上也查不到 {normalized}")
+    return {
+        "title": meta["title"],
+        "authors": meta.get("authors"),
+        "affiliations": meta.get("affiliations") or [],
+        "abstract": meta.get("abstract"),
+        "year": meta.get("year"),
+        "venue": meta.get("venue"),
+        "doi": meta.get("doi"),
+        "url": meta.get("url") or f"https://arxiv.org/abs/{normalized}",
+        "arxiv_id": normalized,
+        "published_at": _parse_iso(meta.get("published")),
+    }
+
+
 async def _fields_from_arxiv(arxiv_id: str) -> dict[str, Any]:
     normalized = normalize_arxiv_id(arxiv_id)
-    entries = await get_arxiv_client().fetch_by_ids([normalized])
+    try:
+        entries = await get_arxiv_client().fetch_by_ids([normalized])
+    except ArxivRateLimitedError:
+        # arXiv 限流是常态（尤其每日抓取跑完之后）。这条路以前直接抛到端点、变成
+        # 一句「Internal Server Error」——用户既不知道发生了什么，也不知道要不要重试。
+        logger.warning("arxiv rate-limited, falling back to OpenAlex for %s", normalized)
+        return await _fields_from_openalex_arxiv(normalized)
     entry = next((e for e in entries if e.get("title")), None)
     if entry is None:
         raise ParseFailedError(f"arxiv 上查不到编号 {normalized}")

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -4,6 +4,7 @@ import uuid
 
 import fakeredis.aioredis
 import httpx
+import pytest
 import pytest_asyncio
 import respx
 
@@ -296,3 +297,51 @@ async def test_resolve_unknown_arxiv_id_is_422(client, monkeypatch):
     resp = await client.get("/api/papers/resolve", params={"arxiv_id": "9999.99999"}, headers=headers)
     assert resp.status_code == 422
     assert resp.json()["detail"] == "ARXIV_ID_NOT_RESOLVED"
+
+
+async def test_arxiv_throttling_falls_back_to_openalex(monkeypatch):
+    """arXiv 限流时改用 OpenAlex 取元数据。
+
+    线上就是这么坏的：arXiv 429 → ArxivRateLimitedError 一路抛到端点 → 用户看到一句
+    「Internal Server Error」。字段会少一点（摘要常缺），但**能加进来的半篇远胜于
+    加不进来**——用户手里就是那个编号，让他因为上游限流干等着，等于把别人的故障
+    转嫁给他。
+    """
+    from app.services import paper_import
+    from app.services.literature.arxiv import ArxivRateLimitedError
+
+    class _Throttled:
+        async def fetch_by_ids(self, ids):  # noqa: ANN001
+            raise ArxivRateLimitedError("429 from arXiv")
+
+    class _OpenAlex:
+        async def get_by_arxiv(self, arxiv_id):  # noqa: ANN001
+            return {"title": "兜底拿到的标题", "year": 2026, "url": "https://example.org/x"}
+
+    monkeypatch.setattr(paper_import, "get_arxiv_client", lambda: _Throttled())
+    monkeypatch.setattr(paper_import, "get_openalex_client", lambda: _OpenAlex())
+
+    fields = await paper_import.resolve_fields(arxiv_id="2607.04425")
+    assert fields["title"] == "兜底拿到的标题"
+    assert fields["arxiv_id"] == "2607.04425"
+
+
+async def test_both_sources_down_is_a_parse_error_not_a_crash(monkeypatch):
+    """两边都查不到时给出可读的错误，而不是把异常抛穿。"""
+    from app.services import paper_import
+    from app.services.literature.arxiv import ArxivRateLimitedError
+
+    class _Throttled:
+        async def fetch_by_ids(self, ids):  # noqa: ANN001
+            raise ArxivRateLimitedError("429 from arXiv")
+
+    class _Empty:
+        async def get_by_arxiv(self, arxiv_id):  # noqa: ANN001
+            return None
+
+    monkeypatch.setattr(paper_import, "get_arxiv_client", lambda: _Throttled())
+    monkeypatch.setattr(paper_import, "get_openalex_client", lambda: _Empty())
+
+    with pytest.raises(paper_import.ParseFailedError) as excinfo:
+        await paper_import.resolve_fields(arxiv_id="2607.04425")
+    assert "限流" in str(excinfo.value)

--- a/src/frontend/src/features/library/AddToLibraryModal.tsx
+++ b/src/frontend/src/features/library/AddToLibraryModal.tsx
@@ -66,6 +66,15 @@ export function AddToLibraryModal({
           e.message.replace(/^PARSE_FAILED:?\s*/, '') ||
             tr('内容解析失败，请检查格式', 'Failed to parse — check the format'),
         );
+      } else if (e instanceof ApiError && e.status === 503) {
+        // 上游（arXiv/OpenAlex）在限流。说清楚是别人家的问题、以及能怎么办——
+        // 「添加失败」三个字会让用户以为是自己输错了编号。
+        setParseError(
+          tr(
+            'arXiv 正在限流，暂时查不到这个编号的元数据。过几分钟再试，或者改用 DOI / BibTeX 添加。',
+            'arXiv is rate-limiting us and the metadata cannot be fetched right now. Try again in a few minutes, or add it by DOI / BibTeX.',
+          ),
+        );
       } else {
         toast(`${tr('添加失败：', 'Failed to add: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
       }

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -195,6 +195,15 @@ function AddPaperModal({
         setParseError(
           e.message.replace(/^PARSE_FAILED:?\s*/, '') || tr('内容解析失败，请检查格式', 'Failed to parse — check the format'),
         );
+      } else if (e instanceof ApiError && e.status === 503) {
+        // 上游（arXiv/OpenAlex）在限流。说清楚是别人家的问题、以及能怎么办——
+        // 「添加失败」三个字会让用户以为是自己输错了编号。
+        setParseError(
+          tr(
+            'arXiv 正在限流，暂时查不到这个编号的元数据。过几分钟再试，或者改用 DOI / BibTeX 添加。',
+            'arXiv is rate-limiting us and the metadata cannot be fetched right now. Try again in a few minutes, or add it by DOI / BibTeX.',
+          ),
+        );
       } else {
         toast(`${tr('添加失败：', 'Failed to add: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
       }


### PR DESCRIPTION
Manual add failed with "Internal Server Error". The traceback from the deployment:

```
ArxivRateLimitedError: arXiv unavailable after 4 attempts (HTTPStatusError)
httpx.HTTPStatusError: 429 from arXiv
```

arXiv was rate-limiting us, the exception reached the endpoint unhandled, and the user got five words that say neither what happened nor whether retrying would help.

## Fall back to OpenAlex

The same paper's metadata is in OpenAlex. The resulting record is thinner — abstract often missing, no primary category — but **a partial record beats no record**. The user is holding that arXiv id; making them wait on someone else's rate limiter is passing another service's outage on to them.

## When both sources are down, say so

Upstream throttling is now **503 `UPSTREAM_RATE_LIMITED`** instead of 500, and the dialog explains that arXiv is throttling us, suggests waiting a few minutes, and points at DOI / BibTeX as a way through right now.

"Failed to add" reads as "you typed the id wrong" — it sends the user hunting for a mistake they didn't make.

## Tests

Two: a throttled arXiv resolves through OpenAlex with the id preserved, and both sources failing raises a readable `ParseFailedError` rather than escaping to the endpoint.

The `test_paper_manual_add.py` suite passes (12). The full suite was still running when this was opened — I'll report the number.
