### PR TITLE
feat: gap and negative-result ledger

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -43,6 +43,9 @@ from app.schemas.libraries import (
     LibraryCreate,
     LibraryDigestRead,
     LibraryDigestSummary,
+    LibraryGapEntryRead,
+    LibraryGapPairRead,
+    LibraryGapsRead,
     LibraryQaRequest,
     LibraryQaResponse,
     MethodCardRead,
@@ -75,6 +78,7 @@ from app.services import chunks as chunks_service
 from app.services import citations as citations_service
 from app.services import concept_fuels as concept_fuels_service
 from app.services import concepts as concepts_service
+from app.services import gap_ledger as gap_ledger_service
 from app.services import graph as graph_service
 from app.services import ingest as ingest_service
 from app.services import libraries as libraries_service
@@ -619,6 +623,44 @@ async def search_library_methods(
         items=[MethodCardRead.model_validate(card) for card in items],
         mode=mode,
         mode_used=mode_used,
+    )
+
+
+@router.get("/libraries/{library_id}/gaps", response_model=LibraryGapsRead)
+async def list_library_gaps(
+    library_id: uuid.UUID,
+    kind: str | None = Query(
+        default=None,
+        pattern="^(gap|contradiction|uncertainty|negative_result|limitation)$",
+    ),
+    top: int = Query(default=50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> LibraryGapsRead:
+    """库级缺口与负结果台账（#665）：聚合库内论文的 gaps@1 抽取产物。
+
+    只读端点走库可见性（公共库全员、个人库仅创建者）。没抽过就是空列表不是
+    404——前端「研究缺口」页据此显示「还没有条目」。矛盾对是启发式配对
+    （heuristic 恒 True），语义见 services/gap_ledger.py。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    entries = await gap_ledger_service.library_gaps(session, library.id, kind=kind, top=top)
+    pairs = gap_ledger_service.find_contradiction_pairs(entries)
+
+    def _read(entry: gap_ledger_service.GapEntry) -> LibraryGapEntryRead:
+        return LibraryGapEntryRead.model_validate(entry)
+
+    return LibraryGapsRead(
+        entries=[_read(e) for e in entries],
+        pairs=[
+            LibraryGapPairRead(
+                a=_read(pair["a"]),
+                b=_read(pair["b"]),
+                shared_terms=pair["shared_terms"],
+                heuristic=pair["heuristic"],
+            )
+            for pair in pairs
+        ],
     )
 
 

--- a/src/backend/app/cli/backfill_extractions.py
+++ b/src/backend/app/cli/backfill_extractions.py
@@ -4,6 +4,7 @@
 
     python -m app.cli.backfill_extractions                 # 全部注册 schema，跳过已抽取
     python -m app.cli.backfill_extractions --schema method # 只回填方法卡
+    python -m app.cli.backfill_extractions --schema gaps   # 只回填缺口与负结果台账（#665）
     python -m app.cli.backfill_extractions --limit 100
     python -m app.cli.backfill_extractions --force         # 覆盖重抽（schema 升版后用）
 

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -39,6 +39,7 @@ _AFFILIATIONS_MARKER = "POLARIS_AUTHOR_AFFIL"  # 逐位作者机构解析（affi
 _CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类（citation_graph.py）
 _EXTRACT_SKELETON_MARKER = "POLARIS_EXTRACT_SKELETON"  # 骨架抽取（services/extraction/）
 _EXTRACT_METHOD_MARKER = "POLARIS_EXTRACT_METHOD"  # 方法卡抽取（services/extraction/，#663）
+_EXTRACT_GAPS_MARKER = "POLARIS_EXTRACT_GAPS"  # 缺口台账抽取（services/extraction/，#665）
 # 库级 agentic RAG 三环节（services/library_rag.py，#644）
 _RAG_EXPAND_MARKER = "POLARIS_RAG_EXPAND"
 _RAG_RERANK_MARKER = "POLARIS_RAG_RERANK"
@@ -454,6 +455,9 @@ class FakeProvider(LLMProvider):
             return FakeProvider._respond_extract_skeleton(last_user)
         if _EXTRACT_METHOD_MARKER in full_text:
             return FakeProvider._respond_extract_method(last_user)
+        # 缺口台账抽取：同上，整篇正文进 user prompt，须先于通用 marker 判断
+        if _EXTRACT_GAPS_MARKER in full_text:
+            return FakeProvider._respond_extract_gaps(last_user)
         # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
         # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
@@ -669,6 +673,34 @@ class FakeProvider(LLMProvider):
                 "dataset": ["数据集一（fake）"],
                 "protocol": "流程：准备数据、跑替身方法、对比指标（fake extraction）",
                 "confidence": 0.9,
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _respond_extract_gaps(last_user: str) -> str:
+        """缺口台账抽取（services/extraction/schemas.GAPS_SCHEMA 对齐，#665）。
+
+        固定两条：一条 gap（statement 回显标题，测试据此断言 prompt 带对了论文）
+        + 一条 limitation，各带假的原文摘录 source_span——测试要验证的是
+        「条目会归一化、锚定会保留、库级聚合能跑通」这条链路，不是抽得多准。"""
+        m = re.search(r"标题：(.+)", last_user)
+        title = m.group(1).strip() if m else "未知论文"
+        return json.dumps(
+            {
+                "entries": [
+                    {
+                        "kind": "gap",
+                        "statement": f"《{title}》指出跨域泛化仍无人解决（fake gap）",
+                        "source_span": "cross-domain generalization remains open (fake span)",
+                    },
+                    {
+                        "kind": "limitation",
+                        "statement": "作者自述评测只覆盖单一数据集（fake limitation）",
+                        "source_span": "our evaluation is limited to a single dataset (fake span)",
+                    },
+                ],
+                "confidence": 0.8,
             },
             ensure_ascii=False,
         )

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -86,6 +86,8 @@ STAGES = (
     # 方法卡抽取（#663）：与骨架同形态（整篇正文进、短 JSON 出），单列环节是
     # 为了让管理员可以给方法卡配不同模型（它比骨架更吃「拆目的/机制」的判断力）
     "extract_method",
+    # 缺口与负结果台账抽取（#665）：同为整篇正文进、条目列表 JSON 出
+    "extract_gaps",
     # 库级 agentic RAG 三环节（#644）：扩展/重排是短 JSON，作答是中档长生成
     "rag_expand",
     "rag_rerank",
@@ -222,6 +224,9 @@ _MEDIUM_CALL_STAGES = frozenset(
         # enrich 链逐篇串行，卡死一篇就堵住整条补全队列
         "extract_skeleton",
         "extract_method",  # 方法卡抽取（#663）：与骨架同一负载形态，同档
+        # 缺口台账抽取（#665）：输入体量与骨架抽取相同（整篇正文），输出是最多
+        # 8 条带原文摘录的条目列表——同样的「重于短档、不配长档」处境，同档
+        "extract_gaps",
     }
 )
 

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -289,3 +289,33 @@ class MethodSearchResponse(BaseModel):
     mode: str
     # semantic = 双轴向量检索；keyword = 嵌入不可用时的确定性关键词降级
     mode_used: str
+
+
+class LibraryGapEntryRead(BaseModel):
+    """缺口台账的一条（#665）：statement 是 LLM 归纳，source_span 是原文摘录锚点。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    paper_id: uuid.UUID
+    paper_title: str
+    kind: str  # gap | contradiction | uncertainty | negative_result | limitation
+    statement: str
+    source_span: str
+    year: int | None = None
+
+
+class LibraryGapPairRead(BaseModel):
+    """疑似矛盾对：两条同概念异立场的条目。heuristic 恒 True——本批次只有
+    启发式配对（共享概念词 + 单侧否定措辞），LLM 细判归后续；前端据此标注
+    「启发式匹配，请核对原文」。"""
+
+    a: LibraryGapEntryRead
+    b: LibraryGapEntryRead
+    shared_terms: list[str] = []
+    heuristic: bool = True
+
+
+class LibraryGapsRead(BaseModel):
+    entries: list[LibraryGapEntryRead] = []
+    # 矛盾对在返回的 entries 范围内配（kind 筛选时对子也跟着窄）
+    pairs: list[LibraryGapPairRead] = []

--- a/src/backend/app/services/extraction/runtime.py
+++ b/src/backend/app/services/extraction/runtime.py
@@ -31,7 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.llm.base import Message
 from app.models.paper import Paper
 from app.models.paper_extraction import PaperExtraction
-from app.services.extraction.schemas import ExtractionSchema, get_schema
+from app.services.extraction.schemas import ExtractionSchema, SchemaField, get_schema
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +108,48 @@ def _normalize_list(value: Any, max_len: int, max_items: int | None) -> list[str
     return items or None
 
 
+def _normalize_entries(value: Any, field: SchemaField) -> list[dict[str, str]] | None:
+    """entries 字段归一化：结构化条目列表，逐条校验、整条取舍。
+
+    与 list 归一化「尽量收下」的姿态不同，entries 是宁缺毋滥：条目不是 dict、
+    白名单键缺失/空串/类型不对、枚举外取值，一律**整条丢弃**而不是修补——
+    缺口台账（gaps@1）的锚定是硬要求，一条没有原文出处（source_span）的记录
+    比没有记录更糟（读者无从核对，聚合层也没法判真伪）。能修的只有超长截断
+    （截断不伤锚定语义）与枚举取值的大小写（模型爱写 "Gap"，统一小写再比对）。
+    条目内不在白名单的键静默丢弃；按全键元组去重（保序）；条数封顶。
+    """
+    if not isinstance(value, list):
+        return None
+    keys = field.entry_keys or ()
+    entries: list[dict[str, str]] = []
+    seen: set[tuple[str, ...]] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        entry: dict[str, str] = {}
+        for key in keys:
+            raw_val = item.get(key.name)
+            if not isinstance(raw_val, str):
+                break
+            text = raw_val.strip()[: key.max_len]
+            if not text:
+                break
+            if key.choices is not None:
+                text = text.lower()
+                if text not in key.choices:
+                    break
+            entry[key.name] = text
+        else:
+            fingerprint = tuple(entry[k.name] for k in keys)
+            if fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            entries.append(entry)
+            if field.max_items is not None and len(entries) >= field.max_items:
+                break
+    return entries or None
+
+
 def normalize_payload(
     schema: ExtractionSchema, raw: dict[str, Any]
 ) -> tuple[dict[str, Any], float | None]:
@@ -120,7 +162,9 @@ def normalize_payload(
     """
     payload: dict[str, Any] = {}
     for field in schema.fields:
-        if field.kind == "list":
+        if field.kind == "entries":
+            value: Any = _normalize_entries(raw.get(field.name), field)
+        elif field.kind == "list":
             value = _normalize_list(raw.get(field.name), field.max_len, field.max_items)
         else:
             value = _normalize_text(raw.get(field.name), field.max_len)

--- a/src/backend/app/services/extraction/schemas.py
+++ b/src/backend/app/services/extraction/schemas.py
@@ -5,10 +5,11 @@ schema 决定三件事：抽哪些字段（白名单）、每个字段长什么�
 里不在白名单的键直接丢弃，超长截断，空串置空。
 
 内置两个通用 schema：骨架 skeleton@1（问题-方法-发现-局限，ORKG contribution
-思路）与方法卡 method@1（目的-机制-基线-数据集-流程，#663 方法库的原料，
-purpose 与 mechanism 各自建向量做双轴检索，见 services/method_index.py）。
-学科 schema（PICO / 任务-数据集-指标 / 合成配方…）按设计报告属后续批次，本模块
-只留 ``register_schema`` 这道缝，不预埋任何学科内容。
+思路）、方法卡 method@1（目的-机制-基线-数据集-流程，#663 方法库的原料，
+purpose 与 mechanism 各自建向量做双轴检索，见 services/method_index.py）与
+缺口台账 gaps@1（GAPMAP 式条目列表，#665）。学科 schema（PICO /
+任务-数据集-指标 / 合成配方…）按设计报告属后续批次，本模块只留
+``register_schema`` 这道缝，不预埋任何学科内容。
 
 版本语义：字段集合或含义变了就 +1 并落进 stage_meta.version，读方据此判断
 存量产物是否过期。同一 id 只注册最新版——不做多版本共存，个人平台的量级
@@ -21,13 +22,30 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
-class SchemaField:
-    """一个抽取字段：text = 单段文本；list = 字符串列表（去重去空、条数封顶）。"""
+class EntryKey:
+    """entries 字段里单个条目的一个键：白名单 + 长度帽 + 可选枚举。
+
+    所有声明的键都是必填——entries 型字段的价值在于每条都是完整的结构化记录
+    （比如缺口台账的每条必须带原文出处），缺任何一键整条丢弃，不做半条记录。
+    """
 
     name: str
-    kind: str  # "text" | "list"
-    max_len: int  # text：整段字符帽；list：单条字符帽
-    max_items: int | None = None  # 仅 list：最多保留几条
+    max_len: int
+    # 取值枚举（如缺口条目的 kind）：归一化时先 strip+小写再比对，枚举外整条丢弃
+    choices: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaField:
+    """一个抽取字段：text = 单段文本；list = 字符串列表（去重去空、条数封顶）；
+    entries = 结构化条目列表（每条是白名单键的 dict，见 EntryKey）。"""
+
+    name: str
+    kind: str  # "text" | "list" | "entries"
+    max_len: int  # text：整段字符帽；list：单条字符帽；entries：不使用（帽在 EntryKey 上）
+    max_items: int | None = None  # list / entries：最多保留几条
+    # 仅 entries：条目键的白名单规格；模型输出里不在其中的键直接丢弃
+    entry_keys: tuple[EntryKey, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,7 +63,18 @@ class ExtractionSchema:
         """字段清单的自然语言描述（进 prompt，确定性生成，与 fields 永不漂移）。"""
         lines = []
         for f in self.fields:
-            if f.kind == "list":
+            if f.kind == "entries":
+                keys = []
+                for k in f.entry_keys or ():
+                    if k.choices:
+                        keys.append(f'"{k.name}"（取值限 {" / ".join(k.choices)}）')
+                    else:
+                        keys.append(f'"{k.name}"（不超过 {k.max_len} 字）')
+                lines.append(
+                    f'- "{f.name}"：对象数组，最多 {f.max_items} 条，'
+                    f"每条含且仅含键 {'、'.join(keys)}；没有可靠内容就给空数组"
+                )
+            elif f.kind == "list":
                 lines.append(
                     f'- "{f.name}"：字符串数组，最多 {f.max_items} 条，'
                     f"每条不超过 {f.max_len} 字；没有可靠内容就给空数组"
@@ -114,6 +143,54 @@ METHOD_SCHEMA = ExtractionSchema(
     stage="extract_method",
 )
 
+# 缺口条目的种类枚举（GAPMAP 的证据类型口径，#665）：
+#   gap            还没人解决的开放问题
+#   contradiction  与其他工作相互矛盾的结论
+#   uncertainty    作者明说「尚不确定 / 证据不足」的判断
+#   negative_result 试过但失败/无效的尝试（负结果）
+#   limitation     作者自述的方法/评测局限
+GAP_KINDS = ("gap", "contradiction", "uncertainty", "negative_result", "limitation")
+
+# 缺口与负结果台账（#665，设计报告 §11 燃料 2+4）。
+#
+# 与 skeleton@1 的 limitations 字段的分工：skeleton 的 limitations 是论文自述局限的
+# **粗摘**（几句话概括，无出处，服务于「一眼看懂这篇论文」）；gaps@1 是**逐条挂原文
+# 出处的细粒度台账**——每条必须带 source_span（≤200 字原文摘录）锚定出处，种类也
+# 更细（缺口/矛盾/不确定/负结果/局限五类），服务于库级聚合与后续的假设生成燃料。
+# 两者并存不算重复：粗摘可以无中生有地概括，台账的硬要求是「说得出这句话在原文
+# 哪里」——无出处的条目宁可不要（归一化直接丢弃，见 runtime._normalize_entries）。
+GAPS_SCHEMA = ExtractionSchema(
+    id="gaps",
+    version=1,
+    stage="extract_gaps",
+    fields=(
+        SchemaField(
+            "entries",
+            "entries",
+            max_len=0,  # entries 型不用字段级字符帽，各键的帽在 entry_keys 上
+            max_items=8,
+            entry_keys=(
+                EntryKey("kind", max_len=32, choices=GAP_KINDS),
+                EntryKey("statement", max_len=300),
+                EntryKey("source_span", max_len=200),
+            ),
+        ),
+    ),
+    prompt_template=(
+        "POLARIS_EXTRACT_GAPS\n"
+        "你是论文缺口与负结果记录员。通读给定论文的标题与正文，找出其中明确提到的："
+        "尚未解决的开放问题（gap）、与其他工作矛盾的结论（contradiction）、"
+        "作者明说不确定的判断（uncertainty）、失败或无效的尝试（negative_result）、"
+        "作者自述的局限（limitation）：\n"
+        "{fields_spec}\n"
+        "每条的 statement 用中文归纳（专有名词保留原文）；source_span 必须是"
+        "**逐字摘自正文的原文片段**（保持原语言，不翻译不改写），用于锚定出处——"
+        "找不到可摘录的原文依据的条目不要写。宁缺毋滥，只记论文明确说了的。\n"
+        '只输出一个 JSON 对象，键为上述字段名，另加 "confidence"（0 到 1，'
+        "你对整份抽取的把握）。只依据原文，不引入外部知识。"
+    ),
+)
+
 _REGISTRY: dict[str, ExtractionSchema] = {}
 
 
@@ -135,3 +212,4 @@ def list_schemas() -> list[ExtractionSchema]:
 
 register_schema(SKELETON_SCHEMA)
 register_schema(METHOD_SCHEMA)
+register_schema(GAPS_SCHEMA)

--- a/src/backend/app/services/gap_ledger.py
+++ b/src/backend/app/services/gap_ledger.py
@@ -1,0 +1,199 @@
+"""库级缺口与负结果台账（#665，设计报告 §11 燃料 2+4，GAPMAP 式）。
+
+数据从 paper_extractions 的 gaps@1 产物聚合（schemas.GAPS_SCHEMA，每条带原文
+摘录锚定出处），本文件全是确定性代码：查表、拍平、过滤、排序、启发式配对——
+判断性工作（逐篇抽条目）已在抽取环节由 LLM 做完，聚合层不再调模型。
+
+矛盾对（contradiction pairs）本 PR 只做**同概念异立场的启发式配对**：两条 statement
+共享足够多的概念词、且恰好一条含否定/反驳措辞，就配成一对并标 heuristic=True。
+不做 LLM 矛盾判定的原因：ContraCrow 式的逐对语义判定要对 O(n²) 候选各打一次模型，
+库一大成本失控，而台账页面是浏览型入口、日常打开率高——贵的判定应该按需触发
+（用户点开某一对再细判），归后续批次；启发式误报由 heuristic 标记 + 双方原文
+摘录兜底，读者一眼能自行核对。
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.services.extraction.schemas import GAP_KINDS, GAPS_SCHEMA
+
+# 排序权重：kind 的优先级折算成「等效年数」加到论文年份上——gap/contradiction
+# 是假设生成最值钱的燃料（别人没解决的 + 相互打架的），优先于负结果/不确定，
+# 自述局限垫底（skeleton 也有粗摘，边际信息最少）。权重取 0..3 的小数量级，
+# 让「新近度」与「种类」互相能翻盘：2026 年的局限排得过 2022 年的 gap，
+# 但同龄论文里 gap 永远在局限前面。
+_KIND_WEIGHTS = {
+    "gap": 3,
+    "contradiction": 3,
+    "negative_result": 2,
+    "uncertainty": 1,
+    "limitation": 0,
+}
+# 没有年份的论文（预印本元数据缺失等）沉底：给不出新近度就别和有年份的抢位置
+_NO_YEAR_SCORE = -1_000_000
+
+
+@dataclass(slots=True)
+class GapEntry:
+    """台账里的一条：出自哪篇论文、什么种类、归纳陈述 + 原文摘录锚点。"""
+
+    paper_id: uuid.UUID
+    paper_title: str
+    kind: str
+    statement: str
+    source_span: str
+    year: int | None
+
+
+def _entry_sort_key(entry: GapEntry) -> tuple:
+    score = (
+        _NO_YEAR_SCORE if entry.year is None else entry.year
+    ) + _KIND_WEIGHTS.get(entry.kind, 0)
+    # 主排序分之后再按年份、statement 定序：同分条目的顺序不随查询顺序漂移
+    return (-score, -(entry.year or 0), entry.statement)
+
+
+async def library_gaps(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    *,
+    kind: str | None = None,
+    top: int = 50,
+) -> list[GapEntry]:
+    """聚合一个库内全部论文的缺口台账条目，排序后取前 top 条。
+
+    成员口径：库内非回收站论文（status != excluded——被淘汰论文的缺口不该
+    继续给这个方向供燃料）。排序 = 论文年份 + kind 权重（见 _KIND_WEIGHTS）。
+    """
+    if kind is not None and kind not in GAP_KINDS:
+        raise ValueError(f"unknown gap kind: {kind!r}")
+    stmt = (
+        select(PaperExtraction, Paper)
+        .join(Paper, Paper.id == PaperExtraction.paper_id)
+        .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+        .where(
+            LibraryPaper.library_id == library_id,
+            LibraryPaper.status != "excluded",
+            PaperExtraction.schema_id == GAPS_SCHEMA.id,
+        )
+    )
+    entries: list[GapEntry] = []
+    for extraction, paper in (await session.execute(stmt)).all():
+        for item in extraction.payload.get("entries") or []:
+            # 归一化在抽取时已做过；这里再做形状防御只为老产物/手工数据不炸接口
+            if not isinstance(item, dict):
+                continue
+            entry_kind = item.get("kind")
+            statement = item.get("statement")
+            span = item.get("source_span")
+            if not (entry_kind and statement and span):
+                continue
+            if kind is not None and entry_kind != kind:
+                continue
+            entries.append(
+                GapEntry(
+                    paper_id=paper.id,
+                    paper_title=paper.title,
+                    kind=entry_kind,
+                    statement=statement,
+                    source_span=span,
+                    year=paper.year,
+                )
+            )
+    entries.sort(key=_entry_sort_key)
+    return entries[:top]
+
+
+# ---- 矛盾对启发式（同概念异立场） ----
+
+# 概念词提取：英文术语（≥4 字符的词，技术名词的主要形态）+ 中文三元组
+# （无分词依赖的确定性近似；三元组比二元组少撞「方法/模型」这类高频泛词）。
+_EN_TERM_RE = re.compile(r"[A-Za-z][A-Za-z0-9+_-]{3,}")
+_CJK_RUN_RE = re.compile(r"[一-鿿]{3,}")
+_EN_STOPWORDS = frozenset(
+    {
+        "this", "that", "with", "from", "have", "been", "does", "not",
+        "only", "into", "over", "such", "than", "then", "them", "these",
+        "those", "when", "which", "while", "will", "would", "could",
+        "should", "there", "their", "about", "after", "before", "between",
+        "under", "based", "using", "used", "more", "most", "less", "least",
+        "fake",  # fake provider 的替身文案里到处都是，别拿它当共享概念
+    }
+)
+# 否定/反驳措辞：英文按词边界（防 "notable" 撞 "not"），中文按多字子串
+# （单字「不」误伤面太大，不收）。命中任一条即视为「反方立场」。
+_EN_NEGATION_RE = re.compile(
+    r"\b(?:not|no|nor|cannot|can't|fails?|failed|worse|negative|refutes?|"
+    r"contradicts?|inconsistent|unable|without)\b",
+    re.IGNORECASE,
+)
+_CJK_NEGATION_CUES = (
+    "并未", "未能", "不能", "无法", "没有", "无人", "相反", "矛盾", "反驳",
+    "失败", "失效", "劣于", "否定", "不成立", "不适用", "不显著", "无效",
+)
+
+
+def _concept_terms(text: str) -> frozenset[str]:
+    terms = {
+        w.lower() for w in _EN_TERM_RE.findall(text) if w.lower() not in _EN_STOPWORDS
+    }
+    for run in _CJK_RUN_RE.findall(text):
+        terms.update(run[i : i + 3] for i in range(len(run) - 2))
+    return frozenset(terms)
+
+
+def _has_negation(text: str) -> bool:
+    if _EN_NEGATION_RE.search(text):
+        return True
+    return any(cue in text for cue in _CJK_NEGATION_CUES)
+
+
+# 至少共享几个概念词才算「谈的是同一件事」：1 个太容易被泛词/巧合命中，
+# 2 个（一个英文术语 + 一个中文片段，或一个 4 字中文概念产出的两个三元组）
+# 是「多半在谈同一概念」的最低门槛
+_MIN_SHARED_TERMS = 2
+_MAX_PAIRS = 20  # 配对是 O(n²) 里挑出来的展示位，页面上超过 20 对没人看
+
+
+def find_contradiction_pairs(
+    entries: list[GapEntry], *, limit: int = _MAX_PAIRS
+) -> list[dict]:
+    """在已排序的台账条目里找疑似矛盾对：同概念、异立场、不同论文。
+
+    输入按 library_gaps 的排序给，配对按 (i, j) 字典序产出——排序靠前
+    （新近且种类值钱）的条目优先占展示位。返回
+    ``{"a", "b", "shared_terms", "heuristic": True}``；heuristic 恒 True，
+    LLM 细判归后续批次（见模块 docstring 的成本论证）。
+    """
+    terms = [_concept_terms(e.statement) for e in entries]
+    negated = [_has_negation(e.statement) for e in entries]
+    pairs: list[dict] = []
+    for i in range(len(entries)):
+        for j in range(i + 1, len(entries)):
+            if entries[i].paper_id == entries[j].paper_id:
+                continue  # 同一篇论文自述的两条不算「相互矛盾的结论」
+            if negated[i] == negated[j]:
+                continue  # 立场同向（都肯定/都否定）不构成对立
+            shared = terms[i] & terms[j]
+            if len(shared) < _MIN_SHARED_TERMS:
+                continue
+            pairs.append(
+                {
+                    "a": entries[i],
+                    "b": entries[j],
+                    "shared_terms": sorted(shared)[:5],
+                    "heuristic": True,
+                }
+            )
+            if len(pairs) >= limit:
+                return pairs
+    return pairs

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -297,7 +297,7 @@ async def enrich_paper(
         logger.warning("enrich citation intents failed for paper %s", paper_id, exc_info=True)
         paper = await _rollback_and_reload()
 
-    # 结构化抽取（#661 骨架 + #663 方法卡，增量钩子）：全文就位后把注册表里的每个
+    # 结构化抽取（#661 骨架 + #663 方法卡 + #665 缺口台账，增量钩子）：全文就位后把注册表里的每个
     # schema 都抽一遍落 paper_extractions。非独立进度阶段（STAGES 不变）、逐 schema
     # best-effort（一个 schema 失败不拖垮其余）；runtime 对无全文论文如实 skip、
     # 不调 LLM——bibtex 导入等 golden 链路因此零输出零副作用。

--- a/src/backend/tests/test_gap_ledger.py
+++ b/src/backend/tests/test_gap_ledger.py
@@ -1,0 +1,352 @@
+"""缺口与负结果台账（#665）：entries 归一化边界、fake 确定性、库级聚合排序、
+启发式矛盾配对、端点权限。"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.models.paper_extraction import PaperExtraction
+from app.services import paper_enrich
+from app.services.extraction.runtime import extract_paper, normalize_payload
+from app.services.extraction.schemas import GAP_KINDS, GAPS_SCHEMA, get_schema
+from app.services.gap_ledger import GapEntry, find_contradiction_pairs, library_gaps
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+FULL_TEXT = """Gap Ledger Probe
+
+Introduction
+
+We study which open problems and negative results a deterministic probe reports.
+
+Discussion
+
+Cross-domain generalization remains an open problem. Our evaluation is limited.
+"""
+
+
+def _write_fulltext(tmp_path, text=FULL_TEXT):
+    path = tmp_path / f"{uuid.uuid4().hex}.txt"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def _entry(kind="gap", statement="s", span="span", **kw):
+    return {"kind": kind, "statement": statement, "source_span": span, **kw}
+
+
+# ---- 1. schema 注册 ----
+
+
+def test_gaps_schema_registered():
+    schema = get_schema("gaps")
+    assert schema is GAPS_SCHEMA
+    assert schema.version == 1
+    assert schema.stage == "extract_gaps"
+    prompt = schema.system_prompt()
+    assert "POLARIS_EXTRACT_GAPS" in prompt
+    assert '"entries"' in prompt
+    # 条目键与枚举都进 prompt（与 entry_keys 定义不漂移）
+    for key in schema.fields[0].entry_keys:
+        assert f'"{key.name}"' in prompt
+    for kind in GAP_KINDS:
+        assert kind in prompt
+
+
+# ---- 2. entries 归一化边界（纯函数） ----
+
+
+def test_normalize_entries_boundaries():
+    raw = {
+        "entries": [
+            _entry(),  # 合法
+            _entry(kind="Gap", statement="大小写归一", span="Span"),  # kind 小写后合法
+            _entry(kind="opinion"),  # 枚举外 kind → 整条丢弃
+            _entry(span="   "),  # 空 span → 整条丢弃（锚定是硬要求）
+            {"kind": "gap", "statement": "缺 source_span 键"},  # 缺键 → 整条丢弃
+            _entry(statement="超长" * 300, span="长" * 300),  # 超长截断但保留
+            "not a dict",  # 非 dict → 丢弃
+            _entry(extra="白名单外的键被丢弃"),
+        ],
+        "hallucinated": "schema 外字段照旧被白名单丢掉",
+        "confidence": 0.5,
+    }
+    payload, confidence = normalize_payload(GAPS_SCHEMA, raw)
+    assert set(payload) == {"entries"}
+    entries = payload["entries"]
+    # 第 8 条与第 1 条全键相同 → 去重；剩：合法、大小写、超长截断 三条
+    assert len(entries) == 3
+    assert entries[0] == {"kind": "gap", "statement": "s", "source_span": "span"}
+    assert entries[1]["kind"] == "gap"
+    assert entries[1]["statement"] == "大小写归一"
+    assert len(entries[2]["statement"]) == 300
+    assert len(entries[2]["source_span"]) == 200
+    assert all(set(e) == {"kind", "statement", "source_span"} for e in entries)
+    assert confidence == 0.5
+
+
+def test_normalize_entries_caps_item_count():
+    raw = {"entries": [_entry(statement=f"条目 {i}") for i in range(12)]}
+    payload, _ = normalize_payload(GAPS_SCHEMA, raw)
+    assert len(payload["entries"]) == 8  # max_items 封顶
+
+
+def test_normalize_entries_all_invalid_yields_empty_payload():
+    raw = {"entries": [_entry(span=""), _entry(kind="nope"), 42]}
+    payload, _ = normalize_payload(GAPS_SCHEMA, raw)
+    assert payload == {}  # 全丢 → 空 payload → 运行时不落表
+
+
+# ---- 3. fake 确定性 + enrich 钩子 ----
+
+
+async def test_extract_gaps_deterministic(client, tmp_path):
+    token = await register_and_login(client, email="gaps@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="gaps-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Gap Ledger Probe",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        outcome = await extract_paper(session, paper, schema_id="gaps")
+        assert outcome.status == "extracted"
+        await session.commit()
+        entries = outcome.row.payload["entries"]
+        # fake provider 固定两条：一条 gap（回显标题）+ 一条 limitation，各带假 span
+        assert [e["kind"] for e in entries] == ["gap", "limitation"]
+        assert "Gap Ledger Probe" in entries[0]["statement"]
+        assert all(e["source_span"] for e in entries)
+        assert outcome.row.stage_meta["stage"] == "extract_gaps"
+
+
+async def test_enrich_hook_extracts_gaps_too(client, tmp_path):
+    token = await register_and_login(client, email="gapshook@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, _ = await make_project_with_library(client, headers, name="gapshook-proj")
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Hooked Gaps Paper",
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        paper_id = paper.id
+
+    async def _noop_emit(stage, status, detail=None):  # noqa: ARG001
+        return None
+
+    async with get_sessionmaker()() as session:
+        from app.models.paper import Paper
+
+        paper = await session.get(Paper, paper_id)
+        await paper_enrich.enrich_paper(
+            session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
+        )
+
+    async with get_sessionmaker()() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(PaperExtraction).where(PaperExtraction.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    gaps = next(row for row in rows if row.schema_id == "gaps")
+    assert len(gaps.payload["entries"]) == 2
+
+
+# ---- 4. 库级聚合：排序 / kind 过滤 / 回收站排除 / top 截断 ----
+
+
+async def _seed_gap_rows(session, project_id, tmp_path, specs):
+    """按 specs 造论文 + gaps 抽取行：specs = [(title, year, status, entries)]。"""
+    papers = []
+    for title, year, status, entries in specs:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title=title,
+            year=year,
+            status=status,
+        )
+        session.add(
+            PaperExtraction(paper_id=paper.id, schema_id="gaps", payload={"entries": entries})
+        )
+        papers.append(paper)
+    await session.commit()
+    return papers
+
+
+async def test_library_gaps_sorting_and_filters(client, tmp_path):
+    token = await register_and_login(client, email="gapsagg@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="gapsagg")
+
+    async with get_sessionmaker()() as session:
+        await _seed_gap_rows(
+            session,
+            project_id,
+            tmp_path,
+            [
+                # 2022 的 gap（分 2025）排在 2024 的 limitation（分 2024）前、
+                # 2026 的 limitation（分 2026）后：新近度与 kind 权重互相能翻盘
+                ("Old Gap", 2022, "compiled", [_entry(statement="旧缺口")]),
+                (
+                    "New Limitation",
+                    2026,
+                    "compiled",
+                    [_entry(kind="limitation", statement="新局限")],
+                ),
+                (
+                    "Mid Limitation",
+                    2024,
+                    "compiled",
+                    [_entry(kind="limitation", statement="中局限")],
+                ),
+                # 回收站论文的条目不聚合
+                ("Trashed", 2027, "excluded", [_entry(statement="回收站缺口")]),
+                # 无年份论文沉底
+                ("No Year", None, "compiled", [_entry(statement="无年份缺口")]),
+            ],
+        )
+
+    async with get_sessionmaker()() as session:
+        entries = await library_gaps(session, library_id)
+        assert [e.statement for e in entries] == ["新局限", "旧缺口", "中局限", "无年份缺口"]
+        assert all(e.statement != "回收站缺口" for e in entries)
+        assert entries[0].paper_title == "New Limitation"
+
+        # kind 过滤
+        only_gaps = await library_gaps(session, library_id, kind="gap")
+        assert {e.kind for e in only_gaps} == {"gap"}
+        assert len(only_gaps) == 2
+
+        # top 截断按排序取前 N
+        top_two = await library_gaps(session, library_id, top=2)
+        assert [e.statement for e in top_two] == ["新局限", "旧缺口"]
+
+
+# ---- 5. 启发式矛盾配对（纯函数） ----
+
+
+def _gap_entry(statement, paper=None, kind="gap", year=2026):
+    return GapEntry(
+        paper_id=paper or uuid.uuid4(),
+        paper_title="t",
+        kind=kind,
+        statement=statement,
+        source_span="span",
+        year=year,
+    )
+
+
+def test_contradiction_pairs_positive():
+    a = _gap_entry("Dropout regularization improves calibration on ImageNet")
+    b = _gap_entry("Dropout regularization does not improve calibration in our runs")
+    pairs = find_contradiction_pairs([a, b])
+    assert len(pairs) == 1
+    assert pairs[0]["heuristic"] is True
+    assert "dropout" in pairs[0]["shared_terms"]
+    assert {pairs[0]["a"].statement, pairs[0]["b"].statement} == {a.statement, b.statement}
+
+
+def test_contradiction_pairs_cjk():
+    a = _gap_entry("对比学习在小样本场景显著提升表现")
+    b = _gap_entry("对比学习在小样本场景并未带来提升")
+    assert len(find_contradiction_pairs([a, b])) == 1
+
+
+def test_contradiction_pairs_negatives():
+    # 无共享概念：都带否定极性差也不配
+    x = _gap_entry("Batch normalization fails on tiny batches")
+    y = _gap_entry("Curriculum ordering improves convergence speed")
+    assert find_contradiction_pairs([x, y]) == []
+    # 同极性（都是肯定句）不配
+    p = _gap_entry("Dropout regularization improves calibration")
+    q = _gap_entry("Dropout regularization improves robustness too")
+    assert find_contradiction_pairs([p, q]) == []
+    # 同一篇论文的两条不配（自述不算相互矛盾）
+    pid = uuid.uuid4()
+    m = _gap_entry("Dropout regularization improves calibration", paper=pid)
+    n = _gap_entry("Dropout regularization does not improve calibration", paper=pid)
+    assert find_contradiction_pairs([m, n]) == []
+
+
+# ---- 6. 端点 ----
+
+
+async def test_gaps_endpoint(client, tmp_path):
+    token = await register_and_login(client, email="gapsapi@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="gapsapi")
+
+    # 没抽过：空列表而非 404
+    resp = await client.get(f"/api/libraries/{library_id}/gaps", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"entries": [], "pairs": []}
+
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Endpoint Gaps Paper",
+            year=2026,
+            full_text_path=_write_fulltext(tmp_path),
+        )
+        await session.commit()
+        outcome = await extract_paper(session, paper, schema_id="gaps")
+        assert outcome.status == "extracted"
+        await session.commit()
+
+    resp = await client.get(f"/api/libraries/{library_id}/gaps", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [e["kind"] for e in body["entries"]] == ["gap", "limitation"]
+    assert body["entries"][0]["paper_title"] == "Endpoint Gaps Paper"
+    assert body["entries"][0]["year"] == 2026
+    assert body["entries"][0]["source_span"]
+
+    # kind 过滤透传
+    resp = await client.get(
+        f"/api/libraries/{library_id}/gaps?kind=limitation", headers=headers
+    )
+    assert [e["kind"] for e in resp.json()["entries"]] == ["limitation"]
+    # 枚举外 kind 直接 422（Query pattern 校验）
+    resp = await client.get(f"/api/libraries/{library_id}/gaps?kind=nope", headers=headers)
+    assert resp.status_code == 422
+
+    # 未登录不可读
+    anon = await client.get(f"/api/libraries/{library_id}/gaps")
+    assert anon.status_code == 401
+
+
+async def test_gaps_endpoint_personal_library_hidden(client):
+    owner = await register_and_login(client, email="gapsowner@example.com")
+    owner_headers = {"Authorization": f"Bearer {owner}"}
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "私人缺口库", "statement": "只给自己看的方向"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+
+    # 创建者可读
+    resp = await client.get(f"/api/libraries/{lib_id}/gaps", headers=owner_headers)
+    assert resp.status_code == 200
+
+    # 他人不可见：按不存在处理（404，不泄漏个人库存在性）
+    other = await register_and_login(client, email="gapsother@example.com")
+    resp = await client.get(
+        f"/api/libraries/{lib_id}/gaps", headers={"Authorization": f"Bearer {other}"}
+    )
+    assert resp.status_code == 404

--- a/src/backend/tests/test_method_library.py
+++ b/src/backend/tests/test_method_library.py
@@ -332,7 +332,8 @@ async def test_enrich_hook_builds_method_index(client, tmp_path):
             .scalars()
             .all()
         )
-    assert sorted(r.schema_id for r in rows) == ["method", "skeleton"]
+    # #665 起注册表里还有缺口台账 gaps：钩子遍历注册表，三个 schema 各一行
+    assert sorted(r.schema_id for r in rows) == ["gaps", "method", "skeleton"]
     assert await _method_vectors_of(paper_id) == ["mechanism", "purpose"]
 
 

--- a/src/backend/tests/test_paper_extraction.py
+++ b/src/backend/tests/test_paper_extraction.py
@@ -235,11 +235,12 @@ async def test_enrich_hook_extracts_skeleton(client, tmp_path):
             session, paper, target=None, user_id=None, project_id=None, emit=_noop_emit
         )
 
-    # #663 起钩子把注册表里的每个 schema 都抽一遍：骨架 + 方法卡各一行
+    # #663/#665 起钩子把注册表里的每个 schema 都抽一遍：骨架 + 方法卡 + 缺口台账各一行
     rows = sorted(await _extraction_rows(paper_id), key=lambda r: r.schema_id)
-    assert [r.schema_id for r in rows] == ["method", "skeleton"]
-    assert "Hooked Extraction Paper" in rows[1].payload["problem"]
-    assert rows[0].payload["purpose"]
+    assert [r.schema_id for r in rows] == ["gaps", "method", "skeleton"]
+    assert "Hooked Extraction Paper" in rows[2].payload["problem"]
+    assert rows[1].payload["purpose"]
+    assert rows[0].payload["entries"]
 
 
 async def test_enrich_hook_zero_output_without_fulltext(client):

--- a/src/frontend/src/features/wiki/GapsTab.tsx
+++ b/src/frontend/src/features/wiki/GapsTab.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { api, type GapKind, type LibraryGapEntry } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+
+/* ============================================================
+   研究缺口台账（#665）：库内论文里「别人还没解决的问题 / 相互矛盾的
+   结论 / 失败的尝试」的聚合视图。每条都带逐字原文摘录（引用块），
+   点论文名跳论文库详情。顶部先摆疑似矛盾对——启发式匹配（共享概念
+   词 + 一侧否定措辞），明确标注请读者对照双方原文自行核对。
+   ============================================================ */
+
+const KIND_META: Record<GapKind, { zh: string; en: string; tone: string }> = {
+  gap: { zh: '没人解决的问题', en: 'Open problem', tone: 'var(--accent)' },
+  contradiction: { zh: '矛盾的结论', en: 'Contradiction', tone: 'var(--warn-tx)' },
+  uncertainty: { zh: '尚不确定', en: 'Uncertain', tone: 'var(--text-3)' },
+  negative_result: { zh: '失败的尝试', en: 'Negative result', tone: 'var(--danger-tx)' },
+  limitation: { zh: '作者自述局限', en: 'Limitation', tone: 'var(--text-3)' },
+};
+
+const KIND_FILTERS: (GapKind | 'all')[] = [
+  'all',
+  'gap',
+  'contradiction',
+  'negative_result',
+  'uncertainty',
+  'limitation',
+];
+
+function KindBadge({ kind }: { kind: GapKind }) {
+  const meta = KIND_META[kind];
+  if (!meta) return null;
+  return (
+    <span className="pill" style={{ color: meta.tone, fontSize: 11, flexShrink: 0 }}>
+      {tr(meta.zh, meta.en)}
+    </span>
+  );
+}
+
+function GapCard({ entry, onOpenPaper }: { entry: LibraryGapEntry; onOpenPaper: (id: string) => void }) {
+  return (
+    <div className="card" style={{ padding: '12px 14px' }}>
+      <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        <KindBadge kind={entry.kind} />
+        <span
+          style={{ fontSize: 12, fontWeight: 600, cursor: 'pointer', color: 'var(--accent)', minWidth: 0 }}
+          title={tr('点击打开论文', 'Click to open the paper')}
+          onClick={() => onOpenPaper(entry.paper_id)}
+        >
+          {entry.paper_title}
+        </span>
+        {entry.year != null && (
+          <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{entry.year}</span>
+        )}
+      </div>
+      <div style={{ fontSize: 13, lineHeight: 1.7, marginTop: 6 }}>{entry.statement}</div>
+      {/* 原文摘录：台账的锚点——AI 归纳可疑时，读者靠这段核对出处 */}
+      <blockquote
+        style={{
+          margin: '8px 0 0',
+          padding: '4px 10px',
+          borderLeft: '3px solid var(--border-2)',
+          fontSize: 12,
+          color: 'var(--text-3)',
+          lineHeight: 1.6,
+        }}
+      >
+        {entry.source_span}
+      </blockquote>
+    </div>
+  );
+}
+
+export function GapsTab({
+  libraryId,
+  onOpenPaper,
+}: {
+  libraryId: string;
+  onOpenPaper: (id: string) => void;
+}) {
+  const [kind, setKind] = useState<GapKind | 'all'>('all');
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['library-gaps', libraryId, kind],
+    queryFn: () => api.getLibraryGaps(libraryId, kind === 'all' ? {} : { kind }),
+    retry: false,
+  });
+
+  const entries = data?.entries ?? [];
+  const pairs = data?.pairs ?? [];
+
+  return (
+    <div className="col" style={{ flex: 1, minHeight: 0 }}>
+      <div style={{ padding: '14px 16px 10px', borderBottom: '1px solid var(--border)' }}>
+        <div style={{ fontSize: 13, color: 'var(--text-2)' }}>
+          {tr(
+            '从库内论文全文里自动整理：别人还没解决的问题、相互矛盾的结论、失败的尝试。每条都附原文出处。',
+            'Auto-collected from full texts in this library: open problems, contradictory findings, failed attempts — each anchored to a verbatim quote.',
+          )}
+        </div>
+        <div className="row gap6 wrap" style={{ marginTop: 10 }}>
+          {KIND_FILTERS.map((f) => (
+            <span key={f} className={`chip${kind === f ? ' on' : ''}`} onClick={() => setKind(f)}>
+              {f === 'all' ? tr('全部', 'All') : tr(KIND_META[f].zh, KIND_META[f].en)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="scroll" style={{ overflowY: 'auto', flex: 1, padding: 16 }}>
+        {isLoading ? (
+          <div className="empty">{tr('整理研究缺口…', 'Collecting research gaps…')}</div>
+        ) : isError ? (
+          <EmptyState
+            compact
+            icon="x"
+            title={tr('无法加载研究缺口', 'Failed to load research gaps')}
+            desc={tr('后端不可用或接口尚未就绪，稍后重试。', 'Backend unavailable or API not ready — try again later.')}
+          />
+        ) : entries.length === 0 ? (
+          <EmptyState
+            compact
+            icon="bulb"
+            title={tr('还没有条目', 'Nothing here yet')}
+            desc={tr(
+              '论文全文就位后会自动整理；也可能这个筛选下确实没有。',
+              'Entries appear automatically once full texts are processed; or this filter simply has none.',
+            )}
+          />
+        ) : (
+          <div className="col gap10">
+            {pairs.length > 0 && (
+              <div className="card" style={{ padding: '12px 14px', background: 'var(--warn-bg)' }}>
+                <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+                  <Icon name="scale" size={14} />
+                  <b style={{ fontSize: 13 }}>{tr('疑似矛盾的结论', 'Possible contradictions')}</b>
+                  <span style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                    {tr('按共同关键词自动匹配，请对照双方原文核实', 'Matched by shared keywords — verify against both quotes')}
+                  </span>
+                </div>
+                <div className="col gap10" style={{ marginTop: 10 }}>
+                  {pairs.map((pair, i) => (
+                    <div key={i} className="col gap6">
+                      <GapCard entry={pair.a} onOpenPaper={onOpenPaper} />
+                      <div style={{ fontSize: 11, color: 'var(--text-3)', textAlign: 'center' }}>
+                        {tr('↕ 说法对不上', '↕ These disagree')}
+                        {pair.shared_terms.length > 0 && ` · ${pair.shared_terms.join(' / ')}`}
+                      </div>
+                      <GapCard entry={pair.b} onOpenPaper={onOpenPaper} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {entries.map((entry, i) => (
+              <GapCard key={i} entry={entry} onOpenPaper={onOpenPaper} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/wiki/WikiPage.tsx
+++ b/src/frontend/src/features/wiki/WikiPage.tsx
@@ -15,6 +15,7 @@ import { IngestTab } from './IngestTab';
 import { NotesTab } from './NotesTab';
 import { MethodsTab } from './MethodsTab';
 import { GovernanceTab } from './GovernanceTab';
+import { GapsTab } from './GapsTab';
 import { LiteratureDiscoveryPanel } from '../libraries/LiteratureDiscoveryPage';
 
 // 图谱与 PPT 弹窗体量大且非默认视图：按需加载
@@ -34,7 +35,7 @@ const PresentationModal = lazy(() =>
    从哪个课题建的，如今仅用来决定要不要显示课题域的 PPT。
    ============================================================ */
 
-type WikiTab = 'discover' | 'papers' | 'concepts' | 'methods' | 'graph' | 'digest' | 'chat' | 'qa' | 'ingest' | 'notes' | 'govern';
+type WikiTab = 'discover' | 'papers' | 'concepts' | 'methods' | 'graph' | 'gaps' | 'digest' | 'chat' | 'qa' | 'ingest' | 'notes' | 'govern';
 
 export function WikiWorkbench({
   pid,
@@ -104,7 +105,7 @@ export function WikiWorkbench({
         seq: (old?.seq ?? 0) + 1,
       }));
       setTab('papers');
-    } else if (tabParam && ['discover', 'papers', 'concepts', 'methods', 'graph', 'digest', 'chat', 'qa', 'ingest', 'notes', 'govern'].includes(tabParam)) {
+    } else if (tabParam && ['discover', 'papers', 'concepts', 'methods', 'graph', 'gaps', 'digest', 'chat', 'qa', 'ingest', 'notes', 'govern'].includes(tabParam)) {
       setTab(tabParam as WikiTab);
     }
     setSearchParams({}, { replace: true });
@@ -173,6 +174,8 @@ export function WikiWorkbench({
             // 方法库走 /libraries/{id}/methods，只有库作用域有这个端点
             ...(libraryId ? [{ v: 'methods' as const, label: tr('方法库', 'Methods') }] : []),
             { v: 'graph', label: tr('图谱', 'Graph') },
+            // 研究缺口台账（#665）走 /libraries/{id}/gaps，只有库作用域有这个端点
+            ...(libraryId ? [{ v: 'gaps' as const, label: tr('研究缺口', 'Research gaps') }] : []),
             ...(libraryId ? [{ v: 'digest' as const, label: tr('每日简报', 'Daily digest') }] : []),
             { v: 'chat', label: tr('文献对话', 'Chat') },
             // 深度问答走 /libraries/{id}/qa，只有库作用域有这个端点
@@ -254,6 +257,8 @@ export function WikiWorkbench({
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
             <GraphTab pid={pid} libraryId={tabLibraryId} onOpenPaper={goPaper} onOpenConcept={goConcept} />
           </Suspense>
+        ) : tab === 'gaps' && libraryId ? (
+          <GapsTab libraryId={libraryId} onOpenPaper={goPaper} />
         ) : tab === 'digest' && libraryId ? (
           <Suspense fallback={<div className="skel" style={{ flex: 1, margin: 16 }} />}>
             <DailyDigestTab

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -672,6 +672,7 @@ export const LLM_STAGES = [
   'citation_intent',
   'extract_skeleton',
   'extract_method',
+  'extract_gaps',
   'rag_expand',
   'rag_rerank',
   'rag_answer',
@@ -1600,6 +1601,32 @@ export interface LibraryBudgetRead {
   remaining_tokens: number | null;
   /** true = 本月预算已用尽（同步任务会被拒绝启动） */
   exhausted: boolean;
+}
+
+/** 缺口台账条目种类（#665）：别人没解决的 / 相互矛盾的 / 不确定的 / 失败的尝试 / 自述局限 */
+export type GapKind = 'gap' | 'contradiction' | 'uncertainty' | 'negative_result' | 'limitation';
+
+/** 缺口台账的一条：statement 是 AI 归纳，source_span 是逐字原文摘录（锚定出处）。 */
+export interface LibraryGapEntry {
+  paper_id: string;
+  paper_title: string;
+  kind: GapKind;
+  statement: string;
+  source_span: string;
+  year: number | null;
+}
+
+/** 疑似矛盾对：启发式匹配（heuristic 恒 true），前端须提示用户核对双方原文。 */
+export interface LibraryGapPair {
+  a: LibraryGapEntry;
+  b: LibraryGapEntry;
+  shared_terms: string[];
+  heuristic: boolean;
+}
+
+export interface LibraryGapsRead {
+  entries: LibraryGapEntry[];
+  pairs: LibraryGapPair[];
 }
 
 // ============================================================
@@ -4187,6 +4214,14 @@ export const api = {
   /** 未连接概念对：可能有关联但还没在同一篇论文里出现过的概念组合（确定性挖掘）。 */
   listLibraryConceptPairs(id: string, top = 20): Promise<UnconnectedConceptPair[]> {
     return request<UnconnectedConceptPair[]>(`/libraries/${id}/concept-pairs?top=${top}`);
+  },
+  /** 库级研究缺口台账（#665）：聚合库内论文的缺口/矛盾/负结果条目。 */
+  getLibraryGaps(id: string, opts: { kind?: GapKind; top?: number } = {}): Promise<LibraryGapsRead> {
+    const params = new URLSearchParams();
+    if (opts.kind) params.set('kind', opts.kind);
+    if (opts.top) params.set('top', String(opts.top));
+    const qs = params.toString();
+    return request<LibraryGapsRead>(`/libraries/${id}/gaps${qs ? `?${qs}` : ''}`);
   },
   searchLibrary(
     id: string,

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -31,6 +31,7 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   citation_intent: { zh: '引文意图分类', en: 'Citation intent classification' },
   extract_skeleton: { zh: '结构化摘要抽取', en: 'Structured summary extraction' },
   extract_method: { zh: '方法卡抽取', en: 'Method card extraction' },
+  extract_gaps: { zh: '研究缺口抽取', en: 'Research gap extraction' },
   rag_expand: { zh: '库问答·查询扩展', en: 'Library Q&A · query expansion' },
   rag_rerank: { zh: '库问答·重排摘要', en: 'Library Q&A · rerank & summarize' },
   rag_answer: { zh: '库问答·作答', en: 'Library Q&A · answering' },


### PR DESCRIPTION
Closes #665. Part of #660 (P2.5 wave 2, item F4); design report §11 fuels 2+4 (GAPMAP-style).

A fine-grained, source-anchored ledger of what the literature says is unsolved, contradictory, uncertain, or failed — distinct from the skeleton's coarse self-stated limitations (division of labor documented at the schema).

- `gaps@1` is the third built-in extraction schema, introducing an `entries` field kind to the runtime: lists of typed objects with per-key whitelists and caps. Normalization is take-whole-or-drop: missing/invalid kind, empty statement, or an empty `source_span` discards the entry — anchoring is a hard requirement, an unanchored claim is worth less than no claim
- entry shape: kind ∈ gap|contradiction|uncertainty|negative_result|limitation, an LLM-condensed statement, and a verbatim source excerpt
- `gap_ledger.library_gaps`: library-level aggregation (recycle bin excluded), ranked by paper year plus kind weights calibrated as equivalent-years so recency and kind can trade off
- contradiction pairs ship as an honest heuristic: cross-paper statements sharing ≥2 concept terms where exactly one side carries negation/refutation phrasing, flagged `heuristic: true` with the shared terms shown — ContraCrow-style LLM adjudication is O(n²) model calls and stays a future on-demand trigger (rationale in the docstring)
- `GET /libraries/{id}/gaps` (visibility-gated) and a "research gaps" library tab: plain-language kind chips, statement + source-quote cards with paper links, heuristic pairs pinned with a verify-against-both-sources caveat
- storage rides `paper_extractions` (#662) — no migration; the enrich hook follows F2's registry-iteration design (this branch deleted its own hand-kept schema list during the rebase, since registration alone now wires a schema in)

Verification: rebased across #666/#667 with semantic merges (three schemas coexist; cross-suite reconciliation green: extraction 3-row hook assertions, method library, concept fuels, stage parity both sides); clean-baseline failure set unchanged, zero new real failures; 12 new tests; goldens untouched; frontend build + vitest 150 green.