### PR TITLE
feat: dual-track parsing adapters with quality-gated selection

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -203,6 +203,19 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("POLARIS_MINERU_CONCURRENCY", "MINERU_CONCURRENCY"),
     )
 
+    # ---- 解析双轨适配器（#650，enrich 链 extract 步骤）----
+    # 自托管 GROBID / MinerU web_api 的服务地址，空 = 该轨不可用（golden 链路不配，
+    # 走纯 PyMuPDF fallback）。注意与上面的 mineru_*（MinerU Cloud 批量接口，版本化
+    # PDF 生命周期用）是两套部署形态，互不复用。
+    grobid_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("POLARIS_GROBID_URL", "GROBID_URL"),
+    )
+    mineru_parse_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("POLARIS_MINERU_URL", "MINERU_URL"),
+    )
+
     # ---- 邮件（密码重置等事务邮件）----
     # smtp_host 为空 = 关闭发信：忘记密码入口在前端自动隐藏（见 /auth/capabilities）。
     smtp_host: str = ""

--- a/src/backend/app/services/citation_graph.py
+++ b/src/backend/app/services/citation_graph.py
@@ -1,7 +1,8 @@
 """引文边构建 + 引文意图分类（#639，设计报告 §10 ③层）。
 
-解析产物就是 pdf_extract 落盘的纯文本全文（没有 GROBID 一类的结构化解析），
-所以这里自带一套确定性的参考文献解析：
+解析产物默认是 pdf_extract 落盘的纯文本全文。#650 起若双轨解析拿到了 GROBID 的
+结构化参考文献（<data_dir>/papers/<id>/references.json，含上下文句），建边优先吃
+它——条目与上下文都比正则可靠；没有该工件时走这里自带的确定性正则解析：
 
 - 定位最后一个 References / Bibliography / 参考文献 标题行，之后是文献表；
 - 编号式（[1] ...）按编号切条目；没有编号则按空行分段兜底；
@@ -141,6 +142,30 @@ def parse_references(full_text: str) -> list[ParsedReference]:
     return refs
 
 
+def _structured_parsed_refs(paper_id: uuid.UUID) -> list[ParsedReference]:
+    """结构化参考文献工件 → ParsedReference 列表（无工件 / 空条目返回 []）。
+
+    序号按工件内顺序 1 起编——GROBID 的条目顺序即文献表顺序，与正则路径的
+    编号语义一致；上下文取首句（建边只存一句，与正则路径同口径）。
+    """
+    from app.services.parsing.select import load_structured_references
+
+    refs: list[ParsedReference] = []
+    for i, entry in enumerate(load_structured_references(str(paper_id)), start=1):
+        raw = " ".join(str(entry.get("raw") or "").split())
+        if not raw:
+            continue
+        contexts = [c for c in entry.get("contexts") or [] if str(c).strip()]
+        refs.append(
+            ParsedReference(
+                index=i,
+                raw=raw[:MAX_REF_RAW_CHARS],
+                context=str(contexts[0])[:MAX_CONTEXT_CHARS] if contexts else None,
+            )
+        )
+    return refs[:MAX_REFERENCES]
+
+
 def _norm_title(text: str) -> str:
     return " ".join(re.sub(r"[^0-9a-z一-鿿]+", " ", text.lower()).split())
 
@@ -181,8 +206,12 @@ async def ensure_citation_edges(
         return 0
     if not paper.full_text_path or not Path(paper.full_text_path).exists():
         return 0
-    full_text = Path(paper.full_text_path).read_text(encoding="utf-8", errors="ignore")
-    refs = parse_references(full_text)
+    # 输入源双轨（#650）：有结构化参考文献工件用它（含上下文句），否则原正则路径。
+    # golden 链路没有该工件，行为不变。
+    refs = _structured_parsed_refs(paper.id)
+    if not refs:
+        full_text = Path(paper.full_text_path).read_text(encoding="utf-8", errors="ignore")
+        refs = parse_references(full_text)
     if not refs:
         return 0
     if existing:

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -201,7 +201,27 @@ async def enrich_paper(
         await emit("extract", "skipped", "no pdf")
     else:
         try:
-            txt_path = await extract_full_text(str(paper_id), Path(paper.pdf_path))
+            # 双轨解析（#650）：配置了 GROBID / MinerU 才走适配器路径（解析→选优→落地
+            # 质检报告与结构化参考文献）；一个都没配时 extract_with_dual_track 内部就是
+            # 原 extract_full_text，行为与旧代码逐字节一致（golden 链路不配 URL）。
+            from app.services.parsing.select import (
+                apply_missing_metadata,
+                dual_track_available,
+                extract_with_dual_track,
+                paper_fallback_metadata,
+            )
+
+            if dual_track_available():
+                outcome = await extract_with_dual_track(
+                    str(paper_id),
+                    Path(paper.pdf_path),
+                    fallback_metadata=paper_fallback_metadata(paper),
+                )
+                txt_path = outcome.txt_path
+                # 只补空字段：resolve 阶段的 arXiv/DOI 权威元数据不被 PDF 解析覆盖
+                apply_missing_metadata(paper, outcome.metadata)
+            else:
+                txt_path = await extract_full_text(str(paper_id), Path(paper.pdf_path))
             paper.full_text_path = str(txt_path)
             await session.commit()
             await emit("extract", "ok")

--- a/src/backend/app/services/parsing/__init__.py
+++ b/src/backend/app/services/parsing/__init__.py
@@ -1,0 +1,1 @@
+"""解析双轨适配器（#650）：契约（contract）、GROBID / MinerU 适配器、质检选优（select）。"""

--- a/src/backend/app/services/parsing/contract.py
+++ b/src/backend/app/services/parsing/contract.py
@@ -1,0 +1,133 @@
+"""解析双轨适配器的公共契约（#650，设计报告 §10 ①层）。
+
+为什么要一层契约：现有解析只有 PyMuPDF 纯文本（literature/pdf_extract.py），
+参考文献靠正则（citation_graph.py）、图表靠启发式裁剪。GROBID / MinerU 这类
+结构化解析服务能给出质量高得多的元数据 / 参考文献 / 正文分节，但它们都是
+可选的外部部署——没配就必须完全退回现状。契约把「解析产物长什么样」与
+「谁解析的」解耦，选优逻辑（select.py）只面向 ParseResult 做逐字段裁决。
+
+适配器为什么不挂 literature/runtime.py 的 AdapterRegistry：那张注册表是检索源
+（search(request) -> SourceSearchPage）的依赖注入容器，按管理员运行时凭据构建、
+带指纹缓存；解析适配器是「PDF 进、结构化产物出」的另一类协议，只有两个成员、
+可用性只看环境变量，硬塞同一注册表只会让两边的类型都变含糊——故独立成小协议。
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+# 元数据字段全集（选优逐字段裁决 / coverage 计分共用）
+METADATA_FIELDS = ("title", "authors", "year", "venue", "doi", "abstract")
+
+# coverage 里「正文够长」的字符数基准：短于此按比例折算（多数论文正文远超此值）
+_BODY_FULL_CHARS = 5000
+
+
+@dataclass(slots=True)
+class ParsedRef:
+    """一条结构化参考文献；contexts 是正文里引用它的上下文句（可空）。"""
+
+    raw: str
+    title: str | None = None
+    authors: list[str] = field(default_factory=list)
+    year: int | None = None
+    doi: str | None = None
+    contexts: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ParsedSection:
+    heading: str
+    text: str
+
+
+@dataclass(slots=True)
+class ParseQuality:
+    coverage: float = 0.0  # 0..1，算法见 compute_coverage
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ParseResult:
+    """一次解析的全部产物。适配器只填自己声明能力对应的字段，其余留空。"""
+
+    metadata: dict[str, Any] = field(default_factory=dict)  # 键取 METADATA_FIELDS 子集
+    references: list[ParsedRef] = field(default_factory=list)
+    sections: list[ParsedSection] = field(default_factory=list)
+    tables: list[dict[str, Any]] = field(default_factory=list)  # 可选：{"markdown"|"html": ...}
+    formulas: list[dict[str, Any]] = field(default_factory=list)  # 可选：{"latex": ...}
+    quality: ParseQuality = field(default_factory=ParseQuality)
+
+    def body_text(self) -> str:
+        """分节拼回正文纯文本（保留标题行，供分段索引 / 检索 / 正则兜底解析用）。"""
+        parts: list[str] = []
+        for section in self.sections:
+            heading = section.heading.strip()
+            text = section.text.strip()
+            if heading and text:
+                parts.append(f"{heading}\n\n{text}")
+            elif heading or text:
+                parts.append(heading or text)
+        return "\n\n".join(parts)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@runtime_checkable
+class ParsingAdapter(Protocol):
+    """解析适配器协议。
+
+    能力旗标声明产物参与哪些字段的选优（select.py 只在旗标为真时才考虑对应产物）；
+    ``available()`` 只看配置、不出网——golden 链路不配 URL 时必须零副作用地判 False；
+    ``parse()`` 出网失败允许抛异常（编排层捕获并记入质检报告），响应拿到但内容
+    不可用时返回 None。
+    """
+
+    name: str
+    provides_metadata: bool
+    provides_references: bool
+    provides_body: bool
+
+    def available(self) -> bool: ...
+
+    async def parse(self, pdf_path: Path) -> ParseResult | None: ...
+
+
+def compute_coverage(
+    result: ParseResult,
+    *,
+    metadata: bool,
+    references: bool,
+    body: bool,
+) -> float:
+    """按适配器声明的能力算覆盖度（各能力等权平均，0..1）。
+
+    - metadata：六个字段里非空的占比；
+    - references：有条目为 1，否则 0；
+    - body：正文字符数对 _BODY_FULL_CHARS 的比例（封顶 1）。
+    确定性纯函数：质检报告里的 coverage 必须可复算、可单测。
+    """
+    parts: list[float] = []
+    if metadata:
+        present = sum(1 for key in METADATA_FIELDS if _non_empty(result.metadata.get(key)))
+        parts.append(present / len(METADATA_FIELDS))
+    if references:
+        parts.append(1.0 if result.references else 0.0)
+    if body:
+        parts.append(min(1.0, len(result.body_text()) / _BODY_FULL_CHARS))
+    if not parts:
+        return 0.0
+    return round(sum(parts) / len(parts), 4)
+
+
+def _non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) > 0
+    return True

--- a/src/backend/app/services/parsing/grobid.py
+++ b/src/backend/app/services/parsing/grobid.py
@@ -1,0 +1,294 @@
+"""GROBID 适配器：POST PDF → TEI XML → 元数据 + 结构化参考文献（+ 引用上下文句）。
+
+自托管 GROBID 的标准接口是 ``POST {base}/api/processFulltextDocument``（multipart
+上传 PDF，返回 TEI XML）。TEI 用标准库 xml.etree 解析——形状很规整，不值得为它
+引入 lxml/BeautifulSoup 这类重依赖。
+
+TEI 里对本模块重要的形状（GROBID 0.7/0.8 实测稳定）：
+- 头部元数据：teiHeader/fileDesc（标题、作者、DOI、刊名、年份）+ profileDesc/abstract；
+- 参考文献：text/back//div[@type="references"]/listBibl/biblStruct，每条带 xml:id
+  （b0、b1…），开 includeRawCitations 时附 note[@type="raw_reference"] 原文；
+- 引用上下文：正文段落里的 <ref type="bibr" target="#b3">[4]</ref> 标记——把段落
+  按句切开，含标记的那句就是该条目的上下文句（确定性，无 LLM）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import httpx
+
+from app.core.config import get_settings
+from app.services.parsing.contract import (
+    ParsedRef,
+    ParsedSection,
+    ParseResult,
+    compute_coverage,
+)
+
+logger = logging.getLogger(__name__)
+
+GROBID_TIMEOUT_SECONDS = 120.0
+# 每条参考文献最多留几句上下文（防个别高被引条目把报告撑爆）
+MAX_CONTEXTS_PER_REF = 5
+MAX_CONTEXT_CHARS = 600
+
+_TEI_NS = "http://www.tei-c.org/ns/1.0"
+_XML_ID = "{http://www.w3.org/XML/1998/namespace}id"
+# 句子边界（与 citation_graph 同口径：英文句读 + 中文句读）
+_SENT_BOUNDARY_RE = re.compile(r"(?<=[.!?。！？])\s+")
+
+
+def _t(tag: str) -> str:
+    return f"{{{_TEI_NS}}}{tag}"
+
+
+def _text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return " ".join("".join(element.itertext()).split())
+
+
+def _person_name(pers: ET.Element) -> str:
+    parts = [_text(el) for el in pers.findall(_t("forename"))]
+    parts.append(_text(pers.find(_t("surname"))))
+    return " ".join(p for p in parts if p)
+
+
+def _authors_of(bibl: ET.Element) -> list[str]:
+    names: list[str] = []
+    for author in bibl.iter(_t("author")):
+        pers = author.find(_t("persName"))
+        if pers is None:
+            continue
+        name = _person_name(pers)
+        if name:
+            names.append(name)
+    return names
+
+
+def _year_of(bibl: ET.Element) -> int | None:
+    for date in bibl.iter(_t("date")):
+        when = date.get("when") or ""
+        m = re.match(r"^(\d{4})", when or _text(date))
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _doi_of(bibl: ET.Element) -> str | None:
+    for idno in bibl.iter(_t("idno")):
+        if (idno.get("type") or "").upper() == "DOI":
+            doi = _text(idno)
+            if doi:
+                return doi
+    return None
+
+
+def _header_metadata(root: ET.Element) -> dict:
+    header = root.find(_t("teiHeader"))
+    if header is None:
+        return {}
+    metadata: dict = {}
+    title = _text(header.find(f"{_t('fileDesc')}/{_t('titleStmt')}/{_t('title')}"))
+    if title:
+        metadata["title"] = title
+    bibl = header.find(f"{_t('fileDesc')}/{_t('sourceDesc')}/{_t('biblStruct')}")
+    if bibl is not None:
+        authors = _authors_of(bibl)
+        if authors:
+            metadata["authors"] = authors
+        year = _year_of(bibl)
+        if year is not None:
+            metadata["year"] = year
+        doi = _doi_of(bibl)
+        if doi:
+            metadata["doi"] = doi
+        # 刊名 / 会议名：monogr/title（期刊 level="j"、专著 level="m"，都可作 venue）
+        venue = _text(bibl.find(f"{_t('monogr')}/{_t('title')}"))
+        if venue and venue != metadata.get("title"):
+            metadata["venue"] = venue
+    abstract = _text(header.find(f"{_t('profileDesc')}/{_t('abstract')}"))
+    if abstract:
+        metadata["abstract"] = abstract
+    return metadata
+
+
+def _paragraph_text_with_refs(p: ET.Element) -> tuple[str, list[tuple[str, int]]]:
+    """段落 → (纯文本, [(参考文献 xml:id, 在文本中的偏移)])。
+
+    偏移记录 <ref type="bibr"> 标记出现的位置，供按句切分后把上下文句挂回条目。
+    """
+    parts: list[str] = []
+    refs: list[tuple[str, int]] = []
+    pos = 0
+
+    def add(text: str) -> None:
+        nonlocal pos
+        parts.append(text)
+        pos += len(text)
+
+    def walk(el: ET.Element) -> None:
+        if el.tag == _t("ref") and (el.get("type") or "") == "bibr":
+            target = (el.get("target") or "").lstrip("#")
+            if target:
+                refs.append((target, pos))
+        if el.text:
+            add(el.text)
+        for child in el:
+            walk(child)
+            if child.tail:
+                add(child.tail)
+
+    walk(p)
+    return "".join(parts), refs
+
+
+def _sentence_spans(text: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    start = 0
+    for m in _SENT_BOUNDARY_RE.finditer(text):
+        spans.append((start, m.start()))
+        start = m.end()
+    spans.append((start, len(text)))
+    return spans
+
+
+def _sections_and_contexts(
+    root: ET.Element,
+) -> tuple[list[ParsedSection], dict[str, list[str]]]:
+    """正文 div → 分节；同时按 <ref type="bibr"> 标记收集每条参考文献的上下文句。"""
+    sections: list[ParsedSection] = []
+    contexts: dict[str, list[str]] = {}
+    body = root.find(f"{_t('text')}/{_t('body')}")
+    if body is None:
+        return sections, contexts
+    for div in body.findall(_t("div")):
+        heading = _text(div.find(_t("head")))
+        paragraphs: list[str] = []
+        for p in div.findall(_t("p")):
+            text, refs = _paragraph_text_with_refs(p)
+            text_norm = " ".join(text.split())
+            if text_norm:
+                paragraphs.append(text_norm)
+            if not refs:
+                continue
+            spans = _sentence_spans(text)
+            for target, offset in refs:
+                sentence = ""
+                for s, e in spans:
+                    if s <= offset < e or (offset >= e and (s, e) == spans[-1]):
+                        sentence = " ".join(text[s:e].split())
+                        break
+                if not sentence:
+                    continue
+                bucket = contexts.setdefault(target, [])
+                sentence = sentence[:MAX_CONTEXT_CHARS]
+                if len(bucket) < MAX_CONTEXTS_PER_REF and sentence not in bucket:
+                    bucket.append(sentence)
+        if heading or paragraphs:
+            sections.append(ParsedSection(heading=heading, text="\n\n".join(paragraphs)))
+    return sections, contexts
+
+
+def _compose_raw(title: str | None, authors: list[str], year: int | None) -> str:
+    pieces = []
+    if authors:
+        pieces.append(", ".join(authors))
+    if year is not None:
+        pieces.append(f"({year})")
+    if title:
+        pieces.append(title)
+    return ". ".join(pieces)
+
+
+def _references(root: ET.Element, contexts: dict[str, list[str]]) -> list[ParsedRef]:
+    refs: list[ParsedRef] = []
+    back = root.find(f"{_t('text')}/{_t('back')}")
+    if back is None:
+        return refs
+    for div in back.iter(_t("div")):
+        if (div.get("type") or "") != "references":
+            continue
+        for bibl in div.iter(_t("biblStruct")):
+            rid = bibl.get(_XML_ID) or ""
+            title = None
+            analytic_title = bibl.find(f"{_t('analytic')}/{_t('title')}")
+            monogr_title = bibl.find(f"{_t('monogr')}/{_t('title')}")
+            title = _text(analytic_title) or _text(monogr_title) or None
+            authors = _authors_of(bibl)
+            year = _year_of(bibl)
+            raw = ""
+            for note in bibl.findall(_t("note")):
+                if (note.get("type") or "") == "raw_reference":
+                    raw = _text(note)
+                    break
+            raw = raw or _compose_raw(title, authors, year)
+            if not raw:
+                continue  # 完全空的条目（解析噪声）不进产物
+            refs.append(
+                ParsedRef(
+                    raw=raw,
+                    title=title,
+                    authors=authors,
+                    year=year,
+                    doi=_doi_of(bibl),
+                    contexts=list(contexts.get(rid, [])),
+                )
+            )
+    return refs
+
+
+def parse_tei(tei_xml: str) -> ParseResult | None:
+    """TEI XML → ParseResult（纯函数，测试用 fixture 直接锁这里的映射）。"""
+    try:
+        root = ET.fromstring(tei_xml)
+    except ET.ParseError:
+        logger.warning("GROBID returned unparseable TEI", exc_info=True)
+        return None
+    sections, contexts = _sections_and_contexts(root)
+    result = ParseResult(
+        metadata=_header_metadata(root),
+        references=_references(root, contexts),
+        sections=sections,
+    )
+    if not result.metadata and not result.references and not result.sections:
+        return None  # 空响应视同解析失败，让选优走 fallback
+    result.quality.coverage = compute_coverage(
+        result, metadata=True, references=True, body=False
+    )
+    return result
+
+
+class GrobidAdapter:
+    """GROBID 解析适配器（POLARIS_GROBID_URL 配置，空 = 不可用）。
+
+    provides_body=False：TEI 正文分节只用来定位引用上下文句；正文来源的选优只在
+    「MinerU / 现有 PyMuPDF 全文」之间裁决（见 select.py 的裁决矩阵），GROBID 的
+    正文抽取本就不是它的强项，不参与竞争。
+    """
+
+    name = "grobid"
+    provides_metadata = True
+    provides_references = True
+    provides_body = False
+
+    def available(self) -> bool:
+        return bool(get_settings().grobid_url.strip())
+
+    async def parse(self, pdf_path: Path) -> ParseResult | None:
+        base = get_settings().grobid_url.strip().rstrip("/")
+        content = await asyncio.to_thread(pdf_path.read_bytes)
+        async with httpx.AsyncClient(timeout=GROBID_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{base}/api/processFulltextDocument",
+                files={"input": (pdf_path.name, content, "application/pdf")},
+                # 要 raw_reference 原文：citation_graph 的条目原文口径与正则路径一致
+                data={"includeRawCitations": "1"},
+            )
+            response.raise_for_status()
+        return parse_tei(response.text)

--- a/src/backend/app/services/parsing/mineru.py
+++ b/src/backend/app/services/parsing/mineru.py
@@ -1,0 +1,150 @@
+"""MinerU（自托管 web api）适配器：POST PDF → markdown → 分节 / 表格 / 公式。
+
+与 services/mineru.py（MinerU Cloud：签名 URL 上传 + 批次轮询，供版本化 PDF
+生命周期用）是两套部署形态——这里对接的是 MinerU 仓库 projects/web_api 那类
+自托管单次解析端点：``POST {base}/file_parse``（multipart 上传 PDF），响应 JSON
+里带 markdown 正文。
+
+响应形状按 MinerU web_api 文档/源码约定为 {"md_content": "..."}；不同版本键名
+有出入（markdown / data.md_content 也见过），_markdown_of 按候选键顺序取第一个
+命中的。**形状映射由 tests/fixtures/mineru_web_sample.json 锁定**（不打真网），
+上游改形状时改 fixture + 候选键即可。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.core.config import get_settings
+from app.services.parsing.contract import (
+    ParsedSection,
+    ParseResult,
+    compute_coverage,
+)
+
+logger = logging.getLogger(__name__)
+
+MINERU_TIMEOUT_SECONDS = 300.0
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_TABLE_LINE_RE = re.compile(r"^\s*\|.*\|\s*$")
+_HTML_TABLE_RE = re.compile(r"<table\b.*?</table>", re.IGNORECASE | re.DOTALL)
+_FORMULA_RE = re.compile(r"\$\$(.+?)\$\$", re.DOTALL)
+
+
+def _markdown_of(payload: Any) -> str:
+    """响应 JSON → markdown 文本；候选键顺序即优先级（fixture 锁定）。"""
+    if isinstance(payload, str):
+        return payload
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("md_content", "markdown", "md"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    nested = payload.get("data") or payload.get("result")
+    if isinstance(nested, (dict, str)):
+        return _markdown_of(nested)
+    return ""
+
+
+def _extract_tables(markdown: str) -> list[dict[str, Any]]:
+    tables: list[dict[str, Any]] = [
+        {"html": block.strip()} for block in _HTML_TABLE_RE.findall(markdown)
+    ]
+    block: list[str] = []
+    for line in [*markdown.splitlines(), ""]:
+        if _TABLE_LINE_RE.match(line):
+            block.append(line.strip())
+            continue
+        if len(block) >= 2:  # 单行竖线多半是正文噪声，不算表
+            tables.append({"markdown": "\n".join(block)})
+        block = []
+    return tables
+
+
+def _extract_formulas(markdown: str) -> list[dict[str, Any]]:
+    formulas: list[dict[str, Any]] = []
+    for latex in _FORMULA_RE.findall(markdown):
+        latex = latex.strip()
+        if latex:
+            formulas.append({"latex": latex})
+    return formulas
+
+
+def parse_mineru_markdown(markdown: str) -> ParseResult | None:
+    """markdown → ParseResult（纯函数，fixture 锁映射）。
+
+    分节按 ATX 标题切；首个标题前的内容归入无标题节。表格 / 公式**另列**而不从
+    节文本里抠掉——正文纯文本要保持完整（分段索引 / 正则参考文献兜底都吃它），
+    tables / formulas 只是结构化补充。
+    """
+    markdown = markdown.replace("\r\n", "\n").strip()
+    if not markdown:
+        return None
+    sections: list[ParsedSection] = []
+    heading = ""
+    lines: list[str] = []
+
+    def flush() -> None:
+        text = "\n".join(lines).strip()
+        if heading or text:
+            sections.append(ParsedSection(heading=heading, text=text))
+
+    for line in markdown.splitlines():
+        m = _HEADING_RE.match(line)
+        if m:
+            flush()
+            heading = m.group(2).strip()
+            lines = []
+        else:
+            lines.append(line)
+    flush()
+    result = ParseResult(
+        sections=sections,
+        tables=_extract_tables(markdown),
+        formulas=_extract_formulas(markdown),
+    )
+    if not result.body_text():
+        return None
+    result.quality.coverage = compute_coverage(
+        result, metadata=False, references=False, body=True
+    )
+    return result
+
+
+class MineruWebAdapter:
+    """MinerU 自托管解析适配器（POLARIS_MINERU_URL 配置，空 = 不可用）。"""
+
+    name = "mineru"
+    provides_metadata = False
+    provides_references = False
+    provides_body = True
+
+    def available(self) -> bool:
+        return bool(get_settings().mineru_parse_url.strip())
+
+    async def parse(self, pdf_path: Path) -> ParseResult | None:
+        base = get_settings().mineru_parse_url.strip().rstrip("/")
+        content = await asyncio.to_thread(pdf_path.read_bytes)
+        async with httpx.AsyncClient(timeout=MINERU_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{base}/file_parse",
+                files={"file": (pdf_path.name, content, "application/pdf")},
+            )
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = response.text  # 个别部署直接回 markdown 文本
+        markdown = _markdown_of(payload)
+        if not markdown:
+            logger.warning("MinerU web api returned no markdown content")
+            return None
+        return parse_mineru_markdown(markdown)

--- a/src/backend/app/services/parsing/select.py
+++ b/src/backend/app/services/parsing/select.py
@@ -1,0 +1,312 @@
+"""双轨解析的质检选优 + 编排 + 产物落盘（#650）。
+
+裁决矩阵（逐字段，确定性）：
+- metadata：GROBID 有值的字段用 GROBID，缺的字段回退现有值（arXiv/DOI 解析或
+  PyMuPDF 路径已有的元数据）；
+- references：GROBID 可用且条目数 > 0 → 用结构化条目（落 references.json，
+  citation_graph 优先吃它）；否则不落文件，引文建边保持原正则路径；
+- body/sections：MinerU 可用且正文非空 → 用 MinerU 分节正文；否则用现有
+  PyMuPDF 全文。
+
+产物全部是文件工件，挂在既有的 <data_dir>/papers/<paper_id>/ 目录下（figures/
+已是先例，论文删除时整目录 rmtree，见 services/papers.py）——不新增表、不加列：
+- parse_quality.json：per-document 质检报告（两轨可用性 / coverage / 错误 / 裁决）；
+- references.json：结构化参考文献（含上下文句）。
+
+golden 保全：两个适配器都没配 URL 时，编排入口 extract_with_dual_track 直接调用
+原 extract_full_text 并且不写任何附加文件——与现状逐字节一致。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.services.parsing.contract import (
+    METADATA_FIELDS,
+    ParseResult,
+    ParsingAdapter,
+    _non_empty,
+)
+from app.services.parsing.grobid import GrobidAdapter
+from app.services.parsing.mineru import MineruWebAdapter
+
+logger = logging.getLogger(__name__)
+
+QUALITY_REPORT_VERSION = 1
+REFERENCES_FILE_VERSION = 1
+
+
+def parsing_adapters() -> tuple[ParsingAdapter, ParsingAdapter]:
+    return (GrobidAdapter(), MineruWebAdapter())
+
+
+def dual_track_available() -> bool:
+    """任一解析适配器配置了 URL？（只看配置，不出网。）"""
+    return any(adapter.available() for adapter in parsing_adapters())
+
+
+def parse_quality_path(paper_id: str) -> Path:
+    from app.services.literature.pdf_extract import papers_dir
+
+    return papers_dir() / str(paper_id) / "parse_quality.json"
+
+
+def structured_references_path(paper_id: str) -> Path:
+    from app.services.literature.pdf_extract import papers_dir
+
+    return papers_dir() / str(paper_id) / "references.json"
+
+
+def load_structured_references(paper_id: str) -> list[dict[str, Any]]:
+    """读结构化参考文献工件；没有 / 读不动一律空列表（调用方回退正则路径）。"""
+    path = structured_references_path(paper_id)
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("unreadable references.json for paper %s", paper_id, exc_info=True)
+        return []
+    refs = payload.get("references") if isinstance(payload, dict) else None
+    return [item for item in refs or [] if isinstance(item, dict) and item.get("raw")]
+
+
+@dataclass(slots=True)
+class SelectionOutcome:
+    """逐字段裁决结果 + 质检报告（编排层据此落盘）。"""
+
+    body: str
+    metadata: dict[str, Any]
+    references: list[dict[str, Any]] | None  # None = 保持正则 fallback，不落文件
+    quality_report: dict[str, Any]
+
+
+def _adapter_report(
+    adapter: ParsingAdapter, result: ParseResult | None, errors: list[str]
+) -> dict[str, Any]:
+    return {
+        "available": adapter.available(),
+        "parsed": result is not None,
+        "coverage": result.quality.coverage if result is not None else None,
+        "errors": errors,
+    }
+
+
+def select_parse(
+    *,
+    grobid: ParseResult | None,
+    mineru: ParseResult | None,
+    fallback_text: str,
+    fallback_metadata: dict[str, Any] | None = None,
+    grobid_errors: list[str] | None = None,
+    mineru_errors: list[str] | None = None,
+    grobid_adapter: ParsingAdapter | None = None,
+    mineru_adapter: ParsingAdapter | None = None,
+) -> SelectionOutcome:
+    """逐字段裁决（纯函数，裁决矩阵见模块 docstring；三种可用性组合都在单测里锁死）。"""
+    grobid_adapter = grobid_adapter or GrobidAdapter()
+    mineru_adapter = mineru_adapter or MineruWebAdapter()
+
+    # metadata：GROBID 有值的字段优先，缺字段回退现有值
+    metadata = {key: (fallback_metadata or {}).get(key) for key in METADATA_FIELDS}
+    metadata_decision = "fallback"
+    if grobid is not None and grobid_adapter.provides_metadata:
+        used = False
+        for key in METADATA_FIELDS:
+            value = grobid.metadata.get(key)
+            if _non_empty(value):
+                metadata[key] = value
+                used = True
+        if used:
+            metadata_decision = "grobid"
+
+    # references：GROBID 条目数 > 0 才换轨，否则保持正则 fallback
+    references: list[dict[str, Any]] | None = None
+    references_decision = "fallback"
+    if grobid is not None and grobid_adapter.provides_references and grobid.references:
+        references = [
+            {
+                "raw": ref.raw,
+                "title": ref.title,
+                "authors": ref.authors,
+                "year": ref.year,
+                "doi": ref.doi,
+                "contexts": ref.contexts,
+            }
+            for ref in grobid.references
+        ]
+        references_decision = "grobid"
+
+    # body：MinerU 正文非空才换轨，否则用现有全文
+    body = fallback_text
+    body_decision = "fallback"
+    if mineru is not None and mineru_adapter.provides_body:
+        mineru_body = mineru.body_text()
+        if mineru_body:
+            body = mineru_body
+            body_decision = "mineru"
+
+    report = {
+        "version": QUALITY_REPORT_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "adapters": {
+            grobid_adapter.name: _adapter_report(grobid_adapter, grobid, grobid_errors or []),
+            mineru_adapter.name: _adapter_report(mineru_adapter, mineru, mineru_errors or []),
+        },
+        "decisions": {
+            "metadata": metadata_decision,
+            "references": references_decision,
+            "body": body_decision,
+        },
+        "counts": {
+            "references": len(references or []),
+            "sections": len(mineru.sections) if mineru is not None else 0,
+            "tables": len(mineru.tables) if mineru is not None else 0,
+            "formulas": len(mineru.formulas) if mineru is not None else 0,
+            "body_chars": len(body),
+        },
+    }
+    return SelectionOutcome(
+        body=body, metadata=metadata, references=references, quality_report=report
+    )
+
+
+@dataclass(slots=True)
+class DualTrackOutcome:
+    txt_path: Path
+    metadata: dict[str, Any] = field(default_factory=dict)
+    quality_report: dict[str, Any] | None = None
+    used_adapters: bool = False
+
+
+async def _run_adapter(
+    adapter: ParsingAdapter, pdf_path: Path
+) -> tuple[ParseResult | None, list[str]]:
+    """单轨解析，失败不抛（批处理语义：坏一轨不拖垮另一轨），错误进质检报告。"""
+    if not adapter.available():
+        return None, []
+    try:
+        result = await adapter.parse(pdf_path)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — 外部服务隔离，错误只进报告
+        logger.warning("%s parse failed for %s", adapter.name, pdf_path, exc_info=True)
+        return None, [f"{type(exc).__name__}: {exc}"[:300]]
+    if result is None:
+        return None, ["EMPTY_RESULT"]
+    return result, []
+
+
+async def extract_with_dual_track(
+    paper_id: str,
+    pdf_path: Path,
+    *,
+    fallback_metadata: dict[str, Any] | None = None,
+) -> DualTrackOutcome:
+    """enrich 链 extract 步骤的双轨入口：适配器可用 → 双轨解析 → 选优 → 落地。
+
+    两轨都没配时**逐字节等价**于原 extract_full_text：写同一份 txt、不产生任何
+    附加文件（golden 链路不配 URL，走的就是这条路）。
+    """
+    from app.services.literature.pdf_extract import extract_full_text, sanitize_text
+
+    # fallback 全文永远先算：它既是 body 的兜底，也保证任何一轨失败都有可用产物
+    txt_path = await extract_full_text(paper_id, pdf_path)
+    grobid_adapter, mineru_adapter = parsing_adapters()
+    if not grobid_adapter.available() and not mineru_adapter.available():
+        return DualTrackOutcome(txt_path=txt_path)
+
+    fallback_text = txt_path.read_text(encoding="utf-8", errors="ignore")
+    grobid_result, grobid_errors = await _run_adapter(grobid_adapter, pdf_path)
+    mineru_result, mineru_errors = await _run_adapter(mineru_adapter, pdf_path)
+    outcome = select_parse(
+        grobid=grobid_result,
+        mineru=mineru_result,
+        fallback_text=fallback_text,
+        fallback_metadata=fallback_metadata,
+        grobid_errors=grobid_errors,
+        mineru_errors=mineru_errors,
+        grobid_adapter=grobid_adapter,
+        mineru_adapter=mineru_adapter,
+    )
+
+    if outcome.quality_report["decisions"]["body"] == "mineru":
+        txt_path.write_text(sanitize_text(outcome.body), encoding="utf-8")
+
+    refs_path = structured_references_path(paper_id)
+    refs_path.parent.mkdir(parents=True, exist_ok=True)
+    if outcome.references is not None:
+        refs_path.write_text(
+            json.dumps(
+                {
+                    "version": REFERENCES_FILE_VERSION,
+                    "source": "grobid",
+                    "references": outcome.references,
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+    else:
+        # 这次拿不到结构化条目就清掉旧文件：引文建边宁可用当前全文重跑正则，
+        # 也不能吃上一版 PDF 的陈旧结构化条目
+        refs_path.unlink(missing_ok=True)
+
+    quality_path = parse_quality_path(paper_id)
+    quality_path.write_text(
+        json.dumps(outcome.quality_report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return DualTrackOutcome(
+        txt_path=txt_path,
+        metadata=outcome.metadata,
+        quality_report=outcome.quality_report,
+        used_adapters=True,
+    )
+
+
+def paper_fallback_metadata(paper: Any) -> dict[str, Any]:
+    """Paper 行当前元数据 → 选优的 fallback 值（authors 统一成名字列表）。"""
+    names: list[str] = []
+    for item in paper.authors or []:
+        name = item.get("name") if isinstance(item, dict) else item
+        if name and str(name).strip():
+            names.append(str(name).strip())
+    return {
+        "title": paper.title,
+        "authors": names,
+        "year": paper.year,
+        "venue": paper.venue,
+        "doi": paper.doi,
+        "abstract": paper.abstract,
+    }
+
+
+def apply_missing_metadata(paper: Any, metadata: dict[str, Any]) -> bool:
+    """把裁决后的元数据写回 Paper 行——**只补空字段**。
+
+    完整裁决产物在质检报告里；写回时不覆盖已有值，因为 resolve 阶段来自
+    arXiv/DOI 的权威元数据不该被 PDF 解析结果顶掉。返回是否有改动。
+    """
+    changed = False
+    if not (paper.abstract or "").strip() and _non_empty(metadata.get("abstract")):
+        paper.abstract = str(metadata["abstract"])
+        changed = True
+    if paper.year is None and isinstance(metadata.get("year"), int):
+        paper.year = metadata["year"]
+        changed = True
+    if not (paper.venue or "").strip() and _non_empty(metadata.get("venue")):
+        paper.venue = str(metadata["venue"])[:255]
+        changed = True
+    if not (paper.doi or "").strip() and _non_empty(metadata.get("doi")):
+        paper.doi = str(metadata["doi"])[:255]
+        changed = True
+    if not paper.authors and _non_empty(metadata.get("authors")):
+        paper.authors = [{"name": str(name)} for name in metadata["authors"]]
+        changed = True
+    return changed

--- a/src/backend/tests/fixtures/grobid_tei_sample.xml
+++ b/src/backend/tests/fixtures/grobid_tei_sample.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt><title level="a" type="main">Deep Agent Survey</title></titleStmt>
+      <sourceDesc>
+        <biblStruct>
+          <analytic>
+            <author><persName><forename type="first">Alice</forename><surname>Zhang</surname></persName></author>
+            <author><persName><forename type="first">Bob</forename><surname>Li</surname></persName></author>
+            <idno type="DOI">10.1234/agent.survey</idno>
+          </analytic>
+          <monogr>
+            <title level="j">Journal of AI Research</title>
+            <imprint><date type="published" when="2024-05-01"/></imprint>
+          </monogr>
+        </biblStruct>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <abstract><div><p>We survey deep agents and their planning loops.</p></div></abstract>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <head>Introduction</head>
+        <p>Early systems established the paradigm of tool-augmented reasoning <ref type="bibr" target="#b0">[1]</ref>. We follow the planning method of <ref type="bibr" target="#b1">[2]</ref> to build our agent loop.</p>
+      </div>
+      <div>
+        <head>Experiments</head>
+        <p>Our results are compared against the strong baseline of <ref type="bibr" target="#b2">[3]</ref>. This closing sentence cites nothing.</p>
+      </div>
+    </body>
+    <back>
+      <div type="references">
+        <listBibl>
+          <biblStruct xml:id="b0">
+            <analytic>
+              <title level="a" type="main">Foundations of Tool-Augmented Reasoning Systems</title>
+              <author><persName><forename type="first">Alice</forename><surname>Zhang</surname></persName></author>
+            </analytic>
+            <monogr><title level="j">Journal of AI</title><imprint><date type="published" when="2020"/></imprint></monogr>
+            <note type="raw_reference">Alice Zhang. Foundations of Tool-Augmented Reasoning Systems. Journal of AI, 2020.</note>
+          </biblStruct>
+          <biblStruct xml:id="b1">
+            <analytic>
+              <title level="a" type="main">Planning With Language Models For Agent Tasks</title>
+              <author><persName><forename type="first">Bob</forename><surname>Li</surname></persName></author>
+              <idno type="DOI">10.5555/planning</idno>
+            </analytic>
+            <monogr><title level="m">NeurIPS</title><imprint><date when="2021-12-06"/></imprint></monogr>
+          </biblStruct>
+          <biblStruct xml:id="b2">
+            <monogr>
+              <title level="m">A Strong Baseline For Agent Benchmarks</title>
+              <author><persName><forename type="first">Carol</forename><surname>Wei</surname></persName></author>
+              <imprint><date when="2022"/></imprint>
+            </monogr>
+          </biblStruct>
+        </listBibl>
+      </div>
+    </back>
+  </text>
+</TEI>

--- a/src/backend/tests/fixtures/mineru_web_sample.json
+++ b/src/backend/tests/fixtures/mineru_web_sample.json
@@ -1,0 +1,3 @@
+{
+  "md_content": "# Deep Agent Survey\n\nIntro paragraph before any numbered heading.\n\n## Method\n\nWe follow a planning method for agent loops.\n\n$$E = mc^2$$\n\n## Results\n\n| metric | value |\n| --- | --- |\n| score | 0.9 |\n\n<table><tr><td>html cell</td></tr></table>\n\nClosing remarks after the table.\n"
+}

--- a/src/backend/tests/test_parsing_adapters.py
+++ b/src/backend/tests/test_parsing_adapters.py
@@ -1,0 +1,458 @@
+"""解析双轨适配器（#650）：TEI/MinerU fixture 映射、选优裁决矩阵、
+适配器不可用 = 现状逐字节不变、citation_graph 双输入源等价。全部 fixture，不打真网。"""
+
+import json
+import uuid
+from pathlib import Path
+
+import pymupdf
+import respx
+from httpx import Response
+from sqlalchemy import select
+
+from app.core.config import get_settings
+from app.core.db import get_sessionmaker
+from app.models.paper import new_paper
+from app.models.paper_citation import PaperCitation
+from app.services.citation_graph import ensure_citation_edges
+from app.services.parsing.contract import ParsedRef, ParsedSection, ParseResult
+from app.services.parsing.grobid import GrobidAdapter, parse_tei
+from app.services.parsing.mineru import MineruWebAdapter, _markdown_of, parse_mineru_markdown
+from app.services.parsing.select import (
+    apply_missing_metadata,
+    dual_track_available,
+    extract_with_dual_track,
+    load_structured_references,
+    parse_quality_path,
+    select_parse,
+    structured_references_path,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+TEI_SAMPLE = (FIXTURES / "grobid_tei_sample.xml").read_text(encoding="utf-8")
+MINERU_SAMPLE = json.loads((FIXTURES / "mineru_web_sample.json").read_text(encoding="utf-8"))
+
+# 与 test_citation_intent.FULL_TEXT 同构的正则可解析全文（编号文献表 + 正文 [n] 标记）
+FULL_TEXT = """Deep Agent Survey
+
+Introduction
+
+Early systems established the paradigm of tool-augmented reasoning [1].
+We follow the planning method of [2] to build our agent loop.
+Our results are compared against the strong baseline of [3].
+
+References
+
+[1] Alice Zhang. Foundations of Tool-Augmented Reasoning Systems. Journal of AI, 2020.
+[2] Bob Li. Planning With Language Models For Agent Tasks. NeurIPS, 2021.
+[3] Carol Wei. A Strong Baseline For Agent Benchmarks. ICML, 2022.
+"""
+
+
+def _make_pdf(tmp_path: Path, text: str = "hello parsing adapters") -> Path:
+    pdf_path = tmp_path / "sample.pdf"
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    doc.save(pdf_path)
+    doc.close()
+    return pdf_path
+
+
+# ---- GROBID：TEI fixture → ParseResult 映射 ----
+
+
+def test_grobid_tei_mapping():
+    result = parse_tei(TEI_SAMPLE)
+    assert result is not None
+    assert result.metadata["title"] == "Deep Agent Survey"
+    assert result.metadata["authors"] == ["Alice Zhang", "Bob Li"]
+    assert result.metadata["year"] == 2024
+    assert result.metadata["venue"] == "Journal of AI Research"
+    assert result.metadata["doi"] == "10.1234/agent.survey"
+    assert "survey deep agents" in result.metadata["abstract"]
+
+    assert [s.heading for s in result.sections] == ["Introduction", "Experiments"]
+    assert "planning method" in result.sections[0].text
+
+    assert len(result.references) == 3
+    # raw_reference 原文优先；没有时由 作者/(年份)/标题 组装
+    assert result.references[0].raw.startswith("Alice Zhang. Foundations")
+    assert result.references[1].raw == (
+        "Bob Li. (2021). Planning With Language Models For Agent Tasks"
+    )
+    assert result.references[1].doi == "10.5555/planning"
+    assert result.references[2].title == "A Strong Baseline For Agent Benchmarks"
+    assert result.references[2].year == 2022
+    # 上下文句：含 <ref type="bibr"> 标记的整句
+    assert result.references[0].contexts == [
+        "Early systems established the paradigm of tool-augmented reasoning [1]."
+    ]
+    assert result.references[1].contexts == [
+        "We follow the planning method of [2] to build our agent loop."
+    ]
+    assert result.references[2].contexts == [
+        "Our results are compared against the strong baseline of [3]."
+    ]
+    assert 0 < result.quality.coverage <= 1
+
+
+def test_grobid_unparseable_tei_returns_none():
+    assert parse_tei("this is not xml <<<") is None
+    assert parse_tei("<TEI xmlns='http://www.tei-c.org/ns/1.0'></TEI>") is None
+
+
+@respx.mock
+async def test_grobid_adapter_posts_pdf(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_settings(), "grobid_url", "http://grobid.test", raising=False)
+    route = respx.post("http://grobid.test/api/processFulltextDocument").mock(
+        return_value=Response(200, text=TEI_SAMPLE)
+    )
+    result = await GrobidAdapter().parse(_make_pdf(tmp_path))
+    assert route.called
+    assert result is not None and result.metadata["title"] == "Deep Agent Survey"
+
+
+# ---- MinerU：markdown fixture → ParseResult 映射 ----
+
+
+def test_mineru_markdown_mapping():
+    result = parse_mineru_markdown(_markdown_of(MINERU_SAMPLE))
+    assert result is not None
+    assert [s.heading for s in result.sections] == ["Deep Agent Survey", "Method", "Results"]
+    assert "Intro paragraph" in result.sections[0].text
+    body = result.body_text()
+    assert body.startswith("Deep Agent Survey")
+    assert "Closing remarks" in body
+    # 表格：markdown 竖线表 + html 表都收；公式收 $$..$$
+    kinds = sorted(k for t in result.tables for k in t)
+    assert kinds == ["html", "markdown"]
+    assert result.formulas == [{"latex": "E = mc^2"}]
+    assert 0 < result.quality.coverage <= 1
+
+
+def test_mineru_payload_shapes():
+    # 不同部署的响应键名（fixture 锁定的候选键顺序）
+    assert _markdown_of({"md_content": "# A"}) == "# A"
+    assert _markdown_of({"markdown": "# B"}) == "# B"
+    assert _markdown_of({"data": {"md_content": "# C"}}) == "# C"
+    assert _markdown_of("# raw text") == "# raw text"
+    assert _markdown_of({"other": 1}) == ""
+    assert parse_mineru_markdown("") is None
+
+
+@respx.mock
+async def test_mineru_adapter_posts_pdf(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_settings(), "mineru_parse_url", "http://mineru.test", raising=False)
+    route = respx.post("http://mineru.test/file_parse").mock(
+        return_value=Response(200, json=MINERU_SAMPLE)
+    )
+    result = await MineruWebAdapter().parse(_make_pdf(tmp_path))
+    assert route.called
+    assert result is not None and result.body_text().startswith("Deep Agent Survey")
+
+
+# ---- 选优裁决矩阵（三种可用性组合） ----
+
+_GROBID_RESULT = ParseResult(
+    metadata={"title": "G Title", "year": 2024, "doi": "10.1/x"},  # 缺 venue/abstract/authors
+    references=[ParsedRef(raw="G ref one", contexts=["cited here."])],
+)
+_MINERU_RESULT = ParseResult(sections=[ParsedSection(heading="H", text="mineru body")])
+_FALLBACK_META = {
+    "title": "Fallback Title",
+    "authors": ["F Author"],
+    "year": 2000,
+    "venue": "Fallback Venue",
+    "doi": None,
+    "abstract": "fallback abstract",
+}
+
+
+def test_select_both_tracks():
+    outcome = select_parse(
+        grobid=_GROBID_RESULT,
+        mineru=_MINERU_RESULT,
+        fallback_text="fallback full text",
+        fallback_metadata=_FALLBACK_META,
+    )
+    # metadata：GROBID 有值的字段用 GROBID，缺的字段回退现有值
+    assert outcome.metadata["title"] == "G Title"
+    assert outcome.metadata["year"] == 2024
+    assert outcome.metadata["doi"] == "10.1/x"
+    assert outcome.metadata["venue"] == "Fallback Venue"
+    assert outcome.metadata["abstract"] == "fallback abstract"
+    assert outcome.metadata["authors"] == ["F Author"]
+    assert outcome.references == [
+        {
+            "raw": "G ref one",
+            "title": None,
+            "authors": [],
+            "year": None,
+            "doi": None,
+            "contexts": ["cited here."],
+        }
+    ]
+    assert outcome.body == "H\n\nmineru body"
+    assert outcome.quality_report["decisions"] == {
+        "metadata": "grobid",
+        "references": "grobid",
+        "body": "mineru",
+    }
+    assert outcome.quality_report["counts"]["references"] == 1
+
+
+def test_select_grobid_only():
+    outcome = select_parse(
+        grobid=_GROBID_RESULT,
+        mineru=None,
+        fallback_text="fallback full text",
+        fallback_metadata=_FALLBACK_META,
+    )
+    assert outcome.body == "fallback full text"
+    assert outcome.references is not None
+    assert outcome.quality_report["decisions"] == {
+        "metadata": "grobid",
+        "references": "grobid",
+        "body": "fallback",
+    }
+
+
+def test_select_mineru_only():
+    outcome = select_parse(
+        grobid=None,
+        mineru=_MINERU_RESULT,
+        fallback_text="fallback full text",
+        fallback_metadata=_FALLBACK_META,
+    )
+    assert outcome.metadata["title"] == "Fallback Title"
+    assert outcome.references is None  # 引文建边保持正则路径
+    assert outcome.body == "H\n\nmineru body"
+    assert outcome.quality_report["decisions"] == {
+        "metadata": "fallback",
+        "references": "fallback",
+        "body": "mineru",
+    }
+
+
+def test_select_grobid_zero_references_falls_back():
+    outcome = select_parse(
+        grobid=ParseResult(metadata={"title": "G"}),  # 条目数 0
+        mineru=None,
+        fallback_text="text",
+        fallback_metadata=_FALLBACK_META,
+    )
+    assert outcome.references is None
+    assert outcome.quality_report["decisions"]["references"] == "fallback"
+
+
+# ---- 适配器不可用 = 现状逐字节不变（golden 保全路径） ----
+
+
+async def test_extract_without_adapters_is_byte_identical(tmp_path):
+    from app.services.literature.pdf_extract import extract_full_text
+
+    assert not dual_track_available()  # 测试套件不配任何解析 URL
+    pdf_path = _make_pdf(tmp_path)
+    legacy_id, dual_id = uuid.uuid4().hex, uuid.uuid4().hex
+    legacy_txt = await extract_full_text(legacy_id, pdf_path)
+    outcome = await extract_with_dual_track(dual_id, pdf_path)
+    assert not outcome.used_adapters
+    assert outcome.txt_path.read_bytes() == legacy_txt.read_bytes()
+    # 不写任何附加工件
+    assert not parse_quality_path(dual_id).exists()
+    assert not structured_references_path(dual_id).exists()
+
+
+@respx.mock
+async def test_extract_dual_track_end_to_end(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_settings(), "grobid_url", "http://grobid.test", raising=False)
+    monkeypatch.setattr(get_settings(), "mineru_parse_url", "http://mineru.test", raising=False)
+    respx.post("http://grobid.test/api/processFulltextDocument").mock(
+        return_value=Response(200, text=TEI_SAMPLE)
+    )
+    respx.post("http://mineru.test/file_parse").mock(
+        return_value=Response(200, json=MINERU_SAMPLE)
+    )
+    paper_id = uuid.uuid4().hex
+    outcome = await extract_with_dual_track(paper_id, _make_pdf(tmp_path))
+    assert outcome.used_adapters
+    # body 用 MinerU 分节正文
+    assert outcome.txt_path.read_text(encoding="utf-8").startswith("Deep Agent Survey")
+    # 结构化参考文献工件（含上下文句）
+    refs = load_structured_references(paper_id)
+    assert len(refs) == 3
+    assert refs[1]["contexts"] == ["We follow the planning method of [2] to build our agent loop."]
+    # 质检报告
+    report = json.loads(parse_quality_path(paper_id).read_text(encoding="utf-8"))
+    assert report["decisions"] == {"metadata": "grobid", "references": "grobid", "body": "mineru"}
+    assert report["adapters"]["grobid"]["parsed"] and report["adapters"]["mineru"]["parsed"]
+    assert outcome.metadata["title"] == "Deep Agent Survey"
+
+
+@respx.mock
+async def test_extract_adapter_failure_degrades_to_fallback(tmp_path, monkeypatch):
+    """两轨都配了但都挂：正文 = 原 PyMuPDF 全文，错误进质检报告，旧结构化工件被清掉。"""
+    from app.services.literature.pdf_extract import extract_full_text
+
+    monkeypatch.setattr(get_settings(), "grobid_url", "http://grobid.test", raising=False)
+    monkeypatch.setattr(get_settings(), "mineru_parse_url", "http://mineru.test", raising=False)
+    respx.post("http://grobid.test/api/processFulltextDocument").mock(
+        return_value=Response(500)
+    )
+    respx.post("http://mineru.test/file_parse").mock(return_value=Response(500))
+    pdf_path = _make_pdf(tmp_path)
+    paper_id = uuid.uuid4().hex
+    stale = structured_references_path(paper_id)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text('{"version": 1, "references": [{"raw": "stale"}]}', encoding="utf-8")
+
+    outcome = await extract_with_dual_track(paper_id, pdf_path)
+    legacy_txt = await extract_full_text(uuid.uuid4().hex, pdf_path)
+    assert outcome.txt_path.read_bytes() == legacy_txt.read_bytes()
+    assert not stale.exists()
+    report = json.loads(parse_quality_path(paper_id).read_text(encoding="utf-8"))
+    assert report["decisions"] == {
+        "metadata": "fallback",
+        "references": "fallback",
+        "body": "fallback",
+    }
+    assert report["adapters"]["grobid"]["errors"]
+    assert report["adapters"]["mineru"]["errors"]
+
+
+# ---- 元数据写回：只补空字段 ----
+
+
+def test_apply_missing_metadata_fills_only_empty_fields():
+    paper = new_paper(title="Existing", doi="10.9/existing", year=None, venue=None)
+    changed = apply_missing_metadata(
+        paper,
+        {
+            "title": "Parsed",
+            "doi": "10.9/parsed",
+            "year": 2023,
+            "venue": "Parsed Venue",
+            "abstract": "parsed abstract",
+            "authors": ["A One"],
+        },
+    )
+    assert changed
+    assert paper.doi == "10.9/existing"  # 已有值不被覆盖
+    assert paper.year == 2023
+    assert paper.venue == "Parsed Venue"
+    assert paper.abstract == "parsed abstract"
+    assert paper.authors == [{"name": "A One"}]
+
+
+# ---- citation_graph：双输入源等价 + 结构化优先 ----
+
+
+async def _edge_rows(session, paper_id):
+    rows = (
+        (
+            await session.execute(
+                select(PaperCitation)
+                .where(PaperCitation.citing_paper_id == paper_id)
+                .order_by(PaperCitation.ref_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [(r.ref_index, r.cited_ref_raw, r.context) for r in rows]
+
+
+async def test_citation_edges_structured_equals_regex(app, tmp_path):
+    """同一篇论文：正则路径与等价的结构化工件必须建出同一组边。"""
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Deep Agent Survey")
+        session.add(paper)
+        await session.flush()
+        full_text_path = tmp_path / "full.txt"
+        full_text_path.write_text(FULL_TEXT, encoding="utf-8")
+        paper.full_text_path = str(full_text_path)
+
+        assert await ensure_citation_edges(session, paper) == 3
+        await session.commit()
+        regex_rows = await _edge_rows(session, paper.id)
+        assert len(regex_rows) == 3
+
+        # 用正则产物同口径构造结构化工件（条目原文 + 首个上下文句），force 重建
+        refs_path = structured_references_path(str(paper.id))
+        refs_path.parent.mkdir(parents=True, exist_ok=True)
+        refs_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "source": "grobid",
+                    "references": [
+                        {"raw": raw, "contexts": [ctx] if ctx else []}
+                        for _idx, raw, ctx in regex_rows
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        assert await ensure_citation_edges(session, paper, force=True) == 3
+        await session.commit()
+        assert await _edge_rows(session, paper.id) == regex_rows
+
+
+async def test_citation_edges_prefer_structured_over_regex(app, tmp_path):
+    """结构化工件存在时优先吃它（条目与全文正则产物不同也以工件为准）。"""
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Deep Agent Survey")
+        session.add(paper)
+        await session.flush()
+        full_text_path = tmp_path / "full.txt"
+        full_text_path.write_text(FULL_TEXT, encoding="utf-8")
+        paper.full_text_path = str(full_text_path)
+        refs_path = structured_references_path(str(paper.id))
+        refs_path.parent.mkdir(parents=True, exist_ok=True)
+        refs_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "source": "grobid",
+                    "references": [
+                        {"raw": "Only Structured Entry. 2024.", "contexts": ["ctx one."]},
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        assert await ensure_citation_edges(session, paper) == 1
+        await session.commit()
+        assert await _edge_rows(session, paper.id) == [
+            (1, "Only Structured Entry. 2024.", "ctx one.")
+        ]
+
+
+async def test_citation_edges_corrupt_artifact_falls_back_to_regex(app, tmp_path):
+    async with get_sessionmaker()() as session:
+        paper = new_paper(title="Deep Agent Survey")
+        session.add(paper)
+        await session.flush()
+        full_text_path = tmp_path / "full.txt"
+        full_text_path.write_text(FULL_TEXT, encoding="utf-8")
+        paper.full_text_path = str(full_text_path)
+        refs_path = structured_references_path(str(paper.id))
+        refs_path.parent.mkdir(parents=True, exist_ok=True)
+        refs_path.write_text("not json at all", encoding="utf-8")
+        assert await ensure_citation_edges(session, paper) == 3  # 正则路径兜底
+
+
+# ---- 可用性只看配置 ----
+
+
+def test_adapter_availability_flags(monkeypatch):
+    assert not GrobidAdapter().available()
+    assert not MineruWebAdapter().available()
+    monkeypatch.setattr(get_settings(), "grobid_url", "http://grobid.test", raising=False)
+    monkeypatch.setattr(get_settings(), "mineru_parse_url", "http://m.test", raising=False)
+    assert GrobidAdapter().available()
+    assert MineruWebAdapter().available()
+    assert dual_track_available()


### PR DESCRIPTION
Closes #650. Part of #635 (P2 wave 3, item E1); design report §10 layer ①.

A parsing-adapter seam in the Python edge: structured parsers plug in, the existing PyMuPDF extraction stays as the always-available fallback, and a per-document quality report records which track won each field.

- `parsing/contract.py`: `ParseResult` (metadata, structured references with context sentences, sections/tables/formulas, quality) and a `ParsingAdapter` protocol with capability flags and a config-only `available()`. Deliberately not hung on the literature `AdapterRegistry` — that is a search-source DI container keyed by admin runtime credentials; parsing is PDF-in/structure-out keyed by environment, and forcing them together muddies both types (rationale in the docstring). The pre-existing `services/mineru.py` is the MinerU *Cloud* pipeline for the versioned-PDF lifecycle; this adapter targets a self-hosted web API and the config comments distinguish the two.
- GROBID adapter (`POLARIS_GROBID_URL`): TEI parsed with the standard library — metadata, biblStruct reference entries, and per-reference context sentences from in-text markers
- MinerU-class adapter (`POLARIS_MINERU_URL`): markdown/JSON payload mapped to sections/tables/formulas, response-shape variants locked by fixture
- `select.py` decision matrix: metadata per-field GROBID-wins-with-fallback, references switch tracks only when GROBID yields entries, body only when MinerU yields text; one track failing never sinks the other
- quality report + structured references land as file artifacts in the existing per-paper directory (deleted with the paper; zero migrations)
- wiring: the enrich extract step goes dual-track only when a URL is configured — otherwise the original code path runs byte-identically (tested); `citation_graph` consumes structured references (same numbering/context contract) when the artifact exists, else the regex parser

18 new fixture-only tests: both mappings, the decision matrix, end-to-end via respx, full-failure degradation, unavailable-equals-status-quo byte equality, and citation-graph equivalence across both input sources.

Verification: clean-baseline 1482 passed + the 3 pre-existing #581 failures; branch suite 1499 passed + those 3 + one known clock-step flake (green 5/5 standalone) — zero new real failures. Goldens byte-identical; no frontend changes.