### PR TITLE
feat: method library with a purpose-mechanism dual index

### DIFF
--- a/src/backend/alembic/versions/e867fcbae4ea_method_vectors.py
+++ b/src/backend/alembic/versions/e867fcbae4ea_method_vectors.py
@@ -1,0 +1,53 @@
+"""方法卡双轴向量表 method_vectors（#663：方法库 purpose–mechanism 双索引）
+
+每篇论文的 method@1 抽取产物按 purpose / mechanism 两根轴各建一条向量，
+主键 (paper_id, axis, space)。与三张既有向量侧表同口径：space 标识向量空间
+（换嵌入模型走空间切换机制）、embedding 列不带维度（postgres 用 pgvector，
+其他方言回退 JSON 只存不查）、不带 library_id（论文是共享内容池，库的边界
+检索时经 library_papers 圈定）。
+
+Revision ID: e867fcbae4ea
+Revises: 58b0bc2d809d
+Create Date: 2026-09-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+from alembic import op
+
+revision: str = "e867fcbae4ea"
+down_revision: str | None = "58b0bc2d809d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    is_postgres = op.get_bind().dialect.name == "postgresql"
+    # postgres 用不带维度的 pgvector 列；其他方言回退 JSON（只存不查），
+    # 与 5d8ebd5cb100 三张向量侧表同款
+    vector_type = Vector() if is_postgres else sa.JSON()
+    op.create_table(
+        "method_vectors",
+        sa.Column(
+            "paper_id",
+            sa.Uuid(),
+            sa.ForeignKey("papers.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("axis", sa.String(length=16), primary_key=True),
+        sa.Column("space", sa.String(length=160), primary_key=True),
+        sa.Column("dim", sa.Integer(), nullable=False),
+        sa.Column("embedding", vector_type, nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=False),
+        sa.Column("text_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("built_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_method_vectors_space", "method_vectors", ["space"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_method_vectors_space", table_name="method_vectors")
+    op.drop_table("method_vectors")

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -45,6 +45,8 @@ from app.schemas.libraries import (
     LibraryDigestSummary,
     LibraryQaRequest,
     LibraryQaResponse,
+    MethodCardRead,
+    MethodSearchResponse,
     PaperMergeRequest,
     PaperMergeResult,
     StatementInterviewQuestion,
@@ -77,6 +79,7 @@ from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
 from app.services import library_chat as library_chat_service
 from app.services import library_rag as library_rag_service
+from app.services import method_index as method_index_service
 from app.services import notes as notes_service
 from app.services import paper_enrich as paper_enrich_service
 from app.services import paper_import as paper_import_service
@@ -581,6 +584,41 @@ async def list_library_concepts(
         )
         for concept, count in rows
     ]
+
+
+@router.get("/libraries/{library_id}/methods", response_model=list[MethodCardRead])
+async def list_library_methods(
+    library_id: uuid.UUID,
+    limit: int = Query(default=100, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[MethodCardRead]:
+    """方法库列表（#663）：库内已抽出方法卡的论文，按入库时间倒序。"""
+    library = await _get_visible_library(session, library_id, user)
+    cards = await method_index_service.list_methods(session, library.id, limit=limit)
+    return [MethodCardRead.model_validate(card) for card in cards]
+
+
+@router.get("/libraries/{library_id}/methods/search", response_model=MethodSearchResponse)
+async def search_library_methods(
+    library_id: uuid.UUID,
+    q: str = Query(min_length=1),
+    mode: str = Query(default="same_purpose", pattern="^(same_purpose|different_mechanism)$"),
+    limit: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> MethodSearchResponse:
+    """方法检索（#663）：same_purpose 找同类做法；different_mechanism 找「目的相近、
+    机制不同」的类比做法。嵌入不可用时降级关键词匹配，mode_used 如实上报。"""
+    library = await _get_visible_library(session, library_id, user)
+    items, mode_used = await method_index_service.search_methods(
+        session, library.id, q, mode=mode, limit=limit, user_id=user.id
+    )
+    return MethodSearchResponse(
+        items=[MethodCardRead.model_validate(card) for card in items],
+        mode=mode,
+        mode_used=mode_used,
+    )
 
 
 @router.get("/libraries/{library_id}/search", response_model=SearchResponse)

--- a/src/backend/app/cli/backfill_extractions.py
+++ b/src/backend/app/cli/backfill_extractions.py
@@ -1,10 +1,14 @@
-"""全库批量回填（#661）：schema 引导的论文骨架抽取。
+"""全库批量回填（#661/#663）：schema 引导的论文结构化抽取。
 
 存量论文一次性覆盖用（新论文由补全钩子增量处理）::
 
-    python -m app.cli.backfill_extractions                 # 通用骨架，跳过已抽取
+    python -m app.cli.backfill_extractions                 # 全部注册 schema，跳过已抽取
+    python -m app.cli.backfill_extractions --schema method # 只回填方法卡
     python -m app.cli.backfill_extractions --limit 100
     python -m app.cli.backfill_extractions --force         # 覆盖重抽（schema 升版后用）
+
+方法卡（method）抽到后顺手刷双轴向量索引（services/method_index.py）；
+provider 不支持嵌入时索引跳过，抽取产物照常落表。
 """
 
 from __future__ import annotations
@@ -19,8 +23,9 @@ from sqlalchemy import select
 from app.core.db import dispose_engine, get_sessionmaker
 from app.core.llm.router import get_llm_router
 from app.models.paper import Paper
-from app.services.extraction.runtime import DEFAULT_SCHEMA_ID, extract_paper
-from app.services.extraction.schemas import get_schema
+from app.services.extraction.runtime import extract_paper
+from app.services.extraction.schemas import get_schema, list_schemas
+from app.services.method_index import METHOD_SCHEMA_ID, refresh_paper_method_index
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +33,9 @@ logger = logging.getLogger(__name__)
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--schema", default=DEFAULT_SCHEMA_ID, help="抽取 schema id（默认通用骨架 skeleton）"
+        "--schema",
+        default="all",
+        help="抽取 schema id（默认 all = 注册表里的全部 schema）",
     )
     parser.add_argument("--limit", type=int, help="只处理最早入库的前 N 篇")
     parser.add_argument(
@@ -38,10 +45,13 @@ def _parser() -> argparse.ArgumentParser:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    stats = {"papers": 0, "extracted": 0, "skipped": 0, "failed": 0}
+    stats = {"papers": 0, "extracted": 0, "skipped": 0, "failed": 0, "indexed": 0}
     try:
         # schema 名写错是调用方错误：进循环前就炸掉，别把每篇都记成 failed
-        get_schema(args.schema)
+        if args.schema == "all":
+            schemas = sorted(list_schemas(), key=lambda item: item.id)
+        else:
+            schemas = [get_schema(args.schema)]
         llm = get_llm_router()
         async with get_sessionmaker()() as session:
             stmt = select(Paper).order_by(Paper.created_at)
@@ -50,20 +60,38 @@ async def _run(args: argparse.Namespace) -> None:
             papers = (await session.execute(stmt)).scalars().all()
             for paper in papers:
                 stats["papers"] += 1
-                try:
-                    outcome = await extract_paper(
-                        session, paper, schema_id=args.schema, llm=llm, force=args.force
-                    )
-                    if outcome.status == "extracted":
-                        await session.commit()
-                        stats["extracted"] += 1
-                    else:
-                        stats["skipped"] += 1
-                        logger.info("skipped %s: %s", paper.id, outcome.reason)
-                except Exception:  # noqa: BLE001 — 单篇失败不拖垮整批
-                    logger.warning("extraction backfill failed for %s", paper.id, exc_info=True)
-                    await session.rollback()
-                    stats["failed"] += 1
+                for schema in schemas:
+                    try:
+                        outcome = await extract_paper(
+                            session, paper, schema_id=schema.id, llm=llm, force=args.force
+                        )
+                        if outcome.status == "extracted":
+                            await session.commit()
+                            stats["extracted"] += 1
+                            if schema.id == METHOD_SCHEMA_ID:
+                                try:
+                                    if await refresh_paper_method_index(session, paper):
+                                        await session.commit()
+                                        stats["indexed"] += 1
+                                except NotImplementedError:
+                                    await session.rollback()
+                                    logger.info(
+                                        "method index skipped: embeddings unsupported"
+                                    )
+                        else:
+                            stats["skipped"] += 1
+                            logger.info(
+                                "skipped %s (%s): %s", paper.id, schema.id, outcome.reason
+                            )
+                    except Exception:  # noqa: BLE001 — 单篇/单 schema 失败不拖垮整批
+                        logger.warning(
+                            "extraction backfill failed for %s (%s)",
+                            paper.id,
+                            schema.id,
+                            exc_info=True,
+                        )
+                        await session.rollback()
+                        stats["failed"] += 1
         print(json.dumps(stats, ensure_ascii=False, indent=2))
     finally:
         await dispose_engine()

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -38,6 +38,7 @@ _FAKE_FIGURE_REF_RE = re.compile(r"^(?:fig|figure|tab|table|eq)\s*[:：]", re.IG
 _AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affiliations.py 专门调用）
 _CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类（citation_graph.py）
 _EXTRACT_SKELETON_MARKER = "POLARIS_EXTRACT_SKELETON"  # 骨架抽取（services/extraction/）
+_EXTRACT_METHOD_MARKER = "POLARIS_EXTRACT_METHOD"  # 方法卡抽取（services/extraction/，#663）
 # 库级 agentic RAG 三环节（services/library_rag.py，#644）
 _RAG_EXPAND_MARKER = "POLARIS_RAG_EXPAND"
 _RAG_RERANK_MARKER = "POLARIS_RAG_RERANK"
@@ -448,9 +449,11 @@ class FakeProvider(LLMProvider):
         # 引文意图分类：user prompt 内嵌论文正文原句（可能撞任意通用 marker），须先判断
         if _CITATION_INTENT_MARKER in full_text:
             return FakeProvider._respond_citation_intent(last_user)
-        # 骨架抽取：user prompt 内嵌整篇正文（同样可能撞通用 marker），须先判断
+        # 骨架/方法卡抽取：user prompt 内嵌整篇正文（同样可能撞通用 marker），须先判断
         if _EXTRACT_SKELETON_MARKER in full_text:
             return FakeProvider._respond_extract_skeleton(last_user)
+        if _EXTRACT_METHOD_MARKER in full_text:
+            return FakeProvider._respond_extract_method(last_user)
         # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
         # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
@@ -642,6 +645,29 @@ class FakeProvider(LLMProvider):
                     "发现二：消融验证各组件必要（fake）",
                 ],
                 "limitations": ["局限一：评测范围有限（fake）"],
+                "confidence": 0.9,
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_extract_method(last_user: str) -> str:
+        """方法卡抽取（services/extraction/schemas.py 的 method@1 对齐，#663）。
+
+        purpose 回显标题的前半段——测试用它控制 purpose 轴的词袋向量（标题相近的
+        论文 purpose 就相近），其余字段固定。测试要的是「抽取会落库、双轴会建向量、
+        检索排序语义成立」这条链路，不是抽得多准。"""
+        m = re.search(r"标题：(.+)", last_user)
+        title = m.group(1).strip() if m else "未知论文"
+        words = title.split()
+        half = " ".join(words[: max(1, (len(words) + 1) // 2)]) if words else title
+        return json.dumps(
+            {
+                "purpose": f"目的：{half}（fake extraction）",
+                "mechanism": "机制：用确定性替身流程达成目标（fake extraction）",
+                "baseline": ["基线方法一（fake）"],
+                "dataset": ["数据集一（fake）"],
+                "protocol": "流程：准备数据、跑替身方法、对比指标（fake extraction）",
                 "confidence": 0.9,
             },
             ensure_ascii=False,

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -83,6 +83,9 @@ STAGES = (
     "citation_intent",
     # schema 引导的论文骨架抽取（#661）：整篇正文进、结构化 JSON 出
     "extract_skeleton",
+    # 方法卡抽取（#663）：与骨架同形态（整篇正文进、短 JSON 出），单列环节是
+    # 为了让管理员可以给方法卡配不同模型（它比骨架更吃「拆目的/机制」的判断力）
+    "extract_method",
     # 库级 agentic RAG 三环节（#644）：扩展/重排是短 JSON，作答是中档长生成
     "rag_expand",
     "rag_rerank",
@@ -218,6 +221,7 @@ _MEDIUM_CALL_STAGES = frozenset(
         # 重得多（extract 短档喂的是单页级片段），但也没有长档 20 分钟的理由：
         # enrich 链逐篇串行，卡死一篇就堵住整条补全队列
         "extract_skeleton",
+        "extract_method",  # 方法卡抽取（#663）：与骨架同一负载形态，同档
     }
 )
 

--- a/src/backend/app/models/vectors.py
+++ b/src/backend/app/models/vectors.py
@@ -70,6 +70,23 @@ class PaperChunkVector(_VectorColumns, Base):
     )
 
 
+class MethodVector(_VectorColumns, Base):
+    """方法卡双轴向量（#663）：每篇论文的 method@1 产物按 purpose / mechanism 两根轴
+    各建一条。轴分开存不是冗余——「同目的异机制」检索要在 purpose 轴找近邻、再按
+    mechanism 轴排远近，两根轴必须独立可查。与 paper_extractions 同口径不带
+    library_id：论文是全平台共享的内容池，库的边界在检索时经 library_papers 圈定。
+    """
+
+    __tablename__ = "method_vectors"
+    __table_args__ = (Index("ix_method_vectors_space", "space"),)
+
+    paper_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("papers.id", ondelete="CASCADE"), primary_key=True
+    )
+    # "purpose" | "mechanism"（services/method_index.py 的 AXES）
+    axis: Mapped[str] = mapped_column(String(16), primary_key=True)
+
+
 class IdeaVector(_VectorColumns, Base):
     """想法向量，想法语义去重用。"""
 

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -260,3 +260,32 @@ class LibraryQaResponse(BaseModel):
     evidence: list[LibraryQaEvidence] = []
     # 实际执行过的检索查询（小库直通时为空表——没有检索这一步）
     queries: list[str] = []
+
+
+# ---- 方法库（#663）：purpose–mechanism 双索引 ----
+
+
+class MethodCardRead(BaseModel):
+    """一张方法卡：method@1 抽取产物的五元组 + 检索时的双轴相似度。
+
+    similarity 是 purpose 轴与查询的相似度（列表视图为 None）；
+    mechanism_similarity 只在语义检索且该论文有机制轴向量时给出——
+    「找异类机制」模式下它越低排得越前。
+    """
+
+    paper_id: uuid.UUID
+    title: str
+    purpose: str | None = None
+    mechanism: str | None = None
+    baseline: list[str] = []
+    dataset: list[str] = []
+    protocol: str | None = None
+    similarity: float | None = None
+    mechanism_similarity: float | None = None
+
+
+class MethodSearchResponse(BaseModel):
+    items: list[MethodCardRead]
+    mode: str
+    # semantic = 双轴向量检索；keyword = 嵌入不可用时的确定性关键词降级
+    mode_used: str

--- a/src/backend/app/services/embedding.py
+++ b/src/backend/app/services/embedding.py
@@ -24,7 +24,7 @@ from app.core.embedding_space import (
     set_active_space,
 )
 from app.models.base import utcnow
-from app.models.vectors import IdeaVector, PaperChunkVector, PaperVector
+from app.models.vectors import IdeaVector, MethodVector, PaperChunkVector, PaperVector
 
 EMBEDDING_STAGE = "embedding"
 
@@ -168,6 +168,29 @@ async def upsert_idea_vector(
     await _upsert(session, IdeaVector, IdeaVector.idea_id, idea_id, vector, space)
 
 
+async def upsert_method_vector(
+    session: AsyncSession,
+    paper_id: uuid.UUID,
+    axis: str,
+    vector: list[float],
+    space: EmbeddingSpace,
+) -> None:
+    """写入/覆盖方法卡某根轴的向量（#663，调用方负责 commit）。
+
+    主键多了一段 axis，故经 ``extra_key`` 走同一个真 upsert 路径——方法卡重抽与
+    多库并发同步会撞同一 (paper_id, axis, space)，「先查后插」在这里同样会炸。
+    """
+    await _upsert(
+        session,
+        MethodVector,
+        MethodVector.paper_id,
+        paper_id,
+        vector,
+        space,
+        extra_key={"axis": axis},
+    )
+
+
 async def _upsert(
     session: AsyncSession,
     model_class: type,
@@ -175,6 +198,8 @@ async def _upsert(
     key: uuid.UUID,
     vector: list[float],
     space: EmbeddingSpace,
+    *,
+    extra_key: dict[str, str] | None = None,
 ) -> None:
     """原子写入/覆盖向量（调用方负责 commit）。
 
@@ -188,8 +213,10 @@ async def _upsert(
         raise EmbeddingSpaceMismatchError(
             f"refusing to store a {len(vector)}-dim vector in space {space}"
         )
+    extra_key = extra_key or {}
     values = {
         key_column.key: key,
+        **extra_key,
         "space": space.key,
         "dim": space.dim,
         "embedding": vector,
@@ -197,19 +224,21 @@ async def _upsert(
         "text_version": TEXT_VERSION,
         "built_at": utcnow(),
     }
+    # 冲突键 = 完整主键（owner 外键 + 可选的附加主键段 + space）
+    key_names = [key_column.key, *extra_key, "space"]
     dialect = session.get_bind().dialect.name
     if dialect == "postgresql":
         from sqlalchemy.dialects.postgresql import insert as _insert
     elif dialect == "sqlite":
         from sqlalchemy.dialects.sqlite import insert as _insert
     else:  # 其余方言没有 ON CONFLICT，退回先查后插（单机开发场景没有并发问题）
+        conditions = [key_column == key, model_class.space == space.key]
+        conditions += [getattr(model_class, name) == v for name, v in extra_key.items()]
         row = (
-            await session.execute(
-                select(model_class).where(key_column == key, model_class.space == space.key)
-            )
+            await session.execute(select(model_class).where(*conditions))
         ).scalar_one_or_none()
         if row is None:
-            row = model_class(**{key_column.key: key, "space": space.key})
+            row = model_class(**{key_column.key: key, **extra_key, "space": space.key})
             session.add(row)
         for field, value in values.items():
             setattr(row, field, value)
@@ -218,12 +247,12 @@ async def _upsert(
     stmt = _insert(model_class).values(**values)
     await session.execute(
         stmt.on_conflict_do_update(
-            index_elements=[key_column.key, "space"],
-            set_={k: v for k, v in values.items() if k not in (key_column.key, "space")},
+            index_elements=key_names,
+            set_={k: v for k, v in values.items() if k not in key_names},
         )
     )
     # 该行可能已在 identity map 里且被这条 INSERT 绕过了，过期它免得读到旧向量
-    existing = await session.get(model_class, (key, space.key))
+    existing = await session.get(model_class, (key, *extra_key.values(), space.key))
     if existing is not None:
         await session.refresh(existing)
 

--- a/src/backend/app/services/extraction/schemas.py
+++ b/src/backend/app/services/extraction/schemas.py
@@ -4,7 +4,9 @@ schema 决定三件事：抽哪些字段（白名单）、每个字段长什么�
 怎么向模型要（prompt 模板）。运行时（runtime.py）对着 schema 做归一化——模型输出
 里不在白名单的键直接丢弃，超长截断，空串置空。
 
-内置只有通用骨架 skeleton@1（问题-方法-发现-局限，ORKG contribution 思路）；
+内置两个通用 schema：骨架 skeleton@1（问题-方法-发现-局限，ORKG contribution
+思路）与方法卡 method@1（目的-机制-基线-数据集-流程，#663 方法库的原料，
+purpose 与 mechanism 各自建向量做双轴检索，见 services/method_index.py）。
 学科 schema（PICO / 任务-数据集-指标 / 合成配方…）按设计报告属后续批次，本模块
 只留 ``register_schema`` 这道缝，不预埋任何学科内容。
 
@@ -81,6 +83,37 @@ SKELETON_SCHEMA = ExtractionSchema(
     ),
 )
 
+# 方法卡（#663）：把一篇论文的做法拆成「要达成什么（purpose）」与「靠什么机制
+# 达成（mechanism）」两根轴，外加复现要素（基线/数据集/流程）。拆成两根轴不是
+# 分类洁癖——方法库的「同目的异机制」类比检索靠它：purpose 轴找目的相近的论文，
+# 再按 mechanism 轴的距离把「换了个思路」的排到前面。字段短帽（400/600 字）是
+# 有意的：进向量的文本要一句话说清一根轴，长篇大论会把两根轴搅成一团。
+# prompt 首行的 POLARIS_EXTRACT_METHOD 是 fake provider 的识别标记（core/llm/fake.py）。
+METHOD_SCHEMA = ExtractionSchema(
+    id="method",
+    version=1,
+    fields=(
+        SchemaField("purpose", "text", max_len=400),
+        SchemaField("mechanism", "text", max_len=400),
+        SchemaField("baseline", "list", max_len=200, max_items=5),
+        SchemaField("dataset", "list", max_len=200, max_items=5),
+        SchemaField("protocol", "text", max_len=600),
+    ),
+    prompt_template=(
+        "POLARIS_EXTRACT_METHOD\n"
+        "你是论文方法卡抽取器。根据给定论文的标题与正文，把它的做法拆成方法卡，"
+        "全部字段用中文表述（专有名词保留原文）：\n"
+        "{fields_spec}\n"
+        "其中 \"purpose\" 只写这个方法要达成的目标（不写怎么做），"
+        "\"mechanism\" 只写达成目标的核心机制（不复述目标）；"
+        "\"baseline\" 是对比的基线方法名，\"dataset\" 是用到的数据集名，"
+        "\"protocol\" 是实验流程的一段概述。"
+        '只输出一个 JSON 对象，键为上述字段名，另加 "confidence"（0 到 1，'
+        "你对整份抽取的把握）。只依据原文，不引入外部知识。"
+    ),
+    stage="extract_method",
+)
+
 _REGISTRY: dict[str, ExtractionSchema] = {}
 
 
@@ -101,3 +134,4 @@ def list_schemas() -> list[ExtractionSchema]:
 
 
 register_schema(SKELETON_SCHEMA)
+register_schema(METHOD_SCHEMA)

--- a/src/backend/app/services/method_index.py
+++ b/src/backend/app/services/method_index.py
@@ -1,0 +1,270 @@
+"""方法库的双轴索引与类比检索（#663，设计报告 §11 燃料 3）。
+
+一篇论文的 method@1 抽取产物（services/extraction/schemas.py）拆出两根语义轴：
+purpose（要达成什么）与 mechanism（靠什么机制达成），各自 embed 一条向量存进
+method_vectors。为什么拆两轴而不是整卡一条向量：方法库最值钱的问法是「同目的
+异机制」——我想达成的目标别人怎么达成的、有没有换个思路的做法。整卡一条向量
+只能回答「像不像」，回答不了「目的像但路子不像」。
+
+检索语义（search_methods）：
+- same_purpose：purpose 轴近邻，纯粹的「找同类做法」；
+- different_mechanism：先取 purpose 轴近邻圈出「目的相近」的池子，再按 mechanism
+  轴与查询的相似度**升序**排——目的最像、机制离得最远的排最前，即类比检索。
+
+向量存储沿用向量侧表口径（models/vectors.py）：不带 library_id（论文是共享内容池，
+库的边界检索时经 library_papers 圈定）、带 space（换嵌入模型走既有的空间切换机制）、
+Python 侧算余弦（候选集 = 单库有方法卡的论文，量级几百，顺序扫描在 sqlite/postgres
+上行为一致，测试也因此可用 fake embedding 确定性断言排序）。
+
+增量：enrich 钩子与 backfill CLI 在 method@1 产物落表后调 refresh_paper_method_index
+同步刷索引。嵌入不可用（NotImplementedError）时由调用方按既有降级路径处理；
+检索侧降级为关键词匹配（mode_used 如实上报），不给一个看着正常实则乱序的结果。
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.models.vectors import MethodVector
+
+logger = logging.getLogger(__name__)
+
+METHOD_SCHEMA_ID = "method"
+
+#: 双轴：进向量的两个 text 字段。list 字段（baseline/dataset）与 protocol 只做
+#: 展示与关键词降级，不进向量——它们是复现要素，不是语义轴。
+AXES = ("purpose", "mechanism")
+
+SEARCH_MODES = ("same_purpose", "different_mechanism")
+
+#: different_mechanism 的 purpose 近邻池子大小下限：池子太小时「目的相近」这个
+#: 前提名存实亡，排序退化成纯 mechanism 距离
+_DIFFERENT_POOL_MIN = 20
+
+
+def _axis_texts(payload: dict[str, Any]) -> dict[str, str]:
+    """method@1 payload 里实际抽到的轴文本（缺键/空串不进结果）。"""
+    out: dict[str, str] = {}
+    for axis in AXES:
+        value = payload.get(axis)
+        if isinstance(value, str) and value.strip():
+            out[axis] = value.strip()
+    return out
+
+
+async def refresh_paper_method_index(
+    session: AsyncSession,
+    paper: Paper,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    library_id: uuid.UUID | None = None,
+) -> bool:
+    """按当前 method@1 产物重建这篇论文的双轴向量，返回是否写了任何行。
+
+    调用方负责 commit。没有产物 / 两根轴都没抽到时**清掉**存量向量而不是留着——
+    重抽可能把某根轴抽没了，幽灵向量会让这篇论文继续在该轴命中。嵌入不可用时
+    抛 NotImplementedError（调用方按 skipped 处理），此时不动存量。
+    """
+    row = await session.scalar(
+        select(PaperExtraction).where(
+            PaperExtraction.paper_id == paper.id,
+            PaperExtraction.schema_id == METHOD_SCHEMA_ID,
+        )
+    )
+    texts = _axis_texts(row.payload) if row is not None else {}
+
+    from app.services.embedding import embed_documents, upsert_method_vector
+
+    wrote = False
+    if texts:
+        axes = list(texts)
+        vectors, space = await embed_documents(
+            session,
+            [texts[a] for a in axes],
+            user_id=user_id,
+            project_id=project_id,
+            library_id=library_id,
+        )
+        for axis, vector in zip(axes, vectors, strict=True):
+            await upsert_method_vector(session, paper.id, axis, vector, space)
+            wrote = True
+
+    # 没抽到的轴清掉（全部空间：旧空间的幽灵在切回旧模型时同样是错的）
+    stale = [a for a in AXES if a not in texts]
+    if stale:
+        await session.execute(
+            delete(MethodVector).where(
+                MethodVector.paper_id == paper.id, MethodVector.axis.in_(stale)
+            )
+        )
+    return wrote
+
+
+async def _method_rows(
+    session: AsyncSession, library_id: uuid.UUID
+) -> list[tuple[Paper, PaperExtraction]]:
+    """库内（相关性达标、不含回收站）有 method@1 产物的论文，按入库时间倒序。"""
+    from app.services.papers import PAPER_STATUS_GROUPS
+
+    stmt = (
+        select(Paper, PaperExtraction)
+        .join(PaperExtraction, PaperExtraction.paper_id == Paper.id)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(
+            PaperExtraction.schema_id == METHOD_SCHEMA_ID,
+            LibraryPaper.library_id == library_id,
+            LibraryPaper.status.in_(PAPER_STATUS_GROUPS["library"]),
+        )
+        .order_by(LibraryPaper.created_at.desc())
+    )
+    return [(paper, ext) for paper, ext in (await session.execute(stmt)).all()]
+
+
+def _card(paper: Paper, ext: PaperExtraction) -> dict[str, Any]:
+    payload = ext.payload or {}
+    return {
+        "paper_id": paper.id,
+        "title": paper.title,
+        "purpose": payload.get("purpose"),
+        "mechanism": payload.get("mechanism"),
+        "baseline": payload.get("baseline") or [],
+        "dataset": payload.get("dataset") or [],
+        "protocol": payload.get("protocol"),
+        "similarity": None,
+        "mechanism_similarity": None,
+    }
+
+
+async def list_methods(
+    session: AsyncSession, library_id: uuid.UUID, *, limit: int = 100
+) -> list[dict[str, Any]]:
+    """方法库列表：库内已抽取论文的五元组卡（无查询时的默认视图）。"""
+    rows = await _method_rows(session, library_id)
+    return [_card(paper, ext) for paper, ext in rows[:limit]]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _tokens(text: str) -> set[str]:
+    return set(re.findall(r"\w+", text.lower()))
+
+
+def _keyword_overlap(query_tokens: set[str], text: str | None) -> int:
+    if not text:
+        return 0
+    return len(query_tokens & _tokens(text))
+
+
+async def search_methods(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    query: str,
+    *,
+    mode: str = "same_purpose",
+    limit: int = 20,
+    user_id: uuid.UUID | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """方法检索，返回 (卡片列表, mode_used)。
+
+    语义路径要求候选在激活空间下有所需轴的向量：same_purpose 只要 purpose 轴，
+    different_mechanism 两轴都要（缺 mechanism 向量的论文没法排远近，如实排除而
+    不是编一个位置）。嵌入不可用时降级为确定性的关键词匹配（mode_used="keyword"）：
+    same_purpose 按 purpose 文本的查询词命中数降序；different_mechanism 先按 purpose
+    命中数圈池子，再按 mechanism 文本的命中数**升序**——语义方向与向量路径一致。
+    """
+    if mode not in SEARCH_MODES:
+        raise ValueError(f"unknown method search mode: {mode!r}")
+    rows = await _method_rows(session, library_id)
+    if not rows:
+        return [], "semantic"
+
+    try:
+        from app.services.embedding import embed_query
+
+        query_vector, space = await embed_query(
+            session, query, user_id=user_id, library_id=library_id
+        )
+    except NotImplementedError:
+        return _keyword_search(rows, query, mode=mode, limit=limit), "keyword"
+
+    vec_rows = (
+        await session.execute(
+            select(MethodVector).where(
+                MethodVector.paper_id.in_([paper.id for paper, _ in rows]),
+                MethodVector.space == space.key,
+            )
+        )
+    ).scalars()
+    vectors: dict[tuple[uuid.UUID, str], list[float]] = {
+        (v.paper_id, v.axis): list(v.embedding) for v in vec_rows
+    }
+
+    scored: list[dict[str, Any]] = []
+    for paper, ext in rows:
+        purpose_vec = vectors.get((paper.id, "purpose"))
+        if purpose_vec is None:
+            continue
+        card = _card(paper, ext)
+        card["similarity"] = _cosine(query_vector, purpose_vec)
+        mechanism_vec = vectors.get((paper.id, "mechanism"))
+        if mechanism_vec is not None:
+            card["mechanism_similarity"] = _cosine(query_vector, mechanism_vec)
+        elif mode == "different_mechanism":
+            continue  # 没有机制轴就没法排「机制远近」
+        scored.append(card)
+
+    # tie-break 用 paper_id 字符串：同分时排序仍然确定
+    scored.sort(key=lambda c: (-c["similarity"], str(c["paper_id"])))
+    if mode == "same_purpose":
+        return scored[:limit], "semantic"
+
+    pool = scored[: max(limit, _DIFFERENT_POOL_MIN)]
+    pool.sort(
+        key=lambda c: (c["mechanism_similarity"], -c["similarity"], str(c["paper_id"]))
+    )
+    return pool[:limit], "semantic"
+
+
+def _keyword_search(
+    rows: list[tuple[Paper, PaperExtraction]],
+    query: str,
+    *,
+    mode: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """确定性关键词降级：查询分词与轴文本的命中数（无 LLM、无向量）。"""
+    query_tokens = _tokens(query)
+    cards: list[tuple[int, int, dict[str, Any]]] = []
+    for paper, ext in rows:
+        card = _card(paper, ext)
+        p_hits = _keyword_overlap(query_tokens, card["purpose"])
+        m_hits = _keyword_overlap(query_tokens, card["mechanism"])
+        cards.append((p_hits, m_hits, card))
+
+    if mode == "same_purpose":
+        cards.sort(key=lambda item: (-item[0], str(item[2]["paper_id"])))
+        return [c for _, _, c in cards[:limit]]
+
+    # different_mechanism：purpose 命中数圈池子，池内 mechanism 命中数升序
+    cards.sort(key=lambda item: (-item[0], str(item[2]["paper_id"])))
+    pool = cards[: max(limit, _DIFFERENT_POOL_MIN)]
+    pool.sort(key=lambda item: (item[1], -item[0], str(item[2]["paper_id"])))
+    return [c for _, _, c in pool[:limit]]

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -297,27 +297,52 @@ async def enrich_paper(
         logger.warning("enrich citation intents failed for paper %s", paper_id, exc_info=True)
         paper = await _rollback_and_reload()
 
-    # 骨架抽取（#661，增量钩子）：全文就位后按通用骨架 schema 抽 problem/method/
-    # findings/limitations 落 paper_extractions。非独立进度阶段（STAGES 不变）、
-    # best-effort；runtime 对无全文论文如实 skip、不调 LLM——bibtex 导入等
-    # golden 链路因此零输出零副作用。
-    try:
-        from app.services.extraction.runtime import extract_paper
+    # 结构化抽取（#661 骨架 + #663 方法卡，增量钩子）：全文就位后把注册表里的每个
+    # schema 都抽一遍落 paper_extractions。非独立进度阶段（STAGES 不变）、逐 schema
+    # best-effort（一个 schema 失败不拖垮其余）；runtime 对无全文论文如实 skip、
+    # 不调 LLM——bibtex 导入等 golden 链路因此零输出零副作用。
+    from app.services.extraction.runtime import extract_paper
+    from app.services.extraction.schemas import list_schemas
+    from app.services.method_index import METHOD_SCHEMA_ID, refresh_paper_method_index
 
-        outcome = await extract_paper(
-            session,
-            paper,
-            user_id=user_id,
-            project_id=project_id,
-            library_id=target_id,
-        )
-        if outcome.status == "extracted":
-            await session.commit()
-    except asyncio.CancelledError:
-        raise
-    except Exception:  # noqa: BLE001
-        logger.warning("enrich skeleton extraction failed for %s", paper_id, exc_info=True)
-        paper = await _rollback_and_reload()
+    method_extracted = False
+    for schema in sorted(list_schemas(), key=lambda item: item.id):
+        try:
+            outcome = await extract_paper(
+                session,
+                paper,
+                schema_id=schema.id,
+                user_id=user_id,
+                project_id=project_id,
+                library_id=target_id,
+            )
+            if outcome.status == "extracted":
+                await session.commit()
+                if schema.id == METHOD_SCHEMA_ID:
+                    method_extracted = True
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "enrich %s extraction failed for %s", schema.id, paper_id, exc_info=True
+            )
+            paper = await _rollback_and_reload()
+
+    # 方法库双轴索引（#663）：方法卡落表后同步刷 purpose/mechanism 向量。
+    # best-effort；provider 不支持嵌入按 skipped 处理（与 embed 阶段同口径）。
+    if method_extracted:
+        try:
+            if await refresh_paper_method_index(
+                session, paper, user_id=user_id, project_id=project_id, library_id=target_id
+            ):
+                await session.commit()
+        except asyncio.CancelledError:
+            raise
+        except NotImplementedError:
+            paper = await _rollback_and_reload()
+        except Exception:  # noqa: BLE001
+            logger.warning("enrich method index failed for %s", paper_id, exc_info=True)
+            paper = await _rollback_and_reload()
 
     # OpenAlex 对齐（#639，增量钩子）：缺 OpenAlex id 的记录按 DOI/arXiv 精确、
     # 标题+年份模糊补 id 并回填空元数据。这是真实出网调用，受设置开关控制

--- a/src/backend/tests/test_method_library.py
+++ b/src/backend/tests/test_method_library.py
@@ -1,0 +1,467 @@
+"""方法库 + purpose–mechanism 双索引（#663）：schema 归一化、双轴索引、检索语义、端点。
+
+排序断言全靠 fake provider 的确定性：fake embedding 是词袋哈希向量
+（core/llm/fake.py::fake_embedding），词面重叠 → 余弦相似，测试据此用轴文本的
+用词控制两根轴的远近。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.models.vectors import MethodVector
+from app.services import paper_enrich
+from app.services.extraction.runtime import extract_paper, normalize_payload
+from app.services.extraction.schemas import METHOD_SCHEMA, get_schema, list_schemas
+from app.services.method_index import refresh_paper_method_index, search_methods
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+FULL_TEXT = """Method Probe Paper
+
+Introduction
+
+We probe how the method schema behaves under deterministic extraction.
+
+Method
+
+A deterministic mechanism section with enough prose to look like a paper.
+"""
+
+
+async def _noop_emit(stage, status, detail=None):  # noqa: ARG001
+    return None
+
+
+def _write_fulltext(tmp_path, text=FULL_TEXT):
+    path = tmp_path / f"{uuid.uuid4().hex}.txt"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+async def _method_vectors_of(paper_id):
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(MethodVector).where(MethodVector.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return sorted(r.axis for r in rows)
+
+
+async def _add_method_paper(
+    session, project_id, *, title, purpose, mechanism, tmp_path=None, **payload_extra
+):
+    """建一篇库内（scored）论文 + 手写 method@1 产物 + 刷双轴索引，返回 paper。"""
+    paper = await add_paper(
+        session, project_id=uuid.UUID(project_id), title=title, status="scored"
+    )
+    payload = {"purpose": purpose, **payload_extra}
+    if mechanism is not None:
+        payload["mechanism"] = mechanism
+    session.add(
+        PaperExtraction(paper_id=paper.id, schema_id="method", payload=payload)
+    )
+    await session.commit()
+    await refresh_paper_method_index(session, paper)
+    await session.commit()
+    return paper
+
+
+# ---- 1. schema 注册与归一化 ----
+
+
+def test_method_schema_registered():
+    schema = get_schema("method")
+    assert schema is METHOD_SCHEMA
+    assert schema.version == 1
+    assert schema.stage == "extract_method"
+    assert [f.name for f in schema.fields] == [
+        "purpose",
+        "mechanism",
+        "baseline",
+        "dataset",
+        "protocol",
+    ]
+    assert schema in list_schemas()
+    prompt = schema.system_prompt()
+    assert "POLARIS_EXTRACT_METHOD" in prompt
+    for field in schema.fields:
+        assert f'"{field.name}"' in prompt
+
+
+def test_method_normalize_caps():
+    raw = {
+        "purpose": "目" * 500,  # 超长截断到 400
+        "mechanism": "   ",  # 空白 → 不入 payload
+        "baseline": [f"基线{i}" for i in range(7)],  # 超过 max_items=5 → 截掉
+        "dataset": ["ds-A", "ds-A", ""],  # 去重去空
+        "protocol": "流" * 700,  # 截断到 600
+        "hallucinated": "白名单外的键必须被丢掉",
+    }
+    payload, _ = normalize_payload(METHOD_SCHEMA, raw)
+    assert set(payload) == {"purpose", "baseline", "dataset", "protocol"}
+    assert len(payload["purpose"]) == 400
+    assert len(payload["baseline"]) == 5
+    assert payload["dataset"] == ["ds-A"]
+    assert len(payload["protocol"]) == 600
+
+
+# ---- 2. 运行时：fake provider 确定性 ----
+
+
+async def test_extract_method_deterministic(client, tmp_path):
+    token = await register_and_login(client, email="method@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="method-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Method Probe Paper",
+            abstract="A probe.",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        outcome = await extract_paper(session, paper, schema_id="method")
+        assert outcome.status == "extracted"
+        await session.commit()
+        row = outcome.row
+        assert row.schema_id == "method"
+        # fake provider：purpose 回显标题前半（断言 prompt 里带对了论文）
+        assert "Method Probe" in row.payload["purpose"]
+        assert row.payload["mechanism"]
+        assert len(row.payload["baseline"]) == 1
+        assert len(row.payload["dataset"]) == 1
+        assert row.payload["protocol"]
+        assert row.stage_meta["stage"] == "extract_method"
+        assert row.stage_meta["version"] == 1
+
+
+# ---- 3. 双轴索引写入与幽灵清理 ----
+
+
+async def test_refresh_index_writes_both_axes_and_clears_stale(client):
+    token = await register_and_login(client, email="methodidx@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="methodidx-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await _add_method_paper(
+            session,
+            project_id,
+            title="Dual Axis Paper",
+            purpose="reduce hallucination in language models",
+            mechanism="retrieval augmentation with external memory",
+        )
+        paper_id = paper.id
+    assert await _method_vectors_of(paper_id) == ["mechanism", "purpose"]
+
+    # 重抽把 mechanism 抽没了 → 该轴向量清掉，不留幽灵
+    async with get_sessionmaker()() as session:
+        row = await session.scalar(
+            select(PaperExtraction).where(PaperExtraction.paper_id == paper_id)
+        )
+        row.payload = {"purpose": "reduce hallucination in language models"}
+        await session.commit()
+        paper = await session.get(Paper, paper_id)
+        await refresh_paper_method_index(session, paper)
+        await session.commit()
+    assert await _method_vectors_of(paper_id) == ["purpose"]
+
+
+# ---- 4. 检索语义：same_purpose / different_mechanism ----
+
+
+async def test_search_same_purpose_ranks_by_purpose_axis(client):
+    token = await register_and_login(client, email="methodsearch@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="methodsearch-proj"
+    )
+
+    async with get_sessionmaker()() as session:
+        target = await _add_method_paper(
+            session,
+            project_id,
+            title="Hallucination Paper",
+            purpose="reduce hallucination in large language models",
+            mechanism="retrieval augmentation with external memory",
+        )
+        other = await _add_method_paper(
+            session,
+            project_id,
+            title="Vision Paper",
+            purpose="speed up training of vision transformers",
+            mechanism="sparse attention kernels",
+        )
+        items, mode_used = await search_methods(
+            session, library_id, "reduce hallucination in language models"
+        )
+        assert mode_used == "semantic"
+        assert [c["paper_id"] for c in items] == [target.id, other.id]
+        assert items[0]["similarity"] > items[1]["similarity"]
+        # 卡片带全五元组字段
+        assert items[0]["purpose"] and items[0]["mechanism"]
+        assert "baseline" in items[0] and "dataset" in items[0]
+
+
+async def test_search_different_mechanism_ranks_far_mechanism_first(client):
+    token = await register_and_login(client, email="methodana@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="methodana-proj"
+    )
+
+    query = "reduce hallucination via retrieval augmentation and external memory"
+    async with get_sessionmaker()() as session:
+        same_mech = await _add_method_paper(
+            session,
+            project_id,
+            title="Same Mechanism Paper",
+            purpose="reduce hallucination in language models",
+            mechanism="retrieval augmentation with external memory lookup",
+        )
+        diff_mech = await _add_method_paper(
+            session,
+            project_id,
+            title="Different Mechanism Paper",
+            purpose="reduce hallucination in language models",
+            mechanism="contrastive decoding with token pruning",
+        )
+        # 同目的：same_purpose 下两篇都命中
+        items, _ = await search_methods(session, library_id, query, mode="same_purpose")
+        assert {c["paper_id"] for c in items} == {same_mech.id, diff_mech.id}
+        # 异机制：目的相近的池子里，机制离查询最远的排最前
+        items, mode_used = await search_methods(
+            session, library_id, query, mode="different_mechanism"
+        )
+        assert mode_used == "semantic"
+        assert [c["paper_id"] for c in items] == [diff_mech.id, same_mech.id]
+        assert items[0]["mechanism_similarity"] < items[1]["mechanism_similarity"]
+
+        # 缺机制轴的论文没法排远近：不进 different_mechanism 结果
+        no_mech = await _add_method_paper(
+            session,
+            project_id,
+            title="No Mechanism Paper",
+            purpose="reduce hallucination in language models",
+            mechanism=None,
+        )
+        items, _ = await search_methods(
+            session, library_id, query, mode="different_mechanism"
+        )
+        assert no_mech.id not in {c["paper_id"] for c in items}
+
+
+async def test_search_keyword_fallback_when_embeddings_unavailable(client, monkeypatch):
+    """嵌入不可用时降级为确定性关键词匹配，mode_used 如实上报。"""
+    token = await register_and_login(client, email="methodkw@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="methodkw-proj"
+    )
+
+    async with get_sessionmaker()() as session:
+        hit = await _add_method_paper(
+            session,
+            project_id,
+            title="Keyword Hit Paper",
+            purpose="reduce hallucination in language models",
+            mechanism="retrieval augmentation",
+        )
+        miss = await _add_method_paper(
+            session,
+            project_id,
+            title="Keyword Miss Paper",
+            purpose="speed up vision transformers",
+            mechanism="sparse kernels",
+        )
+
+        async def _raise(*args, **kwargs):
+            raise NotImplementedError("no embedding")
+
+        import app.services.embedding as embedding_service
+
+        monkeypatch.setattr(embedding_service, "embed_query", _raise)
+        items, mode_used = await search_methods(
+            session, library_id, "reduce hallucination language models"
+        )
+        assert mode_used == "keyword"
+        assert [c["paper_id"] for c in items] == [hit.id, miss.id]
+
+
+# ---- 5. 增量钩子：enrich 抽方法卡 + 同步刷索引 ----
+
+
+async def test_enrich_hook_builds_method_index(client, tmp_path):
+    token = await register_and_login(client, email="methodhook@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="methodhook-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Hooked Method Paper",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+        )
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(PaperExtraction).where(PaperExtraction.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert sorted(r.schema_id for r in rows) == ["method", "skeleton"]
+    assert await _method_vectors_of(paper_id) == ["mechanism", "purpose"]
+
+
+async def test_enrich_hook_zero_output_without_fulltext(client):
+    """golden 保全：无全文时方法卡零输出、双轴索引零行（bibtex 导入链路不受影响）。"""
+    token = await register_and_login(client, email="methodhook2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="methodhook2-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Bibtex Method Paper",
+            abstract="No pdf, no full text.",
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async with get_sessionmaker()() as session:
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+        )
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(PaperExtraction).where(PaperExtraction.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+    assert await _method_vectors_of(paper_id) == []
+
+
+# ---- 6. 端点与可见性 ----
+
+
+async def test_methods_endpoints(client):
+    token = await register_and_login(client, email="methodapi@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="methodapi-proj"
+    )
+
+    async with get_sessionmaker()() as session:
+        paper = await _add_method_paper(
+            session,
+            project_id,
+            title="Endpoint Method Paper",
+            purpose="reduce hallucination in language models",
+            mechanism="retrieval augmentation",
+            baseline=["vanilla decoding"],
+            dataset=["truthfulqa"],
+            protocol="run the benchmark three times",
+        )
+        paper_id = str(paper.id)
+
+    # 列表：五元组卡
+    resp = await client.get(f"/api/libraries/{library_id}/methods", headers=headers)
+    assert resp.status_code == 200, resp.text
+    cards = resp.json()
+    assert len(cards) == 1
+    card = cards[0]
+    assert card["paper_id"] == paper_id
+    assert card["title"] == "Endpoint Method Paper"
+    assert card["baseline"] == ["vanilla decoding"]
+    assert card["dataset"] == ["truthfulqa"]
+    assert card["protocol"] == "run the benchmark three times"
+    assert card["similarity"] is None
+
+    # 检索：两种 mode 都通，带相似度
+    for mode in ("same_purpose", "different_mechanism"):
+        resp = await client.get(
+            f"/api/libraries/{library_id}/methods/search",
+            params={"q": "reduce hallucination", "mode": mode},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mode"] == mode
+        assert body["mode_used"] == "semantic"
+        assert [c["paper_id"] for c in body["items"]] == [paper_id]
+        assert body["items"][0]["similarity"] is not None
+
+    # 非法 mode 直接 422
+    resp = await client.get(
+        f"/api/libraries/{library_id}/methods/search",
+        params={"q": "x", "mode": "nope"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    # 未登录不可读
+    anon = await client.get(f"/api/libraries/{library_id}/methods")
+    assert anon.status_code == 401
+    anon = await client.get(
+        f"/api/libraries/{library_id}/methods/search", params={"q": "x"}
+    )
+    assert anon.status_code == 401
+
+
+async def test_methods_endpoints_hidden_for_foreign_personal_library(client):
+    """个人库对外人按不存在处理（404），方法库端点与其余读端点同口径。"""
+    owner_token = await register_and_login(client, email="methodowner@example.com")
+    owner_headers = {"Authorization": f"Bearer {owner_token}"}
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "personal-methods", "statement": "private methods library"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    library_id = resp.json()["id"]
+
+    # 创建者本人可读
+    resp = await client.get(f"/api/libraries/{library_id}/methods", headers=owner_headers)
+    assert resp.status_code == 200
+
+    stranger_token = await register_and_login(client, email="methodstranger@example.com")
+    stranger_headers = {"Authorization": f"Bearer {stranger_token}"}
+    resp = await client.get(f"/api/libraries/{library_id}/methods", headers=stranger_headers)
+    assert resp.status_code == 404
+    resp = await client.get(
+        f"/api/libraries/{library_id}/methods/search",
+        params={"q": "x"},
+        headers=stranger_headers,
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "58b0bc2d809d"  # Paper skeleton extractions (#661)
+HEAD_REVISION = "e867fcbae4ea"  # Method purpose/mechanism vectors (#663)
+EXTRACTIONS_REVISION = "58b0bc2d809d"  # Paper skeleton extractions (#661)
 CITATIONS_REVISION = "57543f6328a1"  # Paper citation edges (#639)
 HYPOTHESIS_TREE_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
 MEMBERS_DROP_REVISION = "b0dd1709e2a1"  # Drop project_members (#625)
@@ -113,6 +114,7 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "concepts",
                     "paper_chunks",
                     "paper_vectors",
+                    "method_vectors",  # head 新增（#663）；downgrade 后不存在，列检查自动跳过
                     "paper_wikis",
                     "library_papers",
                     "daily_feed_entries",
@@ -554,7 +556,21 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "ix_paper_citations_cited_paper_id",
     } <= _index_names(db_path, "paper_citations")
 
-    # 本分支新增：结构化抽取产物表（#661）
+    # 本分支新增：方法卡双轴向量表（#663）
+    assert "method_vectors" in columns["_tables"]
+    assert {
+        "paper_id",
+        "axis",
+        "space",
+        "dim",
+        "embedding",
+        "model",
+        "text_version",
+        "built_at",
+    } <= columns["method_vectors"]
+    assert "ix_method_vectors_space" in _index_names(db_path, "method_vectors")
+
+    # 结构化抽取产物表（#661）
     assert "paper_extractions" in columns["_tables"]
     assert {
         "paper_id",
@@ -567,7 +583,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉抽取产物表（#661）：引文边表不受影响。
+    # 先退掉方法向量表（#663）：抽取产物表不受影响。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == EXTRACTIONS_REVISION
+    assert "method_vectors" not in columns["_tables"]
+    assert "paper_extractions" in columns["_tables"]
+
+    # 再退掉抽取产物表（#661）：引文边表不受影响。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == CITATIONS_REVISION

--- a/src/backend/tests/test_paper_extraction.py
+++ b/src/backend/tests/test_paper_extraction.py
@@ -235,9 +235,11 @@ async def test_enrich_hook_extracts_skeleton(client, tmp_path):
             session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
         )
 
-    rows = await _extraction_rows(paper_id)
-    assert len(rows) == 1
-    assert "Hooked Extraction Paper" in rows[0].payload["problem"]
+    # #663 起钩子把注册表里的每个 schema 都抽一遍：骨架 + 方法卡各一行
+    rows = sorted(await _extraction_rows(paper_id), key=lambda r: r.schema_id)
+    assert [r.schema_id for r in rows] == ["method", "skeleton"]
+    assert "Hooked Extraction Paper" in rows[1].payload["problem"]
+    assert rows[0].payload["purpose"]
 
 
 async def test_enrich_hook_zero_output_without_fulltext(client):

--- a/src/frontend/src/features/wiki/MethodsTab.tsx
+++ b/src/frontend/src/features/wiki/MethodsTab.tsx
@@ -1,0 +1,205 @@
+import { useState, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Segmented } from '../../components/ui/Segmented';
+import { api, type MethodCard, type MethodSearchMode } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   方法库（#663）：库内论文的「做法」视图。
+   每张卡是一篇论文的方法五元组（目的 / 机制 / 基线 / 数据集 / 流程），
+   由后台从全文自动抽取（method@1 schema）。搜索走 purpose–mechanism
+   双轴向量：「找同类做法」= 目的相近；「找异类机制」= 目的相近但
+   换了路子的做法——类比检索，找灵感用。
+   ============================================================ */
+
+/** 卡片里的一段字段：无内容不渲染（后端约定：没抽到就缺键）。 */
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ fontSize: 12, lineHeight: 1.6 }}>
+      <span style={{ color: 'var(--text-4)', fontWeight: 650, marginRight: 6 }}>{label}</span>
+      <span style={{ color: 'var(--text-2)' }}>{children}</span>
+    </div>
+  );
+}
+
+function MethodCardView({
+  card,
+  onOpenPaper,
+}: {
+  card: MethodCard;
+  onOpenPaper: (id: string) => void;
+}) {
+  return (
+    <div
+      className="card"
+      style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}
+    >
+      <div className="row gap8" style={{ minWidth: 0 }}>
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 650,
+            cursor: 'pointer',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+            flex: 1,
+          }}
+          title={`${card.title} · ${tr('点击打开论文', 'click to open paper')}`}
+          onClick={() => onOpenPaper(card.paper_id)}
+        >
+          {card.title}
+        </span>
+        {typeof card.similarity === 'number' && (
+          <span
+            className="mono"
+            style={{ fontSize: 10, color: 'var(--text-4)', flexShrink: 0 }}
+            title={tr('目的相似度', 'purpose similarity')}
+          >
+            {card.similarity.toFixed(2)}
+          </span>
+        )}
+      </div>
+      {card.purpose && <Field label={tr('目的', 'Purpose')}>{card.purpose}</Field>}
+      {card.mechanism && <Field label={tr('机制', 'Mechanism')}>{card.mechanism}</Field>}
+      {card.baseline.length > 0 && (
+        <Field label={tr('基线', 'Baselines')}>{card.baseline.join(tr('；', '; '))}</Field>
+      )}
+      {card.dataset.length > 0 && (
+        <Field label={tr('数据集', 'Datasets')}>{card.dataset.join(tr('；', '; '))}</Field>
+      )}
+      {card.protocol && <Field label={tr('流程', 'Protocol')}>{card.protocol}</Field>}
+    </div>
+  );
+}
+
+export function MethodsTab({
+  libraryId,
+  onOpenPaper,
+}: {
+  libraryId: string;
+  onOpenPaper: (id: string) => void;
+}) {
+  const [input, setInput] = useState('');
+  const [query, setQuery] = useState('');
+  const [mode, setMode] = useState<MethodSearchMode>('same_purpose');
+
+  const listQuery = useQuery({
+    queryKey: ['library-methods', libraryId],
+    queryFn: () => api.listLibraryMethods(libraryId),
+    enabled: !query,
+    retry: false,
+  });
+  const searchQuery = useQuery({
+    queryKey: ['library-methods-search', libraryId, query, mode],
+    queryFn: () => api.searchLibraryMethods(libraryId, { q: query, mode }),
+    enabled: !!query,
+    retry: false,
+  });
+
+  const searching = !!query;
+  const cards = searching ? (searchQuery.data?.items ?? []) : (listQuery.data ?? []);
+  const loading = searching ? searchQuery.isLoading : listQuery.isLoading;
+  const error = searching ? searchQuery.isError : listQuery.isError;
+
+  const submit = () => setQuery(input.trim());
+
+  return (
+    <div className="col" style={{ flex: 1, minHeight: 0, padding: 16, gap: 12, overflowY: 'auto' }}>
+      <div className="row gap8" style={{ alignItems: 'stretch', flexWrap: 'wrap' }}>
+        <input
+          className="input"
+          style={{ flex: 1, minWidth: 220 }}
+          value={input}
+          placeholder={tr(
+            '描述你想达成的目标，找库里论文的做法…',
+            'Describe the goal; find how papers in this library approach it…',
+          )}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit();
+          }}
+        />
+        <Segmented<MethodSearchMode>
+          options={[
+            { v: 'same_purpose', label: tr('找同类做法', 'Similar approaches') },
+            { v: 'different_mechanism', label: tr('找异类机制', 'Different mechanisms') },
+          ]}
+          value={mode}
+          onChange={setMode}
+        />
+        <button className="btn btn-primary sm" disabled={!input.trim()} onClick={submit}>
+          {tr('搜方法', 'Search')}
+        </button>
+        {searching && (
+          <button
+            className="btn btn-ghost sm"
+            onClick={() => {
+              setQuery('');
+              setInput('');
+            }}
+          >
+            {tr('清空', 'Clear')}
+          </button>
+        )}
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-4)' }}>
+        {mode === 'same_purpose'
+          ? tr(
+              '找同类做法：按「要达成什么」找目的相近的论文。',
+              'Similar approaches: papers whose purpose is closest to your goal.',
+            )
+          : tr(
+              '找异类机制：目的和你相近、但用了不同思路的论文排在前面——找灵感用。',
+              'Different mechanisms: papers with a similar purpose but a different approach come first.',
+            )}
+        {searching && searchQuery.data?.mode_used === 'keyword' && (
+          <span style={{ marginLeft: 6 }}>
+            {tr('（语义检索暂不可用，已按关键词匹配）', '(semantic search unavailable; matched by keywords)')}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="card" style={{ padding: 12, color: 'var(--danger-tx, #c00)', fontSize: 12 }}>
+          {tr('加载方法库失败（后端不可用）', 'Failed to load the method library (backend unavailable)')}
+        </div>
+      )}
+      {loading && <div className="skel" style={{ height: 120 }} />}
+
+      {!loading && !error && cards.length === 0 && (
+        <EmptyState
+          icon="layers"
+          title={
+            searching
+              ? tr('没有匹配的方法卡', 'No matching method cards')
+              : tr('还没有方法卡', 'No method cards yet')
+          }
+          desc={
+            searching
+              ? tr('换个说法描述目标试试。', 'Try describing the goal differently.')
+              : tr(
+                  '论文全文就位后会自动抽出方法卡（目的 / 机制 / 基线 / 数据集 / 流程）。',
+                  'Method cards (purpose / mechanism / baselines / datasets / protocol) are extracted automatically once full text is available.',
+                )
+          }
+        />
+      )}
+
+      {cards.length > 0 && (
+        <div className="col" style={{ gap: 10 }}>
+          {!searching && (
+            <span className="mono" style={{ fontSize: 10, color: 'var(--text-4)' }}>
+              {tr(`方法卡 · ${cards.length} 张`, `Method cards · ${cards.length}`)}
+            </span>
+          )}
+          {cards.map((card) => (
+            <MethodCardView key={card.paper_id} card={card} onOpenPaper={onOpenPaper} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -13,6 +13,7 @@ import { LibraryChatTab } from './LibraryChatTab';
 import { LibraryQaTab } from './LibraryQaTab';
 import { IngestTab } from './IngestTab';
 import { NotesTab } from './NotesTab';
+import { MethodsTab } from './MethodsTab';
 import { GovernanceTab } from './GovernanceTab';
 import { LiteratureDiscoveryPanel } from '../libraries/LiteratureDiscoveryPage';
 
@@ -33,7 +34,7 @@ const PresentationModal = lazy(() =>
    从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
-type WikiTab = 'discover' | 'papers' | 'concepts' | 'graph' | 'digest' | 'chat' | 'qa' | 'ingest' | 'notes' | 'govern';
+type WikiTab = 'discover' | 'papers' | 'concepts' | 'methods' | 'graph' | 'digest' | 'chat' | 'qa' | 'ingest' | 'notes' | 'govern';
 
 export function WikiWorkbench({
   pid,
@@ -103,7 +104,7 @@ export function WikiWorkbench({
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['discover', 'papers', 'concepts', 'graph', 'digest', 'chat', 'qa', 'ingest', 'notes', 'govern'].includes(tabParam)) {
+    } else if (tabParam && ['discover', 'papers', 'concepts', 'methods', 'graph', 'digest', 'chat', 'qa', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -169,6 +170,8 @@ export function WikiWorkbench({
             ...(libraryId ? [{ v: 'discover' as const, label: tr('发现文献', 'Discover') }] : []),
             { v: 'papers', label: `${tr('论文库', 'Papers')}${total !== undefined ? ` · ${total}` : ''}` },
             { v: 'concepts', label: tr('概念库', 'Concepts') },
+            // 方法库走 /libraries/{id}/methods，只有库作用域有这个端点
+            ...(libraryId ? [{ v: 'methods' as const, label: tr('方法库', 'Methods') }] : []),
             { v: 'graph', label: tr('图谱', 'Graph') },
             ...(libraryId ? [{ v: 'digest' as const, label: tr('每日简报', 'Daily digest') }] : []),
             { v: 'chat', label: tr('文献对话', 'Chat') },
@@ -245,6 +248,8 @@ export function WikiWorkbench({
             onOpenPaper={goPaper}
             onWikiLink={onWikiLink}
           />
+        ) : tab === 'methods' && libraryId ? (
+          <MethodsTab libraryId={libraryId} onOpenPaper={goPaper} />
         ) : tab === 'graph' ? (
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
             <GraphTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -671,6 +671,7 @@ export const LLM_STAGES = [
   'review',
   'citation_intent',
   'extract_skeleton',
+  'extract_method',
   'rag_expand',
   'rag_rerank',
   'rag_answer',
@@ -1675,6 +1676,32 @@ export interface LibraryQaResponse {
   evidence: LibraryQaEvidence[];
   /** 实际执行过的检索查询（小库直通时为空） */
   queries: string[];
+}
+
+// —— 方法库（#663）：purpose–mechanism 双索引 ——
+
+export type MethodSearchMode = 'same_purpose' | 'different_mechanism';
+
+/** 一张方法卡：method@1 抽取产物的五元组 + 检索时的双轴相似度。 */
+export interface MethodCard {
+  paper_id: string;
+  title: string;
+  purpose: string | null;
+  mechanism: string | null;
+  baseline: string[];
+  dataset: string[];
+  protocol: string | null;
+  /** purpose 轴与查询的相似度（列表视图为 null） */
+  similarity: number | null;
+  /** mechanism 轴与查询的相似度（「找异类机制」下越低排得越前） */
+  mechanism_similarity: number | null;
+}
+
+export interface MethodSearchResponse {
+  items: MethodCard[];
+  mode: MethodSearchMode | string;
+  /** semantic = 双轴向量检索；keyword = 嵌入不可用时的确定性关键词降级 */
+  mode_used: 'semantic' | 'keyword' | string;
 }
 
 /** 异步建索引端点（相关研究 / 个人库）的返回：入队总数 + 有全文可索引 / 无全文跳过 篇数。 */
@@ -4145,6 +4172,25 @@ export const api = {
     if (opts.mode) params.set('mode', opts.mode);
     if (opts.limit) params.set('limit', String(opts.limit));
     return request<SearchResult>(`/libraries/${id}/search?${params.toString()}`);
+  },
+
+  // —— 方法库（#663）：purpose–mechanism 双索引 ——
+  /** 方法库列表：库内已抽出方法卡的论文（五元组卡）。 */
+  listLibraryMethods(id: string, opts: { limit?: number } = {}): Promise<MethodCard[]> {
+    const params = new URLSearchParams();
+    if (opts.limit) params.set('limit', String(opts.limit));
+    const qs = params.toString();
+    return request<MethodCard[]>(`/libraries/${id}/methods${qs ? `?${qs}` : ''}`);
+  },
+  /** 方法检索：same_purpose 找同类做法；different_mechanism 找「目的相近、机制不同」。 */
+  searchLibraryMethods(
+    id: string,
+    opts: { q: string; mode?: MethodSearchMode; limit?: number },
+  ): Promise<MethodSearchResponse> {
+    const params = new URLSearchParams({ q: opts.q });
+    if (opts.mode) params.set('mode', opts.mode);
+    if (opts.limit) params.set('limit', String(opts.limit));
+    return request<MethodSearchResponse>(`/libraries/${id}/methods/search?${params.toString()}`);
   },
 
   // —— P9d · 独立库文献管理台（镜像 project 作用域的集合端点） ——

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -30,6 +30,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   review: { zh: '论文评审', en: 'Paper review' },
   citation_intent: { zh: '引文意图分类', en: 'Citation intent classification' },
   extract_skeleton: { zh: '结构化摘要抽取', en: 'Structured summary extraction' },
+  extract_method: { zh: '方法卡抽取', en: 'Method card extraction' },
   rag_expand: { zh: '库问答·查询扩展', en: 'Library Q&A · query expansion' },
   rag_rerank: { zh: '库问答·重排摘要', en: 'Library Q&A · rerank & summarize' },
   rag_answer: { zh: '库问答·作答', en: 'Library Q&A · answering' },


### PR DESCRIPTION
Closes #663. Part of #660 (P2.5 wave 2, item F2); design report §11 fuel 3.

The library becomes a cross-domain analogy engine: per-paper method five-tuples with a purpose–mechanism dual embedding index and "same purpose / different mechanism" retrieval.

- `method@1` registers as the second built-in extraction schema (purpose/mechanism text, baseline/dataset lists, protocol) — the first real consumer of the registry seam; the enrich hook now iterates all registered schemas and the backfill CLI defaults to all
- new `method_vectors` table (migration `e867fcbae4ea`): one row per paper+axis+space — a paper holds vectors on both axes, so axis belongs in the key rather than polluting the existing single-key vector tables; column conventions match the existing vector side-tables, and upserts reuse the real UPSERT path
- `search_methods`: `same_purpose` ranks by purpose-axis cosine; `different_mechanism` takes the purpose-neighbor pool and sorts by mechanism-axis similarity *ascending* — closest goal, farthest mechanism first; papers without a mechanism vector are honestly excluded; when embeddings are unavailable the service degrades to deterministic keyword matching and reports `mode_used`
- incremental: index refresh rides the extraction upsert, and a re-extraction that loses an axis clears the stale vector instead of leaving a ghost
- endpoints on the library (visibility-gated) plus a "Methods" tab on the library workbench: five-tuple cards, search, and a plain-language mode toggle

Verification: clean baseline 1541 collected (4 failed: the 2 deterministic #581 legacies + 2 load-flakes green standalone); branch 1552 = baseline + exactly the 11 new tests, 5 failed = the same 4 + one known tournament flake (green standalone and on file re-run) — zero new real failures. Migration roundtrip, goldens, frontend tsc/vitest 150/build all green.