### PR TITLE
fix(experiment): reinstall deps when fix loops change requirements; degrade update_node on passed steps to a re-run clone

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -1939,6 +1939,20 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 files = new_files
                 ctx.checkpoint["exp_files"] = files
                 await executor.write_files(files)
+                if "requirements.txt" in changed:
+                    # 依赖清单变了必须重装，否则修复根本不落地——线上实测：修复循环
+                    # 连续三轮都正确地在 requirements.txt 里升级 transformers，但依赖
+                    # 只在 setup 步装过一次，环境纹丝不动、同签名三连触发零进展提问。
+                    # 模型做对了，平台把它的修复扔了。安装失败不在这里打断：下一轮
+                    # 试跑的 stderr 会带出真实症状，交回修复循环。
+                    await ctx.log("requirements.txt 有变更，重装依赖后再试跑")
+                    with contextlib.suppress(Exception):
+                        dep = await executor.setup_venv()
+                        if dep.exit_status != 0:
+                            await ctx.log(
+                                f"依赖重装未成功（exit={dep.exit_status}），试跑将带错重修",
+                                level="warn",
+                            )
         finally:
             await executor.close()
 
@@ -2364,12 +2378,24 @@ async def experiment_analyze(ctx: ActionContext, params: dict[str, Any]) -> dict
                     "（例如：不同的算法/建模方式/训练目标或损失/数据处理/检索或提示策略等），"
                     "先用一句话说明为什么之前那条路已经到顶、你这次新方向的依据，再给完整文件集合。"
                 )
+        prev_files = ctx.checkpoint.get("exp_files") or {}
         files = await _complete_json(
             ctx, system=system_prompt, user=fix_user, validate=validate_files
         )
         executor = await _open_executor(session, ctx, experiment)
         try:
             await executor.write_files(files)
+            if files.get("requirements.txt") != prev_files.get("requirements.txt"):
+                # 与冒烟修复循环同理：requirements 变更必须真正重装（增量 pip），
+                # 否则下一轮 run 还在旧依赖上跑
+                await ctx.log("requirements.txt 有变更，重装依赖供下一轮使用")
+                with contextlib.suppress(Exception):
+                    dep = await executor.setup_venv()
+                    if dep.exit_status != 0:
+                        await ctx.log(
+                            f"依赖重装未成功（exit={dep.exit_status}），下一轮将带错重修",
+                            level="warn",
+                        )
             await _sync_memory_file(ctx, executor)
         finally:
             await executor.close()

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -1290,8 +1290,35 @@ class VoyageEngine:
                     added += 1
             elif op["op"] == "update_node":
                 row = by_id.get(str(op["step_id"]))
-                if row is None or row.status == "passed":
-                    raise PlanEditError(f"update_node 只能修改未完成步骤：{op['step_id']}")
+                if row is None:
+                    raise PlanEditError(f"update_node 引用不存在的步骤：{op['step_id']}")
+                if row.status == "passed":
+                    # 「修改已通过的步骤」的真实语义 = 带新参数重跑：自动降级为
+                    # 克隆新增（线上实测 navigator 把"重新执行建环境"表达成
+                    # update_node 已通过的 setup 节点，一律拒绝只会逼它绕路或放弃）。
+                    patch = op["patch"]
+                    clone_def = {
+                        "title": str(patch.get("title") or f"重跑：{row.title}")[:255],
+                        "action": row.action,
+                        "params": dict(row.params or {}) | dict(patch.get("params") or {}),
+                        "acceptance": patch.get("acceptance")
+                        or (row.acceptance or {}).get("text"),
+                        "checks": patch.get("checks") or (row.acceptance or {}).get("checks"),
+                        "requires_gate": None,  # 重跑不再重复人工审批
+                        "on_failure": (row.provenance or {}).get("on_failure"),
+                        "budget": row.budget,
+                    }
+                    base = anchor.rank if anchor is not None else max_passed_rank
+                    following = min((r.rank for r in rows if r.rank > base), default=None)
+                    gap = (following - base) / 2 if following is not None else _RANK_GAP
+                    session.add(
+                        self._new_step_row(
+                            run, seq=next_seq, rank=base + gap, step_def=clone_def
+                        )
+                    )
+                    next_seq += 1
+                    added += 1
+                    continue
                 patch = op["patch"]
                 if "params" in patch:
                     row.params = dict(row.params or {}) | dict(patch["params"])

--- a/src/backend/app/agents/voyage/errorsig.py
+++ b/src/backend/app/agents/voyage/errorsig.py
@@ -20,7 +20,11 @@ def error_text(e: BaseException) -> str:
     if not detail and e.__cause__ is not None:
         cause = e.__cause__
         cause_str = str(cause).strip()
-        detail = f"{type(cause).__name__}: {cause_str}" if cause_str else type(cause).__name__
+        if cause_str:
+            detail = f"{type(cause).__name__}: {cause_str}"
+        elif type(cause).__name__ != name:
+            # 同名空 cause 不重复自己（曾产出「ReadTimeout: ReadTimeout」）
+            detail = type(cause).__name__
     if detail:
         return f"{name}: {detail}"
     return f"{name}（{type(e).__module__}.{name}，异常未附带详细信息）"

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -574,6 +574,16 @@ class LLMRouter:
                     attempt + 1,
                     _STREAM_RETRY_ATTEMPTS,
                 )
+                # 终端可见（线上实测：重试只在 worker 日志里，用户盯着终端静默十几分钟）
+                await self.event_bus.publish_voyage_event(
+                    voyage_id,
+                    "log",
+                    {
+                        "message": f"大模型网络请求中断（{type(e).__name__}），"
+                        f"{delay:.0f} 秒后自动重试（{attempt + 1}/{_STREAM_RETRY_ATTEMPTS}）",
+                        "level": "info",
+                    },
+                )
                 await asyncio.sleep(delay)
                 continue
             except BaseException:

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1550,3 +1550,59 @@ async def test_complete_by_voyage_finalizes_nonterminal(client, queue_stub, fake
         assert out is not None and out.status == "done"
         # 已终态：noop（failed/cancelled 同理，不会被覆盖）
         assert await experiments_service.complete_by_voyage(session, uuid.UUID(voyage_id)) is None
+
+
+async def test_smoke_fix_reinstalls_deps_when_requirements_change(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """修复改了 requirements.txt 必须重装依赖（#377）：线上实测修复循环三轮都正确
+    升级 transformers，但依赖只在 setup 装过一次，修复从未落地、同签名死循环。"""
+    fake_ssh.smoke_exits = [1, 0]
+    fake_ssh.smoke_stderr = "ImportError: transformers too old"
+
+    class _ReqBumpProvider(FakeProvider):
+        def __init__(self) -> None:
+            self.bump = 0
+
+        async def complete(self, messages, *, model, temperature=0.7, max_tokens=None, images=None):
+            full = "\n".join(m.content for m in messages)
+            if "冒烟测试退出码" in full:
+                self.bump += 1
+                files = {
+                    "requirements.txt": f"transformers==5.{self.bump}",
+                    "run.sh": "bash --smoke",
+                    "train.py": "print('ok')",
+                }
+                return CompletionResult(
+                    content=json.dumps({"files": files}),
+                    model=model,
+                    finish_reason="stop",
+                    usage={"prompt_tokens": 1, "completion_tokens": 1},
+                )
+            return await super().complete(
+                messages, model=model, temperature=temperature, max_tokens=max_tokens,
+                images=images,
+            )
+
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    voyage_id = resp.json()["voyage_id"]
+
+    router = LLMRouter()
+    router.override_provider(_ReqBumpProvider())
+    engine, _ = _make_engine(router)
+    await engine.run(uuid.UUID(voyage_id))
+    await _approve_gate(client, headers, project_id)
+    await engine.resume(uuid.UUID(voyage_id))
+
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "done", resp.json()["status"]
+    # 前台依赖重装（setup_venv：含 -r requirements.txt 且非后台 setup.log 版）出现两次：
+    # ①冒烟修复改了 requirements.txt 后；②第 1 轮 improve 的新文件把 requirements 又改回
+    # 默认内容后（analyze 路径同样受保护）。第 2 轮 improve 文件不变 → 不再重装。
+    reinstalls = [
+        c for c in fake_ssh.commands if "-r requirements.txt" in c and "setup.log" not in c
+    ]
+    assert len(reinstalls) == 2, fake_ssh.commands

--- a/src/backend/tests/test_voyage_loop.py
+++ b/src/backend/tests/test_voyage_loop.py
@@ -644,3 +644,58 @@ def test_error_text_never_empty():
             raise RuntimeError("") from ce
     except RuntimeError as e:
         assert "connection refused" in error_text(e)
+
+
+async def test_update_passed_step_degrades_to_clone(client, queue_stub):
+    """update_node 指向已通过步骤 = 「带新参数重跑」：自动降级为克隆新增，
+    不再一律拒绝（线上实测 navigator 把"重新执行建环境"表达成改已通过的 setup）。"""
+    from tests.conftest import register_and_login
+
+    token = await register_and_login(client, "clone-degrade@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "cd-proj"}, headers=headers)
+    project_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            project_id=project_id, kind="demo", mode="loop", goal="t", status="executing"
+        )
+        session.add(run)
+        await session.flush()
+        passed = VoyageStep(
+            run_id=run.id, seq=0, rank=0.0, title="建环境", action="sleep",
+            params={"seconds": 0}, acceptance={"text": "ok"}, status="passed",
+        )
+        failed = VoyageStep(
+            run_id=run.id, seq=1, rank=100.0, title="后续", action="sleep",
+            params={"seconds": 0}, acceptance={"text": "ok"}, status="failed",
+        )
+        session.add_all([passed, failed])
+        await session.commit()
+        passed_id, failed_id, run_id = str(passed.id), str(failed.id), run.id
+
+    engine = VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        anchor = await session.get(VoyageStep, uuid.UUID(failed_id))
+        edit = {
+            "reason": "重跑建环境",
+            "finish": False,
+            "edits": [
+                {"op": "update_node", "step_id": passed_id,
+                 "patch": {"params": {"seconds": 1}, "title": "重装依赖"}}
+            ],
+        }
+        added = await engine._apply_plan_edit(session, run, edit, anchor=anchor)
+        await session.commit()
+        assert added == 1
+        steps = (
+            (await session.execute(
+                select(VoyageStep).where(VoyageStep.run_id == run_id).order_by(VoyageStep.rank)
+            )).scalars().all()
+        )
+        # 原已通过节点原封不动；新克隆节点携带 patch 参数、pending 待跑
+        assert steps[0].id == uuid.UUID(passed_id) and steps[0].status == "passed"
+        clone = next(s for s in steps if s.title == "重装依赖")
+        assert clone.status == "pending" and clone.action == "sleep"
+        assert clone.params == {"seconds": 1}


### PR DESCRIPTION
Closes #379

Driven by the live interactive harness test (experiment 902c66f2). Full narrative in the issue; summary:

## 1. Fix-loop requirements changes now actually install
`experiment.smoke`'s fix loop and the analyze improve/debug path call `setup_venv()` (bare metal: venv pip; container: incremental `pip install -r requirements.txt`) whenever a fix changes `requirements.txt`. Install failures are logged to the terminal and surface through the next attempt's stderr instead of crashing the loop. Live case: the model upgraded `transformers` correctly three fix rounds in a row and the environment never changed — the zero-progress detector then escalated what was actually a platform bug.

## 2. `update_node` on a passed step = re-run with new params
`_apply_plan_edit` clones the passed step as a new pending node (patch merged into title/params/acceptance, `on_failure`/`budget` inherited, no repeated human gate) instead of raising `PlanEditError`. Pending/failed steps keep in-place update semantics; missing ids still reject.

## 3. Observability polish
- Each stream retry publishes a terminal log line (was worker-log only — users watched a silent terminal through minutes of backoff).
- `error_text` skips a same-named empty-message cause (`ReadTimeout: ReadTimeout` → qualified-name fallback).

## Tests
- Requirements-change reinstall: fix bumps requirements → exactly the expected foreground `pip install -r requirements.txt` invocations (smoke fix + first improve round), voyage completes.
- Clone-degrade: passed step untouched, clone pending with merged patch; existing invariant tests unchanged (missing id still rejects).
- Suites: experiments/loop/engine/ask/router — 101 passed.