### PR TITLE
feat(reading): resolve AI citations to authorized full-text evidence

### DIFF
--- a/src/backend/app/api/evidence.py
+++ b/src/backend/app/api/evidence.py
@@ -58,4 +58,19 @@ async def resolve_library_evidence(
         session, asset_id=version.asset_id, library_id=library_id
     ) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EVIDENCE_ASSET_NOT_FOUND")
-    return result
+    resolved_chunk = next(
+        (chunk for chunk in chunks if chunk.id == result.chunk_id),
+        None,
+    )
+    anchor_query = f"?library_id={library_id}&evidence={anchor.id}"
+    return result.model_copy(
+        update={
+            "library_id": library_id,
+            "content_version_id": version.id,
+            "parser": version.parser,
+            "section_path": (
+                resolved_chunk.section_path or [] if resolved_chunk is not None else []
+            ),
+            "href": f"/papers/{paper_id}/read{anchor_query}",
+        }
+    )

--- a/src/backend/app/schemas/evidence.py
+++ b/src/backend/app/schemas/evidence.py
@@ -32,7 +32,9 @@ class EvidenceResolution(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     paper_id: uuid.UUID
+    library_id: uuid.UUID | None = None
     anchor_id: uuid.UUID | None
+    content_version_id: uuid.UUID | None = None
     status: EvidenceFallback
     anchor_type: EvidenceAnchorType
     quoted_text: str
@@ -41,4 +43,6 @@ class EvidenceResolution(BaseModel):
     page_start: int | None = None
     page_end: int | None = None
     rects: list[dict[str, float]] = Field(default_factory=list)
+    section_path: list[str] = Field(default_factory=list)
+    parser: str | None = None
     href: str

--- a/src/backend/app/services/evidence.py
+++ b/src/backend/app/services/evidence.py
@@ -215,8 +215,13 @@ def _resolution(
     status: str,
     anchor_type: str,
     quoted_text: str,
+    chunk: PaperContentChunk | None = None,
 ) -> EvidenceResolution:
-    page_start, page_end, rects = _locator_values(anchor)
+    if chunk is None:
+        page_start, page_end, rects = _locator_values(anchor)
+    else:
+        page_start, page_end = chunk.page_start, chunk.page_end
+        rects = chunk.rects if isinstance(chunk.rects, list) else []
     return EvidenceResolution(
         paper_id=anchor.paper_id,
         anchor_id=anchor.id,
@@ -228,6 +233,7 @@ def _resolution(
         page_start=page_start,
         page_end=page_end,
         rects=rects,
+        section_path=(chunk.section_path or []) if chunk is not None else [],
         href=_href(anchor.paper_id, anchor.id),
     )
 
@@ -263,24 +269,34 @@ async def resolve_evidence_anchor(
             status="exact",
             anchor_type=anchor.anchor_type,
             quoted_text=anchor.quoted_text,
+            chunk=current,
         )
     needle = anchor.normalized_text
+    matches: list[PaperContentChunk] = []
     for chunk in chunks:
         normalized = normalize_evidence_text(chunk.text)
-        if needle and (needle in normalized or normalized in needle):
-            status = (
-                anchor.anchor_type
-                if anchor.anchor_type in {"sentence", "paragraph"}
-                else "chunk"
-            )
-            return _resolution(
-                anchor,
-                status=status,
-                anchor_type=status,
-                quoted_text=anchor.quoted_text,
-            )
+        if needle and needle in normalized:
+            matches.append(chunk)
+    if len(matches) == 1:
+        matched = matches[0]
+        fallback = (
+            anchor.anchor_type if anchor.anchor_type in {"sentence", "paragraph"} else "chunk"
+        )
+        return _resolution(
+            anchor,
+            status=fallback,
+            anchor_type=fallback,
+            quoted_text=anchor.quoted_text,
+            chunk=matched,
+        )
     if current is not None:
-        return _resolution(anchor, status="chunk", anchor_type="chunk", quoted_text=current.text)
+        return _resolution(
+            anchor,
+            status="chunk",
+            anchor_type="chunk",
+            quoted_text=current.text,
+            chunk=current,
+        )
     return EvidenceResolution(
         paper_id=anchor.paper_id,
         anchor_id=anchor.id,

--- a/src/backend/tests/test_evidence_anchors.py
+++ b/src/backend/tests/test_evidence_anchors.py
@@ -163,6 +163,46 @@ async def test_resolve_falls_back_to_chunk_then_paper(app) -> None:
         assert result.href.endswith(f"evidence={anchor.id}")
 
 
+@pytest.mark.asyncio
+async def test_resolve_never_selects_an_ambiguous_duplicate(app) -> None:
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Ambiguous evidence paper")
+        session.add(paper)
+        await session.flush()
+        anchor = PaperEvidenceAnchor(
+            paper_id=paper.id,
+            chunk_id=None,
+            source="fulltext",
+            content_revision=content_revision("Repeated result."),
+            anchor_key="sentence:old:0:0:0",
+            anchor_type="sentence",
+            seq=0,
+            paragraph_index=0,
+            sentence_index=0,
+            quoted_text="Repeated result.",
+            normalized_text=normalize_evidence_text("Repeated result."),
+            locator={"page_start": 1},
+        )
+        session.add(anchor)
+        await session.flush()
+        chunks = [
+            PaperContentChunk(
+                id=uuid.uuid4(),
+                content_version_id=uuid.uuid4(),
+                seq=index,
+                text=f"Section {index}. Repeated result.",
+                page_start=index + 2,
+            )
+            for index in range(2)
+        ]
+
+        result = await resolve_evidence_anchor(session, anchor, current_chunks=chunks)
+
+        assert result.status == "paper"
+        assert result.anchor_type == "paper"
+        assert result.page_start is None
+
+
 def test_migration_upgrade_and_downgrade_roundtrip(tmp_path: Path) -> None:
     cfg = Config()
     backend_dir = Path(__file__).resolve().parent.parent

--- a/src/frontend/src/features/reading/PdfReader.tsx
+++ b/src/frontend/src/features/reading/PdfReader.tsx
@@ -34,6 +34,8 @@ import { Markdown } from '../../lib/markdown';
 import { HIGHLIGHT_COLORS, HIGHLIGHT_STYLES, highlightColorMeta } from './shared';
 import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { resolveStructuredResourceUrls } from './structuredContent';
+import { findNormalizedTextRanges, findPreciseNormalizedTextRange } from './evidenceText';
+import './evidence.css';
 
 /* ============================================================
    自建 PDF 阅读器（pdf.js / react-pdf）：
@@ -70,6 +72,9 @@ export interface JumpTarget {
   id: string;
   page: number;
   nonce: number;
+  rects?: HighlightRect[] | null;
+  quote?: string | null;
+  sectionPath?: string[] | null;
 }
 
 /** 阅读器模式：PDF 标注、浏览器标准阅读器、解析后的结构化原文。 */
@@ -102,6 +107,60 @@ interface Pending {
 }
 
 const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+function rangeRects(pageElement: HTMLElement, range: Range): HighlightRect[] {
+  const pageRect = pageElement.getBoundingClientRect();
+  if (pageRect.width <= 0 || pageRect.height <= 0) return [];
+  return Array.from(range.getClientRects())
+    .filter((rect) => rect.width > 1 && rect.height > 1)
+    .map((rect) => ({
+      x0: clamp01((rect.left - pageRect.left) / pageRect.width),
+      y0: clamp01((rect.top - pageRect.top) / pageRect.height),
+      x1: clamp01((rect.right - pageRect.left) / pageRect.width),
+      y1: clamp01((rect.bottom - pageRect.top) / pageRect.height),
+    }));
+}
+
+function rectCenter(rects: HighlightRect[]) {
+  if (!rects.length) return null;
+  const x0 = Math.min(...rects.map((rect) => rect.x0));
+  const y0 = Math.min(...rects.map((rect) => rect.y0));
+  const x1 = Math.max(...rects.map((rect) => rect.x1));
+  const y1 = Math.max(...rects.map((rect) => rect.y1));
+  return { x: (x0 + x1) / 2, y: (y0 + y1) / 2 };
+}
+
+function evidenceTextRects(
+  pageElement: HTMLElement,
+  quote: string,
+  storedRects?: HighlightRect[] | null,
+): HighlightRect[] {
+  const textLayer = pageElement.querySelector<HTMLElement>('.react-pdf__Page__textContent, .textLayer');
+  if (!textLayer || !quote.trim()) return [];
+  const candidates = findNormalizedTextRanges(textLayer, quote)
+    .map((range) => rangeRects(pageElement, range))
+    .filter((rects) => rects.length > 0);
+  if (candidates.length === 1) return candidates[0]!;
+  const target = rectCenter(storedRects ?? []);
+  if (!target || candidates.length < 2) return [];
+  const ranked = candidates
+    .map((rects) => {
+      const center = rectCenter(rects)!;
+      return { rects, distance: Math.hypot(center.x - target.x, center.y - target.y) };
+    })
+    .sort((left, right) => left.distance - right.distance);
+  return ranked[1] && ranked[1].distance - ranked[0]!.distance < 0.015
+    ? []
+    : ranked[0]!.rects;
+}
+
+function usableStoredRects(rects?: HighlightRect[] | null): HighlightRect[] {
+  return (rects ?? []).filter((rect) =>
+    [rect.x0, rect.y0, rect.x1, rect.y1].every((value) => Number.isFinite(value) && value >= 0 && value <= 1)
+    && rect.x1 > rect.x0
+    && rect.y1 > rect.y0,
+  );
+}
 
 /**
  * 只从选区内「真正有文字的文本节点」收集矩形。
@@ -217,6 +276,10 @@ export function PdfReader({
   // 只渲染视口附近的页：每挂一个 <Page> 就要取那一页的数据，全挂等于把整份 PDF 下完，
   // 分段加载就白做了。未渲染的页留一个等高占位块，滚动条长度和跳转位置都不受影响。
   const [visiblePages, setVisiblePages] = useState<Set<number>>(() => new Set([1]));
+  const [evidenceRects, setEvidenceRects] = useState<HighlightRect[]>([]);
+  const [evidencePage, setEvidencePage] = useState<number | null>(null);
+  const [pageRenderTick, setPageRenderTick] = useState(0);
+  const structuredContentRef = useRef<HTMLDivElement | null>(null);
   const pageHeights = useRef<Map<number, number>>(new Map()); // 渲染过的实际高度，占位块照它来
   const [pending, setPending] = useState<Pending | null>(null);
   const [pendingStyle, setPendingStyle] = useState<HighlightStyle>('highlight');
@@ -501,12 +564,105 @@ export function PdfReader({
     [pending, pendingStyle, onCreateHighlight],
   );
 
-  // —— 跳转：定位到目标页并滚动 ——
+  // —— 证据跳转：PDF 文本层优先，存储坐标兜底，最后才切结构化原文 ——
   useEffect(() => {
     if (!jumpTarget) return;
-    const el = pageWrapRefs.current.get(jumpTarget.page);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setMode('annotate');
+    setEvidenceRects([]);
+    setEvidencePage(null);
+    setVisiblePages((current) => {
+      if (current.has(jumpTarget.page)) return current;
+      const next = new Set(current);
+      next.add(jumpTarget.page);
+      return next;
+    });
+    pageWrapRefs.current.get(jumpTarget.page)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [jumpTarget]);
+
+  useEffect(() => {
+    if (!jumpTarget?.quote || mode !== 'annotate') return;
+    let cancelled = false;
+    let frame = 0;
+    let attempts = 0;
+    const locate = () => {
+      if (cancelled) return;
+      const pageElement = pageWrapRefs.current.get(jumpTarget.page);
+      const rects = pageElement
+        ? evidenceTextRects(pageElement, jumpTarget.quote ?? '', jumpTarget.rects)
+        : [];
+      if (rects.length) {
+        setEvidenceRects(rects);
+        setEvidencePage(jumpTarget.page);
+        pageElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return;
+      }
+      attempts += 1;
+      if (attempts < 180) {
+        frame = requestAnimationFrame(locate);
+        return;
+      }
+      const stored = usableStoredRects(jumpTarget.rects);
+      if (stored.length) {
+        setEvidenceRects(stored);
+        setEvidencePage(jumpTarget.page);
+        pageElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      } else if (hasStructuredContent) {
+        setMode('structured');
+        toast(
+          tr(
+            'PDF 文本层无法可靠定位该句，已切换到结构化原文。',
+            'The PDF text layer could not resolve the sentence reliably. Switched to structured text.',
+          ),
+          'info',
+        );
+      }
+    };
+    frame = requestAnimationFrame(locate);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+  }, [hasStructuredContent, jumpTarget, mode, pageRenderTick]);
+
+  useEffect(() => {
+    if (!jumpTarget?.quote || mode !== 'structured' || !structuredQuery.data) return;
+    let cancelled = false;
+    let frame = 0;
+    let attempts = 0;
+    const registry = (CSS as unknown as {
+      highlights?: { set: (name: string, value: unknown) => void; delete: (name: string) => boolean };
+    }).highlights;
+    const HighlightCtor = (window as unknown as { Highlight?: new (...ranges: Range[]) => unknown }).Highlight;
+    const locate = () => {
+      if (cancelled) return;
+      const root = structuredContentRef.current;
+      const range = root
+        ? findPreciseNormalizedTextRange(root, jumpTarget.quote ?? '', {
+            sectionPath: jumpTarget.sectionPath,
+          })
+        : null;
+      if (!range) {
+        attempts += 1;
+        if (attempts < 120) frame = requestAnimationFrame(locate);
+        return;
+      }
+      const element = range.startContainer.parentElement;
+      element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (registry && HighlightCtor) {
+        registry.set('polaris-evidence-source', new HighlightCtor(range));
+      } else {
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    };
+    frame = requestAnimationFrame(locate);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+      registry?.delete('polaris-evidence-source');
+    };
+  }, [jumpTarget, mode, structuredQuery.data]);
 
   // 按页分组的划线
   const highlightsByPage = useMemo(() => {
@@ -654,7 +810,7 @@ export function PdfReader({
           className="scroll paper-reader-body"
           style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '28px clamp(20px, 6vw, 72px)', background: 'var(--surface)' }}
         >
-          <div style={{ width: 'min(100%, 880px)', margin: '0 auto' }}>
+          <div ref={structuredContentRef} style={{ width: 'min(100%, 880px)', margin: '0 auto' }}>
             {hasStructuredContent && structuredQuery.data ? (
               structuredQuery.data.manifest.content_format === 'mineru_markdown' ? (
                 <Markdown source={structuredQuery.data.content} />
@@ -754,7 +910,10 @@ export function PdfReader({
                     width={renderWidth}
                     renderTextLayer
                     renderAnnotationLayer={false}
-                    onRenderSuccess={({ height }) => pageHeights.current.set(pageNo, height)}
+                    onRenderSuccess={({ height }) => {
+                      pageHeights.current.set(pageNo, height);
+                      if (jumpTarget?.page === pageNo) setPageRenderTick((value) => value + 1);
+                    }}
                     loading={
                       <div
                         className="pulse"
@@ -769,6 +928,23 @@ export function PdfReader({
                 )}
                 {/* 标注覆盖层：容器不吃事件，标注单独可点。按样式渲染高亮块/下划线/波浪线 */}
                 <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+                  {evidencePage === pageNo && evidenceRects.map((rect, index) => (
+                    <div
+                      key={`evidence-${jumpTarget?.id ?? 'source'}-${index}`}
+                      aria-hidden="true"
+                      style={{
+                        position: 'absolute',
+                        left: `${rect.x0 * 100}%`,
+                        top: `${rect.y0 * 100}%`,
+                        width: `${(rect.x1 - rect.x0) * 100}%`,
+                        height: `${(rect.y1 - rect.y0) * 100}%`,
+                        borderRadius: 2,
+                        background: 'rgba(250, 204, 21, 0.42)',
+                        boxShadow: '0 0 0 1px rgba(202, 138, 4, 0.72)',
+                        mixBlendMode: 'multiply',
+                      }}
+                    />
+                  ))}
                   {pageHls.map((h) => {
                     const meta = highlightColorMeta(h.color);
                     const active = h.id === activeHighlightId;

--- a/src/frontend/src/features/reading/ReadingPage.tsx
+++ b/src/frontend/src/features/reading/ReadingPage.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import {
   api,
+  ApiError,
   type HighlightCreateInput,
   type HighlightRead,
   type MyMeta,
@@ -56,6 +57,66 @@ export function ReadingPage() {
   const [panel, setPanel] = useState<PanelTab>('highlights');
   const [activeHl, setActiveHl] = useState<string | null>(null);
   const [jump, setJump] = useState<JumpTarget | null>(null);
+  const evidenceParams = new URLSearchParams(location.search);
+  const evidenceLibraryId = evidenceParams.get('library_id');
+  const evidenceAnchorId = evidenceParams.get('evidence');
+  const evidenceQuery = useQuery({
+    queryKey: ['library-evidence', evidenceLibraryId, id, evidenceAnchorId],
+    queryFn: () => api.resolveLibraryEvidence(evidenceLibraryId!, id, evidenceAnchorId!),
+    enabled: Boolean(id && evidenceLibraryId && evidenceAnchorId),
+    retry: false,
+  });
+
+  const clearEvidenceLocation = useCallback(() => {
+    const params = new URLSearchParams(location.search);
+    params.delete('library_id');
+    params.delete('evidence');
+    params.delete('content_version_id');
+    navigate(
+      { pathname: location.pathname, search: params.size ? `?${params}` : '' },
+      { replace: true },
+    );
+  }, [location.pathname, location.search, navigate]);
+
+  useEffect(() => {
+    const evidence = evidenceQuery.data;
+    if (!evidence) return;
+    if (evidence.status === 'paper' || !evidence.page_start) {
+      setJump(null);
+      clearEvidenceLocation();
+      toast(
+        tr(
+          '原句位置已随重新解析变化，已退回论文级来源。',
+          'The sentence moved after reprocessing. Showing the paper-level source.',
+        ),
+        'info',
+      );
+      return;
+    }
+    setJump({
+      id: evidence.anchor_id ?? evidenceAnchorId ?? evidence.chunk_id ?? 'evidence',
+      page: evidence.page_start,
+      nonce: performance.now(),
+      rects: evidence.rects,
+      quote: evidence.quoted_text,
+      sectionPath: evidence.section_path,
+    });
+  }, [clearEvidenceLocation, evidenceAnchorId, evidenceQuery.data]);
+
+  useEffect(() => {
+    if (!evidenceQuery.isError) return;
+    const error = evidenceQuery.error;
+    if (!(error instanceof ApiError) || ![401, 403, 404].includes(error.status)) return;
+    setJump(null);
+    clearEvidenceLocation();
+    toast(
+      tr(
+        '该引用不存在或你已无权读取对应原文，已退回论文级来源。',
+        'The citation is unavailable or no longer authorized. Showing the paper-level source.',
+      ),
+      'info',
+    );
+  }, [clearEvidenceLocation, evidenceQuery.error, evidenceQuery.isError]);
 
   // 右侧面板：可拖拽宽度 + 可收起，均从 localStorage 恢复。
   const splitRef = useRef<HTMLDivElement>(null);
@@ -259,6 +320,11 @@ export function ReadingPage() {
   const starred = paper.starred ?? false;
   const readingStatus: ReadingStatus = paper.reading_status ?? 'unread';
   const libSaved = libState?.saved ?? false;
+  const evidenceTemporarilyUnavailable = Boolean(
+    evidenceAnchorId
+    && evidenceQuery.isError
+    && (!(evidenceQuery.error instanceof ApiError) || evidenceQuery.error.status >= 500),
+  );
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', padding: '14px 18px 16px' }}>
@@ -339,6 +405,19 @@ export function ReadingPage() {
         </button>
       </div>
 
+      {evidenceTemporarilyUnavailable && (
+        <div className="row gap8 wrap" style={{ flexShrink: 0, marginBottom: 10, padding: '8px 10px', border: '1px solid var(--warn-bd)', background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
+          <Icon name="link" size={14} />
+          <span style={{ flex: 1, fontSize: 12 }}>
+            {tr('论文仍可阅读，但精确引用位置暂时无法解析。', 'The paper remains readable, but exact citation positioning is temporarily unavailable.')}
+          </span>
+          <button className="btn btn-ghost sm" disabled={evidenceQuery.isFetching} onClick={() => void evidenceQuery.refetch()}>
+            <Icon name="refresh" size={12} style={evidenceQuery.isFetching ? { animation: 'spin 1s linear infinite' } : undefined} />
+            {tr('重试定位', 'Retry')}
+          </button>
+        </div>
+      )}
+
       {/* —— 左右分栏：右侧可拖拽调宽 / 收起 ——
           外层 .workbench-panx 只在手机上发力：分栏最小可用宽约 640px，窄屏
           放不下，整体改横向平移而不是撑破外壳（拖拽仍是鼠标事件，触屏无效，
@@ -352,7 +431,7 @@ export function ReadingPage() {
           >
             <PdfReader
               paper={paper}
-              libraryId={paperLibId}
+              libraryId={evidenceLibraryId ?? paperLibId}
               highlights={highlights}
               activeHighlightId={activeHl}
               creating={createHlMutation.isPending}

--- a/src/frontend/src/features/reading/__tests__/evidenceArtifact.test.tsx
+++ b/src/frontend/src/features/reading/__tests__/evidenceArtifact.test.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Markdown } from '../../../lib/markdown';
+import { evidenceCitationRenderer, parseEvidenceArtifact } from '../evidenceArtifact';
+
+describe('AI evidence artifact citations', () => {
+  it('removes the private manifest and resolves a unique sentence anchor', () => {
+    const source = 'Grounded claim [文1·句2].\n\n<!-- polaris-ai-evidence:{"refs":[{"article_no":1,"sentence_no":2,"paper_id":"paper-a","content_version_id":"version-a","anchor_id":"anchor-a"}]} -->';
+    const artifact = parseEvidenceArtifact(source);
+    const html = renderToStaticMarkup(
+      <Markdown
+        source={artifact.body}
+        renderCitation={evidenceCitationRenderer({
+          libraryId: 'library-a',
+          fallbackPaperId: 'paper-fallback',
+          title: 'Evidence paper',
+          refs: artifact.refs,
+        })}
+      />,
+    );
+
+    expect(artifact.body).not.toContain('polaris-ai-evidence');
+    expect(html).toContain('/papers/paper-a/read?library_id=library-a&amp;evidence=anchor-a&amp;content_version_id=version-a');
+    expect(html).toContain('[文1·句2]');
+  });
+
+  it('falls back to the paper when the sentence reference is ambiguous', () => {
+    const renderCitation = evidenceCitationRenderer({
+      libraryId: 'library-a',
+      fallbackPaperId: 'paper-a',
+      title: 'Evidence paper',
+      refs: [
+        { article_no: 1, sentence_no: 1, paper_id: 'paper-a', anchor_id: 'first' },
+        { article_no: 1, sentence_no: 1, paper_id: 'paper-a', anchor_id: 'second' },
+      ],
+    });
+    const html = renderToStaticMarkup(<Markdown source="[文1·段3·句1]" renderCitation={renderCitation} />);
+
+    expect(html).toContain('href="/papers/paper-a/read"');
+    expect(html).not.toContain('evidence=');
+  });
+});

--- a/src/frontend/src/features/reading/__tests__/evidenceText.test.ts
+++ b/src/frontend/src/features/reading/__tests__/evidenceText.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { findAllNormalizedTextMatches } from '../evidenceText';
+
+describe('evidence text matching', () => {
+  it('matches a sentence across text parts and punctuation differences', () => {
+    const matches = findAllNormalizedTextMatches(
+      ['The proposed ', 'SAM-3 model', ' improves accuracy by 12.5%.'],
+      'The proposed SAM 3 model improves accuracy by 12.5%.',
+    );
+
+    expect(matches).toEqual([
+      { startPart: 0, startOffset: 0, endPart: 2, endOffset: 26 },
+    ]);
+  });
+
+  it('returns every duplicate so callers cannot silently choose the first', () => {
+    expect(findAllNormalizedTextMatches(
+      ['Repeated evidence sentence.', 'Repeated evidence sentence.'],
+      'Repeated evidence sentence.',
+    )).toHaveLength(2);
+  });
+});

--- a/src/frontend/src/features/reading/evidence.css
+++ b/src/frontend/src/features/reading/evidence.css
@@ -1,0 +1,24 @@
+.evidence-citation {
+  color: var(--accent);
+  font-size: 0.92em;
+  font-weight: 650;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.evidence-citation:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.evidence-citation:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+::highlight(polaris-evidence-source) {
+  color: inherit;
+  background: rgba(250, 204, 21, 0.46);
+  text-decoration: underline 2px rgba(202, 138, 4, 0.9);
+}

--- a/src/frontend/src/features/reading/evidenceArtifact.tsx
+++ b/src/frontend/src/features/reading/evidenceArtifact.tsx
@@ -1,0 +1,85 @@
+import type { CitationRenderer } from '../../lib/markdown';
+import { tr } from '../../lib/i18n';
+import './evidence.css';
+
+const EVIDENCE_MANIFEST_RE = /\n?<!-- polaris-ai-evidence:(\{.*?\}) -->\s*$/s;
+
+export interface AIEvidenceReference {
+  article_no: number;
+  sentence_no: number;
+  paper_id?: string | null;
+  content_version_id?: string | null;
+  anchor_id?: string | null;
+  source?: string | null;
+}
+
+export interface ParsedEvidenceArtifact {
+  body: string;
+  refs: AIEvidenceReference[];
+}
+
+export function parseEvidenceArtifact(source: string): ParsedEvidenceArtifact {
+  const match = EVIDENCE_MANIFEST_RE.exec(source);
+  if (!match) return { body: source, refs: [] };
+  try {
+    const payload = JSON.parse(match[1]!) as { refs?: unknown };
+    const refs = Array.isArray(payload.refs)
+      ? payload.refs.filter((item): item is AIEvidenceReference => {
+          if (!item || typeof item !== 'object') return false;
+          const ref = item as Partial<AIEvidenceReference>;
+          return Number.isInteger(ref.article_no) && Number.isInteger(ref.sentence_no);
+        })
+      : [];
+    return { body: source.slice(0, match.index).trimEnd(), refs };
+  } catch {
+    return { body: source.slice(0, match.index).trimEnd(), refs: [] };
+  }
+}
+
+function matchingReference(
+  refs: AIEvidenceReference[],
+  articleNo: number,
+  sentenceNo?: number,
+): AIEvidenceReference | null {
+  if (sentenceNo === undefined) return null;
+  const matches = refs.filter(
+    (ref) => ref.article_no === articleNo && ref.sentence_no === sentenceNo,
+  );
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+export function evidenceCitationRenderer({
+  libraryId,
+  fallbackPaperId,
+  title,
+  refs,
+}: {
+  libraryId?: string | null;
+  fallbackPaperId: string;
+  title: string;
+  refs: AIEvidenceReference[];
+}): CitationRenderer {
+  return (articleNo, sentenceNo, label) => {
+    const ref = matchingReference(refs, articleNo, sentenceNo);
+    const paperId = ref?.paper_id || fallbackPaperId;
+    const params = new URLSearchParams();
+    if (libraryId && ref?.anchor_id) {
+      params.set('library_id', libraryId);
+      params.set('evidence', ref.anchor_id);
+      if (ref.content_version_id) params.set('content_version_id', ref.content_version_id);
+    }
+    const href = `/papers/${encodeURIComponent(paperId)}/read${params.size ? `?${params}` : ''}`;
+    const exact = Boolean(libraryId && ref?.anchor_id);
+    return (
+      <a
+        href={href}
+        className="evidence-citation"
+        title={exact
+          ? `${title} · ${tr('定位原文句子', 'Locate source sentence')}`
+          : `${title} · ${tr('打开论文来源', 'Open paper source')}`}
+      >
+        {label || (sentenceNo ? `[文${articleNo}·句${sentenceNo}]` : `[文${articleNo}]`)}
+      </a>
+    );
+  };
+}

--- a/src/frontend/src/features/reading/evidenceText.ts
+++ b/src/frontend/src/features/reading/evidenceText.ts
@@ -1,0 +1,117 @@
+interface TextPosition {
+  part: number;
+  start: number;
+  end: number;
+}
+
+export interface NormalizedTextMatch {
+  startPart: number;
+  startOffset: number;
+  endPart: number;
+  endOffset: number;
+}
+
+export interface EvidenceTextHints {
+  sectionPath?: string[] | null;
+}
+
+function compact(value: string): string[] {
+  return Array.from(value.normalize('NFKC').toLocaleLowerCase()).filter((char) =>
+    /[\p{L}\p{N}]/u.test(char),
+  );
+}
+
+function compactString(value?: string | null): string {
+  return compact(value ?? '').join('');
+}
+
+function normalizedParts(parts: string[]) {
+  const positions: TextPosition[] = [];
+  const haystack: string[] = [];
+  parts.forEach((part, partIndex) => {
+    let offset = 0;
+    for (const sourceChar of Array.from(part)) {
+      const width = sourceChar.length;
+      for (const normalizedChar of compact(sourceChar)) {
+        haystack.push(normalizedChar);
+        positions.push({ part: partIndex, start: offset, end: offset + width });
+      }
+      offset += width;
+    }
+  });
+  return { haystack: haystack.join(''), positions };
+}
+
+export function findAllNormalizedTextMatches(parts: string[], quote: string): NormalizedTextMatch[] {
+  const needle = compactString(quote);
+  if (needle.length < 6) return [];
+  const { haystack, positions } = normalizedParts(parts);
+  const matches: NormalizedTextMatch[] = [];
+  let cursor = 0;
+  while (cursor <= haystack.length - needle.length) {
+    const start = haystack.indexOf(needle, cursor);
+    if (start < 0) break;
+    const first = positions[start];
+    const last = positions[start + needle.length - 1];
+    if (first && last) {
+      matches.push({
+        startPart: first.part,
+        startOffset: first.start,
+        endPart: last.part,
+        endOffset: last.end,
+      });
+    }
+    cursor = start + 1;
+  }
+  return matches;
+}
+
+function textNodes(root: HTMLElement): { nodes: Text[]; sections: string[] } {
+  const nodes: Text[] = [];
+  const sections: string[] = [];
+  let section = '';
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const textNode = node as Text;
+    const parent = textNode.parentElement;
+    if (!parent || parent.closest('script, style, [aria-hidden="true"], button, input, textarea, select')) continue;
+    const heading = parent.closest('h1, h2, h3, h4, h5, h6');
+    if (heading?.textContent?.trim()) section = heading.textContent.trim();
+    nodes.push(textNode);
+    sections.push(section);
+  }
+  return { nodes, sections };
+}
+
+function rangeFor(nodes: Text[], match: NormalizedTextMatch): Range | null {
+  const first = nodes[match.startPart];
+  const last = nodes[match.endPart];
+  if (!first || !last) return null;
+  const range = document.createRange();
+  range.setStart(first, match.startOffset);
+  range.setEnd(last, match.endOffset);
+  return range;
+}
+
+export function findNormalizedTextRanges(root: HTMLElement, quote: string): Range[] {
+  const { nodes } = textNodes(root);
+  return findAllNormalizedTextMatches(nodes.map((node) => node.data), quote)
+    .map((match) => rangeFor(nodes, match))
+    .filter((range): range is Range => range !== null);
+}
+
+export function findPreciseNormalizedTextRange(
+  root: HTMLElement,
+  quote: string,
+  hints: EvidenceTextHints = {},
+): Range | null {
+  const { nodes, sections } = textNodes(root);
+  const matches = findAllNormalizedTextMatches(nodes.map((node) => node.data), quote);
+  if (matches.length === 1) return rangeFor(nodes, matches[0]!);
+  const expected = compactString(hints.sectionPath?.at(-1));
+  if (!expected || matches.length === 0) return null;
+  const sectionMatches = matches.filter((match) =>
+    compactString(sections[match.startPart]).includes(expected),
+  );
+  return sectionMatches.length === 1 ? rangeFor(nodes, sectionMatches[0]!) : null;
+}

--- a/src/frontend/src/features/wiki/PaperReader.tsx
+++ b/src/frontend/src/features/wiki/PaperReader.tsx
@@ -1,10 +1,11 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useMemo, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from '../../components/ui/Icon';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import type { PaperDetail } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { portalUrl } from '../../lib/endpoint';
+import { evidenceCitationRenderer, parseEvidenceArtifact } from '../reading/evidenceArtifact';
 
 /* ============================================================
    论文 wiki 阅览模式：把 AI 编译的图文介绍铺成一页干净、居中、
@@ -14,6 +15,7 @@ import { portalUrl } from '../../lib/endpoint';
 
 export function PaperReader({
   paper,
+  libraryId,
   renderFigure,
   onWikiLink,
   onFilterAuthor,
@@ -22,6 +24,7 @@ export function PaperReader({
   wikiContent,
 }: {
   paper: PaperDetail;
+  libraryId?: string | null;
   renderFigure: (n: number) => ReactNode;
   onWikiLink?: WikiLinkHandler;
   /** 点击作者名 → 论文库按该作者过滤 */
@@ -32,6 +35,20 @@ export function PaperReader({
   /** 正文覆写：正文不在 paper 上（如书架条目自带解读）时传进来阅览 */
   wikiContent?: string | null;
 }) {
+  const rawWikiContent = wikiContent ?? paper.wiki_content ?? '';
+  const evidenceArtifact = useMemo(
+    () => parseEvidenceArtifact(rawWikiContent),
+    [rawWikiContent],
+  );
+  const renderCitation = useMemo(
+    () => evidenceCitationRenderer({
+      libraryId,
+      fallbackPaperId: paper.id,
+      title: paper.title,
+      refs: evidenceArtifact.refs,
+    }),
+    [evidenceArtifact.refs, libraryId, paper.id, paper.title],
+  );
   // 打开即打印：等一帧让正文（含图）渲染完再唤起打印
   useEffect(() => {
     if (!autoPrint) return;
@@ -129,12 +146,13 @@ export function PaperReader({
             </div>
           )}
 
-          {(wikiContent ?? paper.wiki_content) ? (
+          {rawWikiContent ? (
             <div className="paper-reader-body">
               <Markdown
-                source={(wikiContent ?? paper.wiki_content)!}
+                source={evidenceArtifact.body}
                 onWikiLink={onWikiLink}
                 renderFigure={renderFigure}
+                renderCitation={renderCitation}
               />
             </div>
           ) : (

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -14,6 +14,7 @@ import { CompileBadge } from '../../components/ui/CompileBadge';
 import { citationExportItems, ExportDropdown } from '../../components/ui/ExportDropdown';
 import { PaperReader } from './PaperReader';
 import { readerFrom } from '../reading/shared';
+import { evidenceCitationRenderer, parseEvidenceArtifact } from '../reading/evidenceArtifact';
 import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { PaperAssetPanel } from '../shared/PaperAssetPanel';
 import { toast } from '../../components/ui/Toast';
@@ -810,6 +811,19 @@ function PaperDetailPane({
     },
     [figures, paperId],
   );
+  const evidenceArtifact = useMemo(
+    () => parseEvidenceArtifact(paper?.wiki_content ?? ''),
+    [paper?.wiki_content],
+  );
+  const renderEvidenceCitation = useMemo(
+    () => evidenceCitationRenderer({
+      libraryId,
+      fallbackPaperId: paperId,
+      title: paper?.title ?? '',
+      refs: evidenceArtifact.refs,
+    }),
+    [evidenceArtifact.refs, libraryId, paper?.title, paperId],
+  );
 
   if (isLoading) return <div className="empty">{tr('加载论文详情…', 'Loading paper…')}</div>;
   if (isError || !paper) {
@@ -1123,7 +1137,12 @@ function PaperDetailPane({
                 </button>
               </div>
             </div>
-            <Markdown source={paper.wiki_content} onWikiLink={onWikiLink} renderFigure={renderFigure} />
+            <Markdown
+              source={evidenceArtifact.body}
+              onWikiLink={onWikiLink}
+              renderFigure={renderFigure}
+              renderCitation={renderEvidenceCitation}
+            />
           </>
         ) : (
           <EmptyState
@@ -1138,6 +1157,7 @@ function PaperDetailPane({
       {readerOpen && (
         <PaperReader
           paper={paper}
+          libraryId={libraryId}
           renderFigure={renderFigure}
           onWikiLink={onWikiLink}
           onFilterAuthor={(name) => {

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1132,6 +1132,24 @@ export interface StructuredContentManifestRead {
   urls_expire_at: string | null;
 }
 
+export interface EvidenceResolutionRead {
+  paper_id: string;
+  library_id: string | null;
+  anchor_id: string | null;
+  content_version_id: string | null;
+  status: 'exact' | 'sentence' | 'paragraph' | 'chunk' | 'paper';
+  anchor_type: 'sentence' | 'paragraph' | 'chunk' | 'paper';
+  quoted_text: string;
+  chunk_id: string | null;
+  seq: number | null;
+  page_start: number | null;
+  page_end: number | null;
+  rects: HighlightRect[];
+  section_path: string[];
+  parser: string | null;
+  href: string;
+}
+
 export interface PageOf<T> {
   items: T[];
   total: number;
@@ -3929,6 +3947,15 @@ export const api = {
   },
   getLibraryPaperStructuredContent(libraryId: string, paperId: string): Promise<StructuredContentManifestRead> {
     return request<StructuredContentManifestRead>(`/libraries/${libraryId}/papers/${paperId}/structured-content`);
+  },
+  resolveLibraryEvidence(
+    libraryId: string,
+    paperId: string,
+    anchorId: string,
+  ): Promise<EvidenceResolutionRead> {
+    return request<EvidenceResolutionRead>(
+      `/libraries/${libraryId}/papers/${paperId}/evidence/${anchorId}`,
+    );
   },
   fetchStructuredContentText(url: string): Promise<string> {
     return requestResourceText(url);

--- a/src/frontend/src/lib/markdown.tsx
+++ b/src/frontend/src/lib/markdown.tsx
@@ -65,7 +65,11 @@ export type LibraryFigureRenderer = (paperId: string, index: number) => ReactNod
  * `[n]`（1-2 位数字）引用角标渲染回调（文献库对话用，编号对应来源清单）；
  * 返回 null 时按普通文本渲染。未提供回调时 `[n]` 不做任何解析。
  */
-export type CitationRenderer = (index: number) => ReactNode;
+export type CitationRenderer = (
+  articleNo: number,
+  sentenceNo?: number,
+  label?: string,
+) => ReactNode;
 export type ImageRenderer = (src: string, alt: string) => ReactNode;
 
 export interface MarkdownProps {
@@ -88,7 +92,7 @@ export interface MarkdownProps {
 /* ---------------- inline ---------------- */
 
 const INLINE_RE =
-  /(`[^`\n]+`)|(!\[\[fig:\d+\]\])|(\[\[([^\]|\n]+)(?:\|([^\]\n]+))?\]\])|(\[([^\]\n]*)\]\((https?:\/\/[^\s)]+)\))|(\*\*([^*\n]+)\*\*)|(\*([^*\n]+)\*)|(~~([^~\n]+)~~)|(\[(\d{1,2})\])|(\$([^\s$](?:[^$\n]*?[^\s$])?)\$)|(\\\((.+?)\\\))/g;
+  /(`[^`\n]+`)|(!\[\[fig:\d+\]\])|(\[\[([^\]|\n]+)(?:\|([^\]\n]+))?\]\])|(\[([^\]\n]*)\]\((https?:\/\/[^\s)]+)\))|(\*\*([^*\n]+)\*\*)|(\*([^*\n]+)\*)|(~~([^~\n]+)~~)|(\[文(\d{1,3})(?:[·.]段\d{1,4})?(?:[·.]句(\d{1,4}))?\])|(\[(\d{1,2})\])|(\$([^\s$](?:[^$\n]*?[^\s$])?)\$)|(\\\((.+?)\\\))/g;
 
 function renderInline(
   text: string,
@@ -109,12 +113,24 @@ function renderInline(
     } else if (m[2] !== undefined) {
       // 行内出现的 ![[fig:N]] 图片标记：剥除不显示（容错，只有独立成行才渲染图）
     } else if (m[15] !== undefined) {
+      // [文N·句M] / [文N·段P·句M]：段落号仅作展示，稳定定位使用证据锚点。
+      const node = renderCitation?.(
+        Number(m[16]),
+        m[17] !== undefined ? Number(m[17]) : undefined,
+        m[15],
+      ) ?? null;
+      out.push(
+        node !== null && node !== undefined && node !== false
+          ? <span key={k++}>{node}</span>
+          : m[15],
+      );
+    } else if (m[18] !== undefined) {
       // [n] 引用角标：交给 renderCitation；无回调 / 返回 null 时按原文输出
-      const node = renderCitation?.(Number(m[16])) ?? null;
+      const node = renderCitation?.(Number(m[19]), undefined, m[18]) ?? null;
       if (node !== null && node !== undefined && node !== false) {
         out.push(<span key={k++}>{node}</span>);
       } else {
-        out.push(m[15]);
+        out.push(m[18]);
       }
     } else if (m[3] !== undefined) {
       const target = (m[4] ?? '').trim();
@@ -169,10 +185,10 @@ function renderInline(
       out.push(<em key={k++}>{renderInline(m[12] ?? '', onWikiLink, renderPaperRef, renderCitation, renderLibraryFigure)}</em>);
     } else if (m[13] !== undefined) {
       out.push(<del key={k++}>{m[14] ?? ''}</del>);
-    } else if (m[17] !== undefined) {
-      out.push(<MathSpan key={k++} tex={m[18] ?? ''} display={false} />);
-    } else if (m[19] !== undefined) {
-      out.push(<MathSpan key={k++} tex={m[20] ?? ''} display={false} />);
+    } else if (m[20] !== undefined) {
+      out.push(<MathSpan key={k++} tex={m[21] ?? ''} display={false} />);
+    } else if (m[22] !== undefined) {
+      out.push(<MathSpan key={k++} tex={m[23] ?? ''} display={false} />);
     }
     last = re.lastIndex;
   }


### PR DESCRIPTION
## Summary

- resolve AI evidence citations through a library-authorized backend endpoint
- prefer PDF text-layer highlighting, with rectangle coordinates as a fallback
- fall back to structured full text when PDF positioning is unavailable
- degrade stale, reparsed, or no-longer-authorized anchors to paper-level navigation instead of dead links
- avoid arbitrary highlighting when repeated text cannot be disambiguated
- wire evidence navigation into the Wiki and paper reading surfaces

## Scope

This PR covers evidence navigation for the Wiki and paper reader surfaces. It does not claim sentence-level provenance across every AI-generated artifact in Polaris.

## Validation

- Backend targeted tests: 31 passed
- Frontend tests: 121 passed
- Frontend production build: passed
- Ruff: passed

Closes #544