### PR TITLE
fix(ideas): keep trashed records out of counts, search, and dedup

### DIFF
--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -728,12 +728,17 @@ async def forge_dedup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, A
             ctx.checkpoint["forge_dedup_done"] = True
             return {"candidates": len(candidates), "dropped": 0, "skipped_reason": "no embedding"}
 
-        # 库内既有 idea：激活空间下无向量的现场补嵌并落库
+        # 库内既有 idea：激活空间下无向量的现场补嵌并落库。
+        # 回收站里的不参与：用户把一个想法扔掉，正是不想再看到它，结果它却留在去重基准里
+        # 把新生成的近似想法判成重复——扔得越多，越生不出东西，而且没有任何提示。
+        # 顺带省掉给这些死记录现场补向量的那一趟嵌入调用。
         existing = (
             (
                 await session.execute(
                     select(Idea).where(
-                        Idea.project_id == ctx.run.project_id, Idea.status != "rejected"
+                        Idea.project_id == ctx.run.project_id,
+                        Idea.status != "rejected",
+                        Idea.trashed_at.is_(None),
                     )
                 )
             )

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -322,7 +322,9 @@ async def idea_counts(session: AsyncSession, project_id: uuid.UUID) -> dict[str,
     rows = (
         await session.execute(
             select(Idea.status, func.count())
-            .where(Idea.project_id == project_id)
+            # 回收站里的不算。这个计数直接喂给界面上的想法数，扔进回收站却看不到数字
+            # 变化，人只会以为删除没生效，然后再删一次。
+            .where(Idea.project_id == project_id, Idea.trashed_at.is_(None))
             .group_by(Idea.status)
         )
     ).all()

--- a/src/backend/app/services/search.py
+++ b/src/backend/app/services/search.py
@@ -38,6 +38,9 @@ async def global_search(
 ) -> list[GlobalSearchHit]:
     pattern = f"%{q}%"
     hits: list[GlobalSearchHit] = []
+    # 加新类型时注意：凡是带 ``trashed_at`` 的实体都要排掉回收站里的。搜索是回收站最容易
+    # 漏掉的出口——列表页都记得过滤，搜索却把删掉的东西照样捞回来，点进去还是活的。
+    # 目前 idea / experiment / manuscript 三种是软删的。
     # 论文/概念按课题关联库并集检索；无关联库 = 无语料时跳过它们，
     # ideas/实验/航程/稿件等课题作用域实体照常匹配（不受关联库影响）。
     library_ids = await get_source_library_ids(session, project_id)
@@ -106,6 +109,7 @@ async def global_search(
                 select(Idea)
                 .where(
                     Idea.project_id == project_id,
+                    Idea.trashed_at.is_(None),
                     or_(Idea.title.ilike(pattern), Idea.summary.ilike(pattern)),
                 )
                 .order_by(Idea.updated_at.desc())
@@ -126,7 +130,12 @@ async def global_search(
         await session.execute(
             select(Experiment, Idea.title)
             .join(Idea, Experiment.idea_id == Idea.id)
-            .where(Experiment.project_id == project_id, Idea.title.ilike(pattern))
+            .where(
+                Experiment.project_id == project_id,
+                Experiment.trashed_at.is_(None),
+                Idea.trashed_at.is_(None),
+                Idea.title.ilike(pattern),
+            )
             .order_by(Experiment.updated_at.desc())
             .limit(limit_per_type)
         )
@@ -163,7 +172,11 @@ async def global_search(
         (
             await session.execute(
                 select(Manuscript)
-                .where(Manuscript.project_id == project_id, Manuscript.title.ilike(pattern))
+                .where(
+                    Manuscript.project_id == project_id,
+                    Manuscript.trashed_at.is_(None),
+                    Manuscript.title.ilike(pattern),
+                )
                 .order_by(Manuscript.updated_at.desc())
                 .limit(limit_per_type)
             )

--- a/src/backend/tests/test_idea_review.py
+++ b/src/backend/tests/test_idea_review.py
@@ -421,3 +421,26 @@ async def test_patch_idea_rejected_only(client, queue_stub, bus_recorder):
         headers={"Authorization": f"Bearer {token_b}"},
     )
     assert resp.status_code == 404
+
+
+async def test_idea_counts_exclude_the_recycle_bin(client, queue_stub):
+    """界面上的想法计数不算回收站里的。
+
+    扔进回收站却看不到数字变化，人只会以为删除没生效然后再删一次。#397 修好了
+    锦标赛那条路，计数这条当时没跟上。
+    """
+    project_id, headers = await _setup_project(client, name="counts-exclude-trashed")
+    for i in range(3):
+        await _seed_idea(project_id, f"留着的想法{i}")
+    trashed_id = await _seed_idea(project_id, "要扔的想法")
+
+    resp = await client.get(f"/api/projects/{project_id}/forge/state", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["idea_counts"]["total"] == 4
+
+    assert (await client.delete(f"/api/ideas/{trashed_id}", headers=headers)).status_code == 204
+
+    resp = await client.get(f"/api/projects/{project_id}/forge/state", headers=headers)
+    counts = resp.json()["idea_counts"]
+    assert counts["total"] == 3, "回收站里的想法仍被计入"
+    assert counts["candidate"] == 3

--- a/src/backend/tests/test_search.py
+++ b/src/backend/tests/test_search.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+from sqlalchemy import select
+
 from app.core.db import get_sessionmaker
 from app.models.experiment import Experiment
 from app.models.idea import Idea
@@ -107,3 +109,47 @@ async def test_search_requires_membership(client):
         headers={"Authorization": f"Bearer {other}"},
     )
     assert resp.status_code == 404
+
+
+async def test_search_skips_the_recycle_bin(client):
+    """回收站里的想法/实验/稿件不得被搜出来。
+
+    这条原则代码里早就定了（见 test_search_excludes_trash.py：论文那半边），只是全局
+    搜索这条路一直没跟上。列表页看不见、搜索却照样捞出来，点进去还是活的——用户会
+    以为删除压根没生效。稿件和实验同样是软删的，一起钉住，免得下次只修一种。
+    """
+    import datetime as dt
+
+    project_id, headers = await _setup(client)
+    pid = uuid.UUID(project_id)
+
+    async def types_for(q: str) -> set[str]:
+        r = await client.get(
+            f"/api/projects/{project_id}/global-search", params={"q": q}, headers=headers
+        )
+        assert r.status_code == 200, r.text
+        return {hit["type"] for hit in r.json()["hits"]}
+
+    before = await types_for("graph")
+    assert {"idea", "experiment", "manuscript"} <= before, "先确认这三类本来搜得到"
+
+    now = dt.datetime.now(dt.UTC)
+    async with get_sessionmaker()() as session:
+        idea = (await session.execute(select(Idea).where(Idea.project_id == pid))).scalar_one()
+        idea.trashed_at = now
+        manuscript = (
+            await session.execute(select(Manuscript).where(Manuscript.project_id == pid))
+        ).scalar_one()
+        manuscript.trashed_at = now
+        experiment = (
+            await session.execute(select(Experiment).where(Experiment.project_id == pid))
+        ).scalar_one()
+        experiment.trashed_at = now
+        await session.commit()
+
+    after = await types_for("graph")
+    assert "idea" not in after, "回收站里的想法仍被搜出来"
+    assert "manuscript" not in after, "回收站里的稿件仍被搜出来"
+    assert "experiment" not in after, "回收站里的实验仍被搜出来"
+    # 没有回收站概念的类型不受影响
+    assert "paper" in after and "voyage" in after


### PR DESCRIPTION
Follow-up to #397, which stopped trashed ideas from entering tournaments. The same leak was open in three other places, found while reviewing that PR.

## Counts

`idea_counts` fed the number the UI shows and did not filter. Trashing an idea left the count unchanged, which reads as the delete not having worked — and the natural response is to delete it again. Confirmed against the running API before fixing:

```
before: {candidate: 4, total: 4}
delete -> 204
after : {candidate: 4, total: 4}
```

## Global search

Trashed records came back in results. The repository had already settled this question for papers — `test_search_excludes_trash.py` opens with *"删掉的论文又被搜出来，比搜不到更让人困惑——尤其它在列表里已经不见了"* — but `global_search` never followed.

Ideas, experiments and manuscripts are all soft-deleted and all three were leaking, so all three are fixed rather than just the one #397 was about. Fixing only ideas would have left the identical defect in the same function. Added a note there so the next entity type with a recycle bin is not missed.

## Forge deduplication

Candidate generation compared new ideas against existing ones without excluding trashed records. Discarding an idea is how a user says they do not want it, and it then stayed in the dedup baseline suppressing anything similar — the more you throw away, the less the forge can generate, and nothing explains why. It also spent embedding calls on those dead records to build the comparison.

## Testing

- 83 passed: `test_search test_search_excludes_trash test_idea_review test_idea_forge test_idea_proposal test_experiments test_manuscripts`
- Ruff clean on the changed files
- Both new tests were run against the unfixed code and fail there, so they test what they claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr