### PR TITLE
feat(extension): add least-privilege PDF archive client

### DIFF
--- a/integrations/polaris-browser-extension/README.md
+++ b/integrations/polaris-browser-extension/README.md
@@ -1,0 +1,35 @@
+# Polaris Extension
+
+This directory contains the least-privilege Manifest V3 reference client for the Polaris PDF download and archive protocol.
+
+## Scope
+
+- Connect to one user-configured Polaris instance with a user-scoped `pol_dl_` API key.
+- Receive `polaris:download-batch:v2` events from that instance.
+- Keep one local task per pushed batch and preserve an independent library/paper binding for every item.
+- Fetch a selected PDF candidate or accept a user-selected local PDF.
+- Verify the `%PDF-` signature, size, and SHA-256 before caching bytes in Cache Storage.
+- Archive cached files to `/api/download-client/archive` with each paper's own identity metadata.
+
+The core client does not include YFR page integration, SCNet automation, Zotero integration, native messaging, publisher-specific automation, CAPTCHA handling, or a fixed-directory bridge.
+
+## Install for development
+
+1. Open `chrome://extensions`.
+2. Enable Developer mode.
+3. Choose **Load unpacked** and select this directory.
+4. Open the side panel, enter the Polaris origin and a `pol_dl_` API key, then test and save the connection.
+
+The extension requests access to the configured Polaris origin when the user saves the connection. Candidate PDF origins are requested only when the user starts a download. It has no install-time host access.
+
+## Protocol
+
+Polaris dispatches a `polaris:download-batch:v2` DOM event. The dynamically registered bridge forwards the payload to the service worker and returns a `polaris:download-batch-ack:v2` event. A batch becomes one task containing multiple items; an item is always archived by its own `library_id`, `paper_id`, nonce, and bibliographic identity.
+
+## Tests
+
+```bash
+npm run check
+```
+
+The tests cover origin and permission normalization, expiring batch validation, independent per-paper bindings, PDF verification and hashing, archive metadata, and manifest permission boundaries.

--- a/integrations/polaris-browser-extension/index.html
+++ b/integrations/polaris-browser-extension/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
+    <title>Polaris Extension</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="app-header">
+        <div>
+          <strong class="brand">POLARIS<span>.</span></strong>
+          <h1>PDF 下载与归档</h1>
+        </div>
+        <span id="connection-badge" class="badge">未连接</span>
+      </header>
+
+      <section class="panel connection-panel" aria-labelledby="connection-title">
+        <div class="section-heading">
+          <div>
+            <span class="eyebrow">WORKSPACE CONNECTION</span>
+            <h2 id="connection-title">连接科研工作台</h2>
+          </div>
+          <span id="connection-status" class="muted" role="status">尚未配置</span>
+        </div>
+        <label for="polaris-origin">Polaris 地址</label>
+        <input id="polaris-origin" type="url" autocomplete="url" placeholder="https://polaris.example.com" />
+        <label for="polaris-api-key">用户 API Key</label>
+        <input id="polaris-api-key" type="password" autocomplete="off" placeholder="pol_dl_..." />
+        <div class="button-row">
+          <button id="test-connection" class="secondary" type="button">测试连接</button>
+          <button id="save-connection" class="primary" type="button">保存连接</button>
+        </div>
+      </section>
+
+      <section class="workspace" aria-labelledby="tasks-title">
+        <div class="section-heading tasks-heading">
+          <div>
+            <span class="eyebrow">DOWNLOAD BATCHES</span>
+            <h2 id="tasks-title">下载任务</h2>
+          </div>
+          <button id="refresh-tasks" class="secondary compact" type="button">刷新</button>
+        </div>
+        <div id="task-list" class="task-list"></div>
+        <div id="empty-state" class="empty-state">
+          <strong>暂无下载任务</strong>
+          <p>在 Polaris 文献发现页选择论文并推送到扩展后，任务会显示在这里。</p>
+        </div>
+      </section>
+
+      <div id="notice" class="notice" role="status" aria-live="polite"></div>
+    </main>
+    <script type="module" src="src/sidepanel/app.js"></script>
+  </body>
+</html>

--- a/integrations/polaris-browser-extension/manifest.json
+++ b/integrations/polaris-browser-extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "name": "Polaris Extension",
+  "description": "Receive Polaris literature batches, cache verified PDFs, and archive them to the correct library papers.",
+  "version": "0.1.0",
+  "minimum_chrome_version": "116",
+  "permissions": [
+    "storage",
+    "scripting",
+    "sidePanel",
+    "unlimitedStorage"
+  ],
+  "optional_host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+  "background": {
+    "service_worker": "src/background/service-worker.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Open Polaris Extension"
+  },
+  "side_panel": {
+    "default_path": "index.html"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; base-uri 'none'"
+  }
+}

--- a/integrations/polaris-browser-extension/package.json
+++ b/integrations/polaris-browser-extension/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "polaris-browser-extension",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --test tests/*.test.js"
+  }
+}

--- a/integrations/polaris-browser-extension/src/background/api.js
+++ b/integrations/polaris-browser-extension/src/background/api.js
@@ -1,0 +1,69 @@
+import { normalizePolarisOrigin } from "../shared/origin.js";
+import { inspectPdf } from "../shared/pdf.js";
+
+function assertApiKey(apiKey) {
+  if (!String(apiKey || "").startsWith("pol_dl_")) throw new Error("Polaris API Key 格式无效");
+}
+
+async function responseError(response, fallback) {
+  const payload = await response.json().catch(() => ({}));
+  if (response.status === 401) return "Polaris API Key 无效或已失效";
+  if (response.status === 403) return "当前用户无权管理目标文献库";
+  return String(payload.detail || fallback);
+}
+
+export async function testPolarisConnection({ instanceOrigin, apiKey, fetchImpl = fetch }) {
+  const origin = normalizePolarisOrigin(instanceOrigin);
+  assertApiKey(apiKey);
+  const response = await fetchImpl(`${origin}/api/download-client/me`, {
+    headers: { "X-Polaris-API-Key": apiKey },
+  });
+  if (!response.ok) throw new Error(await responseError(response, `连接失败（HTTP ${response.status}）`));
+  return { origin, user: await response.json() };
+}
+
+export function archiveMetadataForItem(item) {
+  if (!item?.libraryId || !item?.paperId || !item?.nonce || !item?.title) {
+    throw new Error("论文缺少独立归档绑定");
+  }
+  return {
+    library_id: item.libraryId,
+    paper_id: item.paperId,
+    nonce: item.nonce,
+    doi: item.doi || null,
+    pmid: item.pmid || null,
+    pmcid: item.pmcid || null,
+    arxiv_id: item.arxivId || null,
+    title: item.title,
+    source_url: item.cache?.sourceUrl || item.articleUrl || null,
+  };
+}
+
+export async function archivePdfToPolaris({
+  connection,
+  item,
+  cachedResponse,
+  fetchImpl = fetch,
+}) {
+  const origin = normalizePolarisOrigin(connection?.instanceOrigin);
+  assertApiKey(connection?.apiKey);
+  if (!cachedResponse) throw new Error("浏览器缓存中没有该论文 PDF");
+  const bytes = new Uint8Array(await cachedResponse.arrayBuffer());
+  const inspected = await inspectPdf(bytes);
+  if (item.cache?.sha256 && inspected.sha256 !== item.cache.sha256) {
+    throw new Error("PDF 浏览器缓存校验失败");
+  }
+  const form = new FormData();
+  form.set("metadata", JSON.stringify(archiveMetadataForItem(item)));
+  form.set("pdf", new Blob([bytes], { type: "application/pdf" }), `${item.paperId}.pdf`);
+  const response = await fetchImpl(`${origin}/api/download-client/archive`, {
+    method: "POST",
+    headers: {
+      "X-Polaris-API-Key": connection.apiKey,
+      "X-Polaris-PDF-SHA256": inspected.sha256,
+    },
+    body: form,
+  });
+  if (!response.ok) throw new Error(await responseError(response, `归档失败（HTTP ${response.status}）`));
+  return response.json();
+}

--- a/integrations/polaris-browser-extension/src/background/bridge.js
+++ b/integrations/polaris-browser-extension/src/background/bridge.js
@@ -1,0 +1,41 @@
+import { normalizePolarisOrigin, permissionPatternForUrl } from "../shared/origin.js";
+
+const SCRIPT_ID = "polaris-download-bridge";
+
+export async function requestOriginPermission(origin) {
+  const pattern = permissionPatternForUrl(normalizePolarisOrigin(origin));
+  const granted = await chrome.permissions.request({ origins: [pattern] });
+  if (!granted) throw new Error("需要授权访问该 Polaris 地址");
+  return pattern;
+}
+
+export async function requestUrlPermission(url) {
+  const pattern = permissionPatternForUrl(url);
+  const granted = await chrome.permissions.request({ origins: [pattern] });
+  if (!granted) throw new Error("未授权访问该 PDF 来源");
+  return pattern;
+}
+
+export async function requireUrlPermission(url) {
+  const pattern = permissionPatternForUrl(url);
+  const granted = await chrome.permissions.contains({ origins: [pattern] });
+  if (!granted) throw new Error("未授权访问该 PDF 来源，请重新点击下载");
+  return pattern;
+}
+
+export async function registerPolarisBridge(origin) {
+  const normalized = normalizePolarisOrigin(origin);
+  const pattern = permissionPatternForUrl(normalized);
+  const allowed = await chrome.permissions.contains({ origins: [pattern] });
+  if (!allowed) return false;
+  const registrations = await chrome.scripting.getRegisteredContentScripts({ ids: [SCRIPT_ID] });
+  if (registrations.length) await chrome.scripting.unregisterContentScripts({ ids: [SCRIPT_ID] });
+  await chrome.scripting.registerContentScripts([{
+    id: SCRIPT_ID,
+    matches: [pattern],
+    js: ["src/content/polaris-bridge.js"],
+    runAt: "document_idle",
+    persistAcrossSessions: true,
+  }]);
+  return true;
+}

--- a/integrations/polaris-browser-extension/src/background/cache.js
+++ b/integrations/polaris-browser-extension/src/background/cache.js
@@ -1,0 +1,71 @@
+import { inspectPdf, MAX_PDF_BYTES } from "../shared/pdf.js";
+
+const CACHE_NAME = "polaris-pdf-cache-v1";
+const CACHE_ORIGIN = "https://polaris-extension.invalid";
+
+export function pdfCacheKey(taskId, itemId) {
+  if (!taskId || !itemId) throw new Error("PDF 缓存标识不完整");
+  return `${CACHE_ORIGIN}/pdf/${encodeURIComponent(taskId)}/${encodeURIComponent(itemId)}.pdf`;
+}
+
+export async function cachePdfBytes({ taskId, itemId, value, sourceUrl = null, cacheStorage = caches }) {
+  const inspected = await inspectPdf(value);
+  const cacheKey = pdfCacheKey(taskId, itemId);
+  const cache = await cacheStorage.open(CACHE_NAME);
+  const source = inspected.bytes.buffer.slice(
+    inspected.bytes.byteOffset,
+    inspected.bytes.byteOffset + inspected.bytes.byteLength,
+  );
+  await cache.put(cacheKey, new Response(source, {
+    headers: {
+      "content-type": "application/pdf",
+      "content-length": String(inspected.byteSize),
+      ...(sourceUrl ? { "x-polaris-source-url": sourceUrl.slice(0, 4000) } : {}),
+    },
+  }));
+  return { cacheKey, byteSize: inspected.byteSize, sha256: inspected.sha256, sourceUrl };
+}
+
+export async function fetchAndCachePdf({
+  taskId,
+  itemId,
+  url,
+  fetchImpl = fetch,
+  cacheStorage = caches,
+  maxBytes = MAX_PDF_BYTES,
+}) {
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { Accept: "application/pdf" },
+    credentials: "include",
+    redirect: "follow",
+    cache: "no-store",
+  });
+  if (!response.ok) throw new Error(`PDF 下载失败（HTTP ${response.status}）`);
+  const declaredBytes = Number(response.headers.get("content-length") || 0);
+  if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+    throw new Error("PDF 超过 150 MB 大小上限");
+  }
+  const buffer = await response.arrayBuffer();
+  return cachePdfBytes({
+    taskId,
+    itemId,
+    value: buffer,
+    sourceUrl: response.url || url,
+    cacheStorage,
+  });
+}
+
+export async function getCachedPdf(cacheKey, cacheStorage = caches) {
+  if (!cacheKey) return null;
+  const cache = await cacheStorage.open(CACHE_NAME);
+  return cache.match(cacheKey);
+}
+
+export async function deleteCachedPdf(cacheKey, cacheStorage = caches) {
+  if (!cacheKey) return false;
+  const cache = await cacheStorage.open(CACHE_NAME);
+  return cache.delete(cacheKey);
+}
+
+export const PDF_CACHE_NAME = CACHE_NAME;

--- a/integrations/polaris-browser-extension/src/background/service-worker.js
+++ b/integrations/polaris-browser-extension/src/background/service-worker.js
@@ -1,0 +1,177 @@
+import { archivePdfToPolaris, testPolarisConnection } from "./api.js";
+import { registerPolarisBridge, requireUrlPermission } from "./bridge.js";
+import { deleteCachedPdf, fetchAndCachePdf, getCachedPdf } from "./cache.js";
+import { getConnection, getTask, listTasks, putTask, removeTask, saveConnection, updateItem } from "./storage.js";
+import { createLocalTask, validateDownloadBatch } from "../shared/batch.js";
+import { normalizePolarisOrigin, originsMatch, permissionPatternForUrl } from "../shared/origin.js";
+
+function messageError(error) {
+  return error instanceof Error ? error.message : String(error || "操作失败");
+}
+
+async function publicState() {
+  const connection = await getConnection();
+  return {
+    connection: connection ? {
+      instanceOrigin: connection.instanceOrigin,
+      user: connection.user,
+      hasApiKey: Boolean(connection.apiKey),
+      updatedAt: connection.updatedAt,
+    } : null,
+    tasks: await listTasks(),
+  };
+}
+
+async function connectionInput(payload) {
+  const existing = await getConnection();
+  const instanceOrigin = normalizePolarisOrigin(payload?.instanceOrigin || existing?.instanceOrigin);
+  const suppliedApiKey = String(payload?.apiKey || "").trim();
+  const canReuseExisting = existing && originsMatch(existing.instanceOrigin, instanceOrigin);
+  const apiKey = suppliedApiKey || (canReuseExisting ? existing.apiKey : "");
+  return { instanceOrigin, apiKey };
+}
+
+async function connect(payload, save) {
+  const existing = await getConnection();
+  const input = await connectionInput(payload);
+  const verified = await testPolarisConnection(input);
+  if (save) {
+    const bridgeRegistered = await registerPolarisBridge(input.instanceOrigin);
+    if (!bridgeRegistered) throw new Error("需要授权访问该 Polaris 地址");
+    await saveConnection({ ...input, user: verified.user });
+    if (existing?.instanceOrigin && !originsMatch(existing.instanceOrigin, input.instanceOrigin)) {
+      const pattern = permissionPatternForUrl(existing.instanceOrigin);
+      await chrome.permissions.remove({ origins: [pattern] });
+    }
+  }
+  return { ok: true, origin: verified.origin, user: verified.user };
+}
+
+async function importBatch(message) {
+  const connection = await getConnection();
+  if (!connection?.apiKey) throw new Error("请先在扩展中连接 Polaris");
+  if (!originsMatch(connection.instanceOrigin, message.pageOrigin)) {
+    throw new Error("当前页面与扩展连接的 Polaris 实例不一致");
+  }
+  const validated = validateDownloadBatch(message.payload, message.pageOrigin);
+  if (!validated.ok) throw new Error(validated.error);
+  const tasks = await listTasks();
+  const duplicate = tasks.find((task) => task.batchNonce === validated.value.batchNonce);
+  if (duplicate) return { ok: true, taskId: duplicate.id, count: duplicate.items.length, duplicate: true };
+  const task = createLocalTask(validated.value);
+  await putTask(task);
+  return { ok: true, taskId: task.id, count: task.items.length };
+}
+
+async function taskItem(taskId, itemId) {
+  const task = await getTask(taskId);
+  const item = task?.items.find((entry) => entry.id === itemId);
+  if (!task || !item) throw new Error("下载任务中的论文不存在");
+  return { task, item };
+}
+
+async function downloadItem(payload) {
+  const { task, item } = await taskItem(payload.taskId, payload.itemId);
+  const candidate = item.candidates.find((entry) => entry.url === payload.url) || item.candidates[0];
+  if (!candidate) throw new Error("该论文没有可用的 PDF 候选地址");
+  await requireUrlPermission(candidate.url);
+  await updateItem(task.id, item.id, { ...item, status: "downloading", error: null });
+  try {
+    const cache = await fetchAndCachePdf({ taskId: task.id, itemId: item.id, url: candidate.url });
+    await updateItem(task.id, item.id, (current) => ({ ...current, status: "cached", error: null, cache }));
+    return { ok: true, cache };
+  } catch (error) {
+    await updateItem(task.id, item.id, (current) => ({ ...current, status: "failed", error: messageError(error) }));
+    throw error;
+  }
+}
+
+async function acknowledgeManualCache(payload) {
+  const { task, item } = await taskItem(payload.taskId, payload.itemId);
+  if (!payload.cache?.cacheKey || !payload.cache?.sha256 || !payload.cache?.byteSize) {
+    throw new Error("手动 PDF 缓存信息不完整");
+  }
+  await updateItem(task.id, item.id, { ...item, status: "cached", error: null, cache: payload.cache });
+  return { ok: true };
+}
+
+async function archiveItem(taskId, itemId) {
+  const { task, item } = await taskItem(taskId, itemId);
+  if (!item.cache?.cacheKey) throw new Error("请先缓存该论文 PDF");
+  const connection = await getConnection();
+  if (!connection || !originsMatch(connection.instanceOrigin, task.instanceOrigin)) {
+    throw new Error("任务来源与当前 Polaris 连接不一致");
+  }
+  const cachedResponse = await getCachedPdf(item.cache.cacheKey);
+  await updateItem(task.id, item.id, { ...item, status: "archiving", error: null });
+  try {
+    const archive = await archivePdfToPolaris({ connection, item, cachedResponse });
+    await updateItem(task.id, item.id, (current) => ({ ...current, status: "archived", error: null, archive }));
+    return { ok: true, archive };
+  } catch (error) {
+    await updateItem(task.id, item.id, (current) => ({ ...current, status: "failed", error: messageError(error) }));
+    throw error;
+  }
+}
+
+async function archiveTask(taskId) {
+  const task = await getTask(taskId);
+  if (!task) throw new Error("下载任务不存在");
+  const results = [];
+  for (const item of task.items) {
+    if (!item.cache?.cacheKey || item.status === "archived") continue;
+    try {
+      await archiveItem(taskId, item.id);
+      results.push({ itemId: item.id, ok: true });
+    } catch (error) {
+      results.push({ itemId: item.id, ok: false, error: messageError(error) });
+    }
+  }
+  return {
+    ok: results.some((result) => result.ok),
+    archived: results.filter((result) => result.ok).length,
+    failed: results.filter((result) => !result.ok).length,
+  };
+}
+
+async function deleteTask(taskId) {
+  const removed = await removeTask(taskId);
+  for (const item of removed?.items || []) await deleteCachedPdf(item.cache?.cacheKey);
+  return { ok: true };
+}
+
+async function handleMessage(message) {
+  switch (message?.type) {
+    case "GET_STATE": return { ok: true, ...(await publicState()) };
+    case "TEST_CONNECTION": return connect(message.payload, false);
+    case "SAVE_CONNECTION": return connect(message.payload, true);
+    case "POLARIS_IMPORT_BATCH": return importBatch(message);
+    case "DOWNLOAD_ITEM": return downloadItem(message.payload);
+    case "MANUAL_PDF_CACHED": return acknowledgeManualCache(message.payload);
+    case "ARCHIVE_ITEM": return archiveItem(message.payload.taskId, message.payload.itemId);
+    case "ARCHIVE_TASK": return archiveTask(message.payload.taskId);
+    case "DELETE_TASK": return deleteTask(message.payload.taskId);
+    case "OPEN_ARTICLE":
+      await chrome.tabs.create({ url: message.payload.url });
+      return { ok: true };
+    default: throw new Error("不支持的扩展操作");
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  handleMessage(message)
+    .then((result) => sendResponse(result))
+    .catch((error) => sendResponse({ ok: false, error: messageError(error) }));
+  return true;
+});
+
+async function restoreBridge() {
+  const connection = await getConnection();
+  if (connection?.instanceOrigin) await registerPolarisBridge(connection.instanceOrigin);
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => undefined);
+  restoreBridge().catch(() => undefined);
+});
+chrome.runtime.onStartup.addListener(() => restoreBridge().catch(() => undefined));

--- a/integrations/polaris-browser-extension/src/background/storage.js
+++ b/integrations/polaris-browser-extension/src/background/storage.js
@@ -1,0 +1,75 @@
+const CONNECTION_KEY = "polarisConnection";
+const TASKS_KEY = "polarisDownloadTasks";
+let writeQueue = Promise.resolve();
+
+async function read(key, fallback) {
+  const result = await chrome.storage.local.get(key);
+  return result[key] ?? fallback;
+}
+
+function serializedWrite(operation) {
+  const next = writeQueue.then(operation, operation);
+  writeQueue = next.catch(() => undefined);
+  return next;
+}
+
+export function getConnection() {
+  return read(CONNECTION_KEY, null);
+}
+
+export async function saveConnection(connection) {
+  const value = { ...connection, updatedAt: new Date().toISOString() };
+  await chrome.storage.local.set({ [CONNECTION_KEY]: value });
+  return value;
+}
+
+export function listTasks() {
+  return read(TASKS_KEY, []);
+}
+
+export async function getTask(taskId) {
+  return (await listTasks()).find((task) => task.id === taskId) || null;
+}
+
+export function putTask(task) {
+  return serializedWrite(async () => {
+    const tasks = await listTasks();
+    const index = tasks.findIndex((entry) => entry.id === task.id);
+    if (index >= 0) tasks[index] = task;
+    else tasks.unshift(task);
+    await chrome.storage.local.set({ [TASKS_KEY]: tasks.slice(0, 100) });
+    return task;
+  });
+}
+
+export function updateTask(taskId, updater) {
+  return serializedWrite(async () => {
+    const tasks = await listTasks();
+    const index = tasks.findIndex((entry) => entry.id === taskId);
+    if (index < 0) throw new Error("下载任务不存在");
+    const updated = updater(structuredClone(tasks[index]));
+    updated.updatedAt = new Date().toISOString();
+    tasks[index] = updated;
+    await chrome.storage.local.set({ [TASKS_KEY]: tasks });
+    return updated;
+  });
+}
+
+export function updateItem(taskId, itemId, patch) {
+  return updateTask(taskId, (task) => {
+    const index = task.items.findIndex((item) => item.id === itemId);
+    if (index < 0) throw new Error("下载任务中的论文不存在");
+    const value = typeof patch === "function" ? patch(task.items[index]) : { ...task.items[index], ...patch };
+    task.items[index] = value;
+    return task;
+  });
+}
+
+export function removeTask(taskId) {
+  return serializedWrite(async () => {
+    const tasks = await listTasks();
+    const removed = tasks.find((task) => task.id === taskId) || null;
+    await chrome.storage.local.set({ [TASKS_KEY]: tasks.filter((task) => task.id !== taskId) });
+    return removed;
+  });
+}

--- a/integrations/polaris-browser-extension/src/content/polaris-bridge.js
+++ b/integrations/polaris-browser-extension/src/content/polaris-bridge.js
@@ -1,0 +1,34 @@
+(() => {
+  const PROBE = "polaris:download-extension-probe:v1";
+  const READY = "polaris:download-extension-ready:v1";
+  const BATCH = "polaris:download-batch:v2";
+  const ACK = "polaris:download-batch-ack:v2";
+
+  const clone = (value) => {
+    try {
+      return value == null ? null : JSON.parse(JSON.stringify(value));
+    } catch {
+      return null;
+    }
+  };
+  const signalReady = () => document.dispatchEvent(new CustomEvent(READY));
+
+  document.addEventListener(PROBE, signalReady);
+  document.addEventListener(BATCH, (event) => {
+    const payload = clone(event instanceof CustomEvent ? event.detail : null);
+    const requestId = payload?.batch_nonce || null;
+    chrome.runtime.sendMessage({
+      type: "POLARIS_IMPORT_BATCH",
+      payload,
+      pageOrigin: location.origin,
+    }).then((result) => {
+      const safe = result && typeof result === "object" ? result : { ok: false, error: "扩展返回了无效响应" };
+      document.dispatchEvent(new CustomEvent(ACK, { detail: { ...safe, requestId } }));
+    }).catch(() => {
+      document.dispatchEvent(new CustomEvent(ACK, {
+        detail: { ok: false, requestId, error: "Polaris 扩展暂时不可用" },
+      }));
+    });
+  });
+  signalReady();
+})();

--- a/integrations/polaris-browser-extension/src/shared/batch.js
+++ b/integrations/polaris-browser-extension/src/shared/batch.js
@@ -1,0 +1,123 @@
+import { normalizeHttpUrl, normalizePolarisOrigin } from "./origin.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function object(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value, maxLength) {
+  return String(value || "").trim().slice(0, maxLength);
+}
+
+function uuid(value) {
+  const normalized = text(value, 64);
+  return UUID_RE.test(normalized) ? normalized.toLowerCase() : null;
+}
+
+function identifier(value, maxLength) {
+  const normalized = text(value, maxLength);
+  return normalized || null;
+}
+
+function validateWindow(payload, now) {
+  const issuedAt = Date.parse(payload.issued_at || "");
+  const expiresAt = Date.parse(payload.expires_at || "");
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt)) return false;
+  return issuedAt <= now + 60_000 && expiresAt >= now && expiresAt - issuedAt <= 10 * 60_000;
+}
+
+function normalizeCandidates(value) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 40).map((entry) => {
+    const raw = object(entry) ? entry : { url: entry };
+    const url = normalizeHttpUrl(raw.url);
+    if (!url) return null;
+    return {
+      url,
+      source: text(raw.source, 80) || "polaris",
+      kind: text(raw.kind, 40) || "unknown",
+    };
+  }).filter(Boolean);
+}
+
+export function validateDownloadBatch(payload, pageOrigin, now = Date.now()) {
+  if (!object(payload) || payload.version !== 2) {
+    return { ok: false, error: "不支持的 Polaris 批次版本" };
+  }
+  let instanceOrigin;
+  let eventOrigin;
+  try {
+    instanceOrigin = normalizePolarisOrigin(payload.instance_origin);
+    eventOrigin = normalizePolarisOrigin(pageOrigin);
+  } catch (error) {
+    return { ok: false, error: error.message };
+  }
+  if (instanceOrigin !== eventOrigin) return { ok: false, error: "批次实例与当前页面不一致" };
+  if (!validateWindow(payload, now)) return { ok: false, error: "Polaris 下载批次已过期" };
+
+  const batchNonce = text(payload.batch_nonce, 200);
+  const backendBatchId = payload.backend_batch_id == null ? null : uuid(payload.backend_batch_id);
+  const rawPapers = Array.isArray(payload.papers) ? payload.papers : [];
+  if (batchNonce.length < 16 || (payload.backend_batch_id && !backendBatchId)) {
+    return { ok: false, error: "Polaris 下载批次缺少必要标识" };
+  }
+  if (rawPapers.length < 1 || rawPapers.length > 500) {
+    return { ok: false, error: "Polaris 下载批次论文数量必须为 1-500" };
+  }
+
+  const papers = [];
+  const bindings = new Set();
+  for (const raw of rawPapers) {
+    if (!object(raw)) return { ok: false, error: "Polaris 论文数据格式无效" };
+    const libraryId = uuid(raw.library_id);
+    const paperId = uuid(raw.paper_id);
+    const nonce = text(raw.nonce, 200);
+    const identity = object(raw.identity) ? raw.identity : {};
+    const title = text(identity.title, 2000);
+    if (!libraryId || !paperId || nonce.length < 16 || !title) {
+      return { ok: false, error: "Polaris 论文缺少独立归档标识" };
+    }
+    const binding = `${libraryId}:${paperId}`;
+    if (bindings.has(binding)) return { ok: false, error: "Polaris 下载批次包含重复论文目标" };
+    bindings.add(binding);
+    papers.push({
+      libraryId,
+      paperId,
+      nonce,
+      title,
+      doi: identifier(identity.doi, 512),
+      pmid: identifier(identity.pmid, 64),
+      pmcid: identifier(identity.pmcid, 64),
+      arxivId: identifier(identity.arxiv_id, 128),
+      articleUrl: normalizeHttpUrl(raw.article_url),
+      candidates: normalizeCandidates(raw.pdf_candidates),
+    });
+  }
+  return {
+    ok: true,
+    value: { instanceOrigin, batchNonce, backendBatchId, papers },
+  };
+}
+
+export function createLocalTask(batch, randomUuid = () => crypto.randomUUID(), now = new Date()) {
+  const taskId = randomUuid();
+  return {
+    id: taskId,
+    source: "polaris",
+    instanceOrigin: batch.instanceOrigin,
+    batchNonce: batch.batchNonce,
+    backendBatchId: batch.backendBatchId,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    items: batch.papers.map((paper) => ({
+      id: randomUuid(),
+      taskId,
+      status: "queued",
+      error: null,
+      cache: null,
+      archive: null,
+      ...paper,
+    })),
+  };
+}

--- a/integrations/polaris-browser-extension/src/shared/origin.js
+++ b/integrations/polaris-browser-extension/src/shared/origin.js
@@ -1,0 +1,48 @@
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+function withDefaultProtocol(value) {
+  const text = String(value || "").trim();
+  if (!text || text.includes("://")) return text;
+  const host = text.split(/[/:]/, 1)[0].toLowerCase();
+  return `${LOCAL_HOSTS.has(host) ? "http" : "https"}://${text}`;
+}
+
+export function normalizePolarisOrigin(value) {
+  let url;
+  try {
+    url = new URL(withDefaultProtocol(value));
+  } catch {
+    throw new Error("Polaris 地址无效");
+  }
+  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) {
+    throw new Error("Polaris 地址必须是安全的 HTTP(S) Origin");
+  }
+  if (url.protocol === "http:" && !LOCAL_HOSTS.has(url.hostname.toLowerCase())) {
+    throw new Error("公网 Polaris 地址必须使用 HTTPS");
+  }
+  return url.origin;
+}
+
+export function normalizeHttpUrl(value) {
+  if (!value) return null;
+  try {
+    const url = new URL(String(value));
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function permissionPatternForUrl(value) {
+  const url = new URL(value);
+  return `${url.protocol}//${url.hostname}/*`;
+}
+
+export function originsMatch(left, right) {
+  try {
+    return normalizePolarisOrigin(left) === normalizePolarisOrigin(right);
+  } catch {
+    return false;
+  }
+}

--- a/integrations/polaris-browser-extension/src/shared/pdf.js
+++ b/integrations/polaris-browser-extension/src/shared/pdf.js
@@ -1,0 +1,37 @@
+const SIGNATURE = new TextEncoder().encode("%PDF-");
+
+export const MAX_PDF_BYTES = 150 * 1024 * 1024;
+export const MIN_PDF_BYTES = 1024;
+
+export function toUint8Array(value) {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  throw new Error("PDF 数据格式无效");
+}
+
+export function validatePdfBytes(value, maxBytes = MAX_PDF_BYTES) {
+  const bytes = toUint8Array(value);
+  if (bytes.byteLength < MIN_PDF_BYTES) throw new Error("PDF 文件过小或内容不完整");
+  if (bytes.byteLength > maxBytes) throw new Error("PDF 超过 150 MB 大小上限");
+  for (let index = 0; index < SIGNATURE.length; index += 1) {
+    if (bytes[index] !== SIGNATURE[index]) throw new Error("文件缺少 %PDF- 签名");
+  }
+  return bytes;
+}
+
+export async function sha256Hex(value, subtle = crypto.subtle) {
+  const bytes = toUint8Array(value);
+  const source = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const digest = await subtle.digest("SHA-256", source);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function inspectPdf(value, options = {}) {
+  const bytes = validatePdfBytes(value, options.maxBytes);
+  return {
+    bytes,
+    byteSize: bytes.byteLength,
+    sha256: await sha256Hex(bytes, options.subtle),
+  };
+}

--- a/integrations/polaris-browser-extension/src/sidepanel/app.js
+++ b/integrations/polaris-browser-extension/src/sidepanel/app.js
@@ -1,0 +1,256 @@
+import { cachePdfBytes } from "../background/cache.js";
+import { requestOriginPermission, requestUrlPermission } from "../background/bridge.js";
+import { normalizePolarisOrigin } from "../shared/origin.js";
+
+const originInput = document.querySelector("#polaris-origin");
+const apiKeyInput = document.querySelector("#polaris-api-key");
+const connectionBadge = document.querySelector("#connection-badge");
+const connectionStatus = document.querySelector("#connection-status");
+const taskList = document.querySelector("#task-list");
+const emptyState = document.querySelector("#empty-state");
+const notice = document.querySelector("#notice");
+
+const STATUS_LABELS = {
+  queued: "待下载",
+  downloading: "下载中",
+  cached: "已缓存",
+  archiving: "归档中",
+  archived: "已归档",
+  failed: "需要处理",
+};
+
+let state = { connection: null, tasks: [] };
+let noticeTimer = null;
+
+function showNotice(message, error = false) {
+  notice.textContent = message;
+  notice.className = `notice visible${error ? " error" : ""}`;
+  clearTimeout(noticeTimer);
+  noticeTimer = setTimeout(() => { notice.className = "notice"; }, 4500);
+}
+
+async function send(type, payload = null) {
+  const response = await chrome.runtime.sendMessage({ type, payload });
+  if (!response?.ok) throw new Error(response?.error || "扩展操作失败");
+  return response;
+}
+
+function element(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function button(label, action, dataset = {}, className = "secondary compact") {
+  const node = element("button", className, label);
+  node.type = "button";
+  node.dataset.action = action;
+  Object.assign(node.dataset, dataset);
+  return node;
+}
+
+function formatBytes(bytes) {
+  const value = Number(bytes || 0);
+  if (!value) return "";
+  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function renderConnection() {
+  const connected = Boolean(state.connection?.hasApiKey);
+  connectionBadge.textContent = connected ? "已连接" : "未连接";
+  connectionBadge.className = `badge${connected ? " connected" : ""}`;
+  connectionStatus.textContent = connected
+    ? state.connection.user?.email || "API Key 已验证"
+    : "尚未配置";
+  if (state.connection?.instanceOrigin && !originInput.value) originInput.value = state.connection.instanceOrigin;
+  apiKeyInput.placeholder = connected ? "已保存，留空可继续使用" : "pol_dl_...";
+}
+
+function renderItem(task, item) {
+  const row = element("article", "paper-item");
+  const top = element("div", "paper-top");
+  const title = element("h3", "paper-title", item.title);
+  const status = element("span", `status-chip ${item.status}`, STATUS_LABELS[item.status] || item.status);
+  top.append(title, status);
+  row.append(top);
+
+  const meta = element("div", "item-meta");
+  if (item.doi) meta.append(element("span", "", `DOI ${item.doi}`));
+  if (item.cache?.byteSize) meta.append(element("span", "", formatBytes(item.cache.byteSize)));
+  if (item.cache?.sha256) meta.append(element("span", "", `SHA-256 ${item.cache.sha256.slice(0, 10)}...`));
+  row.append(meta);
+
+  if (item.error) row.append(element("p", "item-error", item.error));
+
+  if (item.candidates.length) {
+    const candidateRow = element("div", "candidate-row");
+    const select = element("select", "candidate-select");
+    select.dataset.taskId = task.id;
+    select.dataset.itemId = item.id;
+    item.candidates.forEach((candidate, index) => {
+      const option = element("option", "", `${candidate.source} · ${new URL(candidate.url).hostname}`);
+      option.value = candidate.url;
+      if (index === 0) option.selected = true;
+      select.append(option);
+    });
+    candidateRow.append(select, button("下载候选 PDF", "download", { taskId: task.id, itemId: item.id }));
+    row.append(candidateRow);
+  }
+
+  const actions = element("div", "item-actions");
+  if (item.articleUrl) actions.append(button("打开论文页", "open", { url: item.articleUrl }));
+  const fileInput = element("input", "file-input");
+  fileInput.type = "file";
+  fileInput.accept = "application/pdf,.pdf";
+  fileInput.dataset.taskId = task.id;
+  fileInput.dataset.itemId = item.id;
+  actions.append(button("选择本地 PDF", "choose-file", { taskId: task.id, itemId: item.id }), fileInput);
+  if (item.cache?.cacheKey && item.status !== "archived") {
+    actions.append(button("归档到 Polaris", "archive", { taskId: task.id, itemId: item.id }, "primary compact"));
+  }
+  row.append(actions);
+  return row;
+}
+
+function renderTask(task) {
+  const card = element("section", "task-card");
+  const head = element("div", "task-head");
+  const title = element("div", "task-title");
+  title.append(
+    element("h3", "", `批量任务 · ${task.items.length} 篇`),
+    element("small", "", new Date(task.createdAt).toLocaleString("zh-CN")),
+  );
+  const archived = task.items.filter((item) => item.status === "archived").length;
+  head.append(title, element("span", "status-chip", `${archived}/${task.items.length} 已归档`));
+  card.append(head);
+
+  const toolbar = element("div", "task-toolbar");
+  toolbar.append(
+    button("批量归档已缓存", "archive-task", { taskId: task.id }, "primary compact"),
+    button("删除任务", "delete-task", { taskId: task.id }, "danger compact"),
+  );
+  card.append(toolbar);
+  const papers = element("div", "paper-list");
+  task.items.forEach((item) => papers.append(renderItem(task, item)));
+  card.append(papers);
+  return card;
+}
+
+function render() {
+  renderConnection();
+  taskList.replaceChildren(...state.tasks.map(renderTask));
+  emptyState.hidden = state.tasks.length > 0;
+}
+
+async function refresh() {
+  const response = await send("GET_STATE");
+  state = { connection: response.connection, tasks: response.tasks };
+  render();
+}
+
+async function withBusy(target, operation) {
+  const previous = target.textContent;
+  target.disabled = true;
+  target.textContent = "处理中...";
+  try {
+    return await operation();
+  } finally {
+    target.disabled = false;
+    target.textContent = previous;
+  }
+}
+
+async function connect(save, target) {
+  await withBusy(target, async () => {
+    const origin = normalizePolarisOrigin(originInput.value || state.connection?.instanceOrigin);
+    await requestOriginPermission(origin);
+    const response = await send(save ? "SAVE_CONNECTION" : "TEST_CONNECTION", {
+      instanceOrigin: origin,
+      apiKey: apiKeyInput.value,
+    });
+    apiKeyInput.value = "";
+    showNotice(`${save ? "已保存" : "连接成功"}：${response.user?.email || response.origin}`);
+    await refresh();
+  });
+}
+
+document.querySelector("#test-connection").addEventListener("click", (event) => {
+  connect(false, event.currentTarget).catch((error) => showNotice(error.message, true));
+});
+document.querySelector("#save-connection").addEventListener("click", (event) => {
+  connect(true, event.currentTarget).catch((error) => showNotice(error.message, true));
+});
+document.querySelector("#refresh-tasks").addEventListener("click", () => {
+  refresh().catch((error) => showNotice(error.message, true));
+});
+
+taskList.addEventListener("click", async (event) => {
+  const target = event.target.closest("button[data-action]");
+  if (!target) return;
+  const { action, taskId, itemId, url } = target.dataset;
+  try {
+    await withBusy(target, async () => {
+      if (action === "open") await send("OPEN_ARTICLE", { url });
+      if (action === "choose-file") {
+        const input = target.parentElement.querySelector(`input[data-item-id="${CSS.escape(itemId)}"]`);
+        input?.click();
+      }
+      if (action === "download") {
+        const select = target.parentElement.querySelector("select");
+        await requestUrlPermission(select.value);
+        await send("DOWNLOAD_ITEM", { taskId, itemId, url: select.value });
+        showNotice("PDF 已验真并缓存到浏览器");
+      }
+      if (action === "archive") {
+        await send("ARCHIVE_ITEM", { taskId, itemId });
+        showNotice("PDF 已归档到对应论文");
+      }
+      if (action === "archive-task") {
+        const result = await send("ARCHIVE_TASK", { taskId });
+        showNotice(`批量归档完成：${result.archived} 篇成功，${result.failed} 篇失败`, result.failed > 0);
+      }
+      if (action === "delete-task") {
+        if (!confirm("删除该任务及浏览器中的 PDF 缓存？此操作不可恢复。")) return;
+        await send("DELETE_TASK", { taskId });
+        showNotice("任务和对应浏览器缓存已删除");
+      }
+    });
+    await refresh();
+  } catch (error) {
+    showNotice(error.message, true);
+    await refresh().catch(() => undefined);
+  }
+});
+
+taskList.addEventListener("change", async (event) => {
+  const input = event.target.closest("input[type=file]");
+  if (!input?.files?.length) return;
+  const file = input.files[0];
+  try {
+    const cache = await cachePdfBytes({
+      taskId: input.dataset.taskId,
+      itemId: input.dataset.itemId,
+      value: await file.arrayBuffer(),
+      sourceUrl: null,
+    });
+    await send("MANUAL_PDF_CACHED", {
+      taskId: input.dataset.taskId,
+      itemId: input.dataset.itemId,
+      cache,
+    });
+    showNotice("本地 PDF 已验真并缓存到浏览器");
+    await refresh();
+  } catch (error) {
+    showNotice(error.message, true);
+  } finally {
+    input.value = "";
+  }
+});
+
+chrome.storage.onChanged.addListener((_changes, areaName) => {
+  if (areaName === "local") refresh().catch(() => undefined);
+});
+
+refresh().catch((error) => showNotice(error.message, true));

--- a/integrations/polaris-browser-extension/src/styles.css
+++ b/integrations/polaris-browser-extension/src/styles.css
@@ -1,0 +1,122 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #17201b;
+  background: #f5f7f5;
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+
+body { margin: 0; min-width: 340px; background: #f5f7f5; }
+
+button, input, select { font: inherit; letter-spacing: 0; }
+
+button { cursor: pointer; }
+
+.app-shell { width: 100%; max-width: 560px; min-height: 100vh; padding: 18px; margin: 0 auto; }
+
+.app-header, .section-heading, .button-row, .task-head, .item-actions, .item-meta {
+  display: flex;
+  align-items: center;
+}
+
+.app-header { justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+
+.brand { font-size: 12px; line-height: 1; letter-spacing: 0; color: #32443a; }
+.brand span { color: #d35b38; }
+
+h1, h2, h3, p { margin: 0; letter-spacing: 0; }
+h1 { margin-top: 5px; font-size: 20px; line-height: 1.25; }
+h2 { margin-top: 3px; font-size: 16px; line-height: 1.3; }
+h3 { font-size: 14px; line-height: 1.45; }
+
+.badge, .status-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid #d6ddd8;
+  border-radius: 6px;
+  background: #fff;
+  color: #56635b;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.badge.connected, .status-chip.archived { border-color: #a8c9b6; background: #edf7f1; color: #22633f; }
+.status-chip.cached { border-color: #9ec5d4; background: #edf7fa; color: #245e73; }
+.status-chip.failed { border-color: #e1aca0; background: #fff2ef; color: #9b3524; }
+.status-chip.downloading, .status-chip.archiving { border-color: #d9bd7d; background: #fff8e8; color: #7a5714; }
+
+.panel {
+  padding: 15px;
+  border: 1px solid #dbe1dc;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.connection-panel { margin-bottom: 22px; }
+.section-heading { justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 13px; }
+.eyebrow { color: #77827b; font-size: 10px; font-weight: 700; letter-spacing: 0; }
+.muted { color: #77827b; font-size: 12px; text-align: right; }
+
+label { display: block; margin: 11px 0 5px; color: #465149; font-size: 12px; font-weight: 650; }
+input, select {
+  width: 100%;
+  min-height: 38px;
+  border: 1px solid #ccd5cf;
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: #fff;
+  color: #17201b;
+  outline: none;
+}
+input:focus, select:focus { border-color: #4c765f; box-shadow: 0 0 0 2px #dfece4; }
+
+.button-row { justify-content: flex-end; gap: 8px; margin-top: 13px; }
+button {
+  min-height: 36px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 7px 12px;
+  font-weight: 650;
+}
+button:disabled { cursor: not-allowed; opacity: .55; }
+.primary { background: #263f32; color: #fff; }
+.primary:hover:not(:disabled) { background: #1d3227; }
+.secondary { border-color: #cbd4ce; background: #fff; color: #35443b; }
+.secondary:hover:not(:disabled) { background: #f0f4f1; }
+.danger { border-color: #e0b7ad; background: #fff; color: #9b3524; }
+.compact { min-height: 32px; padding: 5px 9px; font-size: 12px; }
+
+.tasks-heading { margin-bottom: 10px; }
+.task-list { display: grid; gap: 12px; }
+.task-card { border: 1px solid #d8dfda; border-radius: 8px; background: #fff; overflow: hidden; }
+.task-head { justify-content: space-between; align-items: flex-start; gap: 10px; padding: 13px 14px; border-bottom: 1px solid #e4e8e5; }
+.task-title { display: grid; gap: 3px; }
+.task-title small { color: #7b867f; font-size: 11px; }
+.task-toolbar { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; padding: 10px 14px; background: #fafbfa; border-bottom: 1px solid #e4e8e5; }
+.paper-list { display: grid; }
+.paper-item { padding: 13px 14px; border-bottom: 1px solid #edf0ee; }
+.paper-item:last-child { border-bottom: 0; }
+.paper-top { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: start; }
+.paper-title { overflow-wrap: anywhere; }
+.item-meta { flex-wrap: wrap; gap: 6px 10px; margin-top: 6px; color: #728078; font-size: 11px; }
+.item-error { margin-top: 7px; color: #9b3524; font-size: 12px; line-height: 1.45; overflow-wrap: anywhere; }
+.candidate-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 7px; margin-top: 10px; }
+.item-actions { flex-wrap: wrap; gap: 7px; margin-top: 8px; }
+.file-input { display: none; }
+.empty-state { padding: 30px 20px; border: 1px dashed #cbd4ce; border-radius: 8px; text-align: center; color: #69756e; background: #fafbfa; }
+.empty-state p { margin-top: 6px; font-size: 12px; line-height: 1.55; }
+.notice { position: sticky; bottom: 12px; display: none; margin-top: 12px; padding: 10px 12px; border-radius: 6px; background: #263f32; color: #fff; font-size: 12px; line-height: 1.45; }
+.notice.visible { display: block; }
+.notice.error { background: #9b3524; }
+
+@media (max-width: 410px) {
+  .app-shell { padding: 13px; }
+  .panel { padding: 13px; }
+  .paper-top { grid-template-columns: 1fr; }
+  .paper-top .status-chip { justify-self: start; }
+  .candidate-row { grid-template-columns: 1fr; }
+  .candidate-row button { width: 100%; }
+}

--- a/integrations/polaris-browser-extension/tests/api.test.js
+++ b/integrations/polaris-browser-extension/tests/api.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { archiveMetadataForItem, archivePdfToPolaris, testPolarisConnection } from "../src/background/api.js";
+
+function pdfResponse() {
+  const bytes = new Uint8Array(2048);
+  bytes.set(new TextEncoder().encode("%PDF-1.7\n"));
+  return new Response(bytes, { headers: { "content-type": "application/pdf" } });
+}
+
+function item(paperId, libraryId) {
+  return {
+    paperId,
+    libraryId,
+    nonce: `nonce-${paperId}-1234567890`,
+    title: `Paper ${paperId}`,
+    doi: `10.1000/${paperId}`,
+    articleUrl: `https://publisher.example/${paperId}`,
+    cache: null,
+  };
+}
+
+test("connection client uses the user-scoped API key header", async () => {
+  let request;
+  const result = await testPolarisConnection({
+    instanceOrigin: "https://polaris.example.com/path",
+    apiKey: "pol_dl_test-value",
+    fetchImpl: async (url, init) => {
+      request = { url, init };
+      return new Response(JSON.stringify({ user_id: "user-1", email: "user@example.com" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  assert.equal(request.url, "https://polaris.example.com/api/download-client/me");
+  assert.equal(request.init.headers["X-Polaris-API-Key"], "pol_dl_test-value");
+  assert.equal(result.user.email, "user@example.com");
+});
+
+test("archive metadata always comes from the individual paper binding", () => {
+  const first = archiveMetadataForItem(item("paper-a", "library-a"));
+  const second = archiveMetadataForItem(item("paper-b", "library-b"));
+  assert.deepEqual([first.library_id, first.paper_id], ["library-a", "paper-a"]);
+  assert.deepEqual([second.library_id, second.paper_id], ["library-b", "paper-b"]);
+});
+
+test("archive request sends per-paper metadata and a verified checksum", async () => {
+  const target = item("paper-a", "library-a");
+  let request;
+  const response = await archivePdfToPolaris({
+    connection: { instanceOrigin: "https://polaris.example.com", apiKey: "pol_dl_test-value" },
+    item: target,
+    cachedResponse: pdfResponse(),
+    fetchImpl: async (url, init) => {
+      request = { url, init };
+      return new Response(JSON.stringify({ asset_id: "asset-1", content_version_id: "version-1", status: "queued" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  assert.equal(request.url, "https://polaris.example.com/api/download-client/archive");
+  assert.match(request.init.headers["X-Polaris-PDF-SHA256"], /^[0-9a-f]{64}$/);
+  const metadata = JSON.parse(request.init.body.get("metadata"));
+  assert.equal(metadata.library_id, "library-a");
+  assert.equal(metadata.paper_id, "paper-a");
+  assert.equal(metadata.nonce, target.nonce);
+  assert.equal(response.asset_id, "asset-1");
+});

--- a/integrations/polaris-browser-extension/tests/batch.test.js
+++ b/integrations/polaris-browser-extension/tests/batch.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createLocalTask, validateDownloadBatch } from "../src/shared/batch.js";
+
+const NOW = Date.parse("2026-08-29T08:00:00Z");
+const ORIGIN = "https://polaris.example.com";
+
+function payload() {
+  return {
+    version: 2,
+    instance_origin: ORIGIN,
+    issued_at: "2026-08-29T07:59:30Z",
+    expires_at: "2026-08-29T08:04:30Z",
+    batch_nonce: "batch-nonce-1234567890",
+    backend_batch_id: "3d3bfa16-dacb-4bfa-a93e-83f33150e669",
+    papers: [
+      {
+        nonce: "paper-nonce-1234567890",
+        library_id: "09d24444-0451-4541-8b7e-3f28fafda2d2",
+        paper_id: "03bbcc49-1731-4d47-814f-dbf173f5ed85",
+        identity: { title: "First paper", doi: "10.1000/first" },
+        article_url: "https://publisher.example/first",
+        pdf_candidates: [{ url: "https://cdn.example/first.pdf", source: "oa" }],
+      },
+      {
+        nonce: "paper-nonce-0987654321",
+        library_id: "09d24444-0451-4541-8b7e-3f28fafda2d2",
+        paper_id: "db81be8d-c58c-4609-91d8-1bb75d00959b",
+        identity: { title: "Second paper", pmid: "12345" },
+        article_url: "https://publisher.example/second",
+        pdf_candidates: ["https://cdn.example/second.pdf"],
+      },
+    ],
+  };
+}
+
+test("validates one batch while preserving independent paper bindings", () => {
+  const result = validateDownloadBatch(payload(), ORIGIN, NOW);
+  assert.equal(result.ok, true);
+  assert.equal(result.value.papers.length, 2);
+  assert.equal(result.value.papers[0].paperId, "03bbcc49-1731-4d47-814f-dbf173f5ed85");
+  assert.equal(result.value.papers[1].paperId, "db81be8d-c58c-4609-91d8-1bb75d00959b");
+
+  let counter = 0;
+  const task = createLocalTask(result.value, () => `local-id-${counter += 1}`, new Date(NOW));
+  assert.equal(task.id, "local-id-1");
+  assert.equal(task.items.length, 2);
+  assert.equal(task.items[0].taskId, task.id);
+  assert.notEqual(task.items[0].paperId, task.items[1].paperId);
+  assert.equal(task.items[1].pmid, "12345");
+});
+
+test("rejects expired, cross-origin, and duplicate-bound batches", () => {
+  assert.match(validateDownloadBatch(payload(), ORIGIN, NOW + 10 * 60_000).error, /过期/);
+  assert.match(validateDownloadBatch(payload(), "https://other.example.com", NOW).error, /不一致/);
+  const duplicate = payload();
+  duplicate.papers[1].paper_id = duplicate.papers[0].paper_id;
+  assert.match(validateDownloadBatch(duplicate, ORIGIN, NOW).error, /重复/);
+});
+
+test("rejects malformed PDF candidate URLs without rejecting the paper", () => {
+  const value = payload();
+  value.papers[0].pdf_candidates = ["javascript:alert(1)", "https://cdn.example/paper.pdf"];
+  const result = validateDownloadBatch(value, ORIGIN, NOW);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value.papers[0].candidates.map((entry) => entry.url), ["https://cdn.example/paper.pdf"]);
+});

--- a/integrations/polaris-browser-extension/tests/cache.test.js
+++ b/integrations/polaris-browser-extension/tests/cache.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cachePdfBytes, fetchAndCachePdf, getCachedPdf, pdfCacheKey } from "../src/background/cache.js";
+
+function validPdf() {
+  const bytes = new Uint8Array(2048);
+  bytes.set(new TextEncoder().encode("%PDF-1.7\n"));
+  return bytes;
+}
+
+function memoryCacheStorage() {
+  const entries = new Map();
+  return {
+    entries,
+    async open() {
+      return {
+        async put(key, value) { entries.set(key, value); },
+        async match(key) { return entries.get(key)?.clone() || null; },
+        async delete(key) { return entries.delete(key); },
+      };
+    },
+  };
+}
+
+test("stores verified PDF bytes under a task and item scoped cache key", async () => {
+  const storage = memoryCacheStorage();
+  const result = await cachePdfBytes({
+    taskId: "task-a",
+    itemId: "item-b",
+    value: validPdf(),
+    sourceUrl: "https://cdn.example/paper.pdf",
+    cacheStorage: storage,
+  });
+  assert.equal(result.cacheKey, pdfCacheKey("task-a", "item-b"));
+  assert.equal(result.byteSize, 2048);
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+  const cached = await getCachedPdf(result.cacheKey, storage);
+  assert.equal(cached.headers.get("content-type"), "application/pdf");
+  assert.equal((await cached.arrayBuffer()).byteLength, 2048);
+});
+
+test("candidate fetch rejects an HTML response before it reaches cache", async () => {
+  const storage = memoryCacheStorage();
+  await assert.rejects(fetchAndCachePdf({
+    taskId: "task-a",
+    itemId: "item-b",
+    url: "https://publisher.example/download",
+    fetchImpl: async () => new Response("<!doctype html>".padEnd(2048, " "), { status: 200 }),
+    cacheStorage: storage,
+  }), /%PDF-/);
+  assert.equal(storage.entries.size, 0);
+});

--- a/integrations/polaris-browser-extension/tests/manifest.test.js
+++ b/integrations/polaris-browser-extension/tests/manifest.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function filesBelow(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map((entry) => {
+    const target = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesBelow(target) : [target];
+  }));
+  return nested.flat();
+}
+
+test("manifest has no install-time host access or forbidden capabilities", async () => {
+  const manifest = JSON.parse(await readFile(path.join(root, "manifest.json"), "utf8"));
+  assert.equal(manifest.host_permissions, undefined);
+  assert.deepEqual(manifest.optional_host_permissions, ["http://*/*", "https://*/*"]);
+  assert.deepEqual(manifest.permissions.sort(), ["scripting", "sidePanel", "storage", "unlimitedStorage"].sort());
+  for (const forbidden of ["debugger", "nativeMessaging", "webRequest", "declarativeNetRequestWithHostAccess"]) {
+    assert.equal(manifest.permissions.includes(forbidden), false);
+  }
+});
+
+test("core extension contains no excluded integrations or secrets", async () => {
+  const files = (await filesBelow(root)).filter((file) => (
+    !file.includes(`${path.sep}tests${path.sep}`)
+    && (file.endsWith(".js") || file.endsWith("manifest.json"))
+  ));
+  const source = (await Promise.all(files.map((file) => readFile(file, "utf8")))).join("\n");
+  assert.doesNotMatch(source, /\b(?:YFR|SCNet|Zotero|nativeMessaging|debugger)\b/i);
+  assert.doesNotMatch(source, /(?:sk-|pol_dl_)[A-Za-z0-9_-]{20,}/);
+});

--- a/integrations/polaris-browser-extension/tests/origin.test.js
+++ b/integrations/polaris-browser-extension/tests/origin.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeHttpUrl,
+  normalizePolarisOrigin,
+  originsMatch,
+  permissionPatternForUrl,
+} from "../src/shared/origin.js";
+
+test("normalizes public HTTPS and local development origins", () => {
+  assert.equal(normalizePolarisOrigin("polaris.example.com/path"), "https://polaris.example.com");
+  assert.equal(normalizePolarisOrigin("localhost:8000/libraries"), "http://localhost:8000");
+  assert.equal(originsMatch("https://polaris.example.com/a", "https://polaris.example.com/b"), true);
+});
+
+test("rejects public HTTP and embedded credentials", () => {
+  assert.throws(() => normalizePolarisOrigin("http://polaris.example.com"), /HTTPS/);
+  assert.throws(() => normalizePolarisOrigin("https://user:secret@polaris.example.com"), /安全/);
+});
+
+test("derives an exact-host optional permission pattern", () => {
+  assert.equal(permissionPatternForUrl("https://polaris.example.com:8443/api"), "https://polaris.example.com/*");
+  assert.equal(normalizeHttpUrl("javascript:alert(1)"), null);
+});

--- a/integrations/polaris-browser-extension/tests/pdf.test.js
+++ b/integrations/polaris-browser-extension/tests/pdf.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inspectPdf, validatePdfBytes } from "../src/shared/pdf.js";
+
+function validPdf(size = 2048) {
+  const bytes = new Uint8Array(size);
+  bytes.set(new TextEncoder().encode("%PDF-1.7\n"));
+  return bytes;
+}
+
+test("accepts a signed PDF and returns a stable SHA-256", async () => {
+  const result = await inspectPdf(validPdf());
+  assert.equal(result.byteSize, 2048);
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+  assert.equal((await inspectPdf(validPdf())).sha256, result.sha256);
+});
+
+test("rejects HTML masquerading as PDF and truncated files", () => {
+  const html = new Uint8Array(2048);
+  html.set(new TextEncoder().encode("<!doctype html>"));
+  assert.throws(() => validatePdfBytes(html), /%PDF-/);
+  assert.throws(() => validatePdfBytes(validPdf(128)), /过小/);
+});
+
+test("enforces the caller supplied size limit", () => {
+  assert.throws(() => validatePdfBytes(validPdf(4096), 2048), /大小上限/);
+});

--- a/integrations/polaris-browser-extension/tests/permission-flow.test.js
+++ b/integrations/polaris-browser-extension/tests/permission-flow.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("optional host requests happen in the side panel user gesture handlers", async () => {
+  const sidePanel = await readFile(path.join(root, "src/sidepanel/app.js"), "utf8");
+  const serviceWorker = await readFile(path.join(root, "src/background/service-worker.js"), "utf8");
+  assert.match(sidePanel, /await requestOriginPermission\(origin\)/);
+  assert.match(sidePanel, /await requestUrlPermission\(select\.value\)/);
+  assert.doesNotMatch(serviceWorker, /chrome\.permissions\.request/);
+  assert.match(serviceWorker, /await requireUrlPermission\(candidate\.url\)/);
+});

--- a/integrations/polaris-browser-extension/tests/service-worker-source.test.js
+++ b/integrations/polaris-browser-extension/tests/service-worker-source.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("service worker never reuses a key across different Polaris origins", async () => {
+  const source = await readFile(path.join(root, "src/background/service-worker.js"), "utf8");
+  assert.match(source, /canReuseExisting = existing && originsMatch/);
+  assert.match(source, /suppliedApiKey \|\| \(canReuseExisting \? existing\.apiKey : ""\)/);
+  assert.match(source, /chrome\.permissions\.remove/);
+});


### PR DESCRIPTION
## Summary

- add a least-privilege Manifest V3 reference client for the merged Polaris download/archive protocol
- receive one `polaris:download-batch:v2` event as one local task with independently bound papers
- verify PDF signature, size, and SHA-256 before Cache Storage persistence
- archive every PDF with its own `library_id`, `paper_id`, nonce, and bibliographic identity
- support candidate downloads, manual PDF selection, retry, per-paper archive, and batch archive
- request the configured Polaris and PDF origins only from explicit side-panel actions

## Permission boundary

Install-time permissions are limited to storage, scripting, sidePanel, and unlimitedStorage. HTTP(S) host access is optional and requested for the exact host at the point of use. This PR does not use debugger, nativeMessaging, webRequest, declarative request rewriting, or install-time host permissions.

## Non-goals

This core client does not include external publisher-page integration, SCNet automation, Zotero, native messaging, publisher-specific automation, CAPTCHA handling, binaries, or ZIP artifacts. Those capabilities require separate owner decisions and permission reviews.

## Dependency and mergeability

The branch is based directly on current main (`851abc8`) and does not stack on the open UI PRs. It consumes the already merged `/api/download-client/*` and `/api/download-batches` contracts. It is compatible with the batch event emitted by #533 but remains independently mergeable.

This supersedes only the core Polaris batch/archive scope of #468.

## Verification

- `npm run check`: 18 passed
- Node syntax check for all extension JavaScript: passed
- `uv run pytest tests/test_download_batch_protocol.py -q --tb=short`: 5 passed
- Chromium unpacked-extension load: service worker and modules loaded
- 390 px side-panel visual check with empty and multi-paper states: no horizontal overflow
- manifest permission audit: passed
- sensitive-information scan: passed
- `git diff --check` passed

Closes #538