### PR TITLE
feat(lab): daily-paper bars open that day, not the newest one

### DIFF
--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   keepPreviousData,
   useInfiniteQuery,
@@ -660,7 +660,11 @@ export function DailyPage() {
   // 日期：勾上「全部」就是跨天一起看（默认）；取消勾选后在有数据的日期间前后切换。
   // 只在这些日期间跳，而不是任意日历日——中间没有公告的日子点进去是空的。
   const [showAll, setShowAll] = useState(false);
-  const [day, setDay] = useState('');
+  // 深链 ?date=YYYY-MM-DD（实验室工作台的柱子点进来）。**初值直接取 URL**，
+  // 不只靠下面那个 effect：默认「停在最新一天」的 effect 会先跑，只走 effect 的话
+  // 会先闪一下最新那天再跳到目标日期。
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [day, setDay] = useState(() => searchParams.get('date') ?? '');
   // 高级检索默认展开：分类 / 类型是常用筛选，藏起来用户找不到
   // 默认收起：日期切换已经在工具栏上，高级条件是偶尔才用的东西
   const [advOpen, setAdvOpen] = useState(false);
@@ -715,9 +719,16 @@ export function DailyPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showAll, day, dates.join(',')]);
 
+  // 深链落地：带 ?date= 进来就停在那一天，然后**把参数清掉**——留着的话，之后在
+  // 页内切到别的日期再刷新，又会被它按回去。清参数用 replace，不往历史里塞一条。
+  useEffect(() => {
+    const target = searchParams.get('date');
+    if (!target) return;
+    setShowAll(false);
+    setDay(target);
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
 
-  // 默认停在「全部」：跨天一起看、按时间倒排，最新的自然在最前。以前默认落到最新
-  // 一天，那一天恰好没有新公告（周末）时页面就是空的，看着像坏了。
 
 
   // 点作者/机构 → 列表只留匹配的论文（走已有的高级检索），其余条件重置并展开面板；

--- a/src/frontend/src/features/daily/__tests__/dailyDateDeepLink.test.ts
+++ b/src/frontend/src/features/daily/__tests__/dailyDateDeepLink.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/* ============================================================
+   实验室工作台的每日新论文柱子 → 直达那一天。
+
+   两边各有一半，缺一半就没用：工作台不带 ?date= 是白链，/daily 不认 ?date= 是白传。
+   而两种坏法的表现一模一样——点“8月4日 · 903 篇”落在最新一天，看着像没生效。
+   类型检查看不见这类回归，所以在源码层面钉住。
+   ============================================================ */
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf-8');
+
+/** 只看代码：注释里正好在解释这件事，别把它当成实现。 */
+const code = (source: string) =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const lab = code(read('../../lab/LabPage.tsx'));
+const daily = code(read('../DailyPage.tsx'));
+
+describe('每日新论文的日期直达', () => {
+  it('工作台的柱子带上 ?date=', () => {
+    expect(lab).toMatch(/to=\{`\/daily\?date=\$\{encodeURIComponent\(d\.date\)\}`\}/);
+  });
+
+  it('版块标题旁的按钮不带日期（那是「去看看」，不是某一天）', () => {
+    expect(lab).toContain('to="/daily"');
+  });
+
+  it('/daily 认 ?date=', () => {
+    expect(daily).toContain('useSearchParams');
+    expect(daily).toMatch(/searchParams\.get\('date'\)/);
+  });
+
+  it('日期初值直接取 URL，不只靠 effect', () => {
+    // 只走 effect 的话，「默认停在最新一天」那个 effect 会先跑，
+    // 页面会先闪一下最新那天再跳到目标日期。
+    expect(daily).toMatch(/useState\(\(\) => searchParams\.get\('date'\) \?\? ''\)/);
+  });
+
+  it('用过就把参数清掉，且不往历史里塞记录', () => {
+    // 留着的话，页内切到别的日期再刷新会被它按回去。
+    expect(daily).toMatch(/setSearchParams\(\{\}, \{ replace: true \}\)/);
+  });
+});

--- a/src/frontend/src/features/lab/LabPage.tsx
+++ b/src/frontend/src/features/lab/LabPage.tsx
@@ -324,13 +324,14 @@ function DailyCard() {
 
           {/*
             单序列迷你分布：柱子统一 accent 色（明度区分靠高度），标签用文本色。
-            /daily 目前不认 ?date=，柱子统一进列表页（日期在那里再选）。
+            每根柱子带 ?date= 直达那一天——以前统一跳 /daily 再让人自己翻日期，
+            点“8月4日 · 903 篇”却落在最新一天，看着像没生效。
           */}
           <div className="row" style={{ gap: 8, alignItems: 'flex-end' }}>
             {days.map((d) => (
               <Link
                 key={d.date}
-                to="/daily"
+                to={`/daily?date=${encodeURIComponent(d.date)}`}
                 title={`${d.date} · ${d.count}`}
                 style={{ flex: 1, minWidth: 0, textDecoration: 'none', display: 'block' }}
               >


### PR DESCRIPTION
Reported: clicking an entry in the lab workbench's daily-papers block should go to that day.

## What it did

Every bar linked to `/daily` with no date, so clicking **8月4日 · 903 篇** landed on whichever day was newest. The comment beside it explained why:

```
/daily 目前不认 ?date=，柱子统一进列表页（日期在那里再选）。
```

So it was a known gap rather than an oversight — but on screen it reads as a link that does not work.

## Both halves

Either one alone is useless: a date in the link that nothing reads, or a reader with no link that sends one. **Both fail identically on screen**, which is why the guard test checks them separately and was run with each half reverted in turn.

- `LabPage`: each bar links to `/daily?date=<that day>`. The section-level button beside the heading still goes to plain `/daily` — that one means "go look", not "go to a day".
- `DailyPage`: reads `?date=`, stays on that day, then clears the param.

## Two details worth stating

`day` takes its **initial value straight from the URL**, not only through an effect. The existing "stay on the newest day" effect runs first, so an effect-only version flashes the newest day before jumping to the target. The effect is still there as well, so the param also works when it arrives without a remount.

The param is **cleared after it lands**, with `replace`. Left in place it would snap the page back to that date on the next reload after the reader had moved to another day, and it does not deserve a history entry.

## Also

Dropped a stale comment above `showAll` claiming the default is 「全部」 while the state initialises to `false`. It described behaviour that had been replaced. A comment contradicting the line directly under it is worse than no comment — that exact kind of drift has cost real debugging time in this repo recently.

## Testing

- `tsc --noEmit` clean, `npm run build` succeeds, 91 frontend tests pass
- New guard test verified against both halves reverted; each reversion fails a different assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W19Guz3etiapCERw5XbXnr