### PR TITLE
feat(reading): serve authorized structured paper content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ POLARIS_INVITE_CODE=polaris-lab
 # POLARIS_PUBLIC_BASE_URL=https://polaris.example.edu
 # Short-lived paper-figure download URL lifetime, in seconds.
 POLARIS_MCP_DOWNLOAD_LINK_TTL_SECONDS=900
+# Short-lived structured Markdown, figure, and table URL lifetime, in seconds.
+POLARIS_STRUCTURED_CONTENT_LINK_TTL_SECONDS=300
 
 # ---- Database / Cache ----
 POLARIS_DATABASE_URL=postgresql+asyncpg://polaris:polaris@postgres:5432/polaris

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -42,6 +42,7 @@ from app.api import (
     shelf,
     skills,
     ssh_credentials,
+    structured_content,
     tts,
     users_profile,
     views,
@@ -72,6 +73,7 @@ api_router.include_router(papers.router)
 api_router.include_router(library.router)
 api_router.include_router(literature_discovery.router)
 api_router.include_router(paper_assets.router)
+api_router.include_router(structured_content.router)
 api_router.include_router(libraries.router)
 api_router.include_router(publications.router)
 api_router.include_router(notes.router)

--- a/src/backend/app/api/structured_content.py
+++ b/src/backend/app/api/structured_content.py
@@ -1,0 +1,289 @@
+"""Authorized manifest and signed resources for parsed paper content."""
+
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.paper_content import PaperContentVersion
+from app.models.user import User
+from app.schemas.structured_content import (
+    StructuredContentAssetRead,
+    StructuredContentManifestRead,
+)
+from app.services import libraries as libraries_service
+from app.services import paper_assets as asset_service
+from app.services import paper_content as content_service
+from app.services import papers as papers_service
+from app.services import structured_content as content_access
+
+router = APIRouter(tags=["structured-content"])
+
+
+async def _visible_library_paper(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user: User,
+) -> None:
+    library = await libraries_service.get_library(session, library_id)
+    if library is None or not libraries_service.library_visible_to(library, user):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+    view = await papers_service.get_library_paper_view(
+        session,
+        library_id=library_id,
+        project_id=None,
+        paper_id=paper_id,
+        with_concepts=False,
+    )
+    if view is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+
+
+async def _authorized_version(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    user: User,
+    version_id: uuid.UUID | None = None,
+) -> PaperContentVersion:
+    await _visible_library_paper(
+        session,
+        library_id=library_id,
+        paper_id=paper_id,
+        user=user,
+    )
+    if version_id is None:
+        version = await content_service.current_content_version(session, paper_id=paper_id)
+    else:
+        version = await session.get(PaperContentVersion, version_id)
+    if version is None or version.paper_id != paper_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+    readable = await asset_service.readable_asset(
+        session,
+        asset_id=version.asset_id,
+        library_id=library_id,
+    )
+    if readable is None or readable[0].paper_id != paper_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+    return version
+
+
+def _bundle(version: PaperContentVersion) -> content_access.StructuredContentBundle:
+    try:
+        return content_access.build_bundle(version)
+    except content_access.StructuredContentError as exc:
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="STRUCTURED_CONTENT_INVALID",
+        ) from exc
+
+
+def _resource_links(
+    *,
+    bundle: content_access.StructuredContentBundle,
+    user_id: uuid.UUID,
+    library_id: uuid.UUID,
+    version: PaperContentVersion,
+) -> tuple[dict[str, str], datetime | None]:
+    resources = [
+        item for item in (bundle.markdown, bundle.text, *bundle.assets) if item is not None
+    ]
+    if not resources:
+        return {}, None
+    links: dict[str, str] = {}
+    expires_at: int | None = None
+    for resource in resources:
+        url, claims = content_access.create_resource_url(
+            user_id=user_id,
+            library_id=library_id,
+            paper_id=version.paper_id,
+            version_id=version.id,
+            relative_path=resource.relative_path,
+            expires_at=expires_at,
+        )
+        expires_at = claims.expires_at
+        links[resource.relative_path] = url
+    return links, datetime.fromtimestamp(expires_at, tz=UTC) if expires_at is not None else None
+
+
+@router.get(
+    "/libraries/{library_id}/papers/{paper_id}/structured-content",
+    response_model=StructuredContentManifestRead,
+)
+async def get_structured_content_manifest(
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> StructuredContentManifestRead:
+    version = await _authorized_version(
+        session,
+        library_id=library_id,
+        paper_id=paper_id,
+        user=user,
+    )
+    bundle = _bundle(version)
+    links, expires_at = _resource_links(
+        bundle=bundle,
+        user_id=user.id,
+        library_id=library_id,
+        version=version,
+    )
+    assets = [
+        StructuredContentAssetRead(
+            kind=item.kind,
+            path=item.relative_path,
+            media_type=item.media_type,
+            byte_size=item.byte_size,
+            sha256=item.sha256,
+            url=links[item.relative_path],
+            expires_at=expires_at,
+        )
+        for item in bundle.assets
+        if expires_at is not None
+    ]
+    return StructuredContentManifestRead(
+        content_version_id=version.id,
+        paper_id=version.paper_id,
+        asset_id=version.asset_id,
+        version_no=version.version_no,
+        parser=version.parser,
+        parser_version=version.parser_version,
+        parse_status=version.status,
+        page_count=version.page_count,
+        chunk_count=version.chunk_count,
+        document_vector_state=version.document_vector_state,
+        chunk_vector_state=version.chunk_vector_state,
+        content_format=bundle.content_format,
+        content_hash=bundle.content_hash,
+        markdown_url=(
+            links.get(bundle.markdown.relative_path) if bundle.markdown is not None else None
+        ),
+        text_url=links.get(bundle.text.relative_path) if bundle.text is not None else None,
+        assets=assets,
+        urls_expire_at=expires_at,
+    )
+
+
+def _cache_headers(
+    *,
+    sha256: str,
+    expires_at: int,
+    immutable: bool,
+) -> dict[str, str]:
+    max_age = max(0, expires_at - int(time.time()))
+    directive = f"private, max-age={max_age}"
+    if immutable:
+        directive += ", immutable"
+    return {
+        "Cache-Control": directive,
+        "ETag": f'"{sha256}"',
+        "X-Content-SHA256": sha256,
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": (
+            "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'"
+        ),
+    }
+
+
+@router.get("/structured-content-assets/{token}")
+async def get_structured_content_resource(
+    token: str,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    try:
+        claims = content_access.verify_token(token)
+    except content_access.InvalidStructuredContentToken as exc:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="STRUCTURED_CONTENT_NOT_FOUND",
+        ) from exc
+    user = await session.get(User, claims.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+    version = await _authorized_version(
+        session,
+        library_id=claims.library_id,
+        paper_id=claims.paper_id,
+        user=user,
+        version_id=claims.version_id,
+    )
+    bundle = _bundle(version)
+    resource = bundle.resource(claims.relative_path)
+    if resource is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="STRUCTURED_CONTENT_NOT_FOUND")
+
+    if resource.kind == "markdown":
+        try:
+            markdown = resource.file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="STRUCTURED_CONTENT_INVALID",
+            ) from exc
+        asset_urls = {
+            item.relative_path: content_access.create_resource_url(
+                user_id=claims.user_id,
+                library_id=claims.library_id,
+                paper_id=claims.paper_id,
+                version_id=claims.version_id,
+                relative_path=item.relative_path,
+                expires_at=claims.expires_at,
+            )[0]
+            for item in bundle.assets
+        }
+        rendered = content_access.rewrite_markdown_asset_urls(
+            markdown,
+            markdown_path=resource.relative_path,
+            asset_urls=asset_urls,
+        )
+        content = rendered.encode("utf-8")
+        digest = hashlib.sha256(content).hexdigest()
+        return Response(
+            content=content,
+            media_type="text/markdown",
+            headers=_cache_headers(
+                sha256=digest,
+                expires_at=claims.expires_at,
+                immutable=False,
+            ),
+        )
+
+    if resource.kind == "text":
+        try:
+            content = resource.file_path.read_text(encoding="utf-8").encode("utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="STRUCTURED_CONTENT_INVALID",
+            ) from exc
+        return Response(
+            content=content,
+            media_type="text/plain",
+            headers=_cache_headers(
+                sha256=resource.sha256,
+                expires_at=claims.expires_at,
+                immutable=True,
+            ),
+        )
+
+    return FileResponse(
+        resource.file_path,
+        media_type=resource.media_type,
+        filename=resource.file_path.name,
+        content_disposition_type="inline",
+        headers=_cache_headers(
+            sha256=resource.sha256,
+            expires_at=claims.expires_at,
+            immutable=True,
+        ),
+    )

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     # HTTP MCP 始终复用当前 /mcp 请求的 origin，不读取此项。
     public_base_url: str = ""
     mcp_download_link_ttl_seconds: int = 15 * 60
+    structured_content_link_ttl_seconds: int = 5 * 60
     # prod 下额外放行的跨域前端来源（逗号分隔）。桌面客户端的 app://polaris 恒在白名单内、
     # 无需在此配置；这一项留给「前端与 API 不同域」的部署形态。web 生产走 nginx 同源反代，
     # 根本不进 CORS 分支。用逗号分隔的 str 而非 list[str]：pydantic-settings 对 list[str]

--- a/src/backend/app/schemas/structured_content.py
+++ b/src/backend/app/schemas/structured_content.py
@@ -1,0 +1,37 @@
+"""Public contracts for authorized structured paper content."""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class StructuredContentAssetRead(BaseModel):
+    kind: Literal["image", "table"]
+    path: str
+    media_type: str
+    byte_size: int
+    sha256: str
+    url: str
+    expires_at: datetime
+
+
+class StructuredContentManifestRead(BaseModel):
+    content_version_id: uuid.UUID
+    paper_id: uuid.UUID
+    asset_id: uuid.UUID
+    version_no: int
+    parser: str
+    parser_version: str | None
+    parse_status: str
+    page_count: int
+    chunk_count: int
+    document_vector_state: str
+    chunk_vector_state: str
+    content_format: Literal["mineru_markdown", "plain_text", "unavailable"]
+    content_hash: str | None
+    markdown_url: str | None
+    text_url: str | None
+    assets: list[StructuredContentAssetRead]
+    urls_expire_at: datetime | None

--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -20,6 +20,22 @@ class MineruCloudError(RuntimeError):
     """A MinerU upload, polling, or result conversion failure."""
 
 
+def _safe_request_failure(prefix: str, error: Exception | None) -> MineruCloudError:
+    """Build a stable error without persisting tokens or signed request URLs."""
+
+    if isinstance(error, httpx.HTTPStatusError):
+        detail = f"HTTP_{error.response.status_code}"
+    elif isinstance(error, httpx.TimeoutException):
+        detail = "TIMEOUT"
+    elif isinstance(error, httpx.RequestError):
+        detail = "NETWORK_ERROR"
+    elif error is not None:
+        detail = type(error).__name__.upper()
+    else:
+        detail = "UNKNOWN"
+    return MineruCloudError(f"{prefix}:{detail}")
+
+
 StatusCallback = Callable[[str], Awaitable[None]]
 _SCHEDULERS_LOCK = Lock()
 _MAX_ARCHIVE_FILES = 10_000
@@ -83,12 +99,7 @@ def _result_payload(payload: Any) -> Mapping[str, Any] | None:
 
 def _safe_archive_name(name: str) -> str | None:
     path = PurePosixPath(name.replace("\\", "/"))
-    if (
-        path.is_absolute()
-        or not path.parts
-        or ".." in path.parts
-        or ":" in path.parts[0]
-    ):
+    if path.is_absolute() or not path.parts or ".." in path.parts or ":" in path.parts[0]:
         return None
     return path.as_posix()
 
@@ -156,8 +167,17 @@ def _zip_result(content: bytes, *, pages: int = 0) -> dict[str, Any]:
             files: list[tuple[str, bytes]] = []
             extracted_bytes = 0
             accepted_extensions = {
-                ".md", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
-                ".csv", ".html", ".htm", ".xlsx",
+                ".md",
+                ".png",
+                ".jpg",
+                ".jpeg",
+                ".gif",
+                ".webp",
+                ".svg",
+                ".csv",
+                ".html",
+                ".htm",
+                ".xlsx",
             }
             for info in infos:
                 name = _safe_archive_name(info.filename)
@@ -235,7 +255,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_REQUEST_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_REQUEST_FAILED", last) from last
 
     async def _upload(self, url: str, content: bytes) -> None:
         last: Exception | None = None
@@ -250,7 +270,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_UPLOAD_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_UPLOAD_FAILED", last) from last
 
     async def _get_bytes(self, url: str) -> bytes:
         last: Exception | None = None
@@ -263,7 +283,7 @@ class MineruCloudParser:
                 last = exc
                 if attempt < self._settings.mineru_retries:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise MineruCloudError(f"MINERU_RESULT_DOWNLOAD_FAILED:{last}") from last
+        raise _safe_request_failure("MINERU_RESULT_DOWNLOAD_FAILED", last) from last
 
     async def parse(
         self, pdf_path: Path, *, on_status: StatusCallback | None = None
@@ -330,10 +350,7 @@ class MineruCloudParser:
                         raise MineruCloudError("MINERU_RESULT_URL_MISSING")
                     if state in {"failed", "error", "failure"}:
                         raise MineruCloudError(
-                            str(
-                                _find(row, "err_msg", "error", "message")
-                                or "MINERU_PARSE_FAILED"
-                            )
+                            str(_find(row, "err_msg", "error", "message") or "MINERU_PARSE_FAILED")
                         )
                 await asyncio.sleep(self._settings.mineru_poll_interval_seconds)
             raise MineruCloudError("MINERU_TIMEOUT")

--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -7,7 +7,8 @@ import io
 import re
 import zipfile
 from collections.abc import Awaitable, Callable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from threading import Lock
 from typing import Any
 
 import httpx
@@ -20,6 +21,36 @@ class MineruCloudError(RuntimeError):
 
 
 StatusCallback = Callable[[str], Awaitable[None]]
+_SCHEDULERS_LOCK = Lock()
+_MAX_ARCHIVE_FILES = 10_000
+_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+
+
+class _MineruScheduler:
+    """Share token rotation and concurrency limits across parser instances."""
+
+    def __init__(self, tokens: list[str], concurrency: int) -> None:
+        self.tokens = tuple(tokens)
+        self.semaphore = asyncio.Semaphore(concurrency)
+        self._index = 0
+        self._lock = Lock()
+
+    def next_token(self) -> str:
+        if not self.tokens:
+            raise MineruCloudError("MINERU_NOT_CONFIGURED")
+        with self._lock:
+            token = self.tokens[self._index % len(self.tokens)]
+            self._index += 1
+        return token
+
+
+_SCHEDULERS: dict[tuple[tuple[str, ...], int], _MineruScheduler] = {}
+
+
+def _scheduler(tokens: list[str], concurrency: int) -> _MineruScheduler:
+    key = (tuple(tokens), concurrency)
+    with _SCHEDULERS_LOCK:
+        return _SCHEDULERS.setdefault(key, _MineruScheduler(tokens, concurrency))
 
 
 def _tokens(raw: str) -> list[str]:
@@ -33,6 +64,13 @@ def _find(mapping: Mapping[str, Any], *keys: str) -> Any:
     return None
 
 
+def _page_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _result_payload(payload: Any) -> Mapping[str, Any] | None:
     if isinstance(payload, Mapping):
         for key in ("data", "result", "extract_result", "extractResult"):
@@ -43,7 +81,32 @@ def _result_payload(payload: Any) -> Mapping[str, Any] | None:
     return None
 
 
-def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
+def _safe_archive_name(name: str) -> str | None:
+    path = PurePosixPath(name.replace("\\", "/"))
+    if (
+        path.is_absolute()
+        or not path.parts
+        or ".." in path.parts
+        or ":" in path.parts[0]
+    ):
+        return None
+    return path.as_posix()
+
+
+def _decode_markdown(content: bytes) -> str:
+    try:
+        return content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise MineruCloudError("MINERU_MARKDOWN_ENCODING_INVALID") from exc
+
+
+def _markdown_result(
+    markdown: str,
+    *,
+    pages: int = 0,
+    markdown_path: str = "content.md",
+    artifacts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     text = re.sub(r"\n{3,}", "\n\n", markdown.replace("\r\n", "\n")).strip()
     if not text:
         raise MineruCloudError("MINERU_MARKDOWN_EMPTY")
@@ -66,6 +129,9 @@ def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
                 "anchor_meta": {"parser": "mineru"},
             }
         )
+    artifacts = artifacts or []
+    images = [item["path"] for item in artifacts if item["kind"] == "image"]
+    tables = [item["path"] for item in artifacts if item["kind"] == "table"]
     return {
         "parser": "mineru",
         "parser_version": "cloud",
@@ -73,8 +139,66 @@ def _markdown_result(markdown: str, *, pages: int = 0) -> dict[str, Any]:
         "text": text,
         "pages": pages or current_page,
         "chunks": chunks,
-        "manifest": {"pages": pages or current_page, "images": [], "tables": []},
+        "markdown_path": markdown_path,
+        "artifacts": artifacts,
+        "manifest": {"pages": pages or current_page, "images": images, "tables": tables},
     }
+
+
+def _zip_result(content: bytes, *, pages: int = 0) -> dict[str, Any]:
+    if len(content) > _MAX_ARCHIVE_BYTES:
+        raise MineruCloudError("MINERU_ARCHIVE_TOO_LARGE")
+    try:
+        with zipfile.ZipFile(io.BytesIO(content)) as bundle:
+            infos = bundle.infolist()
+            if len(infos) > _MAX_ARCHIVE_FILES:
+                raise MineruCloudError("MINERU_ARCHIVE_TOO_MANY_FILES")
+            files: list[tuple[str, bytes]] = []
+            extracted_bytes = 0
+            accepted_extensions = {
+                ".md", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
+                ".csv", ".html", ".htm", ".xlsx",
+            }
+            for info in infos:
+                name = _safe_archive_name(info.filename)
+                if (
+                    name is None
+                    or info.is_dir()
+                    or PurePosixPath(name).suffix.lower() not in accepted_extensions
+                ):
+                    continue
+                extracted_bytes += info.file_size
+                if extracted_bytes > _MAX_ARCHIVE_BYTES:
+                    raise MineruCloudError("MINERU_ARCHIVE_TOO_LARGE")
+                files.append((name, bundle.read(info)))
+    except MineruCloudError:
+        raise
+    except (zipfile.BadZipFile, zipfile.LargeZipFile, RuntimeError) as exc:
+        raise MineruCloudError("MINERU_ARCHIVE_INVALID") from exc
+    markdown_files = [(name, data) for name, data in files if name.lower().endswith(".md")]
+    if not markdown_files:
+        raise MineruCloudError("MINERU_MARKDOWN_MISSING")
+    markdown_name, markdown_bytes = max(markdown_files, key=lambda item: len(item[1]))
+    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+    table_extensions = {".csv", ".html", ".htm", ".xlsx"}
+    artifacts: list[dict[str, Any]] = []
+    for name, data in files:
+        suffix = PurePosixPath(name).suffix.lower()
+        kind = (
+            "image"
+            if suffix in image_extensions
+            else "table"
+            if suffix in table_extensions
+            else None
+        )
+        if kind is not None:
+            artifacts.append({"path": name, "kind": kind, "content": data})
+    return _markdown_result(
+        _decode_markdown(markdown_bytes),
+        pages=pages,
+        markdown_path=markdown_name,
+        artifacts=artifacts,
+    )
 
 
 class MineruCloudParser:
@@ -86,19 +210,14 @@ class MineruCloudParser:
         self._client = client or httpx.AsyncClient(timeout=settings.mineru_timeout_seconds)
         self._owns_client = client is None
         self._tokens = _tokens(settings.mineru_api_tokens)
-        self._token_index = 0
-        self._semaphore = asyncio.Semaphore(settings.mineru_concurrency)
+        self._scheduler = _scheduler(self._tokens, settings.mineru_concurrency)
 
     async def aclose(self) -> None:
         if self._owns_client:
             await self._client.aclose()
 
     def _next_token(self) -> str:
-        if not self._tokens:
-            raise MineruCloudError("MINERU_NOT_CONFIGURED")
-        token = self._tokens[self._token_index % len(self._tokens)]
-        self._token_index += 1
-        return token
+        return self._scheduler.next_token()
 
     async def _json(self, method: str, url: str, *, token: str, **kwargs: Any) -> Any:
         last: Exception | None = None
@@ -118,10 +237,38 @@ class MineruCloudParser:
                     await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
         raise MineruCloudError(f"MINERU_REQUEST_FAILED:{last}") from last
 
+    async def _upload(self, url: str, content: bytes) -> None:
+        last: Exception | None = None
+        for attempt in range(self._settings.mineru_retries + 1):
+            try:
+                response = await self._client.put(
+                    url, content=content, headers={"Content-Type": "application/pdf"}
+                )
+                response.raise_for_status()
+                return
+            except httpx.HTTPError as exc:
+                last = exc
+                if attempt < self._settings.mineru_retries:
+                    await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise MineruCloudError(f"MINERU_UPLOAD_FAILED:{last}") from last
+
+    async def _get_bytes(self, url: str) -> bytes:
+        last: Exception | None = None
+        for attempt in range(self._settings.mineru_retries + 1):
+            try:
+                response = await self._client.get(url)
+                response.raise_for_status()
+                return response.content
+            except httpx.HTTPError as exc:
+                last = exc
+                if attempt < self._settings.mineru_retries:
+                    await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
+        raise MineruCloudError(f"MINERU_RESULT_DOWNLOAD_FAILED:{last}") from last
+
     async def parse(
         self, pdf_path: Path, *, on_status: StatusCallback | None = None
     ) -> dict[str, Any]:
-        async with self._semaphore:
+        async with self._scheduler.semaphore:
             token = self._next_token()
             if on_status:
                 await on_status("mineru_uploading")
@@ -137,19 +284,20 @@ class MineruCloudParser:
             if not batch_id or not isinstance(files, list) or not files:
                 raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
             upload = files[0] if isinstance(files[0], Mapping) else {"url": files[0]}
-            upload_url = _find(upload, "url", "upload_url", "uploadUrl")
+            upload_url = _find(upload, "url", "file_url", "upload_url", "uploadUrl")
             if not upload_url:
                 raise MineruCloudError("MINERU_UPLOAD_URL_MISSING")
             pdf_bytes = await asyncio.to_thread(pdf_path.read_bytes)
-            response = await self._client.put(
-                str(upload_url), content=pdf_bytes, headers={"Content-Type": "application/pdf"}
-            )
-            response.raise_for_status()
+            await self._upload(str(upload_url), pdf_bytes)
             if on_status:
                 await on_status("mineru_parsing")
 
             deadline = asyncio.get_running_loop().time() + self._settings.mineru_timeout_seconds
+            polling_started = False
             while asyncio.get_running_loop().time() < deadline:
+                if on_status and not polling_started:
+                    await on_status("mineru_polling")
+                    polling_started = True
                 result = await self._json(
                     "GET",
                     f"{self._settings.mineru_base_url.rstrip('/')}/extract-results/batch/{batch_id}",
@@ -163,29 +311,22 @@ class MineruCloudParser:
                     if state in {"done", "success", "succeeded", "completed"}:
                         markdown_url = _find(row, "markdown_url", "markdownUrl", "md_url", "mdUrl")
                         if markdown_url:
-                            md_response = await self._client.get(str(markdown_url))
-                            md_response.raise_for_status()
+                            if on_status:
+                                await on_status("mineru_downloading_result")
+                            markdown_bytes = await self._get_bytes(str(markdown_url))
                             return _markdown_result(
-                                md_response.text,
-                                pages=int(_find(row, "page_count", "pageCount") or 0),
+                                _decode_markdown(markdown_bytes),
+                                pages=_page_count(_find(row, "page_count", "pageCount")),
                             )
                         zip_url = _find(row, "full_zip_url", "fullZipUrl", "zip_url", "zipUrl")
                         if zip_url:
-                            archive = await self._client.get(str(zip_url))
-                            archive.raise_for_status()
-                            with zipfile.ZipFile(io.BytesIO(archive.content)) as bundle:
-                                md_name = next(
-                                    (
-                                        name
-                                        for name in bundle.namelist()
-                                        if name.lower().endswith(".md")
-                                    ),
-                                    None,
-                                )
-                                if md_name:
-                                    return _markdown_result(
-                                        bundle.read(md_name).decode("utf-8", errors="replace")
-                                    )
+                            if on_status:
+                                await on_status("mineru_downloading_result")
+                            archive_bytes = await self._get_bytes(str(zip_url))
+                            return _zip_result(
+                                archive_bytes,
+                                pages=_page_count(_find(row, "page_count", "pageCount")),
+                            )
                         raise MineruCloudError("MINERU_RESULT_URL_MISSING")
                     if state in {"failed", "error", "failure"}:
                         raise MineruCloudError(

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import re
+import shutil
 import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path, PurePosixPath
@@ -90,9 +91,7 @@ def _pymupdf_parse_sync(pdf_path: Path) -> ParserResult:
     if not text:
         raise ContentParseError("PDF_TEXT_EMPTY")
     markdown = "\n\n".join(
-        f"## Page {i}\n\n{page}"
-        for i, page in enumerate(pages, start=1)
-        if page
+        f"## Page {i}\n\n{page}" for i, page in enumerate(pages, start=1) if page
     )
     return {
         "parser": "pymupdf",
@@ -138,6 +137,104 @@ async def create_content_version(
     return version
 
 
+async def _persist_parse_result(
+    session: AsyncSession,
+    *,
+    version: PaperContentVersion,
+    result: ParserResult,
+    parser_name: str,
+) -> PaperContentVersion:
+    """Persist one immutable parse result and switch the current version atomically."""
+
+    version_id = version.id
+    directory = _version_dir(version_id)
+    try:
+        text = _clean_text(str(result.get("text") or ""))
+        markdown = _clean_text(str(result.get("markdown") or text))
+        chunks = result.get("chunks") or []
+        if not text or not chunks:
+            raise ContentParseError("PARSED_CONTENT_EMPTY")
+
+        text_path = directory / "content.txt"
+        markdown_path = _output_path(directory, result.get("markdown_path"), fallback="content.md")
+        if markdown_path is None:
+            raise ContentParseError("MARKDOWN_PATH_INVALID")
+        manifest_path = directory / "manifest.json"
+        text_path.write_text(text, encoding="utf-8")
+        markdown_path.write_text(markdown, encoding="utf-8")
+        for artifact in result.get("artifacts") or []:
+            if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
+                continue
+            artifact_path = _output_path(directory, artifact.get("path"))
+            if artifact_path is not None:
+                artifact_path.write_bytes(artifact["content"])
+        manifest_path.write_text(
+            json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        await session.execute(
+            delete(PaperContentChunk).where(PaperContentChunk.content_version_id == version.id)
+        )
+        persisted_chunks: list[PaperContentChunk] = []
+        for seq, item in enumerate(chunks):
+            chunk_text = _clean_text(str(item.get("text") or ""))
+            if not chunk_text:
+                continue
+            chunk = PaperContentChunk(
+                content_version_id=version.id,
+                seq=seq,
+                text=chunk_text,
+                page_start=item.get("page_start"),
+                page_end=item.get("page_end"),
+                rects=item.get("rects") or [],
+                section_path=item.get("section_path") or [],
+                anchor_meta=item.get("anchor_meta") or {},
+            )
+            session.add(chunk)
+            persisted_chunks.append(chunk)
+        await session.flush()
+        await persist_chunk_anchors(
+            session,
+            paper_id=version.paper_id,
+            chunks=persisted_chunks,
+            source=parser_name,
+        )
+        version.parser = parser_name
+        version.parser_version = str(
+            result.get("parser_version") or version.parser_version or "unknown"
+        )
+        version.status = "ready" if parser_name == "mineru" else "ready_fallback"
+        version.markdown_key = str(markdown_path)
+        version.text_key = str(text_path)
+        version.manifest_key = str(manifest_path)
+        version.page_count = int(result.get("pages") or 0)
+        version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
+        version.chunk_vector_state = "pending"
+        version.document_vector_state = "pending"
+        await session.execute(
+            PaperContentVersion.__table__.update()
+            .where(
+                PaperContentVersion.paper_id == version.paper_id,
+                PaperContentVersion.id != version.id,
+            )
+            .values(is_current=False)
+        )
+        version.is_current = True
+        await session.commit()
+        return version
+    except Exception as exc:
+        await session.rollback()
+        await asyncio.to_thread(shutil.rmtree, directory, ignore_errors=True)
+        failed = await session.get(PaperContentVersion, version_id)
+        error_code = str(exc) if isinstance(exc, ContentParseError) else "CONTENT_PERSIST_FAILED"
+        if failed is not None:
+            failed.status = "failed"
+            failed.error_code = error_code
+            failed.error_detail = f"{type(exc).__name__}: {error_code}"[:4000]
+            await session.commit()
+        raise ContentParseError(error_code) from exc
+
+
 async def parse_content_version(
     session: AsyncSession,
     *,
@@ -173,6 +270,7 @@ async def parse_content_version(
             else:
                 raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
         if hasattr(mineru_parser, "parse"):
+
             async def update_status(value: str) -> None:
                 version.status = value
                 await session.commit()
@@ -209,87 +307,9 @@ async def parse_content_version(
             await session.commit()
             raise ContentParseError("PYMUPDF_FAILED") from fallback_exc
 
-    text = _clean_text(str(result.get("text") or ""))
-    markdown = _clean_text(str(result.get("markdown") or text))
-    chunks = result.get("chunks") or []
-    if not text or not chunks:
-        version.status = "failed"
-        version.error_code = "PARSED_CONTENT_EMPTY"
-        version.error_detail = "parser returned no text or chunks"
-        await session.commit()
-        raise ContentParseError("PARSED_CONTENT_EMPTY")
-
-    directory = _version_dir(version.id)
-    text_path = directory / "content.txt"
-    markdown_path = _output_path(
-        directory, result.get("markdown_path"), fallback="content.md"
+    return await _persist_parse_result(
+        session, version=version, result=result, parser_name=parser_name
     )
-    if markdown_path is None:
-        raise ContentParseError("MARKDOWN_PATH_INVALID")
-    manifest_path = directory / "manifest.json"
-    text_path.write_text(text, encoding="utf-8")
-    markdown_path.write_text(markdown, encoding="utf-8")
-    for artifact in result.get("artifacts") or []:
-        if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
-            continue
-        artifact_path = _output_path(directory, artifact.get("path"))
-        if artifact_path is not None:
-            artifact_path.write_bytes(artifact["content"])
-    manifest_path.write_text(
-        json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
-    await session.execute(
-        delete(PaperContentChunk).where(
-            PaperContentChunk.content_version_id == version.id
-        )
-    )
-    persisted_chunks: list[PaperContentChunk] = []
-    for seq, item in enumerate(chunks):
-        chunk_text = _clean_text(str(item.get("text") or ""))
-        if not chunk_text:
-            continue
-        chunk = PaperContentChunk(
-            content_version_id=version.id,
-            seq=seq,
-            text=chunk_text,
-            page_start=item.get("page_start"),
-            page_end=item.get("page_end"),
-            rects=item.get("rects") or [],
-            section_path=item.get("section_path") or [],
-            anchor_meta=item.get("anchor_meta") or {},
-        )
-        session.add(chunk)
-        persisted_chunks.append(chunk)
-    await session.flush()  # chunk.id 供锚点引用
-    await persist_chunk_anchors(
-        session,
-        paper_id=version.paper_id,
-        chunks=persisted_chunks,
-        source=parser_name,
-    )
-    version.parser = parser_name
-    version.parser_version = str(
-        result.get("parser_version") or version.parser_version or "unknown"
-    )
-    version.status = "ready" if parser_name == "mineru" else "ready_fallback"
-    version.markdown_key = str(markdown_path)
-    version.text_key = str(text_path)
-    version.manifest_key = str(manifest_path)
-    version.page_count = int(result.get("pages") or 0)
-    version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
-    version.chunk_vector_state = "pending"
-    version.document_vector_state = "pending"
-    await session.execute(
-        PaperContentVersion.__table__.update()
-        .where(
-            PaperContentVersion.paper_id == version.paper_id,
-            PaperContentVersion.id != version.id,
-        )
-        .values(is_current=False)
-    )
-    version.is_current = True
-    await session.commit()
-    return version
 
 
 async def current_content_version(

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -6,7 +6,7 @@ import logging
 import re
 import uuid
 from collections.abc import Awaitable, Callable
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pymupdf
@@ -48,6 +48,23 @@ def _content_root() -> Path:
 def _version_dir(version_id: uuid.UUID) -> Path:
     path = _content_root() / str(version_id)
     path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _output_path(root: Path, name: object, *, fallback: str | None = None) -> Path | None:
+    """Resolve an archive-relative output path below the immutable version directory."""
+    relative = PurePosixPath(str(name or "").replace("\\", "/"))
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or ".." in relative.parts
+        or ":" in relative.parts[0]
+    ):
+        if fallback is None:
+            return None
+        relative = PurePosixPath(fallback)
+    path = root.joinpath(*relative.parts)
+    path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -95,11 +112,12 @@ async def create_content_version(
     parser: str = "mineru",
     parser_version: str | None = None,
 ) -> PaperContentVersion:
-    """Create a new immutable attempt and retire the previous current version."""
-    await session.execute(
-        PaperContentVersion.__table__.update()
-        .where(PaperContentVersion.paper_id == asset.paper_id)
-        .values(is_current=False)
+    """Create an immutable attempt without replacing usable content prematurely."""
+    current = await session.scalar(
+        select(PaperContentVersion.id).where(
+            PaperContentVersion.paper_id == asset.paper_id,
+            PaperContentVersion.is_current.is_(True),
+        )
     )
     latest = await session.scalar(
         select(func.max(PaperContentVersion.version_no)).where(
@@ -113,7 +131,7 @@ async def create_content_version(
         parser=parser,
         parser_version=parser_version,
         status="queued",
-        is_current=True,
+        is_current=current is None,
     )
     session.add(version)
     await session.flush()
@@ -203,10 +221,20 @@ async def parse_content_version(
 
     directory = _version_dir(version.id)
     text_path = directory / "content.txt"
-    markdown_path = directory / "content.md"
+    markdown_path = _output_path(
+        directory, result.get("markdown_path"), fallback="content.md"
+    )
+    if markdown_path is None:
+        raise ContentParseError("MARKDOWN_PATH_INVALID")
     manifest_path = directory / "manifest.json"
     text_path.write_text(text, encoding="utf-8")
     markdown_path.write_text(markdown, encoding="utf-8")
+    for artifact in result.get("artifacts") or []:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("content"), bytes):
+            continue
+        artifact_path = _output_path(directory, artifact.get("path"))
+        if artifact_path is not None:
+            artifact_path.write_bytes(artifact["content"])
     manifest_path.write_text(
         json.dumps(result.get("manifest") or {}, ensure_ascii=False, indent=2), encoding="utf-8"
     )
@@ -251,6 +279,15 @@ async def parse_content_version(
     version.chunk_count = len([item for item in chunks if str(item.get("text") or "").strip()])
     version.chunk_vector_state = "pending"
     version.document_vector_state = "pending"
+    await session.execute(
+        PaperContentVersion.__table__.update()
+        .where(
+            PaperContentVersion.paper_id == version.paper_id,
+            PaperContentVersion.id != version.id,
+        )
+        .values(is_current=False)
+    )
+    version.is_current = True
     await session.commit()
     return version
 

--- a/src/backend/app/services/structured_content.py
+++ b/src/backend/app/services/structured_content.py
@@ -1,0 +1,341 @@
+"""Authorized, path-safe access to immutable structured paper content."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import mimetypes
+import posixpath
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+from urllib.parse import unquote, urlsplit
+
+from app.core.config import get_settings
+from app.models.paper_content import PaperContentVersion
+
+_SIGNING_CONTEXT = b"polaris:structured-content:v1:"
+_MIN_TTL_SECONDS = 60
+_MAX_TTL_SECONDS = 60 * 60
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+_TABLE_EXTENSIONS = {".csv", ".html", ".htm", ".xlsx"}
+_MARKDOWN_DESTINATION = re.compile(
+    r"(?P<prefix>!?\[[^\]\n]*\]\(\s*)(?P<reference><[^>\n]+>|[^)\s]+)(?P<suffix>[^)\n]*\))"
+)
+_HTML_DESTINATION = re.compile(
+    r"(?P<prefix>\b(?:src|href)\s*=\s*[\"'])(?P<reference>[^\"']+)(?P<suffix>[\"'])",
+    re.IGNORECASE,
+)
+
+
+class StructuredContentError(RuntimeError):
+    """Persisted structured content is missing or violates its storage contract."""
+
+
+class InvalidStructuredContentToken(ValueError):
+    """A signed structured-content URL is malformed, forged, or expired."""
+
+
+@dataclass(slots=True, frozen=True)
+class StructuredContentClaims:
+    user_id: uuid.UUID
+    library_id: uuid.UUID
+    paper_id: uuid.UUID
+    version_id: uuid.UUID
+    relative_path: str
+    expires_at: int
+
+
+@dataclass(slots=True, frozen=True)
+class StructuredResource:
+    kind: Literal["markdown", "text", "image", "table"]
+    relative_path: str
+    file_path: Path
+    media_type: str
+    byte_size: int
+    sha256: str
+
+
+@dataclass(slots=True, frozen=True)
+class StructuredContentBundle:
+    content_format: Literal["mineru_markdown", "plain_text", "unavailable"]
+    content_hash: str | None
+    markdown: StructuredResource | None
+    text: StructuredResource | None
+    assets: tuple[StructuredResource, ...]
+
+    def resource(self, relative_path: str) -> StructuredResource | None:
+        for item in (self.markdown, self.text, *self.assets):
+            if item is not None and item.relative_path == relative_path:
+                return item
+        return None
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _signature(body: str) -> str:
+    secret = get_settings().secret_key.encode("utf-8")
+    digest = hmac.new(secret, _SIGNING_CONTEXT + body.encode("ascii"), hashlib.sha256).digest()
+    return _b64encode(digest)
+
+
+def _safe_relative_path(value: object) -> str:
+    raw = str(value or "").replace("\\", "/").strip()
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or path.is_absolute()
+        or not path.parts
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or ":" in path.parts[0]
+    ):
+        raise StructuredContentError("STRUCTURED_CONTENT_PATH_INVALID")
+    return path.as_posix()
+
+
+def create_token(
+    *,
+    user_id: uuid.UUID,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    version_id: uuid.UUID,
+    relative_path: str,
+    expires_at: int | None = None,
+    now: int | None = None,
+) -> tuple[str, StructuredContentClaims]:
+    current = int(time.time()) if now is None else int(now)
+    ttl = max(
+        _MIN_TTL_SECONDS,
+        min(_MAX_TTL_SECONDS, int(get_settings().structured_content_link_ttl_seconds)),
+    )
+    expiry = current + ttl if expires_at is None else int(expires_at)
+    path = _safe_relative_path(relative_path)
+    claims = StructuredContentClaims(
+        user_id=user_id,
+        library_id=library_id,
+        paper_id=paper_id,
+        version_id=version_id,
+        relative_path=path,
+        expires_at=expiry,
+    )
+    payload = {
+        "e": expiry,
+        "l": library_id.hex,
+        "p": paper_id.hex,
+        "u": user_id.hex,
+        "v": version_id.hex,
+        "x": path,
+    }
+    body = _b64encode(
+        json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode(
+            "ascii"
+        )
+    )
+    return f"{body}.{_signature(body)}", claims
+
+
+def verify_token(token: str, *, now: int | None = None) -> StructuredContentClaims:
+    try:
+        body, supplied_signature = token.split(".", 1)
+        if not hmac.compare_digest(supplied_signature, _signature(body)):
+            raise InvalidStructuredContentToken("invalid signature")
+        payload = json.loads(_b64decode(body).decode("ascii"))
+        if not isinstance(payload, dict):
+            raise ValueError("payload is not an object")
+        claims = StructuredContentClaims(
+            user_id=uuid.UUID(hex=str(payload["u"])),
+            library_id=uuid.UUID(hex=str(payload["l"])),
+            paper_id=uuid.UUID(hex=str(payload["p"])),
+            version_id=uuid.UUID(hex=str(payload["v"])),
+            relative_path=_safe_relative_path(payload["x"]),
+            expires_at=int(payload["e"]),
+        )
+    except InvalidStructuredContentToken:
+        raise
+    except (KeyError, TypeError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise InvalidStructuredContentToken("malformed token") from exc
+    current = int(time.time()) if now is None else int(now)
+    if claims.expires_at <= current:
+        raise InvalidStructuredContentToken("expired token")
+    return claims
+
+
+def create_resource_url(
+    *,
+    user_id: uuid.UUID,
+    library_id: uuid.UUID,
+    paper_id: uuid.UUID,
+    version_id: uuid.UUID,
+    relative_path: str,
+    expires_at: int | None = None,
+) -> tuple[str, StructuredContentClaims]:
+    token, claims = create_token(
+        user_id=user_id,
+        library_id=library_id,
+        paper_id=paper_id,
+        version_id=version_id,
+        relative_path=relative_path,
+        expires_at=expires_at,
+    )
+    return f"/api/structured-content-assets/{token}", claims
+
+
+def _version_root(version: PaperContentVersion) -> Path:
+    return (Path(get_settings().data_dir) / "paper-content" / str(version.id)).resolve()
+
+
+def _path_from_key(version: PaperContentVersion, value: str | None) -> tuple[Path, str] | None:
+    if not value:
+        return None
+    root = _version_root(version)
+    candidate = Path(value)
+    resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise StructuredContentError("STRUCTURED_CONTENT_PATH_INVALID") from exc
+    return resolved, _safe_relative_path(PurePosixPath(*relative.parts).as_posix())
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _resource(
+    version: PaperContentVersion,
+    value: str | None,
+    *,
+    kind: Literal["markdown", "text", "image", "table"],
+) -> StructuredResource | None:
+    resolved = _path_from_key(version, value)
+    if resolved is None:
+        return None
+    path, relative = resolved
+    if not path.is_file():
+        raise StructuredContentError("STRUCTURED_CONTENT_FILE_MISSING")
+    media_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    if kind == "markdown":
+        media_type = "text/markdown"
+    elif kind == "text":
+        media_type = "text/plain"
+    return StructuredResource(
+        kind=kind,
+        relative_path=relative,
+        file_path=path,
+        media_type=media_type,
+        byte_size=path.stat().st_size,
+        sha256=_sha256(path),
+    )
+
+
+def _load_manifest(version: PaperContentVersion) -> dict:
+    resolved = _path_from_key(version, version.manifest_key)
+    if resolved is None:
+        return {}
+    path, _ = resolved
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise StructuredContentError("STRUCTURED_MANIFEST_INVALID") from exc
+    if not isinstance(payload, dict):
+        raise StructuredContentError("STRUCTURED_MANIFEST_INVALID")
+    return payload
+
+
+def build_bundle(version: PaperContentVersion) -> StructuredContentBundle:
+    """Resolve persisted files without exposing or trusting storage paths."""
+
+    markdown = _resource(version, version.markdown_key, kind="markdown")
+    text = _resource(version, version.text_key, kind="text")
+    if markdown is None and text is None:
+        return StructuredContentBundle("unavailable", None, None, None, ())
+
+    assets: list[StructuredResource] = []
+    if version.parser == "mineru":
+        manifest = _load_manifest(version)
+        seen: set[str] = set()
+        for key, kind, extensions in (
+            ("images", "image", _IMAGE_EXTENSIONS),
+            ("tables", "table", _TABLE_EXTENSIONS),
+        ):
+            values = manifest.get(key) or []
+            if not isinstance(values, list):
+                raise StructuredContentError("STRUCTURED_MANIFEST_INVALID")
+            for value in values:
+                relative = _safe_relative_path(value)
+                if relative in seen or PurePosixPath(relative).suffix.lower() not in extensions:
+                    continue
+                item = _resource(version, relative, kind=kind)
+                if item is not None:
+                    assets.append(item)
+                    seen.add(relative)
+        content_format: Literal["mineru_markdown", "plain_text", "unavailable"] = (
+            "mineru_markdown" if markdown is not None else "plain_text"
+        )
+        content_hash = (markdown or text).sha256 if (markdown or text) is not None else None
+        return StructuredContentBundle(content_format, content_hash, markdown, text, tuple(assets))
+
+    return StructuredContentBundle(
+        "plain_text",
+        text.sha256 if text is not None else markdown.sha256 if markdown is not None else None,
+        None,
+        text or markdown,
+        (),
+    )
+
+
+def _resolved_reference(markdown_path: str, value: str) -> str | None:
+    reference = value[1:-1] if value.startswith("<") and value.endswith(">") else value
+    parsed = urlsplit(reference)
+    if parsed.scheme or parsed.netloc or parsed.path.startswith("/") or not parsed.path:
+        return None
+    decoded = unquote(parsed.path).replace("\\", "/")
+    joined = posixpath.normpath(posixpath.join(posixpath.dirname(markdown_path), decoded))
+    if joined == ".." or joined.startswith("../"):
+        return None
+    try:
+        return _safe_relative_path(joined)
+    except StructuredContentError:
+        return None
+
+
+def rewrite_markdown_asset_urls(
+    markdown: str,
+    *,
+    markdown_path: str,
+    asset_urls: dict[str, str],
+) -> str:
+    """Rewrite local Markdown and HTML asset references to signed URLs."""
+
+    def markdown_replacement(match: re.Match[str]) -> str:
+        resolved = _resolved_reference(markdown_path, match.group("reference"))
+        url = asset_urls.get(resolved or "")
+        if url is None:
+            return match.group(0)
+        return f'{match.group("prefix")}<{url}>{match.group("suffix")}'
+
+    def html_replacement(match: re.Match[str]) -> str:
+        resolved = _resolved_reference(markdown_path, match.group("reference"))
+        url = asset_urls.get(resolved or "")
+        if url is None:
+            return match.group(0)
+        return f'{match.group("prefix")}{url}{match.group("suffix")}'
+
+    rewritten = _MARKDOWN_DESTINATION.sub(markdown_replacement, markdown)
+    return _HTML_DESTINATION.sub(html_replacement, rewritten)

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 from pathlib import Path
 
+import httpx
 import pytest
 
 from app.core.config import get_settings
@@ -18,7 +19,9 @@ class FakeMineruClient:
         self.calls.append((method, url))
         if method == "POST":
             return FakeResponse(
-                json_data={"data": {"batch_id": "batch-1", "file_urls": [{"url": "https://upload"}]}},
+                json_data={
+                    "data": {"batch_id": "batch-1", "file_urls": [{"url": "https://upload"}]}
+                },
             )
         return FakeResponse(
             json_data={
@@ -142,3 +145,24 @@ def test_scheduler_rotates_configured_tokens():
         "key-a",
         "key-b",
     ]
+
+
+@pytest.mark.asyncio
+async def test_signed_upload_url_is_not_exposed_in_mineru_error(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "mineru_api_tokens", "key-a", raising=False)
+    monkeypatch.setattr(settings, "mineru_retries", 0, raising=False)
+    signed_url = "https://upload.example.test/file?signature=SECRET_SENTINEL"
+
+    class BrokenClient:
+        async def put(self, url, **_kwargs):
+            request = httpx.Request("PUT", url)
+            response = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    parser = MineruCloudParser(client=BrokenClient())
+    with pytest.raises(Exception) as caught:
+        await parser._upload(signed_url, b"pdf")
+
+    assert str(caught.value) == "MINERU_UPLOAD_FAILED:HTTP_401"
+    assert "SECRET_SENTINEL" not in str(caught.value)

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -1,5 +1,7 @@
 """MinerU Cloud upload/poll normalization contract tests."""
 
+import io
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -69,5 +71,74 @@ async def test_mineru_cloud_upload_poll_and_normalize(tmp_path: Path, monkeypatc
     assert result["parser"] == "mineru"
     assert result["pages"] == 2
     assert result["chunks"]
-    assert statuses == ["mineru_uploading", "mineru_parsing"]
+    assert statuses == [
+        "mineru_uploading",
+        "mineru_parsing",
+        "mineru_polling",
+        "mineru_downloading_result",
+    ]
     assert [method for method, _url in client.calls] == ["POST", "PUT", "GET", "GET"]
+
+
+def test_zip_result_keeps_markdown_images_and_tables():
+    from app.services.mineru import _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", "# Title\n\n![Figure](images/figure.png)\n\n| A | B |")
+        bundle.writestr("images/figure.png", b"png-bytes")
+        bundle.writestr("tables/data.csv", "a,b\n1,2")
+    result = _zip_result(buffer.getvalue(), pages=3)
+
+    assert result["pages"] == 3
+    assert result["markdown_path"] == "paper.md"
+    assert {item["path"] for item in result["artifacts"]} == {
+        "images/figure.png",
+        "tables/data.csv",
+    }
+    assert result["manifest"]["images"] == ["images/figure.png"]
+    assert result["manifest"]["tables"] == ["tables/data.csv"]
+
+
+def test_zip_result_ignores_archive_traversal_entries():
+    from app.services.mineru import _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", "# Safe")
+        bundle.writestr("../outside.png", b"not-written")
+
+    result = _zip_result(buffer.getvalue())
+
+    assert result["manifest"]["images"] == []
+
+
+def test_zip_result_rejects_invalid_archive():
+    from app.services.mineru import MineruCloudError, _zip_result
+
+    with pytest.raises(MineruCloudError, match="MINERU_ARCHIVE_INVALID"):
+        _zip_result(b"not-a-zip")
+
+
+def test_zip_result_rejects_invalid_markdown_encoding():
+    from app.services.mineru import MineruCloudError, _zip_result
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("paper.md", b"\xff\xfe")
+
+    with pytest.raises(MineruCloudError, match="MINERU_MARKDOWN_ENCODING_INVALID"):
+        _zip_result(buffer.getvalue())
+
+
+def test_scheduler_rotates_configured_tokens():
+    from app.services.mineru import _MineruScheduler
+
+    scheduler = _MineruScheduler(["key-a", "key-b"], concurrency=2)
+
+    assert [scheduler.next_token() for _ in range(4)] == [
+        "key-a",
+        "key-b",
+        "key-a",
+        "key-b",
+    ]

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -69,9 +69,7 @@ async def test_mineru_failure_falls_back_to_pymupdf_and_persists_version(app, cl
         async def failing_mineru(_path):
             raise RuntimeError("mineru unavailable")
 
-        parsed = await parse_content_version(
-            session, version=version, mineru_parser=failing_mineru
-        )
+        parsed = await parse_content_version(session, version=version, mineru_parser=failing_mineru)
         assert parsed.status == "ready_fallback"
         assert parsed.parser == "pymupdf"
         assert parsed.page_count == 1
@@ -150,9 +148,7 @@ async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
                 "pages": 1,
                 "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
                 "markdown_path": "paper.md",
-                "artifacts": [
-                    {"path": "images/figure.png", "kind": "image", "content": b"png"}
-                ],
+                "artifacts": [{"path": "images/figure.png", "kind": "image", "content": b"png"}],
                 "manifest": {"pages": 1, "images": ["images/figure.png"]},
             }
 
@@ -160,6 +156,46 @@ async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
         version_dir = Path(parsed.markdown_key).parent
         assert (version_dir / "paper.md").read_text(encoding="utf-8").startswith("# Full")
         assert (version_dir / "images" / "figure.png").read_bytes() == b"png"
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_marks_attempt_failed_and_keeps_previous_current(
+    app, client, monkeypatch
+):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await create_content_version(session, asset=asset, parser="pymupdf")
+        await parse_content_version(session, version=first, mineru_parser=None)
+        second = await create_content_version(session, asset=asset)
+
+        async def fake_mineru(_path):
+            return {
+                "parser": "mineru",
+                "markdown": "# Parsed\n\nFull text",
+                "text": "Full text",
+                "pages": 1,
+                "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
+            }
+
+        async def fail_anchor_persistence(*_args, **_kwargs):
+            raise RuntimeError("database write failed")
+
+        monkeypatch.setattr(
+            "app.services.paper_content.persist_chunk_anchors", fail_anchor_persistence
+        )
+        with pytest.raises(ContentParseError, match="CONTENT_PERSIST_FAILED"):
+            await parse_content_version(
+                session, version=second, mineru_parser=fake_mineru, allow_fallback=False
+            )
+        await session.refresh(first)
+        failed = await session.get(PaperContentVersion, second.id)
+        current = await current_content_version(session, paper_id=paper.id)
+
+    assert first.is_current is True
+    assert current is not None and current.id == first.id
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.error_code == "CONTENT_PERSIST_FAILED"
 
 
 @pytest.mark.asyncio
@@ -223,15 +259,11 @@ async def test_vectorize_persists_document_and_chunk_vectors(app, client, monkey
     async def fake_embed_documents(session, texts, **_kwargs):
         return [[float(index), 0.5, 1.0] for index, _ in enumerate(texts)], space
 
-    monkeypatch.setattr(
-        "app.services.embedding.embed_documents", fake_embed_documents
-    )
+    monkeypatch.setattr("app.services.embedding.embed_documents", fake_embed_documents)
     async with get_sessionmaker()() as session:
         version = await create_content_version(session, asset=asset)
         await parse_content_version(session, version=version, mineru_parser=None)
-        await vectorize_content_version(
-            session, version=version, library_id=library.id
-        )
+        await vectorize_content_version(session, version=version, library_id=library.id)
         await session.refresh(version)
         assert version.status == "vector_ready"
         assert version.document_vector_state == "ready"
@@ -243,6 +275,4 @@ async def test_vectorize_persists_document_and_chunk_vectors(app, client, monkey
                 )
             )
         ) is not None
-        assert (
-            await session.scalar(select(PaperContentChunkVector))
-        ) is not None
+        assert (await session.scalar(select(PaperContentChunkVector))) is not None

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -1,6 +1,7 @@
 """Issue #455: versioned parser lifecycle and vector-state persistence."""
 
 import uuid
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -108,6 +109,57 @@ async def test_reparse_creates_new_current_version_without_mutating_old(app, cli
         assert context is not None
         assert context["version_id"] == str(second.id)
         assert context["chunks"][0]["evidence"]
+
+
+@pytest.mark.asyncio
+async def test_failed_reparse_keeps_previous_current_version(app, client):
+    _user_row, _library, paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await create_content_version(session, asset=asset, parser="pymupdf")
+        await parse_content_version(session, version=first, mineru_parser=None)
+        second = await create_content_version(session, asset=asset)
+
+        async def failing_mineru(_path):
+            raise RuntimeError("cloud timeout")
+
+        with pytest.raises(ContentParseError, match="MINERU_FAILED"):
+            await parse_content_version(
+                session,
+                version=second,
+                mineru_parser=failing_mineru,
+                allow_fallback=False,
+            )
+        current = await current_content_version(session, paper_id=paper.id)
+        assert current is not None
+        assert current.id == first.id
+        assert second.is_current is False
+
+
+@pytest.mark.asyncio
+async def test_mineru_artifacts_are_persisted_with_content_version(app, client):
+    _user_row, _library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        version = await create_content_version(session, asset=asset)
+
+        async def fake_mineru(_path):
+            return {
+                "parser": "mineru",
+                "parser_version": "cloud-test",
+                "markdown": "# Full text\n\n![Figure](images/figure.png)",
+                "text": "Full text",
+                "pages": 1,
+                "chunks": [{"text": "Full text", "page_start": 1, "page_end": 1}],
+                "markdown_path": "paper.md",
+                "artifacts": [
+                    {"path": "images/figure.png", "kind": "image", "content": b"png"}
+                ],
+                "manifest": {"pages": 1, "images": ["images/figure.png"]},
+            }
+
+        parsed = await parse_content_version(session, version=version, mineru_parser=fake_mineru)
+        version_dir = Path(parsed.markdown_key).parent
+        assert (version_dir / "paper.md").read_text(encoding="utf-8").startswith("# Full")
+        assert (version_dir / "images" / "figure.png").read_bytes() == b"png"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/test_structured_content_api.py
+++ b/src/backend/tests/test_structured_content_api.py
@@ -1,0 +1,233 @@
+"""Issue #513: authorized structured-content manifests and signed resources."""
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import LibraryPaper
+from app.models.paper_assets import AssetGrant
+from app.models.user import User
+from app.services.paper_assets import create_or_reuse_asset
+from app.services.paper_content import create_content_version, parse_content_version
+from app.services.structured_content import (
+    InvalidStructuredContentToken,
+    StructuredContentError,
+    create_token,
+    verify_token,
+)
+from tests.test_paper_assets import _library, _paper_in_library, _pdf_bytes, _user
+
+
+async def _mineru_content(client):
+    headers, user_id = await _user(client, f"structured-{uuid.uuid4().hex}@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, library)
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=_pdf_bytes("structured source"),
+            user=user,
+            source="upload",
+            sharing_scope="private",
+        )
+        version = await create_content_version(session, asset=asset)
+
+        async def fake_mineru(_path):
+            return {
+                "parser": "mineru",
+                "parser_version": "cloud-test",
+                "markdown": (
+                    "# 结构化原文\n\n"
+                    "![冲击响应图](images/figure.png)\n\n"
+                    "[试验数据](tables/results.csv)\n\n"
+                    '<img src="images/figure.png" alt="response">'
+                ),
+                "text": "结构化原文 冲击响应",
+                "pages": 3,
+                "chunks": [
+                    {
+                        "text": "结构化原文 冲击响应",
+                        "page_start": 2,
+                        "page_end": 2,
+                    }
+                ],
+                "markdown_path": "output/paper.md",
+                "artifacts": [
+                    {
+                        "path": "output/images/figure.png",
+                        "kind": "image",
+                        "content": b"test-png-content",
+                    },
+                    {
+                        "path": "output/tables/results.csv",
+                        "kind": "table",
+                        "content": b"load,response\n10,2.5\n",
+                    },
+                ],
+                "manifest": {
+                    "pages": 3,
+                    "images": ["output/images/figure.png"],
+                    "tables": ["output/tables/results.csv"],
+                },
+            }
+
+        await parse_content_version(session, version=version, mineru_parser=fake_mineru)
+        await session.commit()
+        return headers, user_id, library.id, paper.id, asset.id, version.id
+
+
+async def _pymupdf_content(client):
+    headers, user_id = await _user(client, f"fallback-{uuid.uuid4().hex}@example.com")
+    async with get_sessionmaker()() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        library = await _library(session, user_id=user_id)
+        paper = await _paper_in_library(session, library)
+        asset = await create_or_reuse_asset(
+            session,
+            paper=paper,
+            library=library,
+            content=_pdf_bytes("fallback full text"),
+            user=user,
+            source="upload",
+            sharing_scope="private",
+        )
+        version = await create_content_version(session, asset=asset)
+
+        async def failing_mineru(_path):
+            raise RuntimeError("cloud unavailable")
+
+        await parse_content_version(session, version=version, mineru_parser=failing_mineru)
+        await session.commit()
+        return headers, library.id, paper.id, version.id
+
+
+async def test_mineru_manifest_serves_utf8_markdown_and_signed_assets(app, client):
+    headers, _user_id, library_id, paper_id, _asset_id, version_id = await _mineru_content(
+        client
+    )
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/structured-content",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    manifest = response.json()
+    assert manifest["content_version_id"] == str(version_id)
+    assert manifest["parser"] == "mineru"
+    assert manifest["parse_status"] == "ready"
+    assert manifest["page_count"] == 3
+    assert manifest["content_format"] == "mineru_markdown"
+    assert len(manifest["content_hash"]) == 64
+    assert len(manifest["assets"]) == 2
+    assert "paper-content" not in json.dumps(manifest)
+
+    markdown = await client.get(manifest["markdown_url"])
+    assert markdown.status_code == 200, markdown.text
+    assert markdown.encoding.lower() == "utf-8"
+    assert "结构化原文" in markdown.text
+    assert markdown.text.count("/api/structured-content-assets/") == 3
+    assert "images/figure.png" not in markdown.text
+    assert markdown.headers["cache-control"].startswith("private, max-age=")
+    assert len(markdown.headers["x-content-sha256"]) == 64
+
+    by_kind = {item["kind"]: item for item in manifest["assets"]}
+    image = await client.get(by_kind["image"]["url"])
+    table = await client.get(by_kind["table"]["url"])
+    assert image.status_code == 200 and image.content == b"test-png-content"
+    assert table.status_code == 200 and b"load,response" in table.content
+    assert "immutable" in image.headers["cache-control"]
+    assert image.headers["etag"] == f'"{by_kind["image"]["sha256"]}"'
+
+
+async def test_pymupdf_is_exposed_as_plain_text_without_mineru_assets(app, client):
+    headers, library_id, paper_id, version_id = await _pymupdf_content(client)
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/structured-content",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    manifest = response.json()
+    assert manifest["content_version_id"] == str(version_id)
+    assert manifest["parser"] == "pymupdf"
+    assert manifest["parse_status"] == "ready_fallback"
+    assert manifest["content_format"] == "plain_text"
+    assert manifest["markdown_url"] is None
+    assert manifest["assets"] == []
+
+    text = await client.get(manifest["text_url"])
+    assert text.status_code == 200
+    assert "fallback full text" in text.text
+    assert text.headers["content-type"].startswith("text/plain")
+
+
+async def test_cross_library_access_is_denied_and_revocation_invalidates_signed_url(app, client):
+    headers, user_id, library_id, paper_id, asset_id, _version_id = await _mineru_content(client)
+    response = await client.get(
+        f"/api/libraries/{library_id}/papers/{paper_id}/structured-content",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    signed_markdown_url = response.json()["markdown_url"]
+
+    async with get_sessionmaker()() as session:
+        other_library = await _library(session, user_id=user_id)
+        session.add(
+            LibraryPaper(
+                library_id=other_library.id,
+                paper_id=paper_id,
+                status="included",
+            )
+        )
+        await session.commit()
+        other_library_id = other_library.id
+    denied = await client.get(
+        f"/api/libraries/{other_library_id}/papers/{paper_id}/structured-content",
+        headers=headers,
+    )
+    assert denied.status_code == 404
+
+    async with get_sessionmaker()() as session:
+        grant = await session.scalar(
+            select(AssetGrant).where(
+                AssetGrant.asset_id == asset_id,
+                AssetGrant.library_id == library_id,
+            )
+        )
+        assert grant is not None
+        grant.can_read = False
+        await session.commit()
+    revoked = await client.get(signed_markdown_url)
+    assert revoked.status_code == 404
+
+
+def test_structured_content_tokens_reject_tampering_and_expiry():
+    values = [uuid.uuid4() for _ in range(4)]
+    token, claims = create_token(
+        user_id=values[0],
+        library_id=values[1],
+        paper_id=values[2],
+        version_id=values[3],
+        relative_path="output/paper.md",
+        expires_at=101,
+        now=100,
+    )
+    assert verify_token(token, now=100) == claims
+    with pytest.raises(InvalidStructuredContentToken):
+        verify_token(token, now=101)
+    with pytest.raises(InvalidStructuredContentToken):
+        verify_token(f"{token[:-1]}x", now=100)
+    with pytest.raises(StructuredContentError, match="STRUCTURED_CONTENT_PATH_INVALID"):
+        create_token(
+            user_id=values[0],
+            library_id=values[1],
+            paper_id=values[2],
+            version_id=values[3],
+            relative_path="../private.pdf",
+        )


### PR DESCRIPTION
## Summary

- return the current parsed-content status and a storage-path-free manifest for a library paper
- serve UTF-8 MinerU Markdown, figures, tables, and plain parsed text through authorized endpoints
- rewrite persisted relative Markdown/HTML asset references to short-lived signed URLs
- expose parser, parser version, page/chunk counts, parse status, and both vector states
- return stable SHA-256 content/asset hashes and bounded private cache headers
- keep PyMuPDF fallback explicit as `plain_text` without claiming MinerU figures or tables

## Authorization and storage safety

Every manifest request verifies library visibility, paper membership, and an active readable `AssetGrant`. Every signed resource request repeats those checks, so revocation takes effect before URL expiry. Signed URLs are bound to the requesting user, library, paper, content version, relative path, and expiry.

Persisted storage paths are never returned. Resource resolution rejects absolute paths, traversal, unsafe manifest entries, forged tokens, and expired tokens. HTML/SVG/table responses use a sandboxed content-security policy.

## API

- `GET /api/libraries/{library_id}/papers/{paper_id}/structured-content`
- `GET /api/structured-content-assets/{signed_token}`

`POLARIS_STRUCTURED_CONTENT_LINK_TTL_SECONDS` defaults to 300 seconds and is clamped to 60–3600 seconds.

## Dependency and review order

This PR starts directly from `origin/main@192f019` and contains three commits:

1. `22d20e5` — patch-equivalent to #507 commit `3bb45d9`
2. `eb9544b` — patch-equivalent to #507 commit `670272b`
3. `da42af3` — the #513 structured-content API

Recommended order: merge #507 first, then review the remaining `da42af3` delta here. Git will remove the patch-equivalent #507 changes from this PR after #507 lands. This PR does not depend on the literature discovery/translation stack.

## Verification

- `37 passed` across structured-content API, MinerU lifecycle, content versions, PDF assets, evidence anchors, AI full-text context, and download-batch protocol
- Ruff passed for the backend application, worker, and new tests
- `compileall` passed
- `git diff --check` and sensitive-value scan passed

A full Windows run produced `1473 passed, 6 failed`. The same six failures reproduce unchanged on `origin/main@192f019`: three locale/path failures (CP936 Alembic/API reads and slash normalization) and three existing experiment prompt/state assertions. None touches this PR's files or its verified paths.

Closes #513