### PR TITLE
fix: retry temp-dir cleanup in the bundled-backend smoke on Windows

### DIFF
--- a/src/desktop/src/bootstrap-smoke.ts
+++ b/src/desktop/src/bootstrap-smoke.ts
@@ -154,7 +154,20 @@ async function main(): Promise<void> {
     if (args.keep) {
       console.log(`bootstrap-smoke: --keep，保留 ${dataDir}`);
     } else {
-      await rm(dataDir, { recursive: true, force: true });
+      // Windows 上刚被 kill 的引擎会短暂占着 python.exe 的文件锁，立刻删目录
+      // 会 EPERM——重试几轮；清理失败只警告不改判（冒烟结论以引擎断言为准）
+      for (let i = 0; i < 5; i++) {
+        try {
+          await rm(dataDir, { recursive: true, force: true });
+          break;
+        } catch (err) {
+          if (i === 4) {
+            console.warn(`bootstrap-smoke: 清理 ${dataDir} 失败（${err instanceof Error ? err.message : String(err)}），忽略`);
+          } else {
+            await delay(1_000);
+          }
+        }
+      }
     }
   }
   process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Final Windows finding from the release-matrix runs: in rc4 (run 33825599703) the bundled-backend smoke itself PASSES on Windows — engine healthy in 12.7s, /api/health 200 — but the job still fails because the cleanup `rm` races the just-killed engine's file lock on python.exe (EPERM unlink). The cleanup now retries up to five times with backoff and degrades to a warning: the smoke verdict comes from the engine assertions, and the CI temp dir is discarded with the runner anyway. A re-dispatched matrix validates the full three-platform pass.