### PR TITLE
fix(literature): apply administrator settings at runtime

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -213,7 +213,7 @@ async def set_literature_search_settings(
 ) -> LiteratureSearchSettings:
     try:
         saved = await literature_settings_service.update_settings(
-            session, payload.model_dump(exclude_none=True)
+            session, payload.model_dump(exclude_unset=True)
         )
     except literature_settings_service.InvalidLiteratureSettingError as exc:
         raise HTTPException(
@@ -234,9 +234,11 @@ async def test_literature_provider(
     source = payload.source.strip().lower()
     started = time.perf_counter()
     try:
-        from app.services.literature.runtime import _default_registry
+        from app.services.literature.runtime import build_adapter_registry
 
-        registry = await _default_registry()
+        registry = await build_adapter_registry(
+            await literature_settings_service.get_runtime_settings(session)
+        )
         adapter = registry.get(source)
         if adapter is None:
             raise ValueError(f"unsupported source: {source}")

--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -34,6 +34,7 @@ from app.schemas.literature_discovery import (
     SourceAttemptRead,
 )
 from app.services import libraries as libraries_service
+from app.services import literature_settings as literature_settings_service
 from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
 from app.services.literature import discovery_runs, oa_cache
 
@@ -76,35 +77,47 @@ async def create_run(
     user: User = Depends(current_active_user),
 ) -> SearchRunDetail:
     library = await _managed_library(session, library_id, user)
+    defaults = await literature_settings_service.get_runtime_settings(session)
+    requested_count = data.requested_count or int(defaults["requested_count"])
+    candidate_budget = data.candidate_budget or int(defaults["candidate_budget"])
+    start_year = data.start_year if data.start_year is not None else defaults.get("start_year")
+    end_year = data.end_year if data.end_year is not None else defaults.get("end_year")
+    source_config = {
+        "sources": list(defaults["sources"]),
+        "score_weights": dict(defaults["score_weights"]),
+        **(data.source_config or {}),
+    }
+    # Provider credentials are resolved by workers and never enter run snapshots.
+    source_config.pop("provider_keys", None)
     query_plan = await apply_profile_to_query_plan(
         session,
         library=library,
         topic=data.topic,
         query_plan=data.query_plan,
-        source_config=data.source_config,
+        source_config=source_config,
     )
     run = LiteratureSearchRun(
         library_id=library.id,
         created_by=user.id,
-        requested_count=data.requested_count,
-        candidate_budget=data.candidate_budget,
-        start_year=data.start_year,
-        end_year=data.end_year,
+        requested_count=requested_count,
+        candidate_budget=candidate_budget,
+        start_year=start_year,
+        end_year=end_year,
         topic=data.topic,
         query_plan=query_plan,
-        source_config=data.source_config,
+        source_config=source_config,
         model_version=data.model_version,
         progress={"phase": "queued", "fetched": 0, "accepted": 0},
     )
     session.add(run)
     await session.flush()
-    for source in discovery_runs.enabled_sources(data.source_config, query_plan):
+    for source in discovery_runs.enabled_sources(source_config, query_plan):
         session.add(
             LiteratureSourceAttempt(
                 run_id=run.id,
                 source=source,
                 status="pending",
-                requested_count=data.candidate_budget,
+                requested_count=candidate_budget,
             )
         )
     await session.commit()

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class LiteratureSearchRequest(BaseModel):
     """创建一次检索运行时保存的用户参数。"""
 
-    requested_count: int = Field(default=20, ge=1, le=200)
-    candidate_budget: int = Field(default=80, ge=1, le=1000)
+    requested_count: int | None = Field(default=None, ge=1, le=200)
+    candidate_budget: int | None = Field(default=None, ge=1, le=1000)
     start_year: int | None = Field(default=None, ge=1800, le=3000)
     end_year: int | None = Field(default=None, ge=1800, le=3000)
     topic: str = Field(min_length=1, max_length=4000)

--- a/src/backend/app/services/literature/discovery_runs.py
+++ b/src/backend/app/services/literature/discovery_runs.py
@@ -34,9 +34,10 @@ async def can_manage_discovery(
 def enabled_sources(source_config: dict | None, query_plan: dict | None) -> list[str]:
     """从已保存快照中取得稳定来源顺序；没有配置时不凭空创建来源任务。"""
     sources: Iterable[str] = ()
+    sources_declared = isinstance(source_config, dict) and "sources" in source_config
     if isinstance(source_config, dict):
-        sources = source_config.get("sources") or source_config.keys()
-    if not list(sources) and isinstance(query_plan, dict):
+        sources = source_config["sources"] if "sources" in source_config else source_config.keys()
+    if not list(sources) and not sources_declared and isinstance(query_plan, dict):
         sources = query_plan.get("sources") or ()
     return list(dict.fromkeys(str(s).strip().lower() for s in sources if str(s).strip()))
 

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -11,12 +11,18 @@ import asyncio
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from itertools import count
+from threading import Lock
 from typing import Any
 from urllib.parse import quote
+from xml.etree import ElementTree
 
 import httpx
 
 from app.core.config import get_settings
+
+_KEY_INDEX: dict[str, count] = {}
+_KEY_LOCK = Lock()
 
 
 class ProviderRequestError(RuntimeError):
@@ -74,10 +80,39 @@ def _date_window(request: Any) -> tuple[int | None, int | None]:
     return request.start_year, request.end_year
 
 
+def _within_year(row: Mapping[str, Any], start: int | None, end: int | None) -> bool:
+    year = row.get("year")
+    return year is None or ((start is None or year >= start) and (end is None or year <= end))
+
+
+def _pubmed_abstracts(xml_text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        return result
+    for article in root.findall(".//PubmedArticle"):
+        pmid = _text(article.findtext(".//MedlineCitation/PMID"))
+        parts: list[str] = []
+        for node in article.findall(".//Article/Abstract/AbstractText"):
+            text = _text("".join(node.itertext()))
+            label = _text(node.attrib.get("Label"))
+            if text:
+                parts.append(f"{label}: {text}" if label else text)
+        if pmid and parts:
+            result[pmid] = "\n".join(parts)
+    return result
+
+
 class MultiSourceClient:
     """HTTP client for the non-core providers in the YFR-compatible source set."""
 
-    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        *,
+        provider_keys: Mapping[str, list[str]] | None = None,
+    ) -> None:
         settings = get_settings()
         self._client = client or httpx.AsyncClient(
             proxy=settings.outbound_proxy or None,
@@ -88,6 +123,23 @@ class MultiSourceClient:
         self._owns_client = client is None
         self._timeout = settings.literature_source_timeout_seconds
         self._retries = settings.literature_source_retries
+        self._provider_keys = {
+            str(source).strip().lower(): tuple(
+                str(value).strip() for value in values if str(value).strip()
+            )
+            for source, values in (provider_keys or {}).items()
+        }
+
+    def _key(self, source: str, fallback: str | list[str] = "") -> str:
+        pool = self._provider_keys.get(source, ())
+        if not pool:
+            values = fallback if isinstance(fallback, list) else re.split(r"[,;\s]+", fallback)
+            pool = tuple(str(value).strip() for value in values if str(value).strip())
+        if not pool:
+            return ""
+        with _KEY_LOCK:
+            index = next(_KEY_INDEX.setdefault(source, count()))
+        return pool[index % len(pool)]
 
     async def _request_json(
         self,
@@ -136,6 +188,32 @@ class MultiSourceClient:
             f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
         ) from last_error
 
+    async def _request_text(
+        self,
+        source: str,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        last_error: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+                response = await self._client.request(
+                    method, url, params=params, timeout=self._timeout
+                )
+                response.raise_for_status()
+                return response.text
+            except httpx.HTTPError as exc:
+                last_error = exc
+            if attempt < self._retries:
+                await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise ProviderRequestError(
+            source,
+            "REQUEST_FAILED",
+            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
+        ) from last_error
+
     async def aclose(self) -> None:
         if self._owns_client:
             await self._client.aclose()
@@ -151,7 +229,9 @@ class MultiSourceClient:
             "sciverse": self._search_sciverse,
         }
         handler = handlers.get(source.strip().lower())
-        return await handler(request) if handler else []
+        rows = await handler(request) if handler else []
+        start, end = _date_window(request)
+        return [row for row in rows if _within_year(row, start, end)]
 
     async def lookup_unpaywall(self, doi: str) -> dict[str, Any] | None:
         settings = get_settings()
@@ -171,6 +251,7 @@ class MultiSourceClient:
 
     async def _search_pubmed(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
+        api_key = self._key("pubmed", settings.pubmed_api_key)
         start, end = _date_window(request)
         query = request.query
         if start or end:
@@ -184,8 +265,8 @@ class MultiSourceClient:
             "retmax": min(request.limit, 1000),
             "sort": "relevance",
         }
-        if settings.pubmed_api_key:
-            params["api_key"] = settings.pubmed_api_key
+        if api_key:
+            params["api_key"] = api_key
         if settings.pubmed_email:
             params["email"] = settings.pubmed_email
         try:
@@ -199,8 +280,8 @@ class MultiSourceClient:
             if not ids:
                 return []
             summary_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "json"}
-            if settings.pubmed_api_key:
-                summary_params["api_key"] = settings.pubmed_api_key
+            if api_key:
+                summary_params["api_key"] = api_key
             summary = await self._request_json(
                 "pubmed",
                 "GET",
@@ -208,6 +289,20 @@ class MultiSourceClient:
                 params=summary_params,
             )
             result = summary.get("result") or {}
+            fetch_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "xml"}
+            if api_key:
+                fetch_params["api_key"] = api_key
+            try:
+                abstracts = _pubmed_abstracts(
+                    await self._request_text(
+                        "pubmed",
+                        "GET",
+                        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi",
+                        params=fetch_params,
+                    )
+                )
+            except ProviderRequestError:
+                abstracts = {}
         except ProviderRequestError:
             raise
         rows: list[dict[str, Any]] = []
@@ -225,7 +320,7 @@ class MultiSourceClient:
                     "source": "pubmed",
                     "pmid": str(pmid),
                     "title": _text(item.get("title")),
-                    "abstract": None,
+                    "abstract": abstracts.get(str(pmid)),
                     "authors": _authors(item.get("authors")),
                     "year": _year(item.get("pubdate")),
                     "venue": _text(item.get("fulljournalname") or item.get("source")),
@@ -306,10 +401,14 @@ class MultiSourceClient:
 
     async def _search_core(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
-        if not settings.core_api_key:
+        api_key = self._key("core", settings.core_api_key)
+        if not api_key:
             return []
+        year_filters = [f"yearPublished>={request.start_year or 1800}"]
+        if request.end_year is not None:
+            year_filters.append(f"yearPublished<={request.end_year}")
         params = {
-            "q": f"{request.query} yearPublished>={request.start_year or 1800}",
+            "q": f"{request.query} {' '.join(year_filters)}",
             "limit": min(request.limit, 100),
         }
         try:
@@ -318,7 +417,7 @@ class MultiSourceClient:
                 "POST",
                 "https://api.core.ac.uk/v3/search/works",
                 json=params,
-                headers={"Authorization": f"Bearer {settings.core_api_key}"},
+                headers={"Authorization": f"Bearer {api_key}"},
             )
             items = payload.get("results") or []
         except ProviderRequestError:
@@ -347,14 +446,7 @@ class MultiSourceClient:
 
     async def _search_sciverse(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
-        token = next(
-            (
-                item.strip()
-                for item in re.split(r"[,;\s]+", settings.sciverse_api_tokens)
-                if item.strip()
-            ),
-            "",
-        )
+        token = self._key("sciverse", settings.sciverse_api_tokens)
         if not token:
             return []
         try:

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -78,12 +78,14 @@ class OpenAlexClient:
         client: httpx.AsyncClient | None = None,
         redis: Redis | None = None,
         mailto: str | None = None,
+        api_key: str | None = None,
     ) -> None:
         self._client = client or httpx.AsyncClient(
             proxy=get_settings().outbound_proxy or None, timeout=30.0
         )
         self._cache = ResponseCache(redis)
         self._mailto = mailto if mailto is not None else get_settings().openalex_mailto
+        self._api_key = api_key
 
     async def _get(
         self, path: str, extra_params: dict[str, Any] | None = None
@@ -91,6 +93,8 @@ class OpenAlexClient:
         params: dict[str, Any] = dict(extra_params or {})
         if self._mailto:
             params["mailto"] = self._mailto
+        if self._api_key:
+            params["api_key"] = self._api_key
         key = cache_key("openalex", path, params)
         if (cached := await self._cache.get(key)) is not None:
             return cached or None  # 缓存的 {} 表示 404

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -7,7 +7,10 @@ separate steps. Unpromoted hits never create a Paper or a PDF processing job.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
+import threading
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
@@ -28,6 +31,7 @@ from app.schemas.literature_discovery import (
     SourceSearchPage,
     SourceSearchRequest,
 )
+from app.services import literature_settings
 from app.services.interdisciplinary_retrieval import rerank_interdisciplinary
 from app.services.literature import discovery_runs
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
@@ -35,7 +39,10 @@ from app.services.literature.discovery_ranking import rank_candidates
 from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
 
 logger = logging.getLogger(__name__)
-_DEFAULT_REGISTRY: AdapterRegistry | None = None
+_REGISTRY_CACHE: tuple[str, AdapterRegistry] | None = None
+_REGISTRY_LOCK = asyncio.Lock()
+_ROTATION_LOCK = threading.Lock()
+_ROTATION_INDEX: dict[str, int] = {}
 
 
 class SourceExecutionError(RuntimeError):
@@ -58,6 +65,22 @@ class AdapterRegistry:
 
     def names(self) -> set[str]:
         return set(self._adapters)
+
+
+class RotatingAdapter:
+    """Select one configured credential without persisting it in a run."""
+
+    def __init__(self, name: str, adapters: Sequence[SourceAdapter]) -> None:
+        if not adapters:
+            raise ValueError("at least one adapter is required")
+        self.name = name
+        self._adapters = tuple(adapters)
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        with _ROTATION_LOCK:
+            index = _ROTATION_INDEX.get(self.name, 0)
+            _ROTATION_INDEX[self.name] = index + 1
+        return await self._adapters[index % len(self._adapters)].search(request)
 
 
 class OpenAlexAdapter:
@@ -228,36 +251,74 @@ def _planned_query(run: LiteratureSearchRun, source: str, keywords: Sequence[str
     return str(plan.get("query") or run.topic or (keywords[0] if keywords else "")).strip()
 
 
-async def _default_registry() -> AdapterRegistry:
-    global _DEFAULT_REGISTRY
-    if _DEFAULT_REGISTRY is not None:
-        return _DEFAULT_REGISTRY
-    from app.services.literature.arxiv import ArxivClient
-    from app.services.literature.openalex import OpenAlexClient
-    from app.services.literature.semantic_scholar import SemanticScholarClient
+def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
+    configured = settings.get("provider_keys")
+    values = configured.get(source) if isinstance(configured, Mapping) else None
+    pool = [str(value).strip() for value in values or [] if str(value).strip()]
+    if pool:
+        return pool
+    return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
 
-    multi_source = MultiSourceClient()
-    _DEFAULT_REGISTRY = AdapterRegistry(
-        (
-            OpenAlexAdapter(OpenAlexClient()),
-            SemanticScholarAdapter(SemanticScholarClient()),
-            ArxivAdapter(ArxivClient()),
-            *(
-                MultiSourceAdapter(source, multi_source)
-                for source in (
-                    "pubmed",
-                    "crossref",
-                    "europepmc",
-                    "hal",
-                    "core",
-                    "base",
-                    "sciverse",
-                    "unpaywall",
-                )
-            ),
+
+def _registry_fingerprint(settings: Mapping[str, Any]) -> str:
+    payload = json.dumps(settings, sort_keys=True, ensure_ascii=True, default=str).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+async def build_adapter_registry(runtime_settings: Mapping[str, Any]) -> AdapterRegistry:
+    """Build or reuse adapters from trusted, decrypted administrator settings."""
+    global _REGISTRY_CACHE
+    fingerprint = _registry_fingerprint(runtime_settings)
+    async with _REGISTRY_LOCK:
+        if _REGISTRY_CACHE is not None and _REGISTRY_CACHE[0] == fingerprint:
+            return _REGISTRY_CACHE[1]
+
+        app_settings = get_settings()
+        openalex_keys = _credential_pool(runtime_settings, "openalex") or [""]
+        semantic_keys = _credential_pool(runtime_settings, "semantic", app_settings.s2_api_key) or [
+            ""
+        ]
+
+        from app.services.literature.arxiv import ArxivClient
+        from app.services.literature.openalex import OpenAlexClient
+        from app.services.literature.semantic_scholar import SemanticScholarClient
+
+        multi_source = MultiSourceClient(
+            provider_keys=runtime_settings.get("provider_keys")
+            if isinstance(runtime_settings.get("provider_keys"), Mapping)
+            else None
         )
-    )
-    return _DEFAULT_REGISTRY
+        registry = AdapterRegistry(
+            (
+                RotatingAdapter(
+                    "openalex",
+                    [OpenAlexAdapter(OpenAlexClient(api_key=key or None)) for key in openalex_keys],
+                ),
+                RotatingAdapter(
+                    "semantic",
+                    [
+                        SemanticScholarAdapter(SemanticScholarClient(api_key=key or None))
+                        for key in semantic_keys
+                    ],
+                ),
+                ArxivAdapter(ArxivClient()),
+                *(
+                    MultiSourceAdapter(source, multi_source)
+                    for source in (
+                        "pubmed",
+                        "crossref",
+                        "europepmc",
+                        "hal",
+                        "core",
+                        "base",
+                        "sciverse",
+                        "unpaywall",
+                    )
+                ),
+            )
+        )
+        _REGISTRY_CACHE = (fingerprint, registry)
+        return registry
 
 
 async def run_discovery(
@@ -275,7 +336,10 @@ async def run_discovery(
     if run.status == "cancelled":
         return run
 
-    registry = registry or await _default_registry()
+    if registry is None:
+        registry = await build_adapter_registry(
+            await literature_settings.get_runtime_settings(session)
+        )
     started = now or datetime.now(UTC)
     run.status = "running"
     run.started_at = run.started_at or started

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -55,3 +55,49 @@ async def test_literature_settings_reject_invalid_source_and_year_window(client)
     )
     assert response.status_code == 422
     assert "INVALID_LITERATURE_SETTING:year_window" in response.text
+
+
+async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(client):
+    admin, _ = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/literature-search",
+        json={
+            "sources": ["pubmed", "core"],
+            "requested_count": 50,
+            "candidate_budget": 150,
+            "start_year": 2016,
+            "end_year": 2025,
+            "score_weights": {"relevance": 0.8, "quality": 0.2},
+            "provider_keys": {"pubmed": ["private-pubmed-key"]},
+        },
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    library = await client.post(
+        "/api/libraries",
+        json={"name": "Admin defaults", "statement": "Runtime wiring"},
+        headers=admin,
+    )
+    assert library.status_code == 201, library.text
+
+    response = await client.post(
+        f"/api/libraries/{library.json()['id']}/literature/runs",
+        json={
+            "topic": "structural impact response",
+            "source_config": {"provider_keys": {"pubmed": ["request-injected-secret"]}},
+        },
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    run = response.json()
+    assert run["requested_count"] == 50
+    assert run["candidate_budget"] == 150
+    assert run["start_year"] == 2016
+    assert run["end_year"] == 2025
+    assert run["source_config"] == {
+        "sources": ["pubmed", "core"],
+        "score_weights": {"relevance": 0.8, "quality": 0.2},
+    }
+    assert [attempt["source"] for attempt in run["source_attempts"]] == ["core", "pubmed"]
+    assert "private-pubmed-key" not in response.text
+    assert "request-injected-secret" not in response.text

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -12,8 +12,17 @@ from app.models.literature_discovery import (
     LiteratureSourceAttempt,
 )
 from app.models.paper import Paper
-from app.schemas.literature_discovery import LiteratureCandidate, SourceSearchPage
-from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
+from app.schemas.literature_discovery import (
+    LiteratureCandidate,
+    SourceSearchPage,
+    SourceSearchRequest,
+)
+from app.services.literature import runtime as runtime_service
+from app.services.literature.multi_source import (
+    MultiSourceClient,
+    ProviderRequestError,
+    _pubmed_abstracts,
+)
 from app.services.literature.openalex import _simplify
 from app.services.literature.runtime import (
     AdapterRegistry,
@@ -161,7 +170,7 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
 
 @pytest.mark.asyncio
 async def test_runtime_marks_missing_sources_as_failed(client):
-    run_id, _, _ = await _create_run(client, source_config={})
+    run_id, _, _ = await _create_run(client, source_config={"sources": []})
     async with get_sessionmaker()() as session:
         run = await run_discovery(session, run_id, registry=AdapterRegistry())
         assert run.status == "failed"
@@ -293,3 +302,114 @@ async def test_runtime_persists_provider_error_instead_of_reporting_zero_hit_suc
     assert attempt.error_code == "HTTP_503"
     assert attempt.retryable is True
     assert "HTTP_503" in (run.error_summary or "")
+
+
+@pytest.mark.asyncio
+async def test_runtime_builds_default_registry_from_decrypted_admin_settings(client, monkeypatch):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["pubmed"]},
+        requested_count=1,
+        candidate_budget=3,
+    )
+    adapter = FakeAdapter("pubmed", [_candidate("pubmed", "Configured provider")])
+    runtime_settings = {
+        "sources": ["pubmed"],
+        "provider_keys": {"pubmed": ["decrypted-key"]},
+    }
+    observed = {}
+
+    async def fake_runtime_settings(session):
+        return runtime_settings
+
+    async def fake_registry(settings):
+        observed.update(settings)
+        return AdapterRegistry((adapter,))
+
+    monkeypatch.setattr(
+        runtime_service.literature_settings, "get_runtime_settings", fake_runtime_settings
+    )
+    monkeypatch.setattr(runtime_service, "build_adapter_registry", fake_registry)
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(session, run_id)
+
+    assert run.status == "completed"
+    assert observed["provider_keys"] == {"pubmed": ["decrypted-key"]}
+    assert adapter.requests[0].limit == 3
+
+
+def test_multi_source_key_pool_rotates_and_pubmed_xml_keeps_full_abstract():
+    client = MultiSourceClient(
+        client=object(), provider_keys={"provider-under-test": ["key-a", "key-b"]}
+    )
+    assert {
+        client._key("provider-under-test"),
+        client._key("provider-under-test"),
+    } == {"key-a", "key-b"}
+
+    abstracts = _pubmed_abstracts(
+        """<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>
+        <Article><Abstract><AbstractText Label="BACKGROUND">First sentence.</AbstractText>
+        <AbstractText>Second sentence.</AbstractText></Abstract></Article>
+        </MedlineCitation></PubmedArticle></PubmedArticleSet>"""
+    )
+    assert abstracts == {"123": "BACKGROUND: First sentence.\nSecond sentence."}
+
+
+@pytest.mark.asyncio
+async def test_pubmed_adapter_fetches_abstract_and_forwards_years_and_admin_key():
+    class Response:
+        status_code = 200
+
+        def __init__(self, *, payload=None, text=""):
+            self._payload = payload
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        async def request(self, method, url, **kwargs):
+            self.calls.append((method, url, kwargs))
+            if "esearch" in url:
+                return Response(payload={"esearchresult": {"idlist": ["123"]}})
+            if "esummary" in url:
+                return Response(
+                    payload={
+                        "result": {
+                            "123": {
+                                "title": "PubMed full abstract",
+                                "pubdate": "2020",
+                                "authors": [{"name": "A. Author"}],
+                                "articleids": [{"idtype": "doi", "value": "10.1/pubmed"}],
+                            }
+                        }
+                    }
+                )
+            return Response(
+                text=(
+                    "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>"
+                    "<Article><Abstract><AbstractText>Full indexed abstract.</AbstractText>"
+                    "</Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+                )
+            )
+
+    http_client = Client()
+    client = MultiSourceClient(client=http_client, provider_keys={"pubmed": ["admin-pubmed-key"]})
+    rows = await client.search_source(
+        "pubmed",
+        SourceSearchRequest(query="impact response", start_year=2016, end_year=2025, limit=5),
+    )
+
+    assert rows[0]["abstract"] == "Full indexed abstract."
+    search_params = http_client.calls[0][2]["params"]
+    assert search_params["term"] == "(impact response) AND (2016:2025[pdat])"
+    assert search_params["api_key"] == "admin-pubmed-key"
+    assert all(call[2]["params"]["api_key"] == "admin-pubmed-key" for call in http_client.calls)


### PR DESCRIPTION
## Summary

Follow-up to #495, #497, and #498.

- apply persisted administrator source, count, year-window, and score defaults when creating discovery runs
- keep provider credentials out of run snapshots and resolve decrypted key pools only inside the worker runtime
- rotate OpenAlex, Semantic Scholar, PubMed, CORE, and Sciverse credentials without rebuilding every request
- fetch PubMed abstracts via EFetch and enforce provider year windows consistently
- make an explicit empty source list disable discovery instead of falling through to query-plan sources

## Merge independence

This PR is based directly on current `main` (`192f019`) and does not depend on another open PR. It contains no migrations.

## Verification

- `27 passed` across administrator settings, discovery API/contracts/ranking, and runtime tests
- Ruff checks passed
- `git diff --check` passed