### PR TITLE
feat(voyage): ask-the-user primitive — agent pauses with a question instead of dying

### DIFF
--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -7,13 +7,16 @@ voyage_steps 行，run.plan 只是派生快照），调度规则 = 按 rank 取�
                                       ├→ 原地重试（执行类错误，attempt < max）
                                       ├→ replanning → executing（template/loop）
                                       ├→ paused_gate（审批后 resume）
-                                      ├→ paused_error（pipeline 失败/重规划超限，可修复后重试）
-                                      └→ done / failed
+                                      ├→ paused_ask（agent 死路转向用户提问，回答后 resume）
+                                      ├→ paused_error（pipeline 失败；无人值守 run 的降级兜底）
+                                      └→ done / failed（failed 只由人拍板：cancel/驳回/放弃）
 要点：
 - 失败分派按 run.mode（docs/voyage-loop.md §5.1）：
   执行类错误（observation.error）在节点 max_attempts 内带诊断原地重试；
-  判断类失败（校验未过）不重试——pipeline 直接停（on_failure="fail" → failed，
-  否则 paused_error 等人工修复后断点重试），template/loop 走重规划；
+  判断类失败（校验未过）不重试——pipeline 直接停（paused_error 等人工修复后
+  断点重试），template/loop 走重规划；on_failure="fail" 步骤（smoke/run 这类
+  盲目重跑烧算力的）与各类重规划死路一律转 paused_ask 向用户提问
+  （无人值守 run 没人回答，降级保持旧 paused_error 语义）；
 - 重规划不再删行：旧尾部节点标 obsolete 留痕，新节点按 rank 间隙追加（seq 只增不改）；
 - 每次尝试完整归档进 step.attempts（SSE 事件不持久，审计留痕一律落库）；
 - requires_gate 步骤执行前创建 Gate 并暂停（结束本次 ARQ 任务），approve 后
@@ -47,6 +50,34 @@ from app.services import voyage_messages as messages_service
 
 MAX_REPLANS = 2
 _RANK_GAP = 100.0
+
+# ask 的候选选项（消息是数据，标签存 zh/en 两份，前端渲染处按语言取）。
+# 自由文本回答始终允许；choice 只是给用户的快捷入口与引擎的确定性分支键。
+_ASK_OPTIONS: dict[str, list[dict[str, Any]]] = {
+    "fatal_step": [
+        {"id": "retry", "zh": "重试这一步（可附指示）", "en": "Retry (with instructions)"},
+        {"id": "replan", "zh": "换个方案（请说明思路）", "en": "Change approach (describe how)"},
+        {"id": "abort", "zh": "放弃任务", "en": "Give up"},
+    ],
+    "continue_abort": [
+        {"id": "continue", "zh": "继续（可附指示）", "en": "Continue (with instructions)"},
+        {"id": "abort", "zh": "放弃任务", "en": "Give up"},
+    ],
+    "no_progress": [
+        {"id": "continue", "zh": "给出指示继续", "en": "Continue with instructions"},
+        {"id": "finish", "zh": "按当前结果收尾", "en": "Wrap up with current results"},
+        {"id": "abort", "zh": "放弃任务", "en": "Give up"},
+    ],
+    "done_criteria": [
+        {"id": "accept", "zh": "接受当前结果为完成", "en": "Accept as done"},
+        {"id": "continue", "zh": "继续补做（请说明）", "en": "Keep going (describe what)"},
+        {"id": "abort", "zh": "放弃任务", "en": "Give up"},
+    ],
+    "budget": [
+        {"id": "add_budget", "zh": "追加预算", "en": "Add budget"},
+        {"id": "abort", "zh": "放弃任务", "en": "Give up"},
+    ],
+}
 
 
 class _ExternallyTerminated(Exception):
@@ -232,6 +263,245 @@ class VoyageEngine:
         resume 重放时要么建议已随效果生效、要么原样留在队列。"""
         return await messages_service.pending_chat_messages(session, run.id)
 
+    # ---- 向用户提问（paused_ask）：agent 死路不再打死任务，转成等人回答 ----
+
+    async def _raise_ask(
+        self,
+        session: AsyncSession,
+        run: VoyageRun,
+        *,
+        ask_kind: str,
+        question: str,
+        context: dict[str, Any] | None = None,
+        options: list[dict[str, Any]] | None = None,
+        step: VoyageStep | None = None,
+        fallback_status: str = "paused_error",
+    ) -> None:
+        """插入一条 ask 消息并把任务转 paused_ask（与 paused_gate 同构：结束本次
+        ARQ 任务，回答后由 resume_voyage 续跑）。
+
+        - 幂等：同 run 同 (ask_kind, step_id) 已有 open 提问则不重复插
+          （防 reconcile 重放 executing 状态时重复建）；
+        - 无人值守 run（created_by 为空，cron 发起）没人会来回答，降级为
+          ``fallback_status``（保持旧的 paused_error 语义，交 reclaim 机制处理）。
+        """
+        if run.created_by is None:
+            await self._emit_log(run, f"需要人工处理：{question}", level="error")
+            await self._set_status(session, run, fallback_status)
+            return
+        step_id = step.id if step is not None else None
+        existing = await messages_service.find_open_ask(
+            session, run.id, ask_kind=ask_kind, step_id=step_id
+        )
+        if existing is None:
+            payload: dict[str, Any] = {"ask_kind": ask_kind}
+            if context:
+                payload["context"] = context
+            if options:
+                payload["options"] = options
+            try:
+                message = await messages_service.append_message(
+                    session,
+                    run.id,
+                    role="agent",
+                    kind="ask",
+                    text=question,
+                    payload=payload,
+                    status="open",
+                    step_id=step_id,
+                )
+            except messages_service.MessageSeqConflictError:
+                message = None
+            if message is not None:
+                await self._emit_voyage(
+                    run.id,
+                    "ask.created",
+                    {"message": messages_service.serialize_message(message)},
+                )
+                await self._emit_notify(
+                    run.project_id,
+                    {
+                        "type": "voyage.ask",
+                        "voyage_id": str(run.id),
+                        "question": question[:200],
+                    },
+                )
+        # 终端叙事镜像（level=gate：黄色提示，与人工审批同一视觉家族）
+        await self._emit_log(run, f"AI 有问题需要你回答：{question}", level="gate")
+        await self._set_status(session, run, "paused_ask")
+
+    async def _consume_answered_asks(self, session: AsyncSession, run: VoyageRun) -> bool:
+        """把已回答的提问变成行为（_drive 开头调用）。返回 False 表示任务已停。
+
+        - abort 类回答在 API 侧直接置 failed，不会走到这里；
+        - 回答文本由 API 侧镜像成一条建议消息（kind=chat），随 PR1 的注入点在
+          下一个决策点生效——这里只做确定性效果与状态推进；
+        - 效果与 ask.status='consumed' 同一事务提交（resume 重放幂等）。
+        """
+        asks = await messages_service.answered_asks(session, run.id)
+        if not asks:
+            return True
+        for ask in asks:
+            payload = ask.payload if isinstance(ask.payload, dict) else {}
+            ask_kind = str(payload.get("ask_kind") or "")
+            answer = await messages_service.answer_of(session, ask)
+            answer_payload = (answer.payload if answer else None) or {}
+            choice = str(answer_payload.get("choice") or "")
+
+            # 人给了新输入 = 新的自主额度：重规划计数清零
+            checkpoint = dict(run.checkpoint or {})
+            checkpoint["replans"] = 0
+            run.checkpoint = checkpoint
+
+            if ask_kind == "done_criteria" and choice == "accept":
+                ask.status = "consumed"
+                await session.commit()
+                await self._emit_log(run, "你确认按当前结果完成，任务收束", level="success")
+                await self._set_status(session, run, "done")
+                return False
+
+            if ask_kind == "planning_failed":
+                run.plan = None  # 重新规划（用户指示经建议消息注入 _plan）
+                ask.status = "consumed"
+                await session.commit()
+                continue
+
+            if ask_kind == "fatal_step" and choice == "replan" and ask.step_id is not None:
+                node = await session.get(VoyageStep, ask.step_id)
+                if node is not None and node.status not in ("passed", "obsolete"):
+                    # 回答文本已由 API 镜像成建议消息，_navigator_edit 内部会 drain
+                    step_def = _step_def_from_row(node, run.plan)
+                    ok = await self._navigator_edit(
+                        session,
+                        run,
+                        node,
+                        step_def,
+                        ignore_limit=True,
+                        consume_ask=ask,
+                    )
+                    if not ok:
+                        return False
+                    continue
+
+            if ask_kind in ("no_progress", "done_criteria") and choice == "finish":
+                ask.status = "consumed"
+                await self._wrapup_remaining(session, run, reason="你选择按当前结果收尾")
+                continue
+
+            if ask_kind == "done_criteria":
+                # 继续补做：按用户指示扩展计划（否则所有步骤已 passed，
+                # 循环会直接再撞一次完成标准终检）；指示文本经镜像建议消息 drain
+                if not await self._extend_plan_from_user(session, run, ask):
+                    return False
+                continue
+
+            # 其余（retry / continue / budget 追加等）：确定性效果已在 API 侧完成，
+            # 失败节点由 resume() 复位、指示由建议消息注入，这里只标记消费
+            ask.status = "consumed"
+            await session.commit()
+        return True
+
+    async def _extend_plan_from_user(
+        self,
+        session: AsyncSession,
+        run: VoyageRun,
+        consume_ask: Any,
+    ) -> bool:
+        """完成标准未达成、用户要求继续：按其指示让 Navigator 在计划尾部补步骤。
+
+        用户指示 = 未消费的建议消息（含 API 镜像的回答文本）。
+        编辑生效与 ask 消费同一事务；Navigator 失败/空编辑转新的提问。
+        返回 False 表示任务已停（转 paused_ask）。
+        """
+        await self._set_status(session, run, "replanning")
+        rows = await self._active_rows(session, run)
+        guidance_msgs = await self._drain_user_messages(session, run)
+        combined = messages_service.guidance_text(guidance_msgs)
+        synthetic = {"title": "完成标准未达成", "action": "", "params": {}}
+        try:
+            edit = await self.navigator.on_result(
+                run,
+                synthetic,
+                "完成标准未达成，用户要求继续补做",
+                self._plan_state_summary(rows),
+                user_guidance=combined or None,
+            )
+        except NavigatorError as e:
+            await self._emit_log(run, f"计划扩展失败：{e}", level="error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="replan_error",
+                question="按你的指示扩展计划时 AI 未能给出有效方案，请补充更具体的指示，或选择放弃",
+                context={"error": str(e)},
+                options=_ASK_OPTIONS["continue_abort"],
+            )
+            return False
+        if edit.get("finish") or not edit.get("edits"):
+            consume_ask.status = "consumed"
+            await self._wrapup_remaining(session, run, reason="AI 判断无需补做，按当前结果收尾")
+            return True
+        try:
+            added = await self._apply_plan_edit(session, run, edit, anchor=None)
+        except PlanEditError as e:
+            await self._emit_log(run, f"计划编辑被拒绝：{e}", level="error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="replan_error",
+                question="按你的指示扩展计划时编辑未通过校验，请补充更具体的指示，或选择放弃",
+                context={"error": str(e)},
+                options=_ASK_OPTIONS["continue_abort"],
+            )
+            return False
+        run.plan_iteration = run.plan_iteration + 1
+        self._record_plan_event(
+            run,
+            source="user",
+            reason=str(edit.get("reason") or "") or "用户要求继续补做",
+            added=added,
+            obsoleted=0,
+            trigger_step=None,
+        )
+        if guidance_msgs:
+            messages_service.mark_chat_consumed(guidance_msgs)
+        consume_ask.status = "consumed"
+        await self._regen_plan_snapshot(session, run)
+        await session.commit()
+        await self._emit_log(run, f"已按你的指示扩展计划（新增 {added} 步）", level="plan")
+        await self._set_status(session, run, "executing")
+        return True
+
+    async def _wrapup_remaining(
+        self, session: AsyncSession, run: VoyageRun, *, reason: str
+    ) -> None:
+        """按用户指令收束：作废剩余非收尾步骤，放行收尾步骤（与预算降级收尾同构）。
+
+        与触发它的 ask 消费同一事务提交（调用方已把 ask.status 置 consumed 未提交）。
+        """
+        rows = await self._active_rows(session, run)
+        finishing = self._budget_finishing_steps(run, rows)
+        dropped = [
+            r for r in rows if r.status not in ("passed", "obsolete") and r not in finishing
+        ]
+        for r in dropped:
+            r.status = "obsolete"
+        if dropped:
+            run.plan_iteration = run.plan_iteration + 1
+            self._record_plan_event(
+                run,
+                source="user",
+                reason=reason,
+                added=0,
+                obsoleted=len(dropped),
+                trigger_step=None,
+            )
+            await self._regen_plan_snapshot(session, run)
+        await session.commit()
+        await self._emit_log(
+            run, f"{reason}：作废 {len(dropped)} 个未执行步骤", level="plan"
+        )
+
     # ---- 状态持久化 ----
 
     async def _current_db_status(self, session: AsyncSession, run_id: uuid.UUID) -> str:
@@ -268,6 +538,9 @@ class VoyageEngine:
                     run.mode = expected_mode
                     await session.commit()
                 await self._ensure_skills_snapshot(session, run)
+                # 已回答的提问先变成行为（可能重置计划 / 扩展计划 / 直接收束）
+                if not await self._consume_answered_asks(session, run):
+                    return
                 if run.plan is None:
                     await self._plan(session, run)
                 await self._ensure_step_rows(session, run)
@@ -300,16 +573,34 @@ class VoyageEngine:
     async def _plan(self, session: AsyncSession, run: VoyageRun) -> None:
         await self._set_status(session, run, "planning")
         context = (run.checkpoint or {}).get("params")
+        context = dict(context) if isinstance(context, dict) else None
+        # 用户建议注入规划（重规划场景：回答提问后 plan 被清空重来）
+        guidance_msgs = await self._drain_user_messages(session, run)
+        if guidance_msgs:
+            context = context or {}
+            context["user_guidance"] = messages_service.guidance_text(guidance_msgs)
         try:
-            steps = await self.navigator.plan(run, context if isinstance(context, dict) else None)
+            steps = await self.navigator.plan(run, context)
         except NavigatorError as e:
             run.plan = []
+            await session.commit()
             await self._emit_log(run, f"规划失败：{e}", level="error")
-            await self._set_status(session, run, "failed")
-            raise _ExternallyTerminated("failed") from e
+            # 有人值守：转提问等指示；无人值守（cron）保持旧行为直接 failed
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="planning_failed",
+                question="AI 没能为这个目标规划出有效的执行计划，请补充更具体的指示，或选择放弃",
+                context={"error": str(e)},
+                options=_ASK_OPTIONS["continue_abort"],
+                fallback_status="failed",
+            )
+            raise _ExternallyTerminated(run.status) from e
         run.plan = steps
         if run.done_criteria is None:
             run.done_criteria = done_criteria_for_kind(run.kind)
+        if guidance_msgs:
+            messages_service.mark_chat_consumed(guidance_msgs)
         await session.commit()
         await self._emit_log(run, f"计划就绪，共 {len(steps)} 步", level="success")
 
@@ -419,10 +710,20 @@ class VoyageEngine:
                     )
                     continue
                 else:
-                    await self._emit_log(
-                        run, "预算超限，尚无产出可收尾，任务暂停（paused_error）", level="error"
+                    await self._emit_log(run, "预算超限，尚无产出可收尾", level="error")
+                    usage = run.usage or {}
+                    await self._raise_ask(
+                        session,
+                        run,
+                        ask_kind="budget",
+                        question="token 预算已用尽，而且还没有可以收尾的产出。"
+                "追加预算继续，还是放弃？",
+                        context={
+                            "used_tokens": int(usage.get("total_tokens", 0)),
+                            "max_tokens": int((run.budget or {}).get("max_tokens", 0) or 0),
+                        },
+                        options=_ASK_OPTIONS["budget"],
                     )
-                    await self._set_status(session, run, "paused_error")
                     return
 
             # 复位失败节点（直接 run() 再驱动而未经 resume 复位时）
@@ -437,7 +738,8 @@ class VoyageEngine:
             ):
                 return
 
-            await self._execute_and_verify(session, run, step_def, node)
+            if not await self._execute_and_verify(session, run, step_def, node):
+                return  # 动作主动向用户提问，任务已暂停
 
             if node.verdict and node.verdict.get("passed"):
                 # 节点可携带 plan_signal（如 experiment.analyze 的继续/收束判定）：
@@ -458,8 +760,16 @@ class VoyageEngine:
             )
             if verdict is not None and not verdict.get("passed"):
                 await self._emit_log(run, f"完成标准未达成：{verdict.get('reason')}", level="error")
-                # 终检回灌（loop 模式）留待后续：先一律暂停等人工，防"过早宣告完成"
-                await self._set_status(session, run, "paused_error")
+                # 防"过早宣告完成"：转提问让用户裁决（接受为完成 / 指示补做 / 放弃）
+                await self._raise_ask(
+                    session,
+                    run,
+                    ask_kind="done_criteria",
+                    question=f"所有步骤已执行完，但完成标准还没达成：{verdict.get('reason')}。"
+                    "接受当前结果为完成，还是继续补做？",
+                    context={"reason": str(verdict.get("reason") or "")},
+                    options=_ASK_OPTIONS["done_criteria"],
+                )
                 return
         await self._set_status(session, run, "done")
 
@@ -542,7 +852,8 @@ class VoyageEngine:
         run: VoyageRun,
         step_def: dict[str, Any],
         step_row: VoyageStep,
-    ) -> None:
+    ) -> bool:
+        """执行 + 验证一个节点。返回 False 表示动作主动提问、任务已暂停。"""
         # 注入点①：把未消费的用户建议注入本步骤 params（消费标记与 running 同一事务，
         # resume 重放天然幂等——建议随步骤持久化，不会二次注入）
         guidance_msgs = await self._drain_user_messages(session, run)
@@ -590,6 +901,28 @@ class VoyageEngine:
         await session.commit()
         await self._emit_step(run, step_row)
 
+        # 动作主动提问（observation["ask"]，与 plan_signal 同族约定）：不进验证、
+        # 不消耗尝试预算，节点回 pending 等回答后重跑（回答文本经建议消息注入 params）
+        ask_req = observation.get("ask") if isinstance(observation, dict) else None
+        if isinstance(ask_req, dict) and ask_req.get("question"):
+            self._archive_attempt(step_row)  # 留痕：这次尝试以提问收场
+            step_row.status = "pending"
+            step_row.attempt = max(0, step_row.attempt - 1)
+            await session.commit()
+            await self._emit_step(run, step_row)
+            context = ask_req.get("context")
+            options = ask_req.get("options")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind=str(ask_req.get("ask_kind") or "action_ask"),
+                question=str(ask_req["question"]),
+                context=context if isinstance(context, dict) else None,
+                options=options if isinstance(options, list) else _ASK_OPTIONS["continue_abort"],
+                step=step_row,
+            )
+            return False
+
         await self._set_status(session, run, "verifying")
         verdict, verify_usage = await self.sextant.verify(run, step_def, observation)
         step_row.verdict = verdict
@@ -611,6 +944,7 @@ class VoyageEngine:
         await self._refresh_usage_from_ledger(session, run)
         await session.commit()
         await self._emit_step(run, step_row)
+        return True
 
     @staticmethod
     def _archive_attempt(step_row: VoyageStep) -> None:
@@ -721,18 +1055,44 @@ class VoyageEngine:
             )
             return True
 
-        # 固定管线步骤可声明 on_failure="fail"：不重规划，直接判 voyage 失败
+        # on_failure="fail" 步骤（如 experiment 的 smoke/run：盲目重跑烧算力）：
+        # 不自动重规划，但也不再打死任务——转成向用户提问，等人拍板
+        # （重试 / 换方案 / 放弃）。无人值守 run 降级 paused_error（可 resume）。
         if step_def.get("on_failure") == "fail":
             await self._emit_log(
-                run, f"步骤失败（on_failure=fail，不重规划）：{diagnosis}", level="error"
+                run, f"步骤失败（不自动重试）：{diagnosis}", level="error"
             )
-            await self._set_status(session, run, "failed")
+            attempts_note = (
+                f"（已尝试 {node.attempt} 次）" if node.attempt > 1 else ""
+            )
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="fatal_step",
+                question=f"步骤「{node.title}」失败了{attempts_note}：{diagnosis[:500]}。"
+                "怎么处理？",
+                context={
+                    "step_title": node.title,
+                    "diagnosis": diagnosis[:2000],
+                    "attempt": node.attempt,
+                },
+                options=_ASK_OPTIONS["fatal_step"],
+                step=node,
+            )
             return False
 
         if run.mode == "pipeline":
             # 确定性管线不经 LLM 重规划：暂停等人工（修复代码后可从断点重试，
-            # 前面步骤的成果不作废）
+            # 前面步骤的成果不作废）。语义保持 paused_error（多为无人值守 cron，
+            # reclaim 机制依赖它），但补一条 info 消息让对话流里也看得到诊断。
             await self._emit_log(run, f"步骤失败，任务暂停等待人工处理：{diagnosis}", level="error")
+            await self._post_agent_message(
+                session,
+                run,
+                kind="info",
+                text=f"步骤「{node.title}」失败，任务已暂停：{diagnosis[:500]}",
+                step_id=node.id,
+            )
             await self._set_status(session, run, "paused_error")
             return False
 
@@ -907,20 +1267,36 @@ class VoyageEngine:
         run: VoyageRun,
         failed_node: VoyageStep,
         failed_step: dict[str, Any],
+        *,
+        user_guidance: str | None = None,
+        ignore_limit: bool = False,
+        consume_ask: Any = None,
     ) -> bool:
         """loop 模式失败回灌：Navigator 产出计划编辑。返回 True 表示可继续循环。
 
-        无进展硬停（docs/voyage-loop.md §5.4）：存在失败步骤而 Navigator 返回
-        finish/noop → paused_error 等人工；编辑生效后失败节点自动作废并归档。
+        死路不再 paused_error 硬停，转成向用户提问（无人值守 run 降级）：
+        - 计划调整达上限 → 问「继续/收尾/放弃」（回答会把计数清零）；
+        - Navigator finish/noop / 输出非法 / 编辑被拒 → 问用户要更具体的指示。
+        ``user_guidance``/``ignore_limit``/``consume_ask`` 供 ask 消费路径复用：
+        用户明确要求换方案时不受次数限制，且 ask 的消费标记与编辑生效同一事务。
         """
         checkpoint = dict(run.checkpoint or {})
         replans = int(checkpoint.get("replans", 0))
         diagnosis = str((failed_node.verdict or {}).get("reason", ""))
-        if replans >= MAX_REPLANS:
+        if not ignore_limit and replans >= MAX_REPLANS:
             await self._emit_log(
-                run, f"计划调整已达上限（{MAX_REPLANS} 次），任务暂停等待人工处理", level="error"
+                run, f"计划调整已达上限（{MAX_REPLANS} 次）", level="error"
             )
-            await self._set_status(session, run, "paused_error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="no_progress",
+                question=f"自动调整计划已达 {MAX_REPLANS} 次仍未通过"
+                f"（最近的问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
+                context={"diagnosis": diagnosis[:2000], "replans": replans},
+                options=_ASK_OPTIONS["no_progress"],
+                step=failed_node,
+            )
             return False
 
         await self._set_status(session, run, "replanning")
@@ -929,34 +1305,63 @@ class VoyageEngine:
         # 注入点②：计划调整时把未消费的用户建议交给 Navigator（标记与编辑生效同一事务；
         # LLM 失败 / 编辑被拒时不标记，建议留在队列等下一个决策点）
         guidance_msgs = await self._drain_user_messages(session, run)
-        user_guidance = messages_service.guidance_text(guidance_msgs) or None
+        combined_guidance = (
+            "\n".join(
+                filter(None, [messages_service.guidance_text(guidance_msgs), user_guidance])
+            )
+            or None
+        )
         try:
             edit = await self.navigator.on_result(
                 run,
                 failed_def,
                 diagnosis,
                 self._plan_state_summary(rows),
-                user_guidance=user_guidance,
+                user_guidance=combined_guidance,
             )
         except NavigatorError as e:
             await self._emit_log(run, f"计划调整失败：{e}", level="error")
-            await self._set_status(session, run, "paused_error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="replan_error",
+                question="AI 调整计划时没能给出有效方案，请补充更具体的指示，或选择放弃",
+                context={"error": str(e), "diagnosis": diagnosis[:1000]},
+                options=_ASK_OPTIONS["continue_abort"],
+                step=failed_node,
+            )
             return False
 
         if edit.get("finish") or not edit.get("edits"):
+            reason = str(edit.get("reason") or "noop")
             await self._emit_log(
-                run,
-                f"Navigator 未给出有效调整（{edit.get('reason') or 'noop'}），任务暂停等待人工",
-                level="error",
+                run, f"AI 认为不必再调整（{reason}），等你裁决", level="error"
             )
-            await self._set_status(session, run, "paused_error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="no_progress",
+                question=f"这一步失败后 AI 认为不必再调整计划（理由：{reason[:300]}）。"
+                "按当前结果收尾，还是给出指示继续？",
+                context={"navigator_reason": reason, "diagnosis": diagnosis[:1000]},
+                options=_ASK_OPTIONS["no_progress"],
+                step=failed_node,
+            )
             return False
 
         try:
             added = await self._apply_plan_edit(session, run, edit, anchor=failed_node)
         except PlanEditError as e:
             await self._emit_log(run, f"计划编辑被拒绝：{e}", level="error")
-            await self._set_status(session, run, "paused_error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="replan_error",
+                question="AI 给出的计划调整未通过校验，请补充更具体的指示，或选择放弃",
+                context={"error": str(e), "diagnosis": diagnosis[:1000]},
+                options=_ASK_OPTIONS["continue_abort"],
+                step=failed_node,
+            )
             return False
 
         # 失败节点归档（保留失败态）后自动作废——Navigator 只需给出替代/补充步骤
@@ -980,6 +1385,8 @@ class VoyageEngine:
         )
         if guidance_msgs:
             messages_service.mark_chat_consumed(guidance_msgs, step_id=failed_node.id)
+        if consume_ask is not None:
+            consume_ask.status = "consumed"
         await self._regen_plan_snapshot(session, run)
         await session.commit()
         if guidance_msgs:
@@ -1017,10 +1424,17 @@ class VoyageEngine:
         replans = int(checkpoint.get("replans", 0))
         diagnosis = str((failed_node.verdict or {}).get("reason", ""))
         if replans >= MAX_REPLANS:
-            await self._emit_log(
-                run, f"重规划已达上限（{MAX_REPLANS} 次），任务暂停等待人工处理", level="error"
+            await self._emit_log(run, f"重规划已达上限（{MAX_REPLANS} 次）", level="error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="no_progress",
+                question=f"自动重规划已达 {MAX_REPLANS} 次仍未通过"
+                f"（最近的问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
+                context={"diagnosis": diagnosis[:2000], "replans": replans},
+                options=_ASK_OPTIONS["no_progress"],
+                step=failed_node,
             )
-            await self._set_status(session, run, "paused_error")
             return False
 
         await self._set_status(session, run, "replanning")
@@ -1033,7 +1447,15 @@ class VoyageEngine:
             )
         except NavigatorError as e:
             await self._emit_log(run, f"重规划失败：{e}", level="error")
-            await self._set_status(session, run, "paused_error")
+            await self._raise_ask(
+                session,
+                run,
+                ask_kind="replan_error",
+                question="AI 重规划时没能给出有效方案，请补充更具体的指示，或选择放弃",
+                context={"error": str(e), "diagnosis": diagnosis[:1000]},
+                options=_ASK_OPTIONS["continue_abort"],
+                step=failed_node,
+            )
             return False
 
         # 失败节点起的旧尾部整体作废（留痕；失败节点本身归档进 checkpoint 兼容回放）

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from redis.asyncio import Redis
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
@@ -18,8 +19,9 @@ from app.core.events import EventBus, get_event_bus, voyage_channel
 from app.core.queue import TaskQueue, get_task_queue
 from app.core.redis import get_redis_dep
 from app.models.user import User
-from app.models.voyage import TERMINAL_STATUSES, VoyageRun
+from app.models.voyage import TERMINAL_STATUSES, VoyageMessage, VoyageRun
 from app.schemas.voyage import (
+    VoyageAskAnswer,
     VoyageCreate,
     VoyageDetailRead,
     VoyageMessageCreate,
@@ -29,6 +31,7 @@ from app.schemas.voyage import (
     VoyageSkillUse,
     VoyageTerminalLogRead,
 )
+from app.services import experiments as experiments_service
 from app.services import projects as projects_service
 from app.services import voyage_messages as messages_service
 from app.services import voyages as voyages_service
@@ -118,6 +121,9 @@ async def get_voyage(
         detail.plan_history = [
             VoyagePlanEvent.model_validate(e) for e in history if isinstance(e, dict)
         ]
+    open_ask = await messages_service.open_ask(session, run.id)
+    if open_ask is not None:
+        detail.open_ask = VoyageMessageRead.model_validate(open_ask)
     return detail
 
 
@@ -184,6 +190,120 @@ async def post_voyage_message(
     return VoyageMessageRead.model_validate(message)
 
 
+@router.post(
+    "/{voyage_id}/asks/{message_id}/answer",
+    response_model=VoyageMessageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def answer_voyage_ask(
+    voyage_id: uuid.UUID,
+    message_id: uuid.UUID,
+    data: VoyageAskAnswer,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    queue: TaskQueue = Depends(get_task_queue),
+    bus: EventBus = Depends(get_event_bus),
+) -> VoyageMessageRead:
+    """回答 AI 的提问并恢复任务。
+
+    - ``choice='abort'``：人拍板放弃 → 任务 failed（唯一由用户决定的失败路径）；
+    - 其余：回答落库、文本镜像成一条建议消息（引擎在下一个决策点消费）、
+      确定性即时效果（如追加预算）、paused_ask → executing 并入队续跑。
+    - 重复回答（并发双答）由 ask 行的条件 UPDATE 挡住，409。
+    """
+    run = await _get_owned_voyage(session, voyage_id, user)
+    ask = await session.get(VoyageMessage, message_id)
+    if ask is None or ask.run_id != run.id or ask.kind != "ask":
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ASK_NOT_FOUND")
+    text = data.text.strip()
+    if not text and not data.choice:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail="ANSWER_EMPTY"
+        )
+    # 条件 UPDATE 防并发双答（两个成员同时点回答只有一个生效）
+    result = await session.execute(
+        sa_update(VoyageMessage)
+        .where(VoyageMessage.id == ask.id, VoyageMessage.status == "open")
+        .values(status="answered")
+    )
+    if result.rowcount == 0:
+        await session.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="ASK_NOT_OPEN")
+
+    answer_payload: dict = {}
+    if data.choice:
+        answer_payload["choice"] = data.choice
+    if data.payload:
+        answer_payload["extra"] = data.payload
+    answer = await messages_service.append_message(
+        session,
+        run.id,
+        role="user",
+        kind="answer",
+        text=text or (data.choice or ""),
+        author_id=user.id,
+        payload=answer_payload or None,
+        reply_to=ask.id,
+        step_id=ask.step_id,
+    )
+    await bus.publish_voyage_event(
+        run.id,
+        "ask.answered",
+        {"message": messages_service.serialize_message(answer), "ask_id": str(ask.id)},
+    )
+
+    if data.choice == "abort":
+        # 人拍板放弃：真终态。ask 直接置 consumed（不再有引擎消费）。
+        ask.status = "consumed"
+        run.status = "failed"
+        await session.commit()
+        await bus.publish_voyage_event(
+            run.id, "status", {"status": run.status, "cursor": run.cursor}
+        )
+        if run.project_id is not None:
+            await bus.publish_notify(
+                run.project_id,
+                {"type": "voyage.status", "voyage_id": str(run.id), "status": run.status},
+            )
+        experiment = await experiments_service.fail_by_voyage(session, run.id)
+        if experiment is not None:
+            await bus.publish_notify(
+                experiment.project_id,
+                {
+                    "type": "experiment.status",
+                    "experiment_id": str(experiment.id),
+                    "status": experiment.status,
+                },
+            )
+        return VoyageMessageRead.model_validate(answer)
+
+    # 确定性即时效果：追加预算（缺省翻倍——比让用户拍一个数更省事）
+    ask_kind = (ask.payload or {}).get("ask_kind")
+    if ask_kind == "budget" and data.choice == "add_budget":
+        budget = dict(run.budget or {})
+        current = int(budget.get("max_tokens") or 0)
+        add = int((data.payload or {}).get("add_tokens") or 0)
+        used = int((run.usage or {}).get("total_tokens", 0))
+        budget["max_tokens"] = current + add if add > 0 else max(current * 2, used + 10_000)
+        run.budget = budget
+
+    # 回答文本镜像成建议消息：引擎既有的注入点会把它带给下一个决策
+    if text:
+        await messages_service.append_message(
+            session, run.id, role="user", kind="chat", text=text, author_id=user.id
+        )
+
+    # 恢复执行（条件 UPDATE：不覆盖 cancelled 等外部写入）
+    await session.execute(
+        sa_update(VoyageRun)
+        .where(VoyageRun.id == run.id, VoyageRun.status == "paused_ask")
+        .values(status="executing")
+    )
+    await session.commit()
+    await queue.enqueue("resume_voyage", str(run.id))
+    return VoyageMessageRead.model_validate(answer)
+
+
 @router.post("/{voyage_id}/cancel", response_model=VoyageRead)
 async def cancel_voyage(
     voyage_id: uuid.UUID,
@@ -223,8 +343,14 @@ async def resume_voyage(
     user: User = Depends(current_active_user),
     queue: TaskQueue = Depends(get_task_queue),
 ) -> VoyageRead:
-    """重试 paused_error 的航程（如外部 API 暂时不可达），从断点续跑。"""
+    """重试 paused_error 的航程（如外部 API 暂时不可达），从断点续跑。
+
+    paused_ask 不在此列：AI 在等回答，回答本身就是恢复入口（answer 端点），
+    不给绕过提问的直通门。
+    """
     run = await _get_owned_voyage(session, voyage_id, user)
+    if run.status == "paused_ask":
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="VOYAGE_WAITING_ANSWER")
     if run.status != "paused_error":
         raise HTTPException(status.HTTP_409_CONFLICT, detail="VOYAGE_NOT_PAUSED_ERROR")
     run.status = "executing"

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.core.db import Base
 from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin, utcnow
 
-# 状态机：planning → executing → verifying → (next|replanning|paused_gate|paused_error)
+# 状态机：planning → executing → verifying → (next|replanning|paused_gate|paused_error|paused_ask)
 #         → done / failed / cancelled
 VOYAGE_STATUSES = (
     "planning",
@@ -34,6 +34,7 @@ VOYAGE_STATUSES = (
     "replanning",
     "paused_gate",
     "paused_error",
+    "paused_ask",
     "done",
     "failed",
     "cancelled",
@@ -43,8 +44,9 @@ TERMINAL_STATUSES = frozenset({"done", "failed", "cancelled"})
 # 互斥检查（find_running_ingest_for_library）把任何非终态都当成「在跑」，所以只要
 # 有一个状态漏了认领，那条运行就永远卡住，而它所属的文献库也再不能发起新同步——
 # 实测被重启掐在 planning / verifying 的三条运行卡了四个半小时，零进展。
-# paused_gate / paused_error 不在其列：它们是在等人，不是在等 worker
-# （另有 reclaim_stale_paused_ingests 按陈旧度处理）。
+# paused_gate / paused_error / paused_ask 不在其列：它们是在等人，不是在等 worker
+# （另有 reclaim_stale_paused_ingests 按陈旧度处理）。paused_ask 尤其不能进来：
+# reconcile 自动 resume 会绕过等待中的提问，把「问用户」变成「没人答自己接着跑」。
 IN_FLIGHT_STATUSES = frozenset({"planning", "executing", "verifying", "replanning"})
 
 # ---- 运行模式（docs/voyage-loop.md §2/§3）：由 kind 静态决定，不暴露给用户/LLM 选择 ----

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -113,6 +113,19 @@ class VoyageMessageRead(BaseModel):
     created_at: datetime
 
 
+class VoyageAskAnswer(BaseModel):
+    """用户对 agent 提问的回答：自由文本 + 可选的快捷选项。
+
+    - ``choice``：提问 options 里的候选 id（retry/replan/abort/…），引擎按它走
+      确定性分支；不选也行，纯文本回答默认按「继续（附指示）」处理。
+    - ``payload``：选项附加参数（如追加预算 {"add_tokens": 100000}）。
+    """
+
+    text: str = Field(default="", max_length=8000)
+    choice: str | None = Field(default=None, max_length=32)
+    payload: dict[str, Any] | None = None
+
+
 class VoyageTerminalLogRead(BaseModel):
     """任务终端历史日志的一条：结构化日志行（event=log）或大模型完整输出（event=llm）。"""
 
@@ -132,3 +145,5 @@ class VoyageDetailRead(VoyageRead):
     skills: list[VoyageSkillUse] = Field(default_factory=list)
     # 计划调整历史（路由从 checkpoint["plan_history"] 填充；无调整为 []）
     plan_history: list[VoyagePlanEvent] = Field(default_factory=list)
+    # 当前等回答的提问（paused_ask 时非空；路由填充）
+    open_ask: VoyageMessageRead | None = None

--- a/src/backend/app/services/voyage_messages.py
+++ b/src/backend/app/services/voyage_messages.py
@@ -138,3 +138,78 @@ def mark_chat_consumed(messages: list[VoyageMessage], *, step_id: uuid.UUID | No
 def guidance_text(messages: list[VoyageMessage]) -> str:
     """把待消费建议拼成注入 prompt / params 的纯文本（一行一条）。"""
     return "\n".join(f"- {m.text}" for m in messages)
+
+
+# ---- ask（agent 向用户提问）----
+
+
+async def open_ask(session: AsyncSession, run_id: uuid.UUID) -> VoyageMessage | None:
+    """当前等回答的提问（最多一个活跃；防御性取最新一条）。"""
+    stmt = (
+        select(VoyageMessage)
+        .where(
+            VoyageMessage.run_id == run_id,
+            VoyageMessage.kind == "ask",
+            VoyageMessage.status == "open",
+        )
+        .order_by(VoyageMessage.seq.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def find_open_ask(
+    session: AsyncSession, run_id: uuid.UUID, *, ask_kind: str, step_id: uuid.UUID | None
+) -> VoyageMessage | None:
+    """幂等锚点：同 run 同 (ask_kind, step_id) 已有 open 提问则复用，不重复插。"""
+    stmt = select(VoyageMessage).where(
+        VoyageMessage.run_id == run_id,
+        VoyageMessage.kind == "ask",
+        VoyageMessage.status == "open",
+        VoyageMessage.step_id == step_id,
+    )
+    for m in (await session.execute(stmt)).scalars().all():
+        if (m.payload or {}).get("ask_kind") == ask_kind:
+            return m
+    return None
+
+
+async def answered_asks(session: AsyncSession, run_id: uuid.UUID) -> list[VoyageMessage]:
+    """已回答、等引擎消费的提问，按 seq 升序。"""
+    stmt = (
+        select(VoyageMessage)
+        .where(
+            VoyageMessage.run_id == run_id,
+            VoyageMessage.kind == "ask",
+            VoyageMessage.status == "answered",
+        )
+        .order_by(VoyageMessage.seq)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def answer_of(session: AsyncSession, ask: VoyageMessage) -> VoyageMessage | None:
+    """某提问的（最新一条）回答。"""
+    stmt = (
+        select(VoyageMessage)
+        .where(VoyageMessage.reply_to == ask.id, VoyageMessage.kind == "answer")
+        .order_by(VoyageMessage.seq.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def supersede_open_asks(session: AsyncSession, run_id: uuid.UUID) -> int:
+    """把所有 open 提问置 superseded（cancel / 新提问覆盖旧提问时用）。
+
+    只改内存对象并 flush，由调用方 commit。返回受影响条数。
+    """
+    stmt = select(VoyageMessage).where(
+        VoyageMessage.run_id == run_id,
+        VoyageMessage.kind == "ask",
+        VoyageMessage.status == "open",
+    )
+    rows = list((await session.execute(stmt)).scalars().all())
+    for m in rows:
+        m.status = "superseded"
+    return len(rows)

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -180,9 +180,16 @@ async def delete_voyage(session: AsyncSession, run: VoyageRun) -> None:
 
 
 async def cancel_voyage(session: AsyncSession, run: VoyageRun) -> VoyageRun:
-    """协作式取消：置 cancelled，运行中的引擎在下一步边界自行退出。"""
+    """协作式取消：置 cancelled，运行中的引擎在下一步边界自行退出。
+
+    等回答的提问一并置 superseded——任务都取消了，问题不再需要答案，
+    也不能留着一个能把 cancelled 任务重新拉起来的回答入口。
+    """
     if run.status in TERMINAL_STATUSES:
         raise VoyageAlreadyFinishedError(str(run.id))
+    from app.services import voyage_messages as messages_service
+
+    await messages_service.supersede_open_asks(session, run.id)
     run.status = "cancelled"
     await session.commit()
     await session.refresh(run)

--- a/src/backend/app/tools/workspace.py
+++ b/src/backend/app/tools/workspace.py
@@ -29,7 +29,7 @@ _LOG_CHARS = 2000  # 单条日志上限（大模型完整输出可能极长）
 _GOAL_CHARS = 300
 _MAX_GATES = 50
 
-_PAUSED_STATUSES = frozenset({"paused_gate", "paused_error"})
+_PAUSED_STATUSES = frozenset({"paused_gate", "paused_error", "paused_ask"})
 
 
 def _task_brief(run: VoyageRun) -> dict[str, Any]:

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -338,8 +338,9 @@ async def test_smoke_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus
     assert resp.json()["status"] == "done"
 
 
-async def test_smoke_exhausted_fails_experiment(client, queue_stub, fake_ssh, bus_recorder):
-    """冒烟连续失败（1 次 + 2 次修复重试）→ 实验 failed，固定管线不重规划，voyage failed。"""
+async def test_smoke_exhausted_asks_user(client, queue_stub, fake_ssh, bus_recorder):
+    """冒烟连续失败（1 次 + 2 次修复重试）→ 不再打死任务：转向用户提问（paused_ask），
+    等人拍板重试/换方案/放弃；不自动走 LLM 重规划。"""
     fake_ssh.smoke_exits = [1, 1, 1]
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
@@ -354,12 +355,15 @@ async def test_smoke_exhausted_fails_experiment(client, queue_stub, fake_ssh, bu
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
-    assert voyage["status"] == "failed"
+    assert voyage["status"] == "paused_ask"
+    assert voyage["open_ask"] is not None
+    assert voyage["open_ask"]["payload"]["ask_kind"] == "fatal_step"
     statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
     assert "replanning" not in statuses  # on_failure=fail：不走 LLM 重规划
     smoke_step = voyage["steps"][2]
     assert "冒烟测试连续失败" in smoke_step["observation"]["error"]
 
+    # PR3 前实验行仍由 _guarded 置 failed（联动改造在 experiment 接入批次）
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "failed"
 
@@ -591,7 +595,7 @@ async def test_probe_resources_records_facts_and_missing(client, fake_ssh, bus_r
 
 
 async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_recorder):
-    """超 budget.max_hours → kill 远端进程 + run/experiment/voyage 置 failed。"""
+    """超 budget.max_hours → kill 远端进程 + run/experiment 置 failed，voyage 转提问。"""
     fake_ssh.run_exit = None  # 进程一直不结束
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
@@ -612,7 +616,8 @@ async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_record
     assert detail["status"] == "failed"
     assert detail["runs"][0]["status"] == "failed"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    assert resp.json()["status"] == "failed"
+    assert resp.json()["status"] == "paused_ask"  # run 级失败转提问，等人拍板
+    assert resp.json()["open_ask"]["payload"]["ask_kind"] == "fatal_step"
     run_step = next(s for s in resp.json()["steps"] if s["action"] == "experiment.run")
     assert "max_hours" in run_step["observation"]["error"]
 
@@ -769,7 +774,7 @@ class _PathViolationProvider(FakeProvider):
 
 async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorder):
     """LLM 产出 workdir 外路径 → SSHPathViolationError：不写任何文件（安全护栏），
-    实验 failed；voyage 走 loop 失败回灌（重试 → 计划调整）仍无法推进 → paused_error 等人工。"""
+    实验 failed；voyage 走 loop 失败回灌（重试 → 计划调整）仍无法推进 → 转提问等用户指示。"""
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
@@ -785,7 +790,10 @@ async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorde
 
     resp = await client.get(f"/api/voyages/{voyage_id}?include_obsolete=true", headers=headers)
     voyage = resp.json()
-    assert voyage["status"] == "paused_error"
+    assert voyage["status"] == "paused_ask"
+    # fake navigator 的替代步骤能通过，最终停在完成标准终检的提问上
+    # （真实场景会在更早的调整超限处停下，同样是 paused_ask）
+    assert voyage["open_ask"]["payload"]["ask_kind"] == "done_criteria"
     setup_step = next(s for s in voyage["steps"] if s["action"] == "experiment.setup")
     assert "越界" in setup_step["observation"]["error"]
     assert setup_step["attempt"] == 2  # 执行类错误带诊断原地重试过一次

--- a/src/backend/tests/test_voyage_ask.py
+++ b/src/backend/tests/test_voyage_ask.py
@@ -1,0 +1,423 @@
+"""ask 原语（paused_ask）：agent 死路转向用户提问，回答后推进。
+
+契约：
+- on_failure=fail 步骤失败：有人值守 → paused_ask（提问带候选项）；
+  无人值守（created_by 空，cron 发起）→ 降级 paused_error（没人会来回答）；
+- 提问幂等（reconcile 重放不重复建）；回答后 resume：retry 复位节点续跑、
+  abort 置 failed（唯一由用户决定的失败路径）；
+- 双答 409；paused_ask 下 resume 端点 409（回答即恢复，不给绕过门）；
+- cancel 把 open 提问置 superseded；
+- 完成标准未达成 / 预算耗尽 / 重规划超限 也转提问；
+- paused_ask 不在 IN_FLIGHT_STATUSES（worker reconcile 绝不能绕过提问自动续跑）。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.agents.voyage.engine import VoyageEngine
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.user import User
+from app.models.voyage import IN_FLIGHT_STATUSES, VoyageMessage, VoyageRun, VoyageStep
+from app.services import voyage_messages as messages_service
+from tests.conftest import RecordingBus, register_and_login
+
+FATAL_PLAN = [
+    {
+        "title": "关键步骤",
+        "action": "sleep",
+        "params": {"seconds": -1},
+        "acceptance": None,
+        "requires_gate": None,
+        "on_failure": "fail",
+        "budget": {"max_attempts": 1},
+    }
+]
+
+_OK_STEP = {
+    "title": "普通步骤",
+    "action": "sleep",
+    "params": {"seconds": 0},
+    "acceptance": None,
+    "checks": [{"kind": "no_error"}],
+    "requires_gate": None,
+}
+
+
+async def _make_project(client) -> tuple[str, dict]:
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "ask-proj"}, headers=headers)
+    return resp.json()["id"], headers
+
+
+async def _run(
+    project_id: str,
+    *,
+    kind: str = "custom",
+    plan: list[dict],
+    attended: bool = True,
+    budget: dict | None = None,
+    usage: dict | None = None,
+    checkpoint: dict | None = None,
+    done_criteria: dict | None = None,
+) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        created_by = None
+        if attended:
+            created_by = (
+                await session.execute(select(User.id).order_by(User.created_at))
+            ).scalars().first()
+        run = VoyageRun(
+            kind=kind,
+            goal="ask 契约测试",
+            status="planning",
+            cursor=0,
+            plan=plan,
+            budget=budget,
+            usage=usage,
+            checkpoint=checkpoint,
+            done_criteria=done_criteria,
+            project_id=uuid.UUID(project_id),
+            created_by=created_by,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+def _engine() -> tuple[VoyageEngine, RecordingBus]:
+    bus = RecordingBus()
+    return VoyageEngine(event_bus=bus, llm_router=LLMRouter()), bus
+
+
+async def _open_ask_of(run_id: uuid.UUID) -> VoyageMessage | None:
+    async with get_sessionmaker()() as session:
+        return await messages_service.open_ask(session, run_id)
+
+
+def test_paused_ask_not_in_flight():
+    """reconcile 认领集绝不能包含 paused_ask：等人不等 worker。"""
+    assert "paused_ask" not in IN_FLIGHT_STATUSES
+
+
+async def test_fatal_step_attended_asks(client, queue_stub):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, bus = _engine()
+    await engine.run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "paused_ask"
+        step = (
+            await session.execute(select(VoyageStep).where(VoyageStep.run_id == run_id))
+        ).scalar_one()
+        assert step.status == "failed"  # 失败留痕，不复位不重跑
+    ask = await _open_ask_of(run_id)
+    assert ask is not None and (ask.payload or {}).get("ask_kind") == "fatal_step"
+    assert (ask.payload or {}).get("options"), "提问应带候选项"
+    # SSE ask.created + WS voyage.ask 都发了
+    assert any(e == "ask.created" for _v, e, _d in bus.voyage_events)
+    assert any(m.get("type") == "voyage.ask" for _p, m in bus.notify)
+    # 详情带 open_ask
+    resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
+    assert resp.json()["open_ask"]["id"] == str(ask.id)
+
+
+async def test_fatal_step_unattended_degrades_to_paused_error(client, queue_stub):
+    project_id, _headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN, attended=False)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "paused_error"
+    assert await _open_ask_of(run_id) is None
+
+
+async def test_raise_ask_idempotent_on_replay(client, queue_stub):
+    """重复驱动（reconcile 重放场景）不重复建提问。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    await engine.run(run_id)  # 重放
+    async with get_sessionmaker()() as session:
+        asks = (
+            await session.execute(
+                select(VoyageMessage).where(
+                    VoyageMessage.run_id == run_id, VoyageMessage.kind == "ask"
+                )
+            )
+        ).scalars().all()
+        assert len(asks) == 1 and asks[0].status == "open"
+
+
+async def test_answer_retry_resumes_and_consumes(client, queue_stub, bus_recorder):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+    assert ask is not None
+
+    # "修好"参数后回答：重试
+    async with get_sessionmaker()() as session:
+        step = (
+            await session.execute(select(VoyageStep).where(VoyageStep.run_id == run_id))
+        ).scalar_one()
+        step.params = {"seconds": 0}
+        await session.commit()
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "retry", "text": "参数已修，重试"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["kind"] == "answer" and resp.json()["reply_to"] == str(ask.id)
+    # 状态推进 + 入队续跑
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "executing"
+    assert ("resume_voyage", (str(run_id),), {}) in queue_stub.jobs
+
+    await engine.resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        messages = (
+            await session.execute(
+                select(VoyageMessage)
+                .where(VoyageMessage.run_id == run_id)
+                .order_by(VoyageMessage.seq)
+            )
+        ).scalars().all()
+        the_ask = next(m for m in messages if m.kind == "ask")
+        assert the_ask.status == "consumed"
+        # 回答文本镜像成建议消息，并在重试执行时被消费进 params
+        mirror = next(m for m in messages if m.kind == "chat")
+        assert mirror.consumed_at is not None
+        step = (
+            await session.execute(
+                select(VoyageStep).where(
+                    VoyageStep.run_id == run_id, VoyageStep.status == "passed"
+                )
+            )
+        ).scalar_one()
+        assert "参数已修，重试" in (step.params.get("user_guidance") or [])
+
+
+async def test_answer_abort_fails_voyage(client, queue_stub, bus_recorder):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "abort"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "failed"  # 人拍板的失败：真终态
+        the_ask = await session.get(VoyageMessage, ask.id)
+        assert the_ask.status == "consumed"
+    # abort 不入队续跑
+    assert not any(job[0] == "resume_voyage" for job in queue_stub.jobs)
+
+
+async def test_double_answer_409(client, queue_stub, bus_recorder):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+
+    first = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "retry", "text": "先试"},
+        headers=headers,
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "abort"},
+        headers=headers,
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"] == "ASK_NOT_OPEN"
+
+
+async def test_resume_endpoint_blocked_while_asking(client, queue_stub):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    resp = await client.post(f"/api/voyages/{run_id}/resume", headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "VOYAGE_WAITING_ANSWER"
+
+
+async def test_cancel_supersedes_open_ask(client, queue_stub):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    resp = await client.post(f"/api/voyages/{run_id}/cancel", headers=headers)
+    assert resp.status_code == 200
+    async with get_sessionmaker()() as session:
+        asks = (
+            await session.execute(
+                select(VoyageMessage).where(
+                    VoyageMessage.run_id == run_id, VoyageMessage.kind == "ask"
+                )
+            )
+        ).scalars().all()
+        assert [a.status for a in asks] == ["superseded"]
+    # 已取消：回答入口自然 409（open 提问已不存在）
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{asks[0].id}/answer",
+        json={"choice": "retry"},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+
+
+async def test_done_criteria_unmet_asks_then_accept(client, queue_stub, bus_recorder):
+    """完成标准未达成 → 提问；用户接受为完成 → done（不再一律 paused_error）。"""
+    project_id, headers = await _make_project(client)
+    run_id = await _run(
+        project_id,
+        plan=[_OK_STEP],
+        done_criteria={"checks": [{"kind": "artifact_exists", "key": "artifacts.missing"}]},
+    )
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+    assert ask is not None and (ask.payload or {}).get("ask_kind") == "done_criteria"
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "accept"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    await engine.resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+
+
+async def test_budget_exhausted_asks_then_add_budget(client, queue_stub, bus_recorder):
+    """预算耗尽且无收尾可救 → 提问；追加预算后续跑到完成。"""
+    project_id, headers = await _make_project(client)
+    run_id = await _run(
+        project_id,
+        plan=[_OK_STEP],
+        budget={"max_tokens": 1},
+        usage={"total_tokens": 999_999},
+    )
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+    assert ask is not None and (ask.payload or {}).get("ask_kind") == "budget"
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "add_budget", "payload": {"add_tokens": 2_000_000}},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.budget["max_tokens"] == 2_000_001  # 原 1 + 追加 200 万
+    await engine.resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+
+
+async def test_action_initiated_ask_pauses_without_burning_attempt(
+    client, queue_stub, bus_recorder
+):
+    """动作返回 observation["ask"]（如 analyze 不确定时）：不进验证、不消耗尝试预算，
+    节点回 pending；回答后重跑该步，回答文本经建议消息注入 params。"""
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=[_OK_STEP])
+    engine, _ = _engine()
+
+    asked = False
+    orig_execute = engine.helm.execute
+
+    async def ask_once(ctx, step_def):
+        nonlocal asked
+        if not asked:
+            asked = True
+            return {"ask": {"question": "结果反常，继续用当前方案吗？", "ask_kind": "action_ask"}}
+        return await orig_execute(ctx, step_def)
+
+    engine.helm.execute = ask_once
+    await engine.run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "paused_ask"
+        step = (
+            await session.execute(select(VoyageStep).where(VoyageStep.run_id == run_id))
+        ).scalar_one()
+        assert step.status == "pending" and step.attempt == 0  # 提问不消耗尝试预算
+        assert len(step.attempts or []) == 1  # 但留痕
+    ask = await _open_ask_of(run_id)
+    assert ask is not None and (ask.payload or {}).get("ask_kind") == "action_ask"
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "continue", "text": "继续，注意记录中间结果"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    await engine.resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        step = (
+            await session.execute(select(VoyageStep).where(VoyageStep.run_id == run_id))
+        ).scalar_one()
+        assert "继续，注意记录中间结果" in (step.params.get("user_guidance") or [])
+
+
+async def test_replan_limit_asks_then_guidance_continues(client, queue_stub, bus_recorder):
+    """计划调整超限 → 提问；用户给指示后计数清零、按指示继续到完成。"""
+    project_id, headers = await _make_project(client)
+    plan = [
+        {
+            "title": "机械校验不过的步骤",
+            "action": "sleep",
+            "params": {"seconds": 0},
+            "acceptance": None,
+            "checks": [{"kind": "exit_code", "value": 0}],  # sleep 无 exit_code → 判断类失败
+            "requires_gate": None,
+        }
+    ]
+    run_id = await _run(project_id, plan=plan, checkpoint={"replans": 2})
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+    assert ask is not None and (ask.payload or {}).get("ask_kind") == "no_progress"
+
+    resp = await client.post(
+        f"/api/voyages/{run_id}/asks/{ask.id}/answer",
+        json={"choice": "continue", "text": "换一个能通过的步骤"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    await engine.resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"  # fake navigator 按指示给出替代计划后跑完
+        assert int((run.checkpoint or {}).get("replans", 0)) == 1  # 清零后新一轮调整

--- a/src/backend/tests/test_writing_voyage.py
+++ b/src/backend/tests/test_writing_voyage.py
@@ -297,8 +297,8 @@ async def test_invalid_cite_degrades_with_todo_and_continues(client, queue_stub)
     assert acts[0].payload["section"] == "introduction"
 
 
-async def test_final_compile_failure_fails_voyage(client, queue_stub, monkeypatch):
-    """终编译不 ok → voyage failed（全文编译 ok 为完成条件）。"""
+async def test_final_compile_failure_asks_user(client, queue_stub, monkeypatch):
+    """终编译不 ok → 不再打死任务：转向用户提问（重试/换方案/放弃），等人拍板。"""
 
     def bad_run(engine: str, binary: str, workdir: Path, main_name: str) -> TectonicRun:
         (workdir / "main.log").write_text(
@@ -311,7 +311,8 @@ async def test_final_compile_failure_fails_voyage(client, queue_stub, monkeypatc
     engine, _ = _make_engine()
     await engine.run(uuid.UUID(voyage["id"]))
     run = (await client.get(f"/api/voyages/{voyage['id']}", headers=headers)).json()
-    assert run["status"] == "failed"
+    assert run["status"] == "paused_ask"
+    assert run["open_ask"]["payload"]["ask_kind"] == "fatal_step"
     assert "终编译未通过" in run["steps"][-1]["observation"]["error"]
 
 


### PR DESCRIPTION
> Stacked on #318 (message stream) — the diff shown here is against that branch; merge #318 first, then retarget this to main.

## What

The core of the interactive PEV loop (#314): a new voyage status **`paused_ask`**. Wherever the agent used to die (`failed`) or stall blindly (`paused_error`), it now posts a `kind=ask` message — question, diagnosis context, bilingual quick-choice options — to the run's conversation stream, pauses, and waits for a human answer. Deliberately **not** added to `IN_FLIGHT_STATUSES`, so worker reconcile can never bypass a pending question (contract-tested).

### Dispatch rework (attended runs)

| dead end | before | now |
|---|---|---|
| `on_failure=fail` step (experiment smoke / run round, writing final compile) | voyage `failed`, unrecoverable | ask: retry / change approach / give up |
| replan limit, navigator no-op, invalid plan edit, planning failure | `paused_error` / `failed` | ask with diagnosis; answering resets the replan counter |
| unmet done_criteria | `paused_error` | ask: accept as done / keep going / give up |
| budget exhausted, nothing to wrap up | `paused_error` | ask: add budget (deterministic bump) / give up |
| pipeline step failure | `paused_error` | unchanged (unattended cron semantics) + an info message with the diagnosis |

Unattended runs (`created_by` empty — cron jobs) keep the old semantics via a fallback status, since nobody would answer. `failed` is now only ever entered by an explicit human decision: cancel, gate reject, or an abort answer.

### Answering

`POST /voyages/{id}/asks/{message_id}/answer` `{text?, choice?, payload?}`:
- `abort` → `failed` + experiment linkage (same path as gate reject)
- anything else → answer recorded (`reply_to` the ask), text mirrored as a suggestion message so the existing injection points (#318) carry it into the next decision, deterministic effects applied (budget bump), `paused_ask → executing`, `resume_voyage` enqueued
- double answers 409 via conditional UPDATE; `POST /resume` 409s `VOYAGE_WAITING_ANSWER` while a question is open; cancel supersedes open asks
- answered asks are consumed at drive start **in the same transaction as their effect** — resume replays stay idempotent

### Action-initiated asks

Actions can ask proactively by returning `observation["ask"]` (same family as `plan_signal`): the attempt is archived but **not charged**, the node returns to `pending`, and the answer is injected on the rerun. The experiment analyze/smoke wiring uses this in the follow-up PR (#315).

## Tests

- New `tests/test_voyage_ask.py` (13 cases): attended-vs-unattended dispatch, ask idempotency under replay, answer retry/abort round-trips, double-answer 409, resume blocked while asking, cancel superseding, done_criteria accept, budget bump, replan-limit reset, action-initiated ask.
- Updated contracts: `test_experiments.py` (smoke exhaustion, budget timeout, path violation now end in `paused_ask` with an open ask), `test_writing_voyage.py` (final compile failure asks instead of failing).
- Full suite: 1169 passed. Remaining failure `test_debug_limit_terminates` also fails on pristine `origin/main` (done_criteria regression predating this branch); it is fixed by the follow-up experiment PR.

Closes #314