### PR TITLE
fix(daily): date entries by the announcement, not by when we fetched

### DIFF
--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -62,6 +62,11 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
 
     # 条目原样带给下一步（daily.upsert）：重抓一次既多打一遍 arXiv，也可能拿到不同结果
     ctx.checkpoint["daily_entries"] = by_category
+    # 各分类声明的公告日期也要带过去：entry 的 feed_date 记的是「arXiv 哪天公告的」，
+    # 不是「我们哪天跑的」。数据源滞后那天两者才会不同，而那正是唯一会出事的一天。
+    ctx.checkpoint["daily_batch_dates"] = {
+        category: state.get("batch_date") for category, state in statuses.items()
+    }
 
     result: dict[str, Any] = {
         "categories": categories,
@@ -103,8 +108,15 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
 @register("daily.upsert")
 async def upsert(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     by_category = ctx.checkpoint.get("daily_entries") or {}
+    raw_dates = ctx.checkpoint.get("daily_batch_dates") or {}
     async with get_sessionmaker()() as session:
-        stats = await daily_feed_service.upsert_entries(session, by_category=by_category)
+        stats = await daily_feed_service.upsert_entries(
+            session,
+            by_category=by_category,
+            batch_dates=daily_feed_service.batch_dates_from_statuses(
+                {category: {"batch_date": value} for category, value in raw_dates.items()}
+            ),
+        )
 
     touched = [str(pid) for pid in stats["touched"]]
     ctx.checkpoint["daily_touched_papers"] = touched

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -323,22 +323,53 @@ async def fetch_new_by_category(
     return categories, by_category, statuses
 
 
+def batch_dates_from_statuses(
+    statuses: dict[str, dict[str, Any]],
+) -> dict[str, dt.date | None]:
+    """从 :func:`fetch_new_by_category` 的分类状态里取出各自声明的公告日期。
+
+    按分类分别取，不取一个「全局最大值」：数据源会**按分类各自滞后**（2026-08-12 生产上
+    cs.AI 供的是前一批而 cs.CL 是当天的），取最大值会把滞后那批也标成当天，等于把这个
+    故障重新藏起来。
+    """
+    out: dict[str, dt.date | None] = {}
+    for category, status in statuses.items():
+        raw = status.get("batch_date")
+        try:
+            out[category] = dt.date.fromisoformat(str(raw)) if raw else None
+        except ValueError:
+            out[category] = None
+    return out
+
+
 async def upsert_entries(
     session: AsyncSession,
     *,
     by_category: dict[str, list[dict[str, Any]]],
     today: dt.date | None = None,
+    batch_dates: dict[str, dt.date | None] | None = None,
 ) -> dict[str, Any]:
-    """RSS 条目 → 全局内容池去重 + 建/合并推送 entry；返回 {created, merged, touched}。
+    """当天公告条目 → 全局内容池去重 + 建/合并推送 entry；返回 {created, merged, touched}。
 
     同一篇多分类命中（cross-list）合并进 categories、不重复建行；paper_id 唯一约束
     保证同日重跑幂等（created=0）。``touched`` 是本次涉及的池论文 id（补向量用）。
+
+    ``feed_date`` 记的是 **arXiv 哪天公告的**（``batch_dates``，来自数据源自己声明的
+    日期），不是我们哪天跑的抓取。两者平时一致，所以看不出区别；而恰恰在数据源滞后
+    的那天——也就是唯一会出事的那天——它们不一致，按跑批日期记就会把昨天的论文标成
+    今天的。2026-08-13 生产就是这样：页面上写着「8月13日 · 96 篇」，那 96 篇其实是
+    8-12 那批（id 最大 ``2608.11195``，正是前一天列表页的量级），而当天真正的 446 篇
+    一篇没进。数字看着合理，所以没人会去查。
+
+    拿不到声明日期时才回落到今天：那是「不知道」，不是「就是今天」。
     """
-    feed_date = today or _today_utc()
+    fallback = today or _today_utc()
+    batch_dates = batch_dates or {}
     created = merged = 0
     touched: list[uuid.UUID] = []
 
     for category, entries in by_category.items():
+        feed_date = batch_dates.get(category) or fallback
         for entry in entries:
             title = (entry.get("title") or "").strip()
             arxiv_id = entry.get("arxiv_id")
@@ -462,9 +493,14 @@ async def sync_daily_feed(session: AsyncSession) -> dict[str, Any]:
     （app/agents/voyage/actions_daily.py），两条路径共用下面这几个步骤函数。
     """
     today = _today_utc()
-    categories, by_category, _statuses = await fetch_new_by_category(session)
+    categories, by_category, statuses = await fetch_new_by_category(session)
     fetched = sum(len(v) for v in by_category.values())
-    stats = await upsert_entries(session, by_category=by_category, today=today)
+    stats = await upsert_entries(
+        session,
+        by_category=by_category,
+        today=today,
+        batch_dates=batch_dates_from_statuses(statuses),
+    )
     expired = await cleanup_expired(session, today=today)
     await session.commit()
     embed = await embed_touched_papers(session, paper_ids=stats["touched"])

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -599,6 +599,8 @@ def _action_ctx():
 
 async def test_daily_actions_observation_shapes(client, monkeypatch):
     """四个动作各自的 observation 形状 + 跨步骤用 checkpoint 传值。"""
+    from sqlalchemy import select
+
     from app.agents.voyage.actions import get_action
     from app.core.db import get_sessionmaker
     from app.models.daily_feed import DailyFeedEntry
@@ -1838,3 +1840,86 @@ async def test_probe_stops_at_the_first_category_with_news(client, monkeypatch):
         fresh, _ = await daily_feed.todays_batch_available(session)
     assert fresh is True
     assert asked == ["cs.AI"], f"第一个分类就有新论文，不该继续问下去：{asked}"
+
+
+async def test_feed_date_records_the_announcement_day_not_the_run_day(client, monkeypatch):
+    """entry 的 feed_date 记 arXiv 哪天公告的，不记我们哪天跑的抓取。
+
+    平时两者一致，所以看不出区别；而恰恰在数据源滞后的那天——唯一会出事的那天——
+    它们不一致。按跑批日期记，昨天的论文就会被标成今天的：2026-08-13 生产页面上写着
+    「8月13日 · 96 篇」，那 96 篇其实是 8-12 那批，而当天真正的 446 篇一篇没进。
+    数字看着完全合理，所以没人会去查。
+    """
+    import datetime as dt
+
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.99001", "滞后那批里的论文")]}, batch_date=yesterday
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        await daily_feed.sync_daily_feed(session)
+
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(DailyFeedEntry))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].feed_date == yesterday, (
+        "数据源给的是昨天那批，却被记成今天——漏收就是这样被藏起来的"
+    )
+
+
+async def test_stale_and_fresh_categories_keep_their_own_dates(client, monkeypatch):
+    """按分类各记各的：数据源会**按分类分别**滞后，不能取一个全局日期。
+
+    2026-08-12 生产上 cs.AI 供的是前一批、cs.CL 是当天的。取最大值会把滞后那批也
+    标成当天，等于把这个故障重新藏起来。
+    """
+    import datetime as dt
+
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+    from app.models.paper import Paper
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    today = dt.datetime.now(dt.UTC).date()
+    yesterday = today - dt.timedelta(days=1)
+
+    class _MixedArxiv:
+        async def fetch_new(self, category: str):
+            at = dt.datetime.combine(
+                yesterday if category == "cs.AI" else today, dt.time(), tzinfo=dt.UTC
+            )
+            entry = _rss_entry(
+                "2608.99010" if category == "cs.AI" else "2608.99011", f"{category} 的论文"
+            )
+            return ([entry] if category in ("cs.AI", "cs.CL") else []), at
+
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _MixedArxiv())
+    async with get_sessionmaker()() as session:
+        await daily_feed.sync_daily_feed(session)
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            await session.execute(
+                select(Paper.arxiv_id, DailyFeedEntry.feed_date).join(
+                    DailyFeedEntry, DailyFeedEntry.paper_id == Paper.id
+                )
+            )
+        ).all()
+    by_id = dict(rows)
+    assert by_id["2608.99010"] == yesterday, "滞后的分类要如实记成昨天"
+    assert by_id["2608.99011"] == today


### PR DESCRIPTION
Found while answering "今天生产端只有 96 篇文献吗".

## The answer was no, and the page could not have told you

`feed_date` was set to `_today_utc()` — the day the sync ran. The announcement date was already parsed and carried in the per-category status; nothing read it.

The two agree on every ordinary day, which is why this looked correct. They diverge exactly when the source lags, which is the only day it matters. Then the daily page files yesterday's papers under today, with a plausible-looking count, and nobody has any reason to check.

Production on 2026-08-13 showed **8月13日 · 96 篇**. Those 96 were the 08-12 batch — top id `2608.11195` against that listing's `2608.11204` — while the real 08-13 announcement of 446 papers had 3 of its entries in the pool. Every layer reported success.

```
feed_date  | count | first ingested
2026-08-13 |    96 | 2026-08-13
2026-08-12 |   386 | 2026-08-12
2026-08-11 |  1038 | 2026-08-11
```

`feed_date` had never once differed from the ingest day, which is the giveaway: it was never recording what it claimed to.

## Per category, not per run

Dates are taken per category rather than as one value for the whole run. The source goes stale per category — on 2026-08-12 cs.AI served the previous batch while cs.CL was current the same morning — so collapsing to a single date (a max, say) would relabel the stale half as today and hide the fault all over again.

Falls back to today only when no date was declared. That is "unknown", not "today".

Both the direct entry point and the voyage action path are wired, since production runs the latter.

## Testing

- 123 passed: `test_daily_feed test_literature test_arxiv_listing test_wiki_ingest`
- Ruff clean on changed files
- Both new tests were run against the old `feed_date = today` behaviour and fail there

## Relation to the other two

This is the third distinct fault behind the same symptom, and the one that kept the other two invisible:

- #412 — the probe only asked about `categories[0]`, so a day could pass with no sync at all
- #415 — the RSS source lags a full announcement cycle, so even a correct probe reads yesterday
- this — entries are dated by our clock, so whatever we did fetch always looked like today's

None of the three produce an error. **Production is still running code that predates all of them**, so today's 443 missing papers are still missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr