### PR TITLE
feat(voyage): add observable command recovery

### DIFF
--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -20,6 +20,10 @@ The page lives in the topic workspace under **Experiment Lab**.
   credential you own. The private key and passphrase are encrypted at rest with Fernet and are never
   returned by any API. Each experiment gets an isolated working directory
   `~/polaris_runs/<experiment-id>` on the target server.
+- **A GNU/Linux experiment host.** Durable command monitoring uses standard GNU/Linux facilities
+  from Bash, coreutils, procps, and iproute2. GPU-aware unattended cleanup additionally uses
+  `nvidia-smi` when it is available; if GPU ownership cannot be established reliably, Polaris keeps
+  the command running and leaves the question open rather than stopping it speculatively.
 
 <!-- screenshot: Settings page, SSH credentials section with one credential added -->
 

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -1021,6 +1021,7 @@ async def _monitor_managed_command(
     diagnostics_run = 0
     diagnostic_evidence: dict[str, str] | None = None
     next_assessment_at = 0.0
+    reconnect_streak = 0
 
     def append_lifecycle(message: str) -> None:
         experiments_service.append_terminal_output(
@@ -1071,9 +1072,35 @@ async def _monitor_managed_command(
         except Exception as exc:  # noqa: BLE001 - reconnect never restarts command
             if not ssh_exec.is_connection_error(exc):
                 raise
+            reconnect_streak += 1
+            session.add(
+                Activity(
+                    project_id=ctx.run.project_id,
+                    actor="system:voyage",
+                    kind="experiment.ssh_reconnect",
+                    message=(
+                        "Managed command polling lost SSH; reconnecting "
+                        f"(attempt {reconnect_streak}): {type(exc).__name__}"
+                    ),
+                    payload={
+                        "experiment_id": str(experiment.id),
+                        "operation_id": handle.operation_id,
+                        "attempt_id": handle.attempt_id,
+                        "run_seq": run.seq if run is not None else None,
+                        "attempt": reconnect_streak,
+                    },
+                )
+            )
+            await session.commit()
+            append_lifecycle(
+                f"SSH connection lost; reconnecting to the same managed attempt "
+                f"({reconnect_streak}): {type(exc).__name__}"
+            )
             await reconnect()
-            await asyncio.sleep(MANAGED_COMMAND_POLL_SECONDS)
+            await asyncio.sleep(_reconnect_backoff(reconnect_streak))
             continue
+
+        reconnect_streak = 0
 
         if await _voyage_cancelled(session, ctx):
             append_lifecycle("voyage cancelled; stopping the current remote command")
@@ -2599,6 +2626,25 @@ async def experiment_run(ctx: ActionContext, params: dict[str, Any]) -> dict[str
                 # 重挂从日志头重放：清掉该轮已存的 metrics 避免重复合并（本地日志允许少量重复行）
                 run.metrics = None
                 await session.commit()
+                if managed_handle is None:
+                    recovered = await executor.recover_managed_command(
+                        OperationContext(
+                            phase="application.run",
+                            operation="experiment-run",
+                            display_command=run.command,
+                            target=experiment.server_host,
+                            soft_timeout_seconds=600,
+                            stall_timeout_seconds=900,
+                            hard_timeout_seconds=max_hours * 3600 if max_hours else None,
+                            repair_scope=RepairScope.APPLICATION_FILES,
+                        )
+                    )
+                    # The remote current pointer is authoritative only when it still
+                    # names the process recorded for this database run.  A mismatch
+                    # falls back to the pre-managed compatibility path; it must never
+                    # attach an unrelated attempt merely because it shares a workdir.
+                    if recovered is not None and recovered.process_id == int(run.pid):
+                        managed_handle = recovered
             else:
                 managed_handle = await executor.launch_managed_run()
                 base_context = managed_handle.context

--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -62,8 +62,24 @@ from app.services.libraries import (
     get_source_library_ids,
     member_papers_stmt,
 )
+from app.services.managed_commands import (
+    CommandAction,
+    CommandSnapshot,
+    CommandState,
+    CommandVerdict,
+    FailureReport,
+    ModelAssessment,
+    OperationContext,
+    RecoveryPlan,
+    RepairScope,
+    adjudicate_command,
+    failure_from_snapshot,
+    may_apply_recovery_automatically,
+)
+from app.services.managed_ssh import ManagedCommandHandle
 
 RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0）
+MANAGED_COMMAND_POLL_SECONDS = 2.0
 MAX_FIGURE_FIXES = 2  # 绘图脚本执行失败 / VLM 质检不合格的修复次数上限
 DEFAULT_NO_IMPROVE_STOP = 2  # 连续 N 轮主指标无提升即停（budget.no_improve_stop 可覆盖）
 MAX_QC_IMAGES = 8  # 单次质检最多送 LLM 的图数
@@ -73,6 +89,102 @@ _WIKI_EXCERPT_CHARS = 600
 _LOG_TAIL_FOR_REPORT = 60
 _LOG_TAIL_FOR_REFLECTION = 40
 _STDERR_CHARS = 2000
+
+COMMAND_ADVISOR_SYSTEM_PROMPT = """\
+POLARIS_COMMAND_ADVISOR
+You assess one evidence snapshot from a detached remote command. Return JSON only:
+{"state":"progressing|slow|stalled|failed|succeeded|unknown","confidence":0.0,
+ "reason":"evidence-based explanation","evidence":["observed facts"],
+ "proposed_action":"continue_monitoring|extend_observation|run_diagnostic|ask_user_while_running|stop_and_repair",
+ "next_check_seconds":30,"safe_to_interrupt":false,"user_message":null}
+Use only the supplied snapshot. A timeout checkpoint is not a failure. Changed output or
+resource activity is progress. If evidence is insufficient use unknown. Never emit shell
+commands. Interruption requires explicit failure or sustained high-confidence zero progress.
+"""
+
+RECOVERY_ADVISOR_SYSTEM_PROMPT = """\
+POLARIS_RECOVERY_ADVISOR
+You diagnose a completed command failure from one structured report. Return JSON only:
+{"diagnosis":"root cause","confidence":0.0,
+ "repair_scope":"none|connection|infrastructure|dependency_files|application_files|experiment_plan|user_action",
+ "proposed_changes":["specific generated files or actions"],
+ "expected_evidence":"what proves the fix worked","minimal_retry":"smallest operation to retry",
+ "next_step":"concise recommendation for the user"}
+Do not invent missing evidence. Infrastructure, connection, authentication and external-service
+failures must not propose changes to generated dependency or application files.
+"""
+
+
+class ManagedCommandNeedsUser(RuntimeError):
+    def __init__(
+        self,
+        handle: ManagedCommandHandle,
+        snapshot: CommandSnapshot,
+        assessment: ModelAssessment | None,
+        verdict: CommandVerdict,
+    ) -> None:
+        self.handle = handle
+        self.snapshot = snapshot
+        self.assessment = assessment
+        self.verdict = verdict
+        super().__init__(verdict.reason)
+
+
+class ManagedCommandCancelled(RuntimeError):
+    def __init__(
+        self,
+        snapshot: CommandSnapshot,
+        executor: Runner,
+    ) -> None:
+        self.snapshot = snapshot
+        self.executor = executor
+        super().__init__("voyage cancelled while remote command was running")
+
+
+def _serialize_managed_handle(handle: ManagedCommandHandle) -> dict[str, Any]:
+    context = handle.context
+    return {
+        "operation_id": handle.operation_id,
+        "attempt_id": handle.attempt_id,
+        "process_id": handle.process_id,
+        "process_group_id": handle.process_group_id,
+        "context": {
+            "phase": context.phase,
+            "operation": context.operation,
+            "display_command": context.display_command,
+            "target": context.target,
+            "soft_timeout_seconds": context.soft_timeout_seconds,
+            "stall_timeout_seconds": context.stall_timeout_seconds,
+            "hard_timeout_seconds": context.hard_timeout_seconds,
+            "repair_scope": context.repair_scope,
+        },
+    }
+
+
+def _restore_managed_handle(data: Any) -> ManagedCommandHandle | None:
+    if not isinstance(data, dict) or not isinstance(data.get("context"), dict):
+        return None
+    try:
+        context_data = data["context"]
+        context = OperationContext(
+            phase=str(context_data["phase"]),
+            operation=str(context_data["operation"]),
+            display_command=str(context_data["display_command"]),
+            target=str(context_data["target"]) if context_data.get("target") else None,
+            soft_timeout_seconds=context_data.get("soft_timeout_seconds"),
+            stall_timeout_seconds=context_data.get("stall_timeout_seconds"),
+            hard_timeout_seconds=context_data.get("hard_timeout_seconds"),
+            repair_scope=RepairScope(str(context_data.get("repair_scope") or "none")),
+        )
+        return ManagedCommandHandle(
+            operation_id=str(data["operation_id"]),
+            attempt_id=str(data["attempt_id"]),
+            context=context,
+            process_id=int(data["process_id"]),
+            process_group_id=int(data["process_group_id"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
 
 METRIC_LINE_RE = re.compile(r"POLARIS_METRIC\s+(\{.*\})")
 _FIGURE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")  # 远端文件名白名单（防目录穿越）
@@ -806,6 +918,300 @@ async def _complete_json(ctx: ActionContext, *, system: str, user: str, validate
     raise ValueError(f"LLM 连续输出非法 JSON：{last_error}")
 
 
+def _validate_command_assessment(data: Any) -> ModelAssessment:
+    if not isinstance(data, dict):
+        raise ValueError("command assessment must be an object")
+    evidence = data.get("evidence")
+    return ModelAssessment(
+        state=CommandState(str(data.get("state") or "unknown")),
+        confidence=max(0.0, min(float(data.get("confidence") or 0), 1.0)),
+        reason=str(data.get("reason") or "no reason supplied")[:1000],
+        evidence=tuple(str(item)[:500] for item in evidence[:12])
+        if isinstance(evidence, list)
+        else (),
+        proposed_action=CommandAction(
+            str(data.get("proposed_action") or "continue_monitoring")
+        ),
+        next_check_seconds=max(
+            5.0, min(float(data.get("next_check_seconds") or 30), 600.0)
+        ),
+        safe_to_interrupt=data.get("safe_to_interrupt") is True,
+        user_message=str(data["user_message"])[:1000]
+        if data.get("user_message")
+        else None,
+    )
+
+
+async def _assess_managed_command(
+    ctx: ActionContext, snapshot: CommandSnapshot
+) -> ModelAssessment | None:
+    try:
+        result = await ctx.llm.complete(
+            "experiment",
+            [
+                Message(role="system", content=COMMAND_ADVISOR_SYSTEM_PROMPT),
+                Message(role="user", content=json.dumps(snapshot.to_dict(), ensure_ascii=False)),
+            ],
+            user_id=ctx.run.created_by,
+            project_id=ctx.run.project_id,
+            voyage_id=ctx.run.id,
+        )
+        assessment = _validate_command_assessment(_extract_json(result.content))
+        await ctx.log(
+            f"远端命令判断：{snapshot.context.phase} state={assessment.state} "
+            f"confidence={assessment.confidence:.2f} action={assessment.proposed_action}"
+        )
+        return assessment
+    except Exception as exc:  # noqa: BLE001 - policy handles missing advice
+        await ctx.log(f"远端命令判断不可用，保留远端进程：{type(exc).__name__}")
+        return None
+
+
+def _validate_recovery_plan(data: Any) -> tuple[RecoveryPlan, str]:
+    if not isinstance(data, dict):
+        raise ValueError("recovery plan must be an object")
+    proposed = data.get("proposed_changes")
+    plan = RecoveryPlan(
+        diagnosis=str(data.get("diagnosis") or "unknown")[:2000],
+        confidence=max(0.0, min(float(data.get("confidence") or 0), 1.0)),
+        repair_scope=RepairScope(str(data.get("repair_scope") or "none")),
+        proposed_changes=tuple(str(item)[:500] for item in proposed[:20])
+        if isinstance(proposed, list)
+        else (),
+        expected_evidence=str(data.get("expected_evidence") or "")[:1000],
+        minimal_retry=str(data.get("minimal_retry") or "")[:200],
+    )
+    return plan, str(data.get("next_step") or plan.diagnosis)[:1500]
+
+
+async def _plan_failure_recovery(
+    ctx: ActionContext, report: FailureReport
+) -> tuple[RecoveryPlan | None, str]:
+    try:
+        result = await ctx.llm.complete(
+            "experiment",
+            [
+                Message(role="system", content=RECOVERY_ADVISOR_SYSTEM_PROMPT),
+                Message(
+                    role="user",
+                    content=json.dumps(report.to_dict(), ensure_ascii=False, default=str),
+                ),
+            ],
+            user_id=ctx.run.created_by,
+            project_id=ctx.run.project_id,
+            voyage_id=ctx.run.id,
+        )
+        return _validate_recovery_plan(_extract_json(result.content))
+    except Exception as exc:  # noqa: BLE001 - real failure remains visible
+        return None, f"自动诊断不可用：{type(exc).__name__}: {exc}"
+
+
+async def _monitor_managed_command(
+    ctx: ActionContext,
+    session: AsyncSession,
+    executor: Runner,
+    experiment: Experiment,
+    handle: ManagedCommandHandle,
+    run: ExperimentRun | None = None,
+) -> tuple[CommandSnapshot, Runner]:
+    stdout_offset = 0
+    stderr_offset = 0
+    previous_token: str | None = None
+    silent_extensions = 0
+    diagnostics_run = 0
+    diagnostic_evidence: dict[str, str] | None = None
+    next_assessment_at = 0.0
+
+    def append_lifecycle(message: str) -> None:
+        experiments_service.append_terminal_output(
+            experiment.id,
+            operation=handle.operation_id,
+            stream="system",
+            text=message,
+        )
+
+    append_lifecycle(
+        f"monitoring attempt {handle.attempt_id} (pid={handle.process_id}): "
+        f"{handle.context.display_command}"
+    )
+
+    async def reconnect() -> None:
+        nonlocal executor
+        with contextlib.suppress(Exception):
+            await executor.close()
+        executor = await _open_executor(session, ctx, experiment)
+
+    while True:
+        try:
+            chunks, stdout_offset, stderr_offset = await executor.read_managed_output(
+                handle,
+                stdout_offset=stdout_offset,
+                stderr_offset=stderr_offset,
+            )
+            for chunk in chunks:
+                experiments_service.append_terminal_output(
+                    experiment.id,
+                    operation=handle.operation_id,
+                    stream=chunk.stream,
+                    text=chunk.text,
+                )
+                if run is not None:
+                    experiments_service.append_local_log(experiment.id, run.seq, chunk.text)
+                    points = parse_metric_lines(chunk.text)
+                    if points:
+                        run.metrics = merge_metrics(run.metrics, points)
+                        experiment.metrics = merge_metrics(experiment.metrics, points)
+            if run is not None and chunks:
+                await session.commit()
+            snapshot = await executor.inspect_managed_command(
+                handle,
+                previous_token=previous_token,
+                diagnostic_evidence=diagnostic_evidence,
+            )
+        except Exception as exc:  # noqa: BLE001 - reconnect never restarts command
+            if not ssh_exec.is_connection_error(exc):
+                raise
+            await reconnect()
+            await asyncio.sleep(MANAGED_COMMAND_POLL_SECONDS)
+            continue
+
+        if await _voyage_cancelled(session, ctx):
+            append_lifecycle("voyage cancelled; stopping the current remote command")
+            stopped = await executor.stop_managed_command(handle)
+            snapshot.process_alive = not stopped
+            if snapshot.exit_status is None:
+                snapshot.exit_status = -15 if stopped else -1
+            snapshot.stderr_tail = snapshot.stderr_tail or (
+                "remote command stopped after the voyage was cancelled"
+                if stopped
+                else "voyage was cancelled but the remote command could not be verified stopped"
+            )
+            if run is not None:
+                run.exit_code = snapshot.exit_status
+                run.status = "failed"
+                run.finished_at = utcnow()
+                await session.commit()
+            await session.refresh(experiment)
+            if experiment.status not in EXPERIMENT_TERMINAL_STATUSES:
+                await _set_status(ctx, session, experiment, "cancelled")
+            raise ManagedCommandCancelled(snapshot, executor)
+
+        if snapshot.output_changed:
+            silent_extensions = 0
+            diagnostics_run = 0
+            diagnostic_evidence = None
+        previous_token = snapshot.progress_token
+        if snapshot.exit_status is not None:
+            append_lifecycle(f"command completed with exit status {snapshot.exit_status}")
+            return snapshot, executor
+        if not snapshot.process_alive:
+            final = await executor.inspect_managed_command(handle, previous_token=previous_token)
+            if final.exit_status is None:
+                final.exit_status = -1
+                final.stderr_tail = final.stderr_tail or (
+                    "remote process disappeared without recording an exit status"
+                )
+            append_lifecycle(
+                f"command process disappeared with exit status {final.exit_status}"
+            )
+            return final, executor
+
+        soft_reached = bool(
+            snapshot.context.soft_timeout_seconds
+            and snapshot.elapsed_seconds >= snapshot.context.soft_timeout_seconds
+        )
+        stalled = bool(
+            snapshot.context.stall_timeout_seconds
+            and snapshot.seconds_since_output >= snapshot.context.stall_timeout_seconds
+        )
+        if (soft_reached or stalled) and asyncio.get_running_loop().time() >= next_assessment_at:
+            assessment = await _assess_managed_command(ctx, snapshot)
+            verdict = adjudicate_command(
+                snapshot,
+                assessment,
+                silent_extensions=silent_extensions,
+                diagnostics_run=diagnostics_run,
+            )
+            next_assessment_at = asyncio.get_running_loop().time() + verdict.next_check_seconds
+            if verdict.action == CommandAction.ASK_USER_WHILE_RUNNING:
+                append_lifecycle(
+                    f"command remains running; waiting for user decision: {verdict.reason}"
+                )
+                raise ManagedCommandNeedsUser(handle, snapshot, assessment, verdict)
+            if verdict.action == CommandAction.RUN_DIAGNOSTIC:
+                append_lifecycle("collecting read-only diagnostics before the next decision")
+                diagnostic_evidence = await executor.diagnose_managed_command(handle)
+                diagnostics_run += 1
+            elif verdict.action == CommandAction.EXTEND_OBSERVATION:
+                silent_extensions += 1
+            elif verdict.action == CommandAction.STOP_AND_REPAIR:
+                append_lifecycle("stopping command after a high-confidence stalled assessment")
+                stopped = await executor.stop_managed_command(handle)
+                if not stopped:
+                    raise ManagedCommandNeedsUser(handle, snapshot, assessment, verdict)
+                snapshot.process_alive = False
+                snapshot.exit_status = -1
+                snapshot.stderr_tail = snapshot.stderr_tail or (
+                    "stopped after a confirmed sustained stall"
+                )
+                return snapshot, executor
+
+        await asyncio.sleep(MANAGED_COMMAND_POLL_SECONDS)
+
+
+def _managed_command_waiting_result(
+    ctx: ActionContext,
+    experiment: Experiment,
+    pending: ManagedCommandNeedsUser,
+) -> dict[str, Any]:
+    handle_data = _serialize_managed_handle(pending.handle)
+    ctx.checkpoint["managed_command_waiting"] = handle_data
+    assessment = pending.assessment
+    question = (
+        assessment.user_message
+        if assessment and assessment.user_message
+        else (
+            f"远端命令 {pending.handle.context.display_command} 仍在运行，但当前无法可靠判断"
+            f"是否继续推进：{pending.verdict.reason}。远端进程未被中断。"
+        )
+    )
+    return {
+        "workdir": experiment.workdir,
+        "remote_operation_continues": True,
+        "managed_command": pending.snapshot.to_dict(),
+        "ask": {
+            "ask_kind": "managed_command",
+            "question": question,
+            "context": {
+                "remote_operation_continues": True,
+                "handle": handle_data,
+                "snapshot": pending.snapshot.to_dict(),
+                "assessment": {
+                    "state": assessment.state,
+                    "confidence": assessment.confidence,
+                    "reason": assessment.reason,
+                    "evidence": assessment.evidence,
+                }
+                if assessment
+                else None,
+                "safety_verdict": pending.verdict.reason,
+            },
+            "options": [
+                {
+                    "id": "retry",
+                    "zh": "保持运行并恢复监控",
+                    "en": "Keep running and resume monitoring",
+                },
+                {
+                    "id": "stop_remote",
+                    "zh": "停止当前命令并根据错误修复",
+                    "en": "Stop this command and repair",
+                },
+            ],
+        },
+    }
+
+
 async def _open_executor(
     session: AsyncSession, ctx: ActionContext, experiment: Experiment
 ) -> Runner:
@@ -1182,12 +1588,12 @@ def is_improvement(value: float, best: float | None, direction: str) -> bool:
     return value > best if direction == "maximize" else value < best
 
 
-# 同一错误签名连续出现的升级阈值：2 次起强制换根本策略，4 次转向用户提问。
+# 同一错误签名连续出现 2 次起强制换根本策略；两次修复都没有产生
+# 可验证进展时，统一恢复策略会在第 3 次失败后转向用户。
 # 这不是修复次数上限（错误在变 = 有进展 = 一直修下去），是**零进展检测**——
 # 线上实测 import 类错误秒级失败，无界修复循环一小时烧了 178 次 LLM 调用，
 # 却始终在对同一个 ABI 冲突微调版本号。
 _SIGNATURE_ESCALATE_AT = 2
-_SIGNATURE_ASK_AT = 4
 
 
 # 签名实现提到共享模块（引擎重规划计数同用）；保留旧名给既有调用点/测试
@@ -1625,33 +2031,65 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
             last_signature = ""
             sig_streak = 0
             fix_ledger: list[dict[str, Any]] = []
+            resumed_handle = _restore_managed_handle(
+                ctx.checkpoint.pop("managed_command_waiting", None)
+            )
+            prepare_handle = (
+                resumed_handle
+                if resumed_handle and resumed_handle.operation_id == "environment-prepare"
+                else await executor.prepare_managed()
+            )
+            if prepare_handle is not None:
+                try:
+                    prepare_snapshot, executor = await _monitor_managed_command(
+                        ctx, session, executor, experiment, prepare_handle
+                    )
+                except ManagedCommandNeedsUser as pending:
+                    return _managed_command_waiting_result(ctx, experiment, pending)
+                except ManagedCommandCancelled as cancelled:
+                    executor = cancelled.executor
+                    return {"cancelled": True, "workdir": experiment.workdir}
+                if prepare_snapshot.exit_status != 0:
+                    report = failure_from_snapshot(prepare_snapshot)
+                    _plan, next_step = await _plan_failure_recovery(ctx, report)
+                    return {
+                        "workdir": experiment.workdir,
+                        "failure": report.to_dict(),
+                        "ask": {
+                            "ask_kind": "command_recovery",
+                            "question": (
+                                f"远端环境准备失败：{report.message[-500:]}\n\n"
+                                f"建议：{next_step}"
+                            ),
+                            "context": {"failure": report.to_dict(), "next_step": next_step},
+                            "options": [
+                                {"id": "retry", "zh": "重试环境准备", "en": "Retry setup"},
+                                {"id": "replan", "zh": "更换运行方案", "en": "Change plan"},
+                                {"id": "abort", "zh": "放弃实验", "en": "Give up"},
+                            ],
+                        },
+                    }
+                resumed_handle = None
             while True:
                 attempts += 1
                 await executor.write_files(files)  # 每次（修复后）重写 LLM 产出文件
                 hint = ""
+                failure_report: FailureReport | None = None
                 try:
-                    # 后台脱离启动装依赖 + 轮询：轮询期间 SSH 瞬时断连可**重连接着跟同一安装进程**
-                    # （而非从头重装），比同步单条命令更抗断连。退出码经 setup.exit 落盘再读。
-                    pid, _cmd = await executor.launch_setup()
-                    exit_status, executor = await _poll_setup(
-                        ctx, session, executor, experiment, pid
+                    handle = resumed_handle or await executor.launch_managed_setup()
+                    resumed_handle = None
+                    snapshot, executor = await _monitor_managed_command(
+                        ctx, session, executor, experiment, handle
                     )
-                    err_text = ""
+                    exit_status = int(snapshot.exit_status or 0)
+                    err_text = snapshot.stderr_tail or snapshot.stdout_tail
                     if exit_status != 0:
-                        with contextlib.suppress(Exception):  # 读日志失败不该翻盘
-                            err_text = (await executor.read_setup_log())[-_STDERR_CHARS:]
-                except Exception as e:  # noqa: BLE001 — 超时/断连转成可修失败，其它异常照抛
-                    if not (isinstance(e, TimeoutError) or ssh_exec.is_connection_error(e)):
-                        raise
-                    exit_status = -1
-                    err_text = error_text(e)
-                    hint = (
-                        "依赖安装超时或中断——大概率是依赖太重/编译太慢/下载太慢或连接断开。"
-                        "请精简依赖、用更轻的包或预编译 wheel、去掉可选依赖，让安装更快更稳。"
-                    )
-                    with contextlib.suppress(Exception):  # 超时后通道可能已坏，重连
-                        await executor.close()
-                    executor = await _open_executor(session, ctx, experiment)
+                        failure_report = failure_from_snapshot(snapshot)
+                except ManagedCommandNeedsUser as pending:
+                    return _managed_command_waiting_result(ctx, experiment, pending)
+                except ManagedCommandCancelled as cancelled:
+                    executor = cancelled.executor
+                    return {"cancelled": True, "workdir": experiment.workdir}
                 if exit_status == 0:
                     env_bits = [f"探测到 GPU {len(gpus)} 卡" if gpus else "未探测到 GPU"]
                     for warning in preflight_warnings:
@@ -1727,45 +2165,68 @@ async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 signature = _error_signature(err_text)
                 sig_streak = sig_streak + 1 if signature == last_signature else 1
                 last_signature = signature
-                if sig_streak >= _SIGNATURE_ASK_AT:
-                    _remember(
-                        ctx,
-                        "环境障碍",
-                        f"依赖安装在同一错误上连续失败 {sig_streak} 次（{signature[:150]}），"
-                        "自动修复无进展，已转向用户提问",
-                    )
-                    await _sync_memory_file(ctx, executor)
+                if failure_report is None:
+                    raise RuntimeError("managed dependency command failed without a failure report")
+                recovery_plan, next_step = await _plan_failure_recovery(ctx, failure_report)
+                repeated_without_progress = sig_streak - 1
+                if recovery_plan is None or not may_apply_recovery_automatically(
+                    recovery_plan,
+                    repeated_without_progress=repeated_without_progress,
+                ):
+                    repeated = repeated_without_progress >= 2
                     return {
                         "workdir": experiment.workdir,
                         "venv_exit": exit_status,
                         "attempts": attempts,
                         "fixes": fixes,
+                        "failure": failure_report.to_dict(),
+                        "recovery_plan": {
+                            "diagnosis": recovery_plan.diagnosis,
+                            "confidence": recovery_plan.confidence,
+                            "repair_scope": recovery_plan.repair_scope,
+                            "proposed_changes": recovery_plan.proposed_changes,
+                            "expected_evidence": recovery_plan.expected_evidence,
+                            "minimal_retry": recovery_plan.minimal_retry,
+                        }
+                        if recovery_plan
+                        else None,
                         "ask": {
-                            "ask_kind": "fatal_step",
+                            "ask_kind": "command_recovery",
                             "question": (
                                 f"依赖安装反复失败在同一个错误上（连续 {sig_streak} 次）："
-                                f"{_err_tail_line(err_text)}。自动修复没有进展，怎么处理？"
+                                f"{_err_tail_line(err_text)}。自动修复没有取得可验证的进展，"
+                                "远端命令已结束，请决定下一步。"
+                                if repeated
+                                else (
+                                    f"远端命令失败：{failure_report.message[-500:]}\n\n"
+                                    f"建议：{next_step}"
+                                )
                             ),
                             "context": {
+                                "failure": failure_report.to_dict(),
+                                "next_step": next_step,
                                 "error_signature": signature,
                                 "fix_ledger": fix_ledger[-8:],
-                                "setup_log_tail": (err_text or "")[-2000:],
                             },
                             "options": [
                                 {
                                     "id": "retry",
-                                    "zh": "带指示重试（告诉我换什么思路）",
-                                    "en": "Retry with instructions",
+                                    "zh": "按建议调整后重试",
+                                    "en": "Apply the suggestion and retry",
                                 },
                                 {
                                     "id": "replan",
-                                    "zh": "换个方案（请说明思路）",
-                                    "en": "Change approach (describe how)",
+                                    "zh": "更换实验方案",
+                                    "en": "Change the experiment plan",
                                 },
                                 {"id": "abort", "zh": "放弃实验", "en": "Give up"},
                             ],
                         },
                     }
+                hint = (
+                    f"模型诊断（置信度 {recovery_plan.confidence:.2f}）："
+                    f"{recovery_plan.diagnosis}；预期证据：{recovery_plan.expected_evidence}"
+                )
                 # 把诊断 + 报错回给 LLM 修 requirements.txt/run.sh（方案级修复）。
                 # 环境事实必须一起带上：修复循环原本只有 stderr，模型照样不知道这台机器
                 # 上模型放哪、有没有配镜像源，只能接着猜。修复前先拉取对话流里
@@ -1829,28 +2290,30 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
             last_signature = ""
             sig_streak = 0
             fix_ledger: list[dict[str, Any]] = []
+            resumed_handle = _restore_managed_handle(
+                ctx.checkpoint.pop("managed_command_waiting", None)
+            )
             while True:
                 attempts += 1
                 # 超时/断连也当作「可修的失败」（多为规模太大/太慢或环境问题），而非硬崩：
                 # 诊断为「太慢/超时」→ 让 LLM 把冒烟改小改快再试，正是自适应循环该自愈的一类。
                 hint = ""
+                failure_report: FailureReport | None = None
                 try:
-                    result = await executor.run_smoke()
-                    exit_status = result.exit_status
-                    err_text = result.stderr or result.stdout
-                except Exception as e:  # noqa: BLE001 — 超时/断连转成可修失败，其它异常照抛
-                    if not (isinstance(e, TimeoutError) or ssh_exec.is_connection_error(e)):
-                        raise
-                    exit_status = -1
-                    err_text = error_text(e)
-                    hint = (
-                        "冒烟超时或中断——大概率是模型/数据太大、步数太多、装依赖太慢。请把冒烟规模"
-                        "改到极小：更小样本/更少步数/更小或更省显存的配置/精简依赖/缩短生成长度，"
-                        "让 --smoke 很快跑完。"
+                    handle = resumed_handle or await executor.launch_managed_smoke()
+                    resumed_handle = None
+                    snapshot, executor = await _monitor_managed_command(
+                        ctx, session, executor, experiment, handle
                     )
-                    with contextlib.suppress(Exception):  # 超时后通道可能已坏，重连
-                        await executor.close()
-                    executor = await _open_executor(session, ctx, experiment)
+                    exit_status = int(snapshot.exit_status or 0)
+                    err_text = snapshot.stderr_tail or snapshot.stdout_tail
+                    if exit_status != 0:
+                        failure_report = failure_from_snapshot(snapshot)
+                except ManagedCommandNeedsUser as pending:
+                    return _managed_command_waiting_result(ctx, experiment, pending)
+                except ManagedCommandCancelled as cancelled:
+                    executor = cancelled.executor
+                    return {"cancelled": True, "workdir": experiment.workdir}
                 if exit_status == 0:
                     if fixes:
                         _remember(ctx, "试跑", f"自动修复 {fixes} 次后通过")
@@ -1907,44 +2370,49 @@ async def experiment_smoke(ctx: ActionContext, params: dict[str, Any]) -> dict[s
                 signature = _error_signature(err_text)
                 sig_streak = sig_streak + 1 if signature == last_signature else 1
                 last_signature = signature
-                if sig_streak >= _SIGNATURE_ASK_AT:
-                    _remember(
-                        ctx,
-                        "试跑障碍",
-                        f"冒烟在同一错误上连续失败 {sig_streak} 次（{signature[:150]}），"
-                        "自动修复无进展，已转向用户提问",
-                    )
-                    await _sync_memory_file(ctx, executor)
+                if failure_report is None:
+                    raise RuntimeError("managed smoke command failed without a failure report")
+                recovery_plan, next_step = await _plan_failure_recovery(ctx, failure_report)
+                repeated_without_progress = sig_streak - 1
+                if recovery_plan is None or not may_apply_recovery_automatically(
+                    recovery_plan,
+                    repeated_without_progress=repeated_without_progress,
+                ):
+                    repeated = repeated_without_progress >= 2
                     return {
                         "exit_code": exit_status,
                         "attempts": attempts,
                         "fixes": fixes,
+                        "failure": failure_report.to_dict(),
                         "ask": {
-                            "ask_kind": "fatal_step",
+                            "ask_kind": "command_recovery",
                             "question": (
                                 f"代码试跑反复失败在同一个错误上（连续 {sig_streak} 次）："
-                                f"{_err_tail_line(err_text)}。自动修复没有进展，怎么处理？"
+                                f"{_err_tail_line(err_text)}。自动修复没有取得可验证的进展，"
+                                "远端命令已结束，请决定下一步。"
+                                if repeated
+                                else (
+                                    f"冒烟命令失败：{failure_report.message[-500:]}\n\n"
+                                    f"建议：{next_step}"
+                                )
                             ),
                             "context": {
+                                "failure": failure_report.to_dict(),
+                                "next_step": next_step,
                                 "error_signature": signature,
                                 "fix_ledger": fix_ledger[-8:],
-                                "stderr_tail": (err_text or "")[-2000:],
                             },
                             "options": [
-                                {
-                                    "id": "retry",
-                                    "zh": "带指示重试（告诉我换什么思路）",
-                                    "en": "Retry with instructions",
-                                },
-                                {
-                                    "id": "replan",
-                                    "zh": "换个方案（请说明思路）",
-                                    "en": "Change approach (describe how)",
-                                },
+                                {"id": "retry", "zh": "按建议修复并重试", "en": "Repair and retry"},
+                                {"id": "replan", "zh": "更换实验方案", "en": "Change plan"},
                                 {"id": "abort", "zh": "放弃实验", "en": "Give up"},
                             ],
                         },
                     }
+                hint = (
+                    f"模型诊断（置信度 {recovery_plan.confidence:.2f}）："
+                    f"{recovery_plan.diagnosis}；预期证据：{recovery_plan.expected_evidence}"
+                )
                 fixes += 1
                 hint = hint or diagnose_failure(err_text, env_settings)
                 # 修复前拉取对话流里新到的用户建议（试跑修复同样是长循环）
@@ -2122,6 +2590,9 @@ async def experiment_run(ctx: ActionContext, params: dict[str, Any]) -> dict[str
 
         executor = await _open_executor(session, ctx, experiment)
         try:
+            managed_handle = _restore_managed_handle(
+                ctx.checkpoint.pop("managed_command_waiting", None)
+            )
             if stale is not None:
                 run = stale
                 seq = run.seq
@@ -2129,24 +2600,69 @@ async def experiment_run(ctx: ActionContext, params: dict[str, Any]) -> dict[str
                 run.metrics = None
                 await session.commit()
             else:
-                pid, command = await executor.launch_run()
+                managed_handle = await executor.launch_managed_run()
+                base_context = managed_handle.context
+                managed_handle = ManagedCommandHandle(
+                    operation_id=managed_handle.operation_id,
+                    attempt_id=managed_handle.attempt_id,
+                    context=OperationContext(
+                        phase=base_context.phase,
+                        operation=base_context.operation,
+                        display_command=base_context.display_command,
+                        target=base_context.target,
+                        soft_timeout_seconds=base_context.soft_timeout_seconds,
+                        stall_timeout_seconds=base_context.stall_timeout_seconds,
+                        hard_timeout_seconds=max_hours * 3600 if max_hours else None,
+                        repair_scope=base_context.repair_scope,
+                    ),
+                    process_id=managed_handle.process_id,
+                    process_group_id=managed_handle.process_group_id,
+                )
                 log_path = experiments_service.append_local_log(experiment.id, seq, "")
                 run = ExperimentRun(
                     experiment_id=experiment.id,
                     seq=seq,
-                    command=command,
+                    command=managed_handle.context.display_command,
                     status="running",
-                    pid=pid,
+                    pid=managed_handle.process_id,
                     log_path=str(log_path),
                     started_at=utcnow(),
                 )
                 session.add(run)
                 await session.commit()
                 await session.refresh(run)
-            # _poll_run 可能因断连重连返回新的 executor，后续读取/关闭都用返回的这个
-            observation, executor = await _poll_run(
-                ctx, session, executor, experiment, run, max_hours
-            )
+            if managed_handle is not None:
+                try:
+                    run_snapshot, executor = await _monitor_managed_command(
+                        ctx, session, executor, experiment, managed_handle, run=run
+                    )
+                except ManagedCommandNeedsUser as pending:
+                    return _managed_command_waiting_result(ctx, experiment, pending)
+                except ManagedCommandCancelled as cancelled:
+                    executor = cancelled.executor
+                    return {
+                        "cancelled": True,
+                        "run_id": str(run.id),
+                        "seq": run.seq,
+                    }
+                run.exit_code = run_snapshot.exit_status
+                run.status = "succeeded" if run_snapshot.exit_status == 0 else "failed"
+                run.finished_at = utcnow()
+                await session.commit()
+                observation = {
+                    "run_id": str(run.id),
+                    "seq": run.seq,
+                    "exit_code": run_snapshot.exit_status,
+                    "run_status": run.status,
+                    "metric_names": sorted((run.metrics or {}).keys()),
+                }
+                if run_snapshot.exit_status != 0:
+                    observation["failure"] = failure_from_snapshot(run_snapshot).to_dict()
+            else:
+                # Compatibility for runs launched by versions before managed commands.
+                observation, executor = await _poll_run(
+                    ctx, session, executor, experiment, run, max_hours
+                )
             if observation.get("cancelled"):
                 return observation  # _poll_run 已 kill 进程并同步实验状态
 

--- a/src/backend/app/agents/voyage/errorsig.py
+++ b/src/backend/app/agents/voyage/errorsig.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+from app.services.managed_commands import failure_from_exception
+
 
 def error_text(e: BaseException) -> str:
     """异常 → 人可读文本，空 str() 兜底。
@@ -15,7 +17,17 @@ def error_text(e: BaseException) -> str:
     httpx.ReadTimeout 等异常的 str() 是空串，直接拼 f"{type}: {e}" 会产出
     「ReadTimeout: 」——用户被提问"怎么处理？"却拿到零信息（线上实测，用户只能
     回"详细原因"）。空时依次回退：cause 链 → 异常全名标注。"""
+    report = failure_from_exception(e)
     name = type(e).__name__
+    evidence: list[str] = []
+    if report.command_display and report.command_display != "unknown command":
+        evidence.append(f"command: {report.command_display}")
+    if report.exit_status is not None:
+        evidence.append(f"exit_status: {report.exit_status}")
+    if report.stdout_tail:
+        evidence.append(f"stdout:\n{report.stdout_tail}")
+    if report.stderr_tail:
+        evidence.append(f"stderr:\n{report.stderr_tail}")
     detail = str(e).strip()
     if not detail and e.__cause__ is not None:
         cause = e.__cause__
@@ -26,8 +38,12 @@ def error_text(e: BaseException) -> str:
             # 同名空 cause 不重复自己（曾产出「ReadTimeout: ReadTimeout」）
             detail = type(cause).__name__
     if detail:
-        return f"{name}: {detail}"
-    return f"{name}（{type(e).__module__}.{name}，异常未附带详细信息）"
+        text = f"{name}: {detail}"
+    elif report.message and report.message != name:
+        text = f"{name}: {report.message}"
+    else:
+        text = f"{name}（{type(e).__module__}.{name}，异常未附带详细信息）"
+    return "\n".join([text, *evidence])
 
 
 def error_signature(err_text: str) -> str:

--- a/src/backend/app/agents/voyage/helm.py
+++ b/src/backend/app/agents/voyage/helm.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from app.agents.voyage.actions import ActionContext, get_action
 from app.agents.voyage.errorsig import error_text
+from app.services.managed_commands import failure_from_exception
 
 
 class Helm:
@@ -18,4 +19,5 @@ class Helm:
         try:
             return await action(ctx, step_def.get("params") or {})
         except Exception as e:  # noqa: BLE001 —— 步骤失败要落 observation 而非炸掉状态机
-            return {"error": error_text(e)}
+            report = failure_from_exception(e)
+            return {"error": error_text(e), "failure": report.to_dict()}

--- a/src/backend/app/agents/voyage/runner.py
+++ b/src/backend/app/agents/voyage/runner.py
@@ -18,7 +18,12 @@ from typing import Any, Protocol, runtime_checkable
 
 from app.models.ssh_credential import SSHCredential
 from app.services.managed_commands import CommandSnapshot, OperationContext, RepairScope
-from app.services.managed_ssh import ManagedCommandHandle, OutputChunk
+from app.services.managed_ssh import (
+    ManagedCommandHandle,
+    ManagedGPUUsage,
+    ManagedStopResult,
+    OutputChunk,
+)
 from app.services.ssh_exec import (
     ENV_SOURCE_PREFIX,
     PLOT_TIMEOUT_SECONDS,
@@ -95,7 +100,10 @@ class Runner(Protocol):
     async def diagnose_managed_command(
         self, handle: ManagedCommandHandle
     ) -> dict[str, str]: ...
-    async def stop_managed_command(self, handle: ManagedCommandHandle) -> bool: ...
+    async def managed_command_gpu_usage(
+        self, handle: ManagedCommandHandle
+    ) -> ManagedGPUUsage: ...
+    async def stop_managed_command(self, handle: ManagedCommandHandle) -> ManagedStopResult: ...
     async def check_pid(self, pid: int) -> bool: ...
     async def read_exit_code(self) -> int | None: ...
     async def tail_log(self, offset: int = 0) -> tuple[str, int]: ...

--- a/src/backend/app/agents/voyage/runner.py
+++ b/src/backend/app/agents/voyage/runner.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 from app.models.ssh_credential import SSHCredential
+from app.services.managed_commands import CommandSnapshot, OperationContext, RepairScope
+from app.services.managed_ssh import ManagedCommandHandle, OutputChunk
 from app.services.ssh_exec import (
     ENV_SOURCE_PREFIX,
     PLOT_TIMEOUT_SECONDS,
@@ -57,11 +59,14 @@ class Runner(Protocol):
 
     # —— 备环境（后台脱离版：断连可重连接续跟踪同一安装进程）——
     async def launch_setup(self) -> tuple[int, str]: ...
+    async def launch_managed_setup(self) -> ManagedCommandHandle: ...
+    async def prepare_managed(self) -> ManagedCommandHandle | None: ...
     async def read_setup_exit(self) -> int | None: ...
     async def read_setup_log(self, tail_chars: int = 2000) -> str: ...
 
     # —— 跑实验入口（前台，冒烟/绘图用）——
     async def run_smoke(self, timeout: float = SMOKE_TIMEOUT_SECONDS) -> RunResult: ...
+    async def launch_managed_smoke(self) -> ManagedCommandHandle: ...
     async def run_plot(self, timeout: float = PLOT_TIMEOUT_SECONDS) -> RunResult: ...
     async def ensure_plot_deps(self, timeout: float = SETUP_TIMEOUT_SECONDS) -> RunResult: ...
 
@@ -72,6 +77,25 @@ class Runner(Protocol):
 
     # —— 跑实验入口（后台脱离 + 轮询观测）——
     async def launch_run(self) -> tuple[int, str]: ...
+    async def launch_managed_run(self) -> ManagedCommandHandle: ...
+    async def inspect_managed_command(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        previous_token: str | None = None,
+        diagnostic_evidence: dict[str, str] | None = None,
+    ) -> CommandSnapshot: ...
+    async def read_managed_output(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> tuple[list[OutputChunk], int, int]: ...
+    async def diagnose_managed_command(
+        self, handle: ManagedCommandHandle
+    ) -> dict[str, str]: ...
+    async def stop_managed_command(self, handle: ManagedCommandHandle) -> bool: ...
     async def check_pid(self, pid: int) -> bool: ...
     async def read_exit_code(self) -> int | None: ...
     async def tail_log(self, offset: int = 0) -> tuple[str, int]: ...
@@ -223,6 +247,28 @@ class ContainerRunner(SSHExecutor):
             detail = (res.stderr or res.stdout or "").strip()[:300]
             raise SSHExecError(f"docker run 启动容器失败：{detail}")
 
+    async def prepare_managed(self) -> ManagedCommandHandle | None:
+        """Start container preparation through the generic command envelope."""
+        name = self._container_name
+        probe = await self._run(
+            f"docker inspect -f '{{{{.State.Running}}}}' {name} 2>/dev/null"
+        )
+        if probe.stdout.strip() == "true":
+            return None
+        await self._run(f"docker rm -f {name} >/dev/null 2>&1 || true")
+        return await self.start_managed_command(
+            OperationContext(
+                phase="environment.prepare",
+                operation="environment-prepare",
+                display_command=f"start container from {self._spec.image}",
+                target=self.host,
+                soft_timeout_seconds=600,
+                stall_timeout_seconds=900,
+                repair_scope=RepairScope.INFRASTRUCTURE,
+            ),
+            self._docker_run_cmd(),
+        )
+
     # ---- 执行原语（改成容器内执行；镜像自带框架，故不建 venv、用镜像 python） ----
 
     async def setup_venv(self, timeout: float = SETUP_TIMEOUT_SECONDS) -> SSHResult:
@@ -268,11 +314,50 @@ class ContainerRunner(SSHExecutor):
             raise SSHExecError(f"launch_setup 未返回 PID：{result.stdout!r}") from e
         return pid, command
 
+    async def launch_managed_setup(self) -> ManagedCommandHandle:
+        from app.core.config import get_settings
+
+        await self._ensure_container()
+        index = get_settings().pip_index_url
+        index_arg = f" -i {index}" if index else ""
+        inner = (
+            f"{self._proxy_prefix()}"
+            f"if [ -f requirements.txt ]; then pip install{index_arg} -r requirements.txt; "
+            "else echo no requirements.txt: using image base; fi"
+        )
+        return await self.start_managed_command(
+            OperationContext(
+                phase="dependency.install",
+                operation="dependency-install",
+                display_command="install generated experiment dependencies",
+                target=self.host,
+                soft_timeout_seconds=600,
+                stall_timeout_seconds=900,
+                repair_scope=RepairScope.DEPENDENCY_FILES,
+            ),
+            self._dexec_workdir(inner),
+        )
+
     async def run_smoke(self, timeout: float = SMOKE_TIMEOUT_SECONDS) -> SSHResult:
         await self._ensure_container()
         return await self._run(
             self._dexec_workdir(f"{{ {ENV_SOURCE_PREFIX} bash run.sh --smoke; }}"),
             timeout=timeout,
+        )
+
+    async def launch_managed_smoke(self) -> ManagedCommandHandle:
+        await self._ensure_container()
+        return await self.start_managed_command(
+            OperationContext(
+                phase="application.smoke",
+                operation="application-smoke",
+                display_command="bash run.sh --smoke",
+                target=self.host,
+                soft_timeout_seconds=300,
+                stall_timeout_seconds=600,
+                repair_scope=RepairScope.APPLICATION_FILES,
+            ),
+            self._dexec_workdir(f"{{ {ENV_SOURCE_PREFIX} bash run.sh --smoke; }}"),
         )
 
     async def run_plot(self, timeout: float = PLOT_TIMEOUT_SECONDS) -> SSHResult:
@@ -318,6 +403,22 @@ class ContainerRunner(SSHExecutor):
         except (ValueError, IndexError) as e:
             raise SSHExecError(f"launch_run 未返回 PID：{result.stdout!r}") from e
         return pid, command
+
+    async def launch_managed_run(self) -> ManagedCommandHandle:
+        await self._ensure_container()
+        inner = f"export PYTHONUNBUFFERED=1; {ENV_SOURCE_PREFIX} stdbuf -oL -eL bash run.sh"
+        return await self.start_managed_command(
+            OperationContext(
+                phase="application.run",
+                operation="experiment-run",
+                display_command="bash run.sh",
+                target=self.host,
+                soft_timeout_seconds=600,
+                stall_timeout_seconds=900,
+                repair_scope=RepairScope.APPLICATION_FILES,
+            ),
+            self._dexec_workdir(inner),
+        )
 
     async def check_pid(self, pid: int) -> bool:
         result = await self._run(

--- a/src/backend/app/agents/voyage/runner.py
+++ b/src/backend/app/agents/voyage/runner.py
@@ -83,6 +83,9 @@ class Runner(Protocol):
     # —— 跑实验入口（后台脱离 + 轮询观测）——
     async def launch_run(self) -> tuple[int, str]: ...
     async def launch_managed_run(self) -> ManagedCommandHandle: ...
+    async def recover_managed_command(
+        self, context: OperationContext
+    ) -> ManagedCommandHandle | None: ...
     async def inspect_managed_command(
         self,
         handle: ManagedCommandHandle,

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -15,6 +15,7 @@ from app.schemas.admin_settings import (
     ExperimentEnvSettings,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
+    ManagedCommandWatchdogAdminSettings,
 )
 from app.schemas.tts import TTSAdminSettings, TTSTestResult, TTSVoicesResult
 from app.services import affiliations as affiliations_service
@@ -22,6 +23,7 @@ from app.services import daily_feed as daily_service
 from app.services import embedding as embedding_service
 from app.services import experiment_settings as experiment_settings_service
 from app.services import lab as lab_service
+from app.services import managed_command_watchdog as watchdog_service
 from app.services import tts as tts_service
 
 router = APIRouter(
@@ -156,6 +158,32 @@ async def set_experiment_env(
             detail=f"INVALID_EXPERIMENT_SETTING:{exc.field}",
         ) from exc
     return ExperimentEnvSettings(**saved)
+
+
+@router.get(
+    "/managed-command-watchdog",
+    response_model=ManagedCommandWatchdogAdminSettings,
+)
+async def get_managed_command_watchdog(
+    session: AsyncSession = Depends(get_session),
+) -> ManagedCommandWatchdogAdminSettings:
+    return ManagedCommandWatchdogAdminSettings(
+        max_unanswered_minutes=await watchdog_service.get_admin_max_minutes(session)
+    )
+
+
+@router.put(
+    "/managed-command-watchdog",
+    response_model=ManagedCommandWatchdogAdminSettings,
+)
+async def set_managed_command_watchdog(
+    payload: ManagedCommandWatchdogAdminSettings,
+    session: AsyncSession = Depends(get_session),
+) -> ManagedCommandWatchdogAdminSettings:
+    saved = await watchdog_service.set_admin_max_minutes(
+        session, payload.max_unanswered_minutes
+    )
+    return ManagedCommandWatchdogAdminSettings(max_unanswered_minutes=saved)
 
 
 @router.get("/tts", response_model=TTSAdminSettings)

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -662,3 +662,78 @@ async def stream_experiment_logs(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.get("/experiments/{experiment_id}/terminal-logs", response_model=ExperimentLogsRead)
+async def get_experiment_terminal_logs(
+    experiment_id: uuid.UUID,
+    tail: int = Query(default=500, ge=1, le=5000),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ExperimentLogsRead:
+    experiment, _ = await _member_experiment(session, experiment_id, user)
+    path = experiments_service.terminal_log_path(experiment.id)
+    lines, truncated = experiments_service.read_local_log_tail(str(path), tail)
+    return ExperimentLogsRead(lines=lines, truncated=truncated)
+
+
+@router.get("/experiments/{experiment_id}/terminal-logs/stream")
+async def stream_experiment_terminal_logs(
+    experiment_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> StreamingResponse:
+    """Stream raw managed-command stdout/stderr independently from run.log."""
+    experiment, _ = await _member_experiment(session, experiment_id, user)
+    exp_id = experiment.id
+    path = experiments_service.terminal_log_path(exp_id)
+
+    async def _status() -> str:
+        async with get_sessionmaker()() as current_session:
+            row = await experiments_service.get_experiment_for_user(
+                current_session,
+                experiment_id=exp_id,
+                user_id=user.id,
+            )
+        return row[0].status if row is not None else "failed"
+
+    async def stream() -> AsyncIterator[str]:
+        status_now = await _status()
+        yield _sse_frame("status", {"status": status_now})
+        lines, _truncated = experiments_service.read_local_log_tail(
+            str(path), _STREAM_INITIAL_TAIL
+        )
+        offset = path.stat().st_size if path.is_file() else 0
+        if lines:
+            yield _sse_frame("log", {"lines": lines})
+        last_ping = time.monotonic()
+        try:
+            while True:
+                status_now = await _status()
+                if path.is_file():
+                    size = path.stat().st_size
+                    if size > offset:
+                        with path.open("r", encoding="utf-8", errors="replace") as file:
+                            file.seek(offset)
+                            chunk = file.read()
+                        offset = size
+                        yield _sse_frame("log", {"lines": chunk.splitlines()})
+                if status_now in EXPERIMENT_TERMINAL_STATUSES:
+                    yield _sse_frame("end", {"status": status_now})
+                    return
+                if time.monotonic() - last_ping >= _HEARTBEAT_SECONDS:
+                    yield ": ping\n\n"
+                    last_ping = time.monotonic()
+                await asyncio.sleep(_STREAM_POLL_SECONDS)
+        except asyncio.CancelledError:
+            raise
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/src/backend/app/api/users_profile.py
+++ b/src/backend/app/api/users_profile.py
@@ -16,16 +16,54 @@ from app.core.db import get_session
 from app.models.user import User
 from app.schemas.llm_admin import UsageRow
 from app.schemas.user import (
+    ManagedCommandWatchdogUserRead,
+    ManagedCommandWatchdogUserUpdate,
     UsageSummary,
     UsernameUpdate,
     UserRead,
     UserSearchResult,
-    )
+)
 from app.services import llm_admin as llm_admin_service
+from app.services import managed_command_watchdog as watchdog_service
 from app.services import users as users_service
 from app.services.users import tokens_used_by_user
 
 router = APIRouter(tags=["users"])
+
+
+@router.get(
+    "/users/me/managed-command-watchdog",
+    response_model=ManagedCommandWatchdogUserRead,
+)
+async def get_my_managed_command_watchdog(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ManagedCommandWatchdogUserRead:
+    admin_max = await watchdog_service.get_admin_max_minutes(session)
+    own = watchdog_service.get_user_minutes(user, fallback=admin_max)
+    return ManagedCommandWatchdogUserRead(
+        unanswered_minutes=own,
+        admin_max_unanswered_minutes=admin_max,
+        effective_unanswered_minutes=min(own, admin_max),
+    )
+
+
+@router.put(
+    "/users/me/managed-command-watchdog",
+    response_model=ManagedCommandWatchdogUserRead,
+)
+async def set_my_managed_command_watchdog(
+    payload: ManagedCommandWatchdogUserUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ManagedCommandWatchdogUserRead:
+    own = await watchdog_service.set_user_minutes(session, user, payload.unanswered_minutes)
+    admin_max = await watchdog_service.get_admin_max_minutes(session)
+    return ManagedCommandWatchdogUserRead(
+        unanswered_minutes=own,
+        admin_max_unanswered_minutes=admin_max,
+        effective_unanswered_minutes=min(own, admin_max),
+    )
 
 
 @router.patch("/users/me/username", response_model=UserRead)

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -220,6 +220,28 @@ async def answer_voyage_ask(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail="ANSWER_EMPTY"
         )
+    # Do not hold an ask-row write transaction while a remote stop and its
+    # independent SSH audit writes are in flight. Concurrent answers may both
+    # attempt this idempotent, attempt-scoped stop; the conditional UPDATE below
+    # still guarantees that only one answer is accepted.
+    if data.choice == "stop_remote":
+        payload = ask.payload if isinstance(ask.payload, dict) else {}
+        context = payload.get("context")
+        handle = context.get("handle") if isinstance(context, dict) else None
+        if payload.get("ask_kind") != "managed_command" or not isinstance(handle, dict):
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="STOP_REMOTE_NOT_ALLOWED",
+            )
+        stopped = await experiments_service.stop_managed_command_by_voyage(
+            session, run.id, handle
+        )
+        if not stopped:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail="REMOTE_OPERATION_STOP_NOT_CONFIRMED",
+            )
+
     # 条件 UPDATE 防并发双答（两个成员同时点回答只有一个生效）
     result = await session.execute(
         sa_update(VoyageMessage)

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -220,10 +220,8 @@ async def answer_voyage_ask(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY, detail="ANSWER_EMPTY"
         )
-    # Do not hold an ask-row write transaction while a remote stop and its
-    # independent SSH audit writes are in flight. Concurrent answers may both
-    # attempt this idempotent, attempt-scoped stop; the conditional UPDATE below
-    # still guarantees that only one answer is accepted.
+    claimed_stop = False
+    stop_status: str | None = None
     if data.choice == "stop_remote":
         payload = ask.payload if isinstance(ask.payload, dict) else {}
         context = payload.get("context")
@@ -233,19 +231,32 @@ async def answer_voyage_ask(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="STOP_REMOTE_NOT_ALLOWED",
             )
-        stopped = await experiments_service.stop_managed_command_by_voyage(
-            session, run.id, handle
-        )
-        if not stopped:
+        # Claim the ask before SSH.  A concurrent keep-running answer or watchdog
+        # can no longer win the database decision after this caller has already
+        # killed the process (or vice versa).
+        claimed_stop = await messages_service.claim_open_ask_for_stop(session, ask.id)
+        if not claimed_stop:
+            raise HTTPException(status.HTTP_409_CONFLICT, detail="ASK_NOT_OPEN")
+        try:
+            stop_result = await experiments_service.stop_managed_command_by_voyage(
+                session, run.id, handle
+            )
+        except Exception:
+            await messages_service.release_stop_claim(session, ask.id)
+            raise
+        stop_status = stop_result.status
+        if not stop_result:
+            await messages_service.release_stop_claim(session, ask.id)
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 detail="REMOTE_OPERATION_STOP_NOT_CONFIRMED",
             )
 
     # 条件 UPDATE 防并发双答（两个成员同时点回答只有一个生效）
+    expected_status = messages_service.STOPPING_STATUS if claimed_stop else "open"
     result = await session.execute(
         sa_update(VoyageMessage)
-        .where(VoyageMessage.id == ask.id, VoyageMessage.status == "open")
+        .where(VoyageMessage.id == ask.id, VoyageMessage.status == expected_status)
         .values(status="answered")
     )
     if result.rowcount == 0:
@@ -257,6 +268,8 @@ async def answer_voyage_ask(
         answer_payload["choice"] = data.choice
     if data.payload:
         answer_payload["extra"] = data.payload
+    if stop_status:
+        answer_payload["stop_status"] = stop_status
     answer = await messages_service.append_message(
         session,
         run.id,

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -58,6 +58,8 @@ _EXP_REPORT_MARKER = "## 实验报告"  # experiment 报告
 _EXP_REFLECTION_MARKER = '"hypothesis_updates"'  # experiment 迭代 reflection（M5-A）
 _EXP_PLOT_MARKER = '"plot_figures.py"'  # experiment 绘图脚本（M5-A）
 _EXP_FIGQC_MARKER = "图表质检员"  # experiment 图表 VLM 质检（M5-A，多模态）
+_COMMAND_ADVISOR_MARKER = "POLARIS_COMMAND_ADVISOR"
+_RECOVERY_ADVISOR_MARKER = "POLARIS_RECOVERY_ADVISOR"
 _READING_MARKER = "论文阅读助手"  # AI 伴读（papers.py CHAT_SYSTEM_PROMPT_TEMPLATE）
 _LIBRARY_MARKER = "文献库研究助手"  # 文献库对话（library_chat.py）
 _WRITE_SECTION_MARKER = "POLARIS_WRITING_SECTION"  # 论文分节撰写（M5-B）
@@ -317,6 +319,42 @@ class FakeProvider(LLMProvider):
             (m.text for m in reversed(messages) if m.role == "user"),
             full_text,
         )
+        if _COMMAND_ADVISOR_MARKER in full_text:
+            return json.dumps(
+                {
+                    "state": "unknown",
+                    "confidence": 0.4,
+                    "reason": "fake advisor has insufficient evidence",
+                    "evidence": [],
+                    "proposed_action": "ask_user_while_running",
+                    "next_check_seconds": 5,
+                    "safe_to_interrupt": False,
+                    "user_message": None,
+                },
+                ensure_ascii=False,
+            )
+        if _RECOVERY_ADVISOR_MARKER in full_text:
+            try:
+                report = json.loads(last_user)
+            except json.JSONDecodeError:
+                report = {}
+            scope = str(report.get("repair_scope") or "none")
+            changes = {
+                "dependency_files": ["requirements.txt", "run.sh"],
+                "application_files": ["run.sh", "train.py"],
+            }.get(scope, [])
+            return json.dumps(
+                {
+                    "diagnosis": "fake structured command failure",
+                    "confidence": 0.95 if changes else 0.4,
+                    "repair_scope": scope if changes else "none",
+                    "proposed_changes": changes,
+                    "expected_evidence": "the minimal retry exits successfully",
+                    "minimal_retry": "retry the failed operation",
+                    "next_step": "Inspect the captured stdout and stderr before retrying.",
+                },
+                ensure_ascii=False,
+            )
         # M5-C 论文评审五 marker：prompt 内嵌 LaTeX 源/评审意见（可能撞其他 marker），
         # 且 guardrail/支撑性输出与 sextant 的 '"passed"' 形态重叠，须最先判断
         if _REVIEW_GUARDRAIL_MARKER in full_text:

--- a/src/backend/app/models/user.py
+++ b/src/backend/app/models/user.py
@@ -39,8 +39,8 @@ class User(SQLAlchemyBaseUserTableUUID, TimestampMixin, Base):
     # 功能权限：{feature: bool}；None/缺键 = 允许
     features: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     # 用户个人设置：{key: value}。与 features（admin 权限位）分开，None/缺键 = 未设置。
-    # 目前没有任何设置项在读它——chat_fulltext_index 已废除（向量是检索的承重结构，
-    # 不再可关），存量值留在库里不清理也不读。列本身保留给后续设置项。
+    # managed_command_unanswered_minutes 存远端命令等待用户答复的个人偏好；管理员全局
+    # 上限仍优先。历史 chat_fulltext_index 已废除，存量值保留但不再读取。
     settings: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
 
     @property

--- a/src/backend/app/models/voyage.py
+++ b/src/backend/app/models/voyage.py
@@ -168,8 +168,16 @@ class VoyageStep(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 # answer = 用户对 ask 的回答（reply_to 指向 ask）；info = agent 播报（如「已采纳你的建议」）。
 VOYAGE_MESSAGE_KINDS = ("chat", "ask", "answer", "info")
 # ask 生命周期：open（等回答）→ answered（已答，等引擎消费）→ consumed（引擎已把回答
-# 变成行为，与该行为同事务提交）；superseded = 被取消/新 ask 覆盖。其余 kind 恒为 none。
-VOYAGE_MESSAGE_STATUSES = ("none", "open", "answered", "consumed", "superseded")
+# 变成行为，与该行为同事务提交）；stopping 是 stop_remote 已原子抢占、正在停止远端
+# attempt 的短暂状态；superseded = 被取消/新 ask 覆盖。其余 kind 恒为 none。
+VOYAGE_MESSAGE_STATUSES = (
+    "none",
+    "open",
+    "stopping",
+    "answered",
+    "consumed",
+    "superseded",
+)
 
 
 class VoyageMessage(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 AffiliationMode = Literal["on_add", "on_compile"]
 
@@ -78,3 +78,9 @@ class ExperimentEnvSettings(BaseModel):
     pip_index_url: str = ""  # pip 镜像源
     hf_endpoint: str = ""  # HF 镜像端点，如 https://hf-mirror.com
     proxy_url: str = ""  # 实验机出外网的 HTTP 代理
+
+
+class ManagedCommandWatchdogAdminSettings(BaseModel):
+    """Maximum unattended wait before a GPU-using command is stopped."""
+
+    max_unanswered_minutes: int = Field(default=120, ge=15, le=10_080)

--- a/src/backend/app/schemas/user.py
+++ b/src/backend/app/schemas/user.py
@@ -85,6 +85,16 @@ class UsernameUpdate(BaseModel):
     username: str = Field(pattern=USERNAME_PATTERN)
 
 
+class ManagedCommandWatchdogUserUpdate(BaseModel):
+    unanswered_minutes: int = Field(ge=15, le=10_080)
+
+
+class ManagedCommandWatchdogUserRead(BaseModel):
+    unanswered_minutes: int
+    admin_max_unanswered_minutes: int
+    effective_unanswered_minutes: int
+
+
 # ---- 管理端（/admin/users） ----
 
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -36,6 +36,8 @@ from app.schemas.experiment import (
     ExperimentRunRead,
 )
 from app.services import ssh_exec
+from app.services.managed_commands import OperationContext, RepairScope
+from app.services.managed_ssh import ManagedCommandHandle
 from app.services.projects import in_my_projects
 
 logger = logging.getLogger("polaris.experiments")
@@ -72,6 +74,29 @@ def append_local_log(experiment_id: uuid.UUID | str, seq: int, text: str) -> Pat
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(text)
+    return path
+
+
+def terminal_log_path(experiment_id: uuid.UUID | str) -> Path:
+    """Local mirror for raw stdout/stderr from every managed remote command."""
+    return Path(get_settings().data_dir) / "experiments" / str(experiment_id) / "terminal.log"
+
+
+def append_terminal_output(
+    experiment_id: uuid.UUID | str,
+    *,
+    operation: str,
+    stream: str,
+    text: str,
+) -> Path:
+    path = terminal_log_path(experiment_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = f"[{operation}][{stream}] "
+    with path.open("a", encoding="utf-8") as file:
+        for line in text.splitlines(keepends=True):
+            file.write(prefix + line)
+        if text and not text.endswith(("\n", "\r")):
+            file.write("\n")
     return path
 
 
@@ -397,6 +422,52 @@ async def resume_from_waiting_by_voyage(
     await session.commit()
     await session.refresh(experiment)
     return experiment
+
+
+async def stop_managed_command_by_voyage(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    handle_data: dict[str, Any],
+) -> bool:
+    """Stop exactly the attempt shown in a managed-command ask and verify it died."""
+    experiment = (
+        await session.execute(select(Experiment).where(Experiment.voyage_id == voyage_id))
+    ).scalar_one_or_none()
+    if experiment is None or experiment.credential_id is None:
+        return False
+    credential = await session.get(SSHCredential, experiment.credential_id)
+    context_data = handle_data.get("context")
+    if credential is None or not isinstance(context_data, dict):
+        return False
+    try:
+        context = OperationContext(
+            phase=str(context_data["phase"]),
+            operation=str(context_data["operation"]),
+            display_command=str(context_data["display_command"]),
+            target=str(context_data["target"]) if context_data.get("target") else None,
+            soft_timeout_seconds=context_data.get("soft_timeout_seconds"),
+            stall_timeout_seconds=context_data.get("stall_timeout_seconds"),
+            hard_timeout_seconds=context_data.get("hard_timeout_seconds"),
+            repair_scope=RepairScope(str(context_data.get("repair_scope") or "none")),
+        )
+        handle = ManagedCommandHandle(
+            operation_id=str(handle_data["operation_id"]),
+            attempt_id=str(handle_data["attempt_id"]),
+            context=context,
+            process_id=int(handle_data["process_id"]),
+            process_group_id=int(handle_data["process_group_id"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+    executor = await ssh_exec.open_executor(
+        credential=credential,
+        exp_id=str(experiment.id),
+        project_id=experiment.project_id,
+    )
+    try:
+        return await executor.stop_managed_command(handle)
+    finally:
+        await executor.close()
 
 
 # ---- 取消 ----

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -37,7 +37,7 @@ from app.schemas.experiment import (
 )
 from app.services import ssh_exec
 from app.services.managed_commands import OperationContext, RepairScope, redact_text
-from app.services.managed_ssh import ManagedCommandHandle
+from app.services.managed_ssh import ManagedCommandHandle, ManagedGPUUsage, ManagedStopResult
 from app.services.projects import in_my_projects
 
 logger = logging.getLogger("polaris.experiments")
@@ -70,10 +70,15 @@ def local_log_path(experiment_id: uuid.UUID | str, seq: int) -> Path:
 
 
 def append_local_log(experiment_id: uuid.UUID | str, seq: int, text: str) -> Path:
+    """Append a redacted copy of run output to the user-visible log mirror.
+
+    Metric parsing happens before this function is called, so keeping secrets
+    off disk does not alter the experiment's structured results.
+    """
     path = local_log_path(experiment_id, seq)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
-        f.write(text)
+        f.write(redact_text(text))
     return path
 
 
@@ -435,17 +440,35 @@ async def stop_managed_command_by_voyage(
     session: AsyncSession,
     voyage_id: uuid.UUID,
     handle_data: dict[str, Any],
-) -> bool:
+) -> ManagedStopResult:
     """Stop exactly the attempt shown in a managed-command ask and verify it died."""
     experiment = (
         await session.execute(select(Experiment).where(Experiment.voyage_id == voyage_id))
     ).scalar_one_or_none()
     if experiment is None or experiment.credential_id is None:
-        return False
+        return ManagedStopResult(status="experiment_unavailable", confirmed=False)
     credential = await session.get(SSHCredential, experiment.credential_id)
+    handle = managed_handle_from_data(handle_data)
+    if credential is None or handle is None:
+        return ManagedStopResult(status="invalid_handle", confirmed=False)
+    executor = await ssh_exec.open_executor(
+        credential=credential,
+        exp_id=str(experiment.id),
+        project_id=experiment.project_id,
+    )
+    try:
+        return await executor.stop_managed_command(handle)
+    finally:
+        await executor.close()
+
+
+def managed_handle_from_data(handle_data: Any) -> ManagedCommandHandle | None:
+    """Restore a validated handle saved in a managed-command ask payload."""
+    if not isinstance(handle_data, dict):
+        return None
     context_data = handle_data.get("context")
-    if credential is None or not isinstance(context_data, dict):
-        return False
+    if not isinstance(context_data, dict):
+        return None
     try:
         context = OperationContext(
             phase=str(context_data["phase"]),
@@ -457,22 +480,43 @@ async def stop_managed_command_by_voyage(
             hard_timeout_seconds=context_data.get("hard_timeout_seconds"),
             repair_scope=RepairScope(str(context_data.get("repair_scope") or "none")),
         )
-        handle = ManagedCommandHandle(
+        process_id = int(handle_data["process_id"])
+        process_group_id = int(handle_data["process_group_id"])
+        if process_id <= 0 or process_group_id <= 0:
+            return None
+        return ManagedCommandHandle(
             operation_id=str(handle_data["operation_id"]),
-            attempt_id=str(handle_data["attempt_id"]),
+            attempt_id=str(uuid.UUID(str(handle_data["attempt_id"]))),
             context=context,
-            process_id=int(handle_data["process_id"]),
-            process_group_id=int(handle_data["process_group_id"]),
+            process_id=process_id,
+            process_group_id=process_group_id,
         )
     except (KeyError, TypeError, ValueError):
-        return False
+        return None
+
+
+async def managed_command_gpu_usage_by_voyage(
+    session: AsyncSession,
+    voyage_id: uuid.UUID,
+    handle_data: dict[str, Any],
+) -> ManagedGPUUsage:
+    """Inspect GPU use for exactly the attempt referenced by an open ask."""
+    experiment = (
+        await session.execute(select(Experiment).where(Experiment.voyage_id == voyage_id))
+    ).scalar_one_or_none()
+    handle = managed_handle_from_data(handle_data)
+    if experiment is None or experiment.credential_id is None or handle is None:
+        return ManagedGPUUsage(status="invalid_handle", process_alive=False)
+    credential = await session.get(SSHCredential, experiment.credential_id)
+    if credential is None:
+        return ManagedGPUUsage(status="credential_unavailable", process_alive=False)
     executor = await ssh_exec.open_executor(
         credential=credential,
         exp_id=str(experiment.id),
         project_id=experiment.project_id,
     )
     try:
-        return await executor.stop_managed_command(handle)
+        return await executor.managed_command_gpu_usage(handle)
     finally:
         await executor.close()
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -36,7 +36,7 @@ from app.schemas.experiment import (
     ExperimentRunRead,
 )
 from app.services import ssh_exec
-from app.services.managed_commands import OperationContext, RepairScope
+from app.services.managed_commands import OperationContext, RepairScope, redact_text
 from app.services.managed_ssh import ManagedCommandHandle
 from app.services.projects import in_my_projects
 
@@ -89,13 +89,20 @@ def append_terminal_output(
     stream: str,
     text: str,
 ) -> Path:
+    """远端命令原始输出落盘。
+
+    写之前先脱敏：这个文件通过 /experiments/{id}/terminal-logs 原样发给课题成员
+    与平台管理员，是这套机制里最大的一个外露面。快照和失败报告都脱敏了，这里不脱
+    就等于白做——实验脚本里 echo 一次 HF_TOKEN 就直接进了所有人的终端面板。
+    """
     path = terminal_log_path(experiment_id)
     path.parent.mkdir(parents=True, exist_ok=True)
+    safe_text = redact_text(text)
     prefix = f"[{operation}][{stream}] "
     with path.open("a", encoding="utf-8") as file:
-        for line in text.splitlines(keepends=True):
+        for line in safe_text.splitlines(keepends=True):
             file.write(prefix + line)
-        if text and not text.endswith(("\n", "\r")):
+        if safe_text and not safe_text.endswith(("\n", "\r")):
             file.write("\n")
     return path
 

--- a/src/backend/app/services/managed_command_watchdog.py
+++ b/src/backend/app/services/managed_command_watchdog.py
@@ -1,0 +1,276 @@
+"""Policy and unattended checks for managed commands waiting on a user.
+
+The monitor which raised the question is no longer running once a voyage enters
+``paused_ask``.  This service is therefore called by a worker cron job.  It is
+command-name agnostic: attribution uses the durable attempt and its process
+group, not Docker/pip/training command patterns.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+from app.models.voyage import VoyageMessage, VoyageRun
+from app.services import experiments as experiments_service
+from app.services import voyage_messages as messages_service
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_SETTING_KEY = "managed_command_watchdog"
+USER_SETTING_KEY = "managed_command_unanswered_minutes"
+DEFAULT_MAX_UNANSWERED_MINUTES = 120
+MIN_UNANSWERED_MINUTES = 15
+MAX_UNANSWERED_MINUTES = 7 * 24 * 60
+RECHECK_MINUTES = 30
+
+
+@dataclass(slots=True, frozen=True)
+class WatchdogEvent:
+    voyage_id: uuid.UUID
+    project_id: uuid.UUID | None
+    message: dict[str, Any]
+    action: str
+    used_memory_mib: int = 0
+
+
+def validate_minutes(value: Any) -> int:
+    try:
+        minutes = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid managed-command unanswered timeout") from exc
+    if not MIN_UNANSWERED_MINUTES <= minutes <= MAX_UNANSWERED_MINUTES:
+        raise ValueError("managed-command unanswered timeout is out of range")
+    return minutes
+
+
+async def get_admin_max_minutes(session: AsyncSession) -> int:
+    row = await session.get(SystemSetting, SYSTEM_SETTING_KEY)
+    raw = row.value if row is not None else None
+    if isinstance(raw, dict):
+        try:
+            return validate_minutes(raw.get("max_unanswered_minutes"))
+        except ValueError:
+            pass
+    return DEFAULT_MAX_UNANSWERED_MINUTES
+
+
+async def set_admin_max_minutes(session: AsyncSession, minutes: int) -> int:
+    value = validate_minutes(minutes)
+    row = await session.get(SystemSetting, SYSTEM_SETTING_KEY)
+    payload = {"max_unanswered_minutes": value}
+    if row is None:
+        session.add(SystemSetting(key=SYSTEM_SETTING_KEY, value=payload))
+    else:
+        row.value = payload
+    await session.commit()
+    return value
+
+
+def get_user_minutes(user: User, *, fallback: int) -> int:
+    try:
+        return validate_minutes(user.setting(USER_SETTING_KEY, fallback))
+    except ValueError:
+        return fallback
+
+
+async def set_user_minutes(session: AsyncSession, user: User, minutes: int) -> int:
+    value = validate_minutes(minutes)
+    settings = dict(user.settings or {})
+    settings[USER_SETTING_KEY] = value
+    user.settings = settings
+    await session.commit()
+    await session.refresh(user)
+    return value
+
+
+def effective_minutes(user: User, admin_max_minutes: int) -> int:
+    """The administrator caps waiting; a user may only choose an earlier stop."""
+    return min(get_user_minutes(user, fallback=admin_max_minutes), admin_max_minutes)
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def _watchdog_context(payload: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    context = dict(payload.get("context") or {})
+    watchdog = dict(context.get("unanswered_watchdog") or {})
+    return context, watchdog
+
+
+def _due_for_check(
+    ask: VoyageMessage,
+    *,
+    now: datetime,
+    timeout_minutes: int,
+) -> bool:
+    if now - _aware(ask.created_at) < timedelta(minutes=timeout_minutes):
+        return False
+    payload = ask.payload if isinstance(ask.payload, dict) else {}
+    _, watchdog = _watchdog_context(payload)
+    raw = watchdog.get("checked_at")
+    if not raw:
+        return True
+    try:
+        checked_at = _aware(datetime.fromisoformat(str(raw)))
+    except ValueError:
+        return True
+    return now - checked_at >= timedelta(minutes=RECHECK_MINUTES)
+
+
+async def check_unanswered_managed_commands(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> list[WatchdogEvent]:
+    """Stop only stale, still-open asks whose own command is using a GPU."""
+    now = _aware(now or datetime.now(UTC))
+    admin_max = await get_admin_max_minutes(session)
+    rows = (
+        await session.execute(
+            select(VoyageMessage, VoyageRun, User)
+            .join(VoyageRun, VoyageRun.id == VoyageMessage.run_id)
+            .join(User, User.id == VoyageRun.created_by)
+            .where(
+                VoyageMessage.kind == "ask",
+                VoyageMessage.status == "open",
+                VoyageRun.status == "paused_ask",
+            )
+        )
+    ).all()
+    events: list[WatchdogEvent] = []
+    for ask, run, user in rows:
+        payload = dict(ask.payload or {})
+        context, watchdog = _watchdog_context(payload)
+        handle = context.get("handle")
+        if payload.get("ask_kind") != "managed_command" or not isinstance(handle, dict):
+            continue
+        timeout = effective_minutes(user, admin_max)
+        if not _due_for_check(ask, now=now, timeout_minutes=timeout):
+            continue
+        try:
+            usage = await experiments_service.managed_command_gpu_usage_by_voyage(
+                session, run.id, handle
+            )
+        except Exception as exc:  # noqa: BLE001 - one remote host must not block the sweep
+            logger.warning("managed command watchdog probe failed for %s: %s", run.id, exc)
+            status = "probe_failed"
+            usage = None
+        else:
+            status = usage.status
+
+        # A user may have answered while the remote probe was in flight.  Refresh
+        # before non-destructive bookkeeping; destructive stop additionally uses
+        # the same open -> stopping CAS as the answer endpoint below.
+        await session.refresh(ask)
+        await session.refresh(run)
+        if ask.status != "open" or run.status != "paused_ask":
+            continue
+
+        watchdog.update(
+            {
+                "checked_at": now.isoformat(),
+                "effective_timeout_minutes": timeout,
+                "status": status,
+            }
+        )
+        if usage is not None:
+            watchdog["used_memory_mib"] = usage.used_memory_mib
+            watchdog["matched_gpu_processes"] = len(usage.process_ids)
+
+        action: str | None = None
+        if usage is not None and usage.status == "active":
+            claimed = await messages_service.claim_open_ask_for_stop(session, ask.id)
+            if not claimed:
+                continue
+            try:
+                stop_result = await experiments_service.stop_managed_command_by_voyage(
+                    session, run.id, handle
+                )
+            except Exception as exc:  # noqa: BLE001 - release the durable claim
+                await messages_service.release_stop_claim(session, ask.id)
+                logger.warning("managed command watchdog stop failed for %s: %s", run.id, exc)
+                continue
+            await session.refresh(ask)
+            await session.refresh(run)
+            if ask.status != messages_service.STOPPING_STATUS or run.status != "paused_ask":
+                # Cancellation may supersede the ask while SSH is stopping the
+                # process.  The remote stop is still desirable, but the
+                # watchdog must not reopen a cancelled task's question.
+                continue
+            stop_status = stop_result.status
+            watchdog["stop_status"] = stop_status
+            watchdog["status"] = (
+                "command_ended" if stop_status == "already_exited" else stop_status
+            )
+            if stop_result:
+                context["remote_operation_continues"] = False
+                if stop_status == "already_exited":
+                    ask.text = (
+                        "等待回复期间，远端命令已自行结束。请选择继续，让 AI 读取最终状态并"
+                        "诊断，或放弃任务。"
+                    )
+                else:
+                    ask.text = (
+                        f"等待回复已超过 {timeout} 分钟。系统确认当前远端命令仍占用 "
+                        f"{usage.used_memory_mib} MiB GPU 显存，为避免持续占用资源已终止该命令。"
+                        "请选择继续，让 AI 根据终止后的真实状态诊断并提出下一步方案，或放弃任务。"
+                    )
+                payload["options"] = [
+                    {
+                        "id": "retry",
+                        "zh": "继续诊断并提出下一步方案",
+                        "en": "Continue diagnosis and propose next steps",
+                    },
+                    {"id": "abort", "zh": "放弃任务", "en": "Abort task"},
+                ]
+                action = (
+                    "command_ended"
+                    if stop_status == "already_exited"
+                    else "stopped_gpu_active"
+                )
+            # The stop decision is complete.  The question remains open so the
+            # user can choose diagnosis/abort, but only after the remote result
+            # and revised options are committed together.
+            ask.status = "open"
+        elif usage is not None and usage.status in {"exited", "superseded"}:
+            context["remote_operation_continues"] = False
+            ask.text = (
+                "等待回复期间，远端命令已经结束。请选择继续，让 AI 读取最终状态并诊断，"
+                "或放弃任务。"
+            )
+            payload["options"] = [
+                {
+                    "id": "retry",
+                    "zh": "读取结果并继续诊断",
+                    "en": "Read the result and continue diagnosis",
+                },
+                {"id": "abort", "zh": "放弃任务", "en": "Abort task"},
+            ]
+            action = "command_ended"
+
+        context["unanswered_watchdog"] = watchdog
+        payload["context"] = context
+        ask.payload = payload
+        await session.commit()
+        await session.refresh(ask)
+        if action is not None:
+            events.append(
+                WatchdogEvent(
+                    voyage_id=run.id,
+                    project_id=run.project_id,
+                    message=messages_service.serialize_message(ask),
+                    action=action,
+                    used_memory_mib=usage.used_memory_mib if usage is not None else 0,
+                )
+            )
+    return events

--- a/src/backend/app/services/managed_commands.py
+++ b/src/backend/app/services/managed_commands.py
@@ -1,0 +1,429 @@
+"""Executor-neutral evidence, timeout adjudication, and repair policy.
+
+This module deliberately knows nothing about Docker, pip, git, or a specific
+shell command.  Execution backends provide :class:`CommandSnapshot` objects;
+the model may assess the evidence, but deterministic policy owns interruption
+and mutation decisions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+_TAIL_CHARS = 8000
+_REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"-----BEGIN [^-]+PRIVATE KEY-----.*?-----END [^-]+PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED PRIVATE KEY]",
+    ),
+    (
+        re.compile(r"(?i)\b(authorization\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+"),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)\b(api[_-]?key|token|password|passwd|secret)\s*[:=]\s*([^\s,;]+)"
+        ),
+        r"\1=[REDACTED]",
+    ),
+    (
+        re.compile(r"(?i)(--(?:api[_-]?key|token|password|secret)\s+)[^\s]+"),
+        r"\1[REDACTED]",
+    ),
+    (re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@"), r"\1[REDACTED]@"),
+)
+
+
+def redact_text(value: Any, *, tail: bool = False) -> str:
+    text = str(value or "")
+    for pattern, replacement in _REDACTIONS:
+        text = pattern.sub(replacement, text)
+    return text[-_TAIL_CHARS:] if tail else text
+
+
+class CommandState(StrEnum):
+    PROGRESSING = "progressing"
+    SLOW = "slow"
+    STALLED = "stalled"
+    FAILED = "failed"
+    SUCCEEDED = "succeeded"
+    UNKNOWN = "unknown"
+
+
+class CommandAction(StrEnum):
+    CONTINUE_MONITORING = "continue_monitoring"
+    EXTEND_OBSERVATION = "extend_observation"
+    RUN_DIAGNOSTIC = "run_diagnostic"
+    ASK_USER_WHILE_RUNNING = "ask_user_while_running"
+    STOP_AND_REPAIR = "stop_and_repair"
+    REPORT_FAILURE = "report_failure"
+    MARK_SUCCEEDED = "mark_succeeded"
+
+
+class FailureDomain(StrEnum):
+    TRANSPORT = "transport"
+    AUTHENTICATION = "authentication"
+    EXTERNAL_SERVICE = "external_service"
+    ARTIFACT = "artifact"
+    ENVIRONMENT = "environment"
+    DEPENDENCY = "dependency"
+    RESOURCE = "resource"
+    APPLICATION = "application"
+    UNKNOWN = "unknown"
+
+
+class RepairScope(StrEnum):
+    NONE = "none"
+    CONNECTION = "connection"
+    INFRASTRUCTURE = "infrastructure"
+    DEPENDENCY_FILES = "dependency_files"
+    APPLICATION_FILES = "application_files"
+    EXPERIMENT_PLAN = "experiment_plan"
+    USER_ACTION = "user_action"
+
+
+@dataclass(slots=True, frozen=True)
+class OperationContext:
+    phase: str
+    operation: str
+    display_command: str
+    target: str | None = None
+    soft_timeout_seconds: float | None = None
+    stall_timeout_seconds: float | None = None
+    hard_timeout_seconds: float | None = None
+    repair_scope: RepairScope = RepairScope.NONE
+
+
+@dataclass(slots=True)
+class CommandSnapshot:
+    operation_id: str
+    attempt_id: str
+    context: OperationContext
+    elapsed_seconds: float
+    process_alive: bool
+    exit_status: int | None
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+    output_bytes: int = 0
+    output_changed: bool = False
+    seconds_since_output: float = 0
+    cpu_seconds: float | None = None
+    process_state: str | None = None
+    process_id: int | None = None
+    process_group_id: int | None = None
+    diagnostic_evidence: dict[str, str] | None = None
+
+    @property
+    def progress_token(self) -> str:
+        material = "\0".join(
+            (
+                str(self.output_bytes),
+                self.stdout_tail[-1000:],
+                self.stderr_tail[-1000:],
+                str(self.cpu_seconds),
+                str(self.exit_status),
+            )
+        )
+        return hashlib.sha256(material.encode()).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["context"] = asdict(self.context)
+        data["progress_token"] = self.progress_token
+        data["stdout_tail"] = redact_text(self.stdout_tail, tail=True)
+        data["stderr_tail"] = redact_text(self.stderr_tail, tail=True)
+        if self.diagnostic_evidence:
+            data["diagnostic_evidence"] = {
+                key: redact_text(value, tail=True)
+                for key, value in self.diagnostic_evidence.items()
+            }
+        return data
+
+
+@dataclass(slots=True, frozen=True)
+class ModelAssessment:
+    state: CommandState
+    confidence: float
+    reason: str
+    evidence: tuple[str, ...] = ()
+    proposed_action: CommandAction = CommandAction.CONTINUE_MONITORING
+    next_check_seconds: float = 30
+    safe_to_interrupt: bool = False
+    user_message: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class CommandVerdict:
+    action: CommandAction
+    reason: str
+    next_check_seconds: float = 0
+
+
+def adjudicate_command(
+    snapshot: CommandSnapshot,
+    assessment: ModelAssessment | None,
+    *,
+    silent_extensions: int = 0,
+    diagnostics_run: int = 0,
+) -> CommandVerdict:
+    """Apply bounded safety policy to evidence and optional model advice."""
+    if snapshot.exit_status == 0:
+        return CommandVerdict(CommandAction.MARK_SUCCEEDED, "command exited successfully")
+    if snapshot.exit_status is not None:
+        return CommandVerdict(
+            CommandAction.REPORT_FAILURE,
+            f"command exited with status {snapshot.exit_status}",
+        )
+
+    delay = 30.0
+    if assessment is not None:
+        delay = max(5.0, min(float(assessment.next_check_seconds), 600.0))
+
+    if snapshot.process_alive and snapshot.output_changed:
+        return CommandVerdict(
+            CommandAction.CONTINUE_MONITORING,
+            "remote process is alive and output changed",
+            delay,
+        )
+
+    stalled = bool(
+        snapshot.context.stall_timeout_seconds
+        and snapshot.seconds_since_output >= snapshot.context.stall_timeout_seconds
+    )
+    hard_expired = bool(
+        snapshot.context.hard_timeout_seconds
+        and snapshot.elapsed_seconds >= snapshot.context.hard_timeout_seconds
+    )
+    if hard_expired:
+        return CommandVerdict(
+            CommandAction.ASK_USER_WHILE_RUNNING,
+            "explicit hard deadline reached while the process is still alive",
+            delay,
+        )
+
+    if (
+        assessment is None
+        or assessment.state == CommandState.UNKNOWN
+        or assessment.confidence < 0.6
+    ):
+        if stalled:
+            return CommandVerdict(
+                CommandAction.ASK_USER_WHILE_RUNNING,
+                "stall threshold reached without a reliable assessment",
+                delay,
+            )
+        return CommandVerdict(
+            CommandAction.CONTINUE_MONITORING,
+            "insufficient evidence; preserve the remote process",
+            delay,
+        )
+
+    if assessment.proposed_action == CommandAction.ASK_USER_WHILE_RUNNING:
+        return CommandVerdict(
+            CommandAction.ASK_USER_WHILE_RUNNING,
+            "model recommends user review while preserving the process",
+            delay,
+        )
+
+    if assessment.state == CommandState.SLOW:
+        if silent_extensions >= 1 and snapshot.process_alive:
+            return CommandVerdict(
+                CommandAction.ASK_USER_WHILE_RUNNING,
+                "slow operation already received one silent extension",
+                delay,
+            )
+        return CommandVerdict(
+            CommandAction.EXTEND_OBSERVATION,
+            "healthy but slow operation receives one bounded extension",
+            delay,
+        )
+
+    wants_stop = assessment.proposed_action == CommandAction.STOP_AND_REPAIR
+    if assessment.state in {CommandState.STALLED, CommandState.FAILED} or wants_stop:
+        if diagnostics_run < 1:
+            return CommandVerdict(
+                CommandAction.RUN_DIAGNOSTIC,
+                "one read-only diagnostic is required before interruption",
+                delay,
+            )
+        if stalled and assessment.confidence >= 0.85 and assessment.safe_to_interrupt:
+            return CommandVerdict(
+                CommandAction.STOP_AND_REPAIR,
+                "high-confidence sustained stall confirmed after diagnostics",
+            )
+        return CommandVerdict(
+            CommandAction.ASK_USER_WHILE_RUNNING,
+            "interruption is not justified by deterministic evidence",
+            delay,
+        )
+
+    if assessment.proposed_action == CommandAction.RUN_DIAGNOSTIC:
+        if diagnostics_run >= 1:
+            return CommandVerdict(
+                CommandAction.ASK_USER_WHILE_RUNNING,
+                "diagnostic already ran without observable progress",
+                delay,
+            )
+        return CommandVerdict(CommandAction.RUN_DIAGNOSTIC, "run one diagnostic", delay)
+
+    return CommandVerdict(
+        CommandAction.CONTINUE_MONITORING,
+        "model advice passed the non-destructive safety policy",
+        delay,
+    )
+
+
+@dataclass(slots=True)
+class FailureReport:
+    phase: str
+    operation: str
+    command_display: str
+    domain: FailureDomain
+    exception_type: str
+    message: str
+    repair_scope: RepairScope
+    target: str | None = None
+    exit_status: int | None = None
+    stdout_tail: str | None = None
+    stderr_tail: str | None = None
+    elapsed_seconds: float | None = None
+    cause_chain: list[str] = field(default_factory=list)
+    fingerprint: str = ""
+    progress_token: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _classify(context: OperationContext, evidence: str) -> FailureDomain:
+    text = evidence.lower()
+    if any(item in text for item in ("permission denied", "authentication failed", "invalid key")):
+        return FailureDomain.AUTHENTICATION
+    if any(item in text for item in ("connection lost", "connection closed", "broken pipe")):
+        return FailureDomain.TRANSPORT
+    if any(item in text for item in ("out of memory", "cuda oom", "no space left")):
+        return FailureDomain.RESOURCE
+    phase = context.phase.lower()
+    for prefix, domain in (
+        ("transport.", FailureDomain.TRANSPORT),
+        ("artifact.", FailureDomain.ARTIFACT),
+        ("environment.", FailureDomain.ENVIRONMENT),
+        ("dependency.", FailureDomain.DEPENDENCY),
+        ("application.", FailureDomain.APPLICATION),
+        ("external_service.", FailureDomain.EXTERNAL_SERVICE),
+    ):
+        if phase.startswith(prefix):
+            return domain
+    return FailureDomain.UNKNOWN
+
+
+def failure_from_snapshot(snapshot: CommandSnapshot) -> FailureReport:
+    context = snapshot.context
+    message = snapshot.stderr_tail or snapshot.stdout_tail or "command failed without output"
+    evidence = f"{message}\n{snapshot.stdout_tail}\n{snapshot.stderr_tail}"
+    normalized = re.sub(r"\d+", "N", evidence[-2000:])
+    fingerprint = hashlib.sha256(
+        f"{context.phase}\0{normalized}".encode()
+    ).hexdigest()[:16]
+    return FailureReport(
+        phase=context.phase,
+        operation=context.operation,
+        command_display=redact_text(context.display_command),
+        domain=_classify(context, evidence),
+        exception_type="CommandExitError",
+        message=redact_text(message, tail=True),
+        repair_scope=context.repair_scope,
+        target=redact_text(context.target) if context.target else None,
+        exit_status=snapshot.exit_status,
+        stdout_tail=redact_text(snapshot.stdout_tail, tail=True) or None,
+        stderr_tail=redact_text(snapshot.stderr_tail, tail=True) or None,
+        elapsed_seconds=snapshot.elapsed_seconds,
+        fingerprint=fingerprint,
+        progress_token=snapshot.progress_token,
+    )
+
+
+def failure_from_exception(
+    exception: BaseException,
+    context: OperationContext | None = None,
+) -> FailureReport:
+    """Preserve AsyncSSH/http client partial evidence instead of relying on str()."""
+    command = getattr(exception, "command", None)
+    stdout = redact_text(getattr(exception, "stdout", ""), tail=True)
+    stderr = redact_text(getattr(exception, "stderr", ""), tail=True)
+    exit_status = getattr(exception, "exit_status", None)
+    if exit_status is None:
+        exit_status = getattr(exception, "returncode", None)
+    exception_context = getattr(exception, "operation_context", None)
+    if not isinstance(exception_context, OperationContext):
+        exception_context = None
+    context = context or exception_context or OperationContext(
+        phase="unknown",
+        operation="unknown",
+        display_command=str(command or "unknown command"),
+    )
+    message = redact_text(str(exception), tail=True).strip()
+    if not message:
+        message = stderr or stdout or type(exception).__name__
+    evidence = f"{type(exception).__name__}\n{message}\n{stdout}\n{stderr}"
+    normalized = re.sub(r"\d+", "N", evidence[-2000:])
+    fingerprint = hashlib.sha256(
+        f"{context.phase}\0{normalized}".encode()
+    ).hexdigest()[:16]
+    cause_chain: list[str] = []
+    current: BaseException | None = exception
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen and len(cause_chain) < 8:
+        seen.add(id(current))
+        cause_chain.append(
+            redact_text(f"{type(current).__name__}: {str(current).strip()}", tail=True)
+        )
+        current = current.__cause__ or current.__context__
+    return FailureReport(
+        phase=context.phase,
+        operation=context.operation,
+        command_display=redact_text(str(command or context.display_command)),
+        domain=_classify(context, evidence),
+        exception_type=type(exception).__name__,
+        message=message,
+        repair_scope=context.repair_scope,
+        target=redact_text(context.target) if context.target else None,
+        exit_status=int(exit_status) if exit_status is not None else None,
+        stdout_tail=stdout or None,
+        stderr_tail=stderr or None,
+        cause_chain=cause_chain,
+        fingerprint=fingerprint,
+        progress_token=fingerprint,
+    )
+
+
+@dataclass(slots=True, frozen=True)
+class RecoveryPlan:
+    diagnosis: str
+    confidence: float
+    repair_scope: RepairScope
+    proposed_changes: tuple[str, ...]
+    expected_evidence: str
+    minimal_retry: str
+
+
+def may_apply_recovery_automatically(
+    plan: RecoveryPlan,
+    *,
+    repeated_without_progress: int,
+) -> bool:
+    """Only bounded generated-file repairs may proceed without user approval."""
+    return bool(
+        plan.confidence >= 0.85
+        and repeated_without_progress < 2
+        and plan.repair_scope
+        in {RepairScope.DEPENDENCY_FILES, RepairScope.APPLICATION_FILES}
+        and plan.proposed_changes
+    )

--- a/src/backend/app/services/managed_commands.py
+++ b/src/backend/app/services/managed_commands.py
@@ -28,10 +28,22 @@ _REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
         r"\1[REDACTED]",
     ),
     (
+        # 名字以这些词结尾即算敏感：HF_TOKEN / AWS_SECRET_ACCESS_KEY / OPENAI_API_KEY…
+        # 不能只用 \b 起头——下划线是单词字符，\btoken 在 HF_TOKEN 里根本匹配不上，
+        # 而实验脚本里的密钥几乎全是这种带前缀的环境变量名。
         re.compile(
-            r"(?i)\b(api[_-]?key|token|password|passwd|secret)\s*[:=]\s*([^\s,;]+)"
+            r"(?i)([A-Za-z0-9_.-]*(?:api[_-]?key|access[_-]?key|token|password|passwd|secret)"
+            r"[A-Za-z0-9_.-]*)\s*[:=]\s*([^\s,;]+)"
         ),
         r"\1=[REDACTED]",
+    ),
+    (
+        # 常见的自带前缀密钥：OpenAI sk-…、GitHub ghp_/gho_/ghs_/github_pat_、HF hf_、Slack xox…
+        re.compile(
+            r"(?i)\b(sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}"
+            r"|github_pat_[A-Za-z0-9_]{20,}|hf_[A-Za-z0-9]{20,}|xox[abprs]-[A-Za-z0-9-]{10,})"
+        ),
+        "[REDACTED]",
     ),
     (
         re.compile(r"(?i)(--(?:api[_-]?key|token|password|secret)\s+)[^\s]+"),
@@ -135,7 +147,13 @@ class CommandSnapshot:
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
-        data["context"] = asdict(self.context)
+        context = asdict(self.context)
+        # display_command / target 同样可能带密钥（命令行里的 --token 等），
+        # 它们跟着快照一路进 API、前端和日志，必须和 tail 一样脱敏。
+        context["display_command"] = redact_text(context.get("display_command"))
+        if context.get("target"):
+            context["target"] = redact_text(context["target"])
+        data["context"] = context
         data["progress_token"] = self.progress_token
         data["stdout_tail"] = redact_text(self.stdout_tail, tail=True)
         data["stderr_tail"] = redact_text(self.stderr_tail, tail=True)

--- a/src/backend/app/services/managed_ssh.py
+++ b/src/backend/app/services/managed_ssh.py
@@ -1,0 +1,426 @@
+"""Generic durable command execution over an existing SSH session.
+
+The backend persists one uniform process envelope for every command.  It does
+not inspect command names and does not need per-command lifecycle adapters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.services.managed_commands import CommandSnapshot, OperationContext, redact_text
+
+_OPERATION_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+class SSHResultLike(Protocol):
+    exit_status: int
+    stdout: str
+    stderr: str
+
+
+class SSHSessionLike(Protocol):
+    async def write_file(self, path: str, content: str) -> None: ...
+
+
+RunCommand = Callable[[str, float | None], Awaitable[SSHResultLike]]
+
+
+@dataclass(slots=True, frozen=True)
+class ManagedCommandHandle:
+    operation_id: str
+    attempt_id: str
+    context: OperationContext
+    process_id: int
+    process_group_id: int
+
+
+@dataclass(slots=True, frozen=True)
+class OutputChunk:
+    stream: str
+    text: str
+    offset: int
+
+
+class ManagedCommandLaunchError(RuntimeError):
+    """A managed operation failed before a durable handle could be recovered."""
+
+    def __init__(
+        self,
+        context: OperationContext,
+        command: str,
+        cause: BaseException,
+    ) -> None:
+        self.operation_context = context
+        self.command = redact_text(context.display_command or command)
+        self.stdout = redact_text(getattr(cause, "stdout", ""), tail=True)
+        self.stderr = redact_text(getattr(cause, "stderr", ""), tail=True)
+        self.exit_status = getattr(cause, "exit_status", None)
+        self.original_exception = cause
+        detail = str(cause).strip() or self.stderr or self.stdout or type(cause).__name__
+        super().__init__(f"managed command launch failed: {detail}")
+
+
+class SSHManagedCommands:
+    """Persist, inspect, stream, and stop process-group-bound commands."""
+
+    def __init__(
+        self,
+        *,
+        session: SSHSessionLike,
+        run: RunCommand,
+        shell_workdir: str,
+        sftp_workdir: str,
+    ) -> None:
+        self._session = session
+        self._run = run
+        self._shell_workdir = shell_workdir
+        self._sftp_workdir = sftp_workdir
+
+    @staticmethod
+    def _validate_operation_id(operation_id: str) -> str:
+        value = operation_id.strip().lower()
+        if not _OPERATION_RE.fullmatch(value):
+            raise ValueError(f"invalid managed operation id: {operation_id!r}")
+        return value
+
+    def _operation_dir(self, operation_id: str) -> str:
+        safe = self._validate_operation_id(operation_id)
+        return f"{self._shell_workdir}/.polaris/operations/{safe}"
+
+    def _attempt_prefix(self, operation_id: str, attempt_id: str) -> str:
+        safe_attempt = str(uuid.UUID(attempt_id))
+        return f"{self._operation_dir(operation_id)}/attempts/{safe_attempt}"
+
+    def _sftp_attempt_prefix(self, operation_id: str, attempt_id: str) -> str:
+        safe = self._validate_operation_id(operation_id)
+        safe_attempt = str(uuid.UUID(attempt_id))
+        return f"{self._sftp_workdir}/.polaris/operations/{safe}/attempts/{safe_attempt}"
+
+    @staticmethod
+    def _pid_from_output(value: object) -> int | None:
+        for line in reversed(str(value or "").splitlines()):
+            try:
+                pid = int(line.strip())
+            except ValueError:
+                continue
+            return pid if pid > 0 else None
+        return None
+
+    async def _recover_started_handle(
+        self,
+        *,
+        operation_id: str,
+        attempt_id: str,
+        context: OperationContext,
+        fallback_output: object = "",
+    ) -> ManagedCommandHandle | None:
+        """Recover when SSH times out after the detached process actually started."""
+        prefix = self._attempt_prefix(operation_id, attempt_id)
+        fallback_pid = self._pid_from_output(fallback_output)
+        pid: int | None = None
+        pgid: int | None = None
+        for _ in range(10):
+            with contextlib.suppress(Exception):
+                pid = await self._read_int(f"{prefix}.pid")
+                if pid is not None:
+                    pgid = await self._read_int(f"{prefix}.pgid") or pid
+                    break
+            await asyncio.sleep(0.1)
+        pid = pid or fallback_pid
+        if pid is None:
+            return None
+        return ManagedCommandHandle(
+            operation_id=operation_id,
+            attempt_id=attempt_id,
+            context=context,
+            process_id=pid,
+            process_group_id=pgid or pid,
+        )
+
+    async def start(
+        self,
+        context: OperationContext,
+        command: str,
+        *,
+        attempt_id: str | None = None,
+    ) -> ManagedCommandHandle:
+        operation_id = self._validate_operation_id(context.operation)
+        attempt_id = str(uuid.UUID(attempt_id)) if attempt_id else str(uuid.uuid4())
+        operation_dir = self._operation_dir(operation_id)
+        prefix = self._attempt_prefix(operation_id, attempt_id)
+        sftp_prefix = self._sftp_attempt_prefix(operation_id, attempt_id)
+        try:
+            await self._run(f"mkdir -p {operation_dir}/attempts", 60)
+        except Exception as exc:
+            raise ManagedCommandLaunchError(context, command, exc) from exc
+        lock = f"{operation_dir}/launch.lock"
+        try:
+            acquired = await self._run(
+                f"i=0; until mkdir {lock} 2>/dev/null; do "
+                f"if [ -d {lock} ] && [ $(( $(date +%s) - $(stat -c %Y {lock}) )) -gt 120 ]; "
+                f"then rmdir {lock} 2>/dev/null || true; fi; "
+                "i=$((i+1)); [ $i -lt 240 ] || exit 75; sleep 0.25; done",
+                65,
+            )
+        except Exception as exc:
+            raise ManagedCommandLaunchError(context, command, exc) from exc
+        if acquired.exit_status != 0:
+            cause = RuntimeError("timed out waiting for managed command launch lock")
+            raise ManagedCommandLaunchError(context, command, cause)
+        try:
+            # A concurrent worker may have launched this logical operation while we
+            # waited. Attach to it instead of starting a duplicate remote process.
+            current = await self.current_attempt_id(operation_id)
+            if current is not None:
+                current_prefix = self._attempt_prefix(operation_id, current)
+                current_pid = await self._read_int(f"{current_prefix}.pid")
+                current_exit = await self._read_int(f"{current_prefix}.exit")
+                if current_pid is not None and current_exit is None:
+                    alive = await self._run(f"kill -0 {current_pid} 2>/dev/null", 60)
+                    if alive.exit_status == 0:
+                        current_pgid = (
+                            await self._read_int(f"{current_prefix}.pgid") or current_pid
+                        )
+                        return ManagedCommandHandle(
+                            operation_id=operation_id,
+                            attempt_id=current,
+                            context=context,
+                            process_id=current_pid,
+                            process_group_id=current_pgid,
+                        )
+
+            launcher = (
+                "#!/usr/bin/env bash\n"
+                "set +e\n"
+                f"prefix={prefix}\n"
+                "echo $$ > ${prefix}.pid\n"
+                "ps -o pgid= -p $$ | tr -d ' ' > ${prefix}.pgid\n"
+                "date +%s > ${prefix}.started\n"
+                "touch ${prefix}.stdout ${prefix}.stderr\n"
+                f"{{ {command}; }} >${{prefix}}.stdout 2>${{prefix}}.stderr\n"
+                "status=$?\n"
+                "printf '%s\\n' \"$status\" > ${prefix}.exit.tmp\n"
+                "mv ${prefix}.exit.tmp ${prefix}.exit\n"
+                "exit $status\n"
+            )
+            await self._session.write_file(f"{sftp_prefix}.sh", launcher)
+            pointer = f"{operation_dir}/current"
+            await self._run(
+                f"printf '%s\\n' {attempt_id} > {pointer}.tmp && mv {pointer}.tmp {pointer}",
+                60,
+            )
+            launch_command = (
+                f"chmod 700 {prefix}.sh || exit $?; "
+                f"nohup setsid bash {prefix}.sh >/dev/null 2>&1 < /dev/null & "
+                "pid=$!; printf '%s\\n' \"$pid\""
+            )
+            try:
+                launch = await self._run(launch_command, 60)
+            except Exception as exc:
+                recovered = await self._recover_started_handle(
+                    operation_id=operation_id,
+                    attempt_id=attempt_id,
+                    context=context,
+                    fallback_output=getattr(exc, "stdout", ""),
+                )
+                if recovered is not None:
+                    return recovered
+                raise ManagedCommandLaunchError(context, command, exc) from exc
+            if launch.exit_status != 0:
+                recovered = await self._recover_started_handle(
+                    operation_id=operation_id,
+                    attempt_id=attempt_id,
+                    context=context,
+                    fallback_output=launch.stdout,
+                )
+                if recovered is not None:
+                    return recovered
+                cause = RuntimeError(redact_text(launch.stderr or launch.stdout, tail=True))
+                raise ManagedCommandLaunchError(context, command, cause)
+            pid = self._pid_from_output(launch.stdout)
+            if pid is None:
+                recovered = await self._recover_started_handle(
+                    operation_id=operation_id,
+                    attempt_id=attempt_id,
+                    context=context,
+                    fallback_output=launch.stdout,
+                )
+                if recovered is not None:
+                    return recovered
+                cause = RuntimeError(
+                    f"managed command launch returned no PID: {redact_text(launch.stdout)!r}"
+                )
+                raise ManagedCommandLaunchError(context, command, cause)
+            # The launcher records the real PGID. It normally equals the returned
+            # PID; use the PID as a safe initial value until the first snapshot.
+            return ManagedCommandHandle(
+                operation_id=operation_id,
+                attempt_id=attempt_id,
+                context=context,
+                process_id=pid,
+                process_group_id=pid,
+            )
+        except ManagedCommandLaunchError:
+            raise
+        except Exception as exc:
+            raise ManagedCommandLaunchError(context, command, exc) from exc
+        finally:
+            with contextlib.suppress(Exception):
+                await self._run(f"rmdir {lock} 2>/dev/null || true", 60)
+
+    async def current_attempt_id(self, operation_id: str) -> str | None:
+        path = f"{self._operation_dir(operation_id)}/current"
+        result = await self._run(f"cat {path} 2>/dev/null", 60)
+        if result.exit_status != 0:
+            return None
+        try:
+            return str(uuid.UUID(result.stdout.strip().splitlines()[-1]))
+        except (ValueError, IndexError):
+            return None
+
+    async def _read_int(self, path: str) -> int | None:
+        result = await self._run(f"cat {path} 2>/dev/null", 60)
+        if result.exit_status != 0:
+            return None
+        try:
+            return int(result.stdout.strip().splitlines()[-1])
+        except (ValueError, IndexError):
+            return None
+
+    async def snapshot(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        previous_token: str | None = None,
+        diagnostic_evidence: dict[str, str] | None = None,
+    ) -> CommandSnapshot:
+        prefix = self._attempt_prefix(handle.operation_id, handle.attempt_id)
+        pid = await self._read_int(f"{prefix}.pid") or handle.process_id
+        pgid = await self._read_int(f"{prefix}.pgid") or handle.process_group_id
+        started = await self._read_int(f"{prefix}.started") or int(time.time())
+        exit_status = await self._read_int(f"{prefix}.exit")
+        alive_result = await self._run(f"kill -0 {pid} 2>/dev/null", 60)
+        alive = alive_result.exit_status == 0
+        stat_result = await self._run(
+            f"stat -c '%s %Y' {prefix}.stdout {prefix}.stderr 2>/dev/null",
+            60,
+        )
+        sizes: list[int] = []
+        mtimes: list[int] = []
+        for line in stat_result.stdout.splitlines():
+            try:
+                size_text, mtime_text = line.split()[-2:]
+                sizes.append(int(size_text))
+                mtimes.append(int(mtime_text))
+            except (ValueError, IndexError):
+                continue
+        stdout = await self._run(f"tail -c 8000 {prefix}.stdout 2>/dev/null", 60)
+        stderr = await self._run(f"tail -c 8000 {prefix}.stderr 2>/dev/null", 60)
+        process = await self._run(
+            f"ps -o etimes=,time=,stat=,wchan= -p {pid} 2>/dev/null",
+            60,
+        )
+        cpu_seconds: float | None = None
+        process_state: str | None = None
+        if process.stdout.strip():
+            fields = process.stdout.strip().split()
+            if len(fields) >= 3:
+                process_state = " ".join(fields[2:])
+                try:
+                    parts = [int(part) for part in fields[1].split(":")]
+                    cpu_seconds = float(
+                        sum(
+                            value * (60**index)
+                            for index, value in enumerate(reversed(parts))
+                        )
+                    )
+                except ValueError:
+                    pass
+        now = time.time()
+        snapshot = CommandSnapshot(
+            operation_id=handle.operation_id,
+            attempt_id=handle.attempt_id,
+            context=handle.context,
+            elapsed_seconds=max(0.0, now - started),
+            process_alive=alive,
+            exit_status=exit_status,
+            stdout_tail=stdout.stdout if stdout.exit_status == 0 else "",
+            stderr_tail=stderr.stdout if stderr.exit_status == 0 else "",
+            output_bytes=sum(sizes),
+            seconds_since_output=max(0.0, now - max(mtimes or [started])),
+            cpu_seconds=cpu_seconds,
+            process_state=process_state,
+            process_id=pid,
+            process_group_id=pgid,
+            diagnostic_evidence=diagnostic_evidence,
+        )
+        snapshot.output_changed = (
+            previous_token is not None and snapshot.progress_token != previous_token
+        )
+        return snapshot
+
+    async def read_output(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> tuple[list[OutputChunk], int, int]:
+        prefix = self._attempt_prefix(handle.operation_id, handle.attempt_id)
+        chunks: list[OutputChunk] = []
+        next_offsets: list[int] = []
+        for stream, offset in (("stdout", stdout_offset), ("stderr", stderr_offset)):
+            safe_offset = max(0, int(offset))
+            result = await self._run(
+                f"tail -c +{safe_offset + 1} {prefix}.{stream} 2>/dev/null",
+                60,
+            )
+            text = result.stdout if result.exit_status == 0 else ""
+            next_offset = safe_offset + len(text.encode("utf-8"))
+            next_offsets.append(next_offset)
+            if text:
+                chunks.append(OutputChunk(stream=stream, text=text, offset=next_offset))
+        return chunks, next_offsets[0], next_offsets[1]
+
+    async def diagnose(self, handle: ManagedCommandHandle) -> dict[str, str]:
+        pid = int(handle.process_id)
+        probes = {
+            "process_tree": (
+                f"ps -o pid,ppid,pgid,stat,etime,time,wchan:32,args -p {pid} --no-headers "
+                f"2>/dev/null; ps --ppid {pid} -o pid,ppid,pgid,stat,etime,time,args "
+                "--no-headers 2>/dev/null"
+            ),
+            "resources": "LC_ALL=C free -m 2>/dev/null; df -Pk . 2>/dev/null",
+            "network": f"ss -tpn 2>/dev/null | grep -F 'pid={pid},' | head -n 20",
+        }
+        evidence: dict[str, str] = {}
+        for name, command in probes.items():
+            result = await self._run(command, 60)
+            evidence[name] = redact_text(result.stdout or result.stderr or "unavailable", tail=True)
+        return evidence
+
+    async def stop(self, handle: ManagedCommandHandle) -> bool:
+        current = await self.current_attempt_id(handle.operation_id)
+        if current != handle.attempt_id:
+            return False
+        snapshot = await self.snapshot(handle)
+        if not snapshot.process_alive:
+            return True
+        pgid = int(snapshot.process_group_id or handle.process_group_id)
+        await self._run(
+            f"kill -TERM -- -{pgid} 2>/dev/null || true; "
+            f"i=0; while kill -0 {snapshot.process_id} 2>/dev/null && [ $i -lt 20 ]; "
+            "do sleep 0.25; i=$((i+1)); done; "
+            f"kill -KILL -- -{pgid} 2>/dev/null || true",
+            60,
+        )
+        verified = await self._run(f"kill -0 {snapshot.process_id} 2>/dev/null", 60)
+        return verified.exit_status != 0

--- a/src/backend/app/services/managed_ssh.py
+++ b/src/backend/app/services/managed_ssh.py
@@ -7,6 +7,7 @@ not inspect command names and does not need per-command lifecycle adapters.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import re
 import time
@@ -18,6 +19,9 @@ from typing import Protocol
 from app.services.managed_commands import CommandSnapshot, OperationContext, redact_text
 
 _OPERATION_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+# 单轮增量读取的上限：远端一次刷太多日志时只取这么多，剩下的下一轮接着读。
+_MAX_OUTPUT_CHUNK_BYTES = 262_144
 
 
 class SSHResultLike(Protocol):
@@ -129,9 +133,9 @@ class SSHManagedCommands:
         pgid: int | None = None
         for _ in range(10):
             with contextlib.suppress(Exception):
-                pid = await self._read_int(f"{prefix}.pid")
+                pid = await self._read_positive_int(f"{prefix}.pid")
                 if pid is not None:
-                    pgid = await self._read_int(f"{prefix}.pgid") or pid
+                    pgid = await self._read_positive_int(f"{prefix}.pgid") or pid
                     break
             await asyncio.sleep(0.1)
         pid = pid or fallback_pid
@@ -181,13 +185,13 @@ class SSHManagedCommands:
             current = await self.current_attempt_id(operation_id)
             if current is not None:
                 current_prefix = self._attempt_prefix(operation_id, current)
-                current_pid = await self._read_int(f"{current_prefix}.pid")
+                current_pid = await self._read_positive_int(f"{current_prefix}.pid")
                 current_exit = await self._read_int(f"{current_prefix}.exit")
                 if current_pid is not None and current_exit is None:
                     alive = await self._run(f"kill -0 {current_pid} 2>/dev/null", 60)
                     if alive.exit_status == 0:
                         current_pgid = (
-                            await self._read_int(f"{current_prefix}.pgid") or current_pid
+                            await self._read_positive_int(f"{current_prefix}.pgid") or current_pid
                         )
                         return ManagedCommandHandle(
                             operation_id=operation_id,
@@ -205,7 +209,12 @@ class SSHManagedCommands:
                 "ps -o pgid= -p $$ | tr -d ' ' > ${prefix}.pgid\n"
                 "date +%s > ${prefix}.started\n"
                 "touch ${prefix}.stdout ${prefix}.stderr\n"
-                f"{{ {command}; }} >${{prefix}}.stdout 2>${{prefix}}.stderr\n"
+                # 命令单独成行：写成 `{ cmd; }` 时，只要 cmd 以注释收尾
+                # （`bash run.sh # 说明`），后面的 `; }` 会被一起注释掉，
+                # 整个启动脚本变成语法错误。换行后注释只吃掉它自己那一行。
+                "{\n"
+                f"{command}\n"
+                "} >${prefix}.stdout 2>${prefix}.stderr\n"
                 "status=$?\n"
                 "printf '%s\\n' \"$status\" > ${prefix}.exit.tmp\n"
                 "mv ${prefix}.exit.tmp ${prefix}.exit\n"
@@ -295,6 +304,16 @@ class SSHManagedCommands:
         except (ValueError, IndexError):
             return None
 
+    async def _read_positive_int(self, path: str) -> int | None:
+        """读 pid / pgid 专用：非正数一律当读失败。
+
+        这些值会拼进 ``kill -- -<pgid>``。文件被截断或写坏时读出 0 / 负数，
+        再送进 kill 就不是"没杀成"而是打偏——0 指调用方自己的进程组，
+        -1 在 kill 语义里是"所有能签名的进程"。宁可当没读到，回退到 handle。
+        """
+        value = await self._read_int(path)
+        return value if value is not None and value > 0 else None
+
     async def snapshot(
         self,
         handle: ManagedCommandHandle,
@@ -303,8 +322,8 @@ class SSHManagedCommands:
         diagnostic_evidence: dict[str, str] | None = None,
     ) -> CommandSnapshot:
         prefix = self._attempt_prefix(handle.operation_id, handle.attempt_id)
-        pid = await self._read_int(f"{prefix}.pid") or handle.process_id
-        pgid = await self._read_int(f"{prefix}.pgid") or handle.process_group_id
+        pid = await self._read_positive_int(f"{prefix}.pid") or handle.process_id
+        pgid = await self._read_positive_int(f"{prefix}.pgid") or handle.process_group_id
         started = await self._read_int(f"{prefix}.started") or int(time.time())
         exit_status = await self._read_int(f"{prefix}.exit")
         alive_result = await self._run(f"kill -0 {pid} 2>/dev/null", 60)
@@ -379,15 +398,30 @@ class SSHManagedCommands:
         next_offsets: list[int] = []
         for stream, offset in (("stdout", stdout_offset), ("stderr", stderr_offset)):
             safe_offset = max(0, int(offset))
+            # 走 base64 拿字节：偏移量是字节口径，而 SSH 结果是解码后的 str。
+            # 直接用 len(text.encode()) 记账，遇到多字节字符被切断或非法 UTF-8
+            # （中文日志、带 unicode 的进度条都会）就会与真实消费字节数错位，
+            # 下一轮要么重复吐要么吞掉一段。head -c 同时给单轮读取封顶，
+            # 免得两次轮询之间刷了几百 MB 日志被整包拉回后端。
             result = await self._run(
-                f"tail -c +{safe_offset + 1} {prefix}.{stream} 2>/dev/null",
+                f"tail -c +{safe_offset + 1} {prefix}.{stream} 2>/dev/null "
+                f"| head -c {_MAX_OUTPUT_CHUNK_BYTES} | base64 | tr -d '\\n'",
                 60,
             )
-            text = result.stdout if result.exit_status == 0 else ""
-            next_offset = safe_offset + len(text.encode("utf-8"))
+            raw = b""
+            if result.exit_status == 0 and result.stdout.strip():
+                with contextlib.suppress(Exception):
+                    raw = base64.b64decode(result.stdout.strip(), validate=True)
+            next_offset = safe_offset + len(raw)
             next_offsets.append(next_offset)
-            if text:
-                chunks.append(OutputChunk(stream=stream, text=text, offset=next_offset))
+            if raw:
+                chunks.append(
+                    OutputChunk(
+                        stream=stream,
+                        text=raw.decode("utf-8", errors="replace"),
+                        offset=next_offset,
+                    )
+                )
         return chunks, next_offsets[0], next_offsets[1]
 
     async def diagnose(self, handle: ManagedCommandHandle) -> dict[str, str]:

--- a/src/backend/app/services/managed_ssh.py
+++ b/src/backend/app/services/managed_ssh.py
@@ -317,6 +317,35 @@ class SSHManagedCommands:
         except (ValueError, IndexError):
             return None
 
+    async def recover_current(
+        self, context: OperationContext
+    ) -> ManagedCommandHandle | None:
+        """Recover the durable handle most recently selected for an operation.
+
+        Unlike :meth:`start`, recovery also returns an attempt which has already
+        written its exit status.  A worker can therefore finish bookkeeping for
+        the exact remote command it launched before the restart, instead of
+        starting a duplicate or falling back to legacy ``run.log/run.exit`` files.
+        """
+        operation_id = self._validate_operation_id(context.operation)
+        # Re-read the pointer after recovering the pid/pgid.  A concurrent launch
+        # may rotate ``current`` while these files are being inspected; observing
+        # it is safe, but returning it as the current logical operation is not.
+        for _ in range(2):
+            attempt_id = await self.current_attempt_id(operation_id)
+            if attempt_id is None:
+                return None
+            handle = await self._recover_started_handle(
+                operation_id=operation_id,
+                attempt_id=attempt_id,
+                context=context,
+            )
+            if handle is None:
+                return None
+            if await self.current_attempt_id(operation_id) == attempt_id:
+                return handle
+        return None
+
     async def _read_int(self, path: str) -> int | None:
         result = await self._run(f"cat {path} 2>/dev/null", 60)
         if result.exit_status != 0:

--- a/src/backend/app/services/managed_ssh.py
+++ b/src/backend/app/services/managed_ssh.py
@@ -53,6 +53,27 @@ class OutputChunk:
     offset: int
 
 
+@dataclass(slots=True, frozen=True)
+class ManagedGPUUsage:
+    """GPU processes which can be attributed to one managed process group."""
+
+    status: str
+    process_alive: bool
+    process_ids: tuple[int, ...] = ()
+    used_memory_mib: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class ManagedStopResult:
+    """Verified result of an attempt-scoped remote stop request."""
+
+    status: str
+    confirmed: bool
+
+    def __bool__(self) -> bool:
+        return self.confirmed
+
+
 class ManagedCommandLaunchError(RuntimeError):
     """A managed operation failed before a durable handle could be recovered."""
 
@@ -207,6 +228,7 @@ class SSHManagedCommands:
                 f"prefix={prefix}\n"
                 "echo $$ > ${prefix}.pid\n"
                 "ps -o pgid= -p $$ | tr -d ' ' > ${prefix}.pgid\n"
+                "awk '{print $22}' /proc/$$/stat > ${prefix}.start_ticks 2>/dev/null || true\n"
                 "date +%s > ${prefix}.started\n"
                 "touch ${prefix}.stdout ${prefix}.stderr\n"
                 # 命令单独成行：写成 `{ cmd; }` 时，只要 cmd 以注释收尾
@@ -441,20 +463,131 @@ class SSHManagedCommands:
             evidence[name] = redact_text(result.stdout or result.stderr or "unavailable", tail=True)
         return evidence
 
-    async def stop(self, handle: ManagedCommandHandle) -> bool:
+    async def gpu_usage(self, handle: ManagedCommandHandle) -> ManagedGPUUsage:
+        """Return GPU use attributable to this attempt, never machine-wide use.
+
+        The process group is the durable identity of a managed command.  We
+        deliberately do not treat an unrelated PID from ``nvidia-smi`` as this
+        command merely because it runs on the same host.
+        """
         current = await self.current_attempt_id(handle.operation_id)
         if current != handle.attempt_id:
-            return False
+            return ManagedGPUUsage(status="superseded", process_alive=False)
         snapshot = await self.snapshot(handle)
         if not snapshot.process_alive:
-            return True
+            return ManagedGPUUsage(status="exited", process_alive=False)
+
         pgid = int(snapshot.process_group_id or handle.process_group_id)
-        await self._run(
-            f"kill -TERM -- -{pgid} 2>/dev/null || true; "
-            f"i=0; while kill -0 {snapshot.process_id} 2>/dev/null && [ $i -lt 20 ]; "
-            "do sleep 0.25; i=$((i+1)); done; "
-            f"kill -KILL -- -{pgid} 2>/dev/null || true",
+        processes = await self._run("ps -eo pid=,ppid=,pgid= 2>/dev/null", 60)
+        if processes.exit_status != 0:
+            return ManagedGPUUsage(status="process_probe_unavailable", process_alive=True)
+
+        rows: dict[int, tuple[int, int]] = {}
+        for line in processes.stdout.splitlines():
+            try:
+                pid, ppid, row_pgid = (int(value) for value in line.split()[:3])
+            except (ValueError, IndexError):
+                continue
+            rows[pid] = (ppid, row_pgid)
+        related = {pid for pid, (_, row_pgid) in rows.items() if row_pgid == pgid}
+        # Include descendants as a defensive fallback for shells which create a
+        # separate process group.  This remains command-scoped and does not use
+        # executable-name adapters.
+        changed = True
+        while changed:
+            changed = False
+            for pid, (ppid, _) in rows.items():
+                if ppid in related and pid not in related:
+                    related.add(pid)
+                    changed = True
+
+        gpu = await self._run(
+            "nvidia-smi --query-compute-apps=pid,used_memory "
+            "--format=csv,noheader,nounits 2>/dev/null",
             60,
         )
-        verified = await self._run(f"kill -0 {snapshot.process_id} 2>/dev/null", 60)
-        return verified.exit_status != 0
+        if gpu.exit_status != 0:
+            return ManagedGPUUsage(status="gpu_probe_unavailable", process_alive=True)
+        matches: list[int] = []
+        used_memory = 0
+        for line in gpu.stdout.splitlines():
+            fields = [field.strip() for field in line.split(",", 1)]
+            try:
+                pid = int(fields[0])
+                memory = int(fields[1])
+            except (ValueError, IndexError):
+                continue
+            if pid in related:
+                matches.append(pid)
+                used_memory += max(0, memory)
+        return ManagedGPUUsage(
+            status="active" if matches else "idle",
+            process_alive=True,
+            process_ids=tuple(sorted(matches)),
+            used_memory_mib=used_memory,
+        )
+
+    async def stop(self, handle: ManagedCommandHandle) -> ManagedStopResult:
+        """Stop only the still-current process identity represented by ``handle``.
+
+        The former implementation checked ``current`` and process metadata in
+        separate SSH commands before signalling.  A new attempt (or PID reuse)
+        could slip into those gaps.  This script shares the launch lock and
+        validates attempt, PID/PGID, and (when available) Linux start ticks in
+        the same remote critical section which sends the signal.
+        """
+        operation_dir = self._operation_dir(handle.operation_id)
+        prefix = self._attempt_prefix(handle.operation_id, handle.attempt_id)
+        expected_pid = int(handle.process_id)
+        expected_pgid = int(handle.process_group_id)
+        if expected_pid <= 0 or expected_pgid <= 0:
+            return ManagedStopResult(status="invalid_identity", confirmed=False)
+        script = (
+            "#!/usr/bin/env bash\n"
+            "# polaris-managed-stop\n"
+            "set +e\n"
+            f"operation_dir={operation_dir}\n"
+            f"prefix={prefix}\n"
+            f"expected_attempt={handle.attempt_id}\n"
+            f"expected_pid={expected_pid}\n"
+            f"expected_pgid={expected_pgid}\n"
+            "lock=${operation_dir}/launch.lock\n"
+            "i=0\n"
+            "until mkdir \"$lock\" 2>/dev/null; do\n"
+            "  i=$((i+1)); [ $i -lt 40 ] || { printf 'lock_busy\\n'; exit 75; }\n"
+            "  sleep 0.25\n"
+            "done\n"
+            "trap 'rmdir \"$lock\" 2>/dev/null || true' EXIT\n"
+            "current=$(cat \"${operation_dir}/current\" 2>/dev/null)\n"
+            "[ \"$current\" = \"$expected_attempt\" ] || "
+            "{ printf 'attempt_changed\\n'; exit 76; }\n"
+            "pid=$(cat \"${prefix}.pid\" 2>/dev/null)\n"
+            "pgid=$(cat \"${prefix}.pgid\" 2>/dev/null)\n"
+            "case $pid:$pgid in *[!0-9:]*|:*) printf 'invalid_identity\\n'; exit 76;; esac\n"
+            "[ \"$pid\" = \"$expected_pid\" ] && [ \"$pgid\" = \"$expected_pgid\" ] || "
+            "{ printf 'identity_changed\\n'; exit 76; }\n"
+            "if ! kill -0 \"$pid\" 2>/dev/null; then printf 'already_exited\\n'; exit 0; fi\n"
+            "saved_ticks=$(cat \"${prefix}.start_ticks\" 2>/dev/null)\n"
+            "if [ -n \"$saved_ticks\" ]; then\n"
+            "  current_ticks=$(awk '{print $22}' \"/proc/$pid/stat\" 2>/dev/null)\n"
+            "  [ \"$current_ticks\" = \"$saved_ticks\" ] || "
+            "{ printf 'process_reused\\n'; exit 76; }\n"
+            "fi\n"
+            "kill -TERM -- -\"$pgid\" 2>/dev/null || true\n"
+            "i=0\n"
+            "while kill -0 \"$pid\" 2>/dev/null && [ $i -lt 20 ]; do "
+            "sleep 0.25; i=$((i+1)); done\n"
+            "if kill -0 \"$pid\" 2>/dev/null; then\n"
+            "  kill -KILL -- -\"$pgid\" 2>/dev/null || true\n"
+            "  sleep 0.25\n"
+            "fi\n"
+            "if kill -0 \"$pid\" 2>/dev/null; then printf 'stop_unconfirmed\\n'; exit 1; fi\n"
+            "printf 'stopped\\n'\n"
+        )
+        result = await self._run(script, 70)
+        status = (result.stdout or "").strip().splitlines()
+        outcome = status[-1] if status else "stop_unconfirmed"
+        return ManagedStopResult(
+            status=outcome,
+            confirmed=result.exit_status == 0 and outcome in {"stopped", "already_exited"},
+        )

--- a/src/backend/app/services/ssh_exec.py
+++ b/src/backend/app/services/ssh_exec.py
@@ -25,6 +25,8 @@ from app.models.ssh_credential import SSHCredential
 from app.services.managed_commands import CommandSnapshot, OperationContext, RepairScope
 from app.services.managed_ssh import (
     ManagedCommandHandle,
+    ManagedGPUUsage,
+    ManagedStopResult,
     OutputChunk,
     SSHManagedCommands,
 )
@@ -533,7 +535,12 @@ class SSHExecutor:
     ) -> dict[str, str]:
         return await self._managed_commands().diagnose(handle)
 
-    async def stop_managed_command(self, handle: ManagedCommandHandle) -> bool:
+    async def managed_command_gpu_usage(
+        self, handle: ManagedCommandHandle
+    ) -> ManagedGPUUsage:
+        return await self._managed_commands().gpu_usage(handle)
+
+    async def stop_managed_command(self, handle: ManagedCommandHandle) -> ManagedStopResult:
         return await self._managed_commands().stop(handle)
 
     # ---- 白名单命令模板（唯一的远程命令来源） ----

--- a/src/backend/app/services/ssh_exec.py
+++ b/src/backend/app/services/ssh_exec.py
@@ -504,6 +504,11 @@ class SSHExecutor:
             attempt_id=attempt_id,
         )
 
+    async def recover_managed_command(
+        self, context: OperationContext
+    ) -> ManagedCommandHandle | None:
+        return await self._managed_commands().recover_current(context)
+
     async def inspect_managed_command(
         self,
         handle: ManagedCommandHandle,

--- a/src/backend/app/services/ssh_exec.py
+++ b/src/backend/app/services/ssh_exec.py
@@ -22,6 +22,12 @@ from app.core.db import get_sessionmaker
 from app.core.security import decrypt_secret
 from app.models.activity import Activity
 from app.models.ssh_credential import SSHCredential
+from app.services.managed_commands import CommandSnapshot, OperationContext, RepairScope
+from app.services.managed_ssh import (
+    ManagedCommandHandle,
+    OutputChunk,
+    SSHManagedCommands,
+)
 
 logger = logging.getLogger("polaris.ssh")
 
@@ -474,6 +480,62 @@ class SSHExecutor:
         await self._audit(command)
         return await self._session.run(command, timeout=timeout)
 
+    def _managed_commands(self) -> SSHManagedCommands:
+        """Return the command-name-agnostic durable execution backend."""
+        return SSHManagedCommands(
+            session=self._session,
+            run=self._run,
+            shell_workdir=self.workdir,
+            sftp_workdir=self._sftp_dir,
+        )
+
+    async def start_managed_command(
+        self,
+        context: OperationContext,
+        command: str,
+        *,
+        attempt_id: str | None = None,
+    ) -> ManagedCommandHandle:
+        return await self._managed_commands().start(
+            context,
+            command,
+            attempt_id=attempt_id,
+        )
+
+    async def inspect_managed_command(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        previous_token: str | None = None,
+        diagnostic_evidence: dict[str, str] | None = None,
+    ) -> CommandSnapshot:
+        return await self._managed_commands().snapshot(
+            handle,
+            previous_token=previous_token,
+            diagnostic_evidence=diagnostic_evidence,
+        )
+
+    async def read_managed_output(
+        self,
+        handle: ManagedCommandHandle,
+        *,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> tuple[list[OutputChunk], int, int]:
+        return await self._managed_commands().read_output(
+            handle,
+            stdout_offset=stdout_offset,
+            stderr_offset=stderr_offset,
+        )
+
+    async def diagnose_managed_command(
+        self, handle: ManagedCommandHandle
+    ) -> dict[str, str]:
+        return await self._managed_commands().diagnose(handle)
+
+    async def stop_managed_command(self, handle: ManagedCommandHandle) -> bool:
+        return await self._managed_commands().stop(handle)
+
     # ---- 白名单命令模板（唯一的远程命令来源） ----
 
     async def mkdir_workdir(self) -> SSHResult:
@@ -516,6 +578,21 @@ class SSHExecutor:
         return await self._run(
             f"cd {self.workdir} && {{ {ENV_SOURCE_PREFIX} bash run.sh --smoke; }}",
             timeout=timeout,
+        )
+
+    async def launch_managed_smoke(self) -> ManagedCommandHandle:
+        command = f"cd {self.workdir} && {{ {ENV_SOURCE_PREFIX} bash run.sh --smoke; }}"
+        return await self.start_managed_command(
+            OperationContext(
+                phase="application.smoke",
+                operation="application-smoke",
+                display_command="bash run.sh --smoke",
+                target=self.host,
+                soft_timeout_seconds=300,
+                stall_timeout_seconds=600,
+                repair_scope=RepairScope.APPLICATION_FILES,
+            ),
+            command,
         )
 
     async def run_plot(self, timeout: float = PLOT_TIMEOUT_SECONDS) -> SSHResult:
@@ -602,6 +679,24 @@ class SSHExecutor:
             raise SSHExecError(f"launch_run 未返回 PID：{result.stdout!r}") from e
         return pid, command
 
+    async def launch_managed_run(self) -> ManagedCommandHandle:
+        command = (
+            f"cd {self.workdir} && {{ export PYTHONUNBUFFERED=1; "
+            f"{ENV_SOURCE_PREFIX} stdbuf -oL -eL bash run.sh; }}"
+        )
+        return await self.start_managed_command(
+            OperationContext(
+                phase="application.run",
+                operation="experiment-run",
+                display_command="bash run.sh",
+                target=self.host,
+                soft_timeout_seconds=600,
+                stall_timeout_seconds=900,
+                repair_scope=RepairScope.APPLICATION_FILES,
+            ),
+            command,
+        )
+
     async def check_pid(self, pid: int) -> bool:
         result = await self._run(f"kill -0 {int(pid)} 2>/dev/null && echo alive || echo dead")
         return "alive" in result.stdout
@@ -654,6 +749,24 @@ class SSHExecutor:
         except (ValueError, IndexError) as e:
             raise SSHExecError(f"launch_setup 未返回 PID：{result.stdout!r}") from e
         return pid, command
+
+    async def launch_managed_setup(self) -> ManagedCommandHandle:
+        command = f"cd {self.workdir} && {self._install_script()}"
+        return await self.start_managed_command(
+            OperationContext(
+                phase="dependency.install",
+                operation="dependency-install",
+                display_command="install generated experiment dependencies",
+                target=self.host,
+                soft_timeout_seconds=600,
+                stall_timeout_seconds=900,
+                repair_scope=RepairScope.DEPENDENCY_FILES,
+            ),
+            command,
+        )
+
+    async def prepare_managed(self) -> ManagedCommandHandle | None:
+        return None
 
     async def read_setup_exit(self) -> int | None:
         result = await self._run(f"cat {self.workdir}/setup.exit 2>/dev/null")

--- a/src/backend/app/services/voyage_messages.py
+++ b/src/backend/app/services/voyage_messages.py
@@ -9,7 +9,7 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,6 +18,7 @@ from app.models.voyage import VoyageMessage
 
 _APPEND_RETRIES = 3
 TEXT_MAX_CHARS = 8_000
+STOPPING_STATUS = "stopping"
 
 
 class MessageSeqConflictError(Exception):
@@ -143,6 +144,41 @@ def guidance_text(messages: list[VoyageMessage]) -> str:
 # ---- ask（agent 向用户提问）----
 
 
+async def claim_open_ask_for_stop(session: AsyncSession, ask_id: uuid.UUID) -> bool:
+    """Atomically reserve one open ask before any remote stop side effect.
+
+    User answers and the unattended watchdog share this transition.  Exactly
+    one caller can move ``open -> stopping``; losers must not signal the remote
+    process.  The commit deliberately precedes SSH so no database transaction
+    is held while SSH audit writes use an independent session.
+    """
+    result = await session.execute(
+        update(VoyageMessage)
+        .where(
+            VoyageMessage.id == ask_id,
+            VoyageMessage.kind == "ask",
+            VoyageMessage.status == "open",
+        )
+        .values(status=STOPPING_STATUS)
+    )
+    if result.rowcount == 0:
+        await session.rollback()
+        return False
+    await session.commit()
+    return True
+
+
+async def release_stop_claim(session: AsyncSession, ask_id: uuid.UUID) -> bool:
+    """Return an uncompleted stop claim to the answerable state."""
+    result = await session.execute(
+        update(VoyageMessage)
+        .where(VoyageMessage.id == ask_id, VoyageMessage.status == STOPPING_STATUS)
+        .values(status="open")
+    )
+    await session.commit()
+    return result.rowcount == 1
+
+
 async def open_ask(session: AsyncSession, run_id: uuid.UUID) -> VoyageMessage | None:
     """当前等回答的提问（最多一个活跃；防御性取最新一条）。"""
     stmt = (
@@ -200,14 +236,16 @@ async def answer_of(session: AsyncSession, ask: VoyageMessage) -> VoyageMessage 
 
 
 async def supersede_open_asks(session: AsyncSession, run_id: uuid.UUID) -> int:
-    """把所有 open 提问置 superseded（cancel / 新提问覆盖旧提问时用）。
+    """把所有仍活跃的提问置 superseded（cancel / 新提问覆盖旧提问时用）。
 
+    ``stopping`` 也必须覆盖：取消可能发生在停止权已抢占、SSH 尚未返回的窗口；
+    让取消赢得任务状态，同时远端停止仍可安全完成，但旧回答不能重新拉起任务。
     只改内存对象并 flush，由调用方 commit。返回受影响条数。
     """
     stmt = select(VoyageMessage).where(
         VoyageMessage.run_id == run_id,
         VoyageMessage.kind == "ask",
-        VoyageMessage.status == "open",
+        VoyageMessage.status.in_(("open", STOPPING_STATUS)),
     )
     rows = list((await session.execute(stmt)).scalars().all())
     for m in rows:

--- a/src/backend/tests/fake_ssh.py
+++ b/src/backend/tests/fake_ssh.py
@@ -118,6 +118,7 @@ class FakeSSHSession:
             server.managed_prefix_by_pid[pid] = prefix
             server.managed_files[f"{prefix}.pid"] = str(pid)
             server.managed_files[f"{prefix}.pgid"] = str(pid)
+            server.managed_files[f"{prefix}.start_ticks"] = str(pid * 100)
             started = int(time.time()) - (1000 if exit_status is None else 1)
             server.managed_files[f"{prefix}.started"] = str(started)
             server.managed_files[f"{prefix}.stdout"] = stdout
@@ -155,6 +156,30 @@ class FakeSSHSession:
             if "base64" in command:
                 return SSHResult(0, base64.b64encode(raw).decode(), "")
             return SSHResult(0, raw.decode(errors="replace"), "")
+        if "# polaris-managed-stop" in command:
+            def assignment(name: str) -> str | None:
+                match = re.search(rf"^{name}=([^\n]+)$", command, re.MULTILINE)
+                return match.group(1) if match else None
+
+            operation_dir = assignment("operation_dir")
+            prefix = assignment("prefix")
+            attempt = assignment("expected_attempt")
+            expected_pid = assignment("expected_pid")
+            expected_pgid = assignment("expected_pgid")
+            if not all((operation_dir, prefix, attempt, expected_pid, expected_pgid)):
+                return SSHResult(76, "invalid_identity\n", "")
+            current = server.managed_files.get(f"{operation_dir}/current")
+            if current != attempt:
+                return SSHResult(76, "attempt_changed\n", "")
+            pid = server.managed_files.get(f"{prefix}.pid")
+            pgid = server.managed_files.get(f"{prefix}.pgid")
+            if pid != expected_pid or pgid != expected_pgid:
+                return SSHResult(76, "identity_changed\n", "")
+            if f"{prefix}.exit" in server.managed_files:
+                return SSHResult(0, "already_exited\n", "")
+            server.managed_files[f"{prefix}.exit"] = "-15"
+            server.killed.append(int(expected_pgid))
+            return SSHResult(0, "stopped\n", "")
         if command.startswith("ps -o etimes="):
             return SSHResult(0, "1 00:00:01 S wait\n", "")
         if "kill -TERM -- -" in command:

--- a/src/backend/tests/fake_ssh.py
+++ b/src/backend/tests/fake_ssh.py
@@ -25,6 +25,7 @@ class FakeSSHServer:
     managed_files: dict[str, str] = field(default_factory=dict)
     managed_pid: int = 7373
     managed_prefix_by_pid: dict[int, str] = field(default_factory=dict)
+    managed_output_age_seconds: int = 0
 
     connect_error: str | None = None  # 置为字符串则 connect 抛 ConnectionError
     venv_exit: int = 0
@@ -42,7 +43,9 @@ class FakeSSHServer:
     # 资源预检用：本机文件内容（cat <path> → 内容，如模型 config.json）；未登记 = 缺失
     host_files: dict[str, str] = field(default_factory=dict)
     host_paths: set[str] = field(default_factory=set)  # test -e <path> 存在的路径（数据集目录等）
-    smoke_exits: list[int] = field(default_factory=list)  # 逐次弹出；耗尽后恒 0
+    smoke_exits: list[int | None] = field(
+        default_factory=list
+    )  # 逐次弹出；None = managed smoke 仍在运行，耗尽后恒 0
     smoke_stderr: str = "Traceback (most recent call last): boom"
     run_log: str = ""
     run_exit: int | None = 0  # None = 进程一直不结束（cat run.exit 读不到）
@@ -139,8 +142,10 @@ class FakeSSHSession:
             return SSHResult(0, f"{value}\n", "") if value is not None else SSHResult(1, "", "")
         if command.startswith("stat -c") and ".polaris/operations/" in command:
             paths = command.split(" 2>/dev/null", 1)[0].split()[-2:]
-            now = int(time.time())
-            rows = [f"{len(server.managed_files.get(path, '').encode())} {now}" for path in paths]
+            mtime = int(time.time()) - server.managed_output_age_seconds
+            rows = [
+                f"{len(server.managed_files.get(path, '').encode())} {mtime}" for path in paths
+            ]
             return SSHResult(0, "\n".join(rows) + "\n", "")
         if command.startswith("tail -c") and ".polaris/operations/" in command:
             path = command.split(" 2>/dev/null", 1)[0].split()[-1]

--- a/src/backend/tests/fake_ssh.py
+++ b/src/backend/tests/fake_ssh.py
@@ -8,6 +8,7 @@
 """
 
 import re
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
@@ -20,6 +21,9 @@ class FakeSSHServer:
     files: dict[str, str | bytes] = field(default_factory=dict)
     connects: list[tuple[str, int, str]] = field(default_factory=list)
     killed: list[int] = field(default_factory=list)
+    managed_files: dict[str, str] = field(default_factory=dict)
+    managed_pid: int = 7373
+    managed_prefix_by_pid: dict[int, str] = field(default_factory=dict)
 
     connect_error: str | None = None  # 置为字符串则 connect 抛 ConnectionError
     venv_exit: int = 0
@@ -68,6 +72,91 @@ class FakeSSHSession:
         server.commands.append(command)
         if server.on_command is not None:
             await server.on_command(command)
+
+        # Generic managed-command envelope.  Tests vary the resulting output/exit
+        # through the existing setup/smoke/run fields; lifecycle handling itself
+        # is command-name agnostic.
+        if "nohup setsid bash " in command and ".polaris/operations/" in command:
+            match = re.search(r"nohup setsid bash (\S+)\.sh", command)
+            assert match is not None
+            prefix = match.group(1)
+            operation_match = re.search(r"/operations/([^/]+)/attempts/", prefix)
+            operation = operation_match.group(1) if operation_match else "unknown"
+            launcher_path = f"{prefix[2:] if prefix.startswith('~/') else prefix}.sh"
+            launcher = server.files.get(launcher_path)
+            if isinstance(launcher, str):
+                server.commands.append(launcher)
+                if server.on_command is not None:
+                    await server.on_command(launcher)
+            exit_status: int | None = 0
+            stdout = ""
+            stderr = ""
+            if operation == "dependency-install":
+                exit_status = (
+                    server.setup_exits.pop(0)
+                    if server.setup_exits
+                    else server.setup_exit
+                )
+                stderr = server.setup_log if exit_status else ""
+            elif operation == "application-smoke":
+                exit_status = server.smoke_exits.pop(0) if server.smoke_exits else 0
+                stdout = "smoke ok\n" if exit_status == 0 else ""
+                stderr = server.smoke_stderr if exit_status else ""
+            elif operation == "experiment-run":
+                if server.run_logs:
+                    server.run_log = server.run_logs.pop(0)
+                if server.run_exits:
+                    server.run_exit = server.run_exits.pop(0)
+                exit_status = server.run_exit
+                stdout = server.run_log
+            if operation == "experiment-run":
+                pid = server.pid
+            else:
+                pid = server.managed_pid
+                server.managed_pid += 1
+            server.managed_prefix_by_pid[pid] = prefix
+            server.managed_files[f"{prefix}.pid"] = str(pid)
+            server.managed_files[f"{prefix}.pgid"] = str(pid)
+            started = int(time.time()) - (1000 if exit_status is None else 1)
+            server.managed_files[f"{prefix}.started"] = str(started)
+            server.managed_files[f"{prefix}.stdout"] = stdout
+            server.managed_files[f"{prefix}.stderr"] = stderr
+            if exit_status is not None:
+                server.managed_files[f"{prefix}.exit"] = str(exit_status)
+            return SSHResult(0, f"{pid}\n", "")
+        if command.startswith("printf ") and "/operations/" in command and "/current" in command:
+            match = re.search(
+                r"printf '%s\\n' ([0-9a-f-]+) > (\S+)\.tmp && mv \S+ (\S+)", command
+            )
+            if match:
+                server.managed_files[match.group(3)] = match.group(1)
+            return SSHResult(0, "", "")
+        if command.startswith("cat ") and ".polaris/operations/" in command:
+            path = command.split()[1]
+            value = server.managed_files.get(path)
+            return SSHResult(0, f"{value}\n", "") if value is not None else SSHResult(1, "", "")
+        if command.startswith("stat -c") and ".polaris/operations/" in command:
+            paths = command.split(" 2>/dev/null", 1)[0].split()[-2:]
+            now = int(time.time())
+            rows = [f"{len(server.managed_files.get(path, '').encode())} {now}" for path in paths]
+            return SSHResult(0, "\n".join(rows) + "\n", "")
+        if command.startswith("tail -c") and ".polaris/operations/" in command:
+            path = command.split(" 2>/dev/null", 1)[0].split()[-1]
+            text = server.managed_files.get(path, "")
+            offset_match = re.search(r"tail -c \+(\d+)", command)
+            if offset_match:
+                text = text.encode()[int(offset_match.group(1)) - 1 :].decode()
+            return SSHResult(0, text, "")
+        if command.startswith("ps -o etimes="):
+            return SSHResult(0, "1 00:00:01 S wait\n", "")
+        if "kill -TERM -- -" in command:
+            match = re.search(r"kill -TERM -- -(\d+)", command)
+            pgid = int(match.group(1)) if match else -1
+            prefix = server.managed_prefix_by_pid.get(pgid)
+            if prefix is not None:
+                server.managed_files.setdefault(f"{prefix}.exit", "-15")
+                server.killed.append(pgid)
+            return SSHResult(0, "", "")
 
         # —— 后台脱离装依赖（launch_setup + setup.exit/setup.log 轮询）；须在通用 launch/cat 之前 ——
         if ("setup.exit" in command or "_setup_container.sh" in command) and "echo $!" in command:
@@ -135,11 +224,14 @@ class FakeSSHSession:
         if "kill -0" in command:  # check_pid：exit 已就绪则进程视为已退出
             m = re.search(r"kill -0 (\d+)", command)
             q = int(m.group(1)) if m else -1
-            if q == server.setup_pid:
+            if q in server.managed_prefix_by_pid:
+                prefix = server.managed_prefix_by_pid[q]
+                alive = f"{prefix}.exit" not in server.managed_files
+            elif q == server.setup_pid:
                 alive = server.setup_launched and server.setup_exit is None
             else:
                 alive = server.launched and server.run_exit is None
-            return SSHResult(0, "alive\n" if alive else "dead\n", "")
+            return SSHResult(0 if alive else 1, "alive\n" if alive else "dead\n", "")
         if "tail -c" in command:
             if not server.launched:
                 return SSHResult(1, "", "")

--- a/src/backend/tests/fake_ssh.py
+++ b/src/backend/tests/fake_ssh.py
@@ -7,6 +7,7 @@
 - ``on_command`` 钩子可在特定命令时机注入副作用（如把 voyage 置 cancelled）。
 """
 
+import base64
 import re
 import time
 from collections.abc import Awaitable, Callable
@@ -142,11 +143,18 @@ class FakeSSHSession:
             return SSHResult(0, "\n".join(rows) + "\n", "")
         if command.startswith("tail -c") and ".polaris/operations/" in command:
             path = command.split(" 2>/dev/null", 1)[0].split()[-1]
-            text = server.managed_files.get(path, "")
+            raw = server.managed_files.get(path, "").encode()
             offset_match = re.search(r"tail -c \+(\d+)", command)
             if offset_match:
-                text = text.encode()[int(offset_match.group(1)) - 1 :].decode()
-            return SSHResult(0, text, "")
+                raw = raw[int(offset_match.group(1)) - 1 :]
+            # 增量读取那条管道是 `tail -c +N | head -c CAP | base64 | tr -d '\n'`，
+            # 按字节截断后原样编码；快照的 `tail -c N` 走下面的原文分支。
+            head_match = re.search(r"\|\s*head -c (\d+)", command)
+            if head_match:
+                raw = raw[: int(head_match.group(1))]
+            if "base64" in command:
+                return SSHResult(0, base64.b64encode(raw).decode(), "")
+            return SSHResult(0, raw.decode(errors="replace"), "")
         if command.startswith("ps -o etimes="):
             return SSHResult(0, "1 00:00:01 S wait\n", "")
         if "kill -TERM -- -" in command:

--- a/src/backend/tests/test_experiment_env.py
+++ b/src/backend/tests/test_experiment_env.py
@@ -162,14 +162,20 @@ async def test_command_templates_source_env(client, queue_stub, fake_ssh, bus_re
     assert f"polaris_runs/{exp['id']}/llm_config.json" not in fake_ssh.files
 
     workdir = f"~/polaris_runs/{exp['id']}"
-    smoke = next(c for c in fake_ssh.commands if "--smoke" in c)
-    assert smoke == f"cd {workdir} && {{ {ENV_PREFIX} bash run.sh --smoke; }}"
-    launch = next(c for c in fake_ssh.commands if "nohup" in c and "run.sh" in c)  # run launch
+    # smoke / run 已改走 managed 封套：真正执行的命令写在启动脚本里，重定向与退出码
+    # 由封套接管，所以这里核对的是脚本里那一行内层命令——前缀固定、无可变参数的
+    # 断言意图不变，只是从「整条 SSH 命令」挪到「启动脚本里的命令行」。
+    smoke_launcher = next(c for c in fake_ssh.commands if "--smoke" in c)
+    assert f"cd {workdir} && {{ {ENV_PREFIX} bash run.sh --smoke; }}" in smoke_launcher
+    run_launcher = next(
+        c for c in fake_ssh.commands if "stdbuf -oL -eL bash run.sh" in c
+    )
     # 前缀先 export PYTHONUNBUFFERED=1、再 source env.sh、stdbuf 行缓冲跑 run.sh（日志实时刷新）
     assert (
-        f"nohup bash -c 'export PYTHONUNBUFFERED=1; {ENV_PREFIX} "
-        f"stdbuf -oL -eL bash run.sh > run.log 2>&1; echo $? > run.exit'"
-    ) in launch
+        f"cd {workdir} && {{ export PYTHONUNBUFFERED=1; "
+        f"{ENV_PREFIX} stdbuf -oL -eL bash run.sh; }}"
+    ) in run_launcher
+    # plot 仍是前台白名单模板，没有 managed 化
     plot = next(c for c in fake_ssh.commands if "plot_figures.py" in c and ".venv" in c)
     assert plot == f"cd {workdir} && {{ {ENV_PREFIX} .venv/bin/python plot_figures.py; }}"
 

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -187,6 +187,20 @@ async def _get_detail(client, headers, exp_id):
     return resp.json()
 
 
+def _managed_launches(fake_ssh, operation: str) -> int:
+    """某个 managed 操作被真正启动了几次。
+
+    数「启动」原本靠 run.sh/setup 那几条命令模板的字面量；改走 managed 封套后
+    真正的启动动作是 `nohup setsid bash <operation 目录>/<attempt>.sh`，用它来数。
+    重挂已在跑的进程不会再产生这条命令，所以这个计数仍然区分得开「重挂」与「重启一轮」。
+    """
+    return sum(
+        1
+        for command in fake_ssh.commands
+        if "nohup setsid bash " in command and f"/operations/{operation}/" in command
+    )
+
+
 async def _iterate_observation(client, headers, voyage_id):
     """末个 analyze 节点的 observation（迭代终止判定所在，docs/voyage-loop.md §7）。"""
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
@@ -486,9 +500,7 @@ async def test_cancel_at_round_start(client, queue_stub, fake_ssh, bus_recorder)
     assert detail["runs"][0]["status"] == "succeeded"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     assert resp.json()["status"] == "cancelled"
-    assert (
-        "\n".join(fake_ssh.commands).count("run.sh > run.log") == 1
-    )  # 只数 run 启动（setup 也 nohup）
+    assert _managed_launches(fake_ssh, "experiment-run") == 1  # 第 2 轮没有启动
 
 
 # ---- figures 步骤 ----
@@ -640,6 +652,12 @@ def test_primary_value_and_improvement_unit():
     assert ax.parse_metrics_json('["list"]') == []
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="managed 轮询路径重连后不写 experiment.ssh_reconnect 审计："
+    "该审计只在 actions_experiment 的旧轮询循环里写（捕获连接错误那一支），"
+    "managed 快照走的是另一条路，断连-重连对运维不再留痕。",
+)
 async def test_poll_survives_ssh_reconnect(client, queue_stub, fake_ssh, bus_recorder, monkeypatch):
     """轮询期间 SSH 瞬时断开 → 重连后继续跟踪，实验不因单次断连而失败。
 
@@ -652,8 +670,15 @@ async def test_poll_survives_ssh_reconnect(client, queue_stub, fake_ssh, bus_rec
     state = {"raised": 0}
 
     async def drop_once(command: str) -> None:
-        # 第一轮正式运行读取退出码时断连一次（cat run.exit），之后恢复
-        if command.startswith("cat") and "run.exit" in command and state["raised"] == 0:
+        # 第一轮正式运行读取退出码时断连一次，之后恢复。
+        # 退出码已随 managed 化搬到 .polaris/operations/experiment-run/attempts/<id>.exit，
+        # 原来按 run.exit 匹配的注入自此再没命中过——测试照常绿，但什么都没测。
+        if (
+            command.startswith("cat")
+            and "/operations/experiment-run/" in command
+            and ".exit" in command
+            and state["raised"] == 0
+        ):
             state["raised"] += 1
             raise ConnectionError("SSH connection closed")
 
@@ -690,8 +715,14 @@ async def test_setup_survives_ssh_reconnect(
     state = {"raised": 0}
 
     async def drop_once(command: str) -> None:
-        # 首次读 setup.exit（轮询依赖安装进度）时断连一次，之后恢复
-        if command.startswith("cat") and "setup.exit" in command and state["raised"] == 0:
+        # 首次读安装退出码（轮询依赖安装进度）时断连一次，之后恢复。
+        # 同上：managed 化后退出码在 operations/dependency-install/attempts/<id>.exit。
+        if (
+            command.startswith("cat")
+            and "/operations/dependency-install/" in command
+            and ".exit" in command
+            and state["raised"] == 0
+        ):
             state["raised"] += 1
             raise ConnectionError("SSH connection closed")
 
@@ -705,7 +736,7 @@ async def test_setup_survives_ssh_reconnect(
     assert voyage_status == "done"  # 断连没毒死航程
     assert state["raised"] == 1  # 确实注入了一次断连
     # 只启动了**一次**安装——断连是「重连接着轮询」而非「从头重装」
-    assert "\n".join(fake_ssh.commands).count("rm -f setup.exit") == 1
+    assert _managed_launches(fake_ssh, "dependency-install") == 1
     assert len(fake_ssh.connects) >= 2  # 重连过
 
     detail = await _get_detail(client, headers, exp_id)
@@ -774,6 +805,12 @@ async def test_stuck_escalates_to_approach_change(client, queue_stub, fake_ssh, 
     assert "已连续" in provider.improve_prompts[1]
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="冒烟超时不再自愈：managed 化后走确定性中断策略，"
+    "默认升级为 ask_user_while_running（航程停在 paused_ask）而不是自动改小重试。"
+    "这是产品行为变更，需要作者确认是否有意——无人值守场景下不再自动收敛。",
+)
 async def test_smoke_timeout_is_recoverable(client, queue_stub, fake_ssh, bus_recorder):
     """冒烟超时不再硬崩：诊断为『太慢/超时』→ 自动改小重试 → 通过，航程继续。
 
@@ -805,6 +842,12 @@ async def test_smoke_timeout_is_recoverable(client, queue_stub, fake_ssh, bus_re
     assert len(fake_ssh.connects) >= 2  # 超时后重连过
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="worker 重启后的重挂路径挂死：phase2 的 engine.resume 永不返回。"
+    "此前这条测试因为按旧命令模板计数、在更早的断言就失败，把挂死掩盖了。"
+    "它守的是线上 bug「每次部署重启孤儿一轮」，必须修。",
+)
 async def test_run_reattaches_after_worker_restart(client, queue_stub, fake_ssh, bus_recorder):
     """worker 重启（resume 被打断后重跑）→ run 步骤**重挂**上一轮仍在跑的远端进程，
     不再起第二轮（回归：新旧进程树共写 run.log/run.exit，每次部署重启孤儿一轮）。"""
@@ -822,22 +865,23 @@ async def test_run_reattaches_after_worker_restart(client, queue_stub, fake_ssh,
     task = asyncio.ensure_future(engine.resume(uuid.UUID(voyage_id)))
     for _ in range(200):  # 等 run 真正启动（出现 launch 命令）
         await asyncio.sleep(0.02)
-        if any("rm -f run.exit &&" in c for c in fake_ssh.commands):
+        if _managed_launches(fake_ssh, "experiment-run") >= 1:
             break
     await asyncio.sleep(0.1)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    launches_before = "\n".join(fake_ssh.commands).count("rm -f run.exit &&")
+    launches_before = _managed_launches(fake_ssh, "experiment-run")
     assert launches_before == 1  # 第一次 launch 已发生
 
     # 阶段二：远端进程已结束（run.exit=0 落盘），新 worker 重跑 resume → 应重挂而非再 launch
     fake_ssh.run_exit = 0
     engine2, _ = _make_engine(_router_with(_FixedReflectionProvider("improve")))
-    await engine2.resume(uuid.UUID(voyage_id))
+    # 加时限：重挂路径当前会永久挂起，不设界限整个测试会话都会被卡住
+    await asyncio.wait_for(engine2.resume(uuid.UUID(voyage_id)), 10)
 
-    assert "\n".join(fake_ssh.commands).count("rm -f run.exit &&") == 1  # 没有第二次 launch
+    assert _managed_launches(fake_ssh, "experiment-run") == 1  # 没有第二次 launch
     detail = await _get_detail(client, headers, exp_id)
     assert len(detail["runs"]) == 1  # 没孤儿轮
     assert detail["runs"][0]["status"] == "succeeded"

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -652,12 +652,6 @@ def test_primary_value_and_improvement_unit():
     assert ax.parse_metrics_json('["list"]') == []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="managed 轮询路径重连后不写 experiment.ssh_reconnect 审计："
-    "该审计只在 actions_experiment 的旧轮询循环里写（捕获连接错误那一支），"
-    "managed 快照走的是另一条路，断连-重连对运维不再留痕。",
-)
 async def test_poll_survives_ssh_reconnect(client, queue_stub, fake_ssh, bus_recorder, monkeypatch):
     """轮询期间 SSH 瞬时断开 → 重连后继续跟踪，实验不因单次断连而失败。
 
@@ -805,25 +799,16 @@ async def test_stuck_escalates_to_approach_change(client, queue_stub, fake_ssh, 
     assert "已连续" in provider.improve_prompts[1]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="冒烟超时不再自愈：managed 化后走确定性中断策略，"
-    "默认升级为 ask_user_while_running（航程停在 paused_ask）而不是自动改小重试。"
-    "这是产品行为变更，需要作者确认是否有意——无人值守场景下不再自动收敛。",
-)
-async def test_smoke_timeout_is_recoverable(client, queue_stub, fake_ssh, bus_recorder):
-    """冒烟超时不再硬崩：诊断为『太慢/超时』→ 自动改小重试 → 通过，航程继续。
+async def test_slow_smoke_asks_without_interrupting_remote_command(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """低置信度的 smoke 超时保留远程进程，并把决定交给用户。
 
-    回归自适应循环的一类失败：训练类实验冒烟常因规模太大而超时(TimeoutError),
-    以前直接判失败;现在当作可修失败,重连+让 LLM 把冒烟改小再试。"""
-    state = {"raised": 0}
-
-    async def timeout_once(command: str) -> None:
-        if "--smoke" in command and state["raised"] == 0:
-            state["raised"] += 1
-            raise TimeoutError("smoke timed out")
-
-    fake_ssh.on_command = timeout_once
+    这与 launch SSH 调用自身抛 TimeoutError 不同：这里命令已有 durable handle、仍在运行，
+    只是超过 soft/stall 阈值且没有足够证据证明卡死。平台不得擅自停止或重写生成文件。
+    """
+    fake_ssh.smoke_exits = [None]
+    fake_ssh.managed_output_age_seconds = 1000
     project_id, headers, exp_id, voyage_id = await _launch_experiment(
         client, budget={"max_hours": 2, "max_runs": 1}
     )
@@ -831,23 +816,21 @@ async def test_smoke_timeout_is_recoverable(client, queue_stub, fake_ssh, bus_re
         client, headers, project_id, voyage_id, _router_with(_FixedReflectionProvider("improve"))
     )
 
-    assert state["raised"] == 1  # 确实注入了一次冒烟超时
     voyage_status, _ = await _iterate_observation(client, headers, voyage_id)
-    assert voyage_status == "done"  # 没在 smoke 硬崩,跑到 analyze 并收尾
+    assert voyage_status == "paused_ask"
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    smoke = next(s for s in resp.json()["steps"] if s["action"] == "experiment.smoke")
-    assert smoke["status"] == "passed"
-    assert (smoke["observation"] or {}).get("fixes", 0) >= 1  # 记录了一次方案级修复
-    assert len(fake_ssh.connects) >= 2  # 超时后重连过
+    payload = resp.json()
+    assert payload["open_ask"]["payload"]["ask_kind"] == "managed_command"
+    assert payload["open_ask"]["payload"]["context"]["remote_operation_continues"] is True
+    smoke = next(s for s in payload["steps"] if s["action"] == "experiment.smoke")
+    assert smoke["status"] == "pending"
+    assert _managed_launches(fake_ssh, "application-smoke") == 1
+    assert _managed_launches(fake_ssh, "experiment-run") == 0
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] == "waiting_user"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="worker 重启后的重挂路径挂死：phase2 的 engine.resume 永不返回。"
-    "此前这条测试因为按旧命令模板计数、在更早的断言就失败，把挂死掩盖了。"
-    "它守的是线上 bug「每次部署重启孤儿一轮」，必须修。",
-)
 async def test_run_reattaches_after_worker_restart(client, queue_stub, fake_ssh, bus_recorder):
     """worker 重启（resume 被打断后重跑）→ run 步骤**重挂**上一轮仍在跑的远端进程，
     不再起第二轮（回归：新旧进程树共写 run.log/run.exit，每次部署重启孤儿一轮）。"""
@@ -877,8 +860,10 @@ async def test_run_reattaches_after_worker_restart(client, queue_stub, fake_ssh,
 
     # 阶段二：远端进程已结束（run.exit=0 落盘），新 worker 重跑 resume → 应重挂而非再 launch
     fake_ssh.run_exit = 0
+    managed_prefix = fake_ssh.managed_prefix_by_pid[fake_ssh.pid]
+    fake_ssh.managed_files[f"{managed_prefix}.exit"] = "0"
     engine2, _ = _make_engine(_router_with(_FixedReflectionProvider("improve")))
-    # 加时限：重挂路径当前会永久挂起，不设界限整个测试会话都会被卡住
+    # 界限防止未来回归再次卡住整个测试会话。
     await asyncio.wait_for(engine2.resume(uuid.UUID(voyage_id)), 10)
 
     assert _managed_launches(fake_ssh, "experiment-run") == 1  # 没有第二次 launch

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -259,7 +259,13 @@ async def test_experiment_full_pipeline(client, queue_stub, fake_ssh, bus_record
     assert f"mkdir -p ~/polaris_runs/{exp_id}" in joined
     assert "pip install -r requirements.txt" in joined
     assert "bash run.sh --smoke" in joined
-    assert joined.count("run.sh > run.log") == 3  # 3 轮 run launch（setup 也 nohup，按 run 标记数）
+    assert joined.count("stdbuf -oL -eL bash run.sh") == 3
+
+    resp = await client.get(f"/api/experiments/{exp_id}/terminal-logs", headers=headers)
+    assert resp.status_code == 200
+    terminal_lines = resp.json()["lines"]
+    assert any("[application-smoke][stdout]" in line for line in terminal_lines)
+    assert any("[experiment-run][stdout]" in line for line in terminal_lines)
     assert ".venv/bin/python plot_figures.py" in joined
 
     # 审计：每条远程命令都有 Activity(kind=ssh.exec)
@@ -338,30 +344,29 @@ async def test_smoke_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus
     assert resp.json()["status"] == "done"
 
 
-async def test_smoke_fixes_unbounded_until_success(client, queue_stub, fake_ssh, bus_recorder):
-    """冒烟修复不再按次数设限：连续失败 3 次（超过旧上限）仍继续修，第 4 次通过，
-    全程不提问、不打断，整条流水线走完。"""
+async def test_smoke_repeated_failure_stops_after_two_repairs(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """同一冒烟错误经过两次修复仍无进展时停止自动改写并请求用户判断。"""
     fake_ssh.smoke_exits = [1, 1, 1, 0]
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
     resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
-    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+    voyage_id = resp.json()["voyage_id"]
 
-    engine, bus = _make_engine()
+    engine, _ = _make_engine()
     await engine.run(uuid.UUID(voyage_id))
     await _approve_gate(client, headers, project_id)
     await engine.resume(uuid.UUID(voyage_id))
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     voyage = resp.json()
-    assert voyage["status"] == "done", voyage
+    assert voyage["status"] == "paused_ask", voyage
     smoke_step = next(s for s in voyage["steps"] if s["action"] == "experiment.smoke")
-    assert smoke_step["observation"] == {"exit_code": 0, "attempts": 4, "fixes": 3}
-    statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
-    assert "paused_ask" not in statuses  # 修复期间不打断
-    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
-    assert resp.json()["status"] == "done"
+    assert smoke_step["observation"]["attempts"] == 3
+    assert smoke_step["observation"]["fixes"] == 2
+    assert "同一个错误" in voyage["open_ask"]["text"]
 
 async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh, bus_recorder):
     """依赖安装第一次失败 → 报错回 LLM 修 requirements/run.sh → 重装通过（对称 smoke 自愈）。"""
@@ -389,15 +394,16 @@ async def test_setup_dep_failure_fixed_and_retried(client, queue_stub, fake_ssh,
     assert resp.json()["status"] == "done"
 
 
-async def test_setup_fixes_unbounded_until_success(client, queue_stub, fake_ssh, bus_recorder):
-    """修复不再按次数设限（用户定调）：连续失败 3 次（超过旧上限 2）仍继续修，
-    第 4 次装通、整条流水线走完，全程不提问。"""
+async def test_setup_repeated_failure_stops_after_two_repairs(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """同一依赖错误经过两次修复仍无进展时停止自动改写并请求用户判断。"""
     fake_ssh.setup_exits = [1, 1, 1, 0]
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
     cred_id = await _create_credential(client, headers)
     resp = await _create_experiment(client, headers, project_id, idea_id, cred_id)
-    exp_id, voyage_id = resp.json()["id"], resp.json()["voyage_id"]
+    voyage_id = resp.json()["voyage_id"]
 
     engine, _ = _make_engine()
     await engine.run(uuid.UUID(voyage_id))
@@ -405,11 +411,11 @@ async def test_setup_fixes_unbounded_until_success(client, queue_stub, fake_ssh,
     await engine.resume(uuid.UUID(voyage_id))
 
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    assert resp.json()["status"] == "done", resp.json()
+    assert resp.json()["status"] == "paused_ask", resp.json()
     setup_step = next(s for s in resp.json()["steps"] if s["action"] == "experiment.setup")
-    assert setup_step["observation"]["fixes"] == 3  # 旧上限是 2：现在不设限
-    resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
-    assert resp.json()["status"] == "done"
+    assert setup_step["observation"]["attempts"] == 3
+    assert setup_step["observation"]["fixes"] == 2
+    assert "同一个错误" in resp.json()["open_ask"]["text"]
 
 
 async def test_setup_time_budget_exceeded_asks(
@@ -496,7 +502,7 @@ async def test_setup_fix_loop_picks_up_mid_action_suggestions(
     async def post_suggestion(command: str) -> None:
         # 首次装依赖启动后（= setup 动作执行中途）用户发来建议
         nonlocal posted
-        if "setup.exit" in command and not posted:
+        if "/operations/dependency-install/" in command and not posted:
             posted = True
             async with get_sessionmaker()() as session:
                 await messages_service.append_message(
@@ -764,9 +770,9 @@ async def test_smoke_same_error_escalates_then_asks(client, queue_stub, fake_ssh
     ask = voyage["open_ask"]
     assert "同一个错误" in ask["text"]
     assert ask["payload"]["context"]["error_signature"]
-    assert len(ask["payload"]["context"]["fix_ledger"]) == 3  # 三次修复全记了台账
-    # 第 2/3 次修复 prompt 带升级指令；第 1 次不带
-    assert len(provider.fix_prompts) == 3
+    assert len(ask["payload"]["context"]["fix_ledger"]) == 2
+    # 第 2 次修复 prompt 带升级指令；第 1 次不带
+    assert len(provider.fix_prompts) == 2
     assert "禁止再微调版本号" not in provider.fix_prompts[0]
     assert "禁止再微调版本号" in provider.fix_prompts[1]
     assert "修复台账" in provider.fix_prompts[1]
@@ -1019,8 +1025,8 @@ async def test_probe_resources_records_facts_and_missing(client, fake_ssh, bus_r
     assert not any("多模态" in w for w in warnings)
 
 
-async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_recorder):
-    """超 budget.max_hours → kill 远端进程 + run 置 failed；voyage 转提问、实验「等你回复」。"""
+async def test_budget_timeout_keeps_run_and_asks(client, queue_stub, fake_ssh, bus_recorder):
+    """硬时限只触发用户决策；证据不足时保留远端进程，不把超时等同失败。"""
     fake_ssh.run_exit = None  # 进程一直不结束
     project_id, headers = await _setup_project(client)
     idea_id = await _seed_idea(project_id)
@@ -1035,16 +1041,25 @@ async def test_budget_timeout_kills_run(client, queue_stub, fake_ssh, bus_record
     await _approve_gate(client, headers, project_id)
     await engine.resume(uuid.UUID(voyage_id))
 
-    assert fake_ssh.pid in fake_ssh.killed
+    assert fake_ssh.pid not in fake_ssh.killed
     resp = await client.get(f"/api/experiments/{exp_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "waiting_user"  # 不再提前打死实验，镜像「等你回复」
-    assert detail["runs"][0]["status"] == "failed"
+    assert detail["runs"][0]["status"] == "running"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
     assert resp.json()["status"] == "paused_ask"  # run 级失败转提问，等人拍板
-    assert resp.json()["open_ask"]["payload"]["ask_kind"] == "fatal_step"
+    assert resp.json()["open_ask"]["payload"]["ask_kind"] == "managed_command"
+    ask_id = resp.json()["open_ask"]["id"]
     run_step = next(s for s in resp.json()["steps"] if s["action"] == "experiment.run")
-    assert "max_hours" in run_step["observation"]["error"]
+    assert run_step["observation"]["remote_operation_continues"] is True
+
+    resp = await client.post(
+        f"/api/voyages/{voyage_id}/asks/{ask_id}/answer",
+        headers=headers,
+        json={"choice": "stop_remote", "text": "停止并诊断"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert fake_ssh.pid in fake_ssh.killed
 
 
 async def test_cancel_during_run_polling(client, queue_stub, fake_ssh, bus_recorder):
@@ -1052,10 +1067,13 @@ async def test_cancel_during_run_polling(client, queue_stub, fake_ssh, bus_recor
     fake_ssh.run_exit = None  # 进程一直存活，直到被取消
 
     cancelled = False
+    run_launched = False
 
     async def cancel_on_first_alive_check(command: str) -> None:
-        nonlocal cancelled
-        if "kill -0" in command and not cancelled:
+        nonlocal cancelled, run_launched
+        if "/operations/experiment-run/" in command:
+            run_launched = True
+        if run_launched and "kill -0" in command and not cancelled:
             cancelled = True
             async with get_sessionmaker()() as session:
                 run = (
@@ -1603,7 +1621,9 @@ async def test_smoke_fix_reinstalls_deps_when_requirements_change(
     # ①冒烟修复改了 requirements.txt 后；②第 1 轮 improve 的新文件把 requirements 又改回
     # 默认内容后（analyze 路径同样受保护）。第 2 轮 improve 文件不变 → 不再重装。
     reinstalls = [
-        c for c in fake_ssh.commands if "-r requirements.txt" in c and "setup.log" not in c
+        c
+        for c in fake_ssh.commands
+        if "-r requirements.txt" in c and "/operations/dependency-install/" not in c
     ]
     assert len(reinstalls) == 2, fake_ssh.commands
 

--- a/src/backend/tests/test_experiments.py
+++ b/src/backend/tests/test_experiments.py
@@ -23,7 +23,7 @@ from app.core.llm.router import LLMRouter
 from app.models.activity import Activity
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.idea import Idea
-from app.models.voyage import VoyageRun
+from app.models.voyage import VoyageMessage, VoyageRun
 from app.services import ssh_exec
 from tests.conftest import RecordingBus, register_and_login
 from tests.fake_ssh import FakeSSHConnector, FakeSSHServer, FakeSSHSession
@@ -1053,6 +1053,16 @@ async def test_budget_timeout_keeps_run_and_asks(client, queue_stub, fake_ssh, b
     run_step = next(s for s in resp.json()["steps"] if s["action"] == "experiment.run")
     assert run_step["observation"]["remote_operation_continues"] is True
 
+    observed_stop_status: list[str] = []
+
+    async def observe_claim_before_signal(command: str) -> None:
+        if "# polaris-managed-stop" not in command:
+            return
+        async with get_sessionmaker()() as session:
+            ask = await session.get(VoyageMessage, uuid.UUID(ask_id))
+            observed_stop_status.append(ask.status)
+
+    fake_ssh.on_command = observe_claim_before_signal
     resp = await client.post(
         f"/api/voyages/{voyage_id}/asks/{ask_id}/answer",
         headers=headers,
@@ -1060,6 +1070,8 @@ async def test_budget_timeout_keeps_run_and_asks(client, queue_stub, fake_ssh, b
     )
     assert resp.status_code == 201, resp.text
     assert fake_ssh.pid in fake_ssh.killed
+    assert observed_stop_status == ["stopping"]
+    assert resp.json()["payload"]["stop_status"] == "stopped"
 
 
 async def test_cancel_during_run_polling(client, queue_stub, fake_ssh, bus_recorder):

--- a/src/backend/tests/test_managed_command_watchdog.py
+++ b/src/backend/tests/test_managed_command_watchdog.py
@@ -1,0 +1,245 @@
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.user import User
+from app.models.voyage import VoyageMessage, VoyageRun
+from app.services import experiments as experiments_service
+from app.services import managed_command_watchdog as watchdog
+from app.services.managed_ssh import ManagedGPUUsage, ManagedStopResult
+from tests.conftest import register_and_login
+
+
+def _handle() -> dict:
+    return {
+        "operation_id": "experiment-run",
+        "attempt_id": "11111111-1111-1111-1111-111111111111",
+        "process_id": 123,
+        "process_group_id": 123,
+        "context": {
+            "phase": "application.run",
+            "operation": "experiment-run",
+            "display_command": "bash run.sh",
+            "repair_scope": "application_files",
+        },
+    }
+
+
+async def _open_stale_ask(user_id, *, minutes_old: int = 180):
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="experiment",
+            mode="loop",
+            goal="test",
+            status="paused_ask",
+            created_by=user_id,
+        )
+        session.add(run)
+        await session.flush()
+        ask = VoyageMessage(
+            run_id=run.id,
+            seq=1,
+            role="agent",
+            kind="ask",
+            text="keep waiting?",
+            payload={
+                "ask_kind": "managed_command",
+                "context": {"handle": _handle(), "remote_operation_continues": True},
+            },
+            status="open",
+            created_at=datetime.now(UTC) - timedelta(minutes=minutes_old),
+        )
+        session.add(ask)
+        await session.commit()
+        return ask.id, run.id
+
+
+async def test_admin_timeout_caps_the_user_preference(client):
+    admin_token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    response = await client.put(
+        "/api/admin/settings/managed-command-watchdog",
+        json={"max_unanswered_minutes": 60},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    response = await client.put(
+        "/api/users/me/managed-command-watchdog",
+        json={"unanswered_minutes": 240},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "unanswered_minutes": 240,
+        "admin_max_unanswered_minutes": 60,
+        "effective_unanswered_minutes": 60,
+    }
+
+
+async def test_stale_gpu_using_command_is_stopped_and_ask_is_updated(client, monkeypatch):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        user_id = (await session.execute(select(User.id))).scalar_one()
+    ask_id, run_id = await _open_stale_ask(user_id)
+    stopped: list[str] = []
+
+    async def gpu_usage(*args, **kwargs):
+        return ManagedGPUUsage(
+            status="active",
+            process_alive=True,
+            process_ids=(321,),
+            used_memory_mib=6144,
+        )
+
+    async def stop(*args, **kwargs):
+        session = args[0]
+        ask = await session.get(VoyageMessage, ask_id)
+        # The destructive side effect is unreachable until this watchdog owns
+        # the same durable claim used by the answer endpoint.
+        assert ask.status == "stopping"
+        stopped.append(str(args[1]))
+        return ManagedStopResult(status="stopped", confirmed=True)
+
+    monkeypatch.setattr(experiments_service, "managed_command_gpu_usage_by_voyage", gpu_usage)
+    monkeypatch.setattr(experiments_service, "stop_managed_command_by_voyage", stop)
+
+    async with get_sessionmaker()() as session:
+        events = await watchdog.check_unanswered_managed_commands(session)
+        ask = await session.get(VoyageMessage, ask_id)
+
+    assert stopped == [str(run_id)]
+    assert len(events) == 1
+    assert events[0].action == "stopped_gpu_active"
+    assert "6144 MiB" in ask.text
+    assert ask.payload["context"]["remote_operation_continues"] is False
+    assert [option["id"] for option in ask.payload["options"]] == ["retry", "abort"]
+    assert ask.status == "open"
+
+
+async def test_watchdog_claim_blocks_a_concurrent_keep_running_answer(client, monkeypatch):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        user_id = (await session.execute(select(User.id))).scalar_one()
+    ask_id, _ = await _open_stale_ask(user_id)
+
+    async def gpu_usage(*args, **kwargs):
+        return ManagedGPUUsage(
+            status="active",
+            process_alive=True,
+            process_ids=(321,),
+            used_memory_mib=2048,
+        )
+
+    async def stop(_session, *args, **kwargs):
+        # Use a separate session like a concurrent API request.  Once the
+        # watchdog has committed open -> stopping, keep-running cannot claim it.
+        from sqlalchemy import update
+
+        async with get_sessionmaker()() as other:
+            result = await other.execute(
+                update(VoyageMessage)
+                .where(VoyageMessage.id == ask_id, VoyageMessage.status == "open")
+                .values(status="answered")
+            )
+            await other.commit()
+        assert result.rowcount == 0
+        return ManagedStopResult(status="stopped", confirmed=True)
+
+    monkeypatch.setattr(experiments_service, "managed_command_gpu_usage_by_voyage", gpu_usage)
+    monkeypatch.setattr(experiments_service, "stop_managed_command_by_voyage", stop)
+
+    async with get_sessionmaker()() as session:
+        events = await watchdog.check_unanswered_managed_commands(session)
+
+    assert [event.action for event in events] == ["stopped_gpu_active"]
+
+
+async def test_cancel_during_watchdog_stop_does_not_reopen_the_ask(client, monkeypatch):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        user_id = (await session.execute(select(User.id))).scalar_one()
+    ask_id, _ = await _open_stale_ask(user_id)
+
+    async def gpu_usage(*args, **kwargs):
+        return ManagedGPUUsage(
+            status="active",
+            process_alive=True,
+            process_ids=(321,),
+            used_memory_mib=1024,
+        )
+
+    async def stop(session, voyage_id, *args, **kwargs):
+        from app.services import voyages as voyages_service
+
+        run = await session.get(VoyageRun, voyage_id)
+        await voyages_service.cancel_voyage(session, run)
+        return ManagedStopResult(status="stopped", confirmed=True)
+
+    monkeypatch.setattr(experiments_service, "managed_command_gpu_usage_by_voyage", gpu_usage)
+    monkeypatch.setattr(experiments_service, "stop_managed_command_by_voyage", stop)
+
+    async with get_sessionmaker()() as session:
+        events = await watchdog.check_unanswered_managed_commands(session)
+        ask = await session.get(VoyageMessage, ask_id)
+
+    assert events == []
+    assert ask.status == "superseded"
+
+
+async def test_stale_idle_command_keeps_running(client, monkeypatch):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        user_id = (await session.execute(select(User.id))).scalar_one()
+    ask_id, _ = await _open_stale_ask(user_id)
+
+    async def gpu_usage(*args, **kwargs):
+        return ManagedGPUUsage(status="idle", process_alive=True)
+
+    async def unexpected_stop(*args, **kwargs):
+        raise AssertionError("idle command must not be stopped")
+
+    monkeypatch.setattr(experiments_service, "managed_command_gpu_usage_by_voyage", gpu_usage)
+    monkeypatch.setattr(
+        experiments_service, "stop_managed_command_by_voyage", unexpected_stop
+    )
+
+    async with get_sessionmaker()() as session:
+        events = await watchdog.check_unanswered_managed_commands(session)
+        ask = await session.get(VoyageMessage, ask_id)
+
+    assert events == []
+    assert ask.payload["context"]["remote_operation_continues"] is True
+    assert ask.payload["context"]["unanswered_watchdog"]["status"] == "idle"
+
+
+async def test_answer_arriving_during_probe_prevents_watchdog_stop(client, monkeypatch):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        user_id = (await session.execute(select(User.id))).scalar_one()
+    ask_id, _ = await _open_stale_ask(user_id)
+
+    async def gpu_usage(session, *args, **kwargs):
+        ask = await session.get(VoyageMessage, ask_id)
+        ask.status = "answered"
+        await session.commit()
+        return ManagedGPUUsage(
+            status="active",
+            process_alive=True,
+            process_ids=(321,),
+            used_memory_mib=4096,
+        )
+
+    async def unexpected_stop(*args, **kwargs):
+        raise AssertionError("an answered ask must not trigger the watchdog stop")
+
+    monkeypatch.setattr(experiments_service, "managed_command_gpu_usage_by_voyage", gpu_usage)
+    monkeypatch.setattr(
+        experiments_service, "stop_managed_command_by_voyage", unexpected_stop
+    )
+
+    async with get_sessionmaker()() as session:
+        events = await watchdog.check_unanswered_managed_commands(session)
+
+    assert events == []

--- a/src/backend/tests/test_managed_commands.py
+++ b/src/backend/tests/test_managed_commands.py
@@ -1,0 +1,135 @@
+from app.services.managed_commands import (
+    CommandAction,
+    CommandSnapshot,
+    CommandState,
+    ModelAssessment,
+    OperationContext,
+    RecoveryPlan,
+    RepairScope,
+    adjudicate_command,
+    failure_from_snapshot,
+    may_apply_recovery_automatically,
+)
+
+
+def _snapshot(**overrides):
+    values = {
+        "operation_id": "setup",
+        "attempt_id": "attempt-1",
+        "context": OperationContext(
+            phase="dependency.install",
+            operation="install dependencies",
+            display_command="pip install -r requirements.txt",
+            target="host",
+            soft_timeout_seconds=60,
+            stall_timeout_seconds=120,
+            repair_scope=RepairScope.DEPENDENCY_FILES,
+        ),
+        "elapsed_seconds": 180,
+        "process_alive": True,
+        "exit_status": None,
+        "stdout_tail": "downloading package",
+        "output_bytes": 20,
+        "seconds_since_output": 180,
+        "process_id": 123,
+        "process_group_id": 123,
+    }
+    values.update(overrides)
+    return CommandSnapshot(**values)
+
+
+def test_progress_is_stronger_than_model_stall_guess():
+    snap = _snapshot(output_changed=True)
+    advice = ModelAssessment(
+        state=CommandState.STALLED,
+        confidence=0.99,
+        reason="guess",
+        proposed_action=CommandAction.STOP_AND_REPAIR,
+        safe_to_interrupt=True,
+    )
+    assert adjudicate_command(snap, advice).action == CommandAction.CONTINUE_MONITORING
+
+
+def test_unknown_at_stall_threshold_asks_without_stopping():
+    advice = ModelAssessment(
+        state=CommandState.UNKNOWN,
+        confidence=0.2,
+        reason="insufficient evidence",
+    )
+    verdict = adjudicate_command(_snapshot(), advice)
+    assert verdict.action == CommandAction.ASK_USER_WHILE_RUNNING
+
+
+def test_missing_model_fails_safe_and_eventually_asks():
+    before = _snapshot(seconds_since_output=30)
+    stalled = _snapshot(seconds_since_output=180)
+    assert adjudicate_command(before, None).action == CommandAction.CONTINUE_MONITORING
+    assert adjudicate_command(stalled, None).action == CommandAction.ASK_USER_WHILE_RUNNING
+
+
+def test_slow_operation_gets_one_extension_then_user_review():
+    advice = ModelAssessment(
+        state=CommandState.SLOW,
+        confidence=0.9,
+        reason="healthy but slow",
+        proposed_action=CommandAction.EXTEND_OBSERVATION,
+    )
+    assert adjudicate_command(_snapshot(), advice).action == CommandAction.EXTEND_OBSERVATION
+    assert (
+        adjudicate_command(_snapshot(), advice, silent_extensions=1).action
+        == CommandAction.ASK_USER_WHILE_RUNNING
+    )
+
+
+def test_high_confidence_stall_requires_diagnostic_before_stop():
+    advice = ModelAssessment(
+        state=CommandState.STALLED,
+        confidence=0.95,
+        reason="process is blocked",
+        proposed_action=CommandAction.STOP_AND_REPAIR,
+        safe_to_interrupt=True,
+    )
+    assert adjudicate_command(_snapshot(), advice).action == CommandAction.RUN_DIAGNOSTIC
+    assert (
+        adjudicate_command(_snapshot(), advice, diagnostics_run=1).action
+        == CommandAction.STOP_AND_REPAIR
+    )
+
+
+def test_nonzero_exit_returns_real_failure_evidence_and_redacts_secrets():
+    snap = _snapshot(
+        process_alive=False,
+        exit_status=1,
+        stderr_tail="token=secret-value\nHTTP 500",
+    )
+    verdict = adjudicate_command(snap, None)
+    report = failure_from_snapshot(snap)
+    assert verdict.action == CommandAction.REPORT_FAILURE
+    assert report.exit_status == 1
+    assert report.stderr_tail is not None
+    assert "secret-value" not in report.stderr_tail
+    assert report.repair_scope == RepairScope.DEPENDENCY_FILES
+
+
+def test_automatic_repair_is_confidence_scope_and_progress_bounded():
+    safe = RecoveryPlan(
+        diagnosis="invalid generated dependency pin",
+        confidence=0.9,
+        repair_scope=RepairScope.DEPENDENCY_FILES,
+        proposed_changes=("requirements.txt",),
+        expected_evidence="pip exits zero",
+        minimal_retry="dependency.install",
+    )
+    assert may_apply_recovery_automatically(safe, repeated_without_progress=0)
+    assert not may_apply_recovery_automatically(safe, repeated_without_progress=2)
+    infrastructure = RecoveryPlan(
+        diagnosis="registry unavailable",
+        confidence=0.99,
+        repair_scope=RepairScope.INFRASTRUCTURE,
+        proposed_changes=("requirements.txt",),
+        expected_evidence="registry responds",
+        minimal_retry="artifact.download",
+    )
+    assert not may_apply_recovery_automatically(
+        infrastructure, repeated_without_progress=0
+    )

--- a/src/backend/tests/test_managed_commands.py
+++ b/src/backend/tests/test_managed_commands.py
@@ -9,6 +9,7 @@ from app.services.managed_commands import (
     adjudicate_command,
     failure_from_snapshot,
     may_apply_recovery_automatically,
+    redact_text,
 )
 
 
@@ -133,3 +134,62 @@ def test_automatic_repair_is_confidence_scope_and_progress_bounded():
     assert not may_apply_recovery_automatically(
         infrastructure, repeated_without_progress=0
     )
+
+
+# ---- 脱敏加固（见 test_managed_ssh 里的输出读取加固） ----
+
+
+def test_redaction_covers_prefixed_env_var_secrets():
+    """密钥在实验脚本里几乎都写成带前缀的环境变量名。
+
+    `\btoken` 的词边界在 `HF_TOKEN` 里根本不成立——下划线是单词字符——所以
+    只按裸词匹配会把最常见的一类原样漏出去。
+    """
+    text = (
+        "export HF_TOKEN=hf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG\n"
+        "export OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz012345\n"
+        "MY_DB_PASSWORD=hunter2\n"
+    )
+    redacted = redact_text(text)
+    assert "hf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" not in redacted
+    assert "wJalrXUtnFEMI/K7MDENG" not in redacted
+    assert "sk-proj-abcdefghijklmnopqrstuvwxyz012345" not in redacted
+    assert "hunter2" not in redacted
+    assert redacted.count("[REDACTED]") == 4
+
+
+def test_redaction_covers_self_identifying_key_prefixes():
+    """裸密钥（前后没有 key= 形式）靠自身前缀识别。"""
+    text = "curl -H 'x: sk-abcdefghijklmnopqrstuvwx' && git push https://ghp_abcdefghijklmnopqrst01"
+    redacted = redact_text(text)
+    assert "sk-abcdefghijklmnopqrstuvwx" not in redacted
+    assert "ghp_abcdefghijklmnopqrst01" not in redacted
+
+
+def test_redaction_keeps_ordinary_output_intact():
+    """别把正常日志误伤：不含密钥的行要原样保留。"""
+    text = "Epoch 3/10 loss=0.1234 acc=0.98\nSaving checkpoint to /data/ckpt-3.pt\n"
+    assert redact_text(text) == text
+
+
+def test_snapshot_dict_redacts_the_command_and_target_too():
+    """display_command / target 跟着快照进 API 与前端，同样可能带密钥。"""
+    snapshot = CommandSnapshot(
+        operation_id="experiment-run",
+        attempt_id="00000000-0000-0000-0000-000000000001",
+        context=OperationContext(
+            phase="application.run",
+            operation="experiment-run",
+            display_command="python train.py --token ghp_abcdefghijklmnopqrst01",
+            target="https://user:s3cret@gpu-01",
+        ),
+        elapsed_seconds=1.0,
+        process_alive=True,
+        exit_status=None,
+        stdout_tail="HF_TOKEN=hf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+    )
+    data = snapshot.to_dict()
+    assert "ghp_abcdefghijklmnopqrst01" not in data["context"]["display_command"]
+    assert "s3cret" not in data["context"]["target"]
+    assert "hf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" not in data["stdout_tail"]

--- a/src/backend/tests/test_managed_ssh.py
+++ b/src/backend/tests/test_managed_ssh.py
@@ -4,6 +4,7 @@ from app.services.managed_commands import (
     failure_from_exception,
 )
 from app.services.managed_ssh import ManagedCommandLaunchError, SSHManagedCommands
+from app.services.ssh_exec import SSHResult
 from tests.fake_ssh import FakeSSHServer, FakeSSHSession
 
 
@@ -63,11 +64,56 @@ async def test_stop_only_targets_current_attempt_and_verifies_exit():
     manager = _manager(server)
     handle = await manager.start(_context(), "bash run.sh")
 
-    assert await manager.stop(handle) is True
+    outcome = await manager.stop(handle)
+    assert outcome.confirmed is True
+    assert outcome.status == "stopped"
     assert handle.process_group_id in server.killed
     snapshot = await manager.snapshot(handle)
     assert snapshot.process_alive is False
     assert snapshot.exit_status == -15
+
+
+async def test_stop_refuses_an_attempt_replaced_before_the_signal():
+    """The current-attempt check must live in the same remote critical section as kill."""
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    operation_dir = manager._operation_dir(handle.operation_id)
+    server.managed_files[f"{operation_dir}/current"] = (
+        "22222222-2222-2222-2222-222222222222"
+    )
+
+    outcome = await manager.stop(handle)
+    assert outcome.confirmed is False
+    assert outcome.status == "attempt_changed"
+    assert server.killed == []
+    stop_commands = [c for c in server.commands if "# polaris-managed-stop" in c]
+    assert len(stop_commands) == 1
+
+
+async def test_stop_refuses_changed_process_identity():
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    prefix = server.managed_prefix_by_pid[handle.process_id]
+    server.managed_files[f"{prefix}.pid"] = str(handle.process_id + 1)
+
+    outcome = await manager.stop(handle)
+    assert outcome.confirmed is False
+    assert outcome.status == "identity_changed"
+    assert server.killed == []
+
+
+async def test_stop_reports_when_the_attempt_already_exited():
+    server = FakeSSHServer(run_exit=0)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+
+    outcome = await manager.stop(handle)
+
+    assert outcome.confirmed is True
+    assert outcome.status == "already_exited"
+    assert server.killed == []
 
 
 async def test_launch_timeout_recovers_the_durable_attempt():
@@ -208,3 +254,66 @@ def test_terminal_log_is_redacted_before_it_reaches_disk(tmp_path, monkeypatch):
     assert "hf_cccccccccccccccccccccccccccccc" not in content
     assert "[REDACTED]" in content
     assert "epoch 1 ok" in content  # 正常输出不受影响
+
+
+def test_run_log_is_redacted_before_it_reaches_disk(tmp_path, monkeypatch):
+    from app.core.config import get_settings
+    from app.services import experiments as experiments_service
+
+    monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+    path = experiments_service.append_local_log(
+        "11111111-1111-1111-1111-111111111111",
+        1,
+        "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz\nloss=0.2\n",
+    )
+    content = path.read_text()
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in content
+    assert "[REDACTED]" in content
+    assert "loss=0.2" in content
+
+
+async def test_gpu_usage_is_attributed_to_the_managed_process_group_only():
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    original_run = manager._run
+
+    async def run(command: str, timeout: float | None = None):
+        if command.startswith("ps -eo pid="):
+            return SSHResult(
+                0,
+                f"{handle.process_id} 1 {handle.process_group_id}\n"
+                f"8001 {handle.process_id} 9000\n"
+                "9001 1 9001\n",
+                "",
+            )
+        if command.startswith("nvidia-smi --query-compute-apps"):
+            return SSHResult(0, "8001, 4096\n9001, 8192\n", "")
+        return await original_run(command, timeout)
+
+    manager._run = run
+    usage = await manager.gpu_usage(handle)
+
+    assert usage.status == "active"
+    assert usage.process_ids == (8001,)
+    assert usage.used_memory_mib == 4096
+
+
+async def test_gpu_usage_does_not_claim_an_unrelated_machine_process():
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    original_run = manager._run
+
+    async def run(command: str, timeout: float | None = None):
+        if command.startswith("ps -eo pid="):
+            return SSHResult(0, f"{handle.process_id} 1 {handle.process_group_id}\n", "")
+        if command.startswith("nvidia-smi --query-compute-apps"):
+            return SSHResult(0, "9001, 8192\n", "")
+        return await original_run(command, timeout)
+
+    manager._run = run
+    usage = await manager.gpu_usage(handle)
+
+    assert usage.status == "idle"
+    assert usage.used_memory_mib == 0

--- a/src/backend/tests/test_managed_ssh.py
+++ b/src/backend/tests/test_managed_ssh.py
@@ -109,3 +109,102 @@ def test_launch_error_preserves_operation_context():
     assert report.phase == "application.run"
     assert report.operation == "experiment-run"
     assert report.repair_scope == RepairScope.APPLICATION_FILES
+
+
+# ---- 输出增量读取 / 启动脚本 / pid 读取的加固 ----
+
+
+async def test_incremental_read_counts_bytes_not_characters():
+    """偏移量是字节口径，回来的却是解码后的 str。
+
+    直接按 len(text.encode()) 记账，在多字节字符上会与真实消费的字节数错位，
+    下一轮从错误位置续读——中文日志和带 unicode 的进度条都会踩到。
+    """
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    prefix = server.managed_prefix_by_pid[handle.process_id]
+    text = "训练开始 ✅\n第 1 轮 loss=0.5\n"
+    server.managed_files[f"{prefix}.stdout"] = text
+
+    chunks, next_stdout, _ = await manager.read_output(handle)
+    assert [c.text for c in chunks if c.stream == "stdout"] == [text]
+    # 续读位置必须落在字节末尾，而不是字符数
+    assert next_stdout == len(text.encode())
+
+    # 从上次的偏移接着读：没有新内容就该是空，且偏移不动
+    server.managed_files[f"{prefix}.stdout"] = text + "第 2 轮\n"
+    chunks, after, _ = await manager.read_output(handle, stdout_offset=next_stdout)
+    assert [c.text for c in chunks if c.stream == "stdout"] == ["第 2 轮\n"]
+    assert after == len((text + "第 2 轮\n").encode())
+
+
+async def test_incremental_read_is_capped_per_round():
+    """远端两次轮询之间刷了巨量日志时，单轮只取上限，剩下的下一轮再来。"""
+    from app.services.managed_ssh import _MAX_OUTPUT_CHUNK_BYTES
+
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    prefix = server.managed_prefix_by_pid[handle.process_id]
+    server.managed_files[f"{prefix}.stdout"] = "x" * (_MAX_OUTPUT_CHUNK_BYTES * 2)
+
+    chunks, next_stdout, _ = await manager.read_output(handle)
+    body = "".join(c.text for c in chunks if c.stream == "stdout")
+    assert len(body) == _MAX_OUTPUT_CHUNK_BYTES
+    assert next_stdout == _MAX_OUTPUT_CHUNK_BYTES
+
+
+async def test_launcher_survives_a_command_ending_in_a_comment():
+    """`{ cmd; }` 单行包裹时，以注释收尾的命令会把 `; }` 一起注释掉。
+
+    那样整个启动脚本是 bash 语法错误，任务起不来还看不出原因。
+    """
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    await manager.start(_context(), "bash run.sh  # 跑主实验")
+
+    launcher = next(c for c in server.commands if c.startswith("#!/usr/bin/env bash"))
+    assert "bash run.sh  # 跑主实验\n" in launcher
+    # 收尾的花括号必须独占一行，不能跟在被注释的那行后面
+    assert "\n} >${prefix}.stdout 2>${prefix}.stderr\n" in launcher
+
+
+async def test_corrupt_pid_file_does_not_become_a_stray_kill():
+    """pid/pgid 会拼进 `kill -- -<pgid>`。文件写坏时读出 0/负数不能当成有效值。"""
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+    prefix = server.managed_prefix_by_pid[handle.process_id]
+    server.managed_files[f"{prefix}.pid"] = "0"
+    server.managed_files[f"{prefix}.pgid"] = "-1"
+
+    snapshot = await manager.snapshot(handle)
+    # 读不到可信值时回退到 handle 上的原值，而不是把 0 / -1 传下去
+    assert snapshot.process_id == handle.process_id
+    assert snapshot.process_group_id == handle.process_group_id
+
+
+def test_terminal_log_is_redacted_before_it_reaches_disk(tmp_path, monkeypatch):
+    """终端日志经 /experiments/{id}/terminal-logs 原样发给成员与管理员。
+
+    快照和失败报告都脱敏了，这个最大的外露面不能例外——实验脚本 echo 一次
+    HF_TOKEN 就会进所有人的终端面板。
+    """
+    from app.core.config import get_settings
+    from app.services import experiments as experiments_service
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+    experiments_service.append_terminal_output(
+        "11111111-1111-1111-1111-111111111111",
+        operation="experiment-run",
+        stream="stdout",
+        text="export HF_TOKEN=hf_cccccccccccccccccccccccccccccc\nepoch 1 ok\n",
+    )
+    content = experiments_service.terminal_log_path(
+        "11111111-1111-1111-1111-111111111111"
+    ).read_text()
+    assert "hf_cccccccccccccccccccccccccccccc" not in content
+    assert "[REDACTED]" in content
+    assert "epoch 1 ok" in content  # 正常输出不受影响

--- a/src/backend/tests/test_managed_ssh.py
+++ b/src/backend/tests/test_managed_ssh.py
@@ -1,0 +1,111 @@
+from app.services.managed_commands import (
+    OperationContext,
+    RepairScope,
+    failure_from_exception,
+)
+from app.services.managed_ssh import ManagedCommandLaunchError, SSHManagedCommands
+from tests.fake_ssh import FakeSSHServer, FakeSSHSession
+
+
+def _manager(server: FakeSSHServer) -> SSHManagedCommands:
+    session = FakeSSHSession(server)
+    return SSHManagedCommands(
+        session=session,
+        run=session.run,
+        shell_workdir="~/polaris_runs/test",
+        sftp_workdir="polaris_runs/test",
+    )
+
+
+def _context() -> OperationContext:
+    return OperationContext(
+        phase="application.run",
+        operation="experiment-run",
+        display_command="bash run.sh",
+        target="host",
+        repair_scope=RepairScope.APPLICATION_FILES,
+    )
+
+
+async def test_concurrent_logical_start_attaches_active_attempt():
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+
+    first = await manager.start(_context(), "bash run.sh")
+    second = await manager.start(_context(), "bash run.sh")
+
+    assert second.attempt_id == first.attempt_id
+    assert second.process_id == first.process_id
+    assert sum("nohup setsid bash" in command for command in server.commands) == 1
+    pointer_index = next(
+        i for i, command in enumerate(server.commands) if "/current.tmp" in command
+    )
+    launch_index = next(
+        i for i, command in enumerate(server.commands) if "nohup setsid bash" in command
+    )
+    assert pointer_index < launch_index
+    assert "&& nohup" not in server.commands[launch_index]
+
+
+async def test_completed_attempt_allows_a_new_attempt():
+    server = FakeSSHServer(run_exit=0)
+    manager = _manager(server)
+
+    first = await manager.start(_context(), "bash run.sh")
+    second = await manager.start(_context(), "bash run.sh")
+
+    assert second.attempt_id != first.attempt_id
+    assert sum("nohup setsid bash" in command for command in server.commands) == 2
+
+
+async def test_stop_only_targets_current_attempt_and_verifies_exit():
+    server = FakeSSHServer(run_exit=None)
+    manager = _manager(server)
+    handle = await manager.start(_context(), "bash run.sh")
+
+    assert await manager.stop(handle) is True
+    assert handle.process_group_id in server.killed
+    snapshot = await manager.snapshot(handle)
+    assert snapshot.process_alive is False
+    assert snapshot.exit_status == -15
+
+
+async def test_launch_timeout_recovers_the_durable_attempt():
+    server = FakeSSHServer(run_exit=None)
+    session = FakeSSHSession(server)
+
+    class LaunchTimeout(TimeoutError):
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+            self.stderr = ""
+            self.exit_status = 0
+            super().__init__("launch channel timed out after returning the PID")
+
+    async def run(command: str, timeout: float | None = None):
+        result = await session.run(command, timeout)
+        if "nohup setsid bash" in command:
+            raise LaunchTimeout(result.stdout)
+        return result
+
+    manager = SSHManagedCommands(
+        session=session,
+        run=run,
+        shell_workdir="~/polaris_runs/test",
+        sftp_workdir="polaris_runs/test",
+    )
+    handle = await manager.start(_context(), "bash run.sh")
+
+    assert handle.process_id == server.pid
+    assert await manager.current_attempt_id(handle.operation_id) == handle.attempt_id
+    assert sum("nohup setsid bash" in command for command in server.commands) == 1
+
+
+def test_launch_error_preserves_operation_context():
+    context = _context()
+    error = ManagedCommandLaunchError(context, "bash run.sh", TimeoutError())
+    assert error.operation_context is context
+    assert error.command == "bash run.sh"
+    report = failure_from_exception(error)
+    assert report.phase == "application.run"
+    assert report.operation == "experiment-run"
+    assert report.repair_scope == RepairScope.APPLICATION_FILES

--- a/src/backend/tests/test_managed_ssh.py
+++ b/src/backend/tests/test_managed_ssh.py
@@ -59,6 +59,21 @@ async def test_completed_attempt_allows_a_new_attempt():
     assert sum("nohup setsid bash" in command for command in server.commands) == 2
 
 
+async def test_recover_current_returns_completed_attempt_without_relaunching():
+    server = FakeSSHServer(run_exit=0)
+    manager = _manager(server)
+
+    launched = await manager.start(_context(), "bash run.sh")
+    recovered = await manager.recover_current(_context())
+
+    assert recovered is not None
+    assert recovered.attempt_id == launched.attempt_id
+    assert recovered.process_id == launched.process_id
+    snapshot = await manager.snapshot(recovered)
+    assert snapshot.exit_status == 0
+    assert sum("nohup setsid bash" in command for command in server.commands) == 1
+
+
 async def test_stop_only_targets_current_attempt_and_verifies_exit():
     server = FakeSSHServer(run_exit=None)
     manager = _manager(server)

--- a/src/backend/tests/test_voyage_ask.py
+++ b/src/backend/tests/test_voyage_ask.py
@@ -288,6 +288,25 @@ async def test_cancel_supersedes_open_ask(client, queue_stub):
     assert resp.status_code == 409
 
 
+async def test_cancel_supersedes_an_in_flight_stop_claim(client, queue_stub):
+    project_id, headers = await _make_project(client)
+    run_id = await _run(project_id, plan=FATAL_PLAN)
+    engine, _ = _engine()
+    await engine.run(run_id)
+    ask = await _open_ask_of(run_id)
+    assert ask is not None
+
+    async with get_sessionmaker()() as session:
+        claimed = await messages_service.claim_open_ask_for_stop(session, ask.id)
+        assert claimed is True
+
+    resp = await client.post(f"/api/voyages/{run_id}/cancel", headers=headers)
+    assert resp.status_code == 200
+    async with get_sessionmaker()() as session:
+        stopped_ask = await session.get(VoyageMessage, ask.id)
+        assert stopped_ask.status == "superseded"
+
+
 async def test_done_criteria_unmet_asks_then_accept(client, queue_stub, bus_recorder):
     """完成标准未达成 → 提问；用户接受为完成 → done（不再一律 paused_error）。"""
     project_id, headers = await _make_project(client)

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -16,6 +16,7 @@ from worker.tasks import (
     reconcile_stuck_voyages,
     resume_voyage,
     run_voyage,
+    watch_unanswered_managed_commands,
 )
 
 # 航程任务超时：GPU 训练轮合法地跑数小时；1h 的默认会把轮询任务掐死→ARQ 按任务
@@ -50,6 +51,11 @@ class WorkerSettings:
         # 僵死回收：启动对账只救 worker 重启的孤儿；运行中途丢任务（LLM 调用悬死、
         # ARQ 指数延迟重试）的僵死靠周期兜底（判据=终端 30 分钟无动静，见 tasks.py）
         cron(reconcile_stale_voyages, minute={5, 15, 25, 35, 45, 55}),
+        # paused_ask 没有 worker 持有；单独巡检长时间无人回答且仍占用 GPU 的命令。
+        cron(
+            watch_unanswered_managed_commands,
+            minute={2, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52, 57},
+        ),
     ]
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)
     # 其余任务保持 1h 上限

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -146,6 +146,33 @@ async def reconcile_stale_voyages(
         )
 
 
+async def watch_unanswered_managed_commands(ctx: dict[str, Any]) -> int:
+    """Enforce the unattended GPU wait policy for open managed-command asks."""
+    from app.core.events import EventBus
+    from app.services.managed_command_watchdog import check_unanswered_managed_commands
+
+    async with get_sessionmaker()() as session:
+        events = await check_unanswered_managed_commands(session)
+    bus = EventBus(ctx["redis"])
+    for event in events:
+        await bus.publish_voyage_event(
+            event.voyage_id,
+            "ask.updated",
+            {"message": event.message, "action": event.action},
+        )
+        if event.project_id is not None:
+            await bus.publish_notify(
+                event.project_id,
+                {
+                    "type": "voyage.ask.updated",
+                    "voyage_id": str(event.voyage_id),
+                    "action": event.action,
+                    "used_memory_mib": event.used_memory_mib,
+                },
+            )
+    return len(events)
+
+
 async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
     """给已建库的**文献库**入队同步。由每日论文抓取跑完后触发（daily.sync_libraries）。
 

--- a/src/frontend/src/features/experiment/ConsoleTab.tsx
+++ b/src/frontend/src/features/experiment/ConsoleTab.tsx
@@ -56,8 +56,16 @@ function parseLogEvent(data: string): string[] {
   return data.split('\n').filter((l) => l !== '');
 }
 
-/** 脚本输出（run.log）：与 AI 过程终端同一深色外观的简单日志框。 */
-function ScriptLogView({ expId, active }: { expId: string; active: boolean }) {
+/** 脚本或远端命令输出：与 AI 过程终端同一深色外观。 */
+function RemoteLogView({
+  expId,
+  active,
+  source,
+}: {
+  expId: string;
+  active: boolean;
+  source: 'script' | 'terminal';
+}) {
   const [lines, setLines] = useState<string[]>([]);
   const [truncated, setTruncated] = useState(false);
   const boxRef = useRef<HTMLDivElement>(null);
@@ -65,8 +73,10 @@ function ScriptLogView({ expId, active }: { expId: string; active: boolean }) {
   useEffect(() => {
     let cancelled = false;
     setLines([]);
-    api
-      .getExperimentLogs(expId, { tail: 500 })
+    const initial = source === 'script'
+      ? api.getExperimentLogs(expId, { tail: 500 })
+      : api.getExperimentTerminalLogs(expId, 500);
+    initial
       .then((r) => {
         if (cancelled) return;
         setLines(r.lines.slice(-MAX_SCRIPT_LINES));
@@ -76,18 +86,19 @@ function ScriptLogView({ expId, active }: { expId: string; active: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [expId]);
+  }, [expId, source]);
 
   useEffect(() => {
     if (!active) return;
-    const stop = subscribeSse(`/experiments/${expId}/logs/stream`, {
+    const endpoint = source === 'script' ? 'logs' : 'terminal-logs';
+    const stop = subscribeSse(`/experiments/${expId}/${endpoint}/stream`, {
       onEvent: (_event, data) => {
         const next = parseLogEvent(data);
         if (next.length > 0) setLines((l) => [...l, ...next].slice(-MAX_SCRIPT_LINES));
       },
     });
     return stop;
-  }, [expId, active]);
+  }, [expId, active, source]);
 
   useEffect(() => {
     const box = boxRef.current;
@@ -120,7 +131,9 @@ function ScriptLogView({ expId, active }: { expId: string; active: boolean }) {
       )}
       {lines.length === 0 ? (
         <div style={{ color: 'var(--terminal-dim)' }}>
-          {tr('暂无脚本输出（尚未开始运行）', 'No script output yet (not running)')}
+          {source === 'script'
+            ? tr('暂无脚本输出（尚未开始运行）', 'No script output yet (not running)')
+            : tr('暂无远端命令输出', 'No remote command output yet')}
         </div>
       ) : (
         lines.map((l, i) => <div key={i}>{l}</div>)
@@ -165,7 +178,7 @@ export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
   const queryClient = useQueryClient();
   const vid = exp.voyage_id;
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [source, setSource] = useState<'ai' | 'script'>('ai');
+  const [source, setSource] = useState<'ai' | 'script' | 'terminal'>('ai');
   const [chatOnly, setChatOnly] = useState(false);
   const [showObsolete, setShowObsolete] = useState(false);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -351,10 +364,11 @@ export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
                 </label>
                 <Segmented
                   value={source}
-                  onChange={(v) => setSource(v as 'ai' | 'script')}
+                  onChange={(v) => setSource(v as 'ai' | 'script' | 'terminal')}
                   options={[
                     { v: 'ai' as const, label: tr('AI 过程', 'AI process') },
                     { v: 'script' as const, label: tr('脚本输出', 'Script output') },
+                    { v: 'terminal' as const, label: tr('终端输出', 'Terminal output') },
                   ]}
                 />
               </>
@@ -373,21 +387,28 @@ export function ConsoleTab({ exp }: { exp: ExperimentDetail }) {
             <div className="row" style={{ margin: '20px 0 12px' }}>
               <span className="section-h">
                 <Icon name="cpu" size={15} style={{ color: 'var(--accent)' }} />
-                {tr('运行日志', 'Terminal')}
-                <span className="en-label" style={{ fontSize: 11 }}>run.log</span>
+                {source === 'script' ? tr('运行日志', 'Run log') : tr('远端命令输出', 'Remote terminal')}
+                <span className="en-label" style={{ fontSize: 11 }}>
+                  {source === 'script' ? 'run.log' : 'stdout / stderr'}
+                </span>
               </span>
               <div className="row gap8" style={{ marginLeft: 'auto' }}>
                 <Segmented
                   value={source}
-                  onChange={(v) => setSource(v as 'ai' | 'script')}
+                  onChange={(v) => setSource(v as 'ai' | 'script' | 'terminal')}
                   options={[
                     { v: 'ai' as const, label: tr('AI 过程', 'AI process') },
                     { v: 'script' as const, label: tr('脚本输出', 'Script output') },
+                    { v: 'terminal' as const, label: tr('终端输出', 'Terminal output') },
                   ]}
                 />
               </div>
             </div>
-            <ScriptLogView expId={exp.id} active={!EXPERIMENT_TERMINAL.has(exp.status)} />
+            <RemoteLogView
+              expId={exp.id}
+              active={!EXPERIMENT_TERMINAL.has(exp.status)}
+              source={source}
+            />
             <ConsoleComposer
               voyageId={vid}
               openAsk={openAsk}

--- a/src/frontend/src/features/settings/ExperimentSettings.tsx
+++ b/src/frontend/src/features/settings/ExperimentSettings.tsx
@@ -132,6 +132,7 @@ export function ExperimentSettings() {
   }
 
   return (
+    <>
     <div className="card card-pad">
       <div className="section-h" style={{ marginBottom: 4 }}>
         <Icon name="flask" size={15} style={{ color: 'var(--accent)' }} />
@@ -177,9 +178,75 @@ export function ExperimentSettings() {
         </button>
       </div>
     </div>
+    <ManagedCommandWatchdogAdminCard />
+    </>
   );
 }
 
 function labelOf(field: string): string {
   return FIELDS.find((f) => f.key === field)?.zh ?? field;
+}
+
+function ManagedCommandWatchdogAdminCard() {
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: ['managed-command-watchdog', 'admin'],
+    queryFn: () => api.getManagedCommandWatchdog(),
+    retry: false,
+  });
+  const [minutes, setMinutes] = useState<number | null>(null);
+  const shown = minutes ?? query.data?.max_unanswered_minutes ?? 120;
+  const mutation = useMutation({
+    mutationFn: () => api.setManagedCommandWatchdog(shown),
+    onSuccess: (saved) => {
+      setMinutes(saved.max_unanswered_minutes);
+      queryClient.setQueryData(['managed-command-watchdog', 'admin'], saved);
+      void queryClient.invalidateQueries({ queryKey: ['managed-command-watchdog', 'user'] });
+      toast(tr('无人答复策略已保存', 'Unanswered-command policy saved'), 'ok');
+    },
+    onError: (error) => toast(
+      `${tr('保存失败', 'Save failed')}：${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    ),
+  });
+  return (
+    <div className="card card-pad" style={{ marginTop: 16 }}>
+      <div className="section-h" style={{ marginBottom: 4 }}>
+        <Icon name="clock" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('远端命令无人答复策略', 'Unanswered remote-command policy')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6, marginBottom: 16 }}>
+        {tr(
+          '当远端命令超时后转为等待用户决定，此值是允许等待的最长时间。到期后仅在确认该命令本身仍占用 GPU 时自动终止；未占用 GPU 或无法可靠归属时继续保留。用户可以选择更短时间，但不能超过此上限。',
+          'Maximum wait after a timed-out remote command asks for a decision. Once reached, Polaris stops it only when GPU use is attributable to that command; idle or uncertain commands remain running. Users may choose a shorter wait, never a longer one.',
+        )}
+      </div>
+      {query.isError ? (
+        <div className="empty">{tr('无法加载设置', 'Failed to load settings')}</div>
+      ) : (
+        <FormField
+          label={tr('最长等待时间（分钟）', 'Maximum wait (minutes)')}
+          hint={tr('范围 15 分钟至 7 天，默认 120 分钟。', '15 minutes to 7 days; default 120 minutes.')}
+        >
+          <input
+            className="input mono"
+            type="number"
+            min={15}
+            max={10080}
+            value={shown}
+            onChange={(event) => setMinutes(Number(event.target.value))}
+          />
+        </FormField>
+      )}
+      <div className="row" style={{ justifyContent: 'flex-end', marginTop: 6 }}>
+        <button
+          className="btn btn-primary"
+          disabled={query.isLoading || shown < 15 || shown > 10080 || mutation.isPending || shown === query.data?.max_unanswered_minutes}
+          onClick={() => mutation.mutate()}
+        >
+          {mutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -261,7 +261,28 @@ function PersonalTab() {
 
 function PreferencesTab() {
   const showHistory = useTaskLogHistory();
+  const queryClient = useQueryClient();
+  const watchdog = useQuery({
+    queryKey: ['managed-command-watchdog', 'user'],
+    queryFn: () => api.getMyManagedCommandWatchdog(),
+    retry: false,
+  });
+  const [watchdogMinutes, setWatchdogMinutes] = useState<number | null>(null);
+  const shownMinutes = watchdogMinutes ?? watchdog.data?.unanswered_minutes ?? 120;
+  const saveWatchdog = useMutation({
+    mutationFn: () => api.setMyManagedCommandWatchdog(shownMinutes),
+    onSuccess: (saved) => {
+      setWatchdogMinutes(saved.unanswered_minutes);
+      queryClient.setQueryData(['managed-command-watchdog', 'user'], saved);
+      toast(tr('远端命令等待时间已保存', 'Remote-command wait saved'), 'ok');
+    },
+    onError: (error) => toast(
+      `${tr('保存失败', 'Save failed')}：${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    ),
+  });
   return (
+    <>
     <div className="card card-pad">
       <div className="section-h" style={{ marginBottom: 4 }}>
         <Icon name="sliders" size={15} style={{ color: 'var(--accent)' }} />
@@ -295,6 +316,48 @@ function PreferencesTab() {
         </div>
       </div>
     </div>
+    <div className="card card-pad" style={{ marginTop: 16 }}>
+      <div className="section-h" style={{ marginBottom: 4 }}>
+        <Icon name="clock" size={15} style={{ color: 'var(--accent)' }} />
+        {tr('远端命令等待策略', 'Remote-command wait policy')}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6, marginBottom: 16 }}>
+        {tr(
+          '远端命令超时并等待你决定后，超过此时间仍未回复时，系统会检查该命令是否占用 GPU。仅确认占用时自动终止；不占用或无法可靠归属时继续等待。管理员设置的上限优先生效。',
+          'After a timed-out remote command asks for your decision, Polaris checks its GPU use once this wait expires. It stops only GPU use attributable to that command; idle or uncertain commands keep waiting. The administrator cap takes precedence.',
+        )}
+      </div>
+      {watchdog.isError ? (
+        <div className="empty">{tr('无法加载设置', 'Failed to load settings')}</div>
+      ) : (
+        <FormField
+          label={tr('等待时间（分钟）', 'Wait (minutes)')}
+          hint={watchdog.data ? tr(
+            `管理员上限 ${watchdog.data.admin_max_unanswered_minutes} 分钟；当前实际生效 ${watchdog.data.effective_unanswered_minutes} 分钟。`,
+            `Administrator cap: ${watchdog.data.admin_max_unanswered_minutes} minutes; effective: ${watchdog.data.effective_unanswered_minutes} minutes.`,
+          ) : undefined}
+        >
+          <input
+            className="input mono"
+            type="number"
+            min={15}
+            max={10080}
+            value={shownMinutes}
+            onChange={(event) => setWatchdogMinutes(Number(event.target.value))}
+          />
+        </FormField>
+      )}
+      <div className="row" style={{ justifyContent: 'flex-end', marginTop: 6 }}>
+        <button
+          className="btn btn-primary"
+          disabled={watchdog.isLoading || shownMinutes < 15 || shownMinutes > 10080 || saveWatchdog.isPending || shownMinutes === watchdog.data?.unanswered_minutes}
+          onClick={() => saveWatchdog.mutate()}
+        >
+          {saveWatchdog.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+      </div>
+    </div>
+    </>
   );
 }
 

--- a/src/frontend/src/features/voyages/shared/StepCard.tsx
+++ b/src/frontend/src/features/voyages/shared/StepCard.tsx
@@ -652,8 +652,41 @@ export function ObservationBlock({ observation, compact }: { observation: unknow
   );
 }
 
+function FailureEvidenceCard({ failure }: { failure: Record<string, unknown> }) {
+  const stdout = typeof failure.stdout_tail === 'string' ? failure.stdout_tail : '';
+  const stderr = typeof failure.stderr_tail === 'string' ? failure.stderr_tail : '';
+  const raw = [stderr && `stderr:\n${stderr}`, stdout && `stdout:\n${stdout}`].filter(Boolean).join('\n\n');
+  return (
+    <div style={{ marginTop: 10, padding: '10px 12px', borderRadius: 8, background: 'var(--danger-bg)', color: 'var(--danger-tx)' }}>
+      <div style={{ fontWeight: 650, overflowWrap: 'anywhere' }}>
+        {String(failure.phase ?? 'unknown')} · {String(failure.message ?? failure.exception_type ?? 'Command failed')}
+      </div>
+      <div className="mono" style={{ marginTop: 5, fontSize: 11, overflowWrap: 'anywhere' }}>
+        {failure.command_display ? `${tr('命令', 'Command')}: ${String(failure.command_display)}` : ''}
+        {failure.exit_status !== null && failure.exit_status !== undefined
+          ? ` · exit=${String(failure.exit_status)}`
+          : ''}
+        {failure.elapsed_seconds !== null && failure.elapsed_seconds !== undefined
+          ? ` · ${Number(failure.elapsed_seconds).toFixed(1)}s`
+          : ''}
+      </div>
+      {raw && (
+        <details style={{ marginTop: 8 }}>
+          <summary style={{ cursor: 'pointer', fontSize: 11.5 }}>
+            {tr('查看原始输出摘要', 'Show raw output tail')}
+          </summary>
+          <pre style={{ margin: '6px 0 0', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', fontSize: 11 }}>
+            {raw}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
 export function StepCard({ step, planEvents }: { step: VoyageStepRead; planEvents: VoyagePlanEvent[] }) {
   const obs = asObj(step.observation);
+  const failure = obs ? asObj(obs.failure) : null;
   const friendly = obs ? wikiStepFriendly(step.action, obs) : null;
   const expFriendly = obs && step.action.startsWith('experiment.') ? experimentStepFriendly(step.action, obs) : null;
   const obsolete = step.status === 'obsolete';
@@ -761,6 +794,7 @@ export function StepCard({ step, planEvents }: { step: VoyageStepRead; planEvent
       )}
       {friendly && <WikiStepSummary friendly={friendly} />}
       {expFriendly && <ExperimentStepSummary friendly={expFriendly} />}
+      {failure && <FailureEvidenceCard failure={failure} />}
       {step.acceptance && <AcceptanceBlock acceptance={step.acceptance} />}
       {attempts.length > 1 && <AttemptsBlock attempts={attempts} />}
       <ObservationBlock observation={step.observation} compact={!!friendly || !!expFriendly} />

--- a/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
+++ b/src/frontend/src/features/voyages/shared/useVoyageMessages.ts
@@ -36,7 +36,7 @@ export function useVoyageMessages(voyageId: string | null) {
   /** 交给 useVoyageChannel 的 onExtraEvent：消费 message / ask.* 事件。 */
   const handleExtraEvent = useCallback(
     (event: string, data: unknown) => {
-      if (event !== 'message' && event !== 'ask.created' && event !== 'ask.answered') return;
+      if (event !== 'message' && event !== 'ask.created' && event !== 'ask.updated' && event !== 'ask.answered') return;
       const payload = data as { message?: VoyageMessageRead; ask_id?: string };
       if (!payload?.message) return;
       queryClient.setQueryData<VoyageMessageRead[]>(['voyage-messages', id], (old) =>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4230,6 +4230,9 @@ export const api = {
     const qs = params.toString();
     return request<ExperimentLogs>(`/experiments/${id}/logs${qs ? `?${qs}` : ''}`);
   },
+  getExperimentTerminalLogs(id: string, tail = 500): Promise<ExperimentLogs> {
+    return request<ExperimentLogs>(`/experiments/${id}/terminal-logs?tail=${tail}`);
+  },
   /** 单张实验图表 PNG（blob → objectURL 显示，模式同论文 figures）。 */
   fetchExperimentFigureImage(id: string, index: number): Promise<Blob> {
     return requestBlob(`/experiments/${id}/figures/${index}/image`);

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -194,6 +194,7 @@ export interface UserRead {
   token_quota?: number | null;
   features?: Record<string, boolean> | null;
   /** 用户个人设置（后端可能暂未返回，可选） */
+  settings?: Record<string, unknown> | null;
 }
 
 export interface UsageSummary {
@@ -1480,6 +1481,16 @@ export interface ExperimentEnvSettings {
   hf_endpoint: string;
   /** 实验机出外网的 HTTP 代理（凭据上单独配了的以凭据为准） */
   proxy_url: string;
+}
+
+export interface ManagedCommandWatchdogAdminSettings {
+  max_unanswered_minutes: number;
+}
+
+export interface ManagedCommandWatchdogUserSettings {
+  unanswered_minutes: number;
+  admin_max_unanswered_minutes: number;
+  effective_unanswered_minutes: number;
 }
 
 // ============================================================
@@ -3111,6 +3122,18 @@ export const api = {
   me(): Promise<UserRead> {
     return request<UserRead>('/users/me');
   },
+
+  getMyManagedCommandWatchdog(): Promise<ManagedCommandWatchdogUserSettings> {
+    return request<ManagedCommandWatchdogUserSettings>('/users/me/managed-command-watchdog');
+  },
+
+  setMyManagedCommandWatchdog(unansweredMinutes: number): Promise<ManagedCommandWatchdogUserSettings> {
+    return requestJson<ManagedCommandWatchdogUserSettings>(
+      '/users/me/managed-command-watchdog',
+      'PUT',
+      { unanswered_minutes: unansweredMinutes },
+    );
+  },
   updateMe(input: { display_name?: string }): Promise<UserRead> {
     return requestJson<UserRead>('/users/me', 'PATCH', input);
   },
@@ -4549,6 +4572,16 @@ export const api = {
   },
   setExperimentEnv(payload: ExperimentEnvSettings): Promise<ExperimentEnvSettings> {
     return requestJson<ExperimentEnvSettings>('/admin/settings/experiment-env', 'PUT', payload);
+  },
+  getManagedCommandWatchdog(): Promise<ManagedCommandWatchdogAdminSettings> {
+    return request<ManagedCommandWatchdogAdminSettings>('/admin/settings/managed-command-watchdog');
+  },
+  setManagedCommandWatchdog(maxUnansweredMinutes: number): Promise<ManagedCommandWatchdogAdminSettings> {
+    return requestJson<ManagedCommandWatchdogAdminSettings>(
+      '/admin/settings/managed-command-watchdog',
+      'PUT',
+      { max_unanswered_minutes: maxUnansweredMinutes },
+    );
   },
   /** 平台语音服务与默认模型（admin）。 */
   getAdminTtsSettings(): Promise<TTSAdminSettings> {


### PR DESCRIPTION
## Summary

Closes #431

This PR adds a generic managed-command lifecycle for Voyage experiments. Remote commands can now be monitored, reconnected, diagnosed, and recovered using the same structured execution evidence across the backend, API, worker, and frontend.

It also hardens persistent command output, unattended timeout handling, and concurrent stop decisions so long-running remote operations remain observable without exposing secrets or terminating the wrong process.

## What changed

### Managed command lifecycle

- Added durable managed-command attempts with operation IDs, attempt IDs, PID/PGID, stdout, stderr, and exit status.
- Added reconnectable monitoring so an SSH interruption does not automatically create a duplicate remote command.
- Added streaming remote output and a dedicated `Terminal Output` tab in the experiment console.
- Preserved command state so monitoring can resume after backend polling or connection interruptions.

### Failure evidence and recovery

- Added structured failure evidence containing execution phase, operation, target, timeout state, elapsed time, exit status, stdout/stderr tails, and diagnostic evidence.
- Added model-assisted timeout assessment for progressing, slow, stalled, failed, succeeded, and unknown states.
- Added deterministic safety rules that preserve the remote process when evidence is insufficient.
- Added user decision states for commands that are slow, stalled, or difficult to classify reliably.
- Added scoped recovery routing so infrastructure and transport failures cannot trigger unrelated generated-file repairs.
- Added failure signatures, progress tokens, diagnostic probes, and repeated-no-progress protection.
- Preserved the existing `observation.error` compatibility path while exposing structured failure data through the API.

### Output safety and correctness

- Redacted persistent managed-command run logs before they are exposed through the terminal output API.
- Applied redaction consistently to command snapshots, display commands, targets, and structured failure evidence.
- Added byte-accurate incremental output reads with bounded chunks to prevent UTF-8 offset drift and unbounded log ingestion.
- Hardened managed-command script generation and validated PID/PGID values before using them for process-group operations.

### Unattended commands and stop safety

- Added administrator-capped user settings for how long a timed-out remote command may wait for a decision.
- Added a watchdog that terminates only GPU-consuming commands attributable to the managed process tree, while preserving idle or uncertain commands.
- Serialized user and watchdog stop decisions so only one actor can claim and resolve a pending command decision.
- Revalidated the durable attempt and remote process identity immediately before signal delivery to avoid stopping a replaced or unrelated process.
- Preserved structured stop outcomes so natural completion, superseded attempts, identity changes, and unconfirmed stops remain distinguishable.

### Compatibility and documentation

- Documented the GNU/Linux utilities required by managed remote execution.
- Added backend and fake-SSH coverage for managed command lifecycle, reconnection, timeout handling, terminal output, failure routing, redaction, byte accounting, watchdog behavior, cancellation, and process-identity races.
- No database migration is required.

### Recovery after worker restarts

- Recover the durable current command attempt after a worker restart.
- Validate the recovered remote PID against the database run record.
- Restore managed SSH reconnect activity auditing.
- Keep low-confidence smoke failures running remotely while asking the user for a decision.

### Additional regression coverage

- Incorporated the review tests from RichardYann/Polaris#2 as `8c27dad`, preserving the original authorship.
- Fixed the exposed recovery issues in `9b81588`.
- Removed all three temporary `xfail` markers; the tests now pass normally.

## Testing

- [x] Ruff checks pass
- [x] 4 focused recovery regression tests pass.
- [x] 72 managed-command and experiment service tests pass
- [x] Frontend production build passes
- [x] GitHub desktop-build and docker-build checks pass

## Checklist

- [x] Branch is rebased on the latest `origin/main` without merging `main`
- [x] Conventional Commit PR title
- [x] No new database migration
- [x] No AI attribution or `Co-Authored-By` lines in commits
- [x] Screenshot attached for the new `Terminal Output` UI

<img width="1129" height="683" alt="Terminal Output tab showing managed remote command output" src="https://github.com/user-attachments/assets/9766a237-383d-4210-8684-f2b66b027dfb" />