### PR TITLE
feat(literature): execute multi-source discovery runtime

### DIFF
--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
+from app.core.queue import TaskQueue, get_task_queue
 from app.models.library_direction import DirectionLibrary
 from app.models.literature_discovery import (
     LiteratureSearchHit,
@@ -104,6 +105,29 @@ async def create_run(
         .all()
     )
     return _detail(run, attempts)
+
+
+@router.post(
+    "/libraries/{library_id}/literature/runs/{run_id}/start",
+    response_model=SearchRunRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def start_run(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    queue: TaskQueue = Depends(get_task_queue),
+    user: User = Depends(current_active_user),
+) -> SearchRunRead:
+    """Queue a persisted run without changing its user-requested count."""
+    library = await _managed_library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library.id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    if run.status != "queued":
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="SEARCH_RUN_NOT_QUEUED")
+    await queue.enqueue("run_literature_discovery", str(run.id))
+    return SearchRunRead.model_validate(run)
 
 
 @router.get("/libraries/{library_id}/literature/runs", response_model=SearchRunPage)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -4,7 +4,7 @@ import logging
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger("polaris.config")
@@ -67,8 +67,56 @@ class Settings(BaseSettings):
     chat_agent_enabled: bool = False
 
     # ---- 文献 API ----
-    s2_api_key: str = ""  # Semantic Scholar（可空，限流更严）
-    openalex_mailto: str = "polaris@example.org"  # OpenAlex polite pool
+    s2_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_S2_API_KEY",
+            "SEMANTIC_SCHOLAR_API_KEY",
+            "PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY",
+        ),
+    )  # Semantic Scholar（可空，限流更严）
+    openalex_mailto: str = Field(
+        default="polaris@example.org",
+        validation_alias=AliasChoices("POLARIS_OPENALEX_MAILTO", "OPENALEX_MAILTO"),
+    )  # OpenAlex polite pool
+    pubmed_email: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_PUBMED_EMAIL", "PUBMED_EMAIL", "PAPER_SEARCH_MCP_UNPAYWALL_EMAIL"
+        ),
+    )
+    pubmed_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_PUBMED_API_KEY", "PUBMED_API_KEY", "PAPER_SEARCH_MCP_PUBMED_API_KEY"
+        ),
+    )
+    crossref_mailto: str = Field(
+        default="",
+        validation_alias=AliasChoices("POLARIS_CROSSREF_MAILTO", "CROSSREF_MAILTO"),
+    )
+    core_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_CORE_API_KEY", "CORE_API_KEY", "PAPER_SEARCH_MCP_CORE_API_KEY"
+        ),
+    )
+    unpaywall_email: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_UNPAYWALL_EMAIL", "UNPAYWALL_EMAIL", "PAPER_SEARCH_MCP_UNPAYWALL_EMAIL"
+        ),
+    )
+    sciverse_base_url: str = Field(
+        default="https://api.sciverse.space",
+        validation_alias=AliasChoices("POLARIS_SCIVERSE_BASE_URL", "SCIVERSE_BASE_URL"),
+    )
+    sciverse_api_tokens: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_SCIVERSE_API_TOKENS", "SCIVERSE_API_TOKENS", "SCIVERSE_API_TOKEN"
+        ),
+    )
 
     # ---- 邮件（密码重置等事务邮件）----
     # smtp_host 为空 = 关闭发信：忘记密码入口在前端自动隐藏（见 /auth/capabilities）。
@@ -92,6 +140,9 @@ class Settings(BaseSettings):
 
     @field_validator(
         "s2_api_key",
+        "pubmed_api_key",
+        "core_api_key",
+        "sciverse_api_tokens",
         "openai_compat_api_key",
         "anthropic_api_key",
         "github_token",
@@ -116,9 +167,7 @@ class Settings(BaseSettings):
         """生产环境结构性禁用 fake provider 回退：即便误设 POLARIS_LLM_FAKE_FALLBACK=1
         也一律钉死为 False，杜绝把演示假内容当成真实 AI 输出发给用户。"""
         if self.env == "prod" and self.llm_fake_fallback:
-            logger.warning(
-                "env=prod：忽略 POLARIS_LLM_FAKE_FALLBACK=1，生产禁止 fake LLM 回退"
-            )
+            logger.warning("env=prod：忽略 POLARIS_LLM_FAKE_FALLBACK=1，生产禁止 fake LLM 回退")
             object.__setattr__(self, "llm_fake_fallback", False)
         return self
 

--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -26,6 +26,7 @@ WORKER_FUNCTIONS = frozenset(
         "daily_feed_sync",
         "daily_wiki_ingest",
         "daily_publication_match",
+        "run_literature_discovery",
     }
 )
 

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -1,0 +1,444 @@
+"""Small async clients for the public providers used by the discovery runtime.
+
+The provider payloads are intentionally normalized here instead of leaking
+source-specific JSON into the worker.  Unpaywall is an OA resolver (DOI
+lookup), so its keyword-search method returns no candidates by design.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from app.core.config import get_settings
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return "; ".join(_text(item) for item in value if _text(item))
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", str(value))).strip()
+
+
+def _first(value: Any) -> str:
+    if isinstance(value, list):
+        return _text(value[0]) if value else ""
+    return _text(value)
+
+
+def _doi(value: Any) -> str | None:
+    value = _text(value)
+    value = re.sub(r"^https?://(?:dx\.)?doi\.org/", "", value, flags=re.I)
+    return value or None
+
+
+def _year(value: Any) -> int | None:
+    match = re.search(r"\b(?:19|20)\d{2}\b", _text(value))
+    return int(match.group(0)) if match else None
+
+
+def _authors(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, str):
+        return [{"name": part.strip()} for part in value.split(",") if part.strip()]
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            name = _text(item.get("name") or item.get("fullName") or item.get("authorName"))
+        else:
+            name = _text(item)
+        if name:
+            result.append({"name": name})
+    return result
+
+
+def _date_window(request: Any) -> tuple[int | None, int | None]:
+    return request.start_year, request.end_year
+
+
+class MultiSourceClient:
+    """HTTP client for the non-core providers in the YFR-compatible source set."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        settings = get_settings()
+        self._client = client or httpx.AsyncClient(
+            proxy=settings.outbound_proxy or None,
+            timeout=30.0,
+            follow_redirects=True,
+            headers={"User-Agent": f"Polaris/1.0 (mailto:{settings.openalex_mailto})"},
+        )
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def search_source(self, source: str, request: Any) -> list[dict[str, Any]]:
+        handlers = {
+            "pubmed": self._search_pubmed,
+            "crossref": self._search_crossref,
+            "europepmc": self._search_europepmc,
+            "hal": self._search_hal,
+            "core": self._search_core,
+            "base": self._search_base,
+            "sciverse": self._search_sciverse,
+        }
+        handler = handlers.get(source.strip().lower())
+        return await handler(request) if handler else []
+
+    async def lookup_unpaywall(self, doi: str) -> dict[str, Any] | None:
+        settings = get_settings()
+        if not settings.unpaywall_email or not doi:
+            return None
+        try:
+            response = await self._client.get(
+                f"https://api.unpaywall.org/v2/{quote(doi, safe='/')}",
+                params={"email": settings.unpaywall_email},
+                timeout=15.0,
+            )
+            if response.status_code >= 400:
+                return None
+            payload = response.json()
+        except (httpx.HTTPError, ValueError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    async def _search_pubmed(self, request: Any) -> list[dict[str, Any]]:
+        settings = get_settings()
+        start, end = _date_window(request)
+        query = request.query
+        if start or end:
+            lo = start or 1800
+            hi = end or datetime.now(UTC).year
+            query = f"({query}) AND ({lo}:{hi}[pdat])"
+        params = {
+            "db": "pubmed",
+            "term": query,
+            "retmode": "json",
+            "retmax": min(request.limit, 1000),
+            "sort": "relevance",
+        }
+        if settings.pubmed_api_key:
+            params["api_key"] = settings.pubmed_api_key
+        if settings.pubmed_email:
+            params["email"] = settings.pubmed_email
+        try:
+            response = await self._client.get(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi", params=params
+            )
+            response.raise_for_status()
+            ids = (response.json().get("esearchresult") or {}).get("idlist") or []
+            if not ids:
+                return []
+            summary_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "json"}
+            if settings.pubmed_api_key:
+                summary_params["api_key"] = settings.pubmed_api_key
+            summary = await self._client.get(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
+                params=summary_params,
+            )
+            summary.raise_for_status()
+            result = summary.json().get("result") or {}
+        except (httpx.HTTPError, ValueError):
+            return []
+        rows: list[dict[str, Any]] = []
+        for pmid in ids:
+            item = result.get(str(pmid))
+            if not isinstance(item, dict) or not item.get("title"):
+                continue
+            article_ids = {
+                str(article.get("idtype")): article.get("value")
+                for article in item.get("articleids") or []
+                if isinstance(article, dict)
+            }
+            rows.append(
+                {
+                    "source": "pubmed",
+                    "pmid": str(pmid),
+                    "title": _text(item.get("title")),
+                    "abstract": None,
+                    "authors": _authors(item.get("authors")),
+                    "year": _year(item.get("pubdate")),
+                    "venue": _text(item.get("fulljournalname") or item.get("source")),
+                    "doi": _doi(article_ids.get("doi")),
+                    "url": f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
+                    "metadata": item,
+                }
+            )
+        return rows
+
+    async def _search_crossref(self, request: Any) -> list[dict[str, Any]]:
+        settings = get_settings()
+        filters = ["type:journal-article"]
+        if request.start_year:
+            filters.append(f"from-pub-date:{request.start_year}-01-01")
+        if request.end_year:
+            filters.append(f"until-pub-date:{request.end_year}-12-31")
+        params = {
+            "query": request.query,
+            "rows": min(request.limit, 1000),
+            "filter": ",".join(filters),
+            "sort": "relevance",
+            "order": "desc",
+        }
+        headers = {"User-Agent": f"Polaris/1.0 (mailto:{settings.crossref_mailto})"}
+        try:
+            response = await self._client.get(
+                "https://api.crossref.org/works", params=params, headers=headers
+            )
+            response.raise_for_status()
+            items = (response.json().get("message") or {}).get("items") or []
+        except (httpx.HTTPError, ValueError):
+            return []
+        return [self._crossref_item(item) for item in items if isinstance(item, dict)]
+
+    async def _search_europepmc(self, request: Any) -> list[dict[str, Any]]:
+        start, end = _date_window(request)
+        lo, hi = start or 1800, end or datetime.now(UTC).year
+        params = {
+            "query": f"({request.query}) AND FIRST_PDATE:[{lo}-01-01 TO {hi}-12-31]",
+            "format": "json",
+            "resultType": "core",
+            "pageSize": min(request.limit, 100),
+            "sort": "CITED desc",
+        }
+        try:
+            response = await self._client.get(
+                "https://www.ebi.ac.uk/europepmc/webservices/rest/search", params=params
+            )
+            response.raise_for_status()
+            items = (response.json().get("resultList") or {}).get("result") or []
+        except (httpx.HTTPError, ValueError):
+            return []
+        return [self._europepmc_item(item) for item in items if isinstance(item, dict)]
+
+    async def _search_hal(self, request: Any) -> list[dict[str, Any]]:
+        start, end = _date_window(request)
+        lo, hi = start or 1800, end or datetime.now(UTC).year
+        params = {
+            "q": f"({request.query}) AND producedDateY_i:[{lo} TO {hi}]",
+            "rows": min(request.limit, 100),
+            "sort": "score desc",
+            "fl": (
+                "docid,title_s,authFullName_s,abstract_s,doiId_s,producedDateY_i,"
+                "producedDate_s,journalTitle_s,uri_s,fileMain_s,fileAnnexes_s"
+            ),
+            "wt": "json",
+        }
+        try:
+            response = await self._client.get(
+                "https://api.archives-ouvertes.fr/search/", params=params
+            )
+            response.raise_for_status()
+            items = (response.json().get("response") or {}).get("docs") or []
+        except (httpx.HTTPError, ValueError):
+            return []
+        return [self._hal_item(item) for item in items if isinstance(item, dict)]
+
+    async def _search_core(self, request: Any) -> list[dict[str, Any]]:
+        settings = get_settings()
+        if not settings.core_api_key:
+            return []
+        params = {
+            "q": f"{request.query} yearPublished>={request.start_year or 1800}",
+            "limit": min(request.limit, 100),
+        }
+        try:
+            response = await self._client.post(
+                "https://api.core.ac.uk/v3/search/works",
+                json=params,
+                headers={"Authorization": f"Bearer {settings.core_api_key}"},
+            )
+            response.raise_for_status()
+            items = response.json().get("results") or []
+        except (httpx.HTTPError, ValueError):
+            return []
+        return [self._core_item(item) for item in items if isinstance(item, dict)]
+
+    async def _search_base(self, request: Any) -> list[dict[str, Any]]:
+        start, end = _date_window(request)
+        params = {
+            "func": "PerformSearch",
+            "query": f"{request.query} year:{start or 1800}-{end or datetime.now(UTC).year}",
+            "format": "json",
+            "hits": min(request.limit, 100),
+        }
+        try:
+            response = await self._client.get(
+                "https://api.base-search.net/cgi-bin/BaseHttpSearchInterface.fcgi",
+                params=params,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            items = (payload.get("response") or {}).get("docs") or payload.get("docs") or []
+        except (httpx.HTTPError, ValueError):
+            return []
+        return [self._base_item(item) for item in items if isinstance(item, dict)]
+
+    async def _search_sciverse(self, request: Any) -> list[dict[str, Any]]:
+        settings = get_settings()
+        token = next(
+            (
+                item.strip()
+                for item in re.split(r"[,;\s]+", settings.sciverse_api_tokens)
+                if item.strip()
+            ),
+            "",
+        )
+        if not token:
+            return []
+        try:
+            response = await self._client.post(
+                f"{settings.sciverse_base_url.rstrip('/')}/meta-search",
+                json={
+                    "query": request.query,
+                    "page_size": min(request.limit, 100),
+                    "collection": "papers",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError):
+            return []
+        items = payload.get("results") or payload.get("items") or payload.get("data") or []
+        return [self._sciverse_item(item) for item in items if isinstance(item, dict)]
+
+    @staticmethod
+    def _crossref_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        date_parts = (
+            item.get("published-print") or item.get("published-online") or item.get("issued") or {}
+        ).get("date-parts") or []
+        year = date_parts[0][0] if date_parts and date_parts[0] else _year(item.get("created"))
+        authors = []
+        for author in item.get("author") or []:
+            name = _text(
+                author.get("name")
+                or " ".join(filter(None, [author.get("given"), author.get("family")]))
+            )
+            if name:
+                authors.append({"name": name})
+        pdf_url = next(
+            (
+                _text(link.get("URL"))
+                for link in item.get("link") or []
+                if isinstance(link, dict) and "pdf" in _text(link.get("content-type")).lower()
+            ),
+            None,
+        )
+        return {
+            "source": "crossref",
+            "title": _first(item.get("title")),
+            "abstract": _text(item.get("abstract")),
+            "authors": authors,
+            "year": year,
+            "venue": _first(item.get("container-title")),
+            "doi": _doi(item.get("DOI")),
+            "url": item.get("URL"),
+            "pdf_url": pdf_url,
+            "oa_status": "oa" if pdf_url else None,
+            "citation_count": item.get("is-referenced-by-count"),
+            "metadata": dict(item),
+        }
+
+    @staticmethod
+    def _europepmc_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        links = (item.get("fullTextUrlList") or {}).get("fullTextUrl") or []
+        pdf = next(
+            (
+                _text(link.get("url"))
+                for link in links
+                if isinstance(link, dict) and _text(link.get("documentStyle")).lower() == "pdf"
+            ),
+            None,
+        )
+        return {
+            "source": "europepmc",
+            "title": _text(item.get("title")),
+            "abstract": _text(item.get("abstractText")),
+            "authors": _authors(item.get("authorString")),
+            "year": _year(item.get("firstPublicationDate") or item.get("pubYear")),
+            "venue": _text(item.get("journalTitle")),
+            "doi": _doi(item.get("doi")),
+            "pmid": _text(item.get("pmid")) or None,
+            "url": f"https://europepmc.org/article/{item.get('source')}/{item.get('id')}",
+            "pdf_url": pdf,
+            "oa_status": "oa" if pdf else None,
+            "citation_count": item.get("citedByCount"),
+            "metadata": dict(item),
+        }
+
+    @staticmethod
+    def _hal_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        pdf = _first(item.get("fileMain_s") or item.get("fileAnnexes_s")) or None
+        return {
+            "source": "hal",
+            "title": _first(item.get("title_s")),
+            "abstract": _first(item.get("abstract_s")),
+            "authors": _authors(item.get("authFullName_s")),
+            "year": item.get("producedDateY_i"),
+            "venue": _text(item.get("journalTitle_s")),
+            "doi": _doi(item.get("doiId_s")),
+            "url": _text(item.get("uri_s")) or None,
+            "pdf_url": pdf,
+            "oa_status": "oa" if pdf else None,
+            "metadata": dict(item),
+        }
+
+    @staticmethod
+    def _core_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        pdf = _text(item.get("downloadUrl")) or None
+        return {
+            "source": "core",
+            "title": _text(item.get("title")),
+            "abstract": _text(item.get("abstract")),
+            "authors": _authors(item.get("authors")),
+            "year": item.get("yearPublished") or _year(item.get("publishedDate")),
+            "venue": _text(item.get("publisher") or item.get("journals")),
+            "doi": _doi(item.get("doi")),
+            "url": _text(item.get("sourceFulltextUrls")) or None,
+            "pdf_url": pdf,
+            "oa_status": "oa" if pdf else None,
+            "citation_count": item.get("citationCount"),
+            "metadata": dict(item),
+        }
+
+    @staticmethod
+    def _base_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        url = _first(item.get("dclink") or item.get("dcidentifier")) or None
+        return {
+            "source": "base",
+            "title": _first(item.get("dctitle")),
+            "abstract": _first(item.get("dcdescription")),
+            "authors": _authors(item.get("dccreator")),
+            "year": _year(item.get("dcyear") or item.get("dcdate")),
+            "venue": _first(item.get("dcsource") or item.get("dcpublisher")),
+            "doi": _doi(_first(item.get("dcdoi") or item.get("doi"))),
+            "url": url,
+            "metadata": dict(item),
+        }
+
+    @staticmethod
+    def _sciverse_item(item: Mapping[str, Any]) -> dict[str, Any]:
+        pdf = _text(item.get("pdf_url") or item.get("access_oa_url")) or None
+        return {
+            "source": "sciverse",
+            "title": _text(item.get("title") or item.get("display_name")),
+            "abstract": _text(item.get("abstract")),
+            "authors": _authors(item.get("authors") or item.get("author")),
+            "year": item.get("year") or item.get("publication_published_year"),
+            "venue": _text(item.get("venue") or item.get("publication_venue_name_unified")),
+            "doi": _doi(item.get("doi")),
+            "url": _text(item.get("url") or item.get("access_oa_url")) or None,
+            "pdf_url": pdf,
+            "oa_status": "oa" if pdf else None,
+            "citation_count": item.get("citation_count"),
+            "metadata": dict(item),
+        }

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -16,9 +16,22 @@ ARXIV_DOI_TEMPLATE = "10.48550/arXiv.{arxiv_id}"
 
 def _simplify(work: dict[str, Any]) -> dict[str, Any]:
     primary_location = work.get("primary_location") or {}
+    inverted = work.get("abstract_inverted_index")
+    abstract = None
+    if isinstance(inverted, dict):
+        tokens = [
+            (int(position), str(token))
+            for token, positions in inverted.items()
+            if isinstance(positions, list)
+            for position in positions
+            if isinstance(position, int)
+        ]
+        if tokens:
+            abstract = " ".join(token for _, token in sorted(tokens))
     return {
         "openalex_id": work.get("id"),
         "title": work.get("title"),
+        "abstract": abstract,
         "doi": (work.get("doi") or "").removeprefix("https://doi.org/") or None,
         "url": (
             primary_location.get("landing_page_url") if isinstance(primary_location, dict) else None
@@ -99,9 +112,24 @@ class OpenAlexClient:
         """按 arxiv id 反查（经 DataCite DOI 10.48550/arXiv.<id>）。"""
         return await self.get_by_doi(ARXIV_DOI_TEMPLATE.format(arxiv_id=arxiv_id))
 
-    async def search_works(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
+    async def search_works(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        start_year: int | None = None,
+        end_year: int | None = None,
+    ) -> list[dict[str, Any]]:
         """按标题/关键词全文检索 works（M5-C 引用核验的 S2 降级通道）。"""
-        data = await self._get("/works", {"search": query, "per-page": limit})
+        params: dict[str, Any] = {"search": query, "per-page": limit}
+        filters: list[str] = []
+        if start_year is not None:
+            filters.append(f"from_publication_date:{start_year}-01-01")
+        if end_year is not None:
+            filters.append(f"to_publication_date:{end_year}-12-31")
+        if filters:
+            params["filter"] = ",".join(filters)
+        data = await self._get("/works", params)
         results = (data or {}).get("results") or []
         return [_simplify(w) for w in results if isinstance(w, dict)]
 

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -1,0 +1,448 @@
+"""Execute persisted library-scoped discovery runs through source adapters.
+
+The runtime keeps provider I/O, normalization, ranking, and persistence in
+separate steps. Unpromoted hits never create a Paper or a PDF processing job.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.literature_discovery import (
+    LiteratureSearchHit,
+    LiteratureSearchRun,
+    LiteratureSourceAttempt,
+)
+from app.schemas.literature_discovery import (
+    LiteratureCandidate,
+    SourceAdapter,
+    SourceSearchPage,
+    SourceSearchRequest,
+)
+from app.services.literature import discovery_runs
+from app.services.literature.discovery import candidate_dedup_key, validate_candidate
+from app.services.literature.discovery_ranking import rank_candidates
+from app.services.literature.multi_source import MultiSourceClient
+
+logger = logging.getLogger(__name__)
+_DEFAULT_REGISTRY: AdapterRegistry | None = None
+
+
+class SourceExecutionError(RuntimeError):
+    """A provider failure with a persisted, user-readable category."""
+
+    def __init__(self, code: str, detail: str, *, retryable: bool = False) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.retryable = retryable
+
+
+class AdapterRegistry:
+    """Small dependency-injection registry used by workers and tests."""
+
+    def __init__(self, adapters: Sequence[SourceAdapter] = ()) -> None:
+        self._adapters = {adapter.name.strip().lower(): adapter for adapter in adapters}
+
+    def get(self, source: str) -> SourceAdapter | None:
+        return self._adapters.get(source.strip().lower())
+
+    def names(self) -> set[str]:
+        return set(self._adapters)
+
+
+class OpenAlexAdapter:
+    name = "openalex"
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_works(
+            request.query,
+            limit=request.limit,
+            start_year=request.start_year,
+            end_year=request.end_year,
+        )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_openalex(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+
+class SemanticScholarAdapter:
+    name = "semantic"
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_papers(
+            request.query,
+            limit=request.limit,
+            start_year=request.start_year,
+            end_year=request.end_year,
+        )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_semantic(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+
+class ArxivAdapter:
+    name = "arxiv"
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        since = datetime(request.start_year, 1, 1, tzinfo=UTC) if request.start_year else None
+        until = datetime(request.end_year, 12, 31, 23, 59, tzinfo=UTC) if request.end_year else None
+        rows = await self.client.search(
+            keywords=[request.query], since=since, until=until, limit=request.limit
+        )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_arxiv(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+
+class MultiSourceAdapter:
+    """Adapter for providers that share the normalized YFR-compatible client."""
+
+    def __init__(self, name: str, client: MultiSourceClient) -> None:
+        self.name = name
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_source(self.name, request)
+        return SourceSearchPage(
+            source=self.name,
+            items=[validate_candidate(_candidate_from_generic(self.name, row)) for row in rows],
+            fetched_count=len(rows),
+        )
+
+
+def _candidate_from_openalex(row: Mapping[str, Any]) -> LiteratureCandidate:
+    return validate_candidate(
+        LiteratureCandidate(
+            source="openalex",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=row.get("authors") or [],
+            year=row.get("year"),
+            venue=row.get("venue"),
+            doi=row.get("doi"),
+            url=row.get("url"),
+            citation_count=row.get("cited_by_count"),
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_semantic(row: Mapping[str, Any]) -> LiteratureCandidate:
+    external = row.get("externalIds") or {}
+    return validate_candidate(
+        LiteratureCandidate(
+            source="semantic",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=[a for a in row.get("authors") or [] if isinstance(a, Mapping)],
+            year=row.get("year"),
+            venue=row.get("venue"),
+            doi=external.get("DOI"),
+            arxiv_id=external.get("ArXiv"),
+            semantic_scholar_id=row.get("paperId"),
+            url=row.get("url"),
+            citation_count=row.get("citationCount"),
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_arxiv(row: Mapping[str, Any]) -> LiteratureCandidate:
+    return validate_candidate(
+        LiteratureCandidate(
+            source="arxiv",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=row.get("authors") or [],
+            year=row.get("year"),
+            doi=row.get("doi"),
+            arxiv_id=row.get("arxiv_id"),
+            url=row.get("url"),
+            pdf_url=row.get("pdf_url"),
+            oa_status="oa" if row.get("pdf_url") else None,
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_generic(source: str, row: Mapping[str, Any]) -> LiteratureCandidate:
+    return LiteratureCandidate(
+        source=source,
+        title=str(row.get("title") or "Untitled"),
+        abstract=row.get("abstract"),
+        authors=row.get("authors") or [],
+        year=row.get("year"),
+        venue=row.get("venue"),
+        doi=row.get("doi"),
+        pmid=row.get("pmid"),
+        url=row.get("url"),
+        pdf_url=row.get("pdf_url"),
+        oa_status=row.get("oa_status"),
+        citation_count=row.get("citation_count"),
+        metadata=dict(row.get("metadata") or row),
+    )
+
+
+def _config_values(run: LiteratureSearchRun) -> tuple[list[str], list[str], dict[str, float]]:
+    config = run.source_config if isinstance(run.source_config, dict) else {}
+    sources = discovery_runs.enabled_sources(run.source_config, run.query_plan)
+    keywords = [str(v) for v in config.get("keywords") or [] if str(v).strip()]
+    weights = config.get("score_weights")
+    return sources, keywords, weights if isinstance(weights, dict) else {}
+
+
+def _planned_query(run: LiteratureSearchRun, source: str, keywords: Sequence[str]) -> str:
+    plan = run.query_plan if isinstance(run.query_plan, dict) else {}
+    queries = plan.get("queries")
+    if isinstance(queries, list):
+        for item in queries:
+            if isinstance(item, dict) and str(item.get("source", "")).lower() == source:
+                query = str(item.get("query") or "").strip()
+                if query:
+                    return query
+    return str(plan.get("query") or run.topic or (keywords[0] if keywords else "")).strip()
+
+
+async def _default_registry() -> AdapterRegistry:
+    global _DEFAULT_REGISTRY
+    if _DEFAULT_REGISTRY is not None:
+        return _DEFAULT_REGISTRY
+    from app.services.literature.arxiv import ArxivClient
+    from app.services.literature.openalex import OpenAlexClient
+    from app.services.literature.semantic_scholar import SemanticScholarClient
+
+    multi_source = MultiSourceClient()
+    _DEFAULT_REGISTRY = AdapterRegistry(
+        (
+            OpenAlexAdapter(OpenAlexClient()),
+            SemanticScholarAdapter(SemanticScholarClient()),
+            ArxivAdapter(ArxivClient()),
+            *(
+                MultiSourceAdapter(source, multi_source)
+                for source in (
+                    "pubmed",
+                    "crossref",
+                    "europepmc",
+                    "hal",
+                    "core",
+                    "base",
+                    "sciverse",
+                    "unpaywall",
+                )
+            ),
+        )
+    )
+    return _DEFAULT_REGISTRY
+
+
+async def run_discovery(
+    session: AsyncSession,
+    run_id: uuid.UUID,
+    *,
+    registry: AdapterRegistry | None = None,
+    now: datetime | None = None,
+) -> LiteratureSearchRun:
+    """Execute one persisted run and return its final state."""
+
+    run = await session.get(LiteratureSearchRun, run_id)
+    if run is None:
+        raise ValueError(f"search run not found: {run_id}")
+    if run.status == "cancelled":
+        return run
+
+    registry = registry or await _default_registry()
+    started = now or datetime.now(UTC)
+    run.status = "running"
+    run.started_at = run.started_at or started
+    run.progress = {**(run.progress or {}), "phase": "retrieving", "fetched": 0, "accepted": 0}
+    await session.commit()
+
+    sources, keywords, weights = _config_values(run)
+    if not sources:
+        run.status = "failed"
+        run.error_summary = "NO_SOURCES_CONFIGURED"
+        run.completed_at = started
+        run.progress = {
+            **(run.progress or {}),
+            "phase": "failed",
+            "source": None,
+            "fetched": 0,
+            "accepted": 0,
+            "requested_count": run.requested_count,
+            "candidate_budget": run.candidate_budget,
+            "returned_count": 0,
+        }
+        await session.commit()
+        await session.refresh(run)
+        return run
+    attempts = list(
+        (
+            await session.execute(
+                select(LiteratureSourceAttempt).where(LiteratureSourceAttempt.run_id == run.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    attempt_by_source = {attempt.source.lower(): attempt for attempt in attempts}
+    candidates: list[LiteratureCandidate] = []
+    failures: list[str] = []
+    fetched_total = 0
+
+    for source in sources:
+        attempt = attempt_by_source.get(source)
+        if attempt is None:
+            attempt = LiteratureSourceAttempt(run_id=run.id, source=source)
+            session.add(attempt)
+        adapter = registry.get(source)
+        if adapter is None:
+            attempt.status = "skipped"
+            attempt.error_code = "SOURCE_NOT_CONFIGURED"
+            attempt.error_detail = "No adapter is configured for this source"
+            failures.append(f"{source}: SOURCE_NOT_CONFIGURED")
+            run.progress = {
+                **(run.progress or {}),
+                "phase": "retrieving",
+                "source": source,
+                "fetched": fetched_total,
+                "accepted": len(candidates),
+                "requested_count": run.requested_count,
+                "candidate_budget": run.candidate_budget,
+            }
+            await session.commit()
+            continue
+
+        query = _planned_query(run, source, keywords)
+        attempt.status = "running"
+        attempt.query = query
+        attempt.requested_count = run.candidate_budget
+        attempt.started_at = datetime.now(UTC)
+        await session.commit()
+        try:
+            page = await adapter.search(
+                SourceSearchRequest(
+                    query=query,
+                    start_year=run.start_year,
+                    end_year=run.end_year,
+                    limit=run.candidate_budget,
+                )
+            )
+            validated = [validate_candidate(item) for item in page.items]
+            candidates.extend(validated)
+            fetched_total += page.fetched_count
+            attempt.fetched_count = page.fetched_count
+            attempt.accepted_count = len(validated)
+            attempt.cursor = page.next_cursor
+            attempt.status = "completed"
+            attempt.completed_at = datetime.now(UTC)
+        except Exception as exc:  # noqa: BLE001 - provider isolation is intentional
+            logger.warning("literature source failed: %s", source, exc_info=True)
+            error = (
+                exc
+                if isinstance(exc, SourceExecutionError)
+                else SourceExecutionError("SOURCE_REQUEST_FAILED", str(exc), retryable=True)
+            )
+            attempt.status = "partial" if candidates else "failed"
+            attempt.retryable = error.retryable
+            attempt.error_code = error.code
+            attempt.error_detail = str(error)
+            attempt.completed_at = datetime.now(UTC)
+            failures.append(f"{source}: {error.code}")
+        run.progress = {
+            **(run.progress or {}),
+            "phase": "retrieving",
+            "source": source,
+            "fetched": fetched_total,
+            "accepted": len(candidates),
+            "requested_count": run.requested_count,
+            "candidate_budget": run.candidate_budget,
+        }
+        await session.commit()
+
+    ranked = rank_candidates(
+        [candidate.model_dump() for candidate in candidates],
+        topic=run.topic,
+        keywords=keywords,
+        excluded_keywords=(run.source_config or {}).get("excluded_keywords", [])
+        if isinstance(run.source_config, dict)
+        else (),
+        weights=weights,
+        current_year=(now or datetime.now(UTC)).year,
+        limit=run.requested_count,
+    )
+    for item in ranked:
+        # ``sources`` and ``retrieval_hits`` are ranking metadata, not part of the
+        # strict candidate DTO. Read them from the ranked mapping before validation
+        # so cross-source provenance survives persistence.
+        raw_candidate = item.candidate
+        candidate = validate_candidate(LiteratureCandidate.model_validate(raw_candidate))
+        session.add(
+            LiteratureSearchHit(
+                run_id=run.id,
+                status="candidate",
+                source=candidate.source,
+                dedup_key=item.identity or candidate_dedup_key(candidate),
+                title=candidate.title,
+                abstract=candidate.abstract,
+                authors=candidate.authors,
+                year=candidate.year,
+                venue=candidate.venue,
+                doi=candidate.doi,
+                pmid=candidate.pmid,
+                arxiv_id=candidate.arxiv_id,
+                semantic_scholar_id=candidate.semantic_scholar_id,
+                url=candidate.url,
+                pdf_url=candidate.pdf_url,
+                oa_status=candidate.oa_status,
+                citation_count=candidate.citation_count,
+                scores={
+                    **item.dimensions,
+                    "overall": item.score,
+                    "tier": item.tier,
+                    "reasons": list(item.reasons),
+                },
+                metadata_snapshot={
+                    **(candidate.metadata or {}),
+                    "sources": list(raw_candidate.get("sources") or [candidate.source]),
+                    "retrieval_hits": list(raw_candidate.get("retrieval_hits") or []),
+                },
+            )
+        )
+
+    run.status = "partial" if failures and ranked else "failed" if failures else "completed"
+    run.error_summary = "; ".join(failures) if failures else None
+    run.completed_at = datetime.now(UTC)
+    run.progress = {
+        **(run.progress or {}),
+        "phase": "completed" if run.status != "failed" else "failed",
+        "fetched": fetched_total,
+        "accepted": len(ranked),
+        "requested_count": run.requested_count,
+        "candidate_budget": run.candidate_budget,
+        "returned_count": len(ranked),
+    }
+    await session.commit()
+    await session.refresh(run)
+    return run

--- a/src/backend/app/services/literature/semantic_scholar.py
+++ b/src/backend/app/services/literature/semantic_scholar.py
@@ -82,10 +82,21 @@ class SemanticScholarClient:
         return [row["citedPaper"] for row in data.get("data", []) if row.get("citedPaper")]
 
     async def search_papers(
-        self, query: str, *, limit: int = 10, fields: str = LINK_FIELDS
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        fields: str = LINK_FIELDS,
+        start_year: int | None = None,
+        end_year: int | None = None,
     ) -> list[dict[str, Any]]:
         """按题目/关键词全文检索（Related Work 候选集，docs/api-m5-b.md §5）。"""
-        data = await self._get("/paper/search", {"query": query, "fields": fields, "limit": limit})
+        params: dict[str, Any] = {"query": query, "fields": fields, "limit": limit}
+        if start_year is not None or end_year is not None:
+            lo = start_year or end_year
+            hi = end_year or start_year
+            params["year"] = f"{lo}-{hi}" if lo != hi else str(lo)
+        data = await self._get("/paper/search", params)
         return [row for row in data.get("data", []) if isinstance(row, dict)]
 
     async def get_citations(

--- a/src/backend/tests/test_literature_config_aliases.py
+++ b/src/backend/tests/test_literature_config_aliases.py
@@ -1,0 +1,15 @@
+"""YFR-compatible environment aliases for literature providers."""
+
+from app.core.config import Settings
+
+
+def test_semantic_scholar_and_openalex_aliases(monkeypatch):
+    monkeypatch.delenv("POLARIS_S2_API_KEY", raising=False)
+    monkeypatch.delenv("POLARIS_OPENALEX_MAILTO", raising=False)
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "s2-legacy-key")
+    monkeypatch.setenv("OPENALEX_MAILTO", "research@example.org")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.s2_api_key == "s2-legacy-key"
+    assert settings.openalex_mailto == "research@example.org"

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -1,0 +1,264 @@
+"""Issue #473: execute source adapters and persist ranked candidates."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.literature_discovery import (
+    LiteratureSearchHit,
+    LiteratureSourceAttempt,
+)
+from app.models.paper import Paper
+from app.schemas.literature_discovery import LiteratureCandidate, SourceSearchPage
+from app.services.literature.multi_source import MultiSourceClient
+from app.services.literature.openalex import _simplify
+from app.services.literature.runtime import (
+    AdapterRegistry,
+    MultiSourceAdapter,
+    OpenAlexAdapter,
+    SemanticScholarAdapter,
+    _candidate_from_openalex,
+    run_discovery,
+)
+from tests.conftest import register_and_login
+
+
+class FakeAdapter:
+    def __init__(
+        self,
+        name: str,
+        items: list[LiteratureCandidate],
+        *,
+        error: Exception | None = None,
+    ):
+        self.name = name
+        self.items = items
+        self.error = error
+        self.requests = []
+
+    async def search(self, request):
+        self.requests.append(request)
+        if self.error:
+            raise self.error
+        return SourceSearchPage(source=self.name, items=self.items, fetched_count=len(self.items))
+
+
+def _candidate(source: str, title: str, *, doi: str | None = None, year: int = 2024):
+    return LiteratureCandidate(
+        source=source,
+        title=title,
+        abstract=f"Abstract for {title}",
+        authors=[{"name": "A. Author"}],
+        year=year,
+        venue="Journal of Tests",
+        doi=doi,
+        url=f"https://example.test/{source}",
+    )
+
+
+async def _create_run(client, *, source_config, requested_count=2, candidate_budget=5):
+    token = await register_and_login(client, email=f"runtime-{uuid.uuid4().hex}@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    library = await client.post(
+        "/api/libraries",
+        json={"name": "Runtime library", "statement": "Runtime test"},
+        headers=headers,
+    )
+    assert library.status_code == 201, library.text
+    response = await client.post(
+        f"/api/libraries/{library.json()['id']}/literature/runs",
+        json={
+            "requested_count": requested_count,
+            "candidate_budget": candidate_budget,
+            "start_year": 2016,
+            "end_year": 2025,
+            "topic": "structural impact response",
+            "source_config": source_config,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return uuid.UUID(response.json()["id"]), headers, response.json()["library_id"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_deduplicates_isolates_failures_and_persists_progress(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex", "semantic", "arxiv", "crossref", "core"]},
+        requested_count=2,
+        candidate_budget=5,
+    )
+    duplicate_doi = "10.1234/shared"
+    openalex = FakeAdapter(
+        "openalex",
+        [
+            _candidate("openalex", "Shared impact study", doi=duplicate_doi),
+            _candidate("openalex", "Unique study", year=2023),
+        ],
+    )
+    semantic = FakeAdapter(
+        "semantic",
+        [_candidate("semantic", "Shared impact study", doi=duplicate_doi, year=2022)],
+    )
+    arxiv = FakeAdapter("arxiv", [_candidate("arxiv", "Exploratory arXiv study", year=2025)])
+    core = FakeAdapter("core", [], error=RuntimeError("core unavailable"))
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(
+            session,
+            run_id,
+                registry=AdapterRegistry((openalex, semantic, arxiv, core)),
+            now=datetime(2026, 8, 26, tzinfo=UTC),
+        )
+        assert run.status == "partial"
+        assert run.progress == {
+            "phase": "completed",
+            "source": "core",
+            "fetched": 4,
+            "accepted": 2,
+            "requested_count": 2,
+            "candidate_budget": 5,
+            "returned_count": 2,
+        }
+        attempts = list(
+            (
+                await session.execute(
+                    select(LiteratureSourceAttempt).where(LiteratureSourceAttempt.run_id == run_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {item.source: item.status for item in attempts} == {
+            "openalex": "completed",
+            "semantic": "completed",
+            "arxiv": "completed",
+            "crossref": "skipped",
+            "core": "partial",
+        }
+        hits = list(
+            (
+                await session.execute(
+                    select(LiteratureSearchHit).where(LiteratureSearchHit.run_id == run_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(hits) == 2
+        shared = next(hit for hit in hits if hit.doi == duplicate_doi)
+        assert shared.metadata_snapshot["sources"] == ["openalex", "semantic"]
+        assert await session.scalar(select(func.count()).select_from(Paper)) == 0
+
+    assert [request.start_year for request in openalex.requests] == [2016]
+    assert [request.end_year for request in arxiv.requests] == [2025]
+    assert [request.limit for request in semantic.requests] == [5]
+
+
+@pytest.mark.asyncio
+async def test_runtime_marks_missing_sources_as_failed(client):
+    run_id, _, _ = await _create_run(client, source_config={})
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(session, run_id, registry=AdapterRegistry())
+        assert run.status == "failed"
+        assert run.error_summary == "NO_SOURCES_CONFIGURED"
+        assert run.progress["requested_count"] == run.requested_count
+        assert run.progress["candidate_budget"] == run.candidate_budget
+        assert run.progress["returned_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_start_endpoint_enqueues_without_overwriting_requested_count(client, queue_stub):
+    run_id, headers, library_id = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=7,
+        candidate_budget=80,
+    )
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}/start",
+        headers=headers,
+    )
+    assert response.status_code == 202, response.text
+    assert response.json()["requested_count"] == 7
+    assert queue_stub.jobs == [("run_literature_discovery", (str(run_id),), {})]
+
+
+@pytest.mark.asyncio
+async def test_provider_adapters_forward_year_window_and_restore_openalex_abstract():
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        async def search_works(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return []
+
+        async def search_papers(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return []
+
+    request = type(
+        "Request",
+        (),
+        {"query": "impact response", "limit": 12, "start_year": 2016, "end_year": 2020},
+    )()
+    openalex_client = Client()
+    semantic_client = Client()
+    await OpenAlexAdapter(openalex_client).search(request)
+    await SemanticScholarAdapter(semantic_client).search(request)
+    assert openalex_client.calls[0][1] == {
+        "limit": 12,
+        "start_year": 2016,
+        "end_year": 2020,
+    }
+    assert semantic_client.calls[0][1] == {
+        "limit": 12,
+        "start_year": 2016,
+        "end_year": 2020,
+    }
+
+    candidate = _candidate_from_openalex(
+        _simplify(
+        {
+            "title": "Indexed abstract",
+            "abstract_inverted_index": {"impact": [1], "Dynamic": [0], "response": [2]},
+        }
+        )
+    )
+    assert candidate.abstract == "Dynamic impact response"
+
+
+@pytest.mark.asyncio
+async def test_extended_sources_share_candidate_contract_and_keep_unpaywall_as_resolver():
+    class Client:
+        async def search_source(self, source, request):
+            assert source == "crossref"
+            assert request.start_year == 2016
+            return [
+                {
+                    "title": "Crossref result",
+                    "abstract": "An abstract",
+                    "authors": [{"name": "Author"}],
+                    "year": 2020,
+                    "venue": "Journal",
+                    "doi": "10.1000/example",
+                    "metadata": {"source_id": "cr-1"},
+                }
+            ]
+
+    request = type(
+        "Request",
+        (),
+        {"query": "topic", "limit": 10, "start_year": 2016, "end_year": 2025},
+    )()
+    page = await MultiSourceAdapter("crossref", Client()).search(request)
+    assert page.fetched_count == 1
+    assert page.items[0].source == "crossref"
+    assert page.items[0].doi == "10.1000/example"
+    assert page.items[0].metadata == {"source_id": "cr-1"}
+    assert await MultiSourceClient(client=Client()).search_source("unpaywall", request) == []

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -16,6 +16,7 @@ from worker.tasks import (
     reconcile_stale_voyages,
     reconcile_stuck_voyages,
     resume_voyage,
+    run_literature_discovery,
     run_voyage,
     watch_unanswered_managed_commands,
 )
@@ -38,6 +39,7 @@ class WorkerSettings:
         # 事件驱动后忘了加到这里，于是每次入队都被 arq 丢掉（#216）。
         daily_wiki_ingest,
         daily_publication_match,
+        func(run_literature_discovery, timeout=3600),
     ]
     # 抓取时刻可由管理员配置（SystemSetting daily_feed_sync_time，默认 UTC 02:30 =
     # 北京 10:30；arXiv 约北京 10:00 放新公告）。arq 的 cron 时刻在 worker 启动时就固定

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -377,3 +377,16 @@ async def daily_publication_match(ctx: dict[str, Any]) -> int:
         async with get_sessionmaker()() as session:
             total += await publications_service.match_from_library(session, user_id=uid)
     return total
+
+
+async def run_literature_discovery(ctx: dict[str, Any], run_id: str) -> dict[str, Any]:
+    """Execute one persisted library literature-discovery run."""
+    from app.services.literature.runtime import run_discovery
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(session, uuid.UUID(run_id))
+        return {
+            "run_id": str(run.id),
+            "status": run.status,
+            "returned_count": (run.progress or {}).get("returned_count", 0),
+        }


### PR DESCRIPTION
Rebase of #474 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 23 files / +3014 to **11 files / +1309**. No new migration, so the chain is untouched at `e0f1a2b3c4d5`.

## The resolution that mattered

`worker/settings.py` and `worker/tasks.py`. The branch **replaces** `parse_paper_content_task` with `run_literature_discovery` instead of adding alongside it:

```diff
-    parse_paper_content_task,
+    run_literature_discovery,
-        parse_paper_content_task,
+        func(run_literature_discovery, timeout=3600),
```

arq silently discards a job enqueued for a function it has no registration for — that is #216, and it is why this repo has a `WORKER_FUNCTIONS` consistency guard at all. Taking the branch's side would have left every content-parse job from #492 disappearing into nothing, with no error in the worker, no error in the API, and no failed test. Union-resolved, and the guard in `worker/settings.py` confirms both functions are registered against `app.core.queue.WORKER_FUNCTIONS`.

`models/__init__.py` had likewise dropped the exports from #490, #492, #493 and #494; rebuilt from `main`'s copy plus this branch's addition.

## Verification

- `alembic heads` → single head `e0f1a2b3c4d5` (unchanged; no migration here)
- `import worker.settings` → the WORKER_FUNCTIONS / WorkerSettings.functions cross-check passes
- `tests/test_literature_discovery_runtime.py tests/test_literature_config_aliases.py tests/test_literature_discovery_api.py tests/test_migrations.py tests/test_paper_content.py tests/test_download_batch_protocol.py` → 18 passed
- `ruff check app/ worker/` → clean; `import app.main` → ok

Closes #473. Supersedes #474.