### PR TITLE
docs(rfcs): Polaris 2.0 autonomous discovery platform design

### DIFF
--- a/docs/rfcs/2026-09-02-autonomous-discovery-platform.md
+++ b/docs/rfcs/2026-09-02-autonomous-discovery-platform.md
@@ -1,0 +1,91 @@
+# RFC: Polaris 2.0 — A Deep Research Platform for Autonomous Scientific Discovery
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Target repository | ZJU-REAL/Polaris |
+| Tracking issue | #564 |
+| Full design report | `docs/rfcs/2026-09-02-polaris-2.0-design-report.zh.md` (Chinese, authoritative) |
+| Updated | 2026-09-02 |
+
+## Summary
+
+Polaris is rebuilt from a lab-oriented AI research application into a **Deep
+Research platform for autonomous scientific discovery**. "Deep Research" here
+means deep scientific research, not retrieval-style report writing: given a
+research direction, the agent autonomously runs the full loop —
+survey → hypothesis → experiment → analysis → iteration — and produces
+validated findings. Any discipline can plug in its own data sources,
+simulation tools, instruments, and research processes.
+
+Design tenets: **everything is a plugin, everything composes, everything is
+hot-swappable, everything evolves.** The first two and a half tenets are the
+two composability axioms formalized by cordis (spatial: declarative dependency
+assembly; temporal: fully revertible effects); the fourth is this platform's
+addition — the agent's capability surface grows continuously through the
+ecosystem, user-defined components, and agent-authored tools, not through
+platform releases.
+
+## Architecture
+
+Three-layer kernel on a new runtime split:
+
+1. **L1 plugin kernel** (Node/TS, vendored `@deepseek-ai/cordis`, MIT):
+   plugin tree, service DI with inject gating, effect-reversible lifecycle,
+   declarative config tree with cross-process reconciliation, schema-driven
+   config UI, marketplace, MCP client hub. Runs in the Electron main process.
+2. **L2 agent runtime** (the moat): the existing Voyage engine — durable
+   plan-execute-verify state machine with checkpoint resume — promoted to a
+   generic interpreter of declarative research-process packs; a new
+   `discovery` kind operates on a first-class hypothesis/experiment tree.
+3. **L3 research state layer** (the ecosystem's glue): typed records
+   (paper/project/dataset), libraries, concepts, extractions, evidence
+   anchors, provenance. Plugins interoperate by reading/writing this state,
+   not by talking to each other.
+
+Python remains as the **science edge** — PDF parsing, extraction,
+instrument/simulation drivers, and the existing FastAPI backend mounted as a
+legacy engine — supervised child processes speaking line-delimited JSON-RPC
+(engine semantics) or MCP (tool semantics). Local-first data: SQLite (FTS5 +
+sqlite-vec) plus a file-over-app layout where PDFs, notes, and exports live in
+user-visible folders and the database holds only rebuildable indexes.
+
+Seven extension points share one manifest: data sources, record kinds,
+experiment runners, agent tools (MCP), process packs, discipline packs, and
+UI panels. The literature engine is specified in five layers
+(parse → extract → link → synthesize → apply); extraction schemas are
+discipline-pack assets (PICO, task/dataset/metric, synthesis recipes,
+reactions), and the engine precomputes structured fuel for hypothesis
+generation (unlinked concept pairs, contradiction/gap lists,
+purpose–mechanism method index, negative results) with deterministic
+literature grounding and novelty checks.
+
+Deferred by explicit decision (mechanisms kept, not productized): approval
+gates, cost budgeting, grant/patent record kinds.
+
+## Migration
+
+Strangler-style, product usable at every phase:
+
+- **P0 spike** (hard fallback gate): cordis kernel drives one full legacy
+  chain; SQLite+sqlite-vec benchmark at 100k/500k chunks; JSON-RPC seam +
+  cross-process reconciler prototype. Any failure → fall back to a
+  Python-kernel variant, cost limited to the spike.
+- **P1**: personal Electron shell + kernel + single-user profile
+  (`InlineTaskQueue` replaces Redis/ARQ; SQLite is already the default and
+  the whole test suite runs on it); 15 independent de-lab removal PRs;
+  record-replay regression harness seeded from the deterministic fake LLM
+  provider.
+- **P2/P2.5**: autonomous discovery v1 on the literature domain + literature
+  engine build-out. **P3**: autonomous experiments (Runner v2, process-pack
+  interpreter, BYO runners, OpenFOAM/ngspice → FMU → PyAnsys). **P4**:
+  contract freeze (semver) then ecosystem opening. **P5**: monetization.
+
+## Non-goals (this series)
+
+Visual workflow canvas; subscription-with-included-quota pricing; commercial
+EDA integration; multi-device sync (phase 2 of desktop); full-length survey
+generation.
+
+The Chinese design report is the authoritative specification; this RFC is its
+summary of record for the repository.

--- a/docs/rfcs/2026-09-02-polaris-2.0-design-report.zh.md
+++ b/docs/rfcs/2026-09-02-polaris-2.0-design-report.zh.md
@@ -1,0 +1,462 @@
+# Polaris 2.0 设计报告
+
+## 面向自主科学发现的 Deep Research 平台
+
+| 字段 | 值 |
+| --- | --- |
+| 状态 | 设计报告（权威规范；英文摘要版见同目录 `2026-09-02-autonomous-discovery-platform.md`；tracking issue #564） |
+| 日期 | 2026-09-02 |
+| 依据 | 19 路调研（4 路仓库摸底 + 15 路外部调研，附录 A） |
+| 取代 | 同日决策稿（内容已全部并入本报告） |
+
+---
+
+# 第一部分 愿景
+
+## 1. 定位
+
+> **面向自主科学发现的 Deep Research 平台。**
+> Deep Research 指**深度科研**（不是检索问答意义上的 deep research 功能）：给一个研究方向，agent 自主完成 调研→假设→实验→分析→迭代 的完整科研过程，产出经过验证的发现。任何学科都能通过插件把数据源、设备、仿真、流程接入，让自主科研在该学科成立。
+
+三根支柱：
+
+1. **自主发现循环是产品本体**。长时程、可断点、服务器端持续运行的发现循环（假设/实验树为一等实体）。这不是现有功能之上的「深度模式」，而是平台存在的理由。业界自主发现系统（Sakana AI Scientist v2、Google co-scientist、FutureHouse Kosmos）的共性架构需求——状态外置于上下文、检查点恢复、长任务编排——恰是现有 Voyage 引擎已具备而 DSH 类交互式 harness 没有的能力，这是 Polaris 的先发资产。
+2. **插件生态是自主 agent 的能力面**。插件的第一消费者是 agent，不是人。学科用户写一个数据源/设备驱动/流程包，agent 就能在那个学科开展研究。多学科扩张由生态完成，不由平台排期完成。
+3. **个人拥有**。每个研究者一套自己的自主科研系统；装什么能力、研究什么方向由本人决定；模型中立、数据本地。
+
+支撑基础设施（内建、不进定位）：证据溯源（每条结论可点开到代码/文献——自主产出可信的地基，也是与全行业「引用幻觉」的正面区隔）、工作台 UI（自主 run 的观察与引导面）、互通（Zotero/BibTeX/Markdown/Word-LaTeX）。
+
+**暂缓项**（本期不考虑，机制保留在引擎里不删，业界调研结论记录在案备将来启用）：Gate/人工审批断点、成本预算与用量控制、基金与专利记录类型。自主循环默认直行到底。
+
+## 2. 设计纲领
+
+> **一切皆插件，一切皆可组装，一切皆可插拔，一切皆可进化。**
+
+前两句半正是 cordis 论文（arXiv:2608.25512，被 DeepSeek Harness 采用为插件内核）形式化的两条公理——空间可组合性（依赖声明式组装）与时间可组合性（副作用可完全回退）；第四句是本平台在其上加的第三层。
+
+1. **一切皆插件**：平台自身功能（文献引擎、实验、写作、评审、流程、UI 面板）与第三方组件同权、同一套契约。内核对任何学科和功能一无所知；agent loop 本身也是插件（DSH「无特权内核」原则）。组件的一切用声明式数据描述，内核只做解释与调和。
+2. **一切皆可组装**：组件靠服务声明（provide / inject）互相组装，靠科研状态层互操作。学科包 = 组件的组装配方；流程包把 action 组装成发现循环；用户的整个平台 = 一棵可导出、可分享、可复现的组件配置树。
+3. **一切皆可插拔**：每个组件的全部副作用记账可逆（effect 回收），装/卸/换/升级运行时完成、不重启、不残留；服务下线自动停用消费者、上线自动恢复；单组件失败被隔离不拖垮平台；模型、数据源、runner、流程随时替换。
+4. **一切皆可进化**：Agent 的能力和功能持续增长，不随平台发版。三条进化路径：**生态进化**（插件市场）、**用户进化**（自定义组件：从零写 / 从模板改 / 让 agent 对话式帮写）、**自我进化**（agent 为当前研究即席生成工具、修复失效适配器并沉淀为组件——「可修复工具」构想在此落位，以沙箱 + 样例调用抽测 + 录制回放回归为安全网）。契约 semver 冻结保长期稳定；吸收外部标准（MCP/FMI/SiLA2）而非自造；未预见的组件类型经新 `kind` 扩展而不破坏既有生态。
+
+## 3. 市场依据（要点）
+
+- **空位实证**：「全流程」玩家在封闭化（SciSpace、Claude Science——后者缺开放市场、生科倾斜、绑定 Claude 订阅），「agent」玩家在 B2B 药企化（FutureHouse→Edison、Sakana→Marlin），「生态」玩家没有科研全流程（Obsidian、Zotero）。三者交集无人占据。MCP 正在成为科研插件总线（Elicit 已自我 MCP 化），拼装成本历史最低。窗口有时限：Claude Science 离补上开放市场只有一个决策的距离。
+- **需求实证**：84% 研究者已用 AI，但 80% 停在通用聊天工具，专用工具渗透仅 25%——缺口是「聊天工具做不了的活」：自主的、长时程的、跨工具的研究执行。
+- **付费带**：$15–20/月入门 + $50–100 重度档（credit 计量 agent 长任务）是安全定价区间；单点工具会被模型能力商品化压死（Scholarcy 教训），必须占住工作流与数据。
+- **扩散路径**：bottom-up——学生免费上手 → 组会共享拉新 → 导师/机构付费（Overleaf 剑桥 3 年 280% 增长模式）。放弃实验室市场不是放弃实验室用户，是把 top-down 采购换成 bottom-up 渗透。
+- **旗舰体验**：一次完整的自主发现 run——给一个研究方向，平台自主调研、生成并互搏筛选假设、产出有据的研究方案（纯文献域即可跑）；实验能力接入后同一循环延伸到自主实验。首发人群：博士生的开题/综述周（导入 Zotero 库 → 自主调研 run → 开题方案）。
+
+## 4. 与现有系统的关系
+
+这是一次**重建**（re-founding），不是重构：技术栈换内核（Node/cordis）、产品换定位（个人自主科研）、治理换形态（去实验室化 36 项）。但重建以**绞杀者方式**进行——现有 7 万行 Python 后端整体作为「遗留领域引擎」挂在新内核后先跑，按域迁移，每阶段产品可用。现有三块高价值资产直接升格：
+
+| 现有资产 | 在 2.0 中的位置 |
+| --- | --- |
+| Voyage 引擎（持久化 P-E-V 状态机、断点恢复、checkpoint） | L2 Agent 运行时的核心，升格为流程包通用解释器 |
+| 技能系统（Skill/SkillVersion/市场原型、SKILL.md 渐进披露） | 插件市场与「流程知识组件」的原型 |
+| 文献多源层（RFC #448 系列：AdapterRegistry、11 源、OA 缓存、证据锚点） | 文献引擎 ①③ 层与 E1 扩展点的基础 |
+
+---
+
+# 第二部分 总体架构
+
+## 5. 架构总览
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ 工作台 UI（React，现有前端演进）+ Electron 壳                 │
+│  自主 run 观察台 / 文献库 / 假设树 / 实验 / 写作 / 组件管理    │
+├────────────────────────────────────────────────────────────┤
+│ L3 科研状态层 —— 生态的粘合剂                                 │
+│  records(paper/project/dataset) · library · concept ·       │
+│  hypothesis-tree · experiment · artifact · evidence-anchor · │
+│  provenance                                                  │
+├────────────────────────────────────────────────────────────┤
+│ L2 Agent 运行时 —— 护城河                                    │
+│  Voyage：持久化 plan-execute-verify 状态机 + checkpoint       │
+│  流程包解释器（双投影）· 交互式 Buddy loop · 发现循环 kind      │
+├────────────────────────────────────────────────────────────┤
+│ L1 插件内核 —— vendor @deepseek-ai/cordis                    │
+│  Context/Fiber/Service · inject 门控 · effect 可逆回收 ·      │
+│  配置树 loader+调和 · schema→表单 · 市场 · MCP 客户端枢纽      │
+├────────────────────────────────────────────────────────────┤
+│ 数据：SQLite (FTS5 + sqlite-vec int8) ｜ 用户文件夹           │
+│  （file over app：PDF/笔记/导出物是用户的文件，DB 只存可重建索引）│
+└────────────────────────────────────────────────────────────┘
+      ↕ stdio JSON-RPC / MCP                  ↕ 出站长连接
+  Python 科学边缘（进程插件）              BYO Runner 服务器
+  PDF 解析·抽取·仪器/仿真驱动·遗留引擎     （长任务 run 派发执行）
+```
+
+三层的判断依据：
+
+- **L1 不自研**。cordis 经 Koishi 四年（4603 插件生态）+ DSH 45 万行验证；DSH 的 vendored fork（MIT）带 19 条生产加固（事务化 Loader、fiber 生命周期加固、HMR 精确监视等），直接借用并冻结内部 fork，不追上游。
+- **L2 是对 DSH 的差异化答案**。DSH 是交互式 turn-based，没有「跑三天、断电恢复」的持久化编排；Voyage 有。自主发现系统的共性架构（状态外置、树持久化、检查点）与它逐条对齐。
+- **L3 学 Backstage 教训**。插件生态能组合，不是因为插件机制好，而是所有插件围绕同一实体模型协作（其 software catalog）。科研状态 schema 的质量决定生态上限：文献源插件写入 records，实验插件产出 artifacts，写作插件消费 evidence——插件之间不直接对话，都通过读写状态层互操作。
+
+## 6. 技术路线选型（结论与理由）
+
+**Node/cordis 内核 + Python 科学边缘 + SQLite 本地数据。** 三个备选的裁决：
+
+| 路线 | 结论 | 理由 |
+| --- | --- | --- |
+| A. Python 内核复刻 cordis-lite | 备胎（P0 失败时回退） | 领域逻辑不动，但个人化/桌面化的本地部署无解（Python+Postgres+pgvector+Redis+ARQ 无法在用户笔记本零配置跑）；插件生态无 npm 红利；复刻永远是子集 |
+| **B. Node 内核 + Python 边缘（选定）** | **推荐** | 桌面/local-first 就地消解（Electron 主进程同运行时）；真 cordis 而非克隆；npm 分发红利；DSH 已验证内核；Python 站到 DSH 中「沙箱子进程/MCP 服务」的位置——科学生态（PyMuPDF、PyVISA、PyAnsys、FMPy、Bluesky）本来就长在进程边缘 |
+| C. 全量 Node 重写 | 否决 | 仪器/仿真的 Python 客户端库无 TS 对等物，最终仍要起 Python 子进程，却白背「解析/科学计算硬迁」的成本 |
+
+DSH 的实证边界：它纯 TS 自足是因为 coding agent 的领域能力天然语言无关（执行命令+读写文件+调 LLM）；Polaris 领域重心在 Python，因此 Python 进程作为一等边缘存在，但**编排、配置、市场、UI、agent loop 全部归 Node**。Node↔Python 缝没有先例可抄，是需要自行设计的部分（§22）；缝只开在「引擎级」，统一一种协议。
+
+## 7. L1 插件内核
+
+### 7.1 组件模型
+
+组件 = npm 包（`polaris-plugin-*` / `@scope/polaris-plugin-*`）或纯数据包（流程包/学科包可零代码）。代码组件的入口是 cordis 插件形态：
+
+```ts
+export const name = 'openfoam-runner'
+export const inject = {
+  required: ['runners', 'resources'],     // 服务依赖：齐了才加载，掉了自动停用
+  optional: ['notifications'],
+}
+export const Config = Schema.object({     // schemastery：校验 + 自动渲染配置表单
+  image: Schema.string().default('openfoam/openfoam11-paraview510'),
+  solverTimeout: Schema.number().default(3600).description('求解超时（秒）'),
+})
+export function apply(ctx: Context, config: Config) {
+  ctx.runners.register(defineRunner({ ... }))   // 注册即 effect，卸载自动回收
+  ctx.on('experiment/collect', ...)             // 监听即 effect
+}
+```
+
+manifest（package.json 的 `polaris` 字段，学 koishi 字段 + MCP annotations）：
+
+```jsonc
+{
+  "name": "polaris-plugin-openfoam-runner",
+  "version": "0.3.1",
+  "peerDependencies": { "polaris": "^1.0" },          // 平台版本兼容声明
+  "polaris": {
+    "kind": "runner",                                  // datasource|record-kind|runner|agent-tool|workflow|discipline|panel
+    "description": { "zh": "OpenFOAM CFD 求解", "en": "OpenFOAM CFD solver" },
+    "service": { "required": ["runners"], "implements": [] },
+    "runtime": "python-edge",                          // in-process | python-edge | subprocess-mcp | container
+    "permissions": { "network": ["localhost"], "filesystem": "workdir" },
+    "tools": [ /* 见 §7.5 agent 工具声明 */ ],
+    "locales": ["zh", "en"]
+  }
+}
+```
+
+### 7.2 服务与组装（空间可组合性）
+
+- `ctx.provide(name)` 声明服务槽位，实现方赋值即上线（本身是 effect，undo 即下线）。
+- 消费方以 `inject.required` 声明依赖，内核以 epoch 机制门控：所需服务齐备才加载；任一服务下线或换提供方，组件自动 UNLOADING→重新 LOADING（激活期内锁定提供方实例）。这正是「数据源/runner/LLM provider 可插拔」的启停语义，Koishi 实测 1046 个插件靠它组织（database 510、http 161 个消费者）。
+- 平台核心服务（皆为插件提供）：`records`（状态层读写）、`library`、`llm`（路由）、`tools`（工具注册表）、`runners`、`resources`、`processes`（流程包注册表）、`voyage`（run 发起/查询）、`market`、`pyedge`（Python 边缘进程管理）。
+
+### 7.3 生命周期与插拔（时间可组合性）
+
+- 每个组件实例对应一个 Fiber（状态机 PENDING→LOADING→ACTIVE→UNLOADING→DISPOSED，出错 FAILED 被隔离）。
+- 一切注册（事件、工具、路由、服务、定时器）内部走 `ctx.fiber.effect(execute → disposer)`，disposer LIFO 逆序执行——卸载即完整回滚，不重启进程、不残留状态。
+- 子组件的创建本身是父组件的 effect：插件树天然形成回收树，父卸载级联子卸载。
+- 配置热更新：`fiber.update(config)` → schema 校验 → 组件可拦截做软更新，默认完整卸载重载。
+- **跨进程调和**：组件配置树存 SQLite（不是 yml 文件），Electron 主进程与每个 Python 边缘/runner 进程各自运行一个调和器，对照同一棵树 diff 出本进程职责内的装/卸/更新（K8s 风格）。这是 Polaris 相对 Koishi 的新问题（Koishi 单进程），也是 Node↔Python 缝的核心机制。
+
+### 7.4 配置树与市场
+
+- **安装与启用分离**（Koishi 惯例）：市场装包只落盘；启用是配置树上的一个条目（可分组、组级启停、组级服务隔离）。
+- **配置树 = 唯一事实源 + 双向活文档**：UI 改配置写树，树变更驱动调和器；整棵树可导出/导入——「一个用户的完整平台组装」可复现、可分享（如「材料学研究套装.polaris-profile」）。
+- **市场**：npm 管分发与版本（白嫖托管/semver/CDN），平台自建索引（DB 存储 + 可换源 endpoint——吸取 Koishi 官方市场绑死 npm search API 停摆数月的教训）。治理学 Obsidian + Koishi 合体：自动化安全/质量扫描 + 徽章（official/verified/preview/insecure）+ 评分沉底；`npm deprecate` 即下架；开放期前只上官方源。
+- **质量分级**（机器可检，学 Home Assistant）：bronze＝manifest 合法+配置 schema+测试存在；silver＝增量同步/幂等（数据源）或干跑支持（runner）；gold＝文档+双语；platinum＝生产在用。
+
+### 7.5 插件 → Agent 工具链路
+
+插件是 agent 的能力面，这条链路是全平台最重要的管道：
+
+1. **声明**：manifest `tools[]` 声明——命名空间名（`openfoam.run_case`）、description、when-to-use、JSON Schema、副作用等级（readonly/additive/destructive/physical，仅作数据记录，按等级路由审批列入暂缓项）、幂等性、错误语义。描述是未消毒的攻击面（MCPTox 基准：工具描述投毒平均成功率 36.5%，**越强的模型越顺从恶意元数据**），故上架时 lint 描述（禁指令性文字、隐藏 unicode），副作用等级不信自报。
+2. **注册**：绑定组件生命周期（卸载即注销）；调用参数冻结为不可变 JSON + opaque token（调用身份不可中途篡改）；内置工具与插件工具走同一管道（DSH 一致性原则）。
+3. **披露**：工具可见集按 run 上下文过滤——学科包/流程包当前阶段声明可用工具集，**只交集收窄、永不放宽**，子 agent 再收窄；默认只注入 name + when-to-use 摘要，agent 按需检索完整 schema（ToolSearch 渐进披露模式，防上下文膨胀）。
+4. **执行**：pre-execute 策略瀑布 + 单调守卫（一旦 deny 后续逻辑不可翻案）→ 执行（超时/重试/指标包裹）→ post-execute 规范化 → 结果观察。工具输出一律标记为不可信数据，不与指令混排（防 injection via tool output）。
+5. **隔离阶梯**：官方/审核过的 TS 组件进程内；三方 agent 工具 MCP 子进程（stdio）或远程（Streamable HTTP）；Python 边缘独立进程；实验代码容器/远端。审批与信任绑定**内容哈希**而非包名（防 CVE-2025-54136 MCPoison 式改包不触发重审）。
+6. **质量闸门**（业界空白，差异化机会）：上架前沙箱样例调用抽测（合成任务的调用成功率/参数正确率）；低分工具降级为「需人工确认」而非直接暴露给自主循环。
+
+### 7.6 外部生态吸收：MCP
+
+平台既是 MCP server（现有 `app/mcp/`，对外暴露自身工具，供 Claude Code/DSH 等外部 harness 使用——deepseek-harness 适配器已验证此路），也是 **MCP client 枢纽**：用户注册任意外部 MCP server（stdio 命令或 URL）即成为 agent 工具插件，纳入同一注册表、同一披露与执行管道。这意味着 Elicit、各类数据库、学科工具的既有 MCP 生态可以被直接「装进」平台，而不必逐一开发适配。
+
+## 8. L2 Agent 运行时
+
+### 8.1 双 loop
+
+- **Voyage loop**（持久化）：自主发现 run、文献编译、自动实验、写作。DB 行是真源（VoyageRun/VoyageStep），上下文只是缓存；断点恢复从事件历史确定性重建。现有引擎语义不变，卸掉的是硬编码的 plan 函数（§8.3）。
+- **Buddy loop**(交互式)：对话助手，HTTP 流式，工具即时调用。两者共享工具注册表与状态层，不共享执行器（现有设计已如此，保留）。
+
+### 8.2 发现循环（产品本体）
+
+新 voyage kind `discovery`，围绕**假设/实验树**一等实体：
+
+```
+hypothesis_nodes
+  id · run_id · parent_id · kind(hypothesis|experiment|analysis)
+  statement            -- 假设陈述
+  grounding            -- 子命题→文献id 绑定表（支持/反驳/推测三态）
+  novelty_report       -- 查新结果（逐子命题）
+  feasibility          -- 资源匹配结果
+  score · status(open|expanded|pruned|validated|refuted)
+  artifacts            -- 关联实验/分析产物
+```
+
+- Navigator 在树上做分支/剪枝决策（Sakana v2 的 agentic 树搜索 + AutoRA 不可变 State 的合体），而非线性 plan；恢复即从最优未扩展节点继续。
+- **最小锦标赛**作为可选深度模式：假设成对比较排序 + critic agent（Stanford Virtual Lab 模式），不抄完整 Elo；算力投入=质量旋钮（Google co-scientist 的 test-time scaling 结论：Elo 随算力持续上升未饱和）。
+- 预算按节点/rollout 配额计（业界共识，非墙钟），本期不设硬预算（暂缓项），仅记账。
+- **防失败模式**（Sakana 57% 论文含幻觉数值、A-Lab 被 Nature 更正的教训）：结论强制溯源到代码 cell/文献（Kosmos 模式）；「实验成功」判定过 Sextant 交叉校验（确定性检查优先，LLM rubric 最后）；失败/被剪枝分支强制留痕，防择优汇报。
+
+### 8.3 流程包解释器（Pipeline 插件化）
+
+科研流程从代码降级为数据。学科流程差异集中在四维——循环拓扑（漏斗/螺旋/扇出收敛）、硬闸门位置（IRB/设备排队）、不可逆性（湿实验 vs 可重跑计算）、确定性/判断性配比——流程包把四者做成一等字段：
+
+```yaml
+kind: research-process
+name: simulation-driven          # 仿真学科示例
+extends: base/hypothesis-driven  # 可继承基线流程
+phases:
+  - id: model_setup
+    actions: [draft_model, mesh_check]      # 引用组件注册的 action（带版本）
+    checks: [mesh_quality]                  # 确定性校验（Sextant）
+    rubrics: [physical_plausibility]        # LLM 评审
+  - id: parameter_sweep
+    loop: {kind: fanout, exit_check: convergence, max_parallel: 8}
+  - id: analysis
+    actions: [aggregate_results, sensitivity]
+guidance: |                                  # 软知识：渲染进 Navigator 提示
+  收敛判据未达标时优先加密网格而非放宽容差……
+# gates / irreversible 字段保留在 schema（IRB 类学科现实需要表达力），本期默认不启用拦截
+```
+
+- **双投影**：严格档由引擎按 DAG 执行（agent 是节点，学 GitHub Actions「定义即数据、实现即插件」分层）；自由档把 phases+guidance 渲染进 Navigator 规划提示（agent 读菜谱，学 Anthropic Agent Skills）。
+- **迁移路径**（不推翻引擎）：现有每个 `*_plan()` 硬编码计划函数的输出物化为一份内置流程包 → Navigator 改为「加载选定流程 → 生成计划」→ pipeline/template/loop 三档 kind 收敛为流程定义的属性 → 开放用户编辑（YAML/表单 + 让 agent 对话式改流程；可视化画布明确不做，n8n 式工程黑洞）→ fork/分享/版本化（学 protocols.io 的方法资产 DOI 化 + Galaxy IWC 的 lint+干跑测试收录闸门）。
+- agent 自由规划保留为兜底 = 空流程 + 全量 guidance。
+
+## 9. L3 科研状态层
+
+实体清单（SQLite，Drizzle 管 schema 与迁移）：
+
+| 实体 | 说明 | 来源 |
+| --- | --- | --- |
+| `record` | 多态科研记录：paper / project / dataset（基金、专利暂缓）。内部 UUID 主键；`openalex_id`/`doi`/`arxiv_id`/`pmid` 为唯一索引的外部归一键（不拿外部 id 当主键，防上游合并冲击） | 现 `papers` 表泛化 |
+| `library` | 研究方向库：收录设置（按源 scoping）、rubric、水位线 | 现 DirectionLibrary 简化（去公共/审批/策展人） |
+| `concept` | 概念实体 + 跨论文上链 + 学科术语表标签 | 现 Concept 演进 |
+| `extraction` | ② 层结构化抽取产物：schema id + 版本 + JSON + 置信度 + 原文锚点 | 新增 |
+| `evidence_anchor` | 句/段/块级证据锚点（版本感知） | #448 已建 |
+| `hypothesis_node` | 假设/实验树节点（§8.2） | 新增 |
+| `experiment` / `artifact` | 实验与产物（结果文件、图、指标） | 现有演进 |
+| `provenance` | 每条结论/产物的来源链（代码 cell、文献 id、run id、组件版本） | 新增，组件版本随 checkpoint 快照 |
+
+去重与归一：DOI 归一 → PMID/arXiv/Corpus id 强标识 → 标题+年份+首作者指纹级联（#448 已定义）；预印本与正式版建版本簇不硬合并；dedup 键前缀顺序永不改变、新键种类只追加（存量 `dedup_key` 永不失配）。
+
+学科分类：底层全量采用 OpenAlex topics（4 域/26 field/252 subfield/4516 topic，concepts 已废弃勿用）；展示层自定义 8–12 个「学部」+ 一张 subfield→学部静态映射表；非 OpenAlex 来源经嵌入分到同一 topics 空间。
+
+---
+
+# 第三部分 文献引擎
+
+## 10. 定位与分层
+
+文献不是管理对象，而是自主发现的燃料：假设从文献缺口里长出来、实验设计从文献方法里取材、结论回到文献里验证。**文献引擎的核心资产不是 PDF 库，而是 schema 化的结构化知识层。** 没有任何现有平台做好「一套文献引擎服务多学科」（Elicit 不做本体加权、SciSpace 单篇中心、Consensus 偏二元论断；2026 评测普遍建议「组合用多个工具」）——这是学科包架构的空档。
+
+五层设计，每层划分通用件与学科包可插拔件：
+
+| 层 | 通用件（学科无关） | 学科包可插拔件 |
+| --- | --- | --- |
+| ① 解析 | **双轨**：GROBID（元数据/引文，~120 页/秒）+ MinerU 类（正文/公式 LaTeX/表格 HTML）；OmniDocBench 式质检；Nougat 已过时勿用 | 化学式识别（SMILES/结构式）、工程图纸、领域表格模型 |
+| ② 抽取 | schema 引导抽取运行时（约束解码、归一化、**人机一致性作置信度代理**——Elicit 实证「人机一致即近乎必对」）；通用骨架 schema（问题-方法-发现-局限，ORKG contribution 思路） | **抽取 schema**（实证按学科分化）：PICO/实体关系（生医）、任务-数据集-指标-结果（CS，PapersWithCode 关停后出现真空）、合成配方（材料，F1≈0.96 已可行）、反应抽取（化学）；另支持意图驱动的临时 schema |
+| ③ 关联 | 引文意图分类（便宜，全量做）、OpenAlex 书目图对齐、概念上链框架 | 术语表/本体（MeSH/ACM CCS/材料本体）、同名概念消歧规则（"transformer/stress/cell"依赖领域标签+上下文嵌入） |
+| ④ 综合 | 对比表生成（Elicit 级抽取准确率 81–99% 已实用）、定向综述章节；**不做整篇 survey**（AutoSurvey 类 LLM-judge 高分但 DeepSurvey-Bench 七项学术价值指标全低于 4 分） | 领域综述模板、评价维度 |
+| ⑤ 运用 | PaperQA2 式 agentic RAG 四件套（迭代查询扩展、LLM 重排+上下文摘要、引文图遍历补召回、证据先收集后作答+强制引用接地）；矛盾检测 agent（贵，按需触发——引文立场分布 92.6% 提及/6.5% 支持/0.8% 反驳，反驳稀疏但价值极高；ContraCrow 证明 LLM 检出矛盾已超人类） | 领域 query 翻译/扩展策略 |
+
+长上下文 vs RAG：<20 万 token 稳定小库直接全喂；库级问答 agentic RAG；单篇深读长上下文（lost-in-the-middle 中部掉 20+pp、全量喂贵两个数量级——RAG 仍占 60% 生产系统）。
+
+## 11. 为发现循环预计算的四种结构化燃料
+
+确定性管线产出、随库增量更新（非临时 prompt 拼凑）：
+
+1. **概念图 + 未连接概念对**：Swanson ABC 候选（A–B、B–C 有文献而 A–C 从未共现），开放式 LBD 的种子。
+2. **矛盾对与显式缺口清单**：GAPMAP 式 LLM 抽取（不确定性陈述、局限、矛盾、证据缺失），逐条挂原文出处。gap-finding 尚无成品，产品空白。
+3. **方法库**：每篇抽 purpose / mechanism / baseline / dataset / protocol 五元组。**purpose–mechanism 双索引让文献库变成跨域类比引擎**（「同目的、异机制」检索，KDD 类比挖掘谱系）——多学科平台的组合创新抓手；同时直接回答实验设计的「同类问题别人怎么设置实验」（AgentExpt 路线：10.8 万篇抽 11.7 万 baseline、6.8 万 dataset 实体）。
+4. **负结果与局限条目**：专门抽取 limitation/未达预期段落。约 60% 药物研发阴性结果不进公开记录，AI 管线会把该偏差放大 2.18 倍导致「把旧失败当新发现」——此项是自主发现可信度的必要对冲。
+
+## 12. 文献 → 假设四段管线
+
+确定性与 LLM 明确分工（延续「确定性 vs 判断性分离」架构约定）：
+
+1. **生成**：背景 + 多路灵感检索（语义近邻 / 图谱远端实体 / 跨域类比）→ LLM 组合成假设。范式依据：MOOSE-Chem「假设 ≈ 背景 + 灵感组合」（ICLR 2025，51 篇 Nature 级化学论文重发现验证）；Stanford 100+ 研究者盲评：LLM idea 新颖性显著高于人类专家、可行性略低、**多样性坍缩严重**——大量采样后去重是必要步骤。
+2. **文献接地**：LLM 把假设拆成子命题，每条**强制绑定检索到的真实文献 id**（检索由确定性管线完成，禁止 LLM 自产引文——各模型引文伪造率 14–95%）；无支持的子命题显式标「推测」。
+3. **查新**：逐子命题多轮检索 + judge 比对（学 co-scientist Reflection agent「先摘出假设中已知部分，再逐项对照文献判新」；避开 Sakana 式整句关键词搜索——被第三方评为查新质量差）。
+4. **可行性**：对照方法库/数据集库做资源可得性**确定性匹配**，LLM 只做风险论证。
+
+**支持度产品化**：每条假设展示支持/反驳/推测三类证据卡，逐句挂真实引文与原文片段（HypER/Kosmos provenance 思路）；支持度 = 子命题被独立文献覆盖比例，可点开验证。实验结论回流后触发矛盾对账。
+
+**现有资产落位**：#448 证据锚点 = ③ 层地基；wiki 编译+概念上链 = ③④ 雏形（与 ORKG Ask 同路线，LLM 抽取而非专家众包的规模化路径正确）；pdf_extract/分块/向量 = ① 层起点。主要缺口：② 抽取层（现只有图表与机构）与 §11 四种燃料（现只有较浅的 gap_analysis）。
+
+---
+
+# 第四部分 实验与执行系统
+
+## 13. Runner v2 契约
+
+现有 Runner Protocol 的问题（仓库摸底实证）：19 个原语中 `setup_venv`/`probe_gpu`/`ensure_plot_deps` 是 ML 专属；分派靠「有无 container」二值推断且 `kind` 参数被 noqa 忽略；`launch_run` 返回 int pid（仪器会话/仿真作业句柄装不下）；指标只有 stdout 标量序列一条通道；`write_files` 仅文本（`.slx`/`.mph` 二进制工程文件无法作为物料）。
+
+v2 契约（Python 边缘实现，manifest 在 Node 侧注册）：
+
+```python
+class RunnerPlugin(Protocol):
+    manifest: RunnerManifest
+    async def validate(self, plan) -> list[Issue]        # 物料契约静态校验
+    async def prepare(self, ctx) -> None                 # 环境/License/设备获取
+    async def launch(self, ctx) -> RunHandle             # str 句柄，非 int pid
+    async def poll(self, handle) -> RunStatus
+    async def collect(self, ctx) -> ResultBundle         # 指标 + 结果文件 + 产物登记
+    async def cancel(self, handle) -> None
+    async def cleanup(self, ctx) -> None                 # 必然执行：释放 license/设备归位
+    # 会话型另有 open_session/close_session；dry_run 保留在契约中（暂缓启用）
+```
+
+`RunnerManifest` 声明：`backend` id；`interaction`（batch/session/streaming）；`side_effects`（none/filesystem/network/physical，数据先留）；**物料契约**（必需文件与输入——今天的 `requirements.txt`+`run.sh --smoke` 降格为 python-ml 后端的契约，而非全局校验）；`io_schema`；资源需求（cpu/gpu/mem/walltime）；`licenses: [{feature, server, count}]`（**FlexLM 席位建模为可调度资源**，prepare 阶段排队获取而非报错——接商业仿真软件的关键）；接受的凭据类型；`prompt_pack` 引用（plan/codegen/debug/reflect 提示词按后端可插拔——现有 2927 行 actions_experiment 的 30 处 ML 语汇全部收进 python-ml 的 pack）。
+
+分派：`plan.backend` 显式字段（默认 `python-ml` 保兼容），注册表分派；实验 kind（eval/training/…）退役为科学语义标签。指标扩展：保留标量时间序列主干（DB/UI 承重不动），并行增加**结果文件通道**（collect 返回 csv/mat/json/图像 + 解析器摘要指标）；`direction` 增加 target/tolerance 语义；NaN 记录带标记而非静默丢弃（仿真中 NaN 是发散信号）。
+
+安全铁律延续：**LLM 只产出文件内容，平台只跑固定模板命令**；求解器 CLI 参数来自 manifest 白名单参数（`parse_container_spec` 模式），永不来自 LLM 自由文本。
+
+## 14. 后端矩阵与接入顺序
+
+按 License 摩擦排序（工科集成调研结论）：
+
+| 顺位 | 后端 | 形态 | 验证什么 |
+| --- | --- | --- | --- |
+| 1 | `openfoam` / `ngspice` | 纯容器、零 license | 物料契约 + 结果文件通道 |
+| 2 | `fmu` | FMPy 通用 runner | **一个插件吃下 200+ 建模工具产物**（FMI 3.0 标准）——最高杠杆 |
+| 3 | `pyansys` / `comsol-mph` | gRPC/会话型（PyAnsys 官方 Docker；COMSOL 走 MPh 库） | 会话交互 + license 排队调度 |
+| 4 | `visa-instrument` | PyVISA/SCPI 台式仪器 | 设备租约与互斥（physical 类；Gate 暂缓期内以「不可逆操作确认」的产品文案出现与否待定） |
+| — | 商业 EDA | 暂缓 | 授权合同而非 API 是阻碍 |
+
+设备/资源模型（接仪器与共享 GPU 机的前置条件，现库中完全缺失）：`Resource`（主机/集群队列/license 池/仪器：kind + 凭据 + 容量 + 是否独占）与 `ResourceLease`（run↔resource，独占资源互斥）。`SSHCredential` 泛化为多态 `ConnectionCredential`（kind = ssh/grpc/visa/http，各自加密载荷，沿用 Fernet 层）。
+
+## 15. BYO Runner 协议
+
+桌面是身份与数据的家；runner 是用户附加的执行器（实验室 GPU 机/云主机/本机后台），不是平台租户。
+
+- **两档接入**：① SSH 可达 → 沿现有 asyncssh+Fernet 路线，首连自动推送 runner agent 并锁定版本（学 VS Code Remote-SSH：用户只给地址，安装/升级/守护全自动）；② 内网机 → 一条命令注册（短时效 token，学 GitHub self-hosted runner），agent **出站 WebSocket 长连接拉任务，永不要求开入站端口**；NAT 场景文档化 Tailscale，不自研穿透。
+- **安全底线**（GitHub runner 事故教训：非 ephemeral 环境残留被当后门）：任务默认容器内 ephemeral 执行不残留；注册 token 短命、机器凭据可随时吊销；label/信任级路由，用户机器只跑自己的任务；私钥不出库不进日志。
+- run 派发：voyage run 整体派发到 runner（携带流程包+组件清单，runner 侧调和器拉起所需 Python 边缘组件），事件流回传桌面；桌面离线不中断 run，重连续传。
+
+---
+
+# 第五部分 工作台与产品工程
+
+## 16. 桌面技术栈（一期产品级清单）
+
+- **栈**：Electron + better-sqlite3（或 libsql 为同步留门）+ Drizzle + FTS5 + sqlite-vec（int8 量化；实用上限约几十万向量，超出评估 LanceDB；FTS5+向量 RRF 混合检索为标准模式）。
+- **Python sidecar 学 ComfyUI Desktop**：壳只捆 uv，首启在用户数据目录建 venv 装科学栈——安装包 ≤150MB，首启落盘 300–500MB，需断点续传 + 国内镜像源配置；明确避开 PyInstaller 承载 numpy/PyMuPDF（hook 脆弱）。macOS 公证：bundle 内每个 Mach-O 单独 Hardened Runtime 签名（最常见翻车点）；Windows 走 Azure Trusted Signing（$9.99/月）。
+- **一期必做**：自动更新（全量包；差分二期，有与 Sentry 冲突前科）、崩溃上报（@sentry/electron + sidecar stderr 捕获）、升级前 DB 快照 + 迁移失败回滚、一键全量导出、进程监督（tree-kill + PID 文件清理残留 + 连崩熔断；sidecar 可弃可重启、UI 永远存活——VS Code extension host 模式）、遥测 opt-in 弹窗（Obsidian 零遥测是科研人群口碑资产）。
+- **体验底线**：窗口 <2s 先出，sidecar 懒启动，索引重建后台化带进度。
+- **二期**：差分更新、多设备同步（评估 Turso Sync / PowerSync，勿自研 CRDT）、Linux 包。
+
+## 17. 数据布局：file over app（折中版）
+
+- PDF、笔记/wiki（Markdown + YAML frontmatter）、导出物落**用户可见文件夹**——用户资产永远是文件，可自行备份/git/同步，Obsidian 可直接打开整库；SQLite 只存**可重建的**索引/向量/结构化抽取。DB 损坏可重建，本身即卖点。
+- 「随时可走」产品化：一键全量导出（文献+笔记+假设树+实验记录，zip + JSON/Markdown）做进界面而非条款——反 Mendeley 锁库（加密本地库引发用户出逃的社区集体记忆）之道而行。
+
+## 18. 互通与信任（不搬家原则）
+
+- **一期**：Zotero 单向导入+回写（保留 Better BibTeX citekey——LaTeX/Markdown 写作链事实标准）；BibTeX/CSL JSON 全量进出；Markdown 库 Obsidian 兼容；Word/LaTeX 双导出（Pandoc）。**二期**：Zotero 双向同步、Overleaf Git、.eln（RO-Crate）导出、ORCID。
+- **三个信任设计**：① 每条 AI 结论强制挂证据锚点（点击跳 PDF 高亮段落；无证据明示「未找到支持」）；② 一键全量导出（§17）；③ AI 参与留痕 + 一键生成 ICMJE/Elsevier 格式披露声明（期刊已全面要求披露 AI 使用且禁止 AI 署名——把合规负担做成功能）。
+
+## 19. 模型接入
+
+- **三层**：托管额度充值制（支付宝/微信；底层路由 DeepSeek/GLM——国产 API 个人零门槛、价格约为海外 1/10；LiteLLM proxy 的 virtual key 做每任务记账，不自研网关）｜BYOK（粘贴即验证：发 1-token 探测调用即时反馈；「去开通」直达链接）｜任意 OpenAI 兼容端点。
+- **明确不做**：订阅含额度（Cursor 2025 定价风波实证其与 agent 长循环根本冲突——长任务烧 token 远超任何「典型用户」假设）。
+- 22 个 LLM stage 路由表保留并开放插件命名空间 stage（`plugin:<pack>:<stage>`，声明 fallback stage 继承路由），管理表免前端枚举硬编码。embedding 保持全库单一空间（现 `GLOBAL_ONLY_STAGES` 语义改述为「本库向量必须同空间，切换即重建索引」——个人化后最易被误删的一条，特此标注）。
+- 成本 UX（预估/实时花费/预算触顶/月度警戒）设计已调研完毕，列暂缓项。
+
+---
+
+# 第六部分 质量工程
+
+## 20. 质量基建（按 ROI 排序）
+
+1. **录制-回放回归**（最高优先）：从现有 fake LLM provider 测试演进——真实 voyage run 的完整事件流（prompt、工具调用/结果）落 session fixture，CI 零 API key 只读回放；三条纪律（DSH 实践）：refresh 只在本地、期望 diff 必人审、剥离时间/序列噪声。起步 30–50 条 golden trace 覆盖 发现 run/文献编译/写作，断言以确定性检查为主（工具序列、参数 schema、产物文件树），LLM judge 后置。「模型可见即已记录」不变式：一切到达模型的内容可从日志字节级重构。
+2. **Tracing**：Langfuse 自托管（MIT、数据驻留）；Voyage P-E-V 状态机事件天然是 trace 源，每步落 span，勿建平行体系；采 OTel GenAI 属性但加自有映射层（该约定 2026-07 仍未 stable）。
+3. **长任务验收标准**：任一步骤边界 kill -9 后可恢复且副作用不重复（幂等键）；所有 LLM/工具结果入 journal——**「记录而非重跑」**解决 LLM 不可重放；恢复后上下文从事件历史确定性重建，以「重放 == 原状态」断言验证。
+4. **多模型质保**：单一规范 prompt + 薄适配层（**禁止按模型分叉 prompt**——N prompt × M 改动不可维护，且 harness 敏感性跨模型非单调）；每个宣称支持的模型跑通同一回归集才算支持；BYOK 无法 pin 版本 → 定时金丝雀探针检测供应商静默升级 + JSON schema 违例告警 + 降级路由。
+5. **发布工程**：prompt 版本化 + feature flag（回滚不发版）；离线 eval → shadow → canary 1–5% → A/B；用户差评自动携带 trace 入失败样本库，按周转化为回归 eval 用例。
+6. **插件质量闸门最小集**：manifest/schema 校验 + 描述 lint → 沙箱样例调用抽测 → 审批绑定内容哈希 → 运行时工具输出标记不可信。
+
+---
+
+# 第七部分 迁移
+
+## 21. 现有资产处置总表
+
+**升格**：Voyage 引擎（流程包解释器）；技能系统（市场原型 + 流程知识组件）；文献 #448/#474（E1 与文献引擎 ①③ 层）；tools registry→MCP→deepseek-harness 链路（E4 模板）；Runner Protocol（v2 起点）；SSH 凭据/paused_ask/断点恢复（runner 协议雏形）；`papers` 共享池（语义自然退化为「我的本地池」，零改动）。
+
+**移除**（去实验室化 36 项清单，仓库摸底 ④ 全文另存）：注册码/邀请/邮箱强制验证/首用户自动 admin；admin_users/admin_codes 及对应 UI；User.role/read_only/llm_access/token_quota/features；ProjectMember/ProjectInvite/JoinPage；库 is_public/status/审批流/策展人；排行榜/热度榜/ViewEvent；技能市场审核流；admin-me 双轨 LLM 配置（合并单套）；zju 品牌痕迹（appId/演示号/zjuthesis 默认/邮箱占位）。
+
+**改造**：admin 全局设置→个人设置（文献源 key 池/文档处理凭据/实验环境/TTS/每日分类——RotatingAdapter 多 key 轮转保留）；通知 `notify:project:{id}`→`notify:user:{id}`；每日池→个人订阅；Project 保留但更名 Topic/Vault（URL 作用域/语境/语料范围/挂载点四职责不可删）；反馈系统直连 GitHub 去分诊层；SettingsPage.tsx（187KB 混住）必须先拆。
+
+**原样保留但本期不产品化**：Gate/paused_ask/预算机制（暂缓项）；CRDT 协作编辑（一期保留供多设备，二期随本地化再评估）。
+
+## 22. Node↔Python 边界（无先例、自行设计的部分）
+
+- **原则**：缝只开在引擎级，不开在函数级；单一协议。
+- **协议**：line-delimited JSON-RPC over stdio（桌面 `src/desktop` 已有同款 IPC 契约与 supervisor 雏形），远程 runner 场景同协议走 WebSocket。MCP 用于「工具语义」的边界（外部生态、三方插件），JSON-RPC 用于「引擎语义」的边界（遗留引擎、解析/抽取服务、runner 驱动）——两者不混用。
+- **生命周期映射**：Node 侧每个 python-edge 组件对应一个受监督子进程；配置树调和器在各进程独立运行（§7.3）；进程崩溃 = fiber FAILED，隔离重启不拖垮平台。
+- **遗留引擎挂载**：现 FastAPI 后端整体作为一个 python-edge 组件（HTTP 本地回环），API 面即缝；按域迁移时逐个路由摘除，直到只剩科学驱动与解析。
+
+## 23. 阶段计划
+
+| 阶段 | 内容 | 出口判据 |
+| --- | --- | --- |
+| **P0 spike**（数周） | ① cordis 内核挂遗留引擎跑通一条完整链路；② SQLite+sqlite-vec 文献库性能实测；③ JSON-RPC 缝与跨进程调和器原型 | **任一不过关 → 回退 A 路线（Python 内核复刻），损失仅 spike 成本** |
+| **P1 个人壳+引擎** | Electron+内核+SQLite 单用户免登录；遗留引擎供现有功能；去实验室化纯移除项；录制-回放回归起步 | 现有链路在新壳内端到端可用 |
+| **P2 自主发现 v1（文献域）** | 发现循环 kind + 假设树 + 最小锦标赛；文献引擎 ①③⑤ 层（解析双轨/引文意图/agentic RAG/四段假设管线）；源适配器 TS 插件化（含 CORDIS）；Zotero 导入、证据锚点、披露生成器 | 「给方向→自主调研→有据研究方案」完整 run 可交付；博士生种子用户留存 |
+| **P2.5 文献引擎加厚** | ② 抽取层（通用骨架+首批学科 schema）+ 四种预计算燃料 + ④ 对比表 | 假设生成消费结构化燃料而非裸检索；方法级检索可用 |
+| **P3 自主实验** | Runner v2 + 流程包解释器 + BYO runner 两档 + Resource/Lease/多态凭据；openfoam/ngspice → fmu → pyansys → 仪器 | 非 CS 试点课题组真实跑通自主实验 run |
+| **P4 生态开放** | 学科包/流程包格式经试点验证后**契约冻结（semver）**；市场+质量闸门开放；agent 自制工具（沙箱+抽测护栏） | 第三方首批插件上架 |
+| **P5 商业化** | 托管额度计费、重度档 credit、同步服务 | — |
+
+贯穿约束：每阶段结束产品可用；契约冻结前不对外宣传生态（Koishi 教训：早期快跑随意破坏、对外后主版本冻结，生态才起来）；服务器版维护态，桌面对等后降级为自托管选项。
+
+---
+
+# 第八部分 风险与决策
+
+## 24. 风险登记
+
+| 风险 | 级别 | 缓解 / 止损线 |
+| --- | --- | --- |
+| 平台重建工期失控、行为漂移 | 高 | 绞杀式+遗留引擎兜底；录制-回放对齐测试；P0 硬回退门 |
+| Node↔Python 缝无先例 | 高 | 缝只开引擎级、单一协议；P0 专项验证 |
+| Claude Science 补上开放市场 | 高 | 以速度换位：P2 上差异化（自主 run+溯源），冻结前不声张但试点先行 |
+| 自主发现的可信度（行业性：幻觉数值/查新差/择优汇报） | 高 | §12 管线的确定性接地/查新；provenance 强制；失败分支留痕 |
+| 迁移期产品停滞 | 中 | 冻结实验室向功能；文献域先迁先见效 |
+| cordis v4 仍 rc、核心维护者单点 | 中 | vendor 冻结内部 fork（DSH 全套示范），不追上游 |
+| 个人版经济账（失去实验室摊薄） | 中 | 按需编译+激进缓存；社区共享解读缓存留作后手 |
+| 插件安全（投毒/窃密，pinhaofa 前车） | 中 | 隔离阶梯+描述 lint+内容哈希审批+调用抽测；先只开官方源 |
+| SQLite 承载（向量上限/多设备） | 中 | P0 实测；量化+分库预案；一期单机单写者 |
+| 生态冷启动 | 中 | 前 20 个官方插件即产品战略；3–5 个非 CS 设计伙伴共创 |
+
+## 25. 待拍板决策
+
+1. **立项确认**：接受「重建」级投入（2–4 季度核心链路对等）。本报告前提。
+2. **非 CS 试点学科**：CFD/机械（OpenFOAM，摩擦最低）vs 电路（ngspice）vs 有真实设计伙伴的学科（优先）。
+3. **开源策略**：建议内核+插件 SDK 开源、托管服务收费（Obsidian/DSH 混合模式）；全闭源显著拖慢生态。
+4. **品牌**：新定位下 Polaris 名称与叙事重述。
+
+---
+
+# 附录 A 调研索引（19 路，2026-09-02）
+
+仓库摸底：①整体架构与扩展点（56 action 注册表、kind→plan 硬映射、STAGES 枚举、幽灵技能注入点）②文献模块（18 条 arXiv 假设；#448/#474 适配层现状）③实验模块（30 条 ML 假设；分派单点；无设备模型）④去实验室化 36 项清单。
+外部：⑤插件架构模式（VS Code/Backstage/HA/Grafana/Galaxy/Jupyter/MCP/pluggy/隔离阶梯）⑥多学科数据源（OpenAlex 计费与快照双轨、Europe PMC、CORDIS、topics→学部、去重级联）⑦工科集成（PyAnsys/MPh/FMU/SiLA2/Bluesky/PyVISA/FlexLM/LAP 分级）⑧Cordis 机制（Fiber/effect/inject/schemastery/loader；Python 移植评估）⑨Koishi 生态（4603 插件治理、npm 即市场、投毒与停摆事件、v4 冻结经验）⑩DeepSeek Harness（纯 TS 边界、vendored cordis、Profile/Bundle/Patch）⑪agent-native 工具链路（DSH 工具管道、渐进披露、MCPTox）⑫自主发现系统（Sakana v2/co-scientist/Kosmos/A-Lab 教训/监督点共识）⑬流程插件化（四维差异、protocols.io/IWC、双投影、GitHub Actions 分层）⑭竞品扫描（空位、付费带、失败案例）⑮桌面工程（uv sidecar、sqlite-vec 上限、签名公证、file-over-app）⑯成本与算力（三层接入、LiteLLM、Cursor 风波、GitHub runner/Remote-SSH/Tailscale）⑰质量工程（录制回放、Langfuse、内容哈希、记录而非重跑）⑱文献深度挖掘（解析双轨、schema 学科分化实证、GraphRAG 取舍、survey 不成熟、多学科引擎空档）⑲文献驱动发现 LBD（Swanson→MOOSE-Chem、GAPMAP、接地机制、类比挖掘、引文伪造率、四段管线）。
+
+各路完整报告存于本次会话记录；立项后按仓库惯例产出英文 RFC 与 tracking issues。


### PR DESCRIPTION
## Summary

Adds the chartering documents for the Polaris 2.0 rebuild (tracking: #564):

- `docs/rfcs/2026-09-02-autonomous-discovery-platform.md` — summary RFC of record (English): positioning ("Deep Research platform for autonomous scientific discovery", where Deep Research means deep scientific research), design tenets (everything is a plugin / composes / hot-swappable / evolves), three-layer architecture (cordis-based plugin kernel, Voyage runtime promoted to process-pack interpreter with a first-class hypothesis tree, typed research state layer), Python science edge, local-first SQLite data, migration phases P0–P5 with a hard fallback gate at P0.
- `docs/rfcs/2026-09-02-polaris-2.0-design-report.zh.md` — the full design report (Chinese, authoritative): 8 parts / 25 sections covering the plugin system (manifest, service gating, effect lifecycle, agent-tool pipeline), the five-layer literature engine with discipline-pluggable extraction schemas and the literature→hypothesis pipeline, Runner v2 and the backend matrix, BYO runner protocol, desktop engineering, quality engineering, asset disposition, and the phased migration plan.

Deferred by explicit decision (mechanisms kept, not productized): approval gates, cost budgeting, grant/patent record kinds.

## Notes for review

- Docs-only change; no runtime code touched.
- The next series (P0: workspace foundation, vendored cordis, kernel skeleton, three spikes) will be filed as sub-issues of #564, one branch/PR each.

Refs #564