### PR TITLE
feat(interdisciplinary): orchestrate discipline-aware literature retrieval

### DIFF
--- a/src/backend/alembic/versions/f0a1b2c3d4e5_interdisciplinary_query_matrix.py
+++ b/src/backend/alembic/versions/f0a1b2c3d4e5_interdisciplinary_query_matrix.py
@@ -1,0 +1,27 @@
+"""Persist interdisciplinary retrieval channels and merge the two feature heads."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f0a1b2c3d4e5"
+down_revision: str = "e9f0a1b2c3d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("interdisciplinary_research_profiles") as batch:
+        batch.add_column(sa.Column("query_matrix", _JSON))
+        batch.add_column(sa.Column("evidence_balance", _JSON))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("interdisciplinary_research_profiles") as batch:
+        batch.drop_column("evidence_balance")
+        batch.drop_column("query_matrix")

--- a/src/backend/app/api/interdisciplinary.py
+++ b/src/backend/app/api/interdisciplinary.py
@@ -20,6 +20,7 @@ from app.schemas.interdisciplinary import (
 )
 from app.services import libraries as libraries_service
 from app.services import projects as projects_service
+from app.services.interdisciplinary_retrieval import build_query_matrix, normalize_query_matrix
 
 router = APIRouter(prefix="/projects/{project_id}/interdisciplinary", tags=["interdisciplinary"])
 
@@ -91,6 +92,15 @@ async def save_interdisciplinary_scope(
     profile.evidence_boundary = data.evidence_boundary.strip() if data.evidence_boundary else None
     profile.validation_conditions = data.validation_conditions
     profile.user_questions = data.user_questions
+    profile.query_matrix = normalize_query_matrix(data.query_matrix or []) or build_query_matrix(
+        topic=project.statement or project.name,
+        primary_domain=profile.primary_domain,
+        related_domains=profile.related_domains,
+    )
+    profile.evidence_balance = data.evidence_balance or {
+        profile.primary_domain: 0.5,
+        **{domain: 0.5 / len(profile.related_domains) for domain in profile.related_domains},
+    }
     project.research_mode = "interdisciplinary"
     await session.commit()
     await session.refresh(profile)

--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -34,6 +34,7 @@ from app.schemas.literature_discovery import (
     SourceAttemptRead,
 )
 from app.services import libraries as libraries_service
+from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
 from app.services.literature import discovery_runs, oa_cache
 
 router = APIRouter(tags=["literature-discovery"])
@@ -75,6 +76,13 @@ async def create_run(
     user: User = Depends(current_active_user),
 ) -> SearchRunDetail:
     library = await _managed_library(session, library_id, user)
+    query_plan = await apply_profile_to_query_plan(
+        session,
+        library=library,
+        topic=data.topic,
+        query_plan=data.query_plan,
+        source_config=data.source_config,
+    )
     run = LiteratureSearchRun(
         library_id=library.id,
         created_by=user.id,
@@ -83,14 +91,14 @@ async def create_run(
         start_year=data.start_year,
         end_year=data.end_year,
         topic=data.topic,
-        query_plan=data.query_plan,
+        query_plan=query_plan,
         source_config=data.source_config,
         model_version=data.model_version,
         progress={"phase": "queued", "fetched": 0, "accepted": 0},
     )
     session.add(run)
     await session.flush()
-    for source in discovery_runs.enabled_sources(data.source_config, data.query_plan):
+    for source in discovery_runs.enabled_sources(data.source_config, query_plan):
         session.add(
             LiteratureSourceAttempt(
                 run_id=run.id,

--- a/src/backend/app/models/interdisciplinary.py
+++ b/src/backend/app/models/interdisciplinary.py
@@ -25,6 +25,8 @@ class InterdisciplinaryResearchProfile(UUIDPrimaryKeyMixin, TimestampMixin, Base
     evidence_boundary: Mapped[str | None] = mapped_column(Text)
     validation_conditions: Mapped[list[str] | None] = mapped_column(JSONVariant)
     user_questions: Mapped[list[dict] | None] = mapped_column(JSONVariant)
+    query_matrix: Mapped[list[dict] | None] = mapped_column(JSONVariant)
+    evidence_balance: Mapped[dict | None] = mapped_column(JSONVariant)
     created_by: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
     )

--- a/src/backend/app/schemas/interdisciplinary.py
+++ b/src/backend/app/schemas/interdisciplinary.py
@@ -14,6 +14,8 @@ class InterdisciplinaryScopeDraft(BaseModel):
     evidence_boundary: str | None = Field(default=None, max_length=4000)
     validation_conditions: list[str] | None = Field(default=None, max_length=12)
     user_questions: list[dict] | None = Field(default=None, max_length=12)
+    query_matrix: list[dict] | None = Field(default=None, max_length=24)
+    evidence_balance: dict[str, float] | None = None
 
 
 class InterdisciplinaryScopeRead(InterdisciplinaryScopeDraft):

--- a/src/backend/app/services/interdisciplinary_retrieval.py
+++ b/src/backend/app/services/interdisciplinary_retrieval.py
@@ -1,0 +1,163 @@
+"""Compile confirmed interdisciplinary profiles into auditable discovery plans."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.interdisciplinary import InterdisciplinaryResearchProfile
+from app.models.library_direction import DirectionLibrary
+from app.services.literature.discovery_ranking import RankedCandidate
+
+_CHANNEL_ROLES = {"primary", "related", "bridge", "method_transfer"}
+
+
+def _clean(value: object, *, limit: int = 500) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()[:limit]
+
+
+def build_query_matrix(
+    *, topic: str, primary_domain: str, related_domains: Sequence[str], keywords: Sequence[str] = ()
+) -> list[dict[str, Any]]:
+    """Build deterministic discipline and bridge channels from a confirmed scope."""
+    topic = _clean(topic)
+    primary = _clean(primary_domain, limit=255)
+    related = list(
+        dict.fromkeys(_clean(item, limit=255) for item in related_domains if _clean(item))
+    )
+    terms = list(dict.fromkeys(_clean(item, limit=120) for item in keywords if _clean(item)))[:8]
+    suffix = " OR ".join(f'"{term}"' if " " in term else term for term in terms)
+
+    def query(*parts: str) -> str:
+        base = " AND ".join(f'"{part}"' if " " in part else part for part in parts if part)
+        return f"({base}) AND ({suffix})" if suffix else base
+
+    channels: list[dict[str, Any]] = [
+        {"id": "primary", "discipline": primary, "role": "primary", "query": query(topic, primary)}
+    ]
+    for index, domain in enumerate(related, start=1):
+        channels.extend(
+            (
+                {
+                    "id": f"related-{index}",
+                    "discipline": domain,
+                    "role": "related",
+                    "query": query(topic, domain),
+                },
+                {
+                    "id": f"bridge-{index}",
+                    "discipline": f"{primary} + {domain}",
+                    "role": "bridge",
+                    "query": query(topic, primary, domain),
+                },
+            )
+        )
+    return channels[:24]
+
+
+def normalize_query_matrix(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Validate editable channel rows without accepting opaque provider syntax."""
+    normalized: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        role = _clean(row.get("role"), limit=32).lower()
+        query = _clean(row.get("query"), limit=4000)
+        discipline = _clean(row.get("discipline"), limit=255)
+        if role not in _CHANNEL_ROLES or not query or not discipline:
+            continue
+        normalized.append(
+            {
+                "id": _clean(row.get("id"), limit=64) or f"channel-{index + 1}",
+                "discipline": discipline,
+                "role": role,
+                "query": query,
+            }
+        )
+    return normalized[:24]
+
+
+async def apply_profile_to_query_plan(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    topic: str,
+    query_plan: dict[str, Any] | None,
+    source_config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a run snapshot for a confirmed dedicated library, otherwise preserve input."""
+    current = dict(query_plan or {})
+    if library.library_kind != "interdisciplinary" or library.interdisciplinary_project_id is None:
+        return query_plan
+    profile = await session.scalar(
+        select(InterdisciplinaryResearchProfile).where(
+            InterdisciplinaryResearchProfile.project_id == library.interdisciplinary_project_id,
+            InterdisciplinaryResearchProfile.status == "confirmed",
+        )
+    )
+    if profile is None:
+        return query_plan
+    config = source_config if isinstance(source_config, dict) else {}
+    keywords = [str(item) for item in config.get("keywords") or []]
+    channels = normalize_query_matrix(profile.query_matrix or []) or build_query_matrix(
+        topic=topic,
+        primary_domain=profile.primary_domain,
+        related_domains=profile.related_domains,
+        keywords=keywords,
+    )
+    sources = [
+        str(item).strip().lower()
+        for item in config.get("sources") or []
+        if str(item).strip()
+    ]
+    current["queries"] = [
+        {**channel, "source": source}
+        for source in dict.fromkeys(sources)
+        for channel in channels
+    ]
+    current["interdisciplinary"] = {
+        "profile_id": str(profile.id),
+        "profile_version": profile.version,
+        "primary_domain": profile.primary_domain,
+        "related_domains": list(profile.related_domains),
+        "evidence_balance": profile.evidence_balance or {},
+        "channels": channels,
+    }
+    return current
+
+
+def rerank_interdisciplinary(
+    ranked: Sequence[RankedCandidate], *, query_plan: dict[str, Any] | None, limit: int
+) -> list[RankedCandidate]:
+    """Reward evidenced discipline bridges while retaining base literature quality."""
+    config = (query_plan or {}).get("interdisciplinary") if isinstance(query_plan, dict) else None
+    if not isinstance(config, dict):
+        return list(ranked)[:limit]
+    output: list[RankedCandidate] = []
+    for item in ranked:
+        metadata = item.candidate.get("metadata")
+        hits = metadata.get("retrieval_hits") if isinstance(metadata, dict) else []
+        hits = [hit for hit in hits or [] if isinstance(hit, dict)]
+        disciplines = {str(hit.get("discipline")) for hit in hits if hit.get("discipline")}
+        roles = {str(hit.get("role")) for hit in hits if hit.get("role")}
+        bridge = bool(roles & {"bridge", "method_transfer"}) or len(disciplines) >= 2
+        bridge_score = 1.0 if bridge else min(1.0, len(disciplines) / 2)
+        dimensions = {**item.dimensions, "interdisciplinary_bridge": bridge_score}
+        score = round(item.score * 0.85 + bridge_score * 0.15, 6)
+        reason = "cross-discipline bridge evidence" if bridge else "single-discipline support"
+        reasons = (*item.reasons, reason)
+        tier = "core" if bridge and item.tier != "exploratory" else item.tier
+        output.append(
+            RankedCandidate(
+                identity=item.identity,
+                candidate=item.candidate,
+                score=score,
+                tier=tier,
+                dimensions=dimensions,
+                reasons=reasons,
+            )
+        )
+    output.sort(key=lambda item: (-item.score, item.identity))
+    return output[:limit]

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -28,6 +28,7 @@ from app.schemas.literature_discovery import (
     SourceSearchPage,
     SourceSearchRequest,
 )
+from app.services.interdisciplinary_retrieval import rerank_interdisciplinary
 from app.services.literature import discovery_runs
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
 from app.services.literature.discovery_ranking import rank_candidates
@@ -422,8 +423,10 @@ async def run_discovery(
         else (),
         weights=weights,
         current_year=(now or datetime.now(UTC)).year,
-        limit=run.requested_count,
+        # 先排一个更宽的池子，跨学科重排要在里面挑平衡，再截到请求量。
+        limit=min(len(candidates), max(run.requested_count, run.requested_count * 3)),
     )
+    ranked = rerank_interdisciplinary(ranked, query_plan=run.query_plan, limit=run.requested_count)
     for item in ranked:
         # ``sources`` and ``retrieval_hits`` are ranking metadata, not part of the
         # strict candidate DTO. Read them from the ranked mapping before validation

--- a/src/backend/tests/test_interdisciplinary.py
+++ b/src/backend/tests/test_interdisciplinary.py
@@ -61,6 +61,31 @@ async def test_scope_confirmation_creates_one_dedicated_library(client):
         "Data-driven mechanics",
     ]
 
+    run = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        headers=auth,
+        json={
+            "requested_count": 50,
+            "candidate_budget": 80,
+            "start_year": 2016,
+            "end_year": 2026,
+            "topic": "vision measurements for structural impact response",
+            "source_config": {
+                "sources": ["openalex", "pubmed"],
+                "keywords": ["dynamic impact", "segmentation"],
+            },
+        },
+    )
+    assert run.status_code == 201, run.text
+    body = run.json()
+    assert body["requested_count"] == 50
+    assert body["candidate_budget"] == 80
+    assert body["start_year"] == 2016
+    assert body["query_plan"]["interdisciplinary"]["profile_version"] == 1
+    queries = body["query_plan"]["queries"]
+    assert {item["source"] for item in queries} == {"openalex", "pubmed"}
+    assert {item["role"] for item in queries} >= {"primary", "related", "bridge"}
+
 
 @pytest.mark.asyncio
 async def test_interdisciplinary_scope_is_owner_managed(client):

--- a/src/backend/tests/test_interdisciplinary_retrieval.py
+++ b/src/backend/tests/test_interdisciplinary_retrieval.py
@@ -1,0 +1,47 @@
+"""Cross-discipline query channels preserve user limits and auditable provenance."""
+
+from app.services.interdisciplinary_retrieval import build_query_matrix, rerank_interdisciplinary
+from app.services.literature.discovery_ranking import RankedCandidate
+
+
+def test_query_matrix_has_domain_and_bridge_channels():
+    rows = build_query_matrix(
+        topic="dynamic impact response",
+        primary_domain="Structural engineering",
+        related_domains=["Computer vision", "Data science"],
+        keywords=["segmentation"],
+    )
+
+    assert [row["role"] for row in rows].count("primary") == 1
+    assert [row["role"] for row in rows].count("bridge") == 2
+    assert all("dynamic impact response" in row["query"] for row in rows)
+    assert any("Computer vision" in row["query"] for row in rows)
+
+
+def test_bridge_evidence_reranks_without_discarding_base_quality():
+    base = [
+        RankedCandidate(
+            identity="single",
+            candidate={"metadata": {"retrieval_hits": [{"role": "primary", "discipline": "A"}]}},
+            score=0.9,
+            tier="core",
+            dimensions={"relevance": 0.9},
+            reasons=("high relevance",),
+        ),
+        RankedCandidate(
+            identity="bridge",
+            candidate={"metadata": {"retrieval_hits": [{"role": "bridge", "discipline": "A + B"}]}},
+            score=0.85,
+            tier="supporting",
+            dimensions={"relevance": 0.85},
+            reasons=("relevant",),
+        ),
+    ]
+
+    ranked = rerank_interdisciplinary(
+        base, query_plan={"interdisciplinary": {"profile_id": "p"}}, limit=2
+    )
+
+    assert ranked[0].identity == "bridge"
+    assert ranked[0].dimensions["interdisciplinary_bridge"] == 1.0
+    assert ranked[0].tier == "core"

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "e9f0a1b2c3d4"  # Interdisciplinary research profiles
+HEAD_REVISION = "f0a1b2c3d4e5"  # Interdisciplinary query matrix and evidence balance
+INTERDISCIPLINARY_REVISION = "e9f0a1b2c3d4"  # Interdisciplinary research profiles
 OA_CACHE_REVISION = "d1e2f3a4b5c6"  # Persistent OA cache and promotion audit
 DOWNLOAD_BATCH_REVISION = "e0f1a2b3c4d5"  # Polaris extension download batches and API keys
 EVIDENCE_ANCHOR_REVISION = "e5f6a7b8c9d0"  # Version-aware sentence/paragraph evidence anchors
@@ -476,7 +477,17 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"library_kind", "interdisciplinary_project_id"} <= columns["direction_libraries"]
     assert "research_mode" in columns["projects"]
 
-    # 先退掉跨学科档案迁移，回到 OA 缓存版本。
+    assert {"query_matrix", "evidence_balance"} <= columns["interdisciplinary_research_profiles"]
+
+    # 先退掉查询矩阵迁移，回到跨学科档案版本。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == INTERDISCIPLINARY_REVISION
+    assert not {"query_matrix", "evidence_balance"} & columns[
+        "interdisciplinary_research_profiles"
+    ]
+
+    # 再退掉跨学科档案迁移，回到 OA 缓存版本。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == OA_CACHE_REVISION


### PR DESCRIPTION
Rebase of #483 onto current `main`, landed by the maintainer. Commit authorship preserved as @yyy-OPS. Last of the series.

Diff reduced from 37 files / +2900 to **10 files / +303**.

## Two grafts, not side-takes

Seventeen files conflicted. Fifteen were straightforward — the branch carrying a pre-#489 copy — but two carried real changes inside an old file, so taking either side would have lost something:

**`api/literature_discovery.py`** (`+12/-205` against main). Overwhelmingly the older copy, but it holds this PR's actual entry point: calling `apply_profile_to_query_plan` at run creation and threading the result into `LiteratureSearchRun.query_plan` and `enabled_sources`. Grafted onto `main`'s version. Discarding it made `test_scope_confirmation_creates_one_dedicated_library` fail with `query_plan` as `None`, which is how I found it.

**`services/literature/runtime.py`** (`+95/-80`). Its version predates #497 and would have removed the bounded-provider handling that PR added — the `runnable` list, the retryable `SourceRequestError` path, the per-source attempt zip. `main`'s kept, with the two genuine changes grafted in: ranking a wider pool

```python
        limit=min(len(candidates), max(run.requested_count, run.requested_count * 3)),
    )
    ranked = rerank_interdisciplinary(ranked, query_plan=run.query_plan, limit=run.requested_count)
```

so the interdisciplinary rerank has something to balance across before the cut to `requested_count`.

## Migration

`f0a1b2c3d4e5` chains correctly from `e9f0a1b2c3d4` — no re-pointing needed. But its `add_column` / `drop_column` pair needed `op.batch_alter_table` for SQLite, the same fix as #502.

## Verification

- `alembic heads` → single head `f0a1b2c3d4e5`
- 10 suites (`test_interdisciplinary`, `test_migrations`, `test_literature_discovery_api`, `test_literature_discovery_runtime`, `test_literature_oa_cache`, `test_paper_content`, `test_evidence_anchors`, `test_mineru`, `test_skills_api`, `test_library`) → **47 passed**, including the full round trip down through every revision to `8ff89f7fcdeb`
- `ruff check app/ alembic/ worker/` → clean; `import app.main, worker.settings` → ok

Closes #488. Supersedes #483.