### PR TITLE
feat(literature): make provider failures observable and bounded

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -117,6 +117,30 @@ class Settings(BaseSettings):
             "POLARIS_SCIVERSE_API_TOKENS", "SCIVERSE_API_TOKENS", "SCIVERSE_API_TOKEN"
         ),
     )
+    literature_source_concurrency: int = Field(
+        default=4,
+        ge=1,
+        le=32,
+        validation_alias=AliasChoices(
+            "POLARIS_LITERATURE_SOURCE_CONCURRENCY", "PAPER_SEARCH_SOURCE_CONCURRENCY"
+        ),
+    )
+    literature_source_timeout_seconds: float = Field(
+        default=25.0,
+        gt=0,
+        le=300,
+        validation_alias=AliasChoices(
+            "POLARIS_LITERATURE_SOURCE_TIMEOUT_SECONDS", "PAPER_SEARCH_SOURCE_TIMEOUT_SECONDS"
+        ),
+    )
+    literature_source_retries: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        validation_alias=AliasChoices(
+            "POLARIS_LITERATURE_SOURCE_RETRIES", "PAPER_SEARCH_SOURCE_RETRIES"
+        ),
+    )
 
     # ---- 邮件（密码重置等事务邮件）----
     # smtp_host 为空 = 关闭发信：忘记密码入口在前端自动隐藏（见 /auth/capabilities）。

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -7,6 +7,7 @@ lookup), so its keyword-search method returns no candidates by design.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -16,6 +17,16 @@ from urllib.parse import quote
 import httpx
 
 from app.core.config import get_settings
+
+
+class ProviderRequestError(RuntimeError):
+    """A provider request failed after bounded retries."""
+
+    def __init__(self, source: str, code: str, detail: str, *, retryable: bool = True) -> None:
+        super().__init__(detail)
+        self.source = source
+        self.code = code
+        self.retryable = retryable
 
 
 def _text(value: Any) -> str:
@@ -70,11 +81,60 @@ class MultiSourceClient:
         settings = get_settings()
         self._client = client or httpx.AsyncClient(
             proxy=settings.outbound_proxy or None,
-            timeout=30.0,
+            timeout=settings.literature_source_timeout_seconds,
             follow_redirects=True,
             headers={"User-Agent": f"Polaris/1.0 (mailto:{settings.openalex_mailto})"},
         )
         self._owns_client = client is None
+        self._timeout = settings.literature_source_timeout_seconds
+        self._retries = settings.literature_source_retries
+
+    async def _request_json(
+        self,
+        source: str,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Request JSON with bounded retry and explicit provider errors."""
+        last_error: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+                response = await self._client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    timeout=timeout or self._timeout,
+                )
+                if response.status_code in {408, 425, 429} or response.status_code >= 500:
+                    response.raise_for_status()
+                if response.status_code >= 400:
+                    raise ProviderRequestError(
+                        source,
+                        f"HTTP_{response.status_code}",
+                        f"{source} returned HTTP {response.status_code}",
+                        retryable=False,
+                    )
+                return response.json()
+            except ProviderRequestError as exc:
+                if not exc.retryable:
+                    raise
+                last_error = exc
+            except (httpx.HTTPError, ValueError) as exc:
+                last_error = exc
+            if attempt < self._retries:
+                await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise ProviderRequestError(
+            source,
+            "REQUEST_FAILED",
+            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
+        ) from last_error
 
     async def aclose(self) -> None:
         if self._owns_client:
@@ -98,15 +158,14 @@ class MultiSourceClient:
         if not settings.unpaywall_email or not doi:
             return None
         try:
-            response = await self._client.get(
+            payload = await self._request_json(
+                "unpaywall",
+                "GET",
                 f"https://api.unpaywall.org/v2/{quote(doi, safe='/')}",
                 params={"email": settings.unpaywall_email},
-                timeout=15.0,
+                timeout=min(15.0, self._timeout),
             )
-            if response.status_code >= 400:
-                return None
-            payload = response.json()
-        except (httpx.HTTPError, ValueError):
+        except ProviderRequestError:
             return None
         return payload if isinstance(payload, dict) else None
 
@@ -130,24 +189,27 @@ class MultiSourceClient:
         if settings.pubmed_email:
             params["email"] = settings.pubmed_email
         try:
-            response = await self._client.get(
-                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi", params=params
+            payload = await self._request_json(
+                "pubmed",
+                "GET",
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+                params=params,
             )
-            response.raise_for_status()
-            ids = (response.json().get("esearchresult") or {}).get("idlist") or []
+            ids = (payload.get("esearchresult") or {}).get("idlist") or []
             if not ids:
                 return []
             summary_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "json"}
             if settings.pubmed_api_key:
                 summary_params["api_key"] = settings.pubmed_api_key
-            summary = await self._client.get(
+            summary = await self._request_json(
+                "pubmed",
+                "GET",
                 "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi",
                 params=summary_params,
             )
-            summary.raise_for_status()
-            result = summary.json().get("result") or {}
-        except (httpx.HTTPError, ValueError):
-            return []
+            result = summary.get("result") or {}
+        except ProviderRequestError:
+            raise
         rows: list[dict[str, Any]] = []
         for pmid in ids:
             item = result.get(str(pmid))
@@ -190,13 +252,12 @@ class MultiSourceClient:
         }
         headers = {"User-Agent": f"Polaris/1.0 (mailto:{settings.crossref_mailto})"}
         try:
-            response = await self._client.get(
-                "https://api.crossref.org/works", params=params, headers=headers
+            payload = await self._request_json(
+                "crossref", "GET", "https://api.crossref.org/works", params=params, headers=headers
             )
-            response.raise_for_status()
-            items = (response.json().get("message") or {}).get("items") or []
-        except (httpx.HTTPError, ValueError):
-            return []
+            items = (payload.get("message") or {}).get("items") or []
+        except ProviderRequestError:
+            raise
         return [self._crossref_item(item) for item in items if isinstance(item, dict)]
 
     async def _search_europepmc(self, request: Any) -> list[dict[str, Any]]:
@@ -210,13 +271,15 @@ class MultiSourceClient:
             "sort": "CITED desc",
         }
         try:
-            response = await self._client.get(
-                "https://www.ebi.ac.uk/europepmc/webservices/rest/search", params=params
+            payload = await self._request_json(
+                "europepmc",
+                "GET",
+                "https://www.ebi.ac.uk/europepmc/webservices/rest/search",
+                params=params,
             )
-            response.raise_for_status()
-            items = (response.json().get("resultList") or {}).get("result") or []
-        except (httpx.HTTPError, ValueError):
-            return []
+            items = (payload.get("resultList") or {}).get("result") or []
+        except ProviderRequestError:
+            raise
         return [self._europepmc_item(item) for item in items if isinstance(item, dict)]
 
     async def _search_hal(self, request: Any) -> list[dict[str, Any]]:
@@ -233,13 +296,12 @@ class MultiSourceClient:
             "wt": "json",
         }
         try:
-            response = await self._client.get(
-                "https://api.archives-ouvertes.fr/search/", params=params
+            payload = await self._request_json(
+                "hal", "GET", "https://api.archives-ouvertes.fr/search/", params=params
             )
-            response.raise_for_status()
-            items = (response.json().get("response") or {}).get("docs") or []
-        except (httpx.HTTPError, ValueError):
-            return []
+            items = (payload.get("response") or {}).get("docs") or []
+        except ProviderRequestError:
+            raise
         return [self._hal_item(item) for item in items if isinstance(item, dict)]
 
     async def _search_core(self, request: Any) -> list[dict[str, Any]]:
@@ -251,15 +313,16 @@ class MultiSourceClient:
             "limit": min(request.limit, 100),
         }
         try:
-            response = await self._client.post(
+            payload = await self._request_json(
+                "core",
+                "POST",
                 "https://api.core.ac.uk/v3/search/works",
                 json=params,
                 headers={"Authorization": f"Bearer {settings.core_api_key}"},
             )
-            response.raise_for_status()
-            items = response.json().get("results") or []
-        except (httpx.HTTPError, ValueError):
-            return []
+            items = payload.get("results") or []
+        except ProviderRequestError:
+            raise
         return [self._core_item(item) for item in items if isinstance(item, dict)]
 
     async def _search_base(self, request: Any) -> list[dict[str, Any]]:
@@ -271,15 +334,15 @@ class MultiSourceClient:
             "hits": min(request.limit, 100),
         }
         try:
-            response = await self._client.get(
+            payload = await self._request_json(
+                "base",
+                "GET",
                 "https://api.base-search.net/cgi-bin/BaseHttpSearchInterface.fcgi",
                 params=params,
             )
-            response.raise_for_status()
-            payload = response.json()
             items = (payload.get("response") or {}).get("docs") or payload.get("docs") or []
-        except (httpx.HTTPError, ValueError):
-            return []
+        except ProviderRequestError:
+            raise
         return [self._base_item(item) for item in items if isinstance(item, dict)]
 
     async def _search_sciverse(self, request: Any) -> list[dict[str, Any]]:
@@ -295,7 +358,9 @@ class MultiSourceClient:
         if not token:
             return []
         try:
-            response = await self._client.post(
+            payload = await self._request_json(
+                "sciverse",
+                "POST",
                 f"{settings.sciverse_base_url.rstrip('/')}/meta-search",
                 json={
                     "query": request.query,
@@ -304,10 +369,8 @@ class MultiSourceClient:
                 },
                 headers={"Authorization": f"Bearer {token}"},
             )
-            response.raise_for_status()
-            payload = response.json()
-        except (httpx.HTTPError, ValueError):
-            return []
+        except ProviderRequestError:
+            raise
         items = payload.get("results") or payload.get("items") or payload.get("data") or []
         return [self._sciverse_item(item) for item in items if isinstance(item, dict)]
 

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -6,6 +6,7 @@ separate steps. Unpromoted hits never create a Paper or a PDF processing job.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections.abc import Mapping, Sequence
@@ -15,6 +16,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import get_settings
 from app.models.literature_discovery import (
     LiteratureSearchHit,
     LiteratureSearchRun,
@@ -29,7 +31,7 @@ from app.schemas.literature_discovery import (
 from app.services.literature import discovery_runs
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
 from app.services.literature.discovery_ranking import rank_candidates
-from app.services.literature.multi_source import MultiSourceClient
+from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
 
 logger = logging.getLogger(__name__)
 _DEFAULT_REGISTRY: AdapterRegistry | None = None
@@ -311,6 +313,7 @@ async def run_discovery(
     failures: list[str] = []
     fetched_total = 0
 
+    runnable: list[tuple[str, Any, LiteratureSourceAttempt, str]] = []
     for source in sources:
         attempt = attempt_by_source.get(source)
         if attempt is None:
@@ -339,16 +342,45 @@ async def run_discovery(
         attempt.query = query
         attempt.requested_count = run.candidate_budget
         attempt.started_at = datetime.now(UTC)
-        await session.commit()
-        try:
-            page = await adapter.search(
-                SourceSearchRequest(
-                    query=query,
-                    start_year=run.start_year,
-                    end_year=run.end_year,
-                    limit=run.candidate_budget,
+        runnable.append((source, adapter, attempt, query))
+
+    await session.commit()
+
+    semaphore = asyncio.Semaphore(get_settings().literature_source_concurrency)
+
+    async def fetch(
+        source: str, adapter: Any, query: str
+    ) -> tuple[SourceSearchPage | None, SourceExecutionError | None]:
+        async with semaphore:
+            try:
+                page = await adapter.search(
+                    SourceSearchRequest(
+                        query=query,
+                        start_year=run.start_year,
+                        end_year=run.end_year,
+                        limit=run.candidate_budget,
+                    )
                 )
-            )
+                return page, None
+            except ProviderRequestError as exc:
+                return None, SourceExecutionError(
+                    exc.code, str(exc), retryable=exc.retryable
+                )
+            except Exception as exc:  # noqa: BLE001 - provider isolation is intentional
+                return None, SourceExecutionError(
+                    "SOURCE_REQUEST_FAILED", str(exc), retryable=True
+                )
+
+    results = await asyncio.gather(
+        *(fetch(source, adapter, query) for source, adapter, _, query in runnable)
+    )
+    for (source, _, attempt, _query), (page, source_error) in zip(
+        runnable, results, strict=True
+    ):
+        try:
+            if source_error is not None:
+                raise source_error
+            assert page is not None
             validated = [validate_candidate(item) for item in page.items]
             candidates.extend(validated)
             fetched_total += page.fetched_count

--- a/src/backend/tests/test_literature_config_aliases.py
+++ b/src/backend/tests/test_literature_config_aliases.py
@@ -13,3 +13,15 @@ def test_semantic_scholar_and_openalex_aliases(monkeypatch):
 
     assert settings.s2_api_key == "s2-legacy-key"
     assert settings.openalex_mailto == "research@example.org"
+
+
+def test_source_runtime_aliases(monkeypatch):
+    monkeypatch.setenv("PAPER_SEARCH_SOURCE_CONCURRENCY", "7")
+    monkeypatch.setenv("PAPER_SEARCH_SOURCE_TIMEOUT_SECONDS", "18")
+    monkeypatch.setenv("PAPER_SEARCH_SOURCE_RETRIES", "3")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.literature_source_concurrency == 7
+    assert settings.literature_source_timeout_seconds == 18
+    assert settings.literature_source_retries == 3

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -13,7 +13,7 @@ from app.models.literature_discovery import (
 )
 from app.models.paper import Paper
 from app.schemas.literature_discovery import LiteratureCandidate, SourceSearchPage
-from app.services.literature.multi_source import MultiSourceClient
+from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
 from app.services.literature.openalex import _simplify
 from app.services.literature.runtime import (
     AdapterRegistry,
@@ -262,3 +262,34 @@ async def test_extended_sources_share_candidate_contract_and_keep_unpaywall_as_r
     assert page.items[0].doi == "10.1000/example"
     assert page.items[0].metadata == {"source_id": "cr-1"}
     assert await MultiSourceClient(client=Client()).search_source("unpaywall", request) == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_persists_provider_error_instead_of_reporting_zero_hit_success(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["pubmed"]},
+        requested_count=5,
+        candidate_budget=10,
+    )
+
+    class BrokenAdapter:
+        name = "pubmed"
+
+        async def search(self, request):
+            raise ProviderRequestError(
+                "pubmed", "HTTP_503", "PubMed temporarily unavailable", retryable=True
+            )
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(session, run_id, registry=AdapterRegistry((BrokenAdapter(),)))
+        attempt = await session.scalar(
+            select(LiteratureSourceAttempt).where(LiteratureSourceAttempt.run_id == run_id)
+        )
+
+    assert run.status == "failed"
+    assert run.progress["returned_count"] == 0
+    assert attempt.status == "failed"
+    assert attempt.error_code == "HTTP_503"
+    assert attempt.retryable is True
+    assert "HTTP_503" in (run.error_summary or "")


### PR DESCRIPTION
Rebase of #477 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 32 files / +4985 to **5 files / +222**. Everything else in that diff was already on `main` via #489–#496.

## What is actually in it

`multi_source.py` replaces the inline `httpx` calls with a bounded wrapper — per-source timeouts, retry limits and recorded failure reasons — and `runtime.py` records the outcome per source rather than letting one provider's failure end the run. That is a real rewrite, not a revert artifact, so the branch's versions were taken for those two files plus `core/config.py` and the two test files.

## Resolutions

- the branch re-carries `a7c8d9e0f1b2`, `c8d9e0f1a2b3` and `d1e2f3a4b5c6`; all are on `main` already, and its `d1e2f3a4b5c6` still chains from the pre-rebase parent, so `main`'s copies are kept and the chain is untouched
- `api/paper_assets.py` and `schemas/paper_assets.py` again predate #492 (`+1/-80` and `+1/-37`); `main`'s kept
- `worker/tasks.py` and `models/__init__.py` needed no change — their additions are already on `main`

## Verification

- `alembic heads` → single head `d1e2f3a4b5c6` (unchanged)
- `tests/test_literature_discovery_runtime.py tests/test_literature_config_aliases.py tests/test_migrations.py tests/test_literature_oa_cache.py tests/test_literature_discovery_api.py` → 13 passed
- `ruff check app/ worker/` → clean; `import app.main, worker.settings` → ok

Closes #480. Supersedes #477.