### PR TITLE
fix(voyage): reclaim zombie voyages, stop premature experiment failure, clarify llm.complete semantics

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -2825,7 +2825,14 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
         experiment.report = result.content.strip()
         _remember(ctx, "报告", f"实验报告已生成（约 {len(experiment.report)} 字）")
         run_ok = last_run is not None and last_run.status == "succeeded"
-        final_status = "done" if run_ok else "failed"
+        # failed 只由人拍板：最后一轮未成功时**不写终态**——紧随其后的完成标准检查
+        # 会向用户提问（接受/补做/放弃），终态由用户答案或 voyage 终态联动落定。
+        # 原来这里直接置 failed，把实验锁进终态，waiting_user 镜像与后续状态全部失效。
+        final_status = "done" if run_ok else experiment.status
+        if run_ok:
+            await _set_status(ctx, session, experiment, "done")
+        else:
+            await ctx.log("最后一轮运行未成功——不自动判失败，等完成标准检查和你的裁决")
         session.add(
             Activity(
                 project_id=experiment.project_id,
@@ -2835,7 +2842,7 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 payload={"experiment_id": str(experiment.id), "final_status": final_status},
             )
         )
-        await _set_status(ctx, session, experiment, final_status)
+        await session.commit()
 
     # voyage 级完成标准（done_criteria）断言该标记：防"过早宣告完成"
     ctx.checkpoint["report_done"] = True

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -566,6 +566,12 @@ class VoyageEngine:
             run.status = await self._current_db_status(session, run.id)
             raise _ExternallyTerminated(run.status)
         run.status = status
+        if status == "done":
+            # 终态联动：仍非终态的关联实验随 voyage 落定为 done（报告动作不再自判
+            # failed，用户「接受当前结果」等路径都汇到这里；无关联实验时是 noop）
+            from app.services import experiments as experiments_service
+
+            await experiments_service.complete_by_voyage(session, run.id)
         await self._emit_status(run)
 
     # ---- 主流程 ----

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -59,10 +59,10 @@ POLARIS_PLAN_EDIT
 - 每个新节点必须带 acceptance；单次编辑新增节点 ≤ 8 个
 - 只能引用未完成的步骤 id；已通过/已作废的步骤不可编辑
 - 失败步骤会在编辑生效后自动作废，你只需给出替代/补充步骤
-- artifact.write 只是把文本记录成平台产物（报告/笔记），**不会**修改任何执行环境或
-  远端文件；修复代码/环境/依赖问题必须重跑对应的领域动作步骤（把诊断写进该步 params，
-  例如失败的是 experiment.setup 就新增一个 experiment.setup 节点），不要用 artifact.write
-  去"改文件"
+- artifact.write 只是把文本记录成平台产物（报告/笔记），llm.complete 只产出一段文本
+  （分析/草拟）——这两个动作**不会执行任何命令、不接触执行环境或远端文件**；克隆仓库、
+  装依赖、跑脚本这类要真实执行的事，必须用对应的领域动作步骤（把诊断与要求写进该步
+  params，例如失败的是 experiment.setup 就新增一个 experiment.setup 节点）
 """
 
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -336,6 +336,22 @@ async def fail_by_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Experim
     return experiment
 
 
+async def complete_by_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Experiment | None:
+    """voyage 到达 done：仍非终态的关联实验落定为 done。
+
+    覆盖两条路：完成标准通过（正常收尾）与用户拍板「接受当前结果为完成」。
+    报告动作只在最后一轮成功时自己写 done（failed 只由人拍板，见 #366）——
+    其余情况实验状态一路保持非终态，最终在这里随 voyage 落定。"""
+    stmt = select(Experiment).where(Experiment.voyage_id == voyage_id)
+    experiment = (await session.execute(stmt)).scalar_one_or_none()
+    if experiment is None or experiment.status in EXPERIMENT_TERMINAL_STATUSES:
+        return None
+    experiment.status = "done"
+    await session.commit()
+    await session.refresh(experiment)
+    return experiment
+
+
 async def mark_waiting_by_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> Experiment | None:
     """voyage 转 paused_ask：实验镜像 waiting_user（原状态记进 iteration_state，
     回答后由 :func:`resume_from_waiting_by_voyage` 恢复）。"""

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1529,3 +1529,23 @@ async def test_complete_json_escalates_max_tokens_on_truncation():
     out = await ax._complete_json(ctx, system="s", user="u", validate=lambda d: d)
     assert out == {"a": 1}
     assert calls == [None, 8192]  # 截断后第二次带升档 max_tokens
+
+
+async def test_complete_by_voyage_finalizes_nonterminal(client, queue_stub, fake_ssh):
+    """voyage done 联动：非终态实验落定 done；终态不再动（幂等）。"""
+    from app.services import experiments as experiments_service
+
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+
+    async with get_sessionmaker()() as session:
+        experiment = await session.get(Experiment, uuid.UUID(exp_id))
+        experiment.status = "running"
+        await session.commit()
+        out = await experiments_service.complete_by_voyage(session, uuid.UUID(voyage_id))
+        assert out is not None and out.status == "done"
+        # 已终态：noop（failed/cancelled 同理，不会被覆盖）
+        assert await experiments_service.complete_by_voyage(session, uuid.UUID(voyage_id)) is None

--- a/src/backend/tests/test_worker_reconcile.py
+++ b/src/backend/tests/test_worker_reconcile.py
@@ -1,11 +1,13 @@
-"""worker 启动对账：认领无人执行的 executing 航程（重启/超时把 ARQ 任务弄丢时自动恢复）。"""
+"""worker 对账：启动认领 + 周期僵死回收（重启/超时/任务丢失时自动恢复在途航程）。"""
 
 import uuid
+from datetime import datetime, timedelta
 
 from app.core.db import get_sessionmaker
-from app.models.voyage import VoyageRun
+from app.models.base import utcnow
+from app.models.voyage import VoyageRun, VoyageTerminalLog
 from tests.conftest import register_and_login
-from worker.tasks import reconcile_stuck_voyages
+from worker.tasks import reconcile_stale_voyages, reconcile_stuck_voyages
 
 
 class _RecordingRedis:
@@ -17,21 +19,37 @@ class _RecordingRedis:
         return None
 
 
-async def _seed_voyage(project_id: uuid.UUID, status: str) -> uuid.UUID:
+async def _seed_voyage(
+    project_id: uuid.UUID, status: str, created_at: datetime | None = None
+) -> uuid.UUID:
     async with get_sessionmaker()() as session:
         run = VoyageRun(
             project_id=project_id, kind="experiment", mode="loop", goal="t", status=status
         )
+        if created_at is not None:
+            run.created_at = created_at
         session.add(run)
         await session.commit()
         return run.id
 
 
-async def test_reconcile_enqueues_only_executing(client):
-    token = await register_and_login(client, "reconcile@example.com")
+async def _seed_log(run_id: uuid.UUID, at: datetime) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(
+            VoyageTerminalLog(run_id=run_id, event="log", level="info", message="t", at=at)
+        )
+        await session.commit()
+
+
+async def _make_project(client, email: str) -> uuid.UUID:
+    token = await register_and_login(client, email)
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post("/api/projects", json={"name": "rec-proj"}, headers=headers)
-    project_id = uuid.UUID(resp.json()["id"])
+    return uuid.UUID(resp.json()["id"])
+
+
+async def test_reconcile_enqueues_only_executing(client):
+    project_id = await _make_project(client, "reconcile@example.com")
 
     v_exec = await _seed_voyage(project_id, "executing")
     await _seed_voyage(project_id, "done")
@@ -42,5 +60,24 @@ async def test_reconcile_enqueues_only_executing(client):
     await reconcile_stuck_voyages({"redis": redis})
 
     assert [(f, a[0]) for f, a, _k in redis.jobs] == [("resume_voyage", str(v_exec))]
-    # _job_id 去重键：同一 voyage 不会重复入队
-    assert redis.jobs[0][2]["_job_id"] == f"reconcile-resume-{v_exec}"
+    # 去重键按时间分桶：固定 id 会被 arq 的结果保留期（1h）静默吞掉入队
+    assert redis.jobs[0][2]["_job_id"].startswith(f"reconcile-resume-{v_exec}-")
+
+
+async def test_stale_reclaim_only_grabs_quiet_voyages(client):
+    """周期回收判据：在途 + 终端超时无动静（无日志则看创建时间）才认领。"""
+    project_id = await _make_project(client, "reconcile-stale@example.com")
+    old = utcnow() - timedelta(hours=2)
+
+    v_quiet = await _seed_voyage(project_id, "executing", created_at=old)  # 无日志且够老
+    v_stale_log = await _seed_voyage(project_id, "verifying", created_at=old)
+    await _seed_log(v_stale_log, old + timedelta(minutes=5))  # 日志停在两小时前
+    v_active = await _seed_voyage(project_id, "verifying", created_at=old)
+    await _seed_log(v_active, utcnow())  # 刚有动静
+    await _seed_voyage(project_id, "executing")  # 刚创建（可能还在排队）
+    await _seed_voyage(project_id, "paused_ask", created_at=old)  # 非 in-flight 绝不碰
+
+    redis = _RecordingRedis()
+    await reconcile_stale_voyages({"redis": redis}, stale_minutes=30)
+
+    assert {a[0] for _f, a, _k in redis.jobs} == {str(v_quiet), str(v_stale_log)}

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -12,6 +12,7 @@ from worker.tasks import (
     index_papers_fulltext_task,
     match_user_publications,
     ping_task,
+    reconcile_stale_voyages,
     reconcile_stuck_voyages,
     resume_voyage,
     run_voyage,
@@ -46,6 +47,9 @@ class WorkerSettings:
     cron_jobs = [
         cron(daily_feed_sync, minute=_CHECKPOINT_MINUTES),
         cron(daily_publication_match, minute=_CHECKPOINT_MINUTES),
+        # 僵死回收：启动对账只救 worker 重启的孤儿；运行中途丢任务（LLM 调用悬死、
+        # ARQ 指数延迟重试）的僵死靠周期兜底（判据=终端 30 分钟无动静，见 tasks.py）
+        cron(reconcile_stale_voyages, minute={5, 15, 25, 35, 45, 55}),
     ]
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)
     # 其余任务保持 1h 上限

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -46,13 +46,27 @@ async def resume_voyage(ctx: dict[str, Any], run_id: str) -> None:
     await _make_engine().resume(uuid.UUID(run_id))
 
 
+RECONCILE_DEDUP_WINDOW_SECONDS = 900  # 同一 voyage 15 分钟内只入队一次 resume
+RECONCILE_STALE_MINUTES = 30  # 周期回收：终端无动静超过这个时长才算僵死
+
+
+def _reconcile_job_id(vid: object, now: float) -> str:
+    """时间分桶的去重键。arq 对已有同 id 的任务（排队/在跑/**结果保留期内**）会静默
+    去重——keep_result 默认 1 小时，固定 id 意味着重启后的对账 enqueue 可能被一小时前
+    的旧结果吞掉（线上实测：voyage 卡 verifying 45 分钟无人认领）。分桶让去重只在
+    短窗口内生效。"""
+    return f"reconcile-resume-{vid}-{int(now // RECONCILE_DEDUP_WINDOW_SECONDS)}"
+
+
 async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
     """worker 启动对账：认领无人执行的在途航程（见 IN_FLIGHT_STATUSES）。
 
     被 SIGTERM/超时打断的 ARQ 任务按任务年龄指数延迟重试，长航程会被晾数小时
-    （实测：远端 run.sh 已 exit=0，平台侧 50 分钟无人收尾）。启动时把 executing
+    （实测：远端 run.sh 已 exit=0，平台侧 50 分钟无人收尾）。启动时把在途
     状态的 voyage 重新入队 resume——引擎幂等（setup/run 都会重挂在跑的远端进程，
-    checkpoint 断点恢复），``_job_id`` 去重避免同一 voyage 重复入队。"""
+    checkpoint 断点恢复）。"""
+    import time
+
     from sqlalchemy import select
 
     from app.models.voyage import IN_FLIGHT_STATUSES, VoyageRun
@@ -69,8 +83,67 @@ async def reconcile_stuck_voyages(ctx: dict[str, Any]) -> None:
             .scalars()
             .all()
         )
+    now = time.time()
     for vid in ids:
-        await ctx["redis"].enqueue_job("resume_voyage", str(vid), _job_id=f"reconcile-resume-{vid}")
+        await ctx["redis"].enqueue_job(
+            "resume_voyage", str(vid), _job_id=_reconcile_job_id(vid, now)
+        )
+
+
+async def reconcile_stale_voyages(
+    ctx: dict[str, Any], stale_minutes: int = RECONCILE_STALE_MINUTES
+) -> None:
+    """周期回收（cron）：在途但终端长时间无动静的 voyage 重新入队 resume。
+
+    启动对账只救 worker 重启这一种孤儿；任务在运行中途丢失（LLM 调用悬死后被杀、
+    ARQ 指数延迟重试晾着）产生的僵死靠这里兜底。判据保守：距最后一条终端日志
+    （无日志则取创建时间）超过 ``stale_minutes`` 才认领——活着的长步骤会持续产生
+    日志/轮询输出，短暂静默不会被误抢；引擎本身幂等，偶发的并发 resume 可容忍
+    （arq 中断重试与启动对账本就可能重叠，线上已验证无碍）。"""
+    import time
+    from datetime import timedelta
+
+    from sqlalchemy import func as sa_func
+    from sqlalchemy import or_, select
+
+    from app.models.base import utcnow
+    from app.models.voyage import IN_FLIGHT_STATUSES, VoyageRun, VoyageTerminalLog
+
+    cutoff = utcnow() - timedelta(minutes=stale_minutes)
+    last_log = (
+        select(
+            VoyageTerminalLog.run_id.label("run_id"),
+            sa_func.max(VoyageTerminalLog.at).label("last_at"),
+        )
+        .group_by(VoyageTerminalLog.run_id)
+        .subquery()
+    )
+    async with get_sessionmaker()() as session:
+        ids = (
+            (
+                await session.execute(
+                    select(VoyageRun.id)
+                    .outerjoin(last_log, last_log.c.run_id == VoyageRun.id)
+                    .where(
+                        VoyageRun.status.in_(tuple(IN_FLIGHT_STATUSES)),
+                        or_(
+                            last_log.c.last_at < cutoff,
+                            (last_log.c.last_at.is_(None)) & (VoyageRun.created_at < cutoff),
+                        ),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    if not ids:
+        return
+    logger.warning("reclaiming %d stale in-flight voyage(s): %s", len(ids), ids)
+    now = time.time()
+    for vid in ids:
+        await ctx["redis"].enqueue_job(
+            "resume_voyage", str(vid), _job_id=_reconcile_job_id(vid, now)
+        )
 
 
 async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
Closes #366

Second batch of generic harness fixes from live monitoring of the two production experiments.

## 1. Zombie voyage reclaim
- `reconcile-resume-{vid}` job ids are now time-bucketed (15-min window): arq keeps results for an hour and silently dedups any enqueue whose job id matches a queued/running/**retained-result** job, which is exactly how the post-restart reconcile got swallowed on production (voyage stuck in `verifying` for 45+ min).
- New `reconcile_stale_voyages` cron (every 10 min): resumes in-flight voyages whose latest terminal log (or creation, if no logs) is older than 30 minutes. Startup reconcile only covers worker restarts; this covers jobs lost mid-run (hung LLM call killed with the worker, arq exponential-delay retries). Conservative criterion — live long steps keep emitting logs; engine resume is idempotent and concurrent resumes already occur by design (arq retry + startup reconcile overlapped harmlessly on prod).

## 2. `failed` stays a human decision
`experiment.report` used to write `final_status = "failed"` whenever the last iteration run wasn't `succeeded` — locking the experiment into a terminal state while the voyage was still alive, which then blocked the `waiting_user` mirror and every later status update (observed on production: experiment displayed failed while the user's "continue" answer kept the voyage running). Now:
- report writes `done` only on success, otherwise leaves the status alone and logs why;
- when a voyage reaches `done` (criteria passed or the user accepted the current result), a still-non-terminal linked experiment is finalized to `done` via new `experiments_service.complete_by_voyage` hooked into the engine's status transition.

## 3. `llm.complete` semantics in the plan-edit prompt
The navigator created "clone the repository" as an `llm.complete` step. The prompt now states that `llm.complete` produces text only and `artifact.write` records a platform artifact — neither executes commands nor touches the execution environment; real work must go through domain action steps.

## Tests
- Reconcile: bucketed job id; stale reclaim picks quiet/stale-log voyages only (fresh, active, and paused runs untouched).
- `complete_by_voyage`: finalizes a non-terminal experiment, noop on terminal.
- Suites: experiments/reconcile/engine/ask/loop/api/scope/messages/gates all green (112 passed).