### PR TITLE
A guest sees the topics it was added to, not the whole lab

### DIFF
--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -37,8 +37,16 @@ def is_admin_expr(user_id: uuid.UUID):
 
     这些查询只拿得到 user_id、拿不到 User 对象，所以用 exists 子查询就地判；
     写法与 voyages._visible_filter、libraries.user_visible_paper_stmt 一致。
+
+    只读账号（游客）不算：它顶着 role=admin 是为了看见管理端长什么样，不是为了
+    看见全实验室在做哪些课题。少了这一条，一个演示号打开就是二十几个课题的清单，
+    每个名字都在说这个实验室正在做什么。它该看到的只有别人把它加进去的那些。
     """
-    return select(User.id).where(User.id == user_id, User.role == "admin").exists()
+    return (
+        select(User.id)
+        .where(User.id == user_id, User.role == "admin", User.read_only.is_(False))
+        .exists()
+    )
 
 
 def in_my_projects(project_id_col, user_id: uuid.UUID):

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -56,7 +56,14 @@ def _visible_filter(stmt, user_id: uuid.UUID):
     my_libraries = select(DirectionLibrary.id).where(
         or_(DirectionLibrary.submitted_by == user_id, DirectionLibrary.id.in_(my_curated))
     )
-    is_admin = select(User.id).where(User.id == user_id, User.role == "admin").exists()
+    # 只读账号（游客）不吃这条旁路：课题可见范围已经按成员关系收紧
+    # （见 projects.is_admin_expr），任务这边不跟着收，列表里就会冒出一堆
+    # 它够不着的课题的任务，标题旁边写着「未知课题」。
+    is_admin = (
+        select(User.id)
+        .where(User.id == user_id, User.role == "admin", User.read_only.is_(False))
+        .exists()
+    )
     # 「我发起的」只对有作用域的任务生效：平台级任务（两个 id 都为空）恒为 admin-only。
     mine_scoped = and_(
         VoyageRun.created_by == user_id,
@@ -114,7 +121,7 @@ async def can_view_voyage(
 
     :func:`_visible_filter` 是它的 SQL 镜像，两边必须一起改。
     """
-    if user.role == "admin":
+    if user.role == "admin" and not user.read_only:
         return True
     if run.project_id is None and run.library_id is None:
         return False

--- a/src/backend/tests/test_read_only_topic_scope.py
+++ b/src/backend/tests/test_read_only_topic_scope.py
@@ -1,0 +1,109 @@
+"""只读账号（游客）只看得见别人把它加进去的课题，不是全实验室的课题清单。"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.project import ProjectMember
+from app.models.user import User
+from tests.conftest import register_and_login
+
+
+async def _make_guest(client, admin_token: str) -> str:
+    resp = await client.post(
+        "/api/admin/users",
+        json={
+            "email": "guest@example.com",
+            "password": "gu3st-pass",
+            "display_name": "Guest",
+            "username": "guest",
+            "role": "admin",
+            "read_only": True,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    login = await client.post(
+        "/api/auth/jwt/login", data={"username": "guest", "password": "gu3st-pass"}
+    )
+    assert login.status_code == 200, login.text
+    return login.json()["access_token"]
+
+
+async def _add_guest_to(project_id: str) -> None:
+    async with get_sessionmaker()() as session:
+        guest_id = (
+            await session.execute(select(User.id).where(User.username == "guest"))
+        ).scalar_one()
+        session.add(
+            ProjectMember(
+                project_id=uuid.UUID(project_id), user_id=guest_id, role="member"
+            )
+        )
+        await session.commit()
+
+
+async def test_guest_sees_only_the_topics_it_was_added_to(client):
+    admin = await register_and_login(client)
+    ah = {"Authorization": f"Bearer {admin}"}
+
+    shown = (
+        await client.post(
+            "/api/projects", json={"name": "Shown", "statement": "the demo topic"}, headers=ah
+        )
+    ).json()
+    hidden = await client.post(
+        "/api/projects", json={"name": "Hidden", "statement": "someone else's work"}, headers=ah
+    )
+    assert hidden.status_code in (200, 201)
+
+    guest = await _make_guest(client, admin)
+    gh = {"Authorization": f"Bearer {guest}"}
+
+    # 还没被加进任何课题：一个也看不到（此前顶着 role=admin 能看到全部）
+    listed = await client.get("/api/projects", headers=gh)
+    assert listed.status_code == 200
+    assert listed.json() == []
+
+    await _add_guest_to(shown["id"])
+
+    listed = await client.get("/api/projects", headers=gh)
+    assert listed.status_code == 200
+    names = [p["name"] for p in listed.json()]
+    assert names == ["Shown"], names
+
+    # 够不着的那个点进去也是 404，不是「列表里没有、直连能开」
+    assert (await client.get(f"/api/projects/{hidden.json()['id']}", headers=gh)).status_code == 404
+
+
+async def test_real_admins_still_see_every_topic(client):
+    """收紧的只是只读账号：真管理员照旧全实验室可见，否则任务列表会认不出课题。"""
+    admin = await register_and_login(client)
+    ah = {"Authorization": f"Bearer {admin}"}
+    for name in ("A", "B"):
+        assert (
+            await client.post("/api/projects", json={"name": name, "statement": name}, headers=ah)
+        ).status_code in (200, 201)
+
+    other = await client.post(
+        "/api/admin/users",
+        json={
+            "email": "other@example.com",
+            "password": "0ther-pass",
+            "display_name": "Other Admin",
+            "username": "other_admin",
+            "role": "admin",
+        },
+        headers=ah,
+    )
+    assert other.status_code == 201, other.text
+    token = (
+        await client.post(
+            "/api/auth/jwt/login", data={"username": "other_admin", "password": "0ther-pass"}
+        )
+    ).json()["access_token"]
+
+    listed = await client.get("/api/projects", headers={"Authorization": f"Bearer {token}"})
+    assert listed.status_code == 200
+    assert {p["name"] for p in listed.json()} >= {"A", "B"}


### PR DESCRIPTION
Closes #324

The guest account is `role=admin`, and `is_admin_expr` grants admins every topic in the lab. A demo login opened onto **twenty-five topics**, each name saying what this lab is currently working on.

### Change

Read-only accounts no longer take that bypass. They see the topics someone put them in — which makes "what does the demo show" a **data** decision (add the account to a project) rather than a name written into the code.

### Why voyage visibility moved with it

Leaving it would have been worse than not doing this at all. The task list is platform-wide for admins, so a guest would see tasks belonging to topics it can no longer reach, each labelled *"unknown topic"* — precisely the inconsistency `in_my_projects` documents itself as existing to prevent. The two are one decision, not two.

### Untouched on purpose

| | Why |
| --- | --- |
| **Admin screens** | `require_admin` reads `role`, not this expression — a guest still sees what the admin UI looks like, which is the point of the account |
| **Libraries** | independent of topics since P9b, shared lab-wide, and the literature features are most of what a demo has to show |
| **`can_manage_project`** | a write permission; writes are already refused at the read-only gate |

### Verification

- Full backend suite: **1174 passed, 0 failed.** (`test_experiment_iterate::test_debug_limit_terminates`, flaky on `main` through several earlier PRs, passed in this run too.)
- New tests pin both directions: a guest with no membership sees an empty list and gets `404` on a topic it cannot reach; after being added it sees exactly that one; and a real admin still sees every topic.
- Applied on the running instance already: the demo account was added to **Recursive Self-Improvement** and is a member of nothing else.