### PR TITLE
fix(llm): add stage-specific timeout profiles

### DIFF
--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -619,7 +619,7 @@ async def forge_generate(ctx: ActionContext, params: dict[str, Any]) -> dict[str
 
     candidates = await _complete_json(
         ctx,
-        stage="forge",
+        stage="forge_generate",
         system=GENERATE_SYSTEM_PROMPT + ctx.skill_guidance("forge.generate"),
         user=user_prompt,
         validate=validate,

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -61,6 +61,7 @@ STAGES = (
     "embedding",
     "rerank",
     "forge",
+    "forge_generate",
     "forge_signal",
     "goal_explore",
     "proposal",
@@ -137,7 +138,7 @@ _STREAM_FLUSH_CHARS = 80  # token 增量攒到此长度再广播一段（节流�
 _STREAM_RETRY_ATTEMPTS = 3  # 流式请求网络瞬断整段重试次数
 _STREAM_RETRY_BASE_SECONDS = 2.0
 
-# 一次调用能等多久、重试几次，按环节分两档——两者的合理耐心程度差一个数量级。
+# 一次调用能等多久、重试几次，按环节分三档。
 #
 # 生产实测（gpt-5.6-luna，6 小时）：relevance 中位 13.3s，但 p95 达到 1215s。
 # 那不是模型在慢慢想——4 次尝试 × 300s 超时 + 退避 3+6+12 正好是 1221s，也就是
@@ -148,23 +149,41 @@ _STREAM_RETRY_BASE_SECONDS = 2.0
 # 更没理由等四次；卡住的短请求重试也极少能救回来。长文本环节（编译 / 写作 /
 # 评审）本来就要跑几分钟，保持宽松。
 _SHORT_CALL = (60.0, 2)  # (timeout 秒, 最多尝试次数) → 最坏 60+3+60 = 123s
+_MEDIUM_CALL = (180.0, 2)
 _LONG_CALL = (300.0, 4)
+
+_SHORT_CALL_STAGES = frozenset(
+    {
+        "default",
+        "sextant",
+        "relevance",
+        "extract",
+        "embedding",
+        "rerank",
+        "forge",
+        "forge_signal",
+        "reading",
+        "feedback_issue",
+    }
+)
 
 # 「要给长耐心」与「要流式播出去」是两件事，不能共用一个集合。
 # digest 就是反例：它输出 JSON（不该流式，否则整段 JSON 灌进任务终端日志），
 # 但一次要为一批论文生成洞察，实测 p95 313 秒，必须给长档预算。
-_LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest"})
+# forge_generate 同理：默认一次生成 8 个含方法、实验与风险的完整想法，生产请求
+# 会超过 60 秒；仍保持非流式，避免把半截 JSON 写进任务终端。
+_LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest", "forge_generate"})
 
-# agent 单独一档。一轮 agent 调用 = 思考 + 发起工具调用，比短 JSON 长得多，但**不能**
+# 中档用于多轮代理和较长的结构化生成。一次调用比短 JSON 长得多，但**不能**
 # 直接塞进长档：那是 300s × 4 尝试，最坏 20 分钟攥着一个 HTTP 连接不放，而对话是同步的，
 # 用户早走了。180s × 2 是"够想完一轮、又不至于把连接耗死"的折中。
-_AGENT_CALL = (180.0, 2)
+_MEDIUM_CALL_STAGES = frozenset({"agent", "goal_explore", "proposal_review"})
 
 
 def call_profile(stage: str) -> tuple[float, int]:
     """该环节单次调用的 (超时, 最大尝试次数)。"""
-    if stage == "agent":
-        return _AGENT_CALL
+    if stage in _MEDIUM_CALL_STAGES:
+        return _MEDIUM_CALL
     return _LONG_CALL if stage in _LONG_CALL_STAGES else _SHORT_CALL
 
 

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -122,6 +122,7 @@ def test_stage_catalog():
     assert "extract" in STAGES
     assert "librarian" in STAGES
     assert "feedback_issue" in STAGES
+    assert "forge_generate" in STAGES
     assert len(set(STAGES)) == len(STAGES)  # 无重复
 
 
@@ -338,3 +339,45 @@ async def test_an_explicit_digest_route_wins(client, monkeypatch):
     monkeypatch.setattr(router, "_get_routes", fake_routes)
     _provider, route = await router.resolve("digest")
     assert route.model == "digest-model"
+
+
+# ---- forge 候选生成：长 JSON，路由遵循统一的 default 回退规则 ----
+
+
+def test_forge_generate_gets_the_long_call_budget_without_streaming():
+    """一次生成多个完整 Idea 可能超过 60 秒，但 JSON 不应流式灌入终端。"""
+    from app.core.llm.router import STREAM_STAGES, call_profile
+
+    timeout, attempts = call_profile("forge_generate")
+    assert timeout >= 300
+    assert attempts >= 3
+    assert "forge_generate" not in STREAM_STAGES
+    assert call_profile("forge") == (60.0, 2), "分析和逐条评分仍应保持短调用预算"
+
+
+async def test_forge_generate_falls_back_to_default_when_unset(client, monkeypatch):
+    """未显式配置候选生成路由时跟随 default，与设置页展示保持一致。"""
+    from app.core.llm.router import LLMRouter, ResolvedRoute
+
+    router = LLMRouter()
+
+    def _route(model):
+        return ResolvedRoute(
+            provider_kind="fake",
+            base_url=None,
+            api_key="",
+            model=model,
+            temperature=None,
+            provider_name="fake",
+            effort=None,
+        )
+
+    async def fake_routes(owner_id):
+        return {
+            "forge": _route("forge-model"),
+            "default": _route("default-model"),
+        }
+
+    monkeypatch.setattr(router, "_get_routes", fake_routes)
+    _provider, route = await router.resolve("forge_generate")
+    assert route.model == "default-model", "应跟随 default，而不是隐藏继承 forge"

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -11,7 +11,14 @@ from app.core.llm.base import (
     ToolUseStart,
 )
 from app.core.llm.fake import FakeProvider
-from app.core.llm.router import STAGES, call_profile
+from app.core.llm.router import (
+    _LONG_CALL_STAGES,
+    _MEDIUM_CALL_STAGES,
+    _SHORT_CALL_STAGES,
+    STAGES,
+    STREAM_STAGES,
+    call_profile,
+)
 from app.core.llm.tool_stream import ToolCallAccumulator
 
 
@@ -20,18 +27,35 @@ def test_agent_stage_exists():
     assert "agent" in STAGES
 
 
-def test_agent_gets_its_own_patience_not_the_long_profile():
-    """agent 单独一档，既不是短档也不是长档。
+def test_medium_stages_get_more_patience_without_the_long_profile():
+    """代理、目标构建和方案评审使用中档，既不是短档也不是长档。
 
     短档（60s×2）不够想完一轮；长档（300s×4）最坏 20 分钟攥着一个 HTTP 连接不放，
     而对话是同步的——用户早走了。
     """
-    agent = call_profile("agent")
-    assert agent == (180.0, 2)
-    assert agent != call_profile("relevance"), "不能是短档"
-    assert agent != call_profile("librarian"), "也不能是长档"
+    for stage in ("agent", "goal_explore", "proposal_review"):
+        profile = call_profile(stage)
+        assert profile == (180.0, 2)
+        assert profile != call_profile("relevance"), "不能是短档"
+        assert profile != call_profile("librarian"), "也不能是长档"
     # reading（现有对话）必须保持短档不变
     assert call_profile("reading") == call_profile("relevance")
+
+
+def test_every_known_stage_has_exactly_one_call_profile():
+    """新增 stage 时必须显式归类，避免长任务静默回落到 60 秒短档。"""
+    known = set(STAGES)
+    short = set(_SHORT_CALL_STAGES)
+    medium = set(_MEDIUM_CALL_STAGES)
+    long = set(_LONG_CALL_STAGES)
+
+    classified = short | medium | long
+    assert known <= classified
+    assert classified - known == {"digest"}, "仅允许已知的内部 profile key 不公开为路由"
+    assert short.isdisjoint(medium)
+    assert short.isdisjoint(long)
+    assert medium.isdisjoint(long)
+    assert set(STREAM_STAGES) <= long
 
 
 @pytest.mark.asyncio

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -541,6 +541,7 @@ export const LLM_STAGES = [
   'embedding',
   'rerank',
   'forge',
+  'forge_generate',
   'forge_signal',
   'goal_explore',
   'proposal',

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -16,6 +16,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   embedding: { zh: '向量嵌入', en: 'Embeddings' },
   rerank: { zh: '重排序', en: 'Reranking' },
   forge: { zh: '想法生成', en: 'Idea generation' },
+  forge_generate: { zh: '候选想法生成', en: 'Candidate idea generation' },
   forge_signal: { zh: '信号摘要', en: 'Signal digest' },
   goal_explore: { zh: '目标构建', en: 'Goal building' },
   proposal: { zh: '方案起草', en: 'Proposal drafting' },


### PR DESCRIPTION
## Summary

Give long structured LLM stages an appropriate request budget without allowing short scoring and extraction calls to hold connections for several minutes.

Closes #386

## Area

- [x] frontend
- [x] idea forge
- [x] llm routing / usage

## What changed

- Added explicit short, medium, and long LLM call profiles.
- Kept scoring, extraction, and compact Idea Forge analysis on the short profile.
- Moved bulk candidate idea generation to a dedicated `forge_generate` stage with the long request budget.
- Assigned goal construction and proposal review to the medium profile.
- Added `forge_generate` to the model routing settings so administrators can configure it explicitly.
- Preserved the upstream rule that an unset stage follows the Default route.
- Added tests requiring every public LLM stage to have a deliberate timeout profile.

## Why this approach

Candidate Idea Forge output contains multiple complete ideas with methods, experiment plans, and risks, so it can legitimately take several minutes. Increasing the timeout for the existing `forge` stage would also make short analysis and scoring calls wait too long when a provider is unavailable.

A separate stage keeps the operational budgets independent and also allows deployments to choose a different model when needed.

## Testing

- [x] `tsc --noEmit` / frontend production build passes
- [x] Backend router tests pass — 33 passed
- [x] Manually verified in local dev

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title
- [x] No new database migration
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [ ] Screenshot attached for the new model-routing setting