### PR TITLE
feat(llm): support configurable Anthropic providers

### DIFF
--- a/src/backend/alembic/versions/7b3e91c4a2d8_provider_user_agent.py
+++ b/src/backend/alembic/versions/7b3e91c4a2d8_provider_user_agent.py
@@ -1,0 +1,25 @@
+"""provider user agent
+
+Revision ID: 7b3e91c4a2d8
+Revises: a1c9e73b5d20
+Create Date: 2026-08-10
+
+为 Anthropic 兼容服务提供可选的 Provider 级 User-Agent；空值保持 HTTP 客户端默认行为。
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "7b3e91c4a2d8"
+down_revision: str | None = "a1c9e73b5d20"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("llm_providers", sa.Column("user_agent", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("llm_providers", "user_agent")

--- a/src/backend/app/api/admin_llm.py
+++ b/src/backend/app/api/admin_llm.py
@@ -33,6 +33,7 @@ def _provider_read(provider: LLMProviderConfig) -> ProviderRead:
         name=provider.name,
         kind=provider.kind,
         base_url=provider.base_url,
+        user_agent=provider.user_agent,
         api_key_masked=llm_admin_service.masked_key_of(provider),
         enabled=provider.enabled,
         models=provider.models,

--- a/src/backend/app/api/me_llm.py
+++ b/src/backend/app/api/me_llm.py
@@ -40,6 +40,7 @@ def _provider_read(p: LLMProviderConfig) -> ProviderRead:
         name=p.name,
         kind=p.kind,
         base_url=p.base_url,
+        user_agent=p.user_agent,
         api_key_masked=svc.masked_key_of(p),
         enabled=p.enabled,
         models=p.models,

--- a/src/backend/app/core/llm/anthropic.py
+++ b/src/backend/app/core/llm/anthropic.py
@@ -41,6 +41,18 @@ _DEFAULT_MAX_TOKENS = 4096
 _EFFORT_REJECT_MARKERS = ("effort", "output_config")
 
 
+def _messages_url(base_url: str | None) -> str:
+    """把根地址、版本化 Base URL 或完整端点统一成 Messages API 地址。"""
+    if not base_url:
+        return _API_URL
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/messages"):
+        return normalized
+    if normalized.endswith("/v1"):
+        return f"{normalized}/messages"
+    return f"{normalized}/v1/messages"
+
+
 def _rejects_effort(body: str) -> bool:
     low = body.lower()
     return any(marker in low for marker in _EFFORT_REJECT_MARKERS)
@@ -114,14 +126,21 @@ class AnthropicProvider(LLMProvider):
         self,
         api_key: str,
         *,
+        base_url: str | None = None,
+        user_agent: str | None = None,
         client: httpx.AsyncClient | None = None,
         timeout: float = 300.0,
     ) -> None:
         self._api_key = api_key
+        self._api_url = _messages_url(base_url)
+        self._user_agent = user_agent.strip() if user_agent else None
         self._client = client or httpx.AsyncClient(timeout=timeout)
 
     def _headers(self) -> dict[str, str]:
-        return {"x-api-key": self._api_key, "anthropic-version": _API_VERSION}
+        headers = {"x-api-key": self._api_key, "anthropic-version": _API_VERSION}
+        if self._user_agent:
+            headers["user-agent"] = self._user_agent
+        return headers
 
     @staticmethod
     def _payload(
@@ -213,7 +232,7 @@ class AnthropicProvider(LLMProvider):
     ) -> CompletionResult:
         # TODO(M2): 重试/限速/错误分类
         resp = await self._client.post(
-            _API_URL,
+            self._api_url,
             headers=self._headers(),
             json=self._payload(
                 messages,
@@ -231,7 +250,7 @@ class AnthropicProvider(LLMProvider):
             # 该模型不认这个档位：去掉参数重试一次，别让配错档位打断整个环节
             logger.warning("模型 %s 不支持 effort=%s，已去掉该参数重试", model, effort)
             resp = await self._client.post(
-                _API_URL,
+                self._api_url,
                 headers=self._headers(),
                 json=self._payload(
                     messages,
@@ -326,7 +345,7 @@ class AnthropicProvider(LLMProvider):
         usage: dict[str, Any] = {}
         finish_reason: str | None = None
         async with self._client.stream(
-            "POST", _API_URL, headers=self._headers(), json=payload
+            "POST", self._api_url, headers=self._headers(), json=payload
         ) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -116,6 +116,7 @@ class ResolvedRoute:
     model: str
     temperature: float | None
     provider_name: str = "fake"  # 管理端 provider 名称（调用日志用）
+    user_agent: str | None = None  # Provider 级客户端标识；None = HTTP 客户端默认值
     effort: EffortLevel | None = None  # 推理档位，None = 不发送该参数（用模型默认）
     #: 模型的上下文窗口（token）。None = 管理端没填，调用方按保守常量走。
     #: agent 的历史回放预算靠它——不知道窗口多大，裁剪阈值就只能拍脑袋。
@@ -270,6 +271,7 @@ class LLMRouter:
                     model=route.model,
                     temperature=route.temperature,
                     provider_name=provider.name,
+                    user_agent=provider.user_agent,
                     effort=route.effort,
                     context_window=route.context_window,
                 )
@@ -311,7 +313,14 @@ class LLMRouter:
             return self._override
         # 耐心程度进缓存键：同一个 provider 配置在长/短两档下各持一个客户端
         timeout, attempts = call_profile(stage)
-        key = (route.provider_kind, route.base_url, route.api_key, timeout, attempts)
+        key = (
+            route.provider_kind,
+            route.base_url,
+            route.api_key,
+            route.user_agent,
+            timeout,
+            attempts,
+        )
         if key not in self._providers:
             if route.provider_kind == "openai_compat":
                 base_url = route.base_url or get_settings().openai_compat_base_url
@@ -322,7 +331,12 @@ class LLMRouter:
                     max_attempts=attempts,
                 )
             elif route.provider_kind == "anthropic":
-                self._providers[key] = AnthropicProvider(api_key=route.api_key, timeout=timeout)
+                self._providers[key] = AnthropicProvider(
+                    api_key=route.api_key,
+                    base_url=route.base_url,
+                    user_agent=route.user_agent,
+                    timeout=timeout,
+                )
             elif route.provider_kind == "fake":
                 self._providers[key] = FakeProvider()
             else:

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -39,6 +39,8 @@ class LLMProviderConfig(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     kind: Mapped[str] = mapped_column(String(32), nullable=False)  # openai_compat|anthropic|fake
     base_url: Mapped[str | None] = mapped_column(String(1024))
+    # 可选的 Provider 级客户端标识；仅在显式配置时覆盖 HTTP 客户端默认值。
+    user_agent: Mapped[str | None] = mapped_column(String(255))
     # 明文 key 不落库：core/security.py Fernet 加密后存这里
     api_key_encrypted: Mapped[str | None] = mapped_column(Text)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/src/backend/app/schemas/llm_admin.py
+++ b/src/backend/app/schemas/llm_admin.py
@@ -2,19 +2,21 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.llm.base import EffortLevel
 
 ProviderKind = Literal["openai_compat", "anthropic", "fake"]
+UserAgent = Annotated[str, Field(max_length=255, pattern=r"^[^\r\n]*$")]
 
 
 class ProviderCreate(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     kind: ProviderKind
     base_url: str | None = None
+    user_agent: UserAgent | None = None
     api_key: str | None = None  # 只写不读；入库前 Fernet 加密
     enabled: bool = True
     models: list[str] | None = None  # 可用模型 id 列表（None = 未配置）
@@ -24,6 +26,7 @@ class ProviderUpdate(BaseModel):
     name: str | None = None
     kind: ProviderKind | None = None
     base_url: str | None = None
+    user_agent: UserAgent | None = None  # 空字符串 = 恢复 HTTP 客户端默认值
     api_key: str | None = None  # 空字符串 = 不变
     enabled: bool | None = None
     models: list[str] | None = None  # 整体替换；None = 不变（清空传 []）
@@ -36,6 +39,7 @@ class ProviderRead(BaseModel):
     name: str
     kind: str
     base_url: str | None
+    user_agent: str | None
     api_key_masked: str
     enabled: bool
     models: list[str] | None = None

--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -45,6 +45,12 @@ def masked_key_of(provider: LLMProviderConfig) -> str:
     return mask_api_key(decrypt_secret(provider.api_key_encrypted))
 
 
+def _normalize_user_agent(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.strip() or None
+
+
 # ---- providers ----
 
 
@@ -82,6 +88,7 @@ async def create_provider(
         name=data.name,
         kind=data.kind,
         base_url=data.base_url,
+        user_agent=_normalize_user_agent(data.user_agent),
         api_key_encrypted=encrypt_secret(data.api_key) if data.api_key else None,
         enabled=data.enabled,
         models=data.models,
@@ -102,6 +109,8 @@ async def update_provider(
         provider.kind = data.kind
     if data.base_url is not None:
         provider.base_url = data.base_url
+    if data.user_agent is not None:
+        provider.user_agent = _normalize_user_agent(data.user_agent)
     if data.api_key:  # 空字符串/None = 不变
         provider.api_key_encrypted = encrypt_secret(data.api_key)
     if data.enabled is not None:
@@ -189,7 +198,11 @@ def _build_provider(provider: LLMProviderConfig) -> LLMProvider:
         base_url = provider.base_url or get_settings().openai_compat_base_url
         return OpenAICompatProvider(base_url=base_url, api_key=api_key)
     if provider.kind == "anthropic":
-        return AnthropicProvider(api_key=api_key)
+        return AnthropicProvider(
+            api_key=api_key,
+            base_url=provider.base_url,
+            user_agent=provider.user_agent,
+        )
     return FakeProvider()
 
 

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -49,6 +49,7 @@ async def test_provider_crud_and_key_masking(client):
             "name": "deepseek",
             "kind": "openai_compat",
             "base_url": "https://api.deepseek.com/v1",
+            "user_agent": "relay-client/1.0",
             "api_key": API_KEY,
             "enabled": True,
         },
@@ -57,16 +58,18 @@ async def test_provider_crud_and_key_masking(client):
     assert resp.status_code == 201, resp.text
     provider = resp.json()
     assert provider["api_key_masked"] == "sk-...abcd"  # 只写不读
+    assert provider["user_agent"] == "relay-client/1.0"
     assert "api_key" not in provider
     provider_id = provider["id"]
 
     # 空 api_key = 不变
     resp = await client.patch(
         f"/api/admin/llm/providers/{provider_id}",
-        json={"api_key": "", "enabled": False},
+        json={"api_key": "", "user_agent": "", "enabled": False},
         headers=admin,
     )
     assert resp.json()["api_key_masked"] == "sk-...abcd"
+    assert resp.json()["user_agent"] is None
     assert resp.json()["enabled"] is False
 
     # 换 key → 掩码变化
@@ -316,6 +319,59 @@ async def test_test_model_openai_compat_chat(client):
     assert payload["model"] == "gpt-5.5"
     assert payload["max_tokens"] <= 8
     assert payload["messages"] == [{"role": "user", "content": "ping"}]
+
+
+@respx.mock
+async def test_test_model_anthropic_custom_user_agent(client):
+    admin, _ = await _admin_and_member(client)
+    resp = await client.post(
+        "/api/admin/llm/providers",
+        json={
+            "name": "claude-relay",
+            "kind": "anthropic",
+            "base_url": "http://claude-relay.test/v1",
+            "user_agent": "claude-cli/test",
+            "api_key": API_KEY,
+        },
+        headers=admin,
+    )
+    assert resp.status_code == 201, resp.text
+    provider_id = resp.json()["id"]
+    route = respx.post("http://claude-relay.test/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "claude-opus-5",
+                "content": [{"type": "text", "text": "pong"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+    )
+    resp = await client.post(
+        "/api/admin/llm/test-model",
+        json={"provider_id": provider_id, "model": "claude-opus-5", "capability": "chat"},
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    assert route.calls.last.request.headers["user-agent"] == "claude-cli/test"
+
+    # 真实路由也必须从数据库带出 User-Agent；否则会出现“测试成功、工作流失败”。
+    resp = await client.put(
+        "/api/admin/llm/routes",
+        json=[{"stage": "default", "provider_id": provider_id, "model": "claude-opus-5"}],
+        headers=admin,
+    )
+    assert resp.status_code == 200, resp.text
+    from app.core.llm.router import LLMRouter
+
+    router = LLMRouter()
+    resolved = (await router._load_routes(None))["default"]
+    assert resolved.user_agent == "claude-cli/test"
+    llm = router._provider_for(resolved, "default")
+    assert llm._headers()["user-agent"] == "claude-cli/test"  # type: ignore[attr-defined]
+    await llm.aclose()
 
 
 @respx.mock

--- a/src/backend/tests/test_llm_router.py
+++ b/src/backend/tests/test_llm_router.py
@@ -260,6 +260,28 @@ def test_profile_is_part_of_the_provider_cache_key():
     assert len(router._providers) == 2, "长短档共用了同一个客户端"
 
 
+async def test_user_agent_is_part_of_the_provider_cache_key():
+    """同一端点使用不同客户端标识时不能复用旧 Provider。"""
+    from app.core.llm.router import LLMRouter, ResolvedRoute
+
+    router = LLMRouter()
+    base = dict(
+        provider_kind="anthropic",
+        base_url="https://relay.test/v1",
+        api_key="key",
+        model="m",
+        temperature=None,
+        provider_name="relay",
+    )
+    first = router._provider_for(ResolvedRoute(**base, user_agent="client/1"), "relevance")
+    second = router._provider_for(ResolvedRoute(**base, user_agent="client/2"), "relevance")
+    assert first is not second
+    assert first._headers()["user-agent"] == "client/1"  # type: ignore[attr-defined]
+    assert second._headers()["user-agent"] == "client/2"  # type: ignore[attr-defined]
+    await first.aclose()
+    await second.aclose()
+
+
 # ---- digest 拆成独立 stage（可单独设模型）----
 
 

--- a/src/backend/tests/test_llm_tool_stream.py
+++ b/src/backend/tests/test_llm_tool_stream.py
@@ -288,6 +288,51 @@ def _anthropic_provider(events: list[dict]):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        (None, "https://api.anthropic.com/v1/messages"),
+        ("https://relay.test", "https://relay.test/v1/messages"),
+        ("https://relay.test/v1", "https://relay.test/v1/messages"),
+        ("https://relay.test/v1/messages", "https://relay.test/v1/messages"),
+    ],
+)
+async def test_anthropic_custom_base_url(
+    base_url: str | None, expected_url: str
+) -> None:
+    """自定义 Anthropic Base URL 必须覆盖完整与流式请求使用的硬编码地址。"""
+    from app.core.llm.anthropic import AnthropicProvider
+
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["api_key"] = request.headers["x-api-key"]
+        return httpx.Response(
+            200,
+            json={
+                "content": [{"type": "text", "text": "pong"}],
+                "model": "m",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    provider = AnthropicProvider(
+        "k",
+        base_url=base_url,
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        result = await provider.complete([Message(role="user", content="ping")], model="m")
+    finally:
+        await provider.aclose()
+
+    assert seen == {"url": expected_url, "api_key": "k"}
+    assert result.content == "pong"
+
+
+@pytest.mark.asyncio
 async def test_anthropic_tool_use_blocks_and_usage():
     """content_block_start/input_json_delta/stop 的三段式，外加两处 usage。
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a1c9e73b5d20"  # 浏览事件（文献库/论文点击量）
+HEAD_REVISION = "7b3e91c4a2d8"  # Provider 级可选 User-Agent
+VIEW_EVENTS_REVISION = "a1c9e73b5d20"  # 浏览事件（文献库/论文点击量）
 VOYAGE_MESSAGES_REVISION = "63133f647463"  # 任务对话流：voyage_messages 表
 READ_ONLY_REVISION = "b3f5c1e07a92"  # 只读账号（游客）
 SKILLS_GLOBAL_REVISION = "07e7faea4c7a"  # 技能全局启用（user_skills，不再绑定课题）
@@ -245,8 +246,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"is_binary", "is_folder"} <= columns["manuscript_files"]
     # 用户名列（更早版本）
     assert {"username", "username_locked"} <= columns["users"]
-    # llm_providers.models 列（可用模型列表，更早版本）
-    assert "models" in columns["llm_providers"]
+    # llm_providers 模型列表与可选客户端标识
+    assert {"models", "user_agent"} <= columns["llm_providers"]
     # llm_call_logs / system_settings 表（更早版本）
     assert {"llm_call_logs", "system_settings"} <= columns["_tables"]
     assert {
@@ -367,7 +368,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 浏览事件：文献库/论文的点击量
     assert "view_events" in columns["_tables"]
 
-    # 最新 revision 可往返：先退掉浏览事件。
+    # 最新 revision 可往返：先退掉 Provider 级 User-Agent。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == VIEW_EVENTS_REVISION
+    assert "user_agent" not in columns["llm_providers"]
+    assert "view_events" in columns["_tables"]
+
+    # 再退掉浏览事件。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == VOYAGE_MESSAGES_REVISION

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -822,6 +822,7 @@ interface ProviderDraft {
   name: string;
   kind: LlmProviderKind;
   base_url: string;
+  user_agent: string;
   api_key: string;
   enabled: boolean;
   /** 可用模型列表原始输入（逗号/换行分隔），保存时解析为数组 */
@@ -834,7 +835,7 @@ function parseModels(raw: string): string[] {
 }
 
 function emptyDraft(): ProviderDraft {
-  return { name: '', kind: 'openai_compat', base_url: '', api_key: '', enabled: true, models: '' };
+  return { name: '', kind: 'openai_compat', base_url: '', user_agent: '', api_key: '', enabled: true, models: '' };
 }
 
 function draftFrom(p: LlmProviderRead): ProviderDraft {
@@ -842,6 +843,7 @@ function draftFrom(p: LlmProviderRead): ProviderDraft {
     name: p.name,
     kind: p.kind,
     base_url: p.base_url ?? '',
+    user_agent: p.user_agent ?? '',
     api_key: '',
     enabled: p.enabled,
     models: (p.models ?? []).join('\n'),
@@ -853,6 +855,7 @@ function toInput(d: ProviderDraft): LlmProviderInput {
     name: d.name.trim(),
     kind: d.kind,
     base_url: d.base_url.trim() || undefined,
+    user_agent: d.kind === 'anthropic' ? d.user_agent.trim() : '',
     api_key: d.api_key, // 空字符串 = 不变（PATCH）；POST 时后端忽略空 key
     enabled: d.enabled,
     models: parseModels(d.models), // 整体替换（清空 = []）
@@ -883,6 +886,14 @@ function ProviderForm({ draft, setDraft, isNew }: {
             placeholder="https://api.example.com/v1" disabled={draft.kind === 'fake'} />
         </FormField>
       </div>
+      {draft.kind === 'anthropic' && (
+        <FormField label={tr('User-Agent（可选）', 'User-Agent (optional)')}
+          hint={tr('留空则使用 HTTP 客户端默认值', 'Leave empty to use the HTTP client default')}>
+          <input className="input mono" value={draft.user_agent}
+            onChange={(e) => setDraft({ ...draft, user_agent: e.target.value })}
+            placeholder="claude-cli/2.1.226 (external, sdk-cli)" />
+        </FormField>
+      )}
       <FormField label="API Key"
         hint={isNew ? undefined : tr('留空 = 保持不变；后端只写不读，展示为 masked', 'Leave empty to keep unchanged; write-only on the backend, shown masked')}>
         <input className="input mono" type="password" autoComplete="new-password" value={draft.api_key}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -565,6 +565,7 @@ export interface LlmProviderRead {
   name: string;
   kind: LlmProviderKind;
   base_url: string | null;
+  user_agent: string | null;
   api_key_masked: string | null;
   enabled: boolean;
   /** 可用模型 id 列表（null = 未配置） */
@@ -575,6 +576,8 @@ export interface LlmProviderInput {
   name: string;
   kind: LlmProviderKind;
   base_url?: string;
+  /** 可选；仅 Anthropic Provider 使用，空字符串恢复客户端默认值 */
+  user_agent?: string;
   /** 空字符串 = 不变（PATCH 时） */
   api_key?: string;
   enabled: boolean;


### PR DESCRIPTION
Closes #403

## Summary

- support configurable Base URLs for Anthropic-compatible providers
- support an optional provider-specific User-Agent across test and workflow routes
- expose the configuration through the admin API and settings UI
- add migration, routing, streaming, and admin coverage

## Validation

- targeted Ruff checks passed
- 57 related backend tests passed
- frontend TypeScript and Vite production build passed