### PR TITLE
fix(experiment): cancel a running experiment before trashing it

### DIFF
--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -255,6 +255,14 @@ async def trash_experiments(
     n = 0
     for exp in await _owned_experiments(session, project_id=project_id, ids=ids):
         if exp.trashed_at is None:
+            if exp.status not in EXPERIMENT_TERMINAL_STATUSES:
+                # 运行中的实验先取消（协作式停 voyage + 尽力 kill 远端进程）。
+                # 否则 voyage 成为孤儿：拿着已删实验的 id 反复失败重规划——线上实测
+                # purge 后 voyage 在「experiment not found」上烧了两轮计划调整才被人叫停。
+                try:
+                    await cancel_experiment(session, exp)
+                except Exception:  # noqa: BLE001 — 取消失败不能挡住回收本身
+                    logger.exception("cancel before trash failed: %s", exp.id)
             exp.trashed_at = now
             n += 1
     await session.commit()

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1606,3 +1606,33 @@ async def test_smoke_fix_reinstalls_deps_when_requirements_change(
         c for c in fake_ssh.commands if "-r requirements.txt" in c and "setup.log" not in c
     ]
     assert len(reinstalls) == 2, fake_ssh.commands
+
+
+async def test_trash_running_experiment_cancels_voyage(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """删除/移入回收站会先取消运行中的实验（#379 现场：purge 后孤儿 voyage
+    拿着已删实验的 id 反复重规划烧 LLM，直到有人手动叫停）。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
+    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(voyage_id))  # 跑到 compute_budget 闸门（voyage 在途）
+
+    resp = await client.delete(f"/api/experiments/{exp_id}", headers=headers)
+    assert resp.status_code == 204
+
+    async with get_sessionmaker()() as session:
+        voyage = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        assert voyage.status == "cancelled"
+        experiment = await session.get(Experiment, uuid.UUID(exp_id))
+        assert experiment.status == "cancelled" and experiment.trashed_at is not None
+
+    # 已终态的实验回收：不再走取消（幂等，不报错）
+    resp = await client.post(f"/api/experiments/{exp_id}/restore", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.delete(f"/api/experiments/{exp_id}", headers=headers)
+    assert resp.status_code == 204


### PR DESCRIPTION
Closes #381

Live case from the interactive harness test: the experiment was permanently deleted from the UI while its voyage was mid-flight; the orphan voyage kept failing every step with `ValueError: experiment not found` and burned two full replan cycles before a human cancelled it.

- `trash_experiments` cancels a non-terminal experiment before setting `trashed_at`: cooperative voyage cancel + running runs marked failed + best-effort remote process kill (same semantics as the cancel endpoint). The permanent-delete path trashes first, so it inherits the behavior.
- Cancel failures are logged and never block the trash operation.

Test: trash a running experiment → voyage `cancelled`, experiment `cancelled` + trashed; restore-then-trash of a terminal experiment stays idempotent. Suite: 41 passed.