### PR TITLE
fix(daily): probe every subscribed category, not just the first

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1529,35 +1529,53 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
     于是每次探测都真去打 arXiv——把我们自己打到 429。
 
     「有没有新论文可收」本来就是这个探测唯一关心的事，直接问它。
+
+    **每个订阅分类都要问。** 这里曾经只问 ``categories[0]``，拿它当整批的代表。
+    2026-08-12 生产就栽在这上面：那天 cs.AI 公告的 486 篇碰巧我们全都有了，探测
+    据此判定「没有可收的」，整轮同步一次都没启动；而同一时刻 cs.CL 有 93 篇、
+    cs.CV 148 篇、cs.RO 40 篇、cs.LG 163 篇是新的——一天漏掉 386 篇，界面上只
+    表现为「今日文献没更新」，日志里一条错误也没有。
+
+    正式抓取本来就是按全部分类取的（``fetch_new_by_category``），只有这个探测在
+    用一个分类替所有分类作答；判据和它要守护的动作口径不一致，迟早对不上。
+
+    找到一个没收过的就够了，所以命中即返回：常态下 cs.AI 有新论文，仍然只发一次
+    请求；只有像那天一样首个分类全中时才会继续往后问。
     """
     categories = await get_categories(session)
     if not categories:
         return True, None
-    try:
-        entries, batch_at = await get_arxiv_client().fetch_new(categories[0])
-    except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
-        logger.warning("daily feed probe failed", exc_info=True)
-        return True, None
 
-    declared = batch_at.astimezone(dt.UTC).date().isoformat() if batch_at else None
-    arxiv_ids = [str(e.get("arxiv_id")) for e in entries if e.get("arxiv_id")]
-    if not arxiv_ids:
-        # 一条都没有：周末/节假日的正常形态，没什么可收的
-        return False, declared
+    declared: str | None = None
+    for category in categories:
+        try:
+            entries, batch_at = await get_arxiv_client().fetch_new(category)
+        except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
+            logger.warning("daily feed probe failed for %s", category, exc_info=True)
+            return True, None
 
-    known = set(
-        (
-            await session.execute(
-                select(Paper.arxiv_id)
-                .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
-                .where(Paper.arxiv_id.in_(arxiv_ids))
+        if declared is None and batch_at is not None:
+            declared = batch_at.astimezone(dt.UTC).date().isoformat()
+        arxiv_ids = [str(e.get("arxiv_id")) for e in entries if e.get("arxiv_id")]
+        if not arxiv_ids:
+            continue
+        known = set(
+            (
+                await session.execute(
+                    select(Paper.arxiv_id)
+                    .join(DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id)
+                    .where(Paper.arxiv_id.in_(arxiv_ids))
+                )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    fresh = any(aid not in known for aid in arxiv_ids)
-    return fresh, declared
+        if any(aid not in known for aid in arxiv_ids):
+            return True, declared
+
+    # 全部分类都问过了：要么一条都没公告（周末/节假日的正常形态），
+    # 要么公告的我们已经全收了。两种都没有可做的事。
+    return False, declared
 
 
 # ---- 保留期（可配置） ----

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1757,3 +1757,84 @@ async def test_probe_says_no_when_everything_is_already_in_the_pool(client, monk
         fresh, _ = await daily_feed.todays_batch_available(session)
     assert fresh is False
 
+
+
+async def test_probe_asks_every_category_not_just_the_first(client, monkeypatch):
+    """首个分类全都收过了，也要接着问后面的分类。
+
+    2026-08-12 生产漏了一整天就是这么来的：探测只问 cs.AI，那天 cs.AI 公告的 486 篇
+    我们碰巧全有，于是判定「没有可收的」，整轮同步一次都没启动——而同一时刻 cs.CL /
+    cs.CV / cs.RO / cs.LG 合计 386 篇是新的。界面上只是「今日文献没更新」，日志里
+    一条错误也没有，所以没人会去查。
+
+    正式抓取本来就按全部分类取（fetch_new_by_category），探测却拿一个分类替所有分类
+    作答；判据和它守护的动作口径不一致，迟早对不上。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+
+    # 先让 cs.AI 的这篇真的进池，这样它对下一次探测就是「已收过」
+    seen_id = "2608.88001"
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry(seen_id, "已经收过的")]}),
+    )
+    async with get_sessionmaker()() as session:
+        await daily_feed.sync_daily_feed(session)
+
+    # cs.AI 全是收过的，cs.CV 有新的：必须判成「该抓」
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.AI": [_rss_entry(seen_id, "已经收过的")],
+                "cs.CV": [_rss_entry("2608.88002", "还没收过的")],
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is True, "首个分类没有新论文，就不再看别的分类了"
+
+    # 所有分类都收过了才算没有可做的
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv({"cs.AI": [_rss_entry(seen_id, "已经收过的")]}),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is False
+
+
+async def test_probe_stops_at_the_first_category_with_news(client, monkeypatch):
+    """命中即返回：常态下不该为了探测把每个分类都打一遍。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    asked: list[str] = []
+
+    class _Counting(_StubArxiv):
+        async def fetch_new(self, category: str):
+            asked.append(category)
+            return await super().fetch_new(category)
+
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _Counting(
+            {
+                "cs.AI": [_rss_entry("2608.88010", "新的")],
+                "cs.CV": [_rss_entry("2608.88011", "也是新的")],
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is True
+    assert asked == ["cs.AI"], f"第一个分类就有新论文，不该继续问下去：{asked}"


### PR DESCRIPTION
Found while investigating "今日文献没更新" on production.

## What happened

The probe asked arXiv about `categories[0]` and let that answer stand for the whole batch. Measured on production today:

```
cs.AI   feed= 486 known= 486 MISSING=   0
cs.CL   feed=  95 known=   2 MISSING=  93
cs.CV   feed= 148 known=   0 MISSING= 148
cs.RO   feed=  40 known=   0 MISSING=  40
cs.LG   feed= 164 known=   1 MISSING= 163
```

cs.AI happened to be fully collected already, so the probe reported nothing to do and no sync ran all day — 386 papers in the other four categories were never looked at. There is no error in the logs for this. The only symptom is the feed not updating, which is why it took a user noticing.

The real fetch has always read every category (`fetch_new_by_category`). A guard that checks less than the action it guards will disagree with it eventually, and the day it does, nothing announces itself.

## The fix

Walk every configured category and return on the first one with an unseen paper. An ordinary day, where cs.AI has new work, still costs a single request; the extra lookups only happen when the first category comes back fully known — precisely the case that used to end the day early.

## Testing

- 75 passed: `test_daily_feed test_literature`
- Ruff clean
- The regression test was run against the old single-category behaviour and fails there

A note on that last point, because I nearly shipped a check that proved nothing: my first attempt at reverting the behaviour used a string replace that hit the **first** `for category in categories:` in the file — which is in `fetch_new_by_category`, not the probe — so the tests passed and looked like they were failing to catch the bug. They were fine; the check was wrong. Redone by line number, the test fails as it should.

## Still open

This is not the whole story of today. `rss.arxiv.org/rss/cs.AI` is itself serving a stale batch — max id `2608.09930` against `2608.11204` on `/list/cs.AI/new`, an overlap of 16 out of 239, confirmed by fetching the feed directly rather than through our cache. cs.CL's RSS matches its listing, so this is per-category on arXiv's side. `export.arxiv.org/api/query` sorted by `submittedDate` returns the current batch. Changing where the daily feed reads from is a separate decision and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr