### PR TITLE
fix(frontend): show log-history loading state in terminal; gzip JSON at nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,6 +11,15 @@ server {
     listen 80;
     server_name _;
 
+    # JSON 响应压缩：历史日志接口（/voyages/{id}/logs）payload 可达数 MB 纯文本，
+    # 慢链路（外网转发）裸传要数秒，终端在此期间只显示对话消息像"没有 AI 输出"。
+    # gzip_types 不含 text/event-stream，SSE 不受影响（压缩会破坏其逐条 flush）。
+    gzip on;
+    gzip_types application/json;
+    gzip_min_length 4096;
+    gzip_comp_level 5;
+    gzip_proxied any;
+
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $api_upstream http://api:8000;
 

--- a/src/frontend/src/features/experiment/ConsoleTab.tsx
+++ b/src/frontend/src/features/experiment/ConsoleTab.tsx
@@ -179,9 +179,11 @@ export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
   const voyageActive = !!voyage && !VOYAGE_TERMINAL.has(voyage.status);
 
   const { messages, handleExtraEvent } = useVoyageMessages(vid);
-  const { terminal, live, clearTerminal } = useVoyageChannel(vid, voyageActive, {
-    onExtraEvent: handleExtraEvent,
-  });
+  const { terminal, live, clearTerminal, historyLoading, historyError } = useVoyageChannel(
+    vid,
+    voyageActive,
+    { onExtraEvent: handleExtraEvent },
+  );
 
   const openAsk = openAskOf(voyage, messages);
 
@@ -335,6 +337,8 @@ export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
             onClear={clearTerminal}
             height={420}
             extraEntries={extraEntries}
+            historyLoading={historyLoading}
+            historyError={historyError}
             filter={chatOnly ? () => false : undefined}
             headerExtras={
               <>

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -153,9 +153,11 @@ export function VoyageDetailPage() {
 
   // 对话流（用户建议 / AI 提问）+ 终端 SSE 实时通道
   const { messages, handleExtraEvent } = useVoyageMessages(id);
-  const { terminal, live, clearTerminal } = useVoyageChannel(id, active, {
-    onExtraEvent: handleExtraEvent,
-  });
+  const { terminal, live, clearTerminal, historyLoading, historyError } = useVoyageChannel(
+    id,
+    active,
+    { onExtraEvent: handleExtraEvent },
+  );
   const openAsk = openAskOf(voyage, messages);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const extraEntries = useMemo<TerminalExtraEntry[]>(() => {
@@ -356,6 +358,8 @@ export function VoyageDetailPage() {
         live={live}
         onClear={clearTerminal}
         extraEntries={extraEntries}
+        historyLoading={historyLoading}
+        historyError={historyError}
         footer={
           <ConsoleComposer
             voyageId={id}

--- a/src/frontend/src/features/voyages/shared/terminal.tsx
+++ b/src/frontend/src/features/voyages/shared/terminal.tsx
@@ -235,6 +235,8 @@ export function TaskTerminal({
   footer,
   headerExtras,
   filter,
+  historyLoading,
+  historyError,
 }: {
   state: TerminalState;
   live: boolean;
@@ -249,6 +251,10 @@ export function TaskTerminal({
   headerExtras?: ReactNode;
   /** 条目过滤（只作用于日志/LLM 条目，不影响 extraEntries） */
   filter?: (entry: TerminalEntry) => boolean;
+  /** 历史日志仍在加载（数 MB 的慢请求期间显示占位，避免被当成"没有输出"） */
+  historyLoading?: boolean;
+  /** 历史日志加载失败（重试用尽）：提示只剩实时输出 */
+  historyError?: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const followRef = useRef(true);
@@ -356,11 +362,26 @@ export function TaskTerminal({
             color: 'var(--terminal-fg)',
           }}
         >
+          {historyLoading && (
+            <div style={{ color: 'var(--terminal-dim)', padding: '2px 2px 6px' }}>
+              {tr('正在加载历史日志…', 'Loading log history…')}
+            </div>
+          )}
+          {historyError && (
+            <div style={{ color: 'var(--terminal-dim)', padding: '2px 2px 6px' }}>
+              {tr(
+                '历史日志加载失败，下面只显示实时输出（刷新页面可重试）',
+                'Failed to load log history — showing live output only (refresh to retry)',
+              )}
+            </div>
+          )}
           {empty ? (
             <div style={{ color: 'var(--terminal-dim)', padding: '8px 2px' }}>
-              {live
-                ? tr('等待任务输出…', 'Waiting for task output…')
-                : tr('暂无运行日志', 'No terminal output yet')}
+              {historyLoading
+                ? null
+                : live
+                  ? tr('等待任务输出…', 'Waiting for task output…')
+                  : tr('暂无运行日志', 'No terminal output yet')}
             </div>
           ) : (
             <>

--- a/src/frontend/src/features/voyages/shared/useVoyageChannel.ts
+++ b/src/frontend/src/features/voyages/shared/useVoyageChannel.ts
@@ -30,7 +30,13 @@ export function useVoyageChannel(
   voyageId: string | null,
   active: boolean,
   opts?: { onExtraEvent?: (event: string, data: unknown) => void },
-): { terminal: TerminalState; live: boolean; clearTerminal: () => void } {
+): {
+  terminal: TerminalState;
+  live: boolean;
+  clearTerminal: () => void;
+  historyLoading: boolean;
+  historyError: boolean;
+} {
   const id = voyageId ?? '';
   const queryClient = useQueryClient();
   const [live, setLive] = useState(false);
@@ -66,13 +72,19 @@ export function useVoyageChannel(
 
   // —— 历史日志回放：刷新后 / 打开已结束任务时，从后端拉持久化日志回填终端 ——
   const showHistory = useTaskLogHistory();
-  const { data: logHistory } = useQuery({
+  const {
+    data: logHistory,
+    isLoading: historyLoading,
+    isError: historyError,
+  } = useQuery({
     queryKey: ['voyage-logs', id],
     queryFn: () => api.getVoyageLogs(id),
     enabled: !!id && showHistory,
     staleTime: Infinity, // 历史只在挂载 / 切任务时拉一次，实时增量走 SSE
     refetchOnWindowFocus: false,
-    retry: false,
+    // 历史日志可达数 MB，慢链路/瞬断下一次失败就永远空白（终端只剩对话消息，
+    // 像"没有 AI 输出"）——重试两次，加载与失败状态透出给终端显示占位
+    retry: 2,
   });
   const historyLoadedRef = useRef<string | null>(null);
   useEffect(() => {
@@ -181,5 +193,11 @@ export function useVoyageChannel(
     };
   }, [id, active, queryClient, scheduleTermFlush]);
 
-  return { terminal, live, clearTerminal };
+  return {
+    terminal,
+    live,
+    clearTerminal,
+    historyLoading: !!id && showHistory && historyLoading,
+    historyError: !!id && showHistory && historyError,
+  };
 }


### PR DESCRIPTION
Closes #368

The run-log terminal loads two sources: the tiny conversation query (instant) and the persisted log history, which can be multi-MB of uncompressed JSON (observed 1.5 MB for a ~200-row voyage; LLM outputs are stored up to 50K chars each). On slow links the terminal showed only conversation blocks with no hint that AI output was still loading — and with `retry: false` a single failed request silently dropped history for the whole session.

- `useVoyageChannel` exposes `historyLoading` / `historyError`; the history query now retries twice.
- `TaskTerminal` renders a dim "Loading log history…" placeholder while pending and a "showing live output only" notice on failure. Both call sites (experiment console, voyage detail) wired.
- nginx gzips `application/json` responses ≥4K (comp level 5, `gzip_proxied any`). `text/event-stream` is not in `gzip_types`, so SSE per-event flushing is untouched.

Verified: `tsc --noEmit` clean, `vite build` passes.