### PR TITLE
feat(frontend): experiment console — task map + terminal with in-stream conversation

### DIFF
--- a/src/frontend/src/app/AppShell.tsx
+++ b/src/frontend/src/app/AppShell.tsx
@@ -563,6 +563,12 @@ export function AppShell() {
           toast(tr('任务失败', 'Task failed'), 'error');
           notifyDesktop(tr('任务失败', 'Task failed'));
         }
+      } else if (msg.type === 'voyage.ask') {
+        void queryClient.invalidateQueries({ queryKey: ['voyages'] });
+        void queryClient.invalidateQueries({ queryKey: ['voyage', msg.voyage_id] });
+        void queryClient.invalidateQueries({ queryKey: ['voyage-messages', msg.voyage_id] });
+        toast(`${tr('AI 有问题想问你', 'The AI has a question for you')}：${msg.question}`, 'info');
+        notifyDesktop(tr('AI 有问题想问你', 'The AI has a question for you'), msg.question);
       } else if (msg.type === 'review.message') {
         // 正在看该 session 的组件共享此 query cache → 直接乐观追加（按 id 去重）
         queryClient.setQueryData<ReviewMessageRead[]>(['session-messages', msg.session_id], (old) =>
@@ -597,6 +603,9 @@ export function AppShell() {
         if (msg.status === 'awaiting_gate') {
           toast(tr('实验等待预算审批', 'Experiment awaiting budget approval'), 'info');
           notifyDesktop(tr('实验等待预算审批', 'Experiment awaiting budget approval'));
+        } else if (msg.status === 'waiting_user') {
+          toast(tr('实验暂停：AI 有问题想问你', 'Experiment paused — the AI has a question'), 'info');
+          notifyDesktop(tr('实验暂停：AI 有问题想问你', 'Experiment paused — the AI has a question'));
         } else if (msg.status === 'running') {
           toast(tr('实验正式运行中', 'Experiment running'), 'info');
         } else if (msg.status === 'done') {

--- a/src/frontend/src/components/ui/StatusPill.tsx
+++ b/src/frontend/src/components/ui/StatusPill.tsx
@@ -36,6 +36,7 @@ export const STATUS: Record<string, StatusMeta> = {
   replanning: { cls: 'st-drafted', zh: '调整计划', en: 'replanning' },
   paused_gate: { cls: 'st-candidate', zh: '等待审批', en: 'paused' },
   paused_error: { cls: 'st-failed', zh: '出错暂停', en: 'error' },
+  paused_ask: { cls: 'st-candidate', zh: '等你回复', en: 'waiting for you' },
   failed: { cls: 'st-failed', zh: '失败', en: 'failed' },
   cancelled: { cls: 'st-rejected', zh: '已取消', en: 'cancelled' },
   // —— Voyage 步骤（任务板，docs/voyage-loop.md §4） ——
@@ -44,6 +45,7 @@ export const STATUS: Record<string, StatusMeta> = {
   // —— Experiment 状态（M4 Experiment Lab） ——
   awaiting_gate: { cls: 'st-candidate', zh: '等待审批', en: 'awaiting gate' },
   setup: { cls: 'st-drafted', zh: '建环境', en: 'setup' },
+  waiting_user: { cls: 'st-candidate', zh: '等你回复', en: 'waiting for you' },
   reporting: { cls: 'st-reviewed', zh: '报告中', en: 'reporting' },
   succeeded: { cls: 'st-implemented', zh: '成功', en: 'succeeded' },
   // —— Manuscript 状态（M5-B Paper Writer） ——

--- a/src/frontend/src/features/experiment/ConsoleTab.tsx
+++ b/src/frontend/src/features/experiment/ConsoleTab.tsx
@@ -1,0 +1,398 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { GateCard } from '../../components/ui/GateCard';
+import { Segmented } from '../../components/ui/Segmented';
+import { SysinfoPanel } from '../../components/ui/SysinfoPanel';
+import { toast } from '../../components/ui/Toast';
+import { useShell } from '../../app/AppShell';
+import { subscribeSse } from '../../lib/sse';
+import { tr } from '../../lib/i18n';
+import {
+  api,
+  EXPERIMENT_TERMINAL,
+  VOYAGE_TERMINAL,
+  type ExperimentDetail,
+  type GateDecision,
+} from '../../lib/api';
+import { ActivityBar } from '../voyages/shared/ActivityBar';
+import { StepCard } from '../voyages/shared/StepCard';
+import { byListOrder } from '../voyages/shared/stepUtils';
+import { TaskTerminal, type TerminalExtraEntry } from '../voyages/shared/terminal';
+import { useVoyageChannel } from '../voyages/shared/useVoyageChannel';
+import { openAskOf, useVoyageMessages } from '../voyages/shared/useVoyageMessages';
+import { budgetText } from './shared';
+import { ConsoleComposer } from '../voyages/shared/ConsoleComposer';
+import { messageNode } from '../voyages/shared/AskBlock';
+import { TaskMap } from './TaskMap';
+
+/* ============================================================
+   运行台（console tab）：实验的 AI 任务控制台。
+   ActivityBar（状态一句话 + 暂停态操作）
+   → 任务地图（横向节点带，点选看详情）
+   → 选中节点详情 / 概览（服务器状态 + 进度 + 预算）
+   → 深色终端（AI 过程日志 + 对话混排；可切脚本输出 / 仅看对话）
+   → 对话输入框（建议随时发；AI 提问时高亮等回复）。
+   ============================================================ */
+
+const MAX_SCRIPT_LINES = 2000;
+
+/** SSE data → 脚本日志行（兼容 JSON {line}/{lines} 与纯文本）。 */
+function parseLogEvent(data: string): string[] {
+  try {
+    const p: unknown = JSON.parse(data);
+    if (p && typeof p === 'object') {
+      const rec = p as { line?: unknown; lines?: unknown; message?: unknown };
+      if (typeof rec.line === 'string') return [rec.line];
+      if (Array.isArray(rec.lines)) return rec.lines.filter((l): l is string => typeof l === 'string');
+      if (typeof rec.message === 'string') return [rec.message];
+      return [];
+    }
+    if (typeof p === 'string') return [p];
+  } catch {
+    /* 非 JSON：按纯文本处理 */
+  }
+  return data.split('\n').filter((l) => l !== '');
+}
+
+/** 脚本输出（run.log）：与 AI 过程终端同一深色外观的简单日志框。 */
+function ScriptLogView({ expId, active }: { expId: string; active: boolean }) {
+  const [lines, setLines] = useState<string[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLines([]);
+    api
+      .getExperimentLogs(expId, { tail: 500 })
+      .then((r) => {
+        if (cancelled) return;
+        setLines(r.lines.slice(-MAX_SCRIPT_LINES));
+        setTruncated(r.truncated);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [expId]);
+
+  useEffect(() => {
+    if (!active) return;
+    const stop = subscribeSse(`/experiments/${expId}/logs/stream`, {
+      onEvent: (_event, data) => {
+        const next = parseLogEvent(data);
+        if (next.length > 0) setLines((l) => [...l, ...next].slice(-MAX_SCRIPT_LINES));
+      },
+    });
+    return stop;
+  }, [expId, active]);
+
+  useEffect(() => {
+    const box = boxRef.current;
+    if (box) box.scrollTop = box.scrollHeight;
+  }, [lines]);
+
+  return (
+    <div
+      ref={boxRef}
+      className="scroll"
+      style={{
+        height: 420,
+        overflowY: 'auto',
+        background: 'var(--terminal-bg)',
+        border: '0.5px solid var(--terminal-border)',
+        borderRadius: 12,
+        padding: '12px 14px',
+        fontFamily: 'var(--mono)',
+        fontSize: 11.5,
+        lineHeight: 1.65,
+        color: 'var(--terminal-fg)',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-all',
+      }}
+    >
+      {truncated && (
+        <div style={{ color: 'var(--terminal-dim)' }}>
+          {tr('…（更早日志已截断，仅显示尾部）', '… (earlier log truncated, showing the tail)')}
+        </div>
+      )}
+      {lines.length === 0 ? (
+        <div style={{ color: 'var(--terminal-dim)' }}>
+          {tr('暂无脚本输出（尚未开始运行）', 'No script output yet (not running)')}
+        </div>
+      ) : (
+        lines.map((l, i) => <div key={i}>{l}</div>)
+      )}
+    </div>
+  );
+}
+
+/** 概览面板（未选中节点时）：服务器状态 + 预算 + 任务用量。 */
+function OverviewPanel({ exp }: { exp: ExperimentDetail }) {
+  const sysActive = !EXPERIMENT_TERMINAL.has(exp.status);
+  const sysinfo = useQuery({
+    queryKey: ['experiment', exp.id, 'sysinfo'],
+    queryFn: () => api.getExperimentSysinfo(exp.id),
+    retry: false,
+    refetchInterval: sysActive ? 20_000 : false,
+  });
+  return (
+    <div className="card card-pad">
+      <div className="row gap8" style={{ marginBottom: 10, flexWrap: 'wrap' }}>
+        <span className="section-h">
+          <Icon name="server" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('服务器状态', 'Server status')}
+          {exp.server_host && <span className="mono muted" style={{ fontSize: 11 }}>{exp.server_host}</span>}
+        </span>
+        <span className="pill sm mono" style={{ marginLeft: 'auto', background: 'var(--surface-3)' }}>
+          {budgetText(exp.budget)}
+        </span>
+      </div>
+      <SysinfoPanel
+        loading={sysinfo.isLoading}
+        error={sysinfo.isError}
+        info={sysinfo.data}
+        onRefresh={() => void sysinfo.refetch()}
+      />
+    </div>
+  );
+}
+
+export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
+  const { openGates } = useShell();
+  const queryClient = useQueryClient();
+  const vid = exp.voyage_id;
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [source, setSource] = useState<'ai' | 'script'>('ai');
+  const [chatOnly, setChatOnly] = useState(false);
+  const [showObsolete, setShowObsolete] = useState(false);
+  const composerRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const { data: voyage } = useQuery({
+    queryKey: ['voyage', vid, showObsolete],
+    queryFn: () => api.getVoyage(vid!, { includeObsolete: showObsolete }),
+    enabled: !!vid,
+    retry: false,
+  });
+  const voyageActive = !!voyage && !VOYAGE_TERMINAL.has(voyage.status);
+
+  const { messages, handleExtraEvent } = useVoyageMessages(vid);
+  const { terminal, live, clearTerminal } = useVoyageChannel(vid, voyageActive, {
+    onExtraEvent: handleExtraEvent,
+  });
+
+  const openAsk = openAskOf(voyage, messages);
+
+  const resumeMutation = useMutation({
+    mutationFn: () => api.resumeVoyage(vid!),
+    onSuccess: () => {
+      toast(tr('已重新入队，从断点续跑', 'Re-queued — resuming from where it stopped'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['voyage', vid] });
+    },
+    onError: (e) =>
+      toast(`${tr('重试失败：', 'Retry failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  // paused_gate：就地审批（全局抽屉仍可用，openGates 兜底）
+  const gates = useQuery({
+    queryKey: ['gates', 'pending', exp.project_id],
+    queryFn: () => api.listGates('pending', exp.project_id),
+    enabled: voyage?.status === 'paused_gate',
+    retry: false,
+  });
+  const inlineGate = (gates.data ?? []).find((g) => g.payload?.voyage_id === vid);
+  const decideMutation = useMutation({
+    mutationFn: ({ id, decision, comment }: { id: string; decision: GateDecision; comment?: string }) =>
+      api.decideGate(id, decision, comment),
+    onSuccess: () => {
+      toast(tr('已提交审批结果', 'Decision submitted'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['gates'] });
+      void queryClient.invalidateQueries({ queryKey: ['voyage', vid] });
+      void queryClient.invalidateQueries({ queryKey: ['experiment'] });
+    },
+    onError: (e) =>
+      toast(`${tr('审批失败：', 'Decision failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const steps = useMemo(() => [...(voyage?.steps ?? [])].sort(byListOrder), [voyage?.steps]);
+  const planEvents = voyage?.plan_history ?? [];
+  const selectedStep = steps.find((s) => s.id === selectedId) ?? null;
+  const planAdjusted = (voyage?.plan_iteration ?? 0) > 0;
+
+  const extraEntries = useMemo<TerminalExtraEntry[]>(() => {
+    const out: TerminalExtraEntry[] = [];
+    for (const m of messages) {
+      const node = messageNode(m);
+      if (node) out.push({ id: m.id, at: m.created_at, node });
+    }
+    return out;
+  }, [messages]);
+
+  const focusComposer = () => {
+    composerRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    composerRef.current?.focus();
+  };
+
+  if (!vid) {
+    return (
+      <div className="card">
+        <EmptyState
+          compact
+          icon="server"
+          title={tr('该实验没有关联 AI 任务', 'This experiment has no linked AI task')}
+          desc={tr('早期实验数据，无法使用运行台。', 'Legacy experiment — the console is unavailable.')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="fadeup col gap16">
+      {/* 当前活动 + 暂停态操作 */}
+      {voyage && (
+        <div className="card card-pad">
+          <ActivityBar
+            voyage={voyage}
+            steps={steps}
+            onOpenGates={() => openGates(inlineGate?.id ?? null)}
+            onResume={() => resumeMutation.mutate()}
+            resuming={resumeMutation.isPending}
+            onReply={focusComposer}
+          />
+          {voyage.status === 'paused_gate' && inlineGate && (
+            <div style={{ marginTop: 12 }}>
+              <GateCard
+                gate={inlineGate}
+                expanded
+                onToggle={() => undefined}
+                deciding={decideMutation.isPending}
+                onDecide={(id, decision, comment) => decideMutation.mutate({ id, decision, comment })}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 任务地图 */}
+      <div className="card" style={{ padding: '10px 14px' }}>
+        <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+          <span className="section-h">
+            <Icon name="compass" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('任务地图', 'Task map')}
+          </span>
+          {planAdjusted && (
+            <label
+              className="row gap6"
+              style={{ marginLeft: 'auto', fontSize: 11.5, color: 'var(--text-3)', cursor: 'pointer', userSelect: 'none' }}
+            >
+              <input
+                type="checkbox"
+                checked={showObsolete}
+                onChange={(e) => setShowObsolete(e.target.checked)}
+              />
+              {tr('显示已作废步骤', 'Show obsolete steps')}
+            </label>
+          )}
+        </div>
+        <TaskMap
+          steps={steps}
+          planEvents={planEvents}
+          voyageStatus={voyage?.status ?? null}
+          askStepId={openAsk?.step_id ?? null}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          showObsolete={showObsolete}
+        />
+      </div>
+
+      {/* 选中节点详情 / 概览 */}
+      {selectedStep ? (
+        <div className="col gap8">
+          <div className="row">
+            <span className="section-h">
+              <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+              {tr('步骤详情', 'Step detail')}
+            </span>
+            <button className="btn btn-ghost sm" style={{ marginLeft: 'auto' }} onClick={() => setSelectedId(null)}>
+              <Icon name="x" size={12} />
+              {tr('收起', 'Close')}
+            </button>
+          </div>
+          <StepCard step={selectedStep} planEvents={planEvents} />
+        </div>
+      ) : (
+        <OverviewPanel exp={exp} />
+      )}
+
+      {/* 终端（AI 过程 / 脚本输出）+ 对话输入框 */}
+      <div>
+        {source === 'ai' ? (
+          <TaskTerminal
+            state={terminal}
+            live={live}
+            onClear={clearTerminal}
+            height={420}
+            extraEntries={extraEntries}
+            filter={chatOnly ? () => false : undefined}
+            headerExtras={
+              <>
+                <label
+                  className="row gap6"
+                  style={{ fontSize: 11.5, color: 'var(--text-3)', cursor: 'pointer', userSelect: 'none' }}
+                >
+                  <input type="checkbox" checked={chatOnly} onChange={(e) => setChatOnly(e.target.checked)} />
+                  {tr('仅看对话', 'Chat only')}
+                </label>
+                <Segmented
+                  value={source}
+                  onChange={(v) => setSource(v as 'ai' | 'script')}
+                  options={[
+                    { v: 'ai' as const, label: tr('AI 过程', 'AI process') },
+                    { v: 'script' as const, label: tr('脚本输出', 'Script output') },
+                  ]}
+                />
+              </>
+            }
+            footer={
+              <ConsoleComposer
+                voyageId={vid}
+                openAsk={openAsk}
+                disabled={!!voyage && VOYAGE_TERMINAL.has(voyage.status)}
+                inputRef={composerRef}
+              />
+            }
+          />
+        ) : (
+          <>
+            <div className="row" style={{ margin: '20px 0 12px' }}>
+              <span className="section-h">
+                <Icon name="cpu" size={15} style={{ color: 'var(--accent)' }} />
+                {tr('运行日志', 'Terminal')}
+                <span className="en-label" style={{ fontSize: 11 }}>run.log</span>
+              </span>
+              <div className="row gap8" style={{ marginLeft: 'auto' }}>
+                <Segmented
+                  value={source}
+                  onChange={(v) => setSource(v as 'ai' | 'script')}
+                  options={[
+                    { v: 'ai' as const, label: tr('AI 过程', 'AI process') },
+                    { v: 'script' as const, label: tr('脚本输出', 'Script output') },
+                  ]}
+                />
+              </div>
+            </div>
+            <ScriptLogView expId={exp.id} active={!EXPERIMENT_TERMINAL.has(exp.status)} />
+            <ConsoleComposer
+              voyageId={vid}
+              openAsk={openAsk}
+              disabled={!!voyage && VOYAGE_TERMINAL.has(voyage.status)}
+              inputRef={composerRef}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { StatusPill } from '../../components/ui/StatusPill';
 import { EmptyState } from '../../components/ui/EmptyState';
-import { Timeline, TimelineItem } from '../../components/ui/Timeline';
 import { toast } from '../../components/ui/Toast';
 import { Markdown } from '../../lib/markdown';
 import { useShell } from '../../app/AppShell';
@@ -20,28 +19,28 @@ import {
   type ExperimentDataset,
   type ExperimentDetail,
   type ExperimentPlan,
-  type VoyageStepRead,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { budgetText, HypChip } from './shared';
+import { ConsoleTab } from './ConsoleTab';
 import { RunTab } from './RunTab';
 import { CodeTab } from './CodeTab';
-import { SysinfoPanel } from '../../components/ui/SysinfoPanel';
 import { ExperimentFigures } from './ExperimentFigures';
 
 /* ============================================================
-   /experiment/:id — 实验详情：Plan / Setup / Run / Report 四 Tab。
-   数据源 GET /experiments/{id}（活动状态 5s 轮询 + WS invalidate），
-   Setup 复用关联 voyage 的 steps，Run 内嵌 SSE 日志与指标图。
+   /experiment/:id — 实验详情：运行台 / 计划 / 指标与轮次 / 代码 / 报告。
+   数据源 GET /experiments/{id}（活动状态 5s 轮询 + WS invalidate）；
+   运行台（ConsoleTab）是主视图：任务地图 + 终端对话 + 用户干预入口，
+   原环境 Tab 的服务器状态并入运行台概览、搭建步骤并入任务地图。
    ============================================================ */
 
-type TabKey = 'plan' | 'setup' | 'run' | 'code' | 'report';
+type TabKey = 'console' | 'plan' | 'run' | 'code' | 'report';
 
 /* 文案在渲染处 tr()，避免模块级求值不随语言切换 */
 const TABS: { k: TabKey; zh: string; en: string }[] = [
+  { k: 'console', zh: '运行台', en: 'Console' },
   { k: 'plan', zh: '计划', en: 'Plan' },
-  { k: 'setup', zh: '环境', en: 'Setup' },
-  { k: 'run', zh: '运行与迭代', en: 'Run & iterate' },
+  { k: 'run', zh: '指标与轮次', en: 'Metrics & runs' },
   { k: 'code', zh: '代码', en: 'Code' },
   { k: 'report', zh: '报告', en: 'Report' },
 ];
@@ -506,143 +505,6 @@ function PlanTab({ exp, onOpenGates }: { exp: ExperimentDetail; onOpenGates: () 
   );
 }
 
-/* ---------------- Setup ---------------- */
-
-const SETUP_STEP_RE = /setup|env|smoke|ssh|code|file|install|provision|venv|环境|冒烟|代码|连接/i;
-
-function stepMarker(step: VoyageStepRead): { bg: string; color: string } {
-  if (step.verdict && !step.verdict.passed) return { bg: 'var(--danger-bg)', color: 'var(--danger-tx)' };
-  switch (step.status) {
-    case 'done':
-      return { bg: 'var(--ok-bg)', color: 'var(--ok-tx)' };
-    case 'running':
-      return { bg: 'var(--accent)', color: '#fff' };
-    case 'failed':
-      return { bg: 'var(--danger-bg)', color: 'var(--danger-tx)' };
-    default:
-      return { bg: 'var(--surface-2)', color: 'var(--text-3)' };
-  }
-}
-
-function SetupTab({ exp }: { exp: ExperimentDetail }) {
-  const navigate = useNavigate();
-  const vid = exp.voyage_id;
-  const { data: voyage, isLoading, isError } = useQuery({
-    queryKey: ['voyage', vid],
-    queryFn: () => api.getVoyage(vid!),
-    enabled: !!vid,
-    retry: false,
-  });
-  // 实验所在服务器的系统状态：搭建/运行期间实时刷新（20s）
-  const sysActive = !EXPERIMENT_TERMINAL.has(exp.status);
-  const sysinfo = useQuery({
-    queryKey: ['experiment', exp.id, 'sysinfo'],
-    queryFn: () => api.getExperimentSysinfo(exp.id),
-    retry: false,
-    refetchInterval: sysActive ? 20_000 : false,
-  });
-  const sysinfoCard = (
-    <div className="card card-pad" style={{ marginBottom: 18 }}>
-      <span className="section-h" style={{ marginBottom: 10 }}>
-        <Icon name="server" size={15} style={{ color: 'var(--accent)' }} />
-        {tr('服务器状态', 'Server status')}
-        {exp.server_host && <span className="mono muted" style={{ fontSize: 11 }}>{exp.server_host}</span>}
-      </span>
-      <SysinfoPanel
-        loading={sysinfo.isLoading}
-        error={sysinfo.isError}
-        info={sysinfo.data}
-        onRefresh={() => void sysinfo.refetch()}
-      />
-    </div>
-  );
-
-  if (!vid) {
-    return (
-      <div className="card">
-        <EmptyState
-          compact
-          icon="server"
-          title={tr('尚未关联任务', 'No linked task yet')}
-        />
-      </div>
-    );
-  }
-  if (isLoading) return <div className="empty" style={{ padding: 40 }}>{tr('加载环境搭建步骤…', 'Loading setup steps…')}</div>;
-  if (isError || !voyage) {
-    return (
-      <div className="card">
-        <EmptyState
-          compact
-          icon="x"
-          title={tr('无法加载关联任务', 'Could not load the linked task')}
-          desc={tr('后端不可用或接口尚未就绪。', 'Backend unavailable or the API is not ready yet.')}
-        />
-      </div>
-    );
-  }
-
-  const all = [...(voyage.steps ?? [])].sort((a, b) => a.seq - b.seq);
-  const matched = all.filter((s) => SETUP_STEP_RE.test(`${s.action} ${s.title}`));
-  const steps = matched.length > 0 ? matched : all;
-
-  return (
-    <div className="fadeup" style={{ maxWidth: 860 }}>
-      {sysinfoCard}
-      <div className="row gap8" style={{ marginBottom: 12, justifyContent: 'space-between' }}>
-        <span className="section-h">
-          <Icon name="server" size={15} style={{ color: 'var(--accent)' }} />
-          {tr('环境搭建步骤', 'Setup steps')} <span className="en-label" style={{ fontSize: 11 }}>{tr('来自关联任务', 'from the linked task')}</span>
-        </span>
-        <button
-          className="btn btn-ghost sm mono"
-          style={{ fontSize: 11 }}
-          onClick={() => navigate(`/voyages/${vid}`)}
-        >
-          voyage {vid.slice(0, 8)} →
-        </button>
-      </div>
-      {steps.length === 0 ? (
-        <div className="card empty" style={{ padding: 32, marginBottom: 24 }}>{tr('任务尚未产生步骤', 'The task has no steps yet')}</div>
-      ) : (
-        <div style={{ marginBottom: 24 }}>
-          <Timeline>
-            {steps.map((s, i) => {
-              const m = stepMarker(s);
-              return (
-                <TimelineItem key={s.id} marker={s.seq} markerBg={m.bg} markerColor={m.color} last={i === steps.length - 1}>
-                  <div className="card" style={{ padding: '12px 16px' }}>
-                    <div className="row gap8" style={{ flexWrap: 'wrap' }}>
-                      <span style={{ fontSize: 13, fontWeight: 650 }}>{s.title}</span>
-                      <span className="tag mono" style={{ fontSize: 10.5 }}>{s.action}</span>
-                      <div style={{ marginLeft: 'auto' }}>
-                        <StatusPill status={s.status} sm />
-                      </div>
-                    </div>
-                    {s.started_at && (
-                      <div className="mono muted" style={{ fontSize: 11, marginTop: 7 }}>
-                        {fmtTime(s.started_at)} · {s.finished_at ? `${tr('耗时', 'took')} ${fmtDuration(s.started_at, s.finished_at)}` : tr('进行中', 'in progress')}
-                      </div>
-                    )}
-                    {/* 同任务详情页：reason 可能是一整条没有断点的长 URL，
-                        默认 overflow-wrap 下会溢出盒子而不是换行 */}
-                    {s.verdict && !s.verdict.passed && s.verdict.reason && (
-                      <div style={{ marginTop: 7, fontSize: 12, color: 'var(--danger-tx)', lineHeight: 1.5, overflowWrap: 'anywhere' }}>
-                        {tr('自动校验：', 'Auto check: ')}{s.verdict.reason}
-                      </div>
-                    )}
-                  </div>
-                </TimelineItem>
-              );
-            })}
-          </Timeline>
-        </div>
-      )}
-
-    </div>
-  );
-}
-
 /* ---------------- Report ---------------- */
 
 function ReportTab({ exp }: { exp: ExperimentDetail }) {
@@ -692,7 +554,7 @@ export function ExperimentDetailPage() {
   const queryClient = useQueryClient();
   const { openGates } = useShell();
   const { currentProjectId } = useProject();
-  const [tab, setTab] = useState<TabKey>('plan');
+  const [tab, setTab] = useState<TabKey>('console');
   const defaultedRef = useRef(false);
 
   const { data: exp, isLoading, isError, error, refetch } = useQuery({
@@ -704,14 +566,13 @@ export function ExperimentDetailPage() {
       q.state.data && !EXPERIMENT_TERMINAL.has(q.state.data.status) ? 5_000 : false,
   });
 
-  // 首次加载后按状态定位默认 Tab
+  // 首次加载后按状态定位默认 Tab：活动态一律进运行台（干预入口在那里），
+  // 完成且有报告的进报告页
   useEffect(() => {
     if (!exp || defaultedRef.current) return;
     defaultedRef.current = true;
-    if (exp.status === 'setup') setTab('setup');
-    else if (exp.status === 'running') setTab('run');
-    else if (exp.status === 'reporting' || (exp.status === 'done' && exp.report)) setTab('report');
-    else if (exp.status === 'done' || exp.status === 'failed') setTab('run');
+    if (exp.status === 'done' && exp.report) setTab('report');
+    else setTab('console');
   }, [exp]);
 
   const cancelMutation = useMutation({
@@ -833,9 +694,9 @@ export function ExperimentDetailPage() {
         ))}
       </div>
 
+      {tab === 'console' && <ConsoleTab exp={exp} />}
       {tab === 'plan' && <PlanTab exp={exp} onOpenGates={() => openGates(null)} />}
-      {tab === 'setup' && <SetupTab exp={exp} />}
-      {tab === 'run' && <RunTab exp={exp} active={active} />}
+      {tab === 'run' && <RunTab exp={exp} />}
       {tab === 'code' && <CodeTab exp={exp} active={active} />}
       {tab === 'report' && <ReportTab exp={exp} />}
     </div>

--- a/src/frontend/src/features/experiment/RunTab.tsx
+++ b/src/frontend/src/features/experiment/RunTab.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { Icon } from '../../components/ui/Icon';
 import { StatusPill } from '../../components/ui/StatusPill';
 import { Timeline, TimelineItem } from '../../components/ui/Timeline';
 import { MetricChart, type MetricChartSeries } from '../../components/ui/MetricChart';
-import { subscribeSse } from '../../lib/sse';
 import { fmtDuration, fmtTime } from '../../lib/format';
 import {
-  api,
   type ExperimentDetail,
   type ExperimentRunRead,
   type IterationDecision,
@@ -23,129 +21,8 @@ import { stopReasonText } from './shared';
    - 迭代时间线：每轮一卡（#seq、状态、主指标 + 与上轮差值、
      AI 决定徽章 improve/debug/stop、reflection 三字段折叠）
    - 全部指标曲线（POLARIS_METRIC by step）
-   - 实时日志（GET logs 初始 500 行 + SSE 追加，跟踪最新一轮）
+   实时日志已并入运行台（ConsoleTab 的「脚本输出」源）。
    ============================================================ */
-
-const MAX_LOG_LINES = 2000;
-
-/** SSE data → 日志行数组：兼容 JSON {line}/{lines} 与纯文本。 */
-function parseLogEvent(data: string): string[] {
-  try {
-    const p: unknown = JSON.parse(data);
-    if (p && typeof p === 'object') {
-      const rec = p as { line?: unknown; lines?: unknown; message?: unknown };
-      if (typeof rec.line === 'string') return [rec.line];
-      if (Array.isArray(rec.lines)) return rec.lines.filter((l): l is string => typeof l === 'string');
-      if (typeof rec.message === 'string') return [rec.message];
-      return [];
-    }
-    if (typeof p === 'string') return [p];
-  } catch {
-    /* 非 JSON：按纯文本处理 */
-  }
-  return data.split('\n').filter((l) => l !== '');
-}
-
-function LogPanel({ expId, active }: { expId: string; active: boolean }) {
-  const [lines, setLines] = useState<string[]>([]);
-  const [truncated, setTruncated] = useState(false);
-  const [loadError, setLoadError] = useState(false);
-  const [paused, setPaused] = useState(false);
-  const [live, setLive] = useState(false);
-  const boxRef = useRef<HTMLDivElement>(null);
-
-  // 初始拉取尾部 500 行
-  useEffect(() => {
-    let cancelled = false;
-    setLines([]);
-    setLoadError(false);
-    api
-      .getExperimentLogs(expId, { tail: 500 })
-      .then((r) => {
-        if (cancelled) return;
-        setLines(r.lines.slice(-MAX_LOG_LINES));
-        setTruncated(r.truncated);
-      })
-      .catch(() => {
-        if (!cancelled) setLoadError(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [expId]);
-
-  // 活动状态：SSE 追加
-  useEffect(() => {
-    if (!active) return;
-    const stop = subscribeSse(`/experiments/${expId}/logs/stream`, {
-      onOpen: () => setLive(true),
-      onError: () => setLive(false),
-      onEvent: (_event, data) => {
-        const next = parseLogEvent(data);
-        if (next.length > 0) setLines((l) => [...l, ...next].slice(-MAX_LOG_LINES));
-      },
-    });
-    return () => {
-      stop();
-      setLive(false);
-    };
-  }, [expId, active]);
-
-  // 自动滚底（未暂停时）
-  useEffect(() => {
-    if (paused) return;
-    const box = boxRef.current;
-    if (box) box.scrollTop = box.scrollHeight;
-  }, [lines, paused]);
-
-  return (
-    <div className="card" style={{ overflow: 'hidden' }}>
-      <div className="row card-pad" style={{ justifyContent: 'space-between', paddingBottom: 12 }}>
-        <span className="section-h">
-          <Icon name="file" size={15} style={{ color: 'var(--accent)' }} />
-          {tr('实时日志', 'Live log')} <span className="en-label" style={{ fontSize: 11 }}>run.log · {tr('跟踪最新一轮', 'follows the latest run')}</span>
-        </span>
-        <div className="row gap8">
-          {live && (
-            <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
-              <span className="dot pulse" />
-              LIVE
-            </span>
-          )}
-          <button className="btn btn-soft sm" onClick={() => setPaused((p) => !p)}>
-            <Icon name={paused ? 'play' : 'pause'} size={12} />
-            {paused ? tr('恢复滚动', 'Resume scroll') : tr('暂停滚动', 'Pause scroll')}
-          </button>
-        </div>
-      </div>
-      <div
-        ref={boxRef}
-        className="scroll"
-        style={{
-          fontFamily: 'var(--mono)',
-          fontSize: 11,
-          lineHeight: 1.6,
-          background: 'var(--surface-2)',
-          borderTop: '0.5px solid var(--border)',
-          padding: '10px 16px',
-          height: 320,
-          overflowY: 'auto',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-all',
-        }}
-      >
-        {truncated && <div style={{ color: 'var(--text-4)' }}>{tr('…（更早日志已截断，仅显示尾部）', '… (earlier log truncated, showing the tail)')}</div>}
-        {loadError && lines.length === 0 ? (
-          <div style={{ color: 'var(--text-4)' }}>{tr('暂无日志（尚未开始运行，或后端不可用）', 'No logs yet (not running, or backend unavailable)')}</div>
-        ) : lines.length === 0 ? (
-          <div style={{ color: 'var(--text-4)' }}>{tr('等待日志输出…', 'Waiting for log output…')}</div>
-        ) : (
-          lines.map((l, i) => <div key={i}>{l}</div>)
-        )}
-      </div>
-    </div>
-  );
-}
 
 /* ---------------- 迭代小件 ---------------- */
 
@@ -391,7 +268,7 @@ function IterationStateBar({ exp, runCount }: { exp: ExperimentDetail; runCount:
 
 /* ---------------- Tab 主体 ---------------- */
 
-export function RunTab({ exp, active }: { exp: ExperimentDetail; active: boolean }) {
+export function RunTab({ exp }: { exp: ExperimentDetail }) {
   const runs = [...(exp.runs ?? [])].sort((a, b) => a.seq - b.seq);
   const primary = exp.plan?.primary_metric;
   const direction: PrimaryMetric['direction'] = primary?.direction === 'minimize' ? 'minimize' : 'maximize';
@@ -490,9 +367,6 @@ export function RunTab({ exp, active }: { exp: ExperimentDetail; active: boolean
           <MetricChart series={allSeries} />
         </div>
       )}
-
-      {/* 实时日志 */}
-      <LogPanel expId={exp.id} active={active} />
     </div>
   );
 }

--- a/src/frontend/src/features/experiment/TaskMap.tsx
+++ b/src/frontend/src/features/experiment/TaskMap.tsx
@@ -1,0 +1,392 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Icon, type IconName } from '../../components/ui/Icon';
+import { tr } from '../../lib/i18n';
+import type { VoyagePlanEvent, VoyageStepRead, VoyageStatus } from '../../lib/api';
+import { byListOrder } from '../voyages/shared/stepUtils';
+
+/* ============================================================
+   任务地图：横向演进的节点带（节点 = voyage 步骤，rank 序）。
+   - 计划调整处插旗标分隔；作废步骤淡色划线留在原位（可选显示）；
+   - 审批节点菱形、等回答节点黄色 ? 角标、运行中脉冲；
+   - 连续通过的长段折叠成「✓ 前 N 步」胶囊；自动滚到当前节点；
+   - 自研 flex + 少量样式（仓库惯例：不引图库依赖，颜色全走 token）。
+   ============================================================ */
+
+/** action → 图标（experiment.* 有专属图标，其余按前缀兜底）。 */
+function actionIcon(action: string): IconName {
+  if (action.endsWith('.plan')) return 'compass';
+  if (action.endsWith('.setup')) return 'server';
+  if (action.endsWith('.smoke')) return 'flask';
+  if (action.endsWith('.run')) return 'play';
+  if (action.endsWith('.analyze')) return 'sparkle';
+  if (action.endsWith('.figures')) return 'chart';
+  if (action.endsWith('.report')) return 'pen';
+  return 'layers';
+}
+
+/** 步骤 → 地图上的短标签（第 N 轮 / 分析 N 用轮次计数，渲染处 tr）。 */
+function nodeLabel(step: VoyageStepRead, roundNo: number | null): string {
+  const a = step.action;
+  if (a.endsWith('.plan')) return tr('计划', 'plan');
+  if (a.endsWith('.setup')) return tr('环境', 'setup');
+  if (a.endsWith('.smoke')) return tr('试跑', 'smoke');
+  if (a.endsWith('.run')) return roundNo ? tr(`第 ${roundNo} 轮`, `run ${roundNo}`) : tr('运行', 'run');
+  if (a.endsWith('.analyze')) return roundNo ? tr(`分析 ${roundNo}`, `analyze ${roundNo}`) : tr('分析', 'analyze');
+  if (a.endsWith('.figures')) return tr('图表', 'figures');
+  if (a.endsWith('.report')) return tr('报告', 'report');
+  return step.title.length > 6 ? `${step.title.slice(0, 6)}…` : step.title;
+}
+
+type NodeVisual = 'pending' | 'running' | 'passed' | 'failed' | 'obsolete' | 'ask-wait';
+
+function stepVisual(step: VoyageStepRead, askStepId: string | null): NodeVisual {
+  if (step.status === 'obsolete') return 'obsolete';
+  if (askStepId && step.id === askStepId) return 'ask-wait';
+  if (step.status === 'running' || step.status === 'verifying') return 'running';
+  if (step.status === 'passed') return 'passed';
+  if (step.status === 'failed') return 'failed';
+  return 'pending';
+}
+
+const VISUAL_STYLE: Record<NodeVisual, { bg: string; color: string; border: string }> = {
+  pending: { bg: 'var(--surface-2)', color: 'var(--text-3)', border: '1px dashed var(--border)' },
+  running: { bg: 'var(--accent)', color: '#fff', border: '1px solid var(--accent)' },
+  passed: { bg: 'var(--ok-bg)', color: 'var(--ok-tx)', border: '1px solid transparent' },
+  failed: { bg: 'var(--danger-bg)', color: 'var(--danger-tx)', border: '1px solid transparent' },
+  obsolete: { bg: 'var(--surface-3)', color: 'var(--text-4)', border: '1px solid transparent' },
+  'ask-wait': { bg: 'var(--warn-bg)', color: 'var(--warn-tx)', border: '1px solid var(--warn-tx)' },
+};
+
+type MapItem =
+  | { kind: 'step'; step: VoyageStepRead; roundNo: number | null }
+  | { kind: 'plan-event'; event: VoyagePlanEvent }
+  | { kind: 'collapsed'; steps: VoyageStepRead[] };
+
+/** 连续 passed 段超过该长度时折叠（保尾部一个不折，衔接当前进度更直观）。 */
+const COLLAPSE_MIN = 6;
+
+export function buildTaskMapItems(
+  steps: VoyageStepRead[],
+  planEvents: VoyagePlanEvent[],
+  opts?: { showObsolete?: boolean; collapse?: boolean },
+): MapItem[] {
+  const showObsolete = opts?.showObsolete ?? false;
+  const collapse = opts?.collapse ?? true;
+  const ordered = [...steps].sort(byListOrder).filter((s) => showObsolete || s.status !== 'obsolete');
+  const byIteration = new Map(planEvents.map((e) => [e.iteration, e]));
+  const inserted = new Set<number>();
+
+  // 轮次计数：run/analyze 各自按出现顺序编号（obsolete 不计）
+  let runNo = 0;
+  let analyzeNo = 0;
+  const items: MapItem[] = [];
+  for (const step of ordered) {
+    const iter = step.provenance?.plan_iteration ?? 0;
+    if (iter > 0 && !inserted.has(iter) && byIteration.has(iter)) {
+      inserted.add(iter);
+      items.push({ kind: 'plan-event', event: byIteration.get(iter)! });
+    }
+    let roundNo: number | null = null;
+    if (step.status !== 'obsolete') {
+      if (step.action.endsWith('.run')) roundNo = ++runNo;
+      else if (step.action.endsWith('.analyze')) roundNo = ++analyzeNo;
+    }
+    items.push({ kind: 'step', step, roundNo });
+  }
+
+  if (!collapse) return items;
+  // 折叠连续 passed 步骤段（只折 step 项；plan-event 分隔天然切段）
+  const out: MapItem[] = [];
+  let buffer: Extract<MapItem, { kind: 'step' }>[] = [];
+  const flush = () => {
+    if (buffer.length > COLLAPSE_MIN) {
+      const keepTail = buffer[buffer.length - 1]!;
+      out.push({ kind: 'collapsed', steps: buffer.slice(0, -1).map((b) => b.step) });
+      out.push(keepTail);
+    } else {
+      out.push(...buffer);
+    }
+    buffer = [];
+  };
+  for (const item of items) {
+    if (item.kind === 'step' && item.step.status === 'passed') {
+      buffer.push(item);
+    } else {
+      flush();
+      out.push(item);
+    }
+  }
+  flush();
+  return out;
+}
+
+function Connector() {
+  return (
+    <span
+      aria-hidden
+      style={{ width: 14, height: 1.5, background: 'var(--border)', flexShrink: 0, alignSelf: 'center', marginBottom: 18 }}
+    />
+  );
+}
+
+function StepNode({
+  step,
+  roundNo,
+  selected,
+  visual,
+  onSelect,
+  nodeRef,
+}: {
+  step: VoyageStepRead;
+  roundNo: number | null;
+  selected: boolean;
+  visual: NodeVisual;
+  onSelect: (id: string | null) => void;
+  nodeRef?: (el: HTMLButtonElement | null) => void;
+}) {
+  const style = VISUAL_STYLE[visual];
+  const gate = !!step.requires_gate;
+  const obsolete = visual === 'obsolete';
+  return (
+    <button
+      ref={nodeRef}
+      onClick={() => onSelect(selected ? null : step.id)}
+      title={`${step.title}${step.attempt > 1 ? tr(`（第 ${step.attempt} 次尝试）`, ` (attempt ${step.attempt})`) : ''}`}
+      className="col"
+      style={{
+        border: 'none',
+        background: 'transparent',
+        cursor: 'pointer',
+        padding: '2px 2px 0',
+        alignItems: 'center',
+        gap: 5,
+        flexShrink: 0,
+        width: 62,
+      }}
+    >
+      <span
+        className={visual === 'running' ? 'pulse' : undefined}
+        style={{
+          position: 'relative',
+          width: 34,
+          height: 34,
+          borderRadius: gate ? 9 : 999,
+          transform: gate ? 'rotate(45deg)' : 'none',
+          background: style.bg,
+          color: style.color,
+          border: style.border,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          boxShadow: selected ? '0 0 0 2.5px var(--accent-soft), 0 0 0 4px var(--accent)' : 'none',
+          opacity: obsolete ? 0.55 : 1,
+        }}
+      >
+        <span style={{ transform: gate ? 'rotate(-45deg)' : 'none', display: 'flex' }}>
+          <Icon name={gate ? 'gate' : actionIcon(step.action)} size={15} />
+        </span>
+        {visual === 'ask-wait' && (
+          <span
+            className="pulse"
+            style={{
+              position: 'absolute',
+              top: -5,
+              right: -5,
+              width: 15,
+              height: 15,
+              borderRadius: 999,
+              background: 'var(--warn-tx)',
+              color: '#fff',
+              fontSize: 10,
+              fontWeight: 800,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transform: gate ? 'rotate(-45deg)' : 'none',
+            }}
+          >
+            ?
+          </span>
+        )}
+        {visual === 'failed' && (
+          <span
+            style={{
+              position: 'absolute',
+              top: -4,
+              right: -4,
+              width: 13,
+              height: 13,
+              borderRadius: 999,
+              background: 'var(--danger-tx)',
+              color: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transform: gate ? 'rotate(-45deg)' : 'none',
+            }}
+          >
+            <Icon name="x" size={9} />
+          </span>
+        )}
+      </span>
+      <span
+        style={{
+          fontSize: 10.5,
+          lineHeight: 1.2,
+          color: selected ? 'var(--text)' : 'var(--text-3)',
+          fontWeight: selected ? 700 : 500,
+          textDecoration: obsolete ? 'line-through' : 'none',
+          maxWidth: 62,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {nodeLabel(step, roundNo)}
+      </span>
+    </button>
+  );
+}
+
+export function TaskMap({
+  steps,
+  planEvents,
+  voyageStatus,
+  askStepId,
+  selectedId,
+  onSelect,
+  showObsolete,
+}: {
+  steps: VoyageStepRead[];
+  planEvents: VoyagePlanEvent[];
+  voyageStatus: VoyageStatus | null;
+  /** 等回答的提问挂在哪个步骤上（该节点顶黄色 ? 角标） */
+  askStepId: string | null;
+  selectedId: string | null;
+  onSelect: (stepId: string | null) => void;
+  showObsolete?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const focusRef = useRef<HTMLButtonElement | null>(null);
+
+  const items = useMemo(
+    () => buildTaskMapItems(steps, planEvents, { showObsolete, collapse: !expanded }),
+    [steps, planEvents, showObsolete, expanded],
+  );
+
+  // 当前焦点节点（运行中 / 等回答 / 失败）居中；节点数变化时重新对齐
+  useEffect(() => {
+    focusRef.current?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' });
+  }, [items.length, voyageStatus]);
+
+  if (steps.length === 0) {
+    return (
+      <div className="card empty" style={{ padding: 22, fontSize: 12.5 }}>
+        {voyageStatus === 'planning'
+          ? tr('AI 正在规划步骤…', 'AI is planning the steps…')
+          : tr('暂无步骤', 'No steps yet')}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="scroll"
+      style={{ overflowX: 'auto', padding: '10px 4px 4px', display: 'flex', alignItems: 'flex-start' }}
+    >
+      {items.map((item, i) => {
+        const connector = i > 0 ? <Connector key={`c-${i}`} /> : null;
+        if (item.kind === 'plan-event') {
+          return (
+            <span key={`p-${item.event.iteration}`} className="row" style={{ flexShrink: 0 }}>
+              {connector}
+              <span
+                className="col"
+                title={item.event.reason || tr('计划调整', 'Plan adjusted')}
+                style={{ alignItems: 'center', gap: 5, width: 44, paddingTop: 2 }}
+              >
+                <span
+                  style={{
+                    width: 26,
+                    height: 34,
+                    borderRadius: 8,
+                    background: 'var(--accent-soft)',
+                    color: 'var(--accent-text)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Icon name="refresh" size={13} />
+                </span>
+                <span style={{ fontSize: 10, color: 'var(--accent-text)', whiteSpace: 'nowrap' }}>
+                  {tr(`调整 ${item.event.iteration}`, `adj ${item.event.iteration}`)}
+                </span>
+              </span>
+            </span>
+          );
+        }
+        if (item.kind === 'collapsed') {
+          return (
+            <span key={`col-${i}`} className="row" style={{ flexShrink: 0 }}>
+              {connector}
+              <button
+                onClick={() => setExpanded(true)}
+                title={tr('展开这些已完成的步骤', 'Expand these completed steps')}
+                className="col"
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  alignItems: 'center',
+                  gap: 5,
+                  padding: '2px 2px 0',
+                  flexShrink: 0,
+                }}
+              >
+                <span
+                  style={{
+                    height: 34,
+                    padding: '0 12px',
+                    borderRadius: 999,
+                    background: 'var(--ok-bg)',
+                    color: 'var(--ok-tx)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    fontSize: 11,
+                    fontWeight: 700,
+                  }}
+                >
+                  <Icon name="check" size={12} />
+                  {item.steps.length}
+                </span>
+                <span style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+                  {tr(`${item.steps.length} 步已完成`, `${item.steps.length} done`)}
+                </span>
+              </button>
+            </span>
+          );
+        }
+        const visual = stepVisual(item.step, askStepId);
+        const isFocus =
+          visual === 'running' || visual === 'ask-wait' || (visual === 'failed' && voyageStatus !== 'done');
+        return (
+          <span key={item.step.id} className="row" style={{ flexShrink: 0 }}>
+            {connector}
+            <StepNode
+              step={item.step}
+              roundNo={item.roundNo}
+              selected={selectedId === item.step.id}
+              visual={visual}
+              onSelect={onSelect}
+              nodeRef={isFocus ? (el) => (focusRef.current = el) : undefined}
+            />
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -28,8 +28,11 @@ import {
   stepMarker,
   stepTokenCount,
 } from './shared/stepUtils';
-import { TaskTerminal } from './shared/terminal';
+import { TaskTerminal, type TerminalExtraEntry } from './shared/terminal';
 import { useVoyageChannel } from './shared/useVoyageChannel';
+import { openAskOf, useVoyageMessages } from './shared/useVoyageMessages';
+import { messageNode } from './shared/AskBlock';
+import { ConsoleComposer } from './shared/ConsoleComposer';
 
 /* ============================================================
    /voyages/:id — 任务详情：循环感知的活动状态 + 步骤时间线 + SSE 实时。
@@ -148,8 +151,25 @@ export function VoyageDetailPage() {
 
   const active = !!voyage && !VOYAGE_TERMINAL.has(voyage.status);
 
-  // 终端 + SSE 实时通道（状态/步骤事件自动合并进 ['voyage', id] 缓存）
-  const { terminal, live, clearTerminal } = useVoyageChannel(id, active);
+  // 对话流（用户建议 / AI 提问）+ 终端 SSE 实时通道
+  const { messages, handleExtraEvent } = useVoyageMessages(id);
+  const { terminal, live, clearTerminal } = useVoyageChannel(id, active, {
+    onExtraEvent: handleExtraEvent,
+  });
+  const openAsk = openAskOf(voyage, messages);
+  const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const extraEntries = useMemo<TerminalExtraEntry[]>(() => {
+    const out: TerminalExtraEntry[] = [];
+    for (const m of messages) {
+      const node = messageNode(m);
+      if (node) out.push({ id: m.id, at: m.created_at, node });
+    }
+    return out;
+  }, [messages]);
+  const focusComposer = () => {
+    composerRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    composerRef.current?.focus();
+  };
 
   if (isLoading) {
     return (
@@ -253,6 +273,7 @@ export function VoyageDetailPage() {
           onOpenGates={() => openGates(null)}
           onResume={() => resumeMutation.mutate()}
           resuming={resumeMutation.isPending}
+          onReply={focusComposer}
         />
       </div>
 
@@ -329,8 +350,21 @@ export function VoyageDetailPage() {
         </Timeline>
       )}
 
-      {/* 运行日志终端：结构化日志 + 大模型流式输出，常驻显示 */}
-      <TaskTerminal state={terminal} live={live} onClear={clearTerminal} />
+      {/* 运行日志终端：结构化日志 + 大模型流式输出 + 对话混排，常驻显示 */}
+      <TaskTerminal
+        state={terminal}
+        live={live}
+        onClear={clearTerminal}
+        extraEntries={extraEntries}
+        footer={
+          <ConsoleComposer
+            voyageId={id}
+            openAsk={openAsk}
+            disabled={!!voyage && VOYAGE_TERMINAL.has(voyage.status)}
+            inputRef={composerRef}
+          />
+        }
+      />
     </div>
   );
 }

--- a/src/frontend/src/features/voyages/shared/ActivityBar.tsx
+++ b/src/frontend/src/features/voyages/shared/ActivityBar.tsx
@@ -80,6 +80,8 @@ export function activityText(voyage: VoyageDetail, steps: VoyageStepRead[]): str
       return tr('已暂停：等待人工审批', 'Paused: waiting for approval');
     case 'paused_error':
       return tr('已暂停：执行出错', 'Paused: an error occurred');
+    case 'paused_ask':
+      return tr('已暂停：AI 有问题想问你', 'Paused: the AI has a question for you');
     case 'done': {
       const passed = live.filter((s) => s.status === 'passed').length;
       const adj = voyage.plan_iteration ?? 0;
@@ -98,6 +100,7 @@ export function activityText(voyage: VoyageDetail, steps: VoyageStepRead[]): str
 export function activityDot(status: VoyageStatus): { color: string; pulse: boolean } {
   switch (status) {
     case 'paused_gate':
+    case 'paused_ask':
       return { color: 'var(--warn-tx)', pulse: false };
     case 'paused_error':
     case 'failed':
@@ -117,12 +120,15 @@ export function ActivityBar({
   onOpenGates,
   onResume,
   resuming,
+  onReply,
 }: {
   voyage: VoyageDetail;
   steps: VoyageStepRead[];
   onOpenGates: () => void;
   onResume?: () => void;
   resuming?: boolean;
+  /** paused_ask 时「去回复」按钮的回调（滚动/聚焦到对话输入框） */
+  onReply?: () => void;
 }) {
   const status = voyage.status;
   const dot = activityDot(status);
@@ -160,6 +166,28 @@ export function ActivityBar({
           <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} onClick={onOpenGates}>
             {tr('前往审批', 'Go to approvals')}
           </button>
+        </div>
+      )}
+      {status === 'paused_ask' && (
+        <div
+          className="row gap8"
+          style={{
+            marginTop: 12,
+            padding: '10px 14px',
+            background: 'var(--warn-bg)',
+            color: 'var(--warn-tx)',
+            borderRadius: 10,
+            fontSize: 12.5,
+            fontWeight: 600,
+          }}
+        >
+          <Icon name="sparkle" size={15} />
+          {tr('AI 有问题想问你，回复后任务会继续。', 'The AI has a question — reply to continue the task.')}
+          {onReply && (
+            <button className="btn btn-primary sm" style={{ marginLeft: 'auto' }} onClick={onReply}>
+              {tr('去回复', 'Reply')}
+            </button>
+          )}
         </div>
       )}
       {status === 'paused_error' && (

--- a/src/frontend/src/features/voyages/shared/AskBlock.tsx
+++ b/src/frontend/src/features/voyages/shared/AskBlock.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { Icon } from '../../../components/ui/Icon';
+import { tr, useLang } from '../../../lib/i18n';
+import type { VoyageMessageRead } from '../../../lib/api';
+import { hhmmss } from './terminal';
+
+/* ============================================================
+   终端混排流里的对话块（深色终端配色，走 --terminal-* token）：
+   - AskBlock：AI 提问（等回答时黄框高亮 + 候选项；已回答/已作废转灰）
+   - UserNoteBlock：用户消息（建议 / 回答），右对齐
+   - InfoNoteLine：AI 播报（「已采纳你的建议」等）
+   ============================================================ */
+
+export function askOptionLabel(opt: { id: string; zh?: string; en?: string }, lang: string): string {
+  return (lang === 'en' ? opt.en : opt.zh) || opt.zh || opt.en || opt.id;
+}
+
+/** ask 的诊断上下文 → 可读文本（防御式：结构随 ask_kind 而变）。 */
+function contextText(context: Record<string, unknown> | null | undefined): string | null {
+  if (!context || typeof context !== 'object') return null;
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(context)) {
+    if (value === null || value === undefined || value === '') continue;
+    const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    parts.push(`${key}: ${text}`);
+  }
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+export function AskBlock({ message }: { message: VoyageMessageRead }) {
+  const [open, setOpen] = useState(false);
+  const lang = useLang();
+  const pendingAnswer = message.status === 'open';
+  const superseded = message.status === 'superseded';
+  const options = message.payload?.options ?? [];
+  const ctx = contextText(message.payload?.context);
+  const borderColor = pendingAnswer ? 'var(--terminal-warn)' : 'var(--terminal-border)';
+  return (
+    <div
+      style={{
+        margin: '8px 0',
+        padding: '9px 11px',
+        background: 'var(--terminal-bg-2)',
+        border: `1px solid ${borderColor}`,
+        borderRadius: 8,
+        opacity: superseded ? 0.55 : 1,
+      }}
+    >
+      <div className="row" style={{ gap: 7 }}>
+        {pendingAnswer ? (
+          <span className="dot pulse" style={{ background: 'var(--terminal-warn)', flexShrink: 0 }} />
+        ) : (
+          <Icon name="check" size={12} style={{ color: 'var(--terminal-dim)', flexShrink: 0 }} />
+        )}
+        <span style={{ color: 'var(--terminal-warn)', fontWeight: 700 }}>
+          {tr('AI 提问', 'AI question')}
+        </span>
+        {superseded && (
+          <span style={{ color: 'var(--terminal-dim)' }}>· {tr('已作废', 'superseded')}</span>
+        )}
+        {!pendingAnswer && !superseded && (
+          <span style={{ color: 'var(--terminal-dim)' }}>· {tr('已回复', 'answered')}</span>
+        )}
+        <span style={{ color: 'var(--terminal-dim)', marginLeft: 'auto', fontVariantNumeric: 'tabular-nums' }}>
+          {hhmmss(message.created_at)}
+        </span>
+      </div>
+      <div style={{ marginTop: 5, color: 'var(--terminal-fg)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+        {message.text}
+      </div>
+      {options.length > 0 && (
+        <div className="row gap6 wrap" style={{ marginTop: 7 }}>
+          {options.map((opt) => (
+            <span
+              key={opt.id}
+              style={{
+                padding: '2px 9px',
+                borderRadius: 999,
+                border: '0.5px solid var(--terminal-border)',
+                color: 'var(--terminal-fg)',
+                fontSize: 10.5,
+                opacity: 0.9,
+              }}
+            >
+              {askOptionLabel(opt, lang)}
+            </span>
+          ))}
+        </div>
+      )}
+      {ctx && (
+        <>
+          <button
+            onClick={() => setOpen((o) => !o)}
+            style={{
+              marginTop: 6,
+              border: 'none',
+              background: 'transparent',
+              cursor: 'pointer',
+              padding: 0,
+              fontSize: 11,
+              fontFamily: 'var(--mono)',
+              color: 'var(--terminal-accent)',
+            }}
+          >
+            {open ? tr('收起诊断上下文', 'Hide context') : tr('展开诊断上下文', 'Show context')}
+          </button>
+          {open && (
+            <div
+              style={{
+                marginTop: 5,
+                color: 'var(--terminal-dim)',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                fontSize: 11,
+                maxHeight: 260,
+                overflowY: 'auto',
+              }}
+            >
+              {ctx}
+            </div>
+          )}
+        </>
+      )}
+      {pendingAnswer && (
+        <div style={{ marginTop: 7, color: 'var(--terminal-warn)', fontSize: 11 }}>
+          {tr('↓ 在下方输入框回复后任务会继续', '↓ Reply in the box below to continue the task')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 用户消息（建议 / 回答）：右对齐块。 */
+export function UserNoteBlock({ message }: { message: VoyageMessageRead }) {
+  const isAnswer = message.kind === 'answer';
+  const consumed = message.kind === 'chat' && !!message.consumed_at;
+  return (
+    <div className="row" style={{ justifyContent: 'flex-end', margin: '6px 0' }}>
+      <div
+        style={{
+          maxWidth: '80%',
+          padding: '7px 10px',
+          background: 'var(--terminal-bg-2)',
+          borderLeft: '2.5px solid var(--terminal-accent)',
+          borderRadius: 8,
+        }}
+      >
+        <div className="row" style={{ gap: 6 }}>
+          <span style={{ color: 'var(--terminal-accent)', fontWeight: 700 }}>
+            {isAnswer ? tr('你的回复', 'Your reply') : tr('你的建议', 'Your suggestion')}
+          </span>
+          {consumed && (
+            <span style={{ color: 'var(--terminal-dim)', fontSize: 10.5 }}>
+              · {tr('AI 已采纳', 'picked up')}
+            </span>
+          )}
+          <span style={{ color: 'var(--terminal-dim)', marginLeft: 'auto', fontVariantNumeric: 'tabular-nums' }}>
+            {hhmmss(message.created_at)}
+          </span>
+        </div>
+        {message.text && (
+          <div style={{ marginTop: 3, color: 'var(--terminal-fg)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {message.text}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** AI 播报（info）：一行弱色说明。 */
+export function InfoNoteLine({ message }: { message: VoyageMessageRead }) {
+  return (
+    <div className="row" style={{ gap: 8, alignItems: 'flex-start', padding: '1px 0' }}>
+      <span style={{ color: 'var(--terminal-dim)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+        {hhmmss(message.created_at)}
+      </span>
+      <span style={{ color: 'var(--terminal-plan)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', minWidth: 0 }}>
+        <Icon name="sparkle" size={10} style={{ display: 'inline-block', verticalAlign: '-1px', marginRight: 4 }} />
+        {message.text}
+      </span>
+    </div>
+  );
+}
+
+/** 消息 → 终端混排块（未知 kind 返回 null，调用方跳过）。 */
+export function messageNode(message: VoyageMessageRead) {
+  if (message.kind === 'ask') return <AskBlock message={message} />;
+  if (message.kind === 'chat' || message.kind === 'answer') return <UserNoteBlock message={message} />;
+  if (message.kind === 'info') return <InfoNoteLine message={message} />;
+  return null;
+}

--- a/src/frontend/src/features/voyages/shared/ConsoleComposer.tsx
+++ b/src/frontend/src/features/voyages/shared/ConsoleComposer.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState, type MutableRefObject } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../../components/ui/Icon';
+import { toast } from '../../../components/ui/Toast';
+import { tr, useLang } from '../../../lib/i18n';
+import { api, type VoyageMessageRead } from '../../../lib/api';
+import { askOptionLabel } from './AskBlock';
+
+/* ============================================================
+   对话输入框（终端面板底部）：
+   - 平时：发非阻塞建议（AI 在下一个决策点参考）；
+   - AI 提问等回答时：黄框高亮 + 候选项 chips，发送即回答并恢复任务；
+   - 「放弃」类选项要二次确认（那是唯一由用户决定的失败路径）。
+   ============================================================ */
+
+function upsertMessage(list: VoyageMessageRead[] | undefined, message: VoyageMessageRead) {
+  const prev = list ?? [];
+  if (prev.some((m) => m.id === message.id)) return prev;
+  return [...prev, message].sort((a, b) => a.seq - b.seq);
+}
+
+export function ConsoleComposer({
+  voyageId,
+  openAsk,
+  disabled,
+  inputRef,
+}: {
+  voyageId: string;
+  openAsk: VoyageMessageRead | null;
+  /** 终态任务：没有下一个决策点，禁用输入 */
+  disabled?: boolean;
+  inputRef?: MutableRefObject<HTMLTextAreaElement | null>;
+}) {
+  const queryClient = useQueryClient();
+  const lang = useLang();
+  const [text, setText] = useState('');
+  const [choice, setChoice] = useState<string | null>(null);
+
+  // 切换到新提问时清掉上一个问题的选择
+  useEffect(() => {
+    setChoice(null);
+  }, [openAsk?.id]);
+
+  const afterSend = (message: VoyageMessageRead) => {
+    queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', voyageId], (old) =>
+      upsertMessage(old, message),
+    );
+    void queryClient.invalidateQueries({ queryKey: ['voyage', voyageId] });
+    void queryClient.invalidateQueries({ queryKey: ['experiment'] });
+  };
+
+  const suggestMutation = useMutation({
+    mutationFn: (body: string) => api.postVoyageMessage(voyageId, body),
+    onSuccess: (message) => {
+      afterSend(message);
+      setText('');
+      toast(tr('已发送，AI 会在下一步决策时参考', 'Sent — the AI will factor it in at its next decision'), 'ok');
+    },
+    onError: (e) =>
+      toast(`${tr('发送失败：', 'Send failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const answerMutation = useMutation({
+    mutationFn: (body: { text?: string; choice?: string }) =>
+      api.answerVoyageAsk(voyageId, openAsk!.id, body),
+    onSuccess: (message) => {
+      afterSend(message);
+      setText('');
+      setChoice(null);
+      toast(tr('已回复，任务继续', 'Answered — the task resumes'), 'ok');
+    },
+    onError: (e) =>
+      toast(`${tr('回复失败：', 'Reply failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const busy = suggestMutation.isPending || answerMutation.isPending;
+  const options = openAsk?.payload?.options ?? [];
+
+  const send = () => {
+    const body = text.trim();
+    if (openAsk) {
+      if (!body && !choice) return;
+      if (choice === 'abort' && !window.confirm(tr('确定放弃这个任务？放弃后无法恢复。', 'Give up this task? This cannot be undone.'))) {
+        return;
+      }
+      answerMutation.mutate({ text: body || undefined, choice: choice ?? undefined });
+    } else {
+      if (!body) return;
+      suggestMutation.mutate(body);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        marginTop: 10,
+        padding: 10,
+        borderRadius: 12,
+        border: openAsk ? '1.5px solid var(--warn-tx)' : '0.5px solid var(--border)',
+        background: 'var(--surface)',
+      }}
+    >
+      {openAsk && (
+        <div className="col gap8" style={{ marginBottom: 8 }}>
+          <div className="row gap6" style={{ fontSize: 12, color: 'var(--warn-tx)', fontWeight: 650 }}>
+            <span className="dot pulse" style={{ background: 'var(--warn-tx)' }} />
+            {tr('AI 正在等你回复：', 'The AI is waiting for your reply: ')}
+            <span style={{ color: 'var(--text)', fontWeight: 600, minWidth: 0 }}>{openAsk.text}</span>
+          </div>
+          {options.length > 0 && (
+            <div className="row gap6 wrap">
+              {options.map((opt) => {
+                const active = choice === opt.id;
+                const danger = opt.id === 'abort';
+                return (
+                  <button
+                    key={opt.id}
+                    onClick={() => setChoice(active ? null : opt.id)}
+                    className="pill sm"
+                    style={{
+                      cursor: 'pointer',
+                      border: active ? '1.5px solid currentColor' : '0.5px solid var(--border)',
+                      background: active
+                        ? danger
+                          ? 'var(--danger-bg)'
+                          : 'var(--accent-soft)'
+                        : 'var(--surface-2)',
+                      color: active
+                        ? danger
+                          ? 'var(--danger-tx)'
+                          : 'var(--accent-text)'
+                        : 'var(--text-2)',
+                      fontWeight: active ? 700 : 500,
+                    }}
+                  >
+                    {askOptionLabel(opt, lang)}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+      <div className="row gap8" style={{ alignItems: 'flex-end' }}>
+        <textarea
+          ref={inputRef}
+          className="textarea"
+          rows={2}
+          value={text}
+          disabled={disabled || busy}
+          placeholder={
+            disabled
+              ? tr('任务已结束', 'Task finished')
+              : openAsk
+                ? tr('输入你的回复（可只选上方选项直接发送）…', 'Type your reply (or just pick an option above)…')
+                : tr('随时给 AI 建议，会在下一步决策时参考…', 'Suggest anything — the AI factors it in at its next decision…')
+          }
+          style={{ flex: 1, resize: 'vertical', minHeight: 44, fontSize: 12.5 }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              send();
+            }
+          }}
+        />
+        <button
+          className="btn btn-primary"
+          disabled={disabled || busy || (openAsk ? !text.trim() && !choice : !text.trim())}
+          onClick={send}
+          title={tr('发送（⌘/Ctrl+Enter）', 'Send (⌘/Ctrl+Enter)')}
+        >
+          <Icon name="arrow" size={13} />
+          {busy ? tr('发送中…', 'Sending…') : openAsk ? tr('回复', 'Reply') : tr('发送', 'Send')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
+++ b/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api, ApiError, type VoyageDetail, type VoyageMessageRead } from '../../../lib/api';
+
+/* ============================================================
+   任务对话流数据：初始拉取 + SSE 增量合并（按 id 去重、seq 排序）。
+   与 useVoyageChannel 配合：把它的 onExtraEvent 交给 handleExtraEvent，
+   message / ask.created / ask.answered 事件自动进缓存。
+   ============================================================ */
+
+function upsert(list: VoyageMessageRead[] | undefined, message: VoyageMessageRead) {
+  const prev = list ?? [];
+  const i = prev.findIndex((m) => m.id === message.id);
+  const next = i >= 0 ? prev.map((m, j) => (j === i ? message : m)) : [...prev, message];
+  return next.sort((a, b) => a.seq - b.seq);
+}
+
+export function useVoyageMessages(voyageId: string | null) {
+  const id = voyageId ?? '';
+  const queryClient = useQueryClient();
+
+  const { data: messages } = useQuery({
+    queryKey: ['voyage-messages', id],
+    // 旧后端没有该端点：404 当空流（页面其余部分照常）
+    queryFn: () =>
+      api.listVoyageMessages(id).catch((e) => {
+        if (e instanceof ApiError && e.status === 404) return [] as VoyageMessageRead[];
+        throw e;
+      }),
+    enabled: !!id,
+    staleTime: Infinity, // 增量全走 SSE
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  /** 交给 useVoyageChannel 的 onExtraEvent：消费 message / ask.* 事件。 */
+  const handleExtraEvent = useCallback(
+    (event: string, data: unknown) => {
+      if (event !== 'message' && event !== 'ask.created' && event !== 'ask.answered') return;
+      const payload = data as { message?: VoyageMessageRead };
+      if (!payload?.message) return;
+      queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', id], (old) =>
+        upsert(old, payload.message!),
+      );
+      if (event !== 'message') {
+        // ask 状态变化伴随任务状态变化（paused_ask / executing）：刷详情
+        void queryClient.invalidateQueries({ queryKey: ['voyage', id] });
+      }
+    },
+    [id, queryClient],
+  );
+
+  return { messages: messages ?? [], handleExtraEvent };
+}
+
+/** 当前等回答的提问：详情字段优先，消息流兜底（SSE 先到、详情还没刷时）。 */
+export function openAskOf(
+  voyage: VoyageDetail | undefined,
+  messages: VoyageMessageRead[],
+): VoyageMessageRead | null {
+  if (voyage?.open_ask && voyage.open_ask.status === 'open') return voyage.open_ask;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i]!;
+    if (m.kind === 'ask' && m.status === 'open') return m;
+  }
+  return null;
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -307,6 +307,7 @@ export type VoyageStatus =
   | 'replanning'
   | 'paused_gate'
   | 'paused_error'
+  | 'paused_ask'
   | 'done'
   | 'failed'
   | 'cancelled';
@@ -445,6 +446,51 @@ export interface VoyageDetail extends VoyageRead {
   skills?: { slug: string; name: string; kind: string; version: number; target: string }[];
   /** 计划调整历史（无调整为 [] / 缺失） */
   plan_history?: VoyagePlanEvent[] | null;
+  /** 当前等回答的 AI 提问（paused_ask 时非空） */
+  open_ask?: VoyageMessageRead | null;
+}
+
+// —— 任务对话流：用户建议 / AI 提问与播报（docs/task-system.md）——
+
+export type VoyageMessageKind = 'chat' | 'ask' | 'answer' | 'info';
+
+/** ask 的候选选项（标签 zh/en 两份，渲染处按语言取）。 */
+export interface VoyageAskOption {
+  id: string;
+  zh?: string;
+  en?: string;
+  [extra: string]: unknown;
+}
+
+export interface VoyageMessagePayload {
+  /** kind=ask：提问类别（fatal_step / no_progress / done_criteria / budget / action_ask …） */
+  ask_kind?: string;
+  /** kind=ask：诊断等上下文（结构随 ask_kind 而变，防御式渲染） */
+  context?: Record<string, unknown> | null;
+  /** kind=ask：候选选项 */
+  options?: VoyageAskOption[] | null;
+  /** kind=answer：选中的选项 id */
+  choice?: string | null;
+  [extra: string]: unknown;
+}
+
+export interface VoyageMessageRead {
+  id: string;
+  run_id: string;
+  /** 流内定序 */
+  seq: number;
+  role: 'user' | 'agent';
+  kind: VoyageMessageKind;
+  author_id: string | null;
+  text: string;
+  payload: VoyageMessagePayload | null;
+  /** 仅 kind=ask：open | answered | consumed | superseded（其余恒 none） */
+  status: string;
+  reply_to: string | null;
+  step_id: string | null;
+  /** 仅 kind=chat：被 AI 采纳的时间 */
+  consumed_at: string | null;
+  created_at: string;
 }
 
 /** 任务终端历史日志的一条：结构化日志行（log）或大模型完整输出（llm）。 */
@@ -1702,6 +1748,7 @@ export type ExperimentStatus =
   | 'awaiting_gate'
   | 'setup'
   | 'running'
+  | 'waiting_user'
   | 'reporting'
   | 'done'
   | 'failed'
@@ -3097,6 +3144,23 @@ export const api = {
   /** 任务终端历史日志（结构化日志 + 大模型完整输出），供刷新后 / 事后回看。 */
   getVoyageLogs(id: string): Promise<VoyageTerminalLogRead[]> {
     return request<VoyageTerminalLogRead[]>(`/voyages/${id}/logs`);
+  },
+  /** 任务对话流（用户建议 / AI 提问与播报），按 seq 升序。 */
+  listVoyageMessages(id: string, afterSeq?: number): Promise<VoyageMessageRead[]> {
+    const qs = typeof afterSeq === 'number' ? `?after_seq=${afterSeq}` : '';
+    return request<VoyageMessageRead[]>(`/voyages/${id}/messages${qs}`);
+  },
+  /** 给运行中的任务发一条建议（非阻塞：AI 在下一个决策点参考）。 */
+  postVoyageMessage(id: string, text: string): Promise<VoyageMessageRead> {
+    return requestJson<VoyageMessageRead>(`/voyages/${id}/messages`, 'POST', { text });
+  },
+  /** 回答 AI 的提问并恢复任务（choice='abort' 表示放弃）。 */
+  answerVoyageAsk(
+    id: string,
+    messageId: string,
+    answer: { text?: string; choice?: string; payload?: Record<string, unknown> },
+  ): Promise<VoyageMessageRead> {
+    return requestJson<VoyageMessageRead>(`/voyages/${id}/asks/${messageId}/answer`, 'POST', answer);
   },
 
   // —— Gates ——

--- a/src/frontend/src/lib/ws.ts
+++ b/src/frontend/src/lib/ws.ts
@@ -13,6 +13,7 @@ export type NotificationMessage =
   | { type: 'gate.created'; gate: GateRead }
   | { type: 'gate.decided'; gate: GateRead }
   | { type: 'voyage.status'; voyage_id: string; status: string }
+  | { type: 'voyage.ask'; voyage_id: string; question: string }
   | { type: 'review.message'; session_id: string; project_id?: string; message: ReviewMessageRead }
   | { type: 'idea.status'; idea_id: string; status: string }
   | { type: 'experiment.status'; experiment_id: string; status: string }


### PR DESCRIPTION
> Stacked on #319 (shared extraction). Runtime behavior also needs the backend stack #318 → #320 → #321; against an older backend the page degrades gracefully (empty conversation stream, no ask states).

## What

The experiment detail page gets a new main tab — **运行台 (console)** — the control surface for the interactive PEV loop, per the approved two-layer design (task map + terminal with free-form conversation):

- **Task map** (`TaskMap.tsx`, self-built, zero new deps): horizontal node strip from voyage steps in rank order. Action-specific icons, gate diamonds, plan-adjustment flag separators, obsolete strikethrough (toggleable), running pulse, and a pulsing `?` badge on the step the AI is asking about. Long streaks of passed steps collapse into a count capsule; the strip auto-centers on the active node. Clicking a node shows the shared `StepCard`; otherwise the panel shows the server-status overview (absorbed from the removed Setup tab).
- **Terminal with mixed stream**: the shared `TaskTerminal` renders the conversation inline via `extraEntries` — `AskBlock` (question + option chips + collapsible diagnosis, highlighted while open), `UserNoteBlock` (suggestions/answers, marked once the AI picks them up), `InfoNoteLine` (AI notices) — time-merged with log/LLM entries. Header gains an **AI process | script output** source toggle (the old RunTab `LogPanel` becomes the dark script source) and a **chat-only** filter.
- **Composer** pinned below: suggestions any time ("picked up at the next decision"); when the voyage is `paused_ask` it highlights with the question and quick-choice chips (give-up asks for confirmation), and answering resumes the run.
- `paused_gate` renders the existing `GateCard` in place; `ActivityBar` gets a `paused_ask` banner with a reply shortcut.
- **`VoyageDetailPage` parity**: the generic task page gets the same conversation blocks + composer, so every loop kind shares the experience.
- Plumbing: message/ask types + endpoints in `api.ts`, `paused_ask` / `waiting_user` in status unions + `StatusPill`, `voyage.ask` WS notifications with desktop alerts, tab set becomes console/plan/run/code/report with console as the active-state default.

## Verification

- `tsc --noEmit` clean, `vite build` passes.
- Degradation paths: experiments without a linked voyage → empty state; backend without the message endpoints → 404 treated as an empty stream, composer still rendered but harmless.

Closes #317