### PR TITLE
feat: discovery voyage kind with tree-search planning

### DIFF
--- a/src/backend/app/agents/voyage/__init__.py
+++ b/src/backend/app/agents/voyage/__init__.py
@@ -6,6 +6,7 @@
 
 from app.agents.voyage import (
     actions_daily,  # noqa: F401  注册 daily.*（每日新论文抓取）动作
+    actions_discovery,  # noqa: F401  注册 hypothesis.* / discovery.summarize 树搜索动作
     actions_experiment,  # noqa: F401  注册 experiment.* 动作
     actions_ideas,  # noqa: F401  注册 forge.* / review.pair 等辩论动作
     actions_present,  # noqa: F401  注册 present.*（论文分享 PPT）动作

--- a/src/backend/app/agents/voyage/actions_discovery.py
+++ b/src/backend/app/agents/voyage/actions_discovery.py
@@ -1,0 +1,506 @@
+"""discovery 任务的树搜索动作（#642，设计报告 §8.2，P2 D2）。
+
+四个动作围绕假设树（services/hypothesis_tree.py，#640）展开：
+
+- ``hypothesis.seed``：树空时按研究方向生成根假设入树；
+- ``hypothesis.expand``：对当前最优 open 节点生成 2-3 个子假设、父节点转 expanded；
+- ``hypothesis.prune``：LLM 判某分支不值得继续时写 score 并级联剪枝（留痕不删）；
+- ``discovery.summarize``：把整棵树（含被剪分支）汇总成 run 产物后收束。
+
+**计划不是线性清单**：初始计划只有播种一步，之后每一轮由动作按树状态给出
+plan_signal（expand / summarize），经 plan_edit.discovery_signal_edits 确定性
+分支表追加下一个节点——树才是真源，决策与所选节点 id 记入
+checkpoint["discovery"]，恢复语义见各动作的重放注释。
+
+**每节点记账**：seed/expand 的 LLM token 用量按节点 id 记进
+checkpoint["discovery"]["node_usage"]（只记不限；不动 hypothesis_nodes 表结构，
+避免与并行迁移抢 alembic 链——树可视化要用时 D5 再决定是否上迁移）。
+"""
+
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+
+from app.agents.voyage.actions import ActionContext, register
+from app.core.db import get_sessionmaker
+from app.core.llm.base import Message
+from app.models.hypothesis import HypothesisNode
+from app.models.voyage import VoyageRun
+from app.services import hypothesis_tree as tree_service
+
+# LLM 环节：结构化 JSON 生成，走中档耐心（core/llm/router.py 的 _MEDIUM_CALL_STAGES）
+_STAGE = "discovery_plan"
+
+_MAX_JSON_ATTEMPTS = 3
+# 每轮扩展的子假设数量区间：LLM 多给截断、少给（<2）视为非法输出重试
+_MIN_CHILDREN, _MAX_CHILDREN = 2, 3
+
+SEED_SYSTEM_PROMPT = """\
+POLARIS_DISCOVERY_SEED
+你是 Navigator，负责为一个研究方向提出树搜索的根假设：一条值得展开验证的、
+可检验的核心研究假设。只输出一个 JSON 对象，不要输出任何其他文字：
+{"statement": "假设陈述（一句话，可检验）", "rationale": "一句话依据", \
+"score": 0 到 1 的先验看好程度}
+"""
+
+EXPAND_SYSTEM_PROMPT = """\
+POLARIS_DISCOVERY_EXPAND
+你是 Navigator，负责在假设树上扩展一个节点：把父假设细化/分叉成 2-3 个更具体、
+彼此不同的子假设。若你判断树上某个分支已明显不值得继续，可在 prune 里给出
+（不确定时给空数组）。只输出一个 JSON 对象，不要输出任何其他文字：
+{"children": [{"statement": "子假设陈述", "rationale": "一句话依据", \
+"score": 0 到 1 的看好程度}],
+ "prune": [{"node_id": "要剪掉的节点 id", "score": 0 到 1, "reason": "为什么放弃"}]}
+"""
+
+SUMMARY_SYSTEM_PROMPT = """\
+POLARIS_DISCOVERY_SUMMARY
+你是 Navigator，负责总结一次假设树探索：概述探索了哪些假设、哪些分支被放弃
+及原因、目前最有希望的方向。直接输出总结文本（markdown，不要代码块围栏）。
+"""
+
+
+# ---- checkpoint["discovery"] 工作区 ----
+
+
+def _state(ctx: ActionContext) -> dict[str, Any]:
+    """checkpoint 里的 discovery 工作区（决策留痕 + 轮次账本 + 每节点用量）。
+
+    engine 在动作结束后整体回写 run.checkpoint，这里就地改嵌套 dict 即可。
+    """
+    state = ctx.checkpoint.get("discovery")
+    if not isinstance(state, dict):
+        state = {}
+        ctx.checkpoint["discovery"] = state
+    state.setdefault("rounds", {})
+    state.setdefault("decisions", [])
+    state.setdefault("node_usage", {})
+    return state
+
+
+def _params_of(ctx: ActionContext) -> dict[str, Any]:
+    params = ctx.checkpoint.get("params") if isinstance(ctx.checkpoint, dict) else None
+    return params if isinstance(params, dict) else {}
+
+
+def _max_expansions(ctx: ActionContext) -> int:
+    try:
+        return max(0, int(_params_of(ctx).get("max_expansions", 3)))
+    except (TypeError, ValueError):
+        return 3
+
+
+def _direction(ctx: ActionContext) -> str:
+    return str(_params_of(ctx).get("direction") or ctx.run.goal or "").strip()
+
+
+def _record_decision(
+    ctx: ActionContext,
+    *,
+    action: str,
+    decision: str,
+    node_id: str | None,
+    why: str,
+    round_no: int | None = None,
+) -> None:
+    """每轮决策留痕（哪个节点、为什么）：SSE 不持久，恢复与审计都要靠它。"""
+    _state(ctx)["decisions"].append(
+        {
+            "action": action,
+            "round": round_no,
+            "decision": decision,
+            "node_id": node_id,
+            "why": why,
+        }
+    )
+
+
+def _account_node_usage(ctx: ActionContext, node_id: str, usage: dict[str, Any]) -> None:
+    """把一次 LLM 调用的 token 记到节点头上（只记不限）。"""
+    ledger = _state(ctx)["node_usage"]
+    entry = dict(ledger.get(node_id) or {"prompt_tokens": 0, "completion_tokens": 0})
+    entry["prompt_tokens"] = int(entry.get("prompt_tokens", 0)) + int(
+        usage.get("prompt_tokens", 0) or 0
+    )
+    entry["completion_tokens"] = int(entry.get("completion_tokens", 0)) + int(
+        usage.get("completion_tokens", 0) or 0
+    )
+    ledger[node_id] = entry
+
+
+# ---- LLM JSON 调用（带 usage 回传：每节点记账需要它，_complete_json 不返回） ----
+
+
+def _extract_json(content: str) -> Any:
+    start = content.find("{")
+    end = content.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON object found")
+    return json.loads(content[start : end + 1])
+
+
+async def _complete_json_with_usage(
+    ctx: ActionContext, *, system: str, user: str, validate
+) -> tuple[Any, dict[str, int]]:
+    """LLM JSON 请求：解析/校验失败重试；返回 (结果, 累计 usage)。
+
+    重试轮次的 token 也计入 usage——记账要如实反映这一步真实花了多少。
+    """
+    total = {"prompt_tokens": 0, "completion_tokens": 0}
+    last_error: Exception | None = None
+    for _attempt in range(_MAX_JSON_ATTEMPTS):
+        result = await ctx.llm.complete(
+            _STAGE,
+            [Message(role="system", content=system), Message(role="user", content=user)],
+            user_id=ctx.run.created_by,
+            project_id=ctx.run.project_id,
+            library_id=ctx.run.library_id,
+            voyage_id=ctx.run.id,
+        )
+        usage = result.usage or {}
+        total["prompt_tokens"] += int(usage.get("prompt_tokens", 0) or 0)
+        total["completion_tokens"] += int(usage.get("completion_tokens", 0) or 0)
+        try:
+            return validate(_extract_json(result.content)), total
+        except (ValueError, TypeError, KeyError, json.JSONDecodeError) as e:
+            last_error = e
+    raise ValueError(f"LLM 连续输出非法 JSON：{last_error}")
+
+
+def _clamp_score(raw: Any) -> float | None:
+    try:
+        return min(1.0, max(0.0, float(raw)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_seed(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict) or not str(data.get("statement") or "").strip():
+        raise ValueError('seed 输出需含非空 "statement"')
+    return {
+        "statement": str(data["statement"]).strip(),
+        "score": _clamp_score(data.get("score")),
+    }
+
+
+def _validate_expand(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict) or not isinstance(data.get("children"), list):
+        raise ValueError('expand 输出需含 "children" 列表')
+    children = []
+    for raw in data["children"][:_MAX_CHILDREN]:
+        if not isinstance(raw, dict) or not str(raw.get("statement") or "").strip():
+            raise ValueError("child 需含非空 statement")
+        children.append(
+            {
+                "statement": str(raw["statement"]).strip(),
+                "score": _clamp_score(raw.get("score")),
+            }
+        )
+    if len(children) < _MIN_CHILDREN:
+        raise ValueError(f"expand 至少要给出 {_MIN_CHILDREN} 个子假设")
+    prune = []
+    for raw in data.get("prune") or []:
+        if isinstance(raw, dict) and raw.get("node_id"):
+            prune.append(
+                {
+                    "node_id": str(raw["node_id"]),
+                    "score": _clamp_score(raw.get("score")),
+                    "reason": str(raw.get("reason") or ""),
+                }
+            )
+    return {"children": children, "prune": prune}
+
+
+# ---- 树状态 → 下一步信号（决策的唯一出口，seed/expand 共用） ----
+
+
+async def _expanded_count(session, run_id) -> int:
+    return int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(HypothesisNode)
+                .where(HypothesisNode.run_id == run_id, HypothesisNode.status == "expanded")
+            )
+        ).scalar_one()
+    )
+
+
+async def _next_signal(session, ctx: ActionContext) -> tuple[dict[str, Any], str]:
+    """按「checkpoint 轮次账本 + 树状态」决定下一步，返回 (plan_signal, why)。
+
+    扩展数取 max(账本轮数, 树上 expanded 节点数)：正常路径两者一致；worker 在
+    「子节点已落库、checkpoint 尚未回写」的窗口被杀时账本会少一轮，树上的
+    expanded 计数把它补回来，保证重启后不多扩一轮（见 hypothesis_expand 的
+    重放注释）。
+    """
+    state = _state(ctx)
+    done = max(len(state["rounds"]), await _expanded_count(session, ctx.run.id))
+    limit = _max_expansions(ctx)
+    best = await tree_service.best_open_node(session, ctx.run.id)
+    if best is None:
+        why = "树上已无 open 节点，转入汇总"
+        return {"decision": "summarize", "reason": why}, why
+    if done >= limit:
+        why = f"扩展数已达上限（{done}/{limit}），转入汇总"
+        return {"decision": "summarize", "reason": why}, why
+    why = f"第 {done + 1}/{limit} 轮扩展：当前最优 open 节点 {best.id}（score={best.score}）"
+    return {"decision": "expand", "next_round": done + 1}, why
+
+
+async def _root_of(session, run_id) -> HypothesisNode | None:
+    return (
+        await session.execute(
+            select(HypothesisNode).where(
+                HypothesisNode.run_id == run_id, HypothesisNode.parent_id.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def _as_uuid(raw: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(raw))
+    except ValueError:
+        return uuid.UUID(int=0)  # 必然查不到 → 走「引用无效」跳过路径
+
+
+# ---- 动作 ----
+
+
+@register("hypothesis.seed")
+async def hypothesis_seed(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    """树空 → 按研究方向生成根假设。重放（断点恢复后重跑本步）时树已有根：
+    不再调 LLM、直接复用——单根不变量在服务层是硬约束，重复建根必炸。"""
+    direction = _direction(ctx)
+    if not direction:
+        raise ValueError("discovery 任务缺少研究方向（params.direction）")
+    usage: dict[str, int] = {}
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, ctx.run.id)
+        root = await _root_of(session, ctx.run.id)
+        if root is None:
+            seed, usage = await _complete_json_with_usage(
+                ctx,
+                system=SEED_SYSTEM_PROMPT,
+                user=f"研究方向：{direction}",
+                validate=_validate_seed,
+            )
+            root = await tree_service.create_node(
+                session,
+                run,
+                parent_id=None,
+                kind="hypothesis",
+                statement=seed["statement"],
+                score=seed["score"],
+            )
+            _account_node_usage(ctx, str(root.id), usage)
+            why = "树为空：按研究方向生成根假设"
+        else:
+            why = "断点重放：根假设已存在，复用（不重复调 LLM）"
+        await ctx.log(f"根假设：{root.statement[:120]}", level="success")
+        signal, signal_why = await _next_signal(session, ctx)
+    _record_decision(
+        ctx,
+        action="hypothesis.seed",
+        decision=str(signal["decision"]),
+        node_id=str(root.id),
+        why=f"{why}；{signal_why}",
+        round_no=0,
+    )
+    return {
+        "node_id": str(root.id),
+        "statement": root.statement,
+        "plan_signal": signal,
+        "usage": usage,
+    }
+
+
+async def _apply_prune(session, ctx: ActionContext, entry: dict[str, Any]) -> str | None:
+    """按 LLM 建议剪一个分支：写 score、级联转 pruned（服务层保证留痕不删）。
+
+    引用非法（跨 run / 不存在 / 已是终态）时跳过并留日志——剪枝建议只是建议，
+    不因为一条坏引用打死整个扩展步骤。返回被剪节点 id（跳过返回 None）。
+    """
+    node = await session.get(HypothesisNode, _as_uuid(entry["node_id"]))
+    if node is None or node.run_id != ctx.run.id:
+        await ctx.log(f"剪枝建议引用无效节点 {entry['node_id']}，跳过")
+        return None
+    if node.status in ("pruned", "validated", "refuted"):
+        return None
+    if entry.get("score") is not None:
+        await tree_service.set_score(session, node, entry["score"])
+    await tree_service.transition(session, node, "pruned")
+    _record_decision(
+        ctx,
+        action="hypothesis.prune",
+        decision="pruned",
+        node_id=str(node.id),
+        why=str(entry.get("reason") or "LLM 判定该分支不值得继续"),
+    )
+    await ctx.log(f"剪枝：{node.statement[:80]}（{entry.get('reason') or ''}）")
+    return str(node.id)
+
+
+@register("hypothesis.expand")
+async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    """对当前最优 open 节点扩展一轮：生成 2-3 个子假设、父节点转 expanded。
+
+    恢复语义（确定性重建 = checkpoint 轮次账本 + best_open_node）：
+    - 本轮已在账本里 → 纯重放，不再动树；
+    - 账本没有、但树上 expanded 数已覆盖本轮（worker 在子节点落库之后、
+      checkpoint 回写之前被杀）→ 补记账本、不重复扩；
+    - 否则正常扩展：目标节点取 best_open_node（score 降序、同分取先建的，
+      对同一棵树是确定性的，所以「杀在扩展之前」的重启会选中同一个节点）。
+    """
+    round_no = int(params.get("round") or 0)
+    state = _state(ctx)
+    usage: dict[str, int] = {}
+    children_ids: list[str] = []
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, ctx.run.id)
+        record = state["rounds"].get(str(round_no))
+        if isinstance(record, dict):
+            target_id = record.get("node_id")
+            why = f"断点重放：第 {round_no} 轮已在账本中，不再动树"
+        elif await _expanded_count(session, ctx.run.id) >= round_no:
+            # 子节点已落库但 checkpoint 没记上（杀在两次提交之间）：补记不重扩
+            target_id = None
+            state["rounds"][str(round_no)] = {"node_id": None, "replayed_from_tree": True}
+            why = f"断点重放：树上扩展数已覆盖第 {round_no} 轮，补记账本、不重复扩"
+        else:
+            target = await tree_service.best_open_node(session, ctx.run.id)
+            if target is None:
+                # 全被剪光等极端情况：本轮无事可做，交给信号转汇总
+                target_id = None
+                state["rounds"][str(round_no)] = {"node_id": None, "no_open": True}
+                why = f"第 {round_no} 轮无 open 节点可扩展"
+            else:
+                expansion, usage = await _complete_json_with_usage(
+                    ctx,
+                    system=EXPAND_SYSTEM_PROMPT,
+                    user=(
+                        f"研究方向：{_direction(ctx)}\n"
+                        f"父假设：{target.statement}\n"
+                        f"父假设节点 id：{target.id}"
+                    ),
+                    validate=_validate_expand,
+                )
+                for child in expansion["children"]:
+                    node = await tree_service.create_node(
+                        session,
+                        run,
+                        parent_id=target.id,
+                        kind="hypothesis",
+                        statement=child["statement"],
+                        score=child["score"],
+                    )
+                    children_ids.append(str(node.id))
+                await tree_service.transition(session, target, "expanded")
+                _account_node_usage(ctx, str(target.id), usage)
+                for entry in expansion["prune"]:
+                    await _apply_prune(session, ctx, entry)
+                target_id = str(target.id)
+                state["rounds"][str(round_no)] = {
+                    "node_id": target_id,
+                    "children": children_ids,
+                }
+                why = f"第 {round_no} 轮：扩展最优 open 节点，生成 {len(children_ids)} 个子假设"
+                await ctx.log(
+                    f"扩展「{target.statement[:80]}」→ {len(children_ids)} 个子假设",
+                    level="success",
+                )
+        signal, signal_why = await _next_signal(session, ctx)
+    _record_decision(
+        ctx,
+        action="hypothesis.expand",
+        decision=str(signal["decision"]),
+        node_id=target_id,
+        why=f"{why}；{signal_why}",
+        round_no=round_no,
+    )
+    return {
+        "round": round_no,
+        "node_id": target_id,
+        "children": children_ids,
+        "plan_signal": signal,
+        "usage": usage,
+    }
+
+
+@register("hypothesis.prune")
+async def hypothesis_prune(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    """独立剪枝动作（计划编辑/后续 D3 可显式调度）：写 score + 级联剪枝。"""
+    node_id = str(params.get("node_id") or "")
+    if not node_id:
+        raise ValueError("hypothesis.prune 需要 params.node_id")
+    async with get_sessionmaker()() as session:
+        pruned = await _apply_prune(
+            session,
+            ctx,
+            {
+                "node_id": node_id,
+                "score": _clamp_score(params.get("score")),
+                "reason": str(params.get("reason") or ""),
+            },
+        )
+    return {"pruned": pruned, "usage": {}}
+
+
+@register("discovery.summarize")
+async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
+    """整树汇总为 run 产物：全部节点 + 状态 + 统计，被剪分支保留在案（§8.2
+    防择优汇报）。产物写进 checkpoint["artifacts"]，voyage 完成标准查它。"""
+    state = _state(ctx)
+    async with get_sessionmaker()() as session:
+        nodes = await tree_service.tree_for_run(session, ctx.run.id)
+    stats: dict[str, int] = {}
+    for n in nodes:
+        stats[n.status] = stats.get(n.status, 0) + 1
+    tree_lines = "\n".join(f"- [{n.status}] {n.statement}（score={n.score}）" for n in nodes)
+    result = await ctx.llm.complete(
+        _STAGE,
+        [
+            Message(role="system", content=SUMMARY_SYSTEM_PROMPT),
+            Message(
+                role="user",
+                content=f"研究方向：{_direction(ctx)}\n假设树：\n{tree_lines}",
+            ),
+        ],
+        user_id=ctx.run.created_by,
+        project_id=ctx.run.project_id,
+        library_id=ctx.run.library_id,
+        voyage_id=ctx.run.id,
+    )
+    usage = dict(result.usage or {})
+    artifact = {
+        "direction": _direction(ctx),
+        "summary": result.content,
+        "stats": stats,
+        "nodes": [
+            {
+                "id": str(n.id),
+                "parent_id": str(n.parent_id) if n.parent_id else None,
+                "kind": n.kind,
+                "statement": n.statement,
+                "status": n.status,
+                "score": n.score,
+                # 每节点 token 账本随产物归档（记账在 checkpoint，产物是快照）
+                "usage": state["node_usage"].get(str(n.id)),
+            }
+            for n in nodes
+        ],
+    }
+    artifacts = dict(ctx.checkpoint.get("artifacts") or {})
+    artifacts["discovery-summary.json"] = json.dumps(artifact, ensure_ascii=False)
+    ctx.checkpoint["artifacts"] = artifacts
+    _record_decision(
+        ctx,
+        action="discovery.summarize",
+        decision="summarized",
+        node_id=None,
+        why=f"汇总 {len(nodes)} 个节点（{stats}）",
+    )
+    return {"node_count": len(nodes), "stats": stats, "usage": usage}

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -386,6 +386,11 @@ def experiment_plan(run: VoyageRun) -> list[dict[str, Any]]:
 # voyage 级完成标准（docs/voyage-loop.md §5.4）：engine 在规划时写入 run.done_criteria。
 # experiment 防"过早宣告完成"：迭代必须有明确终止判定、报告必须已生成
 _DONE_CRITERIA_BY_KIND: dict[str, dict[str, Any]] = {
+    # discovery：汇总产物（全部节点+状态+统计）必须已落 checkpoint——树长了一半
+    # 没收尾不算完成；被剪分支也在产物里留痕（§8.2 防择优汇报）
+    "discovery": {
+        "checks": [{"kind": "artifact_exists", "key": "artifacts.discovery-summary.json"}]
+    },
     "experiment": {
         "checks": [
             # 至少有一轮真的跑出了主指标。原来只查「停止原因」+「报告已生成」，
@@ -522,6 +527,27 @@ def paper_review_plan(run: VoyageRun) -> list[dict[str, Any]]:
             "on_failure": "fail",
         }
         for title, action, acceptance in steps
+    ]
+
+
+
+def discovery_plan(run: VoyageRun) -> list[dict[str, Any]]:
+    """discovery 启动计划（#642，设计报告 §8.2，mode=loop）：**只有播种一步**。
+
+    树搜索不预排线性清单：seed/expand 每轮结束后按树状态（best_open_node +
+    checkpoint 轮次账本）给出 plan_signal，由 plan_edit.discovery_signal_edits
+    确定性追加下一步（继续扩展 / 汇总收尾）——计划是树探索过程的「已走轨迹」，
+    真源在 hypothesis_nodes。
+    """
+    return [
+        {
+            "title": "生成根假设",
+            "action": "hypothesis.seed",
+            "params": {},
+            "acceptance": "根假设已入树（断点重放时复用已有根）",
+            "checks": [{"kind": "no_error"}],
+            "requires_gate": None,
+        }
     ]
 
 
@@ -740,6 +766,8 @@ class Navigator:
             return paper_review_plan(run)
         if run.kind == "presentation":
             return presentation_plan(run)
+        if run.kind == "discovery":
+            return discovery_plan(run)
         system = PLAN_SYSTEM_PROMPT % {"actions": ", ".join(sorted(known_actions()))}
         workflows = skill_workflows(run.checkpoint or {})
         if workflows:

--- a/src/backend/app/agents/voyage/plan_edit.py
+++ b/src/backend/app/agents/voyage/plan_edit.py
@@ -199,6 +199,71 @@ def experiment_signal_edits(
     return None
 
 
+
+def discovery_expand_node(round_no: int) -> dict:
+    """一轮假设扩展节点（discovery，docs 设计报告 §8.2）。"""
+    return {
+        "title": f"第 {round_no} 轮扩展假设",
+        "action": "hypothesis.expand",
+        "params": {"round": round_no},
+        "acceptance": "最优 open 节点已扩展出子假设（或按树状态判定本轮无需扩展）",
+        "checks": [{"kind": "no_error"}],
+        "requires_gate": None,
+    }
+
+
+def discovery_summarize_node() -> dict:
+    """汇总收尾节点：标 wrapup——预算耗尽也放行，把已长出的树变成产物。"""
+    return {
+        "title": "汇总假设树",
+        "action": "discovery.summarize",
+        "params": {},
+        "acceptance": "整树（含被剪分支）已汇总为 run 产物",
+        "checks": [{"kind": "no_error"}],
+        "requires_gate": None,
+        "wrapup": True,
+    }
+
+
+def discovery_signal_edits(
+    signal: dict[str, Any], active_rows: list[Any]
+) -> dict[str, Any] | None:
+    """hypothesis.seed / hypothesis.expand 的 plan_signal → 追加下一步（幂等）。
+
+    discovery 不预排线性计划：每轮扩展结束后按树状态给信号，这里只做确定性
+    展开——expand 继续长一轮、summarize 进入收尾。幂等同 experiment 分支表：
+    待办的同类节点已存在则返回 None（防 resume 重放重复追加）。
+    """
+    pending_actions = {r.action for r in active_rows if r.status != "passed"}
+    decision = str(signal.get("decision") or "")
+    if decision == "expand":
+        if "hypothesis.expand" in pending_actions:
+            return None
+        next_round = int(signal.get("next_round") or 0)
+        return {
+            "finish": False,
+            "reason": f"树上仍有可扩展的 open 节点：第 {next_round} 轮扩展",
+            "edits": [
+                {
+                    "op": "add_nodes",
+                    "insert_after": None,
+                    "nodes": [discovery_expand_node(next_round)],
+                }
+            ],
+        }
+    if decision == "summarize":
+        if "discovery.summarize" in pending_actions:
+            return None
+        return {
+            "finish": False,
+            "reason": str(signal.get("reason") or "") or "扩展结束，汇总假设树",
+            "edits": [
+                {"op": "add_nodes", "insert_after": None, "nodes": [discovery_summarize_node()]}
+            ],
+        }
+    return None
+
+
 def review_match_node(index: int) -> dict[str, Any]:
     return {
         "title": f"第 {index + 1} 场辩论",
@@ -241,4 +306,5 @@ def review_signal_edits(signal: dict[str, Any], active_rows: list[Any]) -> dict[
 SIGNAL_TABLES: dict[str, Callable[[dict[str, Any], list[Any]], dict[str, Any] | None]] = {
     "experiment": experiment_signal_edits,
     "idea_review": review_signal_edits,
+    "discovery": discovery_signal_edits,
 }

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -73,6 +73,10 @@ _REVIEW_SUPPORT_MARKER = "POLARIS_REVIEW_SUPPORT"  # 引用支撑性判定
 _REVIEW_META_MARKER = "POLARIS_REVIEW_META"  # meta-review 总结
 _REVIEW_FACTCHECK_MARKER = "POLARIS_REVIEW_FACTCHECK"  # claim 抽查
 # Idea 2.0 深耕（actions_proposal.py 的 system prompt 对齐，docs/api-idea2.md）
+# discovery 树搜索（actions_discovery.py 三个 system prompt 对齐，#642）
+_DISCOVERY_SEED_MARKER = "POLARIS_DISCOVERY_SEED"
+_DISCOVERY_EXPAND_MARKER = "POLARIS_DISCOVERY_EXPAND"
+_DISCOVERY_SUMMARY_MARKER = "POLARIS_DISCOVERY_SUMMARY"
 _GOAL_EXPLORE_MARKER = "POLARIS_GOAL_EXPLORE"  # 目标构建工具循环
 _GOAL_REFINE_MARKER = "POLARIS_GOAL_REFINE"  # 审批意见并入目标
 _PROPOSAL_RELATED_MARKER = "POLARIS_PROPOSAL_RELATED"  # 相关工作（工具循环）
@@ -371,6 +375,16 @@ class FakeProvider(LLMProvider):
             return FakeProvider._respond_review_factcheck(full_text)
         if _PAPER_REVIEWER_MARKER in full_text:
             return FakeProvider._respond_paper_reviewer(full_text)
+        # discovery 树搜索三 marker：user prompt 内嵌方向/假设文本，先于通用 marker
+        if _DISCOVERY_SEED_MARKER in full_text:
+            return FakeProvider._respond_discovery_seed(full_text)
+        if _DISCOVERY_EXPAND_MARKER in full_text:
+            return FakeProvider._respond_discovery_expand(full_text)
+        if _DISCOVERY_SUMMARY_MARKER in full_text:
+            return (
+                "（fake discovery 总结）本次探索围绕研究方向展开：根假设已扩展出子分支，"
+                "无分支被剪除（fake）；最有希望的方向见评分最高的 open 节点。"
+            )
         # Idea 2.0 深耕 marker：prompt 内嵌 goal JSON / wiki 摘录 / 检索结果
         # （会撞 "score"、"out_of_scope"、TL;DR 等通用 marker），须先于它们判断
         if _GOAL_EXPLORE_MARKER in full_text:
@@ -1011,6 +1025,47 @@ class FakeProvider(LLMProvider):
         )
 
     # ---- Idea 2.0 深耕（actions_proposal.py 的 system prompt 对齐，docs/api-idea2.md） ----
+
+    # ---- discovery 树搜索（actions_discovery.py 对齐，#642） ----
+
+    @staticmethod
+    def _respond_discovery_seed(full_text: str) -> str:
+        """播种：回显研究方向的确定性根假设（骨架 run 端到端可重放）。"""
+        m = re.search(r"研究方向：(.+)", full_text)
+        direction = m.group(1).strip() if m else "研究方向（fake）"
+        return json.dumps(
+            {
+                "statement": f"围绕「{direction}」的核心假设（fake root）",
+                "rationale": "fake-seed：确定性根假设",
+                "score": 0.8,
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_discovery_expand(full_text: str) -> str:
+        """扩展：固定两个子假设（A 分高于 B → best_open_node 下一轮选 A，确定性）；
+        prune 恒为空——fake 路径不触发剪枝，骨架 run 的树形状可精确断言。"""
+        m = re.search(r"父假设：(.+)", full_text)
+        parent = m.group(1).strip() if m else "父假设（fake）"
+        return json.dumps(
+            {
+                "children": [
+                    {
+                        "statement": f"{parent[:60]} → 子假设 A（fake）",
+                        "rationale": "fake-expand：路线 A",
+                        "score": 0.7,
+                    },
+                    {
+                        "statement": f"{parent[:60]} → 子假设 B（fake）",
+                        "rationale": "fake-expand：路线 B",
+                        "score": 0.6,
+                    },
+                ],
+                "prune": [],
+            },
+            ensure_ascii=False,
+        )
 
     @staticmethod
     def _respond_goal_explore(full_text: str) -> str:

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -75,6 +75,7 @@ STAGES = (
     "proposal",
     "proposal_review",
     "debate",
+    "discovery_plan",
     "experiment",
     "writing",
     "review",
@@ -180,7 +181,7 @@ _LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest", "forge_generate"})
 # 中档用于多轮代理和较长的结构化生成。一次调用比短 JSON 长得多，但**不能**
 # 直接塞进长档：那是 300s × 4 尝试，最坏 20 分钟攥着一个 HTTP 连接不放，而对话是同步的，
 # 用户早走了。180s × 2 是"够想完一轮、又不至于把连接耗死"的折中。
-_MEDIUM_CALL_STAGES = frozenset({"agent", "goal_explore", "proposal_review"})
+_MEDIUM_CALL_STAGES = frozenset({"agent", "discovery_plan", "goal_explore", "proposal_review"})
 
 
 def call_profile(stage: str) -> tuple[float, int]:

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -4,10 +4,14 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-# M1 仅开放 demo 航程；后续里程碑扩展 ingest/forge/experiment/writing
-VoyageKind = Literal["demo"]
+# 通用创建入口开放的 kind：demo（M1 演示）+ discovery（#642 树搜索探索）。
+# 其余 kind（experiment/writing/…）各有业务入口与专属校验，不走这里。
+VoyageKind = Literal["demo", "discovery"]
+
+# discovery 每轮扩展是一次 LLM 调用 + 2-3 个新节点，上限防手滑填个大数烧钱
+MAX_DISCOVERY_EXPANSIONS = 10
 
 
 class VoyageCreate(BaseModel):
@@ -15,6 +19,28 @@ class VoyageCreate(BaseModel):
     project_id: uuid.UUID
     goal: str = Field(min_length=1)
     params: dict[str, Any] | None = None  # 可含 {"budget": {"max_tokens": ...}}
+
+    @model_validator(mode="after")
+    def _normalize_discovery_params(self) -> "VoyageCreate":
+        """discovery 的参数在创建时就定形（引擎只读 checkpoint.params，不再兜底）：
+        direction 必填；max_expansions 默认 3（0..MAX，整数）；tournament 默认
+        False——锦标赛式对比是后续里程碑，先存档位不实现。"""
+        if self.kind != "discovery":
+            return self
+        params = dict(self.params or {})
+        direction = str(params.get("direction") or "").strip()
+        if not direction:
+            raise ValueError("discovery 任务需要 params.direction（研究方向）")
+        params["direction"] = direction
+        raw = params.get("max_expansions", 3)
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError("max_expansions 必须是整数")
+        if not 0 <= raw <= MAX_DISCOVERY_EXPANSIONS:
+            raise ValueError(f"max_expansions 必须在 0..{MAX_DISCOVERY_EXPANSIONS} 之间")
+        params["max_expansions"] = raw
+        params["tournament"] = bool(params.get("tournament", False))
+        self.params = params
+        return self
 
 
 class VoyageStepRead(BaseModel):

--- a/src/backend/tests/test_voyage_discovery.py
+++ b/src/backend/tests/test_voyage_discovery.py
@@ -1,0 +1,390 @@
+"""discovery 任务（#642，P2 D2）：树搜索规划 + fake 骨架 run 端到端。
+
+- 计划模板只有播种一步（树才是真源），后续每轮由 plan_signal 经确定性分支表展开；
+- 创建入口的参数定形（direction 必填 / max_expansions 默认 3 / tournament 先存不实现）；
+- fake provider 下端到端：根 + 两子 + 状态、汇总产物（被剪分支留痕结构）、每节点记账；
+- max_expansions 截止；
+- 断点恢复两种杀点：扩展前被杀（重启按 best_open_node 确定性重选同一节点）、
+  子节点落库后 checkpoint 回写前被杀（树上 expanded 计数补账，不重复扩）。
+"""
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.agents.voyage import actions as actions_registry
+from app.agents.voyage.engine import VoyageEngine
+from app.agents.voyage.navigator import discovery_plan, done_criteria_for_kind
+from app.agents.voyage.plan_edit import discovery_signal_edits
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.hypothesis import HypothesisNode
+from app.models.voyage import VoyageRun, VoyageStep, mode_for_kind
+from tests.conftest import RecordingBus, register_and_login
+
+# ---- 纯函数：计划模板 + 确定性分支表 ----
+
+
+def test_discovery_plan_only_seeds():
+    """初始计划只有播种一步：树搜索不预排线性清单，后续由树状态驱动。"""
+    plan = discovery_plan(None)  # run 参数未用（模板不依赖 run 状态）
+    assert [s["action"] for s in plan] == ["hypothesis.seed"]
+    assert mode_for_kind("discovery") == "loop"
+    criteria = done_criteria_for_kind("discovery")
+    assert criteria == {
+        "checks": [{"kind": "artifact_exists", "key": "artifacts.discovery-summary.json"}]
+    }
+
+
+class _RowStub:
+    def __init__(self, action: str, status: str) -> None:
+        self.action = action
+        self.status = status
+
+
+def test_discovery_signal_edits_idempotent():
+    """分支表：expand/summarize 各追加一个节点；待办同类节点已存在则跳过（防重放）。"""
+    rows = [_RowStub("hypothesis.seed", "passed")]
+    edit = discovery_signal_edits({"decision": "expand", "next_round": 1}, rows)
+    nodes = edit["edits"][0]["nodes"]
+    assert [n["action"] for n in nodes] == ["hypothesis.expand"]
+    assert nodes[0]["params"] == {"round": 1}
+
+    rows.append(_RowStub("hypothesis.expand", "pending"))
+    assert discovery_signal_edits({"decision": "expand", "next_round": 1}, rows) is None
+
+    edit = discovery_signal_edits({"decision": "summarize", "reason": "上限已到"}, rows)
+    nodes = edit["edits"][0]["nodes"]
+    assert [n["action"] for n in nodes] == ["discovery.summarize"]
+    assert nodes[0]["wrapup"] is True  # 预算耗尽也要能把树落成产物
+
+    rows.append(_RowStub("discovery.summarize", "pending"))
+    assert discovery_signal_edits({"decision": "summarize"}, rows) is None
+    assert discovery_signal_edits({"decision": "unknown"}, rows) is None
+
+
+# ---- 造数据助手 ----
+
+
+async def _make_project(client) -> tuple[str, dict]:
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "discovery-proj"}, headers=headers)
+    return resp.json()["id"], headers
+
+
+async def _make_run(project_id: str, *, direction: str, max_expansions: int) -> uuid.UUID:
+    """直建 run（plan=None：首次驱动由 navigator 的 discovery 模板补计划）。"""
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="discovery",
+            goal=direction,
+            status="planning",
+            cursor=0,
+            checkpoint={
+                "params": {
+                    "direction": direction,
+                    "max_expansions": max_expansions,
+                    "tournament": False,
+                }
+            },
+            project_id=uuid.UUID(project_id),
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+def _engine() -> VoyageEngine:
+    return VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+
+
+async def _tree(run_id: uuid.UUID) -> list[HypothesisNode]:
+    async with get_sessionmaker()() as session:
+        return list(
+            (
+                await session.execute(
+                    select(HypothesisNode)
+                    .where(HypothesisNode.run_id == run_id)
+                    .order_by(HypothesisNode.created_at, HypothesisNode.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+# ---- 创建入口（通用 POST /api/voyages） ----
+
+
+async def test_discovery_create_api_normalizes_params(client, queue_stub):
+    project_id, headers = await _make_project(client)
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "LLM agent 的长期记忆机制",
+            "params": {"direction": "  LLM agent 的长期记忆机制  "},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    run_id = resp.json()["id"]
+    assert ("run_voyage", (run_id,), {}) in queue_stub.jobs
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, uuid.UUID(run_id))
+        params = (run.checkpoint or {})["params"]
+        # 参数在创建时定形：方向去空白、扩展数缺省 3、tournament 先存不实现
+        assert params["direction"] == "LLM agent 的长期记忆机制"
+        assert params["max_expansions"] == 3
+        assert params["tournament"] is False
+
+    # direction 缺失 / max_expansions 非法 → 422（引擎端不再兜底坏参数）
+    for bad_params in ({}, {"direction": "x", "max_expansions": -1},
+                       {"direction": "x", "max_expansions": "many"}):
+        resp = await client.post(
+            "/api/voyages",
+            json={
+                "kind": "discovery",
+                "project_id": project_id,
+                "goal": "g",
+                "params": bad_params,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 422, bad_params
+
+
+# ---- fake 骨架 run 端到端 ----
+
+
+async def test_discovery_skeleton_run(client, queue_stub):
+    """max_expansions=1 的最小闭环：播种 → 一轮扩展 → 汇总 → done。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _make_run(project_id, direction="可验证的 agent 工作流", max_expansions=1)
+    await _engine().run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        assert run.mode == "loop"
+        steps = (
+            (
+                await session.execute(
+                    select(VoyageStep).where(VoyageStep.run_id == run_id).order_by(VoyageStep.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # 计划由信号逐步长出来：seed → expand(1) → summarize，全部通过
+        assert [s.action for s in steps] == [
+            "hypothesis.seed",
+            "hypothesis.expand",
+            "discovery.summarize",
+        ]
+        assert all(s.status == "passed" for s in steps)
+
+        # 树结构：根（expanded，方向回显）+ 两个 open 子假设
+        nodes = await _tree(run_id)
+        assert len(nodes) == 3
+        root, child_a, child_b = nodes
+        assert root.parent_id is None and root.status == "expanded"
+        assert "可验证的 agent 工作流" in root.statement
+        assert root.score == 0.8
+        assert {child_a.parent_id, child_b.parent_id} == {root.id}
+        assert child_a.status == "open" and child_b.status == "open"
+        assert (child_a.score, child_b.score) == (0.7, 0.6)
+
+        # 汇总产物：全部节点 + 状态 + 统计（被剪分支也会留在 nodes 里，这里为 0）
+        artifact = json.loads((run.checkpoint or {})["artifacts"]["discovery-summary.json"])
+        assert artifact["stats"] == {"expanded": 1, "open": 2}
+        assert {n["id"] for n in artifact["nodes"]} == {str(n.id) for n in nodes}
+        assert artifact["summary"].startswith("（fake discovery 总结）")
+
+        # 每轮决策留痕：动作、选中节点、为什么
+        state = (run.checkpoint or {})["discovery"]
+        decisions = state["decisions"]
+        assert [d["decision"] for d in decisions] == ["expand", "summarize", "summarized"]
+        assert all(d["why"] for d in decisions)
+        assert decisions[1]["node_id"] == str(root.id)  # 第 1 轮扩的就是根
+
+        # 每节点记账：seed 记到根、expand 记到被扩展的根（只记不限）
+        usage = state["node_usage"][str(root.id)]
+        assert usage["prompt_tokens"] > 0 and usage["completion_tokens"] > 0
+        # 产物里的节点快照带着账本
+        root_snapshot = next(n for n in artifact["nodes"] if n["id"] == str(root.id))
+        assert root_snapshot["usage"] == usage
+
+
+async def test_discovery_run_is_replayable(client, queue_stub):
+    """确定性：同参数两次骨架 run 长出同形状的树（fake provider 无随机）。"""
+    project_id, _headers = await _make_project(client)
+    shapes = []
+    for _ in range(2):
+        run_id = await _make_run(project_id, direction="同一方向", max_expansions=1)
+        await _engine().run(run_id)
+        nodes = await _tree(run_id)
+        shapes.append([(n.statement, n.status, n.score, n.parent_id is None) for n in nodes])
+    assert shapes[0] == shapes[1]
+
+
+async def test_discovery_max_expansions_cutoff(client, queue_stub):
+    """扩展数达到上限即转汇总：2 轮 → 1 根 + 2×2 子 = 5 节点、2 个 expanded。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _make_run(project_id, direction="截止测试方向", max_expansions=2)
+    await _engine().run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        steps = (
+            (
+                await session.execute(
+                    select(VoyageStep).where(VoyageStep.run_id == run_id).order_by(VoyageStep.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [s.action for s in steps].count("hypothesis.expand") == 2
+    nodes = await _tree(run_id)
+    assert len(nodes) == 5
+    assert sum(1 for n in nodes if n.status == "expanded") == 2
+    assert sum(1 for n in nodes if n.status == "open") == 3
+    # 第 2 轮扩的是第 1 轮的高分子假设 A（best_open_node：score 降序、同分取先建）
+    round2_parent = next(n for n in nodes if n.status == "expanded" and n.parent_id is not None)
+    assert "子假设 A" in round2_parent.statement
+
+
+# ---- 断点恢复（kill 中途重启，从 checkpoint + best_open_node 确定性重建） ----
+
+
+class _Killed(SystemExit):
+    """模拟 worker 被杀：BaseException，穿透 Helm 的 except Exception 直接掀翻驱动。"""
+
+
+async def _run_expecting_kill(run_id: uuid.UUID) -> None:
+    with pytest.raises(_Killed):
+        await _engine().run(run_id)
+
+
+async def test_discovery_resume_kill_before_mutation(client, queue_stub):
+    """杀点①：第 2 轮扩展动手前被杀。重启后步骤复位重跑，best_open_node 对同一棵
+    树是确定性的——重选到同一个节点，最终树与不被杀完全一致。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _make_run(project_id, direction="恢复测试方向", max_expansions=2)
+
+    orig = actions_registry._REGISTRY["hypothesis.expand"]
+    fired = False
+
+    async def killer(ctx, params):
+        nonlocal fired
+        if int(params.get("round") or 0) == 2 and not fired:
+            fired = True
+            raise _Killed(1)  # 动手之前被杀：树未动、checkpoint 未记
+        return await orig(ctx, params)
+
+    actions_registry._REGISTRY["hypothesis.expand"] = killer
+    try:
+        await _run_expecting_kill(run_id)
+    finally:
+        actions_registry._REGISTRY["hypothesis.expand"] = orig
+
+    # 被杀时的现场：run 非终态、第 2 轮扩展停在 running
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "executing"
+        running = (
+            (
+                await session.execute(
+                    select(VoyageStep).where(
+                        VoyageStep.run_id == run_id, VoyageStep.status == "running"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(running) == 1 and running[0].action == "hypothesis.expand"
+    assert len(await _tree(run_id)) == 3  # 第 2 轮尚未动树
+
+    await _engine().resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        state = (run.checkpoint or {})["discovery"]
+        # 两轮都正常入账；第 2 轮选中的目标 = 确定性 best_open_node（高分子假设 A）
+        assert set(state["rounds"]) == {"1", "2"}
+        assert state["rounds"]["2"]["node_id"] is not None
+    nodes = await _tree(run_id)
+    assert len(nodes) == 5
+    round2_parent = next(n for n in nodes if str(n.id) == state["rounds"]["2"]["node_id"])
+    assert "子假设 A" in round2_parent.statement and round2_parent.status == "expanded"
+
+
+async def test_discovery_resume_kill_after_mutation(client, queue_stub):
+    """杀点②：第 2 轮子节点已落库、checkpoint 还没回写就被杀。重启后账本比树少
+    一轮，靠树上的 expanded 计数补账、绝不重复扩——总节点数不变。"""
+    project_id, _headers = await _make_project(client)
+    run_id = await _make_run(project_id, direction="恢复测试方向二", max_expansions=2)
+
+    orig = actions_registry._REGISTRY["hypothesis.expand"]
+    fired = False
+
+    async def killer(ctx, params):
+        nonlocal fired
+        result = await orig(ctx, params)  # 树已提交、ctx.checkpoint 只在内存里
+        if int(params.get("round") or 0) == 2 and not fired:
+            fired = True
+            raise _Killed(1)  # engine 还没来得及把 checkpoint 写回 run
+        return result
+
+    actions_registry._REGISTRY["hypothesis.expand"] = killer
+    try:
+        await _run_expecting_kill(run_id)
+    finally:
+        actions_registry._REGISTRY["hypothesis.expand"] = orig
+
+    assert len(await _tree(run_id)) == 5  # 第 2 轮的两个子节点已落库
+
+    await _engine().resume(run_id)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        state = (run.checkpoint or {})["discovery"]
+        # 第 2 轮由树上 expanded 计数补账（不知道当时选了谁，如实记 None）
+        assert state["rounds"]["2"] == {"node_id": None, "replayed_from_tree": True}
+        assert any("补记" in d["why"] for d in state["decisions"])
+    nodes = await _tree(run_id)
+    assert len(nodes) == 5  # 没有重复扩展
+    assert sum(1 for n in nodes if n.status == "expanded") == 2
+
+
+async def test_discovery_prune_action_cascades(client, queue_stub):
+    """hypothesis.prune：写 score + 级联剪枝（留痕不删），fake 骨架跑完后手动调用。"""
+    from app.agents.voyage.actions import ActionContext
+
+    project_id, _headers = await _make_project(client)
+    run_id = await _make_run(project_id, direction="剪枝测试方向", max_expansions=2)
+    await _engine().run(run_id)
+    nodes = await _tree(run_id)
+    # 第 1 轮的子假设 A 已被第 2 轮扩展：剪它应级联剪掉它的两个孩子
+    target = next(n for n in nodes if n.status == "expanded" and n.parent_id is not None)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint or {}))
+        prune = actions_registry._REGISTRY["hypothesis.prune"]
+        obs = await prune(ctx, {"node_id": str(target.id), "score": 0.1, "reason": "方向不通"})
+        assert obs["pruned"] == str(target.id)
+
+    nodes = await _tree(run_id)
+    pruned = {str(n.id) for n in nodes if n.status == "pruned"}
+    children = {str(n.id) for n in nodes if n.parent_id == target.id}
+    assert str(target.id) in pruned and children <= pruned  # 级联整个子树
+    assert next(n for n in nodes if n.id == target.id).score == 0.1
+    assert len(nodes) == 5  # 留痕不删

--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   type VoyageStepRead,
 } from '../../lib/api';
 import { KindBadge } from './VoyagesPage';
+import { DiscoveryTreeCard } from './discovery';
 import { ActivityBar } from './shared/ActivityBar';
 import { PlanEventCard, StepCard } from './shared/StepCard';
 import {
@@ -281,6 +282,9 @@ export function VoyageDetailPage() {
 
       {/* 文献任务：本次同步结果汇总 */}
       {WIKI_RUN_KINDS.has(voyage.kind) && <WikiRunSummary steps={steps} />}
+
+      {/* 假设探索：节点列表（树是任务的一等产物，逐轮长出来） */}
+      {voyage.kind === 'discovery' && <DiscoveryTreeCard voyage={voyage} />}
 
       {/* 本次任务使用的技能（启动时快照，中途改技能不影响） */}
       {(voyage.skills ?? []).length > 0 && (

--- a/src/frontend/src/features/voyages/VoyagesPage.tsx
+++ b/src/frontend/src/features/voyages/VoyagesPage.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { useProject } from '../../app/project';
 import { api, LIBRARY_TASK_KINDS, VOYAGE_TERMINAL, type VoyageRead } from '../../lib/api';
 import { VoyageActions } from '../../components/ui/VoyageActions';
+import { DiscoveryCreateButton } from './discovery';
 import { fmtDuration, fmtFullTime, fmtRelative } from '../../lib/format';
 import { tr } from '../../lib/i18n';
 
@@ -64,6 +65,7 @@ export const KIND_META: Record<string, KindMeta> = {
   paper_writing: { zh: '论文起草', en: 'Draft writing', icon: 'pen', bg: 'var(--violet-bg)', tx: 'var(--violet-tx)' },
   paper_review: { zh: '论文评审', en: 'Paper review', icon: 'check', bg: 'var(--violet-bg)', tx: 'var(--violet-tx)' },
   presentation: { zh: '论文分享', en: 'Paper slides', icon: 'chart', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
+  discovery: { zh: '假设探索', en: 'Hypothesis discovery', icon: 'compass', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' },
   custom: { zh: '流程技能', en: 'Workflow skill', icon: 'sparkle', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' },
   demo: { zh: '演示', en: 'Demo', icon: 'play', bg: 'var(--surface-3)', tx: 'var(--text-2)' },
   daily_feed_sync: { zh: '每日新论文', en: 'Daily paper sync', icon: 'refresh', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
@@ -254,19 +256,19 @@ export function VoyagesList({
                 <option key={k} value={k}>{tr(KIND_META[k]?.zh ?? k, KIND_META[k]?.en)}</option>
               ))}
             </select>
+            <div style={{ flex: 1 }} />
             {showScopeSwitch && (
-              <>
-                <div style={{ flex: 1 }} />
-                <Segmented
-                  options={[
-                    { v: 'current' as const, label: tr('当前课题', 'Current topic') },
-                    { v: 'all' as const, label: tr('全部课题', 'All topics') },
-                  ]}
-                  value={scope}
-                  onChange={setScope}
-                />
-              </>
+              <Segmented
+                options={[
+                  { v: 'current' as const, label: tr('当前课题', 'Current topic') },
+                  { v: 'all' as const, label: tr('全部课题', 'All topics') },
+                ]}
+                value={scope}
+                onChange={setScope}
+              />
             )}
+            {/* 新建假设探索（#642）：目前唯一从任务列表直接发起的任务类型 */}
+            <DiscoveryCreateButton projectId={currentProjectId ?? null} />
           </div>
 
           {isLoading ? (

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -1,0 +1,209 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { FormField } from '../../components/ui/FormField';
+import { toast } from '../../components/ui/Toast';
+import { api, VOYAGE_TERMINAL, type HypothesisNodeRead, type VoyageRead } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   discovery（假设探索）任务的最小前端面（#642）：
+   - 新建入口：方向文本 + 高级里的扩展轮数（走通用 POST /voyages）；
+   - 详情页的节点列表卡：挂只读假设树 API，按父子缩进平铺展示。
+   树的图形化可视化归后续里程碑（D5），这里只保证「建得了、看得见」。
+   ============================================================ */
+
+const MAX_EXPANSIONS_LIMIT = 10; // 与后端 schemas/voyage.MAX_DISCOVERY_EXPANSIONS 一致
+
+// —— 新建入口 ——
+
+export function DiscoveryCreateButton({ projectId }: { projectId: string | null }) {
+  const [open, setOpen] = useState(false);
+  const [direction, setDirection] = useState('');
+  const [maxExpansions, setMaxExpansions] = useState(3);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      api.createVoyage({
+        kind: 'discovery',
+        project_id: projectId!,
+        goal: direction.trim(),
+        params: { direction: direction.trim(), max_expansions: maxExpansions },
+      }),
+    onSuccess: (run) => {
+      setOpen(false);
+      setDirection('');
+      void queryClient.invalidateQueries({ queryKey: ['voyages'] });
+      navigate(`/voyages/${run.id}`);
+    },
+    onError: (e) =>
+      toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
+  });
+
+  const canSubmit = !!projectId && direction.trim().length > 0 && !createMutation.isPending;
+  return (
+    <>
+      <button
+        className="btn btn-soft"
+        disabled={!projectId}
+        title={projectId ? undefined : tr('先选择一个课题', 'Pick a topic first')}
+        onClick={() => setOpen(true)}
+      >
+        <Icon name="compass" size={13} />
+        {tr('新建假设探索', 'New hypothesis discovery')}
+      </button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title={tr('新建假设探索任务', 'New hypothesis discovery task')}
+        sub={tr(
+          'AI 会围绕这个方向生成假设树：提出根假设，逐轮挑最有希望的分支展开，最后汇总整棵树。',
+          'The AI grows a hypothesis tree around this direction: seed a root hypothesis, expand the most promising branch each round, then summarize the whole tree.',
+        )}
+        footer={
+          <div className="row gap8" style={{ justifyContent: 'flex-end' }}>
+            <button className="btn btn-ghost" onClick={() => setOpen(false)}>
+              {tr('取消', 'Cancel')}
+            </button>
+            <button className="btn btn-primary" disabled={!canSubmit} onClick={() => createMutation.mutate()}>
+              {createMutation.isPending ? tr('创建中…', 'Creating…') : tr('开始探索', 'Start exploring')}
+            </button>
+          </div>
+        }
+      >
+        <div style={{ padding: 20 }}>
+          <FormField
+            label="研究方向"
+            en="Research direction"
+            hint={tr('一句话说清想探索什么，例如：LLM agent 的长期记忆机制', 'One sentence on what to explore, e.g. long-term memory for LLM agents')}
+          >
+            <textarea
+              className="textarea"
+              rows={3}
+              value={direction}
+              onChange={(e) => setDirection(e.target.value)}
+              placeholder={tr('想探索的研究方向…', 'Direction to explore…')}
+            />
+          </FormField>
+          <details style={{ marginTop: 12 }}>
+            <summary style={{ fontSize: 12, color: 'var(--text-3)', cursor: 'pointer', userSelect: 'none' }}>
+              {tr('高级选项', 'Advanced')}
+            </summary>
+            <FormField
+              label="扩展轮数"
+              en="Expansion rounds"
+              hint={tr(`每轮对最有希望的假设展开 2-3 个子假设（0-${MAX_EXPANSIONS_LIMIT}）`, `Each round expands the most promising hypothesis into 2-3 children (0-${MAX_EXPANSIONS_LIMIT})`)}
+              style={{ marginTop: 10 }}
+            >
+              <input
+                className="input"
+                type="number"
+                min={0}
+                max={MAX_EXPANSIONS_LIMIT}
+                value={maxExpansions}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  if (Number.isInteger(v)) setMaxExpansions(Math.max(0, Math.min(MAX_EXPANSIONS_LIMIT, v)));
+                }}
+                style={{ width: 120 }}
+              />
+            </FormField>
+          </details>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+// —— 详情页：假设树节点列表卡 ——
+
+const OPEN_META = { zh: '待探索', en: 'Open', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' };
+const NODE_STATUS_META: Record<string, { zh: string; en: string; bg: string; tx: string }> = {
+  open: OPEN_META,
+  expanded: { zh: '已扩展', en: 'Expanded', bg: 'var(--info-bg)', tx: 'var(--info-tx)' },
+  pruned: { zh: '已剪枝', en: 'Pruned', bg: 'var(--surface-3)', tx: 'var(--text-3)' },
+  validated: { zh: '已验证', en: 'Validated', bg: 'var(--ok-bg)', tx: 'var(--ok-tx)' },
+  refuted: { zh: '已否证', en: 'Refuted', bg: 'var(--danger-bg)', tx: 'var(--danger-tx)' },
+};
+
+/** 平铺列表 → 先根深度序（父在前、子跟随缩进）；孤儿节点按原序垫底兜底。 */
+function orderWithDepth(nodes: HypothesisNodeRead[]): { node: HypothesisNodeRead; depth: number }[] {
+  const byParent = new Map<string | null, HypothesisNodeRead[]>();
+  for (const n of nodes) {
+    const key = n.parent_id ?? null;
+    byParent.set(key, [...(byParent.get(key) ?? []), n]);
+  }
+  const out: { node: HypothesisNodeRead; depth: number }[] = [];
+  const walk = (parent: string | null, depth: number) => {
+    for (const n of byParent.get(parent) ?? []) {
+      out.push({ node: n, depth });
+      walk(n.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  if (out.length < nodes.length) {
+    const seen = new Set(out.map((e) => e.node.id));
+    for (const n of nodes) if (!seen.has(n.id)) out.push({ node: n, depth: 0 });
+  }
+  return out;
+}
+
+export function DiscoveryTreeCard({ voyage }: { voyage: VoyageRead }) {
+  const active = !VOYAGE_TERMINAL.has(voyage.status);
+  const { data } = useQuery({
+    queryKey: ['hypothesis-tree', voyage.id],
+    queryFn: () => api.listHypothesisTree(voyage.id),
+    retry: false,
+    // 任务还在跑就轮询：树是逐轮长出来的
+    refetchInterval: active ? 10_000 : false,
+  });
+  const entries = useMemo(() => orderWithDepth(data ?? []), [data]);
+
+  return (
+    <div className="card card-pad" style={{ marginBottom: 20 }}>
+      <div className="row" style={{ marginBottom: 10 }}>
+        <span className="section-h">
+          <Icon name="compass" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('假设树', 'Hypothesis tree')}
+        </span>
+        {entries.length > 0 && (
+          <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-3)' }}>
+            {entries.length} {tr('个节点', 'nodes')}
+          </span>
+        )}
+      </div>
+      {entries.length === 0 ? (
+        <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
+          {active
+            ? tr('树还没长出来：AI 正在生成根假设…', 'No tree yet — the AI is seeding the root hypothesis…')
+            : tr('这次任务没有留下假设树。', 'This run left no hypothesis tree.')}
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {entries.map(({ node, depth }) => {
+            const m = NODE_STATUS_META[node.status] ?? OPEN_META;
+            return (
+              <div key={node.id} className="row gap8" style={{ paddingLeft: depth * 18, alignItems: 'flex-start' }}>
+                <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }}>
+                  {tr(m.zh, m.en)}
+                </span>
+                <span style={{ fontSize: 12.5, minWidth: 0, textDecoration: node.status === 'pruned' ? 'line-through' : undefined, color: node.status === 'pruned' ? 'var(--text-3)' : undefined }}>
+                  {node.statement}
+                </span>
+                {node.score != null && (
+                  <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
+                    {node.score.toFixed(2)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -470,6 +470,23 @@ export interface VoyageStepRead {
   finished_at: string | null;
 }
 
+/** 假设树节点（discovery 任务的资产，#640；树整体可视化归后续里程碑）。 */
+export interface HypothesisNodeRead {
+  id: string;
+  run_id: string;
+  /** null = 树根 */
+  parent_id: string | null;
+  kind: string; // hypothesis | experiment | analysis
+  statement: string;
+  grounding: unknown[] | null;
+  novelty_report: Record<string, unknown> | null;
+  feasibility: Record<string, unknown> | null;
+  score: number | null;
+  status: string; // open | expanded | pruned | validated | refuted
+  created_at: string;
+  updated_at: string;
+}
+
 export interface VoyageRead {
   id: string;
   kind: string;
@@ -617,6 +634,7 @@ export const LLM_STAGES = [
   'proposal',
   'proposal_review',
   'debate',
+  'discovery_plan',
   'experiment',
   'writing',
   'review',
@@ -3421,6 +3439,15 @@ export const api = {
   },
 
   // —— Voyages ——
+  /** 通用创建入口（demo / discovery）。discovery 的 params 需含 direction（研究方向）。 */
+  createVoyage(input: {
+    kind: 'demo' | 'discovery';
+    project_id: string;
+    goal: string;
+    params?: Record<string, unknown>;
+  }): Promise<VoyageRead> {
+    return requestJson<VoyageRead>('/voyages', 'POST', input);
+  },
   listVoyages(projectId?: string): Promise<VoyageRead[]> {
     const qs = projectId ? `?project_id=${encodeURIComponent(projectId)}` : '';
     return request<VoyageRead[]>(`/voyages${qs}`);
@@ -3459,6 +3486,10 @@ export const api = {
     answer: { text?: string; choice?: string; payload?: Record<string, unknown> },
   ): Promise<VoyageMessageRead> {
     return requestJson<VoyageMessageRead>(`/voyages/${id}/asks/${messageId}/answer`, 'POST', answer);
+  },
+  /** discovery 任务的假设树（拉平列表，父子按 parent_id 拼装；只读）。 */
+  listHypothesisTree(voyageId: string): Promise<HypothesisNodeRead[]> {
+    return request<HypothesisNodeRead[]>(`/voyages/${voyageId}/hypothesis-tree`);
   },
 
   // —— Gates ——

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -24,6 +24,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   proposal: { zh: '方案起草', en: 'Proposal drafting' },
   proposal_review: { zh: '方案评审', en: 'Proposal review' },
   debate: { zh: '辩论评审', en: 'Debate review' },
+  discovery_plan: { zh: '假设树探索', en: 'Hypothesis tree exploration' },
   experiment: { zh: '实验', en: 'Experiments' },
   writing: { zh: '论文撰写', en: 'Paper writing' },
   review: { zh: '论文评审', en: 'Paper review' },


### PR DESCRIPTION
Closes #642. Part of #635 (P2 wave 2, item D2); design report §8.2.

New voyage kind `discovery`: the Navigator plans over the hypothesis tree (#640) instead of a linear plan. The plan is the walked trajectory; the tree is the source of truth.

- runs as a loop-mode kind whose initial plan is a single `hypothesis.seed` step; every subsequent step is appended by the engine's existing deterministic signal-table mechanism (`SIGNAL_TABLES["discovery"]`, same machinery as experiment/idea-review) from the action's `plan_signal`
- decision table each round: no open nodes or expansion budget reached → `summarize`; otherwise expand `best_open_node`
- actions: `hypothesis.seed` (root from the direction), `hypothesis.expand` (2–3 children, parent → expanded), `hypothesis.prune` (score + cascading prune), `discovery.summarize` (full tree + stats artifact; pruned branches retained by construction). Completion requires the summary artifact, so a half-grown tree can never be declared done; the wrapup step survives budget exhaustion
- recovery: a `checkpoint["discovery"]` round ledger (decisions, chosen node ids, per-node token usage — recorded, not enforced) plus the single-root invariant and deterministic `best_open_node` reselection; both kill points (before expansion, and after children land but before checkpoint write) are test-covered with no duplicate expansion and no re-seeding
- params: `direction` (required), `max_expansions` (default 3, cap 10), `tournament` stored for D4 but inert
- new `discovery_plan` LLM stage (medium tier; frontend stage tables in lockstep); the fake provider seeds/expands/summarizes deterministically so the skeleton run replays end to end
- frontend: kind metadata and creation modal (direction + advanced expansion rounds), a read-only hypothesis-tree card on the run detail (full tree view lands with D5)
- no schema changes — node accounting lives in the checkpoint and summary artifact

Verification: full suite 1477 collected = 1474 passed + the 3 pre-existing #581 failures (post-#643 baseline 1468 + exactly the 9 new tests); goldens byte-identical; frontend build and vitest (incl. the stage-parity guard) green. Rebased onto #643 with the stage registries merged (24 stages both sides, parity diff empty).