### PR TITLE
feat(writer): one-click references refresh with main-tex bibliography wiring

### DIFF
--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -50,6 +50,7 @@ from app.schemas.manuscript import (
     ManuscriptFileRename,
     ManuscriptRead,
     ManuscriptUpdate,
+    ReferencesRefreshResult,
     ShareLink,
     ShareLinkCreate,
     TemplateDownloadProgress,
@@ -861,6 +862,21 @@ async def refresh_fact_pack(
 ) -> dict:
     manuscript = await _member_manuscript(session, manuscript_id, user)
     return await manuscripts_service.refresh_fact_pack(session, manuscript)
+
+
+@router.post(
+    "/manuscripts/{manuscript_id}/references/refresh", response_model=ReferencesRefreshResult
+)
+async def refresh_references(
+    manuscript_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ReferencesRefreshResult:
+    """一键刷新参考文献：引用池（相关研究 ∪ 关联文献库）→ references.bib →
+    主 tex 唯一 \\bibliography{references} 接线。"""
+    manuscript = await _member_manuscript(session, manuscript_id, user)
+    result = await latex_compile.refresh_references(session, manuscript, user_id=user.id)
+    return ReferencesRefreshResult(**result)
 
 
 # ---- §4 编译 ----

--- a/src/backend/app/schemas/manuscript.py
+++ b/src/backend/app/schemas/manuscript.py
@@ -172,6 +172,12 @@ class ManuscriptFileContent(BaseModel):
     readonly: bool
 
 
+class ReferencesRefreshResult(BaseModel):
+    entries: int  # references.bib 里写入的条目数
+    bibliography_updated: bool  # 主 tex 的 \bibliography 接线是否有改动
+    main_tex: str | None  # 实际接线的主文件（找不到唯一主文件时为 null）
+
+
 class DraftRequest(BaseModel):
     # null = 模板全部节；显式列表时只写指定节（related_work 也在可选值内）
     sections: list[str] | None = None

--- a/src/backend/app/services/latex_compile.py
+++ b/src/backend/app/services/latex_compile.py
@@ -242,6 +242,87 @@ async def build_references_bib(session: AsyncSession, manuscript: Manuscript) ->
     return bib or extra
 
 
+# 只匹配 \bibliography{...}（\bibliographystyle 后面紧跟的不是 { 所以不会误伤）
+_BIBLIOGRAPHY_RE = re.compile(r"^[ \t]*\\bibliography\{[^}]*\}[ \t]*\n?", re.MULTILINE)
+_BIBSTYLE_RE = re.compile(r"^[ \t]*\\bibliographystyle\{", re.MULTILINE)
+_END_DOCUMENT_RE = re.compile(r"^[ \t]*\\end\{document\}", re.MULTILINE)
+_BIBLIOGRAPHY_LINE = "\\bibliography{references}\n"
+
+
+def normalize_bibliography_wiring(text: str) -> tuple[str, bool]:
+    """把主 tex 的文献表接线归一成唯一一条 ``\\bibliography{references}``。
+
+    多条 \\bibliography（模板残留 + AI 追加的常见事故）会让 BibTeX 因重复
+    \\bibdata 直接失败、全部引用 undefined——这里保留第一条位置并删掉其余；
+    一条都没有时插到 \\bibliographystyle 前（无则 \\end{document} 前，
+    再没有就不动）。返回 (新文本, 是否改动)。
+    """
+    matches = list(_BIBLIOGRAPHY_RE.finditer(text))
+    if matches:
+        if len(matches) == 1 and matches[0].group(0).strip() == "\\bibliography{references}":
+            return text, False  # 已是唯一一条且指向 references，不动
+        head = text[: matches[0].start()]
+        tail = _BIBLIOGRAPHY_RE.sub("", text[matches[0].end() :])
+        return head + _BIBLIOGRAPHY_LINE + tail, True
+    anchor = _BIBSTYLE_RE.search(text) or _END_DOCUMENT_RE.search(text)
+    if anchor is None:
+        return text, False
+    pos = anchor.start()
+    return text[:pos] + _BIBLIOGRAPHY_LINE + text[pos:], True
+
+
+async def _rewire_main_bibliography(
+    session: AsyncSession, manuscript: Manuscript, *, user_id: uuid.UUID
+) -> tuple[str | None, bool]:
+    """主 tex 接线归一落盘（活跃协同房间经 Y 事务替换）；返回 (主文件名, 是否改动)。"""
+    main_path = manuscript.main_tex or MAIN_TEX
+    stmt = select(ManuscriptFile).where(ManuscriptFile.manuscript_id == manuscript.id)
+    files = (await session.execute(stmt)).scalars().all()
+    main = next((f for f in files if f.path == main_path), None)
+    if main is None:
+        # 稿件设置的主文件不存在：退回唯一一个含 \begin{document} 的可编辑 .tex
+        candidates = [
+            f
+            for f in files
+            if f.path.endswith(".tex")
+            and not f.is_binary
+            and not f.readonly
+            and "\\begin{document}" in (f.content or "")
+        ]
+        if len(candidates) != 1:
+            return None, False
+        main = candidates[0]
+    if main.readonly or main.is_binary:
+        return main.path, False
+    rooms = crdt_rooms.get_crdt_rooms()
+    current = rooms.room_content(main.id)
+    text = current if current is not None else main.content
+    rewired, changed = normalize_bibliography_wiring(text)
+    if not changed:
+        return main.path, False
+    via_room = await rooms.set_content(main.id, rewired)
+    if not via_room:
+        main.content = rewired
+        main.updated_by = user_id
+        await manuscript_versions.snapshot_file(
+            session, main, origin="refresh_references", created_by=user_id, content=rewired
+        )
+    await session.commit()
+    return main.path, True
+
+
+async def refresh_references(
+    session: AsyncSession, manuscript: Manuscript, *, user_id: uuid.UUID
+) -> dict[str, Any]:
+    """一键刷新参考文献：重建 fact-pack 引用池（相关研究书架 ∪ 关联文献库）→
+    重写 references.bib（含协同房间同步）→ 主 tex 接线归一。"""
+    await manuscripts_service.refresh_fact_pack(session, manuscript)
+    await sync_references_bib(session, manuscript)
+    main_tex, wired = await _rewire_main_bibliography(session, manuscript, user_id=user_id)
+    entries = len((manuscript.fact_pack or {}).get("citations") or [])
+    return {"entries": entries, "bibliography_updated": wired, "main_tex": main_tex}
+
+
 async def _copy_figures(
     session: AsyncSession, manuscript: Manuscript, workdir: Path
 ) -> list[dict[str, Any]]:

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -28,7 +28,9 @@ from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.manuscript import Manuscript, ManuscriptFile
+from app.models.paper import Paper
 from app.models.project import Project
+from app.models.topic_shelf import TopicPaper
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.manuscript import ManuscriptCreate
 from app.services.citations import DEFAULT_EXPORT_STATUSES, assign_citation_keys
@@ -239,25 +241,39 @@ def _figures_pack(experiment: Experiment) -> list[dict[str, Any]]:
 
 
 async def _citations_pack(session: AsyncSession, *, project_id: uuid.UUID) -> list[dict[str, Any]]:
-    """项目库 compiled/included 全部论文（排序与引用导出一致，bibkey 同规则）。
+    """课题引用语料：关联库 compiled/included 论文 ∪ 相关研究书架在架论文
+    （排序与引用导出一致，bibkey 同规则）。
 
     条目含契约字段 {bibkey, title, year}，附加内部字段 paper_id / source
     供编译时按固定 key 生成 references.bib（避免库变动导致 key 漂移）。
     """
+    entries: dict[uuid.UUID, tuple[Paper, Any]] = {}
     library_ids = await get_source_library_ids(session, project_id)
-    if not library_ids:
-        return []  # 课题无关联库 = 无引用语料
-    rows = dedupe_member_rows(
-        (
-            await session.execute(
-                member_papers_stmt(library_ids).where(
-                    LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES)
+    if library_ids:
+        rows = dedupe_member_rows(
+            (
+                await session.execute(
+                    member_papers_stmt(library_ids).where(
+                        LibraryPaper.status.in_(DEFAULT_EXPORT_STATUSES)
+                    )
                 )
-            )
-        ).all()
-    )
-    rows.sort(key=lambda pm: (pm[0].year is None, pm[0].year or 0, pm[1].created_at))
-    papers = [p for p, _ in rows]
+            ).all()
+        )
+        for paper, membership in rows:
+            entries[paper.id] = (paper, membership.created_at)
+    shelf_rows = (
+        await session.execute(
+            select(Paper, TopicPaper.created_at)
+            .join(TopicPaper, TopicPaper.paper_id == Paper.id)
+            .where(TopicPaper.topic_id == project_id, TopicPaper.trashed_at.is_(None))
+        )
+    ).all()
+    for paper, added_at in shelf_rows:
+        entries.setdefault(paper.id, (paper, added_at))
+    if not entries:
+        return []  # 课题无关联库也无在架论文 = 无引用语料
+    ordered = sorted(entries.values(), key=lambda pm: (pm[0].year is None, pm[0].year or 0, pm[1]))
+    papers = [p for p, _ in ordered]
     keys = assign_citation_keys(papers)
     return [
         {

--- a/src/backend/tests/test_latex_compile.py
+++ b/src/backend/tests/test_latex_compile.py
@@ -260,3 +260,81 @@ async def test_compile_fact_pack_s2_extras_in_bib(client, monkeypatch):
     assert "smith2017attention" in captured["references"]
     assert "@misc{doe2024related," in captured["references"]
     assert "Jane Doe" in captured["references"]
+
+
+# ---- 一键刷新参考文献（相关研究 ∪ 关联库 → references.bib → 主 tex 接线） ----
+
+
+def test_normalize_bibliography_wiring_dedupes_multiple_commands():
+    text = (
+        "\\begin{document}\nBody\n"
+        "\\bibliography{example_paper}\n"
+        "\\bibliography{references}\n"
+        "\\bibliographystyle{icml2026}\n"
+        "\\end{document}\n"
+    )
+    rewired, changed = latex_compile.normalize_bibliography_wiring(text)
+    assert changed
+    assert rewired.count("\\bibliography{") == 1
+    assert "\\bibliography{references}\n\\bibliographystyle{icml2026}" in rewired
+
+
+def test_normalize_bibliography_wiring_inserts_before_style_or_end():
+    with_style = "\\begin{document}\nBody\n\\bibliographystyle{plain}\n\\end{document}\n"
+    rewired, changed = latex_compile.normalize_bibliography_wiring(with_style)
+    assert changed
+    assert "\\bibliography{references}\n\\bibliographystyle{plain}" in rewired
+
+    without_style = "\\begin{document}\nBody\n\\end{document}\n"
+    rewired, changed = latex_compile.normalize_bibliography_wiring(without_style)
+    assert changed
+    assert "\\bibliography{references}\n\\end{document}" in rewired
+
+
+def test_normalize_bibliography_wiring_noop_cases():
+    ok = "\\begin{document}\n\\bibliography{references}\n\\end{document}\n"
+    rewired, changed = latex_compile.normalize_bibliography_wiring(ok)
+    assert not changed
+    assert rewired == ok
+    # 连 \end{document} 都没有（非主文件形态）：不乱插
+    fragment = "just a fragment"
+    rewired, changed = latex_compile.normalize_bibliography_wiring(fragment)
+    assert not changed
+    assert rewired == fragment
+
+
+async def test_refresh_references_endpoint(client):
+    """端点全链路：书架论文进 references.bib；主 tex 双 \\bibliography 收敛成一条。"""
+    from app.models.paper import Paper
+    from app.models.topic_shelf import TopicPaper
+
+    project_id, headers, ms_id, _ = await _make_manuscript_with_facts(client)
+
+    async with get_sessionmaker()() as session:
+        # 相关研究书架论文（不在任何关联库）：@Paper 直建 + 上架
+        shelf_paper = Paper(title="Shelf Only Paper", authors=[{"name": "Bo Chen"}], year=2023)
+        session.add(shelf_paper)
+        await session.flush()
+        session.add(TopicPaper(topic_id=uuid.UUID(project_id), paper_id=shelf_paper.id))
+        # 主 tex 制造双 \bibliography 事故现场
+        ms = await session.get(Manuscript, uuid.UUID(ms_id))
+        await session.refresh(ms, ["files"])
+        main = next(f for f in ms.files if f.path == (ms.main_tex or "main.tex"))
+        main.content = main.content.replace(
+            "\\end{document}",
+            "\\bibliography{example_paper}\n\\bibliography{references}\n\\end{document}",
+        )
+        await session.commit()
+
+    resp = await client.post(f"/api/manuscripts/{ms_id}/references/refresh", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entries"] >= 2  # 库内论文 + 书架论文
+    assert body["bibliography_updated"] is True
+    assert body["main_tex"]
+
+    async with get_sessionmaker()() as session:
+        ms = await session.get(Manuscript, uuid.UUID(ms_id))
+        bibkeys = [c["bibkey"] for c in ms.fact_pack["citations"]]
+        assert "chen2023shelf" in bibkeys
+        assert "smith2017attention" in bibkeys

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -356,6 +356,23 @@ export function WriterEditorPage() {
     if (insertSnippet(snippet)) toast(`已在光标处插入图表 ${figId}`, 'ok');
   }
 
+  // —— 刷新参考文献（引用池 → references.bib → 主 tex 接线） ——
+  const refreshRefsMutation = useMutation({
+    mutationFn: () => api.refreshReferences(id),
+    onSuccess: (res) => {
+      const wiring = res.bibliography_updated
+        ? tr('，并修正了主文件的 \\bibliography 设置', ' and fixed \\bibliography wiring in the main file')
+        : '';
+      toast(
+        tr(`已更新 references.bib（${res.entries} 条文献）${wiring}`, `references.bib updated (${res.entries} entries)${wiring}`),
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['manuscript', id] });
+    },
+    onError: (e) =>
+      toast(`${tr('刷新参考文献失败：', 'Refresh references failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
   // —— 编译 ——
   const compileMutation = useMutation({
     mutationFn: () => api.compileManuscript(id),
@@ -813,6 +830,22 @@ export function WriterEditorPage() {
           <option value="xelatex">XeLaTeX</option>
           <option value="lualatex">LuaLaTeX</option>
         </select>
+        <button
+          className="btn btn-ghost sm"
+          disabled={refreshRefsMutation.isPending}
+          title={tr(
+            '把课题的相关文献与关联文献库重新写入 references.bib，并保证主文件里正确引用它',
+            "Rewrite references.bib from the project's related papers and linked libraries, and wire it into the main file",
+          )}
+          onClick={() => refreshRefsMutation.mutate()}
+        >
+          <Icon
+            name={refreshRefsMutation.isPending ? 'refresh' : 'book'}
+            size={13}
+            style={refreshRefsMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
+          />
+          {refreshRefsMutation.isPending ? tr('刷新中…', 'Refreshing…') : tr('刷新参考文献', 'Refresh references')}
+        </button>
         <button
           className="btn btn-primary sm"
           disabled={compileMutation.isPending}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2143,6 +2143,12 @@ export interface CompileResult {
   duration_ms: number;
 }
 
+export interface ReferencesRefreshResult {
+  entries: number;
+  bibliography_updated: boolean;
+  main_tex: string | null;
+}
+
 // —— fact-pack（防幻觉事实源，AI 起草只允许引用其中的引文/图表/数字） ——
 
 export interface FactPackIdea {
@@ -4227,6 +4233,12 @@ export const api = {
   /** 重新从 experiment + 文献库组装事实包；前端以 invalidate 详情为准。 */
   refreshFactPack(id: string): Promise<FactPack> {
     return request<FactPack>(`/manuscripts/${id}/fact-pack/refresh`, { method: 'POST' });
+  },
+  /** 一键刷新参考文献：引用池（相关研究∪关联库）→ references.bib → 主 tex 接线。 */
+  refreshReferences(id: string): Promise<ReferencesRefreshResult> {
+    return request<ReferencesRefreshResult>(`/manuscripts/${id}/references/refresh`, {
+      method: 'POST',
+    });
   },
   /** 同步编译（tectonic，硬超时 120s），直接返回诊断结果。 */
   compileManuscript(id: string): Promise<CompileResult> {


### PR DESCRIPTION
Closes #345

## What

Adds a **Refresh references** button to the writer workbench (next to Compile) backed by `POST /manuscripts/{id}/references/refresh`, which chains three steps:

1. **Rebuild the citation pool** — `_citations_pack` now exports the union of the project's related-research shelf (`TopicPaper`, non-trashed) and the linked direction libraries (previous behavior), deduped by paper id, with the same deterministic bibkey assignment.
2. **Rewrite `references.bib`** — via the existing `sync_references_bib`, so active CRDT rooms are updated in place and open editors see the change live.
3. **Normalize the main-tex wiring** — new `normalize_bibliography_wiring` keeps exactly one `\bibliography{references}` command: multiple `\bibliography` commands are collapsed into one at the first occurrence (duplicate `\bibdata` makes BibTeX abort, which surfaces as a wall of `Citation 'x' undefined` even when the bib has every key — exactly the failure observed on a real manuscript), and the command is injected before `\bibliographystyle`/`\end{document}` when missing. Room-aware, with a file version snapshot on direct DB writes.

## Tests

- `normalize_bibliography_wiring`: dedupe of multiple commands, insertion before `\bibliographystyle` / `\end{document}`, no-op when already correct or when the file has no anchors.
- Endpoint round-trip: shelf-only paper lands in the fact-pack citations with the expected bibkey; a main tex with a double-`\bibliography` accident is collapsed and reported as `bibliography_updated: true`.
- `pytest tests/test_latex_compile.py tests/test_manuscripts.py tests/test_topic_shelf.py tests/test_manuscript_files.py tests/test_manuscript_export.py` — 36 passed (one-off polaris-api container). `ruff check` clean on changed files; `tsc --noEmit` clean (the 6 pre-existing vitest module errors also occur on main).