### PR TITLE
A guest should not be able to read a registration code

### DIFF
--- a/src/backend/app/api/admin_codes.py
+++ b/src/backend/app/api/admin_codes.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import require_admin
+from app.api.auth import block_read_only_secrets, require_admin
 from app.core.db import get_session
 from app.models.user import User
 from app.schemas.registration_code import RegistrationCodeCreate, RegistrationCodeRead
@@ -54,6 +54,7 @@ async def create_registration_code(
 async def list_registration_codes(
     session: AsyncSession = Depends(get_session),
     _: User = Depends(require_admin),
+    __: User = Depends(block_read_only_secrets),
 ) -> list[RegistrationCodeRead]:
     rows = await codes_service.list_codes(session)
     return [_to_read(rc) for rc in rows]

--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -164,6 +164,18 @@ async def block_read_only_personal_data(user: User = Depends(current_active_user
     return user
 
 
+async def block_read_only_secrets(user: User = Depends(current_active_user)) -> User:
+    """密钥依赖：只读账号（游客）看不到能拿去用的东西。
+
+    与 block_read_only_personal_data 分开是因为理由不同：那条挡的是「实验室里有谁」，
+    这条挡的是「拿了就能用」。注册码尤其如此——只读挡得住写，挡不住它被抄走，因为
+    用它开号走的是公开的注册接口，写入闸门根本看不到那一步。
+    """
+    if user.read_only:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="READ_ONLY_NO_SECRETS")
+    return user
+
+
 async def _check_llm_quota(session: AsyncSession, user: User) -> None:
     if user.token_quota is not None:
         from app.services.users import tokens_used_by_user

--- a/src/backend/tests/test_read_only_personal_data.py
+++ b/src/backend/tests/test_read_only_personal_data.py
@@ -40,6 +40,19 @@ async def test_guest_cannot_read_the_roster(client):
     assert found.json()["detail"] == "READ_ONLY_NO_PERSONAL_DATA"
 
 
+async def test_guest_cannot_read_the_registration_codes(client):
+    """注册码是明文，抄走就能开真账号——只读挡得住写，挡不住它被读走。"""
+    admin = await register_and_login(client)
+    guest = await _make_guest(client, admin)
+
+    codes = await client.get(
+        "/api/admin/registration-codes", headers={"Authorization": f"Bearer {guest}"}
+    )
+    assert codes.status_code == 403
+    # 与名册用不同的错误码：理由不同，一个是「有谁」，一个是「拿了就能用」
+    assert codes.json()["detail"] == "READ_ONLY_NO_SECRETS"
+
+
 async def test_guest_still_sees_the_non_personal_admin_screens(client):
     """挡的是「实验室里有谁」，不是「管理端长什么样」——游客仍该看得见配置。"""
     admin = await register_and_login(client)
@@ -47,8 +60,7 @@ async def test_guest_still_sees_the_non_personal_admin_screens(client):
     gh = {"Authorization": f"Bearer {guest}"}
 
     for path in (
-        "/api/admin/llm/providers",  # 模型配置：没有人的信息
-        "/api/admin/registration-codes",  # 注册码不记兑换人
+        "/api/admin/llm/providers",  # 模型配置：api_key 是脱敏的，没有人的信息
         "/api/admin/settings/experiment-env",
     ):
         resp = await client.get(path, headers=gh)
@@ -61,3 +73,4 @@ async def test_admins_and_members_are_unaffected(client):
     ah = {"Authorization": f"Bearer {admin}"}
     assert (await client.get("/api/admin/users", headers=ah)).status_code == 200
     assert (await client.get("/api/collaborators/search?q=example", headers=ah)).status_code == 200
+    assert (await client.get("/api/admin/registration-codes", headers=ah)).status_code == 200

--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -22,9 +22,10 @@ const ADMIN_TABS: AdminTab[] = ['llm', 'experiment', 'daily', 'users', 'codes', 
 export function AdminSettingsPage() {
   const { data: me, isLoading } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
   const admin = isAdmin(me);
-  // 只读账号（游客）看不到成员名册：那一屏是真实的人的邮箱、用户名和用量。
-  // 后端也会拒（READ_ONLY_NO_PERSONAL_DATA）——这里只是别让入口摆在那里点了报错。
-  const canSeeRoster = !me?.read_only;
+  // 只读账号（游客）看不到两类东西，后端各有守卫，这里只是别让入口摆在那里点了报错：
+  //   名册——那一屏是真实的人的邮箱、用户名和用量（READ_ONLY_NO_PERSONAL_DATA）；
+  //   注册码——明文，抄走就能开真账号（READ_ONLY_NO_SECRETS）。
+  const guest = !!me?.read_only;
   // 支持 /admin?tab=llm 深链
   const [searchParams] = useSearchParams();
   const [tab, setTab] = useState<AdminTab>(() => {
@@ -32,16 +33,17 @@ export function AdminSettingsPage() {
     return t !== null && ADMIN_TABS.includes(t as AdminTab) ? (t as AdminTab) : 'llm';
   });
 
-  // 深链 /admin?tab=users 进来的游客回落到第一个标签，而不是停在一片空白上
-  // （me 还没回来时初值已经定成 users 了，所以这里按渲染时的实际权限再判一次）
-  const shownTab: AdminTab = tab === 'users' && !canSeeRoster ? 'llm' : tab;
+  // 深链 /admin?tab=users|codes 进来的游客回落到第一个标签，而不是停在一片空白上
+  // （me 还没回来时初值已经定下了，所以这里按渲染时的实际权限再判一次）
+  const hiddenForGuest: AdminTab[] = ['users', 'codes'];
+  const shownTab: AdminTab = guest && hiddenForGuest.includes(tab) ? 'llm' : tab;
 
   const items: { v: AdminTab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
     { v: 'experiment', label: tr('实验设置', 'Experiments') },
     { v: 'daily', label: tr('每日论文', 'Daily papers') },
-    ...(canSeeRoster ? [{ v: 'users' as const, label: tr('用户管理', 'Users') }] : []),
-    { v: 'codes', label: tr('注册码', 'Codes') },
+    ...(guest ? [] : [{ v: 'users' as const, label: tr('用户管理', 'Users') }]),
+    ...(guest ? [] : [{ v: 'codes' as const, label: tr('注册码', 'Codes') }]),
     { v: 'feedback', label: tr('反馈', 'Feedback') },
     { v: 'usage', label: tr('用量总览', 'Usage overview') },
   ];
@@ -66,8 +68,8 @@ export function AdminSettingsPage() {
           {shownTab === 'llm' && <LlmTab />}
           {shownTab === 'experiment' && <ExperimentSettings />}
           {shownTab === 'daily' && <DailyCategoriesTab />}
-          {shownTab === 'users' && canSeeRoster && <UsersTab />}
-          {shownTab === 'codes' && <CodesTab />}
+          {shownTab === 'users' && !guest && <UsersTab />}
+          {shownTab === 'codes' && !guest && <CodesTab />}
           {shownTab === 'feedback' && <FeedbackTab />}
           {shownTab === 'usage' && <UsageTab />}
         </>


### PR DESCRIPTION
Closes #311

`GET /api/admin/registration-codes` returns `code` in plaintext, and a guest account (`role=admin` + `read_only`) reaches the Codes tab. Anyone we hand a demo login to could copy a live invite code and register real accounts with it.

### Why read-only was not already enough

A registration code is not information about a person — it is a **usable credential**, and being read-only is no defence against it. The account gets created through the *public register endpoint*, which the write gate never sees. The code is dangerous precisely because it is readable.

That is a different failure from #309, which was about the roster: who is in this lab.

### Changes

- `block_read_only_secrets` refuses read-only accounts with `403 READ_ONLY_NO_SECRETS`.
- The Codes tab joins Users in being dropped from the admin page for guests; a deep link to either falls back to the first tab.
- A **separate** guard and error code rather than reusing `READ_ONLY_NO_PERSONAL_DATA`. The reasons differ — one is "who is here", the other is "this can be used" — and a later reader should not have to work out which one applies.

### The rest of the admin surface was checked

Deliberately untouched, because none of it hands over anything usable:

| Surface | Why it is safe |
|---|---|
| LLM providers | returns `api_key_masked`, never the key |
| SSH credentials | never returns the private key, and the list is scoped to the caller — a fresh guest has none |
| Chat bot webhooks | per-user, same reason |
| `admin/llm/usage` | aggregates by date, stage and model; no identity |

Registration codes were the only readable secret.

### One test changed rather than added

`test_guest_still_sees_the_non_personal_admin_screens` asserted that a guest could list registration codes — exactly the behaviour this PR removes. It now checks the screens that really do carry nothing sensitive, and a new test covers the refusal.

### Verification

- Full backend suite: **1149 passed**. The single failure, `test_experiment_iterate::test_debug_limit_terminates`, reproduces identically on `main` and was confirmed pre-existing back in #308 — untouched here.
- Frontend image builds; `ruff` clean on every file touched.