### PR TITLE
feat(admin): manage document processing runtime settings

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -9,6 +9,12 @@ from app.schemas.admin_settings import (
     AffiliationModeRead,
     AffiliationModeUpdate,
     DailyEmbedBackfillResult,
+    DocumentProcessingCredentialCreate,
+    DocumentProcessingCredentialStatus,
+    DocumentProcessingCredentialUpdate,
+    DocumentProcessingProviderTestResult,
+    DocumentProcessingSettings,
+    DocumentProcessingSettingsUpdate,
     EmbeddingSpaceAdoptResult,
     EmbeddingSpaceItem,
     EmbeddingSpaceStatus,
@@ -28,6 +34,7 @@ from app.schemas.admin_settings import (
 from app.schemas.tts import TTSAdminSettings, TTSTestResult, TTSVoicesResult
 from app.services import affiliations as affiliations_service
 from app.services import daily_feed as daily_service
+from app.services import document_processing_settings as document_processing_settings_service
 from app.services import embedding as embedding_service
 from app.services import experiment_settings as experiment_settings_service
 from app.services import lab as lab_service
@@ -410,6 +417,122 @@ async def test_literature_provider_credential(
         session, credential_id, ok=result.ok, detail=result.detail
     )
     return result
+
+
+@router.get("/document-processing", response_model=DocumentProcessingSettings)
+async def get_document_processing_settings(
+    session: AsyncSession = Depends(get_session),
+) -> DocumentProcessingSettings:
+    return DocumentProcessingSettings(
+        **await document_processing_settings_service.get_settings(session)
+    )
+
+
+@router.put("/document-processing", response_model=DocumentProcessingSettings)
+async def set_document_processing_settings(
+    payload: DocumentProcessingSettingsUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> DocumentProcessingSettings:
+    try:
+        saved = await document_processing_settings_service.update_settings(
+            session, payload.model_dump(exclude_unset=True)
+        )
+    except document_processing_settings_service.InvalidDocumentProcessingSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_DOCUMENT_PROCESSING_SETTING:{exc.field}",
+        ) from exc
+    return DocumentProcessingSettings(**saved)
+
+
+@router.post(
+    "/document-processing/credentials",
+    response_model=DocumentProcessingCredentialStatus,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_document_processing_credential(
+    payload: DocumentProcessingCredentialCreate,
+    session: AsyncSession = Depends(get_session),
+) -> DocumentProcessingCredentialStatus:
+    try:
+        created = await document_processing_settings_service.create_credential(
+            session, **payload.model_dump()
+        )
+    except document_processing_settings_service.InvalidDocumentProcessingSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_DOCUMENT_PROCESSING_CREDENTIAL:{exc.field}",
+        ) from exc
+    return DocumentProcessingCredentialStatus(**created)
+
+
+@router.patch(
+    "/document-processing/credentials/{credential_id}",
+    response_model=DocumentProcessingCredentialStatus,
+)
+async def update_document_processing_credential(
+    credential_id: str,
+    payload: DocumentProcessingCredentialUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> DocumentProcessingCredentialStatus:
+    changes = payload.model_dump(exclude_unset=True)
+    if "label" in changes and changes["label"] is None:
+        changes["label"] = ""
+    try:
+        updated = await document_processing_settings_service.update_credential(
+            session, credential_id, **changes
+        )
+    except document_processing_settings_service.InvalidDocumentProcessingSettingError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"INVALID_DOCUMENT_PROCESSING_CREDENTIAL:{exc.field}",
+        ) from exc
+    if updated is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="DOCUMENT_PROCESSING_CREDENTIAL_NOT_FOUND"
+        )
+    return DocumentProcessingCredentialStatus(**updated)
+
+
+@router.delete(
+    "/document-processing/credentials/{credential_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_document_processing_credential(
+    credential_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    if not await document_processing_settings_service.delete_credential(session, credential_id):
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="DOCUMENT_PROCESSING_CREDENTIAL_NOT_FOUND"
+        )
+
+
+@router.post(
+    "/document-processing/credentials/{credential_id}/test",
+    response_model=DocumentProcessingProviderTestResult,
+)
+async def test_document_processing_credential(
+    credential_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> DocumentProcessingProviderTestResult:
+    secret = await document_processing_settings_service.get_credential_secret(
+        session, credential_id
+    )
+    if secret is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="DOCUMENT_PROCESSING_CREDENTIAL_NOT_FOUND"
+        )
+    runtime = await document_processing_settings_service.get_runtime_config(session)
+    result = await document_processing_settings_service.probe_mineru_credential(
+        base_url=runtime.mineru_base_url,
+        secret=secret,
+        timeout_seconds=runtime.mineru_timeout_seconds,
+    )
+    await document_processing_settings_service.record_credential_health(
+        session, credential_id, ok=result["ok"], detail=result["detail"]
+    )
+    return DocumentProcessingProviderTestResult(**result)
 
 
 @router.put("/tts", response_model=TTSAdminSettings)

--- a/src/backend/app/schemas/admin_settings.py
+++ b/src/backend/app/schemas/admin_settings.py
@@ -148,3 +148,57 @@ class LiteratureProviderTestResult(BaseModel):
     latency_ms: int
     fetched_count: int = 0
     detail: str
+
+
+class DocumentProcessingCredentialStatus(BaseModel):
+    id: str
+    provider: Literal["mineru"] = "mineru"
+    index: int | None = None
+    configured: bool
+    preview: str
+    enabled: bool = True
+    label: str | None = None
+    health: dict[str, Any] | None = None
+    created_at: float | None = None
+    updated_at: float | None = None
+
+
+class DocumentProcessingCredentialCreate(BaseModel):
+    secret: str = Field(min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool = True
+
+
+class DocumentProcessingCredentialUpdate(BaseModel):
+    secret: str | None = Field(default=None, min_length=1, max_length=20_000)
+    label: str | None = Field(default=None, max_length=120)
+    enabled: bool | None = None
+
+
+class DocumentProcessingSettings(BaseModel):
+    mineru_enabled: bool = True
+    mineru_base_url: str = Field(min_length=1, max_length=2000)
+    mineru_timeout_seconds: float = Field(gt=30, le=86_400)
+    mineru_poll_interval_seconds: float = Field(ge=1, le=300)
+    mineru_retries: int = Field(ge=0, le=5)
+    mineru_concurrency: int = Field(ge=1, le=16)
+    pymupdf_fallback_enabled: bool = True
+    mineru_credentials: list[DocumentProcessingCredentialStatus] = Field(default_factory=list)
+
+
+class DocumentProcessingSettingsUpdate(BaseModel):
+    mineru_enabled: bool | None = None
+    mineru_base_url: str | None = Field(default=None, min_length=1, max_length=2000)
+    mineru_timeout_seconds: float | None = Field(default=None, gt=30, le=86_400)
+    mineru_poll_interval_seconds: float | None = Field(default=None, ge=1, le=300)
+    mineru_retries: int | None = Field(default=None, ge=0, le=5)
+    mineru_concurrency: int | None = Field(default=None, ge=1, le=16)
+    pymupdf_fallback_enabled: bool | None = None
+
+
+class DocumentProcessingProviderTestResult(BaseModel):
+    provider: Literal["mineru"] = "mineru"
+    ok: bool
+    latency_ms: int
+    status_code: int | None = None
+    detail: str

--- a/src/backend/app/services/document_processing_settings.py
+++ b/src/backend/app/services/document_processing_settings.py
@@ -1,0 +1,397 @@
+"""Persistent administrator settings for PDF document processing.
+
+MinerU credentials are encrypted at rest and are only decrypted when a worker
+resolves the runtime configuration for a concrete parsing attempt.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+import zlib
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings as get_app_settings
+from app.core.security import decrypt_secret, encrypt_secret
+from app.models.system_setting import SystemSetting
+from app.services.mineru import MineruRuntimeConfig
+
+SETTING_KEY = "document_processing"
+_SETTING_LOCK_ID = zlib.crc32(SETTING_KEY.encode("utf-8"))
+
+
+class InvalidDocumentProcessingSettingError(ValueError):
+    """A document-processing setting failed validation."""
+
+    def __init__(self, field: str, detail: str) -> None:
+        super().__init__(f"{field}: {detail}")
+        self.field = field
+
+
+def _environment_defaults() -> dict[str, Any]:
+    settings = get_app_settings()
+    return {
+        "mineru_enabled": True,
+        "mineru_base_url": settings.mineru_base_url,
+        "mineru_timeout_seconds": settings.mineru_timeout_seconds,
+        "mineru_poll_interval_seconds": settings.mineru_poll_interval_seconds,
+        "mineru_retries": settings.mineru_retries,
+        "mineru_concurrency": settings.mineru_concurrency,
+        "pymupdf_fallback_enabled": True,
+    }
+
+
+async def _setting_for_update(session: AsyncSession) -> SystemSetting | None:
+    if session.get_bind().dialect.name == "postgresql":
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"), {"lock_id": _SETTING_LOCK_ID}
+        )
+    return await session.scalar(
+        select(SystemSetting).where(SystemSetting.key == SETTING_KEY).with_for_update()
+    )
+
+
+def _as_int(value: Any, field: str, *, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise InvalidDocumentProcessingSettingError(field, "must be an integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise InvalidDocumentProcessingSettingError(field, "must be an integer") from exc
+    if not minimum <= result <= maximum:
+        raise InvalidDocumentProcessingSettingError(
+            field, f"must be between {minimum} and {maximum}"
+        )
+    return result
+
+
+def _as_float(value: Any, field: str, *, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool):
+        raise InvalidDocumentProcessingSettingError(field, "must be numeric")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise InvalidDocumentProcessingSettingError(field, "must be numeric") from exc
+    if not minimum <= result <= maximum:
+        raise InvalidDocumentProcessingSettingError(
+            field, f"must be between {minimum:g} and {maximum:g}"
+        )
+    return result
+
+
+def _base_url(value: Any) -> str:
+    url = str(value or "").strip().rstrip("/")
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise InvalidDocumentProcessingSettingError(
+            "mineru_base_url", "must be an HTTP(S) API root without credentials or query"
+        )
+    return url
+
+
+def _normalize(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    defaults = _environment_defaults()
+    source = {**defaults, **dict(value or {})}
+    normalized = {
+        "mineru_enabled": bool(source["mineru_enabled"]),
+        "mineru_base_url": _base_url(source["mineru_base_url"]),
+        "mineru_timeout_seconds": _as_float(
+            source["mineru_timeout_seconds"],
+            "mineru_timeout_seconds",
+            minimum=31,
+            maximum=86_400,
+        ),
+        "mineru_poll_interval_seconds": _as_float(
+            source["mineru_poll_interval_seconds"],
+            "mineru_poll_interval_seconds",
+            minimum=1,
+            maximum=300,
+        ),
+        "mineru_retries": _as_int(source["mineru_retries"], "mineru_retries", minimum=0, maximum=5),
+        "mineru_concurrency": _as_int(
+            source["mineru_concurrency"], "mineru_concurrency", minimum=1, maximum=16
+        ),
+        "pymupdf_fallback_enabled": bool(source["pymupdf_fallback_enabled"]),
+    }
+    if not normalized["mineru_enabled"] and not normalized["pymupdf_fallback_enabled"]:
+        raise InvalidDocumentProcessingSettingError(
+            "parser_policy", "at least one parser must be enabled"
+        )
+    return normalized
+
+
+def _credential_entry(item: Any, index: int) -> dict[str, Any] | None:
+    if isinstance(item, str) and item:
+        stable = uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:mineru:{index}:{item}")
+        return {
+            "id": str(stable),
+            "secret": item,
+            "enabled": True,
+            "label": None,
+            "health": None,
+            "created_at": None,
+            "updated_at": None,
+        }
+    if not isinstance(item, Mapping) or not item.get("secret"):
+        return None
+    credential_id = str(item.get("id") or uuid.uuid4())
+    try:
+        uuid.UUID(credential_id)
+    except ValueError:
+        credential_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"polaris:mineru:{credential_id}"))
+    return {
+        "id": credential_id,
+        "secret": str(item["secret"]),
+        "enabled": bool(item.get("enabled", True)),
+        "label": str(item.get("label") or "").strip() or None,
+        "health": dict(item.get("health") or {}) or None,
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+    }
+
+
+def _credential_pool(value: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    raw = value.get("mineru_credentials") if isinstance(value, Mapping) else None
+    if not isinstance(raw, list):
+        return []
+    return [
+        entry
+        for index, item in enumerate(raw)
+        if (entry := _credential_entry(item, index)) is not None
+    ]
+
+
+def _mask(secret: str) -> str:
+    return f"••••{secret[-4:]}" if len(secret) >= 4 else "••••"
+
+
+def _masked_credentials(value: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": entry["id"],
+            "provider": "mineru",
+            "index": index,
+            "configured": True,
+            "preview": _mask(decrypt_secret(entry["secret"])),
+            "enabled": entry["enabled"],
+            "label": entry["label"],
+            "health": entry["health"],
+            "created_at": entry["created_at"],
+            "updated_at": entry["updated_at"],
+        }
+        for index, entry in enumerate(_credential_pool(value))
+    ]
+
+
+async def get_settings(session: AsyncSession) -> dict[str, Any]:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    return {
+        **_normalize(value),
+        "mineru_credentials": _masked_credentials(value),
+    }
+
+
+async def get_runtime_config(session: AsyncSession) -> MineruRuntimeConfig:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    normalized = _normalize(value)
+    if "mineru_credentials" in value:
+        tokens = [
+            decrypt_secret(entry["secret"]) for entry in _credential_pool(value) if entry["enabled"]
+        ]
+    else:
+        tokens = [
+            item.strip()
+            for item in get_app_settings().mineru_api_tokens.replace(";", ",").split(",")
+            if item.strip()
+        ]
+    return MineruRuntimeConfig(
+        **normalized,
+        mineru_api_tokens=tuple(tokens),
+    )
+
+
+async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dict[str, Any]:
+    row = await _setting_for_update(session)
+    previous = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
+    normalized = _normalize({**previous, **dict(data)})
+    value = dict(normalized)
+    if "mineru_credentials" in previous:
+        value["mineru_credentials"] = previous["mineru_credentials"]
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return await get_settings(session)
+
+
+async def create_credential(
+    session: AsyncSession, *, secret: str, label: str | None, enabled: bool
+) -> dict[str, Any]:
+    secret = secret.strip()
+    if not secret:
+        raise InvalidDocumentProcessingSettingError("secret", "must not be empty")
+    row = await _setting_for_update(session)
+    value = dict(row.value) if row is not None and isinstance(row.value, Mapping) else {}
+    pool = _credential_pool(value)
+    now = time.time()
+    entry = {
+        "id": str(uuid.uuid4()),
+        "secret": encrypt_secret(secret),
+        "enabled": enabled,
+        "label": str(label or "").strip() or None,
+        "health": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    pool.append(entry)
+    value["mineru_credentials"] = pool
+    if row is None:
+        session.add(SystemSetting(key=SETTING_KEY, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return next(item for item in _masked_credentials(value) if item["id"] == entry["id"])
+
+
+async def update_credential(
+    session: AsyncSession,
+    credential_id: str,
+    *,
+    secret: str | None = None,
+    label: str | None = None,
+    enabled: bool | None = None,
+) -> dict[str, Any] | None:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return None
+    value = dict(row.value)
+    pool = _credential_pool(value)
+    for entry in pool:
+        if entry["id"] != credential_id:
+            continue
+        if secret is not None:
+            if not secret.strip():
+                raise InvalidDocumentProcessingSettingError("secret", "must not be empty")
+            entry["secret"] = encrypt_secret(secret.strip())
+        if label is not None:
+            entry["label"] = label.strip() or None
+        if enabled is not None:
+            entry["enabled"] = enabled
+        entry["updated_at"] = time.time()
+        value["mineru_credentials"] = pool
+        row.value = value
+        await session.commit()
+        return next(item for item in _masked_credentials(value) if item["id"] == credential_id)
+    return None
+
+
+async def delete_credential(session: AsyncSession, credential_id: str) -> bool:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return False
+    value = dict(row.value)
+    pool = _credential_pool(value)
+    kept = [entry for entry in pool if entry["id"] != credential_id]
+    if len(kept) == len(pool):
+        return False
+    value["mineru_credentials"] = kept
+    row.value = value
+    await session.commit()
+    return True
+
+
+async def get_credential_secret(session: AsyncSession, credential_id: str) -> str | None:
+    row = await session.get(SystemSetting, SETTING_KEY)
+    value = row.value if row is not None and isinstance(row.value, Mapping) else {}
+    for entry in _credential_pool(value):
+        if entry["id"] == credential_id:
+            return decrypt_secret(entry["secret"])
+    return None
+
+
+async def record_credential_health(
+    session: AsyncSession, credential_id: str, *, ok: bool, detail: str
+) -> None:
+    row = await _setting_for_update(session)
+    if row is None or not isinstance(row.value, Mapping):
+        return
+    value = dict(row.value)
+    pool = _credential_pool(value)
+    for entry in pool:
+        if entry["id"] != credential_id:
+            continue
+        entry["health"] = {
+            "ok": ok,
+            "detail": detail[:500],
+            "checked_at": time.time(),
+        }
+        entry["updated_at"] = time.time()
+        value["mineru_credentials"] = pool
+        row.value = value
+        await session.commit()
+        return
+
+
+async def probe_mineru_credential(
+    *,
+    base_url: str,
+    secret: str,
+    timeout_seconds: float,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Authenticate with an impossible batch id without consuming parse quota."""
+
+    started = time.perf_counter()
+    owns_client = client is None
+    http = client or httpx.AsyncClient(timeout=min(timeout_seconds, 30.0))
+    try:
+        response = await http.get(
+            f"{base_url.rstrip('/')}/extract-results/batch/polaris-connectivity-probe",
+            headers={"Authorization": f"Bearer {secret}"},
+        )
+        status_code = response.status_code
+        ok = 200 <= status_code < 400 or status_code == 404
+        detail = (
+            "MinerU credential accepted"
+            if ok
+            else f"MinerU authentication failed (HTTP_{status_code})"
+            if status_code in {401, 403}
+            else f"MinerU probe failed (HTTP_{status_code})"
+        )
+        return {
+            "provider": "mineru",
+            "ok": ok,
+            "latency_ms": round((time.perf_counter() - started) * 1000),
+            "status_code": status_code,
+            "detail": detail,
+        }
+    except httpx.TimeoutException:
+        detail = "MinerU probe timed out"
+    except httpx.RequestError:
+        detail = "MinerU network request failed"
+    finally:
+        if owns_client:
+            await http.aclose()
+    return {
+        "provider": "mineru",
+        "ok": False,
+        "latency_ms": round((time.perf_counter() - started) * 1000),
+        "status_code": None,
+        "detail": detail,
+    }

--- a/src/backend/app/services/mineru.py
+++ b/src/backend/app/services/mineru.py
@@ -7,6 +7,7 @@ import io
 import re
 import zipfile
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from threading import Lock
 from typing import Any
@@ -40,6 +41,33 @@ StatusCallback = Callable[[str], Awaitable[None]]
 _SCHEDULERS_LOCK = Lock()
 _MAX_ARCHIVE_FILES = 10_000
 _MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class MineruRuntimeConfig:
+    """Immutable MinerU settings resolved for one parsing attempt."""
+
+    mineru_enabled: bool
+    mineru_base_url: str
+    mineru_api_tokens: tuple[str, ...]
+    mineru_timeout_seconds: float
+    mineru_poll_interval_seconds: float
+    mineru_retries: int
+    mineru_concurrency: int
+    pymupdf_fallback_enabled: bool = True
+
+    @classmethod
+    def from_environment(cls) -> MineruRuntimeConfig:
+        settings = get_settings()
+        return cls(
+            mineru_enabled=True,
+            mineru_base_url=settings.mineru_base_url,
+            mineru_api_tokens=tuple(_tokens(settings.mineru_api_tokens)),
+            mineru_timeout_seconds=settings.mineru_timeout_seconds,
+            mineru_poll_interval_seconds=settings.mineru_poll_interval_seconds,
+            mineru_retries=settings.mineru_retries,
+            mineru_concurrency=settings.mineru_concurrency,
+        )
 
 
 class _MineruScheduler:
@@ -224,12 +252,17 @@ def _zip_result(content: bytes, *, pages: int = 0) -> dict[str, Any]:
 class MineruCloudParser:
     """Upload a PDF to MinerU Cloud, poll until completion, and normalize Markdown."""
 
-    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
-        settings = get_settings()
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        *,
+        runtime: MineruRuntimeConfig | None = None,
+    ) -> None:
+        settings = runtime or MineruRuntimeConfig.from_environment()
         self._settings = settings
         self._client = client or httpx.AsyncClient(timeout=settings.mineru_timeout_seconds)
         self._owns_client = client is None
-        self._tokens = _tokens(settings.mineru_api_tokens)
+        self._tokens = list(settings.mineru_api_tokens)
         self._scheduler = _scheduler(self._tokens, settings.mineru_concurrency)
 
     async def aclose(self) -> None:
@@ -288,6 +321,8 @@ class MineruCloudParser:
     async def parse(
         self, pdf_path: Path, *, on_status: StatusCallback | None = None
     ) -> dict[str, Any]:
+        if not self._settings.mineru_enabled:
+            raise MineruCloudError("MINERU_DISABLED")
         async with self._scheduler.semaphore:
             token = self._next_token()
             if on_status:

--- a/src/backend/app/services/paper_content.py
+++ b/src/backend/app/services/paper_content.py
@@ -264,9 +264,14 @@ async def parse_content_version(
     try:
         if mineru_parser is None:
             if version.parser == "mineru":
-                from app.services.mineru import MineruCloudParser
+                from app.services import document_processing_settings
+                from app.services.mineru import MineruCloudError, MineruCloudParser
 
-                mineru_parser = MineruCloudParser()
+                runtime = await document_processing_settings.get_runtime_config(session)
+                allow_fallback = allow_fallback and runtime.pymupdf_fallback_enabled
+                if not runtime.mineru_enabled:
+                    raise MineruCloudError("MINERU_DISABLED")
+                mineru_parser = MineruCloudParser(runtime=runtime)
             else:
                 raise ContentParseError("MINERU_ADAPTER_NOT_CONFIGURED")
         if hasattr(mineru_parser, "parse"):

--- a/src/backend/tests/test_admin_document_processing_settings.py
+++ b/src/backend/tests/test_admin_document_processing_settings.py
@@ -1,0 +1,182 @@
+"""Administrator document-processing settings and MinerU credential lifecycle."""
+
+import httpx
+
+from app.core.config import get_settings
+from app.core.db import get_sessionmaker
+from app.models.system_setting import SystemSetting
+from app.services import document_processing_settings
+from tests.conftest import register_and_login
+
+
+async def _admin_and_member(client):
+    admin = await register_and_login(client, email="processing-admin@example.com")
+    member = await register_and_login(client, email="processing-member@example.com")
+    return {"Authorization": f"Bearer {admin}"}, {"Authorization": f"Bearer {member}"}
+
+
+async def test_document_processing_settings_roundtrip_and_permissions(client):
+    admin, member = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/document-processing",
+        json={
+            "mineru_enabled": True,
+            "mineru_base_url": "https://mineru.example/api/v4/",
+            "mineru_timeout_seconds": 7200,
+            "mineru_poll_interval_seconds": 15,
+            "mineru_retries": 3,
+            "mineru_concurrency": 4,
+            "pymupdf_fallback_enabled": True,
+        },
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["mineru_base_url"] == "https://mineru.example/api/v4"
+    assert payload["mineru_timeout_seconds"] == 7200
+    assert payload["mineru_concurrency"] == 4
+    assert payload["mineru_credentials"] == []
+
+    response = await client.get("/api/admin/settings/document-processing", headers=member)
+    assert response.status_code == 403
+
+
+async def test_document_processing_settings_reject_unsafe_policy_and_url(client):
+    admin, _member = await _admin_and_member(client)
+    response = await client.put(
+        "/api/admin/settings/document-processing",
+        json={"mineru_enabled": False, "pymupdf_fallback_enabled": False},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_DOCUMENT_PROCESSING_SETTING:parser_policy" in response.text
+
+    response = await client.put(
+        "/api/admin/settings/document-processing",
+        json={"mineru_base_url": "https://user:secret@mineru.example/api/v4"},
+        headers=admin,
+    )
+    assert response.status_code == 422
+    assert "INVALID_DOCUMENT_PROCESSING_SETTING:mineru_base_url" in response.text
+
+
+async def test_runtime_keeps_environment_tokens_until_database_pool_is_declared(
+    client, monkeypatch
+):
+    admin, _member = await _admin_and_member(client)
+    app_settings = get_settings()
+    monkeypatch.setattr(app_settings, "mineru_api_tokens", "env-key-a,env-key-b", raising=False)
+    response = await client.put(
+        "/api/admin/settings/document-processing",
+        json={"mineru_concurrency": 3},
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+
+    async with get_sessionmaker()() as session:
+        runtime = await document_processing_settings.get_runtime_config(session)
+
+    assert runtime.mineru_api_tokens == ("env-key-a", "env-key-b")
+
+
+async def test_mineru_credential_crud_is_masked_encrypted_and_controls_runtime(client, monkeypatch):
+    admin, _member = await _admin_and_member(client)
+    app_settings = get_settings()
+    monkeypatch.setattr(app_settings, "mineru_api_tokens", "environment-fallback", raising=False)
+    secret = "mineru-secret-1234"
+    response = await client.post(
+        "/api/admin/settings/document-processing/credentials",
+        json={"secret": secret, "label": "primary", "enabled": True},
+        headers=admin,
+    )
+    assert response.status_code == 201, response.text
+    created = response.json()
+    credential_id = created["id"]
+    assert created["provider"] == "mineru"
+    assert created["preview"] == "••••1234"
+    assert secret not in response.text
+
+    async with get_sessionmaker()() as session:
+        row = await session.get(SystemSetting, document_processing_settings.SETTING_KEY)
+        assert row is not None
+        assert secret not in str(row.value)
+        runtime = await document_processing_settings.get_runtime_config(session)
+        assert runtime.mineru_api_tokens == (secret,)
+
+    response = await client.patch(
+        f"/api/admin/settings/document-processing/credentials/{credential_id}",
+        json={"enabled": False, "label": "disabled"},
+        headers=admin,
+    )
+    assert response.status_code == 200
+    assert response.json()["enabled"] is False
+    async with get_sessionmaker()() as session:
+        runtime = await document_processing_settings.get_runtime_config(session)
+        assert runtime.mineru_api_tokens == ()
+
+    response = await client.delete(
+        f"/api/admin/settings/document-processing/credentials/{credential_id}", headers=admin
+    )
+    assert response.status_code == 204
+    async with get_sessionmaker()() as session:
+        runtime = await document_processing_settings.get_runtime_config(session)
+        assert runtime.mineru_api_tokens == ()
+
+
+async def test_mineru_credential_probe_records_health_without_returning_secret(client, monkeypatch):
+    admin, _member = await _admin_and_member(client)
+    secret = "probe-secret-sentinel"
+    response = await client.post(
+        "/api/admin/settings/document-processing/credentials",
+        json={"secret": secret, "enabled": True},
+        headers=admin,
+    )
+    credential_id = response.json()["id"]
+
+    async def fake_probe(**kwargs):
+        assert kwargs["secret"] == secret
+        return {
+            "provider": "mineru",
+            "ok": True,
+            "latency_ms": 12,
+            "status_code": 404,
+            "detail": "MinerU credential accepted",
+        }
+
+    monkeypatch.setattr(document_processing_settings, "probe_mineru_credential", fake_probe)
+    response = await client.post(
+        f"/api/admin/settings/document-processing/credentials/{credential_id}/test",
+        headers=admin,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert secret not in response.text
+
+    response = await client.get("/api/admin/settings/document-processing", headers=admin)
+    credential = response.json()["mineru_credentials"][0]
+    assert credential["health"]["ok"] is True
+    assert secret not in response.text
+
+
+async def test_mineru_probe_treats_authenticated_not_found_as_success():
+    observed = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["authorization"] = request.headers.get("Authorization")
+        observed["path"] = request.url.path
+        return httpx.Response(404, request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await document_processing_settings.probe_mineru_credential(
+            base_url="https://mineru.example/api/v4",
+            secret="test-key",
+            timeout_seconds=60,
+            client=client,
+        )
+
+    assert result["ok"] is True
+    assert result["status_code"] == 404
+    assert observed == {
+        "authorization": "Bearer test-key",
+        "path": "/api/v4/extract-results/batch/polaris-connectivity-probe",
+    }

--- a/src/backend/tests/test_mineru.py
+++ b/src/backend/tests/test_mineru.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from app.core.config import get_settings
-from app.services.mineru import MineruCloudParser
+from app.services.mineru import MineruCloudParser, MineruRuntimeConfig
 
 
 class FakeMineruClient:
@@ -81,6 +81,30 @@ async def test_mineru_cloud_upload_poll_and_normalize(tmp_path: Path, monkeypatc
         "mineru_downloading_result",
     ]
     assert [method for method, _url in client.calls] == ["POST", "PUT", "GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_mineru_cloud_uses_resolved_runtime_configuration(tmp_path: Path):
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-test")
+    client = FakeMineruClient()
+    runtime = MineruRuntimeConfig(
+        mineru_enabled=True,
+        mineru_base_url="https://mineru-runtime.example/api/v4",
+        mineru_api_tokens=("database-key",),
+        mineru_timeout_seconds=120,
+        mineru_poll_interval_seconds=1,
+        mineru_retries=0,
+        mineru_concurrency=1,
+    )
+
+    result = await MineruCloudParser(client=client, runtime=runtime).parse(pdf)
+
+    assert result["parser"] == "mineru"
+    assert client.calls[0] == (
+        "POST",
+        "https://mineru-runtime.example/api/v4/file-urls/batch",
+    )
 
 
 def test_zip_result_keeps_markdown_images_and_tables():

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -17,6 +17,7 @@ from app.models.paper_content import (
     PaperContentVersionVector,
 )
 from app.models.user import User
+from app.services import document_processing_settings
 from app.services.evidence import (
     current_fulltext_evidence,
     keyword_search_current_fulltext,
@@ -249,6 +250,38 @@ async def test_mineru_failure_without_fallback_is_terminal(app, client):
             )
         assert version.status == "failed"
         assert version.error_code == "MINERU_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_persisted_parser_policy_disables_mineru_and_uses_pymupdf(app, client):
+    _user_row, _library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        await document_processing_settings.update_settings(
+            session,
+            {"mineru_enabled": False, "pymupdf_fallback_enabled": True},
+        )
+        version = await create_content_version(session, asset=asset)
+        parsed = await parse_content_version(session, version=version, mineru_parser=None)
+
+    assert parsed.status == "ready_fallback"
+    assert parsed.parser == "pymupdf"
+    assert "MINERU_DISABLED" in parsed.metadata_snapshot["fallback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_persisted_parser_policy_can_make_mineru_failure_terminal(app, client):
+    _user_row, _library, _paper, asset = await _setup(client)
+    async with get_sessionmaker()() as session:
+        await document_processing_settings.update_settings(
+            session,
+            {"mineru_enabled": True, "pymupdf_fallback_enabled": False},
+        )
+        version = await create_content_version(session, asset=asset)
+        with pytest.raises(ContentParseError, match="MINERU_FAILED"):
+            await parse_content_version(session, version=version, mineru_parser=None)
+
+    assert version.status == "failed"
+    assert version.error_code == "MINERU_FAILED"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #546

## Summary

This PR adds persistent administrator controls for Polaris document-processing runtime behavior.

## What changed

- Added database-backed MinerU runtime settings: enablement, endpoint, timeout, polling interval, retries, concurrency, and PyMuPDF fallback policy.
- Added encrypted multi-key MinerU pool management with masked values, rotation, enable/disable, deletion, and persisted health state.
- Added MinerU connectivity testing using the effective runtime configuration.
- Added explicit precedence rules: database configuration overrides environment defaults; environment key fallback remains available until an administrator explicitly establishes a key pool.
- Wired the effective policy into the paper-content parsing lifecycle, including MinerU-disabled and fallback-disabled terminal behavior.

## Scope and compatibility

- Backend only; administrator UI and literature-search behavior are intentionally out of scope.
- Reuses the existing `system_settings` JSON KV storage; no migration is required.
- No secrets or environment values are included.

## Validation

- 24 document-processing/MinerU/paper-content tests passed.
- 23 related literature, structured-reading, PDF-asset, and evidence tests passed.
- 218 backend tests passed; one unrelated existing Windows `cp936`/UTF-8 Alembic fixture failure remains.
- Ruff checks for changed files and `git diff --check` passed.