### PR TITLE
chore: remove the skill-market review flow and ratings

### DIFF
--- a/src/backend/alembic/versions/d4b8e26f1a93_drop_skill_ratings.py
+++ b/src/backend/alembic/versions/d4b8e26f1a93_drop_skill_ratings.py
@@ -1,0 +1,46 @@
+"""移除技能市场评分表 skill_ratings（部署内互评，个人化定位下撤除）
+
+同批移除：市场审核流（approve/reject/pending 队列）；发布改为直接上架。
+skill_listings 的 status 列保留（approved/delisted 仍在用）。
+
+Revision ID: d4b8e26f1a93
+Revises: c8f2a61d9e37
+Create Date: 2026-09-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4b8e26f1a93"
+down_revision: str | None = "c8f2a61d9e37"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index(op.f("ix_skill_ratings_listing_id"), table_name="skill_ratings")
+    op.drop_table("skill_ratings")
+
+
+def downgrade() -> None:
+    # 复原 f5a6b7c8d9e0 的形状（数据不可恢复）。
+    op.create_table(
+        "skill_ratings",
+        sa.Column("listing_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["listing_id"], ["skill_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "user_id", name="uq_skill_ratings_user"),
+    )
+    op.create_index(
+        op.f("ix_skill_ratings_listing_id"), "skill_ratings", ["listing_id"], unique=False
+    )

--- a/src/backend/app/api/market.py
+++ b/src/backend/app/api/market.py
@@ -1,8 +1,7 @@
 """技能市场路由（docs/skill-system.md §4.3）。
 
-- 发布：POST /skills/{id}/publish（技能主人）→ pending，管理员审核
-- 浏览/详情/安装/评分：登录即可（部署内共享）
-- 审核 approve/reject：仅管理员；下架：发布者或管理员
+- 发布：POST /skills/{id}/publish（技能主人）→ 直接上架
+- 浏览/详情/安装：登录即可；下架：发布者或管理员
 """
 
 import uuid
@@ -10,18 +9,15 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user, require_admin
+from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.models.skill import SkillListing, SkillVersion
 from app.models.user import User
 from app.schemas.skill import (
-    ListingDecision,
     SkillDetail,
     SkillListingDetail,
     SkillListingRead,
     SkillPublishRequest,
-    SkillRatingCreate,
-    SkillRatingRead,
 )
 from app.services import skill_market as market_service
 from app.services import skills as skills_service
@@ -68,14 +64,11 @@ async def publish_skill(
 async def list_market(
     q: str | None = Query(default=None, max_length=100),
     sort: str = Query(default="-created_at", pattern="^(-created_at|installs)$"),
-    status_filter: str = Query(default="approved", alias="status", pattern="^(approved|pending)$"),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[SkillListingRead]:
-    """市场列表。status=pending 为管理员审核队列（非管理员 403）。"""
-    if status_filter == "pending" and user.role != "admin":
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="ADMIN_REQUIRED")
-    listings = await market_service.list_market(session, status=status_filter, q=q, sort=sort)
+    """市场列表（仅已上架条目）。"""
+    listings = await market_service.list_market(session, status="approved", q=q, sort=sort)
     return [
         SkillListingRead(**d) for d in await market_service.annotate_listings(session, listings)
     ]
@@ -117,49 +110,6 @@ async def install_listing(
     return detail
 
 
-@router.post("/market/skills/{listing_id}/approve", response_model=SkillListingRead)
-async def approve_listing(
-    listing_id: uuid.UUID,
-    data: ListingDecision | None = None,
-    session: AsyncSession = Depends(get_session),
-    admin: User = Depends(require_admin),
-) -> SkillListingRead:
-    return await _decide(session, listing_id, admin, approved=True, data=data)
-
-
-@router.post("/market/skills/{listing_id}/reject", response_model=SkillListingRead)
-async def reject_listing(
-    listing_id: uuid.UUID,
-    data: ListingDecision | None = None,
-    session: AsyncSession = Depends(get_session),
-    admin: User = Depends(require_admin),
-) -> SkillListingRead:
-    return await _decide(session, listing_id, admin, approved=False, data=data)
-
-
-async def _decide(
-    session: AsyncSession,
-    listing_id: uuid.UUID,
-    admin: User,
-    *,
-    approved: bool,
-    data: ListingDecision | None,
-) -> SkillListingRead:
-    listing = await _get_listing(session, listing_id)
-    try:
-        listing = await market_service.decide_listing(
-            session,
-            listing,
-            approved=approved,
-            decided_by=admin.id,
-            comment=data.comment if data else None,
-        )
-    except market_service.ListingStateError as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LISTING_ALREADY_DECIDED") from e
-    listing = await _get_listing(session, listing.id)
-    return SkillListingRead(**(await market_service.annotate_listings(session, [listing]))[0])
-
-
 @router.delete("/market/skills/{listing_id}", response_model=SkillListingRead)
 async def delist_listing(
     listing_id: uuid.UUID,
@@ -175,33 +125,3 @@ async def delist_listing(
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="NOT_LISTING_OWNER") from e
     listing = await _get_listing(session, listing.id)
     return SkillListingRead(**(await market_service.annotate_listings(session, [listing]))[0])
-
-
-@router.get("/market/skills/{listing_id}/reviews", response_model=list[SkillRatingRead])
-async def list_reviews(
-    listing_id: uuid.UUID,
-    session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
-) -> list[SkillRatingRead]:
-    await _get_listing(session, listing_id)
-    ratings = await market_service.list_ratings(session, listing_id)
-    return [SkillRatingRead.model_validate(r) for r in ratings]
-
-
-@router.post(
-    "/market/skills/{listing_id}/reviews",
-    response_model=SkillRatingRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_review(
-    listing_id: uuid.UUID,
-    data: SkillRatingCreate,
-    session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
-) -> SkillRatingRead:
-    listing = await _get_listing(session, listing_id)
-    try:
-        rating = await market_service.upsert_rating(session, listing, user_id=user.id, data=data)
-    except market_service.ListingStateError as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LISTING_NOT_APPROVED") from e
-    return SkillRatingRead.model_validate(rating)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -61,7 +61,7 @@ from app.models.project import Project, ProjectMember
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.research_digest import LibraryResearchDigest
 from app.models.review import ReviewMessage, ReviewSession
-from app.models.skill import Skill, SkillListing, SkillRating, SkillVersion, UserSkill
+from app.models.skill import Skill, SkillListing, SkillVersion, UserSkill
 from app.models.ssh_credential import SSHCredential
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
@@ -137,7 +137,6 @@ __all__ = [
     "SSHCredential",
     "Skill",
     "SkillListing",
-    "SkillRating",
     "SkillVersion",
     "SystemSetting",
     "TimestampMixin",

--- a/src/backend/app/models/skill.py
+++ b/src/backend/app/models/skill.py
@@ -6,7 +6,6 @@
 - UserSkill：全局启用记录：用户 × 技能 × 注入点，可 pin 版本与配置
   （技能不绑定课题，启用后对该用户所有新任务生效）
 - SkillListing：技能市场条目（发布指向具体版本，管理员审核后可安装）
-- SkillRating：市场评分（每人每条目一条，可更新）
 """
 
 import uuid
@@ -115,17 +114,3 @@ class SkillListing(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     skill: Mapped[Skill] = relationship()
     version: Mapped[SkillVersion] = relationship()
-
-
-class SkillRating(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    __tablename__ = "skill_ratings"
-    __table_args__ = (UniqueConstraint("listing_id", "user_id", name="uq_skill_ratings_user"),)
-
-    listing_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("skill_listings.id", ondelete="CASCADE"), index=True, nullable=False
-    )
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
-    rating: Mapped[int] = mapped_column(Integer, nullable=False)  # 1-5
-    comment: Mapped[str | None] = mapped_column(Text)

--- a/src/backend/app/schemas/skill.py
+++ b/src/backend/app/schemas/skill.py
@@ -249,8 +249,6 @@ class SkillListingRead(BaseModel):
     # 联表补充（service 填充）
     skill: SkillRead | None = None
     version: int | None = None
-    rating_avg: float | None = None
-    rating_count: int = 0
 
 
 class SkillListingDetail(SkillListingRead):
@@ -258,26 +256,6 @@ class SkillListingDetail(SkillListingRead):
 
     manifest: dict[str, Any] | None = None
     body: str | None = None
-
-
-class SkillRatingCreate(BaseModel):
-    rating: int = Field(ge=1, le=5)
-    comment: str | None = Field(default=None, max_length=2000)
-
-
-class SkillRatingRead(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: uuid.UUID
-    listing_id: uuid.UUID
-    user_id: uuid.UUID
-    rating: int
-    comment: str | None
-    created_at: datetime
-
-
-class ListingDecision(BaseModel):
-    comment: str | None = Field(default=None, max_length=2000)
 
 
 class UserSkillRead(BaseModel):

--- a/src/backend/app/services/skill_market.py
+++ b/src/backend/app/services/skill_market.py
@@ -1,6 +1,6 @@
 """技能市场业务逻辑（docs/skill-system.md §4.3；不 import fastapi）。
 
-部署内共享：发布（pending）→ 管理员审核（approved/rejected）→ 浏览/安装/评分。
+部署内共享：发布即上架（approved）→ 浏览/安装。
 listing 永远指向发布时的具体 SkillVersion；安装 = 拷贝该版本为安装者的 user 技能。
 """
 
@@ -8,15 +8,15 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.skill import Skill, SkillListing, SkillRating, SkillVersion
-from app.schemas.skill import SkillPublishRequest, SkillRatingCreate
+from app.models.skill import Skill, SkillListing, SkillVersion
+from app.schemas.skill import SkillPublishRequest
 from app.services import skills as skills_service
 
-ACTIVE_STATUSES = ("pending", "approved")
+ACTIVE_STATUSES = ("approved",)
 
 
 class ListingConflictError(Exception):
@@ -24,7 +24,7 @@ class ListingConflictError(Exception):
 
 
 class ListingStateError(Exception):
-    """条目状态不允许该操作（如审核非 pending、安装非 approved）。"""
+    """条目状态不允许该操作（如安装非 approved 条目）。"""
 
 
 class NotOwnerError(Exception):
@@ -34,7 +34,7 @@ class NotOwnerError(Exception):
 async def publish_skill(
     session: AsyncSession, skill: Skill, *, user_id: uuid.UUID, data: SkillPublishRequest
 ) -> SkillListing:
-    """发布当前版本到市场（pending，待管理员审核）。builtin 不需要发布。"""
+    """发布当前版本到市场（直接上架）。builtin 不需要发布。"""
     if skill.scope == "builtin" or skill.owner_id != user_id:
         raise NotOwnerError(skill.slug)
     version = await skills_service.latest_version(session, skill.id)
@@ -48,6 +48,7 @@ async def publish_skill(
     listing = SkillListing(
         skill_id=skill.id,
         skill_version_id=version.id,
+        status="approved",
         summary=data.summary or skill.description,
         tags=data.tags or None,
         published_by=user_id,
@@ -56,22 +57,6 @@ async def publish_skill(
     await session.commit()
     await session.refresh(listing)
     return listing
-
-
-async def _rating_stats(
-    session: AsyncSession, listing_ids: list[uuid.UUID]
-) -> dict[uuid.UUID, tuple[float, int]]:
-    if not listing_ids:
-        return {}
-    stmt = (
-        select(SkillRating.listing_id, func.avg(SkillRating.rating), func.count())
-        .where(SkillRating.listing_id.in_(listing_ids))
-        .group_by(SkillRating.listing_id)
-    )
-    return {
-        lid: (round(float(avg), 2), int(count))
-        for lid, avg, count in (await session.execute(stmt)).all()
-    }
 
 
 def _base_read(listing: SkillListing) -> dict[str, Any]:
@@ -99,16 +84,8 @@ def _base_read(listing: SkillListing) -> dict[str, Any]:
 async def annotate_listings(
     session: AsyncSession, listings: Sequence[SkillListing]
 ) -> list[dict[str, Any]]:
-    """联表读数据 + 评分聚合，输出 SkillListingRead 字典列表。"""
-    stats = await _rating_stats(session, [listing.id for listing in listings])
-    out = []
-    for listing in listings:
-        data = _base_read(listing)
-        avg_count = stats.get(listing.id)
-        if avg_count:
-            data["rating_avg"], data["rating_count"] = avg_count
-        out.append(data)
-    return out
+    """联表读数据，输出 SkillListingRead 字典列表。"""
+    return [_base_read(listing) for listing in listings]
 
 
 def _listing_query():
@@ -140,24 +117,6 @@ async def list_market(
 async def get_listing(session: AsyncSession, listing_id: uuid.UUID) -> SkillListing | None:
     stmt = _listing_query().where(SkillListing.id == listing_id)
     return (await session.execute(stmt)).scalar_one_or_none()
-
-
-async def decide_listing(
-    session: AsyncSession,
-    listing: SkillListing,
-    *,
-    approved: bool,
-    decided_by: uuid.UUID,
-    comment: str | None = None,
-) -> SkillListing:
-    if listing.status != "pending":
-        raise ListingStateError(listing.status)
-    listing.status = "approved" if approved else "rejected"
-    listing.decided_by = decided_by
-    listing.comment = comment
-    await session.commit()
-    await session.refresh(listing)
-    return listing
 
 
 async def delist(
@@ -224,31 +183,3 @@ async def _copy_as_user_skill(
         )
     )
     return skill
-
-
-async def upsert_rating(
-    session: AsyncSession, listing: SkillListing, *, user_id: uuid.UUID, data: SkillRatingCreate
-) -> SkillRating:
-    if listing.status != "approved":
-        raise ListingStateError(listing.status)
-    stmt = select(SkillRating).where(
-        SkillRating.listing_id == listing.id, SkillRating.user_id == user_id
-    )
-    rating = (await session.execute(stmt)).scalar_one_or_none()
-    if rating is None:
-        rating = SkillRating(listing_id=listing.id, user_id=user_id)
-        session.add(rating)
-    rating.rating = data.rating
-    rating.comment = data.comment
-    await session.commit()
-    await session.refresh(rating)
-    return rating
-
-
-async def list_ratings(session: AsyncSession, listing_id: uuid.UUID) -> Sequence[SkillRating]:
-    stmt = (
-        select(SkillRating)
-        .where(SkillRating.listing_id == listing_id)
-        .order_by(SkillRating.created_at.desc())
-    )
-    return (await session.execute(stmt)).scalars().all()

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -10,7 +10,8 @@ from alembic import command
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
 HEAD_REVISION = "f3a4b5c6d7e8"  # Scheduled incremental literature discovery
-HEAD_REVISION = "c8f2a61d9e37"  # Drop view events (P1 de-lab)
+HEAD_REVISION = "d4b8e26f1a93"  # Drop skill ratings (P1 de-lab)
+RANKINGS_DROP_REVISION = "c8f2a61d9e37"  # Drop view events (P1 de-lab)
 INVITES_DROP_REVISION = "b7d4f92e6c15"  # Drop project invites (P1 de-lab)
 CODES_DROP_REVISION = "a3e9c17b5f42"  # Drop registration codes (P1 de-lab)
 TRANSLATIONS_REVISION = "f4a5b6c7d8e9"  # Versioned discovery-hit translations
@@ -248,8 +249,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"skills", "skill_versions", "user_skills"} <= columns["_tables"]
     assert "project_skills" not in columns["_tables"]
     assert "project_id" not in columns["skills"]
-    # 技能市场 S4：skill_listings / skill_ratings 表
-    assert {"skill_listings", "skill_ratings"} <= columns["_tables"]
+    # 技能市场 S4：skill_listings 表（skill_ratings 已在 P1 去实验室化中移除）
+    assert "skill_listings" in columns["_tables"]
     # 发表机构列（高级检索）
     assert "affiliations" in columns["papers"]
     # 用户系统 U1：users 三新列 + project_invites 表
@@ -514,7 +515,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "evidence_balance",
     } <= columns["interdisciplinary_research_profile_versions"]
 
-    # First undo the view-events drop: the table comes back.
+    # First undo the skill-ratings drop: the table comes back.
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == RANKINGS_DROP_REVISION
+    assert "skill_ratings" in columns["_tables"]
+
+    # Then undo the view-events drop: that table comes back too.
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == INVITES_DROP_REVISION

--- a/src/backend/tests/test_skill_market.py
+++ b/src/backend/tests/test_skill_market.py
@@ -18,8 +18,6 @@ SKILL_PAYLOAD = {
 }
 
 
-# 注意：首个注册用户自动成为平台 admin（auth 自举逻辑），
-# 因此 alice = 管理员兼发布者，403 断言用第二个用户 bob（member）
 
 
 async def _login(client, email="alice@example.com"):
@@ -31,62 +29,38 @@ async def _publish(client, headers) -> tuple[str, str]:
     skill = (await client.post("/api/skills", json=SKILL_PAYLOAD, headers=headers)).json()
     resp = await client.post(
         f"/api/skills/{skill['id']}/publish",
-        json={"summary": "推荐给全实验室", "tags": ["评分", "idea"]},
+        json={"summary": "推荐给大家", "tags": ["评分", "idea"]},
         headers=headers,
     )
     assert resp.status_code == 201, resp.text
     return skill["id"], resp.json()["id"]
 
 
-async def test_publish_review_flow(client):
-    headers = await _login(client)  # alice：首个用户 = admin
+async def test_publish_lists_immediately(client):
+    headers = await _login(client)
     _skill_id, listing_id = await _publish(client, headers)
+
+    # 发布即上架：任何登录用户立即可见
+    headers_b = await _login(client, email="bob@example.com")
+    market = (await client.get("/api/market/skills", headers=headers_b)).json()
+    assert [m["id"] for m in market] == [listing_id]
+    assert market[0]["status"] == "approved"
+    assert market[0]["skill"]["slug"] == "market-rubric"
+    assert market[0]["version"] == 1
 
     # 重复发布 409
     mine = (await client.get("/api/skills?scope=mine", headers=headers)).json()
     resp = await client.post(f"/api/skills/{mine[0]['id']}/publish", json={}, headers=headers)
     assert resp.status_code == 409
 
-    # 非管理员（bob）看不了审核队列、不能审核
-    headers_b = await _login(client, email="bob@example.com")
-    assert (
-        await client.get("/api/market/skills?status=pending", headers=headers_b)
-    ).status_code == 403
-    assert (
-        await client.post(f"/api/market/skills/{listing_id}/approve", headers=headers_b)
-    ).status_code == 403
-    # 管理员能看到审核队列
-    pending = (await client.get("/api/market/skills?status=pending", headers=headers)).json()
-    assert [p["id"] for p in pending] == [listing_id]
-
-    # pending 条目不出现在市场列表
-    assert (await client.get("/api/market/skills", headers=headers)).json() == []
-
-    # 管理员审核通过
-    resp = await client.post(
-        f"/api/market/skills/{listing_id}/approve", json={"comment": "内容合规"}, headers=headers
-    )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["status"] == "approved"
-    # 二次审核 409
-    assert (
-        await client.post(f"/api/market/skills/{listing_id}/approve", headers=headers)
-    ).status_code == 409
-
-    market = (await client.get("/api/market/skills", headers=headers)).json()
-    assert [m["id"] for m in market] == [listing_id]
-    assert market[0]["skill"]["slug"] == "market-rubric"
-    assert market[0]["version"] == 1
-
     # 详情含全文预览
     detail = (await client.get(f"/api/market/skills/{listing_id}", headers=headers)).json()
     assert detail["body"] == "严格打分。"
 
 
-async def test_install_rating_and_delist(client):
-    headers_a = await _login(client)  # alice：首个用户 = admin
+async def test_install_and_delist(client):
+    headers_a = await _login(client)
     _skill_id, listing_id = await _publish(client, headers_a)
-    await client.post(f"/api/market/skills/{listing_id}/approve", headers=headers_a)
 
     # 另一个用户安装 → 拷为自己的 user 技能
     headers_b = await _login(client, email="bob@example.com")
@@ -98,24 +72,8 @@ async def test_install_rating_and_delist(client):
     assert installed["current_version"]["body"] == "严格打分。"
     mine_b = (await client.get("/api/skills?scope=mine", headers=headers_b)).json()
     assert [s["slug"] for s in mine_b] == ["market-rubric"]
-
-    # 评分（可更新，同人只一条）+ 聚合
-    await client.post(
-        f"/api/market/skills/{listing_id}/reviews",
-        json={"rating": 4, "comment": "好用"},
-        headers=headers_b,
-    )
-    resp = await client.post(
-        f"/api/market/skills/{listing_id}/reviews", json={"rating": 5}, headers=headers_b
-    )
-    assert resp.status_code == 201
-    reviews = (
-        await client.get(f"/api/market/skills/{listing_id}/reviews", headers=headers_b)
-    ).json()
-    assert len(reviews) == 1 and reviews[0]["rating"] == 5
     market = (await client.get("/api/market/skills", headers=headers_b)).json()
     assert market[0]["install_count"] == 1
-    assert market[0]["rating_avg"] == 5.0 and market[0]["rating_count"] == 1
 
     # 发布者下架 → 市场不可见、安装 409
     resp = await client.delete(f"/api/market/skills/{listing_id}", headers=headers_a)

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -13,7 +13,6 @@ import { useIsCompact } from '../../lib/useBreakpoint';
 import { useProject } from '../../app/project';
 import {
   api,
-  isAdmin,
   skillTargetLabel,
   skillKindLabel,
   SKILL_TARGETS,
@@ -157,11 +156,11 @@ function SkillDetailModal({
   const publishMutation = useMutation({
     mutationFn: () => api.publishSkill(skillId),
     onSuccess: () => {
-      toast(tr('已提交发布，等待管理员审核', 'Submitted for admin review'), 'ok');
+      toast(tr('已发布到市场', 'Published to the market'), 'ok');
       void queryClient.invalidateQueries({ queryKey: ['market-skills'] });
     },
     onError: (e) =>
-      toast(e instanceof Error && e.message === 'ALREADY_LISTED' ? tr('该技能已在市场（或待审核中）', 'Already on the market (or pending review)') : `${tr('发布失败', 'Publish failed')}：${errMsg(e)}`, 'error'),
+      toast(e instanceof Error && e.message === 'ALREADY_LISTED' ? tr('该技能已在市场', 'Already on the market') : `${tr('发布失败', 'Publish failed')}：${errMsg(e)}`, 'error'),
   });
   const archiveMutation = useMutation({
     mutationFn: () => api.archiveSkill(skillId),
@@ -569,16 +568,6 @@ function SkillCreateModal({ onClose, onCreated }: { onClose: () => void; onCreat
 
 // ---- 技能市场 ----
 
-function Stars({ avg, count }: { avg: number | null; count: number }) {
-  if (!count) return <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{tr('暂无评分', 'No ratings yet')}</span>;
-  return (
-    <span style={{ fontSize: 11.5, color: 'var(--warn-tx)' }}>
-      ★ {avg?.toFixed(1)}
-      <span style={{ color: 'var(--text-3)', marginLeft: 4 }}>{tr(`（${count} 人）`, `(${count})`)}</span>
-    </span>
-  );
-}
-
 function ListingCard({ l, onOpen }: { l: SkillListingRead; onOpen: () => void }) {
   return (
     <button
@@ -595,30 +584,25 @@ function ListingCard({ l, onOpen }: { l: SkillListingRead; onOpen: () => void })
         <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-3)' }}>{tr(`${l.install_count} 次安装`, `${l.install_count} installs`)}</span>
       </div>
       {l.summary && <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 6, lineHeight: 1.5 }}>{l.summary}</div>}
-      <div className="row gap8" style={{ marginTop: 8, alignItems: 'center' }}>
-        <Stars avg={l.rating_avg} count={l.rating_count} />
-        {(l.tags ?? []).map((t) => (
-          <span key={t} className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
-            {t}
-          </span>
-        ))}
-      </div>
+      {(l.tags ?? []).length > 0 && (
+        <div className="row gap8" style={{ marginTop: 8, alignItems: 'center' }}>
+          {(l.tags ?? []).map((t) => (
+            <span key={t} className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
     </button>
   );
 }
 
 function ListingDetailModal({ listingId, onClose }: { listingId: string; onClose: () => void }) {
   const queryClient = useQueryClient();
-  const [myRating, setMyRating] = useState(0);
-  const [myComment, setMyComment] = useState('');
 
   const { data: listing } = useQuery({
     queryKey: ['market-skill', listingId],
     queryFn: () => api.getMarketSkill(listingId),
-  });
-  const { data: reviews } = useQuery({
-    queryKey: ['market-reviews', listingId],
-    queryFn: () => api.listListingReviews(listingId),
   });
 
   const installMutation = useMutation({
@@ -629,16 +613,6 @@ function ListingDetailModal({ listingId, onClose }: { listingId: string; onClose
       void queryClient.invalidateQueries({ queryKey: ['market-skills'] });
     },
     onError: (e) => toast(`${tr('安装失败', 'Install failed')}：${errMsg(e)}`, 'error'),
-  });
-  const rateMutation = useMutation({
-    mutationFn: () => api.addListingReview(listingId, { rating: myRating, comment: myComment.trim() || undefined }),
-    onSuccess: () => {
-      toast(tr('评分已提交', 'Rating submitted'), 'ok');
-      setMyComment('');
-      void queryClient.invalidateQueries({ queryKey: ['market-reviews', listingId] });
-      void queryClient.invalidateQueries({ queryKey: ['market-skills'] });
-    },
-    onError: (e) => toast(`${tr('评分失败', 'Rating failed')}：${errMsg(e)}`, 'error'),
   });
 
   if (!listing) return null;
@@ -679,74 +653,19 @@ function ListingDetailModal({ listingId, onClose }: { listingId: string; onClose
           {listing.body}
         </pre>
       )}
-
-      {/* 我的评分 */}
-      <div className="row gap8" style={{ marginTop: 14, alignItems: 'center' }}>
-        {[1, 2, 3, 4, 5].map((n) => (
-          <button
-            key={n}
-            className="icon-btn"
-            style={{ width: 26, height: 26, color: n <= myRating ? 'var(--warn-tx)' : 'var(--text-3)', border: 'none', background: 'transparent', fontSize: 16 }}
-            onClick={() => setMyRating(n)}
-            aria-label={tr(`${n} 星`, `${n} stars`)}
-          >
-            {n <= myRating ? '★' : '☆'}
-          </button>
-        ))}
-        <input
-          className="input"
-          style={{ flex: 1 }}
-          placeholder={tr('用后感受（可选）', 'Your experience (optional)')}
-          value={myComment}
-          onChange={(e) => setMyComment(e.target.value)}
-        />
-        <button className="btn btn-soft" disabled={!myRating || rateMutation.isPending} onClick={() => rateMutation.mutate()}>
-          {tr('提交评分', 'Submit rating')}
-        </button>
-      </div>
-
-      {(reviews ?? []).length > 0 && (
-        <div style={{ marginTop: 12 }}>
-          {reviews!.map((r) => (
-            <div key={r.id} className="row gap8" style={{ padding: '5px 0', alignItems: 'baseline' }}>
-              <span style={{ fontSize: 11.5, color: 'var(--warn-tx)', flexShrink: 0 }}>{'★'.repeat(r.rating)}</span>
-              <span style={{ fontSize: 12, color: 'var(--text-2)' }}>{r.comment ?? ''}</span>
-            </div>
-          ))}
-        </div>
-      )}
     </Modal>
   );
 }
 
 function MarketView() {
-  const queryClient = useQueryClient();
   const [q, setQ] = useState('');
   const [sort, setSort] = useState<'-created_at' | 'installs'>('-created_at');
   const [openListing, setOpenListing] = useState<string | null>(null);
-
-  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => api.me(), retry: false, staleTime: 60_000 });
-  const admin = isAdmin(me);
 
   const { data: listings, isLoading, isError } = useQuery({
     queryKey: ['market-skills', sort, q],
     queryFn: () => api.listMarketSkills({ q: q || undefined, sort }),
     retry: false,
-  });
-  const { data: pending } = useQuery({
-    queryKey: ['market-skills', 'pending'],
-    queryFn: () => api.listMarketSkills({ status: 'pending' }),
-    retry: false,
-    enabled: admin,
-  });
-
-  const decideMutation = useMutation({
-    mutationFn: ({ id, decision }: { id: string; decision: 'approve' | 'reject' }) => api.decideListing(id, decision),
-    onSuccess: (listing) => {
-      toast(listing.status === 'approved' ? tr('已上架', 'Listed') : tr('已驳回', 'Rejected'), 'ok');
-      void queryClient.invalidateQueries({ queryKey: ['market-skills'] });
-    },
-    onError: (e) => toast(`${tr('审核失败', 'Review failed')}：${errMsg(e)}`, 'error'),
   });
 
   return (
@@ -763,31 +682,11 @@ function MarketView() {
         <input className="input" style={{ width: 200, marginLeft: 'auto' }} placeholder={tr('搜索市场…', 'Search market…')} value={q} onChange={(e) => setQ(e.target.value)} />
       </div>
 
-      {admin && (pending ?? []).length > 0 && (
-        <div className="card" style={{ padding: '14px 16px', marginBottom: 14, borderLeft: '3px solid var(--warn-tx)' }}>
-          <div style={{ fontSize: 13, fontWeight: 660, marginBottom: 8 }}>{tr('待审核（管理员）', 'Pending review (admin)')}</div>
-          {pending!.map((l) => (
-            <div key={l.id} className="row gap8" style={{ padding: '5px 0', alignItems: 'center' }}>
-              <span style={{ fontSize: 12.5, fontWeight: 600 }}>{l.skill?.name}</span>
-              <span style={{ fontSize: 11.5, color: 'var(--text-3)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {l.summary}
-              </span>
-              <button className="btn btn-soft" style={{ fontSize: 11.5, padding: '3px 10px' }} onClick={() => decideMutation.mutate({ id: l.id, decision: 'approve' })}>
-                {tr('通过', 'Approve')}
-              </button>
-              <button className="btn btn-ghost" style={{ fontSize: 11.5, padding: '3px 10px' }} onClick={() => decideMutation.mutate({ id: l.id, decision: 'reject' })}>
-                {tr('驳回', 'Reject')}
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
       <div style={{ display: 'grid', gap: 10 }}>
         {isError ? (
           <EmptyState icon="sparkle" title={tr('市场加载失败', 'Failed to load market')} desc={tr('后端服务未启动或版本过旧', 'Backend not running or too old')} />
         ) : isLoading ? null : (listings ?? []).length === 0 ? (
-          <EmptyState icon="sparkle" title={tr('市场还是空的', 'The market is empty')} desc={tr('在技能库把你的技能发布到市场，审核通过后即可安装', 'Publish your skills from the library; once approved they can be installed')} />
+          <EmptyState icon="sparkle" title={tr('市场还是空的', 'The market is empty')} desc={tr('在技能库把你的技能发布到市场，发布后大家就能安装', 'Publish your skills from the library so others can install them')} />
         ) : (
           listings!.map((l) => <ListingCard key={l.id} l={l} onOpen={() => setOpenListing(l.id)} />)
         )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2972,22 +2972,11 @@ export interface SkillListingRead {
   created_at: string;
   skill: SkillRead | null;
   version: number | null;
-  rating_avg: number | null;
-  rating_count: number;
 }
 
 export interface SkillListingDetail extends SkillListingRead {
   manifest: SkillManifest | null;
   body: string | null;
-}
-
-export interface SkillRatingRead {
-  id: string;
-  listing_id: string;
-  user_id: string;
-  rating: number;
-  comment: string | null;
-  created_at: string;
 }
 
 /** 跨部署分享的技能包（format 固定 polaris-skill@1）。 */
@@ -5481,17 +5470,14 @@ export const api = {
   },
 
   // —— Skills · 技能市场（docs/skill-system.md §4.3） ——
-  /** 发布我的技能到市场（当前版本），管理员审核后全员可安装。 */
+  /** 发布我的技能到市场（当前版本），发布后全员可安装。 */
   publishSkill(id: string, input: { summary?: string; tags?: string[] } = {}): Promise<SkillListingRead> {
     return requestJson<SkillListingRead>(`/skills/${id}/publish`, 'POST', input);
   },
-  listMarketSkills(
-    opts: { q?: string; sort?: '-created_at' | 'installs'; status?: 'approved' | 'pending' } = {},
-  ): Promise<SkillListingRead[]> {
+  listMarketSkills(opts: { q?: string; sort?: '-created_at' | 'installs' } = {}): Promise<SkillListingRead[]> {
     const params = new URLSearchParams();
     if (opts.q) params.set('q', opts.q);
     if (opts.sort) params.set('sort', opts.sort);
-    if (opts.status) params.set('status', opts.status);
     const qs = params.toString();
     return request<SkillListingRead[]>(`/market/skills${qs ? `?${qs}` : ''}`);
   },
@@ -5502,17 +5488,8 @@ export const api = {
   installMarketSkill(listingId: string): Promise<SkillDetail> {
     return request<SkillDetail>(`/market/skills/${listingId}/install`, { method: 'POST' });
   },
-  decideListing(listingId: string, decision: 'approve' | 'reject', comment?: string): Promise<SkillListingRead> {
-    return requestJson<SkillListingRead>(`/market/skills/${listingId}/${decision}`, 'POST', comment ? { comment } : {});
-  },
   delistListing(listingId: string): Promise<SkillListingRead> {
     return request<SkillListingRead>(`/market/skills/${listingId}`, { method: 'DELETE' });
-  },
-  listListingReviews(listingId: string): Promise<SkillRatingRead[]> {
-    return request<SkillRatingRead[]>(`/market/skills/${listingId}/reviews`);
-  },
-  addListingReview(listingId: string, input: { rating: number; comment?: string }): Promise<SkillRatingRead> {
-    return requestJson<SkillRatingRead>(`/market/skills/${listingId}/reviews`, 'POST', input);
   },
 
   // —— 我的文献库（跨研究方向的个人收藏 + 浏览记录，issue #108） ——


### PR DESCRIPTION
## Summary

P1-B4 (tracking #564), de-lab removal. The skill market's approval pipeline (publish → pending → admin approve/reject) and per-deployment ratings are lab-governance features; on the individual platform, publishing lists immediately and there is no rating audience.

Backend:
- publish → `status="approved"` directly; `ACTIVE_STATUSES` narrows to `("approved",)`; the pending queue filter (+ its 403) leaves the market list endpoint
- approve/reject endpoints + `_decide` + `decide_listing` removed; `ListingDecision` schema removed
- reviews endpoints, `upsert_rating`/`list_ratings`/`_rating_stats`, `SkillRating` model + `skill_ratings` table (`d4b8e26f1a93`; downgrade recreates the original schema; roundtrip chain gains the reversibility step); `rating_avg`/`rating_count` leave `SkillListingRead`
- browse/detail/install/delist unchanged; `skill_listings.status` column stays (approved/delisted in use)

Frontend:
- admin review queue (pending query + approve/reject buttons), `Stars` component + rating display, review form + history, three api-client functions + `SkillRatingRead`, `listMarketSkills` status param; copy updated (publish = 直接上架)

Tests: the publish→review→approve flow tests are replaced by publish-lists-immediately + install/delist tests; migration schema assertions updated.

## Verification

- **Golden transcript (#582) byte-identical**
- Backend suite: **1498 passed, 3 deselected** (pre-existing, #581) — flat vs the B3 baseline (2 old flow tests out, 2 new semantics tests in)
- Frontend build clean; zero residual references
- `ruff check` clean on touched files

Closes #591