### PR TITLE
feat(interdisciplinary): pin workflow profile versions

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -497,6 +497,7 @@ def _prompt_with_context(base: str, ctx: ActionContext) -> str:
     """按 params.eval_model / hf_mirror / extra_notes 给 system prompt 条件追加段落。"""
     params = _params(ctx)
     parts = [base, STACK_GUARD_PROMPT_SECTION]
+    parts.append(ctx.skill_guidance("experiment.plan"))
     if str(params.get("eval_model") or "").strip():
         parts.append(EVAL_MODEL_PROMPT_SECTION)
     if params.get("hf_mirror"):

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -46,6 +46,7 @@ from app.models.base import utcnow
 from app.models.gate import Gate
 from app.models.llm_config import LLMUsage
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun, VoyageStep, mode_for_kind
+from app.services import interdisciplinary_workflows
 from app.services import skills as skills_service
 from app.services import voyage_messages as messages_service
 
@@ -632,6 +633,12 @@ class VoyageEngine:
             else {}
         )
         checkpoint = dict(run.checkpoint or {})
+        interdisciplinary = await interdisciplinary_workflows.snapshot_for_project(
+            session, run.project_id
+        )
+        if interdisciplinary is not None:
+            interdisciplinary_workflows.apply_to_skill_snapshot(snapshot, interdisciplinary)
+            checkpoint["interdisciplinary_context"] = interdisciplinary
         checkpoint["skills"] = snapshot
         run.checkpoint = checkpoint
         await session.commit()

--- a/src/backend/app/api/interdisciplinary.py
+++ b/src/backend/app/api/interdisciplinary.py
@@ -28,6 +28,10 @@ from app.services import interdisciplinary_scope as scope_service
 from app.services import libraries as libraries_service
 from app.services import projects as projects_service
 from app.services.interdisciplinary_retrieval import build_query_matrix, normalize_query_matrix
+from app.services.interdisciplinary_workflows import (
+    InterdisciplinaryScopeInvalidError,
+    validate_disciplines,
+)
 
 
 async def _existing_dedicated_library(
@@ -194,6 +198,12 @@ async def confirm_interdisciplinary_scope(
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT, detail="INTERDISCIPLINARY_SCOPE_INVALID"
         )
+    try:
+        validate_disciplines(profile.primary_domain, list(profile.related_domains))
+    except InterdisciplinaryScopeInvalidError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="INTERDISCIPLINARY_SCOPE_INVALID"
+        ) from exc
     profile.status = "confirmed"
     profile.confirmed_by = user.id
     profile.confirmed_at = datetime.now(UTC)

--- a/src/backend/app/services/interdisciplinary_workflows.py
+++ b/src/backend/app/services/interdisciplinary_workflows.py
@@ -1,0 +1,203 @@
+"""Freeze confirmed interdisciplinary constraints into project workflow runs."""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.interdisciplinary import InterdisciplinaryResearchProfileVersion
+from app.models.project import Project
+from app.models.skill import Skill, SkillVersion
+
+SKILL_SLUG = "interdisciplinary-research-workflow"
+
+_GUIDANCE_TARGETS = (
+    "wiki.score_relevance",
+    "wiki.compile",
+    "wiki.daily_digest",
+    "wiki.trend_synthesize",
+    "forge.gap_analysis",
+    "forge.generate",
+    "forge.score",
+    "experiment.plan",
+    "writing.section",
+    "writing.related_work",
+    "review.referees",
+    "present.outline",
+    "present.slides",
+)
+_PLACEHOLDERS = (
+    "pending",
+    "unknown",
+    "to be confirmed",
+    "tbd",
+    "待确认",
+    "待用户确认",
+    "未确认",
+    "未确定",
+    "未知",
+)
+
+
+class InterdisciplinaryScopeInvalidError(ValueError):
+    pass
+
+
+def validate_disciplines(primary_domain: str, related_domains: list[str]) -> None:
+    """Reject placeholder disciplines before they become confirmed workflow assets."""
+
+    values = [primary_domain, *related_domains]
+    normalized = [str(value or "").strip().casefold() for value in values]
+    if not normalized[0] or not related_domains or any(not value for value in normalized):
+        raise InterdisciplinaryScopeInvalidError("INTERDISCIPLINARY_SCOPE_INVALID")
+    if any(marker in value for value in normalized for marker in _PLACEHOLDERS):
+        raise InterdisciplinaryScopeInvalidError("INTERDISCIPLINARY_SCOPE_INVALID")
+
+
+async def _latest_confirmed_profile(
+    session: AsyncSession, project_id: uuid.UUID
+) -> InterdisciplinaryResearchProfileVersion | None:
+    return await session.scalar(
+        select(InterdisciplinaryResearchProfileVersion)
+        .where(
+            InterdisciplinaryResearchProfileVersion.project_id == project_id,
+            InterdisciplinaryResearchProfileVersion.status == "confirmed",
+        )
+        .order_by(InterdisciplinaryResearchProfileVersion.version.desc())
+        .limit(1)
+    )
+
+
+async def _builtin_skill_version(session: AsyncSession) -> tuple[Skill, SkillVersion] | None:
+    skill = await session.scalar(
+        select(Skill).where(
+            Skill.slug == SKILL_SLUG,
+            Skill.scope == "builtin",
+            Skill.is_archived.is_(False),
+        )
+    )
+    if skill is None:
+        return None
+    version = await session.scalar(
+        select(SkillVersion)
+        .where(SkillVersion.skill_id == skill.id)
+        .order_by(SkillVersion.version.desc())
+        .limit(1)
+    )
+    return (skill, version) if version is not None else None
+
+
+async def snapshot_for_project(
+    session: AsyncSession, project_id: uuid.UUID | None
+) -> dict[str, Any] | None:
+    """Return the latest confirmed profile and current built-in Skill as one immutable payload."""
+
+    if project_id is None:
+        return None
+    project = await session.get(Project, project_id)
+    if project is None or project.research_mode != "interdisciplinary":
+        return None
+    profile = await _latest_confirmed_profile(session, project_id)
+    if profile is None:
+        return None
+    validate_disciplines(profile.primary_domain, list(profile.related_domains or []))
+    skill_pair = await _builtin_skill_version(session)
+    if skill_pair is None:
+        raise RuntimeError("INTERDISCIPLINARY_WORKFLOW_SKILL_MISSING")
+    skill, version = skill_pair
+    return {
+        "schema_version": 1,
+        "project_id": str(project_id),
+        "profile_id": str(profile.profile_id),
+        "profile_version_id": str(profile.id),
+        "profile_version": profile.version,
+        "skill_id": str(skill.id),
+        "skill_version_id": str(version.id),
+        "skill_version": version.version,
+        "skill_slug": skill.slug,
+        "skill_name": skill.name,
+        "skill_body": version.body,
+        "skill_manifest": dict(version.manifest or {}),
+        "research_scope": profile.research_scope,
+        "core_questions": list(profile.core_questions or []),
+        "primary_domain": profile.primary_domain,
+        "related_domains": list(profile.related_domains or []),
+        "evidence_boundary": profile.evidence_boundary,
+        "validation_conditions": list(profile.validation_conditions or []),
+        "query_matrix": list(profile.query_matrix or []),
+        "evidence_balance": dict(profile.evidence_balance or {}),
+    }
+
+
+def _render_guidance(context: dict[str, Any]) -> str:
+    related = ", ".join(context["related_domains"])
+    questions = "\n".join(f"- {item}" for item in context["core_questions"])
+    conditions = "\n".join(f"- {item}" for item in context["validation_conditions"])
+    balance = ", ".join(
+        f"{domain}: {weight}" for domain, weight in context["evidence_balance"].items()
+    )
+    channels = "\n".join(
+        f"- [{row.get('role') or 'unspecified'}] {row.get('discipline') or 'unspecified'}: "
+        f"{str(row.get('query') or '').strip()[:500]}"
+        for row in context["query_matrix"][:24]
+        if isinstance(row, dict) and str(row.get("query") or "").strip()
+    )
+    return (
+        "Immutable interdisciplinary research context for this run:\n"
+        f"- Profile version: {context['profile_version']} "
+        f"({context['profile_version_id']})\n"
+        f"- Primary discipline: {context['primary_domain']}\n"
+        f"- Associated disciplines: {related}\n"
+        f"- Research scope: {context['research_scope']}\n"
+        f"- Core bridge questions:\n{questions}\n"
+        f"- Evidence boundary: {context['evidence_boundary'] or 'Not specified'}\n"
+        f"- Validation conditions:\n{conditions or '- Not specified'}\n"
+        f"- Evidence balance: {balance or 'Not specified'}\n\n"
+        f"- Discipline query channels and terms:\n{channels or '- Not specified'}\n\n"
+        "Apply these constraints throughout the output. Keep the primary discipline responsible "
+        "for the scientific question, identify the non-substitutable contribution of each "
+        "associated discipline, preserve discipline-specific evidence standards, and state "
+        "whether every bridge claim has balanced supporting evidence.\n\n"
+        f"Pinned workflow Skill v{context['skill_version']}:\n{context['skill_body']}"
+    )
+
+
+def apply_to_skill_snapshot(
+    snapshot: dict[str, list[dict[str, Any]]], context: dict[str, Any]
+) -> None:
+    """Add one pinned workflow entry and guidance entries without duplicating user configuration."""
+
+    common = {
+        "skill_id": context["skill_id"],
+        "skill_version_id": context["skill_version_id"],
+        "slug": context["skill_slug"],
+        "name": context["skill_name"],
+        "version": context["skill_version"],
+        "config": {"profile_version_id": context["profile_version_id"]},
+        "personas": [],
+        "output_contract": None,
+    }
+    workflow_entry = {
+        **common,
+        "kind": "workflow",
+        "body": context["skill_body"],
+        "steps": context["skill_manifest"].get("steps") or [],
+    }
+    navigator_entries = snapshot.setdefault("navigator.free_plan", [])
+    if not any(entry.get("slug") == SKILL_SLUG for entry in navigator_entries):
+        navigator_entries.append(workflow_entry)
+
+    guidance = _render_guidance(context)
+    for target in _GUIDANCE_TARGETS:
+        entries = snapshot.setdefault(target, [])
+        if any(entry.get("slug") == SKILL_SLUG for entry in entries):
+            continue
+        entries.append(
+            {
+                **common,
+                "kind": "guidance",
+                "body": guidance,
+                "steps": [],
+            }
+        )

--- a/src/backend/tests/test_interdisciplinary_workflows.py
+++ b/src/backend/tests/test_interdisciplinary_workflows.py
@@ -1,0 +1,174 @@
+"""Interdisciplinary profile and Skill versions stay pinned across project workflows."""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.agents.voyage.actions import ActionContext
+from app.agents.voyage.actions_experiment import _prompt_with_context
+from app.agents.voyage.engine import VoyageEngine
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.project import Project
+from app.models.skill import Skill, SkillVersion
+from app.models.voyage import VoyageRun
+from app.services.interdisciplinary_workflows import SKILL_SLUG
+from app.services.skills import ensure_builtin_skills
+from tests.conftest import RecordingBus, register_and_login
+
+
+def _scope(version: int = 1) -> dict:
+    return {
+        "research_scope": (
+            f"Couple structural mechanics and visual measurement, revision {version}."
+        ),
+        "core_questions": ["Which visual observables preserve mechanical meaning?"],
+        "primary_domain": "Structural engineering",
+        "related_domains": ["Computer vision", "Data science"],
+        "evidence_boundary": "Use only validated structural and visual evidence.",
+        "validation_conditions": ["Compare against independent impact experiments."],
+        "user_questions": [],
+    }
+
+
+async def _project_and_profile(client) -> tuple[dict[str, str], str]:
+    token = await register_and_login(client, email="workflow-owner@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project = await client.post(
+        "/api/projects",
+        headers=headers,
+        json={
+            "name": "Mechanics and vision",
+            "statement": "Measure impact response with segmented video.",
+            "research_mode": "interdisciplinary",
+        },
+    )
+    project_id = project.json()["id"]
+    saved = await client.put(
+        f"/api/projects/{project_id}/interdisciplinary/scope",
+        headers=headers,
+        json=_scope(),
+    )
+    assert saved.status_code == 200, saved.text
+    confirmed = await client.post(
+        f"/api/projects/{project_id}/interdisciplinary/scope/confirm", headers=headers
+    )
+    assert confirmed.status_code == 200, confirmed.text
+    return headers, project_id
+
+
+async def _snapshot_run(project_id: str) -> VoyageRun:
+    async with get_sessionmaker()() as session:
+        await ensure_builtin_skills(session)
+        project = await session.get(Project, uuid.UUID(project_id))
+        run = VoyageRun(
+            kind="idea_forge",
+            goal="Generate interdisciplinary ideas",
+            status="planning",
+            project_id=project.id,
+            created_by=project.owner_id,
+        )
+        session.add(run)
+        await session.commit()
+        await session.refresh(run)
+        engine = VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+        await engine._ensure_skills_snapshot(session, run)
+        await session.refresh(run)
+        return run
+
+
+async def test_run_pins_confirmed_profile_and_builtin_skill_versions(client):
+    headers, project_id = await _project_and_profile(client)
+    first = await _snapshot_run(project_id)
+    first_context = dict((first.checkpoint or {})["interdisciplinary_context"])
+    assert first_context["profile_version"] == 1
+    assert first_context["skill_version"] == 1
+    assert first_context["primary_domain"] == "Structural engineering"
+    assert first_context["related_domains"] == ["Computer vision", "Data science"]
+
+    skills = (first.checkpoint or {})["skills"]
+    assert skills["navigator.free_plan"][0]["kind"] == "workflow"
+    assert skills["forge.generate"][0]["kind"] == "guidance"
+    assert "Core bridge questions" in skills["forge.generate"][0]["body"]
+    assert "Discipline query channels and terms" in skills["forge.generate"][0]["body"]
+    assert "Structural engineering" in skills["forge.generate"][0]["body"]
+    assert "Computer vision" in skills["forge.generate"][0]["body"]
+    assert first_context["profile_version_id"] in skills["forge.generate"][0]["body"]
+
+    ctx = ActionContext(run=first, llm=LLMRouter(), checkpoint=dict(first.checkpoint or {}))
+    assert "Structural engineering" in _prompt_with_context("BASE", ctx)
+
+    async with get_sessionmaker()() as session:
+        skill = await session.scalar(select(Skill).where(Skill.slug == SKILL_SLUG))
+        first_skill_version = await session.scalar(
+            select(SkillVersion).where(
+                SkillVersion.skill_id == skill.id,
+                SkillVersion.version == first_context["skill_version"],
+            )
+        )
+        session.add(
+            SkillVersion(
+                skill_id=skill.id,
+                version=first_skill_version.version + 1,
+                manifest=dict(first_skill_version.manifest),
+                body=f"{first_skill_version.body}\n\nVersion two guidance.",
+                changelog="Test workflow version pinning.",
+            )
+        )
+        await session.commit()
+
+    updated = await client.put(
+        f"/api/projects/{project_id}/interdisciplinary/scope",
+        headers=headers,
+        json=_scope(2),
+    )
+    assert updated.status_code == 200, updated.text
+    confirmed = await client.post(
+        f"/api/projects/{project_id}/interdisciplinary/scope/confirm", headers=headers
+    )
+    assert confirmed.status_code == 200, confirmed.text
+
+    second = await _snapshot_run(project_id)
+    second_context = (second.checkpoint or {})["interdisciplinary_context"]
+    assert second_context["profile_version"] == 2
+    assert second_context["profile_version_id"] != first_context["profile_version_id"]
+    assert second_context["skill_version"] == first_context["skill_version"] + 1
+    assert (first.checkpoint or {})["interdisciplinary_context"] == first_context
+
+
+async def test_conventional_project_keeps_existing_skill_behavior(client):
+    token = await register_and_login(client, email="conventional-workflow@example.com")
+    project = await client.post(
+        "/api/projects",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": "Conventional mechanics", "research_mode": "conventional"},
+    )
+    run = await _snapshot_run(project.json()["id"])
+    assert "interdisciplinary_context" not in (run.checkpoint or {})
+    assert all(
+        entry.get("slug") != "interdisciplinary-research-workflow"
+        for entries in (run.checkpoint or {})["skills"].values()
+        for entry in entries
+    )
+
+
+async def test_placeholder_disciplines_cannot_be_confirmed(client):
+    token = await register_and_login(client, email="placeholder-workflow@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project = await client.post(
+        "/api/projects",
+        headers=headers,
+        json={"name": "Invalid scope", "research_mode": "interdisciplinary"},
+    )
+    project_id = project.json()["id"]
+    saved = await client.put(
+        f"/api/projects/{project_id}/interdisciplinary/scope",
+        headers=headers,
+        json={**_scope(), "primary_domain": "Pending user confirmation"},
+    )
+    assert saved.status_code == 200, saved.text
+    confirmed = await client.post(
+        f"/api/projects/{project_id}/interdisciplinary/scope/confirm", headers=headers
+    )
+    assert confirmed.status_code == 422
+    assert confirmed.json()["detail"] == "INTERDISCIPLINARY_SCOPE_INVALID"


### PR DESCRIPTION
## Summary

- freeze the latest confirmed interdisciplinary profile version into each project Voyage run
- pin the current built-in interdisciplinary workflow Skill version in the same immutable checkpoint
- inject the confirmed scope, disciplines, bridge questions, evidence boundary, validation conditions, query channels, and evidence balance into Wiki, idea, experiment, writing, review, and presentation prompts
- reject placeholder discipline names before profile confirmation
- preserve the existing behavior for conventional projects

## Design

This PR reuses `VoyageRun.checkpoint` instead of adding schema fields or a migration. The first drive snapshots both version IDs and the complete runtime context. Resume and replay read that immutable snapshot, while later runs can bind newer profile or Skill versions.

The built-in workflow remains visible through the existing Skill system. Interdisciplinary guidance is adapted to existing prompt targets, so downstream agents consume one shared contract rather than adding parallel workflow implementations.

## Verification

- `28 passed` across interdisciplinary profiles, retrieval, built-in Skills, Skill execution, version pinning, and conventional-project isolation
- `150 passed` across Voyage, idea generation/review, experiments, writing, paper review, and presentations
- Ruff passed for all changed backend files
- `compileall` passed
- `git diff --check` and sensitive-value scan passed

The only warnings are existing FastAPI/Starlette deprecation warnings for `HTTP_422_UNPROCESSABLE_ENTITY` in unchanged routes.

## Review and rollback

- Based directly on `origin/main@851abc8` after #522 merged
- One commit; no dependency branch or duplicated changes from earlier PRs
- No migration and no persisted-data rewrite
- Rollback is limited to removing the prompt adapter/service and its three call sites

Refs #515. The issue is currently closed because of an earlier incorrect auto-close reference; this PR implements its remaining acceptance criteria.