### PR TITLE
fix(writer): preserve ICML frontmatter in structured drafts

### DIFF
--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -430,11 +430,26 @@ _STRUCTURE_SECTIONS: tuple[tuple[str, str], ...] = (
     ("conclusion", "Conclusion"),
 )
 _STRUCTURE_PLACEHOLDER = "To be drafted."
-_BIB_LINE_RE = re.compile(r"^[ \t]*\\bibliography(?:style)?\{[^{}]*\}[ \t]*$", re.MULTILINE)
+_BIB_STYLE_LINE_RE = re.compile(r"^[ \t]*\\bibliographystyle\{[^{}]*\}[ \t]*$", re.MULTILINE)
+_ICML_STYLE_RE = re.compile(r"\\usepackage(?:\[[^\]]*\])?\{icml\d{4}\}")
+_ICML_NOTICE_RE = re.compile(r"\\printAffiliationsAndNotice(?:\[[^\]]*\])?\{[^{}]*\}")
 
 
 def _section_marker_block(key: str) -> str:
     return f"% POLARIS_SECTION: {key}\n{_STRUCTURE_PLACEHOLDER}\n% POLARIS_SECTION_END: {key}\n"
+
+
+def _icml_frontmatter(preamble: str, body: str) -> str | None:
+    """Return the official ICML title block without retaining sample paper content."""
+    if _ICML_STYLE_RE.search(preamble) is None:
+        return None
+    notice = _ICML_NOTICE_RE.search(body)
+    if notice is None:
+        return None
+    prefix = body[: notice.end()].strip()
+    if "\\twocolumn" not in prefix or "\\icmltitle" not in prefix:
+        return None
+    return prefix + "\n"
 
 
 def build_structured_document(content: str) -> str:
@@ -447,17 +462,18 @@ def build_structured_document(content: str) -> str:
     old_body, tail = rest.split("\\end{document}", 1)
 
     parts: list[str] = []
-    if "\\title" in preamble or "\\maketitle" in old_body:
+    icml_frontmatter = _icml_frontmatter(preamble, old_body)
+    if icml_frontmatter is not None:
+        parts.append(icml_frontmatter)
+    elif "\\title" in preamble or "\\maketitle" in old_body:
         parts.append("\\maketitle\n")
     parts.append("\n\\begin{abstract}\n" + _section_marker_block("abstract") + "\\end{abstract}\n")
     for key, heading in _STRUCTURE_SECTIONS:
         parts.append(f"\n\\section{{{heading}}}\\label{{sec:{key}}}\n" + _section_marker_block(key))
-    # 保留原有的 \bibliographystyle / \bibliography 声明（顺序不变），否则兜底指向 references
-    bib_lines = _BIB_LINE_RE.findall(old_body)
-    if bib_lines:
-        parts.append("\n" + "\n".join(m.strip() for m in bib_lines) + "\n")
-    else:
-        parts.append("\n\\bibliographystyle{plainnat}\n\\bibliography{references}\n")
+    # 保留模板的 bibliography style，但统一使用 Polaris 维护的 references.bib。
+    style_lines = _BIB_STYLE_LINE_RE.findall(old_body)
+    style = style_lines[0].strip() if style_lines else "\\bibliographystyle{plainnat}"
+    parts.append(f"\n{style}\n\\bibliography{{references}}\n")
     middle = "".join(parts)
     return f"{preamble}\\begin{{document}}\n{middle}\\end{{document}}{tail}"
 

--- a/src/backend/tests/test_manuscript_compile_settings.py
+++ b/src/backend/tests/test_manuscript_compile_settings.py
@@ -22,6 +22,44 @@ def test_build_structured_document_adds_markers():
     assert "old body text" not in out  # document 环境正文被替换成骨架
 
 
+def test_build_structured_document_preserves_icml_frontmatter():
+    src = r"""\documentclass{article}
+\usepackage[accepted]{icml2026}
+\begin{document}
+\twocolumn[
+\icmltitle{A Verified ICML Draft}
+\begin{icmlauthorlist}
+\icmlauthor{Ada Smith}{lab}
+\end{icmlauthorlist}
+\icmlaffiliation{lab}{Research Lab}
+\vskip 0.3in
+]
+\printAffiliationsAndNotice{}
+\begin{abstract}
+Official sample abstract that must be replaced.
+\end{abstract}
+\section{Introduction}
+Official sample body that must be replaced.
+\bibliographystyle{icml2026}
+\bibliography{example_paper}
+\end{document}
+"""
+
+    out = manuscripts_service.build_structured_document(src)
+
+    assert "\\twocolumn[" in out
+    assert "\\icmltitle{A Verified ICML Draft}" in out
+    assert "\\icmlauthor{Ada Smith}{lab}" in out
+    assert "\\icmlaffiliation{lab}{Research Lab}" in out
+    assert "\\printAffiliationsAndNotice{}" in out
+    assert "Official sample abstract" not in out
+    assert "Official sample body" not in out
+    assert "% POLARIS_SECTION: abstract" in out
+    assert "\\bibliographystyle{icml2026}" in out
+    assert "\\bibliography{references}" in out
+    assert "\\bibliography{example_paper}" not in out
+
+
 def test_build_structured_document_requires_document_env():
     with pytest.raises(manuscripts_service.StructureError):
         manuscripts_service.build_structured_document("\\documentclass{article} no doc env")


### PR DESCRIPTION
## Summary

Preserve the mandatory ICML title, author, affiliation, and notice block when Polaris replaces the template body with a structured draft. Keep the template bibliography style while consistently targeting Polaris references.bib.

Closes #346

## Area

- [x] backend-api
- [x] writer

## What changed

- detect ICML templates through their package declaration;
- preserve the official frontmatter through printAffiliationsAndNotice;
- replace sample body content with Polaris section markers;
- retain the template bibliography style and use references.bib;
- add a regression test covering the ICML 2026 structure.

## Testing

- [x] pytest tests/test_manuscript_compile_settings.py -q (8 passed)
- [x] ruff check app/services/manuscripts.py tests/test_manuscript_compile_settings.py
- [x] Generated a structured draft from the official ICML 2026 template and compiled it with TeX Live 2025, latexmk, and BibTeX (draft.pdf and draft.bbl produced; no undefined citations)

## Checklist

- [x] Branch is based on the latest origin/main
- [x] Conventional-commit PR title
- [x] No migration
- [x] No AI attribution or Co-Authored-By lines