### PR TITLE
fix(literature): normalize unsupported PDF image colorspaces

### DIFF
--- a/src/backend/app/services/literature/pdf_extract.py
+++ b/src/backend/app/services/literature/pdf_extract.py
@@ -133,9 +133,25 @@ def _white_fraction(img: Any) -> float:
     return sum(1 for v in pixels if v >= 245) / len(pixels)
 
 
+def _pix_png_bytes(pix: Any) -> bytes:
+    """Encode a pixmap as PNG, normalizing colorspaces unsupported by PyMuPDF."""
+    try:
+        return pix.tobytes("png")
+    except ValueError as exc:
+        if "unsupported colorspace" not in str(exc).lower() or pix.colorspace is None:
+            raise
+        import pymupdf
+
+        return pymupdf.Pixmap(pymupdf.csRGB, pix).tobytes("png")
+
+
 def _pix_white_fraction(pix: Any) -> float:
     """Pixmap 铺白后的近白占比（判断 SMask 合并是否把图压成空白 / 候选是否空白）。"""
-    return _white_fraction(_flatten_to_white_rgb(pix.tobytes("png")))
+    try:
+        return _white_fraction(_flatten_to_white_rgb(_pix_png_bytes(pix)))
+    except (RuntimeError, ValueError):
+        logger.warning("cannot normalize PDF pixmap for blank detection", exc_info=True)
+        return 1.0
 
 
 def _flatten_png_white(png_bytes: bytes) -> bytes:
@@ -333,7 +349,11 @@ def _candidate_from_pix(page_no: int, order: int, pix: Any) -> tuple | None:
 
     返回 (页码, 页内序号, 宽, 高, PNG bytes)——预编码好落盘用的字节，避免二次编码。
     """
-    flat = _flatten_to_white_rgb(pix.tobytes("png"))
+    try:
+        flat = _flatten_to_white_rgb(_pix_png_bytes(pix))
+    except (RuntimeError, ValueError):
+        logger.warning("cannot normalize PDF figure candidate on page %d", page_no, exc_info=True)
+        return None
     if _white_fraction(flat) > FIGURE_MAX_WHITE_FRAC:
         return None  # 空矢量簇 / 白色卡片框 / 空白页
     return (page_no, order, pix.width, pix.height, _png_bytes(flat))

--- a/src/backend/tests/test_pdf_extract_colorspace.py
+++ b/src/backend/tests/test_pdf_extract_colorspace.py
@@ -1,0 +1,55 @@
+"""Regression tests for PDF figure colorspace normalization."""
+
+import io
+
+import pymupdf
+import pytest
+from PIL import Image
+
+from app.services.literature import pdf_extract
+
+
+def _pixmap(colorspace):
+    pix = pymupdf.Pixmap(colorspace, pymupdf.IRect(0, 0, 16, 16), 0)
+    pix.clear_with(0)
+    return pix
+
+
+def test_pix_png_bytes_normalizes_cmyk():
+    pix = _pixmap(pymupdf.csCMYK)
+
+    encoded = pdf_extract._pix_png_bytes(pix)
+
+    assert encoded.startswith(b"\x89PNG")
+    with Image.open(io.BytesIO(encoded)) as image:
+        assert image.mode == "RGB"
+        assert image.size == (16, 16)
+
+
+def test_pix_png_bytes_keeps_supported_rgb():
+    pix = _pixmap(pymupdf.csRGB)
+
+    assert pdf_extract._pix_png_bytes(pix) == pix.tobytes("png")
+
+
+def test_pix_png_bytes_does_not_hide_unrelated_value_error():
+    class BrokenPixmap:
+        colorspace = object()
+
+        def tobytes(self, _format):
+            raise ValueError("invalid pixmap data")
+
+    with pytest.raises(ValueError, match="invalid pixmap data"):
+        pdf_extract._pix_png_bytes(BrokenPixmap())
+
+
+def test_candidate_skips_pixmap_that_still_cannot_be_encoded():
+    class BrokenPixmap:
+        colorspace = None
+        width = 16
+        height = 16
+
+        def tobytes(self, _format):
+            raise ValueError("unsupported colorspace for 'png'")
+
+    assert pdf_extract._candidate_from_pix(3, 0, BrokenPixmap()) is None


### PR DESCRIPTION
## Summary

Normalize valid PyMuPDF pixmaps to RGB when their original colorspace cannot be encoded directly as PNG. If an individual figure still cannot be normalized, skip that candidate instead of aborting figure extraction for the paper.

Closes #442

## Area

- [x] backend-api
- [x] literature / wiki

## What changed

- add a focused pixmap-to-PNG normalization helper;
- convert unsupported colorspaces such as DeviceCMYK to RGB;
- keep unrelated encoding errors visible to direct callers;
- treat an unencodable figure candidate as an invalid candidate rather than a paper-level failure;
- add regression coverage for CMYK, RGB, unrelated errors, and candidate failure isolation.

## Testing

- [x] pytest tests/test_pdf_extract_colorspace.py tests/test_paper_figures.py tests/test_figure_crop_expand.py -q (20 passed)
- [x] ruff check app/services/literature/pdf_extract.py tests/test_pdf_extract_colorspace.py

## Checklist

- [x] Branch is based on the latest origin/main
- [x] Conventional-commit PR title
- [x] No migration
- [x] No AI attribution or Co-Authored-By lines