### PR TITLE
fix(voyage): retry streamed LLM calls on network errors, informative error text, no content actions in domain plan edits

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -40,7 +40,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
-from app.agents.voyage.errorsig import error_signature
+from app.agents.voyage.errorsig import error_signature, error_text
 from app.agents.voyage.runner import Runner, open_runner, parse_container_spec
 from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
@@ -741,7 +741,7 @@ def _guarded(func):
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            await _mark_attention(ctx, f"{type(e).__name__}: {e}")
+            await _mark_attention(ctx, error_text(e))
             raise
 
     return wrapper
@@ -1170,6 +1170,12 @@ _SIGNATURE_ASK_AT = 4
 _error_signature = error_signature
 
 
+
+def _err_tail_line(err_text: str) -> str:
+    """报错文本 → 给用户看的尾部关键行（原文，非归一化签名）。"""
+    lines = [ln.strip() for ln in (err_text or "").strip().splitlines() if ln.strip()]
+    return (lines[-1] if lines else "")[:200]
+
 def _render_fix_ledger(ledger: list[dict[str, Any]]) -> str:
     """修复台账 → prompt 注入段（空台账返回空串）。"""
     if not ledger:
@@ -1595,7 +1601,7 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                     if not (isinstance(e, TimeoutError) or ssh_exec.is_connection_error(e)):
                         raise
                     exit_status = -1
-                    err_text = f"{type(e).__name__}: {e}"
+                    err_text = error_text(e)
                     hint = (
                         "依赖安装超时或中断——大概率是依赖太重/编译太慢/下载太慢或连接断开。"
                         "请精简依赖、用更轻的包或预编译 wheel、去掉可选依赖，让安装更快更稳。"
@@ -1695,7 +1701,7 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                             "ask_kind": "fatal_step",
                             "question": (
                                 f"依赖安装反复失败在同一个错误上（连续 {sig_streak} 次）："
-                                f"{signature[:200]}。自动修复没有进展，怎么处理？"
+                                f"{_err_tail_line(err_text)}。自动修复没有进展，怎么处理？"
                             ),
                             "context": {
                                 "error_signature": signature,
@@ -1793,7 +1799,7 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                     if not (isinstance(e, TimeoutError) or ssh_exec.is_connection_error(e)):
                         raise
                     exit_status = -1
-                    err_text = f"{type(e).__name__}: {e}"
+                    err_text = error_text(e)
                     hint = (
                         "冒烟超时或中断——大概率是模型/数据太大、步数太多、装依赖太慢。请把冒烟规模"
                         "改到极小：更小样本/更少步数/更小或更省显存的配置/精简依赖/缩短生成长度，"
@@ -1874,7 +1880,7 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                             "ask_kind": "fatal_step",
                             "question": (
                                 f"代码试跑反复失败在同一个错误上（连续 {sig_streak} 次）："
-                                f"{signature[:200]}。自动修复没有进展，怎么处理？"
+                                f"{_err_tail_line(err_text)}。自动修复没有进展，怎么处理？"
                             ),
                             "context": {
                                 "error_signature": signature,

--- a/src/backend/app/agents/voyage/errorsig.py
+++ b/src/backend/app/agents/voyage/errorsig.py
@@ -9,6 +9,23 @@ from __future__ import annotations
 import re
 
 
+def error_text(e: BaseException) -> str:
+    """异常 → 人可读文本，空 str() 兜底。
+
+    httpx.ReadTimeout 等异常的 str() 是空串，直接拼 f"{type}: {e}" 会产出
+    「ReadTimeout: 」——用户被提问"怎么处理？"却拿到零信息（线上实测，用户只能
+    回"详细原因"）。空时依次回退：cause 链 → 异常全名标注。"""
+    name = type(e).__name__
+    detail = str(e).strip()
+    if not detail and e.__cause__ is not None:
+        cause = e.__cause__
+        cause_str = str(cause).strip()
+        detail = f"{type(cause).__name__}: {cause_str}" if cause_str else type(cause).__name__
+    if detail:
+        return f"{name}: {detail}"
+    return f"{name}（{type(e).__module__}.{name}，异常未附带详细信息）"
+
+
 def error_signature(err_text: str) -> str:
     """报错文本 → 规范化签名（数字/十六进制/路径抹平，取 traceback 尾部关键行）。"""
     lines = [ln.strip() for ln in (err_text or "").strip().splitlines() if ln.strip()]

--- a/src/backend/app/agents/voyage/helm.py
+++ b/src/backend/app/agents/voyage/helm.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from app.agents.voyage.actions import ActionContext, get_action
+from app.agents.voyage.errorsig import error_text
 
 
 class Helm:
@@ -17,4 +18,4 @@ class Helm:
         try:
             return await action(ctx, step_def.get("params") or {})
         except Exception as e:  # noqa: BLE001 —— 步骤失败要落 observation 而非炸掉状态机
-            return {"error": f"{type(e).__name__}: {e}"}
+            return {"error": error_text(e)}

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -637,8 +637,11 @@ def _expand_workflow(slug: str, workflows: list[dict[str, Any]]) -> list[dict[st
     return validate_steps({"steps": entry.get("steps") or []})
 
 
-# 计划调整时不分领域都可用的通用动作（推理/等待类，无副作用域）
+# 纯通用计划（无领域前缀）调整时可用的通用动作
 _GENERIC_EDIT_ACTIONS = frozenset({"sleep", "llm.complete", "artifact.write"})
+# 领域计划（experiment.* 等）调整时唯一放行的通用动作：无副作用、不产出"看似完成"
+# 的内容。llm.complete/artifact.write 见 allowed_edit_actions 内注释。
+_DOMAIN_SAFE_GENERIC_ACTIONS = frozenset({"sleep"})
 
 
 def allowed_edit_actions(run: VoyageRun) -> frozenset[str]:
@@ -660,7 +663,11 @@ def allowed_edit_actions(run: VoyageRun) -> frozenset[str]:
     if not prefixes:
         return registry
     allowed = {a for a in registry if any(a.startswith(p) for p in prefixes)}
-    allowed |= _GENERIC_EDIT_ACTIONS & registry
+    # 领域计划只放行无副作用的通用动作（sleep）。内容型通用动作（llm.complete /
+    # artifact.write）曾被 Navigator 拿来"修远端文件"/"顶替分析步骤"——既执行不了
+    # 任何东西，还把完成标准（依赖领域动作产出的 iterate 指标）永久堵死；prompt 里
+    # 写明语义拦不住（#363 上线后线上仍复发），改为结构性禁止。
+    allowed |= _DOMAIN_SAFE_GENERIC_ACTIONS & registry
     return frozenset(allowed)
 
 

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -7,6 +7,7 @@
   另带 library_id 记到方向库账上（P6 库级月度预算的依据）。
 """
 
+import asyncio
 import logging
 import time
 import uuid
@@ -126,6 +127,8 @@ STREAM_STAGES = frozenset(
     {"navigator", "debate", "experiment", "writing", "proposal", "review", "librarian"}
 )
 _STREAM_FLUSH_CHARS = 80  # token 增量攒到此长度再广播一段（节流，防刷爆 pub/sub）
+_STREAM_RETRY_ATTEMPTS = 3  # 流式请求网络瞬断整段重试次数
+_STREAM_RETRY_BASE_SECONDS = 2.0
 
 # 一次调用能等多久、重试几次，按环节分两档——两者的合理耐心程度差一个数量级。
 #
@@ -515,41 +518,72 @@ class LLMRouter:
         节流见 _STREAM_FLUSH_CHARS：攒够长度再发一段，避免每 token 刷爆 pub/sub；始终
         返回完整 content，对调用方与 complete() 等价（流式 provider 拿不到精确 usage，
         由 _ensure_usage 估算）。
+
+        网络瞬断重试：非流式路径的 _post_with_retry 会自动重试 TransportError，流式
+        路径以前没有——LLM 网关一次 ReadTimeout 就把整个任务步骤打失败（线上实测，
+        冒烟/分析步接连因此转向用户提问）。这里整段重来：每次重试重新广播 llm_start
+        （前端会另起一个输出块），退避后拉新流，收齐才算成功。
         """
+        import httpx
+
+        stream_extra: dict[str, Any] = {"effort": effort} if effort is not None else {}
         collected: list[str] = []
-        buf: list[str] = []
-        buf_len = 0
-        seq = 0
+        last_exc: Exception | None = None
+        for attempt in range(_STREAM_RETRY_ATTEMPTS):
+            collected = []
+            buf: list[str] = []
+            buf_len = 0
+            seq = 0
 
-        async def flush() -> None:
-            nonlocal buf, buf_len, seq
-            if not buf:
-                return
-            await self.event_bus.publish_voyage_event(
-                voyage_id, "llm_delta", {"stage": stage, "delta": "".join(buf), "seq": seq}
-            )
-            seq += 1
-            buf, buf_len = [], 0
+            async def flush() -> None:
+                nonlocal buf, buf_len, seq
+                if not buf:
+                    return
+                await self.event_bus.publish_voyage_event(
+                    voyage_id, "llm_delta", {"stage": stage, "delta": "".join(buf), "seq": seq}
+                )
+                seq += 1
+                buf, buf_len = [], 0
 
-        await self.event_bus.publish_voyage_event(voyage_id, "llm_start", {"stage": stage})
-        try:
-            stream_extra: dict[str, Any] = {"effort": effort} if effort is not None else {}
-            async for chunk in provider.stream(
-                messages,
-                model=route.model,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                images=images,
-                **stream_extra,
-            ):
-                collected.append(chunk)
-                buf.append(chunk)
-                buf_len += len(chunk)
-                if buf_len >= _STREAM_FLUSH_CHARS:
-                    await flush()
-            await flush()
-        finally:
+            await self.event_bus.publish_voyage_event(voyage_id, "llm_start", {"stage": stage})
+            try:
+                async for chunk in provider.stream(
+                    messages,
+                    model=route.model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    images=images,
+                    **stream_extra,
+                ):
+                    collected.append(chunk)
+                    buf.append(chunk)
+                    buf_len += len(chunk)
+                    if buf_len >= _STREAM_FLUSH_CHARS:
+                        await flush()
+                await flush()
+            except (httpx.TransportError, httpx.TimeoutException) as e:
+                await self.event_bus.publish_voyage_event(voyage_id, "llm_end", {"stage": stage})
+                last_exc = e
+                if attempt >= _STREAM_RETRY_ATTEMPTS - 1:
+                    raise
+                delay = _STREAM_RETRY_BASE_SECONDS * (2**attempt)
+                logger.warning(
+                    "LLM 流式请求网络错误（%s），%.0fs 后整段重试（%d/%d）",
+                    type(e).__name__,
+                    delay,
+                    attempt + 1,
+                    _STREAM_RETRY_ATTEMPTS,
+                )
+                await asyncio.sleep(delay)
+                continue
+            except BaseException:
+                await self.event_bus.publish_voyage_event(voyage_id, "llm_end", {"stage": stage})
+                raise
             await self.event_bus.publish_voyage_event(voyage_id, "llm_end", {"stage": stage})
+            last_exc = None
+            break
+        if last_exc is not None:  # 理论上到不了（最后一次失败已 raise），防御性兜底
+            raise last_exc
         full_text = "".join(collected)
         # 大模型完整输出落库，供刷新后 / 事后回放（实时增量已通过 llm_delta 走 SSE）。
         if full_text:

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1216,9 +1216,10 @@ async def test_path_violation_rejected(client, queue_stub, fake_ssh, bus_recorde
     resp = await client.get(f"/api/voyages/{voyage_id}?include_obsolete=true", headers=headers)
     voyage = resp.json()
     assert voyage["status"] == "paused_ask"
-    # fake navigator 的替代步骤能通过，最终停在完成标准终检的提问上
-    # （真实场景会在更早的调整超限处停下，同样是 paused_ask）
-    assert voyage["open_ask"]["payload"]["ask_kind"] == "done_criteria"
+    # fake navigator 的替代步骤是 llm.complete——领域计划禁用内容型通用动作（#373）
+    # 后编辑被校验拒绝，转 replan_error 提问等用户指示（同样是 paused_ask 停住，
+    # 越界文件依然一个都没落盘）
+    assert voyage["open_ask"]["payload"]["ask_kind"] == "replan_error"
     setup_step = next(s for s in voyage["steps"] if s["action"] == "experiment.setup")
     assert "越界" in setup_step["observation"]["error"]
     assert setup_step["attempt"] == 2  # 执行类错误带诊断原地重试过一次

--- a/src/backend/tests/test_voyage_loop.py
+++ b/src/backend/tests/test_voyage_loop.py
@@ -151,7 +151,11 @@ def test_plan_edit_actions_scoped_to_run_domain():
     assert any(a.startswith("experiment.") for a in allowed)
     assert not any(a.startswith("wiki.") for a in allowed)
     assert not any(a.startswith("daily.") for a in allowed)
-    assert "sleep" in allowed  # 通用动作不分领域
+    assert "sleep" in allowed  # 无副作用的通用动作不分领域
+    # 内容型通用动作对领域计划禁用（#373）：navigator 曾拿它们"修远端文件"/
+    # "顶替分析步骤"，产出看似完成实则堵死完成标准
+    assert "llm.complete" not in allowed
+    assert "artifact.write" not in allowed
 
     # 校验器按动作域拒绝越域步骤
     step = {
@@ -581,3 +585,62 @@ async def test_llm_multimodal_stage_also_streams(app):
     assert kinds[0] == "llm_start" and kinds[-1] == "llm_end"
     deltas = [d["delta"] for _v, e, d in bus.voyage_events if e == "llm_delta"]
     assert deltas and "".join(deltas) == result.content
+
+
+async def test_llm_stream_retries_transient_network_error(app):
+    """流式路径网络瞬断（ReadTimeout/ConnectError）整段重试而不是打失败步骤（#373）：
+    重试会重新广播 llm_start（前端另起输出块），最终 content 完整。"""
+    import httpx
+
+    from app.core.llm.base import Message
+    from app.core.llm.fake import FakeProvider
+    from app.core.llm.router import LLMRouter
+
+    class _FlakyProvider(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def stream(self, messages, *, model, temperature=0.7, max_tokens=None, **kw):
+            self.calls += 1
+            if self.calls == 1:
+                raise httpx.ReadTimeout("")  # str() 为空的典型网络异常
+            async for chunk in super().stream(
+                messages, model=model, temperature=temperature, max_tokens=max_tokens
+            ):
+                yield chunk
+
+    bus = RecordingBus()
+    provider = _FlakyProvider()
+    router = LLMRouter()
+    router.event_bus = bus
+    router.override_provider(provider)
+    vid = uuid.uuid4()
+
+    result = await router.complete(
+        "navigator", [Message(role="user", content="规划")], voyage_id=vid
+    )
+    assert provider.calls == 2  # 第一次超时，第二次成功
+    assert result.content
+    kinds = [e for _v, e, _d in bus.voyage_events]
+    assert kinds.count("llm_start") == 2 and kinds.count("llm_end") == 2
+
+
+def test_error_text_never_empty():
+    """异常文本兜底（#373）：httpx.ReadTimeout 的 str() 是空串，不能把
+    「ReadTimeout: 」这种零信息文本放进给用户的提问里。"""
+    import httpx
+
+    from app.agents.voyage.errorsig import error_text
+
+    assert error_text(ValueError("boom")) == "ValueError: boom"
+    empty = error_text(httpx.ReadTimeout(""))
+    assert empty.startswith("ReadTimeout") and len(empty) > len("ReadTimeout: ")
+    # cause 链回退
+    try:
+        try:
+            raise ConnectionError("connection refused")
+        except ConnectionError as ce:
+            raise RuntimeError("") from ce
+    except RuntimeError as e:
+        assert "connection refused" in error_text(e)

--- a/src/frontend/src/features/forge/IdeaDetailPage.tsx
+++ b/src/frontend/src/features/forge/IdeaDetailPage.tsx
@@ -42,11 +42,26 @@ function GoalField({ label, children }: { label: string; children: ReactNode }) 
   );
 }
 
+/** goal JSON 由 LLM/脚本产出，列表字段可能被写成单个字符串（线上实测
+ *  resources_needed.data 是字符串，`.join` 直接把整页炸成错误屏）——统一容错。 */
+function asList(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => (typeof x === 'string' ? x : JSON.stringify(x)));
+  if (typeof v === 'string' && v.trim()) return [v];
+  return [];
+}
+
 function GoalCard({ goal }: { goal: IdeaGoal }) {
   const [showSmoke, setShowSmoke] = useState(false);
   const res = goal.resources_needed;
-  const inScope = goal.scope?.in_scope ?? [];
-  const outScope = goal.scope?.out_of_scope ?? [];
+  // scope 本身也可能是字符串（此时没有 in/out 子列表）
+  const scopeObj = goal.scope && typeof goal.scope === 'object' ? goal.scope : undefined;
+  const scopeText = typeof goal.scope === 'string' ? goal.scope : null;
+  const inScope = asList(scopeObj?.in_scope);
+  const outScope = asList(scopeObj?.out_of_scope);
+  const objectives = asList(goal.objectives);
+  const successCriteria = asList(goal.success_criteria);
+  const keyConcepts = asList(goal.key_concepts);
+  const resData = asList(res?.data);
   return (
     <div className="card card-pad">
       <div className="row gap8" style={{ marginBottom: 14 }}>
@@ -64,15 +79,16 @@ function GoalCard({ goal }: { goal: IdeaGoal }) {
           <b>{goal.question}</b>
         </GoalField>
       )}
-      {(goal.objectives?.length ?? 0) > 0 && (
+      {objectives.length > 0 && (
         <GoalField label={tr('研究目标', 'Objectives')}>
           <ol style={{ margin: 0, paddingLeft: 18 }}>
-            {goal.objectives!.map((o, i) => (
+            {objectives.map((o, i) => (
               <li key={i} style={{ marginBottom: 3 }}>{o}</li>
             ))}
           </ol>
         </GoalField>
       )}
+      {scopeText && <GoalField label={tr('研究范围', 'Scope')}>{scopeText}</GoalField>}
       {(inScope.length > 0 || outScope.length > 0) && (
         <GoalField label={tr('研究范围', 'Scope')}>
           <div className="row gap12 wrap" style={{ alignItems: 'flex-start' }}>
@@ -99,19 +115,19 @@ function GoalCard({ goal }: { goal: IdeaGoal }) {
           </div>
         </GoalField>
       )}
-      {(goal.success_criteria?.length ?? 0) > 0 && (
+      {successCriteria.length > 0 && (
         <GoalField label={tr('成功标准', 'Success criteria')}>
           <ul style={{ margin: 0, paddingLeft: 18 }}>
-            {goal.success_criteria!.map((c, i) => (
+            {successCriteria.map((c, i) => (
               <li key={i} style={{ marginBottom: 3 }}>{c}</li>
             ))}
           </ul>
         </GoalField>
       )}
-      {(goal.key_concepts?.length ?? 0) > 0 && (
+      {keyConcepts.length > 0 && (
         <GoalField label={tr('关键概念', 'Key concepts')}>
           <div className="row gap6 wrap">
-            {goal.key_concepts!.map((c, i) => (
+            {keyConcepts.map((c, i) => (
               <span key={i} className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
                 {c}
               </span>
@@ -128,10 +144,10 @@ function GoalCard({ goal }: { goal: IdeaGoal }) {
                 <span>{tr('算力：', 'Compute: ')}{res.compute}</span>
               </div>
             )}
-            {(res.data?.length ?? 0) > 0 && (
+            {resData.length > 0 && (
               <div className="row gap6" style={{ alignItems: 'flex-start' }}>
                 <Icon name="grid" size={13} style={{ color: 'var(--text-3)', flexShrink: 0, marginTop: 3 }} />
-                <span>{tr('数据：', 'Data: ')}{res.data!.join(tr('、', ', '))}</span>
+                <span>{tr('数据：', 'Data: ')}{resData.join(tr('、', ', '))}</span>
               </div>
             )}
             {res.time_weeks != null && (
@@ -175,7 +191,7 @@ const EVIDENCE_SOURCE_META: Record<IdeaEvidenceSource, { zh: string; en: string;
 
 function EvidenceCard({ idea }: { idea: IdeaDetail }) {
   const navigate = useNavigate();
-  const evidence = idea.evidence ?? [];
+  const evidence = Array.isArray(idea.evidence) ? idea.evidence : [];
   if (evidence.length === 0) return null;
   return (
     <div className="card card-pad">


### PR DESCRIPTION
Closes #373

Driven by the trajectory of experiment 73927b01 (smoke/analyze steps killed by transient gateway timeouts, zero-information asks, navigator faking analysis with content steps until the user had to accept a metricless finish).

## 1. Streamed LLM calls retry transient network errors
`_stream_and_broadcast` (used for all voyage-stage LLM calls) now retries `httpx.TransportError`/`TimeoutException` up to 3 attempts with exponential backoff, mirroring what `_post_with_retry` already did for the non-streaming path. Each retry restarts the stream and re-broadcasts `llm_start`, so the terminal cleanly starts a new output block; content is returned only from a fully collected stream.

## 2. `error_text()` — no more empty error messages
`str(e)` is empty for `httpx.ReadTimeout` and friends, which produced observations and asks reading `ReadTimeout: `. New shared helper falls back to the exception cause chain, then the qualified class name. Wired into helm's observation error and the experiment fix loops.

## 3. Content actions structurally banned from domain plan edits
Prompt-level guidance (#363) was demonstrably insufficient — with it live in production the navigator still replaced `experiment.analyze` with `artifact.write`/`llm.complete` steps that pass while producing nothing, permanently dead-ending done-criteria. `allowed_edit_actions` now grants only `sleep` as the generic action for plans with domain prefixes; pure-generic plans keep the full registry.

## 4. Zero-progress asks show the raw error line
The dedup signature normalizes digits (users saw ``model type `qwenN` ``); questions now carry the raw error tail, the signature stays in ask context.

## Tests
- Stream retry: flaky provider (ReadTimeout then success) → 2 provider calls, 2 llm_start/llm_end pairs, full content.
- `error_text`: plain, empty-str, and cause-chain cases.
- Action scoping: experiment plans exclude `llm.complete`/`artifact.write`, keep `sleep` + `experiment.*`; generic plans unrestricted; path-violation test updated (edit now rejected → `replan_error` ask, still `paused_ask`, still no file written).
- Suites: loop/experiments/router/engine/ask/scope 118 passed.