### PR TITLE
Per-loop enrichment gate, and a budget for batch anchor fallback

### DIFF
--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -11,6 +11,7 @@ asyncio 任务跑，自开新 AsyncSession，按阶段向 redis 频道发进度�
 import asyncio
 import logging
 import uuid
+import weakref
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -36,7 +37,27 @@ EMBED_TEXT_MAX_CHARS = 2000
 # 读不到就取新默认（开）。
 
 _OWNER_TTL_SECONDS = 3600  # 批量任务可能较久；归属 key 与事件回放保留 1 小时
-_ENRICH_SEMAPHORE = asyncio.Semaphore(3)  # 批量导入时限制 PDF/向量/LLM 并发
+
+#: 批量导入时限制 PDF/向量/LLM 并发。**按事件循环各持一个**，不能做成模块级单例：
+#: ``asyncio.Semaphore`` 一旦真的被争用过就绑死在那个循环上，换一个循环再用会抛
+#: ``RuntimeError: ... is bound to a different event loop``。生产是单循环，碰不到；
+#: 测试每个用例一个新循环，于是「先跑一个会争用的批量导入，再跑第二个」必炸——而且
+#: 炸的是后一个用例，看起来像它自己的毛病。已实测复现：同一个信号量在第二个
+#: ``asyncio.run`` 里争用即抛。
+_ENRICH_CONCURRENCY = 3
+_ENRICH_SEMAPHORES: "weakref.WeakKeyDictionary[Any, asyncio.Semaphore]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _enrich_semaphore() -> asyncio.Semaphore:
+    """当前事件循环的补全并发闸。循环消失后条目自动回收。"""
+    loop = asyncio.get_running_loop()
+    sem = _ENRICH_SEMAPHORES.get(loop)
+    if sem is None:
+        sem = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+        _ENRICH_SEMAPHORES[loop] = sem
+    return sem
 
 
 def paper_task_owner_key(task_id: str) -> str:
@@ -362,7 +383,7 @@ async def _run_enrichment(
     redis: Redis,
 ) -> None:
     """限制单进程内补全并发，避免一次批量导入同时压满上游服务。"""
-    async with _ENRICH_SEMAPHORE:
+    async with _enrich_semaphore():
         await _run_enrichment_unbounded(
             task_id=task_id,
             paper_id=paper_id,
@@ -566,7 +587,15 @@ async def launch_paper_batch_import(
 
 
 async def await_task(task_id: str) -> None:
-    """等待某后台任务跑完（测试用；生产不需要）。"""
+    """等待某后台任务跑完。
+
+    批量导入用它等各篇的补全子任务收尾，好在全部完成后发一条 ``done``——所以这不再
+    只是测试用的助手，docstring 曾经这么写，改坏它会让批量导入的完成事件失准。
+
+    只看得见**本进程**起的任务：``_TASKS`` 是进程内字典。任务已经跑完并被回调摘掉，
+    或者压根是别的进程起的，这里都直接返回——对调用方而言「不知道」和「已完成」
+    同样处理，因为真正的完成信号走 SSE，不靠这个函数。
+    """
     task = _TASKS.get(task_id)
     if task is not None:
         await task

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -153,6 +153,11 @@ async def _fields_from_arxiv(arxiv_id: str) -> dict[str, Any]:
     return _fields_from_arxiv_entry(entry, normalized)
 
 
+#: 批量解析里「逐项兜底」的墙钟预算。接口是同步的，超了就把剩下的记成查不到，
+#: 让调用方拿到一份大部分可用的结果，而不是等到网关掐断、什么都没有。
+_BATCH_FALLBACK_BUDGET_SECONDS = 20.0
+
+
 async def resolve_arxiv_fields_batch(arxiv_ids: list[str]) -> list[dict[str, Any]]:
     """一次请求批量解析 arXiv 元数据，结果与输入顺序一一对应。
 
@@ -177,8 +182,17 @@ async def resolve_arxiv_fields_batch(arxiv_ids: list[str]) -> list[dict[str, Any
         if entry.get("arxiv_id") and entry.get("title")
     }
     errors_by_id: dict[str, str] = {}
-    for arxiv_id in unique_ids:
-        if arxiv_id in fields_by_id:
+    missing = [arxiv_id for arxiv_id in unique_ids if arxiv_id not in fields_by_id]
+
+    # 兜底整体设一个墙钟预算。这个接口是同步 POST，前端开着解析中的对话框等它；
+    # 而缺失项是逐个打 OpenAlex 的，arXiv 一限流就变成「50 个 id 串行请求」——
+    # 最坏情况远超网关超时，用户看到的是转圈转到断线，一条元数据也没拿到。
+    # 超预算的部分不再去查，按「查不到」返回：拿到 45 条加 5 条错误，
+    # 比整个请求超时有用得多。
+    deadline = asyncio.get_running_loop().time() + _BATCH_FALLBACK_BUDGET_SECONDS
+    for arxiv_id in missing:
+        if asyncio.get_running_loop().time() >= deadline:
+            errors_by_id[arxiv_id] = f"解析超时，未能确认 {arxiv_id}（可稍后重试）"
             continue
         try:
             fields_by_id[arxiv_id] = await _fields_from_openalex_arxiv(arxiv_id)

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -1,5 +1,6 @@
 """手动添加文献（docs/api-lit.md §4）：三来源 + 去重 409 + 解析失败/互斥 422，全离线。"""
 
+import asyncio
 import json
 import uuid
 
@@ -490,3 +491,58 @@ async def test_both_sources_down_is_a_parse_error_not_a_crash(monkeypatch):
     with pytest.raises(paper_import.ParseFailedError) as excinfo:
         await paper_import.resolve_fields(arxiv_id="2607.04425")
     assert "限流" in str(excinfo.value)
+
+
+def test_enrich_semaphore_survives_a_second_event_loop():
+    """补全并发闸不能是模块级单例——争用过一次就绑死在那个循环上。
+
+    ``asyncio.Semaphore`` 只在真的需要排队时才记住自己的循环，所以「创建即复用」
+    看起来没问题，直到某个用例的批量导入把它用到争用，下一个用例换了新循环再用
+    就抛 ``RuntimeError: ... is bound to a different event loop``——而且报在后一个
+    用例头上，看起来像它自己的毛病。生产是单循环碰不到，测试必踩。
+    """
+    import asyncio
+
+    from app.services.paper_enrich import _ENRICH_CONCURRENCY, _enrich_semaphore
+
+    async def contend() -> list[int]:
+        async def one(i: int) -> int:
+            async with _enrich_semaphore():
+                await asyncio.sleep(0)
+                return i
+
+        # 并发数必须超过闸门宽度，否则根本不会排队，也就测不到绑定
+        return await asyncio.gather(*(one(i) for i in range(_ENRICH_CONCURRENCY + 2)))
+
+    assert asyncio.run(contend()) == list(range(_ENRICH_CONCURRENCY + 2))
+    assert asyncio.run(contend()) == list(range(_ENRICH_CONCURRENCY + 2)), "换个循环就用不了了"
+
+
+async def test_batch_anchor_resolution_gives_up_instead_of_hanging(monkeypatch):
+    """逐项兜底有墙钟预算；超了把剩下的记成查不到，不把同步请求拖到网关超时。
+
+    arXiv 一限流，缺失项就变成逐个打 OpenAlex。50 个锚点串行请求远超网关耐心，
+    用户看到的是转圈到断线、一条都拿不到——那还不如拿回大部分加几条明确的失败。
+    """
+    from app.services import paper_import as svc
+
+    async def never_returns_quickly(arxiv_id: str):
+        await asyncio.sleep(0.05)
+        raise svc.ParseFailedError(f"nope {arxiv_id}")
+
+    class _RateLimited:
+        async def fetch_by_ids(self, ids):
+            raise svc.ArxivRateLimitedError("simulated")
+
+    monkeypatch.setattr(svc, "get_arxiv_client", lambda: _RateLimited())
+    monkeypatch.setattr(svc, "_fields_from_openalex_arxiv", never_returns_quickly)
+    monkeypatch.setattr(svc, "_BATCH_FALLBACK_BUDGET_SECONDS", 0.12)
+
+    ids = [f"2608.{i:05d}" for i in range(30)]
+    results = await svc.resolve_arxiv_fields_batch(ids)
+
+    assert len(results) == len(ids), "顺序与条数必须和输入一一对应"
+    assert all(r.get("error") for r in results), "这一批全都该带错误"
+    timed_out = [r for r in results if "解析超时" in str(r.get("error"))]
+    assert timed_out, "预算用尽后剩下的该直接记成超时，而不是继续逐个等"
+    assert len(timed_out) < len(ids), "预算没用完之前该老老实实地查"


### PR DESCRIPTION
Follow-up to #391, from reviewing it. Merged the PR first because its own tests were green (backend 56 passed, frontend `tsc` clean + 73 passed); these are the three things that surfaced during review.

## Enrichment gate bound itself to one event loop

`_ENRICH_SEMAPHORE` was a module-level `asyncio.Semaphore(3)`. A semaphore only records its loop once it actually has to make someone wait, so an uncontended one looks portable. Reproduced the failure directly:

```
loop1: [0, 1, 2, 3, 4]
loop2 RuntimeError: <asyncio.locks.Semaphore ... [locked]> is bound to a different event loop
```

Production runs a single loop and never hits it. Tests get a fresh loop per case, so the first batch import that actually contends the gate arms it, and a later test fails — reporting the error against the *later* test, which reads like that test is broken. It is now created per running loop, held in a `WeakKeyDictionary` so entries go when loops do.

The regression test contends the gate (concurrency above the gate width — otherwise nothing queues and the binding never happens) across two `asyncio.run` calls. Verified it fails when the gate is put back to a module-level singleton, so it is testing the thing it claims to.

## Batch anchor fallback could outlive the request

`resolve_arxiv_fields_batch` sends one `id_list` query, which is the right shape — 50 anchors cost one rate-limited request. But anything the batch does not return falls back to OpenAlex **one id at a time**, and that path is entered precisely when arXiv is rate-limiting. Fifty anchors then become fifty sequential requests behind a synchronous POST while the user watches a spinner, and the likely outcome is a gateway timeout with nothing returned.

The fallback loop now runs against a wall-clock budget and marks the remainder unresolved. Returning 45 resolved plus 5 explicit failures is worth more than a timeout.

## `await_task` docstring

It said "测试用；生产不需要" while the batch importer had begun using it to wait for child enrichment tasks before emitting `done`. Corrected, including what it does when the task is not in this process — `_TASKS` is per-process, and the real completion signal is the SSE stream.

## Testing

- Backend, 81 passed: `test_paper_manual_add test_paper_add_progress test_library_paper_management test_enrich_chunk_index test_paper_index_status test_literature`
- Ruff clean on the changed modules
- Both new tests verified to fail when their fix is reverted

## Not changed

`/papers/resolve-batch` is authorised with `current_active_user` only, with no project or library scoping. That matches the existing single-item `resolve_paper_meta`, so it is not a regression — but it is now a 50x amplifier on a shared arXiv budget, and a 429 there arms the platform-wide cooldown from #389. Worth deciding separately whether anchor resolution should be scoped or throttled per user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr