### PR TITLE
feat(literature): add discovery workspace API and permissions

### DIFF
--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -1,0 +1,259 @@
+"""Library-scoped literature discovery workspace API."""
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.library_direction import DirectionLibrary
+from app.models.literature_discovery import (
+    LiteratureSearchHit,
+    LiteratureSearchRun,
+    LiteratureSourceAttempt,
+)
+from app.models.user import User
+from app.schemas.literature_discovery import (
+    LiteratureSearchRequest,
+    SearchHitPage,
+    SearchHitRead,
+    SearchRunDetail,
+    SearchRunPage,
+    SearchRunRead,
+    SourceAttemptRead,
+)
+from app.services import libraries as libraries_service
+from app.services.literature import discovery_runs
+
+router = APIRouter(tags=["literature-discovery"])
+
+
+async def _library(session: AsyncSession, library_id: uuid.UUID, user: User) -> DirectionLibrary:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    return library
+
+
+async def _managed_library(
+    session: AsyncSession, library_id: uuid.UUID, user: User
+) -> DirectionLibrary:
+    library = await _library(session, library_id, user)
+    if not await discovery_runs.can_manage_discovery(session, library=library, user=user):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_DISCOVERY_FORBIDDEN")
+    return library
+
+
+def _detail(run: LiteratureSearchRun, attempts: list[LiteratureSourceAttempt]) -> SearchRunDetail:
+    return SearchRunDetail(
+        **SearchRunRead.model_validate(run).model_dump(),
+        source_attempts=[SourceAttemptRead.model_validate(item) for item in attempts],
+    )
+
+
+@router.post(
+    "/libraries/{library_id}/literature/runs",
+    response_model=SearchRunDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_run(
+    library_id: uuid.UUID,
+    data: LiteratureSearchRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchRunDetail:
+    library = await _managed_library(session, library_id, user)
+    run = LiteratureSearchRun(
+        library_id=library.id,
+        created_by=user.id,
+        requested_count=data.requested_count,
+        candidate_budget=data.candidate_budget,
+        start_year=data.start_year,
+        end_year=data.end_year,
+        topic=data.topic,
+        query_plan=data.query_plan,
+        source_config=data.source_config,
+        model_version=data.model_version,
+        progress={"phase": "queued", "fetched": 0, "accepted": 0},
+    )
+    session.add(run)
+    await session.flush()
+    for source in discovery_runs.enabled_sources(data.source_config, data.query_plan):
+        session.add(
+            LiteratureSourceAttempt(
+                run_id=run.id,
+                source=source,
+                status="pending",
+                requested_count=data.candidate_budget,
+            )
+        )
+    await session.commit()
+    await session.refresh(run)
+    attempts = list(
+        (
+            await session.execute(
+                select(LiteratureSourceAttempt)
+                .where(LiteratureSourceAttempt.run_id == run.id)
+                .order_by(LiteratureSourceAttempt.source)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return _detail(run, attempts)
+
+
+@router.get("/libraries/{library_id}/literature/runs", response_model=SearchRunPage)
+async def list_runs(
+    library_id: uuid.UUID,
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchRunPage:
+    library = await _library(session, library_id, user)
+    base = select(LiteratureSearchRun).where(LiteratureSearchRun.library_id == library.id)
+    total = await session.scalar(select(func.count()).select_from(base.subquery())) or 0
+    runs = list(
+        (
+            await session.execute(
+                base.order_by(LiteratureSearchRun.created_at.desc())
+                .offset((page - 1) * size)
+                .limit(size)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return SearchRunPage(
+        items=[SearchRunRead.model_validate(run) for run in runs],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/libraries/{library_id}/literature/runs/{run_id}", response_model=SearchRunDetail)
+async def get_run(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchRunDetail:
+    await _library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    attempts = list(
+        (
+            await session.execute(
+                select(LiteratureSourceAttempt)
+                .where(LiteratureSourceAttempt.run_id == run.id)
+                .order_by(LiteratureSourceAttempt.source)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return _detail(run, attempts)
+
+
+@router.get(
+    "/libraries/{library_id}/literature/runs/{run_id}/hits", response_model=SearchHitPage
+)
+async def list_hits(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    q: str | None = Query(None, max_length=500),
+    source: str | None = Query(None, max_length=64),
+    hit_status: str | None = Query(
+        None, alias="status", pattern="^(candidate|promoted|dismissed)$"
+    ),
+    sort: str = Query("relevance", pattern="^(relevance|novelty|impact|recent|title)$"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchHitPage:
+    await _library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    stmt = select(LiteratureSearchHit).where(LiteratureSearchHit.run_id == run.id)
+    if source:
+        stmt = stmt.where(LiteratureSearchHit.source == source.strip().lower())
+    if hit_status:
+        stmt = stmt.where(LiteratureSearchHit.status == hit_status)
+    if q:
+        pattern = f"%{q.strip()}%"
+        stmt = stmt.where(
+            LiteratureSearchHit.title.ilike(pattern)
+            | LiteratureSearchHit.abstract.ilike(pattern)
+            | LiteratureSearchHit.doi.ilike(pattern)
+        )
+    hits = list((await session.execute(stmt)).scalars().all())
+    if sort == "title":
+        hits.sort(key=lambda hit: (hit.title.casefold(), str(hit.id)))
+    elif sort == "recent":
+        hits.sort(key=lambda hit: (hit.created_at, str(hit.id)), reverse=True)
+    else:
+        score_key = {"relevance": "relevance", "novelty": "novelty", "impact": "impact"}[sort]
+        hits.sort(
+            key=lambda hit: (
+                discovery_runs.score_value(hit, score_key),
+                hit.created_at,
+                str(hit.id),
+            ),
+            reverse=True,
+        )
+    total = len(hits)
+    start = (page - 1) * size
+    return SearchHitPage(
+        items=[SearchHitRead.model_validate(hit) for hit in hits[start : start + size]],
+        total=total,
+        page=page,
+        size=size,
+        sort=sort,
+    )
+
+
+@router.post(
+    "/libraries/{library_id}/literature/runs/{run_id}/cancel", response_model=SearchRunRead
+)
+async def cancel_run(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> SearchRunRead:
+    library = await _managed_library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library.id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    if run.status in {"queued", "running"}:
+        run.status = "cancelled"
+        run.completed_at = datetime.now(UTC)
+        run.progress = {**(run.progress or {}), "phase": "cancelled"}
+        await session.commit()
+        await session.refresh(run)
+    return SearchRunRead.model_validate(run)
+
+
+@router.delete(
+    "/libraries/{library_id}/literature/runs/{run_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_run(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    library = await _managed_library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library.id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    await discovery_runs.delete_run(session, run)
+    await session.commit()

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -24,6 +24,7 @@ from app.api import (
     lab,
     libraries,
     library,
+    literature_discovery,
     manuscripts,
     market,
     mcp_meta,
@@ -65,6 +66,7 @@ api_router.include_router(lab.router)
 api_router.include_router(me_llm.router)
 api_router.include_router(papers.router)
 api_router.include_router(library.router)
+api_router.include_router(literature_discovery.router)
 api_router.include_router(libraries.router)
 api_router.include_router(publications.router)
 api_router.include_router(notes.router)

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -96,3 +96,73 @@ class SearchRunRead(BaseModel):
     completed_at: datetime | None
     created_at: datetime
     updated_at: datetime
+
+
+class SourceAttemptRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    run_id: uuid.UUID
+    source: str
+    status: Literal["pending", "running", "completed", "partial", "failed", "skipped"]
+    query: str | None
+    cursor: str | None
+    requested_count: int | None
+    fetched_count: int
+    accepted_count: int
+    retryable: bool
+    error_code: str | None
+    error_detail: str | None
+    metadata_snapshot: dict[str, Any] | None
+    started_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SearchHitRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    run_id: uuid.UUID
+    paper_id: uuid.UUID | None
+    status: Literal["candidate", "promoted", "dismissed"]
+    source: str
+    dedup_key: str
+    title: str
+    abstract: str | None
+    authors: list[dict[str, Any]] | None
+    year: int | None
+    venue: str | None
+    doi: str | None
+    pmid: str | None
+    arxiv_id: str | None
+    semantic_scholar_id: str | None
+    url: str | None
+    pdf_url: str | None
+    oa_status: str | None
+    citation_count: int | None
+    scores: dict[str, Any] | None
+    metadata_snapshot: dict[str, Any] | None
+    promoted_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SearchHitPage(BaseModel):
+    items: list[SearchHitRead]
+    total: int
+    page: int
+    size: int
+    sort: str
+
+
+class SearchRunDetail(SearchRunRead):
+    source_attempts: list[SourceAttemptRead]
+
+
+class SearchRunPage(BaseModel):
+    items: list[SearchRunRead]
+    total: int
+    page: int
+    size: int

--- a/src/backend/app/services/literature/discovery_runs.py
+++ b/src/backend/app/services/literature/discovery_runs.py
@@ -1,0 +1,65 @@
+"""库作用域文献发现运行的持久化查询和权限规则。"""
+
+import uuid
+from collections.abc import Iterable
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator
+from app.models.literature_discovery import (
+    LiteratureSearchHit,
+    LiteratureSearchRun,
+)
+from app.models.user import User
+
+
+async def can_manage_discovery(
+    session: AsyncSession, *, library: DirectionLibrary, user: User
+) -> bool:
+    """发现运行写权限：平台管理员、库创建者或策展人。"""
+    if user.role == "admin" or library.submitted_by == user.id:
+        return True
+    return (
+        await session.scalar(
+            select(DirectionLibraryCurator.user_id).where(
+                DirectionLibraryCurator.library_id == library.id,
+                DirectionLibraryCurator.user_id == user.id,
+            )
+        )
+        is not None
+    )
+
+
+def enabled_sources(source_config: dict | None, query_plan: dict | None) -> list[str]:
+    """从已保存快照中取得稳定来源顺序；没有配置时不凭空创建来源任务。"""
+    sources: Iterable[str] = ()
+    if isinstance(source_config, dict):
+        sources = source_config.get("sources") or source_config.keys()
+    if not list(sources) and isinstance(query_plan, dict):
+        sources = query_plan.get("sources") or ()
+    return list(dict.fromkeys(str(s).strip().lower() for s in sources if str(s).strip()))
+
+
+async def get_visible_run(
+    session: AsyncSession, *, library_id: uuid.UUID, run_id: uuid.UUID
+) -> LiteratureSearchRun | None:
+    return await session.scalar(
+        select(LiteratureSearchRun).where(
+            LiteratureSearchRun.id == run_id,
+            LiteratureSearchRun.library_id == library_id,
+        )
+    )
+
+
+async def delete_run(session: AsyncSession, run: LiteratureSearchRun) -> None:
+    await session.execute(delete(LiteratureSearchRun).where(LiteratureSearchRun.id == run.id))
+
+
+def score_value(hit: LiteratureSearchHit, key: str) -> float:
+    scores = hit.scores if isinstance(hit.scores, dict) else {}
+    value = scores.get(key)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/backend/tests/test_literature_discovery_api.py
+++ b/src/backend/tests/test_literature_discovery_api.py
@@ -1,0 +1,107 @@
+"""Issue #453: library-scoped discovery API and authorization."""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary
+from app.models.literature_discovery import LiteratureSearchHit
+from tests.conftest import register_and_login
+
+
+async def _headers(client, email: str) -> dict[str, str]:
+    token = await register_and_login(client, email=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _personal_library(client, headers: dict[str, str]) -> str:
+    response = await client.post(
+        "/api/libraries",
+        json={"name": "Discovery API", "statement": "Search API permissions"},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+async def test_owner_can_create_inspect_filter_and_cancel_run(client):
+    await _headers(client, "discovery-admin@example.com")
+    owner = await _headers(client, "discovery-owner@example.com")
+    library_id = await _personal_library(client, owner)
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        json={
+            "requested_count": 12,
+            "candidate_budget": 40,
+            "start_year": 2016,
+            "end_year": 2026,
+            "topic": "structural impact response",
+            "source_config": {"sources": ["openalex", "semantic"]},
+            "query_plan": {"sources": ["crossref"]},
+        },
+        headers=owner,
+    )
+    assert response.status_code == 201, response.text
+    run = response.json()
+    assert run["requested_count"] == 12
+    assert run["candidate_budget"] == 40
+    assert [a["source"] for a in run["source_attempts"]] == ["openalex", "semantic"]
+
+    run_id = run["id"]
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}", headers=owner
+    )
+    assert response.status_code == 200
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}/cancel", headers=owner
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+    async with get_sessionmaker()() as session:
+        hit = LiteratureSearchHit(
+            run_id=uuid.UUID(run_id),
+            source="openalex",
+            dedup_key="doi:10.1/example",
+            title="Impact response",
+            abstract="A structural impact response",
+            scores={"relevance": 0.9, "novelty": 0.4, "impact": 8},
+        )
+        session.add(hit)
+        await session.commit()
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}/hits?sort=relevance&q=structural",
+        headers=owner,
+    )
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["title"] == "Impact response"
+
+
+async def test_personal_library_is_isolated_and_public_library_is_read_only(client):
+    await _headers(client, "visibility-admin@example.com")
+    owner = await _headers(client, "visibility-owner@example.com")
+    stranger = await _headers(client, "visibility-stranger@example.com")
+    library_id = await _personal_library(client, owner)
+
+    response = await client.get(f"/api/libraries/{library_id}/literature/runs", headers=stranger)
+    assert response.status_code == 404
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        json={"topic": "forbidden"},
+        headers=stranger,
+    )
+    assert response.status_code == 404
+
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        library.is_public = True
+        await session.commit()
+    response = await client.get(f"/api/libraries/{library_id}/literature/runs", headers=stranger)
+    assert response.status_code == 200
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        json={"topic": "read-only public access"},
+        headers=stranger,
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
Rebase of #463 onto current `main`, landed by the maintainer. Authorship of the commit is preserved as @yyy-OPS.

#463 could not be merged directly: it is still based on `39be7ce`, the commit `main` was at before #450 merged, so it carried its own copies of the contract models, schemas and the `a7c8d9e0f1b2` migration that are now in `main`. That is exactly the reduction #463's own body describes as step 3 of its merge sequence:

> Drop the contract files and migration already merged by #450, leaving only the API, permission service, router registration, and API tests in this PR.

Doing that here reduces the diff from 11 files / +1132 to **5 files / +505**, with no duplicated migration or model changes.

## One fix on top of the rebase

`app/api/router.py` in #463 contains:

```python
    literature_discovery,
    literature_discovery,
...
api_router.include_router(literature_discovery.router)
api_router.include_router(literature_discovery.router)
```

Imported twice, registered twice. FastAPI accepts duplicate router registrations without complaint, so every discovery route was mounted twice and the OpenAPI schema carried duplicate paths, with nothing failing anywhere. Almost certainly an artifact of the Revert/Reapply churn in the branch series. Removed.

## Verification

- `alembic heads` → single head `a7c8d9e0f1b2`
- `tests/test_literature_discovery_api.py` → 2 passed
- `tests/test_migrations.py tests/test_library_governance.py tests/test_library_approval.py tests/test_literature_discovery_contracts.py` → 33 passed
- `ruff check app/` → clean (it was not, before the duplicate import was removed)

The permission test covers the claims that matter: a stranger gets 404 on a personal library for both read and write, and once the library is public, 200 on read and 403 on write.

Closes #453. Supersedes #463.