### PR TITLE
feat(backend): add desktop profile with inline task queue and in-process redis

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
 
     # ---- App ----
     env: Literal["dev", "prod"] = "dev"
+    # 运行档位：server = 现有多进程形态（uvicorn + arq worker + 外部 Redis/PG）；
+    # desktop = 单进程个人版（SQLite + 进程内任务队列 + 进程内 fakeredis），由
+    # 桌面内核拉起，机器上不需要任何外部服务。见 core/queue.py 与 core/redis.py。
+    profile: Literal["server", "desktop"] = "server"
     secret_key: str = "dev-only-secret-key-change-me"  # JWT 签名
     encryption_key: str = ""  # Fernet key；为空时 security.py 会从 secret_key 派生（仅限 dev）
     invite_code: str = "polaris-lab"  # 注册邀请码（实验室内部制）
@@ -244,6 +248,17 @@ class Settings(BaseSettings):
             logger.warning("env=prod：忽略 POLARIS_LLM_FAKE_FALLBACK=1，生产禁止 fake LLM 回退")
             object.__setattr__(self, "llm_fake_fallback", False)
         return self
+
+    @model_validator(mode="after")
+    def _desktop_forbids_prod(self) -> "Settings":
+        """desktop 档位是单机个人形态，与 env=prod 的多用户部署语义互斥。"""
+        if self.profile == "desktop" and self.env == "prod":
+            raise ValueError("POLARIS_PROFILE=desktop 不能与 POLARIS_ENV=prod 同时使用")
+        return self
+
+    @property
+    def is_desktop(self) -> bool:
+        return self.profile == "desktop"
 
     @property
     def is_sqlite(self) -> bool:

--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -4,11 +4,15 @@
 不依赖真实 Redis。
 """
 
+import asyncio
+import logging
 from typing import Any, Protocol
 
 from arq.connections import ArqRedis, RedisSettings, create_pool
 
 from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 # worker 实际注册在 WorkerSettings.functions 里的任务名，单一事实来源。
 # arq 只执行注册过的函数，入队一个没注册的名字会被**静默丢弃**——#216 就是这么
@@ -70,9 +74,77 @@ class ArqTaskQueue:
         self._pool = None
 
 
-_queue = ArqTaskQueue()
+class _InlineArqRedis:
+    """内联档位下 worker 任务 ctx["redis"] 的替身。
+
+    worker/tasks.py 里的任务把 ctx["redis"] 当 ArqRedis 用：既做普通 redis 操作
+    （EventBus pubsub 等），又调 ``enqueue_job`` 派生新任务。这里把属性访问代理到
+    进程内 redis 客户端，把 ``enqueue_job`` 转回内联队列——派生任务同样内联执行。
+    """
+
+    def __init__(self, queue: "InlineTaskQueue") -> None:
+        self._queue = queue
+
+    async def enqueue_job(self, func: str, *args: Any, **kwargs: Any) -> None:
+        await self._queue.enqueue(func, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        from app.core.redis import get_redis
+
+        return getattr(get_redis(), name)
+
+
+class InlineTaskQueue:
+    """desktop 档位：任务在 API 进程内直接执行，机器上不需要 Redis/arq worker。
+
+    语义对齐 arq 的最小子集：
+    - 只接受 ``WORKER_FUNCTIONS`` 注册过的任务名（同一事实来源、同样当场炸掉）；
+    - ``_job_id`` 保持「同 id 在途去重」语义（arq 用它防重复入队）；其余 arq 专属
+      下划线参数（``_defer_by`` 等）忽略——desktop 单用户场景没有延迟投递需求；
+    - cron 任务不在这里调度（桌面内核接管定时触发）。
+    """
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, asyncio.Task[Any]] = {}
+        self._seq = 0
+
+    async def enqueue(self, func: str, *args: Any, **kwargs: Any) -> None:
+        check_task_name(func)
+        job_id = kwargs.pop("_job_id", None)
+        kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+        if job_id is not None:
+            existing = self._tasks.get(job_id)
+            if existing is not None and not existing.done():
+                return  # 同 id 在途：对齐 arq 的去重语义
+        else:
+            self._seq += 1
+            job_id = f"inline-{self._seq}"
+
+        from worker import tasks as worker_tasks  # 懒导入避免 app↔worker 环
+
+        fn = getattr(worker_tasks, func)
+        ctx = {"redis": _InlineArqRedis(self)}
+        task = asyncio.create_task(fn(ctx, *args, **kwargs), name=f"inline:{func}")
+        self._tasks[job_id] = task
+        task.add_done_callback(lambda t, jid=job_id: self._finish(jid, t))
+
+    def _finish(self, job_id: str, task: asyncio.Task[Any]) -> None:
+        self._tasks.pop(job_id, None)
+        if not task.cancelled() and task.exception() is not None:
+            logger.error("inline task %s failed", task.get_name(), exc_info=task.exception())
+
+    async def drain(self) -> None:
+        """等待所有在途任务结束（测试与优雅停机用）。"""
+        while self._tasks:
+            await asyncio.gather(*list(self._tasks.values()), return_exceptions=True)
+
+
+_queue: TaskQueue | None = None
 
 
 async def get_task_queue() -> TaskQueue:
-    """FastAPI 依赖；测试覆盖为 stub。"""
+    """FastAPI 依赖；测试覆盖为 stub。按档位选择实现（进程级单例）。"""
+    global _queue
+    if _queue is None:
+        _queue = InlineTaskQueue() if get_settings().is_desktop else ArqTaskQueue()
     return _queue

--- a/src/backend/app/core/redis.py
+++ b/src/backend/app/core/redis.py
@@ -14,7 +14,14 @@ _client: Redis | None = None
 def get_redis() -> Redis:
     global _client
     if _client is None:
-        _client = Redis.from_url(get_settings().redis_url, decode_responses=True)
+        if get_settings().is_desktop:
+            # desktop 档位：单进程内嵌 redis 替身——API 与内联任务队列同进程，
+            # pubsub/缓存/事件流全部走进程内，机器上不需要 Redis 服务。
+            import fakeredis.aioredis
+
+            _client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        else:
+            _client = Redis.from_url(get_settings().redis_url, decode_responses=True)
     return _client
 
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "pycrdt-websocket>=0.15",
     "python-pptx>=1.0",
     "tzdata>=2025.2",
+    # desktop 档位运行时依赖（POLARIS_PROFILE=desktop：SQLite + 进程内 redis 替身）
+    "aiosqlite>=0.20",
+    "fakeredis>=2.26",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/tests/test_cors_desktop.py
+++ b/src/backend/tests/test_cors_desktop.py
@@ -21,7 +21,7 @@ def prod_client(monkeypatch):
     """构造 env=prod 的应用客户端；cors_origins 模拟 POLARIS_CORS_ORIGINS。"""
 
     def make(cors_origins: str = "") -> AsyncClient:
-        settings = Settings(env="prod", cors_origins=cors_origins)
+        settings = Settings(env="prod", profile="server", cors_origins=cors_origins)
         monkeypatch.setattr(main_module, "get_settings", lambda: settings)
         return AsyncClient(
             transport=ASGITransport(app=main_module.create_app()), base_url="http://test"
@@ -86,5 +86,6 @@ async def test_dev_still_allows_any_origin(client):
 
 
 def test_cors_origin_list_strips_and_drops_blanks():
-    assert Settings(env="prod", cors_origins=" a , ,b ").cors_origin_list == ["a", "b"]
-    assert Settings(env="prod", cors_origins="").cors_origin_list == []
+    prod = Settings(env="prod", profile="server", cors_origins=" a , ,b ")
+    assert prod.cors_origin_list == ["a", "b"]
+    assert Settings(env="prod", profile="server", cors_origins="").cors_origin_list == []

--- a/src/backend/tests/test_desktop_profile.py
+++ b/src/backend/tests/test_desktop_profile.py
@@ -1,0 +1,92 @@
+"""desktop 档位（POLARIS_PROFILE=desktop）：单进程、内联任务队列、进程内 redis。"""
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+from app.core.queue import InlineTaskQueue, UnregisteredTaskError
+
+
+def test_desktop_profile_forbids_prod_env():
+    with pytest.raises(ValidationError):
+        Settings(profile="desktop", env="prod")
+
+
+def test_desktop_profile_flag():
+    assert Settings(profile="desktop").is_desktop
+    # 显式钉 server：整套测试可能在 POLARIS_PROFILE=desktop 下运行（A2 验收方式）。
+    assert not Settings(profile="server").is_desktop
+
+
+@pytest.mark.asyncio
+async def test_inline_queue_executes_registered_task_in_process():
+    queue = InlineTaskQueue()
+    # ping_task 是注册表里最小的真实任务：内联执行完成即证明
+    # 「入队 → 进程内跑 worker 协程」这条链是通的。
+    await queue.enqueue("ping_task", "desktop")
+    await queue.drain()
+    assert queue._tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_inline_queue_rejects_unregistered_task():
+    queue = InlineTaskQueue()
+    with pytest.raises(UnregisteredTaskError):
+        await queue.enqueue("no_such_task")
+
+
+@pytest.mark.asyncio
+async def test_inline_queue_deduplicates_by_job_id(monkeypatch):
+    import worker.tasks as worker_tasks
+
+    started = []
+    release = asyncio.Event()
+
+    async def slow_task(ctx, message="x"):
+        started.append(message)
+        await release.wait()
+
+    monkeypatch.setattr(worker_tasks, "ping_task", slow_task)
+    queue = InlineTaskQueue()
+    await queue.enqueue("ping_task", "a", _job_id="same")
+    await queue.enqueue("ping_task", "b", _job_id="same")  # 在途同 id：丢弃
+    await asyncio.sleep(0)
+    release.set()
+    await queue.drain()
+    assert started == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_inline_ctx_redis_reenqueues_inline(monkeypatch):
+    """任务经 ctx["redis"].enqueue_job 派生的新任务同样内联执行。"""
+    import worker.tasks as worker_tasks
+
+    ran = []
+
+    async def parent(ctx, message="x"):
+        ran.append(f"parent:{message}")
+        await ctx["redis"].enqueue_job("match_user_publications", "child")
+
+    async def child(ctx, message="x"):
+        ran.append(f"child:{message}")
+
+    queue = InlineTaskQueue()
+    monkeypatch.setattr(worker_tasks, "ping_task", parent)
+    monkeypatch.setattr(worker_tasks, "match_user_publications", child)
+    await queue.enqueue("ping_task", "root")
+    await queue.drain()
+    assert ran == ["parent:root", "child:child"]
+
+
+def test_desktop_redis_is_in_process(monkeypatch):
+    import app.core.redis as redis_mod
+
+    monkeypatch.setattr(redis_mod, "_client", None)
+    monkeypatch.setattr(
+        "app.core.redis.get_settings", lambda: Settings(profile="desktop")
+    )
+    client = redis_mod.get_redis()
+    assert type(client).__module__.startswith("fakeredis")
+    monkeypatch.setattr(redis_mod, "_client", None)


### PR DESCRIPTION
## Summary

P1-A2 (tracking #564): `POLARIS_PROFILE=desktop` runs the backend as **one process with zero external services** — the precondition for the personal desktop shell.

- **InlineTaskQueue** (`app/core/queue.py`): implements the existing `TaskQueue` protocol; `enqueue` validates against `WORKER_FUNCTIONS` (same single source of truth, same fail-fast), then executes the registered worker coroutine in-process via asyncio. The arq-compatible ctx carries a redis shim whose `enqueue_job` routes derived tasks back inline; `_job_id` keeps arq's in-flight dedup semantics; other arq-only underscore kwargs are ignored; cron scheduling is intentionally absent (the desktop kernel takes over scheduling in a later PR).
- **In-process redis** (`app/core/redis.py`): under the desktop profile the lazy singleton resolves to a process-local FakeRedis, so pubsub/eventstream/caches work single-process.
- **Config** (`app/core/config.py`): `profile: server|desktop` with a structural guard — `desktop`+`env=prod` is rejected at settings construction.
- `aiosqlite` and `fakeredis` move to runtime dependencies (SQLite is already the default database).
- Prod-CORS tests pin `profile="server"` explicitly so the entire suite can run under `POLARIS_PROFILE=desktop`.

## Verification

- New tests (7): profile guard, inline execution of a registered task, unregistered-task rejection, `_job_id` dedup, inline re-enqueue via ctx redis shim, in-process redis wiring — pass under both profiles.
- Full suite under `POLARIS_PROFILE=desktop`: **1514 passed, 3 deselected** (the deselections are pre-existing failures on main, unrelated to this change — see #581).
- Full suite under the default profile: unchanged (same 2+1 pre-existing failures only).
- `ruff check` clean on touched files.

Closes #580