### PR TITLE
feat(interdisciplinary): add research profiles and linked literature libraries

### DIFF
--- a/src/backend/alembic/versions/257c979a4b99_publication_paper_link.py
+++ b/src/backend/alembic/versions/257c979a4b99_publication_paper_link.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-21 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/alembic/versions/57e55702bcca_user_library_entries.py
+++ b/src/backend/alembic/versions/57e55702bcca_user_library_entries.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-21 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/alembic/versions/581d172bd41b_conversations.py
+++ b/src/backend/alembic/versions/581d172bd41b_conversations.py
@@ -15,8 +15,9 @@ Revises: 78e222c38b3b
 """
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
 
 revision: str = "581d172bd41b"
 down_revision: str | None = "78e222c38b3b"

--- a/src/backend/alembic/versions/877da11ed6b4_add_compiled_model_to_papers.py
+++ b/src/backend/alembic/versions/877da11ed6b4_add_compiled_model_to_papers.py
@@ -8,8 +8,8 @@ Create Date: 2026-07-21 08:46:49.463027
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '877da11ed6b4'

--- a/src/backend/alembic/versions/8b3b904e7588_library_wiki_snapshot.py
+++ b/src/backend/alembic/versions/8b3b904e7588_library_wiki_snapshot.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-21 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/alembic/versions/a1b2c3d4e5f6_ssh_credential_proxy.py
+++ b/src/backend/alembic/versions/a1b2c3d4e5f6_ssh_credential_proxy.py
@@ -6,6 +6,7 @@ Create Date: 2026-07-15
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision = "a1b2c3d4e5f6"

--- a/src/backend/alembic/versions/a1c9e73b5d20_view_events.py
+++ b/src/backend/alembic/versions/a1c9e73b5d20_view_events.py
@@ -9,6 +9,7 @@ Create Date: 2026-08-06
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "a1c9e73b5d20"

--- a/src/backend/alembic/versions/b3f5c1e07a92_user_read_only.py
+++ b/src/backend/alembic/versions/b3f5c1e07a92_user_read_only.py
@@ -9,6 +9,7 @@ Create Date: 2026-08-06
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "b3f5c1e07a92"

--- a/src/backend/alembic/versions/c31f7a9d40b2_buddy_memories.py
+++ b/src/backend/alembic/versions/c31f7a9d40b2_buddy_memories.py
@@ -10,6 +10,7 @@ Create Date: 2026-08-05
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "c31f7a9d40b2"

--- a/src/backend/alembic/versions/c98c3216fc0a_user_publications.py
+++ b/src/backend/alembic/versions/c98c3216fc0a_user_publications.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-21 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/backend/alembic/versions/d4e8b19c7a55_memory_kind.py
+++ b/src/backend/alembic/versions/d4e8b19c7a55_memory_kind.py
@@ -9,6 +9,7 @@ Create Date: 2026-08-05
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "d4e8b19c7a55"

--- a/src/backend/alembic/versions/d800d34cd207_voyage_terminal_logs.py
+++ b/src/backend/alembic/versions/d800d34cd207_voyage_terminal_logs.py
@@ -9,8 +9,8 @@ Create Date: 2026-07-21 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d800d34cd207"

--- a/src/backend/alembic/versions/e9f0a1b2c3d4_interdisciplinary_profiles.py
+++ b/src/backend/alembic/versions/e9f0a1b2c3d4_interdisciplinary_profiles.py
@@ -1,0 +1,114 @@
+"""Persist interdisciplinary project profiles and dedicated library markers."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e9f0a1b2c3d4"
+down_revision: str | None = "d1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    # SQLite 不支持 ALTER 约束，加带外键的列必须走 batch（仓库既有迁移同此写法）。
+    with op.batch_alter_table("projects") as batch:
+        batch.add_column(
+            sa.Column(
+                "research_mode", sa.String(24), nullable=False, server_default="conventional"
+            )
+        )
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.add_column(
+            sa.Column("library_kind", sa.String(24), nullable=False, server_default="standard")
+        )
+        batch.add_column(sa.Column("interdisciplinary_domains", _JSON, nullable=True))
+        batch.add_column(
+            sa.Column(
+                "interdisciplinary_project_id",
+                sa.Uuid(),
+                sa.ForeignKey(
+                    "projects.id",
+                    ondelete="SET NULL",
+                    name="fk_direction_libraries_interdisciplinary_project",
+                ),
+                nullable=True,
+            )
+        )
+    op.create_index(
+        "ix_direction_libraries_interdisciplinary_project_id",
+        "direction_libraries",
+        ["interdisciplinary_project_id"],
+    )
+    # 「一个课题恰好一个跨学科库」由 schema 保证，而不是只靠 confirm 里的先查后插：
+    # 并发确认（双击、重试）两边都会查到 None，各建一个库，且外键是 SET NULL，多出来的
+    # 那个不会被清掉。
+    op.create_index(
+        "uq_direction_libraries_interdisciplinary_project",
+        "direction_libraries",
+        ["interdisciplinary_project_id"],
+        unique=True,
+        postgresql_where=sa.text("library_kind = 'interdisciplinary'"),
+        sqlite_where=sa.text("library_kind = 'interdisciplinary'"),
+    )
+    op.create_table(
+        "interdisciplinary_research_profiles",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("status", sa.String(16), nullable=False, server_default="draft"),
+        sa.Column("research_scope", sa.Text(), nullable=False),
+        sa.Column("core_questions", _JSON, nullable=False),
+        sa.Column("primary_domain", sa.String(255), nullable=False),
+        sa.Column("related_domains", _JSON, nullable=False),
+        sa.Column("evidence_boundary", sa.Text(), nullable=True),
+        sa.Column("validation_conditions", _JSON, nullable=True),
+        sa.Column("user_questions", _JSON, nullable=True),
+        sa.Column(
+            "created_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+        ),
+        sa.Column(
+            "confirmed_by", sa.Uuid(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+        ),
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_interdisciplinary_research_profiles_project_id",
+        "interdisciplinary_research_profiles",
+        ["project_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_interdisciplinary_research_profiles_project_id",
+        table_name="interdisciplinary_research_profiles",
+    )
+    op.drop_table("interdisciplinary_research_profiles")
+    op.drop_index(
+        "uq_direction_libraries_interdisciplinary_project",
+        table_name="direction_libraries",
+    )
+    op.drop_index(
+        "ix_direction_libraries_interdisciplinary_project_id",
+        table_name="direction_libraries",
+    )
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_column("interdisciplinary_project_id")
+        batch.drop_column("interdisciplinary_domains")
+        batch.drop_column("library_kind")
+    with op.batch_alter_table("projects") as batch:
+        batch.drop_column("research_mode")

--- a/src/backend/app/api/interdisciplinary.py
+++ b/src/backend/app/api/interdisciplinary.py
@@ -1,0 +1,145 @@
+"""Project-scoped interdisciplinary profile and dedicated literature library APIs."""
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.interdisciplinary import InterdisciplinaryResearchProfile
+from app.models.library_direction import DirectionLibrary, TopicSourceLibrary
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.interdisciplinary import (
+    InterdisciplinaryConfirmation,
+    InterdisciplinaryScopeDraft,
+    InterdisciplinaryScopeRead,
+)
+from app.services import libraries as libraries_service
+from app.services import projects as projects_service
+
+router = APIRouter(prefix="/projects/{project_id}/interdisciplinary", tags=["interdisciplinary"])
+
+
+async def _managed_project(
+    session: AsyncSession, project_id: uuid.UUID, user: User
+) -> Project:
+    project = await projects_service.get_project(session, project_id=project_id, user_id=user.id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    if not projects_service.can_manage_project(project, user):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="PROJECT_FORBIDDEN")
+    return project
+
+
+async def _profile(
+    session: AsyncSession, project_id: uuid.UUID
+) -> InterdisciplinaryResearchProfile:
+    profile = await session.scalar(
+        select(InterdisciplinaryResearchProfile).where(
+            InterdisciplinaryResearchProfile.project_id == project_id
+        )
+    )
+    if profile is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="INTERDISCIPLINARY_SCOPE_NOT_FOUND")
+    return profile
+
+
+@router.get("/scope", response_model=InterdisciplinaryScopeRead)
+async def get_interdisciplinary_scope(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> InterdisciplinaryScopeRead:
+    await _managed_project(session, project_id, user)
+    return InterdisciplinaryScopeRead.model_validate(await _profile(session, project_id))
+
+
+@router.put("/scope", response_model=InterdisciplinaryScopeRead)
+async def save_interdisciplinary_scope(
+    project_id: uuid.UUID,
+    data: InterdisciplinaryScopeDraft,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> InterdisciplinaryScopeRead:
+    project = await _managed_project(session, project_id, user)
+    profile = await session.scalar(
+        select(InterdisciplinaryResearchProfile).where(
+            InterdisciplinaryResearchProfile.project_id == project.id
+        )
+    )
+    if profile is None:
+        profile = InterdisciplinaryResearchProfile(
+            project_id=project.id,
+            created_by=user.id,
+            version=1,
+            status="draft",
+        )
+        session.add(profile)
+    else:
+        profile.version += 1
+        profile.status = "draft"
+        profile.confirmed_by = None
+        profile.confirmed_at = None
+    profile.research_scope = data.research_scope.strip()
+    profile.core_questions = [item.strip() for item in data.core_questions if item.strip()]
+    profile.primary_domain = data.primary_domain.strip()
+    profile.related_domains = [item.strip() for item in data.related_domains if item.strip()]
+    profile.evidence_boundary = data.evidence_boundary.strip() if data.evidence_boundary else None
+    profile.validation_conditions = data.validation_conditions
+    profile.user_questions = data.user_questions
+    project.research_mode = "interdisciplinary"
+    await session.commit()
+    await session.refresh(profile)
+    return InterdisciplinaryScopeRead.model_validate(profile)
+
+
+@router.post("/scope/confirm", response_model=InterdisciplinaryConfirmation)
+async def confirm_interdisciplinary_scope(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> InterdisciplinaryConfirmation:
+    project = await _managed_project(session, project_id, user)
+    profile = await _profile(session, project.id)
+    if not profile.core_questions or not profile.related_domains:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="INTERDISCIPLINARY_SCOPE_INVALID"
+        )
+    profile.status = "confirmed"
+    profile.confirmed_by = user.id
+    profile.confirmed_at = datetime.now(UTC)
+    project.research_mode = "interdisciplinary"
+
+    library = await session.scalar(
+        select(DirectionLibrary).where(
+            DirectionLibrary.interdisciplinary_project_id == project.id,
+            DirectionLibrary.library_kind == "interdisciplinary",
+        )
+    )
+    if library is None:
+        library = await libraries_service.create_library(
+            session,
+            name=f"{project.name} · Cross-disciplinary literature",
+            statement=profile.research_scope,
+            keywords={
+                "include": [profile.primary_domain, *profile.related_domains],
+                "interdisciplinary": True,
+            },
+            created_by=user.id,
+        )
+        library.library_kind = "interdisciplinary"
+        library.interdisciplinary_project_id = project.id
+        library.interdisciplinary_domains = [profile.primary_domain, *profile.related_domains]
+        session.add(TopicSourceLibrary(topic_id=project.id, library_id=library.id))
+    else:
+        library.statement = profile.research_scope
+        library.interdisciplinary_domains = [profile.primary_domain, *profile.related_domains]
+    await session.commit()
+    await session.refresh(profile)
+    return InterdisciplinaryConfirmation(
+        profile=InterdisciplinaryScopeRead.model_validate(profile), library_id=library.id
+    )

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -22,6 +22,7 @@ from app.api import (
     ideas,
     ingest,
     integration_tokens,
+    interdisciplinary,
     invites,
     lab,
     libraries,
@@ -77,6 +78,7 @@ api_router.include_router(notes.router)
 api_router.include_router(highlights.router)
 api_router.include_router(concepts.router)
 api_router.include_router(ingest.router)
+api_router.include_router(interdisciplinary.router)
 api_router.include_router(integration_tokens.router)
 api_router.include_router(wiki.router)
 api_router.include_router(ideas.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.feedback import Feedback, FeedbackImage
 from app.models.gate import Gate
 from app.models.idea import Idea
 from app.models.integration_token import IntegrationToken
+from app.models.interdisciplinary import InterdisciplinaryResearchProfile
 from app.models.library import UserLibraryEntry
 from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.literature_discovery import (
@@ -84,6 +85,7 @@ __all__ = [
     "FeedbackImage",
     "Gate",
     "Idea",
+    "InterdisciplinaryResearchProfile",
     "IdeaVector",
     "IntegrationToken",
     "LLMCallLog",

--- a/src/backend/app/models/interdisciplinary.py
+++ b/src/backend/app/models/interdisciplinary.py
@@ -1,0 +1,34 @@
+"""Persistent interdisciplinary research profile and confirmation state."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class InterdisciplinaryResearchProfile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "interdisciplinary_research_profiles"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), unique=True, index=True, nullable=False
+    )
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default="draft", nullable=False)
+    research_scope: Mapped[str] = mapped_column(Text, nullable=False)
+    core_questions: Mapped[list[str]] = mapped_column(JSONVariant, nullable=False)
+    primary_domain: Mapped[str] = mapped_column(String(255), nullable=False)
+    related_domains: Mapped[list[str]] = mapped_column(JSONVariant, nullable=False)
+    evidence_boundary: Mapped[str | None] = mapped_column(Text)
+    validation_conditions: Mapped[list[str] | None] = mapped_column(JSONVariant)
+    user_questions: Mapped[list[dict] | None] = mapped_column(JSONVariant)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    confirmed_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL")
+    )
+    confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -15,7 +15,16 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -25,8 +34,26 @@ from app.models.paper import Paper
 
 class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "direction_libraries"
+    __table_args__ = (
+        # 一个课题最多一个跨学科库；confirm 里的先查后插挡不住并发确认。
+        Index(
+            "uq_direction_libraries_interdisciplinary_project",
+            "interdisciplinary_project_id",
+            unique=True,
+            postgresql_where=text("library_kind = 'interdisciplinary'"),
+            sqlite_where=text("library_kind = 'interdisciplinary'"),
+        ),
+    )
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # standard | interdisciplinary; preserves the existing membership model.
+    library_kind: Mapped[str] = mapped_column(
+        String(24), default="standard", server_default="standard", nullable=False
+    )
+    interdisciplinary_domains: Mapped[list[str] | None] = mapped_column(JSONVariant)
+    interdisciplinary_project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id", ondelete="SET NULL"), index=True
+    )
     statement: Mapped[str | None] = mapped_column(Text)  # 方向陈述（一段话）
     rubric: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 相关性评分标准
     anchors: Mapped[list[Any] | None] = mapped_column(JSONVariant)  # 锚点论文/关键词

--- a/src/backend/app/models/project.py
+++ b/src/backend/app/models/project.py
@@ -18,6 +18,10 @@ class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # P9e：课题语境提示（一句话）。收录配置（rubric/anchors/keywords/goals/scope/
     # questions/cadence）权威源在文献库 ``DirectionLibrary.definition``，不在课题上。
     statement: Mapped[str | None] = mapped_column(Text)
+    # conventional | interdisciplinary; durable project context.
+    research_mode: Mapped[str] = mapped_column(
+        String(24), default="conventional", server_default="conventional", nullable=False
+    )
     status: Mapped[str] = mapped_column(String(32), default="active", nullable=False)
     owner_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False

--- a/src/backend/app/schemas/interdisciplinary.py
+++ b/src/backend/app/schemas/interdisciplinary.py
@@ -1,0 +1,33 @@
+"""API contracts for project-scoped interdisciplinary research profiles."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class InterdisciplinaryScopeDraft(BaseModel):
+    research_scope: str = Field(min_length=10, max_length=4000)
+    core_questions: list[str] = Field(min_length=1, max_length=12)
+    primary_domain: str = Field(min_length=2, max_length=255)
+    related_domains: list[str] = Field(min_length=1, max_length=12)
+    evidence_boundary: str | None = Field(default=None, max_length=4000)
+    validation_conditions: list[str] | None = Field(default=None, max_length=12)
+    user_questions: list[dict] | None = Field(default=None, max_length=12)
+
+
+class InterdisciplinaryScopeRead(InterdisciplinaryScopeDraft):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    version: int
+    status: str
+    created_by: uuid.UUID
+    confirmed_by: uuid.UUID | None
+    confirmed_at: datetime | None
+
+
+class InterdisciplinaryConfirmation(BaseModel):
+    profile: InterdisciplinaryScopeRead
+    library_id: uuid.UUID

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -15,6 +15,8 @@ class DirectionLibrarySummary(BaseModel):
 
     id: uuid.UUID
     name: str
+    library_kind: str = "standard"
+    interdisciplinary_domains: list[str] | None = None
     statement: str | None
     # 过渡期隐式库回指的课题；未来共享库可为 None
     project_id: uuid.UUID | None

--- a/src/backend/app/schemas/project.py
+++ b/src/backend/app/schemas/project.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
@@ -19,12 +20,14 @@ class ProjectCreate(BaseModel):
     slug: str | None = None  # 缺省时由 name 生成
     statement: str | None = Field(default=None, max_length=2000)
     source_library_ids: list[uuid.UUID] = Field(default_factory=list)
+    research_mode: Literal["conventional", "interdisciplinary"] = "conventional"
 
 
 class ProjectUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     statement: str | None = Field(default=None, max_length=2000)
     status: str | None = None  # active | archived
+    research_mode: Literal["conventional", "interdisciplinary"] | None = None
 
 
 class ProjectRead(BaseModel):
@@ -35,6 +38,7 @@ class ProjectRead(BaseModel):
     slug: str
     statement: str | None
     status: str
+    research_mode: Literal["conventional", "interdisciplinary"]
     owner_id: uuid.UUID
     created_at: datetime
     updated_at: datetime

--- a/src/backend/app/services/builtin_skills.py
+++ b/src/backend/app/services/builtin_skills.py
@@ -309,6 +309,89 @@ BUILTIN_SKILLS: list[dict[str, Any]] = [
 - 指标写成结构化 jsonl（step, metric, value），不要只打印到 stdout。
 - 数据处理与训练解耦：预处理产物落盘并带版本号，训练脚本只读产物。
 - 脚本必须支持 --smoke 模式：小数据/少步数跑通全流程后立即退出。
-- 失败要响亮：不吞异常，断言输入形状与数值范围。""",
+        - 失败要响亮：不吞异常，断言输入形状与数值范围。""",
+    },
+    {
+        "slug": "interdisciplinary-research-workflow",
+        "kind": "workflow",
+        "name": "跨学科研究工作流",
+        "name_en": "Interdisciplinary Research Workflow",
+        "description": "跨学科课题从范围确认、分学科检索到证据驱动的想法、实验、写作和评审",
+        "targets": [
+            "navigator.free_plan",
+            "wiki.score_relevance",
+            "forge.generate",
+            "experiment.plan",
+            "writing.section",
+            "writing.related_work",
+            "review.referees",
+            "present.outline",
+        ],
+        "steps": [
+            {
+                "title": "确认交叉研究范围",
+                "action": "llm.complete",
+                "params": {
+                    "stage": "planning",
+                    "prompt": (
+                        "读取课题已确认的主学科、关联学科、核心问题和证据边界。"
+                        "如果任一字段缺失，先提出最少的澄清问题，不要自行补全学科。"
+                    ),
+                },
+                "acceptance": "输出主学科、关联学科、核心问题和证据边界，并标明待确认项",
+                "requires_gate": None,
+            },
+            {
+                "title": "分学科检索并合并证据",
+                "action": "llm.complete",
+                "params": {
+                    "stage": "librarian",
+                    "prompt": (
+                        "先按主学科与各关联学科分别检索，再用统一 DOI/标题身份合并去重。"
+                        "每篇文献保留来源学科、贡献类型、相关性理由和句子级证据，"
+                        "不能把共享关键词当作跨学科关联。"
+                    ),
+                },
+                "acceptance": "输出分学科证据表，并有跨学科合并后的去重文献清单",
+                "requires_gate": None,
+            },
+            {
+                "title": "生成可证伪研究想法",
+                "action": "llm.complete",
+                "params": {
+                    "stage": "ideation",
+                    "prompt": (
+                        "基于已确认范围和分学科证据，生成有明确机制的交叉想法。"
+                        "每个想法必须说明主学科承担的核心问题、关联学科提供的不可替代方法、"
+                        "最小可行实验、风险和可证伪判据。"
+                    ),
+                },
+                "acceptance": "每个想法都有机制差异、最小实验和证据引用",
+                "requires_gate": None,
+            },
+            {
+                "title": "贯穿实验、写作和评审",
+                "action": "llm.complete",
+                "params": {
+                    "stage": "research",
+                    "prompt": (
+                        "后续实验计划、论文写作、PPT提纲和评审均携带同一交叉范围版本。"
+                        "所有引用采用文献编号+句子编号，找不到句子时退回段落或论文级，"
+                        "不得把某一学科的指标冒充另一学科的结论。"
+                    ),
+                },
+                "acceptance": "产物标注交叉研究上下文版本并保留可回溯引用",
+                "requires_gate": None,
+            },
+        ],
+        "body": (
+            "跨学科研究必须先确认范围资产，再进入后续流程。\n\n"
+            "- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n"
+            "- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、"
+            "外部标识和规范化标题去重。\n"
+            "- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，"
+            "不能静默改成无来源的摘要推断。\n"
+            "- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。"
+        ),
     },
 ]

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -401,6 +401,8 @@ def _overview_dict(
     return {
         "id": library.id,
         "name": library.name,
+        "library_kind": library.library_kind,
+        "interdisciplinary_domains": library.interdisciplinary_domains,
         "statement": library.statement,
         "cadence": library.cadence,
         "monthly_budget": library.monthly_budget,

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -124,6 +124,7 @@ async def create_project(
         name=data.name,
         slug=slug,
         statement=statement or None,
+        research_mode=data.research_mode,
         owner_id=owner_id,
     )
     session.add(project)
@@ -186,6 +187,8 @@ async def update_project(session: AsyncSession, project: Project, data: ProjectU
         project.statement = data.statement.strip() or None
     if data.status is not None:
         project.status = data.status
+    if data.research_mode is not None:
+        project.research_mode = data.research_mode
     await session.commit()
     await session.refresh(project)
     return project

--- a/src/backend/tests/test_interdisciplinary.py
+++ b/src/backend/tests/test_interdisciplinary.py
@@ -1,0 +1,85 @@
+"""Smoke tests for the interdisciplinary project/profile/library contract."""
+
+import pytest
+
+from tests.conftest import register_and_login
+
+
+@pytest.mark.asyncio
+async def test_scope_confirmation_creates_one_dedicated_library(client):
+    token = await register_and_login(client, email="interdisciplinary-owner@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    created = await client.post(
+        "/api/projects",
+        headers=auth,
+        json={
+            "name": "Impact-aware segmentation",
+            "statement": "Study structural response with vision-based measurements.",
+            "research_mode": "interdisciplinary",
+        },
+    )
+    assert created.status_code == 201, created.text
+    project_id = created.json()["id"]
+    scope = {
+        "research_scope": (
+            "Use segmentation observations to explain structural response under dynamic impact."
+        ),
+        "core_questions": ["Which visual measurements are mechanically meaningful?"],
+        "primary_domain": "Structural engineering",
+        "related_domains": ["Computer vision", "Data-driven mechanics"],
+        "evidence_boundary": (
+            "Only claims supported by the selected library and validated experiments."
+        ),
+        "validation_conditions": ["Compare predicted and measured displacement fields."],
+        "user_questions": [],
+    }
+    saved = await client.put(
+        f"/api/projects/{project_id}/interdisciplinary/scope", headers=auth, json=scope
+    )
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["status"] == "draft"
+    confirmed = await client.post(
+        f"/api/projects/{project_id}/interdisciplinary/scope/confirm", headers=auth
+    )
+    assert confirmed.status_code == 200, confirmed.text
+    assert confirmed.json()["profile"]["status"] == "confirmed"
+    library_id = confirmed.json()["library_id"]
+
+    repeated = await client.post(
+        f"/api/projects/{project_id}/interdisciplinary/scope/confirm", headers=auth
+    )
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json()["library_id"] == library_id
+
+    libraries = await client.get(f"/api/projects/{project_id}/source-libraries", headers=auth)
+    assert libraries.status_code == 200, libraries.text
+    row = next(item for item in libraries.json() if item["id"] == library_id)
+    assert row["library_kind"] == "interdisciplinary"
+    assert row["interdisciplinary_domains"] == [
+        "Structural engineering",
+        "Computer vision",
+        "Data-driven mechanics",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_interdisciplinary_scope_is_owner_managed(client):
+    owner_token = await register_and_login(client, email="interdisciplinary-owner-2@example.com")
+    other_token = await register_and_login(client, email="interdisciplinary-viewer@example.com")
+    project = await client.post(
+        "/api/projects",
+        headers={"Authorization": f"Bearer {owner_token}"},
+        json={"name": "Private cross domain topic", "research_mode": "interdisciplinary"},
+    )
+    project_id = project.json()["id"]
+    response = await client.put(
+        f"/api/projects/{project_id}/interdisciplinary/scope",
+        headers={"Authorization": f"Bearer {other_token}"},
+        json={
+            "research_scope": "An unauthorized profile must not be writable.",
+            "core_questions": ["Q"],
+            "primary_domain": "Engineering",
+            "related_domains": ["Computing"],
+        },
+    )
+    assert response.status_code in {403, 404}

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "d1e2f3a4b5c6"  # Persistent OA cache and promotion audit
+HEAD_REVISION = "e9f0a1b2c3d4"  # Interdisciplinary research profiles
+OA_CACHE_REVISION = "d1e2f3a4b5c6"  # Persistent OA cache and promotion audit
 DOWNLOAD_BATCH_REVISION = "e0f1a2b3c4d5"  # Polaris extension download batches and API keys
 EVIDENCE_ANCHOR_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
 CONTENT_VERSION_REVISION = "d9e0f1a2b3c4"  # Versioned parsed PDF content and vectors
@@ -131,6 +132,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "download_batch_items",
                     "literature_oa_caches",
                     "literature_oa_attempts",
+                    "interdisciplinary_research_profiles",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -468,7 +470,20 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
 
     assert {"literature_oa_caches", "literature_oa_attempts"} <= columns["_tables"]
 
-    # 先退掉 OA 缓存迁移，回到下载批次协议版本。
+    assert {"primary_domain", "related_domains", "status", "version"} <= columns[
+        "interdisciplinary_research_profiles"
+    ]
+    assert {"library_kind", "interdisciplinary_project_id"} <= columns["direction_libraries"]
+    assert "research_mode" in columns["projects"]
+
+    # 先退掉跨学科档案迁移，回到 OA 缓存版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == OA_CACHE_REVISION
+    assert "interdisciplinary_research_profiles" not in columns["_tables"]
+    assert "library_kind" not in columns["direction_libraries"]
+
+    # 再退掉 OA 缓存迁移，回到下载批次协议版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == DOWNLOAD_BATCH_REVISION

--- a/src/backend/tests/test_skills_api.py
+++ b/src/backend/tests/test_skills_api.py
@@ -117,6 +117,9 @@ async def test_builtin_seed_readonly_and_fork(client):
 
     builtin = (await client.get("/api/skills?scope=builtin", headers=headers)).json()
     assert len(builtin) == len(BUILTIN_SKILLS)
+    cross = next(s for s in builtin if s["slug"] == "interdisciplinary-research-workflow")
+    assert cross["kind"] == "workflow"
+    assert cross["name_en"] == "Interdisciplinary Research Workflow"
     rubric = next(s for s in builtin if s["slug"] == "idea-scoring-rubric")
 
     # 内置只读：追加版本 / 归档均 403


### PR DESCRIPTION
Rebase of #469 and #470 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS. They are combined because #470 is two files and depends entirely on #469.

Three fixes went in on top.

## 1. The migration forked the chain

`e9f0a1b2c3d4` chained from `fe8a86942dc7`, which was not the head when the branch was cut — the head was `8ff89f7fcdeb`. So this forked the chain on its own, before any interaction with the literature series. Re-pointed to `d1e2f3a4b5c6`, the current head.

#469's body describes the resulting failure as environmental:

> migration test is blocked on the repository's existing UTF-8 `alembic.ini` under Windows GBK locale; not a migration assertion failure

In this repository's Linux container it fails with `Multiple head revisions are present` — the assertion, catching what it exists to catch.

## 2. With that fixed, the same test failed again for a different reason

```
NotImplementedError: No support for ALTER of constraints in SQLite dialect.
```

The upgrade adds a column carrying a foreign key and the downgrade drops columns; SQLite can do neither outside batch mode. Both now use `op.batch_alter_table`, which is how the existing migrations in this repo handle it (`d3a7f1c9b2e4_library_lifecycle.py`, `f7c2abfe8aeb_direction_libraries_and_paper_pool.py`), and the foreign key is named so batch mode can reflect it.

Worth noting: this second defect was **invisible while the first one existed**, because the run died at head resolution before reaching the round trip. A failure that is written off as environmental hides whatever is behind it.

## 3. "Exactly one library per project" was not enforced

The PR body says confirmation creates exactly one dedicated library. The handler guards it with a check-then-insert over a **non-unique** index, so two concurrent confirms — a double-click, a retried request — both read `None` and both create one, and the loser is never cleaned up because the foreign key is `SET NULL`.

Added a partial unique index, declared on both the model and the migration:

```python
Index(
    "uq_direction_libraries_interdisciplinary_project",
    "interdisciplinary_project_id",
    unique=True,
    postgresql_where=text("library_kind = 'interdisciplinary'"),
    sqlite_where=text("library_kind = 'interdisciplinary'"),
)
```

## Still open, not changed here

`interdisciplinary_research_profiles.created_by` uses `ondelete="RESTRICT"` while comparable columns elsewhere — including `literature_search_runs.created_by` from #450 — use `SET NULL`. RESTRICT means a user who ever drafted a scope can no longer be deleted. It is `nullable=False`, so changing it is a design decision rather than a rebase fix; flagging it for you.

## Verification

- `alembic heads` → single head `e9f0a1b2c3d4`
- `tests/test_migrations.py tests/test_interdisciplinary.py tests/test_skills_api.py tests/test_library.py` → 26 passed, including the full round trip down through every literature revision to `8ff89f7fcdeb`
- `ruff check app/ alembic/` → clean; `import app.main` → ok

Closes #459, #471. Supersedes #469 and #470.