### PR TITLE
feat(kernel): add @polaris/kernel skeleton with JSON-RPC seam

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build vendored type declarations
+        run: pnpm run vendor:types
+
       - name: Vendored runtime contract test
         run: pnpm --dir vendor/contract-smoke run test
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ src/backend/build/
 
 # electron-builder output (src/desktop/dist is covered by the global dist/ rule)
 src/desktop/release/
+
+# vendored packages: declaration output is built by `pnpm run vendor:types`
+vendor/deepseek-cordis/*/lib/
+vendor/deepseek-cordis/*/tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,9 +4,14 @@
   "version": "0.0.0",
   "packageManager": "pnpm@10.34.5",
   "scripts": {
-    "lint": "pnpm -r --if-present run lint",
+    "lint": "pnpm run vendor:types && pnpm -r --if-present run lint",
     "build": "pnpm -r --if-present run build",
-    "test": "pnpm -r --if-present run test"
+    "test": "pnpm -r --if-present run test",
+    "vendor:types": "tsc -b vendor/deepseek-cordis/cordis vendor/deepseek-cordis/cosmokit vendor/deepseek-cordis/schemastery vendor/deepseek-cordis/loader vendor/deepseek-cordis/include vendor/deepseek-cordis/group vendor/deepseek-cordis/timer vendor/deepseek-cordis/logger-console"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,14 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
 
   src/desktop:
     devDependencies:
@@ -107,6 +114,28 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.1)
+
+  src/kernel:
+    dependencies:
+      '@deepseek-ai/cordis':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/cordis
+      '@deepseek-ai/cosmokit':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/cosmokit
+      '@deepseek-ai/schemastery':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/schemastery
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)
 
   vendor/contract-smoke:
     dependencies:

--- a/src/kernel/package.json
+++ b/src/kernel/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@polaris/kernel",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Polaris plugin kernel: cordis runtime host, config tree, process seams",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@deepseek-ai/cordis": "workspace:*",
+    "@deepseek-ai/cosmokit": "workspace:*",
+    "@deepseek-ai/schemastery": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.4",
+    "vitest": "^3.0.0"
+  }
+}

--- a/src/kernel/src/config/tree.ts
+++ b/src/kernel/src/config/tree.ts
@@ -1,0 +1,45 @@
+/* ============================================================
+   Config tree — module boundary stub.
+
+   The declarative plugin configuration tree is the single source of truth
+   for which components are enabled with which config. Each process (kernel,
+   Python edge, remote runner) runs a reconciler that diffs the desired tree
+   against its live fibers and applies the minimal effect set.
+
+   Spike 3 delivers the cross-process reconciler prototype against this
+   interface; the SQLite-backed store lands with the kernel storage plugin
+   (P1-A5). Until then this file only fixes the shape of the boundary.
+   ============================================================ */
+
+export interface ConfigEntry {
+  /** Stable entry id (hierarchical, `:`-separated). */
+  id: string
+  /** Plugin name the entry instantiates, or a group marker. */
+  name: string
+  /** Plugin config payload (validated by the plugin's schema on apply). */
+  config?: unknown
+  /** Disabled entries stay in the tree but are not instantiated. */
+  disabled?: boolean
+  /** Child entries (groups). */
+  children?: ConfigEntry[]
+}
+
+export interface ConfigTreeStore {
+  /** Read the full desired tree. */
+  load(): Promise<ConfigEntry[]>
+  /** Persist the full desired tree (UI edits write through here). */
+  save(entries: ConfigEntry[]): Promise<void>
+}
+
+/** In-memory store, used by tests and the spikes. */
+export class MemoryConfigTreeStore implements ConfigTreeStore {
+  #entries: ConfigEntry[] = []
+
+  async load(): Promise<ConfigEntry[]> {
+    return structuredClone(this.#entries)
+  }
+
+  async save(entries: ConfigEntry[]): Promise<void> {
+    this.#entries = structuredClone(entries)
+  }
+}

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -1,0 +1,13 @@
+export { Kernel, createKernel, type KernelOptions } from './kernel.ts'
+export {
+  JsonRpcEndpoint,
+  type JsonRpcEndpointOptions,
+  type NotificationHandler,
+  type RpcHandler,
+} from './rpc/jsonrpc.ts'
+export {
+  MemoryConfigTreeStore,
+  type ConfigEntry,
+  type ConfigTreeStore,
+} from './config/tree.ts'
+export { Context } from '@deepseek-ai/cordis'

--- a/src/kernel/src/kernel.ts
+++ b/src/kernel/src/kernel.ts
@@ -1,0 +1,62 @@
+/* ============================================================
+   Polaris kernel: the cordis runtime host.
+
+   The kernel owns exactly one root Context. Everything else — the config
+   tree, process supervisors, the legacy engine, storage, the gateway — is a
+   plugin installed into this context, so that install/uninstall/upgrade are
+   effect-reversible operations (see vendor/deepseek-cordis).
+
+   HARD CONSTRAINT: this package must stay electron-free. It is mounted by
+   the desktop main process in P1, but it must always be startable under
+   bare Node (spikes, CI regression, future headless mode). Enforced by
+   tests/electron-free.test.ts.
+   ============================================================ */
+
+import { Context } from '@deepseek-ai/cordis'
+
+export interface KernelOptions {
+  /** Human-readable instance name, used in logs and diagnostics. */
+  name?: string
+}
+
+export class Kernel {
+  readonly ctx: Context
+  readonly name: string
+  #started = false
+  #stopped = false
+
+  constructor(options: KernelOptions = {}) {
+    this.name = options.name ?? 'polaris'
+    this.ctx = new Context()
+  }
+
+  get started(): boolean {
+    return this.#started && !this.#stopped
+  }
+
+  /**
+   * Start the kernel. Baseline plugins (config tree, supervisors) are
+   * installed by the caller or by profile code; start itself only marks the
+   * kernel live. Idempotent.
+   */
+  async start(): Promise<void> {
+    if (this.#stopped) throw new Error('kernel already stopped')
+    this.#started = true
+  }
+
+  /**
+   * Stop the kernel: dispose the root fiber, which cascades disposal through
+   * every installed plugin and reclaims all registered effects (timers,
+   * listeners, child processes). Idempotent.
+   */
+  async stop(): Promise<void> {
+    if (this.#stopped) return
+    this.#stopped = true
+    await this.ctx.fiber.dispose()
+  }
+}
+
+/** Create a kernel instance. See {@link Kernel}. */
+export function createKernel(options: KernelOptions = {}): Kernel {
+  return new Kernel(options)
+}

--- a/src/kernel/src/rpc/jsonrpc.ts
+++ b/src/kernel/src/rpc/jsonrpc.ts
@@ -1,0 +1,140 @@
+/* ============================================================
+   Line-delimited JSON-RPC 2.0 endpoint over a stream pair.
+
+   Promoted from src/desktop/src/main/agent/rpc.ts (the desktop shell keeps
+   its copy until it mounts the kernel in P1). Framing stays aligned with
+   src/backend/app/mcp/__main__.py: one JSON object per line, so a Python
+   process can sit on the other end of the pipe unchanged.
+
+   This module extends the desktop client with the pieces the kernel seams
+   need: notifications (messages without an id) and inbound method calls
+   (Python → Node), both optional. Backpressure and large-payload handling
+   are Spike 3 scope and will land with benchmarks.
+   ============================================================ */
+
+import type { Readable, Writable } from 'node:stream'
+
+interface Pending {
+  resolve: (value: unknown) => void
+  reject: (err: Error) => void
+  timer: NodeJS.Timeout
+}
+
+export type RpcHandler = (params: unknown) => unknown | Promise<unknown>
+export type NotificationHandler = (method: string, params: unknown) => void
+
+export interface JsonRpcEndpointOptions {
+  /** Timeout for outbound calls, in milliseconds. */
+  timeoutMs?: number
+  /** Called for inbound notifications (messages without an id). */
+  onNotification?: NotificationHandler
+}
+
+export class JsonRpcEndpoint {
+  private nextId = 1
+  private readonly pending = new Map<number, Pending>()
+  private readonly methods = new Map<string, RpcHandler>()
+  private buffer = ''
+  private readonly timeoutMs: number
+  private readonly onNotification?: NotificationHandler
+
+  constructor(
+    private readonly output: Writable,
+    input: Readable,
+    options: JsonRpcEndpointOptions = {},
+  ) {
+    this.timeoutMs = options.timeoutMs ?? 30_000
+    this.onNotification = options.onNotification
+    input.setEncoding('utf8')
+    input.on('data', (chunk: string) => this.onData(chunk))
+  }
+
+  /** Register a handler for inbound calls (the peer's `call` reaches here). */
+  handle(method: string, handler: RpcHandler): () => void {
+    this.methods.set(method, handler)
+    return () => {
+      if (this.methods.get(method) === handler) this.methods.delete(method)
+    }
+  }
+
+  call(method: string, params?: unknown): Promise<unknown> {
+    const id = this.nextId++
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`rpc call timed out: ${method}`))
+      }, this.timeoutMs)
+      this.pending.set(id, { resolve, reject, timer })
+      this.send({ jsonrpc: '2.0', id, method, params })
+    })
+  }
+
+  /** Fire-and-forget notification (no id, no response expected). */
+  notify(method: string, params?: unknown): void {
+    this.send({ jsonrpc: '2.0', method, params })
+  }
+
+  /** Peer process died: reject every in-flight request deterministically. */
+  rejectAll(reason: string): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer)
+      entry.reject(new Error(reason))
+    }
+    this.pending.clear()
+  }
+
+  private send(msg: Record<string, unknown>): void {
+    this.output.write(`${JSON.stringify(msg)}\n`)
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk
+    let nl: number
+    while ((nl = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, nl).trim()
+      this.buffer = this.buffer.slice(nl + 1)
+      if (!line) continue
+      try {
+        void this.dispatch(JSON.parse(line) as Record<string, unknown>)
+      } catch {
+        // Non-JSON on the pipe (usually a library logging to stdout) must
+        // never poison the channel — ignore the line.
+      }
+    }
+  }
+
+  private async dispatch(msg: Record<string, unknown>): Promise<void> {
+    const id = msg.id
+    if (typeof msg.method === 'string') {
+      // Inbound call or notification from the peer.
+      if (typeof id !== 'number') {
+        this.onNotification?.(msg.method, msg.params)
+        return
+      }
+      const handler = this.methods.get(msg.method)
+      if (!handler) {
+        this.send({ jsonrpc: '2.0', id, error: { code: -32601, message: `method not found: ${msg.method}` } })
+        return
+      }
+      try {
+        const result = await handler(msg.params)
+        this.send({ jsonrpc: '2.0', id, result: result ?? null })
+      } catch (error) {
+        this.send({ jsonrpc: '2.0', id, error: { code: -32000, message: (error as Error)?.message ?? 'handler failed' } })
+      }
+      return
+    }
+    // Response to one of our outbound calls.
+    if (typeof id !== 'number') return
+    const entry = this.pending.get(id)
+    if (!entry) return
+    this.pending.delete(id)
+    clearTimeout(entry.timer)
+    if (msg.error) {
+      const err = msg.error as { code?: number; message?: string }
+      entry.reject(new Error(err.message ?? `rpc error ${err.code ?? ''}`))
+    } else {
+      entry.resolve(msg.result)
+    }
+  }
+}

--- a/src/kernel/tests/electron-free.test.ts
+++ b/src/kernel/tests/electron-free.test.ts
@@ -1,0 +1,27 @@
+// The kernel must stay startable under bare Node: no electron import may ever
+// enter this package (see the header of src/kernel.ts). This test enforces it
+// mechanically so no lint stack is needed.
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function* walk(dir: string): Generator<string> {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) yield* walk(path)
+    else if (/\.(ts|tsx|js|cjs|mjs)$/.test(name)) yield path
+  }
+}
+
+describe('kernel stays electron-free', () => {
+  it('no source file imports electron', () => {
+    const offenders: string[] = []
+    for (const file of walk(join(import.meta.dirname, '../src'))) {
+      const text = readFileSync(file, 'utf8')
+      if (/from ['"]electron['"]|require\(['"]electron['"]\)/.test(text)) {
+        offenders.push(file)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/kernel/tests/jsonrpc.test.ts
+++ b/src/kernel/tests/jsonrpc.test.ts
@@ -1,0 +1,88 @@
+import { PassThrough } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+import { JsonRpcEndpoint } from '../src/index.ts'
+
+/** Wire two endpoints together over in-memory pipes. */
+function pair(options?: ConstructorParameters<typeof JsonRpcEndpoint>[2]) {
+  const aToB = new PassThrough()
+  const bToA = new PassThrough()
+  const a = new JsonRpcEndpoint(aToB, bToA, options)
+  const b = new JsonRpcEndpoint(bToA, aToB, options)
+  return { a, b }
+}
+
+describe('line-delimited JSON-RPC endpoint', () => {
+  it('pairs requests with responses across the pipe', async () => {
+    const { a, b } = pair()
+    b.handle('math.add', (params) => {
+      const { x, y } = params as { x: number; y: number }
+      return x + y
+    })
+    await expect(a.call('math.add', { x: 2, y: 40 })).resolves.toBe(42)
+  })
+
+  it('propagates handler errors as rpc errors', async () => {
+    const { a, b } = pair()
+    b.handle('boom', () => {
+      throw new Error('kaput')
+    })
+    await expect(a.call('boom')).rejects.toThrow('kaput')
+  })
+
+  it('reports unknown methods', async () => {
+    const { a } = pair()
+    await expect(a.call('no.such.method')).rejects.toThrow('method not found')
+  })
+
+  it('delivers notifications without id pairing', async () => {
+    const seen: Array<[string, unknown]> = []
+    const aToB = new PassThrough()
+    const bToA = new PassThrough()
+    const a = new JsonRpcEndpoint(aToB, bToA)
+    void new JsonRpcEndpoint(bToA, aToB, {
+      onNotification: (method, params) => seen.push([method, params]),
+    })
+    a.notify('progress', { pct: 50 })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(seen).toEqual([['progress', { pct: 50 }]])
+  })
+
+  it('survives garbage lines on the pipe', async () => {
+    const { a, b } = pair()
+    b.handle('echo', (p) => p)
+    // A library logging to stdout must not poison the channel.
+    ;(a as unknown as { output: PassThrough }).output.write('not json at all\n')
+    await expect(a.call('echo', 'still alive')).resolves.toBe('still alive')
+  })
+
+  it('splits and reassembles multiple messages per chunk', async () => {
+    const out = new PassThrough()
+    const inp = new PassThrough()
+    const results: unknown[] = []
+    const ep = new JsonRpcEndpoint(out, inp)
+    const p1 = ep.call('a').then((r) => results.push(r))
+    const p2 = ep.call('b').then((r) => results.push(r))
+    // Two responses arrive in one chunk, split mid-line across writes.
+    const payload = `${JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'one' })}\n${JSON.stringify({ jsonrpc: '2.0', id: 2, result: 'two' })}\n`
+    inp.write(payload.slice(0, 25))
+    inp.write(payload.slice(25))
+    await Promise.all([p1, p2])
+    expect(results).toEqual(['one', 'two'])
+  })
+
+  it('rejectAll fails every in-flight call deterministically', async () => {
+    const out = new PassThrough()
+    const inp = new PassThrough()
+    const ep = new JsonRpcEndpoint(out, inp)
+    const p = ep.call('never.answered')
+    ep.rejectAll('peer died')
+    await expect(p).rejects.toThrow('peer died')
+  })
+
+  it('times out calls that never get a response', async () => {
+    const out = new PassThrough()
+    const inp = new PassThrough()
+    const ep = new JsonRpcEndpoint(out, inp, { timeoutMs: 50 })
+    await expect(ep.call('slow')).rejects.toThrow('timed out')
+  })
+})

--- a/src/kernel/tests/kernel.test.ts
+++ b/src/kernel/tests/kernel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createKernel, type Context } from '../src/index.ts'
+
+const until = async (cond: () => boolean, ms = 1000) => {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+
+describe('kernel lifecycle', () => {
+  it('starts, hosts plugins, and reclaims their effects on stop', async () => {
+    const kernel = createKernel({ name: 'test' })
+    await kernel.start()
+    expect(kernel.started).toBe(true)
+
+    let ticks = 0
+    let reclaimed = false
+    kernel.ctx.plugin({
+      name: 'probe',
+      apply(ctx: Context) {
+        ctx.effect(() => {
+          const timer = setInterval(() => ticks++, 10)
+          return () => {
+            clearInterval(timer)
+            reclaimed = true
+          }
+        }, 'probe interval')
+      },
+    })
+    await until(() => ticks > 0)
+
+    await kernel.stop()
+    expect(kernel.started).toBe(false)
+    expect(reclaimed).toBe(true)
+    const frozen = ticks
+    await new Promise((r) => setTimeout(r, 50))
+    expect(ticks).toBe(frozen)
+  })
+
+  it('stop is idempotent and start after stop is rejected', async () => {
+    const kernel = createKernel()
+    await kernel.start()
+    await kernel.stop()
+    await kernel.stop()
+    await expect(kernel.start()).rejects.toThrow('already stopped')
+  })
+})

--- a/src/kernel/tsconfig.json
+++ b/src/kernel/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/vendor/deepseek-cordis/UPSTREAM.md
+++ b/vendor/deepseek-cordis/UPSTREAM.md
@@ -6,10 +6,15 @@
 > files preserved per package). Packages taken: cordis, cosmokit, schemastery,
 > loader, include, group, timer, logger-console (hmr intentionally omitted).
 > Polaris local modifications on top of that snapshot:
-> 1. Every `package.json` entry (`main`/`types`/`exports["."]`) points at
->    `src/index.ts` instead of built `lib/` output — Polaris consumes the
->    TypeScript source directly through esbuild/vitest/tsc and does not
->    replicate the upstream tsdown build. `module` fields removed.
+> 1. Runtime entries (`main`, `exports["."].default`) point at `src/index.ts`
+>    instead of built `lib/` output — Polaris consumes the TypeScript source
+>    directly through esbuild/vitest and does not replicate the upstream
+>    tsdown build. `module` fields removed.
+> 2. Type entries (`types`, `exports["."].types`) point at
+>    `lib/types/index.d.ts`, produced by `pnpm run vendor:types` (declaration-
+>    only `tsc -b` using each package's own tsconfig), so downstream strict
+>    typechecking goes through skipLibCheck-shielded declarations instead of
+>    re-checking vendored sources under Polaris compiler options.
 > The rest of this file is the upstream document, kept verbatim for the
 > package manifest and the upstream modification log.
 

--- a/vendor/deepseek-cordis/cordis/package.json
+++ b/vendor/deepseek-cordis/cordis/package.json
@@ -13,11 +13,11 @@
   "sideEffects": false,
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "bin": "bin.js",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/cosmokit/package.json
+++ b/vendor/deepseek-cordis/cosmokit/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/group/package.json
+++ b/vendor/deepseek-cordis/group/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/include/package.json
+++ b/vendor/deepseek-cordis/include/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/loader/package.json
+++ b/vendor/deepseek-cordis/loader/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/logger-console/package.json
+++ b/vendor/deepseek-cordis/logger-console/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/schemastery/package.json
+++ b/vendor/deepseek-cordis/schemastery/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/deepseek-cordis/timer/package.json
+++ b/vendor/deepseek-cordis/timer/package.json
@@ -12,10 +12,10 @@
   },
   "type": "module",
   "main": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./lib/types/index.d.ts",
       "default": "./src/index.ts"
     },
     "./src/*": "./src/*",

--- a/vendor/tsconfig.base.json
+++ b/vendor/tsconfig.base.json
@@ -2,13 +2,18 @@
   // Polaris stand-in for the deepseek-harness repo-root tsconfig.base.json that
   // the vendored packages' tsconfigs extend (they resolve ../../tsconfig.base.json,
   // which lands here). Mirrors the upstream compiler options relevant to source
-  // consumption; the upstream project-graph flags (composite/paths/references)
-  // are intentionally dropped because Polaris consumes the TypeScript sources
-  // directly via esbuild/vitest instead of building lib/ output.
+  // consumption. Unlike the upstream build we emit *declarations only*
+  // (`pnpm run vendor:types` at the repo root): runtime consumption stays on the
+  // TypeScript sources via esbuild/vitest, while tsc consumers resolve the
+  // emitted lib/types and skipLibCheck shields them from the packages' internal
+  // strictness relaxations.
   "compilerOptions": {
     "target": "es2024",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowImportingTsExtensions": true,
@@ -19,7 +24,6 @@
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
-    "noEmit": true,
     "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary

Third PR of the P0 foundation series (tracking #564). Adds `src/kernel` (`@polaris/kernel`), the Node plugin kernel skeleton:

- `createKernel()` hosts exactly one cordis root context; `stop()` disposes the root fiber, cascading disposal through every installed plugin (effect reclamation verified by test). **Electron-free is a hard constraint** — enforced mechanically by `tests/electron-free.test.ts`, so the kernel always starts under bare Node (spikes, CI, future headless mode).
- `JsonRpcEndpoint` promotes the desktop agent rpc module (`src/desktop/src/main/agent/rpc.ts`, which keeps its copy until the shell mounts the kernel in P1-A1): line-delimited JSON-RPC 2.0 with the same framing as `app/mcp/__main__.py`, extended with inbound method handling and notifications. Backpressure/large-payload work is Spike 3 scope.
- Config-tree module boundary stubbed (`ConfigEntry`/`ConfigTreeStore` + memory store) for the Spike 3 reconciler and the P1-A5 SQLite store.
- Vendored packages now expose declaration-only types built by a new root `vendor:types` script (`tsc -b` with each package's own tsconfig): runtime consumption stays on TypeScript sources, while `tsc --noEmit` consumers resolve skipLibCheck-shielded declarations instead of re-checking vendored sources under Polaris strict options. Recorded in `UPSTREAM.md`; `node-ci` builds the declarations before kernel checks.

## Verification

- `pnpm run vendor:types` — clean declaration build for all 8 vendored packages
- `pnpm --dir src/kernel run lint` (tsc --noEmit, strict) ✓
- `pnpm --dir src/kernel run test` — 11/11 (kernel lifecycle + effect reclamation, rpc pairing/errors/notifications/garbage-tolerance/chunk-splitting/rejectAll/timeout, electron-free scan)
- `pnpm --dir vendor/contract-smoke run test` — 3/3

Closes #568