### PR TITLE
docs: P2.5 implementation plan for the literature engine build-out

### DIFF
--- a/docs/rfcs/2026-09-06-p2.5-literature-engine-plan.md
+++ b/docs/rfcs/2026-09-06-p2.5-literature-engine-plan.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Status | Accepted |
 | Date | 2026-09-06 |
-| Tracking | #659 |
+| Tracking | #660 |
 | Design | [Polaris 2.0 design report](2026-09-02-polaris-2.0-design-report.zh.md) §10 layer ②/④, §11 |
 
 P2 delivered the discovery loop end to end on retrieval-grade evidence. P2.5 thickens

--- a/docs/rfcs/2026-09-06-p2.5-literature-engine-plan.md
+++ b/docs/rfcs/2026-09-06-p2.5-literature-engine-plan.md
@@ -1,0 +1,64 @@
+# P2.5 Implementation Plan: Literature Engine Build-Out
+
+| | |
+| --- | --- |
+| Status | Accepted |
+| Date | 2026-09-06 |
+| Tracking | #659 |
+| Design | [Polaris 2.0 design report](2026-09-02-polaris-2.0-design-report.zh.md) §10 layer ②/④, §11 |
+
+P2 delivered the discovery loop end to end on retrieval-grade evidence. P2.5 thickens
+the literature engine so hypothesis generation consumes **structured fuel** instead of
+raw retrieval: the extraction layer (②), the four precomputed fuels (§11), and
+comparison tables (④).
+
+## Exit criteria
+
+- The generate stage's inspiration paths draw from the method library (same-purpose /
+  different-mechanism analogies), unconnected concept pairs, and the gap list — not
+  just chunk retrieval; measurably different candidates under the fake provider.
+- Method-level retrieval works: "how did others set up experiments for problems like
+  this" answers from the extracted five-tuples.
+- A comparison table for a set of selected papers renders from extracted fields with
+  per-cell provenance.
+
+## Work breakdown
+
+- **F1 schema-guided extraction runtime.** A deterministic extraction pass per paper
+  (post-enrich, best-effort, incremental): a universal skeleton schema
+  (problem / method / findings / limitations, ORKG-contribution style) extracted via
+  a constrained LLM stage with normalization; results stored per paper; discipline
+  packs can register additional schemas later (registry seam only — first discipline
+  schema is out of scope). Confidence via self-consistency is deferred; store raw
+  stage confidence.
+- **F2 method library.** Per-paper five-tuple extraction (purpose / mechanism /
+  baseline / dataset / protocol) building on F1's runtime; a purpose–mechanism dual
+  index (embedding per axis) turning the library into a cross-domain analogy engine;
+  a method search endpoint + minimal UI list.
+- **F3 concept graph fuels.** On top of the existing concept linking: co-occurrence
+  edges per library, and the unconnected-pair miner (A–B and B–C co-occur, A–C never
+  does — Swanson ABC seeds), materialized per library and refreshed incrementally.
+- **F4 gap and negative-result ledger.** GAPMAP-style extraction of explicit gaps,
+  contradictions, uncertainty statements, and limitation/negative-result passages,
+  each anchored to its source span; stored per paper, aggregated per library.
+- **F5 comparison tables.** Generate a table for user-selected papers over skeleton +
+  five-tuple fields, each cell carrying provenance (paper id + extracted span);
+  frontend table view with export.
+- **F6 fuel-fed hypothesis generation.** The generate stage's inspiration paths
+  extend to: same-purpose/different-mechanism method analogies (F2), top unconnected
+  pairs (F3), and open gaps (F4); the disclosure report gains the consumed fuel
+  entries. Golden re-record (intentional).
+
+## Sequencing
+
+Wave 1: F1. Wave 2 (parallel on F1): F2 · F3 · F4. Wave 3: F5 · F6.
+
+Same per-PR discipline as P1/P2: one issue, branch from origin/main, full suite vs the
+#581 baseline, goldens byte-identical except where a re-record is the stated intent,
+frontend build + vitest green.
+
+## Non-goals
+
+Discipline-specific schemas (PICO, task-dataset-metric, synthesis recipes) beyond the
+registry seam; whole-survey generation (④ deliberately stops at targeted sections and
+tables); process packs and experiments (P3).


### PR DESCRIPTION
Adds the P2.5 plan (tracking #659): extraction runtime, method library with a purpose–mechanism dual index, concept-graph fuels (unconnected pairs), gap/negative-result ledger, comparison tables, and fuel-fed hypothesis generation — per design report §10②④/§11. Execution tracked in #659.