### PR TITLE
Let the question say which topic it is about

### DIFF
--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Icon } from '../../components/ui/Icon';
 import { PolarisMark } from '../../components/ui/PolarisLogo';
@@ -454,7 +454,27 @@ export function AssistantPanel({
   const [convId, setConvId] = useState<string | null>(null);
   // dock 形态下会话列表是常驻一栏（不再是头部时钟弹层）；overlay 形态屏幕太窄，
   // 仍然用弹层。
-  const [railOpen, setRailOpen] = useState(true);
+  //
+  // **默认收起**：打开 Buddy 是为了问一句话，不是为了翻旧账。两栏一起铺开会把本来
+  // 就窄的对话区再切一刀，而历史一天用不上一次。手动开过就记住，别每次都要再点。
+  const [railOpen, setRailOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('polaris.buddyRailOpen') === '1';
+    } catch {
+      return false;
+    }
+  });
+  const toggleRail = useCallback(() => {
+    setRailOpen((o) => {
+      const next = !o;
+      try {
+        localStorage.setItem('polaris.buddyRailOpen', next ? '1' : '0');
+      } catch {
+        /* 隐私模式：仅本次会话生效 */
+      }
+      return next;
+    });
+  }, []);
   const [historyOpen, setHistoryOpen] = useState(false);
   //: 发完一轮之后标题才生成，列表要跟着刷新一次
   const [railRefresh, setRailRefresh] = useState(0);
@@ -469,11 +489,24 @@ export function AssistantPanel({
   const abortRef = useRef<(() => void) | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
-  // 对话里的「项目」就是平台里的课题。**默认不绑**：绑上之后检索范围就收窄到这个
-  // 课题，而用户多数问题是跨课题的；想收窄时自己勾一下，比默认收窄再去发现「怎么
+  // 对话里的「项目」就是平台里的课题。**默认不选**：选了之后检索范围就收窄到这个
+  // 课题，而用户多数问题是跨课题的；想收窄时自己挑一个，比默认收窄再去发现「怎么
   // 查不到别的库」要好。
-  const { currentProject } = useProject();
-  const [bindProject, setBindProject] = useState(false);
+  //
+  // 以前这里是个开关，只能绑「你现在正在看的那个课题」——想问另一个课题，得先把整个
+  // 界面切过去。现在存的是选中的课题 id，输入框上方那个按钮直接挑。
+  const { projects } = useProject();
+  const [topicId, setTopicId] = useState<string | null>(null);
+  const [topicOpen, setTopicOpen] = useState(false);
+  const [topicQuery, setTopicQuery] = useState('');
+  const topic = useMemo(
+    () => projects.find((p) => p.id === topicId) ?? null,
+    [projects, topicId],
+  );
+  const topicMatches = useMemo(() => {
+    const q = topicQuery.trim().toLowerCase();
+    return q ? projects.filter((p) => p.name.toLowerCase().includes(q)) : projects;
+  }, [projects, topicQuery]);
   // chat = 默认（行为一个字没变）；plan = 只调研出计划等人点头；goal = 带着一个持续目标
   const [mode, setMode] = useState<'chat' | 'plan' | 'goal'>('chat');
   const [goal, setGoal] = useState('');
@@ -529,7 +562,9 @@ export function AssistantPanel({
         const messages = await api.getAssistantMessages(id);
         setConvId(id);
         setHistoryOpen(false);
-        // 会话上存着的课题才是这场对话真正的作用域，跟着切过去
+        // 会话上存着的课题才是这场对话真正的作用域，跟着切过去。
+        // （这句注释以前是空头支票：写着「跟着切」，却没有一行代码在切。）
+        setTopicId(conversations.find((c) => c.id === id)?.project_id ?? null);
         setTurns(
           messages
             // 一轮会落成几条消息：assistant（正文/调用）+ 携带工具结果的那条。
@@ -603,7 +638,7 @@ export function AssistantPanel({
         // 那条路上的权限校验一点没少。用户可以关掉。
         page:
           contextOn && pageContext ? { kind: pageContext.kind, id: pageContext.id } : undefined,
-        projectId: bindProject ? (currentProject?.id ?? null) : null,
+        projectId: topicId,
         mode,
         goal: mode === 'goal' ? goal : undefined,
         onMeta: (meta) => setModel(meta.model),
@@ -628,7 +663,7 @@ export function AssistantPanel({
       },
     );
     },
-    [busy, convId, contextOn, pageContext, currentProject, bindProject, mode, goal],
+    [busy, convId, contextOn, pageContext, topicId, mode, goal],
   );
 
   const send = useCallback(() => {
@@ -725,7 +760,7 @@ export function AssistantPanel({
         {variant === 'dock' ? (
           <button
             className="icon-btn"
-            onClick={() => setRailOpen((o) => !o)}
+            onClick={toggleRail}
             title={tr('会话列表', 'Conversations')}
             style={{ color: railOpen ? 'var(--accent)' : undefined }}
           >
@@ -940,21 +975,29 @@ export function AssistantPanel({
             <Icon name="plus" size={13} />
           </button>
 
-          {bindProject && currentProject ? (
-            <span
-              className="row gap6 hoverable"
-              style={{ alignItems: 'center', cursor: 'pointer', minWidth: 0 }}
-              onClick={() => setBindProject(false)}
-              title={tr('只在这个课题的语料里查；点掉恢复全部', 'Restricted to this topic; click to clear')}
-            >
-              <Icon name="layers" size={12} />
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {currentProject.name}
-              </span>
+          {/* 课题选择：和加号并排。以前这里是一行说明文字，只告诉你现在查的是什么，
+              要换得去别处切；现在它自己就是入口——点开挑一个，再点「全部文献库」放开。 */}
+          <button
+            className="buddy-scope"
+            onClick={() => {
+              setTopicQuery('');
+              setTopicOpen((o) => !o);
+            }}
+            aria-haspopup="listbox"
+            aria-expanded={topicOpen}
+            title={
+              topic
+                ? `${tr('只在这个课题的语料里查', 'Restricted to this topic')} · ${topic.name}`
+                : tr('选一个课题来收窄检索范围', 'Pick a topic to narrow the search')
+            }
+            data-picked={topic ? '1' : undefined}
+          >
+            <Icon name="layers" size={12} />
+            <span className="buddy-scope-label">
+              {topic ? topic.name : tr('全部文献库', 'All libraries')}
             </span>
-          ) : (
-            <span style={{ color: 'var(--text-4)' }}>{tr('全部文献库', 'All libraries')}</span>
-          )}
+            <Icon name="chevDown" size={11} />
+          </button>
 
           {mode !== 'chat' && (
             <>
@@ -977,6 +1020,75 @@ export function AssistantPanel({
             </span>
           )}
 
+          {topicOpen && (
+            <>
+              <div onClick={() => setTopicOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 49 }} />
+              <div className="buddy-scope-menu" role="listbox">
+                {/* 课题可能有几十个，光靠滚的找不到——列表一长就先给个搜索框 */}
+                {projects.length > 7 && (
+                  <input
+                    className="input sm"
+                    autoFocus
+                    value={topicQuery}
+                    onChange={(e) => setTopicQuery(e.target.value)}
+                    placeholder={tr('搜课题…', 'Search topics…')}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') setTopicOpen(false);
+                      // 搜到只剩一个时回车直接选它
+                      const only = topicMatches.length === 1 ? topicMatches[0] : undefined;
+                      if (e.key === 'Enter' && only) {
+                        setTopicId(only.id);
+                        setTopicOpen(false);
+                      }
+                    }}
+                    style={{ marginBottom: 4 }}
+                  />
+                )}
+                <div className="buddy-scope-list">
+                  <button
+                    className="buddy-scope-item"
+                    role="option"
+                    aria-selected={!topicId}
+                    onClick={() => {
+                      setTopicId(null);
+                      setTopicOpen(false);
+                    }}
+                  >
+                    <Icon name="book" size={13} />
+                    <span className="buddy-scope-item-label">{tr('全部文献库', 'All libraries')}</span>
+                    {!topicId && <Icon name="check" size={12} />}
+                  </button>
+                  {projects.length > 0 && <div className="hr" style={{ margin: '4px 2px' }} />}
+                  {topicMatches.map((p) => (
+                    <button
+                      key={p.id}
+                      className="buddy-scope-item"
+                      role="option"
+                      aria-selected={p.id === topicId}
+                      title={p.name}
+                      onClick={() => {
+                        setTopicId(p.id);
+                        setTopicOpen(false);
+                      }}
+                    >
+                      <Icon name="layers" size={13} />
+                      <span className="buddy-scope-item-label">{p.name}</span>
+                      {p.id === topicId && <Icon name="check" size={12} />}
+                    </button>
+                  ))}
+                  {/* 一个课题都没有和「搜不到」是两回事，分开说 */}
+                  {topicMatches.length === 0 && (
+                    <div className="buddy-scope-empty">
+                      {projects.length === 0
+                        ? tr('还没有可见的课题', 'No topics you can see yet')
+                        : tr('没有匹配的课题', 'No topic matches that')}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
           {plusOpen && (
             <>
               <div onClick={() => setPlusOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 49 }} />
@@ -996,15 +1108,6 @@ export function AssistantPanel({
                 }}
                 onClick={() => setPlusOpen(false)}
               >
-                {currentProject && (
-                  <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => setBindProject((b) => !b)}>
-                    <Icon name="layers" size={13} />
-                    <span style={{ flex: 1, textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                      {tr('只查课题', 'Work in a topic')} · {currentProject.name}
-                    </span>
-                    {bindProject && <Icon name="check" size={12} />}
-                  </button>
-                )}
                 <button className="btn btn-ghost sm" style={{ justifyContent: 'flex-start' }} onClick={() => setMode(mode === 'plan' ? 'chat' : 'plan')}>
                   <Icon name="bulb" size={13} />
                   <span style={{ flex: 1, textAlign: 'left' }}>{tr('计划模式 · 先出方案再动手', 'Plan mode · propose before doing')}</span>

--- a/src/frontend/src/features/assistant/__tests__/scopePicker.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/scopePicker.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/* ============================================================
+   输入框上方那一行：加号 + 课题选择。
+
+   这三条都是编译器看不见的回归——把默认值改回 true、把选择器塞进加号菜单、或者
+   让课题重新变成一行只读文字，类型全都照样过。所以在源码层面钉住。
+   ============================================================ */
+
+const source = readFileSync(
+  fileURLToPath(new URL('../AssistantPanel.tsx', import.meta.url)),
+  'utf-8',
+);
+
+/** 从某一行开始数括号的开合，找出这一层在哪一行收口。 */
+function blockEnd(lines: string[], openIndex: number, open: RegExp, close: RegExp): number {
+  let depth = 0;
+  for (let i = openIndex; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    depth += (line.match(open) ?? []).length;
+    depth -= (line.match(close) ?? []).length;
+    if (i > openIndex && depth === 0) return i;
+  }
+  return -1;
+}
+
+describe('会话侧栏的默认状态', () => {
+  it('默认收起：只有存过 1 才展开', () => {
+    // 打开 Buddy 是为了问一句话，不是翻旧账；两栏一起铺开会把对话区再切一刀。
+    expect(source).toContain("localStorage.getItem('polaris.buddyRailOpen') === '1'");
+    // 反面：别再出现无条件展开的初值
+    expect(source).not.toContain('useState(true);\n  const [historyOpen');
+  });
+
+  it('手动开合会被记住', () => {
+    expect(source).toContain("localStorage.setItem('polaris.buddyRailOpen'");
+  });
+});
+
+describe('课题选择', () => {
+  const lines = source.split('\n');
+  const plusButton = lines.findIndex((l) => l.includes('setPlusOpen((o) => !o)'));
+  const scopeButton = lines.findIndex((l) => l.includes('className="buddy-scope"'));
+
+  it('是一枚按钮，和加号并排在输入框上方', () => {
+    expect(plusButton).toBeGreaterThan(0);
+    expect(scopeButton).toBeGreaterThan(plusButton);
+    // 中间不能隔着输入框：两者必须在同一行容器里
+    const composer = lines.findIndex((l) => l.includes('padding: 12, borderTop:'));
+    expect(composer).toBeGreaterThan(0);
+    expect(plusButton).toBeGreaterThan(composer);
+  });
+
+  it('加号菜单里不再有「只查课题」——那件事归选择器了', () => {
+    const menuStart = lines.findIndex((l) => l.includes('{plusOpen && ('));
+    expect(menuStart).toBeGreaterThan(0);
+    const menuEnd = blockEnd(lines, menuStart, /\(/g, /\)/g);
+    expect(menuEnd).toBeGreaterThan(menuStart);
+    const menu = lines.slice(menuStart, menuEnd).join('\n');
+    expect(menu).not.toContain('setTopicId');
+    expect(menu).not.toContain('只查课题');
+  });
+
+  it('选中的课题就是这一轮问话的作用域', () => {
+    // 以前是「绑不绑当前课题」的开关，只能绑你正在看的那个；现在存的是选中的 id
+    expect(source).toContain('projectId: topicId,');
+    expect(source).not.toContain('bindProject');
+  });
+
+  it('载入历史会话时采用它自己的课题', () => {
+    // 这句注释以前是空头支票：写着「跟着切」，却没有一行代码在切
+    expect(source).toContain('setTopicId(conversations.find((c) => c.id === id)?.project_id ?? null)');
+  });
+});

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1485,3 +1485,87 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* —— PolarisBuddy 输入框上方的课题选择 ——
+   和加号并排的一枚小按钮。没选时是安静的灰字（「全部文献库」是常态，不必强调），
+   选了才染上强调色——扫一眼就知道这次问话被收窄到哪。 */
+.buddy-scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 220px;
+  padding: 2px 7px;
+  border: 0.5px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-4);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.buddy-scope:hover {
+  background: var(--surface-3);
+  color: var(--text-2);
+}
+.buddy-scope[data-picked] {
+  border-color: var(--accent-soft);
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+.buddy-scope-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.buddy-scope-menu {
+  position: absolute;
+  left: 30px;          /* 贴着课题按钮，不压住加号 */
+  bottom: 34px;        /* 弹在上方：下面就是输入框 */
+  z-index: 50;
+  width: 268px;
+  padding: 6px;
+  background: var(--surface);
+  border: 0.5px solid var(--border-2);
+  border-radius: 12px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
+}
+.buddy-scope-list {
+  max-height: 268px;
+  overflow-y: auto;
+}
+.buddy-scope-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+.buddy-scope-item:hover {
+  background: var(--surface-2);
+}
+.buddy-scope-item[aria-selected='true'] {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+.buddy-scope-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.buddy-scope-empty {
+  padding: 10px 8px;
+  font-size: 12px;
+  color: var(--text-4);
+}


### PR DESCRIPTION
Closes #326

### The topic becomes a choice

The `+` menu carried **"只查课题 · \<current topic\>"** — a checkbox bound to whichever topic the surrounding app happened to be showing. Asking about a different topic meant navigating the whole UI there and coming back. But the scope of a question belongs to the *question*, not to the page behind the panel.

It is now a button of its own beside the `+`:

- Opens the list of topics you can see — the same `GET /projects` the app uses, so it respects visibility (a guest sees only its own).
- **Searchable**, because this lab has twenty-five topics and scrolling will not find one. Type until one match is left, press Enter, done.
- Not selected stays the default and now says so plainly — *All libraries*, same place, muted. Picking one tints the button, so a glance tells you the question was narrowed and to what.

### The rail starts collapsed

Opening Buddy is usually about asking one thing, not going through old conversations. Two columns split an already narrow panel for a list wanted less than once a day. Open it yourself and that is remembered (`polaris.buddyRailOpen`).

### A comment that was never true

`loadConversation` claimed the conversation's stored topic *"跟着切过去"*. No line of code switched it. Now one does — loading a conversation adopts its scope, which is the only reading under which the old comment was ever right.

### On the tests

Source-level assertions rather than rendering. Every one of these regressions typechecks cleanly: a default flipped back to `true`, the picker folded back into the `+` menu, the topic reduced to read-only text. This follows the convention `panelStructure.test.ts` already set for exactly that reason.

**Both were reverse-verified** — reintroduce the regression and the matching test fails:

| Simulated regression | Result |
| --- | --- |
| `useState(true)` for the rail | `× 默认收起：只有存过 1 才展开` |
| topic option back in the `+` menu | `× 加号菜单里不再有「只查课题」` |

Restored, **42 frontend tests pass**, and the frontend image builds (`tsc --noEmit && vite build`).