### PR TITLE
feat(experiment): wire the experiment loop into the ask mechanism

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -8,11 +8,14 @@
 约定：
 - LLM 只产出 plan JSON / 代码文件内容 / reflection JSON / 绘图脚本 / 报告 markdown，
   远程命令一律走 services/ssh_exec 的白名单模板（LLM 永远不拼 shell）；
-- Experiment.status 与步骤联动（awaiting_gate/setup/running/reporting/done），
-  每次流转发 WS ``experiment.status``；
-- 步骤均声明 ``on_failure="fail"``：执行异常即 voyage failed，动作内部先把
-  Experiment 置 failed 再抛错（_guarded）；轮次的非零退出码**不是**步骤失败——
-  observation 携带 exit_code，由 analyze 诊断走 debug 分支；
+- Experiment.status 与步骤联动（awaiting_gate/setup/running/waiting_user/
+  reporting/done），每次流转发 WS ``experiment.status``；
+- smoke/run 声明 ``on_failure="fail"``：不自动重规划，失败转向用户提问
+  （paused_ask，见 docs/task-system.md）；动作异常只留 Activity 痕迹再抛错
+  （_guarded），不再抢先把 Experiment 打成 failed——failed 只由人拍板（闸门
+  驳回 / 回答「放弃」）。轮次的非零退出码**不是**步骤失败——observation 携带
+  exit_code，由 analyze 诊断走 debug 分支；analyze 拿不准时可 decision=ask
+  向用户提问，smoke 修复额度用尽同样转提问；
 - experiment.run：单轮 launch → 轮询（30s，协作式 cancel / 日志镜像 /
   POLARIS_METRIC + 可选 metrics.json 解析 / 预算超时）→ 主指标 direction 感知比较；
 - experiment.analyze：LLM structured reflection → 假设回写 → 终止判定
@@ -463,13 +466,18 @@ REFLECTION_SYSTEM_PROMPT = """\
 只输出一个 JSON 对象，不要输出任何其他文字或 Markdown 代码块，格式：
 {"observation": "本轮结果观察", "diagnosis": "原因诊断",
  "hypothesis_updates": [{"index": 0, "status": "verified|falsified|testing", "evidence": "证据"}],
- "decision": "improve|debug|stop", "planned_change": "下一轮计划修改", "stop_reason": null}
+ "decision": "improve|debug|stop|ask", "planned_change": "下一轮计划修改", "stop_reason": null,
+ "question": null}
 约束：
 - hypothesis_updates 的 index 是假设清单下标（从 0 开始），status 只能取 verified/falsified/testing
 - 本轮运行失败（exit_code 非 0）时 decision 用 debug；结果已足以回答全部假设时用 stop
 - 本轮失败时，diagnosis 要点明**失败类别**（依赖/环境、模型或框架不兼容、配置/超时/OOM、代码 bug）
   与根因，并在 planned_change 里给出方案级修法（可换依赖/框架/加载方式，不限于改几行代码）
 - decision=stop 时 stop_reason 必填一句话；decision=improve 时 planned_change 必填
+- **拿不准时用 decision=ask 向用户提问**（question 必填一句具体的问题）：比如结果反常到
+  怀疑度量有误、两个改进方向证据相当难以取舍、或继续下去要花大算力而收益存疑。
+  能自己判断就别问；问题里给出候选方向让用户好回答
+- 若给了「用户指示」，那是用户在对话里的最新意见，**优先遵循**
 - 对照实验：若给了「对照汇总」，据 baseline vs treatment 的 delta 判断假设成立与否
   （处理组是否优于 baseline），别只看单个 primary_value；对照结果已清晰时可直接 stop
 """
@@ -538,8 +546,14 @@ async def _set_status(
     )
 
 
-async def _mark_failed(ctx: ActionContext, reason: str) -> None:
-    """异常路径：实验（非终态）置 failed + WS + Activity。"""
+async def _mark_attention(ctx: ActionContext, reason: str) -> None:
+    """异常路径：只留 Activity 痕迹，不再抢先把实验打成 failed。
+
+    命运交给引擎的失败分派——原地重试 / 计划调整 / 转向用户提问（paused_ask）
+    都可能救回来；提前写死终态后 EXPERIMENT_TERMINAL_STATUSES 检查会挡住一切
+    后续状态更新，任务明明救活了实验行却永远躺在 failed。failed 只在两处写：
+    闸门驳回联动与用户回答「放弃」（都走 experiments_service.fail_by_voyage）。
+    """
     async with get_sessionmaker()() as session:
         experiment = await session.get(Experiment, _experiment_id(ctx))
         if experiment is None or experiment.status in EXPERIMENT_TERMINAL_STATUSES:
@@ -548,16 +562,17 @@ async def _mark_failed(ctx: ActionContext, reason: str) -> None:
             Activity(
                 project_id=experiment.project_id,
                 actor="agent:experiment",
-                kind="experiment.failed",
-                message=f"实验失败：{reason[:300]}",
+                kind="experiment.attention",
+                message=f"实验步骤出错：{reason[:300]}",
                 payload={"experiment_id": str(experiment.id), "reason": reason[:1000]},
             )
         )
-        await _set_status(ctx, session, experiment, "failed")
+        await session.commit()
 
 
 def _guarded(func):
-    """动作异常时先把实验置 failed 再抛给 helm（helm 记 observation.error）。"""
+    """动作异常时留 Activity 痕迹再抛给 helm（helm 记 observation.error，
+    引擎分派决定重试 / 调整计划 / 向用户提问）。"""
 
     @functools.wraps(func)
     async def wrapper(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
@@ -566,7 +581,7 @@ def _guarded(func):
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            await _mark_failed(ctx, f"{type(e).__name__}: {e}")
+            await _mark_attention(ctx, f"{type(e).__name__}: {e}")
             raise
 
     return wrapper
@@ -636,7 +651,7 @@ async def _open_executor(
 
 _HYP_STATUSES = ("testing", "verified", "falsified")
 _PM_DIRECTIONS = ("maximize", "minimize")
-_DECISIONS = ("improve", "debug", "stop")
+_DECISIONS = ("improve", "debug", "stop", "ask")
 # 实验类型：驱动执行后端(Runner)与策略选择——eval 评测 / training 训练 / agent 智能体任务 /
 # analysis 数据分析 / other 其它。plan 归类，向后兼容缺省 other。
 _EXPERIMENT_KINDS = ("eval", "training", "agent", "analysis", "other")
@@ -818,9 +833,12 @@ def validate_reflection(data: Any) -> dict[str, Any]:
         )
     decision = data.get("decision")
     if decision not in _DECISIONS:
-        raise ValueError("decision must be improve|debug|stop")
+        raise ValueError("decision must be improve|debug|stop|ask")
     planned_change = data.get("planned_change")
     stop_reason = data.get("stop_reason")
+    question = data.get("question")
+    if decision == "ask" and not (isinstance(question, str) and question.strip()):
+        raise ValueError('decision "ask" requires a non-empty "question"')
     return {
         "observation": observation.strip(),
         "diagnosis": diagnosis.strip(),
@@ -828,6 +846,7 @@ def validate_reflection(data: Any) -> dict[str, Any]:
         "decision": decision,
         "planned_change": str(planned_change).strip() if planned_change else None,
         "stop_reason": str(stop_reason).strip() if stop_reason else None,
+        "question": str(question).strip() if question else None,
     }
 
 
@@ -1396,16 +1415,56 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 if exit_status == 0:
                     return {"exit_code": 0, "attempts": attempts, "fixes": fixes}
                 if fixes >= MAX_SMOKE_FIXES:
-                    raise RuntimeError(
-                        f"冒烟测试连续失败（{attempts} 次，exit={exit_status}）：{err_text[-500:]}"
+                    # 修复额度用尽不再抛错打死：转向用户提问（引擎收到 observation.ask
+                    # 会把节点回 pending、任务转 paused_ask）。回答「重试」会从头重跑
+                    # 本动作（修复计数随之清零），回答文本经 params["user_guidance"] 注入。
+                    await _mark_attention(
+                        ctx, f"冒烟测试连续失败（{attempts} 次，exit={exit_status}）"
                     )
+                    return {
+                        "exit_code": exit_status,
+                        "attempts": attempts,
+                        "fixes": fixes,
+                        "ask": {
+                            "ask_kind": "fatal_step",
+                            "question": (
+                                f"代码试跑连续失败（{attempts} 次，自动修复 {fixes} 次已用尽），"
+                                f"最后的报错：{err_text[-300:]}。怎么处理？"
+                            ),
+                            "context": {
+                                "stderr_tail": err_text[-2000:],
+                                "attempts": attempts,
+                                "fixes": fixes,
+                            },
+                            "options": [
+                                {
+                                    "id": "retry",
+                                    "zh": "带指示重试（换依赖/改配置等）",
+                                    "en": "Retry with instructions",
+                                },
+                                {
+                                    "id": "replan",
+                                    "zh": "换个方案（请说明思路）",
+                                    "en": "Change approach (describe how)",
+                                },
+                                {"id": "abort", "zh": "放弃实验", "en": "Give up"},
+                            ],
+                        },
+                    }
                 # 把诊断提示 + stderr 回给 LLM 修文件（方案级修复）。
                 # 超时那类已经在上面给了 hint；其余按 stderr 签名归类，认不出就留空。
                 fixes += 1
                 hint = hint or diagnose_failure(err_text, env_settings)
+                guidance = params.get("user_guidance")
+                guidance_line = (
+                    f"用户指示（务必优先遵循）：{json.dumps(guidance, ensure_ascii=False)}\n"
+                    if guidance
+                    else ""
+                )
                 user_prompt = (
                     f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
-                    f"冒烟测试退出码：{exit_status}\n"
+                    + guidance_line
+                    + f"冒烟测试退出码：{exit_status}\n"
                     + (f"诊断提示：{hint}\n" if hint else "")
                     + f"stderr：\n{err_text[-_STDERR_CHARS:]}"
                     + _env_facts_prompt(env_settings)
@@ -1669,9 +1728,17 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             else ""
         )
         run_lasts = {k: _last_value(v) for k, v in (run.metrics or {}).items()}
+        # 用户在对话里的建议 / 对提问的回答（引擎注入 step params，见 docs/task-system.md）
+        user_guidance = params.get("user_guidance")
+        guidance_line = (
+            f"用户指示（务必优先遵循）：{json.dumps(user_guidance, ensure_ascii=False)}\n"
+            if user_guidance
+            else ""
+        )
         reflection_user = (
             f"实验计划：{json.dumps(plan, ensure_ascii=False)[:4000]}\n"
             f"主指标：{json.dumps(pm, ensure_ascii=False)}（假设共 {hyp_count} 条）\n"
+            f"{guidance_line}"
             f"本轮运行：seq={run.seq} status={run.status} exit_code={run.exit_code} "
             f"primary_value={run.primary_value}\n"
             f"本轮各指标末值：{json.dumps(run_lasts, ensure_ascii=False)[:1500]}\n"
@@ -1710,8 +1777,28 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
         experiment.iteration_state = dict(state)
         await session.commit()
 
-        # decision 分支与终止条件（顺序与原 iterate 一致，docs/api-m5-a.md §1）
+        # decision=ask：AI 拿不准，向用户提问（引擎收到 observation.ask 转 paused_ask；
+        # 回答后本步骤重跑，回答文本经 params["user_guidance"] 注入上面的反思 prompt）
         decision = reflection["decision"]
+        if decision == "ask":
+            question = reflection.get("question") or "AI 需要你的判断才能继续，这轮结果怎么处理？"
+            return {
+                "seq": run.seq,
+                "decision": decision,
+                "rounds": len(runs),
+                "ask": {
+                    "ask_kind": "action_ask",
+                    "question": question,
+                    "context": {
+                        "observation": reflection.get("observation"),
+                        "diagnosis": reflection.get("diagnosis"),
+                        "primary_value": run.primary_value,
+                        "history": history[-6:],
+                    },
+                },
+            }
+
+        # decision 分支与终止条件（顺序与原 iterate 一致，docs/api-m5-a.md §1）
         hyps = plan.get("hypotheses", [])
         iterate_cp = dict(ctx.checkpoint.get("iterate") or {})
         iterate_started = (
@@ -1763,6 +1850,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             archive_ctx = _render_attempt_archive(prior) if prior else ""
             fix_user = (
                 (archive_ctx + "\n" if archive_ctx else "")
+                + guidance_line
                 + f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
                 + f"reflection 观察：{reflection['observation']}\n"
                 + f"诊断：{reflection['diagnosis']}\n"
@@ -1775,6 +1863,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             system_prompt = _prompt_with_context(IMPROVE_SYSTEM_PROMPT, ctx)
             fix_user = (
                 _render_attempt_archive(archive)
+                + ("\n" + guidance_line if guidance_line else "")
                 + f"\n主指标：{json.dumps(pm, ensure_ascii=False)}\n"
                 + f"当前尝试 seq={run.seq} 主指标={run.primary_value}；"
                 + f"reflection 诊断：{reflection['diagnosis']}\n"

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -329,6 +329,20 @@ class VoyageEngine:
         # 终端叙事镜像（level=gate：黄色提示，与人工审批同一视觉家族）
         await self._emit_log(run, f"AI 有问题需要你回答：{question}", level="gate")
         await self._set_status(session, run, "paused_ask")
+        # 实验状态镜像：详情页/列表不用轮询 voyage 也能显示「等你回复」
+        if run.kind == "experiment":
+            from app.services import experiments as experiments_service
+
+            experiment = await experiments_service.mark_waiting_by_voyage(session, run.id)
+            if experiment is not None:
+                await self._emit_notify(
+                    experiment.project_id,
+                    {
+                        "type": "experiment.status",
+                        "experiment_id": str(experiment.id),
+                        "status": experiment.status,
+                    },
+                )
 
     async def _consume_answered_asks(self, session: AsyncSession, run: VoyageRun) -> bool:
         """把已回答的提问变成行为（_drive 开头调用）。返回 False 表示任务已停。

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -300,6 +300,17 @@ async def answer_voyage_ask(
         .values(status="executing")
     )
     await session.commit()
+    # 实验镜像状态恢复（waiting_user → 提问前的状态）
+    experiment = await experiments_service.resume_from_waiting_by_voyage(session, run.id)
+    if experiment is not None:
+        await bus.publish_notify(
+            experiment.project_id,
+            {
+                "type": "experiment.status",
+                "experiment_id": str(experiment.id),
+                "status": experiment.status,
+            },
+        )
     await queue.enqueue("resume_voyage", str(run.id))
     return VoyageMessageRead.model_validate(answer)
 

--- a/src/backend/app/models/experiment.py
+++ b/src/backend/app/models/experiment.py
@@ -12,12 +12,14 @@ from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
 
 # 状态与 voyage 流水线联动（docs/api-m4.md §2）：
 #   planning →(计划写入) awaiting_gate →(闸门批准) setup → running → reporting → done
-#   任一环节失败 → failed；用户取消 → cancelled
+#   AI 提问等回答 → waiting_user（镜像 voyage paused_ask，回答后恢复原状态）
+#   用户拍板放弃 / 闸门驳回 → failed；用户取消 → cancelled
 EXPERIMENT_STATUSES = (
     "planning",
     "awaiting_gate",
     "setup",
     "running",
+    "waiting_user",
     "reporting",
     "done",
     "failed",

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -18,7 +18,12 @@ from sqlalchemy.orm import selectinload
 
 from app.core.config import get_settings
 from app.models.activity import Activity
-from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment, ExperimentRun
+from app.models.experiment import (
+    EXPERIMENT_STATUSES,
+    EXPERIMENT_TERMINAL_STATUSES,
+    Experiment,
+    ExperimentRun,
+)
 from app.models.idea import Idea
 from app.models.project import Project
 from app.models.ssh_credential import SSHCredential
@@ -301,12 +306,51 @@ def latest_run(experiment: Experiment) -> ExperimentRun | None:
 
 
 async def fail_by_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Experiment | None:
-    """闸门驳回等场景：关联实验（非终态）置 failed，返回该实验。"""
+    """闸门驳回 / 用户拍板放弃等场景：关联实验（非终态）置 failed，返回该实验。"""
     stmt = select(Experiment).where(Experiment.voyage_id == voyage_id)
     experiment = (await session.execute(stmt)).scalar_one_or_none()
     if experiment is None or experiment.status in EXPERIMENT_TERMINAL_STATUSES:
         return None
     experiment.status = "failed"
+    await session.commit()
+    await session.refresh(experiment)
+    return experiment
+
+
+async def mark_waiting_by_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Experiment | None:
+    """voyage 转 paused_ask：实验镜像 waiting_user（原状态记进 iteration_state，
+    回答后由 :func:`resume_from_waiting_by_voyage` 恢复）。"""
+    stmt = select(Experiment).where(Experiment.voyage_id == voyage_id)
+    experiment = (await session.execute(stmt)).scalar_one_or_none()
+    if (
+        experiment is None
+        or experiment.status in EXPERIMENT_TERMINAL_STATUSES
+        or experiment.status == "waiting_user"
+    ):
+        return None
+    state = dict(experiment.iteration_state or {})
+    state["status_before_ask"] = experiment.status
+    experiment.iteration_state = state
+    experiment.status = "waiting_user"
+    await session.commit()
+    await session.refresh(experiment)
+    return experiment
+
+
+async def resume_from_waiting_by_voyage(
+    session: AsyncSession, voyage_id: uuid.UUID
+) -> Experiment | None:
+    """回答提问后：waiting_user 恢复为提问前的状态（后续动作会自行推进状态）。"""
+    stmt = select(Experiment).where(Experiment.voyage_id == voyage_id)
+    experiment = (await session.execute(stmt)).scalar_one_or_none()
+    if experiment is None or experiment.status != "waiting_user":
+        return None
+    state = dict(experiment.iteration_state or {})
+    previous = state.pop("status_before_ask", None)
+    experiment.iteration_state = state
+    if previous not in EXPERIMENT_STATUSES or previous in EXPERIMENT_TERMINAL_STATUSES:
+        previous = "running"
+    experiment.status = str(previous)
     await session.commit()
     await session.refresh(experiment)
     return experiment

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -59,6 +59,7 @@ def _reflection_json(
     updates: list[dict] | None = None,
     planned_change: str | None = "调大学习率（test）",
     stop_reason: str | None = None,
+    question: str | None = None,
 ) -> str:
     return json.dumps(
         {
@@ -70,6 +71,7 @@ def _reflection_json(
             "decision": decision,
             "planned_change": planned_change,
             "stop_reason": stop_reason,
+            "question": question,
         },
         ensure_ascii=False,
     )
@@ -97,6 +99,32 @@ class _FixedReflectionProvider(FakeProvider):
         full = "\n".join(m.content for m in messages)
         if not images and '"hypothesis_updates"' in full:
             return _result(_reflection_json(self._decision, updates=self._updates), model)
+        return await super().complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens, images=images
+        )
+
+
+class _AskOnceProvider(FakeProvider):
+    """第一次 reflection 拿不准（decision=ask），之后 stop；记录是否看到用户指示。"""
+
+    def __init__(self) -> None:
+        self.reflection_calls = 0
+        self.saw_guidance = False
+
+    async def complete(
+        self, messages, *, model, temperature=0.7, max_tokens=None, images=None
+    ) -> CompletionResult:
+        full = "\n".join(m.content for m in messages)
+        if not images and '"hypothesis_updates"' in full:
+            self.reflection_calls += 1
+            if "用户指示" in full:
+                self.saw_guidance = True
+            if self.reflection_calls == 1:
+                return _result(
+                    _reflection_json("ask", question="指标反常，继续当前方案还是换路线？"),
+                    model,
+                )
+            return _result(_reflection_json("stop", stop_reason="用户指示收尾（test）"), model)
         return await super().complete(
             messages, model=model, temperature=temperature, max_tokens=max_tokens, images=images
         )
@@ -207,7 +235,11 @@ async def test_no_improve_stop_budget_param(client, queue_stub, fake_ssh, bus_re
 
 
 async def test_debug_limit_terminates(client, queue_stub, fake_ssh, bus_recorder):
-    """运行失败走 debug 分支：独立限额 3 次，第 4 次 debug 决策直接终止。"""
+    """运行失败走 debug 分支：独立限额 3 次，第 4 次 debug 决策直接终止。
+
+    全部轮次失败 → 一个主指标都没产出 → 完成标准终检不过：不再一律 paused_error，
+    转向用户提问（接受为完成 / 继续补做 / 放弃），实验镜像 waiting_user。
+    """
     fake_ssh.run_exit = 1  # 每轮正式运行都失败
     fake_ssh.run_log = "Traceback: train boom\n"
     project_id, headers, exp_id, voyage_id = await _launch_experiment(client)
@@ -216,20 +248,61 @@ async def test_debug_limit_terminates(client, queue_stub, fake_ssh, bus_recorder
     )
 
     voyage_status, observation = await _iterate_observation(client, headers, voyage_id)
-    assert voyage_status == "done"
+    assert voyage_status == "paused_ask"
     assert observation["stopped_reason"] == "debug_limit"
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["open_ask"]["payload"]["ask_kind"] == "done_criteria"
     detail = await _get_detail(client, headers, exp_id)
     assert len(detail["runs"]) == 4  # 首轮 + 3 次 debug 修复重跑
     assert all(r["status"] == "failed" for r in detail["runs"])
     assert all(r["reflection"]["decision"] == "debug" for r in detail["runs"])
-    assert detail["iteration_state"] == {
-        "no_improve_streak": 0,  # 失败轮无主指标，不计入无提升
-        "debug_count": 3,
-        "stopped_reason": "debug_limit",
-    }
-    # 末轮 failed → 报告收口为 failed
+    state = detail["iteration_state"]
+    assert state["no_improve_streak"] == 0  # 失败轮无主指标，不计入无提升
+    assert state["debug_count"] == 3
+    assert state["stopped_reason"] == "debug_limit"
+    # 末轮全失败 → 报告仍按事实收口为 failed（终态在先，提问镜像不覆盖终态）；
+    # 但 voyage 的完成标准提问仍开着，用户可拍板接受/放弃
     assert detail["status"] == "failed"
     assert detail["report"].startswith("## 实验报告")
+
+
+async def test_analyze_ask_pauses_then_guidance_continues(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """analyze 拿不准（decision=ask）→ 实验转「等你回复」；回答后重跑分析，
+    回答文本作为用户指示进入 reflection prompt。"""
+    project_id, headers, exp_id, voyage_id = await _launch_experiment(client)
+    provider = _AskOnceProvider()
+    engine, _ = _make_engine(_router_with(provider))
+    await engine.run(uuid.UUID(voyage_id))
+    await _approve_gate(client, headers, project_id)
+    await engine.resume(uuid.UUID(voyage_id))
+
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    voyage = resp.json()
+    assert voyage["status"] == "paused_ask"
+    ask = voyage["open_ask"]
+    assert ask is not None and ask["payload"]["ask_kind"] == "action_ask"
+    assert "指标反常" in ask["text"]
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] == "waiting_user"
+
+    resp = await client.post(
+        f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
+        json={"choice": "continue", "text": "指标没问题，按当前结果收尾"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    # 镜像状态恢复（后续动作会继续推进）
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] != "waiting_user"
+
+    engine, _ = _make_engine(_router_with(provider))
+    await engine.resume(uuid.UUID(voyage_id))
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] == "done"
+    assert provider.saw_guidance  # 重跑的 reflection 看到了用户指示
+    assert detail["iteration_state"]["stopped_reason"] == "用户指示收尾（test）"
 
 
 async def test_max_runs_truncates_iteration(client, queue_stub, fake_ssh, bus_recorder):

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -339,9 +339,9 @@ async def test_smoke_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus
 
 
 async def test_smoke_exhausted_asks_user(client, queue_stub, fake_ssh, bus_recorder):
-    """冒烟连续失败（1 次 + 2 次修复重试）→ 不再打死任务：转向用户提问（paused_ask），
-    等人拍板重试/换方案/放弃；不自动走 LLM 重规划。"""
-    fake_ssh.smoke_exits = [1, 1, 1]
+    """冒烟连续失败（1 次 + 2 次修复重试）→ 不再打死任务：动作主动提问（paused_ask），
+    节点回 pending 不烧尝试预算；实验镜像「等你回复」；回答重试后修复计数清零续跑。"""
+    fake_ssh.smoke_exits = [1, 1, 1, 0]  # 前 3 次失败（额度用尽提问），回答重试后第 4 次通过
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
@@ -356,16 +356,31 @@ async def test_smoke_exhausted_asks_user(client, queue_stub, fake_ssh, bus_recor
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
     assert voyage["status"] == "paused_ask"
-    assert voyage["open_ask"] is not None
-    assert voyage["open_ask"]["payload"]["ask_kind"] == "fatal_step"
+    ask = voyage["open_ask"]
+    assert ask is not None and ask["payload"]["ask_kind"] == "fatal_step"
+    assert "代码试跑连续失败" in ask["text"]
     statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
-    assert "replanning" not in statuses  # on_failure=fail：不走 LLM 重规划
+    assert "replanning" not in statuses  # 不走 LLM 重规划
     smoke_step = voyage["steps"][2]
-    assert "冒烟测试连续失败" in smoke_step["observation"]["error"]
+    assert smoke_step["action"] == "experiment.smoke"
+    assert smoke_step["status"] == "pending"  # 提问不烧尝试预算，节点等回答后重跑
 
-    # PR3 前实验行仍由 _guarded 置 failed（联动改造在 experiment 接入批次）
+    # 实验镜像「等你回复」，不再被 _guarded 提前打成 failed
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
-    assert resp.json()["status"] == "failed"
+    assert resp.json()["status"] == "waiting_user"
+
+    # 回答「重试」并附指示 → 恢复执行；冒烟重跑通过，整条流水线走完
+    resp = await client.post(
+        f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
+        json={"choice": "retry", "text": "换个更小的冒烟配置"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    await engine.resume(uuid.UUID(voyage_id))
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "done"
+    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
+    assert resp.json()["status"] == "done"
 
 
 async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus_recorder):
@@ -595,7 +610,7 @@ async def test_probe_resources_records_facts_and_missing(client, fake_ssh, bus_r
 
 
 async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_recorder):
-    """超 budget.max_hours → kill 远端进程 + run/experiment 置 failed，voyage 转提问。"""
+    """超 budget.max_hours → kill 远端进程 + run 置 failed；voyage 转提问、实验「等你回复」。"""
     fake_ssh.run_exit = None  # 进程一直不结束
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
@@ -613,7 +628,7 @@ async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_record
     assert fake_ssh.pid in fake_ssh.killed
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     detail = resp.json()
-    assert detail["status"] == "failed"
+    assert detail["status"] == "waiting_user"  # 不再提前打死实验，镜像「等你回复」
     assert detail["runs"][0]["status"] == "failed"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     assert resp.json()["status"] == "paused_ask"  # run 级失败转提问，等人拍板
@@ -801,7 +816,7 @@ async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorde
     assert "replanning" in statuses  # 重试尽后走了计划调整
     assert fake_ssh.files == {}  # 一个文件都没写出去
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
-    assert resp.json()["status"] == "failed"
+    assert resp.json()["status"] == "waiting_user"  # 提问中，未被提前打死
 
 
 def test_relpath_whitelist_unit():


### PR DESCRIPTION
> Stacked on #320 (ask primitive) — diff shown against that branch; merge order #318 → #320 → this, retargeting as parents land.

## What

Experiment-specific wiring for the ask mechanism (#315):

- **`experiment.smoke`**: when the auto-fix budget (`MAX_SMOKE_FIXES`) is exhausted, the action returns `observation["ask"]` (fatal_step: retry with instructions / change approach / give up) instead of raising. The node goes back to `pending` without burning an attempt; a retry restarts the action with a fresh fix budget and the user's answer injected as `user_guidance` into the fix prompt.
- **`experiment.analyze`**: the reflection decision set gains **`ask`** (a non-empty `question` is required by the validator). The system prompt tells the model to ask only when genuinely uncertain — anomalous metrics, tied improvement directions, expensive-continuation calls — and to include candidate options in the question. After an answer, the rerun feeds the reply into the reflection prompt (and into the improve/debug code-fix prompts) as 用户指示 with top priority.
- **`_guarded` no longer pre-stamps `Experiment.status=failed`**: it records an `experiment.attention` Activity and re-raises, letting engine dispatch decide (retry / replan / ask). This fixes the unrecoverable-terminal bug where a voyage rescued by replanning left the experiment row dead forever. `failed` is now written only by gate-reject linkage and abort answers.
- **Mirror status `waiting_user`**: voyage `paused_ask` ↔ experiment `waiting_user`. The previous status is remembered in `iteration_state.status_before_ask` and restored when the user answers, pushed over the existing `experiment.status` WS event so lists and the detail page show "waiting for you" without polling the voyage.

## Tests

- New: `test_analyze_ask_pauses_then_guidance_continues` (ask → waiting_user → answer → reflection sees the guidance → done), smoke round-trip in `test_smoke_exhausted_asks_user` (ask without burning an attempt → retry answer → pipeline completes).
- `test_debug_limit_terminates` — which fails on pristine `origin/main` — is repaired here with the intended semantics: all-failed rounds leave no primary metric, so the done-criteria check now asks the user instead of silently pausing; the report still honestly wraps up as failed.
- 95 passed across the experiment/ask/loop suites; full suite run before merge.

Closes #315