### PR TITLE
feat(literature): add library discovery workspace

### DIFF
--- a/src/backend/app/api/literature_discovery.py
+++ b/src/backend/app/api/literature_discovery.py
@@ -274,12 +274,19 @@ async def list_hits(
     hit_status: str | None = Query(
         None, alias="status", pattern="^(candidate|promoted|dismissed)$"
     ),
+    year_from: int | None = Query(None, ge=1800, le=3000),
+    year_to: int | None = Query(None, ge=1800, le=3000),
     sort: str = Query("relevance", pattern="^(relevance|novelty|impact|recent|title)$"),
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> SearchHitPage:
+    if year_from is not None and year_to is not None and year_from > year_to:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="YEAR_RANGE_INVALID",
+        )
     await _library(session, library_id, user)
     run = await discovery_runs.get_visible_run(session, library_id=library_id, run_id=run_id)
     if run is None:
@@ -289,6 +296,10 @@ async def list_hits(
         stmt = stmt.where(LiteratureSearchHit.source == source.strip().lower())
     if hit_status:
         stmt = stmt.where(LiteratureSearchHit.status == hit_status)
+    if year_from is not None:
+        stmt = stmt.where(LiteratureSearchHit.year >= year_from)
+    if year_to is not None:
+        stmt = stmt.where(LiteratureSearchHit.year <= year_to)
     if q:
         pattern = f"%{q.strip()}%"
         stmt = stmt.where(

--- a/src/backend/tests/test_literature_discovery_api.py
+++ b/src/backend/tests/test_literature_discovery_api.py
@@ -69,9 +69,19 @@ async def test_owner_can_create_inspect_filter_and_cancel_run(client):
             dedup_key="doi:10.1/example",
             title="Impact response",
             abstract="A structural impact response",
+            year=2024,
             scores={"relevance": 0.9, "novelty": 0.4, "impact": 8},
         )
-        session.add(hit)
+        older = LiteratureSearchHit(
+            run_id=uuid.UUID(run_id),
+            source="semantic",
+            dedup_key="doi:10.1/older",
+            title="Older mechanics study",
+            abstract="Historical mechanics evidence",
+            year=2012,
+            scores={"relevance": 0.7, "novelty": 0.2, "impact": 6},
+        )
+        session.add_all([hit, older])
         await session.commit()
     response = await client.get(
         f"/api/libraries/{library_id}/literature/runs/{run_id}/hits?sort=relevance&q=structural",
@@ -80,6 +90,21 @@ async def test_owner_can_create_inspect_filter_and_cancel_run(client):
     assert response.status_code == 200
     assert response.json()["total"] == 1
     assert response.json()["items"][0]["title"] == "Impact response"
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}/hits?year_from=2020&year_to=2026",
+        headers=owner,
+    )
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["year"] == 2024
+
+    response = await client.get(
+        f"/api/libraries/{library_id}/literature/runs/{run_id}/hits?year_from=2026&year_to=2020",
+        headers=owner,
+    )
+    assert response.status_code == 422
+    assert "YEAR_RANGE_INVALID" in response.text
 
 
 async def test_candidate_budget_cannot_be_smaller_than_requested_result_count(client):

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -64,6 +64,7 @@ import { ReadingDot, readerFrom } from '../reading/shared';
 import { AddToButton } from '../library/AddToPopover';
 import { paperDragProps } from '../assistant/paperDrag';
 import { clampLines } from '../../lib/clamp';
+import { LiteratureDiscoveryPanel } from './LiteratureDiscoveryPage';
 
 // 图谱体量大且非默认视图：按需加载（与 WikiWorkbench 一致）
 const GraphTab = lazy(() => import('../wiki/GraphTab').then((m) => ({ default: m.GraphTab })));
@@ -77,7 +78,7 @@ const DailyDigestTab = lazy(() =>
    全部走 /libraries 读端点；没有任何管理入口，收藏/笔记等个人操作去阅读页做。
    ============================================================ */
 
-type BrowseTab = 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'notes' | 'govern' | 'ingest';
+type BrowseTab = 'discover' | 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'notes' | 'govern' | 'ingest';
 
 const PAGE_SIZE = 20;
 
@@ -927,6 +928,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
       <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<BrowseTab>
           options={[
+            { v: 'discover', label: tr('发现文献', 'Discover') },
             { v: 'papers', label: `${tr('论文库', 'Papers')}${paperTotal !== undefined ? ` · ${paperTotal}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
@@ -969,7 +971,9 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
       <div
         className="card split-card"
       >
-        {tab === 'papers' ? (
+        {tab === 'discover' ? (
+          <LiteratureDiscoveryPanel libraryId={libraryId} readOnly />
+        ) : tab === 'papers' ? (
           <PapersPane
             libraryId={libraryId}
             selectedId={paperId}

--- a/src/frontend/src/features/libraries/LibraryDetailPage.tsx
+++ b/src/frontend/src/features/libraries/LibraryDetailPage.tsx
@@ -75,7 +75,12 @@ export function LibraryDetailPage() {
       {/* 库名与返回入口都在顶栏面包屑里（实验室 › 文献库 › 库名），页面不再单占一行 */}
       <StatusBanner lib={lib} />
       {canManage ? (
-        <WikiWorkbench pid={lib.project_id ?? undefined} libraryId={lib.id} canManage={canManage} />
+        <WikiWorkbench
+          pid={lib.project_id ?? undefined}
+          libraryId={lib.id}
+          canManage={canManage}
+          canManageDiscovery={canManage}
+        />
       ) : (
         <LibraryBrowse libraryId={lib.id} />
       )}

--- a/src/frontend/src/features/libraries/LiteratureDiscoveryPage.tsx
+++ b/src/frontend/src/features/libraries/LiteratureDiscoveryPage.tsx
@@ -1,0 +1,614 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { toast } from '../../components/ui/Toast';
+import {
+  api,
+  type LiteratureOaCache,
+  type LiteratureSearchHit,
+  type LiteratureSearchRun,
+  type LiteratureSearchRunDetail,
+  type LiteratureTranslation,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import {
+  dispatchablePolarisExtensionPapers,
+  dispatchPolarisExtensionBatch,
+  type PolarisExtensionPaper,
+} from '../../lib/polaris-extension';
+
+const TERMINAL = new Set(['completed', 'partial', 'failed', 'cancelled']);
+const CURRENT_YEAR = new Date().getFullYear();
+const PAGE_SIZE = 20;
+
+type HitSort = 'relevance' | 'novelty' | 'impact' | 'recent' | 'title';
+
+const STATUS_LABELS: Record<string, [string, string]> = {
+  queued: ['等待执行', 'Queued'],
+  running: ['检索中', 'Running'],
+  completed: ['已完成', 'Completed'],
+  partial: ['部分完成', 'Partial'],
+  failed: ['失败', 'Failed'],
+  cancelled: ['已取消', 'Cancelled'],
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  arxiv: 'arXiv',
+  pubmed: 'PubMed',
+  europepmc: 'Europe PMC',
+  openalex: 'OpenAlex',
+  semantic: 'Semantic Scholar',
+  crossref: 'Crossref',
+  sciverse: 'Sciverse',
+  unpaywall: 'Unpaywall',
+  core: 'CORE',
+  hal: 'HAL',
+  base: 'BASE',
+};
+
+const SCORE_DIMENSIONS: Array<[string, string, string]> = [
+  ['relevance', '主题相关性', 'Relevance'],
+  ['evidence_quality', '证据质量', 'Evidence quality'],
+  ['impact', '学术影响', 'Impact'],
+  ['novelty', '创新潜力', 'Novelty'],
+  ['recency', '时效性', 'Recency'],
+];
+
+function numeric(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function percentage(value: unknown): number | null {
+  const number = numeric(value);
+  if (number === null) return null;
+  return Math.round(Math.max(0, Math.min(1, number)) * 100);
+}
+
+function sourceName(value: string): string {
+  return SOURCE_LABELS[value.toLowerCase()] ?? value;
+}
+
+function authorNames(hit: LiteratureSearchHit): string {
+  const names = (hit.authors ?? []).flatMap((author) => {
+    const name = author.name ?? author.display_name ?? author.author_name;
+    return typeof name === 'string' && name.trim() ? [name.trim()] : [];
+  });
+  if (!names.length) return tr('作者未知', 'Unknown authors');
+  return names.length > 4 ? `${names.slice(0, 4).join(', ')} et al.` : names.join(', ');
+}
+
+function scoreReasons(hit: LiteratureSearchHit): string[] {
+  const reasons = hit.scores?.reasons;
+  if (Array.isArray(reasons)) return reasons.map(String).filter(Boolean);
+  const reason = hit.scores?.rationale ?? hit.scores?.reason;
+  return typeof reason === 'string' && reason.trim() ? [reason.trim()] : [];
+}
+
+function venueLabels(hit: LiteratureSearchHit): string[] {
+  const metrics = hit.venue_metric_snapshot;
+  if (!metrics) return [];
+  const values: string[] = [];
+  const quartile = metrics.jcr_quartile ?? metrics.quartile;
+  const casZone = metrics.cas_upgraded_zone ?? metrics.cas_zone;
+  const impactFactor = metrics.impact_factor;
+  if (typeof quartile === 'string' && quartile.trim()) values.push(`JCR ${quartile.toUpperCase()}`);
+  if ((typeof casZone === 'string' || typeof casZone === 'number') && String(casZone).trim()) {
+    values.push(`中科院 ${String(casZone).includes('区') ? casZone : `${casZone}区`}`);
+  }
+  if (metrics.cas_top === true) values.push('Top');
+  if (typeof impactFactor === 'number') values.push(`IF ${impactFactor.toFixed(2)}`);
+  return [...new Set(values)].slice(0, 4);
+}
+
+function translatedFields(translation: LiteratureTranslation | undefined) {
+  return translation?.status === 'ready' ? translation.translated_fields : null;
+}
+
+function progressPercent(run: LiteratureSearchRunDetail): number {
+  const progress = run.progress ?? {};
+  const explicit = numeric(progress.percent);
+  if (explicit !== null) return Math.round(Math.max(0, Math.min(100, explicit)));
+  if (run.status === 'completed' || run.status === 'partial') return 100;
+  if (run.status === 'failed' || run.status === 'cancelled') return 100;
+  const phase = String(progress.phase ?? run.status);
+  if (phase === 'queued') return 4;
+  if (phase === 'retrieving') {
+    const done = numeric(progress.query_completed) ?? 0;
+    const total = numeric(progress.query_total) ?? 0;
+    return total > 0 ? Math.round(8 + (done / total) * 57) : 12;
+  }
+  if (phase === 'ranking') return numeric(progress.pending_rerank) === 0 ? 88 : 74;
+  return run.status === 'running' ? 10 : 0;
+}
+
+function progressMessage(run: LiteratureSearchRunDetail): string {
+  const progress = run.progress ?? {};
+  const phase = String(progress.phase ?? run.status);
+  if (phase === 'queued') return tr('任务已保存，等待检索 Worker 接收', 'Saved and waiting for a search worker');
+  if (phase === 'retrieving') {
+    const source = typeof progress.source === 'string' ? sourceName(progress.source) : null;
+    const done = numeric(progress.query_completed);
+    const total = numeric(progress.query_total);
+    const suffix = done !== null && total !== null ? ` · ${done}/${total}` : '';
+    return source
+      ? tr(`正在从 ${source} 检索${suffix}`, `Searching ${source}${suffix}`)
+      : tr('正在执行多源检索', 'Searching multiple sources');
+  }
+  if (phase === 'ranking') {
+    const count = numeric(progress.pending_rerank) ?? numeric(progress.deduplicated);
+    return count !== null
+      ? tr(`正在复核与精排 ${count} 篇候选文献`, `Reranking ${count} candidates`)
+      : tr('正在复核候选文献并生成分层结果', 'Reranking and tiering candidates');
+  }
+  if (run.status === 'completed') return tr('检索完成，结果已持久化', 'Search completed and results saved');
+  if (run.status === 'partial') return tr('部分来源失败，其余结果已保存', 'Some sources failed; available results were saved');
+  if (run.status === 'failed') return tr('检索失败，请查看来源状态', 'Search failed; inspect source status');
+  if (run.status === 'cancelled') return tr('检索已取消', 'Search cancelled');
+  return tr('正在准备检索', 'Preparing search');
+}
+
+export function eligibleExtensionHits(
+  hits: LiteratureSearchHit[],
+  selected: ReadonlySet<string>,
+  oaCache: ReadonlyMap<string, LiteratureOaCache>,
+): LiteratureSearchHit[] {
+  return hits.filter((hit) => (
+    selected.has(hit.id)
+    && hit.status === 'promoted'
+    && !!hit.paper_id
+    && oaCache.get(hit.id)?.status !== 'ready'
+  ));
+}
+
+export function LiteratureDiscoveryPanel({
+  libraryId,
+  readOnly = false,
+}: {
+  libraryId: string;
+  readOnly?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [topic, setTopic] = useState('');
+  const [requestedCount, setRequestedCount] = useState(50);
+  const [startYear, setStartYear] = useState(CURRENT_YEAR - 10);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState('');
+  const [source, setSource] = useState('');
+  const [hitStatus, setHitStatus] = useState<'' | LiteratureSearchHit['status']>('');
+  const [sort, setSort] = useState<HitSort>('relevance');
+  const [yearFrom, setYearFrom] = useState<number | ''>('');
+  const [yearTo, setYearTo] = useState<number | ''>('');
+  const [page, setPage] = useState(1);
+  const [translationIds, setTranslationIds] = useState<Set<string>>(new Set());
+
+  const libraryQuery = useQuery({
+    queryKey: ['library', libraryId],
+    queryFn: () => api.getLibrary(libraryId),
+    enabled: !!libraryId,
+  });
+  const runsQuery = useQuery({
+    queryKey: ['literature-runs', libraryId],
+    queryFn: () => api.listLiteratureRuns(libraryId, { size: 100 }),
+    enabled: !!libraryId,
+    refetchInterval: 5_000,
+  });
+  const runs = runsQuery.data?.items ?? [];
+  const selectedRunId = activeRunId ?? runs[0]?.id ?? null;
+
+  useEffect(() => {
+    setPage(1);
+    setSelected(new Set());
+  }, [selectedRunId, query, source, hitStatus, sort, yearFrom, yearTo]);
+
+  const runQuery = useQuery({
+    queryKey: ['literature-run', libraryId, selectedRunId],
+    queryFn: () => api.getLiteratureRun(libraryId, selectedRunId!),
+    enabled: !!selectedRunId,
+    refetchInterval: (state) => {
+      const status = state.state.data?.status;
+      return status && !TERMINAL.has(status) ? 2_000 : false;
+    },
+  });
+  const hitsQuery = useQuery({
+    queryKey: ['literature-hits', libraryId, selectedRunId, query, source, hitStatus, sort, yearFrom, yearTo, page],
+    queryFn: () => api.listLiteratureHits(libraryId, selectedRunId!, {
+      q: query.trim() || undefined,
+      source: source || undefined,
+      status: hitStatus || undefined,
+      sort,
+      year_from: yearFrom === '' ? undefined : yearFrom,
+      year_to: yearTo === '' ? undefined : yearTo,
+      page,
+      size: PAGE_SIZE,
+    }),
+    enabled: !!selectedRunId,
+    refetchInterval: runQuery.data && !TERMINAL.has(runQuery.data.status) ? 2_000 : false,
+  });
+  const oaQuery = useQuery({
+    queryKey: ['literature-oa-cache', libraryId, selectedRunId],
+    queryFn: () => api.listLiteratureOaCache(libraryId, selectedRunId!),
+    enabled: !!selectedRunId,
+    refetchInterval: runQuery.data && !TERMINAL.has(runQuery.data.status) ? 3_000 : false,
+  });
+  const oaByHit = useMemo(
+    () => new Map((oaQuery.data ?? []).map((item) => [item.hit_id, item])),
+    [oaQuery.data],
+  );
+
+  const translationQueries = useQueries({
+    queries: [...translationIds].map((hitId) => ({
+      queryKey: ['literature-translation', libraryId, selectedRunId, hitId],
+      queryFn: () => api.getLiteratureTranslation(libraryId, selectedRunId!, hitId),
+      enabled: !!selectedRunId,
+      retry: false,
+      refetchInterval: (state: { state: { data?: LiteratureTranslation } }) => {
+        const status = state.state.data?.status;
+        return status === 'queued' || status === 'running' ? 1_500 : false;
+      },
+    })),
+  });
+  const translations = useMemo(() => {
+    const values = new Map<string, LiteratureTranslation>();
+    translationQueries.forEach((result) => {
+      if (result.data) values.set(result.data.hit_id, result.data);
+    });
+    return values;
+  }, [translationQueries]);
+
+  const startMutation = useMutation({
+    mutationFn: async () => {
+      const fallback = libraryQuery.data?.statement?.trim() || libraryQuery.data?.name || '';
+      const created = await api.createLiteratureRun(libraryId, {
+        topic: topic.trim() || fallback,
+        requested_count: requestedCount,
+        start_year: startYear,
+        end_year: CURRENT_YEAR,
+      });
+      await api.startLiteratureRun(libraryId, created.id);
+      return created;
+    },
+    onSuccess: (run) => {
+      setActiveRunId(run.id);
+      void queryClient.invalidateQueries({ queryKey: ['literature-runs', libraryId] });
+      toast(tr('检索任务已进入队列', 'Search queued'), 'ok');
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : tr('无法开始检索', 'Could not start search'), 'error'),
+  });
+  const translateMutation = useMutation({
+    mutationFn: (hitIds: string[]) => api.translateLiteratureHits(libraryId, selectedRunId!, hitIds),
+    onSuccess: (rows) => {
+      setTranslationIds((old) => new Set([...old, ...rows.map((row) => row.hit_id)]));
+      rows.forEach((row) => queryClient.setQueryData(
+        ['literature-translation', libraryId, selectedRunId, row.hit_id],
+        row,
+      ));
+      toast(tr('翻译任务已提交', 'Translation queued'), 'ok');
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : tr('翻译失败', 'Translation failed'), 'error'),
+  });
+  const promoteMutation = useMutation({
+    mutationFn: (hitIds: string[]) => api.promoteLiteratureHits(libraryId, selectedRunId!, hitIds),
+    onSuccess: (items) => {
+      setSelected(new Set());
+      void queryClient.invalidateQueries({ queryKey: ['literature-hits', libraryId, selectedRunId] });
+      void queryClient.invalidateQueries({ queryKey: ['library-papers', libraryId] });
+      toast(tr(`已将 ${items.length} 篇文献加入论文库`, `${items.length} papers added to the library`), 'ok');
+    },
+    onError: () => toast(tr('筛选入库失败', 'Could not add selected papers'), 'error'),
+  });
+  const cacheMutation = useMutation({
+    mutationFn: (hitIds: string[]) => api.cacheLiteratureOaPdfs(libraryId, selectedRunId!, hitIds),
+    onSuccess: (items) => {
+      void queryClient.invalidateQueries({ queryKey: ['literature-oa-cache', libraryId, selectedRunId] });
+      const ready = items.filter((item) => item.status === 'ready').length;
+      toast(tr(`开放 PDF 缓存完成：${ready}/${items.length}`, `OA cache complete: ${ready}/${items.length}`), 'ok');
+    },
+    onError: () => toast(tr('开放 PDF 缓存失败', 'OA PDF caching failed'), 'error'),
+  });
+  const extensionMutation = useMutation({
+    mutationFn: async (items: LiteratureSearchHit[]) => {
+      const papers: PolarisExtensionPaper[] = items.map((hit) => ({
+        libraryId,
+        paperId: hit.paper_id!,
+        title: hit.title,
+        doi: hit.doi,
+        articleUrl: hit.url,
+        pdfCandidates: hit.pdf_url ? [{ url: hit.pdf_url, source: hit.source, kind: 'oa' }] : [],
+      }));
+      const batch = await api.createDownloadBatch(items.map((hit) => ({
+        library_id: libraryId,
+        paper_id: hit.paper_id!,
+        article_url: hit.url,
+        pdf_candidates: hit.pdf_url ? [{ url: hit.pdf_url, source: hit.source, kind: 'oa' }] : [],
+      })));
+      const dispatchable = dispatchablePolarisExtensionPapers(papers, batch.items);
+      const acknowledged = dispatchable.length > 0
+        ? await dispatchPolarisExtensionBatch({ batchId: batch.id, papers: dispatchable })
+        : false;
+      return { batch, acknowledged, dispatchedCount: dispatchable.length };
+    },
+    onSuccess: ({ batch, acknowledged, dispatchedCount }) => {
+      setSelected(new Set());
+      const skipped = batch.items.filter((item) => item.status === 'skipped').length;
+      toast(
+        dispatchedCount === 0
+          ? tr('所选论文均已有可读 PDF，未向扩展发送重复下载任务', 'Every selected paper already has a readable PDF; no duplicate extension task was sent')
+          : acknowledged
+          ? tr(`已推送 1 个扩展任务，共 ${batch.item_count} 篇${skipped ? `，后端跳过 ${skipped} 篇已有 PDF` : ''}`, `Sent one extension batch with ${batch.item_count} papers`)
+          : tr('下载批次已保存；扩展未即时确认，可稍后通过 API Key 认领', 'Batch saved; the extension can claim it later with the API key'),
+        dispatchedCount === 0 || acknowledged ? 'ok' : 'info',
+      );
+    },
+    onError: () => toast(tr('无法创建扩展下载批次', 'Could not create extension batch'), 'error'),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (runId: string) => api.deleteLiteratureRun(libraryId, runId),
+    onSuccess: (_result, runId) => {
+      if (activeRunId === runId) setActiveRunId(null);
+      void queryClient.invalidateQueries({ queryKey: ['literature-runs', libraryId] });
+      toast(tr('检索历史已永久删除', 'Search history permanently deleted'), 'ok');
+    },
+    onError: () => toast(tr('删除失败；运行中的检索需先取消', 'Delete failed; cancel an active run first'), 'error'),
+  });
+  const cancelMutation = useMutation({
+    mutationFn: (runId: string) => api.cancelLiteratureRun(libraryId, runId),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['literature-run', libraryId, selectedRunId] }),
+    onError: () => toast(tr('取消失败', 'Could not cancel the run'), 'error'),
+  });
+
+  const hits = hitsQuery.data?.items ?? [];
+  const selectedHits = hits.filter((hit) => selected.has(hit.id));
+  const candidateIds = selectedHits.filter((hit) => hit.status === 'candidate').map((hit) => hit.id);
+  const oaCandidateIds = selectedHits
+    .filter((hit) => hit.status === 'candidate' && oaByHit.get(hit.id)?.status !== 'ready')
+    .map((hit) => hit.id);
+  const extensionHits = eligibleExtensionHits(hits, selected, oaByHit);
+  const sourceOptions = runQuery.data?.source_attempts.map((attempt) => attempt.source) ?? [];
+  const allVisibleSelected = hits.length > 0 && hits.every((hit) => selected.has(hit.id));
+
+  const toggleHit = (hitId: string) => setSelected((old) => {
+    const next = new Set(old);
+    if (next.has(hitId)) next.delete(hitId);
+    else next.add(hitId);
+    return next;
+  });
+  const confirmDelete = (run: LiteratureSearchRun) => {
+    if (window.confirm(tr(
+      '永久删除本次检索及其候选结果？此操作不可恢复，已经入库的论文和 PDF 不受影响。',
+      'Permanently delete this run and its candidates? Imported papers and PDFs are kept.',
+    ))) deleteMutation.mutate(run.id);
+  };
+
+  return (
+    <div className="literature-discovery">
+      <header className="literature-discovery-header">
+        <div className="literature-discovery-heading">
+          <div className="row gap8">
+            <Icon name="compass" size={17} />
+            <h2>{tr('多源文献发现', 'Literature discovery')}</h2>
+            {readOnly && <span className="pill sm">{tr('只读', 'Read only')}</span>}
+          </div>
+          <p>{tr('检索结果先进入待筛选池；只有入库后的 PDF 才会解析、向量化并进入 AI 证据链。', 'Results enter a review pool first. PDF parsing and indexing start only after import.')}</p>
+        </div>
+        <button className="btn btn-ghost sm" onClick={() => setHistoryOpen(true)}>
+          <Icon name="clock" size={14} />
+          {tr(`检索历史${runsQuery.data ? ` · ${runsQuery.data.total}` : ''}`, `History${runsQuery.data ? ` · ${runsQuery.data.total}` : ''}`)}
+        </button>
+      </header>
+
+      {!readOnly && (
+        <section className="literature-search-launcher">
+          <label className="literature-search-topic">
+            <span>{tr('检索主题补充', 'Topic override')}</span>
+            <input
+              className="input"
+              value={topic}
+              onChange={(event) => setTopic(event.target.value)}
+              placeholder={tr('留空时使用文献库名称与方向定义', 'Uses the library name and definition when empty')}
+              maxLength={4000}
+            />
+          </label>
+          <label>
+            <span>{tr('返回数量', 'Results')}</span>
+            <input className="input" type="number" min={1} max={200} value={requestedCount} onChange={(event) => setRequestedCount(Math.max(1, Math.min(200, Number(event.target.value) || 1)))} />
+          </label>
+          <label>
+            <span>{tr('起始年份', 'Start year')}</span>
+            <input className="input" type="number" min={1800} max={CURRENT_YEAR} value={startYear} onChange={(event) => setStartYear(Math.max(1800, Math.min(CURRENT_YEAR, Number(event.target.value) || CURRENT_YEAR)))} />
+          </label>
+          <button className="btn btn-primary" disabled={startMutation.isPending} onClick={() => startMutation.mutate()}>
+            <Icon name={startMutation.isPending ? 'refresh' : 'search'} size={15} style={startMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
+            {startMutation.isPending ? tr('正在创建', 'Starting') : tr('开始检索', 'Start search')}
+          </button>
+        </section>
+      )}
+
+      {runQuery.data && (
+        <section className="literature-run-status">
+          <div className="literature-run-summary">
+            <div>
+              <span className={`literature-status-dot is-${runQuery.data.status}`} />
+              <strong>{tr(...(STATUS_LABELS[runQuery.data.status] ?? [runQuery.data.status, runQuery.data.status]))}</strong>
+              <span>{progressMessage(runQuery.data)}</span>
+            </div>
+            <div className="row gap8">
+              <span>{runQuery.data.requested_count} {tr('篇', 'papers')}</span>
+              <span>{runQuery.data.start_year ?? '—'}–{runQuery.data.end_year ?? '—'}</span>
+              {!readOnly && !TERMINAL.has(runQuery.data.status) && (
+                <button className="btn btn-ghost sm" disabled={cancelMutation.isPending} onClick={() => cancelMutation.mutate(runQuery.data!.id)}>
+                  {tr('取消', 'Cancel')}
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="bar"><i style={{ width: `${progressPercent(runQuery.data)}%` }} /></div>
+          <div className="literature-source-progress">
+            {runQuery.data.source_attempts.map((attempt) => (
+              <span key={attempt.id} className={`literature-source-chip is-${attempt.status}`} title={attempt.error_detail ?? attempt.query ?? undefined}>
+                <i />{sourceName(attempt.source)}
+                <b>{attempt.accepted_count}</b>
+              </span>
+            ))}
+          </div>
+          {runQuery.data.error_summary && <div className="literature-run-error">{runQuery.data.error_summary}</div>}
+        </section>
+      )}
+
+      {selectedRunId ? (
+        <>
+          <section className="literature-result-toolbar">
+            <label className="literature-filter-search">
+              <Icon name="search" size={14} />
+              <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder={tr('搜索标题、摘要或 DOI', 'Search title, abstract, or DOI')} />
+            </label>
+            <select className="input" value={source} onChange={(event) => setSource(event.target.value)} aria-label={tr('来源', 'Source')}>
+              <option value="">{tr('全部来源', 'All sources')}</option>
+              {sourceOptions.map((value) => <option key={value} value={value}>{sourceName(value)}</option>)}
+            </select>
+            <select className="input" value={hitStatus} onChange={(event) => setHitStatus(event.target.value as typeof hitStatus)} aria-label={tr('入库状态', 'Import status')}>
+              <option value="">{tr('全部状态', 'All statuses')}</option>
+              <option value="candidate">{tr('待筛选', 'Candidate')}</option>
+              <option value="promoted">{tr('已入库', 'Imported')}</option>
+            </select>
+            <input className="input literature-year-input" type="number" min={1800} max={CURRENT_YEAR} value={yearFrom} placeholder={tr('起始年', 'From')} onChange={(event) => setYearFrom(event.target.value ? Number(event.target.value) : '')} />
+            <input className="input literature-year-input" type="number" min={1800} max={CURRENT_YEAR} value={yearTo} placeholder={tr('截止年', 'To')} onChange={(event) => setYearTo(event.target.value ? Number(event.target.value) : '')} />
+            <select className="input" value={sort} onChange={(event) => setSort(event.target.value as HitSort)} aria-label={tr('排序', 'Sort')}>
+              <option value="relevance">{tr('相关度排序', 'Relevance')}</option>
+              <option value="novelty">{tr('新颖度排序', 'Novelty')}</option>
+              <option value="impact">{tr('影响力排序', 'Impact')}</option>
+              <option value="recent">{tr('最近发现', 'Recent')}</option>
+              <option value="title">{tr('标题排序', 'Title')}</option>
+            </select>
+          </section>
+
+          {!readOnly && (
+            <section className="literature-batch-bar">
+              <label className="row gap8">
+                <input type="checkbox" checked={allVisibleSelected} onChange={() => setSelected(allVisibleSelected ? new Set() : new Set(hits.map((hit) => hit.id)))} />
+                <span>{tr(`已选 ${selected.size} 篇`, `${selected.size} selected`)}</span>
+              </label>
+              <div className="row gap8">
+                <button className="btn btn-soft sm" disabled={!selectedHits.length || translateMutation.isPending} onClick={() => translateMutation.mutate(selectedHits.map((hit) => hit.id))}>
+                  <Icon name={translateMutation.isPending ? 'refresh' : 'chat'} size={13} style={translateMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
+                  {tr('译为中文', 'Translate')}
+                </button>
+                <button className="btn btn-soft sm" disabled={!oaCandidateIds.length || cacheMutation.isPending} onClick={() => cacheMutation.mutate(oaCandidateIds)}>
+                  <Icon name="download" size={13} />
+                  {tr(`缓存 OA PDF · ${oaCandidateIds.length}`, `Cache OA PDFs · ${oaCandidateIds.length}`)}
+                </button>
+                <button className="btn btn-soft sm" disabled={!extensionHits.length || extensionMutation.isPending} title={!extensionHits.length && selected.size ? tr('只有已入库且尚无缓存 PDF 的文献可以推送扩展', 'Only imported papers without a cached PDF can be sent') : undefined} onClick={() => extensionMutation.mutate(extensionHits)}>
+                  <Icon name="share" size={13} />
+                  {tr(`推送扩展 · ${extensionHits.length}`, `Send to extension · ${extensionHits.length}`)}
+                </button>
+                <button className="btn btn-primary sm" disabled={!candidateIds.length || promoteMutation.isPending} onClick={() => promoteMutation.mutate(candidateIds)}>
+                  <Icon name="plus" size={13} />
+                  {tr(`筛选入库 · ${candidateIds.length}`, `Import · ${candidateIds.length}`)}
+                </button>
+              </div>
+            </section>
+          )}
+
+          <div className="literature-results-meta">
+            <span>{tr(`共 ${hitsQuery.data?.total ?? 0} 篇结果`, `${hitsQuery.data?.total ?? 0} results`)}</span>
+            <span>{tr('评分口径：相关性 45% · 证据质量 20% · 影响力 15% · 创新 10% · 时效性 10%', 'Scoring: relevance 45%, evidence 20%, impact 15%, novelty 10%, recency 10%')}</span>
+          </div>
+
+          {hitsQuery.isLoading ? (
+            <div className="literature-result-list">{Array.from({ length: 4 }, (_, index) => <div className="skel" style={{ height: 190 }} key={index} />)}</div>
+          ) : hitsQuery.isError ? (
+            <EmptyState icon="x" title={tr('无法加载检索结果', 'Could not load results')} desc={tr('请检查后端连接后重试。', 'Check the backend connection and retry.')} action={<button className="btn btn-soft sm" onClick={() => void hitsQuery.refetch()}>{tr('重试', 'Retry')}</button>} />
+          ) : !hits.length ? (
+            <EmptyState icon="search" title={tr('没有匹配结果', 'No matching papers')} desc={tr('调整搜索、年份、来源或状态筛选条件。', 'Adjust the search, year, source, or status filters.')} />
+          ) : (
+            <div className="literature-result-list">
+              {hits.map((hit) => {
+                const oa = oaByHit.get(hit.id);
+                const translation = translations.get(hit.id);
+                const translated = translatedFields(translation);
+                const translating = translation?.status === 'queued' || translation?.status === 'running';
+                const overall = percentage(hit.scores?.overall);
+                const labels = venueLabels(hit);
+                const reasons = translated?.inclusion_rationale ?? scoreReasons(hit);
+                return (
+                  <article className={`literature-result${selected.has(hit.id) ? ' is-selected' : ''}`} key={hit.id}>
+                    {!readOnly && <input className="literature-result-check" type="checkbox" checked={selected.has(hit.id)} onChange={() => toggleHit(hit.id)} aria-label={tr('选择文献', 'Select paper')} />}
+                    <div className="literature-result-main">
+                      <div className="literature-result-kicker">
+                        <span className="literature-source-badge">{sourceName(hit.source)}</span>
+                        {hit.year && <span>{hit.year}</span>}
+                        <span>{hit.venue || tr('期刊未知', 'Unknown venue')}</span>
+                        {labels.map((label) => <span className="pill sm" key={label}>{label}</span>)}
+                        {hit.citation_count !== null && <span>{tr(`引用 ${hit.citation_count}`, `${hit.citation_count} citations`)}</span>}
+                      </div>
+                      <h3>{translated?.title || hit.title}</h3>
+                      <div className="literature-result-authors">{authorNames(hit)}</div>
+                      <p className="literature-result-abstract">{translated?.abstract || hit.abstract || tr('该来源未提供摘要。', 'No abstract supplied by this source.')}</p>
+                      <div className="literature-result-links">
+                        {hit.doi && <a href={`https://doi.org/${hit.doi}`} target="_blank" rel="noreferrer">DOI {hit.doi}</a>}
+                        {hit.url && <a href={hit.url} target="_blank" rel="noreferrer">{tr('来源页面', 'Source page')}</a>}
+                        {hit.pdf_url && <a href={hit.pdf_url} target="_blank" rel="noreferrer">PDF</a>}
+                        <span className={`literature-asset-state is-${oa?.status ?? (hit.pdf_url ? 'available' : 'missing')}`}>
+                          {oa?.status === 'ready' ? tr('OA 已缓存', 'OA cached') : oa?.status === 'failed' ? tr('OA 缓存失败', 'OA cache failed') : hit.pdf_url ? tr('发现开放 PDF', 'OA PDF found') : tr('未发现 PDF', 'No PDF found')}
+                        </span>
+                        {hit.status === 'promoted' && <span className="literature-imported"><Icon name="check" size={11} />{tr('已入库', 'Imported')}</span>}
+                      </div>
+                      {!!reasons.length && (
+                        <div className="literature-rationale">
+                          <strong>{tr('入选依据', 'Why it was selected')}</strong>
+                          <span>{reasons.join(' · ')}</span>
+                        </div>
+                      )}
+                    </div>
+                    <aside className="literature-score-panel">
+                      <div className="literature-overall-score"><strong>{overall ?? '—'}</strong><span>{tr('综合分', 'Overall')}</span></div>
+                      {SCORE_DIMENSIONS.map(([key, zh, en]) => {
+                        const value = percentage(hit.scores?.[key]);
+                        return <div className="literature-score-row" key={key}><span>{tr(zh, en)}</span><i><b style={{ width: `${value ?? 0}%` }} /></i><em>{value ?? '—'}</em></div>;
+                      })}
+                      {!readOnly && (
+                        <button className="btn btn-ghost sm" disabled={translating || translateMutation.isPending} onClick={() => translateMutation.mutate([hit.id])}>
+                          <Icon name={translating ? 'refresh' : 'chat'} size={12} style={translating ? { animation: 'spin 1s linear infinite' } : undefined} />
+                          {translating ? tr('翻译中', 'Translating') : translated ? tr('重新翻译', 'Translate again') : tr('译为中文', 'Translate')}
+                        </button>
+                      )}
+                      {translation?.status === 'failed' && <small>{translation.error_code || tr('翻译失败', 'Translation failed')}</small>}
+                    </aside>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+
+          {(hitsQuery.data?.total ?? 0) > PAGE_SIZE && (
+            <div className="literature-pagination">
+              <button className="btn btn-ghost sm" disabled={page <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>{tr('上一页', 'Previous')}</button>
+              <span>{page} / {Math.ceil((hitsQuery.data?.total ?? 0) / PAGE_SIZE)}</span>
+              <button className="btn btn-ghost sm" disabled={page * PAGE_SIZE >= (hitsQuery.data?.total ?? 0)} onClick={() => setPage((value) => value + 1)}>{tr('下一页', 'Next')}</button>
+            </div>
+          )}
+        </>
+      ) : (
+        <EmptyState icon="compass" title={tr('还没有检索记录', 'No searches yet')} desc={readOnly ? tr('该文献库尚未运行文献发现。', 'No discovery run has been created for this library.') : tr('设置返回数量和起始年份，开始第一次多源检索。', 'Choose a result count and start year to begin.')} />
+      )}
+
+      <Modal open={historyOpen} onClose={() => setHistoryOpen(false)} title={tr('全部检索历史', 'Search history')} sub={libraryQuery.data?.name} width={780}>
+        <div className="literature-history">
+          {runs.map((run) => (
+            <div className={`literature-history-row${selectedRunId === run.id ? ' is-active' : ''}`} key={run.id}>
+              <button onClick={() => { setActiveRunId(run.id); setHistoryOpen(false); }}>
+                <span><strong>{run.topic}</strong><small>{new Date(run.created_at).toLocaleString()} · {run.trigger === 'scheduled' ? tr('每日增量', 'Scheduled') : tr('手动检索', 'Manual')} · {run.requested_count} {tr('篇', 'papers')} · {run.start_year ?? '—'}–{run.end_year ?? '—'}</small></span>
+                <b>{tr(...(STATUS_LABELS[run.status] ?? [run.status, run.status]))}</b>
+              </button>
+              {!readOnly && TERMINAL.has(run.status) && <button className="icon-btn danger" title={tr('永久删除', 'Delete permanently')} onClick={() => confirmDelete(run)}><Icon name="trash" size={14} /></button>}
+            </div>
+          ))}
+          {!runs.length && <div className="empty">{tr('暂无检索历史', 'No search history')}</div>}
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/frontend/src/features/libraries/__tests__/literatureDiscoverySelection.test.ts
+++ b/src/frontend/src/features/libraries/__tests__/literatureDiscoverySelection.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { LiteratureOaCache, LiteratureSearchHit } from '../../../lib/api';
+import { eligibleExtensionHits } from '../LiteratureDiscoveryPage';
+
+function hit(id: string, status: LiteratureSearchHit['status'], paperId: string | null): LiteratureSearchHit {
+  return { id, status, paper_id: paperId } as LiteratureSearchHit;
+}
+
+describe('eligibleExtensionHits', () => {
+  it('requires an explicit selection and a promoted library paper binding', () => {
+    const candidate = hit('candidate', 'candidate', null);
+    const promoted = hit('promoted', 'promoted', 'paper-1');
+    expect(eligibleExtensionHits(
+      [candidate, promoted],
+      new Set(['candidate', 'promoted']),
+      new Map(),
+    )).toEqual([promoted]);
+  });
+
+  it('skips a promoted paper whose OA PDF is already cached', () => {
+    const promoted = hit('promoted', 'promoted', 'paper-1');
+    const cache = { hit_id: 'promoted', status: 'ready' } as LiteratureOaCache;
+    expect(eligibleExtensionHits(
+      [promoted],
+      new Set(['promoted']),
+      new Map([['promoted', cache]]),
+    )).toEqual([]);
+  });
+});

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -13,6 +13,7 @@ import { LibraryChatTab } from './LibraryChatTab';
 import { IngestTab } from './IngestTab';
 import { NotesTab } from './NotesTab';
 import { GovernanceTab } from './GovernanceTab';
+import { LiteratureDiscoveryPanel } from '../libraries/LiteratureDiscoveryPage';
 
 // 图谱与 PPT 弹窗体量大且非默认视图：按需加载
 const GraphTab = lazy(() => import('./GraphTab').then((m) => ({ default: m.GraphTab })));
@@ -31,17 +32,20 @@ const PresentationModal = lazy(() =>
    从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
-type WikiTab = 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'ingest' | 'notes' | 'govern';
+type WikiTab = 'discover' | 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'ingest' | 'notes' | 'govern';
 
 export function WikiWorkbench({
   pid,
   libraryId,
   canManage = false,
+  canManageDiscovery = false,
 }: {
   pid?: string;
   libraryId?: string;
   /** 能否管理这个库（决定共享 Tab 里的管理操作显不显示）；由调用方按 can_manage 传入。 */
   canManage?: boolean;
+  /** 文献发现的写权限独立于一般库管理权限。 */
+  canManageDiscovery?: boolean;
 }) {
   const navigate = useNavigate();
 
@@ -98,7 +102,7 @@ export function WikiWorkbench({
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['papers', 'concepts', 'graph', 'digest', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
+    } else if (tabParam && ['discover', 'papers', 'concepts', 'graph', 'digest', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -161,6 +165,7 @@ export function WikiWorkbench({
       <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<WikiTab>
           options={[
+            ...(libraryId ? [{ v: 'discover' as const, label: tr('发现文献', 'Discover') }] : []),
             { v: 'papers', label: `${tr('论文库', 'Papers')}${total !== undefined ? ` · ${total}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
             { v: 'graph', label: tr('图谱', 'Graph') },
@@ -214,7 +219,9 @@ export function WikiWorkbench({
           minHeight: 480,
         }}
       >
-        {tab === 'papers' ? (
+        {tab === 'discover' && libraryId ? (
+          <LiteratureDiscoveryPanel libraryId={libraryId} readOnly={!canManageDiscovery} />
+        ) : tab === 'papers' ? (
           <PapersTab
             pid={pid}
             libraryId={tabLibraryId}

--- a/src/frontend/src/lib/__tests__/polarisExtension.test.ts
+++ b/src/frontend/src/lib/__tests__/polarisExtension.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPolarisExtensionPayload,
+  dispatchablePolarisExtensionPapers,
+} from '../polaris-extension';
+
+describe('Polaris extension batch payload', () => {
+  it('keeps every paper independently bound inside one batch', () => {
+    let counter = 0;
+    const payload = createPolarisExtensionPayload({
+      batchId: '44444444-4444-4444-8444-444444444444',
+      papers: Array.from({ length: 10 }, (_, index) => ({
+        libraryId: '11111111-1111-4111-8111-111111111111',
+        paperId: `22222222-2222-4222-8222-${String(index).padStart(12, '0')}`,
+        title: `Paper ${index + 1}`,
+        doi: `10.1000/${index + 1}`,
+      })),
+    }, 'https://polaris.example', new Date('2026-08-15T00:00:00Z'), () => `uuid-${counter += 1}`);
+
+    expect(payload.version).toBe(2);
+    expect(payload.backend_batch_id).toBe('44444444-4444-4444-8444-444444444444');
+    expect(payload.papers).toHaveLength(10);
+    expect(new Set(payload.papers.map((paper) => paper.nonce)).size).toBe(10);
+    expect(payload.papers.every((paper) => paper.library_id && paper.paper_id)).toBe(true);
+  });
+
+  it('dispatches only queued bindings without shifting another paper', () => {
+    const papers = [
+      { libraryId: 'library-a', paperId: 'paper-a', title: 'Cached paper' },
+      { libraryId: 'library-a', paperId: 'paper-b', title: 'Queued paper' },
+    ];
+    const result = dispatchablePolarisExtensionPapers(papers, [
+      { library_id: 'library-a', paper_id: 'paper-b', status: 'queued' },
+      { library_id: 'library-a', paper_id: 'paper-a', status: 'skipped' },
+    ]);
+
+    expect(result).toEqual([papers[1]]);
+  });
+});

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1151,6 +1151,180 @@ export interface DirectionLibraryDetail extends DirectionLibrarySummary {
   definition: ProjectDefinition | null;
 }
 
+// ============================================================
+// 文献发现（库内检索、候选筛选、OA 缓存与扩展下载批次）
+// ============================================================
+
+export type LiteratureSearchStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'partial'
+  | 'failed'
+  | 'cancelled';
+
+export interface LiteratureSourceAttempt {
+  id: string;
+  run_id: string;
+  source: string;
+  status: 'pending' | 'running' | 'completed' | 'partial' | 'failed' | 'skipped';
+  query: string | null;
+  cursor: string | null;
+  requested_count: number | null;
+  fetched_count: number;
+  accepted_count: number;
+  retryable: boolean;
+  error_code: string | null;
+  error_detail: string | null;
+  metadata_snapshot: Record<string, unknown> | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LiteratureSearchRun {
+  id: string;
+  library_id: string;
+  created_by: string | null;
+  status: LiteratureSearchStatus;
+  requested_count: number;
+  candidate_budget: number;
+  start_year: number | null;
+  end_year: number | null;
+  topic: string;
+  query_plan: Record<string, unknown> | null;
+  source_config: Record<string, unknown> | null;
+  model_version: string | null;
+  trigger: 'manual' | 'scheduled';
+  schedule_version: number | null;
+  scheduled_for: string | null;
+  progress: Record<string, unknown> | null;
+  error_summary: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LiteratureSearchRunDetail extends LiteratureSearchRun {
+  source_attempts: LiteratureSourceAttempt[];
+}
+
+export interface LiteratureSearchRunPage {
+  items: LiteratureSearchRun[];
+  total: number;
+  page: number;
+  size: number;
+}
+
+export interface LiteratureSearchHit {
+  id: string;
+  run_id: string;
+  paper_id: string | null;
+  status: 'candidate' | 'promoted' | 'dismissed';
+  source: string;
+  dedup_key: string;
+  title: string;
+  abstract: string | null;
+  authors: Array<Record<string, unknown>> | null;
+  year: number | null;
+  venue: string | null;
+  doi: string | null;
+  pmid: string | null;
+  arxiv_id: string | null;
+  semantic_scholar_id: string | null;
+  url: string | null;
+  pdf_url: string | null;
+  oa_status: string | null;
+  citation_count: number | null;
+  scores: Record<string, unknown> | null;
+  venue_metric_snapshot: Record<string, unknown> | null;
+  metadata_snapshot: Record<string, unknown> | null;
+  promoted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LiteratureSearchHitPage {
+  items: LiteratureSearchHit[];
+  total: number;
+  page: number;
+  size: number;
+  sort: string;
+}
+
+export interface LiteratureOaCache {
+  id: string;
+  hit_id: string;
+  status: string;
+  source_url: string | null;
+  final_url: string | null;
+  source: string | null;
+  blob_id: string | null;
+  sha256: string | null;
+  byte_size: number | null;
+  verification: Record<string, unknown> | null;
+  error_code: string | null;
+  error_detail: string | null;
+  attempt_count: number;
+  downloaded_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LiteratureTranslation {
+  id: string;
+  hit_id: string;
+  target_language: string;
+  source_hash: string;
+  model_version: string;
+  status: 'queued' | 'running' | 'ready' | 'failed';
+  translated_fields: {
+    title?: string;
+    abstract?: string | null;
+    inclusion_rationale?: string[];
+  } | null;
+  error_code: string | null;
+  attempt_count: number;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DownloadBatchItem {
+  id: string;
+  batch_id: string;
+  library_id: string;
+  paper_id: string;
+  expected_identity: Record<string, unknown>;
+  article_url: string | null;
+  pdf_candidates: unknown[] | null;
+  status: string;
+  lease_until: string | null;
+  lease_token?: string | null;
+  attempt_count: number;
+  error: string | null;
+  result: Record<string, unknown> | null;
+}
+
+export interface DownloadBatchCreated {
+  id: string;
+  status: string;
+  item_count: number;
+  items: DownloadBatchItem[];
+}
+
+export interface DownloadBatchRead {
+  id: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  items: DownloadBatchItem[];
+}
+
 /** 文献库管理员（后端叫 curator）。 */
 export interface LibraryCuratorRead {
   user_id: string;
@@ -3686,6 +3860,134 @@ export const api = {
   },
   getLibrary(id: string): Promise<DirectionLibraryDetail> {
     return request<DirectionLibraryDetail>(`/libraries/${id}`);
+  },
+  /** 创建文献发现运行；创建只持久化参数，随后需显式 start，避免请求参数被队列层改写。 */
+  createLiteratureRun(
+    libraryId: string,
+    input: {
+      topic: string;
+      requested_count?: number;
+      candidate_budget?: number;
+      start_year?: number | null;
+      end_year?: number | null;
+    },
+  ): Promise<LiteratureSearchRunDetail> {
+    return requestJson<LiteratureSearchRunDetail>(`/libraries/${libraryId}/literature/runs`, 'POST', input);
+  },
+  startLiteratureRun(libraryId: string, runId: string): Promise<LiteratureSearchRun> {
+    return request<LiteratureSearchRun>(`/libraries/${libraryId}/literature/runs/${runId}/start`, {
+      method: 'POST',
+    });
+  },
+  listLiteratureRuns(
+    libraryId: string,
+    opts: { page?: number; size?: number } = {},
+  ): Promise<LiteratureSearchRunPage> {
+    const params = new URLSearchParams({
+      page: String(opts.page ?? 1),
+      size: String(opts.size ?? 20),
+    });
+    return request<LiteratureSearchRunPage>(`/libraries/${libraryId}/literature/runs?${params}`);
+  },
+  getLiteratureRun(libraryId: string, runId: string): Promise<LiteratureSearchRunDetail> {
+    return request<LiteratureSearchRunDetail>(`/libraries/${libraryId}/literature/runs/${runId}`);
+  },
+  listLiteratureHits(
+    libraryId: string,
+    runId: string,
+    opts: {
+      q?: string;
+      source?: string;
+      status?: LiteratureSearchHit['status'];
+      year_from?: number;
+      year_to?: number;
+      sort?: 'relevance' | 'novelty' | 'impact' | 'recent' | 'title';
+      page?: number;
+      size?: number;
+    } = {},
+  ): Promise<LiteratureSearchHitPage> {
+    const params = new URLSearchParams();
+    if (opts.q) params.set('q', opts.q);
+    if (opts.source) params.set('source', opts.source);
+    if (opts.status) params.set('status', opts.status);
+    if (opts.year_from) params.set('year_from', String(opts.year_from));
+    if (opts.year_to) params.set('year_to', String(opts.year_to));
+    if (opts.sort) params.set('sort', opts.sort);
+    params.set('page', String(opts.page ?? 1));
+    params.set('size', String(opts.size ?? 20));
+    return request<LiteratureSearchHitPage>(
+      `/libraries/${libraryId}/literature/runs/${runId}/hits?${params}`,
+    );
+  },
+  cancelLiteratureRun(libraryId: string, runId: string): Promise<LiteratureSearchRun> {
+    return request<LiteratureSearchRun>(`/libraries/${libraryId}/literature/runs/${runId}/cancel`, {
+      method: 'POST',
+    });
+  },
+  deleteLiteratureRun(libraryId: string, runId: string): Promise<void> {
+    return request<void>(`/libraries/${libraryId}/literature/runs/${runId}`, { method: 'DELETE' });
+  },
+  translateLiteratureHits(
+    libraryId: string,
+    runId: string,
+    hitIds: string[],
+    targetLanguage = 'zh-CN',
+  ): Promise<LiteratureTranslation[]> {
+    return requestJson<LiteratureTranslation[]>(
+      `/libraries/${libraryId}/literature/runs/${runId}/translations`,
+      'POST',
+      { hit_ids: hitIds, target_language: targetLanguage },
+    );
+  },
+  getLiteratureTranslation(
+    libraryId: string,
+    runId: string,
+    hitId: string,
+    targetLanguage = 'zh-CN',
+  ): Promise<LiteratureTranslation> {
+    const lang = encodeURIComponent(targetLanguage);
+    return request<LiteratureTranslation>(
+      `/libraries/${libraryId}/literature/runs/${runId}/hits/${hitId}/translation?target_language=${lang}`,
+    );
+  },
+  listLiteratureOaCache(libraryId: string, runId: string): Promise<LiteratureOaCache[]> {
+    return request<LiteratureOaCache[]>(`/libraries/${libraryId}/literature/runs/${runId}/oa-cache`);
+  },
+  cacheLiteratureOaPdfs(
+    libraryId: string,
+    runId: string,
+    hitIds: string[],
+  ): Promise<LiteratureOaCache[]> {
+    return requestJson<LiteratureOaCache[]>(
+      `/libraries/${libraryId}/literature/runs/${runId}/oa-cache`,
+      'POST',
+      { hit_ids: hitIds },
+    );
+  },
+  promoteLiteratureHits(
+    libraryId: string,
+    runId: string,
+    hitIds: string[],
+  ): Promise<LiteratureSearchHit[]> {
+    return requestJson<LiteratureSearchHit[]>(
+      `/libraries/${libraryId}/literature/runs/${runId}/promote`,
+      'POST',
+      { hit_ids: hitIds },
+    );
+  },
+  createDownloadBatch(
+    targets: Array<{
+      library_id: string;
+      paper_id: string;
+      article_url?: string | null;
+      pdf_candidates?: unknown[] | null;
+    }>,
+  ): Promise<DownloadBatchCreated> {
+    return requestJson<DownloadBatchCreated>('/download-batches', 'POST', { targets });
+  },
+  listDownloadBatches(libraryId?: string): Promise<DownloadBatchRead[]> {
+    const query = libraryId ? `?library_id=${encodeURIComponent(libraryId)}` : '';
+    return request<DownloadBatchRead[]>(`/download-batches${query}`);
   },
   /** 新建文献库（P9b：任意登录用户可建；新库 status=pending 待管理员审批激活）。 */
   createLibrary(input: {

--- a/src/frontend/src/lib/polaris-extension.ts
+++ b/src/frontend/src/lib/polaris-extension.ts
@@ -1,0 +1,94 @@
+export interface PolarisExtensionPaper {
+  libraryId: string;
+  paperId: string;
+  title: string;
+  doi?: string | null;
+  articleUrl?: string | null;
+  pdfCandidates?: unknown[] | null;
+}
+
+export interface PolarisExtensionBatch {
+  batchId: string;
+  papers: PolarisExtensionPaper[];
+}
+
+export interface PolarisExtensionBatchItemState {
+  library_id: string;
+  paper_id: string;
+  status: string;
+}
+
+type ExtensionAck = { ok?: boolean; requestId?: string };
+
+function paperBinding(libraryId: string, paperId: string) {
+  return `${libraryId}:${paperId}`;
+}
+
+/**
+ * 后端是下载资格的最终判定方。只把仍处于 queued 的独立论文绑定交给扩展，
+ * 避免已有 PDF 的 skipped 条目进入浏览器任务，也不依赖数组位置匹配论文。
+ */
+export function dispatchablePolarisExtensionPapers(
+  papers: PolarisExtensionPaper[],
+  items: PolarisExtensionBatchItemState[],
+): PolarisExtensionPaper[] {
+  const queued = new Set(
+    items
+      .filter((item) => item.status === 'queued')
+      .map((item) => paperBinding(item.library_id, item.paper_id)),
+  );
+  return papers.filter((paper) => queued.has(paperBinding(paper.libraryId, paper.paperId)));
+}
+
+export function createPolarisExtensionPayload(
+  input: PolarisExtensionBatch,
+  instanceOrigin: string,
+  issuedAt = new Date(),
+  randomUUID: () => string = () => crypto.randomUUID(),
+) {
+  const batchNonce = `${randomUUID()}-${randomUUID()}`;
+  return {
+    version: 2,
+    instance_origin: instanceOrigin,
+    issued_at: issuedAt.toISOString(),
+    expires_at: new Date(issuedAt.getTime() + 10 * 60_000).toISOString(),
+    batch_nonce: batchNonce,
+    backend_batch_id: input.batchId,
+    papers: input.papers.map((paper) => ({
+      nonce: `${randomUUID()}-${randomUUID()}`,
+      library_id: paper.libraryId,
+      paper_id: paper.paperId,
+      identity: { title: paper.title, doi: paper.doi ?? null },
+      article_url: paper.articleUrl ?? null,
+      pdf_candidates: Array.isArray(paper.pdfCandidates) ? paper.pdfCandidates : [],
+    })),
+  };
+}
+
+/**
+ * 将一个后端下载批次交给浏览器扩展。后端批次负责持久化与绑定，页面事件只负责
+ * 即时唤醒扩展；即使扩展未确认，批次仍可由扩展稍后通过用户 API Key 认领。
+ */
+export function dispatchPolarisExtensionBatch(input: PolarisExtensionBatch): Promise<boolean> {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return Promise.resolve(false);
+  const payload = createPolarisExtensionPayload(input, window.location.origin);
+  return new Promise((resolve) => {
+    let settled = false;
+    const eventName = 'polaris:download-batch-ack:v2';
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener(eventName, onAck as EventListener);
+      window.clearTimeout(timer);
+      resolve(ok);
+    };
+    const onAck = (event: Event) => {
+      const detail = (event as CustomEvent<ExtensionAck>).detail;
+      if (detail?.requestId !== payload.batch_nonce) return;
+      finish(detail.ok === true);
+    };
+    const timer = window.setTimeout(() => finish(false), 8_000);
+    document.addEventListener(eventName, onAck as EventListener);
+    document.dispatchEvent(new CustomEvent('polaris:download-batch:v2', { detail: payload }));
+  });
+}

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1423,6 +1423,147 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 }
 .buddy-scroll img { max-width: 100%; height: auto; }
 
+/* ============================================================
+   库内文献发现工作台
+   ============================================================ */
+.literature-discovery {
+  flex: 1; min-width: 0; overflow-y: auto; padding: 18px 20px 28px;
+  background: var(--surface); color: var(--text);
+}
+.literature-discovery-header {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 18px;
+  padding-bottom: 15px; border-bottom: 0.5px solid var(--border);
+}
+.literature-discovery-heading { min-width: 0; }
+.literature-discovery-heading h2 { margin: 0; font-size: 16px; font-weight: 680; letter-spacing: 0; }
+.literature-discovery-heading p {
+  margin: 5px 0 0; color: var(--text-3); font-size: 12px; line-height: 1.55;
+}
+.literature-search-launcher {
+  display: grid; grid-template-columns: minmax(260px, 1fr) 108px 116px auto;
+  gap: 10px; align-items: end; margin: 16px 0; padding: 14px;
+  background: var(--surface-2); border: 0.5px solid var(--border); border-radius: 8px;
+}
+.literature-search-launcher label { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.literature-search-launcher label > span { color: var(--text-3); font-size: 11.5px; font-weight: 600; }
+.literature-search-launcher .btn { height: 38px; }
+.literature-run-status {
+  margin-bottom: 16px; padding: 13px 14px; border: 0.5px solid var(--border);
+  border-left: 3px solid var(--accent); border-radius: 7px; background: var(--surface);
+}
+.literature-run-summary { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 9px; }
+.literature-run-summary > div:first-child { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.literature-run-summary strong { font-size: 12.5px; }
+.literature-run-summary span { color: var(--text-3); font-size: 11.5px; }
+.literature-status-dot { width: 7px; height: 7px; flex-shrink: 0; border-radius: 50%; background: var(--text-4); }
+.literature-status-dot.is-running, .literature-status-dot.is-queued { background: var(--accent); animation: pulse 1.4s ease-in-out infinite; }
+.literature-status-dot.is-completed { background: var(--ok-tx); }
+.literature-status-dot.is-partial { background: var(--warn-tx); }
+.literature-status-dot.is-failed, .literature-status-dot.is-cancelled { background: var(--danger-tx); }
+.literature-source-progress { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 9px; }
+.literature-source-chip {
+  display: inline-flex; align-items: center; gap: 5px; height: 23px; padding: 0 8px;
+  border: 0.5px solid var(--border); border-radius: 6px; color: var(--text-3); font-size: 10.5px;
+  background: var(--surface-2);
+}
+.literature-source-chip i { width: 5px; height: 5px; border-radius: 50%; background: var(--text-4); }
+.literature-source-chip b { color: var(--text-2); font-family: var(--mono); font-size: 10px; }
+.literature-source-chip.is-running i, .literature-source-chip.is-pending i { background: var(--accent); animation: pulse 1.4s ease-in-out infinite; }
+.literature-source-chip.is-completed i { background: var(--ok-tx); }
+.literature-source-chip.is-partial i, .literature-source-chip.is-skipped i { background: var(--warn-tx); }
+.literature-source-chip.is-failed i { background: var(--danger-tx); }
+.literature-run-error { margin-top: 8px; color: var(--danger-tx); font-size: 11px; line-height: 1.45; }
+.literature-result-toolbar {
+  display: grid; grid-template-columns: minmax(210px, 1fr) 142px 128px 92px 92px 136px;
+  gap: 8px; margin-bottom: 10px;
+}
+.literature-result-toolbar .input { width: 100%; height: 34px; font-size: 12px; }
+.literature-filter-search {
+  display: flex; align-items: center; gap: 7px; min-width: 0; height: 34px; padding: 0 10px;
+  background: var(--surface-2); border: 1px solid var(--border-2); border-radius: 8px; color: var(--text-3);
+}
+.literature-filter-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); background: var(--surface); }
+.literature-filter-search input { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; color: var(--text); font: 12px var(--sans); }
+.literature-batch-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  min-height: 42px; margin-bottom: 8px; padding: 6px 10px;
+  border: 0.5px solid var(--border); border-radius: 7px; background: var(--surface-2);
+}
+.literature-batch-bar label { color: var(--text-2); font-size: 12px; font-weight: 600; }
+.literature-batch-bar input, .literature-result-check { accent-color: var(--accent); }
+.literature-results-meta {
+  display: flex; justify-content: space-between; gap: 12px; margin: 8px 1px 10px;
+  color: var(--text-4); font-size: 10.5px;
+}
+.literature-result-list { display: flex; flex-direction: column; gap: 9px; }
+.literature-result {
+  position: relative; display: grid; grid-template-columns: minmax(0, 1fr) 210px; gap: 18px;
+  padding: 15px 16px; border: 0.5px solid var(--border); border-radius: 7px;
+  background: var(--surface); transition: border-color 0.12s, background 0.12s;
+}
+.literature-result:hover { border-color: var(--border-strong); }
+.literature-result.is-selected { border-color: var(--accent-soft-2); background: var(--accent-soft-row); }
+.literature-result-check { position: absolute; top: 17px; left: 16px; width: 14px; height: 14px; margin: 0; }
+.literature-result-check + .literature-result-main { padding-left: 23px; }
+.literature-result-main { min-width: 0; }
+.literature-result-kicker { display: flex; align-items: center; gap: 7px; min-height: 19px; flex-wrap: wrap; color: var(--text-4); font-size: 10.5px; }
+.literature-source-badge { color: var(--accent-text); font-weight: 700; }
+.literature-result h3 { margin: 6px 0 3px; font-size: 14px; line-height: 1.42; font-weight: 660; letter-spacing: 0; }
+.literature-result-authors { color: var(--text-3); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.literature-result-abstract {
+  display: -webkit-box; margin: 9px 0 0; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 4;
+  color: var(--text-2); font-size: 12px; line-height: 1.65;
+}
+.literature-result-links { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 9px; font-size: 10.5px; }
+.literature-result-links a { color: var(--accent-text); text-decoration: none; }
+.literature-result-links a:hover { text-decoration: underline; }
+.literature-asset-state, .literature-imported { display: inline-flex; align-items: center; gap: 4px; color: var(--text-3); }
+.literature-asset-state.is-ready, .literature-imported { color: var(--ok-tx); }
+.literature-asset-state.is-failed { color: var(--danger-tx); }
+.literature-rationale { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 8px; margin-top: 9px; padding-top: 9px; border-top: 0.5px dashed var(--border); font-size: 11px; line-height: 1.5; }
+.literature-rationale strong { color: var(--text-3); }
+.literature-rationale span { color: var(--text-2); }
+.literature-score-panel { display: flex; flex-direction: column; gap: 7px; padding-left: 16px; border-left: 0.5px solid var(--border); }
+.literature-overall-score { display: flex; align-items: baseline; gap: 6px; margin-bottom: 2px; }
+.literature-overall-score strong { color: var(--accent-text); font: 700 24px/1 var(--mono); }
+.literature-overall-score span { color: var(--text-4); font-size: 10px; }
+.literature-score-row { display: grid; grid-template-columns: 62px minmax(0, 1fr) 24px; align-items: center; gap: 6px; color: var(--text-3); font-size: 10px; }
+.literature-score-row i { height: 4px; overflow: hidden; border-radius: 3px; background: var(--surface-3); }
+.literature-score-row i b { display: block; height: 100%; border-radius: inherit; background: var(--accent); }
+.literature-score-row em { color: var(--text-2); font-style: normal; font-family: var(--mono); text-align: right; }
+.literature-score-panel .btn { align-self: flex-start; margin-top: 4px; }
+.literature-score-panel small { color: var(--danger-tx); font-size: 9.5px; }
+.literature-pagination { display: flex; justify-content: center; align-items: center; gap: 10px; margin-top: 14px; color: var(--text-3); font-size: 11px; }
+.literature-history { display: flex; flex-direction: column; gap: 6px; }
+.literature-history-row { display: flex; gap: 6px; align-items: stretch; border: 0.5px solid var(--border); border-radius: 7px; background: var(--surface); }
+.literature-history-row.is-active { border-color: var(--accent-soft-2); background: var(--accent-soft-row); }
+.literature-history-row > button:first-child { display: flex; flex: 1; align-items: center; justify-content: space-between; gap: 16px; min-width: 0; padding: 10px 12px; border: 0; background: transparent; color: inherit; cursor: pointer; text-align: left; }
+.literature-history-row > button:first-child span { display: flex; flex-direction: column; min-width: 0; }
+.literature-history-row strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.literature-history-row small { margin-top: 4px; color: var(--text-4); font-size: 10.5px; }
+.literature-history-row b { flex-shrink: 0; color: var(--text-3); font-size: 10.5px; font-weight: 600; }
+
+@media (max-width: 1100px) {
+  .literature-search-launcher { grid-template-columns: minmax(220px, 1fr) 100px 110px; }
+  .literature-search-launcher .btn { grid-column: 1 / -1; justify-content: center; }
+  .literature-result-toolbar { grid-template-columns: minmax(220px, 1fr) repeat(2, 130px); }
+  .literature-year-input { max-width: none; }
+}
+
+@media (max-width: 700px) {
+  .literature-discovery { padding: 14px 12px 24px; }
+  .literature-discovery-header, .literature-run-summary, .literature-batch-bar, .literature-results-meta { align-items: stretch; flex-direction: column; }
+  .literature-search-launcher, .literature-result-toolbar { display: grid; grid-template-columns: 1fr; }
+  .literature-search-launcher .btn { grid-column: auto; }
+  .literature-batch-bar > div { align-items: stretch; flex-direction: column; }
+  .literature-batch-bar .btn { justify-content: center; width: 100%; }
+  .literature-result { grid-template-columns: minmax(0, 1fr); gap: 12px; padding: 14px; }
+  .literature-result-check { top: 16px; left: 14px; }
+  .literature-score-panel { padding: 11px 0 0; border-left: 0; border-top: 0.5px solid var(--border); }
+  .literature-score-row { grid-template-columns: 72px minmax(0, 1fr) 28px; }
+  .literature-history-row > button:first-child { align-items: flex-start; flex-direction: column; gap: 5px; }
+}
+
 /* PolarisBuddy 思考中的标识呼吸。幅度刻意很小：余光能看见，读答案时不抢注意力。 */
 @keyframes buddy-breathe {
   0%, 100% { opacity: 1; transform: scale(1); }


### PR DESCRIPTION
## Summary

- add **Discover** as the leftmost tab inside each managed or public library workspace
- render persisted discovery runs with live phase and per-source progress, paginated candidates, search/year/source/status filters, ranking dimensions, venue metrics, rationale, DOI/OA state, and a compact history modal
- expose translation, OA cache, candidate promotion, cancellation, and permanent history deletion with explicit loading and error feedback
- create one persistent Polaris extension batch for selected, already-promoted papers while preserving independent library/paper bindings and skipping server-cached PDFs
- add server-side publication-year filters so result totals and pagination remain correct

## Authorization and lifecycle

- reuses the existing can_manage contract (platform admins, library creators, and curators); public-library readers receive a strictly read-only discovery view
- discovery hits remain a review pool: no Paper/PDF asset parsing or vectorization is triggered until promotion into the library
- no database migration is required

## Merge independence

- based directly on main at 851abc8
- does not depend on #530 or #531 and can be merged independently

## Verification

- frontend test suite: 94 passed
- frontend production build: passed
- literature discovery API and extension batch protocol: 6 passed
- Ruff for touched backend files: passed
- Chrome visual checks: 1360px desktop, 390px mobile, history modal, and public read-only view

Closes #532
## Follow-up fix

The backend batch is now the source of truth for extension dispatch. The page sends only `queued` library and paper bindings, keeps cached `skipped` items in the durable batch history, and emits no extension event when every selected paper already has a readable PDF. Binding IDs, rather than list positions, determine which papers are sent.

The updated branch passes 95 frontend tests, the production build, and 12 focused discovery and download protocol tests.