### PR TITLE
test: shell-level end-to-end suite with Playwright and the local engine

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -82,3 +82,13 @@ jobs:
       - name: Smoke test
         working-directory: src/desktop
         run: xvfb-run -a pnpm run smoke
+
+      # Shell-level E2E (issue #611): drives the real main process with
+      # Playwright's _electron. Only the engine-less group runs here — the
+      # "shell + auto-login" group needs the polaris-api-test:local image,
+      # and building it on every PR costs multiple minutes (see
+      # docker-build.yml); the runner has docker but not the image, so that
+      # group logs an explicit skip. Run it locally with POLARIS_E2E_ENGINE=1.
+      - name: E2E test (no engine)
+        working-directory: src/desktop
+        run: xvfb-run -a pnpm run e2e

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
+      playwright-core:
+        specifier: ^1.49.0
+        version: 1.62.1
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
@@ -2252,6 +2255,11 @@ packages:
   picomatch@4.0.7:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -4922,6 +4930,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.7: {}
+
+  playwright-core@1.62.1: {}
 
   plist@3.1.1:
     dependencies:

--- a/src/desktop/e2e/e2e.ts
+++ b/src/desktop/e2e/e2e.ts
@@ -1,0 +1,238 @@
+/* ============================================================
+   壳级 E2E（issue #611）：用 Playwright 的 _electron 驱动真实的
+   dist/main.cjs，把「起壳 → 本地引擎 → 免登录 → 建课题」这条只有
+   运行时才暴露的链路整条走一遍。与 smoke.ts 互补：smoke 在 Electron
+   进程内做白盒断言，这里从进程外像用户一样操作 UI。
+
+   两个断言组：
+   - A「壳与免登录」：需要 docker 与 polaris-api-test:local 镜像，
+     门控照抄冒烟——设 POLARIS_E2E_ENGINE=1 且镜像存在才跑，否则
+     打明确日志后 skip（CI 无镜像时仍然全绿）。
+   - B「无引擎回落」：不依赖 docker，任何机器必跑。不设引擎 env 起壳，
+     应停在服务器配置页而不是崩溃。
+
+   并行安全：容器名与端口都随机化（经 POLARIS_DESKTOP_ENGINE_CONTAINER /
+   _PORT 覆盖默认值），同机的其他 docker 套件或手动实例互不干扰；
+   userData 指向 mkdtemp 出来的临时目录，单实例锁也随之隔离。
+
+   用法：pnpm run e2e（需要先 build 前端；本包各产物由脚本自动构建）。
+   Linux CI 里需要 xvfb-run。退出码非 0 即失败。
+   ============================================================ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { _electron, type ElectronApplication, type Page } from 'playwright-core';
+
+// Node 里 require('electron') 拿到的是可执行文件路径（字符串），类型声明
+// 描述的是渲染/主进程 API，所以这里显式断言。
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const electronPath = require('electron') as unknown as string;
+
+const MAIN = join(__dirname, 'main.cjs');
+// __dirname = src/desktop/dist → 仓库的 src/backend（与 smoke.ts 同一推导）
+const BACKEND_DIR = join(__dirname, '..', '..', 'backend');
+const ENGINE_IMAGE = 'polaris-api-test:local';
+
+const problems: string[] = [];
+
+function check(label: string, ok: boolean, detail = ''): void {
+  if (ok) {
+    console.log(`  ok   ${label}`);
+  } else {
+    problems.push(label);
+    console.log(`  FAIL ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+/** 起壳用的环境：继承当前进程，但把引擎相关 env 全部清干净——
+    组 B 必须证明「没有任何引擎配置」时壳也能正常起。 */
+function launchEnv(overrides: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  delete env.POLARIS_DESKTOP_ENGINE;
+  delete env.POLARIS_DESKTOP_ENGINE_CONTAINER;
+  delete env.POLARIS_DESKTOP_ENGINE_PORT;
+  // 内部分发机器可能设了默认服务器：会让「未配置服务器」的断言失真
+  delete env.POLARIS_DEFAULT_SERVER_URL;
+  return { ...env, ...overrides };
+}
+
+async function launch(env: Record<string, string>): Promise<{ app: ElectronApplication; page: Page }> {
+  const app = await _electron.launch({
+    executablePath: electronPath,
+    args: [MAIN],
+    env,
+    timeout: 60_000,
+  });
+  // 窗口在 startKernel 之后才创建：docker 引擎首启要跑全部迁移（最长 120s），
+  // 等窗口的超时必须盖过它。
+  const page = app.windows()[0] ?? ((await app.waitForEvent('window', { timeout: 240_000 })) as Page);
+  await page.waitForLoadState('domcontentloaded');
+  return { app, page };
+}
+
+/** 走真实退出路径（app.quit → before-quit → stopKernel → 引擎 disposer），
+    而不是让 Playwright 直接掐进程——容器回收正是要测的东西。 */
+async function shutdown(app: ElectronApplication | null): Promise<void> {
+  if (!app) return;
+  try {
+    await app.evaluate(({ app: electronApp }) => electronApp.quit());
+    await app.waitForEvent('close', { timeout: 30_000 }).catch(() => undefined);
+  } catch {
+    /* 主进程可能已经退了 */
+  }
+  await app.close().catch(() => undefined);
+}
+
+function dockerNames(): string[] {
+  try {
+    return execFileSync('docker', ['ps', '--format', '{{.Names}}'], { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function dockerHasImage(): boolean {
+  try {
+    execFileSync('docker', ['image', 'inspect', ENGINE_IMAGE], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* ---------------- 组 A：壳与免登录（需引擎） ---------------- */
+
+async function groupEngine(): Promise<void> {
+  console.log('壳与免登录（本地引擎）');
+  if (process.env.POLARIS_E2E_ENGINE !== '1') {
+    console.log('  skip 壳与免登录组（未设 POLARIS_E2E_ENGINE=1）');
+    return;
+  }
+  if (!dockerHasImage()) {
+    console.log(`  skip 壳与免登录组（docker 不可用或缺镜像 ${ENGINE_IMAGE}）`);
+    return;
+  }
+
+  // 容器名/端口随机化：默认名 polaris-desktop-engine 若被并行任务占着，
+  // docker run 会直接撞名失败，回收时还可能误删别人的容器。
+  const container = `polaris-desktop-engine-e2e-${Math.random().toString(36).slice(2, 8)}`;
+  const port = 18100 + Math.floor(Math.random() * 1800);
+  const userData = mkdtempSync(join(tmpdir(), 'polaris-e2e-a-'));
+  let app: ElectronApplication | null = null;
+
+  try {
+    const r = await launch(
+      launchEnv({
+        POLARIS_DESKTOP_ENGINE: `docker:${ENGINE_IMAGE}:${BACKEND_DIR}`,
+        POLARIS_DESKTOP_ENGINE_CONTAINER: container,
+        POLARIS_DESKTOP_ENGINE_PORT: String(port),
+        POLARIS_USER_DATA_DIR: userData,
+      }),
+    );
+    app = r.app;
+    const { page } = r;
+
+    // 免登录（#601）：desktop 档后端 local_session=true，RequireAuth 应静默
+    // 换会话直接进工作台。等 AppShell 的侧栏出现即视为「进了应用」；
+    // 全新数据库没有课题，会被 RequireTopic 送到 /start。
+    await page.waitForSelector('.sidebar', { timeout: 60_000 });
+    await page.waitForSelector('text=/选择或创建课题|Pick or create a topic/', { timeout: 30_000 });
+    check('免登录直达工作台（侧栏 + /start 落地页）', true);
+
+    const authCards = await page.locator('.auth-card-title').count();
+    const path = await page.evaluate('window.location.pathname');
+    check('不是登录页/配置页', authCards === 0 && path !== '/login', `authCards=${authCards} path=${String(path)}`);
+
+    // 渲染进程内直接打本地引擎：证明 CSP 放行了 127.0.0.1、端点解析走了本地
+    const health = (await page.evaluate(
+      (u: string) => fetch(u).then((res) => res.status).catch(() => 0),
+      `http://127.0.0.1:${port}/api/health`,
+    )) as number;
+    check('渲染进程可达本地引擎 /api/health', health === 200, `status=${health}`);
+
+    // 深一步：从 UI 建一个课题（常规模式只需名称），断言出现在列表里
+    const topicName = `E2E 课题 ${Math.random().toString(36).slice(2, 8)}`;
+    await page.getByRole('button', { name: /新建课题|New topic/ }).click();
+    await page.waitForSelector('.project-wizard-card', { timeout: 30_000 });
+    await page.locator('.project-wizard-card input.input').first().fill(topicName);
+    await page.getByRole('button', { name: /创建课题|Create topic/ }).click();
+    await page.waitForURL(/app:\/\/polaris\/t\//, { timeout: 30_000 });
+    check('创建课题后进入课题工作台（/t/<id>）', true);
+
+    // 回落地页确认列表可见——整页重载，顺带验证会话在刷新后依然有效
+    await page.goto('app://polaris/start');
+    await page.waitForSelector('.sidebar', { timeout: 60_000 });
+    const visible = await page
+      .getByText(topicName)
+      .first()
+      .isVisible()
+      .catch(() => false);
+    check('新建课题出现在课题列表', visible, `name=${topicName}`);
+  } catch (err) {
+    check('壳与免登录组执行完成', false, String(err).slice(0, 400));
+  } finally {
+    await shutdown(app);
+    // 真实退出路径应已回收容器；轮询确认（docker rm 是异步的）
+    let gone = false;
+    for (let i = 0; i < 30; i++) {
+      if (!dockerNames().includes(container)) {
+        gone = true;
+        break;
+      }
+      await delay(500);
+    }
+    check('退出后引擎容器已回收', gone, `container=${container}`);
+    if (!gone) {
+      // 兜底清理，别把失败现场留给下一轮（上面的 FAIL 已经记账）
+      try {
+        execFileSync('docker', ['rm', '-f', container], { stdio: 'ignore' });
+      } catch {
+        /* 已不在 */
+      }
+    }
+    rmSync(userData, { recursive: true, force: true });
+  }
+}
+
+/* ---------------- 组 B：无引擎回落（必跑） ---------------- */
+
+async function groupNoEngine(): Promise<void> {
+  console.log('\n无引擎回落');
+  const userData = mkdtempSync(join(tmpdir(), 'polaris-e2e-b-'));
+  let app: ElectronApplication | null = null;
+
+  try {
+    const r = await launch(launchEnv({ POLARIS_USER_DATA_DIR: userData }));
+    app = r.app;
+    const { page } = r;
+
+    // 未配置服务器、也没有本地引擎：应停在首启的服务器配置页，而不是白屏/崩溃
+    await page.waitForSelector('.auth-card-title', { timeout: 30_000 });
+    const title = (await page.locator('.auth-card-title').textContent()) ?? '';
+    check('停在服务器配置页', /连接到服务器|Connect to a server/.test(title), `title=${title}`);
+    check('窗口仍然存活（未崩溃）', !page.isClosed());
+
+    const mounted = (await page.evaluate('document.querySelector("#root")?.childElementCount ?? 0')) as number;
+    check('React 应用已挂载', mounted > 0, `children=${mounted}`);
+  } catch (err) {
+    check('无引擎回落组执行完成', false, String(err).slice(0, 400));
+  } finally {
+    await shutdown(app);
+    rmSync(userData, { recursive: true, force: true });
+  }
+}
+
+void (async () => {
+  await groupEngine();
+  await groupNoEngine();
+  console.log(problems.length ? `\n${problems.length} 项失败` : '\n全部通过');
+  process.exit(problems.length ? 1 : 0);
+})();

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -20,7 +20,9 @@
     "stage:resources": "node scripts/fetch-uv.mjs && node scripts/stage-backend.mjs",
     "dist:mac": "pnpm run stage:resources && pnpm run build && electron-builder --mac --universal",
     "dist:win": "pnpm run stage:resources && pnpm run build && electron-builder --win",
-    "dist:linux": "pnpm run stage:resources && pnpm run build && electron-builder --linux"
+    "dist:linux": "pnpm run stage:resources && pnpm run build && electron-builder --linux",
+    "build:e2e": "esbuild e2e/e2e.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/e2e.cjs --packages=external",
+    "e2e": "pnpm run build:main && pnpm run build:preload && pnpm run build:agent && pnpm run build:e2e && node dist/e2e.cjs"
   },
   "dependencies": {
     "@polaris/kernel": "workspace:*"
@@ -30,6 +32,7 @@
     "electron": "^33.0.0",
     "electron-builder": "^25.0.0",
     "esbuild": "^0.24.0",
+    "playwright-core": "^1.49.0",
     "typescript": "^5.5.4"
   }
 }

--- a/src/desktop/src/main/index.ts
+++ b/src/desktop/src/main/index.ts
@@ -13,6 +13,13 @@ import { createWindow, getWindow } from './window';
  */
 const DEEP_LINK_SCHEME = 'polaris';
 
+// 测试挂钩：E2E 用临时 userData 起壳，既保证首启状态干净（config.json /
+// localStorage 都是空的），也让单实例锁按目录隔离——不会与用户正开着的
+// 正式实例互踢。必须在 requestSingleInstanceLock 与一切读 userData 的
+// 代码之前设好。正常启动不设此 env，行为一字不变。
+const userDataOverride = process.env.POLARIS_USER_DATA_DIR;
+if (userDataOverride) app.setPath('userData', userDataOverride);
+
 // 必须早于 app.whenReady()
 registerAppScheme();
 

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -106,6 +106,15 @@ export async function startKernel(): Promise<Kernel> {
   instance.ctx.plugin(desktopProbe);
 
   let engine = parseEngineSpec(process.env.POLARIS_DESKTOP_ENGINE);
+  // 并行隔离（壳级 E2E / 同机多实例）：docker 容器名与宿主端口默认是固定值，
+  // 两个实例同时跑必然撞名撞端口。这两个 env 只在显式指定引擎的测试/调试
+  // 场景使用，打包态的自动引导不经过它们。
+  if (engine) {
+    const name = process.env.POLARIS_DESKTOP_ENGINE_CONTAINER;
+    if (name) engine = { ...engine, containerName: name };
+    const port = Number(process.env.POLARIS_DESKTOP_ENGINE_PORT);
+    if (Number.isInteger(port) && port > 0) engine = { ...engine, port };
+  }
   if (!engine && app.isPackaged) {
     engine = await bootstrapPackagedEngine();
   }

--- a/src/desktop/tsconfig.json
+++ b/src/desktop/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "e2e"]
 }

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -13,6 +13,7 @@ export {
 export {
   ENGINE_CONTAINER,
   LegacyEngineConfig,
+  buildEngineArgv,
   legacyEngine,
   type LegacyEngineService,
 } from './plugins/legacy-engine.ts'

--- a/src/kernel/src/plugins/legacy-engine.ts
+++ b/src/kernel/src/plugins/legacy-engine.ts
@@ -23,7 +23,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 import Schema from '@deepseek-ai/schemastery'
 import type { Context } from '@deepseek-ai/cordis'
 
-/** docker 模式的固定容器名：可预测的名字才能在 disposer 与冒烟里精确回收。 */
+/** docker 模式的默认容器名：可预测的名字才能在 disposer 与冒烟里精确回收。 */
 export const ENGINE_CONTAINER = 'polaris-desktop-engine'
 
 /** 环形日志缓冲的行数上限。取「一屏多一点」：够定位启动失败，不吃内存。 */
@@ -37,6 +37,10 @@ export interface LegacyEngineConfig {
   image?: string
   /** docker 模式：挂到容器 /srv/backend 的后端源码目录（绝对路径）。 */
   backendDir?: string
+  /** docker 模式：容器名，默认 ENGINE_CONTAINER。同机并行多个实例（如壳级
+      E2E 与手动开发实例同时在跑）时必须各用各的名字，否则 docker run 直接
+      撞名失败、disposer 还会误删别人的容器。 */
+  containerName?: string
   /** 宿主侧监听端口（只绑 127.0.0.1）。 */
   port?: number
   /** 健康轮询超时。首启要跑全部 alembic 迁移，默认给足两分钟。 */
@@ -48,6 +52,7 @@ export const LegacyEngineConfig = Schema.object({
   command: Schema.array(String),
   image: Schema.string(),
   backendDir: Schema.string(),
+  containerName: Schema.string(),
   port: Schema.number().default(18080),
   healthTimeoutMs: Schema.number().default(120_000),
 })
@@ -75,7 +80,9 @@ function exited(child: ChildProcess, ms: number): Promise<boolean> {
   })
 }
 
-function buildArgv(config: LegacyEngineConfig, port: number): string[] {
+/** 导出仅为可测性：docker 模式在单测里不真跑容器，但 argv 的拼装（容器名/
+    端口/挂载）必须有回归护栏——E2E 靠自定义容器名与并行套件隔离。 */
+export function buildEngineArgv(config: LegacyEngineConfig, port: number): string[] {
   if (config.mode === 'command') {
     if (!config.command?.length) {
       throw new Error('legacy-engine: mode=command 需要非空的 command argv')
@@ -86,7 +93,7 @@ function buildArgv(config: LegacyEngineConfig, port: number): string[] {
     throw new Error('legacy-engine: mode=docker 需要 image 与 backendDir')
   }
   return [
-    'docker', 'run', '--rm', '--name', ENGINE_CONTAINER,
+    'docker', 'run', '--rm', '--name', config.containerName ?? ENGINE_CONTAINER,
     '-v', `${config.backendDir}:/srv/backend`,
     '-w', '/srv/backend',
     // 只绑回环地址：本地引擎是单机私有服务，绝不能暴露到局域网
@@ -122,7 +129,7 @@ export const legacyEngine = {
     // spawn 放进 effect：fiber 被 dispose（kernel.stop / 插件卸载 / 启动失败）
     // 时 disposer 必然执行，子进程不会变孤儿。
     ctx.effect(() => {
-      const argv = buildArgv(config, port)
+      const argv = buildEngineArgv(config, port)
       child = spawn(argv[0]!, argv.slice(1), {
         stdio: ['ignore', 'pipe', 'pipe'],
         // 两种模式统一注入 desktop 档位环境。docker 模式下真正生效的是
@@ -136,7 +143,7 @@ export const legacyEngine = {
         if (config.mode === 'docker') {
           // 按容器名强删：attached 客户端先死时容器可能残留，名字才是真锚点
           try {
-            execFileSync('docker', ['rm', '-f', ENGINE_CONTAINER], { stdio: 'ignore' })
+            execFileSync('docker', ['rm', '-f', config.containerName ?? ENGINE_CONTAINER], { stdio: 'ignore' })
           } catch {
             /* 容器已不在 */
           }

--- a/src/kernel/tests/legacy-engine.test.ts
+++ b/src/kernel/tests/legacy-engine.test.ts
@@ -2,7 +2,7 @@
    docker 形态由 desktop 冒烟（POLARIS_SMOKE_ENGINE=1）覆盖，这里保证
    在任何 CI 机器上都能跑。假引擎用 node -e 起一个最小 HTTP 服务器。 */
 import { describe, expect, it } from 'vitest'
-import { createKernel, legacyEngine, type LegacyEngineService } from '../src/index.ts'
+import { ENGINE_CONTAINER, buildEngineArgv, createKernel, legacyEngine, type LegacyEngineService } from '../src/index.ts'
 
 const until = async (cond: () => boolean, ms = 5_000): Promise<void> => {
   const start = Date.now()
@@ -93,4 +93,25 @@ describe('legacy-engine plugin (command mode)', () => {
     await until(() => !pidAlive(pid))
     await kernel.stop()
   }, 15_000)
+})
+
+/* docker 模式不真跑容器（那是 desktop 冒烟/E2E 的事），但 argv 拼装要有
+   回归护栏：容器名可覆盖是 E2E 与并行套件互不撞名的前提。 */
+describe('legacy-engine buildEngineArgv (docker mode)', () => {
+  const base = { mode: 'docker' as const, image: 'img:tag', backendDir: '/abs/backend' }
+
+  it('uses the default container name and wires image/mount/port', () => {
+    const argv = buildEngineArgv(base, 18080)
+    expect(argv.slice(0, 5)).toEqual(['docker', 'run', '--rm', '--name', ENGINE_CONTAINER])
+    expect(argv).toContain('img:tag')
+    expect(argv).toContain('/abs/backend:/srv/backend')
+    expect(argv).toContain('127.0.0.1:18080:8000')
+  })
+
+  it('honors a custom containerName so parallel instances do not collide', () => {
+    const argv = buildEngineArgv({ ...base, containerName: 'polaris-engine-e2e-x' }, 19000)
+    expect(argv.slice(3, 5)).toEqual(['--name', 'polaris-engine-e2e-x'])
+    expect(argv).toContain('127.0.0.1:19000:8000')
+    expect(argv).not.toContain(ENGINE_CONTAINER)
+  })
 })


### PR DESCRIPTION
Closes #611. Part of #564 (P1 track C, item C2).

Adds a Playwright-driven E2E that exercises the desktop shell as a user hits it, complementing the golden-transcript harness (#584) which owns the research flows.

- `e2e/e2e.ts` drives the real `dist/main.cjs` via `playwright-core`'s `_electron.launch` — chosen over `playwright`/`@playwright/test` because it exports the same electron support without the browser-download postinstall (Electron ships its own Chromium)
- group A (gated like the engine smoke: `POLARIS_E2E_ENGINE=1` + local api image): boots with a supervised docker engine on a randomized container name and port so parallel suites never collide, then asserts the no-login path lands directly in the workspace, the renderer reaches `/api/health` on the local base, a project created through the real UI wizard shows up after a full reload, and the engine container is reclaimed after a real quit path (before-quit → stopKernel → disposer)
- group B (always runs, CI included): without an engine the shell starts cleanly and stays on the server-config/login surface
- no frontend changes and no test ids — assertions use the existing shell selectors
- supporting hooks: `POLARIS_USER_DATA_DIR` redirects userData before the single-instance lock (clean first-run in a mkdtemp dir, lock isolated per directory); `POLARIS_DESKTOP_ENGINE_CONTAINER`/`_PORT` override the engine container name/port for explicit engine configs; the legacy-engine plugin gains an optional `containerName` (kernel suite now 27 with two docker-argv regressions)
- CI: `desktop-build.yml` runs the suite under xvfb after the smoke; group A skips with an explicit log there — building the api image on every PR would cost several minutes, and the full run remains a one-liner locally