### PR TITLE
feat: evidence-card surface for discovery runs

### DIFF
--- a/src/frontend/src/features/voyages/VoyageDetailPage.tsx
+++ b/src/frontend/src/features/voyages/VoyageDetailPage.tsx
@@ -18,7 +18,7 @@ import {
   type VoyageStepRead,
 } from '../../lib/api';
 import { KindBadge } from './VoyagesPage';
-import { DiscoveryTreeCard } from './discovery';
+import { DiscoveryPanel } from './discovery';
 import { ActivityBar } from './shared/ActivityBar';
 import { PlanEventCard, StepCard } from './shared/StepCard';
 import {
@@ -283,8 +283,8 @@ export function VoyageDetailPage() {
       {/* 文献任务：本次同步结果汇总 */}
       {WIKI_RUN_KINDS.has(voyage.kind) && <WikiRunSummary steps={steps} />}
 
-      {/* 假设探索：节点列表（树是任务的一等产物，逐轮长出来） */}
-      {voyage.kind === 'discovery' && <DiscoveryTreeCard voyage={voyage} />}
+      {/* 假设探索：假设树（树视图 + 方案报告，树是任务的一等产物，逐轮长出来） */}
+      {voyage.kind === 'discovery' && <DiscoveryPanel voyage={voyage} />}
 
       {/* 本次任务使用的技能（启动时快照，中途改技能不影响） */}
       {(voyage.skills ?? []).length > 0 && (

--- a/src/frontend/src/features/voyages/__tests__/discoveryEvidence.test.ts
+++ b/src/frontend/src/features/voyages/__tests__/discoveryEvidence.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import type { HypothesisNodeRead } from '../../../lib/api';
+import {
+  buildReport,
+  flattenTree,
+  MIN_VIABLE_SCORE,
+  parseGrounding,
+  parseNovelty,
+  pruneReasonKind,
+  stanceGroups,
+  supportRatio,
+} from '../discoveryEvidence';
+
+/* discovery 证据卡纯函数（#654）：支持度是要给用户看的百分比，数字必须对——
+   全 speculation、空 grounding、混合立场、脏数据降级都钉死在这里。 */
+
+function entry(stance: string, paperIds: string[] = [], subclaim = 'sc'): unknown {
+  return { subclaim, stance, paper_ids: paperIds, snippets: [] };
+}
+
+function node(over: Partial<HypothesisNodeRead>): HypothesisNodeRead {
+  return {
+    id: 'n1',
+    run_id: 'r1',
+    parent_id: null,
+    kind: 'hypothesis',
+    statement: 's',
+    grounding: null,
+    novelty_report: null,
+    feasibility: null,
+    score: null,
+    status: 'open',
+    created_at: '2026-09-01T00:00:00Z',
+    updated_at: '2026-09-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('supportRatio', () => {
+  it('空 grounding 返回 null（没数据 ≠ 支持度 0）', () => {
+    expect(supportRatio([])).toBeNull();
+    expect(supportRatio(parseGrounding(null))).toBeNull();
+    expect(supportRatio(parseGrounding([]))).toBeNull();
+  });
+
+  it('全 speculation 支持度为 0', () => {
+    const entries = parseGrounding([entry('speculation'), entry('speculation')]);
+    expect(supportRatio(entries)).toBe(0);
+  });
+
+  it('混合立场按「非 speculation 且有引用」的占比计算', () => {
+    const entries = parseGrounding([
+      entry('support', ['p1']),
+      entry('refute', ['p2']),
+      entry('speculation'),
+      entry('support', ['p1', 'p3']),
+    ]);
+    expect(supportRatio(entries)).toBe(3 / 4);
+  });
+
+  it('有立场但没引用的条目降级为 speculation，不计入支持度', () => {
+    const entries = parseGrounding([entry('support', []), entry('refute', ['p1'])]);
+    expect(entries[0]!.stance).toBe('speculation');
+    expect(supportRatio(entries)).toBe(1 / 2);
+  });
+});
+
+describe('parseGrounding', () => {
+  it('脏数据（非对象/空子命题/未知立场）降级不崩', () => {
+    const entries = parseGrounding([
+      null,
+      42,
+      { stance: 'support', paper_ids: ['p1'] }, // 缺 subclaim → 丢弃
+      { subclaim: 'ok', stance: 'banana', paper_ids: ['p1'] }, // 未知立场 → speculation
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!).toMatchObject({ subclaim: 'ok', stance: 'speculation', paperIds: [] });
+  });
+});
+
+describe('parseNovelty', () => {
+  it('verdict 只认 novel/known，其余归 uncertain；judged 缺省为 false', () => {
+    const out = parseNovelty({
+      subclaims: [
+        { subclaim: 'a', verdict: 'novel', paper_ids: [], judged: true },
+        { subclaim: 'b', verdict: 'whatever' },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]!.verdict).toBe('novel');
+    expect(out[1]!).toMatchObject({ verdict: 'uncertain', judged: false });
+  });
+});
+
+describe('stanceGroups', () => {
+  it('三组各归各位', () => {
+    const groups = stanceGroups(
+      parseGrounding([entry('support', ['p1']), entry('refute', ['p2']), entry('speculation')]),
+    );
+    expect(groups.support).toHaveLength(1);
+    expect(groups.refute).toHaveLength(1);
+    expect(groups.speculation).toHaveLength(1);
+  });
+});
+
+describe('flattenTree', () => {
+  const root = node({ id: 'root' });
+  const c1 = node({ id: 'c1', parent_id: 'root' });
+  const c2 = node({ id: 'c2', parent_id: 'root' });
+  const g1 = node({ id: 'g1', parent_id: 'c1' });
+
+  it('先根深度序，子节点缩进一层', () => {
+    const out = flattenTree([root, c1, c2, g1], new Set());
+    expect(out.map((e) => [e.node.id, e.depth])).toEqual([
+      ['root', 0],
+      ['c1', 1],
+      ['g1', 2],
+      ['c2', 1],
+    ]);
+    expect(out[0]!.hasChildren).toBe(true);
+    expect(out[3]!.hasChildren).toBe(false);
+  });
+
+  it('collapsed 的节点不展开子树', () => {
+    const out = flattenTree([root, c1, c2, g1], new Set(['c1']));
+    expect(out.map((e) => e.node.id)).toEqual(['root', 'c1', 'c2']);
+  });
+
+  it('父不在集合里的孤儿按根渲染（坏数据也得看得见）', () => {
+    const orphan = node({ id: 'o1', parent_id: 'missing' });
+    const out = flattenTree([root, orphan], new Set());
+    expect(out.map((e) => [e.node.id, e.depth])).toEqual([
+      ['root', 0],
+      ['o1', 0],
+    ]);
+  });
+});
+
+describe('buildReport', () => {
+  it('存活假设 score 降序、未评分排最后、同分按创建时间；剪枝的进附录', () => {
+    const nodes = [
+      node({ id: 'a', score: 0.2, created_at: '2026-09-01T00:00:02Z' }),
+      node({ id: 'b', score: 0.8 }),
+      node({ id: 'pruned', score: 0.05, status: 'pruned' }),
+      node({ id: 'c', score: null }),
+      node({ id: 'd', score: 0.2, created_at: '2026-09-01T00:00:01Z' }),
+    ];
+    const report = buildReport(nodes);
+    expect(report.alive.map((n) => n.id)).toEqual(['b', 'd', 'a', 'c']);
+    expect(report.pruned.map((n) => n.id)).toEqual(['pruned']);
+  });
+});
+
+describe('pruneReasonKind', () => {
+  it('低于自动剪枝阈值 → low_score；父被剪 → cascade；否则 decided', () => {
+    expect(pruneReasonKind(node({ score: MIN_VIABLE_SCORE - 0.01, status: 'pruned' }), null)).toBe('low_score');
+    expect(pruneReasonKind(node({ score: 0.5, status: 'pruned' }), 'pruned')).toBe('cascade');
+    expect(pruneReasonKind(node({ score: null, status: 'pruned' }), 'expanded')).toBe('decided');
+  });
+});

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -1,18 +1,35 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
 import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
+import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
 import { api, VOYAGE_TERMINAL, type HypothesisNodeRead, type VoyageRead } from '../../lib/api';
 import { tr } from '../../lib/i18n';
+import {
+  buildReport,
+  flattenTree,
+  MIN_VIABLE_SCORE,
+  parseFeasibility,
+  parseGrounding,
+  parseNovelty,
+  pruneReasonKind,
+  stanceGroups,
+  supportRatio,
+  type GroundingEntry,
+  type NoveltyEntry,
+  type Stance,
+} from './discoveryEvidence';
 
 /* ============================================================
-   discovery（假设探索）任务的最小前端面（#642）：
-   - 新建入口：方向文本 + 高级里的扩展轮数（走通用 POST /voyages）；
-   - 详情页的节点列表卡：挂只读假设树 API，按父子缩进平铺展示。
-   树的图形化可视化归后续里程碑（D5），这里只保证「建得了、看得见」。
+   discovery（假设探索）任务的前端面（#642 → #654）：
+   - 新建入口：方向文本 + 文献库 + 高级里的扩展轮数（走通用 POST /voyages）；
+   - 详情页 DiscoveryPanel：树视图（可折叠、点节点看证据卡）与方案报告
+     （存活假设按 score 排序 + 被剪分支附录）两种视图切换。
+   证据卡的数据全部来自只读假设树 API（grounding / novelty_report /
+   feasibility 随节点返回）；解析与支持度计算在 ./discoveryEvidence.ts。
    ============================================================ */
 
 const MAX_EXPANSIONS_LIMIT = 10; // 与后端 schemas/voyage.MAX_DISCOVERY_EXPANSIONS 一致
@@ -145,7 +162,7 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
   );
 }
 
-// —— 详情页：假设树节点列表卡 ——
+// —— 文案映射（模块级常量保留 {zh,en}，渲染处再 tr()，语言切换才生效） ——
 
 const OPEN_META = { zh: '待探索', en: 'Open', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' };
 const NODE_STATUS_META: Record<string, { zh: string; en: string; bg: string; tx: string }> = {
@@ -156,43 +173,513 @@ const NODE_STATUS_META: Record<string, { zh: string; en: string; bg: string; tx:
   refuted: { zh: '已否证', en: 'Refuted', bg: 'var(--danger-bg)', tx: 'var(--danger-tx)' },
 };
 
-/** grounding 的三类立场计数（#648 证据卡的最小增量；完整证据卡 UI 归 D5）。 */
-function stanceCounts(grounding: unknown[] | null): { sup: number; ref: number; spec: number } | null {
-  if (!Array.isArray(grounding) || grounding.length === 0) return null;
-  const counts = { sup: 0, ref: 0, spec: 0 };
-  for (const entry of grounding) {
-    const stance = (entry as { stance?: string } | null)?.stance;
-    if (stance === 'support') counts.sup += 1;
-    else if (stance === 'refute') counts.ref += 1;
-    else counts.spec += 1;
+const STANCE_META: Record<Stance, { zh: string; en: string; color: string }> = {
+  support: { zh: '支持', en: 'Supports', color: 'var(--ok)' },
+  refute: { zh: '反驳', en: 'Refutes', color: 'var(--danger)' },
+  speculation: { zh: '推测（库内没检到证据）', en: 'Speculation (no in-library evidence)', color: 'var(--text-3)' },
+};
+
+const VERDICT_META: Record<NoveltyEntry['verdict'], { zh: string; en: string; bg: string; tx: string }> = {
+  novel: { zh: '新颖', en: 'Novel', bg: 'var(--ok-bg)', tx: 'var(--ok-tx)' },
+  known: { zh: '已有研究', en: 'Known', bg: 'var(--surface-3)', tx: 'var(--text-3)' },
+  uncertain: { zh: '不确定', en: 'Uncertain', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' },
+};
+
+/** 可行性信号的键名翻译（后端 hypothesis_pipeline.feasibility 的确定性信号；
+    未知键按原名展示，后端加信号前端不至于瞎）。 */
+const SIGNAL_LABELS: Record<string, { zh: string; en: string }> = {
+  grounded_paper_count: { zh: '接地论文数', en: 'Grounded papers' },
+  venues: { zh: '来源分布', en: 'Venues' },
+  year_range: { zh: '年份范围', en: 'Year range' },
+  related_chunk_hits: { zh: '库内相关片段数', en: 'Related chunks in library' },
+};
+
+/** 剪枝原因的界面文案：具体原因文本在后端 checkpoint 里、API 不外露，
+    前端按可观测信号（分数阈值 / 父状态）如实推断三类，不编细节。 */
+function pruneReasonText(node: HypothesisNodeRead, parentStatus: string | null): string {
+  const kind = pruneReasonKind(node, parentStatus);
+  if (kind === 'low_score') {
+    return tr(
+      `评分 ${node.score!.toFixed(2)} 低于阈值 ${MIN_VIABLE_SCORE}，扩展时被自动放弃`,
+      `Score ${node.score!.toFixed(2)} fell below the ${MIN_VIABLE_SCORE} threshold — auto-pruned during expansion`,
+    );
   }
-  return counts;
+  if (kind === 'cascade') return tr('父分支被放弃后随之放弃', 'Dropped along with its parent branch');
+  return tr('AI 判定不值得继续（细节见运行日志）', 'The AI judged it not worth pursuing (see run logs)');
 }
 
-/** 平铺列表 → 先根深度序（父在前、子跟随缩进）；孤儿节点按原序垫底兜底。 */
-function orderWithDepth(nodes: HypothesisNodeRead[]): { node: HypothesisNodeRead; depth: number }[] {
-  const byParent = new Map<string | null, HypothesisNodeRead[]>();
-  for (const n of nodes) {
-    const key = n.parent_id ?? null;
-    byParent.set(key, [...(byParent.get(key) ?? []), n]);
+// —— 论文标题解析（证据卡里的引用要能点着标题跳论文） ——
+
+// 一次要解析的标题上限：超出的引用退化为短 id 展示，防极端大树一次打爆请求
+const PAPER_TITLE_FETCH_CAP = 40;
+
+/** paper_ids → 标题映射。逐篇走 ['paper', id]（与全站论文详情同一 queryKey，
+    读过的论文直接命中缓存）；现有 API 没有按 id 批量取标题的端点，如果证据卡
+    引用规模上去了，值得让后端加一个批量标题接口再换掉这里。 */
+function usePaperTitles(paperIds: string[]): Map<string, string> {
+  const results = useQueries({
+    queries: paperIds.slice(0, PAPER_TITLE_FETCH_CAP).map((id) => ({
+      queryKey: ['paper', id],
+      queryFn: () => api.getPaper(id),
+      staleTime: 10 * 60_000,
+      retry: false,
+    })),
+  });
+  const map = new Map<string, string>();
+  results.forEach((r, i) => {
+    const id = paperIds[i];
+    if (id && r.data?.title) map.set(id, r.data.title);
+  });
+  return map;
+}
+
+function PaperChips({ ids, titles }: { ids: string[]; titles: Map<string, string> }) {
+  const navigate = useNavigate();
+  if (ids.length === 0) return null;
+  return (
+    <span className="row" style={{ gap: 4, flexWrap: 'wrap' }}>
+      {ids.map((id) => (
+        <button
+          key={id}
+          type="button"
+          className="pill sm"
+          title={tr('打开论文', 'Open paper')}
+          onClick={() => navigate(`/papers/${id}/read`)}
+          style={{
+            background: 'var(--surface-2)',
+            color: 'var(--accent-text)',
+            border: '0.5px solid var(--border-2)',
+            cursor: 'pointer',
+            maxWidth: 280,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            display: 'inline-block',
+          }}
+        >
+          <Icon name="book" size={10} style={{ marginRight: 3, verticalAlign: -1 }} />
+          {titles.get(id) ?? `${id.slice(0, 8)}…`}
+        </button>
+      ))}
+    </span>
+  );
+}
+
+// —— 支持度条（§12：非推测且有论文引用的子命题占比） ——
+
+function SupportBar({ ratio, style }: { ratio: number | null; style?: CSSProperties }) {
+  if (ratio === null) return null;
+  const pct = Math.round(ratio * 100);
+  return (
+    <div style={style} title={tr('支持度 = 有库内论文托底（非推测）的子命题占比', 'Support = share of subclaims backed by in-library papers (non-speculation)')}>
+      <div className="row" style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 3 }}>
+        <span>{tr('文献支持度', 'Literature support')}</span>
+        <span className="mono" style={{ marginLeft: 'auto' }}>{pct}%</span>
+      </div>
+      <div style={{ height: 6, borderRadius: 3, background: 'var(--surface-3)', overflow: 'hidden' }}>
+        <div style={{ width: `${pct}%`, height: '100%', borderRadius: 3, background: 'var(--ok)' }} />
+      </div>
+    </div>
+  );
+}
+
+// —— 节点证据卡面板（三组证据 + 支持度 + 查新 + 可行性） ——
+
+const CLAMP3: CSSProperties = {
+  display: '-webkit-box',
+  WebkitLineClamp: 3,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+};
+
+function fmtSignal(v: unknown): string {
+  if (v === null || v === undefined) return '—';
+  if (Array.isArray(v)) return v.length === 0 ? '—' : v.join(' – ');
+  if (typeof v === 'object') {
+    const entries = Object.entries(v as Record<string, unknown>);
+    return entries.length === 0 ? '—' : entries.map(([k, n]) => `${k} ×${String(n)}`).join(' · ');
   }
-  const out: { node: HypothesisNodeRead; depth: number }[] = [];
-  const walk = (parent: string | null, depth: number) => {
-    for (const n of byParent.get(parent) ?? []) {
-      out.push({ node: n, depth });
-      walk(n.id, depth + 1);
+  return String(v);
+}
+
+function EvidenceGroup({ stance, entries, titles }: { stance: Stance; entries: GroundingEntry[]; titles: Map<string, string> }) {
+  if (entries.length === 0) return null;
+  const meta = STANCE_META[stance];
+  return (
+    <div style={{ marginTop: 10 }}>
+      <div className="row gap6" style={{ fontSize: 11.5, fontWeight: 650, color: meta.color, marginBottom: 4 }}>
+        {tr(meta.zh, meta.en)}
+        <span className="mono" style={{ fontWeight: 400, color: 'var(--text-4)' }}>×{entries.length}</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {entries.map((e, i) => (
+          <div key={i} style={{ borderLeft: `2px solid ${meta.color}`, paddingLeft: 10 }}>
+            <div style={{ fontSize: 12.5, color: 'var(--text-1)' }}>{e.subclaim}</div>
+            {e.paperIds.length > 0 && (
+              <div style={{ marginTop: 4 }}>
+                <PaperChips ids={e.paperIds} titles={titles} />
+              </div>
+            )}
+            {e.snippets.map((s, j) => (
+              <div
+                key={j}
+                title={s}
+                style={{
+                  ...CLAMP3,
+                  marginTop: 4,
+                  fontSize: 11.5,
+                  lineHeight: 1.55,
+                  color: 'var(--text-3)',
+                  background: 'var(--surface-2)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                }}
+              >
+                {s}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NodeDetailPanel({ node, pruneReason, style }: { node: HypothesisNodeRead; pruneReason: string | null; style?: CSSProperties }) {
+  const grounding = useMemo(() => parseGrounding(node.grounding), [node.grounding]);
+  const novelty = useMemo(() => parseNovelty(node.novelty_report), [node.novelty_report]);
+  const feas = useMemo(() => parseFeasibility(node.feasibility), [node.feasibility]);
+  const groups = stanceGroups(grounding);
+  const ratio = supportRatio(grounding);
+  // 引用到的论文去重后解析标题（接地 + 查新两处都可能引用）
+  const paperIds = useMemo(() => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const list of [...grounding.map((e) => e.paperIds), ...novelty.map((e) => e.paperIds)]) {
+      for (const id of list) {
+        if (!seen.has(id)) {
+          seen.add(id);
+          out.push(id);
+        }
+      }
     }
-  };
-  walk(null, 0);
-  if (out.length < nodes.length) {
-    const seen = new Set(out.map((e) => e.node.id));
-    for (const n of nodes) if (!seen.has(n.id)) out.push({ node: n, depth: 0 });
-  }
-  return out;
+    return out;
+  }, [grounding, novelty]);
+  const titles = usePaperTitles(paperIds);
+
+  const empty = grounding.length === 0 && novelty.length === 0 && !feas;
+  return (
+    <div
+      style={{
+        background: 'var(--surface-1)',
+        border: '0.5px solid var(--border-2)',
+        borderRadius: 10,
+        padding: '10px 14px 12px',
+        ...style,
+      }}
+    >
+      {pruneReason && (
+        <div className="row gap6" style={{ fontSize: 12, color: 'var(--danger-tx)', marginBottom: 8 }}>
+          <Icon name="x" size={12} />
+          {tr('剪枝原因：', 'Pruned because: ')}
+          {pruneReason}
+        </div>
+      )}
+      {empty ? (
+        <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+          {tr(
+            '这个节点还没有证据数据（根假设与待扩展节点不跑接地管线）。',
+            'No evidence data on this node yet (root and unexpanded nodes skip the grounding pipeline).',
+          )}
+        </div>
+      ) : (
+        <>
+          <SupportBar ratio={ratio} />
+          {/* 证据三组：支持 / 反驳 / 推测 */}
+          <EvidenceGroup stance="support" entries={groups.support} titles={titles} />
+          <EvidenceGroup stance="refute" entries={groups.refute} titles={titles} />
+          <EvidenceGroup stance="speculation" entries={groups.speculation} titles={titles} />
+          {/* 查新结论：逐子命题 verdict */}
+          {novelty.length > 0 && (
+            <div style={{ marginTop: 12 }}>
+              <div style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)', marginBottom: 4 }}>
+                {tr('查新结论', 'Novelty check')}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                {novelty.map((e, i) => {
+                  const m = VERDICT_META[e.verdict];
+                  return (
+                    <div key={i} className="row gap6" style={{ alignItems: 'flex-start' }}>
+                      <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }}>
+                        {tr(m.zh, m.en)}
+                      </span>
+                      <span style={{ fontSize: 12.5, minWidth: 0 }}>
+                        {e.subclaim}
+                        {!e.judged && (
+                          <span style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 6 }}>
+                            {tr('（未送查新判定）', '(not judged)')}
+                          </span>
+                        )}
+                      </span>
+                      {e.paperIds.length > 0 && (
+                        <span style={{ marginLeft: 'auto', flexShrink: 0 }}>
+                          <PaperChips ids={e.paperIds} titles={titles} />
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {/* 可行性：确定性信号小表 + 风险论证 */}
+          {feas && (
+            <div style={{ marginTop: 12 }}>
+              <div style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--text-2)', marginBottom: 4 }}>
+                {tr('可行性', 'Feasibility')}
+              </div>
+              {Object.keys(feas.signals).length > 0 && (
+                <div style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '3px 14px', fontSize: 12 }}>
+                  {Object.entries(feas.signals).map(([k, v]) => (
+                    <span key={k} style={{ display: 'contents' }}>
+                      <span style={{ color: 'var(--text-3)' }}>
+                        {SIGNAL_LABELS[k] ? tr(SIGNAL_LABELS[k].zh, SIGNAL_LABELS[k].en) : k}
+                      </span>
+                      <span className="mono" style={{ color: 'var(--text-2)', wordBreak: 'break-word' }}>{fmtSignal(v)}</span>
+                    </span>
+                  ))}
+                </div>
+              )}
+              {feas.riskNote && (
+                <div style={{ fontSize: 12, color: 'var(--text-2)', lineHeight: 1.6, marginTop: 6 }}>
+                  <span style={{ color: 'var(--text-3)' }}>{tr('风险论证：', 'Risk note: ')}</span>
+                  {feas.riskNote}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
-export function DiscoveryTreeCard({ voyage }: { voyage: VoyageRead }) {
+// —— 树视图（可折叠 + 点节点展开证据卡） ——
+
+function TreeView({ nodes }: { nodes: HypothesisNodeRead[] }) {
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const entries = useMemo(() => flattenTree(nodes, collapsed), [nodes, collapsed]);
+  const statusById = useMemo(() => new Map(nodes.map((n) => [n.id, n.status])), [nodes]);
+
+  const toggleCollapse = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {entries.map(({ node, depth, hasChildren }) => {
+        const m = NODE_STATUS_META[node.status] ?? OPEN_META;
+        const pruned = node.status === 'pruned';
+        const reason = pruned
+          ? pruneReasonText(node, node.parent_id ? statusById.get(node.parent_id) ?? null : null)
+          : null;
+        const ratio = supportRatio(parseGrounding(node.grounding));
+        const selected = node.id === selectedId;
+        const isCollapsed = collapsed.has(node.id);
+        return (
+          <div key={node.id}>
+            <div
+              className="row gap6"
+              onClick={() => setSelectedId(selected ? null : node.id)}
+              // 剪枝原因 hover 即见；点开证据卡里还有一份
+              title={reason ? `${node.statement}\n${tr('剪枝原因：', 'Pruned because: ')}${reason}` : node.statement}
+              style={{
+                alignItems: 'center',
+                cursor: 'pointer',
+                borderRadius: 7,
+                padding: '3px 6px',
+                paddingLeft: 6 + depth * 16,
+                background: selected ? 'var(--surface-2)' : undefined,
+              }}
+            >
+              {hasChildren ? (
+                <button
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    toggleCollapse(node.id);
+                  }}
+                  title={isCollapsed ? tr('展开子假设', 'Expand children') : tr('收起子假设', 'Collapse children')}
+                  style={{
+                    border: 'none',
+                    background: 'none',
+                    padding: 0,
+                    width: 18,
+                    height: 18,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                    color: 'var(--text-3)',
+                    flexShrink: 0,
+                  }}
+                >
+                  <Icon
+                    name="chevron"
+                    size={11}
+                    style={{ transform: isCollapsed ? 'none' : 'rotate(90deg)', transition: 'transform .15s' }}
+                  />
+                </button>
+              ) : (
+                <span style={{ width: 18, flexShrink: 0 }} />
+              )}
+              <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }}>
+                {tr(m.zh, m.en)}
+              </span>
+              <span
+                style={{
+                  fontSize: 12.5,
+                  flex: 1,
+                  minWidth: 0,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  textDecoration: pruned ? 'line-through' : undefined,
+                  color: pruned ? 'var(--text-3)' : undefined,
+                }}
+              >
+                {node.statement}
+              </span>
+              <span className="row gap8" style={{ flexShrink: 0, alignItems: 'center' }}>
+                {ratio !== null && (
+                  <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                    {tr('支持', 'sup')} {Math.round(ratio * 100)}%
+                  </span>
+                )}
+                {node.score != null && (
+                  <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                    {node.score.toFixed(2)}
+                  </span>
+                )}
+              </span>
+            </div>
+            {selected && (
+              <NodeDetailPanel
+                node={node}
+                pruneReason={reason}
+                style={{ margin: `6px 0 8px ${6 + depth * 16 + 18}px` }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// —— 方案报告视图 ——
+// 后端 discovery.summarize 把研究方案产物写在 run.checkpoint["artifacts"]，
+// 现有 API 不外露；树端点已含证据卡全部结构化数据，这里按后端同一排序规则
+// （score 降序、未评分垫底、同分按创建时间）就地重建报告——任务没跑完也能
+// 预览当前排序。LLM 的叙述性总结文本只存在于产物里，等后端开放产物读取
+// 接口后再补一段「AI 总结」。
+
+function ReportView({ nodes, active }: { nodes: HypothesisNodeRead[]; active: boolean }) {
+  const { alive, pruned } = useMemo(() => buildReport(nodes), [nodes]);
+  const statusById = useMemo(() => new Map(nodes.map((n) => [n.id, n.status])), [nodes]);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {active && (
+        <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+          {tr('任务还在进行中：以下是当前假设树的即时排序，跑完后会稳定下来。', 'The run is still in progress — this is a live ranking of the current tree; it settles once the run finishes.')}
+        </div>
+      )}
+      {alive.length === 0 && (
+        <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
+          {tr('没有存活的假设（全部被剪枝）。', 'No surviving hypotheses — every branch was pruned.')}
+        </div>
+      )}
+      {alive.map((n, i) => {
+        const m = NODE_STATUS_META[n.status] ?? OPEN_META;
+        const grounding = parseGrounding(n.grounding);
+        const groups = stanceGroups(grounding);
+        const ratio = supportRatio(grounding);
+        return (
+          <div key={n.id} style={{ border: '0.5px solid var(--border-2)', borderRadius: 10, padding: '12px 14px' }}>
+            <div className="row gap8" style={{ alignItems: 'flex-start' }}>
+              <span className="mono" style={{ fontSize: 12, color: 'var(--text-4)', flexShrink: 0, paddingTop: 1 }}>
+                #{i + 1}
+              </span>
+              <span style={{ fontSize: 13.5, fontWeight: 620, flex: 1, minWidth: 0 }}>{n.statement}</span>
+              <span className="row gap6" style={{ flexShrink: 0, alignItems: 'center' }}>
+                <span className="pill sm" style={{ background: m.bg, color: m.tx }}>{tr(m.zh, m.en)}</span>
+                {n.score != null && (
+                  <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>{n.score.toFixed(2)}</span>
+                )}
+              </span>
+            </div>
+            <SupportBar ratio={ratio} style={{ marginTop: 10 }} />
+            {/* 三组证据摘要：只列子命题；引用与原文片段在下面的完整证据卡里 */}
+            {(['support', 'refute', 'speculation'] as const).map(
+              (k) =>
+                groups[k].length > 0 && (
+                  <div key={k} style={{ marginTop: 8 }}>
+                    <div style={{ fontSize: 11, fontWeight: 650, color: STANCE_META[k].color, marginBottom: 2 }}>
+                      {tr(STANCE_META[k].zh, STANCE_META[k].en)}（{groups[k].length}）
+                    </div>
+                    {groups[k].map((e, j) => (
+                      <div key={j} style={{ fontSize: 12, color: 'var(--text-2)', lineHeight: 1.6 }}>
+                        · {e.subclaim}
+                      </div>
+                    ))}
+                  </div>
+                ),
+            )}
+            {(grounding.length > 0 || n.novelty_report || n.feasibility) && (
+              <details style={{ marginTop: 10 }}>
+                <summary style={{ fontSize: 12, color: 'var(--accent-text)', cursor: 'pointer', userSelect: 'none' }}>
+                  {tr('查看完整证据卡（引用论文、原文片段、查新、可行性）', 'Full evidence card (papers, snippets, novelty, feasibility)')}
+                </summary>
+                <NodeDetailPanel node={n} pruneReason={null} style={{ marginTop: 8 }} />
+              </details>
+            )}
+          </div>
+        );
+      })}
+      {/* 被剪分支附录：§8.2 防择优汇报——放弃的路径与原因也是方案的一部分 */}
+      {pruned.length > 0 && (
+        <details style={{ border: '0.5px solid var(--border-2)', borderRadius: 10, padding: '10px 14px' }}>
+          <summary style={{ fontSize: 12.5, fontWeight: 650, cursor: 'pointer', userSelect: 'none', color: 'var(--text-2)' }}>
+            {tr(`被放弃的分支附录（${pruned.length}）`, `Pruned branches appendix (${pruned.length})`)}
+          </summary>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+            {pruned.map((n) => (
+              <div key={n.id}>
+                <div style={{ fontSize: 12.5, color: 'var(--text-2)' }}>{n.statement}</div>
+                <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 1 }}>
+                  {n.score != null && <span className="mono">score {n.score.toFixed(2)} · </span>}
+                  {pruneReasonText(n, n.parent_id ? statusById.get(n.parent_id) ?? null : null)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// —— 详情页入口卡：树视图 / 方案报告 切换 ——
+
+export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
   const active = !VOYAGE_TERMINAL.has(voyage.status);
+  const [view, setView] = useState<'tree' | 'report'>('tree');
   const { data } = useQuery({
     queryKey: ['hypothesis-tree', voyage.id],
     queryFn: () => api.listHypothesisTree(voyage.id),
@@ -200,60 +687,41 @@ export function DiscoveryTreeCard({ voyage }: { voyage: VoyageRead }) {
     // 任务还在跑就轮询：树是逐轮长出来的
     refetchInterval: active ? 10_000 : false,
   });
-  const entries = useMemo(() => orderWithDepth(data ?? []), [data]);
+  const nodes = data ?? [];
 
   return (
     <div className="card card-pad" style={{ marginBottom: 20 }}>
-      <div className="row" style={{ marginBottom: 10 }}>
+      <div className="row" style={{ marginBottom: 10, flexWrap: 'wrap', gap: 8 }}>
         <span className="section-h">
           <Icon name="compass" size={15} style={{ color: 'var(--accent)' }} />
           {tr('假设树', 'Hypothesis tree')}
         </span>
-        {entries.length > 0 && (
-          <span className="mono" style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-3)' }}>
-            {entries.length} {tr('个节点', 'nodes')}
+        {nodes.length > 0 && (
+          <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+            {nodes.length} {tr('个节点', 'nodes')}
           </span>
         )}
+        <span style={{ marginLeft: 'auto' }}>
+          <Segmented
+            options={[
+              { v: 'tree' as const, label: tr('树视图', 'Tree') },
+              { v: 'report' as const, label: tr('方案报告', 'Report') },
+            ]}
+            value={view}
+            onChange={setView}
+          />
+        </span>
       </div>
-      {entries.length === 0 ? (
+      {nodes.length === 0 ? (
         <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
           {active
             ? tr('树还没长出来：AI 正在生成根假设…', 'No tree yet — the AI is seeding the root hypothesis…')
             : tr('这次任务没有留下假设树。', 'This run left no hypothesis tree.')}
         </div>
+      ) : view === 'tree' ? (
+        <TreeView nodes={nodes} />
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {entries.map(({ node, depth }) => {
-            const m = NODE_STATUS_META[node.status] ?? OPEN_META;
-            const counts = stanceCounts(node.grounding);
-            return (
-              <div key={node.id} className="row gap8" style={{ paddingLeft: depth * 18, alignItems: 'flex-start' }}>
-                <span className="pill sm" style={{ background: m.bg, color: m.tx, flexShrink: 0 }}>
-                  {tr(m.zh, m.en)}
-                </span>
-                <span style={{ fontSize: 12.5, minWidth: 0, textDecoration: node.status === 'pruned' ? 'line-through' : undefined, color: node.status === 'pruned' ? 'var(--text-3)' : undefined }}>
-                  {node.statement}
-                </span>
-                <span className="row gap8" style={{ marginLeft: 'auto', flexShrink: 0, alignItems: 'center' }}>
-                  {counts && (
-                    <span
-                      className="mono"
-                      title={tr('文献接地：支持 / 反驳 / 推测 的子命题数', 'Grounding: supported / refuted / speculative subclaims')}
-                      style={{ fontSize: 10.5, color: 'var(--text-4)' }}
-                    >
-                      {tr(`支持${counts.sup}·反驳${counts.ref}·推测${counts.spec}`, `sup ${counts.sup} · ref ${counts.ref} · spec ${counts.spec}`)}
-                    </span>
-                  )}
-                  {node.score != null && (
-                    <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
-                      {node.score.toFixed(2)}
-                    </span>
-                  )}
-                </span>
-              </div>
-            );
-          })}
-        </div>
+        <ReportView nodes={nodes} active={active} />
       )}
     </div>
   );

--- a/src/frontend/src/features/voyages/discoveryEvidence.ts
+++ b/src/frontend/src/features/voyages/discoveryEvidence.ts
@@ -1,0 +1,213 @@
+import type { HypothesisNodeRead } from '../../lib/api';
+
+/* ============================================================
+   discovery 证据卡的纯函数层（#654，设计报告 §12「支持度产品化」）：
+   解析假设节点上的 grounding / novelty_report / feasibility 三块 JSON，
+   算支持度、分立场分组、拼可折叠树、重建方案报告的排序。
+
+   为什么单独抽一个无 React 的模块：
+   - 支持度/排序是「数字要对」的逻辑，抽成纯函数才测得动（vitest）；
+   - 三块 JSON 在 API 类型里是 unknown/Record（后端按管线约定写入，
+     schema 不锁死），解析兜底集中在这里，组件层拿到的都是干净类型。
+   ============================================================ */
+
+// 与后端 services/hypothesis_pipeline.MIN_VIABLE_SCORE 一致：
+// 扩展时低于它的子假设被当场自动剪枝——前端据此推断剪枝原因
+export const MIN_VIABLE_SCORE = 0.15;
+
+export type Stance = 'support' | 'refute' | 'speculation';
+
+/** 一条子命题的文献接地（backend sanitize_grounding 的产出）。 */
+export interface GroundingEntry {
+  subclaim: string;
+  stance: Stance;
+  paperIds: string[];
+  snippets: string[];
+}
+
+/** 一条子命题的查新结论（novelty_report.subclaims 的一项）。 */
+export interface NoveltyEntry {
+  subclaim: string;
+  verdict: 'novel' | 'known' | 'uncertain';
+  paperIds: string[];
+  /** false = 没送 judge（如 speculation 子命题）或 judge 判不动，如实标注 */
+  judged: boolean;
+}
+
+export interface FeasibilityInfo {
+  signals: Record<string, unknown>;
+  riskNote: string;
+}
+
+// ---- 解析（容错：后端字段乱/缺时降级，不炸组件） ----
+
+function asStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+/** grounding JSON → 干净条目列表；立场只认 support/refute（与后端同一口径），
+    其余一律归 speculation——「有立场没证据」不该被当成有证据。 */
+export function parseGrounding(raw: unknown): GroundingEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: GroundingEntry[] = [];
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const rec = item as Record<string, unknown>;
+    const subclaim = typeof rec.subclaim === 'string' ? rec.subclaim.trim() : '';
+    if (!subclaim) continue;
+    const paperIds = asStringArray(rec.paper_ids);
+    const stanceRaw = rec.stance;
+    const stance: Stance =
+      (stanceRaw === 'support' || stanceRaw === 'refute') && paperIds.length > 0
+        ? stanceRaw
+        : 'speculation';
+    out.push({
+      subclaim,
+      stance,
+      paperIds: stance === 'speculation' ? [] : paperIds,
+      snippets: asStringArray(rec.snippets),
+    });
+  }
+  return out;
+}
+
+export function parseNovelty(raw: unknown): NoveltyEntry[] {
+  if (typeof raw !== 'object' || raw === null) return [];
+  const subclaims = (raw as Record<string, unknown>).subclaims;
+  if (!Array.isArray(subclaims)) return [];
+  const out: NoveltyEntry[] = [];
+  for (const item of subclaims) {
+    if (typeof item !== 'object' || item === null) continue;
+    const rec = item as Record<string, unknown>;
+    const subclaim = typeof rec.subclaim === 'string' ? rec.subclaim.trim() : '';
+    if (!subclaim) continue;
+    const verdict =
+      rec.verdict === 'novel' || rec.verdict === 'known' ? rec.verdict : 'uncertain';
+    out.push({
+      subclaim,
+      verdict,
+      paperIds: asStringArray(rec.paper_ids),
+      judged: rec.judged === true,
+    });
+  }
+  return out;
+}
+
+export function parseFeasibility(raw: unknown): FeasibilityInfo | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  const signals =
+    typeof rec.signals === 'object' && rec.signals !== null
+      ? (rec.signals as Record<string, unknown>)
+      : {};
+  const riskNote = typeof rec.risk_note === 'string' ? rec.risk_note : '';
+  if (Object.keys(signals).length === 0 && !riskNote) return null;
+  return { signals, riskNote };
+}
+
+// ---- 支持度（§12：多少子命题真的有库内文献托底） ----
+
+/** 支持度 = 非 speculation 且带论文引用的子命题占比。
+    空 grounding 返回 null（「没有数据」和「支持度为 0」是两回事，
+    界面上前者不画条、后者画一根 0% 的条）。 */
+export function supportRatio(entries: GroundingEntry[]): number | null {
+  if (entries.length === 0) return null;
+  const backed = entries.filter(
+    (e) => e.stance !== 'speculation' && e.paperIds.length > 0,
+  ).length;
+  return backed / entries.length;
+}
+
+export interface StanceGroups {
+  support: GroundingEntry[];
+  refute: GroundingEntry[];
+  speculation: GroundingEntry[];
+}
+
+export function stanceGroups(entries: GroundingEntry[]): StanceGroups {
+  const groups: StanceGroups = { support: [], refute: [], speculation: [] };
+  for (const e of entries) groups[e.stance].push(e);
+  return groups;
+}
+
+// ---- 树结构（可折叠渲染用的扁平化） ----
+
+export interface TreeEntry {
+  node: HypothesisNodeRead;
+  depth: number;
+  hasChildren: boolean;
+}
+
+export function childrenOf(
+  nodes: HypothesisNodeRead[],
+): Map<string | null, HypothesisNodeRead[]> {
+  const byParent = new Map<string | null, HypothesisNodeRead[]>();
+  const ids = new Set(nodes.map((n) => n.id));
+  for (const n of nodes) {
+    // 父不在集合里的孤儿当根挂（正常数据不会出现，防御坏数据渲染不出来）
+    const key = n.parent_id !== null && ids.has(n.parent_id) ? n.parent_id : null;
+    byParent.set(key, [...(byParent.get(key) ?? []), n]);
+  }
+  return byParent;
+}
+
+/** 平铺列表 → 先根深度序，collapsed 集合里的节点不展开子树。 */
+export function flattenTree(
+  nodes: HypothesisNodeRead[],
+  collapsed: ReadonlySet<string>,
+): TreeEntry[] {
+  const byParent = childrenOf(nodes);
+  const out: TreeEntry[] = [];
+  const walk = (parent: string | null, depth: number) => {
+    for (const n of byParent.get(parent) ?? []) {
+      const hasChildren = (byParent.get(n.id) ?? []).length > 0;
+      out.push({ node: n, depth, hasChildren });
+      if (hasChildren && !collapsed.has(n.id)) walk(n.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  return out;
+}
+
+// ---- 方案报告的排序（与后端 discovery.summarize 同一规则就地重建） ----
+// 后端把研究方案产物写在 checkpoint["artifacts"]，现有 API 不外露；
+// 树端点已含存活假设 + 三块证据数据，报告页按同一排序规则重建即可，
+// 不需要后端加接口（LLM 的叙述性总结文本除外，见 ReportView 的说明）。
+
+export interface DiscoveryReport {
+  /** 存活假设：score 降序（未评分排最后），同分按创建时间稳定排序 */
+  alive: HypothesisNodeRead[];
+  /** 被剪分支附录（§8.2 防择优汇报：放弃的路径也是产物的一部分） */
+  pruned: HypothesisNodeRead[];
+}
+
+export function buildReport(nodes: HypothesisNodeRead[]): DiscoveryReport {
+  const alive = nodes
+    .filter((n) => n.status !== 'pruned')
+    .sort((a, b) => {
+      const sa = a.score ?? -1;
+      const sb = b.score ?? -1;
+      if (sa !== sb) return sb - sa;
+      return a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0;
+    });
+  return { alive, pruned: nodes.filter((n) => n.status === 'pruned') };
+}
+
+// ---- 剪枝原因推断 ----
+// 具体原因文本记录在后端 checkpoint 的决策留痕里（API 不外露），
+// 前端按可观测信号如实分三类，文案由组件层 tr() 渲染：
+// - low_score：score 低于自动剪枝阈值 → 扩展时被当场剪掉；
+// - cascade：父分支被剪，随父级联；
+// - decided：AI 显式判定不值得继续（细节见任务运行日志）。
+
+export type PruneReasonKind = 'low_score' | 'cascade' | 'decided';
+
+export function pruneReasonKind(
+  node: HypothesisNodeRead,
+  parentStatus: string | null,
+): PruneReasonKind {
+  if (node.score !== null && node.score < MIN_VIABLE_SCORE) return 'low_score';
+  if (parentStatus === 'pruned') return 'cascade';
+  return 'decided';
+}


### PR DESCRIPTION
Closes #654. Part of #635 (P2 wave 4, item D5); design report §12 (support-degree productization). Frontend-only.

- `discoveryEvidence.ts`: a React-free pure layer — tolerant parsers for the three node JSON blocks (stance/verdict whitelists matching the backend), `supportRatio` (share of non-speculation subclaims with citations; null distinguishes "no data" from 0%), tree flattening with orphan fallback, report building with the backend's exact summarize ordering, and prune-reason inference (low-score / cascade / decided, thresholds matching the engine)
- tree view: collapsible hierarchy with status badges, truncated statements, support percentage and score per row; pruned nodes struck through with reasons on hover; clicking a node expands the detail panel inline
- node detail: support-degree bar → support/refute/speculation evidence groups (subclaim + clickable paper chip + snippet quote) → per-subclaim novelty verdict badges (unjudged shown honestly) → feasibility signal table + risk note; paper titles resolved per the site-wide query convention with a 40-paper cap fallback
- report view: surviving hypotheses ranked with support bars and evidence summaries, pruned-branch appendix collapsed; rendered by rebuilding the summarize artifact's deterministic projection from the tree API (the artifact itself is not exposed by any endpoint today — noted in comments; an artifact read endpoint arrives with the D6 disclosure work)
- 12 new vitest cases for the pure layer (all-speculation, empty grounding, mixed ratios, dirty-data degradation, ordering, prune inference); suite 143 green; build clean