### PR TITLE
feat: comparison tables with per-cell provenance

### DIFF
--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -35,6 +35,8 @@ from app.models.user import User
 from app.schemas.graph import GraphResponse, UnconnectedConceptPair
 from app.schemas.ingest import DigestGenerateRead, IngestRequest, IngestStateRead
 from app.schemas.libraries import (
+    ComparisonRequest,
+    ComparisonTableRead,
     DirectionLibraryDetail,
     DirectionLibrarySummary,
     DirectionLibraryUpdate,
@@ -76,6 +78,7 @@ from app.schemas.paper import (
 from app.schemas.voyage import VoyageRead
 from app.services import chunks as chunks_service
 from app.services import citations as citations_service
+from app.services import comparison as comparison_service
 from app.services import concept_fuels as concept_fuels_service
 from app.services import concepts as concepts_service
 from app.services import gap_ledger as gap_ledger_service
@@ -662,6 +665,33 @@ async def list_library_gaps(
             for pair in pairs
         ],
     )
+
+
+@router.post("/libraries/{library_id}/comparison", response_model=ComparisonTableRead)
+async def build_library_comparison(
+    library_id: uuid.UUID,
+    data: ComparisonRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ComparisonTableRead:
+    """论文对比表（#669）：行 = skeleton/method 抽取字段，列 = 所选论文（2..10 篇）。
+
+    纯读存量抽取产物，零 LLM（见 services/comparison.py）。POST 而非 GET 是因为
+    paper_ids 列表进 URL 会顶到长度上限，且本端点无副作用、无需缓存。
+    条数越界由 body 校验挡（422）；所选论文不属本库按 404——与库不可见同一
+    口径，不泄漏内容池里该论文是否存在。
+    """
+    library = await _get_visible_library(session, library_id, user)
+    try:
+        table = await comparison_service.build_comparison(session, library.id, data.paper_ids)
+    except comparison_service.PaperNotInLibraryError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PAPER_NOT_FOUND") from exc
+    except ValueError as exc:
+        # body 校验已挡 >10；这里兜底服务层帽子（防未来有内部调用绕开校验）
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail="TOO_MANY_PAPERS"
+        ) from exc
+    return ComparisonTableRead.model_validate(table, from_attributes=True)
 
 
 @router.get("/libraries/{library_id}/search", response_model=SearchResponse)

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -319,3 +319,51 @@ class LibraryGapsRead(BaseModel):
     entries: list[LibraryGapEntryRead] = []
     # 矛盾对在返回的 entries 范围内配（kind 筛选时对子也跟着窄）
     pairs: list[LibraryGapPairRead] = []
+
+
+# ---- 论文对比表（#669，设计报告 §10 ④层） ----
+
+
+class ComparisonRequest(BaseModel):
+    """对比请求：paper_ids 的顺序就是表的列序（前端勾选顺序）。
+
+    条数在 body 校验层夹住（2..10 → 越界直接 422）：少于 2 篇没有「对比」可言，
+    多于 10 篇属于综述场景，本批次刻意不做（services/comparison.py）。
+    """
+
+    paper_ids: list[uuid.UUID] = Field(min_length=2, max_length=10)
+
+
+class ComparisonCellRead(BaseModel):
+    """一个格子：present=False 时前端显示「未抽取」而非空白（缺口要可见）。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    value: str | None = None
+    present: bool = False
+    # 溯源：该格出自哪个抽取 schema、何时抽的（没抽过为 None）
+    schema_id: str
+    extracted_at: datetime | None = None
+
+
+class ComparisonRowRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    field: str  # skeleton/method 的字段名（problem/method/…/protocol）
+    schema_id: str
+    cells: list[ComparisonCellRead] = []
+
+
+class ComparisonPaperRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    paper_id: uuid.UUID
+    title: str
+    year: int | None = None
+
+
+class ComparisonTableRead(BaseModel):
+    """行 = 抽取字段，列 = 论文；cells 与 papers 同序同长。"""
+
+    papers: list[ComparisonPaperRead] = []
+    rows: list[ComparisonRowRead] = []

--- a/src/backend/app/services/comparison.py
+++ b/src/backend/app/services/comparison.py
@@ -1,0 +1,176 @@
+"""论文对比表（#669，设计报告 §10 ④层）。
+
+刻意只做**定向表格**，不做整篇综述：行 = skeleton@1 + method@1 的九个抽取字段，
+列 = 用户挑的论文（≤10 篇）。全部数据来自 paper_extractions 的存量产物——
+本文件零 LLM 调用，判断性工作（逐篇抽字段）已在抽取环节做完，对比层只是
+查表 + 摆盘。这样表格秒开、免费、可复算；「先抽后比」也让每个 cell 都能
+指回它的抽取来源（schema_id + extracted_at），综述式的一锅炖给不了这种溯源。
+
+没抽过的论文不挡对比：cell 标 present=False，前端显示「未抽取」并提示去论文
+详情抽——比起悄悄跳过该论文或整表报错，摆一列空位让用户看见缺口在哪。
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.library_direction import LibraryPaper
+from app.models.paper import Paper
+from app.models.paper_extraction import PaperExtraction
+from app.services.extraction.schemas import METHOD_SCHEMA, SKELETON_SCHEMA
+
+# 对比上限：表格是横向并排读的，10 列已经到「一屏放不下、肉眼对不过来」的边缘；
+# 更多论文的横向归纳属于综述场景，本批次刻意不做（见模块 docstring）。
+MAX_COMPARISON_PAPERS = 10
+
+# 行序 = skeleton 四字段在前（任何学科都答得上的骨架），method 五字段在后
+# （复现要素）。直接从 schema 定义推导，字段集演进时对比表自动跟上，不留手抄副本。
+COMPARISON_FIELDS: tuple[tuple[str, str, str], ...] = tuple(
+    (field.name, field.kind, schema.id)
+    for schema in (SKELETON_SCHEMA, METHOD_SCHEMA)
+    for field in schema.fields
+)
+
+
+class PaperNotInLibraryError(LookupError):
+    """请求的论文不在该库（或在回收站）：API 层按 404 处理，不泄漏内容池里是否存在。"""
+
+
+@dataclass(slots=True)
+class ComparisonCell:
+    """一个格子：值 + 是否抽到 + 出处（哪个 schema、何时抽的）。
+
+    present=False 覆盖两种情况：该论文没跑过这个 schema（extracted_at 为 None），
+    或跑过但该字段归一化后为空（extracted_at 保留）。前端统一显示「未抽取」，
+    extracted_at 留给需要细究的读者。
+    """
+
+    value: str | None
+    present: bool
+    schema_id: str
+    extracted_at: datetime | None
+
+
+@dataclass(slots=True)
+class ComparisonRow:
+    field: str
+    schema_id: str
+    cells: list[ComparisonCell]
+
+
+@dataclass(slots=True)
+class ComparisonPaper:
+    paper_id: uuid.UUID
+    title: str
+    year: int | None
+
+
+@dataclass(slots=True)
+class ComparisonTable:
+    papers: list[ComparisonPaper]
+    rows: list[ComparisonRow]
+
+
+def _render_value(raw: object, kind: str) -> str | None:
+    """把抽取产物的一个字段拍成展示串：text 原样，list 用中文分号串起来。
+
+    拍成串而不是把 list 透传给前端：对比表和 CSV 导出都按「一格一段文字」
+    消费，渲染口径收在后端一处，两端不会各拼各的。
+    """
+    if kind == "list":
+        if not isinstance(raw, list) or not raw:
+            return None
+        return "；".join(str(item) for item in raw if str(item).strip()) or None
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+async def build_comparison(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    paper_ids: list[uuid.UUID],
+) -> ComparisonTable:
+    """构建对比表：列序 = 请求顺序（去重后），行序 = COMPARISON_FIELDS。
+
+    列序跟请求走是刻意的——用户在列表里勾选的顺序就是他想并排看的顺序，
+    CSV 导出也依赖这份稳定顺序。成员口径与缺口台账一致：非回收站论文。
+
+    Raises:
+        ValueError: 超过 MAX_COMPARISON_PAPERS 篇（API 层由 body 校验先挡，这里兜底）。
+        PaperNotInLibraryError: 有论文不属于该库或在回收站。
+    """
+    # 去重但保序：同一篇勾两次不该出两列，也不该打乱其余列的顺序
+    ordered_ids = list(dict.fromkeys(paper_ids))
+    if len(ordered_ids) > MAX_COMPARISON_PAPERS:
+        raise ValueError(f"comparison supports at most {MAX_COMPARISON_PAPERS} papers")
+
+    rows = (
+        (
+            await session.execute(
+                select(Paper)
+                .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                .where(
+                    LibraryPaper.library_id == library_id,
+                    LibraryPaper.status != "excluded",
+                    Paper.id.in_(ordered_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_id = {paper.id: paper for paper in rows}
+    missing = [pid for pid in ordered_ids if pid not in by_id]
+    if missing:
+        raise PaperNotInLibraryError(f"papers not in library: {missing}")
+
+    schema_ids = {SKELETON_SCHEMA.id, METHOD_SCHEMA.id}
+    extractions = (
+        (
+            await session.execute(
+                select(PaperExtraction).where(
+                    PaperExtraction.paper_id.in_(ordered_ids),
+                    PaperExtraction.schema_id.in_(schema_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # (paper_id, schema_id) 唯一（表约束），直接建索引
+    by_key = {(row.paper_id, row.schema_id): row for row in extractions}
+
+    table_rows: list[ComparisonRow] = []
+    for field_name, kind, schema_id in COMPARISON_FIELDS:
+        cells: list[ComparisonCell] = []
+        for pid in ordered_ids:
+            extraction = by_key.get((pid, schema_id))
+            value = (
+                _render_value(extraction.payload.get(field_name), kind)
+                if extraction is not None
+                else None
+            )
+            cells.append(
+                ComparisonCell(
+                    value=value,
+                    present=value is not None,
+                    schema_id=schema_id,
+                    extracted_at=extraction.updated_at if extraction is not None else None,
+                )
+            )
+        table_rows.append(ComparisonRow(field=field_name, schema_id=schema_id, cells=cells))
+
+    return ComparisonTable(
+        papers=[
+            ComparisonPaper(paper_id=pid, title=by_id[pid].title, year=by_id[pid].year)
+            for pid in ordered_ids
+        ],
+        rows=table_rows,
+    )

--- a/src/backend/tests/test_comparison.py
+++ b/src/backend/tests/test_comparison.py
@@ -1,0 +1,292 @@
+"""论文对比表（#669）：表构建（有/无产物混合、列序、list 渲染）、条数帽、
+越界论文、端点权限。全链路零 LLM——数据直接种 paper_extractions。"""
+
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.models.paper_extraction import PaperExtraction
+from app.services.comparison import (
+    COMPARISON_FIELDS,
+    MAX_COMPARISON_PAPERS,
+    PaperNotInLibraryError,
+    build_comparison,
+)
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+# 行序契约：skeleton 四字段在前，method 五字段在后（从 schema 推导，这里锚死
+# 顺序——前端 CSV 导出与 vitest 对着同一份顺序断言）
+EXPECTED_FIELDS = [
+    "problem",
+    "method",
+    "findings",
+    "limitations",
+    "purpose",
+    "mechanism",
+    "baseline",
+    "dataset",
+    "protocol",
+]
+
+
+def test_comparison_fields_order():
+    assert [f for f, _, _ in COMPARISON_FIELDS] == EXPECTED_FIELDS
+    # 字段归属：前四行 skeleton，后五行 method
+    assert [s for _, _, s in COMPARISON_FIELDS] == ["skeleton"] * 4 + ["method"] * 5
+
+
+async def _seed_papers(session, project_id, specs):
+    """按 specs 造论文：specs = [(title, year, status, {schema_id: payload})]。"""
+    papers = []
+    for title, year, status, extractions in specs:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title=title, year=year, status=status
+        )
+        for schema_id, payload in extractions.items():
+            session.add(
+                PaperExtraction(paper_id=paper.id, schema_id=schema_id, payload=payload)
+            )
+        papers.append(paper)
+    await session.commit()
+    return papers
+
+
+SKELETON_PAYLOAD = {
+    "problem": "问题 A",
+    "method": "方法 A",
+    "findings": ["发现一", "发现二"],
+    "limitations": ["局限一"],
+}
+METHOD_PAYLOAD = {
+    "purpose": "目的 A",
+    "mechanism": "机制 A",
+    "baseline": ["B1", "B2"],
+    "dataset": ["D1"],
+    "protocol": "流程 A",
+}
+
+
+# ---- 1. 表构建：有/无产物混合、列序、list 渲染 ----
+
+
+async def test_build_comparison_mixed(client):
+    token = await register_and_login(client, email="cmp@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="cmp")
+
+    async with get_sessionmaker()() as session:
+        full, partial, blank = await _seed_papers(
+            session,
+            project_id,
+            [
+                (
+                    "Full Paper",
+                    2026,
+                    "compiled",
+                    {"skeleton": SKELETON_PAYLOAD, "method": METHOD_PAYLOAD},
+                ),
+                # 只抽过 skeleton，且 payload 缺 limitations 键（归一化丢空字段的存量形态）
+                (
+                    "Partial Paper",
+                    2024,
+                    "compiled",
+                    {"skeleton": {"problem": "问题 B", "method": "方法 B", "findings": []}},
+                ),
+                ("Blank Paper", None, "compiled", {}),
+            ],
+        )
+        ids = [full.id, partial.id, blank.id]
+
+    async with get_sessionmaker()() as session:
+        # 列序跟请求走：故意用 blank, full, partial 的顺序
+        table = await build_comparison(session, library_id, [ids[2], ids[0], ids[1]])
+
+    assert [p.title for p in table.papers] == ["Blank Paper", "Full Paper", "Partial Paper"]
+    assert [p.year for p in table.papers] == [None, 2026, 2024]
+    assert [r.field for r in table.rows] == EXPECTED_FIELDS
+    by_field = {r.field: r for r in table.rows}
+
+    # list 字段渲染成中文分号串
+    findings = by_field["findings"]
+    assert findings.cells[1].value == "发现一；发现二"
+    assert findings.cells[1].present is True
+    assert findings.cells[1].schema_id == "skeleton"
+    assert findings.cells[1].extracted_at is not None
+
+    # 没抽过：present=False 且 extracted_at=None（前端据此显示「未抽取」）
+    assert findings.cells[0].present is False
+    assert findings.cells[0].value is None
+    assert findings.cells[0].extracted_at is None
+
+    # 抽过但字段为空（findings=[] / 缺 limitations 键）：present=False，extracted_at 保留
+    assert findings.cells[2].present is False
+    assert findings.cells[2].extracted_at is not None
+    assert by_field["limitations"].cells[2].present is False
+
+    # method 行对只抽 skeleton 的论文是「没抽过」
+    purpose = by_field["purpose"]
+    assert purpose.cells[1].value == "目的 A"
+    assert purpose.cells[2].present is False and purpose.cells[2].extracted_at is None
+
+    # 每行 cells 与 papers 同长同序
+    assert all(len(r.cells) == 3 for r in table.rows)
+
+
+async def test_build_comparison_dedupes_preserving_order(client):
+    token = await register_and_login(client, email="cmpdedupe@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="cmpdedupe")
+
+    async with get_sessionmaker()() as session:
+        a, b = await _seed_papers(
+            session,
+            project_id,
+            [("Paper A", 2026, "compiled", {}), ("Paper B", 2025, "compiled", {})],
+        )
+        ids = [a.id, b.id]
+
+    async with get_sessionmaker()() as session:
+        table = await build_comparison(session, library_id, [ids[1], ids[0], ids[1]])
+    assert [p.title for p in table.papers] == ["Paper B", "Paper A"]
+
+
+# ---- 2. 条数帽 / 越界论文 ----
+
+
+async def test_build_comparison_caps_paper_count(client):
+    token = await register_and_login(client, email="cmpcap@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    _, library_id = await make_project_with_library(client, headers, name="cmpcap")
+
+    async with get_sessionmaker()() as session:
+        with pytest.raises(ValueError):
+            await build_comparison(
+                session, library_id, [uuid.uuid4() for _ in range(MAX_COMPARISON_PAPERS + 1)]
+            )
+
+
+async def test_build_comparison_rejects_foreign_and_trashed_papers(client):
+    token = await register_and_login(client, email="cmpforeign@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="cmpforeign")
+
+    async with get_sessionmaker()() as session:
+        member, trashed = await _seed_papers(
+            session,
+            project_id,
+            [
+                ("Member Paper", 2026, "compiled", {}),
+                # 回收站论文与库外论文同罪：不该出现在对比里
+                ("Trashed Paper", 2026, "excluded", {}),
+            ],
+        )
+        member_id, trashed_id = member.id, trashed.id
+
+    async with get_sessionmaker()() as session:
+        with pytest.raises(PaperNotInLibraryError):
+            await build_comparison(session, library_id, [member_id, uuid.uuid4()])
+        with pytest.raises(PaperNotInLibraryError):
+            await build_comparison(session, library_id, [member_id, trashed_id])
+
+
+# ---- 3. 端点：形状 / 校验 / 权限 ----
+
+
+async def test_comparison_endpoint(client):
+    token = await register_and_login(client, email="cmpapi@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(client, headers, name="cmpapi")
+
+    async with get_sessionmaker()() as session:
+        extracted, raw = await _seed_papers(
+            session,
+            project_id,
+            [
+                (
+                    "Extracted Paper",
+                    2026,
+                    "compiled",
+                    {"skeleton": SKELETON_PAYLOAD, "method": METHOD_PAYLOAD},
+                ),
+                ("Raw Paper", 2025, "compiled", {}),
+            ],
+        )
+        ids = [str(extracted.id), str(raw.id)]
+
+    resp = await client.post(
+        f"/api/libraries/{library_id}/comparison", json={"paper_ids": ids}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [p["title"] for p in body["papers"]] == ["Extracted Paper", "Raw Paper"]
+    assert [r["field"] for r in body["rows"]] == EXPECTED_FIELDS
+    problem = body["rows"][0]
+    assert problem["schema_id"] == "skeleton"
+    assert problem["cells"][0] == {
+        "value": "问题 A",
+        "present": True,
+        "schema_id": "skeleton",
+        "extracted_at": problem["cells"][0]["extracted_at"],
+    }
+    assert problem["cells"][0]["extracted_at"] is not None
+    # 未抽取论文：present=False，前端显示「未抽取」而非空白
+    assert problem["cells"][1]["present"] is False
+    assert problem["cells"][1]["value"] is None
+
+    # 条数校验：<2 或 >10 都是 422（body 层）
+    resp = await client.post(
+        f"/api/libraries/{library_id}/comparison", json={"paper_ids": [ids[0]]}, headers=headers
+    )
+    assert resp.status_code == 422
+    resp = await client.post(
+        f"/api/libraries/{library_id}/comparison",
+        json={"paper_ids": [str(uuid.uuid4()) for _ in range(11)]},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    # 越界论文 → 404
+    resp = await client.post(
+        f"/api/libraries/{library_id}/comparison",
+        json={"paper_ids": [ids[0], str(uuid.uuid4())]},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "PAPER_NOT_FOUND"
+
+    # 未登录不可读
+    anon = await client.post(
+        f"/api/libraries/{library_id}/comparison", json={"paper_ids": ids}
+    )
+    assert anon.status_code == 401
+
+
+async def test_comparison_endpoint_personal_library_hidden(client):
+    owner = await register_and_login(client, email="cmpowner@example.com")
+    owner_headers = {"Authorization": f"Bearer {owner}"}
+    resp = await client.post(
+        "/api/libraries",
+        json={"name": "私人对比库", "statement": "只给自己看的方向"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    lib_id = resp.json()["id"]
+
+    fake_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    # 创建者可达（论文不存在 → 404 PAPER_NOT_FOUND，但库本身可见）
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/comparison", json={"paper_ids": fake_ids}, headers=owner_headers
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "PAPER_NOT_FOUND"
+
+    # 他人不可见：按库不存在处理（LIBRARY_NOT_FOUND，不泄漏个人库存在性）
+    other = await register_and_login(client, email="cmpother@example.com")
+    resp = await client.post(
+        f"/api/libraries/{lib_id}/comparison",
+        json={"paper_ids": fake_ids},
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "LIBRARY_NOT_FOUND"

--- a/src/frontend/src/features/wiki/ComparisonModal.tsx
+++ b/src/frontend/src/features/wiki/ComparisonModal.tsx
@@ -1,0 +1,205 @@
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { api } from '../../lib/api';
+import {
+  COMPARISON_FIELD_META,
+  comparisonColumnTitle,
+  comparisonToCsv,
+  type ComparisonCell,
+} from '../../lib/comparison';
+import { tr } from '../../lib/i18n';
+import { saveBlob } from './shared';
+
+/* ============================================================
+   论文对比表弹窗（#669，设计报告 §10 ④层）：论文列表多选 ≥2 篇后
+   打开。行 = skeleton/method 的九个抽取字段，列 = 所选论文，横向
+   滚动。数据全部来自存量抽取产物（零 LLM，秒开）；没抽过的论文
+   格子灰显「未抽取」——缺口摆出来，比悄悄留空诚实。
+   ============================================================ */
+
+function fieldLabel(field: string): string {
+  const meta = COMPARISON_FIELD_META[field];
+  // 后端 schema 演进先于前端标签表时兜底显示字段名，不至于空一格
+  return meta ? tr(meta.zh, meta.en) : field;
+}
+
+function CellContent({ cell }: { cell: ComparisonCell }) {
+  if (!cell.present || cell.value == null) {
+    return (
+      <span
+        style={{ color: 'var(--text-3)', fontStyle: 'italic' }}
+        title={tr('可在论文详情里运行抽取', 'Run extraction from the paper detail pane')}
+      >
+        {tr('未抽取', 'Not extracted')}
+      </span>
+    );
+  }
+  return <>{cell.value}</>;
+}
+
+export function ComparisonModal({
+  libraryId,
+  paperIds,
+  open,
+  onClose,
+}: {
+  libraryId: string;
+  paperIds: string[];
+  open: boolean;
+  onClose: () => void;
+}) {
+  const { data, isLoading, isError } = useQuery({
+    // paperIds 顺序就是列序，进 key：换一批或换顺序都算新表
+    queryKey: ['library-comparison', libraryId, paperIds],
+    queryFn: () => api.buildLibraryComparison(libraryId, paperIds),
+    enabled: open && paperIds.length >= 2,
+    retry: false,
+  });
+
+  const exportCsv = () => {
+    if (!data) return;
+    const csv = comparisonToCsv(data, {
+      fieldLabel,
+      fieldColumnTitle: tr('字段', 'Field'),
+      absentText: tr('未抽取', 'Not extracted'),
+    });
+    // BOM 让 Excel 认出 UTF-8（中文表头/正文不乱码）；纯函数不掺编码关注点，在这加
+    saveBlob(
+      new Blob(['\ufeff' + csv], { type: 'text/csv;charset=utf-8' }),
+      'polaris-comparison.csv',
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      width={1080}
+      title={
+        <>
+          <Icon name="grid" size={15} />
+          {tr('论文对比', 'Compare papers')}
+        </>
+      }
+      sub={tr(
+        '按结构化抽取字段并排对比所选论文；「未抽取」的论文可在论文详情里运行抽取后再来。',
+        'Side-by-side view over structured extraction fields; run extraction from the paper detail pane for “not extracted” papers.',
+      )}
+      footer={
+        <div className="row gap8" style={{ justifyContent: 'flex-end' }}>
+          <button className="btn btn-soft sm" disabled={!data} onClick={exportCsv}>
+            <Icon name="download" size={13} />
+            {tr('导出 CSV', 'Export CSV')}
+          </button>
+          <button className="btn btn-ghost sm" onClick={onClose}>
+            {tr('关闭', 'Close')}
+          </button>
+        </div>
+      }
+    >
+      {isLoading ? (
+        <div className="empty">{tr('生成对比表…', 'Building comparison…')}</div>
+      ) : isError || !data ? (
+        <EmptyState
+          compact
+          icon="x"
+          title={tr('无法生成对比表', 'Failed to build the comparison')}
+          desc={tr('后端不可用或所选论文已不在本库，稍后重试。', 'Backend unavailable or the papers left this library — try again later.')}
+        />
+      ) : (
+        <div style={{ overflowX: 'auto', maxHeight: '62vh', overflowY: 'auto' }}>
+          <table
+            style={{
+              borderCollapse: 'collapse',
+              fontSize: 12.5,
+              lineHeight: 1.6,
+              // 每列给个最小宽度，列多时横向滚动而不是挤成竖条
+              minWidth: 160 + data.papers.length * 240,
+            }}
+          >
+            <thead>
+              <tr>
+                <th
+                  style={{
+                    position: 'sticky',
+                    left: 0,
+                    top: 0,
+                    zIndex: 2,
+                    background: 'var(--bg-1)',
+                    textAlign: 'left',
+                    padding: '8px 10px',
+                    borderBottom: '1px solid var(--border)',
+                    minWidth: 96,
+                  }}
+                >
+                  {tr('字段', 'Field')}
+                </th>
+                {data.papers.map((paper) => (
+                  <th
+                    key={paper.paper_id}
+                    style={{
+                      position: 'sticky',
+                      top: 0,
+                      zIndex: 1,
+                      background: 'var(--bg-1)',
+                      textAlign: 'left',
+                      padding: '8px 10px',
+                      borderBottom: '1px solid var(--border)',
+                      minWidth: 220,
+                      maxWidth: 320,
+                      fontWeight: 640,
+                    }}
+                    title={comparisonColumnTitle(paper)}
+                  >
+                    {paper.title}
+                    {paper.year != null && (
+                      <span className="mono" style={{ marginLeft: 6, fontSize: 10.5, color: 'var(--text-3)', fontWeight: 400 }}>
+                        {paper.year}
+                      </span>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row) => (
+                <tr key={row.field}>
+                  <td
+                    style={{
+                      position: 'sticky',
+                      left: 0,
+                      background: 'var(--bg-1)',
+                      padding: '8px 10px',
+                      borderBottom: '0.5px solid var(--border)',
+                      fontWeight: 620,
+                      whiteSpace: 'nowrap',
+                      verticalAlign: 'top',
+                    }}
+                  >
+                    {fieldLabel(row.field)}
+                  </td>
+                  {row.cells.map((cell, i) => (
+                    <td
+                      key={data.papers[i]?.paper_id ?? i}
+                      style={{
+                        padding: '8px 10px',
+                        borderBottom: '0.5px solid var(--border)',
+                        verticalAlign: 'top',
+                        minWidth: 220,
+                        maxWidth: 320,
+                      }}
+                    >
+                      <CellContent cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/wiki/PapersTab.tsx
+++ b/src/frontend/src/features/wiki/PapersTab.tsx
@@ -56,6 +56,7 @@ import { paperDragProps } from '../assistant/paperDrag';
 import { clampLines } from '../../lib/clamp';
 import { splitPaperInput } from './paperInput';
 import { ExtensionBatchHistoryModal } from './ExtensionBatchHistoryModal';
+import { ComparisonModal } from './ComparisonModal';
 
 /* ============================================================
    论文库 Tab：左列表（过滤/搜索/排序/加载更多 + 添加文献/导出）
@@ -1352,6 +1353,8 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [trashOpen, setTrashOpen] = useState(false);
+  // 对比表（#669）：多选 2..10 篇后从底栏打开；paperIds 用勾选顺序（就是列序）
+  const [compareOpen, setCompareOpen] = useState(false);
   const [extensionHistoryOpen, setExtensionHistoryOpen] = useState(false);
   const queryClient = useQueryClient();
 
@@ -1849,6 +1852,21 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
                 disabled={selected.size === 0}
                 items={citationExportItems((format) => bulkExportMutation.mutate(format))}
               />
+              {libraryId && selected.size >= 2 && (
+                <button
+                  className="btn btn-soft sm"
+                  disabled={selected.size > 10}
+                  title={
+                    selected.size > 10
+                      ? tr('一次最多对比 10 篇', 'Compare at most 10 papers at once')
+                      : tr('按抽取字段并排对比所选论文', 'Compare the selected papers field by field')
+                  }
+                  onClick={() => setCompareOpen(true)}
+                >
+                  <Icon name="grid" size={12} />
+                  {tr('对比', 'Compare')}
+                </button>
+              )}
               {libraryId && canManage && (
                 <button
                   className="btn btn-soft sm"
@@ -1913,6 +1931,16 @@ export function PapersTab({ pid, libraryId, canManage = false, selectedId, onSel
           libraryId={libraryId}
           open={extensionHistoryOpen}
           onClose={() => setExtensionHistoryOpen(false)}
+        />
+      )}
+
+      {/* —— 论文对比表（#669） —— */}
+      {libraryId && (
+        <ComparisonModal
+          libraryId={libraryId}
+          paperIds={[...selected]}
+          open={compareOpen}
+          onClose={() => setCompareOpen(false)}
         />
       )}
     </div>

--- a/src/frontend/src/lib/__tests__/comparison.test.ts
+++ b/src/frontend/src/lib/__tests__/comparison.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPARISON_FIELD_META,
+  comparisonColumnTitle,
+  comparisonToCsv,
+  csvEscape,
+  type ComparisonCell,
+  type ComparisonTable,
+} from '../comparison';
+
+/* ============================================================
+   对比表 CSV 拼装（#669）：纯函数，重点测三件事——
+   ① absent cell 落调用方给的占位文案（不是空白也不是 "null"）；
+   ② list 字段后端已拼成串，CSV 原样透传；
+   ③ RFC 4180 转义（逗号 / 引号 / 换行）不破列。
+   顺序稳定（行 = rows 原序，列 = papers 原序）是导出可复算的前提。
+   ============================================================ */
+
+function cell(value: string | null, extra: Partial<ComparisonCell> = {}): ComparisonCell {
+  return {
+    value,
+    present: value != null,
+    schema_id: 'skeleton',
+    extracted_at: value != null ? '2026-09-01T00:00:00Z' : null,
+    ...extra,
+  };
+}
+
+const TABLE: ComparisonTable = {
+  papers: [
+    { paper_id: 'p1', title: 'Paper One', year: 2026 },
+    { paper_id: 'p2', title: 'Paper, "Two"', year: null },
+  ],
+  rows: [
+    { field: 'problem', schema_id: 'skeleton', cells: [cell('问题 A'), cell(null)] },
+    // list 字段：后端已用中文分号拼串，前端原样进 CSV
+    { field: 'findings', schema_id: 'skeleton', cells: [cell('发现一；发现二'), cell(null)] },
+    {
+      field: 'protocol',
+      schema_id: 'method',
+      cells: [cell('步骤1, 然后 "验证"\n换行继续'), cell(null)],
+    },
+  ],
+};
+
+describe('csvEscape', () => {
+  it('leaves plain cells untouched', () => {
+    expect(csvEscape('问题 A')).toBe('问题 A');
+  });
+
+  it('quotes commas, quotes and newlines; doubles inner quotes', () => {
+    expect(csvEscape('a,b')).toBe('"a,b"');
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+    expect(csvEscape('line1\nline2')).toBe('"line1\nline2"');
+  });
+});
+
+describe('comparisonColumnTitle', () => {
+  it('appends year only when present', () => {
+    expect(comparisonColumnTitle(TABLE.papers[0]!)).toBe('Paper One (2026)');
+    expect(comparisonColumnTitle(TABLE.papers[1]!)).toBe('Paper, "Two"');
+  });
+});
+
+describe('comparisonToCsv', () => {
+  it('keeps row/column order, fills absent cells with the given text', () => {
+    const csv = comparisonToCsv(TABLE, {
+      fieldLabel: (f) => COMPARISON_FIELD_META[f]?.zh ?? f,
+      fieldColumnTitle: '字段',
+      absentText: '未抽取',
+    });
+    const lines = csv.split('\r\n');
+    // 表头 + 3 行 + 末尾换行产生的空串
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe('字段,Paper One (2026),"Paper, ""Two"""');
+    expect(lines[1]).toBe('研究问题,问题 A,未抽取');
+    expect(lines[2]).toBe('主要发现,发现一；发现二,未抽取');
+    // 含逗号/引号/换行的 cell 整体加引号、内部引号翻倍；cell 内的 \n 不是行分隔符
+    // （\r\n 才是），split 后整行仍是一条
+    expect(lines[3]).toBe('实验流程,"步骤1, 然后 ""验证""\n换行继续",未抽取');
+    expect(lines[4]).toBe('');
+  });
+
+  it('defaults: raw field names, empty absent cells', () => {
+    const csv = comparisonToCsv(TABLE);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('field,Paper One (2026),"Paper, ""Two"""');
+    expect(lines[1]).toBe('problem,问题 A,');
+  });
+
+  it('is byte-stable across repeated calls', () => {
+    expect(comparisonToCsv(TABLE)).toBe(comparisonToCsv(TABLE));
+  });
+
+  it('covers every backend field with a label', () => {
+    // 与后端 COMPARISON_FIELDS 对齐的九个字段都要有中文标签，缺了界面会露英文字段名
+    for (const field of [
+      'problem',
+      'method',
+      'findings',
+      'limitations',
+      'purpose',
+      'mechanism',
+      'baseline',
+      'dataset',
+      'protocol',
+    ]) {
+      expect(COMPARISON_FIELD_META[field], field).toBeTruthy();
+    }
+  });
+});

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { tr } from './i18n';
+import type { ComparisonTable } from './comparison';
 import { apiBase, serverOrigin } from './endpoint';
 import { readToken, writeToken } from './token-store';
 import { LocalUnavailable, noteLocalFailure, resolveLocalHandler } from './local-routes';
@@ -1602,6 +1603,9 @@ export interface LibraryBudgetRead {
   /** true = 本月预算已用尽（同步任务会被拒绝启动） */
   exhausted: boolean;
 }
+
+/** 论文对比表（#669）：类型与 CSV 纯函数同源（lib/comparison.ts），这里转出口给取数方 */
+export type { ComparisonCell, ComparisonPaper, ComparisonRow, ComparisonTable } from './comparison';
 
 /** 缺口台账条目种类（#665）：别人没解决的 / 相互矛盾的 / 不确定的 / 失败的尝试 / 自述局限 */
 export type GapKind = 'gap' | 'contradiction' | 'uncertainty' | 'negative_result' | 'limitation';
@@ -4222,6 +4226,12 @@ export const api = {
     if (opts.top) params.set('top', String(opts.top));
     const qs = params.toString();
     return request<LibraryGapsRead>(`/libraries/${id}/gaps${qs ? `?${qs}` : ''}`);
+  },
+  /** 论文对比表（#669）：行 = 抽取字段，列 = 所选论文（2..10 篇，顺序即列序）。 */
+  buildLibraryComparison(id: string, paperIds: string[]): Promise<ComparisonTable> {
+    return requestJson<ComparisonTable>(`/libraries/${id}/comparison`, 'POST', {
+      paper_ids: paperIds,
+    });
   },
   searchLibrary(
     id: string,

--- a/src/frontend/src/lib/comparison.ts
+++ b/src/frontend/src/lib/comparison.ts
@@ -1,0 +1,96 @@
+/* ============================================================
+   论文对比表（#669）：类型 + 纯函数（CSV 拼装）。
+   与后端 services/comparison.py 对齐：行 = skeleton/method 的九个
+   抽取字段，列 = 所选论文；cell 带 present/schema_id/extracted_at
+   溯源。纯函数抽在这里（不碰 DOM / fetch），vitest 直接测。
+   ============================================================ */
+
+export interface ComparisonCell {
+  /** 渲染串（list 字段后端已用中文分号拼好）；没抽到为 null */
+  value: string | null;
+  /** false = 没抽过该 schema，或抽过但该字段为空 → 界面显示「未抽取」而非空白 */
+  present: boolean;
+  schema_id: string;
+  extracted_at: string | null;
+}
+
+export interface ComparisonRow {
+  field: string;
+  schema_id: string;
+  /** 与 papers 同序同长 */
+  cells: ComparisonCell[];
+}
+
+export interface ComparisonPaper {
+  paper_id: string;
+  title: string;
+  year: number | null;
+}
+
+export interface ComparisonTable {
+  papers: ComparisonPaper[];
+  rows: ComparisonRow[];
+}
+
+/* 字段中文/英文标签：模块级常量按约定保留 {zh, en}，渲染处再 tr()
+   （i18n 约定：顶层 tr 不随语言切换重新求值）。 */
+export const COMPARISON_FIELD_META: Record<string, { zh: string; en: string }> = {
+  problem: { zh: '研究问题', en: 'Problem' },
+  method: { zh: '方法概述', en: 'Method' },
+  findings: { zh: '主要发现', en: 'Findings' },
+  limitations: { zh: '局限', en: 'Limitations' },
+  purpose: { zh: '方法目的', en: 'Purpose' },
+  mechanism: { zh: '核心机制', en: 'Mechanism' },
+  baseline: { zh: '基线', en: 'Baselines' },
+  dataset: { zh: '数据集', en: 'Datasets' },
+  protocol: { zh: '实验流程', en: 'Protocol' },
+};
+
+/** RFC 4180 口径的单元格转义：含逗号/引号/换行才加引号，内部引号翻倍。 */
+export function csvEscape(cell: string): string {
+  if (/[",\r\n]/.test(cell)) return `"${cell.replace(/"/g, '""')}"`;
+  return cell;
+}
+
+/** 列头：标题 + 年份（有才加）。年份进表头是为了导出后离线看也分得清同名论文。 */
+export function comparisonColumnTitle(paper: ComparisonPaper): string {
+  return paper.year != null ? `${paper.title} (${paper.year})` : paper.title;
+}
+
+/**
+ * 把对比表拼成 CSV 文本（不含 BOM——BOM 属下载环节的编码关注点，纯函数不掺）。
+ *
+ * 行序 = table.rows 原序，列序 = table.papers 原序（即用户勾选顺序），
+ * 两端各自稳定，重复导出逐字节一致。absent cell 落 absentText
+ * （界面上的「未抽取」由调用方传进来，纯函数不内置文案）。
+ */
+export function comparisonToCsv(
+  table: ComparisonTable,
+  opts: {
+    fieldLabel?: (field: string) => string;
+    absentText?: string;
+    /** 左上角表头（默认 'field'；界面导出时传「字段」的当前语言文案） */
+    fieldColumnTitle?: string;
+  } = {},
+): string {
+  const label = opts.fieldLabel ?? ((f: string) => f);
+  const absent = opts.absentText ?? '';
+  const lines: string[] = [];
+  lines.push(
+    [opts.fieldColumnTitle ?? 'field', ...table.papers.map(comparisonColumnTitle)]
+      .map(csvEscape)
+      .join(','),
+  );
+  for (const row of table.rows) {
+    lines.push(
+      [
+        label(row.field),
+        ...row.cells.map((cell) => (cell.present && cell.value != null ? cell.value : absent)),
+      ]
+        .map(csvEscape)
+        .join(','),
+    );
+  }
+  // 末尾带换行：POSIX 文本文件口径，也让追加式 diff 干净
+  return lines.join('\r\n') + '\r\n';
+}


### PR DESCRIPTION
Closes #669. Part of #660 (P2.5 wave 3, item F5); design report §10 layer ④ — deliberately targeted tables, no whole-survey generation.

- `comparison.build_comparison`: rows are derived from the skeleton + method schema definitions (no hand-kept copy), columns follow the request order (2–10 papers), cells read `paper_extractions` only — zero LLM. `present: false` distinguishes "extraction never ran" (`extracted_at` null) from "ran but field empty" (timestamp kept), so the table is honest about provenance
- `POST /libraries/{id}/comparison` with body validation, library-visibility 404 semantics, and paper-in-library checks (recycle bin excluded)
- frontend: the existing multi-select on the library paper list gains a "Compare" action (≥2 selected, >10 disabled with a hint) opening a sticky-header scrollable table; absent cells grey out as "not extracted" with a pointer to the paper detail; CSV export via an RFC-4180 pure function (byte-stable ordering, BOM for spreadsheet apps)
- 7 backend tests (mixed presence, out-of-library 404, size bounds, auth) + 7 vitest cases for the CSV/label layer

Verification: clean baseline 1568 passed / 3 pre-existing #581 failures; branch 1575 = baseline + exactly the 7 new tests, identical failure set — zero new; goldens untouched; frontend build + vitest 157 green.