### PR TITLE
fix(literature): make arxiv searches resumable

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -13,13 +13,15 @@
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.voyage.actions import ActionContext, register
@@ -32,7 +34,7 @@ from app.models.daily_feed import DailyFeedEntry
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper, new_paper
 from app.models.research_digest import LibraryResearchDigest
-from app.models.voyage import VoyageStep
+from app.models.voyage import VoyageRun, VoyageStep
 from app.schemas.ingest import TIME_RANGE_DAYS
 from app.services.affiliations import (
     apply_author_affiliations,
@@ -569,15 +571,63 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         params = _params(ctx)
         terms = [t for t in (params.get("query_terms") or []) if str(t).strip()] or include
         days = TIME_RANGE_DAYS.get(str(params.get("time_range") or ""))
-        since = now - timedelta(days=days or 30 * int(knobs["months_back"]))
-        entries = await get_arxiv_client().search(
-            categories=categories,
-            keywords=terms,
-            exclude=exclude,
-            since=since,
-            until=now,
-            limit=limit,
-        )
+        query_signature = hashlib.sha256(
+            json.dumps(
+                {
+                    "categories": categories,
+                    "terms": terms,
+                    "exclude": exclude,
+                    "days": days,
+                    "months_back": int(knobs["months_back"]),
+                    "limit": limit,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode()
+        ).hexdigest()
+        resume = ctx.checkpoint.get("arxiv_search_resume") or {}
+        if resume.get("query_signature") == query_signature and not resume.get("done"):
+            since = _parse_iso(resume.get("since")) or (
+                now - timedelta(days=days or 30 * int(knobs["months_back"]))
+            )
+            until = _parse_iso(resume.get("until")) or now
+            next_start = max(0, int(resume.get("next_start") or 0))
+            fetched_total = max(0, int(resume.get("fetched") or 0))
+            inserted_total = max(0, int(resume.get("inserted") or 0))
+            source_latest_at = resume.get("source_latest_at")
+        else:
+            since = now - timedelta(days=days or 30 * int(knobs["months_back"]))
+            until = now
+            next_start = 0
+            fetched_total = 0
+            inserted_total = 0
+            source_latest_at = None
+
+        def _checkpoint(*, done: bool) -> dict[str, Any]:
+            return {
+                "query_signature": query_signature,
+                "since": since.isoformat(),
+                "until": until.isoformat(),
+                "next_start": next_start,
+                "limit": limit,
+                "fetched": fetched_total,
+                "inserted": inserted_total,
+                "source_latest_at": source_latest_at,
+                "done": done,
+            }
+
+        async def _persist_checkpoint(*, done: bool) -> None:
+            ctx.checkpoint["arxiv_search_resume"] = _checkpoint(done=done)
+            await session.execute(
+                update(VoyageRun)
+                .where(VoyageRun.id == ctx.run.id)
+                .values(checkpoint=dict(ctx.checkpoint))
+            )
+            await session.commit()
+
+        # Persist the fixed time window before the first HTTP call. If page 1 is rate-limited,
+        # resume still uses the exact same result set instead of moving "until" forward.
+        await _persist_checkpoint(done=False)
 
         arxiv_ids, dois, titles = await _existing_keys(session, library.id)
         new_papers: list[Paper] = []
@@ -633,17 +683,44 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             new_papers.append(paper)
             return True
 
-        for entry in entries:
-            await _try_insert(entry, "arxiv")
+        arxiv = get_arxiv_client()
+        while next_start < limit:
+            page_size = min(100, limit - next_start)
+            entries = await arxiv.search_page(
+                categories=categories,
+                keywords=terms,
+                exclude=exclude,
+                since=since,
+                until=until,
+                start=next_start,
+                limit=page_size,
+            )
+            if not entries:
+                await _persist_checkpoint(done=True)
+                break
+            inserted_page = 0
+            for entry in entries:
+                if await _try_insert(entry, "arxiv"):
+                    inserted_page += 1
+            await session.flush()
+            fetched_total += len(entries)
+            inserted_total += inserted_page
+            next_start += len(entries)
+            page_latest = _latest_source_date(entries)
+            if page_latest and (source_latest_at is None or page_latest > source_latest_at):
+                source_latest_at = page_latest
+            done = len(entries) < page_size or next_start >= limit
+            # Paper rows/memberships and next_start are committed atomically. A later 429 can
+            # therefore resume at the next page without losing or replaying this page.
+            await _persist_checkpoint(done=done)
+            if done:
+                break
 
-        await session.flush()  # 拿到新论文 id，供 observation 清单
         brief = _paper_brief(new_papers)
-        await session.commit()
 
-    source_latest_at = _latest_source_date(entries)
     messages: list[str] = []
-    source_fetched = len(entries)
-    cap_hit = len(entries) >= limit
+    source_fetched = fetched_total
+    cap_hit = fetched_total >= limit
     if source_fetched == 0:
         messages.append("本次所有数据源均返回 0 篇；请复查检索配置、源站状态和时间窗口。")
     if cap_hit:
@@ -653,9 +730,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
     diagnostics = {
         "source": "arxiv",
         "source_fetched": source_fetched,
-        "prescreened": len(entries),
-        "query_found": len(entries),
-        "inserted": len(new_papers),
+        "prescreened": fetched_total,
+        "query_found": fetched_total,
+        "inserted": inserted_total,
         "window_since": since.isoformat(),
         "source_latest_at": source_latest_at,
         "cap_hit": cap_hit,
@@ -667,8 +744,8 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
     ctx.checkpoint["watermark_candidate"] = now.isoformat()
     return {
         "source": "arxiv",
-        "found": len(entries),
-        "inserted": len(new_papers),
+        "found": fetched_total,
+        "inserted": inserted_total,
         "new_papers": brief,
         "window_since": since.isoformat(),
         "mode": mode,

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import random
 import re
+import time
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
@@ -59,6 +60,8 @@ _VERSION_RE = re.compile(r"v\d+$")
 _RETRY_STATUSES = frozenset({403, 429, 500, 502, 503, 504})
 # 单次退避上限：Retry-After 可能给出很大的值，voyage 任务不能被一个响应头挂住半天
 _MAX_BACKOFF_SECONDS = 120.0
+_QUERY_COOLDOWN_KEY = "arxiv:query:cooldown_until"
+_QUERY_COOLDOWN_SECONDS = 10 * 60
 
 
 class ArxivError(RuntimeError):
@@ -67,6 +70,10 @@ class ArxivError(RuntimeError):
 
 class ArxivRateLimitedError(ArxivError):
     """被 arXiv 限流，且重试次数耗尽。"""
+
+    def __init__(self, message: str, *, retry_after: int | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 def _parse_iso_dt(raw: Any) -> datetime | None:
@@ -267,6 +274,7 @@ class ArxivClient:
             headers={"User-Agent": f"Polaris/1.0 (+mailto:{settings.openalex_mailto})"},
         )
         self._cache = ResponseCache(redis)
+        self._redis = redis
         # RSS 新鲜源用独立的短 TTL 缓存（3h），跨用户/项目共享当天新公告
         self._rss_cache = ResponseCache(redis, ttl=_RSS_CACHE_TTL)
         # 闸门放 Redis 上，让 api 与 worker 两个进程共享同一个间隔（见 MinIntervalLimiter）
@@ -274,6 +282,30 @@ class ArxivClient:
         self._page_size = page_size
         self._max_retries = max(1, max_retries)
         self._backoff_base = backoff_base
+
+    async def _query_cooldown_remaining(self) -> int:
+        if self._redis is None:
+            return 0
+        try:
+            raw = await self._redis.get(_QUERY_COOLDOWN_KEY)
+        except Exception:  # noqa: BLE001 - Redis loss must not make arXiv unusable
+            return 0
+        if raw is None:
+            return 0
+        try:
+            until = float(raw.decode() if isinstance(raw, bytes) else raw)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, int(until - time.time() + 0.999))
+
+    async def _start_query_cooldown(self, seconds: int) -> int:
+        seconds = max(_QUERY_COOLDOWN_SECONDS, seconds)
+        if self._redis is not None:
+            try:
+                await self._redis.setex(_QUERY_COOLDOWN_KEY, seconds, str(time.time() + seconds))
+            except Exception:  # noqa: BLE001
+                logger.warning("failed to persist arxiv query cooldown", exc_info=True)
+        return seconds
 
     async def _request(self, url: str, *, params: dict[str, Any] | None = None) -> httpx.Response:
         """所有 arXiv 请求的唯一出口：限速 + 遇限流/超时退避重试。
@@ -285,7 +317,13 @@ class ArxivClient:
         进程、各自独立重试，加满抖动才能把它们错开）。退避的同时 ``penalize`` 共享限流器，
         否则同进程里别的协程会接着打过去，等于没退避。
         """
+        if url == API_URL and (remaining := await self._query_cooldown_remaining()):
+            raise ArxivRateLimitedError(
+                f"arXiv query cooling down; retry after {remaining}s", retry_after=remaining
+            )
         last_exc: Exception | None = None
+        last_status: int | None = None
+        last_retry_after: float | None = None
         for attempt in range(self._max_retries):
             await self._limiter.acquire()
             retry_after: float | None = None
@@ -301,6 +339,8 @@ class ArxivClient:
                     resp.raise_for_status()
                     return resp
                 retry_after = _retry_after_seconds(resp)
+                last_status = resp.status_code
+                last_retry_after = retry_after
                 last_exc = httpx.HTTPStatusError(
                     f"{resp.status_code} from arXiv", request=resp.request, response=resp
                 )
@@ -327,10 +367,15 @@ class ArxivClient:
                 url,
             )
             await self._limiter.penalize(delay)
-            await asyncio.sleep(delay)
+            if attempt + 1 < self._max_retries:
+                await asyncio.sleep(delay)
+        cooldown = None
+        if url == API_URL and last_status in (403, 429):
+            cooldown = await self._start_query_cooldown(int(last_retry_after or 0))
         raise ArxivRateLimitedError(
             f"arXiv unavailable after {self._max_retries} attempts"
-            f" ({type(last_exc).__name__}): {url}"
+            f" ({type(last_exc).__name__}): {url}",
+            retry_after=cooldown,
         ) from last_exc
 
     async def _query(self, params: dict[str, Any]) -> list[dict[str, Any]]:
@@ -373,6 +418,29 @@ class ArxivClient:
                 break
             start += len(entries)
         return results[:limit]
+
+    async def search_page(
+        self,
+        *,
+        categories: list[str] | None = None,
+        keywords: list[str] | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        exclude: list[str] | None = None,
+        start: int = 0,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Fetch one stable page so callers can commit a resumable checkpoint."""
+        query = build_search_query(categories or [], keywords or [], since, until, exclude)
+        return await self._query(
+            {
+                "search_query": query,
+                "start": max(0, start),
+                "max_results": max(1, min(self._page_size, limit)),
+                "sortBy": "submittedDate",
+                "sortOrder": "descending",
+            }
+        )
 
     async def fetch_new(self, category: str) -> tuple[list[dict[str, Any]], datetime | None]:
         """抓一个分类的当天新公告（RSS /new，即时无索引滞后）。

--- a/src/backend/tests/test_arxiv_resumable_search.py
+++ b/src/backend/tests/test_arxiv_resumable_search.py
@@ -1,0 +1,140 @@
+"""Regressions for shared arXiv query cooldown and resumable paging."""
+
+import uuid
+
+import fakeredis.aioredis
+import httpx
+import pytest
+import respx
+from sqlalchemy import func, select
+
+from app.agents.voyage import actions_wiki
+from app.agents.voyage.actions import ActionContext
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
+from app.models.voyage import VoyageRun
+from app.services.literature.arxiv import ArxivClient, ArxivRateLimitedError
+from tests.conftest import make_project_with_library, register_and_login
+
+
+@respx.mock
+async def test_arxiv_429_sets_global_query_cooldown():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    client = ArxivClient(redis=redis, min_interval=0, max_retries=1, backoff_base=0)
+    route = respx.get("https://export.arxiv.org/api/query").mock(return_value=httpx.Response(429))
+    with pytest.raises(ArxivRateLimitedError) as first:
+        await client.search_page(keywords=["agents"], limit=1)
+    assert first.value.retry_after == 600
+    with pytest.raises(ArxivRateLimitedError) as second:
+        await client.search_page(keywords=["agents"], limit=1)
+    assert second.value.retry_after and second.value.retry_after > 0
+    assert route.call_count == 1
+    await redis.aclose()
+
+
+async def test_arxiv_search_resumes_after_the_last_committed_page(client, monkeypatch):
+    """A failed second page resumes at its saved offset without replaying page one."""
+
+    class InterruptingArxiv:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+            self.interrupted = False
+            self.entries = [
+                {
+                    "arxiv_id": f"2608.{index:05d}",
+                    "title": f"Resumable arXiv result {index}",
+                    "abstract": f"A deterministic resumable-search paper {index}.",
+                    "authors": [f"Author {index}"],
+                    "year": 2026,
+                    "primary_category": "cs.AI",
+                    "url": f"https://arxiv.org/abs/2608.{index:05d}",
+                    "published": "2026-08-01T00:00:00+00:00",
+                }
+                for index in range(101)
+            ]
+
+        async def search_page(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            start = kwargs["start"]
+            if start == 100 and not self.interrupted:
+                self.interrupted = True
+                raise ArxivRateLimitedError("simulated second-page limit", retry_after=600)
+            return self.entries[start : start + kwargs["limit"]]
+
+    token = await register_and_login(client, email="arxiv-resume@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client,
+        headers,
+        name="arxiv-resume",
+        definition={
+            "statement": "Resumable literature search",
+            "keywords": {"arxiv_categories": ["cs.AI"], "include": ["agents"]},
+        },
+    )
+    checkpoint = {
+        "params": {
+            "mode": "search",
+            "knobs": {"max_papers": 101, "months_back": 6},
+        }
+    }
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="wiki_bootstrap",
+            status="executing",
+            project_id=uuid.UUID(project_id),
+            library_id=library_id,
+            goal="Resume a paginated arXiv search",
+            checkpoint=dict(checkpoint),
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    arxiv = InterruptingArxiv()
+    monkeypatch.setattr(actions_wiki, "get_arxiv_client", lambda: arxiv)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+    first_ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint))
+    with pytest.raises(ArxivRateLimitedError):
+        await actions_wiki.search_candidates(first_ctx, {})
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        saved = run.checkpoint["arxiv_search_resume"]
+        inserted = int(
+            (
+                await session.execute(
+                    select(func.count())
+                    .select_from(LibraryPaper)
+                    .where(LibraryPaper.library_id == library_id)
+                )
+            ).scalar_one()
+        )
+    assert saved["next_start"] == saved["fetched"] == saved["inserted"] == inserted == 100
+    assert saved["done"] is False
+
+    resume_ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint))
+    result = await actions_wiki.search_candidates(resume_ctx, {})
+
+    assert [call["start"] for call in arxiv.calls] == [0, 100, 100]
+    assert arxiv.calls[0]["since"] == arxiv.calls[2]["since"]
+    assert arxiv.calls[0]["until"] == arxiv.calls[2]["until"]
+    assert result["found"] == result["inserted"] == 101
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        completed = run.checkpoint["arxiv_search_resume"]
+        inserted = int(
+            (
+                await session.execute(
+                    select(func.count())
+                    .select_from(LibraryPaper)
+                    .where(LibraryPaper.library_id == library_id)
+                )
+            ).scalar_one()
+        )
+    assert completed["next_start"] == completed["fetched"] == inserted == 101
+    assert completed["done"] is True


### PR DESCRIPTION
## Summary

Make initial arXiv library searches respect a shared rate-limit cooldown and resume from completed pages after interruption.

Closes #388 

## Area

- [x] backend
- [x] literature ingestion
- [x] voyage / worker

## What changed

- Added a Redis-backed global arXiv cooldown shared by API and worker processes.
- Used stable search windows so resumed requests preserve the original query and ordering.
- Persisted page checkpoints as search results are accepted.
- Resumed interrupted and rate-limited searches from the last completed page.
- Kept arXiv as the authoritative source instead of silently switching to a provider with different ranking and duplicate semantics.
- Added regression coverage for shared cooldown and resumable searches.

## Why this approach

Initial library construction can require multiple paginated arXiv requests. Independent in-process retries do not coordinate concurrent API and worker activity, and restarting an interrupted search repeats requests that have already succeeded.

A shared cooldown prevents other processes from immediately continuing after HTTP 429. Stable windows and persisted checkpoints reduce repeated traffic while preserving the result semantics of the original arXiv search.

Automatically falling back to Semantic Scholar is intentionally avoided because its ranking and duplicate behavior differ from arXiv and could change the resulting library.

## Testing

- [x] Resumable-search and global-cooldown regression coverage passed
- [x] 41 wiki-ingest tests passed
- [x] Ruff checks passed

## Checklist

- [x] Branch rebased on the latest `origin/main`
- [x] Conventional-commit PR title
- [x] No database migration
- [x] Backend-only change; no frontend screenshot required
- [x] No AI attribution or `Co-Authored-By` lines