### PR TITLE
feat(literature): support Semantic Scholar Corpus ID imports

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -877,6 +877,7 @@ async def add_library_paper_manually(
             library=library,
             arxiv_id=data.arxiv_id,
             doi=data.doi,
+            corpus_id=data.corpus_id,
             bibtex=data.bibtex,
             project_id=library.project_id,
         )

--- a/src/backend/app/api/library.py
+++ b/src/backend/app/api/library.py
@@ -246,7 +246,11 @@ async def import_entry(
     """
     try:
         result = await paper_import_service.resolve_or_create_pool_paper(
-            session, arxiv_id=body.arxiv_id, doi=body.doi, bibtex=body.bibtex
+            session,
+            arxiv_id=body.arxiv_id,
+            doi=body.doi,
+            corpus_id=body.corpus_id,
+            bibtex=body.bibtex,
         )
     except paper_import_service.ParseFailedError as e:
         raise HTTPException(

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -232,6 +232,7 @@ async def add_paper_manually(
             project_id=project_id,
             arxiv_id=data.arxiv_id,
             doi=data.doi,
+            corpus_id=data.corpus_id,
             bibtex=data.bibtex,
         )
     except paper_import_service.DuplicatePaperError as e:

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -174,22 +174,25 @@ class PaperPdfUrlIn(BaseModel):
 
 
 class PaperManualCreate(BaseModel):
-    """手动添加文献：arxiv_id / doi / bibtex 三选一（docs/api-lit.md §4）。"""
+    """手动添加文献：arxiv_id / doi / corpus_id / bibtex 四选一。"""
 
     arxiv_id: str | None = None
     doi: str | None = None
+    corpus_id: str | None = None
     bibtex: str | None = None
 
     @model_validator(mode="after")
     def _exactly_one(self) -> "PaperManualCreate":
-        provided = [v for v in (self.arxiv_id, self.doi, self.bibtex) if v and v.strip()]
+        provided = [
+            v for v in (self.arxiv_id, self.doi, self.corpus_id, self.bibtex) if v and v.strip()
+        ]
         if len(provided) != 1:
-            raise ValueError("arxiv_id / doi / bibtex 必须且只能填一个")
+            raise ValueError("arxiv_id / doi / corpus_id / bibtex 必须且只能填一个")
         return self
 
 
 class PaperManualBatchCreate(BaseModel):
-    """批量手动添加文献；每项仍遵守三来源互斥规则。"""
+    """批量手动添加文献；每项仍遵守四来源互斥规则。"""
 
     items: list[PaperManualCreate] = Field(min_length=1, max_length=50)
 

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -395,7 +395,7 @@ async def _run_enrichment(
 
 
 def _batch_input_summary(item: dict[str, Any]) -> tuple[str, str]:
-    for source in ("arxiv_id", "doi", "bibtex"):
+    for source in ("arxiv_id", "doi", "corpus_id", "bibtex"):
         value = item.get(source)
         if value:
             compact = " ".join(str(value).split())
@@ -444,6 +444,7 @@ async def _run_batch_import(
                             library=library,
                             arxiv_id=item.get("arxiv_id"),
                             doi=item.get("doi"),
+                            corpus_id=item.get("corpus_id"),
                             bibtex=item.get("bibtex"),
                             project_id=project_id,
                         )

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -18,7 +18,7 @@ from app.services.libraries import (
     get_library_for_project,
     get_membership,
 )
-from app.services.literature import get_arxiv_client, get_openalex_client
+from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
 from app.services.literature.arxiv import ArxivRateLimitedError, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
@@ -233,10 +233,63 @@ async def _fields_from_doi(doi: str) -> dict[str, Any]:
     }
 
 
+def normalize_corpus_id(raw: str) -> str:
+    """Accept a numeric Semantic Scholar Corpus ID or its ``CorpusId:`` form."""
+    value = raw.strip()
+    if value.lower().startswith("corpusid:"):
+        value = value.split(":", 1)[1].strip()
+    if not value.isdigit() or int(value) <= 0:
+        raise ParseFailedError("Corpus ID 必须是正整数，例如 13756489")
+    return str(int(value))
+
+
+async def _fields_from_corpus_id(corpus_id: str) -> dict[str, Any]:
+    normalized = normalize_corpus_id(corpus_id)
+    try:
+        meta = await get_s2_client().get_paper(f"CorpusId:{normalized}")
+    except Exception as e:  # noqa: BLE001 - upstream failures become a readable import error
+        raise ParseFailedError(
+            f"Semantic Scholar 上查不到 Corpus ID {normalized}（{type(e).__name__}）"
+        ) from e
+    title = _clean(meta.get("title"))
+    if not title:
+        raise ParseFailedError(f"Semantic Scholar 上查不到 Corpus ID {normalized}")
+    external = meta.get("externalIds") or {}
+    arxiv_id = normalize_arxiv_id(str(external["ArXiv"])) if external.get("ArXiv") else None
+    doi = _clean(str(external["DOI"])) if external.get("DOI") else None
+    authors = [
+        {"name": str(author["name"]).strip()}
+        for author in (meta.get("authors") or [])
+        if isinstance(author, dict) and str(author.get("name") or "").strip()
+    ]
+    return {
+        "title": title,
+        "authors": authors or None,
+        "abstract": _clean(meta.get("abstract")),
+        "year": meta.get("year"),
+        "venue": _clean(meta.get("venue")),
+        "doi": doi,
+        "url": _clean(meta.get("url")),
+        "arxiv_id": arxiv_id,
+        "published_at": _parse_iso(meta.get("publicationDate")),
+        "external_ids": {
+            key: value
+            for key, value in (
+                ("s2", meta.get("paperId")),
+                ("corpus_id", normalized),
+                ("arxiv", arxiv_id),
+                ("doi", doi),
+            )
+            if value
+        },
+    }
+
+
 async def resolve_fields(
     *,
     arxiv_id: str | None = None,
     doi: str | None = None,
+    corpus_id: str | None = None,
     bibtex: str | None = None,
 ) -> dict[str, Any]:
     """按来源解析论文字段（arxiv > doi > bibtex）；失败抛 ParseFailedError。"""
@@ -244,6 +297,8 @@ async def resolve_fields(
         return await _fields_from_arxiv(arxiv_id)
     if doi:
         return await _fields_from_doi(doi)
+    if corpus_id:
+        return await _fields_from_corpus_id(corpus_id)
     return parse_bibtex_entry(bibtex or "")
 
 
@@ -259,7 +314,7 @@ async def create_pool_paper(
     调用方负责先查池去重（find_pool_paper）与收尾 commit。有 arxiv_id 的尽力而为
     补下 PDF + 抽全文；全文到手且无机构时 LLM 补机构（计费按传入的 user/project 归因）。
     """
-    external_ids: dict[str, str] = {}
+    external_ids: dict[str, str] = dict(fields.get("external_ids") or {})
     if fields.get("arxiv_id"):
         external_ids["arxiv"] = fields["arxiv_id"]
     if fields.get("doi"):
@@ -331,7 +386,7 @@ async def create_pool_paper_stub(
     重活（下载/抽取/向量化/打分）交给后台任务 enrich_paper 分阶段做；此处只做同步、
     确定性的建行工作。调用方负责先查池去重（find_pool_paper）与收尾 commit。
     """
-    external_ids: dict[str, str] = {}
+    external_ids: dict[str, str] = dict(fields.get("external_ids") or {})
     if fields.get("arxiv_id"):
         external_ids["arxiv"] = fields["arxiv_id"]
     if fields.get("doi"):
@@ -374,6 +429,7 @@ async def resolve_or_create_pool_paper(
     *,
     arxiv_id: str | None = None,
     doi: str | None = None,
+    corpus_id: str | None = None,
     bibtex: str | None = None,
     title: str | None = None,
 ) -> ManualAddResult:
@@ -398,9 +454,16 @@ async def resolve_or_create_pool_paper(
         paper = (await session.execute(stmt)).scalars().first()
     if paper is not None:
         return ManualAddResult(paper=paper, created=False)
-    if not (normalized_arxiv or clean_doi or (bibtex and bibtex.strip())):
+    if not (
+        normalized_arxiv
+        or clean_doi
+        or (corpus_id and corpus_id.strip())
+        or (bibtex and bibtex.strip())
+    ):
         raise ParseFailedError("按标题没有找到这篇论文，请提供 arXiv 编号或 DOI")
-    fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
+    fields = await resolve_fields(
+        arxiv_id=arxiv_id, doi=doi, corpus_id=corpus_id, bibtex=bibtex
+    )
     # 解析出的规范 id 再查一次池（输入可能是版本号 / 别名，bibtex 里也可能带 DOI）
     paper = await find_pool_paper(
         session,
@@ -426,6 +489,7 @@ async def add_manual_paper(
     project_id: uuid.UUID,
     arxiv_id: str | None = None,
     doi: str | None = None,
+    corpus_id: str | None = None,
     bibtex: str | None = None,
 ) -> ManualAddResult:
     """手动添加一篇文献到课题起源库（source=manual，成员行 status=included）。
@@ -441,6 +505,7 @@ async def add_manual_paper(
         library=library,
         arxiv_id=arxiv_id,
         doi=doi,
+        corpus_id=corpus_id,
         bibtex=bibtex,
         project_id=project_id,
     )
@@ -452,6 +517,7 @@ async def add_manual_paper_to_library(
     library: Any,
     arxiv_id: str | None = None,
     doi: str | None = None,
+    corpus_id: str | None = None,
     bibtex: str | None = None,
     project_id: uuid.UUID | None = None,
 ) -> ManualAddResult:
@@ -463,7 +529,9 @@ async def add_manual_paper_to_library(
     - 新论文只落元数据行；PDF 下载/全文抽取/向量化/打分由后台任务补全
     project_id 仅用于 LLM 记账归因（补机构等），独立库为空。
     """
-    fields = await resolve_fields(arxiv_id=arxiv_id, doi=doi, bibtex=bibtex)
+    fields = await resolve_fields(
+        arxiv_id=arxiv_id, doi=doi, corpus_id=corpus_id, bibtex=bibtex
+    )
     dedup_key = pool_dedup_key(
         arxiv_id=fields.get("arxiv_id"),
         doi=fields.get("doi"),

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -127,6 +127,55 @@ async def test_add_by_doi(client, lit_clients):
     assert body["url"] == "https://nature.example/landmark"
 
 
+async def test_add_by_semantic_scholar_corpus_id(client, monkeypatch):
+    from app.services import paper_import
+
+    class _SemanticScholar:
+        async def get_paper(self, paper_id):  # noqa: ANN001
+            assert paper_id == "CorpusId:13756489"
+            return {
+                "paperId": "s2-paper-id",
+                "title": "A Corpus Identified Paper",
+                "abstract": "Imported through Semantic Scholar.",
+                "year": 2024,
+                "publicationDate": "2024-05-06",
+                "venue": "Example Conference",
+                "url": "https://www.semanticscholar.org/paper/s2-paper-id",
+                "externalIds": {"DOI": "10.1000/corpus", "ArXiv": "2405.00001"},
+                "authors": [{"name": "Ada Researcher"}],
+            }
+
+    monkeypatch.setattr(paper_import, "get_s2_client", lambda: _SemanticScholar())
+    project_id, headers = await _setup(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/papers",
+        json={"corpus_id": "CorpusId:13756489"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == "A Corpus Identified Paper"
+    assert body["arxiv_id"] == "2405.00001"
+    assert body["doi"] == "10.1000/corpus"
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(body["id"]))
+        assert paper.external_ids == {
+            "s2": "s2-paper-id",
+            "corpus_id": "13756489",
+            "arxiv": "2405.00001",
+            "doi": "10.1000/corpus",
+        }
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "abc", "CorpusId:nope"])
+def test_invalid_corpus_id_is_rejected(value):
+    from app.services.paper_import import ParseFailedError, normalize_corpus_id
+
+    with pytest.raises(ParseFailedError):
+        normalize_corpus_id(value)
+
+
 async def test_add_by_bibtex_and_dedupe_by_doi(client):
     project_id, headers = await _setup(client)
     resp = await client.post(
@@ -300,6 +349,29 @@ async def test_batch_add_is_partial_and_reports_each_item(client, fake_redis):
         "event": "done",
         "data": {"total": 3, "created": 1, "existing": 1, "invalid": 1, "failed": 0},
     }
+
+
+async def test_batch_endpoint_preserves_corpus_id(client, monkeypatch):
+    from app.services import paper_enrich
+
+    captured: dict[str, object] = {}
+
+    async def _launch(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return "corpus-batch-task"
+
+    monkeypatch.setattr(paper_enrich, "launch_paper_batch_import", _launch)
+    project_id, headers = await _setup(client)
+    resp = await client.post(
+        f"/api/projects/{project_id}/paper-imports/batch",
+        json={"items": [{"corpus_id": "13756489"}]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert captured["items"] == [
+        {"arxiv_id": None, "doi": None, "corpus_id": "13756489", "bibtex": None}
+    ]
 
 
 async def test_library_batch_add_endpoint_and_limit(client, fake_redis):

--- a/src/frontend/src/features/library/AddToLibraryModal.tsx
+++ b/src/frontend/src/features/library/AddToLibraryModal.tsx
@@ -16,7 +16,7 @@ import { PaperProgressModal } from './PaperProgressModal';
    不进任何公共文献库。需要下载/抽取时弹分阶段进度。
    ============================================================ */
 
-type AddMethod = 'ref' | 'bibtex';
+type AddMethod = 'ref' | 'corpus' | 'bibtex';
 
 export function AddToLibraryModal({
   open,
@@ -31,6 +31,7 @@ export function AddToLibraryModal({
   const queryClient = useQueryClient();
   const [method, setMethod] = useState<AddMethod>('ref');
   const [ref, setRef] = useState('');
+  const [corpusId, setCorpusId] = useState('');
   const [bibtex, setBibtex] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
   // 后端返回 task_id 时弹出分阶段处理进度（下载 / 抽取 / 向量化）
@@ -38,12 +39,17 @@ export function AddToLibraryModal({
 
   const reset = () => {
     setRef('');
+    setCorpusId('');
     setBibtex('');
     setParseError(null);
   };
 
   const input: PaperImportInput | null =
-    method === 'bibtex' ? (bibtex.trim() ? { bibtex: bibtex.trim() } : null) : parsePaperRef(ref);
+    method === 'bibtex'
+      ? (bibtex.trim() ? { bibtex: bibtex.trim() } : null)
+      : method === 'corpus'
+        ? (corpusId.trim() ? { corpus_id: corpusId.trim() } : null)
+        : parsePaperRef(ref);
 
   const importMutation = useMutation({
     mutationFn: (inp: PaperImportInput) => api.importToLibrary(inp),
@@ -120,6 +126,7 @@ export function AddToLibraryModal({
         <Segmented<AddMethod>
           options={[
             { v: 'ref', label: tr('arXiv 编号 / DOI', 'arXiv ID / DOI') },
+            { v: 'corpus', label: 'Corpus ID' },
             { v: 'bibtex', label: tr('粘贴 BibTeX', 'Paste BibTeX') },
           ]}
           value={method}
@@ -155,6 +162,28 @@ export function AddToLibraryModal({
                   '编号或论文链接都行，其余信息自动抓取。',
                   'An ID or a paper link both work — the rest is fetched automatically.',
                 )}
+              </div>
+            </>
+          ) : method === 'corpus' ? (
+            <>
+              <input
+                className="input mono"
+                autoFocus
+                style={{ width: '100%' }}
+                placeholder={tr('例如 13756489 或 CorpusId:13756489', 'e.g. 13756489 or CorpusId:13756489')}
+                value={corpusId}
+                onChange={(e) => {
+                  setCorpusId(e.target.value);
+                  setParseError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && input && !importMutation.isPending) {
+                    importMutation.mutate(input);
+                  }
+                }}
+              />
+              <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
+                {tr('从 Semantic Scholar 获取论文元数据。', 'Fetches paper metadata from Semantic Scholar.')}
               </div>
             </>
           ) : (

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -121,7 +121,7 @@ export interface PapersTabProps {
 
 /* ---------------- 添加文献 Modal ---------------- */
 
-type ImportMethod = 'arxiv' | 'doi' | 'bibtex';
+type ImportMethod = 'arxiv' | 'doi' | 'corpus' | 'bibtex';
 
 /** 按 BibTeX 条目的配对大括号/圆括号切分，保留坏条目交给后端逐项报错。 */
 function splitBibtexEntries(raw: string): string[] {
@@ -188,6 +188,7 @@ function AddPaperModal({
   const [method, setMethod] = useState<ImportMethod>('arxiv');
   const [arxivId, setArxivId] = useState('');
   const [doi, setDoi] = useState('');
+  const [corpusId, setCorpusId] = useState('');
   const [bibtex, setBibtex] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ taskId: string; total: number } | null>(null);
@@ -200,13 +201,15 @@ function AddPaperModal({
   const batchItems = useMemo<PaperBatchImportInput['items']>(() => {
     if (method === 'arxiv') return splitPaperInput(arxivId).map((value) => ({ arxiv_id: value }));
     if (method === 'doi') return splitPaperInput(doi).map((value) => ({ doi: value }));
+    if (method === 'corpus') return splitPaperInput(corpusId).map((value) => ({ corpus_id: value }));
     return splitBibtexEntries(bibtex).map((value) => ({ bibtex: value }));
-  }, [arxivId, bibtex, doi, method]);
+  }, [arxivId, bibtex, corpusId, doi, method]);
   const tooMany = batchItems.length > 50;
 
   const reset = () => {
     setArxivId('');
     setDoi('');
+    setCorpusId('');
     setBibtex('');
     setParseError(null);
   };
@@ -273,6 +276,7 @@ function AddPaperModal({
         options={[
           { v: 'arxiv', label: 'arXiv ID' },
           { v: 'doi', label: 'DOI' },
+          { v: 'corpus', label: 'Corpus ID' },
           { v: 'bibtex', label: tr('BibTeX 粘贴', 'Paste BibTeX') },
         ]}
         value={method}
@@ -315,6 +319,25 @@ function AddPaperModal({
             />
             <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
               {tr('适合期刊 / 会议论文；最多 50 篇。', 'Best for journal and conference papers; up to 50.')}
+            </div>
+          </>
+        ) : method === 'corpus' ? (
+          <>
+            <textarea
+              className="textarea mono"
+              style={{ width: '100%', minHeight: 112, resize: 'vertical', fontSize: 12 }}
+              placeholder={tr(
+                '多个 Semantic Scholar Corpus ID 可用空格、逗号或换行分隔\n13756489, CorpusId:215416146',
+                'Separate Semantic Scholar Corpus IDs with spaces, commas, or new lines\n13756489, CorpusId:215416146',
+              )}
+              value={corpusId}
+              onChange={(e) => {
+                setCorpusId(e.target.value);
+                setParseError(null);
+              }}
+            />
+            <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
+              {tr('支持纯数字或 CorpusId: 前缀；最多 50 篇。', 'Numeric IDs and the CorpusId: prefix are supported; up to 50.')}
             </div>
           </>
         ) : (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -908,7 +908,11 @@ export interface HighlightCreateInput {
 }
 
 /** 手动添加文献：三选一。 */
-export type PaperImportInput = { arxiv_id: string } | { doi: string } | { bibtex: string };
+export type PaperImportInput =
+  | { arxiv_id: string }
+  | { doi: string }
+  | { corpus_id: string }
+  | { bibtex: string };
 
 export interface PaperBatchImportInput {
   items: PaperImportInput[];
@@ -923,7 +927,7 @@ export type PaperBatchItemStatus = 'created' | 'existing' | 'invalid' | 'failed'
 
 export interface PaperBatchItemResult {
   index: number;
-  source: 'arxiv_id' | 'doi' | 'bibtex' | 'unknown';
+  source: 'arxiv_id' | 'doi' | 'corpus_id' | 'bibtex' | 'unknown';
   input: string;
   status: PaperBatchItemStatus;
   paper_id?: string;


### PR DESCRIPTION
## Summary

Add Semantic Scholar Corpus ID as a paper import option.
Supports both numeric IDs such as `13756489` and values prefixed with `CorpusId:`.

Closes #421

## Area

- [x] frontend
- [x] backend-api
- [x] literature / wiki

## What changed

- Added Corpus ID to the paper import form.
- Added support for single and batch imports.
- Fetched paper metadata through Semantic Scholar.
- Saved the Corpus ID and other available external IDs.
- Added validation and import tests.

## Testing

- [x] Frontend build passes
- [x] Backend tests pass
- [x] Frontend tests pass

## Checklist

- [x] Branch is based on the latest `origin/main`
- [x] Conventional-commit PR title
- [x] No migration required
- [x] No AI attribution or `Co-Authored-By` lines