### PR TITLE
fix(search): make global search actually global

### DIFF
--- a/src/backend/app/api/search.py
+++ b/src/backend/app/api/search.py
@@ -1,32 +1,34 @@
-"""全局搜索路由（顶栏 ⌘K）：GET /projects/{project_id}/global-search?q=。"""
+"""全局搜索路由（顶栏 ⌘K）：GET /global-search?q=。
 
-import uuid
+**不挂课题。** 这里以前是 ``/projects/{project_id}/global-search``，只搜当前课题
+关联的库——于是一篇好端端收录在某个独立库里的论文，站在别的课题上就是搜不到，
+而界面不会说明原因，看起来就像根本没收录。搜索的作用域应当等于「我够得着什么」，
+判据与列表页、详情页共用（见 services/search.global_search 的 docstring）。
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+按课题检索的那份口径仍然保留，供 agent 工具 ``global_search`` 使用——它检索的
+本来就是课题内的想法/实验/稿件。
+"""
+
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.models.user import User
 from app.schemas.search import GlobalSearchResponse
-from app.services import projects as projects_service
 from app.services import search as search_service
 
 router = APIRouter(tags=["search"])
 
 
-@router.get("/projects/{project_id}/global-search", response_model=GlobalSearchResponse)
+@router.get("/global-search", response_model=GlobalSearchResponse)
 async def global_search(
-    project_id: uuid.UUID,
     q: str = Query(min_length=1, max_length=200),
     limit: int = Query(default=5, ge=1, le=20, description="每类结果数上限"),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> GlobalSearchResponse:
-    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
-    if project is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     hits = await search_service.global_search(
-        session, project_id=project_id, q=q, limit_per_type=limit
+        session, user_id=user.id, q=q, limit_per_type=limit
     )
     return GlobalSearchResponse(query=q, hits=hits)

--- a/src/backend/app/services/concepts.py
+++ b/src/backend/app/services/concepts.py
@@ -138,18 +138,22 @@ def normalize_category(raw: Any) -> str:
     return value if value in CONCEPT_CATEGORIES else "other"
 
 
-def library_concept_ids(library_ids: Sequence[uuid.UUID]) -> Select:
+def library_concept_ids(library_ids: Sequence[uuid.UUID] | Select) -> Select:
     """「这些库有哪些**正式**概念」的 concept_id 子查询：库的论文 → 关联概念（去重由 IN 保证）。
 
     候选概念（还没被第 2 篇论文用到）不算数——所有以库/课题为作用域的读路径
     （概念列表、搜索、导出、图谱统计、agent 工具、idea 种子校验）都经此收口。
+
+    ``library_ids`` 也接受一个**子查询**（如「用户够得着的全部库」），这样全局搜索
+    不必绕开这个收口自己拼一遍——绕开的那份迟早会漏掉「候选概念不算数」这一条。
     """
+    scope = library_ids if isinstance(library_ids, Select) else list(library_ids)
     return (
         select(paper_concepts.c.concept_id)
         .join(LibraryPaper, LibraryPaper.paper_id == paper_concepts.c.paper_id)
         .join(Concept, Concept.id == paper_concepts.c.concept_id)
         .where(
-            LibraryPaper.library_id.in_(list(library_ids)),
+            LibraryPaper.library_id.in_(scope),
             Concept.status == CONCEPT_STATUS_ACTIVE,
         )
     )

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -263,13 +263,17 @@ def dedupe_member_rows(
     return list(best.values())
 
 
-def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
-    """用户可见论文（其课题关联的库 ∪ 被任命策展的库 ∪ 平台 admin 全库）的
-    成员行：SELECT (Paper, LibraryPaper, project_id)。
+def visible_library_clause(user_id: uuid.UUID):
+    """「这个库我够得着吗」——库作用域读取口的统一条件，作用于 ``DirectionLibrary.id``。
+
+    够得着 = 库被我参与的某个课题关联 ∪ 我被任命为它的策展人 ∪ 我是平台管理员。
 
     「我课题的库」走关联表 ``topic_source_libraries`` —— 课题与库是多对多关联，
     不是 project_id 回指。按 project_id 判会漏掉课题关联的独立库（那才是常态：
     P9c 起建课题不再自动建库），也会算进已经不再关联的历史起源库。
+
+    单独抽出来是因为不止论文要用：全局搜索的论文与概念两支都得用同一条判据，
+    各写一遍迟早会分叉——而搜索一旦比列表页宽，就是越权，比漏搜严重得多。
     """
     my_projects = select(ProjectMember.project_id).where(ProjectMember.user_id == user_id)
     my_topic_libraries = select(TopicSourceLibrary.library_id).where(
@@ -279,17 +283,28 @@ def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
         DirectionLibraryCurator.user_id == user_id
     )
     is_admin = select(User.id).where(User.id == user_id, User.role == "admin").exists()
+    return or_(
+        DirectionLibrary.id.in_(my_topic_libraries),
+        DirectionLibrary.id.in_(my_curated),
+        is_admin,
+    )
+
+
+def visible_library_ids_stmt(user_id: uuid.UUID) -> Select:
+    """用户够得着的库 id（子查询用）。判据见 :func:`visible_library_clause`。"""
+    return select(DirectionLibrary.id).where(visible_library_clause(user_id))
+
+
+def user_visible_paper_stmt(user_id: uuid.UUID) -> Select:
+    """用户可见论文的成员行：SELECT (Paper, LibraryPaper, project_id)。
+
+    可见性判据见 :func:`visible_library_clause`。
+    """
     return (
         select(Paper, LibraryPaper, DirectionLibrary.project_id)
         .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
         .join(DirectionLibrary, DirectionLibrary.id == LibraryPaper.library_id)
-        .where(
-            or_(
-                DirectionLibrary.id.in_(my_topic_libraries),
-                DirectionLibrary.id.in_(my_curated),
-                is_admin,
-            )
-        )
+        .where(visible_library_clause(user_id))
     )
 
 

--- a/src/backend/app/services/search.py
+++ b/src/backend/app/services/search.py
@@ -17,7 +17,8 @@ from app.models.paper import Concept, Paper
 from app.models.voyage import VoyageRun
 from app.schemas.search import GlobalSearchHit
 from app.services.concepts import library_concept_ids
-from app.services.libraries import get_source_library_ids
+from app.services.libraries import get_source_library_ids, visible_library_ids_stmt
+from app.services.projects import in_my_projects
 
 _SNIPPET_CHARS = 120
 
@@ -32,18 +33,44 @@ def _snippet(text: str | None) -> str | None:
 async def global_search(
     session: AsyncSession,
     *,
-    project_id: uuid.UUID,
     q: str,
     limit_per_type: int = 5,
+    project_id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
 ) -> list[GlobalSearchHit]:
+    """跨实体检索。**作用域二选一**：
+
+    - ``user_id``：用户够得着的全部资产（顶栏 ⌘K 走这条）。判据复用
+      :func:`~app.services.libraries.visible_library_clause` 与
+      :func:`~app.services.projects.in_my_projects`，与列表页、详情页同一口径——
+      搜索比它们宽就是越权，比它们窄就是「明明收录了却搜不到」。
+    - ``project_id``：只搜这个课题（agent 工具 ``global_search`` 走这条，它检索的
+      本来就是课题内的想法/实验/稿件）。
+
+    加新类型时注意：凡是带 ``trashed_at`` 的实体都要排掉回收站里的。搜索是回收站最容易
+    漏掉的出口——列表页都记得过滤，搜索却把删掉的东西照样捞回来，点进去还是活的。
+    目前 idea / experiment / manuscript 三种是软删的。
+    """
+    if (project_id is None) == (user_id is None):
+        raise ValueError("global_search 需要且只需要 project_id 或 user_id 其一")
+
     pattern = f"%{q}%"
     hits: list[GlobalSearchHit] = []
-    # 加新类型时注意：凡是带 ``trashed_at`` 的实体都要排掉回收站里的。搜索是回收站最容易
-    # 漏掉的出口——列表页都记得过滤，搜索却把删掉的东西照样捞回来，点进去还是活的。
-    # 目前 idea / experiment / manuscript 三种是软删的。
-    # 论文/概念按课题关联库并集检索；无关联库 = 无语料时跳过它们，
-    # ideas/实验/航程/稿件等课题作用域实体照常匹配（不受关联库影响）。
-    library_ids = await get_source_library_ids(session, project_id)
+
+    if project_id is not None:
+        # 课题作用域：论文/概念按课题关联库并集检索；无关联库 = 无语料，跳过这两类。
+        library_scope: object = await get_source_library_ids(session, project_id)
+        no_corpus = not library_scope
+
+        def scoped(col):
+            return col == project_id
+    else:
+        assert user_id is not None
+        library_scope = visible_library_ids_stmt(user_id)
+        no_corpus = False  # 子查询为空时自然搜不到，不必先查一次
+
+        def scoped(col):
+            return in_my_projects(col, user_id)
 
     # 跨库并集：group_by(Paper.id) 去掉同一论文命中多库的重复行（状态取任一非回收站行）
     paper_rows = (
@@ -52,7 +79,7 @@ async def global_search(
                 select(Paper, func.min(LibraryPaper.status))
                 .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
                 .where(
-                    LibraryPaper.library_id.in_(library_ids),
+                    LibraryPaper.library_id.in_(library_scope),
                     LibraryPaper.status != "excluded",  # 回收站不出现在搜索里
                     or_(
                         Paper.title.ilike(pattern),
@@ -65,7 +92,7 @@ async def global_search(
                 .limit(limit_per_type)
             )
         ).all()
-        if library_ids
+        if not no_corpus
         else []
     )
     hits += [
@@ -85,7 +112,7 @@ async def global_search(
                 await session.execute(
                     select(Concept)
                     .where(
-                        Concept.id.in_(library_concept_ids(library_ids)),
+                        Concept.id.in_(library_concept_ids(library_scope)),
                         or_(Concept.name.ilike(pattern), Concept.definition.ilike(pattern)),
                     )
                     .order_by(Concept.updated_at.desc())
@@ -95,7 +122,7 @@ async def global_search(
             .scalars()
             .all()
         )
-        if library_ids
+        if not no_corpus
         else []
     )
     hits += [
@@ -108,7 +135,7 @@ async def global_search(
             await session.execute(
                 select(Idea)
                 .where(
-                    Idea.project_id == project_id,
+                    scoped(Idea.project_id),
                     Idea.trashed_at.is_(None),
                     or_(Idea.title.ilike(pattern), Idea.summary.ilike(pattern)),
                 )
@@ -131,7 +158,7 @@ async def global_search(
             select(Experiment, Idea.title)
             .join(Idea, Experiment.idea_id == Idea.id)
             .where(
-                Experiment.project_id == project_id,
+                scoped(Experiment.project_id),
                 Experiment.trashed_at.is_(None),
                 Idea.trashed_at.is_(None),
                 Idea.title.ilike(pattern),
@@ -149,7 +176,7 @@ async def global_search(
         (
             await session.execute(
                 select(VoyageRun)
-                .where(VoyageRun.project_id == project_id, VoyageRun.goal.ilike(pattern))
+                .where(scoped(VoyageRun.project_id), VoyageRun.goal.ilike(pattern))
                 .order_by(VoyageRun.updated_at.desc())
                 .limit(limit_per_type)
             )
@@ -173,7 +200,7 @@ async def global_search(
             await session.execute(
                 select(Manuscript)
                 .where(
-                    Manuscript.project_id == project_id,
+                    scoped(Manuscript.project_id),
                     Manuscript.trashed_at.is_(None),
                     Manuscript.title.ilike(pattern),
                 )

--- a/src/backend/tests/test_search.py
+++ b/src/backend/tests/test_search.py
@@ -64,7 +64,7 @@ async def test_search_across_entities(client):
     project_id, headers = await _setup(client)
 
     resp = await client.get(
-        f"/api/projects/{project_id}/global-search", params={"q": "graph"}, headers=headers
+        "/api/global-search", params={"q": "graph"}, headers=headers
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -85,7 +85,7 @@ async def test_search_matches_are_case_insensitive_and_scoped(client):
     project_id, headers = await _setup(client)
 
     resp = await client.get(
-        f"/api/projects/{project_id}/global-search",
+        "/api/global-search",
         params={"q": "GRAPH RETRIEVAL FOR"},
         headers=headers,
     )
@@ -94,21 +94,54 @@ async def test_search_matches_are_case_insensitive_and_scoped(client):
     assert types == {"paper"}
 
     resp = await client.get(
-        f"/api/projects/{project_id}/global-search", params={"q": "不存在的关键词"}, headers=headers
+        "/api/global-search", params={"q": "不存在的关键词"}, headers=headers
     )
     assert resp.status_code == 200
     assert resp.json()["hits"] == []
 
 
-async def test_search_requires_membership(client):
-    project_id, _ = await _setup(client)
+async def test_search_never_leaks_other_peoples_work(client):
+    """搜索范围 = 我够得着的一切，**一点都不能多**。
+
+    这条以前靠「路由上带课题 id，非成员回 404」来保证。现在搜索不挂课题了，那道
+    门没有了，可见性判据成了唯一的防线——所以它必须被直接钉住，而不是顺带成立。
+
+    越权比漏搜严重得多：漏搜用户会抱怨，越权没人会发现。
+    """
+    await _setup(client)
     other = await register_and_login(client, email="bob@example.com")
+
     resp = await client.get(
-        f"/api/projects/{project_id}/global-search",
+        "/api/global-search",
         params={"q": "graph"},
         headers={"Authorization": f"Bearer {other}"},
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["hits"] == [], "陌生人不该搜到别人课题里的任何东西"
+
+
+async def test_search_spans_every_topic_i_can_reach(client):
+    """跨课题：搜索不再只看「当前课题」。
+
+    这是这次改动的由来——一篇好端端收录在某个库里的论文，站在别的课题上就是搜不到，
+    而界面不会说明原因，看起来就像根本没收录（生产上真的这么误判过一次）。
+    """
+    first_id, headers = await _setup(client)
+
+    # 同一个用户再建一个课题，并在里面放一个可被搜到的想法
+    resp = await client.post("/api/projects", json={"name": "second-proj"}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    second_id = uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        session.add(Idea(project_id=second_id, title="Graph idea in the other topic"))
+        await session.commit()
+
+    resp = await client.get("/api/global-search", params={"q": "graph"}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    titles = [h["title"] for h in resp.json()["hits"] if h["type"] == "idea"]
+    assert "Graph retrieval idea" in titles, "第一个课题的想法"
+    assert "Graph idea in the other topic" in titles, "第二个课题的想法——以前这条搜不到"
+    assert first_id  # 两个课题的东西同时出现在一次搜索里
 
 
 async def test_search_skips_the_recycle_bin(client):
@@ -125,7 +158,7 @@ async def test_search_skips_the_recycle_bin(client):
 
     async def types_for(q: str) -> set[str]:
         r = await client.get(
-            f"/api/projects/{project_id}/global-search", params={"q": q}, headers=headers
+            "/api/global-search", params={"q": q}, headers=headers
         )
         assert r.status_code == 200, r.text
         return {hit["type"] for hit in r.json()["hits"]}

--- a/src/frontend/src/app/SearchPalette.tsx
+++ b/src/frontend/src/app/SearchPalette.tsx
@@ -5,15 +5,15 @@ import { Icon, type IconName } from '../components/ui/Icon';
 import { PaperStatusPill, StatusPill } from '../components/ui/StatusPill';
 import { api, type GlobalSearchHit, type GlobalSearchHitType } from '../lib/api';
 import { tr } from '../lib/i18n';
-import { topicPath, useProject } from './project';
 
 /** 各实体类型的展示顺序 / 文案 / 图标 / 跳转目标（pid = 当前课题，课题域列表页需要拼前缀）。 */
 const TYPE_META: Record<
   GlobalSearchHitType,
-  { zh: string; en: string; icon: IconName; to: (h: GlobalSearchHit, pid: string | null) => string }
+  { zh: string; en: string; icon: IconName; to: (h: GlobalSearchHit) => string }
 > = {
   paper: { zh: '论文', en: 'Papers', icon: 'book', to: (h) => `/papers/${h.id}/read` },
-  concept: { zh: '概念', en: 'Concepts', icon: 'sparkle', to: (h, pid) => topicPath(pid, `wiki?concept=${encodeURIComponent(h.title)}`) },
+  // 概念走非课题路由：搜索现在跨课题，拿「当前课题」拼链接会指到一个根本没有这个概念的课题去
+  concept: { zh: '概念', en: 'Concepts', icon: 'sparkle', to: (h) => `/concepts/${h.id}` },
   idea: { zh: '想法', en: 'Ideas', icon: 'bulb', to: (h) => `/ideas/${h.id}` },
   experiment: { zh: '实验', en: 'Experiments', icon: 'flask', to: (h) => `/experiment/${h.id}` },
   voyage: { zh: 'AI 任务', en: 'Tasks', icon: 'compass', to: (h) => `/voyages/${h.id}` },
@@ -25,7 +25,6 @@ const TYPE_ORDER = Object.keys(TYPE_META) as GlobalSearchHitType[];
 /** 顶栏 ⌘K 全局搜索面板：跨论文/概念/想法/实验/AI 任务/论文稿检索并跳转。 */
 export function SearchPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
   const navigate = useNavigate();
-  const { currentProjectId } = useProject();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [q, setQ] = useState('');
   const [debounced, setDebounced] = useState('');
@@ -48,9 +47,11 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
   }, [q]);
 
   const query = useQuery({
-    queryKey: ['global-search', currentProjectId, debounced],
-    queryFn: () => api.globalSearch(currentProjectId!, debounced),
-    enabled: open && !!currentProjectId && debounced.length > 0,
+    queryKey: ['global-search', debounced],
+    queryFn: () => api.globalSearch(debounced),
+    // 不再要求先选课题：搜索范围是「我够得着的一切」，在 /libraries、/daily
+    // 这类非课题页面上同样该能用——以前这里是禁用的。
+    enabled: open && debounced.length > 0,
     staleTime: 30_000,
     retry: false,
     placeholderData: keepPreviousData,
@@ -69,7 +70,7 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
 
   function go(hit: GlobalSearchHit) {
     onClose();
-    navigate(TYPE_META[hit.type].to(hit, currentProjectId));
+    navigate(TYPE_META[hit.type].to(hit));
   }
 
   function onKeyDown(e: React.KeyboardEvent) {
@@ -91,9 +92,7 @@ export function SearchPalette({ open, onClose }: { open: boolean; onClose: () =>
 
   const showing = debounced.length > 0;
   let body: React.ReactNode;
-  if (!currentProjectId) {
-    body = <div className="empty" style={{ padding: 24 }}>{tr('请先在侧边栏选择一个课题', 'Pick a topic in the sidebar first')}</div>;
-  } else if (!showing) {
+  if (!showing) {
     body = (
       <div className="empty" style={{ padding: 24 }}>
         {tr('输入关键词开始搜索', 'Type keywords to search')}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3337,9 +3337,10 @@ export const api = {
   },
 
   // —— 全局搜索（顶栏 ⌘K）：论文/概念/想法/实验/AI 任务/稿件跨实体检索 ——
-  globalSearch(projectId: string, q: string, limit = 5): Promise<GlobalSearchResponse> {
+  /** 搜索范围 = 我够得着的一切，**不挂课题**（后端按可见性判，与列表页同一口径）。 */
+  globalSearch(q: string, limit = 5): Promise<GlobalSearchResponse> {
     const params = new URLSearchParams({ q, limit: String(limit) });
-    return request<GlobalSearchResponse>(`/projects/${projectId}/global-search?${params}`);
+    return request<GlobalSearchResponse>(`/global-search?${params}`);
   },
 
   // —— M2 · Papers ——


### PR DESCRIPTION
Closes #433

## The report

A paper could not be found in the top-bar search. It had been ingested correctly the whole time — `arXiv:2608.11669`, compiled in the `Rubric` library at relevance 0.95, present in the daily pool too.

Running the real search function against all 26 production topics:

```
q = "Rubric Dropout"
  [rubric训练方法的优化]  papers matched 1   ← the only one
  the other 25 topics     papers matched 0
```

Search scoped papers and concepts to `get_source_library_ids(project_id)`. The `Rubric` library is linked to one topic, so from anywhere else the paper was invisible — with nothing in the UI to say why. It reads as "never ingested", which is the conclusion the reporter drew.

Second problem in the same place: `enabled: open && !!currentProjectId` meant the palette did nothing at all on `/libraries`, `/daily`, or any other non-topic page.

## Scope is now what the user can reach

Reusing the rule the list and detail pages already apply, rather than writing a second one:

- `visible_library_clause` — libraries reachable through my topics ∪ libraries I curate ∪ everything for a platform admin. Extracted from `user_visible_paper_stmt`, which now calls it. Papers and concepts have to answer to the same rule and two copies drift.
- `in_my_projects` — for ideas, experiments, voyages and manuscripts.

`library_concept_ids` now accepts a subquery as well as a list, so search goes through the existing choke point instead of assembling its own concept scope — the docstring there says every library-scoped concept read goes through it, and a second copy would eventually forget that candidate concepts do not count.

## What did not change

`global_search` takes either `project_id` or `user_id` (exactly one). The agent tool in `app/tools/knowledge.py` keeps passing `project_id`, because it searches within a topic by design — *"它检索的是课题内的想法/实验/稿件"*. Only the HTTP route stopped being topic-bound.

Concept results link to `/concepts/:id` instead of a topic-scoped path built from whichever topic happened to be selected — that path would have pointed at a topic which does not contain the concept. The other five hit types already navigated by entity id.

## On the authorization test

`test_search_requires_membership` asserted a 404 from a route that no longer carries a topic id. Deleting it would have removed the only check on the property that mattered, so it was rewritten to assert that directly: a stranger searching gets **zero** hits.

It was then run against a build with `visible_library_clause` and `in_my_projects` both opened up, where it fails. That verification is the point — widening a search errs invisibly in one direction. Under-reaching produces a complaint; over-reaching leaks other people's work and nobody notices.

Also added: a cross-topic test asserting one search returns ideas from two different topics, which is the behaviour this whole change is about.

## Testing

- Backend 82 passed: `test_concept_promotion test_concepts_relink test_wiki_api test_library test_library_governance test_library_lifecycle test_mcp_workspace_tools test_mcp_server`
- Backend 42 passed: `test_search test_search_excludes_trash test_tools_registry test_library_authz_after_decoupling test_library_paper_management test_daily_library_visibility`
- Frontend `tsc --noEmit` clean, `vitest run` 86 passed, `npm run build` succeeds
- Ruff clean across `app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr