### PR TITLE
feat: kernel storage plugin with SQLite-backed config tree

### DIFF
--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -16,4 +16,7 @@ export {
   legacyEngine,
   type LegacyEngineService,
 } from './plugins/legacy-engine.ts'
+export { MIGRATIONS, migrate, openStorage, type Migration } from './storage/db.ts'
+export { PluginMetaStore, SqliteConfigTreeStore } from './storage/store.ts'
+export { StorageConfig, storage, type StorageService } from './plugins/storage.ts'
 export { Context } from '@deepseek-ai/cordis'

--- a/src/kernel/src/plugins/storage.ts
+++ b/src/kernel/src/plugins/storage.ts
@@ -1,0 +1,67 @@
+/* ============================================================
+   storage 插件：为 kernel 挂载 SQLite 持久层。
+
+   打开句柄放进 ctx.effect：fiber 被 dispose（kernel.stop / 插件卸载 /
+   启动失败）时 disposer 必然执行，数据库句柄不会泄漏；重新装载插件
+   等价于重开一次库，migrate 的幂等性保证重开无副作用。
+
+   close 失败只记日志不抛：disposer 跑在整条 dispose 链上，这里一炸
+   会连累其他插件的清理（子进程回收等），句柄泄漏远比清理链断裂便宜。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import type { DatabaseSync } from 'node:sqlite'
+import Schema from '@deepseek-ai/schemastery'
+import type { Context } from '@deepseek-ai/cordis'
+import { migrate, openStorage } from '../storage/db.ts'
+import { PluginMetaStore, SqliteConfigTreeStore } from '../storage/store.ts'
+
+export interface StorageConfig {
+  /** 数据库文件的绝对路径。父目录不存在会自动创建。 */
+  path: string
+}
+
+export const StorageConfig = Schema.object({
+  path: Schema.string().required(),
+})
+
+export interface StorageService {
+  /** 底层句柄。留给需要自建表的插件（配表迁移仍走 MIGRATIONS）。 */
+  db: DatabaseSync
+  /** 配置树的持久化实现（ConfigTreeStore）。 */
+  configTree: SqliteConfigTreeStore
+  /** 插件私有 JSON KV。 */
+  pluginMeta: PluginMetaStore
+  /** 实际打开的数据库文件路径，诊断用。 */
+  path: string
+}
+
+export const storage = {
+  name: 'storage',
+
+  Config: StorageConfig,
+
+  apply(ctx: Context, config: StorageConfig): void {
+    let db!: DatabaseSync
+    ctx.effect(() => {
+      db = openStorage(config.path)
+      migrate(db)
+      return () => {
+        try {
+          db.close()
+        } catch (error) {
+          // 见文件头：吞掉并记日志，绝不让 dispose 链爆炸
+          console.warn(`storage: failed to close database at ${config.path}:`, error)
+        }
+      }
+    }, 'storage database handle')
+
+    const service: StorageService = {
+      db,
+      configTree: new SqliteConfigTreeStore(db),
+      pluginMeta: new PluginMetaStore(db),
+      path: config.path,
+    }
+    ctx.provide('storage', service)
+  },
+}

--- a/src/kernel/src/storage/db.ts
+++ b/src/kernel/src/storage/db.ts
@@ -1,0 +1,102 @@
+/* ============================================================
+   SQLite 存储底座：打开数据库 + 最小前向迁移器。
+
+   为什么是 node:sqlite 而不是 better-sqlite3/drizzle：kernel 要在
+   Electron 主进程与裸 Node 双形态下运行，本机也编不了原生模块——
+   Node 内置的 DatabaseSync 零编译、零依赖，Spike-2
+   （spikes/p0/2-sqlite-bench）已验证它扛得住文献库量级，配置树这种
+   小表更不在话下。
+
+   迁移器刻意做到最小：只前向、不回滚（桌面单机库，坏了靠备份而不是
+   down-migration）、按版本号有序执行、事务内落表并记账，重跑天然无操作。
+   ============================================================ */
+
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+export interface Migration {
+  /** 单调递增的版本号，与 `_migrations` 表记账对齐。 */
+  version: number
+  /** 本版本要执行的 DDL/DML 语句，整体包在一个事务里。 */
+  statements: string[]
+}
+
+/**
+ * 全部前向迁移，按 version 升序追加。已发布的条目一律只增不改——
+ * 改历史条目会让老库与新库走出不同的 schema。
+ */
+export const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    statements: [
+      // 配置树：列与 ConfigEntry 字段一一对应；children 树形结构用
+      // parent_id + position（同层内次序）落平，load 时再拼回去。
+      // config/disabled 允许 NULL 以区分「键不存在」与显式的值，
+      // has_children 记录「children 键是否存在」——这样重开库读回的
+      // 对象能与写入时逐字段一致（含空数组这种边角）。
+      // parent_id 级联删除让整树替换（save 全量覆盖）不用操心孤儿行。
+      `CREATE TABLE config_entries (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT REFERENCES config_entries(id) ON DELETE CASCADE,
+        position INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        config TEXT,
+        disabled INTEGER,
+        has_children INTEGER NOT NULL DEFAULT 0
+      )`,
+      `CREATE INDEX idx_config_entries_parent ON config_entries(parent_id)`,
+      // 插件私有元数据的 JSON KV 区：值统一 JSON 编码，避免每个插件
+      // 自己发明一张小表。
+      `CREATE TABLE plugin_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`,
+    ],
+  },
+]
+
+/**
+ * 打开（必要时创建）数据库文件并设置连接级 PRAGMA。
+ * 父目录不存在时先建好——桌面端首启时 userData 下的子目录未必存在。
+ */
+export function openStorage(path: string): DatabaseSync {
+  mkdirSync(dirname(path), { recursive: true })
+  const db = new DatabaseSync(path)
+  // WAL：读写不互斥，桌面端 UI 读配置树时不被后台写阻塞
+  db.exec('PRAGMA journal_mode = WAL')
+  // foreign_keys 是连接级开关，SQLite 默认关着，每次打开都要显式开
+  db.exec('PRAGMA foreign_keys = ON')
+  return db
+}
+
+/**
+ * 把库推进到最新版本。幂等：已应用的版本按 `_migrations` 记账跳过，
+ * 全部应用过则整个调用是空操作。每个版本的语句在一个事务里执行并
+ * 记账，中途失败回滚，库停在上一个完整版本。
+ */
+export function migrate(db: DatabaseSync, migrations: Migration[] = MIGRATIONS): void {
+  db.exec(`CREATE TABLE IF NOT EXISTS _migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+  )`)
+  const { current } = db
+    .prepare('SELECT COALESCE(MAX(version), 0) AS current FROM _migrations')
+    .get() as { current: number }
+
+  const pending = [...migrations].sort((a, b) => a.version - b.version)
+  for (const migration of pending) {
+    if (migration.version <= current) continue
+    db.exec('BEGIN')
+    try {
+      for (const statement of migration.statements) db.exec(statement)
+      db.prepare('INSERT INTO _migrations (version, applied_at) VALUES (?, ?)')
+        .run(migration.version, new Date().toISOString())
+      db.exec('COMMIT')
+    } catch (error) {
+      db.exec('ROLLBACK')
+      throw error
+    }
+  }
+}

--- a/src/kernel/src/storage/store.ts
+++ b/src/kernel/src/storage/store.ts
@@ -1,0 +1,131 @@
+/* ============================================================
+   SQLite 落地的两个存储：配置树 + 插件元数据 KV。
+
+   SqliteConfigTreeStore 的语义对齐 MemoryConfigTreeStore：save 全量
+   覆盖、load 返回与写入逐字段一致的深拷贝。选全量覆盖而不是 diff
+   写入，是因为配置树很小（几十个条目），UI 每次编辑都拿着整树，
+   diff 只会换来一堆边界 bug；真要增量是 reconciler 的事，不在存储层。
+
+   PluginMetaStore 是各插件的私有 JSON KV：schema 归 _migrations 管，
+   数据归各插件自己管，互不越界。
+   ============================================================ */
+
+import type { DatabaseSync } from 'node:sqlite'
+import type { ConfigEntry, ConfigTreeStore } from '../config/tree.ts'
+
+interface ConfigEntryRow {
+  id: string
+  parent_id: string | null
+  position: number
+  name: string
+  config: string | null
+  disabled: number | null
+  has_children: number
+}
+
+export class SqliteConfigTreeStore implements ConfigTreeStore {
+  readonly #db: DatabaseSync
+
+  constructor(db: DatabaseSync) {
+    this.#db = db
+  }
+
+  /** 读全树：一次 SELECT 拉平表，再按 parent_id + position 拼回树形。 */
+  async load(): Promise<ConfigEntry[]> {
+    const rows = this.#db
+      .prepare('SELECT * FROM config_entries ORDER BY position')
+      .all() as unknown as ConfigEntryRow[]
+
+    const byParent = new Map<string | null, ConfigEntryRow[]>()
+    for (const row of rows) {
+      const siblings = byParent.get(row.parent_id) ?? []
+      siblings.push(row)
+      byParent.set(row.parent_id, siblings)
+    }
+
+    const build = (parentId: string | null): ConfigEntry[] =>
+      (byParent.get(parentId) ?? []).map((row) => {
+        const entry: ConfigEntry = { id: row.id, name: row.name }
+        // 只还原写入时存在的键：undefined 键落库时记 NULL，读回时不补键，
+        // 保证 load(save(x)) 与内存实现的 structuredClone 语义一致
+        if (row.config !== null) entry.config = JSON.parse(row.config)
+        if (row.disabled !== null) entry.disabled = row.disabled !== 0
+        if (row.has_children) entry.children = build(row.id)
+        return entry
+      })
+
+    return build(null)
+  }
+
+  /** 写全树：事务内清空重写。整树替换让 save 天然幂等且原子。 */
+  async save(entries: ConfigEntry[]): Promise<void> {
+    const insert = this.#db.prepare(
+      `INSERT INTO config_entries (id, parent_id, position, name, config, disabled, has_children)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    const walk = (list: ConfigEntry[], parentId: string | null): void => {
+      list.forEach((entry, position) => {
+        insert.run(
+          entry.id,
+          parentId,
+          position,
+          entry.name,
+          entry.config === undefined ? null : JSON.stringify(entry.config),
+          entry.disabled === undefined ? null : entry.disabled ? 1 : 0,
+          entry.children === undefined ? 0 : 1,
+        )
+        if (entry.children) walk(entry.children, entry.id)
+      })
+    }
+
+    this.#db.exec('BEGIN')
+    try {
+      this.#db.exec('DELETE FROM config_entries')
+      walk(entries, null)
+      this.#db.exec('COMMIT')
+    } catch (error) {
+      this.#db.exec('ROLLBACK')
+      throw error
+    }
+  }
+}
+
+/** 插件元数据 KV：值统一 JSON 编解码，键不存在返回 undefined。 */
+export class PluginMetaStore {
+  readonly #db: DatabaseSync
+
+  constructor(db: DatabaseSync) {
+    this.#db = db
+  }
+
+  get(key: string): unknown {
+    const row = this.#db
+      .prepare('SELECT value FROM plugin_meta WHERE key = ?')
+      .get(key) as { value: string } | undefined
+    return row === undefined ? undefined : JSON.parse(row.value)
+  }
+
+  set(key: string, value: unknown): void {
+    // upsert 而不是 delete+insert：单语句原子，也保住主键上的行锁语义
+    this.#db
+      .prepare(
+        `INSERT INTO plugin_meta (key, value, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      )
+      .run(key, JSON.stringify(value), new Date().toISOString())
+  }
+
+  /** 删除键，返回是否真的删了（不存在时 false）。 */
+  delete(key: string): boolean {
+    const result = this.#db.prepare('DELETE FROM plugin_meta WHERE key = ?').run(key)
+    return result.changes > 0
+  }
+
+  /** 全部键，按字典序——稳定次序方便调试与测试断言。 */
+  list(): string[] {
+    const rows = this.#db
+      .prepare('SELECT key FROM plugin_meta ORDER BY key')
+      .all() as unknown as { key: string }[]
+    return rows.map((row) => row.key)
+  }
+}

--- a/src/kernel/tests/storage.test.ts
+++ b/src/kernel/tests/storage.test.ts
@@ -1,0 +1,191 @@
+/* storage 插件与 SQLite 存储的单元测试。全部落在 mkdtemp 出来的临时
+   目录里，跑完整体删除，不污染仓库。ConfigTreeStore 是接口级契约，
+   所以内存实现与 SQLite 实现跑同一套契约用例——两边语义必须一致，
+   reconciler 才能在 spike 与正式形态之间无感切换。 */
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  MIGRATIONS,
+  MemoryConfigTreeStore,
+  PluginMetaStore,
+  SqliteConfigTreeStore,
+  createKernel,
+  migrate,
+  openStorage,
+  storage,
+  type ConfigEntry,
+  type ConfigTreeStore,
+  type StorageService,
+} from '../src/index.ts'
+
+const dir = mkdtempSync(join(tmpdir(), 'kernel-storage-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+let seq = 0
+const freshPath = (): string => join(dir, `db-${++seq}.sqlite`)
+
+/** 覆盖各字段形态的样例树：嵌套分组、中文、显式 disabled、空 children。 */
+const sampleTree = (): ConfigEntry[] => [
+  {
+    id: 'root',
+    name: 'group',
+    children: [
+      { id: 'root:engine', name: 'legacy-engine', config: { mode: 'docker', 端口: 18080 } },
+      { id: 'root:off', name: 'gateway', disabled: true, config: null },
+      { id: 'root:empty', name: 'group', children: [] },
+    ],
+  },
+  { id: 'bare', name: '裸插件' },
+]
+
+/* ---------- ConfigTreeStore 接口契约：两个实现跑同一套 ---------- */
+
+type StoreFactory = () => { store: ConfigTreeStore; close?: () => void }
+
+const implementations: [string, StoreFactory][] = [
+  ['MemoryConfigTreeStore', () => ({ store: new MemoryConfigTreeStore() })],
+  [
+    'SqliteConfigTreeStore',
+    () => {
+      const db = openStorage(freshPath())
+      migrate(db)
+      return { store: new SqliteConfigTreeStore(db), close: () => db.close() }
+    },
+  ],
+]
+
+describe.each(implementations)('ConfigTreeStore contract: %s', (_name, make) => {
+  it('starts empty', async () => {
+    const { store, close } = make()
+    expect(await store.load()).toEqual([])
+    close?.()
+  })
+
+  it('load returns exactly what was saved, field by field', async () => {
+    const { store, close } = make()
+    await store.save(sampleTree())
+    expect(await store.load()).toEqual(sampleTree())
+    close?.()
+  })
+
+  it('load returns a detached copy (mutations do not leak back)', async () => {
+    const { store, close } = make()
+    await store.save(sampleTree())
+    const first = await store.load()
+    first[0]!.name = 'mutated'
+    first[0]!.children!.pop()
+    expect(await store.load()).toEqual(sampleTree())
+    close?.()
+  })
+
+  it('save replaces the whole tree', async () => {
+    const { store, close } = make()
+    await store.save(sampleTree())
+    const next: ConfigEntry[] = [{ id: 'only', name: 'solo', config: { a: [1, 2, 3] } }]
+    await store.save(next)
+    expect(await store.load()).toEqual(next)
+    await store.save([])
+    expect(await store.load()).toEqual([])
+    close?.()
+  })
+})
+
+/* ---------- SQLite 专属：跨重开持久化 + 迁移幂等 ---------- */
+
+describe('sqlite storage', () => {
+  it('config tree survives close/reopen with identical fields', async () => {
+    const path = freshPath()
+    const db = openStorage(path)
+    migrate(db)
+    await new SqliteConfigTreeStore(db).save(sampleTree())
+    db.close()
+
+    const reopened = openStorage(path)
+    migrate(reopened)
+    expect(await new SqliteConfigTreeStore(reopened).load()).toEqual(sampleTree())
+    reopened.close()
+  })
+
+  it('migrate is idempotent across calls and reopens', () => {
+    const path = freshPath()
+    const db = openStorage(path)
+    migrate(db)
+    migrate(db)
+    const count = (): number =>
+      Number(
+        (db.prepare('SELECT COUNT(*) AS n FROM _migrations').get() as { n: number | bigint }).n,
+      )
+    expect(count()).toBe(MIGRATIONS.length)
+    db.close()
+
+    const reopened = openStorage(path)
+    migrate(reopened)
+    const versions = reopened
+      .prepare('SELECT version FROM _migrations ORDER BY version')
+      .all() as unknown as { version: number }[]
+    expect(versions.map((row) => row.version)).toEqual(MIGRATIONS.map((m) => m.version))
+    reopened.close()
+  })
+
+  it('plugin meta round-trips JSON values, including CJK and nesting', () => {
+    const db = openStorage(freshPath())
+    migrate(db)
+    const meta = new PluginMetaStore(db)
+
+    expect(meta.get('missing')).toBeUndefined()
+    meta.set('文献库', { 名称: '个人库', papers: [{ title: '论文①', score: 0.9 }], 启用: true })
+    meta.set('plain', 42)
+    expect(meta.get('文献库')).toEqual({
+      名称: '个人库',
+      papers: [{ title: '论文①', score: 0.9 }],
+      启用: true,
+    })
+    expect(meta.get('plain')).toBe(42)
+
+    // 覆盖写走 upsert 路径
+    meta.set('plain', { nested: { deep: ['值'] } })
+    expect(meta.get('plain')).toEqual({ nested: { deep: ['值'] } })
+
+    expect(meta.list()).toEqual(['plain', '文献库'])
+    expect(meta.delete('plain')).toBe(true)
+    expect(meta.delete('plain')).toBe(false)
+    expect(meta.list()).toEqual(['文献库'])
+    db.close()
+  })
+})
+
+/* ---------- 插件形态：装载 / 卸载 / 重装 ---------- */
+
+describe('storage plugin', () => {
+  it('provides the service, closes the handle on dispose, and reloads', async () => {
+    // 故意用不存在的多级子目录：验证 openStorage 的 mkdir -p
+    const path = join(dir, 'nested', 'deeper', 'kernel.db')
+    const kernel = createKernel({ name: 'storage-test' })
+    await kernel.start()
+
+    const fiber = await kernel.ctx.plugin(storage, { path })
+    const service = kernel.ctx.get('storage') as StorageService | undefined
+    expect(service).toBeTruthy()
+    expect(service!.path).toBe(path)
+    expect(existsSync(path)).toBe(true)
+
+    service!.pluginMeta.set('probe', { 值: 1 })
+    await service!.configTree.save(sampleTree())
+
+    await fiber.dispose()
+    // 句柄确实关了：再操作必须抛错，而不是静默写一个死库
+    expect(() => service!.db.prepare('SELECT 1')).toThrow()
+    expect(kernel.ctx.get('storage')).toBeUndefined()
+
+    // 同一 kernel 里重新装载：migrate 幂等 + 数据还在
+    await kernel.ctx.plugin(storage, { path })
+    const reloaded = kernel.ctx.get('storage') as StorageService
+    expect(reloaded.pluginMeta.get('probe')).toEqual({ 值: 1 })
+    expect(await reloaded.configTree.load()).toEqual(sampleTree())
+
+    await kernel.stop()
+    expect(() => reloaded.db.prepare('SELECT 1')).toThrow()
+  })
+})


### PR DESCRIPTION
Closes #606. Part of #564 (P1 track A, item A5).

Adds a `storage` kernel plugin that persists kernel state locally, replacing the memory-only config tree when installed.

- SQLite via the built-in `node:sqlite` driver — the zero-compile path validated in the P0 spikes; no native build chain, no Electron ABI concerns
- `openStorage(path)`: mkdir-p for the parent directory, WAL journal mode, foreign keys on
- minimal forward-only migration runner: a `_migrations(version, applied_at)` ledger, each version applied in a transaction with rollback on failure; idempotent across reruns and reopens
- `SqliteConfigTreeStore` implements `ConfigTreeStore` with semantics matched field-by-field to `MemoryConfigTreeStore` (NULL columns distinguish absent keys from empty values; `parent_id + position` flattens the tree; `save` is a transactional full replace)
- `PluginMetaStore`: JSON key-value area for plugin metadata (single-statement UPSERT)
- plugin shape: `ctx.effect` opens/migrates and the disposer closes the handle — a close failure logs instead of throwing so it cannot break the rest of the dispose chain; `ctx.provide('storage', { db, configTree, pluginMeta, path })`

Tests (12 new, kernel suite now 25): a shared contract suite runs against both the memory and SQLite stores; SQLite-specific cases cover roundtrip across reopen, migration idempotence, unicode/nested JSON metadata, dispose-then-reinstall retaining data, and handle closure after dispose.