### PR TITLE
fix(daily): do not spend the day's run on stragglers from an old batch

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1582,7 +1582,8 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
     if not categories:
         return True, None
 
-    declared: str | None = None
+    today = _today_utc()
+    latest: dt.date | None = None
     for category in categories:
         try:
             entries, batch_at = await get_arxiv_client().fetch_new(category)
@@ -1590,8 +1591,29 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
             logger.warning("daily feed probe failed for %s", category, exc_info=True)
             return True, None
 
-        if declared is None and batch_at is not None:
-            declared = batch_at.astimezone(dt.UTC).date().isoformat()
+        batch_date = batch_at.astimezone(dt.UTC).date() if batch_at else None
+        if batch_date is not None and (latest is None or batch_date > latest):
+            latest = batch_date
+        # 拿到的还是上一批公告时要分两种情况，因为它们的正确处置正好相反：
+        #
+        # 1. **那一批我们已经收过了**——剩下这些没见过的只是尾巴。为它跑一轮的代价极大：
+        #    already_ran_today 会把当天锁死，两小时后 arXiv 真正放出当天批次时再没人去取。
+        #    2026-08-13 生产就是这样：02:00 UTC（北京 10:00）跑了一轮收了 96 篇尾巴，
+        #    而当天 446 篇 04:00 UTC 才发布，一整天都没进来。
+        # 2. **那一批我们整批没收过**（比如昨天服务挂了）——这是最后的补救窗口。
+        #    ``/new`` 只显示最近一次公告，等今天那批一发布，昨天那批就永远拿不到了。
+        #
+        # 判据是「池子里有没有那天的条目」。feed_date 现在记的正是公告日，所以问得出来。
+        #
+        # 日期判据当年被放弃过，因为 RSS 的 pubDate 会整体滞后一天、判了永远为假。
+        # 换成列表页之后公告日期是页头自己写的，可以信；读不出日期时仍按内容判，
+        # 不因为解析不出日期就整天停摆。
+        if batch_date is not None and batch_date < today:
+            already_have_that_batch = await session.scalar(
+                select(DailyFeedEntry.id).where(DailyFeedEntry.feed_date == batch_date).limit(1)
+            )
+            if already_have_that_batch is not None:
+                continue
         arxiv_ids = [str(e.get("arxiv_id")) for e in entries if e.get("arxiv_id")]
         if not arxiv_ids:
             continue
@@ -1607,11 +1629,11 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
             .all()
         )
         if any(aid not in known for aid in arxiv_ids):
-            return True, declared
+            return True, latest.isoformat() if latest else None
 
-    # 全部分类都问过了：要么一条都没公告（周末/节假日的正常形态），
-    # 要么公告的我们已经全收了。两种都没有可做的事。
-    return False, declared
+    # 全部分类都问过了：要么当天那批还没发布、要么一条都没公告（周末/节假日的正常
+    # 形态）、要么公告的我们已经全收了。三种都没有可做的事，等下一个检查点。
+    return False, latest.isoformat() if latest else None
 
 
 # ---- 保留期（可配置） ----

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -1923,3 +1923,123 @@ async def test_stale_and_fresh_categories_keep_their_own_dates(client, monkeypat
     by_id = dict(rows)
     assert by_id["2608.99010"] == yesterday, "滞后的分类要如实记成昨天"
     assert by_id["2608.99011"] == today
+
+
+async def test_leftovers_from_yesterday_do_not_count_as_todays_batch(client, monkeypatch):
+    """上一批公告**我们已经收过**时，里面剩下的零星几篇不算「今天那批出来了」。
+
+    这是最坏的一种失败：抓取跑一轮、只捡到几十篇昨天的尾巴，而 already_ran_today
+    从此把当天锁死；两小时后 arXiv 真正放出当天批次时，再也没有人去取。
+    2026-08-13 生产就是这样——抓取时刻设的是 02:00 UTC（北京 10:00），而 arXiv 约
+    04:00 UTC（北京 12:00）才发布，那一轮收了 96 篇尾巴，当天 446 篇一整天没进来。
+    """
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+
+    # 先把昨天那批收进来（于是池子里有 feed_date=昨天 的条目）
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.95000", "昨天那批")]}, batch_date=yesterday
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        await daily_feed.sync_daily_feed(session)
+
+    # 同一批公告里又冒出一篇没见过的：这是尾巴，不是今天那批
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "cs.AI": [
+                    _rss_entry("2608.95000", "昨天那批"),
+                    _rss_entry("2608.95001", "昨天那批的尾巴"),
+                ]
+            },
+            batch_date=yesterday,
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, declared = await daily_feed.todays_batch_available(session)
+    assert fresh is False, "拿到的是已收过的上一批，不该判成今天那批已发布"
+    assert declared == yesterday.isoformat()
+
+
+async def test_a_batch_we_missed_entirely_is_still_worth_fetching(client, monkeypatch):
+    """整批没收过的旧公告仍要抓——那是最后的补救窗口。
+
+    ``/new`` 只显示最近一次公告：今天那批一发布，昨天那批就永远拿不到了。所以
+    「跳过旧批次」只能针对已经收过的，不能一刀切，否则服务挂一天就等于永久丢一天。
+    """
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    yesterday = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+
+    # 池子是空的：昨天那批一篇都没收过
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.95009", "昨天那批，我们整批没收")]},
+            batch_date=yesterday,
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, _ = await daily_feed.todays_batch_available(session)
+    assert fresh is True, "整批没收过就该抓，这是过了今天就没有的补救机会"
+
+
+async def test_todays_batch_still_triggers_once_published(client, monkeypatch):
+    """当天批次一发布就照常判为「该抓」——加日期判据不能把正常路径也堵死。"""
+    import datetime as dt
+
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+    today = dt.datetime.now(dt.UTC).date()
+
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {"cs.AI": [_rss_entry("2608.95002", "今天那批")]}, batch_date=today
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, declared = await daily_feed.todays_batch_available(session)
+    assert fresh is True
+    assert declared == today.isoformat()
+
+
+async def test_probe_without_a_readable_date_falls_back_to_content(client, monkeypatch):
+    """读不出公告日期时仍按内容判——不能因为日期解析不出来就整天不抓。"""
+    from app.core.db import get_sessionmaker
+    from app.services import daily_feed
+
+    await register_and_login(client)
+
+    class _NoDate(_StubArxiv):
+        async def fetch_new(self, category: str):
+            entries, _ = await super().fetch_new(category)
+            return entries, None
+
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _NoDate({"cs.AI": [_rss_entry("2608.95003", "日期不明")]}),
+    )
+    async with get_sessionmaker()() as session:
+        fresh, declared = await daily_feed.todays_batch_available(session)
+    assert fresh is True and declared is None


### PR DESCRIPTION
Found while answering why nothing from 8-13 had reached a library. The user's instinct — "是不是时区的问题" — was right about the shape of it.

## The timing

The sync fires at `02:00` **UTC**, which is 10:00 Beijing. arXiv announces around 04:00 UTC, 12:00 Beijing. So the run starts two hours before the papers exist.

The probe judged purely on content, so at 10:00 Beijing it found papers from *yesterday's* batch that we had not collected, called that fresh, and ran. `already_ran_today` then closed the day. When the real batch landed at 12:00, nothing went to fetch it.

That is how 2026-08-13 lost 446 papers with every step reporting success: the 02:00 run collected 96 stragglers, and the day was over.

## Two opposite cases

An old batch has to be told apart two ways round, because the right response is the reverse in each:

- **We already have that batch.** The few unseen ones are stragglers, and a run for them costs the entire day.
- **We have none of it** (we were down overnight). This is the last chance — `/new` only ever shows the most recent announcement, so once today's lands, yesterday's is gone.

My first attempt skipped every old batch, which fixed the reported bug and quietly created the second one: one bad night would have become a permanently lost day. The check now asks the pool whether any entry carries that announcement date — answerable because #416 made `feed_date` record the announcement rather than our clock.

Judging by date was abandoned once, and the test that locked that in is still in the suite: the RSS `pubDate` lagged a day, so the check was always false and the pool froze. The listing page states the date in its own header, verified against reality today, so it can be trusted now. Where no date parses, the content-only judgement still applies rather than stalling for a day.

## Testing

- 58 passed in `test_daily_feed`
- Ruff clean
- The straggler test was run against the ungated probe and fails there
- Worth noting: the three older probe tests failed against my first attempt and pass against this one. They were right and the first attempt was wrong — the content-only rule still holds everywhere except the one case this targets.

## Separately

`daily_feed_sync_time` is `02:00` UTC on production. With this fix the probe simply waits and retries until the batch appears, so it is no longer harmful, but setting it nearer 04:00 UTC would save a couple of hours of polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr