### PR TITLE
feat: disclosure report for discovery runs

### DIFF
--- a/src/backend/app/agents/voyage/actions_discovery.py
+++ b/src/backend/app/agents/voyage/actions_discovery.py
@@ -35,6 +35,7 @@ from app.core.db import get_sessionmaker
 from app.core.llm.base import Message
 from app.models.hypothesis import HypothesisNode
 from app.models.voyage import VoyageRun
+from app.services import discovery_disclosure
 from app.services import hypothesis_pipeline as pipeline
 from app.services import hypothesis_tournament as tournament_service
 from app.services import hypothesis_tree as tree_service
@@ -398,6 +399,12 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                 if not candidates:
                     raise ValueError("hyp_generate 未产出任何候选假设（去重后为空）")
                 usage = dict(gen["usage"])
+                # 检索留痕（D6 披露 #655）：本轮发出的全部查询按阶段收进轮次账本。
+                # generate 的查询归到被扩展的父节点头上（子节点还没出生）
+                round_queries: list[dict[str, Any]] = [
+                    {"phase": "generate", "node_id": str(target.id), **q}
+                    for q in gen["trace"]["queries"]
+                ]
                 # 先算后写：每个候选把 ground/novelty/feasibility/score 全部算完，
                 # 再统一落库——管线再长，树的被杀窗口也不随之变宽（见函数 docstring）
                 computed: list[dict[str, Any]] = []
@@ -443,6 +450,16 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                                 grounded["grounding"], nov["report"]
                             ),
                             "usage": child_usage,
+                            # 接地/查新的查询此刻还没有节点 id 可挂（先算后写），
+                            # 落库后再补上归属
+                            "queries": [
+                                {"phase": "ground", **q}
+                                for q in grounded["trace"]["queries"]
+                            ]
+                            + [
+                                {"phase": "novelty", **q}
+                                for q in nov["trace"]["queries"]
+                            ],
                         }
                     )
                 pruned_children: list[str] = []
@@ -459,6 +476,9 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                         score=item["score"],
                     )
                     children_ids.append(str(node.id))
+                    # 检索留痕补归属：这个子假设的接地/查新查询记它头上
+                    for q in item["queries"]:
+                        round_queries.append({**q, "node_id": str(node.id)})
                     # 每节点记账：这个子假设的接地/查新/可行性花的 token 记它头上
                     _account_node_usage(ctx, str(node.id), item["usage"])
                     usage["prompt_tokens"] += item["usage"]["prompt_tokens"]
@@ -490,6 +510,9 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                     "node_id": target_id,
                     "children": children_ids,
                     "pruned": pruned_children,
+                    # 检索留痕（D6 披露 #655）：本轮查询全录 + 三路灵感的论文集合
+                    "queries": round_queries,
+                    "inspiration_paper_ids": gen["trace"]["inspiration_paper_ids"],
                 }
                 why = (
                     f"第 {round_no} 轮：扩展最优 open 节点，管线产出 "
@@ -580,7 +603,9 @@ async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dic
     """整树汇总为**研究方案**产物（#648）：direction + 存活假设（按 score 降序，
     携带 grounding/novelty/feasibility 三类证据卡数据）+ 被剪分支附录（§8.2
     防择优汇报：放弃的路径和原因也是产物的一部分）+ 全节点快照与统计。
-    产物写进 checkpoint["artifacts"]，voyage 完成标准查它。"""
+    产物写进 checkpoint["artifacts"]，voyage 完成标准查它。同时确定性组装
+    披露报告 artifacts["discovery-disclosure.json"]（#655 D6：检索/阅读/剪枝/
+    对阵/记账全录，services/discovery_disclosure.py）。"""
     state = _state(ctx)
     async with get_sessionmaker()() as session:
         nodes = await tree_service.tree_for_run(session, ctx.run.id)
@@ -687,6 +712,10 @@ async def discovery_summarize(ctx: ActionContext, params: dict[str, Any]) -> dic
     }
     artifacts = dict(ctx.checkpoint.get("artifacts") or {})
     artifacts["discovery-summary.json"] = json.dumps(artifact, ensure_ascii=False)
+    # 披露报告（#655，§8.2）：与研究方案同刻落盘。纯确定性组装（零 LLM），
+    # 数据源是 ctx.checkpoint（run.checkpoint 此刻还是旧账，engine 结束后才回写）
+    disclosure = discovery_disclosure.build_disclosure(ctx.checkpoint, nodes)
+    artifacts["discovery-disclosure.json"] = json.dumps(disclosure, ensure_ascii=False)
     ctx.checkpoint["artifacts"] = artifacts
     _record_decision(
         ctx,

--- a/src/backend/app/api/hypotheses.py
+++ b/src/backend/app/api/hypotheses.py
@@ -1,10 +1,11 @@
-"""假设/实验树读路由（#637）：树整体 + 单节点详情。
+"""假设/实验树读路由（#637）：树整体 + 单节点详情 + run 产物只读（#655）。
 
 只读——树由 discovery 引擎写（D2/D3），用户不直接编辑节点。可见性完全
 复用任务口径（services.voyages.get_voyage 内部的 can_view_voyage）：
 树是 run 的资产，能看任务就能看树，无权限一律 404（不泄露存在性）。
 """
 
+import json
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -20,6 +21,11 @@ from app.services import hypothesis_tree as tree_service
 from app.services import voyages as voyages_service
 
 router = APIRouter(prefix="/voyages", tags=["hypotheses"])
+
+# 可外露的产物白名单（#655）：checkpoint["artifacts"] 里还混着内部状态的余地，
+# 只放行明确面向用户的两份 discovery 产物；名单外一律 404（与不存在同口径，
+# 不泄露「有没有这个键」）。后续 kind 的产物要外露时在这里登记。
+ARTIFACT_WHITELIST = frozenset({"discovery-summary.json", "discovery-disclosure.json"})
 
 
 async def _viewable_run(
@@ -62,6 +68,28 @@ async def get_hypothesis_tournament(
         "matches": state.get("matches") or [],
         "nodes": state.get("nodes") or {},
     }
+
+
+@router.get("/{voyage_id}/artifacts/{name}")
+async def get_voyage_artifact(
+    voyage_id: uuid.UUID,
+    name: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict:
+    """run 产物只读（#655，补 D5 标注的缺口：研究方案/披露报告此前无端点）。
+
+    产物存在 checkpoint["artifacts"]（值是 JSON 字符串），这里解析后返回——
+    前端不必自己 loads。可见性同树端点：能看任务就能看产物，无权限/名单外/
+    尚未产出一律 404。
+    """
+    run = await _viewable_run(session, voyage_id, user)
+    if name not in ARTIFACT_WHITELIST:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ARTIFACT_NOT_FOUND")
+    raw = ((run.checkpoint or {}).get("artifacts") or {}).get(name)
+    if raw is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="ARTIFACT_NOT_FOUND")
+    return {"name": name, "content": json.loads(raw) if isinstance(raw, str) else raw}
 
 
 @router.get(

--- a/src/backend/app/services/discovery_disclosure.py
+++ b/src/backend/app/services/discovery_disclosure.py
@@ -1,0 +1,232 @@
+"""discovery run 的披露报告组装（#655，设计报告 §8.2 防失败模式，P2 D6）。
+
+把一次假设树探索「实际做了什么」从 run 的既有记录里**确定性**拼出来——零 LLM
+调用、零新增判断：检索留痕在 checkpoint 轮次账本（#655 起 expand 记入）、剪枝
+原因在决策留痕、对阵在 tournament 账本、token 在 node_usage，节点证据在树上。
+披露的价值恰恰在于它只是既有事实的重排：报告说的每一句都能指回一条原始记录。
+
+产物形状（artifacts["discovery-disclosure.json"]，summarize 时落盘）::
+
+    {
+      "version": 1,
+      "queries":  [{round, phase: generate|ground|novelty, node_id, query,
+                    paper_ids}],                       # 检索了什么（全录）
+      "papers":   {retrieved, cited, retrieved_not_cited, cited_not_retrieved},
+      "branches": [{node_id, parent_id, statement, status, score,
+                    timeline: [{event: created|expanded|pruned, round,
+                                reason?, cascade_from?}]}],
+      "tournament": {matches, nodes},                  # 深度模式的对阵全录
+      "accounting": {node_usage, total},               # 每节点 + 总量 token
+      "invariants": {cited_subset_of_retrieved, pruned_have_reasons},
+      "warnings":  [{code, ...}],                      # 不变量违反时如实记录
+    }
+
+不变量违反**记 warnings 而不抛错**（§8.2）：披露是对既有 run 的如实陈述，run
+本身有伤（旧版本没留检索痕、断点补账丢了归属）时，报告该把伤口说出来，而不是
+因为伤口存在就拒绝出报告。
+"""
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+# 轮次账本里合法不带检索留痕的记录标志（无事发生 / 断点补账）
+_NO_TRACE_FLAGS = ("no_open", "replayed_from_tree")
+
+
+def _add_unique(out: list[str], ids: Iterable[Any]) -> None:
+    for raw in ids:
+        pid = str(raw)
+        if pid and pid not in out:
+            out.append(pid)
+
+
+def _sorted_rounds(rounds: dict[str, Any]) -> list[tuple[int, dict[str, Any]]]:
+    """轮次账本按轮号升序（键是字符串数字；坏键按 0 处理，不因脏数据拒绝出报）。"""
+
+    def _no(key: str) -> int:
+        try:
+            return int(key)
+        except (TypeError, ValueError):
+            return 0
+
+    return sorted(
+        ((_no(k), v) for k, v in rounds.items() if isinstance(v, dict)),
+        key=lambda kv: kv[0],
+    )
+
+
+def build_disclosure(checkpoint: dict[str, Any], nodes: Sequence[Any]) -> dict[str, Any]:
+    """checkpoint + 假设树节点 → 披露 JSON（纯确定性，见模块 docstring）。
+
+    传 checkpoint 而不是 run：summarize 调用时最新的账本在 ctx.checkpoint 内存里
+    （engine 在动作结束后才回写 run.checkpoint，动作中途读 run 拿到的是旧账）。
+    nodes 按 tree_for_run 的创建序传入，只读 id/parent_id/statement/status/score/
+    grounding/novelty_report——测试可用轻量替身，不必过数据库。
+    """
+    state = checkpoint.get("discovery") if isinstance(checkpoint, dict) else None
+    state = state if isinstance(state, dict) else {}
+    rounds = state.get("rounds") if isinstance(state.get("rounds"), dict) else {}
+    decisions = [d for d in (state.get("decisions") or []) if isinstance(d, dict)]
+    node_usage = (
+        state.get("node_usage") if isinstance(state.get("node_usage"), dict) else {}
+    )
+    tournament = (
+        state.get("tournament") if isinstance(state.get("tournament"), dict) else {}
+    )
+    warnings: list[dict[str, Any]] = []
+
+    # ---- queries：轮次账本里的检索留痕拉平（按轮序，轮内保持记录顺序） ----
+    queries: list[dict[str, Any]] = []
+    retrieved: list[str] = []
+    for round_no, record in _sorted_rounds(rounds):
+        for raw in record.get("queries") or []:
+            if not isinstance(raw, dict):
+                continue
+            paper_ids: list[str] = []
+            _add_unique(paper_ids, raw.get("paper_ids") or [])
+            queries.append(
+                {
+                    "round": round_no,
+                    "phase": str(raw.get("phase") or ""),
+                    "node_id": raw.get("node_id"),
+                    "query": str(raw.get("query") or ""),
+                    "paper_ids": paper_ids,
+                }
+            )
+            _add_unique(retrieved, paper_ids)
+        inspirations = record.get("inspiration_paper_ids")
+        if isinstance(inspirations, dict):
+            # 引文远端/多样窗两路没有查询文本，但论文确实被读过——计入 retrieved
+            for route_ids in inspirations.values():
+                _add_unique(retrieved, route_ids or [])
+        elif record.get("node_id") is not None or not any(
+            record.get(flag) for flag in _NO_TRACE_FLAGS
+        ):
+            # 真扩展过却没有检索留痕：旧版本 run（#655 之前）或脏账，如实标注
+            warnings.append({"code": "round_without_trace", "round": round_no})
+
+    # ---- papers：retrieved 全集 vs 实引（grounding 立场引用 + 查新引用） ----
+    cited: list[str] = []
+    for node in nodes:
+        grounding = node.grounding if isinstance(node.grounding, list) else []
+        for entry in grounding:
+            if isinstance(entry, dict) and entry.get("stance") in ("support", "refute"):
+                _add_unique(cited, entry.get("paper_ids") or [])
+        report = node.novelty_report if isinstance(node.novelty_report, dict) else {}
+        for entry in report.get("subclaims") or []:
+            if isinstance(entry, dict):
+                _add_unique(cited, entry.get("paper_ids") or [])
+    retrieved_set = set(retrieved)
+    cited_not_retrieved = [pid for pid in cited if pid not in retrieved_set]
+    if cited_not_retrieved:
+        # 引用只该来自检索结果（管线的结构性约束）：违反说明留痕缺失或数据有伤
+        warnings.append(
+            {"code": "cited_not_retrieved", "paper_ids": cited_not_retrieved}
+        )
+    papers = {
+        "retrieved": retrieved,
+        "cited": cited,
+        "retrieved_not_cited": [pid for pid in retrieved if pid not in set(cited)],
+        "cited_not_retrieved": cited_not_retrieved,
+    }
+
+    # ---- branches：每节点 created/expanded/pruned 时间线（决策留痕反查原因） ----
+    created_round: dict[str, int] = {}
+    expanded_round: dict[str, int] = {}
+    for round_no, record in _sorted_rounds(rounds):
+        for child_id in record.get("children") or []:
+            created_round.setdefault(str(child_id), round_no)
+        if record.get("node_id"):
+            expanded_round.setdefault(str(record["node_id"]), round_no)
+    prune_decisions: dict[str, dict[str, Any]] = {}
+    for decision in decisions:
+        if decision.get("decision") == "pruned" and decision.get("node_id"):
+            prune_decisions.setdefault(str(decision["node_id"]), decision)
+    parent_of = {
+        str(n.id): (str(n.parent_id) if n.parent_id else None) for n in nodes
+    }
+    status_of = {str(n.id): n.status for n in nodes}
+
+    def _cascade_source(node_id: str) -> str | None:
+        """沿祖先找最近一个「有直接剪枝决策」的被剪节点（级联剪枝的来源）。"""
+        seen = {node_id}
+        current = parent_of.get(node_id)
+        while current is not None and current not in seen:
+            seen.add(current)
+            if status_of.get(current) == "pruned" and current in prune_decisions:
+                return current
+            current = parent_of.get(current)
+        return None
+
+    branches: list[dict[str, Any]] = []
+    pruned_have_reasons = True
+    for node in nodes:
+        node_id = str(node.id)
+        # 根节点是 seed 建的（第 0 轮）；其余节点的出生轮查账本 children 列表，
+        # 查不到（断点补账丢了名单）就如实记 None
+        born = 0 if parent_of.get(node_id) is None else created_round.get(node_id)
+        timeline: list[dict[str, Any]] = [{"event": "created", "round": born}]
+        if node_id in expanded_round:
+            timeline.append({"event": "expanded", "round": expanded_round[node_id]})
+        if node.status == "pruned":
+            decision = prune_decisions.get(node_id)
+            if decision is not None:
+                timeline.append(
+                    {
+                        "event": "pruned",
+                        "round": decision.get("round"),
+                        "reason": str(decision.get("why") or ""),
+                    }
+                )
+            else:
+                source = _cascade_source(node_id)
+                if source is not None:
+                    timeline.append(
+                        {
+                            "event": "pruned",
+                            "round": prune_decisions[source].get("round"),
+                            "reason": "随父分支级联剪枝",
+                            "cascade_from": source,
+                        }
+                    )
+                else:
+                    # 不变量违反：被剪却查无原因（直接决策没有、级联来源也没有）
+                    pruned_have_reasons = False
+                    warnings.append(
+                        {"code": "pruned_without_reason", "node_id": node_id}
+                    )
+                    timeline.append({"event": "pruned", "round": None, "reason": None})
+        branches.append(
+            {
+                "node_id": node_id,
+                "parent_id": parent_of.get(node_id),
+                "statement": node.statement,
+                "status": node.status,
+                "score": node.score,
+                "timeline": timeline,
+            }
+        )
+
+    # ---- accounting：每节点账本原样归档 + 总量 ----
+    total = {"prompt_tokens": 0, "completion_tokens": 0}
+    for entry in node_usage.values():
+        if isinstance(entry, dict):
+            total["prompt_tokens"] += int(entry.get("prompt_tokens", 0) or 0)
+            total["completion_tokens"] += int(entry.get("completion_tokens", 0) or 0)
+
+    return {
+        "version": 1,
+        "queries": queries,
+        "papers": papers,
+        "branches": branches,
+        "tournament": {
+            "matches": tournament.get("matches") or [],
+            "nodes": tournament.get("nodes") or {},
+        },
+        "accounting": {"node_usage": node_usage, "total": total},
+        "invariants": {
+            "cited_subset_of_retrieved": not cited_not_retrieved,
+            "pruned_have_reasons": pruned_have_reasons,
+        },
+        "warnings": warnings,
+    }

--- a/src/backend/app/services/hypothesis_pipeline.py
+++ b/src/backend/app/services/hypothesis_pipeline.py
@@ -158,6 +158,16 @@ async def _complete_json(
     raise ValueError(f"{stage} 连续输出非法 JSON：{last_error}")
 
 
+def _ordered_paper_ids(chunks: list[PaperChunk]) -> list[str]:
+    """片段列表 → 去重保序的 paper_id 字符串列表（检索留痕用，D6 披露 #655）。"""
+    out: list[str] = []
+    for chunk in chunks:
+        pid = str(chunk.paper_id)
+        if pid not in out:
+            out.append(pid)
+    return out
+
+
 async def _paper_titles(
     session: AsyncSession, paper_ids: list[uuid.UUID]
 ) -> dict[uuid.UUID, str]:
@@ -374,8 +384,9 @@ async def generate(
 ) -> dict[str, Any]:
     """三路灵感 → 一次 LLM 组合出 n 个候选 → 去重。
 
-    返回 {"candidates": [{statement, rationale}], "usage": {...}}；
-    candidates 已去重，数量 ≤ n_candidates（可能因折叠更少）。
+    返回 {"candidates": [{statement, rationale}], "usage": {...}, "trace": {...}}；
+    candidates 已去重，数量 ≤ n_candidates（可能因折叠更少）。trace 是确定性
+    检索留痕（查询 + 捞回的 paper_ids），供 expand 记进轮次账本、D6 披露消费。
     """
     usage = {"prompt_tokens": 0, "completion_tokens": 0}
     semantic_chunks = await _retrieve(
@@ -421,7 +432,22 @@ async def generate(
         library_id=library_id,
         voyage_id=voyage_id,
     )
-    return {"candidates": dedup_candidates(raw[:n_candidates]), "usage": usage}
+    return {
+        "candidates": dedup_candidates(raw[:n_candidates]),
+        "usage": usage,
+        # 检索留痕（确定性数据，D6 披露 #655）：发出过什么查询、捞回了哪些论文。
+        # 三路灵感只有语义路有查询文本；引文远端/多样窗按路记论文集合。
+        "trace": {
+            "queries": [
+                {"query": direction, "paper_ids": _ordered_paper_ids(semantic_chunks)}
+            ],
+            "inspiration_paper_ids": {
+                "semantic": _ordered_paper_ids(semantic_chunks),
+                "citation_far": _ordered_paper_ids(far_chunks),
+                "diverse": _ordered_paper_ids(diverse_chunks),
+            },
+        },
+    }
 
 
 # ---- 2) 文献接地：拆子命题 → 确定性检索 → 只许从检索集内选 ----
@@ -507,6 +533,7 @@ async def ground(
         **identity,
     )
     retrieved: list[list[dict[str, Any]]] = []
+    trace_queries: list[dict[str, Any]] = []
     for subclaim in subclaims:
         chunks = await _retrieve(
             session,
@@ -518,6 +545,8 @@ async def ground(
         )
         titles = await _paper_titles(session, list({c.paper_id for c in chunks}))
         retrieved.append([_chunk_entry(c, titles) for c in chunks])
+        # 检索留痕（D6 披露 #655）：接地的查询就是子命题本身
+        trace_queries.append({"query": subclaim, "paper_ids": _ordered_paper_ids(chunks)})
     items = await _complete_json(
         llm,
         GROUND_STAGE,
@@ -533,7 +562,11 @@ async def ground(
         usage=usage,
         **identity,
     )
-    return {"grounding": sanitize_grounding(subclaims, retrieved, items), "usage": usage}
+    return {
+        "grounding": sanitize_grounding(subclaims, retrieved, items),
+        "usage": usage,
+        "trace": {"queries": trace_queries},
+    }
 
 
 # ---- 3) 查新：换措辞再检索 → 逐子命题 judge ----
@@ -577,17 +610,21 @@ async def novelty(
     usage = {"prompt_tokens": 0, "completion_tokens": 0}
     judged_indices = [i for i, e in enumerate(grounding) if e.get("stance") != "speculation"]
     evidence_by_index: dict[int, list[dict[str, Any]]] = {}
+    trace_queries: list[dict[str, Any]] = []
     for i in judged_indices:
+        query = f"{_NOVELTY_QUERY_PREFIX} {grounding[i]['subclaim']}"
         chunks = await _retrieve(
             session,
             library_id=library_id,
-            query=f"{_NOVELTY_QUERY_PREFIX} {grounding[i]['subclaim']}",
+            query=query,
             user_id=user_id,
             project_id=project_id,
             limit=GROUND_TOP_K,
         )
         titles = await _paper_titles(session, list({c.paper_id for c in chunks}))
         evidence_by_index[i] = [_chunk_entry(c, titles) for c in chunks]
+        # 检索留痕（D6 披露 #655）：查新用的是换措辞后的查询，如实记换后的
+        trace_queries.append({"query": query, "paper_ids": _ordered_paper_ids(chunks)})
     verdicts: dict[int, tuple[str, list[str]]] = {}
     if judged_indices:
         try:
@@ -636,7 +673,11 @@ async def novelty(
                 "judged": i in verdicts,
             }
         )
-    return {"report": {"subclaims": subclaim_reports}, "usage": usage}
+    return {
+        "report": {"subclaims": subclaim_reports},
+        "usage": usage,
+        "trace": {"queries": trace_queries},
+    }
 
 
 # ---- 4) 可行性：确定性资源信号 + LLM 只写风险论证 ----

--- a/src/backend/tests/golden/data/discovery_run.json
+++ b/src/backend/tests/golden/data/discovery_run.json
@@ -132,6 +132,171 @@
     "status": "active",
     "updated_at": "<ts>"
   },
+  "discovery_disclosure": {
+    "content": {
+      "accounting": {
+        "node_usage": {
+          "<uuid-10>": {
+            "completion_tokens": 115,
+            "prompt_tokens": 835
+          },
+          "<uuid-11>": {
+            "completion_tokens": 115,
+            "prompt_tokens": 839
+          },
+          "<uuid-8>": {
+            "completion_tokens": 91,
+            "prompt_tokens": 433
+          }
+        },
+        "total": {
+          "completion_tokens": 321,
+          "prompt_tokens": 2107
+        }
+      },
+      "branches": [
+        {
+          "node_id": "<uuid-8>",
+          "parent_id": null,
+          "score": 0.8,
+          "statement": "围绕「structured agent planning」的核心假设（fake root）",
+          "status": "expanded",
+          "timeline": [
+            {
+              "event": "created",
+              "round": 0
+            },
+            {
+              "event": "expanded",
+              "round": 1
+            }
+          ]
+        },
+        {
+          "node_id": "<uuid-10>",
+          "parent_id": "<uuid-8>",
+          "score": 0.25,
+          "statement": "机制假设（fake A）：structured agent planning；父假设：围绕「structu 依赖显式规划机制",
+          "status": "open",
+          "timeline": [
+            {
+              "event": "created",
+              "round": 1
+            }
+          ]
+        },
+        {
+          "node_id": "<uuid-11>",
+          "parent_id": "<uuid-8>",
+          "score": 0.25,
+          "statement": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「structu 需要检索增强验证",
+          "status": "open",
+          "timeline": [
+            {
+              "event": "created",
+              "round": 1
+            }
+          ]
+        }
+      ],
+      "invariants": {
+        "cited_subset_of_retrieved": true,
+        "pruned_have_reasons": true
+      },
+      "papers": {
+        "cited": [
+          "<uuid-4>"
+        ],
+        "cited_not_retrieved": [],
+        "retrieved": [
+          "<uuid-4>",
+          "<uuid-5>"
+        ],
+        "retrieved_not_cited": [
+          "<uuid-5>"
+        ]
+      },
+      "queries": [
+        {
+          "node_id": "<uuid-8>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "generate",
+          "query": "structured agent planning；父假设：围绕「structured agent planning」的核心假设（fake root）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-10>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "ground",
+          "query": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的机制子命题（fake s1）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-10>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "ground",
+          "query": "机制假设（fake A）：structured agent planning；父假设：围绕「stru 的边界子命题（fake s2）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-10>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "novelty",
+          "query": "已有研究 prior work on 机制假设（fake A）：structured agent planning；父假设：围绕「stru 的机制子命题（fake s1）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-11>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "ground",
+          "query": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的机制子命题（fake s1）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-11>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "ground",
+          "query": "证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的边界子命题（fake s2）",
+          "round": 1
+        },
+        {
+          "node_id": "<uuid-11>",
+          "paper_ids": [
+            "<uuid-4>",
+            "<uuid-5>"
+          ],
+          "phase": "novelty",
+          "query": "已有研究 prior work on 证据闭环假设（fake B）：structured agent planning；父假设：围绕「st 的机制子命题（fake s1）",
+          "round": 1
+        }
+      ],
+      "tournament": {
+        "matches": [],
+        "nodes": {}
+      },
+      "version": 1,
+      "warnings": []
+    },
+    "name": "discovery-disclosure.json"
+  },
   "hypothesis_tree": [
     {
       "created_at": "<ts>",

--- a/src/backend/tests/golden/normalize.py
+++ b/src/backend/tests/golden/normalize.py
@@ -1,7 +1,8 @@
 """Golden transcript 归一化：把响应里的易变值替换成稳定占位符。
 
 规则（顺序敏感，UUID 按首见顺序编号，跨步骤稳定）：
-- UUID 字符串 → ``<uuid-N>``
+- UUID 字符串 → ``<uuid-N>``（dict 的**键**也归一化——披露产物的
+  node_usage/终榜按节点 id 作键，#655 起进 transcript）
 - ISO 时间戳 → ``<ts>``
 - JWT（三段 base64url）→ ``<token>``
 - 临时目录绝对路径 → ``<path>``
@@ -30,7 +31,12 @@ class Normalizer:
 
     def normalize(self, obj: Any) -> Any:
         if isinstance(obj, dict):
-            return {k: self.normalize(v) for k, v in obj.items()}
+            return {
+                (self._uuid(k) if isinstance(k, str) and _UUID_RE.match(k) else k): (
+                    self.normalize(v)
+                )
+                for k, v in obj.items()
+            }
         if isinstance(obj, list):
             return [self.normalize(v) for v in obj]
         if isinstance(obj, str):

--- a/src/backend/tests/golden/test_golden_discovery.py
+++ b/src/backend/tests/golden/test_golden_discovery.py
@@ -1,5 +1,5 @@
 """Golden transcript：注册 → 建库 → 建课题 → 两篇 bibtex 论文 → 库索引 →
-建 discovery 任务 → 引擎跑完 → 任务详情 + 假设树。
+建 discovery 任务 → 引擎跑完 → 任务详情 + 假设树 + 披露产物。
 
 D3（#648）的回归闸门：四段假设管线（generate → ground → novelty → feasibility →
 score）在 fake provider + sqlite 上确定性运行——树的形状、每个节点的 grounding /
@@ -155,6 +155,25 @@ async def test_discovery_chain_matches_golden(client, queue_stub):
         await client.get(f"/api/voyages/{run['id']}/hypothesis-tree", headers=headers),
         200,
     )
+    # 披露产物（#655 D6）：检索/阅读/剪枝/记账全录，经通用产物只读端点取回。
+    # 归一化前先做不变量自检——golden 链是「行为没变」的闸门，披露自洽
+    # （实引 ⊆ 检索集、被剪皆有因、零警告）是行为的一部分，必须常绿。
+    disclosure = (
+        await step(
+            "discovery_disclosure",
+            await client.get(
+                f"/api/voyages/{run['id']}/artifacts/discovery-disclosure.json",
+                headers=headers,
+            ),
+            200,
+        )
+    )["content"]
+    assert disclosure["invariants"] == {
+        "cited_subset_of_retrieved": True,
+        "pruned_have_reasons": True,
+    }
+    assert disclosure["warnings"] == []
+    assert disclosure["queries"], "披露里必须有检索留痕"
 
     rendered = json.dumps(transcript, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     if os.environ.get("POLARIS_GOLDEN") == "record":

--- a/src/backend/tests/test_discovery_disclosure.py
+++ b/src/backend/tests/test_discovery_disclosure.py
@@ -1,0 +1,389 @@
+"""discovery 披露报告（#655，§8.2 防失败模式，P2 D6）。
+
+两层：
+- build_disclosure 纯函数——伪造 checkpoint + 轻量节点替身直测组装逻辑
+  （queries 拉平、retrieved/cited 差集、时间线与级联剪枝反查、记账汇总、
+  不变量违反只记 warnings 不抛错）；
+- fake 管线端到端 + 产物只读端点——run 跑完后披露产物落盘且自洽，
+  GET /voyages/{id}/artifacts/{name} 的白名单与 404 口径。
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.agents.voyage.engine import VoyageEngine
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.hypothesis import HypothesisNode
+from app.models.paper import PaperChunk
+from app.services.discovery_disclosure import build_disclosure
+from tests.conftest import (
+    RecordingBus,
+    add_paper,
+    make_project_with_library,
+    register_and_login,
+)
+
+# ---- 纯函数：伪造一次两轮探索的完整现场 ----
+
+ROOT, CHILD_A, CHILD_B, GRANDCHILD = "n-root", "n-a", "n-b", "n-ba"
+P1, P2, P3, P4 = "p1", "p2", "p3", "p4"
+
+
+def _node(node_id, parent_id, status, *, score=0.5, grounding=None, novelty=None):
+    return SimpleNamespace(
+        id=node_id,
+        parent_id=parent_id,
+        statement=f"假设 {node_id}",
+        status=status,
+        score=score,
+        grounding=grounding,
+        novelty_report=novelty,
+    )
+
+
+def _fixture():
+    """根扩出 A/B；B 被显式剪枝（有决策），B 的孩子随之级联（无决策）。
+
+    检索留痕：generate 捞到 P1/P2（灵感另含 P3），A 的接地查询捞 P1、查新捞
+    P2；实引 = A 的 grounding 引 P1 + 查新引 P2 → P3 是「检了没用」差集。
+    """
+    nodes = [
+        _node(ROOT, None, "expanded", score=0.8),
+        _node(
+            CHILD_A,
+            ROOT,
+            "open",
+            score=0.25,
+            grounding=[
+                {"subclaim": "s1", "stance": "support", "paper_ids": [P1]},
+                {"subclaim": "s2", "stance": "speculation", "paper_ids": []},
+            ],
+            novelty={
+                "subclaims": [{"subclaim": "s1", "verdict": "novel", "paper_ids": [P2]}]
+            },
+        ),
+        _node(CHILD_B, ROOT, "pruned", score=0.1),
+        _node(GRANDCHILD, CHILD_B, "pruned", score=None),
+    ]
+    checkpoint = {
+        "discovery": {
+            "rounds": {
+                "1": {
+                    "node_id": ROOT,
+                    "children": [CHILD_A, CHILD_B],
+                    "pruned": [],
+                    "queries": [
+                        {
+                            "phase": "generate",
+                            "node_id": ROOT,
+                            "query": "方向",
+                            "paper_ids": [P1, P2],
+                        },
+                        {
+                            "phase": "ground",
+                            "node_id": CHILD_A,
+                            "query": "s1",
+                            "paper_ids": [P1],
+                        },
+                        {
+                            "phase": "novelty",
+                            "node_id": CHILD_A,
+                            "query": "已有研究 s1",
+                            "paper_ids": [P2],
+                        },
+                    ],
+                    "inspiration_paper_ids": {
+                        "semantic": [P1, P2],
+                        "citation_far": [P3],
+                        "diverse": [],
+                    },
+                },
+            },
+            "decisions": [
+                {"round": 0, "decision": "expand", "node_id": ROOT, "why": "树为空"},
+                {"round": 2, "decision": "pruned", "node_id": CHILD_B, "why": "方向不通"},
+                {"round": 1, "decision": "summarize", "node_id": ROOT, "why": "上限"},
+            ],
+            "node_usage": {
+                ROOT: {"prompt_tokens": 10, "completion_tokens": 5},
+                CHILD_A: {"prompt_tokens": 7, "completion_tokens": 3},
+            },
+            "tournament": {
+                "matches": [
+                    {"round": 1, "a": ROOT, "b": CHILD_A, "winner": "a", "rationale": "r"}
+                ],
+                "nodes": {
+                    ROOT: {"win_rate": 1.0, "matches": 1, "pipeline_score": 0.8, "score": 0.9}
+                },
+            },
+        }
+    }
+    return checkpoint, nodes
+
+
+def test_build_disclosure_full_fixture():
+    checkpoint, nodes = _fixture()
+    d = build_disclosure(checkpoint, nodes)
+
+    # queries：按轮拉平，轮号/阶段/归属/查询/结果全录
+    assert [(q["round"], q["phase"], q["node_id"]) for q in d["queries"]] == [
+        (1, "generate", ROOT),
+        (1, "ground", CHILD_A),
+        (1, "novelty", CHILD_A),
+    ]
+    assert d["queries"][0]["paper_ids"] == [P1, P2]
+
+    # papers：retrieved = 查询命中 ∪ 灵感论文；cited = 接地立场引用 + 查新引用
+    assert d["papers"]["retrieved"] == [P1, P2, P3]
+    assert d["papers"]["cited"] == [P1, P2]
+    assert d["papers"]["retrieved_not_cited"] == [P3]
+    assert d["papers"]["cited_not_retrieved"] == []
+
+    # branches：根第 0 轮出生、第 1 轮被扩展；B 有直接剪枝原因；
+    # B 的孩子无决策 → 反查到级联来源 B
+    by_id = {b["node_id"]: b for b in d["branches"]}
+    assert by_id[ROOT]["timeline"] == [
+        {"event": "created", "round": 0},
+        {"event": "expanded", "round": 1},
+    ]
+    assert by_id[CHILD_A]["timeline"] == [{"event": "created", "round": 1}]
+    assert by_id[CHILD_B]["timeline"][-1] == {
+        "event": "pruned",
+        "round": 2,
+        "reason": "方向不通",
+    }
+    grandchild_pruned = by_id[GRANDCHILD]["timeline"][-1]
+    assert grandchild_pruned["reason"] == "随父分支级联剪枝"
+    assert grandchild_pruned["cascade_from"] == CHILD_B
+    # 级联节点不在任何轮次的 children 名单里（prune 动作建不出它）→ 出生轮如实 None
+    assert by_id[GRANDCHILD]["timeline"][0] == {"event": "created", "round": None}
+
+    # tournament / accounting 原样归档 + 总量
+    assert d["tournament"]["matches"][0]["winner"] == "a"
+    assert d["accounting"]["total"] == {"prompt_tokens": 17, "completion_tokens": 8}
+
+    # 不变量全过、无警告
+    assert d["invariants"] == {
+        "cited_subset_of_retrieved": True,
+        "pruned_have_reasons": True,
+    }
+    assert d["warnings"] == []
+
+
+def test_build_disclosure_records_violations_as_warnings():
+    """三条伤口都如实记 warnings 而不抛错：引用越过检索集、被剪查无原因、
+    断点补账/旧版本轮次没有检索留痕。"""
+    checkpoint, nodes = _fixture()
+    state = checkpoint["discovery"]
+    # ① A 引了一篇从未检索到的论文
+    nodes[1].grounding[0]["paper_ids"] = [P4]
+    # ② B 的剪枝决策丢了（连级联来源也查不到）
+    state["decisions"] = [d for d in state["decisions"] if d.get("decision") != "pruned"]
+    # ③ 第 2 轮是旧格式：真扩展过但没有 queries/inspiration 留痕
+    state["rounds"]["2"] = {"node_id": CHILD_A, "children": [], "pruned": []}
+    # ④ 断点补账轮：node_id 为 None + 标志位，属合法无留痕，不该报警
+    state["rounds"]["3"] = {"node_id": None, "replayed_from_tree": True}
+
+    d = build_disclosure(checkpoint, nodes)
+    codes = [w["code"] for w in d["warnings"]]
+    assert codes.count("round_without_trace") == 1
+    assert {"code": "cited_not_retrieved", "paper_ids": [P4]} in d["warnings"]
+    assert {"code": "pruned_without_reason", "node_id": CHILD_B} in d["warnings"]
+    assert {"code": "pruned_without_reason", "node_id": GRANDCHILD} in d["warnings"]
+    assert d["invariants"] == {
+        "cited_subset_of_retrieved": False,
+        "pruned_have_reasons": False,
+    }
+    assert P4 in d["papers"]["cited_not_retrieved"]
+    # 时间线如实开天窗，而不是编一个原因
+    by_id = {b["node_id"]: b for b in d["branches"]}
+    assert by_id[CHILD_B]["timeline"][-1] == {"event": "pruned", "round": None, "reason": None}
+
+
+def test_build_disclosure_tolerates_empty_run():
+    """空 checkpoint / 空树：出一份空而完整的报告，不炸。"""
+    d = build_disclosure({}, [])
+    assert d["queries"] == [] and d["branches"] == []
+    assert d["papers"]["retrieved"] == [] and d["papers"]["cited"] == []
+    assert d["invariants"] == {
+        "cited_subset_of_retrieved": True,
+        "pruned_have_reasons": True,
+    }
+    assert d["accounting"]["total"] == {"prompt_tokens": 0, "completion_tokens": 0}
+
+
+# ---- fake 管线端到端 + 产物端点 ----
+
+_CORPUS = (
+    "agent planning verification corpus for discovery. "
+    "本库覆盖：披露测试方向 的相关论述与实验证据。" + "库内语料的细节论述。" * 30
+)
+
+
+async def _run_discovery(client, queue_stub) -> tuple[str, dict]:
+    """API 建 run（走正规入口，可见性/参数定形与生产一致）→ 引擎同步跑完。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="disclosure-lib", statement="披露测试库"
+    )
+    async with get_sessionmaker()() as session:
+        for i in range(2):
+            paper = await add_paper(
+                session,
+                project_id=project_id,
+                title=f"Disclosure Paper {i}",
+                abstract=f"abstract {i}",
+                year=2024 + i,
+                venue="TestConf",
+                relevance_score=0.9,
+                status="compiled",
+            )
+            session.add(
+                PaperChunk(
+                    paper_id=paper.id, seq=0, text=f"{_CORPUS}（第 {i} 篇）", source="fulltext"
+                )
+            )
+        await session.commit()
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "披露测试方向",
+            "params": {
+                "direction": "披露测试方向",
+                "library_id": str(library_id),
+                "max_expansions": 1,
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    run_id = resp.json()["id"]
+    await VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter()).run(uuid.UUID(run_id))
+    return run_id, headers
+
+
+@pytest.mark.asyncio
+async def test_disclosure_artifact_written_and_served(client, queue_stub):
+    run_id, headers = await _run_discovery(client, queue_stub)
+
+    resp = await client.get(
+        f"/api/voyages/{run_id}/artifacts/discovery-disclosure.json", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "discovery-disclosure.json"
+    d = body["content"]
+
+    # 真 run 自洽：不变量全过、无警告
+    assert d["invariants"] == {
+        "cited_subset_of_retrieved": True,
+        "pruned_have_reasons": True,
+    }
+    assert d["warnings"] == []
+    # 检索留痕齐全：generate 1 条 + 每子假设接地 2 条/查新 1 条（fake 确定性形状）
+    phases = [q["phase"] for q in d["queries"]]
+    assert phases == [
+        "generate", "ground", "ground", "novelty", "ground", "ground", "novelty",
+    ]
+    assert all(q["round"] == 1 and q["node_id"] for q in d["queries"])
+    # 实引 ⊆ 检索全集，且与树上节点的引用一致
+    assert set(d["papers"]["cited"]) <= set(d["papers"]["retrieved"])
+    async with get_sessionmaker()() as session:
+        nodes = (
+            (
+                await session.execute(
+                    select(HypothesisNode).where(HypothesisNode.run_id == uuid.UUID(run_id))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    cited_from_tree = {
+        pid
+        for n in nodes
+        for g in (n.grounding or [])
+        if g.get("stance") in ("support", "refute")
+        for pid in g["paper_ids"]
+    }
+    assert cited_from_tree <= set(d["papers"]["cited"])
+    # branches 覆盖全树，根有 created+expanded 时间线
+    assert {b["node_id"] for b in d["branches"]} == {str(n.id) for n in nodes}
+    root_branch = next(b for b in d["branches"] if b["parent_id"] is None)
+    assert [e["event"] for e in root_branch["timeline"]] == ["created", "expanded"]
+    # 记账总量 > 0
+    assert d["accounting"]["total"]["prompt_tokens"] > 0
+
+    # 与 checkpoint 里的产物逐字一致（端点只是解析转发，不加工）
+    async with get_sessionmaker()() as session:
+        from app.models.voyage import VoyageRun
+
+        run = await session.get(VoyageRun, uuid.UUID(run_id))
+        stored = json.loads(run.checkpoint["artifacts"]["discovery-disclosure.json"])
+    assert d == stored
+
+    # 研究方案产物同端点可读（D5 标注的缺口：此前 summary 无只读端点）
+    resp = await client.get(
+        f"/api/voyages/{run_id}/artifacts/discovery-summary.json", headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["content"]["direction"] == "披露测试方向"
+
+
+@pytest.mark.asyncio
+async def test_artifact_endpoint_whitelist_and_visibility(client, queue_stub):
+    run_id, headers = await _run_discovery(client, queue_stub)
+
+    # 白名单外一律 404（哪怕 checkpoint 里真有别的键，也不泄露存在性）
+    for name in ("params", "checkpoint.json", "discovery-summary", "..%2Fparams"):
+        resp = await client.get(f"/api/voyages/{run_id}/artifacts/{name}", headers=headers)
+        assert resp.status_code == 404, name
+        assert resp.json()["detail"] in ("ARTIFACT_NOT_FOUND", "Not Found")
+
+    # 别人的 run：404，与任务详情同口径（不泄露存在性）
+    other = await register_and_login(client, email="other@example.com")
+    resp = await client.get(
+        f"/api/voyages/{run_id}/artifacts/discovery-disclosure.json",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 404
+
+    # run 不存在：404
+    resp = await client.get(
+        f"/api/voyages/{uuid.uuid4()}/artifacts/discovery-disclosure.json", headers=headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_artifact_endpoint_404_before_summarize(client, queue_stub):
+    """还没跑到汇总的 run：产物尚未产出，404（前端据此降级为推断视图）。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="empty-lib", statement="s"
+    )
+    resp = await client.post(
+        "/api/voyages",
+        json={
+            "kind": "discovery",
+            "project_id": project_id,
+            "goal": "g",
+            "params": {"direction": "g", "library_id": str(library_id)},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    run_id = resp.json()["id"]
+    resp = await client.get(
+        f"/api/voyages/{run_id}/artifacts/discovery-disclosure.json", headers=headers
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "ARTIFACT_NOT_FOUND"

--- a/src/frontend/src/features/voyages/__tests__/discoveryDisclosure.test.ts
+++ b/src/frontend/src/features/voyages/__tests__/discoveryDisclosure.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseDisclosure,
+  pruneRecordsOf,
+  prunedBranches,
+  queriesByPhase,
+} from '../discoveryDisclosure';
+
+/* 过程记录纯函数（#655）：产物 schema 不锁死，解析容错与视图变换
+   （阶段分组、剪枝原因反查）要钉死——剪枝原因是要给用户看的事实。 */
+
+const ARTIFACT = {
+  version: 1,
+  queries: [
+    { round: 1, phase: 'generate', node_id: 'root', query: 'q-gen', paper_ids: ['p1', 'p2'] },
+    { round: 1, phase: 'ground', node_id: 'a', query: 'q-g1', paper_ids: ['p1'] },
+    { round: 1, phase: 'novelty', node_id: 'a', query: 'q-n1', paper_ids: ['p2'] },
+    { round: 2, phase: 'ground', node_id: 'b', query: 'q-g2', paper_ids: [] },
+  ],
+  papers: {
+    retrieved: ['p1', 'p2', 'p3'],
+    cited: ['p1', 'p2'],
+    retrieved_not_cited: ['p3'],
+    cited_not_retrieved: [],
+  },
+  branches: [
+    {
+      node_id: 'root',
+      parent_id: null,
+      statement: '根假设',
+      status: 'expanded',
+      score: 0.8,
+      timeline: [
+        { event: 'created', round: 0 },
+        { event: 'expanded', round: 1 },
+      ],
+    },
+    {
+      node_id: 'b',
+      parent_id: 'root',
+      statement: '被剪假设',
+      status: 'pruned',
+      score: 0.1,
+      timeline: [
+        { event: 'created', round: 1 },
+        { event: 'pruned', round: 2, reason: 'score=0.1 低于阈值，自动剪枝' },
+      ],
+    },
+    {
+      node_id: 'ba',
+      parent_id: 'b',
+      statement: '级联被剪',
+      status: 'pruned',
+      score: null,
+      timeline: [
+        { event: 'created', round: 2 },
+        { event: 'pruned', round: 2, reason: '随父分支级联剪枝', cascade_from: 'b' },
+      ],
+    },
+  ],
+  accounting: { node_usage: {}, total: { prompt_tokens: 17, completion_tokens: 8 } },
+  invariants: { cited_subset_of_retrieved: true, pruned_have_reasons: true },
+  warnings: [{ code: 'round_without_trace', round: 3 }],
+};
+
+describe('parseDisclosure', () => {
+  it('完整产物解析出全部区块', () => {
+    const d = parseDisclosure(ARTIFACT)!;
+    expect(d.queries).toHaveLength(4);
+    expect(d.queries[0]).toEqual({
+      round: 1,
+      phase: 'generate',
+      nodeId: 'root',
+      query: 'q-gen',
+      paperIds: ['p1', 'p2'],
+    });
+    expect(d.papers.retrievedNotCited).toEqual(['p3']);
+    expect(d.branches.map((b) => b.nodeId)).toEqual(['root', 'b', 'ba']);
+    expect(d.warnings).toEqual([{ code: 'round_without_trace' }]);
+    expect(d.totalTokens).toEqual({ prompt: 17, completion: 8 });
+  });
+
+  it('非对象/坏数据降级：整体 null，字段级丢弃不炸', () => {
+    expect(parseDisclosure(null)).toBeNull();
+    expect(parseDisclosure('x')).toBeNull();
+    const d = parseDisclosure({
+      queries: [{ phase: 'ground' }, 42, { query: 'ok', phase: '未知', paper_ids: ['p', 1] }],
+      branches: [{ statement: '没 id' }, { node_id: 'n', timeline: [{ event: '飞了' }, null] }],
+      warnings: [{ nope: 1 }, 'x', { code: 'k' }],
+    })!;
+    // 没有 query 文本 / 不是对象的条目丢弃；未知阶段归 other，脏 paper_ids 过滤
+    expect(d.queries).toEqual([
+      { round: null, phase: 'other', nodeId: null, query: 'ok', paperIds: ['p'] },
+    ]);
+    expect(d.branches).toHaveLength(1);
+    expect(d.branches[0]!.timeline).toEqual([]);
+    expect(d.warnings).toEqual([{ code: 'k' }]);
+    expect(d.totalTokens).toBeNull();
+    expect(d.papers.retrieved).toEqual([]);
+  });
+});
+
+describe('queriesByPhase', () => {
+  it('按 生成→接地→查新 定序分组，空阶段不出现，组内保持原序', () => {
+    const d = parseDisclosure(ARTIFACT)!;
+    const groups = queriesByPhase(d.queries);
+    expect(groups.map((g) => g.phase)).toEqual(['generate', 'ground', 'novelty']);
+    // 两条 ground（第 1、2 轮）合成一组，顺序不变
+    expect(groups[1]!.items.map((q) => q.query)).toEqual(['q-g1', 'q-g2']);
+  });
+
+  it('空输入返回空组', () => {
+    expect(queriesByPhase([])).toEqual([]);
+  });
+});
+
+describe('pruneRecordsOf / prunedBranches', () => {
+  it('剪枝原因反查表：直接原因带原话，级联带来源', () => {
+    const d = parseDisclosure(ARTIFACT)!;
+    const records = pruneRecordsOf(d);
+    expect(records.size).toBe(2);
+    expect(records.get('b')).toEqual({
+      reason: 'score=0.1 低于阈值，自动剪枝',
+      cascadeFrom: null,
+      round: 2,
+    });
+    expect(records.get('ba')!.cascadeFrom).toBe('b');
+    // 没被剪的节点不在表里（组件层据此退回推断）
+    expect(records.has('root')).toBe(false);
+  });
+
+  it('被剪分支列表保持产物顺序', () => {
+    const d = parseDisclosure(ARTIFACT)!;
+    expect(prunedBranches(d).map((b) => b.nodeId)).toEqual(['b', 'ba']);
+  });
+
+  it('原因缺失（后端 pruned_without_reason 路径）如实为 null', () => {
+    const d = parseDisclosure({
+      branches: [
+        {
+          node_id: 'n',
+          status: 'pruned',
+          statement: 's',
+          timeline: [{ event: 'pruned', round: null, reason: null }],
+        },
+      ],
+    })!;
+    expect(pruneRecordsOf(d).get('n')).toEqual({ reason: null, cascadeFrom: null, round: null });
+  });
+});

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type CSSProperties } from 'react';
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '../../components/ui/Icon';
@@ -28,14 +28,26 @@ import {
   type NoveltyEntry,
   type Stance,
 } from './discoveryEvidence';
+import {
+  parseDisclosure,
+  pruneRecordsOf,
+  prunedBranches,
+  queriesByPhase,
+  type DisclosureData,
+  type DisclosurePhase,
+  type PruneRecord,
+} from './discoveryDisclosure';
 
 /* ============================================================
    discovery（假设探索）任务的前端面（#642 → #654）：
    - 新建入口：方向文本 + 文献库 + 高级里的扩展轮数（走通用 POST /voyages）；
-   - 详情页 DiscoveryPanel：树视图（可折叠、点节点看证据卡）与方案报告
-     （存活假设按 score 排序 + 被剪分支附录）两种视图切换。
+   - 详情页 DiscoveryPanel：树视图（可折叠、点节点看证据卡）、方案报告
+     （存活假设按 score 排序 + 被剪分支附录）、过程记录（#655 披露产物：
+     检索了什么 / 读了什么 / 剪了什么）三种视图切换。
    证据卡的数据全部来自只读假设树 API（grounding / novelty_report /
    feasibility 随节点返回）；解析与支持度计算在 ./discoveryEvidence.ts。
+   过程记录来自产物端点 GET /voyages/{id}/artifacts/…，剪枝原因以产物里的
+   真实决策留痕优先，没有产物（run 未跑完/旧 run）再退回 D5 的推断。
    ============================================================ */
 
 const MAX_EXPANSIONS_LIMIT = 10; // 与后端 schemas/voyage.MAX_DISCOVERY_EXPANSIONS 一致
@@ -224,9 +236,18 @@ const SIGNAL_LABELS: Record<string, { zh: string; en: string }> = {
   related_chunk_hits: { zh: '库内相关片段数', en: 'Related chunks in library' },
 };
 
-/** 剪枝原因的界面文案：具体原因文本在后端 checkpoint 里、API 不外露，
-    前端按可观测信号（分数阈值 / 父状态）如实推断三类，不编细节。 */
-function pruneReasonText(node: HypothesisNodeRead, parentStatus: string | null): string {
+/** 剪枝原因的界面文案：披露产物里有决策留痕的原话（#655）就用原话——
+    级联剪枝例外，产物只有来源标注，文案本地化；产物缺失/该节点查无记录时
+    退回 D5 的推断（分数阈值 / 父状态三分类），不编细节。 */
+function pruneReasonText(
+  node: HypothesisNodeRead,
+  parentStatus: string | null,
+  real: PruneRecord | null | undefined,
+): string {
+  if (real) {
+    if (real.cascadeFrom) return tr('父分支被放弃后随之放弃', 'Dropped along with its parent branch');
+    if (real.reason) return real.reason;
+  }
   const kind = pruneReasonKind(node, parentStatus);
   if (kind === 'low_score') {
     return tr(
@@ -499,10 +520,13 @@ function NodeDetailPanel({ node, pruneReason, style }: { node: HypothesisNodeRea
 function TreeView({
   nodes,
   standings,
+  pruneRecords,
 }: {
   nodes: HypothesisNodeRead[];
   /** 锦标赛终榜（#653 深度模式）：node_id → 战绩；基础模式为空对象 */
   standings: Record<string, HypothesisTournamentStanding>;
+  /** 披露产物里的真实剪枝原因（#655）；产物没到手时为 null，退回推断 */
+  pruneRecords: Map<string, PruneRecord> | null;
 }) {
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -524,7 +548,11 @@ function TreeView({
         const m = NODE_STATUS_META[node.status] ?? OPEN_META;
         const pruned = node.status === 'pruned';
         const reason = pruned
-          ? pruneReasonText(node, node.parent_id ? statusById.get(node.parent_id) ?? null : null)
+          ? pruneReasonText(
+              node,
+              node.parent_id ? statusById.get(node.parent_id) ?? null : null,
+              pruneRecords?.get(node.id),
+            )
           : null;
         const ratio = supportRatio(parseGrounding(node.grounding));
         const selected = node.id === selectedId;
@@ -633,13 +661,21 @@ function TreeView({
 }
 
 // —— 方案报告视图 ——
-// 后端 discovery.summarize 把研究方案产物写在 run.checkpoint["artifacts"]，
-// 现有 API 不外露；树端点已含证据卡全部结构化数据，这里按后端同一排序规则
-// （score 降序、未评分垫底、同分按创建时间）就地重建报告——任务没跑完也能
-// 预览当前排序。LLM 的叙述性总结文本只存在于产物里，等后端开放产物读取
-// 接口后再补一段「AI 总结」。
+// 树端点已含证据卡全部结构化数据，这里按后端同一排序规则（score 降序、
+// 未评分垫底、同分按创建时间）就地重建报告——任务没跑完也能预览当前排序。
+// 剪枝原因：披露产物（#655）里的真实决策留痕优先，产物没到手再推断。
+// LLM 的叙述性总结文本在 discovery-summary.json 产物里（artifacts 端点
+// 已可读），「AI 总结」段落留给后续需要时再补。
 
-function ReportView({ nodes, active }: { nodes: HypothesisNodeRead[]; active: boolean }) {
+function ReportView({
+  nodes,
+  active,
+  pruneRecords,
+}: {
+  nodes: HypothesisNodeRead[];
+  active: boolean;
+  pruneRecords: Map<string, PruneRecord> | null;
+}) {
   const { alive, pruned } = useMemo(() => buildReport(nodes), [nodes]);
   const statusById = useMemo(() => new Map(nodes.map((n) => [n.id, n.status])), [nodes]);
   return (
@@ -713,7 +749,11 @@ function ReportView({ nodes, active }: { nodes: HypothesisNodeRead[]; active: bo
                 <div style={{ fontSize: 12.5, color: 'var(--text-2)' }}>{n.statement}</div>
                 <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 1 }}>
                   {n.score != null && <span className="mono">score {n.score.toFixed(2)} · </span>}
-                  {pruneReasonText(n, n.parent_id ? statusById.get(n.parent_id) ?? null : null)}
+                  {pruneReasonText(
+                    n,
+                    n.parent_id ? statusById.get(n.parent_id) ?? null : null,
+                    pruneRecords?.get(n.id),
+                  )}
                 </div>
               </div>
             ))}
@@ -724,11 +764,209 @@ function ReportView({ nodes, active }: { nodes: HypothesisNodeRead[]; active: bo
   );
 }
 
-// —— 详情页入口卡：树视图 / 方案报告 切换 ——
+// —— 过程记录视图（#655 披露产物：检索了什么 / 读了什么 / 剪了什么） ——
+
+const PHASE_META: Record<DisclosurePhase, { zh: string; en: string }> = {
+  generate: { zh: '找灵感（生成假设前）', en: 'Finding inspiration (before generating)' },
+  ground: { zh: '找证据（逐子命题接地）', en: 'Finding evidence (grounding subclaims)' },
+  novelty: { zh: '查新（换措辞复检）', en: 'Novelty check (re-searched with new wording)' },
+  other: { zh: '其他检索', en: 'Other searches' },
+};
+
+/** 自检警告的大白话文案：产物 warnings 只有 code，细节留在产物 JSON 里。 */
+const WARNING_META: Record<string, { zh: string; en: string }> = {
+  cited_not_retrieved: {
+    zh: '有引用对不上检索记录（引用只该来自检索结果）',
+    en: 'Some citations have no matching search record (citations should only come from searches)',
+  },
+  pruned_without_reason: {
+    zh: '有被放弃的分支查不到放弃原因',
+    en: 'A dropped branch has no recorded reason',
+  },
+  round_without_trace: {
+    zh: '有一轮扩展没有留下检索记录（可能是旧版本跑的或中途重启过）',
+    en: 'An expansion round left no search records (older version or mid-run restart)',
+  },
+};
+
+function DisclosureSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ border: '0.5px solid var(--border-2)', borderRadius: 10, padding: '10px 14px' }}>
+      <div style={{ fontSize: 12.5, fontWeight: 650, color: 'var(--text-2)', marginBottom: 8 }}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function DisclosureView({ disclosure, active }: { disclosure: DisclosureData | null; active: boolean }) {
+  const pruned = disclosure ? prunedBranches(disclosure) : [];
+  // 差集论文解析标题（读了没引用 + 引了没检到两侧都要能点开看）
+  const diffIds = useMemo(() => {
+    if (!disclosure) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const id of [...disclosure.papers.retrievedNotCited, ...disclosure.papers.citedNotRetrieved]) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+    return out;
+  }, [disclosure]);
+  const titles = usePaperTitles(diffIds);
+
+  if (!disclosure) {
+    return (
+      <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
+        {active
+          ? tr('任务跑完后这里会有完整的过程记录：检索了什么、读了什么、剪掉了什么。', 'Once the run finishes, the full process log appears here: what was searched, what was read, what was dropped.')
+          : tr('这次任务没有留下过程记录（可能是旧版本跑的）。', 'This run left no process log (it may predate this feature).')}
+      </div>
+    );
+  }
+
+  const { papers } = disclosure;
+  const groups = queriesByPhase(disclosure.queries);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {/* 自检警告：产物组装时发现的数据伤口，如实亮出来（§8.2） */}
+      {disclosure.warnings.length > 0 && (
+        <div
+          style={{
+            fontSize: 12,
+            color: 'var(--warn-tx)',
+            background: 'var(--warn-bg)',
+            borderRadius: 8,
+            padding: '8px 12px',
+          }}
+        >
+          {disclosure.warnings.map((w, i) => {
+            const meta = WARNING_META[w.code];
+            return (
+              <div key={i} className="row gap6">
+                <Icon name="shield" size={12} style={{ flexShrink: 0 }} />
+                {meta ? tr(meta.zh, meta.en) : w.code}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 检索了什么：查询全录，按阶段分组 */}
+      <DisclosureSection title={tr(`检索了什么（${disclosure.queries.length} 次）`, `What was searched (${disclosure.queries.length} queries)`)}>
+        {groups.length === 0 ? (
+          <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+            {tr('没有检索记录。', 'No search records.')}
+          </div>
+        ) : (
+          groups.map(({ phase, items }) => (
+            <div key={phase} style={{ marginBottom: 8 }}>
+              <div style={{ fontSize: 11.5, fontWeight: 650, color: 'var(--accent-text)', marginBottom: 4 }}>
+                {tr(PHASE_META[phase].zh, PHASE_META[phase].en)}
+                <span className="mono" style={{ fontWeight: 400, color: 'var(--text-4)', marginLeft: 6 }}>×{items.length}</span>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {items.map((q, i) => (
+                  <div key={i} className="row gap6" style={{ alignItems: 'baseline' }}>
+                    {q.round !== null && (
+                      <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)', flexShrink: 0 }}>
+                        {tr(`第 ${q.round} 轮`, `Round ${q.round}`)}
+                      </span>
+                    )}
+                    <span style={{ fontSize: 12, color: 'var(--text-2)', minWidth: 0, overflowWrap: 'anywhere' }}>{q.query}</span>
+                    <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)', flexShrink: 0, marginLeft: 'auto' }}>
+                      {tr(`${q.paperIds.length} 篇`, `${q.paperIds.length} papers`)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </DisclosureSection>
+
+      {/* 读了什么：检索全集 vs 实际引用 + 差集 */}
+      <DisclosureSection
+        title={tr(
+          `读了什么（检索到 ${papers.retrieved.length} 篇，引用了 ${papers.cited.length} 篇）`,
+          `What was read (${papers.retrieved.length} retrieved, ${papers.cited.length} cited)`,
+        )}
+      >
+        {papers.retrievedNotCited.length > 0 && (
+          <div style={{ marginBottom: 6 }}>
+            <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 4 }}>
+              {tr('检索到但最终没引用：', 'Retrieved but never cited:')}
+            </div>
+            <PaperChips ids={papers.retrievedNotCited} titles={titles} />
+          </div>
+        )}
+        {papers.retrievedNotCited.length === 0 && papers.retrieved.length > 0 && (
+          <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+            {tr('检索到的论文全部被引用了。', 'Every retrieved paper ended up cited.')}
+          </div>
+        )}
+        {/* 引了却没检索到：不该发生（引用只能来自检索结果），有就如实标红 */}
+        {papers.citedNotRetrieved.length > 0 && (
+          <div style={{ marginTop: 6 }}>
+            <div style={{ fontSize: 11.5, color: 'var(--danger-tx)', marginBottom: 4 }}>
+              {tr('引用了但检索记录里找不到（数据有伤，见上方警告）：', 'Cited but missing from search records (data gap, see warning above):')}
+            </div>
+            <PaperChips ids={papers.citedNotRetrieved} titles={titles} />
+          </div>
+        )}
+      </DisclosureSection>
+
+      {/* 剪了什么：被放弃分支的时间线与真实原因 */}
+      <DisclosureSection title={tr(`剪了什么（${pruned.length} 个分支）`, `What was dropped (${pruned.length} branches)`)}>
+        {pruned.length === 0 ? (
+          <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+            {tr('没有分支被放弃。', 'No branch was dropped.')}
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {pruned.map((b) => {
+              const createdRound = b.timeline.find((e) => e.event === 'created')?.round ?? null;
+              const prunedEvent = b.timeline.find((e) => e.event === 'pruned');
+              const prunedRound = prunedEvent?.round ?? null;
+              return (
+                <div key={b.nodeId}>
+                  <div style={{ fontSize: 12.5, color: 'var(--text-2)', textDecoration: 'line-through' }}>{b.statement}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 1 }}>
+                    {createdRound !== null && (
+                      <span>{tr(`第 ${createdRound} 轮产生 · `, `Born round ${createdRound} · `)}</span>
+                    )}
+                    {prunedRound !== null && (
+                      <span>{tr(`第 ${prunedRound} 轮放弃 · `, `Dropped round ${prunedRound} · `)}</span>
+                    )}
+                    {b.score !== null && <span className="mono">score {b.score.toFixed(2)} · </span>}
+                    {prunedEvent?.cascadeFrom
+                      ? tr('父分支被放弃后随之放弃', 'Dropped along with its parent branch')
+                      : prunedEvent?.reason ?? tr('原因未记录（见上方警告）', 'No reason recorded (see warning above)')}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </DisclosureSection>
+
+      {disclosure.totalTokens && (
+        <div className="mono" style={{ fontSize: 11, color: 'var(--text-4)' }}>
+          {tr(
+            `全程 token：输入 ${disclosure.totalTokens.prompt} · 输出 ${disclosure.totalTokens.completion}`,
+            `Run tokens: ${disclosure.totalTokens.prompt} in · ${disclosure.totalTokens.completion} out`,
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// —— 详情页入口卡：树视图 / 方案报告 / 过程记录 切换 ——
 
 export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
   const active = !VOYAGE_TERMINAL.has(voyage.status);
-  const [view, setView] = useState<'tree' | 'report'>('tree');
+  const [view, setView] = useState<'tree' | 'report' | 'disclosure'>('tree');
   const { data } = useQuery({
     queryKey: ['hypothesis-tree', voyage.id],
     queryFn: () => api.listHypothesisTree(voyage.id),
@@ -745,6 +983,16 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
     refetchInterval: active ? 10_000 : false,
   });
   const standings = tournament?.nodes ?? {};
+  // 披露产物（#655）：汇总时才落盘，在那之前 404 是常态（retry 关掉、
+  // 任务在跑时低频轮询等它出现）；三个视图都吃它——剪枝原因产物优先
+  const { data: artifact } = useQuery({
+    queryKey: ['voyage-artifact', voyage.id, 'discovery-disclosure.json'],
+    queryFn: () => api.getVoyageArtifact(voyage.id, 'discovery-disclosure.json'),
+    retry: false,
+    refetchInterval: active ? 15_000 : false,
+  });
+  const disclosure = useMemo(() => (artifact ? parseDisclosure(artifact.content) : null), [artifact]);
+  const pruneRecords = useMemo(() => (disclosure ? pruneRecordsOf(disclosure) : null), [disclosure]);
 
   return (
     <div className="card card-pad" style={{ marginBottom: 20 }}>
@@ -763,22 +1011,25 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
             options={[
               { v: 'tree' as const, label: tr('树视图', 'Tree') },
               { v: 'report' as const, label: tr('方案报告', 'Report') },
+              { v: 'disclosure' as const, label: tr('过程记录', 'Process log') },
             ]}
             value={view}
             onChange={setView}
           />
         </span>
       </div>
-      {nodes.length === 0 ? (
+      {view === 'disclosure' ? (
+        <DisclosureView disclosure={disclosure} active={active} />
+      ) : nodes.length === 0 ? (
         <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>
           {active
             ? tr('树还没长出来：AI 正在生成根假设…', 'No tree yet — the AI is seeding the root hypothesis…')
             : tr('这次任务没有留下假设树。', 'This run left no hypothesis tree.')}
         </div>
       ) : view === 'tree' ? (
-        <TreeView nodes={nodes} standings={standings} />
+        <TreeView nodes={nodes} standings={standings} pruneRecords={pruneRecords} />
       ) : (
-        <ReportView nodes={nodes} active={active} />
+        <ReportView nodes={nodes} active={active} pruneRecords={pruneRecords} />
       )}
     </div>
   );

--- a/src/frontend/src/features/voyages/discoveryDisclosure.ts
+++ b/src/frontend/src/features/voyages/discoveryDisclosure.ts
@@ -1,0 +1,202 @@
+/* ============================================================
+   discovery 过程记录（披露产物）的纯函数层（#655，设计报告 §8.2）。
+
+   后端 summarize 时把「实际做了什么」确定性归档成
+   artifacts["discovery-disclosure.json"]（检索全录 / 读过 vs 引用的论文 /
+   分支时间线与真实剪枝原因 / 警告），经 GET /voyages/{id}/artifacts/{name}
+   取回。这里做两件事：
+   - 容错解析成干净类型（产物 schema 不锁死，字段乱/缺时降级不炸组件）；
+   - 视图数据变换（按阶段分组、剪枝原因反查表）——纯函数，vitest 直测。
+   ============================================================ */
+
+export type DisclosurePhase = 'generate' | 'ground' | 'novelty' | 'other';
+
+/** 一次检索：哪一轮、哪个阶段、为哪个节点、查了什么、捞回哪些论文。 */
+export interface DisclosureQuery {
+  round: number | null;
+  phase: DisclosurePhase;
+  nodeId: string | null;
+  query: string;
+  paperIds: string[];
+}
+
+export interface DisclosureTimelineEvent {
+  event: 'created' | 'expanded' | 'pruned';
+  round: number | null;
+  /** pruned 事件才有：后端决策留痕里的原话（数据，不做翻译） */
+  reason: string | null;
+  /** 级联剪枝的来源节点（有它说明本节点是随父被剪的） */
+  cascadeFrom: string | null;
+}
+
+export interface DisclosureBranch {
+  nodeId: string;
+  parentId: string | null;
+  statement: string;
+  status: string;
+  score: number | null;
+  timeline: DisclosureTimelineEvent[];
+}
+
+export interface DisclosureWarning {
+  code: string;
+}
+
+export interface DisclosureData {
+  queries: DisclosureQuery[];
+  papers: {
+    retrieved: string[];
+    cited: string[];
+    retrievedNotCited: string[];
+    citedNotRetrieved: string[];
+  };
+  branches: DisclosureBranch[];
+  warnings: DisclosureWarning[];
+  /** 全 run token 总量（accounting.total；缺失为 null） */
+  totalTokens: { prompt: number; completion: number } | null;
+}
+
+// ---- 解析 ----
+
+function asStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+function asRound(raw: unknown): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+}
+
+function parseQuery(raw: unknown): DisclosureQuery | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  const query = typeof rec.query === 'string' ? rec.query : '';
+  if (!query) return null;
+  const phase =
+    rec.phase === 'generate' || rec.phase === 'ground' || rec.phase === 'novelty'
+      ? rec.phase
+      : 'other';
+  return {
+    round: asRound(rec.round),
+    phase,
+    nodeId: typeof rec.node_id === 'string' ? rec.node_id : null,
+    query,
+    paperIds: asStringArray(rec.paper_ids),
+  };
+}
+
+function parseTimelineEvent(raw: unknown): DisclosureTimelineEvent | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  if (rec.event !== 'created' && rec.event !== 'expanded' && rec.event !== 'pruned') return null;
+  return {
+    event: rec.event,
+    round: asRound(rec.round),
+    reason: typeof rec.reason === 'string' && rec.reason ? rec.reason : null,
+    cascadeFrom: typeof rec.cascade_from === 'string' ? rec.cascade_from : null,
+  };
+}
+
+function parseBranch(raw: unknown): DisclosureBranch | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  if (typeof rec.node_id !== 'string' || !rec.node_id) return null;
+  return {
+    nodeId: rec.node_id,
+    parentId: typeof rec.parent_id === 'string' ? rec.parent_id : null,
+    statement: typeof rec.statement === 'string' ? rec.statement : '',
+    status: typeof rec.status === 'string' ? rec.status : '',
+    score: typeof rec.score === 'number' ? rec.score : null,
+    timeline: Array.isArray(rec.timeline)
+      ? rec.timeline.map(parseTimelineEvent).filter((e): e is DisclosureTimelineEvent => e !== null)
+      : [],
+  };
+}
+
+/** 产物 JSON → 干净结构；根本不是对象（旧产物/坏数据）返回 null，组件降级。 */
+export function parseDisclosure(raw: unknown): DisclosureData | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  const papersRaw =
+    typeof rec.papers === 'object' && rec.papers !== null
+      ? (rec.papers as Record<string, unknown>)
+      : {};
+  const accounting =
+    typeof rec.accounting === 'object' && rec.accounting !== null
+      ? (rec.accounting as Record<string, unknown>)
+      : {};
+  const total =
+    typeof accounting.total === 'object' && accounting.total !== null
+      ? (accounting.total as Record<string, unknown>)
+      : null;
+  return {
+    queries: Array.isArray(rec.queries)
+      ? rec.queries.map(parseQuery).filter((q): q is DisclosureQuery => q !== null)
+      : [],
+    papers: {
+      retrieved: asStringArray(papersRaw.retrieved),
+      cited: asStringArray(papersRaw.cited),
+      retrievedNotCited: asStringArray(papersRaw.retrieved_not_cited),
+      citedNotRetrieved: asStringArray(papersRaw.cited_not_retrieved),
+    },
+    branches: Array.isArray(rec.branches)
+      ? rec.branches.map(parseBranch).filter((b): b is DisclosureBranch => b !== null)
+      : [],
+    warnings: Array.isArray(rec.warnings)
+      ? rec.warnings
+          .filter(
+            (w): w is Record<string, unknown> =>
+              typeof w === 'object' && w !== null && typeof (w as Record<string, unknown>).code === 'string',
+          )
+          .map((w) => ({ code: String(w.code) }))
+      : [],
+    totalTokens: total
+      ? {
+          prompt: typeof total.prompt_tokens === 'number' ? total.prompt_tokens : 0,
+          completion: typeof total.completion_tokens === 'number' ? total.completion_tokens : 0,
+        }
+      : null,
+  };
+}
+
+// ---- 视图变换 ----
+
+const PHASE_ORDER: DisclosurePhase[] = ['generate', 'ground', 'novelty', 'other'];
+
+export interface PhaseGroup {
+  phase: DisclosurePhase;
+  items: DisclosureQuery[];
+}
+
+/** 查询按阶段分组（找灵感 → 找证据 → 查新），空阶段不出现；组内保持原始
+    （轮次内时间）顺序。 */
+export function queriesByPhase(queries: DisclosureQuery[]): PhaseGroup[] {
+  const byPhase = new Map<DisclosurePhase, DisclosureQuery[]>();
+  for (const q of queries) byPhase.set(q.phase, [...(byPhase.get(q.phase) ?? []), q]);
+  return PHASE_ORDER.filter((p) => byPhase.has(p)).map((p) => ({ phase: p, items: byPhase.get(p)! }));
+}
+
+export interface PruneRecord {
+  /** 决策留痕里的原话；级联节点没有原话，reason 为 null、cascadeFrom 指向来源 */
+  reason: string | null;
+  cascadeFrom: string | null;
+  round: number | null;
+}
+
+/** 剪枝原因反查表（node_id → 真实原因）：树视图/报告视图优先用它，
+    没有产物（run 未跑完 / 旧版本 run）时再退回 D5 的推断逻辑。 */
+export function pruneRecordsOf(disclosure: DisclosureData): Map<string, PruneRecord> {
+  const out = new Map<string, PruneRecord>();
+  for (const b of disclosure.branches) {
+    const pruned = b.timeline.find((e) => e.event === 'pruned');
+    if (pruned) {
+      out.set(b.nodeId, { reason: pruned.reason, cascadeFrom: pruned.cascadeFrom, round: pruned.round });
+    }
+  }
+  return out;
+}
+
+/** 被剪分支列表（时间线视图用）：保持产物顺序（＝建树顺序）。 */
+export function prunedBranches(disclosure: DisclosureData): DisclosureBranch[] {
+  return disclosure.branches.filter((b) => b.status === 'pruned');
+}

--- a/src/frontend/src/features/voyages/discoveryEvidence.ts
+++ b/src/frontend/src/features/voyages/discoveryEvidence.ts
@@ -171,9 +171,9 @@ export function flattenTree(
 }
 
 // ---- 方案报告的排序（与后端 discovery.summarize 同一规则就地重建） ----
-// 后端把研究方案产物写在 checkpoint["artifacts"]，现有 API 不外露；
-// 树端点已含存活假设 + 三块证据数据，报告页按同一排序规则重建即可，
-// 不需要后端加接口（LLM 的叙述性总结文本除外，见 ReportView 的说明）。
+// 树端点已含存活假设 + 三块证据数据，报告页按同一排序规则重建即可——
+// 任务没跑完也能预览当前排序（产物要等 summarize）。研究方案/过程记录
+// 产物自 #655 起可经 GET /voyages/{id}/artifacts/{name} 只读取回。
 
 export interface DiscoveryReport {
   /** 存活假设：score 降序（未评分排最后），同分按创建时间稳定排序 */
@@ -194,9 +194,10 @@ export function buildReport(nodes: HypothesisNodeRead[]): DiscoveryReport {
   return { alive, pruned: nodes.filter((n) => n.status === 'pruned') };
 }
 
-// ---- 剪枝原因推断 ----
-// 具体原因文本记录在后端 checkpoint 的决策留痕里（API 不外露），
-// 前端按可观测信号如实分三类，文案由组件层 tr() 渲染：
+// ---- 剪枝原因推断（降级路径） ----
+// 真实原因自 #655 起随披露产物外露（./discoveryDisclosure.ts），组件层
+// 产物优先；这里只服务「产物还没落盘 / 旧 run 没有产物」的降级场景——
+// 按可观测信号如实分三类，文案由组件层 tr() 渲染：
 // - low_score：score 低于自动剪枝阈值 → 扩展时被当场剪掉；
 // - cascade：父分支被剪，随父级联；
 // - decided：AI 显式判定不值得继续（细节见任务运行日志）。

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -511,6 +511,13 @@ export interface HypothesisTournamentRead {
   nodes: Record<string, HypothesisTournamentStanding>;
 }
 
+/** run 产物只读（GET /voyages/{id}/artifacts/{name}，#655）：
+    content 是后端已解析好的产物 JSON（白名单内的产物都是 JSON）。 */
+export interface VoyageArtifactRead {
+  name: string;
+  content: unknown;
+}
+
 export interface VoyageRead {
   id: string;
   kind: string;
@@ -3543,6 +3550,11 @@ export const api = {
   /** 锦标赛披露（#653）：基础模式（tournament=False）返回空结构。 */
   getHypothesisTournament(voyageId: string): Promise<HypothesisTournamentRead> {
     return request<HypothesisTournamentRead>(`/voyages/${voyageId}/tournament`);
+  },
+
+  /** run 产物只读（#655）：白名单外/未产出/无权限一律 404。 */
+  getVoyageArtifact(voyageId: string, name: string): Promise<VoyageArtifactRead> {
+    return request<VoyageArtifactRead>(`/voyages/${voyageId}/artifacts/${encodeURIComponent(name)}`);
   },
 
   // —— Gates ——


### PR DESCRIPTION
Closes #655. Part of #635 (P2 wave 4, item D6 — final P2 item); design report §8.2 (anti-cherry-picking provenance).

Every discovery run now ships a deterministic process record: what was searched, what was read, what was pruned and why.

- lightweight tracing (no LLM behavior change): the pipeline stages return their issued queries and inspiration paper sets; the expand action files them on the round ledger with node attribution
- `discovery_disclosure.build_disclosure(checkpoint, nodes)` — zero LLM calls — assembles `discovery-disclosure.json`: per-phase queries, retrieved-vs-cited paper sets with both difference directions, per-branch timelines (created/expanded/pruned with real reasons; cascades back-referenced to the deciding ancestor), tournament matches, per-node token accounting, and invariant self-checks (cited ⊆ retrieved, every pruned node has a reason) that record warnings instead of throwing
- written alongside the research proposal at summarize time; a new `GET /voyages/{id}/artifacts/{name}` endpoint (whitelisted to the two discovery artifacts, run-visibility 404 semantics) also closes the artifact-access gap flagged in #656
- frontend: a third "Process log" view (plain-language wording per convention) — queries grouped by purpose, retrieved/cited counts with difference chips, prune timelines; tree and report views now prefer the artifact's real prune reasons over the D5 inference
- goldens: `discovery_run.json` intentionally re-recorded — the diff is purely the added disclosure step, prior steps byte-identical; the re-record surfaced and fixed a real normalizer gap (dict *keys* were never normalized, so uuid-keyed accounting would have made every recording unstable); `import_wiki.json` sha-identical

Verification: clean-baseline 1521 passed + the 3 pre-existing #581 failures; branch 1527 passed with the identical failure set — zero new; +6 tests (pure-function paths incl. warnings, end-to-end, endpoint whitelist/404); frontend tsc/vitest/build green.