### PR TITLE
feat(reading): expose versioned PDF assets

### DIFF
--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -28,9 +28,12 @@ import {
   type HighlightRect,
   type HighlightStyle,
   type PaperDetail,
+  type StructuredContentManifestRead,
 } from '../../lib/api';
+import { Markdown } from '../../lib/markdown';
 import { HIGHLIGHT_COLORS, HIGHLIGHT_STYLES, highlightColorMeta } from './shared';
 import { PdfUploadButton } from '../shared/PdfUploadButton';
+import { resolveStructuredResourceUrls } from './structuredContent';
 
 /* ============================================================
    自建 PDF 阅读器（pdf.js / react-pdf）：
@@ -69,8 +72,8 @@ export interface JumpTarget {
   nonce: number;
 }
 
-/** 阅读器模式：annotate = 自建可划线阅读器；standard = 浏览器内置 PDF 阅读器（不支持划线）。 */
-type ReaderMode = 'annotate' | 'standard';
+/** 阅读器模式：PDF 标注、浏览器标准阅读器、解析后的结构化原文。 */
+type ReaderMode = 'annotate' | 'standard' | 'structured';
 
 // 缩放范围与步进（相对「适应宽度」的倍率）。
 const ZOOM_MIN = 0.5;
@@ -79,6 +82,7 @@ const ZOOM_STEP = 0.1;
 
 interface PdfReaderProps {
   paper: PaperDetail;
+  libraryId?: string | null;
   highlights: HighlightRead[];
   activeHighlightId: string | null;
   creating: boolean;
@@ -185,6 +189,7 @@ function annotationRectStyle(
 
 export function PdfReader({
   paper,
+  libraryId,
   highlights,
   activeHighlightId,
   creating,
@@ -230,23 +235,72 @@ export function PdfReader({
     if (dy !== 0) el.style.top = `${parseFloat(el.style.top || '0') + dy}px`;
   }, [pending]);
 
+  const assetsQuery = useQuery({
+    queryKey: ['paper-assets', libraryId, paper.id],
+    queryFn: () => api.listLibraryPaperAssets(libraryId!, paper.id),
+    enabled: !!libraryId,
+    retry: false,
+  });
+  const asset = assetsQuery.data?.items.find((item) => item.is_preferred) ?? assetsQuery.data?.items[0] ?? null;
+  const contentVersionQuery = useQuery({
+    queryKey: ['paper-content-version', libraryId, paper.id],
+    queryFn: async () => {
+      try {
+        return await api.getLibraryPaperContentVersion(libraryId!, paper.id);
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) return null;
+        throw error;
+      }
+    },
+    enabled: !!libraryId,
+    retry: false,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && !['ready', 'ready_fallback', 'vector_ready', 'failed'].includes(status) ? 2_500 : false;
+    },
+  });
+  const contentVersion = contentVersionQuery.data ?? null;
+  const structuredQuery = useQuery({
+    queryKey: ['paper-structured-content', libraryId, paper.id, contentVersion?.id],
+    queryFn: async (): Promise<{ manifest: StructuredContentManifestRead; content: string }> => {
+      const manifest = await api.getLibraryPaperStructuredContent(libraryId!, paper.id);
+      const contentUrl = manifest.markdown_url ?? manifest.text_url;
+      const raw = contentUrl ? await api.fetchStructuredContentText(contentUrl) : '';
+      return {
+        manifest,
+        content: manifest.content_format === 'mineru_markdown' ? resolveStructuredResourceUrls(raw) : raw,
+      };
+    },
+    enabled: !!libraryId && !!contentVersion && ['ready', 'ready_fallback', 'vector_ready'].includes(contentVersion.status),
+    retry: false,
+    staleTime: 4 * 60_000,
+  });
+  const hasPdf = paper.pdf_available || asset !== null;
+  const hasStructuredContent = Boolean(
+    structuredQuery.data && structuredQuery.data.manifest.content_format !== 'unavailable' && structuredQuery.data.content,
+  );
+
   // 标注阅读器把地址直接交给 pdf.js，由它按需发 Range 请求；鉴权头随请求带上，
   // 所以这里不能用 blob。对象要 memo：react-pdf 认引用，每次新对象都会重新加载整份。
   const pdfSource = useMemo(() => {
     const src: { url: string; httpHeaders?: Record<string, string> } = {
-      url: `${apiBase()}/papers/${paper.id}/pdf`,
+      url: asset && libraryId
+        ? `${apiBase()}/libraries/${libraryId}/papers/${paper.id}/assets/${asset.id}/download`
+        : `${apiBase()}/papers/${paper.id}/pdf`,
     };
     const token = getToken();
     if (token) src.httpHeaders = { Authorization: `Bearer ${token}` };
     return src;
-  }, [paper.id]);
+  }, [asset, libraryId, paper.id]);
 
   // 标准阅读器是 <iframe>，带不了 Authorization 头，只能整包下成 blob——所以推迟到
   // 真的切过去才下，默认的标注模式不再为它付这 25MB 的等待。
   const pdfQuery = useQuery({
-    queryKey: ['paper-pdf', paper.id],
-    queryFn: () => api.fetchPaperPdf(paper.id),
-    enabled: mode === 'standard' && paper.pdf_available,
+    queryKey: ['paper-pdf', paper.id, asset?.id],
+    queryFn: () => asset && libraryId
+      ? api.downloadLibraryPaperAsset(libraryId, paper.id, asset.id)
+      : api.fetchPaperPdf(paper.id),
+    enabled: mode === 'standard' && hasPdf,
     retry: false,
     staleTime: Infinity,
   });
@@ -472,9 +526,13 @@ export function PdfReader({
     [],
   );
 
+  if (libraryId && !paper.pdf_available && assetsQuery.isLoading) {
+    return <div className="empty">{tr('正在检查 PDF 资产…', 'Checking PDF assets…')}</div>;
+  }
+
   // 无 PDF：引导获取（原先靠「先整包下一遍，404 就是没有」判断，现在直接读元数据，
   // 免掉一次无谓的整包下载）
-  if (!paper.pdf_available) {
+  if (!hasPdf && !assetsQuery.isLoading) {
     const canFetch = !!paper.arxiv_id;
     return (
       <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -518,7 +576,7 @@ export function PdfReader({
                   {tr('打开原文链接', 'Open source link')}
                 </a>
               ) : null}
-              <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />
+              {!libraryId && <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />}
             </div>
           )}
         />
@@ -537,6 +595,14 @@ export function PdfReader({
           options={[
             { v: 'annotate', label: tr('标注阅读器', 'Annotate') },
             { v: 'standard', label: tr('标准阅读器', 'Standard') },
+            ...(contentVersion && ['ready', 'ready_fallback', 'vector_ready'].includes(contentVersion.status)
+              ? [{
+                  v: 'structured' as const,
+                  label: contentVersion.status === 'ready_fallback'
+                    ? tr('纯原文', 'Plain text')
+                    : tr('结构化原文', 'Structured'),
+                }]
+              : []),
           ]}
           value={mode}
           onChange={setMode}
@@ -570,6 +636,12 @@ export function PdfReader({
               <Icon name="plus" size={14} />
             </button>
           </span>
+        ) : mode === 'structured' ? (
+          <span className="row gap8" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>
+            {structuredQuery.data
+              ? `${structuredQuery.data.manifest.parser} · ${structuredQuery.data.manifest.page_count} ${tr('页', 'pages')} · ${structuredQuery.data.manifest.assets.length} ${tr('项资源', 'assets')}`
+              : tr('正在载入解析结果', 'Loading parsed content')}
+          </span>
         ) : (
           <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-4)' }}>
             {tr('标准阅读器不支持划线标注', 'Standard viewer has no highlighting')}
@@ -577,7 +649,33 @@ export function PdfReader({
         )}
       </div>
 
-      {mode === 'standard' ? (
+      {mode === 'structured' ? (
+        <div
+          className="scroll paper-reader-body"
+          style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '28px clamp(20px, 6vw, 72px)', background: 'var(--surface)' }}
+        >
+          <div style={{ width: 'min(100%, 880px)', margin: '0 auto' }}>
+            {hasStructuredContent && structuredQuery.data ? (
+              structuredQuery.data.manifest.content_format === 'mineru_markdown' ? (
+                <Markdown source={structuredQuery.data.content} />
+              ) : (
+                <article style={{ whiteSpace: 'pre-wrap', fontSize: 13.5, lineHeight: 1.8, color: 'var(--text-2)' }}>
+                  {structuredQuery.data.content}
+                </article>
+              )
+            ) : structuredQuery.isError ? (
+              <EmptyState
+                compact
+                icon="x"
+                title={tr('结构化原文暂时无法加载', 'Structured content is unavailable')}
+                desc={tr('签名链接可能已过期，请刷新页面后重试。', 'The signed link may have expired. Refresh and try again.')}
+              />
+            ) : (
+              <div className="empty">{tr('正在载入解析后的全文…', 'Loading parsed full text…')}</div>
+            )}
+          </div>
+        </div>
+      ) : mode === 'standard' ? (
         // 浏览器内置 PDF 阅读器：自带缩放/搜索/打印，但不承载我们的标注层。
         // 它只认能直接取到的地址，带不了鉴权头，所以这里必须等整包下完拿到 blob。
         url ? (

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -352,6 +352,7 @@ export function ReadingPage() {
           >
             <PdfReader
               paper={paper}
+              libraryId={paperLibId}
               highlights={highlights}
               activeHighlightId={activeHl}
               creating={createHlMutation.isPending}

--- a/src/frontend/src/features/reading/structuredContent.test.ts
+++ b/src/frontend/src/features/reading/structuredContent.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { resolveStructuredResourceUrls } from './structuredContent';
+
+describe('resolveStructuredResourceUrls', () => {
+  it('preserves web same-origin signed URLs', () => {
+    const source = '![figure](/api/structured-content-assets/token-1)';
+    expect(resolveStructuredResourceUrls(source)).toBe(source);
+  });
+
+  it('does not rewrite unrelated paths', () => {
+    expect(resolveStructuredResourceUrls('[paper](/papers/1)')).toBe('[paper](/papers/1)');
+  });
+});

--- a/src/frontend/src/features/reading/structuredContent.ts
+++ b/src/frontend/src/features/reading/structuredContent.ts
@@ -1,0 +1,9 @@
+import { apiResourceUrl } from '../../lib/api';
+
+/** Convert signed same-origin resource links for Electron's remote server origin. */
+export function resolveStructuredResourceUrls(markdown: string): string {
+  return markdown.replace(
+    /([("'])(\/api\/structured-content-assets\/[A-Za-z0-9._~-]+)/g,
+    (_match, prefix: string, url: string) => `${prefix}${apiResourceUrl(url)}`,
+  );
+}

--- a/src/frontend/src/features/shared/PaperAssetPanel.tsx
+++ b/src/frontend/src/features/shared/PaperAssetPanel.tsx
@@ -1,0 +1,316 @@
+import { useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import {
+  api,
+  ApiError,
+  type PaperAssetRead,
+  type PaperContentVersionRead,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+const ACTIVE_PARSE_STATES = new Set([
+  'queued',
+  'mineru_uploading',
+  'mineru_acceptance_wait',
+  'mineru_processing',
+  'mineru_downloading',
+  'parsing',
+  'fallback_parsing',
+]);
+
+export interface AssetStateMeta {
+  label: string;
+  tone: 'neutral' | 'accent' | 'warning' | 'success' | 'danger';
+}
+
+export function parseStateMeta(status?: string | null): AssetStateMeta {
+  switch (status) {
+    case 'queued':
+      return { label: tr('等待解析', 'Queued'), tone: 'warning' };
+    case 'mineru_uploading':
+      return { label: tr('正在上传 MinerU', 'Uploading to MinerU'), tone: 'accent' };
+    case 'mineru_acceptance_wait':
+      return { label: tr('等待 MinerU 接收', 'Waiting for MinerU'), tone: 'accent' };
+    case 'mineru_processing':
+      return { label: tr('MinerU 解析中', 'MinerU parsing'), tone: 'accent' };
+    case 'mineru_downloading':
+      return { label: tr('正在获取 MinerU 结果', 'Fetching MinerU result'), tone: 'accent' };
+    case 'parsing':
+      return { label: tr('原文解析中', 'Parsing full text'), tone: 'accent' };
+    case 'fallback_parsing':
+      return { label: tr('PyMuPDF 兜底解析中', 'PyMuPDF fallback parsing'), tone: 'warning' };
+    case 'ready':
+      return { label: tr('结构化原文已就绪', 'Structured text ready'), tone: 'success' };
+    case 'ready_fallback':
+      return { label: tr('纯原文已就绪', 'Plain full text ready'), tone: 'success' };
+    case 'vector_ready':
+      return { label: tr('解析与向量化完成', 'Parsed and vectorized'), tone: 'success' };
+    case 'failed':
+      return { label: tr('解析失败', 'Parsing failed'), tone: 'danger' };
+    default:
+      return { label: tr('尚未解析', 'Not parsed'), tone: 'neutral' };
+  }
+}
+
+export function vectorStateMeta(state?: string | null): AssetStateMeta {
+  switch (state) {
+    case 'ready':
+      return { label: tr('已完成', 'Ready'), tone: 'success' };
+    case 'building':
+      return { label: tr('构建中', 'Building'), tone: 'accent' };
+    case 'pending':
+      return { label: tr('等待构建', 'Pending'), tone: 'warning' };
+    case 'failed':
+      return { label: tr('构建失败', 'Failed'), tone: 'danger' };
+    default:
+      return { label: tr('未建立', 'Not built'), tone: 'neutral' };
+  }
+}
+
+function toneStyle(tone: AssetStateMeta['tone']): React.CSSProperties {
+  if (tone === 'success') return { background: 'var(--ok-bg)', color: 'var(--ok-tx)' };
+  if (tone === 'danger') return { background: 'var(--danger-bg)', color: 'var(--danger-tx)' };
+  if (tone === 'warning') return { background: 'var(--warn-bg)', color: 'var(--warn-tx)' };
+  if (tone === 'accent') return { background: 'var(--accent-soft)', color: 'var(--accent-text)' };
+  return { background: 'var(--surface-3)', color: 'var(--text-3)' };
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024 * 1024) return `${Math.max(1, Math.round(value / 1024))} KB`;
+  return `${(value / 1024 / 1024).toFixed(value >= 10 * 1024 * 1024 ? 0 : 1)} MB`;
+}
+
+function sourceLabel(source: string): string {
+  const labels: Record<string, string> = {
+    oa: 'OA',
+    upload: tr('用户上传', 'Upload'),
+    extension: tr('扩展归档', 'Extension'),
+    arxiv: 'arXiv',
+    manual: tr('手动导入', 'Manual'),
+  };
+  return labels[source] ?? source;
+}
+
+function sharingLabel(scope: string): string {
+  if (scope === 'public') return tr('公开复用', 'Public reuse');
+  if (scope === 'library') return tr('本库共享', 'Library shared');
+  return tr('私有授权', 'Private grant');
+}
+
+function savePdf(blob: Blob, paperId: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `${paperId}.pdf`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function PaperAssetPanel({
+  libraryId,
+  paperId,
+  doi,
+  canManage,
+}: {
+  libraryId: string;
+  paperId: string;
+  doi?: string | null;
+  canManage: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+  const [sharingScope, setSharingScope] = useState<'private' | 'library' | 'public'>('library');
+  const [reparseAsset, setReparseAsset] = useState<PaperAssetRead | null>(null);
+
+  const assetsQuery = useQuery({
+    queryKey: ['paper-assets', libraryId, paperId],
+    queryFn: () => api.listLibraryPaperAssets(libraryId, paperId),
+    retry: false,
+  });
+  const versionQuery = useQuery({
+    queryKey: ['paper-content-version', libraryId, paperId],
+    queryFn: async () => {
+      try {
+        return await api.getLibraryPaperContentVersion(libraryId, paperId);
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) return null;
+        throw error;
+      }
+    },
+    retry: false,
+    refetchInterval: (query) => {
+      const value = query.state.data as PaperContentVersionRead | null | undefined;
+      return value && (ACTIVE_PARSE_STATES.has(value.status) || value.document_vector_state === 'building' || value.chunk_vector_state === 'building')
+        ? 2_500
+        : false;
+    },
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['paper-assets', libraryId, paperId] });
+    void queryClient.invalidateQueries({ queryKey: ['paper-content-version', libraryId, paperId] });
+    void queryClient.invalidateQueries({ queryKey: ['paper-structured-content', libraryId, paperId] });
+    void queryClient.invalidateQueries({ queryKey: ['paper', libraryId, paperId] });
+    void queryClient.invalidateQueries({ queryKey: ['papers', libraryId] });
+  };
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const asset = await api.uploadLibraryPaperAsset(libraryId, paperId, file, {
+        sharingScope,
+        identityKey: doi ? `doi:${doi.toLowerCase()}` : null,
+      });
+      const version = await api.createLibraryPaperContentVersion(libraryId, paperId, asset.id);
+      return { asset, version };
+    },
+    onSuccess: () => {
+      invalidate();
+      toast(tr('PDF 已保存，MinerU 优先解析任务已开始', 'PDF saved; MinerU-first parsing has started'), 'ok');
+    },
+    onError: (error) => {
+      invalidate();
+      toast(`${tr('PDF 处理失败：', 'PDF processing failed: ')}${error instanceof Error ? error.message : String(error)}`, 'error');
+    },
+  });
+
+  const parseMutation = useMutation({
+    mutationFn: (assetId: string) => api.createLibraryPaperContentVersion(libraryId, paperId, assetId),
+    onSuccess: () => {
+      setReparseAsset(null);
+      invalidate();
+      toast(tr('已提交新的解析版本', 'A new parse version was queued'), 'ok');
+    },
+    onError: (error) => toast(`${tr('提交解析失败：', 'Failed to queue parsing: ')}${error instanceof Error ? error.message : String(error)}`, 'error'),
+  });
+
+  const downloadMutation = useMutation({
+    mutationFn: (asset: PaperAssetRead) => api.downloadLibraryPaperAsset(libraryId, paperId, asset.id),
+    onSuccess: (blob) => savePdf(blob, paperId),
+    onError: (error) => toast(`${tr('下载失败：', 'Download failed: ')}${error instanceof Error ? error.message : String(error)}`, 'error'),
+  });
+
+  const assets = assetsQuery.data?.items ?? [];
+  const preferred = assets.find((asset) => asset.is_preferred) ?? assets[0] ?? null;
+  const version = versionQuery.data ?? null;
+  const parseMeta = parseStateMeta(version?.status);
+  const parsing = Boolean(version && ACTIVE_PARSE_STATES.has(version.status));
+  const documentVector = vectorStateMeta(version?.document_vector_state);
+  const chunkVector = vectorStateMeta(version?.chunk_vector_state);
+
+  return (
+    <section
+      className="paper-asset-panel"
+      aria-label={tr('PDF 资产与全文索引', 'PDF asset and full-text index')}
+      style={{
+        marginTop: 16,
+        padding: '14px 0',
+        borderTop: '0.5px solid var(--border)',
+        borderBottom: '0.5px solid var(--border)',
+      }}
+    >
+      <div className="row gap10 wrap paper-asset-summary" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <div style={{ fontSize: 12.5, fontWeight: 650 }}>{tr('PDF 资产与全文索引', 'PDF asset and full-text index')}</div>
+          <div className="muted" style={{ fontSize: 11.5, marginTop: 3 }}>
+            {preferred
+              ? `${sourceLabel(preferred.source)} · ${sharingLabel(preferred.sharing_scope)} · ${formatBytes(preferred.byte_size)}`
+              : tr('尚未绑定可处理的 PDF', 'No processable PDF is attached')}
+          </div>
+        </div>
+        <div className="row gap6 wrap paper-asset-states">
+          <span className="pill sm" style={toneStyle(parseMeta.tone)}>{parseMeta.label}</span>
+          <span className="pill sm" style={toneStyle(documentVector.tone)} title={tr('标题、摘要与全文摘要的论文级检索向量', 'Paper-level retrieval vector')}>
+            {tr('论文向量', 'Paper vector')} · {documentVector.label}
+          </span>
+          <span className="pill sm" style={toneStyle(chunkVector.tone)} title={tr('供句子级证据检索使用的全文分块向量', 'Full-text chunk vectors for sentence-level evidence retrieval')}>
+            {tr('全文分块', 'Full-text chunks')} · {chunkVector.label}
+          </span>
+        </div>
+      </div>
+
+      {version?.error_code && (
+        <div style={{ marginTop: 10, color: 'var(--danger-tx)', fontSize: 11.5 }}>
+          {version.error_code}{version.error_detail ? ` · ${version.error_detail}` : ''}
+        </div>
+      )}
+
+      <div className="row gap8 wrap paper-asset-actions" style={{ marginTop: 12 }}>
+        {preferred && (
+          <button className="btn btn-ghost sm" disabled={downloadMutation.isPending} onClick={() => downloadMutation.mutate(preferred)}>
+            <Icon name="download" size={13} />
+            {downloadMutation.isPending ? tr('下载中…', 'Downloading…') : tr('下载 PDF', 'Download PDF')}
+          </button>
+        )}
+        {canManage && (
+          <>
+            <input
+              ref={inputRef}
+              type="file"
+              accept="application/pdf,.pdf"
+              hidden
+              onChange={(event) => {
+                const file = event.currentTarget.files?.[0];
+                event.currentTarget.value = '';
+                if (file) uploadMutation.mutate(file);
+              }}
+            />
+            <select
+              className="input sm"
+              aria-label={tr('PDF 共享范围', 'PDF sharing scope')}
+              value={sharingScope}
+              disabled={uploadMutation.isPending}
+              onChange={(event) => setSharingScope(event.target.value as typeof sharingScope)}
+            >
+              <option value="private">{tr('私有授权', 'Private grant')}</option>
+              <option value="library">{tr('本库共享', 'Library shared')}</option>
+              <option value="public">{tr('公开复用', 'Public reuse')}</option>
+            </select>
+            <button className="btn btn-soft sm" disabled={uploadMutation.isPending} onClick={() => inputRef.current?.click()}>
+              <Icon name={uploadMutation.isPending ? 'refresh' : 'plus'} size={13} style={uploadMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
+              {uploadMutation.isPending ? tr('上传并排队…', 'Uploading and queuing…') : tr('上传 PDF', 'Upload PDF')}
+            </button>
+            {preferred && (
+              <button className="btn btn-ghost sm" disabled={parseMutation.isPending || parsing} onClick={() => setReparseAsset(preferred)}>
+                <Icon name="refresh" size={13} />
+                {version?.status === 'failed' ? tr('重试解析', 'Retry parsing') : tr('重新解析', 'Reparse')}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {version && (
+        <div className="mono" style={{ marginTop: 10, fontSize: 10.5, color: 'var(--text-4)' }}>
+          {tr(`内容版本 v${version.version_no} · ${version.parser} · ${version.page_count} 页 · ${version.chunk_count} 个分块`, `Content v${version.version_no} · ${version.parser} · ${version.page_count} pages · ${version.chunk_count} chunks`)}
+        </div>
+      )}
+
+      <ConfirmModal
+        open={reparseAsset !== null}
+        onClose={() => setReparseAsset(null)}
+        title={tr('重新解析 PDF', 'Reparse PDF')}
+        message={(
+          <>
+            <div style={{ marginBottom: 10 }}>
+              {tr('将创建新的内容版本并重新构建全文索引。', 'A new content version and full-text index will be created.')}
+            </div>
+            <div style={{ padding: 12, borderRadius: 6, background: 'var(--warn-bg)', color: 'var(--warn-tx)', lineHeight: 1.65 }}>
+              {tr(
+                '重新解析会替换当前结构化原文、分块和向量。旧 AI 内容仍能打开论文，但原句定位失效时会退回论文级来源。源 PDF 不会删除。',
+                'Reparsing replaces the current structured text, chunks, and vectors. Existing AI content still opens the paper, but stale sentence anchors fall back to the paper-level source. The source PDF is retained.',
+              )}
+            </div>
+          </>
+        )}
+        confirmText={tr('确认重新解析', 'Reparse')}
+        busy={parseMutation.isPending}
+        onConfirm={() => {
+          if (reparseAsset) parseMutation.mutate(reparseAsset.id);
+        }}
+      />
+    </section>
+  );
+}

--- a/src/frontend/src/features/shared/__tests__/PaperAssetPanel.test.ts
+++ b/src/frontend/src/features/shared/__tests__/PaperAssetPanel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { parseStateMeta, vectorStateMeta } from '../PaperAssetPanel';
+
+describe('PaperAssetPanel status mapping', () => {
+  it('keeps MinerU and PyMuPDF fallback stages distinguishable', () => {
+    expect(parseStateMeta('mineru_uploading').label).toContain('MinerU');
+    expect(parseStateMeta('mineru_processing').tone).toBe('accent');
+    expect(parseStateMeta('fallback_parsing').label).toContain('PyMuPDF');
+    expect(parseStateMeta('failed').tone).toBe('danger');
+  });
+
+  it('reports paper and chunk vector states independently', () => {
+    expect(vectorStateMeta('ready').tone).toBe('success');
+    expect(vectorStateMeta('building').tone).toBe('accent');
+    expect(vectorStateMeta('failed').tone).toBe('danger');
+  });
+});

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -15,6 +15,7 @@ import { citationExportItems, ExportDropdown } from '../../components/ui/ExportD
 import { PaperReader } from './PaperReader';
 import { readerFrom } from '../reading/shared';
 import { PdfUploadButton } from '../shared/PdfUploadButton';
+import { PaperAssetPanel } from '../shared/PaperAssetPanel';
 import { toast } from '../../components/ui/Toast';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
@@ -110,6 +111,8 @@ export interface PapersTabProps {
   pid?: string;
   /** 独立库作用域：给定时集合级调用走 /libraries/{id}/* 端点，并隐藏标签编辑/过滤 */
   libraryId?: string;
+  /** Whether the current user may upload and reprocess assets in this library. */
+  canManage?: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onOpenConcept: (id: string) => void;
@@ -710,6 +713,7 @@ function PaperDetailPane({
   paperId,
   pid,
   libraryId,
+  canManage,
   onOpenConcept,
   onWikiLink,
   onFilterAuthor,
@@ -720,7 +724,8 @@ function PaperDetailPane({
 }: {
   paperId: string;
   pid: string;
-  libraryId?: string;
+    libraryId?: string;
+    canManage: boolean;
   onOpenConcept: (id: string) => void;
   onWikiLink: WikiLinkHandler;
   /** 点击作者名 → 论文库按该作者过滤 */
@@ -940,8 +945,17 @@ function PaperDetailPane({
             {tr('原文链接', 'Source link')}
           </a>
         )}
-        <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />
-      </div>
+          {!libraryId && <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />}
+        </div>
+
+        {libraryId && (
+          <PaperAssetPanel
+            libraryId={libraryId}
+            paperId={paper.id}
+            doi={paper.doi}
+            canManage={canManage}
+          />
+        )}
 
       {/* —— 个人状态：星标 + 阅读状态 —— */}
       <div className="row gap12 wrap" style={{ marginTop: 12 }}>
@@ -1157,7 +1171,7 @@ function PaperDetailPane({
 
 /* ---------------- Tab 主体 ---------------- */
 
-export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept, onWikiLink, advSeed }: PapersTabProps) {
+export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSelect, onOpenConcept, onWikiLink, advSeed }: PapersTabProps) {
   const scopeId = libraryId ?? pid ?? '';
   const [view, setView] = useState<ViewFilter>('all');
   const [sort, setSort] = useState<PaperSort>('relevance');
@@ -1703,6 +1717,7 @@ export function PapersTab({ pid, libraryId, selectedId, onSelect, onOpenConcept,
             paperId={selectedId}
             pid={pid ?? ''}
             libraryId={libraryId}
+            canManage={canManage}
             onOpenConcept={onOpenConcept}
             onWikiLink={onWikiLink}
             onFilterAuthor={filterByAuthor}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -218,6 +218,7 @@ export function WikiWorkbench({
           <PapersTab
             pid={pid}
             libraryId={tabLibraryId}
+            canManage={canManage}
             selectedId={paperId}
             onSelect={setPaperId}
             onOpenConcept={goConcept}

--- a/src/frontend/src/lib/__tests__/markdownImages.test.tsx
+++ b/src/frontend/src/lib/__tests__/markdownImages.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Markdown } from '../markdown';
+
+describe('Markdown standard images', () => {
+  it('renders authorized structured-content images lazily', () => {
+    const html = renderToStaticMarkup(
+      <Markdown source={'![Figure 1](/api/structured-content-assets/signed-token)'} />,
+    );
+
+    expect(html).toContain('<img');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('/api/structured-content-assets/signed-token');
+    expect(html).toContain('Figure 1');
+  });
+
+  it('does not render script URLs as images', () => {
+    const html = renderToStaticMarkup(<Markdown source={'![bad](javascript:alert(1))'} />);
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('src="javascript:');
+  });
+
+  it('does not render active SVG data URLs', () => {
+    const html = renderToStaticMarkup(
+      <Markdown source={'![bad](data:image/svg+xml;base64,PHN2Zy8+)'} />,
+    );
+    expect(html).not.toContain('<img');
+  });
+});

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { tr } from './i18n';
-import { apiBase } from './endpoint';
+import { apiBase, serverOrigin } from './endpoint';
 import { readToken, writeToken } from './token-store';
 import { LocalUnavailable, noteLocalFailure, resolveLocalHandler } from './local-routes';
 /* ============================================================
@@ -138,6 +138,24 @@ async function requestBlob(path: string, init: RequestInit = {}): Promise<Blob> 
     throw new ApiError(res.status, readOnlyMessage(detail), body);
   }
   return res.blob();
+}
+
+/** Resolve a short-lived API resource URL in both web and Electron renderers. */
+export function apiResourceUrl(url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  return `${serverOrigin()}${url.startsWith('/') ? url : `/${url}`}`;
+}
+
+/** Fetch text from a signed resource URL returned by the API. */
+async function requestResourceText(url: string): Promise<string> {
+  const headers = new Headers();
+  const token = getToken();
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  const res = await fetch(apiResourceUrl(url), { headers });
+  if (!res.ok) {
+    throw new ApiError(res.status, res.statusText || `HTTP ${res.status}`);
+  }
+  return res.text();
 }
 
 /** Streaming response that deliberately leaves the body unread for Web Audio. */
@@ -931,6 +949,91 @@ export interface PaperDetail extends PaperRead {
   figures?: FigureInfo[];
   /** 手动添加后若仍需分阶段后处理，返回可订阅进度的任务 id；已处理完整时为 null。 */
   task_id?: string | null;
+}
+
+export interface PaperAssetRead {
+  id: string;
+  paper_id: string;
+  blob_id: string;
+  source: string;
+  source_locator: string | null;
+  identity_key: string | null;
+  identity_status: string;
+  sharing_scope: string;
+  state: string;
+  is_preferred: boolean;
+  byte_size: number;
+  sha256: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaperAssetGrantRead {
+  id: string;
+  asset_id: string;
+  library_id: string;
+  status: string;
+  can_read: boolean;
+  can_process: boolean;
+  granted_by: string | null;
+  revoked_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaperAssetPage {
+  items: PaperAssetRead[];
+  grants: PaperAssetGrantRead[];
+}
+
+export interface PaperContentVersionRead {
+  id: string;
+  paper_id: string;
+  asset_id: string;
+  version_no: number;
+  parser: string;
+  parser_version: string | null;
+  status: string;
+  error_code: string | null;
+  error_detail: string | null;
+  attempt: number;
+  page_count: number;
+  chunk_count: number;
+  document_vector_state: string;
+  chunk_vector_state: string;
+  is_current: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StructuredContentAssetRead {
+  kind: 'image' | 'table';
+  path: string;
+  media_type: string;
+  byte_size: number;
+  sha256: string;
+  url: string;
+  expires_at: string;
+}
+
+export interface StructuredContentManifestRead {
+  content_version_id: string;
+  paper_id: string;
+  asset_id: string;
+  version_no: number;
+  parser: string;
+  parser_version: string | null;
+  parse_status: string;
+  page_count: number;
+  chunk_count: number;
+  document_vector_state: string;
+  chunk_vector_state: string;
+  content_format: 'mineru_markdown' | 'plain_text' | 'unavailable';
+  content_hash: string | null;
+  markdown_url: string | null;
+  text_url: string | null;
+  assets: StructuredContentAssetRead[];
+  urls_expire_at: string | null;
 }
 
 export interface PageOf<T> {
@@ -3451,6 +3554,50 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ url }),
     });
+  },
+
+  // —— Library-scoped PDF assets and versioned structured content ——
+  listLibraryPaperAssets(libraryId: string, paperId: string): Promise<PaperAssetPage> {
+    return request<PaperAssetPage>(`/libraries/${libraryId}/papers/${paperId}/assets`);
+  },
+  uploadLibraryPaperAsset(
+    libraryId: string,
+    paperId: string,
+    file: File,
+    options: { sharingScope?: 'private' | 'library' | 'public'; identityKey?: string | null } = {},
+  ): Promise<PaperAssetRead> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('source', 'upload');
+    form.append('sharing_scope', options.sharingScope ?? 'private');
+    form.append('identity_status', 'verified');
+    if (options.identityKey) form.append('identity_key', options.identityKey);
+    return request<PaperAssetRead>(`/libraries/${libraryId}/papers/${paperId}/assets`, {
+      method: 'POST',
+      body: form,
+    });
+  },
+  downloadLibraryPaperAsset(libraryId: string, paperId: string, assetId: string): Promise<Blob> {
+    return requestBlob(`/libraries/${libraryId}/papers/${paperId}/assets/${assetId}/download`);
+  },
+  createLibraryPaperContentVersion(
+    libraryId: string,
+    paperId: string,
+    assetId: string,
+  ): Promise<PaperContentVersionRead> {
+    return request<PaperContentVersionRead>(
+      `/libraries/${libraryId}/papers/${paperId}/assets/${assetId}/content-versions`,
+      { method: 'POST' },
+    );
+  },
+  getLibraryPaperContentVersion(libraryId: string, paperId: string): Promise<PaperContentVersionRead> {
+    return request<PaperContentVersionRead>(`/libraries/${libraryId}/papers/${paperId}/content-version`);
+  },
+  getLibraryPaperStructuredContent(libraryId: string, paperId: string): Promise<StructuredContentManifestRead> {
+    return request<StructuredContentManifestRead>(`/libraries/${libraryId}/papers/${paperId}/structured-content`);
+  },
+  fetchStructuredContentText(url: string): Promise<string> {
+    return requestResourceText(url);
   },
 
   // —— Lit · 论文图片（docs/api-lit.md §6.5） ——

--- a/src/frontend/src/lib/markdown.tsx
+++ b/src/frontend/src/lib/markdown.tsx
@@ -66,6 +66,7 @@ export type LibraryFigureRenderer = (paperId: string, index: number) => ReactNod
  * 返回 null 时按普通文本渲染。未提供回调时 `[n]` 不做任何解析。
  */
 export type CitationRenderer = (index: number) => ReactNode;
+export type ImageRenderer = (src: string, alt: string) => ReactNode;
 
 export interface MarkdownProps {
   source: string;
@@ -78,6 +79,8 @@ export interface MarkdownProps {
   renderLibraryFigure?: LibraryFigureRenderer;
   /** 渲染行内 `[n]` 引用角标（文献库对话） */
   renderCitation?: CitationRenderer;
+  /** Render a standard Markdown image. Defaults to a safe, lazy-loaded image. */
+  renderImage?: ImageRenderer;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -187,6 +190,7 @@ const RE_QUOTE = /^\s*>\s?(.*)$/;
 const RE_TABLE_SEP = /^\s*\|?\s*:?-{2,}[-\s:|]*$/;
 /** 独立一行的 ![[fig:N]] 图片标记（docs/api-lit.md §6.6） */
 const RE_FIG_LINE = /^\s*!\[\[fig:(\d+)\]\]\s*$/;
+const RE_IMAGE_LINE = /^\s*!\[([^\]]*)\]\(<?([^\s)>]+)>?(?:\s+["'][^"']*["'])?\)\s*$/;
 /** 块级公式起始：$$… 或 \[… */
 const RE_MATH_OPEN = /^\s*(\$\$|\\\[)/;
 
@@ -197,7 +201,14 @@ function isBlockStart(line: string): boolean {
     RE_OL.test(line) ||
     RE_QUOTE.test(line) ||
     line.trim().startsWith('```')
+    || RE_IMAGE_LINE.test(line)
   );
+}
+
+function safeImageUrl(url: string): string | null {
+  if (/^https?:\/\//i.test(url) || url.startsWith('/')) return url;
+  if (/^data:image\/(?:png|jpe?g|gif|webp);base64,/i.test(url)) return url;
+  return null;
 }
 
 function splitTableRow(line: string): string[] {
@@ -214,6 +225,7 @@ function parseBlocks(
   renderPaperRef?: PaperRefRenderer,
   renderCitation?: CitationRenderer,
   renderLibraryFigure?: LibraryFigureRenderer,
+  renderImage?: ImageRenderer,
 ): ReactNode[] {
   const lines = src.replace(/\r\n/g, '\n').split('\n');
   const out: ReactNode[] = [];
@@ -287,6 +299,31 @@ function parseBlocks(
       continue;
     }
 
+    // Standard Markdown image. MinerU emits these paths after structure parsing;
+    // the structured-content API rewrites them to short-lived authorized URLs.
+    const imageMatch = RE_IMAGE_LINE.exec(line);
+    if (imageMatch) {
+      const alt = imageMatch[1] ?? '';
+      const src = imageMatch[2] ?? '';
+      const custom = renderImage?.(src, alt) ?? null;
+      const safeSrc = safeImageUrl(src);
+      const node = custom ?? (safeSrc ? (
+        <figure style={{ margin: '18px auto', width: 'fit-content', maxWidth: '100%' }}>
+          <img
+            src={safeSrc}
+            alt={alt}
+            loading="lazy"
+            decoding="async"
+            style={{ display: 'block', maxWidth: '100%', height: 'auto', borderRadius: 4 }}
+          />
+          {alt && <figcaption className="muted" style={{ marginTop: 7, fontSize: 11.5, textAlign: 'center' }}>{alt}</figcaption>}
+        </figure>
+      ) : null);
+      if (node !== null && node !== undefined && node !== false) out.push(<div key={key++}>{node}</div>);
+      i++;
+      continue;
+    }
+
     // 标题
     const h = RE_HEADING.exec(line);
     if (h) {
@@ -346,7 +383,7 @@ function parseBlocks(
         buf.push(q[1] ?? '');
         i++;
       }
-      out.push(<blockquote key={key++}>{parseBlocks(buf.join('\n'), onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure)}</blockquote>);
+      out.push(<blockquote key={key++}>{parseBlocks(buf.join('\n'), onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure, renderImage)}</blockquote>);
       continue;
     }
 
@@ -398,12 +435,13 @@ export function Markdown({
   renderPaperRef,
   renderLibraryFigure,
   renderCitation,
+  renderImage,
   className,
   style,
 }: MarkdownProps) {
   const nodes = useMemo(
-    () => parseBlocks(source, onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure),
-    [source, onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure],
+    () => parseBlocks(source, onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure, renderImage),
+    [source, onWikiLink, renderFigure, renderPaperRef, renderCitation, renderLibraryFigure, renderImage],
   );
   return (
     <div className={`md${className ? ` ${className}` : ''}`} style={style}>

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -33,6 +33,28 @@ html { zoom: 1.1; }
   --winctl-w: calc((100vw - env(titlebar-area-width, calc(100vw - 138px))) / 1.1);
 }
 
+@media (max-width: 680px) {
+  .paper-asset-summary {
+    align-items: flex-start !important;
+  }
+
+  .paper-asset-states {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .paper-asset-actions {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .paper-asset-actions > * {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
 /* 让空出来的带子可以拖动窗口（内容盖住了系统标题栏区域，否则拖不动）。
    只覆盖留白本身，不会挡住任何可点元素。 */
 :root[data-desktop-platform='darwin'] .sidebar::before,


### PR DESCRIPTION
## Summary

Expose the library-scoped PDF asset and versioned full-text APIs already present on `main` in the paper detail and reading workspaces. Library managers can upload and reparse authorized PDFs, while every authorized reader can inspect processing/vector state, download the granted asset, and read MinerU Markdown or PyMuPDF plain text.

Closes #536

## Area

- [x] frontend
- [x] literature / wiki

## What changed

- adds typed clients for `PaperAsset`, `AssetGrant`, `PaperContentVersion`, and structured-content manifests
- uploads a library PDF through the standard asset endpoint and explicitly queues its first content version
- shows provenance, sharing scope, parse stage, paper-vector state, and chunk-vector state in paper details
- lets managers queue a fresh immutable content version with a sentence-anchor fallback warning
- makes the PDF reader use the current library-authorized asset while preserving the legacy paper PDF fallback
- adds structured Markdown/plain-text reading modes backed by signed resource URLs
- renders standard Markdown tables and authorized lazy-loaded images without allowing active image URL schemes
- keeps management controls hidden from non-managers and preserves project-scoped legacy upload behavior
- adds narrow-screen layout rules for the asset status and action groups

## Integration and dependency notes

- Based directly on `origin/main@851abc8`; it is not stacked on #530, #531, #533, or #535.
- Consumes only APIs already merged through #522 and the PDF/content lifecycle changes on `main`.
- Does not add migrations, backend compatibility endpoints, credentials, PDFs, screenshots, or build output.

## Testing

- [x] `npm test` — 98 tests passed
- [x] `npm run build` — TypeScript and Vite production build passed
- [x] `git diff --check`
- [x] sensitive-value scan of changed frontend source
- [x] manually verified with the real components and mocked standard API responses at 1440x1000 and 390x844
- [x] verified structured Markdown headings, GFM-style table layout, signed image rendering, and mobile action wrapping

## Checklist

- [x] Branch is based on the latest `origin/main` without merge commits
- [x] Conventional-commit PR title and commit
- [x] No AI attribution / `Co-Authored-By` lines
- [ ] Screenshots attached (visual verification was local and no generated artifacts are committed)