### PR TITLE
fix(voyage): harness robustness — tolerant template render, signature-aware replans, codegen retry hints

### DIFF
--- a/src/backend/app/agents/voyage/actions.py
+++ b/src/backend/app/agents/voyage/actions.py
@@ -93,7 +93,12 @@ def render_template(template: str, ctx: ActionContext, params: dict[str, Any]) -
     extra = params.get("vars")
     if isinstance(extra, dict):
         mapping.update(extra)
-    return template.format_map(mapping)
+    try:
+        return template.format_map(mapping)
+    except (ValueError, IndexError):
+        # 内容不是合法模板时（花括号来自代码/JSON 本身）原样放行——{goal} 替换只是
+        # 便利功能，动作绝不能因为内容含 "{" 就崩掉
+        return template
 
 
 @register("llm.complete")

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -761,8 +761,12 @@ async def _complete_json(ctx: ActionContext, *, system: str, user: str, validate
     重试必须把上一次的错误回喂给模型。原来是原样重发同一个 prompt——对确定性错误
     （少一个必需文件、生成的 .py 有语法错）这等于让模型再猜一遍同样的题，三次尝试
     烧三次 token 换回同一个错。带上错误后它才知道要改哪里。
+
+    截断（finish_reason=max_tokens）单独处理：JSON 烂在尾部不是模型写错格式，
+    重发同 prompt 必然在同一处再截一刀。升档输出预算并要求紧凑输出后重试。
     """
     last_error: Exception | None = None
+    max_tokens: int | None = None
     for attempt in range(_MAX_JSON_ATTEMPTS):
         prompt = user
         if last_error is not None:
@@ -786,7 +790,15 @@ async def _complete_json(ctx: ActionContext, *, system: str, user: str, validate
             user_id=ctx.run.created_by,
             project_id=ctx.run.project_id,
             voyage_id=ctx.run.id,
+            max_tokens=max_tokens,
         )
+        if getattr(result, "finish_reason", None) == "max_tokens":
+            max_tokens = 16384 if max_tokens else 8192
+            last_error = ValueError(
+                "输出超长被截断（max_tokens）。请压缩输出：省略非必要注释与空行，"
+                "避免重复内容，只保留任务要求的字段与文件"
+            )
+            continue
         try:
             return validate(_extract_json(result.content))
         except (ValueError, TypeError, KeyError, json.JSONDecodeError) as e:

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -40,6 +40,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
+from app.agents.voyage.errorsig import error_signature
 from app.agents.voyage.runner import Runner, open_runner, parse_container_spec
 from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
@@ -66,7 +67,7 @@ RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0�
 MAX_FIGURE_FIXES = 2  # 绘图脚本执行失败 / VLM 质检不合格的修复次数上限
 DEFAULT_NO_IMPROVE_STOP = 2  # 连续 N 轮主指标无提升即停（budget.no_improve_stop 可覆盖）
 MAX_QC_IMAGES = 8  # 单次质检最多送 LLM 的图数
-_MAX_JSON_ATTEMPTS = 3  # 首次 + 重试 2 次
+_MAX_JSON_ATTEMPTS = 5  # 首次 + 重试 4 次——重试都带错误回喂，只有失败才多花调用
 _WIKI_CONTEXT_PAPERS = 6
 _WIKI_EXCERPT_CHARS = 600
 _LOG_TAIL_FOR_REPORT = 60
@@ -765,9 +766,18 @@ async def _complete_json(ctx: ActionContext, *, system: str, user: str, validate
     for attempt in range(_MAX_JSON_ATTEMPTS):
         prompt = user
         if last_error is not None:
+            hint = ""
+            if "语法错误" in str(last_error):
+                # 线上高频根因：代码经 JSON 字符串转义后被写坏（反斜杠续行/转义错位）。
+                # 光回喂错误行模型常在原地打转，点破成因才改得动。
+                hint = (
+                    "\n常见根因：代码放进 JSON 字符串时转义出错（多余或缺失的反斜杠、"
+                    "\\n 与真实换行混用、行尾反斜杠续行）。请重写出错行附近的代码，"
+                    "避免行尾反斜杠与复杂转义写法（如把长 f-string 拆成多次拼接）。"
+                )
             prompt = (
                 f"{user}\n\n---\n"
-                f"上一次输出没通过校验（第 {attempt} 次尝试）：{last_error}\n"
+                f"上一次输出没通过校验（第 {attempt} 次尝试）：{last_error}{hint}\n"
                 "请针对这个错误修正后重新输出完整 JSON，不要重复同样的问题。"
             )
         result = await ctx.llm.complete(
@@ -1144,19 +1154,8 @@ _SIGNATURE_ESCALATE_AT = 2
 _SIGNATURE_ASK_AT = 4
 
 
-def _error_signature(err_text: str) -> str:
-    """报错文本 → 规范化签名（数字/十六进制/路径抹平，取 traceback 尾部关键行）。
-
-    同签名 = 同一个错误在原地打转；不同签名 = 修复改变了故障面（算进展）。"""
-    lines = [ln.strip() for ln in (err_text or "").strip().splitlines() if ln.strip()]
-    # 取最像「结论」的尾部行：异常类型行优先，否则最后两行
-    tail = [ln for ln in lines[-6:] if re.match(r"^[A-Za-z_.]+(Error|Exception|error)\b", ln)]
-    picked = tail[-1:] if tail else lines[-2:]
-    sig = " | ".join(picked)[:300]
-    sig = re.sub(r"0x[0-9a-fA-F]+", "0xX", sig)
-    sig = re.sub(r"\d+", "N", sig)
-    sig = re.sub(r"/[^\s'\"]+", "/PATH", sig)
-    return sig
+# 签名实现提到共享模块（引擎重规划计数同用）；保留旧名给既有调用点/测试
+_error_signature = error_signature
 
 
 def _render_fix_ledger(ledger: list[dict[str, Any]]) -> str:

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.agents.voyage.actions import ActionContext
 from app.agents.voyage.checks import run_deterministic_checks
+from app.agents.voyage.errorsig import error_signature
 from app.agents.voyage.helm import Helm
 from app.agents.voyage.navigator import Navigator, NavigatorError, done_criteria_for_kind
 from app.agents.voyage.plan_edit import SIGNAL_TABLES, PlanEditError
@@ -50,6 +51,27 @@ from app.services import voyage_messages as messages_service
 
 MAX_REPLANS = 2
 _RANK_GAP = 100.0
+
+
+def _replan_progress(checkpoint: dict[str, Any], diagnosis: str) -> tuple[int, str, bool]:
+    """签名感知的重规划计数：错误签名变了 = 有进展 = 计数清零（同 #354 的零进展哲学）。
+
+    计数只累积「同一签名连续未解决」的调整次数——一路在换新错误的 run 永远不会
+    因 MAX_REPLANS 打断用户。没存过上次签名（旧 checkpoint / 空诊断）时不清零，
+    维持原计数语义。返回 (生效计数, 本次签名, 是否同签名重复)。"""
+    sig = error_signature(diagnosis)
+    last_sig = str(checkpoint.get("replan_signature") or "")
+    replans = int(checkpoint.get("replans", 0))
+    repeated = bool(sig) and sig == last_sig
+    if sig and last_sig and not repeated:
+        replans = 0
+    return replans, sig, repeated
+
+
+_ZERO_PROGRESS_DIRECTIVE = (
+    "\n【零进展警告】上一次计划调整后错误签名没有变化——上次的方案没起作用。"
+    "必须换一个根本不同的思路（换动作、换方法、绕开该依赖），不要再微调同类修复。"
+)
 
 # ask 的候选选项（消息是数据，标签存 zh/en 两份，前端渲染处按语言取）。
 # 自由文本回答始终允许；choice 只是给用户的快捷入口与引擎的确定性分支键。
@@ -1304,18 +1326,19 @@ class VoyageEngine:
         用户明确要求换方案时不受次数限制，且 ask 的消费标记与编辑生效同一事务。
         """
         checkpoint = dict(run.checkpoint or {})
-        replans = int(checkpoint.get("replans", 0))
         diagnosis = str((failed_node.verdict or {}).get("reason", ""))
+        # 签名感知：只有「同一错误连续多次调整仍未解决」才打断用户；错误在变=有进展
+        replans, replan_sig, sig_repeated = _replan_progress(checkpoint, diagnosis)
         if not ignore_limit and replans >= MAX_REPLANS:
             await self._emit_log(
-                run, f"计划调整已达上限（{MAX_REPLANS} 次）", level="error"
+                run, f"同一问题连续 {MAX_REPLANS} 次计划调整仍未解决", level="error"
             )
             await self._raise_ask(
                 session,
                 run,
                 ask_kind="no_progress",
-                question=f"自动调整计划已达 {MAX_REPLANS} 次仍未通过"
-                f"（最近的问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
+                question=f"同一个问题连续 {MAX_REPLANS} 次计划调整仍未解决"
+                f"（问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
                 context={"diagnosis": diagnosis[:2000], "replans": replans},
                 options=_ASK_OPTIONS["no_progress"],
                 step=failed_node,
@@ -1334,11 +1357,13 @@ class VoyageEngine:
             )
             or None
         )
+        # 同签名重复时明确告诉 Navigator：上次的编辑没改变故障面，必须换思路
+        nav_diagnosis = diagnosis + _ZERO_PROGRESS_DIRECTIVE if sig_repeated else diagnosis
         try:
             edit = await self.navigator.on_result(
                 run,
                 failed_def,
-                diagnosis,
+                nav_diagnosis,
                 self._plan_state_summary(rows),
                 user_guidance=combined_guidance,
             )
@@ -1393,6 +1418,7 @@ class VoyageEngine:
         failed_node.status = "obsolete"
         checkpoint["replaced_steps"] = replaced
         checkpoint["replans"] = replans + 1
+        checkpoint["replan_signature"] = replan_sig
         run.checkpoint = checkpoint
         run.plan_iteration = run.plan_iteration + 1
         obsoleted = 1 + sum(
@@ -1444,16 +1470,19 @@ class VoyageEngine:
         run.plan 快照由节点行重新派生。
         """
         checkpoint = dict(run.checkpoint or {})
-        replans = int(checkpoint.get("replans", 0))
         diagnosis = str((failed_node.verdict or {}).get("reason", ""))
+        # 签名感知（同 _navigator_edit）：错误在变=有进展，不打断用户
+        replans, replan_sig, sig_repeated = _replan_progress(checkpoint, diagnosis)
         if replans >= MAX_REPLANS:
-            await self._emit_log(run, f"重规划已达上限（{MAX_REPLANS} 次）", level="error")
+            await self._emit_log(
+                run, f"同一问题连续 {MAX_REPLANS} 次重规划仍未解决", level="error"
+            )
             await self._raise_ask(
                 session,
                 run,
                 ask_kind="no_progress",
-                question=f"自动重规划已达 {MAX_REPLANS} 次仍未通过"
-                f"（最近的问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
+                question=f"同一个问题连续 {MAX_REPLANS} 次重规划仍未解决"
+                f"（问题：{diagnosis[:300]}）。需要你给出指示，或选择收尾/放弃",
                 context={"diagnosis": diagnosis[:2000], "replans": replans},
                 options=_ASK_OPTIONS["no_progress"],
                 step=failed_node,
@@ -1464,9 +1493,10 @@ class VoyageEngine:
         # 注入点②（template 同 loop）：用户建议交给重规划，失败不标记消费
         guidance_msgs = await self._drain_user_messages(session, run)
         user_guidance = messages_service.guidance_text(guidance_msgs) or None
+        nav_diagnosis = diagnosis + _ZERO_PROGRESS_DIRECTIVE if sig_repeated else diagnosis
         try:
             new_tail = await self.navigator.replan(
-                run, failed_step, diagnosis, user_guidance=user_guidance
+                run, failed_step, nav_diagnosis, user_guidance=user_guidance
             )
         except NavigatorError as e:
             await self._emit_log(run, f"重规划失败：{e}", level="error")
@@ -1490,6 +1520,7 @@ class VoyageEngine:
         replaced.append(_serialize_step(failed_node))
         checkpoint["replaced_steps"] = replaced
         checkpoint["replans"] = replans + 1
+        checkpoint["replan_signature"] = replan_sig
         run.checkpoint = checkpoint
         run.plan_iteration = run.plan_iteration + 1
 

--- a/src/backend/app/agents/voyage/errorsig.py
+++ b/src/backend/app/agents/voyage/errorsig.py
@@ -1,0 +1,22 @@
+"""错误签名归一化——零进展检测的共享基础（#354 引入，#360 提为共享模块）。
+
+同签名 = 同一个错误在原地打转（零进展）；不同签名 = 修复改变了故障面（算进展）。
+实验修复循环与引擎重规划计数共用这一套判定。
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def error_signature(err_text: str) -> str:
+    """报错文本 → 规范化签名（数字/十六进制/路径抹平，取 traceback 尾部关键行）。"""
+    lines = [ln.strip() for ln in (err_text or "").strip().splitlines() if ln.strip()]
+    # 取最像「结论」的尾部行：异常类型行优先，否则最后两行
+    tail = [ln for ln in lines[-6:] if re.match(r"^[A-Za-z_.]+(Error|Exception|error)\b", ln)]
+    picked = tail[-1:] if tail else lines[-2:]
+    sig = " | ".join(picked)[:300]
+    sig = re.sub(r"0x[0-9a-fA-F]+", "0xX", sig)
+    sig = re.sub(r"\d+", "N", sig)
+    sig = re.sub(r"/[^\s'\"]+", "/PATH", sig)
+    return sig

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -59,6 +59,10 @@ POLARIS_PLAN_EDIT
 - 每个新节点必须带 acceptance；单次编辑新增节点 ≤ 8 个
 - 只能引用未完成的步骤 id；已通过/已作废的步骤不可编辑
 - 失败步骤会在编辑生效后自动作废，你只需给出替代/补充步骤
+- artifact.write 只是把文本记录成平台产物（报告/笔记），**不会**修改任何执行环境或
+  远端文件；修复代码/环境/依赖问题必须重跑对应的领域动作步骤（把诊断写进该步 params，
+  例如失败的是 experiment.setup 就新增一个 experiment.setup 节点），不要用 artifact.write
+  去"改文件"
 """
 
 

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1507,3 +1507,25 @@ async def test_experiment_trash_flow(client):
     r = await client.post(f"/api/projects/{project_id}/experiments/trash/empty", headers=headers)
     assert r.status_code == 200 and r.json()["affected"] == 1
     assert (await client.get(f"/api/experiments/{ids[1]}", headers=headers)).status_code == 404
+
+
+async def test_complete_json_escalates_max_tokens_on_truncation():
+    """截断（finish_reason=max_tokens）≠ 格式错：升档输出预算重试，不烧解析重试次数。"""
+    from types import SimpleNamespace
+
+    calls: list[int | None] = []
+
+    class _TruncatingLLM:
+        async def complete(self, stage, messages, **kw):
+            calls.append(kw.get("max_tokens"))
+            if len(calls) == 1:
+                return SimpleNamespace(content='{"a": 1', finish_reason="max_tokens")
+            return SimpleNamespace(content='{"a": 1}', finish_reason="stop")
+
+    ctx = SimpleNamespace(
+        llm=_TruncatingLLM(),
+        run=SimpleNamespace(created_by=None, project_id=None, id=None),
+    )
+    out = await ax._complete_json(ctx, system="s", user="u", validate=lambda d: d)
+    assert out == {"a": 1}
+    assert calls == [None, 8192]  # 截断后第二次带升档 max_tokens

--- a/src/backend/tests/test_voyage_engine.py
+++ b/src/backend/tests/test_voyage_engine.py
@@ -179,3 +179,59 @@ async def test_cancelled_voyage_engine_noop(client, queue_stub):
     detail = resp.json()
     assert detail["status"] == "cancelled"
     assert all(s["status"] == "pending" for s in detail["steps"]) or detail["steps"] == []
+
+
+# ---- #360 harness 健壮性：模板渲染放行非模板内容 / 签名感知重规划计数 ----
+
+
+def _fake_ctx(checkpoint: dict | None = None):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        run=SimpleNamespace(goal="测试目标", kind="demo"),
+        checkpoint=checkpoint if checkpoint is not None else {},
+    )
+
+
+def test_render_template_passes_through_code_content():
+    """含花括号的代码/JSON 不是模板：必须原样放行，绝不能 ValueError。"""
+    from app.agents.voyage.actions import render_template
+
+    code = 'def f(x):\n    d = {"a": {"b": 1}}\n    return f"{d[\'a\']}{x:.2f}"\n'
+    assert render_template(code, _fake_ctx(), {}) == code
+    # 正常模板路径不受影响
+    assert render_template("目标：{goal}", _fake_ctx(), {}) == "目标：测试目标"
+    # 缺失变量原样保留（旧行为）
+    assert render_template("{unknown}", _fake_ctx(), {}) == "{unknown}"
+
+
+async def test_artifact_write_accepts_brace_content():
+    """线上案例：navigator 用 artifact.write 写修复代码，内容含 { 直接炸步骤。"""
+    from app.agents.voyage.actions import artifact_write
+
+    ctx = _fake_ctx(checkpoint={})
+    out = await artifact_write(ctx, {"name": "fix.py", "content": 'print("{ok}", {1: 2})'})
+    assert out["artifact"] == "fix.py"
+    assert ctx.checkpoint["artifacts"]["fix.py"] == 'print("{ok}", {1: 2})'
+
+
+def test_replan_progress_signature_semantics():
+    """错误签名变了=有进展计数清零；同签名累积；无历史签名维持原计数。"""
+    from app.agents.voyage.engine import _replan_progress
+    from app.agents.voyage.errorsig import error_signature
+
+    err_a = "ImportError: No module named 'triton'"
+    err_b = "SSHExecError: docker run 启动容器失败"
+    sig_a = error_signature(err_a)
+
+    # 无历史签名（旧 checkpoint）：计数保持
+    replans, sig, repeated = _replan_progress({"replans": 2}, err_a)
+    assert (replans, repeated) == (2, False) and sig == sig_a
+    # 同签名重复：计数保持、标记重复（触发零进展指令）
+    replans, _, repeated = _replan_progress({"replans": 1, "replan_signature": sig_a}, err_a)
+    assert (replans, repeated) == (1, True)
+    # 签名变化：计数清零（换了新错误=有进展，不打断用户）
+    replans, sig_new, repeated = _replan_progress(
+        {"replans": 2, "replan_signature": sig_a}, err_b
+    )
+    assert (replans, repeated) == (0, False) and sig_new != sig_a


### PR DESCRIPTION
Closes #360

Five generic harness fixes driven by live monitoring of two production experiments (no experiment-specific special-casing):

## 1. `render_template` tolerates non-template content
`format_map` raised `ValueError: unexpected '{' in field name` whenever `artifact.write`/`llm.complete` params contained code or JSON. Malformed-template content now passes through untouched; `{goal}`/`{kind}` substitution and missing-variable preservation are unchanged.

## 2. Signature-aware engine replan counter
`MAX_REPLANS` now counts only consecutive plan edits that fail with the **same normalized error signature** (shared `errorsig` module, extracted from the #354 experiment fix loops). A changed signature = progress → counter resets, the user is not interrupted. A repeated signature additionally injects a zero-progress directive into the navigator prompt demanding a fundamentally different approach. Old checkpoints without a stored signature keep the previous counting semantics.

## 3. Codegen JSON retry hardening
`_complete_json`: 3 → 5 attempts (retries only happen on failure and always carry error feedback), and syntax-error retries now name the common root cause — JSON string escaping mangling generated code — so the model stops replaying the same broken line.

## 4. Navigator prompt: `artifact.write` semantics
The plan-edit prompt now states that `artifact.write` records a text artifact and cannot modify the execution environment or remote files; code/env repairs must re-run the owning domain step (e.g. `experiment.setup`). In the live run the navigator "fixed" a remote `train.py` via `artifact.write` — a no-op even if it hadn't crashed.

## 5. Output truncation is not a formatting error
Live case on the second experiment: an ~11K-char files JSON was cut at the provider's default output cap and every retry failed at the same offset — the "Expecting ',' delimiter" feedback only makes the prompt longer. `_complete_json` now detects `finish_reason == "max_tokens"`, escalates `max_tokens` (8192 → 16384), and instructs compact output instead of replaying the parse error.

## Tests
- `render_template` passthrough (code content, normal template, missing var) + `artifact.write` with brace content.
- `_replan_progress` semantics: no stored signature keeps count; same signature keeps count and flags repetition; changed signature resets.
- `_complete_json` truncation: escalates `max_tokens` on `finish_reason=max_tokens` and succeeds on retry.
- Full voyage/experiment suites: 142 passed (engine/ask/loop/experiments/scope/messages/api).