### PR TITLE
feat: production legacy-engine kernel plugin and local API base switch

### DIFF
--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -20,7 +20,7 @@ import {
   type RpcRequest,
 } from '../../shared/contract';
 import { capabilityManifest } from '../capabilities';
-import { kernelStatus } from '../kernel';
+import { kernelStatus, localBackend } from '../kernel';
 import { applyUpdate, checkForUpdate } from '../updates';
 import * as host from './methods.host';
 import * as local from './methods.local';
@@ -54,6 +54,7 @@ const HANDLERS: Record<MethodName, Handler> = {
   'host.update.check': () => checkForUpdate(),
   'host.update.apply': () => applyUpdate(),
   'kernel.status': () => kernelStatus(),
+  'kernel.localBackend': () => localBackend(),
   // local.* 一期全部走到 agent 再以 ERR_CAPABILITY_UNAVAILABLE 结束（见 methods.local.ts）
   'local.latex.compile': (p) => local.latexCompile(p),
   'local.fs.pickFolder': (p) => local.pickFolder(p),

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -6,19 +6,21 @@
    ready 时 start，退出路径 stop（fiber.dispose 级联回收所有插件注册
    的副作用——计时器、监听器、子进程）。
 
-   一期内核里只有一个探针插件：不做任何事，存在本身就证明 cordis 插件
-   树被真的建起来了（kernel.status 的 plugins 计数由它兜底 ≥ 1）。
-   后续阶段把 config 树、进程监督、legacy engine 逐个装进来时，
-   改的只有这里的装载列表。
+   装载列表：
+   - desktop-probe：空探针，存在本身就证明 cordis 插件树被真的建起来了
+     （kernel.status 的 plugins 计数由它兜底 ≥ 1）。
+   - legacy-engine：仅当设置了 POLARIS_DESKTOP_ENGINE 时装载，把 Python
+     后端作为本地子进程拉起（desktop 档位单进程，见 #583）；未设置时
+     保持现有的远端服务器流程，一行不变。
    ============================================================ */
 
-import { createKernel, type Kernel } from '@polaris/kernel';
+import { createKernel, legacyEngine, type Kernel, type LegacyEngineConfig } from '@polaris/kernel';
 
-import type { KernelStatus } from '../shared/contract';
+import type { KernelStatus, LocalBackendInfo } from '../shared/contract';
 
 let kernel: Kernel | null = null;
 
-/** 空探针插件。命名走 kebab-case，与将来的 config-tree / legacy-engine 一致。 */
+/** 空探针插件。命名走 kebab-case，与 config-tree / legacy-engine 一致。 */
 const desktopProbe = {
   name: 'desktop-probe',
   apply(): void {
@@ -26,17 +28,64 @@ const desktopProbe = {
   },
 };
 
+/**
+ * POLARIS_DESKTOP_ENGINE 的取值：
+ *   docker:<image>:<backendDirAbs>   如 docker:polaris-api-test:local:/repo/src/backend
+ *   command:<json argv>              如 command:["node","engine.js"]
+ * 未设置 / 解析失败 = 不装本地引擎。
+ */
+function parseEngineSpec(raw: string | undefined): LegacyEngineConfig | null {
+  if (!raw) return null;
+  if (raw.startsWith('command:')) {
+    try {
+      const argv: unknown = JSON.parse(raw.slice('command:'.length));
+      if (Array.isArray(argv) && argv.length > 0 && argv.every((a) => typeof a === 'string')) {
+        return { mode: 'command', command: argv as string[] };
+      }
+    } catch {
+      /* 落到末尾的统一告警 */
+    }
+  } else if (raw.startsWith('docker:')) {
+    const rest = raw.slice('docker:'.length);
+    // 镜像名可带 tag（含冒号），backendDir 是绝对路径：从右往左找第一个
+    // 「其后是绝对路径」的冒号做分隔，避免把 tag 里的冒号切错。
+    for (let i = rest.length - 1; i > 0; i--) {
+      if (rest[i] !== ':') continue;
+      const dir = rest.slice(i + 1);
+      if (dir.startsWith('/') || /^[A-Za-z]:[\\/]/.test(dir)) {
+        return { mode: 'docker', image: rest.slice(0, i), backendDir: dir };
+      }
+    }
+  }
+  console.error(`[kernel] 无法解析 POLARIS_DESKTOP_ENGINE：${raw}`);
+  return null;
+}
+
 /** 幂等启动：重复调用返回同一实例（app ready 与 smoke 都可能触发）。 */
 export async function startKernel(): Promise<Kernel> {
   if (kernel) return kernel;
   const instance = createKernel({ name: 'polaris-desktop' });
   instance.ctx.plugin(desktopProbe);
+
+  const engine = parseEngineSpec(process.env.POLARIS_DESKTOP_ENGINE);
+  if (engine) {
+    // 等到健康（或失败）再返回：窗口在 startKernel 之后才创建，这样
+    // kernel.localBackend 与 CSP 在首个页面请求时就已是最终答案，渲染层
+    // 不用处理「先远端后本地」的中途切换。失败不阻断启动——记录错误后
+    // 回落远端服务器流程（localBackend 返回 null）。
+    try {
+      await instance.ctx.plugin(legacyEngine, engine);
+    } catch (err) {
+      console.error('[kernel] 本地引擎启动失败，回落远端流程：', err);
+    }
+  }
+
   await instance.start();
   kernel = instance;
   return instance;
 }
 
-/** 停机：dispose 根 fiber，级联回收。幂等，未启动时是 no-op。 */
+/** 停机：dispose 根 fiber，级联回收（含本地引擎子进程）。幂等，未启动时是 no-op。 */
 export async function stopKernel(): Promise<void> {
   const instance = kernel;
   kernel = null;
@@ -54,4 +103,15 @@ export function kernelStatus(): KernelStatus {
     name: kernel?.name ?? '',
     plugins: kernel ? kernel.ctx.registry.size : 0,
   };
+}
+
+/**
+ * kernel.localBackend 的实现。ctx.get 是 cordis 公开的免 inject 读服务入口
+ * （reflect mixin，见 vendor/deepseek-cordis/cordis/src/reflect.ts），严格模式
+ * 只在提供方 fiber 处于 ACTIVE 时返回值——引擎没装、还没健康、或已失败时
+ * 一律拿到 undefined，统一折叠成 null 让前端回落远端。
+ */
+export function localBackend(): LocalBackendInfo {
+  const legacy = kernel?.ctx.get('legacy') as { baseUrl?: string } | undefined;
+  return { baseUrl: legacy?.baseUrl ?? null };
 }

--- a/src/desktop/src/main/protocol.ts
+++ b/src/desktop/src/main/protocol.ts
@@ -21,6 +21,7 @@ import { existsSync, statSync } from 'node:fs';
 import { extname, join, normalize, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { localBackend } from './kernel';
 import { stagedRendererDir } from './updates/renderer-store';
 
 export const APP_SCHEME = 'app';
@@ -63,7 +64,7 @@ function rendererRoot(): string {
  * - style-src 'unsafe-inline'：CodeMirror 的 style-mod 与 KaTeX 在运行时
  *   insertRule 注入样式，去掉编辑器和公式渲染会直接崩。
  */
-export function buildCsp(serverUrl: string): string {
+export function buildCsp(serverUrl: string, localBaseUrl?: string | null): string {
   // blob: 必须显式列出：Chromium 里 'self' 不覆盖 blob: URL，而 pdf.js 标注阅读器
   // 是 fetch(blob:…pdf) 取正文（走 connect-src），标准阅读器是 <iframe src=blob:>
   // （走 frame-src）。少了这一项就只有标注阅读器打不开，且只在桌面端复现。
@@ -75,6 +76,17 @@ export function buildCsp(serverUrl: string): string {
       connect.add(u.origin.replace(/^http/, 'ws'));
     } catch {
       /* 地址非法时只留 'self'，前端会停在配置页 */
+    }
+  }
+  // 本地引擎（POLARIS_DESKTOP_ENGINE）：不放行 127.0.0.1 的话 renderer 对
+  // 本地后端的一切 fetch/WS 都会被 CSP 拦死，endpoint.ts 的切换形同虚设。
+  if (localBaseUrl) {
+    try {
+      const u = new URL(localBaseUrl);
+      connect.add(u.origin);
+      connect.add(u.origin.replace(/^http/, 'ws'));
+    } catch {
+      /* 非法地址当作没有本地引擎 */
     }
   }
   return [
@@ -123,7 +135,7 @@ export function handleAppProtocol(getServerUrl: () => string): void {
     const res = await net.fetch(pathToFileURL(filePath).toString());
     const headers = new Headers(res.headers);
     if (filePath.endsWith('.html')) {
-      headers.set('Content-Security-Policy', buildCsp(getServerUrl()));
+      headers.set('Content-Security-Policy', buildCsp(getServerUrl(), localBackend().baseUrl));
     }
     return new Response(res.body, { status: res.status, headers });
   });

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -87,6 +87,14 @@ export interface KernelStatus {
   plugins: number;
 }
 
+/**
+ * 本地引擎地址。内核没拉起本地后端（未设 POLARIS_DESKTOP_ENGINE、或引擎
+ * 启动失败）时 baseUrl 为 null，前端据此回落远端服务器。
+ */
+export interface LocalBackendInfo {
+  baseUrl: string | null;
+}
+
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */
 export type ServerProbe =
   | { ok: true; version: string }
@@ -112,6 +120,8 @@ export interface Methods {
 
   /** 内核状态探针。前端不依赖它做分支，只用于诊断页与冒烟。 */
   'kernel.status': { params: void; result: KernelStatus };
+  /** 本地引擎地址；前端启动时问一次，非空则 REST/WS 全走本地。 */
+  'kernel.localBackend': { params: void; result: LocalBackendInfo };
 
   /* ---- local.*：第二期的本地计算能力 ----
      现在全部声明但不实现（一律抛 ERR_CAPABILITY_UNAVAILABLE），目的是把

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -15,6 +15,7 @@
    ============================================================ */
 
 import { BrowserWindow, app } from 'electron';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -22,7 +23,7 @@ import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
-import { startKernel, stopKernel } from './main/kernel';
+import { localBackend, startKernel, stopKernel } from './main/kernel';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
 import { extractTarGz } from './main/updates/tar';
@@ -460,6 +461,59 @@ void app.whenReady().then(async () => {
   // 同一个更新会被无限提示——这两条就是防这个的。
   check('热更装上的新界面参与版本比较', stagedSupersedes('0.3.2', '0.3.1'));
   check('整包更新反超后旧界面失效', !stagedSupersedes('0.3.2', '0.4.0') && !stagedSupersedes('0.3.2', '0.3.2'));
+
+  // 本地引擎（P1-A4）：真的用 docker 拉起 Python 后端并走一遍
+  // startKernel → kernel.localBackend → /api/health → stopKernel 回收。
+  // 依赖本机 docker 与测试镜像，默认关闭：设 POLARIS_SMOKE_ENGINE=1 才跑，
+  // 前置不满足输出 skip 而不是失败（CI 无 docker 时冒烟仍然全绿）。
+  console.log('\n本地引擎');
+  const ENGINE_IMAGE = 'polaris-api-test:local';
+  const ENGINE_CONTAINER = 'polaris-desktop-engine';
+  const dockerHasImage = (() => {
+    try {
+      execFileSync('docker', ['image', 'inspect', ENGINE_IMAGE], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  if (process.env.POLARIS_SMOKE_ENGINE !== '1') {
+    console.log('  skip 本地引擎组（未设 POLARIS_SMOKE_ENGINE=1）');
+  } else if (!dockerHasImage) {
+    console.log(`  skip 本地引擎组（docker 不可用或缺镜像 ${ENGINE_IMAGE}）`);
+  } else {
+    // 清掉上一轮可能的残留容器，保证本组幂等
+    try {
+      execFileSync('docker', ['rm', '-f', ENGINE_CONTAINER], { stdio: 'ignore' });
+    } catch {
+      /* 不存在 */
+    }
+    // __dirname = src/desktop/dist，后端源码在仓库的 src/backend
+    const backendDir = join(__dirname, '..', '..', 'backend');
+    process.env.POLARIS_DESKTOP_ENGINE = `docker:${ENGINE_IMAGE}:${backendDir}`;
+    try {
+      // 上面主流程已 stopKernel（单例清空），这里起的是全新实例；
+      // startKernel 会等到引擎健康或失败才返回（首启跑全部迁移，最长 120s）。
+      await startKernel();
+      const { baseUrl } = localBackend();
+      check('kernel.localBackend 返回本地地址', baseUrl != null, `baseUrl=${baseUrl}`);
+      if (baseUrl) {
+        const health = await fetch(`${baseUrl}/api/health`).catch(() => null);
+        check('本地引擎 /api/health 可达', health?.ok === true, `status=${health?.status}`);
+      }
+    } finally {
+      await stopKernel();
+      delete process.env.POLARIS_DESKTOP_ENGINE;
+    }
+    const running = (() => {
+      try {
+        return execFileSync('docker', ['ps', '--format', '{{.Names}}'], { encoding: 'utf8' });
+      } catch {
+        return '';
+      }
+    })();
+    check('停机后引擎容器已回收', !running.split('\n').includes(ENGINE_CONTAINER), running.trim());
+  }
 
   if (process.env.POLARIS_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/src/frontend/src/lib/endpoint.ts
+++ b/src/frontend/src/lib/endpoint.ts
@@ -9,6 +9,8 @@
    业务代码只 import 本文件，不直接读 window.__POLARIS__。
    ============================================================ */
 
+import { kernelLocalBackend } from './host';
+
 /** Electron preload 注入的宿主运行时信息（web 端为 undefined）。 */
 export interface PolarisHostRuntime {
   /** 用户配置的服务器地址，如 https://polaris.example.edu（可带尾斜杠，本模块会归一化）。 */
@@ -32,12 +34,44 @@ export function isDesktop(): boolean {
   return hostRuntime() != null;
 }
 
+/* —— 本地引擎（P1-A4）——
+   桌面内核可能已在本机拉起 Python 后端（POLARIS_DESKTOP_ENGINE）。启动时
+   经宿主桥问一次 kernel.localBackend，模块级缓存结果：非空则 REST/WS 全部
+   改走 127.0.0.1。web 端没有宿主桥，探测直接短路成 null——零请求零改动。 */
+
+let localBase: string | null = null;
+let localProbe: Promise<string | null> | null = null;
+
 /**
- * 服务器 origin：web 端为 ''（同源，走相对路径），桌面端为配置的地址（已去尾斜杠）。
+ * 探测本地引擎地址（幂等，结果缓存）。main.tsx 在桌面端挂载前 await 它，
+ * 保证首屏请求就走对地址，而不是「先远端后本地」中途切换。
+ */
+export function probeLocalBackend(): Promise<string | null> {
+  localProbe ??= (async () => {
+    try {
+      const info = await kernelLocalBackend();
+      localBase = info?.baseUrl?.replace(/\/+$/, '') || null;
+    } catch {
+      // 探测失败按「无本地引擎」处理，回落远端；不让一次 IPC 故障卡死首屏
+      localBase = null;
+    }
+    return localBase;
+  })();
+  return localProbe;
+}
+
+/** 远端服务器 origin（不含本地引擎），分享类链接必须用它。 */
+function remoteOrigin(): string {
+  return (hostRuntime()?.serverUrl ?? '').replace(/\/+$/, '');
+}
+
+/**
+ * 服务器 origin：web 端为 ''（同源，走相对路径），桌面端为配置的地址（已去尾斜杠）；
+ * 探测到本地引擎时本地优先。
  * 故意做成函数而非模块级常量：避免依赖「注入早于本模块求值」这一隐式时序。
  */
 export function serverOrigin(): string {
-  return (hostRuntime()?.serverUrl ?? '').replace(/\/+$/, '');
+  return localBase ?? remoteOrigin();
 }
 
 /** REST / SSE 的基址。web 端返回 '/api'，与改造前的字面量完全一致。 */
@@ -61,6 +95,8 @@ export function wsUrl(path: string): string {
  * 收件人多数用浏览器打开，所以桌面端要指向服务器上的 web 门户，而不是 app:// 本地页面。
  */
 export function portalUrl(path = ''): string {
-  const origin = serverOrigin() || (typeof window === 'undefined' ? '' : window.location.origin);
+  // 刻意用 remoteOrigin 而不是 serverOrigin：分享/邀请链接给别人打开，
+  // 指向本机 127.0.0.1 的本地引擎对收件人毫无意义。
+  const origin = remoteOrigin() || (typeof window === 'undefined' ? '' : window.location.origin);
   return `${origin}${path}`;
 }

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -88,6 +88,21 @@ export function setBadgeCount(count: number): void {
   void bridge()?.invoke('host.setBadgeCount', { count });
 }
 
+/** 本地引擎信息（contract.ts 的 LocalBackendInfo 镜像）。 */
+export interface LocalBackendInfo {
+  baseUrl: string | null;
+}
+
+/**
+ * 问主进程要本地引擎地址；web 端返回 null（无桥，零请求）。
+ * 只被 endpoint.ts 的启动探测调用，业务代码不要直接用。
+ */
+export async function kernelLocalBackend(): Promise<LocalBackendInfo | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('kernel.localBackend')) as LocalBackendInfo;
+}
+
 /* —— 能力清单 ——
    前端所有走本地还是走远端的判断只读这张表：绝不读 platform、绝不读版本号
    做特判，否则第二期能力增删又要回来改前端。 */

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,7 +1,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
-import { hostPlatform } from './lib/host';
+import { probeLocalBackend } from './lib/endpoint';
+import { hasHost, hostPlatform } from './lib/host';
 import './styles/global.css';
 
 // 桌面端把平台标在 <html> 上：macOS 的 hiddenInset 标题栏需要页面自己给
@@ -21,8 +22,18 @@ if (!container) {
   throw new Error('#root element not found');
 }
 
-createRoot(container).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+const render = () =>
+  createRoot(container).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+
+// 桌面端先问一次本地引擎地址再挂载（一次 IPC 往返，毫秒级）：让首屏请求
+// 就走对地址，而不是发出去之后才发现该走 127.0.0.1。web 端没有宿主桥，
+// 保持原来的同步挂载路径，行为一字不变。
+if (hasHost()) {
+  void probeLocalBackend().finally(render);
+} else {
+  render();
+}

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -10,4 +10,10 @@ export {
   type ConfigEntry,
   type ConfigTreeStore,
 } from './config/tree.ts'
+export {
+  ENGINE_CONTAINER,
+  LegacyEngineConfig,
+  legacyEngine,
+  type LegacyEngineService,
+} from './plugins/legacy-engine.ts'
 export { Context } from '@deepseek-ai/cordis'

--- a/src/kernel/src/plugins/legacy-engine.ts
+++ b/src/kernel/src/plugins/legacy-engine.ts
@@ -1,0 +1,182 @@
+/* ============================================================
+   legacy-engine 插件：把现有 Python 后端作为受监督子进程拉起。
+
+   P0 Spike-1 原型（spikes/p0/1-legacy-chain）的转正版，但大幅简化：
+   desktop 档位的后端是单进程（POLARIS_PROFILE=desktop = SQLite +
+   进程内任务队列 + 进程内 fakeredis，见 #583），所以只拉一个 api
+   进程——不需要 redis 容器、不需要 worker 容器、不需要共享卷。
+
+   两种模式：
+   - docker：桌面端主用形态。容器名固定，disposer 里 `docker rm -f`
+     兜底：attached 的 docker 客户端死了容器未必跟着死，按名字删才是
+     可靠回收（Spike-1 的结论）。
+   - command：直接 spawn 给定 argv。单元测试用 node -e 起假引擎即可
+     全程不依赖 docker，也是未来裸进程发行形态的座位。
+
+   健康轮询通过后以 ctx.provide('legacy') 挂出服务；失败则抛错让
+   fiber 进 FAILED（cordis 失败路径会照跑 disposer，子进程不会孤儿）。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+import Schema from '@deepseek-ai/schemastery'
+import type { Context } from '@deepseek-ai/cordis'
+
+/** docker 模式的固定容器名：可预测的名字才能在 disposer 与冒烟里精确回收。 */
+export const ENGINE_CONTAINER = 'polaris-desktop-engine'
+
+/** 环形日志缓冲的行数上限。取「一屏多一点」：够定位启动失败，不吃内存。 */
+const LOG_LIMIT = 200
+
+export interface LegacyEngineConfig {
+  mode: 'command' | 'docker'
+  /** command 模式：完整 argv（[0] 是可执行文件）。 */
+  command?: string[]
+  /** docker 模式：镜像名（可带 tag）。 */
+  image?: string
+  /** docker 模式：挂到容器 /srv/backend 的后端源码目录（绝对路径）。 */
+  backendDir?: string
+  /** 宿主侧监听端口（只绑 127.0.0.1）。 */
+  port?: number
+  /** 健康轮询超时。首启要跑全部 alembic 迁移，默认给足两分钟。 */
+  healthTimeoutMs?: number
+}
+
+export const LegacyEngineConfig = Schema.object({
+  mode: Schema.union(['command', 'docker'] as const).required(),
+  command: Schema.array(String),
+  image: Schema.string(),
+  backendDir: Schema.string(),
+  port: Schema.number().default(18080),
+  healthTimeoutMs: Schema.number().default(120_000),
+})
+
+export interface LegacyEngineService {
+  /** 本地后端根地址，如 http://127.0.0.1:18080。 */
+  baseUrl: string
+  /** 最近约 200 行 stdout/stderr（alembic / uvicorn 的启动横幅都在这），排错用。 */
+  logTail(): string
+}
+
+/** 等子进程退出；超时返回 false（调用方决定是否升级成 SIGKILL）。 */
+function exited(child: ChildProcess, ms: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) return resolve(true)
+    const timer = setTimeout(() => {
+      child.off('exit', onExit)
+      resolve(false)
+    }, ms)
+    const onExit = (): void => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    child.once('exit', onExit)
+  })
+}
+
+function buildArgv(config: LegacyEngineConfig, port: number): string[] {
+  if (config.mode === 'command') {
+    if (!config.command?.length) {
+      throw new Error('legacy-engine: mode=command 需要非空的 command argv')
+    }
+    return config.command
+  }
+  if (!config.image || !config.backendDir) {
+    throw new Error('legacy-engine: mode=docker 需要 image 与 backendDir')
+  }
+  return [
+    'docker', 'run', '--rm', '--name', ENGINE_CONTAINER,
+    '-v', `${config.backendDir}:/srv/backend`,
+    '-w', '/srv/backend',
+    // 只绑回环地址：本地引擎是单机私有服务，绝不能暴露到局域网
+    '-p', `127.0.0.1:${port}:8000`,
+    '-e', 'POLARIS_PROFILE=desktop',
+    '-e', 'POLARIS_LLM_FAKE_FALLBACK=1',
+    config.image,
+    'sh', '-lc',
+    // 先迁移后起服务：desktop 档位没有独立 worker 抢跑迁移的问题，串行即可
+    'python -m alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000',
+  ]
+}
+
+export const legacyEngine = {
+  name: 'legacy-engine',
+
+  Config: LegacyEngineConfig,
+
+  async apply(ctx: Context, config: LegacyEngineConfig): Promise<void> {
+    const port = config.port ?? 18080
+    const healthTimeoutMs = config.healthTimeoutMs ?? 120_000
+    const baseUrl = `http://127.0.0.1:${port}`
+
+    const lines: string[] = []
+    const capture = (chunk: Buffer): void => {
+      for (const line of chunk.toString().split('\n')) {
+        if (line) lines.push(line)
+      }
+      if (lines.length > LOG_LIMIT) lines.splice(0, lines.length - LOG_LIMIT)
+    }
+
+    let child!: ChildProcess
+    // spawn 放进 effect：fiber 被 dispose（kernel.stop / 插件卸载 / 启动失败）
+    // 时 disposer 必然执行，子进程不会变孤儿。
+    ctx.effect(() => {
+      const argv = buildArgv(config, port)
+      child = spawn(argv[0]!, argv.slice(1), {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // 两种模式统一注入 desktop 档位环境。docker 模式下真正生效的是
+        // 上面的 -e 参数（这里只影响 docker 客户端，无害）；command 模式
+        // 靠它保证裸进程也跑在单进程档位上。
+        env: { ...process.env, POLARIS_PROFILE: 'desktop', POLARIS_LLM_FAKE_FALLBACK: '1' },
+      })
+      child.stdout!.on('data', capture)
+      child.stderr!.on('data', capture)
+      return async () => {
+        if (config.mode === 'docker') {
+          // 按容器名强删：attached 客户端先死时容器可能残留，名字才是真锚点
+          try {
+            execFileSync('docker', ['rm', '-f', ENGINE_CONTAINER], { stdio: 'ignore' })
+          } catch {
+            /* 容器已不在 */
+          }
+        }
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGTERM')
+          if (!(await exited(child, 5_000))) {
+            child.kill('SIGKILL')
+            await exited(child, 5_000)
+          }
+        }
+      }
+    }, 'legacy-engine process')
+
+    const deadline = Date.now() + healthTimeoutMs
+    for (;;) {
+      // 进程先死了就别傻等到超时：把日志尾巴直接带进错误里，省一轮排错
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(
+          `legacy engine exited before becoming healthy (code=${child.exitCode}, signal=${child.signalCode})\n${lines.join('\n')}`,
+        )
+      }
+      try {
+        const res = await fetch(`${baseUrl}/api/health`)
+        if (res.ok) break
+      } catch {
+        /* 还没起来 */
+      }
+      if (Date.now() > deadline) {
+        throw new Error(
+          `legacy engine did not become healthy within ${healthTimeoutMs}ms\n${lines.join('\n')}`,
+        )
+      }
+      await delay(500)
+    }
+
+    const service: LegacyEngineService = {
+      baseUrl,
+      logTail: () => lines.join('\n'),
+    }
+    ctx.provide('legacy', service)
+  },
+}

--- a/src/kernel/tests/legacy-engine.test.ts
+++ b/src/kernel/tests/legacy-engine.test.ts
@@ -1,0 +1,96 @@
+/* legacy-engine 插件的单元测试：只测 command 模式，故意不碰 docker——
+   docker 形态由 desktop 冒烟（POLARIS_SMOKE_ENGINE=1）覆盖，这里保证
+   在任何 CI 机器上都能跑。假引擎用 node -e 起一个最小 HTTP 服务器。 */
+import { describe, expect, it } from 'vitest'
+import { createKernel, legacyEngine, type LegacyEngineService } from '../src/index.ts'
+
+const until = async (cond: () => boolean, ms = 5_000): Promise<void> => {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 25))
+  }
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** 假引擎脚本：/api/health 返回 {"status":"ok"}，并把 pid 打到 stdout，
+    让测试能经 logTail() 拿到真实进程号做「dispose 后确实死了」的断言。 */
+function fakeEngineScript(port: number): string {
+  return [
+    "const http = require('node:http');",
+    "console.log('pid=' + process.pid);",
+    'const srv = http.createServer((req, res) => {',
+    "  res.setHeader('content-type', 'application/json');",
+    // 顺带回显 profile：断言 command 模式也注入了 POLARIS_PROFILE=desktop
+    "  res.end(JSON.stringify({ status: 'ok', profile: process.env.POLARIS_PROFILE || '' }));",
+    '});',
+    `srv.listen(${port}, '127.0.0.1');`,
+  ].join('\n')
+}
+
+describe('legacy-engine plugin (command mode)', () => {
+  it('provides the legacy service once healthy and kills the process on dispose', async () => {
+    const port = 21000 + Math.floor(Math.random() * 9000)
+    const kernel = createKernel({ name: 'engine-test' })
+    await kernel.start()
+
+    await kernel.ctx.plugin(legacyEngine, {
+      mode: 'command',
+      command: [process.execPath, '-e', fakeEngineScript(port)],
+      port,
+      healthTimeoutMs: 15_000,
+    })
+
+    const legacy = kernel.ctx.get('legacy') as LegacyEngineService | undefined
+    expect(legacy).toBeTruthy()
+    expect(legacy!.baseUrl).toBe(`http://127.0.0.1:${port}`)
+
+    const res = await fetch(`${legacy!.baseUrl}/api/health`)
+    expect(res.ok).toBe(true)
+    const body = (await res.json()) as { status: string; profile: string }
+    expect(body.status).toBe('ok')
+    expect(body.profile).toBe('desktop')
+
+    // stdout 是异步管道，pid 行可能晚于 health 就绪一拍
+    await until(() => /pid=\d+/.test(legacy!.logTail()))
+    const pid = Number(/pid=(\d+)/.exec(legacy!.logTail())![1])
+    expect(pidAlive(pid)).toBe(true)
+
+    await kernel.stop()
+    await until(() => !pidAlive(pid))
+  }, 30_000)
+
+  it('fails the fiber (and reclaims the child) when health never comes up', async () => {
+    const port = 21000 + Math.floor(Math.random() * 9000)
+    const kernel = createKernel({ name: 'engine-timeout' })
+    await kernel.start()
+
+    // 进程活着但从不监听端口：健康轮询必须在超时后抛错、fiber 进 FAILED
+    let message = ''
+    try {
+      await kernel.ctx.plugin(legacyEngine, {
+        mode: 'command',
+        command: [process.execPath, '-e', "console.log('pid=' + process.pid); setInterval(() => {}, 1000);"],
+        port,
+        healthTimeoutMs: 1_500,
+      })
+    } catch (err) {
+      message = String(err)
+    }
+    expect(message).toMatch(/did not become healthy/)
+    // 错误信息必须带日志尾巴（排错的关键承诺），顺便从里面拿到真实 pid
+    const pid = Number(/pid=(\d+)/.exec(message)![1])
+    expect(kernel.ctx.get('legacy')).toBeUndefined()
+    // 失败路径也不能留孤儿：disposer 已随 fiber 失败执行
+    await until(() => !pidAlive(pid))
+    await kernel.stop()
+  }, 15_000)
+})


### PR DESCRIPTION
Closes #602. Part of #564 (P1 track A, item A4).

Promotes the P0 Spike-1 prototype into a production kernel plugin and points the renderer at the locally supervised backend when one is running.

## Kernel
- New `legacy-engine` plugin (electron-free): schemastery config with `command` and `docker` spawn modes, single-process desktop-profile backend (`POLARIS_PROFILE=desktop`, per #580 — no redis/worker containers), health polling with a 120s default budget, a 200-line ring buffer exposed as `logTail()`, and `ctx.provide('legacy', { baseUrl, logTail })` once healthy. The effect disposer kills the child (docker mode additionally `docker rm -f`s the named container, since the attached client dying does not guarantee the container dies).
- Startup failure (timeout or early exit) fails the fiber with the log tail embedded in the error.
- Unit tests use a `node -e` fake engine in command mode: health-gated service availability, child reaped on dispose, and the timeout path also reaps the child. No docker dependency.

## Desktop
- `POLARIS_DESKTOP_ENGINE` (`docker:<image>:<absBackendDir>` or `command:<json argv>`) installs the plugin at kernel start; absence keeps today's remote-server flow. Engine failure logs and falls back to remote instead of blocking startup.
- New IPC method `kernel.localBackend` → `{ baseUrl: string | null }`, read via the public `ctx.get('legacy')` reflect API.
- CSP: the local engine origin (http + ws) is added to `connect-src` — without it every renderer request to 127.0.0.1 is blocked and the endpoint switch is moot.
- Smoke: a "local engine" group runs only when `POLARIS_SMOKE_ENGINE=1` and the `polaris-api-test:local` image exists (skips otherwise): kernel boots the engine, `/api/health` answers on the reported URL, and the container is gone after `stopKernel`.

## Frontend
- `endpoint.ts` probes `kernel.localBackend` once through the host bridge (module-level promise cache); a non-null answer makes `serverOrigin()`/`apiBase()`/`wsUrl()` prefer the local base. `portalUrl()` deliberately stays on the remote origin — share links pointing at 127.0.0.1 are useless to recipients.
- `main.tsx` awaits the probe before mounting only when a host bridge exists, so the first request already targets the right base; the web path keeps its synchronous mount with zero extra requests.

## Verification
- kernel lint + tests: 13 passed (4 files)
- desktop lint + build, frontend build: clean
- desktop smoke with `POLARIS_SMOKE_ENGINE=1` against the real docker image: all groups ok, including the local-engine group (health reachable, container reclaimed)