### PR TITLE
docs(literature): record implementation status and follow-up PR series

### DIFF
--- a/docs/rfcs/2026-08-26-literature-implementation-status.md
+++ b/docs/rfcs/2026-08-26-literature-implementation-status.md
@@ -35,11 +35,13 @@ reader feature is already production-ready.
 | #468 | Polaris Extension | Browser-side batch bridge, local PDF cache, checksum/identity validation, and batch archive client |
 | #469 | Interdisciplinary profile | Versioned scope draft/confirmation, project research mode, and dedicated cross-disciplinary library |
 | #470 | Interdisciplinary Skill | Builtin skill-market workflow for scope, retrieval, evidence, ideas, experiments, writing, and review |
+| #474 | Discovery runtime | Worker-executed OpenAlex/Semantic Scholar/arXiv adapters, year-window propagation, source isolation, progress snapshots, cross-source deduplication, deterministic ranking, and candidate-only persistence |
 
-These PRs provide backend contracts and one extension client. They do not yet
-provide the Polaris main-site discovery screen, real multi-source runtime
-orchestration, MinerU Cloud production client, or universal evidence injection
-into every AI workflow.
+These PRs provide backend contracts, a worker-executed runtime, and one
+extension client. They do not yet provide the Polaris main-site discovery
+screen, the extended provider/key-health matrix, OA cache promotion, MinerU
+Cloud production client, or universal evidence injection into every AI
+workflow.
 
 ## Required follow-up series
 
@@ -50,24 +52,14 @@ must be rebased and parent files removed from its final diff.
 
 ### Runtime and provider series
 
-1. **Discovery runtime adapters**
-   - Execute persisted query plans through OpenAlex, Semantic Scholar, arXiv,
-     and PubMed.
-   - Preserve requested count separately from internal candidate budget.
-   - Pass start/end years to every capable source.
-   - Record source progress, retries, rate limits, authentication failures, and
-     partial results.
-   - Reuse existing Polaris clients and YFR-derived provider logic through a
-     narrow adapter interface. Do not copy the standalone YFR application.
-
-2. **Extended sources and credential health**
+1. **Extended sources and credential health**
    - Add Crossref, Europe PMC, HAL, CORE, BASE, Unpaywall, and Sciverse
      adapters where credentials and service contracts permit.
    - Support encrypted key pools, rotation, per-source connection tests, and
      source-level capability reporting.
    - Keep missing metadata null; never use `Unknown journal` as a data value.
 
-3. **OA discovery cache and promotion**
+2. **OA discovery cache and promotion**
    - Download every verifiable OA candidate into a temporary, content-addressed
      cache during discovery.
    - Do not parse or vectorize an unpromoted candidate.
@@ -76,14 +68,14 @@ must be rebased and parent files removed from its final diff.
 
 ### Polaris product series
 
-4. **Library discovery workspace**
+3. **Library discovery workspace**
    - Add the discovery entry to the existing library navigation.
    - Show title, abstract, authors, venue, DOI, OA state, source evidence,
      score dimensions, inclusion rationale, progress, history, filters, and
      sorting.
    - Enforce creator/curator write access and public-library read-only access.
 
-5. **Administrator literature settings**
+4. **Administrator literature settings**
    - Add source enablement, query limits, year defaults, scoring rubric,
      provider keys, key-pool editing, and connection-test dialogs.
    - Reuse the existing LLM settings interaction style instead of introducing a
@@ -91,7 +83,7 @@ must be rebased and parent files removed from its final diff.
 
 ### Processing and evidence series
 
-6. **MinerU Cloud production adapter**
+5. **MinerU Cloud production adapter**
    - Implement upload, acceptance, processing, result download, polling,
      multi-key rotation, concurrency limits, retry windows, and persisted
      status transitions.
@@ -100,13 +92,13 @@ must be rebased and parent files removed from its final diff.
    - Reparse by creating a new content version; retain the previous active
      version until replacement succeeds.
 
-7. **Reader and PDF evidence navigation**
+6. **Reader and PDF evidence navigation**
    - Render persisted Markdown, figures, and tables safely.
    - Resolve sentence anchors to structured content and PDF text-layer
      coordinates, with quote matching and paper-page fallback.
    - Add visible parsed/vector status and retry controls.
 
-8. **Workflow evidence injection**
+7. **Workflow evidence injection**
    - Make Wiki, chat, ideas, experiments, writing, review, presentations, and
      MCP use the same authorized content-version context and evidence manifest.
    - Do not emit a fine-grained citation when the source text cannot resolve it.
@@ -114,14 +106,14 @@ must be rebased and parent files removed from its final diff.
 
 ### Interdisciplinary runtime series
 
-9. **Profile orchestration**
+8. **Profile orchestration**
    - Repair invalid LLM scope responses into editable drafts.
    - Persist query matrices, primary/associated subject boundaries, bridge-paper
      coverage, and profile-version references.
    - Run per-subject retrieval before cross-subject fusion and report coverage
      separately from relevance.
 
-10. **Skill injection and regression**
+9. **Skill injection and regression**
     - Bind a project to a profile version and Skill template version.
     - Carry the profile constraints into idea, experiment, writing, review, and
       presentation workflows.
@@ -136,7 +128,7 @@ The recommended dependency order is:
 #464 -> #465 -> #466
              └-> #467 -> #468
 #469 -> #470
-runtime adapters -> extended sources -> OA promotion
+runtime adapters (#474) -> extended sources -> OA promotion
 discovery UI -> admin settings
 MinerU production -> reader evidence -> workflow injection
 profile orchestration -> Skill injection

--- a/docs/rfcs/2026-08-26-literature-implementation-status.md
+++ b/docs/rfcs/2026-08-26-literature-implementation-status.md
@@ -35,12 +35,13 @@ reader feature is already production-ready.
 | #468 | Polaris Extension | Browser-side batch bridge, local PDF cache, checksum/identity validation, and batch archive client |
 | #469 | Interdisciplinary profile | Versioned scope draft/confirmation, project research mode, and dedicated cross-disciplinary library |
 | #470 | Interdisciplinary Skill | Builtin skill-market workflow for scope, retrieval, evidence, ideas, experiments, writing, and review |
-| #474 | Discovery runtime | Worker-executed OpenAlex/Semantic Scholar/arXiv adapters, year-window propagation, source isolation, progress snapshots, cross-source deduplication, deterministic ranking, and candidate-only persistence |
+| #474 | Discovery runtime | Worker-executed OpenAlex, Semantic Scholar, arXiv, PubMed, Crossref, Europe PMC, HAL, CORE, BASE, and Sciverse adapters; Unpaywall DOI OA resolution; source isolation, progress snapshots, cross-source deduplication, deterministic ranking, and candidate-only persistence |
+| #476 | OA cache and promotion | Durable OA download attempts, content-addressed PDF cache, PDF identity validation, and idempotent candidate-to-library promotion into `PaperAsset`/`AssetGrant` |
 
-These PRs provide backend contracts, a worker-executed runtime, and one
-extension client. They do not yet provide the Polaris main-site discovery
-screen, the extended provider/key-health matrix, OA cache promotion, MinerU
-Cloud production client, or universal evidence injection into every AI
+These PRs provide backend contracts, a worker-executed multi-source runtime,
+durable OA caching/promotion, and one extension client. They do not yet provide
+the Polaris main-site discovery screen, the administrator key-health matrix,
+MinerU Cloud production polling, or universal evidence injection into every AI
 workflow.
 
 ## Required follow-up series
@@ -52,19 +53,11 @@ must be rebased and parent files removed from its final diff.
 
 ### Runtime and provider series
 
-1. **Extended sources and credential health**
-   - Add Crossref, Europe PMC, HAL, CORE, BASE, Unpaywall, and Sciverse
-     adapters where credentials and service contracts permit.
-   - Support encrypted key pools, rotation, per-source connection tests, and
-     source-level capability reporting.
+1. **Provider credential health**
+   - Add encrypted key pools, rotation, per-source connection tests, and
+     source-level capability reporting for the adapters already present in
+     #474.
    - Keep missing metadata null; never use `Unknown journal` as a data value.
-
-2. **OA discovery cache and promotion**
-   - Download every verifiable OA candidate into a temporary, content-addressed
-     cache during discovery.
-   - Do not parse or vectorize an unpromoted candidate.
-   - On user promotion, validate identity and convert the cache into a formal
-     `PaperAsset` and processing job idempotently.
 
 ### Polaris product series
 
@@ -128,7 +121,8 @@ The recommended dependency order is:
 #464 -> #465 -> #466
              └-> #467 -> #468
 #469 -> #470
-runtime adapters (#474) -> extended sources -> OA promotion
+runtime adapters (#474) -> OA promotion (#476)
+provider credential health -> discovery UI
 discovery UI -> admin settings
 MinerU production -> reader evidence -> workflow injection
 profile orchestration -> Skill injection

--- a/docs/rfcs/2026-08-26-literature-implementation-status.md
+++ b/docs/rfcs/2026-08-26-literature-implementation-status.md
@@ -1,0 +1,167 @@
+# RFC amendment: literature fusion implementation status and follow-up series
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Parent RFC | #448 |
+| Tracking issue | #471 |
+| Target repository | ZJU-REAL/Polaris |
+| Updated | 2026-08-26 |
+
+## Purpose
+
+The parent RFC defines the architecture for library-scoped discovery, PDF
+assets, full-text evidence, Polaris Extension, and interdisciplinary research.
+This amendment records what the first implementation series contains and what
+is still required before the integrated literature workflow is a usable
+product. It does not change the parent RFC's data boundaries, permission model,
+or migration rules.
+
+The implementation series is intentionally split by responsibility. A merged
+contract or persistence PR does not claim that a provider, worker, frontend, or
+reader feature is already production-ready.
+
+## Coverage of the first series
+
+| PR | Boundary | Current coverage |
+| --- | --- | --- |
+| #450 | Discovery contracts | Search runs, source attempts, candidate persistence, snapshots, and candidate identity contract |
+| #452 | Query ranking | Deterministic query planning, normalization, deduplication, score dimensions, and result tiers |
+| #463 | Discovery API | Library-scoped run APIs, candidate filtering, progress reads, and write/read permissions |
+| #464 | PDF assets | Content-addressed blobs, paper assets, grants, identity checks, and scoped reuse |
+| #465 | Content lifecycle | Immutable parse versions, Markdown/text/chunks, MinerU adapter boundary, PyMuPDF fallback state, and vectors |
+| #466 | Evidence anchors | Version-aware sentence/paragraph/chunk anchors and paper-level fallback metadata |
+| #467 | Download protocol | User API keys, multi-paper batches, lease/retry/idempotent archive, and independent library-paper bindings |
+| #468 | Polaris Extension | Browser-side batch bridge, local PDF cache, checksum/identity validation, and batch archive client |
+| #469 | Interdisciplinary profile | Versioned scope draft/confirmation, project research mode, and dedicated cross-disciplinary library |
+| #470 | Interdisciplinary Skill | Builtin skill-market workflow for scope, retrieval, evidence, ideas, experiments, writing, and review |
+
+These PRs provide backend contracts and one extension client. They do not yet
+provide the Polaris main-site discovery screen, real multi-source runtime
+orchestration, MinerU Cloud production client, or universal evidence injection
+into every AI workflow.
+
+## Required follow-up series
+
+Each row becomes one Issue, one branch, and one PR. New branches must start
+from the current `origin/main`, and stacked branches are permitted only when a
+reviewer explicitly requests them. After a dependency lands, the child branch
+must be rebased and parent files removed from its final diff.
+
+### Runtime and provider series
+
+1. **Discovery runtime adapters**
+   - Execute persisted query plans through OpenAlex, Semantic Scholar, arXiv,
+     and PubMed.
+   - Preserve requested count separately from internal candidate budget.
+   - Pass start/end years to every capable source.
+   - Record source progress, retries, rate limits, authentication failures, and
+     partial results.
+   - Reuse existing Polaris clients and YFR-derived provider logic through a
+     narrow adapter interface. Do not copy the standalone YFR application.
+
+2. **Extended sources and credential health**
+   - Add Crossref, Europe PMC, HAL, CORE, BASE, Unpaywall, and Sciverse
+     adapters where credentials and service contracts permit.
+   - Support encrypted key pools, rotation, per-source connection tests, and
+     source-level capability reporting.
+   - Keep missing metadata null; never use `Unknown journal` as a data value.
+
+3. **OA discovery cache and promotion**
+   - Download every verifiable OA candidate into a temporary, content-addressed
+     cache during discovery.
+   - Do not parse or vectorize an unpromoted candidate.
+   - On user promotion, validate identity and convert the cache into a formal
+     `PaperAsset` and processing job idempotently.
+
+### Polaris product series
+
+4. **Library discovery workspace**
+   - Add the discovery entry to the existing library navigation.
+   - Show title, abstract, authors, venue, DOI, OA state, source evidence,
+     score dimensions, inclusion rationale, progress, history, filters, and
+     sorting.
+   - Enforce creator/curator write access and public-library read-only access.
+
+5. **Administrator literature settings**
+   - Add source enablement, query limits, year defaults, scoring rubric,
+     provider keys, key-pool editing, and connection-test dialogs.
+   - Reuse the existing LLM settings interaction style instead of introducing a
+     second settings framework.
+
+### Processing and evidence series
+
+6. **MinerU Cloud production adapter**
+   - Implement upload, acceptance, processing, result download, polling,
+     multi-key rotation, concurrency limits, retry windows, and persisted
+     status transitions.
+   - Start the timeout after MinerU accepts the task. Fall back to PyMuPDF only
+     after a permanent error or exhausted retries.
+   - Reparse by creating a new content version; retain the previous active
+     version until replacement succeeds.
+
+7. **Reader and PDF evidence navigation**
+   - Render persisted Markdown, figures, and tables safely.
+   - Resolve sentence anchors to structured content and PDF text-layer
+     coordinates, with quote matching and paper-page fallback.
+   - Add visible parsed/vector status and retry controls.
+
+8. **Workflow evidence injection**
+   - Make Wiki, chat, ideas, experiments, writing, review, presentations, and
+     MCP use the same authorized content-version context and evidence manifest.
+   - Do not emit a fine-grained citation when the source text cannot resolve it.
+     Use an explicit paper-level fallback instead.
+
+### Interdisciplinary runtime series
+
+9. **Profile orchestration**
+   - Repair invalid LLM scope responses into editable drafts.
+   - Persist query matrices, primary/associated subject boundaries, bridge-paper
+     coverage, and profile-version references.
+   - Run per-subject retrieval before cross-subject fusion and report coverage
+     separately from relevance.
+
+10. **Skill injection and regression**
+    - Bind a project to a profile version and Skill template version.
+    - Carry the profile constraints into idea, experiment, writing, review, and
+      presentation workflows.
+    - Keep conventional project behavior unchanged.
+
+## Merge and review gates
+
+The recommended dependency order is:
+
+```text
+#450 -> #452 -> #463
+#464 -> #465 -> #466
+             └-> #467 -> #468
+#469 -> #470
+runtime adapters -> extended sources -> OA promotion
+discovery UI -> admin settings
+MinerU production -> reader evidence -> workflow injection
+profile orchestration -> Skill injection
+```
+
+Every implementation PR must include:
+
+- an Issue link using `Closes #...` or `Fixes #...`;
+- a single behavior boundary and an explicit non-goal list;
+- focused tests plus compatibility tests for existing paper/library flows;
+- migration upgrade/downgrade coverage when schema changes;
+- Ruff, compile, frontend/build checks where applicable;
+- a sensitive-file scan with no credentials, PDFs, ZIPs, databases, caches, or
+  deployment artifacts;
+- a note explaining whether the branch is independent or temporarily stacked.
+
+The candidate gate remains strict: unpromoted search hits must not create
+formal papers, assets, parse jobs, vectors, or Wiki content. Private and
+institution-authorized PDFs remain grant-scoped even when DOI and bytes match
+an asset in another library.
+
+## Compatibility statement
+
+This amendment does not require the author to merge the entire integrated
+snapshot. Each PR can be reviewed and merged independently in the order above.
+The frozen YFR-integrated directory remains a behavior reference only. Runtime
+code is reimplemented against current Polaris interfaces, with no external YFR
+deployment dependency and no copied credentials.


### PR DESCRIPTION
Closes #471

## Summary
- amend the literature evidence RFC with implementation coverage for #450, #452, and #463-#470
- distinguish backend contracts from provider runtime, main-site frontend, MinerU, reader, OA promotion, and workflow evidence work
- define the dependency-ordered follow-up Issue/PR series and review gates

## Scope
- documentation only
- no code, migrations, deployment changes, credentials, PDFs, ZIPs, or databases

## Validation
- git diff --check passed
- placeholder and sensitive-pattern scan passed