### PR TITLE
feat(literature): add reusable PDF blobs and library asset grants

### DIFF
--- a/src/backend/alembic/versions/c8d9e0f1a2b3_pdf_asset_grants.py
+++ b/src/backend/alembic/versions/c8d9e0f1a2b3_pdf_asset_grants.py
@@ -1,0 +1,97 @@
+"""Content-addressed PDF blobs and library asset grants.
+
+Revision ID: c8d9e0f1a2b3
+Revises: a7c8d9e0f1b2
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c8d9e0f1a2b3"
+down_revision: str | None = "a7c8d9e0f1b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pdf_blobs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("sha256", sa.String(64), nullable=False),
+        sa.Column("byte_size", sa.Integer(), nullable=False),
+        sa.Column("content_type", sa.String(128), nullable=False, server_default="application/pdf"),
+        sa.Column("storage_key", sa.String(1024), nullable=False),
+        sa.Column("state", sa.String(16), nullable=False, server_default="ready"),
+        sa.Column("metadata_snapshot", _JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("sha256", name="uq_pdf_blobs_sha256"),
+    )
+    op.create_index("ix_pdf_blobs_sha256", "pdf_blobs", ["sha256"])
+
+    op.create_table(
+        "paper_assets",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("paper_id", sa.Uuid(), sa.ForeignKey("papers.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("blob_id", sa.Uuid(), sa.ForeignKey("pdf_blobs.id", ondelete="RESTRICT"), nullable=False),
+        sa.Column("source", sa.String(32), nullable=False),
+        sa.Column("source_locator", sa.String(2048), nullable=True),
+        sa.Column("identity_key", sa.String(512), nullable=True),
+        sa.Column("identity_status", sa.String(16), nullable=False, server_default="unverified"),
+        sa.Column("sharing_scope", sa.String(16), nullable=False, server_default="private"),
+        sa.Column("state", sa.String(16), nullable=False, server_default="ready"),
+        sa.Column("is_preferred", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("metadata_snapshot", _JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("paper_id", "blob_id", "source", name="uq_paper_assets_paper_blob_source"),
+    )
+    for name, columns in (
+        ("ix_paper_assets_paper_id", ["paper_id"]),
+        ("ix_paper_assets_blob_id", ["blob_id"]),
+        ("ix_paper_assets_identity_key", ["identity_key"]),
+        ("ix_paper_assets_paper_state", ["paper_id", "state"]),
+    ):
+        op.create_index(name, "paper_assets", columns)
+
+    op.create_table(
+        "asset_grants",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("asset_id", sa.Uuid(), sa.ForeignKey("paper_assets.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("library_id", sa.Uuid(), sa.ForeignKey("direction_libraries.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("status", sa.String(16), nullable=False, server_default="active"),
+        sa.Column("can_read", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("can_process", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("granted_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("revoked_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("metadata_snapshot", _JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("asset_id", "library_id", name="uq_asset_grants_asset_library"),
+    )
+    op.create_index("ix_asset_grants_asset_id", "asset_grants", ["asset_id"])
+    op.create_index("ix_asset_grants_library_id", "asset_grants", ["library_id"])
+    op.create_index("ix_asset_grants_library_status", "asset_grants", ["library_id", "status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_asset_grants_library_status", table_name="asset_grants")
+    op.drop_index("ix_asset_grants_library_id", table_name="asset_grants")
+    op.drop_index("ix_asset_grants_asset_id", table_name="asset_grants")
+    op.drop_table("asset_grants")
+    for name in (
+        "ix_paper_assets_paper_state",
+        "ix_paper_assets_identity_key",
+        "ix_paper_assets_blob_id",
+        "ix_paper_assets_paper_id",
+    ):
+        op.drop_index(name, table_name="paper_assets")
+    op.drop_table("paper_assets")
+    op.drop_index("ix_pdf_blobs_sha256", table_name="pdf_blobs")
+    op.drop_table("pdf_blobs")

--- a/src/backend/app/api/paper_assets.py
+++ b/src/backend/app/api/paper_assets.py
@@ -1,0 +1,221 @@
+"""Library-scoped PDF asset endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi.responses import FileResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.user import User
+from app.schemas.paper_assets import (
+    AssetGrantRead,
+    AssetReuseRequest,
+    PaperAssetPage,
+    PaperAssetRead,
+)
+from app.services import libraries as libraries_service
+from app.services import paper_assets as asset_service
+from app.services import papers as papers_service
+
+router = APIRouter(tags=["paper-assets"])
+
+
+async def _library_for_manager(
+    session: AsyncSession, library_id: uuid.UUID, user: User
+):
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    if not await libraries_service.can_manage_library(session, user=user, library=library):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="LIBRARY_ASSET_MANAGE_FORBIDDEN")
+    return library
+
+
+async def _paper_in_library(
+    session: AsyncSession, library_id: uuid.UUID, paper_id: uuid.UUID, user: User
+):
+    view = await papers_service.get_library_paper_view(
+        session, library_id=library_id, project_id=None, paper_id=paper_id, with_concepts=False
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    return view.paper
+
+
+def _asset_read(asset, blob) -> PaperAssetRead:
+    data = {
+        "id": asset.id,
+        "paper_id": asset.paper_id,
+        "blob_id": asset.blob_id,
+        "source": asset.source,
+        "source_locator": asset.source_locator,
+        "identity_key": asset.identity_key,
+        "identity_status": asset.identity_status,
+        "sharing_scope": asset.sharing_scope,
+        "state": asset.state,
+        "is_preferred": asset.is_preferred,
+        "byte_size": blob.byte_size,
+        "sha256": blob.sha256,
+        "created_at": asset.created_at,
+        "updated_at": asset.updated_at,
+    }
+    return PaperAssetRead.model_validate(data)
+
+
+@router.get(
+    "/libraries/{library_id}/papers/{paper_id}/assets", response_model=PaperAssetPage
+)
+async def list_paper_assets(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperAssetPage:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    await _paper_in_library(session, library_id, paper_id, user)
+    rows = await asset_service.list_assets(session, paper_id=paper_id, library_id=library_id)
+    return PaperAssetPage(
+        items=[
+            _asset_read(asset, blob)
+            for asset, blob, _grant in rows
+        ],
+        grants=[AssetGrantRead.model_validate(grant) for _asset, _blob, grant in rows],
+    )
+
+
+@router.post(
+    "/libraries/{library_id}/papers/{paper_id}/assets",
+    response_model=PaperAssetRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_paper_asset(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    file: UploadFile = File(...),
+    source: str = Form("upload"),
+    source_locator: str | None = Form(None),
+    identity_key: str | None = Form(None),
+    identity_status: str = Form("verified"),
+    sharing_scope: str = Form("private"),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperAssetRead:
+    library = await _library_for_manager(session, library_id, user)
+    paper = await _paper_in_library(session, library_id, paper_id, user)
+    content = await file.read(asset_service.MAX_PDF_BYTES + 1)
+    try:
+        asset = await asset_service.create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=content,
+            user=user,
+            source=source,
+            source_locator=source_locator,
+            identity_key=identity_key,
+            identity_status=identity_status,
+            sharing_scope=sharing_scope,
+        )
+        await session.commit()
+    except asset_service.AssetError as exc:
+        await session.rollback()
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    blob = await session.get(asset_service.PdfBlob, asset.blob_id)
+    if blob is None:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail="PDF_BLOB_MISSING")
+    return _asset_read(asset, blob)
+
+
+@router.post(
+    "/libraries/{library_id}/papers/{paper_id}/assets/reuse",
+    response_model=AssetGrantRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def reuse_paper_asset(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    body: AssetReuseRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> AssetGrantRead:
+    library = await _library_for_manager(session, library_id, user)
+    paper = await _paper_in_library(session, library_id, paper_id, user)
+    asset = await session.get(asset_service.PaperAsset, body.asset_id)
+    if asset is None or asset.paper_id != paper.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ASSET_NOT_FOUND")
+    try:
+        grant = await asset_service.grant_existing_asset(
+            session, asset_id=body.asset_id, target_library=library, user=user
+        )
+        await session.commit()
+    except asset_service.AssetError as exc:
+        await session.rollback()
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return AssetGrantRead.model_validate(grant)
+
+
+@router.post(
+    "/libraries/{library_id}/papers/{paper_id}/assets/reuse-public",
+    response_model=AssetGrantRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def reuse_public_paper_asset(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> AssetGrantRead:
+    """Link the existing public PDF for a DOI/identifier-resolved paper."""
+    library = await _library_for_manager(session, library_id, user)
+    await _paper_in_library(session, library_id, paper_id, user)
+    try:
+        grant = await asset_service.grant_public_asset_for_paper(
+            session, paper_id=paper_id, target_library=library, user=user
+        )
+        await session.commit()
+    except asset_service.AssetNotFoundError as exc:
+        await session.rollback()
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except asset_service.AssetPermissionError as exc:
+        await session.rollback()
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return AssetGrantRead.model_validate(grant)
+
+
+@router.get("/libraries/{library_id}/papers/{paper_id}/assets/{asset_id}/download")
+async def download_paper_asset(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    asset_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> FileResponse:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    await _paper_in_library(session, library_id, paper_id, user)
+    row = await asset_service.readable_asset(
+        session, asset_id=asset_id, library_id=library_id
+    )
+    if row is None or row[0].paper_id != paper_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ASSET_NOT_FOUND")
+    asset, blob = row
+    try:
+        path = asset_service.storage_path_for_blob(blob)
+    except asset_service.AssetError as exc:
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, detail="ASSET_STORAGE_INVALID"
+        ) from exc
+    if not path.is_file():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ASSET_FILE_MISSING")
+    return FileResponse(
+        path,
+        media_type="application/pdf",
+        filename=f"{paper_id}-{asset.id}.pdf",
+        content_disposition_type="inline",
+        headers={"Cache-Control": "private, max-age=300"},
+    )

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -30,6 +30,7 @@ from app.api import (
     mcp_meta,
     me_llm,
     notes,
+    paper_assets,
     papers,
     presentations,
     projects,
@@ -67,6 +68,7 @@ api_router.include_router(me_llm.router)
 api_router.include_router(papers.router)
 api_router.include_router(library.router)
 api_router.include_router(literature_discovery.router)
+api_router.include_router(paper_assets.router)
 api_router.include_router(libraries.router)
 api_router.include_router(publications.router)
 api_router.include_router(notes.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -39,6 +39,7 @@ from app.models.paper import (
     paper_concepts,
     paper_tag_links,
 )
+from app.models.paper_assets import AssetGrant, PaperAsset, PdfBlob
 from app.models.project import Project, ProjectInvite, ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.registration_code import RegistrationCode
@@ -89,6 +90,9 @@ __all__ = [
     "ManuscriptTemplate",
     "ModelRoute",
     "Paper",
+    "PdfBlob",
+    "PaperAsset",
+    "AssetGrant",
     "PaperChunk",
     "PaperChunkVector",
     "PaperHighlight",

--- a/src/backend/app/models/paper_assets.py
+++ b/src/backend/app/models/paper_assets.py
@@ -1,0 +1,80 @@
+"""Content-addressed PDF blobs, paper assets, and library-scoped grants."""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import Boolean, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class PdfBlob(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One immutable PDF byte sequence, addressed by SHA-256."""
+
+    __tablename__ = "pdf_blobs"
+    __table_args__ = (UniqueConstraint("sha256", name="uq_pdf_blobs_sha256"),)
+
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    byte_size: Mapped[int] = mapped_column(nullable=False)
+    content_type: Mapped[str] = mapped_column(
+        String(128), nullable=False, default="application/pdf"
+    )
+    storage_key: Mapped[str] = mapped_column(String(1024), nullable=False)
+    state: Mapped[str] = mapped_column(String(16), nullable=False, default="ready")
+    metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+
+
+class PaperAsset(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A paper's provenance and sharing record for one PDF blob."""
+
+    __tablename__ = "paper_assets"
+    __table_args__ = (
+        UniqueConstraint(
+            "paper_id", "blob_id", "source", name="uq_paper_assets_paper_blob_source"
+        ),
+        Index("ix_paper_assets_paper_state", "paper_id", "state"),
+    )
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    blob_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("pdf_blobs.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_locator: Mapped[str | None] = mapped_column(String(2048))
+    identity_key: Mapped[str | None] = mapped_column(String(512), index=True)
+    identity_status: Mapped[str] = mapped_column(String(16), nullable=False, default="unverified")
+    sharing_scope: Mapped[str] = mapped_column(String(16), nullable=False, default="private")
+    state: Mapped[str] = mapped_column(String(16), nullable=False, default="ready")
+    is_preferred: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+
+
+class AssetGrant(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Explicit permission for a library to read/process a paper asset."""
+
+    __tablename__ = "asset_grants"
+    __table_args__ = (
+        UniqueConstraint("asset_id", "library_id", name="uq_asset_grants_asset_library"),
+        Index("ix_asset_grants_library_status", "library_id", "status"),
+    )
+
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_assets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="active")
+    can_read: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    can_process: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    granted_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+    revoked_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+    metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)

--- a/src/backend/app/schemas/paper_assets.py
+++ b/src/backend/app/schemas/paper_assets.py
@@ -1,0 +1,61 @@
+"""PDF asset and grant API schemas."""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+AssetSource = Literal["oa", "upload", "extension", "arxiv", "manual", "unknown"]
+SharingScope = Literal["private", "library", "public"]
+
+
+class PaperAssetRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    paper_id: uuid.UUID
+    blob_id: uuid.UUID
+    source: str
+    source_locator: str | None
+    identity_key: str | None
+    identity_status: str
+    sharing_scope: str
+    state: str
+    is_preferred: bool
+    byte_size: int
+    sha256: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class AssetGrantRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    asset_id: uuid.UUID
+    library_id: uuid.UUID
+    status: str
+    can_read: bool
+    can_process: bool
+    granted_by: uuid.UUID | None
+    revoked_by: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AssetCreate(BaseModel):
+    source: AssetSource = "upload"
+    source_locator: str | None = Field(default=None, max_length=2048)
+    identity_key: str | None = Field(default=None, max_length=512)
+    identity_status: str = Field(default="verified", max_length=16)
+    sharing_scope: SharingScope = "private"
+
+
+class AssetReuseRequest(BaseModel):
+    asset_id: uuid.UUID
+
+
+class PaperAssetPage(BaseModel):
+    items: list[PaperAssetRead]
+    grants: list[AssetGrantRead]

--- a/src/backend/app/services/paper_assets.py
+++ b/src/backend/app/services/paper_assets.py
@@ -1,0 +1,315 @@
+"""Content-addressed PDF storage and explicit library grants."""
+
+import asyncio
+import hashlib
+import os
+import uuid
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper
+from app.models.paper_assets import AssetGrant, PaperAsset, PdfBlob
+from app.models.user import User
+from app.services import libraries as libraries_service
+
+MAX_PDF_BYTES = 100 * 1024 * 1024
+SHARING_SCOPES = frozenset({"private", "library", "public"})
+
+
+class AssetError(RuntimeError):
+    """Expected asset validation or authorization failure."""
+
+
+class AssetNotFoundError(AssetError):
+    pass
+
+
+class AssetPermissionError(AssetError):
+    pass
+
+
+class AssetAlreadyExistsError(AssetError):
+    pass
+
+
+def _blob_root() -> Path:
+    root = Path(get_settings().data_dir) / "pdf-blobs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def blob_storage_path(sha256: str) -> Path:
+    """Resolve a validated digest to its content-addressed path."""
+    if len(sha256) != 64 or any(c not in "0123456789abcdef" for c in sha256):
+        raise AssetError("invalid PDF blob digest")
+    path = _blob_root() / sha256[:2] / f"{sha256}.pdf"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _validate_pdf(content: bytes) -> None:
+    if not content or len(content) > MAX_PDF_BYTES:
+        raise AssetError("PDF is empty or exceeds the size limit")
+    if not content.startswith(b"%PDF-"):
+        raise AssetError("file header is not PDF")
+    try:
+        import pymupdf
+
+        with pymupdf.open(stream=content, filetype="pdf") as document:
+            if document.needs_pass or document.page_count < 1:
+                raise AssetError("encrypted or empty PDF is not supported")
+    except AssetError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise AssetError("PDF cannot be read") from exc
+
+
+def _write_blob(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_bytes(content)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+async def can_manage_library(
+    session: AsyncSession, *, library: DirectionLibrary, user: User
+) -> bool:
+    return await libraries_service.can_manage_library(session, user=user, library=library)
+
+
+def _paper_identity_keys(paper: Paper) -> set[str]:
+    keys = {paper.dedup_key.lower()} if paper.dedup_key else set()
+    if paper.doi:
+        keys.add(f"doi:{paper.doi.strip().lower().removeprefix('https://doi.org/')}")
+    if paper.arxiv_id:
+        keys.add(f"arxiv:{paper.arxiv_id.strip().lower()}")
+    return keys
+
+
+async def create_or_reuse_asset(
+    session: AsyncSession,
+    *,
+    paper: Paper,
+    library: DirectionLibrary,
+    content: bytes,
+    user: User,
+    source: str,
+    source_locator: str | None = None,
+    identity_key: str | None = None,
+    identity_status: str = "verified",
+    sharing_scope: str = "private",
+) -> PaperAsset:
+    """Persist one immutable PDF and grant the target library access.
+
+    The blob is globally deduplicated, while the asset and grant remain explicit
+    records. Existing private assets are never implicitly reused by another library.
+    """
+    if not await can_manage_library(session, library=library, user=user):
+        raise AssetPermissionError("LIBRARY_ASSET_MANAGE_FORBIDDEN")
+    if sharing_scope not in SHARING_SCOPES:
+        raise AssetError("invalid sharing scope")
+    if source not in {"oa", "upload", "extension", "arxiv", "manual", "unknown"}:
+        raise AssetError("invalid asset source")
+    normalized_identity = identity_key.strip().lower() if identity_key else None
+    if (
+        identity_status == "verified"
+        and normalized_identity is not None
+        and normalized_identity not in _paper_identity_keys(paper)
+    ):
+        raise AssetError("PDF identity does not match the target paper")
+    await asyncio.to_thread(_validate_pdf, content)
+    digest = hashlib.sha256(content).hexdigest()
+    blob = await session.scalar(select(PdfBlob).where(PdfBlob.sha256 == digest))
+    if blob is None:
+        blob = PdfBlob(
+            sha256=digest,
+            byte_size=len(content),
+            storage_key=f"pdf-blobs/{digest[:2]}/{digest}.pdf",
+            content_type="application/pdf",
+            state="ready",
+        )
+        session.add(blob)
+        await session.flush()
+    path = blob_storage_path(blob.sha256)
+    if not path.exists() or path.stat().st_size != len(content):
+        await asyncio.to_thread(_write_blob, path, content)
+
+    asset = await session.scalar(
+        select(PaperAsset).where(
+            PaperAsset.paper_id == paper.id,
+            PaperAsset.blob_id == blob.id,
+            PaperAsset.source == source,
+        )
+    )
+    if asset is None:
+        asset = PaperAsset(
+            paper_id=paper.id,
+            blob_id=blob.id,
+            source=source,
+            source_locator=source_locator,
+            identity_key=normalized_identity,
+            identity_status=identity_status,
+            sharing_scope=sharing_scope,
+            state="ready",
+            is_preferred=True,
+            metadata_snapshot={"sha256": digest, "byte_size": len(content)},
+        )
+        session.add(asset)
+        await session.flush()
+    else:
+        if asset.sharing_scope == "private" and asset.sharing_scope != sharing_scope:
+            raise AssetAlreadyExistsError("asset sharing scope cannot be widened in place")
+
+    existing_grant = await session.scalar(
+        select(AssetGrant).where(
+            AssetGrant.asset_id == asset.id,
+            AssetGrant.library_id == library.id,
+        )
+    )
+    if existing_grant is None:
+        session.add(
+            AssetGrant(
+                asset_id=asset.id,
+                library_id=library.id,
+                status="active",
+                can_read=True,
+                can_process=True,
+                granted_by=user.id,
+            )
+        )
+    elif existing_grant.status != "active":
+        existing_grant.status = "active"
+        existing_grant.can_read = True
+        existing_grant.can_process = True
+        existing_grant.revoked_by = None
+        existing_grant.granted_by = user.id
+    # Keep the legacy reader path working while the asset APIs migrate callers.
+    if not paper.pdf_path:
+        paper.pdf_path = str(path)
+    await session.flush()
+    return asset
+
+
+async def grant_existing_asset(
+    session: AsyncSession,
+    *,
+    asset_id: uuid.UUID,
+    target_library: DirectionLibrary,
+    user: User,
+) -> AssetGrant:
+    """Grant an existing asset only when its sharing policy allows reuse."""
+    if not await can_manage_library(session, library=target_library, user=user):
+        raise AssetPermissionError("LIBRARY_ASSET_MANAGE_FORBIDDEN")
+    asset = await session.get(PaperAsset, asset_id)
+    if asset is None:
+        raise AssetNotFoundError("ASSET_NOT_FOUND")
+    if asset.sharing_scope != "public":
+        existing_target_grant = await session.scalar(
+            select(AssetGrant).where(
+                AssetGrant.asset_id == asset.id,
+                AssetGrant.library_id == target_library.id,
+                AssetGrant.status == "active",
+            )
+        )
+        if existing_target_grant is None:
+            raise AssetPermissionError("ASSET_NOT_SHAREABLE_ACROSS_LIBRARIES")
+    grant = await session.scalar(
+        select(AssetGrant).where(
+            AssetGrant.asset_id == asset.id,
+            AssetGrant.library_id == target_library.id,
+        )
+    )
+    if grant is None:
+        grant = AssetGrant(
+            asset_id=asset.id,
+            library_id=target_library.id,
+            status="active",
+            can_read=True,
+            can_process=True,
+            granted_by=user.id,
+        )
+        session.add(grant)
+    else:
+        grant.status = "active"
+        grant.can_read = True
+        grant.can_process = True
+        grant.revoked_by = None
+        grant.granted_by = user.id
+    await session.flush()
+    return grant
+
+
+async def grant_public_asset_for_paper(
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    target_library: DirectionLibrary,
+    user: User,
+) -> AssetGrant:
+    """Reuse the preferred public asset for a DOI/identifier-resolved paper."""
+    asset = await session.scalar(
+        select(PaperAsset)
+        .join(AssetGrant, AssetGrant.asset_id == PaperAsset.id)
+        .where(
+            PaperAsset.paper_id == paper_id,
+            PaperAsset.sharing_scope == "public",
+            PaperAsset.state == "ready",
+            AssetGrant.status == "active",
+            AssetGrant.can_read.is_(True),
+        )
+        .order_by(PaperAsset.is_preferred.desc(), PaperAsset.created_at.asc())
+    )
+    if asset is None:
+        raise AssetNotFoundError("PUBLIC_ASSET_NOT_FOUND")
+    return await grant_existing_asset(
+        session, asset_id=asset.id, target_library=target_library, user=user
+    )
+
+
+async def list_assets(
+    session: AsyncSession, *, paper_id: uuid.UUID, library_id: uuid.UUID
+) -> list[tuple[PaperAsset, PdfBlob, AssetGrant]]:
+    rows = await session.execute(
+        select(PaperAsset, PdfBlob, AssetGrant)
+        .join(PdfBlob, PdfBlob.id == PaperAsset.blob_id)
+        .join(AssetGrant, AssetGrant.asset_id == PaperAsset.id)
+        .where(
+            PaperAsset.paper_id == paper_id,
+            AssetGrant.library_id == library_id,
+            AssetGrant.status == "active",
+        )
+        .order_by(PaperAsset.is_preferred.desc(), PaperAsset.created_at.desc())
+    )
+    return list(rows.all())
+
+
+async def readable_asset(
+    session: AsyncSession, *, asset_id: uuid.UUID, library_id: uuid.UUID
+) -> tuple[PaperAsset, PdfBlob] | None:
+    row = await session.execute(
+        select(PaperAsset, PdfBlob)
+        .join(PdfBlob, PdfBlob.id == PaperAsset.blob_id)
+        .join(AssetGrant, AssetGrant.asset_id == PaperAsset.id)
+        .where(
+            PaperAsset.id == asset_id,
+            AssetGrant.library_id == library_id,
+            AssetGrant.status == "active",
+            AssetGrant.can_read.is_(True),
+            PdfBlob.state == "ready",
+        )
+    )
+    return row.first()
+
+
+def storage_path_for_blob(blob: PdfBlob) -> Path:
+    expected = blob_storage_path(blob.sha256)
+    if blob.storage_key != f"pdf-blobs/{blob.sha256[:2]}/{blob.sha256}.pdf":
+        raise AssetError("blob storage key mismatch")
+    return expected

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a7c8d9e0f1b2"  # library-scoped literature discovery contracts
+HEAD_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
+LITERATURE_REVISION = "a7c8d9e0f1b2"  # library-scoped literature discovery contracts
 PREVIOUS_HEAD_REVISION = "8ff89f7fcdeb"  # integration tokens
 PROVIDER_UA_REVISION = "7b3e91c4a2d8"  # Provider 级可选 User-Agent
 VIEW_EVENTS_REVISION = "a1c9e73b5d20"  # 浏览事件（文献库/论文点击量）
@@ -113,6 +114,9 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "literature_search_runs",
                     "literature_search_hits",
                     "literature_source_attempts",
+                    "pdf_blobs",
+                    "paper_assets",
+                    "asset_grants",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -418,8 +422,21 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "accepted_count",
         "retryable",
     } <= columns["literature_source_attempts"]
+    assert {"sha256", "byte_size", "storage_key", "state"} <= columns["pdf_blobs"]
+    assert {"paper_id", "blob_id", "source", "sharing_scope", "identity_status"} <= columns[
+        "paper_assets"
+    ]
+    assert {"asset_id", "library_id", "status", "can_read", "can_process"} <= columns[
+        "asset_grants"
+    ]
 
-    # 文献发现合同迁移回退：保留原有 integration_tokens head。
+    # 先退掉 PDF 资产迁移，回到文献发现合同版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == LITERATURE_REVISION
+    assert not {"pdf_blobs", "paper_assets", "asset_grants"} & columns["_tables"]
+
+    # 再退掉文献发现合同，回到集成令牌版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PREVIOUS_HEAD_REVISION
@@ -429,7 +446,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "literature_source_attempts",
     } & columns["_tables"]
 
-    # 先退掉集成令牌。
+    # 再退掉集成令牌。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PROVIDER_UA_REVISION

--- a/src/backend/tests/test_paper_assets.py
+++ b/src/backend/tests/test_paper_assets.py
@@ -1,0 +1,258 @@
+"""Issue #454: content-addressed PDF assets and explicit grants."""
+
+import uuid
+
+import pymupdf
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import new_paper
+from app.models.paper_assets import AssetGrant, PaperAsset, PdfBlob
+from app.models.user import User
+from app.services.paper_assets import (
+    AssetPermissionError,
+    create_or_reuse_asset,
+    grant_existing_asset,
+    grant_public_asset_for_paper,
+    readable_asset,
+)
+from tests.conftest import register_and_login
+
+
+def _pdf_bytes(text: str = "asset test") -> bytes:
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_text((72, 72), text)
+    data = document.tobytes()
+    document.close()
+    return data
+
+
+async def _user(client, email: str) -> tuple[dict[str, str], uuid.UUID]:
+    token = await register_and_login(client, email=email)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with get_sessionmaker()() as session:
+        user_id = (await session.scalar(select(User.id).where(User.email == email)))
+    return headers, user_id
+
+
+async def _library(session, *, user_id: uuid.UUID, public: bool = False) -> DirectionLibrary:
+    library = DirectionLibrary(
+        name=f"asset-{uuid.uuid4().hex[:8]}",
+        statement="PDF asset test",
+        status="active",
+        is_public=public,
+        submitted_by=user_id,
+        created_by=user_id,
+    )
+    session.add(library)
+    await session.flush()
+    return library
+
+
+async def _paper_in_library(session, library: DirectionLibrary):
+    paper = new_paper(title="Asset paper", doi="10.1234/asset")
+    session.add(paper)
+    await session.flush()
+    session.add(LibraryPaper(library_id=library.id, paper_id=paper.id, status="included"))
+    await session.flush()
+    return paper
+
+
+async def test_asset_is_content_addressed_and_idempotent(app, client):
+    _headers, user_id = await _user(client, "asset-owner@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, library)
+        content = _pdf_bytes()
+        first = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=content,
+            user=user,
+            source="upload",
+            sharing_scope="library",
+        )
+        second = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=content,
+            user=user,
+            source="upload",
+            sharing_scope="library",
+        )
+        assert first.id == second.id
+        assert (await session.scalar(select(PdfBlob.sha256))) is not None
+        assert await session.scalar(select(PaperAsset.id)) == first.id
+        assert await session.scalar(select(AssetGrant.id)) is not None
+        await session.commit()
+        row = await readable_asset(session, asset_id=first.id, library_id=library.id)
+        assert row is not None
+        assert row[1].byte_size > 0
+
+
+async def test_private_asset_cannot_be_granted_to_another_library(app, client):
+    _headers, user_id = await _user(client, "asset-private@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        source_library = await _library(session, user_id=user_id)
+        target_library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, source_library)
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=source_library,
+            content=_pdf_bytes("private"),
+            user=user,
+            source="upload",
+            sharing_scope="private",
+        )
+        await session.commit()
+        try:
+            await grant_existing_asset(
+                session, asset_id=asset.id, target_library=target_library, user=user
+            )
+        except AssetPermissionError as exc:
+            assert str(exc) == "ASSET_NOT_SHAREABLE_ACROSS_LIBRARIES"
+        else:
+            raise AssertionError("private asset was granted to another library")
+
+
+async def test_public_asset_can_be_granted_without_copying_blob(app, client):
+    _headers, user_id = await _user(client, "asset-public@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        source_library = await _library(session, user_id=user_id, public=True)
+        target_library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, source_library)
+        session.add(
+            LibraryPaper(
+                library_id=target_library.id, paper_id=paper.id, status="included"
+            )
+        )
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=source_library,
+            content=_pdf_bytes("public"),
+            user=user,
+            source="oa",
+            sharing_scope="public",
+        )
+        grant = await grant_existing_asset(
+            session, asset_id=asset.id, target_library=target_library, user=user
+        )
+        await session.commit()
+        assert grant.library_id == target_library.id
+        blob_count = len(list((await session.execute(select(PdfBlob.id))).scalars()))
+        assert blob_count == 1
+
+
+async def test_public_asset_can_be_reused_by_paper_identity(app, client):
+    _headers, user_id = await _user(client, "asset-public-identity@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        source_library = await _library(session, user_id=user_id, public=True)
+        target_library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, source_library)
+        session.add(
+            LibraryPaper(
+                library_id=target_library.id,
+                paper_id=paper.id,
+                status="included",
+            )
+        )
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=source_library,
+            content=_pdf_bytes("identity"),
+            user=user,
+            source="oa",
+            identity_key="doi:10.1234/asset",
+            sharing_scope="public",
+        )
+        await session.commit()
+        grant = await grant_public_asset_for_paper(
+            session, paper_id=paper.id, target_library=target_library, user=user
+        )
+        await session.commit()
+        assert grant.asset_id == asset.id
+
+
+async def test_asset_http_upload_list_download_and_identity_check(app, client):
+    headers, user_id = await _user(client, "asset-http@example.com")
+    async with get_sessionmaker()() as session:
+        library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, library)
+        await session.commit()
+        library_id = str(library.id)
+        paper_id = str(paper.id)
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets",
+        files={"file": ("paper.pdf", _pdf_bytes("http"), "application/pdf")},
+        data={"source": "upload", "sharing_scope": "private"},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    asset = response.json()
+    assert asset["source"] == "upload"
+    assert len(asset["sha256"]) == 64
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    assert len(response.json()["items"]) == 1
+    asset_id = response.json()["items"][0]["id"]
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets/{asset_id}/download",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")
+    assert response.content.startswith(b"%PDF-")
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets",
+        files={"file": ("wrong.pdf", _pdf_bytes("wrong"), "application/pdf")},
+        data={
+            "source": "extension",
+            "identity_key": "doi:10.9999/not-this-paper",
+            "identity_status": "verified",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 422
+    assert "identity" in response.json()["detail"].lower()
+
+
+async def test_asset_http_private_library_is_not_visible_to_stranger(app, client):
+    owner_headers, owner_id = await _user(client, "asset-http-owner@example.com")
+    stranger_headers, _ = await _user(client, "asset-http-stranger@example.com")
+    async with get_sessionmaker()() as session:
+        library = await _library(session, user_id=owner_id)
+        paper = await _paper_in_library(session, library)
+        await session.commit()
+        library_id = str(library.id)
+        paper_id = str(paper.id)
+    response = await client.post(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets",
+        files={"file": ("paper.pdf", _pdf_bytes("private"), "application/pdf")},
+        headers=owner_headers,
+    )
+    assert response.status_code == 201
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/assets", headers=stranger_headers
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
Rebase of #464 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 14 files / +1683 to **9 files / +1058** — the discovery contracts and `a7c8d9e0f1b2` that #450 and #489 already merged are gone, leaving only the PDF asset work.

## Two conflict resolutions worth recording

Both are cases where taking the branch's side would have silently removed working code, which is what I flagged on #464.

**`app/api/router.py`** — the branch registers `paper_assets` exactly where `main` registers `literature_discovery`:

```
<<<<<<< HEAD
    literature_discovery,
=======
    paper_assets,
>>>>>>> pr464
```

Resolved as a union. Either side alone drops the other's routes, and FastAPI accepts a router that simply is not registered without any error — the endpoints would just 404.

**`app/schemas/literature_discovery.py`** — the branch carries a pre-#463 copy of this file, missing `SourceAttemptRead`, `SearchHitRead` and `SearchHitPage`. Diffing its version against `main`'s shows it adds **nothing** of its own; it is purely the older state, a leftover of the Revert/Reapply churn. `main`'s version kept unchanged. Had the branch's side been taken, `app/api/literature_discovery.py` would have been importing names that no longer exist.

## Migration chain

`c8d9e0f1a2b3` chains from `a7c8d9e0f1b2` — the head after #450 — so this is the version of that revision to keep. The variant carried by #465/#466/#467/#481/#485 chains from `8ff89f7fcdeb` instead and must be dropped when those are rebased, not merged as a second definition.

## Verification

- `alembic heads` → single head `c8d9e0f1a2b3`
- `tests/test_paper_assets.py` → 6 passed
- `tests/test_migrations.py tests/test_literature_discovery_api.py tests/test_literature_discovery_contracts.py tests/test_library_governance.py` → 12 passed, including the two-step downgrade back through `a7c8d9e0f1b2` to `8ff89f7fcdeb`
- `ruff check app/` → clean; `import app.main` → ok

Closes #462. Supersedes #464.