### PR TITLE
feat: hypothesis tree entity and read API for discovery runs

### DIFF
--- a/src/backend/alembic/versions/7e2b9f4c1a86_hypothesis_nodes.py
+++ b/src/backend/alembic/versions/7e2b9f4c1a86_hypothesis_nodes.py
@@ -1,0 +1,54 @@
+"""假设/实验树节点表 hypothesis_nodes（#637，设计报告 §8.2）
+
+discovery run 的一等实体：Navigator 在树上分支/剪枝，恢复即从最优 open 节点
+继续。本迁移只建表；树的读 API 与服务层同 PR 落地，引擎写入是 D2/D3 的事。
+
+Revision ID: 7e2b9f4c1a86
+Revises: b0dd1709e2a1
+Create Date: 2026-09-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "7e2b9f4c1a86"
+down_revision: str | None = "b0dd1709e2a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hypothesis_nodes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("run_id", sa.Uuid(), nullable=False),
+        # 自引用：NULL = 树根（每 run 单根由服务层保证）；父删子随删
+        sa.Column("parent_id", sa.Uuid(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("statement", sa.Text(), nullable=False),
+        sa.Column("grounding", _JSON, nullable=True),
+        sa.Column("novelty_report", _JSON, nullable=True),
+        sa.Column("feasibility", _JSON, nullable=True),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["voyage_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["parent_id"], ["hypothesis_nodes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_hypothesis_nodes_run_id"), "hypothesis_nodes", ["run_id"], unique=False)
+    # best_open_node / 树读取都按 run 过滤后再看 status，status 单列索引足够本期热查询
+    op.create_index(op.f("ix_hypothesis_nodes_status"), "hypothesis_nodes", ["status"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_hypothesis_nodes_status"), table_name="hypothesis_nodes")
+    op.drop_index(op.f("ix_hypothesis_nodes_run_id"), table_name="hypothesis_nodes")
+    op.drop_table("hypothesis_nodes")

--- a/src/backend/app/api/hypotheses.py
+++ b/src/backend/app/api/hypotheses.py
@@ -1,0 +1,62 @@
+"""假设/实验树读路由（#637）：树整体 + 单节点详情。
+
+只读——树由 discovery 引擎写（D2/D3），用户不直接编辑节点。可见性完全
+复用任务口径（services.voyages.get_voyage 内部的 can_view_voyage）：
+树是 run 的资产，能看任务就能看树，无权限一律 404（不泄露存在性）。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.hypothesis import HypothesisNode
+from app.models.user import User
+from app.models.voyage import VoyageRun
+from app.schemas.hypothesis import HypothesisNodeRead
+from app.services import hypothesis_tree as tree_service
+from app.services import voyages as voyages_service
+
+router = APIRouter(prefix="/voyages", tags=["hypotheses"])
+
+
+async def _viewable_run(
+    session: AsyncSession, voyage_id: uuid.UUID, user: User
+) -> VoyageRun:
+    run = await voyages_service.get_voyage(
+        session, voyage_id=voyage_id, user_id=user.id, user=user
+    )
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="VOYAGE_NOT_FOUND")
+    return run
+
+
+@router.get("/{voyage_id}/hypothesis-tree", response_model=list[HypothesisNodeRead])
+async def get_hypothesis_tree(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[HypothesisNodeRead]:
+    """拉平返回 run 的全部节点（父子由前端按 parent_id 拼装）。"""
+    run = await _viewable_run(session, voyage_id, user)
+    nodes = await tree_service.tree_for_run(session, run.id)
+    return [HypothesisNodeRead.model_validate(n) for n in nodes]
+
+
+@router.get(
+    "/{voyage_id}/hypothesis-tree/{node_id}", response_model=HypothesisNodeRead
+)
+async def get_hypothesis_node(
+    voyage_id: uuid.UUID,
+    node_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> HypothesisNodeRead:
+    run = await _viewable_run(session, voyage_id, user)
+    node = await session.get(HypothesisNode, node_id)
+    # 节点必须属于路径里的 run：跨 run 直取节点 id 视为不存在
+    if node is None or node.run_id != run.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="HYPOTHESIS_NODE_NOT_FOUND")
+    return HypothesisNodeRead.model_validate(node)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -16,6 +16,7 @@ from app.api import (
     gates,
     health,
     highlights,
+    hypotheses,
     ideas,
     ingest,
     integration_tokens,
@@ -53,6 +54,7 @@ api_router.include_router(users_profile.router)
 api_router.include_router(projects.router)
 api_router.include_router(gates.router)
 api_router.include_router(voyages.router)
+api_router.include_router(hypotheses.router)
 api_router.include_router(admin_llm.router)
 api_router.include_router(admin_settings.router)
 api_router.include_router(papers.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.email_code import EmailVerificationCode
 from app.models.evidence import PaperEvidenceAnchor
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.gate import Gate
+from app.models.hypothesis import HypothesisNode
 from app.models.idea import Idea
 from app.models.integration_token import IntegrationToken
 from app.models.interdisciplinary import (
@@ -84,6 +85,7 @@ __all__ = [
     "Experiment",
     "ExperimentRun",
     "Gate",
+    "HypothesisNode",
     "Idea",
     "InterdisciplinaryResearchProfile",
     "InterdisciplinaryResearchProfileVersion",

--- a/src/backend/app/models/hypothesis.py
+++ b/src/backend/app/models/hypothesis.py
@@ -1,0 +1,47 @@
+"""假设/实验树：discovery run 的产品本体（设计报告 §8.2，P2 D1）。
+
+Navigator 在树上做分支/剪枝决策而非线性 plan：每个节点是一条假设（或它派生的
+实验/分析），带文献锚定（grounding）、查新（novelty_report）、可行性（feasibility）
+与评分；恢复语义 = 从最优未扩展（open）节点继续。本模块只定义实体，树的写入
+由引擎侧（D2/D3）经 services/hypothesis_tree.py 进行。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import Float, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+# 节点种类：hypothesis 假设本体；experiment/analysis 是它派生的验证动作节点
+HYPOTHESIS_NODE_KINDS = ("hypothesis", "experiment", "analysis")
+
+# 状态机：open →（expanded | pruned）；expanded →（validated | refuted | pruned）
+# validated / refuted / pruned 均为终态——被剪枝分支强制留痕（防择优汇报，§8.2）
+HYPOTHESIS_NODE_STATUSES = ("open", "expanded", "pruned", "validated", "refuted")
+
+
+class HypothesisNode(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "hypothesis_nodes"
+
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("voyage_runs.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # 自引用父节点；NULL = 树根（每 run 单根，由服务层保证）。防环无需额外机制：
+    # 创建时 parent 必须已存在且属同 run，新节点不可能成为任何既有节点的祖先。
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("hypothesis_nodes.id", ondelete="CASCADE"), nullable=True
+    )
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)  # HYPOTHESIS_NODE_KINDS
+    statement: Mapped[str] = mapped_column(Text, nullable=False)  # 假设陈述
+    # 子命题→文献绑定表 [{subclaim, stance: support|refute|speculation,
+    #                     paper_ids: [...], snippets: [...]}]
+    grounding: Mapped[list[Any] | None] = mapped_column(JSONVariant)
+    novelty_report: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 查新（逐子命题）
+    feasibility: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)  # 资源匹配结果
+    score: Mapped[float | None] = mapped_column(Float)  # Navigator 排序依据
+    status: Mapped[str] = mapped_column(
+        String(16), default="open", index=True, nullable=False
+    )  # HYPOTHESIS_NODE_STATUSES

--- a/src/backend/app/schemas/hypothesis.py
+++ b/src/backend/app/schemas/hypothesis.py
@@ -1,0 +1,25 @@
+"""假设/实验树的读 schema（#637）。写入走引擎（D2/D3），本期无写模型。"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class HypothesisNodeRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    run_id: uuid.UUID
+    parent_id: uuid.UUID | None  # None = 树根
+    kind: str  # hypothesis | experiment | analysis
+    statement: str
+    # 子命题→文献绑定 [{subclaim, stance, paper_ids, snippets}]
+    grounding: list[Any] | None
+    novelty_report: dict[str, Any] | None
+    feasibility: dict[str, Any] | None
+    score: float | None
+    status: str  # open | expanded | pruned | validated | refuted
+    created_at: datetime
+    updated_at: datetime

--- a/src/backend/app/services/hypothesis_tree.py
+++ b/src/backend/app/services/hypothesis_tree.py
@@ -1,0 +1,209 @@
+"""假设/实验树的服务层（#637，设计报告 §8.2；不 import fastapi）。
+
+树是 discovery run 的资产：引擎（D2/D3）经这里写节点，读 API 只消费
+tree_for_run。结构不变量全部收在 create_node：
+
+- 每 run 单根：parent_id=None 的节点只许有一个（第二次抛 ValueError，
+  API 层如需暴露转 409）；
+- 防环：parent 必须**已存在**且属同 run——新节点落库时不可能是任何既有
+  节点的祖先，因此按 parent 链构造的图天然无环，无需运行时环检测。
+
+状态机（HYPOTHESIS_NODE_STATUSES）：
+    open → expanded | pruned
+    expanded → validated | refuted | pruned
+validated / refuted / pruned 均为终态；剪枝级联整个子树（被剪分支留痕不删，
+防择优汇报——§8.2 的防失败模式）。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.hypothesis import HYPOTHESIS_NODE_KINDS, HypothesisNode
+from app.models.voyage import VoyageRun
+
+# 合法状态迁移表；不在表里（含从终态出发）一律拒绝
+_TRANSITIONS: dict[str, frozenset[str]] = {
+    "open": frozenset({"expanded", "pruned"}),
+    "expanded": frozenset({"validated", "refuted", "pruned"}),
+}
+
+
+async def create_node(
+    session: AsyncSession,
+    run: VoyageRun,
+    *,
+    parent_id: uuid.UUID | None,
+    kind: str,
+    statement: str,
+    grounding: list[Any] | None = None,
+    novelty_report: dict[str, Any] | None = None,
+    feasibility: dict[str, Any] | None = None,
+    score: float | None = None,
+) -> HypothesisNode:
+    """建节点并 commit。结构不变量（单根/同 run 父/合法 kind）违例抛 ValueError。"""
+    if kind not in HYPOTHESIS_NODE_KINDS:
+        raise ValueError(f"unknown hypothesis node kind: {kind!r}")
+    if parent_id is None:
+        # 每 run 单根：恢复语义（best_open_node）与树读取都假定单棵树，
+        # 多根会让「从最优节点继续」失去唯一起点
+        existing_root = (
+            await session.execute(
+                select(HypothesisNode.id).where(
+                    HypothesisNode.run_id == run.id, HypothesisNode.parent_id.is_(None)
+                )
+            )
+        ).first()
+        if existing_root is not None:
+            raise ValueError(f"run {run.id} already has a root hypothesis node")
+    else:
+        parent = await session.get(HypothesisNode, parent_id)
+        if parent is None or parent.run_id != run.id:
+            # 跨 run 挂父等同于父不存在：树是 run 私有资产，不能互相嫁接
+            raise ValueError(f"parent node {parent_id} not found in run {run.id}")
+    node = HypothesisNode(
+        run_id=run.id,
+        parent_id=parent_id,
+        kind=kind,
+        statement=statement,
+        grounding=grounding,
+        novelty_report=novelty_report,
+        feasibility=feasibility,
+        score=score,
+        status="open",
+    )
+    session.add(node)
+    await session.commit()
+    await session.refresh(node)
+    return node
+
+
+async def set_grounding(
+    session: AsyncSession, node: HypothesisNode, grounding: list[Any] | None
+) -> HypothesisNode:
+    node.grounding = grounding
+    node.updated_at = utcnow()
+    await session.commit()
+    return node
+
+
+async def set_novelty(
+    session: AsyncSession, node: HypothesisNode, novelty_report: dict[str, Any] | None
+) -> HypothesisNode:
+    node.novelty_report = novelty_report
+    node.updated_at = utcnow()
+    await session.commit()
+    return node
+
+
+async def set_feasibility(
+    session: AsyncSession, node: HypothesisNode, feasibility: dict[str, Any] | None
+) -> HypothesisNode:
+    node.feasibility = feasibility
+    node.updated_at = utcnow()
+    await session.commit()
+    return node
+
+
+async def set_score(
+    session: AsyncSession, node: HypothesisNode, score: float | None
+) -> HypothesisNode:
+    node.score = score
+    node.updated_at = utcnow()
+    await session.commit()
+    return node
+
+
+async def transition(
+    session: AsyncSession, node: HypothesisNode, to_status: str
+) -> HypothesisNode:
+    """按状态机迁移并 commit；非法迁移抛 ValueError。
+
+    to_status="pruned" 级联：整个子树全部置 pruned——父分支被放弃后，子节点
+    单独存活没有意义（它们的前提没了），且留痕（而非删除）是 §8.2 防择优
+    汇报的硬要求。级联用迭代逐层下推而不是递归 CTE：sqlite/postgres 都支持
+    WITH RECURSIVE，但 ORM 层拼递归 CTE 的可读性差、收益只在深树，而假设树
+    深度是个位数（每层是一次 Navigator 决策）。
+    """
+    allowed = _TRANSITIONS.get(node.status, frozenset())
+    if to_status not in allowed:
+        raise ValueError(
+            f"invalid hypothesis node transition: {node.status} -> {to_status}"
+        )
+    now = utcnow()
+    node.status = to_status
+    node.updated_at = now
+    if to_status == "pruned":
+        frontier: list[uuid.UUID] = [node.id]
+        while frontier:
+            children = (
+                (
+                    await session.execute(
+                        select(HypothesisNode.id).where(
+                            HypothesisNode.parent_id.in_(frontier)
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if not children:
+                break
+            # 子树无条件置 pruned（不走状态机校验）：validated 的子节点也一并
+            # 剪掉——结论仍留在行里（status 之外的列不动），只是不再是活分支
+            # synchronize_session="fetch"：expire_on_commit=False 下，identity map
+            # 里已加载的子节点对象不会被裸 UPDATE 刷新，同 session 随后的读会
+            # 拿到旧 status——fetch 策略把内存对象一并改掉
+            await session.execute(
+                update(HypothesisNode)
+                .where(HypothesisNode.id.in_(children))
+                .values(status="pruned", updated_at=now)
+                .execution_options(synchronize_session="fetch")
+            )
+            frontier = list(children)
+    await session.commit()
+    await session.refresh(node)
+    return node
+
+
+async def tree_for_run(
+    session: AsyncSession, run_id: uuid.UUID
+) -> list[HypothesisNode]:
+    """一次查询拉平返回 run 的全部节点（父子拼装交给 API/前端）。
+
+    created_at 再按 id 定序：同秒批量建的兄弟节点也要有稳定顺序。
+    """
+    return list(
+        (
+            await session.execute(
+                select(HypothesisNode)
+                .where(HypothesisNode.run_id == run_id)
+                .order_by(HypothesisNode.created_at, HypothesisNode.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def best_open_node(
+    session: AsyncSession, run_id: uuid.UUID
+) -> HypothesisNode | None:
+    """score 最高的 open 节点（D2 恢复语义的地基）；空树/无 open 返回 None。
+
+    score 为空的节点排最后（还没评分不代表最优）；同分按 created_at 取早的，
+    保证恢复起点确定性。
+    """
+    return (
+        await session.execute(
+            select(HypothesisNode)
+            .where(HypothesisNode.run_id == run_id, HypothesisNode.status == "open")
+            .order_by(
+                HypothesisNode.score.desc().nulls_last(), HypothesisNode.created_at
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()

--- a/src/backend/tests/test_hypothesis_tree.py
+++ b/src/backend/tests/test_hypothesis_tree.py
@@ -1,0 +1,283 @@
+"""假设/实验树（#637）：结构不变量、状态机、剪枝级联、恢复排序与读 API。
+
+树由服务层直写（引擎接入是 D2 的事）；API 只读，可见性复用任务口径。
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.hypothesis import HypothesisNode
+from app.models.user import User
+from app.models.voyage import VoyageRun
+from app.services import hypothesis_tree as tree_service
+from tests.conftest import register_and_login
+
+
+async def _hdr(client, email):
+    return {"Authorization": f"Bearer {await register_and_login(client, email=email)}"}
+
+
+async def _user_id(email: str) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return (
+            (await session.execute(select(User).where(User.email == email))).scalar_one().id
+        )
+
+
+async def _make_run(*, project_id=None, created_by=None) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="discovery",
+            goal="假设树测试任务",
+            status="planning",
+            cursor=0,
+            project_id=project_id,
+            created_by=created_by,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+async def _project(client, hdr, *, name="假设树课题") -> uuid.UUID:
+    resp = await client.post(
+        "/api/projects", json={"name": name, "statement": "s"}, headers=hdr
+    )
+    assert resp.status_code == 201, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def test_single_root_per_run(client):
+    """每 run 单根：第二个 parent_id=None 的节点被拒；kind 也要在白名单里。"""
+    run_id = await _make_run()
+    other_run_id = await _make_run()
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根假设"
+        )
+        assert root.status == "open"
+        assert root.parent_id is None
+        with pytest.raises(ValueError):
+            await tree_service.create_node(
+                session, run, parent_id=None, kind="hypothesis", statement="第二个根"
+            )
+        with pytest.raises(ValueError):
+            await tree_service.create_node(
+                session, run, parent_id=root.id, kind="theorem", statement="非法 kind"
+            )
+        # 单根是按 run 算的：另一个 run 建自己的根不受影响
+        other = await session.get(VoyageRun, other_run_id)
+        other_root = await tree_service.create_node(
+            session, other, parent_id=None, kind="hypothesis", statement="另一棵树的根"
+        )
+        assert other_root.run_id == other_run_id
+
+
+async def test_parent_must_belong_to_same_run(client):
+    """跨 run 挂父 = 父不存在：树是 run 私有资产，不能互相嫁接。"""
+    run_a = await _make_run()
+    run_b = await _make_run()
+    async with get_sessionmaker()() as session:
+        a = await session.get(VoyageRun, run_a)
+        b = await session.get(VoyageRun, run_b)
+        root_a = await tree_service.create_node(
+            session, a, parent_id=None, kind="hypothesis", statement="A 的根"
+        )
+        with pytest.raises(ValueError):
+            await tree_service.create_node(
+                session, b, parent_id=root_a.id, kind="hypothesis", statement="嫁接"
+            )
+        with pytest.raises(ValueError):
+            await tree_service.create_node(
+                session, b, parent_id=uuid.uuid4(), kind="hypothesis", statement="幽灵父"
+            )
+
+
+async def test_status_transitions(client):
+    """状态机：open→expanded→validated 合法；跳步 / 从终态出发一律拒绝。"""
+    run_id = await _make_run()
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        node = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根"
+        )
+        # open 不能直达 validated / refuted
+        with pytest.raises(ValueError):
+            await tree_service.transition(session, node, "validated")
+        with pytest.raises(ValueError):
+            await tree_service.transition(session, node, "refuted")
+        node = await tree_service.transition(session, node, "expanded")
+        assert node.status == "expanded"
+        # expanded 不能回 open，也没有 expanded→expanded
+        with pytest.raises(ValueError):
+            await tree_service.transition(session, node, "open")
+        with pytest.raises(ValueError):
+            await tree_service.transition(session, node, "expanded")
+        node = await tree_service.transition(session, node, "validated")
+        assert node.status == "validated"
+        # validated 是终态
+        with pytest.raises(ValueError):
+            await tree_service.transition(session, node, "pruned")
+
+
+async def test_prune_cascades_to_whole_subtree(client):
+    """剪枝级联：被剪节点的整个子树置 pruned；兄弟分支与根不受影响。"""
+    run_id = await _make_run()
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根"
+        )
+        a = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="分支 A"
+        )
+        a1 = await tree_service.create_node(
+            session, run, parent_id=a.id, kind="experiment", statement="A 的实验"
+        )
+        a2 = await tree_service.create_node(
+            session, run, parent_id=a.id, kind="analysis", statement="A 的分析"
+        )
+        a1x = await tree_service.create_node(
+            session, run, parent_id=a1.id, kind="analysis", statement="孙子节点"
+        )
+        b = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="分支 B"
+        )
+        # 已 expanded 的子节点也会被级联剪掉（前提没了，留痕不删）
+        await tree_service.transition(session, a1, "expanded")
+        await tree_service.transition(session, a, "expanded")
+        await tree_service.transition(session, a, "pruned")
+
+        statuses = {
+            n.id: n.status for n in await tree_service.tree_for_run(session, run_id)
+        }
+        assert statuses[a.id] == "pruned"
+        assert statuses[a1.id] == "pruned"
+        assert statuses[a2.id] == "pruned"
+        assert statuses[a1x.id] == "pruned"
+        assert statuses[root.id] == "open"
+        assert statuses[b.id] == "open"
+        # 留痕：被剪的行还在，没有删除
+        assert len(statuses) == 6
+
+
+async def test_best_open_node_ordering(client):
+    """best_open_node：score 降序取 open 第一个；无评分排最后；空树 None。"""
+    run_id = await _make_run()
+    async with get_sessionmaker()() as session:
+        # 空树 None 安全
+        assert await tree_service.best_open_node(session, run_id) is None
+
+        run = await session.get(VoyageRun, run_id)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根", score=0.9
+        )
+        low = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="低分", score=0.2
+        )
+        high = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="高分", score=0.8
+        )
+        unscored = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="未评分"
+        )
+        # 根分最高，但 expanded 后不再是「未扩展」候选
+        await tree_service.transition(session, root, "expanded")
+        best = await tree_service.best_open_node(session, run_id)
+        assert best is not None and best.id == high.id
+        # 高分剪掉后轮到低分；未评分的排最后
+        await tree_service.transition(session, high, "pruned")
+        best = await tree_service.best_open_node(session, run_id)
+        assert best is not None and best.id == low.id
+        await tree_service.transition(session, low, "pruned")
+        best = await tree_service.best_open_node(session, run_id)
+        assert best is not None and best.id == unscored.id
+        # 全部处理完 → None
+        await tree_service.transition(session, unscored, "pruned")
+        assert await tree_service.best_open_node(session, run_id) is None
+
+
+async def test_setters_update_columns(client):
+    """set_* 写对应列；grounding 三态结构原样存取（JSON 列 sqlite 兼容）。"""
+    run_id = await _make_run()
+    grounding = [
+        {
+            "subclaim": "X 提升 Y",
+            "stance": "support",
+            "paper_ids": ["p1", "p2"],
+            "snippets": ["…证据句…"],
+        }
+    ]
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        node = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根"
+        )
+        await tree_service.set_grounding(session, node, grounding)
+        await tree_service.set_novelty(session, node, {"novel": True})
+        await tree_service.set_feasibility(session, node, {"gpu_hours": 4})
+        await tree_service.set_score(session, node, 0.75)
+    async with get_sessionmaker()() as session:
+        fresh = await session.get(HypothesisNode, node.id)
+        assert fresh.grounding == grounding
+        assert fresh.novelty_report == {"novel": True}
+        assert fresh.feasibility == {"gpu_hours": 4}
+        assert fresh.score == 0.75
+
+
+async def test_tree_read_api_and_visibility(client):
+    """GET 树 / 单节点：主人可读；外人 404（不泄露存在性）；跨 run 节点 404。"""
+    owner = await _hdr(client, "hyptree-owner@example.com")
+    owner_id = await _user_id("hyptree-owner@example.com")
+    project_id = await _project(client, owner)
+    run_id = await _make_run(project_id=project_id, created_by=owner_id)
+    other_run_id = await _make_run(project_id=project_id, created_by=owner_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="根假设", score=0.5
+        )
+        child = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="experiment", statement="验证实验"
+        )
+        other = await session.get(VoyageRun, other_run_id)
+        other_root = await tree_service.create_node(
+            session, other, parent_id=None, kind="hypothesis", statement="别的树"
+        )
+
+    resp = await client.get(f"/api/voyages/{run_id}/hypothesis-tree", headers=owner)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()
+    # 不断言顺序：本机容器墙钟会 ±1 秒跳变（#234），created_at 序偶发翻车；
+    # 父子结构本来就由前端按 parent_id 拼装，顺序不承载语义
+    by_id = {n["id"]: n for n in nodes}
+    assert set(by_id) == {str(root.id), str(child.id)}
+    assert by_id[str(root.id)]["parent_id"] is None
+    assert by_id[str(child.id)]["parent_id"] == str(root.id)
+    assert by_id[str(child.id)]["kind"] == "experiment"
+
+    resp = await client.get(
+        f"/api/voyages/{run_id}/hypothesis-tree/{child.id}", headers=owner
+    )
+    assert resp.status_code == 200
+    assert resp.json()["statement"] == "验证实验"
+
+    # 节点必须属于路径里的 run：跨 run 直取 404
+    resp = await client.get(
+        f"/api/voyages/{run_id}/hypothesis-tree/{other_root.id}", headers=owner
+    )
+    assert resp.status_code == 404
+
+    # 外人（非课题主人、非创建者）：树与单节点都 404
+    stranger = await _hdr(client, "hyptree-stranger@example.com")
+    resp = await client.get(f"/api/voyages/{run_id}/hypothesis-tree", headers=stranger)
+    assert resp.status_code == 404
+    resp = await client.get(
+        f"/api/voyages/{run_id}/hypothesis-tree/{root.id}", headers=stranger
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b0dd1709e2a1"  # Drop project_members (#625)
+HEAD_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
+MEMBERS_DROP_REVISION = "b0dd1709e2a1"  # Drop project_members (#625)
 LLM_MERGE_REVISION = "dd572a7f063c"  # Merge LLM config tracks: drop users.llm_self_managed (#621)
 LIBRARY_STATUS_DROP_REVISION = "c3c404803ca4"  # Drop library status/review_note (P1 de-lab)
 FEEDBACK_DROP_REVISION = "9b2e5d81c7a3"  # Drop in-app feedback tables (#617)
@@ -153,6 +154,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "interdisciplinary_research_profile_versions",
                     "registration_codes",  # head 已删；仅 downgrade 断言用
                     "project_members",  # head 已删（#625）；仅 downgrade 断言用
+                    "hypothesis_nodes",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -173,6 +175,20 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert not {"role", "read_only", "llm_access", "token_quota", "features"} & columns[
         "users"
     ]
+    # 假设/实验树节点表（#637，设计报告 §8.2）
+    assert "hypothesis_nodes" in columns["_tables"]
+    assert {
+        "run_id",
+        "parent_id",
+        "kind",
+        "statement",
+        "grounding",
+        "novelty_report",
+        "feasibility",
+        "score",
+        "status",
+    } <= columns["hypothesis_nodes"]
+    assert "ix_hypothesis_nodes_run_id" in _index_names(db_path, "hypothesis_nodes")
     # 课题成员表已随个人化定位删除（#625）：归属只看 projects.owner_id
     assert "project_members" not in columns["_tables"]
     assert "owner_id" in columns["projects"]
@@ -518,7 +534,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "evidence_balance",
     } <= columns["interdisciplinary_research_profile_versions"]
 
-    # 先退掉成员表删除（#625）：project_members 按原形状回来，owner 行由
+    # 先退掉假设树建表（#637）：整表消失，其余不受影响。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == MEMBERS_DROP_REVISION
+    assert "hypothesis_nodes" not in columns["_tables"]
+
+    # 再退掉成员表删除（#625）：project_members 按原形状回来，owner 行由
     # projects.owner_id 反向回填（老代码的可见性判据读成员表，没有它课题全隐身）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
@@ -895,6 +917,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "owner_id" in columns["llm_providers"]
     assert "llm_self_managed" not in columns["users"]  # head 已删（#621）
     assert "project_members" not in columns["_tables"]  # head 已删（#625）
+    assert "hypothesis_nodes" in columns["_tables"]  # 假设树表回归（#637）
     assert not {"feedback", "feedback_images"} & columns["_tables"]  # head 已删（#617）
     # P9a 列在重新 upgrade 后回归
     assert "library_id" in columns["voyage_runs"]


### PR DESCRIPTION
Closes #637. Part of #635 (P2 wave 1, item D1); design report §8.2.

First-class hypothesis/experiment tree for discovery runs — entity, service, and read API only; the voyage engine is untouched (the `discovery` kind wires in with D2).

- `hypothesis_nodes`: uuid PK, run-scoped tree via a self-referencing FK (both FKs cascade), `kind` hypothesis|experiment|analysis, statement, JSON `grounding`/`novelty_report`/`feasibility`, score, indexed `status` open|expanded|pruned|validated|refuted; migration `7e2b9f4c1a86` with full downgrade and roundtrip assertions
- service: `create_node` (kind whitelist, one root per run, parent must pre-exist in the same run — cycle-freedom is structural), field setters, a table-driven `transition` state machine where pruning cascades the whole subtree, `tree_for_run` (single flat query), and `best_open_node` (score-ordered, None-safe — the D2 resume anchor)
- API: `GET /voyages/{id}/hypothesis-tree` and node detail, visibility reusing the voyage predicates (no access or cross-run ids → 404); read-only by design, the tree is written by the engine
- 7 new tests (invariants, transitions, cascade, ordering, API + stranger 404), order-insensitive against this machine's stepping container clock

Verification: full suite 1452 collected = 1449 passed + the 3 pre-existing #581 failures (baseline 1445 + exactly the 7 new tests); goldens untouched; ruff clean.