### PR TITLE
feat(literature): schedule incremental library discovery runs

### DIFF
--- a/src/backend/alembic/versions/f3a4b5c6d7e8_literature_discovery_schedules.py
+++ b/src/backend/alembic/versions/f3a4b5c6d7e8_literature_discovery_schedules.py
@@ -1,0 +1,104 @@
+"""Schedule versioned incremental literature discovery runs."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f3a4b5c6d7e8"
+down_revision: str = "f2a3b4c5d6e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "literature_search_runs",
+        sa.Column("trigger", sa.String(16), nullable=False, server_default="manual"),
+    )
+    op.add_column("literature_search_runs", sa.Column("schedule_version", sa.Integer()))
+    op.add_column(
+        "literature_search_runs", sa.Column("scheduled_for", sa.DateTime(timezone=True))
+    )
+    op.create_index(
+        "uq_literature_search_runs_active_schedule",
+        "literature_search_runs",
+        ["library_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "trigger = 'scheduled' AND status IN ('queued', 'running')"
+        ),
+        sqlite_where=sa.text("trigger = 'scheduled' AND status IN ('queued', 'running')"),
+    )
+    op.create_table(
+        "literature_discovery_schedules",
+        sa.Column(
+            "library_id",
+            sa.Uuid(),
+            sa.ForeignKey("direction_libraries.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("timezone", sa.String(64), nullable=False),
+        sa.Column("hour", sa.Integer(), nullable=False),
+        sa.Column("minute", sa.Integer(), nullable=False),
+        sa.Column("requested_count", sa.Integer(), nullable=False),
+        sa.Column("candidate_budget", sa.Integer(), nullable=False),
+        sa.Column("start_year", sa.Integer()),
+        sa.Column("end_year", sa.Integer()),
+        sa.Column("config_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_by",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+        ),
+        sa.Column("next_run_at", sa.DateTime(timezone=True)),
+        sa.Column(
+            "last_run_id",
+            sa.Uuid(),
+            sa.ForeignKey("literature_search_runs.id", ondelete="SET NULL"),
+        ),
+        sa.Column("last_enqueued_at", sa.DateTime(timezone=True)),
+        sa.Column("last_error_code", sa.String(64)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_literature_discovery_schedules_created_by",
+        "literature_discovery_schedules",
+        ["created_by"],
+    )
+    op.create_index(
+        "ix_literature_discovery_schedules_last_run_id",
+        "literature_discovery_schedules",
+        ["last_run_id"],
+    )
+    op.create_index(
+        "ix_literature_discovery_schedules_due",
+        "literature_discovery_schedules",
+        ["enabled", "next_run_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_literature_discovery_schedules_due",
+        table_name="literature_discovery_schedules",
+    )
+    op.drop_index(
+        "ix_literature_discovery_schedules_last_run_id",
+        table_name="literature_discovery_schedules",
+    )
+    op.drop_index(
+        "ix_literature_discovery_schedules_created_by",
+        table_name="literature_discovery_schedules",
+    )
+    op.drop_table("literature_discovery_schedules")
+    op.drop_index(
+        "uq_literature_search_runs_active_schedule",
+        table_name="literature_search_runs",
+    )
+    op.drop_column("literature_search_runs", "scheduled_for")
+    op.drop_column("literature_search_runs", "schedule_version")
+    op.drop_column("literature_search_runs", "trigger")

--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -22,6 +22,8 @@ from app.models.literature_discovery import (
 )
 from app.models.user import User
 from app.schemas.literature_discovery import (
+    LiteratureDiscoveryScheduleRead,
+    LiteratureDiscoveryScheduleUpdate,
     LiteratureSearchRequest,
     OaCacheBatchRequest,
     OaCacheRead,
@@ -34,10 +36,7 @@ from app.schemas.literature_discovery import (
     SourceAttemptRead,
 )
 from app.services import libraries as libraries_service
-from app.services import literature_settings as literature_settings_service
-from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
-from app.services.literature import discovery_runs, oa_cache
-from app.services.literature.discovery_ranking import normalized_score_weights
+from app.services.literature import discovery_runs, discovery_schedules, oa_cache
 
 router = APIRouter(tags=["literature-discovery"])
 logger = logging.getLogger(__name__)
@@ -66,28 +65,6 @@ def _detail(run: LiteratureSearchRun, attempts: list[LiteratureSourceAttempt]) -
     )
 
 
-def _library_discovery_config(library: DirectionLibrary) -> dict[str, object]:
-    """Project the library's authoritative inclusion rules into one run snapshot."""
-
-    definition = libraries_service.library_definition(library)
-    raw_keywords = definition.get("keywords")
-    keyword_config = raw_keywords if isinstance(raw_keywords, dict) else {}
-    include = [
-        str(item).strip() for item in keyword_config.get("include") or [] if str(item).strip()
-    ]
-    exclude = [
-        str(item).strip() for item in keyword_config.get("exclude") or [] if str(item).strip()
-    ]
-    output: dict[str, object] = {}
-    if include:
-        output["keywords"] = list(dict.fromkeys(include))
-    if exclude:
-        output["excluded_keywords"] = list(dict.fromkeys(exclude))
-    if definition.get("rubric"):
-        output["score_rubric"] = definition["rubric"]
-    return output
-
-
 @router.post(
     "/libraries/{library_id}/literature/runs",
     response_model=SearchRunDetail,
@@ -100,81 +77,110 @@ async def create_run(
     user: User = Depends(current_active_user),
 ) -> SearchRunDetail:
     library = await _managed_library(session, library_id, user)
-    defaults = await literature_settings_service.get_runtime_settings(session)
-    requested_count = data.requested_count or int(defaults["requested_count"])
-    candidate_budget = max(
-        requested_count,
-        data.candidate_budget or int(defaults["candidate_budget"]),
-    )
-    start_year = data.start_year if data.start_year is not None else defaults.get("start_year")
-    end_year = data.end_year if data.end_year is not None else defaults.get("end_year")
-    source_config = {
-        "sources": list(defaults["sources"]),
-        "score_weights": dict(defaults["score_weights"]),
-        **_library_discovery_config(library),
-        **(data.source_config or {}),
-    }
-    source_config["score_weights"] = normalized_score_weights(
-        source_config.get("score_weights")
-        if isinstance(source_config.get("score_weights"), dict)
-        else None
-    )
-    # Provider credentials are resolved by workers and never enter run snapshots.
-    source_config.pop("provider_keys", None)
-    query_plan = await apply_profile_to_query_plan(
+    run = await discovery_runs.create_discovery_run(
         session,
         library=library,
-        topic=data.topic,
-        query_plan=data.query_plan,
-        source_config=source_config,
-    )
-    run = LiteratureSearchRun(
-        library_id=library.id,
+        data=data,
         created_by=user.id,
-        requested_count=requested_count,
-        candidate_budget=candidate_budget,
-        start_year=start_year,
-        end_year=end_year,
-        topic=data.topic,
-        query_plan=query_plan,
-        source_config=source_config,
-        model_version=data.model_version,
-        progress={
-            "phase": "queued",
-            "fetched": 0,
-            "accepted": 0,
-            "requested_count": requested_count,
-            "candidate_budget": candidate_budget,
-            "returned_count": 0,
-            "start_year": start_year,
-            "end_year": end_year,
-        },
     )
-    session.add(run)
-    await session.flush()
-    for source in discovery_runs.enabled_sources(source_config, query_plan):
-        session.add(
-            LiteratureSourceAttempt(
-                run_id=run.id,
-                source=source,
-                status="pending",
-                requested_count=None,
-            )
-        )
     await session.commit()
     await session.refresh(run)
-    attempts = list(
-        (
-            await session.execute(
-                select(LiteratureSourceAttempt)
-                .where(LiteratureSourceAttempt.run_id == run.id)
-                .order_by(LiteratureSourceAttempt.source)
-            )
-        )
-        .scalars()
-        .all()
-    )
+    attempts = await discovery_runs.list_source_attempts(session, run.id)
     return _detail(run, attempts)
+
+
+@router.get(
+    "/libraries/{library_id}/literature/schedule",
+    response_model=LiteratureDiscoveryScheduleRead,
+)
+async def get_discovery_schedule(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LiteratureDiscoveryScheduleRead:
+    library = await _library(session, library_id, user)
+    schedule = await discovery_schedules.get_schedule(session, library.id)
+    if schedule is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_SCHEDULE_NOT_FOUND")
+    return LiteratureDiscoveryScheduleRead.model_validate(schedule)
+
+
+@router.put(
+    "/libraries/{library_id}/literature/schedule",
+    response_model=LiteratureDiscoveryScheduleRead,
+)
+async def set_discovery_schedule(
+    library_id: uuid.UUID,
+    data: LiteratureDiscoveryScheduleUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LiteratureDiscoveryScheduleRead:
+    library = await _managed_library(session, library_id, user)
+    try:
+        schedule = await discovery_schedules.upsert_schedule(
+            session, library=library, data=data, actor_id=user.id
+        )
+    except discovery_schedules.InvalidDiscoveryScheduleError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return LiteratureDiscoveryScheduleRead.model_validate(schedule)
+
+
+@router.delete(
+    "/libraries/{library_id}/literature/schedule",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_discovery_schedule(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    library = await _managed_library(session, library_id, user)
+    schedule = await discovery_schedules.get_schedule(session, library.id)
+    if schedule is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_SCHEDULE_NOT_FOUND")
+    await discovery_schedules.delete_schedule(session, schedule)
+
+
+@router.post(
+    "/libraries/{library_id}/literature/schedule/run",
+    response_model=SearchRunRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def trigger_discovery_schedule(
+    library_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    queue: TaskQueue = Depends(get_task_queue),
+    user: User = Depends(current_active_user),
+) -> SearchRunRead:
+    library = await _managed_library(session, library_id, user)
+    schedule = await discovery_schedules.get_schedule(session, library.id)
+    if schedule is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LITERATURE_SCHEDULE_NOT_FOUND")
+    try:
+        run = await discovery_schedules.trigger_schedule_now(
+            session,
+            library=library,
+            schedule=schedule,
+            actor_id=user.id,
+        )
+    except discovery_schedules.DiscoveryScheduleRunConflictError as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="LITERATURE_SCHEDULE_RUN_ACTIVE",
+        ) from exc
+    try:
+        await queue.enqueue("run_literature_discovery", str(run.id))
+    except Exception as exc:
+        await discovery_schedules.record_dispatch_result(session, run_id=run.id, ok=False)
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LITERATURE_SCHEDULE_QUEUE_UNAVAILABLE",
+        ) from exc
+    await discovery_schedules.record_dispatch_result(session, run_id=run.id, ok=True)
+    return SearchRunRead.model_validate(run)
 
 
 @router.post(

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.interdisciplinary import (
 from app.models.library import UserLibraryEntry
 from app.models.library_direction import DirectionLibrary, DirectionLibraryCurator, LibraryPaper
 from app.models.literature_discovery import (
+    LiteratureDiscoverySchedule,
     LiteratureOaAttempt,
     LiteratureOaCache,
     LiteratureSearchHit,
@@ -96,6 +97,7 @@ __all__ = [
     "LLMCallLog",
     "LibraryPaper",
     "LibraryResearchDigest",
+    "LiteratureDiscoverySchedule",
     "DownloadApiKey",
     "DownloadBatch",
     "DownloadBatchItem",

--- a/src/backend/app/models/literature_discovery.py
+++ b/src/backend/app/models/literature_discovery.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, UniqueConstraint, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
@@ -23,7 +23,18 @@ class LiteratureSearchRun(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     """一次可复现的文献发现运行及其快照。"""
 
     __tablename__ = "literature_search_runs"
-    __table_args__ = (Index("ix_literature_search_runs_library_status", "library_id", "status"),)
+    __table_args__ = (
+        Index("ix_literature_search_runs_library_status", "library_id", "status"),
+        Index(
+            "uq_literature_search_runs_active_schedule",
+            "library_id",
+            unique=True,
+            postgresql_where=text(
+                "trigger = 'scheduled' AND status IN ('queued', 'running')"
+            ),
+            sqlite_where=text("trigger = 'scheduled' AND status IN ('queued', 'running')"),
+        ),
+    )
 
     library_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("direction_libraries.id", ondelete="CASCADE"), index=True, nullable=False
@@ -42,10 +53,52 @@ class LiteratureSearchRun(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     query_plan: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     source_config: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     model_version: Mapped[str | None] = mapped_column(String(255))
+    trigger: Mapped[str] = mapped_column(
+        String(16), default="manual", server_default="manual", nullable=False
+    )
+    schedule_version: Mapped[int | None]
+    scheduled_for: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     progress: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     error_summary: Mapped[str | None] = mapped_column(Text)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class LiteratureDiscoverySchedule(TimestampMixin, Base):
+    """One configurable incremental-discovery schedule per direction library."""
+
+    __tablename__ = "literature_discovery_schedules"
+    __table_args__ = (
+        Index(
+            "ix_literature_discovery_schedules_due",
+            "enabled",
+            "next_run_at",
+        ),
+    )
+
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("direction_libraries.id", ondelete="CASCADE"), primary_key=True
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    timezone: Mapped[str] = mapped_column(String(64), default="UTC", nullable=False)
+    hour: Mapped[int] = mapped_column(nullable=False)
+    minute: Mapped[int] = mapped_column(nullable=False)
+    requested_count: Mapped[int] = mapped_column(nullable=False)
+    candidate_budget: Mapped[int] = mapped_column(nullable=False)
+    start_year: Mapped[int | None]
+    end_year: Mapped[int | None]
+    config_version: Mapped[int] = mapped_column(default=1, server_default="1", nullable=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), index=True
+    )
+    next_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("literature_search_runs.id", ondelete="SET NULL"), index=True
+    )
+    last_enqueued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_error_code: Mapped[str | None] = mapped_column(String(64))
 
 
 class LiteratureSearchHit(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -90,6 +90,9 @@ class SearchRunRead(BaseModel):
     query_plan: dict[str, Any] | None
     source_config: dict[str, Any] | None
     model_version: str | None
+    trigger: Literal["manual", "scheduled"]
+    schedule_version: int | None
+    scheduled_for: datetime | None
     progress: dict[str, Any] | None
     error_summary: str | None
     started_at: datetime | None
@@ -196,3 +199,48 @@ class SearchRunPage(BaseModel):
     total: int
     page: int
     size: int
+
+
+class LiteratureDiscoveryScheduleUpdate(BaseModel):
+    enabled: bool = False
+    timezone: str = Field(default="UTC", min_length=1, max_length=64)
+    hour: int = Field(default=1, ge=0, le=23)
+    minute: int = Field(default=30, ge=0, le=59)
+    requested_count: int = Field(default=50, ge=1, le=200)
+    candidate_budget: int = Field(default=200, ge=1, le=1000)
+    start_year: int | None = Field(default=None, ge=1800, le=3000)
+    end_year: int | None = Field(default=None, ge=1800, le=3000)
+
+    @model_validator(mode="after")
+    def validate_schedule_window(self) -> "LiteratureDiscoveryScheduleUpdate":
+        if self.candidate_budget < self.requested_count:
+            raise ValueError("candidate_budget must not be less than requested_count")
+        if (
+            self.start_year is not None
+            and self.end_year is not None
+            and self.start_year > self.end_year
+        ):
+            raise ValueError("start_year must not be greater than end_year")
+        return self
+
+
+class LiteratureDiscoveryScheduleRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    library_id: uuid.UUID
+    enabled: bool
+    timezone: str
+    hour: int
+    minute: int
+    requested_count: int
+    candidate_budget: int
+    start_year: int | None
+    end_year: int | None
+    config_version: int
+    created_by: uuid.UUID | None
+    next_run_at: datetime | None
+    last_run_id: uuid.UUID | None
+    last_enqueued_at: datetime | None
+    last_error_code: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/src/backend/app/services/literature/discovery_runs.py
+++ b/src/backend/app/services/literature/discovery_runs.py
@@ -2,6 +2,7 @@
 
 import uuid
 from collections.abc import Iterable
+from datetime import datetime
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,8 +11,14 @@ from app.models.library_direction import DirectionLibrary, DirectionLibraryCurat
 from app.models.literature_discovery import (
     LiteratureSearchHit,
     LiteratureSearchRun,
+    LiteratureSourceAttempt,
 )
 from app.models.user import User
+from app.schemas.literature_discovery import LiteratureSearchRequest
+from app.services import libraries as libraries_service
+from app.services import literature_settings as literature_settings_service
+from app.services.interdisciplinary_retrieval import apply_profile_to_query_plan
+from app.services.literature.discovery_ranking import normalized_score_weights
 
 
 async def can_manage_discovery(
@@ -40,6 +47,125 @@ def enabled_sources(source_config: dict | None, query_plan: dict | None) -> list
     if not list(sources) and not sources_declared and isinstance(query_plan, dict):
         sources = query_plan.get("sources") or ()
     return list(dict.fromkeys(str(s).strip().lower() for s in sources if str(s).strip()))
+
+
+def library_discovery_config(library: DirectionLibrary) -> dict[str, object]:
+    """Project the library's authoritative inclusion rules into one run snapshot."""
+
+    definition = libraries_service.library_definition(library)
+    raw_keywords = definition.get("keywords")
+    keyword_config = raw_keywords if isinstance(raw_keywords, dict) else {}
+    include = [
+        str(item).strip() for item in keyword_config.get("include") or [] if str(item).strip()
+    ]
+    exclude = [
+        str(item).strip() for item in keyword_config.get("exclude") or [] if str(item).strip()
+    ]
+    output: dict[str, object] = {}
+    if include:
+        output["keywords"] = list(dict.fromkeys(include))
+    if exclude:
+        output["excluded_keywords"] = list(dict.fromkeys(exclude))
+    if definition.get("rubric"):
+        output["score_rubric"] = definition["rubric"]
+    return output
+
+
+async def create_discovery_run(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    data: LiteratureSearchRequest,
+    created_by: uuid.UUID | None,
+    trigger: str = "manual",
+    schedule_version: int | None = None,
+    scheduled_for: datetime | None = None,
+) -> LiteratureSearchRun:
+    """Create one run from the same settings and library contract for every trigger."""
+
+    defaults = await literature_settings_service.get_runtime_settings(session)
+    requested_count = data.requested_count or int(defaults["requested_count"])
+    candidate_budget = max(
+        requested_count,
+        data.candidate_budget or int(defaults["candidate_budget"]),
+    )
+    start_year = data.start_year if data.start_year is not None else defaults.get("start_year")
+    end_year = data.end_year if data.end_year is not None else defaults.get("end_year")
+    source_config = {
+        "sources": list(defaults["sources"]),
+        "score_weights": dict(defaults["score_weights"]),
+        **library_discovery_config(library),
+        **(data.source_config or {}),
+    }
+    source_config["score_weights"] = normalized_score_weights(
+        source_config.get("score_weights")
+        if isinstance(source_config.get("score_weights"), dict)
+        else None
+    )
+    source_config.pop("provider_keys", None)
+    query_plan = await apply_profile_to_query_plan(
+        session,
+        library=library,
+        topic=data.topic,
+        query_plan=data.query_plan,
+        source_config=source_config,
+    )
+    run = LiteratureSearchRun(
+        library_id=library.id,
+        created_by=created_by,
+        requested_count=requested_count,
+        candidate_budget=candidate_budget,
+        start_year=start_year,
+        end_year=end_year,
+        topic=data.topic,
+        query_plan=query_plan,
+        source_config=source_config,
+        model_version=data.model_version,
+        trigger=trigger,
+        schedule_version=schedule_version,
+        scheduled_for=scheduled_for,
+        progress={
+            "phase": "queued",
+            "fetched": 0,
+            "accepted": 0,
+            "requested_count": requested_count,
+            "candidate_budget": candidate_budget,
+            "returned_count": 0,
+            "start_year": start_year,
+            "end_year": end_year,
+            "trigger": trigger,
+            "schedule_version": schedule_version,
+        },
+    )
+    session.add(run)
+    await session.flush()
+    for source in enabled_sources(source_config, query_plan):
+        session.add(
+            LiteratureSourceAttempt(
+                run_id=run.id,
+                source=source,
+                status="pending",
+                requested_count=None,
+            )
+        )
+    await session.flush()
+    return run
+
+
+async def list_source_attempts(
+    session: AsyncSession, run_id: uuid.UUID
+) -> list[LiteratureSourceAttempt]:
+    return list(
+        (
+            await session.execute(
+                select(LiteratureSourceAttempt)
+                .where(LiteratureSourceAttempt.run_id == run_id)
+                .order_by(LiteratureSourceAttempt.source)
+            )
+        )
+        .scalars()
+        .all()
+    )
 
 
 async def get_visible_run(

--- a/src/backend/app/services/literature/discovery_schedules.py
+++ b/src/backend/app/services/literature/discovery_schedules.py
@@ -1,0 +1,330 @@
+"""Persist and dispatch library-scoped incremental discovery schedules."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import DirectionLibrary
+from app.models.literature_discovery import (
+    LiteratureDiscoverySchedule,
+    LiteratureSearchRun,
+)
+from app.schemas.literature_discovery import (
+    LiteratureDiscoveryScheduleUpdate,
+    LiteratureSearchRequest,
+)
+from app.services import libraries as libraries_service
+from app.services.literature.discovery_runs import create_discovery_run
+
+ACTIVE_RUN_STATUSES = ("queued", "running")
+SCHEDULE_TRIGGER = "scheduled"
+
+
+class InvalidDiscoveryScheduleError(ValueError):
+    """A stable schedule-validation error suitable for an API response."""
+
+
+class DiscoveryScheduleRunConflictError(RuntimeError):
+    """The library already has an active scheduled discovery run."""
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def schedule_timezone(name: str) -> ZoneInfo:
+    normalized = name.strip()
+    try:
+        return ZoneInfo(normalized)
+    except (ValueError, ZoneInfoNotFoundError) as exc:
+        raise InvalidDiscoveryScheduleError("INVALID_TIMEZONE") from exc
+
+
+def next_occurrence(
+    *, timezone: str, hour: int, minute: int, after: datetime
+) -> datetime:
+    """Return the next wall-clock occurrence as an aware UTC timestamp."""
+
+    zone = schedule_timezone(timezone)
+    local_after = _aware(after).astimezone(zone)
+    candidate = datetime.combine(
+        date=local_after.date(),
+        time=time(hour=hour, minute=minute),
+        tzinfo=zone,
+    )
+    if candidate <= local_after:
+        candidate = datetime.combine(
+            date=local_after.date() + timedelta(days=1),
+            time=time(hour=hour, minute=minute),
+            tzinfo=zone,
+        )
+    return candidate.astimezone(UTC)
+
+
+async def get_schedule(
+    session: AsyncSession, library_id: uuid.UUID
+) -> LiteratureDiscoverySchedule | None:
+    return await session.get(LiteratureDiscoverySchedule, library_id)
+
+
+async def _serialize_first_write(session: AsyncSession, library_id: uuid.UUID) -> None:
+    if session.get_bind().dialect.name == "postgresql":
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:library_id))"),
+            {"library_id": str(library_id)},
+        )
+
+
+async def upsert_schedule(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    data: LiteratureDiscoveryScheduleUpdate,
+    actor_id: uuid.UUID,
+    now: datetime | None = None,
+) -> LiteratureDiscoverySchedule:
+    await _serialize_first_write(session, library.id)
+    schedule = await session.get(
+        LiteratureDiscoverySchedule, library.id, with_for_update=True
+    )
+    values = data.model_dump()
+    schedule_timezone(values["timezone"])
+    current = _aware(now or datetime.now(UTC))
+    if schedule is None:
+        schedule = LiteratureDiscoverySchedule(
+            library_id=library.id,
+            created_by=actor_id,
+            config_version=1,
+            **values,
+        )
+        session.add(schedule)
+    else:
+        for key, value in values.items():
+            setattr(schedule, key, value)
+        schedule.config_version += 1
+    schedule.next_run_at = (
+        next_occurrence(
+            timezone=schedule.timezone,
+            hour=schedule.hour,
+            minute=schedule.minute,
+            after=current,
+        )
+        if schedule.enabled
+        else None
+    )
+    schedule.last_error_code = None
+    await session.commit()
+    await session.refresh(schedule)
+    return schedule
+
+
+async def delete_schedule(
+    session: AsyncSession, schedule: LiteratureDiscoverySchedule
+) -> None:
+    await session.delete(schedule)
+    await session.commit()
+
+
+def effective_topic(library: DirectionLibrary) -> str:
+    definition = libraries_service.library_definition(library)
+    for value in (definition.get("statement"), library.statement, library.name):
+        text_value = " ".join(str(value or "").split())
+        if text_value:
+            return text_value[:4000]
+    raise InvalidDiscoveryScheduleError("LIBRARY_TOPIC_MISSING")
+
+
+async def create_scheduled_run(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    schedule: LiteratureDiscoverySchedule,
+    created_by: uuid.UUID | None,
+    scheduled_for: datetime,
+) -> LiteratureSearchRun:
+    request = LiteratureSearchRequest(
+        topic=effective_topic(library),
+        requested_count=schedule.requested_count,
+        candidate_budget=schedule.candidate_budget,
+        start_year=schedule.start_year,
+        end_year=schedule.end_year,
+        source_config={
+            "incremental_discovery": {
+                "schedule_version": schedule.config_version,
+                "scheduled_for": _aware(scheduled_for).isoformat(),
+            }
+        },
+    )
+    return await create_discovery_run(
+        session,
+        library=library,
+        data=request,
+        created_by=created_by,
+        trigger=SCHEDULE_TRIGGER,
+        schedule_version=schedule.config_version,
+        scheduled_for=_aware(scheduled_for),
+    )
+
+
+async def trigger_schedule_now(
+    session: AsyncSession,
+    *,
+    library: DirectionLibrary,
+    schedule: LiteratureDiscoverySchedule,
+    actor_id: uuid.UUID,
+    now: datetime | None = None,
+) -> LiteratureSearchRun:
+    current = _aware(now or datetime.now(UTC))
+    locked_schedule = await session.scalar(
+        select(LiteratureDiscoverySchedule)
+        .where(LiteratureDiscoverySchedule.library_id == schedule.library_id)
+        .with_for_update()
+    )
+    if locked_schedule is not None:
+        schedule = locked_schedule
+    if await _active_scheduled_run(session, library.id) is not None:
+        raise DiscoveryScheduleRunConflictError(str(library.id))
+    try:
+        async with session.begin_nested():
+            run = await create_scheduled_run(
+                session,
+                library=library,
+                schedule=schedule,
+                created_by=actor_id,
+                scheduled_for=current,
+            )
+    except IntegrityError as exc:
+        raise DiscoveryScheduleRunConflictError(str(library.id)) from exc
+    schedule.last_run_id = run.id
+    schedule.last_enqueued_at = None
+    schedule.last_error_code = None
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+async def _active_scheduled_run(
+    session: AsyncSession, library_id: uuid.UUID
+) -> LiteratureSearchRun | None:
+    return await session.scalar(
+        select(LiteratureSearchRun)
+        .where(
+            LiteratureSearchRun.library_id == library_id,
+            LiteratureSearchRun.trigger == SCHEDULE_TRIGGER,
+            LiteratureSearchRun.status.in_(ACTIVE_RUN_STATUSES),
+        )
+        .order_by(LiteratureSearchRun.created_at.desc())
+        .limit(1)
+    )
+
+
+async def claim_due_schedules(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+    limit: int = 50,
+) -> list[uuid.UUID]:
+    """Atomically create due runs and return queued run IDs for ARQ dispatch."""
+
+    current = _aware(now or datetime.now(UTC))
+    statement = (
+        select(LiteratureDiscoverySchedule)
+        .where(
+            LiteratureDiscoverySchedule.enabled.is_(True),
+            LiteratureDiscoverySchedule.next_run_at.is_not(None),
+            LiteratureDiscoverySchedule.next_run_at <= current,
+        )
+        .order_by(LiteratureDiscoverySchedule.next_run_at)
+        .limit(limit)
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        statement = statement.with_for_update(skip_locked=True)
+    schedules = list((await session.execute(statement)).scalars().all())
+    run_ids: list[uuid.UUID] = []
+    for schedule in schedules:
+        scheduled_for = _aware(schedule.next_run_at or current)
+        schedule.next_run_at = next_occurrence(
+            timezone=schedule.timezone,
+            hour=schedule.hour,
+            minute=schedule.minute,
+            after=current,
+        )
+        active = await _active_scheduled_run(session, schedule.library_id)
+        if active is not None:
+            schedule.last_run_id = active.id
+            if active.status == "queued":
+                run_ids.append(active.id)
+            else:
+                schedule.last_error_code = "RUN_ALREADY_ACTIVE"
+            continue
+        library = await session.get(DirectionLibrary, schedule.library_id)
+        if library is None or library.status != "active":
+            schedule.last_error_code = "LIBRARY_NOT_ACTIVE"
+            continue
+        try:
+            async with session.begin_nested():
+                run = await create_scheduled_run(
+                    session,
+                    library=library,
+                    schedule=schedule,
+                    created_by=None,
+                    scheduled_for=scheduled_for,
+                )
+        except Exception as exc:
+            schedule.last_error_code = type(exc).__name__.upper()[:64]
+            continue
+        schedule.last_run_id = run.id
+        schedule.last_enqueued_at = None
+        schedule.last_error_code = None
+        run_ids.append(run.id)
+
+    retry_cutoff = current - timedelta(minutes=15)
+    retry_ids = list(
+        (
+            await session.execute(
+                select(LiteratureSearchRun.id)
+                .join(
+                    LiteratureDiscoverySchedule,
+                    LiteratureDiscoverySchedule.last_run_id == LiteratureSearchRun.id,
+                )
+                .where(
+                    LiteratureDiscoverySchedule.enabled.is_(True),
+                    LiteratureSearchRun.trigger == SCHEDULE_TRIGGER,
+                    LiteratureSearchRun.status == "queued",
+                    (
+                        LiteratureDiscoverySchedule.last_enqueued_at.is_(None)
+                        | (LiteratureDiscoverySchedule.last_enqueued_at < retry_cutoff)
+                    ),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    await session.commit()
+    return list(dict.fromkeys([*run_ids, *retry_ids]))
+
+
+async def record_dispatch_result(
+    session: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    ok: bool,
+    now: datetime | None = None,
+) -> None:
+    schedule = await session.scalar(
+        select(LiteratureDiscoverySchedule).where(
+            LiteratureDiscoverySchedule.last_run_id == run_id
+        )
+    )
+    if schedule is None:
+        return
+    schedule.last_enqueued_at = _aware(now or datetime.now(UTC)) if ok else None
+    schedule.last_error_code = None if ok else "QUEUE_DISPATCH_FAILED"
+    await session.commit()

--- a/src/backend/app/services/literature/incremental_filter.py
+++ b/src/backend/app/services/literature/incremental_filter.py
@@ -1,0 +1,127 @@
+"""Filter candidates already seen by a library's incremental discovery history."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import LibraryPaper
+from app.models.literature_discovery import LiteratureSearchHit, LiteratureSearchRun
+from app.models.paper import Paper
+from app.services.literature.discovery_ranking import candidate_identity
+
+_QUERY_BATCH_SIZE = 250
+
+
+def _identity(candidate: Mapping[str, Any]) -> str:
+    return candidate_identity(candidate)
+
+
+def _paper_aliases(
+    *,
+    doi: str | None,
+    arxiv_id: str | None,
+    title: str,
+    year: int | None,
+    authors: list[Any] | None,
+) -> set[str]:
+    aliases: set[str] = set()
+    if doi:
+        aliases.add(_identity({"doi": doi}))
+    if arxiv_id:
+        aliases.add(_identity({"arxiv_id": arxiv_id}))
+    if title:
+        aliases.add(_identity({"title": title, "year": year, "authors": authors or []}))
+    return aliases
+
+
+def _batches(values: Sequence[Any], size: int = _QUERY_BATCH_SIZE):
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+async def filter_known_candidates(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    candidates: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Return unseen candidates and the number removed from this library's feed."""
+
+    rows = [dict(candidate) for candidate in candidates]
+    if not rows:
+        return rows, 0
+    identity_by_index = [_identity(candidate) for candidate in rows]
+    identities = set(identity_by_index)
+    known: set[str] = set()
+    for identity_batch in _batches(list(identities)):
+        known.update(
+            (
+                await session.execute(
+                    select(LiteratureSearchHit.dedup_key)
+                    .join(
+                        LiteratureSearchRun,
+                        LiteratureSearchRun.id == LiteratureSearchHit.run_id,
+                    )
+                    .where(
+                        LiteratureSearchRun.library_id == library_id,
+                        LiteratureSearchHit.dedup_key.in_(identity_batch),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    for candidate_batch in _batches(rows):
+        batch_identities = {_identity(candidate) for candidate in candidate_batch}
+        dois = {
+            key.removeprefix("doi:") for key in batch_identities if key.startswith("doi:")
+        }
+        arxiv_ids = {
+            key.removeprefix("arxiv:")
+            for key in batch_identities
+            if key.startswith("arxiv:")
+        }
+        titles = {
+            str(candidate.get("title") or "").casefold().strip()
+            for candidate in candidate_batch
+            if str(candidate.get("title") or "").strip()
+        }
+        clauses = []
+        if dois:
+            clauses.append(func.lower(Paper.doi).in_(dois))
+        if arxiv_ids:
+            clauses.append(func.lower(Paper.arxiv_id).in_(arxiv_ids))
+        if titles:
+            clauses.append(func.lower(Paper.title).in_(titles))
+        if not clauses:
+            continue
+        paper_rows = (
+            await session.execute(
+                select(Paper.doi, Paper.arxiv_id, Paper.title, Paper.year, Paper.authors)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(LibraryPaper.library_id == library_id, or_(*clauses))
+            )
+        ).all()
+        for paper in paper_rows:
+            known.update(
+                _paper_aliases(
+                    doi=paper.doi,
+                    arxiv_id=paper.arxiv_id,
+                    title=paper.title,
+                    year=paper.year,
+                    authors=paper.authors,
+                )
+            )
+
+    unseen = [
+        candidate
+        for candidate, identity in zip(rows, identity_by_index, strict=True)
+        if identity not in known
+    ]
+    return unseen, len(rows) - len(unseen)

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -646,6 +646,15 @@ async def run_discovery(
         "\n".join(part for part in (title, abstract) if part) for title, abstract in reference_rows
     ]
     fused = fuse_candidates(candidates, executed_query_count=len(runnable))
+    historical_duplicates = 0
+    if run.trigger == "scheduled":
+        from app.services.literature.incremental_filter import filter_known_candidates
+
+        fused, historical_duplicates = await filter_known_candidates(
+            session,
+            library_id=run.library_id,
+            candidates=fused,
+        )
     owns_metric_service = venue_metric_service is None and owns_registry
     if owns_metric_service:
         from app.services.literature.venue_metrics import build_venue_metric_service
@@ -665,6 +674,7 @@ async def run_discovery(
         "fetched": fetched_total,
         "accepted": len(candidates),
         "deduplicated": len(fused),
+        "historical_duplicates": historical_duplicates,
         "pending_rerank": len(fused),
         "query_completed": len(runnable),
         "query_total": len(runnable),
@@ -796,6 +806,7 @@ async def run_discovery(
         "requested_count": run.requested_count,
         "candidate_budget": run.candidate_budget,
         "returned_count": len(ranked),
+        "historical_duplicates": historical_duplicates,
         "ranking_mode": ranking_snapshot["mode"],
         "start_year": run.start_year,
         "end_year": run.end_year,

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pycrdt>=0.10",
     "pycrdt-websocket>=0.15",
     "python-pptx>=1.0",
+    "tzdata>=2025.2",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/tests/test_literature_discovery_api.py
+++ b/src/backend/tests/test_literature_discovery_api.py
@@ -162,3 +162,109 @@ async def test_personal_library_is_isolated_and_public_library_is_read_only(clie
         headers=stranger,
     )
     assert response.status_code == 403
+
+
+async def test_owner_configures_and_triggers_incremental_schedule(client, queue_stub):
+    owner = await _headers(client, "discovery-schedule-owner@example.com")
+    library_id = await _personal_library(client, owner)
+    payload = {
+        "enabled": True,
+        "timezone": "UTC",
+        "hour": 3,
+        "minute": 45,
+        "requested_count": 50,
+        "candidate_budget": 200,
+        "start_year": 2016,
+        "end_year": 2026,
+    }
+
+    response = await client.put(
+        f"/api/libraries/{library_id}/literature/schedule",
+        json=payload,
+        headers=owner,
+    )
+    assert response.status_code == 200, response.text
+    schedule = response.json()
+    assert schedule["config_version"] == 1
+    assert schedule["requested_count"] == 50
+    assert schedule["start_year"] == 2016
+    assert schedule["next_run_at"] is not None
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/schedule/run",
+        headers=owner,
+    )
+    assert response.status_code == 202, response.text
+    run = response.json()
+    assert run["trigger"] == "scheduled"
+    assert run["schedule_version"] == 1
+    assert run["requested_count"] == 50
+    assert run["start_year"] == 2016
+    assert run["source_config"]["incremental_discovery"]["schedule_version"] == 1
+    assert queue_stub.jobs == [("run_literature_discovery", (run["id"],), {})]
+
+    response = await client.post(
+        f"/api/libraries/{library_id}/literature/schedule/run",
+        headers=owner,
+    )
+    assert response.status_code == 409
+    assert "LITERATURE_SCHEDULE_RUN_ACTIVE" in response.text
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/schedule",
+        headers=owner,
+    )
+    assert response.status_code == 200
+    assert response.json()["last_run_id"] == run["id"]
+    assert response.json()["last_enqueued_at"] is not None
+
+
+async def test_public_schedule_is_read_only_for_non_curators(client):
+    owner = await _headers(client, "public-schedule-owner@example.com")
+    stranger = await _headers(client, "public-schedule-reader@example.com")
+    library_id = await _personal_library(client, owner)
+    response = await client.put(
+        f"/api/libraries/{library_id}/literature/schedule",
+        json={"enabled": False, "timezone": "UTC"},
+        headers=owner,
+    )
+    assert response.status_code == 200, response.text
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
+        assert library is not None
+        library.is_public = True
+        await session.commit()
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/schedule", headers=stranger
+    )
+    assert response.status_code == 200
+    response = await client.put(
+        f"/api/libraries/{library_id}/literature/schedule",
+        json={"enabled": True, "timezone": "UTC"},
+        headers=stranger,
+    )
+    assert response.status_code == 403
+    response = await client.delete(
+        f"/api/libraries/{library_id}/literature/schedule", headers=stranger
+    )
+    assert response.status_code == 403
+
+
+async def test_schedule_rejects_invalid_timezone_and_year_window(client):
+    owner = await _headers(client, "invalid-schedule-owner@example.com")
+    library_id = await _personal_library(client, owner)
+    response = await client.put(
+        f"/api/libraries/{library_id}/literature/schedule",
+        json={"enabled": True, "timezone": "Not/A_Real_Zone"},
+        headers=owner,
+    )
+    assert response.status_code == 422
+    assert "INVALID_TIMEZONE" in response.text
+
+    response = await client.put(
+        f"/api/libraries/{library_id}/literature/schedule",
+        json={"start_year": 2026, "end_year": 2016},
+        headers=owner,
+    )
+    assert response.status_code == 422

--- a/src/backend/tests/test_literature_discovery_runtime.py
+++ b/src/backend/tests/test_literature_discovery_runtime.py
@@ -14,6 +14,7 @@ from app.core.config import get_settings
 from app.core.db import get_sessionmaker
 from app.models.literature_discovery import (
     LiteratureSearchHit,
+    LiteratureSearchRun,
     LiteratureSourceAttempt,
 )
 from app.models.paper import Paper
@@ -349,6 +350,70 @@ async def test_runtime_persists_versioned_metric_snapshot_and_uses_impact(client
     assert hit is not None
     assert hit.venue_metric_snapshot["version"] == "venue-metrics-v1"
     assert hit.scores["impact"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_scheduled_runtime_excludes_library_history_before_ranking(client, monkeypatch):
+    run_id, _, library_id = await _create_run(
+        client,
+        source_config={"sources": ["openalex"]},
+        requested_count=2,
+        candidate_budget=4,
+    )
+    adapter = FakeAdapter(
+        "openalex",
+        [
+            _candidate("openalex", "Historical candidate", doi="10.1000/history"),
+            _candidate("openalex", "New candidate", doi="10.1000/new"),
+        ],
+    )
+
+    async def no_oa_cache(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(oa_cache, "cache_hit_pdf", no_oa_cache)
+    async with get_sessionmaker()() as session:
+        current = await session.get(LiteratureSearchRun, run_id)
+        assert current is not None
+        current.trigger = "scheduled"
+        prior = LiteratureSearchRun(
+            library_id=uuid.UUID(library_id),
+            status="completed",
+            requested_count=1,
+            candidate_budget=1,
+            topic="prior run",
+            trigger="scheduled",
+        )
+        session.add(prior)
+        await session.flush()
+        session.add(
+            LiteratureSearchHit(
+                run_id=prior.id,
+                source="crossref",
+                dedup_key="doi:10.1000/history",
+                title="Historical candidate",
+            )
+        )
+        await session.commit()
+
+        run = await run_discovery(
+            session,
+            run_id,
+            registry=AdapterRegistry((adapter,)),
+            llm_router=RetrievalRouter(),
+        )
+        hits = list(
+            (
+                await session.execute(
+                    select(LiteratureSearchHit).where(LiteratureSearchHit.run_id == run.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert [hit.title for hit in hits] == ["New candidate"]
+    assert run.progress["historical_duplicates"] == 1
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/test_literature_discovery_schedules.py
+++ b/src/backend/tests/test_literature_discovery_schedules.py
@@ -1,0 +1,216 @@
+"""Issue #511: persisted, permission-safe incremental discovery schedules."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.literature_discovery import (
+    LiteratureDiscoverySchedule,
+    LiteratureSearchHit,
+    LiteratureSearchRun,
+)
+from app.models.paper import new_paper
+from app.schemas.literature_discovery import LiteratureDiscoveryScheduleUpdate
+from app.services.literature.discovery_schedules import (
+    claim_due_schedules,
+    next_occurrence,
+    record_dispatch_result,
+    upsert_schedule,
+)
+from app.services.literature.incremental_filter import filter_known_candidates
+from tests.conftest import register_and_login
+from worker.tasks import dispatch_literature_discovery_schedules
+
+
+async def _library(client) -> tuple[DirectionLibrary, object]:
+    token = await register_and_login(client, email="schedule-service-owner@example.com")
+    response = await client.post(
+        "/api/libraries",
+        json={"name": "Scheduled mechanics", "statement": "Dynamic structural response"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201, response.text
+    library_id = uuid.UUID(response.json()["id"])
+    async with get_sessionmaker()() as session:
+        library = await session.get(DirectionLibrary, library_id)
+        assert library is not None
+        library.status = "active"
+        await session.commit()
+        await session.refresh(library)
+        actor_id = library.submitted_by
+        session.expunge(library)
+    return library, actor_id
+
+
+def test_next_occurrence_respects_library_timezone():
+    after = datetime(2026, 8, 28, 0, 0, tzinfo=UTC)
+    assert next_occurrence(
+        timezone="Asia/Shanghai", hour=9, minute=30, after=after
+    ) == datetime(2026, 8, 28, 1, 30, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_due_schedule_creates_one_versioned_run_and_recovers_undispatched_queue(client):
+    library, actor_id = await _library(client)
+    now = datetime(2026, 8, 28, 0, 0, tzinfo=UTC)
+    async with get_sessionmaker()() as session:
+        attached = await session.get(DirectionLibrary, library.id)
+        schedule = await upsert_schedule(
+            session,
+            library=attached,
+            data=LiteratureDiscoveryScheduleUpdate(
+                enabled=True,
+                timezone="UTC",
+                hour=1,
+                minute=30,
+                requested_count=50,
+                candidate_budget=200,
+                start_year=2016,
+            ),
+            actor_id=actor_id,
+            now=now - timedelta(days=1),
+        )
+        schedule.next_run_at = now - timedelta(minutes=1)
+        await session.commit()
+
+        first = await claim_due_schedules(session, now=now)
+        second = await claim_due_schedules(session, now=now + timedelta(minutes=1))
+        run_count = await session.scalar(
+            select(func.count()).select_from(LiteratureSearchRun)
+        )
+        run = await session.get(LiteratureSearchRun, first[0])
+        persisted = await session.get(LiteratureDiscoverySchedule, library.id)
+
+        assert first == second
+        assert run_count == 1
+        assert run is not None
+        assert run.trigger == "scheduled"
+        assert run.schedule_version == 1
+        assert run.requested_count == 50
+        assert run.start_year == 2016
+        assert run.source_config["incremental_discovery"]["schedule_version"] == 1
+        assert persisted.next_run_at > now
+
+        await record_dispatch_result(session, run_id=run.id, ok=True, now=now)
+        assert await claim_due_schedules(session, now=now + timedelta(minutes=2)) == []
+
+
+@pytest.mark.asyncio
+async def test_incremental_filter_removes_historical_hits_and_library_papers(client):
+    library, actor_id = await _library(client)
+    async with get_sessionmaker()() as session:
+        prior = LiteratureSearchRun(
+            library_id=library.id,
+            created_by=actor_id,
+            requested_count=10,
+            candidate_budget=20,
+            topic="prior",
+            trigger="scheduled",
+        )
+        session.add(prior)
+        await session.flush()
+        session.add(
+            LiteratureSearchHit(
+                run_id=prior.id,
+                source="crossref",
+                dedup_key="doi:10.1000/history",
+                title="Historical result",
+            )
+        )
+        paper = new_paper(
+            source="arxiv",
+            dedup_key="arxiv:2608.12345",
+            arxiv_id="2608.12345",
+            doi=None,
+            external_ids=None,
+            title="Already in library",
+            authors=[{"name": "Ada Example"}],
+            abstract=None,
+            year=2026,
+            venue=None,
+            url=None,
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            LibraryPaper(
+                library_id=library.id,
+                paper_id=paper.id,
+                status="scored",
+            )
+        )
+        await session.commit()
+
+        unseen, removed = await filter_known_candidates(
+            session,
+            library_id=library.id,
+            candidates=[
+                {"title": "Historical result", "doi": "10.1000/HISTORY"},
+                {"title": "Already in library", "arxiv_id": "2608.12345"},
+                {"title": "New evidence", "doi": "10.1000/new"},
+            ],
+        )
+
+    assert removed == 2
+    assert [item["title"] for item in unseen] == ["New evidence"]
+
+
+@pytest.mark.asyncio
+async def test_incremental_filter_batches_the_maximum_candidate_pool(client):
+    library, _ = await _library(client)
+    candidates = [
+        {"title": f"Candidate {index}", "doi": f"10.2000/{index}"}
+        for index in range(1000)
+    ]
+    async with get_sessionmaker()() as session:
+        unseen, removed = await filter_known_candidates(
+            session,
+            library_id=library.id,
+            candidates=candidates,
+        )
+
+    assert removed == 0
+    assert len(unseen) == 1000
+
+
+@pytest.mark.asyncio
+async def test_worker_dispatches_due_schedule_and_records_enqueue(client):
+    library, actor_id = await _library(client)
+    async with get_sessionmaker()() as session:
+        attached = await session.get(DirectionLibrary, library.id)
+        schedule = await upsert_schedule(
+            session,
+            library=attached,
+            data=LiteratureDiscoveryScheduleUpdate(
+                enabled=True,
+                timezone="UTC",
+                hour=1,
+                minute=30,
+            ),
+            actor_id=actor_id,
+        )
+        schedule.next_run_at = datetime.now(UTC) - timedelta(minutes=1)
+        await session.commit()
+
+    calls = []
+
+    class Redis:
+        async def enqueue_job(self, name, run_id, **kwargs):
+            calls.append((name, run_id, kwargs))
+
+    dispatched = await dispatch_literature_discovery_schedules({"redis": Redis()})
+
+    assert len(dispatched) == 1
+    assert calls[0][0] == "run_literature_discovery"
+    assert calls[0][1] == dispatched[0]
+    assert calls[0][2]["_job_id"].startswith("scheduled-literature-")
+    async with get_sessionmaker()() as session:
+        schedule = await session.get(LiteratureDiscoverySchedule, library.id)
+        assert schedule is not None
+        assert str(schedule.last_run_id) == dispatched[0]
+        assert schedule.last_enqueued_at is not None
+        assert schedule.last_error_code is None

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "f1a2b3c4d5e6"  # Immutable interdisciplinary scope versions
-HEAD_REVISION = "f2a3b4c5d6e7"  # Versioned literature venue metrics
+HEAD_REVISION = "f3a4b5c6d7e8"  # Scheduled incremental literature discovery
+VENUE_METRIC_REVISION = "f2a3b4c5d6e7"  # Versioned literature venue metrics
 SCOPE_VERSION_REVISION = "f1a2b3c4d5e6"  # Immutable interdisciplinary scope versions
 QUERY_MATRIX_REVISION = "f0a1b2c3d4e5"  # Interdisciplinary query matrix and evidence balance
 INTERDISCIPLINARY_REVISION = "e9f0a1b2c3d4"  # Interdisciplinary research profiles
@@ -124,6 +124,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "literature_search_hits",
                     "literature_source_attempts",
                     "literature_venue_metric_cache",
+                    "literature_discovery_schedules",
                     "pdf_blobs",
                     "paper_assets",
                     "asset_grants",
@@ -170,6 +171,17 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"provider", "identity_key", "metrics", "expires_at"} <= columns[
         "literature_venue_metric_cache"
     ]
+    assert {"trigger", "schedule_version", "scheduled_for"} <= columns[
+        "literature_search_runs"
+    ]
+    assert {
+        "library_id",
+        "enabled",
+        "timezone",
+        "requested_count",
+        "config_version",
+        "next_run_at",
+    } <= columns["literature_discovery_schedules"]
     # 压缩阈值要知道模型的窗口有多大，此前 router 只能拍脑袋
     assert "context_window" in columns["model_routes"]
     # 向量搬进三张侧表，主表上的向量列与元信息列一并删除
@@ -496,8 +508,16 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "evidence_balance",
     } <= columns["interdisciplinary_research_profile_versions"]
 
-    # First remove immutable scope versions and return to the query-matrix head.
-    # First remove venue metrics and return to immutable scope versions.
+    # First remove schedules and return to the venue-metric head.
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == VENUE_METRIC_REVISION
+    assert "literature_discovery_schedules" not in columns["_tables"]
+    assert not {"trigger", "schedule_version", "scheduled_for"} & columns[
+        "literature_search_runs"
+    ]
+
+    # Then remove venue metrics and return to immutable scope versions.
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == SCOPE_VERSION_REVISION

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -9,6 +9,7 @@ from worker.tasks import (
     daily_feed_sync,
     daily_publication_match,
     daily_wiki_ingest,
+    dispatch_literature_discovery_schedules,
     index_papers_fulltext_task,
     match_user_publications,
     parse_paper_content_task,
@@ -50,6 +51,10 @@ class WorkerSettings:
     # 了才同步，时刻不用猜。发表匹配仍按时刻派生（抓取 + 150 分钟）。
     _CHECKPOINT_MINUTES = {0, 15, 30, 45}
     cron_jobs = [
+        cron(
+            dispatch_literature_discovery_schedules,
+            minute={0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55},
+        ),
         cron(daily_feed_sync, minute=_CHECKPOINT_MINUTES),
         cron(daily_publication_match, minute=_CHECKPOINT_MINUTES),
         # 僵死回收：启动对账只救 worker 重启的孤儿；运行中途丢任务（LLM 调用悬死、

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -390,3 +390,37 @@ async def run_literature_discovery(ctx: dict[str, Any], run_id: str) -> dict[str
             "status": run.status,
             "returned_count": (run.progress or {}).get("returned_count", 0),
         }
+
+
+async def dispatch_literature_discovery_schedules(ctx: dict[str, Any]) -> list[str]:
+    """Create due incremental runs and idempotently dispatch them to ARQ."""
+
+    from datetime import UTC, datetime
+
+    from app.services.literature import discovery_schedules
+
+    current = datetime.now(UTC)
+    async with get_sessionmaker()() as session:
+        run_ids = await discovery_schedules.claim_due_schedules(session, now=current)
+    dispatched: list[str] = []
+    bucket = int(current.timestamp() // (15 * 60))
+    for run_id in run_ids:
+        ok = False
+        try:
+            await ctx["redis"].enqueue_job(
+                "run_literature_discovery",
+                str(run_id),
+                _job_id=f"scheduled-literature-{run_id}-{bucket}",
+            )
+            ok = True
+            dispatched.append(str(run_id))
+        except Exception:
+            logger.exception("scheduled literature dispatch failed for %s", run_id)
+        async with get_sessionmaker()() as session:
+            await discovery_schedules.record_dispatch_result(
+                session,
+                run_id=run_id,
+                ok=ok,
+                now=current,
+            )
+    return dispatched


### PR DESCRIPTION
#520 merged, rebased onto current `main`. Authorship preserved as @yyy-OPS.

Migration `f3a4b5c6d7e8` chains correctly from `f2a3b4c5d6e7`.

## The refactor is sound, and I checked rather than assumed

This PR moves run creation out of the API into `discovery_runs.create_discovery_run` so the scheduler and the API share one path. That kind of move is where recently-added behaviour quietly gets left behind, so I checked each thing added since #523 against the new function:

| carried over | |
|---|---|
| administrator defaults (`get_runtime_settings`) | yes |
| `normalized_score_weights` | yes |
| `library_discovery_config` | yes |
| `apply_profile_to_query_plan` | yes |
| `source_config.pop("provider_keys", None)` | yes |

And behaviourally: removing that `pop` from its **new** location still reds `test_provider_keys_never_reach_the_run_snapshot`. The guard followed the code rather than being stranded at the old call site.

## What would have been reverted

`api/interdisciplinary.py` on the branch predates #524 and restores `project.id` in the `IntegrityError` recovery path — the third PR in a row carrying that file. `main`'s version kept, and both credential guards preserved by union-resolving the runtime tests.

## Verification

- `alembic heads` → single head `f3a4b5c6d7e8`
- `tests/test_literature_discovery_runtime.py test_literature_discovery_api.py test_admin_literature_settings.py test_interdisciplinary.py test_migrations.py test_literature_discovery_schedules.py` → 46 passed
- `ruff check app/ worker/` → clean

Closes #512. Supersedes #520.