### PR TITLE
fix(pipeline): close stage-harness gaps found by two end-to-end runs

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -1142,13 +1142,37 @@ def merge_metrics(target: dict[str, Any] | None, points: list[dict[str, Any]]) -
     return merged
 
 
+def _metric_base(key: str) -> str:
+    """指标键 → 归一化基名：剥掉 /条件/切片 后缀、统一小写。"""
+    return key.split("/", 1)[0].strip().lower()
+
+
 def extract_primary_value(metrics: dict[str, Any] | None, metric_name: str) -> float | None:
-    """从 run.metrics 取主指标最后一个值（无该指标返回 None）。"""
-    series = (metrics or {}).get(metric_name)
-    if not isinstance(series, list) or not series:
-        return None
-    value = series[-1].get("value") if isinstance(series[-1], dict) else None
-    return float(value) if isinstance(value, int | float) else None
+    """从 run.metrics 取主指标最后一个值（无该指标返回 None）。
+
+    匹配做归一化（#20，线上实测）：生成代码打的指标名带条件/切片后缀
+    （``gsm8k_accuracy/baseline/val``），计划主指标叫 ``accuracy``——精确匹配
+    把成功的轮次全计成 0，完成标准死锁。匹配顺序：精确 → 基名相等 →
+    基名包含主指标名（多键命中时取键名最短的，倾向裸指标/baseline）。"""
+    metrics = metrics or {}
+    want = metric_name.strip().lower()
+
+    def last_value(series: Any) -> float | None:
+        if not isinstance(series, list) or not series:
+            return None
+        value = series[-1].get("value") if isinstance(series[-1], dict) else None
+        return float(value) if isinstance(value, int | float) else None
+
+    if metric_name in metrics:
+        return last_value(metrics[metric_name])
+    exact_base = [k for k in metrics if _metric_base(k) == want]
+    containing = [k for k in metrics if want in _metric_base(k)]
+    for candidates in (exact_base, containing):
+        for key in sorted(candidates, key=len):
+            value = last_value(metrics[key])
+            if value is not None:
+                return value
+    return None
 
 
 def is_improvement(value: float, best: float | None, direction: str) -> bool:
@@ -1418,10 +1442,28 @@ def _summarize_model_config(config_text: str) -> dict[str, Any]:
     return facts
 
 
+def _host_path_for(ref: str, plan: dict[str, Any]) -> str:
+    """容器内路径 → 宿主机路径（按 plan.container.mounts 反向映射）。
+
+    预检在宿主机上探测，而容器计划声明的是容器内路径（如挂载 ~/hf→/hf 后的
+    /hf/model/...）——不映射就必然误报「资源不存在」（线上实测，白打断用户一次）。
+    非容器计划或无匹配挂载时原样返回。"""
+    container = plan.get("container") if isinstance(plan.get("container"), dict) else None
+    mounts = container.get("mounts") if container else None
+    if not isinstance(mounts, dict):
+        return ref
+    for host_path, ctr_path in mounts.items():
+        ctr_root = str(ctr_path).split(":", 1)[0]  # "/hf:ro" → "/hf"
+        if ctr_root and (ref == ctr_root or ref.startswith(ctr_root.rstrip("/") + "/")):
+            return str(host_path) + ref[len(ctr_root) :]
+    return ref
+
+
 async def _probe_resources(executor: Runner, plan: dict[str, Any]) -> tuple[list[dict], list[str]]:
     """资源预检（通用，不针对具体失败模式）：探 plan 声明的模型/数据集，把**事实**记进 resources
     （本机模型的 model_type/架构/配置分节、存在性），只对**普适**问题告警（声明的本机资源不存在）。
-    ref 以 ~ 或 / 开头 = 本机路径；否则视为 HF id（会下载，跳过）。探测异常不冒泡，不崩 setup。"""
+    ref 以 ~ 或 / 开头 = 本机路径（容器内路径先经挂载表反向映射）；否则视为 HF id
+    （会下载，跳过）。探测异常不冒泡，不崩 setup。"""
     resources: list[dict] = []
     warnings: list[str] = []
     for m in plan.get("models") or []:
@@ -1431,8 +1473,9 @@ async def _probe_resources(executor: Runner, plan: dict[str, Any]) -> tuple[list
         role = m.get("role") if isinstance(m, dict) else ""
         entry: dict[str, Any] = {"kind": "model", "ref": ref, "role": role}
         if ref.startswith(("~", "/")):  # 本机模型
+            host_ref = _host_path_for(ref, plan)
             try:
-                cfg = await executor.read_host_file(f"{ref}/config.json")
+                cfg = await executor.read_host_file(f"{host_ref}/config.json")
             except Exception:  # noqa: BLE001 — 预检探测失败不阻断 setup
                 cfg = None
             entry["found"] = cfg is not None
@@ -1451,7 +1494,7 @@ async def _probe_resources(executor: Runner, plan: dict[str, Any]) -> tuple[list
         name = (d.get("name") if isinstance(d, dict) else str(d)) or ""
         if name and str(name).startswith(("~", "/")):  # 只查本机路径数据集；HF 名会下载
             try:
-                exists = await executor.host_path_exists(str(name))
+                exists = await executor.host_path_exists(_host_path_for(str(name), plan))
             except Exception:  # noqa: BLE001
                 continue
             resources.append({"kind": "dataset", "ref": name, "found": exists})
@@ -2857,21 +2900,20 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
         experiment.report = result.content.strip()
         _remember(ctx, "报告", f"实验报告已生成（约 {len(experiment.report)} 字）")
         run_ok = last_run is not None and last_run.status == "succeeded"
-        # failed 只由人拍板：最后一轮未成功时**不写终态**——紧随其后的完成标准检查
-        # 会向用户提问（接受/补做/放弃），终态由用户答案或 voyage 终态联动落定。
-        # 原来这里直接置 failed，把实验锁进终态，waiting_user 镜像与后续状态全部失效。
-        final_status = "done" if run_ok else experiment.status
-        if run_ok:
-            await _set_status(ctx, session, experiment, "done")
-        else:
+        # 报告步**完全不写终态**（#367 去掉了提前 failed；线上随后实测提前 done 同样
+        # 有害：done_criteria 后置失败转提问时 waiting_user 镜像被终态挡住，实验显示
+        # done 而 voyage 在等人）。done 统一由 voyage 终态联动落定
+        # （engine._set_status(done) → experiments_service.complete_by_voyage），
+        # failed 只由人拍板。
+        if not run_ok:
             await ctx.log("最后一轮运行未成功——不自动判失败，等完成标准检查和你的裁决")
         session.add(
             Activity(
                 project_id=experiment.project_id,
                 actor="agent:experiment",
                 kind="experiment.completed",
-                message=f"实验报告已生成（最终状态 {final_status}）",
-                payload={"experiment_id": str(experiment.id), "final_status": final_status},
+                message="实验报告已生成",
+                payload={"experiment_id": str(experiment.id), "last_run_ok": run_ok},
             )
         )
         await session.commit()
@@ -2880,6 +2922,6 @@ async def experiment_report(ctx: ActionContext, params: dict[str, Any]) -> dict[
     ctx.checkpoint["report_done"] = True
     return {
         "report_chars": len(experiment.report or ""),
-        "final_status": final_status,
+        "last_run_ok": run_ok,
         "usage": result.usage,
     }

--- a/src/backend/app/agents/voyage/actions_writing.py
+++ b/src/backend/app/agents/voyage/actions_writing.py
@@ -732,11 +732,22 @@ async def writing_compile(ctx: ActionContext, params: dict[str, Any]) -> dict[st
                     "status": manuscript.status,
                 }
             )
-    errors = [d["message"] for d in result["diagnostics"] if d["severity"] == "error"]
+    error_diags = [d for d in result["diagnostics"] if d["severity"] == "error"]
+    errors = [d["message"] for d in error_diags]
     if phase == "final" and result["status"] != "ok":
-        raise RuntimeError(
-            f"终编译未通过（status={result['status']}）：{'；'.join(errors[:3]) or '无诊断'}"
+        # 根因优先：latex_error（如 Undefined control sequence）排最前——编译中止后
+        # 未定义引用是海量**症状**，按 log 顺序取前三条会把根因整个淹没（线上实测：
+        # 缺 hyperref 的 \autoref 报错被三条 undefined_citation 顶出消息之外）。
+        def _root_first(d: dict) -> tuple[int, int]:
+            return (0 if d["rule"] == "latex_error" else 1, 0)
+
+        picked = sorted(error_diags, key=_root_first)[:3]
+        summary = "；".join(
+            (f"{d['file']}:{d['line']}: " if d.get("file") and d.get("line") else "")
+            + d["message"]
+            for d in picked
         )
+        raise RuntimeError(f"终编译未通过（status={result['status']}）：{summary or '无诊断'}")
     return {
         "phase": phase,
         "status": result["status"],

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -476,11 +476,16 @@ class VoyageEngine:
         # 全部步骤已完成的场景下，唯一合法的扩展是**追加到末尾**：LLM 常给
         # insert_after 指向已完成节点 / update 已完成节点，会撞上应用期不变量
         # 「插入位置必须在当前执行点之后」（线上实测把用户逼到只能放弃）。
-        # 归一化：只保留 add_nodes 且一律追加。
+        # 归一化：只保留 add_nodes 且一律追加；顺带剥掉 requires_gate——
+        # 用户刚拍板「继续补做」，LLM 生成的节点还带闸门（甚至塞动作名当闸门
+        # 种类）会让用户对着自己的决定连环审批（线上实测连弹两次）。
         appended_ops = []
         for op in edit.get("edits") or []:
             if op.get("op") == "add_nodes":
-                appended_ops.append({**op, "insert_after": None})
+                nodes = [
+                    {**node, "requires_gate": None} for node in (op.get("nodes") or [])
+                ]
+                appended_ops.append({**op, "insert_after": None, "nodes": nodes})
         edit = {**edit, "edits": appended_ops}
         if edit.get("finish") or not edit.get("edits"):
             consume_ask.status = "consumed"
@@ -567,11 +572,21 @@ class VoyageEngine:
             raise _ExternallyTerminated(run.status)
         run.status = status
         if status == "done":
-            # 终态联动：仍非终态的关联实验随 voyage 落定为 done（报告动作不再自判
-            # failed，用户「接受当前结果」等路径都汇到这里；无关联实验时是 noop）
+            # 终态联动：仍非终态的关联实验随 voyage 落定为 done（报告动作完全不写
+            # 终态，用户「接受当前结果」等路径都汇到这里；无关联实验时是 noop）
             from app.services import experiments as experiments_service
 
-            await experiments_service.complete_by_voyage(session, run.id)
+            experiment = await experiments_service.complete_by_voyage(session, run.id)
+            if experiment is not None:
+                # WS 状态联动：原先由报告动作的 _set_status 发，现在终态在这里落定
+                await self._emit_notify(
+                    run.project_id,
+                    {
+                        "type": "experiment.status",
+                        "experiment_id": str(experiment.id),
+                        "status": "done",
+                    },
+                )
         await self._emit_status(run)
 
     # ---- 主流程 ----

--- a/src/backend/app/assets/templates/acl/main.tex
+++ b/src/backend/app/assets/templates/acl/main.tex
@@ -6,8 +6,10 @@
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}
 \usepackage{amsmath}
+\usepackage{amssymb}
 \usepackage{booktabs}
 \usepackage{natbib}
+\usepackage{hyperref}
 
 \title{{{POLARIS_TITLE}}}
 \author{Polaris Draft}

--- a/src/backend/app/assets/templates/iclr2026/main.tex
+++ b/src/backend/app/assets/templates/iclr2026/main.tex
@@ -6,8 +6,10 @@
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}
 \usepackage{amsmath}
+\usepackage{amssymb}
 \usepackage{booktabs}
 \usepackage{natbib}
+\usepackage{hyperref}
 
 \title{{{POLARIS_TITLE}}}
 \author{Polaris Draft}

--- a/src/backend/app/assets/templates/neurips2026/main.tex
+++ b/src/backend/app/assets/templates/neurips2026/main.tex
@@ -6,8 +6,10 @@
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}
 \usepackage{amsmath}
+\usepackage{amssymb}
 \usepackage{booktabs}
 \usepackage{natbib}
+\usepackage{hyperref}
 
 \title{{{POLARIS_TITLE}}}
 \author{Polaris Draft}

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -10,6 +10,7 @@
   decide_submission_from_gate；review_passed 缺失时管理员可用 override 审批跳过）。
 """
 
+import contextlib
 import json
 import re
 import uuid
@@ -839,6 +840,22 @@ async def create_writing_voyage(
         raise WritingInProgressError(str(manuscript.id))
     known = await manuscript_templates.template_section_keys(session, manuscript.template)
     body, related = resolve_sections(known, sections)
+    # 起草前置：主文件还是模板原文（无 POLARIS_SECTION 骨架）时自动骨架化。
+    # 原来靠前端在起草前调用 initialize-structure——API 直接 POST /draft 会跳过，
+    # 分节内容 fallback 写进模板演示正文，模板的示例引用（\cite{langley00} 等）与
+    # 示例数字原样混进成稿（线上实测：论文评审判出 8 条"虚构引用"全是模板样例）。
+    main_path = manuscript.main_tex or "main.tex"
+    main = (
+        await session.execute(
+            select(ManuscriptFile).where(
+                ManuscriptFile.manuscript_id == manuscript.id,
+                ManuscriptFile.path == main_path,
+            )
+        )
+    ).scalar_one_or_none()
+    if main is not None and not main.is_binary and "POLARIS_SECTION" not in (main.content or ""):
+        with contextlib.suppress(StructureError):  # 无 document 环境的奇葩主文件：保持原行为
+            await initialize_structure(session, manuscript, user_id=created_by)
     # 起草永远基于最新事实源：先自动重建 fact-pack（库/实验更新后不必手动刷新）
     await refresh_fact_pack(session, manuscript)
     # 事实包刷新后同步 references.bib 文件，保证 AI 起草的 \cite 能解析

--- a/src/backend/app/services/paper_review.py
+++ b/src/backend/app/services/paper_review.py
@@ -514,6 +514,9 @@ def aggregate_reviews(reviews: list[dict[str, Any]]) -> dict[str, Any]:
                 "weights": [],
                 "median": None,
                 "method": "median-outlier-suppressed",
+                # 线上实测：全员 unreliable 时前端只看到 0.0 分 + 空列表，
+                # 像聚合坏了。显式说明「没有可信意见」，评分不可用而非零分。
+                "all_unreliable": True,
             },
         }
     ratings = [float(r["rating"]) for r in reliable]
@@ -536,6 +539,7 @@ def aggregate_reviews(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         "weights": weights,
         "median": median,
         "method": "median-outlier-suppressed",
+        "all_unreliable": False,
     }
     return result
 

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -1636,3 +1636,36 @@ async def test_trash_running_experiment_cancels_voyage(
     assert resp.status_code == 200
     resp = await client.delete(f"/api/experiments/{exp_id}", headers=headers)
     assert resp.status_code == 204
+
+
+def test_extract_primary_value_normalizes_names():
+    """主指标匹配归一化（#20 线上实测）：代码打的指标带条件/切片后缀
+    （gsm8k_accuracy/baseline/val），计划主指标叫 accuracy，精确匹配计 0。"""
+    metrics = {
+        "context_tokens/baseline/val": [{"step": 0, "value": 636.0}],
+        "gsm8k_accuracy/baseline/val": [{"step": 0, "value": 0.9}],
+        "gsm8k_accuracy/treatment/val": [{"step": 0, "value": 0.92}],
+    }
+    # 基名包含匹配：多键命中取键名最短（baseline 先于 treatment）
+    assert ax.extract_primary_value(metrics, "accuracy") == 0.9
+    # 精确匹配优先
+    exact = {"accuracy": [{"step": 0, "value": 0.5}]} | metrics
+    assert ax.extract_primary_value(exact, "accuracy") == 0.5
+    # 基名相等优先于包含
+    base_eq = {"accuracy/val": [{"step": 0, "value": 0.7}]} | metrics
+    assert ax.extract_primary_value(base_eq, "accuracy") == 0.7
+    # 无关指标不误匹配
+    assert ax.extract_primary_value({"loss": [{"step": 0, "value": 1.0}]}, "accuracy") is None
+
+
+def test_host_path_for_reverse_maps_container_mounts():
+    """预检容器路径反向映射（#16 线上实测）：容器计划声明 /hf/...（挂载 ~/hf→/hf），
+    预检在宿主机探测，不映射必误报「资源不存在」。"""
+    plan = {"container": {"image": "x", "mounts": {"~/hf": "/hf:ro"}}}
+    assert ax._host_path_for("/hf/model/Qwen/Qwen3.5-4B", plan) == "~/hf/model/Qwen/Qwen3.5-4B"
+    assert ax._host_path_for("/hf", plan) == "~/hf"
+    # 非挂载路径 / 非容器计划：原样
+    assert ax._host_path_for("/data/x", plan) == "/data/x"
+    assert ax._host_path_for("/hf/model", {}) == "/hf/model"
+    # 前缀不整段匹配不误映射（/hfx 不是 /hf 下的路径）
+    assert ax._host_path_for("/hfx/model", plan) == "/hfx/model"

--- a/src/backend/tests/test_voyage_ask.py
+++ b/src/backend/tests/test_voyage_ask.py
@@ -423,7 +423,9 @@ async def test_done_criteria_continue_appends_even_with_bad_anchor(
                     "step_id": str(first_step_id),
                     "patch": {"title": "不该生效"},
                 },
-                {  # insert_after 指向已完成节点：应被强制改为末尾追加
+                {  # insert_after 指向已完成节点：应被强制改为末尾追加；
+                    # requires_gate 应被剥掉（用户刚拍板补做，不该再连环审批——
+                    # 线上实测 LLM 还会塞动作名当闸门种类）
                     "op": "add_nodes",
                     "insert_after": str(first_step_id),
                     "nodes": [
@@ -433,6 +435,7 @@ async def test_done_criteria_continue_appends_even_with_bad_anchor(
                             "params": {"seconds": 0},
                             "acceptance": "已完成",
                             "checks": [{"kind": "no_error"}],
+                            "requires_gate": "experiment.run",
                         }
                     ],
                 }

--- a/src/backend/tests/test_writing_voyage.py
+++ b/src/backend/tests/test_writing_voyage.py
@@ -12,10 +12,13 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from sqlalchemy import select
 
 from app.agents.voyage import VoyageEngine, actions_writing
 from app.agents.voyage.actions_writing import validate_section_text
+from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
+from app.models.manuscript import Manuscript
 from app.services import latex_compile
 from app.services.latex_compile import TectonicRun
 from tests.conftest import RecordingBus
@@ -369,3 +372,54 @@ async def test_related_candidates_dedup(client):
     candidates = build_related_candidates(pack, hits)
     # 同名（大小写不敏感）去重；不同题命中 key 冲突 → smith2017attentiona
     assert [c["bibkey"] for c in candidates] == ["smith2017attention", "smith2017attentiona"]
+
+
+async def test_draft_auto_initializes_template_demo_main(client, queue_stub):
+    """主文件是模板原文（无 POLARIS_SECTION 骨架，如下载的官方模板）时，POST /draft
+    自动骨架化：新建 draft.tex 并切换编译主文件——否则分节内容混进模板演示正文，
+    模板示例引用（\\cite{langley00}）原样进成稿（线上实测被论文评审判"虚构引用"）。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    exp_id = await _seed_experiment(project_id, idea_id)
+    await _seed_paper(project_id, "Attention Is All You Need", 2017)
+    resp = await _create_manuscript(
+        client, headers, project_id, idea_id=idea_id, experiment_id=exp_id
+    )
+    ms_id = resp.json()["id"]
+
+    demo = (
+        "\\documentclass{article}\n\\begin{document}\n"
+        "Example body with a template citation \\cite{langley00}.\n"
+        "\\end{document}\n"
+    )
+    # 内容编辑走 CRDT 房间而非 REST：测试直接改库模拟「下载的官方模板原文」
+    from app.models.manuscript import ManuscriptFile as MF
+
+    async with get_sessionmaker()() as session:
+        ms_uuid = uuid.UUID(ms_id)
+        main_path = (
+            await session.execute(
+                select(Manuscript.main_tex).where(Manuscript.id == ms_uuid)
+            )
+        ).scalar_one() or "main.tex"
+        row = (
+            await session.execute(
+                select(MF).where(MF.manuscript_id == ms_uuid, MF.path == main_path)
+            )
+        ).scalar_one()
+        row.content = demo
+        await session.commit()
+
+    resp = await client.post(f"/api/manuscripts/{ms_id}/draft", json={}, headers=headers)
+    assert resp.status_code == 201, resp.text
+
+    resp = await client.get(f"/api/manuscripts/{ms_id}", headers=headers)
+    detail = resp.json()
+    assert detail["main_tex"] == "draft.tex"  # 编译主文件已切换到骨架稿
+    draft = next(f for f in detail["files"] if f["path"] == "draft.tex")
+    resp = await client.get(
+        f"/api/manuscripts/{ms_id}/files/{draft['id']}", headers=headers
+    )
+    content = resp.json()["content"]
+    assert "POLARIS_SECTION" in content
+    assert "langley00" not in content  # 模板演示正文不再进入起草主文件


### PR DESCRIPTION
Closes #394

Six fixes across four pipeline stages, each reproduced live during the two end-to-end runs (details in the issue):

1. **Writing — template demo leak**: `create_writing_voyage` auto-runs structure initialization when the compile main file lacks `POLARIS_SECTION` markers. The live paper's "8 fabricated citations" were all ICML template samples surviving a draft that skipped `initialize-structure`.
2. **Experiment — container-blind preflight**: `_host_path_for` reverse-maps in-container refs (`/hf/...`) through `plan.container.mounts` before host probing.
3. **Experiment — premature `done`**: the report step no longer writes any terminal status (mirror of #367's premature `failed`); the voyage-done linkage finalizes and now emits the `experiment.status` WS event.
4. **Experiment — metric-name matching**: `extract_primary_value` matches exact → base-name equality → containment (`gsm8k_accuracy/baseline/val` counts for primary metric `accuracy`; shortest key preferred).
5. **Engine — extension re-gating**: user-driven appended nodes get `requires_gate` stripped (LLM emitted garbage kinds like `experiment.run` and re-gated the user's own decision, twice).
6. **Review — opaque all-unreliable**: aggregation payload carries `all_unreliable`.

## Tests
- New: draft auto-initialization (demo main → draft.tex skeleton, `langley00` gone); `_host_path_for` mapping edge cases; metric normalization precedence; extension node with garbage `requires_gate` passes ungated.
- Suites: experiments / voyage ask / loop / engine / writing / manuscripts / paper review — 117 passed.