### PR TITLE
feat(literature): add versioned parsing and vector lifecycle

### DIFF
--- a/src/backend/alembic/versions/d9e0f1a2b3c4_paper_content_versions.py
+++ b/src/backend/alembic/versions/d9e0f1a2b3c4_paper_content_versions.py
@@ -1,0 +1,106 @@
+"""Versioned parsed PDF content and vectors.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d9e0f1a2b3c4"
+down_revision: str | None = "c8d9e0f1a2b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paper_content_versions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("paper_id", sa.Uuid(), sa.ForeignKey("papers.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("asset_id", sa.Uuid(), sa.ForeignKey("paper_assets.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("version_no", sa.Integer(), nullable=False),
+        sa.Column("parser", sa.String(32), nullable=False),
+        sa.Column("parser_version", sa.String(128)),
+        sa.Column("status", sa.String(24), nullable=False, server_default="queued"),
+        sa.Column("markdown_key", sa.String(1024)),
+        sa.Column("text_key", sa.String(1024)),
+        sa.Column("manifest_key", sa.String(1024)),
+        sa.Column("error_code", sa.String(64)),
+        sa.Column("error_detail", sa.Text()),
+        sa.Column("attempt", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("page_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("chunk_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("document_vector_state", sa.String(24), nullable=False, server_default="pending"),
+        sa.Column("chunk_vector_state", sa.String(24), nullable=False, server_default="pending"),
+        sa.Column("is_current", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("metadata_snapshot", _JSON),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("paper_id", "version_no", name="uq_paper_content_versions_paper_no"),
+    )
+    op.create_index("ix_paper_content_versions_paper_id", "paper_content_versions", ["paper_id"])
+    op.create_index("ix_paper_content_versions_asset_id", "paper_content_versions", ["asset_id"])
+    op.create_index("ix_paper_content_versions_paper_status", "paper_content_versions", ["paper_id", "status"])
+
+    op.create_table(
+        "paper_content_chunks",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("content_version_id", sa.Uuid(), sa.ForeignKey("paper_content_versions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("page_start", sa.Integer()),
+        sa.Column("page_end", sa.Integer()),
+        sa.Column("rects", _JSON),
+        sa.Column("section_path", _JSON),
+        sa.Column("anchor_meta", _JSON),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("content_version_id", "seq", name="uq_paper_content_chunks_version_seq"),
+    )
+    op.create_index("ix_paper_content_chunks_content_version_id", "paper_content_chunks", ["content_version_id"])
+    op.create_index("ix_paper_content_chunks_version_seq", "paper_content_chunks", ["content_version_id", "seq"])
+
+    for table, owner, fk, unique_name in (
+        ("paper_content_version_vectors", "content_version_id", "paper_content_versions.id", "uq_content_version_vectors_space"),
+        ("paper_content_chunk_vectors", "chunk_id", "paper_content_chunks.id", "uq_content_chunk_vectors_space"),
+    ):
+        op.create_table(
+            table,
+            sa.Column("id", sa.Uuid(), primary_key=True),
+            sa.Column(owner, sa.Uuid(), sa.ForeignKey(fk, ondelete="CASCADE"), nullable=False),
+            sa.Column("space", sa.String(160), nullable=False),
+            sa.Column("dim", sa.Integer(), nullable=False),
+            sa.Column("embedding", _JSON, nullable=False),
+            sa.Column("model", sa.String(128), nullable=False),
+            sa.Column("text_version", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.UniqueConstraint(owner, "space", name=unique_name),
+        )
+        op.create_index(f"ix_{table}_{owner}", table, [owner])
+
+
+def downgrade() -> None:
+    for table, owner in (
+        ("paper_content_chunk_vectors", "chunk_id"),
+        ("paper_content_version_vectors", "content_version_id"),
+    ):
+        op.drop_index(f"ix_{table}_{owner}", table_name=table)
+        op.drop_table(table)
+    op.drop_index("ix_paper_content_chunks_version_seq", table_name="paper_content_chunks")
+    op.drop_index("ix_paper_content_chunks_content_version_id", table_name="paper_content_chunks")
+    op.drop_table("paper_content_chunks")
+    for name in (
+        "ix_paper_content_versions_paper_status",
+        "ix_paper_content_versions_asset_id",
+        "ix_paper_content_versions_paper_id",
+    ):
+        op.drop_index(name, table_name="paper_content_versions")
+    op.drop_table("paper_content_versions")

--- a/src/backend/app/api/paper_assets.py
+++ b/src/backend/app/api/paper_assets.py
@@ -8,15 +8,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
+from app.core.queue import TaskQueue, get_task_queue
 from app.models.user import User
 from app.schemas.paper_assets import (
     AssetGrantRead,
     AssetReuseRequest,
     PaperAssetPage,
     PaperAssetRead,
+    PaperContentChunkRead,
+    PaperContentVersionRead,
 )
 from app.services import libraries as libraries_service
 from app.services import paper_assets as asset_service
+from app.services import paper_content as content_service
 from app.services import papers as papers_service
 
 router = APIRouter(tags=["paper-assets"])
@@ -219,3 +223,78 @@ async def download_paper_asset(
         content_disposition_type="inline",
         headers={"Cache-Control": "private, max-age=300"},
     )
+
+
+@router.post(
+    "/libraries/{library_id}/papers/{paper_id}/assets/{asset_id}/content-versions",
+    response_model=PaperContentVersionRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_paper_content_version(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    asset_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> PaperContentVersionRead:
+    """Queue a fresh parse attempt for an explicitly granted PDF asset."""
+    library = await _library_for_manager(session, library_id, user)
+    paper = await _paper_in_library(session, library_id, paper_id, user)
+    row = await asset_service.readable_asset(
+        session, asset_id=asset_id, library_id=library_id
+    )
+    if row is None or row[0].paper_id != paper.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ASSET_NOT_FOUND")
+    version = await content_service.create_content_version(
+        session, asset=row[0], parser="mineru"
+    )
+    await session.commit()
+    await queue.enqueue(
+        "parse_paper_content_task", str(version.id), str(user.id), str(library.id)
+    )
+    return PaperContentVersionRead.model_validate(version)
+
+
+@router.get(
+    "/libraries/{library_id}/papers/{paper_id}/content-version",
+    response_model=PaperContentVersionRead,
+)
+async def get_current_paper_content_version(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperContentVersionRead:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    await _paper_in_library(session, library_id, paper_id, user)
+    version = await content_service.current_content_version(session, paper_id=paper_id)
+    if version is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONTENT_VERSION_NOT_FOUND")
+    readable = await asset_service.readable_asset(
+        session, asset_id=version.asset_id, library_id=library_id
+    )
+    if readable is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CONTENT_VERSION_NOT_FOUND")
+    return PaperContentVersionRead.model_validate(version)
+
+
+@router.get(
+    "/libraries/{library_id}/papers/{paper_id}/content-version/chunks",
+    response_model=list[PaperContentChunkRead],
+)
+async def get_current_paper_content_chunks(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[PaperContentChunkRead]:
+    version = await get_current_paper_content_version(
+        library_id=library_id, paper_id=paper_id, session=session, user=user
+    )
+    rows = await content_service.list_content_chunks(
+        session, version_id=version.id
+    )
+    return [PaperContentChunkRead.model_validate(row) for row in rows]

--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -22,6 +22,7 @@ WORKER_FUNCTIONS = frozenset(
         "resume_voyage",
         "match_user_publications",
         "index_papers_fulltext_task",
+        "parse_paper_content_task",
         "daily_feed_sync",
         "daily_wiki_ingest",
         "daily_publication_match",

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -40,6 +40,12 @@ from app.models.paper import (
     paper_tag_links,
 )
 from app.models.paper_assets import AssetGrant, PaperAsset, PdfBlob
+from app.models.paper_content import (
+    PaperContentChunk,
+    PaperContentChunkVector,
+    PaperContentVersion,
+    PaperContentVersionVector,
+)
 from app.models.project import Project, ProjectInvite, ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.registration_code import RegistrationCode
@@ -79,6 +85,10 @@ __all__ = [
     "LLMCallLog",
     "LibraryPaper",
     "LibraryResearchDigest",
+    "PaperContentVersion",
+    "PaperContentChunk",
+    "PaperContentVersionVector",
+    "PaperContentChunkVector",
     "LiteratureSearchHit",
     "LiteratureSearchRun",
     "LiteratureSourceAttempt",

--- a/src/backend/app/models/paper_content.py
+++ b/src/backend/app/models/paper_content.py
@@ -1,0 +1,103 @@
+"""Versioned parsed content for a paper PDF.
+
+The PDF asset is immutable; every parser run gets its own content version so
+reader anchors and embeddings never silently point at replaced text.
+"""
+
+import uuid
+from typing import Any
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import JSON, Boolean, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+VectorVariant = JSON().with_variant(Vector(), "postgresql")
+
+
+class PaperContentVersion(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "paper_content_versions"
+    __table_args__ = (
+        UniqueConstraint("paper_id", "version_no", name="uq_paper_content_versions_paper_no"),
+        Index("ix_paper_content_versions_paper_status", "paper_id", "status"),
+    )
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_assets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_no: Mapped[int] = mapped_column(Integer, nullable=False)
+    parser: Mapped[str] = mapped_column(String(32), nullable=False)
+    parser_version: Mapped[str | None] = mapped_column(String(128))
+    status: Mapped[str] = mapped_column(String(24), nullable=False, default="queued")
+    markdown_key: Mapped[str | None] = mapped_column(String(1024))
+    text_key: Mapped[str | None] = mapped_column(String(1024))
+    manifest_key: Mapped[str | None] = mapped_column(String(1024))
+    error_code: Mapped[str | None] = mapped_column(String(64))
+    error_detail: Mapped[str | None] = mapped_column(Text)
+    attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    page_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    document_vector_state: Mapped[str] = mapped_column(
+        String(24), nullable=False, default="pending"
+    )
+    chunk_vector_state: Mapped[str] = mapped_column(
+        String(24), nullable=False, default="pending"
+    )
+    is_current: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+
+
+class PaperContentChunk(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "paper_content_chunks"
+    __table_args__ = (
+        UniqueConstraint("content_version_id", "seq", name="uq_paper_content_chunks_version_seq"),
+        Index("ix_paper_content_chunks_version_seq", "content_version_id", "seq"),
+    )
+
+    content_version_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_content_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    page_start: Mapped[int | None] = mapped_column(Integer)
+    page_end: Mapped[int | None] = mapped_column(Integer)
+    rects: Mapped[list[Any] | None] = mapped_column(JSONVariant)
+    section_path: Mapped[list[str] | None] = mapped_column(JSONVariant)
+    anchor_meta: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+
+
+class PaperContentVersionVector(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "paper_content_version_vectors"
+    __table_args__ = (
+        UniqueConstraint(
+            "content_version_id", "space", name="uq_content_version_vectors_space"
+        ),
+    )
+
+    content_version_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_content_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    space: Mapped[str] = mapped_column(String(160), nullable=False)
+    dim: Mapped[int] = mapped_column(Integer, nullable=False)
+    embedding: Mapped[list[float]] = mapped_column(VectorVariant, nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    text_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+
+class PaperContentChunkVector(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "paper_content_chunk_vectors"
+    __table_args__ = (UniqueConstraint("chunk_id", "space", name="uq_content_chunk_vectors_space"),)
+
+    chunk_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("paper_content_chunks.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    space: Mapped[str] = mapped_column(String(160), nullable=False)
+    dim: Mapped[int] = mapped_column(Integer, nullable=False)
+    embedding: Mapped[list[float]] = mapped_column(VectorVariant, nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    text_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)

--- a/src/backend/app/schemas/paper_assets.py
+++ b/src/backend/app/schemas/paper_assets.py
@@ -59,3 +59,39 @@ class AssetReuseRequest(BaseModel):
 class PaperAssetPage(BaseModel):
     items: list[PaperAssetRead]
     grants: list[AssetGrantRead]
+
+
+class PaperContentVersionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    paper_id: uuid.UUID
+    asset_id: uuid.UUID
+    version_no: int
+    parser: str
+    parser_version: str | None
+    status: str
+    error_code: str | None
+    error_detail: str | None
+    attempt: int
+    page_count: int
+    chunk_count: int
+    document_vector_state: str
+    chunk_vector_state: str
+    is_current: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class PaperContentChunkRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    content_version_id: uuid.UUID
+    seq: int
+    text: str
+    page_start: int | None
+    page_end: int | None
+    rects: list | None
+    section_path: list[str] | None
+    anchor_meta: dict | None

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -1,0 +1,340 @@
+"""MinerU-first, retryable parsing lifecycle for PDF assets."""
+
+import asyncio
+import json
+import logging
+import re
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pymupdf
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.paper_assets import PaperAsset, PdfBlob
+from app.models.paper_content import (
+    PaperContentChunk,
+    PaperContentChunkVector,
+    PaperContentVersion,
+    PaperContentVersionVector,
+)
+from app.services.paper_assets import storage_path_for_blob
+
+logger = logging.getLogger(__name__)
+
+ParserResult = dict[str, Any]
+MineruParser = Callable[[Path], Awaitable[ParserResult]]
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+class ContentParseError(RuntimeError):
+    """A parse attempt failed after the fallback policy was applied."""
+
+
+def _clean_text(value: str) -> str:
+    return _CONTROL_RE.sub("", (value or "").replace("\r\n", "\n").replace("\r", "\n")).strip()
+
+
+def _content_root() -> Path:
+    root = Path(get_settings().data_dir) / "paper-content"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _version_dir(version_id: uuid.UUID) -> Path:
+    path = _content_root() / str(version_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _pymupdf_parse_sync(pdf_path: Path) -> ParserResult:
+    pages: list[str] = []
+    chunks: list[dict[str, Any]] = []
+    with pymupdf.open(pdf_path) as document:
+        for page_no, page in enumerate(document, start=1):
+            text = _clean_text(page.get_text("text"))
+            pages.append(text)
+            if text:
+                chunks.append(
+                    {
+                        "text": text,
+                        "page_start": page_no,
+                        "page_end": page_no,
+                        "rects": [],
+                        "section_path": [],
+                        "anchor_meta": {"parser": "pymupdf", "page": page_no},
+                    }
+                )
+    text = _clean_text("\n\n".join(pages))
+    if not text:
+        raise ContentParseError("PDF_TEXT_EMPTY")
+    markdown = "\n\n".join(
+        f"## Page {i}\n\n{page}"
+        for i, page in enumerate(pages, start=1)
+        if page
+    )
+    return {
+        "parser": "pymupdf",
+        "parser_version": getattr(pymupdf, "VersionBind", None) or "unknown",
+        "markdown": markdown,
+        "text": text,
+        "pages": len(pages),
+        "chunks": chunks,
+        "manifest": {"pages": len(pages), "images": [], "tables": []},
+    }
+
+
+async def create_content_version(
+    session: AsyncSession,
+    *,
+    asset: PaperAsset,
+    parser: str = "mineru",
+    parser_version: str | None = None,
+) -> PaperContentVersion:
+    """Create a new immutable attempt and retire the previous current version."""
+    await session.execute(
+        PaperContentVersion.__table__.update()
+        .where(PaperContentVersion.paper_id == asset.paper_id)
+        .values(is_current=False)
+    )
+    latest = await session.scalar(
+        select(func.max(PaperContentVersion.version_no)).where(
+            PaperContentVersion.paper_id == asset.paper_id
+        )
+    )
+    version = PaperContentVersion(
+        paper_id=asset.paper_id,
+        asset_id=asset.id,
+        version_no=int(latest or 0) + 1,
+        parser=parser,
+        parser_version=parser_version,
+        status="queued",
+        is_current=True,
+    )
+    session.add(version)
+    await session.flush()
+    return version
+
+
+async def parse_content_version(
+    session: AsyncSession,
+    *,
+    version: PaperContentVersion,
+    mineru_parser: MineruParser | None = None,
+    allow_fallback: bool = True,
+) -> PaperContentVersion:
+    """Run one version, persisting status before and after each expensive stage."""
+    asset = await session.get(PaperAsset, version.asset_id)
+    if asset is None:
+        raise ContentParseError("PAPER_ASSET_MISSING")
+    blob = await session.get(PdfBlob, asset.blob_id)
+    if blob is None:
+        raise ContentParseError("PDF_BLOB_MISSING")
+    pdf_path = storage_path_for_blob(blob)
+    if not pdf_path.is_file():
+        raise ContentParseError("PDF_FILE_MISSING")
+
+    version.attempt += 1
+    version.status = "parsing"
+    version.error_code = None
+    version.error_detail = None
+    await session.commit()
+
+    result: ParserResult
+    parser_name = version.parser
+    try:
+        if mineru_parser is None:
+            raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
+        result = await mineru_parser(pdf_path)
+        parser_name = "mineru"
+    except Exception as exc:  # noqa: BLE001 - fallback is an explicit policy
+        if not allow_fallback:
+            version.status = "failed"
+            version.error_code = "MINERU_FAILED"
+            version.error_detail = f"{type(exc).__name__}: {exc}"[:4000]
+            await session.commit()
+            raise ContentParseError("MINERU_FAILED") from exc
+        version.status = "fallback_parsing"
+        version.metadata_snapshot = {
+            **(version.metadata_snapshot or {}),
+            "fallback_reason": f"{type(exc).__name__}: {exc}"[:1000],
+        }
+        await session.commit()
+        try:
+            result = await asyncio.to_thread(_pymupdf_parse_sync, pdf_path)
+            parser_name = "pymupdf"
+        except Exception as fallback_exc:  # noqa: BLE001
+            version.status = "failed"
+            version.error_code = "PYMUPDF_FAILED"
+            version.error_detail = f"{type(fallback_exc).__name__}: {fallback_exc}"[:4000]
+            await session.commit()
+            raise ContentParseError("PYMUPDF_FAILED") from fallback_exc
+
+    text = _clean_text(str(result.get("text") or ""))
+    markdown = _clean_text(str(result.get("markdown") or text))
+    chunks = result.get("chunks") or []
+    if not text or not chunks:
+        version.status = "failed"
+        version.error_code = "PARSED_CONTENT_EMPTY"
+        version.error_detail = "parser returned no text or chunks"
+        await session.commit()
+        raise ContentParseError("PARSED_CONTENT_EMPTY")
+
+    directory = _version_dir(version.id)
+    text_path = directory / "content.txt"
+    markdown_path = directory / "content.md"
+    manifest_path = directory / "manifest.json"
+    text_path.write_text(text, encoding="utf-8")
+    markdown_path.write_text(markdown, encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    await session.execute(
+        delete(PaperContentChunk).where(
+            PaperContentChunk.content_version_id == version.id
+        )
+    )
+    for seq, item in enumerate(chunks):
+        chunk_text = _clean_text(str(item.get("text") or ""))
+        if not chunk_text:
+            continue
+        session.add(
+            PaperContentChunk(
+                content_version_id=version.id,
+                seq=seq,
+                text=chunk_text,
+                page_start=item.get("page_start"),
+                page_end=item.get("page_end"),
+                rects=item.get("rects") or [],
+                section_path=item.get("section_path") or [],
+                anchor_meta=item.get("anchor_meta") or {},
+            )
+        )
+    version.parser = parser_name
+    version.parser_version = str(
+        result.get("parser_version") or version.parser_version or "unknown"
+    )
+    version.status = "ready" if parser_name == "mineru" else "ready_fallback"
+    version.markdown_key = str(markdown_path)
+    version.text_key = str(text_path)
+    version.manifest_key = str(manifest_path)
+    version.page_count = int(result.get("pages") or 0)
+    version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
+    version.chunk_vector_state = "pending"
+    version.document_vector_state = "pending"
+    await session.commit()
+    return version
+
+
+async def current_content_version(
+    session: AsyncSession, *, paper_id: uuid.UUID
+) -> PaperContentVersion | None:
+    return await session.scalar(
+        select(PaperContentVersion)
+        .where(PaperContentVersion.paper_id == paper_id, PaperContentVersion.is_current.is_(True))
+        .order_by(PaperContentVersion.version_no.desc())
+    )
+
+
+async def list_content_chunks(
+    session: AsyncSession, *, version_id: uuid.UUID
+) -> list[PaperContentChunk]:
+    return list(
+        (
+            await session.execute(
+                select(PaperContentChunk)
+                .where(PaperContentChunk.content_version_id == version_id)
+                .order_by(PaperContentChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def vectorize_content_version(
+    session: AsyncSession,
+    *,
+    version: PaperContentVersion,
+    user_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+) -> PaperContentVersion:
+    """Embed parsed full text and every chunk in the active embedding space."""
+    if version.status not in {"ready", "ready_fallback", "vector_ready"}:
+        raise ContentParseError("CONTENT_NOT_READY")
+    chunks = await list_content_chunks(session, version_id=version.id)
+    if not chunks or not version.text_key or not Path(version.text_key).is_file():
+        raise ContentParseError("CONTENT_TEXT_MISSING")
+
+    from app.services.embedding import embed_documents
+
+    version.document_vector_state = "building"
+    version.chunk_vector_state = "building"
+    await session.commit()
+    try:
+        full_text = Path(version.text_key).read_text(encoding="utf-8", errors="ignore")
+        document_vectors, space = await embed_documents(
+            session,
+            [full_text[:12000]],
+            user_id=user_id,
+            library_id=library_id,
+        )
+        await session.execute(
+            delete(PaperContentVersionVector).where(
+                PaperContentVersionVector.content_version_id == version.id,
+                PaperContentVersionVector.space == space.key,
+            )
+        )
+        session.add(
+            PaperContentVersionVector(
+                content_version_id=version.id,
+                space=space.key,
+                dim=space.dim,
+                embedding=document_vectors[0],
+                model=space.model,
+            )
+        )
+        for start in range(0, len(chunks), 32):
+            batch = chunks[start : start + 32]
+            vectors, chunk_space = await embed_documents(
+                session,
+                [chunk.text[:4000] for chunk in batch],
+                user_id=user_id,
+                library_id=library_id,
+            )
+            if chunk_space.key != space.key:
+                raise ContentParseError("EMBEDDING_SPACE_CHANGED_DURING_BUILD")
+            for chunk, vector in zip(batch, vectors, strict=True):
+                await session.execute(
+                    delete(PaperContentChunkVector).where(
+                        PaperContentChunkVector.chunk_id == chunk.id,
+                        PaperContentChunkVector.space == space.key,
+                    )
+                )
+                session.add(
+                    PaperContentChunkVector(
+                        chunk_id=chunk.id,
+                        space=space.key,
+                        dim=space.dim,
+                        embedding=vector,
+                        model=space.model,
+                    )
+                )
+        version.document_vector_state = "ready"
+        version.chunk_vector_state = "ready"
+        version.status = "vector_ready"
+        await session.commit()
+    except Exception as exc:
+        await session.rollback()
+        version = await session.get(PaperContentVersion, version.id)
+        if version is not None:
+            version.document_vector_state = "failed"
+            version.chunk_vector_state = "failed"
+            version.error_code = "VECTOR_BUILD_FAILED"
+            version.error_detail = f"{type(exc).__name__}: {exc}"[:4000]
+            await session.commit()
+        raise
+    return version

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
+HEAD_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
+PDF_ASSET_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
 LITERATURE_REVISION = "a7c8d9e0f1b2"  # library-scoped literature discovery contracts
 PREVIOUS_HEAD_REVISION = "8ff89f7fcdeb"  # integration tokens
 PROVIDER_UA_REVISION = "7b3e91c4a2d8"  # Provider 级可选 User-Agent
@@ -117,6 +118,10 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "pdf_blobs",
                     "paper_assets",
                     "asset_grants",
+                    "paper_content_versions",
+                    "paper_content_chunks",
+                    "paper_content_version_vectors",
+                    "paper_content_chunk_vectors",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -430,7 +435,29 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "asset_grants"
     ]
 
-    # 先退掉 PDF 资产迁移，回到文献发现合同版本。
+    assert {"paper_id", "asset_id", "version_no", "parser", "status", "is_current"} <= columns[
+        "paper_content_versions"
+    ]
+    assert {"content_version_id", "seq", "text", "section_path"} <= columns[
+        "paper_content_chunks"
+    ]
+    assert {"content_version_id", "space", "dim", "embedding"} <= columns[
+        "paper_content_version_vectors"
+    ]
+    assert {"chunk_id", "space", "dim", "embedding"} <= columns["paper_content_chunk_vectors"]
+
+    # 先退掉解析内容版本迁移，回到 PDF 资产版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == PDF_ASSET_REVISION
+    assert not {
+        "paper_content_versions",
+        "paper_content_chunks",
+        "paper_content_version_vectors",
+        "paper_content_chunk_vectors",
+    } & columns["_tables"]
+
+    # 再退掉 PDF 资产迁移，回到文献发现合同版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == LITERATURE_REVISION

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -1,0 +1,144 @@
+"""Issue #455: versioned parser lifecycle and vector-state persistence."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.embedding_space import EmbeddingSpace
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import new_paper
+from app.models.paper_content import (
+    PaperContentChunkVector,
+    PaperContentVersion,
+    PaperContentVersionVector,
+)
+from app.models.user import User
+from app.services.paper_assets import create_or_reuse_asset
+from app.services.paper_content import (
+    ContentParseError,
+    create_content_version,
+    current_content_version,
+    parse_content_version,
+    vectorize_content_version,
+)
+from tests.test_paper_assets import _pdf_bytes, _user
+
+
+async def _setup(client):
+    _headers, user_id = await _user(client, f"content-{uuid.uuid4().hex}@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        library = DirectionLibrary(
+            name=f"content-{uuid.uuid4().hex[:8]}",
+            statement="content test",
+            status="active",
+            submitted_by=user_id,
+            created_by=user_id,
+        )
+        paper = new_paper(title="Content paper", doi="10.1234/content")
+        session.add_all([library, paper])
+        await session.flush()
+        session.add(LibraryPaper(library_id=library.id, paper_id=paper.id, status="included"))
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=_pdf_bytes("full text page"),
+            user=user,
+            source="upload",
+            sharing_scope="private",
+        )
+        await session.commit()
+        return user, library, paper, asset
+
+
+@pytest.mark.asyncio
+async def test_mineru_failure_falls_back_to_pymupdf_and_persists_version(app, client):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+
+        async def failing_mineru(_path):
+            raise RuntimeError("mineru unavailable")
+
+        parsed = await parse_content_version(
+            session, version=version, mineru_parser=failing_mineru
+        )
+        assert parsed.status == "ready_fallback"
+        assert parsed.parser == "pymupdf"
+        assert parsed.page_count == 1
+        assert parsed.chunk_count == 1
+        assert parsed.attempt == 1
+        assert await current_content_version(session, paper_id=paper.id)
+
+
+@pytest.mark.asyncio
+async def test_reparse_creates_new_current_version_without_mutating_old(app, client):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await create_content_version(session, asset=asset, parser="pymupdf")
+        await parse_content_version(session, version=first, mineru_parser=None)
+        second = await create_content_version(session, asset=asset)
+        assert second.version_no == first.version_no + 1
+        await session.refresh(first)
+        assert first.is_current is False
+        assert second.is_current is True
+        saved = await session.scalar(
+            select(PaperContentVersion).where(PaperContentVersion.id == first.id)
+        )
+        assert saved is not None and saved.is_current is False
+
+
+@pytest.mark.asyncio
+async def test_mineru_failure_without_fallback_is_terminal(app, client):
+    _user_row, _library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+
+        async def failing_mineru(_path):
+            raise RuntimeError("mineru unavailable")
+
+        with pytest.raises(ContentParseError, match="MINERU_FAILED"):
+            await parse_content_version(
+                session,
+                version=version,
+                mineru_parser=failing_mineru,
+                allow_fallback=False,
+            )
+        assert version.status == "failed"
+        assert version.error_code == "MINERU_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_vectorize_persists_document_and_chunk_vectors(app, client, monkeypatch):
+    _user_row, library, _paper, asset = await _setup(client)
+    space = EmbeddingSpace(model="test-embedding", dim=3)
+
+    async def fake_embed_documents(session, texts, **_kwargs):
+        return [[float(index), 0.5, 1.0] for index, _ in enumerate(texts)], space
+
+    monkeypatch.setattr(
+        "app.services.embedding.embed_documents", fake_embed_documents
+    )
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+        await parse_content_version(session, version=version, mineru_parser=None)
+        await vectorize_content_version(
+            session, version=version, library_id=library.id
+        )
+        await session.refresh(version)
+        assert version.status == "vector_ready"
+        assert version.document_vector_state == "ready"
+        assert version.chunk_vector_state == "ready"
+        assert (
+            await session.scalar(
+                select(PaperContentVersionVector).where(
+                    PaperContentVersionVector.content_version_id == version.id
+                )
+            )
+        ) is not None
+        assert (
+            await session.scalar(select(PaperContentChunkVector))
+        ) is not None

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -11,6 +11,7 @@ from worker.tasks import (
     daily_wiki_ingest,
     index_papers_fulltext_task,
     match_user_publications,
+    parse_paper_content_task,
     ping_task,
     reconcile_stale_voyages,
     reconcile_stuck_voyages,
@@ -31,6 +32,7 @@ class WorkerSettings:
         func(resume_voyage, timeout=VOYAGE_JOB_TIMEOUT_SECONDS),
         match_user_publications,
         index_papers_fulltext_task,
+        parse_paper_content_task,
         daily_feed_sync,
         # 库同步：由「每日论文抓取」跑完后入队触发。它一度只挂在 cron 上，改成
         # 事件驱动后忘了加到这里，于是每次入队都被 arq 丢掉（#216）。

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -32,6 +32,29 @@ async def ping_task(ctx: dict[str, Any], message: str = "ping") -> str:
     return f"pong: {message}"
 
 
+async def parse_paper_content_task(
+    ctx: dict[str, Any], version_id: str, user_id: str | None = None, library_id: str | None = None
+) -> None:
+    """Parse one immutable content version; MinerU adapters can be injected later."""
+    from app.models.paper_content import PaperContentVersion
+    from app.services.paper_content import parse_content_version, vectorize_content_version
+
+    async with get_sessionmaker()() as session:
+        version = await session.get(PaperContentVersion, uuid.UUID(version_id))
+        if version is None:
+            return
+        await parse_content_version(session, version=version)
+        try:
+            await vectorize_content_version(
+                session,
+                version=version,
+                user_id=uuid.UUID(user_id) if user_id else None,
+                library_id=uuid.UUID(library_id) if library_id else None,
+            )
+        except Exception:
+            logger.exception("content vectorization failed for %s", version_id)
+
+
 def _make_engine() -> VoyageEngine:
     return VoyageEngine(event_bus=EventBus(get_redis()))
 


### PR DESCRIPTION
Rebase of #465 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 16 files / +1939 to **11 files / +883**.

## Resolutions

**Migration.** The branch carries its own `c8d9e0f1a2b3` chaining from `8ff89f7fcdeb` rather than `a7c8d9e0f1b2` — the second of the two contradictory definitions of that revision. `main`'s version kept, so `d9e0f1a2b3c4` extends a linear chain.

**Revert leftovers.** `models/__init__.py` and `router.py` on the branch drop the `literature_discovery` exports and route registration. Resolved as a union in both cases; taking the branch's side would have unregistered the discovery API and removed model exports that are in use.

**Migration test.** The branch's `tests/test_migrations.py` had lost the revision constants and the discovery / PDF-asset assertions that `main` carries, so `--theirs` produced a red test. Rebuilt from `main`'s version and extended:

- `HEAD_REVISION` → `d9e0f1a2b3c4`, new `PDF_ASSET_REVISION` constant
- the four new tables asserted present, with column checks on each
- a third downgrade step, so the round trip now walks `d9e0f1a2b3c4 → c8d9e0f1a2b3 → a7c8d9e0f1b2 → 8ff89f7fcdeb` and asserts the tables disappear at each step

That test is the guard that catches head splits, so it is worth keeping whole rather than letting each branch ship its own truncated copy — that is how the two competing definitions of `c8d9e0f1a2b3` went unnoticed in the first place.

## Verification

- `alembic heads` → single head `d9e0f1a2b3c4`
- `tests/test_migrations.py tests/test_paper_content.py tests/test_paper_assets.py tests/test_literature_discovery_api.py` → 13 passed
- `ruff check app/ tests/test_migrations.py` → clean; `import app.main` → ok

Closes #461. Supersedes #465.