### PR TITLE
feat(papers): support batch paper and anchor input

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -63,6 +63,8 @@ from app.schemas.paper import (
     PaperChatRequest,
     PaperDetail,
     PaperListPage,
+    PaperManualBatchCreate,
+    PaperManualBatchTaskRead,
     PaperManualCreate,
     PaperRead,
     ScoredConcept,
@@ -915,6 +917,32 @@ async def add_library_paper_manually(
     )
     detail = await _paper_detail(session, view, user_id)
     return detail.model_copy(update={"task_id": task_id})
+
+
+@router.post(
+    "/libraries/{library_id}/paper-imports/batch",
+    response_model=PaperManualBatchTaskRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def add_library_papers_manually_batch(
+    library_id: uuid.UUID,
+    data: PaperManualBatchCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> PaperManualBatchTaskRead:
+    """批量添加 1–50 篇文献到指定库；逐项结果通过 paper-task SSE 返回。"""
+    library = await _get_managed_library(session, library_id, user)
+    task_id = await paper_enrich_service.launch_paper_batch_import(
+        redis=redis,
+        items=[item.model_dump() for item in data.items],
+        library_id=library.id,
+        user_id=user.id,
+        project_id=library.project_id,
+    )
+    if task_id is None:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE")
+    return PaperManualBatchTaskRead(task_id=task_id, total=len(data.items))
 
 
 @router.post("/libraries/{library_id}/papers/batch-delete")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -34,6 +34,8 @@ from app.schemas.paper import (
     PaperIndexRebuild,
     PaperIndexStatusRead,
     PaperListPage,
+    PaperManualBatchCreate,
+    PaperManualBatchTaskRead,
     PaperManualCreate,
     PaperMyMetaRead,
     PaperMyMetaUpdate,
@@ -42,6 +44,9 @@ from app.schemas.paper import (
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
+    ResolvedPaperBatchCreate,
+    ResolvedPaperBatchItem,
+    ResolvedPaperBatchRead,
     ResolvedPaperRead,
     TagRead,
 )
@@ -256,6 +261,39 @@ async def add_paper_manually(
     return detail.model_copy(update={"task_id": task_id})
 
 
+@router.post(
+    "/projects/{project_id}/paper-imports/batch",
+    response_model=PaperManualBatchTaskRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def add_papers_manually_batch(
+    project_id: uuid.UUID,
+    data: PaperManualBatchCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> PaperManualBatchTaskRead:
+    """批量添加 1–50 篇文献；逐项提交，部分失败不影响已成功项。"""
+    project = await libraries_service.get_managed_project(session, project_id=project_id, user=user)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    library = await libraries_service.get_library_for_project(session, project_id)
+    if library is None:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail="PROJECT_LIBRARY_NOT_FOUND"
+        )
+    task_id = await paper_enrich_service.launch_paper_batch_import(
+        redis=redis,
+        items=[item.model_dump() for item in data.items],
+        library_id=library.id,
+        user_id=user.id,
+        project_id=project.id,
+    )
+    if task_id is None:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE")
+    return PaperManualBatchTaskRead(task_id=task_id, total=len(data.items))
+
+
 @router.get("/paper-tasks/{task_id}/events")
 async def paper_task_events(
     task_id: str,
@@ -446,6 +484,31 @@ async def resolve_paper_meta(
             str(a.get("name") if isinstance(a, dict) else a)
             for a in (fields.get("authors") or [])
         ][:8],
+    )
+
+
+@router.post("/papers/resolve-batch", response_model=ResolvedPaperBatchRead)
+async def resolve_paper_meta_batch(
+    data: ResolvedPaperBatchCreate,
+    _: User = Depends(current_active_user),
+) -> ResolvedPaperBatchRead:
+    """批量解析锚点元数据；单项失败留在结果中，不影响其它 arXiv id。"""
+    results = await paper_import_service.resolve_arxiv_fields_batch(data.arxiv_ids)
+    return ResolvedPaperBatchRead(
+        items=[
+            ResolvedPaperBatchItem(
+                index=index,
+                arxiv_id=str(fields.get("arxiv_id") or data.arxiv_ids[index]),
+                title=str(fields.get("title") or ""),
+                year=fields.get("year"),
+                authors=[
+                    str(author.get("name") if isinstance(author, dict) else author)
+                    for author in (fields.get("authors") or [])
+                ][:8],
+                error=fields.get("error"),
+            )
+            for index, fields in enumerate(results)
+        ]
     )
 
 

--- a/src/backend/app/core/events.py
+++ b/src/backend/app/core/events.py
@@ -39,7 +39,7 @@ def paper_task_log_key(task_id: str) -> str:
     return f"paper_task:{task_id}:log"
 
 
-_PAPER_TASK_LOG_TTL = 600  # 回放日志存活时间（秒），与归属 key 一致
+_PAPER_TASK_LOG_TTL = 3600  # 批量任务可能较久；与归属 key 一致保留 1 小时
 
 
 async def publish_paper_task_event(

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -182,6 +182,38 @@ class PaperManualCreate(BaseModel):
         return self
 
 
+class PaperManualBatchCreate(BaseModel):
+    """批量手动添加文献；每项仍遵守三来源互斥规则。"""
+
+    items: list[PaperManualCreate] = Field(min_length=1, max_length=50)
+
+
+class PaperManualBatchTaskRead(BaseModel):
+    """批量导入任务已受理；逐项结果通过 paper-task SSE 返回。"""
+
+    task_id: str
+    total: int
+
+
+class ResolvedPaperBatchCreate(BaseModel):
+    """批量解析锚点论文元数据（只读，不入库）。"""
+
+    arxiv_ids: list[str] = Field(min_length=1, max_length=50)
+
+
+class ResolvedPaperBatchItem(BaseModel):
+    index: int
+    arxiv_id: str
+    title: str = ""
+    year: int | None = None
+    authors: list[str] = []
+    error: str | None = None
+
+
+class ResolvedPaperBatchRead(BaseModel):
+    items: list[ResolvedPaperBatchItem]
+
+
 class PaperBatchIds(BaseModel):
     """批量操作（删除/导出）的论文 id 列表。"""
 

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -13,6 +13,7 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
 
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +35,8 @@ EMBED_TEXT_MAX_CHARS = 2000
 # 推送来的论文在语义检索里根本搜不到，而只管一条路径又名不副实。旧键的存量值不迁移，
 # 读不到就取新默认（开）。
 
-_OWNER_TTL_SECONDS = 600  # paper_task_owner 归属 key 存活时间
+_OWNER_TTL_SECONDS = 3600  # 批量任务可能较久；归属 key 与事件回放保留 1 小时
+_ENRICH_SEMAPHORE = asyncio.Semaphore(3)  # 批量导入时限制 PDF/向量/LLM 并发
 
 
 def paper_task_owner_key(task_id: str) -> str:
@@ -298,7 +300,7 @@ async def enrich_paper(
                 await emit("score", "error", f"{type(e).__name__}: {e}")
 
 
-async def _run_enrichment(
+async def _run_enrichment_unbounded(
     *,
     task_id: str,
     paper_id: uuid.UUID,
@@ -350,6 +352,157 @@ async def _run_enrichment(
             logger.warning("failed to publish paper task error event", exc_info=True)
 
 
+async def _run_enrichment(
+    *,
+    task_id: str,
+    paper_id: uuid.UUID,
+    library_id: uuid.UUID | None,
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+    redis: Redis,
+) -> None:
+    """限制单进程内补全并发，避免一次批量导入同时压满上游服务。"""
+    async with _ENRICH_SEMAPHORE:
+        await _run_enrichment_unbounded(
+            task_id=task_id,
+            paper_id=paper_id,
+            library_id=library_id,
+            user_id=user_id,
+            project_id=project_id,
+            redis=redis,
+        )
+
+
+def _batch_input_summary(item: dict[str, Any]) -> tuple[str, str]:
+    for source in ("arxiv_id", "doi", "bibtex"):
+        value = item.get(source)
+        if value:
+            compact = " ".join(str(value).split())
+            return source, compact[:180]
+    return "unknown", ""
+
+
+async def _run_batch_import(
+    *,
+    task_id: str,
+    items: list[dict[str, Any]],
+    library_id: uuid.UUID,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    redis: Redis,
+) -> None:
+    """逐项导入、独立提交，再受控并发补全；一项失败不回滚其它项。"""
+    from app.core.db import get_sessionmaker
+    from app.core.events import EventBus, publish_paper_task_event
+    from app.services import paper_import as paper_import_service
+
+    bus = EventBus(redis)
+    totals = {"created": 0, "existing": 0, "invalid": 0, "failed": 0}
+    enrichment_tasks: list[tuple[int, str]] = []
+
+    try:
+        for index, item in enumerate(items):
+            source, input_value = _batch_input_summary(item)
+            event: dict[str, Any] = {
+                "index": index,
+                "source": source,
+                "input": input_value,
+                "status": "failed",
+            }
+            try:
+                async with get_sessionmaker()() as session:
+                    library = await session.get(DirectionLibrary, library_id)
+                    if library is None:
+                        await publish_paper_task_event(
+                            bus, task_id, "error", {"message": "library not found"}
+                        )
+                        return
+                    try:
+                        result = await paper_import_service.add_manual_paper_to_library(
+                            session,
+                            library=library,
+                            arxiv_id=item.get("arxiv_id"),
+                            doi=item.get("doi"),
+                            bibtex=item.get("bibtex"),
+                            project_id=project_id,
+                        )
+                    except paper_import_service.DuplicatePaperError as e:
+                        paper = await session.get(Paper, e.paper_id)
+                        event.update(
+                            status="existing",
+                            paper_id=str(e.paper_id),
+                            title=paper.title if paper is not None else "",
+                            processing=False,
+                        )
+                    except paper_import_service.ParseFailedError as e:
+                        event.update(status="invalid", error=str(e), processing=False)
+                    else:
+                        paper = result.paper
+                        processing = result.created or not await paper_processing_complete(
+                            session, paper
+                        )
+                        child_task_id: str | None = None
+                        if processing:
+                            child_task_id = await launch_paper_enrichment(
+                                redis=redis,
+                                paper_id=paper.id,
+                                user_id=user_id,
+                                library_id=library_id,
+                                project_id=project_id,
+                            )
+                        if child_task_id:
+                            enrichment_tasks.append((index, child_task_id))
+                        event.update(
+                            status="created",
+                            paper_id=str(paper.id),
+                            title=paper.title,
+                            processing=bool(child_task_id),
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 单项隔离，继续处理后续输入
+                logger.exception("batch paper import item %d failed", index)
+                event.update(status="failed", error=f"{type(e).__name__}: {e}", processing=False)
+
+            status_name = str(event["status"])
+            totals[status_name] += 1
+            await publish_paper_task_event(bus, task_id, "batch_item", event)
+            await publish_paper_task_event(
+                bus,
+                task_id,
+                "batch_progress",
+                {"completed": index + 1, "total": len(items), **totals},
+            )
+
+        async def wait_for_enrichment(index: int, child_task_id: str) -> int:
+            await await_task(child_task_id)
+            return index
+
+        waits = [wait_for_enrichment(index, child_id) for index, child_id in enrichment_tasks]
+        for completed in asyncio.as_completed(waits):
+            index = await completed
+            await publish_paper_task_event(
+                bus, task_id, "batch_enriched", {"index": index}
+            )
+
+        await publish_paper_task_event(
+            bus,
+            task_id,
+            "done",
+            {"total": len(items), **totals},
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("batch paper import task failed: %s", task_id)
+        try:
+            await publish_paper_task_event(
+                bus, task_id, "error", {"message": f"{type(e).__name__}: {e}"}
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to publish batch paper task error event", exc_info=True)
+
+
 async def launch_paper_enrichment(
     *,
     redis: Redis,
@@ -370,6 +523,37 @@ async def launch_paper_enrichment(
         _run_enrichment(
             task_id=task_id,
             paper_id=paper_id,
+            library_id=library_id,
+            user_id=user_id,
+            project_id=project_id,
+            redis=redis,
+        )
+    )
+    _TASKS[task_id] = task
+    task.add_done_callback(lambda t: _TASKS.pop(task_id, None))
+    return task_id
+
+
+async def launch_paper_batch_import(
+    *,
+    redis: Redis,
+    items: list[dict[str, Any]],
+    library_id: uuid.UUID,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+) -> str | None:
+    """登记并启动批量导入父任务；逐项结果与补全状态走同一 SSE 通道。"""
+    task_id = uuid.uuid4().hex
+    try:
+        await redis.setex(paper_task_owner_key(task_id), _OWNER_TTL_SECONDS, str(user_id))
+    except Exception:  # noqa: BLE001
+        logger.warning("batch paper task owner registration failed; import not launched")
+        return None
+
+    task = asyncio.create_task(
+        _run_batch_import(
+            task_id=task_id,
+            items=items,
             library_id=library_id,
             user_id=user_id,
             project_id=project_id,

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -123,6 +123,21 @@ async def _fields_from_openalex_arxiv(arxiv_id: str) -> dict[str, Any]:
     }
 
 
+def _fields_from_arxiv_entry(entry: dict[str, Any], fallback_id: str) -> dict[str, Any]:
+    """把 arXiv 客户端条目转成统一字段；单篇与批量解析共用。"""
+    return {
+        "title": entry["title"],
+        "authors": entry.get("authors"),
+        "abstract": entry.get("abstract"),
+        "year": entry.get("year"),
+        "venue": entry.get("primary_category"),
+        "doi": entry.get("doi"),
+        "url": entry.get("url"),
+        "arxiv_id": entry.get("arxiv_id") or fallback_id,
+        "published_at": _parse_iso(entry.get("published")),
+    }
+
+
 async def _fields_from_arxiv(arxiv_id: str) -> dict[str, Any]:
     normalized = normalize_arxiv_id(arxiv_id)
     try:
@@ -135,17 +150,56 @@ async def _fields_from_arxiv(arxiv_id: str) -> dict[str, Any]:
     entry = next((e for e in entries if e.get("title")), None)
     if entry is None:
         raise ParseFailedError(f"arxiv 上查不到编号 {normalized}")
-    return {
-        "title": entry["title"],
-        "authors": entry.get("authors"),
-        "abstract": entry.get("abstract"),
-        "year": entry.get("year"),
-        "venue": entry.get("primary_category"),
-        "doi": entry.get("doi"),
-        "url": entry.get("url"),
-        "arxiv_id": entry.get("arxiv_id") or normalized,
-        "published_at": _parse_iso(entry.get("published")),
+    return _fields_from_arxiv_entry(entry, normalized)
+
+
+async def resolve_arxiv_fields_batch(arxiv_ids: list[str]) -> list[dict[str, Any]]:
+    """一次请求批量解析 arXiv 元数据，结果与输入顺序一一对应。
+
+    arXiv 支持 ``id_list``，因此 50 个锚点只占一次受限请求。缺失条目再逐项用
+    OpenAlex 兜底；某一项失败只在该项返回 ``error``，不拖垮整批。
+    """
+    normalized = [normalize_arxiv_id(value) for value in arxiv_ids]
+    unique_ids = list(dict.fromkeys(normalized))
+    rate_limited = False
+    try:
+        entries = await get_arxiv_client().fetch_by_ids(unique_ids)
+    except ArxivRateLimitedError:
+        logger.warning("arxiv rate-limited while resolving %d anchors", len(unique_ids))
+        entries = []
+        rate_limited = True
+
+    fields_by_id = {
+        normalize_arxiv_id(str(entry.get("arxiv_id") or "")): _fields_from_arxiv_entry(
+            entry, normalize_arxiv_id(str(entry.get("arxiv_id") or ""))
+        )
+        for entry in entries
+        if entry.get("arxiv_id") and entry.get("title")
     }
+    errors_by_id: dict[str, str] = {}
+    for arxiv_id in unique_ids:
+        if arxiv_id in fields_by_id:
+            continue
+        try:
+            fields_by_id[arxiv_id] = await _fields_from_openalex_arxiv(arxiv_id)
+        except ParseFailedError:
+            errors_by_id[arxiv_id] = (
+                f"arXiv 正在限流，OpenAlex 上也查不到 {arxiv_id}"
+                if rate_limited
+                else f"arxiv 上查不到编号 {arxiv_id}"
+            )
+        except Exception as e:  # noqa: BLE001 — 单个兜底源失败不影响其它锚点
+            logger.warning("anchor metadata fallback failed for %s", arxiv_id, exc_info=True)
+            errors_by_id[arxiv_id] = f"{type(e).__name__}: {e}"
+
+    results: list[dict[str, Any]] = []
+    for arxiv_id in normalized:
+        fields = fields_by_id.get(arxiv_id)
+        if fields is None:
+            results.append({"arxiv_id": arxiv_id, "error": errors_by_id[arxiv_id]})
+        else:
+            results.append(fields)
+    return results
 
 
 async def _fields_from_doi(doi: str) -> dict[str, Any]:

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -1,5 +1,6 @@
 """手动添加文献（docs/api-lit.md §4）：三来源 + 去重 409 + 解析失败/互斥 422，全离线。"""
 
+import json
 import uuid
 
 import fakeredis.aioredis
@@ -262,6 +263,146 @@ async def test_add_mutual_exclusion_422(client):
     assert resp.status_code == 404
 
 
+async def test_batch_add_is_partial_and_reports_each_item(client, fake_redis):
+    """批量导入逐项提交：有效、无效、重复项互不回滚，SSE 给出完整汇总。"""
+    from app.core.events import paper_task_log_key
+    from app.services import paper_enrich
+
+    project_id, headers = await _setup(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/paper-imports/batch",
+        json={
+            "items": [
+                {"bibtex": BIBTEX_ENTRY},
+                {"bibtex": "@article{missing, author={Nobody}}"},
+                {"bibtex": BIBTEX_ENTRY},
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["total"] == 3 and body["task_id"]
+    await paper_enrich.await_task(body["task_id"])
+
+    events = [
+        json.loads(raw)
+        for raw in await fake_redis.lrange(paper_task_log_key(body["task_id"]), 0, -1)
+    ]
+    item_events = [event["data"] for event in events if event["event"] == "batch_item"]
+    assert [item["status"] for item in item_events] == ["created", "invalid", "existing"]
+    assert item_events[0]["paper_id"] == item_events[2]["paper_id"]
+    assert "title" in item_events[0]
+    assert item_events[1]["error"]
+    assert any(event["event"] == "batch_enriched" for event in events)
+    assert events[-1] == {
+        "event": "done",
+        "data": {"total": 3, "created": 1, "existing": 1, "invalid": 1, "failed": 0},
+    }
+
+
+async def test_library_batch_add_endpoint_and_limit(client, fake_redis):
+    """独立的库作用域入口复用同一任务；服务端硬限制最多 50 项。"""
+    from app.services import paper_enrich
+
+    token = await register_and_login(client, email="library-batch@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    _project_id, library_id = await make_project_with_library(
+        client, headers, name="library-batch"
+    )
+    resp = await client.post(
+        f"/api/libraries/{library_id}/paper-imports/batch",
+        json={"items": [{"bibtex": BIBTEX_ENTRY}]},
+        headers=headers,
+    )
+    assert resp.status_code == 202, resp.text
+    await paper_enrich.await_task(resp.json()["task_id"])
+
+    too_many = [{"arxiv_id": f"2406.{index:05d}"} for index in range(51)]
+    resp = await client.post(
+        f"/api/libraries/{library_id}/paper-imports/batch",
+        json={"items": too_many},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_resolve_anchor_batch_keeps_order_and_item_errors(client, monkeypatch):
+    """批量锚点解析一次返回全部结果，失败项不让整个请求变成 422。"""
+    from app.services import paper_import
+
+    async def _fake(arxiv_ids):  # noqa: ANN001
+        assert arxiv_ids == ["2005.11401", "9999.99999"]
+        return [
+            {
+                "arxiv_id": "2005.11401",
+                "title": "Retrieval-Augmented Generation",
+                "year": 2020,
+                "authors": [{"name": "Lewis"}],
+            },
+            {"arxiv_id": "9999.99999", "error": "not found"},
+        ]
+
+    monkeypatch.setattr(paper_import, "resolve_arxiv_fields_batch", _fake)
+    headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
+    resp = await client.post(
+        "/api/papers/resolve-batch",
+        json={"arxiv_ids": ["2005.11401", "9999.99999"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert [item["index"] for item in items] == [0, 1]
+    assert items[0]["title"] == "Retrieval-Augmented Generation"
+    assert items[1]["error"] == "not found" and items[1]["title"] == ""
+
+
+async def test_resolve_anchor_batch_uses_one_arxiv_request_and_falls_back(monkeypatch):
+    """锚点批量解析应合并 arXiv 请求，并只为缺失项调用 OpenAlex。"""
+    from app.services import paper_import
+
+    class _Arxiv:
+        calls: list[list[str]] = []
+
+        async def fetch_by_ids(self, arxiv_ids):  # noqa: ANN001
+            self.calls.append(arxiv_ids)
+            return [
+                {
+                    "arxiv_id": "2005.11401",
+                    "title": "RAG",
+                    "authors": [{"name": "Lewis"}],
+                    "year": 2020,
+                }
+            ]
+
+    class _OpenAlex:
+        calls: list[str] = []
+
+        async def get_by_arxiv(self, arxiv_id):  # noqa: ANN001
+            self.calls.append(arxiv_id)
+            if arxiv_id == "2406.00001":
+                return {"title": "Fallback title", "year": 2024}
+            return None
+
+    arxiv = _Arxiv()
+    openalex = _OpenAlex()
+    monkeypatch.setattr(paper_import, "get_arxiv_client", lambda: arxiv)
+    monkeypatch.setattr(paper_import, "get_openalex_client", lambda: openalex)
+
+    results = await paper_import.resolve_arxiv_fields_batch(
+        ["2005.11401v2", "2406.00001", "9999.99999"]
+    )
+    assert arxiv.calls == [["2005.11401", "2406.00001", "9999.99999"]]
+    assert openalex.calls == ["2406.00001", "9999.99999"]
+    assert [result["arxiv_id"] for result in results] == [
+        "2005.11401",
+        "2406.00001",
+        "9999.99999",
+    ]
+    assert results[1]["title"] == "Fallback title"
+    assert results[2]["error"] == "arxiv 上查不到编号 9999.99999"
+
+
 async def test_resolve_by_arxiv_id_fills_in_the_title(client, monkeypatch):
     """锚点论文只填 arXiv id，题目由系统补上。
 
@@ -277,7 +418,9 @@ async def test_resolve_by_arxiv_id_fills_in_the_title(client, monkeypatch):
     monkeypatch.setattr(paper_import, "resolve_fields", _fake)
     headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
 
-    resp = await client.get("/api/papers/resolve", params={"arxiv_id": "2005.11401"}, headers=headers)
+    resp = await client.get(
+        "/api/papers/resolve", params={"arxiv_id": "2005.11401"}, headers=headers
+    )
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["title"] == "Retrieval-Augmented Generation"
@@ -294,7 +437,9 @@ async def test_resolve_unknown_arxiv_id_is_422(client, monkeypatch):
 
     monkeypatch.setattr(paper_import, "resolve_fields", _fail)
     headers = {"Authorization": f"Bearer {await register_and_login(client)}"}
-    resp = await client.get("/api/papers/resolve", params={"arxiv_id": "9999.99999"}, headers=headers)
+    resp = await client.get(
+        "/api/papers/resolve", params={"arxiv_id": "9999.99999"}, headers=headers
+    )
     assert resp.status_code == 422
     assert resp.json()["detail"] == "ARXIV_ID_NOT_RESOLVED"
 

--- a/src/frontend/src/features/library/PaperBatchProgressModal.tsx
+++ b/src/frontend/src/features/library/PaperBatchProgressModal.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import type { PaperBatchItemResult, PaperBatchItemStatus } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { subscribeSse } from '../../lib/sse';
+
+interface BatchSummary {
+  created: number;
+  existing: number;
+  invalid: number;
+  failed: number;
+}
+
+const EMPTY_SUMMARY: BatchSummary = { created: 0, existing: 0, invalid: 0, failed: 0 };
+
+function statusMeta(status: PaperBatchItemStatus): { zh: string; en: string; icon: 'check' | 'minus' | 'x'; color: string } {
+  if (status === 'created') return { zh: '已添加', en: 'Added', icon: 'check', color: 'var(--ok)' };
+  if (status === 'existing') return { zh: '已存在', en: 'Existing', icon: 'minus', color: 'var(--text-3)' };
+  if (status === 'invalid') return { zh: '格式错误', en: 'Invalid', icon: 'x', color: 'var(--warn)' };
+  return { zh: '添加失败', en: 'Failed', icon: 'x', color: 'var(--danger)' };
+}
+
+export interface PaperBatchProgressModalProps {
+  taskId: string;
+  total: number;
+  onClose: () => void;
+  onDone?: () => void;
+  onOpenPaper?: (paperId: string) => void;
+}
+
+export function PaperBatchProgressModal({
+  taskId,
+  total,
+  onClose,
+  onDone,
+  onOpenPaper,
+}: PaperBatchProgressModalProps) {
+  const [items, setItems] = useState<Record<number, PaperBatchItemResult>>({});
+  const [completed, setCompleted] = useState(0);
+  const [summary, setSummary] = useState<BatchSummary>(EMPTY_SUMMARY);
+  const [done, setDone] = useState(false);
+  const [fatal, setFatal] = useState<string | null>(null);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+
+  useEffect(() => {
+    let stopped = false;
+    const cancel = subscribeSse(`/paper-tasks/${taskId}/events`, {
+      onEvent: (event, data) => {
+        if (stopped) return;
+        try {
+          if (event === 'batch_item') {
+            const item = JSON.parse(data) as PaperBatchItemResult;
+            setItems((prev) => ({ ...prev, [item.index]: item }));
+          } else if (event === 'batch_enriched') {
+            const payload = JSON.parse(data) as { index: number };
+            setItems((prev) => {
+              const item = prev[payload.index];
+              return item ? { ...prev, [payload.index]: { ...item, processing: false } } : prev;
+            });
+          } else if (event === 'batch_progress') {
+            const progress = JSON.parse(data) as BatchSummary & { completed: number };
+            setCompleted(progress.completed);
+            setSummary({
+              created: progress.created,
+              existing: progress.existing,
+              invalid: progress.invalid,
+              failed: progress.failed,
+            });
+          } else if (event === 'done') {
+            const result = JSON.parse(data) as BatchSummary;
+            setSummary(result);
+            setCompleted(total);
+            setDone(true);
+            stopped = true;
+            cancel();
+            onDoneRef.current?.();
+          } else if (event === 'error') {
+            const result = JSON.parse(data) as { message?: string };
+            setFatal(result.message || tr('批量任务失败', 'Batch task failed'));
+            stopped = true;
+            cancel();
+          }
+        } catch {
+          /* 忽略无法解析的事件片段，后续回放仍可继续。 */
+        }
+      },
+    });
+    return () => {
+      stopped = true;
+      cancel();
+    };
+  }, [taskId, total]);
+
+  const orderedItems = useMemo(
+    () => Object.values(items).sort((left, right) => left.index - right.index),
+    [items],
+  );
+  const percent = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0;
+  const stillProcessing = orderedItems.filter((item) => item.processing).length;
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      width={680}
+      title={
+        <>
+          <Icon
+            name={fatal ? 'x' : done ? 'check' : 'refresh'}
+            size={15}
+            style={{
+              color: fatal ? 'var(--danger)' : done ? 'var(--ok)' : 'var(--accent)',
+              animation: !fatal && !done ? 'spin 1s linear infinite' : undefined,
+            }}
+          />
+          {tr('批量添加文献', 'Batch paper import')}
+        </>
+      }
+      sub={tr(
+        `${completed}/${total} 项已解析${stillProcessing ? `，${stillProcessing} 项正在后台处理` : ''}`,
+        `${completed}/${total} parsed${stillProcessing ? `, ${stillProcessing} processing` : ''}`,
+      )}
+      footer={
+        <button className="btn btn-ghost sm" onClick={onClose}>
+          {done ? tr('完成', 'Done') : tr('关闭', 'Close')}
+        </button>
+      }
+    >
+      <div style={{ height: 5, borderRadius: 3, background: 'var(--surface-3)', overflow: 'hidden' }}>
+        <div
+          style={{
+            width: `${percent}%`,
+            height: '100%',
+            background: fatal ? 'var(--danger)' : 'var(--accent)',
+            transition: 'width 180ms ease',
+          }}
+        />
+      </div>
+
+      <div className="row gap12" style={{ marginTop: 12, fontSize: 11.5, color: 'var(--text-2)', flexWrap: 'wrap' }}>
+        <span>{tr('已添加', 'Added')} {summary.created}</span>
+        <span>{tr('已存在', 'Existing')} {summary.existing}</span>
+        <span>{tr('格式错误', 'Invalid')} {summary.invalid}</span>
+        <span>{tr('失败', 'Failed')} {summary.failed}</span>
+      </div>
+
+      <div className="col" style={{ marginTop: 10, maxHeight: 360, overflowY: 'auto' }}>
+        {orderedItems.map((item) => {
+          const meta = statusMeta(item.status);
+          return (
+            <div
+              key={item.index}
+              className="row gap10"
+              style={{ minHeight: 42, padding: '7px 2px', borderBottom: '1px solid var(--border)', alignItems: 'flex-start' }}
+            >
+              <Icon name={meta.icon} size={13} style={{ marginTop: 2, color: meta.color, flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="row gap8" style={{ minWidth: 0 }}>
+                  {item.paper_id && item.title && onOpenPaper ? (
+                    <button
+                      type="button"
+                      className="btn btn-ghost sm"
+                      style={{ minWidth: 0, padding: 0, justifyContent: 'flex-start' }}
+                      onClick={() => onOpenPaper(item.paper_id as string)}
+                    >
+                      <span className="ellipsis">{item.title}</span>
+                    </button>
+                  ) : (
+                    <span className="ellipsis" style={{ fontSize: 12.5 }}>
+                      {item.title || item.input}
+                    </span>
+                  )}
+                  {item.processing && (
+                    <Icon name="refresh" size={11} style={{ color: 'var(--accent)', animation: 'spin 1s linear infinite', flexShrink: 0 }} />
+                  )}
+                </div>
+                {(item.title || item.error) && (
+                  <div
+                    className={item.error ? undefined : 'mono'}
+                    style={{
+                      marginTop: 2,
+                      fontSize: 10.5,
+                      color: item.error ? 'var(--danger-tx)' : 'var(--text-3)',
+                      lineHeight: 1.45,
+                      overflowWrap: 'anywhere',
+                    }}
+                  >
+                    {item.error || item.input}
+                  </div>
+                )}
+              </div>
+              <span style={{ color: meta.color, fontSize: 10.5, whiteSpace: 'nowrap' }}>
+                {tr(meta.zh, meta.en)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {fatal && (
+        <div style={{ marginTop: 12, color: 'var(--danger-tx)', background: 'var(--danger-bg)', padding: '8px 10px', borderRadius: 6 }}>
+          {fatal}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -18,6 +18,7 @@ import {
   type IngestTimeRange,
 } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import { splitPaperInput } from './paperInput';
 
 /* ============================================================
    文献收集 Tab：
@@ -98,7 +99,24 @@ function KnobRange({
   );
 }
 
-/** 锚点论文编辑器：只填 arXiv id，题目由系统补上。
+const MAX_ANCHOR_PAPERS = 50;
+
+function normalizeAnchorArxivId(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^arxiv:\s*/i, '')
+    .replace(/^https?:\/\/(?:www\.)?arxiv\.org\/abs\//i, '')
+    .replace(/v\d+$/i, '');
+}
+
+function parseAnchorIds(raw: string): string[] {
+  const normalized = splitPaperInput(raw)
+    .map(normalizeAnchorArxivId)
+    .filter(Boolean);
+  return [...new Set(normalized)];
+}
+
+/** 锚点论文编辑器：批量填写 arXiv id，题目由系统一次性补上。
  *
  * 从「收录设置」搬到这里——锚点是给「从锚点论文扩展」用的输入，放在收录设置里
  * 与检索/打分的配置混在一起，用户找不到它跟哪个动作有关。 */
@@ -117,23 +135,45 @@ function AnchorEditor({
   const [busy, setBusy] = useState(false);
 
   async function add() {
-    const id = draft.trim();
-    if (!id) return;
-    if (anchors.some((a) => (a.arxiv_id || '').trim() === id)) {
+    const existing = new Set(anchors.map((anchor) => normalizeAnchorArxivId(anchor.arxiv_id || '')));
+    const ids = parseAnchorIds(draft).filter((id) => !existing.has(id));
+    if (ids.length === 0) {
       toast(tr('这篇已经在列表里了', 'Already in the list'), 'info');
+      return;
+    }
+    if (anchors.length + ids.length > MAX_ANCHOR_PAPERS) {
+      toast(
+        tr(
+          `锚点论文最多 ${MAX_ANCHOR_PAPERS} 篇；当前已有 ${anchors.length} 篇。`,
+          `Anchor papers are limited to ${MAX_ANCHOR_PAPERS}; ${anchors.length} already exist.`,
+        ),
+        'error',
+      );
       return;
     }
     setBusy(true);
     try {
-      // 题目自动补：解析不出也照样加进去（id 是有效输入，题目只是给人看的确认）
-      let title = '';
-      try {
-        title = (await api.resolvePaperByArxivId(id)).title;
-      } catch {
-        toast(tr('没解析出题目，已按 id 添加', 'Could not resolve the title — added by id'), 'info');
+      const resolved = await api.resolvePapersByArxivIds(ids);
+      const additions = ids.map((id, index) => ({
+        arxiv_id: resolved.items[index]?.arxiv_id || id,
+        title: resolved.items[index]?.title || '',
+      }));
+      const failed = resolved.items.filter((item) => item.error).length;
+      onChange([...anchors, ...additions]);
+      if (failed > 0) {
+        toast(
+          tr(`${failed} 篇未解析出题目，已按 arXiv ID 添加。`, `${failed} titles could not be resolved; IDs were added.`),
+          'info',
+        );
       }
-      onChange([...anchors, { arxiv_id: id, title }]);
       setDraft('');
+    } catch {
+      onChange([...anchors, ...ids.map((id) => ({ arxiv_id: id, title: '' }))]);
+      setDraft('');
+      toast(
+        tr('题目批量解析暂时不可用，已按 arXiv ID 添加。', 'Title resolution is unavailable; the arXiv IDs were added.'),
+        'info',
+      );
     } finally {
       setBusy(false);
     }
@@ -165,18 +205,32 @@ function AnchorEditor({
         </div>
       )}
       {!disabled && (
-        <div className="row gap8">
-          <input
-            className="input"
-            style={{ flex: 1 }}
+        <div className="col gap8">
+          <textarea
+            className="textarea mono"
+            style={{ width: '100%', minHeight: 94, resize: 'vertical', fontSize: 12 }}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void add(); } }}
-            placeholder={tr('填 arXiv id，如 2005.11401', 'arXiv id, e.g. 2005.11401')}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault();
+                void add();
+              }
+            }}
+            placeholder={tr(
+              '多个 arXiv ID 或 URL 可用空格、逗号或换行分隔\n2005.11401, https://arxiv.org/abs/2406.00001',
+              'Separate multiple arXiv IDs or URLs with spaces, commas, or new lines\n2005.11401, https://arxiv.org/abs/2406.00001',
+            )}
           />
-          <button type="button" className="btn btn-soft sm" disabled={busy || !draft.trim()} onClick={() => void add()}>
-            {busy ? tr('解析中…', 'Resolving…') : tr('添加', 'Add')}
-          </button>
+          <div className="row" style={{ justifyContent: 'flex-end' }}>
+            <button type="button" className="btn btn-soft sm" disabled={busy || !draft.trim()} onClick={() => void add()}>
+              {busy
+                ? tr('解析中…', 'Resolving…')
+                : parseAnchorIds(draft).length > 1
+                  ? tr(`添加 ${parseAnchorIds(draft).length} 篇`, `Add ${parseAnchorIds(draft).length}`)
+                  : tr('添加', 'Add')}
+            </button>
+          </div>
         </div>
       )}
       {libraryId && anchors.length === 0 && (

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -23,8 +23,8 @@ import {
   ApiError,
   type CitationFormat,
   type MyMeta,
+  type PaperBatchImportInput,
   type PaperDetail,
-  type PaperImportInput,
   type PaperRead,
   type PaperSort,
   type PaperStatusFilter,
@@ -47,9 +47,10 @@ import { READING_STATUS, ReadingDot } from '../reading/shared';
 import { PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
-import { PaperProgressModal } from '../library/PaperProgressModal';
+import { PaperBatchProgressModal } from '../library/PaperBatchProgressModal';
 import { paperDragProps } from '../assistant/paperDrag';
 import { clampLines } from '../../lib/clamp';
+import { splitPaperInput } from './paperInput';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -121,6 +122,52 @@ export interface PapersTabProps {
 
 type ImportMethod = 'arxiv' | 'doi' | 'bibtex';
 
+/** 按 BibTeX 条目的配对大括号/圆括号切分，保留坏条目交给后端逐项报错。 */
+function splitBibtexEntries(raw: string): string[] {
+  const entries: string[] = [];
+  let start = -1;
+  let opener = '';
+  let closer = '';
+  let depth = 0;
+  let escaped = false;
+
+  for (let i = 0; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (start < 0) {
+      if (char !== '@') continue;
+      let cursor = i + 1;
+      while (cursor < raw.length && /[A-Za-z]/.test(raw.charAt(cursor))) cursor += 1;
+      while (cursor < raw.length && /\s/.test(raw.charAt(cursor))) cursor += 1;
+      const opening = raw.charAt(cursor);
+      if (opening !== '{' && opening !== '(') continue;
+      start = i;
+      opener = opening;
+      closer = opener === '{' ? '}' : ')';
+      depth = 1;
+      i = cursor;
+      continue;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === opener) depth += 1;
+    if (char === closer) depth -= 1;
+    if (depth === 0) {
+      entries.push(raw.slice(start, i + 1).trim());
+      start = -1;
+    }
+  }
+
+  if (start >= 0) entries.push(raw.slice(start).trim());
+  if (entries.length === 0 && raw.trim()) entries.push(raw.trim());
+  return entries;
+}
+
 function AddPaperModal({
   pid,
   libraryId,
@@ -142,26 +189,19 @@ function AddPaperModal({
   const [doi, setDoi] = useState('');
   const [bibtex, setBibtex] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
-  // 手动添加后若后端返回 task_id，弹出分阶段处理进度
-  const [progress, setProgress] = useState<{ taskId: string; title: string } | null>(null);
+  const [progress, setProgress] = useState<{ taskId: string; total: number } | null>(null);
 
   const invalidateLists = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['papers', scopeId] });
     void queryClient.invalidateQueries({ queryKey: ['ingest-state', scopeId] });
   }, [queryClient, scopeId]);
 
-  const input: PaperImportInput | null =
-    method === 'arxiv'
-      ? arxivId.trim()
-        ? { arxiv_id: arxivId.trim() }
-        : null
-      : method === 'doi'
-        ? doi.trim()
-          ? { doi: doi.trim() }
-          : null
-        : bibtex.trim()
-          ? { bibtex: bibtex.trim() }
-          : null;
+  const batchItems = useMemo<PaperBatchImportInput['items']>(() => {
+    if (method === 'arxiv') return splitPaperInput(arxivId).map((value) => ({ arxiv_id: value }));
+    if (method === 'doi') return splitPaperInput(doi).map((value) => ({ doi: value }));
+    return splitBibtexEntries(bibtex).map((value) => ({ bibtex: value }));
+  }, [arxivId, bibtex, doi, method]);
+  const tooMany = batchItems.length > 50;
 
   const reset = () => {
     setArxivId('');
@@ -171,38 +211,22 @@ function AddPaperModal({
   };
 
   const importMutation = useMutation({
-    mutationFn: (inp: PaperImportInput) => (libraryId ? api.importLibraryPaper(libraryId, inp) : api.importPaper(pid, inp)),
-    onSuccess: (p) => {
-      invalidateLists();
+    mutationFn: (input: PaperBatchImportInput) => (
+      libraryId ? api.importLibraryPapersBatch(libraryId, input) : api.importPapersBatch(pid, input)
+    ),
+    onSuccess: (task) => {
       reset();
       onClose();
-      onImported(p.id);
-      if (p.task_id) {
-        // 还需后处理：弹进度弹窗替代成功 toast，避免重复打扰
-        setProgress({ taskId: p.task_id, title: p.title });
-      } else {
-        toast(tr('文献已加进论文库', 'Paper added to the library'), 'ok');
-      }
+      setProgress({ taskId: task.task_id, total: task.total });
     },
     onError: (e) => {
-      if (e instanceof ApiError && e.status === 409) {
-        const paperId = (e.body as { paper_id?: string } | null | undefined)?.paper_id;
-        toast(tr('这篇论文已经在库中，已为你打开', 'This paper is already in the library — opened it for you'), 'info');
-        reset();
-        onClose();
-        if (paperId) onImported(paperId);
-      } else if (e instanceof ApiError && e.status === 422) {
+      if (e instanceof ApiError && e.status === 422) {
         setParseError(
-          e.message.replace(/^PARSE_FAILED:?\s*/, '') || tr('内容解析失败，请检查格式', 'Failed to parse — check the format'),
+          tr('输入格式不正确，或一次超过 50 篇。', 'Invalid input, or more than 50 papers were submitted.'),
         );
       } else if (e instanceof ApiError && e.status === 503) {
-        // 上游（arXiv/OpenAlex）在限流。说清楚是别人家的问题、以及能怎么办——
-        // 「添加失败」三个字会让用户以为是自己输错了编号。
         setParseError(
-          tr(
-            'arXiv 正在限流，暂时查不到这个编号的元数据。过几分钟再试，或者改用 DOI / BibTeX 添加。',
-            'arXiv is rate-limiting us and the metadata cannot be fetched right now. Try again in a few minutes, or add it by DOI / BibTeX.',
-          ),
+          tr('后台任务服务暂时不可用，请稍后再试。', 'The background task service is temporarily unavailable.'),
         );
       } else {
         toast(`${tr('添加失败：', 'Failed to add: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
@@ -224,8 +248,8 @@ function AddPaperModal({
           </button>
           <button
             className="btn btn-primary sm"
-            disabled={!input || importMutation.isPending}
-            onClick={() => input && importMutation.mutate(input)}
+            disabled={batchItems.length === 0 || tooMany || importMutation.isPending}
+            onClick={() => importMutation.mutate({ items: batchItems })}
           >
             {importMutation.isPending ? (
               <>
@@ -235,7 +259,9 @@ function AddPaperModal({
             ) : (
               <>
                 <Icon name="plus" size={13} />
-                {tr('添加', 'Add')}
+                {batchItems.length > 1
+                  ? tr(`添加 ${batchItems.length} 篇`, `Add ${batchItems.length}`)
+                  : tr('添加', 'Add')}
               </>
             )}
           </button>
@@ -257,10 +283,13 @@ function AddPaperModal({
       <div style={{ marginTop: 14 }}>
         {method === 'arxiv' ? (
           <>
-            <input
-              className="input mono"
-              style={{ width: '100%' }}
-              placeholder={tr('例如 2405.01234 或 2405.01234v2', 'e.g. 2405.01234 or 2405.01234v2')}
+            <textarea
+              className="textarea mono"
+              style={{ width: '100%', minHeight: 112, resize: 'vertical', fontSize: 12 }}
+              placeholder={tr(
+                '多个 arXiv ID 可用空格、逗号或换行分隔\n2405.01234, 2405.01235v2',
+                'Separate multiple arXiv IDs with spaces, commas, or new lines\n2405.01234, 2405.01235v2',
+              )}
               value={arxivId}
               onChange={(e) => {
                 setArxivId(e.target.value);
@@ -270,10 +299,13 @@ function AddPaperModal({
           </>
         ) : method === 'doi' ? (
           <>
-            <input
-              className="input mono"
-              style={{ width: '100%' }}
-              placeholder={tr('例如 10.1145/3567890.1234567', 'e.g. 10.1145/3567890.1234567')}
+            <textarea
+              className="textarea mono"
+              style={{ width: '100%', minHeight: 112, resize: 'vertical', fontSize: 12 }}
+              placeholder={tr(
+                '多个 DOI 可用空格、逗号或换行分隔\n10.1145/3567890.1234567, 10.1000/example',
+                'Separate multiple DOIs with spaces, commas, or new lines\n10.1145/3567890.1234567, 10.1000/example',
+              )}
               value={doi}
               onChange={(e) => {
                 setDoi(e.target.value);
@@ -281,7 +313,7 @@ function AddPaperModal({
               }}
             />
             <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
-              {tr('适合期刊 / 会议论文。', 'Best for journal and conference papers.')}
+              {tr('适合期刊 / 会议论文；最多 50 篇。', 'Best for journal and conference papers; up to 50.')}
             </div>
           </>
         ) : (
@@ -290,8 +322,8 @@ function AddPaperModal({
               className="textarea mono"
               style={{ width: '100%', minHeight: 150, resize: 'vertical', fontSize: 12 }}
               placeholder={tr(
-                '粘贴单条 BibTeX 条目，例如：\n@inproceedings{smith2024example,\n  title = {...},\n  author = {...},\n  year = {2024},\n}',
-                'Paste one BibTeX entry, e.g.:\n@inproceedings{smith2024example,\n  title = {...},\n  author = {...},\n  year = {2024},\n}',
+                '可连续粘贴多条 BibTeX：\n@inproceedings{smith2024example,\n  title = {...},\n  year = {2024},\n}\n\n@article{doe2025example, ...}',
+                'Paste multiple BibTeX entries:\n@inproceedings{smith2024example,\n  title = {...},\n  year = {2024},\n}\n\n@article{doe2025example, ...}',
               )}
               value={bibtex}
               onChange={(e) => {
@@ -301,11 +333,16 @@ function AddPaperModal({
             />
             <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
               {tr(
-                '一次粘贴一条；title 必填，作者/年份/期刊/DOI 能解析多少取多少。',
-                'One entry at a time; title is required — authors/year/venue/DOI are parsed on a best-effort basis.',
+                '最多 50 条；title 必填。无效条目不会阻断其它条目。',
+                'Up to 50 entries; title is required. Invalid entries do not block the others.',
               )}
             </div>
           </>
+        )}
+        {tooMany && (
+          <div style={{ marginTop: 10, fontSize: 11.5, color: 'var(--danger-tx)' }}>
+            {tr(`当前识别到 ${batchItems.length} 篇，一次最多 50 篇。`, `${batchItems.length} detected; the limit is 50.`)}
+          </div>
         )}
         {parseError && (
           <div
@@ -325,11 +362,15 @@ function AddPaperModal({
       </div>
     </Modal>
     {progress && (
-      <PaperProgressModal
+      <PaperBatchProgressModal
         taskId={progress.taskId}
-        paperTitle={progress.title}
+        total={progress.total}
         onClose={() => setProgress(null)}
         onDone={invalidateLists}
+        onOpenPaper={(paperId) => {
+          onImported(paperId);
+          setProgress(null);
+        }}
       />
     )}
     </>

--- a/src/frontend/src/features/wiki/paperInput.test.ts
+++ b/src/frontend/src/features/wiki/paperInput.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { splitPaperInput } from './paperInput';
+
+describe('splitPaperInput', () => {
+  it.each([
+    ['comma', '1709.06158,1711.07280'],
+    ['space', '1709.06158 1711.07280'],
+    ['line feed', '1709.06158\n1711.07280'],
+    ['Windows line ending', '1709.06158\r\n1711.07280'],
+    ['mixed whitespace and punctuation', '1709.06158\t， 1711.07280；'],
+  ])('splits identifiers separated by %s', (_label, input) => {
+    expect(splitPaperInput(input)).toEqual(['1709.06158', '1711.07280']);
+  });
+});

--- a/src/frontend/src/features/wiki/paperInput.ts
+++ b/src/frontend/src/features/wiki/paperInput.ts
@@ -1,0 +1,9 @@
+const PAPER_INPUT_SEPARATOR_RE = /[\s,，;；]+/u;
+
+/** Split pasted paper identifiers on whitespace, commas, or semicolons. */
+export function splitPaperInput(raw: string): string[] {
+  return raw
+    .split(PAPER_INPUT_SEPARATOR_RE)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -907,6 +907,28 @@ export interface HighlightCreateInput {
 /** 手动添加文献：三选一。 */
 export type PaperImportInput = { arxiv_id: string } | { doi: string } | { bibtex: string };
 
+export interface PaperBatchImportInput {
+  items: PaperImportInput[];
+}
+
+export interface PaperBatchTask {
+  task_id: string;
+  total: number;
+}
+
+export type PaperBatchItemStatus = 'created' | 'existing' | 'invalid' | 'failed';
+
+export interface PaperBatchItemResult {
+  index: number;
+  source: 'arxiv_id' | 'doi' | 'bibtex' | 'unknown';
+  input: string;
+  status: PaperBatchItemStatus;
+  paper_id?: string;
+  title?: string;
+  error?: string;
+  processing?: boolean;
+}
+
 export interface TagRead {
   id: string;
   name: string;
@@ -2916,6 +2938,11 @@ export interface ResolvedPaper {
   authors: string[];
 }
 
+export interface ResolvedPaperBatchItem extends ResolvedPaper {
+  index: number;
+  error: string | null;
+}
+
 /** 收录了某篇论文的文献库（带相关度分）。 */
 export interface CollectingLibrary {
   library_id: string;
@@ -3394,6 +3421,10 @@ export const api = {
   importPaper(projectId: string, input: PaperImportInput): Promise<PaperDetail> {
     return requestJson<PaperDetail>(`/projects/${projectId}/papers`, 'POST', input);
   },
+  /** 批量导入 1–50 篇；逐项结果通过返回 task_id 的 SSE 流获取。 */
+  importPapersBatch(projectId: string, input: PaperBatchImportInput): Promise<PaperBatchTask> {
+    return requestJson<PaperBatchTask>(`/projects/${projectId}/paper-imports/batch`, 'POST', input);
+  },
 
   // —— Lit · 标签与个人状态 ——
   listTags(projectId: string): Promise<TagRead[]> {
@@ -3689,6 +3720,10 @@ export const api = {
   /** 手动添加文献到库；409 → PAPER_EXISTS（body 含 paper_id）；422 → PARSE_FAILED。 */
   importLibraryPaper(id: string, input: PaperImportInput): Promise<PaperDetail> {
     return requestJson<PaperDetail>(`/libraries/${id}/papers`, 'POST', input);
+  },
+  /** 批量手动添加到指定库；逐项结果通过 paper-task SSE 获取。 */
+  importLibraryPapersBatch(id: string, input: PaperBatchImportInput): Promise<PaperBatchTask> {
+    return requestJson<PaperBatchTask>(`/libraries/${id}/paper-imports/batch`, 'POST', input);
   },
   /** 批量删除库内论文：默认软删（回收站），hard=true 彻底删除。 */
   batchDeleteLibraryPapers(id: string, paperIds: string[], hard = false): Promise<{ deleted: number }> {
@@ -4957,6 +4992,11 @@ export const api = {
   },
   resolvePaperByArxivId(arxivId: string): Promise<ResolvedPaper> {
     return request<ResolvedPaper>(`/papers/resolve?arxiv_id=${encodeURIComponent(arxivId)}`);
+  },
+  resolvePapersByArxivIds(arxivIds: string[]): Promise<{ items: ResolvedPaperBatchItem[] }> {
+    return requestJson<{ items: ResolvedPaperBatchItem[] }>('/papers/resolve-batch', 'POST', {
+      arxiv_ids: arxivIds,
+    });
   },
   refreshDailyFeed(): Promise<{ status: string; voyage_id: string }> {
     return request<{ status: string; voyage_id: string }>('/daily/refresh', { method: 'POST' });


### PR DESCRIPTION
## Summary

Adds batch paper import and batch anchor resolution so users can paste multiple arXiv IDs, DOIs, or BibTeX entries in one operation. Inputs accept spaces, commas, or line breaks, and per-item failures do not roll back successful imports.

## Area

- [x] frontend
- [x] backend-api
- [x] literature / wiki

## What changed

- Add project- and library-scoped batch import endpoints with a 50-item limit and per-item progress events.
- Add batch arXiv metadata resolution for anchor papers while preserving input order and item-level errors.
- Add batch progress UI and flexible identifier parsing for spaces, commas, semicolons, and line breaks.
- Add backend and frontend regression coverage for batch behavior and separators.

## Testing

- [x] `tsc --noEmit` / frontend build passes (frontend touched)
- [x] Backend tests pass (`16 passed` in `test_paper_manual_add.py`)
- [x] Ruff passes for changed backend modules and tests
- [x] Focused frontend separator tests pass (`5 passed`)

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title (`feat|fix|chore|docs(scope): …`)
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [ ] Screenshots attached for UI changes