### PR TITLE
feat(literature): add reproducible multi-query retrieval and reranking

### DIFF
--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -37,6 +37,7 @@ from app.services import libraries as libraries_service
 from app.services import literature_settings as literature_settings_service
 from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
 from app.services.literature import discovery_runs, oa_cache
+from app.services.literature.discovery_ranking import normalized_score_weights
 
 router = APIRouter(tags=["literature-discovery"])
 logger = logging.getLogger(__name__)
@@ -65,6 +66,28 @@ def _detail(run: LiteratureSearchRun, attempts: list[LiteratureSourceAttempt]) -
     )
 
 
+def _library_discovery_config(library: DirectionLibrary) -> dict[str, object]:
+    """Project the library's authoritative inclusion rules into one run snapshot."""
+
+    definition = libraries_service.library_definition(library)
+    raw_keywords = definition.get("keywords")
+    keyword_config = raw_keywords if isinstance(raw_keywords, dict) else {}
+    include = [
+        str(item).strip() for item in keyword_config.get("include") or [] if str(item).strip()
+    ]
+    exclude = [
+        str(item).strip() for item in keyword_config.get("exclude") or [] if str(item).strip()
+    ]
+    output: dict[str, object] = {}
+    if include:
+        output["keywords"] = list(dict.fromkeys(include))
+    if exclude:
+        output["excluded_keywords"] = list(dict.fromkeys(exclude))
+    if definition.get("rubric"):
+        output["score_rubric"] = definition["rubric"]
+    return output
+
+
 @router.post(
     "/libraries/{library_id}/literature/runs",
     response_model=SearchRunDetail,
@@ -79,14 +102,23 @@ async def create_run(
     library = await _managed_library(session, library_id, user)
     defaults = await literature_settings_service.get_runtime_settings(session)
     requested_count = data.requested_count or int(defaults["requested_count"])
-    candidate_budget = data.candidate_budget or int(defaults["candidate_budget"])
+    candidate_budget = max(
+        requested_count,
+        data.candidate_budget or int(defaults["candidate_budget"]),
+    )
     start_year = data.start_year if data.start_year is not None else defaults.get("start_year")
     end_year = data.end_year if data.end_year is not None else defaults.get("end_year")
     source_config = {
         "sources": list(defaults["sources"]),
         "score_weights": dict(defaults["score_weights"]),
+        **_library_discovery_config(library),
         **(data.source_config or {}),
     }
+    source_config["score_weights"] = normalized_score_weights(
+        source_config.get("score_weights")
+        if isinstance(source_config.get("score_weights"), dict)
+        else None
+    )
     # Provider credentials are resolved by workers and never enter run snapshots.
     source_config.pop("provider_keys", None)
     query_plan = await apply_profile_to_query_plan(
@@ -107,7 +139,16 @@ async def create_run(
         query_plan=query_plan,
         source_config=source_config,
         model_version=data.model_version,
-        progress={"phase": "queued", "fetched": 0, "accepted": 0},
+        progress={
+            "phase": "queued",
+            "fetched": 0,
+            "accepted": 0,
+            "requested_count": requested_count,
+            "candidate_budget": candidate_budget,
+            "returned_count": 0,
+            "start_year": start_year,
+            "end_year": end_year,
+        },
     )
     session.add(run)
     await session.flush()
@@ -117,7 +158,7 @@ async def create_run(
                 run_id=run.id,
                 source=source,
                 status="pending",
-                requested_count=candidate_budget,
+                requested_count=None,
             )
         )
     await session.commit()
@@ -214,9 +255,7 @@ async def get_run(
     return _detail(run, attempts)
 
 
-@router.get(
-    "/libraries/{library_id}/literature/runs/{run_id}/hits", response_model=SearchHitPage
-)
+@router.get("/libraries/{library_id}/literature/runs/{run_id}/hits", response_model=SearchHitPage)
 async def list_hits(
     library_id: uuid.UUID,
     run_id: uuid.UUID,
@@ -325,13 +364,17 @@ async def list_oa_cache(
     if run is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="SEARCH_RUN_NOT_FOUND")
     rows = (
-        await session.execute(
-            select(LiteratureOaCache)
-            .join(LiteratureSearchHit, LiteratureSearchHit.id == LiteratureOaCache.hit_id)
-            .where(LiteratureSearchHit.run_id == run.id)
-            .order_by(LiteratureOaCache.created_at.desc())
+        (
+            await session.execute(
+                select(LiteratureOaCache)
+                .join(LiteratureSearchHit, LiteratureSearchHit.id == LiteratureOaCache.hit_id)
+                .where(LiteratureSearchHit.run_id == run.id)
+                .order_by(LiteratureOaCache.created_at.desc())
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     return [OaCacheRead.model_validate(item) for item in rows]
 
 
@@ -431,8 +474,10 @@ async def promote_hits(
                 path = storage_path_for_blob(blob)
                 if path.is_file():
                     content = await asyncio.to_thread(path.read_bytes)
-                    identity = f"doi:{hit.doi.lower()}" if hit.doi else (
-                        f"arxiv:{hit.arxiv_id.lower()}" if hit.arxiv_id else None
+                    identity = (
+                        f"doi:{hit.doi.lower()}"
+                        if hit.doi
+                        else (f"arxiv:{hit.arxiv_id.lower()}" if hit.arxiv_id else None)
                     )
                     await create_or_reuse_asset(
                         session,

--- a/src/backend/app/services/interdisciplinary_retrieval.py
+++ b/src/backend/app/services/interdisciplinary_retrieval.py
@@ -131,7 +131,12 @@ async def apply_profile_to_query_plan(
 def rerank_interdisciplinary(
     ranked: Sequence[RankedCandidate], *, query_plan: dict[str, Any] | None, limit: int
 ) -> list[RankedCandidate]:
-    """Reward evidenced discipline bridges while retaining base literature quality."""
+    """Expose discipline coverage and use it only as a stable tie-breaker.
+
+    Discipline coverage is useful for balancing an interdisciplinary result set,
+    but it is not a research-quality dimension and therefore must not change the
+    candidate's quality score.
+    """
     config = (query_plan or {}).get("interdisciplinary") if isinstance(query_plan, dict) else None
     if not isinstance(config, dict):
         return list(ranked)[:limit]
@@ -146,20 +151,24 @@ def rerank_interdisciplinary(
         roles = {str(hit.get("role")) for hit in hits if hit.get("role")}
         bridge = bool(roles & {"bridge", "method_transfer"}) or len(disciplines) >= 2
         bridge_score = 1.0 if bridge else min(1.0, len(disciplines) / 2)
-        dimensions = {**item.dimensions, "interdisciplinary_bridge": bridge_score}
-        score = round(item.score * 0.85 + bridge_score * 0.15, 6)
+        dimensions = {**item.dimensions, "discipline_coverage": bridge_score}
         reason = "cross-discipline bridge evidence" if bridge else "single-discipline support"
         reasons = (*item.reasons, reason)
-        tier = "core" if bridge and item.tier != "exploratory" else item.tier
         output.append(
             RankedCandidate(
                 identity=item.identity,
                 candidate=item.candidate,
-                score=score,
-                tier=tier,
+                score=item.score,
+                tier=item.tier,
                 dimensions=dimensions,
                 reasons=reasons,
             )
         )
-    output.sort(key=lambda item: (-item.score, item.identity))
+    output.sort(
+        key=lambda item: (
+            -(item.score * 0.85 + item.dimensions["discipline_coverage"] * 0.15),
+            -item.score,
+            item.identity,
+        )
+    )
     return output[:limit]

--- a/src/backend/app/services/literature/arxiv.py
+++ b/src/backend/app/services/literature/arxiv.py
@@ -53,6 +53,10 @@ _RSS_CACHE_TTL = 10 * 60
 _RSS_KEEP_TYPES = frozenset({"new", "cross"})
 
 _VERSION_RE = re.compile(r"v\d+$")
+_BOOLEAN_QUERY_TOKEN_RE = re.compile(
+    r'"[^"\r\n]+"|\(|\)|\bAND\b|\bOR\b|\bNOT\b|[^\s()]+', re.IGNORECASE
+)
+_ARXIV_FIELD_RE = re.compile(r"^(?:all|ti|au|abs|co|jr|cat|rn|id):", re.IGNORECASE)
 
 # 值得重试的状态码。429 是标准限流；**403 也算**——arXiv 历史上对它认为过量的客户端
 # 直接返 403 而不是 429，当成永久失败会让整批论文白白丢掉。5xx 是服务端抖动。
@@ -272,6 +276,32 @@ def build_search_query(
     return query
 
 
+def build_raw_search_query(
+    query: str, since: datetime | None = None, until: datetime | None = None
+) -> str:
+    """Compile a validated Boolean query without quoting its operators as one phrase."""
+
+    compiled: list[str] = []
+    for token in _BOOLEAN_QUERY_TOKEN_RE.findall(query):
+        upper = token.upper()
+        if upper in {"AND", "OR", "ANDNOT"} or token in {"(", ")"}:
+            compiled.append(upper if upper in {"AND", "OR", "ANDNOT"} else token)
+        elif upper == "NOT":
+            compiled.append("ANDNOT")
+        elif _ARXIV_FIELD_RE.match(token):
+            compiled.append(token)
+        elif token.startswith('"') and token.endswith('"'):
+            compiled.append(f"all:{token}")
+        else:
+            compiled.append(f"all:{token}")
+    expression = " ".join(compiled) if compiled else "all:*"
+    if since or until:
+        lo = since.strftime("%Y%m%d%H%M") if since else "000001010000"
+        hi = until.strftime("%Y%m%d%H%M") if until else "999912312359"
+        expression = f"({expression}) AND submittedDate:[{lo} TO {hi}]"
+    return expression
+
+
 class ArxivClient:
     def __init__(
         self,
@@ -454,6 +484,36 @@ class ArxivClient:
             )
             results.extend(entries)
             if len(entries) < batch:  # 已到末页
+                break
+            start += len(entries)
+        return results[:limit]
+
+    async def search_raw(
+        self,
+        query: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Search a preplanned Boolean expression while preserving its operators."""
+
+        search_query = build_raw_search_query(query, since, until)
+        results: list[dict[str, Any]] = []
+        start = 0
+        while len(results) < limit:
+            batch = min(self.page_size, limit - len(results))
+            entries = await self._query(
+                {
+                    "search_query": search_query,
+                    "start": start,
+                    "max_results": batch,
+                    "sortBy": "submittedDate",
+                    "sortOrder": "descending",
+                }
+            )
+            results.extend(entries)
+            if len(entries) < batch:
                 break
             start += len(entries)
         return results[:limit]

--- a/src/backend/app/services/literature/discovery_ranking.py
+++ b/src/backend/app/services/literature/discovery_ranking.py
@@ -15,12 +15,14 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 DEFAULT_SCORE_WEIGHTS: dict[str, float] = {
-    "relevance": 0.50,
-    "evidence": 0.20,
+    "relevance": 0.45,
+    "evidence_quality": 0.20,
     "impact": 0.15,
     "novelty": 0.10,
-    "open_access": 0.05,
+    "recency": 0.10,
 }
+
+SCORING_VERSION = "literature-quality-v2"
 
 _TOKEN_RE = re.compile(r"[a-z0-9\u3400-\u9fff]+", re.IGNORECASE)
 
@@ -214,6 +216,17 @@ def _merge_pair(left: Mapping[str, Any], right: Mapping[str, Any]) -> dict[str, 
     for key, value in other.items():
         if key in {"sources", "retrieval_hits"}:
             merged[key] = _merge_list(merged.get(key), value)
+        elif key == "metadata" and isinstance(value, Mapping):
+            current = merged.get("metadata")
+            metadata = dict(current) if isinstance(current, Mapping) else {}
+            for metadata_key, metadata_value in value.items():
+                if metadata_key == "retrieval_hits":
+                    metadata[metadata_key] = _merge_list(
+                        metadata.get(metadata_key), metadata_value
+                    )
+                elif not metadata.get(metadata_key) and metadata_value not in (None, "", []):
+                    metadata[metadata_key] = metadata_value
+            merged[key] = metadata
         elif key == "citation_count":
             merged[key] = max(int(merged.get(key) or 0), int(value or 0))
         elif not merged.get(key) and value not in (None, "", []):
@@ -281,6 +294,7 @@ def _dimension_scores(
     topic: str,
     keywords: Sequence[str],
     current_year: int,
+    reference_texts: Sequence[str],
 ) -> dict[str, float]:
     text_tokens = _tokens(
         " ".join(
@@ -298,36 +312,63 @@ def _dimension_scores(
     )
     source_count = len(candidate.get("sources") or [])
     evidence_fallback = min(1.0, completeness * 0.8 + min(source_count, 3) / 15)
-    evidence = _unit(candidate.get("evidence_score"))
+    evidence = _unit(candidate.get("evidence_quality_score"))
+    if evidence is None:
+        evidence = _unit(candidate.get("evidence_score"))
 
     citations = max(0, int(candidate.get("citation_count") or 0))
     impact_fallback = min(1.0, math.log1p(citations) / math.log(1001))
     impact = _unit(candidate.get("impact_score"))
 
     published_year = _year(candidate)
-    novelty_fallback = (
+    recency_fallback = (
         max(0.0, min(1.0, 1 - (current_year - published_year) / 10))
         if published_year is not None
         else 0.0
     )
     novelty = _unit(candidate.get("novelty_score"))
-    has_oa = bool(candidate.get("pdf_url") or candidate.get("oa_url") or candidate.get("is_oa"))
+    if novelty is None and reference_texts:
+        similarities: list[float] = []
+        for reference in reference_texts:
+            reference_tokens = _tokens(reference)
+            union = text_tokens | reference_tokens
+            similarities.append(len(text_tokens & reference_tokens) / max(1, len(union)))
+        novelty = 1 - max(similarities, default=0.0)
+    recency = _unit(candidate.get("recency_score"))
+    retrieval_score = _unit(candidate.get("retrieval_score"))
+    if relevance is None and retrieval_score is not None:
+        relevance_value = lexical_relevance * 0.75 + retrieval_score * 0.25
+    else:
+        relevance_value = relevance if relevance is not None else lexical_relevance
 
     return {
-        "relevance": round(relevance if relevance is not None else lexical_relevance, 6),
-        "evidence": round(evidence if evidence is not None else evidence_fallback, 6),
+        "relevance": round(relevance_value, 6),
+        "evidence_quality": round(evidence if evidence is not None else evidence_fallback, 6),
         "impact": round(impact if impact is not None else impact_fallback, 6),
-        "novelty": round(novelty if novelty is not None else novelty_fallback, 6),
-        "open_access": 1.0 if has_oa else 0.0,
+        "novelty": round(novelty if novelty is not None else 0.0, 6),
+        "recency": round(recency if recency is not None else recency_fallback, 6),
     }
 
 
-def _normalized_weights(weights: Mapping[str, float] | None) -> dict[str, float]:
-    values = dict(DEFAULT_SCORE_WEIGHTS)
+def normalized_score_weights(weights: Mapping[str, float] | None) -> dict[str, float]:
+    """Normalize the stable score contract while accepting legacy setting names."""
+
+    values = (
+        dict(DEFAULT_SCORE_WEIGHTS)
+        if weights is None
+        else dict.fromkeys(DEFAULT_SCORE_WEIGHTS, 0.0)
+    )
     if weights is not None:
-        for key in values:
-            if key in weights:
-                values[key] = max(0.0, float(weights[key]))
+        aliases = {
+            "evidence": "evidence_quality",
+            "quality": "evidence_quality",
+        }
+        supplied: dict[str, float] = {}
+        for raw_key, raw_value in weights.items():
+            key = aliases.get(str(raw_key), str(raw_key))
+            if key in values:
+                supplied[key] = max(0.0, float(raw_value))
+        values.update(supplied or DEFAULT_SCORE_WEIGHTS)
     total = sum(values.values())
     if total <= 0:
         raise ValueError("score weights must contain a positive value")
@@ -350,13 +391,14 @@ def rank_candidates(
     excluded_keywords: Sequence[str] = (),
     weights: Mapping[str, float] | None = None,
     current_year: int,
+    reference_texts: Sequence[str] = (),
     limit: int | None = None,
 ) -> list[RankedCandidate]:
     """过滤明确排除项，计算分项得分并产生确定性排序。"""
 
     if limit is not None and limit < 0:
         raise ValueError("limit must not be negative")
-    normalized_weights = _normalized_weights(weights)
+    normalized_weights = normalized_score_weights(weights)
     exclusions = [_normalized_text(term) for term in excluded_keywords if str(term).strip()]
     ranked: list[RankedCandidate] = []
     for candidate in merge_candidates(candidates):
@@ -370,6 +412,7 @@ def rank_candidates(
             topic=topic,
             keywords=keywords,
             current_year=current_year,
+            reference_texts=reference_texts,
         )
         score = round(
             sum(dimensions[name] * normalized_weights[name] for name in normalized_weights), 6

--- a/src/backend/app/services/literature/retrieval_quality.py
+++ b/src/backend/app/services/literature/retrieval_quality.py
@@ -1,0 +1,482 @@
+"""Reproducible query generation, budget allocation, fusion, and model reranking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shlex
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from app.core.llm.base import Message
+from app.services.literature.discovery_ranking import (
+    RankedCandidate,
+    candidate_identity,
+    merge_candidates,
+    normalized_score_weights,
+)
+
+logger = logging.getLogger(__name__)
+
+QUERY_PLAN_VERSION = "literature-query-v2"
+RANKING_VERSION = "literature-ranking-v2"
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+_LATIN_RE = re.compile(r"[A-Za-z]")
+_NON_LATIN_LETTER_RE = re.compile(r"[^\W\d_A-Za-z]", re.UNICODE)
+_PLAIN_QUERY_SOURCES = frozenset({"openalex", "semantic", "crossref"})
+
+
+class QueryGenerationError(RuntimeError):
+    """No validated scholarly query can be produced without inventing broad terms."""
+
+
+@dataclass(frozen=True, slots=True)
+class QueryFamily:
+    purpose: Literal["core", "coverage"]
+    query: str
+    seed_id: str | None = None
+    discipline: str | None = None
+    role: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutableQuery:
+    source: str
+    purpose: Literal["core", "coverage"]
+    query: str
+    limit: int
+    seed_id: str | None = None
+    discipline: str | None = None
+    role: str | None = None
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "purpose": self.purpose,
+            "query": self.query,
+            "limit": self.limit,
+            **({"seed_id": self.seed_id} if self.seed_id else {}),
+            **({"discipline": self.discipline} if self.discipline else {}),
+            **({"role": self.role} if self.role else {}),
+        }
+
+
+def _clean(value: Any, *, limit: int = 4000) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()[:limit]
+
+
+def _extract_json(value: str) -> Any:
+    text = value.strip()
+    fenced = _JSON_FENCE_RE.search(text)
+    if fenced:
+        text = fenced.group(1).strip()
+    first = min((index for index in (text.find("{"), text.find("[")) if index >= 0), default=-1)
+    if first > 0:
+        text = text[first:]
+    decoder = json.JSONDecoder()
+    payload, _ = decoder.raw_decode(text)
+    return payload
+
+
+def _is_english_query(query: str) -> bool:
+    latin = len(_LATIN_RE.findall(query))
+    other = len(_NON_LATIN_LETTER_RE.findall(query))
+    return latin >= 4 and latin / max(1, latin + other) >= 0.85
+
+
+def _english_fallback_families(
+    *, topic: str, keywords: Sequence[str], query_plan: Mapping[str, Any] | None
+) -> list[QueryFamily]:
+    """Build a bounded English fallback when the query model is unavailable."""
+
+    seeds = _seed_families(topic=topic, keywords=keywords, query_plan=query_plan)
+    latin_terms: list[str] = []
+    for value in (topic, *keywords, *(seed.query for seed in seeds)):
+        terms = re.findall(r"[A-Za-z][A-Za-z0-9-]{2,}", str(value))
+        latin_terms.extend(terms)
+    latin_terms = list(dict.fromkeys(term.casefold() for term in latin_terms))[:8]
+    if len(latin_terms) < 2:
+        raise QueryGenerationError("QUERY_GENERATION_FAILED")
+    core = " AND ".join(f'"{term}"' for term in latin_terms[:4])
+    output = [QueryFamily(purpose="core", query=core, seed_id="fallback-core")]
+    if len(latin_terms) > 4:
+        output.append(
+            QueryFamily(
+                purpose="coverage",
+                query=" OR ".join(f'"{term}"' for term in latin_terms[4:]),
+                seed_id="fallback-coverage",
+            )
+        )
+    return output
+
+
+def compile_source_query(source: str, query: str) -> str:
+    """Compile the generated Boolean expression for a provider's query contract."""
+
+    normalized_source = source.strip().lower()
+    cleaned = _clean(query, limit=800)
+    if normalized_source not in _PLAIN_QUERY_SOURCES:
+        return cleaned
+    try:
+        tokens = shlex.split(cleaned.replace("(", " ").replace(")", " "))
+    except ValueError:
+        tokens = cleaned.replace('"', " ").split()
+    output: list[str] = []
+    skip_next = False
+    for token in tokens:
+        upper = token.upper()
+        if upper == "NOT":
+            skip_next = True
+            continue
+        if upper in {"AND", "OR"}:
+            continue
+        if skip_next or token.startswith("-"):
+            skip_next = False
+            continue
+        value = token.strip()
+        if value and value.casefold() not in {item.casefold() for item in output}:
+            output.append(value)
+    return " ".join(output) or cleaned
+
+
+def _seed_families(
+    *, topic: str, keywords: Sequence[str], query_plan: Mapping[str, Any] | None
+) -> list[QueryFamily]:
+    rows = query_plan.get("queries") if isinstance(query_plan, Mapping) else None
+    output: list[QueryFamily] = []
+    seen: set[tuple[str, str | None]] = set()
+    if isinstance(rows, list):
+        for index, row in enumerate(rows):
+            if not isinstance(row, Mapping):
+                continue
+            query = _clean(row.get("query"))
+            purpose = str(row.get("purpose") or "coverage").lower()
+            purpose = purpose if purpose in {"core", "coverage"} else "coverage"
+            seed_id = _clean(row.get("id") or row.get("seed_id"), limit=64) or f"seed-{index + 1}"
+            key = (query.casefold(), seed_id)
+            if not query or key in seen:
+                continue
+            seen.add(key)
+            output.append(
+                QueryFamily(
+                    purpose=purpose,
+                    query=query,
+                    seed_id=seed_id,
+                    discipline=_clean(row.get("discipline"), limit=255) or None,
+                    role=_clean(row.get("role"), limit=32) or None,
+                )
+            )
+    if output:
+        return output[:12]
+
+    explicit_query = _clean(query_plan.get("query")) if isinstance(query_plan, Mapping) else ""
+    topic = explicit_query or _clean(topic)
+    terms = list(dict.fromkeys(_clean(item, limit=160) for item in keywords if _clean(item)))[:12]
+    output.append(QueryFamily(purpose="core", query=topic, seed_id="core"))
+    if terms:
+        output.append(QueryFamily(purpose="coverage", query=" OR ".join(terms), seed_id="coverage"))
+    return output
+
+
+def _validated_generated_families(payload: Any, seeds: Sequence[QueryFamily]) -> list[QueryFamily]:
+    rows = payload.get("queries") if isinstance(payload, Mapping) else None
+    if not isinstance(rows, list):
+        raise ValueError("queries must be a list")
+    seed_by_id = {seed.seed_id: seed for seed in seeds if seed.seed_id}
+    output: list[QueryFamily] = []
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        query = _clean(row.get("query"))
+        if not query or len(query) > 800 or not _is_english_query(query):
+            continue
+        purpose = str(row.get("purpose") or "coverage").lower()
+        if purpose not in {"core", "coverage"}:
+            continue
+        seed_id = _clean(row.get("seed_id"), limit=64) or None
+        seed = seed_by_id.get(seed_id)
+        key = query.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(
+            QueryFamily(
+                purpose=purpose,
+                query=query,
+                seed_id=seed_id,
+                discipline=seed.discipline if seed else None,
+                role=seed.role if seed else None,
+            )
+        )
+    required_purposes = {item.purpose for item in seeds}
+    returned_purposes = {item.purpose for item in output}
+    if not output or not required_purposes.issubset(returned_purposes):
+        missing = ", ".join(sorted(required_purposes - returned_purposes))
+        raise ValueError(f"valid English query purposes missing: {missing or 'core'}")
+    return output[:12]
+
+
+async def generate_query_families(
+    *,
+    llm_router: Any,
+    topic: str,
+    keywords: Sequence[str],
+    excluded_keywords: Sequence[str],
+    query_plan: Mapping[str, Any] | None,
+    user_id: uuid.UUID | None,
+    library_id: uuid.UUID,
+    score_rubric: Any = None,
+    max_attempts: int = 3,
+) -> tuple[list[QueryFamily], dict[str, Any]]:
+    """Generate validated English query families and return an auditable snapshot."""
+
+    seeds = _seed_families(topic=topic, keywords=keywords, query_plan=query_plan)
+    seed_payload = [
+        {
+            "seed_id": item.seed_id,
+            "purpose": item.purpose,
+            "query": item.query,
+            "discipline": item.discipline,
+            "role": item.role,
+        }
+        for item in seeds
+    ]
+    prompt = {
+        "topic": topic,
+        "keywords": list(keywords),
+        "excluded_keywords": list(excluded_keywords),
+        "score_rubric": score_rubric,
+        "seed_queries": seed_payload,
+    }
+    errors: list[str] = []
+    for attempt in range(1, max_attempts + 1):
+        try:
+            retry_context = {"previous_validation_errors": errors[-2:]} if errors else {}
+            result = await llm_router.complete(
+                "extract",
+                [
+                    Message(
+                        role="system",
+                        content=(
+                            "Create high-precision scholarly search queries. "
+                            "Return strict JSON only: "
+                            '{"queries":[{"seed_id":"...","purpose":"core|coverage",'
+                            '"query":"English Boolean query"}]}. '
+                            "Use English technical terms, preserve seed_id when a seed is refined, "
+                            "include at least one core query, avoid broad "
+                            "single-word queries, and do not include excluded concepts."
+                        ),
+                    ),
+                    Message(
+                        role="user",
+                        content=json.dumps({**prompt, **retry_context}, ensure_ascii=False),
+                    ),
+                ],
+                temperature=0.1,
+                max_tokens=1800,
+                user_id=user_id,
+                library_id=library_id,
+            )
+            families = _validated_generated_families(_extract_json(result.content), seeds)
+            return families, {
+                "version": QUERY_PLAN_VERSION,
+                "mode": "model",
+                "model": result.model,
+                "attempts": attempt,
+                "validation_errors": errors,
+            }
+        except Exception as exc:  # noqa: BLE001 - deterministic fallback is required
+            errors.append(f"{type(exc).__name__}: {exc}"[:500])
+            logger.debug("literature query generation attempt %s failed", attempt, exc_info=True)
+    logger.warning("literature query generation failed; using deterministic fallback")
+    fallback = _english_fallback_families(topic=topic, keywords=keywords, query_plan=query_plan)
+    return fallback, {
+        "version": QUERY_PLAN_VERSION,
+        "mode": "deterministic_fallback",
+        "model": None,
+        "attempts": max_attempts,
+        "validation_errors": errors,
+    }
+
+
+def allocate_query_budget(
+    *, sources: Sequence[str], families: Sequence[QueryFamily], candidate_budget: int
+) -> list[ExecutableQuery]:
+    """Allocate one aggregate budget across source-query pairs, core pairs first."""
+
+    if candidate_budget < 1:
+        raise ValueError("candidate_budget must be positive")
+    unique_sources = list(dict.fromkeys(_clean(source, limit=64).lower() for source in sources))
+    unique_sources = [source for source in unique_sources if source]
+    ordered_families = sorted(families, key=lambda item: item.purpose != "core")
+    pairs = [(source, family) for family in ordered_families for source in unique_sources]
+    active = pairs[:candidate_budget]
+    if not active:
+        return []
+    quotas = [1] * len(active)
+    remaining = candidate_budget - len(active)
+    for index in range(remaining):
+        quotas[index % len(quotas)] += 1
+    return [
+        ExecutableQuery(
+            source=source,
+            purpose=family.purpose,
+            query=compile_source_query(source, family.query),
+            limit=quota,
+            seed_id=family.seed_id,
+            discipline=family.discipline,
+            role=family.role,
+        )
+        for (source, family), quota in zip(active, quotas, strict=True)
+    ]
+
+
+def add_retrieval_hit(
+    candidate: Mapping[str, Any], *, task: ExecutableQuery, rank: int
+) -> dict[str, Any]:
+    output = dict(candidate)
+    metadata = dict(output.get("metadata") or {})
+    metadata["retrieval_hits"] = [
+        {
+            "source": task.source,
+            "purpose": task.purpose,
+            "query": task.query,
+            "rank": rank,
+            **({"seed_id": task.seed_id} if task.seed_id else {}),
+            **({"discipline": task.discipline} if task.discipline else {}),
+            **({"role": task.role} if task.role else {}),
+        }
+    ]
+    output["metadata"] = metadata
+    return output
+
+
+def fuse_candidates(
+    candidates: Sequence[Mapping[str, Any]], *, executed_query_count: int
+) -> list[dict[str, Any]]:
+    """Merge duplicates and attach a normalized reciprocal-rank-fusion score."""
+
+    merged = merge_candidates(candidates)
+    denominator = max(1, executed_query_count) / 61
+    for candidate in merged:
+        metadata = candidate.get("metadata")
+        hits = metadata.get("retrieval_hits") if isinstance(metadata, Mapping) else []
+        score = sum(1 / (60 + max(1, int(hit.get("rank") or 1))) for hit in hits or [])
+        candidate["retrieval_score"] = round(min(1.0, score / denominator), 6)
+    return merged
+
+
+def _rerank_document(item: RankedCandidate) -> str:
+    candidate = item.candidate
+    return "\n".join(
+        part
+        for part in (
+            _clean(candidate.get("title"), limit=2000),
+            _clean(candidate.get("abstract"), limit=8000),
+            _clean(candidate.get("keywords"), limit=1000),
+        )
+        if part
+    )[:10_000]
+
+
+def _tier(score: float) -> Literal["core", "supporting", "exploratory"]:
+    if score >= 0.75:
+        return "core"
+    if score >= 0.50:
+        return "supporting"
+    return "exploratory"
+
+
+async def model_rerank(
+    *,
+    llm_router: Any,
+    topic: str,
+    ranked: Sequence[RankedCandidate],
+    weights: Mapping[str, float] | None,
+    limit: int,
+    user_id: uuid.UUID | None,
+    library_id: uuid.UUID,
+    score_rubric: Any = None,
+) -> tuple[list[RankedCandidate], dict[str, Any]]:
+    """Replace only relevance with model scores; retain deterministic quality dimensions."""
+
+    pool = list(ranked)
+    if not pool or limit <= 0:
+        return [], {"version": RANKING_VERSION, "mode": "deterministic", "model": None}
+    try:
+        rerank_query = topic
+        if score_rubric:
+            rerank_query = (
+                f"{topic}\nLibrary relevance rubric: "
+                f"{json.dumps(score_rubric, ensure_ascii=False, default=str)}"
+            )[:8000]
+        results = await llm_router.rerank(
+            rerank_query,
+            [_rerank_document(item) for item in pool],
+            top_n=len(pool),
+            user_id=user_id,
+            library_id=library_id,
+        )
+        normalized_weights = normalized_score_weights(weights)
+        model_scores = {
+            index: max(0.0, min(1.0, float(model_score)))
+            for index, model_score in results
+            if 0 <= index < len(pool)
+        }
+        if not model_scores:
+            raise ValueError("reranker returned no valid rows")
+        output: list[RankedCandidate] = []
+        for index, item in enumerate(pool):
+            relevance = model_scores.get(index, item.dimensions["relevance"])
+            dimensions = {**item.dimensions, "relevance": round(relevance, 6)}
+            score = round(
+                sum(dimensions[name] * normalized_weights[name] for name in normalized_weights),
+                6,
+            )
+            output.append(
+                RankedCandidate(
+                    identity=item.identity,
+                    candidate=item.candidate,
+                    score=score,
+                    tier=_tier(score),
+                    dimensions=dimensions,
+                    reasons=(
+                        *item.reasons,
+                        f"model_relevance={relevance:.3f}"
+                        if index in model_scores
+                        else "model_relevance=not_returned; deterministic score retained",
+                    ),
+                )
+            )
+        output.sort(key=lambda item: (-item.score, item.identity))
+        try:
+            model = await llm_router.model_name("rerank", user_id)
+        except Exception:  # model metadata is advisory; a successful rerank is still usable
+            model = None
+        return output[:limit], {
+            "version": RANKING_VERSION,
+            "mode": "model",
+            "model": model,
+            "pool_size": len(pool),
+            "rubric_applied": bool(score_rubric),
+        }
+    except Exception as exc:  # noqa: BLE001 - deterministic fallback is required
+        logger.warning("literature rerank failed, using deterministic ranking", exc_info=True)
+        return pool[:limit], {
+            "version": RANKING_VERSION,
+            "mode": "deterministic_fallback",
+            "model": None,
+            "pool_size": len(pool),
+            "rubric_applied": bool(score_rubric),
+            "error": f"{type(exc).__name__}: {exc}"[:500],
+        }
+
+
+def retrieval_identity(candidate: Mapping[str, Any]) -> str:
+    """Expose the stable identity for diagnostics without duplicating normalization."""
+
+    return candidate_identity(candidate)

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -16,15 +16,18 @@ from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
+from app.core.llm.router import get_llm_router
+from app.models.library_direction import LibraryPaper
 from app.models.literature_discovery import (
     LiteratureSearchHit,
     LiteratureSearchRun,
     LiteratureSourceAttempt,
 )
+from app.models.paper import Paper
 from app.schemas.literature_discovery import (
     LiteratureCandidate,
     SourceAdapter,
@@ -35,8 +38,17 @@ from app.services import literature_settings
 from app.services.interdisciplinary_retrieval import rerank_interdisciplinary
 from app.services.literature import discovery_runs
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
-from app.services.literature.discovery_ranking import rank_candidates
+from app.services.literature.discovery_ranking import SCORING_VERSION, rank_candidates
 from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
+from app.services.literature.retrieval_quality import (
+    ExecutableQuery,
+    QueryGenerationError,
+    add_retrieval_hit,
+    allocate_query_budget,
+    fuse_candidates,
+    generate_query_families,
+    model_rerank,
+)
 
 logger = logging.getLogger(__name__)
 _REGISTRY_CACHE: tuple[str, AdapterRegistry] | None = None
@@ -132,9 +144,14 @@ class ArxivAdapter:
     async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
         since = datetime(request.start_year, 1, 1, tzinfo=UTC) if request.start_year else None
         until = datetime(request.end_year, 12, 31, 23, 59, tzinfo=UTC) if request.end_year else None
-        rows = await self.client.search(
-            keywords=[request.query], since=since, until=until, limit=request.limit
-        )
+        if hasattr(self.client, "search_raw"):
+            rows = await self.client.search_raw(
+                request.query, since=since, until=until, limit=request.limit
+            )
+        else:
+            rows = await self.client.search(
+                keywords=[request.query], since=since, until=until, limit=request.limit
+            )
         return SourceSearchPage(
             source=self.name,
             items=[_candidate_from_arxiv(row) for row in rows],
@@ -234,21 +251,12 @@ def _candidate_from_generic(source: str, row: Mapping[str, Any]) -> LiteratureCa
 def _config_values(run: LiteratureSearchRun) -> tuple[list[str], list[str], dict[str, float]]:
     config = run.source_config if isinstance(run.source_config, dict) else {}
     sources = discovery_runs.enabled_sources(run.source_config, run.query_plan)
-    keywords = [str(v) for v in config.get("keywords") or [] if str(v).strip()]
+    raw_keywords = config.get("keywords")
+    keywords = (
+        [str(v) for v in raw_keywords if str(v).strip()] if isinstance(raw_keywords, list) else []
+    )
     weights = config.get("score_weights")
     return sources, keywords, weights if isinstance(weights, dict) else {}
-
-
-def _planned_query(run: LiteratureSearchRun, source: str, keywords: Sequence[str]) -> str:
-    plan = run.query_plan if isinstance(run.query_plan, dict) else {}
-    queries = plan.get("queries")
-    if isinstance(queries, list):
-        for item in queries:
-            if isinstance(item, dict) and str(item.get("source", "")).lower() == source:
-                query = str(item.get("query") or "").strip()
-                if query:
-                    return query
-    return str(plan.get("query") or run.topic or (keywords[0] if keywords else "")).strip()
 
 
 def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
@@ -326,14 +334,20 @@ async def run_discovery(
     run_id: uuid.UUID,
     *,
     registry: AdapterRegistry | None = None,
+    llm_router: Any | None = None,
     now: datetime | None = None,
 ) -> LiteratureSearchRun:
     """Execute one persisted run and return its final state."""
 
-    run = await session.get(LiteratureSearchRun, run_id)
+    run = await session.scalar(
+        select(LiteratureSearchRun)
+        .where(LiteratureSearchRun.id == run_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
     if run is None:
         raise ValueError(f"search run not found: {run_id}")
-    if run.status == "cancelled":
+    if run.status != "queued":
         return run
 
     if registry is None:
@@ -364,6 +378,71 @@ async def run_discovery(
         await session.commit()
         await session.refresh(run)
         return run
+    llm_router = llm_router or get_llm_router()
+    source_config = run.source_config if isinstance(run.source_config, dict) else {}
+    raw_exclusions = source_config.get("excluded_keywords")
+    excluded_keywords = (
+        [str(item) for item in raw_exclusions if str(item).strip()]
+        if isinstance(raw_exclusions, list)
+        else []
+    )
+    score_rubric = source_config.get("score_rubric")
+    try:
+        families, generation_snapshot = await generate_query_families(
+            llm_router=llm_router,
+            topic=run.topic,
+            keywords=keywords,
+            excluded_keywords=excluded_keywords,
+            score_rubric=score_rubric,
+            query_plan=run.query_plan,
+            user_id=run.created_by,
+            library_id=run.library_id,
+        )
+    except QueryGenerationError:
+        run.status = "failed"
+        run.error_summary = "QUERY_GENERATION_FAILED"
+        run.completed_at = datetime.now(UTC)
+        run.progress = {
+            **(run.progress or {}),
+            "phase": "failed",
+            "error_code": "QUERY_GENERATION_FAILED",
+            "requested_count": run.requested_count,
+            "candidate_budget": run.candidate_budget,
+            "returned_count": 0,
+        }
+        await session.commit()
+        await session.refresh(run)
+        return run
+    tasks = allocate_query_budget(
+        sources=sources,
+        families=families,
+        candidate_budget=run.candidate_budget,
+    )
+    plan_snapshot = dict(run.query_plan or {})
+    plan_snapshot.update(
+        {
+            "version": generation_snapshot["version"],
+            "query_generation": generation_snapshot,
+            "queries": [task.snapshot() for task in tasks],
+            "candidate_budget": run.candidate_budget,
+            "start_year": run.start_year,
+            "end_year": run.end_year,
+        }
+    )
+    run.query_plan = plan_snapshot
+    if run.model_version is None:
+        run.model_version = generation_snapshot.get("model")
+    run.progress = {
+        **(run.progress or {}),
+        "phase": "retrieving",
+        "query_total": len(tasks),
+        "query_completed": 0,
+        "requested_count": run.requested_count,
+        "candidate_budget": run.candidate_budget,
+        "start_year": run.start_year,
+        "end_year": run.end_year,
+    }
+    await session.commit()
     attempts = list(
         (
             await session.execute(
@@ -374,16 +453,26 @@ async def run_discovery(
         .all()
     )
     attempt_by_source = {attempt.source.lower(): attempt for attempt in attempts}
-    candidates: list[LiteratureCandidate] = []
+    candidates: list[dict[str, Any]] = []
     failures: list[str] = []
     fetched_total = 0
 
-    runnable: list[tuple[str, Any, LiteratureSourceAttempt, str]] = []
+    tasks_by_source: dict[str, list[ExecutableQuery]] = {source: [] for source in sources}
+    for task in tasks:
+        tasks_by_source.setdefault(task.source, []).append(task)
+    runnable: list[tuple[ExecutableQuery, Any, LiteratureSourceAttempt]] = []
     for source in sources:
         attempt = attempt_by_source.get(source)
         if attempt is None:
             attempt = LiteratureSourceAttempt(run_id=run.id, source=source)
             session.add(attempt)
+            attempt_by_source[source] = attempt
+        source_tasks = tasks_by_source.get(source, [])
+        if not source_tasks:
+            attempt.status = "skipped"
+            attempt.error_code = "BUDGET_NOT_ALLOCATED"
+            attempt.error_detail = "Aggregate candidate budget did not allocate this source"
+            continue
         adapter = registry.get(source)
         if adapter is None:
             attempt.status = "skipped"
@@ -402,94 +491,202 @@ async def run_discovery(
             await session.commit()
             continue
 
-        query = _planned_query(run, source, keywords)
         attempt.status = "running"
-        attempt.query = query
-        attempt.requested_count = run.candidate_budget
+        attempt.query = "\n".join(task.query for task in source_tasks)
+        attempt.requested_count = sum(task.limit for task in source_tasks)
         attempt.started_at = datetime.now(UTC)
-        runnable.append((source, adapter, attempt, query))
+        attempt.metadata_snapshot = {
+            "queries": [task.snapshot() for task in source_tasks],
+            "start_year": run.start_year,
+            "end_year": run.end_year,
+        }
+        runnable.extend((task, adapter, attempt) for task in source_tasks)
 
     await session.commit()
 
     semaphore = asyncio.Semaphore(get_settings().literature_source_concurrency)
 
     async def fetch(
-        source: str, adapter: Any, query: str
-    ) -> tuple[SourceSearchPage | None, SourceExecutionError | None]:
+        task_index: int, task: ExecutableQuery, adapter: Any
+    ) -> tuple[int, SourceSearchPage | None, SourceExecutionError | None]:
         async with semaphore:
             try:
                 page = await adapter.search(
                     SourceSearchRequest(
-                        query=query,
+                        query=task.query,
                         start_year=run.start_year,
                         end_year=run.end_year,
-                        limit=run.candidate_budget,
+                        limit=task.limit,
                     )
                 )
-                return page, None
+                return task_index, page, None
             except ProviderRequestError as exc:
-                return None, SourceExecutionError(
-                    exc.code, str(exc), retryable=exc.retryable
+                return (
+                    task_index,
+                    None,
+                    SourceExecutionError(
+                        exc.code, f"{task.source} provider request failed", retryable=exc.retryable
+                    ),
                 )
             except Exception as exc:  # noqa: BLE001 - provider isolation is intentional
-                return None, SourceExecutionError(
-                    "SOURCE_REQUEST_FAILED", str(exc), retryable=True
+                return (
+                    task_index,
+                    None,
+                    SourceExecutionError(
+                        "SOURCE_REQUEST_FAILED",
+                        f"{task.source} provider raised {type(exc).__name__}",
+                        retryable=True,
+                    ),
                 )
 
-    results = await asyncio.gather(
-        *(fetch(source, adapter, query) for source, adapter, _, query in runnable)
-    )
-    for (source, _, attempt, _query), (page, source_error) in zip(
-        runnable, results, strict=True
-    ):
+    source_stats: dict[str, dict[str, Any]] = {
+        source: {"fetched": 0, "accepted": 0, "succeeded": 0, "failed": []} for source in sources
+    }
+    accepted_total = 0
+    candidates_by_query: dict[int, list[dict[str, Any]]] = {}
+    pending = [
+        asyncio.create_task(fetch(task_index, task, adapter))
+        for task_index, (task, adapter, _) in enumerate(runnable)
+    ]
+    for completed_count, completed in enumerate(asyncio.as_completed(pending), start=1):
+        task_index, page, source_error = await completed
+        task, _, attempt = runnable[task_index]
+        source = task.source
+        stats = source_stats[source]
         try:
             if source_error is not None:
                 raise source_error
             assert page is not None
             validated = [validate_candidate(item) for item in page.items]
-            candidates.extend(validated)
+            filtered = [
+                item
+                for item in validated
+                if (run.start_year is None or item.year is None or item.year >= run.start_year)
+                and (run.end_year is None or item.year is None or item.year <= run.end_year)
+            ]
+            query_candidates = list(
+                add_retrieval_hit(item.model_dump(), task=task, rank=rank)
+                for rank, item in enumerate(filtered, start=1)
+            )
+            candidates_by_query[task_index] = query_candidates
             fetched_total += page.fetched_count
-            attempt.fetched_count = page.fetched_count
-            attempt.accepted_count = len(validated)
-            attempt.cursor = page.next_cursor
-            attempt.status = "completed"
-            attempt.completed_at = datetime.now(UTC)
+            accepted_total += len(query_candidates)
+            stats["fetched"] += page.fetched_count
+            stats["accepted"] += len(filtered)
+            stats["succeeded"] += 1
+            attempt.cursor = page.next_cursor or attempt.cursor
         except Exception as exc:  # noqa: BLE001 - provider isolation is intentional
             logger.warning("literature source failed: %s", source, exc_info=True)
             error = (
                 exc
                 if isinstance(exc, SourceExecutionError)
-                else SourceExecutionError("SOURCE_REQUEST_FAILED", str(exc), retryable=True)
+                else SourceExecutionError(
+                    "SOURCE_REQUEST_FAILED",
+                    f"candidate processing raised {type(exc).__name__}",
+                    retryable=True,
+                )
             )
-            attempt.status = "partial" if candidates else "failed"
             attempt.retryable = error.retryable
             attempt.error_code = error.code
             attempt.error_detail = str(error)
-            attempt.completed_at = datetime.now(UTC)
-            failures.append(f"{source}: {error.code}")
+            stats["failed"].append(error.code)
         run.progress = {
             **(run.progress or {}),
             "phase": "retrieving",
             "source": source,
+            "query_purpose": task.purpose,
+            "query_index": task_index + 1,
+            "query_total": len(runnable),
+            "query_completed": completed_count,
             "fetched": fetched_total,
-            "accepted": len(candidates),
+            "accepted": accepted_total,
             "requested_count": run.requested_count,
             "candidate_budget": run.candidate_budget,
         }
         await session.commit()
 
+    candidates = [
+        candidate
+        for task_index in range(len(runnable))
+        for candidate in candidates_by_query.get(task_index, [])
+    ]
+
+    for source in sources:
+        attempt = attempt_by_source.get(source)
+        if attempt is None or attempt.status == "skipped":
+            continue
+        stats = source_stats[source]
+        attempt.fetched_count = stats["fetched"]
+        attempt.accepted_count = stats["accepted"]
+        if stats["failed"]:
+            attempt.status = "partial" if stats["succeeded"] else "failed"
+            failures.append(f"{source}: {','.join(stats['failed'])}")
+        else:
+            attempt.status = "completed"
+        attempt.completed_at = datetime.now(UTC)
+    await session.commit()
+
+    reference_rows = (
+        await session.execute(
+            select(Paper.title, Paper.abstract)
+            .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+            .where(
+                LibraryPaper.library_id == run.library_id,
+                LibraryPaper.status.in_(("scored", "fetched", "compiled", "included")),
+            )
+            .limit(2000)
+        )
+    ).all()
+    reference_texts = [
+        "\n".join(part for part in (title, abstract) if part) for title, abstract in reference_rows
+    ]
+    fused = fuse_candidates(candidates, executed_query_count=len(runnable))
+    run.progress = {
+        **(run.progress or {}),
+        "phase": "ranking",
+        "fetched": fetched_total,
+        "accepted": len(candidates),
+        "deduplicated": len(fused),
+        "pending_rerank": len(fused),
+        "query_completed": len(runnable),
+        "query_total": len(runnable),
+        "requested_count": run.requested_count,
+        "candidate_budget": run.candidate_budget,
+        "start_year": run.start_year,
+        "end_year": run.end_year,
+    }
+    await session.commit()
     ranked = rank_candidates(
-        [candidate.model_dump() for candidate in candidates],
+        fused,
         topic=run.topic,
         keywords=keywords,
-        excluded_keywords=(run.source_config or {}).get("excluded_keywords", [])
-        if isinstance(run.source_config, dict)
-        else (),
+        excluded_keywords=excluded_keywords,
         weights=weights,
         current_year=(now or datetime.now(UTC)).year,
+        reference_texts=reference_texts,
         # 先排一个更宽的池子，跨学科重排要在里面挑平衡，再截到请求量。
-        limit=min(len(candidates), max(run.requested_count, run.requested_count * 3)),
+        limit=min(len(fused), max(run.requested_count, run.requested_count * 3)),
     )
+    ranked, ranking_snapshot = await model_rerank(
+        llm_router=llm_router,
+        topic=run.topic,
+        score_rubric=score_rubric,
+        ranked=ranked,
+        weights=weights,
+        limit=len(ranked),
+        user_id=run.created_by,
+        library_id=run.library_id,
+    )
+    run.progress = {
+        **(run.progress or {}),
+        "phase": "ranking",
+        "pending_rerank": 0,
+        "ranked_count": len(ranked),
+    }
+    await session.commit()
+    plan_snapshot = dict(run.query_plan or {})
+    plan_snapshot["ranking"] = ranking_snapshot
+    run.query_plan = plan_snapshot
     ranked = rerank_interdisciplinary(ranked, query_plan=run.query_plan, limit=run.requested_count)
     for item in ranked:
         # ``sources`` and ``retrieval_hits`` are ranking metadata, not part of the
@@ -521,11 +718,24 @@ async def run_discovery(
                     "overall": item.score,
                     "tier": item.tier,
                     "reasons": list(item.reasons),
+                    "scoring_version": SCORING_VERSION,
+                    "ranking_mode": ranking_snapshot["mode"],
+                    "ranking_model": ranking_snapshot.get("model"),
+                    "open_access": bool(
+                        candidate.pdf_url
+                        or candidate.oa_status
+                        or (
+                            candidate.metadata.get("is_oa")
+                            if isinstance(candidate.metadata, dict)
+                            else False
+                        )
+                    ),
+                    "pdf_cached": False,
                 },
                 metadata_snapshot={
                     **(candidate.metadata or {}),
                     "sources": list(raw_candidate.get("sources") or [candidate.source]),
-                    "retrieval_hits": list(raw_candidate.get("retrieval_hits") or []),
+                    "retrieval_hits": list((candidate.metadata or {}).get("retrieval_hits") or []),
                 },
             )
         )
@@ -540,7 +750,10 @@ async def run_discovery(
             await session.execute(
                 select(LiteratureSearchHit).where(
                     LiteratureSearchHit.run_id == run.id,
-                    LiteratureSearchHit.pdf_url.is_not(None),
+                    or_(
+                        LiteratureSearchHit.pdf_url.is_not(None),
+                        LiteratureSearchHit.doi.is_not(None),
+                    ),
                 )
             )
         )
@@ -564,6 +777,9 @@ async def run_discovery(
         "requested_count": run.requested_count,
         "candidate_budget": run.candidate_budget,
         "returned_count": len(ranked),
+        "ranking_mode": ranking_snapshot["mode"],
+        "start_year": run.start_year,
+        "end_year": run.end_year,
     }
     await session.commit()
     await session.refresh(run)

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -32,9 +32,10 @@ SUPPORTED_SOURCES = (
 )
 DEFAULT_SCORE_WEIGHTS = {
     "relevance": 0.45,
-    "quality": 0.2,
-    "novelty": 0.2,
-    "recency": 0.15,
+    "evidence_quality": 0.20,
+    "impact": 0.15,
+    "novelty": 0.10,
+    "recency": 0.10,
 }
 DEFAULTS: dict[str, Any] = {
     "sources": ["openalex", "semantic", "arxiv", "pubmed", "crossref"],
@@ -91,8 +92,16 @@ def _normalize(data: Any) -> dict[str, Any]:
     raw_weights = source.get("score_weights", DEFAULTS["score_weights"])
     if not isinstance(raw_weights, Mapping):
         raise InvalidLiteratureSettingError("score_weights", "must be an object")
-    weights: dict[str, float] = {}
-    for key, value in raw_weights.items():
+    weights = (
+        dict(DEFAULT_SCORE_WEIGHTS)
+        if "score_weights" not in source
+        else dict.fromkeys(DEFAULT_SCORE_WEIGHTS, 0.0)
+    )
+    aliases = {"quality": "evidence_quality", "evidence": "evidence_quality"}
+    for raw_key, value in raw_weights.items():
+        key = aliases.get(str(raw_key), str(raw_key))
+        if key not in DEFAULT_SCORE_WEIGHTS:
+            raise InvalidLiteratureSettingError(f"score_weights.{key}", "unsupported dimension")
         try:
             number = float(value)
         except (TypeError, ValueError) as exc:
@@ -101,7 +110,7 @@ def _normalize(data: Any) -> dict[str, Any]:
             raise InvalidLiteratureSettingError(
                 f"score_weights.{key}", "must be finite and non-negative"
             )
-        weights[str(key)] = number
+        weights[key] = number
     if not weights or sum(weights.values()) <= 0:
         raise InvalidLiteratureSettingError(
             "score_weights", "at least one positive weight is required"

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -97,6 +97,13 @@ async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(cli
     assert run["source_config"] == {
         "sources": ["pubmed", "core"],
         "score_weights": {"relevance": 0.8, "quality": 0.2},
+        "score_weights": {
+            "relevance": 0.8,
+            "evidence_quality": 0.2,
+            "impact": 0.0,
+            "novelty": 0.0,
+            "recency": 0.0,
+        },
     }
     assert [attempt["source"] for attempt in run["source_attempts"]] == ["core", "pubmed"]
     assert "private-pubmed-key" not in response.text

--- a/src/backend/tests/test_interdisciplinary_retrieval.py
+++ b/src/backend/tests/test_interdisciplinary_retrieval.py
@@ -43,5 +43,6 @@ def test_bridge_evidence_reranks_without_discarding_base_quality():
     )
 
     assert ranked[0].identity == "bridge"
-    assert ranked[0].dimensions["interdisciplinary_bridge"] == 1.0
-    assert ranked[0].tier == "core"
+    assert ranked[0].dimensions["discipline_coverage"] == 1.0
+    assert ranked[0].tier == "supporting"
+    assert ranked[0].score == 0.85

--- a/src/backend/tests/test_literature.py
+++ b/src/backend/tests/test_literature.py
@@ -1,5 +1,7 @@
 """文献源客户端单测：respx mock HTTP，fakeredis 缓存；零真实网络。"""
 
+from datetime import UTC, datetime
+
 import fakeredis.aioredis
 import httpx
 import pytest
@@ -9,6 +11,7 @@ import respx
 from app.services.literature.arxiv import (
     ArxivClient,
     ArxivRateLimitedError,
+    build_raw_search_query,
     build_search_query,
     normalize_arxiv_id,
 )
@@ -124,6 +127,19 @@ def test_normalize_arxiv_id_and_query():
     assert normalize_arxiv_id("2406.00001v3") == "2406.00001"
     q = build_search_query(["cs.LG", "cs.AI"], ["research agent"])
     assert q == '(cat:cs.LG OR cat:cs.AI) AND (all:"research agent")'
+
+
+def test_build_raw_search_query_preserves_boolean_operators_and_years():
+    q = build_raw_search_query(
+        '"structural impact" AND (damage OR failure) NOT review',
+        datetime(2016, 1, 1, tzinfo=UTC),
+        datetime(2026, 12, 31, tzinfo=UTC),
+    )
+
+    assert 'all:"structural impact" AND ( all:damage OR all:failure )' in q
+    assert "ANDNOT all:review" in q
+    assert "submittedDate:[201601010000 TO 202612310000]" in q
+    assert "all:ANDNOT" not in build_raw_search_query("impact ANDNOT review")
 
 
 @respx.mock

--- a/src/backend/tests/test_literature_discovery_api.py
+++ b/src/backend/tests/test_literature_discovery_api.py
@@ -45,7 +45,11 @@ async def test_owner_can_create_inspect_filter_and_cancel_run(client):
     run = response.json()
     assert run["requested_count"] == 12
     assert run["candidate_budget"] == 40
+    assert run["progress"]["requested_count"] == 12
+    assert run["progress"]["candidate_budget"] == 40
+    assert run["progress"]["returned_count"] == 0
     assert [a["source"] for a in run["source_attempts"]] == ["openalex", "semantic"]
+    assert all(attempt["requested_count"] is None for attempt in run["source_attempts"])
 
     run_id = run["id"]
     response = await client.get(
@@ -76,6 +80,59 @@ async def test_owner_can_create_inspect_filter_and_cancel_run(client):
     assert response.status_code == 200
     assert response.json()["total"] == 1
     assert response.json()["items"][0]["title"] == "Impact response"
+
+
+async def test_candidate_budget_cannot_be_smaller_than_requested_result_count(client):
+    owner = await _headers(client, "discovery-budget-owner@example.com")
+    library_id = await _personal_library(client, owner)
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        json={
+            "requested_count": 50,
+            "candidate_budget": 20,
+            "topic": "structural impact response",
+            "source_config": {"sources": ["openalex"]},
+        },
+        headers=owner,
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["requested_count"] == 50
+    assert response.json()["candidate_budget"] == 50
+
+
+async def test_run_snapshot_inherits_library_keywords_exclusions_and_rubric(client):
+    owner = await _headers(client, "discovery-library-config@example.com")
+    library_id = await _personal_library(client, owner)
+    rubric = [{"name": "mechanism evidence", "description": "Prefer validated mechanics"}]
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert library is not None
+        library.definition = {
+            "statement": "Impact response of structural members",
+            "keywords": {
+                "include": ["impact response", "damage mechanics"],
+                "exclude": ["review"],
+            },
+            "rubric": rubric,
+        }
+        await session.commit()
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/runs",
+        json={
+            "topic": "structural impact response",
+            "source_config": {"sources": ["openalex"]},
+        },
+        headers=owner,
+    )
+
+    assert response.status_code == 201, response.text
+    source_config = response.json()["source_config"]
+    assert source_config["keywords"] == ["impact response", "damage mechanics"]
+    assert source_config["excluded_keywords"] == ["review"]
+    assert source_config["score_rubric"] == rubric
 
 
 async def test_personal_library_is_isolated_and_public_library_is_read_only(client):

--- a/src/backend/tests/test_literature_discovery_ranking.py
+++ b/src/backend/tests/test_literature_discovery_ranking.py
@@ -124,10 +124,10 @@ def test_ranking_is_explainable_filtered_and_stable() -> None:
     assert first[0].candidate["title"].startswith("Dynamic impact")
     assert set(first[0].dimensions) == {
         "relevance",
-        "evidence",
+        "evidence_quality",
         "impact",
         "novelty",
-        "open_access",
+        "recency",
     }
     assert len(first[0].reasons) == 5
 
@@ -171,3 +171,27 @@ def test_limit_zero_returns_no_results() -> None:
         limit=0,
     )
     assert ranked == []
+
+
+def test_novelty_compares_candidates_with_existing_library_content() -> None:
+    ranked = rank_candidates(
+        [
+            {
+                "source": "a",
+                "title": "Structural impact response",
+                "abstract": "Damage mechanics of composite beams",
+            },
+            {
+                "source": "b",
+                "title": "Protein folding with graph neural networks",
+                "abstract": "Molecular structure prediction",
+            },
+        ],
+        topic="structural impact response",
+        current_year=2026,
+        reference_texts=["Structural impact response. Damage mechanics of composite beams."],
+    )
+
+    by_title = {item.candidate["title"]: item for item in ranked}
+    assert by_title["Protein folding with graph neural networks"].dimensions["novelty"] > 0.9
+    assert by_title["Structural impact response"].dimensions["novelty"] < 0.2

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -1,7 +1,10 @@
 """Issue #473: execute source adapters and persist ranked candidates."""
 
+import asyncio
+import json
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import func, select
@@ -17,6 +20,7 @@ from app.schemas.literature_discovery import (
     SourceSearchPage,
     SourceSearchRequest,
 )
+from app.services.literature import oa_cache
 from app.services.literature import runtime as runtime_service
 from app.services.literature.multi_source import (
     MultiSourceClient,
@@ -68,7 +72,9 @@ def _candidate(source: str, title: str, *, doi: str | None = None, year: int = 2
     )
 
 
-async def _create_run(client, *, source_config, requested_count=2, candidate_budget=5):
+async def _create_run(
+    client, *, source_config, requested_count=2, candidate_budget=5, query_plan=None
+):
     token = await register_and_login(client, email=f"runtime-{uuid.uuid4().hex}@example.com")
     headers = {"Authorization": f"Bearer {token}"}
     library = await client.post(
@@ -86,11 +92,267 @@ async def _create_run(client, *, source_config, requested_count=2, candidate_bud
             "end_year": 2025,
             "topic": "structural impact response",
             "source_config": source_config,
+            "query_plan": query_plan,
         },
         headers=headers,
     )
     assert response.status_code == 201, response.text
     return uuid.UUID(response.json()["id"]), headers, response.json()["library_id"]
+
+
+class RetrievalRouter:
+    async def complete(self, stage, messages, **kwargs):
+        del messages, kwargs
+        assert stage == "extract"
+        return SimpleNamespace(
+            content=json.dumps(
+                {
+                    "queries": [
+                        {
+                            "seed_id": "core",
+                            "purpose": "core",
+                            "query": '"structural impact" AND response',
+                        },
+                        {
+                            "seed_id": "coverage",
+                            "purpose": "coverage",
+                            "query": '"damage mechanics" OR failure',
+                        },
+                    ]
+                }
+            ),
+            model="query-model",
+        )
+
+    async def rerank(self, query, documents, **kwargs):
+        del query, documents, kwargs
+        raise NotImplementedError
+
+
+class InvalidQueryRouter:
+    async def complete(self, stage, messages, **kwargs):
+        del stage, messages, kwargs
+        return SimpleNamespace(content="not-json", model="query-model")
+
+    async def rerank(self, query, documents, **kwargs):
+        del query, documents, kwargs
+        raise AssertionError("reranking must not run without a valid query")
+
+
+@pytest.mark.asyncio
+async def test_runtime_executes_multiple_queries_with_aggregate_budget_and_year_filter(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=3,
+        candidate_budget=6,
+        query_plan={
+            "queries": [
+                {"id": "core", "purpose": "core", "query": "structural impact"},
+                {"id": "coverage", "purpose": "coverage", "query": "damage mechanics"},
+            ]
+        },
+    )
+    adapter = FakeAdapter(
+        "openalex",
+        [
+            _candidate("openalex", "Out of range", year=2015),
+            _candidate("openalex", "In range", year=2020),
+        ],
+    )
+
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+            now=datetime(2026, 8, 26, tzinfo=UTC),
+        )
+        hits = list(
+            (
+                await session.execute(
+                    select(LiteratureSearchHit).where(LiteratureSearchHit.run_id == run_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(adapter.requests) == 2
+    assert sum(request.limit for request in adapter.requests) == 6
+    assert all(request.start_year == 2016 for request in adapter.requests)
+    assert all(request.end_year == 2025 for request in adapter.requests)
+    assert {hit.title for hit in hits} == {"In range"}
+    assert len(hits[0].metadata_snapshot["retrieval_hits"]) == 2
+    assert run.query_plan["ranking"]["mode"] == "deterministic_fallback"
+
+
+@pytest.mark.asyncio
+async def test_runtime_fails_instead_of_running_a_generic_query_when_generation_is_invalid(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"], "keywords": ["结构响应"]},
+        requested_count=3,
+        candidate_budget=6,
+    )
+    adapter = FakeAdapter("openalex", [_candidate("openalex", "Must not be fetched")])
+
+    async with get_sessionmaker()() as session:
+        queued = await session.get(runtime_service.LiteratureSearchRun, run_id)
+        queued.topic = "基于视觉模型的结构冲击损伤识别"
+        await session.commit()
+        run = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=InvalidQueryRouter(),
+        )
+
+    assert run.status == "failed"
+    assert run.error_summary == "QUERY_GENERATION_FAILED"
+    assert run.progress["error_code"] == "QUERY_GENERATION_FAILED"
+    assert adapter.requests == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_is_idempotent_after_completion(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=1,
+        candidate_budget=1,
+    )
+    adapter = FakeAdapter("openalex", [_candidate("openalex", "Stable result")])
+    async with get_sessionmaker()() as session:
+        first = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+        )
+        second = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+        )
+        hit_count = await session.scalar(
+            select(func.count())
+            .select_from(LiteratureSearchHit)
+            .where(LiteratureSearchHit.run_id == run_id)
+        )
+
+    assert first.id == second.id
+    assert second.status == "completed"
+    assert hit_count == 1
+    assert len(adapter.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_does_not_execute_a_run_already_claimed_by_another_worker(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=1,
+        candidate_budget=1,
+    )
+    adapter = FakeAdapter("openalex", [_candidate("openalex", "Must not be fetched")])
+    async with get_sessionmaker()() as session:
+        claimed = await session.get(runtime_service.LiteratureSearchRun, run_id)
+        assert claimed is not None
+        claimed.status = "running"
+        await session.commit()
+        run = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+        )
+
+    assert run.status == "running"
+    assert adapter.requests == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_attempts_oa_resolution_for_doi_only_candidates(client, monkeypatch):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=1,
+        candidate_budget=1,
+    )
+    adapter = FakeAdapter(
+        "openalex", [_candidate("openalex", "DOI resolver candidate", doi="10.1000/oa")]
+    )
+    observed: list[str | None] = []
+
+    async def fake_cache_hit_pdf(session, hit):
+        del session
+        observed.append(hit.doi)
+        return None
+
+    monkeypatch.setattr(oa_cache, "cache_hit_pdf", fake_cache_hit_pdf)
+    async with get_sessionmaker()() as session:
+        await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+        )
+
+    assert observed == ["10.1000/oa"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_persists_progress_as_each_provider_query_completes(client):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex", "semantic"]},
+        requested_count=1,
+        candidate_budget=2,
+    )
+    release_slow = asyncio.Event()
+    fast_finished = asyncio.Event()
+
+    class FastAdapter(FakeAdapter):
+        async def search(self, request):
+            result = await super().search(request)
+            fast_finished.set()
+            return result
+
+    class SlowAdapter(FakeAdapter):
+        async def search(self, request):
+            await release_slow.wait()
+            return await super().search(request)
+
+    registry = AdapterRegistry(
+        (
+            FastAdapter("openalex", [_candidate("openalex", "Fast result")]),
+            SlowAdapter("semantic", [_candidate("semantic", "Slow result")]),
+        )
+    )
+    async with get_sessionmaker()() as worker_session:
+        execution = asyncio.create_task(
+            run_discovery(
+                worker_session,
+                run_id,
+                registry=registry,
+                llm_router=RetrievalRouter(),
+            )
+        )
+        await asyncio.wait_for(fast_finished.wait(), timeout=2)
+        observed_completed = 0
+        for _ in range(20):
+            async with get_sessionmaker()() as observer_session:
+                observed = await observer_session.get(runtime_service.LiteratureSearchRun, run_id)
+                observed_completed = int((observed.progress or {}).get("query_completed") or 0)
+            if observed_completed:
+                break
+            await asyncio.sleep(0.05)
+        assert observed_completed >= 1
+        release_slow.set()
+        await asyncio.wait_for(execution, timeout=3)
 
 
 @pytest.mark.asyncio
@@ -120,19 +382,22 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
         run = await run_discovery(
             session,
             run_id,
-                registry=AdapterRegistry((openalex, semantic, arxiv, core)),
+            registry=AdapterRegistry((openalex, semantic, arxiv, core)),
             now=datetime(2026, 8, 26, tzinfo=UTC),
         )
         assert run.status == "partial"
-        assert run.progress == {
-            "phase": "completed",
-            "source": "core",
-            "fetched": 4,
-            "accepted": 2,
-            "requested_count": 2,
-            "candidate_budget": 5,
-            "returned_count": 2,
-        }
+        assert run.progress["phase"] == "completed"
+        assert run.progress["source"] == "core"
+        assert run.progress["fetched"] == 4
+        assert run.progress["accepted"] == 2
+        assert run.progress["requested_count"] == 2
+        assert run.progress["candidate_budget"] == 5
+        assert run.progress["returned_count"] == 2
+        assert run.progress["deduplicated"] == 3
+        assert run.progress["pending_rerank"] == 0
+        assert run.progress["ranked_count"] == 3
+        assert run.progress["start_year"] == 2016
+        assert run.progress["end_year"] == 2025
         attempts = list(
             (
                 await session.execute(
@@ -147,7 +412,7 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
             "semantic": "completed",
             "arxiv": "completed",
             "crossref": "skipped",
-            "core": "partial",
+            "core": "failed",
         }
         hits = list(
             (
@@ -165,7 +430,7 @@ async def test_runtime_deduplicates_isolates_failures_and_persists_progress(clie
 
     assert [request.start_year for request in openalex.requests] == [2016]
     assert [request.end_year for request in arxiv.requests] == [2025]
-    assert [request.limit for request in semantic.requests] == [5]
+    assert [request.limit for request in semantic.requests] == [1]
 
 
 @pytest.mark.asyncio
@@ -233,10 +498,10 @@ async def test_provider_adapters_forward_year_window_and_restore_openalex_abstra
 
     candidate = _candidate_from_openalex(
         _simplify(
-        {
-            "title": "Indexed abstract",
-            "abstract_inverted_index": {"impact": [1], "Dynamic": [0], "response": [2]},
-        }
+            {
+                "title": "Indexed abstract",
+                "abstract_inverted_index": {"impact": [1], "Dynamic": [0], "response": [2]},
+            }
         )
     )
     assert candidate.abstract == "Dynamic impact response"

--- a/src/backend/tests/test_literature_retrieval_quality.py
+++ b/src/backend/tests/test_literature_retrieval_quality.py
@@ -1,0 +1,214 @@
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.services.literature.discovery_ranking import rank_candidates
+from app.services.literature.retrieval_quality import (
+    QueryFamily,
+    QueryGenerationError,
+    add_retrieval_hit,
+    allocate_query_budget,
+    compile_source_query,
+    fuse_candidates,
+    generate_query_families,
+    model_rerank,
+)
+
+
+class QueryRouter:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    async def complete(self, stage, messages, **kwargs):
+        del messages, kwargs
+        assert stage == "extract"
+        response = self.responses[self.calls]
+        self.calls += 1
+        return SimpleNamespace(content=response, model="query-model")
+
+
+@pytest.mark.asyncio
+async def test_query_generation_retries_until_the_plan_is_valid_english():
+    router = QueryRouter(
+        [
+            json.dumps({"queries": [{"seed_id": "core", "purpose": "core", "query": "结构冲击"}]}),
+            json.dumps(
+                {
+                    "queries": [
+                        {
+                            "seed_id": "core",
+                            "purpose": "core",
+                            "query": '"structural impact" AND "damage response"',
+                        },
+                        {
+                            "seed_id": "coverage",
+                            "purpose": "coverage",
+                            "query": '"finite element" OR "failure mode"',
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+    families, snapshot = await generate_query_families(
+        llm_router=router,
+        topic="结构冲击响应",
+        keywords=["有限元", "破坏模式"],
+        excluded_keywords=["综述"],
+        query_plan=None,
+        user_id=None,
+        library_id=uuid4(),
+    )
+
+    assert router.calls == 2
+    assert [item.purpose for item in families] == ["core", "coverage"]
+    assert all("结构" not in item.query for item in families)
+    assert snapshot == {
+        "version": "literature-query-v2",
+        "mode": "model",
+        "model": "query-model",
+        "attempts": 2,
+        "validation_errors": ["ValueError: valid English query purposes missing: core, coverage"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_query_generation_fallback_does_not_execute_raw_chinese_topic():
+    router = QueryRouter(["not json", "still not json", "no structured response"])
+
+    with pytest.raises(QueryGenerationError, match="QUERY_GENERATION_FAILED"):
+        await generate_query_families(
+            llm_router=router,
+            topic="基于视觉模型的结构冲击损伤识别",
+            keywords=["结构响应"],
+            excluded_keywords=[],
+            query_plan=None,
+            user_id=None,
+            library_id=uuid4(),
+        )
+
+
+def test_source_query_compiler_preserves_boolean_sources_and_simplifies_plain_search():
+    query = '("structural impact" AND response) NOT review'
+
+    assert compile_source_query("pubmed", query) == query
+    assert compile_source_query("openalex", query) == "structural impact response"
+    assert compile_source_query("semantic", query) == "structural impact response"
+
+
+def test_candidate_budget_is_aggregate_across_sources_and_queries():
+    tasks = allocate_query_budget(
+        sources=["openalex", "semantic", "arxiv"],
+        families=[
+            QueryFamily(purpose="core", query="impact response"),
+            QueryFamily(purpose="coverage", query="damage mechanics"),
+        ],
+        candidate_budget=20,
+    )
+
+    assert len(tasks) == 6
+    assert sum(task.limit for task in tasks) == 20
+    assert {task.source for task in tasks} == {"openalex", "semantic", "arxiv"}
+    assert {task.purpose for task in tasks} == {"core", "coverage"}
+
+
+def test_reciprocal_rank_fusion_preserves_query_provenance():
+    core = QueryFamily(purpose="core", query="impact response")
+    coverage = QueryFamily(purpose="coverage", query="damage mechanics")
+    tasks = allocate_query_budget(
+        sources=["openalex"], families=[core, coverage], candidate_budget=4
+    )
+    rows = [
+        add_retrieval_hit(
+            {"source": "openalex", "title": "Shared", "doi": "10.1/shared"},
+            task=tasks[0],
+            rank=1,
+        ),
+        add_retrieval_hit(
+            {"source": "semantic", "title": "Shared", "doi": "10.1/shared"},
+            task=tasks[1],
+            rank=2,
+        ),
+    ]
+
+    fused = fuse_candidates(rows, executed_query_count=2)
+
+    assert len(fused) == 1
+    assert len(fused[0]["metadata"]["retrieval_hits"]) == 2
+    assert fused[0]["retrieval_score"] > 0.9
+
+
+class RerankRouter:
+    async def rerank(self, query, documents, **kwargs):
+        del query, documents, kwargs
+        return [(1, 0.95), (0, 0.1)]
+
+    async def model_name(self, stage, user_id):
+        del user_id
+        assert stage == "rerank"
+        return "rerank-model"
+
+
+class PartialRerankRouter(RerankRouter):
+    async def rerank(self, query, documents, **kwargs):
+        del query, documents, kwargs
+        return [(1, 0.95)]
+
+
+@pytest.mark.asyncio
+async def test_model_rerank_replaces_relevance_but_keeps_quality_dimensions():
+    deterministic = rank_candidates(
+        [
+            {"source": "a", "title": "Impact response", "year": 2026},
+            {"source": "b", "title": "General mechanics", "year": 2025},
+        ],
+        topic="impact response",
+        current_year=2026,
+    )
+    reranked, snapshot = await model_rerank(
+        llm_router=RerankRouter(),
+        topic="impact response",
+        ranked=deterministic,
+        weights=None,
+        limit=2,
+        user_id=None,
+        library_id=uuid4(),
+    )
+
+    assert reranked[0].candidate["title"] == "General mechanics"
+    assert reranked[0].dimensions["relevance"] == 0.95
+    assert reranked[0].dimensions["recency"] == deterministic[1].dimensions["recency"]
+    assert snapshot["mode"] == "model"
+    assert snapshot["model"] == "rerank-model"
+
+
+@pytest.mark.asyncio
+async def test_partial_model_rerank_never_drops_unreturned_candidates():
+    deterministic = rank_candidates(
+        [
+            {"source": "a", "title": "Impact response", "year": 2026},
+            {"source": "b", "title": "General mechanics", "year": 2025},
+        ],
+        topic="impact response",
+        current_year=2026,
+    )
+
+    reranked, snapshot = await model_rerank(
+        llm_router=PartialRerankRouter(),
+        topic="impact response",
+        ranked=deterministic,
+        weights=None,
+        limit=2,
+        user_id=None,
+        library_id=uuid4(),
+    )
+
+    assert len(reranked) == 2
+    assert {item.candidate["title"] for item in reranked} == {
+        "Impact response",
+        "General mechanics",
+    }
+    assert snapshot["mode"] == "model"


### PR DESCRIPTION
#516 merged, rebased onto current `main`. Authorship preserved as @yyy-OPS.

The PR body states it is based on #504's head and asks for #504 to land first — which it did, squashed as #523. That squash is why four files conflicted; the content itself was fine.

## Resolutions

- `api/literature_discovery.py`, `services/literature/runtime.py` — this PR's side taken; all three hunks are its own forward changes (candidate budget floored at `requested_count`, library-level discovery config merged in, normalized score weights)
- `tests/test_literature_discovery_runtime.py`, `tests/test_admin_literature_settings.py` — union; both sides add distinct tests

## What I checked rather than assumed

The `provider_keys` stripping from #523 sits a few lines below one of the conflict hunks, so it was in range of being lost. It survives, and I re-ran the sensitivity check afterwards: removing `source_config.pop("provider_keys", None)` still reds `test_provider_keys_never_reach_the_run_snapshot`. A guard is only worth having if it still bites after the next merge lands on top of it.

## Verification

- `alembic heads` → single head `f1a2b3c4d5e6` (no migration in this PR)
- `tests/test_literature_discovery_runtime.py test_admin_literature_settings.py test_literature_discovery_api.py test_interdisciplinary_retrieval.py test_migrations.py` → 26 passed
- `ruff check app/ worker/` → clean

Closes #515. Supersedes #516.