### PR TITLE
feat(literature): expose Unpaywall resolver health

### DIFF
--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -242,6 +242,27 @@ async def test_literature_provider(
     source = payload.source.strip().lower()
     started = time.perf_counter()
     try:
+        if source == "unpaywall":
+            from app.services.literature.multi_source import MultiSourceClient
+
+            resolver = MultiSourceClient()
+            try:
+                matched = await resolver.lookup_unpaywall(payload.query)
+            finally:
+                await resolver.aclose()
+            if matched is None:
+                raise ValueError("resolver returned no record; check the contact email and DOI")
+            result = LiteratureProviderTestResult(
+                source=source,
+                ok=True,
+                latency_ms=round((time.perf_counter() - started) * 1000),
+                fetched_count=1,
+                detail="OA resolver responded",
+            )
+            await literature_settings_service.record_provider_health(
+                session, source=source, ok=result.ok, detail=result.detail
+            )
+            return result
         if source == "easyscholar":
             from app.services.literature.venue_metrics import probe_venue_metric_provider
 

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -218,6 +218,36 @@ async def test_easyscholar_credential_uses_metric_probe(client, monkeypatch):
     }
 
 
+async def test_unpaywall_health_probe_uses_doi_resolver_without_adding_search_source(
+    client, monkeypatch
+):
+    admin, _ = await _admin_and_member(client)
+    observed = {}
+
+    class Resolver:
+        async def lookup_unpaywall(self, doi):
+            observed["doi"] = doi
+            return {"doi": doi, "best_oa_location": {"url_for_pdf": "https://example.test/a.pdf"}}
+
+        async def aclose(self):
+            observed["closed"] = True
+
+    monkeypatch.setattr("app.services.literature.multi_source.MultiSourceClient", Resolver)
+    response = await client.post(
+        "/api/admin/settings/literature-search/test",
+        json={"source": "unpaywall", "query": "10.1000/test-doi"},
+        headers=admin,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert response.json()["fetched_count"] == 1
+    assert observed == {"doi": "10.1000/test-doi", "closed": True}
+    settings = await client.get("/api/admin/settings/literature-search", headers=admin)
+    assert "unpaywall" not in settings.json()["sources"]
+    assert settings.json()["provider_health"]["unpaywall"]["ok"] is True
+
+
 async def test_single_credential_probe_updates_only_that_entry(client, monkeypatch):
     admin, _ = await _admin_and_member(client)
     response = await client.post(

--- a/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
+++ b/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
@@ -17,6 +17,7 @@ import {
 import { tr } from '../../lib/i18n';
 import {
   CREDENTIAL_SOURCES,
+  RESOLVER_SOURCES,
   SCORE_DIMENSIONS,
   SEARCH_SOURCES,
   buildLiteratureSettingsUpdate,
@@ -380,6 +381,35 @@ export function LiteratureSearchSettingsPanel() {
                 <button className="btn btn-soft sm" disabled={providerTestMutation.isPending} onClick={() => providerTestMutation.mutate(source.id)}>
                   <Icon name={testing ? 'refresh' : 'play'} size={12} style={testing ? { animation: 'spin 1s linear infinite' } : undefined} />
                   {testing ? tr('测试中…', 'Testing…') : tr('测试来源', 'Test source')}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <div className="section-h" style={{ margin: '20px 0 6px' }}>
+          <Icon name="link" size={14} style={{ color: 'var(--accent)' }} />
+          {tr('开放获取解析器', 'Open-access resolvers')}
+        </div>
+        <div className="literature-settings-intro" style={{ marginBottom: 12 }}>
+          {tr('解析器不生成候选论文，也不占检索配额；它们按 DOI 为候选结果补充可缓存的开放 PDF。', 'Resolvers do not create candidates or consume retrieval quota. They add cacheable open PDFs to existing DOI-bearing candidates.')}
+        </div>
+        <div className="literature-source-grid">
+          {RESOLVER_SOURCES.map((source) => {
+            const health = settingsQuery.data?.provider_health[source.id];
+            const testing = providerTestMutation.isPending && providerTestMutation.variables === source.id;
+            return (
+              <div key={source.id} className="literature-source-card enabled">
+                <div className="row" style={{ justifyContent: 'space-between', gap: 12 }}>
+                  <div className="row gap8">
+                    <strong>{source.zh}</strong>
+                    <span className="pill sm">{tr('OA 解析', 'OA resolver')}</span>
+                    <HealthBadge health={health} />
+                  </div>
+                </div>
+                <p>{tr(source.descriptionZh, source.descriptionEn)}</p>
+                <button className="btn btn-soft sm" disabled={providerTestMutation.isPending} onClick={() => providerTestMutation.mutate(source.id)}>
+                  <Icon name={testing ? 'refresh' : 'play'} size={12} style={testing ? { animation: 'spin 1s linear infinite' } : undefined} />
+                  {testing ? tr('测试中…', 'Testing…') : tr('测试解析器', 'Test resolver')}
                 </button>
               </div>
             );

--- a/src/frontend/src/features/settings/__tests__/literatureSettings.test.ts
+++ b/src/frontend/src/features/settings/__tests__/literatureSettings.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   LITERATURE_SOURCES,
+  RESOLVER_SOURCES,
+  SEARCH_SOURCES,
   buildLiteratureSettingsUpdate,
   type LiteratureSettingsDraft,
   validateLiteratureSettingsDraft,
@@ -27,6 +29,12 @@ describe('literature search settings model', () => {
     expect(LITERATURE_SOURCES.find((source) => source.id === 'openalex')?.credentialMode).toBe('optional');
     expect(LITERATURE_SOURCES.find((source) => source.id === 'sciverse')?.credentialMode).toBe('required');
     expect(LITERATURE_SOURCES.find((source) => source.id === 'easyscholar')?.metricOnly).toBe(true);
+  });
+
+  it('exposes Unpaywall as an OA resolver without treating it as a search source', () => {
+    expect(RESOLVER_SOURCES.map((source) => source.id)).toContain('unpaywall');
+    expect(validDraft().sources).not.toContain('unpaywall');
+    expect(LITERATURE_SOURCES.find((source) => source.id === 'unpaywall')?.testQuery).toMatch(/^10\./);
   });
 
   it('accepts the configured result count and year window', () => {
@@ -62,5 +70,20 @@ describe('literature search settings model', () => {
     expect(payload).not.toHaveProperty('provider_keys');
     expect(payload).not.toHaveProperty('provider_health');
     expect(JSON.stringify(payload)).not.toContain('••••1234');
+  });
+});
+
+describe('source role separation', () => {
+  it('keeps resolver-only and metric-only providers out of the search source list', () => {
+    // Unpaywall 按 DOI 补 OA 地址，EasyScholar 只做期刊指标。任何一个漏进
+    // SEARCH_SOURCES，都会被当成检索源发查询：占候选配额、进 source 快照，
+    // 而结果里根本不会有文献 —— 从界面上看只是"这个源没搜到东西"。
+    const searchIds = SEARCH_SOURCES.map((source) => source.id);
+    expect(searchIds).not.toContain('unpaywall');
+    expect(searchIds).not.toContain('easyscholar');
+    expect(RESOLVER_SOURCES.map((source) => source.id)).toEqual(['unpaywall']);
+    // 反过来，真正的检索源不能被误标成 resolver/metric 而消失
+    expect(searchIds).toContain('openalex');
+    expect(searchIds).toContain('arxiv');
   });
 });

--- a/src/frontend/src/features/settings/literatureSettingsModel.ts
+++ b/src/frontend/src/features/settings/literatureSettingsModel.ts
@@ -13,6 +13,7 @@ export interface SourceDefinition {
   descriptionEn: string;
   credentialMode: CredentialMode;
   metricOnly?: boolean;
+  resolverOnly?: boolean;
   testQuery: string;
 }
 
@@ -27,10 +28,14 @@ export const LITERATURE_SOURCES: SourceDefinition[] = [
   { id: 'core', zh: 'CORE', en: 'CORE', descriptionZh: '聚合开放获取仓储，需要 API Key。', descriptionEn: 'Aggregated open-access repositories; requires an API key.', credentialMode: 'required', testQuery: 'structural engineering' },
   { id: 'base', zh: 'BASE', en: 'BASE', descriptionZh: '学术搜索聚合源，无需 API Key。', descriptionEn: 'Academic search aggregator with no API key required.', credentialMode: 'none', testQuery: 'structural engineering' },
   { id: 'sciverse', zh: 'Sciverse', en: 'Sciverse', descriptionZh: '补充出版商聚合检索，需要令牌并支持轮询。', descriptionEn: 'Publisher-aggregated retrieval; requires rotating tokens.', credentialMode: 'required', testQuery: 'structural engineering' },
+  { id: 'unpaywall', zh: 'Unpaywall', en: 'Unpaywall', descriptionZh: '按 DOI 补充开放获取地址，用于候选 PDF 缓存；联系邮箱由服务器环境变量配置。', descriptionEn: 'Resolves open-access locations by DOI for candidate PDF caching; the contact email is configured on the server.', credentialMode: 'none', resolverOnly: true, testQuery: '10.1038/s41586-020-2649-2' },
   { id: 'easyscholar', zh: 'EasyScholar', en: 'EasyScholar', descriptionZh: '期刊等级与评价指标，只参与指标增强。', descriptionEn: 'Journal rankings and metrics; used only for venue enrichment.', credentialMode: 'required', metricOnly: true, testQuery: 'Nature' },
 ];
 
-export const SEARCH_SOURCES = LITERATURE_SOURCES.filter((source) => !source.metricOnly);
+export const SEARCH_SOURCES = LITERATURE_SOURCES.filter(
+  (source) => !source.metricOnly && !source.resolverOnly,
+);
+export const RESOLVER_SOURCES = LITERATURE_SOURCES.filter((source) => source.resolverOnly);
 export const CREDENTIAL_SOURCES = LITERATURE_SOURCES.filter(
   (source) => source.credentialMode !== 'none',
 );


### PR DESCRIPTION
#558 merged with one test added. Authorship preserved as @yyy-OPS. Based on current `main`, no migration, clean merge.

## The modelling is right

`resolverOnly` sits alongside the existing `metricOnly` flag rather than introducing a second mechanism, and `SEARCH_SOURCES` / `RESOLVER_SOURCES` / `CREDENTIAL_SOURCES` derive from the one list. Adding a role to an existing taxonomy beats adding a parallel one.

The backend probe is genuinely a resolver probe — `lookup_unpaywall(payload.query)` against a real DOI, with the client closed in a `finally` — and its test name says exactly what it is defending (`…_uses_doi_resolver_without_adding_search_source`).

## The frontend half of that claim had no guard

Removing `!source.resolverOnly` from the `SEARCH_SOURCES` filter left all six frontend tests green. So nothing stopped Unpaywall drifting back into the search list, where it would be queried as a bibliographic source: consuming candidate quota, entering source snapshots, and returning no papers — which from the UI reads as "this source found nothing" rather than "this source should never have been asked".

Added a test pinning the role separation in both directions: `unpaywall` and `easyscholar` stay out of `SEARCH_SOURCES`, `RESOLVER_SOURCES` is exactly `['unpaywall']`, and real search sources (`openalex`, `arxiv`) stay in — so mislabelling a search source as resolver-only fails too. Dropping the filter clause reds it.

## Verification

- backend `tests/test_admin_literature_settings.py test_literature_oa_cache.py test_literature_discovery_runtime.py` → 32 passed; ruff clean
- frontend `tsc --noEmit` clean; `vitest run` → 130 passed

Closes #555. Supersedes #558.