### PR TITLE
feat(reading): add versioned evidence anchors

### DIFF
--- a/src/backend/alembic/versions/e5f6a7b8c9d0_paper_evidence_anchors.py
+++ b/src/backend/alembic/versions/e5f6a7b8c9d0_paper_evidence_anchors.py
@@ -1,0 +1,76 @@
+"""Add immutable sentence and paragraph evidence anchors.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d9e0f1a2b3c4
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | None = "d9e0f1a2b3c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paper_evidence_anchors",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "paper_id",
+            sa.Uuid(),
+            sa.ForeignKey("papers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "chunk_id",
+            sa.Uuid(),
+            sa.ForeignKey("paper_content_chunks.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("source", sa.String(16), nullable=False),
+        sa.Column("content_revision", sa.String(64), nullable=False),
+        sa.Column("anchor_key", sa.String(255), nullable=False),
+        sa.Column("anchor_type", sa.String(16), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=True),
+        sa.Column("paragraph_index", sa.Integer(), nullable=True),
+        sa.Column("sentence_index", sa.Integer(), nullable=True),
+        sa.Column("quoted_text", sa.Text(), nullable=False),
+        sa.Column("normalized_text", sa.Text(), nullable=False),
+        sa.Column("locator", _JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "paper_id",
+            "content_revision",
+            "anchor_key",
+            name="uq_paper_evidence_anchors_revision_key",
+        ),
+    )
+    op.create_index(
+        "ix_paper_evidence_anchors_paper_id", "paper_evidence_anchors", ["paper_id"]
+    )
+    op.create_index(
+        "ix_paper_evidence_anchors_paper_revision",
+        "paper_evidence_anchors",
+        ["paper_id", "content_revision"],
+    )
+    op.create_index(
+        "ix_paper_evidence_anchors_chunk_id", "paper_evidence_anchors", ["chunk_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_paper_evidence_anchors_chunk_id", table_name="paper_evidence_anchors")
+    op.drop_index(
+        "ix_paper_evidence_anchors_paper_revision", table_name="paper_evidence_anchors"
+    )
+    op.drop_index("ix_paper_evidence_anchors_paper_id", table_name="paper_evidence_anchors")
+    op.drop_table("paper_evidence_anchors")

--- a/src/backend/app/api/evidence.py
+++ b/src/backend/app/api/evidence.py
@@ -1,0 +1,61 @@
+"""Library-scoped evidence resolution for AI citation navigation."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.evidence import PaperEvidenceAnchor
+from app.models.user import User
+from app.schemas.evidence import EvidenceResolution
+from app.services import libraries as libraries_service
+from app.services import paper_assets as asset_service
+from app.services import paper_content as content_service
+from app.services import papers as papers_service
+from app.services.evidence import resolve_evidence_anchor
+
+router = APIRouter(tags=["evidence"])
+
+
+@router.get(
+    "/libraries/{library_id}/papers/{paper_id}/evidence/{anchor_id}",
+    response_model=EvidenceResolution,
+)
+async def resolve_library_evidence(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    anchor_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> EvidenceResolution:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    paper = await papers_service.get_library_paper_view(
+        session, library_id=library_id, project_id=None, paper_id=paper_id, with_concepts=False
+    )
+    if paper is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    anchor = await session.scalar(
+        select(PaperEvidenceAnchor).where(
+            PaperEvidenceAnchor.id == anchor_id,
+            PaperEvidenceAnchor.paper_id == paper_id,
+        )
+    )
+    if anchor is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EVIDENCE_NOT_FOUND")
+    version = await content_service.current_content_version(session, paper_id=paper_id)
+    chunks = (
+        await content_service.list_content_chunks(session, version_id=version.id)
+        if version is not None
+        else []
+    )
+    result = await resolve_evidence_anchor(session, anchor, current_chunks=chunks)
+    if version is None or await asset_service.readable_asset(
+        session, asset_id=version.asset_id, library_id=library_id
+    ) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EVIDENCE_ASSET_NOT_FOUND")
+    return result

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -12,6 +12,7 @@ from app.api import (
     chat_bots,
     concepts,
     daily,
+    evidence,
     experiments,
     feedback,
     gates,
@@ -88,5 +89,6 @@ api_router.include_router(mcp_meta.router)
 api_router.include_router(presentations.router)
 api_router.include_router(ssh_credentials.router)
 api_router.include_router(tts.router)
+api_router.include_router(evidence.router)
 api_router.include_router(experiments.router)
 api_router.include_router(manuscripts.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.chat_bot import ChatBotConfig
 from app.models.conversation import Conversation, ConversationMessage
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
 from app.models.email_code import EmailVerificationCode
+from app.models.evidence import PaperEvidenceAnchor
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
@@ -85,6 +86,7 @@ __all__ = [
     "LLMCallLog",
     "LibraryPaper",
     "LibraryResearchDigest",
+    "PaperEvidenceAnchor",
     "PaperContentVersion",
     "PaperContentChunk",
     "PaperContentVersionVector",

--- a/src/backend/app/models/evidence.py
+++ b/src/backend/app/models/evidence.py
@@ -1,0 +1,47 @@
+"""持久化的论文证据锚点。
+
+锚点绑定不可变的内容修订哈希；重新解析不会覆盖旧锚点，阅读器解析失败时由服务层
+返回句子、段落、分块或论文级回退结果。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class PaperEvidenceAnchor(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """一条可追溯的句子/段落/分块/论文证据位置。"""
+
+    __tablename__ = "paper_evidence_anchors"
+    __table_args__ = (
+        UniqueConstraint(
+            "paper_id",
+            "content_revision",
+            "anchor_key",
+            name="uq_paper_evidence_anchors_revision_key",
+        ),
+        Index("ix_paper_evidence_anchors_paper_revision", "paper_id", "content_revision"),
+        Index("ix_paper_evidence_anchors_chunk", "chunk_id"),
+    )
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    chunk_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("paper_content_chunks.id", ondelete="SET NULL"), nullable=True
+    )
+    source: Mapped[str] = mapped_column(String(16), nullable=False)
+    content_revision: Mapped[str] = mapped_column(String(64), nullable=False)
+    anchor_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    anchor_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    seq: Mapped[int | None] = mapped_column(Integer)
+    paragraph_index: Mapped[int | None] = mapped_column(Integer)
+    sentence_index: Mapped[int | None] = mapped_column(Integer)
+    quoted_text: Mapped[str] = mapped_column(Text, nullable=False)
+    normalized_text: Mapped[str] = mapped_column(Text, nullable=False)
+    locator: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)

--- a/src/backend/app/schemas/evidence.py
+++ b/src/backend/app/schemas/evidence.py
@@ -1,0 +1,44 @@
+"""阅读器、MCP 和 AI 产物共用的证据定位 DTO。"""
+
+import uuid
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+EvidenceAnchorType = Literal["sentence", "paragraph", "chunk", "paper"]
+EvidenceFallback = Literal["exact", "sentence", "paragraph", "chunk", "paper"]
+
+
+class EvidenceAnchorRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    paper_id: uuid.UUID
+    chunk_id: uuid.UUID | None
+    source: str
+    content_revision: str
+    anchor_key: str
+    anchor_type: EvidenceAnchorType
+    seq: int | None
+    paragraph_index: int | None
+    sentence_index: int | None
+    quoted_text: str
+    locator: dict[str, Any] | None
+
+
+class EvidenceResolution(BaseModel):
+    """解析后的最佳定位；``fallback`` 说明为何没有精确到句子。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    paper_id: uuid.UUID
+    anchor_id: uuid.UUID | None
+    status: EvidenceFallback
+    anchor_type: EvidenceAnchorType
+    quoted_text: str
+    chunk_id: uuid.UUID | None = None
+    seq: int | None = None
+    page_start: int | None = None
+    page_end: int | None = None
+    rects: list[dict[str, float]] = Field(default_factory=list)
+    href: str

--- a/src/backend/app/services/evidence.py
+++ b/src/backend/app/services/evidence.py
@@ -1,0 +1,266 @@
+"""句子/段落级证据锚点的生成、持久化和内容版本回退。"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+import uuid
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.evidence import PaperEvidenceAnchor
+from app.models.paper_content import PaperContentChunk, PaperContentVersion
+from app.schemas.evidence import EvidenceResolution
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?。！？])(?:[\"'”’»\)\]]+)?\s+|\n+")
+_JOINED_HYPHEN = "\ufff0"
+
+
+def normalize_evidence_text(value: str) -> str:
+    text = unicodedata.normalize("NFKC", str(value or "")).replace("\u00ad", "")
+    text = re.sub(r"-\s*\n\s*", "", text)
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def content_revision(text: str) -> str:
+    return hashlib.sha256(normalize_evidence_text(text).encode("utf-8")).hexdigest()
+
+
+def split_paragraphs(text: str) -> list[str]:
+    return [part.strip() for part in re.split(r"\n\s*\n+", text) if part.strip()]
+
+
+def split_sentences(text: str) -> list[str]:
+    protected = re.sub(r"-\s*\n\s*", f"-{_JOINED_HYPHEN}", text)
+    sentences = [
+        part.replace(_JOINED_HYPHEN, "\n").strip()
+        for part in _SENTENCE_BOUNDARY.split(protected)
+        if part.strip()
+    ]
+    return sentences or ([text.strip()] if text.strip() else [])
+
+
+@dataclass(frozen=True, slots=True)
+class AnchorPayload:
+    paper_id: uuid.UUID
+    chunk_id: uuid.UUID | None
+    source: str
+    content_revision: str
+    anchor_key: str
+    anchor_type: str
+    seq: int | None
+    paragraph_index: int | None
+    sentence_index: int | None
+    quoted_text: str
+    normalized_text: str
+    locator: dict[str, Any]
+
+
+def _locator(
+    *, page_start: int | None, page_end: int | None, rects: list[dict[str, float]] | None
+) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    if page_start is not None:
+        value["page_start"] = page_start
+    if page_end is not None:
+        value["page_end"] = page_end
+    if rects:
+        value["rects"] = rects
+    return value
+
+
+def build_chunk_anchor_payloads(
+    *,
+    paper_id: uuid.UUID,
+    chunk_id: uuid.UUID | None,
+    seq: int | None,
+    text: str,
+    source: str,
+    page_start: int | None = None,
+    page_end: int | None = None,
+    rects: list[dict[str, float]] | None = None,
+) -> list[AnchorPayload]:
+    raw = text.strip()
+    if not raw:
+        return []
+    revision = content_revision(raw)
+    common = {
+        "paper_id": paper_id,
+        "chunk_id": chunk_id,
+        "source": source,
+        "content_revision": revision,
+        "seq": seq,
+    }
+    base_locator = _locator(page_start=page_start, page_end=page_end, rects=rects)
+    payloads = [
+        AnchorPayload(
+            **common,
+            anchor_key=f"chunk:{seq if seq is not None else 'na'}",
+            anchor_type="chunk",
+            paragraph_index=None,
+            sentence_index=None,
+            quoted_text=raw,
+            normalized_text=normalize_evidence_text(raw),
+            locator=base_locator,
+        )
+    ]
+    for paragraph_index, paragraph in enumerate(split_paragraphs(raw)):
+        payloads.append(
+            AnchorPayload(
+                **common,
+                anchor_key=f"paragraph:{seq if seq is not None else 'na'}:{paragraph_index}",
+                anchor_type="paragraph",
+                paragraph_index=paragraph_index,
+                sentence_index=None,
+                quoted_text=paragraph,
+                normalized_text=normalize_evidence_text(paragraph),
+                locator=base_locator,
+            )
+        )
+        for sentence_index, sentence in enumerate(split_sentences(paragraph)):
+            payloads.append(
+                AnchorPayload(
+                    **common,
+                    anchor_key=(
+                        f"sentence:{seq if seq is not None else 'na'}:"
+                        f"{paragraph_index}:{sentence_index}"
+                    ),
+                    anchor_type="sentence",
+                    paragraph_index=paragraph_index,
+                    sentence_index=sentence_index,
+                    quoted_text=sentence,
+                    normalized_text=normalize_evidence_text(sentence),
+                    locator=base_locator,
+                )
+            )
+    return payloads
+
+
+async def persist_chunk_anchors(
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    chunks: Iterable[PaperContentChunk],
+    source: str | None = None,
+    locators: Mapping[uuid.UUID, Mapping[str, Any]] | None = None,
+) -> int:
+    created = 0
+    for chunk in chunks:
+        raw = str(chunk.text or "").strip()
+        if not raw:
+            continue
+        locator = dict(locators.get(chunk.id, {}) if locators else {})
+        locator.setdefault("page_start", chunk.page_start)
+        locator.setdefault("page_end", chunk.page_end)
+        if not locator.get("rects") and isinstance(chunk.rects, list):
+            locator["rects"] = chunk.rects
+        for payload in build_chunk_anchor_payloads(
+            paper_id=paper_id,
+            chunk_id=chunk.id,
+            seq=chunk.seq,
+            text=raw,
+            source=source or "content",
+            page_start=locator.get("page_start"),
+            page_end=locator.get("page_end"),
+            rects=locator.get("rects"),
+        ):
+            exists = await session.scalar(
+                select(PaperEvidenceAnchor.id).where(
+                    PaperEvidenceAnchor.paper_id == payload.paper_id,
+                    PaperEvidenceAnchor.content_revision == payload.content_revision,
+                    PaperEvidenceAnchor.anchor_key == payload.anchor_key,
+                )
+            )
+            if exists is None:
+                session.add(PaperEvidenceAnchor(**asdict(payload)))
+                created += 1
+    if created:
+        await session.flush()
+    return created
+
+
+def _locator_values(
+    anchor: PaperEvidenceAnchor,
+) -> tuple[int | None, int | None, list[dict[str, float]]]:
+    locator = anchor.locator if isinstance(anchor.locator, dict) else {}
+    rects = locator.get("rects") if isinstance(locator.get("rects"), list) else []
+    return locator.get("page_start"), locator.get("page_end"), rects
+
+
+def _href(paper_id: uuid.UUID, anchor_id: uuid.UUID | None) -> str:
+    suffix = f"&evidence={anchor_id}" if anchor_id else ""
+    return f"/papers/{paper_id}/read?evidence=1{suffix}"
+
+
+def _resolution(
+    anchor: PaperEvidenceAnchor, *, status: str, anchor_type: str, quoted_text: str
+) -> EvidenceResolution:
+    page_start, page_end, rects = _locator_values(anchor)
+    return EvidenceResolution(
+        paper_id=anchor.paper_id,
+        anchor_id=anchor.id,
+        status=status,
+        anchor_type=anchor_type,
+        quoted_text=quoted_text,
+        chunk_id=anchor.chunk_id,
+        seq=anchor.seq,
+        page_start=page_start,
+        page_end=page_end,
+        rects=rects,
+        href=_href(anchor.paper_id, anchor.id),
+    )
+
+
+async def resolve_evidence_anchor(
+    session: AsyncSession,
+    anchor: PaperEvidenceAnchor,
+    *,
+    current_chunks: Sequence[PaperContentChunk] | None = None,
+) -> EvidenceResolution:
+    chunks = list(current_chunks or [])
+    if not chunks:
+        chunks = list(
+            (
+                await session.execute(
+                    select(PaperContentChunk)
+                    .join(
+                        PaperContentVersion,
+                        PaperContentVersion.id == PaperContentChunk.content_version_id,
+                    )
+                    .where(
+                        PaperContentVersion.paper_id == anchor.paper_id,
+                        PaperContentVersion.is_current.is_(True),
+                    )
+                )
+            ).scalars()
+        )
+    current = next((chunk for chunk in chunks if chunk.id == anchor.chunk_id), None)
+    if current is not None and content_revision(current.text) == anchor.content_revision:
+        return _resolution(
+            anchor, status="exact", anchor_type=anchor.anchor_type, quoted_text=anchor.quoted_text
+        )
+    needle = anchor.normalized_text
+    for chunk in chunks:
+        normalized = normalize_evidence_text(chunk.text)
+        if needle and (needle in normalized or normalized in needle):
+            status = (
+                anchor.anchor_type if anchor.anchor_type in {"sentence", "paragraph"} else "chunk"
+            )
+            return _resolution(
+                anchor, status=status, anchor_type=status, quoted_text=anchor.quoted_text
+            )
+    if current is not None:
+        return _resolution(anchor, status="chunk", anchor_type="chunk", quoted_text=current.text)
+    return EvidenceResolution(
+        paper_id=anchor.paper_id,
+        anchor_id=anchor.id,
+        status="paper",
+        anchor_type="paper",
+        quoted_text=anchor.quoted_text,
+        href=_href(anchor.paper_id, anchor.id),
+    )

--- a/src/backend/tests/test_evidence_anchors.py
+++ b/src/backend/tests/test_evidence_anchors.py
@@ -1,0 +1,179 @@
+"""证据锚点生成、版本回退和迁移回归。"""
+
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+
+from alembic import command
+from app.core.db import get_sessionmaker
+from app.models.evidence import PaperEvidenceAnchor
+from app.models.paper import new_paper
+from app.models.paper_assets import PaperAsset, PdfBlob
+from app.models.paper_content import PaperContentChunk, PaperContentVersion
+from app.services.evidence import (
+    build_chunk_anchor_payloads,
+    content_revision,
+    normalize_evidence_text,
+    persist_chunk_anchors,
+    resolve_evidence_anchor,
+    split_sentences,
+)
+
+
+def test_normalization_and_sentence_split_are_deterministic() -> None:
+    text = "A hyphen-\nated result is stable. 第二句有效。"
+    assert normalize_evidence_text(text) == "a hyphenated result is stable. 第二句有效。"
+    assert split_sentences(text) == ["A hyphen-\nated result is stable.", "第二句有效。"]
+
+
+def test_payloads_include_sentence_paragraph_and_chunk_anchors() -> None:
+    paper_id = uuid.uuid4()
+    chunk_id = uuid.uuid4()
+    payloads = build_chunk_anchor_payloads(
+        paper_id=paper_id,
+        chunk_id=chunk_id,
+        seq=3,
+        text="First sentence. Second sentence.\n\nA new paragraph.",
+        source="fulltext",
+        page_start=4,
+        page_end=5,
+        rects=[{"x0": 0.1, "y0": 0.2, "x1": 0.5, "y1": 0.3}],
+    )
+    assert {payload.anchor_type for payload in payloads} == {"chunk", "paragraph", "sentence"}
+    full_text = "First sentence. Second sentence.\n\nA new paragraph."
+    assert all(
+        payload.content_revision
+        == content_revision(
+            payload.quoted_text if payload.anchor_type == "chunk" else full_text
+        )
+        for payload in payloads
+    )
+    assert all(payload.locator["page_start"] == 4 for payload in payloads)
+
+
+@pytest.mark.asyncio
+async def test_persist_is_idempotent_and_keeps_reparse_revision(app) -> None:
+    chunk_id = uuid.uuid4()
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Evidence test paper")
+        session.add(paper)
+        await session.flush()
+        blob = PdfBlob(
+            sha256="a" * 64,
+            byte_size=1,
+            storage_key=f"pdf-blobs/aa/{'a' * 64}.pdf",
+            content_type="application/pdf",
+            state="ready",
+        )
+        session.add(blob)
+        await session.flush()
+        asset = PaperAsset(paper_id=paper.id, blob_id=blob.id, source="upload", state="ready")
+        session.add(asset)
+        await session.flush()
+        version = PaperContentVersion(
+            paper_id=paper.id,
+            asset_id=asset.id,
+            version_no=1,
+            parser="pymupdf",
+            status="ready_fallback",
+            is_current=True,
+        )
+        session.add(version)
+        await session.flush()
+        chunk = PaperContentChunk(
+            id=chunk_id,
+            content_version_id=version.id,
+            seq=0,
+            text="Original sentence.",
+        )
+        session.add(chunk)
+        await session.flush()
+        first = await persist_chunk_anchors(session, paper_id=paper.id, chunks=[chunk])
+        second = await persist_chunk_anchors(session, paper_id=paper.id, chunks=[chunk])
+        chunk.text = "Reparsed sentence."
+        await session.flush()
+        third = await persist_chunk_anchors(session, paper_id=paper.id, chunks=[chunk])
+        await session.commit()
+        assert first == 3 and second == 0 and third == 3
+        rows = (
+            await session.execute(
+                __import__("sqlalchemy").select(PaperEvidenceAnchor).where(
+                    PaperEvidenceAnchor.paper_id == paper.id
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 6
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_back_to_chunk_then_paper(app) -> None:
+    chunk_id = uuid.uuid4()
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Evidence fallback paper")
+        session.add(paper)
+        await session.flush()
+        blob = PdfBlob(
+            sha256="b" * 64,
+            byte_size=1,
+            storage_key=f"pdf-blobs/bb/{'b' * 64}.pdf",
+            content_type="application/pdf",
+            state="ready",
+        )
+        session.add(blob)
+        await session.flush()
+        asset = PaperAsset(paper_id=paper.id, blob_id=blob.id, source="upload", state="ready")
+        session.add(asset)
+        await session.flush()
+        version = PaperContentVersion(
+            paper_id=paper.id,
+            asset_id=asset.id,
+            version_no=1,
+            parser="pymupdf",
+            status="ready_fallback",
+            is_current=True,
+        )
+        session.add(version)
+        await session.flush()
+        chunk = PaperContentChunk(
+            id=chunk_id,
+            content_version_id=version.id,
+            seq=0,
+            text="A sentence that will change.",
+        )
+        session.add(chunk)
+        await session.flush()
+        await persist_chunk_anchors(session, paper_id=paper.id, chunks=[chunk])
+        await session.commit()
+        anchor = (
+            await session.execute(
+                __import__("sqlalchemy").select(PaperEvidenceAnchor).where(
+                    PaperEvidenceAnchor.paper_id == paper.id,
+                    PaperEvidenceAnchor.anchor_type == "sentence",
+                )
+            )
+        ).scalars().first()
+        assert anchor is not None
+        chunk.text = "A completely unrelated replacement."
+        await session.flush()
+        result = await resolve_evidence_anchor(session, anchor, current_chunks=[chunk])
+        assert result.status == "chunk"
+        assert result.anchor_type == "chunk"
+        assert result.href.endswith(f"evidence={anchor.id}")
+
+
+def test_migration_upgrade_and_downgrade_roundtrip(tmp_path: Path) -> None:
+    cfg = Config()
+    backend_dir = Path(__file__).resolve().parent.parent
+    cfg.set_main_option("script_location", str(backend_dir / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{tmp_path / 'evidence.db'}")
+    command.upgrade(cfg, "head")
+    import sqlite3
+
+    with sqlite3.connect(tmp_path / "evidence.db") as connection:
+        foreign_keys = connection.execute(
+            "PRAGMA foreign_key_list('paper_evidence_anchors')"
+        ).fetchall()
+    assert any(row[2] == "paper_content_chunks" for row in foreign_keys)
+    command.downgrade(cfg, "-1")

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
+HEAD_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
+CONTENT_VERSION_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
 PDF_ASSET_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
 LITERATURE_REVISION = "a7c8d9e0f1b2"  # library-scoped literature discovery contracts
 PREVIOUS_HEAD_REVISION = "8ff89f7fcdeb"  # integration tokens
@@ -122,6 +123,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "paper_content_chunks",
                     "paper_content_version_vectors",
                     "paper_content_chunk_vectors",
+                    "paper_evidence_anchors",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -446,7 +448,22 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     ]
     assert {"chunk_id", "space", "dim", "embedding"} <= columns["paper_content_chunk_vectors"]
 
-    # 先退掉解析内容版本迁移，回到 PDF 资产版本。
+    assert {
+        "anchor_type",
+        "anchor_key",
+        "content_revision",
+        "quoted_text",
+        "normalized_text",
+        "locator",
+    } <= columns["paper_evidence_anchors"]
+
+    # 先退掉证据锚点迁移，回到解析内容版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CONTENT_VERSION_REVISION
+    assert "paper_evidence_anchors" not in columns["_tables"]
+
+    # 再退掉解析内容版本迁移，回到 PDF 资产版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == PDF_ASSET_REVISION


### PR DESCRIPTION
Rebase of #466 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 22 files / +2601 to **9 files / +686**.

## Resolutions

Same three as #492, same cause — the branch predates #489/#490/#492 and carries its own copies:

- its duplicate `c8d9e0f1a2b3` chains from `8ff89f7fcdeb`; `main`'s version kept
- `router.py` and `models/__init__.py` drop the `literature_discovery` route and exports; union-resolved
- `tests/test_migrations.py` extended from `main`'s copy rather than replaced — `HEAD_REVISION` → `e5f6a7b8c9d0`, `CONTENT_VERSION_REVISION` added, the anchors table asserted, and a fourth downgrade step so the round trip walks `e5f6a7b8c9d0 → d9e0f1a2b3c4 → c8d9e0f1a2b3 → a7c8d9e0f1b2 → 8ff89f7fcdeb`

The new migration's own `down_revision` was already correct (`d9e0f1a2b3c4`).

## One thing worth flagging

`app/services/evidence.py` — this PR's largest new file, 255 lines — had six lines over the configured 100-column limit, so `ruff check app/` was red. Looking at #466's verification section explains why:

```
ruff check src/backend/app/api/download_client.py src/backend/app/models/download_client.py ...
All checks passed
```

Those are #467's files, not this PR's. The check was run against a different PR's file list, so this PR's own new service was never linted. Formatted here.

Worth fixing at the process level rather than per PR: `ruff check app/` over the whole package costs the same as naming files and cannot be pointed at the wrong ones.

## Verification

- `alembic heads` → single head `e5f6a7b8c9d0`
- `tests/test_migrations.py tests/test_evidence_anchors.py tests/test_paper_content.py tests/test_paper_assets.py tests/test_literature_discovery_api.py` → 18 passed
- `ruff check app/ tests/test_migrations.py` → clean; `import app.main` → ok

Closes #460. Supersedes #466.