### PR TITLE
fix(llm): name the provider cache key so its type stops drifting

### DIFF
--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -212,6 +212,11 @@ def call_profile(stage: str) -> tuple[float, int]:
     return _SHORT_CALL
 
 
+#: provider 客户端缓存的键：(kind, base_url, api_key, user_agent, timeout, attempts)。
+#: 与 ``_provider_for`` 构造键的地方保持一致。
+_ProviderKey = dict[tuple[str, str | None, str, str | None, float, int], LLMProvider]
+
+
 class LLMRouter:
     """stage → (provider 实例, model)；complete/stream 自动记账。
 
@@ -227,7 +232,11 @@ class LLMRouter:
         self._self_managed: dict[uuid.UUID, tuple[bool, float]] = {}
         # 键含耐心档位（见 call_profile）：长/短两档各持一个客户端。键是实现细节，
         # 要在测试里替换 provider 请用 override_provider()，别直接往这个字典里塞。
-        self._providers: dict[tuple[str, str | None, str, float, int], LLMProvider] = {}
+        #
+        # 凡是会改变客户端行为的字段都必须在键里，否则两份配置会共用同一个客户端，
+        # 后配的那份静默用着前一份的连接参数。加 user_agent 时键跟着加了，
+        # 这行标注没跟上——标注是给下一个改键的人看的，写错就等于没有。
+        self._providers: _ProviderKey = {}
         self._override: LLMProvider | None = None
         self.event_bus: Any | None = None
 

--- a/src/backend/tests/test_llm_router_tools.py
+++ b/src/backend/tests/test_llm_router_tools.py
@@ -231,3 +231,31 @@ def test_tools_unsupported_is_detected_from_the_body():
     assert _tools_unsupported('{"error":{"message":"tools is not supported for this model"}}')
     assert _tools_unsupported("Unsupported parameter: 'tools'")
     assert not _tools_unsupported('{"error":{"message":"context length exceeded"}}')
+
+
+def test_provider_cache_key_covers_every_client_affecting_field():
+    """会改变客户端行为的字段必须全在缓存键里。
+
+    漏一个的表现是：两份配置共用同一个 HTTP 客户端，后配的那份静默用着前一份的
+    连接参数——base_url 指向 A、请求却发去 B，日志里两边都看不出问题。user_agent
+    加进来时键跟着加了，这条用来保证下一个字段不会漏。
+    """
+    import inspect
+
+    from app.core.llm import router as router_mod
+
+    src = inspect.getsource(router_mod.LLMRouter._provider_for)
+    key_block = src.split("key = (", 1)[1].split(")", 1)[0]
+    for field in ("provider_kind", "base_url", "api_key", "user_agent"):
+        assert f"route.{field}" in key_block, f"缓存键漏了 route.{field}"
+    assert "timeout" in key_block and "attempts" in key_block, "耐心档位也要进键"
+
+
+def test_provider_cache_key_annotation_matches_the_real_key():
+    """键的类型标注要和实际构造的键等长，否则标注是错的还没人发现。"""
+    import typing
+
+    from app.core.llm.router import _ProviderKey
+
+    key_type = typing.get_args(typing.get_args(_ProviderKey)[0])
+    assert len(key_type) == 6, f"标注是 {len(key_type)} 元组，实际键是 6 元组"


### PR DESCRIPTION
Follow-up to #404, which is merged.

#404 added `user_agent` to the provider client cache key, and got that right — two providers differing only by user agent must not share one HTTP client, or the second one silently sends requests through the first one's connection settings. The type annotation next to it still described the old five-part key.

A wrong annotation is worse than no annotation. It is the thing the next person reads before touching the key, and it tells them the field they are adding does not belong there. The failure it invites is quiet: a `base_url` pointing at A while requests go to B, with nothing in the logs to show for it.

Named the key type and added two guards:

- every client-affecting field (`provider_kind`, `base_url`, `api_key`, `user_agent`, plus the patience profile) must appear where the key is built
- the annotation's arity must match the real key

Both were run against a key with `user_agent` removed and fail there, so they test what they claim rather than passing by construction.

## Testing

- 76 passed: `test_llm_router test_llm_router_tools test_admin_llm test_per_user_llm test_llm_tool_stream`
- Ruff clean

## On #404 itself

Reviewed and merged: migration adds a nullable column and leaves a single alembic head (checked with `alembic heads` on the branch, and the upgrade/downgrade round-trip test passes), the UI gates the User-Agent field to Anthropic providers and clears it for other kinds, and the cache key was extended properly. 94 backend and 75 frontend tests passed on the branch with `tsc` clean.

One small thing left alone: the admin API schema accepts `user_agent` for any provider kind while only the Anthropic client applies it. The UI never sends it for other kinds, so nothing is reachable today — but an API client could set it and see it ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr