### PR TITLE
feat: concept co-occurrence and unconnected-pair fuels

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -32,7 +32,7 @@ from app.core.redis import get_redis_dep
 from app.models.library_direction import DirectionLibrary, LibraryPaper
 from app.models.project import Project
 from app.models.user import User
-from app.schemas.graph import GraphResponse
+from app.schemas.graph import GraphResponse, UnconnectedConceptPair
 from app.schemas.ingest import DigestGenerateRead, IngestRequest, IngestStateRead
 from app.schemas.libraries import (
     DirectionLibraryDetail,
@@ -73,6 +73,7 @@ from app.schemas.paper import (
 from app.schemas.voyage import VoyageRead
 from app.services import chunks as chunks_service
 from app.services import citations as citations_service
+from app.services import concept_fuels as concept_fuels_service
 from app.services import concepts as concepts_service
 from app.services import graph as graph_service
 from app.services import ingest as ingest_service
@@ -1061,6 +1062,25 @@ async def library_graph(
     library = await _get_visible_library(session, library_id, user)
     data = await graph_service.library_graph(session, library_id=library.id)
     return GraphResponse(**data)
+
+
+@router.get("/libraries/{library_id}/concept-pairs", response_model=list[UnconnectedConceptPair])
+async def list_library_concept_pairs(
+    library_id: uuid.UUID,
+    top: int = Query(default=50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[UnconnectedConceptPair]:
+    """未连接概念对（P2.5 F3，Swanson ABC）：库里「可能有关联但还没人一起研究」的概念组合。
+
+    确定性挖掘（不走 LLM），随读即时计算——数据永远反映当前概念上链结果；
+    鉴权与图谱同口径（按库可见性可读）。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    pairs = await concept_fuels_service.mine_unconnected_pairs(
+        session, library_id=library.id, top_n=top
+    )
+    return [UnconnectedConceptPair(**pair) for pair in pairs]
 
 
 @router.get("/libraries/{library_id}/notes", response_model=NotebookPage)

--- a/src/backend/app/schemas/graph.py
+++ b/src/backend/app/schemas/graph.py
@@ -32,3 +32,26 @@ class GraphResponse(BaseModel):
     edges: list[GraphEdge]
     paper_total: int  # 项目内符合条件的论文总数
     truncated: bool  # 超出上限被截断（按相关度保留 top N）
+
+
+# —— 未连接概念对（P2.5 F3，Swanson ABC；服务见 services/concept_fuels.py） ——
+
+
+class ConceptPairNode(BaseModel):
+    """候选对 / 桥概念的最小引用（uuid 字符串 + 名字，点击跳概念详情够用）。"""
+
+    id: str
+    name: str
+
+
+class ConceptPairBridge(ConceptPairNode):
+    strength: int  # 该桥的 min(w(A,B), w(B,C))
+
+
+class UnconnectedConceptPair(BaseModel):
+    """A–C 从未同篇出现、但经共同邻居相连的概念对；strength = Σ_B min(w(A,B), w(B,C))。"""
+
+    concept_a: ConceptPairNode
+    concept_c: ConceptPairNode  # 规范序：concept_a.id < concept_c.id
+    strength: int
+    bridges: list[ConceptPairBridge]  # 最强的 ≤5 个桥概念，按强度降序

--- a/src/backend/app/services/concept_fuels.py
+++ b/src/backend/app/services/concept_fuels.py
@@ -1,0 +1,147 @@
+"""概念燃料（P2.5 F3，#664；设计报告 §11 燃料 1）：库内概念共现 + 未连接概念对挖掘。
+
+纯确定性计算，不走 LLM。共现口径：两个**正式**概念（active，候选不算——与概念列表 /
+图谱同一收口）关联到同一篇库内论文记 1 次共现，边权 = 这样的论文数；论文范围与图谱一致
+（:data:`app.services.graph.GRAPH_PAPER_STATUSES`）——回收站 / 未过筛选的论文不供燃料。
+
+为什么**不物化**（不建 concept_cooccurrence 表）：实测 dev 库最大 163 个概念 /
+~1.3k 个共现对实例（每篇平均 3–6 个概念），整库共现即时聚合是一次带索引的 join +
+Python 分组，毫秒级；即使规模涨两个数量级也在亚秒内。物化要换来的只是省这一次聚合，
+代价却是迁移（与并行 F2/F4 撞链）+ 增量刷新钩子 + 陈旧数据对账三件事。即时算读路径
+永远反映当前 paper_concepts——正确性由构造保证，没有「落后于库内容变更」的状态。
+若未来出现万级概念的库，再把本模块的聚合结果落表即可（接口不变）。
+
+未连接对（Swanson ABC）：A–B 与 B–C 有共现而 A–C 从未共现 → 候选 (A, C)。
+bridge 强度取 Σ_B min(w(A,B), w(B,C))——每条桥的贡献受两侧较弱一边限制（一侧只共现
+过 1 次的桥再多也只算 1），可逐桥拆开解释，且不像乘积那样被单个高频概念抬爆。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import LibraryPaper
+from app.models.paper import CONCEPT_STATUS_ACTIVE, Concept, paper_concepts
+from app.services.graph import GRAPH_PAPER_STATUSES
+
+# 防爆阈值：库内正式概念超过这个数时，只保留度数（共现邻居数）top 席位再挖掘。
+# 挖掘是 Σ_B deg(B)² 的（对每个桥概念枚举其邻居两两组合），概念数封顶后总工作量
+# 上界 ~2·n·E，n=2000 时最坏也在秒级；实测库在 10² 量级，远够不到这里。
+COOCCURRENCE_MAX_CONCEPTS = 2000
+# 每个候选对最多附带的桥概念数（按强度取最强的几条，够解释即可）
+MAX_BRIDGES_PER_PAIR = 5
+
+
+async def library_cooccurrence(
+    session: AsyncSession, *, library_id: uuid.UUID
+) -> tuple[dict[uuid.UUID, str], dict[uuid.UUID, dict[uuid.UUID, int]]]:
+    """库内概念共现图：返回 (概念 id→名字, 邻接表 adj[a][b] = 共现论文数)。
+
+    邻接表对称（a∈adj[b] ⇔ b∈adj[a]）；孤立概念（库内没与任何概念同篇出现过的）
+    不出现在邻接表里——它们既当不了桥也构不成候选对。
+    """
+    rows = (
+        await session.execute(
+            select(paper_concepts.c.paper_id, Concept.id, Concept.name)
+            .join(Concept, Concept.id == paper_concepts.c.concept_id)
+            .join(LibraryPaper, LibraryPaper.paper_id == paper_concepts.c.paper_id)
+            .where(
+                LibraryPaper.library_id == library_id,
+                LibraryPaper.status.in_(GRAPH_PAPER_STATUSES),
+                Concept.status == CONCEPT_STATUS_ACTIVE,
+            )
+        )
+    ).all()
+    names: dict[uuid.UUID, str] = {}
+    by_paper: dict[uuid.UUID, list[uuid.UUID]] = {}
+    for paper_id, concept_id, name in rows:
+        names[concept_id] = name
+        by_paper.setdefault(paper_id, []).append(concept_id)
+
+    adj: dict[uuid.UUID, dict[uuid.UUID, int]] = {}
+    for concept_ids in by_paper.values():
+        # 同一篇论文的概念两两共现一次（paper_concepts 有唯一约束，无重复行）
+        ordered = sorted(set(concept_ids))
+        for i, a in enumerate(ordered):
+            for b in ordered[i + 1 :]:
+                adj.setdefault(a, {})[b] = adj.get(a, {}).get(b, 0) + 1
+                adj.setdefault(b, {})[a] = adj[a][b]
+    return names, adj
+
+
+def _prune_to_top_degree(
+    adj: dict[uuid.UUID, dict[uuid.UUID, int]],
+    names: dict[uuid.UUID, str],
+    cap: int,
+) -> dict[uuid.UUID, dict[uuid.UUID, int]]:
+    """防爆：概念数超过 ``cap`` 时只保留度数 top 席位，边随之收缩到保留集内。
+
+    为什么按度数取：挖掘的工作量集中在高度数桥概念上，且低度数概念既提供不了几条桥、
+    也几乎构不成有分量的候选对——裁掉它们对 top 结果影响最小。并列时按共现总权重、
+    再按名字取，保证结果确定。
+    """
+    if len(adj) <= cap:
+        return adj
+    kept = set(
+        sorted(
+            adj,
+            key=lambda cid: (-len(adj[cid]), -sum(adj[cid].values()), names.get(cid, ""), cid),
+        )[:cap]
+    )
+    return {a: {b: w for b, w in nbrs.items() if b in kept} for a, nbrs in adj.items() if a in kept}
+
+
+async def mine_unconnected_pairs(
+    session: AsyncSession, *, library_id: uuid.UUID, top_n: int = 50
+) -> list[dict[str, Any]]:
+    """挖掘库内「可能有关联但从未同篇出现」的概念对（Swanson ABC 候选）。
+
+    返回按强度降序的 top_n 个候选对，每个形如::
+
+        {"concept_a": {"id", "name"}, "concept_c": {"id", "name"},
+         "strength": int, "bridges": [{"id", "name", "strength"}, ...]}
+
+    concept_a / concept_c 取规范序（a < c，按 uuid）；bridges 为最强的
+    ≤ :data:`MAX_BRIDGES_PER_PAIR` 个桥概念，strength 为该桥的 min(w(A,B), w(B,C))。
+    排序全程确定：总强度并列时按（名字序的）概念名对排。
+    """
+    names, adj = await library_cooccurrence(session, library_id=library_id)
+    adj = _prune_to_top_degree(adj, names, COOCCURRENCE_MAX_CONCEPTS)
+
+    strength: dict[tuple[uuid.UUID, uuid.UUID], int] = {}
+    bridges: dict[tuple[uuid.UUID, uuid.UUID], list[tuple[int, uuid.UUID]]] = {}
+    for b, nbrs in adj.items():
+        neighbors = sorted(nbrs)  # 排过序，枚举出的 (a, c) 天然满足规范序 a < c
+        for i, a in enumerate(neighbors):
+            a_nbrs = adj[a]
+            for c in neighbors[i + 1 :]:
+                if c in a_nbrs:
+                    continue  # A–C 已经共现过，不是「未连接」候选
+                w = min(nbrs[a], nbrs[c])
+                key = (a, c)
+                strength[key] = strength.get(key, 0) + w
+                bridges.setdefault(key, []).append((w, b))
+
+    # 并列强度按「名字序的概念名对」定序：不依赖随机 uuid，跑多少遍结果都一样
+    ranked = sorted(
+        strength.items(),
+        key=lambda kv: (-kv[1], tuple(sorted((names[kv[0][0]], names[kv[0][1]])))),
+    )[: max(top_n, 0)]
+
+    out: list[dict[str, Any]] = []
+    for (a, c), total in ranked:
+        top_bridges = sorted(bridges[(a, c)], key=lambda wb: (-wb[0], names[wb[1]], wb[1]))
+        out.append(
+            {
+                "concept_a": {"id": str(a), "name": names[a]},
+                "concept_c": {"id": str(c), "name": names[c]},
+                "strength": total,
+                "bridges": [
+                    {"id": str(b), "name": names[b], "strength": w}
+                    for w, b in top_bridges[:MAX_BRIDGES_PER_PAIR]
+                ],
+            }
+        )
+    return out

--- a/src/backend/tests/test_concept_fuels.py
+++ b/src/backend/tests/test_concept_fuels.py
@@ -1,0 +1,235 @@
+"""概念燃料（P2.5 F3，#664）：共现挖掘 mine_unconnected_pairs 与 concept-pairs 端点。
+
+小图夹具（权重 = 共现论文数）：
+
+    alpha ──2── bridge-one ──2── gamma
+    alpha ──1── bridge-two ──1── gamma
+                bridge-two ──1── delta ──1── gamma
+
+alpha–gamma 从未同篇出现 → 是最强候选：Σ min = min(2,2) + min(1,1) = 3。
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.library_direction import DirectionLibrary
+from app.models.user import User
+from app.services import concept_fuels
+
+from .conftest import add_concept, add_paper, make_project_with_library, register_and_login
+
+# 期望的完整挖掘结果：(概念名对, 总强度, [(桥名, 桥强度), ...])，按总强度降序
+EXPECTED = [
+    (("alpha", "gamma"), 3, [("bridge-one", 2), ("bridge-two", 1)]),
+    (("bridge-one", "bridge-two"), 2, [("alpha", 1), ("gamma", 1)]),
+    (("alpha", "delta"), 1, [("bridge-two", 1)]),
+    (("bridge-one", "delta"), 1, [("gamma", 1)]),
+]
+
+
+async def _setup(client):
+    """建库并造出模块 docstring 里的小图，返回 (headers, library_id)。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="fuel-proj")
+    pid = uuid.UUID(project_id)
+
+    async with get_sessionmaker()() as session:
+        names = ["alpha", "bridge-one", "bridge-two", "gamma", "delta"]
+        c = {}
+        for name in names:
+            c[name] = await add_concept(session, project_id=pid, name=name, slug=f"s-{name}")
+        # 候选概念（还没转正）不参与挖掘
+        cand = await add_concept(
+            session, project_id=pid, name="cand-x", slug="s-cand-x", status="candidate"
+        )
+        groups = [
+            ["alpha", "bridge-one"],
+            ["alpha", "bridge-one"],
+            ["bridge-one", "gamma"],
+            ["bridge-one", "gamma"],
+            ["alpha", "bridge-two"],
+            ["bridge-two", "gamma", "delta"],
+        ]
+        for i, group in enumerate(groups):
+            await add_paper(
+                session,
+                project_id=pid,
+                title=f"P{i}",
+                status="included",
+                concepts=[c[n] for n in group],
+            )
+        # 未过筛选的论文（默认 status=candidate）不算共现：alpha–gamma 必须仍是未连接对
+        await add_paper(
+            session, project_id=pid, title="unscored", concepts=[c["alpha"], c["gamma"]]
+        )
+        # 候选概念同篇也不进图
+        await add_paper(
+            session,
+            project_id=pid,
+            title="with-cand",
+            status="included",
+            concepts=[c["alpha"], cand],
+        )
+        await session.commit()
+    return headers, library_id
+
+
+def _shape(pairs):
+    """把服务返回压成 EXPECTED 的形状，便于整表断言。
+
+    对内的名字按字典序放（展示序是 uuid 规范序，随机 uuid 下两种都可能），
+    EXPECTED 里的名字对也都写成字典序。"""
+    return [
+        (
+            tuple(sorted((p["concept_a"]["name"], p["concept_c"]["name"]))),
+            p["strength"],
+            [(b["name"], b["strength"]) for b in p["bridges"]],
+        )
+        for p in pairs
+    ]
+
+
+async def test_mine_unconnected_pairs_exact(client):
+    _headers, library_id = await _setup(client)
+    async with get_sessionmaker()() as session:
+        pairs = await concept_fuels.mine_unconnected_pairs(session, library_id=library_id)
+
+    assert _shape(pairs) == EXPECTED
+    # 规范序：concept_a.id < concept_c.id（uuid 字符串序 == uuid 数值序）
+    for p in pairs:
+        assert p["concept_a"]["id"] < p["concept_c"]["id"]
+    # 候选概念不出现在任何位置
+    all_names = {
+        n
+        for p in pairs
+        for n in (
+            p["concept_a"]["name"],
+            p["concept_c"]["name"],
+            *[b["name"] for b in p["bridges"]],
+        )
+    }
+    assert "cand-x" not in all_names
+
+
+async def test_other_library_cooccurrence_does_not_leak(client):
+    # 同两个概念在别的库共现，不影响本库的「从未共现」判定（共现是库维度的）
+    headers, library_id = await _setup(client)
+    project2, _lib2 = await make_project_with_library(client, headers, name="fuel-proj-2")
+    pid2 = uuid.UUID(project2)
+    async with get_sessionmaker()() as session:
+        rows = await concept_fuels.library_cooccurrence(session, library_id=library_id)
+        names = set(rows[0].values())
+        assert names == {"alpha", "bridge-one", "bridge-two", "gamma", "delta"}
+        # 在库 2 里让 alpha 与 gamma 同篇出现
+        from app.models.paper import Concept
+
+        c = {
+            concept.name: concept
+            for concept in (
+                (await session.execute(select(Concept).where(Concept.name.in_(["alpha", "gamma"]))))
+                .scalars()
+                .all()
+            )
+        }
+        await add_paper(
+            session,
+            project_id=pid2,
+            title="elsewhere",
+            status="included",
+            concepts=[c["alpha"], c["gamma"]],
+        )
+        await session.commit()
+        pairs = await concept_fuels.mine_unconnected_pairs(session, library_id=library_id)
+    assert _shape(pairs)[0] == EXPECTED[0]  # (alpha, gamma) 仍是本库的未连接对
+
+
+async def test_top_n_truncates(client):
+    _headers, library_id = await _setup(client)
+    async with get_sessionmaker()() as session:
+        pairs = await concept_fuels.mine_unconnected_pairs(session, library_id=library_id, top_n=2)
+    assert _shape(pairs) == EXPECTED[:2]
+
+
+async def test_bridges_capped_at_five(client):
+    # 6 条桥都成立时只保留最强的 5 条（总强度仍算全部桥）
+    token = await register_and_login(client, email="cap@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="cap-proj")
+    pid = uuid.UUID(project_id)
+    async with get_sessionmaker()() as session:
+        a = await add_concept(session, project_id=pid, name="left", slug="s-left")
+        cc = await add_concept(session, project_id=pid, name="right", slug="s-right")
+        for i in range(6):
+            b = await add_concept(session, project_id=pid, name=f"mid-{i}", slug=f"s-mid-{i}")
+            for pair in ([a, b], [b, cc]):
+                await add_paper(
+                    session,
+                    project_id=pid,
+                    title=f"p-{i}-{pair[0].name}",
+                    status="included",
+                    concepts=pair,
+                )
+        await session.commit()
+        pairs = await concept_fuels.mine_unconnected_pairs(session, library_id=library_id)
+    (pair,) = [
+        p for p in pairs if {p["concept_a"]["name"], p["concept_c"]["name"]} == {"left", "right"}
+    ]
+    assert pair["strength"] == 6
+    assert len(pair["bridges"]) == concept_fuels.MAX_BRIDGES_PER_PAIR
+    assert [b["name"] for b in pair["bridges"]] == [f"mid-{i}" for i in range(5)]  # 并列按名字
+
+
+async def test_prune_branch_keeps_top_degree(client, monkeypatch):
+    # 概念数超阈值走防爆分支：按度数（并列按共现总权重）保留 top 4 → delta 被裁掉
+    _headers, library_id = await _setup(client)
+    monkeypatch.setattr(concept_fuels, "COOCCURRENCE_MAX_CONCEPTS", 4)
+    async with get_sessionmaker()() as session:
+        pairs = await concept_fuels.mine_unconnected_pairs(session, library_id=library_id)
+    assert _shape(pairs) == [
+        (("alpha", "gamma"), 3, [("bridge-one", 2), ("bridge-two", 1)]),
+        (("bridge-one", "bridge-two"), 2, [("alpha", 1), ("gamma", 1)]),
+    ]
+
+
+async def test_concept_pairs_endpoint(client):
+    headers, library_id = await _setup(client)
+    resp = await client.get(f"/api/libraries/{library_id}/concept-pairs?top=1", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    pair = body[0]
+    assert {pair["concept_a"]["name"], pair["concept_c"]["name"]} == {"alpha", "gamma"}
+    assert pair["strength"] == 3
+    assert [(b["name"], b["strength"]) for b in pair["bridges"]] == [
+        ("bridge-one", 2),
+        ("bridge-two", 1),
+    ]
+
+
+async def test_concept_pairs_personal_library_hidden(client):
+    # 个人库仅创建者可见：陌生人访问按 404（与其他只读端点同口径）
+    token_owner = await register_and_login(client, email="owner@example.com")
+    owner_headers = {"Authorization": f"Bearer {token_owner}"}
+    async with get_sessionmaker()() as session:
+        owner = (
+            await session.execute(select(User).where(User.email == "owner@example.com"))
+        ).scalar_one()
+        library = DirectionLibrary(
+            name="private-lib", is_public=False, submitted_by=owner.id, created_by=owner.id
+        )
+        session.add(library)
+        await session.commit()
+        library_id = library.id
+
+    token_other = await register_and_login(client, email="other@example.com")
+    resp = await client.get(
+        f"/api/libraries/{library_id}/concept-pairs",
+        headers={"Authorization": f"Bearer {token_other}"},
+    )
+    assert resp.status_code == 404
+    resp = await client.get(f"/api/libraries/{library_id}/concept-pairs", headers=owner_headers)
+    assert resp.status_code == 200
+    assert resp.json() == []  # 空库 → 空结果而不是报错

--- a/src/frontend/src/features/wiki/ConceptsTab.tsx
+++ b/src/frontend/src/features/wiki/ConceptsTab.tsx
@@ -4,7 +4,7 @@ import { Icon } from '../../components/ui/Icon';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { Markdown, type WikiLinkHandler } from '../../lib/markdown';
-import { api, type ConceptCategory, type ConceptRead } from '../../lib/api';
+import { api, type ConceptCategory, type ConceptRead, type UnconnectedConceptPair } from '../../lib/api';
 import { clickable } from '../../lib/a11y';
 import { tr } from '../../lib/i18n';
 import { categoryMeta, CONCEPT_CATEGORY, SearchInput, Section, useDebounced } from './shared';
@@ -79,6 +79,97 @@ function ConceptRow({ c, active, onClick }: { c: ConceptRead; active: boolean; o
           }}
         >
           {c.definition}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 未连接概念对面板（P2.5 F3）：占用右侧详情区，列出「可能有关联但还没人
+    一起研究」的概念组合与牵线的桥概念；点任一概念名跳回该概念详情。 */
+function ConceptPairsPane({
+  libraryId,
+  onOpenConcept,
+  onClose,
+}: {
+  libraryId: string;
+  onOpenConcept: (id: string) => void;
+  onClose: () => void;
+}) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['lib-concept-pairs', libraryId],
+    queryFn: () => api.listLibraryConceptPairs(libraryId),
+    retry: false,
+  });
+  const pairs: UnconnectedConceptPair[] = data ?? [];
+
+  return (
+    <div className="scroll fadeup" style={{ overflowY: 'auto', flex: 1, padding: '26px 32px 60px' }}>
+      <div className="row gap8" style={{ marginBottom: 6 }}>
+        <Icon name="sparkle" size={16} style={{ color: 'var(--accent)' }} />
+        <h1 style={{ fontSize: 18, fontWeight: 680, margin: 0, letterSpacing: '-0.01em', flex: 1 }}>
+          {tr('未连接概念对', 'Unconnected concept pairs')}
+        </h1>
+        <button className="icon-btn" style={{ width: 26, height: 26, borderRadius: 7 }} onClick={onClose}
+          title={tr('返回概念详情', 'Back to concept detail')}>
+          <Icon name="x" size={13} />
+        </button>
+      </div>
+      <p className="muted" style={{ fontSize: 12.5, lineHeight: 1.6, margin: '0 0 18px' }}>
+        {tr(
+          '这些概念组合可能有关联但还没人一起研究：两个概念各自都和同一些「桥」概念一起出现过，但它们俩从没出现在同一篇论文里。分数越高，值得一看的可能性越大。',
+          'Concept combinations that may be related but unexplored: both co-occur with the same “bridge” concepts, yet never appear together in one paper. Higher scores are more promising.',
+        )}
+      </p>
+
+      {isLoading ? (
+        <div className="empty">{tr('挖掘概念对…', 'Mining concept pairs…')}</div>
+      ) : isError ? (
+        <EmptyState
+          compact
+          icon="x"
+          title={tr('无法加载概念对', 'Failed to load concept pairs')}
+          desc={tr('后端不可用，稍后重试。', 'Backend unavailable — try again later.')}
+        />
+      ) : pairs.length === 0 ? (
+        <EmptyState
+          compact
+          icon="layers"
+          title={tr('还挖不出概念对', 'No pairs to mine yet')}
+          desc={tr(
+            '概念多起来之后（多篇论文、多个共同话题）这里才会有结果。',
+            'Results appear once the library has more concepts appearing across papers.',
+          )}
+        />
+      ) : (
+        <div className="col gap8">
+          {pairs.map((p) => (
+            <div key={`${p.concept_a.id}-${p.concept_c.id}`} className="card" style={{ padding: '12px 14px' }}>
+              <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+                <span className="wikilink" style={{ fontWeight: 650 }} {...clickable(() => onOpenConcept(p.concept_a.id))}>
+                  {p.concept_a.name}
+                </span>
+                <Icon name="link" size={12} style={{ color: 'var(--text-4)' }} />
+                <span className="wikilink" style={{ fontWeight: 650 }} {...clickable(() => onOpenConcept(p.concept_c.id))}>
+                  {p.concept_c.name}
+                </span>
+                <span className="mono" style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--text-3)' }}>
+                  {tr(`关联分 ${p.strength}`, `score ${p.strength}`)}
+                </span>
+              </div>
+              {p.bridges.length > 0 && (
+                <div className="row gap6 wrap" style={{ marginTop: 8, alignItems: 'center' }}>
+                  <span className="muted" style={{ fontSize: 11.5 }}>{tr('牵线的概念：', 'Bridged by:')}</span>
+                  {p.bridges.map((b) => (
+                    <span key={b.id} className="chip" {...clickable(() => onOpenConcept(b.id))}>
+                      {b.name}
+                      <span className="mono" style={{ fontSize: 10, color: 'var(--text-3)', marginLeft: 4 }}>×{b.strength}</span>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>
@@ -208,6 +299,8 @@ export function ConceptsTab({
 }: ConceptsTabProps) {
   const queryClient = useQueryClient();
   const [category, setCategory] = useState<CategoryFilter>('all');
+  // 未连接概念对面板（仅库作用域有此入口；选中概念时自动关掉）
+  const [showPairs, setShowPairs] = useState(false);
   const [qInput, setQInput] = useState('');
   const q = useDebounced(qInput.trim());
 
@@ -299,6 +392,24 @@ export function ConceptsTab({
               );
             })}
           </div>
+          {libraryId && (
+            <div
+              className="card hoverable"
+              style={{ marginTop: 10, padding: '9px 12px', background: showPairs ? 'var(--accent-soft)' : 'var(--surface-2)' }}
+              {...clickable(() => setShowPairs(true))}
+            >
+              <div className="row gap8">
+                <Icon name="sparkle" size={13} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 12, fontWeight: 650 }}>{tr('未连接概念对', 'Unconnected concept pairs')}</div>
+                  <div className="muted" style={{ fontSize: 11, marginTop: 1 }}>
+                    {tr('可能有关联但还没人一起研究的概念组合', 'Combos that may be related but unexplored')}
+                  </div>
+                </div>
+                <Icon name="arrow" size={12} style={{ color: 'var(--text-4)', marginLeft: 'auto', flexShrink: 0 }} />
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="scroll" style={{ overflowY: 'auto', flex: 1 }}>
@@ -341,14 +452,32 @@ export function ConceptsTab({
             />
           ) : (
             concepts.map((c) => (
-              <ConceptRow key={c.id} c={c} active={c.id === selectedId} onClick={() => onSelect(c.id)} />
+              <ConceptRow
+                key={c.id}
+                c={c}
+                active={c.id === selectedId}
+                // 概念对面板开着时点列表 = 想看这个概念：先关面板再选中
+                onClick={() => {
+                  setShowPairs(false);
+                  onSelect(c.id);
+                }}
+              />
             ))
           )}
         </div>
       </div>
 
       <div className="split-detail">
-        {selectedId ? (
+        {showPairs && libraryId ? (
+          <ConceptPairsPane
+            libraryId={libraryId}
+            onOpenConcept={(id) => {
+              setShowPairs(false);
+              onSelect(id);
+            }}
+            onClose={() => setShowPairs(false)}
+          />
+        ) : selectedId ? (
           <ConceptDetailPane
             conceptId={selectedId}
             libraryId={libraryId}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1308,6 +1308,26 @@ export interface ConceptDetail extends ConceptRead {
   related: { id: string; name: string }[];
 }
 
+/** 未连接概念对（P2.5 F3，Swanson ABC）：两个概念从未同篇出现，但共享共现邻居。 */
+export interface ConceptPairNode {
+  id: string;
+  name: string;
+}
+
+export interface ConceptPairBridge extends ConceptPairNode {
+  /** 这条桥的强度 = min(与 A 的共现数, 与 C 的共现数) */
+  strength: number;
+}
+
+export interface UnconnectedConceptPair {
+  concept_a: ConceptPairNode;
+  concept_c: ConceptPairNode;
+  /** 所有桥强度之和（越大越值得看） */
+  strength: number;
+  /** 最强的 ≤5 个桥概念 */
+  bridges: ConceptPairBridge[];
+}
+
 /** 全库概念补建结果（POST /projects/{id}/concepts/relink）。 */
 export interface ConceptRelinkResult {
   papers: number;
@@ -4163,6 +4183,10 @@ export const api = {
     if (opts.q) params.set('q', opts.q);
     const qs = params.toString();
     return request<ConceptRead[]>(`/libraries/${id}/concepts${qs ? `?${qs}` : ''}`);
+  },
+  /** 未连接概念对：可能有关联但还没在同一篇论文里出现过的概念组合（确定性挖掘）。 */
+  listLibraryConceptPairs(id: string, top = 20): Promise<UnconnectedConceptPair[]> {
+    return request<UnconnectedConceptPair[]>(`/libraries/${id}/concept-pairs?top=${top}`);
   },
   searchLibrary(
     id: string,


### PR DESCRIPTION
Closes #664. Part of #660 (P2.5 wave 2, item F3); design report §11 fuel 1 (Swanson ABC seeds). Deterministic, no LLM.

- concepts are platform-global with library membership derived through `library_papers → paper_concepts`; there were no concept–concept edges anywhere
- **compute-on-read, no materialization**: the largest real library measures 163 active concepts / ~1.3k co-occurrence pairs — one indexed join plus in-Python grouping, milliseconds, and still sub-second two orders of magnitude up. Materializing would buy one aggregation at the price of a migration (racing two parallel table-adding branches), refresh hooks, and staleness accounting; the read path derives from `paper_concepts` directly so the incremental-refresh requirement holds *by construction*. The service interface stays stable if a table becomes warranted later (rationale in the module docstring)
- co-occurrence counts only active concepts and graph-grade paper statuses (recycle bin and unscreened papers feed no fuel)
- `mine_unconnected_pairs`: A–B and B–C co-occur while A–C never does → candidate pair with bridge strength Σ_B min(w(A,B), w(B,C)), each pair carrying its ≤5 strongest bridge concepts with per-bridge values — fully explainable, deterministic ordering with canonical pair order
- blow-up guard: above 2000 concepts only the top-degree seats enter mining (bridging concentrates on high-degree bridges, so the tail contributes least to top results); bounded at ~2·n·E
- `GET /libraries/{id}/concept-pairs` (visibility-gated) plus a plain-language "unconnected concept pairs" pane on the concepts tab with bridge chips linking to concept detail

7 new tests pin the exact strengths and bridges of a known 5-concept graph, canonical ordering, truncation, the guard branch (patched threshold), library isolation, unscreened exclusion, and endpoint auth.

Verification: clean baseline 4 failed / 1537; branch 3 failed / 1545 — the failure set is a strict subset of baseline (one known flake recovered), zero new; goldens untouched; rebased onto #666 with zero conflicts; frontend build + vitest 150 green.