### PR TITLE
feat(admin): add literature provider credential pool lifecycle

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -15,6 +15,10 @@ from app.schemas.admin_settings import (
     ExperimentEnvSettings,
     LabLeaderboardSettingRead,
     LabLeaderboardSettingUpdate,
+    LiteratureProviderCredentialCreate,
+    LiteratureProviderCredentialTestRequest,
+    LiteratureProviderCredentialUpdate,
+    LiteratureProviderKeyStatus,
     LiteratureProviderTestRequest,
     LiteratureProviderTestResult,
     LiteratureSearchSettings,
@@ -30,6 +34,7 @@ from app.services import lab as lab_service
 from app.services import literature_settings as literature_settings_service
 from app.services import managed_command_watchdog as watchdog_service
 from app.services import tts as tts_service
+from app.services.literature.multi_source import provider_failure_detail
 
 router = APIRouter(
     prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_admin)]
@@ -118,9 +123,7 @@ async def adopt_embedding_space(
             "active": True,
         },
     )
-    return EmbeddingSpaceAdoptResult(
-        active=EmbeddingSpaceItem(**current), previous=previous
-    )
+    return EmbeddingSpaceAdoptResult(active=EmbeddingSpaceItem(**current), previous=previous)
 
 
 @router.get("/lab-leaderboard", response_model=LabLeaderboardSettingRead)
@@ -185,9 +188,7 @@ async def set_managed_command_watchdog(
     payload: ManagedCommandWatchdogAdminSettings,
     session: AsyncSession = Depends(get_session),
 ) -> ManagedCommandWatchdogAdminSettings:
-    saved = await watchdog_service.set_admin_max_minutes(
-        session, payload.max_unanswered_minutes
-    )
+    saved = await watchdog_service.set_admin_max_minutes(session, payload.max_unanswered_minutes)
     return ManagedCommandWatchdogAdminSettings(max_unanswered_minutes=saved)
 
 
@@ -258,10 +259,117 @@ async def test_literature_provider(
             source=source,
             ok=False,
             latency_ms=round((time.perf_counter() - started) * 1000),
-            detail=f"{type(exc).__name__}: {exc}"[:500],
+            detail=provider_failure_detail(source, exc)[1],
         )
     await literature_settings_service.record_provider_health(
         session, source=source, ok=result.ok, detail=result.detail
+    )
+    return result
+
+
+@router.post(
+    "/literature-search/credentials",
+    response_model=LiteratureProviderKeyStatus,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_literature_provider_credential(
+    payload: LiteratureProviderCredentialCreate,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderKeyStatus:
+    try:
+        result = await literature_settings_service.create_provider_credential(
+            session, **payload.model_dump()
+        )
+    except literature_settings_service.InvalidLiteratureSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_LITERATURE_CREDENTIAL:{exc.field}",
+        ) from exc
+    return LiteratureProviderKeyStatus(**result)
+
+
+@router.patch(
+    "/literature-search/credentials/{credential_id}",
+    response_model=LiteratureProviderKeyStatus,
+)
+async def update_literature_provider_credential(
+    credential_id: str,
+    payload: LiteratureProviderCredentialUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderKeyStatus:
+    changes = payload.model_dump(exclude_unset=True)
+    if "label" in changes and changes["label"] is None:
+        changes["label"] = ""
+    try:
+        result = await literature_settings_service.update_provider_credential(
+            session, credential_id, **changes
+        )
+    except literature_settings_service.InvalidLiteratureSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_LITERATURE_CREDENTIAL:{exc.field}",
+        ) from exc
+    if result is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+    return LiteratureProviderKeyStatus(**result)
+
+
+@router.delete(
+    "/literature-search/credentials/{credential_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_literature_provider_credential(
+    credential_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    if not await literature_settings_service.delete_provider_credential(session, credential_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+
+
+@router.post(
+    "/literature-search/credentials/{credential_id}/test",
+    response_model=LiteratureProviderTestResult,
+)
+async def test_literature_provider_credential(
+    credential_id: str,
+    payload: LiteratureProviderCredentialTestRequest,
+    session: AsyncSession = Depends(get_session),
+) -> LiteratureProviderTestResult:
+    import time
+
+    credential = await literature_settings_service.get_provider_credential_secret(
+        session, credential_id
+    )
+    if credential is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_CREDENTIAL_NOT_FOUND")
+    source, secret = credential
+    started = time.perf_counter()
+    try:
+        from app.schemas.literature_discovery import SourceSearchRequest
+        from app.services.literature.runtime import build_adapter_registry
+
+        runtime_settings = await literature_settings_service.get_runtime_settings(session)
+        runtime_settings["provider_keys"] = {source: [secret]}
+        adapter = (await build_adapter_registry(runtime_settings)).get(source)
+        if adapter is None:
+            raise ValueError(f"unsupported source: {source}")
+        page = await adapter.search(SourceSearchRequest(query=payload.query, limit=1))
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=True,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            fetched_count=page.fetched_count,
+            detail="credential responded",
+        )
+    except Exception as exc:  # noqa: BLE001 - probe failures are returned as health state
+        result = LiteratureProviderTestResult(
+            source=source,
+            ok=False,
+            latency_ms=round((time.perf_counter() - started) * 1000),
+            detail=provider_failure_detail(source, exc)[1],
+        )
+    await literature_settings_service.record_credential_health(
+        session, credential_id, ok=result.ok, detail=result.detail
     )
     return result
 

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -87,9 +87,33 @@ class ManagedCommandWatchdogAdminSettings(BaseModel):
 
 
 class LiteratureProviderKeyStatus(BaseModel):
-    index: int
+    id: str
+    source: str
+    index: int | None = None
     configured: bool
     preview: str
+    enabled: bool = True
+    label: str | None = None
+    health: dict[str, Any] | None = None
+    created_at: float | None = None
+    updated_at: float | None = None
+
+
+class LiteratureProviderCredentialCreate(BaseModel):
+    source: str = Field(min_length=1, max_length=64)
+    secret: str = Field(min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool = True
+
+
+class LiteratureProviderCredentialUpdate(BaseModel):
+    secret: str | None = Field(default=None, min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool | None = None
+
+
+class LiteratureProviderCredentialTestRequest(BaseModel):
+    query: str = Field(default="research", min_length=1, max_length=4000)
 
 
 class LiteratureSearchSettings(BaseModel):
@@ -99,8 +123,8 @@ class LiteratureSearchSettings(BaseModel):
     start_year: int | None = Field(default=None, ge=1800, le=3000)
     end_year: int | None = Field(default=None, ge=1800, le=3000)
     score_weights: dict[str, float]
-    provider_keys: dict[str, list[LiteratureProviderKeyStatus]] = {}
-    provider_health: dict[str, dict[str, Any]] = {}
+    provider_keys: dict[str, list[LiteratureProviderKeyStatus]] = Field(default_factory=dict)
+    provider_health: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
 class LiteratureSearchSettingsUpdate(BaseModel):

--- a/src/backend/app/services/literature/multi_source.py
+++ b/src/backend/app/services/literature/multi_source.py
@@ -35,6 +35,26 @@ class ProviderRequestError(RuntimeError):
         self.retryable = retryable
 
 
+def provider_failure_detail(source: str, error: Exception | None) -> tuple[str, str]:
+    """Return a stable provider failure without URLs, query strings, or headers."""
+
+    if isinstance(error, ProviderRequestError):
+        code = error.code
+    elif isinstance(error, httpx.HTTPStatusError):
+        code = f"HTTP_{error.response.status_code}"
+    elif isinstance(error, httpx.TimeoutException):
+        code = "TIMEOUT"
+    elif isinstance(error, httpx.RequestError):
+        code = "NETWORK_ERROR"
+    elif isinstance(error, ValueError):
+        code = "INVALID_RESPONSE"
+    elif error is not None:
+        code = type(error).__name__.upper()
+    else:
+        code = "REQUEST_FAILED"
+    return code, f"{source} provider request failed ({code})"
+
+
 def _text(value: Any) -> str:
     if value is None:
         return ""
@@ -131,8 +151,9 @@ class MultiSourceClient:
         }
 
     def _key(self, source: str, fallback: str | list[str] = "") -> str:
+        configured = source in self._provider_keys
         pool = self._provider_keys.get(source, ())
-        if not pool:
+        if not configured:
             values = fallback if isinstance(fallback, list) else re.split(r"[,;\s]+", fallback)
             pool = tuple(str(value).strip() for value in values if str(value).strip())
         if not pool:
@@ -182,11 +203,8 @@ class MultiSourceClient:
                 last_error = exc
             if attempt < self._retries:
                 await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise ProviderRequestError(
-            source,
-            "REQUEST_FAILED",
-            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
-        ) from last_error
+        code, detail = provider_failure_detail(source, last_error)
+        raise ProviderRequestError(source, code, detail) from last_error
 
     async def _request_text(
         self,
@@ -208,11 +226,8 @@ class MultiSourceClient:
                 last_error = exc
             if attempt < self._retries:
                 await asyncio.sleep(min(2.0, 0.25 * (2**attempt)))
-        raise ProviderRequestError(
-            source,
-            "REQUEST_FAILED",
-            f"{type(last_error).__name__}: {last_error}" if last_error else "request failed",
-        ) from last_error
+        code, detail = provider_failure_detail(source, last_error)
+        raise ProviderRequestError(source, code, detail) from last_error
 
     async def aclose(self) -> None:
         if self._owns_client:

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -261,9 +261,12 @@ def _config_values(run: LiteratureSearchRun) -> tuple[list[str], list[str], dict
 
 def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
     configured = settings.get("provider_keys")
-    values = configured.get(source) if isinstance(configured, Mapping) else None
+    # 「这个源没配」和「配了但空（= 管理员停用了）」必须分开：只看池子空不空的话，
+    # 停用等于无效——照样回落到环境变量里的凭据，而且没有任何提示。
+    declared = isinstance(configured, Mapping) and source in configured
+    values = configured.get(source) if declared else None
     pool = [str(value).strip() for value in values or [] if str(value).strip()]
-    if pool:
+    if declared:
         return pool
     return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
 

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -9,15 +9,19 @@ from __future__ import annotations
 
 import math
 import time
+import uuid
+import zlib
 from collections.abc import Mapping
 from typing import Any
 
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import decrypt_secret, encrypt_secret
 from app.models.system_setting import SystemSetting
 
 SETTING_KEY = "literature_search"
+_SETTING_LOCK_ID = zlib.crc32(SETTING_KEY.encode("utf-8"))
 SUPPORTED_SOURCES = (
     "openalex",
     "semantic",
@@ -54,6 +58,19 @@ class InvalidLiteratureSettingError(ValueError):
     def __init__(self, field: str, detail: str) -> None:
         super().__init__(f"{field}: {detail}")
         self.field = field
+
+
+async def _setting_for_update(session: AsyncSession) -> SystemSetting | None:
+    """Serialize read-modify-write updates to the shared settings document."""
+
+    if session.get_bind().dialect.name == "postgresql":
+        # A row lock cannot serialize the first write while the singleton row is absent.
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"), {"lock_id": _SETTING_LOCK_ID}
+        )
+    return await session.scalar(
+        select(SystemSetting).where(SystemSetting.key == SETTING_KEY).with_for_update()
+    )
 
 
 def _as_int(value: Any, field: str, *, minimum: int, maximum: int) -> int:
@@ -134,21 +151,74 @@ def _mask(token: str) -> str:
     return f"••••{token[-4:]}" if len(token) >= 4 else "••••"
 
 
-def _masked(value: Mapping[str, Any] | None) -> dict[str, Any]:
+def _credential_entry(source: str, item: Any, index: int) -> dict[str, Any] | None:
+    """Normalize legacy encrypted strings and current credential objects."""
+
+    if isinstance(item, str) and item:
+        stable = uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:{source}:{index}:{item}")
+        return {
+            "id": str(stable),
+            "secret": item,
+            "enabled": True,
+            "label": None,
+            "health": None,
+            "created_at": None,
+            "updated_at": None,
+        }
+    if not isinstance(item, Mapping) or not item.get("secret"):
+        return None
+    credential_id = str(item.get("id") or uuid.uuid4())
+    try:
+        uuid.UUID(credential_id)
+    except ValueError:
+        credential_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:{source}:{credential_id}"))
+    return {
+        "id": credential_id,
+        "secret": str(item["secret"]),
+        "enabled": bool(item.get("enabled", True)),
+        "label": str(item.get("label") or "").strip() or None,
+        "health": dict(item.get("health") or {}) or None,
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+    }
+
+
+def _credential_pools(value: Mapping[str, Any] | None) -> dict[str, list[dict[str, Any]]]:
     keys = value.get("provider_keys") if isinstance(value, Mapping) else {}
+    pools: dict[str, list[dict[str, Any]]] = {}
+    if not isinstance(keys, Mapping):
+        return pools
+    for source, items in keys.items():
+        if not isinstance(items, list):
+            continue
+        normalized = [
+            entry
+            for index, item in enumerate(items)
+            if (entry := _credential_entry(str(source), item, index)) is not None
+        ]
+        if normalized:
+            pools[str(source)] = normalized
+    return pools
+
+
+def _masked(value: Mapping[str, Any] | None) -> dict[str, Any]:
     result: dict[str, list[dict[str, Any]]] = {}
-    if isinstance(keys, Mapping):
-        for source, pool in keys.items():
-            if isinstance(pool, list):
-                result[str(source)] = [
-                    {
-                        "index": index,
-                        "configured": bool(item),
-                        "preview": _mask(decrypt_secret(str(item))) if item else "••••",
-                    }
-                    for index, item in enumerate(pool)
-                    if item
-                ]
+    for source, pool in _credential_pools(value).items():
+        result[source] = [
+            {
+                "id": item["id"],
+                "source": source,
+                "index": index,
+                "configured": True,
+                "preview": _mask(decrypt_secret(item["secret"])),
+                "enabled": item["enabled"],
+                "label": item["label"],
+                "health": item["health"],
+                "created_at": item["created_at"],
+                "updated_at": item["updated_at"],
+            }
+            for index, item in enumerate(pool)
+        ]
     return result
 
 
@@ -166,18 +236,15 @@ async def get_runtime_settings(session: AsyncSession) -> dict[str, Any]:
     row = await session.get(SystemSetting, SETTING_KEY)
     value = row.value if row is not None and isinstance(row.value, Mapping) else {}
     normalized = {**DEFAULTS, **_normalize(value)}
-    encrypted = value.get("provider_keys") if isinstance(value, Mapping) else {}
     pools: dict[str, list[str]] = {}
-    if isinstance(encrypted, Mapping):
-        for source, items in encrypted.items():
-            if isinstance(items, list):
-                pools[str(source)] = [decrypt_secret(str(item)) for item in items if item]
+    for source, items in _credential_pools(value).items():
+        pools[source] = [decrypt_secret(item["secret"]) for item in items if item["enabled"]]
     normalized["provider_keys"] = pools
     return normalized
 
 
 async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dict[str, Any]:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     previous = row.value if row is not None and isinstance(row.value, Mapping) else {}
     normalized = _normalize({**(previous if isinstance(previous, Mapping) else {}), **dict(data)})
     if "provider_keys" in data and data["provider_keys"] is not None:
@@ -195,13 +262,23 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
                 raise InvalidLiteratureSettingError(
                     f"provider_keys.{source_name}", "must be a non-empty string list"
                 )
-            encrypted[source_name] = [encrypt_secret(str(item).strip()) for item in values]
+            now = time.time()
+            encrypted[source_name] = [
+                {
+                    "id": str(uuid.uuid4()),
+                    "secret": encrypt_secret(str(item).strip()),
+                    "enabled": True,
+                    "label": None,
+                    "health": None,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+                for item in values
+            ]
         normalized["provider_keys"] = encrypted
     else:
         normalized["provider_keys"] = (
-            dict(previous.get("provider_keys") or {})
-            if isinstance(previous, Mapping)
-            else {}
+            dict(previous.get("provider_keys") or {}) if isinstance(previous, Mapping) else {}
         )
     if row is None:
         session.add(SystemSetting(key=SETTING_KEY, value=normalized))
@@ -211,10 +288,144 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
     return await get_settings(session)
 
 
+def _validate_credential_source(source: str) -> str:
+    source = source.strip().lower()
+    if source not in SUPPORTED_SOURCES:
+        raise InvalidLiteratureSettingError("source", f"unsupported source: {source}")
+    if source == "arxiv":
+        raise InvalidLiteratureSettingError("source", "arxiv does not require credentials")
+    return source
+
+
+async def create_provider_credential(
+    session: AsyncSession,
+    *,
+    source: str,
+    secret: str,
+    label: str | None,
+    enabled: bool,
+) -> dict[str, Any]:
+    source = _validate_credential_source(source)
+    secret = secret.strip()
+    if not secret:
+        raise InvalidLiteratureSettingError("secret", "must not be empty")
+    row = await _setting_for_update(session)
+    value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
+    pools = _credential_pools(value)
+    now = time.time()
+    entry = {
+        "id": str(uuid.uuid4()),
+        "secret": encrypt_secret(secret),
+        "enabled": enabled,
+        "label": str(label or "").strip() or None,
+        "health": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    pools.setdefault(source, []).append(entry)
+    value["provider_keys"] = pools
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return next(item for item in _masked(value)[source] if item["id"] == entry["id"])
+
+
+async def update_provider_credential(
+    session: AsyncSession,
+    credential_id: str,
+    *,
+    secret: str | None = None,
+    label: str | None = None,
+    enabled: bool | None = None,
+) -> dict[str, Any] | None:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return None
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    for source, entries in pools.items():
+        for entry in entries:
+            if entry["id"] != credential_id:
+                continue
+            if secret is not None:
+                if not secret.strip():
+                    raise InvalidLiteratureSettingError("secret", "must not be empty")
+                entry["secret"] = encrypt_secret(secret.strip())
+            if label is not None:
+                entry["label"] = label.strip() or None
+            if enabled is not None:
+                entry["enabled"] = enabled
+            entry["updated_at"] = time.time()
+            value["provider_keys"] = pools
+            row.value = value
+            await session.commit()
+            return next(item for item in _masked(value)[source] if item["id"] == credential_id)
+    return None
+
+
+async def delete_provider_credential(session: AsyncSession, credential_id: str) -> bool:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return False
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    found = False
+    for source, entries in list(pools.items()):
+        kept = [entry for entry in entries if entry["id"] != credential_id]
+        found = found or len(kept) != len(entries)
+        if kept:
+            pools[source] = kept
+        else:
+            pools.pop(source, None)
+    if not found:
+        return False
+    value["provider_keys"] = pools
+    row.value = value
+    await session.commit()
+    return True
+
+
+async def get_provider_credential_secret(
+    session: AsyncSession, credential_id: str
+) -> tuple[str, str] | None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    for source, entries in _credential_pools(value).items():
+        for entry in entries:
+            if entry["id"] == credential_id:
+                return source, decrypt_secret(entry["secret"])
+    return None
+
+
+async def record_credential_health(
+    session: AsyncSession, credential_id: str, *, ok: bool, detail: str
+) -> None:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return
+    value = dict(row.value)
+    pools = _credential_pools(value)
+    for entries in pools.values():
+        for entry in entries:
+            if entry["id"] == credential_id:
+                entry["health"] = {
+                    "ok": ok,
+                    "detail": detail[:500],
+                    "checked_at": time.time(),
+                }
+                entry["updated_at"] = time.time()
+                value["provider_keys"] = pools
+                row.value = value
+                await session.commit()
+                return
+
+
 async def record_provider_health(
     session: AsyncSession, *, source: str, ok: bool, detail: str
 ) -> None:
-    row = await session.get(SystemSetting, SETTING_KEY)
+    row = await _setting_for_update(session)
     value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
     health = dict(value.get("provider_health") or {})
     health[source] = {"ok": ok, "detail": detail[:500], "checked_at": time.time()}

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -1,5 +1,10 @@
 """管理员文献检索设置：持久化、脱敏、校验和权限。"""
 
+import httpx
+
+from app.core.db import get_sessionmaker
+from app.schemas.literature_discovery import SourceSearchPage
+from app.services import literature_settings
 from tests.conftest import register_and_login
 
 
@@ -96,7 +101,6 @@ async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(cli
     assert run["end_year"] == 2025
     assert run["source_config"] == {
         "sources": ["pubmed", "core"],
-        "score_weights": {"relevance": 0.8, "quality": 0.2},
         "score_weights": {
             "relevance": 0.8,
             "evidence_quality": 0.2,
@@ -108,3 +112,168 @@ async def test_discovery_run_inherits_admin_defaults_without_persisting_keys(cli
     assert [attempt["source"] for attempt in run["source_attempts"]] == ["core", "pubmed"]
     assert "private-pubmed-key" not in response.text
     assert "request-injected-secret" not in response.text
+
+
+async def test_provider_credential_crud_has_stable_id_and_runtime_enable_gate(client):
+    admin, member = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={
+            "source": "openalex",
+            "secret": "openalex-secret-1234",
+            "label": "primary",
+            "enabled": True,
+        },
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    created = response.json()
+    credential_id = created["id"]
+    assert created["source"] == "openalex"
+    assert created["preview"] == "••••1234"
+    assert created["label"] == "primary"
+    assert "openalex-secret-1234" not in response.text
+
+    response = await client.patch(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}",
+        json={"secret": "replacement-secret-5678", "label": "secondary", "enabled": False},
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == credential_id
+    assert response.json()["preview"] == "••••5678"
+    assert response.json()["enabled"] is False
+
+    async with get_sessionmaker()() as session:
+        runtime = await literature_settings.get_runtime_settings(session)
+    assert runtime["provider_keys"]["openalex"] == []
+
+    response = await client.patch(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}",
+        json={"enabled": True, "label": None},
+        headers=admin,
+    )
+    assert response.status_code == 200
+    assert response.json()["label"] is None
+    async with get_sessionmaker()() as session:
+        runtime = await literature_settings.get_runtime_settings(session)
+    assert runtime["provider_keys"]["openalex"] == ["replacement-secret-5678"]
+
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=member
+    )
+    assert response.status_code == 403
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=admin
+    )
+    assert response.status_code == 204
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=admin
+    )
+    assert response.status_code == 404
+
+
+async def test_arxiv_rejects_credentials_because_public_api_needs_no_key(client):
+    admin, _ = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "arxiv", "secret": "unnecessary-key"},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_LITERATURE_CREDENTIAL:source" in response.text
+
+
+async def test_single_credential_probe_updates_only_that_entry(client, monkeypatch):
+    admin, _ = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "semantic", "secret": "semantic-key-under-test"},
+        headers=admin,
+    )
+    credential_id = response.json()["id"]
+    observed = {}
+
+    class Adapter:
+        async def search(self, request):
+            observed["query"] = request.query
+            return SourceSearchPage(source="semantic", fetched_count=1)
+
+    class Registry:
+        def get(self, source):
+            observed["source"] = source
+            return Adapter()
+
+    async def fake_registry(settings):
+        observed["keys"] = settings["provider_keys"]
+        return Registry()
+
+    from app.services.literature import runtime
+
+    monkeypatch.setattr(runtime, "build_adapter_registry", fake_registry)
+    response = await client.post(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}/test",
+        json={"query": "impact response"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert observed == {
+        "keys": {"semantic": ["semantic-key-under-test"]},
+        "source": "semantic",
+        "query": "impact response",
+    }
+    response = await client.get("/api/admin/settings/literature-search", headers=admin)
+    item = response.json()["provider_keys"]["semantic"][0]
+    assert item["id"] == credential_id
+    assert item["health"]["ok"] is True
+
+
+async def test_credential_probe_never_returns_or_persists_secret_url(client, monkeypatch):
+    admin, _ = await _admin_and_member(client)
+    secret = "SECRET_SENTINEL"
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "openalex", "secret": secret},
+        headers=admin,
+    )
+    credential_id = response.json()["id"]
+
+    class Adapter:
+        async def search(self, request):
+            del request
+            request = httpx.Request(
+                "GET", f"https://api.openalex.org/works?api_key={secret}&search=x"
+            )
+            upstream = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=upstream)
+
+    class Registry:
+        def get(self, source):
+            assert source == "openalex"
+            return Adapter()
+
+    async def fake_registry(settings):
+        assert settings["provider_keys"] == {"openalex": [secret]}
+        return Registry()
+
+    from app.services.literature import runtime
+
+    monkeypatch.setattr(runtime, "build_adapter_registry", fake_registry)
+    response = await client.post(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}/test",
+        json={"query": "impact response"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is False
+    assert response.json()["detail"] == "openalex provider request failed (HTTP_401)"
+    assert secret not in response.text
+    saved = await client.get("/api/admin/settings/literature-search", headers=admin)
+    assert secret not in saved.text
+    assert (
+        saved.json()["provider_keys"]["openalex"][0]["health"]["detail"]
+        == response.json()["detail"]
+    )

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -6,9 +6,11 @@ import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from sqlalchemy import func, select
 
+from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.models.literature_discovery import (
     LiteratureSearchHit,
@@ -570,6 +572,33 @@ async def test_runtime_persists_provider_error_instead_of_reporting_zero_hit_suc
 
 
 @pytest.mark.asyncio
+async def test_multi_source_retry_error_does_not_expose_query_credentials(monkeypatch):
+    secret = "SECRET_SENTINEL"
+    settings = get_settings()
+    monkeypatch.setattr(settings, "literature_source_retries", 0, raising=False)
+
+    class BrokenClient:
+        async def request(self, method, url, **kwargs):
+            del method, url, kwargs
+            request = httpx.Request(
+                "GET", f"https://eutils.ncbi.nlm.nih.gov/esearch?api_key={secret}"
+            )
+            return httpx.Response(503, request=request)
+
+    provider = MultiSourceClient(client=BrokenClient())
+    with pytest.raises(ProviderRequestError) as caught:
+        await provider._request_json(
+            "pubmed",
+            "GET",
+            "https://eutils.ncbi.nlm.nih.gov/esearch",
+            params={"api_key": secret},
+        )
+
+    assert caught.value.code == "HTTP_503"
+    assert secret not in str(caught.value)
+
+
+@pytest.mark.asyncio
 async def test_runtime_builds_default_registry_from_decrypted_admin_settings(client, monkeypatch):
     run_id, _, _ = await _create_run(
         client,
@@ -620,6 +649,13 @@ def test_multi_source_key_pool_rotates_and_pubmed_xml_keeps_full_abstract():
         </MedlineCitation></PubmedArticle></PubmedArticleSet>"""
     )
     assert abstracts == {"123": "BACKGROUND: First sentence.\nSecond sentence."}
+
+
+def test_explicit_empty_key_pool_does_not_fall_back_to_environment_key():
+    client = MultiSourceClient(client=object(), provider_keys={"core": []})
+
+    assert client._key("core", "environment-key") == ""
+    assert client._key("unconfigured", "environment-key") == "environment-key"
 
 
 @pytest.mark.asyncio
@@ -717,3 +753,26 @@ async def test_provider_keys_never_reach_the_run_snapshot(client):
         persisted = repr(run.source_config) + repr(run.query_plan) + repr(run.progress)
     assert "SECRET-LEAK" not in persisted, persisted
     assert "provider_keys" not in (run.source_config or {})
+
+
+def test_disabled_credential_pool_does_not_fall_back_to_env():
+    """管理员把某个源的凭据池清空 = 停用，不能再回落到环境变量里的 key。
+
+    只判断池子空不空的话，「配了但清空」和「压根没配」就没区别：停用等于无效，
+    请求照样用环境凭据发出去，而且从外面完全看不出来——账单和配额会先于任何
+    报错告诉你这件事。
+    """
+    from app.services.literature.runtime import _credential_pool
+
+    # 没配过这个源 → 允许回落到环境凭据
+    assert _credential_pool({}, "openalex", "env-key") == ["env-key"]
+    assert _credential_pool({"provider_keys": {}}, "openalex", "env-key") == ["env-key"]
+
+    # 配了但清空 = 显式停用 → 不回落
+    assert _credential_pool({"provider_keys": {"openalex": []}}, "openalex", "env-key") == []
+    assert _credential_pool({"provider_keys": {"openalex": ["  "]}}, "openalex", "env-key") == []
+
+    # 配了且非空 → 用配置的
+    assert _credential_pool(
+        {"provider_keys": {"openalex": ["a", "b"]}}, "openalex", "env-key"
+    ) == ["a", "b"]

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -543,10 +543,11 @@ async def test_collecting_libraries_lists_only_admitted_and_visible(client):
     candidate 是还没打分、excluded 是打分没过，两者都不算「收录」——混进来会让人
     以为库里有这篇。个人库不能经这个接口泄漏给别人。
     """
+    from sqlalchemy import select as _select
+
     from app.models.library_direction import DirectionLibrary, LibraryPaper
     from app.models.paper import new_paper
     from app.models.user import User
-    from sqlalchemy import select as _select
 
     owner_token = await register_and_login(client, email="collect-owner@example.com")
     owner = {"Authorization": f"Bearer {owner_token}"}

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -503,10 +503,11 @@ async def test_delete_voyage_only_when_finished(client):
 
 async def test_delete_voyage_keeps_token_accounting(client):
     """删任务不该把它花过的 token 从账上抹掉——用量行只解引用，不删。"""
+    from sqlalchemy import select as _select
+
     from app.core.db import get_sessionmaker
     from app.models.llm_config import LLMUsage
     from app.models.voyage import VoyageRun
-    from sqlalchemy import select as _select
 
     token = await register_and_login(client, email="del2@example.com")
     headers = {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
#517 merged, rebased onto current `main`. Authorship preserved as @yyy-OPS.

Its branch is based on #504's head, which landed as #523, and #516 landed as #525 in between — so `runtime.py` and `api/literature_discovery.py` conflicted with the retrieval work.

## The resolution that mattered

My first pass took this PR's side for `runtime.py` and reds seven tests: that copy predates #525, so it silently dropped the progress reporting (`progress["deduplicated"]` and friends). Redone as `main`'s version with only this PR's own change applied on top, which turns out to be three lines:

```diff
-    values = configured.get(source) if isinstance(configured, Mapping) else None
+    declared = isinstance(configured, Mapping) and source in configured
+    values = configured.get(source) if declared else None
-    if pool:
+    if declared:
```

That distinction is the substance of *"prevent disabled credential pools from silently falling back to environment credentials"*. Judging only by whether the pool is empty makes "configured but emptied" indistinguishable from "never configured", so disabling a provider becomes a no-op — requests keep going out on the environment credentials, and the first thing that tells you is the bill or the rate limit, not an error.

For `api/literature_discovery.py` the three conflicting hunks were the reverse: this branch carries the pre-#525 state, so `main`'s side was kept.

## Added

A test pinning the four cases of `_credential_pool` — unconfigured falls back, `{}` falls back, `[]` and `["  "]` do not, populated wins. Reverting `if declared:` to `if pool:` reds it.

Also removed a duplicate `score_weights` dict key that the test-file union produced (`F601`); the surviving one is #525's five-dimension normalized form.

## Verification

- `alembic heads` → single head `f1a2b3c4d5e6` (no migration in this PR)
- `tests/test_admin_literature_settings.py test_literature_discovery_runtime.py test_literature_discovery_api.py test_migrations.py` → 31 passed
- `ruff check app/ worker/` and the touched test files → clean

Closes #518. Supersedes #517.