### PR TITLE
feat(voyage): per-run message stream so users can talk to a running task

### DIFF
--- a/src/backend/alembic/versions/63133f647463_voyage_messages.py
+++ b/src/backend/alembic/versions/63133f647463_voyage_messages.py
@@ -1,0 +1,65 @@
+"""voyage messages (per-run conversation stream between user and task agent)
+
+Revision ID: 63133f647463
+Revises: b3f5c1e07a92
+Create Date: 2026-08-06 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "63133f647463"
+down_revision: str | None = "b3f5c1e07a92"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "voyage_messages",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("run_id", sa.Uuid(), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(length=16), nullable=False),
+        sa.Column("author_id", sa.Uuid(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=True,
+        ),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("reply_to", sa.Uuid(), nullable=True),
+        sa.Column("step_id", sa.Uuid(), nullable=True),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("consumed_step_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["voyage_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["author_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["reply_to"], ["voyage_messages.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["step_id"], ["voyage_steps.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["consumed_step_id"], ["voyage_steps.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", "seq", name="uq_voyage_messages_run_seq"),
+    )
+    op.create_index(op.f("ix_voyage_messages_run_id"), "voyage_messages", ["run_id"], unique=False)
+    op.create_index(
+        "ix_voyage_messages_run_kind_status",
+        "voyage_messages",
+        ["run_id", "kind", "status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_voyage_messages_run_kind_status", table_name="voyage_messages")
+    op.drop_index(op.f("ix_voyage_messages_run_id"), table_name="voyage_messages")
+    op.drop_table("voyage_messages")

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -43,6 +43,7 @@ from app.models.gate import Gate
 from app.models.llm_config import LLMUsage
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun, VoyageStep, mode_for_kind
 from app.services import skills as skills_service
+from app.services import voyage_messages as messages_service
 
 MAX_REPLANS = 2
 _RANK_GAP = 100.0
@@ -193,6 +194,43 @@ class VoyageEngine:
         if step_id is not None:
             data["step_id"] = str(step_id)
         await self._emit_voyage(run.id, "log", data)
+
+    async def _post_agent_message(
+        self,
+        session: AsyncSession,
+        run: VoyageRun,
+        *,
+        kind: str,
+        text: str,
+        payload: dict[str, Any] | None = None,
+        status: str = "none",
+        step_id: uuid.UUID | None = None,
+    ) -> None:
+        """agent 侧消息落对话流 + SSE `message` 事件（尽力而为，不影响主流程）。"""
+        try:
+            message = await messages_service.append_message(
+                session,
+                run.id,
+                role="agent",
+                kind=kind,
+                text=text,
+                payload=payload,
+                status=status,
+                step_id=step_id,
+            )
+        except messages_service.MessageSeqConflictError:
+            return
+        await self._emit_voyage(
+            run.id, "message", {"message": messages_service.serialize_message(message)}
+        )
+
+    # ---- 用户建议消费（docs/task-system.md：非阻塞反馈在下一个决策点注入）----
+
+    async def _drain_user_messages(self, session: AsyncSession, run: VoyageRun) -> list[Any]:
+        """取未消费的用户建议（不标记）。标记与效果必须同一事务提交：
+        用 :func:`messages_service.mark_chat_consumed` 后由调用方 commit，
+        resume 重放时要么建议已随效果生效、要么原样留在队列。"""
+        return await messages_service.pending_chat_messages(session, run.id)
 
     # ---- 状态持久化 ----
 
@@ -505,11 +543,30 @@ class VoyageEngine:
         step_def: dict[str, Any],
         step_row: VoyageStep,
     ) -> None:
+        # 注入点①：把未消费的用户建议注入本步骤 params（消费标记与 running 同一事务，
+        # resume 重放天然幂等——建议随步骤持久化，不会二次注入）
+        guidance_msgs = await self._drain_user_messages(session, run)
+        if guidance_msgs:
+            params = dict(step_row.params or {})
+            params["user_guidance"] = list(params.get("user_guidance") or []) + [
+                m.text for m in guidance_msgs
+            ]
+            step_row.params = params
+            step_def["params"] = params  # step_def 在本次调用前构建，需同步
+            messages_service.mark_chat_consumed(guidance_msgs, step_id=step_row.id)
         step_row.status = "running"
         step_row.attempt = step_row.attempt + 1
         step_row.started_at = utcnow()
         await session.commit()
         await self._emit_step(run, step_row)
+        if guidance_msgs:
+            await self._post_agent_message(
+                session,
+                run,
+                kind="info",
+                text=f"已收到你的 {len(guidance_msgs)} 条建议，执行「{step_row.title}」时一并参考",
+                step_id=step_row.id,
+            )
         retry_note = f"（第 {step_row.attempt} 次尝试）" if step_row.attempt > 1 else ""
         await self._emit_log(
             run,
@@ -869,9 +926,17 @@ class VoyageEngine:
         await self._set_status(session, run, "replanning")
         rows = await self._active_rows(session, run)
         failed_def = dict(failed_step) | {"step_id": str(failed_node.id)}
+        # 注入点②：计划调整时把未消费的用户建议交给 Navigator（标记与编辑生效同一事务；
+        # LLM 失败 / 编辑被拒时不标记，建议留在队列等下一个决策点）
+        guidance_msgs = await self._drain_user_messages(session, run)
+        user_guidance = messages_service.guidance_text(guidance_msgs) or None
         try:
             edit = await self.navigator.on_result(
-                run, failed_def, diagnosis, self._plan_state_summary(rows)
+                run,
+                failed_def,
+                diagnosis,
+                self._plan_state_summary(rows),
+                user_guidance=user_guidance,
             )
         except NavigatorError as e:
             await self._emit_log(run, f"计划调整失败：{e}", level="error")
@@ -913,8 +978,18 @@ class VoyageEngine:
             obsoleted=obsoleted,
             trigger_step=failed_node.title,
         )
+        if guidance_msgs:
+            messages_service.mark_chat_consumed(guidance_msgs, step_id=failed_node.id)
         await self._regen_plan_snapshot(session, run)
         await session.commit()
+        if guidance_msgs:
+            await self._post_agent_message(
+                session,
+                run,
+                kind="info",
+                text=f"计划调整时参考了你的 {len(guidance_msgs)} 条建议",
+                step_id=failed_node.id,
+            )
         await self._emit_log(
             run,
             f"第 {replans + 1} 次计划调整完成（{edit.get('reason') or ''}，"
@@ -949,8 +1024,13 @@ class VoyageEngine:
             return False
 
         await self._set_status(session, run, "replanning")
+        # 注入点②（template 同 loop）：用户建议交给重规划，失败不标记消费
+        guidance_msgs = await self._drain_user_messages(session, run)
+        user_guidance = messages_service.guidance_text(guidance_msgs) or None
         try:
-            new_tail = await self.navigator.replan(run, failed_step, diagnosis)
+            new_tail = await self.navigator.replan(
+                run, failed_step, diagnosis, user_guidance=user_guidance
+            )
         except NavigatorError as e:
             await self._emit_log(run, f"重规划失败：{e}", level="error")
             await self._set_status(session, run, "paused_error")
@@ -993,10 +1073,20 @@ class VoyageEngine:
             obsoleted=len(tail),
             trigger_step=failed_node.title,
         )
+        if guidance_msgs:
+            messages_service.mark_chat_consumed(guidance_msgs, step_id=failed_node.id)
         # run.plan 快照单向派生：已通过前缀 + 新尾部
         passed_defs = [_step_def_from_row(r, run.plan) for r in rows if r.status == "passed"]
         run.plan = passed_defs + list(new_tail)
         await session.commit()
+        if guidance_msgs:
+            await self._post_agent_message(
+                session,
+                run,
+                kind="info",
+                text=f"重规划时参考了你的 {len(guidance_msgs)} 条建议",
+                step_id=failed_node.id,
+            )
         await self._emit_log(
             run,
             f"第 {replans + 1} 次重规划完成，剩余 {len(new_tail)} 步（诊断：{diagnosis}）",

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -686,11 +686,16 @@ class Navigator:
         return await self._ask_for_steps(run, system, user_prompt, workflows=workflows)
 
     async def replan(
-        self, run: VoyageRun, failed_step: dict[str, Any], diagnosis: str
+        self,
+        run: VoyageRun,
+        failed_step: dict[str, Any],
+        diagnosis: str,
+        user_guidance: str | None = None,
     ) -> list[dict[str, Any]]:
         """验证失败后重规划：返回替换「失败步骤起的剩余计划」的新步骤列表。
 
         idea_proposal 走确定性重规划（novelty 三档分支等），不经 LLM。
+        ``user_guidance``：用户在任务对话流里的未消费建议（优先遵循）。
         """
         if run.kind == "idea_proposal":
             return proposal_replan(run, failed_step, diagnosis)
@@ -701,6 +706,8 @@ class Navigator:
             f"失败步骤：{json.dumps(failed_step, ensure_ascii=False, default=str)}\n"
             f"失败诊断：{diagnosis}"
         )
+        if user_guidance:
+            user_prompt += f"\n用户对这次调整的补充指示（务必优先遵循）：\n{user_guidance}"
         return await self._ask_for_steps(run, system, user_prompt)
 
     async def on_result(
@@ -709,11 +716,13 @@ class Navigator:
         failed_step: dict[str, Any],
         diagnosis: str,
         plan_state: str,
+        user_guidance: str | None = None,
     ) -> dict[str, Any]:
         """loop 模式失败回灌：LLM 产出**计划编辑**而非替换尾部（docs/voyage-loop.md §5.3）。
 
         输出经 validate_plan_edit 严格校验（schema / 动作注册表 / 新增节点上限 /
         新节点必须带验收）；连续非法抛 NavigatorError（engine 转 paused_error）。
+        ``user_guidance``：用户在任务对话流里的未消费建议（优先遵循）。
         """
         system = PLAN_EDIT_SYSTEM_PROMPT % {"actions": ", ".join(sorted(known_actions()))}
         user_prompt = (
@@ -722,6 +731,8 @@ class Navigator:
             f"失败步骤：{json.dumps(failed_step, ensure_ascii=False, default=str)}\n"
             f"失败诊断：{diagnosis}"
         )
+        if user_guidance:
+            user_prompt += f"\n用户对这次调整的补充指示（务必优先遵循）：\n{user_guidance}"
         last_error: Exception | None = None
         for _attempt in range(_MAX_ATTEMPTS):
             result = await self._llm.complete(

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import current_active_user
 from app.api.chat_stream import sse_frame as _sse_frame
 from app.core.db import get_session
-from app.core.events import voyage_channel
+from app.core.events import EventBus, get_event_bus, voyage_channel
 from app.core.queue import TaskQueue, get_task_queue
 from app.core.redis import get_redis_dep
 from app.models.user import User
@@ -22,12 +22,15 @@ from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.voyage import (
     VoyageCreate,
     VoyageDetailRead,
+    VoyageMessageCreate,
+    VoyageMessageRead,
     VoyagePlanEvent,
     VoyageRead,
     VoyageSkillUse,
     VoyageTerminalLogRead,
 )
 from app.services import projects as projects_service
+from app.services import voyage_messages as messages_service
 from app.services import voyages as voyages_service
 
 router = APIRouter(prefix="/voyages", tags=["voyages"])
@@ -130,6 +133,55 @@ async def get_voyage_logs(
 
     rows = await fetch_terminal_logs(session, voyage_id)
     return [VoyageTerminalLogRead.model_validate(r) for r in rows]
+
+
+@router.get("/{voyage_id}/messages", response_model=list[VoyageMessageRead])
+async def list_voyage_messages(
+    voyage_id: uuid.UUID,
+    after_seq: int | None = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=1000),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[VoyageMessageRead]:
+    """任务对话流（用户建议 / agent 提问与播报），按 seq 升序。"""
+    await _get_owned_voyage(session, voyage_id, user)
+    rows = await messages_service.list_messages(
+        session, voyage_id, after_seq=after_seq, limit=limit
+    )
+    return [VoyageMessageRead.model_validate(r) for r in rows]
+
+
+@router.post(
+    "/{voyage_id}/messages",
+    response_model=VoyageMessageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_voyage_message(
+    voyage_id: uuid.UUID,
+    data: VoyageMessageCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    bus: EventBus = Depends(get_event_bus),
+) -> VoyageMessageRead:
+    """给运行中的任务发一条建议（非阻塞：agent 在下一个决策点参考）。
+
+    终态任务没有下一个决策点，409；暂停中的任务可以发（恢复后消费）。
+    """
+    run = await _get_owned_voyage(session, voyage_id, user)
+    if run.status in TERMINAL_STATUSES:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="VOYAGE_ALREADY_FINISHED")
+    message = await messages_service.append_message(
+        session,
+        run.id,
+        role="user",
+        kind="chat",
+        text=data.text,
+        author_id=user.id,
+    )
+    await bus.publish_voyage_event(
+        run.id, "message", {"message": messages_service.serialize_message(message)}
+    )
+    return VoyageMessageRead.model_validate(message)
 
 
 @router.post("/{voyage_id}/cancel", response_model=VoyageRead)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -44,7 +44,7 @@ from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
 from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
-from app.models.voyage import VoyageRun, VoyageStep
+from app.models.voyage import VoyageMessage, VoyageRun, VoyageStep
 
 __all__ = [
     "Activity",
@@ -106,6 +106,7 @@ __all__ = [
     "UserPublication",
     "UserSkill",
     "UUIDPrimaryKeyMixin",
+    "VoyageMessage",
     "VoyageRun",
     "VoyageStep",
     "paper_concepts",

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -2,6 +2,7 @@
 
 - VoyageRun：一次航程（目标、计划、游标、检查点、预算/用量）
 - VoyageStep：航程中的单个步骤（动作、观测、Sextant 判定、token 记账）
+- VoyageMessage：任务级对话流（用户建议 / agent 提问与播报），run 资产随任务级联删除
 """
 
 import uuid
@@ -13,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -157,6 +159,55 @@ class VoyageStep(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     run: Mapped[VoyageRun] = relationship(back_populates="steps")
+
+
+# 消息种类：chat = 用户的非阻塞建议（agent 在下一个决策点消费）；
+# ask = agent 向用户提问（阻塞，任务转 paused_ask，见 docs/task-system.md）；
+# answer = 用户对 ask 的回答（reply_to 指向 ask）；info = agent 播报（如「已采纳你的建议」）。
+VOYAGE_MESSAGE_KINDS = ("chat", "ask", "answer", "info")
+# ask 生命周期：open（等回答）→ answered（已答，等引擎消费）→ consumed（引擎已把回答
+# 变成行为，与该行为同事务提交）；superseded = 被取消/新 ask 覆盖。其余 kind 恒为 none。
+VOYAGE_MESSAGE_STATUSES = ("none", "open", "answered", "consumed", "superseded")
+
+
+class VoyageMessage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """任务对话流的一条消息：用户与任务 agent 的双向通道。
+
+    run 资产（非用户资产）：项目成员共享同一条流，随任务级联删除——与
+    Conversation（用户资产，课题删了对话还在）刻意区分，不复用。
+    """
+
+    __tablename__ = "voyage_messages"
+    __table_args__ = (
+        UniqueConstraint("run_id", "seq", name="uq_voyage_messages_run_seq"),
+        # 引擎热查询：open ask / 未消费 chat 都按 (run_id, kind, status) 走
+        Index("ix_voyage_messages_run_kind_status", "run_id", "kind", "status"),
+    )
+
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("voyage_runs.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # 流内定序（同 conversation_messages 模式：max+1 分配，唯一约束兜底并发）
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    role: Mapped[str] = mapped_column(String(16), nullable=False)  # user | agent
+    # agent 侧消息无作者；用户删号不删流（历史建议仍是任务因果链的一部分）
+    author_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"))
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)  # VOYAGE_MESSAGE_KINDS
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    # kind=ask: {ask_kind, diagnosis?, context?, options: [{id,label,effect?}]}
+    # kind=answer: {choice?, extra?}
+    payload: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    # 仅 kind=ask 有意义（引擎按 (run_id, kind, status) 查 open/answered，不查 JSON path）
+    status: Mapped[str] = mapped_column(String(16), default="none", nullable=False)
+    reply_to: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("voyage_messages.id", ondelete="SET NULL")
+    )
+    step_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("voyage_steps.id", ondelete="SET NULL")
+    )
+    # 仅 kind=chat：被 agent 消费的时间与位置（审计 + resume 重放幂等锚点）
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    consumed_step_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("voyage_steps.id"))
 
 
 class VoyageTerminalLog(Base):

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -85,6 +85,34 @@ class VoyagePlanEvent(BaseModel):
     at: datetime | None = None
 
 
+class VoyageMessageCreate(BaseModel):
+    """用户向任务发一条建议（非阻塞：agent 在下一个决策点参考）。"""
+
+    text: str = Field(min_length=1, max_length=8000)
+
+
+class VoyageMessageRead(BaseModel):
+    """任务对话流的一条消息（用户建议 / agent 提问 / 回答 / agent 播报）。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    run_id: uuid.UUID
+    seq: int  # 流内定序
+    role: Literal["user", "agent"]
+    kind: Literal["chat", "ask", "answer", "info"]
+    author_id: uuid.UUID | None = None
+    text: str
+    # kind=ask: {ask_kind, diagnosis?, context?, options: [...]}；kind=answer: {choice?, extra?}
+    payload: dict[str, Any] | None = None
+    # 仅 kind=ask：open | answered | consumed | superseded（其余恒 none）
+    status: str = "none"
+    reply_to: uuid.UUID | None = None
+    step_id: uuid.UUID | None = None
+    consumed_at: datetime | None = None  # 仅 kind=chat：被 agent 消费的时间
+    created_at: datetime
+
+
 class VoyageTerminalLogRead(BaseModel):
     """任务终端历史日志的一条：结构化日志行（event=log）或大模型完整输出（event=llm）。"""
 

--- a/src/backend/app/services/voyage_messages.py
+++ b/src/backend/app/services/voyage_messages.py
@@ -1,0 +1,140 @@
+"""任务对话流：用户与任务 agent 的双向消息（不 import fastapi）。
+
+- append_message：流内 seq 定序追加（max+1；唯一约束兜底并发，冲突重试）。
+- pending_chat_messages / mark_chat_consumed：非阻塞用户建议的排队与消费。
+  消费标记必须与「建议生效的那次落库」同一事务提交（调用方 commit），
+  这样 resume 重放不会重复注入——建议要么随效果一起生效，要么原样留在队列里。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.voyage import VoyageMessage
+
+_APPEND_RETRIES = 3
+TEXT_MAX_CHARS = 8_000
+
+
+class MessageSeqConflictError(Exception):
+    """并发追加连续撞 seq 唯一约束（重试耗尽）。"""
+
+
+def serialize_message(message: VoyageMessage) -> dict[str, Any]:
+    """SSE `message` 事件与 API 共用的消息序列化。"""
+    return {
+        "id": str(message.id),
+        "run_id": str(message.run_id),
+        "seq": message.seq,
+        "role": message.role,
+        "kind": message.kind,
+        "text": message.text,
+        "payload": message.payload,
+        "status": message.status,
+        "reply_to": str(message.reply_to) if message.reply_to else None,
+        "step_id": str(message.step_id) if message.step_id else None,
+        "consumed_at": message.consumed_at.isoformat() if message.consumed_at else None,
+        "created_at": message.created_at.isoformat() if message.created_at else None,
+    }
+
+
+async def append_message(
+    session: AsyncSession,
+    run_id: uuid.UUID,
+    *,
+    role: str,
+    kind: str,
+    text: str,
+    author_id: uuid.UUID | None = None,
+    payload: dict[str, Any] | None = None,
+    status: str = "none",
+    reply_to: uuid.UUID | None = None,
+    step_id: uuid.UUID | None = None,
+) -> VoyageMessage:
+    """追加一条消息并 commit；返回持久化行。
+
+    seq = 当前最大值 + 1；用户发帖与引擎播报可能并发，撞唯一约束就重算重试。
+    注意：本函数自己 commit（seq 分配需要独立提交点），调用方若有未提交状态
+    应先行 commit 或改用独立 session。
+    """
+    last_error: IntegrityError | None = None
+    for _ in range(_APPEND_RETRIES):
+        next_seq = (
+            await session.execute(
+                select(VoyageMessage.seq)
+                .where(VoyageMessage.run_id == run_id)
+                .order_by(VoyageMessage.seq.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        message = VoyageMessage(
+            run_id=run_id,
+            seq=(next_seq or 0) + 1,
+            role=role,
+            author_id=author_id,
+            kind=kind,
+            text=text[:TEXT_MAX_CHARS],
+            payload=payload,
+            status=status,
+            reply_to=reply_to,
+            step_id=step_id,
+        )
+        session.add(message)
+        try:
+            await session.commit()
+        except IntegrityError as e:
+            await session.rollback()
+            last_error = e
+            continue
+        await session.refresh(message)
+        return message
+    raise MessageSeqConflictError(str(run_id)) from last_error
+
+
+async def list_messages(
+    session: AsyncSession,
+    run_id: uuid.UUID,
+    *,
+    after_seq: int | None = None,
+    limit: int = 500,
+) -> list[VoyageMessage]:
+    stmt = (
+        select(VoyageMessage)
+        .where(VoyageMessage.run_id == run_id)
+        .order_by(VoyageMessage.seq)
+        .limit(limit)
+    )
+    if after_seq is not None:
+        stmt = stmt.where(VoyageMessage.seq > after_seq)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def pending_chat_messages(session: AsyncSession, run_id: uuid.UUID) -> list[VoyageMessage]:
+    """未被 agent 消费的用户建议，按 seq 升序。"""
+    stmt = (
+        select(VoyageMessage)
+        .where(
+            VoyageMessage.run_id == run_id,
+            VoyageMessage.kind == "chat",
+            VoyageMessage.consumed_at.is_(None),
+        )
+        .order_by(VoyageMessage.seq)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+def mark_chat_consumed(messages: list[VoyageMessage], *, step_id: uuid.UUID | None = None) -> None:
+    """标记建议已消费。只改内存对象，**由调用方与效果同一事务 commit**。"""
+    now = utcnow()
+    for message in messages:
+        message.consumed_at = now
+        message.consumed_step_id = step_id
+
+
+def guidance_text(messages: list[VoyageMessage]) -> str:
+    """把待消费建议拼成注入 prompt / params 的纯文本（一行一条）。"""
+    return "\n".join(f"- {m.text}" for m in messages)

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b3f5c1e07a92"  # 只读账号（游客）：能看的由 role 决定，能改的一律没有
+HEAD_REVISION = "63133f647463"  # 任务对话流：voyage_messages 表（用户与任务 agent 的双向通道）
+READ_ONLY_REVISION = "b3f5c1e07a92"  # 只读账号（游客）
 SKILLS_GLOBAL_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
 MEMORY_KIND_REVISION = "d4e8b19c7a55"  # 记忆分层：fact 每轮带上 / note 检索到才回上下文
 BUDDY_REVISION = "c31f7a9d40b2"  # Buddy 的长期记忆（用户自己写的）
@@ -358,8 +359,16 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["library_research_digests"]
     assert "relevance_reason" in columns["library_papers"]
     assert "scored_run_id" in columns["library_papers"]  # 打分归属改记运行 id
+    # 任务对话流：用户与任务 agent 的双向消息
+    assert "voyage_messages" in columns["_tables"]
 
-    # 最新 revision 可往返：先退掉只读账号。
+    # 最新 revision 可往返：先退掉任务对话流。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == READ_ONLY_REVISION
+    assert "voyage_messages" not in columns["_tables"]
+
+    # 再退掉只读账号。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == MEMORY_KIND_REVISION

--- a/src/backend/tests/test_voyage_messages.py
+++ b/src/backend/tests/test_voyage_messages.py
@@ -1,0 +1,241 @@
+"""任务对话流（voyage_messages）：API 收发 + 引擎在决策点消费用户建议。
+
+- POST/GET /voyages/{id}/messages：追加建议（终态 409）与按 seq 回放；
+- 注入点①：步骤执行前把未消费建议注入 step.params["user_guidance"]，
+  消费标记与 running 同一事务（resume 重放不重复注入）；
+- 注入点②：loop 失败回灌时未消费建议交给 Navigator（user_guidance 形参）。
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.agents.voyage.engine import VoyageEngine
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.voyage import VoyageMessage, VoyageRun, VoyageStep
+from app.services import voyage_messages as messages_service
+from tests.conftest import RecordingBus, register_and_login
+
+
+async def _make_project(client) -> tuple[str, dict]:
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "msg-proj"}, headers=headers)
+    return resp.json()["id"], headers
+
+
+async def _manual_run(project_id: str, *, kind: str, plan: list[dict], status="planning"):
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind=kind,
+            goal="对话流测试",
+            status=status,
+            cursor=0,
+            plan=plan,
+            project_id=uuid.UUID(project_id),
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+def _engine() -> VoyageEngine:
+    return VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+
+
+_SLEEP_OK = {
+    "title": "确定性步骤",
+    "action": "sleep",
+    "params": {"seconds": 0},
+    "acceptance": None,
+    "checks": [{"kind": "no_error"}],
+    "requires_gate": None,
+}
+
+
+# ---- API ----
+
+
+async def test_post_and_list_messages(client, bus_recorder):
+    project_id, headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK])
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/messages", json={"text": "先跑小样本"}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["seq"] == 1 and body["role"] == "user" and body["kind"] == "chat"
+    assert body["consumed_at"] is None
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/messages", json={"text": "预算别超"}, headers=headers
+    )
+    assert resp.json()["seq"] == 2
+
+    # 发布了 SSE message 事件（前端对话流实时追加）
+    events = [e for (vid, e, _d) in bus_recorder.voyage_events if e == "message"]
+    assert len(events) == 2
+
+    resp = await client.get(f"/api/voyages/{run_id}/messages", headers=headers)
+    assert resp.status_code == 200
+    seqs = [m["seq"] for m in resp.json()]
+    assert seqs == [1, 2]
+
+    # after_seq 增量拉取
+    resp = await client.get(f"/api/voyages/{run_id}/messages?after_seq=1", headers=headers)
+    assert [m["seq"] for m in resp.json()] == [2]
+
+
+async def test_post_message_terminal_voyage_409(client, bus_recorder):
+    project_id, headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK], status="done")
+    resp = await client.post(
+        f"/api/voyages/{run_id}/messages", json={"text": "太晚了"}, headers=headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "VOYAGE_ALREADY_FINISHED"
+
+
+async def test_messages_require_view_permission(client, bus_recorder):
+    project_id, _headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK])
+    outsider = await register_and_login(client, email="mallory@example.com")
+    outsider_headers = {"Authorization": f"Bearer {outsider}"}
+    resp = await client.get(f"/api/voyages/{run_id}/messages", headers=outsider_headers)
+    assert resp.status_code == 404
+    resp = await client.post(
+        f"/api/voyages/{run_id}/messages", json={"text": "hi"}, headers=outsider_headers
+    )
+    assert resp.status_code == 404
+
+
+# ---- 引擎消费 ----
+
+
+async def test_step_execution_drains_guidance_into_params(client, queue_stub):
+    """注入点①：执行前未消费建议进 step.params["user_guidance"] 并标记消费。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK])
+    async with get_sessionmaker()() as session:
+        await messages_service.append_message(
+            session, run_id, role="user", kind="chat", text="注意用小学习率"
+        )
+
+    await _engine().run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        step = (
+            await session.execute(select(VoyageStep).where(VoyageStep.run_id == run_id))
+        ).scalar_one()
+        assert step.params["user_guidance"] == ["注意用小学习率"]
+        messages = (
+            (
+                await session.execute(
+                    select(VoyageMessage)
+                    .where(VoyageMessage.run_id == run_id)
+                    .order_by(VoyageMessage.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        chat = [m for m in messages if m.kind == "chat"]
+        assert len(chat) == 1
+        assert chat[0].consumed_at is not None
+        assert chat[0].consumed_step_id == step.id
+        # 消费后有 agent 播报（用户能看到建议被采纳）
+        infos = [m for m in messages if m.kind == "info" and m.role == "agent"]
+        assert len(infos) == 1 and "1 条建议" in infos[0].text
+
+
+async def test_navigator_edit_receives_pending_guidance(client, queue_stub):
+    """注入点②：失败回灌时执行期间新到的建议交给 Navigator（user_guidance）。"""
+    project_id, _headers = await _make_project(client)
+    plan = [
+        {
+            "title": "会失败的步骤",
+            "action": "sleep",
+            "params": {"seconds": -1},
+            "acceptance": None,
+            "requires_gate": None,
+        }
+    ]
+    run_id = await _manual_run(project_id, kind="custom", plan=plan)
+
+    engine = _engine()
+    exec_count = 0
+    orig_execute = engine.helm.execute
+
+    async def execute_and_post(ctx, step_def):
+        nonlocal exec_count
+        exec_count += 1
+        observation = await orig_execute(ctx, step_def)
+        # 模拟用户在步骤执行期间发来建议
+        async with get_sessionmaker()() as session:
+            await messages_service.append_message(
+                session, run_id, role="user", kind="chat", text=f"建议 {exec_count}"
+            )
+        return observation
+
+    engine.helm.execute = execute_and_post
+
+    captured: dict = {}
+    orig_on_result = engine.navigator.on_result
+
+    async def spy_on_result(run, failed_step, diagnosis, plan_state, user_guidance=None):
+        captured["guidance"] = user_guidance
+        return await orig_on_result(
+            run, failed_step, diagnosis, plan_state, user_guidance=user_guidance
+        )
+
+    engine.navigator.on_result = spy_on_result
+    await engine.run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"  # fake navigator 给出替代计划后跑完
+        rows = (
+            (
+                await session.execute(
+                    select(VoyageStep).where(VoyageStep.run_id == run_id).order_by(VoyageStep.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        failed = rows[0]
+        # 第 1 条建议在原地重试（第 2 次执行）时注入了失败节点 params
+        assert failed.params["user_guidance"] == ["建议 1"]
+        # 第 2 条建议在计划调整时交给了 Navigator
+        assert captured["guidance"] is not None and "建议 2" in captured["guidance"]
+        # 最后一次执行期间发的建议之后再无决策点，留在队列（其余全部被消费）
+        pending = await messages_service.pending_chat_messages(session, run_id)
+        assert [m.text for m in pending] == [f"建议 {exec_count}"]
+
+
+async def test_append_message_seq_is_monotonic(client):
+    project_id, _headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK])
+    async with get_sessionmaker()() as session:
+        first = await messages_service.append_message(
+            session, run_id, role="user", kind="chat", text="a"
+        )
+        second = await messages_service.append_message(
+            session, run_id, role="agent", kind="info", text="b"
+        )
+        assert (first.seq, second.seq) == (1, 2)
+        rows = await messages_service.list_messages(session, run_id)
+        assert [m.text for m in rows] == ["a", "b"]
+
+
+@pytest.mark.parametrize("bad", ["", "x" * 8001])
+async def test_post_message_validation(client, bus_recorder, bad):
+    project_id, headers = await _make_project(client)
+    run_id = await _manual_run(project_id, kind="custom", plan=[_SLEEP_OK])
+    resp = await client.post(f"/api/voyages/{run_id}/messages", json={"text": bad}, headers=headers)
+    assert resp.status_code == 422


### PR DESCRIPTION
## What

Groundwork for the interactive PEV loop (design in #313): a per-run conversation stream between the user and the task agent, plus engine-side consumption of user suggestions at every decision point.

- **New table `voyage_messages`** — run-scoped stream (cascade-deleted with the run), `kind ∈ chat | ask | answer | info`. The ask lifecycle columns (`status`, `reply_to`, payload) land now so the follow-up ask primitive (#314) needs no second migration. Deliberately *not* reusing `conversations`: that table is a user asset with single-turn semantics; this stream is a run asset shared by everyone who can view the voyage.
- **`GET/POST /voyages/{id}/messages`** — replay by `seq` (with `after_seq` incremental fetch) and append non-blocking suggestions; 409 `VOYAGE_ALREADY_FINISHED` on terminal runs; posting publishes an SSE `message` event on the existing `voyage:{id}:events` channel.
- **Engine drain points** — unconsumed `chat` messages are injected:
  - into `step.params["user_guidance"]` before each step execution, committed atomically with the `running` transition (resume replays can never double-inject);
  - into Navigator `on_result` / `replan` prompts (new optional `user_guidance` parameter), marked consumed only in the same transaction that actually lands the plan edit — if the LLM fails or the edit is rejected, the suggestion stays queued for the next decision point.
- Every consumption posts an agent `info` message back to the stream so the user can see their advice was picked up.

## Tests

- New `tests/test_voyage_messages.py` (8 cases): API append/replay/409/authz, drain-into-params idempotency anchors, Navigator receiving mid-execution suggestions, seq monotonicity, validation.
- `test_migrations.py` roundtrip extended for the new head.
- Full suite: 1157 passed; the only failure unrelated to this branch (`test_debug_limit_terminates`) also fails on pristine `origin/main`.

Closes #313
