### PR TITLE
fix(chat): send JSON writes with Content-Type so they stop 422ing

### DIFF
--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4764,19 +4764,16 @@ export const api = {
     return request('/chat/memories');
   },
   setBuddyMemoryEnabled(enabled: boolean): Promise<{ enabled: boolean }> {
-    return request('/chat/memory/enabled', { method: 'PUT', body: JSON.stringify({ enabled }) });
+    return requestJson<{ enabled: boolean }>('/chat/memory/enabled', 'PUT', { enabled });
   },
   addBuddyMemory(text: string): Promise<{ id: string; text: string; created_at: string }> {
-    return request('/chat/memories', { method: 'POST', body: JSON.stringify({ text }) });
+    return requestJson<{ id: string; text: string; created_at: string }>('/chat/memories', 'POST', { text });
   },
   deleteBuddyMemory(id: string): Promise<void> {
     return request(`/chat/memories/${id}`, { method: 'DELETE' });
   },
   renameAssistantConversation(id: string, title: string): Promise<void> {
-    return request(`/chat/conversations/${id}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ title }),
-    });
+    return requestJson<void>(`/chat/conversations/${id}`, 'PATCH', { title });
   },
   deleteAssistantConversation(id: string): Promise<void> {
     return request(`/chat/conversations/${id}`, { method: 'DELETE' });


### PR DESCRIPTION
Closes #305

## Problem

With Buddy long-term memory enabled, the write operations — add memory, toggle memory on/off, rename a conversation — fail with 422 `model_attributes_type`, while reads work fine.

## Root cause

`request()` only injects `Authorization` and never sets `Content-Type`; `requestJson()` is the helper that sets `Content-Type: application/json`. Three chat write calls used `request()` with a manually stringified body:

- `setBuddyMemoryEnabled` → `PUT /chat/memory/enabled`
- `addBuddyMemory` → `POST /chat/memories`
- `renameAssistantConversation` → `PATCH /chat/conversations/{id}`

A string body without a declared `Content-Type` is sent as `text/plain` by the browser, and FastAPI's pydantic v2 models cannot extract fields from that, hence the 422.

## Fix

Route the three calls through `requestJson()` like every other JSON write in the module (e.g. `createAssistantConversation`). No other `request()` call in `api.ts` passes a stringified JSON body, so these were the only three offenders.

## Verification

- `tsc --noEmit` clean on non-test files; `vite build` passes.
- The desktop app picks the fix up with the next packaged release, as noted in the issue.