### PR TITLE
feat(frontend): expose interdisciplinary project workflows

### DIFF
--- a/src/frontend/src/features/libraries/LibraryPicker.tsx
+++ b/src/frontend/src/features/libraries/LibraryPicker.tsx
@@ -12,21 +12,25 @@ export function LibraryPicker({
   selectedIds,
   onToggle,
   disabled,
+  disabledIds,
 }: {
   libraries: DirectionLibrarySummary[];
   selectedIds: Set<string>;
   onToggle: (id: string) => void;
   disabled?: boolean;
+  /** 个别不可解除的关联（例如课题专属交叉证据库）。 */
+  disabledIds?: ReadonlySet<string>;
 }) {
   return (
     <div className="col gap8">
       {libraries.map((lib) => {
         const on = selectedIds.has(lib.id);
+        const itemDisabled = !!disabled || !!disabledIds?.has(lib.id);
         return (
           <button
             key={lib.id}
             type="button"
-            disabled={disabled}
+            disabled={itemDisabled}
             className="card hoverable"
             onClick={() => onToggle(lib.id)}
             style={{
@@ -35,7 +39,7 @@ export function LibraryPicker({
               gap: 12,
               alignItems: 'center',
               textAlign: 'left',
-              cursor: disabled ? 'default' : 'pointer',
+              cursor: itemDisabled ? 'default' : 'pointer',
               border: on ? '1px solid var(--accent)' : '0.5px solid var(--border)',
               background: on ? 'var(--accent-soft)' : 'var(--surface)',
             }}
@@ -63,6 +67,9 @@ export function LibraryPicker({
                   <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
                     {tr('我在用', 'In use')}
                   </span>
+                )}
+                {lib.library_kind === 'interdisciplinary' && (
+                  <span className="pill sm">{tr('专属交叉库', 'Dedicated interdisciplinary')}</span>
                 )}
               </div>
               <div

--- a/src/frontend/src/features/projects/InterdisciplinaryScopePanel.tsx
+++ b/src/frontend/src/features/projects/InterdisciplinaryScopePanel.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import {
+  api,
+  ApiError,
+  isAdmin,
+  type DirectionLibrarySummary,
+  type InterdisciplinaryScopeDraft,
+  type InterdisciplinaryScopeRead,
+  type ProjectRead,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import {
+  splitInterdisciplinaryTerms,
+  validateInterdisciplinaryScope,
+} from './interdisciplinaryWorkflow';
+import './interdisciplinary.css';
+
+interface EditableScope {
+  researchScope: string;
+  coreQuestions: string;
+  primaryDomain: string;
+  relatedDomains: string;
+  evidenceBoundary: string;
+  validationConditions: string;
+  userQuestions: Record<string, unknown>[] | null;
+  queryMatrix: Record<string, unknown>[] | null;
+  evidenceBalance: Record<string, number> | null;
+}
+
+function editableScope(scope: InterdisciplinaryScopeDraft): EditableScope {
+  return {
+    researchScope: scope.research_scope,
+    coreQuestions: scope.core_questions.join('\n'),
+    primaryDomain: scope.primary_domain,
+    relatedDomains: scope.related_domains.join(', '),
+    evidenceBoundary: scope.evidence_boundary ?? '',
+    validationConditions: (scope.validation_conditions ?? []).join('\n'),
+    userQuestions: scope.user_questions ?? null,
+    queryMatrix: scope.query_matrix ?? null,
+    evidenceBalance: scope.evidence_balance ?? null,
+  };
+}
+
+function scopeDraft(scope: EditableScope): InterdisciplinaryScopeDraft {
+  return {
+    research_scope: scope.researchScope.trim(),
+    core_questions: scope.coreQuestions
+      .split(/\n+/)
+      .map((item) => item.trim())
+      .filter(Boolean),
+    primary_domain: scope.primaryDomain.trim(),
+    related_domains: splitInterdisciplinaryTerms(scope.relatedDomains),
+    evidence_boundary: scope.evidenceBoundary.trim() || null,
+    validation_conditions: scope.validationConditions
+      .split(/\n+/)
+      .map((item) => item.trim())
+      .filter(Boolean),
+    user_questions: scope.userQuestions,
+    query_matrix: scope.queryMatrix,
+    evidence_balance: scope.evidenceBalance,
+  };
+}
+
+export function InterdisciplinaryScopePanel({
+  project,
+  dedicatedLibrary,
+}: {
+  project: ProjectRead;
+  dedicatedLibrary?: DirectionLibrarySummary;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState<EditableScope | null>(null);
+  const [context, setContext] = useState('');
+  const [clarificationQuestions, setClarificationQuestions] = useState<string[]>([]);
+  const [rationale, setRationale] = useState('');
+  const [model, setModel] = useState('');
+
+  const meQuery = useQuery({
+    queryKey: ['me'],
+    queryFn: () => api.me(),
+    retry: false,
+    staleTime: 60_000,
+  });
+  const canManage = !!meQuery.data
+    && (project.owner_id === meQuery.data.id || isAdmin(meQuery.data));
+
+  const scopeQuery = useQuery({
+    queryKey: ['interdisciplinary-scope', project.id],
+    queryFn: () => api.getInterdisciplinaryScope(project.id),
+    enabled: canManage,
+    retry: false,
+  });
+  const versionsQuery = useQuery({
+    queryKey: ['interdisciplinary-scope-versions', project.id],
+    queryFn: () => api.listInterdisciplinaryScopeVersions(project.id),
+    enabled: canManage,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (scopeQuery.data) setEditing(editableScope(scopeQuery.data));
+  }, [scopeQuery.data]);
+
+  const analyze = useMutation({
+    mutationFn: () => api.suggestInterdisciplinaryScope({
+      name: project.name,
+      statement: project.statement ?? project.name,
+      ...(context.trim() ? { user_context: context.trim() } : {}),
+    }),
+    onSuccess: (suggestion) => {
+      setEditing(editableScope(suggestion));
+      setClarificationQuestions(suggestion.clarification_questions);
+      setRationale(suggestion.rationale);
+      setModel(suggestion.model);
+      toast(tr('已生成新的可编辑草案', 'New editable draft generated'), 'ok');
+    },
+    onError: (error) => toast(
+      `${tr('分析失败：', 'Analysis failed: ')}${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    ),
+  });
+
+  function invalidate() {
+    void queryClient.invalidateQueries({ queryKey: ['interdisciplinary-scope', project.id] });
+    void queryClient.invalidateQueries({ queryKey: ['interdisciplinary-scope-versions', project.id] });
+    void queryClient.invalidateQueries({ queryKey: ['sourceLibraries', project.id] });
+    void queryClient.invalidateQueries({ queryKey: ['libraries'] });
+    void queryClient.invalidateQueries({ queryKey: ['projects'] });
+  }
+
+  const save = useMutation({
+    mutationFn: async (confirm: boolean) => {
+      if (!editing) throw new Error('INTERDISCIPLINARY_SCOPE_REQUIRED');
+      const draft = scopeDraft(editing);
+      const invalid = validateInterdisciplinaryScope(draft);
+      if (invalid) throw new Error(`INTERDISCIPLINARY_SCOPE_INVALID:${invalid}`);
+      const saved = await api.saveInterdisciplinaryScope(project.id, draft);
+      if (!confirm) return { profile: saved, library_id: null };
+      return api.confirmInterdisciplinaryScope(project.id);
+    },
+    onSuccess: (result, confirm) => {
+      invalidate();
+      if (confirm) {
+        toast(tr('交叉范围已确认，专属文献库已同步', 'Scope confirmed and dedicated library synchronized'), 'ok');
+      } else {
+        setEditing(editableScope(result.profile));
+        toast(tr('交叉范围草案已保存', 'Scope draft saved'), 'ok');
+      }
+    },
+    onError: (error) => toast(
+      `${tr('保存失败：', 'Save failed: ')}${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    ),
+  });
+
+  const scopeMissing = scopeQuery.error instanceof ApiError && scopeQuery.error.status === 404;
+  const versions = versionsQuery.data ?? [];
+  const latest = scopeQuery.data;
+
+  if (meQuery.isLoading) {
+    return <section className="card interdisciplinary-profile-card"><div className="skel interdisciplinary-profile-skeleton" /></section>;
+  }
+
+  if (!canManage) {
+    return (
+      <section className="card interdisciplinary-profile-card">
+        <div className="interdisciplinary-profile-head">
+          <div>
+            <span className="pill sm">{tr('跨学科研究', 'Interdisciplinary')}</span>
+            <h3>{tr('学科范围与专属证据库', 'Scope and dedicated evidence library')}</h3>
+            <p>{tr('完整交叉范围仅对课题创建者和平台管理员开放。', 'The complete scope is available to the topic owner and platform admins.')}</p>
+          </div>
+          {dedicatedLibrary && (
+            <button className="btn btn-soft sm" onClick={() => navigate(`/libraries/${dedicatedLibrary.id}`)}>
+              <Icon name="book" size={12} />
+              {tr('打开专属库', 'Open library')}
+            </button>
+          )}
+        </div>
+      </section>
+    );
+  }
+
+  if (scopeQuery.isLoading && !editing) {
+    return <section className="card interdisciplinary-profile-card"><div className="skel interdisciplinary-profile-skeleton" /></section>;
+  }
+
+  return (
+    <section className="card interdisciplinary-profile-card">
+      <div className="interdisciplinary-profile-head">
+        <div>
+          <span className="pill sm">{tr('跨学科研究', 'Interdisciplinary')}</span>
+          <h3>{tr('学科范围与检索边界', 'Scope and retrieval boundary')}</h3>
+          <p>
+            {latest
+              ? tr('每次保存都会形成新版本；确认后同步到专属交叉文献库。', 'Each save creates a version. Confirmation synchronizes the dedicated library.')
+              : tr('课题已创建，但交叉范围尚未完成。重新分析后即可恢复。', 'The topic exists, but its scope is incomplete. Analyze again to recover.')}
+          </p>
+        </div>
+        <div className="row gap8 interdisciplinary-profile-actions">
+          {latest && <span className="mono muted">v{latest.version} · {latest.status}</span>}
+          {dedicatedLibrary && (
+            <button className="btn btn-soft sm" onClick={() => navigate(`/libraries/${dedicatedLibrary.id}`)}>
+              <Icon name="book" size={12} />
+              {tr('专属库', 'Library')}
+            </button>
+          )}
+          <button className="btn btn-soft sm" disabled={analyze.isPending || save.isPending} onClick={() => analyze.mutate()}>
+            <Icon name={analyze.isPending ? 'refresh' : 'sparkle'} size={12} />
+            {analyze.isPending ? tr('分析中…', 'Analyzing…') : tr('重新分析', 'Analyze again')}
+          </button>
+        </div>
+      </div>
+
+      {(scopeMissing || !latest) && !editing && (
+        <div className="interdisciplinary-recovery">
+          {tr('未找到已保存的交叉范围。点击“重新分析”生成可编辑草案。', 'No saved scope was found. Analyze again to create an editable draft.')}
+        </div>
+      )}
+
+      {!!clarificationQuestions.length && (
+        <div className="interdisciplinary-questions">
+          <span className="label">{tr('需要你判断的问题', 'Questions for you')}</span>
+          {clarificationQuestions.map((question, index) => (
+            <div key={`${index}-${question}`}><b>{index + 1}</b><span>{question}</span></div>
+          ))}
+          <textarea className="textarea" rows={3} value={context} onChange={(event) => setContext(event.target.value)} placeholder={tr('补充回答后可再次分析', 'Add answers and analyze again')} />
+        </div>
+      )}
+
+      {editing && (
+        <>
+          <div className="interdisciplinary-profile-grid">
+            <label className="col gap6 profile-span">
+              <span className="label">{tr('交叉研究范围', 'Research scope')}</span>
+              <textarea className="textarea" rows={4} value={editing.researchScope} onChange={(event) => setEditing({ ...editing, researchScope: event.target.value })} />
+            </label>
+            <label className="col gap6 profile-span">
+              <span className="label">{tr('核心交叉问题', 'Core questions')}</span>
+              <textarea className="textarea" rows={4} value={editing.coreQuestions} onChange={(event) => setEditing({ ...editing, coreQuestions: event.target.value })} />
+            </label>
+            <label className="col gap6">
+              <span className="label">{tr('主学科', 'Primary domain')}</span>
+              <input className="input" value={editing.primaryDomain} onChange={(event) => setEditing({ ...editing, primaryDomain: event.target.value, queryMatrix: null, evidenceBalance: null })} />
+            </label>
+            <label className="col gap6">
+              <span className="label">{tr('关联学科', 'Related domains')}</span>
+              <input className="input" value={editing.relatedDomains} onChange={(event) => setEditing({ ...editing, relatedDomains: event.target.value, queryMatrix: null, evidenceBalance: null })} />
+            </label>
+            <label className="col gap6">
+              <span className="label">{tr('证据边界', 'Evidence boundary')}</span>
+              <textarea className="textarea" rows={3} value={editing.evidenceBoundary} onChange={(event) => setEditing({ ...editing, evidenceBoundary: event.target.value })} />
+            </label>
+            <label className="col gap6">
+              <span className="label">{tr('验证条件', 'Validation conditions')}</span>
+              <textarea className="textarea" rows={3} value={editing.validationConditions} onChange={(event) => setEditing({ ...editing, validationConditions: event.target.value })} />
+            </label>
+          </div>
+          {rationale && (
+            <div className="interdisciplinary-rationale">
+              <span>{tr('建议依据', 'Rationale')}</span>
+              <p>{rationale}</p>
+              {model && <small>{model}</small>}
+            </div>
+          )}
+          <div className="row gap8 interdisciplinary-save-actions">
+            <button className="btn btn-soft sm" disabled={save.isPending} onClick={() => save.mutate(false)}>
+              <Icon name="check" size={12} />
+              {save.isPending ? tr('保存中…', 'Saving…') : tr('保存新版本草案', 'Save version draft')}
+            </button>
+            <button className="btn btn-primary sm" disabled={save.isPending} onClick={() => save.mutate(true)}>
+              <Icon name="sparkle" size={12} />
+              {tr('确认并同步专属库', 'Confirm and sync library')}
+            </button>
+          </div>
+        </>
+      )}
+
+      {!!versions.length && (
+        <details className="interdisciplinary-version-history">
+          <summary>{tr(`版本历史 · ${versions.length}`, `Version history · ${versions.length}`)}</summary>
+          {versions.map((version: InterdisciplinaryScopeRead) => (
+            <div key={version.id}>
+              <span className="mono">v{version.version}</span>
+              <b>{version.status}</b>
+              <span>{version.primary_domain} · {version.related_domains.join(' / ')}</span>
+            </div>
+          ))}
+        </details>
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/features/projects/ProjectDetailPage.tsx
+++ b/src/frontend/src/features/projects/ProjectDetailPage.tsx
@@ -14,6 +14,7 @@ import { portalUrl } from '../../lib/endpoint';
 import { copyText } from '../../lib/clipboard';
 import { useLibraries } from '../libraries/hooks';
 import { LibraryPicker } from '../libraries/LibraryPicker';
+import { InterdisciplinaryScopePanel } from './InterdisciplinaryScopePanel';
 
 /* ============================================================
    /projects/:id — 课题设置：只留真正的课题属性
@@ -134,13 +135,20 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
   });
   const librariesQuery = useLibraries();
   const allLibraries = librariesQuery.data ?? [];
+  const protectedLibraryIds = new Set(
+    (sourceLibraries ?? [])
+      .filter((library) => library.library_kind === 'interdisciplinary')
+      .map((library) => library.id),
+  );
   const [linkOpen, setLinkOpen] = useState(false);
   const [linkDraft, setLinkDraft] = useState<Set<string>>(new Set());
   function openLinkEditor() {
+    if (!sourceLibraries) return;
     setLinkDraft(new Set((sourceLibraries ?? []).map((l) => l.id)));
     setLinkOpen(true);
   }
   function toggleLinkDraft(libId: string) {
+    if (protectedLibraryIds.has(libId)) return;
     setLinkDraft((prev) => {
       const next = new Set(prev);
       if (next.has(libId)) next.delete(libId);
@@ -149,7 +157,10 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
     });
   }
   const setSourceLibsMutation = useMutation({
-    mutationFn: (ids: string[]) => api.setSourceLibraries(id, ids),
+    mutationFn: (ids: string[]) => api.setSourceLibraries(
+      id,
+      [...new Set([...ids, ...protectedLibraryIds])],
+    ),
     onSuccess: (libs) => {
       queryClient.setQueryData(['sourceLibraries', id], libs);
       // 课题语料 = 关联库并集：相关缓存全部失效
@@ -325,12 +336,25 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
           <div className="empty" style={{ padding: 30 }}>{tr('平台还没有文献库。', 'No libraries on the platform yet.')}</div>
         ) : (
           <div style={{ maxHeight: '55vh', overflowY: 'auto', marginTop: 4 }}>
-            <LibraryPicker libraries={allLibraries} selectedIds={linkDraft} onToggle={toggleLinkDraft} disabled={setSourceLibsMutation.isPending} />
+            <LibraryPicker
+              libraries={allLibraries}
+              selectedIds={linkDraft}
+              onToggle={toggleLinkDraft}
+              disabled={setSourceLibsMutation.isPending}
+              disabledIds={protectedLibraryIds}
+            />
           </div>
         )}
       </Modal>
 
       <div className="col gap16">
+        {project.research_mode === 'interdisciplinary' && (
+          <InterdisciplinaryScopePanel
+            project={project}
+            dedicatedLibrary={sourceLibraries?.find((library) => library.library_kind === 'interdisciplinary')}
+          />
+        )}
+
         {/* 一句话定义 */}
         <SectionCard icon="sparkle" zh="课题定义" en="Statement">
           <EditableText value={project.statement ?? ''} placeholder={tr('尚未填写一句话定义', 'No one-line statement yet')}
@@ -340,7 +364,7 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
         {/* 关联文献库 */}
         <SectionCard icon="book" zh="关联文献库" en="Linked libraries"
           action={
-            <button className="btn btn-soft sm" onClick={openLinkEditor}>
+            <button className="btn btn-soft sm" onClick={openLinkEditor} disabled={!sourceLibraries}>
               <Icon name="pen" size={12} />
               {tr('管理', 'Manage')}
             </button>
@@ -360,8 +384,18 @@ export function ProjectSettings({ id, embedded = false }: { id: string; embedded
                     <Icon name="book" size={14} />
                   </span>
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 13, fontWeight: 600 }}>{lib.name}</div>
+                    <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+                      <span style={{ fontSize: 13, fontWeight: 600 }}>{lib.name}</span>
+                      {lib.library_kind === 'interdisciplinary' && (
+                        <span className="pill sm">{tr('专属交叉库', 'Dedicated interdisciplinary')}</span>
+                      )}
+                    </div>
                     {lib.statement && <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginTop: 2, lineHeight: 1.4 }}>{lib.statement}</div>}
+                    {!!lib.interdisciplinary_domains?.length && (
+                      <div className="muted" style={{ fontSize: 11, marginTop: 3 }}>
+                        {lib.interdisciplinary_domains.join(' · ')}
+                      </div>
+                    )}
                   </div>
                   <span className="mono muted" style={{ fontSize: 11, flexShrink: 0 }}>{tr(`${lib.paper_count} 篇`, `${lib.paper_count} papers`)}</span>
                 </div>

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -6,18 +6,22 @@ import { PageHead } from '../../components/ui/PageHead';
 import { FormField } from '../../components/ui/FormField';
 import { toast } from '../../components/ui/Toast';
 import { topicPath, useProject } from '../../app/project';
-import { api } from '../../lib/api';
+import {
+  api,
+  type InterdisciplinaryScopeDraft,
+  type InterdisciplinaryScopeSuggestion,
+} from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { useLibraries } from '../libraries/hooks';
 import { LibraryPicker } from '../libraries/LibraryPicker';
-
-/* ============================================================
-   /projects/new — 建课题（30 秒）。
-   只有三件事：课题名称 + 一句话 statement + 关联哪些已有文献库（可跳过）。
-   收录配置（rubric / 关键词 / arXiv 分类 / 节奏 / 锚点 …）属于文献库，在
-   建库表单里填、由文献库管理员维护；建课题不碰这些。
-   创建成功后进课题工作台。
-   ============================================================ */
+import { ResearchModeFields } from './ResearchModeFields';
+import {
+  createInterdisciplinaryProject,
+  InterdisciplinarySetupError,
+  splitInterdisciplinaryTerms,
+  validateInterdisciplinaryScope,
+  type ResearchMode,
+} from './interdisciplinaryWorkflow';
 
 export function ProjectWizardPage() {
   const navigate = useNavigate();
@@ -26,100 +30,329 @@ export function ProjectWizardPage() {
 
   const [name, setName] = useState('');
   const [statement, setStatement] = useState('');
+  const [researchMode, setResearchMode] = useState<ResearchMode>('conventional');
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [analyzingScope, setAnalyzingScope] = useState(false);
+  const [scopeContext, setScopeContext] = useState('');
+  const [suggestion, setSuggestion] = useState<InterdisciplinaryScopeSuggestion | null>(null);
+  const [researchScope, setResearchScope] = useState('');
+  const [coreQuestions, setCoreQuestions] = useState('');
+  const [primaryDomain, setPrimaryDomain] = useState('');
+  const [relatedDomains, setRelatedDomains] = useState('');
+  const [evidenceBoundary, setEvidenceBoundary] = useState('');
+  const [validationConditions, setValidationConditions] = useState('');
 
-  // 只能关联已激活（active）的文献库；pending/rejected 不作为语料
   const librariesQuery = useLibraries();
-  const libraries = (librariesQuery.data ?? []).filter((l) => l.status === 'active');
+  const libraries = (librariesQuery.data ?? []).filter((library) => library.status === 'active');
   const [selectedLibraryIds, setSelectedLibraryIds] = useState<Set<string>>(new Set());
-  function toggleLibrary(libId: string) {
-    setSelectedLibraryIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(libId)) next.delete(libId);
-      else next.add(libId);
+
+  function toggleLibrary(libraryId: string) {
+    setSelectedLibraryIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(libraryId)) next.delete(libraryId);
+      else next.add(libraryId);
       return next;
     });
   }
 
-  /** 创建课题：名称 + 一句话 + 关联库，一次调用；成功后进课题工作台。 */
+  function applySuggestion(next: InterdisciplinaryScopeSuggestion) {
+    setSuggestion(next);
+    setResearchScope(next.research_scope);
+    setCoreQuestions(next.core_questions.join('\n'));
+    setPrimaryDomain(next.primary_domain);
+    setRelatedDomains(next.related_domains.join(', '));
+    setEvidenceBoundary(next.evidence_boundary ?? '');
+    setValidationConditions((next.validation_conditions ?? []).join('\n'));
+  }
+
+  function buildScopeDraft(): InterdisciplinaryScopeDraft {
+    return {
+      research_scope: researchScope.trim(),
+      core_questions: coreQuestions
+        .split(/\n+/)
+        .map((item) => item.trim())
+        .filter(Boolean),
+      primary_domain: primaryDomain.trim(),
+      related_domains: splitInterdisciplinaryTerms(relatedDomains),
+      evidence_boundary: evidenceBoundary.trim() || null,
+      validation_conditions: validationConditions
+        .split(/\n+/)
+        .map((item) => item.trim())
+        .filter(Boolean),
+      user_questions: suggestion?.user_questions ?? null,
+      query_matrix: suggestion?.query_matrix ?? null,
+      evidence_balance: suggestion?.evidence_balance ?? null,
+    };
+  }
+
+  async function analyzeScope() {
+    if (!name.trim() || statement.trim().length < 5) {
+      setFormError(
+        tr(
+          '跨学科研究需要先填写课题名称和不少于 5 个字符的一句话定义',
+          'Enter a topic name and a definition of at least 5 characters first',
+        ),
+      );
+      return;
+    }
+    setFormError(null);
+    setAnalyzingScope(true);
+    try {
+      const next = await api.suggestInterdisciplinaryScope({
+        name: name.trim(),
+        statement: statement.trim(),
+        ...(scopeContext.trim() ? { user_context: scopeContext.trim() } : {}),
+      });
+      applySuggestion(next);
+      toast(tr('已生成可编辑的交叉范围草案', 'Editable scope draft generated'), 'ok');
+    } catch (error) {
+      toast(
+        `${tr('范围分析失败：', 'Scope analysis failed: ')}${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
+    } finally {
+      setAnalyzingScope(false);
+    }
+  }
+
+  async function finishCreation(projectId: string) {
+    await queryClient.invalidateQueries({ queryKey: ['projects'] });
+    await queryClient.invalidateQueries({ queryKey: ['sourceLibraries', projectId] });
+    setCurrentProjectId(projectId);
+  }
+
   async function create() {
     if (!name.trim()) {
       setFormError(tr('请填写课题名称', 'Please enter a topic name'));
       return;
     }
+    if (researchMode === 'interdisciplinary' && statement.trim().length < 5) {
+      setFormError(
+        tr(
+          '跨学科研究需要填写不少于 5 个字符的一句话定义',
+          'Interdisciplinary research needs a definition of at least 5 characters',
+        ),
+      );
+      return;
+    }
+
+    const scope = buildScopeDraft();
+    const invalidField = researchMode === 'interdisciplinary'
+      ? validateInterdisciplinaryScope(scope)
+      : null;
+    if (invalidField) {
+      const labels: Record<string, string> = {
+        research_scope: tr('交叉研究范围', 'research scope'),
+        core_questions: tr('核心交叉问题', 'core questions'),
+        primary_domain: tr('主学科', 'primary domain'),
+        related_domains: tr('关联学科', 'related domains'),
+      };
+      setFormError(
+        tr(
+          `请先分析并完整填写${labels[invalidField] ?? invalidField}`,
+          `Analyze and complete ${labels[invalidField] ?? invalidField} first`,
+        ),
+      );
+      return;
+    }
+
     setFormError(null);
     setSubmitting(true);
     try {
-      const created = await api.createProject({
+      if (researchMode === 'conventional') {
+        const created = await api.createProject({
+          name: name.trim(),
+          statement: statement.trim() || undefined,
+          source_library_ids: [...selectedLibraryIds],
+          research_mode: 'conventional',
+        });
+        await finishCreation(created.id);
+        toast(tr('课题已创建', 'Topic created'), 'ok');
+        navigate(topicPath(created.id));
+        return;
+      }
+
+      const { project } = await createInterdisciplinaryProject(api, {
         name: name.trim(),
-        statement: statement.trim() || undefined,
-        source_library_ids: [...selectedLibraryIds],
+        statement: statement.trim(),
+        sourceLibraryIds: [...selectedLibraryIds],
+        scope,
       });
-      await queryClient.invalidateQueries({ queryKey: ['projects'] });
-      setCurrentProjectId(created.id);
-      toast(tr('课题已创建', 'Topic created'), 'ok');
-      navigate(topicPath(created.id));
-    } catch (e) {
-      toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+      await finishCreation(project.id);
+      toast(tr('跨学科课题和专属交叉文献库已创建', 'Topic and dedicated evidence library created'), 'ok');
+      navigate(topicPath(project.id));
+    } catch (error) {
+      if (error instanceof InterdisciplinarySetupError) {
+        await finishCreation(error.project.id);
+        const phase = error.stage === 'save-scope'
+          ? tr('交叉范围尚未保存', 'the scope was not saved')
+          : tr('交叉范围尚未确认，专属库尚未创建', 'the scope was not confirmed and the dedicated library was not created');
+        toast(
+          `${tr('课题已创建，但', 'The topic was created, but ')}${phase}：${error.message}`,
+          'error',
+        );
+        navigate(`${topicPath(error.project.id)}?tab=settings`);
+        return;
+      }
+      toast(
+        `${tr('创建失败：', 'Create failed: ')}${error instanceof Error ? error.message : String(error)}`,
+        'error',
+      );
     } finally {
       setSubmitting(false);
     }
   }
 
+  const scopeReady = researchMode === 'conventional'
+    || (suggestion !== null && validateInterdisciplinaryScope(buildScopeDraft()) === null);
+
   return (
-    <div className="page fadeup" style={{ maxWidth: 720 }}>
-      <PageHead
-        eyebrow="Polaris · Topics"
-        title={tr('新建课题', 'New topic')}
+    <div className="page fadeup project-wizard-page">
+      <PageHead eyebrow="Polaris · Topics" title={tr('新建课题', 'New topic')} />
+
+      <ResearchModeFields
+        mode={researchMode}
+        onModeChange={(mode) => {
+          setResearchMode(mode);
+          setFormError(null);
+        }}
       />
 
-      {/* —— 名称 + 一句话 —— */}
-      <div className="card card-pad" style={{ marginBottom: 12 }}>
+      <div className="card card-pad project-wizard-card">
         <FormField label={tr('课题名称', 'Name')}>
-          <input className="input" value={name} onChange={(e) => setName(e.target.value)}
-            placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')} />
+          <input
+            className="input"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={tr('如：LLM 自主科研智能体', 'e.g. LLM autonomous research agents')}
+          />
         </FormField>
         <FormField
           label={tr('一句话定义', 'Statement')}
-          hint={tr('一句话说清研究什么（可选）', 'One sentence on what this topic studies (optional)')}
+          hint={researchMode === 'interdisciplinary'
+            ? tr('用于分析研究对象、方法来源和验证边界', 'Used to analyze the object, methods and validation boundary')
+            : tr('一句话说清研究什么（可选）', 'One sentence on what this topic studies (optional)')}
         >
-          <textarea className="textarea" rows={3} value={statement} onChange={(e) => setStatement(e.target.value)}
-            placeholder={tr('如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统', 'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper')} />
+          <textarea
+            className="textarea"
+            rows={3}
+            value={statement}
+            onChange={(event) => setStatement(event.target.value)}
+            placeholder={tr(
+              '如：让 LLM agent 端到端完成从文献调研到论文的研究方法与系统',
+              'e.g. Methods and systems for LLM agents to go end-to-end from literature survey to paper',
+            )}
+          />
         </FormField>
-        {formError && <div className="field-error" style={{ marginTop: 4 }}>{formError}</div>}
+        {formError && <div className="field-error project-wizard-error">{formError}</div>}
       </div>
 
-      {/* —— 关联文献库（可选，可全部不选） —— */}
-      <div className="card card-pad" style={{ marginBottom: 12 }}>
-        <div className="row" style={{ justifyContent: 'space-between', marginBottom: 4 }}>
+      {researchMode === 'interdisciplinary' && (
+        <div className="card card-pad interdisciplinary-scope-wizard">
+          <div className="interdisciplinary-scope-head">
+            <div>
+              <span className="section-h">
+                <Icon name="layers" size={15} />
+                {tr('交叉研究范围', 'Interdisciplinary scope')}
+              </span>
+              <p>
+                {tr(
+                  '先让 AI 给出学科边界和核心问题，再由你判断、补充和确认。',
+                  'Let AI propose the domain boundary and core questions, then review and confirm them.',
+                )}
+              </p>
+            </div>
+            <button className="btn btn-soft" disabled={analyzingScope || submitting} onClick={() => void analyzeScope()}>
+              <Icon name={analyzingScope ? 'refresh' : 'sparkle'} size={14} />
+              {analyzingScope
+                ? tr('分析中…', 'Analyzing…')
+                : suggestion
+                  ? tr('重新分析', 'Analyze again')
+                  : tr('分析交叉范围', 'Analyze scope')}
+            </button>
+          </div>
+
+          {!!suggestion?.clarification_questions.length && (
+            <div className="interdisciplinary-questions">
+              <span className="label">{tr('需要你判断的问题', 'Questions for you')}</span>
+              {suggestion.clarification_questions.map((question, index) => (
+                <div key={`${index}-${question}`}>
+                  <b>{index + 1}</b>
+                  <span>{question}</span>
+                </div>
+              ))}
+              <textarea
+                className="textarea"
+                rows={3}
+                value={scopeContext}
+                onChange={(event) => setScopeContext(event.target.value)}
+                placeholder={tr('按需补充回答，再点击重新分析', 'Add answers as needed, then analyze again')}
+              />
+            </div>
+          )}
+
+          {suggestion && (
+            <div className="interdisciplinary-scope-review">
+              <FormField label={tr('交叉研究范围', 'Scope')}>
+                <textarea className="textarea" rows={4} value={researchScope} onChange={(event) => setResearchScope(event.target.value)} />
+              </FormField>
+              <FormField label={tr('核心交叉问题', 'Core questions')} hint={tr('每行一个问题', 'One question per line')}>
+                <textarea className="textarea" rows={4} value={coreQuestions} onChange={(event) => setCoreQuestions(event.target.value)} />
+              </FormField>
+              <div className="interdisciplinary-field-grid">
+                <FormField label={tr('主学科', 'Primary domain')}>
+                  <input className="input" value={primaryDomain} onChange={(event) => setPrimaryDomain(event.target.value)} />
+                </FormField>
+                <FormField label={tr('关联学科', 'Related domains')} hint={tr('使用逗号分隔', 'Comma separated')}>
+                  <input className="input" value={relatedDomains} onChange={(event) => setRelatedDomains(event.target.value)} />
+                </FormField>
+              </div>
+              <div className="interdisciplinary-field-grid">
+                <FormField label={tr('证据边界', 'Evidence boundary')}>
+                  <textarea className="textarea" rows={3} value={evidenceBoundary} onChange={(event) => setEvidenceBoundary(event.target.value)} />
+                </FormField>
+                <FormField label={tr('验证条件', 'Validation conditions')} hint={tr('每行一项', 'One per line')}>
+                  <textarea className="textarea" rows={3} value={validationConditions} onChange={(event) => setValidationConditions(event.target.value)} />
+                </FormField>
+              </div>
+              <div className="interdisciplinary-rationale">
+                <span>{tr('建议依据', 'Rationale')}</span>
+                <p>{suggestion.rationale}</p>
+                <small>{suggestion.model}</small>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="card card-pad project-wizard-card">
+        <div className="row project-wizard-section-head">
           <span className="section-h">
             <Icon name="book" size={15} style={{ color: 'var(--accent)' }} />
             {tr('关联文献库', 'Linked libraries')}
           </span>
           {libraries.length > 0 && (
-            <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+            <span className="muted project-wizard-selection-count">
               {tr(`已选 ${selectedLibraryIds.size} 个`, `${selectedLibraryIds.size} selected`)}
             </span>
           )}
         </div>
-        <div style={{ fontSize: 12.5, color: 'var(--text-3)', margin: '2px 0 12px', lineHeight: 1.6 }}>
-          {tr(
-            '可以不选，稍后在课题设置里加。',
-            'Optional — you can add libraries later in topic settings.',
-          )}
-        </div>
+        <p className="project-wizard-hint">
+          {researchMode === 'interdisciplinary'
+            ? tr(
+                '可关联已有学科库作为补充证据；确认范围后还会自动创建专属交叉文献库。',
+                'Optionally link discipline libraries as supporting evidence. A dedicated interdisciplinary library is created after confirmation.',
+              )
+            : tr('可以不选，稍后在课题设置里添加。', 'Optional. You can add libraries later in topic settings.')}
+        </p>
         {librariesQuery.isLoading ? (
           <div className="col gap8">
-            {[0, 1].map((i) => (
-              <div key={i} className="skel" style={{ height: 64, borderRadius: 12 }} />
-            ))}
+            {[0, 1].map((index) => <div key={index} className="skel project-wizard-library-skeleton" />)}
           </div>
         ) : libraries.length === 0 ? (
-          <div className="empty" style={{ padding: '20px 14px', textAlign: 'center' }}>
-            <div style={{ marginBottom: 10, color: 'var(--text-3)', lineHeight: 1.6 }}>
-              {tr('还没有可关联的文献库。', 'No libraries available to link yet.')}
-            </div>
+          <div className="empty project-wizard-empty">
+            <div>{tr('还没有可关联的文献库。', 'No libraries available to link yet.')}</div>
             <button className="btn btn-soft sm" onClick={() => navigate('/libraries')}>
               <Icon name="book" size={13} />
               {tr('去文献库新建一个（需管理员审批）', 'Create one under Libraries (needs admin approval)')}
@@ -130,11 +363,18 @@ export function ProjectWizardPage() {
         )}
       </div>
 
-      {/* 底部操作栏 */}
-      <div className="row gap10" style={{ marginTop: 18, justifyContent: 'flex-end' }}>
-        <button className="btn btn-primary" onClick={() => void create()} disabled={submitting}>
+      <div className="row project-wizard-actions">
+        <button
+          className="btn btn-primary"
+          onClick={() => void create()}
+          disabled={submitting || analyzingScope || !scopeReady}
+        >
           <Icon name="check" size={14} />
-          {submitting ? tr('创建中…', 'Creating…') : tr('创建课题', 'Create topic')}
+          {submitting
+            ? tr('创建中…', 'Creating…')
+            : researchMode === 'interdisciplinary'
+              ? tr('确认范围并创建课题', 'Confirm scope and create topic')
+              : tr('创建课题', 'Create topic')}
         </button>
       </div>
     </div>

--- a/src/frontend/src/features/projects/ResearchModeFields.tsx
+++ b/src/frontend/src/features/projects/ResearchModeFields.tsx
@@ -1,0 +1,40 @@
+import { FormField } from '../../components/ui/FormField';
+import { Icon } from '../../components/ui/Icon';
+import { Segmented } from '../../components/ui/Segmented';
+import { tr } from '../../lib/i18n';
+import type { ResearchMode } from './interdisciplinaryWorkflow';
+import './interdisciplinary.css';
+
+export function ResearchModeFields({
+  mode,
+  onModeChange,
+}: {
+  mode: ResearchMode;
+  onModeChange: (mode: ResearchMode) => void;
+}) {
+  return (
+    <div className="card card-pad research-mode-card">
+      <FormField label={tr('研究方式', 'Research mode')}>
+        <Segmented
+          options={[
+            { v: 'conventional' as const, label: tr('常规研究', 'Conventional') },
+            { v: 'interdisciplinary' as const, label: tr('跨学科研究', 'Interdisciplinary') },
+          ]}
+          value={mode}
+          onChange={onModeChange}
+        />
+      </FormField>
+      {mode === 'interdisciplinary' && (
+        <div className="research-mode-note">
+          <Icon name="layers" size={14} />
+          <span>
+            {tr(
+              'AI 先生成可编辑草案；只有在你确认后，范围版本和专属交叉文献库才会持久化。',
+              'AI first proposes an editable draft. The versioned scope and dedicated evidence library are persisted only after confirmation.',
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/projects/__tests__/interdisciplinaryWorkflow.test.ts
+++ b/src/frontend/src/features/projects/__tests__/interdisciplinaryWorkflow.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  InterdisciplinaryConfirmation,
+  InterdisciplinaryScopeDraft,
+  InterdisciplinaryScopeRead,
+  ProjectRead,
+} from '../../../lib/api';
+import {
+  createInterdisciplinaryProject,
+  splitInterdisciplinaryTerms,
+  validateInterdisciplinaryScope,
+} from '../interdisciplinaryWorkflow';
+
+const project: ProjectRead = {
+  id: 'project-1',
+  name: 'Impact-aware segmentation',
+  slug: 'impact-aware-segmentation',
+  statement: 'Combine structural impact mechanics with computer vision.',
+  status: 'active',
+  research_mode: 'interdisciplinary',
+  owner_id: 'user-1',
+  created_at: '2026-08-29T00:00:00Z',
+  updated_at: '2026-08-29T00:00:00Z',
+};
+
+const scope: InterdisciplinaryScopeDraft = {
+  research_scope: 'Study impact damage under controlled loading and image acquisition conditions.',
+  core_questions: ['How can segmentation evidence quantify structural failure?'],
+  primary_domain: 'Structural engineering',
+  related_domains: ['Computer vision'],
+};
+
+const saved: InterdisciplinaryScopeRead = {
+  ...scope,
+  id: 'scope-1',
+  project_id: project.id,
+  version: 1,
+  status: 'draft',
+  created_by: 'user-1',
+  confirmed_by: null,
+  confirmed_at: null,
+};
+
+const confirmation: InterdisciplinaryConfirmation = {
+  profile: { ...saved, status: 'confirmed', confirmed_by: 'user-1' },
+  library_id: 'library-1',
+};
+
+describe('interdisciplinary workflow', () => {
+  it('normalizes and deduplicates comma-separated domains', () => {
+    expect(splitInterdisciplinaryTerms('Mechanics， Computer vision; Mechanics\nStatistics')).toEqual([
+      'Mechanics',
+      'Computer vision',
+      'Statistics',
+    ]);
+  });
+
+  it('requires a usable scope, question, primary domain and related domain', () => {
+    expect(validateInterdisciplinaryScope(scope)).toBeNull();
+    expect(validateInterdisciplinaryScope({ ...scope, core_questions: [] })).toBe('core_questions');
+    expect(validateInterdisciplinaryScope({ ...scope, related_domains: [] })).toBe('related_domains');
+  });
+
+  it('persists create, scope save and confirmation in order', async () => {
+    const events: string[] = [];
+    const client = {
+      createProject: vi.fn(async () => { events.push('create'); return project; }),
+      saveInterdisciplinaryScope: vi.fn(async () => { events.push('save'); return saved; }),
+      confirmInterdisciplinaryScope: vi.fn(async () => { events.push('confirm'); return confirmation; }),
+    };
+
+    const result = await createInterdisciplinaryProject(client, {
+      name: project.name,
+      statement: project.statement!,
+      sourceLibraryIds: ['discipline-library'],
+      scope,
+    });
+
+    expect(events).toEqual(['create', 'save', 'confirm']);
+    expect(client.createProject).toHaveBeenCalledWith({
+      name: project.name,
+      statement: project.statement,
+      source_library_ids: ['discipline-library'],
+      research_mode: 'interdisciplinary',
+    });
+    expect(result.confirmation.library_id).toBe('library-1');
+  });
+
+  it('reports a recoverable partial project when saving the scope fails', async () => {
+    const client = {
+      createProject: vi.fn(async () => project),
+      saveInterdisciplinaryScope: vi.fn(async () => { throw new Error('save failed'); }),
+      confirmInterdisciplinaryScope: vi.fn(async () => confirmation),
+    };
+
+    await expect(createInterdisciplinaryProject(client, {
+      name: project.name,
+      statement: project.statement!,
+      sourceLibraryIds: [],
+      scope,
+    })).rejects.toMatchObject({
+      stage: 'save-scope',
+      project,
+    });
+    expect(client.confirmInterdisciplinaryScope).not.toHaveBeenCalled();
+  });
+
+  it('reports the confirmation stage without losing the created project', async () => {
+    const client = {
+      createProject: vi.fn(async () => project),
+      saveInterdisciplinaryScope: vi.fn(async () => saved),
+      confirmInterdisciplinaryScope: vi.fn(async () => { throw new Error('confirm failed'); }),
+    };
+
+    await expect(createInterdisciplinaryProject(client, {
+      name: project.name,
+      statement: project.statement!,
+      sourceLibraryIds: [],
+      scope,
+    })).rejects.toMatchObject({
+      stage: 'confirm-scope',
+      project,
+    });
+  });
+});

--- a/src/frontend/src/features/projects/interdisciplinary.css
+++ b/src/frontend/src/features/projects/interdisciplinary.css
@@ -1,0 +1,56 @@
+/* 跨学科课题工作流：保持紧凑、证据优先，并与课题设置视觉一致。 */
+.project-wizard-page { max-width: 820px; }
+.research-mode-card,
+.project-wizard-card,
+.interdisciplinary-scope-wizard { margin-bottom: 12px; }
+.research-mode-note { display: flex; gap: 8px; margin-top: 14px; border-top: 1px solid var(--border); padding-top: 13px; color: var(--text-3); font-size: 12px; line-height: 1.55; }
+.research-mode-note svg { flex: 0 0 auto; margin-top: 2px; color: var(--accent); }
+.project-wizard-error { margin-top: 4px; }
+.project-wizard-section-head { justify-content: space-between; margin-bottom: 4px; }
+.project-wizard-selection-count { font-size: 11.5px; }
+.project-wizard-hint { margin: 2px 0 12px; color: var(--text-3); font-size: 12.5px; line-height: 1.6; }
+.project-wizard-library-skeleton { height: 64px; border-radius: 8px; }
+.project-wizard-empty { padding: 20px 14px; text-align: center; }
+.project-wizard-empty > div { margin-bottom: 10px; color: var(--text-3); line-height: 1.6; }
+.project-wizard-actions { justify-content: flex-end; margin-top: 18px; }
+
+.interdisciplinary-scope-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
+.interdisciplinary-scope-head p { margin: 5px 0 0; color: var(--text-3); font-size: 12px; line-height: 1.5; }
+.interdisciplinary-questions { display: grid; gap: 7px; margin-top: 15px; border-top: 1px solid var(--border); padding-top: 13px; }
+.interdisciplinary-questions > div { display: grid; grid-template-columns: 22px minmax(0, 1fr); align-items: start; gap: 8px; color: var(--text-2); font-size: 12px; line-height: 1.5; }
+.interdisciplinary-questions > div b { display: grid; width: 20px; height: 20px; place-items: center; border-radius: 50%; background: var(--accent-soft); color: var(--accent-text); font-size: 10px; }
+.interdisciplinary-scope-review { margin-top: 15px; border-top: 1px solid var(--border); padding-top: 14px; }
+.interdisciplinary-field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.interdisciplinary-rationale { position: relative; border-left: 2px solid var(--accent); padding: 8px 78px 8px 11px; background: var(--surface-2); }
+.interdisciplinary-rationale span { color: var(--text-3); font-size: 10.5px; font-weight: 650; }
+.interdisciplinary-rationale p { margin: 3px 0 0; color: var(--text-2); font-size: 12px; line-height: 1.55; }
+.interdisciplinary-rationale small { position: absolute; top: 9px; right: 10px; color: var(--text-4); font-family: var(--mono); font-size: 9.5px; }
+
+.interdisciplinary-profile-card { padding: 18px; }
+.interdisciplinary-profile-head { display: flex; justify-content: space-between; gap: 16px; }
+.interdisciplinary-profile-head h3 { margin: 7px 0 3px; font-size: 14px; }
+.interdisciplinary-profile-head p { margin: 0; color: var(--text-3); font-size: 12px; line-height: 1.55; }
+.interdisciplinary-profile-actions { align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+.interdisciplinary-profile-skeleton { height: 160px; }
+.interdisciplinary-recovery { margin-top: 14px; border: 1px dashed var(--border-2); border-radius: 6px; padding: 12px; color: var(--text-3); font-size: 12px; line-height: 1.55; }
+.interdisciplinary-profile-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 11px; margin-top: 16px; }
+.interdisciplinary-profile-grid .profile-span { grid-column: 1 / -1; }
+.interdisciplinary-save-actions { justify-content: flex-end; margin-top: 14px; }
+.interdisciplinary-version-history { margin-top: 13px; border-top: 1px solid var(--border); padding-top: 10px; color: var(--text-3); font-size: 11.5px; }
+.interdisciplinary-version-history > summary { cursor: pointer; }
+.interdisciplinary-version-history > div { display: grid; grid-template-columns: 48px 80px minmax(0, 1fr); gap: 8px; padding: 6px 2px; border-bottom: 1px solid var(--border); }
+
+@media (max-width: 720px) {
+  .interdisciplinary-scope-head,
+  .interdisciplinary-profile-head { flex-direction: column; }
+  .interdisciplinary-scope-head .btn { width: 100%; }
+  .interdisciplinary-field-grid,
+  .interdisciplinary-profile-grid { grid-template-columns: minmax(0, 1fr); }
+  .interdisciplinary-profile-grid .profile-span { grid-column: auto; }
+  .interdisciplinary-profile-actions,
+  .interdisciplinary-save-actions { width: 100%; justify-content: stretch; }
+  .interdisciplinary-profile-actions .btn,
+  .interdisciplinary-save-actions .btn { flex: 1 1 150px; }
+  .interdisciplinary-rationale { padding-right: 11px; }
+  .interdisciplinary-rationale small { position: static; display: block; margin-top: 6px; }
+}

--- a/src/frontend/src/features/projects/interdisciplinaryWorkflow.ts
+++ b/src/frontend/src/features/projects/interdisciplinaryWorkflow.ts
@@ -1,0 +1,83 @@
+import type {
+  InterdisciplinaryConfirmation,
+  InterdisciplinaryScopeDraft,
+  InterdisciplinaryScopeRead,
+  ProjectRead,
+} from '../../lib/api';
+
+export type ResearchMode = 'conventional' | 'interdisciplinary';
+
+export function splitInterdisciplinaryTerms(value: string): string[] {
+  return [...new Set(
+    value
+      .split(/[,，;；\n]/)
+      .map((item) => item.trim())
+      .filter(Boolean),
+  )];
+}
+
+export function validateInterdisciplinaryScope(draft: InterdisciplinaryScopeDraft): string | null {
+  if (draft.research_scope.trim().length < 10) return 'research_scope';
+  if (!draft.core_questions.some((item) => item.trim())) return 'core_questions';
+  if (draft.primary_domain.trim().length < 2) return 'primary_domain';
+  if (!draft.related_domains.some((item) => item.trim())) return 'related_domains';
+  return null;
+}
+
+export type InterdisciplinarySetupStage = 'save-scope' | 'confirm-scope';
+
+export class InterdisciplinarySetupError extends Error {
+  readonly project: ProjectRead;
+  readonly stage: InterdisciplinarySetupStage;
+
+  constructor(project: ProjectRead, stage: InterdisciplinarySetupStage, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = 'InterdisciplinarySetupError';
+    this.project = project;
+    this.stage = stage;
+  }
+}
+
+interface WorkflowApi {
+  createProject(input: {
+    name: string;
+    statement?: string;
+    source_library_ids?: string[];
+    research_mode?: ResearchMode;
+  }): Promise<ProjectRead>;
+  saveInterdisciplinaryScope(
+    projectId: string,
+    input: InterdisciplinaryScopeDraft,
+  ): Promise<InterdisciplinaryScopeRead>;
+  confirmInterdisciplinaryScope(projectId: string): Promise<InterdisciplinaryConfirmation>;
+}
+
+export async function createInterdisciplinaryProject(
+  client: WorkflowApi,
+  input: {
+    name: string;
+    statement: string;
+    sourceLibraryIds: string[];
+    scope: InterdisciplinaryScopeDraft;
+  },
+): Promise<{ project: ProjectRead; confirmation: InterdisciplinaryConfirmation }> {
+  const project = await client.createProject({
+    name: input.name,
+    statement: input.statement,
+    source_library_ids: input.sourceLibraryIds,
+    research_mode: 'interdisciplinary',
+  });
+
+  try {
+    await client.saveInterdisciplinaryScope(project.id, input.scope);
+  } catch (error) {
+    throw new InterdisciplinarySetupError(project, 'save-scope', error);
+  }
+
+  try {
+    const confirmation = await client.confirmInterdisciplinaryScope(project.id);
+    return { project, confirmation };
+  } catch (error) {
+    throw new InterdisciplinarySetupError(project, 'confirm-scope', error);
+  }
+}

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -5,6 +5,7 @@ import { toast } from '../../components/ui/Toast';
 import { api, isAdmin, type DirectionLibraryDetail, type DuplicateCandidatePaper, type ProjectDefinition } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { InclusionSettingsForm, type InclusionValue } from '../libraries/InclusionSettingsForm';
+import { InterdisciplinaryScopePanel } from '../projects/InterdisciplinaryScopePanel';
 
 /** library.definition → 收录设置表单初值 */
 function fromDefinition(def: ProjectDefinition | null): InclusionValue {
@@ -45,7 +46,15 @@ export function GovernanceTab({ libraryId, readOnly = false }: { libraryId: stri
   return (
     <div className="col gap16" style={{ padding: 20, overflowY: 'auto' }}>
       {lib && <LibraryInfoCard lib={lib} readOnly={readOnly} admin={admin} />}
-      {lib && <InclusionSettingsCard lib={lib} readOnly={readOnly} />}
+      {lib?.library_kind === 'interdisciplinary' && lib.project_id && (
+        <InterdisciplinaryLibraryScope projectId={lib.project_id} library={lib} />
+      )}
+      {lib && (
+        <InclusionSettingsCard
+          lib={lib}
+          readOnly={readOnly || lib.library_kind === 'interdisciplinary'}
+        />
+      )}
       {/* 预算 / 管理员名单 / 重复论文均为管理门数据，普通用户取不到 → 只读时不渲染 */}
       {!readOnly && (
         <>
@@ -56,6 +65,26 @@ export function GovernanceTab({ libraryId, readOnly = false }: { libraryId: stri
       )}
     </div>
   );
+}
+
+function InterdisciplinaryLibraryScope({
+  projectId,
+  library,
+}: {
+  projectId: string;
+  library: DirectionLibraryDetail;
+}) {
+  const projectQuery = useQuery({
+    queryKey: ['project', projectId],
+    queryFn: () => api.getProject(projectId),
+    retry: false,
+  });
+
+  if (projectQuery.isLoading) {
+    return <section className="card interdisciplinary-profile-card"><div className="skel interdisciplinary-profile-skeleton" /></section>;
+  }
+  if (!projectQuery.data) return null;
+  return <InterdisciplinaryScopePanel project={projectQuery.data} dedicatedLibrary={library} />;
 }
 
 /* —— 重复论文候选与合并 —— */

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -267,7 +267,7 @@ export function WikiWorkbench({
             onGoGovern={libraryId ? () => setTab('govern') : undefined}
           />
         ) : tab === 'govern' && libraryId ? (
-          <GovernanceTab libraryId={libraryId} />
+          <GovernanceTab libraryId={libraryId} readOnly={!canManage} />
         ) : (
           <NotesTab pid={pid} libraryId={tabLibraryId} />
         )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -379,11 +379,47 @@ export interface ProjectMemberRead {
 export interface ProjectRead {
   id: string;
   name: string;
+  slug: string;
   statement: string | null;
-  status?: string;
+  status: string;
+  research_mode: 'conventional' | 'interdisciplinary';
+  owner_id: string;
   members?: ProjectMemberRead[];
-  created_at?: string;
-  updated_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InterdisciplinaryScopeDraft {
+  research_scope: string;
+  core_questions: string[];
+  primary_domain: string;
+  related_domains: string[];
+  evidence_boundary?: string | null;
+  validation_conditions?: string[] | null;
+  user_questions?: Record<string, unknown>[] | null;
+  query_matrix?: Record<string, unknown>[] | null;
+  evidence_balance?: Record<string, number> | null;
+}
+
+export interface InterdisciplinaryScopeSuggestion extends InterdisciplinaryScopeDraft {
+  clarification_questions: string[];
+  rationale: string;
+  model: string;
+}
+
+export interface InterdisciplinaryScopeRead extends InterdisciplinaryScopeDraft {
+  id: string;
+  project_id: string;
+  version: number;
+  status: string;
+  created_by: string;
+  confirmed_by: string | null;
+  confirmed_at: string | null;
+}
+
+export interface InterdisciplinaryConfirmation {
+  profile: InterdisciplinaryScopeRead;
+  library_id: string;
 }
 
 // ============================================================
@@ -1115,6 +1151,10 @@ export interface ConceptRelinkResult {
 export interface DirectionLibrarySummary {
   id: string;
   name: string;
+  /** standard = 普通库；interdisciplinary = 课题专属交叉证据库。 */
+  library_kind: 'standard' | 'interdisciplinary' | string;
+  /** 专属交叉库当前确认的学科范围。 */
+  interdisciplinary_domains: string[] | null;
   statement: string | null;
   /** 背后课题（过渡期隐式库 1:1 回指；未来共享库可为 null） */
   project_id: string | null;
@@ -3279,8 +3319,45 @@ export const api = {
     name: string;
     statement?: string;
     source_library_ids?: string[];
+    research_mode?: 'conventional' | 'interdisciplinary';
   }): Promise<ProjectRead> {
     return requestJson<ProjectRead>('/projects', 'POST', input);
+  },
+  suggestInterdisciplinaryScope(input: {
+    name: string;
+    statement: string;
+    user_context?: string;
+  }): Promise<InterdisciplinaryScopeSuggestion> {
+    return requestJson<InterdisciplinaryScopeSuggestion>(
+      '/projects/interdisciplinary-scope/suggest',
+      'POST',
+      input,
+    );
+  },
+  getInterdisciplinaryScope(projectId: string): Promise<InterdisciplinaryScopeRead> {
+    return request<InterdisciplinaryScopeRead>(`/projects/${projectId}/interdisciplinary/scope`);
+  },
+  listInterdisciplinaryScopeVersions(projectId: string): Promise<InterdisciplinaryScopeRead[]> {
+    return request<InterdisciplinaryScopeRead[]>(
+      `/projects/${projectId}/interdisciplinary/scope/versions`,
+    );
+  },
+  saveInterdisciplinaryScope(
+    projectId: string,
+    input: InterdisciplinaryScopeDraft,
+  ): Promise<InterdisciplinaryScopeRead> {
+    return requestJson<InterdisciplinaryScopeRead>(
+      `/projects/${projectId}/interdisciplinary/scope`,
+      'PUT',
+      input,
+    );
+  },
+  confirmInterdisciplinaryScope(projectId: string): Promise<InterdisciplinaryConfirmation> {
+    return requestJson<InterdisciplinaryConfirmation>(
+      `/projects/${projectId}/interdisciplinary/scope/confirm`,
+      'POST',
+      {},
+    );
   },
   getProject(id: string): Promise<ProjectRead> {
     return request<ProjectRead>(`/projects/${id}`);


### PR DESCRIPTION
## Summary

This PR exposes the interdisciplinary project workflow already supported by the backend.

Users can choose an interdisciplinary topic, ask the configured model for a scope draft, answer clarification questions, edit the result, and confirm it. The frontend then follows the backend contract in order:

1. create the project with `research_mode: interdisciplinary`;
2. save the reviewed scope;
3. confirm the scope and provision the dedicated evidence library.

If the second or third request fails, the project remains available and the user is sent to project settings with a precise recovery message.

Project settings and dedicated-library governance share one scope panel. It shows the current version, disciplines, research boundary, core questions, validation conditions, and version history. Only the project owner or a platform administrator can load or edit the complete scope, matching the existing API checks. The ordinary library picker also preserves the dedicated interdisciplinary library.

Conventional project creation keeps its previous behavior.

## Main changes

- add typed frontend contracts for interdisciplinary scope APIs and library metadata;
- add conventional and interdisciplinary modes to the project wizard;
- add editable scope analysis and clarification questions;
- add a tested create, save, confirm coordinator with partial-success recovery;
- add a shared scope and version panel to project settings and dedicated-library governance;
- make governance respect `can_manage` and remove mutation controls from read-only users;
- identify dedicated libraries by `library_kind`, not by list position;
- preserve the dedicated library during source-library replacement;
- add responsive styles for desktop and narrow screens.

## Tests

- `npm test`: 17 files, 96 tests passed
- `npm run build`: passed
- `pytest tests/test_interdisciplinary.py -q`: 4 passed
- workflow unit tests: 5 passed
- `git diff --check`: passed
- sensitive-value scan: passed

Visual checks used the real React build with mocked API responses:

- 1440 by 1000: no horizontal overflow
- 390 by 844: no horizontal overflow; long questions and form fields remain usable

## Integration

The branch starts directly from `main` at `851abc89cca551c7e54ff999d424521df5dc4bbd`. It does not depend on another open PR.

Closes #540
## Integration follow-up

Interdisciplinary styles now live in a feature-owned stylesheet instead of `global.css`. The layout is unchanged, and the separation avoids a merge conflict with #533, #535, and #537.

A local aggregate merge of #530, #531, #533, #535, #537, #539, #541, and #543 passed 115 frontend tests, the production build, 18 extension tests, and 86 focused backend tests.