### PR TITLE
chore: retire library approval-status columns

### DIFF
--- a/src/backend/alembic/versions/c3c404803ca4_drop_library_status_columns.py
+++ b/src/backend/alembic/versions/c3c404803ca4_drop_library_status_columns.py
@@ -1,0 +1,39 @@
+"""退役 direction_libraries 的审批残留列（status/review_note）
+
+个人化定位（#619）：库的审批流已随 #593/#596 整体移除——新建库即刻可用、
+pending/rejected 再无写入口，status 恒为 'active'，review_note 恒空。两列只剩
+「看起来还有一套生命周期」的误导性，删掉。共享语义由 is_public 独立承担
+（服主部署下创建者可直接设置的「公开给所有人」开关）。
+
+Revision ID: c3c404803ca4
+Revises: 9b2e5d81c7a3
+Create Date: 2026-09-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c3c404803ca4"
+down_revision: str | None = "9b2e5d81c7a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # sqlite 无法原地删列，batch_alter_table 走「重建表」路径；pg 上等价于 DROP COLUMN
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_column("review_note")
+        batch.drop_column("status")
+
+
+def downgrade() -> None:
+    # 复原 d3a7f1c9b2e4 的形状；数据不可恢复：status 全部落回 server_default 'active'
+    # （与「审批流移除后一切库皆 active」的现实一致），review_note 落 NULL。
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.add_column(
+            sa.Column("status", sa.String(length=16), nullable=False, server_default="active")
+        )
+        batch.add_column(sa.Column("review_note", sa.Text(), nullable=True))

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -146,17 +146,14 @@ async def _reads_with_extras(
 @router.get("/libraries", response_model=list[DirectionLibrarySummary])
 async def list_libraries(
     type: str | None = Query(default=None, pattern="^(personal|public|all)$"),
-    status_filter: str | None = Query(default=None, alias="status"),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[DirectionLibrarySummary]:
-    """可见方向库（P10）：普通用户看自己的个人库 + 全部公共库，admin 看全部。
+    """可见方向库（P10）：自己的个人库 + 全部公共库 + 无主库。
 
-    可选 ``type``（personal|public|all，默认 all）与 ``status`` 在可见集合内进一步筛选。
+    可选 ``type``（personal|public|all，默认 all）在可见集合内进一步筛选。
     """
-    rows = await libraries_service.list_libraries_overview(
-        session, user=user, type=type, status=status_filter
-    )
+    rows = await libraries_service.list_libraries_overview(session, user=user, type=type)
     return [DirectionLibrarySummary(**row) for row in rows]
 
 
@@ -169,9 +166,9 @@ async def create_library(
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
     """用户独立新建方向文献库（任意登录用户，P10）：新库即刻可用的**个人库**
-    （status=active、is_public=false，仅创建者 + admin 可见，token 记创建者账），
-    无需审批。创建者记为 submitted_by 并自动成为该库策展人。想转公共（全实验室可见、
-    走系统 key）经 POST /libraries/{id}/request-public 申请、admin 审批。不属于任何课题。
+    （is_public=false，仅创建者可见，token 记创建者账）。创建者记为 submitted_by；
+    想公开给所有人在库设置里直接打开 is_public（审批流已随 #593/#596 移除）。
+    不属于任何课题。
     """
     library = await libraries_service.create_library(
         session,
@@ -233,7 +230,7 @@ async def get_library(
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
     library = await _get_library(session, library_id)
-    # 可见性（P9b）：pending/rejected 库仅创建者 + admin 可见，其余人视为不存在。
+    # 可见性（P10）：个人库仅创建者可见，其余人视为不存在（404，不泄漏存在性）。
     if not libraries_service.library_visible_to(library, user):
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
     row = await libraries_service.library_overview(session, library=library, user=user)
@@ -268,8 +265,6 @@ async def generate_library_digest(
 ) -> DigestGenerateRead:
     """生成今日简报：有今日更新则直接生成，否则先执行一次增量同步。"""
     library = await _get_managed_library(session, library_id, user)
-    if library.status != "active":
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_NOT_ACTIVE")
     project = (
         await session.get(Project, library.project_id) if library.project_id is not None else None
     )
@@ -316,8 +311,8 @@ async def update_library(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> DirectionLibraryDetail:
-    """编辑库定义（可管理者）：name/monthly_budget 与收录配置（statement/cadence/
-    rubric/anchors/keywords/goals/scope/questions）。
+    """编辑库定义（可管理者）：name/monthly_budget/is_public（公开给所有人）与收录
+    配置（statement/cadence/rubric/anchors/keywords/goals/scope/questions）。
 
     P8a：收录配置写入 library.definition（ingest 唯一权威源），不再写回起源课题。
     """
@@ -391,9 +386,6 @@ async def start_library_ingest(
     带上 project 以兼容活动流/鉴权。互斥以库为准，超预算 409 拒绝。
     """
     library = await _get_managed_library(session, library_id, user)
-    if library.status != "active":
-        # 待审批 / 已驳回的库不能抓取（P9b：仅 active 且预算内可触发）。
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_NOT_ACTIVE")
     project = (
         await session.get(Project, library.project_id) if library.project_id is not None else None
     )

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -65,15 +65,9 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     ingest_state: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
     cadence: Mapped[str | None] = mapped_column(String(32))  # 同步节奏：daily | weekly | ...
     monthly_budget: Mapped[int | None]  # 每月 ingest 预算（P6 治理用）
-    # 生命周期（P9b）：pending 待审批 | active 已激活（可抓取）| rejected 已驳回。
-    # server_default='active'——存量库与课题隐式起源库都视为已激活；用户经
-    # POST /libraries 独立建的库显式落 pending，管理员审批后转 active。
-    status: Mapped[str] = mapped_column(String(16), nullable=False, server_default="active")
-    review_note: Mapped[str | None] = mapped_column(Text)  # 驳回理由（status=rejected 时有值）
-    # 归属（P10）：个人库 is_public=false（仅创建者 + admin 可见/可管理），公共库
-    # is_public=true（全实验室可见，全体 admin + 创建者/策展人可管理）。个人库经
-    # POST /libraries/{id}/request-public 申请、admin 审批后转公共。存量 active 库
-    # 迁移回填为公共（保留原全员可读语义）。
+    # 共享开关（原 P10「个人/公共」归属）：false = 仅创建者可见的个人库；true = 对本
+    # 部署所有用户可见。审批流已随 #593/#596 移除、status/review_note 残留列随 #619
+    # 删除：创建者在库设置里直接切换，不再经任何审批。
     is_public: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -20,12 +20,12 @@ class DirectionLibrarySummary(BaseModel):
     statement: str | None
     # 过渡期隐式库回指的课题；未来共享库可为 None
     project_id: uuid.UUID | None
-    # 生命周期（P9b）：pending 待审批（=申请转公共）| active 可用 | rejected 已驳回
-    status: str
-    # 归属（P10）：个人库 false（仅创建者 + admin 可见）| 公共库 true（全实验室可见）
-    is_public: bool = False
-    # 驳回理由（转公共被驳回时有值）
+    # 审批流残留（#619 删列）：恒为 "active" / None。语义已死，但仍随响应下发——
+    # golden transcript 逐字节比对响应形状，纯移除改动不动 wire 形状。
+    status: str = "active"
     review_note: str | None = None
+    # 共享开关：false = 仅创建者可见的个人库 | true = 对本部署所有用户可见
+    is_public: bool = False
     # 库创建者（个人库仅创建者 + admin 可见）
     submitted_by: uuid.UUID | None = None
     # 创建者展示名（submitted_by 的 display_name，前端展示归属）
@@ -55,7 +55,7 @@ class DirectionLibraryDetail(DirectionLibrarySummary):
 
 
 class LibraryCreate(BaseModel):
-    """独立新建方向文献库（POST /libraries，任意登录用户；新库 status=pending 待审批）。
+    """独立新建方向文献库（POST /libraries，任意登录用户；新库即刻可用，无审批）。
 
     P9b：必填仅 name + statement；anchors 只填 arxiv-id 列表（抓取时解析元数据），
     keywords 可选。创建只是配置，不触发抓取、不花 token。
@@ -100,12 +100,6 @@ class SuggestedAnchor(BaseModel):
     reason: str | None = None
 
 
-class LibraryReject(BaseModel):
-    """驳回 pending 库（POST /libraries/{id}/reject，平台 admin）。"""
-
-    note: str | None = Field(default=None, max_length=2000)
-
-
 class SourceLibrariesUpdate(BaseModel):
     """课题关联库全量替换（PUT /projects/{id}/source-libraries）；空列表 = 清空关联。"""
 
@@ -132,6 +126,8 @@ class DirectionLibraryUpdate(BaseModel):
     in_scope: list[Any] | None = None
     out_of_scope: list[Any] | None = None
     questions: list[Any] | None = None
+    # 共享开关（#619）：审批流移除后创建者直接设置「公开给所有人」；None = 不改
+    is_public: bool | None = None
 
 
 class CuratorsUpdate(BaseModel):

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -504,16 +504,14 @@ async def reclaim_stale_paused_ingests(session: AsyncSession) -> list[uuid.UUID]
 
 
 async def find_due_daily_libraries(session: AsyncSession) -> list[DirectionLibrary]:
-    """每日增量的对象，**直接按文献库选**：active、已 bootstrap、无任务在跑。
+    """每日增量的对象，**直接按文献库选**：已 bootstrap、无任务在跑。
 
     以前是遍历 Project 再找库，于是 ``project_id`` 为空的独立库一个都进不来——生产上
-    11 个活跃库里有 6 个是独立库，全靠人工点击才会同步。另外那条路径也没检查库的
-    ``status``，pending/rejected 但留有历史水位线的库照样会被 cron 拉起来。
+    11 个活跃库里有 6 个是独立库，全靠人工点击才会同步。审批流移除后不再有
+    pending/rejected 之分（#619 删列），全部库都是候选，靠下面的水位线/互斥筛。
     """
     libraries = (
-        (await session.execute(select(DirectionLibrary).where(DirectionLibrary.status == "active")))
-        .scalars()
-        .all()
+        (await session.execute(select(DirectionLibrary))).scalars().all()
     )
     # 今天已经**自动**同步过的库不再重复选。这一条以前写在调用方，而且是全局的：
     # 「今天有任意一条 wiki_ingest」就整轮跳过。于是任何人手动同步任何一个库，当天

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -405,9 +405,7 @@ def _overview_dict(
         "monthly_budget": library.monthly_budget,
         "definition": library_definition(library),
         "project_id": library.project_id,
-        "status": library.status,
         "is_public": library.is_public,
-        "review_note": library.review_note,
         "submitted_by": library.submitted_by,
         "owner_name": owner_name,
         "is_owner": is_owner,
@@ -438,13 +436,12 @@ async def list_libraries_overview(
     *,
     user: User,
     type: str | None = None,
-    status: str | None = None,
 ) -> list[dict[str, Any]]:
     """可见方向库 + 概要统计（P10）。
 
-    可见范围：admin 看全部；普通用户看**自己的个人库（submitted_by==me 且非 public）
-    ∪ 全部公共库（is_public）**。可选 ``type``（personal|public|all，默认 all）与
-    ``status`` 做进一步筛选（都不影响可见性边界，只在可见集合内过滤）。
+    可见范围：自己的个人库（submitted_by==me 且非 public）∪ 全部公共库（is_public）
+    ∪ 无主库。可选 ``type``（personal|public|all，默认 all）在可见集合内进一步筛选
+    （不影响可见性边界）。
     """
     libraries = (
         (await session.execute(select(DirectionLibrary).order_by(DirectionLibrary.created_at)))
@@ -464,8 +461,6 @@ async def list_libraries_overview(
         if want == "personal" and lib.is_public:
             continue
         if want == "public" and not lib.is_public:
-            continue
-        if status is not None and lib.status != status:
             continue
         result.append(
             _overview_dict(
@@ -554,14 +549,12 @@ async def create_library(
     keywords: dict[str, Any] | None = None,
     monthly_budget: int | None = None,
     created_by: uuid.UUID,
-    status: str = "active",
 ) -> DirectionLibrary:
     """用户独立新建方向文献库（P10；``project_id`` 恒为 NULL——不属于任何课题，靠关联被消费）。
 
-    P10：任意登录用户可建，新库默认 ``status='active'`` + ``is_public=false``——即刻
-    可用的**个人库**（仅创建者 + admin 可见，token 记创建者账），无需审批。创建者记为
-    ``submitted_by`` 并自动加为该库策展人（文献库管理员）。想让全实验室可见/走系统 key
-    的，经 ``POST /libraries/{id}/request-public`` 申请、admin 审批后转公共库。
+    任意登录用户可建，新库即刻可用、默认 ``is_public=false``（仅创建者可见，token 记
+    创建者账）。创建者记为 ``submitted_by``。想公开给所有人：创建者在库设置里直接打开
+    ``is_public``（审批流已随 #593/#596 移除）。
 
     flush + refresh，不 commit（调用方 api 层负责事务收尾）。
     """
@@ -586,7 +579,6 @@ async def create_library(
         monthly_budget=monthly_budget,
         created_by=created_by,
         submitted_by=created_by,
-        status=status,
         project_id=None,
     )
     session.add(library)
@@ -677,7 +669,7 @@ async def update_library(
 ) -> DirectionLibrary:
     """编辑库定义（显式传 null 可清空）。P8a：库是收录配置的唯一权威源。
 
-    - name / monthly_budget 落标量列；
+    - name / monthly_budget / is_public 落标量列；
     - statement/cadence/rubric/anchors/keywords/questions/goals/scope 等收录配置写入
       library.definition（ingest 从这里取数），并把有对应标量列的键镜像回列供展示；
     - 允许整体传入 ``definition`` 一次性替换。
@@ -687,6 +679,10 @@ async def update_library(
         library.name = fields["name"]  # name 非空约束：显式 null/空串视为不改名
     if "monthly_budget" in fields:
         library.monthly_budget = fields["monthly_budget"]
+    # 共享开关（#619）：审批流移除后由创建者直接设置；None（显式传 null）视为不改——
+    # 这个开关没有「清空」语义，误清成 False 会把公共库悄悄藏起来。
+    if fields.get("is_public") is not None:
+        library.is_public = bool(fields["is_public"])
 
     config_keys = [k for k in fields if k in _CONFIG_TO_DEFINITION]
     if "definition" in fields or config_keys:

--- a/src/backend/app/services/literature/discovery_schedules.py
+++ b/src/backend/app/services/literature/discovery_schedules.py
@@ -264,8 +264,9 @@ async def claim_due_schedules(
                 schedule.last_error_code = "RUN_ALREADY_ACTIVE"
             continue
         library = await session.get(DirectionLibrary, schedule.library_id)
-        if library is None or library.status != "active":
-            schedule.last_error_code = "LIBRARY_NOT_ACTIVE"
+        if library is None:
+            # 库已被删而定时任务行还挂着（审批流移除后这是唯一的「库不可用」情形）
+            schedule.last_error_code = "LIBRARY_NOT_FOUND"
             continue
         try:
             async with session.begin_nested():

--- a/src/backend/app/services/obsidian_vault_sync.py
+++ b/src/backend/app/services/obsidian_vault_sync.py
@@ -359,7 +359,6 @@ async def _resolve_library(
         name=name,
         statement=statement,
         created_by=project.owner_id,
-        status="active",
     )
     session.add(TopicSourceLibrary(topic_id=project.id, library_id=library.id))
     await session.commit()

--- a/src/backend/app/tools/libraries.py
+++ b/src/backend/app/tools/libraries.py
@@ -41,7 +41,6 @@ def _library_brief(row: dict[str, Any], *, linked: bool) -> dict[str, Any]:
         "library_id": str(row["id"]),
         "name": row["name"],
         "is_public": row["is_public"],
-        "status": row["status"],
         "paper_count": row["paper_count"],
         "concept_count": row["concept_count"],
         "linked_to_this_topic": linked,

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -134,8 +134,7 @@ async def ensure_project_library(session, project_id):
     library = DirectionLibrary(
         name=project.name if project else "test-lib",
         project_id=pid,
-        status="active",
-        is_public=True,  # 课题起源库=共享库（P10：全实验室可读，等价存量 active 回填公共）
+        is_public=True,  # 课题起源库=共享库（P10：全实验室可读）
         created_by=None,
         # 起源库记课题主人为创建者：库级写权限 = admin ∪ 创建者（策展人已随 #593 移除）
         submitted_by=project.owner_id if project else None,
@@ -303,7 +302,6 @@ async def make_project_with_library(
             name=name,
             definition=definition,
             project_id=project_id,
-            status="active",
             is_public=True,  # 课题起源库=共享库（P10：全实验室可读）
             created_by=None,
             submitted_by=owner_id,

--- a/src/backend/tests/test_download_batch_protocol.py
+++ b/src/backend/tests/test_download_batch_protocol.py
@@ -33,7 +33,6 @@ async def _target(email: str, *, name: str = "batch library", papers: int = 1):
         ).scalar_one()
         library = DirectionLibrary(
             name=name,
-            status="active",
             is_public=False,
             submitted_by=owner.id,
             created_by=owner.id,

--- a/src/backend/tests/test_lab_dashboard.py
+++ b/src/backend/tests/test_lab_dashboard.py
@@ -37,7 +37,7 @@ async def _make_library(*, name, is_public, owner_email=None) -> uuid.UUID:
                 await session.execute(select(User).where(User.email == owner_email))
             ).scalar_one().id
         library = DirectionLibrary(
-            name=name, status="active", is_public=is_public, submitted_by=submitted_by
+            name=name, is_public=is_public, submitted_by=submitted_by
         )
         session.add(library)
         await session.commit()

--- a/src/backend/tests/test_library_approval.py
+++ b/src/backend/tests/test_library_approval.py
@@ -1,6 +1,7 @@
-"""文献库归属与可见性 —— 建库即 active 个人库（转公共审批流已随实验室定位移除）。
+"""文献库归属与可见性 —— 建库即个人库（转公共审批流已随实验室定位移除，
+status/review_note 残留列随 #619 删除）。
 
-- 任意登录用户建库 → 即刻可用的**个人库**（status=active、is_public=false）；
+- 任意登录用户建库 → 即刻可用的**个人库**（is_public=false）；
 - 个人库仅创建者可见/可管理，token 记创建者账（admin 旁路已随 #614 移除）；
 - 存量公共库（is_public=true）仍全员可见；
 - 删除：一律创建者本人。
@@ -18,7 +19,7 @@ async def _hdr(client, email):
 
 
 async def _make_public(lib_id: str) -> None:
-    """直接把库置为公共（原转公共审批流已随实验室定位移除，测试造数据用）。"""
+    """直接把库置为公共（造数据快捷方式；正路是创建者 PATCH is_public，见下方专测）。"""
     async with get_sessionmaker()() as session:
         lib = await session.get(DirectionLibrary, uuid.UUID(lib_id))
         lib.is_public = True
@@ -33,7 +34,6 @@ async def _create_personal(client, headers, name="用户建的库"):
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["status"] == "active"
     assert body["is_public"] is False
     return body["id"]
 
@@ -47,7 +47,6 @@ async def test_user_creates_personal_active_library(client):
     lib_id = await _create_personal(client, user)
     async with get_sessionmaker()() as session:
         lib = await session.get(DirectionLibrary, uuid.UUID(lib_id))
-        assert lib.status == "active"
         assert lib.is_public is False
         assert lib.submitted_by is not None
         assert lib.definition["anchor_papers"] == ["2401.00001"]
@@ -250,6 +249,37 @@ async def test_list_type_filter(client):
     resp = await client.get("/api/libraries?type=public", headers=owner)
     ids = {x["id"] for x in resp.json()}
     assert public_id in ids and personal_id not in ids
+
+
+# ---- 共享开关：创建者直接切换 is_public（#619，审批流的替代物） ----
+
+
+async def test_creator_toggles_is_public_via_settings(client):
+    """审批流删掉后，「公开给所有人」就是创建者在库设置里直接拨的开关。
+
+    - 非创建者拨不动（403）；
+    - 打开 → 全员可见；关上 → 回到仅创建者可见；
+    - 显式传 null 视为不改（这个开关没有「清空」语义，误清成 False 会把公共库藏起来）。
+    """
+    owner = await _hdr(client, "toggle-owner@example.com")
+    stranger = await _hdr(client, "toggle-stranger@example.com")
+    lib_id = await _create_personal(client, owner, name="开关测试库")
+
+    resp = await client.patch(
+        f"/api/libraries/{lib_id}", json={"is_public": True}, headers=stranger
+    )
+    assert resp.status_code == 403, resp.text
+
+    resp = await client.patch(f"/api/libraries/{lib_id}", json={"is_public": True}, headers=owner)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["is_public"] is True
+    assert (await client.get(f"/api/libraries/{lib_id}", headers=stranger)).status_code == 200
+
+    resp = await client.patch(f"/api/libraries/{lib_id}", json={"is_public": False}, headers=owner)
+    assert resp.json()["is_public"] is False
+    resp = await client.patch(f"/api/libraries/{lib_id}", json={"is_public": None}, headers=owner)
+    assert resp.json()["is_public"] is False
+    assert (await client.get(f"/api/libraries/{lib_id}", headers=stranger)).status_code == 404
 
 
 # ---- 删除权限 ----

--- a/src/backend/tests/test_library_lifecycle.py
+++ b/src/backend/tests/test_library_lifecycle.py
@@ -56,7 +56,7 @@ async def test_create_project_can_link_existing_libraries(client):
     """P9c：建课题入参可关联已有库；语料 = 关联库并集。"""
     admin = await _register(client, "p7-link@example.com")
     async with get_sessionmaker()() as session:
-        lib = DirectionLibrary(name="已有库", created_by=None, project_id=None, status="active")
+        lib = DirectionLibrary(name="已有库", created_by=None, project_id=None)
         session.add(lib)
         await session.commit()
         lib_id = lib.id

--- a/src/backend/tests/test_literature_discovery_schedules.py
+++ b/src/backend/tests/test_literature_discovery_schedules.py
@@ -38,9 +38,6 @@ async def _library(client) -> tuple[DirectionLibrary, object]:
     async with get_sessionmaker()() as session:
         library = await session.get(DirectionLibrary, library_id)
         assert library is not None
-        library.status = "active"
-        await session.commit()
-        await session.refresh(library)
         actor_id = library.submitted_by
         session.expunge(library)
     return library, actor_id

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "f3a4b5c6d7e8"  # Scheduled incremental literature discovery
-HEAD_REVISION = "9b2e5d81c7a3"  # Drop in-app feedback tables (#617)
+HEAD_REVISION = "c3c404803ca4"  # Drop library status/review_note (P1 de-lab)
+FEEDBACK_DROP_REVISION = "9b2e5d81c7a3"  # Drop in-app feedback tables (#617)
 GOVERNANCE_DROP_REVISION = "4f8d2c9b7a61"  # Drop user governance columns (P1 de-lab)
 CURATORS_DROP_REVISION = "e6c31f84a2d5"  # Drop library curators (P1 de-lab)
 SKILL_RATINGS_DROP_REVISION = "d4b8e26f1a93"  # Drop skill ratings (P1 de-lab)
@@ -277,9 +277,10 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 任务系统库化 P9a：voyage_runs / activities 新增 library_id（project_id 转可空）
     assert "library_id" in columns["voyage_runs"]
     assert "library_id" in columns["activities"]
-    # 文献库生命周期 P9b：direction_libraries 新增 status/review_note/submitted_by
-    assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]
-    # 文献库归属 P10：direction_libraries.is_public 个人/公共
+    # P9b 只剩 submitted_by；status/review_note 审批残留已删（#619）
+    assert "submitted_by" in columns["direction_libraries"]
+    assert not {"status", "review_note"} & columns["direction_libraries"]
+    # 共享开关：direction_libraries.is_public（个人库 / 公开给所有人）
     assert "is_public" in columns["direction_libraries"]
     # P9e：课题 statement 上列；project.definition / projects.ingest_state 退役删列
     assert "statement" in columns["projects"]
@@ -510,7 +511,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "evidence_balance",
     } <= columns["interdisciplinary_research_profile_versions"]
 
-    # First undo the feedback-tables drop: both tables come back.
+    # 先退掉库状态删列：status/review_note 按原形状回来（server_default='active'）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == FEEDBACK_DROP_REVISION
+    assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]
+
+    # Then undo the feedback-tables drop: both tables come back.
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == GOVERNANCE_DROP_REVISION
@@ -803,7 +810,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 只退一步：标签库化（mig1）仍在，paper_tags 仍以 library_id 为键
     assert "library_id" in columns["paper_tags"]
     assert "project_id" not in columns["paper_tags"]
-    # P9b 三列仍在（本次 downgrade 未触及），P9a 的 library_id 仍在
+    # P9b 三列在场（#619 删列已在链条前段回退），P9a 的 library_id 仍在
     assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]
     assert "library_id" in columns["voyage_runs"]
     assert "library_id" in columns["activities"]
@@ -861,8 +868,9 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # P9a 列在重新 upgrade 后回归
     assert "library_id" in columns["voyage_runs"]
     assert "library_id" in columns["activities"]
-    # P9b 列在重新 upgrade 后回归
-    assert {"status", "review_note", "submitted_by"} <= columns["direction_libraries"]
+    # P9b 的 submitted_by 回归；status/review_note 在 head 已删（#619）
+    assert "submitted_by" in columns["direction_libraries"]
+    assert not {"status", "review_note"} & columns["direction_libraries"]
     # P10 归属列在重新 upgrade 后回归
     assert "is_public" in columns["direction_libraries"]
     # P9e 列在重新 upgrade 后回归：projects.statement 在、definition/ingest_state 删

--- a/src/backend/tests/test_paper_assets.py
+++ b/src/backend/tests/test_paper_assets.py
@@ -41,7 +41,6 @@ async def _library(session, *, user_id: uuid.UUID, public: bool = False) -> Dire
     library = DirectionLibrary(
         name=f"asset-{uuid.uuid4().hex[:8]}",
         statement="PDF asset test",
-        status="active",
         is_public=public,
         submitted_by=user_id,
         created_by=user_id,

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -41,7 +41,6 @@ async def _setup(client):
         library = DirectionLibrary(
             name=f"content-{uuid.uuid4().hex[:8]}",
             statement="content test",
-            status="active",
             submitted_by=user_id,
             created_by=user_id,
         )

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -548,7 +548,7 @@ async def test_collecting_libraries_lists_only_admitted_and_visible(client):
             ("别人的个人库", "scored", False, 0.85),
         ):
             lib = DirectionLibrary(
-                name=name, status="active", is_public=is_public, submitted_by=me.id
+                name=name, is_public=is_public, submitted_by=me.id
             )
             session.add(lib)
             await session.flush()

--- a/src/backend/tests/test_source_libraries.py
+++ b/src/backend/tests/test_source_libraries.py
@@ -146,8 +146,7 @@ async def test_create_library_admin_independent(client):
     assert body["name"] == "独立库"
     assert body["project_id"] is None
     assert body["is_mine"] is False
-    # P10：新建库即刻可用的个人库（active + 非 public），无需审批
-    assert body["status"] == "active"
+    # P10：新建库即刻可用的个人库（非 public），无需审批（status 列已随 #619 删除）
     assert body["is_public"] is False
 
 
@@ -162,7 +161,6 @@ async def test_create_library_any_user_allowed(client):
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["status"] == "active"
     assert body["is_public"] is False
     assert body["can_manage"] is True  # 创建者可管理自己的个人库
 

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -1003,8 +1003,6 @@ async def _create_standalone_library(client, headers, *, name="独立库-自动�
     assert resp.status_code == 201, resp.text
     body = resp.json()
     library_id = body["id"]
-    # P10：新库即刻是 active 个人库，无需审批即可触发抓取（token 记创建者账）。
-    assert body["status"] == "active"
     return library_id
 
 
@@ -1352,27 +1350,6 @@ async def test_a_library_is_only_auto_synced_once_a_day(client, queue_stub, wiki
         await session.commit()
 
     async with get_sessionmaker()() as session:
-        assert await ingest_service.find_due_daily_libraries(session) == []
-
-
-async def test_non_active_library_is_not_due(client, queue_stub, wiki_mocks):
-    """库 status 不是 active 就不该被 cron 拉起来——老的按课题选表压根没查这个字段。"""
-    token = await register_and_login(client, email="due-inactive@example.com")
-    headers = {"Authorization": f"Bearer {token}"}
-    library_id = await _create_standalone_library(client, headers, name="独立库-停用")
-
-    resp = await client.post(
-        f"/api/libraries/{library_id}/ingest/run",
-        json={"mode": "bootstrap", "knobs": KNOBS},
-        headers=headers,
-    )
-    engine, _ = _make_engine()
-    await engine.run(uuid.UUID(resp.json()["id"]))
-
-    async with get_sessionmaker()() as session:
-        library = await session.get(DirectionLibrary, uuid.UUID(library_id))
-        library.status = "rejected"
-        await session.commit()
         assert await ingest_service.find_due_daily_libraries(session) == []
 
 

--- a/src/frontend/src/features/projects/ProjectWizardPage.tsx
+++ b/src/frontend/src/features/projects/ProjectWizardPage.tsx
@@ -44,7 +44,7 @@ export function ProjectWizardPage() {
   const [validationConditions, setValidationConditions] = useState('');
 
   const librariesQuery = useLibraries();
-  const libraries = (librariesQuery.data ?? []).filter((library) => library.status === 'active');
+  const libraries = librariesQuery.data ?? [];
   const [selectedLibraryIds, setSelectedLibraryIds] = useState<Set<string>>(new Set());
 
   function toggleLibrary(libraryId: string) {

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -94,10 +94,9 @@ export function StartPage() {
     const preset = getLang() === 'en' ? SAMPLE_TOPIC.en : SAMPLE_TOPIC.zh;
     // 语料优先绑 RSI 文献库（示例课题就是讲这个方向）；找不到才退回任一公共库
     const visible = librariesQuery.data ?? [];
-    const active = visible.filter((l) => l.status === 'active');
     const lib =
-      active.find((l) => SAMPLE_LIBRARY_NAMES.some((n) => l.name.toLowerCase().includes(n.toLowerCase()))) ??
-      active.find((l) => l.is_public);
+      visible.find((l) => SAMPLE_LIBRARY_NAMES.some((n) => l.name.toLowerCase().includes(n.toLowerCase()))) ??
+      visible.find((l) => l.is_public);
     setCreatingSample(true);
     try {
       const created = await api.createProject({

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -270,17 +270,20 @@ function LibraryInfoCard({
   const [name, setName] = useState(lib.name);
   const [statement, setStatement] = useState(lib.statement ?? '');
   const [budget, setBudget] = useState(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+  const [isPublic, setIsPublic] = useState(lib.is_public);
 
   // 库切换 / 保存后回填
   useEffect(() => {
     setName(lib.name);
     setStatement(lib.statement ?? '');
     setBudget(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+    setIsPublic(lib.is_public);
   }, [lib]);
 
   const dirty =
     name !== lib.name ||
     statement !== (lib.statement ?? '') ||
+    isPublic !== lib.is_public ||
     budget !== (lib.monthly_budget == null ? '' : String(lib.monthly_budget));
 
   const save = useMutation({
@@ -289,6 +292,7 @@ function LibraryInfoCard({
         name: name.trim() || lib.name,
         statement: statement.trim() || null,
         monthly_budget: budget.trim() === '' ? null : Math.max(0, Math.floor(Number(budget))),
+        is_public: isPublic,
       }),
     onSuccess: () => {
       toast(tr('库信息已保存', 'Library info saved'), 'ok');
@@ -335,6 +339,21 @@ function LibraryInfoCard({
             )}
           />
         </label>
+        {/* 共享开关：审批流已移除（#619），创建者在这里直接决定库是否对所有人可见 */}
+        {!readOnly && (
+          <label className="row gap8" style={{ alignItems: 'center', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+              style={{ width: 14, height: 14, margin: 0, accentColor: 'var(--accent)', cursor: 'pointer' }}
+            />
+            <span style={{ fontSize: 13 }}>{tr('公开给所有人', 'Visible to everyone')}</span>
+            <span className="muted" style={{ fontSize: 12 }}>
+              {tr('开启后本部署的所有用户都能浏览这个库', 'Everyone on this deployment can browse this library')}
+            </span>
+          </label>
+        )}
         {!readOnly && (
         <div className="row gap12" style={{ flexWrap: 'wrap' }}>
           <label className="col gap6" style={{ minWidth: 220 }}>

--- a/src/frontend/src/features/wiki/IngestTab.tsx
+++ b/src/frontend/src/features/wiki/IngestTab.tsx
@@ -312,11 +312,6 @@ export function IngestTab({ pid, libraryId, state, stateError, stateLoading, onG
           tr('这个文献库本月 AI 预算已用尽，同步已暂停；下月自动恢复，或请管理员调高预算。', 'This library has used up its monthly AI budget — syncing is paused until next month, or ask an admin to raise the budget.'),
           'error',
         );
-      } else if (e instanceof ApiError && e.message === 'LIBRARY_NOT_ACTIVE') {
-        toast(
-          tr('文献库还未激活，管理员批准后才能开始抓取。', 'Library is not active yet — an admin must approve it before ingest can start.'),
-          'error',
-        );
       } else if (e instanceof ApiError && e.status === 409) {
         toast(
           tr('该文献库已有一个文献任务在运行，请等待其完成。', 'A literature task is already running for this library — wait for it to finish.'),

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1327,14 +1327,12 @@ export interface DirectionLibrarySummary {
   is_mine: boolean;
   /** 是否可管理本库：成员 ∪ 文献库管理员 ∪ 创建者 ∪ 平台管理员（P6/P9b） */
   can_manage: boolean;
-  /** 归属模型：个人库 false（归属人=owner_name）| 公共库 true（实验室/全体 admin 所有） */
+  /** 共享开关：false = 仅创建者可见的个人库 | true = 对本部署所有用户可见 */
   is_public: boolean;
   /** 归属人名（个人库=创建者；公共库=原创建者/策展人；可能为空） */
   owner_name: string | null;
   /** 请求者是否本库归属人（submitted_by==我）：个人库删除入口据此判定 */
   is_owner: boolean;
-  /** 生命周期：新建库即 active；pending/rejected 为历史遗留值 */
-  status: 'pending' | 'active' | 'rejected';
   /** 库创建者 */
   submitted_by: string | null;
   paper_count: number;
@@ -4105,6 +4103,8 @@ export const api = {
       anchors?: AnchorPaper[] | null;
       keywords?: KeywordSpec | null;
       questions?: string[] | null;
+      /** 公开给所有人（创建者直接设置，无审批）；不传 = 不改 */
+      is_public?: boolean;
     },
   ): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>(`/libraries/${id}`, 'PATCH', input);


### PR DESCRIPTION
Closes #619. Part of #564 (P1 track B).

The library public-approval flow was removed in #593/#596; this retires its schema residue and finishes the sharing model.

- migration `c3c404803ca4` (on top of `9b2e5d81c7a3`) drops `direction_libraries.status` and `review_note`; downgrade restores the original shapes; migration-roundtrip assertions extended and the chain verified single-head
- `is_public` is now a plain owner-settable sharing flag: `DirectionLibraryUpdate` gains an optional `is_public` (explicit null means "leave unchanged"), authorized by the existing manage predicate, and the library settings card gets a "Visible to everyone" checkbox — previously the only path to public was the deleted approval flow
- every `status` read/write is gone: overview/creation/list filtering, the `LIBRARY_NOT_ACTIVE` gates on digest/ingest routes, the daily-ingest due filter, discovery-schedule lookups (404 instead of a dead error code), the assistant tool brief, and an orphaned `create_library(status=…)` call in vault sync
- wire compatibility: `DirectionLibrarySummary.status/review_note` remain as schema constants so recorded golden transcripts stay byte-identical
- frontend drops the `status === 'active'` filters and the dead error branch

Verification: full suite 1463 collected = 1460 passed + the 3 pre-existing #581 failures (zero new; −1 obsolete test, +1 sharing-toggle test); goldens byte-identical; frontend build clean.