### PR TITLE
feat(papers): fetch a missing PDF from a public link

### DIFF
--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -41,6 +41,7 @@ from app.schemas.paper import (
     PaperMyMetaUpdate,
     PaperMyTagsRead,
     PaperMyTagsUpdate,
+    PaperPdfUrlIn,
     PaperRead,
     PaperTagsUpdate,
     PaperUpdate,
@@ -60,6 +61,7 @@ from app.services import paper_wiki as paper_wiki_service
 from app.services import papers as papers_service
 from app.services import wiki_compile as wiki_compile_service
 from app.services.literature.pdf_extract import figure_path
+from app.services.literature.pdf_source import PdfUrlError
 
 logger = logging.getLogger(__name__)
 
@@ -657,6 +659,43 @@ async def upload_paper_pdf(
         )
     except papers_service.PdfAlreadyExistsError as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="PDF_ALREADY_EXISTS") from exc
+    except papers_service.PdfUploadInvalidError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="PDF_UPLOAD_INVALID"
+        ) from exc
+    return await _paper_detail(session, view, user.id)
+
+
+@router.post("/papers/{paper_id}/pdf-url", response_model=PaperDetail)
+async def upload_paper_pdf_from_url(
+    paper_id: uuid.UUID,
+    data: PaperPdfUrlIn,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperDetail:
+    """给尚无 PDF 的可见论文按公开链接取原件；后处理与本地上传完全一致。
+
+    链接不可用（内网、下载失败、拿回来的不是 PDF）统一回 422 并把原因带上——
+    这类失败几乎都是用户能自己修的（粘成了落地页而不是 PDF、站点要登录），
+    只回一个错误码等于让人猜。
+    """
+    view = await _get_member_paper(
+        session, paper_id, user, with_concepts=True, include_pool=True
+    )
+    try:
+        await papers_service.upload_pdf_from_url(
+            session,
+            view.paper,
+            data.url,
+            user_id=user.id,
+            project_id=view.project_id,
+        )
+    except papers_service.PdfAlreadyExistsError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="PDF_ALREADY_EXISTS") from exc
+    except PdfUrlError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail=f"PDF_URL_UNUSABLE: {exc}"
+        ) from exc
     except papers_service.PdfUploadInvalidError as exc:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT, detail="PDF_UPLOAD_INVALID"

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -167,6 +167,12 @@ class PaperListPage(BaseModel):
     size: int
 
 
+class PaperPdfUrlIn(BaseModel):
+    """按公开链接补 PDF。链接本身的安全校验在服务层（见 literature/pdf_source.py）。"""
+
+    url: str = Field(min_length=1, max_length=2048)
+
+
 class PaperManualCreate(BaseModel):
     """手动添加文献：arxiv_id / doi / bibtex 三选一（docs/api-lit.md §4）。"""
 

--- a/src/backend/app/services/literature/pdf_source.py
+++ b/src/backend/app/services/literature/pdf_source.py
@@ -1,0 +1,148 @@
+"""按用户给的公开链接取 PDF。
+
+这条路和别处不同：**URL 由用户输入**，所以它是一个我们代替用户发起请求的入口，
+天然带 SSRF 面。下面的防护按「攻击者完全控制那个域名」来设计，而不是按「用户只是
+粘错了链接」。
+"""
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+#: 和上传走同一个上限，免得两条入口对同一篇论文给出不同答案。
+MAX_PDF_BYTES = 100 * 1024 * 1024
+MAX_REDIRECTS = 5
+_CONNECT_TIMEOUT = 15.0
+_READ_TIMEOUT = 60.0
+
+
+class PdfUrlError(RuntimeError):
+    """这个链接不能用（不合法、指向内网、下载失败或者拿回来的不是 PDF）。"""
+
+
+def _check_shape(parsed: object) -> None:
+    scheme = getattr(parsed, "scheme", "")
+    if scheme not in ("http", "https") or not getattr(parsed, "hostname", None):
+        raise PdfUrlError("只支持公开的 http/https 链接")
+    if getattr(parsed, "username", None) or getattr(parsed, "password", None):
+        raise PdfUrlError("链接里不能带用户名或密码")
+
+
+def _reject_non_public(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    """挡掉本机 / 内网 / 保留地址。
+
+    用 ``is_global`` 而不是自己列网段：私有、环回、链路本地、保留段、
+    运营商级 NAT（100.64/10）它都算在内，少写一条就是一个洞。
+    """
+    if not address.is_global:
+        raise PdfUrlError("链接不能指向本机、内网或保留地址")
+
+
+async def _precheck_dns(parsed: object) -> None:
+    """连接之前先看这个主机名解析到哪里。"""
+    hostname = str(getattr(parsed, "hostname", "") or "")
+    try:
+        literal = ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        _reject_non_public(literal)
+        return
+
+    scheme = getattr(parsed, "scheme", "http")
+    port = getattr(parsed, "port", None) or (443 if scheme == "https" else 80)
+    try:
+        rows = await asyncio.get_running_loop().getaddrinfo(
+            hostname, port, type=socket.SOCK_STREAM
+        )
+    except OSError as e:
+        raise PdfUrlError(f"解析不了这个地址：{hostname}") from e
+    addresses = {ipaddress.ip_address(row[4][0]) for row in rows}
+    if not addresses:
+        raise PdfUrlError(f"解析不了这个地址：{hostname}")
+    for address in addresses:
+        _reject_non_public(address)
+
+
+def _check_connected_peer(response: httpx.Response) -> None:
+    """连上之后，再看**真正连到了哪儿**。
+
+    只做连接前的 DNS 校验是挡不住的：校验查一次、httpx 连接时又查一次，中间那一瞬
+    足够攻击者的 DNS 换个答案——第一次给公网 IP 过关，第二次给 127.0.0.1。这是
+    教科书式的 DNS 重绑定，而链接正是攻击者提供的，所以这不是理论风险。
+
+    这里在读响应体**之前**核对实际对端地址，命中就断开。请求头已经发出去了，挡不住
+    那一次「盲发」，但拿不到任何内网响应内容。
+    """
+    stream = response.extensions.get("network_stream")
+    if stream is None:  # 测试替身 / 非默认 transport：没有可核对的对端
+        return
+    peer = stream.get_extra_info("server_addr")
+    if not peer:
+        return
+    try:
+        address = ipaddress.ip_address(str(peer[0]))
+    except ValueError:
+        return
+    _reject_non_public(address)
+
+
+async def download_pdf(url: str) -> bytes:
+    """按公开链接取回 PDF 字节。
+
+    重定向自己走，**每一跳都重新校验**：只验第一个 URL 是最常见的漏法，
+    一个公网地址 302 到 ``http://169.254.169.254/`` 就绕过去了。
+    """
+    settings = get_settings()
+    proxy = settings.outbound_proxy or None
+    current = url.strip()
+
+    async with httpx.AsyncClient(
+        proxy=proxy,
+        timeout=httpx.Timeout(_READ_TIMEOUT, connect=_CONNECT_TIMEOUT),
+        follow_redirects=False,
+        headers={"User-Agent": "Polaris/1.0 PDF fetcher"},
+    ) as client:
+        for hop in range(MAX_REDIRECTS + 1):
+            parsed = urlsplit(current)
+            _check_shape(parsed)
+            await _precheck_dns(parsed)
+            try:
+                async with client.stream("GET", current) as response:
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise PdfUrlError("对方返回了没有目标的重定向")
+                        if hop >= MAX_REDIRECTS:
+                            raise PdfUrlError("重定向次数过多")
+                        current = urljoin(current, location)
+                        continue
+                    # 走代理时对端是代理本身（往往就是个内网地址），核对它没有意义；
+                    # 这种部署下「请求到底落在哪」由代理决定，不在我们这一层。
+                    if proxy is None:
+                        _check_connected_peer(response)
+                    response.raise_for_status()
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > MAX_PDF_BYTES:
+                            raise PdfUrlError("PDF 超过 100 MB 上限")
+                        chunks.append(chunk)
+            except PdfUrlError:
+                raise
+            except httpx.HTTPError as e:
+                raise PdfUrlError(f"下载失败：{type(e).__name__}: {e}") from e
+            content = b"".join(chunks)
+            if not content:
+                raise PdfUrlError("下载到的内容是空的")
+            return content
+    raise PdfUrlError("重定向次数过多")

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -1083,6 +1083,34 @@ async def upload_pdf(
     )
 
 
+async def upload_pdf_from_url(
+    session: AsyncSession,
+    paper: Paper,
+    url: str,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> Paper:
+    """按用户给的公开链接取 PDF，接到现有论文上。
+
+    和本地上传共用同一套规矩：已有 PDF 就拒绝（不覆盖原件）、同样的内容校验、
+    同一条后处理流水线。差别只在字节从哪里来——而那一段是有 SSRF 面的，
+    单独放在 :mod:`app.services.literature.pdf_source` 里。
+    """
+    from app.services.literature.pdf_extract import save_pdf
+    from app.services.literature.pdf_source import download_pdf
+
+    # 先挡住已有 PDF 再下载：否则每被拒一次都白跑一趟外网。
+    if paper.pdf_path and Path(paper.pdf_path).exists():
+        raise PdfAlreadyExistsError(str(paper.id))
+    content = await download_pdf(url)
+    await asyncio.to_thread(_validate_pdf_content, content)
+    pdf_path = save_pdf(str(paper.id), content)
+    return await _process_saved_pdf(
+        session, paper, pdf_path, user_id=user_id, project_id=project_id
+    )
+
+
 async def fetch_pdf(
     session: AsyncSession,
     paper: Paper,

--- a/src/backend/tests/test_paper_reading.py
+++ b/src/backend/tests/test_paper_reading.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import fakeredis.aioredis
 import httpx
+import pytest
 import pytest_asyncio
 import respx
 from sqlalchemy import select
@@ -319,3 +320,91 @@ async def test_chat_with_referenced_papers(client):
     ) as resp:
         body2 = (await resp.aread()).decode("utf-8")
     assert "event: sources" not in body2
+
+
+# ---- 按公开链接补 PDF（issue #398）----
+
+
+async def test_pdf_url_import_runs_the_same_pipeline_and_never_overwrites(client, monkeypatch):
+    """链接补下来的 PDF 与本地上传同权：同样抽全文，同样拒绝覆盖原件。"""
+    from app.services.literature import pdf_source
+
+    _, headers, paper_id = await _setup(client, arxiv_id=None, email="pdfurl@example.com")
+    content = _pdf_bytes("fetched over http")
+
+    async def fake_download(url: str) -> bytes:
+        assert url == "https://example.org/paper.pdf"
+        return content
+
+    monkeypatch.setattr(pdf_source, "download_pdf", fake_download)
+
+    resp = await client.post(
+        f"/api/papers/{paper_id}/pdf-url",
+        json={"url": "https://example.org/paper.pdf"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pdf_available"] is True
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(paper_id))
+        assert "fetched over http" in Path(paper.full_text_path).read_text(encoding="utf-8")
+
+    # 已经有原件了：链接这条路同样不许覆盖，和上传一个规矩
+    again = await client.post(
+        f"/api/papers/{paper_id}/pdf-url",
+        json={"url": "https://example.org/other.pdf"},
+        headers=headers,
+    )
+    assert again.status_code == 409
+    assert again.json()["detail"] == "PDF_ALREADY_EXISTS"
+
+
+async def test_pdf_url_rejects_private_targets(client):
+    """URL 由用户给，所以按「域名完全受攻击者控制」来防。"""
+    from app.services.literature.pdf_source import PdfUrlError, download_pdf
+
+    _, headers, paper_id = await _setup(client, arxiv_id=None, email="ssrf@example.com")
+
+    # 必须校验**拒绝的理由**：连不上内网地址同样会抛 PdfUrlError，
+    # 只断言异常类型的话，把整个 is_global 检查删掉测试照样绿（实测如此）。
+    private = (
+        "http://127.0.0.1/x.pdf",
+        "http://169.254.169.254/latest/meta-data",  # 云元数据服务
+        "http://10.0.0.5/internal.pdf",
+        "http://[::1]/x.pdf",
+    )
+    for bad in private:
+        with pytest.raises(PdfUrlError, match="本机|内网|保留"):
+            await download_pdf(bad)
+
+    with pytest.raises(PdfUrlError, match="http/https"):
+        await download_pdf("file:///etc/passwd")
+    with pytest.raises(PdfUrlError, match="用户名或密码"):
+        await download_pdf("http://user:pw@example.org/x.pdf")
+
+    # 走 API 时同样是可读的 422，而不是 500
+    resp = await client.post(
+        f"/api/papers/{paper_id}/pdf-url",
+        json={"url": "http://127.0.0.1/x.pdf"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"].startswith("PDF_URL_UNUSABLE")
+
+
+async def test_pdf_url_revalidates_every_redirect_hop():
+    """只验第一个 URL 挡不住 302 到内网——每一跳都要重新校验。"""
+    import httpx
+    import respx
+
+    from app.services.literature.pdf_source import PdfUrlError, download_pdf
+
+    with respx.mock:
+        respx.get("https://example.org/paper.pdf").mock(
+            return_value=httpx.Response(
+                302, headers={"location": "http://169.254.169.254/latest/meta-data"}
+            )
+        )
+        with pytest.raises(PdfUrlError, match="内网|本机|保留"):
+            await download_pdf("https://example.org/paper.pdf")

--- a/src/frontend/src/features/shared/PdfUploadButton.tsx
+++ b/src/frontend/src/features/shared/PdfUploadButton.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { toast } from '../../components/ui/Toast';
@@ -19,6 +19,10 @@ function uploadError(error: unknown): string {
     if (error.message.includes('PDF_ALREADY_EXISTS')) {
       return tr('这篇论文已经有 PDF', 'This paper already has a PDF');
     }
+    // 后端把不可用的原因拼在错误码后面（粘成落地页、站点要登录、指向内网……）。
+    // 这类失败几乎都是用户自己能修的，所以原样透出去，不要压成一句「失败」。
+    const unusable = /PDF_URL_UNUSABLE:\s*(.+)$/.exec(error.message);
+    if (unusable) return unusable[1]!.trim();
   }
   return error instanceof Error ? error.message : String(error);
 }
@@ -31,22 +35,40 @@ export function PdfUploadButton({
   pdfAvailable: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [url, setUrl] = useState('');
   const queryClient = useQueryClient();
+  const applyDetail = (detail: PaperDetail) => {
+    queryClient.setQueriesData<PaperDetail>({ queryKey: ['paper'] }, (old) =>
+      old?.id === paperId ? detail : old,
+    );
+    void queryClient.invalidateQueries({ queryKey: ['papers'] });
+    void queryClient.invalidateQueries({ queryKey: ['library'] });
+    void queryClient.invalidateQueries({ queryKey: ['shelf'] });
+  };
   const mutation = useMutation({
     mutationFn: (file: File) => api.uploadPaperPdf(paperId, file),
     onSuccess: (detail) => {
-      queryClient.setQueriesData<PaperDetail>({ queryKey: ['paper'] }, (old) =>
-        old?.id === paperId ? detail : old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ['papers'] });
-      void queryClient.invalidateQueries({ queryKey: ['library'] });
-      void queryClient.invalidateQueries({ queryKey: ['shelf'] });
+      applyDetail(detail);
       toast(tr('PDF 已上传，可以阅读全文了', 'PDF uploaded — the full paper is ready to read'), 'ok');
     },
     onError: (error) => toast(`${tr('上传 PDF 失败：', 'PDF upload failed: ')}${uploadError(error)}`, 'error'),
   });
 
+  const urlMutation = useMutation({
+    mutationFn: (url: string) => api.uploadPaperPdfFromUrl(paperId, url),
+    onSuccess: (detail) => {
+      applyDetail(detail);
+      setUrl('');
+      setLinkOpen(false);
+      toast(tr('PDF 已取回，可以阅读全文了', 'PDF fetched — the full paper is ready to read'), 'ok');
+    },
+    onError: (error) => toast(`${tr('按链接取 PDF 失败：', 'Fetching the PDF failed: ')}${uploadError(error)}`, 'error'),
+  });
+
   if (pdfAvailable) return null;
+
+  const busy = mutation.isPending || urlMutation.isPending;
 
   return (
     <>
@@ -66,7 +88,7 @@ export function PdfUploadButton({
         className="btn btn-ghost sm"
         aria-label={tr('上传 PDF', 'Upload PDF')}
         aria-busy={mutation.isPending}
-        disabled={mutation.isPending}
+        disabled={busy}
         onClick={() => inputRef.current?.click()}
       >
         <Icon
@@ -76,6 +98,38 @@ export function PdfUploadButton({
         />
         {mutation.isPending ? tr('上传处理中…', 'Uploading…') : tr('上传 PDF', 'Upload PDF')}
       </button>
+      <button
+        type="button"
+        className="btn btn-ghost sm"
+        aria-label={tr('用链接添加 PDF', 'Add PDF from a link')}
+        disabled={busy}
+        onClick={() => setLinkOpen((open) => !open)}
+      >
+        <Icon name="link" size={13} />
+        {tr('用链接', 'From link')}
+      </button>
+      {linkOpen && (
+        <form
+          className="row gap-xs"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmed = url.trim();
+            if (trimmed) urlMutation.mutate(trimmed);
+          }}
+        >
+          <input
+            className="input sm"
+            type="url"
+            value={url}
+            autoFocus
+            placeholder={tr('可直接下载的 PDF 链接', 'Direct link to a PDF')}
+            onChange={(event) => setUrl(event.target.value)}
+          />
+          <button type="submit" className="btn sm" disabled={busy || !url.trim()}>
+            {urlMutation.isPending ? tr('取回中…', 'Fetching…') : tr('取回', 'Fetch')}
+          </button>
+        </form>
+      )}
     </>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3316,6 +3316,13 @@ export const api = {
     form.append('file', file);
     return request<PaperDetail>(`/papers/${id}/pdf`, { method: 'POST', body: form });
   },
+  /** 按公开链接给尚无 PDF 的论文补原件（后端做 SSRF 校验，见 literature/pdf_source.py）。 */
+  uploadPaperPdfFromUrl(id: string, url: string): Promise<PaperDetail> {
+    return request<PaperDetail>(`/papers/${id}/pdf-url`, {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+  },
 
   // —— Lit · 论文图片（docs/api-lit.md §6.5） ——
   /** 论文图片元数据列表；无图返回 []。 */


### PR DESCRIPTION
Closes #398

#401 landed the local-upload half of that issue. This is the other half: paste a direct link and Polaris fetches it.

## Why not #399

#399 was written for this, but it cannot be merged as it stands:

- **It conflicts with `main`.** GitHub reports `mergeable=false`; a trial merge collides in `api/papers.py`, `services/papers.py`, `PdfReader.tsx` and `lib/api.ts` — the four files #401 changed. #399 predates it and adds a second `upload_paper_pdf` at the same path.
- **It replaces existing PDFs**, which we decided against. That was the core of its design, so re-scoping is not a small edit.
- **DNS rebinding is open.** It resolves and checks the address, then lets httpx resolve again when connecting. An attacker controlling their own domain answers public on the first lookup and `127.0.0.1` on the second.

Its approach was sound and is reused here — in particular re-validating on every redirect hop, which most implementations miss. Left a comment on #399 explaining this.

## Behaviour

Identical rules to the upload path, deliberately: a paper that already has a PDF gets `409 PDF_ALREADY_EXISTS`, content is validated the same way, and `_process_saved_pdf` runs afterwards. A paper should not end up readable differently depending on where its PDF came from. The existing-PDF check runs *before* the download, so a refused request does not first pull 100 MB.

## SSRF

The URL is user-supplied, so this is written assuming the domain is hostile rather than mistyped.

- Scheme and credential checks; DNS pre-check that every resolved address is `is_global` — the property rather than a hand-written range list, since carrier-grade NAT and the reserved blocks are easy to leave out.
- The redirect chain is walked manually and **every hop is re-validated**. Validating only the first URL is the usual gap; one 302 to `169.254.169.254` walks straight through it.
- After connecting, the real peer address is checked before the body is read. The pre-check alone does not hold — it resolves once, httpx resolves again, and a hostile DNS can answer differently the second time. This closes the read side of that window; the request headers still go out, which is the part a pre-check cannot fix without pinning the connection.

When an outbound proxy is configured the peer *is* the proxy, so that last check is skipped and where the request lands is the proxy's business. Stated in the code rather than left as a silent hole — this deployment does set `POLARIS_OUTBOUND_PROXY`.

## Frontend

The link input goes in the shared `PdfUploadButton` that #401 introduced, so all four surfaces that already offer upload get it with no further changes, and both actions disappear together once `pdf_available` is true. The backend appends the reason to `PDF_URL_UNUSABLE`, and the UI shows it: these failures are nearly always user-fixable (a landing page instead of the PDF, a site requiring login), and a bare error code just makes people guess.

## Testing

- Backend 66 passed: `test_paper_reading test_paper_manual_add test_library_paper_management test_literature test_enrich_chunk_index`
- Frontend `tsc --noEmit` clean, `vitest run` 75 passed including #401's component tests
- Ruff clean across `app/`

The rejection tests assert **why** each URL was refused, not just that something raised. The first version asserted the exception type alone and still passed with the entire address check deleted — failing to connect to `127.0.0.1` raises the same error. Verified the current tests fail when the check is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr