### PR TITLE
feat(literature): persist administrator discovery settings

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -15,6 +15,10 @@ from app.schemas.admin_settings import (
     ExperimentEnvSettings,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
+    LiteratureProviderTestRequest,
+    LiteratureProviderTestResult,
+    LiteratureSearchSettings,
+    LiteratureSearchSettingsUpdate,
     ManagedCommandWatchdogAdminSettings,
 )
 from app.schemas.tts import TTSAdminSettings, TTSTestResult, TTSVoicesResult
@@ -23,6 +27,7 @@ from app.services import daily_feed as daily_service
 from app.services import embedding as embedding_service
 from app.services import experiment_settings as experiment_settings_service
 from app.services import lab as lab_service
+from app.services import literature_settings as literature_settings_service
 from app.services import managed_command_watchdog as watchdog_service
 from app.services import tts as tts_service
 
@@ -192,6 +197,71 @@ async def get_tts_settings(
 ) -> TTSAdminSettings:
     """Platform speech provider and default model."""
     return TTSAdminSettings(**await tts_service.get_admin_settings(session))
+
+
+@router.get("/literature-search", response_model=LiteratureSearchSettings)
+async def get_literature_search_settings(
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureSearchSettings:
+    return LiteratureSearchSettings(**await literature_settings_service.get_settings(session))
+
+
+@router.put("/literature-search", response_model=LiteratureSearchSettings)
+async def set_literature_search_settings(
+    payload: LiteratureSearchSettingsUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureSearchSettings:
+    try:
+        saved = await literature_settings_service.update_settings(
+            session, payload.model_dump(exclude_none=True)
+        )
+    except literature_settings_service.InvalidLiteratureSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_LITERATURE_SETTING:{exc.field}",
+        ) from exc
+    return LiteratureSearchSettings(**saved)
+
+
+@router.post("/literature-search/test", response_model=LiteratureProviderTestResult)
+async def test_literature_provider(
+    payload: LiteratureProviderTestRequest,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderTestResult:
+    """Run a one-result health probe through the same adapter registry as workers."""
+    import time
+
+    source = payload.source.strip().lower()
+    started = time.perf_counter()
+    try:
+        from app.services.literature.runtime import _default_registry
+
+        registry = await _default_registry()
+        adapter = registry.get(source)
+        if adapter is None:
+            raise ValueError(f"unsupported source: {source}")
+        from app.schemas.literature_discovery import SourceSearchRequest
+
+        page = await adapter.search(SourceSearchRequest(query=payload.query, limit=1))
+        detail = "provider responded"
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=True,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            fetched_count=page.fetched_count,
+            detail=detail,
+        )
+    except Exception as exc:  # noqa: BLE001 - health endpoint returns structured failure
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=False,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            detail=f"{type(exc).__name__}: {exc}"[:500],
+        )
+    await literature_settings_service.record_provider_health(
+        session, source=source, ok=result.ok, detail=result.detail
+    )
+    return result
 
 
 @router.put("/tts", response_model=TTSAdminSettings)

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -1,6 +1,6 @@
 """管理端全局设置 schema（system_settings 表读写）。"""
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -84,3 +84,43 @@ class ManagedCommandWatchdogAdminSettings(BaseModel):
     """Maximum unattended wait before a GPU-using command is stopped."""
 
     max_unanswered_minutes: int = Field(default=120, ge=15, le=10_080)
+
+
+class LiteratureProviderKeyStatus(BaseModel):
+    index: int
+    configured: bool
+    preview: str
+
+
+class LiteratureSearchSettings(BaseModel):
+    sources: list[str]
+    requested_count: int = Field(ge=1, le=200)
+    candidate_budget: int = Field(ge=1, le=1000)
+    start_year: int | None = Field(default=None, ge=1800, le=3000)
+    end_year: int | None = Field(default=None, ge=1800, le=3000)
+    score_weights: dict[str, float]
+    provider_keys: dict[str, list[LiteratureProviderKeyStatus]] = {}
+    provider_health: dict[str, dict[str, Any]] = {}
+
+
+class LiteratureSearchSettingsUpdate(BaseModel):
+    sources: list[str] | None = None
+    requested_count: int | None = Field(default=None, ge=1, le=200)
+    candidate_budget: int | None = Field(default=None, ge=1, le=1000)
+    start_year: int | None = Field(default=None, ge=1800, le=3000)
+    end_year: int | None = Field(default=None, ge=1800, le=3000)
+    score_weights: dict[str, float] | None = None
+    provider_keys: dict[str, list[str]] | None = None
+
+
+class LiteratureProviderTestRequest(BaseModel):
+    source: str
+    query: str = Field(min_length=1, max_length=4000)
+
+
+class LiteratureProviderTestResult(BaseModel):
+    source: str
+    ok: bool
+    latency_ms: int
+    fetched_count: int = 0
+    detail: str

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -1,0 +1,217 @@
+"""Persistent administrator settings for literature discovery.
+
+Provider credentials are encrypted at rest and are never returned by the read
+endpoint.  A key list is replaced atomically when supplied, which makes key
+rotation explicit and avoids accidentally deleting an existing pool.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import decrypt_secret, encrypt_secret
+from app.models.system_setting import SystemSetting
+
+SETTING_KEY = "literature_search"
+SUPPORTED_SOURCES = (
+    "openalex",
+    "semantic",
+    "arxiv",
+    "pubmed",
+    "crossref",
+    "europepmc",
+    "hal",
+    "core",
+    "base",
+    "sciverse",
+)
+DEFAULT_SCORE_WEIGHTS = {
+    "relevance": 0.45,
+    "quality": 0.2,
+    "novelty": 0.2,
+    "recency": 0.15,
+}
+DEFAULTS: dict[str, Any] = {
+    "sources": ["openalex", "semantic", "arxiv", "pubmed", "crossref"],
+    "requested_count": 20,
+    "candidate_budget": 80,
+    "start_year": None,
+    "end_year": None,
+    "score_weights": DEFAULT_SCORE_WEIGHTS,
+    "provider_keys": {},
+}
+
+
+class InvalidLiteratureSettingError(ValueError):
+    """A field failed administrator setting validation."""
+
+    def __init__(self, field: str, detail: str) -> None:
+        super().__init__(f"{field}: {detail}")
+        self.field = field
+
+
+def _as_int(value: Any, field: str, *, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise InvalidLiteratureSettingError(field, "must be an integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise InvalidLiteratureSettingError(field, "must be an integer") from exc
+    if not minimum <= result <= maximum:
+        raise InvalidLiteratureSettingError(field, f"must be between {minimum} and {maximum}")
+    return result
+
+
+def _normalize(data: Any) -> dict[str, Any]:
+    source = data if isinstance(data, Mapping) else {}
+    raw_sources = source.get("sources", DEFAULTS["sources"])
+    if not isinstance(raw_sources, list):
+        raise InvalidLiteratureSettingError("sources", "must be a list")
+    sources = list(
+        dict.fromkeys(str(item).strip().lower() for item in raw_sources if str(item).strip())
+    )
+    unknown = [item for item in sources if item not in SUPPORTED_SOURCES]
+    if unknown:
+        raise InvalidLiteratureSettingError("sources", f"unsupported source: {unknown[0]}")
+
+    start_year = source.get("start_year")
+    end_year = source.get("end_year")
+    if start_year is not None:
+        start_year = _as_int(start_year, "start_year", minimum=1800, maximum=3000)
+    if end_year is not None:
+        end_year = _as_int(end_year, "end_year", minimum=1800, maximum=3000)
+    if start_year is not None and end_year is not None and start_year > end_year:
+        raise InvalidLiteratureSettingError("year_window", "start_year must not exceed end_year")
+
+    raw_weights = source.get("score_weights", DEFAULTS["score_weights"])
+    if not isinstance(raw_weights, Mapping):
+        raise InvalidLiteratureSettingError("score_weights", "must be an object")
+    weights: dict[str, float] = {}
+    for key, value in raw_weights.items():
+        try:
+            number = float(value)
+        except (TypeError, ValueError) as exc:
+            raise InvalidLiteratureSettingError(f"score_weights.{key}", "must be numeric") from exc
+        if not math.isfinite(number) or number < 0:
+            raise InvalidLiteratureSettingError(
+                f"score_weights.{key}", "must be finite and non-negative"
+            )
+        weights[str(key)] = number
+    if not weights or sum(weights.values()) <= 0:
+        raise InvalidLiteratureSettingError(
+            "score_weights", "at least one positive weight is required"
+        )
+
+    return {
+        "sources": sources,
+        "requested_count": _as_int(
+            source.get("requested_count", 20), "requested_count", minimum=1, maximum=200
+        ),
+        "candidate_budget": _as_int(
+            source.get("candidate_budget", 80), "candidate_budget", minimum=1, maximum=1000
+        ),
+        "start_year": start_year,
+        "end_year": end_year,
+        "score_weights": weights,
+    }
+
+
+def _mask(token: str) -> str:
+    return f"••••{token[-4:]}" if len(token) >= 4 else "••••"
+
+
+def _masked(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    keys = value.get("provider_keys") if isinstance(value, Mapping) else {}
+    result: dict[str, list[dict[str, Any]]] = {}
+    if isinstance(keys, Mapping):
+        for source, pool in keys.items():
+            if isinstance(pool, list):
+                result[str(source)] = [
+                    {
+                        "index": index,
+                        "configured": bool(item),
+                        "preview": _mask(decrypt_secret(str(item))) if item else "••••",
+                    }
+                    for index, item in enumerate(pool)
+                    if item
+                ]
+    return result
+
+
+async def get_settings(session: AsyncSession) -> dict[str, Any]:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    normalized = {**DEFAULTS, **_normalize(value)}
+    normalized["provider_keys"] = _masked(value)
+    normalized["provider_health"] = dict(value.get("provider_health") or {})
+    return normalized
+
+
+async def get_runtime_settings(session: AsyncSession) -> dict[str, Any]:
+    """Return decrypted provider credentials for trusted server-side callers only."""
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    normalized = {**DEFAULTS, **_normalize(value)}
+    encrypted = value.get("provider_keys") if isinstance(value, Mapping) else {}
+    pools: dict[str, list[str]] = {}
+    if isinstance(encrypted, Mapping):
+        for source, items in encrypted.items():
+            if isinstance(items, list):
+                pools[str(source)] = [decrypt_secret(str(item)) for item in items if item]
+    normalized["provider_keys"] = pools
+    return normalized
+
+
+async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dict[str, Any]:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    previous = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    normalized = _normalize({**(previous if isinstance(previous, Mapping) else {}), **dict(data)})
+    if "provider_keys" in data and data["provider_keys"] is not None:
+        raw_pools = data["provider_keys"]
+        if not isinstance(raw_pools, Mapping):
+            raise InvalidLiteratureSettingError("provider_keys", "must be an object")
+        encrypted: dict[str, list[str]] = {}
+        for source, values in raw_pools.items():
+            source_name = str(source).strip().lower()
+            if source_name not in SUPPORTED_SOURCES:
+                raise InvalidLiteratureSettingError(
+                    "provider_keys", f"unsupported source: {source_name}"
+                )
+            if not isinstance(values, list) or any(not str(item).strip() for item in values):
+                raise InvalidLiteratureSettingError(
+                    f"provider_keys.{source_name}", "must be a non-empty string list"
+                )
+            encrypted[source_name] = [encrypt_secret(str(item).strip()) for item in values]
+        normalized["provider_keys"] = encrypted
+    else:
+        normalized["provider_keys"] = (
+            dict(previous.get("provider_keys") or {})
+            if isinstance(previous, Mapping)
+            else {}
+        )
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=normalized))
+    else:
+        row.value = normalized
+    await session.commit()
+    return await get_settings(session)
+
+
+async def record_provider_health(
+    session: AsyncSession, *, source: str, ok: bool, detail: str
+) -> None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
+    health = dict(value.get("provider_health") or {})
+    health[source] = {"ok": ok, "detail": detail[:500], "checked_at": time.time()}
+    value["provider_health"] = health
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -1,0 +1,57 @@
+"""管理员文献检索设置：持久化、脱敏、校验和权限。"""
+
+from tests.conftest import register_and_login
+
+
+async def _admin_and_member(client):
+    admin = await register_and_login(client, email="lit-admin@example.com")
+    member = await register_and_login(client, email="lit-member@example.com")
+    return {"Authorization": f"Bearer {admin}"}, {"Authorization": f"Bearer {member}"}
+
+
+async def test_literature_settings_roundtrip_masks_provider_keys(client):
+    admin, member = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/literature-search",
+        json={
+            "sources": ["openalex", "semantic", "sciverse"],
+            "requested_count": 50,
+            "candidate_budget": 200,
+            "start_year": 2016,
+            "end_year": 2026,
+            "score_weights": {"relevance": 0.7, "quality": 0.3},
+            "provider_keys": {"sciverse": ["sciverse-secret-1234", "sciverse-secret-5678"]},
+        },
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["requested_count"] == 50
+    assert payload["provider_keys"]["sciverse"][0]["preview"] == "••••1234"
+    assert "sciverse-secret-1234" not in response.text
+
+    response = await client.get("/api/admin/settings/literature-search", headers=admin)
+    assert response.status_code == 200
+    assert response.json()["provider_keys"]["sciverse"][1]["configured"] is True
+
+    response = await client.get("/api/admin/settings/literature-search", headers=member)
+    assert response.status_code == 403
+
+
+async def test_literature_settings_reject_invalid_source_and_year_window(client):
+    admin, _ = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/literature-search",
+        json={"sources": ["not-a-provider"]},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_LITERATURE_SETTING:sources" in response.text
+
+    response = await client.put(
+        "/api/admin/settings/literature-search",
+        json={"start_year": 2026, "end_year": 2016},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_LITERATURE_SETTING:year_window" in response.text


### PR DESCRIPTION
Rebase of #478 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 36 files / +5370 to **4 files / +385**. Everything else was already on `main` via #489–#497; what is genuinely new here is `services/literature_settings.py`, its admin endpoints, the schema and its tests.

## Resolutions

All six conflicted files were cases of the branch carrying a pre-#489 copy, so `main`'s versions were kept throughout:

| file | branch vs main |
|---|---|
| `api/paper_assets.py` | `+1/-80` |
| `schemas/paper_assets.py` | `+1/-37` |
| `models/__init__.py` | `+2/-18` |
| `tests/test_migrations.py` | `+8/-73` |
| `worker/tasks.py` | `+10/-33` |
| `d1e2f3a4b5c6_literature_oa_cache.py` | `+2/-2` (pre-rebase parent) |

No new migration, so the chain is untouched.

It reuses the existing admin settings surface rather than introducing a second settings framework, which is what #472's follow-up list asked for.

## Verification

- `alembic heads` → single head `d1e2f3a4b5c6` (unchanged)
- `tests/test_admin_literature_settings.py tests/test_migrations.py tests/test_literature_discovery_runtime.py tests/test_admin_llm.py` → 28 passed
- `ruff check app/ worker/` → clean; `import app.main, worker.settings` → ok

Closes #482. Supersedes #478.