### PR TITLE
feat: minimal hypothesis tournament depth mode

### DIFF
--- a/src/backend/app/agents/voyage/actions_discovery.py
+++ b/src/backend/app/agents/voyage/actions_discovery.py
@@ -9,6 +9,11 @@
 - ``hypothesis.prune``：显式剪枝入口，写 score 并级联剪枝（留痕不删）；
 - ``discovery.summarize``：把整棵树（含被剪分支）汇总成研究方案产物后收束。
 
+params.tournament=True 时是深度模式（#653）：每轮扩展落库后跑一场锦标赛
+（services/hypothesis_tournament.py）——score 前 6 的 open|expanded 假设两两
+对比、win-rate 与 pipeline score 对半混成新 score 写回节点，比较记录进
+checkpoint["discovery"]["tournament"]（供 D6 披露、API /tournament 消费）。
+
 **计划不是线性清单**：初始计划只有播种一步，之后每一轮由动作按树状态给出
 plan_signal（expand / summarize），经 plan_edit.discovery_signal_edits 确定性
 分支表追加下一个节点——树才是真源，决策与所选节点 id 记入
@@ -31,6 +36,7 @@ from app.core.llm.base import Message
 from app.models.hypothesis import HypothesisNode
 from app.models.voyage import VoyageRun
 from app.services import hypothesis_pipeline as pipeline
+from app.services import hypothesis_tournament as tournament_service
 from app.services import hypothesis_tree as tree_service
 
 # LLM 环节：结构化 JSON 生成，走中档耐心（core/llm/router.py 的 _MEDIUM_CALL_STAGES）
@@ -83,6 +89,10 @@ def _max_expansions(ctx: ActionContext) -> int:
         return max(0, int(_params_of(ctx).get("max_expansions", 3)))
     except (TypeError, ValueError):
         return 3
+
+
+def _tournament_enabled(ctx: ActionContext) -> bool:
+    return bool(_params_of(ctx).get("tournament"))
 
 
 def _direction(ctx: ActionContext) -> str:
@@ -340,6 +350,11 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
       对同一棵树是确定性的，所以「杀在扩展之前」的重启会选中同一个节点）。
       管线的全部 LLM/检索都发生在动树**之前**（先算后写）：被杀在管线中途时
     树还没动，重启就是干净重跑，「落库了一半」的窗口没有因为管线变长而变宽。
+
+    锦标赛（params.tournament=True，#653）跑在本轮树落库**之后**：它只改分数
+    （set_score 幂等），不建删节点，被杀窗口不因它变宽。已知降级：杀在锦标赛
+    中途时，重启走「树上扩展数已覆盖本轮」的补记路径、该轮锦标赛不补跑——
+    参赛节点保持 pipeline 分，排序退化为基础模式，宁可少赛一轮也不重复扣费。
     """
     round_no = int(params.get("round") or 0)
     state = _state(ctx)
@@ -486,6 +501,43 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                     + (f"（低分剪枝 {len(pruned_children)} 个）" if pruned_children else ""),
                     level="success",
                 )
+                if _tournament_enabled(ctx):
+                    # 深度模式：本轮树已落库，跑一场锦标赛给存活假设重新排位。
+                    # prior = 各节点首赛留档的 pipeline 分（防止上一轮的混合分
+                    # 被当成绝对分再混一次，见 tournament 模块 docstring）
+                    t_state = state.setdefault("tournament", {"matches": [], "nodes": {}})
+                    outcome = await tournament_service.run_tournament(
+                        session,
+                        ctx.llm,
+                        run=run,
+                        nodes=await tree_service.tree_for_run(session, ctx.run.id),
+                        prior_pipeline_scores={
+                            nid: entry.get("pipeline_score")
+                            for nid, entry in t_state["nodes"].items()
+                        },
+                        round_no=round_no,
+                        user_id=ctx.run.created_by,
+                        project_id=ctx.run.project_id,
+                        library_id=library_id,
+                    )
+                    # 对阵记录累加、终榜整体覆盖（榜单永远是最新一场之后的排位）
+                    t_state["matches"].extend(outcome["matches"])
+                    t_state["nodes"].update(outcome["nodes"])
+                    state["rounds"][str(round_no)]["tournament_matches"] = len(
+                        outcome["matches"]
+                    )
+                    # 记账：总账并入本步 usage，每场的 token 对半记到参赛双方头上
+                    for key in ("prompt_tokens", "completion_tokens"):
+                        usage[key] += outcome["usage"][key]
+                    for nid, node_usage in outcome["node_usage"].items():
+                        _account_node_usage(ctx, nid, node_usage)
+                    if outcome["matches"]:
+                        # 终端播报用大白话（界面不讲「锦标赛」行话，代码标识符除外）
+                        await ctx.log(
+                            f"深度对比：{len(outcome['nodes'])} 个假设两两比了 "
+                            f"{len(outcome['matches'])} 场，score 已按胜率混合更新",
+                            level="success",
+                        )
         signal, signal_why = await _next_signal(session, ctx)
     _record_decision(
         ctx,
@@ -558,10 +610,48 @@ async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dic
         for d in state["decisions"]
         if d.get("decision") == "pruned" and d.get("node_id")
     }
+    # 锦标赛终榜（深度模式 #653；基础模式为空 dict，下面所有分支都退化为原行为，
+    # golden 链因此逐字节不变）
+    standings = (state.get("tournament") or {}).get("nodes") or {}
+
+    def _pipeline_score_of(n: HypothesisNode) -> float:
+        """排序破平用的 pipeline 分：参赛节点取首赛留档，其余就是自身 score。"""
+        entry = standings.get(str(n.id)) or {}
+        if entry.get("pipeline_score") is not None:
+            return float(entry["pipeline_score"])
+        return n.score if n.score is not None else -1.0
+
+    def _tournament_of(n: HypothesisNode) -> dict[str, Any] | None:
+        entry = standings.get(str(n.id))
+        if not isinstance(entry, dict):
+            return None
+        return {"win_rate": entry.get("win_rate"), "matches": entry.get("matches")}
+
+    def _hypothesis_entry(n: HypothesisNode) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "id": str(n.id),
+            "statement": n.statement,
+            "status": n.status,
+            "score": n.score,
+            "grounding": n.grounding,
+            "novelty_report": n.novelty_report,
+            "feasibility": n.feasibility,
+        }
+        # 参赛节点才带 tournament 字段：混合分的来路要在方案里说得清（D6 披露）
+        tournament = _tournament_of(n)
+        if tournament is not None:
+            entry["tournament"] = tournament
+        return entry
+
     alive = sorted(
         (n for n in nodes if n.status != "pruned"),
-        # score 降序（未评分的排最后），同分按建立顺序稳定排序
-        key=lambda n: (-(n.score if n.score is not None else -1.0), n.created_at),
+        # score 降序（未评分的排最后）；混合分同分按 pipeline 分破（绝对证据分
+        # 高者靠前——胜率并列时让「文献说了什么」拍板）；再按建立顺序稳定排序
+        key=lambda n: (
+            -(n.score if n.score is not None else -1.0),
+            -_pipeline_score_of(n),
+            n.created_at,
+        ),
     )
     artifact = {
         "direction": _direction(ctx),
@@ -569,18 +659,7 @@ async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dic
         "stats": stats,
         # 研究方案主体：存活假设 + 三类证据卡数据（支持/反驳/推测的 grounding、
         # 逐子命题查新结论、可行性信号与风险论证），前端/导出直接消费
-        "hypotheses": [
-            {
-                "id": str(n.id),
-                "statement": n.statement,
-                "status": n.status,
-                "score": n.score,
-                "grounding": n.grounding,
-                "novelty_report": n.novelty_report,
-                "feasibility": n.feasibility,
-            }
-            for n in alive
-        ],
+        "hypotheses": [_hypothesis_entry(n) for n in alive],
         # 附录：被剪分支及原因（留痕不删的消费端）
         "pruned_appendix": [
             {

--- a/src/backend/app/api/hypotheses.py
+++ b/src/backend/app/api/hypotheses.py
@@ -45,6 +45,25 @@ async def get_hypothesis_tree(
     return [HypothesisNodeRead.model_validate(n) for n in nodes]
 
 
+@router.get("/{voyage_id}/tournament")
+async def get_hypothesis_tournament(
+    voyage_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict:
+    """锦标赛披露（#653，深度模式）：对阵全记录 + 参赛节点终榜。
+
+    数据在 run 的 checkpoint 轮次账本里（不动 hypothesis_nodes 表结构），所以走
+    独立端点而不是并进树节点响应；基础模式（tournament=False）如实返回空结构。
+    """
+    run = await _viewable_run(session, voyage_id, user)
+    state = ((run.checkpoint or {}).get("discovery") or {}).get("tournament") or {}
+    return {
+        "matches": state.get("matches") or [],
+        "nodes": state.get("nodes") or {},
+    }
+
+
 @router.get(
     "/{voyage_id}/hypothesis-tree/{node_id}", response_model=HypothesisNodeRead
 )

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -86,6 +86,9 @@ _HYP_GENERATE_MARKER = "POLARIS_HYP_GENERATE"
 _HYP_GROUND_MARKER = "POLARIS_HYP_GROUND"
 _HYP_NOVELTY_MARKER = "POLARIS_HYP_NOVELTY"
 _HYP_FEASIBILITY_MARKER = "POLARIS_HYP_FEASIBILITY"
+# 锦标赛两两对比（services/hypothesis_tournament.py，#653）。system prompt 里有
+# "winner" 字样，会撞 debate 裁判的 _JUDGE_MARKER——必须先于它判断
+_HYP_COMPARE_MARKER = "POLARIS_HYP_COMPARE"
 _GOAL_EXPLORE_MARKER = "POLARIS_GOAL_EXPLORE"  # 目标构建工具循环
 _GOAL_REFINE_MARKER = "POLARIS_GOAL_REFINE"  # 审批意见并入目标
 _PROPOSAL_RELATED_MARKER = "POLARIS_PROPOSAL_RELATED"  # 相关工作（工具循环）
@@ -394,6 +397,8 @@ class FakeProvider(LLMProvider):
             return FakeProvider._respond_hyp_novelty(last_user)
         if _HYP_FEASIBILITY_MARKER in full_text:
             return FakeProvider._respond_hyp_feasibility()
+        if _HYP_COMPARE_MARKER in full_text:
+            return FakeProvider._respond_hyp_compare(last_user)
         # discovery 树搜索 marker：user prompt 内嵌方向/假设文本，先于通用 marker
         if _DISCOVERY_SEED_MARKER in full_text:
             return FakeProvider._respond_discovery_seed(full_text)
@@ -1198,6 +1203,39 @@ class FakeProvider(LLMProvider):
                 }
             )
         return json.dumps({"items": out}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_hyp_compare(last_user: str) -> str:
+        """锦标赛对比：陈述字典序小者胜、同串判 tie（确定性 → 排序可精确断言）。
+
+        rationale 写明这是替身规则：真模型判的是研究价值，fake 只保证「同一对
+        假设永远同一结果」——测试与断点重放要的都是这个。
+        """
+        payload = FakeProvider._payload_of(last_user)
+        a_side = payload.get("a") if isinstance(payload.get("a"), dict) else {}
+        b_side = payload.get("b") if isinstance(payload.get("b"), dict) else {}
+        a = str(a_side.get("statement") or "")
+        b = str(b_side.get("statement") or "")
+        if a == b:
+            return json.dumps(
+                {
+                    "winner": "tie",
+                    "rationale": "fake-compare：两假设陈述相同，判平局（确定性替身规则）",
+                },
+                ensure_ascii=False,
+            )
+        winner = "a" if a < b else "b"
+        chosen = a if winner == "a" else b
+        return json.dumps(
+            {
+                "winner": winner,
+                "rationale": (
+                    "fake-compare：按陈述字典序取小者胜（可重放的确定性替身规则），"
+                    f"「{chosen[:40]}」胜出"
+                ),
+            },
+            ensure_ascii=False,
+        )
 
     @staticmethod
     def _respond_hyp_feasibility() -> str:

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -91,6 +91,8 @@ STAGES = (
     "hyp_ground",
     "hyp_novelty",
     "hyp_feasibility",
+    # 假设锦标赛两两对比（#653）：短 JSON 判定（短档）
+    "hyp_compare",
 )
 
 _ROUTE_CACHE_TTL = 60.0
@@ -182,6 +184,7 @@ _SHORT_CALL_STAGES = frozenset(
         "rag_rerank",  # 库问答重排+摘要：短 JSON（#644）
         "hyp_novelty",  # 假设查新逐条判定：短 JSON（#648）
         "hyp_feasibility",  # 假设可行性风险论证：短 JSON（#648）
+        "hyp_compare",  # 假设锦标赛两两对比：短 JSON（#653）
     }
 )
 

--- a/src/backend/app/schemas/voyage.py
+++ b/src/backend/app/schemas/voyage.py
@@ -25,8 +25,9 @@ class VoyageCreate(BaseModel):
         """discovery 的参数在创建时就定形（引擎只读 checkpoint.params，不再兜底）：
         direction 必填；library_id 必填（#648：四段假设管线的检索/接地边界就是
         这个库，没有库的 discovery 无从接地——可见性由 API 层校验）；
-        max_expansions 默认 3（0..MAX，整数）；tournament 默认 False——锦标赛式
-        对比是后续里程碑，先存档位不实现。"""
+        max_expansions 默认 3（0..MAX，整数）；tournament 默认 False——True 时
+        每轮扩展后对头部假设跑两两对比锦标赛、按胜率混合重排 score（#653），
+        深度换成本，默认关。"""
         if self.kind != "discovery":
             return self
         params = dict(self.params or {})

--- a/src/backend/app/services/hypothesis_tournament.py
+++ b/src/backend/app/services/hypothesis_tournament.py
@@ -1,0 +1,200 @@
+"""假设锦标赛深度模式（#653，设计报告 §12，P2 D4；不 import fastapi）。
+
+四段管线的 score（novel 比例 × support 覆盖率，hypothesis_pipeline.score_hypothesis）
+是逐假设独立算的绝对分：可解释，但分不出「两个都及格的假设哪个更值得先做」。
+锦标赛补的就是这半边——把当前最有希望的假设**两两对比**（co-scientist 的
+Elo 排位思路取最小实现：单轮 round-robin，不做多轮淘汰），让相对判断参与排序：
+
+- 参赛者 = pipeline score 前 ``MAX_CONTENDERS`` 的 open|expanded 假设节点。
+  上限卡死配对数（C(6,2)=15 对），深度模式的加时成本随树增长有界；
+- 每对打一场 ``hyp_compare``（短档 JSON 判定）：给裁判两假设的陈述 +
+  接地立场摘要 + 查新结论，判 winner（a|b|tie）+ 一句 rationale。
+  **不给裁判看 pipeline score**——相对判断要独立于绝对分，否则只是复读；
+- win-rate = 胜场 / 参赛场（tie 各记半场）；
+- 新 score = 0.5 × pipeline score + 0.5 × win-rate。对半开是有意的：绝对分
+  （证据说了什么）与相对分（裁判怎么排）谁也不该压倒谁，权重调优留给后续
+  里程碑。同分排序由消费端（discovery.summarize）按 pipeline score 破。
+
+pipeline score 的口径：节点**首次参赛前**的 score。多轮扩展下节点会反复参赛，
+若每轮都拿「当前分」当 pipeline 分，上一轮的 win-rate 会被再次混入、绝对分被
+逐轮稀释——所以调用方要把首赛留档的 pipeline_score（prior）传回来。
+
+比较记录（对阵、判决、rationale）由调用方写进 checkpoint 轮次账本，供 D6 披露。
+"""
+
+import uuid
+from itertools import combinations
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.router import LLMRouter
+from app.models.hypothesis import HypothesisNode
+from app.models.voyage import VoyageRun
+from app.services import hypothesis_tree as tree_service
+
+# 与管线四环节共用同一套 JSON 调用约定（解析重试 + usage 如实归并），刻意不再抄一份
+from app.services.hypothesis_pipeline import _complete_json
+
+# LLM 环节（router.py STAGES / 前端 LLM_STAGES 同步登记）：短 JSON 判定走短档
+COMPARE_STAGE = "hyp_compare"
+
+# 参赛上限：round-robin 配对数是 C(n,2)，6 人封顶 15 场——深度模式的加时成本
+# 必须有界，且排位靠后的假设本来就不在「谁先做」的争议区里
+MAX_CONTENDERS = 6
+# pipeline 绝对分与锦标赛相对分的混合权重（见模块 docstring 的 why）
+PIPELINE_WEIGHT = 0.5
+
+COMPARE_SYSTEM_PROMPT = """\
+POLARIS_HYP_COMPARE
+你是研究假设对比裁判。输入 JSON 里是两个假设（a / b），各带陈述、逐子命题的
+文献接地立场（support/refute/speculation）与查新结论（known/novel/uncertain）。
+判断哪个更值得优先投入验证——综合新颖性、证据扎实度与可检验性；难分高下时
+如实判平局。只输出 JSON：{"winner": "a|b|tie", "rationale": "一句话理由"}"""
+
+
+def pick_contenders(nodes: list[HypothesisNode]) -> list[HypothesisNode]:
+    """选参赛者：open|expanded 的假设节点按 pipeline score 前 MAX_CONTENDERS。
+
+    expanded 也参赛：被扩展只说明它探过了，不说明它不如新生的子假设——
+    排序面向「整棵树里哪些假设最值得写进方案」，不是只排叶子。
+    终态（pruned/validated/refuted）不参赛：结论已定，无需再排。
+    同分按 created_at 取先建的（与 best_open_node 同一确定性口径）。
+    """
+    alive = [n for n in nodes if n.kind == "hypothesis" and n.status in ("open", "expanded")]
+    alive.sort(key=lambda n: (-(n.score if n.score is not None else -1.0), n.created_at))
+    return alive[:MAX_CONTENDERS]
+
+
+def _brief(node: HypothesisNode) -> dict[str, Any]:
+    """裁判可见的假设摘要：陈述 + 接地立场 + 查新结论，**不含分数**（独立判断）。"""
+    grounding = node.grounding if isinstance(node.grounding, list) else []
+    subclaims = (node.novelty_report or {}).get("subclaims") or []
+    return {
+        "statement": node.statement,
+        "grounding": [
+            {"subclaim": g.get("subclaim"), "stance": g.get("stance")}
+            for g in grounding
+            if isinstance(g, dict)
+        ],
+        "novelty": [
+            {"subclaim": e.get("subclaim"), "verdict": e.get("verdict")}
+            for e in subclaims
+            if isinstance(e, dict)
+        ],
+    }
+
+
+def _validate_compare(data: Any) -> dict[str, str]:
+    if not isinstance(data, dict) or data.get("winner") not in ("a", "b", "tie"):
+        raise ValueError('compare 输出需含 "winner"（a|b|tie）')
+    return {
+        "winner": str(data["winner"]),
+        "rationale": str(data.get("rationale") or "").strip(),
+    }
+
+
+def blend_score(pipeline_score: float | None, win_rate: float) -> float:
+    """新 score = 0.5 × pipeline + 0.5 × win-rate；pipeline 缺失按 0 记（诚实缺省：
+    没被管线评过分的假设不该白得绝对分的一半）。"""
+    base = pipeline_score if pipeline_score is not None else 0.0
+    return round(PIPELINE_WEIGHT * base + (1 - PIPELINE_WEIGHT) * win_rate, 4)
+
+
+async def run_tournament(
+    session: AsyncSession,
+    llm: LLMRouter,
+    *,
+    run: VoyageRun,
+    nodes: list[HypothesisNode],
+    prior_pipeline_scores: dict[str, Any] | None = None,
+    round_no: int | None = None,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID,
+) -> dict[str, Any]:
+    """single round-robin：选参赛者 → 逐对裁判 → win-rate 混分 → set_score 落库。
+
+    返回::
+
+        {
+          "matches":  [{round, a, b, winner, rationale}, ...],  # 对阵全记录
+          "nodes":    {node_id: {win_rate, matches, pipeline_score, score}},  # 终榜
+          "node_usage": {node_id: {prompt_tokens, completion_tokens}},  # 每节点分摊
+          "usage":    {prompt_tokens, completion_tokens},  # 总账
+        }
+
+    参赛不足 2 人时是无事发生的空结果（不动树、不调 LLM）。
+    ``prior_pipeline_scores``：往轮首赛留档的 pipeline 分（{node_id: score}，
+    见模块 docstring——防止上一轮的混合分被当成绝对分再混一次）。
+    """
+    usage = {"prompt_tokens": 0, "completion_tokens": 0}
+    contenders = pick_contenders(nodes)
+    if len(contenders) < 2:
+        return {"matches": [], "nodes": {}, "node_usage": {}, "usage": usage}
+    prior = prior_pipeline_scores or {}
+    # 参赛者的 pipeline 分：首赛用当前分留档，往轮参赛者沿用首赛留档
+    pipeline_scores: dict[str, float | None] = {
+        str(n.id): prior.get(str(n.id), n.score) for n in contenders
+    }
+    matches: list[dict[str, Any]] = []
+    node_usage: dict[str, dict[str, int]] = {
+        str(n.id): {"prompt_tokens": 0, "completion_tokens": 0} for n in contenders
+    }
+    # 胜场按 tie 各半记：用「半场 = 1」的整数计数（wins2）避免浮点累加误差
+    wins2: dict[str, int] = {str(n.id): 0 for n in contenders}
+    games: dict[str, int] = {str(n.id): 0 for n in contenders}
+    for a, b in combinations(contenders, 2):
+        match_usage = {"prompt_tokens": 0, "completion_tokens": 0}
+        verdict = await _complete_json(
+            llm,
+            COMPARE_STAGE,
+            system=COMPARE_SYSTEM_PROMPT,
+            payload={"a": _brief(a), "b": _brief(b)},
+            validate=_validate_compare,
+            usage=match_usage,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+            voyage_id=run.id,
+        )
+        id_a, id_b = str(a.id), str(b.id)
+        games[id_a] += 1
+        games[id_b] += 1
+        if verdict["winner"] == "a":
+            wins2[id_a] += 2
+        elif verdict["winner"] == "b":
+            wins2[id_b] += 2
+        else:
+            wins2[id_a] += 1
+            wins2[id_b] += 1
+        matches.append(
+            {
+                "round": round_no,
+                "a": id_a,
+                "b": id_b,
+                "winner": verdict["winner"],
+                "rationale": verdict["rationale"],
+            }
+        )
+        # 每节点记账：一场对比是两个假设共同消费的，token 对半分摊
+        # （零头记给 a——确定性分法，总量守恒）
+        for key in ("prompt_tokens", "completion_tokens"):
+            usage[key] += match_usage[key]
+            node_usage[id_b][key] += match_usage[key] // 2
+            node_usage[id_a][key] += match_usage[key] - match_usage[key] // 2
+    standings: dict[str, dict[str, Any]] = {}
+    for node in contenders:
+        node_id = str(node.id)
+        win_rate = round(wins2[node_id] / (2 * games[node_id]), 4)
+        blended = blend_score(pipeline_scores[node_id], win_rate)
+        standings[node_id] = {
+            "win_rate": win_rate,
+            "matches": games[node_id],
+            "pipeline_score": pipeline_scores[node_id],
+            "score": blended,
+        }
+        # 混合分直接写回节点 score：best_open_node 的下一轮选点与 summarize 的
+        # 方案排序都读它——锦标赛的意义就是改变后续决策，不是只留一张榜
+        await tree_service.set_score(session, node, blended)
+    return {"matches": matches, "nodes": standings, "node_usage": node_usage, "usage": usage}

--- a/src/backend/tests/test_hypothesis_tournament.py
+++ b/src/backend/tests/test_hypothesis_tournament.py
@@ -1,0 +1,340 @@
+"""假设锦标赛深度模式（#653 D4）：round-robin 对比 → win-rate 混分重排。
+
+- fake provider 的对比替身规则是「陈述字典序小者胜、同串判 tie」——完全确定性，
+  所以开/关锦标赛的排序差异、win-rate 与混合分都能精确断言；
+- 服务层：参赛上限（>6 只取 score 前 6、C(6,2)=15 场）、状态/kind 过滤、tie 各记
+  半场、不足 2 人无事发生、pipeline 分首赛留档（prior 防止混合分被二次混合）;
+- 端到端：tournament=True 的 run 每轮扩展后重排 score、比较记录进轮次账本、
+  节点记账含锦标赛 token、汇总产物给参赛节点带 tournament 字段、披露端点可读；
+  tournament=False 的 run 与 #648 行为逐项一致（golden 链也钉着这点）。
+"""
+
+import json
+import uuid
+
+from sqlalchemy import select
+
+from app.agents.voyage.engine import VoyageEngine
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.hypothesis import HypothesisNode
+from app.models.voyage import VoyageRun
+from app.services import hypothesis_tournament as tournament
+from app.services import hypothesis_tree as tree_service
+from tests.conftest import RecordingBus
+from tests.test_voyage_discovery import _make_workspace, _tree
+
+# ---- 服务层（直接驱动 run_tournament，树用 tree_service 手搭） ----
+
+
+async def _bare_run(session) -> VoyageRun:
+    """最小 discovery run（服务层测试不走引擎，只要 run_id 挂树）。"""
+    run = VoyageRun(kind="discovery", goal="tournament-service", status="executing", cursor=0)
+    session.add(run)
+    await session.commit()
+    return run
+
+
+async def test_tournament_caps_contenders_and_filters(client):
+    """9 个节点：pruned/experiment 不参赛，score 前 6 参赛打满 15 场，
+    榜外节点分数原封不动。fake 规则下（"h1" < "h2" < …）战绩完全可预期。"""
+    async with get_sessionmaker()() as session:
+        run = await _bare_run(session)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="h-root", score=0.05
+        )
+        children = []
+        for i, score in enumerate([0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2]):
+            children.append(
+                await tree_service.create_node(
+                    session,
+                    run,
+                    parent_id=root.id,
+                    kind="hypothesis",
+                    statement=f"h{i + 1}",
+                    score=score,
+                )
+            )
+        # 高分但已剪枝 / 非假设 kind：都不该入场
+        pruned = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="hypothesis", statement="h0-pruned", score=0.95
+        )
+        await tree_service.transition(session, pruned, "pruned")
+        experiment = await tree_service.create_node(
+            session, run, parent_id=root.id, kind="experiment", statement="h0-exp", score=0.99
+        )
+        nodes = await tree_service.tree_for_run(session, run.id)
+        result = await tournament.run_tournament(
+            session, LLMRouter(), run=run, nodes=nodes, library_id=uuid.uuid4()
+        )
+
+        # 参赛者 = score 前 6 的子节点；root(0.05)/h7(0.2) 落榜，pruned/experiment 出局
+        contender_ids = {str(c.id) for c in children[:6]}
+        assert set(result["nodes"]) == contender_ids
+        assert len(result["matches"]) == 15  # C(6,2)
+        assert all(m["winner"] in ("a", "b") for m in result["matches"])
+        # 字典序：h1 全胜 → 胜率 1.0、0.8、0.6、0.4、0.2、0.0 依次递减
+        expected = {
+            "h1": (1.0, 0.9),  # 0.5×0.8 + 0.5×1.0
+            "h2": (0.8, 0.75),
+            "h3": (0.6, 0.6),
+            "h4": (0.4, 0.45),
+            "h5": (0.2, 0.3),
+            "h6": (0.0, 0.15),
+        }
+        for child in children[:6]:
+            entry = result["nodes"][str(child.id)]
+            win_rate, blended = expected[child.statement]
+            assert entry["win_rate"] == win_rate
+            assert entry["score"] == blended
+            assert entry["matches"] == 5
+            await session.refresh(child)
+            assert child.score == blended  # set_score 已落库
+        # 榜外与出局节点：分数原封不动
+        for node, score in ((children[6], 0.2), (root, 0.05), (pruned, 0.95), (experiment, 0.99)):
+            await session.refresh(node)
+            assert node.score == score
+        # 记账：每场 token 对半分摊，参赛者人人有份、总量守恒
+        assert set(result["node_usage"]) == contender_ids
+        assert all(u["prompt_tokens"] > 0 for u in result["node_usage"].values())
+        for key in ("prompt_tokens", "completion_tokens"):
+            assert sum(u[key] for u in result["node_usage"].values()) == result["usage"][key]
+
+
+async def test_tournament_tie_and_prior_pipeline_scores(client):
+    """同串陈述判 tie（各记半场）；prior 让第二次锦标赛仍从原始 pipeline 分混合，
+    而不是把上一轮的混合分再混一次。"""
+    async with get_sessionmaker()() as session:
+        run = await _bare_run(session)
+        a = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="same-claim", score=0.4
+        )
+        b = await tree_service.create_node(
+            session, run, parent_id=a.id, kind="hypothesis", statement="same-claim", score=0.2
+        )
+        nodes = await tree_service.tree_for_run(session, run.id)
+        first = await tournament.run_tournament(
+            session, LLMRouter(), run=run, nodes=nodes, library_id=uuid.uuid4()
+        )
+        assert [m["winner"] for m in first["matches"]] == ["tie"]
+        assert first["nodes"][str(a.id)] == {
+            "win_rate": 0.5,
+            "matches": 1,
+            "pipeline_score": 0.4,
+            "score": 0.45,  # 0.5×0.4 + 0.5×0.5
+        }
+        assert first["nodes"][str(b.id)]["score"] == 0.35
+        # 第二次带 prior：pipeline 分沿用首赛留档（0.4/0.2），结果稳定不漂移；
+        # 若错拿当前混合分（0.45/0.35）再混，分数会被逐轮稀释
+        nodes = await tree_service.tree_for_run(session, run.id)
+        second = await tournament.run_tournament(
+            session,
+            LLMRouter(),
+            run=run,
+            nodes=nodes,
+            prior_pipeline_scores={
+                nid: entry["pipeline_score"] for nid, entry in first["nodes"].items()
+            },
+            library_id=uuid.uuid4(),
+        )
+        assert second["nodes"] == first["nodes"]
+
+
+async def test_tournament_needs_two_contenders(client):
+    """只有一个存活假设：无对手，无事发生（不调 LLM、不改分）。"""
+    async with get_sessionmaker()() as session:
+        run = await _bare_run(session)
+        root = await tree_service.create_node(
+            session, run, parent_id=None, kind="hypothesis", statement="lonely", score=0.6
+        )
+        result = await tournament.run_tournament(
+            session,
+            LLMRouter(),
+            run=run,
+            nodes=await tree_service.tree_for_run(session, run.id),
+            library_id=uuid.uuid4(),
+        )
+        assert result == {
+            "matches": [],
+            "nodes": {},
+            "node_usage": {},
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+        }
+        await session.refresh(root)
+        assert root.score == 0.6
+
+
+def test_blend_score_treats_missing_pipeline_as_zero():
+    assert tournament.blend_score(None, 1.0) == 0.5
+    assert tournament.blend_score(0.8, 0.0) == 0.4
+
+
+# ---- 端到端：开 vs 关（fake 确定性下排序差异可精确断言） ----
+
+
+async def _create_run_via_api(
+    client, headers, project_id: str, library_id: uuid.UUID, *, tournament_on: bool
+) -> uuid.UUID:
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "可验证的 agent 工作流",
+            "params": {
+                "direction": "可验证的 agent 工作流",
+                "library_id": str(library_id),
+                "max_expansions": 1,
+                "tournament": tournament_on,
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _node_usage_of(run_id: uuid.UUID) -> dict:
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        return (run.checkpoint or {})["discovery"]["node_usage"]
+
+
+async def test_tournament_run_reranks_vs_off(client, queue_stub):
+    """同一工作区各跑一遍开/关：关 = #648 原行为；开 = 三个存活假设打 3 场，
+    fake 字典序（围 < 机 < 证）下 root 全胜、fake A 半胜、fake B 全败，
+    score 从 [0.8, 0.25, 0.25] 重排为 [0.9, 0.375, 0.125]。"""
+    project_id, library_id, headers = await _make_workspace(client)
+    engine = VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+
+    run_off = await _create_run_via_api(
+        client, headers, project_id, library_id, tournament_on=False
+    )
+    run_on = await _create_run_via_api(client, headers, project_id, library_id, tournament_on=True)
+    await engine.run(run_off)
+    await engine.run(run_on)
+
+    def _pick(nodes: list[HypothesisNode]) -> tuple[HypothesisNode, HypothesisNode, HypothesisNode]:
+        root = next(n for n in nodes if n.parent_id is None)
+        child_a = next(n for n in nodes if "fake A" in n.statement)
+        child_b = next(n for n in nodes if "fake B" in n.statement)
+        return root, child_a, child_b
+
+    # 关：分数保持管线原值，账本无锦标赛痕迹
+    off_nodes = await _tree(run_off)
+    off_root, off_a, off_b = _pick(off_nodes)
+    assert (off_root.score, off_a.score, off_b.score) == (0.8, 0.25, 0.25)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_off)
+        state = (run.checkpoint or {})["discovery"]
+        off_artifact = json.loads((run.checkpoint or {})["artifacts"]["discovery-summary.json"])
+    assert "tournament" not in state
+    assert all("tournament" not in h for h in off_artifact["hypotheses"])
+    assert [h["score"] for h in off_artifact["hypotheses"]] == [0.8, 0.25, 0.25]
+
+    # 开：win-rate 混分改写节点 score 与方案排序
+    on_nodes = await _tree(run_on)
+    root, child_a, child_b = _pick(on_nodes)
+    assert (root.score, child_a.score, child_b.score) == (0.9, 0.375, 0.125)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_on)
+        state = (run.checkpoint or {})["discovery"]
+        artifact = json.loads((run.checkpoint or {})["artifacts"]["discovery-summary.json"])
+    t_state = state["tournament"]
+    # 3 个存活假设 round-robin 3 场；fake 规则下小字典序一方全胜（都记成 a 胜，
+    # 因为配对按 score 排位生成、排位高的一方恰好都是字典序小的）
+    assert len(t_state["matches"]) == 3
+    assert [m["winner"] for m in t_state["matches"]] == ["a", "a", "a"]
+    assert all("fake-compare" in m["rationale"] for m in t_state["matches"])
+    assert all(m["round"] == 1 for m in t_state["matches"])
+    assert t_state["nodes"][str(root.id)] == {
+        "win_rate": 1.0,
+        "matches": 2,
+        "pipeline_score": 0.8,
+        "score": 0.9,
+    }
+    assert t_state["nodes"][str(child_a.id)]["win_rate"] == 0.5
+    assert t_state["nodes"][str(child_b.id)]["win_rate"] == 0.0
+    # 轮次账本挂了本轮对阵数
+    assert state["rounds"]["1"]["tournament_matches"] == 3
+    # 方案产物：排序反映混合分，参赛节点带 tournament 字段
+    assert [h["score"] for h in artifact["hypotheses"]] == [0.9, 0.375, 0.125]
+    assert [h["tournament"]["win_rate"] for h in artifact["hypotheses"]] == [1.0, 0.5, 0.0]
+    assert all(h["tournament"]["matches"] == 2 for h in artifact["hypotheses"])
+    # 记账：锦标赛 token 记在参赛节点头上——开局的每个节点都比关局同位节点花得多
+    off_usage, on_usage = await _node_usage_of(run_off), await _node_usage_of(run_on)
+    for on_node, off_node in ((root, off_root), (child_a, off_a), (child_b, off_b)):
+        assert (
+            on_usage[str(on_node.id)]["prompt_tokens"]
+            > off_usage[str(off_node.id)]["prompt_tokens"]
+        )
+
+    # 披露端点：开局回对阵与终榜，关局如实回空结构
+    resp = await client.get(f"/api/voyages/{run_on}/tournament", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["matches"]) == 3 and set(body["nodes"]) == {
+        str(root.id),
+        str(child_a.id),
+        str(child_b.id),
+    }
+    resp = await client.get(f"/api/voyages/{run_off}/tournament", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"matches": [], "nodes": {}}
+
+
+async def test_tournament_multi_round_keeps_pipeline_prior(client, queue_stub):
+    """两轮扩展：第二轮锦标赛沿用参赛老将首赛留档的 pipeline 分（root 0.8、
+    fake A 0.25），对阵记录跨轮累加（3 + C(5,2)=10 = 13 场）。"""
+    project_id, library_id, headers = await _make_workspace(client)
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "可验证的 agent 工作流",
+            "params": {
+                "direction": "可验证的 agent 工作流",
+                "library_id": str(library_id),
+                "max_expansions": 2,
+                "tournament": True,
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    run_id = uuid.UUID(resp.json()["id"])
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter()).run(run_id)
+
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+        assert run.status == "done"
+        state = (run.checkpoint or {})["discovery"]
+        nodes = (
+            (
+                await session.execute(
+                    select(HypothesisNode)
+                    .where(HypothesisNode.run_id == run_id)
+                    .order_by(HypothesisNode.created_at, HypothesisNode.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    t_state = state["tournament"]
+    assert [m["round"] for m in t_state["matches"]] == [1] * 3 + [2] * 10
+    # 第一轮的三位老将第二轮继续参赛：pipeline 分保持首赛留档，不被混合分覆盖
+    root = next(n for n in nodes if n.parent_id is None)
+    round1_a = next(n for n in nodes if n.parent_id == root.id and "fake A" in n.statement)
+    assert t_state["nodes"][str(root.id)]["pipeline_score"] == 0.8
+    assert t_state["nodes"][str(round1_a.id)]["pipeline_score"] == 0.25
+    # 第二轮 5 个存活假设全员入场（1 根 + 4 子，各打 4 场）
+    round2_entries = [e for e in t_state["nodes"].values() if e["matches"] == 4]
+    assert len(round2_entries) == 5
+    # root 字典序最小（围 < 机 < 证）依旧全胜，混合分 = 0.5×0.8 + 0.5×1.0
+    assert t_state["nodes"][str(root.id)] == {
+        "win_rate": 1.0,
+        "matches": 4,
+        "pipeline_score": 0.8,
+        "score": 0.9,
+    }

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -6,7 +6,13 @@ import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
 import { Segmented } from '../../components/ui/Segmented';
 import { toast } from '../../components/ui/Toast';
-import { api, VOYAGE_TERMINAL, type HypothesisNodeRead, type VoyageRead } from '../../lib/api';
+import {
+  api,
+  VOYAGE_TERMINAL,
+  type HypothesisNodeRead,
+  type HypothesisTournamentStanding,
+  type VoyageRead,
+} from '../../lib/api';
 import { tr } from '../../lib/i18n';
 import {
   buildReport,
@@ -41,6 +47,7 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
   const [direction, setDirection] = useState('');
   const [libraryId, setLibraryId] = useState('');
   const [maxExpansions, setMaxExpansions] = useState(3);
+  const [tournament, setTournament] = useState(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   // 文献库必选（#648）：四段假设管线的检索/接地边界就是这个库
@@ -56,7 +63,12 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
         kind: 'discovery',
         project_id: projectId!,
         goal: direction.trim(),
-        params: { direction: direction.trim(), max_expansions: maxExpansions, library_id: libraryId },
+        params: {
+          direction: direction.trim(),
+          max_expansions: maxExpansions,
+          library_id: libraryId,
+          tournament,
+        },
       }),
     onSuccess: (run) => {
       setOpen(false);
@@ -154,6 +166,24 @@ export function DiscoveryCreateButton({ projectId }: { projectId: string | null 
                 }}
                 style={{ width: 120 }}
               />
+            </FormField>
+            <FormField
+              label="深度对比排位"
+              en="Deep comparison ranking"
+              hint={tr(
+                '每轮扩展后让最有希望的假设两两对比，按胜率重新排位（更准，也更花 token）',
+                'After each round, pit the top hypotheses against each other pairwise and re-rank by win rate (more accurate, costs more tokens)',
+              )}
+              style={{ marginTop: 10 }}
+            >
+              <label className="row gap8" style={{ fontSize: 12.5, cursor: 'pointer', userSelect: 'none' }}>
+                <input
+                  type="checkbox"
+                  checked={tournament}
+                  onChange={(e) => setTournament(e.target.checked)}
+                />
+                {tr('让假设两两比一比再排名', 'Pit hypotheses against each other before ranking')}
+              </label>
             </FormField>
           </details>
         </div>
@@ -466,7 +496,14 @@ function NodeDetailPanel({ node, pruneReason, style }: { node: HypothesisNodeRea
 
 // —— 树视图（可折叠 + 点节点展开证据卡） ——
 
-function TreeView({ nodes }: { nodes: HypothesisNodeRead[] }) {
+function TreeView({
+  nodes,
+  standings,
+}: {
+  nodes: HypothesisNodeRead[];
+  /** 锦标赛终榜（#653 深度模式）：node_id → 战绩；基础模式为空对象 */
+  standings: Record<string, HypothesisTournamentStanding>;
+}) {
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const entries = useMemo(() => flattenTree(nodes, collapsed), [nodes, collapsed]);
@@ -560,6 +597,18 @@ function TreeView({ nodes }: { nodes: HypothesisNodeRead[] }) {
                 {ratio !== null && (
                   <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
                     {tr('支持', 'sup')} {Math.round(ratio * 100)}%
+                  </span>
+                )}
+                {standings[node.id] && (
+                  <span
+                    className="pill sm"
+                    title={tr(
+                      `深度对比：${standings[node.id]!.matches} 场两两对比的胜率（平局各记半场）`,
+                      `Deep comparison: win rate over ${standings[node.id]!.matches} pairwise matches (ties count as half)`,
+                    )}
+                    style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}
+                  >
+                    {tr('胜率', 'wins')} {Math.round(standings[node.id]!.win_rate * 100)}%
                   </span>
                 )}
                 {node.score != null && (
@@ -688,6 +737,14 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
     refetchInterval: active ? 10_000 : false,
   });
   const nodes = data ?? [];
+  // 锦标赛终榜（#653）：基础模式返回空结构，树视图的胜率徽章自然不渲染
+  const { data: tournament } = useQuery({
+    queryKey: ['hypothesis-tournament', voyage.id],
+    queryFn: () => api.getHypothesisTournament(voyage.id),
+    retry: false,
+    refetchInterval: active ? 10_000 : false,
+  });
+  const standings = tournament?.nodes ?? {};
 
   return (
     <div className="card card-pad" style={{ marginBottom: 20 }}>
@@ -719,7 +776,7 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
             : tr('这次任务没有留下假设树。', 'This run left no hypothesis tree.')}
         </div>
       ) : view === 'tree' ? (
-        <TreeView nodes={nodes} />
+        <TreeView nodes={nodes} standings={standings} />
       ) : (
         <ReportView nodes={nodes} active={active} />
       )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -487,6 +487,30 @@ export interface HypothesisNodeRead {
   updated_at: string;
 }
 
+/** 锦标赛终榜里一个参赛假设的战绩（#653，深度模式）。 */
+export interface HypothesisTournamentStanding {
+  /** 胜率（tie 各记半场），0-1 */
+  win_rate: number;
+  /** 参赛场数 */
+  matches: number;
+  /** 参赛前的管线绝对分（混合 score 的另一半来源） */
+  pipeline_score: number | null;
+  /** 混合后的新 score（已写回节点） */
+  score: number;
+}
+
+/** 锦标赛披露（GET /voyages/{id}/tournament）：对阵记录 + 参赛节点终榜。 */
+export interface HypothesisTournamentRead {
+  matches: {
+    round: number | null;
+    a: string;
+    b: string;
+    winner: 'a' | 'b' | 'tie';
+    rationale: string;
+  }[];
+  nodes: Record<string, HypothesisTournamentStanding>;
+}
+
 export interface VoyageRead {
   id: string;
   kind: string;
@@ -646,6 +670,7 @@ export const LLM_STAGES = [
   'hyp_ground',
   'hyp_novelty',
   'hyp_feasibility',
+  'hyp_compare',
 ] as const;
 
 export interface LlmProviderRead {
@@ -3514,6 +3539,10 @@ export const api = {
   /** discovery 任务的假设树（拉平列表，父子按 parent_id 拼装；只读）。 */
   listHypothesisTree(voyageId: string): Promise<HypothesisNodeRead[]> {
     return request<HypothesisNodeRead[]>(`/voyages/${voyageId}/hypothesis-tree`);
+  },
+  /** 锦标赛披露（#653）：基础模式（tournament=False）返回空结构。 */
+  getHypothesisTournament(voyageId: string): Promise<HypothesisTournamentRead> {
+    return request<HypothesisTournamentRead>(`/voyages/${voyageId}/tournament`);
   },
 
   // —— Gates ——

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -36,4 +36,5 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   hyp_ground: { zh: '假设·文献接地', en: 'Hypothesis · grounding' },
   hyp_novelty: { zh: '假设·查新判定', en: 'Hypothesis · novelty check' },
   hyp_feasibility: { zh: '假设·可行性论证', en: 'Hypothesis · feasibility' },
+  hyp_compare: { zh: '假设·两两对比', en: 'Hypothesis · pairwise compare' },
 };


### PR DESCRIPTION
Closes #653. Part of #635 (P2 wave 4, item D4); design report §8.2 (compute investment as the quality knob).

Optional depth mode refining the flat pipeline score with pairwise comparison; off by default (`params.tournament`, stored since #645).

- `hypothesis_tournament.run_tournament`: the top-6 open/expanded hypotheses by pipeline score enter round-robin comparison (≤15 pairs); a new short-tier `hyp_compare` stage judges each pair on statement + grounding summary + novelty verdicts, returning winner and a one-line rationale (deterministic under the fake provider: lexicographically smaller statement wins, so runs replay)
- scoring: win-rate (ties half) blends 0.5/0.5 with the pipeline score; ties break by pipeline score; every match (pairing, verdict, rationale) is recorded on the round ledger for the D6 disclosure trail, and token usage lands in the per-node accounting
- engine wiring: after an expansion round with tournament enabled, participant scores update through the tree service; the summarize proposal carries `tournament: {win_rate, matches}` per surviving hypothesis
- frontend: the creation form's advanced section exposes the toggle; tree rows show a win-rate badge when present; stage registries synced (parity guards green)
- goldens byte-identical — the golden chain keeps tournament off

Verification: branch suite green vs the clean baseline with only the pre-existing #581 failures (zero new); new tests cover on-vs-off ordering change, the top-6 cap, tie handling, and accounting; rebased onto #656 with the frontend rebuilt (build + vitest 143 green).