### PR TITLE
feat(review): retry failed tournament matches

### DIFF
--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -913,13 +913,49 @@ def _rounds(ctx: ActionContext) -> int:
         return DEFAULT_ROUNDS
 
 
+def _pair_key(idea_a: str, idea_b: str) -> tuple[str, str]:
+    return (idea_a, idea_b) if idea_a < idea_b else (idea_b, idea_a)
+
+
 @register("review.pair")
 async def review_pair(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     if isinstance(ctx.checkpoint.get("review_pairs"), list):  # 断点幂等
         return {"pairs": len(ctx.checkpoint["review_pairs"]), "skipped": True}
     explicit_ids = _params(ctx).get("idea_ids")
+    retry_pairs = _params(ctx).get("retry_pairs")
 
     async with get_sessionmaker()() as session:
+        if isinstance(retry_pairs, list):
+            pairs = [
+                [str(pair[0]), str(pair[1])]
+                for pair in retry_pairs
+                if isinstance(pair, list) and len(pair) == 2
+            ]
+            participant_ids = {idea_id for pair in pairs for idea_id in pair}
+            ideas = list(
+                (
+                    await session.execute(
+                        select(Idea).where(
+                            Idea.project_id == ctx.run.project_id,
+                            Idea.id.in_([uuid.UUID(i) for i in participant_ids]),
+                            Idea.trashed_at.is_(None),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if {str(i.id) for i in ideas} != participant_ids:
+                raise ValueError("retry participant missing or trashed")
+            ctx.checkpoint["review_pairs"] = pairs
+            return {
+                "participants": len(participant_ids),
+                "pairs": len(pairs),
+                "bye": None,
+                "retry": True,
+                "plan_signal": {"decision": "matches", "count": len(pairs)},
+            }
+
         stmt = select(Idea).where(
             Idea.project_id == ctx.run.project_id,
             Idea.trashed_at.is_(None),
@@ -1194,15 +1230,43 @@ async def review_match(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
 @register("review.summarize")
 async def review_summarize(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     results: list[dict[str, Any]] = list(ctx.checkpoint.get("review_results") or [])
+    planned_pairs: list[list[str]] = list(ctx.checkpoint.get("review_pairs") or [])
+    completed = {
+        _pair_key(str(result["idea_a"]), str(result["idea_b"]))
+        for result in results
+        if result.get("idea_a") and result.get("idea_b")
+    }
+    failed_pairs = [
+        pair
+        for pair in planned_pairs
+        if _pair_key(str(pair[0]), str(pair[1])) not in completed
+    ]
+    ctx.checkpoint["review_failed_pairs"] = failed_pairs
     async with get_sessionmaker()() as session:
         session.add(
             Activity(
                 project_id=ctx.run.project_id,
                 actor="agent:idea-review",
                 kind="review.completed",
-                message=f"Idea 评审锦标赛完成：{len(results)} 场辩论",
-                payload={"voyage_id": str(ctx.run.id), "matches": len(results)},
+                message=(
+                    f"Idea 评审锦标赛完成：{len(results)}/{len(planned_pairs)} 场成功"
+                    if failed_pairs
+                    else f"Idea 评审锦标赛完成：{len(results)} 场辩论"
+                ),
+                payload={
+                    "voyage_id": str(ctx.run.id),
+                    "matches": len(results),
+                    "planned": len(planned_pairs),
+                    "failed": len(failed_pairs),
+                },
             )
         )
         await session.commit()
-    return {"matches": len(results), "results": results}
+    return {
+        "matches": len(results),
+        "planned": len(planned_pairs),
+        "failed": len(failed_pairs),
+        "partial": bool(failed_pairs),
+        "failed_pairs": failed_pairs,
+        "results": results,
+    }

--- a/src/backend/app/api/ideas.py
+++ b/src/backend/app/api/ideas.py
@@ -343,6 +343,51 @@ async def get_leaderboard(
     return [IdeaLeaderboardEntry.model_validate(i) for i in ideas]
 
 
+@router.get("/projects/{project_id}/review/tournament/latest")
+async def latest_tournament_summary(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict | None:
+    await _member_project(session, project_id, user)
+    run = await ideas_service.latest_review_tournament(session, project_id)
+    return ideas_service.review_tournament_summary(run)
+
+
+@router.post(
+    "/projects/{project_id}/review/tournament/retry-failed",
+    response_model=VoyageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def retry_failed_tournament_matches(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_review),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> VoyageRead:
+    project = await _member_project(session, project_id, user)
+    source = await ideas_service.latest_review_tournament(session, project_id)
+    if source is None:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="NO_TOURNAMENT_TO_RETRY")
+    try:
+        run = await ideas_service.create_retry_tournament_voyage(
+            session,
+            project=project,
+            source=source,
+            created_by=user.id,
+        )
+    except ideas_service.IdeaVoyageConflictError as e:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="IDEA_VOYAGE_ALREADY_RUNNING"
+        ) from e
+    except ideas_service.TournamentRetryUnavailableError as e:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="TOURNAMENT_RETRY_UNAVAILABLE"
+        ) from e
+    await queue.enqueue("run_voyage", str(run.id))
+    return VoyageRead.model_validate(run)
+
+
 # ---- 讨论（人机同场） ----
 
 

--- a/src/backend/app/services/ideas.py
+++ b/src/backend/app/services/ideas.py
@@ -55,6 +55,10 @@ class InvalidSeedError(Exception):
     """深耕种子引用的 concept/paper/idea 不存在或不属于本项目。"""
 
 
+class TournamentRetryUnavailableError(Exception):
+    """The latest tournament is running, fully successful, or has invalid participants."""
+
+
 # ---- voyage 创建 ----
 
 
@@ -74,6 +78,11 @@ async def find_running_idea_voyage(
     return (await session.execute(stmt)).scalar_one_or_none()
 
 
+async def _lock_project_idea_creation(session: AsyncSession, project_id: uuid.UUID) -> None:
+    """Serialize idea voyage creation so retry requests cannot create duplicate runs."""
+    await session.execute(select(Project.id).where(Project.id == project_id).with_for_update())
+
+
 async def create_forge_voyage(
     session: AsyncSession,
     *,
@@ -82,6 +91,7 @@ async def create_forge_voyage(
     created_by: uuid.UUID | None,
 ) -> VoyageRun:
     """建 idea_forge voyage（forge/review 互斥 + Activity 落记录），由调用方入队 run_voyage。"""
+    await _lock_project_idea_creation(session, project.id)
     if await find_running_idea_voyage(session, project.id) is not None:
         raise IdeaVoyageConflictError(str(project.id))
     run = VoyageRun(
@@ -117,6 +127,7 @@ async def create_tournament_voyage(
     created_by: uuid.UUID | None,
 ) -> VoyageRun:
     """建 idea_review（辩论锦标赛）voyage；参与者不足 2 个抛 NotEnoughIdeasError。"""
+    await _lock_project_idea_creation(session, project.id)
     if await find_running_idea_voyage(session, project.id) is not None:
         raise IdeaVoyageConflictError(str(project.id))
 
@@ -166,6 +177,141 @@ async def create_tournament_voyage(
             kind="review.started",
             message=f"Idea 评审锦标赛已启动（{participant_count} 个想法）",
             payload=params,
+        )
+    )
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+def _review_pair_key(idea_a: str, idea_b: str) -> tuple[str, str]:
+    return (idea_a, idea_b) if idea_a < idea_b else (idea_b, idea_a)
+
+
+def _failed_review_pairs(run: VoyageRun) -> list[list[str]]:
+    checkpoint = run.checkpoint or {}
+    planned = checkpoint.get("review_pairs") or []
+    results = checkpoint.get("review_results") or []
+    completed = {
+        _review_pair_key(str(result.get("idea_a")), str(result.get("idea_b")))
+        for result in results
+        if isinstance(result, dict) and result.get("idea_a") and result.get("idea_b")
+    }
+    return [
+        [str(pair[0]), str(pair[1])]
+        for pair in planned
+        if isinstance(pair, list)
+        and len(pair) == 2
+        and _review_pair_key(str(pair[0]), str(pair[1])) not in completed
+    ]
+
+
+async def latest_review_tournament(
+    session: AsyncSession, project_id: uuid.UUID
+) -> VoyageRun | None:
+    stmt = (
+        select(VoyageRun)
+        .where(VoyageRun.project_id == project_id, VoyageRun.kind == "idea_review")
+        .order_by(VoyageRun.created_at.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def review_tournament_summary(run: VoyageRun | None) -> dict[str, Any] | None:
+    if run is None:
+        return None
+    checkpoint = run.checkpoint or {}
+    params = checkpoint.get("params") or {}
+    planned = checkpoint.get("review_pairs") or []
+    results = checkpoint.get("review_results") or []
+    failed = _failed_review_pairs(run)
+    return {
+        "voyage_id": str(run.id),
+        "root_voyage_id": str(params.get("retry_of") or run.id),
+        "status": run.status,
+        "planned": len(planned),
+        "completed": len(results),
+        "failed": len(failed),
+        "is_retry": bool(params.get("retry_of")),
+        "can_retry": run.status in TERMINAL_STATUSES and bool(failed),
+    }
+
+
+async def create_retry_tournament_voyage(
+    session: AsyncSession,
+    *,
+    project: Project,
+    source: VoyageRun,
+    created_by: uuid.UUID | None,
+) -> VoyageRun:
+    """Create a supplement run containing only the source run's unfinished pairs."""
+    await _lock_project_idea_creation(session, project.id)
+    if await find_running_idea_voyage(session, project.id) is not None:
+        raise IdeaVoyageConflictError(str(project.id))
+    if source.project_id != project.id or source.kind != "idea_review":
+        raise TournamentRetryUnavailableError(str(source.id))
+    if source.status not in TERMINAL_STATUSES:
+        raise TournamentRetryUnavailableError(str(source.id))
+    failed_pairs = _failed_review_pairs(source)
+    if not failed_pairs:
+        raise TournamentRetryUnavailableError(str(source.id))
+
+    participant_ids = {uuid.UUID(idea_id) for pair in failed_pairs for idea_id in pair}
+    current_ids = {
+        idea_id
+        for (idea_id,) in (
+            await session.execute(
+                select(Idea.id).where(
+                    Idea.project_id == project.id,
+                    Idea.id.in_(participant_ids),
+                    Idea.trashed_at.is_(None),
+                )
+            )
+        ).all()
+    }
+    if current_ids != participant_ids:
+        raise TournamentRetryUnavailableError(str(source.id))
+
+    source_params = (source.checkpoint or {}).get("params") or {}
+    root_id = str(source_params.get("retry_of") or source.id)
+    params = {
+        "idea_ids": sorted(str(idea_id) for idea_id in participant_ids),
+        "rounds": int(source_params.get("rounds") or 2),
+        "personas": source_params.get("personas"),
+        "retry_pairs": failed_pairs,
+        "retry_of": root_id,
+        "retry_source": str(source.id),
+    }
+    matches = len(failed_pairs)
+    run = VoyageRun(
+        kind="idea_review",
+        goal=f"Idea 评审锦标赛补赛：{project.name}",
+        status="planning",
+        cursor=0,
+        checkpoint={"params": params},
+        budget={
+            "max_tokens": matches
+            * (2 * int(params["rounds"]) + 1)
+            * _TOKENS_PER_MATCH_CALL
+        },
+        project_id=project.id,
+        created_by=created_by,
+    )
+    session.add(run)
+    await session.flush()
+    session.add(
+        Activity(
+            project_id=project.id,
+            actor=f"user:{created_by}" if created_by else "system",
+            kind="review.retry_started",
+            message=f"Idea 锦标赛补赛已启动（{matches} 场待补）",
+            payload={
+                "voyage_id": str(run.id),
+                "root_voyage_id": root_id,
+                "source_voyage_id": str(source.id),
+                "matches": matches,
+            },
         )
     )
     await session.commit()
@@ -233,6 +379,7 @@ async def create_deep_voyage(
     created_by: uuid.UUID | None,
 ) -> VoyageRun:
     """建 idea_proposal voyage（深度生成，docs/api-idea2.md §2），由调用方入队 run_voyage。"""
+    await _lock_project_idea_creation(session, project.id)
     if await find_running_idea_voyage(session, project.id) is not None:
         raise IdeaVoyageConflictError(str(project.id))
     seed_brief = await _validate_seed(

--- a/src/backend/tests/test_idea_review.py
+++ b/src/backend/tests/test_idea_review.py
@@ -46,6 +46,15 @@ def _make_engine() -> tuple[VoyageEngine, RecordingBus]:
     return VoyageEngine(event_bus=bus, llm_router=LLMRouter()), bus
 
 
+class _FailOnePairProvider(FakeProvider):
+    async def complete(self, messages, *, model, temperature=0.7, max_tokens=None):
+        if any("FAIL_PAIR" in message.content for message in messages):
+            raise RuntimeError("temporary upstream failure")
+        return await super().complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens
+        )
+
+
 async def test_tournament_fans_out_per_match_nodes(client, queue_stub):
     """4 个 idea → 2 场对局：pair 展开 2 个 review.match 节点（每场可见、可逐场查预算），
     顺序 pair → match×2 → summarize，全部通过（docs/voyage-loop.md §7）。"""
@@ -100,6 +109,86 @@ async def test_tournament_excludes_trashed_ideas(client, queue_stub):
     )
     assert pair_observation["participants"] == 4
     assert pair_observation["pairs"] == 2
+
+
+async def test_partial_tournament_retries_only_failed_matches(client, queue_stub):
+    project_id, headers = await _setup_project(client, name="failed-match-retry")
+    idea_ids = [
+        await _seed_idea(project_id, "想法 A"),
+        await _seed_idea(project_id, "想法 B"),
+        await _seed_idea(project_id, "FAIL_PAIR 想法 C"),
+        await _seed_idea(project_id, "FAIL_PAIR 想法 D"),
+    ]
+    resp = await client.post(
+        f"/api/projects/{project_id}/review/tournament", json={"rounds": 1}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    router = LLMRouter()
+    router.override_provider(_FailOnePairProvider())
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=router).run(
+        uuid.UUID(resp.json()["id"])
+    )
+
+    summary = (
+        await client.get(
+            f"/api/projects/{project_id}/review/tournament/latest", headers=headers
+        )
+    ).json()
+    assert summary["planned"] == 2
+    assert summary["completed"] == 1
+    assert summary["failed"] == 1
+    assert summary["can_retry"] is True
+
+    retry = await client.post(
+        f"/api/projects/{project_id}/review/tournament/retry-failed", headers=headers
+    )
+    assert retry.status_code == 201, retry.text
+    duplicate = await client.post(
+        f"/api/projects/{project_id}/review/tournament/retry-failed", headers=headers
+    )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "IDEA_VOYAGE_ALREADY_RUNNING"
+
+    retry_engine, _ = _make_engine()
+    await retry_engine.run(uuid.UUID(retry.json()["id"]))
+    summary = (
+        await client.get(
+            f"/api/projects/{project_id}/review/tournament/latest", headers=headers
+        )
+    ).json()
+    assert summary["is_retry"] is True
+    assert summary["planned"] == 1
+    assert summary["completed"] == 1
+    assert summary["failed"] == 0
+    assert summary["can_retry"] is False
+
+    async with get_sessionmaker()() as session:
+        ideas = [await session.get(Idea, uuid.UUID(idea_id)) for idea_id in idea_ids]
+        assert all(idea is not None and idea.matches == 1 for idea in ideas)
+
+
+async def test_failed_match_retry_rejects_trashed_participant(client, queue_stub):
+    project_id, headers = await _setup_project(client, name="retry-trashed")
+    await _seed_idea(project_id, "想法 A")
+    await _seed_idea(project_id, "想法 B")
+    failed_a = await _seed_idea(project_id, "FAIL_PAIR 想法 C")
+    await _seed_idea(project_id, "FAIL_PAIR 想法 D")
+    resp = await client.post(
+        f"/api/projects/{project_id}/review/tournament", json={"rounds": 1}, headers=headers
+    )
+    router = LLMRouter()
+    router.override_provider(_FailOnePairProvider())
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=router).run(
+        uuid.UUID(resp.json()["id"])
+    )
+    trashed = await client.delete(f"/api/ideas/{failed_a}", headers=headers)
+    assert trashed.status_code == 204, trashed.text
+
+    retry = await client.post(
+        f"/api/projects/{project_id}/review/tournament/retry-failed", headers=headers
+    )
+    assert retry.status_code == 409
+    assert retry.json()["detail"] == "TOURNAMENT_RETRY_UNAVAILABLE"
 
 
 async def test_tournament_debate_elo_and_leaderboard(client, queue_stub):

--- a/src/frontend/src/features/review/ReviewPage.tsx
+++ b/src/frontend/src/features/review/ReviewPage.tsx
@@ -539,6 +539,7 @@ function MatchesTab({
 
 export function ReviewPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isLoading: projectsLoading, currentProject, currentProjectId } = useProject();
   const pid = currentProjectId;
@@ -580,6 +581,15 @@ export function ReviewPage() {
   });
   const rows = leaderboardQuery.data ?? [];
 
+  const tournamentQuery = useQuery({
+    queryKey: ['latest-tournament', pid],
+    queryFn: () => api.getLatestTournamentSummary(pid!),
+    enabled: !!pid,
+    retry: false,
+    refetchInterval: runningVoyage ? 5_000 : false,
+  });
+  const latestTournament = tournamentQuery.data ?? null;
+
   // 晋级按钮 owner 可见：项目 owner 或平台 admin；成员信息缺失时放行（后端仍会校验）
   const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
   const members = currentProject?.members;
@@ -587,6 +597,21 @@ export function ReviewPage() {
     isAdmin(me) ||
     !members ||
     members.some((m) => m.role === 'owner' && ((me?.id && m.user_id === me.id) || (me?.email && m.email === me.email)));
+
+  const retryMutation = useMutation({
+    mutationFn: () => api.retryFailedTournamentMatches(pid!),
+    onSuccess: (voyage) => {
+      toast(tr('失败对局补赛已开始', 'Failed-match retry started'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['latest-tournament', pid] });
+      void queryClient.invalidateQueries({ queryKey: ['forge-state', pid] });
+      navigate(`/voyages/${voyage.id}`);
+    },
+    onError: (e) =>
+      toast(
+        `${tr('补赛启动失败', 'Failed to start retry')}：${e instanceof Error ? e.message : String(e)}`,
+        'error',
+      ),
+  });
 
   return (
     <div className="page fadeup" style={{ maxWidth: 1280 }}>
@@ -620,6 +645,37 @@ export function ReviewPage() {
               voyage {runningVoyage.slice(0, 8)}…
             </span>
             <Icon name="arrow" size={14} style={{ color: 'var(--accent-text)' }} />
+          </div>
+        </div>
+      )}
+
+      {!runningVoyage && latestTournament && latestTournament.failed > 0 && (
+        <div
+          className="card card-pad"
+          style={{ marginBottom: 16, borderColor: 'var(--warn)', background: 'var(--warn-bg)' }}
+        >
+          <div className="row gap10">
+            <Icon name="x" size={15} style={{ color: 'var(--warn)' }} />
+            <span style={{ fontSize: 13, fontWeight: 650 }}>
+              {tr(
+                `最新一轮部分完成：成功 ${latestTournament.completed}/${latestTournament.planned}，${latestTournament.failed} 场待补赛`,
+                `Latest round partially completed: ${latestTournament.completed}/${latestTournament.planned} succeeded; ${latestTournament.failed} need retry`,
+              )}
+            </span>
+            {latestTournament.can_retry && (
+              <button
+                className="btn btn-soft sm"
+                style={{ marginLeft: 'auto' }}
+                disabled={retryMutation.isPending}
+                onClick={() => retryMutation.mutate()}
+              >
+                <Icon name="refresh" size={13} />
+                {tr(
+                  `补跑失败对局（${latestTournament.failed}）`,
+                  `Retry failed matches (${latestTournament.failed})`,
+                )}
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1670,6 +1670,17 @@ export interface LeaderboardRow extends IdeaRead {
   wins: number;
 }
 
+export interface TournamentSummary {
+  voyage_id: string;
+  root_voyage_id: string;
+  status: string;
+  planned: number;
+  completed: number;
+  failed: number;
+  is_retry: boolean;
+  can_retry: boolean;
+}
+
 /** idea_match = 一场辩论；idea_discussion = 常驻人机讨论区。 */
 export type ReviewTargetType = 'idea_match' | 'idea_discussion';
 
@@ -4004,6 +4015,14 @@ export const api = {
   },
   getLeaderboard(projectId: string): Promise<LeaderboardRow[]> {
     return request<LeaderboardRow[]>(`/projects/${projectId}/review/leaderboard`);
+  },
+  getLatestTournamentSummary(projectId: string): Promise<TournamentSummary | null> {
+    return request<TournamentSummary | null>(`/projects/${projectId}/review/tournament/latest`);
+  },
+  retryFailedTournamentMatches(projectId: string): Promise<VoyageRead> {
+    return request<VoyageRead>(`/projects/${projectId}/review/tournament/retry-failed`, {
+      method: 'POST',
+    });
   },
 
   // —— M3 · 讨论 / 辩论 session ——


### PR DESCRIPTION
## Summary

- track failed matches in partially completed tournaments
- add an API to retry only those matches
- prevent duplicate retry runs
- add a retry notice and button to the review page
- reject retries when a participant is no longer available

## Testing

- [x] 10 Idea Review backend tests passed
- [x] Ruff checks passed
- [x] 80 frontend tests passed
- [x] TypeScript and production build passed

Closes #423
