### PR TITLE
fix(literature): score pool hits in new libraries

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -309,7 +309,9 @@ async def collect(
     tasks: list[DailyCollectTask] = []
     for paper_id in payload.paper_ids:
         paper = await session.get(Paper, paper_id)
-        if paper is None or await paper_enrich_service.paper_processing_complete(session, paper):
+        if paper is None or await paper_enrich_service.paper_processing_complete(
+            session, paper, library_id=target_library_id
+        ):
             continue
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -900,7 +900,9 @@ async def add_library_paper_manually(
         ) from e
     paper_id, user_id, project_id = result.paper.id, user.id, library.project_id
     task_id: str | None = None
-    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    already_done = await paper_enrich_service.paper_processing_complete(
+        session, result.paper, library_id=library.id
+    )
     if result.created or not already_done:
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -248,9 +248,13 @@ async def add_paper_manually(
     paper_id, user_id = result.paper.id, user.id
     # 后台补全：新建或未处理完整时启动（含针对起源库 definition 的打分）
     task_id: str | None = None
-    already_done = await paper_enrich_service.paper_processing_complete(session, result.paper)
+    library = await libraries_service.get_library_for_project(session, project_id)
+    already_done = await paper_enrich_service.paper_processing_complete(
+        session,
+        result.paper,
+        library_id=library.id if library is not None else None,
+    )
     if result.created or not already_done:
-        library = await libraries_service.get_library_for_project(session, project_id)
         task_id = await paper_enrich_service.launch_paper_enrichment(
             redis=redis,
             paper_id=paper_id,

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -70,15 +70,29 @@ _TASKS: dict[str, asyncio.Task] = {}
 Emit = Callable[..., Awaitable[None]]
 
 
-async def paper_processing_complete(session: AsyncSession, paper: Paper) -> bool:
-    """论文是否已处理完整（PDF + 全文 + 当前空间下的向量都在）——完整则无需再补全。
+async def paper_processing_complete(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    library_id: uuid.UUID | None = None,
+) -> bool:
+    """论文是否已处理完整（共享内容齐备，且目标库成员已打分）。
 
     「有向量」按**激活空间**算：换了嵌入模型之后，旧空间的向量对检索已经不可见，
     这篇论文就该重新走一遍补全，而不是因为库里还留着旧向量就认为它已就绪。
+    ``library_id`` 为空时只检查共享内容；指定目标库时还要求该成员行已有相关性分。
     """
     if not (paper.pdf_path and paper.full_text_path):
         return False
-    return await has_current_paper_vector(session, paper)
+    if not await has_current_paper_vector(session, paper):
+        return False
+    if library_id is None:
+        return True
+
+    from app.services.libraries import get_membership
+
+    membership = await get_membership(session, library_id=library_id, paper_id=paper.id)
+    return membership is not None and membership.relevance_score is not None
 
 
 def paper_embedding_text(paper: Paper) -> str:
@@ -461,7 +475,7 @@ async def _run_batch_import(
                     else:
                         paper = result.paper
                         processing = result.created or not await paper_processing_complete(
-                            session, paper
+                            session, paper, library_id=library_id
                         )
                         child_task_id: str | None = None
                         if processing:

--- a/src/backend/app/services/relevance.py
+++ b/src/backend/app/services/relevance.py
@@ -149,13 +149,14 @@ async def score_paper_relevance(
     data = _extract_json(result.content)
     score = min(1.0, max(0.0, float(data["score"])))
     membership.relevance_score = score
+    membership.relevance_reason = str(data.get("reason") or "")
     # **只在空的时候填。** 打分是库侧判断，而 tldr 挂在全平台共享的论文上：谁最后
     # 打分谁就覆盖掉前一个库（乃至编译产出的正式 TL;DR），于是所有库看到的都是最后
     # 那个库的判词。这里只当「还没有摘要时的临时占位」，编译一跑就由正式的接管。
     paper.tldr = paper.tldr or str(data.get("tldr") or "")
     membership.scored_at = utcnow()
     membership.scored_run_id = voyage_id  # 手动加论文没有任务，留 NULL
-    return RelevanceResult(score=score, reason=str(data.get("reason") or ""), tldr=paper.tldr or "")
+    return RelevanceResult(score=score, reason=membership.relevance_reason, tldr=paper.tldr or "")
 
 
 async def score_added_paper_best_effort(

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -257,6 +257,24 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     resp = await client.get("/api/daily/papers", headers=headers)
     item = resp.json()["items"][0]
 
+    # 即使池论文的共享内容已经齐全，新方向库成员尚未打分时也必须启动补全。
+    from app.core.db import get_sessionmaker
+    from app.models.paper import Paper
+    from app.services import paper_enrich
+    from tests.vector_helpers import set_paper_vector
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, uuid.UUID(item["paper_id"]))
+        assert paper is not None
+        paper.pdf_path = "/tmp/complete.pdf"
+        paper.full_text_path = "/tmp/complete.txt"
+        await session.commit()
+        await set_paper_vector(session, paper.id)
+        assert await paper_enrich.paper_processing_complete(session, paper)
+        assert not await paper_enrich.paper_processing_complete(
+            session, paper, library_id=library_id
+        )
+
     payload = {
         "paper_ids": [item["paper_id"]],
         "direction_library_ids": [str(library_id)],
@@ -270,8 +288,6 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
         launched.append(kwargs)
         return "task-stub"
 
-    from app.services import paper_enrich
-
     monkeypatch.setattr(paper_enrich, "launch_paper_enrichment", _fake_launch)
 
     resp = await client.post("/api/daily/collect", json=payload, headers=headers)
@@ -282,7 +298,7 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     # 入架必入个人库（add_to_shelf 自带同步），个人库目标看到的是「已存在」
     assert results["personal"]["added"] + results["personal"]["skipped_existing"] == 1
 
-    # 池论文是轻量行（无 PDF）→ 必然触发补全，且目标库/课题归因正确
+    # 共享内容已齐全，但目标库尚无评分 → 仍须补全，且目标库/课题归因正确
     assert len(launched) == 1
     assert str(launched[0]["paper_id"]) == item["paper_id"]
     assert launched[0]["library_id"] == library_id
@@ -303,7 +319,6 @@ async def test_collect_to_library_topic_personal(client, monkeypatch):
     # 成员行 status=included
     from sqlalchemy import select
 
-    from app.core.db import get_sessionmaker
     from app.models.library_direction import LibraryPaper
 
     async with get_sessionmaker()() as session:

--- a/src/backend/tests/test_paper_add_progress.py
+++ b/src/backend/tests/test_paper_add_progress.py
@@ -76,8 +76,8 @@ async def test_manual_add_returns_task_id_for_new_paper(client, lit_clients, fak
     await paper_enrich.await_task(task_id)  # 排空后台任务（触发 pdf 404 download）
 
 
-async def test_manual_add_task_id_null_when_pool_hit_complete(client, fake_redis):
-    """池命中且已处理完整（有 pdf/全文/embedding）→ task_id 为 null。"""
+async def test_manual_add_pool_hit_complete_still_scores_new_membership(client, fake_redis):
+    """池命中且共享内容完整时，仍为新方向库成员启动打分。"""
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
     proj_a, _ = await make_project_with_library(client, headers, name="seed-proj")
@@ -95,13 +95,23 @@ async def test_manual_add_task_id_null_when_pool_hit_complete(client, fake_redis
         )
         await session.commit()
 
-    # 加同一 DOI 到另一课题：池命中、本库无成员行、论文已完整 → 不启动任务
+    # 加同一 DOI 到另一课题：共享内容已完整，但目标库成员尚未打分 → 仍启动任务
     bibtex = "@article{c,\n title={Fully Processed Paper},\n doi={10.5555/complete},\n}"
     resp = await client.post(
         f"/api/projects/{proj_b}/papers", json={"bibtex": bibtex}, headers=headers
     )
     assert resp.status_code == 201, resp.text
-    assert resp.json()["task_id"] is None
+    task_id = resp.json()["task_id"]
+    assert task_id
+    await paper_enrich.await_task(task_id)
+
+    async with get_sessionmaker()() as session:
+        membership = await membership_of(
+            session, project_id=proj_b, paper_id=resp.json()["id"]
+        )
+        assert membership.relevance_score is not None
+        assert membership.relevance_reason
+        assert membership.scored_at is not None
 
 
 # ---- 2. enrich_paper 阶段事件顺序 + 出错继续 + done ----

--- a/src/backend/tests/test_paper_manual_add.py
+++ b/src/backend/tests/test_paper_manual_add.py
@@ -242,8 +242,88 @@ async def test_add_scores_relevance_best_effort(client, fake_redis):
     async with get_sessionmaker()() as session:
         membership = await membership_of(session, project_id=project_id, paper_id=body["id"])
         assert membership.relevance_score is not None and membership.relevance_score > 0.6
+        assert membership.relevance_reason
         assert membership.scored_at is not None
         assert membership.status == "included"  # 人工纳入，打分不改状态
+
+
+@pytest.mark.parametrize("batch", [False, True], ids=["single", "batch"])
+async def test_complete_pool_hit_still_scores_new_library_membership(
+    client, fake_redis, tmp_path, batch
+):
+    """共享内容已完整的池命中仍须为新方向库成员打分。"""
+    from app.models.paper import new_paper
+    from app.services import paper_enrich
+    from app.services.libraries import get_membership
+    from app.services.paper_import import pool_dedup_key
+    from tests.vector_helpers import set_paper_vector
+
+    project_id, headers = await _setup(client)
+    async with get_sessionmaker()() as session:
+        from app.services.libraries import get_library_for_project
+
+        library = await get_library_for_project(session, uuid.UUID(project_id))
+        assert library is not None
+        library_id = library.id
+
+        suffix = "batch" if batch else "single"
+        title = f"Complete Pool Paper {suffix}"
+        doi = f"10.1000/complete-{suffix}"
+        pdf_path = tmp_path / f"{suffix}.pdf"
+        text_path = tmp_path / f"{suffix}.txt"
+        pdf_path.write_bytes(b"%PDF-1.4\n")
+        text_path.write_text("Complete paper full text.", encoding="utf-8")
+        paper = new_paper(
+            source="manual",
+            dedup_key=pool_dedup_key(
+                arxiv_id=None,
+                doi=doi,
+                title=title,
+                year=2025,
+                authors=[{"name": "Test Author"}],
+            ),
+            title=title,
+            authors=[{"name": "Test Author"}],
+            affiliations=["Test Lab"],
+            abstract="A relevant completed pool paper.",
+            year=2025,
+            doi=doi,
+            pdf_path=str(pdf_path),
+            full_text_path=str(text_path),
+        )
+        session.add(paper)
+        await session.flush()
+        paper_id = paper.id
+        await set_paper_vector(session, paper_id)
+
+    bibtex = (
+        f"@article{{complete-{suffix},\n"
+        f" title={{{title}}},\n author={{Test Author}},\n year={{2025}},\n doi={{{doi}}}\n}}"
+    )
+    if batch:
+        resp = await client.post(
+            f"/api/libraries/{library_id}/paper-imports/batch",
+            json={"items": [{"bibtex": bibtex}]},
+            headers=headers,
+        )
+    else:
+        resp = await client.post(
+            f"/api/libraries/{library_id}/papers",
+            json={"bibtex": bibtex},
+            headers=headers,
+        )
+    assert resp.status_code in (201, 202), resp.text
+    assert resp.json()["task_id"]
+    await paper_enrich.await_task(resp.json()["task_id"])
+
+    async with get_sessionmaker()() as session:
+        membership = await get_membership(
+            session, library_id=library_id, paper_id=paper_id
+        )
+        assert membership is not None
+        assert membership.relevance_score is not None
+        assert membership.relevance_reason
+        assert membership.scored_at is not None
 
 
 async def test_add_low_score_keeps_included(client, fake_redis):


### PR DESCRIPTION
## Summary

Ensure an already-enriched pool paper still receives library-specific relevance scoring when it gains a new direction-library membership. Shared PDF, full-text, and embedding work remains reusable; only missing target-library work causes enrichment to launch.

Fixes #437

## Area

- [ ] frontend
- [ ] desktop (Electron client)
- [x] backend-api
- [ ] voyage (task loop)
- [x] literature / wiki
- [x] daily papers
- [ ] idea forge
- [ ] experiment
- [ ] writer
- [ ] review
- [ ] skills
- [ ] llm routing / usage
- [ ] auth / users
- [ ] infra / deploy
- [ ] docs

## What changed

- Make enrichment completeness target-library-aware for project, library single/batch, and daily-collect entry points.
- Keep shelf and personal-library imports content-only when no direction library is targeted.
- Persist the relevance reason alongside score and timestamp.
- Add regression coverage for fully processed pool hits and verify shared stages are reused.

## Testing

- [x] `pytest -q tests/test_paper_manual_add.py tests/test_paper_add_progress.py tests/test_relevance_context.py tests/test_daily_feed.py::test_collect_to_library_topic_personal` — 42 passed
- [x] Daily completed-pool regression rerun after writing a real active-space `PaperVector` — 1 passed
- [x] Ruff passed on all 8 changed Python files
- [x] `git diff --check origin/main...HEAD`

## Checklist

- [x] Branch is rebased on the latest `origin/main` (not merged from main)
- [x] Conventional-commit PR title (`feat|fix|chore|docs(scope): …`)
- [x] No AI attribution / `Co-Authored-By` lines in commits
- [x] No migration or UI changes