### PR TITLE
feat(admin): add document processing settings UI

### DIFF
--- a/docs/superpowers/specs/2026-09-02-polaris-upstream-frontend-completion-design.md
+++ b/docs/superpowers/specs/2026-09-02-polaris-upstream-frontend-completion-design.md
@@ -1,0 +1,44 @@
+# Polaris upstream frontend completion
+
+## Scope
+
+This change set closes three frontend gaps left after the literature backend was merged:
+
+1. expose document-processing runtime settings and the MinerU credential pool to administrators;
+2. make the existing Unpaywall resolver selectable and testable from literature settings;
+3. keep the literature list/detail workspace usable when the main content area is 1025-1280 pixels wide.
+
+Each item is delivered as an independent pull request based on the same upstream commit. None of the branches depends on another branch.
+
+## Document-processing administration
+
+The administrator page gains a `Document processing` tab. It calls the existing `/api/admin/settings/document-processing` endpoints and does not introduce a second configuration store.
+
+The page contains two bounded sections:
+
+- runtime policy: MinerU enablement, API root, timeout, polling interval, retries, concurrency, and PyMuPDF fallback;
+- MinerU credential pool: add, edit, enable/disable, delete, and connection-test actions.
+
+Secrets remain write-only. Editing a credential with an empty secret preserves the stored value. General settings are saved explicitly; credential actions persist immediately, matching the literature provider settings.
+
+## Unpaywall settings
+
+Unpaywall remains an OA resolver rather than a primary bibliographic search source. It is shown separately from selectable search sources and can be tested with a DOI. This prevents an empty resolver adapter from consuming candidate-search quota or appearing as a zero-result database.
+
+No credential pool is added because the current resolver uses the contact email from server settings. Resolver health is persisted with the other provider health records.
+
+## Responsive literature workspace
+
+The existing `.content` element already establishes a named inline-size container. The fix uses that container as the breakpoint source so the UI reacts to the width that is actually available after the application sidebar and docked panels are accounted for.
+
+When the main area is at most 1180 pixels wide:
+
+- list/detail workspaces stack vertically;
+- the list receives a bounded height and a bottom divider;
+- page tabs become a single-line horizontal scroller, preventing labels from collapsing into one character per line.
+
+The existing viewport rules remain as fallbacks for browsers without container-query support. Mobile behavior is unchanged.
+
+## Verification
+
+Each branch must pass its focused tests, the complete frontend test suite, and the production build. The Unpaywall branch also runs the administrator-settings and literature-runtime backend tests. The responsive branch is checked at desktop, 1025-1280 pixel, and mobile widths with screenshots and overflow measurements.

--- a/src/frontend/src/features/settings/AdminSettingsPage.tsx
+++ b/src/frontend/src/features/settings/AdminSettingsPage.tsx
@@ -6,6 +6,7 @@ import { PageHead } from '../../components/ui/PageHead';
 import { Segmented } from '../../components/ui/Segmented';
 import { ExperimentSettings } from './ExperimentSettings';
 import { LiteratureSearchSettingsPanel } from './LiteratureSearchSettings';
+import { DocumentProcessingSettingsPanel } from './DocumentProcessingSettings';
 import { FeedbackTab } from '../feedback/FeedbackTab';
 import { tr } from '../../lib/i18n';
 import { api, isAdmin } from '../../lib/api';
@@ -16,9 +17,9 @@ import { CodesTab, DailyCategoriesTab, LlmTab, UsageTab, UsersTab } from './Sett
    各标签页组件仍住在 SettingsPage.tsx（与个人设置共用一批内部小组件），这里只负责壳层。
    ============================================================ */
 
-type AdminTab = 'llm' | 'literature' | 'experiment' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
+type AdminTab = 'llm' | 'literature' | 'processing' | 'experiment' | 'daily' | 'users' | 'codes' | 'feedback' | 'usage';
 
-const ADMIN_TABS: AdminTab[] = ['llm', 'literature', 'experiment', 'daily', 'users', 'codes', 'feedback', 'usage'];
+const ADMIN_TABS: AdminTab[] = ['llm', 'literature', 'processing', 'experiment', 'daily', 'users', 'codes', 'feedback', 'usage'];
 
 export function AdminSettingsPage() {
   const { data: me, isLoading } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false });
@@ -42,6 +43,7 @@ export function AdminSettingsPage() {
   const items: { v: AdminTab; label: string }[] = [
     { v: 'llm', label: tr('LLM 管理', 'LLM admin') },
     { v: 'literature', label: tr('文献检索', 'Literature search') },
+    { v: 'processing', label: tr('文档处理', 'Document processing') },
     { v: 'experiment', label: tr('实验设置', 'Experiments') },
     { v: 'daily', label: tr('每日论文', 'Daily papers') },
     ...(guest ? [] : [{ v: 'users' as const, label: tr('用户管理', 'Users') }]),
@@ -69,6 +71,7 @@ export function AdminSettingsPage() {
           </div>
           {shownTab === 'llm' && <LlmTab />}
           {shownTab === 'literature' && <LiteratureSearchSettingsPanel />}
+          {shownTab === 'processing' && <DocumentProcessingSettingsPanel />}
           {shownTab === 'experiment' && <ExperimentSettings />}
           {shownTab === 'daily' && <DailyCategoriesTab />}
           {shownTab === 'users' && !guest && <UsersTab />}

--- a/src/frontend/src/features/settings/DocumentProcessingSettings.tsx
+++ b/src/frontend/src/features/settings/DocumentProcessingSettings.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { FormField } from '../../components/ui/FormField';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { Switch } from '../../components/ui/Switch';
+import { toast } from '../../components/ui/Toast';
+import {
+  ApiError,
+  api,
+  type DocumentProcessingCredentialCreate,
+  type DocumentProcessingCredentialStatus,
+  type DocumentProcessingCredentialUpdate,
+  type LiteratureProviderHealth,
+} from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import {
+  documentProcessingDraftFrom,
+  validateDocumentProcessingDraft,
+  type DocumentProcessingDraft,
+} from './documentProcessingSettingsModel';
+
+interface CredentialDraft {
+  label: string;
+  secret: string;
+  enabled: boolean;
+}
+
+interface CredentialModalState {
+  mode: 'create' | 'edit';
+  credential?: DocumentProcessingCredentialStatus;
+}
+
+const EMPTY_CREDENTIAL: CredentialDraft = { label: '', secret: '', enabled: true };
+
+function errorText(error: unknown): string {
+  if (error instanceof ApiError) {
+    const code = error.message.split(':')[0];
+    if (code === 'INVALID_DOCUMENT_PROCESSING_SETTING') {
+      return tr('文档处理设置无效，请检查标出的字段。', 'Document-processing settings are invalid.');
+    }
+    if (code === 'INVALID_DOCUMENT_PROCESSING_CREDENTIAL') {
+      return tr('MinerU 密钥无效。', 'The MinerU credential is invalid.');
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatTime(timestamp: number | null | undefined): string {
+  if (!timestamp) return tr('尚未测试', 'Not tested');
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp * 1000));
+}
+
+function HealthBadge({ health }: { health: LiteratureProviderHealth | null | undefined }) {
+  if (!health) return <span className="pill sm">{tr('未测试', 'Untested')}</span>;
+  return (
+    <span
+      className="pill sm"
+      title={`${health.detail} · ${formatTime(health.checked_at)}`}
+      style={health.ok
+        ? { background: 'var(--ok-bg)', color: 'var(--ok-tx)' }
+        : { background: 'var(--danger-bg)', color: 'var(--danger-tx)' }}
+    >
+      <span className="dot" />
+      {health.ok ? tr('可用', 'Available') : tr('失效', 'Failed')}
+    </span>
+  );
+}
+
+export function DocumentProcessingSettingsPanel() {
+  const queryClient = useQueryClient();
+  const settingsQuery = useQuery({
+    queryKey: ['admin-document-processing-settings'],
+    queryFn: () => api.getDocumentProcessingSettings(),
+    retry: false,
+  });
+  const [draft, setDraft] = useState<DocumentProcessingDraft | null>(null);
+  const [badField, setBadField] = useState<string | null>(null);
+  const [credentialModal, setCredentialModal] = useState<CredentialModalState | null>(null);
+  const [credentialDraft, setCredentialDraft] = useState<CredentialDraft>(EMPTY_CREDENTIAL);
+  const [deleteCredential, setDeleteCredential] = useState<DocumentProcessingCredentialStatus | null>(null);
+
+  useEffect(() => {
+    if (settingsQuery.data && draft === null) {
+      setDraft(documentProcessingDraftFrom(settingsQuery.data));
+    }
+  }, [draft, settingsQuery.data]);
+
+  const shown = draft ?? (settingsQuery.data ? documentProcessingDraftFrom(settingsQuery.data) : null);
+  const storedDraft = useMemo(
+    () => (settingsQuery.data ? documentProcessingDraftFrom(settingsQuery.data) : null),
+    [settingsQuery.data],
+  );
+  const dirty = !!shown && !!storedDraft && JSON.stringify(shown) !== JSON.stringify(storedDraft);
+  const credentials = settingsQuery.data?.mineru_credentials ?? [];
+  const healthyCount = credentials.filter((credential) => credential.health?.ok).length;
+  const enabledCount = credentials.filter((credential) => credential.enabled).length;
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['admin-document-processing-settings'] });
+
+  const saveMutation = useMutation({
+    mutationFn: (value: DocumentProcessingDraft) => api.setDocumentProcessingSettings(value),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(['admin-document-processing-settings'], saved);
+      setDraft(documentProcessingDraftFrom(saved));
+      setBadField(null);
+      toast(tr('文档处理设置已保存', 'Document-processing settings saved'), 'ok');
+    },
+    onError: (error) => toast(`${tr('保存失败', 'Save failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (input: DocumentProcessingCredentialCreate) => api.createDocumentProcessingCredential(input),
+    onSuccess: () => {
+      setCredentialModal(null);
+      void invalidate();
+      toast(tr('MinerU 密钥已加密保存', 'MinerU credential saved encrypted'), 'ok');
+    },
+    onError: (error) => toast(`${tr('保存失败', 'Save failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, input }: { id: string; input: DocumentProcessingCredentialUpdate }) => api.updateDocumentProcessingCredential(id, input),
+    onSuccess: () => {
+      setCredentialModal(null);
+      void invalidate();
+      toast(tr('MinerU 密钥已更新', 'MinerU credential updated'), 'ok');
+    },
+    onError: (error) => toast(`${tr('更新失败', 'Update failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: (credential: DocumentProcessingCredentialStatus) => api.updateDocumentProcessingCredential(credential.id, { enabled: !credential.enabled }),
+    onSuccess: (credential) => {
+      void invalidate();
+      toast(credential.enabled ? tr('密钥已启用', 'Credential enabled') : tr('密钥已停用', 'Credential disabled'), 'ok');
+    },
+    onError: (error) => toast(`${tr('操作失败', 'Action failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (credential: DocumentProcessingCredentialStatus) => api.testDocumentProcessingCredential(credential.id),
+    onSuccess: (result) => {
+      void invalidate();
+      toast(
+        result.ok
+          ? tr(`MinerU 连接成功，${result.latency_ms} ms`, `MinerU connected in ${result.latency_ms} ms`)
+          : tr(`MinerU 连接失败：${result.detail}`, `MinerU connection failed: ${result.detail}`),
+        result.ok ? 'ok' : 'error',
+      );
+    },
+    onError: (error) => toast(`${tr('测试失败', 'Test failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.deleteDocumentProcessingCredential(id),
+    onSuccess: () => {
+      setDeleteCredential(null);
+      void invalidate();
+      toast(tr('MinerU 密钥已删除', 'MinerU credential deleted'), 'ok');
+    },
+    onError: (error) => toast(`${tr('删除失败', 'Delete failed')}：${errorText(error)}`, 'error'),
+  });
+
+  const openCreate = () => {
+    setCredentialDraft(EMPTY_CREDENTIAL);
+    setCredentialModal({ mode: 'create' });
+  };
+
+  const openEdit = (credential: DocumentProcessingCredentialStatus) => {
+    setCredentialDraft({ label: credential.label ?? '', secret: '', enabled: credential.enabled });
+    setCredentialModal({ mode: 'edit', credential });
+  };
+
+  const saveCredential = () => {
+    if (!credentialModal) return;
+    const label = credentialDraft.label.trim() || null;
+    if (credentialModal.mode === 'create') {
+      if (!credentialDraft.secret.trim()) return;
+      createMutation.mutate({ secret: credentialDraft.secret.trim(), label, enabled: credentialDraft.enabled });
+      return;
+    }
+    const input: DocumentProcessingCredentialUpdate = { label, enabled: credentialDraft.enabled };
+    if (credentialDraft.secret.trim()) input.secret = credentialDraft.secret.trim();
+    updateMutation.mutate({ id: credentialModal.credential!.id, input });
+  };
+
+  const saveSettings = () => {
+    if (!shown) return;
+    const invalid = validateDocumentProcessingDraft(shown);
+    setBadField(invalid);
+    if (invalid) {
+      toast(tr('请先修正文档处理设置', 'Fix the document-processing settings first'), 'error');
+      return;
+    }
+    saveMutation.mutate(shown);
+  };
+
+  if (settingsQuery.isLoading) return <div className="empty">{tr('加载中…', 'Loading…')}</div>;
+  if (settingsQuery.isError || !shown) {
+    return (
+      <div className="card card-pad empty">
+        {tr('无法加载文档处理设置（后端不可用或无权限）', 'Failed to load document-processing settings')}
+        <div style={{ marginTop: 10 }}>
+          <button className="btn btn-soft sm" onClick={() => void settingsQuery.refetch()}>{tr('重试', 'Retry')}</button>
+        </div>
+      </div>
+    );
+  }
+
+  const credentialBusy = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="literature-settings-stack">
+      <div className="literature-settings-summary">
+        <div>
+          <div className="section-h">
+            <Icon name="file" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('PDF 解析运行策略', 'PDF processing policy')}
+          </div>
+          <div className="literature-settings-intro">
+            {tr('进入论文库的 PDF 按此策略解析。MinerU 密钥按启用顺序轮询，失败后按设置重试或回退 PyMuPDF。', 'Library PDFs follow this policy. Enabled MinerU credentials rotate before the configured retry and PyMuPDF fallback policy is applied.')}
+          </div>
+        </div>
+        <div className="literature-settings-stats" aria-label={tr('配置概览', 'Configuration summary')}>
+          <div><strong>{enabledCount}</strong><span>{tr('启用密钥', 'enabled keys')}</span></div>
+          <div><strong>{healthyCount}</strong><span>{tr('测试可用', 'healthy')}</span></div>
+          <div><strong>{shown.mineru_concurrency}</strong><span>{tr('并发任务', 'concurrency')}</span></div>
+        </div>
+      </div>
+
+      {badField === 'parser_policy' && (
+        <div className="field-error">{tr('MinerU 与 PyMuPDF 至少启用一个。', 'Enable at least one parser.')}</div>
+      )}
+
+      <div className="settings-main-side">
+        <section className="card card-pad">
+          <div className="section-h" style={{ marginBottom: 16 }}>
+            <Icon name="server" size={15} style={{ color: 'var(--accent)' }} />
+            MinerU
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-text">
+              <div className="field-label">{tr('启用 MinerU', 'Enable MinerU')}</div>
+              <div className="field-hint">{tr('优先生成结构化 Markdown、图片与可定位正文。', 'Prefer structured Markdown, figures, and anchorable text.')}</div>
+            </div>
+            <Switch checked={shown.mineru_enabled} onChange={(mineru_enabled) => setDraft({ ...shown, mineru_enabled })} />
+          </div>
+          <FormField
+            label={tr('API 根地址', 'API root')}
+            error={badField === 'mineru_base_url' ? tr('请输入不含凭据、查询参数或片段的 HTTP(S) 地址', 'Enter an HTTP(S) root without credentials, query, or fragment') : null}
+          >
+            <input className="input mono" value={shown.mineru_base_url} onChange={(event) => setDraft({ ...shown, mineru_base_url: event.target.value })} />
+          </FormField>
+          <div className="settings-fields literature-settings-fields-compact" style={{ marginTop: 14 }}>
+            <NumberField label={tr('解析超时（秒）', 'Parse timeout (s)')} value={shown.mineru_timeout_seconds} min={31} max={86400} error={badField === 'mineru_timeout_seconds'} onChange={(mineru_timeout_seconds) => setDraft({ ...shown, mineru_timeout_seconds })} />
+            <NumberField label={tr('轮询间隔（秒）', 'Poll interval (s)')} value={shown.mineru_poll_interval_seconds} min={1} max={300} error={badField === 'mineru_poll_interval_seconds'} onChange={(mineru_poll_interval_seconds) => setDraft({ ...shown, mineru_poll_interval_seconds })} />
+            <NumberField label={tr('失败重试次数', 'Retry count')} value={shown.mineru_retries} min={0} max={5} error={badField === 'mineru_retries'} integer onChange={(mineru_retries) => setDraft({ ...shown, mineru_retries })} />
+            <NumberField label={tr('并发解析数', 'Parse concurrency')} value={shown.mineru_concurrency} min={1} max={16} error={badField === 'mineru_concurrency'} integer onChange={(mineru_concurrency) => setDraft({ ...shown, mineru_concurrency })} />
+          </div>
+        </section>
+
+        <section className="card card-pad">
+          <div className="section-h" style={{ marginBottom: 16 }}>
+            <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('回退与处理边界', 'Fallback and boundaries')}
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-text">
+              <div className="field-label">{tr('启用 PyMuPDF 回退', 'Enable PyMuPDF fallback')}</div>
+              <div className="field-hint">{tr('MinerU 明确失败且重试耗尽后，仍提取纯文本供检索与引用。', 'Extract plain text for retrieval and citation after MinerU explicitly fails and exhausts retries.')}</div>
+            </div>
+            <Switch checked={shown.pymupdf_fallback_enabled} onChange={(pymupdf_fallback_enabled) => setDraft({ ...shown, pymupdf_fallback_enabled })} />
+          </div>
+          <div className="literature-settings-intro" style={{ marginTop: 18 }}>
+            {tr('检索候选池中的 PDF 不在这里处理；只有已进入论文库的 PDF 才会创建解析与向量任务。', 'PDFs in the discovery candidate pool are not processed here. Parsing and embedding begin only after a PDF enters a library.')}
+          </div>
+        </section>
+      </div>
+
+      <section className="card card-pad">
+        <div className="literature-credential-group-head">
+          <div>
+            <div className="section-h">
+              <Icon name="shield" size={15} style={{ color: 'var(--accent)' }} />
+              {tr('MinerU 密钥池', 'MinerU credential pool')}
+            </div>
+            <p>{tr('密钥加密保存且不回传明文。测试操作使用对应密钥访问当前 API 根地址。', 'Secrets are encrypted and never returned. Tests use the selected credential against the current API root.')}</p>
+          </div>
+          <button className="btn btn-primary sm" onClick={openCreate}>
+            <Icon name="plus" size={12} />
+            {tr('添加密钥', 'Add key')}
+          </button>
+        </div>
+        {credentials.length === 0 ? (
+          <div className="literature-credential-empty">{tr('尚未配置 MinerU 密钥。', 'No MinerU credential configured.')}</div>
+        ) : (
+          <div className="literature-credential-list">
+            {credentials.map((credential) => {
+              const testing = testMutation.isPending && testMutation.variables?.id === credential.id;
+              const toggling = toggleMutation.isPending && toggleMutation.variables?.id === credential.id;
+              return (
+                <div className="literature-credential-row" key={credential.id}>
+                  <div className="literature-credential-identity">
+                    <div className="row gap8 wrap">
+                      <strong>{credential.label || tr('未命名密钥', 'Unnamed credential')}</strong>
+                      <code>{credential.preview}</code>
+                      <HealthBadge health={credential.health} />
+                      {!credential.enabled && <span className="pill sm">{tr('已停用', 'Disabled')}</span>}
+                    </div>
+                    <span>{credential.health ? `${credential.health.detail} · ${formatTime(credential.health.checked_at)}` : tr('保存后尚未测试', 'Not tested since it was saved')}</span>
+                  </div>
+                  <div className="row gap6 literature-credential-actions">
+                    <Switch checked={credential.enabled} disabled={toggling} onChange={() => toggleMutation.mutate(credential)} />
+                    <button className="btn btn-soft sm" disabled={testing} onClick={() => testMutation.mutate(credential)}>
+                      <Icon name={testing ? 'refresh' : 'play'} size={12} style={testing ? { animation: 'spin 1s linear infinite' } : undefined} />
+                      {testing ? tr('测试中…', 'Testing…') : tr('测试', 'Test')}
+                    </button>
+                    <button className="icon-btn" title={tr('编辑密钥', 'Edit credential')} onClick={() => openEdit(credential)}><Icon name="pen" size={13} /></button>
+                    <button className="icon-btn" title={tr('删除密钥', 'Delete credential')} onClick={() => setDeleteCredential(credential)}><Icon name="trash" size={13} /></button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <div className="literature-settings-savebar">
+        <div>
+          <strong>{dirty ? tr('有未保存的文档处理设置', 'Unsaved document-processing settings') : tr('文档处理设置已同步', 'Document-processing settings are in sync')}</strong>
+          <span>{tr('密钥操作会单独即时保存。', 'Credential changes save immediately.')}</span>
+        </div>
+        <button className="btn btn-primary" disabled={!dirty || saveMutation.isPending} onClick={saveSettings}>
+          {saveMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存处理设置', 'Save processing settings')}
+        </button>
+      </div>
+
+      <Modal
+        open={credentialModal !== null}
+        onClose={() => !credentialBusy && setCredentialModal(null)}
+        title={credentialModal?.mode === 'edit' ? tr('编辑 MinerU 密钥', 'Edit MinerU credential') : tr('新增 MinerU 密钥', 'Add MinerU credential')}
+        sub={tr('密钥只写不读', 'Secrets are write-only')}
+        width={500}
+        footer={<>
+          <button className="btn btn-ghost" disabled={credentialBusy} onClick={() => setCredentialModal(null)}>{tr('取消', 'Cancel')}</button>
+          <button className="btn btn-primary" disabled={credentialBusy || (credentialModal?.mode === 'create' && !credentialDraft.secret.trim())} onClick={saveCredential}>{credentialBusy ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}</button>
+        </>}
+      >
+        <FormField label={tr('密钥标签', 'Credential label')} hint={tr('用于区分同一池中的多个密钥。', 'Distinguishes credentials in the same pool.')}>
+          <input className="input" maxLength={120} value={credentialDraft.label} placeholder={tr('可选', 'Optional')} onChange={(event) => setCredentialDraft({ ...credentialDraft, label: event.target.value })} />
+        </FormField>
+        <FormField label={tr(credentialModal?.mode === 'edit' ? '替换密钥' : 'API Key', credentialModal?.mode === 'edit' ? 'Replacement secret' : 'API key')} hint={credentialModal?.mode === 'edit' ? tr('留空保留当前密钥。', 'Leave empty to keep the current secret.') : tr('保存后只显示末四位。', 'Only the last four characters remain visible after saving.')}>
+          <input className="input mono" type="password" autoComplete="new-password" value={credentialDraft.secret} placeholder={credentialModal?.mode === 'edit' ? tr('留空则不修改', 'Leave empty to keep') : '••••••••'} onChange={(event) => setCredentialDraft({ ...credentialDraft, secret: event.target.value })} />
+        </FormField>
+        <div className="settings-row">
+          <div className="settings-row-text">
+            <div className="field-label">{tr('启用此密钥', 'Enable this credential')}</div>
+            <div className="field-hint">{tr('停用后保留配置，但不进入轮询池。', 'Disabled credentials remain stored but leave the rotation pool.')}</div>
+          </div>
+          <Switch checked={credentialDraft.enabled} onChange={(enabled) => setCredentialDraft({ ...credentialDraft, enabled })} />
+        </div>
+      </Modal>
+
+      <ConfirmModal
+        open={deleteCredential !== null}
+        onClose={() => setDeleteCredential(null)}
+        title={tr('删除 MinerU 密钥', 'Delete MinerU credential')}
+        message={deleteCredential ? tr(`确定永久删除“${deleteCredential.label ?? deleteCredential.preview}”吗？删除后无法恢复。`, `Permanently delete “${deleteCredential.label ?? deleteCredential.preview}”? This cannot be undone.`) : ''}
+        confirmText={tr('删除', 'Delete')}
+        danger
+        busy={deleteMutation.isPending}
+        onConfirm={() => deleteCredential && deleteMutation.mutate(deleteCredential.id)}
+      />
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  error,
+  integer = false,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  error: boolean;
+  integer?: boolean;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <FormField label={label} error={error ? tr(`请输入 ${min}–${max} 范围内的数值`, `Enter a value from ${min} to ${max}`) : null}>
+      <input className="input mono" type="number" min={min} max={max} step={integer ? 1 : 'any'} value={value} onChange={(event) => onChange(Number(event.target.value))} />
+    </FormField>
+  );
+}

--- a/src/frontend/src/features/settings/__tests__/documentProcessingSettings.test.ts
+++ b/src/frontend/src/features/settings/__tests__/documentProcessingSettings.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { DocumentProcessingSettings } from '../../../lib/api';
+import {
+  documentProcessingDraftFrom,
+  validateDocumentProcessingDraft,
+} from '../documentProcessingSettingsModel';
+
+const SETTINGS: DocumentProcessingSettings = {
+  mineru_enabled: true,
+  mineru_base_url: 'https://mineru.net/api/v4',
+  mineru_timeout_seconds: 3600,
+  mineru_poll_interval_seconds: 10,
+  mineru_retries: 2,
+  mineru_concurrency: 2,
+  pymupdf_fallback_enabled: true,
+  mineru_credentials: [
+    {
+      id: 'c1',
+      provider: 'mineru',
+      index: 0,
+      configured: true,
+      preview: '••••1234',
+      enabled: true,
+      label: null,
+      health: null,
+      created_at: null,
+      updated_at: null,
+    },
+  ],
+};
+
+describe('document-processing administrator settings', () => {
+  it('omits write-only credentials from the settings update', () => {
+    // fixture 里必须真的带着凭据，否则 not.toHaveProperty 是空转的：
+    // 用一份本来就没有该字段的输入去断言它不存在，删掉排除逻辑也不会红。
+    const draft = documentProcessingDraftFrom(SETTINGS);
+    expect(draft).not.toHaveProperty('mineru_credentials');
+    expect(JSON.stringify(draft)).not.toContain('••••1234');
+  });
+
+  it('accepts the production MinerU policy', () => {
+    expect(validateDocumentProcessingDraft(documentProcessingDraftFrom(SETTINGS))).toBeNull();
+  });
+
+  it('requires one parser and validates worker bounds', () => {
+    expect(validateDocumentProcessingDraft({
+      ...documentProcessingDraftFrom(SETTINGS),
+      mineru_enabled: false,
+      pymupdf_fallback_enabled: false,
+    })).toBe('parser_policy');
+    expect(validateDocumentProcessingDraft({
+      ...documentProcessingDraftFrom(SETTINGS),
+      mineru_concurrency: 17,
+    })).toBe('mineru_concurrency');
+  });
+
+  it('rejects API roots containing credentials or query parameters', () => {
+    expect(validateDocumentProcessingDraft({
+      ...documentProcessingDraftFrom(SETTINGS),
+      mineru_base_url: 'https://token@mineru.net/api?key=secret',
+    })).toBe('mineru_base_url');
+  });
+});

--- a/src/frontend/src/features/settings/documentProcessingSettingsModel.ts
+++ b/src/frontend/src/features/settings/documentProcessingSettingsModel.ts
@@ -1,0 +1,32 @@
+import type {
+  DocumentProcessingSettings,
+  DocumentProcessingSettingsUpdate,
+} from '../../lib/api';
+
+export type DocumentProcessingDraft = DocumentProcessingSettingsUpdate;
+
+export function documentProcessingDraftFrom(
+  settings: DocumentProcessingSettings,
+): DocumentProcessingDraft {
+  const { mineru_credentials: _credentials, ...draft } = settings;
+  return draft;
+}
+
+export function validateDocumentProcessingDraft(
+  draft: DocumentProcessingDraft,
+): string | null {
+  if (!draft.mineru_enabled && !draft.pymupdf_fallback_enabled) return 'parser_policy';
+  try {
+    const url = new URL(draft.mineru_base_url);
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+      return 'mineru_base_url';
+    }
+  } catch {
+    return 'mineru_base_url';
+  }
+  if (!Number.isFinite(draft.mineru_timeout_seconds) || draft.mineru_timeout_seconds <= 30 || draft.mineru_timeout_seconds > 86_400) return 'mineru_timeout_seconds';
+  if (!Number.isFinite(draft.mineru_poll_interval_seconds) || draft.mineru_poll_interval_seconds < 1 || draft.mineru_poll_interval_seconds > 300) return 'mineru_poll_interval_seconds';
+  if (!Number.isInteger(draft.mineru_retries) || draft.mineru_retries < 0 || draft.mineru_retries > 5) return 'mineru_retries';
+  if (!Number.isInteger(draft.mineru_concurrency) || draft.mineru_concurrency < 1 || draft.mineru_concurrency > 16) return 'mineru_concurrency';
+  return null;
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -861,6 +861,55 @@ export interface LiteratureProviderTestResult {
   detail: string;
 }
 
+export interface DocumentProcessingCredentialStatus {
+  id: string;
+  provider: 'mineru';
+  index: number | null;
+  configured: boolean;
+  preview: string;
+  enabled: boolean;
+  label: string | null;
+  health: LiteratureProviderHealth | null;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+export interface DocumentProcessingSettings {
+  mineru_enabled: boolean;
+  mineru_base_url: string;
+  mineru_timeout_seconds: number;
+  mineru_poll_interval_seconds: number;
+  mineru_retries: number;
+  mineru_concurrency: number;
+  pymupdf_fallback_enabled: boolean;
+  mineru_credentials: DocumentProcessingCredentialStatus[];
+}
+
+export type DocumentProcessingSettingsUpdate = Omit<
+  DocumentProcessingSettings,
+  'mineru_credentials'
+>;
+
+export interface DocumentProcessingCredentialCreate {
+  secret: string;
+  label?: string | null;
+  enabled?: boolean;
+}
+
+export interface DocumentProcessingCredentialUpdate {
+  secret?: string;
+  label?: string | null;
+  enabled?: boolean;
+}
+
+export interface DocumentProcessingProviderTestResult {
+  provider: 'mineru';
+  ok: boolean;
+  latency_ms: number;
+  status_code: number | null;
+  detail: string;
+}
+
 /** 补建历史向量的结果计数。 */
 export interface DailyEmbedBackfillResult {
   embedded: number;
@@ -5238,6 +5287,51 @@ export const api = {
       `/admin/settings/literature-search/credentials/${id}/test`,
       'POST',
       { query },
+    );
+  },
+  getDocumentProcessingSettings(): Promise<DocumentProcessingSettings> {
+    return request<DocumentProcessingSettings>('/admin/settings/document-processing');
+  },
+  setDocumentProcessingSettings(
+    input: DocumentProcessingSettingsUpdate,
+  ): Promise<DocumentProcessingSettings> {
+    return requestJson<DocumentProcessingSettings>(
+      '/admin/settings/document-processing',
+      'PUT',
+      input,
+    );
+  },
+  createDocumentProcessingCredential(
+    input: DocumentProcessingCredentialCreate,
+  ): Promise<DocumentProcessingCredentialStatus> {
+    return requestJson<DocumentProcessingCredentialStatus>(
+      '/admin/settings/document-processing/credentials',
+      'POST',
+      input,
+    );
+  },
+  updateDocumentProcessingCredential(
+    id: string,
+    input: DocumentProcessingCredentialUpdate,
+  ): Promise<DocumentProcessingCredentialStatus> {
+    return requestJson<DocumentProcessingCredentialStatus>(
+      `/admin/settings/document-processing/credentials/${id}`,
+      'PATCH',
+      input,
+    );
+  },
+  deleteDocumentProcessingCredential(id: string): Promise<void> {
+    return request<void>(`/admin/settings/document-processing/credentials/${id}`, {
+      method: 'DELETE',
+    });
+  },
+  testDocumentProcessingCredential(
+    id: string,
+  ): Promise<DocumentProcessingProviderTestResult> {
+    return requestJson<DocumentProcessingProviderTestResult>(
+      `/admin/settings/document-processing/credentials/${id}/test`,
+      'POST',
+      {},
     );
   },
   /** 实验室概况页的用量排行榜是否对普通成员可见（admin，默认开）。 */


### PR DESCRIPTION
#557 merged with one test strengthened. Authorship preserved as @yyy-OPS. Frontend only, no migration, clean merge.

## The credential test is real this time

`documentProcessingDraftFrom` strips `mineru_credentials` before the update payload, and the fixture actually carries that field — so unlike the equivalent in #535, this assertion is not vacuous. Removing the destructure reds it. Good.

Two small strengthenings: the fixture's credential list was `[]`, so I filled it with a masked preview (the shape a real `GET` returns), and added an assertion that `••••1234` never appears in the serialised draft. Absence-of-key and absence-of-value are different failures and both are worth pinning where secrets are involved.

## One shape note, not changed

The stripping is a destructure-exclusion — a denylist of one:

```ts
const { mineru_credentials: _credentials, ...draft } = settings;
```

`buildLiteratureSettingsUpdate` in the sibling settings page uses an explicit allowlist instead, which fails closed when the backend response grows a field. If a masked health or preview field is ever added to `DocumentProcessingSettings`, this one flows it straight back into the update. Not a defect today — just the difference between the two settings pages, and the allowlist is the shape that stays correct without anyone remembering.

## Also worth noting

The client-side validation mirrors the backend's `_base_url` rule exactly — rejecting a MinerU root that carries credentials, a query string or a fragment — so a key cannot be smuggled in through what looks like an endpoint field, and the user learns that before the round trip rather than after.

## Verification

- `tsc --noEmit` clean; `vitest run` → 128 passed

Closes #556. Supersedes #557.