### PR TITLE
fix(frontend): keep pdfjs assets real files under pnpm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       lib0:
         specifier: ^0.2.117
         version: 0.2.117
+      pdfjs-dist:
+        specifier: 4.8.69
+        version: 4.8.69
       react:
         specifier: ^18.3.1
         version: 18.3.1

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -21,6 +21,7 @@
     "codemirror": "^6.0.2",
     "katex": "^0.17.0",
     "lib0": "^0.2.117",
+    "pdfjs-dist": "4.8.69",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-pdf": "^9.2.1",

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -10,7 +10,12 @@ import { cpSync } from 'node:fs';
 function copyPdfAssets(): Plugin {
   for (const dir of ['cmaps', 'standard_fonts']) {
     try {
-      cpSync(`node_modules/pdfjs-dist/${dir}`, `public/pdfjs/${dir}`, { recursive: true });
+      // dereference: pnpm 下 node_modules/pdfjs-dist 是指向 store 的符号链接，
+      // 默认拷贝会把链接原样复制进 public/，打包后成为悬空链接。
+      cpSync(`node_modules/pdfjs-dist/${dir}`, `public/pdfjs/${dir}`, {
+        recursive: true,
+        dereference: true,
+      });
     } catch (e) {
       console.warn(`[copy-pdf-assets] ${dir} 拷贝失败:`, (e as Error)?.message);
     }


### PR DESCRIPTION
## Summary

Repairs the desktop smoke failure introduced by the pnpm migration (#569, run 33675589409, assertion "pdfjs cmaps 可取"):

- `pdfjs-dist` becomes a direct dependency of the frontend, pinned to `4.8.69` (the exact version react-pdf resolves) — under pnpm's strict layout the transitive copy is no longer visible at `node_modules/pdfjs-dist`, so `copyPdfAssets()` silently copied nothing.
- `cpSync` now passes `dereference: true` so the copy ships file contents instead of reproducing the pnpm store symlink as a dangling link inside `public/pdfjs`.

## Verification

- `pnpm --dir src/frontend run build` from a clean worktree, then checked `dist/pdfjs/cmaps/Adobe-Japan1-UCS2.bcmap` and `dist/pdfjs/standard_fonts/*` are regular files (not symlinks).

Closes #570