### PR TITLE
fix(review): exclude trashed ideas from tournaments

### DIFF
--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -915,7 +915,10 @@ async def review_pair(ctx: ActionContext, params: dict[str, Any]) -> dict[str, A
     explicit_ids = _params(ctx).get("idea_ids")
 
     async with get_sessionmaker()() as session:
-        stmt = select(Idea).where(Idea.project_id == ctx.run.project_id)
+        stmt = select(Idea).where(
+            Idea.project_id == ctx.run.project_id,
+            Idea.trashed_at.is_(None),
+        )
         if explicit_ids:
             stmt = stmt.where(Idea.id.in_([uuid.UUID(str(i)) for i in explicit_ids]))
         else:

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -122,7 +122,11 @@ async def create_tournament_voyage(
 
     if data.idea_ids:
         wanted = list(dict.fromkeys(data.idea_ids))
-        stmt = select(Idea.id).where(Idea.project_id == project.id, Idea.id.in_(wanted))
+        stmt = select(Idea.id).where(
+            Idea.project_id == project.id,
+            Idea.id.in_(wanted),
+            Idea.trashed_at.is_(None),
+        )
         found = {row for (row,) in (await session.execute(stmt)).all()}
         missing = [str(i) for i in wanted if i not in found]
         if missing:
@@ -130,7 +134,9 @@ async def create_tournament_voyage(
         participant_count = len(wanted)
     else:
         stmt = select(func.count()).where(
-            Idea.project_id == project.id, Idea.status.in_(("candidate", "under_review"))
+            Idea.project_id == project.id,
+            Idea.status.in_(("candidate", "under_review")),
+            Idea.trashed_at.is_(None),
         )
         participant_count = int((await session.execute(stmt)).scalar_one())
     if participant_count < 2:

--- a/src/backend/tests/test_idea_review.py
+++ b/src/backend/tests/test_idea_review.py
@@ -72,6 +72,36 @@ async def test_tournament_fans_out_per_match_nodes(client, queue_stub):
     assert [s["observation"]["match_index"] for s in match_steps] == [0, 1]
 
 
+async def test_tournament_excludes_trashed_ideas(client, queue_stub):
+    project_id, headers = await _setup_project(client, name="exclude-trashed")
+    visible_ids = [await _seed_idea(project_id, f"当前想法{i}") for i in range(4)]
+    trashed_id = await _seed_idea(project_id, "回收站想法")
+    resp = await client.delete(f"/api/ideas/{trashed_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+
+    # Explicit selection must not provide a way to re-introduce a trashed idea.
+    resp = await client.post(
+        f"/api/projects/{project_id}/review/tournament",
+        json={"idea_ids": [visible_ids[0], trashed_id], "rounds": 1},
+        headers=headers,
+    )
+    assert resp.status_code == 400 and resp.json()["detail"] == "INVALID_IDEA_IDS"
+
+    # Automatic selection sees only the four current ideas, hence two matches.
+    resp = await client.post(
+        f"/api/projects/{project_id}/review/tournament", json={"rounds": 1}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    engine, _ = _make_engine()
+    await engine.run(uuid.UUID(resp.json()["id"]))
+    detail = (await client.get(f"/api/voyages/{resp.json()['id']}", headers=headers)).json()
+    pair_observation = next(
+        s["observation"] for s in detail["steps"] if s["action"] == "review.pair"
+    )
+    assert pair_observation["participants"] == 4
+    assert pair_observation["pairs"] == 2
+
+
 async def test_tournament_debate_elo_and_leaderboard(client, queue_stub):
     project_id, headers = await _setup_project(client)
     idea_a = await _seed_idea(project_id, "想法甲：agent 规划新范式")


### PR DESCRIPTION
## Summary

Exclude soft-deleted ideas from both tournament request validation and worker-side pairing, so trashed records cannot be reintroduced through explicit IDs or automatic selection.

Closes #396

## Area

- [x] backend-api
- [x] voyage (task loop)
- [x] review

## What changed

- Filter tournament participants with `Idea.trashed_at.is_(None)` during request validation and automatic participant counting.
- Apply the same defensive filter in the `review.pair` worker action.
- Reject explicit selections containing a trashed idea as `INVALID_IDEA_IDS`.
- Add regression coverage for explicit and automatic tournament selection.

## Testing

- [x] Backend tests pass (`tests/test_idea_review.py`: 7 passed)
- [x] Ruff passes on all changed backend files

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title
- [x] No migration is required
- [x] No AI attribution / `Co-Authored-By` lines in commits