### PR TITLE
feat: schema-guided extraction runtime with the skeleton schema

### DIFF
--- a/src/backend/alembic/versions/58b0bc2d809d_paper_extractions.py
+++ b/src/backend/alembic/versions/58b0bc2d809d_paper_extractions.py
@@ -1,0 +1,52 @@
+"""结构化抽取产物表 paper_extractions（#661：schema 引导抽取运行时）
+
+每行一份「某 schema 对某论文」的抽取结果：payload 是按 schema 字段白名单
+归一化后的 JSON（通用骨架 skeleton@1 = problem/method/findings/limitations），
+confidence 是模型自评置信度（可空），stage_meta 记 {model, stage, version} 溯源。
+同一 (paper_id, schema_id) 唯一——重抽是 UPSERT 覆盖，不留历史版本。
+
+Revision ID: 58b0bc2d809d
+Revises: 57543f6328a1
+Create Date: 2026-09-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "58b0bc2d809d"
+down_revision: str | None = "57543f6328a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 与 models/base.py 的 JSONVariant 同口径：postgres 用 JSONB，sqlite 回退通用 JSON
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paper_extractions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("paper_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_id", sa.String(length=64), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("stage_meta", _JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["paper_id"], ["papers.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "paper_id", "schema_id", name="uq_paper_extractions_paper_schema"
+        ),
+    )
+    # 查询习惯：详情页按论文取全部 schema 的产物
+    op.create_index("ix_paper_extractions_paper_id", "paper_extractions", ["paper_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_paper_extractions_paper_id", table_name="paper_extractions")
+    op.drop_table("paper_extractions")

--- a/src/backend/app/api/papers.py
+++ b/src/backend/app/api/papers.py
@@ -32,6 +32,7 @@ from app.schemas.paper import (
     PaperCitationItem,
     PaperCitationsRead,
     PaperDetail,
+    PaperExtractionRead,
     PaperFigure,
     PaperFiguresResponse,
     PaperIndexRebuild,
@@ -874,6 +875,24 @@ async def get_paper_citations(
         if by_intent.get(intent)
     ]
     return PaperCitationsRead(total=len(rows), groups=groups)
+
+
+@router.get("/papers/{paper_id}/extractions", response_model=list[PaperExtractionRead])
+async def get_paper_extractions(
+    paper_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[PaperExtractionRead]:
+    """这篇论文的结构化抽取产物（#661），每 schema 一条。
+
+    独立子端点而非并进 PaperDetail：详情是热路径且被 golden 逐字节锁着，
+    抽取产物只有展开「结构化摘要」时才需要。没抽过就是空列表，不是 404。
+    """
+    from app.services.extraction.runtime import list_extractions
+
+    await _get_member_paper(session, paper_id, user, include_pool=True)
+    rows = await list_extractions(session, paper_id)
+    return [PaperExtractionRead.model_validate(row) for row in rows]
 
 
 @router.get("/papers/{paper_id}/index-status", response_model=PaperIndexStatusRead)

--- a/src/backend/app/cli/backfill_extractions.py
+++ b/src/backend/app/cli/backfill_extractions.py
@@ -1,0 +1,78 @@
+"""全库批量回填（#661）：schema 引导的论文骨架抽取。
+
+存量论文一次性覆盖用（新论文由补全钩子增量处理）::
+
+    python -m app.cli.backfill_extractions                 # 通用骨架，跳过已抽取
+    python -m app.cli.backfill_extractions --limit 100
+    python -m app.cli.backfill_extractions --force         # 覆盖重抽（schema 升版后用）
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+from sqlalchemy import select
+
+from app.core.db import dispose_engine, get_sessionmaker
+from app.core.llm.router import get_llm_router
+from app.models.paper import Paper
+from app.services.extraction.runtime import DEFAULT_SCHEMA_ID, extract_paper
+from app.services.extraction.schemas import get_schema
+
+logger = logging.getLogger(__name__)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--schema", default=DEFAULT_SCHEMA_ID, help="抽取 schema id（默认通用骨架 skeleton）"
+    )
+    parser.add_argument("--limit", type=int, help="只处理最早入库的前 N 篇")
+    parser.add_argument(
+        "--force", action="store_true", help="已有产物也覆盖重抽（schema 升版后回填用）"
+    )
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> None:
+    stats = {"papers": 0, "extracted": 0, "skipped": 0, "failed": 0}
+    try:
+        # schema 名写错是调用方错误：进循环前就炸掉，别把每篇都记成 failed
+        get_schema(args.schema)
+        llm = get_llm_router()
+        async with get_sessionmaker()() as session:
+            stmt = select(Paper).order_by(Paper.created_at)
+            if args.limit:
+                stmt = stmt.limit(args.limit)
+            papers = (await session.execute(stmt)).scalars().all()
+            for paper in papers:
+                stats["papers"] += 1
+                try:
+                    outcome = await extract_paper(
+                        session, paper, schema_id=args.schema, llm=llm, force=args.force
+                    )
+                    if outcome.status == "extracted":
+                        await session.commit()
+                        stats["extracted"] += 1
+                    else:
+                        stats["skipped"] += 1
+                        logger.info("skipped %s: %s", paper.id, outcome.reason)
+                except Exception:  # noqa: BLE001 — 单篇失败不拖垮整批
+                    logger.warning("extraction backfill failed for %s", paper.id, exc_info=True)
+                    await session.rollback()
+                    stats["failed"] += 1
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+    finally:
+        await dispose_engine()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(_run(_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -37,6 +37,7 @@ _CONCEPTS_MARKER = "概念列表："
 _FAKE_FIGURE_REF_RE = re.compile(r"^(?:fig|figure|tab|table|eq)\s*[:：]", re.IGNORECASE)
 _AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affiliations.py 专门调用）
 _CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类（citation_graph.py）
+_EXTRACT_SKELETON_MARKER = "POLARIS_EXTRACT_SKELETON"  # 骨架抽取（services/extraction/）
 # 库级 agentic RAG 三环节（services/library_rag.py，#644）
 _RAG_EXPAND_MARKER = "POLARIS_RAG_EXPAND"
 _RAG_RERANK_MARKER = "POLARIS_RAG_RERANK"
@@ -447,6 +448,9 @@ class FakeProvider(LLMProvider):
         # 引文意图分类：user prompt 内嵌论文正文原句（可能撞任意通用 marker），须先判断
         if _CITATION_INTENT_MARKER in full_text:
             return FakeProvider._respond_citation_intent(last_user)
+        # 骨架抽取：user prompt 内嵌整篇正文（同样可能撞通用 marker），须先判断
+        if _EXTRACT_SKELETON_MARKER in full_text:
+            return FakeProvider._respond_extract_skeleton(last_user)
         # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
         # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
@@ -620,6 +624,28 @@ class FakeProvider(LLMProvider):
                     break
             out.append({"index": item["index"], "intent": intent, "confidence": confidence})
         return json.dumps({"items": out}, ensure_ascii=False)
+
+    @staticmethod
+    def _respond_extract_skeleton(last_user: str) -> str:
+        """骨架抽取（services/extraction/runtime.py 对齐，#661）：确定性四字段 JSON。
+
+        problem 回显标题（测试据此断言 prompt 里带对了论文），其余固定——
+        测试要的是「抽取会归一化、会落库、会展示」这条链路，不是抽得多准。"""
+        m = re.search(r"标题：(.+)", last_user)
+        title = m.group(1).strip() if m else "未知论文"
+        return json.dumps(
+            {
+                "problem": f"《{title}》要解决的核心问题（fake extraction）",
+                "method": "提出确定性替身方法并给出流程（fake extraction）",
+                "findings": [
+                    "发现一：替身指标优于基线（fake）",
+                    "发现二：消融验证各组件必要（fake）",
+                ],
+                "limitations": ["局限一：评测范围有限（fake）"],
+                "confidence": 0.9,
+            },
+            ensure_ascii=False,
+        )
 
     # ---- 库级 agentic RAG（services/library_rag.py 的三个 system prompt 对齐，#644） ----
 

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -81,6 +81,8 @@ STAGES = (
     "review",
     "reading",
     "citation_intent",
+    # schema 引导的论文骨架抽取（#661）：整篇正文进、结构化 JSON 出
+    "extract_skeleton",
     # 库级 agentic RAG 三环节（#644）：扩展/重排是短 JSON，作答是中档长生成
     "rag_expand",
     "rag_rerank",
@@ -212,6 +214,10 @@ _MEDIUM_CALL_STAGES = frozenset(
         "rag_answer",
         "hyp_generate",
         "hyp_ground",
+        # 骨架抽取（#661）：一次吃约 2.4 万字正文、产四字段 JSON——比短 JSON 环节
+        # 重得多（extract 短档喂的是单页级片段），但也没有长档 20 分钟的理由：
+        # enrich 链逐篇串行，卡死一篇就堵住整条补全队列
+        "extract_skeleton",
     }
 )
 

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -58,6 +58,7 @@ from app.models.paper_content import (
     PaperContentVersion,
     PaperContentVersionVector,
 )
+from app.models.paper_extraction import PaperExtraction
 from app.models.project import Project
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.research_digest import LibraryResearchDigest
@@ -123,6 +124,7 @@ __all__ = [
     "CITATION_INTENTS",
     "PaperAsset",
     "PaperCitation",
+    "PaperExtraction",
     "AssetGrant",
     "PaperChunk",
     "PaperChunkVector",

--- a/src/backend/app/models/paper_extraction.py
+++ b/src/backend/app/models/paper_extraction.py
@@ -1,0 +1,41 @@
+"""论文结构化抽取产物（#661，设计报告 §10 ②层）。
+
+papers 是全平台共享的内容池，抽取产物跟着论文本体走（类比 paper_wikis /
+paper_citations），因此这张表**不带 library_id**。每行一份「某 schema 对某论文」
+的抽取结果：payload 按 schema 字段白名单归一化后的 JSON（services/extraction/），
+同一 (paper_id, schema_id) 唯一——重跑是 UPSERT 覆盖，不留历史版本；schema 演进
+靠版本号进 stage_meta，读方按需判断是否过期重抽。
+"""
+
+import uuid
+
+from sqlalchemy import Float, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class PaperExtraction(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """一篇论文在一个抽取 schema 下的结构化产物。
+
+    ``payload`` 只存归一化通过的字段（全空不落行）；``confidence`` 是模型对整份
+    产物的自评置信度（0..1，可空——模型没给就空着，不编数）。
+    """
+
+    __tablename__ = "paper_extractions"
+    __table_args__ = (
+        # 每 schema 每论文一份：重抽是覆盖语义，唯一约束兜住并发重复
+        UniqueConstraint("paper_id", "schema_id", name="uq_paper_extractions_paper_schema"),
+    )
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # 注册表里的 schema 标识（services/extraction/schemas.py），如 "skeleton"
+    schema_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    # 归一化后的抽取结果：{字段名: str | list[str]}，键取 schema 字段白名单子集
+    payload: Mapped[dict] = mapped_column(JSONVariant, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float)
+    # 溯源元信息：{"model": 实际模型名, "stage": LLM 环节, "version": schema 版本}
+    stage_meta: Mapped[dict | None] = mapped_column(JSONVariant)

--- a/src/backend/app/schemas/paper.py
+++ b/src/backend/app/schemas/paper.py
@@ -148,6 +148,21 @@ class PaperCitationsRead(BaseModel):
     groups: list[PaperCitationGroup]
 
 
+class PaperExtractionRead(BaseModel):
+    """一份结构化抽取产物（#661；详情页「结构化摘要」折叠区的数据）。
+
+    payload 只含抽到的字段（空字段不带键，前端据此不渲染空段落）。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    schema_id: str
+    payload: dict[str, Any]
+    confidence: float | None = None
+    # {"model", "stage", "version"}：产物溯源（哪个模型、哪个环节、schema 第几版）
+    stage_meta: dict[str, Any] | None = None
+    updated_at: datetime
+
+
 class VectorStatusRead(BaseModel):
     """一种向量的状态（前端红绿点 + 悬浮显示构建时间与模型名）。
 

--- a/src/backend/app/services/extraction/__init__.py
+++ b/src/backend/app/services/extraction/__init__.py
@@ -1,0 +1,6 @@
+"""schema 引导的结构化抽取（#661，设计报告 §10 ②层）。
+
+schemas.py 是抽取 schema 注册表（内置通用骨架 skeleton@1，学科包后续经
+``register_schema`` 挂载）；runtime.py 是抽取运行时（取正文 → LLM 抽取 →
+归一化 → UPSERT 落 paper_extractions）。
+"""

--- a/src/backend/app/services/extraction/runtime.py
+++ b/src/backend/app/services/extraction/runtime.py
@@ -1,0 +1,229 @@
+"""schema 引导抽取运行时（#661，设计报告 §10 ②层）。
+
+一次抽取 = 取正文 → 按 schema 生成 prompt → LLM（extract_skeleton 环节，短 JSON
+非流式）→ 校验归一化 → UPSERT 落 paper_extractions。判断性的只有「读文归纳」这一步
+走 LLM；其余（正文选取、截断、归一化、落表）全是确定性代码。
+
+正文口径：读 full_text_path 的 txt。双轨解析（#650）在裁决时已把 MinerU 的分节
+正文拼回这份 txt（select.py 的 body 裁决），所以这里读 txt 就是「优先分节正文、
+退回 PyMuPDF 全文」的口径，不必再碰解析工件。**没有全文就如实 skip**——摘要不
+冒充正文：骨架抽取的价值在于全文证据（发现/局限多在正文后半段），拿摘要硬抽
+只会产出置信度虚高的半成品。bibtex 导入这类无 PDF 论文因此零输出零副作用
+（golden 链路不受影响）。
+
+失败语义与 citation_graph 一致：无正文 / 模型输出解析不动 / 归一化后全空，
+一律返回 skipped + 原因，不抛——批量回填时一篇论文的坏输出不该拖垮整批。
+调用方负责 commit。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.llm.base import Message
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.services.extraction.schemas import ExtractionSchema, get_schema
+
+logger = logging.getLogger(__name__)
+
+# 正文进 prompt 的字符预算，与 wiki 编译同口径（wiki_compile.FULLTEXT_PROMPT_CHARS）。
+# 不直接 import 那个常量：两处预算语义不同（编译要图文铺陈，抽取只要骨架），
+# 将来允许各自调整，共享一个名字反而把它们焊死。
+EXTRACT_PROMPT_CHARS = 24000
+
+DEFAULT_SCHEMA_ID = "skeleton"
+
+
+@dataclass(slots=True)
+class ExtractionOutcome:
+    """一次抽取的结果：extracted = 落了表；skipped = 没落表且 reason 说明为什么。"""
+
+    status: str  # "extracted" | "skipped"
+    reason: str | None = None
+    row: PaperExtraction | None = None
+
+
+def _read_body(paper: Paper) -> str | None:
+    """论文正文（截断到预算）；无全文 / 文件缺失 / 内容为空一律 None。"""
+    if not paper.full_text_path:
+        return None
+    path = Path(paper.full_text_path)
+    if not path.exists():
+        return None
+    body = path.read_text(encoding="utf-8", errors="ignore").strip()
+    return body[:EXTRACT_PROMPT_CHARS] or None
+
+
+def _parse_json_object(content: str) -> dict[str, Any] | None:
+    """模型输出 → 首个 JSON 对象；解析不动 / 不是对象返回 None。"""
+    start, end = content.find("{"), content.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        payload = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _normalize_text(value: Any, max_len: int) -> str | None:
+    """text 字段归一化：只收字符串，去首尾空白，空串置 None，超长截断。"""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text[:max_len] or None
+
+
+def _normalize_list(value: Any, max_len: int, max_items: int | None) -> list[str] | None:
+    """list 字段归一化：去空、去重（保序）、单条截断、条数封顶；空列表置 None。
+
+    模型偶尔把单条内容直接给成字符串而不是单元素数组——收下它，这类形状偏差
+    不值得整份产物作废。
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return None
+    items: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        text = item.strip()[:max_len]
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        items.append(text)
+        if max_items is not None and len(items) >= max_items:
+            break
+    return items or None
+
+
+def normalize_payload(
+    schema: ExtractionSchema, raw: dict[str, Any]
+) -> tuple[dict[str, Any], float | None]:
+    """模型输出 → (归一化 payload, 置信度)。
+
+    字段白名单：不在 schema 里的键直接丢弃（模型自作主张加的字段不入库）。
+    空字段（空串 / 空列表 / 类型不对）不进 payload——「没抽到」用缺键表达，
+    读方与前端据此不渲染，而不是渲染一个空段落。payload 可能为空 dict，
+    调用方据此不落表。
+    """
+    payload: dict[str, Any] = {}
+    for field in schema.fields:
+        if field.kind == "list":
+            value = _normalize_list(raw.get(field.name), field.max_len, field.max_items)
+        else:
+            value = _normalize_text(raw.get(field.name), field.max_len)
+        if value is not None:
+            payload[field.name] = value
+    confidence: float | None = None
+    raw_conf = raw.get("confidence")
+    if isinstance(raw_conf, (int, float)) and not isinstance(raw_conf, bool):
+        confidence = min(1.0, max(0.0, float(raw_conf)))
+    return payload, confidence
+
+
+def build_user_prompt(schema: ExtractionSchema, paper: Paper, body: str) -> str:
+    """抽取 user prompt（标题行与 librarian 编译同格式，fake provider 靠它回显）。"""
+    del schema  # 目前各 schema 共用同一份材料口径；字段差异全在 system prompt
+    return (
+        f"标题：{paper.title}\n"
+        f"摘要：{(paper.abstract or '').strip() or '（无）'}\n"
+        f"正文：\n{body}"
+    )
+
+
+async def extract_paper(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    schema_id: str = DEFAULT_SCHEMA_ID,
+    llm: Any = None,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+    force: bool = False,
+) -> ExtractionOutcome:
+    """对一篇论文跑一遍 schema 抽取；已有产物且非 force 时幂等跳过。调用方负责 commit。
+
+    未知 schema_id 抛 ValueError——那是调用方代码写错，不是运行期波动，
+    不能吞成 skip。其余失败一律 skipped + 原因。
+    """
+    schema = get_schema(schema_id)
+    existing = await session.scalar(
+        select(PaperExtraction).where(
+            PaperExtraction.paper_id == paper.id,
+            PaperExtraction.schema_id == schema.id,
+        )
+    )
+    if existing is not None and not force:
+        return ExtractionOutcome("skipped", "already extracted", existing)
+
+    body = _read_body(paper)
+    if body is None:
+        return ExtractionOutcome("skipped", "no full text")
+
+    if llm is None:
+        from app.core.llm.router import get_llm_router
+
+        llm = get_llm_router()
+    result = await llm.complete(
+        schema.stage,
+        [
+            Message(role="system", content=schema.system_prompt()),
+            Message(role="user", content=build_user_prompt(schema, paper, body)),
+        ],
+        temperature=0.0,
+        user_id=user_id,
+        project_id=project_id,
+        library_id=library_id,
+    )
+    raw = _parse_json_object(result.content)
+    if raw is None:
+        logger.warning("extraction output unparseable for paper %s (%s)", paper.id, schema.id)
+        return ExtractionOutcome("skipped", "unparseable model output")
+    payload, confidence = normalize_payload(schema, raw)
+    if not payload:
+        # 归一化后一个字段都没剩：与其存一行空产物骗过「已抽取」判定，不如不落表，
+        # 下次重跑还有机会抽出来
+        return ExtractionOutcome("skipped", "empty extraction")
+
+    stage_meta = {"model": result.model, "stage": schema.stage, "version": schema.version}
+    if existing is not None:
+        existing.payload = payload
+        existing.confidence = confidence
+        existing.stage_meta = stage_meta
+        row = existing
+    else:
+        row = PaperExtraction(
+            paper_id=paper.id,
+            schema_id=schema.id,
+            payload=payload,
+            confidence=confidence,
+            stage_meta=stage_meta,
+        )
+        session.add(row)
+    await session.flush()
+    return ExtractionOutcome("extracted", None, row)
+
+
+async def list_extractions(
+    session: AsyncSession, paper_id: uuid.UUID
+) -> list[PaperExtraction]:
+    """一篇论文的全部抽取产物（详情页「结构化摘要」区的原料），按 schema_id 稳定排序。"""
+    stmt = (
+        select(PaperExtraction)
+        .where(PaperExtraction.paper_id == paper_id)
+        .order_by(PaperExtraction.schema_id)
+    )
+    return list((await session.execute(stmt)).scalars().all())

--- a/src/backend/app/services/extraction/schemas.py
+++ b/src/backend/app/services/extraction/schemas.py
@@ -1,0 +1,103 @@
+"""抽取 schema 注册表（#661）。
+
+schema 决定三件事：抽哪些字段（白名单）、每个字段长什么样（text/list + 长度帽）、
+怎么向模型要（prompt 模板）。运行时（runtime.py）对着 schema 做归一化——模型输出
+里不在白名单的键直接丢弃，超长截断，空串置空。
+
+内置只有通用骨架 skeleton@1（问题-方法-发现-局限，ORKG contribution 思路）；
+学科 schema（PICO / 任务-数据集-指标 / 合成配方…）按设计报告属后续批次，本模块
+只留 ``register_schema`` 这道缝，不预埋任何学科内容。
+
+版本语义：字段集合或含义变了就 +1 并落进 stage_meta.version，读方据此判断
+存量产物是否过期。同一 id 只注册最新版——不做多版本共存，个人平台的量级
+重抽一遍比维护版本矩阵便宜。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaField:
+    """一个抽取字段：text = 单段文本；list = 字符串列表（去重去空、条数封顶）。"""
+
+    name: str
+    kind: str  # "text" | "list"
+    max_len: int  # text：整段字符帽；list：单条字符帽
+    max_items: int | None = None  # 仅 list：最多保留几条
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionSchema:
+    id: str
+    version: int
+    fields: tuple[SchemaField, ...]
+    # system prompt 模板，{fields_spec} 占位符由 field_spec_text() 填充
+    prompt_template: str
+    # 该 schema 走哪个 LLM 环节（须在 core/llm/router.py 的 STAGES 里注册好路由与档位；
+    # 学科包挂新 schema 时要么复用已有环节，要么连同 STAGES/前端清单一起加）
+    stage: str = "extract_skeleton"
+
+    def field_spec_text(self) -> str:
+        """字段清单的自然语言描述（进 prompt，确定性生成，与 fields 永不漂移）。"""
+        lines = []
+        for f in self.fields:
+            if f.kind == "list":
+                lines.append(
+                    f'- "{f.name}"：字符串数组，最多 {f.max_items} 条，'
+                    f"每条不超过 {f.max_len} 字；没有可靠内容就给空数组"
+                )
+            else:
+                lines.append(
+                    f'- "{f.name}"：一段文本，不超过 {f.max_len} 字；'
+                    "原文没讲清就给 null，不要编造"
+                )
+        return "\n".join(lines)
+
+    def system_prompt(self) -> str:
+        return self.prompt_template.format(fields_spec=self.field_spec_text())
+
+
+# 通用骨架：任何学科的论文都答得上的四个问题（问题-方法-发现-局限）。
+# prompt 首行的 POLARIS_EXTRACT_SKELETON 是 fake provider 的识别标记
+# （core/llm/fake.py 对齐），真模型把它当无害前缀。
+SKELETON_SCHEMA = ExtractionSchema(
+    id="skeleton",
+    version=1,
+    fields=(
+        SchemaField("problem", "text", max_len=800),
+        SchemaField("method", "text", max_len=800),
+        SchemaField("findings", "list", max_len=300, max_items=5),
+        SchemaField("limitations", "list", max_len=300, max_items=3),
+    ),
+    prompt_template=(
+        "POLARIS_EXTRACT_SKELETON\n"
+        "你是论文结构化抽取器。根据给定论文的标题与正文，抽取它的通用骨架，"
+        "全部字段用中文表述（专有名词保留原文）：\n"
+        "{fields_spec}\n"
+        '只输出一个 JSON 对象，键为上述字段名，另加 "confidence"（0 到 1，'
+        "你对整份抽取的把握）。只依据原文，不引入外部知识。"
+    ),
+)
+
+_REGISTRY: dict[str, ExtractionSchema] = {}
+
+
+def register_schema(schema: ExtractionSchema) -> None:
+    """挂载一个抽取 schema（学科包的接入点）。同 id 重复注册视为版本演进，直接覆盖。"""
+    _REGISTRY[schema.id] = schema
+
+
+def get_schema(schema_id: str) -> ExtractionSchema:
+    schema = _REGISTRY.get(schema_id)
+    if schema is None:
+        raise ValueError(f"unknown extraction schema: {schema_id!r}")
+    return schema
+
+
+def list_schemas() -> list[ExtractionSchema]:
+    return list(_REGISTRY.values())
+
+
+register_schema(SKELETON_SCHEMA)

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -297,6 +297,28 @@ async def enrich_paper(
         logger.warning("enrich citation intents failed for paper %s", paper_id, exc_info=True)
         paper = await _rollback_and_reload()
 
+    # 骨架抽取（#661，增量钩子）：全文就位后按通用骨架 schema 抽 problem/method/
+    # findings/limitations 落 paper_extractions。非独立进度阶段（STAGES 不变）、
+    # best-effort；runtime 对无全文论文如实 skip、不调 LLM——bibtex 导入等
+    # golden 链路因此零输出零副作用。
+    try:
+        from app.services.extraction.runtime import extract_paper
+
+        outcome = await extract_paper(
+            session,
+            paper,
+            user_id=user_id,
+            project_id=project_id,
+            library_id=target_id,
+        )
+        if outcome.status == "extracted":
+            await session.commit()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("enrich skeleton extraction failed for %s", paper_id, exc_info=True)
+        paper = await _rollback_and_reload()
+
     # OpenAlex 对齐（#639，增量钩子）：缺 OpenAlex id 的记录按 DOI/arXiv 精确、
     # 标题+年份模糊补 id 并回填空元数据。这是真实出网调用，受设置开关控制
     # （测试套件默认关，见 core/config.py）；best-effort，不发进度事件。

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "57543f6328a1"  # Paper citation edges (#639)
+HEAD_REVISION = "58b0bc2d809d"  # Paper skeleton extractions (#661)
+CITATIONS_REVISION = "57543f6328a1"  # Paper citation edges (#639)
 HYPOTHESIS_TREE_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
 MEMBERS_DROP_REVISION = "b0dd1709e2a1"  # Drop project_members (#625)
 LLM_MERGE_REVISION = "dd572a7f063c"  # Merge LLM config tracks: drop users.llm_self_managed (#621)
@@ -147,6 +148,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "paper_content_chunk_vectors",
                     "paper_evidence_anchors",
                     "paper_citations",
+                    "paper_extractions",
                     "download_api_keys",
                     "download_batches",
                     "download_batch_items",
@@ -552,7 +554,27 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "ix_paper_citations_cited_paper_id",
     } <= _index_names(db_path, "paper_citations")
 
-    # 先退掉引文边表（#639）：假设树表不受影响。
+    # 本分支新增：结构化抽取产物表（#661）
+    assert "paper_extractions" in columns["_tables"]
+    assert {
+        "paper_id",
+        "schema_id",
+        "payload",
+        "confidence",
+        "stage_meta",
+        "created_at",
+        "updated_at",
+    } <= columns["paper_extractions"]
+    assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
+
+    # 先退掉抽取产物表（#661）：引文边表不受影响。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CITATIONS_REVISION
+    assert "paper_extractions" not in columns["_tables"]
+    assert "paper_citations" in columns["_tables"]
+
+    # 再退掉引文边表（#639）：假设树表不受影响。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == HYPOTHESIS_TREE_REVISION
@@ -927,6 +949,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    assert "paper_extractions" in columns["_tables"]  # 抽取产物表回归（#661）
     assert "paper_citations" in columns["_tables"]  # 引文边表回归（#639）
     assert "effort" in columns["model_routes"]
     assert "chat_bot_configs" in columns["_tables"]

--- a/src/backend/tests/test_paper_extraction.py
+++ b/src/backend/tests/test_paper_extraction.py
@@ -1,0 +1,309 @@
+"""schema 引导的骨架抽取（#661）：归一化边界、运行时确定性、幂等、钩子与端点。"""
+
+import uuid
+
+from sqlalchemy import func, select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.services import paper_enrich
+from app.services.extraction.runtime import extract_paper, normalize_payload
+from app.services.extraction.schemas import SKELETON_SCHEMA, get_schema, list_schemas
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+FULL_TEXT = """Deterministic Extraction Probe
+
+Introduction
+
+We study how deterministic probes behave under schema-guided extraction.
+
+Method
+
+A fake but structured method section with enough prose to look like a paper.
+
+Results
+
+The probe extracts a stable skeleton every time.
+"""
+
+
+async def _noop_emit(stage, status, detail=None):  # noqa: ARG001
+    return None
+
+
+def _write_fulltext(tmp_path, text=FULL_TEXT):
+    path = tmp_path / f"{uuid.uuid4().hex}.txt"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+async def _extraction_rows(paper_id):
+    async with get_sessionmaker()() as session:
+        return (
+            (
+                await session.execute(
+                    select(PaperExtraction).where(PaperExtraction.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+# ---- 1. schema 注册表 ----
+
+
+def test_skeleton_schema_registered():
+    schema = get_schema("skeleton")
+    assert schema is SKELETON_SCHEMA
+    assert schema.version == 1
+    assert [f.name for f in schema.fields] == ["problem", "method", "findings", "limitations"]
+    assert schema in list_schemas()
+    # prompt 由 schema 生成：字段清单与 fields 定义不漂移
+    prompt = schema.system_prompt()
+    assert "POLARIS_EXTRACT_SKELETON" in prompt
+    for field in schema.fields:
+        assert f'"{field.name}"' in prompt
+
+
+def test_unknown_schema_raises():
+    try:
+        get_schema("nope")
+    except ValueError as e:
+        assert "nope" in str(e)
+    else:
+        raise AssertionError("unknown schema must raise")
+
+
+# ---- 2. 归一化边界（纯函数） ----
+
+
+def test_normalize_caps_dedupes_and_drops_empty():
+    raw = {
+        "problem": "  x" + "长" * 2000,  # 超长截断
+        "method": "   ",  # 空白 → 不入 payload
+        "findings": [
+            "  重复的发现  ",
+            "重复的发现",  # strip 后重复 → 去重
+            "",
+            123,  # 非字符串 → 丢弃
+            "发现 A",
+            "发现 B",
+            "发现 C",
+            "发现 D",
+            "发现 E",  # 超过 max_items=5 → 截掉
+        ],
+        "limitations": [],  # 空列表 → 不入 payload
+        "hallucinated_field": "模型自作主张的键必须被白名单丢掉",
+        "confidence": 3.5,  # 越界 → 夹到 1.0
+    }
+    payload, confidence = normalize_payload(SKELETON_SCHEMA, raw)
+    assert set(payload) == {"problem", "findings"}
+    assert len(payload["problem"]) == 800  # max_len 帽
+    assert payload["findings"] == ["重复的发现", "发现 A", "发现 B", "发现 C", "发现 D"]
+    assert confidence == 1.0
+
+
+def test_normalize_accepts_bare_string_as_single_item_list():
+    payload, confidence = normalize_payload(
+        SKELETON_SCHEMA, {"findings": "单条发现给成了字符串"}
+    )
+    assert payload == {"findings": ["单条发现给成了字符串"]}
+    assert confidence is None  # 模型没给就空着，不编数
+
+
+def test_normalize_all_empty_yields_empty_payload():
+    payload, _ = normalize_payload(
+        SKELETON_SCHEMA, {"problem": "", "method": None, "findings": [], "limitations": ["  "]}
+    )
+    assert payload == {}
+
+
+# ---- 3. 运行时：fake provider 确定性 + 幂等 UPSERT + 无正文 skip ----
+
+
+async def test_extract_deterministic_and_idempotent(client, tmp_path):
+    token = await register_and_login(client, email="extract@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extract-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deterministic Extraction Probe",
+            abstract="A probe.",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        outcome = await extract_paper(session, paper)
+        assert outcome.status == "extracted"
+        await session.commit()
+        row = outcome.row
+        assert row.schema_id == "skeleton"
+        # fake provider：problem 回显标题（断言 prompt 里带对了论文）
+        assert "Deterministic Extraction Probe" in row.payload["problem"]
+        assert row.payload["method"]
+        assert len(row.payload["findings"]) == 2
+        assert len(row.payload["limitations"]) == 1
+        assert row.confidence == 0.9
+        assert row.stage_meta["stage"] == "extract_skeleton"
+        assert row.stage_meta["version"] == 1
+        assert row.stage_meta["model"]
+
+        # 幂等：已有产物直接跳过，不重复调用也不再落行
+        again = await extract_paper(session, paper)
+        assert again.status == "skipped"
+        assert again.reason == "already extracted"
+
+        # force：覆盖重抽仍是同一行（UPSERT 语义，唯一约束兜底）
+        forced = await extract_paper(session, paper, force=True)
+        assert forced.status == "extracted"
+        assert forced.row.id == row.id
+        await session.commit()
+        count = await session.scalar(
+            select(func.count())
+            .select_from(PaperExtraction)
+            .where(PaperExtraction.paper_id == paper.id)
+        )
+        assert count == 1
+
+
+async def test_extract_skips_without_fulltext(client):
+    token = await register_and_login(client, email="extractskip@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extractskip-proj")
+
+    async with get_sessionmaker()() as session:
+        # bibtex 导入形态：有标题摘要、无全文——如实 skip，不许拿摘要冒充正文
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="No Fulltext Paper",
+            abstract="Abstract only.",
+        )
+        await session.commit()
+        paper_id = paper.id
+        outcome = await extract_paper(session, paper)
+        assert outcome.status == "skipped"
+        assert outcome.reason == "no full text"
+    assert await _extraction_rows(paper_id) == []
+
+
+async def test_extract_unknown_schema_raises(client, tmp_path):
+    token = await register_and_login(client, email="extractbad@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extractbad-proj")
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Bad Schema Paper",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        try:
+            await extract_paper(session, paper, schema_id="nope")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("unknown schema must raise, not skip")
+
+
+# ---- 4. 增量钩子：enrich_paper 顺带抽骨架 ----
+
+
+async def test_enrich_hook_extracts_skeleton(client, tmp_path):
+    token = await register_and_login(client, email="extracthook@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extracthook-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Hooked Extraction Paper",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+        )
+
+    rows = await _extraction_rows(paper_id)
+    assert len(rows) == 1
+    assert "Hooked Extraction Paper" in rows[0].payload["problem"]
+
+
+async def test_enrich_hook_zero_output_without_fulltext(client):
+    """golden 保全的机制性验证：无全文的论文走完 enrich 链不产生任何抽取行。"""
+    token = await register_and_login(client, email="extracthook2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extracthook2-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Bibtex Style Paper",
+            abstract="No pdf, no full text.",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+        )
+    assert await _extraction_rows(paper_id) == []
+
+
+# ---- 5. 端点 ----
+
+
+async def test_extractions_endpoint(client, tmp_path):
+    token = await register_and_login(client, email="extractapi@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="extractapi-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Endpoint Extraction Paper",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    # 没抽过：空列表而非 404（前端折叠区据此显示「还没有」）
+    resp = await client.get(f"/api/papers/{paper_id}/extractions", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        outcome = await extract_paper(session, paper)
+        assert outcome.status == "extracted"
+        await session.commit()
+
+    resp = await client.get(f"/api/papers/{paper_id}/extractions", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    item = body[0]
+    assert item["schema_id"] == "skeleton"
+    assert "Endpoint Extraction Paper" in item["payload"]["problem"]
+    assert item["confidence"] == 0.9
+    assert item["stage_meta"]["stage"] == "extract_skeleton"
+    assert item["updated_at"]
+
+    # 未登录不可读
+    anon = await client.get(f"/api/papers/{paper_id}/extractions")
+    assert anon.status_code == 401

--- a/src/frontend/src/features/libraries/LibraryBrowse.tsx
+++ b/src/frontend/src/features/libraries/LibraryBrowse.tsx
@@ -33,6 +33,7 @@ import {
   PaperMyTagChips,
   PaperMyTagsRow,
   PaperCitationsSection,
+  PaperExtractionsSection,
   PaperNotesSection,
   WikiHeaderActions,
 } from '../shared/PaperDetailBlocks';
@@ -453,6 +454,9 @@ function PaperDetailPane({
 
       {/* —— 我的笔记（个人维度，只读浏览也能写） —— */}
       <PaperNotesSection paperId={paper.id} noteCount={paper.note_count ?? 0} invalidateKeys={noteKeys} />
+
+      {/* —— 结构化摘要（骨架抽取，#661） —— */}
+      <PaperExtractionsSection paperId={paper.id} />
 
       {/* —— 引文（按意图分组，#639） —— */}
       <PaperCitationsSection paperId={paper.id} />

--- a/src/frontend/src/features/shared/PaperDetailBlocks.tsx
+++ b/src/frontend/src/features/shared/PaperDetailBlocks.tsx
@@ -582,3 +582,112 @@ export function PaperCitationsSection({ paperId }: { paperId: string }) {
   );
 }
 
+/* ---------------- 结构化摘要（schema 引导抽取，#661） ---------------- */
+
+/** 通用骨架四字段的大白话名字与展示顺序（模块级常量只存 zh/en，渲染处再 tr()）。 */
+const SKELETON_FIELDS: { key: string; zh: string; en: string }[] = [
+  { key: 'problem', zh: '研究问题', en: 'Problem' },
+  { key: 'method', zh: '方法', en: 'Method' },
+  { key: 'findings', zh: '主要发现', en: 'Findings' },
+  { key: 'limitations', zh: '局限', en: 'Limitations' },
+];
+
+/** 单个抽取字段：text 渲染成段落，list 渲染成条目；空字段（缺键）由调用方跳过。 */
+function ExtractionField({ label, value }: { label: string; value: string | string[] }) {
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ fontSize: 11, fontWeight: 650, color: 'var(--text-3)', marginBottom: 3 }}>{label}</div>
+      {Array.isArray(value) ? (
+        <ul style={{ margin: 0, paddingLeft: 18 }}>
+          {value.map((item, i) => (
+            <li key={i} style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--text-2)', overflowWrap: 'break-word' }}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p style={{ margin: 0, fontSize: 12, lineHeight: 1.55, color: 'var(--text-2)', overflowWrap: 'break-word' }}>
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 论文详情的结构化摘要折叠区（#661）：通用骨架 schema 的 problem/method/findings/
+ * limitations 四段，空字段不显示。折叠卡：展开才拉数据（与引文分组同一理由）。
+ */
+export function PaperExtractionsSection({ paperId }: { paperId: string }) {
+  const [open, setOpen] = useState(false);
+  const extractionsQuery = useQuery({
+    queryKey: ['paper-extractions', paperId],
+    queryFn: () => api.getPaperExtractions(paperId),
+    enabled: open,
+    retry: false,
+  });
+  const extractions = extractionsQuery.data ?? [];
+
+  return (
+    <div className="card" style={{ marginTop: 18, overflow: 'hidden' }}>
+      <div
+        className="row"
+        onClick={() => setOpen((o) => !o)}
+        style={{ padding: '11px 16px', cursor: 'pointer', justifyContent: 'space-between', userSelect: 'none' }}
+      >
+        <span className="row gap6" style={{ fontSize: 12.5, fontWeight: 650 }}>
+          <Icon name="layers" size={12} style={{ color: 'var(--text-3)' }} />
+          {tr('结构化摘要', 'Structured summary')}
+        </span>
+        <Icon
+          name="chevDown"
+          size={13}
+          style={{ color: 'var(--text-3)', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
+        />
+      </div>
+      {open && (
+        <div style={{ padding: '0 16px 14px' }}>
+          {extractionsQuery.isLoading ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr('加载结构化摘要…', 'Loading structured summary…')}
+            </p>
+          ) : extractionsQuery.isError ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr('结构化摘要加载失败。', 'Failed to load the structured summary.')}
+            </p>
+          ) : extractions.length === 0 ? (
+            <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+              {tr(
+                '还没有结构化摘要——需要先有 PDF 全文，抽取会在论文补全时自动进行。',
+                'No structured summary yet — it is extracted automatically once the full text is available.',
+              )}
+            </p>
+          ) : (
+            extractions.map((extraction) => {
+              /* 已知骨架字段按固定顺序渲染；将来学科 schema 的额外字段按 payload 键序兜底展示 */
+              const known = SKELETON_FIELDS.filter((f) => extraction.payload[f.key] != null);
+              const knownKeys = new Set(SKELETON_FIELDS.map((f) => f.key));
+              const extra = Object.keys(extraction.payload).filter((k) => !knownKeys.has(k));
+              return (
+                <div key={extraction.schema_id} style={{ marginTop: 8 }}>
+                  {known.map((f) => (
+                    <ExtractionField key={f.key} label={tr(f.zh, f.en)} value={extraction.payload[f.key]!} />
+                  ))}
+                  {extra.map((key) => (
+                    <ExtractionField key={key} label={key} value={extraction.payload[key]!} />
+                  ))}
+                  {typeof extraction.confidence === 'number' && (
+                    <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+                      {tr('抽取置信度', 'Extraction confidence')} {Math.round(extraction.confidence * 100)}%
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -48,7 +48,7 @@ import {
   useDebounced,
 } from './shared';
 import { READING_STATUS, ReadingDot } from '../reading/shared';
-import { PaperCitationsSection, PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
+import { PaperCitationsSection, PaperExtractionsSection, PaperMyTagChips, PaperMyTagsRow, PaperNotesSection } from '../shared/PaperDetailBlocks';
 import { TrashModal, type TrashItemView } from '../shared/TrashModal';
 import { AddToButton } from '../library/AddToPopover';
 import { PaperBatchProgressModal } from '../library/PaperBatchProgressModal';
@@ -1184,6 +1184,9 @@ function PaperDetailPane({
         noteCount={paper.note_count ?? 0}
         invalidateKeys={[['papers'], ['paper', paper.id]]}
       />
+
+      {/* —— 结构化摘要（骨架抽取，#661）：展开才拉数据的折叠卡 —— */}
+      <PaperExtractionsSection paperId={paper.id} />
 
       {/* —— 引文（按意图分组，#639）：展开才拉数据的简单列表 —— */}
       <PaperCitationsSection paperId={paper.id} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -670,6 +670,7 @@ export const LLM_STAGES = [
   'writing',
   'review',
   'citation_intent',
+  'extract_skeleton',
   'rag_expand',
   'rag_rerank',
   'rag_answer',
@@ -1736,6 +1737,21 @@ export interface PaperCitationGroup {
 export interface PaperCitations {
   total: number;
   groups: PaperCitationGroup[];
+}
+
+// ============================================================
+// 结构化抽取（#661）：详情页「结构化摘要」折叠区
+// ============================================================
+
+export interface PaperExtraction {
+  /** 抽取 schema 标识；通用骨架为 'skeleton' */
+  schema_id: string;
+  /** 归一化后的抽取结果：只含抽到的字段（空字段不带键，直接不渲染） */
+  payload: Record<string, string | string[]>;
+  confidence: number | null;
+  /** 产物溯源：{ model, stage, version } */
+  stage_meta: Record<string, unknown> | null;
+  updated_at: string;
 }
 
 // ============================================================
@@ -3739,6 +3755,10 @@ export const api = {
   /** 按意图分组的引文列表（#639）；没建过边时 total=0、groups=[] */
   getPaperCitations(id: string): Promise<PaperCitations> {
     return request<PaperCitations>(`/papers/${id}/citations`);
+  },
+  /** 结构化抽取产物（#661），每 schema 一条；没抽过是空列表而非 404 */
+  getPaperExtractions(id: string): Promise<PaperExtraction[]> {
+    return request<PaperExtraction[]>(`/papers/${id}/extractions`);
   },
   /** 手动重建这篇论文的向量（有就覆盖，没有就新建）；同步返回重建后的状态。需大模型使用权限。 */
   rebuildPaperIndex(

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -29,6 +29,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   writing: { zh: '论文撰写', en: 'Paper writing' },
   review: { zh: '论文评审', en: 'Paper review' },
   citation_intent: { zh: '引文意图分类', en: 'Citation intent classification' },
+  extract_skeleton: { zh: '结构化摘要抽取', en: 'Structured summary extraction' },
   rag_expand: { zh: '库问答·查询扩展', en: 'Library Q&A · query expansion' },
   rag_rerank: { zh: '库问答·重排摘要', en: 'Library Q&A · rerank & summarize' },
   rag_answer: { zh: '库问答·作答', en: 'Library Q&A · answering' },


### PR DESCRIPTION
Closes #661. Part of #660 (P2.5 wave 1, item F1); design report §10 layer ②.

A deterministic per-paper extraction pass producing the universal skeleton — problem / method / findings / limitations — via a constrained LLM stage with normalization. The registry is the discipline-pack seam; no discipline content ships here.

- `paper_extractions` (migration `58b0bc2d809d`): payload JSON with stage metadata for provenance, unique per paper+schema — re-extraction is an idempotent UPSERT, no version history
- schema registry: `skeleton@1` with typed fields and length caps; the system prompt is generated from the field definitions so prompt and schema can never drift; `register_schema()` is the future discipline-pack entry point
- runtime: reads the full text (the dual-track parser (#650) already folds sectioned body text into it; no full text → honest skip, the abstract is never passed off as a body), truncates to budget, runs the medium-tier `extract_skeleton` stage, then a pure normalization pass (key whitelist, length caps, list dedup/caps, confidence clamp, all-empty → skip); every failure path returns a skip reason instead of throwing
- wiring: a best-effort post-enrich step in the citation-edge pattern plus a backfill CLI; deterministic fake-provider marker
- surface: `GET /papers/{id}/extractions` (separate sub-endpoint, golden-safe) and a collapsed "structured summary" card on both paper detail panels with graceful rendering of future non-skeleton fields
- golden safety is mechanism-tested: bibtex papers have no full text, so the enrich hook provably produces zero output and zero side effects; both golden chains byte-identical

Verification: clean-baseline 1530 collected; branch 1541 = baseline + exactly the 11 new tests; full suite 1538 passed + the 3 pre-existing #581 failures — zero new; migration roundtrip green; frontend tsc/vitest 150/build green.