### PR TITLE
Guest mode: an account that sees everything and changes nothing

### DIFF
--- a/src/backend/alembic/versions/b3f5c1e07a92_user_read_only.py
+++ b/src/backend/alembic/versions/b3f5c1e07a92_user_read_only.py
@@ -1,0 +1,30 @@
+"""read-only (guest) accounts
+
+Revision ID: b3f5c1e07a92
+Revises: d4e8b19c7a55
+Create Date: 2026-08-06
+
+只读账号：能看的由 role 决定，能改的一律没有。存量用户全部不是只读——
+默认 false，加列不动任何人的权限。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3f5c1e07a92"
+down_revision: str | None = "d4e8b19c7a55"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "read_only", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "read_only")

--- a/src/backend/app/api/admin_users.py
+++ b/src/backend/app/api/admin_users.py
@@ -35,6 +35,7 @@ async def _read(session: AsyncSession, target: User) -> AdminUserRead:
         display_name=target.display_name,
         username=target.username,
         role=target.role,
+        read_only=target.read_only,
         is_active=target.is_active,
         has_avatar=target.has_avatar,
         llm_access=target.llm_access,
@@ -85,7 +86,12 @@ async def create_user(
     target = await users_service.admin_update_user(
         session,
         target,
-        {"role": data.role, "llm_access": data.llm_access, "token_quota": data.token_quota},
+        {
+            "role": data.role,
+            "read_only": data.read_only,
+            "llm_access": data.llm_access,
+            "token_quota": data.token_quota,
+        },
     )
     return await _read(session, target)
 
@@ -103,7 +109,10 @@ async def update_user(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="USER_NOT_FOUND")
     payload = data.model_dump(exclude_unset=True)
     # 不能修改自己的角色/停用自己（防止管理员把自己锁在门外）
-    if target.id == admin.id and ("role" in payload or "is_active" in payload):
+    # 不能修改自己的角色/停用自己/把自己变成只读（防止管理员把自己锁在门外）
+    if target.id == admin.id and (
+        "role" in payload or "is_active" in payload or "read_only" in payload
+    ):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="CANNOT_MODIFY_SELF_ROLE")
     # 重置密码：API 层用 password_helper 预先 hash，再交给 service
     if payload.pop("password", None) is not None:

--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -119,6 +119,30 @@ fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 
 # 其他路由用这个依赖拿当前登录用户
 current_active_user = fastapi_users.current_user(active=True)
+# 没登录不报错、返回 None——写入闸门要挂在所有路由上，公开端点不能因此变成必须登录
+current_user_optional = fastapi_users.current_user(active=True, optional=True)
+
+# 写入闸门放行的方法。收口在 HTTP 方法上，而不是给 211 个写端点逐个加守卫：
+# app/api 下没有任何 GET/HEAD 处理器写库，也没有任何一个走 LLM 守卫（加这层时
+# 遍历过全部处理器的 AST 核对），所以在这个代码库里「不安全方法」就等于「写」。
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+# 登出是 POST，但它只销毁调用者自己的会话。不放行的话游客连退出登录都做不到。
+_READ_ONLY_ALLOWED_PATHS = frozenset({"/api/auth/jwt/logout"})
+
+
+async def block_read_only_writes(
+    request: Request,
+    user: User | None = Depends(current_user_optional),
+) -> None:
+    """只读账号的写入闸门（挂在整个 /api 与 /mcp 上，见 main.py）。
+
+    未登录直接放行——该拦的由各端点自己的鉴权依赖去拦，这里只管「登录了但只读」。
+    """
+    if user is None or not user.read_only:
+        return
+    if request.method in _SAFE_METHODS or request.url.path in _READ_ONLY_ALLOWED_PATHS:
+        return
+    raise HTTPException(status.HTTP_403_FORBIDDEN, detail="READ_ONLY_ACCOUNT")
 
 
 async def require_admin(user: User = Depends(current_active_user)) -> User:
@@ -138,6 +162,10 @@ async def _check_llm_quota(session: AsyncSession, user: User) -> None:
 
 def _check_llm_access(user: User, *, chat: bool) -> None:
     """大模型使用权限：full=不限 | chat_only=仅文献对话与 AI 伴读 | blocked=锁定。"""
+    # 只读账号一个 token 也不该花。写入闸门已经挡住了所有调模型的入口（它们全是
+    # POST），这里再挡一次是为了不依赖「建号的人记得把 llm_access 设成 blocked」。
+    if user.read_only:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LLM_ACCESS_BLOCKED")
     level = user.llm_access or "full"
     if level == "blocked":
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LLM_ACCESS_BLOCKED")

--- a/src/backend/app/api/ws.py
+++ b/src/backend/app/api/ws.py
@@ -153,6 +153,11 @@ async def manuscript_crdt_ws(
     if file.readonly:
         await websocket.close(code=4403)  # 只读模板文件不开协同房间
         return
+    if user.read_only:
+        # 只读账号（游客）：协同房间是条写入通道，进来就能改正文。稿件正文照样能
+        # 用 HTTP 的 GET 读到，所以这里挡掉不影响「看得见」。
+        await websocket.close(code=4403)
+        return
 
     await websocket.accept()
     rooms = get_crdt_rooms()

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -3,11 +3,12 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app import __version__
+from app.api.auth import block_read_only_writes
 from app.api.router import api_router
 from app.api.ws import router as ws_router
 from app.core.config import get_settings
@@ -79,11 +80,15 @@ def create_app() -> FastAPI:
         # 未配置大模型：统一 503，前端提示到设置页配置，而不是 500 堆栈
         return JSONResponse(status_code=503, content={"detail": "LLM_NOT_CONFIGURED"})
 
-    app.include_router(api_router, prefix="/api")
+    # 只读账号的写入闸门挂在路由器层：一处生效，新端点自动被覆盖，不会因为
+    # 有人加了个 POST 忘记加守卫就漏出去。
+    read_only_gate = [Depends(block_read_only_writes)]
+    app.include_router(api_router, prefix="/api", dependencies=read_only_gate)
     # WS 不挂 /api 前缀：nginx 按 /ws 反代（Upgrade），见 docs/architecture.md §7
+    # WS 走不到 HTTP 依赖，只读账号在 ws.py 里各自挡（协同房间是写，通知只是收）
     app.include_router(ws_router)
     # MCP 只读工具服务：POST /mcp（Streamable HTTP，JSON-RPC 2.0），见 docs/mcp.md
-    app.include_router(mcp_router)
+    app.include_router(mcp_router, dependencies=read_only_gate)
     return app
 
 

--- a/src/backend/app/models/user.py
+++ b/src/backend/app/models/user.py
@@ -23,6 +23,10 @@ class User(SQLAlchemyBaseUserTableUUID, TimestampMixin, Base):
     # 用户名只能在个人设置里改一次：改过一次后锁定（admin 预设即锁定）。
     username_locked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     role: Mapped[str] = mapped_column(String(32), default="member", nullable=False)  # admin|member
+    # 只读账号（游客）：看得见的和 role 决定的一样多，写得动的一样也没有。
+    # 与 role 正交是有意的——游客要看管理端就给 role=admin，26 处 role 判断照旧生效，
+    # 不必为「能看但不能改」再发明一个角色、再逐处回头改判断。
+    read_only: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # 大模型使用权限：full=不限 | chat_only=仅文献对话与 AI 伴读 | blocked=锁定
     llm_access: Mapped[str] = mapped_column(String(16), default="full", nullable=False)
     # LLM 配置归属：False=被管理员接管（用全局 provider/路由）| True=自管（用自己的）。

--- a/src/backend/app/schemas/user.py
+++ b/src/backend/app/schemas/user.py
@@ -15,6 +15,8 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
     username: str | None = None
     username_locked: bool = False
     role: str
+    # 只读账号（游客）：前端据此挂只读横幅、把写入入口收起来
+    read_only: bool = False
     llm_access: str = "full"
     llm_self_managed: bool = False
     has_avatar: bool = False
@@ -92,6 +94,7 @@ class AdminUserRead(BaseModel):
     display_name: str
     username: str | None
     role: str
+    read_only: bool = False
     is_active: bool
     has_avatar: bool
     llm_access: str
@@ -110,6 +113,8 @@ class AdminUserCreate(BaseModel):
     display_name: str = Field(min_length=1, max_length=255)
     username: str = Field(pattern=USERNAME_PATTERN)
     role: str = Field(default="member", pattern="^(admin|member)$")
+    # 游客号：role=admin + read_only=true，看得见管理端、写不动任何东西
+    read_only: bool = False
     llm_access: str = Field(default="full", pattern="^(full|chat_only|blocked)$")
     token_quota: int | None = Field(default=None, ge=0)
 
@@ -120,6 +125,7 @@ class AdminUserUpdate(BaseModel):
     # 重置密码（≥8 位）；不传 = 不变
     password: str | None = Field(default=None, min_length=8, max_length=128)
     role: str | None = Field(default=None, pattern="^(admin|member)$")
+    read_only: bool | None = None
     is_active: bool | None = None
     # token_quota：传 -1 表示清除配额（恢复不限）
     token_quota: int | None = Field(default=None, ge=-1)

--- a/src/backend/app/services/users.py
+++ b/src/backend/app/services/users.py
@@ -59,6 +59,7 @@ async def list_users_with_usage(session: AsyncSession) -> list[dict[str, Any]]:
             "display_name": u.display_name,
             "username": u.username,
             "role": u.role,
+            "read_only": u.read_only,
             "is_active": u.is_active,
             "has_avatar": u.has_avatar,
             "token_quota": u.token_quota,
@@ -103,6 +104,8 @@ async def admin_update_user(session: AsyncSession, user: User, data: dict[str, A
         user.role = v
     if (v := data.get("is_active")) is not None:
         user.is_active = v
+    if (v := data.get("read_only")) is not None:
+        user.read_only = v
     if (v := data.get("token_quota")) is not None:
         user.token_quota = None if v == -1 else v
     if (v := data.get("llm_access")) is not None:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,9 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "d4e8b19c7a55"  # 记忆分层：fact 每轮带上 / note 检索到才回上下文
+HEAD_REVISION = "b3f5c1e07a92"  # 只读账号（游客）：能看的由 role 决定，能改的一律没有
 SKILLS_GLOBAL_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
+MEMORY_KIND_REVISION = "d4e8b19c7a55"  # 记忆分层：fact 每轮带上 / note 检索到才回上下文
 BUDDY_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
 SKILLS_REVISION = "a22aa895244c"  # Skills v2（SKILL.md 渐进披露）
 DIGEST_REVISION = "e6a1c9d4f207"  # 文献库每日简报 + 相关性理由
@@ -116,6 +117,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "read_only" in columns["users"]  # 只读账号（游客）
     assert "effort" in columns["model_routes"]  # 推理档位可配（NULL = 用模型默认）
     # 对话搬到服务端：agent 一轮里可能调好几次工具，历史不能只活在浏览器 localStorage
     assert {"conversations", "conversation_messages"} <= columns["_tables"]
@@ -357,7 +359,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
 
-    # 最新 revision 可往返：先退掉记忆分层。
+    # 最新 revision 可往返：先退掉只读账号。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == MEMORY_KIND_REVISION
+    assert "read_only" not in columns["users"]
+
+    # 再退掉记忆分层。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == SKILLS_GLOBAL_REVISION

--- a/src/backend/tests/test_read_only_account.py
+++ b/src/backend/tests/test_read_only_account.py
@@ -1,0 +1,113 @@
+"""只读账号（游客）：看得见管理端，写不动任何东西，也花不掉一个 token。"""
+
+import ast
+import pathlib
+
+from tests.conftest import register_and_login
+
+API_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "api"
+
+
+async def _make_guest(client, admin_token: str) -> str:
+    """建一个游客号并登录：role=admin 才看得见管理端，read_only 才写不动。"""
+    resp = await client.post(
+        "/api/admin/users",
+        json={
+            "email": "guest@example.com",
+            "password": "gu3st-pass",
+            "display_name": "Guest",
+            "username": "guest",
+            "role": "admin",
+            "read_only": True,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["read_only"] is True
+    login = await client.post(
+        "/api/auth/jwt/login", data={"username": "guest", "password": "gu3st-pass"}
+    )
+    assert login.status_code == 200, login.text
+    return login.json()["access_token"]
+
+
+async def test_guest_reads_admin_views_but_cannot_write(client):
+    admin = await register_and_login(client)
+    guest = await _make_guest(client, admin)
+    gh = {"Authorization": f"Bearer {guest}"}
+
+    # 看得见：管理员才能看的用户列表照常 200
+    assert (await client.get("/api/admin/users", headers=gh)).status_code == 200
+    me = await client.get("/api/users/me", headers=gh)
+    assert me.status_code == 200
+    assert me.json()["read_only"] is True  # 前端据此挂只读横幅
+
+    # 写不动：四种写方法一律 403 READ_ONLY_ACCOUNT
+    post = await client.post("/api/projects", json={"name": "X", "statement": "x"}, headers=gh)
+    assert post.status_code == 403
+    assert post.json()["detail"] == "READ_ONLY_ACCOUNT"
+
+    patch = await client.patch("/api/users/me/username", json={"username": "zzz"}, headers=gh)
+    assert patch.status_code == 403
+    assert patch.json()["detail"] == "READ_ONLY_ACCOUNT"
+
+    # 连管理端的写也一样挡住——游客不能靠 admin 身份给自己解开只读
+    unlock = await client.patch(
+        "/api/admin/users/00000000-0000-0000-0000-000000000001",
+        json={"read_only": False},
+        headers=gh,
+    )
+    assert unlock.status_code == 403
+    assert unlock.json()["detail"] == "READ_ONLY_ACCOUNT"
+
+
+async def test_guest_cannot_spend_a_token(client):
+    """写入闸门之外再挡一层：LLM 守卫对只读账号直接拒，不看 llm_access 设成了什么。"""
+    from app.api.auth import _check_llm_access
+    from app.models.user import User
+
+    guest = User(read_only=True, llm_access="full")
+    for chat in (True, False):
+        try:
+            _check_llm_access(guest, chat=chat)
+        except Exception as e:  # HTTPException
+            assert getattr(e, "detail", None) == "LLM_ACCESS_BLOCKED"
+        else:
+            raise AssertionError("只读账号不该通过 LLM 守卫")
+
+
+async def test_normal_user_is_unaffected(client):
+    """闸门只认 read_only：普通用户照常写。"""
+    admin = await register_and_login(client)
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "Normal", "statement": "still writable"},
+        headers={"Authorization": f"Bearer {admin}"},
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+
+def test_no_get_handler_writes_or_calls_the_model():
+    """闸门把「不安全方法」当成「写」，这条前提必须一直成立。
+
+    哪天有人在 GET 里 commit 或挂上 LLM 守卫，这个断言就会先响——否则游客会从
+    那个洞里写进去，而闸门一无所知。
+    """
+    offenders = []
+    for path in sorted(API_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            is_read = any(
+                isinstance(f := (d.func if isinstance(d, ast.Call) else d), ast.Attribute)
+                and f.attr in ("get", "head")
+                for d in node.decorator_list
+            )
+            if not is_read:
+                continue
+            dumped = ast.dump(node)
+            for marker in ("commit", "enqueue", "require_llm", "require_forge"):
+                if marker in dumped:
+                    offenders.append(f"{path.name}:{node.lineno} {node.name} -> {marker}")
+    assert not offenders, "GET/HEAD 处理器里出现了写入或模型调用：" + "; ".join(offenders)

--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -923,6 +923,19 @@ export function AppShell() {
             </div>
           )}
         </div>
+        {/* 只读账号：说在前面，别让人填完一整张表才被拒。常驻不可关——它不是通知，
+            是这个会话的事实。 */}
+        {me?.read_only && (
+          <div className="readonly-strip" role="status">
+            <Icon name="shield" size={13} />
+            <span>
+              {tr(
+                '只读账号：可以查看全部内容，但不能修改任何东西，也不会调用大模型。',
+                'Read-only account: you can view everything, but nothing can be changed and no model is called.',
+              )}
+            </span>
+          </div>
+        )}
         <div className="content scroll">
           <Outlet context={ctx} />
         </div>

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -3224,6 +3224,7 @@ function CreateUserModal({ onClose }: { onClose: () => void }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [role, setRole] = useState<'member' | 'admin'>('member');
+  const [readOnly, setReadOnly] = useState(false);
   const [llmAccess, setLlmAccess] = useState<'full' | 'chat_only' | 'blocked'>('full');
   const [quota, setQuota] = useState('');
 
@@ -3241,6 +3242,7 @@ function CreateUserModal({ onClose }: { onClose: () => void }) {
         display_name: displayName.trim(),
         username: username.trim(),
         role,
+        read_only: readOnly,
         llm_access: llmAccess,
         token_quota: quota.trim() === '' ? null : Math.max(0, Number(quota)),
       }),
@@ -3316,6 +3318,19 @@ function CreateUserModal({ onClose }: { onClose: () => void }) {
         error={quotaInvalid ? tr('请输入非负整数', 'Enter a non-negative number') : null}
       >
         <input className="input mono" value={quota} onChange={(e) => setQuota(e.target.value)} placeholder={tr('不限', 'Unlimited')} />
+      </FormField>
+      <FormField
+        label={tr('只读账号', 'Read-only account')}
+        hint={tr(
+          '打开后：这个账号能看到角色允许看的一切，但改不动任何东西，也不会调用大模型。给人演示时用。',
+          'When on, the account sees everything its role allows but cannot change anything and never calls a model. Use it for demos.',
+        )}
+        style={{ marginBottom: 0 }}
+      >
+        <label className="row gap8" style={{ cursor: 'pointer' }}>
+          <input type="checkbox" checked={readOnly} onChange={(e) => setReadOnly(e.target.checked)} />
+          <span>{tr('只能查看，不能修改', 'Can view, cannot change')}</span>
+        </label>
       </FormField>
     </Modal>
   );
@@ -3394,6 +3409,7 @@ function UserEditModal({ u, onClose }: { u: AdminUserRead; onClose: () => void }
   const [username, setUsername] = useState(u.username || '');
   const [password, setPassword] = useState('');
   const [role, setRole] = useState(u.role);
+  const [readOnly, setReadOnly] = useState(u.read_only);
   const [active, setActive] = useState(u.is_active);
   const [quota, setQuota] = useState(u.token_quota != null ? String(u.token_quota) : '');
   const [llmAccess, setLlmAccess] = useState(u.llm_access || 'full');
@@ -3413,6 +3429,7 @@ function UserEditModal({ u, onClose }: { u: AdminUserRead; onClose: () => void }
         username: username.trim(),
         ...(password !== '' ? { password } : {}),
         role,
+        read_only: readOnly,
         is_active: active,
         token_quota: quota.trim() === '' ? -1 : Math.max(0, Number(quota)),
         features,
@@ -3485,6 +3502,18 @@ function UserEditModal({ u, onClose }: { u: AdminUserRead; onClose: () => void }
           />
         </FormField>
       </div>
+      <FormField
+        label={tr('只读账号', 'Read-only account')}
+        hint={tr(
+          '打开后：能看到角色允许看的一切，但改不动任何东西，也不会调用大模型。',
+          'When on, this account sees everything its role allows but cannot change anything and never calls a model.',
+        )}
+      >
+        <label className="row gap8" style={{ cursor: 'pointer' }}>
+          <input type="checkbox" checked={readOnly} onChange={(e) => setReadOnly(e.target.checked)} />
+          <span>{tr('只能查看，不能修改', 'Can view, cannot change')}</span>
+        </label>
+      </FormField>
       <FormField label={tr('大模型使用', 'LLM access')} hint={tr('限制该用户能否调用大模型', 'Controls whether this user can call LLMs')}>
         <SelectMenu
           value={llmAccess}
@@ -3684,6 +3713,12 @@ export function UsersTab() {
                     <span className="pill sm" style={u.role === 'admin' ? { background: 'var(--accent-soft)', color: 'var(--accent-text)' } : undefined}>
                       {u.role === 'admin' ? tr('管理员', 'Admin') : tr('成员', 'Member')}
                     </span>
+                    {/* 只读是和角色正交的一维：一个只读管理员看得见全部、改不动任何东西 */}
+                    {u.read_only && (
+                      <span className="pill sm" style={{ marginLeft: 4 }} title={tr('只能查看，不能修改', 'Can view, cannot change')}>
+                        {tr('只读', 'Read-only')}
+                      </span>
+                    )}
                   </td>
                   <td>
                     <span className="pill sm" style={{ background: u.is_active ? 'var(--ok-bg)' : 'var(--surface-3)', color: u.is_active ? 'var(--ok-tx)' : 'var(--text-3)' }}>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -76,12 +76,18 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
     } catch {
       /* non-JSON error body — keep statusText */
     }
-    throw new ApiError(res.status, detail, body);
+    throw new ApiError(res.status, readOnlyMessage(detail), body);
   }
   if (res.status === 204) {
     return undefined as T;
   }
   return (await res.json()) as T;
+}
+
+/** 只读账号撞上写操作时，别把后端的错误码原样甩给用户。只此一处，全站受益。 */
+function readOnlyMessage(detail: string): string {
+  if (detail !== 'READ_ONLY_ACCOUNT') return detail;
+  return tr('这是只读账号，只能查看，不能修改。', 'This account is read-only — you can look, but not change anything.');
 }
 
 function requestJson<T>(path: string, method: string, body: unknown): Promise<T> {
@@ -142,6 +148,8 @@ export interface UserRead {
   username?: string | null;
   username_locked?: boolean;
   role?: string;
+  /** true = 只读账号（游客）：看得见，改不动 */
+  read_only?: boolean;
   llm_access?: 'full' | 'chat_only' | 'blocked';
   /** true = 用户自管 LLM 配置；false = 由管理员统一接管（用全局配置） */
   llm_self_managed?: boolean;
@@ -162,6 +170,8 @@ export interface AdminUserRead {
   display_name: string;
   username: string | null;
   role: string;
+  /** true = 只读账号（游客） */
+  read_only: boolean;
   is_active: boolean;
   has_avatar: boolean;
   llm_access: string;
@@ -2942,6 +2952,8 @@ export const api = {
     display_name: string;
     username: string;
     role: 'member' | 'admin';
+    /** true = 只读账号（游客）：看得见角色允许看的一切，改不动任何东西 */
+    read_only?: boolean;
     llm_access: 'full' | 'chat_only' | 'blocked';
     /** 留空 = 不限 */
     token_quota?: number | null;
@@ -2956,6 +2968,7 @@ export const api = {
       /** 重置密码，至少 8 位；留空即不改 */
       password?: string;
       role?: string;
+      read_only?: boolean;
       is_active?: boolean;
       token_quota?: number;
       features?: Record<string, boolean>;

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1465,3 +1465,23 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(25, 169, 116, 0.45); }
   50% { opacity: 0.5; box-shadow: 0 0 0 4px rgba(25, 169, 116, 0); }
 }
+
+/* 只读账号（游客）的常驻提示条：贴在顶栏下沿，占一行，不盖内容。
+   用警示色而不是危险色——只读不是出错，是这个账号本来的样子。 */
+.readonly-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  font-size: 12px;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border-bottom: 0.5px solid var(--border-2);
+  flex-shrink: 0;
+}
+.readonly-strip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Closes #307

Hand someone a login that shows the whole platform, admin views included, with no way to alter state and no way to spend a token.

### The shape of it

`role` already decides what you see, and it is consulted in 26 places. Rather than invent a `guest` role and revisit all of them, `read_only` is a second, orthogonal axis:

**a guest is `role=admin` + `read_only=true`.**

Visibility keeps its existing meaning; mutability gets its own. Nothing that reads `role` had to change.

### One gate, not 211

There are 211 write endpoints. Guarding each one is the kind of thing that works until someone adds the 212th. Instead a single router-level dependency refuses any unsafe HTTP method from a read-only user with `403 READ_ONLY_ACCOUNT`.

That is only sound if HTTP method is a faithful proxy for "write" in this codebase — so the claim is checked rather than assumed. `test_no_get_handler_writes_or_calls_the_model` walks the AST of every handler in `app/api` and fails if any `GET`/`HEAD` commits, enqueues, or sits behind an LLM guard. It passes today, and it is there to break loudly the day someone opens that hole, because the gate itself would never notice.

Logout stays open — otherwise a guest cannot end their own session.

### The two paths that skip the dependency

- **CRDT manuscripts room.** Collaborative editing is a write channel over WebSocket, and WebSocket routes never reach an HTTP dependency. Read-only users are closed with 4403. Manuscript text is still readable over `GET`, so nothing becomes invisible.
- **`/mcp`.** Mounted separately, so it gets the same gate at its own mount. Its tools were already read-only.

### Tokens

The LLM guard refuses read-only users outright rather than trusting `llm_access`. The write gate already covers every model entry point (all of them are `POST`), so this is the second lock: a guest cannot spend a token even if whoever created the account left `llm_access` at `full`.

### What the user sees

A strip under the topbar states the session is read-only. The single place API errors are raised turns `READ_ONLY_ACCOUNT` into a sentence, so every feature reports it sensibly without 100 call sites learning about it. Admins get a checkbox on the create and edit forms, and a badge in the user list.

### Verification

- Full backend suite: **1144 passed**. Two failures, both understood: `test_migrations` needed its pinned head revision advanced (done in this PR), and `test_experiment_iterate::test_debug_limit_terminates` fails identically on `main` at 1413686 — pre-existing, untouched here.
- Frontend image builds (`tsc --noEmit && vite build`).
- `ruff` clean on every file this PR touches.
- Migration `b3f5c1e07a92` adds one column with `default false`, so no existing user's permissions move; the downgrade roundtrip is covered.