### PR TITLE
feat(spikes): benchmark SQLite + sqlite-vec for the local literature store

### DIFF
--- a/docs/rfcs/p0-spike-report.md
+++ b/docs/rfcs/p0-spike-report.md
@@ -44,6 +44,56 @@ Findings for the real python-edge plugin (P1):
 
 Pending.
 
-## Spike 2 — SQLite + sqlite-vec literature-store benchmark ⏳
+## Spike 2 — SQLite + sqlite-vec literature-store benchmark ✅ (conditional)
 
-Pending.
+Issue #576. Code: `spikes/p0/2-sqlite-bench` (bench.mjs + CI smoke at 2k scale).
+
+Setup: Node built-in `node:sqlite` driver + prebuilt sqlite-vec 0.1.7 loadable
+extension (zero native compilation), 1024-dim embeddings int8-quantized,
+`vec0` virtual table with `library_id` as partition key, FTS5
+external-content table, WAL. Synthetic reproducible data (seeded PRNG),
+10 libraries, 500 queries (200 at 500k) after warmup. Machine: macOS arm64.
+
+| Metric | 100k chunks | 500k chunks | Bar | Verdict |
+| --- | --- | --- | --- | --- |
+| Vector KNN (global scan) P95 | 101 ms | 477 ms | 80 / 200 ms | ❌ fails at both scales |
+| **Vector KNN (library-partitioned) P95** | **10.9 ms** | **48 ms** | 80 / 200 ms | ✅ 4–7× headroom |
+| FTS5 BM25 P95 | 1.3 ms | 8.1 ms | — | ✅ |
+| Hybrid RRF (global) P95 | 103 ms | 528 ms | 80 / 200 ms | ❌ global; partitioned hybrid ≈ partitioned KNN + FTS ✅ |
+| Cold open + first query | 95 ms | 440 ms | < 1.5 s | ✅ |
+| DB size | 0.19 GB | 0.93 GB | < 2 GB @500k | ✅ |
+| Ingest throughput | 10.9k rows/s | 11.1k rows/s | — | ✅ (500k in 45 s) |
+| int8 vs f32 top-20 overlap | 0.872 | 0.885 | ≥ 0.9 | ⚠️ see finding 2 |
+
+**Verdict: conditional pass — SQLite carries the local literature store if
+and only if vector search is library-partitioned.** This matches the
+product's dominant access pattern (relevance scoring, RAG, and evidence
+retrieval are all library-scoped), so it is a design rule, not a compromise.
+
+Findings:
+
+1. **Library partitioning is mandatory.** Brute-force global scan grows
+   linearly (≈0.9 ms per 1k chunks) and blows the bars beyond ~50k chunks;
+   the `vec0` partition key gives a clean 10× cut. Cross-library search must
+   fan out per-library and merge (or use a two-stage design) — recorded as a
+   storage-plugin design rule. If a future workload truly needs global ANN,
+   the escape hatches are LanceDB or sqlite-vec's planned ANN indexes.
+2. **int8 overlap 0.872–0.885 is a worst-case bound, not a failure.** The
+   synthetic vectors are uniform-random (isotropic), which maximizes
+   quantization damage; real embedding distributions are anisotropic and
+   quantize better. Follow-up recorded: re-measure on real bge-m3 vectors
+   during P1-A5 before freezing the quantization choice; f32 storage
+   (4× size) is the fallback.
+3. **`node:sqlite` + prebuilt sqlite-vec is a viable zero-compile path** for
+   the spike and possibly for production — worth keeping as an alternative to
+   better-sqlite3 (one less native build in the Electron packaging chain).
+   Two binding quirks recorded: integers must be bound as BigInt (numbers
+   arrive as FLOAT and vec0 partition keys reject them), and int8 vectors
+   must be wrapped in `vec_int8(?)` (raw 1024-byte blobs are otherwise
+   misread as float32).
+4. **Electron re-run is deferred to CI.** This development machine's Xcode
+   CLT installation is broken (libc++ headers missing entirely — no C++
+   compilation possible, better-sqlite3 unbuildable locally), so the
+   native-ABI-under-Electron leg moves to the packaging work (P1-A6) where
+   prebuilds and electron-rebuild run in CI. The `node:sqlite` numbers above
+   measure the same SQLite engine and are valid for the storage decision.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,19 @@ importers:
         specifier: ^5.5.4
         version: 5.9.3
 
+  spikes/p0/2-sqlite-bench:
+    dependencies:
+      sqlite-vec:
+        specifier: 0.1.7-alpha.2
+        version: 0.1.7-alpha.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)
+
   spikes/p0/3-rpc-reconcile:
     dependencies:
       '@polaris/kernel':
@@ -2449,6 +2462,34 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.7-alpha.2:
+    resolution: {integrity: sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==}
 
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
@@ -5137,6 +5178,29 @@ snapshots:
 
   sprintf-js@1.1.3:
     optional: true
+
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec@0.1.7-alpha.2:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.7-alpha.2
+      sqlite-vec-darwin-x64: 0.1.7-alpha.2
+      sqlite-vec-linux-arm64: 0.1.7-alpha.2
+      sqlite-vec-linux-x64: 0.1.7-alpha.2
+      sqlite-vec-windows-x64: 0.1.7-alpha.2
 
   ssri@9.0.1:
     dependencies:

--- a/spikes/p0/2-sqlite-bench/bench.mjs
+++ b/spikes/p0/2-sqlite-bench/bench.mjs
@@ -1,0 +1,206 @@
+// P0 Spike 2: can SQLite (FTS5 + sqlite-vec, int8) carry the local literature store?
+// Runs on the Node built-in sqlite driver (node:sqlite) + the prebuilt sqlite-vec
+// loadable extension — zero native compilation. (better-sqlite3 measures the same
+// SQLite engine through a different binding; the ABI/packaging chain for it is
+// exercised in CI where prebuilds exist.)
+// Usage: node bench.mjs [--count 100000] [--dim 1024] [--db /tmp/spike2.db] [--json out.json]
+import { DatabaseSync } from 'node:sqlite'
+import { getLoadablePath } from 'sqlite-vec'
+import { existsSync, rmSync, statSync, writeFileSync } from 'node:fs'
+
+const arg = (name, dflt) => {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 ? process.argv[i + 1] : dflt
+}
+const COUNT = Number(arg('count', 100_000))
+const DIM = Number(arg('dim', 1024))
+const DB_PATH = arg('db', `/tmp/spike2-${COUNT}.db`)
+const JSON_OUT = arg('json', '')
+const LIBRARIES = 10
+const QUERIES = Number(arg('queries', 500))
+const WARMUP = Number(arg('warmup', 100))
+
+// Deterministic PRNG (mulberry32) so runs are reproducible.
+function mulberry32(seed) {
+  return function () {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+const rand = mulberry32(42)
+
+const VOCAB = Array.from({ length: 5000 }, (_, i) => `term${i}`)
+function chunkText() {
+  const words = []
+  for (let i = 0; i < 60; i++) words.push(VOCAB[Math.floor(rand() * VOCAB.length)])
+  return words.join(' ')
+}
+
+// Random unit vector, then int8 quantization (x*127 clamp).
+function randomVec() {
+  const v = new Float32Array(DIM)
+  let norm = 0
+  for (let i = 0; i < DIM; i++) {
+    v[i] = rand() * 2 - 1
+    norm += v[i] * v[i]
+  }
+  norm = Math.sqrt(norm)
+  const q = new Int8Array(DIM)
+  for (let i = 0; i < DIM; i++) {
+    v[i] /= norm
+    q[i] = Math.max(-127, Math.min(127, Math.round(v[i] * 127)))
+  }
+  return { f32: v, i8: new Uint8Array(q.buffer) }
+}
+
+function percentile(samples, p) {
+  const s = [...samples].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]
+}
+const stats = (samples) => ({
+  p50: +percentile(samples, 50).toFixed(2),
+  p95: +percentile(samples, 95).toFixed(2),
+  p99: +percentile(samples, 99).toFixed(2),
+})
+
+const report = {
+  count: COUNT,
+  dim: DIM,
+  runtime: process.versions.electron ? `electron ${process.versions.electron}` : `node ${process.versions.node}`,
+  driver: 'node:sqlite',
+}
+const log = (...a) => console.log('[bench]', ...a)
+
+if (existsSync(DB_PATH)) rmSync(DB_PATH)
+const db = new DatabaseSync(DB_PATH, { allowExtension: true })
+db.loadExtension(getLoadablePath())
+db.exec('PRAGMA journal_mode = WAL')
+db.exec('PRAGMA synchronous = NORMAL')
+
+db.exec(`
+  CREATE TABLE chunks (id INTEGER PRIMARY KEY, library_id INTEGER NOT NULL, text TEXT NOT NULL);
+  CREATE VIRTUAL TABLE chunks_fts USING fts5(text, content='chunks', content_rowid='id');
+  CREATE VIRTUAL TABLE chunks_vec USING vec0(
+    library_id INTEGER partition key,
+    embedding int8[${DIM}] distance_metric=cosine
+  );
+`)
+
+// ---- ingest ----
+log(`ingesting ${COUNT} chunks (dim=${DIM}, int8) on ${report.runtime}...`)
+const t0 = performance.now()
+const insChunk = db.prepare('INSERT INTO chunks (id, library_id, text) VALUES (?, ?, ?)')
+const insFts = db.prepare('INSERT INTO chunks_fts (rowid, text) VALUES (?, ?)')
+const insVec = db.prepare('INSERT INTO chunks_vec (rowid, library_id, embedding) VALUES (?, ?, vec_int8(?))')
+const keepF32 = new Map() // sample of float vectors for the recall check
+let inBatch = 0
+db.exec('BEGIN')
+for (let id = 1; id <= COUNT; id++) {
+  const lib = 1 + Math.floor(rand() * LIBRARIES)
+  const vec = randomVec()
+  if (id <= 2000) keepF32.set(id, vec.f32)
+  const text = chunkText()
+  insChunk.run(BigInt(id), BigInt(lib), text)
+  insFts.run(BigInt(id), text)
+  insVec.run(BigInt(id), BigInt(lib), vec.i8)
+  if (++inBatch === 2000) {
+    db.exec('COMMIT')
+    db.exec('BEGIN')
+    inBatch = 0
+  }
+}
+db.exec('COMMIT')
+const ingestSec = (performance.now() - t0) / 1000
+report.ingest = { seconds: +ingestSec.toFixed(1), rowsPerSec: Math.round(COUNT / ingestSec) }
+log(`ingest: ${report.ingest.seconds}s (${report.ingest.rowsPerSec} rows/s)`)
+db.exec("INSERT INTO chunks_fts(chunks_fts) VALUES('optimize')")
+report.dbBytes = statSync(DB_PATH).size
+log(`db size: ${(report.dbBytes / 1e9).toFixed(2)} GB`)
+
+// ---- query helpers ----
+const qVec = db.prepare(
+  `SELECT rowid, distance FROM chunks_vec WHERE embedding MATCH vec_int8(?) AND k = 50 ORDER BY distance`,
+)
+const qVecLib = db.prepare(
+  `SELECT rowid, distance FROM chunks_vec WHERE embedding MATCH vec_int8(?) AND library_id = ? AND k = 50 ORDER BY distance`,
+)
+const qFts = db.prepare(
+  `SELECT rowid, rank FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY rank LIMIT 50`,
+)
+const queryVecs = Array.from({ length: QUERIES + WARMUP }, () => randomVec())
+const queryTerms = Array.from(
+  { length: QUERIES + WARMUP },
+  () => `${VOCAB[Math.floor(rand() * VOCAB.length)]} OR ${VOCAB[Math.floor(rand() * VOCAB.length)]}`,
+)
+
+function bench(name, fn) {
+  for (let i = 0; i < WARMUP; i++) fn(i)
+  const samples = []
+  for (let i = 0; i < QUERIES; i++) {
+    const t = performance.now()
+    fn(WARMUP + i)
+    samples.push(performance.now() - t)
+  }
+  report[name] = stats(samples)
+  log(`${name}: p50=${report[name].p50}ms p95=${report[name].p95}ms p99=${report[name].p99}ms`)
+}
+
+bench('vectorKnn', (i) => qVec.all(queryVecs[i].i8))
+bench('vectorKnnPartitioned', (i) => qVecLib.all(queryVecs[i].i8, BigInt(1 + (i % LIBRARIES))))
+bench('fts', (i) => qFts.all(queryTerms[i]))
+bench('hybridRrf', (i) => {
+  const v = qVec.all(queryVecs[i].i8)
+  const f = qFts.all(queryTerms[i])
+  const score = new Map()
+  v.forEach((r, rank) => score.set(r.rowid, (score.get(r.rowid) ?? 0) + 1 / (60 + rank)))
+  f.forEach((r, rank) => score.set(r.rowid, (score.get(r.rowid) ?? 0) + 1 / (60 + rank)))
+  ;[...score.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20)
+})
+
+// ---- int8 vs float32 recall (top-20 overlap, brute force over the f32 sample) ----
+{
+  const ids = [...keepF32.keys()]
+  let overlapSum = 0
+  const trials = 20
+  for (let t = 0; t < trials; t++) {
+    const q = queryVecs[t].f32
+    const dots = ids.map((id) => {
+      const v = keepF32.get(id)
+      let d = 0
+      for (let i = 0; i < DIM; i++) d += q[i] * v[i]
+      return [id, d]
+    })
+    const truth = new Set(dots.sort((a, b) => b[1] - a[1]).slice(0, 20).map(([id]) => id))
+    const qi = new Int8Array(queryVecs[t].i8.buffer)
+    const dotsQ = ids.map((id) => {
+      const v = keepF32.get(id)
+      let d = 0
+      for (let i = 0; i < DIM; i++) d += qi[i] * Math.max(-127, Math.min(127, Math.round(v[i] * 127)))
+      return [id, d]
+    })
+    const got = dotsQ.sort((a, b) => b[1] - a[1]).slice(0, 20).map(([id]) => id)
+    overlapSum += got.filter((id) => truth.has(id)).length / 20
+  }
+  report.int8Top20Overlap = +(overlapSum / trials).toFixed(3)
+  log(`int8 vs f32 top-20 overlap: ${report.int8Top20Overlap}`)
+}
+
+// ---- cold open + first query ----
+db.close()
+{
+  const t = performance.now()
+  const db2 = new DatabaseSync(DB_PATH, { readOnly: true, allowExtension: true })
+  db2.loadExtension(getLoadablePath())
+  db2
+    .prepare(`SELECT rowid FROM chunks_vec WHERE embedding MATCH vec_int8(?) AND k = 50 ORDER BY distance`)
+    .all(queryVecs[0].i8)
+  report.coldOpenFirstQueryMs = +(performance.now() - t).toFixed(0)
+  log(`cold open + first query: ${report.coldOpenFirstQueryMs}ms`)
+  db2.close()
+}
+
+if (JSON_OUT) writeFileSync(JSON_OUT, JSON.stringify(report, null, 2))
+log('done', JSON.stringify(report))

--- a/spikes/p0/2-sqlite-bench/package.json
+++ b/spikes/p0/2-sqlite-bench/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "polaris-spike-sqlite-bench",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "bench": "node bench.mjs",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "sqlite-vec": "0.1.7-alpha.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/spikes/p0/2-sqlite-bench/smoke.test.ts
+++ b/spikes/p0/2-sqlite-bench/smoke.test.ts
@@ -1,0 +1,25 @@
+// CI smoke: the benchmark pipeline runs end-to-end at a tiny scale.
+// Real gate numbers come from local runs recorded in docs/rfcs/p0-spike-report.md.
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { readFileSync, rmSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+describe('sqlite bench pipeline', () => {
+  it('runs end-to-end at small scale', () => {
+    const out = join(here, 'smoke-report.json')
+    execFileSync('node', [join(here, 'bench.mjs'), '--count', '2000', '--db', '/tmp/spike2-smoke.db', '--json', out], {
+      stdio: 'pipe',
+      timeout: 120_000,
+    })
+    const report = JSON.parse(readFileSync(out, 'utf8'))
+    rmSync(out)
+    rmSync('/tmp/spike2-smoke.db', { force: true })
+    expect(report.count).toBe(2000)
+    expect(report.vectorKnn.p95).toBeGreaterThan(0)
+    expect(report.int8Top20Overlap).toBeGreaterThan(0.8)
+  }, 120_000)
+})


### PR DESCRIPTION
## Summary

P0 Spike 2 (tracking #564): quantifies whether SQLite (FTS5 + sqlite-vec int8) can carry the local-first literature store. Runs on the Node built-in `node:sqlite` driver + the prebuilt sqlite-vec loadable extension — zero native compilation.

**Verdict: conditional pass — the bars are met if and only if vector search is library-partitioned**, which matches the product's dominant access pattern (relevance scoring, RAG, evidence retrieval are all library-scoped).

| Metric | 100k | 500k | Bar |
| --- | --- | --- | --- |
| Vector KNN global P95 | 101ms ❌ | 477ms ❌ | 80/200ms |
| **Vector KNN partitioned P95** | **10.9ms ✅** | **48ms ✅** | 80/200ms |
| FTS5 P95 | 1.3ms | 8.1ms | — |
| Cold open + first query | 95ms | 440ms | <1.5s |
| DB size | 0.19GB | 0.93GB | <2GB |
| int8 top-20 overlap | 0.872 | 0.885 | ≥0.9 ⚠️ worst-case bound (isotropic random vectors); re-measure on real embeddings in P1-A5 |

Key findings (full detail in `docs/rfcs/p0-spike-report.md`): library partitioning becomes a storage design rule (cross-library search = per-library fan-out + merge); `node:sqlite` + prebuilt sqlite-vec is a viable zero-compile alternative to better-sqlite3 (binding quirks recorded: BigInt for integers, `vec_int8()` wrapper for raw blobs); the Electron-ABI leg moves to CI packaging (P1-A6) because this dev machine's CLT is broken (no local C++ toolchain).

`spikes/p0/2-sqlite-bench` ships the reproducible bench (seeded PRNG) + a 2k-scale CI smoke test.

## Verification

- `pnpm --dir spikes/p0/2-sqlite-bench run test` — 1/1 (end-to-end pipeline at 2k scale)
- Full runs: `node bench.mjs --count 100000` / `--count 500000` (numbers above)

Closes #576