### PR TITLE
fix(tools): let the assistant read the daily papers it just found

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,7 +132,7 @@ token or `POLARIS_MCP_USER_EMAIL`; the caller never supplies a user ID.
 | `search_papers` | Search papers in the topic's corpus. `mode=semantic` (default) falls back to keyword when embeddings are unavailable. |
 | `search_chunks` | Passage-level search — lands on the paragraph rather than the paper. |
 | `grep_fulltext` | Literal string match across the full texts, with a small context window per hit. Better than semantic search for exact terms, model names, dataset names, or formula symbols. |
-| `get_paper` | Metadata, authors, status, abstract, concept tags. |
+| `get_paper` | Metadata, authors, status, abstract, concept tags. `in_library` tells you whether the paper is actually collected into a library — `false` means it is still only a daily-pool candidate. |
 | `read_wiki` | The platform's compiled reading note for a paper (falls back to the abstract). |
 | `read_fulltext` | Full text; give a `query` for the most relevant passage, or page through it. |
 | `related_papers` | Nearest neighbours by shared concepts. |
@@ -213,6 +213,11 @@ decision and tell you, but the decision stays with a person in the web app.
 linked to this topic) · `get_library` (its statement, keywords, anchors, sync cadence) ·
 `search_daily_pool` (the upstream feed of new arXiv announcements not yet collected into any
 library).
+
+Papers returned by `search_daily_pool` are, by definition, in no library at all, so the reading
+tools accept their ids as a deliberate exception: `get_paper`, `read_wiki` and `read_fulltext` will
+resolve a daily-pool paper even though it has no library membership, and report `in_library: false`.
+Everything else stays scoped to the libraries this session can search.
 
 A topic holds no papers of its own — its corpus is the union of the libraries linked to it. That is
 why `get_project_status` lists `source_libraries`, and why an empty corpus usually means no library

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -421,7 +421,7 @@ async def list_papers(
     return [PaperView(paper, membership, project_id) for paper, membership in page_rows], int(total)
 
 
-async def _paper_in_daily_feed(session: AsyncSession, paper_id: uuid.UUID) -> bool:
+async def paper_in_daily_feed(session: AsyncSession, paper_id: uuid.UUID) -> bool:
     """论文是否在当前每日推送里——每日池全实验室可读，登录用户即可读它。"""
     from app.models.daily_feed import DailyFeedEntry
 
@@ -488,7 +488,7 @@ async def _pool_paper_view(
     topic_id = (await session.execute(stmt)).scalar_one_or_none()
     if topic_id is None:
         entry = await user_library.entry_for_paper(session, user_id=user_id, paper=paper)
-        if entry is None and not await _paper_in_daily_feed(session, paper_id):
+        if entry is None and not await paper_in_daily_feed(session, paper_id):
             # 书架 / 个人库都不可达，也不在每日推送里 → 视为不存在
             return None
     membership = LibraryPaper(

--- a/src/backend/app/tools/external.py
+++ b/src/backend/app/tools/external.py
@@ -6,15 +6,13 @@
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
 
 from app.core.db import get_sessionmaker
-from app.models.paper import Paper
 from app.services.literature import get_openalex_client, get_s2_client
 from app.tools.context import ToolContext
 from app.tools.registry import tool
-from app.tools.scope import membership_in_scope
+from app.tools.scope import readable_paper
 
 _MAX_K = 10
 
@@ -81,16 +79,8 @@ async def _resolve_ref(ctx: ToolContext, args: dict[str, Any]) -> str:
     raw = str(args.get("paper_id") or "").strip()
     if not raw:
         raise ValueError("需要 paper_ref（arXiv:xxx / DOI:xxx / S2 id）或库内 paper_id")
-    try:
-        pid = uuid.UUID(raw)
-    except ValueError as e:
-        raise ValueError(f"paper_id 不是合法 uuid：{raw}") from e
     async with get_sessionmaker()() as session:
-        paper = await session.get(Paper, pid)
-        if paper is None or (
-            await membership_in_scope(session, ctx, pid)
-        ) is None:
-            raise ValueError(f"库内不存在该论文：{raw}")
+        paper = (await readable_paper(session, ctx, raw)).view
         if paper.arxiv_id:
             return f"arXiv:{paper.arxiv_id}"
         if paper.doi:

--- a/src/backend/app/tools/figures.py
+++ b/src/backend/app/tools/figures.py
@@ -10,8 +10,6 @@ import uuid
 from collections import Counter
 from typing import Any
 
-from sqlalchemy.orm import selectinload
-
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper
 from app.services import citations as citations_service
@@ -23,7 +21,7 @@ from app.services.paper_figure_downloads import create_download_link
 from app.tools.context import ToolContext
 from app.tools.literature import search_papers as _search_papers
 from app.tools.registry import ToolImage, ToolResult, tool
-from app.tools.scope import membership_in_scope
+from app.tools.scope import paper_access, readable_paper
 
 FIGURE_KINDS = ["motivation", "method", "architecture", "experiment", "other"]
 _MAX_BATCH = 8
@@ -32,20 +30,8 @@ _MAX_BATCH = 8
 async def _project_paper(
     session: Any, ctx: ToolContext, raw_id: Any, *, with_concepts: bool = False
 ) -> Paper:
-    try:
-        pid = uuid.UUID(str(raw_id))
-    except ValueError as e:
-        raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
-    opts = [selectinload(Paper.concepts)] if with_concepts else None
-    paper = await session.get(Paper, pid, options=opts)
-    membership = (
-        await membership_in_scope(session, ctx, pid)
-        if paper is not None
-        else None
-    )
-    if paper is None or membership is None:
-        raise ValueError(f"库内不存在该论文：{raw_id}")
-    return paper
+    access = await readable_paper(session, ctx, raw_id, with_concepts=with_concepts)
+    return access.view.paper
 
 
 def _figure_ref(paper_id: uuid.UUID, index: int) -> dict[str, Any]:
@@ -256,11 +242,10 @@ async def find_figures(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
     out: list[dict[str, Any]] = []
     async with get_sessionmaker()() as session:
         for pid in paper_ids:
-            paper = await session.get(Paper, pid)
-            if paper is None or (
-                await membership_in_scope(session, ctx, pid)
-            ) is None:
+            access = await paper_access(session, ctx, pid)
+            if access is None:
                 continue
+            paper = access.view
             for fig in paper.figures or []:
                 if not fig.get("important"):
                     continue
@@ -320,9 +305,7 @@ async def get_paper_notes(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
         paper = await _project_paper(session, ctx, args.get("paper_id"))
         # 笔记仅作者本人可见：无用户语境（系统内部调用）时返回空
         rows = (
-            await notes_service.list_paper_notes(
-                session, paper_id=paper.id, author_id=ctx.user_id
-            )
+            await notes_service.list_paper_notes(session, paper_id=paper.id, author_id=ctx.user_id)
             if ctx.user_id is not None
             else []
         )

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -6,7 +6,6 @@ import uuid
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper, PaperChunk
@@ -16,7 +15,7 @@ from app.services import search as search_service
 from app.services.embedding import embed_query
 from app.tools.context import ToolContext
 from app.tools.registry import tool
-from app.tools.scope import library_ids_for, membership_in_scope
+from app.tools.scope import library_ids_for, readable_paper
 
 _CHUNK_CHARS = 1200
 _MAX_K = 12
@@ -111,22 +110,9 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     summarize=lambda a, r: f"论文详情：{r.get('title', a.get('paper_id', ''))}",
 )
 async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
-    try:
-        paper_id = uuid.UUID(str(args.get("paper_id")))
-    except ValueError as e:
-        raise ValueError(f"paper_id 不是合法 uuid：{args.get('paper_id')}") from e
     async with get_sessionmaker()() as session:
-        stmt = (
-            select(Paper)
-            .where(Paper.id == paper_id)
-            .options(selectinload(Paper.concepts))
-        )
-        paper = (await session.execute(stmt)).scalar_one_or_none()
-        membership = (
-            await membership_in_scope(session, ctx, paper_id) if paper is not None else None
-        )
-        if paper is None or membership is None:
-            raise ValueError(f"库内不存在该论文：{args.get('paper_id')}")
+        access = await readable_paper(session, ctx, args.get("paper_id"), with_concepts=True)
+        paper = access.view
         authors = [a.get("name") for a in (paper.authors or []) if isinstance(a, dict)]
         return {
             "paper_id": str(paper.id),
@@ -137,11 +123,14 @@ async def get_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
             "arxiv_id": paper.arxiv_id,
             "doi": paper.doi,
             "url": paper.url,
-            "status": membership.status,
+            "status": paper.status,
+            # 没进库的论文（每日新论文/书架/个人库）也读得到，但别让模型把它当成
+            # 「你库里的工作」——status 在这种情况下是合成的，说明不了收录与否。
+            "in_library": access.in_library,
             "tldr": paper.tldr,
             "abstract": (paper.abstract or "")[:2000] or None,
             "concepts": [c.name for c in paper.concepts],
-            "has_wiki": paper.wiki is not None,
+            "has_wiki": paper.has_wiki,
             "has_fulltext": bool(paper.full_text_path),
         }
 

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +21,7 @@ from app.services.paper_review import relevant_excerpt
 from app.services.papers import PaperView
 from app.tools.context import ToolContext
 from app.tools.registry import tool
-from app.tools.scope import library_ids_for, membership_in_scope
+from app.tools.scope import library_ids_for, readable_paper
 
 _WIKI_CHARS = 8000
 _FULLTEXT_PAGE_CHARS = 6000
@@ -55,17 +54,7 @@ def _paper_brief(paper: PaperView, score: float | None = None) -> dict[str, Any]
 
 
 async def _get_project_paper(session: Any, ctx: ToolContext, raw_id: Any) -> PaperView:
-    try:
-        paper_id = uuid.UUID(str(raw_id))
-    except ValueError as e:
-        raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
-    paper = await session.get(Paper, paper_id)
-    membership = (
-        await membership_in_scope(session, ctx, paper_id) if paper is not None else None
-    )
-    if paper is None or membership is None:
-        raise ValueError(f"库内不存在该论文：{raw_id}")
-    return PaperView(paper, membership, ctx.project_id)
+    return (await readable_paper(session, ctx, raw_id)).view
 
 
 @tool(

--- a/src/backend/app/tools/scope.py
+++ b/src/backend/app/tools/scope.py
@@ -14,11 +14,15 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
 from app.models.project import ProjectMember
 from app.models.user import User
 from app.services.libraries import (
@@ -26,6 +30,7 @@ from app.services.libraries import (
     library_visible_to,
     membership_rank,
 )
+from app.services.papers import PaperView, paper_in_daily_feed
 from app.tools.context import ToolContext
 
 
@@ -99,3 +104,70 @@ async def membership_in_scope(
     if not rows:
         return None
     return min(rows, key=membership_rank)
+
+
+@dataclass(frozen=True, slots=True)
+class PaperAccess:
+    """一篇读得到的论文，外加「它进库了没有」。
+
+    ``in_library`` 为假就是每日新论文池里那种**还没被任何库收录**的论文。工具要把
+    这个区别如实告诉模型，否则它会把一篇今天刚出的新论文说成「你库里的工作」。
+    """
+
+    view: PaperView
+    in_library: bool
+
+
+async def paper_access(
+    session: AsyncSession, ctx: ToolContext, paper_id: uuid.UUID, *, with_concepts: bool = False
+) -> PaperAccess | None:
+    """这次能不能读这篇论文；读不到返回 None。**所有**按 id 读单篇论文的工具走这里。
+
+    先按本次范围取成员行（:func:`membership_in_scope`），范围外再看它在不在每日新论文
+    池里——每日新论文全实验室可读（``paper_in_daily_feed``，与 HTTP 端点的池级兜底同
+    一条判据），登录用户就能读。
+
+    为什么非兜底不可：``search_daily_pool`` 交给模型的，按定义就是**尚未收录进任何库**
+    的当日新论文。只认成员行的话，助手拿自己上一步搜出来的 id 挨个读详情，20 篇能错
+    20 篇，还都报「库内不存在该论文」——而那些论文就在用户眼前的每日新论文页上。这与
+    :func:`project_ids_for` 修过的是同一类毛病：范围判严了，症状却长得像数据没了。
+
+    兜底只开每日池这一条：它是唯一会把库外论文 id 交到模型手上的工具。书架 / 个人库
+    那些 HTTP 端点也放行的路径这里一概不认——工具没有渠道拿到那些 id，放开只会平白
+    松掉课题范围。
+    """
+    membership = await membership_in_scope(session, ctx, paper_id)
+    options = [selectinload(Paper.concepts)] if with_concepts else None
+    if membership is not None:
+        paper = await session.get(Paper, paper_id, options=options)
+        if paper is not None:
+            return PaperAccess(PaperView(paper, membership, ctx.project_id), True)
+    if ctx.user_id is None:  # 系统内部调用没有身份，每日池的「登录即可读」无从谈起
+        return None
+    if not await paper_in_daily_feed(session, paper_id):
+        return None
+    paper = await session.get(Paper, paper_id, options=options)
+    if paper is None:
+        return None
+    # 临时成员行（不入 session、永不落库），口径同 services/papers 的池级兜底视角。
+    # status=candidate：它确实还只是个候选，别让它看起来像已收录。
+    pooled = LibraryPaper(
+        status="candidate", created_at=paper.created_at, updated_at=paper.updated_at
+    )
+    return PaperAccess(PaperView(paper, pooled, None), False)
+
+
+async def readable_paper(
+    session: AsyncSession, ctx: ToolContext, raw_id: Any, *, with_concepts: bool = False
+) -> PaperAccess:
+    """:func:`paper_access` 加上参数解析与报错，给「拿一个 id 读一篇」的工具用。"""
+    try:
+        paper_id = uuid.UUID(str(raw_id))
+    except (ValueError, AttributeError, TypeError) as e:
+        raise ValueError(f"paper_id 不是合法 uuid：{raw_id}") from e
+    access = await paper_access(session, ctx, paper_id, with_concepts=with_concepts)
+    if access is None:
+        # 不可见与不存在一律同一口径，不泄露存在性；但话要说清找过哪几处，
+        # 否则「库内不存在」会让人以为论文丢了。
+        raise ValueError(f"读不到这篇论文（不在本次能检索的文献库，也不在每日新论文里）：{raw_id}")
+    return access

--- a/src/backend/tests/test_pool_paper_access.py
+++ b/src/backend/tests/test_pool_paper_access.py
@@ -4,6 +4,8 @@
 
 import uuid
 
+import pytest
+
 from app.core.db import get_sessionmaker
 from app.models.paper import Paper
 from tests.conftest import register_and_login
@@ -76,9 +78,7 @@ async def test_shelved_pool_paper_full_reading_chain(client):
         f"/api/papers/{paper_id}/my-meta", json={"starred": True}, headers=headers
     )
     assert resp.status_code == 200 and resp.json()["starred"] is True
-    resp = await client.post(
-        "/api/me/library/visits", json={"paper_id": paper_id}, headers=headers
-    )
+    resp = await client.post("/api/me/library/visits", json={"paper_id": paper_id}, headers=headers)
     assert resp.status_code == 201, resp.text
     resp = await client.get(f"/api/me/library/state?paper_id={paper_id}", headers=headers)
     assert resp.status_code == 200 and resp.json()["saved"] is True  # 入架已代收藏
@@ -174,3 +174,115 @@ async def test_pool_paper_not_in_daily_feed_stays_hidden(client):
     token = await register_and_login(client, email="daily-stranger@example.com")
     resp = await client.get(f"/api/papers/{paper_id}", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 404
+
+
+# ---- 工具层（PolarisBuddy / MCP）：每日新论文必须读得到，其余照旧按范围收紧 ----
+#
+# 与上面 HTTP 端点的兜底**故意不完全一致**：端点还放行书架 / 个人库可达的论文，工具
+# 层不放行。工具压根没有渠道拿到那些 id（只有 search_daily_pool 会把库外论文交给模型），
+# 跟着放开只会平白松掉课题范围。这一条的边界由 test_tools_registry 那边钉住。
+
+
+async def _daily_only_paper(**fields) -> str:
+    """造一篇只在每日新论文池里的论文：有 Paper 行，零库成员行。"""
+    import datetime as dt
+
+    from app.models.daily_feed import DailyFeedEntry
+
+    paper_id = await _seed_pool_only_paper(**({"source": "arxiv"} | fields))
+    async with get_sessionmaker()() as session:
+        session.add(
+            DailyFeedEntry(
+                paper_id=uuid.UUID(paper_id),
+                feed_date=dt.datetime.now(dt.UTC).date(),
+                primary_category="cs.AI",
+            )
+        )
+        await session.commit()
+    return paper_id
+
+
+async def _buddy_ctx(client, email: str):
+    """全局助手的上下文：有身份，但一个库都搜不到（library_ids=()）。"""
+    from sqlalchemy import select
+
+    from app.core.llm.router import LLMRouter
+    from app.models.user import User
+    from app.tools import ToolContext
+
+    await register_and_login(client, email=email)
+    async with get_sessionmaker()() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        user_id = user.id
+    return ToolContext(project_id=None, llm=LLMRouter(), library_ids=(), user_id=user_id)
+
+
+async def test_buddy_can_read_the_daily_papers_it_just_searched(client):
+    """``search_daily_pool`` 搜出来的论文，``get_paper`` 必须读得到。
+
+    线上现象：助手搜出 20 篇当日新论文，挨个 get_paper，20 篇全报「库内不存在该论文」，
+    整条「今天有什么和我相关」的链路一步都走不动。根因是每日池按定义装的就是**还没
+    进任何库**的论文，而工具层只认库成员行——这条链路必然 100% 失败，且论文就明明白白
+    摆在用户眼前的每日新论文页上。同一篇论文 HTTP 端点早就读得到（见上面几条），是工具
+    层的可见性判断没跟上。
+    """
+    import app.tools as tools
+
+    ctx = await _buddy_ctx(client, "buddy-daily@example.com")
+    paper_id = await _daily_only_paper(title="Daily Pool Paper", abstract="brand new today")
+
+    found = await tools.run_tool(ctx, "search_daily_pool", {"limit": 20})
+    assert paper_id in [p["paper_id"] for p in found["papers"]], found
+
+    detail = await tools.run_tool(ctx, "get_paper", {"paper_id": paper_id})
+    assert detail["title"] == "Daily Pool Paper"
+    # 读得到，但别让模型把今天刚出的新论文说成「你库里的工作」
+    assert detail["in_library"] is False
+
+
+async def test_reading_tools_agree_with_get_paper_on_daily_papers(client):
+    """能 get_paper 就能 read_wiki / read_fulltext：四个闸门是同一个，不能各判各的。
+
+    #269 之后又栽过一次的老毛病——漏改一个模块，症状是某类工具在某种上下文里整体
+    失灵，而其它工具一切正常。
+    """
+    import app.tools as tools
+
+    ctx = await _buddy_ctx(client, "buddy-daily-read@example.com")
+    paper_id = await _daily_only_paper(title="Daily Readable", abstract="no wiki, no fulltext")
+
+    wiki = await tools.run_tool(ctx, "read_wiki", {"paper_id": paper_id})
+    assert wiki["wiki"] is None and wiki["abstract"] == "no wiki, no fulltext"
+    text = await tools.run_tool(ctx, "read_fulltext", {"paper_id": paper_id})
+    assert text["text"] is None and text["abstract"] == "no wiki, no fulltext"
+
+
+async def test_tools_still_refuse_a_paper_nobody_can_see(client):
+    """兜底没有放宽边界：不在每日池、也没入架/收藏的池论文，工具照旧读不到。"""
+    import app.tools as tools
+
+    ctx = await _buddy_ctx(client, "buddy-stranger@example.com")
+    paper_id = await _seed_pool_only_paper(title="Nobody's Paper For Tools")
+
+    with pytest.raises(ValueError) as err:
+        await tools.run_tool(ctx, "get_paper", {"paper_id": paper_id})
+    # 报错要说清找过哪几处；「库内不存在」会让人以为论文丢了
+    assert "读不到这篇论文" in str(err.value)
+
+
+def test_no_tool_module_decides_paper_readability_on_its_own():
+    """按 id 读单篇论文的可见性判断只能住在 scope.py 里。
+
+    这条是上一条的结构性版本：#269 那次漏改了三个模块，这次漏改的是每日池兜底。
+    症状都一样难联想——某类工具在某种上下文里整体失灵。与其指望下次记得，不如把
+    「别自己判成员资格」钉死在测试里。
+    """
+    import pathlib
+
+    tools_dir = pathlib.Path(__file__).resolve().parent.parent / "app" / "tools"
+    offenders = [
+        path.name
+        for path in tools_dir.glob("*.py")
+        if path.name != "scope.py" and "membership_in_scope" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], f"这些模块还在自己判论文成员资格：{offenders}"

--- a/src/backend/tests/test_tools_registry.py
+++ b/src/backend/tests/test_tools_registry.py
@@ -244,5 +244,19 @@ async def test_cross_project_isolation(client):
         b_paper_id = str(paper.id)
 
     ctx_a = _ctx(proj_a)
-    with pytest.raises(ValueError, match="库内不存在"):
+    with pytest.raises(ValueError, match="读不到这篇论文"):
         await tools.run_tool(ctx_a, "get_paper", {"paper_id": b_paper_id})
+
+    # 带上身份也一样：每日池兜底只认每日新论文，不是「这个人能看到的都放行」——
+    # 否则课题范围会顺着兜底悄悄松掉（B 的起源库是公共库，HTTP 端点确实放行它）。
+    from sqlalchemy import select
+
+    from app.models.user import User
+
+    async with get_sessionmaker()() as session:
+        user_a = (
+            await session.execute(select(User).where(User.email == "a@example.com"))
+        ).scalar_one()
+    ctx_a_with_identity = ToolContext(project_id=proj_a, llm=LLMRouter(), user_id=user_a.id)
+    with pytest.raises(ValueError, match="读不到这篇论文"):
+        await tools.run_tool(ctx_a_with_identity, "get_paper", {"paper_id": b_paper_id})


### PR DESCRIPTION
Closes #429.

`search_daily_pool` returns, by definition, arXiv announcements that are in no library yet. Every tool that resolved a paper by id required a library membership row, so the assistant could not read back a single id its own search had just handed it: twenty hits, twenty failures, each reported as `库内不存在该论文` for a paper sitting on the user's daily page.

The HTTP endpoints solved this long ago — `get_paper_for_user(include_pool=True)`, whose docstring already says the daily feed is readable lab-wide without being collected. The tools layer never caught up, so `app/tools/` was stricter than the web app for the same paper and the same user.

## What changed

- **One gate for by-id paper reads.** `tools/scope.py` gains `paper_access` / `readable_paper`: in-scope membership first, then the daily pool. Four near-identical gates (`knowledge.get_paper`, `literature._get_project_paper` → `read_wiki`/`read_fulltext`, `figures._project_paper`, `external._resolve_ref`) now share it, along with their duplicated uuid parsing and error text.
- **`get_paper` reports `in_library`.** A pool paper is readable but is not library work; the model needs to be able to tell the difference, and its synthesized status is `candidate`.
- **Error wording.** `库内不存在该论文` → `读不到这篇论文（不在本次能检索的文献库，也不在每日新论文里）`. Non-disclosure is preserved — the message is identical whether or not the paper exists — it just no longer implies the paper is gone.
- `_paper_in_daily_feed` becomes public as `paper_in_daily_feed`; `docs/mcp.md` records the new field and the exception.

## Scope of the fallback

The daily pool **only**, not the shelf and personal-library paths the endpoints also allow. `search_daily_pool` is the sole tool that hands out-of-library ids to the model, so widening further would loosen topic scope for ids the tools can never obtain.

This matters more than it looks: topic origin libraries are public, so the broad version of this fallback does let a topic-scoped agent read another topic's papers once an identity is present. `test_cross_project_isolation` did not catch that, because its context carried no `user_id` — it now asserts the isolation with an identity present as well.

## Tests

Four tools-layer tests land next to the HTTP-layer ones in `test_pool_paper_access.py`, including a structural test that no tool module decides paper readability on its own — #269 was lost to exactly that, one module at a time.

- Full suite: **1286 passed, 2 failed**. Both failures (`test_experiment_env::test_prompt_with_context_unit`, `test_experiment_iterate::test_debug_repeats_until_run_budget`) reproduce unchanged on a pristine `origin/main` checkout and are unrelated to this branch.
- Sensitivity: all four new tests fail against unmodified app code; the five pre-existing HTTP tests in that file still pass.
