### PR TITLE
fix: extract the uv zip with Expand-Archive on Windows

### DIFF
--- a/src/desktop/scripts/fetch-uv.mjs
+++ b/src/desktop/scripts/fetch-uv.mjs
@@ -102,7 +102,17 @@ async function fetchTarget(target) {
   const extractDir = join(cacheDir, target, 'extract');
   rmSync(extractDir, { recursive: true, force: true });
   mkdirSync(extractDir, { recursive: true });
-  execFileSync('tar', ['-xf', archive, '-C', extractDir], { stdio: 'inherit' });
+  if (process.platform === 'win32' && archive.endsWith('.zip')) {
+    // CI 的 PATH 上 MSYS tar 先于系统 bsdtar，解 zip 直接 exit 128——
+    // 用 Expand-Archive 绕开 tar 选型问题（win10+ 恒有）。
+    execFileSync(
+      'powershell',
+      ['-NoProfile', '-Command', `Expand-Archive -Path '${archive}' -DestinationPath '${extractDir}' -Force`],
+      { stdio: 'inherit' },
+    );
+  } else {
+    execFileSync('tar', ['-xf', archive, '-C', extractDir], { stdio: 'inherit' });
+  }
   const bin = findBinary(extractDir, binName);
   if (!bin) throw new Error(`fetch-uv: 解包后找不到 ${binName}（${asset}）`);
   cpSync(bin, cached);


### PR DESCRIPTION
The first 3-platform run of the release matrix after #610 failed on Windows: `tar -xf` exits 128 on the uv zip because the MSYS tar earlier on the runner's PATH cannot read zip archives. On win32 the script now extracts with PowerShell's `Expand-Archive` (present on every Windows 10+ host) and keeps bsdtar for the tar.gz assets elsewhere. macOS and Linux legs of run 33822682200 passed, including the bundled-backend smoke; a re-dispatched matrix run validates this fix.