### PR TITLE
feat(daily): read the daily announcement from the listing page, not RSS

### DIFF
--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -206,6 +206,24 @@ def _parse_rss_item(item: ET.Element) -> dict[str, Any] | None:
     }
 
 
+def _parse_listing_date(raw: str | None) -> datetime | None:
+    """把列表页页头的日期（``12 August 2026``）转成 UTC datetime。
+
+    这是**页面自己声明的公告日期**，比 RSS 的 ``pubDate`` 可信：后者会整体滞后一天，
+    历史上「一直等待今天的批次」就是被它坑的。解析不出来返回 None，交由调用方按
+    「不知道是哪天」处理，而不是瞎猜一个今天。
+    """
+    if not raw:
+        return None
+    for fmt in ("%d %B %Y", "%d %b %Y"):
+        try:
+            return datetime.strptime(raw.strip(), fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    logger.warning("unrecognised arxiv listing date: %r", raw)
+    return None
+
+
 def _parse_rss(text: str) -> tuple[list[dict[str, Any]], datetime | None]:
     """解析 RSS，返回 (条目, **这一批的公告日期**)。
 
@@ -469,10 +487,17 @@ class ArxivClient:
         )
 
     async def fetch_new(self, category: str) -> tuple[list[dict[str, Any]], datetime | None]:
-        """抓一个分类的当天新公告（RSS /new，即时无索引滞后）。
+        """抓一个分类的当天新公告（``/list/{category}/new`` 列表页）。
 
-        只返回 announce_type ∈ {new, cross} 的条目（replace/replace-cross 是旧论文更新，
-        已在解析时剔除）；字段与 ``search`` 返回的 entry 对齐，便于复用入库逻辑。
+        只返回 announce_type ∈ {new, cross} 的条目（Replacement 是旧论文更新，
+        解析时按分段剔除）；字段与 ``search`` 返回的 entry 对齐，便于复用入库逻辑。
+
+        **数据源从 rss.arxiv.org 换成了列表页。** RSS 会按分类各自陈旧，而且毫无迹象：
+        2026-08-12 生产上 cs.AI 的 RSS 供的是上一批（最大 id ``2608.09930``），同一时刻
+        网页已经是 ``2608.11204``，两边只重合 16 篇；同一天 cs.CL 的 RSS 却是新的。
+        ``lastBuildDate`` 照样写着当天，于是「拿到旧批次」和「今天没新论文」在下游长得
+        一模一样——去重后一条不进，每一步都报成功。列表页每段自带 ``showing X of Y``，
+        这两件事才分得开（见 :mod:`.arxiv_listing`）。
 
         **失败原样上抛**（限流已在 :meth:`_request` 里重试过，走到这里是真失败）。
         这里曾经把任何异常吞成 []，于是「被限流」和「今天确实没有新论文」变成同一个
@@ -481,15 +506,37 @@ class ArxivClient:
         :func:`app.services.daily_feed.fetch_new_by_category`。
         失败不写缓存，下次重试。
         """
-        key = cache_key("arxiv", "rss_new", {"category": category})
+        from app.services.literature.arxiv_listing import (
+            LISTING_PAGE_SIZE,
+            LISTING_URL_TEMPLATE,
+            ArxivListingError,
+            parse_listing,
+        )
+
+        key = cache_key("arxiv", "listing_new", {"category": category})
         if (cached := await self._rss_cache.get(key)) is not None:
-            # 不再按「声明的日期是不是今天」决定能不能用缓存：arXiv 的 RSS 日期字段
-            # 会整体滞后一天（见 daily_feed.todays_batch_available），那样判的结果是
-            # 缓存永远写不进、每次探测都真打 arXiv。改用短 TTL 控制陈旧程度。
+            # 不按「声明的日期是不是今天」决定能不能用缓存——那样判的结果是缓存永远
+            # 写不进、每次探测都真打 arXiv。改用短 TTL 控制陈旧程度。
             return cached["entries"], _parse_iso_dt(cached.get("batch_at"))
-        resp = await self._request(RSS_URL_TEMPLATE.format(category=category))
-        entries, batch_at = _parse_rss(resp.text)
-        # 失败不写缓存（见 _request）；成功的一律写，靠短 TTL 控制陈旧程度
+
+        entries: list[dict[str, Any]] = []
+        announced: str | None = None
+        skip = 0
+        # 实测单个分类 200–350 条、整个 cs 也才 1096，一页就够；翻页是给「页面说没给全」
+        # 兜底的，正常不会走到。上限防的是解析出错导致的死循环。
+        for _page in range(10):
+            url = LISTING_URL_TEMPLATE.format(category=category)
+            resp = await self._request(url, params={"skip": skip, "show": LISTING_PAGE_SIZE})
+            page_entries, page_date, incomplete = parse_listing(resp.text)
+            announced = announced or page_date
+            entries.extend(page_entries)
+            if not incomplete or not page_entries:
+                break
+            skip += len(page_entries)
+        else:
+            raise ArxivListingError(f"{category} 列表页翻了 10 页仍未取完")
+
+        batch_at = _parse_listing_date(announced)
         await self._rss_cache.set(
             key, {"entries": entries, "batch_at": batch_at.isoformat() if batch_at else None}
         )

--- a/src/backend/app/services/literature/arxiv_listing.py
+++ b/src/backend/app/services/literature/arxiv_listing.py
@@ -1,0 +1,194 @@
+"""解析 arXiv 的每日公告列表页（``/list/{category}/new``）。
+
+**为什么不用 RSS。** ``rss.arxiv.org`` 会按分类各自陈旧：2026-08-12 生产上
+cs.AI 的 RSS 供的是上一批（最大 id ``2608.09930``），而同一时刻网页列表已经是
+``2608.11204``，两边只重合 16 篇；cs.CL 的 RSS 却是新的。RSS 还把 ``lastBuildDate``
+写成当天，所以这种陈旧**没有任何迹象**——条目几百条，去重后一条不进，每一步都报成功。
+
+列表页在三件事上更适合当数据源：
+
+1. 公告日期是页面自己写的（``Showing new listings for Wednesday, 12 August 2026``），
+   不像 RSS 的 ``pubDate`` 会整体滞后一天；
+2. New / Cross / Replacement 分段标注，和我们「只收 new+cross」的口径天然对齐；
+3. **每段自带条数**（``showing 79 of 79 entries``），于是「解析坏了」和「今天没公告」
+   可以区分开——这正是 RSS 给不了的，也是那次漏收一整天没被发现的原因。
+
+代价是依赖 HTML 结构。所以这里的原则是**宁可炸掉也不要静默返回空**：条数对不上就抛
+:class:`ArxivListingError`，交给调用方按失败处理。
+"""
+
+import logging
+import re
+from html import unescape
+from typing import Any
+
+from app.services.literature.arxiv import (
+    ABS_URL_TEMPLATE,
+    PDF_URL_TEMPLATE,
+    normalize_arxiv_id,
+)
+
+logger = logging.getLogger(__name__)
+
+LISTING_URL_TEMPLATE = "https://arxiv.org/list/{category}/new"
+
+#: 页面自己声明的每页上限。显式带上，不吃「默认给全量」这个随时会变的行为。
+LISTING_PAGE_SIZE = 2000
+
+#: 只收这两段。Replacement 是旧论文更新，不是当天新公告。
+_WANTED_SECTIONS = ("new", "cross")
+
+_SECTION_RE = re.compile(
+    r"<h3[^>]*>\s*(New|Cross|Replacement)\s+submissions?\s*"
+    r"\(showing\s+(?:first\s+)?(\d+)\s+of\s+(\d+)\s+entries\)",
+    re.I,
+)
+_HEADER_DATE_RE = re.compile(
+    r"<h3[^>]*>\s*Showing new listings for\s+(?:\w+day),?\s*(\d{1,2}\s+\w+\s+\d{4})", re.I
+)
+_ENTRY_RE = re.compile(r"<dt>(?P<dt>.*?)</dt>\s*<dd>(?P<dd>.*?)</dd>", re.S)
+_ARXIV_ID_RE = re.compile(r"arXiv:(\d{4}\.\d{4,5})")
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+class ArxivListingError(RuntimeError):
+    """列表页取不到或解析不出来。**绝不退化成空结果。**"""
+
+
+def _text(fragment: str) -> str:
+    return unescape(_TAG_RE.sub(" ", fragment)).replace("\xa0", " ").strip()
+
+
+def _collapse(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _section_spans(html: str) -> list[tuple[str, int, int, int, int]]:
+    """切出各段：(名字, 本页条数, 总条数, 正文起点, 正文终点)。"""
+    marks = list(_SECTION_RE.finditer(html))
+    spans: list[tuple[str, int, int, int, int]] = []
+    for index, mark in enumerate(marks):
+        end = marks[index + 1].start() if index + 1 < len(marks) else len(html)
+        spans.append(
+            (mark.group(1).lower(), int(mark.group(2)), int(mark.group(3)), mark.end(), end)
+        )
+    return spans
+
+
+def _div(dd_html: str, class_name: str) -> str | None:
+    """取 ``<div class='list-xxx'>`` 的内容。
+
+    按 class 取，不在拍平后的文本里按 ``Title:`` / ``Subjects:`` 这类字样切——
+    页面里标题和作者之间没有任何标签词，纯文本切法会把作者名粘进标题，
+    而这种错不会报任何异常，只会让库里多出一堆标题带人名的论文。
+    """
+    match = re.search(
+        rf"<div[^>]*class=['\"][^'\"]*\b{class_name}\b[^'\"]*['\"][^>]*>(.*?)</div>",
+        dd_html,
+        re.S | re.I,
+    )
+    return match.group(1) if match else None
+
+
+def _strip_descriptor(fragment: str) -> str:
+    """去掉 ``<span class='descriptor'>Title:</span>`` 这类前缀标签。"""
+    return re.sub(
+        r"<span[^>]*class=['\"][^'\"]*descriptor[^'\"]*['\"][^>]*>.*?</span>",
+        " ",
+        fragment,
+        flags=re.S | re.I,
+    )
+
+
+def _parse_entry(dt_html: str, dd_html: str) -> dict[str, Any] | None:
+    """把一条 dt/dd 解析成与 RSS 条目同形状的 dict。
+
+    id **只从 dt 里取**：dd 是摘要正文，里面完全可能提到别的 arXiv 编号，
+    拿正则扫全页会凭空多收论文（实测某天页面上唯一 id 比 ``Total of`` 多一个）。
+    """
+    id_match = _ARXIV_ID_RE.search(dt_html)
+    if id_match is None:
+        return None
+    arxiv_id = normalize_arxiv_id(id_match.group(1))
+
+    title_html = _div(dd_html, "list-title")
+    title = _collapse(_text(_strip_descriptor(title_html))) if title_html else ""
+    if not arxiv_id or not title:
+        return None
+
+    authors_html = _div(dd_html, "list-authors") or ""
+    names = [_collapse(_text(a)) for a in re.findall(r"<a[^>]*>(.*?)</a>", authors_html, re.S)]
+    authors = [{"name": n} for n in names if n] or None
+
+    subjects_html = _div(dd_html, "list-subjects") or ""
+    primary_match = re.search(
+        r"<span[^>]*class=['\"][^'\"]*primary-subject[^'\"]*['\"][^>]*>(.*?)</span>",
+        subjects_html,
+        re.S | re.I,
+    )
+    subjects_text = _text(_strip_descriptor(subjects_html))
+    categories = re.findall(r"\(([a-zA-Z\-]+\.[a-zA-Z\-]+)\)", subjects_text)
+    primary = None
+    if primary_match:
+        found = re.search(r"\(([a-zA-Z\-]+\.[a-zA-Z\-]+)\)", _text(primary_match.group(1)))
+        primary = found.group(1) if found else None
+    if primary:
+        # arXiv 明确标了主分类就用它，别拿「列表里的第一个」当主分类
+        categories = [primary] + [c for c in categories if c != primary]
+
+    abstract_match = re.search(r"<p[^>]*class=['\"][^'\"]*mathjax[^'\"]*['\"][^>]*>(.*?)</p>",
+                               dd_html, re.S | re.I)
+    abstract = _collapse(_text(abstract_match.group(1))) if abstract_match else None
+
+    return {
+        "arxiv_id": arxiv_id,
+        "title": title,
+        "abstract": abstract,
+        "authors": authors,
+        "published": None,
+        "updated": None,
+        "year": None,
+        "categories": categories,
+        "primary_category": primary or (categories[0] if categories else None),
+        "doi": None,
+        "url": ABS_URL_TEMPLATE.format(arxiv_id=arxiv_id),
+        "pdf_url": PDF_URL_TEMPLATE.format(arxiv_id=arxiv_id),
+        "announce_type": None,  # 由调用方按所在分段填
+    }
+
+
+def parse_listing(html: str) -> tuple[list[dict[str, Any]], str | None, bool]:
+    """解析一页，返回 (条目, 公告日期原文, 是否还有没取完的)。
+
+    条目只含 new + cross。段头写着本页几条、总共几条，两处都用上：
+    解析出的条数对不上本页声明 → 抛错（结构变了）；本页声明 < 总数 → 还要翻页。
+    """
+    spans = _section_spans(html)
+    if not spans:
+        raise ArxivListingError("列表页里找不到任何分段标题（页面结构可能变了）")
+
+    date_match = _HEADER_DATE_RE.search(html)
+    announced = date_match.group(1) if date_match else None
+
+    entries: list[dict[str, Any]] = []
+    incomplete = False
+    for name, shown, total, start, end in spans:
+        if name not in _WANTED_SECTIONS:
+            continue
+        if shown < total:
+            incomplete = True
+        parsed = [
+            entry
+            for match in _ENTRY_RE.finditer(html[start:end])
+            if (entry := _parse_entry(match.group("dt"), match.group("dd"))) is not None
+        ]
+        # 解析不出来必须炸。静默少收和「今天没公告」在下游长得一模一样，
+        # 而后者是完全正常的一天——分不开就等于这类故障永远不会被发现。
+        if len(parsed) != shown:
+            raise ArxivListingError(
+                f"{name} 段声明 {shown} 条，实际解析出 {len(parsed)} 条（页面结构可能变了）"
+            )
+        for entry in parsed:
+            entry["announce_type"] = name
+        entries.extend(parsed)
+    return entries, announced, incomplete

--- a/src/backend/tests/fixtures/arxiv_listing_sample.html
+++ b/src/backend/tests/fixtures/arxiv_listing_sample.html
@@ -1,0 +1,179 @@
+<html><body><h3>Showing new listings for Wednesday, 12 August 2026</h3>
+<h3>New submissions (showing 2 of 2 entries)</h3>
+<dt>
+      <a name='item1'>[1]</a>
+      <a href ="/abs/2608.09949" title="Abstract" id="2608.09949">
+        arXiv:2608.09949
+      </a>
+      
+        [<a href="/pdf/2608.09949" title="Download PDF" id="pdf-2608.09949" aria-labelledby="pdf-2608.09949">pdf</a>, <a href="https://arxiv.org/html/2608.09949v1" title="View HTML" id="html-2608.09949" aria-labelledby="html-2608.09949" rel="noopener noreferrer" target="_blank">html</a>, <a href="/format/2608.09949" title="Other formats" id="oth-2608.09949" aria-labelledby="oth-2608.09949">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          Closed-Loop LLM Co-Pilots for Digital Agriculture
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Kernbach,+S">Serge Kernbach</a></div>
+
+
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Artificial Intelligence (cs.AI)</span>; Biological Physics (physics.bio-ph)
+        </div>
+
+        <p class='mathjax'>
+          This study evaluates the application of Large Language Models (LLMs) in complex biological systems, evolving from data analysis to autonomous, AI-guided experimentation. The framework is driven by data from a 49-channel phytosensor network, encompassing multispectral, electrochemical, and dielectric modalities. To enhance accessibility, the system provides real-time natural-language interpretation for both specialists and non-experts. However, its core advantage lies in the transition from human-in-the-loop analysis to autonomous control. Processing biophysical data, the LLM evaluates plant physiology and triggers hardware actuators to optimize microclimates, execute phenotyping protocols, or induce controlled stress scenarios. This closed-loop architecture establishes a direct AI-biology interface, enabling data-driven exploration of complex biosystems and ecologies. The framework was validated across three case studies, based on a vertical farm and a single-plant setup and deciphered complex micro- and macro-fluctuations in plant physiology. Agents in a production-scale deployment executed multi-parameter optimization, balancing biomass accumulation, chlorophyll content, and energy consumption. The LLM processed biosensing telemetry to modulate full-spectrum, 450 nm, and 660 nm lighting at 2-hour intervals. Compared to periodic control, the system in minimal-time mode reduced the production cycle by 35%. In the energy-optimization mode, it reduced energy consumption by 18% with only a marginal increase in cultivation time, exploiting physiological inertia via light pulses. Finally, the agents autonomously developed an unforeseen strategy of dark-induced chlorophyll accumulation, resulting in a 67.9% energy saving. This framework transforms LLMs into autonomous co-pilots for digital agriculture, improving the cost-to-value ratio and lowering computational and expert-labor constraints.
+        </p>
+      </div>
+    </dd>
+<dt>
+      <a name='item2'>[2]</a>
+      <a href ="/abs/2608.09967" title="Abstract" id="2608.09967">
+        arXiv:2608.09967
+      </a>
+      
+        [<a href="/pdf/2608.09967" title="Download PDF" id="pdf-2608.09967" aria-labelledby="pdf-2608.09967">pdf</a>, <a href="https://arxiv.org/html/2608.09967v1" title="View HTML" id="html-2608.09967" aria-labelledby="html-2608.09967" rel="noopener noreferrer" target="_blank">html</a>, <a href="/format/2608.09967" title="Other formats" id="oth-2608.09967" aria-labelledby="oth-2608.09967">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          SPOTting the Future: Lookahead Explanations for Deep Reinforcement Learning
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Gozlan,+T">Tamar Gozlan</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Goldman,+C+V">Claudia V. Goldman</a></div>
+
+
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Artificial Intelligence (cs.AI)</span>; Machine Learning (cs.LG)
+        </div>
+
+        <p class='mathjax'>
+          Deep reinforcement learning (DRL) agents achieve strong performance in complex environments, yet their decision-making processes remain difficult to interpret. We introduce SPOT (Sampling Policy Observation Tree), a novel model-agnostic, sampling-based framework for interpreting DRL policies. Given access to the policy and an environment simulator, SPOT constructs an interpretable finite-horizon tree by sampling actions and recursively simulating the resulting successor states. The tree provides an empirical representation of the policy&#39;s action preferences and their possible downstream evolution. We provide formal guarantees establishing SPOT&#39;s asymptotic recovery of the policy&#39;s unique most probable action and characterizing its disagreement behavior under high-entropy policies. We demonstrate SPOT in the SUMO-RL traffic-signal control domain. The case study illustrates how its tree-based representation can be used to inspect policy preferences, compare alternative future trajectories, and reveal downstream behaviors that are not visible through single-timestep feature-attribution methods.
+        </p>
+      </div>
+    </dd>
+<h3>Cross submissions (showing 2 of 2 entries)</h3>
+<dt>
+      <a name='item80'>[80]</a>
+      <a href ="/abs/2505.11635" title="Abstract" id="2505.11635">
+        arXiv:2505.11635
+      </a>
+          (cross-list from cs.LG)
+
+        [<a href="/pdf/2505.11635" title="Download PDF" id="pdf-2505.11635" aria-labelledby="pdf-2505.11635">pdf</a>, <a href="https://arxiv.org/html/2505.11635v2" title="View HTML" id="html-2505.11635" aria-labelledby="html-2505.11635" rel="noopener noreferrer" target="_blank">html</a>, <a href="/format/2505.11635" title="Other formats" id="oth-2505.11635" aria-labelledby="oth-2505.11635">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          The Gaussian-Multinoulli Restricted Boltzmann Machine: A Potts Model Extension of the GRBM
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Kapasi,+N">Nikhil Kapasi</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Elfouly,+M">Mohamed Elfouly</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Whitehead,+W">William Whitehead</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Theogarajan,+L">Luke Theogarajan</a></div>
+
+        <div class='list-comments mathjax'><span class='descriptor'>Comments:</span>
+          11 pages, 3 figures (1 figure has 2 subfigures), conference
+        </div>
+
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Machine Learning (cs.LG)</span>; Artificial Intelligence (cs.AI)
+        </div>
+
+        <p class='mathjax'>
+          Many real-world tasks, from associative memory to symbolic reasoning, benefit from discrete, structured representations that standard continuous latent models can struggle to express. We introduce the Gaussian-Multinoulli Restricted Boltzmann Machine (GM-RBM), a generative energy-based model that extends the Gaussian-Bernoulli RBM (GB-RBM) by replacing binary hidden units with q-state categorical (Potts) units, yielding a richer latent state space for multivalued concepts. We provide a self-contained derivation of the energy, conditional distributions, and learning rules, and detail practical training choices (contrastive divergence with temperature annealing and intra-slot diversity constraints) that avoid state collapse. To separate architectural effects from sheer latent capacity, we evaluate under both capacity-matched and parameter-matched setups, comparing GM-RBM with GB-RBM configured to have the same number of possible latent assignments. On analogical recall and structured memory benchmarks, GM-RBM achieves competitive, and in several regimes improved, recall at equal capacity with comparable training cost, despite using only Gibbs updates. The discrete q-ary formulation is also amenable to efficient implementation. These results clarify when categorical hidden units provide a simple, scalable alternative to binary latents for discrete inference within tractable RBMs.
+        </p>
+      </div>
+    </dd>
+<dt>
+      <a name='item81'>[81]</a>
+      <a href ="/abs/2607.28646" title="Abstract" id="2607.28646">
+        arXiv:2607.28646
+      </a>
+          (cross-list from cs.HC)
+
+        [<a href="/pdf/2607.28646" title="Download PDF" id="pdf-2607.28646" aria-labelledby="pdf-2607.28646">pdf</a>, <a href="/format/2607.28646" title="Other formats" id="oth-2607.28646" aria-labelledby="oth-2607.28646">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          &#34;YES! YES! I absolutely love this insight!&#34; Affirmative Narration as Interactional Strategy in Dialogues with LLM Chatbots
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Roine,+H">Hanna-Riikka Roine</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Refsum,+A+S">Anne Sigrid Refsum</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Rettberg,+J+W">Jill Walker Rettberg</a></div>
+
+        <div class='list-comments mathjax'><span class='descriptor'>Comments:</span>
+          In review for a special issue of Narrative Inquiry
+        </div>
+
+        <div class='list-journal-ref'><span class='descriptor'>Journal-ref:</span>
+          2026 Narrative Inquiry 23 (2)
+        </div>
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Human-Computer Interaction (cs.HC)</span>; Artificial Intelligence (cs.AI)
+        </div>
+
+        <p class='mathjax'>
+          This article analyses narrative mechanisms that are common in dialogues with LLM chatbots. In combination, these mechanisms produce an interactional strategy for maximising user engagement, which we call affirmative narration. Affirmative narration serves to convince users of the chatbot&#39;s utility. We analyse three narrative mechanisms that support affirmative narration in human-LLM dialogues: firstly, guiding the user to view the chatbot as an intelligent and reliable character; secondly, activating masterplots, culturally significant and recurring story templates; and thirdly, using characters and masterplots not only to affirm, but also to isolate the user. The case studies range from a journalist&#39;s unsettling chatbot experiment to cases where users have experienced delusions or even died by suicide after lengthy interactions with a chatbot. The analyses illustrate the worrying sides of affirmative narration, and the article thus concludes with a discussion of LLMs as a genre of fictional narrative media that requires a new type of literacy.
+        </p>
+      </div>
+    </dd>
+<h3>Replacement submissions (showing 2 of 2 entries)</h3>
+<dt>
+      <a name='item212'>[212]</a>
+      <a href ="/abs/2112.07752" title="Abstract" id="2112.07752">
+        arXiv:2112.07752
+      </a>
+          (replaced)
+
+        [<a href="/pdf/2112.07752" title="Download PDF" id="pdf-2112.07752" aria-labelledby="pdf-2112.07752">pdf</a>, <a href="https://arxiv.org/html/2112.07752v5" title="View HTML" id="html-2112.07752" aria-labelledby="html-2112.07752" rel="noopener noreferrer" target="_blank">html</a>, <a href="/format/2112.07752" title="Other formats" id="oth-2112.07752" aria-labelledby="oth-2112.07752">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          Representation and Invariance in Reinforcement Learning
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Alexander,+S">Samuel Alexander</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Pedersen,+A+P">Arthur Paul Pedersen</a></div>
+
+        <div class='list-comments mathjax'><span class='descriptor'>Comments:</span>
+          16 pages, 1 figure
+        </div>
+
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Artificial Intelligence (cs.AI)</span>; Computer Science and Game Theory (cs.GT); Machine Learning (cs.LG)
+        </div>
+
+        <p class='mathjax'>
+          Researchers have formalized reinforcement learning (RL) in different ways. If an agent in one RL framework is to run within another RL framework&#39;s environments, the agent must first be converted, or mapped, into that other framework. In this paper, we lay foundations for studying relative-intelligence-preserving mappability between RL frameworks. We introduce a criterion which is sufficient for relative intelligence to be preserved according to one particular method of measuring intelligence. We show that this criterion cannot be met when mapping between certain deterministic and stochastic RL frameworks, suggesting inherent fundamental differences between these different versions of RL.
+        </p>
+      </div>
+    </dd>
+<dt>
+      <a name='item213'>[213]</a>
+      <a href ="/abs/2505.23399" title="Abstract" id="2505.23399">
+        arXiv:2505.23399
+      </a>
+          (replaced)
+
+        [<a href="/pdf/2505.23399" title="Download PDF" id="pdf-2505.23399" aria-labelledby="pdf-2505.23399">pdf</a>, <a href="https://arxiv.org/html/2505.23399v2" title="View HTML" id="html-2505.23399" aria-labelledby="html-2505.23399" rel="noopener noreferrer" target="_blank">html</a>, <a href="/format/2505.23399" title="Other formats" id="oth-2505.23399" aria-labelledby="oth-2505.23399">other</a>]
+    </dt>
+    <dd>
+      <div class='meta'>
+        <div class='list-title mathjax'><span class='descriptor'>Title:</span>
+          GAM-Agent: Game-Theoretic and Uncertainty-Aware Collaboration for Complex Visual Reasoning
+        </div>
+        <div class='list-authors'><a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Zhang,+J">Jusheng Zhang</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Fan,+Y">Yijia Fan</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Lin,+W">Wenjun Lin</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Chen,+R">Ruiqi Chen</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Jiang,+H">Haoyi Jiang</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Chai,+W">Wenhao Chai</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Wang,+J">Jian Wang</a>, <a href="https://arxiv.org/search/cs?searchtype=author&amp;query=Wang,+K">Keze Wang</a></div>
+
+        <div class='list-comments mathjax'><span class='descriptor'>Comments:</span>
+          Accepted at NeurIPS 2025. Code available at <a href="https://github.com/jushengzhang/Gam-Agent" rel="external noopener nofollow" class="link-external link-https">this https URL</a>
+        </div>
+
+
+        <div class='list-subjects'><span class='descriptor'>Subjects:</span>
+          <span class="primary-subject">Artificial Intelligence (cs.AI)</span>
+        </div>
+
+        <p class='mathjax'>
+          We propose GAM-Agent, a game-theoretic multi-agent framework for enhancing vision-language reasoning. Unlike prior single-agent or monolithic models, GAM-Agent formulates the reasoning process as a non-zero-sum game between base agents--each specializing in visual perception subtasks--and a critical agent that verifies logic consistency and factual correctness. Agents communicate via structured claims, evidence, and uncertainty estimates. The framework introduces an uncertainty-aware controller to dynamically adjust agent collaboration, triggering multi-round debates when disagreement or ambiguity is detected. This process yields more robust and interpretable predictions. Experiments on four challenging benchmarks--MMMU, MMBench, MVBench, and V*Bench--demonstrate that GAM-Agent significantly improves performance across various VLM backbones. Notably, GAM-Agent boosts the accuracy of small-to-mid scale models (e.g., Qwen2.5-VL-7B, InternVL3-14B) by 5--6\%, and still enhances strong models like GPT-4o by up to 2--3\%. Our approach is modular, scalable, and generalizable, offering a path toward reliable and explainable multi-agent multimodal reasoning.
+        </p>
+      </div>
+    </dd></body></html>

--- a/src/backend/tests/test_arxiv_listing.py
+++ b/src/backend/tests/test_arxiv_listing.py
@@ -1,0 +1,69 @@
+"""解析 arXiv 每日公告列表页。
+
+样本是从 2026-08-12 真实的 ``/list/cs.AI/new`` 裁下来的：页头、三个分段标题、每段两条
+真实条目，标记与嵌套一字未改。手写的假 HTML 只能验证「我以为页面长什么样」，
+而这个解析器唯一的风险就是我以为的和实际不一样。
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.services.literature.arxiv_listing import ArxivListingError, parse_listing
+
+SAMPLE = (Path(__file__).parent / "fixtures" / "arxiv_listing_sample.html").read_text()
+
+
+def test_parses_real_markup_into_entries():
+    entries, announced, incomplete = parse_listing(SAMPLE)
+
+    assert announced == "12 August 2026", "公告日期取页面自己写的，不取 RSS 那个会滞后的"
+    assert incomplete is False
+    assert len(entries) == 4
+
+    first = entries[0]
+    assert first["arxiv_id"] == "2608.09949"
+    assert first["title"] == "Closed-Loop LLM Co-Pilots for Digital Agriculture"
+    # 标题和作者之间没有任何标签词，按纯文本切会把作者名粘进标题且不报错
+    assert "Kernbach" not in first["title"]
+    assert [a["name"] for a in first["authors"]] == ["Serge Kernbach"]
+    assert first["primary_category"] == "cs.AI"
+    assert "physics.bio-ph" in first["categories"]
+    assert first["abstract"] and first["abstract"].startswith("This study evaluates")
+    assert first["url"].endswith("2608.09949")
+
+
+def test_replacements_are_left_out():
+    """Replacement 是旧论文更新，不是当天新公告。"""
+    entries, _, _ = parse_listing(SAMPLE)
+    kinds = {e["announce_type"] for e in entries}
+    assert kinds == {"new", "cross"}
+
+
+def test_count_mismatch_raises_instead_of_returning_less():
+    """段头说 2 条、只解析出 1 条 → 抛错。
+
+    这是换掉 RSS 的全部理由。少收和「今天没公告」在下游长得一模一样，而后者是完全
+    正常的一天；分不开，这类故障就永远不会被发现——2026-08-12 漏掉一整天正是如此。
+    """
+    # 模拟 arXiv 改了类名——这正是 HTML 解析真实会遇到的失效方式
+    broken = SAMPLE.replace("list-title", "list-heading", 1)
+    with pytest.raises(ArxivListingError, match="解析出"):
+        parse_listing(broken)
+
+
+def test_missing_sections_raise():
+    """页面完全变样时不能返回空——空是「今天没论文」的意思。"""
+    with pytest.raises(ArxivListingError):
+        parse_listing("<html><body>arXiv is down for maintenance</body></html>")
+
+
+def test_truncated_page_reports_incomplete():
+    """段头写 first N of M 时要说「还没取完」，让上层去翻页。"""
+    truncated = SAMPLE.replace(
+        "<h3>New submissions (showing 2 of 2 entries)</h3>",
+        "<h3>New submissions (showing first 2 of 90 entries)</h3>",
+    )
+    entries, _, incomplete = parse_listing(truncated)
+    assert incomplete is True
+    assert len(entries) == 4, "本页解析出的照常返回，翻页交给调用方"

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -150,50 +150,49 @@ async def test_arxiv_search_parses_and_caches(cache_redis):
 
 
 @respx.mock
-async def test_arxiv_fetch_new_rss_parses_filters_and_caches(cache_redis):
-    import datetime as _dt
+async def test_arxiv_fetch_new_parses_the_listing_page_and_caches(cache_redis):
+    """当天新公告改从 ``/list/{cat}/new`` 取。
 
-    today = _dt.datetime.now(_dt.UTC).date()
-    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
-        return_value=httpx.Response(200, text=_rss_with_batch_date(today))
+    换源的原因见 arxiv_listing 模块头：rss.arxiv.org 会按分类各自陈旧，而且把
+    lastBuildDate 照写成当天，于是「拿到旧批次」在下游和「今天没新论文」完全一样。
+    """
+    from pathlib import Path
+
+    sample = (Path(__file__).parent / "fixtures" / "arxiv_listing_sample.html").read_text()
+    route = respx.get(url__regex=r"https://arxiv\.org/list/cs\.CL/new.*").mock(
+        return_value=httpx.Response(200, text=sample)
     )
     client = ArxivClient(redis=cache_redis, min_interval=0)
     entries, batch_at = await client.fetch_new("cs.CL")
-    assert batch_at is not None and batch_at.astimezone(_dt.UTC).date() == today
 
-    # 只留 announce_type ∈ {new, cross}；replace / replace-cross（旧论文更新）被跳过
-    assert [e["announce_type"] for e in entries] == ["new", "cross"]
+    # 公告日期取页面页头自己写的那一行，不取会滞后一天的 RSS pubDate
+    assert batch_at is not None and batch_at.date().isoformat() == "2026-08-12"
+    # 只留 new + cross；Replacement（旧论文更新）按分段剔除
+    assert {e["announce_type"] for e in entries} == {"new", "cross"}
     first = entries[0]
-    assert first["arxiv_id"] == "2607.10001"  # guid 的 v1 版本号被 normalize 去掉
-    assert first["title"] == "Computer-Use Agents at Scale"
-    # description "Abstract:" 之后截取为摘要
-    assert first["abstract"] == (
-        "We study computer use agents operating at scale with strong results."
-    )
-    assert first["authors"] == [{"name": "Alice Smith"}, {"name": "Bob Jones"}]
-    assert first["categories"] == ["cs.CL", "cs.AI"]
-    assert first["primary_category"] == "cs.CL"
-    assert first["year"] == 2026
-    assert first["published"].startswith("2026-07-20")
-    assert first["pdf_url"].endswith("/pdf/2607.10001")
+    assert first["arxiv_id"] == "2608.09949"
+    assert first["title"] == "Closed-Loop LLM Co-Pilots for Digital Agriculture"
+    assert first["authors"] == [{"name": "Serge Kernbach"}]
+    assert first["primary_category"] == "cs.AI"
+    assert first["abstract"].startswith("This study evaluates")
+    assert first["pdf_url"].endswith("/pdf/2608.09949")
     assert first["doi"] is None
-    assert entries[1]["arxiv_id"] == "2607.10002"  # v2 也被去版本号
 
     # 短 TTL 缓存命中：相同分类第二次调用不再发 HTTP
     again, _ = await client.fetch_new("cs.CL")
-    assert [e["arxiv_id"] for e in again] == ["2607.10001", "2607.10002"]
+    assert [e["arxiv_id"] for e in again] == [e["arxiv_id"] for e in entries]
     assert route.call_count == 1
     await client.aclose()
 
 
 @respx.mock
 async def test_arxiv_fetch_new_raises_after_exhausted_retries(cache_redis):
-    """RSS 失败原样上抛，**不再吞成 []**。
+    """取数失败原样上抛，**不再吞成 []**。
 
     吞掉的话「被限流」和「今天确实没有新论文」就成了同一个结果，而每日池是所有
     文献库的唯一供给——静默的空池等于全实验室当天颗粒无收却无人知晓。
     """
-    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/.*").mock(
+    route = respx.get(url__regex=r"https://arxiv\.org/list/.*").mock(
         return_value=httpx.Response(503)
     )
     client = ArxivClient(redis=cache_redis, min_interval=0, backoff_base=0.0, max_retries=2)
@@ -458,8 +457,8 @@ async def test_penalize_extends_the_shared_gate(cache_redis):
     assert ttl > 1000
     assert b._interval > 0  # b 会在 acquire 时撞上这个闸门
 @respx.mock
-async def test_rss_is_cached_regardless_of_the_declared_date(cache_redis):
-    """RSS 一律进缓存，陈旧程度由**短 TTL**控制。
+async def test_listing_is_cached_regardless_of_the_declared_date(cache_redis):
+    """取回的公告一律进缓存，陈旧程度由**短 TTL**控制。
 
     这条原来钉的是「陈旧批次不进缓存」——判据是 RSS 里声明的批次日期。现实推翻了它：
     arXiv 的日期字段会整体滞后一天（网页版已经是次日的清单、条目 id 也是当天的，而
@@ -469,11 +468,13 @@ async def test_rss_is_cached_regardless_of_the_declared_date(cache_redis):
     「今天那批出来了没有」现在按内容判（见 daily_feed.todays_batch_available），
     缓存只需保证别太旧。
     """
-    import datetime as _dt
 
-    yesterday = _dt.datetime.now(_dt.UTC).date() - _dt.timedelta(days=1)
-    route = respx.get(url__regex=r"https://rss\.arxiv\.org/rss/cs\.CL").mock(
-        return_value=httpx.Response(200, text=_rss_with_batch_date(yesterday))
+    from pathlib import Path
+
+    # 样本页头写的是 2026-08-12，对「今天」而言早已是过去
+    sample = (Path(__file__).parent / "fixtures" / "arxiv_listing_sample.html").read_text()
+    route = respx.get(url__regex=r"https://arxiv\.org/list/cs\.CL/new.*").mock(
+        return_value=httpx.Response(200, text=sample)
     )
     client = ArxivClient(redis=cache_redis, min_interval=0)
 


### PR DESCRIPTION
Closes #414

`rss.arxiv.org` goes stale per category and gives no sign of it. Measured on production on 2026-08-12:

| | listing page | RSS | overlap | missing from our pool |
| --- | --- | --- | --- | --- |
| cs.AI | 239, max `2608.11204` | 486, max `2608.09930` | **16** | 212 |
| cs.CL | 108, max `2608.11200` | 95, max `2608.11200` | 95 | 93 |

cs.AI served the previous batch while cs.CL was current, the same morning, both reporting `lastBuildDate` of that day. Verified by fetching the feed directly rather than through our cache, so it is not ours.

Downstream a stale batch and a quiet day are indistinguishable: hundreds of entries arrive, dedup drops all of them, every step reports success. Nothing to alert on. That is why a person had to notice.

## Why the listing page

- It states the announcement date itself, instead of a `pubDate` that lags a day — the lag that already forced the batch check off dates and onto content.
- New / Cross / Replacement are labelled sections, which is the split we already apply.
- Each section carries `showing X of Y`, so **a broken parse is distinguishable from a day with no papers**. That is the point of the change; every version of this bug has been invisible because those two produce the same result.

`Allow: /list` in arXiv's robots.txt. `export.arxiv.org/api/query` also has the current batch but has no announcement day and no new/cross split, so it answers a different question.

## Parsing

Anchored on the page's own classes — `list-title`, `list-authors`, `list-subjects`, `primary-subject` — not on flattened text. There is no label between the title and the authors, so a text split glues the author name onto the title and raises nothing; the real-markup fixture caught exactly that in my first draft, which produced `Closed-Loop LLM Co-Pilots for Digital Agriculture Serge Kernbach` with an empty author list.

Ids are read only from the `<dt>` anchors, never a page-wide scan: abstracts cite other arXiv numbers, and the page I checked had one more unique id than its own `Total of` line.

Count mismatch raises rather than returning what was parsed. Returning less is how a day disappears quietly.

## Paging

A fallback, not the normal path. One category runs 200–350 entries and all of `cs` is 1096, against a stated 2000 per page — verified, no truncation at any of those. `show` is sent explicitly rather than trusting the default, and the section counts decide whether another page is needed, with a loop bound so a parse fault cannot spin.

## Testing

- 139 passed: `test_arxiv_listing test_literature test_daily_feed test_wiki_ingest test_paper_manual_add`
- Ruff clean on changed files. `app/` and `tests/` carry 9 pre-existing errors on `main`; confirmed by running the same check on a clean `origin/main` checkout.
- Parser run against the full 1.1 MB live page before trimming: 211 entries (79 new + 132 cross), matching the section headers exactly, with zero missing titles, authors, abstracts or primary categories.

The fixture is cut from that page — header, all three section headings, two genuine entries each, markup untouched. Hand-written HTML would only confirm what I assumed the page looks like, which is the one thing this parser must not get wrong.

## Note

Three tests in `test_literature.py` described the RSS source and were rewritten for the listing page. Each keeps the property it was protecting: parse-and-cache, failures raising instead of returning `[]`, and caching regardless of the declared date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr