### PR TITLE
feat(papers): support replaceable pdf sources

### DIFF
--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,6 +41,7 @@ from app.schemas.paper import (
     PaperMyMetaUpdate,
     PaperMyTagsRead,
     PaperMyTagsUpdate,
+    PaperPdfUrlCreate,
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
@@ -626,6 +627,90 @@ async def fetch_paper_pdf(
     except papers_service.PdfFetchFailedError as e:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="PDF_FETCH_FAILED") from e
     return await _paper_detail(session, view, user.id)
+
+
+async def _replace_pdf_and_launch(
+    *,
+    session: AsyncSession,
+    redis: Redis,
+    view: papers_service.PaperView,
+    user: User,
+    content: bytes,
+) -> PaperDetail:
+    await papers_service.replace_pdf_content(session, view.paper, content)
+    task_id = await paper_enrich_service.launch_paper_enrichment(
+        redis=redis,
+        paper_id=view.id,
+        user_id=user.id,
+        library_id=view.library_id,
+        project_id=view.project_id,
+    )
+    refreshed = await papers_service.get_paper_for_user(
+        session,
+        paper_id=view.id,
+        user_id=user.id,
+        with_concepts=True,
+        include_pool=True,
+    )
+    detail = await _paper_detail(session, refreshed, user.id)
+    return detail.model_copy(update={"task_id": task_id})
+
+
+@router.put("/papers/{paper_id}/pdf", response_model=PaperDetail)
+async def upload_paper_pdf(
+    paper_id: uuid.UUID,
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> PaperDetail:
+    """Upload or replace a PDF, then rebuild all PDF-derived artifacts in the background."""
+    from app.services.literature.pdf_source import MAX_PDF_BYTES, PdfValidationError
+
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
+    parts: list[bytes] = []
+    total = 0
+    try:
+        while chunk := await file.read(1024 * 1024):
+            total += len(chunk)
+            if total > MAX_PDF_BYTES:
+                raise HTTPException(
+                    status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="PDF_TOO_LARGE"
+                )
+            parts.append(chunk)
+    finally:
+        await file.close()
+    try:
+        return await _replace_pdf_and_launch(
+            session=session, redis=redis, view=view, user=user, content=b"".join(parts)
+        )
+    except PdfValidationError as e:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+
+
+@router.post("/papers/{paper_id}/fetch-pdf-url", response_model=PaperDetail)
+async def fetch_paper_pdf_url(
+    paper_id: uuid.UUID,
+    data: PaperPdfUrlCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> PaperDetail:
+    """Fetch a public PDF URL safely and install/replace it for this paper."""
+    from app.services.literature.pdf_source import (
+        PdfUrlFetchError,
+        PdfValidationError,
+        download_pdf_url,
+    )
+
+    view = await _get_member_paper(session, paper_id, user, include_pool=True)
+    try:
+        content = await download_pdf_url(data.url)
+        return await _replace_pdf_and_launch(
+            session=session, redis=redis, view=view, user=user, content=content
+        )
+    except (PdfUrlFetchError, PdfValidationError) as e:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
 
 # ---- 论文图片（docs/api-lit.md §6.5） ----

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -222,6 +222,12 @@ class PaperBatchIds(BaseModel):
     hard: bool = False
 
 
+class PaperPdfUrlCreate(BaseModel):
+    """通过公开 URL 补录或替换论文 PDF。"""
+
+    url: str = Field(min_length=8, max_length=4096)
+
+
 class PaperTagsUpdate(BaseModel):
     """整组覆盖论文标签；空数组=清空。"""
 

--- a/src/backend/app/services/literature/pdf_extract.py
+++ b/src/backend/app/services/literature/pdf_extract.py
@@ -62,8 +62,13 @@ def figure_path(paper_id: str, index: int) -> Path:
 
 
 def save_pdf(paper_id: str, content: bytes) -> Path:
+    from app.services.literature.pdf_source import validate_pdf_bytes
+
+    validate_pdf_bytes(content)
     path = papers_dir() / f"{paper_id}.pdf"
-    path.write_bytes(content)
+    tmp = path.with_suffix(".pdf.tmp")
+    tmp.write_bytes(content)
+    tmp.replace(path)
     return path
 
 

--- a/src/backend/app/services/literature/pdf_source.py
+++ b/src/backend/app/services/literature/pdf_source.py
@@ -1,0 +1,91 @@
+"""Generic and safe PDF source handling for user supplied / metadata URLs."""
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+from app.core.config import get_settings
+
+MAX_PDF_BYTES = 100 * 1024 * 1024
+MAX_REDIRECTS = 5
+
+
+class PdfValidationError(ValueError):
+    """The downloaded/uploaded payload is not an acceptable PDF."""
+
+
+class PdfUrlFetchError(RuntimeError):
+    """A remote PDF URL could not be fetched safely."""
+
+
+def validate_pdf_bytes(content: bytes) -> None:
+    if not content.startswith(b"%PDF-"):
+        raise PdfValidationError("文件不是有效的 PDF（缺少 %PDF- 文件头）")
+    if len(content) > MAX_PDF_BYTES:
+        raise PdfValidationError("PDF 超过 100 MB 大小限制")
+
+
+async def _validate_public_url(url: str) -> None:
+    parsed = urlsplit(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise PdfUrlFetchError("仅支持公开的 http/https PDF 链接")
+    if parsed.username or parsed.password:
+        raise PdfUrlFetchError("PDF 链接不能包含用户名或密码")
+    try:
+        literal = ipaddress.ip_address(parsed.hostname)
+        addresses = [literal]
+    except ValueError:
+        try:
+            rows = await asyncio.get_running_loop().getaddrinfo(
+                parsed.hostname,
+                parsed.port or (443 if parsed.scheme == "https" else 80),
+                type=socket.SOCK_STREAM,
+            )
+        except OSError as e:
+            raise PdfUrlFetchError(f"无法解析 PDF 地址：{parsed.hostname}") from e
+        addresses = list({ipaddress.ip_address(row[4][0]) for row in rows})
+    if not addresses or any(not address.is_global for address in addresses):
+        raise PdfUrlFetchError("PDF 链接不能指向本机、内网或保留地址")
+
+
+async def download_pdf_url(url: str) -> bytes:
+    """Download a public PDF with redirect, SSRF and size protections."""
+    current = url.strip()
+    settings = get_settings()
+    async with httpx.AsyncClient(
+        proxy=settings.outbound_proxy or None,
+        timeout=httpx.Timeout(60.0, connect=15.0),
+        follow_redirects=False,
+        headers={"User-Agent": "Polaris/1.0 PDF fetcher"},
+    ) as client:
+        for redirect_count in range(MAX_REDIRECTS + 1):
+            await _validate_public_url(current)
+            try:
+                async with client.stream("GET", current) as response:
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise PdfUrlFetchError("PDF 源返回了无目标的重定向")
+                        if redirect_count >= MAX_REDIRECTS:
+                            raise PdfUrlFetchError("PDF 链接重定向次数过多")
+                        current = urljoin(current, location)
+                        continue
+                    response.raise_for_status()
+                    parts: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > MAX_PDF_BYTES:
+                            raise PdfValidationError("PDF 超过 100 MB 大小限制")
+                        parts.append(chunk)
+            except (PdfValidationError, PdfUrlFetchError):
+                raise
+            except httpx.HTTPError as e:
+                raise PdfUrlFetchError(f"PDF 下载失败：{type(e).__name__}: {e}") from e
+            content = b"".join(parts)
+            validate_pdf_bytes(content)
+            return content
+    raise PdfUrlFetchError("PDF 下载失败")

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -30,6 +30,7 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import (
     Concept,
     Paper,
+    PaperChunk,
     PaperNote,
     PaperTag,
     PaperUserMeta,
@@ -1043,6 +1044,22 @@ async def fetch_pdf(
     except Exception:  # noqa: BLE001
         logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
+    return paper
+
+
+async def replace_pdf_content(session: AsyncSession, paper: Paper, content: bytes) -> Paper:
+    """Atomically install/replace a PDF and invalidate all PDF-derived artifacts."""
+    from app.services.literature.pdf_extract import figures_dir, papers_dir, save_pdf
+
+    txt_path = papers_dir() / f"{paper.id}.txt"
+    if txt_path.exists():
+        txt_path.unlink()
+    shutil.rmtree(figures_dir(str(paper.id)), ignore_errors=True)
+    await session.execute(delete(PaperChunk).where(PaperChunk.paper_id == paper.id))
+    paper.pdf_path = str(save_pdf(str(paper.id), content))
+    paper.full_text_path = None
+    paper.figures = None
+    await session.commit()
     return paper
 
 

--- a/src/backend/tests/test_literature_pdf_sources.py
+++ b/src/backend/tests/test_literature_pdf_sources.py
@@ -1,0 +1,19 @@
+"""Regressions for uploaded and remotely fetched PDF sources."""
+
+import pytest
+
+from app.services.literature import pdf_source
+
+
+def test_pdf_validation_accepts_pdf_header():
+    pdf_source.validate_pdf_bytes(b"%PDF-1.7\ncontent")
+
+
+def test_pdf_validation_rejects_non_pdf_payload():
+    with pytest.raises(pdf_source.PdfValidationError):
+        pdf_source.validate_pdf_bytes(b"<html>not a pdf</html>")
+
+
+async def test_pdf_url_rejects_private_address():
+    with pytest.raises(pdf_source.PdfUrlFetchError):
+        await pdf_source.download_pdf_url("http://127.0.0.1/private.pdf")

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -357,6 +357,43 @@ export function PdfReader({
     },
   });
 
+  const pdfFileInput = useRef<HTMLInputElement | null>(null);
+  const replacePdfMutation = useMutation({
+    mutationFn: (source: { file: File } | { url: string }) =>
+      'file' in source
+        ? api.uploadPaperPdf(paper.id, source.file)
+        : api.fetchPaperPdfUrl(paper.id, source.url),
+    onSuccess: (updated) => {
+      toast(
+        updated.task_id ? 'PDF 已保存，正在后台重建全文和图片' : 'PDF 已保存',
+        'ok',
+      );
+      void queryClient.invalidateQueries({ queryKey: ['paper-pdf', paper.id] });
+      void queryClient.invalidateQueries({ queryKey: ['paper'] });
+    },
+    onError: (e) =>
+      toast(`PDF 补录失败：${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const submitPdfUrl = useCallback(() => {
+    const url = window.prompt('请输入可直接下载的 PDF 链接');
+    if (url?.trim()) replacePdfMutation.mutate({ url: url.trim() });
+  }, [replacePdfMutation]);
+
+  const uploadInput = (
+    <input
+      ref={pdfFileInput}
+      type="file"
+      accept="application/pdf,.pdf"
+      hidden
+      onChange={(e) => {
+        const file = e.target.files?.[0];
+        if (file) replacePdfMutation.mutate({ file });
+        e.currentTarget.value = '';
+      }}
+    />
+  );
+
   // —— 划词：mouseup 后读取选区，落到某一页并归一化 ——
   const captureSelection = useCallback(() => {
     const sel = window.getSelection();
@@ -483,10 +520,12 @@ export function PdfReader({
           desc={
             canFetch
               ? undefined
-              : '这篇论文不是 arXiv 来源，暂时不支持自动下载 PDF，可以通过右上角原文链接查看。'
+              : '可以上传本地 PDF，或提供可直接下载的 PDF 链接。'
           }
           action={
-            canFetch ? (
+            <div className="row gap8" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
+              {uploadInput}
+              {canFetch && (
               <button
                 className="btn btn-primary"
                 disabled={fetchPdfMutation.isPending}
@@ -504,18 +543,24 @@ export function PdfReader({
                   </>
                 )}
               </button>
-            ) : paper.url ? (
-              <a
+              )}
+              <button
+                className={canFetch ? 'btn btn-ghost' : 'btn btn-primary'}
+                disabled={replacePdfMutation.isPending}
+                onClick={() => pdfFileInput.current?.click()}
+              >
+                <Icon name="file" size={14} />
+                上传 PDF
+              </button>
+              <button
                 className="btn btn-ghost"
-                href={paper.url}
-                target="_blank"
-                rel="noreferrer noopener"
-                style={{ textDecoration: 'none' }}
+                disabled={replacePdfMutation.isPending}
+                onClick={submitPdfUrl}
               >
                 <Icon name="link" size={14} />
-                打开原文链接
-              </a>
-            ) : undefined
+                PDF 链接
+              </button>
+            </div>
           }
         />
       </div>
@@ -537,6 +582,22 @@ export function PdfReader({
           value={mode}
           onChange={setMode}
         />
+        {uploadInput}
+        <button
+          className="btn btn-ghost sm"
+          disabled={replacePdfMutation.isPending}
+          onClick={() => pdfFileInput.current?.click()}
+        >
+          替换 PDF
+        </button>
+        <button
+          className="icon-btn"
+          title="通过 PDF 链接替换"
+          disabled={replacePdfMutation.isPending}
+          onClick={submitPdfUrl}
+        >
+          <Icon name="link" size={14} />
+        </button>
         {mode === 'annotate' ? (
           <span className="row gap6" style={{ marginLeft: 'auto' }}>
             <button

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3307,6 +3307,16 @@ export const api = {
   requestPaperPdf(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}/fetch-pdf`, { method: 'POST' });
   },
+  /** 上传并替换 PDF；服务端随后后台重建全文、图片和分块。 */
+  uploadPaperPdf(id: string, file: File): Promise<PaperDetail> {
+    const form = new FormData();
+    form.append('file', file);
+    return request<PaperDetail>(`/papers/${id}/pdf`, { method: 'PUT', body: form });
+  },
+  /** 通过公开 PDF URL 补录或替换。 */
+  fetchPaperPdfUrl(id: string, url: string): Promise<PaperDetail> {
+    return requestJson<PaperDetail>(`/papers/${id}/fetch-pdf-url`, 'POST', { url });
+  },
 
   // —— Lit · 论文图片（docs/api-lit.md §6.5） ——
   /** 论文图片元数据列表；无图返回 []。 */


### PR DESCRIPTION
## Summary

Allow users to upload a PDF or fetch one from a public URL for an existing paper, then rebuild all PDF-derived artifacts so non-arXiv papers remain readable and compilable.

Closes #398

## Area

- [x] frontend
- [x] backend-api
- [x] literature / wiki

## What changed

- Add authenticated endpoints for multipart PDF upload and public PDF URL fetching.
- Validate the PDF header and enforce a 100 MB size limit.
- Protect URL downloads with scheme, credential, DNS/IP, redirect and private-network checks.
- Replace the stored PDF and invalidate stale full text, figures and paper chunks.
- Launch background enrichment after replacement.
- Add upload and URL replacement controls to the PDF reader.
- Add focused regression tests for PDF validation and unsafe URL rejection.

## Testing

- [x] `tsc --noEmit` / frontend production build passes
- [x] Backend tests pass (`tests/test_literature_pdf_sources.py`: 3 passed)
- [x] Ruff passes on all changed backend files

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title
- [x] No migration is required
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [ ] Screenshots attached for UI changes