### PR TITLE
Make every shown stage configurable, and tighten the arXiv cooldown

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -595,6 +595,12 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             fetched_total = max(0, int(resume.get("fetched") or 0))
             inserted_total = max(0, int(resume.get("inserted") or 0))
             source_latest_at = resume.get("source_latest_at")
+            # 清单也要跨续跑累计。只留 id+title 且有条数上限，带着走很便宜；
+            # 不带的话，续跑那一轮的 observation 会写着「新增 101 篇」却只列出最后
+            # 一页的 1 篇——数字和清单当场打架，看的人只能怀疑是不是漏了 100 篇。
+            brief_acc = [
+                dict(item) for item in (resume.get("brief") or []) if isinstance(item, dict)
+            ]
         else:
             since = now - timedelta(days=days or 30 * int(knobs["months_back"]))
             until = now
@@ -602,6 +608,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             fetched_total = 0
             inserted_total = 0
             source_latest_at = None
+            brief_acc = []
 
         def _checkpoint(*, done: bool) -> dict[str, Any]:
             return {
@@ -613,6 +620,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 "fetched": fetched_total,
                 "inserted": inserted_total,
                 "source_latest_at": source_latest_at,
+                "brief": brief_acc,
                 "done": done,
             }
 
@@ -685,7 +693,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
 
         arxiv = get_arxiv_client()
         while next_start < limit:
-            page_size = min(100, limit - next_start)
+            # 页大小问客户端要，别写死：下面拿 len(entries) < page_size 判末页，
+            # 一旦要的比客户端肯给的多，第一页就会被误判成末页，搜索静默截断。
+            page_size = min(arxiv.page_size, limit - next_start)
             entries = await arxiv.search_page(
                 categories=categories,
                 keywords=terms,
@@ -706,6 +716,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             fetched_total += len(entries)
             inserted_total += inserted_page
             next_start += len(entries)
+            if inserted_page:
+                brief_acc.extend(_paper_brief(new_papers[-inserted_page:]))
+                del brief_acc[_OBS_LIST_CAP:]
             page_latest = _latest_source_date(entries)
             if page_latest and (source_latest_at is None or page_latest > source_latest_at):
                 source_latest_at = page_latest
@@ -716,7 +729,7 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             if done:
                 break
 
-        brief = _paper_brief(new_papers)
+        brief = brief_acc
 
     messages: list[str] = []
     source_fetched = fetched_total

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -50,6 +50,12 @@ class LLMNotConfiguredError(RuntimeError):
 # librarian 与 extract 的分工：librarian = 长文本 + 多模态（wiki 图文精读编译、
 # 论文图筛选注释、幻灯片大纲/内容/视觉评审），要强模型；extract = 纯文本短 JSON
 # 结构化抽取（作者↔机构解析、概念定义批量生成、建库向导收录设置），小模型够用。
+#
+# **这个元组必须和前端 ``src/frontend/src/lib/api.ts`` 的 ``LLM_STAGES`` 逐项对齐。**
+# 两边漂了就是双向坏：这里少一个，设置页照样把它画出来，管理员一配，整表覆盖的
+# PUT 被 400 `unknown stage` 顶回来——不是那一行被忽略，是**整张路由表存不进去**；
+# 这里多一个，那个环节在界面上根本不存在，只能改数据库。digest 少了一年多没人发现，
+# 因为它当时偷偷继承 librarian，看起来「能用」（见下面的回退说明）。
 STAGES = (
     "default",
     "agent",
@@ -57,6 +63,7 @@ STAGES = (
     "sextant",
     "relevance",
     "librarian",
+    "digest",
     "extract",
     "embedding",
     "rerank",
@@ -181,10 +188,27 @@ _MEDIUM_CALL_STAGES = frozenset({"agent", "goal_explore", "proposal_review"})
 
 
 def call_profile(stage: str) -> tuple[float, int]:
-    """该环节单次调用的 (超时, 最大尝试次数)。"""
+    """该环节单次调用的 (超时, 最大尝试次数)。
+
+    三个集合都真的参与判定。曾经只判中/长两档、``else`` 一律短档，于是
+    ``_SHORT_CALL_STAGES`` 成了只有测试在读的摆设——它和真实行为可以静默漂移，
+    而测试还一直是绿的。现在漏归类的环节走 ``_SHORT_CALL`` 之前先喊一声：
+    短档 60s 对一个长生成环节是致命的（#386 就是这么把想法生成掐死的），
+    而这种事从日志里看只是「provider 失败」。
+    """
     if stage in _MEDIUM_CALL_STAGES:
         return _MEDIUM_CALL
-    return _LONG_CALL if stage in _LONG_CALL_STAGES else _SHORT_CALL
+    if stage in _LONG_CALL_STAGES:
+        return _LONG_CALL
+    if stage not in _SHORT_CALL_STAGES:
+        logger.warning(
+            "stage %r has no call profile; defaulting to the short budget %s. "
+            "Classify it in router.py, a long stage silently capped at 60s looks "
+            "like a provider outage.",
+            stage,
+            _SHORT_CALL,
+        )
+    return _SHORT_CALL
 
 
 class LLMRouter:

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -283,6 +283,11 @@ class ArxivClient:
         self._max_retries = max(1, max_retries)
         self._backoff_base = backoff_base
 
+    @property
+    def page_size(self) -> int:
+        """一次最多取几条。翻页的调用方按它要页，别自己写死。"""
+        return self._page_size
+
     async def _query_cooldown_remaining(self) -> int:
         if self._redis is None:
             return 0
@@ -299,7 +304,16 @@ class ArxivClient:
         return max(0, int(until - time.time() + 0.999))
 
     async def _start_query_cooldown(self, seconds: int) -> int:
-        seconds = max(_QUERY_COOLDOWN_SECONDS, seconds)
+        """冻结全平台的 arXiv 检索一段时间。**服务器说等多久就等多久。**
+
+        这里原本是 ``max(_QUERY_COOLDOWN_SECONDS, seconds)``——服务器回 ``Retry-After: 5``
+        也照样停 10 分钟。这个冷却是平台级的单键，一个人的建库搜索踩到限流，所有人
+        的检索都跟着停，所以分寸得由对方定：给了 ``Retry-After`` 就信它，没给才用
+        我们自己的保守默认。上限仍然压住，免得一个离谱的响应头把检索冻住半天
+        （和 ``_MAX_BACKOFF_SECONDS`` 同一个道理）。
+        """
+        seconds = seconds if seconds > 0 else _QUERY_COOLDOWN_SECONDS
+        seconds = max(1, min(seconds, _QUERY_COOLDOWN_SECONDS))
         if self._redis is not None:
             try:
                 await self._redis.setex(_QUERY_COOLDOWN_KEY, seconds, str(time.time() + seconds))
@@ -370,7 +384,10 @@ class ArxivClient:
             if attempt + 1 < self._max_retries:
                 await asyncio.sleep(delay)
         cooldown = None
-        if url == API_URL and last_status in (403, 429):
+        # 只有 429 才冻结全平台。403 一并算限流是过度反应：arXiv 的 403 更常见的原因
+        # 是 User-Agent / 来源被拦，那种情况等十分钟不会变好，却把所有人的检索连坐了。
+        # 冷却是单键、平台级的，触发条件必须是「对方明确说你太快了」。
+        if url == API_URL and last_status == 429:
             cooldown = await self._start_query_cooldown(int(last_retry_after or 0))
         raise ArxivRateLimitedError(
             f"arXiv unavailable after {self._max_retries} attempts"
@@ -398,20 +415,24 @@ class ArxivClient:
         exclude: list[str] | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """分类+关键词搜索（日期窗口、可排除词），自动翻页至 limit。"""
-        query = build_search_query(categories or [], keywords or [], since, until, exclude)
+        """分类+关键词搜索（日期窗口、可排除词），自动翻页至 limit。
+
+        翻页逻辑就是 :meth:`search_page` 的循环，不再各写一份：可续跑的建库搜索把
+        循环挪到了调用方（每页一个 checkpoint），这里留一份给不需要断点的调用方。
+        两份各自实现过一次分页终止条件，而只有其中一份有测试——那正是分歧的开始。
+        """
         results: list[dict[str, Any]] = []
         start = 0
         while len(results) < limit:
-            batch = min(self._page_size, limit - len(results))
-            entries = await self._query(
-                {
-                    "search_query": query,
-                    "start": start,
-                    "max_results": batch,
-                    "sortBy": "submittedDate",
-                    "sortOrder": "descending",
-                }
+            batch = min(self.page_size, limit - len(results))
+            entries = await self.search_page(
+                categories=categories,
+                keywords=keywords,
+                since=since,
+                until=until,
+                exclude=exclude,
+                start=start,
+                limit=batch,
             )
             results.extend(entries)
             if len(entries) < batch:  # 已到末页
@@ -430,13 +451,18 @@ class ArxivClient:
         start: int = 0,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """Fetch one stable page so callers can commit a resumable checkpoint."""
+        """取一页（稳定窗口），让调用方能按页提交可续跑的断点。
+
+        ``limit`` 会被压到 :attr:`page_size` 以内，所以调用方判断「到末页了没有」时
+        必须拿 :attr:`page_size` 去要页，别自己写死一个数——写死 100 而客户端页大小
+        是 50 的话，返回 50 会被误判成末页，搜索**静默截断**且不报错。
+        """
         query = build_search_query(categories or [], keywords or [], since, until, exclude)
         return await self._query(
             {
                 "search_query": query,
                 "start": max(0, start),
-                "max_results": max(1, min(self._page_size, limit)),
+                "max_results": max(1, min(self.page_size, limit)),
                 "sortBy": "submittedDate",
                 "sortOrder": "descending",
             }

--- a/src/backend/tests/test_arxiv_resumable_search.py
+++ b/src/backend/tests/test_arxiv_resumable_search.py
@@ -37,6 +37,10 @@ async def test_arxiv_search_resumes_after_the_last_committed_page(client, monkey
     """A failed second page resumes at its saved offset without replaying page one."""
 
     class InterruptingArxiv:
+        # 和真客户端一样对外报页大小。调用方按它要页并据此判末页，替身少了这个属性，
+        # 测试就测不到真实的分页终止路径。
+        page_size = 100
+
         def __init__(self) -> None:
             self.calls: list[dict] = []
             self.interrupted = False
@@ -123,6 +127,13 @@ async def test_arxiv_search_resumes_after_the_last_committed_page(client, monkey
     assert arxiv.calls[0]["since"] == arxiv.calls[2]["since"]
     assert arxiv.calls[0]["until"] == arxiv.calls[2]["until"]
     assert result["found"] == result["inserted"] == 101
+    # 清单跨续跑累计：续跑那一轮内存里只有最后一页的 1 篇，但 observation 报的是
+    # 整次搜索的 101 篇。两者对不上时，看的人无从判断是不是真丢了 100 篇。
+    assert result["new_papers"], "续跑后清单不能是空的"
+    assert result["new_papers"][0]["title"] == "Resumable arXiv result 0", (
+        "清单该从第一页开始，而不是只剩续跑那一页"
+    )
+    assert len({item["id"] for item in result["new_papers"]}) == len(result["new_papers"])
 
     async with get_sessionmaker()() as session:
         run = await session.get(VoyageRun, run_id)
@@ -138,3 +149,43 @@ async def test_arxiv_search_resumes_after_the_last_committed_page(client, monkey
         )
     assert completed["next_start"] == completed["fetched"] == inserted == 101
     assert completed["done"] is True
+
+
+@respx.mock
+async def test_arxiv_403_does_not_freeze_everyone_elses_search():
+    """403 不触发平台级冷却。
+
+    冷却是**单键、全平台**的：一个人的建库搜索踩到它，所有人的检索都停。所以触发
+    条件必须是对方明确说「你太快了」（429）。arXiv 的 403 更常见的原因是 UA/来源
+    被拦——那种情况等十分钟不会变好，却把整个实验室连坐了。
+    """
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    client = ArxivClient(redis=redis, min_interval=0, max_retries=1, backoff_base=0)
+    route = respx.get("https://export.arxiv.org/api/query").mock(return_value=httpx.Response(403))
+
+    with pytest.raises(ArxivRateLimitedError) as first:
+        await client.search_page(keywords=["agents"], limit=1)
+    assert first.value.retry_after is None, "403 不该开冷却"
+
+    # 下一次调用仍然真的打出去（没有被冷却挡在门外）
+    with pytest.raises(ArxivRateLimitedError):
+        await client.search_page(keywords=["agents"], limit=1)
+    assert route.call_count == 2
+    await redis.aclose()
+
+
+@respx.mock
+async def test_cooldown_honours_a_short_retry_after():
+    """服务器说等 5 秒就等 5 秒，不要一律按 10 分钟顶格。
+
+    这个冷却冻的是所有人的检索，分寸该由对方定；顶格只是在没给建议时的兜底。
+    """
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    client = ArxivClient(redis=redis, min_interval=0, max_retries=1, backoff_base=0)
+    respx.get("https://export.arxiv.org/api/query").mock(
+        return_value=httpx.Response(429, headers={"Retry-After": "5"})
+    )
+    with pytest.raises(ArxivRateLimitedError) as caught:
+        await client.search_page(keywords=["agents"], limit=1)
+    assert caught.value.retry_after == 5, "Retry-After 被无视了"
+    await redis.aclose()

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -43,15 +43,25 @@ def test_medium_stages_get_more_patience_without_the_long_profile():
 
 
 def test_every_known_stage_has_exactly_one_call_profile():
-    """新增 stage 时必须显式归类，避免长任务静默回落到 60 秒短档。"""
+    """新增 stage 时必须显式归类，避免长任务静默回落到 60 秒短档。
+
+    这里一度写着 ``classified - known == {"digest"}``，注解是「仅允许已知的内部
+    profile key 不公开为路由」。那不是不变量，是当时 digest 漏进 ``STAGES`` 的
+    bug 被顺手固化了——digest 在设置页上一直是公开可配的一行，只是后端不认，
+    管理员一配整张路由表就存不进去。断言把这个错状态钉成了「约定」，谁去修
+    ``STAGES`` 都会先被它拦下，还以为自己破坏了什么。
+
+    档位集合里不该出现 ``STAGES`` 之外的名字：那种名字要么是拼错的（对应的环节
+    因此静默落回短档），要么就是又一个该公开却没公开的环节。
+    """
     known = set(STAGES)
     short = set(_SHORT_CALL_STAGES)
     medium = set(_MEDIUM_CALL_STAGES)
     long = set(_LONG_CALL_STAGES)
 
     classified = short | medium | long
-    assert known <= classified
-    assert classified - known == {"digest"}, "仅允许已知的内部 profile key 不公开为路由"
+    assert known <= classified, f"这些环节没归档位：{sorted(known - classified)}"
+    assert classified <= known, f"档位集合里有不存在的环节：{sorted(classified - known)}"
     assert short.isdisjoint(medium)
     assert short.isdisjoint(long)
     assert medium.isdisjoint(long)

--- a/src/frontend/src/lib/__tests__/stageRegistry.test.ts
+++ b/src/frontend/src/lib/__tests__/stageRegistry.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { LLM_STAGES } from '../api';
+import { STAGE_LABELS } from '../stageLabels';
+
+/* ============================================================
+   前端的 stage 清单必须和后端 router.py 的 STAGES 逐项一致。
+
+   这是类型检查永远看不见的一类回归，而且两个方向都真的坏过：
+
+   - 前端多一个后端没有的（`digest` 就是这样）：设置页照常把那一行画出来，管理员
+     一配就 400 `unknown stage`。而 PUT 是**整表覆盖**，所以挂掉的不是那一行，是
+     整张路由表——界面只报「保存失败」，没人会想到是某个环节名字对不上。
+     它躲了很久没被发现，因为那时 digest 在后端偷偷继承 librarian，跑起来「像是好的」。
+
+   - 后端多一个前端没有的（`agent` 就是这样）：那个环节在界面上根本不存在，
+     配不了也看不见，只能直接改数据库。
+
+   后端没有跑测试的 CI 工作流，前端有；而 vitest 跑在 node 里读得到后端源码。
+   所以这条守卫放在这边。
+   ============================================================ */
+
+const routerSource = readFileSync(
+  fileURLToPath(new URL('../../../../backend/app/core/llm/router.py', import.meta.url)),
+  'utf-8',
+);
+
+/** 从 router.py 里抠出 STAGES 元组的字面量成员。 */
+const backendStages = (() => {
+  const body = /^STAGES = \(([\s\S]*?)^\)/m.exec(routerSource)?.[1];
+  if (!body) throw new Error('router.py 里找不到 STAGES 元组——改了形状就同步改这里');
+  return [...body.matchAll(/"([a-z_]+)"/g)].map((m) => m[1]!);
+})();
+
+describe('LLM stage 清单', () => {
+  it('后端确实被解析到了（守卫本身不能空跑）', () => {
+    expect(backendStages.length).toBeGreaterThan(10);
+    expect(backendStages).toContain('default');
+  });
+
+  it('前后端逐项一致', () => {
+    expect([...LLM_STAGES].sort()).toEqual([...backendStages].sort());
+  });
+
+  it('每个环节都有大白话名字', () => {
+    const missing = LLM_STAGES.filter((stage) => !STAGE_LABELS[stage]);
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -528,9 +528,14 @@ export interface GateRead {
 
 export type LlmProviderKind = 'openai_compat' | 'anthropic' | 'fake';
 
-/** 与后端 `app/core/llm/router.py` 的 STAGES 保持一致（大白话名字见 lib/stageLabels.ts）。 */
+/** 与后端 `app/core/llm/router.py` 的 STAGES 保持一致（大白话名字见 lib/stageLabels.ts）。
+ *
+ * 逐项对齐不是洁癖：这里多一个后端没有的，管理员一配就会让**整张路由表**存不进去
+ * （PUT 是整表覆盖，遇到未知 stage 直接 400）；这里少一个后端有的，那个环节在界面上
+ * 就不存在，只能改数据库。两边都真实发生过。 */
 export const LLM_STAGES = [
   'default',
+  'agent',
   'navigator',
   'sextant',
   'relevance',

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -6,6 +6,7 @@
  */
 export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   default: { zh: '默认', en: 'Default' },
+  agent: { zh: '文献助手对话', en: 'Literature assistant chat' },
   navigator: { zh: '任务规划', en: 'Task planning' },
   sextant: { zh: '自动校验', en: 'Auto verification' },
   relevance: { zh: '相关度打分', en: 'Relevance scoring' },


### PR DESCRIPTION
Follow-ups to #385, #387 and #389, found while reviewing them. Two commits.

## 1. The settings page showed a stage that could not be saved

The frontend `LLM_STAGES` list and the backend `STAGES` tuple had drifted **in both directions**.

`digest` was in the settings page but not in `STAGES`. `PUT /api/admin/llm/routes` replaces the whole table, so an admin who picked a model for **每日研究简报** did not get that row ignored — the entire routing table failed to save:

```
PUT /api/admin/llm/routes  with a digest row  -> 400 {"detail":"unknown stage: digest"}
                           without it         -> 200
```

It went unnoticed because `digest` used to inherit the `librarian` route, so leaving the row alone looked like it worked. Removing that inheritance in #385 is what made the gap matter: the stage the page offers is now the only way to point the digest anywhere other than Default, and it was rejected on save.

`agent` had the opposite problem — present in `STAGES`, absent from the settings page, configurable only by editing the database.

Both lists now agree, and a vitest guard parses `STAGES` out of `router.py` and compares. It lives on the frontend side because the backend has no test workflow in CI and the frontend does. Verified it fails when either list drifts, not just that it passes.

`call_profile` now consults all three profile sets. `_SHORT_CALL_STAGES` arrived in #387 but nothing except a test read it, so it could drift from behaviour while staying green; an unclassified stage now logs a warning before falling back to the short budget, because a long stage silently capped at 60s reads as a provider outage — which is exactly #386.

The profile test asserted `classified - known == {"digest"}` with the note *"仅允许已知的内部 profile key 不公开为路由"*. That had frozen the missing entry into an invariant and would have blocked this fix. It now requires the two sets to agree.

## 2. arXiv cooldown scope and resumed-run reporting

The resumable search from #389 is sound where it counts — the per-page checkpoint commits through its own session, so progress survives an action that raises, and the cooldown gates only the query endpoint, leaving the RSS daily feed alone. Four things around it:

- **403 no longer arms the cooldown.** It is a single Redis key shared platform-wide, so one search freezes everyone else. arXiv answers 403 when it dislikes a user agent or origin, and ten minutes of waiting does not fix that. Only 429 arms it.
- **A short `Retry-After` is honoured.** `max(600, retry_after)` meant the server could ask for five seconds and get ten minutes. When the wait is imposed on everyone, the server sets the length; our default is the fallback for when it says nothing, and remains the ceiling.
- **`observation["new_papers"]` matches `inserted` again.** The list held only the current attempt while the count covered the whole search, so a resumed run reported 101 new papers and listed one. The list now accumulates through the checkpoint — capped at `_OBS_LIST_CAP`, ids and titles only.
- **`search()` delegates to `search_page`.** It had kept a second pagination loop, and the tests exercised `search()` while production ran the new one. The page size is now asked of the client instead of hardcoded to 100: the loop stops on a short page, so requesting more than the client returns would treat page one as the last and truncate the search silently. The test double gained the same attribute — it did not have it, which is how the divergence stayed invisible.

## Testing

- Backend, 175 passed: `test_literature test_wiki_ingest test_arxiv_resumable_search test_llm_router test_llm_router_tools test_admin_llm test_per_user_llm test_daily_feed test_research_digest_batching`
- Frontend: `tsc --noEmit` clean, `vitest run` 68 passed across 10 files
- New regressions: 403 does not arm the cooldown, a short `Retry-After` is respected, a resumed run lists papers from the first page, and the stage lists agree

## Note

#387 and #389 came from a fork, so these corrections could not be pushed onto their branches. They are here rather than in those PRs, and the original commits keep their authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr