### PR TITLE
feat: agentic RAG over the library index

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -43,6 +43,8 @@ from app.schemas.libraries import (
     LibraryCreate,
     LibraryDigestRead,
     LibraryDigestSummary,
+    LibraryQaRequest,
+    LibraryQaResponse,
     PaperMergeRequest,
     PaperMergeResult,
     StatementInterviewQuestion,
@@ -74,6 +76,7 @@ from app.services import graph as graph_service
 from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
+from app.services import library_rag as library_rag_service
 from app.services import notes as notes_service
 from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
@@ -1082,6 +1085,36 @@ async def chat_with_library(
     return chat_stream_response(
         messages, sources, user_id=user_id, project_id=project_id, log_label="library chat"
     )
+
+
+@router.post("/libraries/{library_id}/qa", response_model=LibraryQaResponse)
+async def library_qa(
+    library_id: uuid.UUID,
+    data: LibraryQaRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibraryQaResponse:
+    """库级深度问答（agentic RAG，#644）：证据先行的一问一答，非流式。
+
+    与 ``/chat``（单趟检索 + 流式闲聊）互补：这里跑完整的四件套流水线（查询扩展 →
+    引文图补召回 → 重排 → 证据先行作答），返回结构化证据集，每条引用都可回溯到
+    库内片段。按库可见性可读，费用记个人。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    try:
+        result = await library_rag_service.answer(
+            session,
+            library.id,
+            data.question,
+            user_id=user.id,
+            max_rounds=data.max_rounds,
+        )
+    except ProgrammingError as e:  # paper_chunks 表还没迁移
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="DB_MIGRATION_REQUIRED: 请先执行数据库迁移（make migrate）",
+        ) from e
+    return LibraryQaResponse(**result)
 
 
 # ---- P6 治理：重复论文合并 ----

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -37,6 +37,10 @@ _CONCEPTS_MARKER = "概念列表："
 _FAKE_FIGURE_REF_RE = re.compile(r"^(?:fig|figure|tab|table|eq)\s*[:：]", re.IGNORECASE)
 _AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affiliations.py 专门调用）
 _CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类（citation_graph.py）
+# 库级 agentic RAG 三环节（services/library_rag.py，#644）
+_RAG_EXPAND_MARKER = "POLARIS_RAG_EXPAND"
+_RAG_RERANK_MARKER = "POLARIS_RAG_RERANK"
+_RAG_ANSWER_MARKER = "POLARIS_RAG_ANSWER"
 _AFFIL_COMPILE_MARKER = "POLARIS_AFFILIATIONS"  # on_compile 折叠进 wiki 编译的机构定界块请求
 # on_compile 模式下 librarian 编译输出附带的确定性机构定界块（与 FULL_TEXT 对齐）
 _FAKE_AFFIL_BLOCK = (
@@ -415,6 +419,13 @@ class FakeProvider(LLMProvider):
                 },
                 ensure_ascii=False,
             )
+        # 库级 RAG 三环节：user prompt 内嵌检索片段（可能撞任意通用 marker），须先判断
+        if _RAG_EXPAND_MARKER in full_text:
+            return FakeProvider._respond_rag_expand()
+        if _RAG_RERANK_MARKER in full_text:
+            return FakeProvider._respond_rag_rerank(last_user)
+        if _RAG_ANSWER_MARKER in full_text:
+            return FakeProvider._respond_rag_answer(last_user)
         # 引文意图分类：user prompt 内嵌论文正文原句（可能撞任意通用 marker），须先判断
         if _CITATION_INTENT_MARKER in full_text:
             return FakeProvider._respond_citation_intent(last_user)
@@ -591,6 +602,51 @@ class FakeProvider(LLMProvider):
                     break
             out.append({"index": item["index"], "intent": intent, "confidence": confidence})
         return json.dumps({"items": out}, ensure_ascii=False)
+
+    # ---- 库级 agentic RAG（services/library_rag.py 的三个 system prompt 对齐，#644） ----
+
+    @staticmethod
+    def _respond_rag_expand() -> str:
+        """查询扩展：固定回一条补充查询（确定性；测试语料据此埋「expansion probe」）。"""
+        return json.dumps({"queries": ["expansion probe query (fake)"]}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_rag_rerank(last_user: str) -> str:
+        """重排+摘要：恒序回传（按输入顺序给递减分），每条配确定性假摘要。"""
+        start = last_user.find("{")
+        try:
+            payload = json.loads(last_user[start:]) if start != -1 else {}
+        except json.JSONDecodeError:
+            payload = {}
+        out = []
+        for i, item in enumerate(payload.get("items") or []):
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            out.append(
+                {
+                    "id": item["id"],
+                    "score": round(max(0.0, 1.0 - 0.05 * i), 2),
+                    "summary": f"（fake 摘要）{str(item.get('text') or '')[:40]}",
+                }
+            )
+        return json.dumps({"items": out}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_rag_answer(last_user: str) -> str:
+        """证据先行作答：回显问题 + 引用首条证据的 paper_id（确定性、可校验）。"""
+        start = last_user.find("{")
+        try:
+            payload = json.loads(last_user[start:]) if start != -1 else {}
+        except json.JSONDecodeError:
+            payload = {}
+        question = str(payload.get("question") or "")[:200]
+        evidence = [e for e in (payload.get("evidence") or []) if isinstance(e, dict)]
+        first_id = str(evidence[0].get("paper_id")) if evidence else ""
+        cite = f" [{first_id}]" if first_id else ""
+        return (
+            f"（fake RAG 作答）关于「{question}」：综合证据集，核心结论成立{cite}。"
+            "证据集之外的内容，我无法确定。"
+        )
 
     @staticmethod
     def _respond_daily_digest(last_user: str) -> str:

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -81,6 +81,10 @@ STAGES = (
     "review",
     "reading",
     "citation_intent",
+    # 库级 agentic RAG 三环节（#644）：扩展/重排是短 JSON，作答是中档长生成
+    "rag_expand",
+    "rag_rerank",
+    "rag_answer",
 )
 
 _ROUTE_CACHE_TTL = 60.0
@@ -168,6 +172,8 @@ _SHORT_CALL_STAGES = frozenset(
         "forge_signal",
         "reading",
         "citation_intent",  # 引文意图批量分类：短 JSON、便宜模型（#639）
+        "rag_expand",  # 库问答查询扩展：短 JSON（#644）
+        "rag_rerank",  # 库问答重排+摘要：短 JSON（#644）
     }
 )
 
@@ -181,7 +187,11 @@ _LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest", "forge_generate"})
 # 中档用于多轮代理和较长的结构化生成。一次调用比短 JSON 长得多，但**不能**
 # 直接塞进长档：那是 300s × 4 尝试，最坏 20 分钟攥着一个 HTTP 连接不放，而对话是同步的，
 # 用户早走了。180s × 2 是"够想完一轮、又不至于把连接耗死"的折中。
-_MEDIUM_CALL_STAGES = frozenset({"agent", "discovery_plan", "goal_explore", "proposal_review"})
+# rag_answer 是同步问答里的长生成（证据集大、要逐句挂引用），60s 短档会掐死它，
+# 但它又是用户干等着的请求，不能给长档 20 分钟的耐心——与 agent 同档。
+_MEDIUM_CALL_STAGES = frozenset(
+    {"agent", "discovery_plan", "goal_explore", "proposal_review", "rag_answer"}
+)
 
 
 def call_profile(stage: str) -> tuple[float, int]:

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -233,3 +233,30 @@ class StatementInterviewResponse(BaseModel):
     total: int
     question: StatementInterviewQuestion | None = None
     statement: str | None = None
+
+
+# ---- 库级 agentic RAG 问答（#644） ----
+
+
+class LibraryQaRequest(BaseModel):
+    question: str = Field(min_length=1, max_length=2000)
+    # 检索轮数上限（首轮 + 扩展轮）；界面暂不暴露，留给调用方调
+    max_rounds: int = Field(default=2, ge=1, le=4)
+
+
+class LibraryQaEvidence(BaseModel):
+    """一条证据：via 标注它怎么进的证据集（vector/expansion/citation/direct）。"""
+
+    paper_id: uuid.UUID
+    chunk_id: uuid.UUID | None = None
+    title: str = ""
+    snippet: str = ""
+    score: float | None = None
+    via: str = "vector"
+
+
+class LibraryQaResponse(BaseModel):
+    answer: str
+    evidence: list[LibraryQaEvidence] = []
+    # 实际执行过的检索查询（小库直通时为空表——没有检索这一步）
+    queries: list[str] = []

--- a/src/backend/app/services/library_rag.py
+++ b/src/backend/app/services/library_rag.py
@@ -1,0 +1,603 @@
+"""库级 agentic RAG（#644，设计报告 §10 ⑤层，PaperQA2 四件套；不 import fastapi）。
+
+与 ``library_chat.py``（单趟检索 + 流式闲聊）不同，这里是一条**证据先行**的问答
+流水线，四个环节可单测、可重放：
+
+1. 迭代查询扩展：首轮按问题检索 top-k，``rag_expand`` 环节基于命中提出 ≤3 条
+   补充查询，再确定性执行（最多 ``max_rounds`` 轮）——一次检索抓不全的多跳问题
+   靠补充查询补齐；
+2. 重排 + 摘要：合并去重后 ``rag_rerank`` 环节一次调用批量打分排序，top-n 各配
+   一句上下文摘要；
+3. 引文图补召回：对强命中论文沿 paper_citations 边（引用 + 被引）把库内邻居的
+   高分片段拉进候选（确定性，无 LLM）——语义检索按相似度召回，引文边补上
+   「被它引用/引用它」这层结构性相关；
+4. 证据先行作答：``rag_answer`` 环节**只看见证据集**，要求逐句挂 [paper_id]
+   引用；后处理校验引用 id ∈ 证据集，越界即剥离并标注——引用只能指向真实证据，
+   结构上杜绝编造引用。
+
+小库直通：库内片段总量按 字符数/4 估算 <200k token 时跳过整条检索流水线，
+全部片段直接喂给 ``rag_answer``——检索的意义在于「装不下才挑」，装得下就别挑，
+挑就有漏。
+
+检索底座复用 chunks.py：postgres+embedding 可用走向量，否则关键词降级；首轮与
+扩展轮共用同一条降级路径（降级后 ``via`` 仍按轮次记 vector/expansion——它标的是
+「这条证据怎么来的」，不是用了哪个检索引擎）。
+"""
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.base import Message
+from app.core.llm.router import LLMRouter
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper, PaperChunk
+from app.models.paper_citation import PaperCitation
+from app.services import chunks as chunks_service
+from app.services.embedding import embed_query
+from app.services.papers import PAPER_STATUS_GROUPS
+
+logger = logging.getLogger(__name__)
+
+TOP_K = 8  # 每轮检索取回的片段数
+MAX_EXPANSION_QUERIES = 3  # 每轮扩展最多补几条查询
+RERANK_POOL = 24  # 送重排的候选上限（重排是一次 LLM 调用，输入要有上界）
+TOP_N_EVIDENCE = 8  # 重排后进入作答的证据数
+SNIPPET_CHARS = 360  # 证据卡片上的片段截断
+RERANK_DOC_CHARS = 600  # 送重排的单条文本截断
+# 小库直通阈值（token，按 字符数/4 估算）。测试里把它 monkeypatch 成 0 可强制走
+# 检索流水线——正常测试库都只有几个片段，永远命中直通分支。
+DIRECT_TOKEN_BUDGET = 200_000
+CITATION_SEED_PAPERS = 3  # 沿引文边扩展的强命中论文数
+MAX_CITATION_NEIGHBORS = 4  # 最多拉入几个引文邻居
+CITATION_NEIGHBOR_CHUNKS = 2  # 每个邻居拉入的高分片段数
+
+_WORD_RE = re.compile(r"[\w一-鿿]+")
+# 回答里的引用标记：[<paper uuid>]。作答环节要求模型只用这种形态引用。
+_CITE_RE = re.compile(
+    r"\[([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\]"
+)
+
+_EXPAND_SYSTEM = """\
+POLARIS_RAG_EXPAND
+你是文献检索的查询扩展器。输入 JSON 里是用户问题和首轮检索命中的片段。
+基于命中内容判断还缺哪些角度，提出最多 3 条**互补**的检索查询（换措辞、换切入点、
+补上位/下位概念），不要重复原问题。
+只输出 JSON：{"queries": ["...", "..."]}；没有值得补的角度就输出 {"queries": []}。"""
+
+_RERANK_SYSTEM = """\
+POLARIS_RAG_RERANK
+你是检索结果重排器。输入 JSON 里是用户问题和候选片段（各带 id）。
+对每条片段按「回答该问题的有用程度」给 0~1 分，并配一句它讲了什么的摘要。
+只输出 JSON：{"items": [{"id": <原样回传>, "score": 0到1, "summary": "..."}]}。"""
+
+_ANSWER_SYSTEM = """\
+POLARIS_RAG_ANSWER
+你是文献库问答助手。输入 JSON 里是问题和检索到的证据集（每条带 paper_id）。
+回答要求：
+- 只依据证据回答；证据没有覆盖的，直接说明「文献库中未检索到相关内容」，不要编造；
+- 每个论断句末尾标注它依据的证据来源，格式是 [paper_id]（方括号里放证据里的
+  paper_id 原文，如 [123e4567-e89b-12d3-a456-426614174000]；多来源就连写多个）；
+- 只允许引用证据集里出现过的 paper_id；
+- 用中文回答，讲清楚、说人话。"""
+
+
+@dataclass(slots=True)
+class _Candidate:
+    """一条候选证据。``order`` 是进入候选集的先后（重排同分时的确定性 tie-break）。"""
+
+    chunk: PaperChunk
+    score: float
+    via: str  # vector | expansion | citation | direct
+    order: int
+
+
+def _json_payload(content: str) -> dict:
+    """从模型输出里抠出第一个 {...} 并解析；失败返回 {}（调用方按解析失败降级）。"""
+    start, end = content.find("{"), content.rfind("}")
+    if start == -1 or end <= start:
+        return {}
+    try:
+        payload = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _search_round(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    query: str,
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+) -> list[tuple[PaperChunk, float]]:
+    """执行一轮检索：向量优先，关键词降级，任何失败不上抛（与 library_chat 同路径）。"""
+    if chunks_service.chunk_vector_search_supported(session):
+        try:
+            vector, space = await embed_query(
+                session, query, user_id=user_id, project_id=project_id
+            )
+            rows = await chunks_service.semantic_search_chunks(
+                session,
+                library_ids=[library_id],
+                query_vector=vector,
+                space=space,
+                limit=TOP_K,
+            )
+            if rows:
+                return rows
+        except NotImplementedError:
+            pass
+        except Exception:  # noqa: BLE001 — 检索失败降级关键词，不打断问答
+            logger.warning("rag vector search failed; falling back to keyword", exc_info=True)
+            await session.rollback()  # postgres 报错后事务已中止，先回滚
+    try:
+        return await chunks_service.keyword_search_chunks(
+            session, library_ids=[library_id], q=query, limit=TOP_K
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("rag keyword search failed; returning no hits", exc_info=True)
+        await session.rollback()
+        return []
+
+
+def _merge_hits(
+    candidates: dict[uuid.UUID, _Candidate],
+    rows: list[tuple[PaperChunk, float]],
+    *,
+    via: str,
+) -> None:
+    """把一轮命中并入候选集：chunk 去重，重复命中保留更高分；``via`` 记首次来源。"""
+    for chunk, score in rows:
+        existing = candidates.get(chunk.id)
+        if existing is None:
+            candidates[chunk.id] = _Candidate(
+                chunk=chunk, score=float(score), via=via, order=len(candidates)
+            )
+        elif float(score) > existing.score:
+            existing.score = float(score)
+
+
+async def _expand_queries(
+    llm: LLMRouter,
+    *,
+    question: str,
+    executed: list[str],
+    candidates: dict[uuid.UUID, "_Candidate"],
+    papers: dict[uuid.UUID, Paper],
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+) -> list[str]:
+    """rag_expand 环节：基于当前命中提出 ≤3 条补充查询（去重、剔除已执行过的）。"""
+    ranked = sorted(candidates.values(), key=lambda c: (-c.score, c.order))[:TOP_K]
+    hits = [
+        {
+            "paper_id": str(c.chunk.paper_id),
+            "title": (papers[c.chunk.paper_id].title if c.chunk.paper_id in papers else ""),
+            "snippet": c.chunk.text[:300],
+        }
+        for c in ranked
+    ]
+    result = await llm.complete(
+        "rag_expand",
+        [
+            Message(role="system", content=_EXPAND_SYSTEM),
+            Message(
+                role="user",
+                content=json.dumps({"question": question, "hits": hits}, ensure_ascii=False),
+            ),
+        ],
+        temperature=0.0,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    seen = {q.strip() for q in executed}
+    out: list[str] = []
+    for raw in _json_payload(result.content).get("queries") or []:
+        if not isinstance(raw, str):
+            continue
+        query = raw.strip()
+        if query and query not in seen:
+            seen.add(query)
+            out.append(query)
+        if len(out) >= MAX_EXPANSION_QUERIES:
+            break
+    return out
+
+
+async def _citation_supplement(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    question: str,
+    candidates: dict[uuid.UUID, "_Candidate"],
+) -> None:
+    """引文图补召回（确定性，无 LLM）：强命中论文的库内引文邻居贡献高分片段。
+
+    「邻居的高分片段」按问题分词的命中数打分（与关键词降级检索同一口径），全都
+    不沾边时退回开头片段——邻居是因为**引文关系**被拉进来的，正文措辞不同不该
+    让它出局。
+    """
+    if not candidates:
+        return
+    ranked = sorted(candidates.values(), key=lambda c: (-c.score, c.order))
+    seeds: list[uuid.UUID] = []
+    for cand in ranked:
+        if cand.chunk.paper_id not in seeds:
+            seeds.append(cand.chunk.paper_id)
+        if len(seeds) >= CITATION_SEED_PAPERS:
+            break
+    # 库内成员集合（回收站/候选不算）：邻居必须在库里，问答的语料边界不能被引文边突破
+    member_ids = set(
+        (
+            await session.execute(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    edges = (
+        (
+            await session.execute(
+                select(PaperCitation)
+                .where(
+                    PaperCitation.citing_paper_id.in_(seeds)
+                    | PaperCitation.cited_paper_id.in_(seeds)
+                )
+                .order_by(PaperCitation.citing_paper_id, PaperCitation.ref_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    covered = {c.chunk.paper_id for c in candidates.values()}
+    neighbors: list[uuid.UUID] = []
+    for edge in edges:
+        for pid in (edge.cited_paper_id, edge.citing_paper_id):
+            if (
+                pid is not None
+                and pid not in seeds
+                and pid in member_ids
+                and pid not in covered
+                and pid not in neighbors
+            ):
+                neighbors.append(pid)
+    neighbors = neighbors[:MAX_CITATION_NEIGHBORS]
+    if not neighbors:
+        return
+    terms = [t for t in _WORD_RE.findall(question.lower()) if len(t) >= 2][:8]
+    chunks = (
+        (
+            await session.execute(
+                select(PaperChunk)
+                .where(PaperChunk.paper_id.in_(neighbors))
+                .order_by(PaperChunk.paper_id, PaperChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_paper: dict[uuid.UUID, list[PaperChunk]] = {}
+    for chunk in chunks:
+        by_paper.setdefault(chunk.paper_id, []).append(chunk)
+
+    def term_score(chunk: PaperChunk) -> float:
+        lowered = chunk.text.lower()
+        return float(sum(1 for t in terms if t in lowered))
+
+    for pid in neighbors:
+        rows = by_paper.get(pid) or []
+        rows.sort(key=lambda c: (-term_score(c), c.seq))
+        for chunk in rows[:CITATION_NEIGHBOR_CHUNKS]:
+            # 归一化到 0~1，和检索得分同量纲；关键词全不沾边给个非零底分，
+            # 保证「因引文关系入选」的片段不会在重排解析失败的兜底排序里垫底消失
+            score = (term_score(chunk) / len(terms)) if terms else 0.0
+            _merge_hits(candidates, [(chunk, max(score, 0.05))], via="citation")
+
+
+async def _rerank(
+    llm: LLMRouter,
+    *,
+    question: str,
+    ordered: list["_Candidate"],
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+) -> tuple[list["_Candidate"], dict[uuid.UUID, float], dict[uuid.UUID, str]]:
+    """rag_rerank 环节：批量打分排序 + 逐条摘要（同一次调用）。
+
+    返回 (重排后的候选, chunk_id→重排分, chunk_id→摘要)。输出解析失败时保持
+    原始检索得分排序（确定性兜底，不重试）。
+    """
+    items = [
+        {"id": i, "paper_id": str(c.chunk.paper_id), "text": c.chunk.text[:RERANK_DOC_CHARS]}
+        for i, c in enumerate(ordered)
+    ]
+    result = await llm.complete(
+        "rag_rerank",
+        [
+            Message(role="system", content=_RERANK_SYSTEM),
+            Message(
+                role="user",
+                content=json.dumps({"question": question, "items": items}, ensure_ascii=False),
+            ),
+        ],
+        temperature=0.0,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    parsed: dict[int, tuple[float, str]] = {}
+    for item in _json_payload(result.content).get("items") or []:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), int):
+            continue
+        idx = int(item["id"])
+        if not 0 <= idx < len(ordered):
+            continue
+        raw_score = item.get("score")
+        score = float(raw_score) if isinstance(raw_score, (int, float)) else 0.0
+        parsed[idx] = (min(1.0, max(0.0, score)), str(item.get("summary") or ""))
+    if not parsed:
+        logger.warning("rag_rerank output unparseable; keeping retrieval order")
+        return ordered, {}, {}
+    # 打过分的按 (分数, 原序) 排；漏打分的按原序垫后——一条都不丢
+    scored = sorted(
+        (i for i in range(len(ordered)) if i in parsed), key=lambda i: (-parsed[i][0], i)
+    )
+    missing = [i for i in range(len(ordered)) if i not in parsed]
+    reranked = [ordered[i] for i in scored + missing]
+    rerank_scores = {ordered[i].chunk.id: parsed[i][0] for i in parsed}
+    summaries = {ordered[i].chunk.id: parsed[i][1] for i in parsed if parsed[i][1]}
+    return reranked, rerank_scores, summaries
+
+
+def _strip_invalid_citations(answer_text: str, allowed: set[str]) -> tuple[str, int]:
+    """剥离不在证据集内的 [paper_id] 引用，返回 (清理后的回答, 剥离数)。
+
+    引用校验是这条流水线「结构上杜绝编造引用」的最后一环：模型给的每个引用要么
+    指向真实证据，要么被摘掉并明说——不存在「看起来有出处」的第三态。
+    """
+    stripped = 0
+
+    def _replace(m: re.Match) -> str:
+        nonlocal stripped
+        if m.group(1).lower() in allowed:
+            return m.group(0)
+        stripped += 1
+        return ""
+
+    cleaned = _CITE_RE.sub(_replace, answer_text)
+    if stripped:
+        cleaned = cleaned.rstrip() + f"\n\n（注：已剥离 {stripped} 处不在证据集内的引用。）"
+    return cleaned, stripped
+
+
+async def _paper_rows(
+    session: AsyncSession, paper_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, Paper]:
+    if not paper_ids:
+        return {}
+    rows = (
+        (await session.execute(select(Paper).where(Paper.id.in_(paper_ids)))).scalars().all()
+    )
+    return {p.id: p for p in rows}
+
+
+def _evidence_entry(
+    cand: "_Candidate",
+    papers: dict[uuid.UUID, Paper],
+    *,
+    score: float | None,
+) -> dict:
+    paper = papers.get(cand.chunk.paper_id)
+    return {
+        "paper_id": str(cand.chunk.paper_id),
+        "chunk_id": str(cand.chunk.id),
+        "title": paper.title if paper is not None else "",
+        "snippet": cand.chunk.text[:SNIPPET_CHARS],
+        "score": score,
+        "via": cand.via,
+    }
+
+
+async def _answer_from_evidence(
+    llm: LLMRouter,
+    *,
+    question: str,
+    evidence: list[dict],
+    summaries_by_chunk: dict[str, str],
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+) -> str:
+    """rag_answer 环节：只喂证据集作答，再做引用越界校验。"""
+    payload = {
+        "question": question,
+        "evidence": [
+            {
+                "paper_id": e["paper_id"],
+                "title": e["title"],
+                "snippet": e["snippet"],
+                "summary": summaries_by_chunk.get(e["chunk_id"] or "", ""),
+            }
+            for e in evidence
+        ],
+    }
+    result = await llm.complete(
+        "rag_answer",
+        [
+            Message(role="system", content=_ANSWER_SYSTEM),
+            Message(role="user", content=json.dumps(payload, ensure_ascii=False)),
+        ],
+        temperature=0.0,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    allowed = {e["paper_id"].lower() for e in evidence}
+    cleaned, _stripped = _strip_invalid_citations(result.content, allowed)
+    return cleaned
+
+
+def _member_chunks_stmt(library_id: uuid.UUID):
+    """库内可检索片段（membership 口径与检索一致：回收站/候选不算）。"""
+    return (
+        select(PaperChunk)
+        .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+        .where(
+            LibraryPaper.library_id == library_id,
+            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+        )
+    )
+
+
+async def answer(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    question: str,
+    *,
+    user_id: uuid.UUID | None,
+    max_rounds: int = 2,
+) -> dict:
+    """库级 agentic RAG 入口：问题 → {answer, evidence, queries}。
+
+    ``evidence`` 每条：{paper_id, chunk_id, title, snippet, score, via}，
+    ``via`` ∈ vector（首轮检索）/ expansion（扩展查询）/ citation（引文图补召回）/
+    direct（小库直通，全部片段直供）。``queries`` 是实际执行过的检索查询
+    （直通分支为空表）。调用方负责库可见性校验。
+    """
+    from app.core.llm.router import get_llm_router
+
+    llm = get_llm_router()
+    library = await session.get(DirectionLibrary, library_id)
+    project_id = library.project_id if library is not None else None
+
+    # ---- 小库直通：装得下就全喂，不挑（挑就有漏） ----
+    total_chars = int(
+        (
+            await session.execute(
+                select(func.coalesce(func.sum(func.length(PaperChunk.text)), 0))
+                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
+            )
+        ).scalar_one()
+        or 0
+    )
+    if total_chars == 0:
+        # 没有任何可检索片段：不调 LLM，明说没内容（空证据下作答只会诱导编造）
+        return {
+            "answer": "文献库中还没有可检索的内容（请先收录论文并建立全文索引）。",
+            "evidence": [],
+            "queries": [],
+        }
+    if total_chars // 4 < DIRECT_TOKEN_BUDGET:
+        chunks = (
+            (
+                await session.execute(
+                    _member_chunks_stmt(library_id).order_by(
+                        PaperChunk.paper_id, PaperChunk.seq
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        direct = [
+            _Candidate(chunk=c, score=0.0, via="direct", order=i) for i, c in enumerate(chunks)
+        ]
+        papers = await _paper_rows(session, list({c.chunk.paper_id for c in direct}))
+        evidence = [_evidence_entry(c, papers, score=None) for c in direct]
+        text = await _answer_from_evidence(
+            llm,
+            question=question,
+            evidence=evidence,
+            summaries_by_chunk={},
+            user_id=user_id,
+            project_id=project_id,
+        )
+        return {"answer": text, "evidence": evidence, "queries": []}
+
+    # ---- 1) 迭代查询扩展 ----
+    candidates: dict[uuid.UUID, _Candidate] = {}
+    executed: list[str] = [question]
+    _merge_hits(
+        candidates,
+        await _search_round(
+            session, library_id=library_id, query=question, user_id=user_id, project_id=project_id
+        ),
+        via="vector",
+    )
+    for _round in range(max(0, max_rounds - 1)):
+        if not candidates:
+            break  # 一条都没命中：没有可供扩展的依据，扩展只会放大噪声
+        papers = await _paper_rows(
+            session, list({c.chunk.paper_id for c in candidates.values()})
+        )
+        new_queries = await _expand_queries(
+            llm,
+            question=question,
+            executed=executed,
+            candidates=candidates,
+            papers=papers,
+            user_id=user_id,
+            project_id=project_id,
+        )
+        if not new_queries:
+            break
+        for query in new_queries:
+            executed.append(query)
+            _merge_hits(
+                candidates,
+                await _search_round(
+                    session,
+                    library_id=library_id,
+                    query=query,
+                    user_id=user_id,
+                    project_id=project_id,
+                ),
+                via="expansion",
+            )
+
+    if not candidates:
+        return {
+            "answer": "文献库中未检索到与问题相关的内容。",
+            "evidence": [],
+            "queries": executed,
+        }
+
+    # ---- 3) 引文图补召回（确定性，无 LLM） ----
+    await _citation_supplement(
+        session, library_id=library_id, question=question, candidates=candidates
+    )
+
+    # ---- 2) 重排 + 摘要 ----
+    ordered = sorted(candidates.values(), key=lambda c: (-c.score, c.order))[:RERANK_POOL]
+    reranked, rerank_scores, summaries = await _rerank(
+        llm, question=question, ordered=ordered, user_id=user_id, project_id=project_id
+    )
+    top = reranked[:TOP_N_EVIDENCE]
+    papers = await _paper_rows(session, list({c.chunk.paper_id for c in top}))
+    evidence = [
+        _evidence_entry(c, papers, score=rerank_scores.get(c.chunk.id, c.score)) for c in top
+    ]
+    summaries_by_chunk = {str(cid): text for cid, text in summaries.items()}
+
+    # ---- 4) 证据先行作答 ----
+    text = await _answer_from_evidence(
+        llm,
+        question=question,
+        evidence=evidence,
+        summaries_by_chunk=summaries_by_chunk,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    return {"answer": text, "evidence": evidence, "queries": executed}

--- a/src/backend/tests/test_library_rag.py
+++ b/src/backend/tests/test_library_rag.py
@@ -1,0 +1,223 @@
+"""库级 agentic RAG（#644）：四件套逐环节确定性用例 + 端到端问答。
+
+sqlite 测试库没有 pgvector，检索走关键词降级路径——四件套的判定全都不依赖
+向量相似度，语料按「哪条查询能命中哪篇论文」精确埋词：
+
+- 问题 "planning agent approaches" 只命中论文 A；
+- fake provider 的扩展查询固定为 "expansion probe query (fake)"，只命中论文 B
+  （正文埋 "expansion probe"）；
+- 论文 C 不含任何查询词，只能靠 A→C 的引文边补召回进来。
+"""
+
+import uuid
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import PaperChunk
+from app.models.paper_citation import PaperCitation
+from app.services import library_rag
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+QUESTION = "planning agent approaches"
+FAKE_EXPANSION_QUERY = "expansion probe query (fake)"
+
+# 每篇正文只含「自己该被谁命中」的词，互不串词（fake/query 等词也都只出现在 B）
+BODY_A = "planning agent approaches with tree search. " + "规划方法的细节论述。" * 60
+BODY_B = "expansion probe details for the follow-up. " + "补充角度的细节论述。" * 60
+BODY_C = "structural neighbor without matching terms. " + "结构性相关的邻居论述。" * 60
+
+
+async def _setup(client, *, with_citation_edge=False, papers=("A", "B", "C")):
+    """建库 + 三篇论文（可选 A→C 引文边）+ 全文索引，返回 (headers, library_id, ids)。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="rag-lib", statement="LLM agent 规划"
+    )
+
+    import tempfile
+
+    txt_dir = Path(tempfile.mkdtemp(prefix="polaris-rag-"))
+    bodies = {"A": BODY_A, "B": BODY_B, "C": BODY_C}
+    titles = {"A": "Planning Agents Survey", "B": "Probe Target", "C": "Cited Neighbor"}
+    ids: dict[str, uuid.UUID] = {}
+    async with get_sessionmaker()() as session:
+        for key in papers:
+            txt = txt_dir / f"{key}.txt"
+            txt.write_text(bodies[key], encoding="utf-8")
+            paper = await add_paper(
+                session,
+                project_id=project_id,
+                title=titles[key],
+                abstract=f"{titles[key]} abstract",
+                year=2026,
+                relevance_score=0.9,
+                status="compiled",
+                full_text_path=str(txt),
+            )
+            ids[key] = paper.id
+        if with_citation_edge:
+            # A 引用 C：citation 补召回唯一能把 C 拉进证据集的通道
+            session.add(
+                PaperCitation(
+                    citing_paper_id=ids["A"],
+                    cited_paper_id=ids["C"],
+                    ref_index=1,
+                    cited_ref_raw="[1] Cited Neighbor.",
+                )
+            )
+        await session.commit()
+
+    resp = await client.post(f"/api/libraries/{library_id}/index/rebuild", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return headers, library_id, ids
+
+
+# ---- 小库直通 ----
+
+
+async def test_small_library_takes_the_direct_path(client):
+    """片段总量在预算内：跳过检索（queries 为空），全部片段作为证据直供作答。"""
+    headers, library_id, ids = await _setup(client, papers=("A", "B"))
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/qa", json={"question": QUESTION}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["queries"] == []
+    assert len(body["evidence"]) > 0
+    assert all(e["via"] == "direct" for e in body["evidence"])
+    # 直通证据覆盖库内全部片段
+    async with get_sessionmaker()() as session:
+        total = len((await session.execute(select(PaperChunk))).scalars().all())
+    assert len(body["evidence"]) == total
+    # fake 作答回显问题并引用首条证据；该引用在证据集内，不会被剥离
+    assert "fake RAG 作答" in body["answer"] and QUESTION in body["answer"]
+    assert f"[{body['evidence'][0]['paper_id']}]" in body["answer"]
+
+
+async def test_empty_library_answers_without_llm(client):
+    """没有任何片段：不作答不编造，明说没内容。"""
+    token = await register_and_login(client, email="rag-empty@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    _project_id, library_id = await make_project_with_library(client, headers, name="empty-lib")
+    resp = await client.post(
+        f"/api/libraries/{library_id}/qa", json={"question": "有什么内容？"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["evidence"] == [] and body["queries"] == []
+    assert "还没有可检索的内容" in body["answer"]
+
+
+# ---- 迭代查询扩展 ----
+
+
+async def test_expansion_round_pulls_in_the_probe_paper(client, monkeypatch):
+    """max_rounds=2：首轮命中 A，扩展查询命中 B（via=expansion），queries 记录两条。"""
+    monkeypatch.setattr(library_rag, "DIRECT_TOKEN_BUDGET", 0)  # 强制走检索流水线
+    headers, library_id, ids = await _setup(client)
+
+    async with get_sessionmaker()() as session:
+        result = await library_rag.answer(
+            session, library_id, QUESTION, user_id=None, max_rounds=2
+        )
+    assert result["queries"] == [QUESTION, FAKE_EXPANSION_QUERY]
+    via_by_paper = {e["paper_id"]: e["via"] for e in result["evidence"]}
+    assert via_by_paper.get(str(ids["A"])) == "vector"
+    assert via_by_paper.get(str(ids["B"])) == "expansion"
+
+
+async def test_max_rounds_one_skips_expansion(client, monkeypatch):
+    """max_rounds=1：只跑首轮，不调用扩展环节，B 进不了证据集。"""
+    monkeypatch.setattr(library_rag, "DIRECT_TOKEN_BUDGET", 0)
+    headers, library_id, ids = await _setup(client)
+
+    async with get_sessionmaker()() as session:
+        result = await library_rag.answer(
+            session, library_id, QUESTION, user_id=None, max_rounds=1
+        )
+    assert result["queries"] == [QUESTION]
+    assert str(ids["B"]) not in {e["paper_id"] for e in result["evidence"]}
+
+
+# ---- 引文图补召回 ----
+
+
+async def test_citation_edge_recalls_the_neighbor(client, monkeypatch):
+    """C 不含任何查询词，只有 A→C 的引文边能把它拉进证据集（via=citation）。"""
+    monkeypatch.setattr(library_rag, "DIRECT_TOKEN_BUDGET", 0)
+    headers, library_id, ids = await _setup(client, with_citation_edge=True)
+
+    async with get_sessionmaker()() as session:
+        result = await library_rag.answer(
+            session, library_id, QUESTION, user_id=None, max_rounds=2
+        )
+    via_by_paper = {e["paper_id"]: e["via"] for e in result["evidence"]}
+    assert via_by_paper.get(str(ids["C"])) == "citation"
+
+
+async def test_without_citation_edge_the_neighbor_stays_out(client, monkeypatch):
+    """对照：没有引文边时 C 无法进入证据集（证明上一条确实是引文边的功劳）。"""
+    monkeypatch.setattr(library_rag, "DIRECT_TOKEN_BUDGET", 0)
+    headers, library_id, ids = await _setup(client, with_citation_edge=False)
+
+    async with get_sessionmaker()() as session:
+        result = await library_rag.answer(
+            session, library_id, QUESTION, user_id=None, max_rounds=2
+        )
+    assert str(ids["C"]) not in {e["paper_id"] for e in result["evidence"]}
+
+
+# ---- 引用越界剥离（纯函数） ----
+
+
+def test_invalid_citations_are_stripped_and_annotated():
+    good = "123e4567-e89b-12d3-a456-426614174000"
+    bad = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    text = f"结论一 [{good}]。结论二 [{bad}]。普通编号 [1] 不动。"
+    cleaned, stripped = library_rag._strip_invalid_citations(text, {good})
+    assert stripped == 1
+    assert f"[{good}]" in cleaned and f"[{bad}]" not in cleaned
+    assert "[1]" in cleaned  # 非 uuid 形态的方括号不归引用校验管
+    assert "已剥离 1 处" in cleaned
+    # 全部合法时原样返回、不加注
+    same, none_stripped = library_rag._strip_invalid_citations(f"结论 [{good}]。", {good})
+    assert none_stripped == 0 and "已剥离" not in same
+
+
+# ---- 端到端（API，四件套全开） ----
+
+
+async def test_qa_api_end_to_end_over_the_full_pipeline(client, monkeypatch):
+    """扩展 + 引文补召回 + 重排 + 作答全链：证据三种 via 齐备，引用可回溯。"""
+    monkeypatch.setattr(library_rag, "DIRECT_TOKEN_BUDGET", 0)
+    headers, library_id, ids = await _setup(client, with_citation_edge=True)
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/qa",
+        json={"question": QUESTION, "max_rounds": 2},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["queries"] == [QUESTION, FAKE_EXPANSION_QUERY]
+    vias = {e["via"] for e in body["evidence"]}
+    assert {"vector", "expansion", "citation"} <= vias
+    # 每条证据都能回溯：paper_id/chunk_id/snippet 齐备
+    for e in body["evidence"]:
+        assert e["paper_id"] and e["chunk_id"] and e["snippet"]
+    # fake 作答引用首条证据的 paper_id；它在证据集内，未被剥离
+    assert f"[{body['evidence'][0]['paper_id']}]" in body["answer"]
+    # 重排（fake 恒序）后首条证据来自首轮命中的 A
+    assert body["evidence"][0]["paper_id"] == str(ids["A"])
+
+    # 库不存在 → 404（可见性判据与其他库端点同一入口）
+    missing = uuid.uuid4()
+    resp = await client.post(
+        f"/api/libraries/{missing}/qa", json={"question": "hi"}, headers=headers
+    )
+    assert resp.status_code == 404

--- a/src/frontend/src/features/wiki/LibraryQaTab.tsx
+++ b/src/frontend/src/features/wiki/LibraryQaTab.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { api, type LibraryQaResponse } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   库级深度问答（agentic RAG，#644）：一问一答、证据先行。
+   与「文献对话」互补：那边是多轮流式闲聊；这边跑完整检索流水线
+   （查询扩展 → 引文补召回 → 重排 → 作答），回答里的每个引用都
+   指向下方的证据卡，可点开对应论文。刻意做成最小问答框，不带历史。
+   ============================================================ */
+
+const VIA_LABELS: Record<string, { zh: string; en: string }> = {
+  vector: { zh: '语义检索', en: 'retrieval' },
+  expansion: { zh: '查询扩展', en: 'expansion' },
+  citation: { zh: '引文关联', en: 'citation' },
+  direct: { zh: '全库直供', en: 'whole library' },
+};
+
+/** 回答里的 [paper_id] 引用 → 可点击的 [n] 角标（n = 该论文在证据卡里的编号）。 */
+function AnswerText({
+  answer,
+  paperIndex,
+  onOpenPaper,
+}: {
+  answer: string;
+  paperIndex: Map<string, number>;
+  onOpenPaper: (id: string) => void;
+}) {
+  const parts = answer.split(/\[([0-9a-fA-F-]{36})\]/g);
+  return (
+    <div style={{ fontSize: 13, lineHeight: 1.7, whiteSpace: 'pre-wrap' }}>
+      {parts.map((part, i) => {
+        // split 捕获组：奇数位是 paper_id
+        if (i % 2 === 0) return <span key={i}>{part}</span>;
+        const n = paperIndex.get(part.toLowerCase());
+        if (n === undefined) return <span key={i}>[{part}]</span>;
+        return (
+          <span
+            key={i}
+            role="link"
+            tabIndex={0}
+            title={tr('点击打开对应论文', 'Open the cited paper')}
+            onClick={() => onOpenPaper(part)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onOpenPaper(part);
+            }}
+            style={{
+              display: 'inline-block',
+              padding: '0 4px',
+              margin: '0 1px',
+              borderRadius: 5,
+              background: 'var(--accent-soft)',
+              color: 'var(--accent-text)',
+              fontSize: '0.82em',
+              fontWeight: 650,
+              cursor: 'pointer',
+              verticalAlign: '0.15em',
+            }}
+          >
+            {n}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export function LibraryQaTab({
+  libraryId,
+  onOpenPaper,
+}: {
+  libraryId: string;
+  onOpenPaper: (id: string) => void;
+}) {
+  const [question, setQuestion] = useState('');
+  const [result, setResult] = useState<LibraryQaResponse | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (q: string) => api.libraryQa(libraryId, q),
+    onSuccess: setResult,
+  });
+
+  // 证据卡编号按论文去重（同一篇论文的多个片段共用一个编号，与回答角标一致）
+  const paperIndex = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of result?.evidence ?? []) {
+      const key = e.paper_id.toLowerCase();
+      if (!map.has(key)) map.set(key, map.size + 1);
+    }
+    return map;
+  }, [result]);
+
+  const ask = () => {
+    const q = question.trim();
+    if (!q || mutation.isPending) return;
+    mutation.mutate(q);
+  };
+
+  return (
+    <div className="col" style={{ flex: 1, minHeight: 0, padding: 16, gap: 12, overflowY: 'auto' }}>
+      <div className="row gap8" style={{ alignItems: 'stretch' }}>
+        <input
+          className="input"
+          style={{ flex: 1 }}
+          value={question}
+          placeholder={tr(
+            '向整个文献库提问；回答只依据检索到的证据，每个引用都可回溯…',
+            'Ask the whole library; answers cite retrieved evidence only…',
+          )}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') ask();
+          }}
+        />
+        <button className="btn btn-primary sm" disabled={mutation.isPending || !question.trim()} onClick={ask}>
+          {mutation.isPending ? tr('检索作答中…', 'Answering…') : tr('提问', 'Ask')}
+        </button>
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-4)' }}>
+        {tr(
+          '深度问答：查询扩展 + 引文关联补召回 + 重排后，只依据证据作答（不看证据外的内容）。',
+          'Deep Q&A: query expansion + citation-graph recall + reranking; the answer is grounded in the evidence below.',
+        )}
+      </div>
+
+      {mutation.isError && (
+        <div className="card" style={{ padding: 12, color: 'var(--danger-tx, #c00)', fontSize: 12 }}>
+          {tr('提问失败：', 'Request failed: ')}
+          {mutation.error instanceof Error ? mutation.error.message : String(mutation.error)}
+        </div>
+      )}
+
+      {!result && !mutation.isPending && !mutation.isError && (
+        <EmptyState
+          icon="chat"
+          title={tr('问一个需要翻遍全库才能答的问题', 'Ask something that takes the whole library to answer')}
+          desc={tr('例如：这个方向的方法可以分几类？谁和谁在互相引用？', 'e.g. What are the main method families? Who cites whom?')}
+        />
+      )}
+
+      {result && (
+        <>
+          <div className="card" style={{ padding: 14 }}>
+            <AnswerText answer={result.answer} paperIndex={paperIndex} onOpenPaper={onOpenPaper} />
+            {result.queries.length > 0 && (
+              <div style={{ marginTop: 10, fontSize: 10.5, color: 'var(--text-4)' }}>
+                {tr('执行过的检索：', 'Queries run: ')}
+                {result.queries.join(tr('；', '; '))}
+              </div>
+            )}
+          </div>
+
+          {result.evidence.length > 0 && (
+            <div className="col" style={{ gap: 6 }}>
+              <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+                {tr(`证据 · ${result.evidence.length} 条`, `Evidence · ${result.evidence.length}`)}
+              </span>
+              {result.evidence.map((e, i) => (
+                <div
+                  key={e.chunk_id ?? `${e.paper_id}-${i}`}
+                  className="row gap8"
+                  style={{
+                    padding: '8px 10px',
+                    borderRadius: 8,
+                    background: 'var(--surface)',
+                    border: '0.5px solid var(--border)',
+                    alignItems: 'flex-start',
+                  }}
+                >
+                  <span className="mono" style={{ color: 'var(--accent-text)', fontSize: 11, flexShrink: 0 }}>
+                    [{paperIndex.get(e.paper_id.toLowerCase()) ?? '?'}]
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div className="row gap6" style={{ minWidth: 0 }}>
+                      <span
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 600,
+                          cursor: 'pointer',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          minWidth: 0,
+                        }}
+                        title={`${e.title} · ${tr('点击打开论文', 'click to open paper')}`}
+                        onClick={() => onOpenPaper(e.paper_id)}
+                      >
+                        {e.title || e.paper_id}
+                      </span>
+                      <span className="tag" style={{ fontSize: 9.5, flexShrink: 0 }}>
+                        {tr(VIA_LABELS[e.via]?.zh ?? e.via, VIA_LABELS[e.via]?.en ?? e.via)}
+                      </span>
+                      {typeof e.score === 'number' && (
+                        <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)', flexShrink: 0 }}>
+                          {e.score.toFixed(2)}
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ marginTop: 3, fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.55 }}>
+                      {e.snippet}
+                    </div>
+                  </div>
+                  <button
+                    className="icon-btn"
+                    style={{ width: 22, height: 22, border: 'none', background: 'transparent', flexShrink: 0 }}
+                    title={tr('打开论文详情', 'Open paper detail')}
+                    onClick={() => onOpenPaper(e.paper_id)}
+                  >
+                    <Icon name="layers" size={12} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -10,6 +10,7 @@ import { ExportMenu, PapersTab, type AdvSearchSeed } from './PapersTab';
 import { ConceptsTab } from './ConceptsTab';
 import { pickConceptByName } from './shared';
 import { LibraryChatTab } from './LibraryChatTab';
+import { LibraryQaTab } from './LibraryQaTab';
 import { IngestTab } from './IngestTab';
 import { NotesTab } from './NotesTab';
 import { GovernanceTab } from './GovernanceTab';
@@ -32,7 +33,7 @@ const PresentationModal = lazy(() =>
    从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
-type WikiTab = 'discover' | 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'ingest' | 'notes' | 'govern';
+type WikiTab = 'discover' | 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'qa' | 'ingest' | 'notes' | 'govern';
 
 export function WikiWorkbench({
   pid,
@@ -102,7 +103,7 @@ export function WikiWorkbench({
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['discover', 'papers', 'concepts', 'graph', 'digest', 'chat', 'ingest', 'notes', 'govern'].includes(tabParam)) {
+    } else if (tabParam && ['discover', 'papers', 'concepts', 'graph', 'digest', 'chat', 'qa', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -171,6 +172,8 @@ export function WikiWorkbench({
             { v: 'graph', label: tr('图谱', 'Graph') },
             ...(libraryId ? [{ v: 'digest' as const, label: tr('每日简报', 'Daily digest') }] : []),
             { v: 'chat', label: tr('文献对话', 'Chat') },
+            // 深度问答走 /libraries/{id}/qa，只有库作用域有这个端点
+            ...(libraryId ? [{ v: 'qa' as const, label: tr('深度问答', 'Deep Q&A') }] : []),
             { v: 'notes', label: tr('笔记', 'Notes') },
             ...(libraryId ? [{ v: 'govern' as const, label: tr('文献库配置', 'Library config') }] : []),
             // 建库与同步放到最后一个标签
@@ -265,6 +268,8 @@ export function WikiWorkbench({
             onOpenPaper={goPaper}
             onWikiLink={onWikiLink}
           />
+        ) : tab === 'qa' && libraryId ? (
+          <LibraryQaTab libraryId={libraryId} onOpenPaper={goPaper} />
         ) : tab === 'ingest' ? (
           <IngestTab
             pid={pid}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -639,6 +639,9 @@ export const LLM_STAGES = [
   'writing',
   'review',
   'citation_intent',
+  'rag_expand',
+  'rag_rerank',
+  'rag_answer',
 ] as const;
 
 export interface LlmProviderRead {
@@ -1618,6 +1621,23 @@ export interface RebuildIndexResult {
   embedded: number;
   embed_error: string | null;
   total_chunks: number;
+}
+
+/** 深度问答证据卡：via 标注证据怎么来的（vector/expansion/citation/direct）。 */
+export interface LibraryQaEvidence {
+  paper_id: string;
+  chunk_id: string | null;
+  title: string;
+  snippet: string;
+  score: number | null;
+  via: 'vector' | 'expansion' | 'citation' | 'direct' | string;
+}
+
+export interface LibraryQaResponse {
+  answer: string;
+  evidence: LibraryQaEvidence[];
+  /** 实际执行过的检索查询（小库直通时为空） */
+  queries: string[];
 }
 
 /** 异步建索引端点（相关研究 / 个人库）的返回：入队总数 + 有全文可索引 / 无全文跳过 篇数。 */
@@ -4262,6 +4282,10 @@ export const api = {
   /** 库作用域全文索引重建（独立库也可用；需该库管理权限）。 */
   rebuildLibraryFulltextIndex(libraryId: string): Promise<RebuildIndexResult> {
     return request<RebuildIndexResult>(`/libraries/${libraryId}/index/rebuild`, { method: 'POST' });
+  },
+  /** 库级深度问答（agentic RAG，#644）：证据先行的一问一答，非流式。 */
+  libraryQa(libraryId: string, question: string): Promise<LibraryQaResponse> {
+    return requestJson<LibraryQaResponse>(`/libraries/${libraryId}/qa`, 'POST', { question });
   },
   /** 可选全文索引：为本课题「相关研究」这批论文异步建全文索引（设置关时后端 409 INDEXING_DISABLED）。 */
   buildShelfIndex(projectId: string): Promise<QueuedIndexResult> {

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -29,4 +29,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   writing: { zh: '论文撰写', en: 'Paper writing' },
   review: { zh: '论文评审', en: 'Paper review' },
   citation_intent: { zh: '引文意图分类', en: 'Citation intent classification' },
+  rag_expand: { zh: '库问答·查询扩展', en: 'Library Q&A · query expansion' },
+  rag_rerank: { zh: '库问答·重排摘要', en: 'Library Q&A · rerank & summarize' },
+  rag_answer: { zh: '库问答·作答', en: 'Library Q&A · answering' },
 };


### PR DESCRIPTION
Closes #644. Part of #635 (P2 wave 2, item E3); design report §10 layer ⑤.

The evidence machine for library QA and the upcoming D3 pipeline stages — PaperQA2-style four pieces as a service, exposed on a new structured endpoint.

## Why a new surface
The two existing "library QA" faces are contractually different things: `/libraries/{id}/chat` is a streaming conversational contract (single-pass retrieval, SSE, numbered citations) and the chat agent's `search_chunks` is a passage-retrieval primitive inside an LLM-driven tool loop. Forcing a multi-stage pipeline into either breaks their contracts, so `POST /libraries/{id}/qa` (non-streaming, structured evidence) coexists with them; the division of labor is documented at both sites.

## The four pieces (`library_rag.answer`)
1. iterative query expansion: first-round retrieval (vector, keyword fallback shared with chat) → `rag_expand` proposes ≤3 follow-up queries → executed deterministically, bounded by `max_rounds`
2. citation-graph recall (deterministic, no LLM): strong hits walk `paper_citations` both ways, library-membership-scoped, top chunks per neighbor tagged `via: citation`
3. `rag_rerank`: one batched call scores and summarizes; a parse failure falls back to retrieval order and unscored items sink rather than drop
4. evidence-first answering: `rag_answer` sees only the evidence set and must cite `[paper_id]` per claim; post-processing strips any citation outside the evidence set and annotates the removal — fabricated citations are structurally impossible
- small-library bypass: <200k estimated tokens of chunks feed the answer stage directly (`via: direct`); an empty library answers honestly without an LLM call

## Wiring
- three new stages (`rag_expand`/`rag_rerank` short tier, `rag_answer` medium) with deterministic fake-provider responders; stage-parity guards green on both sides
- frontend: a "Deep Q&A" tab on the library workbench (library scope only) — question box, answer, evidence cards with paper links/snippets/via badges, `tr(zh,en)`
- no migrations; goldens byte-identical

Verification: full suite 1472 passed vs clean-baseline 1464 (+8 new tests), same 3 pre-existing #581 failures, one known clock-step flake verified green standalone; rebased onto #645 with the stage registries merged; frontend build and vitest green.