### PR TITLE
fix(llm): keep provider settings accessible after key rotation

### DIFF
--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from typing import Any
 
+from cryptography.fernet import InvalidToken
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,7 +43,12 @@ def mask_api_key(key: str | None) -> str:
 def masked_key_of(provider: LLMProviderConfig) -> str:
     if not provider.api_key_encrypted:
         return ""
-    return mask_api_key(decrypt_secret(provider.api_key_encrypted))
+    try:
+        return mask_api_key(decrypt_secret(provider.api_key_encrypted))
+    except (InvalidToken, ValueError):
+        # Keep the settings page recoverable after an encryption-key rotation.
+        # Runtime provider construction still decrypts strictly and fails closed.
+        return "*** (needs reconfiguration)"
 
 
 def _normalize_user_agent(value: str | None) -> str | None:

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -5,6 +5,7 @@ import uuid
 
 import httpx
 import respx
+from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
@@ -14,6 +15,36 @@ from app.services import llm_admin
 from tests.conftest import register_and_login
 
 API_KEY = "sk-abcdef1234567890abcd"
+
+
+def test_masked_key_of_survives_encryption_key_rotation(monkeypatch):
+    provider = llm_admin.LLMProviderConfig(
+        name="rotated",
+        kind="openai_compat",
+        api_key_encrypted="encrypted-with-old-key",
+    )
+
+    def stale_secret(_token):
+        raise InvalidToken
+
+    monkeypatch.setattr(llm_admin, "decrypt_secret", stale_secret)
+
+    assert llm_admin.masked_key_of(provider) == "*** (needs reconfiguration)"
+
+
+def test_masked_key_of_keeps_short_or_unrelated_decrypt_errors(monkeypatch):
+    provider = llm_admin.LLMProviderConfig(
+        name="broken",
+        kind="openai_compat",
+        api_key_encrypted="broken-token",
+    )
+
+    def malformed_secret(_token):
+        raise ValueError("malformed token")
+
+    monkeypatch.setattr(llm_admin, "decrypt_secret", malformed_secret)
+
+    assert llm_admin.masked_key_of(provider) == "*** (needs reconfiguration)"
 
 
 async def _admin_and_member(client):


### PR DESCRIPTION
## Summary

Keep the administrator LLM provider settings page usable after a Fernet encryption-key rotation. A stale encrypted API key is shown as needing reconfiguration, while runtime provider construction remains strict and fails closed.

Closes #444

## Area

- [x] backend-api
- [x] llm routing / usage

## What changed

- handle InvalidToken and malformed-token ValueError while producing the masked key;
- return an explicit reconfiguration marker instead of failing the provider list endpoint;
- add regression coverage for stale and malformed encrypted values.

## Testing

- [x] pytest tests/test_admin_llm.py -q (18 passed)
- [x] ruff check app/services/llm_admin.py tests/test_admin_llm.py

## Security note

This change affects only the administrative masked representation. Runtime decryption and model calls still fail closed until the provider key is replaced.

## Checklist

- [x] Branch is based on the latest origin/main
- [x] Conventional-commit PR title
- [x] No migration
- [x] No AI attribution or Co-Authored-By lines