### PR TITLE
feat(spikes): validate JSON-RPC seam and cross-process reconciler

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -46,3 +46,9 @@ jobs:
             pnpm --dir src/kernel --if-present run lint
             pnpm --dir src/kernel --if-present run test
           fi
+
+      - name: Spike tests
+        run: |
+          for dir in spikes/p0/*/; do
+            [ -f "$dir/package.json" ] && pnpm --dir "$dir" --if-present run test
+          done

--- a/docs/rfcs/p0-spike-report.md
+++ b/docs/rfcs/p0-spike-report.md
@@ -1,0 +1,49 @@
+# P0 Spike Report
+
+| Field | Value |
+| --- | --- |
+| Status | In progress (gate review when all three spikes conclude) |
+| Tracking issue | #564 |
+| Gate rule | Any spike failing its acceptance bar → fall back to the Python-kernel variant; cost limited to the spikes |
+
+## Spike 3 — JSON-RPC seam + cross-process config-tree reconciler ✅
+
+Issue #574. Code: `spikes/p0/3-rpc-reconcile` (excluded from packaging; deletable wholesale).
+
+Setup: `@polaris/kernel`'s `JsonRpcEndpoint` over a supervised `python3` child
+process running a pure-stdlib sidecar (framing aligned with
+`app/mcp/__main__.py`); a reconciler prototype that diffs a desired config
+tree against the sidecar's reported live set, pushes `config.apply`, collects
+per-component progress notifications into an effect log, and verifies
+convergence via `config.report`. Crash model: the sidecar is stateless; on
+death the supervisor respawns it empty and the reconciler re-applies the
+desired tree (state lives kernel-side).
+
+| Acceptance bar | Result |
+| --- | --- |
+| Bidirectional echo ×1000, RTT P95 < 5 ms | **P50 0.02 ms · P95 0.03 ms · P99 0.08 ms** (macOS, Python 3.14) |
+| 5 MB single-line payload survives framing both directions | ✅ length + tail intact |
+| Add / update / remove tree changes each trigger exactly the minimal component effect set | ✅ effect-log equality assertions (`start:src:pubmed` alone on add; `update:src:openalex` alone on config change; exactly two `stop`s on remove+disable) |
+| kill -9 recovery < 5 s, reconverged, in-flight requests rejected deterministically | ✅ restart=1, report matches desired, in-flight call rejects with `sidecar exited` |
+
+Findings for the real python-edge plugin (P1):
+
+1. Line-delimited JSON-RPC over stdio is comfortably fast for engine-level
+   seams (sub-0.1 ms RTT); no need for a heavier transport until proven
+   otherwise.
+2. 5 MB single-line payloads pass, but both ends buffer the full line —
+   PDF-scale blobs should move via file paths or chunked notifications, not
+   inline params. (Recorded as a python-edge design rule.)
+3. "Sidecar stateless + kernel-side desired tree + respawn-then-reapply" is a
+   sound crash model and keeps the reconciler trivial; the effect-minimality
+   assertions carry over as the contract for the production reconciler.
+4. `rejectAll` on process exit (inherited from the desktop supervisor design)
+   is exactly right — no in-flight caller ever hangs across a crash.
+
+## Spike 1 — kernel drives a full legacy-engine chain ⏳
+
+Pending.
+
+## Spike 2 — SQLite + sqlite-vec literature-store benchmark ⏳
+
+Pending.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,22 @@ importers:
         specifier: ^5.5.4
         version: 5.9.3
 
+  spikes/p0/3-rpc-reconcile:
+    dependencies:
+      '@polaris/kernel':
+        specifier: workspace:*
+        version: link:../../../src/kernel
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)
+
   src/desktop:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ packages:
   - src/kernel
   - vendor/deepseek-cordis/*
   - vendor/contract-smoke
-  - spikes/*
+  - spikes/p0/*

--- a/spikes/p0/3-rpc-reconcile/package.json
+++ b/spikes/p0/3-rpc-reconcile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "polaris-spike-rpc-reconcile",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@polaris/kernel": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.4",
+    "vitest": "^3.0.0"
+  }
+}

--- a/spikes/p0/3-rpc-reconcile/sidecar.py
+++ b/spikes/p0/3-rpc-reconcile/sidecar.py
@@ -1,0 +1,88 @@
+"""P0 Spike 3: minimal Python sidecar for the Node<->Python engine seam.
+
+Line-delimited JSON-RPC 2.0 over stdio, framing aligned with
+src/backend/app/mcp/__main__.py (one JSON object per line). Pure stdlib.
+
+State model: the sidecar holds a flat "live set" of config entries, mimicking
+a python-edge process that hosts components. `config.apply` reconciles the
+live set toward the pushed desired entries and reports each individual
+component action as a progress notification, so the Node reconciler can
+assert the minimal effect set. The process itself is stateless across
+restarts: after a crash the supervisor respawns it empty and the reconciler
+re-applies the desired tree (state lives in the kernel, not here).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+live: dict[str, dict[str, Any]] = {}
+
+
+def send(msg: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def notify(method: str, params: Any) -> None:
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def handle(method: str, params: Any) -> Any:
+    if method == "initialize":
+        return {"name": "spike-sidecar", "pid": __import__("os").getpid()}
+    if method == "echo":
+        return params
+    if method == "blob.echo":
+        # Large-payload probe: return the byte length plus a checksum-ish tail.
+        blob = params.get("blob", "") if isinstance(params, dict) else ""
+        return {"length": len(blob), "tail": blob[-16:]}
+    if method == "pdf.parse":
+        return {"pages": 0, "note": "stub"}
+    if method == "config.report":
+        return {"entries": sorted(live.values(), key=lambda e: e["id"])}
+    if method == "config.apply":
+        desired = {e["id"]: e for e in params.get("entries", [])}
+        actions: list[dict[str, str]] = []
+        for eid in sorted(set(live) - set(desired)):
+            del live[eid]
+            actions.append({"op": "stop", "id": eid})
+        for eid, entry in sorted(desired.items()):
+            if eid not in live:
+                live[eid] = entry
+                actions.append({"op": "start", "id": eid})
+            elif live[eid] != entry:
+                live[eid] = entry
+                actions.append({"op": "update", "id": eid})
+        for action in actions:
+            notify("config.progress", action)
+        return {"actions": actions}
+    raise ValueError(f"method not found: {method}")
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        mid = msg.get("id")
+        method = msg.get("method")
+        if not isinstance(method, str):
+            continue
+        try:
+            result = handle(method, msg.get("params"))
+            if mid is not None:
+                send({"jsonrpc": "2.0", "id": mid, "result": result})
+        except Exception as exc:  # noqa: BLE001 - single failure boundary
+            if mid is not None:
+                send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32000, "message": str(exc)}})
+
+
+if __name__ == "__main__":
+    main()

--- a/spikes/p0/3-rpc-reconcile/spike.test.ts
+++ b/spikes/p0/3-rpc-reconcile/spike.test.ts
@@ -1,0 +1,118 @@
+// P0 Spike 3 acceptance tests (see issue #574 and the P0 gate report).
+import { describe, expect, it } from 'vitest'
+import { Reconciler } from './src/reconciler.ts'
+import { Sidecar } from './src/supervisor.ts'
+
+const until = async (cond: () => boolean, ms = 5000) => {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+function percentile(samples: number[], p: number): number {
+  const sorted = [...samples].sort((a, b) => a - b)
+  return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))]!
+}
+
+describe('P0 spike 3: JSON-RPC seam + cross-process reconciler', () => {
+  it('bidirectional echo x1000 with RTT P95 < 5ms', async () => {
+    const sidecar = new Sidecar()
+    sidecar.start()
+    await sidecar.rpc.call('initialize')
+    // Warmup.
+    for (let i = 0; i < 50; i++) await sidecar.rpc.call('echo', { i })
+    const samples: number[] = []
+    for (let i = 0; i < 1000; i++) {
+      const t0 = performance.now()
+      const res = await sidecar.rpc.call('echo', { seq: i })
+      samples.push(performance.now() - t0)
+      if ((res as { seq: number }).seq !== i) throw new Error('echo mismatch')
+    }
+    const p95 = percentile(samples, 95)
+    // eslint-disable-next-line no-console
+    console.log(`echo RTT p50=${percentile(samples, 50).toFixed(2)}ms p95=${p95.toFixed(2)}ms p99=${percentile(samples, 99).toFixed(2)}ms`)
+    await sidecar.stop()
+    expect(p95).toBeLessThan(5)
+  }, 60_000)
+
+  it('5MB single-line payload survives framing in both directions', async () => {
+    const sidecar = new Sidecar()
+    sidecar.start()
+    const blob = 'x'.repeat(5 * 1024 * 1024 - 16) + 'END-OF-BLOB-MARK'
+    const res = (await sidecar.rpc.call('blob.echo', { blob })) as { length: number; tail: string }
+    await sidecar.stop()
+    expect(res.length).toBe(blob.length)
+    expect(res.tail).toBe('END-OF-BLOB-MARK')
+  }, 30_000)
+
+  it('add/update/remove each trigger exactly the minimal component effect set', async () => {
+    const r = new Reconciler()
+    await r.startProcess()
+
+    // Initial tree: two components.
+    await r.setDesired([
+      { id: 'src:openalex', name: 'openalex-source', config: { key: 'a' } },
+      { id: 'parse:grobid', name: 'grobid-parser', config: {} },
+    ])
+    expect(r.componentEffects().map((e) => `${e.op}:${e.id}`).sort()).toEqual([
+      'start:parse:grobid',
+      'start:src:openalex',
+    ])
+
+    // Add one component: only that one starts.
+    let mark = r.effects.length
+    await r.setDesired([
+      { id: 'src:openalex', name: 'openalex-source', config: { key: 'a' } },
+      { id: 'parse:grobid', name: 'grobid-parser', config: {} },
+      { id: 'src:pubmed', name: 'pubmed-source', config: {} },
+    ])
+    expect(r.componentEffects(mark).map((e) => `${e.op}:${e.id}`)).toEqual(['start:src:pubmed'])
+
+    // Update one component's config: only that one updates.
+    mark = r.effects.length
+    await r.setDesired([
+      { id: 'src:openalex', name: 'openalex-source', config: { key: 'b' } },
+      { id: 'parse:grobid', name: 'grobid-parser', config: {} },
+      { id: 'src:pubmed', name: 'pubmed-source', config: {} },
+    ])
+    expect(r.componentEffects(mark).map((e) => `${e.op}:${e.id}`)).toEqual(['update:src:openalex'])
+
+    // Remove + disable: exactly two stops, nothing else.
+    mark = r.effects.length
+    await r.setDesired([
+      { id: 'src:openalex', name: 'openalex-source', config: { key: 'b' } },
+      { id: 'parse:grobid', name: 'grobid-parser', config: {}, disabled: true },
+    ])
+    expect(r.componentEffects(mark).map((e) => `${e.op}:${e.id}`).sort()).toEqual([
+      'stop:parse:grobid',
+      'stop:src:pubmed',
+    ])
+
+    await r.sidecar.stop()
+  }, 30_000)
+
+  it('kill -9 recovers within 5s, converges, and rejects in-flight calls deterministically', async () => {
+    const r = new Reconciler()
+    await r.startProcess()
+    await r.setDesired([
+      { id: 'src:openalex', name: 'openalex-source', config: { key: 'a' } },
+      { id: 'src:pubmed', name: 'pubmed-source', config: {} },
+    ])
+    const beforeConverged = r.effects.filter((e) => e.op === 'converged').length
+
+    // An in-flight call must fail deterministically, not hang.
+    const inflight = r.sidecar.rpc.call('echo', { hang: true })
+    r.sidecar.child.kill('SIGKILL')
+    await expect(inflight).rejects.toThrow('sidecar exited')
+
+    // The supervisor respawns an empty sidecar; the reconciler re-applies the
+    // desired tree and converges again.
+    await until(() => r.effects.filter((e) => e.op === 'converged').length > beforeConverged)
+    expect(r.sidecar.restarts).toBe(1)
+    const report = (await r.sidecar.rpc.call('config.report')) as { entries: unknown[] }
+    expect(report.entries).toHaveLength(2)
+    await r.sidecar.stop()
+  }, 30_000)
+})

--- a/spikes/p0/3-rpc-reconcile/src/reconciler.ts
+++ b/spikes/p0/3-rpc-reconcile/src/reconciler.ts
@@ -1,0 +1,79 @@
+/* Cross-process config-tree reconciler prototype.
+
+   The kernel holds the desired tree; each edge process owns a live subset.
+   reconcile() diffs desired against the sidecar's reported state, pushes one
+   config.apply with the full desired set (the sidecar computes and reports
+   its own minimal action set), and verifies convergence via config.report.
+   Every externally visible step lands in an effect log so tests can assert
+   the minimal effect set. Crash recovery: on sidecar death the supervisor
+   respawns an empty process and reconcile() re-applies the desired tree —
+   state lives kernel-side only. */
+
+import type { ConfigEntry } from '@polaris/kernel'
+import { Sidecar } from './supervisor.ts'
+
+export interface Effect {
+  op: 'spawn' | 'stop' | 'start' | 'update' | 'apply' | 'converged'
+  id?: string
+}
+
+export class Reconciler {
+  readonly effects: Effect[] = []
+  desired: ConfigEntry[] = []
+  sidecar!: Sidecar
+  #reconciling: Promise<void> | null = null
+
+  async startProcess(): Promise<void> {
+    this.sidecar = new Sidecar({
+      onNotification: (method, params) => {
+        if (method === 'config.progress') {
+          const { op, id } = params as { op: Effect['op']; id: string }
+          this.effects.push({ op, id })
+        }
+      },
+      onExit: () => {
+        // Crash: respawn empty and drive back to the desired tree.
+        this.effects.push({ op: 'spawn' })
+        this.sidecar.restarts++
+        this.sidecar.start()
+        void this.reconcile()
+      },
+    })
+    this.effects.push({ op: 'spawn' })
+    this.sidecar.start()
+    await this.sidecar.rpc.call('initialize')
+  }
+
+  /** Set the desired tree and drive the sidecar to it. */
+  async setDesired(entries: ConfigEntry[]): Promise<void> {
+    this.desired = entries
+    await this.reconcile()
+  }
+
+  async reconcile(): Promise<void> {
+    // Serialize overlapping reconcile calls (crash recovery vs user edits).
+    while (this.#reconciling) await this.#reconciling
+    this.#reconciling = this.#doReconcile()
+    try {
+      await this.#reconciling
+    } finally {
+      this.#reconciling = null
+    }
+  }
+
+  async #doReconcile(): Promise<void> {
+    const enabled = this.desired.filter((e) => !e.disabled)
+    await this.sidecar.rpc.call('config.apply', { entries: enabled })
+    this.effects.push({ op: 'apply' })
+    const report = (await this.sidecar.rpc.call('config.report')) as { entries: ConfigEntry[] }
+    const got = JSON.stringify([...report.entries].sort((a, b) => a.id.localeCompare(b.id)))
+    const want = JSON.stringify([...enabled].sort((a, b) => a.id.localeCompare(b.id)))
+    if (got !== want) throw new Error(`not converged:\n got ${got}\nwant ${want}`)
+    this.effects.push({ op: 'converged' })
+  }
+
+  /** Component-level effects observed since the given index. */
+  componentEffects(since = 0): Effect[] {
+    return this.effects.slice(since).filter((e) => ['start', 'stop', 'update'].includes(e.op))
+  }
+}

--- a/spikes/p0/3-rpc-reconcile/src/supervisor.ts
+++ b/spikes/p0/3-rpc-reconcile/src/supervisor.ts
@@ -1,0 +1,42 @@
+/* Supervised Python sidecar: spawn, JSON-RPC endpoint, restart on death.
+   Prototype for the kernel's python-edge plugin (P1); findings feed the
+   P0 gate report. */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { JsonRpcEndpoint, type NotificationHandler } from '@polaris/kernel'
+
+const here = dirname(fileURLToPath(import.meta.url))
+export const SIDECAR = join(here, '..', 'sidecar.py')
+
+export interface SupervisorEvents {
+  onExit?: (code: number | null, signal: string | null) => void
+  onNotification?: NotificationHandler
+}
+
+export class Sidecar {
+  child!: ChildProcess
+  rpc!: JsonRpcEndpoint
+  restarts = 0
+
+  constructor(private readonly events: SupervisorEvents = {}) {}
+
+  start(): void {
+    this.child = spawn('python3', [SIDECAR], { stdio: ['pipe', 'pipe', 'inherit'] })
+    this.rpc = new JsonRpcEndpoint(this.child.stdin!, this.child.stdout!, {
+      onNotification: this.events.onNotification,
+    })
+    this.child.on('exit', (code, signal) => {
+      // Deterministic rejection of every in-flight request; the reconciler
+      // decides whether to respawn.
+      this.rpc.rejectAll(`sidecar exited (code=${code}, signal=${signal})`)
+      this.events.onExit?.(code, signal)
+    })
+  }
+
+  async stop(): Promise<void> {
+    this.child.kill()
+    await new Promise((r) => this.child.once('exit', r))
+  }
+}

--- a/spikes/p0/3-rpc-reconcile/tsconfig.json
+++ b/spikes/p0/3-rpc-reconcile/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "spike.test.ts"]
+}


### PR DESCRIPTION
## Summary

P0 Spike 3 (tracking #564): prototypes and validates the Node↔Python engine seam that the whole rebuild depends on.

- `spikes/p0/3-rpc-reconcile/sidecar.py` — pure-stdlib Python sidecar, line-delimited JSON-RPC 2.0 with framing aligned to `app/mcp/__main__.py`; hosts a flat live set of config entries and reports per-component actions as progress notifications
- `src/supervisor.ts` — spawn + `JsonRpcEndpoint` + deterministic `rejectAll` on exit
- `src/reconciler.ts` — desired tree → `config.apply` → effect log → `config.report` convergence check; crash model = stateless sidecar, respawn then re-apply
- `spike.test.ts` — the four acceptance bars from #574, all passing:
  - echo ×1000 RTT **P50 0.02ms / P95 0.03ms / P99 0.08ms** (bar: P95 < 5ms)
  - 5MB single-line payload survives framing both directions
  - add/update/remove each trigger exactly the minimal component effect set (effect-log equality)
  - kill -9: in-flight call rejects deterministically, respawn + reconverge < 5s
- `docs/rfcs/p0-spike-report.md` — gate report started with Spike 3 findings (notably: 5MB inline works but PDF-scale blobs should move via file paths or chunked notifications)

Workspace glob `spikes/*` → `spikes/p0/*` so the nested spike package resolves. Spike code is excluded from packaging and deletable wholesale.

## Verification

- `pnpm --dir spikes/p0/3-rpc-reconcile run test` — 4/4 passing (node-ci also runs on this path)

Closes #574