### PR TITLE
feat(extension): add Polaris batch archive protocol

### DIFF
--- a/src/backend/alembic/versions/e0f1a2b3c4d5_download_batch_protocol.py
+++ b/src/backend/alembic/versions/e0f1a2b3c4d5_download_batch_protocol.py
@@ -1,0 +1,101 @@
+"""Polaris browser extension download batches and API keys.
+
+Revision ID: e0f1a2b3c4d5
+Revises: e5f6a7b8c9d0
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e0f1a2b3c4d5"
+down_revision: str | None = "e5f6a7b8c9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "download_api_keys",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("key_prefix", sa.String(24), nullable=False),
+        sa.Column("secret_hash", sa.String(64), nullable=False),
+        sa.Column("scopes", _JSON, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False, server_default="active"),
+        sa.Column("last_used_at", sa.DateTime(timezone=True)),
+        sa.Column("expires_at", sa.DateTime(timezone=True)),
+        sa.Column("revoked_at", sa.DateTime(timezone=True)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("user_id"),
+        sa.UniqueConstraint("key_prefix"),
+    )
+    op.create_index("ix_download_api_keys_user_id", "download_api_keys", ["user_id"])
+    op.create_index("ix_download_api_keys_key_prefix", "download_api_keys", ["key_prefix"])
+
+    op.create_table(
+        "download_batches",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("status", sa.String(24), nullable=False, server_default="queued"),
+        sa.Column("completed_at", sa.DateTime(timezone=True)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_download_batches_created_by", "download_batches", ["created_by"])
+    op.create_index("ix_download_batches_status", "download_batches", ["status"])
+
+    op.create_table(
+        "download_batch_items",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("batch_id", sa.Uuid(), sa.ForeignKey("download_batches.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("library_id", sa.Uuid(), sa.ForeignKey("direction_libraries.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("paper_id", sa.Uuid(), sa.ForeignKey("papers.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("expected_identity", _JSON, nullable=False),
+        sa.Column("article_url", sa.Text()),
+        sa.Column("pdf_candidates", _JSON),
+        sa.Column("status", sa.String(24), nullable=False, server_default="queued"),
+        sa.Column("claimed_at", sa.DateTime(timezone=True)),
+        sa.Column("lease_until", sa.DateTime(timezone=True)),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True)),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("result", _JSON),
+        sa.Column("error", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("batch_id", "library_id", "paper_id", name="uq_download_item_target"),
+    )
+    op.create_index("ix_download_batch_items_batch_id", "download_batch_items", ["batch_id"])
+    op.create_index("ix_download_batch_items_created_by", "download_batch_items", ["created_by"])
+    op.create_index("ix_download_batch_items_library_id", "download_batch_items", ["library_id"])
+    op.create_index("ix_download_batch_items_paper_id", "download_batch_items", ["paper_id"])
+    op.create_index("ix_download_batch_items_status", "download_batch_items", ["status"])
+    op.create_index(
+        "ix_download_items_owner_status", "download_batch_items", ["created_by", "status"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_download_items_owner_status", table_name="download_batch_items")
+    for name in (
+        "ix_download_batch_items_status",
+        "ix_download_batch_items_paper_id",
+        "ix_download_batch_items_library_id",
+        "ix_download_batch_items_created_by",
+        "ix_download_batch_items_batch_id",
+    ):
+        op.drop_index(name, table_name="download_batch_items")
+    op.drop_table("download_batch_items")
+    op.drop_index("ix_download_batches_status", table_name="download_batches")
+    op.drop_index("ix_download_batches_created_by", table_name="download_batches")
+    op.drop_table("download_batches")
+    op.drop_index("ix_download_api_keys_key_prefix", table_name="download_api_keys")
+    op.drop_index("ix_download_api_keys_user_id", table_name="download_api_keys")
+    op.drop_table("download_api_keys")

--- a/src/backend/app/api/download_client.py
+++ b/src/backend/app/api/download_client.py
@@ -1,0 +1,690 @@
+"""User API-key driven protocol used by the Polaris browser extension."""
+
+import hashlib
+import hmac
+import json
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user, current_user_optional
+from app.core.config import get_settings
+from app.core.db import get_session
+from app.core.queue import TaskQueue, get_task_queue
+from app.models.download_client import DownloadApiKey, DownloadBatch, DownloadBatchItem
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper
+from app.models.user import User
+from app.schemas.download_client import (
+    DownloadApiKeyCreated,
+    DownloadArchiveMetadata,
+    DownloadArchiveResult,
+    DownloadBatchCreate,
+    DownloadBatchCreated,
+    DownloadBatchRead,
+    DownloadCacheAck,
+    DownloadHeartbeat,
+    DownloadItemRead,
+    DownloadResult,
+)
+from app.services import libraries as libraries_service
+from app.services import paper_assets as asset_service
+from app.services import paper_content as content_service
+
+router = APIRouter(tags=["download-client"])
+
+SCOPES = ["download_batch:read", "download_batch:update", "paper_pdf:upload"]
+LEASE_MINUTES = 10
+TERMINAL_ITEM_STATUSES = {"uploaded", "skipped", "failed", "blocked", "cancelled"}
+
+
+def _hash_key(value: str) -> str:
+    return hmac.new(
+        get_settings().secret_key.encode("utf-8"), value.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def _expected_identity(paper: Paper) -> dict[str, str]:
+    identity: dict[str, str] = {}
+    if paper.dedup_key:
+        identity["dedup_key"] = paper.dedup_key
+    if paper.doi:
+        identity["doi"] = paper.doi
+    if paper.arxiv_id:
+        identity["arxiv_id"] = paper.arxiv_id
+    for key in ("pmid", "pmcid"):
+        value = (paper.external_ids or {}).get(key)
+        if value:
+            identity[key] = str(value)
+    return identity
+
+
+def _normalize_doi(value: str) -> str:
+    return value.strip().lower().removeprefix("https://doi.org/").removeprefix("doi:")
+
+
+def _identity_matches(metadata: DownloadArchiveMetadata, paper: Paper) -> bool:
+    supplied = False
+    if metadata.doi:
+        supplied = True
+        if not paper.doi or _normalize_doi(metadata.doi) != _normalize_doi(paper.doi):
+            return False
+    external = {str(k).lower(): str(v).lower() for k, v in (paper.external_ids or {}).items()}
+    for name, value in (("pmid", metadata.pmid), ("pmcid", metadata.pmcid)):
+        if value:
+            supplied = True
+            if external.get(name) != str(value).strip().lower():
+                return False
+    if metadata.arxiv_id:
+        supplied = True
+        if (
+            not paper.arxiv_id
+            or paper.arxiv_id.strip().lower() != metadata.arxiv_id.strip().lower()
+        ):
+            return False
+    if supplied:
+        return True
+    return " ".join(metadata.title.casefold().split()) == " ".join(
+        (paper.title or "").casefold().split()
+    )
+
+
+async def _require_managed_library(
+    session: AsyncSession, *, library_id: uuid.UUID, user: User
+) -> DirectionLibrary:
+    library = await session.get(DirectionLibrary, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
+    if not await libraries_service.can_manage_library(session, user=user, library=library):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="DOWNLOAD_LIBRARY_FORBIDDEN")
+    return library
+
+
+async def download_client_user(
+    x_polaris_api_key: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> User:
+    if not x_polaris_api_key or not x_polaris_api_key.startswith("pol_dl_"):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="DOWNLOAD_API_KEY_REQUIRED")
+    prefix = x_polaris_api_key[:24]
+    row = (
+        await session.execute(
+            select(DownloadApiKey, User)
+            .join(User, User.id == DownloadApiKey.user_id)
+            .where(DownloadApiKey.key_prefix == prefix, DownloadApiKey.status == "active")
+        )
+    ).first()
+    if row is None or not hmac.compare_digest(row[0].secret_hash, _hash_key(x_polaris_api_key)):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="DOWNLOAD_API_KEY_INVALID")
+    key, user = row
+    now = datetime.now(UTC)
+    if not user.is_active or (key.expires_at is not None and key.expires_at <= now):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="DOWNLOAD_API_KEY_EXPIRED")
+    key.last_used_at = now
+    await session.commit()
+    return user
+
+
+async def download_batch_user(
+    x_polaris_api_key: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+    bearer_user: User | None = Depends(current_user_optional),
+) -> User:
+    """Authenticate batch creation from the UI session or the extension API key."""
+    if x_polaris_api_key:
+        return await download_client_user(x_polaris_api_key, session)
+    if bearer_user is not None:
+        return bearer_user
+    raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="DOWNLOAD_AUTH_REQUIRED")
+
+
+def _new_api_key() -> str:
+    return "pol_dl_" + secrets.token_urlsafe(32)
+
+
+@router.post("/me/download-api-key", response_model=DownloadApiKeyCreated)
+async def rotate_download_api_key(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> DownloadApiKeyCreated:
+    existing = await session.scalar(select(DownloadApiKey).where(DownloadApiKey.user_id == user.id))
+    raw = _new_api_key()
+    if existing is None:
+        key = DownloadApiKey(
+            user_id=user.id,
+            key_prefix=raw[:24],
+            secret_hash=_hash_key(raw),
+            scopes=SCOPES,
+            status="active",
+        )
+        session.add(key)
+    else:
+        key = existing
+        key.key_prefix = raw[:24]
+        key.secret_hash = _hash_key(raw)
+        key.scopes = SCOPES
+        key.status = "active"
+        key.revoked_at = None
+        key.expires_at = None
+    await session.commit()
+    return DownloadApiKeyCreated(api_key=raw, key_prefix=key.key_prefix, created_at=key.created_at)
+
+
+@router.delete("/me/download-api-key", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_download_api_key(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    key = await session.scalar(select(DownloadApiKey).where(DownloadApiKey.user_id == user.id))
+    if key is not None:
+        key.status = "revoked"
+        key.revoked_at = datetime.now(UTC)
+        await session.commit()
+
+
+async def _cached_asset(
+    session: AsyncSession, *, paper_id: uuid.UUID, library_id: uuid.UUID
+) -> tuple[uuid.UUID, str] | None:
+    rows = await asset_service.list_assets(session, paper_id=paper_id, library_id=library_id)
+    for asset, blob, _grant in rows:
+        if asset.state == "ready" and blob.state == "ready":
+            return asset.id, blob.sha256
+    return None
+
+
+async def _reuse_public_asset(
+    session: AsyncSession, *, paper_id: uuid.UUID, library: DirectionLibrary, user: User
+) -> tuple[uuid.UUID, str] | None:
+    try:
+        grant = await asset_service.grant_public_asset_for_paper(
+            session, paper_id=paper_id, target_library=library, user=user
+        )
+    except asset_service.AssetNotFoundError:
+        return None
+    asset = await session.get(asset_service.PaperAsset, grant.asset_id)
+    blob = await session.get(asset_service.PdfBlob, asset.blob_id) if asset is not None else None
+    if asset is None or blob is None:
+        return None
+    return asset.id, blob.sha256
+
+
+def _public_result(result: dict | None) -> dict | None:
+    if not result:
+        return result
+    return {key: value for key, value in result.items() if key != "_lease_token_hash"}
+
+
+def _item_read(item: DownloadBatchItem, *, lease_token: str | None = None) -> DownloadItemRead:
+    return DownloadItemRead(
+        id=item.id,
+        batch_id=item.batch_id,
+        library_id=item.library_id,
+        paper_id=item.paper_id,
+        expected_identity=item.expected_identity,
+        article_url=item.article_url,
+        pdf_candidates=item.pdf_candidates,
+        status=item.status,
+        lease_until=item.lease_until,
+        lease_token=lease_token,
+        attempt_count=item.attempt_count,
+        error=item.error,
+        result=_public_result(item.result),
+    )
+
+
+async def _refresh_batch(session: AsyncSession, batch_id: uuid.UUID) -> None:
+    batch = await session.get(DownloadBatch, batch_id)
+    if batch is None:
+        return
+    statuses = list(
+        (
+            await session.execute(
+                select(DownloadBatchItem.status).where(DownloadBatchItem.batch_id == batch_id)
+            )
+        ).scalars()
+    )
+    if not statuses:
+        batch.status = "failed"
+    elif all(value in TERMINAL_ITEM_STATUSES for value in statuses):
+        uploaded = sum(value == "uploaded" for value in statuses)
+        skipped = sum(value == "skipped" for value in statuses)
+        if uploaded == len(statuses) or uploaded + skipped == len(statuses):
+            batch.status = "completed"
+        elif uploaded or skipped:
+            batch.status = "partial"
+        else:
+            batch.status = "failed"
+        batch.completed_at = datetime.now(UTC)
+    elif any(value != "queued" for value in statuses):
+        batch.status = "running"
+
+
+async def _batch_items(session: AsyncSession, batch_id: uuid.UUID) -> list[DownloadBatchItem]:
+    return list(
+        (
+            await session.execute(
+                select(DownloadBatchItem)
+                .where(DownloadBatchItem.batch_id == batch_id)
+                .order_by(DownloadBatchItem.created_at)
+            )
+        ).scalars()
+    )
+
+
+@router.post("/download-batches", response_model=DownloadBatchCreated)
+async def create_download_batch(
+    data: DownloadBatchCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(download_batch_user),
+) -> DownloadBatchCreated:
+    batch = DownloadBatch(created_by=user.id, status="queued")
+    session.add(batch)
+    await session.flush()
+    seen: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for target in data.targets:
+        pair = (target.library_id, target.paper_id)
+        if pair in seen:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT, detail="DUPLICATE_DOWNLOAD_TARGET"
+            )
+        seen.add(pair)
+        library = await _require_managed_library(session, library_id=target.library_id, user=user)
+        paper = await session.get(Paper, target.paper_id)
+        if paper is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+        item = DownloadBatchItem(
+            batch_id=batch.id,
+            created_by=user.id,
+            library_id=target.library_id,
+            paper_id=paper.id,
+            expected_identity=_expected_identity(paper),
+            article_url=target.article_url or paper.url,
+            pdf_candidates=target.pdf_candidates,
+        )
+        cached = await _cached_asset(session, paper_id=paper.id, library_id=target.library_id)
+        if cached is None:
+            cached = await _reuse_public_asset(
+                session, paper_id=paper.id, library=library, user=user
+            )
+        if cached is not None:
+            asset_id, sha256 = cached
+            item.status = "skipped"
+            item.result = {"reason": "already_cached", "asset_id": str(asset_id), "sha256": sha256}
+        session.add(item)
+    await _refresh_batch(session, batch.id)
+    await session.commit()
+    return DownloadBatchCreated(
+        id=batch.id,
+        status=batch.status,
+        item_count=len(data.targets),
+        items=[_item_read(item) for item in await _batch_items(session, batch.id)],
+    )
+
+
+@router.get("/download-batches", response_model=list[DownloadBatchRead])
+async def list_download_batches(
+    library_id: uuid.UUID | None = None,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[DownloadBatchRead]:
+    item_ids = select(DownloadBatchItem.batch_id).where(DownloadBatchItem.created_by == user.id)
+    if library_id is not None:
+        item_ids = item_ids.where(DownloadBatchItem.library_id == library_id)
+    batches = list(
+        (
+            await session.execute(
+                select(DownloadBatch)
+                .where(DownloadBatch.created_by == user.id, DownloadBatch.id.in_(item_ids))
+                .order_by(DownloadBatch.created_at.desc())
+                .limit(50)
+            )
+        ).scalars()
+    )
+    if not batches:
+        return []
+    items = list(
+        (
+            await session.execute(
+                select(DownloadBatchItem)
+                .where(DownloadBatchItem.batch_id.in_([batch.id for batch in batches]))
+                .order_by(DownloadBatchItem.created_at)
+            )
+        ).scalars()
+    )
+    grouped: dict[uuid.UUID, list[DownloadItemRead]] = {}
+    for item in items:
+        grouped.setdefault(item.batch_id, []).append(_item_read(item))
+    return [
+        DownloadBatchRead(
+            id=batch.id,
+            status=batch.status,
+            created_at=batch.created_at,
+            updated_at=batch.updated_at,
+            completed_at=batch.completed_at,
+            items=grouped.get(batch.id, []),
+        )
+        for batch in batches
+    ]
+
+
+@router.get("/download-client/me")
+async def get_download_client_me(user: User = Depends(download_client_user)) -> dict[str, str]:
+    return {"user_id": str(user.id), "email": user.email}
+
+
+@router.post("/download-client/items/claim", response_model=DownloadItemRead | None)
+async def claim_download_item(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(download_client_user),
+) -> DownloadItemRead | None:
+    now = datetime.now(UTC)
+    stmt = (
+        select(DownloadBatchItem)
+        .where(
+            DownloadBatchItem.created_by == user.id,
+            DownloadBatchItem.status.in_(("queued", "claimed", "downloading")),
+            (DownloadBatchItem.lease_until.is_(None)) | (DownloadBatchItem.lease_until < now),
+        )
+        .order_by(DownloadBatchItem.created_at)
+        .limit(1)
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        stmt = stmt.with_for_update(skip_locked=True)
+    item = (await session.execute(stmt)).scalar_one_or_none()
+    if item is None:
+        return None
+    item.status = "claimed"
+    item.claimed_at = now
+    item.heartbeat_at = now
+    item.lease_until = now + timedelta(minutes=LEASE_MINUTES)
+    item.attempt_count += 1
+    lease_token = secrets.token_urlsafe(32)
+    item.result = {"_lease_token_hash": hashlib.sha256(lease_token.encode()).hexdigest()}
+    await _refresh_batch(session, item.batch_id)
+    await session.commit()
+    return _item_read(item, lease_token=lease_token)
+
+
+async def _owned_item(session: AsyncSession, item_id: uuid.UUID, user: User) -> DownloadBatchItem:
+    item = await session.get(DownloadBatchItem, item_id)
+    if item is None or item.created_by != user.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="DOWNLOAD_ITEM_NOT_FOUND")
+    return item
+
+
+def _require_active_lease(item: DownloadBatchItem, token: str | None, *, now: datetime) -> None:
+    expected = (item.result or {}).get("_lease_token_hash")
+    actual = hashlib.sha256(token.encode()).hexdigest() if token else ""
+    lease_until = item.lease_until
+    if lease_until is not None and lease_until.tzinfo is None:
+        lease_until = lease_until.replace(tzinfo=UTC)
+    if (
+        item.status not in {"claimed", "downloading", "cached", "uploading"}
+        or lease_until is None
+        or lease_until <= now
+        or not isinstance(expected, str)
+        or not hmac.compare_digest(expected, actual)
+    ):
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="DOWNLOAD_ITEM_LEASE_INVALID")
+
+
+@router.post("/download-client/items/{item_id}/heartbeat")
+async def heartbeat_download_item(
+    item_id: uuid.UUID,
+    data: DownloadHeartbeat,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(download_client_user),
+    x_polaris_lease_token: str | None = Header(default=None),
+) -> dict[str, str]:
+    item = await _owned_item(session, item_id, user)
+    _require_active_lease(item, x_polaris_lease_token, now=datetime.now(UTC))
+    item.status = data.status
+    item.heartbeat_at = datetime.now(UTC)
+    item.lease_until = datetime.now(UTC) + timedelta(minutes=LEASE_MINUTES)
+    await session.commit()
+    return {"status": item.status}
+
+
+@router.post("/download-client/items/{item_id}/cache")
+async def acknowledge_download_cache(
+    item_id: uuid.UUID,
+    data: DownloadCacheAck,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(download_client_user),
+    x_polaris_lease_token: str | None = Header(default=None),
+) -> dict[str, str | int]:
+    item = await _owned_item(session, item_id, user)
+    _require_active_lease(item, x_polaris_lease_token, now=datetime.now(UTC))
+    item.status = "cached"
+    item.heartbeat_at = datetime.now(UTC)
+    item.lease_until = datetime.now(UTC) + timedelta(minutes=LEASE_MINUTES)
+    item.result = {
+        **(item.result or {}),
+        "local_sha256": data.sha256.lower(),
+        "local_byte_size": data.byte_size,
+    }
+    await session.commit()
+    return {"status": item.status, "sha256": data.sha256.lower(), "byte_size": data.byte_size}
+
+
+@router.post("/download-client/items/{item_id}/result")
+async def report_download_result(
+    item_id: uuid.UUID,
+    data: DownloadResult,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(download_client_user),
+    x_polaris_lease_token: str | None = Header(default=None),
+) -> dict[str, str]:
+    item = await _owned_item(session, item_id, user)
+    if item.status in TERMINAL_ITEM_STATUSES:
+        if item.status == data.status:
+            return {"status": item.status}
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="DOWNLOAD_ITEM_TERMINAL")
+    _require_active_lease(item, x_polaris_lease_token, now=datetime.now(UTC))
+    item.status, item.error, item.result = data.status, data.error, data.evidence
+    item.lease_until = None
+    await _refresh_batch(session, item.batch_id)
+    await session.commit()
+    return {"status": item.status}
+
+
+async def _archive_bound_pdf(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    paper: Paper,
+    user: User,
+    content: bytes,
+    source_url: str | None,
+    queue: TaskQueue,
+    expected_sha256: str | None = None,
+) -> tuple[uuid.UUID, uuid.UUID, str]:
+    if expected_sha256 and not hmac.compare_digest(
+        expected_sha256.strip().lower(), hashlib.sha256(content).hexdigest()
+    ):
+        raise ValueError("PDF_CHECKSUM_MISMATCH")
+    membership, _ = await libraries_service.ensure_membership(
+        session, library_id=library.id, paper_id=paper.id, status="included"
+    )
+    membership.status = "included"
+    # Extension PDFs may be institution-authorized. Keep them inside the target
+    # library; only explicitly public/OA assets may be reused across libraries.
+    sharing_scope = "library"
+    asset = await asset_service.create_or_reuse_asset(
+        session,
+        paper=paper,
+        library=library,
+        content=content,
+        user=user,
+        source="extension",
+        source_locator=source_url,
+        identity_key=paper.dedup_key,
+        identity_status="verified",
+        sharing_scope=sharing_scope,
+    )
+    current = await content_service.current_content_version(session, paper_id=paper.id)
+    enqueue_parse = False
+    if current is not None and current.asset_id == asset.id and current.status != "failed":
+        version = current
+    else:
+        version = await content_service.create_content_version(
+            session, asset=asset, parser="mineru"
+        )
+        enqueue_parse = True
+    await session.commit()
+    if enqueue_parse:
+        await queue.enqueue(
+            "parse_paper_content_task", str(version.id), str(user.id), str(library.id)
+        )
+    return asset.id, version.id, version.status
+
+
+async def _complete_matching_items(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    asset_id: uuid.UUID,
+    content_version_id: uuid.UUID,
+) -> None:
+    items = list(
+        (
+            await session.execute(
+                select(DownloadBatchItem).where(
+                    DownloadBatchItem.created_by == user_id,
+                    DownloadBatchItem.library_id == library_id,
+                    DownloadBatchItem.paper_id == paper_id,
+                    DownloadBatchItem.status.notin_(TERMINAL_ITEM_STATUSES),
+                )
+            )
+        ).scalars()
+    )
+    batch_ids: set[uuid.UUID] = set()
+    for item in items:
+        item.status = "uploaded"
+        item.error = None
+        item.lease_until = None
+        item.result = {
+            "asset_id": str(asset_id),
+            "content_version_id": str(content_version_id),
+        }
+        batch_ids.add(item.batch_id)
+    await session.flush()
+    for batch_id in batch_ids:
+        await _refresh_batch(session, batch_id)
+
+
+@router.post("/download-client/items/{item_id}/pdf", status_code=status.HTTP_201_CREATED)
+async def upload_downloaded_pdf(
+    item_id: uuid.UUID,
+    pdf: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+    queue: TaskQueue = Depends(get_task_queue),
+    user: User = Depends(download_client_user),
+    x_polaris_lease_token: str | None = Header(default=None),
+    x_polaris_pdf_sha256: str | None = Header(default=None),
+) -> dict[str, str]:
+    item = await _owned_item(session, item_id, user)
+    if item.status in {"uploaded", "skipped"} and item.result:
+        return {
+            key: str(item.result[key])
+            for key in ("asset_id", "content_version_id")
+            if key in item.result
+        }
+    _require_active_lease(item, x_polaris_lease_token, now=datetime.now(UTC))
+    library = await _require_managed_library(session, library_id=item.library_id, user=user)
+    paper = await session.get(Paper, item.paper_id)
+    if paper is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    content = await pdf.read(asset_service.MAX_PDF_BYTES + 1)
+    expected_sha256 = (item.result or {}).get("local_sha256") or x_polaris_pdf_sha256
+    try:
+        asset_id, version_id, version_status = await _archive_bound_pdf(
+            session,
+            library=library,
+            paper=paper,
+            user=user,
+            content=content,
+            source_url=item.article_url,
+            queue=queue,
+            expected_sha256=expected_sha256,
+        )
+    except Exception as exc:  # noqa: BLE001 - item failure is persisted for retry visibility
+        await session.rollback()
+        item = await session.get(DownloadBatchItem, item_id)
+        if item is not None:
+            item.status, item.error, item.lease_until = "failed", str(exc)[:4000], None
+            await _refresh_batch(session, item.batch_id)
+            await session.commit()
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    item.status = "uploaded"
+    item.result = {"asset_id": str(asset_id), "content_version_id": str(version_id)}
+    item.lease_until = None
+    await _refresh_batch(session, item.batch_id)
+    await session.commit()
+    return {
+        "asset_id": str(asset_id),
+        "content_version_id": str(version_id),
+        "status": version_status,
+    }
+
+
+@router.post(
+    "/download-client/archive",
+    response_model=DownloadArchiveResult,
+    status_code=status.HTTP_201_CREATED,
+)
+async def archive_downloaded_pdf(
+    metadata: str = Form(...),
+    pdf: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+    queue: TaskQueue = Depends(get_task_queue),
+    user: User = Depends(download_client_user),
+    x_polaris_pdf_sha256: str | None = Header(default=None),
+) -> DownloadArchiveResult:
+    try:
+        archive = DownloadArchiveMetadata.model_validate(json.loads(metadata))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="DOWNLOAD_ARCHIVE_METADATA_INVALID"
+        ) from exc
+    library = await _require_managed_library(session, library_id=archive.library_id, user=user)
+    paper = await session.get(Paper, archive.paper_id)
+    if paper is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    if not _identity_matches(archive, paper):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="DOWNLOAD_ARCHIVE_IDENTITY_MISMATCH"
+        )
+    content = await pdf.read(asset_service.MAX_PDF_BYTES + 1)
+    try:
+        asset_id, version_id, version_status = await _archive_bound_pdf(
+            session,
+            library=library,
+            paper=paper,
+            user=user,
+            content=content,
+            source_url=archive.source_url,
+            queue=queue,
+            expected_sha256=x_polaris_pdf_sha256,
+        )
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    await _complete_matching_items(
+        session,
+        user_id=user.id,
+        library_id=library.id,
+        paper_id=paper.id,
+        asset_id=asset_id,
+        content_version_id=version_id,
+    )
+    await session.commit()
+    return DownloadArchiveResult(
+        asset_id=asset_id, content_version_id=version_id, status=version_status
+    )

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -12,6 +12,7 @@ from app.api import (
     chat_bots,
     concepts,
     daily,
+    download_client,
     evidence,
     experiments,
     feedback,
@@ -82,6 +83,7 @@ api_router.include_router(ideas.router)
 api_router.include_router(search.router)
 api_router.include_router(shelf.router)
 api_router.include_router(daily.router)
+api_router.include_router(download_client.router)
 api_router.include_router(deepseek_harness_router)
 api_router.include_router(skills.router)
 api_router.include_router(market.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.buddy_memory import BuddyMemory
 from app.models.chat_bot import ChatBotConfig
 from app.models.conversation import Conversation, ConversationMessage
 from app.models.daily_feed import DailyFeedEntry, DailyFeedLike
+from app.models.download_client import DownloadApiKey, DownloadBatch, DownloadBatchItem
 from app.models.email_code import EmailVerificationCode
 from app.models.evidence import PaperEvidenceAnchor
 from app.models.experiment import Experiment, ExperimentRun
@@ -86,6 +87,9 @@ __all__ = [
     "LLMCallLog",
     "LibraryPaper",
     "LibraryResearchDigest",
+    "DownloadApiKey",
+    "DownloadBatch",
+    "DownloadBatchItem",
     "PaperEvidenceAnchor",
     "PaperContentVersion",
     "PaperContentChunk",

--- a/src/backend/app/models/download_client.py
+++ b/src/backend/app/models/download_client.py
@@ -1,0 +1,69 @@
+"""Persistent browser-extension download batches and leased items."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class DownloadApiKey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "download_api_keys"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True
+    )
+    key_prefix: Mapped[str] = mapped_column(String(24), unique=True, nullable=False, index=True)
+    secret_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    scopes: Mapped[list[Any]] = mapped_column(JSONVariant, default=list, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default="active", nullable=False)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class DownloadBatch(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "download_batches"
+
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(String(24), default="queued", nullable=False, index=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class DownloadBatchItem(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "download_batch_items"
+    __table_args__ = (
+        UniqueConstraint("batch_id", "library_id", "paper_id", name="uq_download_item_target"),
+        Index("ix_download_items_owner_status", "created_by", "status"),
+    )
+
+    batch_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("download_batches.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    expected_identity: Mapped[dict[str, Any]] = mapped_column(
+        JSONVariant, default=dict, nullable=False
+    )
+    article_url: Mapped[str | None] = mapped_column(Text)
+    pdf_candidates: Mapped[list[Any] | None] = mapped_column(JSONVariant)
+    status: Mapped[str] = mapped_column(String(24), default="queued", nullable=False, index=True)
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    lease_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    heartbeat_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    attempt_count: Mapped[int] = mapped_column(default=0, nullable=False)
+    result: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    error: Mapped[str | None] = mapped_column(Text)

--- a/src/backend/app/schemas/download_client.py
+++ b/src/backend/app/schemas/download_client.py
@@ -1,0 +1,89 @@
+"""API contracts for the Polaris browser extension."""
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class DownloadApiKeyCreated(BaseModel):
+    api_key: str
+    key_prefix: str
+    created_at: datetime
+
+
+class DownloadTarget(BaseModel):
+    library_id: uuid.UUID
+    paper_id: uuid.UUID
+    article_url: str | None = Field(default=None, max_length=4000)
+    pdf_candidates: list[Any] | None = None
+
+
+class DownloadBatchCreate(BaseModel):
+    targets: list[DownloadTarget] = Field(min_length=1, max_length=500)
+
+
+class DownloadItemRead(BaseModel):
+    id: uuid.UUID
+    batch_id: uuid.UUID
+    library_id: uuid.UUID
+    paper_id: uuid.UUID
+    expected_identity: dict[str, Any]
+    article_url: str | None
+    pdf_candidates: list[Any] | None
+    status: str
+    lease_until: datetime | None
+    lease_token: str | None = None
+    attempt_count: int
+    error: str | None = None
+    result: dict[str, Any] | None = None
+
+
+class DownloadBatchCreated(BaseModel):
+    id: uuid.UUID
+    status: str
+    item_count: int
+    items: list[DownloadItemRead]
+
+
+class DownloadBatchRead(BaseModel):
+    id: uuid.UUID
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None
+    items: list[DownloadItemRead]
+
+
+class DownloadHeartbeat(BaseModel):
+    status: Literal["downloading", "uploading"] = "downloading"
+
+
+class DownloadCacheAck(BaseModel):
+    sha256: str = Field(pattern=r"^[0-9a-fA-F]{64}$")
+    byte_size: int = Field(gt=0)
+
+
+class DownloadResult(BaseModel):
+    status: Literal["failed", "blocked", "cancelled"]
+    error: str | None = Field(default=None, max_length=4000)
+    evidence: dict[str, Any] | None = None
+
+
+class DownloadArchiveMetadata(BaseModel):
+    library_id: uuid.UUID
+    paper_id: uuid.UUID
+    nonce: str = Field(min_length=16, max_length=200)
+    doi: str | None = Field(default=None, max_length=512)
+    pmid: str | None = Field(default=None, max_length=64)
+    pmcid: str | None = Field(default=None, max_length=64)
+    arxiv_id: str | None = Field(default=None, max_length=128)
+    title: str = Field(min_length=1, max_length=2000)
+    source_url: str | None = Field(default=None, max_length=4000)
+
+
+class DownloadArchiveResult(BaseModel):
+    asset_id: uuid.UUID
+    content_version_id: uuid.UUID
+    status: str

--- a/src/backend/tests/test_download_batch_protocol.py
+++ b/src/backend/tests/test_download_batch_protocol.py
@@ -1,0 +1,223 @@
+"""Smoke tests for the Polaris extension batch/archive contract."""
+
+import hashlib
+import uuid
+
+import pymupdf
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import new_paper
+from tests.conftest import register_and_login
+
+
+def _pdf_bytes(title: str = "test") -> bytes:
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_text((72, 72), title)
+    data = document.tobytes()
+    document.close()
+    return data
+
+
+async def _target(email: str, *, name: str = "batch library", papers: int = 1):
+    async with get_sessionmaker()() as session:
+        owner = (
+            await session.execute(
+                select(__import__("app.models.user", fromlist=["User"]).User).where(
+                    __import__("app.models.user", fromlist=["User"]).User.email == email
+                )
+            )
+        ).scalar_one()
+        library = DirectionLibrary(
+            name=name,
+            status="active",
+            is_public=False,
+            submitted_by=owner.id,
+            created_by=owner.id,
+        )
+        session.add(library)
+        await session.flush()
+        paper_rows = []
+        for index in range(papers):
+            paper = new_paper(
+                dedup_key=f"doi:10.5555/batch-{uuid.uuid4().hex}",
+                title=f"Batch paper {index}",
+                doi=f"10.5555/batch-{uuid.uuid4().hex}",
+                url="https://publisher.example/article",
+            )
+            # The dedup key is the stable identity used by the asset contract.
+            paper.doi = paper.dedup_key.removeprefix("doi:")
+            session.add(paper)
+            await session.flush()
+            session.add(LibraryPaper(library_id=library.id, paper_id=paper.id, status="included"))
+            paper_rows.append(paper)
+        await session.commit()
+        return str(library.id), [str(paper.id) for paper in paper_rows]
+
+
+@pytest.mark.asyncio
+async def test_batch_creates_one_batch_and_rotates_key(client):
+    token = await register_and_login(client, email="batch-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("batch-owner@example.com", papers=2)
+
+    first = await client.post("/api/me/download-api-key", headers=auth)
+    second = await client.post("/api/me/download-api-key", headers=auth)
+    assert first.status_code == second.status_code == 200
+    assert first.json()["api_key"] != second.json()["api_key"]
+    assert (
+        await client.get(
+            "/api/download-client/me", headers={"X-Polaris-API-Key": first.json()["api_key"]}
+        )
+    ).status_code == 401
+    assert (
+        await client.get(
+            "/api/download-client/me", headers={"X-Polaris-API-Key": second.json()["api_key"]}
+        )
+    ).status_code == 200
+
+    created = await client.post(
+        "/api/download-batches",
+        headers=auth,
+        json={
+            "targets": [{"library_id": library_id, "paper_id": paper_id} for paper_id in paper_ids]
+        },
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["item_count"] == 2
+    assert len(created.json()["items"]) == 2
+    assert {item["status"] for item in created.json()["items"]} == {"queued"}
+    batches = (await client.get("/api/download-batches", headers=auth)).json()
+    batch = next(value for value in batches if value["id"] == created.json()["id"])
+    assert len(batch["items"]) == 2
+    assert {item["status"] for item in batch["items"]} == {"queued"}
+
+
+@pytest.mark.asyncio
+async def test_batch_claim_upload_is_bound_and_idempotent(client, queue_stub):
+    token = await register_and_login(client, email="archive-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("archive-owner@example.com")
+    created = await client.post(
+        "/api/download-batches",
+        headers=auth,
+        json={"targets": [{"library_id": library_id, "paper_id": paper_ids[0]}]},
+    )
+    assert created.status_code == 200
+    api_key = (await client.post("/api/me/download-api-key", headers=auth)).json()["api_key"]
+    key_headers = {"X-Polaris-API-Key": api_key}
+    item = (await client.post("/api/download-client/items/claim", headers=key_headers)).json()
+    data = _pdf_bytes("archive target")
+    cached = await client.post(
+        f"/api/download-client/items/{item['id']}/cache",
+        headers={**key_headers, "X-Polaris-Lease-Token": item["lease_token"]},
+        json={"sha256": hashlib.sha256(data).hexdigest(), "byte_size": len(data)},
+    )
+    assert cached.status_code == 200
+    response = await client.post(
+        f"/api/download-client/items/{item['id']}/pdf",
+        headers={
+            **key_headers,
+            "X-Polaris-Lease-Token": item["lease_token"],
+            "X-Polaris-PDF-SHA256": hashlib.sha256(data).hexdigest(),
+        },
+        files={"pdf": ("paper.pdf", data, "application/pdf")},
+    )
+    assert response.status_code == 201, response.text
+    assert any(job[0] == "parse_paper_content_task" for job in queue_stub.jobs)
+    again = await client.post(
+        f"/api/download-client/items/{item['id']}/pdf",
+        headers={**key_headers, "X-Polaris-Lease-Token": item["lease_token"]},
+        files={"pdf": ("paper.pdf", data, "application/pdf")},
+    )
+    assert again.status_code == 201
+    assert again.json()["asset_id"] == response.json()["asset_id"]
+
+
+@pytest.mark.asyncio
+async def test_cached_target_is_skipped_without_losing_item(client):
+    token = await register_and_login(client, email="cached-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("cached-owner@example.com")
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary
+        from app.models.paper import Paper
+        from app.models.user import User
+        from app.services.paper_assets import create_or_reuse_asset
+
+        user = (
+            await session.execute(select(User).where(User.email == "cached-owner@example.com"))
+        ).scalar_one()
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        paper = await session.get(Paper, uuid.UUID(paper_ids[0]))
+        await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=_pdf_bytes("cached"),
+            user=user,
+            source="manual",
+            identity_key=paper.dedup_key,
+            identity_status="verified",
+        )
+        await session.commit()
+    created = await client.post(
+        "/api/download-batches",
+        headers=auth,
+        json={"targets": [{"library_id": library_id, "paper_id": paper_ids[0]}]},
+    )
+    assert created.status_code == 200
+    assert created.json()["status"] == "completed"
+    batch = next(
+        value
+        for value in (await client.get("/api/download-batches", headers=auth)).json()
+        if value["id"] == created.json()["id"]
+    )
+    assert batch["items"][0]["status"] == "skipped"
+    assert batch["items"][0]["result"]["reason"] == "already_cached"
+
+
+@pytest.mark.asyncio
+async def test_extension_api_key_can_create_batch_and_receives_item_status(client):
+    token = await register_and_login(client, email="extension-batch-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("extension-batch-owner@example.com", papers=2)
+    api_key = (await client.post("/api/me/download-api-key", headers=auth)).json()["api_key"]
+    created = await client.post(
+        "/api/download-batches",
+        headers={"X-Polaris-API-Key": api_key},
+        json={
+            "targets": [
+                {"library_id": library_id, "paper_id": paper_id} for paper_id in paper_ids
+            ]
+        },
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["item_count"] == 2
+    assert [item["paper_id"] for item in created.json()["items"]] == paper_ids
+
+
+@pytest.mark.asyncio
+async def test_direct_archive_rejects_wrong_identity(client, queue_stub):
+    token = await register_and_login(client, email="identity-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("identity-owner@example.com")
+    api_key = (await client.post("/api/me/download-api-key", headers=auth)).json()["api_key"]
+    metadata = {
+        "library_id": library_id,
+        "paper_id": paper_ids[0],
+        "nonce": "identity-test-nonce-001",
+        "doi": "10.5555/wrong",
+        "title": "Batch paper 0",
+    }
+    response = await client.post(
+        "/api/download-client/archive",
+        headers={"X-Polaris-API-Key": api_key},
+        data={"metadata": __import__("json").dumps(metadata)},
+        files={"pdf": ("paper.pdf", _pdf_bytes("wrong"), "application/pdf")},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "DOWNLOAD_ARCHIVE_IDENTITY_MISMATCH"

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
+HEAD_REVISION = "e0f1a2b3c4d5"  # Polaris extension download batches and API keys
+EVIDENCE_ANCHOR_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
 CONTENT_VERSION_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
 PDF_ASSET_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
 LITERATURE_REVISION = "a7c8d9e0f1b2"  # library-scoped literature discovery contracts
@@ -124,6 +125,9 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "paper_content_version_vectors",
                     "paper_content_chunk_vectors",
                     "paper_evidence_anchors",
+                    "download_api_keys",
+                    "download_batches",
+                    "download_batch_items",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -457,7 +461,19 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "locator",
     } <= columns["paper_evidence_anchors"]
 
-    # 先退掉证据锚点迁移，回到解析内容版本。
+    assert {"download_api_keys", "download_batches", "download_batch_items"} <= columns["_tables"]
+
+    # 先退掉下载批次协议迁移，回到证据锚点版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == EVIDENCE_ANCHOR_REVISION
+    assert not {
+        "download_api_keys",
+        "download_batches",
+        "download_batch_items",
+    } & columns["_tables"]
+
+    # 再退掉证据锚点迁移，回到解析内容版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == CONTENT_VERSION_REVISION


### PR DESCRIPTION
Rebase of #467 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 21 files / +3134 to **10 files / +1049**.

## The migration needed re-pointing

`e0f1a2b3c4d5` chained from `d9e0f1a2b3c4`. That was the head when this branch was cut, but the evidence anchors (#493) landed on `d9e0f1a2b3c4` first, so merging this unchanged would have produced exactly the fork I flagged on #472:

```
d9e0f1a2b3c4
 ├── e5f6a7b8c9d0   (evidence anchors)
 └── e0f1a2b3c4d5   (this)
```

Two heads, and `alembic upgrade head` fails. Re-pointed to `e5f6a7b8c9d0`, so the chain stays linear. This is the mechanical part of a rebase that is easy to miss, because nothing in the branch itself is wrong — the head simply moved underneath it.

## Other resolutions

Same as the preceding rebases: duplicate `c8d9e0f1a2b3` dropped in favour of `main`'s, `router.py` and `models/__init__.py` union-resolved so both the `literature_discovery` route and the evidence exports survive, `tests/test_migrations.py` extended from `main`'s copy with a fifth downgrade step.

## Verification

- `alembic heads` → single head `e0f1a2b3c4d5`; round trip walks all five steps back to `8ff89f7fcdeb`
- `tests/test_migrations.py tests/test_download_batch_protocol.py tests/test_evidence_anchors.py tests/test_literature_discovery_api.py` → 13 passed
- `ruff check app/ tests/test_migrations.py` → clean; `import app.main` → ok

Closes #458. Supersedes #467.