### PR TITLE
feat(papers): allow uploading missing PDFs

### DIFF
--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -66,6 +66,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["papers"])
 
 _HEARTBEAT_SECONDS = 15.0
+MAX_PDF_UPLOAD_BYTES = 100 * 1024 * 1024
 
 
 async def _reads_with_extras(
@@ -625,6 +626,41 @@ async def fetch_paper_pdf(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="PDF_SOURCE_UNSUPPORTED") from e
     except papers_service.PdfFetchFailedError as e:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="PDF_FETCH_FAILED") from e
+    return await _paper_detail(session, view, user.id)
+
+
+@router.post("/papers/{paper_id}/pdf", response_model=PaperDetail)
+async def upload_paper_pdf(
+    paper_id: uuid.UUID,
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """给尚无 PDF 的可见论文上传原件，并同步完成全文抽取、分块与索引。"""
+    view = await _get_member_paper(
+        session, paper_id, user, with_concepts=True, include_pool=True
+    )
+    content = await file.read(MAX_PDF_UPLOAD_BYTES + 1)
+    if not content:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail="PDF_UPLOAD_EMPTY")
+    if len(content) > MAX_PDF_UPLOAD_BYTES:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="PDF_UPLOAD_TOO_LARGE"
+        )
+    try:
+        await papers_service.upload_pdf(
+            session,
+            view.paper,
+            content,
+            user_id=user.id,
+            project_id=view.project_id,
+        )
+    except papers_service.PdfAlreadyExistsError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="PDF_ALREADY_EXISTS") from exc
+    except papers_service.PdfUploadInvalidError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="PDF_UPLOAD_INVALID"
+        ) from exc
     return await _paper_detail(session, view, user.id)
 
 

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -79,6 +79,14 @@ class PdfFetchFailedError(Exception):
     """PDF 下载失败（上游不可达 / 非 200 等）。"""
 
 
+class PdfAlreadyExistsError(Exception):
+    """论文已经有可用 PDF；上传接口不允许静默覆盖原件。"""
+
+
+class PdfUploadInvalidError(Exception):
+    """上传内容不是可读取的 PDF。"""
+
+
 class PaperView:
     """内容池论文 + 库成员行的合并视角（字段口径与旧单表 Paper 一致）。
 
@@ -954,34 +962,38 @@ async def empty_library_trash(session: AsyncSession, *, library: Any) -> int:
 # ---- PDF 按需补下（docs/api-lit.md §1） ----
 
 
-async def fetch_pdf(
+def _validate_pdf_content(content: bytes) -> None:
+    """校验上传内容确实是至少含一页、无需密码的 PDF。"""
+    if not content.startswith(b"%PDF-"):
+        raise PdfUploadInvalidError("文件头不是 PDF")
+    try:
+        import pymupdf
+
+        with pymupdf.open(stream=content, filetype="pdf") as doc:
+            if doc.needs_pass:
+                raise PdfUploadInvalidError("暂不支持加密 PDF")
+            if doc.page_count < 1:
+                raise PdfUploadInvalidError("PDF 没有页面")
+    except PdfUploadInvalidError:
+        raise
+    except Exception as exc:
+        raise PdfUploadInvalidError(f"PDF 无法读取：{exc}") from exc
+
+
+async def _process_saved_pdf(
     session: AsyncSession,
     paper: Paper,
+    pdf_path: Path,
     *,
     user_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
 ) -> Paper:
-    """按需补下 PDF + 抽全文；已有 PDF 文件时幂等直接返回（只动内容池本体字段）。
+    """对已经落盘的 PDF 执行统一后处理：全文、分块、向量和机构。"""
+    from app.services.literature.pdf_extract import extract_full_text
 
-    - 无 arxiv_id → PdfSourceUnsupportedError（路由映射 400）
-    - 下载失败 → PdfFetchFailedError（路由映射 502）
-    - 全文抽取失败只记日志，不影响 PDF 落盘
-    """
-    from app.services.literature import get_arxiv_client
-    from app.services.literature.pdf_extract import extract_full_text, save_pdf
-
-    if paper.pdf_path and Path(paper.pdf_path).exists():
-        return paper
-    if not paper.arxiv_id:
-        raise PdfSourceUnsupportedError("论文没有 arxiv 编号，暂不支持自动获取 PDF")
-    try:
-        content = await get_arxiv_client().download_pdf(paper.arxiv_id)
-    except asyncio.CancelledError:
-        raise
-    except Exception as e:
-        raise PdfFetchFailedError(f"{type(e).__name__}: {e}") from e
-    pdf_path = save_pdf(str(paper.id), content)
     paper.pdf_path = str(pdf_path)
+    # 新上传/重新取得原件时不能沿用旧全文路径；抽取失败就明确退化为仅有 PDF。
+    paper.full_text_path = None
     try:
         txt_path = await extract_full_text(str(paper.id), pdf_path)
         paper.full_text_path = str(txt_path)
@@ -1006,18 +1018,23 @@ async def fetch_pdf(
     # 发表机构：on_add 模式下全文到手后 LLM 从标题页逐位作者解析机构（此路径原先不补
     # 机构）；on_compile 模式跳过，改由 wiki 编译折叠抽取。失败不影响主流程
     if not paper.affiliations and paper.full_text_path:
-        from app.core.llm.router import get_llm_router
-        from app.services.affiliations import (
-            apply_author_affiliations,
-            extract_author_affiliations_llm,
-            get_affiliation_extraction_mode,
-        )
-
-        if await get_affiliation_extraction_mode(session) == "on_add":
-            mapping = await extract_author_affiliations_llm(
-                paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+        try:
+            from app.core.llm.router import get_llm_router
+            from app.services.affiliations import (
+                apply_author_affiliations,
+                extract_author_affiliations_llm,
+                get_affiliation_extraction_mode,
             )
-            apply_author_affiliations(paper, mapping)
+
+            if await get_affiliation_extraction_mode(session) == "on_add":
+                mapping = await extract_author_affiliations_llm(
+                    paper, llm=get_llm_router(), user_id=user_id, project_id=project_id
+                )
+                apply_author_affiliations(paper, mapping)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "affiliation extraction failed for paper %s", paper.id, exc_info=True
+            )
     await session.commit()
     # 摘要兜底块的向量 = 论文级向量的拷贝（零 token，不受任何开关控制）
     from app.services.chunks import sync_abstract_chunk_vectors
@@ -1044,6 +1061,58 @@ async def fetch_pdf(
         logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
     return paper
+
+
+async def upload_pdf(
+    session: AsyncSession,
+    paper: Paper,
+    content: bytes,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> Paper:
+    """把用户提供的 PDF 接到现有论文，并走与自动下载相同的后处理流水线。"""
+    from app.services.literature.pdf_extract import save_pdf
+
+    if paper.pdf_path and Path(paper.pdf_path).exists():
+        raise PdfAlreadyExistsError(str(paper.id))
+    await asyncio.to_thread(_validate_pdf_content, content)
+    pdf_path = save_pdf(str(paper.id), content)
+    return await _process_saved_pdf(
+        session, paper, pdf_path, user_id=user_id, project_id=project_id
+    )
+
+
+async def fetch_pdf(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> Paper:
+    """按需补下 PDF + 抽全文；已有 PDF 文件时幂等直接返回（只动内容池本体字段）。
+
+    - 无 arxiv_id → PdfSourceUnsupportedError（路由映射 400）
+    - 下载失败 → PdfFetchFailedError（路由映射 502）
+    - 全文抽取失败只记日志，不影响 PDF 落盘
+    """
+    from app.services.literature import get_arxiv_client
+    from app.services.literature.pdf_extract import save_pdf
+
+    if paper.pdf_path and Path(paper.pdf_path).exists():
+        return paper
+    if not paper.arxiv_id:
+        raise PdfSourceUnsupportedError("论文没有 arxiv 编号，暂不支持自动获取 PDF")
+    try:
+        content = await get_arxiv_client().download_pdf(paper.arxiv_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        raise PdfFetchFailedError(f"{type(e).__name__}: {e}") from e
+    pdf_path = save_pdf(str(paper.id), content)
+    return await _process_saved_pdf(
+        session, paper, pdf_path, user_id=user_id, project_id=project_id
+    )
 
 
 # ---- AI 伴读上下文（docs/api-lit.md §3） ----

--- a/src/backend/tests/test_paper_reading.py
+++ b/src/backend/tests/test_paper_reading.py
@@ -2,6 +2,7 @@
 
 import json
 import uuid
+from pathlib import Path
 
 import fakeredis.aioredis
 import httpx
@@ -143,6 +144,58 @@ async def test_fetch_pdf_download_failure_502(client, lit_clients):
     resp = await client.post(f"/api/papers/{paper_id}/fetch-pdf", headers=headers)
     assert resp.status_code == 502
     assert resp.json()["detail"] == "PDF_FETCH_FAILED"
+
+
+async def test_upload_pdf_for_non_arxiv_paper_and_prevent_overwrite(client):
+    _, headers, paper_id = await _setup(client, arxiv_id=None, email="upload@example.com")
+    content = _pdf_bytes("locally supplied full text")
+
+    resp = await client.post(
+        f"/api/papers/{paper_id}/pdf",
+        files={"file": ("paper.pdf", content, "application/pdf")},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pdf_available"] is True
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(paper_id))
+        assert paper.pdf_path and paper.full_text_path
+        assert "locally supplied full text" in Path(paper.full_text_path).read_text(
+            encoding="utf-8"
+        )
+
+    served = await client.get(f"/api/papers/{paper_id}/pdf", headers=headers)
+    assert served.status_code == 200
+    assert served.content == content
+
+    duplicate = await client.post(
+        f"/api/papers/{paper_id}/pdf",
+        files={"file": ("replacement.pdf", _pdf_bytes("replacement"), "application/pdf")},
+        headers=headers,
+    )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "PDF_ALREADY_EXISTS"
+
+
+async def test_upload_pdf_rejects_empty_and_invalid_files(client):
+    _, headers, paper_id = await _setup(client, arxiv_id=None, email="bad-upload@example.com")
+
+    empty = await client.post(
+        f"/api/papers/{paper_id}/pdf",
+        files={"file": ("empty.pdf", b"", "application/pdf")},
+        headers=headers,
+    )
+    assert empty.status_code == 422
+    assert empty.json()["detail"] == "PDF_UPLOAD_EMPTY"
+
+    invalid = await client.post(
+        f"/api/papers/{paper_id}/pdf",
+        files={"file": ("fake.pdf", b"%PDF-not-really-a-pdf", "application/pdf")},
+        headers=headers,
+    )
+    assert invalid.status_code == 422
+    assert invalid.json()["detail"] == "PDF_UPLOAD_INVALID"
 
 
 def _parse_sse(text: str) -> list[tuple[str, dict]]:

--- a/src/frontend/src/features/library/LibraryDetailPane.tsx
+++ b/src/frontend/src/features/library/LibraryDetailPane.tsx
@@ -22,6 +22,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useTopicLibrary } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
+import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
@@ -304,6 +305,7 @@ export function LibraryDetailPane({
             {tr('原文链接', 'Source link')}
           </a>
         )}
+        {alive && <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />}
       </div>
 
       {/* —— 个人状态：星标 + 阅读状态（论文还在才有） —— */}

--- a/src/frontend/src/features/reading/InfoPanel.tsx
+++ b/src/frontend/src/features/reading/InfoPanel.tsx
@@ -14,6 +14,7 @@ import { type PaperConceptRef, type PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { topicPath } from '../../app/project';
 import { PaperMyTagsRow } from '../shared/PaperDetailBlocks';
+import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { MetaFold } from '../wiki/shared';
 
 /* ============================================================
@@ -123,18 +124,21 @@ export function InfoPanel({
           ))}
         </div>
       )}
-      {extUrl && (
-        <a
-          className="btn btn-ghost sm"
-          href={extUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          style={{ textDecoration: 'none', marginTop: 10, display: 'inline-flex' }}
-        >
-          <Icon name="link" size={12} />
-          {arxivUrl ? tr('arXiv 原文', 'View on arXiv') : tr('原文链接', 'Source link')}
-        </a>
-      )}
+      <div className="row gap8 wrap" style={{ marginTop: 10 }}>
+        {extUrl && (
+          <a
+            className="btn btn-ghost sm"
+            href={extUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{ textDecoration: 'none' }}
+          >
+            <Icon name="link" size={12} />
+            {arxivUrl ? tr('arXiv 原文', 'View on arXiv') : tr('原文链接', 'Source link')}
+          </a>
+        )}
+        <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />
+      </div>
 
       {/* —— 元信息（默认折叠） —— */}
       <MetaFold style={{ margin: '14px 0 0' }}>

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -30,6 +30,7 @@ import {
   type PaperDetail,
 } from '../../lib/api';
 import { HIGHLIGHT_COLORS, HIGHLIGHT_STYLES, highlightColorMeta } from './shared';
+import { PdfUploadButton } from '../shared/PdfUploadButton';
 
 /* ============================================================
    自建 PDF 阅读器（pdf.js / react-pdf）：
@@ -485,38 +486,41 @@ export function PdfReader({
               ? undefined
               : '这篇论文不是 arXiv 来源，暂时不支持自动下载 PDF，可以通过右上角原文链接查看。'
           }
-          action={
-            canFetch ? (
-              <button
-                className="btn btn-primary"
-                disabled={fetchPdfMutation.isPending}
-                onClick={() => fetchPdfMutation.mutate()}
-              >
-                {fetchPdfMutation.isPending ? (
-                  <>
-                    <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
-                    正在下载…
-                  </>
-                ) : (
-                  <>
-                    <Icon name="download" size={14} />
-                    获取 PDF
-                  </>
-                )}
-              </button>
-            ) : paper.url ? (
-              <a
-                className="btn btn-ghost"
-                href={paper.url}
-                target="_blank"
-                rel="noreferrer noopener"
-                style={{ textDecoration: 'none' }}
-              >
-                <Icon name="link" size={14} />
-                打开原文链接
-              </a>
-            ) : undefined
-          }
+          action={(
+            <div className="row gap8 wrap" style={{ justifyContent: 'center' }}>
+              {canFetch ? (
+                <button
+                  className="btn btn-primary"
+                  disabled={fetchPdfMutation.isPending}
+                  onClick={() => fetchPdfMutation.mutate()}
+                >
+                  {fetchPdfMutation.isPending ? (
+                    <>
+                      <Icon name="refresh" size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                      {tr('正在下载…', 'Downloading…')}
+                    </>
+                  ) : (
+                    <>
+                      <Icon name="download" size={14} />
+                      {tr('获取 PDF', 'Fetch PDF')}
+                    </>
+                  )}
+                </button>
+              ) : paper.url ? (
+                <a
+                  className="btn btn-ghost"
+                  href={paper.url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Icon name="link" size={14} />
+                  {tr('打开原文链接', 'Open source link')}
+                </a>
+              ) : null}
+              <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />
+            </div>
+          )}
         />
       </div>
     );

--- a/src/frontend/src/features/research/ShelfDetailPane.tsx
+++ b/src/frontend/src/features/research/ShelfDetailPane.tsx
@@ -16,6 +16,7 @@ import { tr } from '../../lib/i18n';
 import { libraryPath, useLibraries } from '../libraries/hooks';
 import { readerFrom } from '../reading/shared';
 import { PaperReader } from '../wiki/PaperReader';
+import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { AffiliationChips, AuthorLinks, MetaFold, usePoolConceptNav } from '../wiki/shared';
 import {
@@ -348,6 +349,7 @@ export function ShelfDetailPane({
             {tr('原文链接', 'Source link')}
           </a>
         )}
+        {paper && <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />}
         {onShelf ? (
           <button
             className="btn btn-ghost sm"

--- a/src/frontend/src/features/shared/PdfUploadButton.tsx
+++ b/src/frontend/src/features/shared/PdfUploadButton.tsx
@@ -1,0 +1,81 @@
+import { useRef } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import { api, ApiError, type PaperDetail } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+function uploadError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.message.includes('PDF_UPLOAD_TOO_LARGE')) {
+      return tr('PDF 超过 100 MB 上限', 'The PDF exceeds the 100 MB limit');
+    }
+    if (error.message.includes('PDF_UPLOAD_INVALID')) {
+      return tr('文件不是有效的 PDF，或 PDF 已加密', 'The file is not a valid PDF or is password-protected');
+    }
+    if (error.message.includes('PDF_UPLOAD_EMPTY')) {
+      return tr('所选 PDF 是空文件', 'The selected PDF is empty');
+    }
+    if (error.message.includes('PDF_ALREADY_EXISTS')) {
+      return tr('这篇论文已经有 PDF', 'This paper already has a PDF');
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function PdfUploadButton({
+  paperId,
+  pdfAvailable,
+}: {
+  paperId: string;
+  pdfAvailable: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (file: File) => api.uploadPaperPdf(paperId, file),
+    onSuccess: (detail) => {
+      queryClient.setQueriesData<PaperDetail>({ queryKey: ['paper'] }, (old) =>
+        old?.id === paperId ? detail : old,
+      );
+      void queryClient.invalidateQueries({ queryKey: ['papers'] });
+      void queryClient.invalidateQueries({ queryKey: ['library'] });
+      void queryClient.invalidateQueries({ queryKey: ['shelf'] });
+      toast(tr('PDF 已上传，可以阅读全文了', 'PDF uploaded — the full paper is ready to read'), 'ok');
+    },
+    onError: (error) => toast(`${tr('上传 PDF 失败：', 'PDF upload failed: ')}${uploadError(error)}`, 'error'),
+  });
+
+  if (pdfAvailable) return null;
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        hidden
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          event.currentTarget.value = '';
+          if (file) mutation.mutate(file);
+        }}
+      />
+      <button
+        type="button"
+        className="btn btn-ghost sm"
+        aria-label={tr('上传 PDF', 'Upload PDF')}
+        aria-busy={mutation.isPending}
+        disabled={mutation.isPending}
+        onClick={() => inputRef.current?.click()}
+      >
+        <Icon
+          name={mutation.isPending ? 'refresh' : 'download'}
+          size={13}
+          style={mutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined}
+        />
+        {mutation.isPending ? tr('上传处理中…', 'Uploading…') : tr('上传 PDF', 'Upload PDF')}
+      </button>
+    </>
+  );
+}

--- a/src/frontend/src/features/shared/__tests__/PdfUploadButton.test.tsx
+++ b/src/frontend/src/features/shared/__tests__/PdfUploadButton.test.tsx
@@ -1,0 +1,26 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { PdfUploadButton } from '../PdfUploadButton';
+
+function render(pdfAvailable: boolean): string {
+  const client = new QueryClient();
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <PdfUploadButton paperId="paper-id" pdfAvailable={pdfAvailable} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('PdfUploadButton', () => {
+  it('没有 PDF 时显示上传入口和 PDF 文件选择器', () => {
+    const html = render(false);
+    expect(html).toContain('type="file"');
+    expect(html).toContain('accept="application/pdf,.pdf"');
+    expect(html).toContain('上传 PDF');
+  });
+
+  it('已经有 PDF 时不渲染任何上传入口', () => {
+    expect(render(true)).toBe('');
+  });
+});

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -14,6 +14,7 @@ import { CompileBadge } from '../../components/ui/CompileBadge';
 import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { PaperReader } from './PaperReader';
 import { readerFrom } from '../reading/shared';
+import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { toast } from '../../components/ui/Toast';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
@@ -916,6 +917,7 @@ function PaperDetailPane({
             {tr('原文链接', 'Source link')}
           </a>
         )}
+        <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />
       </div>
 
       {/* —— 个人状态：星标 + 阅读状态 —— */}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3307,6 +3307,12 @@ export const api = {
   requestPaperPdf(id: string): Promise<PaperDetail> {
     return request<PaperDetail>(`/papers/${id}/fetch-pdf`, { method: 'POST' });
   },
+  /** 给尚无 PDF 的论文上传本地原件；后端会继续抽全文、分块并建立索引。 */
+  uploadPaperPdf(id: string, file: File): Promise<PaperDetail> {
+    const form = new FormData();
+    form.append('file', file);
+    return request<PaperDetail>(`/papers/${id}/pdf`, { method: 'POST', body: form });
+  },
 
   // —— Lit · 论文图片（docs/api-lit.md §6.5） ——
   /** 论文图片元数据列表；无图返回 []。 */


### PR DESCRIPTION
## Summary

Allow users to attach a local PDF to a paper when no PDF is currently available, including non-arXiv imports. Existing PDFs remain protected from replacement, and successful uploads reuse the full-text extraction and indexing pipeline.

Closes #400

## Area

- [x] frontend
- [x] backend-api
- [x] literature / wiki

## What changed

- Add an authenticated multipart PDF upload endpoint with a 100 MB limit and content validation.
- Reject empty, malformed, password-protected, oversized, and duplicate PDF uploads.
- Reuse the existing extraction, chunking, embedding, and affiliation post-processing flow.
- Add a shared upload control next to source links and in the missing-PDF reader state.
- Render no upload control when `pdf_available` is already true.
- Add backend upload/read/overwrite/validation coverage and frontend visibility coverage.

## Testing

- [x] `npx tsc --noEmit`
- [x] `npm test` — 75 passed
- [x] `npm run build`
- [x] `pytest -q tests/test_paper_reading.py` — 8 passed
- [x] Ruff checks for all changed backend files
- [x] Manually verified local upload, extraction, PDF.js loading, full responses, range requests, and duplicate rejection

The full backend suite produced 1,234 passes and three unrelated failures. Each failure reproduces unchanged on a clean `origin/main` checkout:

- `test_experiment_iterate.py::test_debug_repeats_until_run_budget`
- `test_latex_compile.py::test_compile_success_with_stubbed_tectonic`
- `test_experiment_env.py::test_prompt_with_context_unit`

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title (`feat|fix|chore|docs(scope): …`)
- [x] No database migration is required
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [ ] Screenshots attached for UI changes