### PR TITLE
Unset LLM stages follow Default, and a bad trend JSON no longer pauses the sync

### DIFF
--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -87,10 +87,17 @@ _CAPABILITY_STAGES = frozenset({"embedding", "rerank"})
 # rerank 不在此列：它是逐条打分，不涉及跨调用可比性，各用各的没有问题。
 GLOBAL_ONLY_STAGES = frozenset({"embedding"})
 
-# 新环节拆出来时的兼容回退：没显式配路由就沿用原来那个环节的，行为不变。
-# digest 原先是直接复用 librarian 的调用，拆开只是为了能单独设模型——
-# 存量部署不配也不该因此改变行为（default 路由指向的往往是另一类模型）。
-_STAGE_ROUTE_FALLBACKS = {"digest": "librarian", "agent": "reading"}
+# 没显式配路由的环节一律回退 default——设置页就是这么写的（「未单独设置的环节自动
+# 跟随默认」），那一行还直接显示着 default 的模型名。
+#
+# 这里曾经有一张兼容表：digest 拆出来时回退 librarian、agent 回退 reading，理由是
+# 「存量部署不配也不该改变行为」。代价是设置页从此在说谎——管理员把默认设成 A、
+# 界面上「每日研究简报」显示跟随默认 A，实际调用打的却是 B。2026-08-10 生产就栽在
+# 这上面：默认配的是 qwen-flash，简报却一直走 librarian 的 gpt-5.6-luna，那天网关
+# 抖动返回截断 JSON，三个库的同步全停了，排查时谁也想不到它没走默认。
+#
+# 「行为不变」保的是没人看的存量默认值，「界面说什么就是什么」保的是每一次人工配置。
+# 后者更值钱：想要原来的模型，显式配一行就是了，而界面骗人是查不出来的。
 
 
 @dataclass(slots=True, frozen=True)
@@ -284,6 +291,9 @@ class LLMRouter:
     ) -> tuple[LLMProvider, ResolvedRoute]:
         """按有效 owner 查路由表（缓存 60s），无则回退 default 路由。
 
+        没显式配的环节一律回退 ``default``，不存在「继承另一个环节」这回事——设置页
+        就是这么告诉管理员的，界面显示跟随默认哪个模型，实际就得打那个模型。
+
         owner 由 user 的接管状态决定：自管用户用自己的 owner=user 配置（admin 的
         对他失效——即"配好前不可用"）；被接管用户及无 user_id 的系统调用用
         全局(owner=NULL, admin)配置。``GLOBAL_ONLY_STAGES``（嵌入）不吃这一套，
@@ -300,8 +310,6 @@ class LLMRouter:
         owner_id = await self._effective_owner(user_id, stage)
         routes = await self._get_routes(owner_id)
         route = routes.get(stage)
-        if route is None and (inherited := _STAGE_ROUTE_FALLBACKS.get(stage)):
-            route = routes.get(inherited)
         if route is None:
             if stage in _CAPABILITY_STAGES:
                 if not routes and get_settings().llm_fake_fallback:

--- a/src/backend/app/services/research_digest.py
+++ b/src/backend/app/services/research_digest.py
@@ -754,7 +754,8 @@ async def synthesize_rolling_trends(
         .scalars()
         .all()
     )
-    if not digest.paper_insights:
+    async def carry_forward() -> LibraryResearchDigest:
+        """沿用上一份趋势收尾。今天没有新洞察、或综合实在做不出来时都走这里。"""
         prior = previous[0] if previous else None
         digest.rolling_trends = list(prior.rolling_trends or []) if prior else []
         digest.trend_content = (
@@ -765,6 +766,9 @@ async def synthesize_rolling_trends(
         digest.trend_model = "carried-forward"
         await session.commit()
         return digest
+
+    if not digest.paper_insights:
+        return await carry_forward()
 
     history = [
         {
@@ -787,47 +791,68 @@ async def synthesize_rolling_trends(
             }
         ],
     }
-    result = await llm.complete(
-        "digest",
-        [
-            Message(role="system", content=TREND_SYSTEM_PROMPT + extra_guidance),
-            Message(role="user", content=json.dumps(payload, ensure_ascii=False)),
-        ],
-        user_id=user_id,
-        project_id=run.project_id,
-        library_id=library.id,
-        voyage_id=run.id,
+    # 和逐批生成洞察一样：重试几次，再不行就降级，**不抛错**。
+    # 2026-08-10 生产上模型返回了一段被截断的 JSON（网关提前断流，却报 200），
+    # 这里一次 json.loads 失败就把三个库的整轮同步打成 paused_error——而前七步
+    # 的成果（候选、打分、全文、编译、上链、简报）都已经落库了，趋势快照只是
+    # 最后一件附加产物。让它拖死整轮同步，代价和收益完全不成比例。
+    last_error: Exception | None = None
+    for attempt in range(1, _DIGEST_MAX_ATTEMPTS + 1):
+        try:
+            result = await llm.complete(
+                "digest",
+                [
+                    Message(role="system", content=TREND_SYSTEM_PROMPT + extra_guidance),
+                    Message(role="user", content=json.dumps(payload, ensure_ascii=False)),
+                ],
+                user_id=user_id,
+                project_id=run.project_id,
+                library_id=library.id,
+                voyage_id=run.id,
+            )
+            generated = _extract_json_object(result.content)
+            if not isinstance(generated.get("trends"), list):
+                raise ValueError("trend synthesis JSON misses trends")
+        except Exception as error:  # noqa: BLE001 — 连不上、超时、JSON 坏了，处理方式一样
+            last_error = error
+            if attempt < _DIGEST_MAX_ATTEMPTS:
+                await _retry_pause(attempt)
+            continue
+
+        allowed_status = {"emerging", "active", "converging", "stale"}
+        trends: list[dict[str, Any]] = []
+        for item in generated["trends"][:12]:
+            if not isinstance(item, dict):
+                continue
+            title = _string(item.get("title"))
+            summary = _string(item.get("summary"))
+            trajectory = _string(item.get("evidence_trajectory"))
+            if not (title and summary and trajectory):
+                continue
+            status = str(item.get("status") or "active")
+            trends.append(
+                {
+                    "title": title,
+                    "status": status if status in allowed_status else "active",
+                    "summary": summary,
+                    "evidence_trajectory": trajectory,
+                    "concepts": [str(name) for name in (item.get("concepts") or [])],
+                    "paper_ids": [str(pid) for pid in (item.get("paper_ids") or [])],
+                    "last_seen": _string(item.get("last_seen"), digest.report_date.isoformat()),
+                }
+            )
+        digest.rolling_trends = trends
+        digest.trend_content = _render_trends_markdown(trends, digest.report_date)
+        digest.trend_model = result.model or "unknown"
+        await session.commit()
+        return digest
+
+    logger.warning(
+        "trend synthesis failed after %s attempts, carrying previous trends forward: %s",
+        _DIGEST_MAX_ATTEMPTS,
+        last_error,
     )
-    generated = _extract_json_object(result.content)
-    if not isinstance(generated.get("trends"), list):
-        raise ValueError("trend synthesis JSON misses trends")
-    allowed_status = {"emerging", "active", "converging", "stale"}
-    trends: list[dict[str, Any]] = []
-    for item in generated["trends"][:12]:
-        if not isinstance(item, dict):
-            continue
-        title = _string(item.get("title"))
-        summary = _string(item.get("summary"))
-        trajectory = _string(item.get("evidence_trajectory"))
-        if not (title and summary and trajectory):
-            continue
-        status = str(item.get("status") or "active")
-        trends.append(
-            {
-                "title": title,
-                "status": status if status in allowed_status else "active",
-                "summary": summary,
-                "evidence_trajectory": trajectory,
-                "concepts": [str(name) for name in (item.get("concepts") or [])],
-                "paper_ids": [str(pid) for pid in (item.get("paper_ids") or [])],
-                "last_seen": _string(item.get("last_seen"), digest.report_date.isoformat()),
-            }
-        )
-    digest.rolling_trends = trends
-    digest.trend_content = _render_trends_markdown(trends, digest.report_date)
-    digest.trend_model = result.model or "unknown"
-    await session.commit()
-    return digest
+    return await carry_forward()
 
 
 async def list_digest_summaries(

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -277,11 +277,13 @@ def test_digest_gets_the_long_call_budget_without_streaming():
     assert "digest" not in STREAM_STAGES, "digest 输出 JSON，不该流式"
 
 
-async def test_digest_falls_back_to_the_librarian_route_when_unset(client, monkeypatch):
-    """没显式配 digest 路由时沿用 librarian 的，存量部署行为不变。
+async def test_digest_falls_back_to_default_not_to_librarian(client, monkeypatch):
+    """没显式配 digest 路由时跟随 default，哪怕 librarian 配着别的模型。
 
-    digest 原先就是直接复用 librarian 的调用，拆出来只为能单独设模型。若回退到
-    default，存量部署会悄悄换成另一类模型——那不是拆分该带来的后果。
+    这里曾经回退 librarian（digest 是从它拆出来的），于是设置页说的和实际打的不是
+    一回事：界面显示「每日研究简报 · 跟随默认」并列着 default 的模型名，调用却走
+    librarian。2026-08-10 生产因此排查了半天——默认明明配的 qwen-flash，日志里
+    却全是 gpt-5.6-luna。界面承诺什么，解析就得给什么。
     """
     from app.core.llm.router import LLMRouter, ResolvedRoute
 
@@ -310,11 +312,11 @@ async def test_digest_falls_back_to_the_librarian_route_when_unset(client, monke
 
     monkeypatch.setattr(router, "_get_routes", fake_routes)
     _provider, route = await router.resolve("digest")
-    assert route.model == "librarian-model", "应当沿用 librarian，而不是掉到 default"
+    assert route.model == "default-model", "应当跟随 default，而不是偷偷继承 librarian"
 
 
-async def test_an_explicit_digest_route_wins_over_the_fallback(client, monkeypatch):
-    """显式配了 digest 就用它——拆分的意义就在这里。"""
+async def test_an_explicit_digest_route_wins(client, monkeypatch):
+    """显式配了 digest 就用它——拆成独立环节的意义就在这里。"""
     from app.core.llm.router import LLMRouter, ResolvedRoute
 
     router = LLMRouter()

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -11,14 +11,13 @@ from app.core.llm.base import (
     ToolUseStart,
 )
 from app.core.llm.fake import FakeProvider
-from app.core.llm.router import _STAGE_ROUTE_FALLBACKS, STAGES, call_profile
+from app.core.llm.router import STAGES, call_profile
 from app.core.llm.tool_stream import ToolCallAccumulator
 
 
-def test_agent_stage_exists_and_falls_back_to_reading():
-    """新 stage 未配置时继承 reading 的路由——存量部署不用改任何配置就能跑。"""
+def test_agent_stage_exists():
+    """agent 是个可单独配路由的环节；没配时和别的环节一样跟随 default。"""
     assert "agent" in STAGES
-    assert _STAGE_ROUTE_FALLBACKS["agent"] == "reading"
 
 
 def test_agent_gets_its_own_patience_not_the_long_profile():

--- a/src/backend/tests/test_research_digest_batching.py
+++ b/src/backend/tests/test_research_digest_batching.py
@@ -223,3 +223,106 @@ async def test_a_batch_that_never_completes_degrades_instead_of_raising():
         if item["paper_id"] != papers[12]["paper_id"]
     )
     assert retries == 2, "该批应当补跑到上限（共三轮）"
+
+
+class _BrokenTrendLLM:
+    """趋势综合永远返回截断的 JSON——2026-08-10 生产上网关提前断流的形态。"""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def complete(self, stage, messages, **kwargs):
+        assert stage == "digest"
+        assert "POLARIS_TREND_SYNTHESIS" in messages[0].content
+        self.calls += 1
+        # 结尾停在半个字符串上，和线上那次一模一样
+        return CompletionResult(
+            content='{"trends":[{"title":"半截","paper_ids":["8793c979-',
+            model="fake-trend",
+        )
+
+
+@pytest.mark.asyncio
+async def test_broken_trend_json_carries_forward_instead_of_failing_the_sync(client):
+    """趋势综合拿不到可用 JSON 时沿用上一份，不把整轮同步打成 paused_error。
+
+    2026-08-10 生产上三个库就是这么停的：前七步（候选、打分、全文、编译、上链、
+    简报）全部落库了，最后一步一次 json.loads 失败，整轮同步停下等人，而水位线
+    也就没记上。趋势快照是附加产物，不该有这个权力。
+    """
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.models.library_direction import DirectionLibrary as _Library
+    from app.models.research_digest import LibraryResearchDigest
+    from app.models.voyage import VoyageRun as _Run
+    from app.services.research_digest import synthesize_rolling_trends
+
+    library_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    yesterday_trends = [
+        {
+            "title": "昨天那条主线",
+            "status": "active",
+            "summary": "昨天的判断",
+            "evidence_trajectory": "昨天的证据",
+            "concepts": [],
+            "paper_ids": [],
+            "last_seen": "2026-08-09",
+        }
+    ]
+
+    async with get_sessionmaker()() as session:
+        session.add(_Library(id=library_id, name="趋势降级库", definition={"statement": "agent"}))
+        session.add(_Run(id=run_id, kind="wiki_ingest", goal="每日自动同步：趋势降级库"))
+        await session.flush()
+        session.add(
+            LibraryResearchDigest(
+                library_id=library_id,
+                report_date=dt.date(2026, 8, 9),
+                source="voyage",
+                mode="incremental",
+                counts={},
+                source_diagnostics={},
+                paper_insights=[],
+                excluded_papers=[],
+                cross_paper_signals=[],
+                summary="昨天的简报",
+                content="# 昨天",
+                rolling_trends=yesterday_trends,
+                trend_content="# 昨天的趋势",
+                trend_model="fake-trend",
+            )
+        )
+        session.add(
+            LibraryResearchDigest(
+                library_id=library_id,
+                voyage_id=run_id,
+                report_date=dt.date(2026, 8, 10),
+                source="voyage",
+                mode="incremental",
+                counts={},
+                source_diagnostics={},
+                paper_insights=[{"paper_id": str(uuid.uuid4()), "highlight": "今天有货"}],
+                excluded_papers=[],
+                cross_paper_signals=[],
+                summary="今天的简报",
+                content="# 今天",
+                rolling_trends=[],
+                trend_content="",
+            )
+        )
+        await session.commit()
+
+    llm = _BrokenTrendLLM()
+    async with get_sessionmaker()() as session:
+        run = await session.get(_Run, run_id)
+        library = await session.get(_Library, library_id)
+        digest = await synthesize_rolling_trends(
+            session, run=run, library=library, llm=llm, user_id=None, extra_guidance=""
+        )
+
+    assert llm.calls == 3, "坏 JSON 该重试到上限，而不是一次就放弃"
+    assert digest.trend_model == "carried-forward"
+    assert digest.rolling_trends == yesterday_trends, "应当沿用昨天的趋势线"
+    assert digest.trend_content == "# 昨天的趋势"


### PR DESCRIPTION
Closes #384

Two defects behind the 2026-08-10 daily-sync incident, one commit each.

## 1. Unset stages follow `default`

The settings page states that **"stages without their own row follow Default"** and renders such a row as `Follows default` beside the default route's provider and model. The router disagreed:

```python
_STAGE_ROUTE_FALLBACKS = {"digest": "librarian", "agent": "reading"}
```

Added in #239 when `digest` was split out of `librarian`, so that existing deployments would keep the same model. The trade it made: behaviour continuity for defaults nobody had inspected, in exchange for every later configuration being misread.

Production had `Default = dashscope/qwen-flash` and no explicit `digest` row, so the page showed the daily digest following `qwen-flash`. Every call went to `gpt-5.6-luna`. When that gateway misbehaved, the logs named a model that appeared nowhere in the admin's configuration, which is what made the incident hard to read.

Removed. Anyone who wants the previous model configures that stage explicitly — that is what splitting the stage was for.

**This changes resolution for deployments that relied on the shim:** `digest` and `agent` now follow `default`. Worth a look at the routing table before deploying.

## 2. Trend synthesis degrades instead of failing the run

`synthesize_rolling_trends` used a bare `json.loads` with no retry (`attempt=1` on all three failed steps). The gateway returned a response reported as `status=ok` but cut mid-string:

```
…"paper_ids":["8793c979-
```

One such response left `SWE`, `Embodied Agent` and `GUI Agent` at `paused_error`. By that point every earlier step had committed: papers ingested (+12, +32, +8), wiki pages compiled, concepts linked, daily digest written. Only the trend snapshot and the watermark were missing.

`_generate_insight_batch` in the same module already answers this — it retries `_DIGEST_MAX_ATTEMPTS` times and then degrades rather than raising, because the digest is an additional product and should not sink the steps before it. The trend snapshot sits one step further out and had none of that. It now shares the retry budget and falls back to the previous trends, reusing the carry-forward path this function already takes on a day with no new insights.

## Tests

- `test_digest_falls_back_to_default_not_to_librarian` replaces the test that asserted the old inheritance.
- `test_broken_trend_json_carries_forward_instead_of_failing_the_sync` reproduces the truncated payload verbatim and asserts three attempts, `trend_model == "carried-forward"`, and yesterday's trends preserved.
- `test_research_digest_batching.py test_llm_router.py test_llm_router_tools.py` — 33 passed.
- `test_admin_llm test_per_user_llm test_llm_not_configured test_me_llm_extras test_llm_call_logs test_wiki_ingest test_daily_feed test_literature` — 154 passed.

## Not included

The three production runs are still at `paused_error`; nothing was changed on the server. They can be resumed from the run console once this is deployed, and the papers are already in the libraries either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr