### PR TITLE
fix(daily): probe by content, not by the date arXiv declares; and never orphan a tool message

### DIFF
--- a/src/backend/app/api/chat_agent.py
+++ b/src/backend/app/api/chat_agent.py
@@ -488,10 +488,10 @@ async def run_turn(
             # shield 是必需的——取消态下再 await 数据库写会被二次取消。
             import asyncio
 
-            blocks = timeline.blocks()
-            if blocks:
+            parts = timeline.messages()
+            if parts:
                 await asyncio.shield(
-                    _persist_answer(conv_id, user_id, blocks, timeline.text, stop_reason, usage)
+                    _persist_answer(conv_id, user_id, parts, timeline.text, stop_reason, usage)
                 )
                 await asyncio.shield(
                     _name_conversation(
@@ -606,6 +606,33 @@ class _TurnTimeline:
             self._blocks.append(ThinkingBlock("".join(self._thinking)))
             self._thinking = []
 
+    def messages(self) -> list[tuple[str, list[Any]]]:
+        """按**落库时的消息边界**切开：assistant（正文/思考/调用）+ 携带工具结果的消息。
+
+        不能把整轮塞进一条 assistant 消息——回放到 OpenAI 形状时，工具结果会变成
+        没有 tool_calls 前置的孤儿 tool 消息，中转直接 400。这条边界与循环里跑的时候
+        用的是同一套（结果单独成一条消息），回放才可能和当时等价。
+        """
+        self._flush_thinking()
+        out: list[tuple[str, list[Any]]] = []
+        current: list[Any] = []
+        for block in self._blocks:
+            if isinstance(block, ToolResultBlock):
+                if current:
+                    out.append(("assistant", current))
+                    current = []
+                if out and out[-1][0] == "tool_results":
+                    out[-1][1].append(block)
+                else:
+                    out.append(("tool_results", [block]))
+                continue
+            if out and out[-1][0] == "tool_results" and current == []:
+                pass
+            current.append(block)
+        if current:
+            out.append(("assistant", current))
+        return out
+
     def blocks(self) -> list[Any]:
         self._flush_thinking()
         return list(self._blocks)
@@ -634,7 +661,7 @@ async def _name_conversation(
 async def _persist_answer(
     conversation_id: uuid.UUID,
     user_id: uuid.UUID,
-    blocks: list[Any],
+    parts: list[tuple[str, list[Any]]],
     text: str,
     stop_reason: str,
     usage: dict[str, Any],
@@ -646,14 +673,22 @@ async def _persist_answer(
         conv = await store.get_or_create(
             session, user_id=user_id, scope_kind="global", conversation_id=conversation_id
         )
-        await store.append_message(
-            session,
-            conversation=conv,
-            role="assistant",
-            blocks=blocks,
-            text=text,
-            usage=usage or None,
-            stop_reason=stop_reason,
-            status="complete" if stop_reason != "interrupted" else "interrupted",
-        )
+        for index, (role, blocks) in enumerate(parts):
+            last = index == len(parts) - 1
+            await store.append_message(
+                session,
+                conversation=conv,
+                # 工具结果按 Anthropic 的形状装在 role="user" 里；kind 标出来，
+                # 好让回放与界面都能认出「这不是用户说的话」。
+                role="assistant" if role == "assistant" else "user",
+                kind="normal" if role == "assistant" else "tool_results",
+                blocks=blocks,
+                # 用量与终态只记在最后一条上，否则一轮会被算成好几轮
+                text=text if last else None,
+                usage=usage or None if last else None,
+                stop_reason=stop_reason if last else None,
+                status=("complete" if stop_reason != "interrupted" else "interrupted")
+                if last
+                else "complete",
+            )
         await session.commit()

--- a/src/backend/app/core/llm/openai_compat.py
+++ b/src/backend/app/core/llm/openai_compat.py
@@ -133,6 +133,29 @@ def _messages_payload(messages: Sequence[Message]) -> list[dict[str, Any]]:
         images = [b for b in blocks if isinstance(b, ImageBlock)]
 
         if tool_results:
+            # 同一条消息里既有调用又有结果时，**必须先把调用发出去**：OpenAI 要求
+            # role="tool" 前面有一条带 tool_calls 的 assistant，否则 400
+            # （"Messages with role 'tool' must be a response to a preceding message
+            # with 'tool_calls'"）。落库时把整轮塞进一条 assistant 消息就会撞上这个；
+            # 存量历史已经是那个形状，所以这里必须能兜住。
+            if tool_uses:
+                out.append(
+                    {
+                        "role": "assistant",
+                        "content": "\n".join(texts),
+                        "tool_calls": [
+                            {
+                                "id": call.id,
+                                "type": "function",
+                                "function": {
+                                    "name": call.name,
+                                    "arguments": json.dumps(call.input, ensure_ascii=False),
+                                },
+                            }
+                            for call in tool_uses
+                        ],
+                    }
+                )
             for result in tool_results:
                 out.append(
                     {

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1458,7 +1458,9 @@ async def record_probe(
     batch_date: str | None,
     exhausted: bool = False,
 ) -> dict[str, Any]:
-    """记一次「探了但今天那批还没出来」。返回记完之后的状态。"""
+    """记一次「探了但今天那批还没出来」。返回记完之后的状态。
+
+    """
     state = await probe_state(session, now=now)
     state["attempts"] += 1
     state["batch_date"] = batch_date
@@ -1516,26 +1518,46 @@ async def claim_today(session: AsyncSession, key: str, *, now: dt.datetime) -> b
 
 
 async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | None]:
-    """arXiv 上今天那批公告出来了没有。返回 (出来了吗, 探到的批次日期)。
+    """arXiv 上有我们还没收的论文吗。返回 (有没有, 这批声明的日期)。
 
-    只探**一个**分类：批次是全站一起发的，探一个就够，没必要为了一个判断打三次。
-    探测本身很便宜（一次 RSS，且陈旧批次不进缓存所以每次都是新的）。
+    **判据是内容，不是日期。** 曾经用 channel 的 ``pubDate`` 判「是不是今天那批」，
+    结果 arXiv 的 RSS 日期字段会整体滞后一天：网页版明明已经是 8-06 的清单、条目
+    id 也是当天的（2608.026xx），而 channel 与 item 的 pubDate 都还写着 8-05。于是
+    判据永远为假，池子一直停在昨天，界面上就一直「等待今天的批次」。
 
-    拿不到批次日期（解析不出 / RSS 没给）时返回 True——宁可照常抓一次，也不能因为
-    一个判断失灵就再也不抓了。
+    连带的代价还不止于此：日期判据也把 RSS 缓存的写入条件卡死了（永远不「新鲜」），
+    于是每次探测都真去打 arXiv——把我们自己打到 429。
+
+    「有没有新论文可收」本来就是这个探测唯一关心的事，直接问它。
     """
     categories = await get_categories(session)
     if not categories:
         return True, None
     try:
-        _, batch_at = await get_arxiv_client().fetch_new(categories[0])
+        entries, batch_at = await get_arxiv_client().fetch_new(categories[0])
     except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
         logger.warning("daily feed probe failed", exc_info=True)
         return True, None
-    if batch_at is None:
-        return True, None
-    batch_date = batch_at.astimezone(dt.UTC).date()
-    return batch_date >= _today_utc(), batch_date.isoformat()
+
+    declared = batch_at.astimezone(dt.UTC).date().isoformat() if batch_at else None
+    arxiv_ids = [str(e.get("arxiv_id")) for e in entries if e.get("arxiv_id")]
+    if not arxiv_ids:
+        # 一条都没有：周末/节假日的正常形态，没什么可收的
+        return False, declared
+
+    known = set(
+        (
+            await session.execute(
+                select(Paper.arxiv_id)
+                .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
+                .where(Paper.arxiv_id.in_(arxiv_ids))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    fresh = any(aid not in known for aid in arxiv_ids)
+    return fresh, declared
 
 
 # ---- 保留期（可配置） ----

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -43,7 +43,10 @@ _RSS_NS = {
 
 # RSS /new 每天更新一次、URL 只按分类（对所有用户/项目相同）→ 短 TTL 缓存跨用户共享，
 # 当天能及时拿到新公告又不重复打 arXiv。3 小时。
-_RSS_CACHE_TTL = 3 * 3600
+#: RSS 缓存时长。**短**，因为轮询要在同一天内看到批次的变化；而它必须存在，因为
+#: 不缓存就等于每次探测都打 arXiv——生产上正是这么被 429 的（日期判据恒假 →
+#: 从来没写进过缓存 → 每次都真打）。
+_RSS_CACHE_TTL = 10 * 60
 
 # 只接纳当天首发/跨列表公告；replace / replace-cross 是旧论文更新，跳过。
 _RSS_KEEP_TYPES = frozenset({"new", "cross"})
@@ -194,16 +197,6 @@ def _parse_rss_item(item: ET.Element) -> dict[str, Any] | None:
         "pdf_url": PDF_URL_TEMPLATE.format(arxiv_id=arxiv_id),
         "announce_type": announce,
     }
-
-
-def _batch_is_fresh(batch_at: datetime | None) -> bool:
-    """这批公告还算「今天的」吗。读缓存与写缓存**共用这一条判据**。
-
-    解析不出批次日期时算新鲜：宁可照常抓一次，也不能因为一个判断失灵就再也不抓。
-    """
-    if batch_at is None:
-        return True
-    return batch_at.astimezone(UTC).date() >= datetime.now(UTC).date()
 
 
 def _parse_rss(text: str) -> tuple[list[dict[str, Any]], datetime | None]:
@@ -396,21 +389,16 @@ class ArxivClient:
         """
         key = cache_key("arxiv", "rss_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
-            cached_at = _parse_iso_dt(cached.get("batch_at"))
-            # **读的时候也要查新鲜度**，不是只在写的时候查：昨天 23:50 存进来的那份，
-            # 当时确实是「今天的」，跨过 UTC 零点它就成了旧批次——而缓存还有两小时
-            # 才到期。只查写不查读，等于每天 00:00–03:00 UTC（北京 08:00–11:00）的探测
-            # 全部拿到昨天那批，判定「今天那批还没出来」，白等一上午。
-            if _batch_is_fresh(cached_at):
-                return cached["entries"], cached_at
+            # 不再按「声明的日期是不是今天」决定能不能用缓存：arXiv 的 RSS 日期字段
+            # 会整体滞后一天（见 daily_feed.todays_batch_available），那样判的结果是
+            # 缓存永远写不进、每次探测都真打 arXiv。改用短 TTL 控制陈旧程度。
+            return cached["entries"], _parse_iso_dt(cached.get("batch_at"))
         resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
         entries, batch_at = _parse_rss(resp.text)
-        # **陈旧批次不写缓存**：调用方会每 15 分钟探一次直到当天那批出现，缓存住旧批次
-        # 会让接下来三小时的探测全部拿到同一份，轮询就白做了。与「失败不写缓存」同理。
-        if _batch_is_fresh(batch_at):
-            await self._rss_cache.set(
-                key, {"entries": entries, "batch_at": batch_at.isoformat() if batch_at else None}
-            )
+        # 失败不写缓存（见 _request）；成功的一律写，靠短 TTL 控制陈旧程度
+        await self._rss_cache.set(
+            key, {"entries": entries, "batch_at": batch_at.isoformat() if batch_at else None}
+        )
         return entries, batch_at
 
     async def fetch_by_ids(self, arxiv_ids: list[str]) -> list[dict[str, Any]]:

--- a/src/backend/tests/test_chat_agent_api.py
+++ b/src/backend/tests/test_chat_agent_api.py
@@ -482,9 +482,11 @@ async def test_a_turn_persists_its_whole_timeline_not_just_the_answer(client, ag
     messages = (
         await client.get(f"/api/chat/conversations/{conv_id}/messages", headers=headers)
     ).json()
-    assistant = [m for m in messages if m["role"] == "assistant"]
-    assert assistant, "助手消息没落库"
-    kinds = [b.get("kind") for m in assistant for b in (m["blocks"] or [])]
+    # 一轮会落成几条消息：assistant（正文/思考/调用）与携带工具结果的那条分开。
+    # 塞进一条的话，回放到 OpenAI 形状时工具结果就成了没有 tool_calls 前置的孤儿。
+    turn = [m for m in messages if m["role"] == "assistant" or m["kind"] == "tool_results"]
+    assert turn, "助手消息没落库"
+    kinds = [b.get("kind") for m in turn for b in (m["blocks"] or [])]
     assert "tool_use" in kinds, f"工具调用没落库：{kinds}"
     assert "tool_result" in kinds, f"工具结果没落库：{kinds}"
     assert "text" in kinds
@@ -492,7 +494,7 @@ async def test_a_turn_persists_its_whole_timeline_not_just_the_answer(client, ag
     # 工具结果存的是摘要而不是完整 payload——回放只需要「调了什么、拿到什么样的东西」
     results = [
         json.loads(b["content"])
-        for m in assistant
+        for m in turn
         for b in (m["blocks"] or [])
         if b.get("kind") == "tool_result"
     ]
@@ -605,3 +607,64 @@ async def test_plan_mode_tells_the_model_to_propose_before_acting(client, agent_
     assert "只做调研和规划" in plan and "update_plan" in plan
     goal = mode_instructions("goal", goal="把 CUA 这条线读透")
     assert "把 CUA 这条线读透" in goal
+
+
+async def test_replayed_history_never_orphans_a_tool_message(client, agent_on):
+    """回放出来的历史必须能原样喂回 OpenAI 形状的中转。
+
+    线上撞到的 400：「Messages with role 'tool' must be a response to a preceding
+    message with 'tool_calls'」——因为整轮曾被塞进**一条** assistant 消息，工具结果
+    和调用挤在一起，展开后 tool 消息前面没有带 tool_calls 的 assistant。
+    """
+    from app.core.llm.openai_compat import _messages_payload
+    from app.services import conversations as store
+
+    headers = await _headers(client, "orphan@example.com")
+    await _project_with_paper(client, headers, "Orphan Tool Message Paper")
+    conv_id = (await client.post("/api/chat/conversations", json={}, headers=headers)).json()["id"]
+
+    marker = 'POLARIS_FAKE_TOOL:search_papers:{"query": "Orphan", "mode": "keyword"}'
+    async with client.stream(
+        "POST",
+        f"/api/chat/conversations/{conv_id}/turn",
+        json={"question": f"查一下\n{marker}"},
+        headers=headers,
+    ) as stream:
+        await stream.aread()
+
+    async with get_sessionmaker()() as session:
+        history = await store.replay(session, conversation_id=uuid.UUID(conv_id))
+
+    payload = _messages_payload(history)
+    for index, entry in enumerate(payload):
+        if entry["role"] != "tool":
+            continue
+        assert index > 0, "tool 消息不能是第一条"
+        prev = payload[index - 1]
+        assert prev.get("tool_calls") or prev["role"] == "tool", (
+            f"第 {index} 条 tool 消息前面没有带 tool_calls 的 assistant：{payload[:index + 1]}"
+        )
+
+
+def test_a_single_message_holding_both_call_and_result_still_translates():
+    """存量历史就是这个形状（一条消息里既有调用又有结果），必须还能回放。"""
+    from app.core.llm.base import Message, TextBlock, ToolResultBlock, ToolUseBlock
+    from app.core.llm.openai_compat import _messages_payload
+
+    payload = _messages_payload(
+        [
+            Message(role="user", content="查一下"),
+            Message(
+                role="assistant",
+                content=[
+                    TextBlock("我去查"),
+                    ToolUseBlock("call-1", "search_papers", {"query": "x"}),
+                    ToolResultBlock("call-1", '{"results": []}'),
+                ],
+            ),
+        ]
+    )
+    roles = [e["role"] for e in payload]
+    assert roles == ["user", "assistant", "tool"]
+    assert payload[1]["tool_calls"][0]["id"] == "call-1"
+    assert payload[2]["tool_call_id"] == "call-1"

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1191,7 +1191,13 @@ async def test_probe_creates_the_run_once_the_batch_appears(client, monkeypatch)
     ctx = {"redis": _Redis()}
     assert await daily_feed_sync(ctx) is None  # 还没发布
 
-    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv({}))
+    # 批次「出现」= 有我们还没收的论文，而**不是**声明日期变成了今天：arXiv 的日期
+    # 字段会滞后一天，按日期判会永远等下去。
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2608.66001", "新到的")]}, batch_date=yesterday),
+    )
     run_id = await daily_feed_sync(ctx)
     assert run_id is not None
     assert enqueued == [("run_voyage", run_id)]
@@ -1365,6 +1371,7 @@ async def test_probe_reports_whether_todays_batch_is_out(client, monkeypatch):
     await register_and_login(client)
     yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
 
+    # 空批次 = 没有可收的（周末/节假日的正常形态），日期照常如实报出来
     monkeypatch.setattr(
         daily_feed, "get_arxiv_client", lambda: _StubArxiv({}, batch_date=yesterday)
     )
@@ -1372,7 +1379,15 @@ async def test_probe_reports_whether_todays_batch_is_out(client, monkeypatch):
         fresh, seen = await daily_feed.todays_batch_available(session)
     assert fresh is False and seen == yesterday.isoformat()
 
-    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv({}))
+    # 有我们没收过的论文 = 该抓了。**与它声明哪天无关**：arXiv 的日期字段会滞后一天，
+    # 按日期判会永远判成「还没发」——生产上池子就是这么停在昨天的。
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.77001", "没收过的")]}, batch_date=yesterday
+        ),
+    )
     async with get_sessionmaker()() as session:
         fresh, _ = await daily_feed.todays_batch_available(session)
     assert fresh is True
@@ -1695,3 +1710,50 @@ def _fake_batch_available(batch_date: str):
         return True, batch_date
 
     return _available
+
+
+async def test_probe_looks_at_content_not_at_the_declared_date(client, monkeypatch):
+    """探测判「有没有我们还没收的论文」，而不是「声明日期是不是今天」。
+
+    生产上就是这么卡住的：arXiv 的 RSS 日期字段整体滞后一天——网页版已经是 8-06 的
+    清单、条目 id 也是当天的（2608.026xx），而 channel/item 的 pubDate 都还写着 8-05。
+    按日期判永远为假，池子停在昨天，界面上一直「等待今天的批次（7/10）」。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    assert await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+
+    # 日期声明成昨天（模拟 arXiv 的滞后），内容是我们没见过的新论文
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.90001", "全新的一篇")]}, batch_date=yesterday.date()
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, declared = await daily_feed.todays_batch_available(session)
+    assert fresh is True, "内容是新的就该抓，别管它声明的日期"
+    assert declared == yesterday.date().isoformat()  # 日期照常如实报出来
+
+
+async def test_probe_says_no_when_everything_is_already_in_the_pool(client, monkeypatch):
+    """同一批重复出现时不再触发抓取——这才是「还没发新的」的真正含义。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    assert await register_and_login(client)
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry("2608.90002", "已经收过的")]}),
+    )
+    async with get_sessionmaker()() as session:
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is False
+

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -102,11 +102,11 @@ Abstract: A revised cross-listed older paper.</description>
 def _rss_with_batch_date(day) -> str:
     """把 fixture 的批次日期换成指定日期。
 
-    批次日期不是今天时**不会进缓存**（否则轮询会一直拿到同一份旧批次），所以想验证
-    缓存就必须让它声明今天。
+    RSS 的日期字段不可靠（arXiv 会整体滞后一天），如今它只是被如实带出来、不决定
+    任何事；这个 helper 只是让夹具能造出想要的声明日期。
     """
-    from email.utils import format_datetime
     import datetime as _dt
+    from email.utils import format_datetime
 
     at = _dt.datetime.combine(day, _dt.time(), tzinfo=_dt.timezone(_dt.timedelta(hours=-4)))
     return ARXIV_RSS.replace("__CHANNEL_PUBDATE__", format_datetime(at))
@@ -183,44 +183,6 @@ async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
     again, _ = await client.fetch_new("cs.CL")
     assert [e["arxiv_id"] for e in again] == ["2607.10001", "2607.10002"]
     assert route.call_count == 1
-    await client.aclose()
-
-
-@respx.mock
-async def test_a_cached_batch_goes_stale_at_midnight_utc(cache_redis):
-    """跨过 UTC 零点后，昨天缓存的那批不能再当「今天的」返回。
-
-    真事：08-04 23:5x UTC 存进缓存的批次，当时确实是今天的；三小时 TTL 让它一直活到
-    08-05 02:5x。读路径不查新鲜度，于是整个 00:00–03:00 UTC（北京 08:00–11:00）窗口
-    里，探测反复拿到昨天那批，判定「今天那批还没出来」——界面上就停在「等待今天的
-    批次（2/10）· 最新 08-04」，而 arXiv 早发了。写的时候查新鲜度、读的时候不查，
-    等于只挡住了一半。
-
-    直接把旧条目塞进缓存来构造这个局面，而不是去改模块里的 ``datetime``：被测的就是
-    「读路径会不会丢掉过期条目」，不必为此动全局状态。
-    """
-    import datetime as _dt
-
-    from app.services.literature.cache import cache_key
-
-    today = _dt.datetime.now(_dt.UTC).date()
-    yesterday = today - _dt.timedelta(days=1)
-    stale_at = _dt.datetime.combine(yesterday, _dt.time(23, 55), tzinfo=_dt.UTC)
-
-    client = ArxivClient(redis=cache_redis, min_interval=0)
-    # 昨天 23:55 写进去的那份：当时是新鲜的，现在不是了，但离过期还有两小时
-    await client._rss_cache.set(
-        cache_key("arxiv", "rss_new", {"category": "cs.CL"}),
-        {"entries": [{"arxiv_id": "old-batch"}], "batch_at": stale_at.isoformat()},
-    )
-    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
-        return_value=httpx.Response(200, text=_rss_with_batch_date(today))
-    )
-
-    entries, batch_at = await client.fetch_new("cs.CL")
-    assert route.call_count == 1, "过期批次不该再从缓存里返回，应该重新抓一次"
-    assert batch_at is not None and batch_at.astimezone(_dt.UTC).date() == today
-    assert [e["arxiv_id"] for e in entries] == ["2607.10001", "2607.10002"]
     await client.aclose()
 
 
@@ -495,14 +457,17 @@ async def test_penalize_extends_the_shared_gate(cache_redis):
     ttl = await cache_redis.pttl("lit:arxiv:gate")
     assert ttl > 1000
     assert b._interval > 0  # b 会在 acquire 时撞上这个闸门
-
-
 @respx.mock
-async def test_stale_rss_batch_is_not_cached(cache_redis):
-    """**陈旧批次不进缓存**——这是每 15 分钟轮询能生效的前提。
+async def test_rss_is_cached_regardless_of_the_declared_date(cache_redis):
+    """RSS 一律进缓存，陈旧程度由**短 TTL**控制。
 
-    RSS 缓存 3 小时。上午探到旧批次一旦被缓存住，接下来三小时的每一次探测都会拿到
-    同一份，轮询就白做了：当天批次出来了也发现不了。
+    这条原来钉的是「陈旧批次不进缓存」——判据是 RSS 里声明的批次日期。现实推翻了它：
+    arXiv 的日期字段会整体滞后一天（网页版已经是次日的清单、条目 id 也是当天的，而
+    channel/item 的 pubDate 还写着前一天）。按日期判的结果是**缓存永远写不进**，于是
+    每次探测都真去打 arXiv——把我们自己打到 429。
+
+    「今天那批出来了没有」现在按内容判（见 daily_feed.todays_batch_available），
+    缓存只需保证别太旧。
     """
     import datetime as _dt
 
@@ -514,5 +479,12 @@ async def test_stale_rss_batch_is_not_cached(cache_redis):
 
     await client.fetch_new("cs.CL")
     await client.fetch_new("cs.CL")
-    assert route.call_count == 2, "旧批次被缓存住的话，轮询永远发现不了当天那批"
+    assert route.call_count == 1, "声明日期不是今天也要进缓存，否则每次探测都真打 arXiv"
     await client.aclose()
+
+
+def test_the_rss_cache_ttl_stays_short():
+    """轮询要在同一天内看到批次变化，缓存就不能长。"""
+    from app.services.literature.arxiv import _RSS_CACHE_TTL
+
+    assert _RSS_CACHE_TTL <= 15 * 60

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -532,11 +532,20 @@ export function AssistantPanel({
         // 会话上存着的课题才是这场对话真正的作用域，跟着切过去
         setTurns(
           messages
-            .filter((m) => m.role === 'user' || m.role === 'assistant')
-            .map((m) => ({
-              role: m.role as 'user' | 'assistant',
-              blocks: restoreBlocks(m),
-            })),
+            // 一轮会落成几条消息：assistant（正文/调用）+ 携带工具结果的那条。
+            // 后者 role 是 user（Anthropic 形状），但**不是用户说的话**——按 kind 认出来
+            // 并入上一轮，否则历史里会冒出一堆空的「提问」。
+            .reduce<Turn[]>((turns, m) => {
+              if (m.role !== 'user' && m.role !== 'assistant') return turns;
+              const blocks = restoreBlocks(m);
+              const last = turns[turns.length - 1];
+              if (m.kind === 'tool_results' && last) {
+                last.blocks = [...last.blocks, ...blocks];
+                return turns;
+              }
+              turns.push({ role: m.role as 'user' | 'assistant', blocks });
+              return turns;
+            }, []),
         );
       } catch {
         /* 载入失败保持现状 */

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4807,7 +4807,7 @@ export const api = {
   /** 全局助手：一场会话的完整消息（含工具块；SSE 里的 preview 是截断的）。 */
   getAssistantMessages(
     conversationId: string,
-  ): Promise<{ role: string; text: string; blocks: unknown[]; status: string }[]> {
+  ): Promise<{ role: string; kind: string; text: string; blocks: unknown[]; status: string }[]> {
     return request(`/chat/conversations/${conversationId}/messages`);
   },
   /** 全局助手：新建一场会话（后端开关关着时 404）。 */


### PR DESCRIPTION
Two bugs from one live session, plus a wrong theory of mine that the evidence killed.

## 1. The feed waited for a batch arXiv had already published

It sat at "waiting for today's batch (7/10)". Checked against the source instead of assuming:

```
listing page:          Showing new listings for Thursday, 6 August 2026
RSS items:             oai:arXiv.org:2608.02609v1, 2608.02612v1, …   (today's)
channel/item pubDate:  Wed, 05 Aug 2026 00:00:00 -0400                (yesterday)
```

**arXiv's RSS date fields lag a day behind the content they serve.** Our probe asked "is the declared date today?" — permanently false — so the pool stayed on yesterday while the counter climbed.

The same unreliable date also gated the RSS cache: never "fresh", never cached, so every probe hit arXiv for real. That is very likely why we started seeing the 429s that broke manual paper adding in #303.

The probe now asks the only question it ever cared about: **are there papers here we haven't collected?** It compares the feed's arXiv ids against the pool. The declared date is still reported as information and decides nothing. Caching no longer depends on it either — successful fetches are cached under a short (10 min) TTL, which bounds staleness without trusting a field that lies.

Three tests pinned the old rule and are rewritten; two that existed only to defend the date-based cache gate are deleted rather than loosened.

**A theory I had before this, removed rather than left in:** that arXiv publishes at 04:00 UTC and our 02:00 fetch time was simply too early. The listing page (already showing Aug 6 at 03:40 UTC) disproved it.

## 2. Orphan tool messages

```
Invalid messages at index 4. Messages with role 'tool' must be a response
to a preceding message with 'tool_calls'.
```

That error is legible only because of #296; the bug behind it is mine, from #290. Persisting a turn put the whole timeline into **one** assistant message — text, tool_use and tool_result together. The OpenAI adapter, on seeing tool results, emitted only the `role: "tool"` messages and dropped the calls, so replayed history led with tool messages answering nothing.

Fixed at both ends, because both are needed:

- **Shape**: a turn is persisted as the same messages the loop actually ran — assistant (text / thinking / tool_use), then a message carrying that round's tool results, marked `kind="tool_results"`. Replay can only be equivalent to the live run if it has the same boundaries.
- **Translation**: when one message *does* contain both calls and results — which is every conversation stored since #290 — the adapter emits the assistant-with-tool_calls first, then the tool messages. Existing history has to remain replayable, and migrating it would be a bigger, riskier operation than making the translator honest.

The frontend folds `tool_results` messages into the preceding turn: their role is `user` (Anthropic's shape) but they aren't something the user said, and without this the history sprouts empty questions.

Tests: a real turn's replayed history goes through `_messages_payload` and every tool message is asserted to follow tool_calls; the legacy single-message shape is pinned to translate into assistant + tool. The earlier test asserting "the whole turn lands in one message" pinned the bug and is rewritten.

Full suite **1141 passed** (the single failure, `test_debug_limit_terminates`, pre-exists on `main`), vitest **36 passed**.
