### PR TITLE
feat(literature): enrich candidates with versioned venue metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ POLARIS_SMTP_TIMEOUT=20
 # ---- Literature APIs ----
 # Semantic Scholar (optional; rate limits are tighter without a key)
 POLARIS_S2_API_KEY=
+# Venue metrics use OpenAlex anonymously by default. EasyScholar is optional;
+# prefer adding its SecretKey through the administrator credential pool.
+POLARIS_EASYSCHOLAR_BASE_URL=https://www.easyscholar.cc/open/getPublicationRank
+POLARIS_EASYSCHOLAR_SECRET_KEYS=
+POLARIS_VENUE_METRICS_CACHE_TTL_DAYS=30
+POLARIS_VENUE_METRICS_CONCURRENCY=4
 # Outbound proxy for literature APIs, when arXiv/S2/OpenAlex are unreliable
 # directly. LLM and intranet traffic does not go through it.
 # To reach a proxy on the host from inside docker, use host.docker.internal:

--- a/src/backend/alembic/versions/f2a3b4c5d6e7_literature_venue_metrics.py
+++ b/src/backend/alembic/versions/f2a3b4c5d6e7_literature_venue_metrics.py
@@ -1,0 +1,46 @@
+"""Persist versioned literature venue metric snapshots and cache entries."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: str = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.add_column("literature_search_hits", sa.Column("venue_metric_snapshot", _JSON))
+    op.create_table(
+        "literature_venue_metric_cache",
+        sa.Column("provider", sa.String(32), primary_key=True),
+        sa.Column("identity_key", sa.String(512), primary_key=True),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("venue_name", sa.String(512)),
+        sa.Column("issn_l", sa.String(16)),
+        sa.Column("metrics", _JSON),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_literature_venue_metric_cache_expires_at",
+        "literature_venue_metric_cache",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_literature_venue_metric_cache_expires_at",
+        table_name="literature_venue_metric_cache",
+    )
+    op.drop_table("literature_venue_metric_cache")
+    op.drop_column("literature_search_hits", "venue_metric_snapshot")

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -235,6 +235,25 @@ async def test_literature_provider(
     source = payload.source.strip().lower()
     started = time.perf_counter()
     try:
+        if source == "easyscholar":
+            from app.services.literature.venue_metrics import probe_venue_metric_provider
+
+            matched = await probe_venue_metric_provider(
+                await literature_settings_service.get_runtime_settings(session),
+                source=source,
+                venue_name=payload.query,
+            )
+            result = LiteratureProviderTestResult(
+                source=source,
+                ok=True,
+                latency_ms=round((time.perf_counter() - started) * 1000),
+                fetched_count=int(matched),
+                detail="metric provider responded",
+            )
+            await literature_settings_service.record_provider_health(
+                session, source=source, ok=result.ok, detail=result.detail
+            )
+            return result
         from app.services.literature.runtime import build_adapter_registry
 
         registry = await build_adapter_registry(
@@ -345,6 +364,25 @@ async def test_literature_provider_credential(
     source, secret = credential
     started = time.perf_counter()
     try:
+        if source == "easyscholar":
+            from app.services.literature.venue_metrics import probe_venue_metric_provider
+
+            runtime_settings = await literature_settings_service.get_runtime_settings(session)
+            runtime_settings["provider_keys"] = {source: [secret]}
+            matched = await probe_venue_metric_provider(
+                runtime_settings, source=source, venue_name=payload.query
+            )
+            result = LiteratureProviderTestResult(
+                source=source,
+                ok=True,
+                latency_ms=round((time.perf_counter() - started) * 1000),
+                fetched_count=int(matched),
+                detail="credential responded",
+            )
+            await literature_settings_service.record_credential_health(
+                session, credential_id, ok=result.ok, detail=result.detail
+            )
+            return result
         from app.schemas.literature_discovery import SourceSearchRequest
         from app.services.literature.runtime import build_adapter_registry
 

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -141,6 +141,18 @@ class Settings(BaseSettings):
             "POLARIS_LITERATURE_SOURCE_RETRIES", "PAPER_SEARCH_SOURCE_RETRIES"
         ),
     )
+    venue_metrics_cache_ttl_days: int = Field(default=30, ge=1, le=3650)
+    venue_metrics_concurrency: int = Field(default=4, ge=1, le=16)
+    easyscholar_base_url: str = Field(
+        default="https://www.easyscholar.cc/open/getPublicationRank",
+        validation_alias=AliasChoices("POLARIS_EASYSCHOLAR_BASE_URL", "EASYSCHOLAR_BASE_URL"),
+    )
+    easyscholar_secret_keys: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POLARIS_EASYSCHOLAR_SECRET_KEYS", "EASYSCHOLAR_SECRET_KEYS"
+        ),
+    )
     mineru_base_url: str = Field(
         default="https://mineru.net/api/v4",
         validation_alias=AliasChoices("POLARIS_MINERU_BASE_URL", "MINERU_BASE_URL"),

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -27,6 +27,7 @@ from app.models.literature_discovery import (
     LiteratureSearchHit,
     LiteratureSearchRun,
     LiteratureSourceAttempt,
+    LiteratureVenueMetricCache,
 )
 from app.models.llm_config import LLMCallLog, LLMProviderConfig, LLMUsage, ModelRoute
 from app.models.manuscript import (
@@ -108,6 +109,7 @@ __all__ = [
     "LiteratureSearchHit",
     "LiteratureSearchRun",
     "LiteratureSourceAttempt",
+    "LiteratureVenueMetricCache",
     "LLMProviderConfig",
     "LLMUsage",
     "Manuscript",

--- a/src/backend/app/models/literature_discovery.py
+++ b/src/backend/app/models/literature_discovery.py
@@ -85,6 +85,7 @@ class LiteratureSearchHit(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     oa_status: Mapped[str | None] = mapped_column(String(32))
     citation_count: Mapped[int | None]
     scores: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    venue_metric_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     promoted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
@@ -118,6 +119,23 @@ class LiteratureSourceAttempt(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     metadata_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class LiteratureVenueMetricCache(TimestampMixin, Base):
+    """Provider-scoped venue metrics cached independently from discovery hits."""
+
+    __tablename__ = "literature_venue_metric_cache"
+
+    provider: Mapped[str] = mapped_column(String(32), primary_key=True)
+    identity_key: Mapped[str] = mapped_column(String(512), primary_key=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    venue_name: Mapped[str | None] = mapped_column(String(512))
+    issn_l: Mapped[str | None] = mapped_column(String(16))
+    metrics: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+    fetched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
 
 
 class LiteratureOaCache(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -143,6 +143,7 @@ class SearchHitRead(BaseModel):
     oa_status: str | None
     citation_count: int | None
     scores: dict[str, Any] | None
+    venue_metric_snapshot: dict[str, Any] | None
     metadata_snapshot: dict[str, Any] | None
     promoted_at: datetime | None
     created_at: datetime

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -16,6 +16,7 @@ ARXIV_DOI_TEMPLATE = "10.48550/arXiv.{arxiv_id}"
 
 def _simplify(work: dict[str, Any]) -> dict[str, Any]:
     primary_location = work.get("primary_location") or {}
+    primary_source = primary_location.get("source") or {}
     inverted = work.get("abstract_inverted_index")
     abstract = None
     if isinstance(inverted, dict):
@@ -43,6 +44,11 @@ def _simplify(work: dict[str, Any]) -> dict[str, Any]:
         "venue": (work.get("primary_location") or {}).get("source", {}).get("display_name")
         if isinstance((work.get("primary_location") or {}).get("source"), dict)
         else None,
+        "openalex_source_id": primary_source.get("id")
+        if isinstance(primary_source, dict)
+        else None,
+        "issn_l": primary_source.get("issn_l") if isinstance(primary_source, dict) else None,
+        "issns": primary_source.get("issn") if isinstance(primary_source, dict) else [],
         "cited_by_count": work.get("cited_by_count", 0),
         # 作者 + 每位作者的机构（OpenAlex 结构化给出 authorships[].institutions）
         "authors": [

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -338,6 +338,7 @@ async def run_discovery(
     *,
     registry: AdapterRegistry | None = None,
     llm_router: Any | None = None,
+    venue_metric_service: Any | None = None,
     now: datetime | None = None,
 ) -> LiteratureSearchRun:
     """Execute one persisted run and return its final state."""
@@ -353,10 +354,11 @@ async def run_discovery(
     if run.status != "queued":
         return run
 
-    if registry is None:
-        registry = await build_adapter_registry(
-            await literature_settings.get_runtime_settings(session)
-        )
+    owns_registry = registry is None
+    runtime_settings: Mapping[str, Any] | None = None
+    if owns_registry:
+        runtime_settings = await literature_settings.get_runtime_settings(session)
+        registry = await build_adapter_registry(runtime_settings)
     started = now or datetime.now(UTC)
     run.status = "running"
     run.started_at = run.started_at or started
@@ -644,6 +646,19 @@ async def run_discovery(
         "\n".join(part for part in (title, abstract) if part) for title, abstract in reference_rows
     ]
     fused = fuse_candidates(candidates, executed_query_count=len(runnable))
+    owns_metric_service = venue_metric_service is None and owns_registry
+    if owns_metric_service:
+        from app.services.literature.venue_metrics import build_venue_metric_service
+
+        venue_metric_service = build_venue_metric_service(runtime_settings or {})
+    if venue_metric_service is not None:
+        try:
+            fused = await venue_metric_service.enrich_candidates(session, fused)
+        except Exception:  # metrics must never make discovery candidates unusable
+            logger.warning("venue metric enrichment failed", exc_info=True)
+        finally:
+            if owns_metric_service and hasattr(venue_metric_service, "aclose"):
+                await venue_metric_service.aclose()
     run.progress = {
         **(run.progress or {}),
         "phase": "ranking",
@@ -735,6 +750,7 @@ async def run_discovery(
                     ),
                     "pdf_cached": False,
                 },
+                venue_metric_snapshot=raw_candidate.get("venue_metric_snapshot"),
                 metadata_snapshot={
                     **(candidate.metadata or {}),
                     "sources": list(raw_candidate.get("sources") or [candidate.source]),

--- a/src/backend/app/services/literature/venue_metrics.py
+++ b/src/backend/app/services/literature/venue_metrics.py
@@ -1,0 +1,561 @@
+"""Versioned journal and conference metrics for literature discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.base import utcnow
+from app.models.literature_discovery import LiteratureVenueMetricCache
+
+METRIC_SNAPSHOT_VERSION = "venue-metrics-v1"
+_ISSN_RE = re.compile(r"\b\d{4}-[\dXx]{4}\b")
+_UNKNOWN_VENUES = {
+    "unknown",
+    "unknown journal",
+    "unknown conference",
+    "unknown venue",
+    "n/a",
+    "na",
+    "none",
+    "未知",
+    "未知期刊",
+    "未知会议",
+}
+
+
+class VenueMetricProviderError(RuntimeError):
+    """A stable provider error that never contains a request URL or credential."""
+
+    def __init__(self, provider: str, code: str) -> None:
+        super().__init__(f"{provider} venue metric lookup failed ({code})")
+        self.provider = provider
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class VenueIdentity:
+    key: str
+    name: str
+    issn_l: str | None
+    issns: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class VenueMetricResult:
+    provider: str
+    venue_name: str | None
+    issn_l: str | None
+    metrics: dict[str, Any]
+
+
+class VenueMetricProvider(Protocol):
+    name: str
+
+    async def lookup(self, identity: VenueIdentity) -> VenueMetricResult | None: ...
+
+
+def normalize_venue(value: Any) -> str | None:
+    text = " ".join(str(value or "").split()).strip(" .")
+    return None if not text or text.casefold() in _UNKNOWN_VENUES else text[:512]
+
+
+def _canonical_name(value: Any) -> str:
+    return re.sub(r"[^a-z0-9\u3400-\u9fff]+", "", str(value or "").casefold())
+
+
+def _issns(value: Any) -> list[str]:
+    output: list[str] = []
+
+    def collect(item: Any) -> None:
+        if isinstance(item, Mapping):
+            for nested in item.values():
+                collect(nested)
+            return
+        if isinstance(item, (list, tuple, set)):
+            for nested in item:
+                collect(nested)
+            return
+        for match in _ISSN_RE.finditer(str(item or "")):
+            normalized = match.group(0).upper()
+            if normalized not in output:
+                output.append(normalized)
+
+    collect(value)
+    return output
+
+
+def venue_identity(candidate: Mapping[str, Any]) -> VenueIdentity | None:
+    venue = normalize_venue(candidate.get("venue"))
+    metadata = candidate.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    issn_l = next(
+        iter(
+            _issns(
+                metadata.get("issn_l") or metadata.get("issnL")
+            )
+        ),
+        None,
+    )
+    issns = _issns(
+        [
+            issn_l,
+            *(
+                metadata.get("issns")
+                if isinstance(metadata.get("issns"), list)
+                else [
+                    metadata.get("issn"),
+                    metadata.get("ISSN"),
+                    metadata.get("issn-type"),
+                ]
+            ),
+        ]
+    )
+    if not venue and not issns:
+        return None
+    key = f"issn:{issn_l or issns[0]}" if issns else f"name:{_canonical_name(venue)}"
+    return VenueIdentity(key=key, name=venue or issns[0], issn_l=issn_l, issns=tuple(issns))
+
+
+def _provider_error_code(error: Exception) -> str:
+    if isinstance(error, VenueMetricProviderError):
+        return error.code
+    if isinstance(error, httpx.HTTPStatusError):
+        return f"HTTP_{error.response.status_code}"
+    if isinstance(error, httpx.TimeoutException):
+        return "TIMEOUT"
+    if isinstance(error, httpx.RequestError):
+        return "NETWORK_ERROR"
+    if isinstance(error, ValueError):
+        return "INVALID_RESPONSE"
+    return type(error).__name__.upper()
+
+
+class _KeyRotator:
+    def __init__(self, keys: Sequence[str]) -> None:
+        self._keys = tuple(dict.fromkeys(key.strip() for key in keys if key.strip()))
+        self._index = 0
+        self._lock = asyncio.Lock()
+
+    async def next(self) -> str | None:
+        if not self._keys:
+            return None
+        async with self._lock:
+            key = self._keys[self._index % len(self._keys)]
+            self._index += 1
+            return key
+
+
+class OpenAlexVenueMetricProvider:
+    name = "openalex"
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        keys: Sequence[str] = (),
+        mailto: str = "",
+    ) -> None:
+        self._client = client
+        self._keys = _KeyRotator(keys)
+        self._mailto = mailto.strip()
+
+    async def _get(self, url: str, *, params: dict[str, Any] | None = None) -> Any:
+        query = dict(params or {})
+        if self._mailto:
+            query["mailto"] = self._mailto
+        if key := await self._keys.next():
+            query["api_key"] = key
+        try:
+            response = await self._client.get(url, params=query)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            raise VenueMetricProviderError(self.name, _provider_error_code(exc)) from exc
+
+    @staticmethod
+    def _result(source: Mapping[str, Any]) -> VenueMetricResult | None:
+        source_type = str(source.get("type") or "").casefold()
+        if source_type and source_type not in {"journal", "conference", "proceedings"}:
+            return None
+        stats = source.get("summary_stats")
+        stats = stats if isinstance(stats, Mapping) else {}
+        metrics = {
+            "two_year_mean_citedness": _number(stats.get("2yr_mean_citedness")),
+            "h_index": _integer(stats.get("h_index")),
+            "i10_index": _integer(stats.get("i10_index")),
+            "works_count": _integer(source.get("works_count")),
+            "cited_by_count": _integer(source.get("cited_by_count")),
+            "is_oa": bool(source.get("is_oa")),
+            "is_in_doaj": bool(source.get("is_in_doaj")),
+            "openalex_source_id": source.get("id"),
+        }
+        metrics = {key: value for key, value in metrics.items() if value is not None}
+        return VenueMetricResult(
+            provider="openalex",
+            venue_name=normalize_venue(source.get("display_name")),
+            issn_l=next(iter(_issns(source.get("issn_l"))), None),
+            metrics=metrics,
+        )
+
+    async def lookup(self, identity: VenueIdentity) -> VenueMetricResult | None:
+        for issn in identity.issns:
+            source = await self._get(f"https://api.openalex.org/sources/issn:{issn}")
+            if isinstance(source, Mapping) and (result := self._result(source)):
+                return result
+        payload = await self._get(
+            "https://api.openalex.org/sources",
+            params={"search": identity.name, "filter": "type:journal", "per_page": 5},
+        )
+        expected = _canonical_name(identity.name)
+        for source in payload.get("results") or [] if isinstance(payload, Mapping) else []:
+            if not isinstance(source, Mapping):
+                continue
+            aliases = [source.get("display_name"), *(source.get("alternate_titles") or [])]
+            if expected and expected in {_canonical_name(alias) for alias in aliases}:
+                return self._result(source)
+        return None
+
+
+class EasyScholarVenueMetricProvider:
+    name = "easyscholar"
+
+    def __init__(self, client: httpx.AsyncClient, *, keys: Sequence[str], base_url: str) -> None:
+        self._client = client
+        self._keys = _KeyRotator(keys)
+        self._base_url = base_url
+
+    async def lookup(self, identity: VenueIdentity) -> VenueMetricResult | None:
+        key = await self._keys.next()
+        if not key:
+            return None
+        try:
+            response = await self._client.get(
+                self._base_url,
+                params={"secretKey": key, "publicationName": identity.name},
+                follow_redirects=False,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
+            raise VenueMetricProviderError(self.name, _provider_error_code(exc)) from exc
+        if not isinstance(payload, Mapping):
+            raise VenueMetricProviderError(self.name, "INVALID_RESPONSE")
+        code = _integer(payload.get("code"))
+        if code != 200:
+            raise VenueMetricProviderError(self.name, f"API_{code or 'ERROR'}")
+        data = payload.get("data")
+        data = data if isinstance(data, Mapping) else {}
+        official_group = data.get("officialRank")
+        official_group = official_group if isinstance(official_group, Mapping) else {}
+        official = official_group.get("all")
+        official = official if isinstance(official, Mapping) else {}
+        metrics = {
+            "impact_factor": _number(official.get("sciif")),
+            "five_year_impact_factor": _number(official.get("sciif5")),
+            "jcr_quartile": _quartile(official.get("sci") or official.get("ssci")),
+            "jci": _number(official.get("jci")),
+            "cas_base_zone": _zone(official.get("sciBase")),
+            "cas_upgraded_zone": _zone(official.get("sciUp")),
+        }
+        metrics = {name: value for name, value in metrics.items() if value is not None}
+        if not metrics:
+            return None
+        return VenueMetricResult(
+            provider="easyscholar",
+            venue_name=identity.name,
+            issn_l=identity.issn_l,
+            metrics=metrics,
+        )
+
+
+def _number(value: Any) -> float | None:
+    try:
+        match = re.search(r"-?\d+(?:\.\d+)?", str(value or ""))
+        return float(match.group(0)) if match else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _integer(value: Any) -> int | None:
+    number = _number(value)
+    return int(number) if number is not None else None
+
+
+def _quartile(value: Any) -> str | None:
+    match = re.search(r"(?<![A-Z0-9])Q\s*([1-4])(?!\d)", str(value or ""), re.I)
+    return f"Q{match.group(1)}" if match else None
+
+
+def _zone(value: Any) -> int | None:
+    match = re.search(r"(?<!\d)([1-4])\s*(?:区|zone)?(?!\d)", str(value or ""), re.I)
+    return int(match.group(1)) if match else None
+
+
+def metric_impact_score(metrics: Mapping[str, Any]) -> float | None:
+    values: list[float] = []
+    if (impact_factor := _number(metrics.get("impact_factor"))) is not None:
+        values.append(1 - math.exp(-max(0.0, impact_factor) / 8))
+    if (citedness := _number(metrics.get("two_year_mean_citedness"))) is not None:
+        values.append(1 - math.exp(-max(0.0, citedness) / 8))
+    if (h_index := _number(metrics.get("h_index"))) is not None:
+        values.append(min(1.0, math.log1p(max(0.0, h_index)) / math.log(201)))
+    quartile = str(metrics.get("jcr_quartile") or "").upper()
+    if quartile in {"Q1", "Q2", "Q3", "Q4"}:
+        values.append({"Q1": 1.0, "Q2": 0.75, "Q3": 0.5, "Q4": 0.25}[quartile])
+    return round(sum(values) / len(values), 6) if values else None
+
+
+class VenueMetricService:
+    def __init__(
+        self,
+        providers: Sequence[VenueMetricProvider],
+        *,
+        ttl_days: int = 30,
+        concurrency: int = 4,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.providers = tuple(providers)
+        self.ttl = timedelta(days=max(1, ttl_days))
+        self.concurrency = max(1, concurrency)
+        self._client = client
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def enrich_candidates(
+        self, session: AsyncSession, candidates: Sequence[Mapping[str, Any]]
+    ) -> list[dict[str, Any]]:
+        output = [dict(candidate) for candidate in candidates]
+        identities: dict[str, VenueIdentity] = {}
+        for candidate in output:
+            candidate["venue"] = normalize_venue(candidate.get("venue"))
+            if identity := venue_identity(candidate):
+                identities.setdefault(identity.key, identity)
+        if not identities or not self.providers:
+            return output
+
+        now = datetime.now(UTC)
+        cache_rows = list(
+            (
+                await session.execute(
+                    select(LiteratureVenueMetricCache).where(
+                        LiteratureVenueMetricCache.provider.in_(
+                            [provider.name for provider in self.providers]
+                        ),
+                        LiteratureVenueMetricCache.identity_key.in_(identities),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        cached = {
+            (row.provider, row.identity_key): row
+            for row in cache_rows
+            if _aware(row.expires_at) > now
+        }
+        semaphore = asyncio.Semaphore(self.concurrency)
+
+        async def resolve(provider: VenueMetricProvider, identity: VenueIdentity):
+            row = cached.get((provider.name, identity.key))
+            if row is not None:
+                result = (
+                    VenueMetricResult(provider.name, row.venue_name, row.issn_l, dict(row.metrics))
+                    if row.status == "resolved" and isinstance(row.metrics, Mapping)
+                    else None
+                )
+                return provider.name, identity, result, None, _aware(row.fetched_at), _aware(
+                    row.expires_at
+                )
+            async with semaphore:
+                try:
+                    result = await provider.lookup(identity)
+                    return provider.name, identity, result, None, now, now + self.ttl
+                except Exception as exc:  # provider isolation is intentional
+                    return provider.name, identity, None, _provider_error_code(exc), now, now
+
+        resolutions = await asyncio.gather(
+            *(
+                resolve(provider, identity)
+                for identity in identities.values()
+                for provider in self.providers
+            )
+        )
+        by_identity: dict[str, list[tuple[Any, ...]]] = {}
+        for row in resolutions:
+            by_identity.setdefault(row[1].key, []).append(row)
+            provider, identity, result, error, fetched_at, expires_at = row
+            if error is None and (provider, identity.key) not in cached:
+                await _upsert_cache(
+                    session,
+                    provider=provider,
+                    identity=identity,
+                    result=result,
+                    fetched_at=fetched_at,
+                    expires_at=expires_at,
+                )
+        await session.flush()
+
+        for candidate in output:
+            identity = venue_identity(candidate)
+            if identity is None:
+                continue
+            metrics: dict[str, Any] = {}
+            providers: list[dict[str, Any]] = []
+            errors: dict[str, str] = {}
+            venue_name = candidate.get("venue")
+            issn_l = identity.issn_l
+            for provider, _, result, error, fetched_at, expires_at in by_identity[identity.key]:
+                if error:
+                    errors[provider] = error
+                    continue
+                providers.append(
+                    {
+                        "provider": provider,
+                        "status": "resolved" if result else "not_found",
+                        "fetched_at": fetched_at.isoformat(),
+                        "expires_at": expires_at.isoformat(),
+                    }
+                )
+                if result:
+                    metrics.update(result.metrics)
+                    venue_name = result.venue_name or venue_name
+                    issn_l = result.issn_l or issn_l
+            impact_score = metric_impact_score(metrics)
+            snapshot = {
+                "version": METRIC_SNAPSHOT_VERSION,
+                "identity": identity.key,
+                "venue_name": venue_name,
+                "issn_l": issn_l,
+                "providers": providers,
+                "metrics": metrics or None,
+                "provider_errors": errors or None,
+                "impact_score": impact_score,
+            }
+            candidate["venue_metric_snapshot"] = snapshot
+            if impact_score is not None:
+                candidate["impact_score"] = impact_score
+        return output
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def _upsert_cache(
+    session: AsyncSession,
+    *,
+    provider: str,
+    identity: VenueIdentity,
+    result: VenueMetricResult | None,
+    fetched_at: datetime,
+    expires_at: datetime,
+) -> None:
+    values = {
+        "provider": provider,
+        "identity_key": identity.key,
+        "status": "resolved" if result else "not_found",
+        "venue_name": result.venue_name if result else identity.name,
+        "issn_l": result.issn_l if result else identity.issn_l,
+        "metrics": result.metrics if result else None,
+        "fetched_at": fetched_at,
+        "expires_at": expires_at,
+        "created_at": utcnow(),
+        "updated_at": utcnow(),
+    }
+    table = LiteratureVenueMetricCache.__table__
+    immutable = {"provider", "identity_key", "created_at"}
+    update_values = {key: value for key, value in values.items() if key not in immutable}
+    dialect = session.get_bind().dialect.name
+    if dialect == "postgresql":
+        statement = postgresql_insert(table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[table.c.provider, table.c.identity_key], set_=update_values
+        )
+    elif dialect == "sqlite":
+        statement = sqlite_insert(table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[table.c.provider, table.c.identity_key], set_=update_values
+        )
+    else:
+        existing = await session.get(LiteratureVenueMetricCache, (provider, identity.key))
+        if existing is None:
+            session.add(LiteratureVenueMetricCache(**values))
+        else:
+            for key, value in update_values.items():
+                setattr(existing, key, value)
+        return
+    await session.execute(statement)
+
+
+def _pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
+    pools = settings.get("provider_keys")
+    declared = isinstance(pools, Mapping) and source in pools
+    values = pools.get(source) if declared else None
+    if declared:
+        return [str(value).strip() for value in values or [] if str(value).strip()]
+    return [value.strip() for value in re.split(r"[,;\r\n]+", fallback) if value.strip()]
+
+
+def build_venue_metric_service(runtime_settings: Mapping[str, Any]) -> VenueMetricService:
+    settings = get_settings()
+    client = httpx.AsyncClient(
+        proxy=settings.outbound_proxy or None,
+        timeout=settings.literature_source_timeout_seconds,
+    )
+    providers: list[VenueMetricProvider] = [
+        OpenAlexVenueMetricProvider(
+            client,
+            keys=_pool(runtime_settings, "openalex"),
+            mailto=settings.openalex_mailto,
+        )
+    ]
+    easyscholar_keys = _pool(
+        runtime_settings, "easyscholar", settings.easyscholar_secret_keys
+    )
+    if easyscholar_keys:
+        providers.append(
+            EasyScholarVenueMetricProvider(
+                client,
+                keys=easyscholar_keys,
+                base_url=settings.easyscholar_base_url,
+            )
+        )
+    return VenueMetricService(
+        providers,
+        ttl_days=settings.venue_metrics_cache_ttl_days,
+        concurrency=settings.venue_metrics_concurrency,
+        client=client,
+    )
+
+
+async def probe_venue_metric_provider(
+    runtime_settings: Mapping[str, Any], *, source: str, venue_name: str
+) -> bool:
+    """Probe one configured metric provider without exposing its credential."""
+
+    service = build_venue_metric_service(runtime_settings)
+    identity = venue_identity({"venue": venue_name})
+    provider = next((item for item in service.providers if item.name == source), None)
+    try:
+        if provider is None or identity is None:
+            raise VenueMetricProviderError(source, "NOT_CONFIGURED")
+        return await provider.lookup(identity) is not None
+    finally:
+        await service.aclose()

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -34,6 +34,7 @@ SUPPORTED_SOURCES = (
     "base",
     "sciverse",
 )
+CREDENTIAL_SOURCES = (*SUPPORTED_SOURCES, "easyscholar")
 DEFAULT_SCORE_WEIGHTS = {
     "relevance": 0.45,
     "evidence_quality": 0.20,
@@ -254,7 +255,7 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
         encrypted: dict[str, list[str]] = {}
         for source, values in raw_pools.items():
             source_name = str(source).strip().lower()
-            if source_name not in SUPPORTED_SOURCES:
+            if source_name not in CREDENTIAL_SOURCES:
                 raise InvalidLiteratureSettingError(
                     "provider_keys", f"unsupported source: {source_name}"
                 )
@@ -290,7 +291,7 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
 
 def _validate_credential_source(source: str) -> str:
     source = source.strip().lower()
-    if source not in SUPPORTED_SOURCES:
+    if source not in CREDENTIAL_SOURCES:
         raise InvalidLiteratureSettingError("source", f"unsupported source: {source}")
     if source == "arxiv":
         raise InvalidLiteratureSettingError("source", "arxiv does not require credentials")

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -184,6 +184,40 @@ async def test_arxiv_rejects_credentials_because_public_api_needs_no_key(client)
     assert "INVALID_LITERATURE_CREDENTIAL:source" in response.text
 
 
+async def test_easyscholar_credential_uses_metric_probe(client, monkeypatch):
+    admin, _ = await _admin_and_member(client)
+    response = await client.post(
+        "/api/admin/settings/literature-search/credentials",
+        json={"source": "easyscholar", "secret": "easyscholar-secret"},
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    credential_id = response.json()["id"]
+    observed = {}
+
+    async def fake_probe(settings, *, source, venue_name):
+        observed.update(settings=settings, source=source, venue_name=venue_name)
+        return True
+
+    monkeypatch.setattr(
+        "app.services.literature.venue_metrics.probe_venue_metric_provider", fake_probe
+    )
+    response = await client.post(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}/test",
+        json={"query": "Journal of Tests"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert response.json()["fetched_count"] == 1
+    assert observed["source"] == "easyscholar"
+    assert observed["venue_name"] == "Journal of Tests"
+    assert observed["settings"]["provider_keys"] == {
+        "easyscholar": ["easyscholar-secret"]
+    }
+
+
 async def test_single_credential_probe_updates_only_that_entry(client, monkeypatch):
     admin, _ = await _admin_and_member(client)
     response = await client.post(

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -307,6 +307,51 @@ async def test_runtime_attempts_oa_resolution_for_doi_only_candidates(client, mo
 
 
 @pytest.mark.asyncio
+async def test_runtime_persists_versioned_metric_snapshot_and_uses_impact(client, monkeypatch):
+    run_id, _, _ = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=1,
+        candidate_budget=1,
+    )
+    candidate = _candidate("openalex", "Metric candidate")
+    candidate.venue = "Journal of Tests"
+    candidate.citation_count = 0
+
+    class MetricService:
+        async def enrich_candidates(self, session, candidates):
+            del session
+            enriched = [dict(item) for item in candidates]
+            enriched[0]["impact_score"] = 1.0
+            enriched[0]["venue_metric_snapshot"] = {
+                "version": "venue-metrics-v1",
+                "identity": "name:journaloftests",
+                "metrics": {"impact_factor": 10.0},
+            }
+            return enriched
+
+    async def no_oa_cache(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(oa_cache, "cache_hit_pdf", no_oa_cache)
+    async with get_sessionmaker()() as session:
+        run = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((FakeAdapter("openalex", [candidate]),)),
+            llm_router=RetrievalRouter(),
+            venue_metric_service=MetricService(),
+        )
+        hit = await session.scalar(
+            select(LiteratureSearchHit).where(LiteratureSearchHit.run_id == run.id)
+        )
+
+    assert hit is not None
+    assert hit.venue_metric_snapshot["version"] == "venue-metrics-v1"
+    assert hit.scores["impact"] == 1.0
+
+
+@pytest.mark.asyncio
 async def test_runtime_persists_progress_as_each_provider_query_completes(client):
     run_id, _, _ = await _create_run(
         client,

--- a/src/backend/tests/test_literature_venue_metrics.py
+++ b/src/backend/tests/test_literature_venue_metrics.py
@@ -1,0 +1,179 @@
+"""Issue #510: provider-isolated, versioned venue metric enrichment."""
+
+import httpx
+import pytest
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.literature_discovery import LiteratureVenueMetricCache
+from app.services.literature.venue_metrics import (
+    EasyScholarVenueMetricProvider,
+    OpenAlexVenueMetricProvider,
+    VenueIdentity,
+    VenueMetricProviderError,
+    VenueMetricResult,
+    VenueMetricService,
+    metric_impact_score,
+    normalize_venue,
+    venue_identity,
+)
+
+
+class FakeProvider:
+    name = "fake"
+
+    def __init__(self, result=None, error: Exception | None = None):
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    async def lookup(self, identity):
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return self.result
+
+
+def test_venue_identity_rejects_placeholders_and_prefers_issn():
+    assert normalize_venue(" Unknown journal ") is None
+    assert venue_identity({"venue": "Unknown journal"}) is None
+
+    identity = venue_identity(
+        {"venue": "Journal of Tests", "metadata": {"issn_l": "1234-567X"}}
+    )
+    assert identity == VenueIdentity(
+        key="issn:1234-567X",
+        name="Journal of Tests",
+        issn_l="1234-567X",
+        issns=("1234-567X",),
+    )
+
+    crossref = venue_identity(
+        {
+            "venue": "Journal of Tests",
+            "metadata": {
+                "ISSN": ["9876-5432"],
+                "issn-type": [{"value": "1234-567X", "type": "electronic"}],
+            },
+        }
+    )
+    assert crossref is not None
+    assert crossref.issns == ("9876-5432", "1234-567X")
+
+
+@pytest.mark.asyncio
+async def test_metric_service_caches_resolved_snapshot_without_mutating_metadata(client):
+    provider = FakeProvider(
+        VenueMetricResult(
+            provider="fake",
+            venue_name="Journal of Tests",
+            issn_l="1234-567X",
+            metrics={"impact_factor": 8.0, "jcr_quartile": "Q1"},
+        )
+    )
+    service = VenueMetricService([provider], ttl_days=30)
+    candidate = {
+        "title": "A paper",
+        "venue": "Journal of Tests",
+        "metadata": {"source_field": "unchanged"},
+    }
+    async with get_sessionmaker()() as session:
+        first = await service.enrich_candidates(session, [candidate])
+        await session.commit()
+        second = await service.enrich_candidates(session, [candidate])
+        cache_count = await session.scalar(
+            select(func.count()).select_from(LiteratureVenueMetricCache)
+        )
+
+    assert provider.calls == 1
+    assert cache_count == 1
+    assert first[0]["metadata"] == {"source_field": "unchanged"}
+    assert first[0]["venue_metric_snapshot"]["version"] == "venue-metrics-v1"
+    assert first[0]["venue_metric_snapshot"]["metrics"]["impact_factor"] == 8.0
+    assert first[0]["impact_score"] == second[0]["impact_score"]
+
+
+@pytest.mark.asyncio
+async def test_metric_provider_failure_is_visible_but_candidate_remains_usable(client):
+    provider = FakeProvider(error=VenueMetricProviderError("fake", "TIMEOUT"))
+    service = VenueMetricService([provider])
+    async with get_sessionmaker()() as session:
+        result = await service.enrich_candidates(
+            session, [{"title": "Candidate", "venue": "Journal of Tests"}]
+        )
+
+    assert result[0]["title"] == "Candidate"
+    assert result[0]["venue_metric_snapshot"]["metrics"] is None
+    assert result[0]["venue_metric_snapshot"]["provider_errors"] == {"fake": "TIMEOUT"}
+    assert "impact_score" not in result[0]
+
+
+def test_verified_metrics_map_only_to_bounded_impact_score():
+    score = metric_impact_score(
+        {"impact_factor": 12.5, "h_index": 150, "jcr_quartile": "Q1"}
+    )
+    assert score is not None and 0 < score <= 1
+    assert metric_impact_score({"provider_error": "TIMEOUT"}) is None
+
+
+@pytest.mark.asyncio
+async def test_openalex_provider_requires_exact_title_match():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "results": [
+                    {
+                        "id": "https://openalex.org/S1",
+                        "type": "journal",
+                        "display_name": "Journal of Tests",
+                        "summary_stats": {"2yr_mean_citedness": 3.5, "h_index": 42},
+                    }
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAlexVenueMetricProvider(client)
+        result = await provider.lookup(
+            VenueIdentity("name:journaloftests", "Journal of Tests", None, ())
+        )
+
+    assert result is not None
+    assert result.metrics["two_year_mean_citedness"] == 3.5
+    assert result.metrics["h_index"] == 42
+
+
+@pytest.mark.asyncio
+async def test_easyscholar_provider_maps_rank_fields_without_storing_secret():
+    observed_url = ""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal observed_url
+        observed_url = str(request.url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "code": 200,
+                "data": {
+                    "officialRank": {
+                        "all": {"sciif": "6.2", "sci": "Q1", "sciBase": "2区"}
+                    }
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = EasyScholarVenueMetricProvider(
+            client, keys=["SECRET_SENTINEL"], base_url="https://metrics.example.test/rank"
+        )
+        result = await provider.lookup(
+            VenueIdentity("name:journaloftests", "Journal of Tests", None, ())
+        )
+
+    assert "SECRET_SENTINEL" in observed_url
+    assert result is not None
+    assert result.metrics == {"impact_factor": 6.2, "jcr_quartile": "Q1", "cas_base_zone": 2}
+    assert "SECRET_SENTINEL" not in repr(result)

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -10,6 +10,8 @@ from alembic import command
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
 HEAD_REVISION = "f1a2b3c4d5e6"  # Immutable interdisciplinary scope versions
+HEAD_REVISION = "f2a3b4c5d6e7"  # Versioned literature venue metrics
+SCOPE_VERSION_REVISION = "f1a2b3c4d5e6"  # Immutable interdisciplinary scope versions
 QUERY_MATRIX_REVISION = "f0a1b2c3d4e5"  # Interdisciplinary query matrix and evidence balance
 INTERDISCIPLINARY_REVISION = "e9f0a1b2c3d4"  # Interdisciplinary research profiles
 OA_CACHE_REVISION = "d1e2f3a4b5c6"  # Persistent OA cache and promotion audit
@@ -121,6 +123,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "literature_search_runs",
                     "literature_search_hits",
                     "literature_source_attempts",
+                    "literature_venue_metric_cache",
                     "pdf_blobs",
                     "paper_assets",
                     "asset_grants",
@@ -163,6 +166,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"blocks", "text", "seq", "status", "sources"} <= columns["conversation_messages"]
     # 这场对话花了多少 token（voyage_id 的对偶）
     assert "conversation_id" in columns["llm_usage"]
+    assert "venue_metric_snapshot" in columns["literature_search_hits"]
+    assert {"provider", "identity_key", "metrics", "expires_at"} <= columns[
+        "literature_venue_metric_cache"
+    ]
     # 压缩阈值要知道模型的窗口有多大，此前 router 只能拍脑袋
     assert "context_window" in columns["model_routes"]
     # 向量搬进三张侧表，主表上的向量列与元信息列一并删除
@@ -490,6 +497,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["interdisciplinary_research_profile_versions"]
 
     # First remove immutable scope versions and return to the query-matrix head.
+    # First remove venue metrics and return to immutable scope versions.
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SCOPE_VERSION_REVISION
+    assert "literature_venue_metric_cache" not in columns["_tables"]
+    assert "venue_metric_snapshot" not in columns["literature_search_hits"]
+
+    # Then remove immutable scope versions and return to the query-matrix head.
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == QUERY_MATRIX_REVISION


### PR DESCRIPTION
#519 merged, rebased onto current `main`. Authorship preserved as @yyy-OPS.

Migration `f2a3b4c5d6e7` chains correctly from `f1a2b3c4d5e6`; the duplicate `f1a2b3c4d5e6` it carries is byte-identical to the merged one, so nothing to reconcile there. That is a real improvement over the previous series.

## Two things this branch would have silently reverted

It is based on `main` as of yesterday, so it predates #524 and #526.

**`api/interdisciplinary.py`** — its copy restores `project.id` in the `IntegrityError` recovery path, undoing the `MissingGreenlet` fix from #524, and removes the extracted `_existing_dedicated_library` helper that makes the race testable at all. `main`'s version kept. I re-checked afterwards: reverting the fix by hand still reds `test_concurrent_confirmation_recovers_instead_of_500`, so the guard survived the merge intact.

**`tests/test_literature_discovery_runtime.py`** — its copy drops both credential guards (`test_provider_keys_never_reach_the_run_snapshot` from #523, `test_disabled_credential_pool_does_not_fall_back_to_env` from #526). Union-resolved; both are present and both still bite.

This is the recurring shape on this series: a branch cut before a fix lands carries the pre-fix file, and merging it un-fixes things with nothing failing. Rebasing before pushing is what stops it.

## `runtime.py`

Resolved hunk by hunk rather than by side — this PR's venue-metric wiring taken, `#526`'s `_credential_pool` "declared vs empty" distinction kept.

## Verification

- `alembic heads` → single head `f2a3b4c5d6e7`
- `tests/test_literature_discovery_runtime.py test_admin_literature_settings.py test_interdisciplinary.py test_migrations.py` → 33 passed
- `ruff check app/ worker/` → clean

Closes #513. Supersedes #519.