### PR TITLE
fix(present): review every rendered slide, not just the first 8

### DIFF
--- a/src/backend/app/agents/voyage/actions_present.py
+++ b/src/backend/app/agents/voyage/actions_present.py
@@ -40,6 +40,12 @@ _MAX_JSON_ATTEMPTS = 3
 _SINGLE_BODY_CHARS = 12000
 _SURVEY_BODY_CHARS = 4000
 _FIX_ROUNDS = 2
+
+#: 视觉审查一次送审几页。上限本身是合理的——一次塞满整份 deck 既贵也可能超上下文；
+#: 错的是**在上限之内假装看全了**：以前提示词说「共 N 页」却只发 images[:8]，
+#: 模型对收到的图回 ok=true，循环就退出，对外表现为整份 deck 视觉审查通过（#436）。
+#: 现在按这个大小分批，每批都送审，提示词只描述本批实际发出去的东西。
+_VISUAL_BATCH = 8
 _STAGE = "librarian"  # 多模态路由（大纲/甲板/视觉评审共用）
 
 DECK_JSON_SPEC = """\
@@ -293,31 +299,47 @@ async def present_build(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
 
     # ②视觉反馈迭代：soffice 渲染成图 → VLM 审 → LLM 修（无 soffice 降级跳过）
     visual_rounds, visual_issues = 0, []
+    rendered_pages = reviewed_pages = 0
     if soffice_available():
         for _ in range(_FIX_ROUNDS):
             images = render_slide_images(pptx)
             if not images:
                 break
+            rendered_pages = len(images)
 
             def validate(data: Any) -> dict[str, Any]:
                 if not isinstance(data, dict) or not isinstance(data.get("ok"), bool):
                     raise ValueError("expected {ok, issues}")
                 return {"ok": data["ok"], "issues": data.get("issues") or []}
 
-            review = await _complete_json(
-                ctx,
-                system=VISUAL_SYSTEM,
-                user=f"共 {len(images)} 页渲染图，按顺序对应第 1-{len(images)} 页。",
-                validate=validate,
-                images=images[:8],
-            )
-            if review["ok"] or not review["issues"]:
+            # 整份 deck 逐批过一遍：每批只声明自己那几页，并要求 slide 填**绝对页码**——
+            # 不要求的话每批都会从 1 开始编号，修复时会照着改错页。
+            round_issues: list[Any] = []
+            for start in range(0, len(images), _VISUAL_BATCH):
+                chunk = images[start : start + _VISUAL_BATCH]
+                first, last = start + 1, start + len(chunk)
+                review = await _complete_json(
+                    ctx,
+                    system=VISUAL_SYSTEM,
+                    user=(
+                        f"这是整份 deck（共 {len(images)} 页）中第 {first}-{last} 页的渲染图，"
+                        f"随消息附上 {len(chunk)} 张，顺序与页码一致。"
+                        f"issues 里的 slide 请填**整份 deck 的绝对页码**（即 {first}-{last} 之间）。"
+                    ),
+                    validate=validate,
+                    images=chunk,
+                )
+                if not review["ok"]:
+                    round_issues.extend(review["issues"])
+            reviewed_pages = len(images)
+
+            if not round_issues:
                 break
             visual_rounds += 1
-            visual_issues = review["issues"]
+            visual_issues = round_issues
             diagnosis = "\n".join(
                 f"- 第 {i.get('slide')} 页：{i.get('problem')}（建议：{i.get('fix')}）"
-                for i in review["issues"]
+                for i in round_issues
                 if isinstance(i, dict)
             )
             deck = await _fix_deck(ctx, spec.model_dump(), "视觉审查未通过：\n" + diagnosis)
@@ -344,6 +366,10 @@ async def present_build(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
         "text_fix_rounds": text_rounds,
         "visual_fix_rounds": visual_rounds,
         "render_feedback": "soffice" if soffice_available() else "skipped",
+        # 审了几页要能从外面看见。以前只报「视觉审查跑过」，审的是 8 页还是 25 页
+        # 完全看不出来——看不出来就意味着这类缺口只能靠人读代码发现（#436 正是如此）。
+        "rendered_pages": rendered_pages,
+        "reviewed_pages": reviewed_pages,
         "unresolved_text_issues": remaining,
         "last_visual_issues": visual_issues,
     }

--- a/src/backend/app/services/presentation.py
+++ b/src/backend/app/services/presentation.py
@@ -105,11 +105,17 @@ class DeckSlide(BaseModel):
     notes: str = ""
 
 
+#: 一份 deck 最多几页。**视觉审查的渲染上限跟着它走**（见 render_slide_images）——
+#: 两个上限分处两个文件、各写各的字面量，正是「13-25 页从未被渲染、更没被审查，
+#: 而流程照报通过」的来源（#436）。要改页数上限，改这一个地方。
+MAX_DECK_SLIDES = 25
+
+
 class DeckSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     title: str
-    slides: list[DeckSlide] = Field(min_length=3, max_length=25)
+    slides: list[DeckSlide] = Field(min_length=3, max_length=MAX_DECK_SLIDES)
 
 
 # ---- 确定性校验 ----
@@ -466,7 +472,13 @@ def soffice_available() -> bool:
     return shutil.which("soffice") is not None
 
 
-def render_slide_images(pptx_bytes: bytes, *, max_pages: int = 12) -> list[bytes]:
+def render_slide_images(pptx_bytes: bytes, *, max_pages: int = MAX_DECK_SLIDES) -> list[bytes]:
+    """把 pptx 渲染成每页一张 PNG。
+
+    默认渲染上限 = :data:`MAX_DECK_SLIDES`，即「deck 能有多少页就渲染多少页」。
+    以前默认 12，而 deck 最多 25 页，于是第 13 页往后从来没被渲染过——调用方拿到
+    12 张图，也就只可能审 12 页，而它对外报告的是整份 deck 通过。
+    """
     if not soffice_available():
         return []
     import fitz

--- a/src/backend/tests/test_presentation.py
+++ b/src/backend/tests/test_presentation.py
@@ -3,7 +3,9 @@
 import io
 import uuid
 
+import pytest
 from pptx import Presentation as PptxFile
+from pydantic import ValidationError
 
 from app.services.presentation import DeckSpec, build_deck, validate_deck_spec
 from tests.conftest import add_paper, register_and_login
@@ -171,3 +173,146 @@ async def test_create_presentation_voyage(client, queue_stub):
         headers=headers,
     )
     assert resp.status_code == 422
+
+
+# ---- 视觉审查必须覆盖整份 deck（#436）----
+
+
+class _RecordingVLM:
+    """记录每次视觉审查收到几张图、提示词声称的是哪几页。
+
+    第一轮全部回 ok，用来验证覆盖范围；把 ``fail_page`` 设成某个绝对页码，
+    那一批会回一条问题，用来验证页码基准。
+    """
+
+    def __init__(self, fail_page: int | None = None) -> None:
+        self.calls: list[dict] = []
+        self.fix_prompts: list[str] = []
+        self.deck: dict = {}  # 由 _run_build 填成被测 deck，修复调用原样回它
+        self.fail_page = fail_page
+
+    async def complete(self, stage, messages, *, images=None, **kwargs):
+        import json as _json
+        import re as _re
+
+        from app.core.llm.base import CompletionResult
+
+        user = messages[-1].content
+        if not images:
+            # 没带图 = 修复调用。deck 本身是合规的，所以只该由视觉问题触发；
+            # 没报问题却走到这里说明文本校验规则变了，此时"审了几页"的断言已不成立。
+            assert self.fail_page is not None, "deck 应当已合规，不该触发文本修复"
+            self.fix_prompts.append(user)
+            return CompletionResult(content=_json.dumps(self.deck), model="fake-llm")
+
+        span = _re.search(r"第 (\d+)-(\d+) 页", user)
+        first, last = (int(span.group(1)), int(span.group(2))) if span else (0, 0)
+        self.calls.append({"images": len(images or []), "first": first, "last": last, "user": user})
+
+        issues = []
+        if self.fail_page is not None and first <= self.fail_page <= last:
+            issues = [{"slide": self.fail_page, "problem": "文字溢出", "fix": "缩短标题"}]
+        return CompletionResult(
+            content=_json.dumps({"ok": not issues, "issues": issues}), model="fake-vlm"
+        )
+
+
+def _wide_deck(pages: int) -> dict:
+    """一份 pages 页的合法 deck（首页封面、末页结语，中间填内容页）。"""
+    slides = [DECK["slides"][0], DECK["slides"][1]]
+    slides += [
+        {"kind": "content", "title": f"第 {i} 节", "bullets": [f"要点 {i}", f"补充 {i}"]}
+        for i in range(len(slides) + 1, pages)
+    ]
+    slides.append(DECK["slides"][-1])
+    return {"title": "长 deck", "slides": slides}
+
+
+async def _run_build(monkeypatch, *, pages: int, vlm: _RecordingVLM):
+    """跑 present.build，把渲染与 soffice 探测都替换掉（CI 没有 soffice）。"""
+    from app.agents.voyage import actions_present
+    from app.agents.voyage.actions import ActionContext
+    from app.models.voyage import VoyageRun
+
+    monkeypatch.setattr(actions_present, "soffice_available", lambda: True)
+    monkeypatch.setattr(actions_present, "render_slide_images", lambda _pptx: [_PNG] * pages)
+
+    async def _no_papers(_ctx):
+        return []
+
+    monkeypatch.setattr(actions_present, "_load_papers", _no_papers)
+
+    vlm.deck = _wide_deck(pages)
+    run = VoyageRun(id=uuid.uuid4(), kind="presentation", goal="测试")
+    ctx = ActionContext(run=run, llm=vlm, checkpoint={"present_deck": vlm.deck})
+    return await actions_present.present_build(ctx, {})
+
+
+def test_render_page_cap_matches_deck_cap():
+    """渲染上限必须等于 deck 页数上限，否则超出的页连图都没有，更谈不上被审。
+
+    #436 报的是 images[:8]，但其实有两道截断：render_slide_images 的 max_pages 曾默认 12，
+    而 DeckSpec 允许 25 页——13-25 页从来没被渲染过，也从来没人发现。两个上限分处两个文件、
+    各写各的字面量，这条用例就是不让它们再各自漂。
+    """
+    import inspect
+
+    from app.services.presentation import MAX_DECK_SLIDES, DeckSpec, render_slide_images
+
+    default = inspect.signature(render_slide_images).parameters["max_pages"].default
+    assert default == MAX_DECK_SLIDES, f"渲染上限 {default} ≠ deck 上限 {MAX_DECK_SLIDES}"
+
+    # 且 MAX_DECK_SLIDES 确实是 deck 真正能达到的页数（常量与校验规则也得对得上）
+    DeckSpec.model_validate(_wide_deck(MAX_DECK_SLIDES))
+    with pytest.raises(ValidationError):
+        DeckSpec.model_validate(_wide_deck(MAX_DECK_SLIDES + 1))
+
+
+async def test_visual_review_covers_every_rendered_page(monkeypatch, tmp_path):
+    """25 页的 deck，每一页都要恰好被送审一次。
+
+    以前提示词说「共 N 页」却只发 images[:8]：第 9 页往后从未被看过，而模型对收到的
+    8 张回 ok=true，循环就退出，对外表现为整份 deck 视觉审查通过。这种失败没有任何
+    报错，只能靠读代码发现——所以这里直接钉住覆盖范围。
+    """
+    from app.core.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
+    vlm = _RecordingVLM()
+    result = await _run_build(monkeypatch, pages=25, vlm=vlm)
+
+    covered: list[int] = []
+    for call in vlm.calls:
+        covered.extend(range(call["first"], call["last"] + 1))
+        # 提示词声称的页数必须等于真正附上的图片数——这两者不一致正是 #436 的成因
+        assert call["last"] - call["first"] + 1 == call["images"], call["user"]
+
+    assert covered == list(range(1, 26)), f"每页恰好一次，实际：{covered}"
+    assert result["rendered_pages"] == 25
+    assert result["reviewed_pages"] == 25
+
+
+async def test_visual_issue_pages_are_absolute(monkeypatch, tmp_path):
+    """第二批里报的问题，页码要是整份 deck 的绝对页码，不是批内序号。
+
+    不要求绝对页码的话，每批都会从 1 开始编号，修复时会照着改错页。
+    """
+    from app.core.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
+    vlm = _RecordingVLM(fail_page=9)  # 第二批的第一页
+    result = await _run_build(monkeypatch, pages=25, vlm=vlm)
+
+    assert result["visual_fix_rounds"] >= 1, "报了问题就该进修复轮"
+
+    # 第 9 页落在第二批（9-16）的第一张。诊断必须说"第 9 页"——若按批内序号编号就成了"第 1 页"，
+    # 修复会照着改封面。
+    assert vlm.fix_prompts, "视觉问题应当触发一次修复调用"
+    assert "第 9 页" in vlm.fix_prompts[0], vlm.fix_prompts[0]
+
+    # 且送审提示词本身要向模型交代绝对页码基准，否则上面那个页码只是碰巧对
+    second = vlm.calls[1]
+    assert (second["first"], second["last"]) == (9, 16), vlm.calls
+    assert "绝对页码" in second["user"], second["user"]
+    pages = [i["slide"] for i in result["last_visual_issues"]]
+    assert pages == [9], f"应当是绝对页码 9，实际 {pages}"


### PR DESCRIPTION
Closes #436

## What was wrong

The visual-review prompt told the model it was seeing "N pages of renders" while attaching only `images[:8]`. Slides 9 and beyond were never looked at. The model returned `ok=true` for the 8 it did see, the loop exited, and the run reported the whole deck as visually approved — no error, no warning, nothing visible from outside.

The report is accurate and precise. Verifying it turned up a second truncation the report did not mention:

```python
render_slide_images(pptx_bytes, *, max_pages: int = 12)   # cap #1, a default buried in a helper
images=images[:8]                                          # cap #2, the one reported
DeckSpec: slides = Field(min_length=3, max_length=25)      # but a deck may have 25 pages
```

So for a 25-page deck, **slides 13-25 were never rendered at all**, only 8 of the 12 rendered ones were reviewed, and the prompt claimed 12. The two caps lived in different files, each with its own literal, neither aware of the other.

There was also a page-numbering hazard: the prompt said "in order, pages 1-12" while attaching 8 images, so the model's page basis was wrong — it could flag problems on pages it had never seen, or attach the right problem to the wrong page number.

## What changed

- **`MAX_DECK_SLIDES = 25`** in `presentation.py` is now the single source for both the deck cap and the render cap, with a comment at each end explaining why they must not drift apart.
- **Batched review** (`_VISUAL_BATCH = 8`): the deck is walked in batches, and each prompt describes *only the pages it actually attaches* and demands **absolute** page numbers in `slide`. Without that, every batch would number from 1 and the fix round would edit the wrong slide. Issues from all batches are merged; any batch failing means the round fails.
- **`rendered_pages` / `reviewed_pages`** are added to the `present.build` observation. "How many pages were actually reviewed" was previously invisible, which is exactly why this went unnoticed.

Cost note: 25 pages = 4 batches, at most 2 fix rounds → 8 VLM calls worst case (previously a fixed 2). Presentation building is manually triggered and infrequent, so this is batched unconditionally rather than tracking which batches need re-review.

## Tests

Three new cases in `test_presentation.py` (the existing 4 covered none of the visual path):

1. `test_render_page_cap_matches_deck_cap` — render cap equals deck cap, and the constant is the page count the deck can actually reach
2. `test_visual_review_covers_every_rendered_page` — for a 25-page deck, every page is submitted exactly once, and each prompt's claimed page span equals the number of images actually attached
3. `test_visual_issue_pages_are_absolute` — a problem on page 9 (first slide of batch 2) reaches the fix diagnosis as "第 9 页", not "第 1 页"

**Each was verified to fail against the previous implementation** — reverting to `images[:8]` reds 2 and 3 (with the assertion output printing the bug itself: "25 张图，按顺序对应第 1-25 页" alongside `images: 8`), and restoring `max_pages=12` reds 1.

`pytest tests/test_presentation.py tests/test_voyage_engine.py tests/test_voyage_loop.py tests/test_voyages_api.py tests/test_writing_voyage.py` → 47 passed. `ruff check app/` clean.