### PR TITLE
fix(literature): preserve MinerU parse assets and versions

### DIFF
--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -20,6 +20,22 @@ class MineruCloudError(RuntimeError):
     """A MinerU upload, polling, or result conversion failure."""
 
 
+def _safe_request_failure(prefix: str, error: Exception | None) -> MineruCloudError:
+    """Build a stable error without persisting tokens or signed request URLs."""
+
+    if isinstance(error, httpx.HTTPStatusError):
+        detail = f"HTTP_{error.response.status_code}"
+    elif isinstance(error, httpx.TimeoutException):
+        detail = "TIMEOUT"
+    elif isinstance(error, httpx.RequestError):
+        detail = "NETWORK_ERROR"
+    elif error is not None:
+        detail = type(error).__name__.upper()
+    else:
+        detail = "UNKNOWN"
+    return MineruCloudError(f"{prefix}:{detail}")
+
+
 StatusCallback = Callable[[str], Awaitable[None]]
 _SCHEDULERS_LOCK = Lock()
 _MAX_ARCHIVE_FILES = 10_000
@@ -83,12 +99,7 @@ def _result_payload(payload: Any) -> Mapping[str, Any] | None:
 
 def _safe_archive_name(name: str) -> str | None:
     path = PurePosixPath(name.replace("\\", "/"))
-    if (
-        path.is_absolute()
-        or not path.parts
-        or ".." in path.parts
-        or ":" in path.parts[0]
-    ):
+    if path.is_absolute() or not path.parts or ".." in path.parts or ":" in path.parts[0]:
         return None
     return path.as_posix()
 
@@ -156,8 +167,17 @@ def _zip_result(content: bytes, *, pages: int = 0) -> dict[str, Any]:
             files: list[tuple[str, bytes]] = []
             extracted_bytes = 0
             accepted_extensions = {
-                ".md", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
-                ".csv", ".html", ".htm", ".xlsx",
+                ".md",
+                ".png",
+                ".jpg",
+                ".jpeg",
+                ".gif",
+                ".webp",
+                ".svg",
+                ".csv",
+                ".html",
+                ".htm",
+                ".xlsx",
             }
             for info in infos:
                 name = _safe_archive_name(info.filename)
@@ -235,7 +255,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_REQUEST_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_REQUEST_FAILED", last) from last
 
     async def _upload(self, url: str, content: bytes) -> None:
         last: Exception | None = None
@@ -250,7 +270,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_UPLOAD_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_UPLOAD_FAILED", last) from last
 
     async def _get_bytes(self, url: str) -> bytes:
         last: Exception | None = None
@@ -263,7 +283,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_RESULT_DOWNLOAD_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_RESULT_DOWNLOAD_FAILED", last) from last
 
     async def parse(
         self, pdf_path: Path, *, on_status: StatusCallback | None = None
@@ -330,10 +350,7 @@ class MineruCloudParser:
                         raise MineruCloudError("MINERU_RESULT_URL_MISSING")
                     if state in {"failed", "error", "failure"}:
                         raise MineruCloudError(
-                            str(
-                                _find(row, "err_msg", "error", "message")
-                                or "MINERU_PARSE_FAILED"
-                            )
+                            str(_find(row, "err_msg", "error", "message") or "MINERU_PARSE_FAILED")
                         )
                 await asyncio.sleep(self._settings.mineru_poll_interval_seconds)
             raise MineruCloudError("MINERU_TIMEOUT")

--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -7,7 +7,8 @@ import io
 import re
 import zipfile
 from collections.abc import Awaitable, Callable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from threading import Lock
 from typing import Any
 
 import httpx
@@ -20,6 +21,36 @@ class MineruCloudError(RuntimeError):
 
 
 StatusCallback = Callable[[str], Awaitable[None]]
+_SCHEDULERS_LOCK = Lock()
+_MAX_ARCHIVE_FILES = 10_000
+_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+
+
+class _MineruScheduler:
+    """Share token rotation and concurrency limits across parser instances."""
+
+    def __init__(self, tokens: list[str], concurrency: int) -> None:
+        self.tokens = tuple(tokens)
+        self.semaphore = asyncio.Semaphore(concurrency)
+        self._index = 0
+        self._lock = Lock()
+
+    def next_token(self) -> str:
+        if not self.tokens:
+            raise MineruCloudError("MINERU_NOT_CONFIGURED")
+        with self._lock:
+            token = self.tokens[self._index % len(self.tokens)]
+            self._index += 1
+        return token
+
+
+_SCHEDULERS: dict[tuple[tuple[str, ...], int], _MineruScheduler] = {}
+
+
+def _scheduler(tokens: list[str], concurrency: int) -> _MineruScheduler:
+    key = (tuple(tokens), concurrency)
+    with _SCHEDULERS_LOCK:
+        return _SCHEDULERS.setdefault(key, _MineruScheduler(tokens, concurrency))
 
 
 def _tokens(raw: str) -> list[str]:
@@ -33,6 +64,13 @@ def _find(mapping: Mapping[str, Any], *keys: str) -> Any:
     return None
 
 
+def _page_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _result_payload(payload: Any) -> Mapping[str, Any] | None:
     if isinstance(payload, Mapping):
         for key in ("data", "result", "extract_result", "extractResult"):
@@ -43,7 +81,32 @@ def _result_payload(payload: Any) -> Mapping[str, Any] | None:
     return None
 
 
-def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
+def _safe_archive_name(name: str) -> str | None:
+    path = PurePosixPath(name.replace("\\", "/"))
+    if (
+        path.is_absolute()
+        or not path.parts
+        or ".." in path.parts
+        or ":" in path.parts[0]
+    ):
+        return None
+    return path.as_posix()
+
+
+def _decode_markdown(content: bytes) -> str:
+    try:
+        return content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise MineruCloudError("MINERU_MARKDOWN_ENCODING_INVALID") from exc
+
+
+def _markdown_result(
+    markdown: str,
+    *,
+    pages: int = 0,
+    markdown_path: str = "content.md",
+    artifacts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     text = re.sub(r"\n{3,}", "\n\n", markdown.replace("\r\n", "\n")).strip()
     if not text:
         raise MineruCloudError("MINERU_MARKDOWN_EMPTY")
@@ -66,6 +129,9 @@ def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
                 "anchor_meta": {"parser": "mineru"},
             }
         )
+    artifacts = artifacts or []
+    images = [item["path"] for item in artifacts if item["kind"] == "image"]
+    tables = [item["path"] for item in artifacts if item["kind"] == "table"]
     return {
         "parser": "mineru",
         "parser_version": "cloud",
@@ -73,8 +139,66 @@ def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
         "text": text,
         "pages": pages or current_page,
         "chunks": chunks,
-        "manifest": {"pages": pages or current_page, "images": [], "tables": []},
+        "markdown_path": markdown_path,
+        "artifacts": artifacts,
+        "manifest": {"pages": pages or current_page, "images": images, "tables": tables},
     }
+
+
+def _zip_result(content: bytes, *, pages: int = 0) -> dict[str, Any]:
+    if len(content) > _MAX_ARCHIVE_BYTES:
+        raise MineruCloudError("MINERU_ARCHIVE_TOO_LARGE")
+    try:
+        with zipfile.ZipFile(io.BytesIO(content)) as bundle:
+            infos = bundle.infolist()
+            if len(infos) > _MAX_ARCHIVE_FILES:
+                raise MineruCloudError("MINERU_ARCHIVE_TOO_MANY_FILES")
+            files: list[tuple[str, bytes]] = []
+            extracted_bytes = 0
+            accepted_extensions = {
+                ".md", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
+                ".csv", ".html", ".htm", ".xlsx",
+            }
+            for info in infos:
+                name = _safe_archive_name(info.filename)
+                if (
+                    name is None
+                    or info.is_dir()
+                    or PurePosixPath(name).suffix.lower() not in accepted_extensions
+                ):
+                    continue
+                extracted_bytes += info.file_size
+                if extracted_bytes > _MAX_ARCHIVE_BYTES:
+                    raise MineruCloudError("MINERU_ARCHIVE_TOO_LARGE")
+                files.append((name, bundle.read(info)))
+    except MineruCloudError:
+        raise
+    except (zipfile.BadZipFile, zipfile.LargeZipFile, RuntimeError) as exc:
+        raise MineruCloudError("MINERU_ARCHIVE_INVALID") from exc
+    markdown_files = [(name, data) for name, data in files if name.lower().endswith(".md")]
+    if not markdown_files:
+        raise MineruCloudError("MINERU_MARKDOWN_MISSING")
+    markdown_name, markdown_bytes = max(markdown_files, key=lambda item: len(item[1]))
+    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+    table_extensions = {".csv", ".html", ".htm", ".xlsx"}
+    artifacts: list[dict[str, Any]] = []
+    for name, data in files:
+        suffix = PurePosixPath(name).suffix.lower()
+        kind = (
+            "image"
+            if suffix in image_extensions
+            else "table"
+            if suffix in table_extensions
+            else None
+        )
+        if kind is not None:
+            artifacts.append({"path": name, "kind": kind, "content": data})
+    return _markdown_result(
+        _decode_markdown(markdown_bytes),
+        pages=pages,
+        markdown_path=markdown_name,
+        artifacts=artifacts,
+    )
 
 
 class MineruCloudParser:
@@ -86,19 +210,14 @@ class MineruCloudParser:
         self._client = client or httpx.AsyncClient(timeout=settings.mineru_timeout_seconds)
         self._owns_client = client is None
         self._tokens = _tokens(settings.mineru_api_tokens)
-        self._token_index = 0
-        self._semaphore = asyncio.Semaphore(settings.mineru_concurrency)
+        self._scheduler = _scheduler(self._tokens, settings.mineru_concurrency)
 
     async def aclose(self) -> None:
         if self._owns_client:
             await self._client.aclose()
 
     def _next_token(self) -> str:
-        if not self._tokens:
-            raise MineruCloudError("MINERU_NOT_CONFIGURED")
-        token = self._tokens[self._token_index % len(self._tokens)]
-        self._token_index += 1
-        return token
+        return self._scheduler.next_token()
 
     async def _json(self, method: str, url: str, *, token: str, **kwargs: Any) -> Any:
         last: Exception | None = None
@@ -118,10 +237,38 @@ class MineruCloudParser:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
         raise MineruCloudError(f"MINERU_REQUEST_FAILED:{last}") from last
 
+    async def _upload(self, url: str, content: bytes) -> None:
+        last: Exception | None = None
+        for attempt in range(self._settings.mineru_retries + 1):
+            try:
+                response = await self._client.put(
+                    url, content=content, headers={"Content-Type": "application/pdf"}
+                )
+                response.raise_for_status()
+                return
+            except httpx.HTTPError as exc:
+                last = exc
+                if attempt < self._settings.mineru_retries:
+                    await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise MineruCloudError(f"MINERU_UPLOAD_FAILED:{last}") from last
+
+    async def _get_bytes(self, url: str) -> bytes:
+        last: Exception | None = None
+        for attempt in range(self._settings.mineru_retries + 1):
+            try:
+                response = await self._client.get(url)
+                response.raise_for_status()
+                return response.content
+            except httpx.HTTPError as exc:
+                last = exc
+                if attempt < self._settings.mineru_retries:
+                    await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise MineruCloudError(f"MINERU_RESULT_DOWNLOAD_FAILED:{last}") from last
+
     async def parse(
         self, pdf_path: Path, *, on_status: StatusCallback | None = None
     ) -> dict[str, Any]:
-        async with self._semaphore:
+        async with self._scheduler.semaphore:
             token = self._next_token()
             if on_status:
                 await on_status("mineru_uploading")
@@ -137,19 +284,20 @@ class MineruCloudParser:
             if not batch_id or not isinstance(files, list) or not files:
                 raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
             upload = files[0] if isinstance(files[0], Mapping) else {"url": files[0]}
-            upload_url = _find(upload, "url", "upload_url", "uploadUrl")
+            upload_url = _find(upload, "url", "file_url", "upload_url", "uploadUrl")
             if not upload_url:
                 raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
             pdf_bytes = await asyncio.to_thread(pdf_path.read_bytes)
-            response = await self._client.put(
-                str(upload_url), content=pdf_bytes, headers={"Content-Type": "application/pdf"}
-            )
-            response.raise_for_status()
+            await self._upload(str(upload_url), pdf_bytes)
             if on_status:
                 await on_status("mineru_parsing")
 
             deadline = asyncio.get_running_loop().time() + self._settings.mineru_timeout_seconds
+            polling_started = False
             while asyncio.get_running_loop().time() < deadline:
+                if on_status and not polling_started:
+                    await on_status("mineru_polling")
+                    polling_started = True
                 result = await self._json(
                     "GET",
                     f"{self._settings.mineru_base_url.rstrip('/')}/extract-results/batch/{batch_id}",
@@ -163,29 +311,22 @@ class MineruCloudParser:
                     if state in {"done", "success", "succeeded", "completed"}:
                         markdown_url = _find(row, "markdown_url", "markdownUrl", "md_url", "mdUrl")
                         if markdown_url:
-                            md_response = await self._client.get(str(markdown_url))
-                            md_response.raise_for_status()
+                            if on_status:
+                                await on_status("mineru_downloading_result")
+                            markdown_bytes = await self._get_bytes(str(markdown_url))
                             return _markdown_result(
-                                md_response.text,
-                                pages=int(_find(row, "page_count", "pageCount") or 0),
+                                _decode_markdown(markdown_bytes),
+                                pages=_page_count(_find(row, "page_count", "pageCount")),
                             )
                         zip_url = _find(row, "full_zip_url", "fullZipUrl", "zip_url", "zipUrl")
                         if zip_url:
-                            archive = await self._client.get(str(zip_url))
-                            archive.raise_for_status()
-                            with zipfile.ZipFile(io.BytesIO(archive.content)) as bundle:
-                                md_name = next(
-                                    (
-                                        name
-                                        for name in bundle.namelist()
-                                        if name.lower().endswith(".md")
-                                    ),
-                                    None,
-                                )
-                                if md_name:
-                                    return _markdown_result(
-                                        bundle.read(md_name).decode("utf-8", errors="replace")
-                                    )
+                            if on_status:
+                                await on_status("mineru_downloading_result")
+                            archive_bytes = await self._get_bytes(str(zip_url))
+                            return _zip_result(
+                                archive_bytes,
+                                pages=_page_count(_find(row, "page_count", "pageCount")),
+                            )
                         raise MineruCloudError("MINERU_RESULT_URL_MISSING")
                     if state in {"failed", "error", "failure"}:
                         raise MineruCloudError(

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import re
+import shutil
 import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path, PurePosixPath
@@ -90,9 +91,7 @@ def _pymupdf_parse_sync(pdf_path: Path) -> ParserResult:
     if not text:
         raise ContentParseError("PDF_TEXT_EMPTY")
     markdown = "\n\n".join(
-        f"## Page {i}\n\n{page}"
-        for i, page in enumerate(pages, start=1)
-        if page
+        f"## Page {i}\n\n{page}" for i, page in enumerate(pages, start=1) if page
     )
     return {
         "parser": "pymupdf",
@@ -138,6 +137,104 @@ async def create_content_version(
     return version
 
 
+async def _persist_parse_result(
+    session: AsyncSession,
+    *,
+    version: PaperContentVersion,
+    result: ParserResult,
+    parser_name: str,
+) -> PaperContentVersion:
+    """Persist one immutable parse result and switch the current version atomically."""
+
+    version_id = version.id
+    directory = _version_dir(version_id)
+    try:
+        text = _clean_text(str(result.get("text") or ""))
+        markdown = _clean_text(str(result.get("markdown") or text))
+        chunks = result.get("chunks") or []
+        if not text or not chunks:
+            raise ContentParseError("PARSED_CONTENT_EMPTY")
+
+        text_path = directory / "content.txt"
+        markdown_path = _output_path(directory, result.get("markdown_path"), fallback="content.md")
+        if markdown_path is None:
+            raise ContentParseError("MARKDOWN_PATH_INVALID")
+        manifest_path = directory / "manifest.json"
+        text_path.write_text(text, encoding="utf-8")
+        markdown_path.write_text(markdown, encoding="utf-8")
+        for artifact in result.get("artifacts") or []:
+            if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
+                continue
+            artifact_path = _output_path(directory, artifact.get("path"))
+            if artifact_path is not None:
+                artifact_path.write_bytes(artifact["content"])
+        manifest_path.write_text(
+            json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        await session.execute(
+            delete(PaperContentChunk).where(PaperContentChunk.content_version_id == version.id)
+        )
+        persisted_chunks: list[PaperContentChunk] = []
+        for seq, item in enumerate(chunks):
+            chunk_text = _clean_text(str(item.get("text") or ""))
+            if not chunk_text:
+                continue
+            chunk = PaperContentChunk(
+                content_version_id=version.id,
+                seq=seq,
+                text=chunk_text,
+                page_start=item.get("page_start"),
+                page_end=item.get("page_end"),
+                rects=item.get("rects") or [],
+                section_path=item.get("section_path") or [],
+                anchor_meta=item.get("anchor_meta") or {},
+            )
+            session.add(chunk)
+            persisted_chunks.append(chunk)
+        await session.flush()
+        await persist_chunk_anchors(
+            session,
+            paper_id=version.paper_id,
+            chunks=persisted_chunks,
+            source=parser_name,
+        )
+        version.parser = parser_name
+        version.parser_version = str(
+            result.get("parser_version") or version.parser_version or "unknown"
+        )
+        version.status = "ready" if parser_name == "mineru" else "ready_fallback"
+        version.markdown_key = str(markdown_path)
+        version.text_key = str(text_path)
+        version.manifest_key = str(manifest_path)
+        version.page_count = int(result.get("pages") or 0)
+        version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
+        version.chunk_vector_state = "pending"
+        version.document_vector_state = "pending"
+        await session.execute(
+            PaperContentVersion.__table__.update()
+            .where(
+                PaperContentVersion.paper_id == version.paper_id,
+                PaperContentVersion.id != version.id,
+            )
+            .values(is_current=False)
+        )
+        version.is_current = True
+        await session.commit()
+        return version
+    except Exception as exc:
+        await session.rollback()
+        await asyncio.to_thread(shutil.rmtree, directory, ignore_errors=True)
+        failed = await session.get(PaperContentVersion, version_id)
+        error_code = str(exc) if isinstance(exc, ContentParseError) else "CONTENT_PERSIST_FAILED"
+        if failed is not None:
+            failed.status = "failed"
+            failed.error_code = error_code
+            failed.error_detail = f"{type(exc).__name__}: {error_code}"[:4000]
+            await session.commit()
+        raise ContentParseError(error_code) from exc
+
+
 async def parse_content_version(
     session: AsyncSession,
     *,
@@ -173,6 +270,7 @@ async def parse_content_version(
             else:
                 raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
         if hasattr(mineru_parser, "parse"):
+
             async def update_status(value: str) -> None:
                 version.status = value
                 await session.commit()
@@ -209,87 +307,9 @@ async def parse_content_version(
             await session.commit()
             raise ContentParseError("PYMUPDF_FAILED") from fallback_exc
 
-    text = _clean_text(str(result.get("text") or ""))
-    markdown = _clean_text(str(result.get("markdown") or text))
-    chunks = result.get("chunks") or []
-    if not text or not chunks:
-        version.status = "failed"
-        version.error_code = "PARSED_CONTENT_EMPTY"
-        version.error_detail = "parser returned no text or chunks"
-        await session.commit()
-        raise ContentParseError("PARSED_CONTENT_EMPTY")
-
-    directory = _version_dir(version.id)
-    text_path = directory / "content.txt"
-    markdown_path = _output_path(
-        directory, result.get("markdown_path"), fallback="content.md"
+    return await _persist_parse_result(
+        session, version=version, result=result, parser_name=parser_name
     )
-    if markdown_path is None:
-        raise ContentParseError("MARKDOWN_PATH_INVALID")
-    manifest_path = directory / "manifest.json"
-    text_path.write_text(text, encoding="utf-8")
-    markdown_path.write_text(markdown, encoding="utf-8")
-    for artifact in result.get("artifacts") or []:
-        if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
-            continue
-        artifact_path = _output_path(directory, artifact.get("path"))
-        if artifact_path is not None:
-            artifact_path.write_bytes(artifact["content"])
-    manifest_path.write_text(
-        json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
-    await session.execute(
-        delete(PaperContentChunk).where(
-            PaperContentChunk.content_version_id == version.id
-        )
-    )
-    persisted_chunks: list[PaperContentChunk] = []
-    for seq, item in enumerate(chunks):
-        chunk_text = _clean_text(str(item.get("text") or ""))
-        if not chunk_text:
-            continue
-        chunk = PaperContentChunk(
-            content_version_id=version.id,
-            seq=seq,
-            text=chunk_text,
-            page_start=item.get("page_start"),
-            page_end=item.get("page_end"),
-            rects=item.get("rects") or [],
-            section_path=item.get("section_path") or [],
-            anchor_meta=item.get("anchor_meta") or {},
-        )
-        session.add(chunk)
-        persisted_chunks.append(chunk)
-    await session.flush()  # chunk.id 供锚点引用
-    await persist_chunk_anchors(
-        session,
-        paper_id=version.paper_id,
-        chunks=persisted_chunks,
-        source=parser_name,
-    )
-    version.parser = parser_name
-    version.parser_version = str(
-        result.get("parser_version") or version.parser_version or "unknown"
-    )
-    version.status = "ready" if parser_name == "mineru" else "ready_fallback"
-    version.markdown_key = str(markdown_path)
-    version.text_key = str(text_path)
-    version.manifest_key = str(manifest_path)
-    version.page_count = int(result.get("pages") or 0)
-    version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
-    version.chunk_vector_state = "pending"
-    version.document_vector_state = "pending"
-    await session.execute(
-        PaperContentVersion.__table__.update()
-        .where(
-            PaperContentVersion.paper_id == version.paper_id,
-            PaperContentVersion.id != version.id,
-        )
-        .values(is_current=False)
-    )
-    version.is_current = True
-    await session.commit()
-    return version
 
 
 async def current_content_version(

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -6,7 +6,7 @@ import logging
 import re
 import uuid
 from collections.abc import Awaitable, Callable
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pymupdf
@@ -48,6 +48,23 @@ def _content_root() -> Path:
 def _version_dir(version_id: uuid.UUID) -> Path:
     path = _content_root() / str(version_id)
     path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _output_path(root: Path, name: object, *, fallback: str | None = None) -> Path | None:
+    """Resolve an archive-relative output path below the immutable version directory."""
+    relative = PurePosixPath(str(name or "").replace("\\", "/"))
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or ".." in relative.parts
+        or ":" in relative.parts[0]
+    ):
+        if fallback is None:
+            return None
+        relative = PurePosixPath(fallback)
+    path = root.joinpath(*relative.parts)
+    path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -95,11 +112,12 @@ async def create_content_version(
     parser: str = "mineru",
     parser_version: str | None = None,
 ) -> PaperContentVersion:
-    """Create a new immutable attempt and retire the previous current version."""
-    await session.execute(
-        PaperContentVersion.__table__.update()
-        .where(PaperContentVersion.paper_id == asset.paper_id)
-        .values(is_current=False)
+    """Create an immutable attempt without replacing usable content prematurely."""
+    current = await session.scalar(
+        select(PaperContentVersion.id).where(
+            PaperContentVersion.paper_id == asset.paper_id,
+            PaperContentVersion.is_current.is_(True),
+        )
     )
     latest = await session.scalar(
         select(func.max(PaperContentVersion.version_no)).where(
@@ -113,7 +131,7 @@ async def create_content_version(
         parser=parser,
         parser_version=parser_version,
         status="queued",
-        is_current=True,
+        is_current=current is None,
     )
     session.add(version)
     await session.flush()
@@ -203,10 +221,20 @@ async def parse_content_version(
 
     directory = _version_dir(version.id)
     text_path = directory / "content.txt"
-    markdown_path = directory / "content.md"
+    markdown_path = _output_path(
+        directory, result.get("markdown_path"), fallback="content.md"
+    )
+    if markdown_path is None:
+        raise ContentParseError("MARKDOWN_PATH_INVALID")
     manifest_path = directory / "manifest.json"
     text_path.write_text(text, encoding="utf-8")
     markdown_path.write_text(markdown, encoding="utf-8")
+    for artifact in result.get("artifacts") or []:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
+            continue
+        artifact_path = _output_path(directory, artifact.get("path"))
+        if artifact_path is not None:
+            artifact_path.write_bytes(artifact["content"])
     manifest_path.write_text(
         json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2), encoding="utf-8"
     )
@@ -251,6 +279,15 @@ async def parse_content_version(
     version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
     version.chunk_vector_state = "pending"
     version.document_vector_state = "pending"
+    await session.execute(
+        PaperContentVersion.__table__.update()
+        .where(
+            PaperContentVersion.paper_id == version.paper_id,
+            PaperContentVersion.id != version.id,
+        )
+        .values(is_current=False)
+    )
+    version.is_current = True
     await session.commit()
     return version
 

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 from pathlib import Path
 
+import httpx
 import pytest
 
 from app.core.config import get_settings
@@ -18,7 +19,9 @@ class FakeMineruClient:
         self.calls.append((method, url))
         if method == "POST":
             return FakeResponse(
-                json_data={"data": {"batch_id": "batch-1", "file_urls": [{"url": "https://upload"}]}},
+                json_data={
+                    "data": {"batch_id": "batch-1", "file_urls": [{"url": "https://upload"}]}
+                },
             )
         return FakeResponse(
             json_data={
@@ -142,3 +145,24 @@ def test_scheduler_rotates_configured_tokens():
         "key-a",
         "key-b",
     ]
+
+
+@pytest.mark.asyncio
+async def test_signed_upload_url_is_not_exposed_in_mineru_error(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "mineru_api_tokens", "key-a", raising=False)
+    monkeypatch.setattr(settings, "mineru_retries", 0, raising=False)
+    signed_url = "https://upload.example.test/file?signature=SECRET_SENTINEL"
+
+    class BrokenClient:
+        async def put(self, url, **_kwargs):
+            request = httpx.Request("PUT", url)
+            response = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    parser = MineruCloudParser(client=BrokenClient())
+    with pytest.raises(Exception) as caught:
+        await parser._upload(signed_url, b"pdf")
+
+    assert str(caught.value) == "MINERU_UPLOAD_FAILED:HTTP_401"
+    assert "SECRET_SENTINEL" not in str(caught.value)

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -1,5 +1,7 @@
 """MinerU Cloud upload/poll normalization contract tests."""
 
+import io
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -69,5 +71,74 @@ async def test_mineru_cloud_upload_poll_and_normalize(tmp_path: Path, monkeypatc
     assert result["parser"] == "mineru"
     assert result["pages"] == 2
     assert result["chunks"]
-    assert statuses == ["mineru_uploading", "mineru_parsing"]
+    assert statuses == [
+        "mineru_uploading",
+        "mineru_parsing",
+        "mineru_polling",
+        "mineru_downloading_result",
+    ]
     assert [method for method, _url in client.calls] == ["POST", "PUT", "GET", "GET"]
+
+
+def test_zip_result_keeps_markdown_images_and_tables():
+    from app.services.mineru import _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", "# Title\n\n![Figure](images/figure.png)\n\n| A | B |")
+        bundle.writestr("images/figure.png", b"png-bytes")
+        bundle.writestr("tables/data.csv", "a,b\n1,2")
+    result = _zip_result(buffer.getvalue(), pages=3)
+
+    assert result["pages"] == 3
+    assert result["markdown_path"] == "paper.md"
+    assert {item["path"] for item in result["artifacts"]} == {
+        "images/figure.png",
+        "tables/data.csv",
+    }
+    assert result["manifest"]["images"] == ["images/figure.png"]
+    assert result["manifest"]["tables"] == ["tables/data.csv"]
+
+
+def test_zip_result_ignores_archive_traversal_entries():
+    from app.services.mineru import _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", "# Safe")
+        bundle.writestr("../outside.png", b"not-written")
+
+    result = _zip_result(buffer.getvalue())
+
+    assert result["manifest"]["images"] == []
+
+
+def test_zip_result_rejects_invalid_archive():
+    from app.services.mineru import MineruCloudError, _zip_result
+
+    with pytest.raises(MineruCloudError, match="MINERU_ARCHIVE_INVALID"):
+        _zip_result(b"not-a-zip")
+
+
+def test_zip_result_rejects_invalid_markdown_encoding():
+    from app.services.mineru import MineruCloudError, _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", b"\xff\xfe")
+
+    with pytest.raises(MineruCloudError, match="MINERU_MARKDOWN_ENCODING_INVALID"):
+        _zip_result(buffer.getvalue())
+
+
+def test_scheduler_rotates_configured_tokens():
+    from app.services.mineru import _MineruScheduler
+
+    scheduler = _MineruScheduler(["key-a", "key-b"], concurrency=2)
+
+    assert [scheduler.next_token() for _ in range(4)] == [
+        "key-a",
+        "key-b",
+        "key-a",
+        "key-b",
+    ]

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -69,9 +69,7 @@ async def test_mineru_failure_falls_back_to_pymupdf_and_persists_version(app, cl
         async def failing_mineru(_path):
             raise RuntimeError("mineru unavailable")
 
-        parsed = await parse_content_version(
-            session, version=version, mineru_parser=failing_mineru
-        )
+        parsed = await parse_content_version(session, version=version, mineru_parser=failing_mineru)
         assert parsed.status == "ready_fallback"
         assert parsed.parser == "pymupdf"
         assert parsed.page_count == 1
@@ -150,9 +148,7 @@ async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
                 "pages": 1,
                 "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
                 "markdown_path": "paper.md",
-                "artifacts": [
-                    {"path": "images/figure.png", "kind": "image", "content": b"png"}
-                ],
+                "artifacts": [{"path": "images/figure.png", "kind": "image", "content": b"png"}],
                 "manifest": {"pages": 1, "images": ["images/figure.png"]},
             }
 
@@ -160,6 +156,46 @@ async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
         version_dir = Path(parsed.markdown_key).parent
         assert (version_dir / "paper.md").read_text(encoding="utf-8").startswith("# Full")
         assert (version_dir / "images" / "figure.png").read_bytes() == b"png"
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_marks_attempt_failed_and_keeps_previous_current(
+    app, client, monkeypatch
+):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await create_content_version(session, asset=asset, parser="pymupdf")
+        await parse_content_version(session, version=first, mineru_parser=None)
+        second = await create_content_version(session, asset=asset)
+
+        async def fake_mineru(_path):
+            return {
+                "parser": "mineru",
+                "markdown": "# Parsed\n\nFull text",
+                "text": "Full text",
+                "pages": 1,
+                "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
+            }
+
+        async def fail_anchor_persistence(*_args, **_kwargs):
+            raise RuntimeError("database write failed")
+
+        monkeypatch.setattr(
+            "app.services.paper_content.persist_chunk_anchors", fail_anchor_persistence
+        )
+        with pytest.raises(ContentParseError, match="CONTENT_PERSIST_FAILED"):
+            await parse_content_version(
+                session, version=second, mineru_parser=fake_mineru, allow_fallback=False
+            )
+        await session.refresh(first)
+        failed = await session.get(PaperContentVersion, second.id)
+        current = await current_content_version(session, paper_id=paper.id)
+
+    assert first.is_current is True
+    assert current is not None and current.id == first.id
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.error_code == "CONTENT_PERSIST_FAILED"
 
 
 @pytest.mark.asyncio
@@ -223,15 +259,11 @@ async def test_vectorize_persists_document_and_chunk_vectors(app, client, monkey
     async def fake_embed_documents(session, texts, **_kwargs):
         return [[float(index), 0.5, 1.0] for index, _ in enumerate(texts)], space
 
-    monkeypatch.setattr(
-        "app.services.embedding.embed_documents", fake_embed_documents
-    )
+    monkeypatch.setattr("app.services.embedding.embed_documents", fake_embed_documents)
     async with get_sessionmaker()() as session:
         version = await create_content_version(session, asset=asset)
         await parse_content_version(session, version=version, mineru_parser=None)
-        await vectorize_content_version(
-            session, version=version, library_id=library.id
-        )
+        await vectorize_content_version(session, version=version, library_id=library.id)
         await session.refresh(version)
         assert version.status == "vector_ready"
         assert version.document_vector_state == "ready"
@@ -243,6 +275,4 @@ async def test_vectorize_persists_document_and_chunk_vectors(app, client, monkey
                 )
             )
         ) is not None
-        assert (
-            await session.scalar(select(PaperContentChunkVector))
-        ) is not None
+        assert (await session.scalar(select(PaperContentChunkVector))) is not None

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -1,6 +1,7 @@
 """Issue #455: versioned parser lifecycle and vector-state persistence."""
 
 import uuid
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -108,6 +109,57 @@ async def test_reparse_creates_new_current_version_without_mutating_old(app, cli
         assert context is not None
         assert context["version_id"] == str(second.id)
         assert context["chunks"][0]["evidence"]
+
+
+@pytest.mark.asyncio
+async def test_failed_reparse_keeps_previous_current_version(app, client):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await create_content_version(session, asset=asset, parser="pymupdf")
+        await parse_content_version(session, version=first, mineru_parser=None)
+        second = await create_content_version(session, asset=asset)
+
+        async def failing_mineru(_path):
+            raise RuntimeError("cloud timeout")
+
+        with pytest.raises(ContentParseError, match="MINERU_FAILED"):
+            await parse_content_version(
+                session,
+                version=second,
+                mineru_parser=failing_mineru,
+                allow_fallback=False,
+            )
+        current = await current_content_version(session, paper_id=paper.id)
+        assert current is not None
+        assert current.id == first.id
+        assert second.is_current is False
+
+
+@pytest.mark.asyncio
+async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
+    _user_row, _library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+
+        async def fake_mineru(_path):
+            return {
+                "parser": "mineru",
+                "parser_version": "cloud-test",
+                "markdown": "# Full text\n\n![Figure](images/figure.png)",
+                "text": "Full text",
+                "pages": 1,
+                "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
+                "markdown_path": "paper.md",
+                "artifacts": [
+                    {"path": "images/figure.png", "kind": "image", "content": b"png"}
+                ],
+                "manifest": {"pages": 1, "images": ["images/figure.png"]},
+            }
+
+        parsed = await parse_content_version(session, version=version, mineru_parser=fake_mineru)
+        version_dir = Path(parsed.markdown_key).parent
+        assert (version_dir / "paper.md").read_text(encoding="utf-8").startswith("# Full")
+        assert (version_dir / "images" / "figure.png").read_bytes() == b"png"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- share MinerU token rotation and concurrency limits across parser instances
- separate upload, processing poll and result-download status transitions
- validate ZIP paths, expanded size, file count and Markdown encoding
- persist MinerU Markdown, image and table artifacts under the content version
- keep the previous current version until a replacement parse succeeds

## Problem

A reparse currently marks the new version as current before MinerU finishes. If the cloud parse fails, callers can lose access to usable structured content. Result ZIP handling also replaces invalid UTF-8 and keeps only one Markdown file, which hides encoding failures and drops figures and tables.

## Behavior

The parser now reports `mineru_uploading`, `mineru_parsing`, `mineru_polling` and `mineru_downloading_result`. The processing deadline starts after the upload succeeds. Upload and result download calls use bounded retries.

ZIP output accepts Markdown, image and table assets only. It rejects unsafe paths, oversized archives and malformed Markdown. A successful parse stores those artifacts inside the immutable content-version directory.

Creating a reparse attempt no longer retires the active version. The service switches `is_current` only after content, chunks and evidence anchors have been persisted. Failed reparses retain the previous current version. PyMuPDF fallback behavior is unchanged.

## Compatibility

- No database migration.
- No API schema change.
- No frontend change.
- Existing vectorization still starts after parsing through the same worker task.
- The branch starts directly from `origin/main@192f019` and does not depend on #504 or #505.

## Non-goals

- structured reader endpoints or UI
- historical version deletion
- embedding model or vector schema changes

## Verification

```text
python -m ruff check app/services/mineru.py app/services/paper_content.py tests/test_mineru.py tests/test_paper_content.py
All checks passed

python -m pytest -q tests/test_mineru.py tests/test_paper_content.py tests/test_evidence_anchors.py tests/test_download_batch_protocol.py tests/test_paper_assets.py
29 passed, 2 warnings
```

The warnings are the existing FastAPI 422 deprecation and SQLite Alembic foreign-key reflection warnings. A changed-diff sensitive-value scan and `git diff --check` also passed.

Closes #506