### PR TITLE
Point readers at a live instance they can look around

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ run, and PolarisBuddy.
 
 https://github.com/user-attachments/assets/388972c1-7ffa-45f2-94c4-07f388379ba2
 
+### Try it live
+
+A guest account on a running instance, for looking around:
+
+| | |
+| --- | --- |
+| **URL** | http://101.37.174.109:8080 |
+| **Username** | `guest` |
+| **Password** | `zjuguest123` |
+
+**The account is for demonstration only: it is read-only and cannot call any model.** It reaches every
+screen, the admin views included, but nothing it does changes state — creating, editing, deleting and
+uploading are all refused, and no LLM call will run, whether from chat, compilation or the assistant.
+Lab members' details and the registration codes are hidden from it as well. It is there to show what
+the platform looks like, not to do work on it.
+
 ## The research pipeline
 
 Polaris models research as six stages. Each stage produces durable artifacts that the next stage


### PR DESCRIPTION
The demo video shows what Polaris does; this lets someone open it.

Adds a **Try it live** block under the existing Demo section with the instance URL and the guest credentials.

### On stating the limits

The guest account is read-only and cannot call a model, so the section says so plainly rather than leaving a reader to find the limits by hitting them:

> **The account is for demonstration only: it is read-only and cannot call any model.**

### Verified against the running instance before publishing

Rather than trusting that the account behaves as described:

| Check | Result |
| --- | --- |
| Sign in with the published credentials | works |
| `role` / `read_only` | `admin` / `true` — sees the admin views, changes nothing |
| `POST /api/projects` | `403` |
| `GET /api/admin/users` | `403` |
| `GET /api/admin/registration-codes` | `403` |

So every claim in the new paragraph is true of the instance being linked.

### One note for whoever owns the instance

The account's `llm_access` is still `full`; model calls are blocked by the read-only guard added in #308, not by `llm_access`. That is sufficient today. Setting `llm_access` to blocked as well would make it belt-and-braces, and is a one-click change in the admin UI rather than something to do in this PR.