### PR TITLE
feat: single-user no-login under the desktop profile

### DIFF
--- a/src/backend/app/api/auth.py
+++ b/src/backend/app/api/auth.py
@@ -314,9 +314,60 @@ async def register(
 
 @router.get("/auth/capabilities", tags=["auth"])
 async def auth_capabilities() -> dict[str, bool]:
-    """前端据此决定是否显示验证码输入与「忘记密码」——没配 SMTP 就别给走不通的入口。"""
-    enabled = get_settings().email_enabled
-    return {"email": enabled, "password_reset": enabled, "register_email_code": enabled}
+    """前端据此决定是否显示验证码输入与「忘记密码」——没配 SMTP 就别给走不通的入口。
+
+    ``local_session``：desktop 档位免登录（见 /auth/local-session）。前端见到它为
+    true 就自动取会话、不再渲染登录页。"""
+    settings = get_settings()
+    enabled = settings.email_enabled
+    return {
+        "email": enabled,
+        "password_reset": enabled,
+        "register_email_code": enabled,
+        "local_session": settings.is_desktop,
+    }
+
+
+# desktop 档位的本地用户身份。固定邮箱做幂等键；机器的主人就是自己的管理员。
+LOCAL_USER_EMAIL = "local@polaris.desktop"
+LOCAL_USERNAME = "local"
+
+
+@router.post("/auth/local-session", tags=["auth"])
+async def local_session(
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """desktop 档位免登录：幂等确保本地用户存在并直接签发会话。
+
+    server 档位下这个端点结构性不存在（404）——不是 403：多用户部署里它就不该
+    被发现。本地用户 role=admin（个人机器的主人管理自己的一切），密码是随机散列、
+    永远无法用于登录——会话只能经这个端点取得，而它只在单机档位存在。
+    """
+    if not get_settings().is_desktop:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    user = (
+        await session.execute(select(User).where(User.email == LOCAL_USER_EMAIL))
+    ).scalar_one_or_none()
+    if user is None:
+        import secrets as _secrets
+
+        from fastapi_users.password import PasswordHelper
+
+        user = User(
+            email=LOCAL_USER_EMAIL,
+            hashed_password=PasswordHelper().hash(_secrets.token_urlsafe(32)),
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            display_name="Local",
+            username=LOCAL_USERNAME,
+            role="admin",
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+    token = await get_jwt_strategy().write_token(user)
+    return {"access_token": token, "token_type": "bearer"}
 
 
 @router.post("/auth/send-code", response_model=SendCodeResult, tags=["auth"])

--- a/src/backend/tests/test_desktop_local_session.py
+++ b/src/backend/tests/test_desktop_local_session.py
@@ -1,0 +1,55 @@
+"""desktop 档位免登录（POST /auth/local-session）。"""
+
+import pytest
+
+from app.core.config import Settings
+
+pytestmark = pytest.mark.asyncio
+
+
+def _desktop_settings():
+    # 其余字段（secret_key/database_url 等）沿用 conftest 注入的测试环境变量，
+    # 只切档位——token 校验与其他端点共用同一 secret。
+    return Settings(profile="desktop")
+
+
+async def test_local_session_absent_in_server_profile(client):
+    resp = await client.post("/api/auth/local-session")
+    assert resp.status_code == 404
+
+
+async def test_local_session_provisions_admin_and_is_idempotent(client, monkeypatch):
+    monkeypatch.setattr("app.api.auth.get_settings", _desktop_settings)
+
+    resp = await client.post("/api/auth/local-session")
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    me = await client.get("/api/users/me", headers=headers)
+    assert me.status_code == 200, me.text
+    body = me.json()
+    assert body["email"] == "local@polaris.desktop"
+    assert body["role"] == "admin"
+
+    # 幂等：第二次不再建新用户，会话仍指向同一身份
+    resp2 = await client.post("/api/auth/local-session")
+    assert resp2.status_code == 200
+    me2 = await client.get(
+        "/api/users/me", headers={"Authorization": f"Bearer {resp2.json()['access_token']}"}
+    )
+    assert me2.json()["id"] == body["id"]
+
+    # 会话能用于受保护的写端点（建课题）
+    project = await client.post(
+        "/api/projects", json={"name": "本地课题", "statement": "s"}, headers=headers
+    )
+    assert project.status_code == 201, project.text
+
+
+async def test_capabilities_reports_local_session(client, monkeypatch):
+    resp = await client.get("/api/auth/capabilities")
+    assert resp.json()["local_session"] is False
+    monkeypatch.setattr("app.api.auth.get_settings", _desktop_settings)
+    resp = await client.get("/api/auth/capabilities")
+    assert resp.json()["local_session"] is True

--- a/src/backend/tests/test_email_auth.py
+++ b/src/backend/tests/test_email_auth.py
@@ -54,6 +54,7 @@ async def test_capabilities_follows_smtp_config(client, email_on):
         "email": True,
         "password_reset": True,
         "register_email_code": True,
+        "local_session": False,  # server 档位无免登录（desktop 档见 test_desktop_local_session）
     }
 
 

--- a/src/frontend/src/app/UserMenu.tsx
+++ b/src/frontend/src/app/UserMenu.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Avatar } from '../components/ui/Avatar';
 import { Icon } from '../components/ui/Icon';
 import { Modal } from '../components/ui/Modal';
 import { useAuth } from './auth';
-import { isAdmin, type UserRead } from '../lib/api';
+import { api, isAdmin, type UserRead } from '../lib/api';
 import { tr } from '../lib/i18n';
 
 /* 侧栏底部用户区：点头像弹出菜单（关于我们 / 设置 / 退出登录）。邀请协作者入口在研究方向详情页。 */
@@ -99,6 +100,15 @@ export function UserMenu({ me, collapsed }: { me: UserRead | undefined; collapse
   const [aboutOpen, setAboutOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
+  // desktop 免登录模式下没有「登录」这回事，退出入口一并隐藏
+  const capabilities = useQuery({
+    queryKey: ['auth-capabilities'],
+    queryFn: () => api.authCapabilities(),
+    staleTime: Infinity,
+    retry: false,
+  });
+  const localSession = capabilities.data?.local_session === true;
+
   // 点击菜单外部 / Esc 关闭（菜单是 rootRef 的子元素，contains 即可覆盖）
   useEffect(() => {
     if (!open) return;
@@ -165,19 +175,23 @@ export function UserMenu({ me, collapsed }: { me: UserRead | undefined; collapse
             <Icon name="settings" size={15} />
             {tr('设置', 'Settings')}
           </button>
-          <div className="user-menu-sep" />
-          <button
-            className="user-menu-item danger"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false);
-              logout();
-              navigate('/login');
-            }}
-          >
-            <Icon name="logout" size={15} />
-            {tr('退出登录', 'Log out')}
-          </button>
+          {!localSession && (
+            <>
+              <div className="user-menu-sep" />
+              <button
+                className="user-menu-item danger"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  logout();
+                  navigate('/login');
+                }}
+              >
+                <Icon name="logout" size={15} />
+                {tr('退出登录', 'Log out')}
+              </button>
+            </>
+          )}
         </div>
       )}
       <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />

--- a/src/frontend/src/app/auth.tsx
+++ b/src/frontend/src/app/auth.tsx
@@ -1,7 +1,8 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { api, getToken, setToken, type RegisterInput } from '../lib/api';
+import { acquireLocalSession, detectLocalSession } from '../lib/local-session';
 import { setLastAccount, setRemembered } from '../lib/token-store';
 
 interface AuthValue {
@@ -12,6 +13,8 @@ interface AuthValue {
   /** 注册（含邀请码）后自动登录。 */
   register: (input: RegisterInput) => Promise<void>;
   logout: () => void;
+  /** 采纳一个已按惯例落存储的 token（desktop 免登录引导用），不清缓存。 */
+  adoptToken: (token: string) => void;
 }
 
 const AuthContext = createContext<AuthValue | null>(null);
@@ -42,6 +45,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [login],
   );
 
+  const adoptToken = useCallback((t: string) => {
+    setToken(t);
+    setTokenState(t);
+  }, []);
+
   const logout = useCallback(() => {
     setToken(null);
     setTokenState(null);
@@ -50,8 +58,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [queryClient]);
 
   const value = useMemo<AuthValue>(
-    () => ({ token, isAuthenticated: token !== null, login, register, logout }),
-    [token, login, register, logout],
+    () => ({ token, isAuthenticated: token !== null, login, register, logout, adoptToken }),
+    [token, login, register, logout, adoptToken],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -63,12 +71,35 @@ export function useAuth(): AuthValue {
   return ctx;
 }
 
-/** 路由守卫：未登录跳转 /login。 */
+/** 路由守卫：未登录先探测 desktop 免登录能力——支持就静默取会话直接进应用
+    （用户永远不见登录页），否则回落到 /login。探测期间渲染空白，避免闪现登录页。 */
 export function RequireAuth({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, adoptToken } = useAuth();
   const location = useLocation();
-  if (!isAuthenticated) {
+  // checking = 正在探测/取会话；login = 免登录不可用，走现有登录页流程
+  const [fallback, setFallback] = useState<'checking' | 'login'>('checking');
+
+  useEffect(() => {
+    if (isAuthenticated) return;
+    let alive = true;
+    void (async () => {
+      if (await detectLocalSession()) {
+        const token = await acquireLocalSession();
+        if (token) {
+          if (alive) adoptToken(token);
+          return;
+        }
+      }
+      if (alive) setFallback('login');
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [isAuthenticated, adoptToken]);
+
+  if (isAuthenticated) return <>{children}</>;
+  if (fallback === 'login') {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }
-  return <>{children}</>;
+  return null;
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import { tr } from './i18n';
 import { apiBase, serverOrigin } from './endpoint';
 import { readToken, writeToken } from './token-store';
 import { LocalUnavailable, noteLocalFailure, resolveLocalHandler } from './local-routes';
+import { handleUnauthorized, requestLocalSessionToken } from './local-session';
 /* ============================================================
    Polaris API client — thin fetch wrapper.
    baseURL /api (proxied to FastAPI at :8000 in dev), JSON,
@@ -58,11 +59,10 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   }
   const res = await fetch(`${apiBase()}${path}`, { ...init, headers });
   if (res.status === 401 && token && !path.startsWith('/auth/')) {
-    // 会话过期/失效：清 token 并跳登录（避免在登录/注册接口上误触发）
+    // 会话过期/失效：清 token 后统一处理——免登录模式重取本地会话并刷新页面，
+    // 否则跳登录（避免在登录/注册接口上误触发）
     setToken(null);
-    if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
-      window.location.assign('/login');
-    }
+    handleUnauthorized();
   }
   if (!res.ok) {
     let detail = res.statusText || `HTTP ${res.status}`;
@@ -119,9 +119,7 @@ async function requestBlob(path: string, init: RequestInit = {}): Promise<Blob> 
   const res = await fetch(`${apiBase()}${path}`, { ...init, headers });
   if (res.status === 401 && token && !path.startsWith('/auth/')) {
     setToken(null);
-    if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
-      window.location.assign('/login');
-    }
+    handleUnauthorized();
   }
   if (!res.ok) {
     let detail = res.statusText || `HTTP ${res.status}`;
@@ -166,9 +164,7 @@ async function requestStream(path: string, init: RequestInit = {}): Promise<Resp
   const res = await fetch(`${apiBase()}${path}`, { ...init, headers });
   if (res.status === 401 && token && !path.startsWith('/auth/')) {
     setToken(null);
-    if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
-      window.location.assign('/login');
-    }
+    handleUnauthorized();
   }
   if (!res.ok) {
     let detail = res.statusText || `HTTP ${res.status}`;
@@ -306,6 +302,8 @@ export interface AuthCapabilities {
   email: boolean;
   password_reset: boolean;
   register_email_code: boolean;
+  /** true = desktop 档位免登录：前端自动取本地会话、不渲染登录页、隐藏退出入口 */
+  local_session: boolean;
 }
 
 export interface SendCodeResult {
@@ -3474,6 +3472,11 @@ export const api = {
   /** 邮件系统是否可用（决定验证码与「忘记密码」入口是否显示）。 */
   authCapabilities(): Promise<AuthCapabilities> {
     return request<AuthCapabilities>('/auth/capabilities');
+  },
+
+  /** desktop 档位免登录：无凭证换取本地会话 token（server 档位 404）。 */
+  localSession(): Promise<string> {
+    return requestLocalSessionToken();
   },
 
   /** 申请邮箱验证码；冷却中返回 sent=false 与剩余秒数。 */

--- a/src/frontend/src/lib/local-session.ts
+++ b/src/frontend/src/lib/local-session.ts
@@ -1,0 +1,80 @@
+/* ============================================================
+   desktop 档位免登录（P1-A3）。
+
+   后端 /auth/capabilities 返回 local_session=true 时，前端不渲染登录页：
+   启动（或路由守卫判定未登录）时直接 POST /auth/local-session 换会话 token。
+   server 档位该端点结构性 404，一切失败都静默回落到现有登录页流程。
+
+   这里刻意用裸 fetch 而不是 lib/api.ts 的 request：
+   ① 两个端点都无鉴权，不需要 Bearer/本地路由层；
+   ② api.ts 的 401 拦截会调用本模块（handleUnauthorized），反向依赖会成环。
+   ============================================================ */
+
+import { apiBase } from './endpoint';
+import { writeToken } from './token-store';
+
+/** local_session 能力的模块级缓存：部署档位在进程生命周期内不会变。 */
+let localSessionCached: boolean | null = null;
+
+/** 查询后端是否支持免登录（结果记忆化；网络失败按 false 处理并同样缓存）。 */
+export async function detectLocalSession(): Promise<boolean> {
+  if (localSessionCached !== null) return localSessionCached;
+  try {
+    const res = await fetch(`${apiBase()}/auth/capabilities`);
+    if (!res.ok) {
+      localSessionCached = false;
+    } else {
+      const data = (await res.json()) as { local_session?: boolean };
+      localSessionCached = data.local_session === true;
+    }
+  } catch {
+    localSessionCached = false;
+  }
+  return localSessionCached;
+}
+
+/** POST /auth/local-session（无 body、无鉴权）。server 档位 404 时抛错。 */
+export async function requestLocalSessionToken(): Promise<string> {
+  const res = await fetch(`${apiBase()}/auth/local-session`, { method: 'POST' });
+  if (!res.ok) throw new Error(`local-session HTTP ${res.status}`);
+  const data = (await res.json()) as { access_token: string; token_type: string };
+  return data.access_token;
+}
+
+/** 取本地会话并按现有惯例落存储；失败返回 null（调用方回落登录页）。 */
+export async function acquireLocalSession(): Promise<string | null> {
+  try {
+    const token = await requestLocalSessionToken();
+    writeToken(token);
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+/* —— 401 统一处理 ——
+   api.ts 三个请求封装（request/requestBlob/requestStream）撞到 401 时调这里：
+   免登录模式下重取会话并整页刷新（而不是踢去登录页）；其余情况维持原行为跳
+   /login。并发 401 只触发一次。 */
+let recovering = false;
+
+export function handleUnauthorized(): void {
+  if (typeof window === 'undefined') return;
+  if (recovering) return;
+  recovering = true;
+  void (async () => {
+    if (await detectLocalSession()) {
+      const token = await acquireLocalSession();
+      if (token) {
+        // token 已落存储，整页刷新让所有查询带新会话重来
+        window.location.reload();
+        return;
+      }
+    }
+    if (window.location.pathname !== '/login') {
+      window.location.assign('/login');
+      return;
+    }
+    recovering = false;
+  })();
+}


### PR DESCRIPTION
## Summary

P1-A3 (tracking #564): under `POLARIS_PROFILE=desktop` the platform is single-user with no login.

Backend:
- `POST /auth/local-session` — idempotently provisions the local user (fixed identity `local@polaris.desktop`, admin role — the machine's owner administers their own machine; random unusable password, so this endpoint is the only way to a session) and returns a JWT. **Structurally absent (404) in the server profile** — a multi-user deployment should not even discover it.
- `GET /auth/capabilities` gains `local_session` for frontend discovery. Server-profile registration/invite-code paths untouched.

Frontend:
- `lib/local-session.ts` centralizes the mode: capability detection (memoized), session acquisition, and the unified 401 recovery (re-acquire + reload in desktop mode; redirect to /login otherwise — the three duplicated 401 inline blocks in `api.ts` collapse into this single path)
- the route guard acquires the session **before** rendering anything, so the login page never flashes; failures fall back to the normal login flow
- the logout entry hides when sessions are automatic

## Verification

- Backend suite on the rebased branch: **1491 passed, 0 failed, 3 deselected** (pre-existing, #581) — 1488 post-#600 baseline + 3 new local-session tests (server-profile 404, provision/idempotency/protected-write, capabilities)
- Golden transcript byte-identical; frontend `tsc --noEmit && vite build` clean
- `ruff check` clean on touched files

Closes #597