### PR TITLE
feat(experiment): unlimited auto-fixing under a time budget, AI intake questions

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -63,9 +63,6 @@ from app.services.libraries import (
 )
 
 RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0）
-MAX_SETUP_FIXES = 2  # 依赖安装失败回 LLM 修 requirements/run.sh 的次数上限
-MAX_SMOKE_FIXES = 2  # 冒烟失败回 LLM 修代码的次数上限
-MAX_DEBUG_FIXES = 3  # 迭代内 debug 分支独立限额（docs/api-m5-a.md §1）
 MAX_FIGURE_FIXES = 2  # 绘图脚本执行失败 / VLM 质检不合格的修复次数上限
 DEFAULT_NO_IMPROVE_STOP = 2  # 连续 N 轮主指标无提升即停（budget.no_improve_stop 可覆盖）
 MAX_QC_IMAGES = 8  # 单次质检最多送 LLM 的图数
@@ -364,6 +361,12 @@ EXTRA_NOTES_PROMPT_SECTION = """\
 {notes}
 """
 
+INTAKE_PROMPT_SECTION = """\
+
+开题问答（创建实验时按想法向用户确认的关键信息，务必遵循）：
+{qa}
+"""
+
 HF_MIRROR_ENDPOINT = "https://hf-mirror.com"
 
 
@@ -378,6 +381,16 @@ def _prompt_with_context(base: str, ctx: ActionContext) -> str:
     notes = str(params.get("extra_notes") or "").strip()
     if notes:
         parts.append(EXTRA_NOTES_PROMPT_SECTION.format(notes=notes))
+    intake = params.get("intake")
+    if isinstance(intake, list):
+        qa_lines = [
+            f"- 问：{str(qa.get('question') or '').strip()}\n"
+            f"  答：{str(qa.get('answer') or '').strip()}"
+            for qa in intake
+            if isinstance(qa, dict) and str(qa.get("answer") or "").strip()
+        ]
+        if qa_lines:
+            parts.append(INTAKE_PROMPT_SECTION.format(qa="\n".join(qa_lines)))
     return "".join(parts)
 
 
@@ -1113,6 +1126,15 @@ def is_improvement(value: float, best: float | None, direction: str) -> bool:
     return value > best if direction == "maximize" else value < best
 
 
+def _phase_deadline_exceeded(budget: dict[str, Any] | None, phase_started: datetime) -> bool:
+    """修复循环的唯一刹车：本阶段耗时超出 budget.max_hours（0/缺省 = 无限时）。
+
+    用户定调：自动修复不按次数设限，只受一开始定义的时间预算约束。
+    相位起点取循环开始（不含排队/等审批/等回答的时间）。"""
+    max_hours = float((budget or {}).get("max_hours") or 0)
+    return bool(max_hours) and _elapsed_hours(phase_started) > max_hours
+
+
 def _elapsed_hours(started_at: datetime | None) -> float:
     if started_at is None:
         return 0.0
@@ -1453,9 +1475,12 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 )
 
             # 依赖安装自愈（对称 smoke）：装不上/太慢/断连都当「可修的失败」而非硬崩——
-            # 超时/断连→重连重试；pip 报错→回 LLM 修 requirements.txt/run.sh 再装（≤2 次）。
+            # 超时/断连→重连重试；pip 报错→回 LLM 修 requirements.txt/run.sh 再装。
+            # 修复次数不设上限（用户定调：只受时间预算约束，默认无限时）；
+            # 每轮修复都是一次真实安装（分钟级），LLM 调用频率天然被实际工作限速。
             fixes = 0
             attempts = 0
+            phase_started = utcnow()
             while True:
                 attempts += 1
                 await executor.write_files(files)  # 每次（修复后）重写 LLM 产出文件
@@ -1504,18 +1529,18 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                     if preflight_warnings:
                         obs["preflight_warnings"] = preflight_warnings
                     return obs
-                if fixes >= MAX_SETUP_FIXES:
-                    # 修复额度用尽不再抛错：抛错会让引擎原地重试整个 setup——
-                    # 又从头拉镜像/装依赖一遍（线上实测「一直装镜像」就是这个循环）。
-                    # 转向用户提问，等人给指示再动。
+                if _phase_deadline_exceeded(experiment.budget, phase_started):
+                    # 不按修复次数设限（用户定调），只受时间预算约束：超时转向用户提问。
+                    # 抛错会让引擎原地重试整个 setup——又从头拉镜像/装依赖一遍
+                    # （线上实测「一直装镜像」就是这个循环），所以一律提问不抛错。
                     detail = err_text or "（无输出，多为连接中断或超时）"
                     await _mark_attention(
-                        ctx, f"依赖安装连续失败（{attempts} 次，exit={exit_status}）"
+                        ctx, f"依赖安装超出时间预算（{attempts} 次，exit={exit_status}）"
                     )
                     _remember(
                         ctx,
                         "环境障碍",
-                        f"依赖安装 {attempts} 次未通过（exit={exit_status}）："
+                        f"依赖安装超出时间预算（{attempts} 次尝试，exit={exit_status}）："
                         f"{detail[-200:]}，已转向用户提问",
                     )
                     await _sync_memory_file(ctx, executor)
@@ -1527,8 +1552,8 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         "ask": {
                             "ask_kind": "fatal_step",
                             "question": (
-                                f"实验环境装不起来（尝试 {attempts} 次，"
-                                f"自动修复 {fixes} 次已用尽），"
+                                f"实验环境装不起来（已尝试 {attempts} 次、"
+                                f"自动修复 {fixes} 次，超出时间预算），"
                                 f"最后的报错：{detail[-300:]}。怎么处理？"
                             ),
                             "context": {
@@ -1580,7 +1605,7 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
             await executor.close()
 
 
-# ---- 3. 冒烟测试：exit 0 通过；失败回 LLM 修文件（≤2 次） ----
+# ---- 3. 冒烟测试：exit 0 通过；失败回 LLM 修文件（不限次数，超时预算转提问） ----
 
 
 @register("experiment.smoke")
@@ -1596,6 +1621,7 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
         try:
             attempts = 0
             fixes = 0
+            phase_started = utcnow()  # 修复不限次数，只受时间预算约束（用户定调）
             while True:
                 attempts += 1
                 # 超时/断连也当作「可修的失败」（多为规模太大/太慢或环境问题），而非硬崩：
@@ -1623,17 +1649,17 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         _remember(ctx, "试跑", f"自动修复 {fixes} 次后通过")
                     await _sync_memory_file(ctx, executor)
                     return {"exit_code": 0, "attempts": attempts, "fixes": fixes}
-                if fixes >= MAX_SMOKE_FIXES:
-                    # 修复额度用尽不再抛错打死：转向用户提问（引擎收到 observation.ask
-                    # 会把节点回 pending、任务转 paused_ask）。回答「重试」会从头重跑
-                    # 本动作（修复计数随之清零），回答文本经 params["user_guidance"] 注入。
+                if _phase_deadline_exceeded(experiment.budget, phase_started):
+                    # 修复不设次数上限（用户定调），超出时间预算才转向用户提问
+                    # （引擎收到 observation.ask 会把节点回 pending、任务转 paused_ask）。
+                    # 回答「重试」会从头重跑本动作，回答文本经 params["user_guidance"] 注入。
                     await _mark_attention(
-                        ctx, f"冒烟测试连续失败（{attempts} 次，exit={exit_status}）"
+                        ctx, f"冒烟测试超出时间预算（{attempts} 次，exit={exit_status}）"
                     )
                     _remember(
                         ctx,
                         "试跑障碍",
-                        f"冒烟 {attempts} 次未通过（exit={exit_status}）："
+                        f"冒烟超出时间预算（{attempts} 次尝试，exit={exit_status}）："
                         f"{err_text[-200:]}，已转向用户提问",
                     )
                     await _sync_memory_file(ctx, executor)
@@ -1644,7 +1670,8 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                         "ask": {
                             "ask_kind": "fatal_step",
                             "question": (
-                                f"代码试跑连续失败（{attempts} 次，自动修复 {fixes} 次已用尽），"
+                                f"代码试跑一直不通过（已尝试 {attempts} 次、"
+                                f"自动修复 {fixes} 次，超出时间预算），"
                                 f"最后的报错：{err_text[-300:]}。怎么处理？"
                             ),
                             "context": {
@@ -1964,7 +1991,7 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             f"{cond_line}"
             f"历史各轮：{json.dumps(history, ensure_ascii=False)}\n"
             f"迭代状态：无提升连续 {state['no_improve_streak']} 轮，"
-            f"debug 已用 {state['debug_count']}/{MAX_DEBUG_FIXES} 次\n"
+            f"debug 已修 {state['debug_count']} 次\n"
             f"本轮日志尾部：\n" + "\n".join(log_lines)
         )
         reflection = await _complete_json(
@@ -2049,8 +2076,8 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
             stopped_reason = "max_runs"
         elif max_hours and _elapsed_hours(iterate_started) > max_hours:
             stopped_reason = "max_hours"
-        elif decision == "debug" and state["debug_count"] >= MAX_DEBUG_FIXES:
-            stopped_reason = "debug_limit"
+        # debug 不再按次数终止（用户定调：只受时间/轮数预算约束）——
+        # debug_count 仍然记账，供面板与 reflection 观察
 
         if stopped_reason:
             _remember(ctx, "终止判定", f"迭代结束：{stopped_reason}")
@@ -2257,7 +2284,7 @@ async def _poll_run(
                     raise
             continue  # 远端状态持久化，重连后下一轮继续跟踪
 
-        if max_hours >= 0 and _elapsed_hours(run.started_at) > max_hours:
+        if max_hours and _elapsed_hours(run.started_at) > max_hours:
             try:
                 await executor.kill_pid(int(run.pid or 0))
                 await ingest_chunk()

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -326,7 +326,7 @@ def experiment_plan(run: VoyageRun) -> list[dict[str, Any]]:
 
     失败语义按节点分派：plan/setup/analyze/figures/report 失败走 loop 回灌
     （原地重试 → AI 计划调整）；smoke 保留 on_failure="fail"——动作内部已有
-    LLM 修复循环（MAX_SMOKE_FIXES），修完仍失败说明代码根本性不可用，诚实硬停
+    LLM 修复循环（只受时间预算约束），仍失败会转向用户提问，不自动重规划
     且 max_attempts=1 防引擎级重跑整个修复循环。
     """
     steps = [

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -31,6 +31,9 @@ from app.schemas.common import BatchResult, TrashBatchAction
 from app.schemas.experiment import (
     ExperimentCreate,
     ExperimentDetail,
+    ExperimentIntakeQuestion,
+    ExperimentIntakeQuestions,
+    ExperimentIntakeRequest,
     ExperimentLogsRead,
     ExperimentRead,
 )
@@ -39,6 +42,79 @@ from app.services import projects as projects_service
 from app.services import ssh_exec
 
 router = APIRouter(tags=["experiments"])
+
+# 开题提问：按 idea 让 AI 提出 ≤5 个影响开局的整体性问题（数据集/规模/评测口径/
+# 资源与框架约束/成功判据），代替静态表单字段；其余不确定点实验中经 ask 机制动态交互。
+_INTAKE_MAX_QUESTIONS = 5
+_INTAKE_SYSTEM_PROMPT = """\
+你是 Experiment Lab 的开题助手。用户选定了一个研究想法，准备交给自动化实验 agent
+（它会自己规划、写代码、建环境、跑实验、分析迭代）。请提出对「实验规划与环境设置」
+最关键的问题，帮用户在开局把方向定准。
+只输出一个 JSON 对象，不要输出任何其他文字或 Markdown 代码块，格式：
+{"questions": [{"question": "问题", "hint": "一句提示/候选/示例，帮助快速作答"}]}
+约束：
+- 最多 5 个；只问**影响开局的整体性问题**（如用哪个数据集与规模、评测口径与基线、
+  GPU/框架/模型约束、成功判据、要不要对照组）；能在实验过程中动态确认的细节不要问
+- 问题必须针对这个想法本身，不问放之四海皆准的空话；已经能从想法内容里读出的答案不要再问
+- 用大白话，中文提问
+"""
+
+
+@router.post(
+    "/projects/{project_id}/experiments/intake-questions",
+    response_model=ExperimentIntakeQuestions,
+)
+async def experiment_intake_questions(
+    project_id: uuid.UUID,
+    data: ExperimentIntakeRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_experiment),
+) -> ExperimentIntakeQuestions:
+    """按 idea 生成开题问题（LLM 不可用/输出非法时降级为空列表，前端直接创建）。"""
+    import json as _json
+
+    from app.core.llm.base import Message
+    from app.core.llm.router import get_llm_router
+    from app.models.idea import Idea
+
+    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    idea = await session.get(Idea, data.idea_id)
+    if idea is None or idea.project_id != project.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="IDEA_NOT_FOUND")
+
+    user_prompt = (
+        f"想法标题：{idea.title}\n"
+        f"想法概述：{idea.summary or '（无）'}\n"
+        f"想法详情：\n{(idea.content or '')[:4000]}"
+    )
+    try:
+        result = await get_llm_router().complete(
+            "experiment",
+            [
+                Message(role="system", content=_INTAKE_SYSTEM_PROMPT),
+                Message(role="user", content=user_prompt),
+            ],
+            user_id=user.id,
+            project_id=project.id,
+        )
+        start, end = result.content.find("{"), result.content.rfind("}")
+        payload = _json.loads(result.content[start : end + 1])
+        questions: list[ExperimentIntakeQuestion] = []
+        for raw in payload.get("questions") or []:
+            if not isinstance(raw, dict):
+                continue
+            question = str(raw.get("question") or "").strip()
+            if not question:
+                continue
+            hint = str(raw.get("hint") or "").strip() or None
+            questions.append(ExperimentIntakeQuestion(question=question[:500], hint=hint))
+            if len(questions) >= _INTAKE_MAX_QUESTIONS:
+                break
+        return ExperimentIntakeQuestions(questions=questions)
+    except Exception:  # noqa: BLE001 — 开题提问是增强项，失败不阻塞创建
+        return ExperimentIntakeQuestions(questions=[])
 
 _HEARTBEAT_SECONDS = 15.0
 _STREAM_POLL_SECONDS = 1.0

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -8,10 +8,18 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ExperimentBudget(BaseModel):
-    max_hours: float = Field(default=4, ge=0)
+    # 0 = 无限时（默认）：修复循环/运行轮询只受它约束，不再按次数设限（用户定调）
+    max_hours: float = Field(default=0, ge=0)
     max_runs: int = Field(default=10, ge=1)
     # 连续 N 轮主指标无提升即停（docs/api-m5-a.md §3）
     no_improve_stop: int = Field(default=2, ge=1)
+
+
+class IntakeQA(BaseModel):
+    """开题问答：创建实验时 AI 按 idea 提出的问题与用户的回答（可留空）。"""
+
+    question: str = Field(min_length=1, max_length=500)
+    answer: str = Field(default="", max_length=4000)
 
 
 class ExperimentParams(BaseModel):
@@ -24,6 +32,22 @@ class ExperimentParams(BaseModel):
     hf_mirror: bool = False
     # 用户对实验的补充说明（原文进 plan 与 codegen prompt）
     extra_notes: str | None = None
+    # 开题问答（AI 按 idea 生成 ≤5 个整体性问题，用户作答后随创建提交；
+    # 原文进 plan 与 codegen prompt——其余不确定点实验中经 ask 机制动态交互）
+    intake: list[IntakeQA] | None = None
+
+
+class ExperimentIntakeQuestion(BaseModel):
+    question: str
+    hint: str | None = None
+
+
+class ExperimentIntakeQuestions(BaseModel):
+    questions: list[ExperimentIntakeQuestion]
+
+
+class ExperimentIntakeRequest(BaseModel):
+    idea_id: uuid.UUID
 
 
 class ExperimentCreate(BaseModel):

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -39,7 +39,8 @@ from app.services.projects import in_my_projects
 
 logger = logging.getLogger("polaris.experiments")
 
-DEFAULT_BUDGET: dict[str, Any] = {"max_hours": 4, "max_runs": 10, "no_improve_stop": 2}
+# max_hours=0 = 无限时（用户定调：修复/运行只受显式时间预算约束，默认不设限）
+DEFAULT_BUDGET: dict[str, Any] = {"max_hours": 0, "max_runs": 10, "no_improve_stop": 2}
 
 
 class IdeaNotFoundError(Exception):
@@ -145,6 +146,12 @@ async def create_experiment(
                 "eval_model": params.eval_model if params else None,
                 "hf_mirror": bool(params.hf_mirror) if params else False,
                 "extra_notes": params.extra_notes if params else None,
+                # 开题问答（AI 按 idea 生成的问题 + 用户回答）：进 plan/codegen prompt
+                "intake": (
+                    [qa.model_dump() for qa in params.intake]
+                    if params and params.intake
+                    else None
+                ),
             }
         },
         budget=None,

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -236,37 +236,33 @@ async def test_no_improve_stop_budget_param(client, queue_stub, fake_ssh, bus_re
     assert detail["iteration_state"]["no_improve_streak"] == 3
 
 
-async def test_debug_limit_terminates(client, queue_stub, fake_ssh, bus_recorder):
-    """运行失败走 debug 分支：独立限额 3 次，第 4 次 debug 决策直接终止。
-
-    全部轮次失败 → 一个主指标都没产出 → 完成标准终检不过：不再一律 paused_error，
-    转向用户提问（接受为完成 / 继续补做 / 放弃），实验镜像 waiting_user。
-    """
+async def test_debug_repeats_until_run_budget(client, queue_stub, fake_ssh, bus_recorder):
+    """debug 不再按次数终止（旧限额 3 次）：只受轮数/时间预算约束。
+    每轮都失败、decision 一直 debug → 修到 max_runs 截断；全部轮次失败 →
+    完成标准终检转提问（零主指标），报告仍按事实收口为 failed。"""
     fake_ssh.run_exit = 1  # 每轮正式运行都失败
     fake_ssh.run_log = "Traceback: train boom\n"
-    project_id, headers, exp_id, voyage_id = await _launch_experiment(client)
+    project_id, headers, exp_id, voyage_id = await _launch_experiment(
+        client, budget={"max_hours": 2, "max_runs": 5}
+    )
     await _drive_pipeline(
         client, headers, project_id, voyage_id, _router_with(_FixedReflectionProvider("debug"))
     )
 
     voyage_status, observation = await _iterate_observation(client, headers, voyage_id)
     assert voyage_status == "paused_ask"
-    assert observation["stopped_reason"] == "debug_limit"
+    assert observation["stopped_reason"] == "max_runs"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     assert resp.json()["open_ask"]["payload"]["ask_kind"] == "done_criteria"
     detail = await _get_detail(client, headers, exp_id)
-    assert len(detail["runs"]) == 4  # 首轮 + 3 次 debug 修复重跑
+    assert len(detail["runs"]) == 5  # 修过 4 次（超过旧限额 3）仍在继续，直到轮数预算
     assert all(r["status"] == "failed" for r in detail["runs"])
     assert all(r["reflection"]["decision"] == "debug" for r in detail["runs"])
     state = detail["iteration_state"]
-    assert state["no_improve_streak"] == 0  # 失败轮无主指标，不计入无提升
-    assert state["debug_count"] == 3
-    assert state["stopped_reason"] == "debug_limit"
-    # 末轮全失败 → 报告仍按事实收口为 failed（终态在先，提问镜像不覆盖终态）；
-    # 但 voyage 的完成标准提问仍开着，用户可拍板接受/放弃
+    assert state["debug_count"] == 4  # 不再在 3 处截断
+    assert state["stopped_reason"] == "max_runs"
     assert detail["status"] == "failed"
     assert detail["report"].startswith("## 实验报告")
-
 
 async def test_analyze_ask_pauses_then_guidance_continues(
     client, queue_stub, fake_ssh, bus_recorder

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -338,10 +338,10 @@ async def test_smoke_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus
     assert resp.json()["status"] == "done"
 
 
-async def test_smoke_exhausted_asks_user(client, queue_stub, fake_ssh, bus_recorder):
-    """冒烟连续失败（1 次 + 2 次修复重试）→ 不再打死任务：动作主动提问（paused_ask），
-    节点回 pending 不烧尝试预算；实验镜像「等你回复」；回答重试后修复计数清零续跑。"""
-    fake_ssh.smoke_exits = [1, 1, 1, 0]  # 前 3 次失败（额度用尽提问），回答重试后第 4 次通过
+async def test_smoke_fixes_unbounded_until_success(client, queue_stub, fake_ssh, bus_recorder):
+    """冒烟修复不再按次数设限：连续失败 3 次（超过旧上限）仍继续修，第 4 次通过，
+    全程不提问、不打断，整条流水线走完。"""
+    fake_ssh.smoke_exits = [1, 1, 1, 0]
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
@@ -355,33 +355,13 @@ async def test_smoke_exhausted_asks_user(client, queue_stub, fake_ssh, bus_recor
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
-    assert voyage["status"] == "paused_ask"
-    ask = voyage["open_ask"]
-    assert ask is not None and ask["payload"]["ask_kind"] == "fatal_step"
-    assert "代码试跑连续失败" in ask["text"]
+    assert voyage["status"] == "done", voyage
+    smoke_step = next(s for s in voyage["steps"] if s["action"] == "experiment.smoke")
+    assert smoke_step["observation"] == {"exit_code": 0, "attempts": 4, "fixes": 3}
     statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
-    assert "replanning" not in statuses  # 不走 LLM 重规划
-    smoke_step = voyage["steps"][2]
-    assert smoke_step["action"] == "experiment.smoke"
-    assert smoke_step["status"] == "pending"  # 提问不烧尝试预算，节点等回答后重跑
-
-    # 实验镜像「等你回复」，不再被 _guarded 提前打成 failed
-    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
-    assert resp.json()["status"] == "waiting_user"
-
-    # 回答「重试」并附指示 → 恢复执行；冒烟重跑通过，整条流水线走完
-    resp = await client.post(
-        f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
-        json={"choice": "retry", "text": "换个更小的冒烟配置"},
-        headers=headers,
-    )
-    assert resp.status_code == 201
-    await engine.resume(uuid.UUID(voyage_id))
-    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    assert resp.json()["status"] == "done"
+    assert "paused_ask" not in statuses  # 修复期间不打断
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "done"
-
 
 async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus_recorder):
     """依赖安装第一次失败 → 报错回 LLM 修 requirements/run.sh → 重装通过（对称 smoke 自愈）。"""
@@ -409,10 +389,10 @@ async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh,
     assert resp.json()["status"] == "done"
 
 
-async def test_setup_deps_exhausted_asks_then_retry(client, queue_stub, fake_ssh, bus_recorder):
-    """依赖装不上、内部修复用尽 → 不再抛错让引擎盲目重装（线上实测「一直装镜像」）：
-    转向用户提问（paused_ask）；回答重试后修复计数清零、装通、整条流水线走完。"""
-    fake_ssh.setup_exits = [1, 1, 1, 0]  # 耗尽一轮内部修复（1 次 + 2 次 fixes）→ 提问；答后重装通过
+async def test_setup_fixes_unbounded_until_success(client, queue_stub, fake_ssh, bus_recorder):
+    """修复不再按次数设限（用户定调）：连续失败 3 次（超过旧上限 2）仍继续修，
+    第 4 次装通、整条流水线走完，全程不提问。"""
+    fake_ssh.setup_exits = [1, 1, 1, 0]
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
@@ -425,26 +405,58 @@ async def test_setup_deps_exhausted_asks_then_retry(client, queue_stub, fake_ssh
     await engine.resume(uuid.UUID(voyage_id))
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "done", resp.json()
+    setup_step = next(s for s in resp.json()["steps"] if s["action"] == "experiment.setup")
+    assert setup_step["observation"]["fixes"] == 3  # 旧上限是 2：现在不设限
+    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
+    assert resp.json()["status"] == "done"
+
+
+async def test_setup_time_budget_exceeded_asks(
+    client, queue_stub, fake_ssh, bus_recorder, monkeypatch
+):
+    """唯一的刹车是时间预算：超出 budget.max_hours → 转向用户提问；
+    回答重试后（时间预算内）装通走完。"""
+    fake_ssh.setup_exits = [1, 0]
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(
+        client, headers, project_id, idea_id, cred_id, budget={"max_hours": 2, "max_runs": 3}
+    )
+    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(voyage_id))
+    await _approve_gate(client, headers, project_id)
+    # 让「本阶段已耗时」显得超预算（相位时钟拨快）
+    monkeypatch.setattr(ax, "_phase_deadline_exceeded", lambda budget, started: True)
+    await engine.resume(uuid.UUID(voyage_id))
+
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
     assert voyage["status"] == "paused_ask", voyage
     ask = voyage["open_ask"]
-    assert ask is not None and "实验环境装不起来" in ask["text"]
-    setup_step = next(s for s in voyage["steps"] if s["action"] == "experiment.setup")
-    assert setup_step["status"] == "pending"  # 提问不烧尝试预算
+    assert ask is not None and "超出时间预算" in ask["text"]
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "waiting_user"
 
-    # 回答重试 → setup 重跑（第 4 个退出码 0）→ 全程走完
+    # 回答重试（恢复真实时钟）→ 装通走完
+    monkeypatch.setattr(
+        ax, "_phase_deadline_exceeded", ax._phase_deadline_exceeded.__wrapped__
+        if hasattr(ax._phase_deadline_exceeded, "__wrapped__")
+        else ax._phase_deadline_exceeded,
+    )
+    monkeypatch.undo()
+    monkeypatch.setattr(ax, "RUN_POLL_SECONDS", 0)  # undo 会连 fast_poll 一起撤销，补回
     resp = await client.post(
         f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
-        json={"choice": "retry", "text": "精简依赖再装一次"},
+        json={"choice": "retry", "text": "换更快的镜像源"},
         headers=headers,
     )
     assert resp.status_code == 201
     await engine.resume(uuid.UUID(voyage_id))
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    assert resp.json()["status"] == "done"
-    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.json()["status"] == "done"
 
 
@@ -597,6 +609,93 @@ async def test_experiment_memory_written_and_synced(client, queue_stub, fake_ssh
         assert "第 3 轮结论" in resp.json()["content"]
     finally:
         ssh_exec.set_connector_factory(None)
+
+
+class _IntakeProvider(FakeProvider):
+    """开题提问：返回 6 个问题（超上限，应被截到 5）。"""
+
+    async def complete(self, messages, *, model, temperature=0.7, max_tokens=None, images=None):
+        full = "\n".join(m.content for m in messages)
+        if "开题助手" in full:
+            payload = {
+                "questions": [
+                    {"question": f"问题 {i}：用哪个数据集？", "hint": f"提示 {i}"}
+                    for i in range(1, 7)
+                ]
+            }
+            return CompletionResult(
+                content=json.dumps(payload, ensure_ascii=False),
+                model=model,
+                finish_reason="stop",
+                usage={"prompt_tokens": 1, "completion_tokens": 1},
+            )
+        return await super().complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens, images=images
+        )
+
+
+async def test_intake_questions_and_answers_reach_plan(client, queue_stub, fake_ssh, bus_recorder):
+    """开题提问端点：按 idea 生成问题（≤5 截断）；回答随创建提交后进 plan prompt。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+
+    from app.core.llm import router as llm_router_module
+
+    router = llm_router_module.get_llm_router()
+    router.override_provider(_IntakeProvider())
+    try:
+        resp = await client.post(
+            f"/api/projects/{project_id}/experiments/intake-questions",
+            json={"idea_id": idea_id},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        questions = resp.json()["questions"]
+        assert len(questions) == 5  # 超出上限被截断
+        assert questions[0]["question"].startswith("问题 1")
+        assert questions[0]["hint"] == "提示 1"
+    finally:
+        llm_router_module.reset_llm_router()
+
+    # 带开题问答创建：答案进 plan prompt（prompt spy）
+    class _PlanPromptSpy(FakeProvider):
+        def __init__(self) -> None:
+            self.saw_intake = False
+
+        async def complete(self, messages, *, model, temperature=0.7, max_tokens=None, images=None):
+            full = "\n".join(m.content for m in messages)
+            if "开题问答" in full and "用 GSM8K 的前 500 条" in full:
+                self.saw_intake = True
+            return await FakeProvider.complete(
+                self, messages, model=model, temperature=temperature, max_tokens=max_tokens,
+                images=images,
+            )
+
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    # 重建一个带 intake 的实验（上面的默认建实验只是确认互不影响）
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={
+            "idea_id": idea_id,
+            "credential_id": cred_id,
+            "params": {
+                "intake": [
+                    {"question": "用哪个数据集？", "answer": "用 GSM8K 的前 500 条"},
+                    {"question": "要对照组吗？", "answer": ""},
+                ]
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    voyage_id = resp.json()["voyage_id"]
+    spy = _PlanPromptSpy()
+    router = LLMRouter()
+    router.override_provider(spy)
+    engine, _ = _make_engine(router)
+    await engine.run(uuid.UUID(voyage_id))  # 跑到 compute_budget 闸门（plan 已生成）
+    assert spy.saw_intake
 
 
 def test_parse_gpu_csv_unit():
@@ -783,7 +882,7 @@ async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_record
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
     resp = await _create_experiment(
-        client, headers, project_id, idea_id, cred_id, budget={"max_hours": 0, "max_runs": 3}
+        client, headers, project_id, idea_id, cred_id, budget={"max_hours": 1e-9, "max_runs": 3}
     )
     exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
 
@@ -1063,10 +1162,10 @@ async def test_create_experiment_validation(client, queue_stub, fake_ssh):
     assert resp.status_code == 404
     assert resp.json()["detail"] == "CREDENTIAL_NOT_FOUND"
 
-    # 默认预算（M5-A：含 no_improve_stop）
+    # 默认预算：时数 0 = 无限时（用户定调），轮数与无提升阈值保底
     resp = await _create_experiment(client, headers, project_id, promoted_id, cred_id)
     assert resp.status_code == 201
-    assert resp.json()["budget"] == {"max_hours": 4, "max_runs": 10, "no_improve_stop": 2}
+    assert resp.json()["budget"] == {"max_hours": 0, "max_runs": 10, "no_improve_stop": 2}
 
 
 async def test_experiment_member_permissions(client, queue_stub, fake_ssh):

--- a/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
+++ b/src/frontend/src/features/experiment/ExperimentDetailPage.tsx
@@ -622,12 +622,6 @@ export function ExperimentDetailPage() {
       {/* 页头 */}
       <div className="row" style={{ alignItems: 'flex-start', marginBottom: 4 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="h-eyebrow row gap8">
-            <span className="row gap6" style={{ cursor: 'pointer' }} onClick={() => navigate(topicPath(exp.project_id, 'experiment'))}>
-              ← Experiment Lab
-            </span>
-            <span className="mono" style={{ textTransform: 'none', color: 'var(--text-4)' }}>{exp.id.slice(0, 8)}</span>
-          </div>
           <h1 className="h-title" style={{ fontSize: 20 }}>{exp.idea_title}</h1>
           <div className="row gap8" style={{ marginTop: 10, flexWrap: 'wrap' }}>
             <StatusPill status={exp.status} sm />

--- a/src/frontend/src/features/experiment/NewExperimentModal.tsx
+++ b/src/frontend/src/features/experiment/NewExperimentModal.tsx
@@ -6,14 +6,15 @@ import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
 import { toast } from '../../components/ui/Toast';
 import { SelectMenu } from '../../components/ui/SelectMenu';
-import { api } from '../../lib/api';
+import { api, type ExperimentIntakeQuestion } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
 
 /* ============================================================
    新建实验 Modal：选 promoted idea + SSH 凭据 + 预算 →
-   POST /projects/{pid}/experiments（后端同时创建 experiment voyage）。
-   无凭据时提示去设置页添加。
+   AI 按 idea 生成 ≤5 个开题问题（代替静态 GPU 提示/高级选项表单），
+   用户作答（可跳过）→ POST /projects/{pid}/experiments。
+   其余不确定点实验过程中经提问机制动态交互——用户决定权更大、更灵活。
    ============================================================ */
 
 export interface NewExperimentModalProps {
@@ -30,13 +31,11 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
 
   const [ideaId, setIdeaId] = useState('');
   const [credentialId, setCredentialId] = useState('');
-  const [maxHours, setMaxHours] = useState('4');
+  const [maxHours, setMaxHours] = useState('');
   const [maxRuns, setMaxRuns] = useState('10');
-  const [gpuHint, setGpuHint] = useState('');
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [evalModel, setEvalModel] = useState('');
-  const [hfMirror, setHfMirror] = useState(false);
-  const [extraNotes, setExtraNotes] = useState('');
+  const [questions, setQuestions] = useState<ExperimentIntakeQuestion[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [intakeState, setIntakeState] = useState<'idle' | 'loading' | 'ready' | 'skipped'>('idle');
 
   const ideasQuery = useQuery({
     queryKey: ['ideas', pid, 'promoted'],
@@ -57,13 +56,11 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
   useEffect(() => {
     if (!open) return;
     setIdeaId(initialIdeaId ?? '');
-    setMaxHours('4');
+    setMaxHours('');
     setMaxRuns('10');
-    setGpuHint('');
-    setShowAdvanced(false);
-    setEvalModel('');
-    setHfMirror(false);
-    setExtraNotes('');
+    setQuestions([]);
+    setAnswers([]);
+    setIntakeState('idle');
   }, [open, initialIdeaId]);
 
   // 凭据加载后默认选第一个
@@ -75,22 +72,46 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
     if (creds.length === 0) setCredentialId('');
   }, [open, creds, credentialId]);
 
+  // 选定 idea → AI 生成开题问题（失败/为空则静默降级：直接创建）
+  useEffect(() => {
+    if (!open || !ideaId) return;
+    let cancelled = false;
+    setIntakeState('loading');
+    setQuestions([]);
+    setAnswers([]);
+    api
+      .getExperimentIntakeQuestions(pid, ideaId)
+      .then((r) => {
+        if (cancelled) return;
+        const qs = (r.questions ?? []).slice(0, 5);
+        setQuestions(qs);
+        setAnswers(qs.map(() => ''));
+        setIntakeState(qs.length > 0 ? 'ready' : 'skipped');
+      })
+      .catch(() => {
+        if (!cancelled) setIntakeState('skipped');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, pid, ideaId]);
+
   const mutation = useMutation({
     mutationFn: () => {
       const hours = Number(maxHours);
       const runs = Number(maxRuns);
+      const intake = questions
+        .map((q, i) => ({ question: q.question, answer: (answers[i] ?? '').trim() }))
+        .filter((qa) => qa.answer !== '');
       return api.createExperiment(pid, {
         idea_id: ideaId,
         credential_id: credentialId,
         params: {
-          ...(gpuHint.trim() ? { gpu_hint: gpuHint.trim() } : {}),
-          ...(evalModel.trim() ? { eval_model: evalModel.trim() } : {}),
-          ...(hfMirror ? { hf_mirror: true } : {}),
-          ...(extraNotes.trim() ? { extra_notes: extraNotes.trim() } : {}),
+          ...(intake.length > 0 ? { intake } : {}),
           budget: {
-            ...(Number.isFinite(hours) && hours > 0 ? { max_hours: hours } : {}),
+            // 留空 = 无限时（后端 0 = 不设时限）
+            max_hours: Number.isFinite(hours) && hours > 0 ? hours : 0,
             ...(Number.isFinite(runs) && runs > 0 ? { max_runs: runs } : {}),
-            // M5-A 固定值：连续 2 轮主指标无提升自动停止
             no_improve_stop: 2,
           },
         },
@@ -187,84 +208,66 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
       )}
 
       <div className="row gap12" style={{ alignItems: 'flex-start' }}>
-        <FormField label={tr('预算 · 最长时数', 'Budget · max hours')} en="max_hours" style={{ flex: 1 }}>
-          <input className="input mono" inputMode="decimal" value={maxHours} onChange={(e) => setMaxHours(e.target.value)} placeholder="4" />
+        <FormField
+          label={tr('时间预算（小时）', 'Time budget (hours)')}
+          en="max_hours"
+          style={{ flex: 1 }}
+          hint={tr('留空 = 不限时。这是唯一的自动修复刹车：超时会暂停并问你怎么办。', 'Empty = unlimited. The only brake on auto-fixing: on timeout it pauses and asks you.')}
+        >
+          <input className="input mono" inputMode="decimal" value={maxHours} onChange={(e) => setMaxHours(e.target.value)} placeholder={tr('不限', 'unlimited')} />
         </FormField>
-        <FormField label={tr('预算 · 最多运行轮数', 'Budget · max runs')} en="max_runs" style={{ flex: 1 }}>
+        <FormField label={tr('最多运行轮数', 'Max runs')} en="max_runs" style={{ flex: 1 }}>
           <input className="input mono" inputMode="numeric" value={maxRuns} onChange={(e) => setMaxRuns(e.target.value)} placeholder="10" />
         </FormField>
         <FormField
-          label={tr('预算 · 无提升自动停', 'Budget · auto stop')}
+          label={tr('无提升自动停', 'Auto stop')}
           en="no_improve_stop"
           style={{ flex: 1 }}
-          hint={tr('固定值：连续 2 轮主指标无提升自动停止。', 'Fixed: stops after 2 runs in a row without metric gain.')}
+          hint={tr('连续 2 轮主指标无提升自动收尾。', 'Wraps up after 2 runs in a row without metric gain.')}
         >
           <input className="input mono" value={tr('2 轮', '2 runs')} disabled />
         </FormField>
       </div>
-      <FormField label={tr('GPU 提示（可选）', 'GPU hint (optional)')} en="gpu_hint" hint={tr('供计划阶段参考。', 'Used as a reference when planning.')}>
-        <input className="input mono" value={gpuHint} onChange={(e) => setGpuHint(e.target.value)} placeholder={tr('如 1×A100', 'e.g. 1×A100')} />
-      </FormField>
 
-      <button
-        type="button"
-        className="btn btn-ghost sm"
-        style={{ marginBottom: showAdvanced ? 10 : 14, paddingLeft: 0 }}
-        onClick={() => setShowAdvanced((v) => !v)}
-      >
-        <Icon name={showAdvanced ? 'chevDown' : 'chevron'} size={13} />
-        {tr('高级选项', 'Advanced options')}
-      </button>
-      {showAdvanced && (
-        <>
-          <FormField
-            label={tr('评测模型（可选）', 'Eval model (optional)')}
-            en="eval_model"
-            hint={tr(
-              '实验代码将获得该模型的 API 访问，接入点与密钥写入工作目录 llm_config.json。',
-              'The experiment code gets API access to this model; endpoint and key are written to llm_config.json in the workdir.',
-            )}
-          >
-            <input
-              className="input mono"
-              value={evalModel}
-              onChange={(e) => setEvalModel(e.target.value)}
-              placeholder="qwen36-35b-a3b"
-            />
-          </FormField>
-          <FormField
-            label={tr('HuggingFace 镜像', 'HuggingFace mirror')}
-            en="hf_mirror"
-            hint={tr('训练类实验从 hf-mirror.com 拉取模型与数据集（大陆网络推荐勾选）。', 'Training experiments pull models and datasets from hf-mirror.com (recommended on mainland-China networks).')}
-          >
-            <label className="row gap8" style={{ fontSize: 12.5, cursor: 'pointer' }}>
-              <input type="checkbox" checked={hfMirror} onChange={(e) => setHfMirror(e.target.checked)} />
-              {tr('启用 HF 镜像（注入 HF_ENDPOINT）', 'Enable HF mirror (injects HF_ENDPOINT)')}
-            </label>
-          </FormField>
-          <FormField
-            label={tr('补充说明（可选）', 'Extra notes (optional)')}
-            en="extra_notes"
-            hint={tr(
-              '会原文提供给计划与代码生成的 AI。',
-              'Passed verbatim to the planning and code-writing AI.',
-            )}
-          >
-            <textarea
-              className="textarea"
-              rows={3}
-              value={extraNotes}
-              onChange={(e) => setExtraNotes(e.target.value)}
-              placeholder={tr('如：只评测 ALFWorld 前 30 个任务；必须对比 ReAct 基线', 'e.g. only eval the first 30 ALFWorld tasks; must compare against the ReAct baseline')}
-            />
-          </FormField>
-        </>
+      {/* 开题问答：选定 idea 后 AI 生成 ≤5 个整体性问题（可不答；实验中还能随时对话） */}
+      {ideaId && intakeState === 'loading' && (
+        <div className="row gap8" style={{ padding: '14px 4px', fontSize: 12.5, color: 'var(--text-3)' }}>
+          <Icon name="sparkle" size={14} style={{ color: 'var(--accent)', animation: 'ai-dot-pulse 1.2s ease-in-out infinite' }} />
+          {tr('AI 正在根据这个想法准备几个开题问题…', 'The AI is preparing a few intake questions for this idea…')}
+        </div>
+      )}
+      {ideaId && intakeState === 'ready' && (
+        <div style={{ marginBottom: 6 }}>
+          <div className="row gap6" style={{ marginBottom: 10 }}>
+            <Icon name="sparkle" size={14} style={{ color: 'var(--accent)' }} />
+            <span style={{ fontSize: 13, fontWeight: 650 }}>
+              {tr('AI 想先确认几件事', 'The AI wants to confirm a few things first')}
+            </span>
+            <span style={{ fontSize: 11.5, color: 'var(--text-4)' }}>
+              {tr('（不答也行，实验中还能随时对话补充）', '(optional — you can also chat during the run)')}
+            </span>
+          </div>
+          {questions.map((q, i) => (
+            <FormField key={i} label={`${i + 1}. ${q.question}`} hint={q.hint ?? undefined}>
+              <textarea
+                className="textarea"
+                rows={2}
+                value={answers[i] ?? ''}
+                onChange={(e) =>
+                  setAnswers((prev) => prev.map((a, j) => (j === i ? e.target.value : a)))
+                }
+                placeholder={tr('（可留空，交给 AI 判断）', '(leave empty to let the AI decide)')}
+                style={{ minHeight: 44 }}
+              />
+            </FormField>
+          ))}
+        </div>
       )}
 
       <div style={{ fontSize: 11, color: 'var(--text-4)', lineHeight: 1.6 }}>
         {tr(
-          '消耗真实算力前会提交算力预算审批等待人工确认；超时或超预算会自动终止并标记失败。',
-          'Before real compute is spent, a budget approval is submitted for human sign-off; runs over time or budget are killed and marked failed.',
+          '消耗真实算力前会提交算力预算审批等待人工确认；实验中 AI 拿不准会随时暂停问你。',
+          'Before real compute is spent, a budget approval awaits human sign-off; whenever the AI is unsure mid-run it pauses and asks you.',
         )}
       </div>
     </Modal>

--- a/src/frontend/src/features/experiment/RunTab.tsx
+++ b/src/frontend/src/features/experiment/RunTab.tsx
@@ -238,8 +238,7 @@ function IterationStateBar({ exp, runCount }: { exp: ExperimentDetail; runCount:
     },
     {
       label: tr('修错次数', 'Debug attempts'),
-      value: `${st?.debug_count ?? 0} / 3`,
-      warn: (st?.debug_count ?? 0) >= 2,
+      value: String(st?.debug_count ?? 0),
     },
   ];
   return (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1945,6 +1945,17 @@ export interface ExperimentCodeFile {
   content: string;
 }
 
+/** 开题问答：创建实验时 AI 按 idea 提出的问题与用户的回答（可留空）。 */
+export interface ExperimentIntakeQA {
+  question: string;
+  answer: string;
+}
+
+export interface ExperimentIntakeQuestion {
+  question: string;
+  hint: string | null;
+}
+
 export interface CreateExperimentInput {
   idea_id: string;
   credential_id: string;
@@ -1957,6 +1968,8 @@ export interface CreateExperimentInput {
     hf_mirror?: boolean;
     /** 用户对实验的补充说明（进计划与代码生成 prompt） */
     extra_notes?: string;
+    /** 开题问答（AI 按 idea 生成的问题 + 用户回答；进计划与代码生成 prompt） */
+    intake?: ExperimentIntakeQA[];
   };
 }
 
@@ -3978,6 +3991,17 @@ export const api = {
   // —— M4 · Experiments ——
   createExperiment(projectId: string, input: CreateExperimentInput): Promise<ExperimentRead> {
     return requestJson<ExperimentRead>(`/projects/${projectId}/experiments`, 'POST', input);
+  },
+  /** 开题提问：AI 按 idea 生成 ≤5 个整体性问题（失败/不可用时返回空列表）。 */
+  getExperimentIntakeQuestions(
+    projectId: string,
+    ideaId: string,
+  ): Promise<{ questions: ExperimentIntakeQuestion[] }> {
+    return requestJson<{ questions: ExperimentIntakeQuestion[] }>(
+      `/projects/${projectId}/experiments/intake-questions`,
+      'POST',
+      { idea_id: ideaId },
+    );
   },
   /** 默认返回活动列表；opts.trashed=true 返回回收站（已软删除的实验）。 */
   listExperiments(projectId: string, opts?: { trashed?: boolean }): Promise<ExperimentRead[]> {


### PR DESCRIPTION
Implements #339.

## 1. Fix counts are gone — time is the only brake

- `MAX_SETUP_FIXES` / `MAX_SMOKE_FIXES` / `MAX_DEBUG_FIXES` removed. Setup and smoke fix loops repair indefinitely until success or the phase exceeds `budget.max_hours` (`_phase_deadline_exceeded`, measured from loop start so waiting time doesn't count), at which point they **ask the user** with the log tail and warnings as context. Every iteration still re-drains conversation guidance, so the user can steer or abort at any moment.
- Analyze's debug branch no longer terminates on a count; only `max_runs` / `max_hours` / no-improve budgets apply (`debug_count` still tracked for display).
- `max_hours` semantics unified: **0 / unset = unlimited** everywhere; the per-run poll previously treated 0 as an instant timeout (test updated to `1e-9` to keep the kill coverage). Default budget is now unlimited time.

## 2. AI intake questions replace static form fields

- New endpoint `POST /projects/{pid}/experiments/intake-questions`: up to 5 idea-specific, opening-level questions (dataset & scale, eval protocol & baselines, resource/framework constraints, success criteria). Failure degrades to an empty list; creation is never blocked.
- The modal drops GPU hint + advanced options; answers ride as `params.intake` and are injected verbatim into plan/codegen prompts (`开题问答` section). Mid-run uncertainty stays with the interactive ask mechanism — the user keeps the wheel throughout.
- Also removes the `← Experiment Lab · id` eyebrow on the detail page and the stale `/3` debug counter.

## Tests

- setup/smoke unbounded-fix round-trips (3 failures > old cap, then success, no interruption)
- time-budget-exceeded ask + answer-retry recovery (phase clock monkeypatched)
- debug repeats past the old limit until `max_runs` (rewrite of the old debug-limit test)
- intake endpoint truncates to 5 and validates; answers reach the plan prompt (prompt spy)
- 97 passed across the experiment/ask/loop suites; `tsc` + `vite build` clean

Closes #339