### PR TITLE
feat: citation-intent classification and OpenAlex alignment

### DIFF
--- a/src/backend/alembic/versions/57543f6328a1_paper_citations.py
+++ b/src/backend/alembic/versions/57543f6328a1_paper_citations.py
@@ -1,0 +1,56 @@
+"""引文边表 paper_citations（#639：引文意图分类 + OpenAlex 对齐）
+
+每行一条「citing 论文 → 参考文献条目」边：条目原文永远保留（池外文献只有
+这一份信息），cited_paper_id 是尽力而为的池内对齐（SET NULL 断链不删边），
+intent/confidence 由 citation_intent 环节的 LLM 分类回填。
+
+Revision ID: 57543f6328a1
+Revises: 7e2b9f4c1a86
+Create Date: 2026-09-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "57543f6328a1"
+down_revision: str | None = "7e2b9f4c1a86"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paper_citations",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("citing_paper_id", sa.Uuid(), nullable=False),
+        sa.Column("cited_paper_id", sa.Uuid(), nullable=True),
+        sa.Column("ref_index", sa.Integer(), nullable=False),
+        sa.Column("cited_ref_raw", sa.Text(), nullable=False),
+        sa.Column("context", sa.Text(), nullable=True),
+        sa.Column("intent", sa.String(length=16), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["citing_paper_id"], ["papers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["cited_paper_id"], ["papers.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "citing_paper_id", "ref_index", name="uq_paper_citations_citing_ref"
+        ),
+    )
+    # 查询习惯：详情页按 citing 取整篇引文，反查「谁引了这篇」按 cited
+    op.create_index(
+        "ix_paper_citations_citing_paper_id", "paper_citations", ["citing_paper_id"]
+    )
+    op.create_index(
+        "ix_paper_citations_cited_paper_id", "paper_citations", ["cited_paper_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_paper_citations_cited_paper_id", table_name="paper_citations")
+    op.drop_index("ix_paper_citations_citing_paper_id", table_name="paper_citations")
+    op.drop_table("paper_citations")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -28,6 +28,9 @@ from app.schemas.paper import (
     MyTagRead,
     PaperBatchIds,
     PaperChatRequest,
+    PaperCitationGroup,
+    PaperCitationItem,
+    PaperCitationsRead,
     PaperDetail,
     PaperFigure,
     PaperFiguresResponse,
@@ -51,6 +54,7 @@ from app.schemas.paper import (
     ResolvedPaperRead,
     TagRead,
 )
+from app.services import citation_graph as citation_graph_service
 from app.services import figure_annotate as figure_service
 from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
@@ -841,6 +845,35 @@ async def get_collecting_libraries(
     await _get_member_paper(session, paper_id, user, include_pool=True)
     rows = await papers_service.collecting_libraries(session, paper_id, user)
     return [CollectingLibraryRead(**row) for row in rows]
+
+
+@router.get("/papers/{paper_id}/citations", response_model=PaperCitationsRead)
+async def get_paper_citations(
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> PaperCitationsRead:
+    """按意图分组的引文列表（#639）。
+
+    分组顺序固定（CITATION_INTENTS 声明序），未分类的归到 intent=null 一组殿后；
+    空组不返回。深度 UI（引文网络图等）归 D5，这里只给详情页的分组列表。
+    """
+    from app.models.paper_citation import CITATION_INTENTS
+
+    await _get_member_paper(session, paper_id, user, include_pool=True)
+    rows = await citation_graph_service.list_citations(session, paper_id)
+    by_intent: dict[str | None, list[PaperCitationItem]] = {}
+    for citation, cited_title in rows:
+        item = PaperCitationItem.model_validate(citation).model_copy(
+            update={"cited_paper_title": cited_title}
+        )
+        by_intent.setdefault(citation.intent, []).append(item)
+    groups = [
+        PaperCitationGroup(intent=intent, items=by_intent[intent])
+        for intent in [*CITATION_INTENTS, None]
+        if by_intent.get(intent)
+    ]
+    return PaperCitationsRead(total=len(rows), groups=groups)
 
 
 @router.get("/papers/{paper_id}/index-status", response_model=PaperIndexStatusRead)

--- a/src/backend/app/cli/backfill_citations.py
+++ b/src/backend/app/cli/backfill_citations.py
@@ -1,0 +1,85 @@
+"""全库批量回填（#639）：引文边构建 + 引文意图分类 + OpenAlex 对齐。
+
+存量论文一次性覆盖用（新论文由补全钩子增量处理）::
+
+    python -m app.cli.backfill_citations            # 全部三步
+    python -m app.cli.backfill_citations --skip-align --limit 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+from sqlalchemy import select
+
+from app.core.db import dispose_engine, get_sessionmaker
+from app.core.llm.router import get_llm_router
+from app.models.paper import Paper
+
+logger = logging.getLogger(__name__)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skip-intents", action="store_true", help="只建边不做意图分类")
+    parser.add_argument("--skip-align", action="store_true", help="不做 OpenAlex 对齐")
+    parser.add_argument(
+        "--force-edges", action="store_true", help="重建已有引文边（丢弃已分类的意图）"
+    )
+    parser.add_argument("--limit", type=int, help="只处理最早入库的前 N 篇")
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> None:
+    stats = {"papers": 0, "edges": 0, "classified": 0, "aligned": 0, "failed": 0}
+    try:
+        from app.services.citation_graph import (
+            classify_citation_intents,
+            ensure_citation_edges,
+        )
+
+        llm = get_llm_router()
+        async with get_sessionmaker()() as session:
+            stmt = select(Paper).order_by(Paper.created_at)
+            if args.limit:
+                stmt = stmt.limit(args.limit)
+            papers = (await session.execute(stmt)).scalars().all()
+            for paper in papers:
+                stats["papers"] += 1
+                try:
+                    edges = await ensure_citation_edges(
+                        session, paper, force=args.force_edges
+                    )
+                    if edges:
+                        await session.commit()
+                        stats["edges"] += edges
+                    if not args.skip_intents:
+                        classified = await classify_citation_intents(session, paper, llm)
+                        if classified:
+                            await session.commit()
+                            stats["classified"] += classified
+                except Exception:  # noqa: BLE001 — 单篇失败不拖垮整批
+                    logger.warning("citation backfill failed for %s", paper.id, exc_info=True)
+                    await session.rollback()
+                    stats["failed"] += 1
+            if not args.skip_align:
+                from app.services.openalex_align import align_missing_papers
+
+                align_stats = await align_missing_papers(session, limit=args.limit)
+                stats["aligned"] = align_stats["aligned"]
+                stats["failed"] += align_stats["failed"]
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+    finally:
+        await dispose_engine()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(_run(_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -88,6 +88,10 @@ class Settings(BaseSettings):
         default="polaris@example.org",
         validation_alias=AliasChoices("POLARIS_OPENALEX_MAILTO", "OPENALEX_MAILTO"),
     )  # OpenAlex polite pool
+    # 新论文补全时顺带做 OpenAlex 对齐（#639）。默认开；测试套件置 0——
+    # 补全钩子里的对齐是真实出网调用，离线跑测试不该碰它（专测对齐的用例
+    # 自己注入 mock 客户端并临时打开）。
+    openalex_align_on_enrich: bool = True
     pubmed_email: str = Field(
         default="",
         validation_alias=AliasChoices(

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -36,6 +36,7 @@ _CONCEPTS_MARKER = "概念列表："
 # fake 的「这不是概念」判据（替身规则，见 _respond_concepts）：图/表引用形态
 _FAKE_FIGURE_REF_RE = re.compile(r"^(?:fig|figure|tab|table|eq)\s*[:：]", re.IGNORECASE)
 _AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affiliations.py 专门调用）
+_CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类（citation_graph.py）
 _AFFIL_COMPILE_MARKER = "POLARIS_AFFILIATIONS"  # on_compile 折叠进 wiki 编译的机构定界块请求
 # on_compile 模式下 librarian 编译输出附带的确定性机构定界块（与 FULL_TEXT 对齐）
 _FAKE_AFFIL_BLOCK = (
@@ -400,6 +401,9 @@ class FakeProvider(LLMProvider):
                 },
                 ensure_ascii=False,
             )
+        # 引文意图分类：user prompt 内嵌论文正文原句（可能撞任意通用 marker），须先判断
+        if _CITATION_INTENT_MARKER in full_text:
+            return FakeProvider._respond_citation_intent(last_user)
         # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
         # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
@@ -538,6 +542,41 @@ class FakeProvider(LLMProvider):
             },
             ensure_ascii=False,
         )
+
+
+    # 引文意图的确定性替身规则（citation_graph.py 的 prompt 对齐）：真模型按语义判
+    # 五档意图，fake 只按上下文关键词给可预期的结果——测试要的是「分类会落库、
+    # 会分组展示」这条链路，不是判得多准。规则顺序即优先级。
+    _FAKE_INTENT_RULES = (
+        ("comparison", ("compare", "compared", "comparison", "outperform", "对比", "优于")),
+        ("contrast", ("however", "unlike", "in contrast", "contrary", "相反", "不同于")),
+        (
+            "method",
+            ("we use", "we adopt", "we follow", "follow", "build on", "based on", "采用", "沿用"),
+        ),
+        ("support", ("consistent with", "support", "corroborate", "in line with", "支持", "一致")),
+    )
+
+    @staticmethod
+    def _respond_citation_intent(last_user: str) -> str:
+        """引文意图批量分类：user prompt 是 {"items": [{"index", "context"}]} JSON。"""
+        start = last_user.find("{")
+        try:
+            payload = json.loads(last_user[start:]) if start != -1 else {}
+        except json.JSONDecodeError:
+            payload = {}
+        out = []
+        for item in payload.get("items") or []:
+            if not isinstance(item, dict) or "index" not in item:
+                continue
+            context = str(item.get("context") or "").lower()
+            intent, confidence = "background", 0.6
+            for name, keywords in FakeProvider._FAKE_INTENT_RULES:
+                if any(k in context for k in keywords):
+                    intent, confidence = name, 0.9
+                    break
+            out.append({"index": item["index"], "intent": intent, "confidence": confidence})
+        return json.dumps({"items": out}, ensure_ascii=False)
 
     @staticmethod
     def _respond_daily_digest(last_user: str) -> str:

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -79,6 +79,7 @@ STAGES = (
     "writing",
     "review",
     "reading",
+    "citation_intent",
 )
 
 _ROUTE_CACHE_TTL = 60.0
@@ -165,6 +166,7 @@ _SHORT_CALL_STAGES = frozenset(
         "forge",
         "forge_signal",
         "reading",
+        "citation_intent",  # 引文意图批量分类：短 JSON、便宜模型（#639）
     }
 )
 

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -51,6 +51,7 @@ from app.models.paper import (
     paper_tag_links,
 )
 from app.models.paper_assets import AssetGrant, PaperAsset, PdfBlob
+from app.models.paper_citation import CITATION_INTENTS, PaperCitation
 from app.models.paper_content import (
     PaperContentChunk,
     PaperContentChunkVector,
@@ -119,7 +120,9 @@ __all__ = [
     "ModelRoute",
     "Paper",
     "PdfBlob",
+    "CITATION_INTENTS",
     "PaperAsset",
+    "PaperCitation",
     "AssetGrant",
     "PaperChunk",
     "PaperChunkVector",

--- a/src/backend/app/models/paper_citation.py
+++ b/src/backend/app/models/paper_citation.py
@@ -1,0 +1,53 @@
+"""论文引文边（#639：引文意图分类 + OpenAlex 对齐的存储落点）。
+
+papers 是全平台共享的内容池，引文关系跟着论文本体走（类比 paper_wikis /
+paper_chunks），因此这张表**不带 library_id**——「某个库的引文网络」一律由
+库成员（library_papers）推导，不另存一份归属。
+
+每行一条「citing → 参考文献条目」边：cited_ref_raw 永远保留解析出的条目原文
+（被引论文不在池内时它就是全部信息）；cited_paper_id 是尽力而为的池内对齐，
+被引论文后来入库/被删都不影响边本身（SET NULL）。
+"""
+
+import uuid
+
+from sqlalchemy import Float, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
+
+# 引文意图五档（设计报告 §10 ③层，#639）：
+# background 背景铺垫 | method 方法沿用 | comparison 实验对比 |
+# support 结论支持 | contrast 观点相左
+CITATION_INTENTS = ("background", "method", "comparison", "support", "contrast")
+
+
+class PaperCitation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """引文边：citing 论文的第 ref_index 条参考文献。
+
+    ``intent`` / ``confidence`` 由 citation_intent 环节的 LLM 分类回填，
+    分类前为 NULL（前端按「未分类」分组展示）。"""
+
+    __tablename__ = "paper_citations"
+    __table_args__ = (
+        # 同一篇论文的参考文献序号唯一：重建引文边先删后插，靠它兜住并发重复
+        UniqueConstraint("citing_paper_id", "ref_index", name="uq_paper_citations_citing_ref"),
+    )
+
+    citing_paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # 池内对齐（可空）：被引论文恰好也在内容池时指过去；删除被引论文只断链不删边
+    cited_paper_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("papers.id", ondelete="SET NULL"), index=True
+    )
+    # 参考文献序号（1 起；无编号的参考文献列表按出现顺序编）
+    ref_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    # 参考文献条目原文（解析产物，永远保留——池外文献只有这一份信息）
+    cited_ref_raw: Mapped[str] = mapped_column(Text, nullable=False)
+    # 正文中的引用上下文句（[n] 标记所在句）；作者-年份式引用解析不到时为 NULL，
+    # 意图分类降级用「条目原文 + citing 论文标题摘要」
+    context: Mapped[str | None] = mapped_column(Text)
+    intent: Mapped[str | None] = mapped_column(String(16))  # CITATION_INTENTS 之一
+    confidence: Mapped[float | None] = mapped_column(Float)

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -121,6 +121,33 @@ class PaperDetail(PaperRead):
         return v or []
 
 
+class PaperCitationItem(BaseModel):
+    """一条引文边（详情页引文列表项）。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    ref_index: int
+    cited_ref_raw: str
+    context: str | None = None
+    intent: str | None = None  # background|method|comparison|support|contrast；未分类为 null
+    confidence: float | None = None
+    cited_paper_id: uuid.UUID | None = None  # 池内对齐命中时给（前端可跳转）
+    cited_paper_title: str | None = None
+
+
+class PaperCitationGroup(BaseModel):
+    intent: str | None  # null = 还没分类那组
+    items: list[PaperCitationItem]
+
+
+class PaperCitationsRead(BaseModel):
+    """按意图分组的引文列表（#639；分组聚合在后端做，前端拿来即渲染）。"""
+
+    total: int
+    groups: list[PaperCitationGroup]
+
+
 class VectorStatusRead(BaseModel):
     """一种向量的状态（前端红绿点 + 悬浮显示构建时间与模型名）。
 

--- a/src/backend/app/services/citation_graph.py
+++ b/src/backend/app/services/citation_graph.py
@@ -1,0 +1,332 @@
+"""引文边构建 + 引文意图分类（#639，设计报告 §10 ③层）。
+
+解析产物就是 pdf_extract 落盘的纯文本全文（没有 GROBID 一类的结构化解析），
+所以这里自带一套确定性的参考文献解析：
+
+- 定位最后一个 References / Bibliography / 参考文献 标题行，之后是文献表；
+- 编号式（[1] ...）按编号切条目；没有编号则按空行分段兜底；
+- 引用上下文句：正文里含 [n] / [n,m] / [n-m] 标记的句子，按编号回挂到条目。
+
+作者-年份式引用（Smith et al., 2020）解析不到上下文——意图分类降级用
+「条目原文 + citing 论文标题摘要」，这正是任务里约定的降级路径。
+
+意图分类走 citation_intent 环节（便宜小模型、短 JSON、批量 20 条一call）；
+fake provider 下按上下文关键词给确定性结果（core/llm/fake.py 对齐）。
+"""
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.base import Message
+from app.models.paper import Paper
+from app.models.paper_citation import CITATION_INTENTS, PaperCitation
+
+logger = logging.getLogger(__name__)
+
+# 解析护栏：超长论文/解析异常时不至于灌出海量边
+MAX_REFERENCES = 300
+MAX_REF_RAW_CHARS = 1000
+MAX_CONTEXT_CHARS = 600
+# 一次 LLM 调用最多分类多少条（短 JSON，20 条以内输出可控）
+INTENT_BATCH_SIZE = 20
+
+# 参考文献节标题（整行）；取**最后一个**匹配——正文里提到 "references" 的概率
+# 远大于文献表后面还有一个同名标题
+_REF_HEADING_RE = re.compile(
+    r"^\s*(?:references|bibliography|参考文献)\s*:?\s*$", re.IGNORECASE | re.MULTILINE
+)
+# 编号式条目起点：行首 [12]
+_NUM_ENTRY_RE = re.compile(r"^\s*\[(\d{1,3})\]", re.MULTILINE)
+# 正文引用标记：[3] / [3,5] / [3-6]（数字与逗号/连字符的组合）
+_CITE_MARK_RE = re.compile(r"\[(\d{1,3}(?:\s*[,\-–]\s*\d{1,3})*)\]")
+# 句子边界（英文句号/问叹号 + 中文句读）
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?。！？])\s+")
+
+
+@dataclass(slots=True)
+class ParsedReference:
+    index: int  # 1 起的参考文献序号
+    raw: str  # 条目原文
+    context: str | None = None  # 正文引用上下文句（解析不到为 None）
+
+
+def split_reference_section(full_text: str) -> tuple[str, str]:
+    """全文 → (正文, 参考文献节文本)；没有文献节时后者为空串。"""
+    last = None
+    for m in _REF_HEADING_RE.finditer(full_text):
+        last = m
+    if last is None:
+        return full_text, ""
+    return full_text[: last.start()], full_text[last.end() :]
+
+
+def _entries_numbered(refs_text: str) -> list[tuple[int, str]]:
+    marks = list(_NUM_ENTRY_RE.finditer(refs_text))
+    entries: list[tuple[int, str]] = []
+    for i, m in enumerate(marks):
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(refs_text)
+        raw = " ".join(refs_text[m.end() : end].split())
+        if raw:
+            entries.append((int(m.group(1)), raw[:MAX_REF_RAW_CHARS]))
+    return entries
+
+
+def _entries_fallback(refs_text: str) -> list[tuple[int, str]]:
+    """无编号文献表：按空行分段；一整坨没有空行时按行给（arXiv 抽取常见形态）。"""
+    blocks = [b for b in re.split(r"\n\s*\n", refs_text) if b.strip()]
+    if len(blocks) <= 1:
+        blocks = [line for line in refs_text.splitlines() if line.strip()]
+    entries = []
+    for i, block in enumerate(blocks, start=1):
+        raw = " ".join(block.split())
+        # 太短的行（页码、栏尾残句）不算条目
+        if len(raw) >= 20:
+            entries.append((i, raw[:MAX_REF_RAW_CHARS]))
+    return entries
+
+
+def _expand_marks(spec: str) -> list[int]:
+    """引用标记内容 → 编号列表："3,5" → [3,5]；"3-6" → [3,4,5,6]。"""
+    out: list[int] = []
+    for part in re.split(r"\s*,\s*", spec):
+        m = re.match(r"^(\d+)\s*[\-–]\s*(\d+)$", part)
+        if m:
+            lo, hi = int(m.group(1)), int(m.group(2))
+            if lo <= hi and hi - lo <= 50:
+                out.extend(range(lo, hi + 1))
+        elif part.strip().isdigit():
+            out.append(int(part))
+    return out
+
+
+def _citation_contexts(body: str) -> dict[int, str]:
+    """正文 → {参考文献编号: 首个引用上下文句}。"""
+    contexts: dict[int, str] = {}
+    for sentence in _SENTENCE_SPLIT_RE.split(body):
+        sentence = " ".join(sentence.split())
+        if not sentence or len(sentence) < 15:
+            continue
+        for m in _CITE_MARK_RE.finditer(sentence):
+            for n in _expand_marks(m.group(1)):
+                contexts.setdefault(n, sentence[:MAX_CONTEXT_CHARS])
+    return contexts
+
+
+def parse_references(full_text: str) -> list[ParsedReference]:
+    """全文 → 带上下文句的参考文献列表（确定性，无 LLM）。"""
+    body, refs_text = split_reference_section(full_text)
+    if not refs_text.strip():
+        return []
+    entries = _entries_numbered(refs_text)
+    if len(entries) >= 2:
+        contexts = _citation_contexts(body)
+    else:
+        entries = _entries_fallback(refs_text)
+        contexts = {}  # 无编号 → 正文标记对不上号，全部走降级路径
+    seen: set[int] = set()
+    refs: list[ParsedReference] = []
+    for index, raw in entries[:MAX_REFERENCES]:
+        if index in seen:  # 解析噪声（正文残留的 [n]）不覆盖先到的条目
+            continue
+        seen.add(index)
+        refs.append(ParsedReference(index=index, raw=raw, context=contexts.get(index)))
+    return refs
+
+
+def _norm_title(text: str) -> str:
+    return " ".join(re.sub(r"[^0-9a-z一-鿿]+", " ", text.lower()).split())
+
+
+async def _match_pool_papers(
+    session: AsyncSession, refs: list[ParsedReference], *, citing_id: uuid.UUID
+) -> dict[int, uuid.UUID]:
+    """条目原文 ⊇ 池内论文标题（归一化后）→ 池内对齐。个人平台的池量级下全表标题可扫。"""
+    rows = (await session.execute(select(Paper.id, Paper.title))).all()
+    normalized_refs = {r.index: _norm_title(r.raw) for r in refs}
+    matched: dict[int, uuid.UUID] = {}
+    for paper_id, title in rows:
+        if paper_id == citing_id:
+            continue
+        norm = _norm_title(title or "")
+        if len(norm) < 20:  # 太短的标题子串匹配假阳性太高，不对齐
+            continue
+        for index, ref_norm in normalized_refs.items():
+            if index not in matched and norm in ref_norm:
+                matched[index] = paper_id
+    return matched
+
+
+async def ensure_citation_edges(
+    session: AsyncSession, paper: Paper, *, force: bool = False
+) -> int:
+    """为一篇论文建引文边；已建过则跳过（force 重建先删后插）。调用方负责 commit。
+
+    返回新建边数。没有全文（或全文里解析不出文献表）返回 0——增量钩子据此
+    对 bibtex/每日推送这类无 PDF 论文零输出（golden 链路不受影响）。
+    """
+    existing = await session.scalar(
+        select(func.count())
+        .select_from(PaperCitation)
+        .where(PaperCitation.citing_paper_id == paper.id)
+    )
+    if existing and not force:
+        return 0
+    if not paper.full_text_path or not Path(paper.full_text_path).exists():
+        return 0
+    full_text = Path(paper.full_text_path).read_text(encoding="utf-8", errors="ignore")
+    refs = parse_references(full_text)
+    if not refs:
+        return 0
+    if existing:
+        for row in (
+            await session.execute(
+                select(PaperCitation).where(PaperCitation.citing_paper_id == paper.id)
+            )
+        ).scalars():
+            await session.delete(row)
+        await session.flush()
+    matched = await _match_pool_papers(session, refs, citing_id=paper.id)
+    for ref in refs:
+        session.add(
+            PaperCitation(
+                citing_paper_id=paper.id,
+                cited_paper_id=matched.get(ref.index),
+                ref_index=ref.index,
+                cited_ref_raw=ref.raw,
+                context=ref.context,
+            )
+        )
+    return len(refs)
+
+
+# ---- 意图分类（citation_intent 环节） ----
+
+_INTENT_SYSTEM_PROMPT = (
+    "POLARIS_CITATION_INTENT\n"
+    "你是引文意图分类器。输入 JSON 的 items 每条是论文里一处引用的上下文\n"
+    "（context 是正文引用句；解析不到时是参考文献条目 + citing 论文的标题摘要）。\n"
+    "对每条判定引用意图，五选一：\n"
+    "background（背景铺垫）| method（方法沿用/扩展）| comparison（作为对比对象）|\n"
+    "support（支持本文结论）| contrast（与本文观点相左）。\n"
+    '只输出 JSON：{"items": [{"index": <原样回传>, "intent": "...", "confidence": 0到1}]}'
+)
+
+
+def _fallback_context(ref: PaperCitation, paper: Paper) -> str:
+    """无上下文句的降级输入：条目原文 + citing 论文标题摘要。"""
+    abstract = (paper.abstract or "")[:300]
+    return f"[REF] {ref.cited_ref_raw}\n[CITING] {paper.title or ''}. {abstract}"[
+        :MAX_CONTEXT_CHARS * 2
+    ]
+
+
+def _parse_intent_response(content: str) -> dict[int, tuple[str, float | None]]:
+    start, end = content.find("{"), content.rfind("}")
+    if start == -1 or end <= start:
+        return {}
+    try:
+        payload = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        return {}
+    out: dict[int, tuple[str, float | None]] = {}
+    for item in payload.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        intent = str(item.get("intent") or "")
+        if intent not in CITATION_INTENTS or not isinstance(item.get("index"), int):
+            continue
+        confidence: float | None = None
+        raw_conf = item.get("confidence")
+        if isinstance(raw_conf, (int, float)):
+            confidence = min(1.0, max(0.0, float(raw_conf)))
+        out[int(item["index"])] = (intent, confidence)
+    return out
+
+
+async def classify_citation_intents(
+    session: AsyncSession,
+    paper: Paper,
+    llm: Any,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+) -> int:
+    """把这篇论文 intent 还空着的引文边批量分类。调用方负责 commit，返回落库条数。
+
+    批量便宜路径：20 条一次 complete（citation_intent 环节，短 JSON 档）。
+    单批解析失败只丢那一批（记日志），不打断其余批次——批量任务跑全库时
+    一篇论文的坏输出不该拖垮整个回填。
+    """
+    pending = (
+        (
+            await session.execute(
+                select(PaperCitation)
+                .where(
+                    PaperCitation.citing_paper_id == paper.id,
+                    PaperCitation.intent.is_(None),
+                )
+                .order_by(PaperCitation.ref_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not pending:
+        return 0
+    classified = 0
+    for i in range(0, len(pending), INTENT_BATCH_SIZE):
+        batch = pending[i : i + INTENT_BATCH_SIZE]
+        items = [
+            {
+                "index": ref.ref_index,
+                "context": ref.context or _fallback_context(ref, paper),
+            }
+            for ref in batch
+        ]
+        result = await llm.complete(
+            "citation_intent",
+            [
+                Message(role="system", content=_INTENT_SYSTEM_PROMPT),
+                Message(role="user", content=json.dumps({"items": items}, ensure_ascii=False)),
+            ],
+            temperature=0.0,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+        )
+        parsed = _parse_intent_response(result.content)
+        if not parsed:
+            logger.warning(
+                "citation intent batch unparseable for paper %s (batch %d)", paper.id, i
+            )
+            continue
+        for ref in batch:
+            hit = parsed.get(ref.ref_index)
+            if hit is None:
+                continue
+            ref.intent, ref.confidence = hit
+            classified += 1
+    return classified
+
+
+async def list_citations(
+    session: AsyncSession, paper_id: uuid.UUID
+) -> list[tuple[PaperCitation, str | None]]:
+    """一篇论文的全部引文边 + 池内被引论文标题（详情页按 intent 分组的原料）。"""
+    cited = select(Paper.id.label("pid"), Paper.title.label("ptitle")).subquery()
+    stmt = (
+        select(PaperCitation, cited.c.ptitle)
+        .outerjoin(cited, cited.c.pid == PaperCitation.cited_paper_id)
+        .where(PaperCitation.citing_paper_id == paper_id)
+        .order_by(PaperCitation.ref_index)
+    )
+    return [(row[0], row[1]) for row in (await session.execute(stmt)).all()]

--- a/src/backend/app/services/literature/openalex.py
+++ b/src/backend/app/services/literature/openalex.py
@@ -6,9 +6,12 @@ import httpx
 from redis.asyncio import Redis
 
 from app.core.config import get_settings
-from app.services.literature.cache import ResponseCache, cache_key
+from app.services.literature.cache import ResponseCache, TokenBucket, cache_key
 
 API_BASE = "https://api.openalex.org"
+
+# polite pool 名义上限 10 req/s；批量对齐会连续打，按一半留余量
+_POLITE_RATE = 5.0
 
 # arXiv 论文的 DataCite DOI 前缀
 ARXIV_DOI_TEMPLATE = "10.48550/arXiv.{arxiv_id}"
@@ -85,6 +88,7 @@ class OpenAlexClient:
         redis: Redis | None = None,
         mailto: str | None = None,
         api_key: str | None = None,
+        rate: float = _POLITE_RATE,
     ) -> None:
         self._client = client or httpx.AsyncClient(
             proxy=get_settings().outbound_proxy or None, timeout=30.0
@@ -92,6 +96,8 @@ class OpenAlexClient:
         self._cache = ResponseCache(redis)
         self._mailto = mailto if mailto is not None else get_settings().openalex_mailto
         self._api_key = api_key
+        # 令牌桶限流（#639 批量对齐补上；容量=rate*2 允许零星调用不等待）
+        self._bucket = TokenBucket(rate=rate, capacity=max(1.0, rate * 2))
 
     async def _get(
         self, path: str, extra_params: dict[str, Any] | None = None
@@ -104,6 +110,7 @@ class OpenAlexClient:
         key = cache_key("openalex", path, params)
         if (cached := await self._cache.get(key)) is not None:
             return cached or None  # 缓存的 {} 表示 404
+        await self._bucket.acquire()  # 限流只管真实出网；缓存命中不占令牌
         resp = await self._client.get(f"{API_BASE}{path}", params=params)
         if resp.status_code == 404:
             await self._cache.set(key, {})

--- a/src/backend/app/services/openalex_align.py
+++ b/src/backend/app/services/openalex_align.py
@@ -1,0 +1,160 @@
+"""OpenAlex 对齐（#639）：给缺 OpenAlex id 的论文补 id 并回填缺失元数据。
+
+匹配顺序：DOI 精确 → arXiv id 精确（经 DataCite DOI）→ 标题+年份模糊。
+openalex id 落 papers.external_ids["openalex"]（该 JSON 列本来就是给外部
+id 预留的，不为此加列）；回填只补空字段——已有值一律不动，OpenAlex 的
+元数据质量参差，覆盖用户手工修过的字段得不偿失。
+
+客户端限速/缓存复用 OpenAlexClient 自身（缓存原有；限流本次补上，见
+services/literature/openalex.py）。
+"""
+
+import logging
+import re
+from difflib import SequenceMatcher
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.models.paper import Paper
+from app.services.literature import get_openalex_client
+from app.services.literature.openalex import OpenAlexClient
+
+logger = logging.getLogger(__name__)
+
+# 标题模糊匹配阈值（归一化后 SequenceMatcher ratio）。0.92：容得下大小写/
+# 标点/连字差异，容不下换了半句话的另一篇
+TITLE_MATCH_RATIO = 0.92
+# external_ids 里的键名
+OPENALEX_KEY = "openalex"
+
+
+def openalex_id_of(paper: Paper) -> str | None:
+    ids = paper.external_ids if isinstance(paper.external_ids, dict) else {}
+    value = ids.get(OPENALEX_KEY)
+    return str(value) if value else None
+
+
+def _norm_title(text: str) -> str:
+    return " ".join(re.sub(r"[^0-9a-z一-鿿]+", " ", text.lower()).split())
+
+
+def _short_openalex_id(raw: str) -> str:
+    """https://openalex.org/W123 → W123（API 返回的是完整 URL 形态）。"""
+    return raw.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _title_matches(a: str, b: str) -> bool:
+    na, nb = _norm_title(a), _norm_title(b)
+    if not na or not nb:
+        return False
+    return na == nb or SequenceMatcher(None, na, nb).ratio() >= TITLE_MATCH_RATIO
+
+
+def _year_compatible(paper_year: int | None, meta_year: Any) -> bool:
+    """年份宽容 ±1：预印本与正式发表常差一年；有一边缺年份不作为否决条件。"""
+    if paper_year is None or not isinstance(meta_year, int):
+        return True
+    return abs(paper_year - meta_year) <= 1
+
+
+def apply_openalex_meta(paper: Paper, meta: dict[str, Any]) -> bool:
+    """把 OpenAlex work 元数据落到论文上：存 id + 只补空字段。返回是否有改动。"""
+    changed = False
+    short_id = _short_openalex_id(str(meta.get("openalex_id") or ""))
+    if short_id and openalex_id_of(paper) != short_id:
+        ids = dict(paper.external_ids) if isinstance(paper.external_ids, dict) else {}
+        ids[OPENALEX_KEY] = short_id
+        paper.external_ids = ids
+        # JSON 列的字典就地换新对象，SQLAlchemy 不一定察觉，显式标脏
+        flag_modified(paper, "external_ids")
+        changed = True
+    # 空字段回填清单：都是 OpenAlex 可靠给得出的（citation count 池表没有对应列，
+    # 不为回填加列——被引数已在检索链路按需取用）
+    backfills: tuple[tuple[str, Any], ...] = (
+        ("doi", meta.get("doi")),
+        ("abstract", meta.get("abstract")),
+        ("venue", meta.get("venue")),
+        ("year", meta.get("year")),
+        ("url", meta.get("url")),
+    )
+    for field, value in backfills:
+        if value and not getattr(paper, field):
+            setattr(paper, field, value)
+            changed = True
+    if meta.get("affiliations") and not paper.affiliations:
+        paper.affiliations = list(meta["affiliations"])
+        changed = True
+    return changed
+
+
+async def align_paper(
+    session: AsyncSession,  # noqa: ARG001 —— 与其余 service 签名一致，便于将来查重
+    paper: Paper,
+    *,
+    client: OpenAlexClient | None = None,
+) -> bool:
+    """给一篇缺 OpenAlex id 的论文找对齐。调用方负责 commit，返回是否有改动。
+
+    已有 id 直接返回 False（幂等）；查不到/标题对不上不写任何东西。
+    """
+    if openalex_id_of(paper):
+        return False
+    client = client or get_openalex_client()
+    meta: dict[str, Any] | None = None
+    if paper.doi:
+        meta = await client.get_by_doi(paper.doi)
+    elif paper.arxiv_id:
+        meta = await client.get_by_arxiv(paper.arxiv_id)
+    elif paper.title:
+        year = paper.year
+        candidates = await client.search_works(
+            paper.title,
+            limit=5,
+            start_year=year - 1 if year else None,
+            end_year=year + 1 if year else None,
+        )
+        meta = next(
+            (
+                c
+                for c in candidates
+                if _title_matches(paper.title, str(c.get("title") or ""))
+                and _year_compatible(year, c.get("year"))
+            ),
+            None,
+        )
+    if not meta or not meta.get("openalex_id"):
+        return False
+    # 精确通道（DOI/arXiv）拿回来的也复核一下标题：DOI 录错时宁可不对齐
+    if meta.get("title") and paper.title and not _title_matches(paper.title, str(meta["title"])):
+        logger.info("openalex alignment rejected by title mismatch for paper %s", paper.id)
+        return False
+    return apply_openalex_meta(paper, meta)
+
+
+async def align_missing_papers(
+    session: AsyncSession,
+    *,
+    client: OpenAlexClient | None = None,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """批量对齐（CLI 全库回填用）：逐篇 commit，单篇失败不拖垮整批。"""
+    stmt = select(Paper).order_by(Paper.created_at)
+    if limit:
+        stmt = stmt.limit(limit)
+    stats = {"scanned": 0, "aligned": 0, "failed": 0}
+    for paper in (await session.execute(stmt)).scalars():
+        if openalex_id_of(paper):
+            continue
+        stats["scanned"] += 1
+        try:
+            if await align_paper(session, paper, client=client):
+                await session.commit()
+                stats["aligned"] += 1
+        except Exception:  # noqa: BLE001 — 单篇尽力而为
+            logger.warning("openalex alignment failed for paper %s", paper.id, exc_info=True)
+            await session.rollback()
+            stats["failed"] += 1
+    return stats

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -250,6 +250,50 @@ async def enrich_paper(
             logger.warning("enrich affiliations failed for paper %s", paper_id, exc_info=True)
             paper = await _rollback_and_reload()
 
+    # 引文意图（#639，增量钩子）：全文就位后建引文边并批量分类意图。非独立进度
+    # 阶段（STAGES 不变）、best-effort；无全文/无文献表时零输出——bibtex 导入等
+    # golden 链路因此逐字节不受影响。
+    try:
+        from app.core.llm.router import get_llm_router
+        from app.services.citation_graph import (
+            classify_citation_intents,
+            ensure_citation_edges,
+        )
+
+        if await ensure_citation_edges(session, paper):
+            await session.commit()
+        if await classify_citation_intents(
+            session,
+            paper,
+            get_llm_router(),
+            user_id=user_id,
+            project_id=project_id,
+            library_id=target_id,
+        ):
+            await session.commit()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("enrich citation intents failed for paper %s", paper_id, exc_info=True)
+        paper = await _rollback_and_reload()
+
+    # OpenAlex 对齐（#639，增量钩子）：缺 OpenAlex id 的记录按 DOI/arXiv 精确、
+    # 标题+年份模糊补 id 并回填空元数据。这是真实出网调用，受设置开关控制
+    # （测试套件默认关，见 core/config.py）；best-effort，不发进度事件。
+    from app.core.config import get_settings
+
+    if get_settings().openalex_align_on_enrich:
+        try:
+            from app.services.openalex_align import align_paper
+
+            if await align_paper(session, paper):
+                await session.commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning("enrich openalex alignment failed for %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
+
     # ---- embed ----
     await emit("embed", "running")
     if await has_current_paper_vector(session, paper):

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -18,6 +18,8 @@ os.environ["POLARIS_INVITE_CODE"] = "test-invite"
 os.environ["POLARIS_ENCRYPTION_KEY"] = ""
 os.environ["POLARIS_DATA_DIR"] = f"{_TMPDIR}/data"  # PDF/全文落盘目录（M2）
 os.environ["POLARIS_LLM_FAKE_FALLBACK"] = "1"  # 测试套件依赖确定性 fake provider
+# 补全钩子里的 OpenAlex 对齐是真实出网调用，离线测试一律关（专测用例自行开）
+os.environ["POLARIS_OPENALEX_ALIGN_ON_ENRICH"] = "0"
 
 from app.core.db import Base, dispose_engine, get_engine  # noqa: E402
 from app.core.events import get_event_bus  # noqa: E402

--- a/src/backend/tests/test_citation_intent.py
+++ b/src/backend/tests/test_citation_intent.py
@@ -1,0 +1,447 @@
+"""引文意图分类 + OpenAlex 对齐（#639）：解析/分类确定性、对齐匹配规则、增量钩子。"""
+
+import uuid
+
+import fakeredis.aioredis
+import httpx
+import pytest_asyncio
+import respx
+from sqlalchemy import select
+
+from app.core.config import get_settings
+from app.core.db import get_sessionmaker
+from app.core.llm.router import get_llm_router
+from app.models.paper import Paper
+from app.models.paper_citation import PaperCitation
+from app.services import paper_enrich
+from app.services.citation_graph import (
+    classify_citation_intents,
+    ensure_citation_edges,
+    parse_references,
+)
+from app.services.literature import reset_clients, set_clients
+from app.services.literature.openalex import OpenAlexClient
+from app.services.openalex_align import align_paper, openalex_id_of
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+# 五种上下文句各触发 fake provider 的一条确定性规则（core/llm/fake.py 对齐）：
+# [1] 无关键词 → background；[2] we follow → method；[3] compared → comparison；
+# [4] consistent with → support；[5] however/unlike → contrast
+FULL_TEXT = """Deep Agent Survey
+
+Introduction
+
+Early systems established the paradigm of tool-augmented reasoning [1].
+We follow the planning method of [2] to build our agent loop.
+Our results are compared against the strong baseline of [3].
+Our findings are consistent with the observations reported in [4].
+However, unlike the claims made in [5], we find scaling alone is insufficient.
+
+References
+
+[1] Alice Zhang. Foundations of Tool-Augmented Reasoning Systems. Journal of AI, 2020.
+[2] Bob Li. Planning With Language Models For Agent Tasks. NeurIPS, 2021.
+[3] Carol Wei. A Strong Baseline For Agent Benchmarks. ICML, 2022.
+[4] Dan Wu. Observations On Agent Generalization Behavior. 2023.
+[5] Eve Lin. Scaling Is All You Need For Agents. 2024.
+"""
+
+EXPECTED_INTENTS = {
+    1: "background",
+    2: "method",
+    3: "comparison",
+    4: "support",
+    5: "contrast",
+}
+
+
+async def _noop_emit(stage, status, detail=None):  # noqa: ARG001
+    return None
+
+
+def _write_fulltext(tmp_path, text=FULL_TEXT):
+    path = tmp_path / f"{uuid.uuid4().hex}.txt"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+@pytest_asyncio.fixture
+async def oa_redis():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    yield redis
+    await redis.aclose()
+
+
+def _work(openalex_id, title, *, year=2024, abstract_words=None, venue=None):
+    """构造 OpenAlex work 响应（_simplify 的输入形态）。"""
+    inverted = (
+        {w: [i] for i, w in enumerate(abstract_words)} if abstract_words else None
+    )
+    return {
+        "id": openalex_id,
+        "title": title,
+        "publication_year": year,
+        "publication_date": f"{year}-01-01",
+        "abstract_inverted_index": inverted,
+        "doi": "https://doi.org/10.9999/aligned",
+        "cited_by_count": 42,
+        "primary_location": {
+            "landing_page_url": "https://example.org/paper",
+            "source": {"id": "S1", "display_name": venue or "Test Venue", "issn_l": None},
+        },
+        "authorships": [],
+    }
+
+
+# ---- 1. 参考文献解析（确定性，无 LLM） ----
+
+
+def test_parse_references_numbered_with_contexts():
+    refs = parse_references(FULL_TEXT)
+    assert [r.index for r in refs] == [1, 2, 3, 4, 5]
+    assert refs[0].raw.startswith("Alice Zhang.")
+    # 上下文句按编号回挂
+    assert "tool-augmented reasoning [1]" in refs[0].context
+    assert "We follow the planning method" in refs[1].context
+    assert refs[4].context.startswith("However, unlike")
+
+
+def test_parse_references_unnumbered_falls_back_without_contexts():
+    text = (
+        "Body text citing prior work in prose form.\n\n"
+        "References\n\n"
+        "Alice Zhang. Foundations of Tool-Augmented Reasoning Systems. 2020.\n"
+        "Bob Li. Planning With Language Models For Agent Tasks. 2021.\n"
+    )
+    refs = parse_references(text)
+    assert [r.index for r in refs] == [1, 2]
+    assert all(r.context is None for r in refs)  # 对不上号 → 全部走降级路径
+
+
+def test_parse_references_absent_section_yields_nothing():
+    assert parse_references("just a body, no reference section at all.") == []
+
+
+# ---- 2. 建边 + 意图分类（fake provider 确定性） ----
+
+
+async def test_edges_built_and_intents_classified_deterministically(client, tmp_path):
+    token = await register_and_login(client, email="cite@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="cite-proj")
+
+    async with get_sessionmaker()() as session:
+        # 池内先放一篇标题与 [2] 条目相同的论文 → 应完成池内对齐
+        cited = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Planning With Language Models For Agent Tasks",
+        )
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deep Agent Survey",
+            abstract="A survey of agent systems.",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        created = await ensure_citation_edges(session, paper)
+        assert created == 5
+        # 幂等：已建过则跳过，不重复灌边
+        assert await ensure_citation_edges(session, paper) == 0
+        classified = await classify_citation_intents(session, paper, get_llm_router())
+        assert classified == 5
+        await session.commit()
+
+        rows = (
+            (
+                await session.execute(
+                    select(PaperCitation)
+                    .where(PaperCitation.citing_paper_id == paper.id)
+                    .order_by(PaperCitation.ref_index)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {r.ref_index: r.intent for r in rows} == EXPECTED_INTENTS
+        assert all(r.confidence is not None for r in rows)
+        by_index = {r.ref_index: r for r in rows}
+        assert by_index[2].cited_paper_id == cited.id  # 池内对齐命中
+        assert by_index[1].cited_paper_id is None
+
+
+# ---- 3. 增量钩子：enrich_paper 顺带建边分类；对齐开关默认关 ----
+
+
+async def test_enrich_hook_builds_citation_edges(client, tmp_path):
+    token = await register_and_login(client, email="hook@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="hook-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deep Agent Survey",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    with respx.mock(assert_all_called=False) as router:
+        oa_route = router.get(url__regex=r"https://api\.openalex\.org/.*").mock(
+            return_value=httpx.Response(404)
+        )
+        async with get_sessionmaker()() as session:
+            paper = await session.get(Paper, paper_id)
+            await paper_enrich.enrich_paper(
+                session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+            )
+    # 对齐开关在测试环境默认关（conftest 置 0）：不许有任何出网调用
+    assert oa_route.call_count == 0
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(PaperCitation).where(PaperCitation.citing_paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 5
+    assert {r.ref_index: r.intent for r in rows} == EXPECTED_INTENTS
+
+
+async def test_enrich_hook_aligns_openalex_when_enabled(
+    client, tmp_path, monkeypatch, oa_redis
+):
+    token = await register_and_login(client, email="hookalign@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="hookalign-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Aligned By Enrich Hook Paper",
+            doi="10.5555/hook",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    monkeypatch.setattr(get_settings(), "openalex_align_on_enrich", True)
+    set_clients(openalex=OpenAlexClient(redis=oa_redis, mailto="t@example.org"))
+    try:
+        with respx.mock(assert_all_called=False) as router:
+            router.get(url__regex=r"https://api\.openalex\.org/works/doi:.*").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=_work(
+                        "https://openalex.org/W777", "Aligned By Enrich Hook Paper"
+                    ),
+                )
+            )
+            async with get_sessionmaker()() as session:
+                paper = await session.get(Paper, paper_id)
+                await paper_enrich.enrich_paper(
+                    session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+                )
+    finally:
+        reset_clients()
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        assert openalex_id_of(paper) == "W777"
+
+
+# ---- 4. OpenAlex 对齐匹配规则（mock 响应） ----
+
+
+async def test_align_by_doi_backfills_only_empty_fields(client, oa_redis):
+    token = await register_and_login(client, email="align@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="align-proj")
+    oa_client = OpenAlexClient(redis=oa_redis, mailto="t@example.org")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Aligned Paper About Agents",
+            doi="10.5555/aligned",
+            venue="Original Venue",  # 已有值不许被覆盖
+        )
+        await session.commit()
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(url__regex=r"https://api\.openalex\.org/works/doi:.*").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=_work(
+                        "https://openalex.org/W123",
+                        "Aligned Paper About Agents",
+                        abstract_words=["Backfilled", "abstract", "text."],
+                        venue="OpenAlex Venue",
+                    ),
+                )
+            )
+            assert await align_paper(session, paper, client=oa_client) is True
+        await session.commit()
+        await session.refresh(paper)
+        assert openalex_id_of(paper) == "W123"
+        assert paper.abstract == "Backfilled abstract text."  # 空字段回填
+        assert paper.venue == "Original Venue"  # 已有值保持不动
+        # 幂等：已有 id 不再出网
+        assert await align_paper(session, paper, client=oa_client) is False
+
+
+async def test_align_rejects_doi_hit_with_mismatched_title(client, oa_redis):
+    token = await register_and_login(client, email="align2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="align2-proj")
+    oa_client = OpenAlexClient(redis=oa_redis, mailto="t@example.org")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="A Completely Different Subject Entirely",
+            doi="10.5555/wrong",
+        )
+        await session.commit()
+        with respx.mock(assert_all_called=False) as router:
+            router.get(url__regex=r"https://api\.openalex\.org/works/doi:.*").mock(
+                return_value=httpx.Response(
+                    200, json=_work("https://openalex.org/W999", "An Unrelated Paper Title")
+                )
+            )
+            assert await align_paper(session, paper, client=oa_client) is False
+        assert openalex_id_of(paper) is None
+
+
+async def test_align_by_title_year_fuzzy_match(client, oa_redis):
+    token = await register_and_login(client, email="align3@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="align3-proj")
+    oa_client = OpenAlexClient(redis=oa_redis, mailto="t@example.org")
+
+    search_payload = {
+        "results": [
+            _work("https://openalex.org/W1", "Some Other Work On Agents", year=2023),
+            # 标题只差标点大小写、年份差 1（预印本 vs 正式发表）→ 应命中
+            _work("https://openalex.org/W2", "Fuzzy matched agent paper:  a study", year=2023),
+        ]
+    }
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Fuzzy Matched Agent Paper: A Study",
+            year=2022,
+        )
+        await session.commit()
+        with respx.mock(assert_all_called=False) as router:
+            router.get(url__regex=r"https://api\.openalex\.org/works\?.*").mock(
+                return_value=httpx.Response(200, json=search_payload)
+            )
+            assert await align_paper(session, paper, client=oa_client) is True
+        await session.commit()
+        await session.refresh(paper)
+        assert openalex_id_of(paper) == "W2"
+
+
+async def test_align_by_title_rejects_wrong_year(client, oa_redis):
+    token = await register_and_login(client, email="align4@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="align4-proj")
+    oa_client = OpenAlexClient(redis=oa_redis, mailto="t@example.org")
+
+    search_payload = {
+        "results": [_work("https://openalex.org/W3", "Year Gated Agent Paper Title", year=2018)]
+    }
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Year Gated Agent Paper Title",
+            year=2024,  # 与候选差 6 年 → 拒绝
+        )
+        await session.commit()
+        with respx.mock(assert_all_called=False) as router:
+            router.get(url__regex=r"https://api\.openalex\.org/works\?.*").mock(
+                return_value=httpx.Response(200, json=search_payload)
+            )
+            assert await align_paper(session, paper, client=oa_client) is False
+        assert openalex_id_of(paper) is None
+
+
+# ---- 5. 详情端点：按意图分组 ----
+
+
+async def test_citations_endpoint_groups_by_intent(client, tmp_path):
+    token = await register_and_login(client, email="group@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="group-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deep Agent Survey",
+            abstract="A survey.",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        await ensure_citation_edges(session, paper)
+        await classify_citation_intents(session, paper, get_llm_router())
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.get(f"/api/papers/{paper_id}/citations", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 5
+    # 分组顺序 = CITATION_INTENTS 声明序；每组恰好一条（fixture 各触发一档）
+    assert [g["intent"] for g in body["groups"]] == [
+        "background",
+        "method",
+        "comparison",
+        "support",
+        "contrast",
+    ]
+    method_item = body["groups"][1]["items"][0]
+    assert method_item["ref_index"] == 2
+    assert "Planning With Language Models" in method_item["cited_ref_raw"]
+    assert "We follow the planning method" in method_item["context"]
+
+    # 未登录不可读
+    anon = await client.get(f"/api/papers/{paper_id}/citations")
+    assert anon.status_code == 401
+
+
+async def test_citations_endpoint_unclassified_group_last(client, tmp_path):
+    token = await register_and_login(client, email="group2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="group2-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deep Agent Survey",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        await ensure_citation_edges(session, paper)  # 只建边不分类 → 全部未分类
+        await session.commit()
+        paper_id = paper.id
+
+    resp = await client.get(f"/api/papers/{paper_id}/citations", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 5
+    assert [g["intent"] for g in body["groups"]] == [None]
+    assert len(body["groups"][0]["items"]) == 5

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
+HEAD_REVISION = "57543f6328a1"  # Paper citation edges (#639)
+HYPOTHESIS_TREE_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
 MEMBERS_DROP_REVISION = "b0dd1709e2a1"  # Drop project_members (#625)
 LLM_MERGE_REVISION = "dd572a7f063c"  # Merge LLM config tracks: drop users.llm_self_managed (#621)
 LIBRARY_STATUS_DROP_REVISION = "c3c404803ca4"  # Drop library status/review_note (P1 de-lab)
@@ -145,6 +146,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "paper_content_version_vectors",
                     "paper_content_chunk_vectors",
                     "paper_evidence_anchors",
+                    "paper_citations",
                     "download_api_keys",
                     "download_batches",
                     "download_batch_items",
@@ -534,7 +536,30 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "evidence_balance",
     } <= columns["interdisciplinary_research_profile_versions"]
 
-    # 先退掉假设树建表（#637）：整表消失，其余不受影响。
+    # 本分支新增：引文边表（#639）
+    assert "paper_citations" in columns["_tables"]
+    assert {
+        "citing_paper_id",
+        "cited_paper_id",
+        "ref_index",
+        "cited_ref_raw",
+        "context",
+        "intent",
+        "confidence",
+    } <= columns["paper_citations"]
+    assert {
+        "ix_paper_citations_citing_paper_id",
+        "ix_paper_citations_cited_paper_id",
+    } <= _index_names(db_path, "paper_citations")
+
+    # 先退掉引文边表（#639）：假设树表不受影响。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == HYPOTHESIS_TREE_REVISION
+    assert "paper_citations" not in columns["_tables"]
+    assert "hypothesis_nodes" in columns["_tables"]
+
+    # 再退掉假设树建表（#637）：整表消失，其余不受影响。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == MEMBERS_DROP_REVISION
@@ -902,6 +927,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "paper_citations" in columns["_tables"]  # 引文边表回归（#639）
     assert "effort" in columns["model_routes"]
     assert "chat_bot_configs" in columns["_tables"]
     # 索引回归；个人标签表、回收站列与两张备份表也仍在

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -32,6 +32,7 @@ import {
   PaperMyMetaRow,
   PaperMyTagChips,
   PaperMyTagsRow,
+  PaperCitationsSection,
   PaperNotesSection,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
@@ -452,6 +453,9 @@ function PaperDetailPane({
 
       {/* —— 我的笔记（个人维度，只读浏览也能写） —— */}
       <PaperNotesSection paperId={paper.id} noteCount={paper.note_count ?? 0} invalidateKeys={noteKeys} />
+
+      {/* —— 引文（按意图分组，#639） —— */}
+      <PaperCitationsSection paperId={paper.id} />
 
       {/* —— 重要图片画廊（只读：不给提取/重新提取入口，那是管理员操作） —— */}
       <FiguresSection paper={paper} readOnly defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)} />

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -4,7 +4,7 @@ import { Icon } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
-import { api, type MyMeta, type PaperConceptRef, type ReadingStatus } from '../../lib/api';
+import { api, type CitationIntent, type MyMeta, type PaperConceptRef, type ReadingStatus } from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import { NoteCard } from '../reading/NotesPanel';
 import { READING_STATUS } from '../reading/shared';
@@ -474,3 +474,111 @@ export function WikiHeaderActions({
     </div>
   );
 }
+
+/* ---------------- 引文（按意图分组，#639） ---------------- */
+
+/** 意图五档的大白话名字（模块级常量只存 zh/en，渲染处再 tr()）。 */
+const CITATION_INTENT_LABELS: Record<CitationIntent, { zh: string; en: string }> = {
+  background: { zh: '背景铺垫', en: 'Background' },
+  method: { zh: '方法沿用', en: 'Method' },
+  comparison: { zh: '实验对比', en: 'Comparison' },
+  support: { zh: '结论支持', en: 'Support' },
+  contrast: { zh: '观点相左', en: 'Contrast' },
+};
+
+/**
+ * 论文详情的引文分组列表（简单列表；引文网络等深度 UI 归 D5）。
+ * 折叠卡：展开才拉数据——绝大多数浏览不看引文，不值得每次详情都多一个请求。
+ */
+export function PaperCitationsSection({ paperId }: { paperId: string }) {
+  const [open, setOpen] = useState(false);
+  const citationsQuery = useQuery({
+    queryKey: ['paper-citations', paperId],
+    queryFn: () => api.getPaperCitations(paperId),
+    enabled: open,
+    retry: false,
+  });
+  const groups = citationsQuery.data?.groups ?? [];
+  const total = citationsQuery.data?.total;
+
+  return (
+    <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
+      <div
+        className="row"
+        onClick={() => setOpen((o) => !o)}
+        style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+      >
+        <span className="row gap6" style={{ fontSize: 12.5, fontWeight: 650 }}>
+          <Icon name="link" size={12} style={{ color: 'var(--text-3)' }} />
+          {tr('引文（按意图）', 'Citations by intent')}
+          {typeof total === 'number' && (
+            <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 400 }}>
+              · {total}
+            </span>
+          )}
+        </span>
+        <Icon
+          name="chevDown"
+          size={13}
+          style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+        />
+      </div>
+      {open && (
+        <div style={{ padding: '0 16px 14px' }}>
+          {citationsQuery.isLoading ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr('加载引文…', 'Loading citations…')}
+            </p>
+          ) : citationsQuery.isError ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr('引文加载失败。', 'Failed to load citations.')}
+            </p>
+          ) : groups.length === 0 ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr(
+                '还没有解析出引文——需要先有 PDF 全文（含参考文献表）。',
+                'No citations parsed yet — the paper needs a full text with a reference list.',
+              )}
+            </p>
+          ) : (
+            groups.map((group) => {
+              const label = group.intent ? CITATION_INTENT_LABELS[group.intent] : null;
+              return (
+                <div key={group.intent ?? 'unclassified'} style={{ marginBottom: 10 }}>
+                  <div className="row gap6" style={{ margin: '8px 0 6px' }}>
+                    <span
+                      className="pill sm"
+                      style={{ background: group.intent ? 'var(--accent-soft)' : 'var(--surface-3)', color: group.intent ? 'var(--accent-text)' : 'var(--text-3)' }}
+                    >
+                      {label ? tr(label.zh, label.en) : tr('未分类', 'Unclassified')}
+                    </span>
+                    <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                      {group.items.length}
+                    </span>
+                  </div>
+                  {group.items.map((item) => (
+                    <div key={item.id} style={{ padding: '5px 0', borderBottom: '0.5px solid var(--border)' }}>
+                      <div style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--text-2)', overflowWrap: 'break-word' }}>
+                        <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', marginRight: 6 }}>
+                          [{item.ref_index}]
+                        </span>
+                        {item.cited_paper_title ?? item.cited_ref_raw}
+                      </div>
+                      {item.context && (
+                        <div style={{ fontSize: 11, lineHeight: 1.55, color: 'var(--text-4)', marginTop: 2, overflowWrap: 'break-word' }}>
+                          {tr('引用处：', 'Cited as: ')}
+                          {item.context}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -48,7 +48,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
-import { PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
+import { PaperCitationsSection, PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperBatchProgressModal } from '../library/PaperBatchProgressModal';
@@ -1184,6 +1184,9 @@ function PaperDetailPane({
         noteCount={paper.note_count ?? 0}
         invalidateKeys={[['papers'], ['paper', paper.id]]}
       />
+
+      {/* —— 引文（按意图分组，#639）：展开才拉数据的简单列表 —— */}
+      <PaperCitationsSection paperId={paper.id} />
 
       {/* —— 重要图片画廊（有图显示；正文已嵌图时默认折叠，避免重复视觉） —— */}
       <FiguresSection paper={paper} defaultCollapsed={hasEmbeddedFigures(paper.wiki_content, figures)} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -620,6 +620,7 @@ export const LLM_STAGES = [
   'experiment',
   'writing',
   'review',
+  'citation_intent',
 ] as const;
 
 export interface LlmProviderRead {
@@ -1629,6 +1630,38 @@ export interface PaperIndexStatus {
   has_fulltext: boolean;
   /** fulltext=按 PDF 全文切 | abstract=无全文时的标题+摘要兜底块 | null=还没分段 */
   chunk_source: 'fulltext' | 'abstract' | null;
+}
+
+// ============================================================
+// 引文意图（#639）：详情页按意图分组的引文列表
+// ============================================================
+
+export type CitationIntent = 'background' | 'method' | 'comparison' | 'support' | 'contrast';
+
+export interface PaperCitationItem {
+  id: string;
+  /** 参考文献序号（1 起） */
+  ref_index: number;
+  /** 参考文献条目原文（被引论文不在库里时它就是全部信息） */
+  cited_ref_raw: string;
+  /** 正文引用上下文句；解析不到为 null */
+  context: string | null;
+  intent: CitationIntent | null;
+  confidence: number | null;
+  /** 被引论文恰好也在内容池时给 id/标题（可跳转） */
+  cited_paper_id: string | null;
+  cited_paper_title: string | null;
+}
+
+export interface PaperCitationGroup {
+  /** null = 还没分类那组（殿后） */
+  intent: CitationIntent | null;
+  items: PaperCitationItem[];
+}
+
+export interface PaperCitations {
+  total: number;
+  groups: PaperCitationGroup[];
 }
 
 // ============================================================
@@ -3606,6 +3639,10 @@ export const api = {
   /** 这篇论文的两种向量各自建没建、何时建的、用的哪个模型（只读，权限同看论文）。 */
   getPaperIndexStatus(id: string): Promise<PaperIndexStatus> {
     return request<PaperIndexStatus>(`/papers/${id}/index-status`);
+  },
+  /** 按意图分组的引文列表（#639）；没建过边时 total=0、groups=[] */
+  getPaperCitations(id: string): Promise<PaperCitations> {
+    return request<PaperCitations>(`/papers/${id}/citations`);
   },
   /** 手动重建这篇论文的向量（有就覆盖，没有就新建）；同步返回重建后的状态。需大模型使用权限。 */
   rebuildPaperIndex(

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -27,4 +27,5 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   experiment: { zh: '实验', en: 'Experiments' },
   writing: { zh: '论文撰写', en: 'Paper writing' },
   review: { zh: '论文评审', en: 'Paper review' },
+  citation_intent: { zh: '引文意图分类', en: 'Citation intent classification' },
 };


### PR DESCRIPTION
Closes #639. Part of #635 (P2 wave 1, item E2); design report §10 layer ③.

Association-layer groundwork: a citation graph with intent labels, and OpenAlex identity alignment with metadata backfill.

## Citation graph + intent
- new `paper_citations` (migration `57543f6328a1` on `7e2b9f4c1a86`): citing/cited FKs (cited nullable + raw entry text), ref_index with a per-paper uniqueness, context sentence, intent, confidence. No library column — papers are a global content pool, edges follow the paper like chunks/wikis do
- deterministic reference parsing from the extracted full text (References-section location, `[n]` entry splitting, in-text marker back-linking for context sentences; unnumbered bibliographies degrade to entry-only classification)
- new `citation_intent` LLM stage (short-call tier; frontend stage tables kept in lockstep): background|method|comparison|support|contrast + confidence, batched 20/call; the fake provider classifies deterministically by keyword rules
- pool-internal edge resolution and idempotent re-runs

## OpenAlex alignment
- DOI exact → arXiv exact → normalized-title+year fuzzy (similarity ≥0.92, ±1 year), with title cross-checks even on exact hits; the id lands in the existing `external_ids` JSON, and only empty metadata fields are backfilled
- the client gains a token-bucket rate limit (cache hits don't consume tokens)
- runs incrementally as best-effort enrich steps plus a backfill CLI; the enrich-time alignment sits behind `POLARIS_OPENALEX_ALIGN_ON_ENRICH` (default on, off in tests) because it is a real network call and many existing tests drive enrich unmocked

## Surface
- `GET /papers/{id}/citations` returns intent-grouped citations (fixed group order, unclassified last); a collapsed section on both paper-detail panels fetches on expand. `PaperDetail` itself is untouched — the goldens record that schema
- goldens byte-identical (no redis in the golden chain → enrich never starts; bibtex papers have no full text; alignment gated off in tests)

Verification: full suite 1468 collected = 1465 passed + the 3 pre-existing #581 failures (clean-main baseline 1456 + exactly the 12 new tests); single alembic head verified; frontend build + vitest green.