### PR TITLE
feat(lab): count library and paper views, and show a 7-day heat list

### DIFF
--- a/src/backend/alembic/versions/a1c9e73b5d20_view_events.py
+++ b/src/backend/alembic/versions/a1c9e73b5d20_view_events.py
@@ -1,0 +1,43 @@
+"""view events
+
+Revision ID: a1c9e73b5d20
+Revises: 63133f647463
+Create Date: 2026-08-06
+
+文献库与论文的浏览事件。目标 id 不加外键：删掉的对象不该把「它曾被读过」这件事
+一并抹掉，查询时按当前可见对象过滤就够了。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1c9e73b5d20"
+down_revision: str | None = "63133f647463"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "view_events",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_view_events_kind_created", "view_events", ["kind", "created_at"])
+    op.create_index("ix_view_events_target_created", "view_events", ["target_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_view_events_target_created", table_name="view_events")
+    op.drop_index("ix_view_events_kind_created", table_name="view_events")
+    op.drop_table("view_events")

--- a/src/backend/app/api/lab.py
+++ b/src/backend/app/api/lab.py
@@ -22,8 +22,27 @@ from app.schemas.lab import (
 from app.schemas.llm_admin import UsageRow
 from app.services import lab as lab_service
 from app.services import llm_admin as llm_admin_service
+from app.services import view_stats
 
 router = APIRouter(prefix="/lab", tags=["lab"])
+
+
+@router.get("/hot")
+async def lab_hot(
+    days: int = Query(default=7, ge=1, le=90),
+    limit: int = Query(default=5, ge=1, le=20),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, list[dict[str, object]]]:
+    """最近 N 天被打开得最多的文献库与论文。
+
+    只返回计数，不按人展开——实验室里「谁在读什么」是敏感信息，热度需要的只是总数。
+    库按可见性过滤：看不见的库不该出现在榜上，哪怕它很热。
+    """
+    return {
+        "libraries": await view_stats.hot_libraries(session, user=user, days=days, limit=limit),
+        "papers": await view_stats.hot_papers(session, user=user, days=days, limit=limit),
+    }
 
 
 @router.get("/stats", response_model=LabStats)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -37,12 +37,14 @@ from app.api import (
     skills,
     ssh_credentials,
     users_profile,
+    views,
     voyages,
     wiki,
 )
 
 api_router = APIRouter()
 api_router.include_router(health.router)
+api_router.include_router(views.router)
 api_router.include_router(chat_agent.router)
 api_router.include_router(auth.router)
 api_router.include_router(chat_bots.router)

--- a/src/backend/app/api/views.py
+++ b/src/backend/app/api/views.py
@@ -1,0 +1,42 @@
+"""浏览打点：前端在打开文献库/论文时调一次。
+
+**只写不读**：读走 /lab/hot。分开是因为写这条路要极轻——它挂在每一次打开动作上，
+不能因为统计而拖慢正事，也不该在失败时影响页面。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.user import User
+from app.models.view_event import VIEW_KINDS
+from app.services import view_stats
+
+router = APIRouter(prefix="/views", tags=["views"])
+
+
+class ViewCreate(BaseModel):
+    kind: str = Field(pattern="^(library|paper)$")
+    target_id: uuid.UUID
+
+
+@router.post("", status_code=202)
+async def record_view(
+    payload: ViewCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict[str, bool]:
+    """记一次浏览。返回 counted=false 表示被去重窗口挡掉了（不是错误）。
+
+    202 而不是 201：这是一条**尽力而为**的记录，调用方不该等它、也不该因为它失败而
+    改变行为。
+    """
+    assert payload.kind in VIEW_KINDS
+    counted = await view_stats.record_view(
+        session, kind=payload.kind, target_id=payload.target_id, user_id=user.id
+    )
+    return {"counted": counted}

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -44,6 +44,7 @@ from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
 from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
+from app.models.view_event import ViewEvent
 from app.models.voyage import VoyageMessage, VoyageRun, VoyageStep
 
 __all__ = [
@@ -100,6 +101,7 @@ __all__ = [
     "TimestampMixin",
     "TopicPaper",
     "User",
+    "ViewEvent",
     "UserAuthorProfile",
     "UserLibraryEntry",
     "UserPaperTag",

--- a/src/backend/app/models/view_event.py
+++ b/src/backend/app/models/view_event.py
@@ -1,0 +1,37 @@
+"""浏览事件：谁在什么时候打开了哪个文献库 / 哪篇论文。
+
+单独一张表而不是复用 ``activities``：活动流是**语义事件**（每条都要有一句给人读的
+message），点击是高频、无语义的数据点，混在一起会把活动流冲没。
+
+留 ``user_id`` 只为**去重**（同一个人反复刷新不该算多次热度），API 一律不按人返回。
+实验室里"谁在读什么"是敏感信息，能不暴露就不暴露。
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+
+#: 目前只统计这两类。加新类型时记得同步 API 的白名单——不做白名单的话，
+#: 前端写错一个字就会在表里堆出一类谁也看不懂的数据。
+VIEW_KINDS = ("library", "paper")
+
+
+class ViewEvent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "view_events"
+    __table_args__ = (
+        # 热度查询永远是「最近 N 天 + 按类型」，索引照这个形状建
+        Index("ix_view_events_kind_created", "kind", "created_at"),
+        Index("ix_view_events_target_created", "target_id", "created_at"),
+    )
+
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    #: 目标 id。**不加外键**：论文和库分属两张表，而且目标删掉之后这条浏览记录
+    #: 仍然是真实发生过的事，不该跟着消失（查询时按当前可见对象过滤即可）。
+    target_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), index=True, nullable=True
+    )

--- a/src/backend/app/services/view_stats.py
+++ b/src/backend/app/services/view_stats.py
@@ -1,0 +1,111 @@
+"""浏览统计：记一次点击，以及最近 N 天的热度。
+
+三条口径写在这里，因为它们决定了这些数字**能不能拿来当依据**：
+
+1. **同一个人短时间内重复打开只算一次**。不去重的话，热度榜衡量的是「谁刷新得
+   最勤」，而不是「哪篇被更多人看」——一个人在一篇论文上来回切标签页就能屠榜。
+2. **删掉的对象不出现在榜上，但它的历史记录不删**。事件表不加外键正是为此：
+   「它曾被读过」是真实发生过的事；查询时按当前可见对象过滤即可。
+3. **只返回总数，不按人展开**。实验室里「谁在读什么」是敏感信息，热度需要的
+   只是计数。
+"""
+
+import datetime as dt
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper
+from app.models.user import User
+from app.models.view_event import VIEW_KINDS, ViewEvent
+
+#: 去重窗口：同一个人在这段时间内重复打开同一个对象只记一次。
+#: 一小时是「读一篇论文」的量级——来回切标签页、刷新、从不同入口再点一次，
+#: 都还是同一次阅读。不去重的话，热度榜衡量的是谁刷新得最勤。
+DEDUP_MINUTES = 60
+
+#: 热度榜默认看多少天 / 返回多少条。
+DEFAULT_DAYS = 7
+DEFAULT_LIMIT = 5
+
+
+async def record_view(
+    session: AsyncSession, *, kind: str, target_id: uuid.UUID, user_id: uuid.UUID | None
+) -> bool:
+    """记一次浏览；被去重窗口挡掉时返回 False。"""
+    if kind not in VIEW_KINDS:
+        raise ValueError(f"未知的浏览类型：{kind}")
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=DEDUP_MINUTES)
+    if user_id is not None:
+        recent = await session.scalar(
+            select(ViewEvent.id)
+            .where(
+                ViewEvent.kind == kind,
+                ViewEvent.target_id == target_id,
+                ViewEvent.user_id == user_id,
+                ViewEvent.created_at >= since,
+            )
+            .limit(1)
+        )
+        if recent is not None:
+            return False
+    session.add(ViewEvent(kind=kind, target_id=target_id, user_id=user_id))
+    await session.commit()
+    return True
+
+
+async def _counts(
+    session: AsyncSession, *, kind: str, days: int, limit: int
+) -> list[tuple[uuid.UUID, int]]:
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(days=days)
+    rows = await session.execute(
+        select(ViewEvent.target_id, func.count(ViewEvent.id).label("views"))
+        .where(ViewEvent.kind == kind, ViewEvent.created_at >= since)
+        .group_by(ViewEvent.target_id)
+        .order_by(func.count(ViewEvent.id).desc())
+        # 多取一些：下面还要按可见性过滤，掉队的要有人补位
+        .limit(limit * 4)
+    )
+    return [(row[0], int(row[1])) for row in rows.all()]
+
+
+async def hot_libraries(
+    session: AsyncSession, *, user: User, days: int = DEFAULT_DAYS, limit: int = DEFAULT_LIMIT
+) -> list[dict[str, object]]:
+    """最近 N 天最常被打开的文献库（只含这个人看得见的）。"""
+    from app.services.libraries import library_visible_to
+
+    counts = dict(await _counts(session, kind="library", days=days, limit=limit))
+    if not counts:
+        return []
+    rows = (
+        (await session.execute(select(DirectionLibrary).where(DirectionLibrary.id.in_(counts))))
+        .scalars()
+        .all()
+    )
+    out = [
+        {"id": str(lib.id), "name": lib.name, "views": counts[lib.id]}
+        for lib in rows
+        if library_visible_to(lib, user)
+    ]
+    out.sort(key=lambda item: -int(item["views"]))
+    return out[:limit]
+
+
+async def hot_papers(
+    session: AsyncSession, *, user: User, days: int = DEFAULT_DAYS, limit: int = DEFAULT_LIMIT
+) -> list[dict[str, object]]:
+    """最近 N 天最常被打开的论文。"""
+    counts = dict(await _counts(session, kind="paper", days=days, limit=limit))
+    if not counts:
+        return []
+    rows = (
+        (await session.execute(select(Paper).where(Paper.id.in_(counts)))).scalars().all()
+    )
+    out = [
+        {"id": str(paper.id), "title": paper.title, "views": counts[paper.id]} for paper in rows
+    ]
+    out.sort(key=lambda item: -int(item["views"]))
+    return out[:limit]

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "63133f647463"  # 任务对话流：voyage_messages 表（用户与任务 agent 的双向通道）
+HEAD_REVISION = "a1c9e73b5d20"  # 浏览事件（文献库/论文点击量）
+VOYAGE_MESSAGES_REVISION = "63133f647463"  # 任务对话流：voyage_messages 表
 READ_ONLY_REVISION = "b3f5c1e07a92"  # 只读账号（游客）
 SKILLS_GLOBAL_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
 MEMORY_KIND_REVISION = "d4e8b19c7a55"  # 记忆分层：fact 每轮带上 / note 检索到才回上下文
@@ -102,6 +103,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "agent_skill_files",
                     "skills",
                     "buddy_memories",
+                    "view_events",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -362,7 +364,16 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 任务对话流：用户与任务 agent 的双向消息
     assert "voyage_messages" in columns["_tables"]
 
-    # 最新 revision 可往返：先退掉任务对话流。
+    # 浏览事件：文献库/论文的点击量
+    assert "view_events" in columns["_tables"]
+
+    # 最新 revision 可往返：先退掉浏览事件。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == VOYAGE_MESSAGES_REVISION
+    assert "view_events" not in columns["_tables"]
+
+    # 再退掉任务对话流。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == READ_ONLY_REVISION

--- a/src/backend/tests/test_view_stats.py
+++ b/src/backend/tests/test_view_stats.py
@@ -1,0 +1,128 @@
+"""浏览统计：去重、可见性、只出计数。
+
+这些口径决定了热度数字能不能当依据，所以逐条钉住。
+"""
+
+import datetime as dt
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.services import view_stats
+from tests.conftest import register_and_login
+
+
+async def _user_id(email: str):
+    from sqlalchemy import select
+
+    from app.models.user import User
+
+    async with get_sessionmaker()() as session:
+        return (await session.execute(select(User.id).where(User.email == email))).scalar_one()
+
+
+async def test_one_person_clicking_repeatedly_counts_once(client):
+    """同一个人一小时内点多少次都只算一次。
+
+    不去重的话，热度榜衡量的是「谁刷新得最勤」——一个人来回切标签页就能屠榜。
+    """
+    assert await register_and_login(client, email="views-a@example.com")
+    uid = await _user_id("views-a@example.com")
+    target = uuid.uuid4()
+
+    async with get_sessionmaker()() as session:
+        assert await view_stats.record_view(
+            session, kind="paper", target_id=target, user_id=uid
+        ) is True
+        for _ in range(4):
+            assert await view_stats.record_view(
+                session, kind="paper", target_id=target, user_id=uid
+            ) is False
+
+
+async def test_different_people_each_count(client):
+    """去重是按人算的：两个人各看一次就是两次。"""
+    assert await register_and_login(client, email="views-b@example.com")
+    assert await register_and_login(client, email="views-c@example.com")
+    b, c = await _user_id("views-b@example.com"), await _user_id("views-c@example.com")
+    target = uuid.uuid4()
+
+    async with get_sessionmaker()() as session:
+        assert await view_stats.record_view(session, kind="paper", target_id=target, user_id=b)
+        assert await view_stats.record_view(session, kind="paper", target_id=target, user_id=c)
+
+
+async def test_the_window_is_an_hour(client):
+    """窗口过去之后再点就算新的一次。"""
+    from app.models.view_event import ViewEvent
+
+    assert await register_and_login(client, email="views-d@example.com")
+    uid = await _user_id("views-d@example.com")
+    target = uuid.uuid4()
+
+    async with get_sessionmaker()() as session:
+        # 造一条一小时零一分钟前的记录
+        old = ViewEvent(kind="paper", target_id=target, user_id=uid)
+        old.created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+            minutes=view_stats.DEDUP_MINUTES + 1
+        )
+        session.add(old)
+        await session.commit()
+
+        assert await view_stats.record_view(
+            session, kind="paper", target_id=target, user_id=uid
+        ) is True
+
+
+async def test_unknown_kinds_are_refused(client):
+    """类型不做白名单的话，前端写错一个字就会在表里堆出谁也看不懂的数据。"""
+    import pytest
+
+    assert await register_and_login(client, email="views-e@example.com")
+    async with get_sessionmaker()() as session:
+        with pytest.raises(ValueError):
+            await view_stats.record_view(
+                session, kind="idea", target_id=uuid.uuid4(), user_id=None
+            )
+
+
+async def test_hot_lists_only_show_what_you_can_see(client):
+    """看不见的库不出现在榜上，哪怕它更热。"""
+    from sqlalchemy import select
+
+    from app.models.library_direction import DirectionLibrary
+    from app.models.user import User
+    from app.models.view_event import ViewEvent
+
+    # 第一个注册的是管理员，而管理员本来就看得见全部库——这条要验的是**普通成员**
+    assert await register_and_login(client, email="views-admin@example.com")
+    assert await register_and_login(client, email="views-f@example.com")
+    uid = await _user_id("views-f@example.com")
+
+    async with get_sessionmaker()() as session:
+        public = DirectionLibrary(name="公共库", definition={"statement": "x"}, is_public=True)
+        private = DirectionLibrary(name="别人的私库", definition={"statement": "x"})
+        session.add_all([public, private])
+        await session.flush()
+        # 私库热度更高：三次 vs 一次。user_id 留空即可——去重只在有用户时生效，
+        # 这里要的是「计数」而不是「谁看的」。
+        for _ in range(3):
+            session.add(ViewEvent(kind="library", target_id=private.id, user_id=None))
+        session.add(ViewEvent(kind="library", target_id=public.id, user_id=uid))
+        await session.commit()
+
+        user = (await session.execute(select(User).where(User.id == uid))).scalar_one()
+        hot = await view_stats.hot_libraries(session, user=user)
+
+    names = [row["name"] for row in hot]
+    assert "公共库" in names
+    assert "别人的私库" not in names, "热度再高也不能让人看见他无权看的库"
+
+
+async def test_the_endpoint_answers_with_counts_only(client):
+    """API 只出总数，不按人展开——谁在读什么是敏感信息。"""
+    token = await register_and_login(client, email="views-g@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    body = (await client.get("/api/lab/hot", headers=headers)).json()
+    assert set(body) == {"libraries", "papers"}
+    for row in body["libraries"] + body["papers"]:
+        assert set(row) <= {"id", "name", "title", "views"}

--- a/src/frontend/src/components/ui/StatusPill.tsx
+++ b/src/frontend/src/components/ui/StatusPill.tsx
@@ -68,9 +68,15 @@ const PAPER_STATUS: Record<string, StatusMeta> = {
   excluded: { cls: 'st-rejected', zh: '已删除', en: 'removed' },
 };
 
-/** 论文状态 pill：把内部六种 status 折叠为用户可见三态。 */
-export function PaperStatusPill({ status, sm }: StatusPillProps) {
-  const s = PAPER_STATUS[status] ?? { cls: '', zh: status, en: status };
+/** 论文状态 pill：把内部六种 status 折叠为用户可见三态。
+
+    ``hasWiki`` 优先于 status：**「编译过没有」是论文级的事实**（解读存在 paper_wikis
+    上，全平台一份），而 status 是成员行上的判断。人工纳入的论文状态一直是 included，
+    编译完也不会变——只看 status 的话，明明已经编译出解读的论文在列表里仍写着「已纳入」。
+    以事实为准，别让用户去分辨两套口径。 */
+export function PaperStatusPill({ status, hasWiki, sm }: StatusPillProps) {
+  const effective = hasWiki && status !== 'excluded' ? 'compiled' : status;
+  const s = PAPER_STATUS[effective] ?? { cls: '', zh: status, en: status };
   return (
     <span className={`pill ${s.cls}${sm ? ' sm' : ''}`}>
       <span className="dot" />
@@ -80,6 +86,8 @@ export function PaperStatusPill({ status, sm }: StatusPillProps) {
 }
 
 export interface StatusPillProps {
+  /** 这篇有没有编译出解读（论文级事实，优先于成员行 status） */
+  hasWiki?: boolean;
   status: string;
   sm?: boolean;
 }

--- a/src/frontend/src/features/lab/HotLists.tsx
+++ b/src/frontend/src/features/lab/HotLists.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '../../components/ui/Icon';
+import { api } from '../../lib/api';
+import { clampLines } from '../../lib/clamp';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   最近 7 天的文献库 / 论文热度。
+
+   只出计数，不出「谁看的」——实验室里「某人在读什么」是敏感信息，而热度需要的
+   只是总数。同一个人一小时内重复打开只算一次（后端去重），否则这张榜衡量的是
+   谁刷新得最勤。
+
+   没有数据时**整块不显示**：一张全是 0 的榜既没信息也占地方，还会让人以为统计坏了。
+   ============================================================ */
+
+function HotCard({
+  title,
+  rows,
+  onOpen,
+}: {
+  title: string;
+  rows: { id: string; label: string; views: number }[];
+  onOpen: (id: string) => void;
+}) {
+  const max = Math.max(...rows.map((r) => r.views), 1);
+  return (
+    <div className="card card-pad" style={{ flex: 1, minWidth: 0 }}>
+      <div className="section-h" style={{ marginBottom: 10 }}>
+        <Icon name="chart" size={15} style={{ color: 'var(--accent)' }} />
+        {title}
+      </div>
+      <div className="col gap8">
+        {rows.map((row, i) => (
+          <div
+            key={row.id}
+            className="hoverable"
+            onClick={() => onOpen(row.id)}
+            style={{ cursor: 'pointer', padding: '2px 4px', borderRadius: 6 }}
+          >
+            <div className="row gap8" style={{ alignItems: 'baseline' }}>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-4)', width: 14 }}>
+                {i + 1}
+              </span>
+              <span style={{ flex: 1, minWidth: 0, fontSize: 12.5, ...clampLines(1) }} title={row.label}>
+                {row.label}
+              </span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                {row.views}
+              </span>
+            </div>
+            {/* 一条细条：数字之间的差距比数字本身更说明问题 */}
+            <div style={{ height: 3, background: 'var(--surface-3)', borderRadius: 2, marginTop: 4 }}>
+              <div
+                style={{
+                  height: 3,
+                  width: `${Math.round((row.views / max) * 100)}%`,
+                  background: 'var(--accent)',
+                  borderRadius: 2,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function HotLists() {
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: ['lab-hot'],
+    queryFn: () => api.getLabHot(7, 5),
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const libraries = data?.libraries ?? [];
+  const papers = data?.papers ?? [];
+  if (libraries.length === 0 && papers.length === 0) return null;
+
+  return (
+    <div className="row gap16 wrap" style={{ marginBottom: 20, alignItems: 'stretch' }}>
+      {libraries.length > 0 && (
+        <HotCard
+          title={tr('7 天文献库热度', 'Libraries · last 7 days')}
+          rows={libraries.map((l) => ({ id: l.id, label: l.name, views: l.views }))}
+          onOpen={(id) => navigate(`/libraries/${id}`)}
+        />
+      )}
+      {papers.length > 0 && (
+        <HotCard
+          title={tr('7 天论文热度', 'Papers · last 7 days')}
+          rows={papers.map((p) => ({ id: p.id, label: p.title, views: p.views }))}
+          onOpen={(id) => navigate(`/papers/${id}/read`)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -33,6 +33,7 @@ import {
   matchFilter,
   type Filter,
 } from '../voyages/VoyagesPage';
+import { HotLists } from './HotLists';
 
 /* ============================================================
    /lab — 实验室工作台
@@ -911,6 +912,7 @@ function OverviewTab() {
 
   return (
     <>
+      <HotLists />
       <div className="row gap16 dash-stats" style={{ marginBottom: 20 }}>
         <StatCard
           icon="book"

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -177,7 +177,7 @@ const PaperRow = memo(function PaperRow({
         <AddToButton paperId={p.id} />
       </div>
       <div className="row gap8" style={{ marginTop: 6 }}>
-        <PaperStatusPill status={p.status} sm />
+        <PaperStatusPill status={p.status} hasWiki={p.has_wiki} sm />
         <ReadingDot status={p.reading_status} />
         <PaperMyTagChips myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
@@ -300,7 +300,7 @@ function PaperDetailPane({
       <div className="row" style={{ alignItems: 'flex-start', gap: 20 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
-            <PaperStatusPill status={paper.status} sm />
+            <PaperStatusPill status={paper.status} hasWiki={paper.has_wiki} sm />
             {paper.venue && (
               <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
                 {paper.venue}

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -8,6 +8,7 @@ import { api, isAdmin, type DirectionLibraryDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { WikiWorkbench } from '../wiki/WikiPage';
 import { LibraryBrowse } from './LibraryBrowse';
+import { trackView } from '../../lib/viewTracking';
 
 /* ============================================================
    /libraries/:id — 文献库详情（P5c + P6 治理 + P9b 生命周期）
@@ -20,6 +21,11 @@ import { LibraryBrowse } from './LibraryBrowse';
 
 export function LibraryDetailPage() {
   const { id = '' } = useParams();
+
+  // 浏览打点：尽力而为，失败咽掉（去重在后端，同一个人一小时内只算一次）
+  useEffect(() => {
+    trackView('library', id);
+  }, [id]);
   const navigate = useNavigate();
 
   const { data: lib, isLoading, isError, refetch } = useQuery({

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -65,7 +65,7 @@ export function InfoPanel({
     <div className="scroll" style={{ flex: 1, overflowY: 'auto', padding: '14px 16px 40px' }}>
       {/* —— 头部 —— */}
       <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
-        <PaperStatusPill status={paper.status} sm />
+        <PaperStatusPill status={paper.status} hasWiki={paper.has_wiki} sm />
         {paper.venue && (
           <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
             {paper.venue}

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -22,6 +22,7 @@ import { PdfReader, type JumpTarget } from './PdfReader';
 import { ChatPanel } from './ChatPanel';
 import { InfoPanel } from './InfoPanel';
 import { READING_STATUS, readerBackLabel, type ReaderFrom } from './shared';
+import { trackView } from '../../lib/viewTracking';
 
 /* ============================================================
    /papers/:id/read — 论文阅读工作台：
@@ -42,6 +43,11 @@ const LS_COLLAPSED = 'polaris.reading.rightCollapsed';
 
 export function ReadingPage() {
   const { id = '' } = useParams<{ id: string }>();
+
+  // 浏览打点：尽力而为，失败咽掉（去重在后端，同一个人一小时内只算一次）
+  useEffect(() => {
+    trackView('paper', id);
+  }, [id]);
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -601,7 +601,7 @@ const PaperRow = memo(function PaperRow({
         <AddToButton paperId={p.id} />
       </div>
       <div className="row gap8" style={{ marginTop: 6 }}>
-        <PaperStatusPill status={p.status} sm />
+        <PaperStatusPill status={p.status} hasWiki={p.has_wiki} sm />
         <ReadingDot status={p.reading_status} />
         <PaperMyTagChips myTags={p.my_tags} />
         {(p.note_count ?? 0) > 0 && (
@@ -764,7 +764,7 @@ function PaperDetailPane({
       <div className="row" style={{ alignItems: 'flex-start', gap: 20 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="row gap8 wrap" style={{ marginBottom: 8 }}>
-            <PaperStatusPill status={paper.status} sm />
+            <PaperStatusPill status={paper.status} hasWiki={paper.has_wiki} sm />
             {paper.venue && (
               <span className="pill sm" style={{ background: 'var(--surface-3)' }}>
                 {paper.venue}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4930,6 +4930,17 @@ export const api = {
   createAssistantConversation(scope: { scope_kind?: string; project_id?: string } = {}): Promise<{ id: string; title: string }> {
     return requestJson<{ id: string; title: string }>('/chat/conversations', 'POST', scope);
   },
+  /** 记一次浏览（尽力而为：失败不影响页面，去重由后端做）。 */
+  recordView(kind: 'library' | 'paper', targetId: string): Promise<{ counted: boolean }> {
+    return request('/views', { method: 'POST', body: JSON.stringify({ kind, target_id: targetId }) });
+  },
+  /** 最近 N 天的文献库/论文热度（只出计数）。 */
+  getLabHot(days = 7, limit = 5): Promise<{
+    libraries: { id: string; name: string; views: number }[];
+    papers: { id: string; title: string; views: number }[];
+  }> {
+    return request(`/lab/hot?days=${days}&limit=${limit}`);
+  },
   getDailySyncStatus(): Promise<DailySyncStatus> {
     return request<DailySyncStatus>('/daily/sync-status');
   },

--- a/src/frontend/src/lib/viewTracking.ts
+++ b/src/frontend/src/lib/viewTracking.ts
@@ -1,0 +1,24 @@
+import { api } from './api';
+
+/* ============================================================
+   浏览打点。
+
+   **尽力而为**：失败一律咽掉。统计是附带产物，不能因为它让页面出错或变慢——
+   一个因为埋点挂了而打不开的论文页，比没有热度榜糟得多。
+
+   去重在后端做（同一个人一小时内只算一次）。前端只在这里挡住 React 严格模式下
+   同一次挂载的重复调用，省一个来回。
+   ============================================================ */
+
+const seen = new Set<string>();
+
+export function trackView(kind: 'library' | 'paper', targetId: string | null | undefined): void {
+  if (!targetId) return;
+  const key = `${kind}:${targetId}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  void api.recordView(kind, targetId).catch(() => {
+    // 记不上就算了。下次打开还有机会，而这次阅读本身不该受影响。
+    seen.delete(key);
+  });
+}


### PR DESCRIPTION
Clicks on a library or a paper are recorded, and the lab workbench gets two seven-day lists: which libraries and which papers people actually opened.

## Three decisions that decide whether the numbers mean anything

**One person's repeated clicks count once an hour.** Without deduplication the chart measures who refreshes most eagerly — switching tabs on a single paper would top it. An hour is the scale of "reading a paper": re-opening from another entry point, refreshing, coming back after a detour are all the same read.

**Deleted objects leave the chart but keep their history.** The event table deliberately has no foreign key to the target: "this was read" stays true after the target is gone. Queries filter by what is currently visible instead.

**Only totals are returned, never per-person rows.** In a lab, "who is reading what" is sensitive; heat needs the count and nothing more. Libraries are additionally filtered by visibility — a library you can't see must not appear, however hot it is.

## Shape

Its own table rather than `activities`: that stream is semantic events, each carrying a human-readable message for the timeline, and high-frequency clicks would flood it.

Recording is best-effort and fire-and-forget from the frontend (202, failures swallowed). A paper page that won't open because analytics broke is far worse than a missing chart. Empty lists render nothing at all — a chart of zeroes carries no information and reads as a broken feature.

## Also here: the status badge was lying

Papers that had already been compiled still showed **"included"** in lists. The badge rendered the membership row's `status`, while "has this been compiled" is a paper-level fact stored in `paper_wikis`. A manually included paper stays `included` forever, compiled or not — so the badge could never say otherwise.

The badge now follows the fact (`has_wiki`) rather than the field, in the library browser, the papers tab, and the reading panel.

## Tests

Six on the counting rules: dedup per person, dedup is per-person (two people each count), the hour boundary, unknown kinds refused, visibility filtering (verified with a non-admin — admins see every library by design, which would have made the assertion vacuous), and a counts-only payload. The migration round-trip is extended for the new table.

Frontend: vitest **48 passed**, `tsc --noEmit` and `vite build` clean. Full backend suite was still running when this was opened — I'll report the number.
