### PR TITLE
test(backend): add golden-transcript regression harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dist/
 
 # --- Data / runtime ---
 data/
+# golden transcripts are committed test fixtures, not runtime data
+!src/backend/tests/golden/data/
 logs/
 *.sqlite3
 *.db

--- a/src/backend/tests/golden/data/import_wiki.json
+++ b/src/backend/tests/golden/data/import_wiki.json
@@ -1,0 +1,184 @@
+{
+  "add_paper_bibtex": {
+    "abstract": "Synthetic record for the golden transcript harness: manual import, fake librarian compile, and index bookkeeping with zero network access.",
+    "affiliations": [],
+    "arxiv_id": null,
+    "authors": [
+      {
+        "affiliations": [],
+        "name": "Probe, Golden"
+      },
+      {
+        "affiliations": [],
+        "name": "Chain, Import"
+      }
+    ],
+    "compiled_at": null,
+    "compiled_by_name": null,
+    "compiled_model": null,
+    "concepts": [],
+    "created_at": "<ts>",
+    "doi": null,
+    "figures": [],
+    "has_wiki": false,
+    "id": "<uuid-4>",
+    "library_id": "<uuid-2>",
+    "my_tags": [],
+    "note_count": 0,
+    "pdf_available": false,
+    "project_id": null,
+    "published_at": null,
+    "reading_status": "unread",
+    "relevance_score": null,
+    "starred": false,
+    "status": "included",
+    "tags": [],
+    "task_id": null,
+    "title": "Deterministic Golden Chain Probe",
+    "tldr": null,
+    "trash_reason": null,
+    "url": null,
+    "venue": "Journal of Reproducible Plumbing",
+    "wiki_content": null,
+    "year": 2026
+  },
+  "create_library": {
+    "cadence": null,
+    "can_manage": true,
+    "concept_count": 0,
+    "created_at": "<ts>",
+    "definition": {
+      "statement": "Deterministic golden-transcript library covering reproducible plumbing."
+    },
+    "id": "<uuid-2>",
+    "interdisciplinary_domains": null,
+    "is_mine": false,
+    "is_owner": true,
+    "is_public": false,
+    "last_compiled_at": null,
+    "last_synced_at": null,
+    "library_kind": "standard",
+    "monthly_budget": null,
+    "name": "Golden Library",
+    "owner_name": "Golden Probe",
+    "paper_count": 0,
+    "project_id": null,
+    "review_note": null,
+    "statement": "Deterministic golden-transcript library covering reproducible plumbing.",
+    "status": "active",
+    "submitted_by": "<uuid-1>",
+    "updated_at": "<ts>"
+  },
+  "create_project": {
+    "created_at": "<ts>",
+    "id": "<uuid-3>",
+    "name": "Golden Project",
+    "owner_id": "<uuid-1>",
+    "research_mode": "conventional",
+    "slug": "golden-project",
+    "statement": "golden transcript chain",
+    "status": "active",
+    "updated_at": "<ts>"
+  },
+  "index_rebuild": {
+    "chunk_count": 1,
+    "chunk_source": "abstract",
+    "chunk_vector": {
+      "built": true,
+      "built_at": "<ts>",
+      "model": "fake-default",
+      "stale": false
+    },
+    "embedded_chunk_count": 1,
+    "has_fulltext": false,
+    "paper_vector": {
+      "built": true,
+      "built_at": "<ts>",
+      "model": "fake-default",
+      "stale": false
+    }
+  },
+  "index_status": {
+    "chunk_count": 1,
+    "chunk_source": "abstract",
+    "chunk_vector": {
+      "built": true,
+      "built_at": "<ts>",
+      "model": "fake-default",
+      "stale": false
+    },
+    "embedded_chunk_count": 1,
+    "has_fulltext": false,
+    "paper_vector": {
+      "built": true,
+      "built_at": "<ts>",
+      "model": "fake-default",
+      "stale": false
+    }
+  },
+  "login": {
+    "access_token": "<token>",
+    "token_type": "bearer"
+  },
+  "recompile_wiki": {
+    "abstract": "Synthetic record for the golden transcript harness: manual import, fake librarian compile, and index bookkeeping with zero network access.",
+    "affiliations": [],
+    "arxiv_id": null,
+    "authors": [
+      {
+        "affiliations": [],
+        "name": "Probe, Golden"
+      },
+      {
+        "affiliations": [],
+        "name": "Chain, Import"
+      }
+    ],
+    "compiled_at": "<ts>",
+    "compiled_by_name": "Golden Probe",
+    "compiled_model": "fake-default",
+    "concepts": [],
+    "created_at": "<ts>",
+    "doi": null,
+    "figures": [],
+    "has_wiki": true,
+    "id": "<uuid-4>",
+    "library_id": "<uuid-2>",
+    "my_tags": [],
+    "note_count": 0,
+    "pdf_available": false,
+    "project_id": null,
+    "published_at": null,
+    "reading_status": "unread",
+    "relevance_score": null,
+    "starred": false,
+    "status": "included",
+    "tags": [],
+    "task_id": null,
+    "title": "Deterministic Golden Chain Probe",
+    "tldr": "Deterministic Golden Chain Probe 的一句话总结（fake librarian）。",
+    "trash_reason": null,
+    "url": null,
+    "venue": "Journal of Reproducible Plumbing",
+    "wiki_content": "## TL;DR\n\nDeterministic Golden Chain Probe 的一句话总结（fake librarian）。\n\n## 研究背景与动机\n\n围绕 [[Agent]] 场景的关键问题展开叙述（fake）。\n\n## 方法\n\n提出基于 [[Agent]] 与 [[强化学习]] 的方法，分段展开讲解（fake）。\n\n## 实验与结果\n\n在多个基准上验证有效（fake）。\n\n## 讨论与可借鉴点\n\n可复用其训练流程，局限在于评测范围（fake）。\n\n<!-- polaris-ai-evidence:{\"version\":1,\"mode\":\"abstract_only\",\"paper_count\":1,\"refs\":[{\"article_no\":1,\"sentence_no\":1,\"paper_id\":\"<uuid-4>\",\"href\":\"/papers/<uuid-4>/read?evidence=1\",\"source\":\"abstract_only\"}]} -->\n",
+    "year": 2026
+  },
+  "register": {
+    "display_name": "Golden Probe",
+    "email": "golden@example.com",
+    "features": null,
+    "has_avatar": false,
+    "id": "<uuid-1>",
+    "is_active": true,
+    "is_superuser": false,
+    "is_verified": false,
+    "llm_access": "full",
+    "llm_self_managed": false,
+    "read_only": false,
+    "role": "admin",
+    "settings": null,
+    "token_quota": null,
+    "username": "goldenprobe",
+    "username_locked": false
+  }
+}

--- a/src/backend/tests/golden/normalize.py
+++ b/src/backend/tests/golden/normalize.py
@@ -1,0 +1,47 @@
+"""Golden transcript 归一化：把响应里的易变值替换成稳定占位符。
+
+规则（顺序敏感，UUID 按首见顺序编号，跨步骤稳定）：
+- UUID 字符串 → ``<uuid-N>``
+- ISO 时间戳 → ``<ts>``
+- JWT（三段 base64url）→ ``<token>``
+- 临时目录绝对路径 → ``<path>``
+
+其余内容必须逐字节稳定——fake provider 与 bibtex 离线导入保证这一点。
+"""
+
+import re
+from typing import Any
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_UUID_INLINE_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$")
+_JWT_RE = re.compile(r"^[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}$")
+_PATH_RE = re.compile(r"(/private)?/(tmp|var)/[^\s\"]*")
+
+
+class Normalizer:
+    def __init__(self) -> None:
+        self._uuids: dict[str, str] = {}
+
+    def _uuid(self, value: str) -> str:
+        if value not in self._uuids:
+            self._uuids[value] = f"<uuid-{len(self._uuids) + 1}>"
+        return self._uuids[value]
+
+    def normalize(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: self.normalize(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self.normalize(v) for v in obj]
+        if isinstance(obj, str):
+            if _UUID_RE.match(obj):
+                return self._uuid(obj)
+            if _TS_RE.match(obj):
+                return "<ts>"
+            if _JWT_RE.match(obj):
+                return "<token>"
+            # 长文本里内嵌的 uuid / 路径（如 wiki 里的图片链接、错误信息）
+            obj = _UUID_INLINE_RE.sub(lambda m: self._uuid(m.group(0)), obj)
+            obj = _PATH_RE.sub("<path>", obj)
+            return obj
+        return obj

--- a/src/backend/tests/golden/test_golden_import_wiki.py
+++ b/src/backend/tests/golden/test_golden_import_wiki.py
@@ -1,0 +1,130 @@
+"""Golden transcript：注册 → 建库 → 建课题 → bibtex 导入 → wiki 编译 → 索引状态。
+
+整条链在 fake provider + sqlite 上确定性运行，每步响应归一化后与
+``tests/golden/data/import_wiki.json`` 逐字节比对。
+
+这是 B 轨（去实验室化移除）的回归闸门：**纯移除 PR 必须保持 golden 不变**。
+golden 变了 = 行为变了，需要人工审查 diff 并说明理由。
+
+更新方式（仅限本地，CI 只比对，纪律来自 DSH 的 snapshot 流程）::
+
+    POLARIS_GOLDEN=record python -m pytest tests/golden -q
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import INVITE_CODE
+from tests.golden.normalize import Normalizer
+
+GOLDEN_PATH = Path(__file__).parent / "data" / "import_wiki.json"
+
+BIBTEX = """@article{golden2026probe,
+  title = {Deterministic Golden Chain Probe},
+  author = {Probe, Golden and Chain, Import},
+  journal = {Journal of Reproducible Plumbing},
+  year = {2026},
+  abstract = {Synthetic record for the golden transcript harness: manual import,
+fake librarian compile, and index bookkeeping with zero network access.}
+}"""
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_import_wiki_chain_matches_golden(client):
+    n = Normalizer()
+    transcript: dict[str, object] = {}
+
+    async def step(name: str, resp, expect: int) -> dict:
+        assert resp.status_code == expect, f"{name}: {resp.status_code} {resp.text[:300]}"
+        body = resp.json()
+        transcript[name] = n.normalize(body)
+        return body
+
+    await step(
+        "register",
+        await client.post(
+            "/api/auth/register",
+            json={
+                "email": "golden@example.com",
+                "password": "str0ng-password",
+                "display_name": "Golden Probe",
+                "username": "goldenprobe",
+                "invite_code": INVITE_CODE,
+            },
+        ),
+        201,
+    )
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": "golden@example.com", "password": "str0ng-password"},
+    )
+    await step("login", login, 200)
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+    library = await step(
+        "create_library",
+        await client.post(
+            "/api/libraries",
+            json={
+                "name": "Golden Library",
+                "statement": (
+                    "Deterministic golden-transcript library covering reproducible plumbing."
+                ),
+            },
+            headers=headers,
+        ),
+        201,
+    )
+    project = await step(
+        "create_project",
+        await client.post(
+            "/api/projects",
+            json={
+                "name": "Golden Project",
+                "statement": "golden transcript chain",
+                "source_library_ids": [library["id"]],
+            },
+            headers=headers,
+        ),
+        201,
+    )
+    paper = await step(
+        "add_paper_bibtex",
+        await client.post(
+            f"/api/projects/{project['id']}/papers", json={"bibtex": BIBTEX}, headers=headers
+        ),
+        201,
+    )
+    await step(
+        "recompile_wiki",
+        await client.post(f"/api/papers/{paper['id']}/recompile", headers=headers),
+        200,
+    )
+    await step(
+        "index_rebuild",
+        await client.post(f"/api/papers/{paper['id']}/index/rebuild", headers=headers),
+        200,
+    )
+    await step(
+        "index_status",
+        await client.get(f"/api/papers/{paper['id']}/index-status", headers=headers),
+        200,
+    )
+
+    rendered = json.dumps(transcript, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if os.environ.get("POLARIS_GOLDEN") == "record":
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(rendered, encoding="utf-8")
+        pytest.skip(f"golden recorded: {GOLDEN_PATH}")
+    assert GOLDEN_PATH.exists(), (
+        "golden 文件缺失：本地用 POLARIS_GOLDEN=record 录制一次并连同代码提交"
+    )
+    expected = GOLDEN_PATH.read_text(encoding="utf-8")
+    assert rendered == expected, (
+        "golden transcript 变了。若这是有意的行为变更：本地 POLARIS_GOLDEN=record 重录，"
+        "人工审查 diff 后随代码一起提交；纯移除 PR 不允许改 golden。"
+    )


### PR DESCRIPTION
## Summary

P1-C1 (tracking #564; ordered before the bulk of the track-B removals). Adds the golden-transcript harness that turns "pure removal" into a machine-checkable property:

- `tests/golden/test_golden_import_wiki.py` drives register → create library → create project (linked) → manual **bibtex** import (offline) → wiki recompile (fake librarian) → index rebuild → index status, entirely on the fake LLM provider and sqlite
- `tests/golden/normalize.py` replaces volatile values with stable placeholders — UUIDs become `<uuid-N>` in first-seen order (cross-step identity is preserved), ISO timestamps `<ts>`, JWTs `<token>`, tmp paths `<path>`
- the rendered transcript is compared **byte-for-byte** against `tests/golden/data/import_wiki.json`
- `POLARIS_GOLDEN=record` rewrites goldens locally and skips; CI only compares — golden diffs must be reviewed by a human with the change that caused them (recording discipline borrowed from DSH's snapshot flow)
- every track-B removal PR must keep this golden unchanged; a golden diff means behavior changed

Follow-up (separate PR): a second golden chain covering one voyage round.

## Verification

- Recorded once, then replayed 3× — stable byte-for-byte; golden contains zero raw UUIDs/timestamps
- `ruff check tests/golden` clean

Closes #582