### PR TITLE
A guest should not see the lab's roster

### DIFF
--- a/src/backend/app/api/admin_users.py
+++ b/src/backend/app/api/admin_users.py
@@ -7,7 +7,12 @@ from fastapi_users import exceptions
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import UserManager, get_user_manager, require_admin
+from app.api.auth import (
+    UserManager,
+    block_read_only_personal_data,
+    get_user_manager,
+    require_admin,
+)
 from app.core.db import get_session
 from app.models.project import Project
 from app.models.user import User
@@ -51,6 +56,7 @@ async def _read(session: AsyncSession, target: User) -> AdminUserRead:
 async def list_users(
     session: AsyncSession = Depends(get_session),
     _: User = Depends(require_admin),
+    __: User = Depends(block_read_only_personal_data),
 ) -> list[AdminUserRead]:
     rows = await users_service.list_users_with_usage(session)
     return [AdminUserRead(**r) for r in rows]

--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -152,6 +152,18 @@ async def require_admin(user: User = Depends(current_active_user)) -> User:
     return user
 
 
+async def block_read_only_personal_data(user: User = Depends(current_active_user)) -> User:
+    """名册依赖：只读账号（游客）看不到实验室成员的个人信息。
+
+    游客号是 role=admin + read_only，为的是「能看到管理端长什么样」，不是「能看到
+    这个实验室里都有谁、邮箱是多少」。挡在接口上而不是只把前端标签藏起来——藏了
+    标签接口还照答，等于没藏。
+    """
+    if user.read_only:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="READ_ONLY_NO_PERSONAL_DATA")
+    return user
+
+
 async def _check_llm_quota(session: AsyncSession, user: User) -> None:
     if user.token_quota is not None:
         from app.services.users import tokens_used_by_user

--- a/src/backend/app/api/users_profile.py
+++ b/src/backend/app/api/users_profile.py
@@ -10,7 +10,7 @@ from PIL import Image
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user
+from app.api.auth import block_read_only_personal_data, current_active_user
 from app.core.config import get_settings
 from app.core.db import get_session
 from app.models.user import User
@@ -56,8 +56,12 @@ async def search_users(
     q: str,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
+    _: User = Depends(block_read_only_personal_data),
 ) -> list[UserSearchResult]:
-    """按 email/显示名模糊查平台用户（加协作者用）；排除自己。"""
+    """按 email/显示名模糊查平台用户（加协作者用）；排除自己。
+
+    只读账号（游客）走不到这里：这个接口返回成员邮箱，藏了设置页的名册却留着它，
+    等于换个入口把同一份东西交出去。"""
     rows = await users_service.search_users(session, q, limit=10, exclude_ids=[user.id])
     return [UserSearchResult(id=u.id, email=u.email, display_name=u.display_name) for u in rows]
 

--- a/src/backend/tests/test_read_only_account.py
+++ b/src/backend/tests/test_read_only_account.py
@@ -36,8 +36,9 @@ async def test_guest_reads_admin_views_but_cannot_write(client):
     guest = await _make_guest(client, admin)
     gh = {"Authorization": f"Bearer {guest}"}
 
-    # 看得见：管理员才能看的用户列表照常 200
-    assert (await client.get("/api/admin/users", headers=gh)).status_code == 200
+    # 看得见：管理员才能看的配置页照常 200（成员名册另有守卫，见
+    # test_read_only_personal_data.py——游客能看管理端长什么样，但看不到实验室里有谁）
+    assert (await client.get("/api/admin/llm/providers", headers=gh)).status_code == 200
     me = await client.get("/api/users/me", headers=gh)
     assert me.status_code == 200
     assert me.json()["read_only"] is True  # 前端据此挂只读横幅

--- a/src/backend/tests/test_read_only_personal_data.py
+++ b/src/backend/tests/test_read_only_personal_data.py
@@ -1,0 +1,63 @@
+"""只读账号（游客）看不到实验室成员的个人信息：名册与按邮箱查人都拒。"""
+
+from tests.conftest import register_and_login
+
+
+async def _make_guest(client, admin_token: str) -> str:
+    resp = await client.post(
+        "/api/admin/users",
+        json={
+            "email": "guest@example.com",
+            "password": "gu3st-pass",
+            "display_name": "Guest",
+            "username": "guest",
+            "role": "admin",
+            "read_only": True,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    login = await client.post(
+        "/api/auth/jwt/login", data={"username": "guest", "password": "gu3st-pass"}
+    )
+    assert login.status_code == 200, login.text
+    return login.json()["access_token"]
+
+
+async def test_guest_cannot_read_the_roster(client):
+    admin = await register_and_login(client)
+    guest = await _make_guest(client, admin)
+    gh = {"Authorization": f"Bearer {guest}"}
+
+    # 名册：管理员看得到，游客看不到
+    listed = await client.get("/api/admin/users", headers=gh)
+    assert listed.status_code == 403
+    assert listed.json()["detail"] == "READ_ONLY_NO_PERSONAL_DATA"
+
+    # 换个入口也拿不到同一份东西：按邮箱模糊查人会返回成员邮箱
+    found = await client.get("/api/collaborators/search?q=example", headers=gh)
+    assert found.status_code == 403
+    assert found.json()["detail"] == "READ_ONLY_NO_PERSONAL_DATA"
+
+
+async def test_guest_still_sees_the_non_personal_admin_screens(client):
+    """挡的是「实验室里有谁」，不是「管理端长什么样」——游客仍该看得见配置。"""
+    admin = await register_and_login(client)
+    guest = await _make_guest(client, admin)
+    gh = {"Authorization": f"Bearer {guest}"}
+
+    for path in (
+        "/api/admin/llm/providers",  # 模型配置：没有人的信息
+        "/api/admin/registration-codes",  # 注册码不记兑换人
+        "/api/admin/settings/experiment-env",
+    ):
+        resp = await client.get(path, headers=gh)
+        assert resp.status_code == 200, f"{path} -> {resp.status_code} {resp.text}"
+
+
+async def test_admins_and_members_are_unaffected(client):
+    """闸门只认 read_only：真管理员照常看名册，普通成员照常查协作者。"""
+    admin = await register_and_login(client)
+    ah = {"Authorization": f"Bearer {admin}"}
+    assert (await client.get("/api/admin/users", headers=ah)).status_code == 200
+    assert (await client.get("/api/collaborators/search?q=example", headers=ah)).status_code == 200

--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -22,6 +22,9 @@ const ADMIN_TABS: AdminTab[] = ['llm', 'experiment', 'daily', 'users', 'codes', 
 export function AdminSettingsPage() {
   const { data: me, isLoading } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
   const admin = isAdmin(me);
+  // 只读账号（游客）看不到成员名册：那一屏是真实的人的邮箱、用户名和用量。
+  // 后端也会拒（READ_ONLY_NO_PERSONAL_DATA）——这里只是别让入口摆在那里点了报错。
+  const canSeeRoster = !me?.read_only;
   // 支持 /admin?tab=llm 深链
   const [searchParams] = useSearchParams();
   const [tab, setTab] = useState<AdminTab>(() => {
@@ -29,11 +32,15 @@ export function AdminSettingsPage() {
     return t !== null && ADMIN_TABS.includes(t as AdminTab) ? (t as AdminTab) : 'llm';
   });
 
+  // 深链 /admin?tab=users 进来的游客回落到第一个标签，而不是停在一片空白上
+  // （me 还没回来时初值已经定成 users 了，所以这里按渲染时的实际权限再判一次）
+  const shownTab: AdminTab = tab === 'users' && !canSeeRoster ? 'llm' : tab;
+
   const items: { v: AdminTab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
     { v: 'experiment', label: tr('实验设置', 'Experiments') },
     { v: 'daily', label: tr('每日论文', 'Daily papers') },
-    { v: 'users', label: tr('用户管理', 'Users') },
+    ...(canSeeRoster ? [{ v: 'users' as const, label: tr('用户管理', 'Users') }] : []),
     { v: 'codes', label: tr('注册码', 'Codes') },
     { v: 'feedback', label: tr('反馈', 'Feedback') },
     { v: 'usage', label: tr('用量总览', 'Usage overview') },
@@ -54,15 +61,15 @@ export function AdminSettingsPage() {
       ) : (
         <>
           <div className="row" style={{ gap: 12, marginBottom: 22, flexWrap: 'wrap', alignItems: 'center' }}>
-            <Segmented options={items} value={tab} onChange={setTab} />
+            <Segmented options={items} value={shownTab} onChange={setTab} />
           </div>
-          {tab === 'llm' && <LlmTab />}
-          {tab === 'experiment' && <ExperimentSettings />}
-          {tab === 'daily' && <DailyCategoriesTab />}
-          {tab === 'users' && <UsersTab />}
-          {tab === 'codes' && <CodesTab />}
-          {tab === 'feedback' && <FeedbackTab />}
-          {tab === 'usage' && <UsageTab />}
+          {shownTab === 'llm' && <LlmTab />}
+          {shownTab === 'experiment' && <ExperimentSettings />}
+          {shownTab === 'daily' && <DailyCategoriesTab />}
+          {shownTab === 'users' && canSeeRoster && <UsersTab />}
+          {shownTab === 'codes' && <CodesTab />}
+          {shownTab === 'feedback' && <FeedbackTab />}
+          {shownTab === 'usage' && <UsageTab />}
         </>
       )}
     </div>


### PR DESCRIPTION
Closes #309

The guest account is `role=admin` + `read_only`, so it reached **Settings → Users**: every member's email, username and token usage. Handing that to whoever we give a demo login to is not what the account is for — it exists to show what the platform looks like, not who is in this lab.

### Changes

- `GET /api/admin/users` refuses read-only accounts with `403 READ_ONLY_NO_PERSONAL_DATA`, and the tab is dropped from the admin page for them. **The endpoint is the part that matters** — hiding a tab whose API still answers is theatre.
- `GET /api/collaborators/search` gets the same guard. It fuzzy-matches members by email and returns their addresses to any logged-in account, so leaving it open would hand over the same roster through a second door.

### What a guest still sees

Deliberately unchanged, because none of it is about people:

| Screen | Why it stays |
|---|---|
| LLM providers / routes | configuration |
| Daily papers, experiment settings | configuration |
| `admin/llm/usage` | aggregates by date, stage and model — no per-user identity |
| Registration codes | no redeemer recorded |

**Feedback** carries submitter display names (no email) and is left alone on purpose. Hiding it is a call about the feedback tab rather than part of "don't show the roster", and it should be decided on its own.

### Deep links

`/admin?tab=users` lands a guest on the first tab rather than a blank page. `me` has not arrived when the initial tab is chosen, so the decision is re-made at render.

### One test changed rather than added

`test_guest_reads_admin_views_but_cannot_write` asserted that a guest could list users — it was asserting exactly the behaviour this PR removes. It now checks a screen with no personal data on it, so it still covers "a guest sees the admin surface".

### Verification

- Full backend suite: **1148 passed**. The single failure, `test_experiment_iterate::test_debug_limit_terminates`, reproduces identically on `main` and was confirmed pre-existing in #308 — untouched here.
- New tests cover all three directions: the guest is refused on both endpoints, the guest still gets 200 on the non-personal admin screens, and real admins and members are unaffected.
- Frontend image builds; `ruff` clean on every file touched.