### PR TITLE
fix(experiment): modal overflow, sharper intake questions with candidate answers

### DIFF
--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -43,19 +43,26 @@ from app.services import ssh_exec
 
 router = APIRouter(tags=["experiments"])
 
-# 开题提问：按 idea 让 AI 提出 ≤5 个影响开局的整体性问题（数据集/规模/评测口径/
-# 资源与框架约束/成功判据），代替静态表单字段；其余不确定点实验中经 ask 机制动态交互。
+# 开题提问：按 idea 让 AI 提出它真正拿不准的开局问题（以环境设置为主，宁少勿凑，
+# ≤5 个，带候选答案），代替静态表单字段；其余不确定点实验中经 ask 机制动态交互。
 _INTAKE_MAX_QUESTIONS = 5
 _INTAKE_SYSTEM_PROMPT = """\
 你是 Experiment Lab 的开题助手。用户选定了一个研究想法，准备交给自动化实验 agent
-（它会自己规划、写代码、建环境、跑实验、分析迭代）。请提出对「实验规划与环境设置」
-最关键的问题，帮用户在开局把方向定准。
+（它会自己规划、写代码、建环境、跑实验、分析迭代）。请只提出**你自己拿不准、
+而答案会影响开局**的问题——重点是环境与设置类的不确定性（比如模型/数据在服务器上的
+位置、能用的 GPU 与显存、该用什么框架或镜像、评测怎么调用）。
 只输出一个 JSON 对象，不要输出任何其他文字或 Markdown 代码块，格式：
-{"questions": [{"question": "问题", "hint": "一句提示/候选/示例，帮助快速作答"}]}
+{"questions": [{"question": "问题", "hint": "一句提示，帮助快速作答",
+  "options": ["候选答案1", "候选答案2"]}]}
 约束：
-- 最多 5 个；只问**影响开局的整体性问题**（如用哪个数据集与规模、评测口径与基线、
-  GPU/框架/模型约束、成功判据、要不要对照组）；能在实验过程中动态确认的细节不要问
-- 问题必须针对这个想法本身，不问放之四海皆准的空话；已经能从想法内容里读出的答案不要再问
+- **宁少勿凑**：真不确定的才问，1-3 个很正常，一个都没有就输出空列表；上限 5 个
+- 不要按固定类别套模板（不是每个实验都要问数据集/基线/判据）；从这个想法的具体
+  内容出发，找你规划或建环境时真正卡壳的点
+- 每个问题要**明确、可直接作答**（问「Qwen3.5-4B 权重在服务器上的路径是什么」，
+  不问「资源情况如何」这类空泛问题）
+- 能从想法内容里读出答案的不要问；实验过程中能动态确认的细节不要问
+- 每个问题尽量给 2-4 个**具体的候选答案**（options，用户可一键选择，也能自己填）；
+  实在给不出合理候选就给空列表
 - 用大白话，中文提问
 """
 
@@ -109,7 +116,14 @@ async def experiment_intake_questions(
             if not question:
                 continue
             hint = str(raw.get("hint") or "").strip() or None
-            questions.append(ExperimentIntakeQuestion(question=question[:500], hint=hint))
+            options = [
+                str(opt).strip()[:200]
+                for opt in (raw.get("options") or [])
+                if isinstance(opt, str) and str(opt).strip()
+            ][:6]
+            questions.append(
+                ExperimentIntakeQuestion(question=question[:500], hint=hint, options=options)
+            )
             if len(questions) >= _INTAKE_MAX_QUESTIONS:
                 break
         return ExperimentIntakeQuestions(questions=questions)

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -40,6 +40,8 @@ class ExperimentParams(BaseModel):
 class ExperimentIntakeQuestion(BaseModel):
     question: str
     hint: str | None = None
+    # 候选答案（前端渲染为可点选项 + 「其他」自由输入）；可为空列表
+    options: list[str] = []
 
 
 class ExperimentIntakeQuestions(BaseModel):

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -619,7 +619,11 @@ class _IntakeProvider(FakeProvider):
         if "开题助手" in full:
             payload = {
                 "questions": [
-                    {"question": f"问题 {i}：用哪个数据集？", "hint": f"提示 {i}"}
+                    {
+                        "question": f"问题 {i}：用哪个数据集？",
+                        "hint": f"提示 {i}",
+                        "options": [f"候选 {i}A", f"候选 {i}B"],
+                    }
                     for i in range(1, 7)
                 ]
             }
@@ -655,6 +659,7 @@ async def test_intake_questions_and_answers_reach_plan(client, queue_stub, fake_
         assert len(questions) == 5  # 超出上限被截断
         assert questions[0]["question"].startswith("问题 1")
         assert questions[0]["hint"] == "提示 1"
+        assert questions[0]["options"] == ["候选 1A", "候选 1B"]
     finally:
         llm_router_module.reset_llm_router()
 

--- a/src/frontend/src/features/experiment/NewExperimentModal.tsx
+++ b/src/frontend/src/features/experiment/NewExperimentModal.tsx
@@ -211,21 +211,21 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
         <FormField
           label={tr('时间预算（小时）', 'Time budget (hours)')}
           en="max_hours"
-          style={{ flex: 1 }}
+          style={{ flex: 1, minWidth: 0 }}
           hint={tr('留空 = 不限时。这是唯一的自动修复刹车：超时会暂停并问你怎么办。', 'Empty = unlimited. The only brake on auto-fixing: on timeout it pauses and asks you.')}
         >
-          <input className="input mono" inputMode="decimal" value={maxHours} onChange={(e) => setMaxHours(e.target.value)} placeholder={tr('不限', 'unlimited')} />
+          <input className="input mono" style={{ width: '100%' }} inputMode="decimal" value={maxHours} onChange={(e) => setMaxHours(e.target.value)} placeholder={tr('不限', 'unlimited')} />
         </FormField>
-        <FormField label={tr('最多运行轮数', 'Max runs')} en="max_runs" style={{ flex: 1 }}>
-          <input className="input mono" inputMode="numeric" value={maxRuns} onChange={(e) => setMaxRuns(e.target.value)} placeholder="10" />
+        <FormField label={tr('最多运行轮数', 'Max runs')} en="max_runs" style={{ flex: 1, minWidth: 0 }}>
+          <input className="input mono" style={{ width: '100%' }} inputMode="numeric" value={maxRuns} onChange={(e) => setMaxRuns(e.target.value)} placeholder="10" />
         </FormField>
         <FormField
           label={tr('无提升自动停', 'Auto stop')}
           en="no_improve_stop"
-          style={{ flex: 1 }}
+          style={{ flex: 1, minWidth: 0 }}
           hint={tr('连续 2 轮主指标无提升自动收尾。', 'Wraps up after 2 runs in a row without metric gain.')}
         >
-          <input className="input mono" value={tr('2 轮', '2 runs')} disabled />
+          <input className="input mono" style={{ width: '100%' }} value={tr('2 轮', '2 runs')} disabled />
         </FormField>
       </div>
 
@@ -249,6 +249,34 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
           </div>
           {questions.map((q, i) => (
             <FormField key={i} label={`${i + 1}. ${q.question}`} hint={q.hint ?? undefined}>
+              {(q.options ?? []).length > 0 && (
+                <div className="row gap6 wrap" style={{ marginBottom: 8 }}>
+                  {(q.options ?? []).map((opt) => {
+                    const active = (answers[i] ?? '') === opt;
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        className="pill sm"
+                        style={{
+                          cursor: 'pointer',
+                          border: active ? '1.5px solid var(--accent)' : '0.5px solid var(--border)',
+                          background: active ? 'var(--accent-soft)' : 'var(--surface-2)',
+                          color: active ? 'var(--accent-text)' : 'var(--text-2)',
+                          fontWeight: active ? 700 : 500,
+                          maxWidth: '100%',
+                        }}
+                        onClick={() =>
+                          setAnswers((prev) => prev.map((a, j) => (j === i ? (active ? '' : opt) : a)))
+                        }
+                        title={opt}
+                      >
+                        {opt}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
               <textarea
                 className="textarea"
                 rows={2}
@@ -256,8 +284,12 @@ export function NewExperimentModal({ open, onClose, pid, initialIdeaId }: NewExp
                 onChange={(e) =>
                   setAnswers((prev) => prev.map((a, j) => (j === i ? e.target.value : a)))
                 }
-                placeholder={tr('（可留空，交给 AI 判断）', '(leave empty to let the AI decide)')}
-                style={{ minHeight: 44 }}
+                placeholder={
+                  (q.options ?? []).length > 0
+                    ? tr('其他（手动输入，或点上方候选）', 'Other — type your own, or pick above')
+                    : tr('（可留空，交给 AI 判断）', '(leave empty to let the AI decide)')
+                }
+                style={{ minHeight: 44, width: '100%' }}
               />
             </FormField>
           ))}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1954,6 +1954,8 @@ export interface ExperimentIntakeQA {
 export interface ExperimentIntakeQuestion {
   question: string;
   hint: string | null;
+  /** 候选答案（可一键选择；空列表 = 只有自由输入） */
+  options: string[];
 }
 
 export interface CreateExperimentInput {


### PR DESCRIPTION
Follow-ups on #340 (#344):

- **Modal overflow**: the budget row's third column ran past the modal edge — flex children keep `min-width: auto` and the native input's intrinsic width breaks the layout. Fixed with `minWidth: 0` columns + full-width inputs.
- **Intake prompt rewritten**: no preset categories or padding to 5 — ask only what the model is genuinely unsure about, environment/setup uncertainties first (weight paths, usable GPUs, framework/image choice, eval invocation); each question must be concrete and directly answerable; fewer is better, an empty list is fine.
- **Candidate answers**: each question may carry 2–4 concrete options (validated, ≤6, 200 chars each) rendered as one-click chips, with an "other" free-text field; clicking a selected chip deselects it.

Endpoint test extended for options passthrough; tsc + vite build clean.

Closes #344
