### PR TITLE
docs: point DeepSeek Harness bundle links at the repository

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -105,7 +105,7 @@ The optional `X-Polaris-Tool-Profile` request header selects a stable catalog:
 
 Profiles govern both discovery and direct invocation. A client cannot call a
 hidden tool by guessing its name. See the
-[DeepSeek Harness bundle](../integrations/deepseek-harness/README.md) for token,
+[DeepSeek Harness bundle](https://github.com/ZJU-REAL/Polaris/tree/main/integrations/deepseek-harness) for token,
 installation, and skill-provider instructions.
 
 ---
@@ -349,5 +349,5 @@ that breaks a tool fails the build rather than surfacing in your agent.
   contract.
 - [Configuration](configuration.md#application-settings-polaris_-prefix) — public URL and link
   lifetime settings.
-- [DeepSeek Harness bundle](../integrations/deepseek-harness/README.md) — native
+- [DeepSeek Harness bundle](https://github.com/ZJU-REAL/Polaris/tree/main/integrations/deepseek-harness) — native
   skills, MCP profiles, installation, and operations.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -156,7 +156,7 @@ the model. After a Polaris skill loads, its `allowed-tools` list restricts only
 the current turn's Polaris MCP tools. Multiple skill lists intersect, and the
 restriction never widens the existing DSH tool surface.
 
-See [Polaris for DeepSeek Harness](../integrations/deepseek-harness/README.md)
+See [Polaris for DeepSeek Harness](https://github.com/ZJU-REAL/Polaris/tree/main/integrations/deepseek-harness)
 for installation, token scopes, failure behavior, and configuration.
 
 ## Tips and limits


### PR DESCRIPTION
The docs site build fails with 3 dead links: `docs/mcp.md` and `docs/skills.md` link `../integrations/deepseek-harness/README.md`, which exists in the repository but outside the site's content root, so every Pages deploy since the links were added (#427) aborts. Replace the relative links with the repository URL — valid both on GitHub and on the rendered site.