### PR TITLE
fix(papers): keep TL;DR about the paper, not about one library's direction

### DIFF
--- a/src/backend/app/services/paper_wiki.py
+++ b/src/backend/app/services/paper_wiki.py
@@ -43,6 +43,13 @@ async def upsert_wiki(
         wiki.model = model
         wiki.compiled_by = compiled_by
         wiki.updated_at = utcnow()  # 内容不变时也算一次新编译
+    # 解读里的 ## TL;DR 是这篇论文**权威的**一句话总结：编译提示词不带任何库的方向
+    # 陈述或 rubric，所以它对全平台是同一份。同步回 paper.tldr，覆盖掉打分阶段可能
+    # 留下的临时占位——那份是对着某一个库的方向写的，不该被别的库当成论文摘要看。
+    from app.services.obsidian_vault_sync import extract_tldr
+
+    if (compiled_tldr := extract_tldr(content)):
+        paper.tldr = compiled_tldr
     await session.flush()
     # 内存里的 paper 跟上（后续 link_paper_concepts / 出参都直接读 paper.wiki_content）
     set_committed_value(paper, "wiki", wiki)

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -25,7 +25,13 @@ RELEVANCE_SYSTEM_PROMPT = """\
 你是文献相关性评审，对照研究方向定义评估一篇论文（只看标题与摘要）。
 只输出一个 JSON 对象，不要输出任何其他文字或 Markdown 代码块，格式：
 {"score": 0 到 1 之间的小数, "reason": "简要理由", "tldr": "一句话中文总结"}
-"""
+
+reason 与 tldr 是两回事，别写成同一句：
+- reason 是**给这个方向的判词**，可以说相关或不相关、缺了什么。
+- tldr 是**这篇论文本身**的一句话总结：它解决什么问题、方法核心是什么、效果如何。
+  **不要提研究方向，不要出现「相关性较低」「不涉及……」这类判断。**
+  一篇论文全平台只有一份 tldr，被所有文献库共用——写成对某个方向的判词，别的库
+  看到的就是一句与自己无关的评价。"""
 
 
 @dataclass
@@ -143,7 +149,10 @@ async def score_paper_relevance(
     data = _extract_json(result.content)
     score = min(1.0, max(0.0, float(data["score"])))
     membership.relevance_score = score
-    paper.tldr = str(data.get("tldr") or "") or paper.tldr
+    # **只在空的时候填。** 打分是库侧判断，而 tldr 挂在全平台共享的论文上：谁最后
+    # 打分谁就覆盖掉前一个库（乃至编译产出的正式 TL;DR），于是所有库看到的都是最后
+    # 那个库的判词。这里只当「还没有摘要时的临时占位」，编译一跑就由正式的接管。
+    paper.tldr = paper.tldr or str(data.get("tldr") or "")
     membership.scored_at = utcnow()
     membership.scored_run_id = voyage_id  # 手动加论文没有任务，留 NULL
     return RelevanceResult(score=score, reason=str(data.get("reason") or ""), tldr=paper.tldr or "")

--- a/src/backend/tests/test_relevance_context.py
+++ b/src/backend/tests/test_relevance_context.py
@@ -43,3 +43,51 @@ def test_falls_back_to_library_name_without_statement():
     assert "RAG" in build_direction_query({"keywords": {"include": ["RAG"]}}, "某个库")
     # 什么都没有也不该炸
     assert build_direction_query(None, "") == ""
+
+
+# ---- TL;DR 是论文自己的，不是对某个库的判词 ----
+
+
+def test_prompt_separates_the_verdict_from_the_summary():
+    """提示词必须把 reason 和 tldr 分开，并明说 tldr 不许提方向。
+
+    生产上 papers.tldr 长这样：「论文关注延迟反馈下策略评估的诊断方法，不涉及长期运行
+    智能体的自主性、记忆或持续执行，相关性较低。」——那是对某一个库的判词，却挂在
+    全平台共享的论文上。整段提示词都在讲「对照研究方向评估」，不明确要求，模型给出
+    的自然就是判词。
+    """
+    from app.services.relevance import RELEVANCE_SYSTEM_PROMPT
+
+    assert "不要提研究方向" in RELEVANCE_SYSTEM_PROMPT
+    assert "相关性较低" in RELEVANCE_SYSTEM_PROMPT  # 明确点名不许写成这种句子
+    assert "全平台只有一份" in RELEVANCE_SYSTEM_PROMPT
+
+
+def test_scoring_only_fills_an_empty_tldr():
+    """打分只在 tldr 为空时填，绝不覆盖。
+
+    覆盖的后果是「谁最后打分谁说了算」：A 库打完是 A 的判词，B 库一打分就换成 B 的，
+    而两者都会被第三个库、每日流和搜索结果当成这篇论文的摘要显示。
+    """
+    import inspect
+
+    from app.services import relevance
+
+    src = inspect.getsource(relevance.score_paper_relevance)
+    assert "paper.tldr = paper.tldr or " in src, "必须是「空了才填」，不能反过来"
+
+
+def test_compiled_wiki_becomes_the_authoritative_tldr():
+    """编译出的 ## TL;DR 要写回 paper.tldr。
+
+    编译提示词不带任何库的方向陈述或 rubric，所以它对全平台是同一份——这正是
+    「一篇论文一份解读」想要的东西。不写回的话，papers.tldr 就只剩打分阶段那个
+    带方向色彩的占位。
+    """
+    import inspect
+
+    from app.services import paper_wiki
+
+    src = inspect.getsource(paper_wiki.upsert_wiki)
+    assert "extract_tldr" in src
+    assert "paper.tldr = compiled_tldr" in src

--- a/src/backend/tests/test_tldr_is_paper_level.py
+++ b/src/backend/tests/test_tldr_is_paper_level.py
@@ -1,0 +1,53 @@
+"""TL;DR 属于论文本身，不属于任何一个文献库。
+
+生产上这条被打破过：papers.tldr 里存的是相关性打分写下的判词——
+「论文关注延迟反馈下策略评估的诊断方法，不涉及长期运行智能体……相关性较低。」
+那是对某一个库的方向说的，却挂在全平台共享的论文上，于是每个库、每日流和搜索
+结果看到的都是别人库的评价。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper
+from app.services.paper_wiki import upsert_wiki
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+WIKI = """## TL;DR
+该论文提出一种两阶段检索方法，在三个基准上把召回率提升了 8 个百分点。
+
+## 方法
+省略。
+"""
+
+
+async def test_compiled_tldr_replaces_the_scoring_placeholder(client):
+    """编译一跑，正式 TL;DR 就该接管打分阶段留下的占位。"""
+    token = await register_and_login(client, email="tldr@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _library_id = await make_project_with_library(
+        client, headers, name="tldr-proj", definition={"statement": "长期运行智能体"}
+    )
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Two-stage retrieval",
+            # 打分阶段留下的、带方向色彩的占位
+            tldr="该研究不涉及长期运行智能体的持续执行，相关性较低。",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await upsert_wiki(session, paper=paper, content=WIKI, model="fake")
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        tldr = (await session.execute(select(Paper.tldr).where(Paper.id == paper_id))).scalar_one()
+    assert "相关性较低" not in tldr, "编译之后不该还挂着对某个库的判词"
+    assert "两阶段检索方法" in tldr


### PR DESCRIPTION
Reported: the TL;DR field explains a paper's relevance to some library, which it should never do.

Confirmed on production — every recent `papers.tldr` reads as a verdict:

```
该研究提出一个面向户外动态环境的视觉-语言导航数据集，但未深入探讨长期自主智能体的持续执行机制。
该论文是关于随机根查找的优化算法理论研究，不涉及长期运行智能体或持续自主系统。
论文关注延迟反馈下策略评估的诊断方法，不涉及长期运行智能体的自主性、记忆或持续执行，相关性较低。
```

Those answer "does this fit the Long-Running Agent library". They are stored on `papers.tldr`, which every library, the daily feed and search all read — so a paper carries one library's opinion of it wherever it appears.

This contradicts what the repo already states: one wiki per paper, shared platform-wide, compiled with no library statement or rubric. `builtin_skills.py` even defines the field — *"TL;DR 用一句话回答「这篇论文解决了什么问题、方法核心一句话是什么、效果如何」"* — with nothing about directions.

## Three causes

**The prompt conflates verdict and summary.** `reason` and `tldr` are requested side by side, inside a system prompt opening 对照研究方向定义评估, with the library's statement and rubric in the user message. Nothing said they differ, so the model wrote the verdict twice. Now separated, naming the exact phrasing to avoid — that is what it kept producing, so it is worth being blunt about.

**Scoring overwrote unconditionally.** `paper.tldr = new or paper.tldr` meant the last library to score won, including over a compiled summary. It now fills only when empty, as a placeholder until something real exists.

**The compiled TL;DR was never written back.** `papers.tldr` had exactly two writers: relevance scoring, and the Obsidian import. For natively compiled papers the placeholder was all it ever held — the wiki's own `## TL;DR` stayed inside `paper_wikis.content`. `upsert_wiki` now writes it through, reusing the extraction the Obsidian path already uses.

## Testing

- 70 passed: `test_relevance_context test_tldr_is_paper_level test_paper_wiki_unified test_wiki_ingest test_obsidian_vault_sync test_library_paper_management`
- Ruff clean
- New end-to-end test seeds a direction-flavoured placeholder, compiles a wiki, and asserts the verdict is gone. Verified it fails with the write-back removed.

## Existing data

Rows still hold the old verdicts and correct themselves as papers are recompiled. A backfill from existing `paper_wikis` is straightforward and deliberately not in this PR — say the word and I will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr