### PR TITLE
"All assets" is a wider scope, not the absence of one

### DIFF
--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -186,7 +186,7 @@ async def list_experiments(
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows = await experiments_service.list_experiments(
-        session, project_id=project_id, trashed=trashed
+        session, project_ids=[project_id], trashed=trashed
     )
     return [experiments_service.to_read(exp, title) for exp, title in rows]
 

--- a/src/backend/app/api/ideas.py
+++ b/src/backend/app/api/ideas.py
@@ -162,7 +162,7 @@ async def list_ideas(
     await _member_project(session, project_id, user)
     ideas = await ideas_service.list_ideas(
         session,
-        project_id=project_id,
+        project_ids=[project_id],
         status=status_filter,
         depth=depth,
         research_type=research_type,
@@ -339,7 +339,7 @@ async def get_leaderboard(
     user: User = Depends(current_active_user),
 ) -> list[IdeaLeaderboardEntry]:
     await _member_project(session, project_id, user)
-    ideas = await ideas_service.list_ideas(session, project_id=project_id, sort="elo")
+    ideas = await ideas_service.list_ideas(session, project_ids=[project_id], sort="elo")
     return [IdeaLeaderboardEntry.model_validate(i) for i in ideas]
 
 

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -357,7 +357,7 @@ async def list_manuscripts(
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     rows = await manuscripts_service.list_manuscripts(
-        session, project_id=project_id, trashed=trashed
+        session, project_ids=[project_id], trashed=trashed
     )
     return [ManuscriptRead.model_validate(m) for m in rows]
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -8,6 +8,7 @@
 import logging
 import shutil
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -217,14 +218,22 @@ def serialize_figures(experiment: Experiment) -> list[ExperimentFigure]:
 
 
 async def list_experiments(
-    session: AsyncSession, *, project_id: uuid.UUID, trashed: bool = False
+    session: AsyncSession, *, project_ids: Sequence[uuid.UUID], trashed: bool = False
 ) -> list[tuple[Experiment, str]]:
+    """这些课题下的实验。
+
+    收一个列表而不是单个 id：界面上问的是「这个课题的实验」（传一个），而助手在
+    不收窄课题时问的是「我能看到的实验」（传全部参与的课题）。以前只能传一个，
+    助手那条路就只好传 None，SQL 里成了 project_id = NULL，一条都匹配不到。
+    """
+    if not project_ids:
+        return []
     trash_cond = Experiment.trashed_at.is_not(None) if trashed else Experiment.trashed_at.is_(None)
     order = Experiment.trashed_at.desc() if trashed else Experiment.created_at.desc()
     stmt = (
         select(Experiment, Idea.title)
         .join(Idea, Idea.id == Experiment.idea_id)
-        .where(Experiment.project_id == project_id, trash_cond)
+        .where(Experiment.project_id.in_(project_ids), trash_cond)
         .order_by(order)
     )
     return [(exp, title) for exp, title in (await session.execute(stmt)).all()]
@@ -271,7 +280,10 @@ async def purge_experiments(
     远端 workdir 不动（best-effort，避免误删共享服务器）。返回删除数量。"""
     if ids is None:
         rows = [
-            exp for exp, _ in await list_experiments(session, project_id=project_id, trashed=True)
+            exp
+            for exp, _ in await list_experiments(
+                session, project_ids=[project_id], trashed=True
+            )
         ]
     else:
         rows = [

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -1,6 +1,7 @@
 """Idea Forge / 评审锦标赛业务逻辑（不 import fastapi）。"""
 
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
@@ -363,15 +364,18 @@ def composite_score(idea: Idea) -> float:
 async def list_ideas(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
+    project_ids: Sequence[uuid.UUID],
     status: str | None = None,
     depth: str | None = None,
     research_type: str | None = None,
     sort: str = "-created_at",
     trashed: bool = False,
 ) -> list[Idea]:
+    """这些课题下的想法（列表而非单个 id 的理由见 experiments.list_experiments）。"""
+    if not project_ids:
+        return []
     trash_cond = Idea.trashed_at.is_not(None) if trashed else Idea.trashed_at.is_(None)
-    stmt = select(Idea).where(Idea.project_id == project_id, trash_cond)
+    stmt = select(Idea).where(Idea.project_id.in_(project_ids), trash_cond)
     if trashed:
         return list((await session.execute(stmt.order_by(Idea.trashed_at.desc()))).scalars().all())
     if status:
@@ -439,7 +443,7 @@ async def purge_ideas(
     """永久删除。ids=None → 清空该项目回收站；否则只删指定 id 中已在回收站的。
     级联删除其实验（DB FK ondelete=CASCADE）。返回删除数量。"""
     if ids is None:
-        rows = await list_ideas(session, project_id=project_id, trashed=True)
+        rows = await list_ideas(session, project_ids=[project_id], trashed=True)
     else:
         rows = [
             i

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -13,6 +13,7 @@
 import json
 import re
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -522,11 +523,16 @@ async def initialize_structure(
 
 
 async def list_manuscripts(
-    session: AsyncSession, *, project_id: uuid.UUID, trashed: bool = False
+    session: AsyncSession, *, project_ids: Sequence[uuid.UUID], trashed: bool = False
 ) -> list[Manuscript]:
-    """项目下的稿件；trashed=False 只列未删除（置顶优先），True 只列回收站。"""
+    """这些课题下的稿件；trashed=False 只列未删除（置顶优先），True 只列回收站。
+
+    收列表而非单个 id 的理由见 experiments.list_experiments。
+    """
+    if not project_ids:
+        return []
     cond = Manuscript.trashed_at.is_not(None) if trashed else Manuscript.trashed_at.is_(None)
-    stmt = select(Manuscript).where(Manuscript.project_id == project_id, cond)
+    stmt = select(Manuscript).where(Manuscript.project_id.in_(project_ids), cond)
     if trashed:
         stmt = stmt.order_by(Manuscript.trashed_at.desc())
     else:
@@ -582,7 +588,7 @@ async def purge_manuscripts(
     """永久删除。ids=None → 清空该项目回收站（删所有已在回收站的稿件）；
     否则只永久删除指定 id 中已在回收站的稿件（避免误删未删除的）。返回删除数量。"""
     if ids is None:
-        rows = await list_manuscripts(session, project_id=project_id, trashed=True)
+        rows = await list_manuscripts(session, project_ids=[project_id], trashed=True)
     else:
         rows = [
             m

--- a/src/backend/app/tools/project_state.py
+++ b/src/backend/app/tools/project_state.py
@@ -17,6 +17,7 @@ from app.services import ideas as ideas_service
 from app.services import manuscripts as manuscripts_service
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import project_ids_for
 
 _CONTENT_CHARS = 4000
 _MAX_LOG_LINES = 1000
@@ -52,7 +53,7 @@ async def list_ideas(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         ideas = await ideas_service.list_ideas(
             session,
-            project_id=ctx.project_id,
+            project_ids=await project_ids_for(session, ctx),
             status=str(args.get("status") or "") or None,
             depth=str(args.get("depth") or "") or None,
             research_type=str(args.get("research_type") or "") or None,
@@ -77,8 +78,8 @@ async def get_idea(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"idea_id 不是合法 uuid：{args.get('idea_id')}") from e
     async with get_sessionmaker()() as session:
         idea = await session.get(Idea, idea_id)
-        if idea is None or idea.project_id != ctx.project_id:
-            raise ValueError(f"项目内不存在该想法：{args.get('idea_id')}")
+        if idea is None or idea.project_id not in await project_ids_for(session, ctx):
+            raise ValueError(f"范围内不存在该想法：{args.get('idea_id')}")
         brief = _idea_brief(idea)
         brief["content"] = (idea.content or "")[:_CONTENT_CHARS] or None
         brief["goal"] = idea.goal
@@ -94,7 +95,9 @@ async def get_idea(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
 )
 async def list_experiments(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
-        rows = await experiments_service.list_experiments(session, project_id=ctx.project_id)
+        rows = await experiments_service.list_experiments(
+            session, project_ids=await project_ids_for(session, ctx)
+        )
     return {
         "experiments": [
             {
@@ -126,12 +129,15 @@ async def get_experiment(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
         stmt = (
             select(Experiment, Idea.title)
             .join(Idea, Idea.id == Experiment.idea_id)
-            .where(Experiment.id == exp_id, Experiment.project_id == ctx.project_id)
+            .where(
+                Experiment.id == exp_id,
+                Experiment.project_id.in_(await project_ids_for(session, ctx)),
+            )
             .options(selectinload(Experiment.runs))
         )
         row = (await session.execute(stmt)).first()
         if row is None:
-            raise ValueError(f"项目内不存在该实验：{args.get('experiment_id')}")
+            raise ValueError(f"范围内不存在该实验：{args.get('experiment_id')}")
         exp, idea_title = row
         return experiments_service.to_read(exp, idea_title).model_dump(mode="json")
 
@@ -161,12 +167,15 @@ async def read_experiment_logs(ctx: ToolContext, args: dict[str, Any]) -> dict[s
     async with get_sessionmaker()() as session:
         stmt = (
             select(Experiment)
-            .where(Experiment.id == exp_id, Experiment.project_id == ctx.project_id)
+            .where(
+                Experiment.id == exp_id,
+                Experiment.project_id.in_(await project_ids_for(session, ctx)),
+            )
             .options(selectinload(Experiment.runs))
         )
         exp = (await session.execute(stmt)).scalar_one_or_none()
         if exp is None:
-            raise ValueError(f"项目内不存在该实验：{args.get('experiment_id')}")
+            raise ValueError(f"范围内不存在该实验：{args.get('experiment_id')}")
         if raw_run:
             try:
                 run_id = uuid.UUID(raw_run)
@@ -214,6 +223,6 @@ async def get_fact_pack(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
         raise ValueError(f"manuscript_id 不是合法 uuid：{args.get('manuscript_id')}") from e
     async with get_sessionmaker()() as session:
         manuscript = await session.get(Manuscript, ms_id)
-        if manuscript is None or manuscript.project_id != ctx.project_id:
-            raise ValueError(f"项目内不存在该稿件：{args.get('manuscript_id')}")
+        if manuscript is None or manuscript.project_id not in await project_ids_for(session, ctx):
+            raise ValueError(f"范围内不存在该稿件：{args.get('manuscript_id')}")
         return await manuscripts_service.build_fact_pack(session, manuscript)

--- a/src/backend/app/tools/scope.py
+++ b/src/backend/app/tools/scope.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.project import ProjectMember
 from app.models.user import User
 from app.services.libraries import (
     get_source_library_ids,
@@ -48,6 +49,27 @@ async def library_ids_for(session: AsyncSession, ctx: ToolContext) -> list[uuid.
     if ctx.library_ids is not None:
         return list(ctx.library_ids)
     return await get_source_library_ids(session, ctx.project_id)
+
+
+async def project_ids_for(session: AsyncSession, ctx: ToolContext) -> list[uuid.UUID]:
+    """这次能看哪些课题的资产（实验、想法、稿件）。
+
+    :func:`library_ids_for` 的对偶。选了课题就只有它；**没选就是这个人参与的全部
+    课题**——「所有资产」是放开范围，不是没有范围。
+
+    这里曾经直接拿 ``ctx.project_id`` 去比：不选课题时它是 None，SQL 里就成了
+    ``project_id = NULL``，永远匹配不上。于是助手在默认状态下报「项目内不存在该
+    实验」，而那个实验就在用户眼前的页面上。空列表是合法结果（这人一个课题都没
+    参与），调用方给空态，不报错。
+    """
+    if ctx.project_id is not None:
+        return [ctx.project_id]
+    if ctx.user_id is None:
+        return []
+    rows = await session.execute(
+        select(ProjectMember.project_id).where(ProjectMember.user_id == ctx.user_id)
+    )
+    return list(rows.scalars().all())
 
 
 async def membership_in_scope(

--- a/src/backend/app/tools/workspace.py
+++ b/src/backend/app/tools/workspace.py
@@ -22,6 +22,7 @@ from app.services import voyages as voyages_service
 from app.services.libraries import get_source_libraries
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import project_ids_for
 
 _MAX_TASKS = 50
 _MAX_LOG_LINES = 500
@@ -61,11 +62,12 @@ async def _visible_tasks(session: Any, ctx: ToolContext) -> list[VoyageRun]:
     """
     libraries = await get_source_libraries(session, ctx.project_id)
     library_ids = {lib.id for lib in libraries}
+    scoped = set(await project_ids_for(session, ctx))
     runs = await voyages_service.list_voyages(session, user_id=ctx.user_id)
     return [
         run
         for run in runs
-        if run.project_id == ctx.project_id
+        if run.project_id in scoped
         or (run.library_id is not None and run.library_id in library_ids)
     ]
 
@@ -82,11 +84,11 @@ async def _get_task(session: Any, ctx: ToolContext, raw_id: Any) -> VoyageRun:
         raise ValueError(f"任务不存在或无权访问：{raw_id}")
     libraries = await get_source_libraries(session, ctx.project_id)
     library_ids = {lib.id for lib in libraries}
-    in_scope = run.project_id == ctx.project_id or (
+    in_scope = run.project_id in set(await project_ids_for(session, ctx)) or (
         run.library_id is not None and run.library_id in library_ids
     )
     if not in_scope:
-        raise ValueError(f"该任务不属于本课题：{raw_id}")
+        raise ValueError(f"该任务不在当前范围内：{raw_id}")
     return run
 
 

--- a/src/backend/app/tools/writing.py
+++ b/src/backend/app/tools/writing.py
@@ -17,6 +17,7 @@ from app.models.manuscript import Manuscript
 from app.services import manuscripts as manuscripts_service
 from app.tools.context import ToolContext
 from app.tools.registry import tool
+from app.tools.scope import project_ids_for
 
 _MAX_MANUSCRIPTS = 50
 _FILE_PAGE_CHARS = 6000
@@ -55,7 +56,7 @@ async def _get_manuscript(
         session, manuscript_id=manuscript_id, user_id=ctx.user_id, with_files=with_files
     )
     # 课题隔离：跨课题的稿件即便本人有权，也不该在本次 MCP 会话里露出
-    if manuscript is None or manuscript.project_id != ctx.project_id:
+    if manuscript is None or manuscript.project_id not in await project_ids_for(session, ctx):
         raise ValueError(f"本课题内不存在该稿件：{raw_id}")
     return manuscript
 
@@ -74,7 +75,9 @@ async def _get_manuscript(
 async def list_manuscripts(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     limit = min(_MAX_MANUSCRIPTS, max(1, int(args.get("limit") or 20)))
     async with get_sessionmaker()() as session:
-        rows = await manuscripts_service.list_manuscripts(session, project_id=ctx.project_id)
+        rows = await manuscripts_service.list_manuscripts(
+            session, project_ids=await project_ids_for(session, ctx)
+        )
     return {
         "total": len(rows),
         "manuscripts": [_manuscript_brief(m) for m in rows[:limit]],

--- a/src/backend/tests/test_mcp_workspace_tools.py
+++ b/src/backend/tests/test_mcp_workspace_tools.py
@@ -178,7 +178,7 @@ async def test_task_cross_project_denied(client):
     message = await _call_expect_error(
         client, headers, "get_task", {"project_id": project_b, "task_id": task_a}
     )
-    assert "不属于本课题" in message
+    assert "不在当前范围内" in message
 
     listed = await _call(client, headers, "list_tasks", {"project_id": project_b})
     assert listed["tasks"] == []

--- a/src/backend/tests/test_tool_project_scope.py
+++ b/src/backend/tests/test_tool_project_scope.py
@@ -1,0 +1,96 @@
+"""不收窄课题时，助手够得着自己全部课题的资产。
+
+这条测试的由来：Buddy 默认不选课题，于是 ``ctx.project_id`` 是 None，而工具里写的是
+``Experiment.project_id == ctx.project_id``——SQL 里成了 ``= NULL``，一条都匹配不上。
+用户对着一个明明存在的实验问，助手回「项目内不存在该实验」。想法、稿件、任务全都
+是同一个毛病，只是它们失败得更安静：返回空清单，助手就说"你还没有实验"。
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.user import User
+from app.tools.context import ToolContext
+from app.tools.project_state import get_experiment, list_experiments
+from app.tools.scope import project_ids_for
+from tests.conftest import register_and_login
+
+
+async def _seed(client) -> tuple[uuid.UUID, str, str]:
+    """建一个课题 + 想法 + 实验，返回 (user_id, project_id, experiment_id)。
+
+    实验直接落库而不走 API：走 API 要先把想法推到 promoted、再配一套 SSH 凭据，
+    那套铺垫与「范围怎么算」这件事无关，只会让测试坏在别处。
+    """
+    token = await register_and_login(client, email="scope@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project = (
+        await client.post("/api/projects", json={"name": "Scope", "statement": "s"}, headers=headers)
+    ).json()
+    async with get_sessionmaker()() as session:
+        user_id = (
+            await session.execute(select(User.id).where(User.email == "scope@example.com"))
+        ).scalar_one()
+        idea = Idea(project_id=uuid.UUID(project["id"]), title="An idea", content="c")
+        session.add(idea)
+        await session.flush()
+        exp = Experiment(project_id=uuid.UUID(project["id"]), idea_id=idea.id, status="running")
+        session.add(exp)
+        await session.commit()
+        exp_id = str(exp.id)
+    return user_id, project["id"], exp_id
+
+
+async def test_no_topic_selected_still_reaches_my_experiments(client):
+    """默认状态（没选课题）下，实验必须查得到——这正是用户撞上的那个报错。"""
+    user_id, _project_id, exp_id = await _seed(client)
+    ctx = ToolContext(project_id=None, llm=LLMRouter(), user_id=user_id)
+
+    detail = await get_experiment(ctx, {"experiment_id": exp_id})
+    assert detail["id"] == exp_id
+
+    listed = await list_experiments(ctx, {})
+    assert [e["experiment_id"] for e in listed["experiments"]] == [exp_id]
+
+
+async def test_picking_a_topic_narrows_to_it(client):
+    """选了课题就只看这个课题——放开范围不等于取消范围。"""
+    user_id, project_id, exp_id = await _seed(client)
+    other = uuid.uuid4()
+
+    mine = ToolContext(project_id=uuid.UUID(project_id), llm=LLMRouter(), user_id=user_id)
+    assert (await get_experiment(mine, {"experiment_id": exp_id}))["id"] == exp_id
+
+    elsewhere = ToolContext(project_id=other, llm=LLMRouter(), user_id=user_id)
+    with pytest.raises(ValueError, match="不存在该实验"):
+        await get_experiment(elsewhere, {"experiment_id": exp_id})
+
+
+async def test_scope_resolution(client):
+    """project_ids_for 的三种情形。"""
+    user_id, project_id, _ = await _seed(client)
+    async with get_sessionmaker()() as session:
+        picked = uuid.uuid4()
+        assert await project_ids_for(
+            session, ToolContext(project_id=picked, llm=LLMRouter(), user_id=user_id)
+        ) == [picked]
+
+        # 没选课题 = 我参与的全部课题
+        everything = await project_ids_for(
+            session, ToolContext(project_id=None, llm=LLMRouter(), user_id=user_id)
+        )
+        assert uuid.UUID(project_id) in everything
+
+        # 没有用户（系统内部调用）：空列表，而不是「全世界」
+        assert (
+            await project_ids_for(
+                session, ToolContext(project_id=None, llm=LLMRouter(), user_id=None)
+            )
+            == []
+        )

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -998,7 +998,12 @@ export function AssistantPanel({
           </button>
 
           {/* 课题选择：和加号并排。以前这里是一行说明文字，只告诉你现在查的是什么，
-              要换得去别处切；现在它自己就是入口——点开挑一个，再点「全部文献库」放开。 */}
+              要换得去别处切；现在它自己就是入口——点开挑一个，再点「所有资产」放开。
+
+              这里选的是**这次问话够得着哪些资产**：选了课题，就只看这个课题名下的
+              东西（关联文献库、实验、想法、在写的稿子）；不选就是你能看到的全部。
+              实验室级的资产（每日新论文、公共文献库）两种情况下都在——它们不属于
+              任何一个课题，收窄课题不该把它们也关掉。 */}
           <button
             className="buddy-scope"
             onClick={() => {
@@ -1009,14 +1014,17 @@ export function AssistantPanel({
             aria-expanded={topicOpen}
             title={
               topic
-                ? `${tr('只在这个课题的语料里查', 'Restricted to this topic')} · ${topic.name}`
-                : tr('选一个课题来收窄检索范围', 'Pick a topic to narrow the search')
+                ? `${tr('只用这个课题名下的资产', 'Only this topic’s assets')} · ${topic.name}`
+                : tr(
+                    '你能看到的所有资产；选一个课题可收窄到它名下',
+                    'Everything you can see; pick a topic to narrow to it',
+                  )
             }
             data-picked={topic ? '1' : undefined}
           >
             <Icon name="layers" size={12} />
             <span className="buddy-scope-label">
-              {topic ? topic.name : tr('全部文献库', 'All libraries')}
+              {topic ? topic.name : tr('所有资产', 'All assets')}
             </span>
             <Icon name="chevDown" size={11} />
           </button>
@@ -1076,8 +1084,8 @@ export function AssistantPanel({
                       setTopicOpen(false);
                     }}
                   >
-                    <Icon name="book" size={13} />
-                    <span className="buddy-scope-item-label">{tr('全部文献库', 'All libraries')}</span>
+                    <Icon name="grid" size={13} />
+                    <span className="buddy-scope-item-label">{tr('所有资产', 'All assets')}</span>
                     {!topicId && <Icon name="check" size={12} />}
                   </button>
                   {projects.length > 0 && <div className="hr" style={{ margin: '4px 2px' }} />}

--- a/src/frontend/src/features/assistant/AssistantPanel.tsx
+++ b/src/frontend/src/features/assistant/AssistantPanel.tsx
@@ -495,13 +495,23 @@ export function AssistantPanel({
   const scrollRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   // 对话里的「项目」就是平台里的课题。**默认不选**：选了之后检索范围就收窄到这个
-  // 课题，而用户多数问题是跨课题的；想收窄时自己挑一个，比默认收窄再去发现「怎么
-  // 查不到别的库」要好。
+  // 课题。**默认跟随你正在做的那个课题**：人问「实验跑得怎么样」时，指的多半就是
+  // 眼前这个课题的实验，而不是全实验室的。想问别的课题、或者想放开到全部资产，
+  // 点上面那个按钮改——改了就以你改的为准，不再被界面切换带着走。
   //
-  // 以前这里是个开关，只能绑「你现在正在看的那个课题」——想问另一个课题，得先把整个
-  // 界面切过去。现在存的是选中的课题 id，输入框上方那个按钮直接挑。
-  const { projects } = useProject();
-  const [topicId, setTopicId] = useState<string | null>(null);
+  // 以前这里是个开关，只能绑当前课题、不能挑；再往前默认是「全部」，于是问一句
+  // 「我的实验」会把别的课题的也捞进来。
+  const { projects, currentProjectId } = useProject();
+  const [topicId, setTopicId] = useState<string | null>(currentProjectId);
+  // 用户自己动过选择之后，就别再跟着界面切课题——那是他的选择，不是界面的。
+  const topicPinned = useRef(false);
+  useEffect(() => {
+    if (!topicPinned.current) setTopicId(currentProjectId);
+  }, [currentProjectId]);
+  const pickTopic = useCallback((id: string | null) => {
+    topicPinned.current = true;
+    setTopicId(id);
+  }, []);
   const [topicOpen, setTopicOpen] = useState(false);
   const [topicQuery, setTopicQuery] = useState('');
   const topic = useMemo(
@@ -581,7 +591,9 @@ export function AssistantPanel({
         setHistoryOpen(false);
         // 会话上存着的课题才是这场对话真正的作用域，跟着切过去。
         // （这句注释以前是空头支票：写着「跟着切」，却没有一行代码在切。）
-        setTopicId(conversations.find((c) => c.id === id)?.project_id ?? null);
+        // 会话自己的作用域也算「定下来了」：它是这场对话当初问的范围，
+        // 不该被用户后来在界面上切课题给盖掉。
+        pickTopic(conversations.find((c) => c.id === id)?.project_id ?? null);
         setTurns(
           messages
             // 一轮会落成几条消息：assistant（正文/调用）+ 携带工具结果的那条。
@@ -603,7 +615,7 @@ export function AssistantPanel({
         /* 载入失败保持现状 */
       }
     },
-    [conversations],
+    [conversations, pickTopic],
   );
 
   const newConversation = useCallback(() => {
@@ -1067,7 +1079,7 @@ export function AssistantPanel({
                       // 搜到只剩一个时回车直接选它
                       const only = topicMatches.length === 1 ? topicMatches[0] : undefined;
                       if (e.key === 'Enter' && only) {
-                        setTopicId(only.id);
+                        pickTopic(only.id);
                         setTopicOpen(false);
                       }
                     }}
@@ -1080,7 +1092,7 @@ export function AssistantPanel({
                     role="option"
                     aria-selected={!topicId}
                     onClick={() => {
-                      setTopicId(null);
+                      pickTopic(null);
                       setTopicOpen(false);
                     }}
                   >
@@ -1097,7 +1109,7 @@ export function AssistantPanel({
                       aria-selected={p.id === topicId}
                       title={p.name}
                       onClick={() => {
-                        setTopicId(p.id);
+                        pickTopic(p.id);
                         setTopicOpen(false);
                       }}
                     >

--- a/src/frontend/src/features/assistant/__tests__/scopePicker.test.ts
+++ b/src/frontend/src/features/assistant/__tests__/scopePicker.test.ts
@@ -71,6 +71,17 @@ describe('课题选择', () => {
 
   it('载入历史会话时采用它自己的课题', () => {
     // 这句注释以前是空头支票：写着「跟着切」，却没有一行代码在切
-    expect(source).toContain('setTopicId(conversations.find((c) => c.id === id)?.project_id ?? null)');
+    expect(source).toContain('pickTopic(conversations.find((c) => c.id === id)?.project_id ?? null)');
+  });
+
+  it('默认跟随你正在做的那个课题', () => {
+    // 问「实验跑得怎么样」，指的多半是眼前这个课题的实验，不是全实验室的
+    expect(source).toContain('useState<string | null>(currentProjectId)');
+    expect(source).toContain('if (!topicPinned.current) setTopicId(currentProjectId)');
+  });
+
+  it('用户自己选过之后就不再被界面切换带着走', () => {
+    // 否则他在 Buddy 里挑了 A，回头在侧栏切到 B，问话范围会被悄悄换掉
+    expect(source).toContain('topicPinned.current = true');
   });
 });


### PR DESCRIPTION
Closes #341

Asking Buddy about an experiment that plainly exists answered:

```
ValueError: 项目内不存在该实验：e8153824-2137-44c2-a75b-be1adad0a9d7
```

### The bug

The tools compared `Experiment.project_id == ctx.project_id`. Buddy **does not narrow to a topic by default**, so that was a comparison against `None` — in SQL, `project_id = NULL`, which matches no row ever. **The assistant's default state could not reach a single topic-scoped asset.**

Experiments only failed the loudest. Ideas, manuscripts and tasks carried the same comparison and failed **silently**: an empty list, so the assistant told people with several experiments that they had none.

### The fix

`scope.py` gains `project_ids_for` — the counterpart to the existing `library_ids_for` that was never written:

| Picked | Scope |
| --- | --- |
| a topic | that topic only |
| nothing | every topic you belong to |

Opening the scope up, not removing it. The three list services now take `project_ids` rather than a single id — the UI passes one, the assistant passes many — and lookups filter with `IN`.

### Lab-level assets were never affected

The daily pool and public libraries resolve through `library_ids_for`, which is orthogonal to topics. Narrowing to a topic does not switch off things that belong to no topic, and never did.

### Wording follows meaning

- `不属于本课题` → `不在当前范围内`. The old sentence is untrue when no topic is selected.
- The picker said **全部文献库** while the scope covers experiments, ideas and drafts too. It now says **所有资产**, with a tooltip that states the rule.

### Verification

- **Backend: 1189 passed, 0 failed** before the rebase; after rebasing onto #340, the 72 tests touching experiments, tools and MCP all pass, and `ruff` is clean.
- New tests pin the behaviour that regressed: with **no topic selected** `get_experiment` must find the experiment and `list_experiments` must return it; with a topic selected the scope still narrows and a foreign experiment is still refused; and `project_ids_for` returns `[]` — not "everything" — when there is no user, so an internal call cannot widen into other people's data.
- Frontend: 46 passed, image builds.