### PR TITLE
feat: literature source adapters as kernel plugins

### DIFF
--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -20,4 +20,21 @@ export {
 export { MIGRATIONS, migrate, openStorage, type Migration } from './storage/db.ts'
 export { PluginMetaStore, SqliteConfigTreeStore } from './storage/store.ts'
 export { StorageConfig, storage, type StorageService } from './plugins/storage.ts'
+export {
+  type FetchImpl,
+  type SourceAdapter,
+  type SourceAuthor,
+  type SourceRecord,
+  type SourceSearchOptions,
+} from './sources/contract.ts'
+export { OPENALEX_BASE, OpenAlexAdapter, openAlexRecord, type OpenAlexAdapterOptions } from './sources/openalex.ts'
+export {
+  CORDIS_BASE,
+  CordisProjectsAdapter,
+  buildCordisQuery,
+  cordisDetailRecord,
+  cordisSearchRecord,
+  type CordisProjectsAdapterOptions,
+} from './sources/cordis-projects.ts'
+export { SourcesConfig, sources, type SourcesService } from './plugins/sources.ts'
 export { Context } from '@deepseek-ai/cordis'

--- a/src/kernel/src/plugins/sources.ts
+++ b/src/kernel/src/plugins/sources.ts
@@ -1,0 +1,80 @@
+/* ============================================================
+   sources 插件：把文献源适配器注册成 kernel 服务（#646，P2 E4）。
+
+   配置树按源开关 + 参数（schemastery 校验），启用的源构造成
+   SourceAdapter 实例，经 ctx.provide('sources') 挂出统一入口。
+   桌面端接线（配置树装载）归市场工作，这里只管注册面。
+
+   注册表的填充放进 ctx.effect：适配器本身无句柄可回收，但插件
+   卸载/重载时 disposer 清空注册表，可以保证还攥着旧 service 引用
+   的消费方立刻查不到已下线的源——而不是继续拿着一套僵尸适配器。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import Schema from '@deepseek-ai/schemastery'
+import type { Context } from '@deepseek-ai/cordis'
+import type { SourceAdapter } from '../sources/contract.ts'
+import { OpenAlexAdapter } from '../sources/openalex.ts'
+import { CordisProjectsAdapter } from '../sources/cordis-projects.ts'
+
+/* 字段全部可选：schemastery 校验时会补全默认值（enabled 默认 true），
+   TS 形状对齐「调用方可以只写想覆盖的部分」这一使用姿势。 */
+export interface SourcesConfig {
+  adapters?: {
+    openalex?: { enabled?: boolean; mailto?: string; baseUrl?: string }
+    'cordis-projects'?: { enabled?: boolean; baseUrl?: string }
+  }
+}
+
+export const SourcesConfig: Schema<SourcesConfig> = Schema.object({
+  adapters: Schema.object({
+    openalex: Schema.object({
+      enabled: Schema.boolean().default(true),
+      // polite pool 联系邮箱；不填走匿名池，功能不受影响只是限速更紧
+      mailto: Schema.string(),
+      baseUrl: Schema.string(),
+    }),
+    'cordis-projects': Schema.object({
+      enabled: Schema.boolean().default(true),
+      baseUrl: Schema.string(),
+    }),
+  }),
+})
+
+export interface SourcesService {
+  /** 当前启用的适配器，注册顺序稳定。 */
+  list(): SourceAdapter[]
+  get(id: string): SourceAdapter | undefined
+}
+
+export const sources = {
+  name: 'sources',
+
+  Config: SourcesConfig,
+
+  apply(ctx: Context, config: SourcesConfig): void {
+    const registry = new Map<string, SourceAdapter>()
+    ctx.effect(() => {
+      // 防御性 ?? {}：cordis 正常会用 Config 校验补全默认值，但直接
+      // 调 apply 的测试/嵌入方不一定走那条路
+      const openalex = config.adapters?.openalex ?? {}
+      const cordisProjects = config.adapters?.['cordis-projects'] ?? {}
+      if (openalex.enabled !== false) {
+        registry.set(
+          'openalex',
+          new OpenAlexAdapter({ baseUrl: openalex.baseUrl, mailto: openalex.mailto }),
+        )
+      }
+      if (cordisProjects.enabled !== false) {
+        registry.set('cordis-projects', new CordisProjectsAdapter({ baseUrl: cordisProjects.baseUrl }))
+      }
+      return () => registry.clear()
+    }, 'sources adapter registry')
+
+    const service: SourcesService = {
+      list: () => [...registry.values()],
+      get: (id) => registry.get(id),
+    }
+    ctx.provide('sources', service)
+  },
+}

--- a/src/kernel/src/sources/contract.ts
+++ b/src/kernel/src/sources/contract.ts
@@ -1,0 +1,58 @@
+/* ============================================================
+   文献源适配器契约（#646，P2 E4）。
+
+   把「从某个外部源检索文献/项目并归一化」抽成 kernel 级契约，后续
+   各源（OpenAlex / CORDIS projects / arXiv / S2 …）都以插件适配器的
+   形式挂进来，上层（desktop、市场装载的配置树）只面向这一个形状。
+
+   SourceRecord 的字段口径对齐后端 app/schemas/paper.py 的 PaperRead
+   （title/authors/year/venue/arxiv_id/doi/url…），只是命名转成 TS 惯用
+   的 camelCase：两边语义一致，未来 kernel 记录喂回后端入库时不需要
+   再做一层字段翻译。year/venue 学后端用「必有键、可为 null」而不是
+   可选键——消费方可以无脑读，不用先探测键存在性。
+   ============================================================ */
+
+/** 作者：对齐后端 AuthorRead（name + 尽力而为的机构列表）。 */
+export interface SourceAuthor {
+  name: string
+  /** 该作者的所属机构；源没给就省略。 */
+  affiliations?: string[]
+}
+
+/** 各源检索结果的归一化记录。 */
+export interface SourceRecord {
+  /** 源内原生 id（OpenAlex 短 id `W…`、CORDIS 项目号）。必须能原样喂回 fetchByIds。 */
+  id: string
+  /** 产出该记录的适配器 id，冗余进记录便于混排后溯源。 */
+  source: string
+  title: string
+  authors: SourceAuthor[]
+  year: number | null
+  venue: string | null
+  doi?: string
+  arxivId?: string
+  abstract?: string
+  url?: string
+  /** 各源独有、不值得归一化的字段（被引数 / funding / programme 等）。 */
+  extra?: Record<string, unknown>
+}
+
+export interface SourceSearchOptions {
+  /** 最多返回多少条；各适配器自己映射到源的分页参数。 */
+  limit?: number
+}
+
+/** 单个文献源适配器。实现必须无共享可变状态：注册表可随插件重载重建。 */
+export interface SourceAdapter {
+  /** 稳定 id（配置键 / SourceRecord.source 都用它），kebab-case。 */
+  id: string
+  /** 给人看的名字（设置界面用）。 */
+  label: string
+  /** 关键词检索。 */
+  search(query: string, opts?: SourceSearchOptions): Promise<SourceRecord[]>
+  /** 按源内 id 批量取全量记录；不存在的 id 静默跳过（部分成功优于整批失败）。 */
+  fetchByIds(ids: string[]): Promise<SourceRecord[]>
+}
+
+/** 适配器出网的 fetch 形状。构造时可注入，单测用 fixture 替身不打真网。 */
+export type FetchImpl = typeof globalThis.fetch

--- a/src/kernel/src/sources/cordis-projects.ts
+++ b/src/kernel/src/sources/cordis-projects.ts
@@ -1,0 +1,204 @@
+/* ============================================================
+   EU CORDIS 项目适配器：直连 cordis.europa.eu 开放数据 API。
+
+   注意别跟 vendor/deepseek-cordis（插件运行时框架）搞混：这里的
+   CORDIS 是欧盟科研项目库（设计报告 §14「papers + EU projects」），
+   后端目前完全没有对应适配器，所以只能 kernel 直连。
+
+   API 形状均已对真实服务验证过（2026-09，见 #646）：
+   - 检索：GET /api/search/results?q=<查询语言>&format=json&num=N&page=P
+     查询语言形如 contenttype='project' AND 'graphene'；
+     响应 {status, payload:{total, results:[{id, reference, acronym,
+     title, teaser, programme:[{code,…}], startDate, endDate,
+     coordinatedIn, rcn}]}}。列表里 startDate 是本地化模板串
+     （"1 {{month_05}} 2018"），只能正则抠年份；不含协调机构名。
+   - 详情：GET /project/id/{id}?format=json
+     含 objective（全文目标）、identifiers.grantDoi（10.3030/<id>）、
+     ISO 日期，协调机构在 relations.associations 里
+     （contenttype='organization' 且 attributes.type='coordinator'）。
+
+   归一化到论文口径的映射约定：objective/teaser→abstract、协调机构→
+   authors（项目没有自然人作者，机构是最接近的署名主体）、框架计划
+   （H2020/HORIZON）→venue；经费与 programme 明细进 extra。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import type { FetchImpl, SourceAdapter, SourceRecord, SourceSearchOptions } from './contract.ts'
+
+export const CORDIS_BASE = 'https://cordis.europa.eu'
+
+const DEFAULT_LIMIT = 10
+
+export interface CordisProjectsAdapterOptions {
+  /** 换基址仅供测试；默认官方站点。 */
+  baseUrl?: string
+  fetchImpl?: FetchImpl
+}
+
+/** 检索列表里的一条 project（只声明用到的字段）。 */
+interface CordisSearchHit {
+  id?: string
+  reference?: string
+  acronym?: string
+  title?: string
+  teaser?: string
+  startDate?: string
+  endDate?: string
+  coordinatedIn?: string
+  rcn?: string
+  programme?: { code?: string; id?: string; title?: string }[]
+}
+
+/** 详情端点的 project JSON（只声明用到的字段）。 */
+interface CordisProjectDetail {
+  id?: string
+  rcn?: string
+  acronym?: string
+  title?: string
+  teaser?: string
+  objective?: string
+  keywords?: string
+  status?: string
+  totalCost?: string
+  ecMaxContribution?: string
+  startDate?: string
+  endDate?: string
+  identifiers?: { grantDoi?: string }
+  relations?: { associations?: CordisAssociation[] }
+}
+
+interface CordisAssociation {
+  contenttype?: string
+  legalName?: string
+  code?: string
+  frameworkProgramme?: string
+  title?: string
+  attributes?: { type?: string }
+}
+
+/** 组装 CORDIS 查询语言。单引号是语法定界符，用户词里的一律替换成空格。 */
+export function buildCordisQuery(query: string): string {
+  const cleaned = query.replace(/'/g, ' ').replace(/\s+/g, ' ').trim()
+  return `contenttype='project' AND '${cleaned}'`
+}
+
+/** 从各种日期形态里抠年份：列表是 "1 {{month_05}} 2018"，详情是 ISO。 */
+function yearOf(value: string | undefined): number | null {
+  const match = /(?:19|20)\d{2}/.exec(value ?? '')
+  return match ? Number(match[0]) : null
+}
+
+function projectUrl(baseUrl: string, id: string): string {
+  return `${baseUrl}/project/id/${id}`
+}
+
+/** 导出仅为可测性：检索列表条目 → SourceRecord 的纯映射。 */
+export function cordisSearchRecord(hit: CordisSearchHit, baseUrl = CORDIS_BASE): SourceRecord {
+  const id = String(hit.id ?? hit.reference ?? '')
+  const programme = (hit.programme ?? []).map((p) => ({
+    code: p.code ?? null,
+    id: p.id ?? null,
+    title: p.title ?? null,
+  }))
+  const record: SourceRecord = {
+    id,
+    source: 'cordis-projects',
+    title: hit.title ?? '',
+    // 列表响应没有协调机构名，authors 留空；要机构走 fetchByIds
+    authors: [],
+    year: yearOf(hit.startDate),
+    venue: hit.programme?.[0]?.code ?? null,
+    url: projectUrl(baseUrl, id),
+    extra: {
+      acronym: hit.acronym ?? null,
+      rcn: hit.rcn ?? null,
+      coordinatedIn: hit.coordinatedIn ?? null,
+      programme,
+      startDate: hit.startDate ?? null,
+      endDate: hit.endDate ?? null,
+    },
+  }
+  if (hit.teaser) record.abstract = hit.teaser
+  return record
+}
+
+/** 导出仅为可测性：详情 JSON → SourceRecord 的纯映射。 */
+export function cordisDetailRecord(detail: CordisProjectDetail, baseUrl = CORDIS_BASE): SourceRecord {
+  const id = String(detail.id ?? '')
+  const associations = detail.relations?.associations ?? []
+  const coordinators = associations.filter(
+    (a) => a.contenttype === 'organization' && a.attributes?.type === 'coordinator' && a.legalName,
+  )
+  const legalBasis = associations.filter(
+    (a) => a.contenttype === 'programme' && a.attributes?.type === 'relatedLegalBasis',
+  )
+  const record: SourceRecord = {
+    id,
+    source: 'cordis-projects',
+    title: detail.title ?? '',
+    authors: coordinators.map((a) => ({ name: a.legalName! })),
+    year: yearOf(detail.startDate),
+    // 框架计划名（H2020/HORIZON）当 venue：它对项目的意义最接近「发表处」
+    venue: legalBasis[0]?.frameworkProgramme ?? null,
+    url: projectUrl(baseUrl, id),
+    extra: {
+      acronym: detail.acronym ?? null,
+      rcn: detail.rcn ?? null,
+      keywords: detail.keywords ?? null,
+      status: detail.status ?? null,
+      funding: {
+        totalCost: detail.totalCost ?? null,
+        ecMaxContribution: detail.ecMaxContribution ?? null,
+      },
+      programme: legalBasis.map((a) => ({ code: a.code ?? null, title: a.title ?? null })),
+      startDate: detail.startDate ?? null,
+      endDate: detail.endDate ?? null,
+    },
+  }
+  const abstract = detail.objective || detail.teaser
+  if (abstract) record.abstract = abstract
+  if (detail.identifiers?.grantDoi) record.doi = detail.identifiers.grantDoi
+  return record
+}
+
+export class CordisProjectsAdapter implements SourceAdapter {
+  readonly id = 'cordis-projects'
+  readonly label = 'EU CORDIS Projects'
+  readonly #baseUrl: string
+  readonly #fetch: FetchImpl
+
+  constructor(options: CordisProjectsAdapterOptions = {}) {
+    this.#baseUrl = (options.baseUrl ?? CORDIS_BASE).replace(/\/+$/, '')
+    this.#fetch = options.fetchImpl ?? globalThis.fetch
+  }
+
+  async search(query: string, opts?: SourceSearchOptions): Promise<SourceRecord[]> {
+    const limit = Math.max(1, opts?.limit ?? DEFAULT_LIMIT)
+    const url = new URL(`${this.#baseUrl}/api/search/results`)
+    url.searchParams.set('q', buildCordisQuery(query))
+    url.searchParams.set('format', 'json')
+    url.searchParams.set('num', String(limit))
+    url.searchParams.set('page', '1')
+    const res = await this.#fetch(url, { headers: { 'user-agent': 'polaris-kernel/0.1' } })
+    if (!res.ok) throw new Error(`cordis-projects: search failed with HTTP ${res.status}`)
+    const data = (await res.json()) as { payload?: { results?: unknown[] } }
+    return (data.payload?.results ?? [])
+      .filter((row): row is CordisSearchHit => Boolean(row) && typeof row === 'object')
+      .map((row) => cordisSearchRecord(row, this.#baseUrl))
+  }
+
+  async fetchByIds(ids: string[]): Promise<SourceRecord[]> {
+    // 详情端点才有 objective / 协调机构 / grantDoi，所以按 id 走详情而不是
+    // 拿 id 再搜一遍；404 即「没有这个项目」跳过，其余错误如实抛出
+    const records: SourceRecord[] = []
+    for (const id of ids) {
+      const url = new URL(`${this.#baseUrl}/project/id/${encodeURIComponent(id)}`)
+      url.searchParams.set('format', 'json')
+      const res = await this.#fetch(url, { headers: { 'user-agent': 'polaris-kernel/0.1' } })
+      if (res.status === 404) continue
+      if (!res.ok) throw new Error(`cordis-projects: fetch ${id} failed with HTTP ${res.status}`)
+      records.push(cordisDetailRecord((await res.json()) as CordisProjectDetail, this.#baseUrl))
+    }
+    return records
+  }
+}

--- a/src/kernel/src/sources/openalex.ts
+++ b/src/kernel/src/sources/openalex.ts
@@ -1,0 +1,168 @@
+/* ============================================================
+   OpenAlex 适配器：kernel 直连 api.openalex.org。
+
+   为什么直连而不经 legacy 后端代理（#604 的 baseUrl）：后端的
+   OpenAlex 能力只暴露在两处——admin 健康探针（limit=1、只回计数不回
+   记录、要管理员身份）和库级异步 discovery run 管线（建 run→跑批→查
+   hits，绑库绑用户）。两者都不是「同步搜一把拿记录」的形状，为代理
+   而新开后端端点又违背 P2「能力上移」的方向，所以这里带上自己的
+   HTTP 客户端。字段归一化口径抄后端 openalex.py 的 _simplify（摘要
+   从 abstract_inverted_index 重建、DOI 去 https://doi.org/ 前缀、
+   authorships→authors+affiliations），保证两边入库语义一致。
+
+   免 key，走 polite pool：带 UA，配了 mailto 就一并带上（OpenAlex
+   官方建议，能进更快的服务池）。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import type { FetchImpl, SourceAdapter, SourceAuthor, SourceRecord, SourceSearchOptions } from './contract.ts'
+
+export const OPENALEX_BASE = 'https://api.openalex.org'
+
+/** arXiv 论文的 DataCite DOI 前缀（对齐后端 ARXIV_DOI_TEMPLATE）。 */
+const ARXIV_DOI_PREFIX = '10.48550/arxiv.'
+
+const DEFAULT_LIMIT = 10
+
+export interface OpenAlexAdapterOptions {
+  /** 换基址仅供测试/私有镜像；默认官方 API。 */
+  baseUrl?: string
+  /** polite pool 联系邮箱；空则匿名池。 */
+  mailto?: string
+  fetchImpl?: FetchImpl
+}
+
+/** OpenAlex work 原始 JSON（只声明用到的字段）。 */
+interface OpenAlexWork {
+  id?: string
+  title?: string | null
+  publication_year?: number | null
+  publication_date?: string | null
+  doi?: string | null
+  cited_by_count?: number
+  abstract_inverted_index?: Record<string, number[]> | null
+  primary_location?: {
+    landing_page_url?: string | null
+    source?: { display_name?: string | null } | null
+  } | null
+  authorships?: {
+    author?: { display_name?: string | null } | null
+    institutions?: { display_name?: string | null }[] | null
+  }[]
+}
+
+/** 摘要重建：inverted index 是 {token: [位置…]}，按位置排序拼回原文。 */
+function rebuildAbstract(inverted: Record<string, number[]> | null | undefined): string | undefined {
+  if (!inverted || typeof inverted !== 'object') return undefined
+  const tokens: [number, string][] = []
+  for (const [token, positions] of Object.entries(inverted)) {
+    if (!Array.isArray(positions)) continue
+    for (const position of positions) {
+      if (Number.isInteger(position)) tokens.push([position, token])
+    }
+  }
+  if (!tokens.length) return undefined
+  tokens.sort((a, b) => a[0] - b[0])
+  return tokens.map(([, token]) => token).join(' ')
+}
+
+function normalizeAuthors(work: OpenAlexWork): SourceAuthor[] {
+  const authors: SourceAuthor[] = []
+  for (const authorship of work.authorships ?? []) {
+    const name = authorship?.author?.display_name
+    if (!name) continue
+    // 机构去重保序，抄后端 dict.fromkeys 的语义
+    const affiliations = [
+      ...new Set(
+        (authorship.institutions ?? [])
+          .map((inst) => inst?.display_name)
+          .filter((v): v is string => Boolean(v)),
+      ),
+    ]
+    authors.push(affiliations.length ? { name, affiliations } : { name })
+  }
+  return authors
+}
+
+/** 导出仅为可测性：work JSON → SourceRecord 的纯映射。 */
+export function openAlexRecord(work: OpenAlexWork): SourceRecord {
+  // id 统一存短形（W…）：短形能直接拼回 /works/{id}，fetchByIds 才能闭环
+  const id = (work.id ?? '').replace(/^https:\/\/openalex\.org\//, '')
+  const doi = (work.doi ?? '').replace(/^https:\/\/doi\.org\//, '') || undefined
+  // arXiv id 从 DataCite DOI 反推（10.48550/arXiv.<id>），后端同款约定
+  const arxivId = doi?.toLowerCase().startsWith(ARXIV_DOI_PREFIX)
+    ? doi.slice(ARXIV_DOI_PREFIX.length)
+    : undefined
+  const record: SourceRecord = {
+    id,
+    source: 'openalex',
+    title: work.title ?? '',
+    authors: normalizeAuthors(work),
+    year: work.publication_year ?? null,
+    venue: work.primary_location?.source?.display_name ?? null,
+    extra: {
+      citedByCount: work.cited_by_count ?? 0,
+      publishedDate: work.publication_date ?? null,
+      openalexId: work.id ?? null,
+    },
+  }
+  if (doi) record.doi = doi
+  if (arxivId) record.arxivId = arxivId
+  const abstract = rebuildAbstract(work.abstract_inverted_index)
+  if (abstract) record.abstract = abstract
+  const url = work.primary_location?.landing_page_url ?? work.doi ?? undefined
+  if (url) record.url = url
+  return record
+}
+
+export class OpenAlexAdapter implements SourceAdapter {
+  readonly id = 'openalex'
+  readonly label = 'OpenAlex'
+  readonly #baseUrl: string
+  readonly #mailto?: string
+  readonly #fetch: FetchImpl
+
+  constructor(options: OpenAlexAdapterOptions = {}) {
+    this.#baseUrl = (options.baseUrl ?? OPENALEX_BASE).replace(/\/+$/, '')
+    this.#mailto = options.mailto || undefined
+    this.#fetch = options.fetchImpl ?? globalThis.fetch
+  }
+
+  #headers(): Record<string, string> {
+    // polite pool 要求可辨识的 UA；mailto 同时进 UA 与查询参数
+    const contact = this.#mailto ? ` (mailto:${this.#mailto})` : ''
+    return { 'user-agent': `polaris-kernel/0.1${contact}` }
+  }
+
+  #withMailto(url: URL): URL {
+    if (this.#mailto) url.searchParams.set('mailto', this.#mailto)
+    return url
+  }
+
+  async search(query: string, opts?: SourceSearchOptions): Promise<SourceRecord[]> {
+    const limit = Math.max(1, opts?.limit ?? DEFAULT_LIMIT)
+    const url = new URL(`${this.#baseUrl}/works`)
+    url.searchParams.set('search', query)
+    url.searchParams.set('per-page', String(limit))
+    const res = await this.#fetch(this.#withMailto(url), { headers: this.#headers() })
+    if (!res.ok) throw new Error(`openalex: search failed with HTTP ${res.status}`)
+    const data = (await res.json()) as { results?: unknown[] }
+    return (data.results ?? [])
+      .filter((row): row is OpenAlexWork => Boolean(row) && typeof row === 'object')
+      .map(openAlexRecord)
+  }
+
+  async fetchByIds(ids: string[]): Promise<SourceRecord[]> {
+    // 逐个 GET /works/{id}：官方文档记载的形状，404 即「没有这条」跳过；
+    // 其余错误如实抛出——静默吞掉服务端故障会把「源挂了」伪装成「查无此文」
+    const records: SourceRecord[] = []
+    for (const id of ids) {
+      const url = new URL(`${this.#baseUrl}/works/${encodeURIComponent(id)}`)
+      const res = await this.#fetch(this.#withMailto(url), { headers: this.#headers() })
+      if (res.status === 404) continue
+      if (!res.ok) throw new Error(`openalex: fetch ${id} failed with HTTP ${res.status}`)
+      records.push(openAlexRecord((await res.json()) as OpenAlexWork))
+    }
+    return records
+  }
+}

--- a/src/kernel/tests/sources.test.ts
+++ b/src/kernel/tests/sources.test.ts
@@ -1,0 +1,313 @@
+/* 文献源适配器（#646）的单元测试：全程不打真网——fetch 一律注入
+   fixture 替身。CORDIS fixture 按真实 API 响应裁剪（2026-09 对
+   cordis.europa.eu 实测的形状，见 cordis-projects.ts 文件头），
+   OpenAlex fixture 按官方 work 对象形状（与后端 openalex.py 同源）。 */
+import { describe, expect, it } from 'vitest'
+import {
+  CORDIS_BASE,
+  CordisProjectsAdapter,
+  OpenAlexAdapter,
+  buildCordisQuery,
+  cordisDetailRecord,
+  cordisSearchRecord,
+  createKernel,
+  openAlexRecord,
+  sources,
+  type FetchImpl,
+  type SourcesService,
+} from '../src/index.ts'
+
+/* ---------- fetch 替身：记录请求，按 URL 回 fixture ---------- */
+
+interface FakeCall {
+  url: URL
+  headers: Record<string, string>
+}
+
+function fakeFetch(handler: (url: URL) => { status?: number; body?: unknown }): {
+  impl: FetchImpl
+  calls: FakeCall[]
+} {
+  const calls: FakeCall[] = []
+  const impl = (async (input: unknown, init?: RequestInit) => {
+    const url = new URL(String(input))
+    calls.push({ url, headers: { ...((init?.headers as Record<string, string>) ?? {}) } })
+    const { status = 200, body = {} } = handler(url)
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as FetchImpl
+  return { impl, calls }
+}
+
+/* ---------- OpenAlex fixtures ---------- */
+
+const openAlexWork = {
+  id: 'https://openalex.org/W2741809807',
+  title: 'Graphene at wafer scale',
+  publication_year: 2021,
+  publication_date: '2021-03-01',
+  doi: 'https://doi.org/10.48550/arXiv.2103.01234',
+  cited_by_count: 42,
+  abstract_inverted_index: { Graphene: [0], scales: [1], well: [2] },
+  primary_location: {
+    landing_page_url: 'https://arxiv.org/abs/2103.01234',
+    source: { display_name: 'arXiv' },
+  },
+  authorships: [
+    {
+      author: { display_name: 'Ada Lovelace' },
+      // 重复机构必须去重保序
+      institutions: [{ display_name: 'Zhejiang University' }, { display_name: 'Zhejiang University' }],
+    },
+    { author: { display_name: 'Alan Turing' }, institutions: [] },
+    // 没有名字的 authorship 必须被丢弃
+    { author: {}, institutions: [{ display_name: 'Ghost Lab' }] },
+  ],
+}
+
+describe('openAlexRecord mapping', () => {
+  it('normalizes a work into a SourceRecord aligned with backend paper fields', () => {
+    const record = openAlexRecord(openAlexWork)
+    expect(record.id).toBe('W2741809807')
+    expect(record.source).toBe('openalex')
+    expect(record.title).toBe('Graphene at wafer scale')
+    expect(record.year).toBe(2021)
+    expect(record.venue).toBe('arXiv')
+    expect(record.doi).toBe('10.48550/arXiv.2103.01234')
+    // DataCite DOI 前缀反推 arXiv id（与后端 ARXIV_DOI_TEMPLATE 同款约定）
+    expect(record.arxivId).toBe('2103.01234')
+    expect(record.abstract).toBe('Graphene scales well')
+    expect(record.url).toBe('https://arxiv.org/abs/2103.01234')
+    expect(record.authors).toEqual([
+      { name: 'Ada Lovelace', affiliations: ['Zhejiang University'] },
+      { name: 'Alan Turing' },
+    ])
+    expect(record.extra).toMatchObject({ citedByCount: 42, publishedDate: '2021-03-01' })
+  })
+
+  it('leaves optional fields absent when the work has no doi/abstract/url', () => {
+    const record = openAlexRecord({ id: 'https://openalex.org/W1', title: 'Bare' })
+    expect(record.year).toBeNull()
+    expect(record.venue).toBeNull()
+    expect(record.doi).toBeUndefined()
+    expect(record.arxivId).toBeUndefined()
+    expect(record.abstract).toBeUndefined()
+    expect(record.url).toBeUndefined()
+  })
+})
+
+describe('OpenAlexAdapter', () => {
+  it('searches /works with per-page, mailto and an identifying UA', async () => {
+    const { impl, calls } = fakeFetch(() => ({ body: { results: [openAlexWork, null] } }))
+    const adapter = new OpenAlexAdapter({ mailto: 'team@example.com', fetchImpl: impl })
+    const records = await adapter.search('graphene wafers', { limit: 3 })
+
+    expect(records).toHaveLength(1)
+    expect(records[0]!.id).toBe('W2741809807')
+    const call = calls[0]!
+    expect(call.url.origin).toBe('https://api.openalex.org')
+    expect(call.url.pathname).toBe('/works')
+    expect(call.url.searchParams.get('search')).toBe('graphene wafers')
+    expect(call.url.searchParams.get('per-page')).toBe('3')
+    expect(call.url.searchParams.get('mailto')).toBe('team@example.com')
+    expect(call.headers['user-agent']).toContain('polaris-kernel')
+    expect(call.headers['user-agent']).toContain('team@example.com')
+  })
+
+  it('fetchByIds hits /works/{id}, skips 404s and keeps the rest', async () => {
+    const { impl, calls } = fakeFetch((url) =>
+      url.pathname.endsWith('/W404') ? { status: 404 } : { body: openAlexWork },
+    )
+    const adapter = new OpenAlexAdapter({ fetchImpl: impl })
+    const records = await adapter.fetchByIds(['W404', 'W2741809807'])
+
+    expect(records.map((r) => r.id)).toEqual(['W2741809807'])
+    expect(calls.map((c) => c.url.pathname)).toEqual(['/works/W404', '/works/W2741809807'])
+  })
+
+  it('surfaces non-404 failures instead of returning partial silence', async () => {
+    const { impl } = fakeFetch(() => ({ status: 503 }))
+    const adapter = new OpenAlexAdapter({ fetchImpl: impl })
+    await expect(adapter.search('x')).rejects.toThrow(/HTTP 503/)
+    await expect(adapter.fetchByIds(['W1'])).rejects.toThrow(/HTTP 503/)
+  })
+})
+
+/* ---------- CORDIS fixtures（按真实响应裁剪） ---------- */
+
+const cordisSearchHit = {
+  reference: '811715',
+  id: '811715',
+  acronym: 'G4SEMI',
+  programme: [
+    { code: 'H2020', id: 'H2020-EU.3.', title: "PRIORITY 'Societal challenges" },
+    { code: 'H2020', id: 'H2020-EU.2.3.', title: 'INDUSTRIAL LEADERSHIP - Innovation In SMEs' },
+  ],
+  // 列表端点的日期是本地化模板串——年份只能正则抠
+  startDate: '1 {{month_05}} 2018',
+  endDate: '30 {{month_04}} 2020',
+  coordinatedIn: 'Spain',
+  teaser: 'G4SEMI goal is to create added value through Graphene-on-wafer...',
+  rcn: '217599',
+  contentType: 'project',
+  title: 'Graphene for Semiconductor Industry',
+}
+
+const cordisDetail = {
+  contenttype: 'project',
+  rcn: '217599',
+  id: '811715',
+  acronym: 'G4SEMI',
+  teaser: 'G4SEMI goal is to create added value...',
+  objective: 'G4SEMI goal is to create added value through the introduction of Graphene-on-wafer at competitive cost.',
+  title: 'Graphene for Semiconductor Industry',
+  keywords: 'Graphene, CVD Graphene, photosensors',
+  totalCost: '1961125',
+  ecMaxContribution: '1372787.5',
+  startDate: '2018-05-01',
+  endDate: '2020-04-30',
+  status: 'CLOSED',
+  identifiers: { grantDoi: '10.3030/811715' },
+  relations: {
+    associations: [
+      {
+        contenttype: 'organization',
+        legalName: 'GRAPHENEA SEMICONDUCTOR SL',
+        attributes: { type: 'coordinator', ecContribution: '1372787.5' },
+      },
+      { contenttype: 'organization', legalName: 'SOME THIRD PARTY', attributes: { type: 'thirdParty' } },
+      {
+        contenttype: 'programme',
+        code: 'H2020-EU.2.1.',
+        frameworkProgramme: 'H2020',
+        title: 'INDUSTRIAL LEADERSHIP - LEIT',
+        attributes: { type: 'relatedLegalBasis' },
+      },
+      {
+        contenttype: 'programme',
+        code: 'EIC-SMEInst-2018-2020',
+        frameworkProgramme: 'H2020',
+        title: 'SME instrument',
+        attributes: { type: 'relatedTopic' },
+      },
+    ],
+  },
+}
+
+describe('cordis query + mapping', () => {
+  it('builds the documented query language and strips quote characters', () => {
+    expect(buildCordisQuery('graphene wafers')).toBe("contenttype='project' AND 'graphene wafers'")
+    expect(buildCordisQuery("gra'phene   chips")).toBe("contenttype='project' AND 'gra phene chips'")
+  })
+
+  it('maps a search hit: teaser→abstract, year from localized date, programme→venue/extra', () => {
+    const record = cordisSearchRecord(cordisSearchHit)
+    expect(record.id).toBe('811715')
+    expect(record.source).toBe('cordis-projects')
+    expect(record.title).toBe('Graphene for Semiconductor Industry')
+    expect(record.authors).toEqual([]) // 列表响应没有协调机构名
+    expect(record.year).toBe(2018)
+    expect(record.venue).toBe('H2020')
+    expect(record.abstract).toContain('Graphene-on-wafer')
+    expect(record.url).toBe(`${CORDIS_BASE}/project/id/811715`)
+    expect(record.extra).toMatchObject({ acronym: 'G4SEMI', rcn: '217599', coordinatedIn: 'Spain' })
+    expect((record.extra as { programme: unknown[] }).programme).toHaveLength(2)
+  })
+
+  it('maps a detail: objective→abstract, coordinator→authors, grantDoi→doi, funding in extra', () => {
+    const record = cordisDetailRecord(cordisDetail)
+    expect(record.id).toBe('811715')
+    expect(record.abstract).toBe(cordisDetail.objective)
+    expect(record.authors).toEqual([{ name: 'GRAPHENEA SEMICONDUCTOR SL' }])
+    expect(record.doi).toBe('10.3030/811715')
+    expect(record.year).toBe(2018)
+    expect(record.venue).toBe('H2020')
+    expect(record.extra).toMatchObject({
+      funding: { totalCost: '1961125', ecMaxContribution: '1372787.5' },
+      keywords: 'Graphene, CVD Graphene, photosensors',
+      status: 'CLOSED',
+    })
+    // programme 只收 relatedLegalBasis，relatedTopic 不混进来
+    expect((record.extra as { programme: { code: string | null }[] }).programme).toEqual([
+      { code: 'H2020-EU.2.1.', title: 'INDUSTRIAL LEADERSHIP - LEIT' },
+    ])
+  })
+})
+
+describe('CordisProjectsAdapter', () => {
+  it('searches /api/search/results with the query language and json format', async () => {
+    const { impl, calls } = fakeFetch(() => ({
+      body: { status: true, payload: { total: 1, results: [cordisSearchHit] } },
+    }))
+    const adapter = new CordisProjectsAdapter({ fetchImpl: impl })
+    const records = await adapter.search('graphene', { limit: 5 })
+
+    expect(records.map((r) => r.id)).toEqual(['811715'])
+    const call = calls[0]!
+    expect(call.url.origin).toBe('https://cordis.europa.eu')
+    expect(call.url.pathname).toBe('/api/search/results')
+    expect(call.url.searchParams.get('q')).toBe("contenttype='project' AND 'graphene'")
+    expect(call.url.searchParams.get('format')).toBe('json')
+    expect(call.url.searchParams.get('num')).toBe('5')
+    expect(call.url.searchParams.get('page')).toBe('1')
+  })
+
+  it('fetchByIds hits /project/id/{id}?format=json and skips 404s', async () => {
+    const { impl, calls } = fakeFetch((url) =>
+      url.pathname.endsWith('/999999') ? { status: 404 } : { body: cordisDetail },
+    )
+    const adapter = new CordisProjectsAdapter({ fetchImpl: impl })
+    const records = await adapter.fetchByIds(['999999', '811715'])
+
+    expect(records.map((r) => r.id)).toEqual(['811715'])
+    expect(calls.map((c) => c.url.pathname)).toEqual(['/project/id/999999', '/project/id/811715'])
+    expect(calls[1]!.url.searchParams.get('format')).toBe('json')
+  })
+})
+
+/* ---------- sources 插件：注册 / 开关 / 卸载回收 ---------- */
+
+describe('sources plugin', () => {
+  it('registers enabled adapters and filters disabled ones', async () => {
+    const kernel = createKernel({ name: 'sources-test' })
+    await kernel.start()
+    await kernel.ctx.plugin(sources, {
+      adapters: {
+        openalex: { enabled: true, mailto: 'team@example.com' },
+        'cordis-projects': { enabled: false },
+      },
+    })
+
+    const service = kernel.ctx.get('sources') as SourcesService
+    expect(service).toBeTruthy()
+    expect(service.list().map((a) => a.id)).toEqual(['openalex'])
+    expect(service.get('openalex')?.label).toBe('OpenAlex')
+    expect(service.get('cordis-projects')).toBeUndefined()
+    await kernel.stop()
+  })
+
+  it('enables every adapter by default (schemastery fills the config tree)', async () => {
+    const kernel = createKernel({ name: 'sources-defaults' })
+    await kernel.start()
+    await kernel.ctx.plugin(sources, {})
+
+    const service = kernel.ctx.get('sources') as SourcesService
+    expect(service.list().map((a) => a.id)).toEqual(['openalex', 'cordis-projects'])
+    await kernel.stop()
+  })
+
+  it('clears the registry on dispose so stale service refs stop resolving adapters', async () => {
+    const kernel = createKernel({ name: 'sources-dispose' })
+    await kernel.start()
+    await kernel.ctx.plugin(sources, {})
+    const service = kernel.ctx.get('sources') as SourcesService
+    expect(service.list().length).toBeGreaterThan(0)
+
+    await kernel.stop()
+    // effect disposer 清空注册表：旧引用不能再查到已下线的源
+    expect(service.list()).toEqual([])
+    expect(service.get('openalex')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #646. Part of #635 (P2 wave 3, item E4).

Moves the literature source seam into the kernel so sources are installable plugins — the first concrete instance of the everything-is-a-plugin tenet on the literature side.

- `sources/contract.ts`: `SourceAdapter { id, label, search, fetchByIds }` returning normalized `SourceRecord`s (field names aligned with the backend paper schema: authors with optional affiliations, nullable year/venue keys, doi/arxivId/abstract/url, source-specific `extra`); fetch is constructor-injected for tests
- OpenAlex adapter connects directly to api.openalex.org (polite-pool UA + mailto). Investigation first: the backend has no proxyable synchronous search endpoint (only an admin health probe and the async discovery-run pipeline), so proxying via `ctx.get('legacy')` had nothing to call and adding a backend endpoint would run against the capability-migration direction; normalization mirrors the backend client's `_simplify` (inverted-index abstract rebuild, DOI prefix stripping, DataCite-DOI→arXiv-id recovery)
- EU CORDIS projects adapter (no backend counterpart existed) against the live-verified search/detail APIs: objective/teaser→abstract, coordinator legal name→authors, framework programme→venue, grant DOI→doi, funding details in `extra`
- `sources` plugin: per-source schemastery config (enabled/mailto/baseUrl), registry populated inside `ctx.effect` so disposal empties it, `ctx.provide('sources', { list, get })`
- electron-free (mechanical scan covers the new files); desktop config-tree installation deliberately deferred to the marketplace work

13 new kernel tests, no real network (fixtures trimmed from live responses): mapping for both sources, URL/UA assertions, 404-skip vs error propagation, enable filtering, config defaults, registry cleanup after dispose. Kernel suite 40 green; backend/frontend untouched.