### PR TITLE
fix(frontend): adapt literature workspaces to constrained widths

### DIFF
--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -925,7 +925,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
 
   return (
     <>
-      <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
+      <div className="row literature-workspace-tabs" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<BrowseTab>
           options={[
             { v: 'discover', label: tr('发现文献', 'Discover') },
@@ -969,7 +969,7 @@ export function LibraryBrowse({ libraryId }: { libraryId: string }) {
       </div>
 
       <div
-        className="card split-card"
+        className="card split-card literature-workspace-card"
       >
         {tab === 'discover' ? (
           <LiteratureDiscoveryPanel libraryId={libraryId} readOnly />

--- a/src/frontend/src/features/library/LibraryPage.tsx
+++ b/src/frontend/src/features/library/LibraryPage.tsx
@@ -592,7 +592,7 @@ export function LibraryPage() {
       style={{ maxWidth: 1360, paddingBottom: 24 }}
     >
       {/* —— tab 行：操作并在同一行右侧，顶部不再单占一行 —— */}
-      <div className="row page-tabs" style={{ marginBottom: 14 }}>
+      <div className="row page-tabs literature-workspace-tabs" style={{ marginBottom: 14 }}>
         <Segmented<PageTab>
           options={[
             { v: 'saved', label: tr('我的收藏', 'Saved') },
@@ -645,7 +645,7 @@ export function LibraryPage() {
 
       {/* —— 卡片容器（同文献追踪的论文库外壳） —— */}
       <div
-        className="card split-card"
+        className="card split-card literature-workspace-card"
       >
         {tab === 'chat' ? (
           /* ======== 个人文献库对话 ======== */

--- a/src/frontend/src/features/library/__tests__/literatureWorkspaceResponsive.test.ts
+++ b/src/frontend/src/features/library/__tests__/literatureWorkspaceResponsive.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(
+  fileURLToPath(new URL('../../../styles/global.css', import.meta.url)),
+  'utf-8',
+);
+const personalLibrary = readFileSync(
+  fileURLToPath(new URL('../LibraryPage.tsx', import.meta.url)),
+  'utf-8',
+);
+const projectLibrary = readFileSync(
+  fileURLToPath(new URL('../../wiki/WikiPage.tsx', import.meta.url)),
+  'utf-8',
+);
+const publicLibrary = readFileSync(
+  fileURLToPath(new URL('../../libraries/LibraryBrowse.tsx', import.meta.url)),
+  'utf-8',
+);
+
+describe('literature workspace responsive layout', () => {
+  it('marks each literature workspace without changing shared split behavior', () => {
+    for (const source of [personalLibrary, projectLibrary, publicLibrary]) {
+      expect(source).toContain('literature-workspace-tabs');
+      expect(source).toContain('literature-workspace-card');
+    }
+  });
+
+  it('uses the main content container and preserves complete tab labels', () => {
+    expect(css).toContain('@container mainarea (max-width: 1180px)');
+    expect(css).toContain('.literature-workspace-card .split { flex-direction: column; }');
+    expect(css).toMatch(/\.literature-workspace-tabs \.segmented > button[\s\S]*white-space: nowrap/);
+  });
+});

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -162,7 +162,7 @@ export function WikiWorkbench({
 
   return (
     <>
-      <div className="row" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
+      <div className="row literature-workspace-tabs" style={{ marginBottom: 14, justifyContent: 'space-between' }}>
         <Segmented<WikiTab>
           options={[
             ...(libraryId ? [{ v: 'discover' as const, label: tr('发现文献', 'Discover') }] : []),
@@ -210,7 +210,7 @@ export function WikiWorkbench({
       </div>
 
       <div
-        className="card"
+        className="card literature-workspace-card"
         style={{
           overflow: 'hidden',
           display: 'flex',

--- a/src/frontend/src/styles/global.css
+++ b/src/frontend/src/styles/global.css
@@ -1689,6 +1689,29 @@ input[type="range"] { accent-color: var(--accent); cursor: pointer; }
 /* ============================================================
    主区变窄时（多半是 PolarisBuddy 拉开了，而不是窗口变小）
    ============================================================ */
+@container mainarea (max-width: 1180px) {
+  /* 文献工作台按真实内容区宽度重排。视口仍宽但侧栏或 Buddy 占位时，
+     继续保留左右双栏会把详情标题和导航标签压成逐字换行。 */
+  .literature-workspace-card .split { flex-direction: column; }
+  .literature-workspace-card .split > .split-list {
+    width: 100%; max-height: 44vh; flex-shrink: 0;
+    border-right: 0; border-bottom: 0.5px solid var(--border);
+  }
+  .literature-workspace-tabs {
+    flex-wrap: nowrap; min-width: 0; overflow-x: auto;
+    -webkit-overflow-scrolling: touch; scrollbar-width: none;
+  }
+  .literature-workspace-tabs::-webkit-scrollbar,
+  .literature-workspace-tabs .segmented::-webkit-scrollbar { display: none; }
+  .literature-workspace-tabs .segmented {
+    max-width: 100%; overflow-x: auto; flex-shrink: 0;
+    -webkit-overflow-scrolling: touch; scrollbar-width: none;
+  }
+  .literature-workspace-tabs .segmented > button {
+    flex-shrink: 0; white-space: nowrap;
+  }
+}
+
 @container mainarea (max-width: 900px) {
   /* 统计卡：两列比四列挤成竖排单字强得多 */
   .dash-stats { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }


### PR DESCRIPTION
## Summary

- trigger literature workspace reflow from the actual main-area width
- stack list and detail panes below 1180 pixels of available content
- keep navigation labels on one line with horizontal scrolling
- cover personal, project, and public literature libraries

The branch is based directly on main at a330d15 and changes no business logic. It does not depend on the other frontend completion pull requests.

## Tests

- npm test -- --run: 119 passed
- npm run build
- visual checks at 1180px and 1025px main viewports
- verified zero document-level horizontal overflow at 1025px

Closes #556