### PR TITLE
fix(writer,llm,literature): follow-ups from reviewing #441, #443, #445

### DIFF
--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -45,9 +45,15 @@ def masked_key_of(provider: LLMProviderConfig) -> str:
         return ""
     try:
         return mask_api_key(decrypt_secret(provider.api_key_encrypted))
-    except (InvalidToken, ValueError):
-        # Keep the settings page recoverable after an encryption-key rotation.
-        # Runtime provider construction still decrypts strictly and fails closed.
+    except InvalidToken:
+        # 这一条记录解不开（多半是加密密钥轮换过）→ 让设置页仍能打开、能重填。
+        # 运行时构造 provider 走的是另一条 decrypt_secret，仍然严格 fail closed。
+        #
+        # 只接 InvalidToken，不接 ValueError：token 无论怎么坏，Fernet.decrypt 抛的都是
+        # InvalidToken；真正会抛 ValueError 的是 Fernet(key) 本身——也就是服务端
+        # POLARIS_ENCRYPTION_KEY 配错了。那是部署错误，不是某个 provider 的数据问题，
+        # 接住它会让每个 provider 都显示"去重填 key"，而管理员照做时 encrypt_secret 会
+        # 抛同一个 ValueError 报 500，唯一的线索却已经被吞掉了。
         return "*** (needs reconfiguration)"
 
 

--- a/src/backend/app/services/manuscripts.py
+++ b/src/backend/app/services/manuscripts.py
@@ -12,6 +12,7 @@
 
 import contextlib
 import json
+import logging
 import re
 import uuid
 from collections.abc import Sequence
@@ -42,6 +43,8 @@ from app.services.libraries import (
     member_papers_stmt,
 )
 from app.services.projects import in_my_projects
+
+logger = logging.getLogger(__name__)
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "assets" / "templates"
 TEMPLATE_KEYS = ("neurips2026", "iclr2026", "acl")
@@ -431,12 +434,30 @@ _STRUCTURE_SECTIONS: tuple[tuple[str, str], ...] = (
 )
 _STRUCTURE_PLACEHOLDER = "To be drafted."
 _BIB_STYLE_LINE_RE = re.compile(r"^[ \t]*\\bibliographystyle\{[^{}]*\}[ \t]*$", re.MULTILINE)
-_ICML_STYLE_RE = re.compile(r"\\usepackage(?:\[[^\]]*\])?\{icml\d{4}\}")
-_ICML_NOTICE_RE = re.compile(r"\\printAffiliationsAndNotice(?:\[[^\]]*\])?\{[^{}]*\}")
+# 包名可能与别的包写在同一条 \usepackage 里（{icml2026,times}），所以不要求它独占花括号。
+_ICML_STYLE_RE = re.compile(r"\\usepackage(?:\[[^\]]*\])?\{[^{}]*\bicml\d{4}\b[^{}]*\}")
+_ICML_NOTICE_RE = re.compile(r"\\printAffiliationsAndNotice(?:\[[^\]]*\])?\{")
 
 
 def _section_marker_block(key: str) -> str:
     return f"% POLARIS_SECTION: {key}\n{_STRUCTURE_PLACEHOLDER}\n% POLARIS_SECTION_END: {key}\n"
+
+
+def _brace_group_end(text: str, open_pos: int) -> int | None:
+    """从 text[open_pos] 这个 ``{`` 起找配平的 ``}``，返回它之后一位；不配平则 None。
+
+    不能用 ``\\{[^{}]*\\}`` 一把梭：``\\printAffiliationsAndNotice{\\icmlEqualContribution{}}``
+    这种带嵌套花括号的参数会匹配失败，进而整块标题块被丢掉、draft.tex 又变回不可编译。
+    """
+    depth = 0
+    for i in range(open_pos, len(text)):
+        if text[i] == "{" and (i == 0 or text[i - 1] != "\\"):
+            depth += 1
+        elif text[i] == "}" and text[i - 1] != "\\":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
 
 
 def _icml_frontmatter(preamble: str, body: str) -> str | None:
@@ -444,9 +465,10 @@ def _icml_frontmatter(preamble: str, body: str) -> str | None:
     if _ICML_STYLE_RE.search(preamble) is None:
         return None
     notice = _ICML_NOTICE_RE.search(body)
-    if notice is None:
+    end = _brace_group_end(body, notice.end() - 1) if notice else None
+    if end is None:
         return None
-    prefix = body[: notice.end()].strip()
+    prefix = body[:end].strip()
     if "\\twocolumn" not in prefix or "\\icmltitle" not in prefix:
         return None
     return prefix + "\n"
@@ -465,15 +487,31 @@ def build_structured_document(content: str) -> str:
     icml_frontmatter = _icml_frontmatter(preamble, old_body)
     if icml_frontmatter is not None:
         parts.append(icml_frontmatter)
-    elif "\\title" in preamble or "\\maketitle" in old_body:
-        parts.append("\\maketitle\n")
+    else:
+        if _ICML_STYLE_RE.search(preamble) is not None:
+            # 认出是 ICML 模板却没能取出标题块 —— 产出的 draft.tex 必然编译不过（#346）。
+            # 这里不静默回退：不留痕的话，用户看到的只是"编译失败"，排查会从头再来一遍。
+            logger.warning(
+                "icml template detected but title block not extractable; "
+                "structured draft will not compile until \\twocolumn[\\icmltitle...] "
+                "and \\printAffiliationsAndNotice are present in the template body"
+            )
+        if "\\title" in preamble or "\\maketitle" in old_body:
+            parts.append("\\maketitle\n")
     parts.append("\n\\begin{abstract}\n" + _section_marker_block("abstract") + "\\end{abstract}\n")
     for key, heading in _STRUCTURE_SECTIONS:
         parts.append(f"\n\\section{{{heading}}}\\label{{sec:{key}}}\n" + _section_marker_block(key))
-    # 保留模板的 bibliography style，但统一使用 Polaris 维护的 references.bib。
+    # 保留模板的 bibliography style，但统一使用 Polaris 维护的 references.bib
+    # （工作区必然有这一份，见下方 initialize_structure 的兜底；模板自带的
+    #  \bibliography{example_paper} 指向一个不存在的文件，保留它只会让每条 \cite 都 undefined）。
     style_lines = _BIB_STYLE_LINE_RE.findall(old_body)
-    style = style_lines[0].strip() if style_lines else "\\bibliographystyle{plainnat}"
-    parts.append(f"\n{style}\n\\bibliography{{references}}\n")
+    if style_lines:
+        style = style_lines[0].strip() + "\n"
+    elif _BIB_STYLE_LINE_RE.search(preamble):
+        style = ""  # preamble 里已经声明过，再补一条会把它覆盖掉（BibTeX 取最后一条）
+    else:
+        style = "\\bibliographystyle{plainnat}\n"
+    parts.append(f"\n{style}\\bibliography{{references}}\n")
     middle = "".join(parts)
     return f"{preamble}\\begin{{document}}\n{middle}\\end{{document}}{tail}"
 

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -4,10 +4,12 @@ import asyncio
 import uuid
 
 import httpx
+import pytest
 import respx
 from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 
+from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.core.llm.fake import FakeProvider
 from app.models.llm_config import LLMCallLog, LLMUsage
@@ -32,19 +34,54 @@ def test_masked_key_of_survives_encryption_key_rotation(monkeypatch):
     assert llm_admin.masked_key_of(provider) == "*** (needs reconfiguration)"
 
 
-def test_masked_key_of_keeps_short_or_unrelated_decrypt_errors(monkeypatch):
-    provider = llm_admin.LLMProviderConfig(
-        name="broken",
-        kind="openai_compat",
-        api_key_encrypted="broken-token",
-    )
+def test_masked_key_of_survives_real_key_rotation(monkeypatch):
+    """真跑一次轮换，不 mock 异常：确认坏掉的 token 走的确实是 InvalidToken 这条路。
 
-    def malformed_secret(_token):
-        raise ValueError("malformed token")
+    上一条用例把 decrypt_secret 换成直接 raise，证明的是"接住 InvalidToken 会怎样"，
+    而不是"轮换后真的抛 InvalidToken"。两件事都得钉住，否则收窄 except 时没有依据。
+    """
+    from cryptography.fernet import Fernet
 
-    monkeypatch.setattr(llm_admin, "decrypt_secret", malformed_secret)
+    from app.core import security
 
-    assert llm_admin.masked_key_of(provider) == "*** (needs reconfiguration)"
+    old_key, new_key = Fernet.generate_key().decode(), Fernet.generate_key().decode()
+    settings = get_settings()
+
+    monkeypatch.setattr(settings, "encryption_key", old_key, raising=False)
+    security.get_fernet.cache_clear()
+    stale = security.encrypt_secret(API_KEY)
+
+    monkeypatch.setattr(settings, "encryption_key", new_key, raising=False)
+    security.get_fernet.cache_clear()
+    try:
+        provider = llm_admin.LLMProviderConfig(
+            name="rotated", kind="openai_compat", api_key_encrypted=stale
+        )
+        assert llm_admin.masked_key_of(provider) == "*** (needs reconfiguration)"
+    finally:
+        security.get_fernet.cache_clear()
+
+
+def test_masked_key_of_surfaces_a_misconfigured_server_key(monkeypatch):
+    """服务端 POLARIS_ENCRYPTION_KEY 本身配错时不能伪装成"这个 provider 要重填"。
+
+    Fernet.decrypt 对任何坏 token 抛的都是 InvalidToken；ValueError 只会来自
+    Fernet(key) 构造，也就是部署配错。把它一起接住的话，每个 provider 都会显示
+    "needs reconfiguration"，管理员照着重填时 encrypt_secret 抛同一个 ValueError 报
+    500，而真正的原因（密钥格式不对）已经被吞掉，排查会从错误的方向开始。
+    """
+    from app.core import security
+
+    monkeypatch.setattr(get_settings(), "encryption_key", "not-a-real-key", raising=False)
+    security.get_fernet.cache_clear()
+    try:
+        provider = llm_admin.LLMProviderConfig(
+            name="broken", kind="openai_compat", api_key_encrypted="whatever"
+        )
+        with pytest.raises(ValueError, match="Fernet key"):
+            llm_admin.masked_key_of(provider)
+    finally:
+        security.get_fernet.cache_clear()
 
 
 async def _admin_and_member(client):

--- a/src/backend/tests/test_manuscript_compile_settings.py
+++ b/src/backend/tests/test_manuscript_compile_settings.py
@@ -60,6 +60,72 @@ Official sample body that must be replaced.
     assert "\\bibliography{example_paper}" not in out
 
 
+_ICML_HEAD = (
+    "\\twocolumn[\n\\icmltitle{T}\n"
+    "\\begin{icmlauthorlist}\\icmlauthor{A}{l}\\end{icmlauthorlist}\n"
+    "\\icmlaffiliation{l}{Lab}\n\\vskip 0.3in\n]\n"
+    "\\printAffiliationsAndNotice{\\icmlEqualContribution}\n"
+)
+
+
+def _icml_doc(pkg: str, head: str = _ICML_HEAD) -> str:
+    return (
+        "\\documentclass{article}\n" + pkg + "\n\\begin{document}\n" + head +
+        "Sample body.\n\\bibliographystyle{icml2026}\n"
+        "\\bibliography{example_paper}\n\\end{document}\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        "\\usepackage[accepted]{icml2026}",
+        "\\usepackage{icml2026}",
+        # 与别的包写在同一条 \usepackage 里也算 ICML —— 要求它独占花括号的话，这份模板
+        # 会被判成普通模板，标题块照丢，draft.tex 又回到 #346 的不可编译状态。
+        "\\usepackage{icml2026,times}",
+    ],
+)
+def test_icml_frontmatter_survives_package_spelling(pkg):
+    out = manuscripts_service.build_structured_document(_icml_doc(pkg))
+    assert "\\icmltitle{T}" in out
+    assert "\\printAffiliationsAndNotice" in out
+
+
+def test_icml_frontmatter_survives_nested_braces_in_notice():
+    """notice 的参数带嵌套花括号时也要认出来（\\{[^{}]*\\} 这种写法会在这里失配）。"""
+    head = _ICML_HEAD.replace(
+        "{\\icmlEqualContribution}", "{\\icmlEqualContribution\\footnote{eq}}"
+    )
+    out = manuscripts_service.build_structured_document(_icml_doc("\\usepackage{icml2026}", head))
+    assert "\\icmltitle{T}" in out
+    assert "\\footnote{eq}}" in out
+
+
+def test_icml_without_title_block_warns_instead_of_failing_silently(caplog):
+    """认出是 ICML 却取不出标题块 → 产物必然编译不过，至少要留痕。"""
+    src = _icml_doc("\\usepackage{icml2026}", head="\\icmltitle{T}\n")
+    with caplog.at_level("WARNING"):
+        out = manuscripts_service.build_structured_document(src)
+    assert "\\printAffiliationsAndNotice" not in out
+    assert any("icml template detected" in r.message for r in caplog.records), caplog.text
+
+
+def test_preamble_bibliography_style_is_not_overridden():
+    """模板把 \\bibliographystyle 写在 preamble 时，别在 body 里再补一条把它盖掉。
+
+    BibTeX 取最后一条声明，多补的 plainnat 会静默替换掉用户模板指定的样式。
+    """
+    src = (
+        "\\documentclass{article}\n\\bibliographystyle{acm}\n"
+        "\\begin{document}\nBody\n\\bibliography{mybib}\n\\end{document}\n"
+    )
+    out = manuscripts_service.build_structured_document(src)
+    assert "\\bibliographystyle{acm}" in out
+    assert "\\bibliographystyle{plainnat}" not in out
+    assert "\\bibliography{references}" in out  # bib 文件仍统一到 Polaris 维护的那份
+
+
 def test_build_structured_document_requires_document_env():
     with pytest.raises(manuscripts_service.StructureError):
         manuscripts_service.build_structured_document("\\documentclass{article} no doc env")

--- a/src/backend/tests/test_pdf_extract_colorspace.py
+++ b/src/backend/tests/test_pdf_extract_colorspace.py
@@ -53,3 +53,22 @@ def test_candidate_skips_pixmap_that_still_cannot_be_encoded():
             raise ValueError("unsupported colorspace for 'png'")
 
     assert pdf_extract._candidate_from_pix(3, 0, BrokenPixmap()) is None
+
+
+def test_nonblank_cmyk_pixmap_becomes_a_real_candidate():
+    """整条路径要走通，不能只证明编码函数不抛异常。
+
+    上面的 CMYK 用例填的是 0 —— CMYK 里 0 = 无墨 = 白，这样的候选会先被空白判据
+    丢掉，所以它测到的只是 _pix_png_bytes 本身。真正修的是"一张 CMYK 图能不能被
+    抽成图"，那就得用一张非空白的图走完 _candidate_from_pix。
+    """
+    pix = pymupdf.Pixmap(pymupdf.csCMYK, pymupdf.IRect(0, 0, 64, 64), 0)
+    pix.clear_with(200)  # 满墨 = 深色，绝不会被当成空白
+
+    candidate = pdf_extract._candidate_from_pix(3, 0, pix)
+
+    assert candidate is not None, "非空白 CMYK 图不该被丢弃"
+    page_no, order, width, height, png = candidate
+    assert (page_no, order, width, height) == (3, 0, 64, 64)
+    assert png.startswith(b"\x89PNG")
+    assert pdf_extract._pix_white_fraction(pix) < pdf_extract.FIGURE_MAX_WHITE_FRAC


### PR DESCRIPTION
Follow-ups from reviewing #441, #443 and #445. All three were correct fixes for their issues and are merged; these are the edge cases that surfaced while testing them. Nothing here is deployed yet — production is still on the 8-13 build.

## writer (#441 / #346)

Three template spellings silently fell back to the uncompilable skeleton — the exact state #346 describes — with nothing logged:

| input | before |
|---|---|
| `\usepackage{icml2026,times}` | not recognised as ICML (package had to sit alone in the braces) |
| `\printAffiliationsAndNotice{\icmlEqualContribution\footnote{...}}` | `\{[^{}]*\}` cannot span nested braces |
| ICML template genuinely missing the title block | nothing recoverable, but the user only sees "compile failed" |

Detection now tolerates grouped package lists, the notice argument is found by scanning for the balanced closing brace, and a template recognised as ICML whose title block cannot be extracted logs a warning instead of degrading in silence.

Separately, forcing `\bibliography{references}` is right — `initialize_structure` guarantees that file exists, and the template's own `\bibliography{example_paper}` points at a file that never will. But appending a fallback `\bibliographystyle{plainnat}` also **overrode a style declared in the preamble**, since BibTeX honours the last declaration, so a template specifying `acm` there silently compiled as `plainnat`. The fallback is now emitted only when neither body nor preamble declares one. All three bundled templates declare theirs in the body, so their output is byte-identical either way.

## llm (#445 / #444)

`masked_key_of` caught `ValueError` alongside `InvalidToken`. Probing the actual failure modes:

```
rotated key   -> InvalidToken
garbage token -> InvalidToken
Fernet("not-a-real-key") -> ValueError: Fernet key must be 32 url-safe base64-encoded bytes
```

`Fernet.decrypt` raises `InvalidToken` for every bad token, so the only realistic source of `ValueError` is `Fernet(key)` itself — a misconfigured `POLARIS_ENCRYPTION_KEY`. Catching it dressed a deployment error as a per-provider data error: every provider read `*** (needs reconfiguration)`, and an administrator following that instruction hit the identical `ValueError` from `encrypt_secret` as a 500, with the one useful clue already swallowed. Verified by running that scenario.

The catch is now `InvalidToken` only. The rotation case is additionally covered by a test that performs a real encrypt-then-rotate round trip, rather than asserting the behaviour through a mocked raise — the existing test proved "catching InvalidToken works", not "rotation raises InvalidToken", and narrowing the clause needs the second fact.

## literature (#443 / #442)

The CMYK regression test filled the pixmap with `0`, which in CMYK is no ink — white — so the candidate was dropped by the blank check before the fix could matter, and the test only exercised `_pix_png_bytes`. Added a non-blank CMYK pixmap that runs the whole of `_candidate_from_pix`, which is the behaviour the issue is about.

I also checked the other two `tobytes("png")` sites in the codebase (`actions_review.py`, `presentation.py`): both render whole pages via `page.get_pixmap()`, which always yields RGB, so #443's scoping was right.

## Testing

`pytest tests/test_manuscript_compile_settings.py tests/test_manuscripts.py tests/test_admin_llm.py tests/test_pdf_extract_colorspace.py tests/test_paper_figures.py tests/test_figure_crop_expand.py tests/test_writing_voyage.py` → 74 passed. `ruff check app/` clean.

Every new test was verified to fail against the previous implementation:

- reverting the writer changes reds 4 of the new cases while the two standard ICML spellings keep passing
- restoring `except (InvalidToken, ValueError)` reds the misconfigured-key case
- reverting `_pix_png_bytes` reds the CMYK cases with `ValueError: unsupported colorspace for 'png'`