### PR TITLE
feat: four-stage hypothesis pipeline for discovery runs

### DIFF
--- a/src/backend/app/agents/voyage/actions_discovery.py
+++ b/src/backend/app/agents/voyage/actions_discovery.py
@@ -3,9 +3,11 @@
 四个动作围绕假设树（services/hypothesis_tree.py，#640）展开：
 
 - ``hypothesis.seed``：树空时按研究方向生成根假设入树；
-- ``hypothesis.expand``：对当前最优 open 节点生成 2-3 个子假设、父节点转 expanded；
-- ``hypothesis.prune``：LLM 判某分支不值得继续时写 score 并级联剪枝（留痕不删）；
-- ``discovery.summarize``：把整棵树（含被剪分支）汇总成 run 产物后收束。
+- ``hypothesis.expand``：对当前最优 open 节点跑四段假设管线（#648，
+  services/hypothesis_pipeline.py）：generate 产 2-3 个子候选，逐个
+  ground → novelty → feasibility → score 写进节点，低分自动剪枝；
+- ``hypothesis.prune``：显式剪枝入口，写 score 并级联剪枝（留痕不删）；
+- ``discovery.summarize``：把整棵树（含被剪分支）汇总成研究方案产物后收束。
 
 **计划不是线性清单**：初始计划只有播种一步，之后每一轮由动作按树状态给出
 plan_signal（expand / summarize），经 plan_edit.discovery_signal_edits 确定性
@@ -28,14 +30,15 @@ from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
 from app.models.hypothesis import HypothesisNode
 from app.models.voyage import VoyageRun
+from app.services import hypothesis_pipeline as pipeline
 from app.services import hypothesis_tree as tree_service
 
 # LLM 环节：结构化 JSON 生成，走中档耐心（core/llm/router.py 的 _MEDIUM_CALL_STAGES）
 _STAGE = "discovery_plan"
 
 _MAX_JSON_ATTEMPTS = 3
-# 每轮扩展的子假设数量区间：LLM 多给截断、少给（<2）视为非法输出重试
-_MIN_CHILDREN, _MAX_CHILDREN = 2, 3
+# 每轮扩展的子候选上限：管线 generate 按它要候选，多给截断（去重后可能更少）
+_MAX_CHILDREN = 3
 
 SEED_SYSTEM_PROMPT = """\
 POLARIS_DISCOVERY_SEED
@@ -43,16 +46,6 @@ POLARIS_DISCOVERY_SEED
 可检验的核心研究假设。只输出一个 JSON 对象，不要输出任何其他文字：
 {"statement": "假设陈述（一句话，可检验）", "rationale": "一句话依据", \
 "score": 0 到 1 的先验看好程度}
-"""
-
-EXPAND_SYSTEM_PROMPT = """\
-POLARIS_DISCOVERY_EXPAND
-你是 Navigator，负责在假设树上扩展一个节点：把父假设细化/分叉成 2-3 个更具体、
-彼此不同的子假设。若你判断树上某个分支已明显不值得继续，可在 prune 里给出
-（不确定时给空数组）。只输出一个 JSON 对象，不要输出任何其他文字：
-{"children": [{"statement": "子假设陈述", "rationale": "一句话依据", \
-"score": 0 到 1 的看好程度}],
- "prune": [{"node_id": "要剪掉的节点 id", "score": 0 到 1, "reason": "为什么放弃"}]}
 """
 
 SUMMARY_SYSTEM_PROMPT = """\
@@ -94,6 +87,22 @@ def _max_expansions(ctx: ActionContext) -> int:
 
 def _direction(ctx: ActionContext) -> str:
     return str(_params_of(ctx).get("direction") or ctx.run.goal or "").strip()
+
+
+def _require_library_id(ctx: ActionContext) -> uuid.UUID:
+    """discovery 的库关联（#648 起 params.library_id 必填，创建入口已校验可见性）。
+
+    优先 run.library_id（创建时落列，费用记账与可见性都按它走）；直建的存量/
+    测试 run 兜底读 params。两处都没有直接报错——四段管线的检索边界就是这个库，
+    没有库关联的 discovery 无从接地。
+    """
+    if ctx.run.library_id is not None:
+        return ctx.run.library_id
+    raw = _params_of(ctx).get("library_id")
+    try:
+        return uuid.UUID(str(raw))
+    except (TypeError, ValueError):
+        raise ValueError("discovery 任务缺少文献库关联（params.library_id）") from None
 
 
 def _record_decision(
@@ -183,34 +192,6 @@ def _validate_seed(data: Any) -> dict[str, Any]:
         "statement": str(data["statement"]).strip(),
         "score": _clamp_score(data.get("score")),
     }
-
-
-def _validate_expand(data: Any) -> dict[str, Any]:
-    if not isinstance(data, dict) or not isinstance(data.get("children"), list):
-        raise ValueError('expand 输出需含 "children" 列表')
-    children = []
-    for raw in data["children"][:_MAX_CHILDREN]:
-        if not isinstance(raw, dict) or not str(raw.get("statement") or "").strip():
-            raise ValueError("child 需含非空 statement")
-        children.append(
-            {
-                "statement": str(raw["statement"]).strip(),
-                "score": _clamp_score(raw.get("score")),
-            }
-        )
-    if len(children) < _MIN_CHILDREN:
-        raise ValueError(f"expand 至少要给出 {_MIN_CHILDREN} 个子假设")
-    prune = []
-    for raw in data.get("prune") or []:
-        if isinstance(raw, dict) and raw.get("node_id"):
-            prune.append(
-                {
-                    "node_id": str(raw["node_id"]),
-                    "score": _clamp_score(raw.get("score")),
-                    "reason": str(raw.get("reason") or ""),
-                }
-            )
-    return {"children": children, "prune": prune}
 
 
 # ---- 树状态 → 下一步信号（决策的唯一出口，seed/expand 共用） ----
@@ -346,7 +327,10 @@ async def _apply_prune(session, ctx: ActionContext, entry: dict[str, Any]) -> st
 
 @register("hypothesis.expand")
 async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
-    """对当前最优 open 节点扩展一轮：生成 2-3 个子假设、父节点转 expanded。
+    """对当前最优 open 节点扩展一轮（#648 起走四段管线）：generate 产 2-3 个
+    子候选，逐个 ground → novelty → feasibility → score 全部算完后一次性落库，
+    低于 pipeline.MIN_VIABLE_SCORE 的子节点当场剪枝（级联、留痕不删），父节点
+    转 expanded。
 
     恢复语义（确定性重建 = checkpoint 轮次账本 + best_open_node）：
     - 本轮已在账本里 → 纯重放，不再动树；
@@ -354,6 +338,8 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
       checkpoint 回写之前被杀）→ 补记账本、不重复扩；
     - 否则正常扩展：目标节点取 best_open_node（score 降序、同分取先建的，
       对同一棵树是确定性的，所以「杀在扩展之前」的重启会选中同一个节点）。
+      管线的全部 LLM/检索都发生在动树**之前**（先算后写）：被杀在管线中途时
+    树还没动，重启就是干净重跑，「落库了一半」的窗口没有因为管线变长而变宽。
     """
     round_no = int(params.get("round") or 0)
     state = _state(ctx)
@@ -378,38 +364,126 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 state["rounds"][str(round_no)] = {"node_id": None, "no_open": True}
                 why = f"第 {round_no} 轮无 open 节点可扩展"
             else:
-                expansion, usage = await _complete_json_with_usage(
-                    ctx,
-                    system=EXPAND_SYSTEM_PROMPT,
-                    user=(
-                        f"研究方向：{_direction(ctx)}\n"
-                        f"父假设：{target.statement}\n"
-                        f"父假设节点 id：{target.id}"
-                    ),
-                    validate=_validate_expand,
+                library_id = _require_library_id(ctx)
+                identity: dict[str, Any] = {
+                    "user_id": ctx.run.created_by,
+                    "project_id": ctx.run.project_id,
+                    "voyage_id": ctx.run.id,
+                }
+                # 方向语境 = run 方向 + 被扩展节点的陈述：候选要围绕这个分支细化
+                gen = await pipeline.generate(
+                    session,
+                    ctx.llm,
+                    library_id=library_id,
+                    direction=f"{_direction(ctx)}；父假设：{target.statement}",
+                    n_candidates=_MAX_CHILDREN,
+                    **identity,
                 )
-                for child in expansion["children"]:
+                candidates = gen["candidates"][:_MAX_CHILDREN]
+                if not candidates:
+                    raise ValueError("hyp_generate 未产出任何候选假设（去重后为空）")
+                usage = dict(gen["usage"])
+                # 先算后写：每个候选把 ground/novelty/feasibility/score 全部算完，
+                # 再统一落库——管线再长，树的被杀窗口也不随之变宽（见函数 docstring）
+                computed: list[dict[str, Any]] = []
+                for cand in candidates:
+                    grounded = await pipeline.ground(
+                        session,
+                        ctx.llm,
+                        library_id=library_id,
+                        statement=cand["statement"],
+                        **identity,
+                    )
+                    nov = await pipeline.novelty(
+                        session,
+                        ctx.llm,
+                        library_id=library_id,
+                        statement=cand["statement"],
+                        grounding=grounded["grounding"],
+                        **identity,
+                    )
+                    feas = await pipeline.feasibility(
+                        session,
+                        ctx.llm,
+                        library_id=library_id,
+                        statement=cand["statement"],
+                        grounding=grounded["grounding"],
+                        **identity,
+                    )
+                    child_usage = {"prompt_tokens": 0, "completion_tokens": 0}
+                    for part in (grounded, nov, feas):
+                        child_usage["prompt_tokens"] += int(
+                            part["usage"].get("prompt_tokens", 0) or 0
+                        )
+                        child_usage["completion_tokens"] += int(
+                            part["usage"].get("completion_tokens", 0) or 0
+                        )
+                    computed.append(
+                        {
+                            "statement": cand["statement"],
+                            "grounding": grounded["grounding"],
+                            "novelty_report": nov["report"],
+                            "feasibility": feas["feasibility"],
+                            "score": pipeline.score_hypothesis(
+                                grounded["grounding"], nov["report"]
+                            ),
+                            "usage": child_usage,
+                        }
+                    )
+                pruned_children: list[str] = []
+                for item in computed:
                     node = await tree_service.create_node(
                         session,
                         run,
                         parent_id=target.id,
                         kind="hypothesis",
-                        statement=child["statement"],
-                        score=child["score"],
+                        statement=item["statement"],
+                        grounding=item["grounding"],
+                        novelty_report=item["novelty_report"],
+                        feasibility=item["feasibility"],
+                        score=item["score"],
                     )
                     children_ids.append(str(node.id))
+                    # 每节点记账：这个子假设的接地/查新/可行性花的 token 记它头上
+                    _account_node_usage(ctx, str(node.id), item["usage"])
+                    usage["prompt_tokens"] += item["usage"]["prompt_tokens"]
+                    usage["completion_tokens"] += item["usage"]["completion_tokens"]
+                    if item["score"] < pipeline.MIN_VIABLE_SCORE:
+                        # 低分自动剪枝：与 hypothesis.prune 同一状态机语义
+                        # （级联、留痕不删），分数与依据都留在节点行里可复查
+                        await tree_service.transition(session, node, "pruned")
+                        pruned_children.append(str(node.id))
+                        _record_decision(
+                            ctx,
+                            action="hypothesis.prune",
+                            decision="pruned",
+                            node_id=str(node.id),
+                            why=(
+                                f"score={item['score']} 低于阈值 "
+                                f"{pipeline.MIN_VIABLE_SCORE}，自动剪枝"
+                            ),
+                            round_no=round_no,
+                        )
+                        await ctx.log(
+                            f"低分剪枝：{item['statement'][:80]}（score={item['score']}）"
+                        )
                 await tree_service.transition(session, target, "expanded")
-                _account_node_usage(ctx, str(target.id), usage)
-                for entry in expansion["prune"]:
-                    await _apply_prune(session, ctx, entry)
+                # generate 的开销记到被扩展的父节点头上（子节点还没出生）
+                _account_node_usage(ctx, str(target.id), gen["usage"])
                 target_id = str(target.id)
                 state["rounds"][str(round_no)] = {
                     "node_id": target_id,
                     "children": children_ids,
+                    "pruned": pruned_children,
                 }
-                why = f"第 {round_no} 轮：扩展最优 open 节点，生成 {len(children_ids)} 个子假设"
+                why = (
+                    f"第 {round_no} 轮：扩展最优 open 节点，管线产出 "
+                    f"{len(children_ids)} 个子假设"
+                    + (f"（{len(pruned_children)} 个低分被剪）" if pruned_children else "")
+                )
                 await ctx.log(
-                    f"扩展「{target.statement[:80]}」→ {len(children_ids)} 个子假设",
+                    f"扩展「{target.statement[:80]}」→ {len(children_ids)} 个子假设"
+                    + (f"（低分剪枝 {len(pruned_children)} 个）" if pruned_children else ""),
                     level="success",
                 )
         signal, signal_why = await _next_signal(session, ctx)
@@ -451,8 +525,10 @@ async def hypothesis_prune(ctx: ActionContext, params: dict[str, Any]) -> dict[s
 
 @register("discovery.summarize")
 async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
-    """整树汇总为 run 产物：全部节点 + 状态 + 统计，被剪分支保留在案（§8.2
-    防择优汇报）。产物写进 checkpoint["artifacts"]，voyage 完成标准查它。"""
+    """整树汇总为**研究方案**产物（#648）：direction + 存活假设（按 score 降序，
+    携带 grounding/novelty/feasibility 三类证据卡数据）+ 被剪分支附录（§8.2
+    防择优汇报：放弃的路径和原因也是产物的一部分）+ 全节点快照与统计。
+    产物写进 checkpoint["artifacts"]，voyage 完成标准查它。"""
     state = _state(ctx)
     async with get_sessionmaker()() as session:
         nodes = await tree_service.tree_for_run(session, ctx.run.id)
@@ -475,10 +551,47 @@ async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dic
         voyage_id=ctx.run.id,
     )
     usage = dict(result.usage or {})
+    # 被剪节点的剪枝原因：从决策留痕反查（显式/自动剪枝都记了 why）；
+    # 没记到的（随父级联被剪的子孙）如实标注级联
+    prune_reasons = {
+        str(d.get("node_id")): str(d.get("why") or "")
+        for d in state["decisions"]
+        if d.get("decision") == "pruned" and d.get("node_id")
+    }
+    alive = sorted(
+        (n for n in nodes if n.status != "pruned"),
+        # score 降序（未评分的排最后），同分按建立顺序稳定排序
+        key=lambda n: (-(n.score if n.score is not None else -1.0), n.created_at),
+    )
     artifact = {
         "direction": _direction(ctx),
         "summary": result.content,
         "stats": stats,
+        # 研究方案主体：存活假设 + 三类证据卡数据（支持/反驳/推测的 grounding、
+        # 逐子命题查新结论、可行性信号与风险论证），前端/导出直接消费
+        "hypotheses": [
+            {
+                "id": str(n.id),
+                "statement": n.statement,
+                "status": n.status,
+                "score": n.score,
+                "grounding": n.grounding,
+                "novelty_report": n.novelty_report,
+                "feasibility": n.feasibility,
+            }
+            for n in alive
+        ],
+        # 附录：被剪分支及原因（留痕不删的消费端）
+        "pruned_appendix": [
+            {
+                "id": str(n.id),
+                "statement": n.statement,
+                "score": n.score,
+                "reason": prune_reasons.get(str(n.id), "随父分支级联剪枝"),
+            }
+            for n in nodes
+            if n.status == "pruned"
+        ],
         "nodes": [
             {
                 "id": str(n.id),

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -32,6 +32,7 @@ from app.schemas.voyage import (
     VoyageTerminalLogRead,
 )
 from app.services import experiments as experiments_service
+from app.services import libraries as libraries_service
 from app.services import projects as projects_service
 from app.services import voyage_messages as messages_service
 from app.services import voyages as voyages_service
@@ -64,6 +65,14 @@ async def create_voyage(
     )
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
+    if data.kind == "discovery":
+        # 假设管线的检索边界（#648）：库必须存在且对请求者可见；不可见按不存在
+        # 处理（404），与库只读端点同口径——不经 id 泄漏个人库的存在性
+        library = await libraries_service.get_library(
+            session, uuid.UUID(str((data.params or {})["library_id"]))
+        )
+        if library is None or not libraries_service.library_visible_to(library, user):
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="LIBRARY_NOT_FOUND")
     run = await voyages_service.create_voyage(session, created_by=user.id, data=data)
     await queue.enqueue("run_voyage", str(run.id))
     return VoyageRead.model_validate(run)

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -79,8 +79,13 @@ _REVIEW_FACTCHECK_MARKER = "POLARIS_REVIEW_FACTCHECK"  # claim 抽查
 # Idea 2.0 深耕（actions_proposal.py 的 system prompt 对齐，docs/api-idea2.md）
 # discovery 树搜索（actions_discovery.py 三个 system prompt 对齐，#642）
 _DISCOVERY_SEED_MARKER = "POLARIS_DISCOVERY_SEED"
-_DISCOVERY_EXPAND_MARKER = "POLARIS_DISCOVERY_EXPAND"
 _DISCOVERY_SUMMARY_MARKER = "POLARIS_DISCOVERY_SUMMARY"
+# 文献→假设四段管线（services/hypothesis_pipeline.py，#648）。ground 的拆分与
+# 选证据两次调用共用一个 marker，靠 user payload 里有无 "retrieved" 区分。
+_HYP_GENERATE_MARKER = "POLARIS_HYP_GENERATE"
+_HYP_GROUND_MARKER = "POLARIS_HYP_GROUND"
+_HYP_NOVELTY_MARKER = "POLARIS_HYP_NOVELTY"
+_HYP_FEASIBILITY_MARKER = "POLARIS_HYP_FEASIBILITY"
 _GOAL_EXPLORE_MARKER = "POLARIS_GOAL_EXPLORE"  # 目标构建工具循环
 _GOAL_REFINE_MARKER = "POLARIS_GOAL_REFINE"  # 审批意见并入目标
 _PROPOSAL_RELATED_MARKER = "POLARIS_PROPOSAL_RELATED"  # 相关工作（工具循环）
@@ -379,11 +384,19 @@ class FakeProvider(LLMProvider):
             return FakeProvider._respond_review_factcheck(full_text)
         if _PAPER_REVIEWER_MARKER in full_text:
             return FakeProvider._respond_paper_reviewer(full_text)
-        # discovery 树搜索三 marker：user prompt 内嵌方向/假设文本，先于通用 marker
+        # 假设管线四 marker（#648）：user payload 内嵌检索片段（可能撞任意通用
+        # marker），须先于通用 marker 判断
+        if _HYP_GENERATE_MARKER in full_text:
+            return FakeProvider._respond_hyp_generate(last_user)
+        if _HYP_GROUND_MARKER in full_text:
+            return FakeProvider._respond_hyp_ground(last_user)
+        if _HYP_NOVELTY_MARKER in full_text:
+            return FakeProvider._respond_hyp_novelty(last_user)
+        if _HYP_FEASIBILITY_MARKER in full_text:
+            return FakeProvider._respond_hyp_feasibility()
+        # discovery 树搜索 marker：user prompt 内嵌方向/假设文本，先于通用 marker
         if _DISCOVERY_SEED_MARKER in full_text:
             return FakeProvider._respond_discovery_seed(full_text)
-        if _DISCOVERY_EXPAND_MARKER in full_text:
-            return FakeProvider._respond_discovery_expand(full_text)
         if _DISCOVERY_SUMMARY_MARKER in full_text:
             return (
                 "（fake discovery 总结）本次探索围绕研究方向展开：根假设已扩展出子分支，"
@@ -1098,28 +1111,99 @@ class FakeProvider(LLMProvider):
             ensure_ascii=False,
         )
 
+    # ---- 文献→假设四段管线（services/hypothesis_pipeline.py 对齐，#648） ----
+
     @staticmethod
-    def _respond_discovery_expand(full_text: str) -> str:
-        """扩展：固定两个子假设（A 分高于 B → best_open_node 下一轮选 A，确定性）；
-        prune 恒为空——fake 路径不触发剪枝，骨架 run 的树形状可精确断言。"""
-        m = re.search(r"父假设：(.+)", full_text)
-        parent = m.group(1).strip() if m else "父假设（fake）"
+    def _payload_of(last_user: str) -> dict:
+        """user prompt 是 JSON payload 的环节统一解析入口；解析失败返回 {}。"""
+        start = last_user.find("{")
+        try:
+            payload = json.loads(last_user[start:]) if start != -1 else {}
+        except json.JSONDecodeError:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _respond_hyp_generate(last_user: str) -> str:
+        """生成：固定两个回显 direction 的候选。两条措辞刻意差异大——去重折叠
+        （SequenceMatcher>0.85）不该吃掉它们，完整 run 的树形状才可精确断言。"""
+        direction = str(FakeProvider._payload_of(last_user).get("direction") or "")[:40]
         return json.dumps(
             {
-                "children": [
+                "candidates": [
                     {
-                        "statement": f"{parent[:60]} → 子假设 A（fake）",
-                        "rationale": "fake-expand：路线 A",
-                        "score": 0.7,
+                        "statement": f"机制假设（fake A）：{direction} 依赖显式规划机制",
+                        "rationale": "fake-generate：语义近邻灵感组合",
                     },
                     {
-                        "statement": f"{parent[:60]} → 子假设 B（fake）",
-                        "rationale": "fake-expand：路线 B",
-                        "score": 0.6,
+                        "statement": f"证据闭环假设（fake B）：{direction} 需要检索增强验证",
+                        "rationale": "fake-generate：引文远端灵感组合",
                     },
-                ],
-                "prune": [],
+                ]
             },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_hyp_ground(last_user: str) -> str:
+        """接地：拆分调用（payload 无 "items"）固定拆 2 条回显 statement 的子命题；
+        选证据调用（payload 带 retrieved）第一条选检索首 id 表 support、其余一律
+        speculation——保证 score=0.25 的确定性中间态（novel½ × support½）。"""
+        payload = FakeProvider._payload_of(last_user)
+        if not isinstance(payload.get("items"), list):
+            statement = str(payload.get("statement") or "")[:50]
+            return json.dumps(
+                {
+                    "subclaims": [
+                        f"{statement} 的机制子命题（fake s1）",
+                        f"{statement} 的边界子命题（fake s2）",
+                    ]
+                },
+                ensure_ascii=False,
+            )
+        out = []
+        for i, item in enumerate(payload["items"]):
+            if not isinstance(item, dict):
+                continue
+            retrieved = [r for r in (item.get("retrieved") or []) if isinstance(r, dict)]
+            if i == 0 and retrieved:
+                out.append(
+                    {
+                        "index": item.get("index"),
+                        "stance": "support",
+                        "paper_ids": [str(retrieved[0].get("paper_id"))],
+                    }
+                )
+            else:
+                out.append(
+                    {"index": item.get("index"), "stance": "speculation", "paper_ids": []}
+                )
+        return json.dumps({"items": out}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_hyp_novelty(last_user: str) -> str:
+        """查新：第一条 novel（引证据首 id）、其余 uncertain（确定性）。"""
+        payload = FakeProvider._payload_of(last_user)
+        out = []
+        for i, item in enumerate(payload.get("items") or []):
+            if not isinstance(item, dict):
+                continue
+            evidence = [e for e in (item.get("evidence") or []) if isinstance(e, dict)]
+            novel = i == 0
+            out.append(
+                {
+                    "index": item.get("index"),
+                    "verdict": "novel" if novel else "uncertain",
+                    "paper_ids": [str(evidence[0].get("paper_id"))] if novel and evidence else [],
+                }
+            )
+        return json.dumps({"items": out}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_hyp_feasibility() -> str:
+        """可行性：固定风险论证段（信号本身由代码确定性统计，fake 不碰）。"""
+        return json.dumps(
+            {"risk_note": "（fake 可行性）库内证据规模有限，验证前需扩充语料复核（fake）。"},
             ensure_ascii=False,
         )
 

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -85,6 +85,12 @@ STAGES = (
     "rag_expand",
     "rag_rerank",
     "rag_answer",
+    # 文献→假设四段管线（#648）：generate/ground 是较长的结构化生成（中档），
+    # novelty/feasibility 是短 JSON 判定（短档）
+    "hyp_generate",
+    "hyp_ground",
+    "hyp_novelty",
+    "hyp_feasibility",
 )
 
 _ROUTE_CACHE_TTL = 60.0
@@ -174,6 +180,8 @@ _SHORT_CALL_STAGES = frozenset(
         "citation_intent",  # 引文意图批量分类：短 JSON、便宜模型（#639）
         "rag_expand",  # 库问答查询扩展：短 JSON（#644）
         "rag_rerank",  # 库问答重排+摘要：短 JSON（#644）
+        "hyp_novelty",  # 假设查新逐条判定：短 JSON（#648）
+        "hyp_feasibility",  # 假设可行性风险论证：短 JSON（#648）
     }
 )
 
@@ -189,8 +197,19 @@ _LONG_CALL_STAGES = STREAM_STAGES | frozenset({"digest", "forge_generate"})
 # 用户早走了。180s × 2 是"够想完一轮、又不至于把连接耗死"的折中。
 # rag_answer 是同步问答里的长生成（证据集大、要逐句挂引用），60s 短档会掐死它，
 # 但它又是用户干等着的请求，不能给长档 20 分钟的耐心——与 agent 同档。
+# hyp_generate / hyp_ground 同理：一次要组合多路灵感 / 拆解并逐条选证据，
+# 输出比短 JSON 长得多，但 discovery 是逐候选串行调用，长档 20 分钟的耐心
+# 会让一轮扩展的最坏时长完全失控。
 _MEDIUM_CALL_STAGES = frozenset(
-    {"agent", "discovery_plan", "goal_explore", "proposal_review", "rag_answer"}
+    {
+        "agent",
+        "discovery_plan",
+        "goal_explore",
+        "proposal_review",
+        "rag_answer",
+        "hyp_generate",
+        "hyp_ground",
+    }
 )
 
 

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -23,8 +23,10 @@ class VoyageCreate(BaseModel):
     @model_validator(mode="after")
     def _normalize_discovery_params(self) -> "VoyageCreate":
         """discovery 的参数在创建时就定形（引擎只读 checkpoint.params，不再兜底）：
-        direction 必填；max_expansions 默认 3（0..MAX，整数）；tournament 默认
-        False——锦标赛式对比是后续里程碑，先存档位不实现。"""
+        direction 必填；library_id 必填（#648：四段假设管线的检索/接地边界就是
+        这个库，没有库的 discovery 无从接地——可见性由 API 层校验）；
+        max_expansions 默认 3（0..MAX，整数）；tournament 默认 False——锦标赛式
+        对比是后续里程碑，先存档位不实现。"""
         if self.kind != "discovery":
             return self
         params = dict(self.params or {})
@@ -32,6 +34,12 @@ class VoyageCreate(BaseModel):
         if not direction:
             raise ValueError("discovery 任务需要 params.direction（研究方向）")
         params["direction"] = direction
+        try:
+            params["library_id"] = str(uuid.UUID(str(params.get("library_id"))))
+        except (TypeError, ValueError):
+            raise ValueError(
+                "discovery 任务需要 params.library_id（关联文献库）"
+            ) from None
         raw = params.get("max_expansions", 3)
         if isinstance(raw, bool) or not isinstance(raw, int):
             raise ValueError("max_expansions 必须是整数")

--- a/src/backend/app/services/hypothesis_pipeline.py
+++ b/src/backend/app/services/hypothesis_pipeline.py
@@ -1,0 +1,737 @@
+"""文献 → 假设四段管线（#648，设计报告 §12，P2 D3；不 import fastapi）。
+
+生成（generate）→ 文献接地（ground）→ 查新（novelty）→ 可行性（feasibility），
+供 discovery 引擎（actions_discovery.hypothesis_expand）逐候选调用。全程延续
+「确定性 vs 判断性分离」：检索、去重、越界校验、资源信号统计全是确定性代码，
+LLM 只负责五件判断性的事——组合灵感成假设、拆子命题、从检索结果里选证据表
+立场、判已知/新颖、写风险论证段。
+
+1. **generate**：三路灵感确定性取材——语义近邻（direction 直接检索）、引文图
+   远端（命中论文沿引文边走 2 跳、只取非直接邻居：图距离远的实体更可能带来
+   跨域组合，MOOSE-Chem「假设 ≈ 背景 + 灵感组合」）、多样窗（未被覆盖论文的
+   等距片段窗口，替代随机采样以保证可重放）→ ``hyp_generate`` 一次调用组合出
+   n 个候选 → SequenceMatcher 相似度 >0.85 折叠去重（Stanford 100+ 研究者盲评：
+   LLM 假设多样性坍缩严重，大量采样后去重是必要步骤，§12）。
+2. **ground**：``hyp_ground`` 拆子命题（≤5）→ 逐子命题确定性检索 top-5 →
+   同环节第二次调用只允许从检索结果里**选择** paper_id + 立场（support/refute）
+   或判 speculation；后处理校验所选 id ∈ 检索集，越界一律降为 speculation——
+   引用只能指向真实检索结果，结构上杜绝编造引文（各模型引文伪造率 14–95%）。
+3. **novelty**：非 speculation 子命题换措辞再检索一轮（同一措辞查两遍只会
+   复读接地结果），``hyp_novelty`` 逐条判 known / novel / uncertain——先摘出
+   假设中已知的部分再逐项对照文献，co-scientist Reflection 路线。
+4. **feasibility**：venue/年份分布、库内相关片段密度等可得性信号**确定性**
+   统计，``hyp_feasibility`` 只写风险论证段——资源匹配是查表不是发挥。
+
+score = novel 比例 × support 覆盖率。选这个最笨的公式是有意的：两个因子各自
+可解释、各自单调（新颖子命题越多越值得做，有文献支持的子命题越多越扎实），
+乘积天然惩罚偏科——全新颖但无接地是空中楼阁，全接地但不新颖是重复劳动。
+加权、校准、两两对比这些精细化留给 D4 锦标赛，先让分数「能解释给人听」。
+"""
+
+import json
+import uuid
+from difflib import SequenceMatcher
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.base import Message
+from app.core.llm.router import LLMRouter
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper, PaperChunk
+from app.models.paper_citation import PaperCitation
+from app.services import chunks as chunks_service
+from app.services import library_rag
+from app.services.papers import PAPER_STATUS_GROUPS
+
+# 四个 LLM 环节（router.py STAGES / 前端 LLM_STAGES 同步登记）：
+# generate/ground 是较长的结构化生成走中档，novelty/feasibility 是短 JSON 判定走短档
+GENERATE_STAGE = "hyp_generate"
+GROUND_STAGE = "hyp_ground"
+NOVELTY_STAGE = "hyp_novelty"
+FEASIBILITY_STAGE = "hyp_feasibility"
+
+DEFAULT_CANDIDATES = 6  # generate 默认一次要多少候选（去重前）
+MAX_SUBCLAIMS = 5  # 子命题上限：多了检索与判定成本线性涨，而假设该是聚焦的
+GROUND_TOP_K = 5  # 每条子命题送给 LLM 挑选的检索结果数
+DEDUP_THRESHOLD = 0.85  # 陈述相似度超过它视为同一假设（去重折叠）
+INSPIRATION_PER_ROUTE = 3  # 引文远端 / 多样窗两路各取几条灵感
+SNIPPET_CHARS = 300  # 灵感与证据片段的截断长度
+DENSITY_LIMIT = 50  # 相关片段密度统计的计数上限（信号要的是量级，不是全量）
+# expand 后低于此分自动剪枝（actions_discovery 消费）。0.15 = 「不到一半子命题
+# 新颖 × 不到一半有支持」量级以下：两个维度都不及格的假设不值得占用后续预算
+MIN_VIABLE_SCORE = 0.15
+
+_MAX_JSON_ATTEMPTS = 3
+
+GENERATE_SYSTEM_PROMPT = """\
+POLARIS_HYP_GENERATE
+你是研究假设生成器。输入 JSON 里是研究方向和三路文献灵感（semantic=语义近邻、
+citation_far=引文图远端、diverse=多样窗口片段）。请把方向与灵感**组合**成最多 n 个
+彼此不同、可检验的研究假设（鼓励跨片段组合，而不是逐条改写）。
+只输出 JSON：{"candidates": [{"statement": "假设陈述（一句话，可检验）", \
+"rationale": "一句话依据（引用了哪路灵感）"}]}"""
+
+GROUND_SPLIT_SYSTEM_PROMPT = """\
+POLARIS_HYP_GROUND
+你是假设分解器。把输入 JSON 里的假设陈述拆成最多 5 条可独立检索验证的子命题
+（每条一句话，合起来覆盖假设的关键断言）。
+只输出 JSON：{"subclaims": ["...", "..."]}"""
+
+GROUND_SELECT_SYSTEM_PROMPT = """\
+POLARIS_HYP_GROUND
+你是文献接地判定器。输入 JSON 的 items 每条是一个子命题和为它检索到的文献片段
+（各带 paper_id）。对每条子命题：若某些片段支持/反驳它，给出立场和所依据的
+paper_id 列表；检索结果都不相关时判 speculation（推测，paper_ids 留空）。
+**只允许使用 retrieved 里出现过的 paper_id，禁止编造。**
+只输出 JSON：{"items": [{"index": <原样回传>, \
+"stance": "support|refute|speculation", "paper_ids": ["..."]}]}"""
+
+NOVELTY_SYSTEM_PROMPT = """\
+POLARIS_HYP_NOVELTY
+你是查新判定器。输入 JSON 的 items 每条是假设的一个子命题和再次检索到的文献
+片段。对每条判定：该子命题是否已被这些文献覆盖——
+known（已有文献明确覆盖）| novel（文献未覆盖，是新的）| uncertain（证据不足以判定）。
+paper_ids 只允许来自 evidence。
+只输出 JSON：{"items": [{"index": <原样回传>, \
+"verdict": "known|novel|uncertain", "paper_ids": ["..."]}]}"""
+
+FEASIBILITY_SYSTEM_PROMPT = """\
+POLARIS_HYP_FEASIBILITY
+你是可行性风险论证员。输入 JSON 里是假设陈述和已经确定性统计好的资源信号
+（接地文献数、venue/年份分布、库内相关片段密度）。**不要重新估计这些数字**，
+只基于它们写一段简短的风险论证（哪些信号偏弱、验证该假设前要补什么）。
+只输出 JSON：{"risk_note": "..."}"""
+
+
+# ---- 通用小件 ----
+
+
+def _merge_usage(total: dict[str, int], usage: dict[str, Any] | None) -> dict[str, int]:
+    total["prompt_tokens"] += int((usage or {}).get("prompt_tokens", 0) or 0)
+    total["completion_tokens"] += int((usage or {}).get("completion_tokens", 0) or 0)
+    return total
+
+
+def _extract_json(content: str) -> Any:
+    start = content.find("{")
+    end = content.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON object found")
+    return json.loads(content[start : end + 1])
+
+
+async def _complete_json(
+    llm: LLMRouter,
+    stage: str,
+    *,
+    system: str,
+    payload: dict[str, Any],
+    validate,
+    usage: dict[str, int],
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+    library_id: uuid.UUID,
+    voyage_id: uuid.UUID | None,
+) -> Any:
+    """LLM JSON 请求：解析/校验失败重试，重试轮次的 token 也如实并入 usage。"""
+    last_error: Exception | None = None
+    for _attempt in range(_MAX_JSON_ATTEMPTS):
+        result = await llm.complete(
+            stage,
+            [
+                Message(role="system", content=system),
+                Message(role="user", content=json.dumps(payload, ensure_ascii=False)),
+            ],
+            temperature=0.0,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
+        )
+        _merge_usage(usage, result.usage)
+        try:
+            return validate(_extract_json(result.content))
+        except (ValueError, TypeError, KeyError, json.JSONDecodeError) as e:
+            last_error = e
+    raise ValueError(f"{stage} 连续输出非法 JSON：{last_error}")
+
+
+async def _paper_titles(
+    session: AsyncSession, paper_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, str]:
+    if not paper_ids:
+        return {}
+    rows = (
+        await session.execute(select(Paper.id, Paper.title).where(Paper.id.in_(paper_ids)))
+    ).all()
+    return {pid: (title or "") for pid, title in rows}
+
+
+def _chunk_entry(chunk: PaperChunk, titles: dict[uuid.UUID, str]) -> dict[str, Any]:
+    return {
+        "paper_id": str(chunk.paper_id),
+        "title": titles.get(chunk.paper_id, ""),
+        "snippet": chunk.text[:SNIPPET_CHARS],
+    }
+
+
+async def _member_paper_ids(session: AsyncSession, library_id: uuid.UUID) -> set[uuid.UUID]:
+    """库内成员论文集合（回收站/候选不算）：所有灵感与证据都不许越过库边界。"""
+    return set(
+        (
+            await session.execute(
+                select(LibraryPaper.paper_id).where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _retrieve(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    query: str,
+    user_id: uuid.UUID | None,
+    project_id: uuid.UUID | None,
+    limit: int,
+) -> list[PaperChunk]:
+    """确定性检索原语：复用 RAG 的单轮检索（向量优先、关键词降级），截前 limit 条。
+
+    刻意不走 library_rag.answer 的完整流水线——那里面有查询扩展和重排两次 LLM
+    判断，接地/查新要的是「同样输入永远同样证据集」的确定性检索。
+    """
+    rows = await library_rag.retrieve_round(
+        session, library_id=library_id, query=query, user_id=user_id, project_id=project_id
+    )
+    return [chunk for chunk, _score in rows[:limit]]
+
+
+# ---- 1) 生成：三路灵感 → 一次组合 → 去重 ----
+
+
+async def _citation_far_chunks(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    seed_paper_ids: list[uuid.UUID],
+) -> list[PaperChunk]:
+    """引文图远端灵感：从命中论文沿引文边走 2 跳，只取**非直接邻居**的库内论文。
+
+    直接邻居（引用/被引）与种子的相关性语义检索多半也够得着；隔一层的论文才是
+    「结构上有关联、语义上够得远」的跨域灵感来源。逐跳 BFS 而非递归 CTE：假设树
+    同款理由——两跳的小查询，可读性优先。
+    """
+    if not seed_paper_ids:
+        return []
+    member_ids = await _member_paper_ids(session, library_id)
+
+    async def neighbors(frontier: list[uuid.UUID]) -> list[uuid.UUID]:
+        edges = (
+            (
+                await session.execute(
+                    select(PaperCitation)
+                    .where(
+                        PaperCitation.citing_paper_id.in_(frontier)
+                        | PaperCitation.cited_paper_id.in_(frontier)
+                    )
+                    .order_by(PaperCitation.citing_paper_id, PaperCitation.ref_index)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        out: list[uuid.UUID] = []
+        for edge in edges:
+            for pid in (edge.cited_paper_id, edge.citing_paper_id):
+                if pid is not None and pid not in frontier and pid not in out:
+                    out.append(pid)
+        return out
+
+    seeds = list(seed_paper_ids)
+    hop1 = [pid for pid in await neighbors(seeds) if pid not in seeds]
+    if not hop1:
+        return []
+    hop2 = [
+        pid
+        for pid in await neighbors(hop1)
+        if pid not in seeds and pid not in hop1 and pid in member_ids
+    ][:INSPIRATION_PER_ROUTE]
+    if not hop2:
+        return []
+    # 每篇远端论文取开头片段：远端灵感靠「它讲什么」而非「哪句最像方向」入选
+    chunks = (
+        (
+            await session.execute(
+                select(PaperChunk)
+                .where(PaperChunk.paper_id.in_(hop2))
+                .order_by(PaperChunk.paper_id, PaperChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    first_by_paper: dict[uuid.UUID, PaperChunk] = {}
+    for chunk in chunks:
+        first_by_paper.setdefault(chunk.paper_id, chunk)
+    return [first_by_paper[pid] for pid in hop2 if pid in first_by_paper]
+
+
+async def _diverse_window_chunks(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    exclude_paper_ids: set[uuid.UUID],
+) -> list[PaperChunk]:
+    """多样窗灵感：未被前两路覆盖的库内片段，按等距窗口取样。
+
+    「随机多样窗」的随机在这里被有意替换成等距取样：discovery run 的每一步都要
+    可重放（断点恢复 / golden 比对），随机源会让同一 run 两次重放长出不同的树。
+    等距窗口保留了「打散位置、覆盖不同论文段落」的多样性收益，又是纯确定性的。
+    """
+    rows = (
+        (
+            await session.execute(
+                select(PaperChunk)
+                .join(LibraryPaper, LibraryPaper.paper_id == PaperChunk.paper_id)
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+                )
+                .order_by(PaperChunk.paper_id, PaperChunk.seq)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pool = [c for c in rows if c.paper_id not in exclude_paper_ids] or list(rows)
+    if not pool:
+        return []
+    stride = max(1, len(pool) // INSPIRATION_PER_ROUTE)
+    return pool[::stride][:INSPIRATION_PER_ROUTE]
+
+
+def _norm_statement(text: str) -> str:
+    return " ".join(str(text).lower().split())
+
+
+def dedup_candidates(
+    candidates: list[dict[str, Any]], *, threshold: float = DEDUP_THRESHOLD
+) -> list[dict[str, Any]]:
+    """按陈述相似度折叠近重复候选（保留先出现的——LLM 输出顺序即其置信排序）。
+
+    SequenceMatcher 而非嵌入相似度：去重要拦的是「同一句话换个说法」这种表层
+    重复（多样性坍缩的典型形态），字符级相似度便宜、确定、够用。
+    """
+    kept: list[dict[str, Any]] = []
+    for cand in candidates:
+        norm = _norm_statement(cand.get("statement") or "")
+        if not norm:
+            continue
+        duplicate = any(
+            SequenceMatcher(None, norm, _norm_statement(k["statement"])).ratio() > threshold
+            for k in kept
+        )
+        if not duplicate:
+            kept.append(cand)
+    return kept
+
+
+def _validate_generate(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, dict) or not isinstance(data.get("candidates"), list):
+        raise ValueError('generate 输出需含 "candidates" 列表')
+    out = []
+    for raw in data["candidates"]:
+        if not isinstance(raw, dict) or not str(raw.get("statement") or "").strip():
+            continue
+        out.append(
+            {
+                "statement": str(raw["statement"]).strip(),
+                "rationale": str(raw.get("rationale") or "").strip(),
+            }
+        )
+    if not out:
+        raise ValueError("generate 未给出任何含非空 statement 的候选")
+    return out
+
+
+async def generate(
+    session: AsyncSession,
+    llm: LLMRouter,
+    *,
+    library_id: uuid.UUID,
+    direction: str,
+    n_candidates: int = DEFAULT_CANDIDATES,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """三路灵感 → 一次 LLM 组合出 n 个候选 → 去重。
+
+    返回 {"candidates": [{statement, rationale}], "usage": {...}}；
+    candidates 已去重，数量 ≤ n_candidates（可能因折叠更少）。
+    """
+    usage = {"prompt_tokens": 0, "completion_tokens": 0}
+    semantic_chunks = await _retrieve(
+        session,
+        library_id=library_id,
+        query=direction,
+        user_id=user_id,
+        project_id=project_id,
+        limit=library_rag.TOP_K,
+    )
+    covered = {c.paper_id for c in semantic_chunks}
+    seed_papers: list[uuid.UUID] = []
+    for chunk in semantic_chunks:
+        if chunk.paper_id not in seed_papers:
+            seed_papers.append(chunk.paper_id)
+    far_chunks = await _citation_far_chunks(
+        session, library_id=library_id, seed_paper_ids=seed_papers[:INSPIRATION_PER_ROUTE]
+    )
+    covered |= {c.paper_id for c in far_chunks}
+    diverse_chunks = await _diverse_window_chunks(
+        session, library_id=library_id, exclude_paper_ids=covered
+    )
+    all_ids = list({c.paper_id for c in semantic_chunks + far_chunks + diverse_chunks})
+    titles = await _paper_titles(session, all_ids)
+    payload = {
+        "direction": direction,
+        "n": n_candidates,
+        "inspirations": {
+            "semantic": [_chunk_entry(c, titles) for c in semantic_chunks],
+            "citation_far": [_chunk_entry(c, titles) for c in far_chunks],
+            "diverse": [_chunk_entry(c, titles) for c in diverse_chunks],
+        },
+    }
+    raw = await _complete_json(
+        llm,
+        GENERATE_STAGE,
+        system=GENERATE_SYSTEM_PROMPT,
+        payload=payload,
+        validate=_validate_generate,
+        usage=usage,
+        user_id=user_id,
+        project_id=project_id,
+        library_id=library_id,
+        voyage_id=voyage_id,
+    )
+    return {"candidates": dedup_candidates(raw[:n_candidates]), "usage": usage}
+
+
+# ---- 2) 文献接地：拆子命题 → 确定性检索 → 只许从检索集内选 ----
+
+
+def _validate_subclaims(data: Any) -> list[str]:
+    if not isinstance(data, dict) or not isinstance(data.get("subclaims"), list):
+        raise ValueError('ground 拆分输出需含 "subclaims" 列表')
+    out = [str(s).strip() for s in data["subclaims"] if str(s or "").strip()]
+    if not out:
+        raise ValueError("ground 未拆出任何非空子命题")
+    return out[:MAX_SUBCLAIMS]
+
+
+def _validate_indexed_items(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+        raise ValueError('输出需含 "items" 列表')
+    return [it for it in data["items"] if isinstance(it, dict)]
+
+
+def sanitize_grounding(
+    subclaims: list[str],
+    retrieved: list[list[dict[str, Any]]],
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """接地后处理（纯函数，越界校验的落点）：
+
+    - 立场只认 support/refute，其余（含缺失/乱写）一律 speculation；
+    - paper_ids 逐条与**该子命题自己的**检索集求交，越界 id 直接丢弃；
+    - 立场是 support/refute 但没剩下任何合法 id → 降为 speculation——
+      「有立场没证据」和编造引文一样不可信；
+    - snippets 回填所选论文在检索集里的片段，证据卡（D5）直接可用。
+    """
+    by_index: dict[int, dict[str, Any]] = {}
+    for item in items:
+        idx = item.get("index")
+        if isinstance(idx, int) and idx not in by_index:
+            by_index[idx] = item
+    out: list[dict[str, Any]] = []
+    for i, subclaim in enumerate(subclaims):
+        pool = retrieved[i] if i < len(retrieved) else []
+        allowed = {entry["paper_id"] for entry in pool}
+        raw = by_index.get(i) or {}
+        stance = str(raw.get("stance") or "")
+        ids = [str(p) for p in (raw.get("paper_ids") or []) if str(p) in allowed]
+        # 同一论文多次入选只留一次（顺序保持）
+        ids = list(dict.fromkeys(ids))
+        if stance not in ("support", "refute") or not ids:
+            stance, ids = "speculation", []
+        chosen = set(ids)
+        snippets = [entry["snippet"] for entry in pool if entry["paper_id"] in chosen]
+        out.append(
+            {"subclaim": subclaim, "stance": stance, "paper_ids": ids, "snippets": snippets}
+        )
+    return out
+
+
+async def ground(
+    session: AsyncSession,
+    llm: LLMRouter,
+    *,
+    library_id: uuid.UUID,
+    statement: str,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """假设 → grounding JSON（与 models/hypothesis.py 的 D1 注释一致）：
+
+    [{"subclaim", "stance": "support|refute|speculation", "paper_ids", "snippets"}]
+    """
+    usage = {"prompt_tokens": 0, "completion_tokens": 0}
+    identity = dict(
+        user_id=user_id, project_id=project_id, library_id=library_id, voyage_id=voyage_id
+    )
+    subclaims = await _complete_json(
+        llm,
+        GROUND_STAGE,
+        system=GROUND_SPLIT_SYSTEM_PROMPT,
+        payload={"statement": statement},
+        validate=_validate_subclaims,
+        usage=usage,
+        **identity,
+    )
+    retrieved: list[list[dict[str, Any]]] = []
+    for subclaim in subclaims:
+        chunks = await _retrieve(
+            session,
+            library_id=library_id,
+            query=subclaim,
+            user_id=user_id,
+            project_id=project_id,
+            limit=GROUND_TOP_K,
+        )
+        titles = await _paper_titles(session, list({c.paper_id for c in chunks}))
+        retrieved.append([_chunk_entry(c, titles) for c in chunks])
+    items = await _complete_json(
+        llm,
+        GROUND_STAGE,
+        system=GROUND_SELECT_SYSTEM_PROMPT,
+        payload={
+            "statement": statement,
+            "items": [
+                {"index": i, "subclaim": sub, "retrieved": retrieved[i]}
+                for i, sub in enumerate(subclaims)
+            ],
+        },
+        validate=_validate_indexed_items,
+        usage=usage,
+        **identity,
+    )
+    return {"grounding": sanitize_grounding(subclaims, retrieved, items), "usage": usage}
+
+
+# ---- 3) 查新：换措辞再检索 → 逐子命题 judge ----
+
+# 换措辞的确定性前缀：目的不是「更好的查询」，而是**换一个角度**再捞一轮——
+# 同一措辞查两遍只会复读接地结果，查新就成了自证
+_NOVELTY_QUERY_PREFIX = "已有研究 prior work on"
+
+_NOVELTY_VERDICTS = ("known", "novel", "uncertain")
+
+
+def novelty_ratio(report: dict[str, Any]) -> float:
+    """novel 子命题占比（score 公式的一半；空报告为 0）。"""
+    subclaims = report.get("subclaims") or []
+    if not subclaims:
+        return 0.0
+    novel = sum(1 for e in subclaims if e.get("verdict") == "novel")
+    return novel / len(subclaims)
+
+
+async def novelty(
+    session: AsyncSession,
+    llm: LLMRouter,
+    *,
+    library_id: uuid.UUID,
+    statement: str,
+    grounding: list[dict[str, Any]],
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """逐子命题查新 → novelty_report：
+
+    {"subclaims": [{"subclaim", "verdict": "known|novel|uncertain",
+                    "paper_ids", "judged"}]}
+
+    speculation 子命题不送 judge（库里连接地证据都没有，「是否已被覆盖」无从
+    判起），如实记 uncertain / judged=False。judge 输出解析失败也整体降级为
+    uncertain——查新判不动不等于假设不成立，不该炸掉整轮扩展。
+    """
+    usage = {"prompt_tokens": 0, "completion_tokens": 0}
+    judged_indices = [i for i, e in enumerate(grounding) if e.get("stance") != "speculation"]
+    evidence_by_index: dict[int, list[dict[str, Any]]] = {}
+    for i in judged_indices:
+        chunks = await _retrieve(
+            session,
+            library_id=library_id,
+            query=f"{_NOVELTY_QUERY_PREFIX} {grounding[i]['subclaim']}",
+            user_id=user_id,
+            project_id=project_id,
+            limit=GROUND_TOP_K,
+        )
+        titles = await _paper_titles(session, list({c.paper_id for c in chunks}))
+        evidence_by_index[i] = [_chunk_entry(c, titles) for c in chunks]
+    verdicts: dict[int, tuple[str, list[str]]] = {}
+    if judged_indices:
+        try:
+            items = await _complete_json(
+                llm,
+                NOVELTY_STAGE,
+                system=NOVELTY_SYSTEM_PROMPT,
+                payload={
+                    "statement": statement,
+                    "items": [
+                        {
+                            "index": i,
+                            "subclaim": grounding[i]["subclaim"],
+                            "evidence": evidence_by_index[i],
+                        }
+                        for i in judged_indices
+                    ],
+                },
+                validate=_validate_indexed_items,
+                usage=usage,
+                user_id=user_id,
+                project_id=project_id,
+                library_id=library_id,
+                voyage_id=voyage_id,
+            )
+            for item in items:
+                idx = item.get("index")
+                if not isinstance(idx, int) or idx not in evidence_by_index:
+                    continue
+                verdict = str(item.get("verdict") or "")
+                if verdict not in _NOVELTY_VERDICTS:
+                    verdict = "uncertain"
+                allowed = {e["paper_id"] for e in evidence_by_index[idx]}
+                ids = [str(p) for p in (item.get("paper_ids") or []) if str(p) in allowed]
+                verdicts[idx] = (verdict, list(dict.fromkeys(ids)))
+        except ValueError:
+            verdicts = {}  # 判不动 → 全部 uncertain（诚实缺省）
+    subclaim_reports = []
+    for i, entry in enumerate(grounding):
+        verdict, ids = verdicts.get(i, ("uncertain", []))
+        subclaim_reports.append(
+            {
+                "subclaim": entry["subclaim"],
+                "verdict": verdict,
+                "paper_ids": ids,
+                "judged": i in verdicts,
+            }
+        )
+    return {"report": {"subclaims": subclaim_reports}, "usage": usage}
+
+
+# ---- 4) 可行性：确定性资源信号 + LLM 只写风险论证 ----
+
+
+def _validate_risk_note(data: Any) -> str:
+    if not isinstance(data, dict) or not str(data.get("risk_note") or "").strip():
+        raise ValueError('feasibility 输出需含非空 "risk_note"')
+    return str(data["risk_note"]).strip()
+
+
+async def feasibility(
+    session: AsyncSession,
+    llm: LLMRouter,
+    *,
+    library_id: uuid.UUID,
+    statement: str,
+    grounding: list[dict[str, Any]],
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    voyage_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """feasibility JSON = {"signals": {确定性信号}, "risk_note": LLM 风险论证}。
+
+    signals 全部由代码统计（§12：资源匹配是确定性查表）：
+    - grounded_paper_count / venues / year_range：接地文献的规模与来源分布，
+      「有多少扎实文献托底、来自哪里、新不新」；
+    - related_chunk_hits：库内与该假设相关的片段密度（关键词口径），密度低
+      意味着验证材料在库内很薄，得先扩充语料。
+    """
+    grounded_ids: list[uuid.UUID] = []
+    for entry in grounding:
+        if entry.get("stance") == "speculation":
+            continue
+        for raw in entry.get("paper_ids") or []:
+            pid = uuid.UUID(str(raw))
+            if pid not in grounded_ids:
+                grounded_ids.append(pid)
+    papers = []
+    if grounded_ids:
+        papers = (
+            (await session.execute(select(Paper).where(Paper.id.in_(grounded_ids))))
+            .scalars()
+            .all()
+        )
+    venues: dict[str, int] = {}
+    years: list[int] = []
+    for paper in papers:
+        if paper.venue:
+            venues[paper.venue] = venues.get(paper.venue, 0) + 1
+        if paper.year:
+            years.append(int(paper.year))
+    try:
+        related_hits = len(
+            await chunks_service.keyword_search_chunks(
+                session, library_ids=[library_id], q=statement, limit=DENSITY_LIMIT
+            )
+        )
+    except Exception:  # noqa: BLE001 — 密度只是参考信号，统计失败按 0 记不上抛
+        related_hits = 0
+    signals = {
+        "grounded_paper_count": len(papers),
+        "venues": dict(sorted(venues.items())),
+        "year_range": [min(years), max(years)] if years else None,
+        "related_chunk_hits": related_hits,
+    }
+    usage = {"prompt_tokens": 0, "completion_tokens": 0}
+    try:
+        risk_note = await _complete_json(
+            llm,
+            FEASIBILITY_STAGE,
+            system=FEASIBILITY_SYSTEM_PROMPT,
+            payload={"statement": statement, "signals": signals},
+            validate=_validate_risk_note,
+            usage=usage,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=voyage_id,
+        )
+    except ValueError:
+        # 风险论证写不出来不影响信号本身的价值：信号照常入库，note 如实说不可用
+        risk_note = "（风险论证生成失败，仅供确定性信号参考。）"
+    return {"feasibility": {"signals": signals, "risk_note": risk_note}, "usage": usage}
+
+
+# ---- 评分 ----
+
+
+def score_hypothesis(
+    grounding: list[dict[str, Any]], novelty_report: dict[str, Any]
+) -> float:
+    """score = novel 比例 × support 覆盖率（见模块 docstring 的 why）。"""
+    total = len(grounding)
+    if total == 0:
+        return 0.0
+    support = sum(1 for e in grounding if e.get("stance") == "support")
+    return round(novelty_ratio(novelty_report) * (support / total), 4)

--- a/src/backend/app/services/library_rag.py
+++ b/src/backend/app/services/library_rag.py
@@ -147,6 +147,13 @@ async def _search_round(
         return []
 
 
+# D3 假设管线（services/hypothesis_pipeline.py，#648）复用的确定性检索原语别名：
+# 一轮检索 = 向量优先、关键词降级、失败不上抛。公开命名以示这是稳定的复用面；
+# answer() 完整流水线里的 LLM 环节（查询扩展/重排/作答）**不在**此复用面之内——
+# 接地与查新要的是「同样输入永远同样证据集」，不能混进判断性环节。
+retrieve_round = _search_round
+
+
 def _merge_hits(
     candidates: dict[uuid.UUID, _Candidate],
     rows: list[tuple[PaperChunk, float]],

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -23,6 +23,12 @@ async def create_voyage(
 ) -> VoyageRun:
     params = data.params or {}
     budget = params.get("budget") if isinstance(params.get("budget"), dict) else None
+    # discovery 的库关联落列（#648）：schema 已定形为合法 UUID 字符串。落在
+    # run.library_id 而不是只留在 params 里——LLM 费用记账、任务列表的库过滤
+    # 都按这一列走，params 只是创建时的原始输入存档。
+    library_id = None
+    if data.kind == "discovery":
+        library_id = uuid.UUID(str(params["library_id"]))
     run = VoyageRun(
         kind=data.kind,
         goal=data.goal,
@@ -31,6 +37,7 @@ async def create_voyage(
         checkpoint={"params": params} if params else None,
         budget=budget,
         project_id=data.project_id,
+        library_id=library_id,
         created_by=created_by,
     )
     session.add(run)

--- a/src/backend/tests/golden/data/discovery_run.json
+++ b/src/backend/tests/golden/data/discovery_run.json
@@ -1,0 +1,610 @@
+{
+  "add_paper_one": {
+    "abstract": "Synthetic record one: structured agent planning with verifiable checkpoints for the deterministic golden harness.",
+    "affiliations": [],
+    "arxiv_id": null,
+    "authors": [
+      {
+        "affiliations": [],
+        "name": "Probe, Golden"
+      }
+    ],
+    "compiled_at": null,
+    "compiled_by_name": null,
+    "compiled_model": null,
+    "concepts": [],
+    "created_at": "<ts>",
+    "doi": null,
+    "figures": [],
+    "has_wiki": false,
+    "id": "<uuid-4>",
+    "library_id": "<uuid-2>",
+    "my_tags": [],
+    "note_count": 0,
+    "pdf_available": false,
+    "project_id": null,
+    "published_at": null,
+    "reading_status": "unread",
+    "relevance_score": null,
+    "starred": false,
+    "status": "included",
+    "tags": [],
+    "task_id": null,
+    "title": "Structured Agent Planning Probe",
+    "tldr": null,
+    "trash_reason": null,
+    "url": null,
+    "venue": "Journal of Reproducible Plumbing",
+    "wiki_content": null,
+    "year": 2026
+  },
+  "add_paper_two": {
+    "abstract": "Synthetic record two: structured agent planning evidence with grounded citations for the deterministic golden harness.",
+    "affiliations": [],
+    "arxiv_id": null,
+    "authors": [
+      {
+        "affiliations": [],
+        "name": "Chain, Import"
+      }
+    ],
+    "compiled_at": null,
+    "compiled_by_name": null,
+    "compiled_model": null,
+    "concepts": [],
+    "created_at": "<ts>",
+    "doi": null,
+    "figures": [],
+    "has_wiki": false,
+    "id": "<uuid-5>",
+    "library_id": "<uuid-2>",
+    "my_tags": [],
+    "note_count": 0,
+    "pdf_available": false,
+    "project_id": null,
+    "published_at": null,
+    "reading_status": "unread",
+    "relevance_score": null,
+    "starred": false,
+    "status": "included",
+    "tags": [],
+    "task_id": null,
+    "title": "Grounded Hypothesis Evidence Probe",
+    "tldr": null,
+    "trash_reason": null,
+    "url": null,
+    "venue": "Journal of Reproducible Plumbing",
+    "wiki_content": null,
+    "year": 2026
+  },
+  "create_discovery": {
+    "budget": null,
+    "created_at": "<ts>",
+    "created_by": "<uuid-1>",
+    "cursor": 0,
+    "goal": "structured agent planning",
+    "id": "<uuid-6>",
+    "kind": "discovery",
+    "library_id": "<uuid-2>",
+    "mode": "loop",
+    "plan": null,
+    "plan_iteration": 0,
+    "project_id": "<uuid-3>",
+    "status": "planning",
+    "updated_at": "<ts>",
+    "usage": null
+  },
+  "create_library": {
+    "cadence": null,
+    "can_manage": true,
+    "concept_count": 0,
+    "created_at": "<ts>",
+    "definition": {
+      "statement": "Deterministic golden-transcript library for the hypothesis pipeline."
+    },
+    "id": "<uuid-2>",
+    "interdisciplinary_domains": null,
+    "is_mine": false,
+    "is_owner": true,
+    "is_public": false,
+    "last_compiled_at": null,
+    "last_synced_at": null,
+    "library_kind": "standard",
+    "monthly_budget": null,
+    "name": "Discovery Golden Library",
+    "owner_name": "Discovery Golden",
+    "paper_count": 0,
+    "project_id": null,
+    "review_note": null,
+    "statement": "Deterministic golden-transcript library for the hypothesis pipeline.",
+    "status": "active",
+    "submitted_by": "<uuid-1>",
+    "updated_at": "<ts>"
+  },
+  "create_project": {
+    "created_at": "<ts>",
+    "id": "<uuid-3>",
+    "name": "Discovery Golden Project",
+    "owner_id": "<uuid-1>",
+    "research_mode": "conventional",
+    "slug": "discovery-golden-project",
+    "statement": "golden discovery chain",
+    "status": "active",
+    "updated_at": "<ts>"
+  },
+  "hypothesis_tree": [
+    {
+      "created_at": "<ts>",
+      "feasibility": null,
+      "grounding": null,
+      "id": "<uuid-8>",
+      "kind": "hypothesis",
+      "novelty_report": null,
+      "parent_id": null,
+      "run_id": "<uuid-6>",
+      "score": 0.8,
+      "statement": "围绕「structured agent planning」的核心假设（fake root）",
+      "status": "expanded",
+      "updated_at": "<ts>"
+    },
+    {
+      "created_at": "<ts>",
+      "feasibility": {
+        "risk_note": "（fake 可行性）库内证据规模有限，验证前需扩充语料复核（fake）。",
+        "signals": {
+          "grounded_paper_count": 1,
+          "related_chunk_hits": 2,
+          "venues": {
+            "Journal of Reproducible Plumbing": 1
+          },
+          "year_range": [
+            2026,
+            2026
+          ]
+        }
+      },
+      "grounding": [
+        {
+          "paper_ids": [
+            "<uuid-4>"
+          ],
+          "snippets": [
+            "Structured Agent Planning Probe\nProbe, Golden\nSynthetic record one: structured agent planning with verifiable checkpoints for the deterministic golden harness."
+          ],
+          "stance": "support",
+          "subclaim": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的机制子命题（fake s1）"
+        },
+        {
+          "paper_ids": [],
+          "snippets": [],
+          "stance": "speculation",
+          "subclaim": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的边界子命题（fake s2）"
+        }
+      ],
+      "id": "<uuid-10>",
+      "kind": "hypothesis",
+      "novelty_report": {
+        "subclaims": [
+          {
+            "judged": true,
+            "paper_ids": [
+              "<uuid-4>"
+            ],
+            "subclaim": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的机制子命题（fake s1）",
+            "verdict": "novel"
+          },
+          {
+            "judged": false,
+            "paper_ids": [],
+            "subclaim": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的边界子命题（fake s2）",
+            "verdict": "uncertain"
+          }
+        ]
+      },
+      "parent_id": "<uuid-8>",
+      "run_id": "<uuid-6>",
+      "score": 0.25,
+      "statement": "机制假设（fake A）：structured agent planning；父假设：围绕「structu 依赖显式规划机制",
+      "status": "open",
+      "updated_at": "<ts>"
+    },
+    {
+      "created_at": "<ts>",
+      "feasibility": {
+        "risk_note": "（fake 可行性）库内证据规模有限，验证前需扩充语料复核（fake）。",
+        "signals": {
+          "grounded_paper_count": 1,
+          "related_chunk_hits": 2,
+          "venues": {
+            "Journal of Reproducible Plumbing": 1
+          },
+          "year_range": [
+            2026,
+            2026
+          ]
+        }
+      },
+      "grounding": [
+        {
+          "paper_ids": [
+            "<uuid-4>"
+          ],
+          "snippets": [
+            "Structured Agent Planning Probe\nProbe, Golden\nSynthetic record one: structured agent planning with verifiable checkpoints for the deterministic golden harness."
+          ],
+          "stance": "support",
+          "subclaim": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的机制子命题（fake s1）"
+        },
+        {
+          "paper_ids": [],
+          "snippets": [],
+          "stance": "speculation",
+          "subclaim": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的边界子命题（fake s2）"
+        }
+      ],
+      "id": "<uuid-11>",
+      "kind": "hypothesis",
+      "novelty_report": {
+        "subclaims": [
+          {
+            "judged": true,
+            "paper_ids": [
+              "<uuid-4>"
+            ],
+            "subclaim": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的机制子命题（fake s1）",
+            "verdict": "novel"
+          },
+          {
+            "judged": false,
+            "paper_ids": [],
+            "subclaim": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的边界子命题（fake s2）",
+            "verdict": "uncertain"
+          }
+        ]
+      },
+      "parent_id": "<uuid-8>",
+      "run_id": "<uuid-6>",
+      "score": 0.25,
+      "statement": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「structu 需要检索增强验证",
+      "status": "open",
+      "updated_at": "<ts>"
+    }
+  ],
+  "library_index_rebuild": {
+    "abstract_vectors_copied": 0,
+    "chunks_created": 2,
+    "embed_error": null,
+    "embedded": 0,
+    "papers_indexed": 2,
+    "total_chunks": 2
+  },
+  "login": {
+    "access_token": "<token>",
+    "token_type": "bearer"
+  },
+  "register": {
+    "display_name": "Discovery Golden",
+    "email": "discovery-golden@example.com",
+    "has_avatar": false,
+    "id": "<uuid-1>",
+    "is_active": true,
+    "is_superuser": false,
+    "is_verified": false,
+    "llm_self_managed": false,
+    "settings": null,
+    "username": "discoverygolden",
+    "username_locked": false
+  },
+  "voyage_detail": {
+    "budget": null,
+    "created_at": "<ts>",
+    "created_by": "<uuid-1>",
+    "cursor": 3,
+    "goal": "structured agent planning",
+    "id": "<uuid-6>",
+    "kind": "discovery",
+    "library_id": "<uuid-2>",
+    "mode": "loop",
+    "open_ask": null,
+    "plan": [
+      {
+        "acceptance": "根假设已入树（断点重放时复用已有根）",
+        "action": "hypothesis.seed",
+        "checks": [
+          {
+            "kind": "no_error"
+          }
+        ],
+        "on_failure": null,
+        "params": {},
+        "requires_gate": null,
+        "title": "生成根假设",
+        "wrapup": null
+      },
+      {
+        "acceptance": "最优 open 节点已扩展出子假设（或按树状态判定本轮无需扩展）",
+        "action": "hypothesis.expand",
+        "checks": [
+          {
+            "kind": "no_error"
+          }
+        ],
+        "on_failure": null,
+        "params": {
+          "round": 1
+        },
+        "requires_gate": null,
+        "title": "第 1 轮扩展假设",
+        "wrapup": null
+      },
+      {
+        "acceptance": "整树（含被剪分支）已汇总为 run 产物",
+        "action": "discovery.summarize",
+        "checks": [
+          {
+            "kind": "no_error"
+          }
+        ],
+        "on_failure": null,
+        "params": {},
+        "requires_gate": null,
+        "title": "汇总假设树",
+        "wrapup": true
+      }
+    ],
+    "plan_history": [
+      {
+        "added": 1,
+        "at": "<ts>",
+        "iteration": 1,
+        "obsoleted": 0,
+        "reason": "树上仍有可扩展的 open 节点：第 1 轮扩展",
+        "source": "signal",
+        "trigger_step": "生成根假设"
+      },
+      {
+        "added": 1,
+        "at": "<ts>",
+        "iteration": 2,
+        "obsoleted": 0,
+        "reason": "扩展数已达上限（1/1），转入汇总",
+        "source": "signal",
+        "trigger_step": "第 1 轮扩展假设"
+      }
+    ],
+    "plan_iteration": 2,
+    "project_id": "<uuid-3>",
+    "skills": [],
+    "status": "done",
+    "steps": [
+      {
+        "acceptance": {
+          "checks": [
+            {
+              "kind": "no_error"
+            }
+          ],
+          "text": "根假设已入树（断点重放时复用已有根）"
+        },
+        "action": "hypothesis.seed",
+        "attempt": 1,
+        "attempts": [
+          {
+            "attempt": 1,
+            "finished_at": "<ts>",
+            "observation": {
+              "node_id": "<uuid-8>",
+              "plan_signal": {
+                "decision": "expand",
+                "next_round": 1
+              },
+              "statement": "围绕「structured agent planning」的核心假设（fake root）",
+              "usage": {
+                "completion_tokens": 27,
+                "prompt_tokens": 52
+              }
+            },
+            "started_at": "<ts>",
+            "tokens": {
+              "completion_tokens": 27,
+              "prompt_tokens": 52
+            },
+            "verdict": {
+              "passed": true,
+              "reason": "确定性检查全部通过（no_error）"
+            }
+          }
+        ],
+        "finished_at": "<ts>",
+        "id": "<uuid-7>",
+        "observation": {
+          "node_id": "<uuid-8>",
+          "plan_signal": {
+            "decision": "expand",
+            "next_round": 1
+          },
+          "statement": "围绕「structured agent planning」的核心假设（fake root）",
+          "usage": {
+            "completion_tokens": 27,
+            "prompt_tokens": 52
+          }
+        },
+        "params": {},
+        "provenance": {
+          "plan_iteration": 0
+        },
+        "rank": 0.0,
+        "requires_gate": null,
+        "seq": 0,
+        "started_at": "<ts>",
+        "status": "passed",
+        "title": "生成根假设",
+        "tokens": {
+          "completion_tokens": 27,
+          "prompt_tokens": 52
+        },
+        "verdict": {
+          "passed": true,
+          "reason": "确定性检查全部通过（no_error）"
+        }
+      },
+      {
+        "acceptance": {
+          "checks": [
+            {
+              "kind": "no_error"
+            }
+          ],
+          "text": "最优 open 节点已扩展出子假设（或按树状态判定本轮无需扩展）"
+        },
+        "action": "hypothesis.expand",
+        "attempt": 1,
+        "attempts": [
+          {
+            "attempt": 1,
+            "finished_at": "<ts>",
+            "observation": {
+              "children": [
+                "<uuid-10>",
+                "<uuid-11>"
+              ],
+              "node_id": "<uuid-8>",
+              "plan_signal": {
+                "decision": "summarize",
+                "reason": "扩展数已达上限（1/1），转入汇总"
+              },
+              "round": 1,
+              "usage": {
+                "completion_tokens": 294,
+                "prompt_tokens": 2055
+              }
+            },
+            "started_at": "<ts>",
+            "tokens": {
+              "completion_tokens": 294,
+              "prompt_tokens": 2055
+            },
+            "verdict": {
+              "passed": true,
+              "reason": "确定性检查全部通过（no_error）"
+            }
+          }
+        ],
+        "finished_at": "<ts>",
+        "id": "<uuid-9>",
+        "observation": {
+          "children": [
+            "<uuid-10>",
+            "<uuid-11>"
+          ],
+          "node_id": "<uuid-8>",
+          "plan_signal": {
+            "decision": "summarize",
+            "reason": "扩展数已达上限（1/1），转入汇总"
+          },
+          "round": 1,
+          "usage": {
+            "completion_tokens": 294,
+            "prompt_tokens": 2055
+          }
+        },
+        "params": {
+          "round": 1
+        },
+        "provenance": {
+          "plan_iteration": 0
+        },
+        "rank": 100.0,
+        "requires_gate": null,
+        "seq": 1,
+        "started_at": "<ts>",
+        "status": "passed",
+        "title": "第 1 轮扩展假设",
+        "tokens": {
+          "completion_tokens": 294,
+          "prompt_tokens": 2055
+        },
+        "verdict": {
+          "passed": true,
+          "reason": "确定性检查全部通过（no_error）"
+        }
+      },
+      {
+        "acceptance": {
+          "checks": [
+            {
+              "kind": "no_error"
+            }
+          ],
+          "text": "整树（含被剪分支）已汇总为 run 产物"
+        },
+        "action": "discovery.summarize",
+        "attempt": 1,
+        "attempts": [
+          {
+            "attempt": 1,
+            "finished_at": "<ts>",
+            "observation": {
+              "node_count": 3,
+              "stats": {
+                "expanded": 1,
+                "open": 2
+              },
+              "usage": {
+                "completion_tokens": 19,
+                "prompt_tokens": 95
+              }
+            },
+            "started_at": "<ts>",
+            "tokens": {
+              "completion_tokens": 19,
+              "prompt_tokens": 95
+            },
+            "verdict": {
+              "passed": true,
+              "reason": "确定性检查全部通过（no_error）"
+            }
+          }
+        ],
+        "finished_at": "<ts>",
+        "id": "<uuid-12>",
+        "observation": {
+          "node_count": 3,
+          "stats": {
+            "expanded": 1,
+            "open": 2
+          },
+          "usage": {
+            "completion_tokens": 19,
+            "prompt_tokens": 95
+          }
+        },
+        "params": {},
+        "provenance": {
+          "plan_iteration": 1,
+          "wrapup": true
+        },
+        "rank": 200.0,
+        "requires_gate": null,
+        "seq": 2,
+        "started_at": "<ts>",
+        "status": "passed",
+        "title": "汇总假设树",
+        "tokens": {
+          "completion_tokens": 19,
+          "prompt_tokens": 95
+        },
+        "verdict": {
+          "passed": true,
+          "reason": "确定性检查全部通过（no_error）"
+        }
+      }
+    ],
+    "updated_at": "<ts>",
+    "usage": {
+      "completion_tokens": 340,
+      "prompt_tokens": 2202,
+      "total_tokens": 2542
+    }
+  }
+}

--- a/src/backend/tests/golden/test_golden_discovery.py
+++ b/src/backend/tests/golden/test_golden_discovery.py
@@ -1,0 +1,171 @@
+"""Golden transcript：注册 → 建库 → 建课题 → 两篇 bibtex 论文 → 库索引 →
+建 discovery 任务 → 引擎跑完 → 任务详情 + 假设树。
+
+D3（#648）的回归闸门：四段假设管线（generate → ground → novelty → feasibility →
+score）在 fake provider + sqlite 上确定性运行——树的形状、每个节点的 grounding /
+novelty_report / feasibility / score、步骤观测与 token 记账，归一化后与
+``tests/golden/data/discovery_run.json`` 逐字节比对。golden 变了 = 管线行为变了，
+需要人工审查 diff 并说明理由。
+
+引擎驱动（VoyageEngine.run）不是 HTTP 步骤，不进 transcript；transcript 只收
+API 面上的可观测结果——golden 钉的是对外行为，不是内部实现。
+
+更新方式（仅限本地，CI 只比对）::
+
+    POLARIS_GOLDEN=record python -m pytest tests/golden -q
+"""
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from app.agents.voyage.engine import VoyageEngine
+from app.core.llm.router import LLMRouter
+from tests.conftest import INVITE_CODE, RecordingBus
+from tests.golden.normalize import Normalizer
+
+GOLDEN_PATH = Path(__file__).parent / "data" / "discovery_run.json"
+
+# 摘要里埋方向词（structured / agent / planning）：bibtex 论文没有全文，库索引
+# 给它们建「标题+作者+摘要」兜底块，接地检索靠这些词命中
+BIBTEX_ONE = """@article{golden2026planner,
+  title = {Structured Agent Planning Probe},
+  author = {Probe, Golden},
+  journal = {Journal of Reproducible Plumbing},
+  year = {2026},
+  abstract = {Synthetic record one: structured agent planning with verifiable
+checkpoints for the deterministic golden harness.}
+}"""
+
+BIBTEX_TWO = """@article{golden2026grounding,
+  title = {Grounded Hypothesis Evidence Probe},
+  author = {Chain, Import},
+  journal = {Journal of Reproducible Plumbing},
+  year = {2026},
+  abstract = {Synthetic record two: structured agent planning evidence with
+grounded citations for the deterministic golden harness.}
+}"""
+
+DIRECTION = "structured agent planning"
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_discovery_chain_matches_golden(client, queue_stub):
+    n = Normalizer()
+    transcript: dict[str, object] = {}
+
+    async def step(name: str, resp, expect: int) -> dict:
+        assert resp.status_code == expect, f"{name}: {resp.status_code} {resp.text[:300]}"
+        body = resp.json()
+        transcript[name] = n.normalize(body)
+        return body
+
+    await step(
+        "register",
+        await client.post(
+            "/api/auth/register",
+            json={
+                "email": "discovery-golden@example.com",
+                "password": "str0ng-password",
+                "display_name": "Discovery Golden",
+                "username": "discoverygolden",
+                "invite_code": INVITE_CODE,
+            },
+        ),
+        201,
+    )
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": "discovery-golden@example.com", "password": "str0ng-password"},
+    )
+    await step("login", login, 200)
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+    library = await step(
+        "create_library",
+        await client.post(
+            "/api/libraries",
+            json={
+                "name": "Discovery Golden Library",
+                "statement": "Deterministic golden-transcript library for the hypothesis pipeline.",
+            },
+            headers=headers,
+        ),
+        201,
+    )
+    project = await step(
+        "create_project",
+        await client.post(
+            "/api/projects",
+            json={
+                "name": "Discovery Golden Project",
+                "statement": "golden discovery chain",
+                "source_library_ids": [library["id"]],
+            },
+            headers=headers,
+        ),
+        201,
+    )
+    for name, bibtex in (("add_paper_one", BIBTEX_ONE), ("add_paper_two", BIBTEX_TWO)):
+        await step(
+            name,
+            await client.post(
+                f"/api/projects/{project['id']}/papers", json={"bibtex": bibtex}, headers=headers
+            ),
+            201,
+        )
+    await step(
+        "library_index_rebuild",
+        await client.post(f"/api/libraries/{library['id']}/index/rebuild", headers=headers),
+        200,
+    )
+    run = await step(
+        "create_discovery",
+        await client.post(
+            "/api/voyages",
+            json={
+                "kind": "discovery",
+                "project_id": project["id"],
+                "goal": DIRECTION,
+                "params": {
+                    "direction": DIRECTION,
+                    "library_id": library["id"],
+                    "max_expansions": 1,
+                },
+            },
+            headers=headers,
+        ),
+        201,
+    )
+
+    # 引擎驱动（非 HTTP 步骤）：queue 是 stub，不会有 worker 来跑，这里同步跑完
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter()).run(uuid.UUID(run["id"]))
+
+    await step(
+        "voyage_detail",
+        await client.get(f"/api/voyages/{run['id']}", headers=headers),
+        200,
+    )
+    await step(
+        "hypothesis_tree",
+        await client.get(f"/api/voyages/{run['id']}/hypothesis-tree", headers=headers),
+        200,
+    )
+
+    rendered = json.dumps(transcript, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if os.environ.get("POLARIS_GOLDEN") == "record":
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(rendered, encoding="utf-8")
+        pytest.skip(f"golden recorded: {GOLDEN_PATH}")
+    assert GOLDEN_PATH.exists(), (
+        "golden 文件缺失：本地用 POLARIS_GOLDEN=record 录制一次并连同代码提交"
+    )
+    expected = GOLDEN_PATH.read_text(encoding="utf-8")
+    assert rendered == expected, (
+        "golden transcript 变了。若这是有意的行为变更：本地 POLARIS_GOLDEN=record 重录，"
+        "人工审查 diff 后随代码一起提交。"
+    )

--- a/src/backend/tests/test_hypothesis_pipeline.py
+++ b/src/backend/tests/test_hypothesis_pipeline.py
@@ -1,0 +1,301 @@
+"""文献→假设四段管线（#648，services/hypothesis_pipeline.py）：逐段确定性用例。
+
+sqlite 测试库没有 pgvector，检索原语走关键词降级路径；fake provider 的四个
+marker 输出全部确定性（见 core/llm/fake.py），因此每段的输入→输出可以精确断言：
+
+- generate：三路灵感取材（语义近邻 / 引文 2 跳远端 / 多样窗）+ 去重折叠；
+- ground：拆子命题 → top-5 检索 → 只许从检索集内选 + 越界引用降 speculation；
+- novelty：换措辞复检 + 逐子命题 verdict（speculation 不送 judge）；
+- feasibility：确定性资源信号 + fake 风险论证；
+- score：novel 比例 × support 覆盖率 的乘积公式。
+"""
+
+import uuid
+
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.paper import PaperChunk
+from app.models.paper_citation import PaperCitation
+from app.services import hypothesis_pipeline as pipeline
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+DIRECTION = "agent planning verification"
+
+# 语料按「哪条查询能命中哪篇论文」精确埋词：A 被方向命中；B 只能靠 A→M→B 的
+# 引文 2 跳进灵感；C 不含任何查询词，只能被多样窗捞到
+BODY_A = "agent planning verification with tree search. " + "规划方法的细节论述。" * 20
+BODY_M = "intermediate hop paper body. " + "中间论文的论述。" * 20
+BODY_B = "distant structural relative body. " + "远端论文的论述。" * 20
+BODY_C = "unrelated diverse window body. " + "多样窗论文的论述。" * 20
+
+
+async def _setup(client, *, with_citations: bool = False):
+    """建库 + 四篇带片段的成员论文（可选 A→M→B 引文链），返回 (library_id, ids)。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="pipeline-lib", statement="假设管线测试库"
+    )
+    bodies = {"A": BODY_A, "M": BODY_M, "B": BODY_B, "C": BODY_C}
+    ids: dict[str, uuid.UUID] = {}
+    async with get_sessionmaker()() as session:
+        for key, body in bodies.items():
+            paper = await add_paper(
+                session,
+                project_id=project_id,
+                title=f"Pipeline Paper {key}",
+                abstract=f"abstract {key}",
+                year=2020 + len(ids),
+                venue="VenueX" if key in ("A", "M") else "VenueY",
+                relevance_score=0.9,
+                status="compiled",
+            )
+            session.add(PaperChunk(paper_id=paper.id, seq=0, text=body, source="fulltext"))
+            ids[key] = paper.id
+        if with_citations:
+            # A→M→B：B 与 A 图距离 2，是「非直接邻居」的远端灵感来源
+            session.add(
+                PaperCitation(
+                    citing_paper_id=ids["A"],
+                    cited_paper_id=ids["M"],
+                    ref_index=1,
+                    cited_ref_raw="[1] Pipeline Paper M.",
+                )
+            )
+            session.add(
+                PaperCitation(
+                    citing_paper_id=ids["M"],
+                    cited_paper_id=ids["B"],
+                    ref_index=1,
+                    cited_ref_raw="[1] Pipeline Paper B.",
+                )
+            )
+        await session.commit()
+    return library_id, ids
+
+
+# ---- 纯函数：去重折叠 / 越界引用降级 / 评分 ----
+
+
+def test_dedup_candidates_collapses_near_duplicates():
+    """相似度 >0.85 折叠（保留先出现的）；措辞差异大的都保留；空陈述丢弃。"""
+    kept = pipeline.dedup_candidates(
+        [
+            {"statement": "Planning improves agent reliability in long tasks"},
+            # 近重复：只差一个标点
+            {"statement": "Planning improves agent reliability in long tasks!"},
+            {"statement": "Retrieval grounding reduces hallucinated citations"},
+            {"statement": "  "},  # 空陈述
+        ]
+    )
+    assert [c["statement"] for c in kept] == [
+        "Planning improves agent reliability in long tasks",
+        "Retrieval grounding reduces hallucinated citations",
+    ]
+
+
+def test_sanitize_grounding_downgrades_out_of_set_citations():
+    """越界校验：id 不在该子命题自己的检索集内 → 丢弃；没剩合法 id → speculation。"""
+    subclaims = ["s0", "s1", "s2"]
+    retrieved = [
+        [{"paper_id": "p-a", "title": "A", "snippet": "snip-a"}],
+        [{"paper_id": "p-b", "title": "B", "snippet": "snip-b"}],
+        [],
+    ]
+    items = [
+        # 合法引用 + 一条越界 id（越界的被静默丢弃，合法的保留）
+        {"index": 0, "stance": "support", "paper_ids": ["p-a", "p-forged"]},
+        # 全部越界（含跨子命题引用 p-a：不在 s1 自己的检索集里也算越界）→ speculation
+        {"index": 1, "stance": "refute", "paper_ids": ["p-a", "p-forged"]},
+        # 乱写的立场 → speculation
+        {"index": 2, "stance": "definitely-true", "paper_ids": []},
+    ]
+    out = pipeline.sanitize_grounding(subclaims, retrieved, items)
+    assert out[0] == {
+        "subclaim": "s0",
+        "stance": "support",
+        "paper_ids": ["p-a"],
+        "snippets": ["snip-a"],
+    }
+    assert out[1]["stance"] == "speculation" and out[1]["paper_ids"] == []
+    assert out[2]["stance"] == "speculation"
+
+
+def test_sanitize_grounding_missing_item_is_speculation():
+    """LLM 漏答某条子命题：诚实缺省为 speculation，而不是报错或编造。"""
+    retrieved = [[{"paper_id": "p", "title": "", "snippet": "x"}]]
+    out = pipeline.sanitize_grounding(["s0"], retrieved, [])
+    assert out == [{"subclaim": "s0", "stance": "speculation", "paper_ids": [], "snippets": []}]
+
+
+def test_score_hypothesis_is_product_of_ratios():
+    """score = novel 比例 × support 覆盖率；空接地为 0（没有子命题就没有依据）。"""
+    grounding = [
+        {"subclaim": "s0", "stance": "support"},
+        {"subclaim": "s1", "stance": "speculation"},
+    ]
+    report = {"subclaims": [{"verdict": "novel"}, {"verdict": "uncertain"}]}
+    assert pipeline.score_hypothesis(grounding, report) == 0.25  # (1/2) × (1/2)
+    all_support_novel = [{"subclaim": "s", "stance": "support"}] * 2
+    full = {"subclaims": [{"verdict": "novel"}, {"verdict": "novel"}]}
+    assert pipeline.score_hypothesis(all_support_novel, full) == 1.0
+    assert pipeline.score_hypothesis([], {"subclaims": []}) == 0.0
+    assert pipeline.novelty_ratio({"subclaims": []}) == 0.0
+
+
+# ---- 灵感取材（确定性辅助函数） ----
+
+
+async def test_citation_far_route_reaches_two_hop_papers(client):
+    """引文远端：A 的 2 跳邻居是 B（经 M）；直接邻居 M 不入选，B 的片段入选。"""
+    library_id, ids = await _setup(client, with_citations=True)
+    async with get_sessionmaker()() as session:
+        chunks = await pipeline._citation_far_chunks(
+            session, library_id=library_id, seed_paper_ids=[ids["A"]]
+        )
+    assert [c.paper_id for c in chunks] == [ids["B"]]
+
+
+async def test_diverse_window_route_excludes_covered_papers(client):
+    """多样窗：已被其他两路覆盖的论文让位，等距取样确定性可复现。"""
+    library_id, ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        first = await pipeline._diverse_window_chunks(
+            session, library_id=library_id, exclude_paper_ids={ids["A"], ids["M"]}
+        )
+        second = await pipeline._diverse_window_chunks(
+            session, library_id=library_id, exclude_paper_ids={ids["A"], ids["M"]}
+        )
+    assert {c.paper_id for c in first} <= {ids["B"], ids["C"]}
+    assert [(c.paper_id, c.seq) for c in first] == [(c.paper_id, c.seq) for c in second]
+
+
+async def test_generate_returns_deduped_candidates_with_usage(client):
+    """generate 端到端（fake）：两个回显方向的候选，去重不误伤，usage 有账。"""
+    library_id, _ids = await _setup(client, with_citations=True)
+    async with get_sessionmaker()() as session:
+        result = await pipeline.generate(
+            session, LLMRouter(), library_id=library_id, direction=DIRECTION, n_candidates=3
+        )
+    statements = [c["statement"] for c in result["candidates"]]
+    assert len(statements) == 2  # fake 固定两候选，措辞差异大、不被折叠
+    assert all(DIRECTION[:20] in s for s in statements)
+    assert result["usage"]["prompt_tokens"] > 0
+
+
+# ---- 接地 / 查新 / 可行性（fake 端到端） ----
+
+
+async def test_ground_selects_real_paper_and_marks_speculation(client):
+    """ground：拆 2 条子命题；第一条 support 引真实库内论文并回填片段，
+    第二条 speculation（fake 确定性行为，也是无证据时的诚实缺省）。"""
+    library_id, ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        result = await pipeline.ground(
+            session,
+            LLMRouter(),
+            library_id=library_id,
+            statement=f"关于 {DIRECTION} 的机制假设",
+        )
+    grounding = result["grounding"]
+    assert [g["stance"] for g in grounding] == ["support", "speculation"]
+    assert grounding[0]["paper_ids"] == [str(ids["A"])]  # 方向词只埋在 A 里
+    assert grounding[0]["snippets"] and "agent planning" in grounding[0]["snippets"][0]
+    assert result["usage"]["prompt_tokens"] > 0
+
+
+async def test_ground_without_hits_is_all_speculation(client):
+    """库里检索不到任何相关片段：不许硬选 → 全部 speculation。"""
+    library_id, _ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        result = await pipeline.ground(
+            session,
+            LLMRouter(),
+            library_id=library_id,
+            statement="冰川沉积物同位素定年",  # 与库内语料零重叠
+        )
+    assert [g["stance"] for g in result["grounding"]] == ["speculation", "speculation"]
+    assert all(g["paper_ids"] == [] for g in result["grounding"])
+
+
+async def test_novelty_judges_only_grounded_subclaims(client):
+    """novelty：support 子命题送 judge（fake 判 novel、引证据首 id）；
+    speculation 不送 judge、如实 uncertain / judged=False。"""
+    library_id, ids = await _setup(client)
+    grounding = [
+        {
+            "subclaim": f"{DIRECTION} 的机制子命题",
+            "stance": "support",
+            "paper_ids": [str(ids["A"])],
+        },
+        {"subclaim": "无证据的推测子命题", "stance": "speculation", "paper_ids": []},
+    ]
+    async with get_sessionmaker()() as session:
+        result = await pipeline.novelty(
+            session,
+            LLMRouter(),
+            library_id=library_id,
+            statement="stmt",
+            grounding=grounding,
+        )
+    report = result["report"]["subclaims"]
+    assert [r["verdict"] for r in report] == ["novel", "uncertain"]
+    assert [r["judged"] for r in report] == [True, False]
+    assert report[0]["paper_ids"] == [str(ids["A"])]  # 复检查询仍只命中 A
+    assert result["usage"]["prompt_tokens"] > 0
+
+
+async def test_novelty_all_speculation_skips_llm(client):
+    """全 speculation：没有可判的子命题，不调 LLM（usage 为零）、全 uncertain。"""
+    library_id, _ids = await _setup(client)
+    grounding = [{"subclaim": "s", "stance": "speculation", "paper_ids": []}]
+    async with get_sessionmaker()() as session:
+        result = await pipeline.novelty(
+            session, LLMRouter(), library_id=library_id, statement="stmt", grounding=grounding
+        )
+    assert result["report"]["subclaims"][0]["verdict"] == "uncertain"
+    assert result["usage"] == {"prompt_tokens": 0, "completion_tokens": 0}
+
+
+async def test_feasibility_signals_are_deterministic(client):
+    """feasibility：venue/年份/密度信号由代码统计（fake 不碰），风险论证来自 LLM。"""
+    library_id, ids = await _setup(client)
+    grounding = [
+        {
+            "subclaim": "s0",
+            "stance": "support",
+            "paper_ids": [str(ids["A"]), str(ids["B"])],
+        },
+        {"subclaim": "s1", "stance": "speculation", "paper_ids": []},
+    ]
+    async with get_sessionmaker()() as session:
+        result = await pipeline.feasibility(
+            session,
+            LLMRouter(),
+            library_id=library_id,
+            statement=DIRECTION,
+            grounding=grounding,
+        )
+    signals = result["feasibility"]["signals"]
+    assert signals["grounded_paper_count"] == 2
+    assert signals["venues"] == {"VenueX": 1, "VenueY": 1}
+    assert signals["year_range"] == [2020, 2022]  # A=2020、B=2022（M 不在接地集里）
+    assert signals["related_chunk_hits"] >= 1  # 方向词埋在 A 的片段里
+    assert "fake 可行性" in result["feasibility"]["risk_note"]
+
+
+async def test_feasibility_empty_grounding_still_reports_signals(client):
+    """全推测的假设也要有可行性信号（都是 0/空）：信号是统计不是判断。"""
+    library_id, _ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        result = await pipeline.feasibility(
+            session,
+            LLMRouter(),
+            library_id=library_id,
+            statement="冰川沉积物同位素定年",
+            grounding=[{"subclaim": "s", "stance": "speculation", "paper_ids": []}],
+        )
+    signals = result["feasibility"]["signals"]
+    assert signals["grounded_paper_count"] == 0
+    assert signals["venues"] == {} and signals["year_range"] is None
+    assert signals["related_chunk_hits"] == 0

--- a/src/backend/tests/test_voyage_discovery.py
+++ b/src/backend/tests/test_voyage_discovery.py
@@ -1,11 +1,16 @@
-"""discovery 任务（#642，P2 D2）：树搜索规划 + fake 骨架 run 端到端。
+"""discovery 任务（#642 D2 + #648 D3）：树搜索规划 + 四段假设管线端到端。
 
 - 计划模板只有播种一步（树才是真源），后续每轮由 plan_signal 经确定性分支表展开；
-- 创建入口的参数定形（direction 必填 / max_expansions 默认 3 / tournament 先存不实现）；
-- fake provider 下端到端：根 + 两子 + 状态、汇总产物（被剪分支留痕结构）、每节点记账；
+- 创建入口的参数定形（direction/library_id 必填 / max_expansions 默认 3 /
+  tournament 先存不实现）+ 库可见性校验；
+- fake provider 下端到端：每轮扩展走 generate → ground → novelty → feasibility →
+  score 管线，子节点带三类证据数据落库（fake 确定性中间态 score=0.25）；
+- 低分（score < 0.15）子候选自动剪枝（级联留痕语义与 hypothesis.prune 一致）；
+- 汇总产物升级为研究方案（存活假设按 score 降序 + 被剪分支附录）；
 - max_expansions 截止；
-- 断点恢复两种杀点：扩展前被杀（重启按 best_open_node 确定性重选同一节点）、
-  子节点落库后 checkpoint 回写前被杀（树上 expanded 计数补账，不重复扩）。
+- 断点恢复两种杀点：扩展前被杀（管线全部发生在动树之前，重启即干净重跑、
+  best_open_node 确定性重选同一节点）、子节点落库后 checkpoint 回写前被杀
+  （树上 expanded 计数补账，不重复扩）。
 """
 
 import json
@@ -21,8 +26,14 @@ from app.agents.voyage.plan_edit import discovery_signal_edits
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
 from app.models.hypothesis import HypothesisNode
+from app.models.paper import PaperChunk
 from app.models.voyage import VoyageRun, VoyageStep, mode_for_kind
-from tests.conftest import RecordingBus, register_and_login
+from tests.conftest import (
+    RecordingBus,
+    add_paper,
+    make_project_with_library,
+    register_and_login,
+)
 
 # ---- 纯函数：计划模板 + 确定性分支表 ----
 
@@ -67,15 +78,48 @@ def test_discovery_signal_edits_idempotent():
 
 # ---- 造数据助手 ----
 
+# 库内语料：覆盖各测试用到的方向短语（fake 管线的子命题会回显方向文本，关键词
+# 检索按整段中文 token 匹配，所以语料必须**逐字包含**这些短语才能命中接地检索）
+_CORPUS_HIT = (
+    "agent planning verification corpus for discovery. "
+    "本库覆盖：可验证的 agent 工作流、同一方向、截止测试方向、恢复测试方向二、"
+    "剪枝测试方向 的相关论述与实验证据。" + "库内语料的细节论述。" * 30
+)
+# 与任何方向都不相干的语料（低分自动剪枝路径专用：接地检索必然空手而归）
+_CORPUS_MISS = "alpine botanical taxonomy notes. " + "高山植物志的形态描述。" * 30
 
-async def _make_project(client) -> tuple[str, dict]:
+
+async def _make_workspace(client, *, corpus: str = _CORPUS_HIT) -> tuple[str, uuid.UUID, dict]:
+    """建课题 + 关联库 + 两篇带片段的成员论文，返回 (project_id, library_id, headers)。"""
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
-    resp = await client.post("/api/projects", json={"name": "discovery-proj"}, headers=headers)
-    return resp.json()["id"], headers
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="discovery-lib", statement="discovery 管线测试库"
+    )
+    async with get_sessionmaker()() as session:
+        for i in range(2):
+            paper = await add_paper(
+                session,
+                project_id=project_id,
+                title=f"Discovery Corpus Paper {i}",
+                abstract=f"corpus abstract {i}",
+                year=2024 + i,
+                venue="TestConf",
+                relevance_score=0.9,
+                status="compiled",
+            )
+            session.add(
+                PaperChunk(
+                    paper_id=paper.id, seq=0, text=f"{corpus}（第 {i} 篇）", source="fulltext"
+                )
+            )
+        await session.commit()
+    return project_id, library_id, headers
 
 
-async def _make_run(project_id: str, *, direction: str, max_expansions: int) -> uuid.UUID:
+async def _make_run(
+    project_id: str, library_id: uuid.UUID, *, direction: str, max_expansions: int
+) -> uuid.UUID:
     """直建 run（plan=None：首次驱动由 navigator 的 discovery 模板补计划）。"""
     async with get_sessionmaker()() as session:
         run = VoyageRun(
@@ -86,11 +130,13 @@ async def _make_run(project_id: str, *, direction: str, max_expansions: int) -> 
             checkpoint={
                 "params": {
                     "direction": direction,
+                    "library_id": str(library_id),
                     "max_expansions": max_expansions,
                     "tournament": False,
                 }
             },
             project_id=uuid.UUID(project_id),
+            library_id=library_id,
         )
         session.add(run)
         await session.commit()
@@ -116,18 +162,33 @@ async def _tree(run_id: uuid.UUID) -> list[HypothesisNode]:
         )
 
 
+async def _library_paper_ids(library_id: uuid.UUID) -> set[str]:
+    from app.models.library_direction import LibraryPaper
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            await session.execute(
+                select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library_id)
+            )
+        ).scalars()
+        return {str(pid) for pid in rows}
+
+
 # ---- 创建入口（通用 POST /api/voyages） ----
 
 
 async def test_discovery_create_api_normalizes_params(client, queue_stub):
-    project_id, headers = await _make_project(client)
+    project_id, library_id, headers = await _make_workspace(client)
     resp = await client.post(
         "/api/voyages",
         json={
             "kind": "discovery",
             "project_id": project_id,
             "goal": "LLM agent 的长期记忆机制",
-            "params": {"direction": "  LLM agent 的长期记忆机制  "},
+            "params": {
+                "direction": "  LLM agent 的长期记忆机制  ",
+                "library_id": str(library_id),
+            },
         },
         headers=headers,
     )
@@ -137,14 +198,22 @@ async def test_discovery_create_api_normalizes_params(client, queue_stub):
     async with get_sessionmaker()() as session:
         run = await session.get(VoyageRun, uuid.UUID(run_id))
         params = (run.checkpoint or {})["params"]
-        # 参数在创建时定形：方向去空白、扩展数缺省 3、tournament 先存不实现
+        # 参数在创建时定形：方向去空白、扩展数缺省 3、tournament 先存不实现；
+        # 库关联同时落列（费用记账/列表过滤按列走，params 只是输入存档）
         assert params["direction"] == "LLM agent 的长期记忆机制"
+        assert params["library_id"] == str(library_id)
         assert params["max_expansions"] == 3
         assert params["tournament"] is False
+        assert run.library_id == library_id
 
-    # direction 缺失 / max_expansions 非法 → 422（引擎端不再兜底坏参数）
-    for bad_params in ({}, {"direction": "x", "max_expansions": -1},
-                       {"direction": "x", "max_expansions": "many"}):
+    # direction/library_id 缺失、max_expansions 非法 → 422（引擎端不再兜底坏参数）
+    for bad_params in (
+        {},
+        {"direction": "x"},  # #648 起 library_id 必填
+        {"direction": "x", "library_id": "not-a-uuid"},
+        {"direction": "x", "library_id": str(library_id), "max_expansions": -1},
+        {"direction": "x", "library_id": str(library_id), "max_expansions": "many"},
+    ):
         resp = await client.post(
             "/api/voyages",
             json={
@@ -157,14 +226,30 @@ async def test_discovery_create_api_normalizes_params(client, queue_stub):
         )
         assert resp.status_code == 422, bad_params
 
+    # 库不存在（或不可见）→ 404，与库只读端点同口径
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "g",
+            "params": {"direction": "x", "library_id": str(uuid.uuid4())},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "LIBRARY_NOT_FOUND"
 
-# ---- fake 骨架 run 端到端 ----
+
+# ---- fake 管线 run 端到端 ----
 
 
-async def test_discovery_skeleton_run(client, queue_stub):
-    """max_expansions=1 的最小闭环：播种 → 一轮扩展 → 汇总 → done。"""
-    project_id, _headers = await _make_project(client)
-    run_id = await _make_run(project_id, direction="可验证的 agent 工作流", max_expansions=1)
+async def test_discovery_pipeline_run(client, queue_stub):
+    """max_expansions=1 的最小闭环：播种 → 一轮管线扩展 → 汇总 → done。"""
+    project_id, library_id, _headers = await _make_workspace(client)
+    run_id = await _make_run(
+        project_id, library_id, direction="可验证的 agent 工作流", max_expansions=1
+    )
     await _engine().run(run_id)
 
     async with get_sessionmaker()() as session:
@@ -188,7 +273,7 @@ async def test_discovery_skeleton_run(client, queue_stub):
         ]
         assert all(s.status == "passed" for s in steps)
 
-        # 树结构：根（expanded，方向回显）+ 两个 open 子假设
+        # 树结构：根（expanded，方向回显）+ 两个 open 子假设（fake 管线中间态）
         nodes = await _tree(run_id)
         assert len(nodes) == 3
         root, child_a, child_b = nodes
@@ -197,11 +282,42 @@ async def test_discovery_skeleton_run(client, queue_stub):
         assert root.score == 0.8
         assert {child_a.parent_id, child_b.parent_id} == {root.id}
         assert child_a.status == "open" and child_b.status == "open"
-        assert (child_a.score, child_b.score) == (0.7, 0.6)
+        assert "fake A" in child_a.statement and "fake B" in child_b.statement
 
-        # 汇总产物：全部节点 + 状态 + 统计（被剪分支也会留在 nodes 里，这里为 0）
+        member_ids = await _library_paper_ids(library_id)
+        for child in (child_a, child_b):
+            # 接地：2 条子命题——第一条 support（引用真实库内论文 + 回填片段），
+            # 第二条 speculation（fake 的确定性中间态）
+            grounding = child.grounding
+            assert [g["stance"] for g in grounding] == ["support", "speculation"]
+            assert grounding[0]["paper_ids"] and set(grounding[0]["paper_ids"]) <= member_ids
+            assert grounding[0]["snippets"]
+            assert grounding[1]["paper_ids"] == [] and grounding[1]["snippets"] == []
+            # 查新：support 子命题判 novel（引证据），speculation 不送 judge、如实 uncertain
+            report = child.novelty_report["subclaims"]
+            assert [r["verdict"] for r in report] == ["novel", "uncertain"]
+            assert [r["judged"] for r in report] == [True, False]
+            assert set(report[0]["paper_ids"]) <= member_ids
+            # 可行性：确定性信号 + fake 风险论证
+            signals = child.feasibility["signals"]
+            assert signals["grounded_paper_count"] == 1
+            assert signals["related_chunk_hits"] >= 1
+            assert signals["venues"] == {"TestConf": 1}
+            assert "fake 可行性" in child.feasibility["risk_note"]
+            # score = novel 比例 (1/2) × support 覆盖率 (1/2)
+            assert child.score == 0.25
+
+        # 汇总产物 = 研究方案：存活假设按 score 降序、被剪附录为空、全节点快照
         artifact = json.loads((run.checkpoint or {})["artifacts"]["discovery-summary.json"])
         assert artifact["stats"] == {"expanded": 1, "open": 2}
+        assert artifact["direction"] == "可验证的 agent 工作流"
+        assert [h["score"] for h in artifact["hypotheses"]] == [0.8, 0.25, 0.25]
+        assert artifact["hypotheses"][0]["id"] == str(root.id)
+        # 证据卡数据随方案携带（前端/导出直接消费）
+        assert artifact["hypotheses"][1]["grounding"][0]["stance"] == "support"
+        assert artifact["hypotheses"][1]["novelty_report"]["subclaims"]
+        assert artifact["hypotheses"][1]["feasibility"]["signals"]
+        assert artifact["pruned_appendix"] == []
         assert {n["id"] for n in artifact["nodes"]} == {str(n.id) for n in nodes}
         assert artifact["summary"].startswith("（fake discovery 总结）")
 
@@ -212,30 +328,72 @@ async def test_discovery_skeleton_run(client, queue_stub):
         assert all(d["why"] for d in decisions)
         assert decisions[1]["node_id"] == str(root.id)  # 第 1 轮扩的就是根
 
-        # 每节点记账：seed 记到根、expand 记到被扩展的根（只记不限）
+        # 每节点记账：seed+generate 记到根；每个子节点记它自己的接地/查新/可行性
         usage = state["node_usage"][str(root.id)]
         assert usage["prompt_tokens"] > 0 and usage["completion_tokens"] > 0
+        for child in (child_a, child_b):
+            child_usage = state["node_usage"][str(child.id)]
+            assert child_usage["prompt_tokens"] > 0 and child_usage["completion_tokens"] > 0
         # 产物里的节点快照带着账本
         root_snapshot = next(n for n in artifact["nodes"] if n["id"] == str(root.id))
         assert root_snapshot["usage"] == usage
 
 
 async def test_discovery_run_is_replayable(client, queue_stub):
-    """确定性：同参数两次骨架 run 长出同形状的树（fake provider 无随机）。"""
-    project_id, _headers = await _make_project(client)
+    """确定性：同参数两次管线 run 长出同形状的树（检索/取材/评分全无随机源）。"""
+    project_id, library_id, _headers = await _make_workspace(client)
     shapes = []
     for _ in range(2):
-        run_id = await _make_run(project_id, direction="同一方向", max_expansions=1)
+        run_id = await _make_run(project_id, library_id, direction="同一方向", max_expansions=1)
         await _engine().run(run_id)
         nodes = await _tree(run_id)
-        shapes.append([(n.statement, n.status, n.score, n.parent_id is None) for n in nodes])
+        shapes.append(
+            [
+                (n.statement, n.status, n.score, n.parent_id is None, json.dumps(n.grounding))
+                for n in nodes
+            ]
+        )
     assert shapes[0] == shapes[1]
+
+
+async def test_discovery_low_score_children_auto_pruned(client, queue_stub):
+    """库里没有任何相关语料：接地检索空手 → 全 speculation → score=0 < 0.15 →
+    两个子候选当场剪枝（留痕不删）→ 无 open 节点 → 直接转汇总。"""
+    project_id, library_id, _headers = await _make_workspace(client, corpus=_CORPUS_MISS)
+    run_id = await _make_run(project_id, library_id, direction="东岸洋流建模", max_expansions=3)
+    await _engine().run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        state = (run.checkpoint or {})["discovery"]
+    nodes = await _tree(run_id)
+    assert len(nodes) == 3
+    root = next(n for n in nodes if n.parent_id is None)
+    children = [n for n in nodes if n.parent_id is not None]
+    assert root.status == "expanded"
+    # 无接地证据的候选：全 speculation → score 0 → 自动剪枝
+    assert all(n.status == "pruned" and n.score == 0.0 for n in children)
+    assert all(g["stance"] == "speculation" for n in children for g in n.grounding)
+    # 剪枝决策留痕（含阈值依据），账本记了本轮的被剪名单
+    pruned_ids = {str(n.id) for n in children}
+    pruned_decisions = [d for d in state["decisions"] if d["decision"] == "pruned"]
+    assert {d["node_id"] for d in pruned_decisions} == pruned_ids
+    assert all("自动剪枝" in d["why"] for d in pruned_decisions)
+    assert set(state["rounds"]["1"]["pruned"]) == pruned_ids
+    # 汇总产物：方案主体只剩根，附录如实收录被剪分支及原因
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        artifact = json.loads((run.checkpoint or {})["artifacts"]["discovery-summary.json"])
+    assert [h["id"] for h in artifact["hypotheses"]] == [str(root.id)]
+    assert {p["id"] for p in artifact["pruned_appendix"]} == pruned_ids
+    assert all("自动剪枝" in p["reason"] for p in artifact["pruned_appendix"])
 
 
 async def test_discovery_max_expansions_cutoff(client, queue_stub):
     """扩展数达到上限即转汇总：2 轮 → 1 根 + 2×2 子 = 5 节点、2 个 expanded。"""
-    project_id, _headers = await _make_project(client)
-    run_id = await _make_run(project_id, direction="截止测试方向", max_expansions=2)
+    project_id, library_id, _headers = await _make_workspace(client)
+    run_id = await _make_run(project_id, library_id, direction="截止测试方向", max_expansions=2)
     await _engine().run(run_id)
 
     async with get_sessionmaker()() as session:
@@ -255,9 +413,9 @@ async def test_discovery_max_expansions_cutoff(client, queue_stub):
     assert len(nodes) == 5
     assert sum(1 for n in nodes if n.status == "expanded") == 2
     assert sum(1 for n in nodes if n.status == "open") == 3
-    # 第 2 轮扩的是第 1 轮的高分子假设 A（best_open_node：score 降序、同分取先建）
+    # 第 2 轮扩的是第 1 轮的先建子候选（同分 0.25，best_open_node 同分取先建）
     round2_parent = next(n for n in nodes if n.status == "expanded" and n.parent_id is not None)
-    assert "子假设 A" in round2_parent.statement
+    assert "fake A" in round2_parent.statement
 
 
 # ---- 断点恢复（kill 中途重启，从 checkpoint + best_open_node 确定性重建） ----
@@ -273,10 +431,11 @@ async def _run_expecting_kill(run_id: uuid.UUID) -> None:
 
 
 async def test_discovery_resume_kill_before_mutation(client, queue_stub):
-    """杀点①：第 2 轮扩展动手前被杀。重启后步骤复位重跑，best_open_node 对同一棵
-    树是确定性的——重选到同一个节点，最终树与不被杀完全一致。"""
-    project_id, _headers = await _make_project(client)
-    run_id = await _make_run(project_id, direction="恢复测试方向", max_expansions=2)
+    """杀点①：第 2 轮扩展动手前被杀。管线的 LLM/检索全部发生在动树之前，重启后
+    步骤复位重跑；best_open_node 对同一棵树是确定性的——重选到同一个节点，
+    最终树与不被杀完全一致。"""
+    project_id, library_id, _headers = await _make_workspace(client)
+    run_id = await _make_run(project_id, library_id, direction="恢复测试方向", max_expansions=2)
 
     orig = actions_registry._REGISTRY["hypothesis.expand"]
     fired = False
@@ -317,20 +476,20 @@ async def test_discovery_resume_kill_before_mutation(client, queue_stub):
         run = await session.get(VoyageRun, run_id)
         assert run.status == "done"
         state = (run.checkpoint or {})["discovery"]
-        # 两轮都正常入账；第 2 轮选中的目标 = 确定性 best_open_node（高分子假设 A）
+        # 两轮都正常入账；第 2 轮选中的目标 = 确定性 best_open_node（先建子候选）
         assert set(state["rounds"]) == {"1", "2"}
         assert state["rounds"]["2"]["node_id"] is not None
     nodes = await _tree(run_id)
     assert len(nodes) == 5
     round2_parent = next(n for n in nodes if str(n.id) == state["rounds"]["2"]["node_id"])
-    assert "子假设 A" in round2_parent.statement and round2_parent.status == "expanded"
+    assert "fake A" in round2_parent.statement and round2_parent.status == "expanded"
 
 
 async def test_discovery_resume_kill_after_mutation(client, queue_stub):
     """杀点②：第 2 轮子节点已落库、checkpoint 还没回写就被杀。重启后账本比树少
     一轮，靠树上的 expanded 计数补账、绝不重复扩——总节点数不变。"""
-    project_id, _headers = await _make_project(client)
-    run_id = await _make_run(project_id, direction="恢复测试方向二", max_expansions=2)
+    project_id, library_id, _headers = await _make_workspace(client)
+    run_id = await _make_run(project_id, library_id, direction="恢复测试方向二", max_expansions=2)
 
     orig = actions_registry._REGISTRY["hypothesis.expand"]
     fired = False
@@ -365,14 +524,14 @@ async def test_discovery_resume_kill_after_mutation(client, queue_stub):
 
 
 async def test_discovery_prune_action_cascades(client, queue_stub):
-    """hypothesis.prune：写 score + 级联剪枝（留痕不删），fake 骨架跑完后手动调用。"""
+    """hypothesis.prune：写 score + 级联剪枝（留痕不删），fake 管线跑完后手动调用。"""
     from app.agents.voyage.actions import ActionContext
 
-    project_id, _headers = await _make_project(client)
-    run_id = await _make_run(project_id, direction="剪枝测试方向", max_expansions=2)
+    project_id, library_id, _headers = await _make_workspace(client)
+    run_id = await _make_run(project_id, library_id, direction="剪枝测试方向", max_expansions=2)
     await _engine().run(run_id)
     nodes = await _tree(run_id)
-    # 第 1 轮的子假设 A 已被第 2 轮扩展：剪它应级联剪掉它的两个孩子
+    # 第 1 轮的先建子候选已被第 2 轮扩展：剪它应级联剪掉它的两个孩子
     target = next(n for n in nodes if n.status == "expanded" and n.parent_id is not None)
 
     async with get_sessionmaker()() as session:

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -22,9 +22,16 @@ const MAX_EXPANSIONS_LIMIT = 10; // 与后端 schemas/voyage.MAX_DISCOVERY_EXPAN
 export function DiscoveryCreateButton({ projectId }: { projectId: string | null }) {
   const [open, setOpen] = useState(false);
   const [direction, setDirection] = useState('');
+  const [libraryId, setLibraryId] = useState('');
   const [maxExpansions, setMaxExpansions] = useState(3);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  // 文献库必选（#648）：四段假设管线的检索/接地边界就是这个库
+  const { data: libraries } = useQuery({
+    queryKey: ['libraries', 'all'],
+    queryFn: () => api.listLibraries(),
+    enabled: open,
+  });
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -32,7 +39,7 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
         kind: 'discovery',
         project_id: projectId!,
         goal: direction.trim(),
-        params: { direction: direction.trim(), max_expansions: maxExpansions },
+        params: { direction: direction.trim(), max_expansions: maxExpansions, library_id: libraryId },
       }),
     onSuccess: (run) => {
       setOpen(false);
@@ -44,7 +51,7 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
       toast(`${tr('创建失败：', 'Create failed: ')}${e instanceof Error ? e.message : String(e)}`, 'error'),
   });
 
-  const canSubmit = !!projectId && direction.trim().length > 0 && !createMutation.isPending;
+  const canSubmit = !!projectId && direction.trim().length > 0 && !!libraryId && !createMutation.isPending;
   return (
     <>
       <button
@@ -89,6 +96,25 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
               placeholder={tr('想探索的研究方向…', 'Direction to explore…')}
             />
           </FormField>
+          <FormField
+            label="文献库"
+            en="Library"
+            hint={tr('假设的文献接地与查新都在这个库里检索', 'Grounding and novelty checks retrieve from this library')}
+            style={{ marginTop: 10 }}
+          >
+            <select
+              className="input"
+              value={libraryId}
+              onChange={(e) => setLibraryId(e.target.value)}
+            >
+              <option value="">{tr('选择文献库…', 'Pick a library…')}</option>
+              {(libraries ?? []).map((lib) => (
+                <option key={lib.id} value={lib.id}>
+                  {lib.name}（{lib.paper_count} {tr('篇', 'papers')}）
+                </option>
+              ))}
+            </select>
+          </FormField>
           <details style={{ marginTop: 12 }}>
             <summary style={{ fontSize: 12, color: 'var(--text-3)', cursor: 'pointer', userSelect: 'none' }}>
               {tr('高级选项', 'Advanced')}
@@ -129,6 +155,19 @@ const NODE_STATUS_META: Record<string, { zh: string; en: string; bg: string; tx:
   validated: { zh: '已验证', en: 'Validated', bg: 'var(--ok-bg)', tx: 'var(--ok-tx)' },
   refuted: { zh: '已否证', en: 'Refuted', bg: 'var(--danger-bg)', tx: 'var(--danger-tx)' },
 };
+
+/** grounding 的三类立场计数（#648 证据卡的最小增量；完整证据卡 UI 归 D5）。 */
+function stanceCounts(grounding: unknown[] | null): { sup: number; ref: number; spec: number } | null {
+  if (!Array.isArray(grounding) || grounding.length === 0) return null;
+  const counts = { sup: 0, ref: 0, spec: 0 };
+  for (const entry of grounding) {
+    const stance = (entry as { stance?: string } | null)?.stance;
+    if (stance === 'support') counts.sup += 1;
+    else if (stance === 'refute') counts.ref += 1;
+    else counts.spec += 1;
+  }
+  return counts;
+}
 
 /** 平铺列表 → 先根深度序（父在前、子跟随缩进）；孤儿节点按原序垫底兜底。 */
 function orderWithDepth(nodes: HypothesisNodeRead[]): { node: HypothesisNodeRead; depth: number }[] {
@@ -186,6 +225,7 @@ export function DiscoveryTreeCard({ voyage }: { voyage: VoyageRead }) {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {entries.map(({ node, depth }) => {
             const m = NODE_STATUS_META[node.status] ?? OPEN_META;
+            const counts = stanceCounts(node.grounding);
             return (
               <div key={node.id} className="row gap8" style={{ paddingLeft: depth * 18, alignItems: 'flex-start' }}>
                 <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }}>
@@ -194,11 +234,22 @@ export function DiscoveryTreeCard({ voyage }: { voyage: VoyageRead }) {
                 <span style={{ fontSize: 12.5, minWidth: 0, textDecoration: node.status === 'pruned' ? 'line-through' : undefined, color: node.status === 'pruned' ? 'var(--text-3)' : undefined }}>
                   {node.statement}
                 </span>
-                {node.score != null && (
-                  <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0 }}>
-                    {node.score.toFixed(2)}
-                  </span>
-                )}
+                <span className="row gap8" style={{ marginLeft: 'auto', flexShrink: 0, alignItems: 'center' }}>
+                  {counts && (
+                    <span
+                      className="mono"
+                      title={tr('文献接地：支持 / 反驳 / 推测 的子命题数', 'Grounding: supported / refuted / speculative subclaims')}
+                      style={{ fontSize: 10.5, color: 'var(--text-4)' }}
+                    >
+                      {tr(`支持${counts.sup}·反驳${counts.ref}·推测${counts.spec}`, `sup ${counts.sup} · ref ${counts.ref} · spec ${counts.spec}`)}
+                    </span>
+                  )}
+                  {node.score != null && (
+                    <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                      {node.score.toFixed(2)}
+                    </span>
+                  )}
+                </span>
               </div>
             );
           })}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -642,6 +642,10 @@ export const LLM_STAGES = [
   'rag_expand',
   'rag_rerank',
   'rag_answer',
+  'hyp_generate',
+  'hyp_ground',
+  'hyp_novelty',
+  'hyp_feasibility',
 ] as const;
 
 export interface LlmProviderRead {

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -32,4 +32,8 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   rag_expand: { zh: '库问答·查询扩展', en: 'Library Q&A · query expansion' },
   rag_rerank: { zh: '库问答·重排摘要', en: 'Library Q&A · rerank & summarize' },
   rag_answer: { zh: '库问答·作答', en: 'Library Q&A · answering' },
+  hyp_generate: { zh: '假设·候选生成', en: 'Hypothesis · generation' },
+  hyp_ground: { zh: '假设·文献接地', en: 'Hypothesis · grounding' },
+  hyp_novelty: { zh: '假设·查新判定', en: 'Hypothesis · novelty check' },
+  hyp_feasibility: { zh: '假设·可行性论证', en: 'Hypothesis · feasibility' },
 };


### PR DESCRIPTION
Closes #648. Part of #635 (P2 wave 3, item D3); design report §12. This is the core of the P2 exit criterion: direction → grounded, novelty-checked, feasibility-checked research proposal.

## The pipeline (`hypothesis_pipeline.py`, deterministic vs judgment split throughout)
1. **generate** — three deterministic inspiration paths (semantic neighbors via the RAG retrieval primitive, citation-graph 2-hop non-neighbors, evenly-spaced diversity windows over uncovered papers — evenly spaced instead of random so runs replay) → `hyp_generate` composes n candidates → `SequenceMatcher>0.85` dedup against diversity collapse
2. **ground** — `hyp_ground` splits into ≤5 subclaims; each subclaim gets a deterministic top-5 retrieval and the LLM may only *select* from those ids with a support|refute stance; `sanitize_grounding` drops out-of-set ids and demotes unsupported claims to speculation — fabricated citations are structurally impossible
3. **novelty** — reworded re-retrieval per non-speculation subclaim → `hyp_novelty` judges known|novel|uncertain item-by-item; speculation is honestly uncertain/unjudged; parse failures degrade to uncertain instead of sinking the run
4. **feasibility** — deterministic signals (grounded paper count, venues, year range, related-chunk density); `hyp_feasibility` writes only the risk note

score = novel share × support coverage (explainable, monotone, the product punishes one-sided hypotheses; tournament refinement is D4). Below 0.15 the node auto-prunes with cascade and provenance.

## Discovery integration
- `hypothesis.expand` upgrades from skeleton children to pipeline-backed expansion, compute-then-write so the D2 kill-point recovery tests pass unchanged; per-node usage accounting extended
- `discovery.summarize` now emits a research-proposal artifact: surviving hypotheses (score-ordered, with the three-stance evidence-card data) plus a pruned-branch appendix with reasons — anti-cherry-picking by construction
- discovery runs now require `params.library_id` (validated, mirrored to the run column — no migration; the column existed), with library-visibility 404 semantics and a library picker in the creation form

## Determinism + golden
Four new fake-provider markers make the full run replayable; a new golden chain (create library + 2 papers → discovery run to completion → detail + tree) records it end to end, replays byte-stable. The existing `import_wiki.json` golden is byte-identical.

Verification: clean-baseline 1480 passed / 5 failed (3 pre-existing #581, one known order flake, one self-inflicted inspect artifact during baselining); branch suite 1497 passed / 3 failed, failure set ⊆ baseline — zero new real failures; +13 pipeline tests, +1 golden, 10 upgraded discovery tests. Rebased onto #649/#651 with zero conflicts; frontend build, vitest, and the stage-parity guards green.