### PR TITLE
feat(admin): add literature search settings workspace

### DIFF
--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { ExperimentSettings } from './ExperimentSettings';
+import { LiteratureSearchSettingsPanel } from './LiteratureSearchSettings';
 import { FeedbackTab } from '../feedback/FeedbackTab';
 import { tr } from '../../lib/i18n';
 import { api, isAdmin } from '../../lib/api';
@@ -15,9 +16,9 @@ import { CodesTab, DailyCategoriesTab, LlmTab, UsageTab, UsersTab } from './Sett
    各标签页组件仍住在 SettingsPage.tsx（与个人设置共用一批内部小组件），这里只负责壳层。
    ============================================================ */
 
-type AdminTab = 'llm' | 'experiment' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
+type AdminTab = 'llm' | 'literature' | 'experiment' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
 
-const ADMIN_TABS: AdminTab[] = ['llm', 'experiment', 'daily', 'users', 'codes', 'feedback', 'usage'];
+const ADMIN_TABS: AdminTab[] = ['llm', 'literature', 'experiment', 'daily', 'users', 'codes', 'feedback', 'usage'];
 
 export function AdminSettingsPage() {
   const { data: me, isLoading } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
@@ -40,6 +41,7 @@ export function AdminSettingsPage() {
 
   const items: { v: AdminTab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
+    { v: 'literature', label: tr('文献检索', 'Literature search') },
     { v: 'experiment', label: tr('实验设置', 'Experiments') },
     { v: 'daily', label: tr('每日论文', 'Daily papers') },
     ...(guest ? [] : [{ v: 'users' as const, label: tr('用户管理', 'Users') }]),
@@ -66,6 +68,7 @@ export function AdminSettingsPage() {
             <Segmented options={items} value={shownTab} onChange={setTab} />
           </div>
           {shownTab === 'llm' && <LlmTab />}
+          {shownTab === 'literature' && <LiteratureSearchSettingsPanel />}
           {shownTab === 'experiment' && <ExperimentSettings />}
           {shownTab === 'daily' && <DailyCategoriesTab />}
           {shownTab === 'users' && !guest && <UsersTab />}

--- a/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
+++ b/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
@@ -1,0 +1,577 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { FormField } from '../../components/ui/FormField';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { Switch } from '../../components/ui/Switch';
+import { toast } from '../../components/ui/Toast';
+import {
+  ApiError,
+  api,
+  type LiteratureProviderCredentialCreate,
+  type LiteratureProviderCredentialUpdate,
+  type LiteratureProviderHealth,
+  type LiteratureProviderKeyStatus,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import {
+  CREDENTIAL_SOURCES,
+  SCORE_DIMENSIONS,
+  SEARCH_SOURCES,
+  buildLiteratureSettingsUpdate,
+  draftFrom,
+  sourceById,
+  validateLiteratureSettingsDraft,
+  type LiteratureSettingsDraft,
+  type SourceDefinition,
+} from './literatureSettingsModel';
+
+function errorText(error: unknown): string {
+  if (error instanceof ApiError) {
+    const code = error.message.split(':')[0];
+    if (code === 'INVALID_LITERATURE_SETTING') return tr('设置字段无效，请检查数值范围。', 'A setting is invalid; check the value range.');
+    if (code === 'INVALID_LITERATURE_CREDENTIAL') return tr('密钥内容或来源无效。', 'The credential or provider is invalid.');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatTime(timestamp: number | null | undefined): string {
+  if (!timestamp) return tr('尚未测试', 'Not tested');
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp * 1000));
+}
+
+function HealthBadge({ health }: { health: LiteratureProviderHealth | null | undefined }) {
+  if (!health) return <span className="pill sm">{tr('未测试', 'Untested')}</span>;
+  return (
+    <span
+      className="pill sm"
+      title={`${health.detail} · ${formatTime(health.checked_at)}`}
+      style={health.ok
+        ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+        : { background: 'var(--danger-bg)', color: 'var(--danger-tx)' }}
+    >
+      <span className="dot" />
+      {health.ok ? tr('可用', 'Available') : tr('失效', 'Failed')}
+    </span>
+  );
+}
+
+interface CredentialModalState {
+  mode: 'create' | 'edit';
+  source: string;
+  credential?: LiteratureProviderKeyStatus;
+}
+
+interface CredentialDraft {
+  label: string;
+  secret: string;
+  enabled: boolean;
+}
+
+const EMPTY_CREDENTIAL: CredentialDraft = { label: '', secret: '', enabled: true };
+
+export function LiteratureSearchSettingsPanel() {
+  const queryClient = useQueryClient();
+  const settingsQuery = useQuery({
+    queryKey: ['admin-literature-search-settings'],
+    queryFn: () => api.getLiteratureSearchSettings(),
+    retry: false,
+  });
+  const [draft, setDraft] = useState<LiteratureSettingsDraft | null>(null);
+  const [badField, setBadField] = useState<string | null>(null);
+  const [credentialModal, setCredentialModal] = useState<CredentialModalState | null>(null);
+  const [credentialDraft, setCredentialDraft] = useState<CredentialDraft>(EMPTY_CREDENTIAL);
+  const [deleteCredential, setDeleteCredential] = useState<LiteratureProviderKeyStatus | null>(null);
+
+  useEffect(() => {
+    if (settingsQuery.data && draft === null) setDraft(draftFrom(settingsQuery.data));
+  }, [draft, settingsQuery.data]);
+
+  const shown = draft ?? (settingsQuery.data ? draftFrom(settingsQuery.data) : null);
+  const storedDraft = useMemo(
+    () => (settingsQuery.data ? draftFrom(settingsQuery.data) : null),
+    [settingsQuery.data],
+  );
+  const dirty = !!shown && !!storedDraft && JSON.stringify(shown) !== JSON.stringify(storedDraft);
+  const credentials = settingsQuery.data?.provider_keys ?? {};
+  const credentialSources = useMemo(() => {
+    const known = new Set(CREDENTIAL_SOURCES.map((source) => source.id));
+    const legacy = Object.keys(credentials)
+      .filter((source) => source !== 'arxiv' && !known.has(source))
+      .sort()
+      .map(sourceById);
+    return [...CREDENTIAL_SOURCES, ...legacy];
+  }, [credentials]);
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['admin-literature-search-settings'] });
+
+  const saveMutation = useMutation({
+    mutationFn: (value: LiteratureSettingsDraft) => api.setLiteratureSearchSettings(buildLiteratureSettingsUpdate(value)),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(['admin-literature-search-settings'], saved);
+      setDraft(draftFrom(saved));
+      setBadField(null);
+      toast(tr('文献检索设置已保存', 'Literature search settings saved'), 'ok');
+    },
+    onError: (error) => toast(`${tr('保存失败', 'Save failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const providerTestMutation = useMutation({
+    mutationFn: (sourceId: string) => {
+      const source = sourceById(sourceId);
+      return api.testLiteratureProvider(sourceId, source.testQuery);
+    },
+    onSuccess: (result) => {
+      void invalidate();
+      toast(
+        result.ok
+          ? tr(`${sourceById(result.source).zh} 连接成功，${result.latency_ms} ms`, `${sourceById(result.source).en} connected in ${result.latency_ms} ms`)
+          : tr(`${sourceById(result.source).zh} 连接失败：${result.detail}`, `${sourceById(result.source).en} failed: ${result.detail}`),
+        result.ok ? 'ok' : 'error',
+      );
+    },
+    onError: (error) => toast(`${tr('测试失败', 'Test failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const createCredentialMutation = useMutation({
+    mutationFn: (input: LiteratureProviderCredentialCreate) => api.createLiteratureProviderCredential(input),
+    onSuccess: () => {
+      setCredentialModal(null);
+      void invalidate();
+      toast(tr('密钥已加密保存', 'Credential saved encrypted'), 'ok');
+    },
+    onError: (error) => toast(`${tr('保存失败', 'Save failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const updateCredentialMutation = useMutation({
+    mutationFn: ({ id, input }: { id: string; input: LiteratureProviderCredentialUpdate }) => api.updateLiteratureProviderCredential(id, input),
+    onSuccess: () => {
+      setCredentialModal(null);
+      void invalidate();
+      toast(tr('密钥设置已更新', 'Credential updated'), 'ok');
+    },
+    onError: (error) => toast(`${tr('更新失败', 'Update failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const toggleCredentialMutation = useMutation({
+    mutationFn: (credential: LiteratureProviderKeyStatus) => api.updateLiteratureProviderCredential(credential.id, { enabled: !credential.enabled }),
+    onSuccess: (credential) => {
+      void invalidate();
+      toast(credential.enabled ? tr('密钥已启用', 'Credential enabled') : tr('密钥已停用', 'Credential disabled'), 'ok');
+    },
+    onError: (error) => toast(`${tr('操作失败', 'Operation failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const credentialTestMutation = useMutation({
+    mutationFn: (credential: LiteratureProviderKeyStatus) => api.testLiteratureProviderCredential(credential.id, sourceById(credential.source).testQuery),
+    onSuccess: (result) => {
+      void invalidate();
+      toast(
+        result.ok ? tr(`密钥可用，${result.latency_ms} ms`, `Credential works, ${result.latency_ms} ms`) : tr(`密钥测试失败：${result.detail}`, `Credential test failed: ${result.detail}`),
+        result.ok ? 'ok' : 'error',
+      );
+    },
+    onError: (error) => toast(`${tr('测试失败', 'Test failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const deleteCredentialMutation = useMutation({
+    mutationFn: (id: string) => api.deleteLiteratureProviderCredential(id),
+    onSuccess: () => {
+      setDeleteCredential(null);
+      void invalidate();
+      toast(tr('密钥已删除', 'Credential deleted'), 'ok');
+    },
+    onError: (error) => toast(`${tr('删除失败', 'Delete failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const openCreateCredential = (source: string) => {
+    setCredentialDraft(EMPTY_CREDENTIAL);
+    setCredentialModal({ mode: 'create', source });
+  };
+
+  const openEditCredential = (credential: LiteratureProviderKeyStatus) => {
+    setCredentialDraft({ label: credential.label ?? '', secret: '', enabled: credential.enabled });
+    setCredentialModal({ mode: 'edit', source: credential.source, credential });
+  };
+
+  const saveCredential = () => {
+    if (!credentialModal) return;
+    const label = credentialDraft.label.trim() || null;
+    if (credentialModal.mode === 'create') {
+      if (!credentialDraft.secret.trim()) return;
+      createCredentialMutation.mutate({
+        source: credentialModal.source,
+        secret: credentialDraft.secret.trim(),
+        label,
+        enabled: credentialDraft.enabled,
+      });
+      return;
+    }
+    const input: LiteratureProviderCredentialUpdate = {
+      label,
+      enabled: credentialDraft.enabled,
+    };
+    if (credentialDraft.secret.trim()) input.secret = credentialDraft.secret.trim();
+    updateCredentialMutation.mutate({ id: credentialModal.credential!.id, input });
+  };
+
+  const saveSettings = () => {
+    if (!shown) return;
+    const invalid = validateLiteratureSettingsDraft(shown);
+    setBadField(invalid);
+    if (invalid) {
+      toast(tr('请先修正标出的检索设置', 'Fix the highlighted search settings first'), 'error');
+      return;
+    }
+    saveMutation.mutate(shown);
+  };
+
+  if (settingsQuery.isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (settingsQuery.isError || !shown) {
+    return (
+      <div className="card card-pad empty">
+        {tr('无法加载文献检索设置（后端不可用或无权限）', 'Failed to load literature search settings (backend unavailable or no permission)')}
+        <div style={{ marginTop: 10 }}>
+          <button className="btn btn-soft sm" onClick={() => void settingsQuery.refetch()}>{tr('重试', 'Retry')}</button>
+        </div>
+      </div>
+    );
+  }
+
+  const enabledSourceCount = shown.sources.length;
+  const configuredKeyCount = Object.values(credentials).reduce((total, pool) => total + pool.length, 0);
+  const healthyKeyCount = Object.values(credentials).flat().filter((credential) => credential.health?.ok).length;
+  const credentialBusy = createCredentialMutation.isPending || updateCredentialMutation.isPending;
+
+  return (
+    <div className="literature-settings-stack">
+      <div className="literature-settings-summary">
+        <div>
+          <div className="section-h">
+            <Icon name="search" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('文献发现运行基线', 'Literature discovery baseline')}
+          </div>
+          <div className="literature-settings-intro">
+            {tr(
+              '这些是所有文献库新建检索的默认值。文献库自己的关键词、排除词和评分说明仍作为检索式生成与精排依据。',
+              'These defaults seed every new library search. Each library’s keywords, exclusions, and scoring rubric still guide query generation and reranking.',
+            )}
+          </div>
+        </div>
+        <div className="literature-settings-stats" aria-label={tr('配置概览', 'Configuration summary')}>
+          <div><strong>{enabledSourceCount}</strong><span>{tr('启用来源', 'sources')}</span></div>
+          <div><strong>{configuredKeyCount}</strong><span>{tr('已存密钥', 'keys')}</span></div>
+          <div><strong>{healthyKeyCount}</strong><span>{tr('测试可用', 'healthy')}</span></div>
+        </div>
+      </div>
+
+      <div className="settings-main-side">
+        <section className="card card-pad">
+          <div className="section-h" style={{ marginBottom: 16 }}>
+            <Icon name="sliders" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('检索运行', 'Retrieval run')}
+          </div>
+          <div className="settings-fields literature-settings-fields-compact">
+            <FormField
+              label={tr('返回数量', 'Result count')}
+              hint={tr('每次精排后保留 1–200 篇。', 'Keep 1–200 papers after reranking.')}
+              error={badField === 'requested_count' ? tr('请输入 1–200 的整数', 'Enter an integer from 1 to 200') : null}
+            >
+              <input className="input mono" type="number" min={1} max={200} value={shown.requested_count} onChange={(event) => setDraft({ ...shown, requested_count: Number(event.target.value) })} />
+            </FormField>
+            <FormField
+              label={tr('候选预算', 'Candidate budget')}
+              hint={tr('多源去重与复核前的候选上限。', 'Candidate cap before deduplication and review.')}
+              error={badField === 'candidate_budget' || badField === 'candidate_budget_lt_requested' ? tr('应为 1–1000，且不小于返回数量', 'Use 1–1000 and not less than result count') : null}
+            >
+              <input className="input mono" type="number" min={1} max={1000} value={shown.candidate_budget} onChange={(event) => setDraft({ ...shown, candidate_budget: Number(event.target.value) })} />
+            </FormField>
+            <FormField
+              label={tr('默认起始年份', 'Default start year')}
+              hint={tr('留空表示不限。文献库检索时可覆盖。', 'Empty means no limit; library searches may override it.')}
+              error={badField === 'start_year' || badField === 'year_window' ? tr('年份范围无效', 'Invalid year range') : null}
+            >
+              <input className="input mono" type="number" min={1800} max={3000} placeholder="2016" value={shown.start_year ?? ''} onChange={(event) => setDraft({ ...shown, start_year: event.target.value ? Number(event.target.value) : null })} />
+            </FormField>
+            <FormField
+              label={tr('默认结束年份', 'Default end year')}
+              hint={tr('留空表示截至当前。', 'Empty means through the present.')}
+              error={badField === 'end_year' || badField === 'year_window' ? tr('年份范围无效', 'Invalid year range') : null}
+            >
+              <input className="input mono" type="number" min={1800} max={3000} placeholder={String(new Date().getFullYear())} value={shown.end_year ?? ''} onChange={(event) => setDraft({ ...shown, end_year: event.target.value ? Number(event.target.value) : null })} />
+            </FormField>
+          </div>
+        </section>
+
+        <section className="card card-pad">
+          <div className="section-h" style={{ marginBottom: 6 }}>
+            <Icon name="chart" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('评分标准', 'Scoring weights')}
+          </div>
+          <div className="literature-settings-intro" style={{ marginBottom: 12 }}>
+            {tr('沿用 YFR 五维评分基线；可按科研方向调整，系统会在排序时归一化。', 'Uses the YFR five-dimension baseline; tune it by research direction and ranking will normalize it.')}
+          </div>
+          <div className="literature-weight-grid">
+            {SCORE_DIMENSIONS.map((dimension) => (
+              <label key={dimension.id} className="literature-weight-row">
+                <span>{tr(dimension.zh, dimension.en)}</span>
+                <input
+                  className="input mono"
+                  type="number"
+                  min={0}
+                  step={0.05}
+                  value={shown.score_weights[dimension.id] ?? 0}
+                  onChange={(event) => setDraft({
+                    ...shown,
+                    score_weights: { ...shown.score_weights, [dimension.id]: Number(event.target.value) },
+                  })}
+                />
+              </label>
+            ))}
+          </div>
+          {badField === 'score_weights' && <div className="field-error" style={{ marginTop: 8 }}>{tr('权重必须为非负数，且至少一项大于 0', 'Weights must be non-negative and at least one must be positive')}</div>}
+        </section>
+      </div>
+
+      <section className="card card-pad">
+        <div className="section-h" style={{ marginBottom: 6 }}>
+          <Icon name="server" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('检索来源', 'Search sources')}
+        </div>
+        <div className="literature-settings-intro" style={{ marginBottom: 14 }}>
+          {tr('勾选结果会实时成为新检索的来源快照。运行中的历史检索不受后续修改影响。', 'Enabled providers are snapshotted into new searches. Existing runs are unaffected by later changes.')}
+        </div>
+        {badField === 'sources' && <div className="field-error" style={{ marginBottom: 10 }}>{tr('至少启用一个检索来源', 'Enable at least one search source')}</div>}
+        <div className="literature-source-grid">
+          {SEARCH_SOURCES.map((source) => {
+            const enabled = shown.sources.includes(source.id);
+            const health = settingsQuery.data?.provider_health[source.id];
+            const testing = providerTestMutation.isPending && providerTestMutation.variables === source.id;
+            return (
+              <div key={source.id} className={`literature-source-card${enabled ? ' enabled' : ''}`}>
+                <div className="row" style={{ justifyContent: 'space-between', gap: 12 }}>
+                  <div className="row gap8">
+                    <strong>{source.zh}</strong>
+                    {source.credentialMode === 'none' && <span className="pill sm">{tr('免密钥', 'No key')}</span>}
+                    <HealthBadge health={health} />
+                  </div>
+                  <Switch
+                    checked={enabled}
+                    onChange={(checked) => {
+                      setBadField(null);
+                      setDraft({
+                        ...shown,
+                        sources: checked
+                          ? SEARCH_SOURCES.filter((item) => item.id === source.id || shown.sources.includes(item.id)).map((item) => item.id)
+                          : shown.sources.filter((id) => id !== source.id),
+                      });
+                    }}
+                    aria-label={tr(`${checkedLabel(enabled)} ${source.zh}`, `${checkedLabelEn(enabled)} ${source.en}`)}
+                  />
+                </div>
+                <p>{tr(source.descriptionZh, source.descriptionEn)}</p>
+                <button className="btn btn-soft sm" disabled={providerTestMutation.isPending} onClick={() => providerTestMutation.mutate(source.id)}>
+                  <Icon name={testing ? 'refresh' : 'play'} size={12} style={testing ? { animation: 'spin 1s linear infinite' } : undefined} />
+                  {testing ? tr('测试中…', 'Testing…') : tr('测试来源', 'Test source')}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="card card-pad">
+        <div className="row literature-credentials-heading">
+          <div>
+            <div className="section-h">
+              <Icon name="shield" size={15} style={{ color: 'var(--accent)' }} />
+              {tr('来源凭据池', 'Provider credential pools')}
+            </div>
+            <div className="literature-settings-intro">
+              {tr('密钥加密保存且永不回传明文。同一来源配置多个密钥时，后端按请求轮询。', 'Secrets are encrypted and never returned. Multiple credentials for one provider rotate across requests.')}
+            </div>
+          </div>
+        </div>
+        <div className="literature-credential-groups">
+          {credentialSources.map((source) => (
+            <CredentialGroup
+              key={source.id}
+              source={source}
+              credentials={credentials[source.id] ?? []}
+              providerHealth={settingsQuery.data?.provider_health[source.id]}
+              testingId={credentialTestMutation.isPending ? credentialTestMutation.variables?.id : null}
+              togglingId={toggleCredentialMutation.isPending ? toggleCredentialMutation.variables?.id : null}
+              onAdd={() => openCreateCredential(source.id)}
+              onEdit={openEditCredential}
+              onDelete={setDeleteCredential}
+              onTest={(credential) => credentialTestMutation.mutate(credential)}
+              onToggle={(credential) => toggleCredentialMutation.mutate(credential)}
+              onTestProvider={() => providerTestMutation.mutate(source.id)}
+              providerTesting={providerTestMutation.isPending && providerTestMutation.variables === source.id}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="literature-settings-savebar">
+        <div>
+          <strong>{dirty ? tr('有未保存的检索设置', 'Unsaved search settings') : tr('检索设置已同步', 'Search settings are in sync')}</strong>
+          <span>{tr('凭据增删改会单独即时保存。', 'Credential changes save immediately.')}</span>
+        </div>
+        <button className="btn btn-primary" disabled={!dirty || saveMutation.isPending} onClick={saveSettings}>
+          {saveMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存检索设置', 'Save search settings')}
+        </button>
+      </div>
+
+      <Modal
+        open={credentialModal !== null}
+        onClose={() => !credentialBusy && setCredentialModal(null)}
+        title={credentialModal?.mode === 'edit' ? tr('编辑来源密钥', 'Edit provider credential') : tr('新增来源密钥', 'Add provider credential')}
+        sub={credentialModal ? tr(`${sourceById(credentialModal.source).zh} · 密钥只写不读`, `${sourceById(credentialModal.source).en} · secrets are write-only`) : undefined}
+        width={500}
+        footer={
+          <>
+            <button className="btn btn-ghost" disabled={credentialBusy} onClick={() => setCredentialModal(null)}>{tr('取消', 'Cancel')}</button>
+            <button className="btn btn-primary" disabled={credentialBusy || (credentialModal?.mode === 'create' && !credentialDraft.secret.trim())} onClick={saveCredential}>
+              {credentialBusy ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+            </button>
+          </>
+        }
+      >
+        <FormField label={tr('密钥标签', 'Credential label')} hint={tr('用于区分同一来源的多个密钥，例如“实验室主账号”。', 'Distinguishes keys in the same pool, such as “Lab primary”.')}>
+          <input className="input" maxLength={120} value={credentialDraft.label} placeholder={tr('可选', 'Optional')} onChange={(event) => setCredentialDraft({ ...credentialDraft, label: event.target.value })} />
+        </FormField>
+        <FormField
+          label={tr(credentialModal?.mode === 'edit' ? '替换密钥' : 'API Key / Token', credentialModal?.mode === 'edit' ? 'Replacement secret' : 'API key / token')}
+          hint={credentialModal?.mode === 'edit' ? tr('留空保留当前密钥；输入新值才会替换。', 'Leave empty to keep the current secret; enter a value only to replace it.') : tr('保存后只显示末四位，无法再次读取。', 'Only the last four characters remain visible after saving.')}
+        >
+          <input className="input mono" type="password" autoComplete="new-password" value={credentialDraft.secret} placeholder={credentialModal?.mode === 'edit' ? tr('留空则不修改', 'Leave empty to keep') : '••••••••'} onChange={(event) => setCredentialDraft({ ...credentialDraft, secret: event.target.value })} />
+        </FormField>
+        <div className="settings-row">
+          <div className="settings-row-text">
+            <div className="field-label">{tr('启用此密钥', 'Enable this credential')}</div>
+            <div className="field-hint">{tr('停用后保留配置，但不会进入轮询池。', 'Disabled credentials remain stored but leave the rotation pool.')}</div>
+          </div>
+          <Switch checked={credentialDraft.enabled} onChange={(enabled) => setCredentialDraft({ ...credentialDraft, enabled })} aria-label={tr('启用此密钥', 'Enable this credential')} />
+        </div>
+      </Modal>
+
+      <ConfirmModal
+        open={deleteCredential !== null}
+        onClose={() => setDeleteCredential(null)}
+        title={tr('删除来源密钥', 'Delete provider credential')}
+        message={deleteCredential ? tr(`确定永久删除 ${sourceById(deleteCredential.source).zh} 的“${deleteCredential.label ?? deleteCredential.preview}”吗？删除后无法恢复。`, `Permanently delete “${deleteCredential.label ?? deleteCredential.preview}” from ${sourceById(deleteCredential.source).en}? This cannot be undone.`) : ''}
+        confirmText={tr('删除', 'Delete')}
+        danger
+        busy={deleteCredentialMutation.isPending}
+        onConfirm={() => deleteCredential && deleteCredentialMutation.mutate(deleteCredential.id)}
+      />
+    </div>
+  );
+}
+
+function checkedLabel(enabled: boolean): string {
+  return enabled ? '停用' : '启用';
+}
+
+function checkedLabelEn(enabled: boolean): string {
+  return enabled ? 'Disable' : 'Enable';
+}
+
+interface CredentialGroupProps {
+  source: SourceDefinition;
+  credentials: LiteratureProviderKeyStatus[];
+  providerHealth: LiteratureProviderHealth | undefined;
+  testingId: string | null | undefined;
+  togglingId: string | null | undefined;
+  providerTesting: boolean;
+  onAdd: () => void;
+  onEdit: (credential: LiteratureProviderKeyStatus) => void;
+  onDelete: (credential: LiteratureProviderKeyStatus) => void;
+  onTest: (credential: LiteratureProviderKeyStatus) => void;
+  onToggle: (credential: LiteratureProviderKeyStatus) => void;
+  onTestProvider: () => void;
+}
+
+function CredentialGroup({
+  source,
+  credentials,
+  providerHealth,
+  testingId,
+  togglingId,
+  providerTesting,
+  onAdd,
+  onEdit,
+  onDelete,
+  onTest,
+  onToggle,
+  onTestProvider,
+}: CredentialGroupProps) {
+  return (
+    <div className="literature-credential-group">
+      <div className="literature-credential-group-head">
+        <div>
+          <div className="row gap8">
+            <strong>{source.zh}</strong>
+            <span className="pill sm">{source.metricOnly ? tr('期刊指标', 'Metrics') : source.credentialMode === 'required' ? tr('需要密钥', 'Key required') : tr('可选密钥', 'Optional key')}</span>
+            <HealthBadge health={providerHealth} />
+          </div>
+          <p>{tr(source.descriptionZh, source.descriptionEn)}</p>
+        </div>
+        <div className="row gap6 wrap">
+          <button className="btn btn-soft sm" disabled={providerTesting} onClick={onTestProvider}>
+            <Icon name={providerTesting ? 'refresh' : 'play'} size={12} style={providerTesting ? { animation: 'spin 1s linear infinite' } : undefined} />
+            {providerTesting ? tr('测试中…', 'Testing…') : tr('测试来源', 'Test provider')}
+          </button>
+          <button className="btn btn-primary sm" onClick={onAdd}>
+            <Icon name="plus" size={12} />
+            {tr('添加密钥', 'Add key')}
+          </button>
+        </div>
+      </div>
+      {credentials.length === 0 ? (
+        <div className="literature-credential-empty">
+          {source.credentialMode === 'required'
+            ? tr('尚未配置密钥；该来源无法通过管理员密钥池运行。', 'No credential configured; this provider cannot use the administrator key pool.')
+            : tr('尚未配置密钥；当前使用匿名额度或服务器环境变量。', 'No credential configured; anonymous quota or server environment fallback is used.')}
+        </div>
+      ) : (
+        <div className="literature-credential-list">
+          {credentials.map((credential) => {
+            const testing = testingId === credential.id;
+            const toggling = togglingId === credential.id;
+            return (
+              <div key={credential.id} className="literature-credential-row">
+                <div className="literature-credential-identity">
+                  <div className="row gap8 wrap">
+                    <strong>{credential.label || tr('未命名密钥', 'Unnamed credential')}</strong>
+                    <code>{credential.preview}</code>
+                    <HealthBadge health={credential.health} />
+                    {!credential.enabled && <span className="pill sm">{tr('已停用', 'Disabled')}</span>}
+                  </div>
+                  <span>{credential.health ? `${credential.health.detail} · ${formatTime(credential.health.checked_at)}` : tr('保存后尚未做独立连接测试', 'Not independently tested since it was saved')}</span>
+                </div>
+                <div className="row gap6 literature-credential-actions">
+                  <Switch checked={credential.enabled} disabled={toggling} onChange={() => onToggle(credential)} aria-label={tr(`切换 ${credential.label ?? credential.preview}`, `Toggle ${credential.label ?? credential.preview}`)} />
+                  <button className="btn btn-soft sm" disabled={testing} onClick={() => onTest(credential)}>
+                    <Icon name={testing ? 'refresh' : 'play'} size={12} style={testing ? { animation: 'spin 1s linear infinite' } : undefined} />
+                    {testing ? tr('测试中…', 'Testing…') : tr('测试', 'Test')}
+                  </button>
+                  <button className="icon-btn" title={tr('编辑密钥', 'Edit credential')} onClick={() => onEdit(credential)}><Icon name="pen" size={13} /></button>
+                  <button className="icon-btn" title={tr('删除密钥', 'Delete credential')} onClick={() => onDelete(credential)}><Icon name="trash" size={13} /></button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
+++ b/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
@@ -316,7 +316,7 @@ export function LiteratureSearchSettingsPanel() {
             {tr('评分标准', 'Scoring weights')}
           </div>
           <div className="literature-settings-intro" style={{ marginBottom: 12 }}>
-            {tr('沿用 YFR 五维评分基线；可按科研方向调整，系统会在排序时归一化。', 'Uses the YFR five-dimension baseline; tune it by research direction and ranking will normalize it.')}
+            {tr('沿用 Polaris 五维评分基线；可按科研方向调整，系统会在排序时归一化。', 'Uses the Polaris five-dimension baseline; tune it by research direction and ranking will normalize it.')}
           </div>
           <div className="literature-weight-grid">
             {SCORE_DIMENSIONS.map((dimension) => (

--- a/src/frontend/src/features/settings/__tests__/literatureSettings.test.ts
+++ b/src/frontend/src/features/settings/__tests__/literatureSettings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LITERATURE_SOURCES,
+  buildLiteratureSettingsUpdate,
+  type LiteratureSettingsDraft,
+  validateLiteratureSettingsDraft,
+} from '../literatureSettingsModel';
+
+const validDraft = (): LiteratureSettingsDraft => ({
+  sources: ['openalex', 'arxiv', 'pubmed'],
+  requested_count: 50,
+  candidate_budget: 200,
+  start_year: 2016,
+  end_year: 2026,
+  score_weights: {
+    relevance: 0.45,
+    evidence_quality: 0.2,
+    impact: 0.15,
+    novelty: 0.1,
+    recency: 0.1,
+  },
+});
+
+describe('literature search settings model', () => {
+  it('keeps arXiv keyless and exposes credential pools only where useful', () => {
+    expect(LITERATURE_SOURCES.find((source) => source.id === 'arxiv')?.credentialMode).toBe('none');
+    expect(LITERATURE_SOURCES.find((source) => source.id === 'openalex')?.credentialMode).toBe('optional');
+    expect(LITERATURE_SOURCES.find((source) => source.id === 'sciverse')?.credentialMode).toBe('required');
+    expect(LITERATURE_SOURCES.find((source) => source.id === 'easyscholar')?.metricOnly).toBe(true);
+  });
+
+  it('accepts the configured result count and year window', () => {
+    expect(validateLiteratureSettingsDraft(validDraft())).toBeNull();
+  });
+
+  it('rejects a candidate budget smaller than the requested result count', () => {
+    const draft = validDraft();
+    draft.candidate_budget = 49;
+    expect(validateLiteratureSettingsDraft(draft)).toBe('candidate_budget_lt_requested');
+  });
+
+  it('rejects inverted years and an empty source set', () => {
+    const draft = validDraft();
+    draft.start_year = 2027;
+    expect(validateLiteratureSettingsDraft(draft)).toBe('year_window');
+    draft.start_year = 2016;
+    draft.sources = [];
+    expect(validateLiteratureSettingsDraft(draft)).toBe('sources');
+  });
+
+  it('builds a settings-only payload without masked credentials or health state', () => {
+    const payload = buildLiteratureSettingsUpdate(validDraft());
+    expect(payload).toEqual(validDraft());
+    expect(payload).not.toHaveProperty('provider_keys');
+    expect(payload).not.toHaveProperty('provider_health');
+  });
+});

--- a/src/frontend/src/features/settings/literatureSettingsModel.ts
+++ b/src/frontend/src/features/settings/literatureSettingsModel.ts
@@ -1,0 +1,107 @@
+import type {
+  LiteratureSearchSettings,
+  LiteratureSearchSettingsUpdate,
+} from '../../lib/api';
+
+export type CredentialMode = 'none' | 'optional' | 'required';
+
+export interface SourceDefinition {
+  id: string;
+  zh: string;
+  en: string;
+  descriptionZh: string;
+  descriptionEn: string;
+  credentialMode: CredentialMode;
+  metricOnly?: boolean;
+  testQuery: string;
+}
+
+export const LITERATURE_SOURCES: SourceDefinition[] = [
+  { id: 'openalex', zh: 'OpenAlex', en: 'OpenAlex', descriptionZh: '覆盖广、引用关系完整，支持多密钥轮询。', descriptionEn: 'Broad coverage and citation graph; supports rotating multiple keys.', credentialMode: 'optional', testQuery: 'structural engineering' },
+  { id: 'semantic', zh: 'Semantic Scholar', en: 'Semantic Scholar', descriptionZh: '补充摘要、引用量和跨来源标识。', descriptionEn: 'Adds abstracts, citation counts, and cross-source identifiers.', credentialMode: 'optional', testQuery: 'structural engineering' },
+  { id: 'arxiv', zh: 'arXiv', en: 'arXiv', descriptionZh: '预印本实时检索，无需 API Key。', descriptionEn: 'Live preprint search with no API key required.', credentialMode: 'none', testQuery: 'machine learning' },
+  { id: 'pubmed', zh: 'PubMed', en: 'PubMed', descriptionZh: '生命科学与医学 E-utilities 检索，可配置密钥池。', descriptionEn: 'Life-science and medical E-utilities search with an optional key pool.', credentialMode: 'optional', testQuery: 'cancer immunotherapy' },
+  { id: 'crossref', zh: 'Crossref', en: 'Crossref', descriptionZh: 'DOI 元数据与出版信息，无需 API Key。', descriptionEn: 'DOI and publication metadata with no API key required.', credentialMode: 'none', testQuery: 'structural engineering' },
+  { id: 'europepmc', zh: 'Europe PMC', en: 'Europe PMC', descriptionZh: '生物医学论文与开放全文线索，无需 API Key。', descriptionEn: 'Biomedical papers and open-full-text signals with no API key required.', credentialMode: 'none', testQuery: 'protein structure' },
+  { id: 'hal', zh: 'HAL', en: 'HAL', descriptionZh: '欧洲开放学术仓储，无需 API Key。', descriptionEn: 'European open research repository with no API key required.', credentialMode: 'none', testQuery: 'finite element analysis' },
+  { id: 'core', zh: 'CORE', en: 'CORE', descriptionZh: '聚合开放获取仓储，需要 API Key。', descriptionEn: 'Aggregated open-access repositories; requires an API key.', credentialMode: 'required', testQuery: 'structural engineering' },
+  { id: 'base', zh: 'BASE', en: 'BASE', descriptionZh: '学术搜索聚合源，无需 API Key。', descriptionEn: 'Academic search aggregator with no API key required.', credentialMode: 'none', testQuery: 'structural engineering' },
+  { id: 'sciverse', zh: 'Sciverse', en: 'Sciverse', descriptionZh: '补充出版商聚合检索，需要令牌并支持轮询。', descriptionEn: 'Publisher-aggregated retrieval; requires rotating tokens.', credentialMode: 'required', testQuery: 'structural engineering' },
+  { id: 'easyscholar', zh: 'EasyScholar', en: 'EasyScholar', descriptionZh: '期刊等级与评价指标，只参与指标增强。', descriptionEn: 'Journal rankings and metrics; used only for venue enrichment.', credentialMode: 'required', metricOnly: true, testQuery: 'Nature' },
+];
+
+export const SEARCH_SOURCES = LITERATURE_SOURCES.filter((source) => !source.metricOnly);
+export const CREDENTIAL_SOURCES = LITERATURE_SOURCES.filter(
+  (source) => source.credentialMode !== 'none',
+);
+
+export const SCORE_DIMENSIONS = [
+  { id: 'relevance', zh: '主题相关度', en: 'Relevance' },
+  { id: 'evidence_quality', zh: '证据质量', en: 'Evidence quality' },
+  { id: 'impact', zh: '学术影响力', en: 'Impact' },
+  { id: 'novelty', zh: '新颖度', en: 'Novelty' },
+  { id: 'recency', zh: '时效性', en: 'Recency' },
+] as const;
+
+export interface LiteratureSettingsDraft {
+  sources: string[];
+  requested_count: number;
+  candidate_budget: number;
+  start_year: number | null;
+  end_year: number | null;
+  score_weights: Record<string, number>;
+}
+
+export function draftFrom(settings: LiteratureSearchSettings): LiteratureSettingsDraft {
+  return {
+    sources: SEARCH_SOURCES.filter((source) => settings.sources.includes(source.id)).map(
+      (source) => source.id,
+    ),
+    requested_count: settings.requested_count,
+    candidate_budget: settings.candidate_budget,
+    start_year: settings.start_year,
+    end_year: settings.end_year,
+    score_weights: Object.fromEntries(
+      SCORE_DIMENSIONS.map((dimension) => [dimension.id, settings.score_weights[dimension.id] ?? 0]),
+    ),
+  };
+}
+
+export function validateLiteratureSettingsDraft(draft: LiteratureSettingsDraft): string | null {
+  if (draft.sources.length === 0) return 'sources';
+  if (!Number.isInteger(draft.requested_count) || draft.requested_count < 1 || draft.requested_count > 200) return 'requested_count';
+  if (!Number.isInteger(draft.candidate_budget) || draft.candidate_budget < 1 || draft.candidate_budget > 1000) return 'candidate_budget';
+  if (draft.candidate_budget < draft.requested_count) return 'candidate_budget_lt_requested';
+  if (draft.start_year !== null && (draft.start_year < 1800 || draft.start_year > 3000)) return 'start_year';
+  if (draft.end_year !== null && (draft.end_year < 1800 || draft.end_year > 3000)) return 'end_year';
+  if (draft.start_year !== null && draft.end_year !== null && draft.start_year > draft.end_year) return 'year_window';
+  const weights = SCORE_DIMENSIONS.map((dimension) => draft.score_weights[dimension.id] ?? 0);
+  if (weights.some((weight) => !Number.isFinite(weight) || weight < 0)) return 'score_weights';
+  if (weights.reduce((total, weight) => total + weight, 0) <= 0) return 'score_weights';
+  return null;
+}
+
+export function buildLiteratureSettingsUpdate(
+  draft: LiteratureSettingsDraft,
+): LiteratureSearchSettingsUpdate {
+  return {
+    sources: [...draft.sources],
+    requested_count: draft.requested_count,
+    candidate_budget: draft.candidate_budget,
+    start_year: draft.start_year,
+    end_year: draft.end_year,
+    score_weights: { ...draft.score_weights },
+  };
+}
+
+export function sourceById(id: string): SourceDefinition {
+  return LITERATURE_SOURCES.find((source) => source.id === id) ?? {
+    id,
+    zh: id,
+    en: id,
+    descriptionZh: '自定义检索来源。',
+    descriptionEn: 'Custom literature provider.',
+    credentialMode: 'optional',
+    testQuery: 'research',
+  };
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -747,6 +747,66 @@ export interface AffiliationModeRead {
   mode: AffiliationMode;
 }
 
+export interface LiteratureProviderHealth {
+  ok: boolean;
+  detail: string;
+  checked_at: number;
+}
+
+export interface LiteratureProviderKeyStatus {
+  id: string;
+  source: string;
+  index: number | null;
+  configured: boolean;
+  preview: string;
+  enabled: boolean;
+  label: string | null;
+  health: LiteratureProviderHealth | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+export interface LiteratureSearchSettings {
+  sources: string[];
+  requested_count: number;
+  candidate_budget: number;
+  start_year: number | null;
+  end_year: number | null;
+  score_weights: Record<string, number>;
+  provider_keys: Record<string, LiteratureProviderKeyStatus[]>;
+  provider_health: Record<string, LiteratureProviderHealth>;
+}
+
+export interface LiteratureSearchSettingsUpdate {
+  sources?: string[];
+  requested_count?: number;
+  candidate_budget?: number;
+  start_year?: number | null;
+  end_year?: number | null;
+  score_weights?: Record<string, number>;
+}
+
+export interface LiteratureProviderCredentialCreate {
+  source: string;
+  secret: string;
+  label?: string | null;
+  enabled?: boolean;
+}
+
+export interface LiteratureProviderCredentialUpdate {
+  secret?: string;
+  label?: string | null;
+  enabled?: boolean;
+}
+
+export interface LiteratureProviderTestResult {
+  source: string;
+  ok: boolean;
+  latency_ms: number;
+  fetched_count: number;
+  detail: string;
+}
+
 /** 补建历史向量的结果计数。 */
 export interface DailyEmbedBackfillResult {
   embedded: number;
@@ -4559,6 +4619,50 @@ export const api = {
   },
   setAffiliationMode(mode: AffiliationMode): Promise<AffiliationModeRead> {
     return requestJson<AffiliationModeRead>('/admin/settings/affiliation-mode', 'PUT', { mode });
+  },
+  getLiteratureSearchSettings(): Promise<LiteratureSearchSettings> {
+    return request<LiteratureSearchSettings>('/admin/settings/literature-search');
+  },
+  setLiteratureSearchSettings(
+    input: LiteratureSearchSettingsUpdate,
+  ): Promise<LiteratureSearchSettings> {
+    return requestJson<LiteratureSearchSettings>('/admin/settings/literature-search', 'PUT', input);
+  },
+  testLiteratureProvider(source: string, query: string): Promise<LiteratureProviderTestResult> {
+    return requestJson<LiteratureProviderTestResult>(
+      '/admin/settings/literature-search/test',
+      'POST',
+      { source, query },
+    );
+  },
+  createLiteratureProviderCredential(
+    input: LiteratureProviderCredentialCreate,
+  ): Promise<LiteratureProviderKeyStatus> {
+    return requestJson<LiteratureProviderKeyStatus>(
+      '/admin/settings/literature-search/credentials',
+      'POST',
+      input,
+    );
+  },
+  updateLiteratureProviderCredential(
+    id: string,
+    input: LiteratureProviderCredentialUpdate,
+  ): Promise<LiteratureProviderKeyStatus> {
+    return requestJson<LiteratureProviderKeyStatus>(
+      `/admin/settings/literature-search/credentials/${id}`,
+      'PATCH',
+      input,
+    );
+  },
+  deleteLiteratureProviderCredential(id: string): Promise<void> {
+    return request<void>(`/admin/settings/literature-search/credentials/${id}`, { method: 'DELETE' });
+  },
+  testLiteratureProviderCredential(id: string, query: string): Promise<LiteratureProviderTestResult> {
+    return requestJson<LiteratureProviderTestResult>(
+      `/admin/settings/literature-search/credentials/${id}/test`,
+      'POST',
+      { query },
+    );
   },
   /** 实验室概况页的用量排行榜是否对普通成员可见（admin，默认开）。 */
   getLabLeaderboardEnabled(): Promise<LabLeaderboardSetting> {

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -589,6 +589,83 @@ input {
 .settings-row:last-child { padding-bottom: 4px; }
 .settings-row-text { flex: 1; min-width: 0; }
 
+/* 管理员文献检索：沿用设置页密度，把运行参数、来源和凭据池分成可扫描的层级。 */
+.literature-settings-stack { display: flex; flex-direction: column; gap: 18px; }
+.literature-settings-summary {
+  display: flex; align-items: center; justify-content: space-between; gap: 24px;
+  padding: 17px 20px; border: 0.5px solid var(--border); border-radius: var(--radius);
+  background: var(--surface); box-shadow: var(--shadow-card);
+}
+.literature-settings-intro {
+  margin-top: 5px; color: var(--text-3); font-size: 12px; line-height: 1.65;
+}
+.literature-settings-stats { display: flex; align-items: stretch; flex-shrink: 0; }
+.literature-settings-stats > div {
+  min-width: 82px; padding: 1px 15px; border-left: 0.5px solid var(--border-2);
+  display: flex; flex-direction: column; align-items: flex-end;
+}
+.literature-settings-stats strong { font-family: var(--mono); font-size: 18px; line-height: 1.1; }
+.literature-settings-stats span { margin-top: 4px; color: var(--text-3); font-size: 10.5px; }
+.literature-settings-fields-compact { grid-template-columns: repeat(2, minmax(150px, 1fr)); }
+.literature-weight-grid { display: flex; flex-direction: column; }
+.literature-weight-row {
+  display: grid; grid-template-columns: minmax(0, 1fr) 92px; align-items: center; gap: 14px;
+  min-height: 44px; border-top: 0.5px solid var(--border-2); color: var(--text-2); font-size: 12.5px;
+}
+.literature-weight-row:first-child { border-top: 0; }
+.literature-weight-row .input { height: 31px; text-align: right; }
+.literature-source-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 10px;
+}
+.literature-source-card {
+  min-width: 0; padding: 14px; border: 0.5px solid var(--border); border-radius: 8px;
+  background: var(--surface-2); transition: border-color 0.14s, background 0.14s;
+}
+.literature-source-card.enabled { border-color: var(--accent-soft-2); background: var(--accent-soft-row); }
+.literature-source-card strong { font-size: 12.5px; }
+.literature-source-card p,
+.literature-credential-group p {
+  min-height: 36px; margin: 7px 0 11px; color: var(--text-3); font-size: 11.5px; line-height: 1.55;
+}
+.literature-credentials-heading { justify-content: space-between; gap: 18px; margin-bottom: 15px; }
+.literature-credential-groups { display: flex; flex-direction: column; gap: 12px; }
+.literature-credential-group {
+  overflow: hidden; border: 0.5px solid var(--border); border-radius: 8px; background: var(--surface-2);
+}
+.literature-credential-group-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 14px 16px 11px;
+}
+.literature-credential-group-head p { min-height: 0; margin-bottom: 0; }
+.literature-credential-empty {
+  padding: 11px 16px; border-top: 0.5px solid var(--border); color: var(--text-3); font-size: 11.5px;
+  background: var(--surface);
+}
+.literature-credential-list { border-top: 0.5px solid var(--border); background: var(--surface); }
+.literature-credential-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 11px 16px;
+}
+.literature-credential-row + .literature-credential-row { border-top: 0.5px solid var(--border-2); }
+.literature-credential-identity { min-width: 0; flex: 1; }
+.literature-credential-identity strong { font-size: 12px; }
+.literature-credential-identity code {
+  padding: 2px 6px; border-radius: 4px; background: var(--surface-3); color: var(--text-2);
+  font-family: var(--mono); font-size: 10.5px;
+}
+.literature-credential-identity > span {
+  display: block; overflow: hidden; margin-top: 4px; color: var(--text-3); font-size: 10.5px;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.literature-credential-actions { flex-shrink: 0; }
+.literature-settings-savebar {
+  position: sticky; bottom: 12px; z-index: 4; display: flex; align-items: center;
+  justify-content: space-between; gap: 18px; padding: 12px 14px 12px 16px;
+  border: 0.5px solid var(--border-strong); border-radius: 9px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent); box-shadow: var(--shadow-pop);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+}
+.literature-settings-savebar strong { display: block; font-size: 12px; }
+.literature-settings-savebar span { display: block; margin-top: 2px; color: var(--text-3); font-size: 10.5px; }
+
 /* animations */
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 .pulse { animation: pulse 1.6s ease-in-out infinite; }
@@ -1318,6 +1395,22 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
     padding-left: max(12px, env(safe-area-inset-left));
     padding-right: max(12px, env(safe-area-inset-right));
   }
+
+  .literature-settings-summary,
+  .literature-credential-group-head,
+  .literature-credential-row,
+  .literature-settings-savebar { align-items: stretch; flex-direction: column; }
+  .literature-settings-stats { width: 100%; }
+  .literature-settings-stats > div {
+    min-width: 0; padding: 8px 12px; border-left: 0; border-right: 0.5px solid var(--border-2);
+    align-items: flex-start; flex: 1;
+  }
+  .literature-settings-stats > div:last-child { border-right: 0; }
+  .literature-settings-fields-compact { grid-template-columns: minmax(0, 1fr); }
+  .literature-source-grid { grid-template-columns: minmax(0, 1fr); }
+  .literature-credential-actions { justify-content: flex-start; }
+  .literature-settings-savebar { bottom: 8px; }
+  .literature-settings-savebar .btn { justify-content: center; width: 100%; }
 
   /* —— 不破版的关键一招：标签列自动折行 ——
         全站 200+ 处「固定宽标签 + flexShrink:0」的两栏行靠这条自动堆叠。


### PR DESCRIPTION
## Summary

- add a `Literature search` tab to the existing administrator settings console
- expose retrieval defaults, enabled sources, Polaris scoring weights, provider health, and credential pools through the API merged in #526
- add modal-based credential create/edit flows plus per-provider and per-key connection tests
- keep stored secrets write-only: the UI displays only the backend mask and never pre-fills an existing secret
- support multiple rotating keys, explicit keyless sources such as arXiv, and legacy credential pools returned by the backend

## Architecture and merge boundary

This is a frontend-only PR based directly on `main@851abc8`. It depends only on the backend contract already merged in #526 and does **not** depend on #530, #531, or #533. It can be reviewed and merged independently.

The page does not add a standalone literature product area. It stays inside the current administrator settings shell and uses the existing Polaris cards, segmented navigation, switches, modal, confirmation dialog, toast, and responsive layout primitives.

## Security behavior

- credential secrets are accepted only in create/edit modals and are never read back
- editing with an empty secret preserves the current encrypted value
- enable/disable, test, and delete operate on one credential ID at a time
- settings updates omit `provider_keys` and `provider_health`, so saving retrieval defaults cannot replace or erase the credential pool

## Validation

- `npm test`: 17 files, 96 tests passed
- `npm run build`: TypeScript and Vite production build passed
- focused settings contract tests: 5 passed
- desktop (1360px), mobile (390px), credential-pool, and credential-modal visual checks completed
- `git diff --check` passed
- sensitive-value scan passed

Closes #534