### PR TITLE
fix(voyage): scope plan-edit actions to the run's domain, heal zero-run analyze

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -1703,7 +1703,15 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             .all()
         )
         if not runs:
-            raise ValueError("没有可分析的运行轮次")
+            # 计划调整可能把本轮 run 作废/漏排（如换方案后直接落到 analyze）。
+            # 报错会触发又一轮 LLM 重排（实测螺旋出跨域乱步骤）；确定性自愈：
+            # 发 plan_signal 让分支表补一轮 run + analyze，从头跑起。
+            await ctx.log("没有可分析的运行轮次，自动补一轮运行")
+            return {
+                "skipped": True,
+                "reason": "no_runs",
+                "plan_signal": {"decision": "continue", "next_round": 1},
+            }
         run = runs[-1]
         history = [
             {

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -551,8 +551,15 @@ def _extract_json(content: str) -> Any:
     return json.loads(content[start : end + 1])
 
 
-def validate_steps(data: Any) -> list[dict[str, Any]]:
-    """校验 {"steps": [...]} schema，返回规范化步骤列表；非法则抛 ValueError。"""
+def validate_steps(
+    data: Any, *, allowed_actions: frozenset[str] | set[str] | None = None
+) -> list[dict[str, Any]]:
+    """校验 {"steps": [...]} schema，返回规范化步骤列表；非法则抛 ValueError。
+
+    ``allowed_actions``：进一步收窄可用动作域（None = 整个注册表）。计划调整时
+    必须按任务的动作族收窄——线上实测过 LLM 给实验任务插入 wiki/每日抓论文动作，
+    步骤"通过"了但干的完全是别的领域的事，终端里满屏「cs.AI 抓到 N 篇」。
+    """
     if not isinstance(data, dict) or not isinstance(data.get("steps"), list):
         raise ValueError('expected {"steps": [...]}')
     steps: list[dict[str, Any]] = []
@@ -567,6 +574,11 @@ def validate_steps(data: Any) -> list[dict[str, Any]]:
             raise ValueError(f"step {i} missing title")
         if action not in actions:
             raise ValueError(f"step {i} has unknown action: {action!r}")
+        if allowed_actions is not None and action not in allowed_actions:
+            raise ValueError(
+                f"step {i} action {action!r} 不在本任务可用的动作域内，"
+                f"只能使用：{', '.join(sorted(allowed_actions))}"
+            )
         if not isinstance(params, dict):
             raise ValueError(f"step {i} params is not an object")
         requires_gate = raw.get("requires_gate")
@@ -621,6 +633,33 @@ def _expand_workflow(slug: str, workflows: list[dict[str, Any]]) -> list[dict[st
     return validate_steps({"steps": entry.get("steps") or []})
 
 
+# 计划调整时不分领域都可用的通用动作（推理/等待类，无副作用域）
+_GENERIC_EDIT_ACTIONS = frozenset({"sleep", "llm.complete", "artifact.write"})
+
+
+def allowed_edit_actions(run: VoyageRun) -> frozenset[str]:
+    """计划调整（replan/on_result）可用的动作域：现有计划的动作族 + 通用动作。
+
+    动作族按前缀推导（experiment. / wiki. / …）：实验任务的调整只能继续用
+    experiment.* 与通用动作，不能引入 wiki/daily 等其他领域的平台动作——
+    那些动作各有自己的任务类型与作用域假设，跨域插入会拿着错误的
+    checkpoint 干别的领域的事。计划无前缀信息（纯通用动作）时不设限。
+    """
+    prefixes: set[str] = set()
+    for step in run.plan or []:
+        if not isinstance(step, dict):
+            continue
+        action = str(step.get("action") or "")
+        if "." in action:
+            prefixes.add(action.split(".", 1)[0] + ".")
+    registry = frozenset(known_actions())
+    if not prefixes:
+        return registry
+    allowed = {a for a in registry if any(a.startswith(p) for p in prefixes)}
+    allowed |= _GENERIC_EDIT_ACTIONS & registry
+    return frozenset(allowed)
+
+
 class Navigator:
     def __init__(self, llm: LLMRouter) -> None:
         self._llm = llm
@@ -631,6 +670,7 @@ class Navigator:
         system: str,
         user_prompt: str,
         workflows: list[dict[str, Any]] | None = None,
+        allowed_actions: frozenset[str] | None = None,
     ) -> list[dict[str, Any]]:
         last_error: Exception | None = None
         for _attempt in range(_MAX_ATTEMPTS):
@@ -649,7 +689,7 @@ class Navigator:
                 data = _extract_json(result.content)
                 if workflows and isinstance(data, dict) and data.get("use_skill"):
                     return _expand_workflow(str(data["use_skill"]), workflows)
-                return validate_steps(data)
+                return validate_steps(data, allowed_actions=allowed_actions)
             except (ValueError, json.JSONDecodeError) as e:
                 last_error = e
         raise NavigatorError(f"navigator produced invalid plan: {last_error}")
@@ -699,7 +739,8 @@ class Navigator:
         """
         if run.kind == "idea_proposal":
             return proposal_replan(run, failed_step, diagnosis)
-        system = REPLAN_SYSTEM_PROMPT % {"actions": ", ".join(sorted(known_actions()))}
+        allowed = allowed_edit_actions(run)
+        system = REPLAN_SYSTEM_PROMPT % {"actions": ", ".join(sorted(allowed))}
         user_prompt = (
             f"目标：{run.goal}\n"
             f"原计划：{json.dumps(run.plan or [], ensure_ascii=False, default=str)}\n"
@@ -708,7 +749,7 @@ class Navigator:
         )
         if user_guidance:
             user_prompt += f"\n用户对这次调整的补充指示（务必优先遵循）：\n{user_guidance}"
-        return await self._ask_for_steps(run, system, user_prompt)
+        return await self._ask_for_steps(run, system, user_prompt, allowed_actions=allowed)
 
     async def on_result(
         self,
@@ -720,11 +761,12 @@ class Navigator:
     ) -> dict[str, Any]:
         """loop 模式失败回灌：LLM 产出**计划编辑**而非替换尾部（docs/voyage-loop.md §5.3）。
 
-        输出经 validate_plan_edit 严格校验（schema / 动作注册表 / 新增节点上限 /
-        新节点必须带验收）；连续非法抛 NavigatorError（engine 转 paused_error）。
+        输出经 validate_plan_edit 严格校验（schema / 动作域（按任务动作族收窄）/
+        新增节点上限 / 新节点必须带验收）；连续非法抛 NavigatorError。
         ``user_guidance``：用户在任务对话流里的未消费建议（优先遵循）。
         """
-        system = PLAN_EDIT_SYSTEM_PROMPT % {"actions": ", ".join(sorted(known_actions()))}
+        allowed = allowed_edit_actions(run)
+        system = PLAN_EDIT_SYSTEM_PROMPT % {"actions": ", ".join(sorted(allowed))}
         user_prompt = (
             f"目标：{run.goal}\n"
             f"当前计划状态：\n{plan_state}\n"
@@ -748,7 +790,10 @@ class Navigator:
             )
             try:
                 data = _extract_json(result.content)
-                return validate_plan_edit(data, step_validator=validate_steps)
+                return validate_plan_edit(
+                    data,
+                    step_validator=lambda d: validate_steps(d, allowed_actions=allowed),
+                )
             except (ValueError, json.JSONDecodeError) as e:
                 last_error = e
         raise NavigatorError(f"navigator produced invalid plan edit: {last_error}")

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -305,6 +305,37 @@ async def test_analyze_ask_pauses_then_guidance_continues(
     assert detail["iteration_state"]["stopped_reason"] == "用户指示收尾（test）"
 
 
+async def test_analyze_without_runs_self_heals(client, queue_stub, fake_ssh, bus_recorder):
+    """analyze 在零轮次上不再报错（报错会触发 LLM 重排、实测螺旋出跨域乱步骤）：
+    确定性发 plan_signal 补一轮 run + analyze，从头跑起。"""
+    from sqlalchemy import delete
+
+    from app.agents.voyage.actions import ActionContext
+    from app.agents.voyage.actions_experiment import experiment_analyze
+    from app.models.experiment import ExperimentRun as ExperimentRunModel
+
+    project_id, headers, exp_id, voyage_id = await _launch_experiment(client)
+    await _drive_pipeline(
+        client, headers, project_id, voyage_id, _router_with(_FixedReflectionProvider("stop"))
+    )
+
+    async with get_sessionmaker()() as session:
+        await session.execute(
+            delete(ExperimentRunModel).where(
+                ExperimentRunModel.experiment_id == uuid.UUID(exp_id)
+            )
+        )
+        await session.commit()
+        run = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        ctx = ActionContext(
+            run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint or {})
+        )
+        observation = await experiment_analyze(ctx, {})
+
+    assert observation["skipped"] is True and observation["reason"] == "no_runs"
+    assert observation["plan_signal"] == {"decision": "continue", "next_round": 1}
+
+
 async def test_max_runs_truncates_iteration(client, queue_stub, fake_ssh, bus_recorder):
     """达 budget.max_runs 截断（指标仍在提升、decision 一直 improve）。"""
     fake_ssh.run_logs = [metric_log(0.7), metric_log(0.8)]

--- a/src/backend/tests/test_voyage_loop.py
+++ b/src/backend/tests/test_voyage_loop.py
@@ -139,6 +139,39 @@ class _RowStub:
         self.status = status
 
 
+def test_plan_edit_actions_scoped_to_run_domain():
+    """计划调整的动作域按任务动作族收窄：实验任务只能用 experiment.* + 通用动作，
+    不能插入 wiki/daily 等其他领域的平台动作（线上实测 LLM 干过，终端满屏抓论文）。"""
+    from app.agents.voyage.navigator import allowed_edit_actions, experiment_plan
+
+    class _RunStub:
+        plan = experiment_plan(None)
+
+    allowed = allowed_edit_actions(_RunStub())
+    assert any(a.startswith("experiment.") for a in allowed)
+    assert not any(a.startswith("wiki.") for a in allowed)
+    assert not any(a.startswith("daily.") for a in allowed)
+    assert "sleep" in allowed  # 通用动作不分领域
+
+    # 校验器按动作域拒绝越域步骤
+    step = {
+        "title": "检查日志文件",
+        "action": "wiki.search_candidates",
+        "params": {},
+        "acceptance": "完成",
+    }
+    with pytest.raises(ValueError, match="动作域"):
+        validate_steps({"steps": [step]}, allowed_actions=allowed)
+
+    # 无前缀信息的计划（纯通用动作）不设限
+    class _GenericRunStub:
+        plan = [{"title": "t", "action": "sleep", "params": {}}]
+
+    from app.agents.voyage.actions import known_actions
+
+    assert allowed_edit_actions(_GenericRunStub()) == frozenset(known_actions())
+
+
 def test_experiment_node_failure_semantics():
     """experiment mode=loop 的节点级失败语义（docs/voyage-loop.md §7）：
     run/smoke 硬停（on_failure=fail + max_attempts=1，防盲目重跑烧算力/重复修复循环），


### PR DESCRIPTION
Fixes the two loop-quality bugs from the first live experiment (#331):

1. **Action-domain scoping for plan adjustments.** `allowed_edit_actions(run)` derives the run's action families from its own plan (prefix rule: `experiment.*`, `wiki.*`, …) and adds generic no-domain actions (`sleep`, `llm.complete`, `artifact.write`). Navigator `on_result` (loop edits) and `replan` (template) now put exactly this allowlist in the prompt **and** enforce it in `validate_steps` — an out-of-domain step fails validation with the allowed list in the error, so the LLM retry can self-correct. Plans with no domain prefix (generic demos) keep the full registry, as does free-form initial planning.
2. **Zero-run analyze self-heal.** `experiment.analyze` with no run rounds used to raise (→ step failure → another LLM replan → the spiral that produced the cross-domain step). It now logs and returns `plan_signal {continue, next_round: 1}`; the idempotent branch table appends a fresh run + analyze round deterministically.

Tests: new `test_plan_edit_actions_scoped_to_run_domain` and `test_analyze_without_runs_self_heals`; 82 passed across the loop/experiment/ask suites.

Closes #331