### PR TITLE
fix(experiment): make user guidance reach every decision point

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -50,10 +50,11 @@ from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperWiki
 from app.models.ssh_credential import SSHCredential
-from app.models.voyage import VoyageRun
+from app.models.voyage import VoyageRun, VoyageStep
 from app.services import experiment_settings as experiment_settings_service
 from app.services import experiments as experiments_service
 from app.services import ssh_exec
+from app.services import voyage_messages as messages_service
 from app.services.figure_annotate import prepare_image_for_llm
 from app.services.libraries import (
     dedupe_member_rows,
@@ -568,6 +569,47 @@ async def _mark_attention(ctx: ActionContext, reason: str) -> None:
             )
         )
         await session.commit()
+
+
+def _guidance_line(params: dict[str, Any]) -> str:
+    """params["user_guidance"] → prompt 注入行（无建议时空串）。
+
+    每个 LLM 决策点都必须带上这一行——线上实测过：建议只接了 smoke/analyze，
+    用户对着装依赖循环连发建议全被无视（docs/task-system.md）。
+    """
+    guidance = params.get("user_guidance")
+    if not guidance:
+        return ""
+    return f"用户指示（务必优先遵循）：{json.dumps(guidance, ensure_ascii=False)}\n"
+
+
+async def _refresh_user_guidance(ctx: ActionContext, params: dict[str, Any]) -> str:
+    """长动作（setup/smoke 修复循环）每一轮把对话流里**新到**的建议并入 guidance。
+
+    引擎只在步骤开始时注入一次；装依赖/修代码动辄几十分钟，期间用户发的建议
+    不该等到下一个步骤边界才被看见。消费标记与「并入步骤 params」同一事务提交
+    （resume 重放不会重复注入也不会丢建议）；失败静默降级为用已有 guidance。
+    返回最新的 prompt 注入行。
+    """
+    try:
+        async with get_sessionmaker()() as session:
+            pending = await messages_service.pending_chat_messages(session, ctx.run.id)
+            if pending:
+                merged = list(params.get("user_guidance") or []) + [m.text for m in pending]
+                step = (
+                    await session.get(VoyageStep, ctx.step_id) if ctx.step_id else None
+                )
+                if step is not None:
+                    step_params = dict(step.params or {})
+                    step_params["user_guidance"] = merged
+                    step.params = step_params
+                messages_service.mark_chat_consumed(pending, step_id=ctx.step_id)
+                await session.commit()
+                params["user_guidance"] = merged
+                await ctx.log(f"已收到你的 {len(pending)} 条建议，立即用于当前修复")
+    except Exception:  # noqa: BLE001 — 建议拉取失败不能影响修复主流程
+        pass
+    return _guidance_line(params)
 
 
 def _guarded(func):
@@ -1122,6 +1164,7 @@ async def experiment_plan(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                 f"想法详情：\n{(idea.content or '')[:4000]}\n"
                 f"{_proposal_context(idea)}\n"
                 f"相关 wiki 摘要：\n{wiki_context}\n\n"
+                f"{_guidance_line(params)}"
                 f"预算约束：{json.dumps(experiment.budget or {}, ensure_ascii=False)}\n"
                 f"GPU 提示：{gpu_hint or '（无）'}"
             )
@@ -1245,6 +1288,7 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         if not isinstance(files, dict):  # 断点幂等：已生成的代码不重复调 LLM
             user_prompt = (
                 f"实验计划：{json.dumps(experiment.plan or {}, ensure_ascii=False)[:8000]}\n"
+                f"{_guidance_line(params)}"
                 f"预算：{json.dumps(experiment.budget or {}, ensure_ascii=False)}"
                 f"{_env_facts_prompt(env_settings)}"
             )
@@ -1347,18 +1391,57 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         obs["preflight_warnings"] = preflight_warnings
                     return obs
                 if fixes >= MAX_SETUP_FIXES:
+                    # 修复额度用尽不再抛错：抛错会让引擎原地重试整个 setup——
+                    # 又从头拉镜像/装依赖一遍（线上实测「一直装镜像」就是这个循环）。
+                    # 转向用户提问，等人给指示再动。
                     detail = err_text or "（无输出，多为连接中断或超时）"
-                    raise RuntimeError(
-                        f"依赖安装失败（exit={exit_status}，{attempts} 次）：{detail}"
+                    await _mark_attention(
+                        ctx, f"依赖安装连续失败（{attempts} 次，exit={exit_status}）"
                     )
+                    return {
+                        "workdir": experiment.workdir,
+                        "venv_exit": exit_status,
+                        "attempts": attempts,
+                        "fixes": fixes,
+                        "ask": {
+                            "ask_kind": "fatal_step",
+                            "question": (
+                                f"实验环境装不起来（尝试 {attempts} 次，"
+                                f"自动修复 {fixes} 次已用尽），"
+                                f"最后的报错：{detail[-300:]}。怎么处理？"
+                            ),
+                            "context": {
+                                "setup_log_tail": detail[-2000:],
+                                "attempts": attempts,
+                                "fixes": fixes,
+                                "preflight_warnings": preflight_warnings,
+                            },
+                            "options": [
+                                {
+                                    "id": "retry",
+                                    "zh": "带指示重试（换依赖/换镜像/改配置等）",
+                                    "en": "Retry with instructions",
+                                },
+                                {
+                                    "id": "replan",
+                                    "zh": "换个方案（请说明思路）",
+                                    "en": "Change approach (describe how)",
+                                },
+                                {"id": "abort", "zh": "放弃实验", "en": "Give up"},
+                            ],
+                        },
+                    }
                 # 把诊断 + 报错回给 LLM 修 requirements.txt/run.sh（方案级修复）。
                 # 环境事实必须一起带上：修复循环原本只有 stderr，模型照样不知道这台机器
-                # 上模型放哪、有没有配镜像源，只能接着猜。
+                # 上模型放哪、有没有配镜像源，只能接着猜。修复前先拉取对话流里
+                # 新到的用户建议——装依赖动辄几十分钟，用户在旁边说话不能装听不见。
                 fixes += 1
                 hint = hint or diagnose_failure(err_text, env_settings)
+                guidance_line = await _refresh_user_guidance(ctx, params)
                 user_prompt = (
                     f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
-                    f"依赖安装退出码：{exit_status}\n"
+                    + guidance_line
+                    + f"依赖安装退出码：{exit_status}\n"
                     + (f"诊断提示：{hint}\n" if hint else "")
                     + f"报错：\n{err_text}"
                     + _env_facts_prompt(env_settings)
@@ -1455,12 +1538,8 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 # 超时那类已经在上面给了 hint；其余按 stderr 签名归类，认不出就留空。
                 fixes += 1
                 hint = hint or diagnose_failure(err_text, env_settings)
-                guidance = params.get("user_guidance")
-                guidance_line = (
-                    f"用户指示（务必优先遵循）：{json.dumps(guidance, ensure_ascii=False)}\n"
-                    if guidance
-                    else ""
-                )
+                # 修复前拉取对话流里新到的用户建议（试跑修复同样是长循环）
+                guidance_line = await _refresh_user_guidance(ctx, params)
                 user_prompt = (
                     f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
                     + guidance_line
@@ -1737,12 +1816,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
         )
         run_lasts = {k: _last_value(v) for k, v in (run.metrics or {}).items()}
         # 用户在对话里的建议 / 对提问的回答（引擎注入 step params，见 docs/task-system.md）
-        user_guidance = params.get("user_guidance")
-        guidance_line = (
-            f"用户指示（务必优先遵循）：{json.dumps(user_guidance, ensure_ascii=False)}\n"
-            if user_guidance
-            else ""
-        )
+        guidance_line = _guidance_line(params)
         reflection_user = (
             f"实验计划：{json.dumps(plan, ensure_ascii=False)[:4000]}\n"
             f"主指标：{json.dumps(pm, ensure_ascii=False)}（假设共 {hyp_count} 条）\n"
@@ -2206,6 +2280,7 @@ async def experiment_figures(ctx: ActionContext, params: dict[str, Any]) -> dict
                 if plot_files is None:
                     plot_user = (
                         f"主指标：{json.dumps(plan.get('primary_metric'), ensure_ascii=False)}\n"
+                        f"{_guidance_line(params)}"
                         f"metrics_all.json 内容预览：{metrics_all_text[:4000]}\n"
                         + (f"上一版脚本的问题（请修复）：{problem}" if problem else "")
                     )
@@ -2331,6 +2406,7 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
         )
         user_prompt = (
             f"实验计划：{json.dumps(experiment.plan or {}, ensure_ascii=False)[:4000]}\n"
+            f"{_guidance_line(params)}"
             f"迭代各轮：{json.dumps(runs_brief, ensure_ascii=False)}\n"
             f"迭代状态：{json.dumps(experiment.iteration_state or {}, ensure_ascii=False)}\n"
             f"指标数据：{json.dumps(experiment.metrics or {}, ensure_ascii=False)[:4000]}\n"

--- a/src/backend/app/api/gates.py
+++ b/src/backend/app/api/gates.py
@@ -20,11 +20,13 @@ from app.core.events import EventBus, get_event_bus
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.gate import Gate
 from app.models.user import User
+from app.models.voyage import VoyageRun
 from app.schemas.gate import GateDecision, GateRead
 from app.services import experiments as experiments_service
 from app.services import gates as gates_service
 from app.services import ideas as ideas_service
 from app.services import manuscripts as manuscripts_service
+from app.services import voyage_messages as messages_service
 
 router = APIRouter(prefix="/gates", tags=["gates"])
 
@@ -91,6 +93,29 @@ async def _decide(
     voyage_id = gates_service.gate_voyage_id(gate)
     if voyage_id is not None:
         if approved:
+            # 审批意见并入任务对话流：以前批准时 comment 直接被丢弃，
+            # 用户在预算闸门写的「先用小模型跑」这类指示 agent 永远看不到。
+            # 走既有建议通道（下一个决策点自动注入 + 消费留痕）。
+            comment = (data.comment or "").strip() if data is not None else ""
+            # 先确认 voyage 行确实存在：payload 里的 id 可能指向已删任务，
+            # 外键失败的回滚会把 session 里的 gate 弄过期、砸了后面的联动
+            if comment and await session.get(VoyageRun, voyage_id) is not None:
+                try:
+                    message = await messages_service.append_message(
+                        session,
+                        voyage_id,
+                        role="user",
+                        kind="chat",
+                        text=f"（审批意见）{comment}",
+                        author_id=user.id,
+                    )
+                    await bus.publish_voyage_event(
+                        voyage_id,
+                        "message",
+                        {"message": messages_service.serialize_message(message)},
+                    )
+                except messages_service.MessageSeqConflictError:
+                    pass  # 极小概率并发撞 seq：意见仍在 gate.comment 里，不阻塞审批
             await queue.enqueue("resume_voyage", str(voyage_id))
         else:
             run = await gates_service.fail_voyage(session, voyage_id)

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -409,10 +409,10 @@ async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh,
     assert resp.json()["status"] == "done"
 
 
-async def test_setup_deps_escalate_not_hard_fail(client, queue_stub, fake_ssh, bus_recorder):
-    """依赖装不上、内部修复用尽 → setup 不像 smoke 那样硬停：它是「可换方案」节点，
-    升级到引擎级重试/AI 计划调整（navigator：setup 走 loop 回灌）。本例重试后恢复 → voyage done。"""
-    fake_ssh.setup_exits = [1, 1, 1]  # 够耗尽一轮内部修复（1 次 + 2 次 fixes）后升级
+async def test_setup_deps_exhausted_asks_then_retry(client, queue_stub, fake_ssh, bus_recorder):
+    """依赖装不上、内部修复用尽 → 不再抛错让引擎盲目重装（线上实测「一直装镜像」）：
+    转向用户提问（paused_ask）；回答重试后修复计数清零、装通、整条流水线走完。"""
+    fake_ssh.setup_exits = [1, 1, 1, 0]  # 耗尽一轮内部修复（1 次 + 2 次 fixes）→ 提问；答后重装通过
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
@@ -426,10 +426,123 @@ async def test_setup_deps_escalate_not_hard_fail(client, queue_stub, fake_ssh, b
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
-    # 关键区别：内部修复用尽后 setup 不硬停，升级重试后恢复完成（对比 smoke 用尽即 failed）
-    assert voyage["status"] == "done", voyage
+    assert voyage["status"] == "paused_ask", voyage
+    ask = voyage["open_ask"]
+    assert ask is not None and "实验环境装不起来" in ask["text"]
+    setup_step = next(s for s in voyage["steps"] if s["action"] == "experiment.setup")
+    assert setup_step["status"] == "pending"  # 提问不烧尝试预算
+    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
+    assert resp.json()["status"] == "waiting_user"
+
+    # 回答重试 → setup 重跑（第 4 个退出码 0）→ 全程走完
+    resp = await client.post(
+        f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
+        json={"choice": "retry", "text": "精简依赖再装一次"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    await engine.resume(uuid.UUID(voyage_id))
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "done"
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "done"
+
+
+async def test_setup_fix_loop_picks_up_mid_action_suggestions(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """长动作期间的建议不再等下一个步骤边界：setup 修复循环每一轮实时拉取
+    对话流新消息，注入修复 prompt 并标记消费（与步骤 params 持久化同事务）。"""
+    from app.core.llm.base import CompletionResult
+    from app.services import voyage_messages as messages_service
+
+    fake_ssh.setup_exits = [1, 0]  # 失败一次 → 修复一轮（期间用户发建议）→ 装通
+
+    class _FixPromptSpy(FakeProvider):
+        def __init__(self) -> None:
+            self.fix_prompts: list[str] = []
+
+        async def complete(
+            self, messages, *, model, temperature=0.7, max_tokens=None, images=None
+        ) -> CompletionResult:
+            full = "\n".join(m.content for m in messages)
+            if "依赖安装退出码" in full:
+                self.fix_prompts.append(full)
+            return await super().complete(
+                messages, model=model, temperature=temperature, max_tokens=max_tokens,
+                images=images,
+            )
+
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    voyage_id = resp.json()["voyage_id"]
+
+    posted = False
+
+    async def post_suggestion(command: str) -> None:
+        # 首次装依赖启动后（= setup 动作执行中途）用户发来建议
+        nonlocal posted
+        if "setup.exit" in command and not posted:
+            posted = True
+            async with get_sessionmaker()() as session:
+                await messages_service.append_message(
+                    session,
+                    uuid.UUID(voyage_id),
+                    role="user",
+                    kind="chat",
+                    text="换成 torch 的 cpu 版本",
+                )
+
+    fake_ssh.on_command = post_suggestion
+
+    provider = _FixPromptSpy()
+    router = LLMRouter()
+    router.override_provider(provider)
+    engine, _ = _make_engine(router)
+    await engine.run(uuid.UUID(voyage_id))
+    await _approve_gate(client, headers, project_id)
+    await engine.resume(uuid.UUID(voyage_id))
+
+    assert posted
+    assert provider.fix_prompts, "应发生过一次依赖修复"
+    assert "换成 torch 的 cpu 版本" in provider.fix_prompts[0]
+    assert "用户指示" in provider.fix_prompts[0]
+    async with get_sessionmaker()() as session:
+        pending = await messages_service.pending_chat_messages(session, uuid.UUID(voyage_id))
+        assert pending == []  # 已消费，不残留
+
+
+async def test_gate_approve_comment_flows_into_conversation(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """批准闸门时写的意见不再被丢弃：镜像成对话流建议，恢复执行后被消费。"""
+    from app.services import voyage_messages as messages_service
+
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    voyage_id = resp.json()["voyage_id"]
+
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(voyage_id))  # 停在 compute_budget 闸门
+    resp = await client.get(f"/api/gates?project_id={project_id}", headers=headers)
+    gate = resp.json()[0]
+    resp = await client.post(
+        f"/api/gates/{gate['id']}/approve", json={"comment": "先用小模型跑"}, headers=headers
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/api/voyages/{voyage_id}/messages", headers=headers)
+    chat = [m for m in resp.json() if m["kind"] == "chat"]
+    assert any("先用小模型跑" in m["text"] for m in chat), chat
+
+    await engine.resume(uuid.UUID(voyage_id))
+    async with get_sessionmaker()() as session:
+        pending = await messages_service.pending_chat_messages(session, uuid.UUID(voyage_id))
+        assert pending == []  # 恢复执行后意见已注入决策点并标记消费
 
 
 def test_parse_gpu_csv_unit():


### PR DESCRIPTION
Driven by the live case in #335 (experiment stuck re-installing its environment, user suggestions ignored). All fixes are structural — they harden the harness for any experiment, not this one:

| hole | fix |
|---|---|
| Guidance injected only at step start; setup/smoke fix loops run for tens of minutes blind to new messages | fix loops re-drain the conversation each iteration via `_refresh_user_guidance` — consumption is committed **atomically with persisting the merged guidance into the step row** (resume replays neither drop nor double-inject), and the terminal acknowledges the pickup |
| Only 2 of 8 experiment LLM call sites read `user_guidance` | shared `_guidance_line` renderer wired into plan, setup codegen, setup fix, smoke fix, analyze (reflection + improve/debug), figures, report |
| Setup fix exhaustion raised → engine retried the whole action → full image pull/reinstall again before every replan（「一直装镜像」） | exhaustion now asks the user (fatal_step, same shape as smoke) with setup log tail + preflight warnings; retry restarts with a fresh fix budget without burning the attempt |
| Approved gate comments were discarded | mirrored into the conversation stream as a suggestion (voyage-existence check guards stale payloads), flowing through the same injection/consumption channel |

Tests: setup-exhaustion ask round-trip, mid-action suggestion pickup (prompt spy asserts the suggestion lands in the very next fix prompt), gate-comment mirroring + consumption. 95 passed across the experiment/gates/ask/loop suites.

Closes #335