### PR TITLE
feat(experiment): file-based experiment memory the agent reads and writes

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -212,13 +212,23 @@ DEBUG_SYSTEM_PROMPT = (
 )
 
 
+#: 全文渲染的近期尝试数（其余压成一行摘要——上下文预算给记忆与最新代码，不给旧全文）
+_ARCHIVE_RECENT_FULL = 2
+
+
 def _render_attempt_archive(
-    archive: list[dict[str, Any]], per_file_cap: int = 2000, best_file_cap: int = 4000
+    archive: list[dict[str, Any]],
+    per_file_cap: int = 2000,
+    best_file_cap: int = 4000,
+    recent_full: int = _ARCHIVE_RECENT_FULL,
 ) -> str:
     """把历史尝试（源码+得分+轨迹）渲染进迭代 proposer 提示——通用的「先验经验档案」。
 
-    非某类实验专属：渲染每次尝试的**全部**源码文件（不假设入口文件名），最优尝试给更长上下文，
-    其余截断；轨迹给尾部。让 proposer 据全量历史而非最后一轮提出下一次尝试。"""
+    体量有界（docs/task-system.md，对照 Anthropic long-running agent 结论）：
+    只有**最优尝试**与**最近 recent_full 次**渲染源码全文（分别截断
+    best_file_cap / per_file_cap），更早的尝试压成一行摘要——它们的结论已经
+    蒸馏进实验记忆（MEMORY.md），全文重放只会稀释信号。旧行为（全量渲染）
+    在 10 轮实验上能吃掉 ~70K 字符且无上限。"""
     if not archive:
         return ""
 
@@ -227,14 +237,21 @@ def _render_attempt_archive(
         return (1, float(v)) if isinstance(v, int | float) else (0, float("-inf"))
 
     best = max(archive, key=_score)
-    parts = [f"历史尝试档案（共 {len(archive)} 次，含源码/得分/轨迹，据此提出下一次尝试）："]
+    recent = set(map(id, archive[-max(recent_full, 0) :]))
+    parts = [f"历史尝试档案（共 {len(archive)} 次；最优与最近 {recent_full} 次含源码全文）："]
     for c in archive:
         star = " ★迄今最好" if c is best else ""
         delta = c.get("conditions_delta")
         delta_s = json.dumps(delta, ensure_ascii=False) if delta else "—"
-        parts.append(
-            f"\n[尝试 seq={c.get('seq')} | 主指标={c.get('primary_value')}{star} | 对照={delta_s}]"
+        header = (
+            f"\n[尝试 seq={c.get('seq')} | 主指标={c.get('primary_value')}{star}"
+            f" | 对照={delta_s}]"
         )
+        if c is not best and id(c) not in recent:
+            observation = str(c.get("observation") or "")[:200]
+            parts.append(header + (f" 观察：{observation}" if observation else ""))
+            continue
+        parts.append(header)
         cap = best_file_cap if c is best else per_file_cap
         # 渲染全部源码文件（跳过 requirements 这类噪音），不假设固定入口名，保证通用
         for name, code in sorted((c.get("files") or {}).items()):
@@ -245,6 +262,81 @@ def _render_attempt_archive(
         if trace:
             parts.append(f"执行轨迹尾部：{trace[-600:]}")
     return "\n".join(parts) + "\n"
+
+
+# ---- 实验记忆（docs/task-system.md）：以文件为载体的跨轮持续记忆 ----
+#
+# 载体是 workdir 根下的 MEMORY.md（人可读、实验脚本可读、前端 code 端点可实时看），
+# checkpoint["memory_md"] 是真源镜像（engine 每步持久化；服务器断连时前端仍可读）。
+# 平台在关键事件处确定性写入（计划定稿/环境事实/每轮结论/修复额度用尽/用户决策/
+# 终止判定），AI 经 reflection.memory_note 自主记笔记；所有实验 LLM 决策点注入
+# 记忆尾部——context 再长，跨轮的关键结论也不丢。
+
+MEMORY_REL = "MEMORY.md"
+_MEMORY_MAX_CHARS = 40_000  # 镜像总量上限：超出滚动丢弃最旧条目（标题行保留）
+_MEMORY_PROMPT_CHARS = 6_000  # 注入 prompt 的尾部预算（新条目优先）
+_MEMORY_HEADER = (
+    "# 实验记忆\n\n"
+    "平台与 AI 共同维护的跨轮记忆：关键决策、环境事实、每轮结论、已证伪路径。\n"
+    "实验脚本可直接读取本文件；新条目在文件末尾。\n"
+)
+
+
+def _memory_text(ctx: ActionContext) -> str:
+    return str(ctx.checkpoint.get("memory_md") or "")
+
+
+def _remember(ctx: ActionContext, section: str, text: str) -> None:
+    """向实验记忆追加一条（只写 checkpoint 镜像；workdir 副本由 _sync_memory_file 推）。"""
+    text = (text or "").strip()
+    if not text:
+        return
+    memory = _memory_text(ctx) or _MEMORY_HEADER
+    stamp = utcnow().strftime("%m-%d %H:%M")
+    memory += f"\n### [{stamp}] {section}\n{text}\n"
+    if len(memory) > _MEMORY_MAX_CHARS:
+        tail = memory[-_MEMORY_MAX_CHARS:]
+        cut = tail.find("\n### ")
+        if cut >= 0:
+            tail = tail[cut:]
+        memory = _MEMORY_HEADER + "\n（更早的记忆条目已滚动丢弃）\n" + tail
+    ctx.checkpoint["memory_md"] = memory
+
+
+async def _sync_memory_file(ctx: ActionContext, executor: Runner) -> None:
+    """把记忆镜像推到 workdir/MEMORY.md（尽力而为：推不动不影响主流程）。"""
+    memory = _memory_text(ctx)
+    if not memory:
+        return
+    with contextlib.suppress(Exception):
+        await executor.write_files({MEMORY_REL: memory})
+
+
+def _memory_prompt(ctx: ActionContext) -> str:
+    """记忆尾部 → prompt 注入段（有界；无记忆时空串）。"""
+    memory = _memory_text(ctx)
+    if not memory:
+        return ""
+    tail = memory[-_MEMORY_PROMPT_CHARS:]
+    if len(memory) > _MEMORY_PROMPT_CHARS:
+        cut = tail.find("\n### ")
+        if cut >= 0:
+            tail = "（更早条目省略，见 MEMORY.md）" + tail[cut:]
+    return f"实验记忆（MEMORY.md，跨轮持续维护——先读它再决策）：\n{tail}\n"
+
+
+def _remember_guidance(ctx: ActionContext, params: dict[str, Any]) -> None:
+    """把注入本步骤的用户指示记进记忆（按步骤去重：resume 重放/修复循环不重复记）。"""
+    guidance = list(params.get("user_guidance") or [])
+    if not guidance or ctx.step_id is None:
+        return
+    key = f"memory_guidance_seen_{ctx.step_id}"
+    seen = int(ctx.checkpoint.get(key) or 0)
+    if len(guidance) <= seen:
+        return
+    for text in guidance[seen:]:
+        _remember(ctx, "用户指示", str(text)[:300])
+    ctx.checkpoint[key] = len(guidance)
 
 
 # ---- 按实验 params 条件追加的 system prompt 段落（plan 与全部 codegen prompt 共用） ----
@@ -468,7 +560,7 @@ REFLECTION_SYSTEM_PROMPT = """\
 {"observation": "本轮结果观察", "diagnosis": "原因诊断",
  "hypothesis_updates": [{"index": 0, "status": "verified|falsified|testing", "evidence": "证据"}],
  "decision": "improve|debug|stop|ask", "planned_change": "下一轮计划修改", "stop_reason": null,
- "question": null}
+ "question": null, "memory_note": null}
 约束：
 - hypothesis_updates 的 index 是假设清单下标（从 0 开始），status 只能取 verified/falsified/testing
 - 本轮运行失败（exit_code 非 0）时 decision 用 debug；结果已足以回答全部假设时用 stop
@@ -479,6 +571,8 @@ REFLECTION_SYSTEM_PROMPT = """\
   怀疑度量有误、两个改进方向证据相当难以取舍、或继续下去要花大算力而收益存疑。
   能自己判断就别问；问题里给出候选方向让用户好回答
 - 若给了「用户指示」，那是用户在对话里的最新意见，**优先遵循**
+- memory_note 可选：想跨轮记住的关键结论/教训（一两句，如「X 方向已证伪：原因」），
+  会写进实验记忆（MEMORY.md）供后续轮次与收尾报告使用
 - 对照实验：若给了「对照汇总」，据 baseline vs treatment 的 delta 判断假设成立与否
   （处理组是否优于 baseline），别只看单个 primary_value；对照结果已清晰时可直接 stop
 """
@@ -881,6 +975,7 @@ def validate_reflection(data: Any) -> dict[str, Any]:
     question = data.get("question")
     if decision == "ask" and not (isinstance(question, str) and question.strip()):
         raise ValueError('decision "ask" requires a non-empty "question"')
+    memory_note = data.get("memory_note")
     return {
         "observation": observation.strip(),
         "diagnosis": diagnosis.strip(),
@@ -889,6 +984,7 @@ def validate_reflection(data: Any) -> dict[str, Any]:
         "planned_change": str(planned_change).strip() if planned_change else None,
         "stop_reason": str(stop_reason).strip() if stop_reason else None,
         "question": str(question).strip() if question else None,
+        "memory_note": str(memory_note).strip() if memory_note else None,
     }
 
 
@@ -1176,6 +1272,15 @@ async def experiment_plan(ctx: ActionContext, params: dict[str, Any]) -> dict[st
             )
             experiment.plan = plan
             await session.commit()
+            pm_def = plan.get("primary_metric") or {}
+            hyp_texts = [str(h.get("text", ""))[:80] for h in plan.get("hypotheses", [])]
+            _remember(
+                ctx,
+                "实验计划定稿",
+                f"主指标：{pm_def.get('name')}（{pm_def.get('direction')}）；"
+                f"假设 {len(hyp_texts)} 条：" + "；".join(hyp_texts[:6]) + "；"
+                f"预算：{json.dumps(experiment.budget or {}, ensure_ascii=False)}",
+            )
         plan = experiment.plan
 
         # 预算闸门 payload（engine 建 Gate 时合并）：实验 id + 预算摘要 + 计划摘要
@@ -1285,9 +1390,11 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         env_settings = await experiment_settings_service.get_settings(session)
 
         files = ctx.checkpoint.get("exp_files")
+        _remember_guidance(ctx, params)
         if not isinstance(files, dict):  # 断点幂等：已生成的代码不重复调 LLM
             user_prompt = (
                 f"实验计划：{json.dumps(experiment.plan or {}, ensure_ascii=False)[:8000]}\n"
+                f"{_memory_prompt(ctx)}"
                 f"{_guidance_line(params)}"
                 f"预算：{json.dumps(experiment.budget or {}, ensure_ascii=False)}"
                 f"{_env_facts_prompt(env_settings)}"
@@ -1377,6 +1484,13 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         await executor.close()
                     executor = await _open_executor(session, ctx, experiment)
                 if exit_status == 0:
+                    env_bits = [f"探测到 GPU {len(gpus)} 卡" if gpus else "未探测到 GPU"]
+                    for warning in preflight_warnings:
+                        env_bits.append(str(warning)[:200])
+                    if fixes:
+                        env_bits.append(f"依赖安装经 {fixes} 次自动修复后通过")
+                    _remember(ctx, "环境事实", "；".join(env_bits))
+                    await _sync_memory_file(ctx, executor)
                     written = list(files) + list(platform_files)
                     obs: dict[str, Any] = {
                         "workdir": experiment.workdir,
@@ -1398,6 +1512,13 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                     await _mark_attention(
                         ctx, f"依赖安装连续失败（{attempts} 次，exit={exit_status}）"
                     )
+                    _remember(
+                        ctx,
+                        "环境障碍",
+                        f"依赖安装 {attempts} 次未通过（exit={exit_status}）："
+                        f"{detail[-200:]}，已转向用户提问",
+                    )
+                    await _sync_memory_file(ctx, executor)
                     return {
                         "workdir": experiment.workdir,
                         "venv_exit": exit_status,
@@ -1438,8 +1559,10 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 fixes += 1
                 hint = hint or diagnose_failure(err_text, env_settings)
                 guidance_line = await _refresh_user_guidance(ctx, params)
+                _remember_guidance(ctx, params)
                 user_prompt = (
                     f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
+                    + _memory_prompt(ctx)
                     + guidance_line
                     + f"依赖安装退出码：{exit_status}\n"
                     + (f"诊断提示：{hint}\n" if hint else "")
@@ -1496,6 +1619,9 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         await executor.close()
                     executor = await _open_executor(session, ctx, experiment)
                 if exit_status == 0:
+                    if fixes:
+                        _remember(ctx, "试跑", f"自动修复 {fixes} 次后通过")
+                    await _sync_memory_file(ctx, executor)
                     return {"exit_code": 0, "attempts": attempts, "fixes": fixes}
                 if fixes >= MAX_SMOKE_FIXES:
                     # 修复额度用尽不再抛错打死：转向用户提问（引擎收到 observation.ask
@@ -1504,6 +1630,13 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                     await _mark_attention(
                         ctx, f"冒烟测试连续失败（{attempts} 次，exit={exit_status}）"
                     )
+                    _remember(
+                        ctx,
+                        "试跑障碍",
+                        f"冒烟 {attempts} 次未通过（exit={exit_status}）："
+                        f"{err_text[-200:]}，已转向用户提问",
+                    )
+                    await _sync_memory_file(ctx, executor)
                     return {
                         "exit_code": exit_status,
                         "attempts": attempts,
@@ -1540,8 +1673,10 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 hint = hint or diagnose_failure(err_text, env_settings)
                 # 修复前拉取对话流里新到的用户建议（试跑修复同样是长循环）
                 guidance_line = await _refresh_user_guidance(ctx, params)
+                _remember_guidance(ctx, params)
                 user_prompt = (
                     f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
+                    + _memory_prompt(ctx)
                     + guidance_line
                     + f"冒烟测试退出码：{exit_status}\n"
                     + (f"诊断提示：{hint}\n" if hint else "")
@@ -1816,10 +1951,12 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
         )
         run_lasts = {k: _last_value(v) for k, v in (run.metrics or {}).items()}
         # 用户在对话里的建议 / 对提问的回答（引擎注入 step params，见 docs/task-system.md）
+        _remember_guidance(ctx, params)
         guidance_line = _guidance_line(params)
         reflection_user = (
             f"实验计划：{json.dumps(plan, ensure_ascii=False)[:4000]}\n"
             f"主指标：{json.dumps(pm, ensure_ascii=False)}（假设共 {hyp_count} 条）\n"
+            f"{_memory_prompt(ctx)}"
             f"{guidance_line}"
             f"本轮运行：seq={run.seq} status={run.status} exit_code={run.exit_code} "
             f"primary_value={run.primary_value}\n"
@@ -1837,6 +1974,19 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             validate=validate_reflection,
         )
         run.reflection = reflection
+        _remember(
+            ctx,
+            f"第 {run.seq} 轮结论",
+            f"主指标 {run.primary_value}；决策 {reflection['decision']}；"
+            f"诊断：{str(reflection.get('diagnosis') or '')[:250]}"
+            + (
+                f"；下一步：{str(reflection.get('planned_change') or '')[:250]}"
+                if reflection.get("planned_change")
+                else ""
+            ),
+        )
+        if reflection.get("memory_note"):
+            _remember(ctx, "AI 笔记", str(reflection["memory_note"])[:600])
 
         # 尝试存档（通用先验经验档案）：把本轮实现的源码/得分/轨迹存起来，供后续迭代 proposer 读取
         # 全量历史（不是只看上一轮）。记录产生本轮 run 的实现（当前 exp_files）。
@@ -1903,6 +2053,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             stopped_reason = "debug_limit"
 
         if stopped_reason:
+            _remember(ctx, "终止判定", f"迭代结束：{stopped_reason}")
             state["stopped_reason"] = stopped_reason
             experiment.iteration_state = dict(state)
             await session.commit()
@@ -1932,6 +2083,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             archive_ctx = _render_attempt_archive(prior) if prior else ""
             fix_user = (
                 (archive_ctx + "\n" if archive_ctx else "")
+                + _memory_prompt(ctx)
                 + guidance_line
                 + f"当前文件：{json.dumps(files, ensure_ascii=False)[:8000]}\n\n"
                 + f"reflection 观察：{reflection['observation']}\n"
@@ -1945,7 +2097,9 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             system_prompt = _prompt_with_context(IMPROVE_SYSTEM_PROMPT, ctx)
             fix_user = (
                 _render_attempt_archive(archive)
-                + ("\n" + guidance_line if guidance_line else "")
+                + "\n"
+                + _memory_prompt(ctx)
+                + guidance_line
                 + f"\n主指标：{json.dumps(pm, ensure_ascii=False)}\n"
                 + f"当前尝试 seq={run.seq} 主指标={run.primary_value}；"
                 + f"reflection 诊断：{reflection['diagnosis']}\n"
@@ -1968,6 +2122,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
         executor = await _open_executor(session, ctx, experiment)
         try:
             await executor.write_files(files)
+            await _sync_memory_file(ctx, executor)
         finally:
             await executor.close()
         ctx.checkpoint["exp_files"] = files
@@ -2292,6 +2447,7 @@ async def experiment_figures(ctx: ActionContext, params: dict[str, Any]) -> dict
                     )
                     ctx.checkpoint["plot_files"] = plot_files
                 await executor.write_files(plot_files)
+                await _sync_memory_file(ctx, executor)
 
                 # 绘图依赖确定性保证（幂等；失败不阻断——真实错误由 run_plot 暴露）
                 with contextlib.suppress(Exception):
@@ -2406,6 +2562,7 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
         )
         user_prompt = (
             f"实验计划：{json.dumps(experiment.plan or {}, ensure_ascii=False)[:4000]}\n"
+            f"{_memory_prompt(ctx)}"
             f"{_guidance_line(params)}"
             f"迭代各轮：{json.dumps(runs_brief, ensure_ascii=False)}\n"
             f"迭代状态：{json.dumps(experiment.iteration_state or {}, ensure_ascii=False)}\n"
@@ -2424,6 +2581,7 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
             voyage_id=ctx.run.id,
         )
         experiment.report = result.content.strip()
+        _remember(ctx, "报告", f"实验报告已生成（约 {len(experiment.report)} 字）")
         run_ok = last_run is not None and last_run.status == "succeeded"
         final_status = "done" if run_ok else "failed"
         session.add(

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -243,12 +243,21 @@ async def _open_exp_executor(session: AsyncSession, experiment: Experiment):
 
 
 async def _checkpoint_files(session: AsyncSession, experiment: Experiment) -> dict[str, str]:
-    """voyage checkpoint 里的 exp_files 快照（服务器不可达时的回退来源）。"""
+    """voyage checkpoint 里的文件快照（服务器不可达时的回退来源）。
+
+    exp_files（LLM 产出的源码）+ memory_md（实验记忆镜像，映射为 MEMORY.md）——
+    记忆的真源在 checkpoint，断连时前端记忆页照常可读。
+    """
     if experiment.voyage_id is None:
         return {}
     voyage = await session.get(VoyageRun, experiment.voyage_id)
-    files = (voyage.checkpoint or {}).get("exp_files") if voyage is not None else None
-    return {str(k): str(v) for k, v in files.items()} if isinstance(files, dict) else {}
+    checkpoint = (voyage.checkpoint or {}) if voyage is not None else {}
+    files = checkpoint.get("exp_files")
+    out = {str(k): str(v) for k, v in files.items()} if isinstance(files, dict) else {}
+    memory = checkpoint.get("memory_md")
+    if memory:
+        out["MEMORY.md"] = str(memory)
+    return out
 
 
 @router.get("/experiments/{experiment_id}/sysinfo")

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -60,6 +60,7 @@ def _reflection_json(
     planned_change: str | None = "调大学习率（test）",
     stop_reason: str | None = None,
     question: str | None = None,
+    memory_note: str | None = None,
 ) -> str:
     return json.dumps(
         {
@@ -72,6 +73,7 @@ def _reflection_json(
             "planned_change": planned_change,
             "stop_reason": stop_reason,
             "question": question,
+            "memory_note": memory_note,
         },
         ensure_ascii=False,
     )
@@ -334,6 +336,72 @@ async def test_analyze_without_runs_self_heals(client, queue_stub, fake_ssh, bus
 
     assert observation["skipped"] is True and observation["reason"] == "no_runs"
     assert observation["plan_signal"] == {"decision": "continue", "next_round": 1}
+
+
+class _NoteThenStopProvider(FakeProvider):
+    """第一轮 reflection 留 memory_note（improve），第二轮 stop；记录 prompt 是否带记忆。"""
+
+    def __init__(self) -> None:
+        self.reflection_calls = 0
+        self.later_prompt_had_memory = False
+
+    async def complete(
+        self, messages, *, model, temperature=0.7, max_tokens=None, images=None
+    ) -> CompletionResult:
+        full = "\n".join(m.content for m in messages)
+        if not images and '"hypothesis_updates"' in full:
+            self.reflection_calls += 1
+            if self.reflection_calls == 1:
+                return _result(
+                    _reflection_json(
+                        "improve", memory_note="小学习率方向已证伪：损失不降（test note）"
+                    ),
+                    model,
+                )
+            if "实验记忆" in full and "test note" in full:
+                self.later_prompt_had_memory = True
+            return _result(_reflection_json("stop", stop_reason="足够了（test）"), model)
+        return await super().complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens, images=images
+        )
+
+
+async def test_memory_note_persists_and_reinjected(client, queue_stub, fake_ssh, bus_recorder):
+    """AI 的 memory_note 落进实验记忆，并在后续轮次的 reflection prompt 里可见。"""
+    fake_ssh.run_logs = [metric_log(0.7), metric_log(0.75)]
+    project_id, headers, exp_id, voyage_id = await _launch_experiment(client)
+    provider = _NoteThenStopProvider()
+    await _drive_pipeline(client, headers, project_id, voyage_id, _router_with(provider))
+
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] == "done"
+    async with get_sessionmaker()() as session:
+        voyage = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        memory = (voyage.checkpoint or {}).get("memory_md") or ""
+    assert "AI 笔记" in memory and "test note" in memory
+    assert provider.later_prompt_had_memory  # 第二轮 reflection 读到了第一轮的笔记
+
+
+def test_render_attempt_archive_bounded():
+    """历史尝试档案有界：只有最优 + 最近 2 次渲染源码全文，更早的压成一行摘要。"""
+    from app.agents.voyage.actions_experiment import _render_attempt_archive
+
+    archive = [
+        {
+            "seq": i,
+            "primary_value": 0.5 + i * 0.05 if i != 3 else 0.99,  # seq=3 是最优
+            "files": {"train.py": f"code round {i}" * 10},
+            "trace": f"trace {i}",
+            "observation": f"obs {i}",
+        }
+        for i in range(1, 6)
+    ]
+    text = _render_attempt_archive(archive)
+    # 最优（seq=3）与最近两次（seq=4,5）带源码
+    assert text.count("源码（train.py") == 3
+    # 更早的（seq=1,2）只有摘要行（带观察，不带源码）
+    assert "seq=1" in text and "obs 1" in text
+    assert "seq=2" in text and "obs 2" in text
 
 
 async def test_max_runs_truncates_iteration(client, queue_stub, fake_ssh, bus_recorder):

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -545,6 +545,60 @@ async def test_gate_approve_comment_flows_into_conversation(
         assert pending == []  # 恢复执行后意见已注入决策点并标记消费
 
 
+async def test_experiment_memory_written_and_synced(client, queue_stub, fake_ssh, bus_recorder):
+    """实验记忆：关键事件确定性写入 checkpoint 镜像，并同步到 workdir/MEMORY.md；
+    /code 端点可读（前端记忆页数据源）。"""
+    fake_ssh.run_logs = [RUN_LOG, metric_log(0.75), metric_log(0.8)]
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(
+        client, headers, project_id, idea_id, cred_id, budget={"max_hours": 2, "max_runs": 3}
+    )
+    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(voyage_id))
+    await _approve_gate(client, headers, project_id)
+    await engine.resume(uuid.UUID(voyage_id))
+
+    async with get_sessionmaker()() as session:
+        voyage = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        memory = (voyage.checkpoint or {}).get("memory_md") or ""
+    assert "实验计划定稿" in memory
+    assert "环境事实" in memory
+    assert "第 1 轮结论" in memory and "第 3 轮结论" in memory
+    assert "终止判定" in memory
+    assert "报告" in memory
+    # workdir 副本已同步（脚本可读、CodeTab 可见）；fake 按全路径存键
+    memory_key = next(k for k in fake_ssh.files if k.endswith("/MEMORY.md"))
+    remote = fake_ssh.files[memory_key]
+    remote_text = remote.decode("utf-8") if isinstance(remote, bytes) else str(remote)
+    assert "实验计划定稿" in remote_text
+    # 前端记忆页数据源：/code/file 实时读
+    resp = await client.get(
+        f"/api/experiments/{exp_id}/code/file", params={"path": "MEMORY.md"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert "实验计划定稿" in resp.json()["content"]
+
+    # 服务器不可达 → 回退 checkpoint 镜像（source=checkpoint）
+    class _DeadConnector:
+        async def connect(self, *a, **k):
+            raise OSError("unreachable (test)")
+
+    ssh_exec.set_connector_factory(lambda: _DeadConnector())
+    try:
+        resp = await client.get(
+            f"/api/experiments/{exp_id}/code/file", params={"path": "MEMORY.md"}, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["source"] == "checkpoint"
+        assert "第 3 轮结论" in resp.json()["content"]
+    finally:
+        ssh_exec.set_connector_factory(None)
+
+
 def test_parse_gpu_csv_unit():
     """nvidia-smi CSV 解析：正常行解析、非法/短行跳过、空输入 → 空列表。"""
     text = "0, 49140, 48000\n1, 49140, 12000\nbad line\n2, x, y\n"
@@ -927,7 +981,8 @@ async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorde
     assert setup_step["attempt"] == 2  # 执行类错误带诊断原地重试过一次
     statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
     assert "replanning" in statuses  # 重试尽后走了计划调整
-    assert fake_ssh.files == {}  # 一个文件都没写出去
+    # 安全护栏的本质：越界文件绝不落盘（自愈后的合法平台文件如 MEMORY.md 允许写）
+    assert not any("evil" in path for path in fake_ssh.files)
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "waiting_user"  # 提问中，未被提前打死
 

--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -23,6 +23,7 @@ import {
 import { tr } from '../../lib/i18n';
 import { budgetText, HypChip } from './shared';
 import { ConsoleTab } from './ConsoleTab';
+import { MemoryTab } from './MemoryTab';
 import { RunTab } from './RunTab';
 import { CodeTab } from './CodeTab';
 import { ExperimentFigures } from './ExperimentFigures';
@@ -34,13 +35,14 @@ import { ExperimentFigures } from './ExperimentFigures';
    原环境 Tab 的服务器状态并入运行台概览、搭建步骤并入任务地图。
    ============================================================ */
 
-type TabKey = 'console' | 'plan' | 'run' | 'code' | 'report';
+type TabKey = 'console' | 'plan' | 'run' | 'memory' | 'code' | 'report';
 
 /* 文案在渲染处 tr()，避免模块级求值不随语言切换 */
 const TABS: { k: TabKey; zh: string; en: string }[] = [
   { k: 'console', zh: '运行台', en: 'Console' },
   { k: 'plan', zh: '计划', en: 'Plan' },
   { k: 'run', zh: '指标与轮次', en: 'Metrics & runs' },
+  { k: 'memory', zh: '记忆', en: 'Memory' },
   { k: 'code', zh: '代码', en: 'Code' },
   { k: 'report', zh: '报告', en: 'Report' },
 ];
@@ -697,6 +699,7 @@ export function ExperimentDetailPage() {
       {tab === 'console' && <ConsoleTab exp={exp} />}
       {tab === 'plan' && <PlanTab exp={exp} onOpenGates={() => openGates(null)} />}
       {tab === 'run' && <RunTab exp={exp} />}
+      {tab === 'memory' && <MemoryTab exp={exp} />}
       {tab === 'code' && <CodeTab exp={exp} active={active} />}
       {tab === 'report' && <ReportTab exp={exp} />}
     </div>

--- a/src/frontend/src/features/experiment/MemoryTab.tsx
+++ b/src/frontend/src/features/experiment/MemoryTab.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Markdown } from '../../lib/markdown';
+import { tr } from '../../lib/i18n';
+import { api, EXPERIMENT_TERMINAL, type ExperimentDetail } from '../../lib/api';
+
+/* ============================================================
+   记忆 Tab：实验的跨轮记忆文件（workdir/MEMORY.md）。
+   平台在关键事件写入（计划/环境/每轮结论/用户决策/终止），AI 经
+   reflection.memory_note 自主补笔记；这里做人类友好的审查视图。
+   数据走既有 /experiments/{id}/code/file 端点（服务器实时优先、
+   checkpoint 镜像回退），零新后端接口。
+   ============================================================ */
+
+export function MemoryTab({ exp }: { exp: ExperimentDetail }) {
+  const [raw, setRaw] = useState(false);
+  const active = !EXPERIMENT_TERMINAL.has(exp.status);
+  const { data, isLoading } = useQuery({
+    queryKey: ['experiment', exp.id, 'memory'],
+    queryFn: () => api.getExperimentCodeFile(exp.id, 'MEMORY.md'),
+    enabled: !!exp.voyage_id,
+    retry: false,
+    refetchInterval: active ? 15_000 : false,
+  });
+
+  if (!exp.voyage_id) {
+    return (
+      <div className="card">
+        <EmptyState
+          compact
+          icon="book"
+          title={tr('该实验没有关联 AI 任务', 'This experiment has no linked AI task')}
+        />
+      </div>
+    );
+  }
+  if (isLoading) {
+    return <div className="empty" style={{ padding: 40 }}>{tr('加载实验记忆…', 'Loading memory…')}</div>;
+  }
+  const content = data?.content ?? '';
+  if (!content.trim()) {
+    return (
+      <div className="card">
+        <EmptyState
+          compact
+          icon="book"
+          title={tr('记忆还没建立', 'No memory yet')}
+          desc={tr(
+            '实验计划定稿后，平台与 AI 会把关键决策、环境事实、每轮结论写进这里。',
+            'Once the plan is finalized, the platform and the AI record key decisions, environment facts and per-round conclusions here.',
+          )}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="fadeup" style={{ maxWidth: 860 }}>
+      <div className="row gap8" style={{ marginBottom: 12, flexWrap: 'wrap' }}>
+        <span className="section-h">
+          <Icon name="book" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('实验记忆', 'Experiment memory')}
+          <span className="en-label mono" style={{ fontSize: 11 }}>MEMORY.md</span>
+        </span>
+        <div className="row gap8" style={{ marginLeft: 'auto' }}>
+          {data?.source && (
+            <span
+              className="pill sm"
+              style={
+                data.source === 'ssh'
+                  ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+                  : { background: 'var(--surface-3)', color: 'var(--text-2)' }
+              }
+              title={
+                data.source === 'ssh'
+                  ? tr('从实验服务器实时读取', 'Read live from the experiment server')
+                  : tr('服务器不可达，显示平台镜像', 'Server unreachable — showing the platform mirror')
+              }
+            >
+              {data.source === 'ssh' ? tr('服务器实时', 'live') : tr('平台镜像', 'mirror')}
+            </span>
+          )}
+          <button className="btn btn-ghost sm" onClick={() => setRaw((r) => !r)}>
+            <Icon name="file" size={12} />
+            {raw ? tr('渲染视图', 'Rendered') : tr('查看原文', 'Raw')}
+          </button>
+        </div>
+      </div>
+      <div className="card card-pad">
+        {raw ? (
+          <pre
+            className="mono scroll"
+            style={{ fontSize: 11.5, lineHeight: 1.6, whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0 }}
+          >
+            {content}
+          </pre>
+        ) : (
+          <Markdown source={content} />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements #337 — the durable, human-reviewable memory layer for the experiment loop, following the Anthropic long-running-agent playbook (progress files + structured note-taking + bounded context).

## Design

- **Carrier**: `MEMORY.md` at the workdir root. The voyage checkpoint mirror (`memory_md`) is the source of truth — the engine persists it every step, it survives unreachable servers, and the `/code` fallback maps it back to `MEMORY.md` so the frontend always has something to show. The workdir copy is pushed best-effort wherever an executor is already open (setup, smoke, improve/debug writes, figures), so experiment scripts can read it too.
- **Writes** (deterministic, timestamped sections): plan finalized · environment facts + preflight warnings · per-round conclusions (metric/decision/diagnosis/next change) · fix-budget exhaustion · injected user guidance (per-step deduped) · stop verdict · report done. Plus **agent-authored notes**: reflection gains an optional `memory_note`.
- **Reads**: all experiment LLM call sites get the tail-bounded (6K chars) memory injected. And the biggest context bomb is defused: `_render_attempt_archive` now renders full source only for the best + 2 most recent attempts — older rounds collapse to one-line summaries (previously unbounded full-source replay, ~70K chars by round 10).
- **Frontend**: new 记忆 tab — Markdown rendering, live/mirror source badge, raw toggle; reuses `getExperimentCodeFile`, zero new endpoints.

## Tests

- Full-pipeline: memory sections written, workdir copy synced, `/code/file` serves it live, and serves the checkpoint mirror with `source=checkpoint` when SSH is down.
- `memory_note` persists and is visible in the next round's reflection prompt (prompt spy).
- Bounded archive rendering unit test.
- `test_path_violation_rejected` assertion modernized to its actual security core (no out-of-workdir file is ever written) since the self-healing loop now legitimately writes platform files afterwards.

57 passed across the experiment suites; `tsc` + `vite build` clean.

Closes #337