### PR TITLE
fix(tests): adapt remaining helpers to the removed library approval flow

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -137,6 +137,8 @@ async def ensure_project_library(session, project_id):
         status="active",
         is_public=True,  # 课题起源库=共享库（P10：全实验室可读，等价存量 active 回填公共）
         created_by=None,
+        # 起源库记课题主人为创建者：库级写权限 = admin ∪ 创建者（策展人已随 #593 移除）
+        submitted_by=project.owner_id if project else None,
     )
     session.add(library)
     await session.flush()
@@ -295,6 +297,7 @@ async def make_project_with_library(
     resp = await client.post("/api/projects", json=payload, headers=headers)
     assert resp.status_code == 201, resp.text
     project_id = _uuid.UUID(resp.json()["id"])
+    owner_id = _uuid.UUID(resp.json()["owner_id"])
     async with get_sessionmaker()() as session:
         library = DirectionLibrary(
             name=name,
@@ -303,6 +306,7 @@ async def make_project_with_library(
             status="active",
             is_public=True,  # 课题起源库=共享库（P10：全实验室可读）
             created_by=None,
+            submitted_by=owner_id,
         )
         if definition:
             library.statement = definition.get("statement")

--- a/src/backend/tests/test_library_citations_export.py
+++ b/src/backend/tests/test_library_citations_export.py
@@ -36,8 +36,13 @@ async def _create_active_standalone(client, creator_headers, admin_headers):
     assert resp.status_code == 201, resp.text
     lib_id = resp.json()["id"]
     assert resp.json()["project_id"] is None
-    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
-    assert resp.status_code == 200, resp.text
+    # 转公共审批流已移除（#593）：直接置 is_public 复原「已批准的公共独立库」语义
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary as _DL
+
+        lib = await session.get(_DL, uuid.UUID(lib_id))
+        lib.is_public = True
+        await session.commit()
     return lib_id
 
 

--- a/src/backend/tests/test_library_paper_management.py
+++ b/src/backend/tests/test_library_paper_management.py
@@ -61,8 +61,13 @@ async def _create_active_standalone(client, creator_headers, admin_headers, name
     assert resp.status_code == 201, resp.text
     lib_id = resp.json()["id"]
     assert resp.json()["project_id"] is None
-    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
-    assert resp.status_code == 200, resp.text
+    # 转公共审批流已移除（#593）：直接置 is_public 复原「已批准的公共独立库」语义
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary as _DL
+
+        lib = await session.get(_DL, uuid.UUID(lib_id))
+        lib.is_public = True
+        await session.commit()
     return lib_id
 
 

--- a/src/backend/tests/test_library_scoped_capabilities.py
+++ b/src/backend/tests/test_library_scoped_capabilities.py
@@ -43,8 +43,13 @@ async def _setup(client, *, prefix):
     assert resp.status_code == 201, resp.text
     assert resp.json()["project_id"] is None
     lib_id = resp.json()["id"]
-    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin)
-    assert resp.status_code == 200, resp.text
+    # 转公共审批流已移除（#593）：直接置 is_public 复原「已批准的公共独立库」语义
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary as _DL
+
+        lib = await session.get(_DL, uuid.UUID(lib_id))
+        lib.is_public = True
+        await session.commit()
     return creator, admin, lib_id
 
 

--- a/src/backend/tests/test_scoped_paper_detail.py
+++ b/src/backend/tests/test_scoped_paper_detail.py
@@ -38,8 +38,13 @@ async def _create_active_standalone(client, creator_headers, admin_headers, name
     )
     assert resp.status_code == 201, resp.text
     lib_id = resp.json()["id"]
-    resp = await client.post(f"/api/libraries/{lib_id}/approve", headers=admin_headers)
-    assert resp.status_code == 200, resp.text
+    # 转公共审批流已移除（#593）：直接置 is_public 复原「已批准的公共独立库」语义
+    async with get_sessionmaker()() as session:
+        from app.models.library_direction import DirectionLibrary as _DL
+
+        lib = await session.get(_DL, uuid.UUID(lib_id))
+        lib.is_public = True
+        await session.commit()
     return lib_id
 
 

--- a/src/backend/tests/test_voyage_scope.py
+++ b/src/backend/tests/test_voyage_scope.py
@@ -72,7 +72,14 @@ async def _library(client, admin_hdr, owner_hdr, *, name) -> str:
         "/api/libraries", json={"name": name, "statement": "测试库"}, headers=owner_hdr
     )
     assert resp.status_code == 201, resp.text
-    return resp.json()["id"]
+    lib_id = resp.json()["id"]
+    # 转公共审批流已移除（#593）：直接置 is_public 复原「已批准的公共独立库」语义
+    # （本文件多个用例的前提是公共库对全员可读，如 can_open 一例）
+    async with get_sessionmaker()() as session:
+        lib = await session.get(DirectionLibrary, uuid.UUID(lib_id))
+        lib.is_public = True
+        await session.commit()
+    return lib_id
 
 
 async def test_library_voyages_stay_out_of_the_topic_list(client):


### PR DESCRIPTION
## Summary

Repairs the test fallout from #593/#596 (tracked in #599): the pre-merge suite run for that PR was accidentally executed against a checkout without its changes (wrong working directory across worktrees), and with no backend CI the breakage landed on main (~35 failing tests).

- The standalone-library helpers in `test_scoped_paper_detail`, `test_library_paper_management`, `test_library_scoped_capabilities`, `test_library_citations_export` (shared by the scoped-trash / orphan-gc / chat-fulltext suites) and the voyage-scope `_library` helper called the removed `POST /libraries/{id}/approve`. They now flip `is_public` directly in the DB — the exact semantics the approve call used to produce (an approved, public standalone library), so every downstream test's premise is preserved.
- Both conftest library factories (`ensure_project_library`, `make_project_with_library`) now record the project owner as `submitted_by`: the manage predicate is admin-or-creator since #593, and helper-created origin libraries previously carried no creator at all — the rewritten governance assertions exposed this gap.

## Verification

- All 8 previously failing files: 55/55, then 52/52 after the conftest change (incl. governance + wiki-ingest + golden)
- **Full suite: 1488 passed, 0 failed, 3 deselected** (pre-existing, #581) — count reconciles: 1498 baseline − 10 tests deleted in #593
- Golden transcript byte-identical

Process fix applied on my side: suite runs now use absolute mount paths (no `$PWD` ambiguity across worktrees). The deeper guard is a backend-test CI job — worth adding once a runner budget is decided.

Closes #599