### PR TITLE
feat(admin): add literature provider credential pool lifecycle

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -213,7 +213,7 @@ async def set_literature_search_settings(
 ) -> LiteratureSearchSettings:
     try:
         saved = await literature_settings_service.update_settings(
-            session, payload.model_dump(exclude_none=True)
+            session, payload.model_dump(exclude_unset=True)
         )
     except literature_settings_service.InvalidLiteratureSettingError as exc:
         raise HTTPException(
@@ -234,9 +234,11 @@ async def test_literature_provider(
     source = payload.source.strip().lower()
     started = time.perf_counter()
     try:
-        from app.services.literature.runtime import _default_registry
+        from app.services.literature.runtime import build_adapter_registry
 
-        registry = await _default_registry()
+        registry = await build_adapter_registry(
+            await literature_settings_service.get_runtime_settings(session)
+        )
         adapter = registry.get(source)
         if adapter is None:
             raise ValueError(f"unsupported source: {source}")

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -34,6 +34,7 @@ from app.services import lab as lab_service
 from app.services import literature_settings as literature_settings_service
 from app.services import managed_command_watchdog as watchdog_service
 from app.services import tts as tts_service
+from app.services.literature.multi_source import provider_failure_detail
 
 router = APIRouter(
     prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
@@ -122,9 +123,7 @@ async def adopt_embedding_space(
             "active": True,
         },
     )
-    return EmbeddingSpaceAdoptResult(
-        active=EmbeddingSpaceItem(**current), previous=previous
-    )
+    return EmbeddingSpaceAdoptResult(active=EmbeddingSpaceItem(**current), previous=previous)
 
 
 @router.get("/lab-leaderboard", response_model=LabLeaderboardSettingRead)
@@ -189,9 +188,7 @@ async def set_managed_command_watchdog(
     payload: ManagedCommandWatchdogAdminSettings,
     session: AsyncSession = Depends(get_session),
 ) -> ManagedCommandWatchdogAdminSettings:
-    saved = await watchdog_service.set_admin_max_minutes(
-        session, payload.max_unanswered_minutes
-    )
+    saved = await watchdog_service.set_admin_max_minutes(session, payload.max_unanswered_minutes)
     return ManagedCommandWatchdogAdminSettings(max_unanswered_minutes=saved)
 
 
@@ -262,7 +259,7 @@ async def test_literature_provider(
             source=source,
             ok=False,
             latency_ms=round((time.perf_counter() - started) * 1000),
-            detail=f"{type(exc).__name__}: {exc}"[:500],
+            detail=provider_failure_detail(source, exc)[1],
         )
     await literature_settings_service.record_provider_health(
         session, source=source, ok=result.ok, detail=result.detail
@@ -369,7 +366,7 @@ async def test_literature_provider_credential(
             source=source,
             ok=False,
             latency_ms=round((time.perf_counter() - started) * 1000),
-            detail=f"{type(exc).__name__}: {exc}"[:500],
+            detail=provider_failure_detail(source, exc)[1],
         )
     await literature_settings_service.record_credential_health(
         session, credential_id, ok=result.ok, detail=result.detail

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -15,6 +15,10 @@ from app.schemas.admin_settings import (
     ExperimentEnvSettings,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
+    LiteratureProviderCredentialCreate,
+    LiteratureProviderCredentialTestRequest,
+    LiteratureProviderCredentialUpdate,
+    LiteratureProviderKeyStatus,
     LiteratureProviderTestRequest,
     LiteratureProviderTestResult,
     LiteratureSearchSettings,
@@ -262,6 +266,113 @@ async def test_literature_provider(
         )
     await literature_settings_service.record_provider_health(
         session, source=source, ok=result.ok, detail=result.detail
+    )
+    return result
+
+
+@router.post(
+    "/literature-search/credentials",
+    response_model=LiteratureProviderKeyStatus,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_literature_provider_credential(
+    payload: LiteratureProviderCredentialCreate,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderKeyStatus:
+    try:
+        result = await literature_settings_service.create_provider_credential(
+            session, **payload.model_dump()
+        )
+    except literature_settings_service.InvalidLiteratureSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_LITERATURE_CREDENTIAL:{exc.field}",
+        ) from exc
+    return LiteratureProviderKeyStatus(**result)
+
+
+@router.patch(
+    "/literature-search/credentials/{credential_id}",
+    response_model=LiteratureProviderKeyStatus,
+)
+async def update_literature_provider_credential(
+    credential_id: str,
+    payload: LiteratureProviderCredentialUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderKeyStatus:
+    changes = payload.model_dump(exclude_unset=True)
+    if "label" in changes and changes["label"] is None:
+        changes["label"] = ""
+    try:
+        result = await literature_settings_service.update_provider_credential(
+            session, credential_id, **changes
+        )
+    except literature_settings_service.InvalidLiteratureSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_LITERATURE_CREDENTIAL:{exc.field}",
+        ) from exc
+    if result is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+    return LiteratureProviderKeyStatus(**result)
+
+
+@router.delete(
+    "/literature-search/credentials/{credential_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_literature_provider_credential(
+    credential_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    if not await literature_settings_service.delete_provider_credential(session, credential_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+
+
+@router.post(
+    "/literature-search/credentials/{credential_id}/test",
+    response_model=LiteratureProviderTestResult,
+)
+async def test_literature_provider_credential(
+    credential_id: str,
+    payload: LiteratureProviderCredentialTestRequest,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderTestResult:
+    import time
+
+    credential = await literature_settings_service.get_provider_credential_secret(
+        session, credential_id
+    )
+    if credential is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+    source, secret = credential
+    started = time.perf_counter()
+    try:
+        from app.schemas.literature_discovery import SourceSearchRequest
+        from app.services.literature.runtime import build_adapter_registry
+
+        runtime_settings = await literature_settings_service.get_runtime_settings(session)
+        runtime_settings["provider_keys"] = {source: [secret]}
+        adapter = (await build_adapter_registry(runtime_settings)).get(source)
+        if adapter is None:
+            raise ValueError(f"unsupported source: {source}")
+        page = await adapter.search(SourceSearchRequest(query=payload.query, limit=1))
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=True,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            fetched_count=page.fetched_count,
+            detail="credential responded",
+        )
+    except Exception as exc:  # noqa: BLE001 - probe failures are returned as health state
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=False,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            detail=f"{type(exc).__name__}: {exc}"[:500],
+        )
+    await literature_settings_service.record_credential_health(
+        session, credential_id, ok=result.ok, detail=result.detail
     )
     return result
 

--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -34,6 +34,7 @@ from app.schemas.literature_discovery import (
     SourceAttemptRead,
 )
 from app.services import libraries as libraries_service
+from app.services import literature_settings as literature_settings_service
 from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
 from app.services.literature import discovery_runs, oa_cache
 
@@ -76,35 +77,47 @@ async def create_run(
     user: User = Depends(current_active_user),
 ) -> SearchRunDetail:
     library = await _managed_library(session, library_id, user)
+    defaults = await literature_settings_service.get_runtime_settings(session)
+    requested_count = data.requested_count or int(defaults["requested_count"])
+    candidate_budget = data.candidate_budget or int(defaults["candidate_budget"])
+    start_year = data.start_year if data.start_year is not None else defaults.get("start_year")
+    end_year = data.end_year if data.end_year is not None else defaults.get("end_year")
+    source_config = {
+        "sources": list(defaults["sources"]),
+        "score_weights": dict(defaults["score_weights"]),
+        **(data.source_config or {}),
+    }
+    # Provider credentials are resolved by workers and never enter run snapshots.
+    source_config.pop("provider_keys", None)
     query_plan = await apply_profile_to_query_plan(
         session,
         library=library,
         topic=data.topic,
         query_plan=data.query_plan,
-        source_config=data.source_config,
+        source_config=source_config,
     )
     run = LiteratureSearchRun(
         library_id=library.id,
         created_by=user.id,
-        requested_count=data.requested_count,
-        candidate_budget=data.candidate_budget,
-        start_year=data.start_year,
-        end_year=data.end_year,
+        requested_count=requested_count,
+        candidate_budget=candidate_budget,
+        start_year=start_year,
+        end_year=end_year,
         topic=data.topic,
         query_plan=query_plan,
-        source_config=data.source_config,
+        source_config=source_config,
         model_version=data.model_version,
         progress={"phase": "queued", "fetched": 0, "accepted": 0},
     )
     session.add(run)
     await session.flush()
-    for source in discovery_runs.enabled_sources(data.source_config, query_plan):
+    for source in discovery_runs.enabled_sources(source_config, query_plan):
         session.add(
             LiteratureSourceAttempt(
                 run_id=run.id,
                 source=source,
                 status="pending",
-                requested_count=data.candidate_budget,
+                requested_count=candidate_budget,
             )
         )
     await session.commit()

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -87,9 +87,33 @@ class ManagedCommandWatchdogAdminSettings(BaseModel):
 
 
 class LiteratureProviderKeyStatus(BaseModel):
-    index: int
+    id: str
+    source: str
+    index: int | None = None
     configured: bool
     preview: str
+    enabled: bool = True
+    label: str | None = None
+    health: dict[str, Any] | None = None
+    created_at: float | None = None
+    updated_at: float | None = None
+
+
+class LiteratureProviderCredentialCreate(BaseModel):
+    source: str = Field(min_length=1, max_length=64)
+    secret: str = Field(min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool = True
+
+
+class LiteratureProviderCredentialUpdate(BaseModel):
+    secret: str | None = Field(default=None, min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool | None = None
+
+
+class LiteratureProviderCredentialTestRequest(BaseModel):
+    query: str = Field(default="research", min_length=1, max_length=4000)
 
 
 class LiteratureSearchSettings(BaseModel):
@@ -99,8 +123,8 @@ class LiteratureSearchSettings(BaseModel):
     start_year: int | None = Field(default=None, ge=1800, le=3000)
     end_year: int | None = Field(default=None, ge=1800, le=3000)
     score_weights: dict[str, float]
-    provider_keys: dict[str, list[LiteratureProviderKeyStatus]] = {}
-    provider_health: dict[str, dict[str, Any]] = {}
+    provider_keys: dict[str, list[LiteratureProviderKeyStatus]] = Field(default_factory=dict)
+    provider_health: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
 class LiteratureSearchSettingsUpdate(BaseModel):

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class LiteratureSearchRequest(BaseModel):
     """创建一次检索运行时保存的用户参数。"""
 
-    requested_count: int = Field(default=20, ge=1, le=200)
-    candidate_budget: int = Field(default=80, ge=1, le=1000)
+    requested_count: int | None = Field(default=None, ge=1, le=200)
+    candidate_budget: int | None = Field(default=None, ge=1, le=1000)
     start_year: int | None = Field(default=None, ge=1800, le=3000)
     end_year: int | None = Field(default=None, ge=1800, le=3000)
     topic: str = Field(min_length=1, max_length=4000)

--- a/src/backend/app/services/literature/discovery_runs.py
+++ b/src/backend/app/services/literature/discovery_runs.py
@@ -34,9 +34,10 @@ async def can_manage_discovery(
 def enabled_sources(source_config: dict | None, query_plan: dict | None) -> list[str]:
     """从已保存快照中取得稳定来源顺序；没有配置时不凭空创建来源任务。"""
     sources: Iterable[str] = ()
+    sources_declared = isinstance(source_config, dict) and "sources" in source_config
     if isinstance(source_config, dict):
-        sources = source_config.get("sources") or source_config.keys()
-    if not list(sources) and isinstance(query_plan, dict):
+        sources = source_config["sources"] if "sources" in source_config else source_config.keys()
+    if not list(sources) and not sources_declared and isinstance(query_plan, dict):
         sources = query_plan.get("sources") or ()
     return list(dict.fromkeys(str(s).strip().lower() for s in sources if str(s).strip()))
 

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -131,8 +131,9 @@ class MultiSourceClient:
         }
 
     def _key(self, source: str, fallback: str | list[str] = "") -> str:
+        configured = source in self._provider_keys
         pool = self._provider_keys.get(source, ())
-        if not pool:
+        if not configured:
             values = fallback if isinstance(fallback, list) else re.split(r"[,;\s]+", fallback)
             pool = tuple(str(value).strip() for value in values if str(value).strip())
         if not pool:

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -35,6 +35,26 @@ class ProviderRequestError(RuntimeError):
         self.retryable = retryable
 
 
+def provider_failure_detail(source: str, error: Exception | None) -> tuple[str, str]:
+    """Return a stable provider failure without URLs, query strings, or headers."""
+
+    if isinstance(error, ProviderRequestError):
+        code = error.code
+    elif isinstance(error, httpx.HTTPStatusError):
+        code = f"HTTP_{error.response.status_code}"
+    elif isinstance(error, httpx.TimeoutException):
+        code = "TIMEOUT"
+    elif isinstance(error, httpx.RequestError):
+        code = "NETWORK_ERROR"
+    elif isinstance(error, ValueError):
+        code = "INVALID_RESPONSE"
+    elif error is not None:
+        code = type(error).__name__.upper()
+    else:
+        code = "REQUEST_FAILED"
+    return code, f"{source} provider request failed ({code})"
+
+
 def _text(value: Any) -> str:
     if value is None:
         return ""
@@ -183,11 +203,8 @@ class MultiSourceClient:
                 last_error = exc
             if attempt < self._retries:
                 await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise ProviderRequestError(
-            source,
-            "REQUEST_FAILED",
-            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
-        ) from last_error
+        code, detail = provider_failure_detail(source, last_error)
+        raise ProviderRequestError(source, code, detail) from last_error
 
     async def _request_text(
         self,
@@ -209,11 +226,8 @@ class MultiSourceClient:
                 last_error = exc
             if attempt < self._retries:
                 await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise ProviderRequestError(
-            source,
-            "REQUEST_FAILED",
-            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
-        ) from last_error
+        code, detail = provider_failure_detail(source, last_error)
+        raise ProviderRequestError(source, code, detail) from last_error
 
     async def aclose(self) -> None:
         if self._owns_client:

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -11,12 +11,18 @@ import asyncio
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from itertools import count
+from threading import Lock
 from typing import Any
 from urllib.parse import quote
+from xml.etree import ElementTree
 
 import httpx
 
 from app.core.config import get_settings
+
+_KEY_INDEX: dict[str, count] = {}
+_KEY_LOCK = Lock()
 
 
 class ProviderRequestError(RuntimeError):
@@ -74,10 +80,39 @@ def _date_window(request: Any) -> tuple[int | None, int | None]:
     return request.start_year, request.end_year
 
 
+def _within_year(row: Mapping[str, Any], start: int | None, end: int | None) -> bool:
+    year = row.get("year")
+    return year is None or ((start is None or year >= start) and (end is None or year <= end))
+
+
+def _pubmed_abstracts(xml_text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        return result
+    for article in root.findall(".//PubmedArticle"):
+        pmid = _text(article.findtext(".//MedlineCitation/PMID"))
+        parts: list[str] = []
+        for node in article.findall(".//Article/Abstract/AbstractText"):
+            text = _text("".join(node.itertext()))
+            label = _text(node.attrib.get("Label"))
+            if text:
+                parts.append(f"{label}: {text}" if label else text)
+        if pmid and parts:
+            result[pmid] = "\n".join(parts)
+    return result
+
+
 class MultiSourceClient:
     """HTTP client for the non-core providers in the YFR-compatible source set."""
 
-    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        *,
+        provider_keys: Mapping[str, list[str]] | None = None,
+    ) -> None:
         settings = get_settings()
         self._client = client or httpx.AsyncClient(
             proxy=settings.outbound_proxy or None,
@@ -88,6 +123,23 @@ class MultiSourceClient:
         self._owns_client = client is None
         self._timeout = settings.literature_source_timeout_seconds
         self._retries = settings.literature_source_retries
+        self._provider_keys = {
+            str(source).strip().lower(): tuple(
+                str(value).strip() for value in values if str(value).strip()
+            )
+            for source, values in (provider_keys or {}).items()
+        }
+
+    def _key(self, source: str, fallback: str | list[str] = "") -> str:
+        pool = self._provider_keys.get(source, ())
+        if not pool:
+            values = fallback if isinstance(fallback, list) else re.split(r"[,;\s]+", fallback)
+            pool = tuple(str(value).strip() for value in values if str(value).strip())
+        if not pool:
+            return ""
+        with _KEY_LOCK:
+            index = next(_KEY_INDEX.setdefault(source, count()))
+        return pool[index % len(pool)]
 
     async def _request_json(
         self,
@@ -136,6 +188,32 @@ class MultiSourceClient:
             f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
         ) from last_error
 
+    async def _request_text(
+        self,
+        source: str,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        last_error: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+                response = await self._client.request(
+                    method, url, params=params, timeout=self._timeout
+                )
+                response.raise_for_status()
+                return response.text
+            except httpx.HTTPError as exc:
+                last_error = exc
+            if attempt < self._retries:
+                await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise ProviderRequestError(
+            source,
+            "REQUEST_FAILED",
+            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
+        ) from last_error
+
     async def aclose(self) -> None:
         if self._owns_client:
             await self._client.aclose()
@@ -151,7 +229,9 @@ class MultiSourceClient:
             "sciverse": self._search_sciverse,
         }
         handler = handlers.get(source.strip().lower())
-        return await handler(request) if handler else []
+        rows = await handler(request) if handler else []
+        start, end = _date_window(request)
+        return [row for row in rows if _within_year(row, start, end)]
 
     async def lookup_unpaywall(self, doi: str) -> dict[str, Any] | None:
         settings = get_settings()
@@ -171,6 +251,7 @@ class MultiSourceClient:
 
     async def _search_pubmed(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
+        api_key = self._key("pubmed", settings.pubmed_api_key)
         start, end = _date_window(request)
         query = request.query
         if start or end:
@@ -184,8 +265,8 @@ class MultiSourceClient:
             "retmax": min(request.limit, 1000),
             "sort": "relevance",
         }
-        if settings.pubmed_api_key:
-            params["api_key"] = settings.pubmed_api_key
+        if api_key:
+            params["api_key"] = api_key
         if settings.pubmed_email:
             params["email"] = settings.pubmed_email
         try:
@@ -199,8 +280,8 @@ class MultiSourceClient:
             if not ids:
                 return []
             summary_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "json"}
-            if settings.pubmed_api_key:
-                summary_params["api_key"] = settings.pubmed_api_key
+            if api_key:
+                summary_params["api_key"] = api_key
             summary = await self._request_json(
                 "pubmed",
                 "GET",
@@ -208,6 +289,20 @@ class MultiSourceClient:
                 params=summary_params,
             )
             result = summary.get("result") or {}
+            fetch_params = {"db": "pubmed", "id": ",".join(ids), "retmode": "xml"}
+            if api_key:
+                fetch_params["api_key"] = api_key
+            try:
+                abstracts = _pubmed_abstracts(
+                    await self._request_text(
+                        "pubmed",
+                        "GET",
+                        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi",
+                        params=fetch_params,
+                    )
+                )
+            except ProviderRequestError:
+                abstracts = {}
         except ProviderRequestError:
             raise
         rows: list[dict[str, Any]] = []
@@ -225,7 +320,7 @@ class MultiSourceClient:
                     "source": "pubmed",
                     "pmid": str(pmid),
                     "title": _text(item.get("title")),
-                    "abstract": None,
+                    "abstract": abstracts.get(str(pmid)),
                     "authors": _authors(item.get("authors")),
                     "year": _year(item.get("pubdate")),
                     "venue": _text(item.get("fulljournalname") or item.get("source")),
@@ -306,10 +401,14 @@ class MultiSourceClient:
 
     async def _search_core(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
-        if not settings.core_api_key:
+        api_key = self._key("core", settings.core_api_key)
+        if not api_key:
             return []
+        year_filters = [f"yearPublished>={request.start_year or 1800}"]
+        if request.end_year is not None:
+            year_filters.append(f"yearPublished<={request.end_year}")
         params = {
-            "q": f"{request.query} yearPublished>={request.start_year or 1800}",
+            "q": f"{request.query} {' '.join(year_filters)}",
             "limit": min(request.limit, 100),
         }
         try:
@@ -318,7 +417,7 @@ class MultiSourceClient:
                 "POST",
                 "https://api.core.ac.uk/v3/search/works",
                 json=params,
-                headers={"Authorization": f"Bearer {settings.core_api_key}"},
+                headers={"Authorization": f"Bearer {api_key}"},
             )
             items = payload.get("results") or []
         except ProviderRequestError:
@@ -347,14 +446,7 @@ class MultiSourceClient:
 
     async def _search_sciverse(self, request: Any) -> list[dict[str, Any]]:
         settings = get_settings()
-        token = next(
-            (
-                item.strip()
-                for item in re.split(r"[,;\s]+", settings.sciverse_api_tokens)
-                if item.strip()
-            ),
-            "",
-        )
+        token = self._key("sciverse", settings.sciverse_api_tokens)
         if not token:
             return []
         try:

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -78,12 +78,14 @@ class OpenAlexClient:
         client: httpx.AsyncClient | None = None,
         redis: Redis | None = None,
         mailto: str | None = None,
+        api_key: str | None = None,
     ) -> None:
         self._client = client or httpx.AsyncClient(
             proxy=get_settings().outbound_proxy or None, timeout=30.0
         )
         self._cache = ResponseCache(redis)
         self._mailto = mailto if mailto is not None else get_settings().openalex_mailto
+        self._api_key = api_key
 
     async def _get(
         self, path: str, extra_params: dict[str, Any] | None = None
@@ -91,6 +93,8 @@ class OpenAlexClient:
         params: dict[str, Any] = dict(extra_params or {})
         if self._mailto:
             params["mailto"] = self._mailto
+        if self._api_key:
+            params["api_key"] = self._api_key
         key = cache_key("openalex", path, params)
         if (cached := await self._cache.get(key)) is not None:
             return cached or None  # 缓存的 {} 表示 404

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -253,9 +253,10 @@ def _planned_query(run: LiteratureSearchRun, source: str, keywords: Sequence[str
 
 def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
     configured = settings.get("provider_keys")
-    values = configured.get(source) if isinstance(configured, Mapping) else None
+    declared = isinstance(configured, Mapping) and source in configured
+    values = configured.get(source) if declared else None
     pool = [str(value).strip() for value in values or [] if str(value).strip()]
-    if pool:
+    if declared:
         return pool
     return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
 

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -7,7 +7,10 @@ separate steps. Unpromoted hits never create a Paper or a PDF processing job.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
+import threading
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
@@ -28,6 +31,7 @@ from app.schemas.literature_discovery import (
     SourceSearchPage,
     SourceSearchRequest,
 )
+from app.services import literature_settings
 from app.services.interdisciplinary_retrieval import rerank_interdisciplinary
 from app.services.literature import discovery_runs
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
@@ -35,7 +39,10 @@ from app.services.literature.discovery_ranking import rank_candidates
 from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
 
 logger = logging.getLogger(__name__)
-_DEFAULT_REGISTRY: AdapterRegistry | None = None
+_REGISTRY_CACHE: tuple[str, AdapterRegistry] | None = None
+_REGISTRY_LOCK = asyncio.Lock()
+_ROTATION_LOCK = threading.Lock()
+_ROTATION_INDEX: dict[str, int] = {}
 
 
 class SourceExecutionError(RuntimeError):
@@ -58,6 +65,22 @@ class AdapterRegistry:
 
     def names(self) -> set[str]:
         return set(self._adapters)
+
+
+class RotatingAdapter:
+    """Select one configured credential without persisting it in a run."""
+
+    def __init__(self, name: str, adapters: Sequence[SourceAdapter]) -> None:
+        if not adapters:
+            raise ValueError("at least one adapter is required")
+        self.name = name
+        self._adapters = tuple(adapters)
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        with _ROTATION_LOCK:
+            index = _ROTATION_INDEX.get(self.name, 0)
+            _ROTATION_INDEX[self.name] = index + 1
+        return await self._adapters[index % len(self._adapters)].search(request)
 
 
 class OpenAlexAdapter:
@@ -228,36 +251,74 @@ def _planned_query(run: LiteratureSearchRun, source: str, keywords: Sequence[str
     return str(plan.get("query") or run.topic or (keywords[0] if keywords else "")).strip()
 
 
-async def _default_registry() -> AdapterRegistry:
-    global _DEFAULT_REGISTRY
-    if _DEFAULT_REGISTRY is not None:
-        return _DEFAULT_REGISTRY
-    from app.services.literature.arxiv import ArxivClient
-    from app.services.literature.openalex import OpenAlexClient
-    from app.services.literature.semantic_scholar import SemanticScholarClient
+def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
+    configured = settings.get("provider_keys")
+    values = configured.get(source) if isinstance(configured, Mapping) else None
+    pool = [str(value).strip() for value in values or [] if str(value).strip()]
+    if pool:
+        return pool
+    return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
 
-    multi_source = MultiSourceClient()
-    _DEFAULT_REGISTRY = AdapterRegistry(
-        (
-            OpenAlexAdapter(OpenAlexClient()),
-            SemanticScholarAdapter(SemanticScholarClient()),
-            ArxivAdapter(ArxivClient()),
-            *(
-                MultiSourceAdapter(source, multi_source)
-                for source in (
-                    "pubmed",
-                    "crossref",
-                    "europepmc",
-                    "hal",
-                    "core",
-                    "base",
-                    "sciverse",
-                    "unpaywall",
-                )
-            ),
+
+def _registry_fingerprint(settings: Mapping[str, Any]) -> str:
+    payload = json.dumps(settings, sort_keys=True, ensure_ascii=True, default=str).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+async def build_adapter_registry(runtime_settings: Mapping[str, Any]) -> AdapterRegistry:
+    """Build or reuse adapters from trusted, decrypted administrator settings."""
+    global _REGISTRY_CACHE
+    fingerprint = _registry_fingerprint(runtime_settings)
+    async with _REGISTRY_LOCK:
+        if _REGISTRY_CACHE is not None and _REGISTRY_CACHE[0] == fingerprint:
+            return _REGISTRY_CACHE[1]
+
+        app_settings = get_settings()
+        openalex_keys = _credential_pool(runtime_settings, "openalex") or [""]
+        semantic_keys = _credential_pool(runtime_settings, "semantic", app_settings.s2_api_key) or [
+            ""
+        ]
+
+        from app.services.literature.arxiv import ArxivClient
+        from app.services.literature.openalex import OpenAlexClient
+        from app.services.literature.semantic_scholar import SemanticScholarClient
+
+        multi_source = MultiSourceClient(
+            provider_keys=runtime_settings.get("provider_keys")
+            if isinstance(runtime_settings.get("provider_keys"), Mapping)
+            else None
         )
-    )
-    return _DEFAULT_REGISTRY
+        registry = AdapterRegistry(
+            (
+                RotatingAdapter(
+                    "openalex",
+                    [OpenAlexAdapter(OpenAlexClient(api_key=key or None)) for key in openalex_keys],
+                ),
+                RotatingAdapter(
+                    "semantic",
+                    [
+                        SemanticScholarAdapter(SemanticScholarClient(api_key=key or None))
+                        for key in semantic_keys
+                    ],
+                ),
+                ArxivAdapter(ArxivClient()),
+                *(
+                    MultiSourceAdapter(source, multi_source)
+                    for source in (
+                        "pubmed",
+                        "crossref",
+                        "europepmc",
+                        "hal",
+                        "core",
+                        "base",
+                        "sciverse",
+                        "unpaywall",
+                    )
+                ),
+            )
+        )
+        _REGISTRY_CACHE = (fingerprint, registry)
+        return registry
 
 
 async def run_discovery(
@@ -275,7 +336,10 @@ async def run_discovery(
     if run.status == "cancelled":
         return run
 
-    registry = registry or await _default_registry()
+    if registry is None:
+        registry = await build_adapter_registry(
+            await literature_settings.get_runtime_settings(session)
+        )
     started = now or datetime.now(UTC)
     run.status = "running"
     run.started_at = run.started_at or started

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 import time
+import uuid
 from collections.abc import Mapping
 from typing import Any
 
@@ -125,21 +126,74 @@ def _mask(token: str) -> str:
     return f"••••{token[-4:]}" if len(token) >= 4 else "••••"
 
 
-def _masked(value: Mapping[str, Any] | None) -> dict[str, Any]:
+def _credential_entry(source: str, item: Any, index: int) -> dict[str, Any] | None:
+    """Normalize legacy encrypted strings and current credential objects."""
+
+    if isinstance(item, str) and item:
+        stable = uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:{source}:{index}:{item}")
+        return {
+            "id": str(stable),
+            "secret": item,
+            "enabled": True,
+            "label": None,
+            "health": None,
+            "created_at": None,
+            "updated_at": None,
+        }
+    if not isinstance(item, Mapping) or not item.get("secret"):
+        return None
+    credential_id = str(item.get("id") or uuid.uuid4())
+    try:
+        uuid.UUID(credential_id)
+    except ValueError:
+        credential_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:{source}:{credential_id}"))
+    return {
+        "id": credential_id,
+        "secret": str(item["secret"]),
+        "enabled": bool(item.get("enabled", True)),
+        "label": str(item.get("label") or "").strip() or None,
+        "health": dict(item.get("health") or {}) or None,
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+    }
+
+
+def _credential_pools(value: Mapping[str, Any] | None) -> dict[str, list[dict[str, Any]]]:
     keys = value.get("provider_keys") if isinstance(value, Mapping) else {}
+    pools: dict[str, list[dict[str, Any]]] = {}
+    if not isinstance(keys, Mapping):
+        return pools
+    for source, items in keys.items():
+        if not isinstance(items, list):
+            continue
+        normalized = [
+            entry
+            for index, item in enumerate(items)
+            if (entry := _credential_entry(str(source), item, index)) is not None
+        ]
+        if normalized:
+            pools[str(source)] = normalized
+    return pools
+
+
+def _masked(value: Mapping[str, Any] | None) -> dict[str, Any]:
     result: dict[str, list[dict[str, Any]]] = {}
-    if isinstance(keys, Mapping):
-        for source, pool in keys.items():
-            if isinstance(pool, list):
-                result[str(source)] = [
-                    {
-                        "index": index,
-                        "configured": bool(item),
-                        "preview": _mask(decrypt_secret(str(item))) if item else "••••",
-                    }
-                    for index, item in enumerate(pool)
-                    if item
-                ]
+    for source, pool in _credential_pools(value).items():
+        result[source] = [
+            {
+                "id": item["id"],
+                "source": source,
+                "index": index,
+                "configured": True,
+                "preview": _mask(decrypt_secret(item["secret"])),
+                "enabled": item["enabled"],
+                "label": item["label"],
+                "health": item["health"],
+                "created_at": item["created_at"],
+                "updated_at": item["updated_at"],
+            }
+            for index, item in enumerate(pool)
+        ]
     return result
 
 
@@ -157,12 +211,13 @@ async def get_runtime_settings(session: AsyncSession) -> dict[str, Any]:
     row = await session.get(SystemSetting, SETTING_KEY)
     value = row.value if row is not None and isinstance(row.value, Mapping) else {}
     normalized = {**DEFAULTS, **_normalize(value)}
-    encrypted = value.get("provider_keys") if isinstance(value, Mapping) else {}
     pools: dict[str, list[str]] = {}
-    if isinstance(encrypted, Mapping):
-        for source, items in encrypted.items():
-            if isinstance(items, list):
-                pools[str(source)] = [decrypt_secret(str(item)) for item in items if item]
+    for source, items in _credential_pools(value).items():
+        pools[source] = [
+            decrypt_secret(item["secret"])
+            for item in items
+            if item["enabled"]
+        ]
     normalized["provider_keys"] = pools
     return normalized
 
@@ -186,7 +241,19 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
                 raise InvalidLiteratureSettingError(
                     f"provider_keys.{source_name}", "must be a non-empty string list"
                 )
-            encrypted[source_name] = [encrypt_secret(str(item).strip()) for item in values]
+            now = time.time()
+            encrypted[source_name] = [
+                {
+                    "id": str(uuid.uuid4()),
+                    "secret": encrypt_secret(str(item).strip()),
+                    "enabled": True,
+                    "label": None,
+                    "health": None,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+                for item in values
+            ]
         normalized["provider_keys"] = encrypted
     else:
         normalized["provider_keys"] = (
@@ -200,6 +267,142 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
         row.value = normalized
     await session.commit()
     return await get_settings(session)
+
+
+def _validate_credential_source(source: str) -> str:
+    source = source.strip().lower()
+    if source not in SUPPORTED_SOURCES:
+        raise InvalidLiteratureSettingError("source", f"unsupported source: {source}")
+    if source == "arxiv":
+        raise InvalidLiteratureSettingError("source", "arxiv does not require credentials")
+    return source
+
+
+async def create_provider_credential(
+    session: AsyncSession,
+    *,
+    source: str,
+    secret: str,
+    label: str | None,
+    enabled: bool,
+) -> dict[str, Any]:
+    source = _validate_credential_source(source)
+    secret = secret.strip()
+    if not secret:
+        raise InvalidLiteratureSettingError("secret", "must not be empty")
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
+    pools = _credential_pools(value)
+    now = time.time()
+    entry = {
+        "id": str(uuid.uuid4()),
+        "secret": encrypt_secret(secret),
+        "enabled": enabled,
+        "label": str(label or "").strip() or None,
+        "health": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    pools.setdefault(source, []).append(entry)
+    value["provider_keys"] = pools
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return next(item for item in _masked(value)[source] if item["id"] == entry["id"])
+
+
+async def update_provider_credential(
+    session: AsyncSession,
+    credential_id: str,
+    *,
+    secret: str | None = None,
+    label: str | None = None,
+    enabled: bool | None = None,
+) -> dict[str, Any] | None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    if row is None or not isinstance(row.value, Mapping):
+        return None
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    for source, entries in pools.items():
+        for entry in entries:
+            if entry["id"] != credential_id:
+                continue
+            if secret is not None:
+                if not secret.strip():
+                    raise InvalidLiteratureSettingError("secret", "must not be empty")
+                entry["secret"] = encrypt_secret(secret.strip())
+            if label is not None:
+                entry["label"] = label.strip() or None
+            if enabled is not None:
+                entry["enabled"] = enabled
+            entry["updated_at"] = time.time()
+            value["provider_keys"] = pools
+            row.value = value
+            await session.commit()
+            return next(
+                item for item in _masked(value)[source] if item["id"] == credential_id
+            )
+    return None
+
+
+async def delete_provider_credential(session: AsyncSession, credential_id: str) -> bool:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    if row is None or not isinstance(row.value, Mapping):
+        return False
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    found = False
+    for source, entries in list(pools.items()):
+        kept = [entry for entry in entries if entry["id"] != credential_id]
+        found = found or len(kept) != len(entries)
+        if kept:
+            pools[source] = kept
+        else:
+            pools.pop(source, None)
+    if not found:
+        return False
+    value["provider_keys"] = pools
+    row.value = value
+    await session.commit()
+    return True
+
+
+async def get_provider_credential_secret(
+    session: AsyncSession, credential_id: str
+) -> tuple[str, str] | None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    for source, entries in _credential_pools(value).items():
+        for entry in entries:
+            if entry["id"] == credential_id:
+                return source, decrypt_secret(entry["secret"])
+    return None
+
+
+async def record_credential_health(
+    session: AsyncSession, credential_id: str, *, ok: bool, detail: str
+) -> None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    if row is None or not isinstance(row.value, Mapping):
+        return
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    for entries in pools.values():
+        for entry in entries:
+            if entry["id"] == credential_id:
+                entry["health"] = {
+                    "ok": ok,
+                    "detail": detail[:500],
+                    "checked_at": time.time(),
+                }
+                entry["updated_at"] = time.time()
+                value["provider_keys"] = pools
+                row.value = value
+                await session.commit()
+                return
 
 
 async def record_provider_health(

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -10,15 +10,18 @@ from __future__ import annotations
 import math
 import time
 import uuid
+import zlib
 from collections.abc import Mapping
 from typing import Any
 
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import decrypt_secret, encrypt_secret
 from app.models.system_setting import SystemSetting
 
 SETTING_KEY = "literature_search"
+_SETTING_LOCK_ID = zlib.crc32(SETTING_KEY.encode("utf-8"))
 SUPPORTED_SOURCES = (
     "openalex",
     "semantic",
@@ -54,6 +57,19 @@ class InvalidLiteratureSettingError(ValueError):
     def __init__(self, field: str, detail: str) -> None:
         super().__init__(f"{field}: {detail}")
         self.field = field
+
+
+async def _setting_for_update(session: AsyncSession) -> SystemSetting | None:
+    """Serialize read-modify-write updates to the shared settings document."""
+
+    if session.get_bind().dialect.name == "postgresql":
+        # A row lock cannot serialize the first write while the singleton row is absent.
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"), {"lock_id": _SETTING_LOCK_ID}
+        )
+    return await session.scalar(
+        select(SystemSetting).where(SystemSetting.key == SETTING_KEY).with_for_update()
+    )
 
 
 def _as_int(value: Any, field: str, *, minimum: int, maximum: int) -> int:
@@ -213,17 +229,13 @@ async def get_runtime_settings(session: AsyncSession) -> dict[str, Any]:
     normalized = {**DEFAULTS, **_normalize(value)}
     pools: dict[str, list[str]] = {}
     for source, items in _credential_pools(value).items():
-        pools[source] = [
-            decrypt_secret(item["secret"])
-            for item in items
-            if item["enabled"]
-        ]
+        pools[source] = [decrypt_secret(item["secret"]) for item in items if item["enabled"]]
     normalized["provider_keys"] = pools
     return normalized
 
 
 async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dict[str, Any]:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     previous = row.value if row is not None and isinstance(row.value, Mapping) else {}
     normalized = _normalize({**(previous if isinstance(previous, Mapping) else {}), **dict(data)})
     if "provider_keys" in data and data["provider_keys"] is not None:
@@ -257,9 +269,7 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
         normalized["provider_keys"] = encrypted
     else:
         normalized["provider_keys"] = (
-            dict(previous.get("provider_keys") or {})
-            if isinstance(previous, Mapping)
-            else {}
+            dict(previous.get("provider_keys") or {}) if isinstance(previous, Mapping) else {}
         )
     if row is None:
         session.add(SystemSetting(key=SETTING_KEY, value=normalized))
@@ -290,7 +300,7 @@ async def create_provider_credential(
     secret = secret.strip()
     if not secret:
         raise InvalidLiteratureSettingError("secret", "must not be empty")
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
     pools = _credential_pools(value)
     now = time.time()
@@ -321,7 +331,7 @@ async def update_provider_credential(
     label: str | None = None,
     enabled: bool | None = None,
 ) -> dict[str, Any] | None:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     if row is None or not isinstance(row.value, Mapping):
         return None
     value = dict(row.value)
@@ -342,14 +352,12 @@ async def update_provider_credential(
             value["provider_keys"] = pools
             row.value = value
             await session.commit()
-            return next(
-                item for item in _masked(value)[source] if item["id"] == credential_id
-            )
+            return next(item for item in _masked(value)[source] if item["id"] == credential_id)
     return None
 
 
 async def delete_provider_credential(session: AsyncSession, credential_id: str) -> bool:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     if row is None or not isinstance(row.value, Mapping):
         return False
     value = dict(row.value)
@@ -385,7 +393,7 @@ async def get_provider_credential_secret(
 async def record_credential_health(
     session: AsyncSession, credential_id: str, *, ok: bool, detail: str
 ) -> None:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     if row is None or not isinstance(row.value, Mapping):
         return
     value = dict(row.value)
@@ -408,7 +416,7 @@ async def record_credential_health(
 async def record_provider_health(
     session: AsyncSession, *, source: str, ok: bool, detail: str
 ) -> None:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
     health = dict(value.get("provider_health") or {})
     health[source] = {"ok": ok, "detail": detail[:500], "checked_at": time.time()}

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -1,5 +1,8 @@
 """管理员文献检索设置：持久化、脱敏、校验和权限。"""
 
+from app.core.db import get_sessionmaker
+from app.schemas.literature_discovery import SourceSearchPage
+from app.services import literature_settings
 from tests.conftest import register_and_login
 
 
@@ -101,3 +104,119 @@ async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(cli
     assert [attempt["source"] for attempt in run["source_attempts"]] == ["core", "pubmed"]
     assert "private-pubmed-key" not in response.text
     assert "request-injected-secret" not in response.text
+
+
+async def test_provider_credential_crud_has_stable_id_and_runtime_enable_gate(client):
+    admin, member = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={
+            "source": "openalex",
+            "secret": "openalex-secret-1234",
+            "label": "primary",
+            "enabled": True,
+        },
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    created = response.json()
+    credential_id = created["id"]
+    assert created["source"] == "openalex"
+    assert created["preview"] == "••••1234"
+    assert created["label"] == "primary"
+    assert "openalex-secret-1234" not in response.text
+
+    response = await client.patch(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}",
+        json={"secret": "replacement-secret-5678", "label": "secondary", "enabled": False},
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == credential_id
+    assert response.json()["preview"] == "••••5678"
+    assert response.json()["enabled"] is False
+
+    async with get_sessionmaker()() as session:
+        runtime = await literature_settings.get_runtime_settings(session)
+    assert runtime["provider_keys"]["openalex"] == []
+
+    response = await client.patch(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}",
+        json={"enabled": True, "label": None},
+        headers=admin,
+    )
+    assert response.status_code == 200
+    assert response.json()["label"] is None
+    async with get_sessionmaker()() as session:
+        runtime = await literature_settings.get_runtime_settings(session)
+    assert runtime["provider_keys"]["openalex"] == ["replacement-secret-5678"]
+
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=member
+    )
+    assert response.status_code == 403
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=admin
+    )
+    assert response.status_code == 204
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=admin
+    )
+    assert response.status_code == 404
+
+
+async def test_arxiv_rejects_credentials_because_public_api_needs_no_key(client):
+    admin, _ = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "arxiv", "secret": "unnecessary-key"},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_LITERATURE_CREDENTIAL:source" in response.text
+
+
+async def test_single_credential_probe_updates_only_that_entry(client, monkeypatch):
+    admin, _ = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "semantic", "secret": "semantic-key-under-test"},
+        headers=admin,
+    )
+    credential_id = response.json()["id"]
+    observed = {}
+
+    class Adapter:
+        async def search(self, request):
+            observed["query"] = request.query
+            return SourceSearchPage(source="semantic", fetched_count=1)
+
+    class Registry:
+        def get(self, source):
+            observed["source"] = source
+            return Adapter()
+
+    async def fake_registry(settings):
+        observed["keys"] = settings["provider_keys"]
+        return Registry()
+
+    from app.services.literature import runtime
+
+    monkeypatch.setattr(runtime, "build_adapter_registry", fake_registry)
+    response = await client.post(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}/test",
+        json={"query": "impact response"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert observed == {
+        "keys": {"semantic": ["semantic-key-under-test"]},
+        "source": "semantic",
+        "query": "impact response",
+    }
+    response = await client.get("/api/admin/settings/literature-search", headers=admin)
+    item = response.json()["provider_keys"]["semantic"][0]
+    assert item["id"] == credential_id
+    assert item["health"]["ok"] is True

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -55,3 +55,49 @@ async def test_literature_settings_reject_invalid_source_and_year_window(client)
     )
     assert response.status_code == 422
     assert "INVALID_LITERATURE_SETTING:year_window" in response.text
+
+
+async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(client):
+    admin, _ = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/literature-search",
+        json={
+            "sources": ["pubmed", "core"],
+            "requested_count": 50,
+            "candidate_budget": 150,
+            "start_year": 2016,
+            "end_year": 2025,
+            "score_weights": {"relevance": 0.8, "quality": 0.2},
+            "provider_keys": {"pubmed": ["private-pubmed-key"]},
+        },
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    library = await client.post(
+        "/api/libraries",
+        json={"name": "Admin defaults", "statement": "Runtime wiring"},
+        headers=admin,
+    )
+    assert library.status_code == 201, library.text
+
+    response = await client.post(
+        f"/api/libraries/{library.json()['id']}/literature/runs",
+        json={
+            "topic": "structural impact response",
+            "source_config": {"provider_keys": {"pubmed": ["request-injected-secret"]}},
+        },
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    run = response.json()
+    assert run["requested_count"] == 50
+    assert run["candidate_budget"] == 150
+    assert run["start_year"] == 2016
+    assert run["end_year"] == 2025
+    assert run["source_config"] == {
+        "sources": ["pubmed", "core"],
+        "score_weights": {"relevance": 0.8, "quality": 0.2},
+    }
+    assert [attempt["source"] for attempt in run["source_attempts"]] == ["core", "pubmed"]
+    assert "private-pubmed-key" not in response.text
+    assert "request-injected-secret" not in response.text

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -1,5 +1,7 @@
 """管理员文献检索设置：持久化、脱敏、校验和权限。"""
 
+import httpx
+
 from app.core.db import get_sessionmaker
 from app.schemas.literature_discovery import SourceSearchPage
 from app.services import literature_settings
@@ -220,3 +222,52 @@ async def test_single_credential_probe_updates_only_that_entry(client, monkeypat
     item = response.json()["provider_keys"]["semantic"][0]
     assert item["id"] == credential_id
     assert item["health"]["ok"] is True
+
+
+async def test_credential_probe_never_returns_or_persists_secret_url(client, monkeypatch):
+    admin, _ = await _admin_and_member(client)
+    secret = "SECRET_SENTINEL"
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "openalex", "secret": secret},
+        headers=admin,
+    )
+    credential_id = response.json()["id"]
+
+    class Adapter:
+        async def search(self, request):
+            del request
+            request = httpx.Request(
+                "GET", f"https://api.openalex.org/works?api_key={secret}&search=x"
+            )
+            upstream = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=upstream)
+
+    class Registry:
+        def get(self, source):
+            assert source == "openalex"
+            return Adapter()
+
+    async def fake_registry(settings):
+        assert settings["provider_keys"] == {"openalex": [secret]}
+        return Registry()
+
+    from app.services.literature import runtime
+
+    monkeypatch.setattr(runtime, "build_adapter_registry", fake_registry)
+    response = await client.post(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}/test",
+        json={"query": "impact response"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is False
+    assert response.json()["detail"] == "openalex provider request failed (HTTP_401)"
+    assert secret not in response.text
+    saved = await client.get("/api/admin/settings/literature-search", headers=admin)
+    assert secret not in saved.text
+    assert (
+        saved.json()["provider_keys"]["openalex"][0]["health"]["detail"]
+        == response.json()["detail"]
+    )

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -357,6 +357,13 @@ def test_multi_source_key_pool_rotates_and_pubmed_xml_keeps_full_abstract():
     assert abstracts == {"123": "BACKGROUND: First sentence.\nSecond sentence."}
 
 
+def test_explicit_empty_key_pool_does_not_fall_back_to_environment_key():
+    client = MultiSourceClient(client=object(), provider_keys={"core": []})
+
+    assert client._key("core", "environment-key") == ""
+    assert client._key("unconfigured", "environment-key") == "environment-key"
+
+
 @pytest.mark.asyncio
 async def test_pubmed_adapter_fetches_abstract_and_forwards_years_and_admin_key():
     class Response:

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -12,8 +12,17 @@ from app.models.literature_discovery import (
     LiteratureSourceAttempt,
 )
 from app.models.paper import Paper
-from app.schemas.literature_discovery import LiteratureCandidate, SourceSearchPage
-from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
+from app.schemas.literature_discovery import (
+    LiteratureCandidate,
+    SourceSearchPage,
+    SourceSearchRequest,
+)
+from app.services.literature import runtime as runtime_service
+from app.services.literature.multi_source import (
+    MultiSourceClient,
+    ProviderRequestError,
+    _pubmed_abstracts,
+)
 from app.services.literature.openalex import _simplify
 from app.services.literature.runtime import (
     AdapterRegistry,
@@ -161,7 +170,7 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
 
 @pytest.mark.asyncio
 async def test_runtime_marks_missing_sources_as_failed(client):
-    run_id, _, _ = await _create_run(client, source_config={})
+    run_id, _, _ = await _create_run(client, source_config={"sources": []})
     async with get_sessionmaker()() as session:
         run = await run_discovery(session, run_id, registry=AdapterRegistry())
         assert run.status == "failed"
@@ -293,3 +302,114 @@ async def test_runtime_persists_provider_error_instead_of_reporting_zero_hit_suc
     assert attempt.error_code == "HTTP_503"
     assert attempt.retryable is True
     assert "HTTP_503" in (run.error_summary or "")
+
+
+@pytest.mark.asyncio
+async def test_runtime_builds_default_registry_from_decrypted_admin_settings(client, monkeypatch):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["pubmed"]},
+        requested_count=1,
+        candidate_budget=3,
+    )
+    adapter = FakeAdapter("pubmed", [_candidate("pubmed", "Configured provider")])
+    runtime_settings = {
+        "sources": ["pubmed"],
+        "provider_keys": {"pubmed": ["decrypted-key"]},
+    }
+    observed = {}
+
+    async def fake_runtime_settings(session):
+        return runtime_settings
+
+    async def fake_registry(settings):
+        observed.update(settings)
+        return AdapterRegistry((adapter,))
+
+    monkeypatch.setattr(
+        runtime_service.literature_settings, "get_runtime_settings", fake_runtime_settings
+    )
+    monkeypatch.setattr(runtime_service, "build_adapter_registry", fake_registry)
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(session, run_id)
+
+    assert run.status == "completed"
+    assert observed["provider_keys"] == {"pubmed": ["decrypted-key"]}
+    assert adapter.requests[0].limit == 3
+
+
+def test_multi_source_key_pool_rotates_and_pubmed_xml_keeps_full_abstract():
+    client = MultiSourceClient(
+        client=object(), provider_keys={"provider-under-test": ["key-a", "key-b"]}
+    )
+    assert {
+        client._key("provider-under-test"),
+        client._key("provider-under-test"),
+    } == {"key-a", "key-b"}
+
+    abstracts = _pubmed_abstracts(
+        """<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>
+        <Article><Abstract><AbstractText Label="BACKGROUND">First sentence.</AbstractText>
+        <AbstractText>Second sentence.</AbstractText></Abstract></Article>
+        </MedlineCitation></PubmedArticle></PubmedArticleSet>"""
+    )
+    assert abstracts == {"123": "BACKGROUND: First sentence.\nSecond sentence."}
+
+
+@pytest.mark.asyncio
+async def test_pubmed_adapter_fetches_abstract_and_forwards_years_and_admin_key():
+    class Response:
+        status_code = 200
+
+        def __init__(self, *, payload=None, text=""):
+            self._payload = payload
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        async def request(self, method, url, **kwargs):
+            self.calls.append((method, url, kwargs))
+            if "esearch" in url:
+                return Response(payload={"esearchresult": {"idlist": ["123"]}})
+            if "esummary" in url:
+                return Response(
+                    payload={
+                        "result": {
+                            "123": {
+                                "title": "PubMed full abstract",
+                                "pubdate": "2020",
+                                "authors": [{"name": "A. Author"}],
+                                "articleids": [{"idtype": "doi", "value": "10.1/pubmed"}],
+                            }
+                        }
+                    }
+                )
+            return Response(
+                text=(
+                    "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>"
+                    "<Article><Abstract><AbstractText>Full indexed abstract.</AbstractText>"
+                    "</Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+                )
+            )
+
+    http_client = Client()
+    client = MultiSourceClient(client=http_client, provider_keys={"pubmed": ["admin-pubmed-key"]})
+    rows = await client.search_source(
+        "pubmed",
+        SourceSearchRequest(query="impact response", start_year=2016, end_year=2025, limit=5),
+    )
+
+    assert rows[0]["abstract"] == "Full indexed abstract."
+    search_params = http_client.calls[0][2]["params"]
+    assert search_params["term"] == "(impact response) AND (2016:2025[pdat])"
+    assert search_params["api_key"] == "admin-pubmed-key"
+    assert all(call[2]["params"]["api_key"] == "admin-pubmed-key" for call in http_client.calls)

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -3,9 +3,11 @@
 import uuid
 from datetime import UTC, datetime
 
+import httpx
 import pytest
 from sqlalchemy import func, select
 
+from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.models.literature_discovery import (
     LiteratureSearchHit,
@@ -120,7 +122,7 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
         run = await run_discovery(
             session,
             run_id,
-                registry=AdapterRegistry((openalex, semantic, arxiv, core)),
+            registry=AdapterRegistry((openalex, semantic, arxiv, core)),
             now=datetime(2026, 8, 26, tzinfo=UTC),
         )
         assert run.status == "partial"
@@ -233,10 +235,10 @@ async def test_provider_adapters_forward_year_window_and_restore_openalex_abstra
 
     candidate = _candidate_from_openalex(
         _simplify(
-        {
-            "title": "Indexed abstract",
-            "abstract_inverted_index": {"impact": [1], "Dynamic": [0], "response": [2]},
-        }
+            {
+                "title": "Indexed abstract",
+                "abstract_inverted_index": {"impact": [1], "Dynamic": [0], "response": [2]},
+            }
         )
     )
     assert candidate.abstract == "Dynamic impact response"
@@ -302,6 +304,33 @@ async def test_runtime_persists_provider_error_instead_of_reporting_zero_hit_suc
     assert attempt.error_code == "HTTP_503"
     assert attempt.retryable is True
     assert "HTTP_503" in (run.error_summary or "")
+
+
+@pytest.mark.asyncio
+async def test_multi_source_retry_error_does_not_expose_query_credentials(monkeypatch):
+    secret = "SECRET_SENTINEL"
+    settings = get_settings()
+    monkeypatch.setattr(settings, "literature_source_retries", 0, raising=False)
+
+    class BrokenClient:
+        async def request(self, method, url, **kwargs):
+            del method, url, kwargs
+            request = httpx.Request(
+                "GET", f"https://eutils.ncbi.nlm.nih.gov/esearch?api_key={secret}"
+            )
+            return httpx.Response(503, request=request)
+
+    provider = MultiSourceClient(client=BrokenClient())
+    with pytest.raises(ProviderRequestError) as caught:
+        await provider._request_json(
+            "pubmed",
+            "GET",
+            "https://eutils.ncbi.nlm.nih.gov/esearch",
+            params={"api_key": secret},
+        )
+
+    assert caught.value.code == "HTTP_503"
+    assert secret not in str(caught.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- give every provider credential a stable UUID and encrypted persisted value
- expose masked credential metadata without returning plaintext secrets
- add administrator-only create, edit, enable/disable, delete, and per-key connection-test operations
- persist per-key health snapshots for administration without leaking credentials into logs or runtime snapshots
- support round-robin selection for multi-key providers, including OpenAlex
- retain compatibility with legacy string-array credential pools
- reject credentials for arXiv because its public API does not require a key
- prevent disabled credential pools from silently falling back to environment credentials

## Dependency and merge order

This PR depends on #504. Its branch is based directly on the #504 head commit because credential selection is consumed by the administrator-settings runtime introduced there. It is independent of #508 and does not include retrieval-quality changes.

Recommended merge order: #504, then #508, then this PR. The #508-before-#509 order minimizes review conflicts in shared runtime/settings files, although the feature commits themselves are independent.

## Verification

- focused backend tests: `16 passed`
- Ruff on all changed Python files: passed
- `git diff --check`: passed
- full backend baseline comparison: `1422 passed, 6 failed`; the same six Windows/path/prompt assertion failures reproduce on clean `origin/main` and are unrelated to this change
- sensitive-data scan: no credentials, tokens, environment files, PDFs, archives, databases, or logs included

Closes #509