### PR TITLE
fix: keep alembic.ini ASCII so Windows locale decoding cannot break it

### DIFF
--- a/src/backend/alembic.ini
+++ b/src/backend/alembic.ini
@@ -1,7 +1,9 @@
 [alembic]
 script_location = alembic
 prepend_sys_path = .
-# URL 留空：env.py 从 app settings（POLARIS_DATABASE_URL）读取
+# URL left empty: env.py reads it from app settings (POLARIS_DATABASE_URL).
+# ASCII only in this file: alembic reads it with encoding="locale" (PEP 597),
+# which is cp1252 on Windows no matter what PYTHONUTF8 says.
 sqlalchemy.url =
 
 [loggers]


### PR DESCRIPTION
Third and root-cause Windows finding from the release-matrix runs: alembic reads `alembic.ini` with `encoding="locale"` (PEP 597), which on Windows is cp1252 regardless of `PYTHONUTF8` — so the file's one Chinese comment (byte 0x8f) crashed `alembic upgrade head` in the bundled engine (runs 33822682200 / 33824038158; the #631 UTF-8-mode fix is correct but cannot reach an explicit locale read). The comment is now English with a warning that this file must stay ASCII. A re-dispatched matrix validates the full Windows leg.