### PR TITLE
feat(desktop): mount @polaris/kernel in the main process

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
+      # The desktop shell imports @polaris/kernel, whose vendored cordis runtime
+      # ships TypeScript sources; tsc must resolve the declaration output instead
+      # of re-checking those sources under the shell's strict options.
+      - name: Build vendored type declarations
+        run: pnpm run vendor:types
+
       - name: Build renderer
         run: pnpm --dir src/frontend run build
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -91,6 +91,12 @@ jobs:
         shell: bash
         run: pnpm install --frozen-lockfile
 
+      # See desktop-build.yml: the shell's typecheck/build needs the vendored
+      # runtime's declaration output, not its raw TypeScript sources.
+      - name: Build vendored type declarations
+        shell: bash
+        run: pnpm run vendor:types
+
       - name: Build renderer
         shell: bash
         run: pnpm --dir src/frontend run build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,10 @@ importers:
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)
 
   src/desktop:
+    dependencies:
+      '@polaris/kernel':
+        specifier: workspace:*
+        version: link:../kernel
     devDependencies:
       '@types/node':
         specifier: ^22.0.0

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -20,6 +20,9 @@
     "dist:win": "pnpm run build && electron-builder --win",
     "dist:linux": "pnpm run build && electron-builder --linux"
   },
+  "dependencies": {
+    "@polaris/kernel": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "electron": "^33.0.0",

--- a/src/desktop/src/main/index.ts
+++ b/src/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, shell } from 'electron';
 
 import { installIpc } from './ipc/router';
+import { startKernel, stopKernel } from './kernel';
 import { installMenu } from './menu';
 import { APP_ORIGIN, handleAppProtocol, registerAppScheme } from './protocol';
 import { readConfig } from './store';
@@ -31,7 +32,10 @@ if (!app.requestSingleInstanceLock()) {
     // 一期不处理跳转目标，只保证协议已注册、不会把 URL 当文件打开
   });
 
-  void app.whenReady().then(() => {
+  void app.whenReady().then(async () => {
+    // 内核先于 IPC：installIpc 一装好 renderer 就可能打 kernel.status，
+    // 不能让它读到「还没启动」的假象。start 本身不做 IO，不拖慢首窗。
+    await startKernel();
     app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
     handleAppProtocol(() => readConfig().serverUrl);
     installIpc();
@@ -41,6 +45,19 @@ if (!app.requestSingleInstanceLock()) {
     app.on('activate', () => {
       if (!getWindow()) createWindow();
     });
+  });
+
+  // 退出路径统一走 before-quit（cmd+Q、菜单退出、window-all-closed 的 app.quit
+  // 都会经过这里）。kernel.stop 是异步的（fiber.dispose 级联回收），而 Electron
+  // 的退出流程不等 Promise，所以第一次先拦下退出、停完内核再重新 quit。
+  let kernelStopping = false;
+  app.on('before-quit', (event) => {
+    if (kernelStopping) return;
+    kernelStopping = true;
+    event.preventDefault();
+    void stopKernel()
+      .catch((err) => console.error('[kernel] stop failed:', err))
+      .finally(() => app.quit());
   });
 
   // 全局兜底：任何新建的 webContents（含未来可能出现的子窗口）都不允许

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -20,6 +20,7 @@ import {
   type RpcRequest,
 } from '../../shared/contract';
 import { capabilityManifest } from '../capabilities';
+import { kernelStatus } from '../kernel';
 import { applyUpdate, checkForUpdate } from '../updates';
 import * as host from './methods.host';
 import * as local from './methods.local';
@@ -52,6 +53,7 @@ const HANDLERS: Record<MethodName, Handler> = {
   'host.capabilities': () => capabilityManifest(),
   'host.update.check': () => checkForUpdate(),
   'host.update.apply': () => applyUpdate(),
+  'kernel.status': () => kernelStatus(),
   // local.* 一期全部走到 agent 再以 ERR_CAPABILITY_UNAVAILABLE 结束（见 methods.local.ts）
   'local.latex.compile': (p) => local.latexCompile(p),
   'local.fs.pickFolder': (p) => local.pickFolder(p),

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -1,0 +1,57 @@
+/* ============================================================
+   @polaris/kernel 在桌面主进程里的挂载点。
+
+   与 agent/supervisor.ts 同样的组织方式：模块级单例 + 具名访问函数，
+   不把 kernel 实例挂到全局或到处传。生命周期绑定 app：
+   ready 时 start，退出路径 stop（fiber.dispose 级联回收所有插件注册
+   的副作用——计时器、监听器、子进程）。
+
+   一期内核里只有一个探针插件：不做任何事，存在本身就证明 cordis 插件
+   树被真的建起来了（kernel.status 的 plugins 计数由它兜底 ≥ 1）。
+   后续阶段把 config 树、进程监督、legacy engine 逐个装进来时，
+   改的只有这里的装载列表。
+   ============================================================ */
+
+import { createKernel, type Kernel } from '@polaris/kernel';
+
+import type { KernelStatus } from '../shared/contract';
+
+let kernel: Kernel | null = null;
+
+/** 空探针插件。命名走 kebab-case，与将来的 config-tree / legacy-engine 一致。 */
+const desktopProbe = {
+  name: 'desktop-probe',
+  apply(): void {
+    /* 故意为空：只占一个 registry 名额 */
+  },
+};
+
+/** 幂等启动：重复调用返回同一实例（app ready 与 smoke 都可能触发）。 */
+export async function startKernel(): Promise<Kernel> {
+  if (kernel) return kernel;
+  const instance = createKernel({ name: 'polaris-desktop' });
+  instance.ctx.plugin(desktopProbe);
+  await instance.start();
+  kernel = instance;
+  return instance;
+}
+
+/** 停机：dispose 根 fiber，级联回收。幂等，未启动时是 no-op。 */
+export async function stopKernel(): Promise<void> {
+  const instance = kernel;
+  kernel = null;
+  if (instance) await instance.stop();
+}
+
+/**
+ * kernel.status 的实现。plugins 用 ctx.registry.size —— cordis 公开文档口径
+ * 「已注册插件 runtime 的数量」（vendor/deepseek-cordis/cordis/src/registry.ts），
+ * 不数 fiber：同一插件多次装载仍算一个 runtime，作为「插件树活着」的指标更稳。
+ */
+export function kernelStatus(): KernelStatus {
+  return {
+    started: kernel?.started ?? false,
+    name: kernel?.name ?? '',
+    plugins: kernel ? kernel.ctx.registry.size : 0,
+  };
+}

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -7,8 +7,9 @@
    单通道让 preload 写完就不再改——加方法只动本文件与 main 侧实现。
 
    方法命名：<域>.<对象>.<动词>。
-   host.*  = 外壳能力，桌面端恒可用。
-   local.* = 本地计算能力（第二期），届时只往 Methods 里加条目。
+   host.*   = 外壳能力，桌面端恒可用。
+   local.*  = 本地计算能力（第二期），届时只往 Methods 里加条目。
+   kernel.* = 内核（@polaris/kernel）状态，桌面端恒可用。
    ============================================================ */
 
 /** preload 同步注入到 window.__POLARIS__ 的静态事实（见 preload/index.ts 的说明）。 */
@@ -76,6 +77,16 @@ export interface UpdateInfo {
   installerUrl?: string;
 }
 
+/**
+ * 内核运行状态。plugins = cordis registry 里已注册的插件 runtime 数量
+ * （ctx.registry.size，公开口径）；一期只有探针插件，恒 ≥ 1 即为健康。
+ */
+export interface KernelStatus {
+  started: boolean;
+  name: string;
+  plugins: number;
+}
+
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */
 export type ServerProbe =
   | { ok: true; version: string }
@@ -98,6 +109,9 @@ export interface Methods {
   'host.update.check': { params: void; result: UpdateInfo };
   /** 下载并应用上一次检查到的更新；进度走 job.* 事件。 */
   'host.update.apply': { params: void; result: JobHandle };
+
+  /** 内核状态探针。前端不依赖它做分支，只用于诊断页与冒烟。 */
+  'kernel.status': { params: void; result: KernelStatus };
 
   /* ---- local.*：第二期的本地计算能力 ----
      现在全部声明但不实现（一律抛 ERR_CAPABILITY_UNAVAILABLE），目的是把

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -22,6 +22,7 @@ import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
+import { startKernel, stopKernel } from './main/kernel';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
 import { extractTarGz } from './main/updates/tar';
@@ -45,6 +46,7 @@ function check(label: string, ok: boolean, detail = ''): void {
 void app.whenReady().then(async () => {
   handleAppProtocol(() => SERVER_URL);
   installIpc(); // preload 的 sendSync 依赖它，不装就测不到真实注入链路
+  await startKernel(); // 与 main/index.ts 同序：内核先于窗口，kernel.status 才是真的
 
   console.log('CSP');
   const csp = buildCsp(SERVER_URL);
@@ -358,6 +360,21 @@ void app.whenReady().then(async () => {
     localError.includes('method not implemented in phase 1'),
     localError.slice(0, 120),
   );
+
+  // 内核：证明 @polaris/kernel 真的挂在主进程里，且 renderer 能经唯一
+  // IPC 通道读到它的状态（renderer → preload → router → kernel 单例）。
+  console.log('\n内核');
+  const kernelState = (await win.webContents.executeJavaScript(
+    `window.polaris.invoke('kernel.status').catch(e => ({ error: String(e && e.message || e) }))`,
+  )) as { started?: boolean; name?: string; plugins?: number; error?: string };
+  check('kernel.status 经 IPC 往返返回', kernelState.error === undefined, kernelState.error ?? '');
+  check('内核已启动（started=true）', kernelState.started === true);
+  check('实例名为 polaris-desktop', kernelState.name === 'polaris-desktop', `name=${kernelState.name}`);
+  check('探针插件已注册（plugins ≥ 1）', (kernelState.plugins ?? 0) >= 1, `plugins=${kernelState.plugins}`);
+
+  // smoke 用 app.exit 直接退出、不经过 before-quit，这里手动停机以覆盖
+  // stop 路径（fiber.dispose 级联）不抛错。
+  await stopKernel();
 
   stopAgent();
 

--- a/src/desktop/tsconfig.json
+++ b/src/desktop/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "noEmit": true,
     "types": ["node"]


### PR DESCRIPTION
## Summary

P1-A1 (tracking #564): the desktop shell mounts the plugin kernel delivered in P0 (#573).

- `src/desktop/src/main/kernel.ts` — mount point organized like `agent/supervisor.ts`: module singleton + named accessors; `startKernel()` is idempotent, `stopKernel()` disposes the root fiber (cascading effect reclamation). A no-op `desktop-probe` plugin proves the plugin tree is live; future stages (config tree, process supervision, legacy engine) only extend the install list here.
- `main/index.ts` — kernel starts on `whenReady` **before** IPC installs; `before-quit` intercepts once, awaits `stopKernel()`, then re-quits (Electron's quit path doesn't await promises).
- `shared/contract.ts` — new `kernel.*` domain with `kernel.status` → `{ started, name, plugins }`; `plugins` uses `ctx.registry.size` (cordis's documented "registered plugin runtimes" count — stable under repeated installs of one plugin). Preload untouched (generic invoke pass-through is the contract's design).
- `smoke.ts` — new kernel assertion group (IPC round-trip, started=true, name, plugins≥1) + a dispose-path call; runs under real Electron.
- `desktop/tsconfig.json` gains `allowImportingTsExtensions` (the kernel package exports TypeScript sources with `.ts`-suffixed imports; `noEmit` is already set, so this is legal).
- Phase-1 capability table and the stub agent are intentionally untouched — flipping local capabilities is A4.

## Verification

- `pnpm --dir src/desktop run lint` / `run build` clean
- `pnpm --dir src/kernel run test` — 11/11, no regression
- `pnpm --dir src/desktop run smoke` on a live Electron: new kernel group 4/4 ok, suite ends 全部通过

Closes #594