### PR TITLE
feat(literature): cache OA PDFs and promote selected hits

### DIFF
--- a/src/backend/alembic/versions/d1e2f3a4b5c6_literature_oa_cache.py
+++ b/src/backend/alembic/versions/d1e2f3a4b5c6_literature_oa_cache.py
@@ -1,0 +1,75 @@
+"""Persistent OA cache and promotion audit for literature discovery."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d1e2f3a4b5c6"
+down_revision: str | None = "e0f1a2b3c4d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "literature_oa_caches",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "hit_id",
+            sa.Uuid(),
+            sa.ForeignKey("literature_search_hits.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(16), nullable=False, server_default="pending"),
+        sa.Column("source_url", sa.String(2048)),
+        sa.Column("final_url", sa.String(2048)),
+        sa.Column("source", sa.String(64)),
+        sa.Column("blob_id", sa.Uuid(), sa.ForeignKey("pdf_blobs.id", ondelete="SET NULL")),
+        sa.Column("sha256", sa.String(64)),
+        sa.Column("byte_size", sa.Integer()),
+        sa.Column("verification", _JSON),
+        sa.Column("error_code", sa.String(64)),
+        sa.Column("error_detail", sa.Text()),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("downloaded_at", sa.DateTime(timezone=True)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("hit_id", name="uq_literature_oa_caches_hit"),
+    )
+    op.create_index("ix_literature_oa_caches_status", "literature_oa_caches", ["status"])
+    op.create_index("ix_literature_oa_caches_blob_id", "literature_oa_caches", ["blob_id"])
+    op.create_index("ix_literature_oa_caches_sha256", "literature_oa_caches", ["sha256"])
+
+    op.create_table(
+        "literature_oa_attempts",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "cache_id",
+            sa.Uuid(),
+            sa.ForeignKey("literature_oa_caches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("url", sa.String(2048), nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("http_status", sa.Integer()),
+        sa.Column("error_code", sa.String(64)),
+        sa.Column("error_detail", sa.Text()),
+        sa.Column("verification", _JSON),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_literature_oa_attempts_cache", "literature_oa_attempts", ["cache_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_literature_oa_attempts_cache", table_name="literature_oa_attempts")
+    op.drop_table("literature_oa_attempts")
+    op.drop_index("ix_literature_oa_caches_sha256", table_name="literature_oa_caches")
+    op.drop_index("ix_literature_oa_caches_blob_id", table_name="literature_oa_caches")
+    op.drop_index("ix_literature_oa_caches_status", table_name="literature_oa_caches")
+    op.drop_table("literature_oa_caches")

--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -1,5 +1,7 @@
 """Library-scoped literature discovery workspace API."""
 
+import asyncio
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -10,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.core.queue import TaskQueue, get_task_queue
+from app.core.redis import get_redis_dep
 from app.models.library_direction import DirectionLibrary
 from app.models.literature_discovery import (
+    LiteratureOaCache,
     LiteratureSearchHit,
     LiteratureSearchRun,
     LiteratureSourceAttempt,
@@ -19,6 +23,9 @@ from app.models.literature_discovery import (
 from app.models.user import User
 from app.schemas.literature_discovery import (
     LiteratureSearchRequest,
+    OaCacheBatchRequest,
+    OaCacheRead,
+    PromoteHitsRequest,
     SearchHitPage,
     SearchHitRead,
     SearchRunDetail,
@@ -27,9 +34,10 @@ from app.schemas.literature_discovery import (
     SourceAttemptRead,
 )
 from app.services import libraries as libraries_service
-from app.services.literature import discovery_runs
+from app.services.literature import discovery_runs, oa_cache
 
 router = APIRouter(tags=["literature-discovery"])
+logger = logging.getLogger(__name__)
 
 
 async def _library(session: AsyncSession, library_id: uuid.UUID, user: User) -> DirectionLibrary:
@@ -242,6 +250,199 @@ async def list_hits(
         size=size,
         sort=sort,
     )
+
+
+@router.post(
+    "/libraries/{library_id}/literature/runs/{run_id}/oa-cache",
+    response_model=list[OaCacheRead],
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def cache_oa_pdfs(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    body: OaCacheBatchRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[OaCacheRead]:
+    """Cache OA PDFs for selected discovery candidates; this does not promote them."""
+    await _managed_library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    hits = list(
+        (
+            await session.execute(
+                select(LiteratureSearchHit).where(
+                    LiteratureSearchHit.run_id == run.id,
+                    LiteratureSearchHit.id.in_(body.hit_ids),
+                    LiteratureSearchHit.status == "candidate",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    cached = []
+    for hit in hits:
+        cached.append(await oa_cache.cache_hit_pdf(session, hit))
+    await session.commit()
+    return [OaCacheRead.model_validate(item) for item in cached]
+
+
+@router.get(
+    "/libraries/{library_id}/literature/runs/{run_id}/oa-cache",
+    response_model=list[OaCacheRead],
+)
+async def list_oa_cache(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[OaCacheRead]:
+    await _library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    rows = (
+        await session.execute(
+            select(LiteratureOaCache)
+            .join(LiteratureSearchHit, LiteratureSearchHit.id == LiteratureOaCache.hit_id)
+            .where(LiteratureSearchHit.run_id == run.id)
+            .order_by(LiteratureOaCache.created_at.desc())
+        )
+    ).scalars().all()
+    return [OaCacheRead.model_validate(item) for item in rows]
+
+
+@router.post(
+    "/libraries/{library_id}/literature/runs/{run_id}/promote",
+    response_model=list[SearchHitRead],
+    status_code=status.HTTP_201_CREATED,
+)
+async def promote_hits(
+    library_id: uuid.UUID,
+    run_id: uuid.UUID,
+    body: PromoteHitsRequest,
+    session: AsyncSession = Depends(get_session),
+    redis=Depends(get_redis_dep),
+    user: User = Depends(current_active_user),
+) -> list[SearchHitRead]:
+    """Promote candidates into the library, then launch the normal enrichment pipeline."""
+    library = await _managed_library(session, library_id, user)
+    run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
+    from app.models.paper import Paper, new_paper
+    from app.services.dedup import pool_dedup_key
+    from app.services.libraries import ensure_membership, find_pool_paper
+    from app.services.paper_assets import create_or_reuse_asset, storage_path_for_blob
+    from app.services.paper_enrich import launch_paper_enrichment
+
+    hits = list(
+        (
+            await session.execute(
+                select(LiteratureSearchHit).where(
+                    LiteratureSearchHit.run_id == run.id,
+                    LiteratureSearchHit.id.in_(body.hit_ids),
+                    LiteratureSearchHit.status.in_(["candidate", "promoted"]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    promoted: list[LiteratureSearchHit] = []
+    task_inputs: list[tuple[uuid.UUID, bool]] = []
+    for hit in hits:
+        # Repeating a promotion request is safe, but it must not relaunch
+        # enrichment or mutate an already-promoted paper a second time.
+        if hit.status == "promoted":
+            promoted.append(hit)
+            continue
+        paper = await session.get(Paper, hit.paper_id) if hit.paper_id else None
+        if paper is None:
+            dedup_key = pool_dedup_key(
+                arxiv_id=hit.arxiv_id,
+                doi=hit.doi,
+                title=hit.title,
+                year=hit.year,
+                authors=hit.authors,
+            )
+            paper = await find_pool_paper(
+                session, arxiv_id=hit.arxiv_id, doi=hit.doi, dedup_key=dedup_key
+            )
+            if paper is None:
+                paper = new_paper(
+                    source=hit.source,
+                    dedup_key=dedup_key,
+                    arxiv_id=hit.arxiv_id,
+                    doi=hit.doi,
+                    external_ids=hit.metadata_snapshot,
+                    title=hit.title,
+                    authors=hit.authors,
+                    abstract=hit.abstract,
+                    year=hit.year,
+                    venue=hit.venue,
+                    url=hit.url,
+                )
+                session.add(paper)
+                await session.flush()
+        scores = hit.scores if isinstance(hit.scores, dict) else {}
+        reasons = scores.get("reasons")
+        if isinstance(reasons, list):
+            rationale = "; ".join(str(reason) for reason in reasons if str(reason).strip())
+        else:
+            rationale = scores.get("reason") or scores.get("rationale")
+        membership, _ = await ensure_membership(
+            session,
+            library_id=library.id,
+            paper_id=paper.id,
+            status="candidate",
+            relevance_score=scores.get("relevance"),
+            relevance_reason=rationale,
+        )
+        cache = await session.scalar(
+            select(LiteratureOaCache).where(LiteratureOaCache.hit_id == hit.id)
+        )
+        if cache is not None and cache.status == "ready" and cache.blob_id is not None:
+            blob = await session.get(oa_cache.PdfBlob, cache.blob_id)
+            if blob is not None:
+                path = storage_path_for_blob(blob)
+                if path.is_file():
+                    content = await asyncio.to_thread(path.read_bytes)
+                    identity = f"doi:{hit.doi.lower()}" if hit.doi else (
+                        f"arxiv:{hit.arxiv_id.lower()}" if hit.arxiv_id else None
+                    )
+                    await create_or_reuse_asset(
+                        session,
+                        paper=paper,
+                        library=library,
+                        content=content,
+                        user=user,
+                        source="oa",
+                        source_locator=cache.final_url or cache.source_url,
+                        identity_key=identity,
+                        identity_status="verified" if identity else "unverified",
+                        sharing_scope="public",
+                    )
+        hit.paper_id = paper.id
+        hit.status = "promoted"
+        hit.promoted_at = datetime.now(UTC)
+        promoted.append(hit)
+        task_inputs.append((paper.id, True))
+    await session.commit()
+    for paper_id, _ in task_inputs:
+        try:
+            await launch_paper_enrichment(
+                redis=redis,
+                paper_id=paper_id,
+                user_id=user.id,
+                library_id=library.id,
+                project_id=library.project_id,
+            )
+        except Exception:  # noqa: BLE001 - promotion remains durable if worker is unavailable
+            logger.exception("failed to launch enrichment for promoted paper %s", paper_id)
+    return [SearchHitRead.model_validate(item) for item in promoted]
 
 
 @router.post(

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -18,6 +18,8 @@ from app.models.integration_token import IntegrationToken
 from app.models.library import UserLibraryEntry
 from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.literature_discovery import (
+    LiteratureOaAttempt,
+    LiteratureOaCache,
     LiteratureSearchHit,
     LiteratureSearchRun,
     LiteratureSourceAttempt,
@@ -95,6 +97,8 @@ __all__ = [
     "PaperContentChunk",
     "PaperContentVersionVector",
     "PaperContentChunkVector",
+    "LiteratureOaCache",
+    "LiteratureOaAttempt",
     "LiteratureSearchHit",
     "LiteratureSearchRun",
     "LiteratureSourceAttempt",

--- a/src/backend/app/models/literature_discovery.py
+++ b/src/backend/app/models/literature_discovery.py
@@ -118,3 +118,54 @@ class LiteratureSourceAttempt(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class LiteratureOaCache(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Persistent OA download state for a discovery hit.
+
+    This cache is deliberately separate from ``PaperAsset``: discovery results
+    may be cached before the user accepts them into a library.
+    """
+
+    __tablename__ = "literature_oa_caches"
+    __table_args__ = (
+        UniqueConstraint("hit_id", name="uq_literature_oa_caches_hit"),
+        Index("ix_literature_oa_caches_status", "status"),
+    )
+
+    hit_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("literature_search_hits.id", ondelete="CASCADE"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(
+        String(16), default="pending", server_default="pending", nullable=False
+    )
+    source_url: Mapped[str | None] = mapped_column(String(2048))
+    final_url: Mapped[str | None] = mapped_column(String(2048))
+    source: Mapped[str | None] = mapped_column(String(64))
+    blob_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("pdf_blobs.id", ondelete="SET NULL"), index=True
+    )
+    sha256: Mapped[str | None] = mapped_column(String(64), index=True)
+    byte_size: Mapped[int | None]
+    verification: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    error_code: Mapped[str | None] = mapped_column(String(64))
+    error_detail: Mapped[str | None] = mapped_column(Text)
+    attempt_count: Mapped[int] = mapped_column(default=0, server_default="0", nullable=False)
+    downloaded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class LiteratureOaAttempt(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Immutable audit row for each OA URL attempt."""
+
+    __tablename__ = "literature_oa_attempts"
+    __table_args__ = (Index("ix_literature_oa_attempts_cache", "cache_id"),)
+
+    cache_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("literature_oa_caches.id", ondelete="CASCADE"), nullable=False
+    )
+    url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    http_status: Mapped[int | None]
+    error_code: Mapped[str | None] = mapped_column(String(64))
+    error_detail: Mapped[str | None] = mapped_column(Text)
+    verification: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -157,6 +157,35 @@ class SearchHitPage(BaseModel):
     sort: str
 
 
+class OaCacheRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    hit_id: uuid.UUID
+    status: str
+    source_url: str | None
+    final_url: str | None
+    source: str | None
+    blob_id: uuid.UUID | None
+    sha256: str | None
+    byte_size: int | None
+    verification: dict[str, Any] | None
+    error_code: str | None
+    error_detail: str | None
+    attempt_count: int
+    downloaded_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class OaCacheBatchRequest(BaseModel):
+    hit_ids: list[uuid.UUID] = Field(min_length=1, max_length=200)
+
+
+class PromoteHitsRequest(BaseModel):
+    hit_ids: list[uuid.UUID] = Field(min_length=1, max_length=200)
+
+
 class SearchRunDetail(SearchRunRead):
     source_attempts: list[SourceAttemptRead]
 

--- a/src/backend/app/services/literature/oa_cache.py
+++ b/src/backend/app/services/literature/oa_cache.py
@@ -1,0 +1,270 @@
+"""OA PDF pre-cache and promotion primitives for literature discovery."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import os
+import socket
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.literature_discovery import (
+    LiteratureOaAttempt,
+    LiteratureOaCache,
+    LiteratureSearchHit,
+)
+from app.models.paper_assets import PdfBlob
+from app.services.paper_assets import _validate_pdf, blob_storage_path
+
+MAX_OA_BYTES = 150 * 1024 * 1024
+MAX_REDIRECTS = 5
+
+
+class OaDownloadError(RuntimeError):
+    def __init__(self, code: str, detail: str, *, http_status: int | None = None) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+        self.http_status = http_status
+
+
+def _public_url(value: str) -> bool:
+    parsed = urlsplit(value)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if parsed.scheme not in {"http", "https"} or not host:
+        return False
+    if host in {"localhost", "localhost.localdomain"} or host.endswith(".local"):
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return True
+    return address.is_global
+
+
+async def _assert_public_url(value: str) -> None:
+    import asyncio
+
+    if not _public_url(value):
+        raise OaDownloadError("PDF_URL_PRIVATE", "OA URL is not public")
+    host = urlsplit(value).hostname
+    if host is None:
+        raise OaDownloadError("PDF_URL_INVALID", "OA URL has no host")
+    try:
+        addresses = await asyncio.to_thread(
+            lambda: {item[4][0] for item in socket.getaddrinfo(host, None)}
+        )
+    except socket.gaierror as exc:
+        raise OaDownloadError("PDF_HOST_UNRESOLVED", str(exc)) from exc
+    if any(not ipaddress.ip_address(address).is_global for address in addresses):
+        raise OaDownloadError("PDF_URL_PRIVATE", "OA URL resolves to a private network")
+
+
+def candidate_urls(hit: LiteratureSearchHit) -> list[tuple[str, str]]:
+    """Collect provider PDF links without turning metadata pages into PDFs."""
+    metadata = hit.metadata_snapshot if isinstance(hit.metadata_snapshot, dict) else {}
+    candidates: list[tuple[str, str]] = []
+
+    def add(url: Any, source: str) -> None:
+        value = str(url or "").strip()
+        if value and _public_url(value) and value not in {item[0] for item in candidates}:
+            candidates.append((value, source))
+
+    add(hit.pdf_url, hit.source)
+    for key, source in (
+        ("pdf_url", hit.source),
+        ("url_for_pdf", hit.source),
+        ("openAccessPdf", "semantic"),
+    ):
+        value = metadata.get(key)
+        if isinstance(value, dict):
+            add(value.get("url_for_pdf") or value.get("pdf_url") or value.get("url"), source)
+        else:
+            add(value, source)
+    for key, source in (("best_oa_location", "unpaywall"), ("primary_location", "openalex")):
+        value = metadata.get(key)
+        if isinstance(value, dict):
+            add(value.get("url_for_pdf") or value.get("pdf_url"), source)
+    for key, source in (
+        ("oa_locations", "unpaywall"),
+        ("locations", "openalex"),
+        ("links", hit.source),
+    ):
+        for value in metadata.get(key) or []:
+            if isinstance(value, dict):
+                add(value.get("url_for_pdf") or value.get("pdf_url") or value.get("url"), source)
+    if hit.arxiv_id:
+        add(f"https://arxiv.org/pdf/{hit.arxiv_id}.pdf", "arxiv")
+    if hit.pmid and str(hit.pmid).upper().startswith("PMC"):
+        add(f"https://europepmc.org/articles/{hit.pmid}?pdf=render", "europepmc")
+    return candidates
+
+
+async def _download(url: str) -> tuple[bytes, str, int | None]:
+    current = url
+    timeout = httpx.Timeout(45.0, connect=15.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+        for _ in range(MAX_REDIRECTS + 1):
+            await _assert_public_url(current)
+            response = await client.get(current, headers={"Accept": "application/pdf,*/*"})
+            if response.status_code in {301, 302, 303, 307, 308}:
+                location = response.headers.get("location")
+                if not location:
+                    raise OaDownloadError("PDF_REDIRECT_INVALID", "redirect has no location")
+                current = urljoin(current, location)
+                continue
+            if response.status_code >= 400:
+                raise OaDownloadError(
+                    "PDF_HTTP_ERROR",
+                    f"HTTP {response.status_code}",
+                    http_status=response.status_code,
+                )
+            content = response.content
+            if len(content) > MAX_OA_BYTES:
+                raise OaDownloadError("PDF_TOO_LARGE", "PDF exceeds the configured size limit")
+            if not content.startswith(b"%PDF-"):
+                raise OaDownloadError("PDF_SIGNATURE_INVALID", "response is not a PDF")
+            return content, str(response.url), response.status_code
+    raise OaDownloadError("PDF_REDIRECT_LIMIT", "too many PDF redirects")
+
+
+async def _unpaywall_urls(hit: LiteratureSearchHit) -> list[tuple[str, str]]:
+    """Resolve DOI OA locations as a fallback when providers omitted a PDF URL."""
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    if not hit.doi or not settings.unpaywall_email:
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(
+                f"https://api.unpaywall.org/v2/{hit.doi}",
+                params={"email": settings.unpaywall_email},
+            )
+            if response.status_code >= 400:
+                return []
+            payload = response.json()
+    except (httpx.HTTPError, ValueError):
+        return []
+    locations = [payload.get("best_oa_location") or {}, *(payload.get("oa_locations") or [])]
+    return [
+        (str(location["url_for_pdf"]), "unpaywall")
+        for location in locations
+        if isinstance(location, dict)
+        and location.get("url_for_pdf")
+        and _public_url(str(location["url_for_pdf"]))
+    ]
+
+
+async def cache_hit_pdf(
+    session: AsyncSession, hit: LiteratureSearchHit
+) -> LiteratureOaCache:
+    cache = await session.scalar(
+        select(LiteratureOaCache).where(LiteratureOaCache.hit_id == hit.id)
+    )
+    if cache is None:
+        cache = LiteratureOaCache(hit_id=hit.id, status="pending")
+        session.add(cache)
+        await session.flush()
+    if cache.status == "ready":
+        return cache
+
+    urls = candidate_urls(hit)
+    if hit.doi:
+        for url, source in await _unpaywall_urls(hit):
+            if url not in {item[0] for item in urls}:
+                urls.append((url, source))
+    if not urls:
+        cache.status = "unavailable"
+        cache.error_code = "OA_PDF_NOT_FOUND"
+        cache.error_detail = "No verified OA PDF URL was returned by the providers"
+        await session.flush()
+        return cache
+
+    cache.status = "downloading"
+    cache.attempt_count = (cache.attempt_count or 0) + 1
+    await session.flush()
+    last_error: OaDownloadError | None = None
+    for url, source in urls:
+        attempt = LiteratureOaAttempt(cache_id=cache.id, url=url, status="running")
+        session.add(attempt)
+        await session.flush()
+        try:
+            content, final_url, http_status = await _download(url)
+            await _validate_pdf_async(content)
+            digest = hashlib.sha256(content).hexdigest()
+            blob = await session.scalar(select(PdfBlob).where(PdfBlob.sha256 == digest))
+            if blob is None:
+                blob = PdfBlob(
+                    sha256=digest,
+                    byte_size=len(content),
+                    storage_key=f"pdf-blobs/{digest[:2]}/{digest}.pdf",
+                    content_type="application/pdf",
+                    state="ready",
+                )
+                session.add(blob)
+                await session.flush()
+            path = blob_storage_path(digest)
+            if not path.exists():
+                await _write_blob(path, content)
+            cache.status = "ready"
+            cache.source_url = url
+            cache.final_url = final_url
+            cache.source = source
+            cache.blob_id = blob.id
+            cache.sha256 = digest
+            cache.byte_size = len(content)
+            cache.verification = {"pdf_signature": True, "parsed": True}
+            cache.downloaded_at = datetime.now(UTC)
+            cache.error_code = None
+            cache.error_detail = None
+            attempt.status = "success"
+            attempt.http_status = http_status
+            attempt.verification = cache.verification
+            await session.flush()
+            return cache
+        except OaDownloadError as exc:
+            last_error = exc
+            attempt.status = "failed"
+            attempt.http_status = exc.http_status
+            attempt.error_code = exc.code
+            attempt.error_detail = exc.detail
+        except Exception as exc:  # noqa: BLE001
+            last_error = OaDownloadError("PDF_PARSE_FAILED", str(exc))
+            attempt.status = "failed"
+            attempt.error_code = last_error.code
+            attempt.error_detail = last_error.detail
+    cache.status = "failed"
+    cache.error_code = last_error.code if last_error else "OA_DOWNLOAD_FAILED"
+    cache.error_detail = last_error.detail if last_error else "all OA URLs failed"
+    await session.flush()
+    return cache
+
+
+async def _validate_pdf_async(content: bytes) -> None:
+    import asyncio
+
+    await asyncio.to_thread(_validate_pdf, content)
+
+
+async def _write_blob(path: Path, content: bytes) -> None:
+    import asyncio
+
+    def write() -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            temp.write_bytes(content)
+            os.replace(temp, path)
+        finally:
+            temp.unlink(missing_ok=True)
+
+    await asyncio.to_thread(write)

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -431,6 +431,29 @@ async def run_discovery(
             )
         )
 
+    # Cache explicit OA PDFs while hits are still candidates.  This never
+    # creates a Paper, asset, parse job, or vector; promotion remains the gate.
+    await session.flush()
+    from app.services.literature.oa_cache import cache_hit_pdf
+
+    oa_hits = list(
+        (
+            await session.execute(
+                select(LiteratureSearchHit).where(
+                    LiteratureSearchHit.run_id == run.id,
+                    LiteratureSearchHit.pdf_url.is_not(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for hit in oa_hits:
+        try:
+            await cache_hit_pdf(session, hit)
+        except Exception:  # noqa: BLE001 - metadata results must survive OA failures
+            logger.warning("OA pre-cache failed for hit %s", hit.id, exc_info=True)
+
     run.status = "partial" if failures and ranked else "failed" if failures else "completed"
     run.error_summary = "; ".join(failures) if failures else None
     run.completed_at = datetime.now(UTC)

--- a/src/backend/tests/test_literature_oa_cache.py
+++ b/src/backend/tests/test_literature_oa_cache.py
@@ -1,0 +1,96 @@
+"""Issue #475: OA cache is durable and remains separate from promotion."""
+
+import uuid
+
+import pymupdf
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.literature_discovery import (
+    LiteratureOaAttempt,
+    LiteratureOaCache,
+    LiteratureSearchHit,
+    LiteratureSearchRun,
+)
+from app.services.literature import oa_cache
+from tests.test_literature_discovery_runtime import _create_run
+
+
+def _pdf_bytes() -> bytes:
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_text((72, 72), "OA cache test")
+    data = document.tobytes()
+    document.close()
+    return data
+
+
+@pytest.mark.asyncio
+async def test_oa_cache_persists_verified_blob_and_attempt(client, monkeypatch):
+    run_id, _headers, _library_id = await _create_run(
+        client, source_config={"sources": ["openalex"]}
+    )
+    async with get_sessionmaker()() as session:
+        hit = LiteratureSearchHit(
+            run_id=run_id,
+            source="openalex",
+            dedup_key=f"doi:10.1234/{uuid.uuid4().hex}",
+            title="OA cache test",
+            doi="10.1234/oa-cache",
+            pdf_url="https://papers.example.test/test.pdf",
+        )
+        session.add(hit)
+        await session.flush()
+
+        async def fake_download(_url):
+            return _pdf_bytes(), "https://papers.example.test/test.pdf", 200
+
+        async def fake_write(path, content):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+
+        monkeypatch.setattr(oa_cache, "_download", fake_download)
+        monkeypatch.setattr(oa_cache, "_write_blob", fake_write)
+        cache = await oa_cache.cache_hit_pdf(session, hit)
+        await session.commit()
+
+        assert cache.status == "ready"
+        assert cache.blob_id is not None
+        assert cache.sha256 is not None
+        assert await session.scalar(
+            select(LiteratureOaAttempt).where(LiteratureOaAttempt.cache_id == cache.id)
+        )
+        assert await session.scalar(
+            select(LiteratureSearchRun.id).where(LiteratureSearchRun.id == run_id)
+        )
+        assert await session.scalar(
+            select(LiteratureOaCache.id).where(LiteratureOaCache.id == cache.id)
+        )
+
+
+@pytest.mark.asyncio
+async def test_oa_cache_without_pdf_url_is_not_promoted(client):
+    run_id, _headers, _library_id = await _create_run(
+        client, source_config={"sources": ["openalex"]}
+    )
+    async with get_sessionmaker()() as session:
+        hit = LiteratureSearchHit(
+            run_id=run_id,
+            source="openalex",
+            dedup_key=f"title:{uuid.uuid4().hex}",
+            title="No OA file",
+        )
+        session.add(hit)
+        await session.flush()
+        cache = await oa_cache.cache_hit_pdf(session, hit)
+        assert cache.status == "unavailable"
+        assert cache.error_code == "OA_PDF_NOT_FOUND"
+        assert (
+            await session.scalar(
+                select(LiteratureOaAttempt.id).where(
+                    LiteratureOaAttempt.cache_id == cache.id
+                )
+            )
+            is None
+        )

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "e0f1a2b3c4d5"  # Polaris extension download batches and API keys
+HEAD_REVISION = "d1e2f3a4b5c6"  # Persistent OA cache and promotion audit
+DOWNLOAD_BATCH_REVISION = "e0f1a2b3c4d5"  # Polaris extension download batches and API keys
 EVIDENCE_ANCHOR_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
 CONTENT_VERSION_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
 PDF_ASSET_REVISION = "c8d9e0f1a2b3"  # Content-addressed PDF assets and grants
@@ -128,6 +129,8 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "download_api_keys",
                     "download_batches",
                     "download_batch_items",
+                    "literature_oa_caches",
+                    "literature_oa_attempts",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -463,7 +466,15 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
 
     assert {"download_api_keys", "download_batches", "download_batch_items"} <= columns["_tables"]
 
-    # 先退掉下载批次协议迁移，回到证据锚点版本。
+    assert {"literature_oa_caches", "literature_oa_attempts"} <= columns["_tables"]
+
+    # 先退掉 OA 缓存迁移，回到下载批次协议版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == DOWNLOAD_BATCH_REVISION
+    assert not {"literature_oa_caches", "literature_oa_attempts"} & columns["_tables"]
+
+    # 再退掉下载批次协议迁移，回到证据锚点版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == EVIDENCE_ANCHOR_REVISION


### PR DESCRIPTION
Rebase of #476 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 32 files / +4823 to **13 files / +1400**.

## Migration re-pointed

`d1e2f3a4b5c6` chained from `c8d9e0f1a2b3`, which stopped being the head three migrations ago (#492, #493, #494 all landed on top of it). Re-pointed to `e0f1a2b3c4d5`. Unchanged, it would have forked the chain at `c8d9e0f1a2b3` into a second head.

## Resolutions

**`api/paper_assets.py` and `schemas/paper_assets.py`** — the branch's copies predate #492 and score `+1/-80` and `+1/-37` against `main`. Taking them would have deleted the content-lifecycle additions while adding a single line. `main`'s versions kept.

**`models/__init__.py`** — again dropped the exports from the preceding PRs; rebuilt from `main`'s copy plus `LiteratureOaCache` and `LiteratureOaAttempt`.

**`worker/tasks.py`** — the branch's `run_literature_discovery` is already on `main` via #495, so no change was needed.

**`tests/test_migrations.py`** — extended from `main`'s copy: `HEAD_REVISION` → `d1e2f3a4b5c6`, `DOWNLOAD_BATCH_REVISION` added, the two OA tables asserted, sixth downgrade step added.

## Verification

- `alembic heads` → single head `d1e2f3a4b5c6`; round trip walks six steps back to `8ff89f7fcdeb`
- `tests/test_migrations.py tests/test_literature_oa_cache.py tests/test_literature_discovery_runtime.py tests/test_literature_discovery_api.py tests/test_paper_assets.py tests/test_paper_content.py` → 20 passed
- `ruff check app/ worker/` → clean; `import app.main, worker.settings` → ok

Closes #475. Supersedes #476.