### PR TITLE
feat(ai): query versioned full text with evidence

### DIFF
--- a/src/backend/app/services/evidence.py
+++ b/src/backend/app/services/evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import unicodedata
 import uuid
@@ -10,15 +11,20 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import exists, select
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.evidence import PaperEvidenceAnchor
+from app.models.library_direction import LibraryPaper
+from app.models.paper_assets import AssetGrant
 from app.models.paper_content import PaperContentChunk, PaperContentVersion
 from app.schemas.evidence import EvidenceResolution
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?。！？])(?:[\"'”’»\)\]]+)?\s+|\n+")
 _JOINED_HYPHEN = "\ufff0"
+_WORD_RE = re.compile(r"[\w\u4e00-\u9fff]+")
+_READY_CONTENT_STATUSES = ("ready", "ready_fallback", "vector_ready")
 
 
 def normalize_evidence_text(value: str) -> str:
@@ -62,7 +68,10 @@ class AnchorPayload:
 
 
 def _locator(
-    *, page_start: int | None, page_end: int | None, rects: list[dict[str, float]] | None
+    *,
+    page_start: int | None,
+    page_end: int | None,
+    rects: list[dict[str, float]] | None,
 ) -> dict[str, Any]:
     value: dict[str, Any] = {}
     if page_start is not None:
@@ -100,7 +109,7 @@ def build_chunk_anchor_payloads(
     payloads = [
         AnchorPayload(
             **common,
-            anchor_key=f"chunk:{seq if seq is not None else 'na'}",
+            anchor_key=f"chunk:{chunk_id or 'na'}:{seq if seq is not None else 'na'}",
             anchor_type="chunk",
             paragraph_index=None,
             sentence_index=None,
@@ -113,7 +122,10 @@ def build_chunk_anchor_payloads(
         payloads.append(
             AnchorPayload(
                 **common,
-                anchor_key=f"paragraph:{seq if seq is not None else 'na'}:{paragraph_index}",
+                anchor_key=(
+                    f"paragraph:{chunk_id or 'na'}:"
+                    f"{seq if seq is not None else 'na'}:{paragraph_index}"
+                ),
                 anchor_type="paragraph",
                 paragraph_index=paragraph_index,
                 sentence_index=None,
@@ -127,7 +139,7 @@ def build_chunk_anchor_payloads(
                 AnchorPayload(
                     **common,
                     anchor_key=(
-                        f"sentence:{seq if seq is not None else 'na'}:"
+                        f"sentence:{chunk_id or 'na'}:{seq if seq is not None else 'na'}:"
                         f"{paragraph_index}:{sentence_index}"
                     ),
                     anchor_type="sentence",
@@ -198,7 +210,11 @@ def _href(paper_id: uuid.UUID, anchor_id: uuid.UUID | None) -> str:
 
 
 def _resolution(
-    anchor: PaperEvidenceAnchor, *, status: str, anchor_type: str, quoted_text: str
+    anchor: PaperEvidenceAnchor,
+    *,
+    status: str,
+    anchor_type: str,
+    quoted_text: str,
 ) -> EvidenceResolution:
     page_start, page_end, rects = _locator_values(anchor)
     return EvidenceResolution(
@@ -237,22 +253,31 @@ async def resolve_evidence_anchor(
                         PaperContentVersion.is_current.is_(True),
                     )
                 )
-            ).scalars()
+            )
+            .scalars()
         )
     current = next((chunk for chunk in chunks if chunk.id == anchor.chunk_id), None)
     if current is not None and content_revision(current.text) == anchor.content_revision:
         return _resolution(
-            anchor, status="exact", anchor_type=anchor.anchor_type, quoted_text=anchor.quoted_text
+            anchor,
+            status="exact",
+            anchor_type=anchor.anchor_type,
+            quoted_text=anchor.quoted_text,
         )
     needle = anchor.normalized_text
     for chunk in chunks:
         normalized = normalize_evidence_text(chunk.text)
         if needle and (needle in normalized or normalized in needle):
             status = (
-                anchor.anchor_type if anchor.anchor_type in {"sentence", "paragraph"} else "chunk"
+                anchor.anchor_type
+                if anchor.anchor_type in {"sentence", "paragraph"}
+                else "chunk"
             )
             return _resolution(
-                anchor, status=status, anchor_type=status, quoted_text=anchor.quoted_text
+                anchor,
+                status=status,
+                anchor_type=status,
+                quoted_text=anchor.quoted_text,
             )
     if current is not None:
         return _resolution(anchor, status="chunk", anchor_type="chunk", quoted_text=current.text)
@@ -264,3 +289,291 @@ async def resolve_evidence_anchor(
         quoted_text=anchor.quoted_text,
         href=_href(anchor.paper_id, anchor.id),
     )
+
+
+async def current_fulltext_evidence(
+    session: AsyncSession,
+    *,
+    paper_id: uuid.UUID,
+    library_ids: Sequence[uuid.UUID] | None = None,
+    query: str | None = None,
+    offset: int = 0,
+    limit: int = 8,
+) -> dict[str, Any] | None:
+    """Return current parsed chunks with sentence anchors for agent and MCP tools."""
+    version_query = select(PaperContentVersion).where(
+            PaperContentVersion.paper_id == paper_id,
+            PaperContentVersion.is_current.is_(True),
+            PaperContentVersion.status.in_(_READY_CONTENT_STATUSES),
+        )
+    if library_ids is not None:
+        if not library_ids:
+            return None
+        version_query = version_query.where(_asset_grant_exists(library_ids))
+    version = await session.scalar(version_query)
+    if version is None:
+        return None
+    chunks = list(
+        (
+            await session.execute(
+                select(PaperContentChunk)
+                .where(PaperContentChunk.content_version_id == version.id)
+                .order_by(PaperContentChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if query:
+        terms = {part for part in normalize_evidence_text(query).split() if len(part) > 1}
+        chunks.sort(
+            key=lambda chunk: (
+                -sum(term in normalize_evidence_text(chunk.text) for term in terms),
+                chunk.seq,
+            )
+        )
+    selected = chunks[max(0, offset) : max(0, offset) + max(1, min(limit, 20))]
+    if not selected:
+        return {
+            "version_id": str(version.id),
+            "parser": version.parser,
+            "chunks": [],
+            "next_offset": None,
+        }
+    anchors = list(
+        (
+            await session.execute(
+                select(PaperEvidenceAnchor)
+                .where(
+                    PaperEvidenceAnchor.chunk_id.in_([chunk.id for chunk in selected]),
+                    PaperEvidenceAnchor.anchor_type == "sentence",
+                )
+                .order_by(
+                    PaperEvidenceAnchor.seq,
+                    PaperEvidenceAnchor.paragraph_index,
+                    PaperEvidenceAnchor.sentence_index,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_chunk: dict[uuid.UUID, list[PaperEvidenceAnchor]] = {}
+    for anchor in anchors:
+        by_chunk.setdefault(anchor.chunk_id, []).append(anchor)
+    rows: list[dict[str, Any]] = []
+    citation_no = 0
+    for chunk in selected:
+        references = []
+        for anchor in by_chunk.get(chunk.id, []):
+            citation_no += 1
+            page_start, page_end, rects = _locator_values(anchor)
+            references.append(
+                {
+                    "citation_no": citation_no,
+                    "anchor_id": str(anchor.id),
+                    "quoted_text": anchor.quoted_text,
+                    "page_start": page_start,
+                    "page_end": page_end,
+                    "rects": rects,
+                    "href": _href(paper_id, anchor.id),
+                }
+            )
+        rows.append(
+            {
+                "chunk_id": str(chunk.id),
+                "seq": chunk.seq,
+                "text": chunk.text,
+                "page_start": chunk.page_start,
+                "page_end": chunk.page_end,
+                "evidence": references,
+            }
+        )
+    next_offset = offset + len(selected) if offset + len(selected) < len(chunks) else None
+    return {
+        "version_id": str(version.id),
+        "parser": version.parser,
+        "chunks": rows,
+        "next_offset": next_offset,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class FulltextChunkHit:
+    chunk: PaperContentChunk
+    paper_id: uuid.UUID
+    score: float
+
+
+def fulltext_vector_search_supported(session: AsyncSession) -> bool:
+    return session.get_bind().dialect.name == "postgresql"
+
+
+def _library_scope_exists(library_ids: Sequence[uuid.UUID]):
+    from app.services.papers import PAPER_STATUS_GROUPS
+
+    return exists(
+        select(LibraryPaper.paper_id).where(
+            LibraryPaper.paper_id == PaperContentVersion.paper_id,
+            LibraryPaper.library_id.in_(library_ids),
+            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+        )
+    )
+
+
+def _asset_grant_exists(library_ids: Sequence[uuid.UUID]):
+    return exists(
+        select(AssetGrant.id).where(
+            AssetGrant.asset_id == PaperContentVersion.asset_id,
+            AssetGrant.library_id.in_(library_ids),
+            AssetGrant.status == "active",
+            AssetGrant.can_read.is_(True),
+        )
+    )
+
+
+async def keyword_search_current_fulltext(
+    session: AsyncSession,
+    *,
+    library_ids: Sequence[uuid.UUID],
+    query: str,
+    limit: int,
+) -> list[FulltextChunkHit]:
+    """Search current parsed content without selecting JSON columns through DISTINCT."""
+    if not library_ids:
+        return []
+    terms = [term for term in _WORD_RE.findall(query.casefold()) if len(term) >= 2][:8]
+    if not terms:
+        return []
+    condition = PaperContentChunk.text.ilike(f"%{terms[0]}%")
+    for term in terms[1:]:
+        condition |= PaperContentChunk.text.ilike(f"%{term}%")
+    rows = (
+        await session.execute(
+            select(PaperContentChunk, PaperContentVersion.paper_id)
+            .join(
+                PaperContentVersion,
+                PaperContentVersion.id == PaperContentChunk.content_version_id,
+            )
+            .where(
+                PaperContentVersion.is_current.is_(True),
+                PaperContentVersion.status.in_(_READY_CONTENT_STATUSES),
+                _library_scope_exists(library_ids),
+                _asset_grant_exists(library_ids),
+                condition,
+            )
+            .limit(max(1, limit) * 5)
+        )
+    ).all()
+
+    def score_of(chunk: PaperContentChunk) -> float:
+        lowered = chunk.text.casefold()
+        return float(sum(term in lowered for term in terms))
+
+    hits = [
+        FulltextChunkHit(chunk=chunk, paper_id=paper_id, score=score_of(chunk))
+        for chunk, paper_id in rows
+    ]
+    return sorted(hits, key=lambda hit: (-hit.score, hit.chunk.seq))[:limit]
+
+
+async def semantic_search_current_fulltext(
+    session: AsyncSession,
+    *,
+    library_ids: Sequence[uuid.UUID],
+    query_vector: list[float],
+    space_key: str,
+    limit: int,
+) -> list[FulltextChunkHit]:
+    """Search current full-text vectors with permission checks in correlated EXISTS."""
+    if not library_ids or not fulltext_vector_search_supported(session):
+        return []
+    from app.services.papers import PAPER_STATUS_GROUPS
+
+    rows = (
+        await session.execute(
+            sa_text(
+                "SELECT c.id, cv.paper_id, "
+                "1 - (v.embedding <=> CAST(:qv AS vector)) AS score "
+                "FROM paper_content_chunk_vectors v "
+                "JOIN paper_content_chunks c ON c.id = v.chunk_id "
+                "JOIN paper_content_versions cv ON cv.id = c.content_version_id "
+                "WHERE v.space = :space AND cv.is_current = true "
+                "AND cv.status = ANY(CAST(:content_statuses AS varchar[])) "
+                "AND EXISTS (SELECT 1 FROM library_papers lp "
+                "WHERE lp.paper_id = cv.paper_id "
+                "AND lp.library_id = ANY(CAST(:libs AS uuid[])) "
+                "AND lp.status = ANY(CAST(:paper_statuses AS varchar[]))) "
+                "AND EXISTS (SELECT 1 FROM asset_grants ag "
+                "WHERE ag.asset_id = cv.asset_id "
+                "AND ag.library_id = ANY(CAST(:libs AS uuid[])) "
+                "AND ag.status = 'active' AND ag.can_read = true) "
+                "ORDER BY score DESC LIMIT :k"
+            ),
+            {
+                "qv": json.dumps(query_vector),
+                "space": space_key,
+                "libs": [str(value) for value in library_ids],
+                "content_statuses": list(_READY_CONTENT_STATUSES),
+                "paper_statuses": list(PAPER_STATUS_GROUPS["library"]),
+                "k": max(1, limit),
+            },
+        )
+    ).all()
+    if not rows:
+        return []
+    scores = {row.id: float(row.score) for row in rows}
+    paper_ids = {row.id: row.paper_id for row in rows}
+    chunks = list(
+        (
+            await session.execute(
+                select(PaperContentChunk).where(PaperContentChunk.id.in_(scores))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_id = {chunk.id: chunk for chunk in chunks}
+    return [
+        FulltextChunkHit(
+            chunk=by_id[row.id],
+            paper_id=paper_ids[row.id],
+            score=scores[row.id],
+        )
+        for row in rows
+        if row.id in by_id
+    ]
+
+
+async def sentence_evidence_for_chunks(
+    session: AsyncSession,
+    chunks: Sequence[PaperContentChunk],
+) -> dict[uuid.UUID, list[dict[str, Any]]]:
+    if not chunks:
+        return {}
+    anchors = list(
+        (
+            await session.execute(
+                select(PaperEvidenceAnchor).where(
+                    PaperEvidenceAnchor.chunk_id.in_([chunk.id for chunk in chunks]),
+                    PaperEvidenceAnchor.anchor_type == "sentence",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    result: dict[uuid.UUID, list[dict[str, Any]]] = {}
+    for anchor in anchors:
+        page_start, page_end, rects = _locator_values(anchor)
+        result.setdefault(anchor.chunk_id, []).append(
+            {
+                "anchor_id": str(anchor.id),
+                "quoted_text": anchor.quoted_text,
+                "page_start": page_start,
+                "page_end": page_end,
+                "rects": rects,
+                "href": _href(anchor.paper_id, anchor.id),
+            }
+        )
+    return result

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -21,6 +21,7 @@ from app.models.paper_content import (
     PaperContentVersion,
     PaperContentVersionVector,
 )
+from app.services.evidence import persist_chunk_anchors
 from app.services.paper_assets import storage_path_for_blob
 
 logger = logging.getLogger(__name__)
@@ -214,22 +215,30 @@ async def parse_content_version(
             PaperContentChunk.content_version_id == version.id
         )
     )
+    persisted_chunks: list[PaperContentChunk] = []
     for seq, item in enumerate(chunks):
         chunk_text = _clean_text(str(item.get("text") or ""))
         if not chunk_text:
             continue
-        session.add(
-            PaperContentChunk(
-                content_version_id=version.id,
-                seq=seq,
-                text=chunk_text,
-                page_start=item.get("page_start"),
-                page_end=item.get("page_end"),
-                rects=item.get("rects") or [],
-                section_path=item.get("section_path") or [],
-                anchor_meta=item.get("anchor_meta") or {},
-            )
+        chunk = PaperContentChunk(
+            content_version_id=version.id,
+            seq=seq,
+            text=chunk_text,
+            page_start=item.get("page_start"),
+            page_end=item.get("page_end"),
+            rects=item.get("rects") or [],
+            section_path=item.get("section_path") or [],
+            anchor_meta=item.get("anchor_meta") or {},
         )
+        session.add(chunk)
+        persisted_chunks.append(chunk)
+    await session.flush()  # chunk.id 供锚点引用
+    await persist_chunk_anchors(
+        session,
+        paper_id=version.paper_id,
+        chunks=persisted_chunks,
+        source=parser_name,
+    )
     version.parser = parser_name
     version.parser_version = str(
         result.get("parser_version") or version.parser_version or "unknown"

--- a/src/backend/app/tools/knowledge.py
+++ b/src/backend/app/tools/knowledge.py
@@ -13,6 +13,13 @@ from app.services import chunks as chunks_service
 from app.services import graph as graph_service
 from app.services import search as search_service
 from app.services.embedding import embed_query
+from app.services.evidence import (
+    FulltextChunkHit,
+    fulltext_vector_search_supported,
+    keyword_search_current_fulltext,
+    semantic_search_current_fulltext,
+    sentence_evidence_for_chunks,
+)
 from app.tools.context import ToolContext
 from app.tools.registry import tool
 from app.tools.scope import library_ids_for, readable_paper
@@ -44,12 +51,16 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
 
     async with get_sessionmaker()() as session:
         library_ids = await library_ids_for(session, ctx)
+        fulltext_rows: list[FulltextChunkHit] = []
         rows: list[tuple[PaperChunk, float]] = []
         used_mode = "keyword"
         if (
             mode == "semantic"
             and library_ids
-            and chunks_service.chunk_vector_search_supported(session)
+            and (
+                fulltext_vector_search_supported(session)
+                or chunks_service.chunk_vector_search_supported(session)
+            )
         ):
             try:
                 vector, space = await embed_query(
@@ -59,24 +70,56 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
                     project_id=ctx.project_id,
                     voyage_id=ctx.voyage_id,
                 )
-                rows = await chunks_service.semantic_search_chunks(
-                    session,
-                    library_ids=library_ids,
-                    query_vector=vector,
-                    space=space,
-                    limit=k,
-                )
-                used_mode = "semantic"
             except Exception:  # noqa: BLE001 — embedding 服务挂了也要能用，降级到关键词
-                rows = []
-        if not rows and library_ids:
-            rows = await chunks_service.keyword_search_chunks(
-                session, library_ids=library_ids, q=query, limit=k
+                vector = None
+                space = None
+            if vector is not None and space is not None:
+                try:
+                    fulltext_rows = await semantic_search_current_fulltext(
+                        session,
+                        library_ids=library_ids,
+                        query_vector=vector,
+                        space_key=space.key,
+                        limit=k,
+                    )
+                except Exception:  # noqa: BLE001 — 版本化索引失败时保留旧索引兜底
+                    fulltext_rows = []
+                try:
+                    if len(fulltext_rows) < k:
+                        rows = await chunks_service.semantic_search_chunks(
+                            session,
+                            library_ids=library_ids,
+                            query_vector=vector,
+                            space=space,
+                            limit=k,
+                        )
+                except Exception:  # noqa: BLE001 — 旧索引失败不丢弃已命中的版本化全文
+                    rows = []
+                if fulltext_rows or rows:
+                    used_mode = "semantic"
+        if not fulltext_rows and not rows and library_ids:
+            fulltext_rows = await keyword_search_current_fulltext(
+                session, library_ids=library_ids, query=query, limit=k
             )
-            used_mode = used_mode if rows and used_mode == "semantic" else "keyword"
+            if len(fulltext_rows) < k:
+                rows = await chunks_service.keyword_search_chunks(
+                    session, library_ids=library_ids, q=query, limit=k
+                )
+            used_mode = "keyword"
+
+        versioned_paper_ids = {hit.paper_id for hit in fulltext_rows}
+        rows = [
+            (chunk, score)
+            for chunk, score in rows
+            if chunk.paper_id not in versioned_paper_ids
+        ]
+        rows = rows[: max(0, k - len(fulltext_rows))]
+        evidence = await sentence_evidence_for_chunks(
+            session, [hit.chunk for hit in fulltext_rows]
+        )
 
         # 补论文标题（一次批量查询，避免 N+1）
-        paper_ids = {c.paper_id for c, _ in rows}
+        paper_ids = versioned_paper_ids | {c.paper_id for c, _ in rows}
         titles: dict[uuid.UUID, str] = {}
         if paper_ids:
             title_rows = await session.execute(
@@ -87,6 +130,18 @@ async def search_chunks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
     return {
         "mode": used_mode,
         "chunks": [
+            {
+                "paper_id": str(hit.paper_id),
+                "title": titles.get(hit.paper_id),
+                "seq": hit.chunk.seq,
+                "text": (hit.chunk.text or "")[:_CHUNK_CHARS],
+                "score": round(float(hit.score), 3),
+                "content_version_id": str(hit.chunk.content_version_id),
+                "evidence": evidence.get(hit.chunk.id, []),
+            }
+            for hit in fulltext_rows
+        ]
+        + [
             {
                 "paper_id": str(c.paper_id),
                 "title": titles.get(c.paper_id),

--- a/src/backend/app/tools/literature.py
+++ b/src/backend/app/tools/literature.py
@@ -17,6 +17,7 @@ from app.services import concepts as concepts_service
 from app.services import papers as papers_service
 from app.services.concepts import library_concept_ids
 from app.services.embedding import embed_query
+from app.services.evidence import current_fulltext_evidence
 from app.services.paper_review import relevant_excerpt
 from app.services.papers import PaperView
 from app.tools.context import ToolContext
@@ -168,6 +169,30 @@ def _read_fulltext_summary(a: dict[str, Any], r: dict[str, Any]) -> str:
 async def read_fulltext(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         paper = await _get_project_paper(session, ctx, args.get("paper_id"))
+        library_ids = await library_ids_for(session, ctx)
+        query = str(args.get("query") or "").strip()
+        page = max(0, int(args.get("page") or 0))
+        parsed = await current_fulltext_evidence(
+            session,
+            paper_id=paper.id,
+            library_ids=library_ids,
+            query=query or None,
+            offset=page * 8,
+            limit=8,
+        )
+        if parsed is not None and parsed["chunks"]:
+            chunks = parsed["chunks"]
+            return {
+                "paper_id": str(paper.id),
+                "title": paper.title,
+                "query": query or None,
+                "page": page,
+                "parser": parsed["parser"],
+                "content_version_id": parsed["version_id"],
+                "text": "\n\n".join(str(chunk["text"]) for chunk in chunks)[:_FULLTEXT_PAGE_CHARS],
+                "evidence": [ref for chunk in chunks for ref in chunk["evidence"]],
+                "next_page": page + 1 if parsed["next_offset"] is not None else None,
+            }
         path = Path(paper.full_text_path) if paper.full_text_path else None
         title = paper.title
         paper_id = str(paper.id)
@@ -181,7 +206,6 @@ async def read_fulltext(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any
             }
         full_text = path.read_text(encoding="utf-8", errors="ignore")
 
-    query = str(args.get("query") or "").strip()
     if query:
         return {
             "paper_id": paper_id,

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -9,12 +9,17 @@ from app.core.db import get_sessionmaker
 from app.core.embedding_space import EmbeddingSpace
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import new_paper
+from app.models.paper_assets import AssetGrant
 from app.models.paper_content import (
     PaperContentChunkVector,
     PaperContentVersion,
     PaperContentVersionVector,
 )
 from app.models.user import User
+from app.services.evidence import (
+    current_fulltext_evidence,
+    keyword_search_current_fulltext,
+)
 from app.services.paper_assets import create_or_reuse_asset
 from app.services.paper_content import (
     ContentParseError,
@@ -72,6 +77,15 @@ async def test_mineru_failure_falls_back_to_pymupdf_and_persists_version(app, cl
         assert parsed.chunk_count == 1
         assert parsed.attempt == 1
         assert await current_content_version(session, paper_id=paper.id)
+        context = await current_fulltext_evidence(
+            session, paper_id=paper.id, query="full text", limit=4
+        )
+        assert context is not None
+        assert context["parser"] == "pymupdf"
+        assert context["chunks"][0]["text"]
+        assert context["chunks"][0]["evidence"][0]["href"].startswith(
+            f"/papers/{paper.id}/read?evidence=1"
+        )
 
 
 @pytest.mark.asyncio
@@ -82,6 +96,7 @@ async def test_reparse_creates_new_current_version_without_mutating_old(app, cli
         await parse_content_version(session, version=first, mineru_parser=None)
         second = await create_content_version(session, asset=asset)
         assert second.version_no == first.version_no + 1
+        await parse_content_version(session, version=second, mineru_parser=None)
         await session.refresh(first)
         assert first.is_current is False
         assert second.is_current is True
@@ -89,6 +104,43 @@ async def test_reparse_creates_new_current_version_without_mutating_old(app, cli
             select(PaperContentVersion).where(PaperContentVersion.id == first.id)
         )
         assert saved is not None and saved.is_current is False
+        context = await current_fulltext_evidence(session, paper_id=paper.id)
+        assert context is not None
+        assert context["version_id"] == str(second.id)
+        assert context["chunks"][0]["evidence"]
+
+
+@pytest.mark.asyncio
+async def test_current_fulltext_search_enforces_asset_grant(app, client):
+    _user_row, library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+        await parse_content_version(session, version=version, mineru_parser=None)
+        hits = await keyword_search_current_fulltext(
+            session,
+            library_ids=[library.id],
+            query="full text",
+            limit=4,
+        )
+        assert len(hits) == 1
+        assert hits[0].paper_id == asset.paper_id
+
+        grant = await session.scalar(
+            select(AssetGrant).where(
+                AssetGrant.asset_id == asset.id,
+                AssetGrant.library_id == library.id,
+            )
+        )
+        assert grant is not None
+        grant.can_read = False
+        await session.flush()
+        denied = await keyword_search_current_fulltext(
+            session,
+            library_ids=[library.id],
+            query="full text",
+            limit=4,
+        )
+        assert denied == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Rebase of #485 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS.

Diff reduced from 26 files / +2729 to **6 files / +491**.

## One hand merge

`services/paper_content.py` could not be resolved by taking a side. The branch's copy is the pre-MinerU stub that #499 replaced — but it also carries this PR's real change: collecting the chunks it creates and calling `persist_chunk_anchors` once they exist.

`main`'s MinerU version is kept and that call grafted onto it:

```python
        session.add(chunk)
        persisted_chunks.append(chunk)
    await session.flush()  # chunk.id 供锚点引用
    await persist_chunk_anchors(
        session,
        paper_id=version.paper_id,
        chunks=persisted_chunks,
        source=parser_name,
    )
```

The explicit `flush()` is needed because the anchors reference `chunk.id`, and `source=parser_name` rather than `version.parser` because `version.parser` is assigned a few lines further down — reading it here would record the previous parser.

## The evidence.py conflict was cosmetic

`services/evidence.py` showed `+324/-11`, but every one of the eleven removed lines is a re-wrap. That file was reformatted when #493 landed (it had six lines over the 100-column limit and had never been linted), so the branch's copy differs from `main` by layout, not content. Took the branch's version for the genuine +324 and re-ran the formatter.

## Verification

- `alembic heads` → single head `d1e2f3a4b5c6` (unchanged)
- `tests/test_paper_content.py tests/test_evidence_anchors.py tests/test_mineru.py tests/test_ai_evidence_context.py tests/test_migrations.py` → 14 passed
- `ruff check app/ worker/` → clean; `import app.main` → ok

Closes #487. Supersedes #485.