### PR TITLE
fix(frontend): console composer typing and stale ask state

### DIFF
--- a/src/frontend/src/features/voyages/shared/ConsoleComposer.tsx
+++ b/src/frontend/src/features/voyages/shared/ConsoleComposer.tsx
@@ -63,14 +63,31 @@ export function ConsoleComposer({
   const answerMutation = useMutation({
     mutationFn: (body: { text?: string; choice?: string }) =>
       api.answerVoyageAsk(voyageId, openAsk!.id, body),
-    onSuccess: (message) => {
+    onSuccess: (message, _body) => {
+      // 本地立刻把提问置为已回答（SSE 的 ask.answered 只带回答消息，
+      // 不带更新后的提问行；不改缓存的话界面会一直卡在「等你回复」）
+      const askId = message.reply_to;
+      if (askId) {
+        queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', voyageId], (old) =>
+          (old ?? []).map((m) => (m.id === askId ? { ...m, status: 'answered' } : m)),
+        );
+      }
       afterSend(message);
       setText('');
       setChoice(null);
       toast(tr('已回复，任务继续', 'Answered — the task resumes'), 'ok');
     },
-    onError: (e) =>
-      toast(`${tr('回复失败：', 'Reply failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+    onError: (e) => {
+      const notOpen = e instanceof Error && e.message.includes('ASK_NOT_OPEN');
+      if (notOpen) {
+        // 提问已被回答/作废（可能在别的窗口答过）：以服务端为准刷新，自愈过期界面
+        void queryClient.invalidateQueries({ queryKey: ['voyage-messages', voyageId] });
+        void queryClient.invalidateQueries({ queryKey: ['voyage', voyageId] });
+        toast(tr('这个问题已经回复过了，界面已刷新', 'Already answered — refreshed the view'), 'info');
+        return;
+      }
+      toast(`${tr('回复失败：', 'Reply failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+    },
   });
 
   const busy = suggestMutation.isPending || answerMutation.isPending;
@@ -147,6 +164,7 @@ export function ConsoleComposer({
           className="textarea"
           rows={2}
           value={text}
+          onChange={(e) => setText(e.target.value)}
           disabled={disabled || busy}
           placeholder={
             disabled

--- a/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
+++ b/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
@@ -37,11 +37,19 @@ export function useVoyageMessages(voyageId: string | null) {
   const handleExtraEvent = useCallback(
     (event: string, data: unknown) => {
       if (event !== 'message' && event !== 'ask.created' && event !== 'ask.answered') return;
-      const payload = data as { message?: VoyageMessageRead };
+      const payload = data as { message?: VoyageMessageRead; ask_id?: string };
       if (!payload?.message) return;
       queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', id], (old) =>
         upsert(old, payload.message!),
       );
+      if (event === 'ask.answered' && payload.ask_id) {
+        // 事件只带回答消息；被回答的提问行要就地翻状态，否则界面卡在「等你回复」
+        queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', id], (old) =>
+          (old ?? []).map((m) =>
+            m.id === payload.ask_id && m.status === 'open' ? { ...m, status: 'answered' } : m,
+          ),
+        );
+      }
       if (event !== 'message') {
         // ask 状态变化伴随任务状态变化（paused_ask / executing）：刷详情
         void queryClient.invalidateQueries({ queryKey: ['voyage', id] });


### PR DESCRIPTION
Two fixes for the experiment console conversation flow (#322), both reported in first real use:

1. **Composer could not be typed into** — the controlled textarea had no `onChange`, so React rendered it read-only. One line: wire `onChange` to the state setter.
2. **Answered questions stayed in "waiting for your reply"** — the `ask.answered` SSE event carries only the answer message, so the cached ask row kept `status: "open"`; the composer kept showing the old question and a second answer attempt dead-ended with 409 `ASK_NOT_OPEN`. Now:
   - answer success flips the ask's status in the message cache immediately (`reply_to` links back to the ask);
   - the `ask.answered` SSE handler also flips it by `ask_id` (covers other open windows);
   - a 409 `ASK_NOT_OPEN` refetches messages + voyage detail and tells the user the question was already answered, instead of leaving a stuck view.

`tsc --noEmit` and `vite build` pass.

Closes #329