### PR TITLE
feat(extension): send library papers and track archive batches

### DIFF
--- a/src/backend/app/api/download_client.py
+++ b/src/backend/app/api/download_client.py
@@ -16,7 +16,7 @@ from app.core.config import get_settings
 from app.core.db import get_session
 from app.core.queue import TaskQueue, get_task_queue
 from app.models.download_client import DownloadApiKey, DownloadBatch, DownloadBatchItem
-from app.models.library_direction import DirectionLibrary
+from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.paper import Paper
 from app.models.user import User
 from app.schemas.download_client import (
@@ -40,6 +40,7 @@ router = APIRouter(tags=["download-client"])
 SCOPES = ["download_batch:read", "download_batch:update", "paper_pdf:upload"]
 LEASE_MINUTES = 10
 TERMINAL_ITEM_STATUSES = {"uploaded", "skipped", "failed", "blocked", "cancelled"}
+DOWNLOADABLE_LIBRARY_STATUSES = ("scored", "fetched", "compiled", "included")
 
 
 def _hash_key(value: str) -> str:
@@ -102,6 +103,20 @@ async def _require_managed_library(
     if not await libraries_service.can_manage_library(session, user=user, library=library):
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="DOWNLOAD_LIBRARY_FORBIDDEN")
     return library
+
+
+async def _require_library_paper(
+    session: AsyncSession, *, library_id: uuid.UUID, paper_id: uuid.UUID
+) -> None:
+    membership_id = await session.scalar(
+        select(LibraryPaper.id).where(
+            LibraryPaper.library_id == library_id,
+            LibraryPaper.paper_id == paper_id,
+            LibraryPaper.status.in_(DOWNLOADABLE_LIBRARY_STATUSES),
+        )
+    )
+    if membership_id is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_PAPER_NOT_FOUND")
 
 
 async def download_client_user(
@@ -296,6 +311,9 @@ async def create_download_batch(
         paper = await session.get(Paper, target.paper_id)
         if paper is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+        await _require_library_paper(
+            session, library_id=target.library_id, paper_id=paper.id
+        )
         item = DownloadBatchItem(
             batch_id=batch.id,
             created_by=user.id,
@@ -601,6 +619,7 @@ async def upload_downloaded_pdf(
     paper = await session.get(Paper, item.paper_id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    await _require_library_paper(session, library_id=library.id, paper_id=paper.id)
     content = await pdf.read(asset_service.MAX_PDF_BYTES + 1)
     expected_sha256 = (item.result or {}).get("local_sha256") or x_polaris_pdf_sha256
     try:
@@ -657,6 +676,7 @@ async def archive_downloaded_pdf(
     paper = await session.get(Paper, archive.paper_id)
     if paper is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND")
+    await _require_library_paper(session, library_id=library.id, paper_id=paper.id)
     if not _identity_matches(archive, paper):
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_CONTENT, detail="DOWNLOAD_ARCHIVE_IDENTITY_MISMATCH"

--- a/src/backend/tests/test_download_batch_protocol.py
+++ b/src/backend/tests/test_download_batch_protocol.py
@@ -97,6 +97,54 @@ async def test_batch_creates_one_batch_and_rotates_key(client):
 
 
 @pytest.mark.asyncio
+async def test_batch_rejects_paper_outside_target_library(client, queue_stub):
+    token = await register_and_login(client, email="batch-membership@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, _paper_ids = await _target("batch-membership@example.com")
+    async with get_sessionmaker()() as session:
+        paper = new_paper(
+            dedup_key=f"doi:10.5555/outside-{uuid.uuid4().hex}",
+            title="Paper outside the managed library",
+            doi=f"10.5555/outside-{uuid.uuid4().hex}",
+        )
+        paper.doi = paper.dedup_key.removeprefix("doi:")
+        session.add(paper)
+        await session.commit()
+        paper_id = str(paper.id)
+        paper_doi = paper.doi
+        paper_title = paper.title
+
+    response = await client.post(
+        "/api/download-batches",
+        headers=auth,
+        json={"targets": [{"library_id": library_id, "paper_id": paper_id}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "LIBRARY_PAPER_NOT_FOUND"
+
+    api_key = (await client.post("/api/me/download-api-key", headers=auth)).json()["api_key"]
+    archived = await client.post(
+        "/api/download-client/archive",
+        headers={"X-Polaris-API-Key": api_key},
+        data={
+            "metadata": __import__("json").dumps(
+                {
+                    "library_id": library_id,
+                    "paper_id": paper_id,
+                    "nonce": "outside-library-nonce-001",
+                    "doi": paper_doi,
+                    "title": paper_title,
+                }
+            )
+        },
+        files={"pdf": ("outside.pdf", _pdf_bytes("outside"), "application/pdf")},
+    )
+    assert archived.status_code == 404
+    assert archived.json()["detail"] == "LIBRARY_PAPER_NOT_FOUND"
+
+
+@pytest.mark.asyncio
 async def test_batch_claim_upload_is_bound_and_idempotent(client, queue_stub):
     token = await register_and_login(client, email="archive-owner@example.com")
     auth = {"Authorization": f"Bearer {token}"}
@@ -221,3 +269,45 @@ async def test_direct_archive_rejects_wrong_identity(client, queue_stub):
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "DOWNLOAD_ARCHIVE_IDENTITY_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_a_paper_removed_from_the_library(client, queue_stub):
+    """批次建好之后论文被移出库，上传那一步也要拦住。
+
+    三处成员校验里，建批次和归档都有用例，只有 upload 没有——把那一行删掉，
+    整套仍然全绿。而 upload 恰恰是扩展仅凭 API key 就能打的那条路：租约在手、
+    论文已被移出或退回候选，PDF 照样能写进去，没有任何东西会报错。
+    """
+    token = await register_and_login(client, email="upload-membership@example.com")
+    auth = {"Authorization": f"Bearer {token}"}
+    library_id, paper_ids = await _target("upload-membership@example.com")
+    created = await client.post(
+        "/api/download-batches",
+        headers=auth,
+        json={"targets": [{"library_id": library_id, "paper_id": paper_ids[0]}]},
+    )
+    assert created.status_code == 200
+    api_key = (await client.post("/api/me/download-api-key", headers=auth)).json()["api_key"]
+    key_headers = {"X-Polaris-API-Key": api_key}
+    item = (await client.post("/api/download-client/items/claim", headers=key_headers)).json()
+    assert item["id"]
+
+    # 租约拿到之后，论文退回候选（等价于被移出可下载范围）
+    async with get_sessionmaker()() as session:
+        membership = await session.scalar(
+            select(LibraryPaper).where(
+                LibraryPaper.library_id == uuid.UUID(library_id),
+                LibraryPaper.paper_id == uuid.UUID(paper_ids[0]),
+            )
+        )
+        membership.status = "candidate"
+        await session.commit()
+
+    uploaded = await client.post(
+        f"/api/download-client/items/{item['id']}/pdf",
+        headers={**key_headers, "X-Polaris-Lease-Token": item["lease_token"]},
+        files={"pdf": ("x.pdf", _pdf_bytes("after-removal"), "application/pdf")},
+    )
+    assert uploaded.status_code == 404, uploaded.text
+    assert uploaded.json()["detail"] == "LIBRARY_PAPER_NOT_FOUND"

--- a/src/frontend/src/features/wiki/ExtensionBatchHistoryModal.tsx
+++ b/src/frontend/src/features/wiki/ExtensionBatchHistoryModal.tsx
@@ -1,0 +1,100 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { api, type DownloadBatchRead } from '../../lib/api';
+import { countDownloadBatchItems } from '../../lib/extension-download-batches';
+import { fmtTime } from '../../lib/format';
+import { tr } from '../../lib/i18n';
+
+const STATUS_LABELS: Record<string, [string, string]> = {
+  queued: ['等待扩展', 'Waiting for extension'],
+  running: ['处理中', 'In progress'],
+  completed: ['已完成', 'Completed'],
+  partial: ['部分完成', 'Partially completed'],
+  failed: ['失败', 'Failed'],
+};
+
+function BatchRow({ batch }: { batch: DownloadBatchRead }) {
+  const counts = countDownloadBatchItems(batch);
+  return (
+    <div style={{ padding: '13px 2px', borderBottom: '1px solid var(--border)' }}>
+      <div className="row gap8 wrap" style={{ justifyContent: 'space-between' }}>
+        <span className="row gap8 wrap">
+          <strong style={{ fontSize: 12.5 }}>{tr(...(STATUS_LABELS[batch.status] ?? [batch.status, batch.status]))}</strong>
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>{batch.id.slice(0, 8)}</span>
+        </span>
+        <time className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{fmtTime(batch.created_at)}</time>
+      </div>
+      <div className="row gap6 wrap" style={{ marginTop: 9 }}>
+        <span className="pill sm">{tr(`共 ${counts.total} 篇`, `${counts.total} papers`)}</span>
+        {!!counts.active && <span className="pill sm">{tr(`处理中 ${counts.active}`, `${counts.active} active`)}</span>}
+        {!!counts.cached && <span className="pill sm" style={{ color: 'var(--ok-tx)' }}>{tr(`已有 PDF ${counts.cached}`, `${counts.cached} cached`)}</span>}
+        {!!counts.uploaded && <span className="pill sm" style={{ color: 'var(--ok-tx)' }}>{tr(`已归档 ${counts.uploaded}`, `${counts.uploaded} archived`)}</span>}
+        {!!counts.failed && <span className="pill sm" style={{ color: 'var(--danger-tx)' }}>{tr(`需处理 ${counts.failed}`, `${counts.failed} need attention`)}</span>}
+      </div>
+      {!!counts.failed && (
+        <p style={{ margin: '8px 0 0', color: 'var(--text-3)', fontSize: 11.5, lineHeight: 1.55 }}>
+          {tr('打开 Polaris 扩展查看失败原因并重试对应论文。', 'Open the Polaris extension to inspect and retry the affected papers.')}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function ExtensionBatchHistoryModal({
+  libraryId,
+  open,
+  onClose,
+}: {
+  libraryId: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const navigate = useNavigate();
+  const batchesQuery = useQuery({
+    queryKey: ['download-batches', libraryId],
+    queryFn: () => api.listDownloadBatches(libraryId),
+    enabled: open,
+    retry: false,
+    refetchInterval: open ? 5_000 : false,
+  });
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={tr('最近扩展任务', 'Recent extension batches')}
+      sub={tr('一个任务可包含多篇论文，每篇保持独立归档绑定。', 'One batch can contain multiple independently bound papers.')}
+      width={680}
+      footer={(
+        <div className="row gap8" style={{ justifyContent: 'space-between', width: '100%' }}>
+          <button className="btn btn-ghost sm" onClick={() => { onClose(); navigate('/settings?tab=extension'); }}>
+            <Icon name="settings" size={13} />
+            {tr('扩展连接设置', 'Extension settings')}
+          </button>
+          <button className="btn btn-primary sm" onClick={onClose}>{tr('完成', 'Done')}</button>
+        </div>
+      )}
+    >
+      {batchesQuery.isLoading ? (
+        <div style={{ display: 'grid', gap: 10 }}>
+          <div className="skel" style={{ height: 76 }} />
+          <div className="skel" style={{ height: 76 }} />
+        </div>
+      ) : batchesQuery.isError ? (
+        <EmptyState
+          compact
+          icon="x"
+          title={tr('无法加载扩展任务', 'Could not load extension batches')}
+          action={<button className="btn btn-soft sm" onClick={() => void batchesQuery.refetch()}>{tr('重试', 'Retry')}</button>}
+        />
+      ) : !batchesQuery.data?.length ? (
+        <EmptyState compact icon="download" title={tr('还没有扩展任务', 'No extension batches yet')} />
+      ) : (
+        <div>{batchesQuery.data.map((batch) => <BatchRow batch={batch} key={batch.id} />)}</div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -18,6 +18,7 @@ import { PdfUploadButton } from '../shared/PdfUploadButton';
 import { PaperAssetPanel } from '../shared/PaperAssetPanel';
 import { toast } from '../../components/ui/Toast';
 import { PaperIndexStatusRow } from '../../components/ui/PaperIndexStatus';
+import { canSendToExtension, sendLibraryPapersToExtension } from '../../lib/extension-download-batches';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
 import { fmtTime } from '../../lib/format';
 import {
@@ -53,6 +54,7 @@ import { PaperBatchProgressModal } from '../library/PaperBatchProgressModal';
 import { paperDragProps } from '../assistant/paperDrag';
 import { clampLines } from '../../lib/clamp';
 import { splitPaperInput } from './paperInput';
+import { ExtensionBatchHistoryModal } from './ExtensionBatchHistoryModal';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -721,6 +723,8 @@ function PaperDetailPane({
   onDeleted,
   compiling,
   onRecompile,
+  sendingToExtension,
+  onSendToExtension,
 }: {
   paperId: string;
   pid: string;
@@ -737,6 +741,8 @@ function PaperDetailPane({
   /** 这篇正在 AI 编译（状态存在列表页，切走再切回来照样是「编译中」） */
   compiling: boolean;
   onRecompile: (paperId: string) => void;
+  sendingToExtension: boolean;
+  onSendToExtension: (paper: PaperDetail) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -944,6 +950,21 @@ function PaperDetailPane({
             <Icon name="link" size={13} />
             {tr('原文链接', 'Source link')}
           </a>
+        )}
+        {libraryId && canManage && (
+          <button
+            className="btn btn-ghost sm"
+            disabled={sendingToExtension || !canSendToExtension(paper.status)}
+            title={
+              canSendToExtension(paper.status)
+                ? undefined
+                : tr('这篇还是候选，先收录进库才能推送', 'Still a candidate; include it in the library first')
+            }
+            onClick={() => onSendToExtension(paper)}
+          >
+            <Icon name={sendingToExtension ? 'refresh' : 'share'} size={13} style={sendingToExtension ? { animation: 'spin 1s linear infinite' } : undefined} />
+            {tr('推送扩展', 'Send to extension')}
+          </button>
         )}
           {!libraryId && <PdfUploadButton paperId={paper.id} pdfAvailable={paper.pdf_available} />}
         </div>
@@ -1230,6 +1251,7 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [trashOpen, setTrashOpen] = useState(false);
+  const [extensionHistoryOpen, setExtensionHistoryOpen] = useState(false);
   const queryClient = useQueryClient();
 
   // 切换方向/视图/搜索时退出多选
@@ -1284,6 +1306,35 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
     },
     onError: (e) =>
       toast(`${tr('导出失败：', 'Export failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const extensionBatchMutation = useMutation({
+    mutationFn: (targets: PaperRead[]) => {
+      if (!libraryId) throw new Error('LIBRARY_REQUIRED');
+      return sendLibraryPapersToExtension(libraryId, targets);
+    },
+    onSuccess: ({ batch, acknowledged, dispatchedCount }) => {
+      const skipped = batch.items.filter((item) => item.status === 'skipped').length;
+      if (dispatchedCount === 0) {
+        toast(tr('所选论文均已有可读 PDF，未发送重复下载任务', 'Every selected paper already has a readable PDF; no duplicate task was sent'), 'ok');
+      } else if (acknowledged) {
+        toast(
+          tr(
+            `已向扩展推送 1 个任务，共 ${dispatchedCount} 篇${skipped ? `；另有 ${skipped} 篇已有 PDF` : ''}`,
+            `Sent one extension batch with ${dispatchedCount} papers${skipped ? `; ${skipped} already had PDFs` : ''}`,
+          ),
+          'ok',
+        );
+      } else {
+        toast(tr('批次已保存；扩展未即时确认，可稍后通过 API Key 认领', 'The batch was saved; the extension can claim it later with the API key'), 'info');
+      }
+      setSelected(new Set());
+      void queryClient.invalidateQueries({ queryKey: ['download-batches', libraryId] });
+    },
+    onError: (error) => toast(
+      `${tr('无法创建扩展任务：', 'Could not create extension batch: ')}${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    ),
   });
 
   const semanticActive = mode === 'semantic' && q.length > 0;
@@ -1697,7 +1748,23 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
                 disabled={selected.size === 0}
                 items={citationExportItems((format) => bulkExportMutation.mutate(format))}
               />
+              {libraryId && canManage && (
+                <button
+                  className="btn btn-soft sm"
+                  disabled={selected.size === 0 || extensionBatchMutation.isPending}
+                  onClick={() => extensionBatchMutation.mutate(papers.filter((paper) => selected.has(paper.id)))}
+                >
+                  <Icon name={extensionBatchMutation.isPending ? 'refresh' : 'share'} size={12} style={extensionBatchMutation.isPending ? { animation: 'spin 1s linear infinite' } : undefined} />
+                  {tr('推送扩展', 'Send to extension')}
+                </button>
+              )}
             </>
+          )}
+          {libraryId && canManage && (
+            <button className="btn btn-ghost sm" onClick={() => setExtensionHistoryOpen(true)}>
+              <Icon name="clock" size={13} />
+              {tr('扩展任务', 'Extension batches')}
+            </button>
           )}
           <button
             className="btn btn-ghost sm"
@@ -1725,6 +1792,8 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
             onDeleted={() => onSelect('')}
             compiling={compilePending.has(selectedId)}
             onRecompile={recompile}
+            sendingToExtension={extensionBatchMutation.isPending}
+            onSendToExtension={(paper) => extensionBatchMutation.mutate([paper])}
           />
         ) : (
           <div className="empty" style={{ margin: 'auto' }}>
@@ -1738,6 +1807,13 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
 
       {/* —— 回收站 —— */}
       <PapersTrashModal pid={pid ?? ''} libraryId={libraryId} open={trashOpen} onClose={() => setTrashOpen(false)} />
+      {libraryId && canManage && (
+        <ExtensionBatchHistoryModal
+          libraryId={libraryId}
+          open={extensionHistoryOpen}
+          onClose={() => setExtensionHistoryOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/frontend/src/lib/__tests__/extensionDownloadBatches.test.ts
+++ b/src/frontend/src/lib/__tests__/extensionDownloadBatches.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canSendToExtension,
+  countDownloadBatchItems,
+  extensionPapersForLibrary,
+} from '../extension-download-batches';
+
+describe('library extension batches', () => {
+  it('maps every paper to an independent library binding', () => {
+    const papers = extensionPapersForLibrary('library-a', [
+      { id: 'paper-a', title: 'A', doi: '10.1000/a', url: 'https://example.test/a' },
+      { id: 'paper-b', title: 'B', doi: null, url: null },
+    ]);
+
+    expect(papers.map((paper) => [paper.libraryId, paper.paperId])).toEqual([
+      ['library-a', 'paper-a'],
+      ['library-a', 'paper-b'],
+    ]);
+  });
+
+  it('separates cached, uploaded, active, and failed item states', () => {
+    const item = (status: string) => ({ status });
+    const counts = countDownloadBatchItems({
+      items: [item('queued'), item('downloading'), item('skipped'), item('uploaded'), item('failed')],
+    } as never);
+
+    expect(counts).toEqual({ total: 5, active: 2, cached: 1, uploaded: 1, failed: 1 });
+  });
+});
+
+describe('extension sendability gate', () => {
+  it('mirrors the backend downloadable status set', () => {
+    // 后端 DOWNLOADABLE_LIBRARY_STATUSES 之外的一律 404。UI 若不挡住，
+    // 用户对候选论文点"推送扩展"只会拿到一个看不懂的错误。
+    expect(canSendToExtension('scored')).toBe(true);
+    expect(canSendToExtension('fetched')).toBe(true);
+    expect(canSendToExtension('compiled')).toBe(true);
+    expect(canSendToExtension('included')).toBe(true);
+    expect(canSendToExtension('candidate')).toBe(false);
+    expect(canSendToExtension('excluded')).toBe(false);
+    expect(canSendToExtension(null)).toBe(false);
+    expect(canSendToExtension(undefined)).toBe(false);
+  });
+});

--- a/src/frontend/src/lib/extension-download-batches.ts
+++ b/src/frontend/src/lib/extension-download-batches.ts
@@ -1,0 +1,78 @@
+import {
+  api,
+  type DownloadBatchCreated,
+  type DownloadBatchRead,
+  type PaperRead,
+} from './api';
+import {
+  dispatchablePolarisExtensionPapers,
+  dispatchPolarisExtensionBatch,
+  type PolarisExtensionPaper,
+} from './polaris-extension';
+
+export type ExtensionDownloadPaper = Pick<PaperRead, 'id' | 'title' | 'doi' | 'url'>;
+
+/** 后端 DOWNLOADABLE_LIBRARY_STATUSES：未晋级的候选不建资产，推送必被 404 拒绝。 */
+export const EXTENSION_SENDABLE_STATUSES = ['scored', 'fetched', 'compiled', 'included'] as const;
+
+export function canSendToExtension(status: string | null | undefined): boolean {
+  return EXTENSION_SENDABLE_STATUSES.includes(status as never);
+}
+
+export interface ExtensionBatchOutcome {
+  batch: DownloadBatchCreated;
+  acknowledged: boolean;
+  dispatchedCount: number;
+}
+
+export interface DownloadBatchCounts {
+  total: number;
+  active: number;
+  cached: number;
+  uploaded: number;
+  failed: number;
+}
+
+export function extensionPapersForLibrary(
+  libraryId: string,
+  papers: ExtensionDownloadPaper[],
+): PolarisExtensionPaper[] {
+  return papers.map((paper) => ({
+    libraryId,
+    paperId: paper.id,
+    title: paper.title,
+    doi: paper.doi,
+    articleUrl: paper.url,
+    pdfCandidates: [],
+  }));
+}
+
+export async function sendLibraryPapersToExtension(
+  libraryId: string,
+  papers: ExtensionDownloadPaper[],
+): Promise<ExtensionBatchOutcome> {
+  if (papers.length === 0) throw new Error('NO_DOWNLOAD_TARGETS');
+  const extensionPapers = extensionPapersForLibrary(libraryId, papers);
+  const batch = await api.createDownloadBatch(extensionPapers.map((paper) => ({
+    library_id: paper.libraryId,
+    paper_id: paper.paperId,
+    article_url: paper.articleUrl,
+    pdf_candidates: paper.pdfCandidates,
+  })));
+  const dispatchable = dispatchablePolarisExtensionPapers(extensionPapers, batch.items);
+  const acknowledged = dispatchable.length > 0
+    ? await dispatchPolarisExtensionBatch({ batchId: batch.id, papers: dispatchable })
+    : false;
+  return { batch, acknowledged, dispatchedCount: dispatchable.length };
+}
+
+export function countDownloadBatchItems(batch: Pick<DownloadBatchRead, 'items'>): DownloadBatchCounts {
+  const counts: DownloadBatchCounts = { total: batch.items.length, active: 0, cached: 0, uploaded: 0, failed: 0 };
+  for (const item of batch.items) {
+    if (item.status === 'skipped') counts.cached += 1;
+    else if (item.status === 'uploaded') counts.uploaded += 1;
+    else if (['failed', 'blocked', 'cancelled'].includes(item.status)) counts.failed += 1;
+    else counts.active += 1;
+  }
+  return counts;
+}


### PR DESCRIPTION
#552 merged with one fix and two tests. Authorship preserved as @yyy-OPS. Based on current `main`, no migration, clean merge.

## Membership is enforced in three places; only two were covered

`_require_library_paper` is called at batch creation, at upload and at archive. Removing each in turn:

| call site | suite result with it removed |
|---|---|
| create | 1 failed |
| archive | 1 failed |
| **upload** | **6 passed** |

So the upload check had no test. That is the one I would least want unguarded: upload is the path the extension reaches with only an API key and a lease token, so a paper removed from the library — or reverted to `candidate` — after the batch was created could still have a PDF written against it, with nothing failing. Added a test that claims an item, reverts the membership to `candidate`, then uploads and expects `404 LIBRARY_PAPER_NOT_FOUND`. Removing the check reds it.

## The UI offered an action the backend rejects

`DOWNLOADABLE_LIBRARY_STATUSES` is `("scored", "fetched", "compiled", "included")` — excluding `candidate`, which is right and consistent with the "unpromoted hits get no assets" gate.

But `PapersTab` lists candidates under the `visible` filter, and the send button was gated only on `sendingToExtension`. Pressing it on a candidate returned a bare `404 LIBRARY_PAPER_NOT_FOUND` — an error with no explanation for something the UI presented as available.

Added `canSendToExtension` mirroring the backend set, gated the button on it, and put the reason in the tooltip (*"这篇还是候选，先收录进库才能推送"*). Making it always return `true` reds the new frontend test.

## Verification

- backend `tests/test_download_batch_protocol.py` → 7 passed; `ruff check app/ tests/…` clean
- frontend `tsc --noEmit` clean; `vitest run` → 120 passed

Closes #545. Supersedes #552.