### PR TITLE
feat: Zotero library import

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -10,11 +10,13 @@ papers/wiki/concepts 路由里，鉴权同样接入库级写权限助手。
 
 import json
 import logging
+import shutil
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from redis.asyncio import Redis
 from sqlalchemy import select
@@ -79,6 +81,7 @@ from app.services import paper_merge as paper_merge_service
 from app.services import papers as papers_service
 from app.services import research_digest as research_digest_service
 from app.services import statement_interview as interview
+from app.services import zotero_import as zotero_import_service
 from app.services.embedding import embed_query
 from app.services.literature.arxiv import ArxivRateLimitedError
 from app.services.wiki_export import build_obsidian_zip_for_libraries
@@ -808,6 +811,103 @@ async def add_library_papers_manually_batch(
     if task_id is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE")
     return PaperManualBatchTaskRead(task_id=task_id, total=len(data.items))
+
+
+# ---- Zotero 库导入（#638） ----
+
+#: 一次导入的 .bib 条数上限。批量手动添加限 50 是「人肉粘贴」的量级；Zotero 是
+#: 整库搬迁，放宽到 500，再大的库建议按分类分批导出。
+MAX_ZOTERO_ENTRIES = 500
+MAX_ZOTERO_BIB_BYTES = 20 * 1024 * 1024
+MAX_ZOTERO_ZIP_BYTES = 500 * 1024 * 1024
+#: 任务归属 key 的 TTL 与 worker 任务超时对齐（4h）：导完之前 SSE 鉴权不能先过期。
+ZOTERO_TASK_OWNER_TTL_SECONDS = 4 * 3600
+
+
+@router.post(
+    "/libraries/{library_id}/import/zotero",
+    response_model=PaperManualBatchTaskRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def import_library_zotero(
+    library_id: uuid.UUID,
+    bib: UploadFile = File(...),
+    attachments: UploadFile | None = File(None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> PaperManualBatchTaskRead:
+    """从 Zotero 导出的 .bib（可选附件 zip）批量导入本库（可管理者）。
+
+    同步阶段只解析计数 + 把上传暂存到共享数据卷（api/worker 同挂），逐条建行、
+    三级去重、挂附件、后台补全都在 zotero_import 任务里做；进度与结果走
+    /paper-tasks/{task_id}/events（与批量手动添加同一事件口径）。
+    """
+    library = await _get_managed_library(session, library_id, user)
+    raw = await bib.read(MAX_ZOTERO_BIB_BYTES + 1)
+    if len(raw) > MAX_ZOTERO_BIB_BYTES:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="ZOTERO_BIB_TOO_LARGE"
+        )
+    try:
+        # 同步解析一遍是为了当场把「文件根本不是 bib」顶回去并给出条数；worker 侧
+        # 会从暂存文件重新解析（任务参数只传路径，跨进程不传大对象）。
+        entries = zotero_import_service.parse_zotero_bib(
+            raw.decode("utf-8-sig", errors="replace")
+        )
+    except paper_import_service.ParseFailedError as e:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail=f"PARSE_FAILED: {e}"
+        ) from e
+    if len(entries) > MAX_ZOTERO_ENTRIES:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT, detail="ZOTERO_TOO_MANY_ENTRIES"
+        )
+
+    task_id = uuid.uuid4().hex
+    try:
+        await redis.setex(
+            paper_enrich_service.paper_task_owner_key(task_id),
+            ZOTERO_TASK_OWNER_TTL_SECONDS,
+            str(user.id),
+        )
+    except Exception as e:  # noqa: BLE001 — redis 不可达时任务进度无从追踪，直接拒绝
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE"
+        ) from e
+
+    from app.core.config import get_settings
+
+    staged = Path(get_settings().data_dir) / "zotero_imports" / task_id
+    staged.mkdir(parents=True, exist_ok=True)
+    bib_path = staged / "library.bib"
+    bib_path.write_bytes(raw)
+    zip_path: Path | None = None
+    if attachments is not None and attachments.filename:
+        zip_path = staged / "attachments.zip"
+        size = 0
+        with zip_path.open("wb") as out:
+            # 附件包可能有几百 MB，分块落盘而不是整包进内存；超限当场清掉暂存目录
+            while chunk := await attachments.read(1024 * 1024):
+                size += len(chunk)
+                if size > MAX_ZOTERO_ZIP_BYTES:
+                    shutil.rmtree(staged, ignore_errors=True)
+                    raise HTTPException(
+                        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="ZOTERO_ZIP_TOO_LARGE",
+                    )
+                out.write(chunk)
+    await queue.enqueue(
+        "zotero_import",
+        task_id=task_id,
+        bib_path=str(bib_path),
+        zip_path=str(zip_path) if zip_path else None,
+        library_id=str(library.id),
+        user_id=str(user.id),
+        project_id=str(library.project_id) if library.project_id else None,
+    )
+    return PaperManualBatchTaskRead(task_id=task_id, total=len(entries))
 
 
 @router.post("/libraries/{library_id}/papers/batch-delete")

--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -32,6 +32,7 @@ WORKER_FUNCTIONS = frozenset(
         "daily_publication_match",
         "run_literature_discovery",
         "translate_literature_hit",
+        "zotero_import",
     }
 )
 

--- a/src/backend/app/services/zotero_import.py
+++ b/src/backend/app/services/zotero_import.py
@@ -1,0 +1,468 @@
+"""Zotero 库导入（#638）：解析 Zotero/BetterBibTeX 导出的 .bib（可选附件 zip），批量入库。
+
+与批量手动添加（paper_enrich._run_batch_import）同一套事件口径（batch_item /
+batch_progress / batch_enriched / done），前端直接复用 PaperBatchProgressModal；
+建行与补全也复用同一入口（create_pool_paper_stub / launch_paper_enrichment），
+不另起一条创建链路。
+
+去重按「目标库现有论文」做三级匹配：DOI → arXiv id → 规范化标题（小写去标点，
+口径 = services/dedup.normalize_title）。命中记 duplicates（事件 status="existing"，
+reason 标注命中层级），不重复建行；三级都未命中才查全局内容池（池命中且不在本库
+→ 只补成员行）。库内索引随导入即时更新，同一个 .bib 里自带的重复条目也会被挡住。
+"""
+
+import asyncio
+import logging
+import re
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from redis.asyncio import Redis
+from sqlalchemy import select
+
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.services.dedup import normalize_title
+from app.services.literature.arxiv import normalize_arxiv_id
+
+# _clean 是 bibtex 字段清洗的既有口径（去大括号、折叠空白）；解析结果要和手动
+# bibtex 添加落的字段长得一样，所以直接复用而不是再抄一份。
+from app.services.paper_import import ParseFailedError, _clean
+
+logger = logging.getLogger(__name__)
+
+#: 单条附件解压上限，对齐 PDF 上传上限（api/papers.MAX_PDF_UPLOAD_BYTES）——
+#: zip 里再大的成员也不该比直接上传能塞进更多字节（顺带挡 zip bomb）。
+MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024
+
+_ARXIV_URL_RE = re.compile(r"arxiv\.org/(?:abs|pdf)/([a-zA-Z0-9.\-/]+?)(?:\.pdf)?(?:$|[\s}])")
+_ARXIV_NOTE_RE = re.compile(r"arxiv[:\s]+(\d{4}\.\d{4,5}(?:v\d+)?)", re.IGNORECASE)
+_YEAR_RE = re.compile(r"\d{4}")
+
+
+def _entry_arxiv_id(entry: dict[str, Any]) -> str | None:
+    """eprint 优先；Zotero 常把 arXiv 线索丢在 url / note 里，作兜底扫一遍。"""
+    eprint = _clean(entry.get("eprint"))
+    if eprint:
+        prefix = (entry.get("archiveprefix") or entry.get("eprinttype") or "arxiv").lower()
+        if "arxiv" in prefix:
+            return normalize_arxiv_id(eprint)
+    for field in ("url", "note", "howpublished"):
+        value = entry.get(field) or ""
+        found = _ARXIV_URL_RE.search(value) or _ARXIV_NOTE_RE.search(value)
+        if found:
+            return normalize_arxiv_id(found.group(1))
+    return None
+
+
+def _pdf_hints(file_field: str | None) -> list[str]:
+    """从 Zotero 的 file 字段提取 PDF 相对路径候选。
+
+    Zotero 的格式是 ``描述:路径:MIME``、多个附件以 ``;`` 相连，路径里的 ``:`` ``;``
+    ``\\`` 会转义；BetterBibTeX 也可能只写一段裸路径。这里不逐格解析三元组，
+    而是把未转义分隔符切开后**凡以 .pdf 结尾的片段都算候选**——描述和 MIME 不会
+    以 .pdf 结尾，这样对两种方言都稳。
+    """
+    if not file_field:
+        return []
+    hints: list[str] = []
+    for chunk in re.split(r"(?<!\\)[;:]", file_field):
+        part = chunk.replace("\\:", ":").replace("\\;", ";").replace("\\\\", "\\")
+        part = part.replace("\\", "/").strip().strip("{}")
+        if part.lower().endswith(".pdf"):
+            hints.append(part)
+    return hints
+
+
+def parse_zotero_bib(text: str) -> list[dict[str, Any]]:
+    """解析整个 .bib 文件 → 逐条字段 dict（title 缺失不在此处拦，交由导入记 invalid）。
+
+    字段映射与 paper_import.parse_bibtex_entry 同口径，另补 Zotero/biblatex 方言：
+    journaltitle（biblatex 期刊名）、date（biblatex 年份）、file（附件路径）、
+    url/note 里的 arXiv 线索。LaTeX 转义（重音等）由 convert_to_unicode 还原。
+    """
+    import bibtexparser
+    from bibtexparser.bparser import BibTexParser
+    from bibtexparser.customization import convert_to_unicode
+
+    try:
+        parser = BibTexParser(common_strings=True)
+        parser.ignore_nonstandard_types = False  # Zotero 会导出 @online/@software 等
+        parser.customization = convert_to_unicode
+        db = bibtexparser.loads(text, parser=parser)
+    except Exception as e:  # noqa: BLE001 — 解析库的各种异常统一归为解析失败
+        raise ParseFailedError(f"bib 文件解析出错（{type(e).__name__}）") from e
+    if not db.entries:
+        raise ParseFailedError("bib 文件里没有可识别的条目")
+
+    results: list[dict[str, Any]] = []
+    for entry in db.entries:
+        year: int | None = None
+        year_match = _YEAR_RE.search(entry.get("year") or entry.get("date") or "")
+        if year_match:
+            year = int(year_match.group())
+        doi = _clean(entry.get("doi"))
+        if doi:
+            doi = doi.removeprefix("https://doi.org/").removeprefix("http://doi.org/")
+        results.append(
+            {
+                "citekey": entry.get("ID") or "",
+                "title": _clean(entry.get("title")),
+                "authors": [
+                    {"name": name}
+                    for raw in (entry.get("author") or entry.get("editor") or "").split(" and ")
+                    if (name := _clean(raw))
+                ],
+                "year": year,
+                "venue": _clean(
+                    entry.get("journal") or entry.get("journaltitle") or entry.get("booktitle")
+                ),
+                "doi": doi,
+                "arxiv_id": _entry_arxiv_id(entry),
+                "abstract": _clean(entry.get("abstract")),
+                "url": _clean(entry.get("url")),
+                "pdf_hints": _pdf_hints(entry.get("file")),
+            }
+        )
+    return results
+
+
+class ZipAttachmentIndex:
+    """附件 zip 的查找索引：file 字段相对路径 → zip 成员（Zotero 的 files/ 结构）。
+
+    匹配从严到宽：完整路径后缀 → 唯一同名文件 → 唯一同名（citekey / 规范化标题）。
+    宽松层要求唯一命中，宁可漏挂也不错挂。
+    """
+
+    def __init__(self, zf: zipfile.ZipFile) -> None:
+        self._zf = zf
+        self._paths: dict[str, str] = {}  # 规范化小写全路径 → 成员名
+        self._basenames: dict[str, list[str]] = {}  # 小写文件名 → 成员名列表
+        for info in zf.infolist():
+            if info.is_dir() or not info.filename.lower().endswith(".pdf"):
+                continue
+            normalized = info.filename.replace("\\", "/").lower()
+            self._paths[normalized] = info.filename
+            self._basenames.setdefault(normalized.rsplit("/", 1)[-1], []).append(info.filename)
+
+    def _member_for(self, entry: dict[str, Any]) -> str | None:
+        for hint in entry.get("pdf_hints") or []:
+            target = hint.lower().lstrip("/")
+            for path, member in self._paths.items():
+                if path == target or path.endswith("/" + target):
+                    return member
+            candidates = self._basenames.get(target.rsplit("/", 1)[-1])
+            if candidates and len(candidates) == 1:
+                return candidates[0]
+        # 无 file 字段（或没匹配上）：按 citekey / 标题同名兜底
+        citekey = (entry.get("citekey") or "").lower()
+        if citekey:
+            candidates = self._basenames.get(f"{citekey}.pdf")
+            if candidates and len(candidates) == 1:
+                return candidates[0]
+        title = entry.get("title")
+        if title:
+            wanted = normalize_title(title)
+            matched = [
+                members[0]
+                for base, members in self._basenames.items()
+                if len(members) == 1 and normalize_title(base.removesuffix(".pdf")) == wanted
+            ]
+            if len(matched) == 1:
+                return matched[0]
+        return None
+
+    def find(self, entry: dict[str, Any]) -> bytes | None:
+        member = self._member_for(entry)
+        if member is None:
+            return None
+        if self._zf.getinfo(member).file_size > MAX_ATTACHMENT_BYTES:
+            logger.warning("zotero attachment too large, skipped: %s", member)
+            return None
+        return self._zf.read(member)
+
+
+class LibraryDedupIndex:
+    """目标库现有论文的三级去重索引：DOI → arXiv id → 规范化标题。"""
+
+    def __init__(self) -> None:
+        self._by_doi: dict[str, uuid.UUID] = {}
+        self._by_arxiv: dict[str, uuid.UUID] = {}
+        self._by_title: dict[str, uuid.UUID] = {}
+
+    def add(
+        self,
+        paper_id: uuid.UUID,
+        *,
+        doi: str | None,
+        arxiv_id: str | None,
+        title: str | None,
+    ) -> None:
+        if doi:
+            self._by_doi.setdefault(doi.lower(), paper_id)
+        if arxiv_id:
+            self._by_arxiv.setdefault(arxiv_id.lower(), paper_id)
+        if title:
+            self._by_title.setdefault(normalize_title(title), paper_id)
+
+    def match(self, fields: dict[str, Any]) -> tuple[uuid.UUID, str] | None:
+        """命中返回 (已有 paper_id, 命中层级 doi|arxiv|title)。"""
+        doi = fields.get("doi")
+        if doi and (hit := self._by_doi.get(doi.lower())) is not None:
+            return hit, "doi"
+        arxiv_id = fields.get("arxiv_id")
+        if arxiv_id and (hit := self._by_arxiv.get(arxiv_id.lower())) is not None:
+            return hit, "arxiv"
+        title = fields.get("title")
+        if title and (hit := self._by_title.get(normalize_title(title))) is not None:
+            return hit, "title"
+        return None
+
+
+async def build_library_dedup_index(session: Any, library_id: uuid.UUID) -> LibraryDedupIndex:
+    """扫目标库全部成员（含回收站——在库即算「已有」）建索引。"""
+    index = LibraryDedupIndex()
+    rows = await session.execute(
+        select(Paper.id, Paper.doi, Paper.arxiv_id, Paper.title)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(LibraryPaper.library_id == library_id)
+    )
+    for paper_id, doi, arxiv_id, title in rows:
+        index.add(paper_id, doi=doi, arxiv_id=arxiv_id, title=title)
+    return index
+
+
+def _staged_root() -> Path:
+    from app.core.config import get_settings
+
+    return Path(get_settings().data_dir) / "zotero_imports"
+
+
+def _cleanup_staged(bib_path: Path) -> None:
+    """删掉这次导入落盘的暂存目录；只清 zotero_imports 之下的，测试临时目录不动。"""
+    import shutil
+
+    staged_dir = bib_path.parent
+    try:
+        if staged_dir.parent.resolve() == _staged_root().resolve():
+            shutil.rmtree(staged_dir, ignore_errors=True)
+    except OSError:
+        logger.warning("failed to clean staged zotero import dir: %s", staged_dir)
+
+
+async def run_zotero_import(
+    redis: Redis,
+    *,
+    task_id: str,
+    bib_path: str,
+    zip_path: str | None,
+    library_id: uuid.UUID,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+) -> dict[str, int]:
+    """执行一次 Zotero 导入：逐条独立提交，一条失败不影响其它条目。
+
+    进度与结果走 paper-task 事件通道（与批量手动添加同口径），API 侧已注册任务
+    归属，前端订阅 /paper-tasks/{task_id}/events 即可。返回汇总计数（arq 结果可查）：
+    created=导入、existing=重复（reason 标注 doi/arxiv/title/pool）、invalid=缺 title、
+    failed=异常。
+    """
+    from app.core.db import get_sessionmaker
+    from app.core.events import EventBus, publish_paper_task_event
+    from app.services import paper_enrich
+    from app.services import papers as papers_service
+    from app.services.dedup import pool_dedup_key
+    from app.services.libraries import ensure_membership, find_pool_paper, get_membership
+    from app.services.paper_import import create_pool_paper_stub
+
+    bus = EventBus(redis)
+    totals = {"created": 0, "existing": 0, "invalid": 0, "failed": 0}
+    enrichment_tasks: list[tuple[int, str]] = []
+    zf: zipfile.ZipFile | None = None
+
+    try:
+        try:
+            entries = parse_zotero_bib(Path(bib_path).read_text(encoding="utf-8-sig"))
+        except (OSError, ParseFailedError) as e:
+            await publish_paper_task_event(bus, task_id, "error", {"message": str(e)})
+            return totals
+
+        attachments: ZipAttachmentIndex | None = None
+        if zip_path:
+            try:
+                zf = zipfile.ZipFile(zip_path)
+                attachments = ZipAttachmentIndex(zf)
+            except (OSError, zipfile.BadZipFile):
+                # 附件包坏了不拦导入本身：条目照进，只是都不带 PDF
+                logger.warning("zotero attachment zip unusable: %s", zip_path, exc_info=True)
+
+        async with get_sessionmaker()() as session:
+            if await session.get(DirectionLibrary, library_id) is None:
+                await publish_paper_task_event(
+                    bus, task_id, "error", {"message": "library not found"}
+                )
+                return totals
+            index = await build_library_dedup_index(session, library_id)
+
+        for i, fields in enumerate(entries):
+            event: dict[str, Any] = {
+                "index": i,
+                "source": "zotero",
+                "input": fields.get("citekey") or (fields.get("title") or "")[:120],
+                "status": "failed",
+                "processing": False,
+            }
+            try:
+                if not fields.get("title"):
+                    event.update(status="invalid", error="条目缺少 title")
+                elif (hit := index.match(fields)) is not None:
+                    matched_id, reason = hit
+                    async with get_sessionmaker()() as session:
+                        paper = await session.get(Paper, matched_id)
+                    event.update(
+                        status="existing",
+                        reason=reason,
+                        paper_id=str(matched_id),
+                        title=paper.title if paper is not None else fields["title"],
+                    )
+                else:
+                    async with get_sessionmaker()() as session:
+                        pooled = await find_pool_paper(
+                            session,
+                            arxiv_id=fields.get("arxiv_id"),
+                            doi=fields.get("doi"),
+                            dedup_key=pool_dedup_key(
+                                arxiv_id=fields.get("arxiv_id"),
+                                doi=fields.get("doi"),
+                                title=fields["title"],
+                                year=fields.get("year"),
+                                authors=fields.get("authors"),
+                            ),
+                        )
+                        if pooled is not None and (
+                            await get_membership(
+                                session, library_id=library_id, paper_id=pooled.id
+                            )
+                        ) is not None:
+                            # 三级索引漏网的库内命中（如库行 doi 为空、池键靠年份+首作者对上）
+                            index.add(
+                                pooled.id,
+                                doi=fields.get("doi"),
+                                arxiv_id=fields.get("arxiv_id"),
+                                title=fields.get("title"),
+                            )
+                            event.update(
+                                status="existing",
+                                reason="pool",
+                                paper_id=str(pooled.id),
+                                title=pooled.title,
+                            )
+                        else:
+                            paper = pooled or await create_pool_paper_stub(
+                                session, fields=fields
+                            )
+                            await ensure_membership(
+                                session,
+                                library_id=library_id,
+                                paper_id=paper.id,
+                                status="included",
+                            )
+                            await session.commit()
+                            await session.refresh(paper)
+                            paper_id, title = paper.id, paper.title
+                            # 挂附件走 PDF 上传的同一入口（校验 + 全文 + 分块 + 向量），
+                            # 失败不推翻导入：论文已在库里，只是没带上 PDF
+                            content = attachments.find(fields) if attachments else None
+                            if content is not None and not paper.pdf_path:
+                                try:
+                                    await papers_service.upload_pdf(
+                                        session,
+                                        paper,
+                                        content,
+                                        user_id=user_id,
+                                        project_id=project_id,
+                                    )
+                                    await session.commit()
+                                    event["attachment"] = True
+                                except asyncio.CancelledError:
+                                    raise
+                                except Exception as e:  # noqa: BLE001
+                                    await session.rollback()
+                                    logger.warning(
+                                        "zotero attachment failed for %s",
+                                        paper_id,
+                                        exc_info=True,
+                                    )
+                                    event["attachment_error"] = f"{type(e).__name__}: {e}"
+                            index.add(
+                                paper_id,
+                                doi=fields.get("doi"),
+                                arxiv_id=fields.get("arxiv_id"),
+                                title=fields.get("title"),
+                            )
+                            paper = await session.get(Paper, paper_id)
+                            done_already = await paper_enrich.paper_processing_complete(
+                                session, paper, library_id=library_id
+                            )
+                            child_task_id: str | None = None
+                            if not done_already:
+                                child_task_id = await paper_enrich.launch_paper_enrichment(
+                                    redis=redis,
+                                    paper_id=paper_id,
+                                    user_id=user_id,
+                                    library_id=library_id,
+                                    project_id=project_id,
+                                )
+                            if child_task_id:
+                                enrichment_tasks.append((i, child_task_id))
+                            event.update(
+                                status="created",
+                                paper_id=str(paper_id),
+                                title=title,
+                                processing=bool(child_task_id),
+                            )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 单条隔离，继续处理后续条目
+                logger.exception("zotero import entry %d failed", i)
+                event.update(status="failed", error=f"{type(e).__name__}: {e}")
+
+            totals[str(event["status"])] += 1
+            await publish_paper_task_event(bus, task_id, "batch_item", event)
+            await publish_paper_task_event(
+                bus,
+                task_id,
+                "batch_progress",
+                {"completed": i + 1, "total": len(entries), **totals},
+            )
+
+        async def _wait(item_index: int, child_id: str) -> int:
+            await paper_enrich.await_task(child_id)
+            return item_index
+
+        waits = [_wait(item_index, child_id) for item_index, child_id in enrichment_tasks]
+        for completed in asyncio.as_completed(waits):
+            finished = await completed
+            await publish_paper_task_event(bus, task_id, "batch_enriched", {"index": finished})
+
+        await publish_paper_task_event(
+            bus, task_id, "done", {"total": len(entries), **totals}
+        )
+        return totals
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("zotero import task failed: %s", task_id)
+        try:
+            await publish_paper_task_event(
+                bus, task_id, "error", {"message": f"{type(e).__name__}: {e}"}
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to publish zotero import error event", exc_info=True)
+        return totals
+    finally:
+        if zf is not None:
+            zf.close()
+        _cleanup_staged(Path(bib_path))

--- a/src/backend/tests/test_zotero_import.py
+++ b/src/backend/tests/test_zotero_import.py
@@ -1,0 +1,317 @@
+"""Zotero 库导入（#638）：.bib 解析 + 三级去重 + 附件挂载 + 事件汇总，全离线。
+
+直接驱动 worker 任务函数（fake redis + fake enrich），不依赖真实 ARQ/网络。
+"""
+
+import json
+import uuid
+import zipfile
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.events import paper_task_log_key
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper, new_paper
+from app.models.user import User
+from app.services.dedup import pool_dedup_key
+from tests.conftest import make_project_with_library, register_and_login
+
+# 8 条固定 fixture：新 DOI / DOI 重复 / arXiv 重复 / 标题重复 / 无标识符 /
+# 缺 title / 带附件 / 异常字段（biblatex date、note 里的 arXiv、LaTeX 转义）
+FIXTURE_BIB = r"""
+@article{fresh2024,
+  title = {A Fresh {DOI} Paper},
+  author = {Lee, Ann and Bob Jones},
+  year = {2024},
+  journal = {Nature ML},
+  doi = {10.5000/fresh},
+  abstract = {Fresh work on agents.},
+}
+
+@article{dupdoi2020,
+  title = {Different Title Entirely},
+  author = {Bob, Sponge},
+  year = {2020},
+  doi = {10.4000/EXISTING},
+}
+
+@article{duparxiv2024,
+  title = {Also A Different Name},
+  author = {Carol, X},
+  year = {2024},
+  eprint = {2401.11111v2},
+  archiveprefix = {arXiv},
+}
+
+@inproceedings{duptitle2022,
+  title = {The  {Known} Paper: A Study!!},
+  author = {Dave, Y},
+  year = {2022},
+  booktitle = {Proceedings of Nowhere},
+}
+
+@misc{standalone2019,
+  title = {Standalone Note Without Identifiers},
+  author = {Carol Zhang},
+  year = {2019},
+}
+
+@article{broken2021,
+  author = {Nobody},
+  year = {2021},
+}
+
+@article{withpdf2023,
+  title = {Paper With Attachment},
+  author = {Dan, Q},
+  year = {2023},
+  doi = {10.5000/withpdf},
+  file = {Full Text PDF:files/42/withpdf.pdf:application/pdf},
+}
+
+@software{weird2024,
+  title = {An Online Tool with {\"U}nicode {Braces}},
+  author = {M{\"u}ller, K.},
+  date = {2024-05-01},
+  url = {https://example.org/tool},
+  note = {arXiv:2402.22222 [cs]},
+}
+"""
+
+
+def _one_page_pdf() -> bytes:
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Paper With Attachment full text.")
+    return doc.tobytes()
+
+
+async def _seed_library(client):
+    """建库 + 三篇既有论文（DOI / arXiv / 标题 各一），返回 (library_id, user_id)。"""
+    token = await register_and_login(client, email="zotero@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    _project_id, library_id = await make_project_with_library(client, headers, name="zotero-lib")
+    async with get_sessionmaker()() as session:
+        user_id = (
+            await session.execute(select(User.id).where(User.email == "zotero@example.com"))
+        ).scalar_one()
+        seeds = [
+            {"title": "Existing DOI Paper", "doi": "10.4000/existing", "arxiv_id": None},
+            {"title": "Existing Arxiv Paper", "doi": None, "arxiv_id": "2401.11111"},
+            # 标题重复靠规范化（小写去标点空白）对上，故意与 bib 里写法不同
+            {"title": "The Known Paper -- A Study", "doi": None, "arxiv_id": None},
+        ]
+        for seed in seeds:
+            paper = new_paper(
+                source="manual",
+                dedup_key=pool_dedup_key(
+                    arxiv_id=seed["arxiv_id"], doi=seed["doi"], title=seed["title"]
+                ),
+                title=seed["title"],
+                doi=seed["doi"],
+                arxiv_id=seed["arxiv_id"],
+            )
+            session.add(paper)
+            await session.flush()
+            session.add(
+                LibraryPaper(library_id=library_id, paper_id=paper.id, status="included")
+            )
+        await session.commit()
+    return library_id, user_id, headers
+
+
+async def _read_events(fake_redis, task_id):
+    return [json.loads(raw) for raw in await fake_redis.lrange(paper_task_log_key(task_id), 0, -1)]
+
+
+async def test_zotero_import_dedup_attachments_and_summary(
+    client, fake_redis, tmp_path, monkeypatch
+):
+    """全链：8 条 fixture → 4 导入 / 3 重复（doi、arxiv、title）/ 1 无效，附件挂上。"""
+    from app.services import paper_enrich
+    from worker import tasks as worker_tasks
+
+    library_id, user_id, _headers = await _seed_library(client)
+
+    launched: list[uuid.UUID] = []
+
+    async def _fake_launch(*, redis, paper_id, user_id, library_id=None, project_id=None):
+        launched.append(paper_id)
+        return None  # 不起真实补全：测试只关心导入与去重本身
+
+    monkeypatch.setattr(paper_enrich, "launch_paper_enrichment", _fake_launch)
+
+    bib_path = tmp_path / "library.bib"
+    bib_path.write_text(FIXTURE_BIB, encoding="utf-8")
+    zip_path = tmp_path / "files.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("export/files/42/withpdf.pdf", _one_page_pdf())
+
+    totals = await worker_tasks.zotero_import(
+        {"redis": fake_redis},
+        task_id="ztest",
+        bib_path=str(bib_path),
+        zip_path=str(zip_path),
+        library_id=str(library_id),
+        user_id=str(user_id),
+        project_id=None,
+    )
+    assert totals == {"created": 4, "existing": 3, "invalid": 1, "failed": 0}
+
+    events = await _read_events(fake_redis, "ztest")
+    items = [event["data"] for event in events if event["event"] == "batch_item"]
+    assert [item["status"] for item in items] == [
+        "created", "existing", "existing", "existing", "created", "invalid", "created", "created",
+    ]
+    # 三级去重理由逐级命中：DOI（大小写不敏感）→ arXiv（去版本号）→ 规范化标题
+    assert [item["reason"] for item in items if item["status"] == "existing"] == [
+        "doi", "arxiv", "title",
+    ]
+    assert items[5]["error"]  # 缺 title 的条目带原因
+    assert items[6].get("attachment") is True
+    assert events[-1] == {
+        "event": "done",
+        "data": {"total": 8, "created": 4, "existing": 3, "invalid": 1, "failed": 0},
+    }
+    assert len(launched) == 4  # 每条新导入都请求了后台补全
+
+    async with get_sessionmaker()() as session:
+        member_count = (
+            await session.execute(
+                select(LibraryPaper).where(LibraryPaper.library_id == library_id)
+            )
+        ).scalars().all()
+        assert len(member_count) == 7  # 3 既有 + 4 新导入，重复条目没建新行
+
+        attached = (
+            await session.execute(select(Paper).where(Paper.doi == "10.5000/withpdf"))
+        ).scalar_one()
+        assert attached.pdf_path and attached.full_text_path  # 附件走上传入口，全文一并抽好
+
+        weird = (
+            await session.execute(
+                select(Paper).where(Paper.title.ilike("%Online Tool%"))
+            )
+        ).scalar_one()
+        # 异常字段兜底：biblatex date 取年份，note 里的 arXiv 线索提出来
+        assert weird.year == 2024
+        assert weird.arxiv_id == "2402.22222"
+        assert weird.authors == [{"name": "Müller, K."}]
+
+
+async def test_zotero_import_within_file_duplicate(client, fake_redis, tmp_path, monkeypatch):
+    """同一个 .bib 里重复的条目也会被挡住（索引随导入即时更新）。"""
+    from app.services import paper_enrich
+    from worker import tasks as worker_tasks
+
+    library_id, user_id, _headers = await _seed_library(client)
+
+    async def _noop(**_kwargs):
+        return None
+
+    monkeypatch.setattr(paper_enrich, "launch_paper_enrichment", _noop)
+
+    bib_path = tmp_path / "dups.bib"
+    bib_path.write_text(
+        "@article{a, title={Twice Imported Paper}, author={A}, year={2024}, doi={10.6000/twice}}\n"
+        "@article{b, title={Twice Imported Paper vv}, author={A}, year={2024},"
+        " doi={10.6000/TWICE}}\n",
+        encoding="utf-8",
+    )
+    totals = await worker_tasks.zotero_import(
+        {"redis": fake_redis},
+        task_id="zdup",
+        bib_path=str(bib_path),
+        zip_path=None,
+        library_id=str(library_id),
+        user_id=str(user_id),
+        project_id=None,
+    )
+    assert totals == {"created": 1, "existing": 1, "invalid": 0, "failed": 0}
+    events = await _read_events(fake_redis, "zdup")
+    items = [e["data"] for e in events if e["event"] == "batch_item"]
+    assert items[1]["status"] == "existing" and items[1]["reason"] == "doi"
+
+
+async def test_zotero_import_endpoint_enqueues_and_authz(client, fake_redis, queue_stub):
+    """API：202 回 task_id/total 并入队；坏文件 422；非库管理者拒绝。"""
+    token = await register_and_login(client, email="zotero-api@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "zotero-api-lib", "statement": "Zotero import test library"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    library_id = resp.json()["id"]
+
+    files = {"bib": ("library.bib", FIXTURE_BIB.encode(), "text/x-bibtex")}
+    resp = await client.post(
+        f"/api/libraries/{library_id}/import/zotero", files=files, headers=headers
+    )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["total"] == 8 and body["task_id"]
+    assert queue_stub.jobs and queue_stub.jobs[0][0] == "zotero_import"
+    kwargs = queue_stub.jobs[0][2]
+    assert kwargs["library_id"] == library_id and kwargs["zip_path"] is None
+    # 暂存文件已落盘，worker 可从共享数据卷读到
+    from pathlib import Path
+
+    assert Path(kwargs["bib_path"]).read_text(encoding="utf-8") == FIXTURE_BIB
+    # 任务归属已登记：SSE 端点按它鉴权
+    from app.services.paper_enrich import paper_task_owner_key
+
+    owner = await fake_redis.get(paper_task_owner_key(body["task_id"]))
+    assert owner is not None
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/import/zotero",
+        files={"bib": ("broken.bib", b"not a bib file at all", "text/plain")},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    outsider = await register_and_login(client, email="zotero-outsider@example.com")
+    resp = await client.post(
+        f"/api/libraries/{library_id}/import/zotero",
+        files=files,
+        headers={"Authorization": f"Bearer {outsider}"},
+    )
+    assert resp.status_code in (403, 404)
+
+
+async def test_zotero_import_endpoint_accepts_zip(client, fake_redis, queue_stub, tmp_path):
+    """带附件 zip 的 multipart：zip 分块暂存到任务目录并随任务参数下发。"""
+    import io
+
+    token = await register_and_login(client, email="zotero-zip@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "zotero-zip-lib", "statement": "Zotero zip test library"},
+        headers=headers,
+    )
+    library_id = resp.json()["id"]
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("files/42/withpdf.pdf", b"%PDF-1.4 stub")
+    resp = await client.post(
+        f"/api/libraries/{library_id}/import/zotero",
+        files={
+            "bib": ("library.bib", FIXTURE_BIB.encode(), "text/x-bibtex"),
+            "attachments": ("files.zip", buffer.getvalue(), "application/zip"),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 202, resp.text
+    kwargs = queue_stub.jobs[0][2]
+    from pathlib import Path
+
+    assert kwargs["zip_path"] and Path(kwargs["zip_path"]).exists()
+    with zipfile.ZipFile(kwargs["zip_path"]) as zf:
+        assert zf.namelist() == ["files/42/withpdf.pdf"]

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -21,6 +21,7 @@ from worker.tasks import (
     run_voyage,
     translate_literature_hit,
     watch_unanswered_managed_commands,
+    zotero_import,
 )
 
 # 航程任务超时：GPU 训练轮合法地跑数小时；1h 的默认会把轮询任务掐死→ARQ 按任务
@@ -43,6 +44,8 @@ class WorkerSettings:
         daily_publication_match,
         func(run_literature_discovery, timeout=3600),
         func(translate_literature_hit, timeout=600),
+        # Zotero 导入：整库几百条 + 逐篇补全（LLM 打分限并发 3），1h 上限不够用
+        func(zotero_import, timeout=4 * 3600),
     ]
     # 抓取时刻可由管理员配置（SystemSetting daily_feed_sync_time，默认 UTC 02:30 =
     # 北京 10:30；arXiv 约北京 10:00 放新公告）。arq 的 cron 时刻在 worker 启动时就固定

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -462,3 +462,32 @@ async def translate_literature_hit(ctx: dict[str, Any], translation_id: str) -> 
             "translation_id": translation_id,
             "status": row.status if row is not None else "missing",
         }
+
+
+async def zotero_import(
+    ctx: dict[str, Any],
+    *,
+    task_id: str,
+    bib_path: str,
+    zip_path: str | None,
+    library_id: str,
+    user_id: str,
+    project_id: str | None = None,
+) -> dict[str, int]:
+    """Zotero 库导入（#638）：API 侧把上传暂存到 data_dir 后入队，这里逐条落库。
+
+    文件走共享数据卷（api 与 worker 同挂 /srv/data），进度与结果按 paper-task
+    事件口径发（任务归属在 API 入队前已注册），前端订阅
+    /paper-tasks/{task_id}/events。返回汇总计数（arq 结果可查）。
+    """
+    from app.services.zotero_import import run_zotero_import
+
+    return await run_zotero_import(
+        ctx["redis"],
+        task_id=task_id,
+        bib_path=bib_path,
+        zip_path=zip_path or None,
+        library_id=uuid.UUID(library_id),
+        user_id=uuid.UUID(user_id),
+        project_id=uuid.UUID(project_id) if project_id else None,
+    )

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -127,7 +127,7 @@ export interface PapersTabProps {
 
 /* ---------------- 添加文献 Modal ---------------- */
 
-type ImportMethod = 'arxiv' | 'doi' | 'corpus' | 'bibtex';
+type ImportMethod = 'arxiv' | 'doi' | 'corpus' | 'bibtex' | 'zotero';
 
 /** 按 BibTeX 条目的配对大括号/圆括号切分，保留坏条目交给后端逐项报错。 */
 function splitBibtexEntries(raw: string): string[] {
@@ -196,6 +196,8 @@ function AddPaperModal({
   const [doi, setDoi] = useState('');
   const [corpusId, setCorpusId] = useState('');
   const [bibtex, setBibtex] = useState('');
+  const [zoteroBib, setZoteroBib] = useState<File | null>(null);
+  const [zoteroZip, setZoteroZip] = useState<File | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ taskId: string; total: number } | null>(null);
 
@@ -217,6 +219,8 @@ function AddPaperModal({
     setDoi('');
     setCorpusId('');
     setBibtex('');
+    setZoteroBib(null);
+    setZoteroZip(null);
     setParseError(null);
   };
 
@@ -244,6 +248,33 @@ function AddPaperModal({
     },
   });
 
+  // Zotero 导入是文件上传（multipart），与逐条 JSON 的批量添加分开一条 mutation；
+  // 结果复用同一个 paper-task 进度弹窗。
+  const zoteroMutation = useMutation({
+    mutationFn: ({ bib, zip }: { bib: File; zip: File | null }) =>
+      api.importLibraryZotero(libraryId!, bib, zip),
+    onSuccess: (task) => {
+      reset();
+      onClose();
+      setProgress({ taskId: task.task_id, total: task.total });
+    },
+    onError: (e) => {
+      if (e instanceof ApiError && e.status === 422) {
+        setParseError(
+          tr('无法从这个 .bib 文件解析出文献条目，或条目超过 500 条。', 'No entries could be parsed from this .bib file, or it holds more than 500 entries.'),
+        );
+      } else if (e instanceof ApiError && e.status === 413) {
+        setParseError(tr('文件太大，请在 Zotero 里分批导出后再试。', 'The file is too large; export smaller batches from Zotero.'));
+      } else if (e instanceof ApiError && e.status === 503) {
+        setParseError(
+          tr('后台任务服务暂时不可用，请稍后再试。', 'The background task service is temporarily unavailable.'),
+        );
+      } else {
+        toast(`${tr('导入失败：', 'Import failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error');
+      }
+    },
+  });
+
   return (
     <>
     <Modal
@@ -258,13 +289,28 @@ function AddPaperModal({
           </button>
           <button
             className="btn btn-primary sm"
-            disabled={batchItems.length === 0 || tooMany || importMutation.isPending}
-            onClick={() => importMutation.mutate({ items: batchItems })}
+            disabled={
+              method === 'zotero'
+                ? !zoteroBib || zoteroMutation.isPending
+                : batchItems.length === 0 || tooMany || importMutation.isPending
+            }
+            onClick={() => {
+              if (method === 'zotero') {
+                if (libraryId && zoteroBib) zoteroMutation.mutate({ bib: zoteroBib, zip: zoteroZip });
+              } else {
+                importMutation.mutate({ items: batchItems });
+              }
+            }}
           >
-            {importMutation.isPending ? (
+            {(method === 'zotero' ? zoteroMutation.isPending : importMutation.isPending) ? (
               <>
                 <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
-                {tr('添加中…', 'Adding…')}
+                {method === 'zotero' ? tr('导入中…', 'Importing…') : tr('添加中…', 'Adding…')}
+              </>
+            ) : method === 'zotero' ? (
+              <>
+                <Icon name="plus" size={13} />
+                {tr('导入', 'Import')}
               </>
             ) : (
               <>
@@ -284,6 +330,7 @@ function AddPaperModal({
           { v: 'doi', label: 'DOI' },
           { v: 'corpus', label: 'Corpus ID' },
           { v: 'bibtex', label: tr('BibTeX 粘贴', 'Paste BibTeX') },
+          ...(libraryId ? [{ v: 'zotero' as const, label: tr('Zotero 导入', 'Zotero import') }] : []),
         ]}
         value={method}
         onChange={(m) => {
@@ -344,6 +391,34 @@ function AddPaperModal({
             />
             <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
               {tr('支持纯数字或 CorpusId: 前缀；最多 50 篇。', 'Numeric IDs and the CorpusId: prefix are supported; up to 50.')}
+            </div>
+          </>
+        ) : method === 'zotero' ? (
+          <>
+            <label className="col" style={{ gap: 6, fontSize: 12 }}>
+              <span>{tr('BibTeX 文件（Zotero / Better BibTeX 导出的 .bib）', 'BibTeX file (.bib exported from Zotero / Better BibTeX)')}</span>
+              <input
+                type="file"
+                accept=".bib,text/x-bibtex"
+                onChange={(e) => {
+                  setZoteroBib(e.target.files?.[0] ?? null);
+                  setParseError(null);
+                }}
+              />
+            </label>
+            <label className="col" style={{ gap: 6, fontSize: 12, marginTop: 12 }}>
+              <span>{tr('附件压缩包（可选：把带 files/ 目录的导出文件夹打包成 zip）', 'Attachments archive (optional: zip the export folder that contains files/)')}</span>
+              <input
+                type="file"
+                accept=".zip,application/zip"
+                onChange={(e) => setZoteroZip(e.target.files?.[0] ?? null)}
+              />
+            </label>
+            <div className="muted" style={{ fontSize: 11.5, marginTop: 8, lineHeight: 1.6 }}>
+              {tr(
+                '在 Zotero 中右键分类 → 导出分类，格式选 BibTeX；勾选「导出文件」可连 PDF 一起带上。已在库里的文献（按 DOI / arXiv / 标题判断）会自动跳过。',
+                'In Zotero right-click a collection and choose Export Collection with the BibTeX format; check “Export Files” to include PDFs. Papers already in the library (matched by DOI / arXiv / title) are skipped automatically.',
+              )}
             </div>
           </>
         ) : (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4056,6 +4056,13 @@ export const api = {
   importLibraryPapersBatch(id: string, input: PaperBatchImportInput): Promise<PaperBatchTask> {
     return requestJson<PaperBatchTask>(`/libraries/${id}/paper-imports/batch`, 'POST', input);
   },
+  /** Zotero 导入：.bib（可选附件 zip）multipart 上传，逐项结果同走 paper-task SSE。 */
+  importLibraryZotero(id: string, bib: File, attachments?: File | null): Promise<PaperBatchTask> {
+    const form = new FormData();
+    form.append('bib', bib);
+    if (attachments) form.append('attachments', attachments);
+    return request<PaperBatchTask>(`/libraries/${id}/import/zotero`, { method: 'POST', body: form });
+  },
   /** 批量删除库内论文：默认软删（回收站），hard=true 彻底删除。 */
   batchDeleteLibraryPapers(id: string, paperIds: string[], hard = false): Promise<{ deleted: number }> {
     return requestJson<{ deleted: number }>(`/libraries/${id}/papers/batch-delete`, 'POST', {


### PR DESCRIPTION
Closes #638. Part of #635 (P2 wave 1, item E5).

Imports an existing Zotero personal library into a Polaris library through the normal ingestion machinery — nothing bypasses the pool/enrich pipeline.

- parsing: the already-present bibtexparser with LaTeX-unicode conversion and nonstandard entry types (`@online`/`@software`); field mapping covers author/editor, biblatex `date`, journal→journaltitle→booktitle, DOI prefix stripping, and arXiv ids from `eprint` or embedded URLs (version-normalized)
- attachments: Zotero `file` triplets and BetterBibTeX bare paths resolved against the optional zip (path-suffix → unique-basename → citekey/title match, 100MB per-file cap); PDFs go through the existing upload path (validation, full text, chunking, vectors); an attachment failure never sinks the import
- dedup: three-level index against the target library (lowercased DOI → versionless arXiv id → normalized title), updated live so in-file duplicates are caught too; misses then consult the global content pool (pool hit not in library just adds membership)
- execution: a queued `zotero_import` task (4h cap) emitting the same batch events as bulk add, so the existing progress modal and SSE endpoint just work; API is `POST /libraries/{id}/import/zotero` (multipart, manage-predicate gated, 500 entries / 20MB bib / 500MB zip, 202 with task id)
- frontend: a "Zotero import" pane in the add-papers dialog (library scope only), `tr(zh,en)` copy, result summary of imported/duplicates/failed
- no schema changes — staging on disk, progress over events

Verification: full suite 1449 collected = 1446 passed + the 3 pre-existing #581 failures (baseline 1445 + exactly the 4 new tests, which drive the worker end-to-end over an 8-entry fixture); goldens untouched; frontend build and vitest green.