### PR TITLE
feat(integrations): add DeepSeek Harness plugin adapter

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,8 +9,10 @@ got.
 The default MCP surface is read-only. An agent connected with the ordinary
 profile can inform itself about your work but cannot change it. A separately
 authorized DeepSeek Harness profile can expose `remember`, which writes only to
-the current user's assistant memory. Starting an ingest, forging ideas,
-launching an experiment, approving a gate, and drafting a paper remain web-only.
+the current user's assistant memory, and only once that user has turned Buddy
+memory on — the same opt-in the in-app tool surface requires. Starting an
+ingest, forging ideas, launching an experiment, approving a gate, and drafting a
+paper remain web-only.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -6,16 +6,18 @@ you have collected, read their wiki pages and full text, look at concepts and th
 see which AI tasks are running, what is waiting on a human decision, and how far a manuscript has
 got.
 
-**Everything exposed today is read-only.** No tool creates, edits, or deletes anything, and no tool
-runs anything on a remote machine. An agent connected to this server can inform itself about your
-work; it cannot change it. Writes (starting an ingest, forging ideas, launching an experiment,
-drafting a paper) remain web-only for now.
+The default MCP surface is read-only. An agent connected with the ordinary
+profile can inform itself about your work but cannot change it. A separately
+authorized DeepSeek Harness profile can expose `remember`, which writes only to
+the current user's assistant memory. Starting an ingest, forging ideas,
+launching an experiment, approving a gate, and drafting a paper remain web-only.
 
 ---
 
 ## 1. Connect
 
-Two transports, same tools, same permissions.
+Both transports expose the legacy catalog by default. Streamable HTTP also
+supports the scoped profiles described below.
 
 ### Streamable HTTP (recommended)
 
@@ -71,20 +73,46 @@ Call `list_accessible_projects` first when the agent doesn't know which topic to
 use. This user-scoped tool needs no `project_id`; it returns the IDs, names,
 slugs, status, and statements of the topics available to the authenticated user.
 
-Every other tool call carries a `project_id`, which identifies the research
-topic you want the agent to inspect. The server verifies your access on every
-call. A task, manuscript, or library belonging to another topic is reported as
-not found, even when you can access it through another topic. Library visibility
-follows the platform's existing rules: your own personal libraries plus every
-shared library, and nothing more.
+Every project-scoped tool call carries a `project_id`, which identifies the
+research topic you want the agent to inspect. The user-scoped `recall` and
+`remember` tools derive identity from the credential and need no project ID.
+The server verifies your access on every call. A task, manuscript, or library
+belonging to another topic is reported as not found, even when you can access
+it through another topic. Library visibility follows the platform's existing
+rules: your own personal libraries plus every shared library, and nothing more.
 
 You can also find a topic ID in the web app's URL: `/t/<topic-id>`.
 
 ---
 
+### Long-lived integration tokens and profiles
+
+Persistent agents should use a scoped integration token instead of a browser
+JWT. Create one with `POST /api/integration-tokens`; the plaintext is returned
+once, while Polaris stores only a digest. Tokens can carry `skills:read`,
+`mcp:read`, and `mcp:write`, expire after a configured number of days, and can
+be revoked with `DELETE /api/integration-tokens/{id}`.
+
+The optional `X-Polaris-Tool-Profile` request header selects a stable catalog:
+
+| Profile | Tools | Required scope |
+| --- | --- | --- |
+| Omitted | Legacy read-only catalog | `mcp:read` |
+| `dsh-readonly-v1` | Read-only catalog without DSH-native duplicates | `mcp:read` |
+| `dsh-full-v1` | DSH catalog plus approved write tools | `mcp:read`, `mcp:write` |
+
+Profiles govern both discovery and direct invocation. A client cannot call a
+hidden tool by guessing its name. See the
+[DeepSeek Harness bundle](../integrations/deepseek-harness/README.md) for token,
+installation, and skill-provider instructions.
+
+---
+
 ## 2. Tools
 
-46 tools in ten groups. Names are stable; treat them as API.
+The legacy catalog contains 46 tools in ten groups. The DSH profiles hide the
+skill, planning, and sub-agent tools because Harness already provides those
+natively. Names are stable within a versioned profile; treat them as API.
 
 ### Project discovery
 
@@ -207,8 +235,10 @@ These exist primarily for PolarisBuddy, the in-app assistant that shares this to
 appear in the MCP catalog too: `run_subagent` (delegate a retrieval-heavy sub-task to a fresh agent
 that only reports its conclusion) · `skill_load` and `skill_read_file` (fetch an agent skill's body
 and attachments on demand) · `recall` (search your own PolarisBuddy memory; its writing counterpart
-`remember` is not exposed over MCP) · `submit_plan` (hand a step plan over for approval — only
-meaningful in a conversation that can render it).
+`remember` is excluded from read-only profiles) · `submit_plan` (hand a step
+plan over for approval — only meaningful in a conversation that can render it).
+The `dsh-full-v1` profile exposes `remember` only when the integration token has
+`mcp:write` and the account itself is not read-only.
 
 ---
 
@@ -255,7 +285,9 @@ get_fact_pack manuscript_id=…                       → the sanctioned facts f
 
 ## 4. Behaviour and limits
 
-- **Read-only.** Every tool is a query. `tools/list` reports `read_only: true` for all of them.
+- **Read-only by default.** The legacy and `dsh-readonly-v1` catalogs contain
+  only query tools. `dsh-full-v1` additionally exposes explicitly approved
+  writes and requires a scoped credential.
 - **Truncation is explicit.** Long text is capped (wiki 8 000 chars, full text 6 000 per page, chunks
   1 200, logs by line count) and the response says so — `truncated: true`, or `page`/`pages` so you
   know a next call exists.
@@ -298,6 +330,7 @@ that breaks a tool fails the build rather than surfacing in your agent.
 | A figure download URL returns `FIGURE_LINK_INVALID` | The signed URL expired or was modified. Call `get_paper_figure` again to create a new link. |
 | A stdio figure result contains a relative URL | Set `POLARIS_PUBLIC_BASE_URL` to the server root that the agent can reach. |
 | Tools missing from `tools/list` | Old server version, or the client cached an earlier list — reconnect. |
+| `MCP_WRITE_SCOPE_REQUIRED` | `dsh-full-v1` needs both `mcp:read` and `mcp:write`, and the account must not be read-only. |
 
 ---
 
@@ -309,3 +342,5 @@ that breaks a tool fails the build rather than surfacing in your agent.
   contract.
 - [Configuration](configuration.md#application-settings-polaris_-prefix) — public URL and link
   lifetime settings.
+- [DeepSeek Harness bundle](../integrations/deepseek-harness/README.md) — native
+  skills, MCP profiles, installation, and operations.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -142,6 +142,23 @@ delegates broad surveys to a sub-agent. Your own skills are created by POSTing a
 `POST /api/chat/skills` (same slug overwrites your copy; built-ins are untouchable), and everything
 visible to you is listed — and yours deletable — under **Settings → PolarisBuddy → Skills**.
 
+### DeepSeek Harness
+
+The Polaris DSH bundle carries assistant skills through Harness's native
+`ctx.skills` provider API. It does not map each skill to an MCP tool. The normal
+DSH `skill` tool performs body loading, while `polaris_skill_resource` reads one
+declared attachment on demand. The official DSH MCP bridge carries the separate
+Polaris tool catalog.
+
+User skills shadow same-slug built-ins. Manual skills remain available through
+DSH's standard `/skill-name` gesture, and automatic skills remain visible to
+the model. After a Polaris skill loads, its `allowed-tools` list restricts only
+the current turn's Polaris MCP tools. Multiple skill lists intersect, and the
+restriction never widens the existing DSH tool surface.
+
+See [Polaris for DeepSeek Harness](../integrations/deepseek-harness/README.md)
+for installation, token scopes, failure behavior, and configuration.
+
 ## Tips and limits
 
 - **Skills are declarative.** No skill layer executes code. Task skills carry markdown, rubrics,

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,0 +1,182 @@
+# Polaris for DeepSeek Harness
+
+This package connects one Polaris account to DeepSeek Harness (DSH). It is a
+DSH bundle with two independent adapters:
+
+| Polaris capability | DSH extension point | Implementation |
+| --- | --- | --- |
+| MCP tools | `ctx.tools` | Official `@deepseek-ai/dsh-mcp-client` |
+| Assistant skills | `ctx.skills` | Native Polaris skill provider |
+| Skill attachments | `ctx.tools` | `polaris_skill_resource` |
+
+The plugin does carry assistant skills. It does not expose them as duplicate
+MCP tools. DSH receives a native skill catalog, loads full instructions through
+its own `skill` tool, and fetches attachments only when needed.
+
+## Architecture
+
+```text
+DeepSeek Harness
+├── official MCP client ── POST /mcp ── Polaris tool registry
+└── Polaris skill provider
+    ├── GET .../v1/skills ───────────── catalog and ETag
+    ├── GET .../v1/skills/{slug} ────── full skill body
+    └── polaris_skill_resource ──────── one attachment
+```
+
+The backend applies the selected MCP profile to both `tools/list` and
+`tools/call`. Knowing the name of a hidden tool therefore cannot bypass the
+profile. The plugin applies a skill's `allowed-tools` policy to the current DSH
+agent turn. It hides denied Polaris MCP schemas and also installs an execution
+guard for tools discovered later in the same turn.
+
+## Requirements
+
+- Polaris with migration `8ff89f7fcdeb` applied.
+- DeepSeek Harness `0.1.0-rc.6`.
+- Node.js 20 or newer for local package builds.
+- A Polaris integration token. Do not use a short-lived browser JWT in a
+  persistent DSH profile.
+
+## Prepare Polaris
+
+Apply the database migration:
+
+```bash
+cd src/backend
+.venv/bin/alembic upgrade head
+```
+
+Create a token with a current user JWT. The plaintext token is returned only
+by this request; Polaris stores only its SHA-256 digest.
+
+```bash
+curl --fail-with-body \
+  -X POST https://polaris.example.edu/api/integration-tokens \
+  -H "Authorization: Bearer $POLARIS_SESSION_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "DeepSeek Harness",
+    "scopes": ["skills:read", "mcp:read"],
+    "expires_in_days": 90
+  }'
+```
+
+Available scopes are:
+
+- `skills:read`: discover and load visible assistant skills and attachments.
+- `mcp:read`: connect to `/mcp` and use read-only tools.
+- `mcp:write`: select `dsh-full-v1`; this also requires `mcp:read`.
+
+The only write tool currently exposed by `dsh-full-v1` is `remember`. A
+read-only Polaris account cannot use the full profile even if its token names
+the write scope.
+
+List or revoke credentials with `GET /api/integration-tokens` and
+`DELETE /api/integration-tokens/{id}`. Revocation takes effect on the next
+request.
+
+## Build and install the bundle
+
+Build from this checkout, then add the directory to the DSH profile that should
+receive Polaris. The DSH CLI links local bundles through its profile package
+manager.
+
+```bash
+cd integrations/deepseek-harness
+npm ci
+npm run check
+dsh plugin --profile web add "$PWD"
+```
+
+Use another profile name, such as `headless`, when appropriate. Configure the
+environment before starting DSH:
+
+```bash
+export POLARIS_BASE_URL=https://polaris.example.edu
+export POLARIS_DSH_TOKEN=polaris_it_replace_me
+export POLARIS_DSH_TOOL_PROFILE=dsh-readonly-v1
+
+dsh --profile web --dump-config
+dsh --profile web
+```
+
+`--dump-config` should contain the `polaris-mcp` and `polaris-skills` rows. Do
+not put the token directly in `cordis.patch.yml` or commit it to source control.
+
+To remove the bundle:
+
+```bash
+dsh plugin --profile web remove @polaris-ai/deepseek-harness-plugin
+```
+
+## Bundle configuration
+
+The bundled patch reads three environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `POLARIS_BASE_URL` | `http://127.0.0.1:8000` | Reachable Polaris server root |
+| `POLARIS_DSH_TOKEN` | empty | Scoped integration token |
+| `POLARIS_DSH_TOOL_PROFILE` | `dsh-readonly-v1` | Backend MCP profile |
+
+The native plugin row also accepts these configuration fields:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `serverName` | `polaris` | MCP namespace used for policy matching |
+| `refreshIntervalMs` | `30000` | Skill catalog polling interval |
+| `requestTimeoutMs` | `10000` | Polaris discovery request timeout |
+| `failOnStartupError` | `false` | Fail DSH boot when discovery fails |
+| `allowedToolsMode` | `enforce` | `enforce`, `advisory`, or `off` |
+| `userSkillRank` | `340` | DSH candidate rank for user skills |
+| `builtinSkillRank` | `360` | DSH candidate rank for built-ins |
+
+The `serverName` value must match the official MCP client row. If a user skill
+and a Polaris built-in share a slug, the user skill wins before either is sent
+to DSH. `allowedToolsMode: advisory` logs violations without hiding or blocking
+tools; `off` disables policy tracking entirely.
+
+## Skill behavior
+
+Polaris sends only names, trigger descriptions, invocation mode, policy
+metadata, and attachment metadata during discovery. Full bodies are loaded on
+demand through DSH's native `skill` tool.
+
+- `invocation: auto` makes a skill model- and user-invocable.
+- `invocation: manual` keeps it out of model-driven loading but allows the
+  standard DSH `/skill-name` user gesture.
+- `allowed-tools: null` leaves the existing tool surface unchanged.
+- A non-empty `allowed-tools` list is matched against raw Polaris tool names,
+  such as `search_papers`, not namespaced DSH names.
+- Loading several Polaris skills in one turn intersects their allowlists. It
+  never adds a tool and never restricts non-Polaris DSH tools.
+- Restrictions are cleared on turn completion, turn error, or agent disposal.
+
+Catalog responses use semantic ETags. A transient refresh error keeps the last
+known catalog but marks discovery incomplete. A `401` or `403` clears cached
+skills and invalidates DSH discovery, so a revoked token fails closed.
+
+## Verification
+
+Run the package checks locally:
+
+```bash
+npm run check
+npm audit --audit-level=low
+npm pack --dry-run
+```
+
+After DSH starts, verify that its tool catalog contains names such as
+`mcp__polaris__search_papers`, does not contain Polaris's `skill_load`, and that
+Polaris assistant skills appear in DSH's native skill catalog.
+
+Common failures:
+
+| Symptom | Resolution |
+| --- | --- |
+| Skill discovery logs HTTP 401 | Replace or recreate the expired or revoked token. |
+| Skill discovery logs HTTP 403 | Add `skills:read` to a new token. Token scopes cannot be edited. |
+| MCP startup logs HTTP 403 | Add `mcp:read`, or stop selecting `dsh-full-v1` without `mcp:write`. |
+| No Polaris tools appear | Check `/mcp`, the profile header, and `--dump-config`. |
+| A skill denies a tool | Use raw Polaris names; multiple policies intersect. |

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -68,13 +68,16 @@ Available scopes are:
 - `mcp:read`: connect to `/mcp` and use read-only tools.
 - `mcp:write`: select `dsh-full-v1`; this also requires `mcp:read`.
 
-The only write tool currently exposed by `dsh-full-v1` is `remember`. A
+The only write tool currently exposed by `dsh-full-v1` is `remember`, and it
+appears only after the account turns Buddy memory on; until then it is hidden
+from both discovery and invocation, matching the in-app tool surface. A
 read-only Polaris account cannot use the full profile even if its token names
 the write scope.
 
 List or revoke credentials with `GET /api/integration-tokens` and
 `DELETE /api/integration-tokens/{id}`. Revocation takes effect on the next
-request.
+request. Demoting an account to read-only likewise blocks `/mcp` for its
+existing tokens on the next request, not only for its browser session.
 
 ## Build and install the bundle
 

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,0 +1,30 @@
+# Polaris tools use the official DSH MCP bridge.  Polaris skills use the native
+# provider below, so the DSH tool profile removes the duplicate skill tools.
+- insert:
+    - id: polaris-mcp
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: polaris
+        transport: streamable-http
+        url: !!js '(process.env.POLARIS_BASE_URL ?? "http://127.0.0.1:8000").replace(/\/$/, "") + "/mcp"'
+        headers:
+          Authorization: !!js '`Bearer ${process.env.POLARIS_DSH_TOKEN ?? ""}`'
+          X-Polaris-Tool-Profile: !!js 'process.env.POLARIS_DSH_TOOL_PROFILE ?? "dsh-readonly-v1"'
+        toolCallTimeoutMs: 60000
+        failOnStartupError: false
+        reconnect:
+          enabled: true
+          initialDelayMs: 500
+          maxDelayMs: 30000
+          maxAttempts: 10
+
+    - id: polaris-skills
+      name: '@polaris-ai/deepseek-harness-plugin'
+      config:
+        baseUrl: !!js 'process.env.POLARIS_BASE_URL ?? "http://127.0.0.1:8000"'
+        token: !!js 'process.env.POLARIS_DSH_TOKEN ?? ""'
+        serverName: polaris
+        refreshIntervalMs: 30000
+        requestTimeoutMs: 10000
+        failOnStartupError: false
+        allowedToolsMode: enforce

--- a/integrations/deepseek-harness/package-lock.json
+++ b/integrations/deepseek-harness/package-lock.json
@@ -1,0 +1,3070 @@
+{
+  "name": "@polaris-ai/deepseek-harness-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@polaris-ai/deepseek-harness-plugin",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@deepseek-ai/dsh-mcp-client": "0.1.0-rc.6",
+        "@deepseek-ai/schemastery": "3.18.1",
+        "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "@deepseek-ai/cordis": "4.0.1",
+        "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+        "@types/node": "22.18.0",
+        "typescript": "5.9.2",
+        "vitest": "3.2.7"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
+      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "bin": {
+        "cordis": "bin.js"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-include": {
+          "optional": true
+        },
+        "@deepseek-ai/cordis-plugin-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
+      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.6.tgz",
+      "integrity": "sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.6.tgz",
+      "integrity": "sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.6.tgz",
+      "integrity": "sha512-E8j9Nby24qP4rfrdcfc7bpt1CHpGT3tYmycOJJkEOH4ptIdT1m2ro9nmnSd5CWYukTr64A77vjm2WGqHRI92UA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.6.tgz",
+      "integrity": "sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.6.tgz",
+      "integrity": "sha512-WfEfOi99a4cpOugRAHTBSTnesLieu3ist1q9PXDXFBHX++K1rAl9+sB7YrdnbB8LH0UOY532gS9xJUYU6w0SLw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.6.tgz",
+      "integrity": "sha512-kuFGC8bHlzGTwlRxQhXjf3CYWl8M4NzH+EYIkrW8rri4iMc9W53xrdvkil5No/DUlMm8g1u7GdeiWYFy0TMvtA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-mcp-client": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.0-rc.6.tgz",
+      "integrity": "sha512-seBl0SLn308CbPwGVSm2BM3HECaNln3mbpcdHtw4DjnI5mZRILxC6wgKXAtYcNWKxMY1FaiwFWcgQ2+HHCQ7PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.6.tgz",
+      "integrity": "sha512-UlDLV4syLoJinNg9imhXrSAHrdaTa5Ff8gg46rzjFJGPUOhAk3DZff0hryT5OhrBi0A5Tj92qVpg2pRVvxnUzQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.6.tgz",
+      "integrity": "sha512-8tu8I6VWC7050GAUXWhcEWQw4pakALQc8TlhKr52m7Y4+kIKeNt3FBgP86PaGPBtpK0p5zUPRQNkFpzZbBdxyw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.6.tgz",
+      "integrity": "sha512-VyRlCOASIRuTflKwn4NvbdAXxSPnnLJ+RAQUI4GK5pOtPwI2DhJrbovqpyp5kNAkZMsqvIeHWu5PcCEJ+FpQ2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.6.tgz",
+      "integrity": "sha512-nZaZRjSnE1he+GAd14vURAH7n3Fw5eGx3nzMbkB96Y6Qx+oQB/7PTuXxKVxlCh8TSfMJTf851ahwWb1eALjKlw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.6.tgz",
+      "integrity": "sha512-E7g+XChh4q4/wX++v56z1pV4SA1Rtz42xkznLPPi9FlXrrzJxwHMOUzBZ9Rz3Y1kLhQ++HJG3ZatmNx3rjFilg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.6.tgz",
+      "integrity": "sha512-CUean0fAnfsJVszFEip7PsU/S26W+JfDFfsza2dCtlw8n6xlkbHA9Gjxdk2aTwqDGCgXEPkRW7mYkdJ0n6FR7w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.6.tgz",
+      "integrity": "sha512-Tu08EPK3JyK0iNjH4FGzu/1uADynNSS6SmwOLdfytUN0YNqwNuKFSt2OJUg19famNlTgy992DcHfDu0T+gLXFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.6.tgz",
+      "integrity": "sha512-weWzN8r01YCkoDCAM7BsKw2YhRrD4zL8N2SAZu9hovYtXSq8xHXsP4Zh8RLYIlYcuotjyff/6hic+0TJPd14YA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.6.tgz",
+      "integrity": "sha512-9rnkSDGOpu2XUeGwbPeTzVUTFWTND1PMPM5L/ZQPptV5yyZlQiNxM2rCC6OdL+ZVerwxEqrRhZIQn/KVtQfKag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
+      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@polaris-ai/deepseek-harness-plugin",
+  "version": "0.1.0",
+  "description": "DeepSeek Harness bundle for Polaris MCP tools and native agent skills",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "cordis.patch.yml",
+    "README.md"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "check": "npm run build && npm test",
+    "prepack": "npm run build"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@deepseek-ai/dsh-mcp-client": "0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "3.18.1",
+    "zod": "4.4.3"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-skill": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-system-prompt": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "@types/node": "22.18.0",
+    "typescript": "5.9.2",
+    "vitest": "3.2.7"
+  },
+  "license": "Apache-2.0"
+}

--- a/integrations/deepseek-harness/src/client.ts
+++ b/integrations/deepseek-harness/src/client.ts
@@ -1,0 +1,126 @@
+import {
+  SkillCatalogSchema,
+  SkillDefinitionSchema,
+  type PolarisSkillCatalog,
+  type PolarisSkillDefinition,
+} from './contracts.js'
+
+export class PolarisApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'PolarisApiError'
+  }
+}
+
+export type CatalogFetchResult =
+  | { readonly kind: 'not-modified'; readonly etag?: string }
+  | { readonly kind: 'catalog'; readonly value: PolarisSkillCatalog; readonly etag?: string }
+
+interface RequestOptions {
+  readonly signal?: AbortSignal | undefined
+  readonly etag?: string | undefined
+  readonly accept?: string
+}
+
+export class PolarisClient {
+  readonly baseUrl: URL
+
+  constructor(
+    baseUrl: string,
+    private readonly token: string,
+    private readonly timeoutMs: number,
+  ) {
+    this.baseUrl = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
+    if (!['http:', 'https:'].includes(this.baseUrl.protocol)) {
+      throw new Error('baseUrl must use http or https')
+    }
+    if (token.length === 0) throw new Error('token must not be empty')
+    if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+      throw new Error('requestTimeoutMs must be a positive integer')
+    }
+  }
+
+  async fetchCatalog(signal?: AbortSignal, etag?: string): Promise<CatalogFetchResult> {
+    const response = await this.request(
+      'api/integrations/deepseek-harness/v1/skills',
+      { signal, etag },
+    )
+    const responseEtag = response.headers.get('etag') ?? undefined
+    if (response.status === 304) {
+      return { kind: 'not-modified', ...(responseEtag === undefined ? {} : { etag: responseEtag }) }
+    }
+    await this.requireOk(response)
+    const value = SkillCatalogSchema.parse(await response.json())
+    return {
+      kind: 'catalog',
+      value,
+      ...(responseEtag === undefined ? {} : { etag: responseEtag }),
+    }
+  }
+
+  async fetchSkill(slug: string, signal?: AbortSignal): Promise<PolarisSkillDefinition | undefined> {
+    const response = await this.request(
+      `api/integrations/deepseek-harness/v1/skills/${encodeURIComponent(slug)}`,
+      { signal },
+    )
+    if (response.status === 404) return undefined
+    await this.requireOk(response)
+    return SkillDefinitionSchema.parse(await response.json())
+  }
+
+  async fetchSkillFile(
+    slug: string,
+    path: string,
+    signal?: AbortSignal,
+  ): Promise<{ readonly content: string; readonly revision?: string } | undefined> {
+    const encodedPath = path.split('/').map(segment => encodeURIComponent(segment)).join('/')
+    const response = await this.request(
+      `api/integrations/deepseek-harness/v1/skills/${encodeURIComponent(slug)}/files/${encodedPath}`,
+      { signal, accept: 'text/plain' },
+    )
+    if (response.status === 404) return undefined
+    await this.requireOk(response)
+    const etag = response.headers.get('etag')?.replace(/^(?:W\/)?"|"$/g, '')
+    return {
+      content: await response.text(),
+      ...(etag === undefined ? {} : { revision: etag }),
+    }
+  }
+
+  private async request(path: string, options: RequestOptions): Promise<Response> {
+    const controller = new AbortController()
+    const timeout = setTimeout(
+      () => controller.abort(new Error(`Polaris request timed out after ${this.timeoutMs}ms`)),
+      this.timeoutMs,
+    )
+    const abort = (): void => controller.abort(options.signal?.reason)
+    options.signal?.addEventListener('abort', abort, { once: true })
+    if (options.signal?.aborted) abort()
+    try {
+      return await fetch(new URL(path, this.baseUrl), {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: options.accept ?? 'application/json',
+          ...(options.etag === undefined ? {} : { 'If-None-Match': options.etag }),
+        },
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', abort)
+    }
+  }
+
+  private async requireOk(response: Response): Promise<void> {
+    if (response.ok) return
+    const detail = (await response.text()).slice(0, 500)
+    throw new PolarisApiError(
+      response.status,
+      `Polaris API request failed with HTTP ${response.status}${detail ? `: ${detail}` : ''}`,
+    )
+  }
+}

--- a/integrations/deepseek-harness/src/client.ts
+++ b/integrations/deepseek-harness/src/client.ts
@@ -76,7 +76,15 @@ export class PolarisClient {
     path: string,
     signal?: AbortSignal,
   ): Promise<{ readonly content: string; readonly revision?: string } | undefined> {
-    const encodedPath = path.split('/').map(segment => encodeURIComponent(segment)).join('/')
+    const segments = path.split('/')
+    // A skill declares attachments as fixed relative paths; encodeURIComponent
+    // leaves '.'/'..' intact and new URL() collapses them, so an empty, dot, or
+    // dot-dot segment would retarget the authenticated request outside the
+    // skill-files route. Reject before encoding: an undeclared path is absent.
+    if (segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+      return undefined
+    }
+    const encodedPath = segments.map(segment => encodeURIComponent(segment)).join('/')
     const response = await this.request(
       `api/integrations/deepseek-harness/v1/skills/${encodeURIComponent(slug)}/files/${encodedPath}`,
       { signal, accept: 'text/plain' },

--- a/integrations/deepseek-harness/src/contracts.ts
+++ b/integrations/deepseek-harness/src/contracts.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+export const SkillFileSchema = z.object({
+  path: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  revision: z.string().regex(/^[a-f0-9]{64}$/),
+}).strict()
+
+export const SkillCatalogItemSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  invocation: z.enum(['auto', 'manual']),
+  scope: z.enum(['builtin', 'user']),
+  allowedTools: z.array(z.string().min(1)).nullable(),
+  files: z.array(SkillFileSchema),
+  revision: z.string().regex(/^[a-f0-9]{64}$/),
+  updatedAt: z.iso.datetime({ offset: true }),
+}).strict()
+
+export const SkillCatalogSchema = z.object({
+  revision: z.string().regex(/^[a-f0-9]{64}$/),
+  skills: z.array(SkillCatalogItemSchema),
+}).strict()
+
+export const SkillDefinitionSchema = SkillCatalogItemSchema.extend({
+  body: z.string(),
+}).strict()
+
+export type PolarisSkillCatalog = z.infer<typeof SkillCatalogSchema>
+export type PolarisSkillCatalogItem = z.infer<typeof SkillCatalogItemSchema>
+export type PolarisSkillDefinition = z.infer<typeof SkillDefinitionSchema>
+
+export interface PolarisSkillPolicy {
+  readonly provider: 'polaris'
+  readonly name: string
+  readonly allowedTools: readonly string[] | null
+  readonly userInvocable: boolean
+  readonly revision: string
+}

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -1,0 +1,116 @@
+import type { Context } from '@deepseek-ai/cordis'
+import z from '@deepseek-ai/schemastery'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type {} from '@deepseek-ai/dsh-agent'
+import type {} from '@deepseek-ai/dsh-skill'
+import { PolarisClient } from './client.js'
+import { installSkillPolicy } from './policy.js'
+import { PolarisSkillProvider } from './provider.js'
+
+export const name = 'polaris-deepseek-harness'
+export const inject = ['agents', 'tools', 'skills']
+
+export interface Config {
+  readonly baseUrl: string
+  readonly token: string
+  readonly serverName?: string
+  readonly refreshIntervalMs?: number
+  readonly requestTimeoutMs?: number
+  readonly failOnStartupError?: boolean
+  readonly allowedToolsMode?: 'enforce' | 'advisory' | 'off'
+  readonly userSkillRank?: number
+  readonly builtinSkillRank?: number
+}
+
+const SERVER_NAME = /^[A-Za-z0-9_-]{1,32}$/
+
+export const Config: z<Config> = z.object({
+  baseUrl: z.string().required(),
+  token: z.string().required().role('secret'),
+  serverName: z.string().pattern(SERVER_NAME).default('polaris'),
+  refreshIntervalMs: z.number().min(1000).default(30_000),
+  requestTimeoutMs: z.number().min(1).default(10_000),
+  failOnStartupError: z.boolean().default(false),
+  allowedToolsMode: z.union(['enforce', 'advisory', 'off']).default('enforce'),
+  userSkillRank: z.number().default(340),
+  builtinSkillRank: z.number().default(360),
+})
+
+export async function apply(ctx: Context, config: Config): Promise<void> {
+  const serverName = config.serverName ?? 'polaris'
+  const refreshIntervalMs = config.refreshIntervalMs ?? 30_000
+  const requestTimeoutMs = config.requestTimeoutMs ?? 10_000
+  const client = new PolarisClient(config.baseUrl, config.token, requestTimeoutMs)
+  const provider = new PolarisSkillProvider(
+    ctx,
+    client,
+    {
+      user: config.userSkillRank ?? 340,
+      builtin: config.builtinSkillRank ?? 360,
+    },
+    refreshIntervalMs,
+  )
+
+  if (config.failOnStartupError === true) await provider.initialize()
+  ctx.skills.registerProvider(control => {
+    provider.bind(control)
+    return provider
+  })
+
+  const resourceTool = defineTool({
+    name: 'polaris_skill_resource',
+    description: 'Read one text attachment named by a loaded Polaris skill. Use only paths listed in that skill.',
+    parameters: {
+      skill: { type: 'string', required: true, description: 'Exact Polaris skill name.' },
+      path: { type: 'string', required: true, description: 'Relative attachment path listed by the skill.' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          skill: { type: 'string', required: true },
+          path: { type: 'string', required: true },
+          content: { type: 'string', required: true },
+          revision: { type: 'string' },
+        },
+      },
+      render: (_args, value) => [{ type: 'text', text: value.content }],
+    },
+    async execute(args, exec) {
+      const result = await client.fetchSkillFile(args.skill, args.path, exec.signal)
+      if (result === undefined) {
+        throw new Error(`Polaris skill "${args.skill}" has no attachment "${args.path}"`)
+      }
+      return {
+        skill: args.skill,
+        path: args.path,
+        content: result.content,
+        ...(result.revision === undefined ? {} : { revision: result.revision }),
+      }
+    },
+    isConcurrencySafe: () => true,
+    presentCall: args => ({
+      card: 'generic',
+      title: `Read Polaris skill resource ${args.skill}/${args.path}`,
+      kind: 'read',
+      rawInput: `${args.skill}/${args.path}`,
+    }),
+  })
+  ctx.tools.register(resourceTool)
+
+  const policyMode = config.allowedToolsMode ?? 'enforce'
+  if (policyMode !== 'off') {
+    installSkillPolicy(ctx, provider, serverName, policyMode)
+  }
+}
+
+export { PolarisApiError, PolarisClient } from './client.js'
+export { intersectAllowed, invokedSkillNames, PolarisSkillPolicyController } from './policy.js'
+export { PolarisSkillProvider } from './provider.js'
+export type {
+  PolarisSkillCatalog,
+  PolarisSkillCatalogItem,
+  PolarisSkillDefinition,
+  PolarisSkillPolicy,
+} from './contracts.js'

--- a/integrations/deepseek-harness/src/policy.ts
+++ b/integrations/deepseek-harness/src/policy.ts
@@ -1,0 +1,186 @@
+import type { Context } from '@deepseek-ai/cordis'
+import type { Agent, PreStepDecision } from '@deepseek-ai/dsh-agent'
+import type { UserMessage } from '@deepseek-ai/dsh-session'
+import type { PostToolDecision, ToolExecutionResult } from '@deepseek-ai/dsh-tools'
+import { isUserInvocable } from '@deepseek-ai/dsh-skill'
+import type { PolarisSkillPolicy } from './contracts.js'
+import type { PolarisSkillProvider } from './provider.js'
+
+// Keep this token contract identical to @deepseek-ai/dsh-tool-skill.  Applying
+// policy to a token that DSH did not recognize as an invocation would only
+// make the turn more restrictive without loading the corresponding skill.
+const SKILL_GESTURE = /(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$)/g
+
+interface ActiveRestriction {
+  readonly turn: number
+  allowed: Set<string>
+  liftRestriction: (() => void) | undefined
+  liftGuard: () => void
+}
+
+export function invokedSkillNames(messages: readonly UserMessage[]): string[] {
+  const names: string[] = []
+  for (const message of messages) {
+    if ((message.source as { kind?: unknown }).kind !== 'user') continue
+    for (const block of message.content) {
+      if (block.type !== 'text') continue
+      for (const match of block.text.matchAll(SKILL_GESTURE)) {
+        const name = match[2]
+        if (name !== undefined && !names.includes(name)) names.push(name)
+      }
+    }
+  }
+  return names
+}
+
+export function intersectAllowed(
+  current: ReadonlySet<string> | undefined,
+  incoming: readonly string[] | null,
+): Set<string> | undefined {
+  if (incoming === null) return current === undefined ? undefined : new Set(current)
+  const next = new Set(incoming)
+  if (current === undefined) return next
+  return new Set([...current].filter(name => next.has(name)))
+}
+
+function currentTurn(agent: Agent): number | undefined {
+  for (let index = agent.session.events.length - 1; index >= 0; index -= 1) {
+    const event = agent.session.events[index]
+    if (event?.type === 'turn/start') return event.data.turn
+  }
+  return undefined
+}
+
+function loadedPolarisSkill(result: Readonly<ToolExecutionResult>): string | undefined {
+  if (result.isError || typeof result.value !== 'object' || result.value === null) return undefined
+  const value = result.value as Record<string, unknown>
+  return value.provider === 'polaris' && typeof value.name === 'string' ? value.name : undefined
+}
+
+export class PolarisSkillPolicyController {
+  private readonly active = new Map<Agent, ActiveRestriction>()
+  private rebuilding = false
+  private readonly prefix: string
+
+  constructor(
+    private readonly ctx: Context,
+    serverName: string,
+    private readonly mode: 'enforce' | 'advisory' = 'enforce',
+  ) {
+    this.prefix = `mcp__${serverName}__`
+  }
+
+  apply(agent: Agent, turn: number, policy: PolarisSkillPolicy): void {
+    let state = this.active.get(agent)
+    if (state !== undefined && state.turn !== turn) {
+      this.clear(agent)
+      state = undefined
+    }
+    const allowed = intersectAllowed(state?.allowed, policy.allowedTools)
+    if (allowed === undefined) return
+    if (state === undefined) {
+      const liftGuard = agent.ctx.tools.guard(exec => {
+        const live = this.active.get(agent)
+        if (live === undefined || !exec.name.startsWith(this.prefix)) return undefined
+        const rawName = exec.name.slice(this.prefix.length)
+        if (live.allowed.has(rawName)) return undefined
+        const message = `Polaris skill policy denies tool "${rawName}" for turn ${live.turn}`
+        if (this.mode === 'advisory') {
+          this.ctx.logger.warn(`polaris-skill-policy: advisory: ${message}`)
+          return undefined
+        }
+        return message
+      })
+      state = { turn, allowed, liftRestriction: undefined, liftGuard }
+      this.active.set(agent, state)
+    } else {
+      state.allowed = allowed
+    }
+    this.rebuild(agent, state)
+  }
+
+  refreshAll(): void {
+    if (this.rebuilding) return
+    for (const [agent, state] of this.active) this.rebuild(agent, state)
+  }
+
+  clear(agent: Agent): void {
+    const state = this.active.get(agent)
+    if (state === undefined) return
+    this.active.delete(agent)
+    state.liftRestriction?.()
+    state.liftGuard()
+  }
+
+  clearTurn(agent: Agent, turn: number): void {
+    if (this.active.get(agent)?.turn === turn) this.clear(agent)
+  }
+
+  private rebuild(agent: Agent, state: ActiveRestriction): void {
+    if (this.rebuilding) return
+    this.rebuilding = true
+    try {
+      state.liftRestriction?.()
+      state.liftRestriction = undefined
+      if (this.mode === 'advisory') return
+      const denied = agent.ctx.tools.schemas(agent)
+        .map(tool => tool.name)
+        .filter(name => name.startsWith(this.prefix))
+        .filter(name => !state.allowed.has(name.slice(this.prefix.length)))
+      if (denied.length > 0) {
+        state.liftRestriction = agent.ctx.tools.restrict({ deny: denied })
+      }
+    } finally {
+      this.rebuilding = false
+    }
+  }
+}
+
+export function installSkillPolicy(
+  ctx: Context,
+  provider: PolarisSkillProvider,
+  serverName: string,
+  mode: 'enforce' | 'advisory' = 'enforce',
+): void {
+  const controller = new PolarisSkillPolicyController(ctx, serverName, mode)
+
+  ctx.on('tools/change', () => controller.refreshAll())
+  ctx.on('agent/disposed', ({ agent }) => controller.clear(agent))
+  ctx.on('agent/error', ({ agent, turn }) => controller.clearTurn(agent, turn))
+  ctx.on('agent/turn-stopping', ({ agent, turn }) => controller.clearTurn(agent, turn))
+
+  ctx.on('tools/post-execute', async (exec, result, next): Promise<PostToolDecision> => {
+    const decision = await next()
+    if (exec.name !== 'skill' || exec.agent === undefined) return decision
+    const name = loadedPolarisSkill(result)
+    const turn = currentTurn(exec.agent)
+    const policy = name === undefined ? undefined : provider.policy(name)
+    if (turn !== undefined && policy !== undefined) controller.apply(exec.agent, turn, policy)
+    return decision
+  })
+
+  ctx.on('agent/pre-step', async (
+    { agent, messages, turn, signal },
+    next,
+  ): Promise<PreStepDecision> => {
+    const existing = currentTurn(agent)
+    if (existing !== undefined && existing !== turn) controller.clear(agent)
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    const names = invokedSkillNames(messages)
+    if (names.length === 0) return decision
+    const summaries = await ctx.skills.list({
+      cwd: agent.session.header.cwd,
+      signal,
+      scope: agent,
+    })
+    signal.throwIfAborted()
+    for (const name of names) {
+      const summary = summaries.find(skill => skill.name === name)
+      if (summary?.provider !== 'polaris' || !isUserInvocable(summary)) continue
+      const policy = provider.policy(name)
+      if (policy !== undefined) controller.apply(agent, turn, policy)
+    }
+    return decision
+  })
+}

--- a/integrations/deepseek-harness/src/provider.ts
+++ b/integrations/deepseek-harness/src/provider.ts
@@ -1,0 +1,200 @@
+import type { Context } from '@deepseek-ai/cordis'
+import type {
+  SkillCandidate,
+  SkillDefinition,
+  SkillLookupOptions,
+  SkillProvider,
+  SkillProviderControl,
+} from '@deepseek-ai/dsh-skill'
+import type { PolarisSkillCatalogItem, PolarisSkillPolicy } from './contracts.js'
+import { PolarisApiError, PolarisClient } from './client.js'
+
+export interface ProviderRanks {
+  readonly user: number
+  readonly builtin: number
+}
+
+interface PolarisLocator {
+  readonly id: string
+  readonly slug: string
+  readonly revision: string
+}
+
+function locator(value: unknown): PolarisLocator | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const record = value as Record<string, unknown>
+  if (typeof record.id !== 'string'
+    || typeof record.slug !== 'string'
+    || typeof record.revision !== 'string') return undefined
+  return { id: record.id, slug: record.slug, revision: record.revision }
+}
+
+export class PolarisSkillProvider implements SkillProvider {
+  readonly name = 'polaris'
+  private catalog: readonly PolarisSkillCatalogItem[] | undefined
+  private etag: string | undefined
+  private authoritative = false
+  private readonly policies = new Map<string, PolarisSkillPolicy>()
+
+  constructor(
+    private readonly ctx: Context,
+    private readonly client: PolarisClient,
+    private readonly ranks: ProviderRanks,
+    private readonly refreshIntervalMs: number,
+  ) {}
+
+  async initialize(signal?: AbortSignal): Promise<void> {
+    await this.refresh(signal)
+  }
+
+  bind(control: SkillProviderControl): void {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const schedule = (): void => {
+      if (control.signal.aborted) return
+      timer = setTimeout(() => void poll(), this.refreshIntervalMs)
+    }
+    const poll = async (): Promise<void> => {
+      try {
+        const changed = await this.refresh(control.signal)
+        if (changed) control.invalidate()
+      } catch (error) {
+        if (error instanceof PolarisApiError && [401, 403].includes(error.status)) {
+          if (this.clear()) control.invalidate()
+        }
+        if (!control.signal.aborted) {
+          this.ctx.logger.warn(`polaris-skill-provider: refresh failed: ${errorMessage(error)}`)
+        }
+      } finally {
+        schedule()
+      }
+    }
+    control.signal.addEventListener('abort', () => {
+      if (timer !== undefined) clearTimeout(timer)
+    }, { once: true })
+    schedule()
+  }
+
+  readonly list = async (
+    options: SkillLookupOptions,
+  ): Promise<readonly SkillCandidate[] | { readonly candidates: readonly SkillCandidate[]; readonly complete: boolean }> => {
+    try {
+      await this.refresh(options.signal)
+    } catch (error) {
+      if (error instanceof PolarisApiError && [401, 403].includes(error.status)) {
+        this.clear()
+      }
+      this.ctx.logger.warn(`polaris-skill-provider: discovery failed: ${errorMessage(error)}`)
+      return { candidates: this.candidates(), complete: false }
+    }
+    const candidates = this.candidates()
+    return this.authoritative ? candidates : { candidates, complete: false }
+  }
+
+  readonly get = async (
+    candidate: SkillCandidate,
+    options: SkillLookupOptions,
+  ): Promise<SkillDefinition | undefined> => {
+    const target = locator(candidate.locator)
+    if (target === undefined) return undefined
+    const definition = await this.client.fetchSkill(target.slug, options.signal)
+    if (definition === undefined || definition.id !== target.id) {
+      this.authoritative = false
+      return undefined
+    }
+    this.rememberPolicy(definition)
+    return {
+      name: definition.slug,
+      description: definition.description,
+      invocation: {
+        modelInvocable: definition.invocation === 'auto',
+        userInvocable: true,
+      },
+      source: definition.scope === 'user' ? 'polaris-user' : 'polaris-builtin',
+      provider: this.name,
+      ...(definition.files.length === 0 ? {} : {
+        resourceBase: {
+          kind: 'opaque' as const,
+          description: `Use polaris_skill_resource with skill="${definition.slug}" and the relative file path.`,
+        },
+      }),
+      content: definition.body,
+      metadata: {
+        polarisAllowedTools: definition.allowedTools,
+        polarisRevision: definition.revision,
+      },
+    }
+  }
+
+  policy(name: string): PolarisSkillPolicy | undefined {
+    return this.policies.get(name)
+  }
+
+  private candidates(): readonly SkillCandidate[] {
+    return (this.catalog ?? []).map(skill => ({
+      name: skill.slug,
+      description: skill.description,
+      invocation: {
+        modelInvocable: skill.invocation === 'auto',
+        userInvocable: true,
+      },
+      source: skill.scope === 'user' ? 'polaris-user' : 'polaris-builtin',
+      provider: this.name,
+      rank: skill.scope === 'user' ? this.ranks.user : this.ranks.builtin,
+      locator: { id: skill.id, slug: skill.slug, revision: skill.revision },
+      ...(skill.files.length === 0 ? {} : {
+        resourceBase: {
+          kind: 'opaque' as const,
+          description: `Use polaris_skill_resource with skill="${skill.slug}" and the relative file path.`,
+        },
+      }),
+      metadata: {
+        polarisAllowedTools: skill.allowedTools,
+        polarisRevision: skill.revision,
+      },
+    }))
+  }
+
+  private async refresh(signal?: AbortSignal): Promise<boolean> {
+    const result = await this.client.fetchCatalog(signal, this.etag)
+    if (result.kind === 'not-modified') {
+      this.authoritative = true
+      if (result.etag !== undefined) this.etag = result.etag
+      return false
+    }
+    const previousRevision = this.catalogRevision()
+    this.catalog = result.value.skills
+    this.etag = result.etag
+    this.authoritative = true
+    this.policies.clear()
+    for (const skill of this.catalog) this.rememberPolicy(skill)
+    return previousRevision !== result.value.revision
+  }
+
+  private catalogRevision(): string | undefined {
+    const raw = this.etag?.replace(/^(?:W\/)?"|"$/g, '')
+    return raw && /^[a-f0-9]{64}$/.test(raw) ? raw : undefined
+  }
+
+  private rememberPolicy(skill: PolarisSkillCatalogItem): void {
+    this.policies.set(skill.slug, {
+      provider: 'polaris',
+      name: skill.slug,
+      allowedTools: skill.allowedTools,
+      userInvocable: true,
+      revision: skill.revision,
+    })
+  }
+
+  private clear(): boolean {
+    const changed = this.catalog !== undefined || this.policies.size > 0
+    this.catalog = undefined
+    this.etag = undefined
+    this.authoritative = false
+    this.policies.clear()
+    return changed
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/integrations/deepseek-harness/tests/activation.test.ts
+++ b/integrations/deepseek-harness/tests/activation.test.ts
@@ -1,0 +1,31 @@
+import { Context } from '@deepseek-ai/cordis'
+import AgentRegistry from '@deepseek-ai/dsh-agent'
+import SkillRegistry from '@deepseek-ai/dsh-skill'
+import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
+import ToolRuntime from '@deepseek-ai/dsh-tools'
+import { describe, expect, it } from 'vitest'
+import * as PolarisPlugin from '../src/index.js'
+
+describe('DSH plugin activation', () => {
+  it('registers and disposes against the real Cordis service stack', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SystemPrompt)
+    await ctx.plugin(ToolRuntime)
+    await ctx.plugin(AgentRegistry)
+    await ctx.plugin(SkillRegistry)
+
+    const fiber = await ctx.plugin(PolarisPlugin, {
+      baseUrl: 'http://127.0.0.1:9',
+      token: 'test-token',
+      failOnStartupError: false,
+    })
+    expect(ctx.tools.schemas().map(tool => tool.name)).toContain(
+      'polaris_skill_resource',
+    )
+
+    await fiber.dispose()
+    expect(ctx.tools.schemas().map(tool => tool.name)).not.toContain(
+      'polaris_skill_resource',
+    )
+  })
+})

--- a/integrations/deepseek-harness/tests/client.test.ts
+++ b/integrations/deepseek-harness/tests/client.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PolarisApiError, PolarisClient } from '../src/client.js'
+
+const revision = 'a'.repeat(64)
+
+function catalog() {
+  return {
+    revision,
+    skills: [{
+      id: 'd95375e8-414d-467c-8928-8531dcbc864e',
+      slug: 'paper-triage',
+      name: 'Paper triage',
+      description: 'Use when triaging papers.',
+      invocation: 'auto',
+      scope: 'user',
+      allowedTools: ['search_papers'],
+      files: [],
+      revision,
+      updatedAt: '2026-08-13T12:00:00Z',
+    }],
+  }
+}
+
+describe('PolarisClient', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('authenticates discovery and supports conditional requests', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(catalog()), {
+        status: 200,
+        headers: { 'content-type': 'application/json', etag: `"${revision}"` },
+      }))
+      .mockResolvedValueOnce(new Response(null, {
+        status: 304,
+        headers: { etag: `"${revision}"` },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new PolarisClient('https://polaris.example/base/', 'secret', 1000)
+
+    const first = await client.fetchCatalog()
+    expect(first.kind).toBe('catalog')
+    const firstCall = fetchMock.mock.calls[0]
+    expect(String(firstCall?.[0])).toBe(
+      'https://polaris.example/base/api/integrations/deepseek-harness/v1/skills',
+    )
+    expect(firstCall?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer secret',
+      Accept: 'application/json',
+    })
+
+    const second = await client.fetchCatalog(undefined, `"${revision}"`)
+    expect(second).toEqual({ kind: 'not-modified', etag: `"${revision}"` })
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      'If-None-Match': `"${revision}"`,
+    })
+  })
+
+  it('encodes attachment path segments and reports HTTP failures', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('template', {
+        status: 200,
+        headers: { etag: `"${revision}"` },
+      }))
+      .mockResolvedValueOnce(new Response('denied', { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new PolarisClient('https://polaris.example', 'secret', 1000)
+
+    await expect(client.fetchSkillFile('paper-triage', 'refs/a b.md')).resolves.toEqual({
+      content: 'template',
+      revision,
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('refs/a%20b.md')
+    await expect(client.fetchCatalog()).rejects.toEqual(
+      expect.objectContaining<Partial<PolarisApiError>>({ status: 403 }),
+    )
+  })
+})

--- a/integrations/deepseek-harness/tests/client.test.ts
+++ b/integrations/deepseek-harness/tests/client.test.ts
@@ -74,4 +74,15 @@ describe('PolarisClient', () => {
       expect.objectContaining<Partial<PolarisApiError>>({ status: 403 }),
     )
   })
+
+  it('refuses dot-segment paths that would escape the skill-files route', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new PolarisClient('https://polaris.example', 'secret', 1000)
+
+    for (const path of ['../../api/integration-tokens', 'refs/../../secret', '.', 'refs//x.md']) {
+      await expect(client.fetchSkillFile('paper-triage', path)).resolves.toBeUndefined()
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })

--- a/integrations/deepseek-harness/tests/policy.test.ts
+++ b/integrations/deepseek-harness/tests/policy.test.ts
@@ -1,0 +1,114 @@
+import type { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { UserMessage } from '@deepseek-ai/dsh-session'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  intersectAllowed,
+  invokedSkillNames,
+  PolarisSkillPolicyController,
+} from '../src/policy.js'
+
+describe('skill policy helpers', () => {
+  it('extracts unique explicit skill gestures only from user text', () => {
+    const messages = [{
+      source: { kind: 'user' },
+      content: [
+        { type: 'text', text: 'Please /paper-triage and /paper-triage now.' },
+        { type: 'text', text: 'Then /write-review' },
+      ],
+    }, {
+      source: { kind: 'assistant' },
+      content: [{ type: 'text', text: '/ignored-skill' }],
+    }] as unknown as readonly UserMessage[]
+
+    expect(invokedSkillNames(messages)).toEqual(['paper-triage', 'write-review'])
+  })
+
+  it('intersects multiple skill allowlists without ever widening', () => {
+    expect(intersectAllowed(undefined, null)).toBeUndefined()
+    expect([...intersectAllowed(undefined, ['search_papers', 'get_paper'])!]).toEqual([
+      'search_papers',
+      'get_paper',
+    ])
+    expect([
+      ...intersectAllowed(new Set(['search_papers', 'get_paper']), ['get_paper', 'remember'])!,
+    ]).toEqual(['get_paper'])
+  })
+
+  it('hides and guards denied Polaris MCP tools for the active turn', () => {
+    let guard: ((exec: { name: string }) => string | undefined) | undefined
+    let denied: readonly string[] = []
+    const liftGuard = vi.fn()
+    const liftRestriction = vi.fn()
+    const tools = {
+      guard: vi.fn((callback: typeof guard) => {
+        guard = callback
+        return liftGuard
+      }),
+      schemas: vi.fn(() => [
+        { name: 'mcp__polaris__search_papers' },
+        { name: 'mcp__polaris__get_paper' },
+        { name: 'skill' },
+      ]),
+      restrict: vi.fn(({ deny }: { deny: readonly string[] }) => {
+        denied = deny
+        return liftRestriction
+      }),
+    }
+    const agent = {
+      ctx: { tools },
+      session: { events: [{ type: 'turn/start', data: { turn: 7 } }] },
+    } as unknown as Agent
+    const controller = new PolarisSkillPolicyController({} as Context, 'polaris')
+
+    controller.apply(agent, 7, {
+      provider: 'polaris',
+      name: 'paper-triage',
+      allowedTools: ['search_papers'],
+      userInvocable: true,
+      revision: 'c'.repeat(64),
+    })
+    expect(denied).toEqual(['mcp__polaris__get_paper'])
+    expect(guard?.({ name: 'mcp__polaris__search_papers' })).toBeUndefined()
+    expect(guard?.({ name: 'mcp__polaris__get_paper' })).toContain('denies tool')
+    expect(guard?.({ name: 'skill' })).toBeUndefined()
+
+    controller.clearTurn(agent, 7)
+    expect(liftRestriction).toHaveBeenCalledOnce()
+    expect(liftGuard).toHaveBeenCalledOnce()
+  })
+
+  it('reports advisory violations without hiding or blocking tools', () => {
+    let guard: ((exec: { name: string }) => string | undefined) | undefined
+    const warn = vi.fn()
+    const tools = {
+      guard: vi.fn((callback: typeof guard) => {
+        guard = callback
+        return vi.fn()
+      }),
+      schemas: vi.fn(() => [{ name: 'mcp__polaris__get_paper' }]),
+      restrict: vi.fn(),
+    }
+    const agent = {
+      ctx: { tools },
+      session: { events: [{ type: 'turn/start', data: { turn: 8 } }] },
+    } as unknown as Agent
+    const controller = new PolarisSkillPolicyController(
+      { logger: { warn } } as unknown as Context,
+      'polaris',
+      'advisory',
+    )
+
+    controller.apply(agent, 8, {
+      provider: 'polaris',
+      name: 'paper-triage',
+      allowedTools: ['search_papers'],
+      userInvocable: true,
+      revision: 'd'.repeat(64),
+    })
+
+    expect(tools.restrict).not.toHaveBeenCalled()
+    expect(guard?.({ name: 'mcp__polaris__get_paper' })).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('advisory'))
+  })
+})

--- a/integrations/deepseek-harness/tests/provider.test.ts
+++ b/integrations/deepseek-harness/tests/provider.test.ts
@@ -1,0 +1,85 @@
+import type { Context } from '@deepseek-ai/cordis'
+import type { SkillCandidate, SkillLookupOptions } from '@deepseek-ai/dsh-skill'
+import { describe, expect, it, vi } from 'vitest'
+import type { PolarisClient } from '../src/client.js'
+import { PolarisApiError } from '../src/client.js'
+import { PolarisSkillProvider } from '../src/provider.js'
+
+const revision = 'b'.repeat(64)
+const item = {
+  id: '2b4e728f-28d9-4240-a826-65283f248b9d',
+  slug: 'literature-review',
+  name: 'Literature review',
+  description: 'Use when reviewing a body of literature.',
+  invocation: 'manual' as const,
+  scope: 'user' as const,
+  allowedTools: ['search_papers'],
+  files: [{ path: 'rubric.md', size: 6, revision }],
+  revision,
+  updatedAt: '2026-08-13T12:00:00Z',
+}
+
+function context(): Context {
+  return { logger: { warn: vi.fn() } } as unknown as Context
+}
+
+const options = {} as SkillLookupOptions
+
+describe('PolarisSkillProvider', () => {
+  it('publishes native candidates and loads their definition and policy', async () => {
+    const client = {
+      fetchCatalog: vi.fn().mockResolvedValue({
+        kind: 'catalog',
+        value: { revision, skills: [item] },
+        etag: `"${revision}"`,
+      }),
+      fetchSkill: vi.fn().mockResolvedValue({ ...item, body: '# Review' }),
+    } as unknown as PolarisClient
+    const provider = new PolarisSkillProvider(
+      context(), client, { user: 340, builtin: 360 }, 30_000,
+    )
+
+    const listed = await provider.list(options)
+    expect(Array.isArray(listed)).toBe(true)
+    const candidate = (listed as readonly SkillCandidate[])[0]
+    expect(candidate).toMatchObject({
+      name: 'literature-review',
+      provider: 'polaris',
+      rank: 340,
+      invocation: { modelInvocable: false, userInvocable: true },
+    })
+
+    const definition = await provider.get(candidate!, options)
+    expect(definition).toMatchObject({
+      name: 'literature-review',
+      provider: 'polaris',
+      content: '# Review',
+    })
+    expect(provider.policy('literature-review')).toEqual({
+      provider: 'polaris',
+      name: 'literature-review',
+      allowedTools: ['search_papers'],
+      userInvocable: true,
+      revision,
+    })
+  })
+
+  it('fails closed and marks discovery incomplete after authentication loss', async () => {
+    const client = {
+      fetchCatalog: vi.fn()
+        .mockResolvedValueOnce({
+          kind: 'catalog',
+          value: { revision, skills: [item] },
+          etag: `"${revision}"`,
+        })
+        .mockRejectedValueOnce(new PolarisApiError(401, 'expired')),
+    } as unknown as PolarisClient
+    const provider = new PolarisSkillProvider(
+      context(), client, { user: 340, builtin: 360 }, 30_000,
+    )
+
+    expect(await provider.list(options)).toHaveLength(1)
+    await expect(provider.list(options)).resolves.toEqual({ candidates: [], complete: false })
+    expect(provider.policy('literature-review')).toBeUndefined()
+  })
+})

--- a/integrations/deepseek-harness/tsconfig.json
+++ b/integrations/deepseek-harness/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/backend/alembic/versions/8ff89f7fcdeb_add_integration_tokens.py
+++ b/src/backend/alembic/versions/8ff89f7fcdeb_add_integration_tokens.py
@@ -1,0 +1,60 @@
+"""add integration tokens
+
+Revision ID: 8ff89f7fcdeb
+Revises: 7b3e91c4a2d8
+Create Date: 2026-08-13 21:37:41.622536
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8ff89f7fcdeb"
+down_revision: str | None = "7b3e91c4a2d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(JSONB(), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "integration_tokens",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(80), nullable=False),
+        sa.Column("token_prefix", sa.String(24), nullable=False),
+        sa.Column("token_hash", sa.String(64), nullable=False),
+        sa.Column("scopes", _JSON, nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_integration_tokens_user_id", "integration_tokens", ["user_id"])
+    op.create_index(
+        "ix_integration_tokens_token_hash", "integration_tokens", ["token_hash"], unique=True
+    )
+    op.create_index(
+        "ix_integration_tokens_user_revoked",
+        "integration_tokens",
+        ["user_id", "revoked_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_tokens_user_revoked", table_name="integration_tokens")
+    op.drop_index("ix_integration_tokens_token_hash", table_name="integration_tokens")
+    op.drop_index("ix_integration_tokens_user_id", table_name="integration_tokens")
+    op.drop_table("integration_tokens")

--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.security import OAuth2PasswordRequestForm
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer, OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, exceptions
 from fastapi_users.authentication import AuthenticationBackend, BearerTransport, JWTStrategy
 from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
@@ -25,6 +25,7 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services import email as email_service
+from app.services import integration_tokens as token_service
 from app.services import projects as projects_service
 from app.services import registration_codes as codes_service
 from app.services import verification
@@ -129,20 +130,46 @@ _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 # 登出是 POST，但它只销毁调用者自己的会话。不放行的话游客连退出登录都做不到。
 _READ_ONLY_ALLOWED_PATHS = frozenset({"/api/auth/jwt/logout"})
 
+# 这道闸门也要认得 Integration Token：否则只读账号用它先前签发的 token 就能绕过
+# JWT 身份、继续写 /api 与 /mcp。auto_error=False 让无凭据的请求照常落到各端点自己
+# 的鉴权依赖去处理。
+_bearer = HTTPBearer(auto_error=False)
+
 
 async def block_read_only_writes(
     request: Request,
     user: User | None = Depends(current_user_optional),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+    session: AsyncSession = Depends(get_session),
 ) -> None:
     """只读账号的写入闸门（挂在整个 /api 与 /mcp 上，见 main.py）。
 
     未登录直接放行——该拦的由各端点自己的鉴权依赖去拦，这里只管「登录了但只读」。
+    JWT 与 Integration Token 都算「登录」：只要背后的账号是只读，任何非安全方法都拦，
+    这样降级为只读后先前签发的 token 也立即失去写权限。
     """
-    if user is None or not user.read_only:
-        return
     if request.method in _SAFE_METHODS or request.url.path in _READ_ONLY_ALLOWED_PATHS:
         return
-    raise HTTPException(status.HTTP_403_FORBIDDEN, detail="READ_ONLY_ACCOUNT")
+    if await _caller_is_read_only(session, user, credentials):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="READ_ONLY_ACCOUNT")
+
+
+async def _caller_is_read_only(
+    session: AsyncSession,
+    jwt_user: User | None,
+    credentials: HTTPAuthorizationCredentials | None,
+) -> bool:
+    """这次请求背后的账号是不是只读——JWT 身份优先，其次认 Integration Token。"""
+    if jwt_user is not None:
+        return jwt_user.read_only
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        return False
+    raw_token = credentials.credentials
+    if not raw_token.startswith(token_service.TOKEN_MARKER):
+        return False
+    # touch=False：闸门只做判断，不刷新 last_used_at，那由端点自己的鉴权去记。
+    authenticated = await token_service.authenticate_token(session, raw_token, touch=False)
+    return authenticated is not None and authenticated.user.read_only
 
 
 async def require_admin(user: User = Depends(current_active_user)) -> User:

--- a/src/backend/app/api/integration_auth.py
+++ b/src/backend/app/api/integration_auth.py
@@ -1,0 +1,82 @@
+"""Authentication shared by the MCP endpoint and integration APIs."""
+
+from dataclasses import dataclass
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_user_optional
+from app.core.db import get_session
+from app.models.user import User
+from app.services import integration_tokens as token_service
+
+_bearer = HTTPBearer(auto_error=False)
+_JWT_INTEGRATION_SCOPES = frozenset({"skills:read", "mcp:read"})
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationPrincipal:
+    """An authenticated user plus the capabilities granted to this credential."""
+
+    user: User
+    scopes: frozenset[str]
+    credential_kind: str
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status.HTTP_401_UNAUTHORIZED,
+        detail="INVALID_INTEGRATION_TOKEN",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def current_integration_principal(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+    jwt_user: User | None = Depends(current_user_optional),
+    session: AsyncSession = Depends(get_session),
+) -> IntegrationPrincipal:
+    """Accept a normal session JWT or a scoped Polaris integration token."""
+
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise _unauthorized()
+    raw_token = credentials.credentials
+    if raw_token.startswith(token_service.TOKEN_MARKER):
+        authenticated = await token_service.authenticate_token(
+            session,
+            raw_token,
+            touch=request.method not in {"GET", "HEAD", "OPTIONS"},
+        )
+        if authenticated is None:
+            raise _unauthorized()
+        return IntegrationPrincipal(
+            user=authenticated.user,
+            scopes=frozenset(authenticated.token.scopes),
+            credential_kind="integration_token",
+        )
+    if jwt_user is None:
+        raise _unauthorized()
+    return IntegrationPrincipal(
+        user=jwt_user,
+        scopes=_JWT_INTEGRATION_SCOPES,
+        credential_kind="jwt",
+    )
+
+
+def require_integration_scope(scope: str):
+    """Create a dependency that rejects credentials missing one required scope."""
+
+    async def dependency(
+        principal: IntegrationPrincipal = Depends(current_integration_principal),
+    ) -> IntegrationPrincipal:
+        if scope not in principal.scopes:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="INTEGRATION_SCOPE_REQUIRED")
+        return principal
+
+    return dependency
+
+
+require_skills_read = require_integration_scope("skills:read")
+require_mcp_read = require_integration_scope("mcp:read")

--- a/src/backend/app/api/integration_tokens.py
+++ b/src/backend/app/api/integration_tokens.py
@@ -1,0 +1,51 @@
+"""User-managed credentials for external agents and automation."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.user import User
+from app.schemas.integration_token import (
+    IntegrationTokenCreate,
+    IntegrationTokenCreated,
+    IntegrationTokenRead,
+)
+from app.services import integration_tokens as token_service
+
+router = APIRouter(prefix="/integration-tokens", tags=["integration-tokens"])
+
+
+@router.get("", response_model=list[IntegrationTokenRead])
+async def list_integration_tokens(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[IntegrationTokenRead]:
+    tokens = await token_service.list_tokens(session, user_id=user.id)
+    return [IntegrationTokenRead.model_validate(token) for token in tokens]
+
+
+@router.post("", response_model=IntegrationTokenCreated, status_code=status.HTTP_201_CREATED)
+async def create_integration_token(
+    data: IntegrationTokenCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> IntegrationTokenCreated:
+    token, raw_token = await token_service.create_token(session, user_id=user.id, data=data)
+    return IntegrationTokenCreated(
+        **IntegrationTokenRead.model_validate(token).model_dump(), token=raw_token
+    )
+
+
+@router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_integration_token(
+    token_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    token = await token_service.get_owned_token(session, token_id=token_id, user_id=user.id)
+    if token is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="INTEGRATION_TOKEN_NOT_FOUND")
+    await token_service.revoke_token(session, token)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -19,6 +19,7 @@ from app.api import (
     highlights,
     ideas,
     ingest,
+    integration_tokens,
     invites,
     lab,
     libraries,
@@ -42,6 +43,7 @@ from app.api import (
     voyages,
     wiki,
 )
+from app.integrations.deepseek_harness.api import router as deepseek_harness_router
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -69,11 +71,13 @@ api_router.include_router(notes.router)
 api_router.include_router(highlights.router)
 api_router.include_router(concepts.router)
 api_router.include_router(ingest.router)
+api_router.include_router(integration_tokens.router)
 api_router.include_router(wiki.router)
 api_router.include_router(ideas.router)
 api_router.include_router(search.router)
 api_router.include_router(shelf.router)
 api_router.include_router(daily.router)
+api_router.include_router(deepseek_harness_router)
 api_router.include_router(skills.router)
 api_router.include_router(market.router)
 api_router.include_router(mcp_meta.router)

--- a/src/backend/app/integrations/__init__.py
+++ b/src/backend/app/integrations/__init__.py
@@ -1,0 +1,20 @@
+"""Composition root for optional external-runtime adapters."""
+
+from app.integrations.deepseek_harness.profile import PROFILES as DEEPSEEK_HARNESS_PROFILES
+from app.mcp.profiles import DEFAULT_PROFILE, MCPToolProfile
+
+_MCP_PROFILES = {profile.name: profile for profile in DEEPSEEK_HARNESS_PROFILES}
+
+
+def resolve_mcp_profile(name: str | None) -> MCPToolProfile:
+    """Resolve a transport header without coupling MCP core to one runtime."""
+
+    if name is None or not name.strip():
+        return DEFAULT_PROFILE
+    normalized = name.strip()
+    try:
+        return _MCP_PROFILES[normalized]
+    except KeyError as exc:
+        raise ValueError(
+            f"未知 MCP 工具 Profile：{normalized}；可用：{', '.join(sorted(_MCP_PROFILES))}"
+        ) from exc

--- a/src/backend/app/integrations/deepseek_harness/__init__.py
+++ b/src/backend/app/integrations/deepseek_harness/__init__.py
@@ -1,0 +1,1 @@
+"""DeepSeek Harness adapter for Polaris MCP tools and assistant skills."""

--- a/src/backend/app/integrations/deepseek_harness/api.py
+++ b/src/backend/app/integrations/deepseek_harness/api.py
@@ -1,0 +1,90 @@
+"""Versioned, read-only API consumed by the DeepSeek Harness plugin."""
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.integration_auth import IntegrationPrincipal, require_skills_read
+from app.core.db import get_session
+from app.integrations.deepseek_harness import service
+from app.integrations.deepseek_harness.schemas import (
+    HarnessSkillCatalog,
+    HarnessSkillDefinition,
+)
+
+router = APIRouter(
+    prefix="/integrations/deepseek-harness/v1",
+    tags=["deepseek-harness"],
+)
+
+
+def _etag(revision: str) -> str:
+    return f'"{revision}"'
+
+
+def _cache_headers(revision: str) -> dict[str, str]:
+    return {"ETag": _etag(revision), "Cache-Control": "private, no-cache"}
+
+
+def _not_modified(if_none_match: str | None, revision: str) -> bool:
+    if if_none_match is None:
+        return False
+    expected = _etag(revision)
+    candidates = (candidate.strip() for candidate in if_none_match.split(","))
+    return any(candidate in {"*", expected, f"W/{expected}"} for candidate in candidates)
+
+
+@router.get("/skills", response_model=HarnessSkillCatalog)
+async def list_harness_skills(
+    response: Response,
+    if_none_match: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+    principal: IntegrationPrincipal = Depends(require_skills_read),
+) -> HarnessSkillCatalog | Response:
+    catalog = await service.skill_catalog(session, user_id=principal.user.id)
+    headers = _cache_headers(catalog.revision)
+    if _not_modified(if_none_match, catalog.revision):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
+    return catalog
+
+
+@router.get("/skills/{slug}", response_model=HarnessSkillDefinition)
+async def get_harness_skill(
+    slug: str,
+    response: Response,
+    if_none_match: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+    principal: IntegrationPrincipal = Depends(require_skills_read),
+) -> HarnessSkillDefinition | Response:
+    definition = await service.skill_definition(session, user_id=principal.user.id, slug=slug)
+    if definition is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SKILL_NOT_FOUND")
+    headers = _cache_headers(definition.revision)
+    if _not_modified(if_none_match, definition.revision):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
+    return definition
+
+
+@router.get("/skills/{slug}/files/{path:path}", response_class=PlainTextResponse)
+async def get_harness_skill_file(
+    slug: str,
+    path: str,
+    session: AsyncSession = Depends(get_session),
+    principal: IntegrationPrincipal = Depends(require_skills_read),
+) -> PlainTextResponse:
+    if not path:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SKILL_FILE_NOT_FOUND")
+    found = await service.skill_file(session, user_id=principal.user.id, slug=slug, path=path)
+    if found is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SKILL_FILE_NOT_FOUND")
+    content, revision = found
+    return PlainTextResponse(
+        content,
+        headers={
+            "ETag": _etag(revision),
+            "Cache-Control": "private, no-cache",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/src/backend/app/integrations/deepseek_harness/profile.py
+++ b/src/backend/app/integrations/deepseek_harness/profile.py
@@ -1,0 +1,26 @@
+"""DeepSeek Harness-specific MCP profile declarations."""
+
+from app.mcp.profiles import MCPToolProfile
+
+_NATIVE_REPLACEMENTS = frozenset(
+    {
+        "run_subagent",
+        "skill_load",
+        "skill_read_file",
+        "submit_plan",
+        "update_plan",
+    }
+)
+
+READONLY_PROFILE = MCPToolProfile(
+    name="dsh-readonly-v1",
+    include_writes=False,
+    excluded=_NATIVE_REPLACEMENTS,
+)
+FULL_PROFILE = MCPToolProfile(
+    name="dsh-full-v1",
+    include_writes=True,
+    excluded=_NATIVE_REPLACEMENTS,
+)
+
+PROFILES = (READONLY_PROFILE, FULL_PROFILE)

--- a/src/backend/app/integrations/deepseek_harness/schemas.py
+++ b/src/backend/app/integrations/deepseek_harness/schemas.py
@@ -1,0 +1,46 @@
+"""Versioned response contracts consumed by the DeepSeek Harness plugin."""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_REVISION_PATTERN = r"^[a-f0-9]{64}$"
+
+
+class HarnessSkillFile(BaseModel):
+    path: str = Field(min_length=1)
+    size: int = Field(ge=0)
+    revision: str = Field(pattern=_REVISION_PATTERN)
+
+
+class HarnessSkillCatalogItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: uuid.UUID
+    slug: str = Field(pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    invocation: Literal["auto", "manual"]
+    scope: Literal["builtin", "user"]
+    allowed_tools: list[str] | None = Field(alias="allowedTools")
+    files: list[HarnessSkillFile]
+    revision: str = Field(pattern=_REVISION_PATTERN)
+    updated_at: datetime = Field(alias="updatedAt")
+
+    @field_validator("updated_at")
+    @classmethod
+    def normalize_updated_at(cls, value: datetime) -> datetime:
+        """SQLite drops timezone metadata; the external contract always emits UTC."""
+
+        return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+class HarnessSkillCatalog(BaseModel):
+    revision: str
+    skills: list[HarnessSkillCatalogItem]
+
+
+class HarnessSkillDefinition(HarnessSkillCatalogItem):
+    body: str

--- a/src/backend/app/integrations/deepseek_harness/service.py
+++ b/src/backend/app/integrations/deepseek_harness/service.py
@@ -2,12 +2,14 @@
 
 import hashlib
 import json
+import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +21,8 @@ from app.integrations.deepseek_harness.schemas import (
 )
 from app.models.agent_skill import AgentSkill, AgentSkillFile
 from app.services import agent_skills
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,6 +90,22 @@ def _skill_revision(skill: AgentSkill, files: Sequence[_FileRecord]) -> str:
     )
 
 
+def _safe_catalog_item(
+    skill: AgentSkill, files: Sequence[_FileRecord]
+) -> HarnessSkillCatalogItem | None:
+    """A row that predates the current slug rule must not 500 the whole catalog.
+
+    Creation now enforces the Harness slug rule, but a legacy row could still
+    violate the response contract; skip it rather than fail discovery for every
+    other skill this user has.
+    """
+    try:
+        return _catalog_item(skill, files)
+    except ValidationError:
+        logger.warning("skipping skill %s: not representable in the Harness catalog", skill.slug)
+        return None
+
+
 def _catalog_item(skill: AgentSkill, files: Sequence[_FileRecord]) -> HarnessSkillCatalogItem:
     return HarnessSkillCatalogItem(
         id=skill.id,
@@ -107,7 +127,11 @@ def _catalog_item(skill: AgentSkill, files: Sequence[_FileRecord]) -> HarnessSki
 async def skill_catalog(session: AsyncSession, *, user_id: uuid.UUID) -> HarnessSkillCatalog:
     skills = await agent_skills.visible_skills(session, user_id=user_id)
     files = await _files_by_skill(session, [skill.id for skill in skills])
-    items = [_catalog_item(skill, files.get(skill.id, ())) for skill in skills]
+    items = [
+        item
+        for skill in skills
+        if (item := _safe_catalog_item(skill, files.get(skill.id, ()))) is not None
+    ]
     items.sort(key=lambda item: item.slug)
     return HarnessSkillCatalog(
         revision=_hash_json([[item.slug, item.revision] for item in items]), skills=items
@@ -121,7 +145,9 @@ async def skill_definition(
     if skill is None:
         return None
     files = (await _files_by_skill(session, [skill.id])).get(skill.id, [])
-    item = _catalog_item(skill, files)
+    item = _safe_catalog_item(skill, files)
+    if item is None:
+        return None
     return HarnessSkillDefinition(**item.model_dump(), body=skill.body)
 
 

--- a/src/backend/app/integrations/deepseek_harness/service.py
+++ b/src/backend/app/integrations/deepseek_harness/service.py
@@ -1,0 +1,143 @@
+"""Read-only projection of Polaris assistant skills for DeepSeek Harness."""
+
+import hashlib
+import json
+import uuid
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.deepseek_harness.schemas import (
+    HarnessSkillCatalog,
+    HarnessSkillCatalogItem,
+    HarnessSkillDefinition,
+    HarnessSkillFile,
+)
+from app.models.agent_skill import AgentSkill, AgentSkillFile
+from app.services import agent_skills
+
+
+@dataclass(frozen=True, slots=True)
+class _FileRecord:
+    path: str
+    content: str
+    size: int
+
+    @property
+    def revision(self) -> str:
+        return hashlib.sha256(self.content.encode("utf-8")).hexdigest()
+
+
+def _hash_json(value: object) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _utc_iso(value: datetime) -> str:
+    normalized = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+    return normalized.isoformat()
+
+
+async def _files_by_skill(
+    session: AsyncSession, skill_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, list[_FileRecord]]:
+    if not skill_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(
+                AgentSkillFile.skill_id,
+                AgentSkillFile.path,
+                AgentSkillFile.content,
+                AgentSkillFile.size,
+            )
+            .where(AgentSkillFile.skill_id.in_(skill_ids))
+            .order_by(AgentSkillFile.path)
+        )
+    ).all()
+    grouped: dict[uuid.UUID, list[_FileRecord]] = defaultdict(list)
+    for skill_id, path, content, size in rows:
+        grouped[skill_id].append(_FileRecord(path=path, content=content, size=size))
+    return dict(grouped)
+
+
+def _skill_revision(skill: AgentSkill, files: Sequence[_FileRecord]) -> str:
+    """Hash only semantic content, so load counters do not invalidate catalogs."""
+
+    return _hash_json(
+        {
+            "id": str(skill.id),
+            "slug": skill.slug,
+            "name": skill.name,
+            "description": skill.description,
+            "body": skill.body,
+            "invocation": skill.invocation,
+            "scope": skill.scope,
+            "allowedTools": skill.allowed_tools,
+            "updatedAt": _utc_iso(skill.updated_at),
+            "files": [
+                {"path": item.path, "size": item.size, "revision": item.revision} for item in files
+            ],
+        }
+    )
+
+
+def _catalog_item(skill: AgentSkill, files: Sequence[_FileRecord]) -> HarnessSkillCatalogItem:
+    return HarnessSkillCatalogItem(
+        id=skill.id,
+        slug=skill.slug,
+        name=skill.name,
+        description=skill.description,
+        invocation=skill.invocation,
+        scope=skill.scope,
+        allowedTools=skill.allowed_tools,
+        files=[
+            HarnessSkillFile(path=item.path, size=item.size, revision=item.revision)
+            for item in files
+        ],
+        revision=_skill_revision(skill, files),
+        updatedAt=skill.updated_at,
+    )
+
+
+async def skill_catalog(session: AsyncSession, *, user_id: uuid.UUID) -> HarnessSkillCatalog:
+    skills = await agent_skills.visible_skills(session, user_id=user_id)
+    files = await _files_by_skill(session, [skill.id for skill in skills])
+    items = [_catalog_item(skill, files.get(skill.id, ())) for skill in skills]
+    items.sort(key=lambda item: item.slug)
+    return HarnessSkillCatalog(
+        revision=_hash_json([[item.slug, item.revision] for item in items]), skills=items
+    )
+
+
+async def skill_definition(
+    session: AsyncSession, *, user_id: uuid.UUID, slug: str
+) -> HarnessSkillDefinition | None:
+    skill = await agent_skills.get_visible_skill(session, slug=slug, user_id=user_id)
+    if skill is None:
+        return None
+    files = (await _files_by_skill(session, [skill.id])).get(skill.id, [])
+    item = _catalog_item(skill, files)
+    return HarnessSkillDefinition(**item.model_dump(), body=skill.body)
+
+
+async def skill_file(
+    session: AsyncSession, *, user_id: uuid.UUID, slug: str, path: str
+) -> tuple[str, str] | None:
+    skill = await agent_skills.get_visible_skill(session, slug=slug, user_id=user_id)
+    if skill is None:
+        return None
+    content = await session.scalar(
+        select(AgentSkillFile.content).where(
+            AgentSkillFile.skill_id == skill.id,
+            AgentSkillFile.path == path,
+        )
+    )
+    if content is None:
+        return None
+    revision = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return content, revision

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -87,7 +87,7 @@ def create_app() -> FastAPI:
     # WS 不挂 /api 前缀：nginx 按 /ws 反代（Upgrade），见 docs/architecture.md §7
     # WS 走不到 HTTP 依赖，只读账号在 ws.py 里各自挡（协同房间是写，通知只是收）
     app.include_router(ws_router)
-    # MCP 只读工具服务：POST /mcp（Streamable HTTP，JSON-RPC 2.0），见 docs/mcp.md
+    # MCP 工具服务：默认只读；受 scope 保护的 Profile 可显式开放写工具。
     app.include_router(mcp_router, dependencies=read_only_gate)
     return app
 

--- a/src/backend/app/mcp/__init__.py
+++ b/src/backend/app/mcp/__init__.py
@@ -1,4 +1,4 @@
-"""Polaris MCP 服务：把统一只读工具注册表暴露给外部 MCP 客户端。
+"""Polaris MCP 服务：把统一工具注册表按授权 Profile 暴露给外部 MCP 客户端。
 
 - HTTP：``app.mcp.http.router`` 挂在 FastAPI 主应用 ``POST /mcp``（见 app/main.py）。
 - stdio：``python -m app.mcp``（本地桌面客户端，如 Claude Desktop）。

--- a/src/backend/app/mcp/dispatch.py
+++ b/src/backend/app/mcp/dispatch.py
@@ -1,9 +1,9 @@
 """MCP 协议核心（传输无关）：把统一工具注册表包装成 MCP 的 tools/list + tools/call。
 
 实现 MCP JSON-RPC 2.0 的核心方法（initialize / tools.list / tools.call / ping），
-HTTP 与 stdio 两种传输共用这里的 ``handle_rpc``。工具全部只读：项目级工具
-的 inputSchema 追加必填 ``project_id`` 并在调用时校验成员身份；用户级发现工具
-只依赖传输层已认证的 user_id。
+HTTP 与 stdio 两种传输共用这里的 ``handle_rpc``。默认 Profile 只读；显式授权的
+Profile 可以纳入写工具。项目级工具的 inputSchema 追加必填 ``project_id`` 并在调用时
+校验成员身份；用户级发现工具只依赖传输层已认证的 user_id。
 """
 
 from __future__ import annotations
@@ -16,11 +16,11 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.llm.router import get_llm_router
+from app.mcp.profiles import DEFAULT_PROFILE, MCPToolProfile, profile_tools
 from app.services import projects as projects_service
 from app.tools import (
     ToolContext,
     get_tool,
-    list_tools,
     result_images,
     result_payload,
     run_tool,
@@ -45,19 +45,11 @@ def _mcp_input_schema(base: dict[str, Any], *, project_scoped: bool) -> dict[str
     return {**base, "type": "object", "properties": props, "required": required}
 
 
-#: 只在对话里有意义的工具，不进 MCP 清单。``update_plan`` 记的是「这场对话的计划」，
-#: 对外部 MCP 客户端就是个回声——它没有对话，也没有能画进度的界面。
-_CONVERSATION_ONLY = frozenset({"update_plan"})
-
-
-def tool_definitions() -> list[dict[str, Any]]:
+def tool_definitions(
+    profile: MCPToolProfile = DEFAULT_PROFILE,
+) -> list[dict[str, Any]]:
     """MCP tools/list 载荷：用户级发现工具优先，其余保持注册顺序。"""
-    specs = [
-        spec
-        for spec in list_tools()
-        if spec.read_only  # 外部 MCP 客户端只拿只读工具，见下方注释
-        and spec.name not in _CONVERSATION_ONLY
-    ]
+    specs = profile_tools(profile)
     specs.sort(key=lambda spec: spec.scope != "user")
     return [
         {
@@ -66,6 +58,13 @@ def tool_definitions() -> list[dict[str, Any]]:
             "inputSchema": _mcp_input_schema(
                 spec.input_schema, project_scoped=spec.scope == "project"
             ),
+            "annotations": {
+                "title": spec.name,
+                "readOnlyHint": spec.read_only,
+                "destructiveHint": False,
+                "idempotentHint": spec.read_only,
+                "openWorldHint": spec.network,
+            },
         }
         for spec in specs
     ]
@@ -106,11 +105,15 @@ async def call_tool(
     name: str,
     arguments: dict[str, Any],
     base_url: str | None = None,
+    profile: MCPToolProfile = DEFAULT_PROFILE,
+    allow_writes: bool = False,
 ) -> dict[str, Any]:
-    """执行一个只读工具；成员校验 + 参数错误都转成 isError 结果（不抛给协议层）。"""
+    """执行一个 Profile 允许的工具；发现与直接调用共享同一授权判断。"""
     spec = get_tool(name)
     if spec is None:
         return _text_result(f"未知工具：{name}", is_error=True)
+    if not profile.exposes(spec):
+        return _text_result(f"工具 {name!r} 不在 MCP Profile {profile.name!r} 中", is_error=True)
     args = dict(arguments or {})
     project_id: uuid.UUID | None = None
     if spec.scope == "project":
@@ -134,14 +137,14 @@ async def call_tool(
         # 自检等内部调用方可能仍统一注入 project_id，用户级工具不向 handler 泄漏它。
         args.pop("project_id", None)
 
-    # allow_writes 保持默认 False：外部 MCP 客户端（Claude Desktop / Cursor）只有平台
-    # JWT，没有经过任何对话内审批，不该拿到写能力。上面的 tools/list 也只列只读工具，
-    # 两道一起才算数——只过滤清单挡不住知道名字直接调的。
+    # 默认 Profile 和普通 JWT 都保持只读。只有 Profile 明确纳入写工具，且传输层已验证
+    # mcp:write scope，才把 allow_writes 打开；两道一起防止知道名字后绕过 tools/list。
     ctx = ToolContext(
         project_id=project_id,
         llm=get_llm_router(),
         user_id=user_id,
         base_url=base_url,
+        allow_writes=allow_writes and profile.include_writes,
     )
     try:
         result = await run_tool(ctx, name, args)
@@ -166,6 +169,8 @@ async def handle_rpc(
     session: AsyncSession,
     user_id: uuid.UUID,
     base_url: str | None = None,
+    profile: MCPToolProfile = DEFAULT_PROFILE,
+    allow_writes: bool = False,
 ) -> dict[str, Any] | None:
     """派发单条 JSON-RPC 消息；通知（无 id / notifications.*）返回 None（无响应）。"""
     method = message.get("method")
@@ -190,7 +195,7 @@ async def handle_rpc(
     if method == "ping":
         return _rpc_ok(msg_id, {})
     if method == "tools/list":
-        return _rpc_ok(msg_id, {"tools": tool_definitions()})
+        return _rpc_ok(msg_id, {"tools": tool_definitions(profile)})
     if method == "tools/call":
         name = params.get("name")
         if not isinstance(name, str):
@@ -202,6 +207,8 @@ async def handle_rpc(
             name=name,
             arguments=arguments,
             base_url=base_url,
+            profile=profile,
+            allow_writes=allow_writes,
         )
         return _rpc_ok(msg_id, result)
 

--- a/src/backend/app/mcp/http.py
+++ b/src/backend/app/mcp/http.py
@@ -1,7 +1,7 @@
-"""MCP over Streamable HTTP（JSON 响应模式）：把只读工具暴露给外部 MCP 客户端。
+"""MCP over Streamable HTTP（JSON 响应模式）：向外部 MCP 客户端暴露工具。
 
-单端点 ``POST /mcp``，JSON-RPC 2.0（支持单条与批量）。认证复用平台 JWT
-（``Authorization: Bearer <token>``，即 /api/auth/jwt/login 拿到的令牌）；
+单端点 ``POST /mcp``，JSON-RPC 2.0（支持单条与批量）。认证支持平台 JWT 与
+可吊销的 Integration Token；
 项目级工具携带 project_id 并校验访问权，用户级发现工具直接使用 JWT 身份。
 """
 
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user
+from app.api.integration_auth import IntegrationPrincipal, require_mcp_read
 from app.core.db import get_session
+from app.integrations import resolve_mcp_profile
 from app.mcp.dispatch import handle_rpc
-from app.models.user import User
 
 router = APIRouter(tags=["mcp"])
 
@@ -24,9 +24,18 @@ router = APIRouter(tags=["mcp"])
 @router.post("/mcp")
 async def mcp_endpoint(
     request: Request,
+    tool_profile: str | None = Header(default=None, alias="X-Polaris-Tool-Profile"),
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
+    principal: IntegrationPrincipal = Depends(require_mcp_read),
 ) -> Response:
+    try:
+        profile = resolve_mcp_profile(tool_profile)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    allow_writes = "mcp:write" in principal.scopes and not principal.user.read_only
+    if profile.include_writes and not allow_writes:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="MCP_WRITE_SCOPE_REQUIRED")
+
     body: Any = await request.json()
     # 图片下载与 MCP 严格同源：客户端调的是 https://host/mcp，工具就返回
     # https://host/api/...。不读额外配置，避免 MCP 地址与下载地址发生漂移。
@@ -41,8 +50,10 @@ async def mcp_endpoint(
                 resp := await handle_rpc(
                     msg,
                     session=session,
-                    user_id=user.id,
+                    user_id=principal.user.id,
                     base_url=base_url,
+                    profile=profile,
+                    allow_writes=allow_writes,
                 )
             )
             is not None
@@ -59,8 +70,10 @@ async def mcp_endpoint(
     resp = await handle_rpc(
         body,
         session=session,
-        user_id=user.id,
+        user_id=principal.user.id,
         base_url=base_url,
+        profile=profile,
+        allow_writes=allow_writes,
     )
     if resp is None:  # 通知
         return Response(status_code=202)

--- a/src/backend/app/mcp/http.py
+++ b/src/backend/app/mcp/http.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
@@ -17,8 +18,24 @@ from app.api.integration_auth import IntegrationPrincipal, require_mcp_read
 from app.core.db import get_session
 from app.integrations import resolve_mcp_profile
 from app.mcp.dispatch import handle_rpc
+from app.mcp.profiles import MCPToolProfile
+from app.services import buddy
+from app.tools.memory import MEMORY_TOOL_NAMES
 
 router = APIRouter(tags=["mcp"])
+
+
+def _apply_memory_gate(profile: MCPToolProfile, principal: IntegrationPrincipal) -> MCPToolProfile:
+    """Hide the memory tools unless the user turned memory on.
+
+    Buddy memory is an opt-in that defaults off; the in-app tool surface omits
+    ``remember``/``recall`` entirely until then. Mirror that here so an MCP
+    write token cannot persist memory the user never enabled — the exclusion
+    covers both discovery and invocation, since both consult ``profile.exposes``.
+    """
+    if buddy.memory_enabled(principal.user):
+        return profile
+    return replace(profile, excluded=profile.excluded | frozenset(MEMORY_TOOL_NAMES))
 
 
 @router.post("/mcp")
@@ -32,6 +49,7 @@ async def mcp_endpoint(
         profile = resolve_mcp_profile(tool_profile)
     except ValueError as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    profile = _apply_memory_gate(profile, principal)
     allow_writes = "mcp:write" in principal.scopes and not principal.user.read_only
     if profile.include_writes and not allow_writes:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="MCP_WRITE_SCOPE_REQUIRED")

--- a/src/backend/app/mcp/profiles.py
+++ b/src/backend/app/mcp/profiles.py
@@ -1,0 +1,39 @@
+"""Transport-agnostic MCP tool visibility policies.
+
+Runtime-specific profiles live in ``app.integrations``.  The MCP core only
+knows how to apply a resolved policy, so adding an external runtime does not
+add runtime-specific names or tool lists to the protocol implementation.
+"""
+
+from dataclasses import dataclass
+
+from app.tools.registry import ToolSpec, list_tools
+
+_CONVERSATION_ONLY = frozenset({"update_plan"})
+
+
+@dataclass(frozen=True, slots=True)
+class MCPToolProfile:
+    """An immutable allow policy applied to both discovery and invocation."""
+
+    name: str
+    include_writes: bool
+    excluded: frozenset[str]
+
+    def exposes(self, spec: ToolSpec) -> bool:
+        if spec.name in self.excluded:
+            return False
+        return spec.read_only or self.include_writes
+
+
+DEFAULT_PROFILE = MCPToolProfile(
+    name="default",
+    include_writes=False,
+    excluded=_CONVERSATION_ONLY,
+)
+
+
+def profile_tools(profile: MCPToolProfile) -> list[ToolSpec]:
+    """Return the registry entries visible under one profile."""
+
+    return [spec for spec in list_tools() if profile.exposes(spec)]

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.experiment import Experiment, ExperimentRun
 from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
 from app.models.idea import Idea
+from app.models.integration_token import IntegrationToken
 from app.models.library import UserLibraryEntry
 from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.llm_config import LLMCallLog, LLMProviderConfig, LLMUsage, ModelRoute
@@ -68,6 +69,7 @@ __all__ = [
     "Gate",
     "Idea",
     "IdeaVector",
+    "IntegrationToken",
     "LLMCallLog",
     "LibraryPaper",
     "LibraryResearchDigest",

--- a/src/backend/app/models/integration_token.py
+++ b/src/backend/app/models/integration_token.py
@@ -1,0 +1,33 @@
+"""External integration tokens.
+
+The plaintext token is shown exactly once.  Only its SHA-256 digest is kept in
+the database; the random token carries enough entropy that a fast digest is
+appropriate for lookup without turning authentication into a table scan.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class IntegrationToken(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A scoped, revocable bearer token owned by one user."""
+
+    __tablename__ = "integration_tokens"
+    __table_args__ = (Index("ix_integration_tokens_user_revoked", "user_id", "revoked_at"),)
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    token_prefix: Mapped[str] = mapped_column(String(24), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    scopes: Mapped[list[str]] = mapped_column(JSONVariant, nullable=False, default=list)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/schemas/integration_token.py
+++ b/src/backend/app/schemas/integration_token.py
@@ -1,0 +1,59 @@
+"""Schemas for creating and managing external integration tokens."""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+IntegrationScope = Literal["skills:read", "mcp:read", "mcp:write"]
+
+
+class IntegrationTokenCreate(BaseModel):
+    """Create a time-limited token; the plaintext is returned once."""
+
+    name: str = Field(min_length=1, max_length=80)
+    scopes: list[IntegrationScope] = Field(
+        default_factory=lambda: ["skills:read", "mcp:read"], min_length=1, max_length=3
+    )
+    expires_in_days: int = Field(default=90, ge=1, le=3650)
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name must not be blank")
+        return stripped
+
+    @field_validator("scopes")
+    @classmethod
+    def deduplicate_scopes(cls, value: list[IntegrationScope]) -> list[IntegrationScope]:
+        return list(dict.fromkeys(value))
+
+    @model_validator(mode="after")
+    def write_requires_read(self) -> "IntegrationTokenCreate":
+        if "mcp:write" in self.scopes and "mcp:read" not in self.scopes:
+            raise ValueError("mcp:write requires mcp:read")
+        return self
+
+
+class IntegrationTokenRead(BaseModel):
+    """Safe token metadata.  It never contains the bearer secret or digest."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    token_prefix: str
+    scopes: list[str]
+    expires_at: datetime
+    revoked_at: datetime | None
+    last_used_at: datetime | None
+    created_at: datetime
+
+
+class IntegrationTokenCreated(IntegrationTokenRead):
+    """Creation response containing the one-time plaintext token."""
+
+    token: str

--- a/src/backend/app/services/agent_skills.py
+++ b/src/backend/app/services/agent_skills.py
@@ -9,7 +9,7 @@ import re
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import case, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_skill import (
@@ -104,16 +104,24 @@ def parse_skill_md(text: str) -> dict[str, Any]:
 
 
 async def visible_skills(session: AsyncSession, *, user_id: uuid.UUID | None) -> list[AgentSkill]:
-    """这个用户能看到的技能：内置的 + 自己的。"""
+    """这个用户能看到的技能：内置的 + 自己的，同 slug 时自己的优先。"""
     stmt = select(AgentSkill).where(AgentSkill.enabled.is_(True))
     if user_id is None:
         stmt = stmt.where(AgentSkill.scope == "builtin")
     else:
-        stmt = stmt.where(
-            (AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id)
+        stmt = stmt.where((AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id))
+        stmt = stmt.order_by(
+            case((AgentSkill.owner_id == user_id, 0), else_=1),
+            AgentSkill.load_count.desc(),
+            AgentSkill.slug,
         )
-    stmt = stmt.order_by(AgentSkill.load_count.desc(), AgentSkill.slug)
-    return list((await session.execute(stmt)).scalars().all())
+    rows = list((await session.execute(stmt)).scalars().all())
+    # 用户技能是对同名内置技能的显式覆盖。先按上面的优先级选胜者，再恢复目录按
+    # 使用频率排序的既有行为，避免同一个 slug 在目录里出现两次。
+    winners: dict[str, AgentSkill] = {}
+    for skill in rows:
+        winners.setdefault(skill.slug, skill)
+    return sorted(winners.values(), key=lambda skill: (-skill.load_count, skill.slug))
 
 
 async def render_catalog(session: AsyncSession, *, user_id: uuid.UUID | None) -> str:
@@ -146,17 +154,13 @@ async def load_skill(
     if skill is None:
         return None
     files = (
-        (
-            await session.execute(
-                select(AgentSkillFile.path, AgentSkillFile.size).where(
-                    AgentSkillFile.skill_id == skill.id
-                )
+        await session.execute(
+            select(AgentSkillFile.path, AgentSkillFile.size).where(
+                AgentSkillFile.skill_id == skill.id
             )
         )
-        .all()
-    )
-    skill.load_count += 1
-    await session.flush()
+    ).all()
+    await increment_load_count(session, skill=skill)
     return {
         "slug": skill.slug,
         "name": skill.name,
@@ -185,15 +189,40 @@ async def read_skill_file(
     return row[:FILE_MAX_CHARS] if row is not None else None
 
 
-async def _find(
+async def get_visible_skill(
     session: AsyncSession, *, slug: str, user_id: uuid.UUID | None
 ) -> AgentSkill | None:
+    """按目录同一规则解析一个技能；用户同名覆盖内置。"""
+
     stmt = select(AgentSkill).where(AgentSkill.slug == slug, AgentSkill.enabled.is_(True))
     if user_id is None:
         stmt = stmt.where(AgentSkill.scope == "builtin")
     else:
-        stmt = stmt.where((AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id))
+        stmt = stmt.where(
+            (AgentSkill.scope == "builtin") | (AgentSkill.owner_id == user_id)
+        ).order_by(case((AgentSkill.owner_id == user_id, 0), else_=1))
     return (await session.execute(stmt)).scalars().first()
+
+
+async def increment_load_count(session: AsyncSession, *, skill: AgentSkill) -> None:
+    """Record a load without changing the skill's semantic update timestamp."""
+
+    await session.execute(
+        update(AgentSkill)
+        .where(AgentSkill.id == skill.id)
+        .values(
+            load_count=AgentSkill.load_count + 1,
+            updated_at=AgentSkill.updated_at,
+        )
+    )
+
+
+async def _find(
+    session: AsyncSession, *, slug: str, user_id: uuid.UUID | None
+) -> AgentSkill | None:
+    """Backward-compatible private alias for the tool-facing loaders."""
+
+    return await get_visible_skill(session, slug=slug, user_id=user_id)
 
 
 async def upsert_from_md(

--- a/src/backend/app/services/agent_skills.py
+++ b/src/backend/app/services/agent_skills.py
@@ -25,7 +25,11 @@ CATALOG_MAX_CHARS = 4000
 #: 单个附件的大小上限
 FILE_MAX_CHARS = 256 * 1024
 
-_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}$")
+# slug 用短横线分段，段间单横线、无结尾横线。与 DeepSeek Harness 目录契约
+# （app/integrations/deepseek_harness/schemas.py 与插件 zod）同规则，否则一个能建成
+# 但序列化不出去的 slug（如 ``paper--triage``/``triage-``）会把整份目录接口打成 500。
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SLUG_MAX_CHARS = 63
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.S)
 
 
@@ -82,7 +86,7 @@ def parse_skill_md(text: str) -> dict[str, Any]:
         fields["description"] = " ".join(lines)
 
     slug = str(fields.get("name") or "").strip()
-    if not _SLUG_RE.match(slug):
+    if not _SLUG_RE.match(slug) or len(slug) > _SLUG_MAX_CHARS:
         raise SkillParseError(f"name 必须是小写短横线 slug：{slug!r}")
     description = str(fields.get("description") or "").strip()
     if not description:

--- a/src/backend/app/services/integration_tokens.py
+++ b/src/backend/app/services/integration_tokens.py
@@ -1,0 +1,107 @@
+"""Issue, authenticate, list, and revoke external integration tokens."""
+
+import hashlib
+import secrets
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.integration_token import IntegrationToken
+from app.models.user import User
+from app.schemas.integration_token import IntegrationTokenCreate
+
+TOKEN_MARKER = "polaris_it_"
+LAST_USED_WRITE_INTERVAL = timedelta(minutes=15)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthenticatedIntegrationToken:
+    """The authenticated database token and its active user."""
+
+    token: IntegrationToken
+    user: User
+
+
+def _digest(raw_token: str) -> str:
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+async def create_token(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    data: IntegrationTokenCreate,
+) -> tuple[IntegrationToken, str]:
+    """Create a high-entropy token and return its plaintext exactly once."""
+
+    raw_token = TOKEN_MARKER + secrets.token_urlsafe(32)
+    token = IntegrationToken(
+        user_id=user_id,
+        name=data.name,
+        token_prefix=raw_token[:20],
+        token_hash=_digest(raw_token),
+        scopes=list(data.scopes),
+        expires_at=utcnow() + timedelta(days=data.expires_in_days),
+    )
+    session.add(token)
+    await session.commit()
+    await session.refresh(token)
+    return token, raw_token
+
+
+async def list_tokens(session: AsyncSession, *, user_id: uuid.UUID) -> Sequence[IntegrationToken]:
+    stmt = (
+        select(IntegrationToken)
+        .where(IntegrationToken.user_id == user_id)
+        .order_by(IntegrationToken.created_at.desc())
+    )
+    return (await session.execute(stmt)).scalars().all()
+
+
+async def get_owned_token(
+    session: AsyncSession, *, token_id: uuid.UUID, user_id: uuid.UUID
+) -> IntegrationToken | None:
+    token = await session.get(IntegrationToken, token_id)
+    if token is None or token.user_id != user_id:
+        return None
+    return token
+
+
+async def revoke_token(session: AsyncSession, token: IntegrationToken) -> None:
+    if token.revoked_at is None:
+        token.revoked_at = utcnow()
+        await session.commit()
+
+
+async def authenticate_token(
+    session: AsyncSession, raw_token: str, *, touch: bool = True
+) -> AuthenticatedIntegrationToken | None:
+    """Resolve an active token without ever loading tokens by their public prefix."""
+
+    if not raw_token.startswith(TOKEN_MARKER):
+        return None
+    token = await session.scalar(
+        select(IntegrationToken).where(IntegrationToken.token_hash == _digest(raw_token))
+    )
+    now = utcnow()
+    if token is None or token.revoked_at is not None or _as_utc(token.expires_at) <= now:
+        return None
+    user = await session.get(User, token.user_id)
+    if user is None or not user.is_active:
+        return None
+
+    if touch and (
+        token.last_used_at is None or now - _as_utc(token.last_used_at) >= LAST_USED_WRITE_INTERVAL
+    ):
+        token.last_used_at = now
+        await session.commit()
+    return AuthenticatedIntegrationToken(token=token, user=user)

--- a/src/backend/app/tools/memory.py
+++ b/src/backend/app/tools/memory.py
@@ -41,6 +41,7 @@ _KINDS = ("fact", "note")
         "required": ["text"],
     },
     read_only=False,
+    scope="user",
     summarize=lambda a, r: f"记住（{a.get('kind', 'fact')}）：{str(a.get('text', ''))[:40]}",
 )
 async def remember(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
@@ -72,6 +73,7 @@ async def remember(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
             "k": {"type": "integer", "minimum": 1, "maximum": 20, "default": 8},
         },
     },
+    scope="user",
     summarize=lambda a, r: f"回忆「{a.get('query', '')}」→ {len(r.get('items') or [])} 条",
 )
 async def recall(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:

--- a/src/backend/tests/test_deepseek_harness_integration.py
+++ b/src/backend/tests/test_deepseek_harness_integration.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import pytest
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
@@ -9,8 +10,15 @@ from app.integrations.deepseek_harness.profile import FULL_PROFILE, READONLY_PRO
 from app.models.agent_skill import AgentSkill
 from app.models.integration_token import IntegrationToken
 from app.models.user import User
-from app.services import agent_skills
+from app.services import agent_skills, buddy
 from tests.conftest import register_and_login
+
+
+async def _set_memory_enabled(user_id: uuid.UUID, enabled: bool) -> None:
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        await buddy.set_memory_enabled(session, user=user, enabled=enabled)
 
 
 async def _user(client, email: str) -> tuple[str, uuid.UUID]:
@@ -82,6 +90,41 @@ def test_dsh_profiles_are_declared_in_the_adapter_layer():
     assert READONLY_PROFILE.include_writes is False
     assert FULL_PROFILE.name == "dsh-full-v1"
     assert FULL_PROFILE.include_writes is True
+
+
+async def test_skill_creation_rejects_slugs_the_catalog_cannot_represent():
+    # The catalog contract forbids trailing and doubled hyphens; creation must
+    # reject them at the door so a saved skill can never 500 the catalog.
+    for bad in ("paper--triage", "triage-"):
+        with pytest.raises(agent_skills.SkillParseError):
+            await _put_skill(user_id=None, slug=bad, body="# body", scope="builtin")
+
+
+async def test_legacy_nonconforming_skill_is_skipped_not_fatal(client):
+    jwt, user_id = await _user(client, "dsh-legacy-slug@example.com")
+    token = await _integration_token(client, jwt, scopes=["skills:read"])
+    await _put_skill(user_id=user_id, slug="clean-skill", body="# ok")
+    # A row that predates the tightened rule, inserted straight past validation.
+    async with get_sessionmaker()() as session:
+        session.add(
+            AgentSkill(
+                slug="legacy--slug",
+                name="legacy",
+                description="legacy skill",
+                body="# legacy",
+                invocation="auto",
+                scope="user",
+                owner_id=user_id,
+            )
+        )
+        await session.commit()
+
+    endpoint = "/api/integrations/deepseek-harness/v1/skills"
+    catalog = await client.get(endpoint, headers=_headers(token["token"]))
+    assert catalog.status_code == 200, catalog.text
+    assert [skill["slug"] for skill in catalog.json()["skills"]] == ["clean-skill"]
+    detail = await client.get(f"{endpoint}/legacy--slug", headers=_headers(token["token"]))
+    assert detail.status_code == 404
 
 
 async def test_integration_token_is_scoped_one_time_and_revocable(client):
@@ -271,6 +314,36 @@ async def test_dsh_mcp_profiles_enforce_discovery_and_direct_calls(client):
     )
     assert denied_full.status_code == 403
 
+    remember_call = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "remember",
+            "arguments": {"text": "Prefer concise summaries", "kind": "fact"},
+        },
+    }
+
+    # Memory is an opt-in that defaults off: the write tools must stay out of the
+    # surface, and naming remember directly must not persist anything.
+    memory_off = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(full_token["token"], profile="dsh-full-v1"),
+    )
+    assert memory_off.status_code == 200, memory_off.text
+    assert {"remember", "recall"}.isdisjoint(
+        tool["name"] for tool in memory_off.json()["result"]["tools"]
+    )
+    blocked = await client.post(
+        "/mcp",
+        json=remember_call,
+        headers=_headers(full_token["token"], profile="dsh-full-v1"),
+    )
+    assert blocked.status_code == 200
+    assert blocked.json()["result"]["isError"] is True
+
+    await _set_memory_enabled(user_id, True)
     full = await client.post(
         "/mcp",
         json=request,
@@ -281,15 +354,7 @@ async def test_dsh_mcp_profiles_enforce_discovery_and_direct_calls(client):
     assert "remember" in full_names
     remembered = await client.post(
         "/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": "remember",
-                "arguments": {"text": "Prefer concise summaries", "kind": "fact"},
-            },
-        },
+        json=remember_call,
         headers=_headers(full_token["token"], profile="dsh-full-v1"),
     )
     assert remembered.status_code == 200
@@ -307,9 +372,18 @@ async def test_dsh_mcp_profiles_enforce_discovery_and_direct_calls(client):
         assert user is not None
         user.read_only = True
         await session.commit()
+    # Demoting the account revokes MCP for its previously minted tokens too, not
+    # just its JWT: the read-only gate resolves token identity, so both the write
+    # profile and a plain read request are refused.
     read_only_account = await client.post(
         "/mcp",
         json=request,
         headers=_headers(full_token["token"], profile="dsh-full-v1"),
     )
     assert read_only_account.status_code == 403
+    read_only_read = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(read_token["token"], profile="dsh-readonly-v1"),
+    )
+    assert read_only_read.status_code == 403

--- a/src/backend/tests/test_deepseek_harness_integration.py
+++ b/src/backend/tests/test_deepseek_harness_integration.py
@@ -1,0 +1,315 @@
+"""DeepSeek Harness integration: scoped tokens, native skills, and MCP profiles."""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.integrations.deepseek_harness.profile import FULL_PROFILE, READONLY_PROFILE
+from app.models.agent_skill import AgentSkill
+from app.models.integration_token import IntegrationToken
+from app.models.user import User
+from app.services import agent_skills
+from tests.conftest import register_and_login
+
+
+async def _user(client, email: str) -> tuple[str, uuid.UUID]:
+    jwt = await register_and_login(client, email=email)
+    async with get_sessionmaker()() as session:
+        user_id = await session.scalar(select(User.id).where(User.email == email))
+    assert user_id is not None
+    return jwt, user_id
+
+
+async def _integration_token(
+    client,
+    jwt: str,
+    *,
+    scopes: list[str],
+    name: str = "DeepSeek Harness",
+) -> dict:
+    response = await client.post(
+        "/api/integration-tokens",
+        json={"name": name, "scopes": scopes, "expires_in_days": 30},
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _headers(raw_token: str, *, profile: str | None = None) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {raw_token}"}
+    if profile is not None:
+        headers["X-Polaris-Tool-Profile"] = profile
+    return headers
+
+
+async def _put_skill(
+    *,
+    user_id: uuid.UUID | None,
+    slug: str,
+    body: str,
+    scope: str = "user",
+    invocation: str = "auto",
+    tools: str = "search_papers, get_paper",
+    files: dict[str, str] | None = None,
+) -> AgentSkill:
+    text = f"""\
+---
+name: {slug}
+title: {slug} title
+description: Use when the user needs {slug}.
+allowed-tools: [{tools}]
+invocation: {invocation}
+---
+
+{body}
+"""
+    async with get_sessionmaker()() as session:
+        skill = await agent_skills.upsert_from_md(
+            session,
+            text=text,
+            user_id=user_id,
+            scope=scope,
+            files=files,
+        )
+        await session.commit()
+        return skill
+
+
+def test_dsh_profiles_are_declared_in_the_adapter_layer():
+    assert READONLY_PROFILE.name == "dsh-readonly-v1"
+    assert READONLY_PROFILE.include_writes is False
+    assert FULL_PROFILE.name == "dsh-full-v1"
+    assert FULL_PROFILE.include_writes is True
+
+
+async def test_integration_token_is_scoped_one_time_and_revocable(client):
+    jwt, _ = await _user(client, "dsh-token@example.com")
+    created = await _integration_token(client, jwt, scopes=["skills:read"])
+
+    assert created["token"].startswith("polaris_it_")
+    assert created["token_prefix"] == created["token"][:20]
+    async with get_sessionmaker()() as session:
+        stored = await session.get(IntegrationToken, uuid.UUID(created["id"]))
+        assert stored is not None
+        assert stored.token_hash != created["token"]
+        assert len(stored.token_hash) == 64
+    listing = await client.get(
+        "/api/integration-tokens",
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert listing.status_code == 200
+    assert len(listing.json()) == 1
+    assert "token" not in listing.json()[0]
+    assert "token_hash" not in listing.json()[0]
+
+    skills = await client.get(
+        "/api/integrations/deepseek-harness/v1/skills",
+        headers=_headers(created["token"]),
+    )
+    assert skills.status_code == 200
+    async with get_sessionmaker()() as session:
+        read_only_use = await session.get(IntegrationToken, uuid.UUID(created["id"]))
+        assert read_only_use is not None
+        assert read_only_use.last_used_at is None
+    mcp = await client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        headers=_headers(created["token"]),
+    )
+    assert mcp.status_code == 403
+
+    other_jwt, _ = await _user(client, "dsh-token-other@example.com")
+    wrong_owner = await client.delete(
+        f"/api/integration-tokens/{created['id']}",
+        headers={"Authorization": f"Bearer {other_jwt}"},
+    )
+    assert wrong_owner.status_code == 404
+
+    revoked = await client.delete(
+        f"/api/integration-tokens/{created['id']}",
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert revoked.status_code == 204
+    rejected = await client.get(
+        "/api/integrations/deepseek-harness/v1/skills",
+        headers=_headers(created["token"]),
+    )
+    assert rejected.status_code == 401
+
+    blank = await client.post(
+        "/api/integration-tokens",
+        json={"name": "   ", "scopes": ["skills:read"]},
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert blank.status_code == 422
+    invalid_scopes = await client.post(
+        "/api/integration-tokens",
+        json={"name": "bad", "scopes": ["mcp:write"]},
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert invalid_scopes.status_code == 422
+
+
+async def test_native_skill_catalog_isolated_shadowed_and_cacheable(client):
+    jwt, user_id = await _user(client, "dsh-skills@example.com")
+    _, other_user_id = await _user(client, "dsh-skills-other@example.com")
+    token = await _integration_token(client, jwt, scopes=["skills:read"])
+
+    await _put_skill(
+        user_id=None,
+        slug="review-papers",
+        body="# Builtin body",
+        scope="builtin",
+    )
+    await _put_skill(
+        user_id=user_id,
+        slug="review-papers",
+        body="# User body",
+        invocation="manual",
+        tools="search_papers",
+        files={"references/rubric.md": "# Rubric\nKeep relevant work."},
+    )
+    await _put_skill(
+        user_id=other_user_id,
+        slug="private-skill",
+        body="# Other user's body",
+    )
+
+    endpoint = "/api/integrations/deepseek-harness/v1/skills"
+    response = await client.get(endpoint, headers=_headers(token["token"]))
+    assert response.status_code == 200, response.text
+    etag = response.headers["etag"]
+    catalog = response.json()
+    assert [skill["slug"] for skill in catalog["skills"]] == ["review-papers"]
+    item = catalog["skills"][0]
+    assert item["scope"] == "user"
+    assert item["invocation"] == "manual"
+    assert item["allowedTools"] == ["search_papers"]
+    assert item["files"][0]["path"] == "references/rubric.md"
+    assert item["updatedAt"].endswith(("Z", "+00:00"))
+    assert "body" not in item
+
+    detail = await client.get(f"{endpoint}/review-papers", headers=_headers(token["token"]))
+    assert detail.status_code == 200
+    assert detail.json()["body"] == "# User body"
+    detail_etag = detail.headers["etag"]
+    unchanged_detail = await client.get(
+        f"{endpoint}/review-papers",
+        headers={**_headers(token["token"]), "If-None-Match": detail_etag},
+    )
+    assert unchanged_detail.status_code == 304
+
+    unchanged_catalog = await client.get(
+        endpoint,
+        headers={**_headers(token["token"]), "If-None-Match": etag},
+    )
+    assert unchanged_catalog.status_code == 304
+
+    attachment = await client.get(
+        f"{endpoint}/review-papers/files/references/rubric.md",
+        headers=_headers(token["token"]),
+    )
+    assert attachment.status_code == 200
+    assert attachment.text.startswith("# Rubric")
+    assert attachment.headers["x-content-type-options"] == "nosniff"
+    missing = await client.get(
+        f"{endpoint}/review-papers/files/references/missing.md",
+        headers=_headers(token["token"]),
+    )
+    assert missing.status_code == 404
+
+
+async def test_dsh_mcp_profiles_enforce_discovery_and_direct_calls(client):
+    jwt, user_id = await _user(client, "dsh-mcp@example.com")
+    read_token = await _integration_token(client, jwt, scopes=["mcp:read"])
+    full_token = await _integration_token(
+        client,
+        jwt,
+        scopes=["mcp:read", "mcp:write"],
+        name="DeepSeek Harness full",
+    )
+    request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+
+    readonly = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(read_token["token"], profile="dsh-readonly-v1"),
+    )
+    assert readonly.status_code == 200, readonly.text
+    readonly_names = {tool["name"] for tool in readonly.json()["result"]["tools"]}
+    assert "search_papers" in readonly_names
+    assert "remember" not in readonly_names
+    assert {
+        "run_subagent",
+        "skill_load",
+        "skill_read_file",
+        "submit_plan",
+        "update_plan",
+    }.isdisjoint(readonly_names)
+
+    direct_call = await client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "skill_load", "arguments": {"slug": "anything"}},
+        },
+        headers=_headers(read_token["token"], profile="dsh-readonly-v1"),
+    )
+    assert direct_call.status_code == 200
+    result = direct_call.json()["result"]
+    assert result["isError"] is True
+    assert "dsh-readonly-v1" in result["content"][0]["text"]
+
+    denied_full = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(read_token["token"], profile="dsh-full-v1"),
+    )
+    assert denied_full.status_code == 403
+
+    full = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(full_token["token"], profile="dsh-full-v1"),
+    )
+    assert full.status_code == 200, full.text
+    full_names = {tool["name"] for tool in full.json()["result"]["tools"]}
+    assert "remember" in full_names
+    remembered = await client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "remember",
+                "arguments": {"text": "Prefer concise summaries", "kind": "fact"},
+            },
+        },
+        headers=_headers(full_token["token"], profile="dsh-full-v1"),
+    )
+    assert remembered.status_code == 200
+    assert remembered.json()["result"]["isError"] is False, remembered.text
+
+    invalid_profile = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(read_token["token"], profile="unknown"),
+    )
+    assert invalid_profile.status_code == 400
+
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        user.read_only = True
+        await session.commit()
+    read_only_account = await client.post(
+        "/mcp",
+        json=request,
+        headers=_headers(full_token["token"], profile="dsh-full-v1"),
+    )
+    assert read_only_account.status_code == 403

--- a/src/backend/tests/test_mcp_server.py
+++ b/src/backend/tests/test_mcp_server.py
@@ -17,7 +17,8 @@ async def _setup(client, email="mcp@example.com"):
     project_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
         session.add(
-            await add_paper(session,
+            await add_paper(
+                session,
                 project_id=uuid.UUID(project_id),
                 source="manual",
                 title="MCP retrieval paper",
@@ -68,9 +69,10 @@ async def test_initialize_and_tools_list(client):
         "get_concept",
         "external_search",
     } <= names
-    # 用户级发现工具是 project_id 的获取入口，自身不能再要 project_id。
+    # 用户级工具由凭证身份隔离，自身不能再要 project_id。
+    user_scoped = {"list_accessible_projects", "recall"}
     for t in tools:
-        if t["name"] == "list_accessible_projects":
+        if t["name"] in user_scoped:
             assert "project_id" not in t["inputSchema"]["properties"]
             assert "project_id" not in t["inputSchema"].get("required", [])
         else:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "7b3e91c4a2d8"  # Provider 级可选 User-Agent
+HEAD_REVISION = "8ff89f7fcdeb"  # DeepSeek Harness integration tokens
+PROVIDER_UA_REVISION = "7b3e91c4a2d8"  # Provider 级可选 User-Agent
 VIEW_EVENTS_REVISION = "a1c9e73b5d20"  # 浏览事件（文献库/论文点击量）
 VOYAGE_MESSAGES_REVISION = "63133f647463"  # 任务对话流：voyage_messages 表
 READ_ONLY_REVISION = "b3f5c1e07a92"  # 只读账号（游客）
@@ -105,6 +106,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "skills",
                     "buddy_memories",
                     "view_events",
+                    "integration_tokens",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -127,9 +129,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"conversations", "conversation_messages"} <= columns["_tables"]
     # Skills v2：技能是「一句 description 常驻 + 正文按需加载」，附件单独一张表
     assert {"agent_skills", "agent_skill_files"} <= columns["_tables"]
-    assert {"slug", "description", "body", "allowed_tools", "invocation"} <= columns[
-        "agent_skills"
-    ]
+    assert {"slug", "description", "body", "allowed_tools", "invocation"} <= columns["agent_skills"]
     assert {"scope_kind", "scope_id", "usage", "active_stream_id"} <= columns["conversations"]
     assert {"blocks", "text", "seq", "status", "sources"} <= columns["conversation_messages"]
     # 这场对话花了多少 token（voyage_id 的对偶）
@@ -368,7 +368,27 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 浏览事件：文献库/论文的点击量
     assert "view_events" in columns["_tables"]
 
-    # 最新 revision 可往返：先退掉 Provider 级 User-Agent。
+    # 外部 agent 使用有 scope、可撤销、只存摘要的长期凭证。
+    assert "integration_tokens" in columns["_tables"]
+    assert {
+        "user_id",
+        "name",
+        "token_prefix",
+        "token_hash",
+        "scopes",
+        "expires_at",
+        "revoked_at",
+        "last_used_at",
+    } <= columns["integration_tokens"]
+
+    # 先退掉集成令牌。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == PROVIDER_UA_REVISION
+    assert "integration_tokens" not in columns["_tables"]
+    assert "user_agent" in columns["llm_providers"]
+
+    # 再退掉 Provider 级 User-Agent。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == VIEW_EVENTS_REVISION

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -66,9 +66,9 @@ def test_registry_has_expected_tools():
     writers = {spec.name for spec in tools.list_tools() if not spec.read_only}
     assert writers == {"remember"}
 
-    # 目前只有项目发现不需要 project_id；其余工具默认保持项目隔离。
+    # 项目发现与个人记忆按认证用户隔离，不要求调用方伪造 project_id。
     user_scoped = {spec.name for spec in tools.list_tools() if spec.scope == "user"}
-    assert user_scoped == {"list_accessible_projects"}
+    assert user_scoped == {"list_accessible_projects", "recall", "remember"}
 
 
 def test_tool_descriptions_are_formal():
@@ -169,14 +169,16 @@ async def test_search_chunks_keyword_mode_skips_embedding(client, monkeypatch):
 async def test_library_tools_end_to_end(client):
     project_id = await _project(client)
     async with get_sessionmaker()() as session:
-        concept = await add_concept(session,
+        concept = await add_concept(
+            session,
             project_id=project_id,
             name="Retrieval",
             slug="retrieval",
             definition="按需取信息",
             category="method",
         )
-        paper = await add_paper(session,
+        paper = await add_paper(
+            session,
             project_id=project_id,
             source="manual",
             title="Retrieval Augmented Agents",


### PR DESCRIPTION
## Summary

Connects a Polaris account to DeepSeek Harness (DSH) through a two-part integration.

**Backend**
- Revocable integration tokens (`polaris_it_*`): plaintext returned once at creation, SHA-256 digest at rest, scopes `skills:read` / `mcp:read` / `mcp:write`, managed via `/api/integration-tokens` (migration `8ff89f7fcdeb`). Session JWTs keep working with read scopes, so the existing MCP page flow is unchanged.
- Versioned MCP tool profiles (`dsh-readonly-v1`, `dsh-full-v1`) selected by the `X-Polaris-Tool-Profile` header and applied to both `tools/list` and `tools/call`, so a hidden tool cannot be invoked by guessing its name. The profiles hide `skill_load`, `skill_read_file`, planning, and sub-agent tools that Harness provides natively.
- Skills discovery API (`/api/integrations/deepseek-harness/v1/skills`) with semantic ETags, on-demand skill bodies, and per-file attachment fetches.

**DSH bundle** (`integrations/deepseek-harness/`)
- Installable patch-layer bundle: mounts the official `@deepseek-ai/dsh-mcp-client` for Polaris tools and a native skill provider that surfaces Polaris assistant skills through DSH's own `skill` tool, so skills are not duplicated as MCP tools.
- Enforces a loaded skill's `allowed-tools` policy for the current agent turn: denied Polaris tool schemas are hidden, an execution guard covers tools discovered later in the turn, multiple skill allowlists intersect, and restrictions clear on turn completion, turn error, or agent disposal.
- A 401/403 during catalog refresh clears cached skills, so a revoked token fails closed.

## Testing

- `npm run check` in `integrations/deepseek-harness`: tsc build plus vitest suites (client, provider, policy, and activation against the real Cordis service stack).
- Backend: `test_deepseek_harness_integration.py`, updated `test_mcp_server.py`, and the migration round-trip in `test_migrations.py`.
- Verified end to end against a live deployment: DSH registers the Polaris catalog under `mcp__polaris__*`, discovers assistant skills natively, loads bodies on demand, and profile enforcement holds on both discovery and invocation.