### PR TITLE
feat(literature): add MinerU Cloud parsing lifecycle

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -141,6 +141,42 @@ class Settings(BaseSettings):
             "POLARIS_LITERATURE_SOURCE_RETRIES", "PAPER_SEARCH_SOURCE_RETRIES"
         ),
     )
+    mineru_base_url: str = Field(
+        default="https://mineru.net/api/v4",
+        validation_alias=AliasChoices("POLARIS_MINERU_BASE_URL", "MINERU_BASE_URL"),
+    )
+    mineru_api_tokens: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_MINERU_API_TOKENS", "MINERU_API_TOKENS", "MINERU_API_KEY"
+        ),
+    )
+    mineru_timeout_seconds: float = Field(
+        default=3600.0,
+        gt=30,
+        le=86_400,
+        validation_alias=AliasChoices("POLARIS_MINERU_TIMEOUT_SECONDS", "MINERU_TIMEOUT_SECONDS"),
+    )
+    mineru_poll_interval_seconds: float = Field(
+        default=10.0,
+        ge=1,
+        le=300,
+        validation_alias=AliasChoices(
+            "POLARIS_MINERU_POLL_INTERVAL_SECONDS", "MINERU_POLL_INTERVAL_SECONDS"
+        ),
+    )
+    mineru_retries: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        validation_alias=AliasChoices("POLARIS_MINERU_RETRIES", "MINERU_RETRIES"),
+    )
+    mineru_concurrency: int = Field(
+        default=2,
+        ge=1,
+        le=16,
+        validation_alias=AliasChoices("POLARIS_MINERU_CONCURRENCY", "MINERU_CONCURRENCY"),
+    )
 
     # ---- 邮件（密码重置等事务邮件）----
     # smtp_host 为空 = 关闭发信：忘记密码入口在前端自动隐藏（见 /auth/capabilities）。
@@ -167,6 +203,7 @@ class Settings(BaseSettings):
         "pubmed_api_key",
         "core_api_key",
         "sciverse_api_tokens",
+        "mineru_api_tokens",
         "openai_compat_api_key",
         "anthropic_api_key",
         "github_token",

--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -1,0 +1,204 @@
+"""MinerU Cloud parser adapter used by the versioned PDF lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import re
+import zipfile
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.core.config import get_settings
+
+
+class MineruCloudError(RuntimeError):
+    """A MinerU upload, polling, or result conversion failure."""
+
+
+StatusCallback = Callable[[str], Awaitable[None]]
+
+
+def _tokens(raw: str) -> list[str]:
+    return [item.strip() for item in re.split(r"[,;\s]+", raw or "") if item.strip()]
+
+
+def _find(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
+
+
+def _result_payload(payload: Any) -> Mapping[str, Any] | None:
+    if isinstance(payload, Mapping):
+        for key in ("data", "result", "extract_result", "extractResult"):
+            nested = payload.get(key)
+            if isinstance(nested, Mapping):
+                return nested
+        return payload
+    return None
+
+
+def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
+    text = re.sub(r"\n{3,}", "\n\n", markdown.replace("\r\n", "\n")).strip()
+    if not text:
+        raise MineruCloudError("MINERU_MARKDOWN_EMPTY")
+    chunks: list[dict[str, Any]] = []
+    current_page = 1
+    for block in re.split(r"\n\s*\n", text):
+        block = block.strip()
+        if not block:
+            continue
+        page_match = re.search(r"(?:^|\n)\s*<!--\s*page\s*:?\s*(\d+)\s*-->", block, re.I)
+        if page_match:
+            current_page = int(page_match.group(1))
+        chunks.append(
+            {
+                "text": block,
+                "page_start": current_page,
+                "page_end": current_page,
+                "rects": [],
+                "section_path": [],
+                "anchor_meta": {"parser": "mineru"},
+            }
+        )
+    return {
+        "parser": "mineru",
+        "parser_version": "cloud",
+        "markdown": text,
+        "text": text,
+        "pages": pages or current_page,
+        "chunks": chunks,
+        "manifest": {"pages": pages or current_page, "images": [], "tables": []},
+    }
+
+
+class MineruCloudParser:
+    """Upload a PDF to MinerU Cloud, poll until completion, and normalize Markdown."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        settings = get_settings()
+        self._settings = settings
+        self._client = client or httpx.AsyncClient(timeout=settings.mineru_timeout_seconds)
+        self._owns_client = client is None
+        self._tokens = _tokens(settings.mineru_api_tokens)
+        self._token_index = 0
+        self._semaphore = asyncio.Semaphore(settings.mineru_concurrency)
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    def _next_token(self) -> str:
+        if not self._tokens:
+            raise MineruCloudError("MINERU_NOT_CONFIGURED")
+        token = self._tokens[self._token_index % len(self._tokens)]
+        self._token_index += 1
+        return token
+
+    async def _json(self, method: str, url: str, *, token: str, **kwargs: Any) -> Any:
+        last: Exception | None = None
+        for attempt in range(self._settings.mineru_retries + 1):
+            try:
+                response = await self._client.request(
+                    method,
+                    url,
+                    headers={"Authorization": f"Bearer {token}"},
+                    **kwargs,
+                )
+                response.raise_for_status()
+                return response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                last = exc
+                if attempt < self._settings.mineru_retries:
+                    await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise MineruCloudError(f"MINERU_REQUEST_FAILED:{last}") from last
+
+    async def parse(
+        self, pdf_path: Path, *, on_status: StatusCallback | None = None
+    ) -> dict[str, Any]:
+        async with self._semaphore:
+            token = self._next_token()
+            if on_status:
+                await on_status("mineru_uploading")
+            payload = await self._json(
+                "POST",
+                f"{self._settings.mineru_base_url.rstrip('/')}/file-urls/batch",
+                token=token,
+                json={"files": [{"name": pdf_path.name}]},
+            )
+            data = _result_payload(payload) or {}
+            batch_id = _find(data, "batch_id", "batchId", "id")
+            files = _find(data, "file_urls", "fileUrls", "files") or []
+            if not batch_id or not isinstance(files, list) or not files:
+                raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
+            upload = files[0] if isinstance(files[0], Mapping) else {"url": files[0]}
+            upload_url = _find(upload, "url", "upload_url", "uploadUrl")
+            if not upload_url:
+                raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
+            pdf_bytes = await asyncio.to_thread(pdf_path.read_bytes)
+            response = await self._client.put(
+                str(upload_url), content=pdf_bytes, headers={"Content-Type": "application/pdf"}
+            )
+            response.raise_for_status()
+            if on_status:
+                await on_status("mineru_parsing")
+
+            deadline = asyncio.get_running_loop().time() + self._settings.mineru_timeout_seconds
+            while asyncio.get_running_loop().time() < deadline:
+                result = await self._json(
+                    "GET",
+                    f"{self._settings.mineru_base_url.rstrip('/')}/extract-results/batch/{batch_id}",
+                    token=token,
+                )
+                parsed = _result_payload(result) or {}
+                rows = _find(parsed, "extract_result_list", "extractResultList", "files") or []
+                row = rows[0] if isinstance(rows, list) and rows else parsed
+                if isinstance(row, Mapping):
+                    state = str(_find(row, "state", "status") or "").lower()
+                    if state in {"done", "success", "succeeded", "completed"}:
+                        markdown_url = _find(row, "markdown_url", "markdownUrl", "md_url", "mdUrl")
+                        if markdown_url:
+                            md_response = await self._client.get(str(markdown_url))
+                            md_response.raise_for_status()
+                            return _markdown_result(
+                                md_response.text,
+                                pages=int(_find(row, "page_count", "pageCount") or 0),
+                            )
+                        zip_url = _find(row, "full_zip_url", "fullZipUrl", "zip_url", "zipUrl")
+                        if zip_url:
+                            archive = await self._client.get(str(zip_url))
+                            archive.raise_for_status()
+                            with zipfile.ZipFile(io.BytesIO(archive.content)) as bundle:
+                                md_name = next(
+                                    (
+                                        name
+                                        for name in bundle.namelist()
+                                        if name.lower().endswith(".md")
+                                    ),
+                                    None,
+                                )
+                                if md_name:
+                                    return _markdown_result(
+                                        bundle.read(md_name).decode("utf-8", errors="replace")
+                                    )
+                        raise MineruCloudError("MINERU_RESULT_URL_MISSING")
+                    if state in {"failed", "error", "failure"}:
+                        raise MineruCloudError(
+                            str(
+                                _find(row, "err_msg", "error", "message")
+                                or "MINERU_PARSE_FAILED"
+                            )
+                        )
+                await asyncio.sleep(self._settings.mineru_poll_interval_seconds)
+            raise MineruCloudError("MINERU_TIMEOUT")
+
+    async def __call__(self, pdf_path: Path) -> dict[str, Any]:
+        try:
+            return await self.parse(pdf_path)
+        finally:
+            await self.aclose()

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -138,7 +138,7 @@ async def parse_content_version(
         raise ContentParseError("PDF_FILE_MISSING")
 
     version.attempt += 1
-    version.status = "parsing"
+    version.status = "mineru_uploading" if version.parser == "mineru" else "parsing"
     version.error_code = None
     version.error_detail = None
     await session.commit()
@@ -147,8 +147,25 @@ async def parse_content_version(
     parser_name = version.parser
     try:
         if mineru_parser is None:
-            raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
-        result = await mineru_parser(pdf_path)
+            if version.parser == "mineru":
+                from app.services.mineru import MineruCloudParser
+
+                mineru_parser = MineruCloudParser()
+            else:
+                raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
+        if hasattr(mineru_parser, "parse"):
+            async def update_status(value: str) -> None:
+                version.status = value
+                await session.commit()
+
+            try:
+                result = await mineru_parser.parse(pdf_path, on_status=update_status)  # type: ignore[attr-defined]
+            finally:
+                close = getattr(mineru_parser, "aclose", None)
+                if close is not None:
+                    await close()
+        else:
+            result = await mineru_parser(pdf_path)
         parser_name = "mineru"
     except Exception as exc:  # noqa: BLE001 - fallback is an explicit policy
         if not allow_fallback:

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -1,0 +1,73 @@
+"""MinerU Cloud upload/poll normalization contract tests."""
+
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.mineru import MineruCloudParser
+
+
+class FakeMineruClient:
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+
+    async def request(self, method, url, **_kwargs):
+        self.calls.append((method, url))
+        if method == "POST":
+            return FakeResponse(
+                json_data={"data": {"batch_id": "batch-1", "file_urls": [{"url": "https://upload"}]}},
+            )
+        return FakeResponse(
+            json_data={
+                "data": {
+                    "extract_result_list": [
+                        {"state": "done", "markdown_url": "https://markdown", "page_count": 2}
+                    ]
+                }
+            },
+        )
+
+    async def put(self, url, **_kwargs):
+        self.calls.append(("PUT", url))
+        return FakeResponse()
+
+    async def get(self, url, **_kwargs):
+        self.calls.append(("GET", url))
+        return FakeResponse(text="# Heading\n\nFull text from MinerU")
+
+
+class FakeResponse:
+    def __init__(self, *, json_data=None, text=""):
+        self._json_data = json_data
+        self.text = text
+        self.content = text.encode("utf-8")
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.asyncio
+async def test_mineru_cloud_upload_poll_and_normalize(tmp_path: Path, monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "mineru_api_tokens", "key-a,key-b", raising=False)
+    monkeypatch.setattr(settings, "mineru_poll_interval_seconds", 0.01, raising=False)
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-test")
+    client = FakeMineruClient()
+    statuses: list[str] = []
+
+    async def on_status(value: str) -> None:
+        statuses.append(value)
+
+    parser = MineruCloudParser(client=client)
+    result = await parser.parse(pdf, on_status=on_status)
+
+    assert result["parser"] == "mineru"
+    assert result["pages"] == 2
+    assert result["chunks"]
+    assert statuses == ["mineru_uploading", "mineru_parsing"]
+    assert [method for method, _url in client.calls] == ["POST", "PUT", "GET", "GET"]


### PR DESCRIPTION
Rebase of #479 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 42 files / +6552 to **4 files / +334** — the adapter, its config, the parse-path wiring and its tests. Everything else was already on `main` via #489–#498.

## Two resolutions kept `main`'s side

**The migration.** The branch carries its own `d9e0f1a2b3c4` chaining from `d1e2f3a4b5c6`:

```
main:    c8d9e0f1a2b3 → d9e0f1a2b3c4 → … → d1e2f3a4b5c6
branch:  c8d9e0f1a2b3 → d1e2f3a4b5c6 → d9e0f1a2b3c4
```

Same revision id, opposite order — the second of the two contradictory definitions I flagged on #472. `main`'s copy kept.

**`worker/tasks.py`.** The branch removes the `vectorize_content_version` call from the parse task:

```diff
-        try:
-            await vectorize_content_version(
-                session,
-                version=version,
-                ...
-            )
```

Nothing replaces it, so vectors would simply stop being built after a parse — no exception, no failing test, and the only visible symptom would be search quietly degrading later. Its one genuine addition to that file, `run_literature_discovery`, is already on `main` via #495, so `main`'s version is kept unchanged.

If dropping vectorization there was deliberate — moved into the MinerU path, or deferred — say so and I will land that as its own change; it should not ride along inside a rebase.

## Verification

- `alembic heads` → single head `d1e2f3a4b5c6` (unchanged)
- `tests/test_mineru.py tests/test_paper_content.py tests/test_migrations.py tests/test_literature_discovery_runtime.py` → 12 passed
- `ruff check app/ worker/` → clean; `import app.main, worker.settings` → ok

Closes #484. Supersedes #479.